### PR TITLE
Fix error-message component to match new Storybook format

### DIFF
--- a/ui/components/ui/error-message/README.mdx
+++ b/ui/components/ui/error-message/README.mdx
@@ -1,0 +1,15 @@
+import { Story, Canvas, ArgsTable } from '@storybook/addon-docs';
+
+import ErrorMessage from '.';
+
+# Error Message
+
+This component highlights error messages
+
+<Canvas>
+  <Story id="ui-components-ui-error-message-error-message-stories-js--default-story" />
+</Canvas>
+
+## Component API
+
+<ArgsTable of={ErrorMessage} />

--- a/ui/components/ui/error-message/error-message.component.js
+++ b/ui/components/ui/error-message/error-message.component.js
@@ -19,11 +19,11 @@ const ErrorMessage = (props, context) => {
 
 ErrorMessage.propTypes = {
   /**
-   * Show error message content
+   * The text content for the error message
    */
   errorMessage: PropTypes.string,
   /**
-   * Show error message content with translate key
+   * The translate key for localization. Uses context.t(). Will override the error message
    */
   errorKey: PropTypes.string,
 };

--- a/ui/components/ui/error-message/error-message.component.js
+++ b/ui/components/ui/error-message/error-message.component.js
@@ -18,7 +18,13 @@ const ErrorMessage = (props, context) => {
 };
 
 ErrorMessage.propTypes = {
+  /**
+   * Show error message content
+   */
   errorMessage: PropTypes.string,
+  /**
+   * Show error message content with translate key
+   */
   errorKey: PropTypes.string,
 };
 

--- a/ui/components/ui/error-message/error-message.stories.js
+++ b/ui/components/ui/error-message/error-message.stories.js
@@ -1,14 +1,26 @@
 import React from 'react';
-import { text } from '@storybook/addon-knobs';
+import README from './README.mdx';
 import ErrorMessage from '.';
 
 export default {
   title: 'Components/UI/ErrorMessage',
   id: __filename,
+  component: ErrorMessage,
+  parameters: {
+    docs: {
+      page: README,
+    },
+  },
+  argTypes: {
+    errorMessage: { control: 'text' },
+    errorKey: { control: 'text' },
+  },
 };
 
-export const DefaultStory = () => (
-  <ErrorMessage errorMessage={text('Error Message:', 'There was an error!')} />
-);
+export const DefaultStory = (args) => <ErrorMessage {...args} />;
 
 DefaultStory.storyName = 'Default';
+
+DefaultStory.args = {
+  errorMessage: 'There was an error!',
+};


### PR DESCRIPTION
Updating `ErrorMessage` story:
- Add js doc comments to proptypes to allow ArgsTable to show up
- Add `README.MDX`
- Add controls for interaction of component

**Manual testing steps**
- Go to latest CI build of storybook or run `yarn storybook`
- Search "ErrorMessage" in storybook
- Use Controls to interact with component
- Check docs page to see Props table

**Images**

<img width="1439" alt="Screen Shot 2021-12-02 at 9 26 23 AM" src="https://user-images.githubusercontent.com/8112138/144472546-da43fa42-fae8-468d-b5b6-39cb33a79e9d.png">
<img width="1436" alt="Screen Shot 2021-12-02 at 9 26 28 AM" src="https://user-images.githubusercontent.com/8112138/144472552-83671a0f-673d-4928-a9fb-15fad43f4f98.png">


