### PR TITLE
 mainnet tokens autopopulate add token form fields when on custom networks #12087

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -1595,7 +1595,7 @@
     "message": "Ethereum Mainnet"
   },
   "mainnetToken": {
-    "message": "This is a mainnet token address. We do not expect it to work on the current network..."
+    "message": "This address matches a known mainnet token address. Recheck the contract address and network for the token you are trying to add."
   },
   "makeAnotherSwap": {
     "message": "Create a new swap"

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -1594,6 +1594,9 @@
   "mainnet": {
     "message": "Ethereum Mainnet"
   },
+  "mainnetToken": {
+    "message": "This is a mainnet token"
+  },
   "makeAnotherSwap": {
     "message": "Create a new swap"
   },

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -1595,7 +1595,7 @@
     "message": "Ethereum Mainnet"
   },
   "mainnetToken": {
-    "message": "This is a mainnet token"
+    "message": "This is a mainnet token address. We do not expect it to work on the current network..."
   },
   "makeAnotherSwap": {
     "message": "Create a new swap"

--- a/ui/pages/import-token/import-token.component.js
+++ b/ui/pages/import-token/import-token.component.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { getTokenTrackerLink } from '@metamask/etherscan-link';
+import contractMap from '@metamask/contract-metadata';
 import {
   checkExistingAddresses,
   getURLHostName,
@@ -64,6 +65,7 @@ class ImportToken extends Component {
     forceEditSymbol: false,
     symbolAutoFilled: false,
     decimalAutoFilled: false,
+    mainnetTokenWarning: null,
   };
 
   componentDidMount() {
@@ -134,6 +136,12 @@ class ImportToken extends Component {
     );
   }
 
+  hasWarning() {
+    const { mainnetTokenWarning } = this.state;
+
+    return mainnetTokenWarning;
+  }
+
   hasSelected() {
     const { customAddress = '', selectedTokens = {} } = this.state;
     return customAddress || Object.keys(selectedTokens).length > 0;
@@ -192,6 +200,7 @@ class ImportToken extends Component {
       tokenSelectorError: null,
       symbolAutoFilled: false,
       decimalAutoFilled: false,
+      mainnetTokenWarning: null,
     });
 
     const addressIsValid = isValidHexAddress(customAddress, {
@@ -199,10 +208,31 @@ class ImportToken extends Component {
     });
     const standardAddress = addHexPrefix(customAddress).toLowerCase();
 
+    function isMainnetToken(key, address) {
+      if (key !== address) return false;
+      return true;
+    }
+
+    let mainnetToken;
+
+    Object.keys(contractMap).find(
+      (key) => (mainnetToken = isMainnetToken(key, customAddress)),
+    );
+
     switch (true) {
       case !addressIsValid:
         this.setState({
           customAddressError: this.context.t('invalidAddress'),
+          customSymbol: '',
+          customDecimals: 0,
+          customSymbolError: null,
+          customDecimalsError: null,
+        });
+
+        break;
+      case mainnetToken:
+        this.setState({
+          mainnetTokenWarning: this.context.t('mainnetToken'),
           customSymbol: '',
           customDecimals: 0,
           customSymbolError: null,
@@ -270,6 +300,7 @@ class ImportToken extends Component {
       forceEditSymbol,
       symbolAutoFilled,
       decimalAutoFilled,
+      mainnetTokenWarning,
     } = this.state;
 
     const { chainId, rpcPrefs } = this.props;
@@ -310,7 +341,7 @@ class ImportToken extends Component {
           type="text"
           value={customAddress}
           onChange={(e) => this.handleCustomAddressChange(e.target.value)}
-          error={customAddressError}
+          error={customAddressError || mainnetTokenWarning}
           fullWidth
           autoFocus
           margin="normal"

--- a/ui/pages/import-token/import-token.component.js
+++ b/ui/pages/import-token/import-token.component.js
@@ -208,16 +208,15 @@ class ImportToken extends Component {
     });
     const standardAddress = addHexPrefix(customAddress).toLowerCase();
 
-    function isMainnetToken(key, address) {
-      if (key !== address) return false;
-      return true;
-    }
+    let isMainnetToken = false;
 
-    let mainnetToken;
+    Object.keys(contractMap).forEach((key) => {
+      if (key.toLowerCase() === customAddress.toLowerCase()) {
+        isMainnetToken = true;
+      }
+    });
 
-    Object.keys(contractMap).find(
-      (key) => (mainnetToken = isMainnetToken(key, customAddress)),
-    );
+    const isMainnetNetwork = this.props.chainId === '0x1';
 
     switch (true) {
       case !addressIsValid:
@@ -230,7 +229,7 @@ class ImportToken extends Component {
         });
 
         break;
-      case mainnetToken:
+      case isMainnetToken && !isMainnetNetwork:
         this.setState({
           mainnetTokenWarning: this.context.t('mainnetToken'),
           customSymbol: '',

--- a/ui/pages/import-token/import-token.component.js
+++ b/ui/pages/import-token/import-token.component.js
@@ -136,12 +136,6 @@ class ImportToken extends Component {
     );
   }
 
-  hasWarning() {
-    const { mainnetTokenWarning } = this.state;
-
-    return mainnetTokenWarning;
-  }
-
   hasSelected() {
     const { customAddress = '', selectedTokens = {} } = this.state;
     return customAddress || Object.keys(selectedTokens).length > 0;
@@ -208,13 +202,9 @@ class ImportToken extends Component {
     });
     const standardAddress = addHexPrefix(customAddress).toLowerCase();
 
-    let isMainnetToken = false;
-
-    Object.keys(contractMap).forEach((key) => {
-      if (key.toLowerCase() === customAddress.toLowerCase()) {
-        isMainnetToken = true;
-      }
-    });
+    const isMainnetToken = Object.keys(contractMap).some(
+      (key) => key.toLowerCase() === customAddress.toLowerCase(),
+    );
 
     const isMainnetNetwork = this.props.chainId === '0x1';
 


### PR DESCRIPTION
Fixes: https://github.com/MetaMask/metamask-extension/issues/12087

Explanation:  
When trying to import mainnet token user gets error message 'This is a mainnet token' and symbol and decimals fields are not autopopulated but user is able to submit.
![Screenshot from 2021-11-23 11-57-18](https://user-images.githubusercontent.com/92531782/143013605-17b511b0-0274-4e4e-9a2d-20e1ea17d9ae.png)
