### PR TITLE
Fix pulse-loader component for new Storybook format

### DIFF
--- a/ui/components/ui/pulse-loader/README.mdx
+++ b/ui/components/ui/pulse-loader/README.mdx
@@ -1,0 +1,11 @@
+import { Story, Canvas, ArgsTable } from '@storybook/addon-docs';
+
+import PulseLoader from '.';
+
+# Pulse Loader
+
+Loading indicator with 3 pulsing dots
+
+<Canvas>
+  <Story id="ui-components-ui-pulse-loader-pulse-loader-stories-js--default-story" />
+</Canvas>

--- a/ui/components/ui/pulse-loader/pulse-loader.stories.js
+++ b/ui/components/ui/pulse-loader/pulse-loader.stories.js
@@ -1,9 +1,16 @@
 import React from 'react';
+import README from './README.mdx';
 import PulseLoader from '.';
 
 export default {
   title: 'Components/UI/PulseLoader',
   id: __filename,
+  component: PulseLoader,
+  parameters: {
+    docs: {
+      page: README,
+    },
+  },
 };
 
 export const DefaultStory = () => <PulseLoader />;


### PR DESCRIPTION
Updating `PulseLoader` story:
- Add `README.MDX`

**Manual testing steps**
- Go to latest CI build of storybook or run `yarn storybook`
- Search "PulseLoader" in storybook
- Check docs page to see description

**Images**
<img width="721" alt="Screen Shot 2021-12-02 at 1 02 33 PM" src="https://user-images.githubusercontent.com/8112138/144502685-324c85ea-7d02-4ea6-adda-3cd23bfe03bd.png">
<img width="1437" alt="Screen Shot 2021-12-02 at 1 02 37 PM" src="https://user-images.githubusercontent.com/8112138/144502688-a711faa6-98b5-4a2a-8be5-2f300008d393.png">



