### PR TITLE
Fix: "BigNumber Error: times() number type has more than 15 significant digits"

### DIFF
--- a/app/scripts/controllers/swaps.js
+++ b/app/scripts/controllers/swaps.js
@@ -746,7 +746,7 @@ export default class SwapsController {
       const conversionRateForSorting = tokenConversionRate || 1;
 
       const ethValueOfTokens = decimalAdjustedDestinationAmount.times(
-        conversionRateForSorting,
+        conversionRateForSorting.toString(10),
         10,
       );
 
@@ -768,7 +768,7 @@ export default class SwapsController {
         quote.ethValueOfTokens = ethValueOfTokens.toString(10);
         quote.overallValueOfQuote = overallValueOfQuoteForSorting.toString(10);
         quote.metaMaskFeeInEth = metaMaskFeeInTokens
-          .times(conversionRateForCalculations)
+          .times(conversionRateForCalculations.toString(10))
           .toString(10);
       }
 


### PR DESCRIPTION
## Description
It resolves an issue when numbers used in the `.times()` BigNumber function had more than 15 significant digits.

## Testing
- Switch to Polygon
- Try to swap from MATIC to AAVE
- You will see quotes instead of the occasional "Error fetching quotes" page

## Screenshots
![image](https://user-images.githubusercontent.com/80175477/143055288-964c5a77-8139-4de4-940e-f37979536f6f.png)