### PR TITLE
Fix dropdown component for new Storybook format

### DIFF
--- a/ui/components/ui/dropdown/README.mdx
+++ b/ui/components/ui/dropdown/README.mdx
@@ -1,0 +1,35 @@
+import { Story, Canvas, ArgsTable } from '@storybook/addon-docs';
+
+import Dropdown from '.';
+
+# Dropdown
+
+A toggleable menu that allows the user to choose one value from a predefined list
+
+<Canvas>
+  <Story id="ui-components-ui-dropdown-dropdown-stories-js--default-story" />
+</Canvas>
+
+## Component API
+
+<ArgsTable of={Dropdown} />
+
+## Usage
+
+### Options Without Names
+
+<Canvas>
+  <Story id="ui-components-ui-dropdown-dropdown-stories-js--options-without-names" />
+</Canvas>
+
+### Options With Long Names
+
+<Canvas>
+  <Story id="ui-components-ui-dropdown-dropdown-stories-js--options-with-long-names" />
+</Canvas>
+
+### Options With Long Names And Short Width
+
+<Canvas>
+  <Story id="ui-components-ui-dropdown-dropdown-stories-js--options-with-long-names-and-short-width" />
+</Canvas>

--- a/ui/components/ui/dropdown/dropdown.js
+++ b/ui/components/ui/dropdown/dropdown.js
@@ -41,17 +41,38 @@ const Dropdown = ({
 };
 
 Dropdown.propTypes = {
+  /**
+   * Add CSS class to the component
+   */
   className: PropTypes.string,
+  /**
+   * Check if component disabled
+   */
   disabled: PropTypes.bool,
+  /**
+   * Show title of the component
+   */
   title: PropTypes.string,
+  /**
+   * On options change handler
+   */
   onChange: PropTypes.func.isRequired,
+  /**
+   * Predefined options for component
+   */
   options: PropTypes.arrayOf(
     PropTypes.exact({
       name: PropTypes.string,
       value: PropTypes.string.isRequired,
     }),
   ).isRequired,
+  /**
+   * Selected options of dropdown
+   */
   selectedOption: PropTypes.string,
+  /**
+   * Add inline style for the component
+   */
   style: PropTypes.object,
 };
 

--- a/ui/components/ui/dropdown/dropdown.js
+++ b/ui/components/ui/dropdown/dropdown.js
@@ -4,10 +4,10 @@ import classnames from 'classnames';
 
 const Dropdown = ({
   className,
-  disabled,
+  disabled = false,
   onChange,
   options,
-  selectedOption,
+  selectedOption = null,
   style,
   title,
 }) => {
@@ -42,15 +42,15 @@ const Dropdown = ({
 
 Dropdown.propTypes = {
   /**
-   * Add CSS class to the component
+   * Additional css className to add to root of Dropdown component
    */
   className: PropTypes.string,
   /**
-   * Check if component disabled
+   * Disable dropdown by setting to true
    */
   disabled: PropTypes.bool,
   /**
-   * Show title of the component
+   * Title of the dropdown
    */
   title: PropTypes.string,
   /**
@@ -74,14 +74,6 @@ Dropdown.propTypes = {
    * Add inline style for the component
    */
   style: PropTypes.object,
-};
-
-Dropdown.defaultProps = {
-  className: undefined,
-  disabled: false,
-  title: undefined,
-  selectedOption: null,
-  style: undefined,
 };
 
 export default Dropdown;

--- a/ui/components/ui/dropdown/dropdown.stories.js
+++ b/ui/components/ui/dropdown/dropdown.stories.js
@@ -1,12 +1,6 @@
 import React from 'react';
-import { action } from '@storybook/addon-actions';
-import { boolean, select, text } from '@storybook/addon-knobs';
+import README from './README.mdx';
 import Dropdown from '.';
-
-export default {
-  title: 'Components/UI/Dropdown',
-  id: __filename,
-};
 
 const unnamedOptions = [...Array(10).keys()].map((index) => {
   return { value: `option${index}` };
@@ -23,65 +17,67 @@ const namedOptionsWithVeryLongNames = unnamedOptions.map((option, index) => {
   };
 });
 
-export const DefaultStory = () => (
-  <Dropdown
-    disabled={boolean('Disabled', false)}
-    title={text('Title', 'Test dropdown name')}
-    onChange={action('Selection changed')}
-    options={namedOptions}
-    required={boolean('Required', false)}
-    selectedOption={select(
-      'Selected Option',
-      namedOptions.map((option) => option.value),
-      namedOptions[0].value,
-    )}
-  />
-);
+export default {
+  title: 'Components/UI/Dropdown',
+  id: __filename,
+  component: Dropdown,
+  parameters: {
+    docs: {
+      page: README,
+    },
+  },
+  argTypes: {
+    className: { control: 'text' },
+    disabled: { control: 'boolean' },
+    title: { control: 'text' },
+    onChange: { action: 'onChange' },
+    options: { control: 'array' },
+    selectedOption: { control: 'text' },
+    style: { control: 'object' },
+  },
+};
+
+export const DefaultStory = (args) => <Dropdown {...args} />;
 
 DefaultStory.storyName = 'Default';
 
-export const OptionsWithoutNames = () => (
-  <Dropdown
-    disabled={boolean('Disabled', false)}
-    title={text('Title', 'Test dropdown name')}
-    onChange={action('Selection changed')}
-    options={unnamedOptions}
-    required={boolean('Required', false)}
-    selectedOption={select(
-      'Selected Option',
-      unnamedOptions.map((option) => option.value),
-      unnamedOptions[0].value,
-    )}
-  />
+DefaultStory.args = {
+  disabled: false,
+  title: 'Test Dropdown Name',
+  options: namedOptions,
+  required: false,
+  selectedOption: namedOptions[0].value,
+};
+
+export const OptionsWithoutNames = (args) => <Dropdown {...args} />;
+
+OptionsWithoutNames.args = {
+  disabled: false,
+  title: 'Test Dropdown Name',
+  options: unnamedOptions,
+  required: false,
+  selectedOption: unnamedOptions[0].value,
+};
+
+export const OptionsWithLongNames = (args) => <Dropdown {...args} />;
+
+OptionsWithLongNames.args = {
+  disabled: false,
+  title: 'Test Dropdown Name',
+  options: namedOptionsWithVeryLongNames,
+  required: false,
+  selectedOption: namedOptionsWithVeryLongNames[0].value,
+};
+
+export const OptionsWithLongNamesAndShortWidth = (args) => (
+  <Dropdown {...args} />
 );
 
-export const OptionsWithLongNames = () => (
-  <Dropdown
-    disabled={boolean('Disabled', false)}
-    title={text('Title', 'Test dropdown name')}
-    onChange={action('Selection changed')}
-    options={namedOptionsWithVeryLongNames}
-    required={boolean('Required', false)}
-    selectedOption={select(
-      'Selected Option',
-      namedOptionsWithVeryLongNames.map((option) => option.value),
-      namedOptionsWithVeryLongNames[0].value,
-    )}
-  />
-);
-
-export const OptionsWithLongNamesAndShortWidth = () => (
-  <Dropdown
-    disabled={boolean('Disabled', false)}
-    title={text('Title', 'Test dropdown name')}
-    onChange={action('Selection changed')}
-    options={namedOptionsWithVeryLongNames}
-    required={boolean('Required', false)}
-    selectedOption={select(
-      'Selected Option',
-      namedOptionsWithVeryLongNames.map((option) => option.value),
-      namedOptionsWithVeryLongNames[0].value,
-    )}
-    style={{ width: '200px' }}
-  />
-);
+OptionsWithLongNamesAndShortWidth.args = {
+  disabled: false,
+  title: 'Test Dropdown Name',
+  options: namedOptionsWithVeryLongNames,
+  required: false,
+  selectedOption: namedOptionsWithVeryLongNames[0].value,
+  style: { width: '200px' },
+};

--- a/ui/components/ui/dropdown/dropdown.stories.js
+++ b/ui/components/ui/dropdown/dropdown.stories.js
@@ -45,7 +45,6 @@ DefaultStory.args = {
   disabled: false,
   title: 'Test Dropdown Name',
   options: namedOptions,
-  required: false,
   selectedOption: namedOptions[0].value,
 };
 
@@ -55,7 +54,6 @@ OptionsWithoutNames.args = {
   disabled: false,
   title: 'Test Dropdown Name',
   options: unnamedOptions,
-  required: false,
   selectedOption: unnamedOptions[0].value,
 };
 
@@ -65,7 +63,6 @@ OptionsWithLongNames.args = {
   disabled: false,
   title: 'Test Dropdown Name',
   options: namedOptionsWithVeryLongNames,
-  required: false,
   selectedOption: namedOptionsWithVeryLongNames[0].value,
 };
 
@@ -77,7 +74,6 @@ OptionsWithLongNamesAndShortWidth.args = {
   disabled: false,
   title: 'Test Dropdown Name',
   options: namedOptionsWithVeryLongNames,
-  required: false,
   selectedOption: namedOptionsWithVeryLongNames[0].value,
   style: { width: '200px' },
 };


### PR DESCRIPTION
Updating `Dropdown`:
- Add js doc comments to proptypes to allow ArgsTable to show up
- Add README.MDX
- Add controls for interaction of component
- Updating default prop convention and removing `undefined` props as they are `undefined` by default

**Manual testing steps**
- Go to latest CI build of storybook
- Search "Dropdown"
- Use Controls to interact with component
- Check docs page to see Props table

**Images**

<img width="1437" alt="Screen Shot 2021-12-02 at 12 24 59 PM" src="https://user-images.githubusercontent.com/8112138/144498450-e79acb0a-2ae2-4804-867d-473426028daa.png">

![screencapture-localhost-6006-2021-12-02-12_25_07](https://user-images.githubusercontent.com/8112138/144498470-1465af14-c82c-43aa-b11d-5a92462ba147.png)


