### PR TITLE
Fix transaction-detail for new Storybook format

### DIFF
--- a/ui/components/app/transaction-detail/README.mdx
+++ b/ui/components/app/transaction-detail/README.mdx
@@ -1,0 +1,16 @@
+import { Story, Canvas, ArgsTable } from '@storybook/addon-docs';
+
+import TransactionDetail from '.';
+
+# Transaction Detail
+
+Show transaction detail including estimated gas fee and total fee.
+
+<Canvas>
+  <Story id="ui-components-app-transaction-detail-transaction-detail-stories-js--default-story" />
+</Canvas>
+
+## Component API
+
+<ArgsTable of={TransactionDetail} />
+

--- a/ui/components/app/transaction-detail/transaction-detail.component.js
+++ b/ui/components/app/transaction-detail/transaction-detail.component.js
@@ -115,5 +115,9 @@ TransactionDetail.propTypes = {
    * onClick handler for the Edit link
    */
   onEdit: PropTypes.func,
+  /**
+   * If there is a error in getting correct estimates we show a message to the user
+   * which they can acknowledge and proceed with their transaction
+   */
   userAcknowledgedGasMissing: PropTypes.bool.isRequired,
 };

--- a/ui/components/app/transaction-detail/transaction-detail.component.js
+++ b/ui/components/app/transaction-detail/transaction-detail.component.js
@@ -107,7 +107,13 @@ export default function TransactionDetail({
 }
 
 TransactionDetail.propTypes = {
+  /**
+   * Show item content for transaction detail
+   */
   rows: PropTypes.arrayOf(TransactionDetailItem).isRequired,
+  /**
+   * Edit transaction handler
+   */
   onEdit: PropTypes.func,
   userAcknowledgedGasMissing: PropTypes.bool.isRequired,
 };

--- a/ui/components/app/transaction-detail/transaction-detail.component.js
+++ b/ui/components/app/transaction-detail/transaction-detail.component.js
@@ -108,11 +108,11 @@ export default function TransactionDetail({
 
 TransactionDetail.propTypes = {
   /**
-   * Show item content for transaction detail
+   * Show item content for transaction detail. Array of TransactionDetailItem components
    */
   rows: PropTypes.arrayOf(TransactionDetailItem).isRequired,
   /**
-   * Edit transaction handler
+   * onClick handler for the Edit link
    */
   onEdit: PropTypes.func,
   userAcknowledgedGasMissing: PropTypes.bool.isRequired,

--- a/ui/components/app/transaction-detail/transaction-detail.stories.js
+++ b/ui/components/app/transaction-detail/transaction-detail.stories.js
@@ -1,13 +1,23 @@
 import React from 'react';
-import { action } from '@storybook/addon-actions';
 import InfoTooltip from '../../ui/info-tooltip/info-tooltip';
 import TransactionDetailItem from '../transaction-detail-item/transaction-detail-item.component';
 import GasTiming from '../gas-timing/gas-timing.component';
+import README from './README.mdx';
 import TransactionDetail from '.';
 
 export default {
   title: 'Components/App/TransactionDetail',
   id: __filename,
+  component: TransactionDetail,
+  parameters: {
+    docs: {
+      page: README,
+    },
+  },
+  argTypes: {
+    rows: { control: 'array' },
+    onEdit: { action: 'onEdit' },
+  },
 };
 
 const rows = [
@@ -44,20 +54,12 @@ const rows = [
   />,
 ];
 
-export const DefaultStory = () => {
-  return (
-    <div style={{ width: '400px' }}>
-      <TransactionDetail rows={rows} />
-    </div>
-  );
+export const DefaultStory = (args) => {
+  return <TransactionDetail {...args} />;
 };
 
 DefaultStory.storyName = 'Default';
 
-export const Editable = () => {
-  return (
-    <div style={{ width: '400px' }}>
-      <TransactionDetail rows={rows} onEdit={() => action('Edit!')()} />
-    </div>
-  );
+DefaultStory.args = {
+  rows,
 };


### PR DESCRIPTION
Updating `TransactionDetail` story:
- Add js doc comments to proptypes to allow ArgsTable to show up
- Add `README.MDX`
- Add controls for interaction of component

**Manual testing steps**
- Go to latest CI build of storybook or run `yarn storybook`
- Search "TransactionDetail" in storybook
- Use Controls to interact with component
- Check docs page to see Props table

**Images**

<img width="1437" alt="Screen Shot 2021-12-02 at 1 17 18 PM" src="https://user-images.githubusercontent.com/8112138/144504586-a0e0b80d-9e53-46a3-91e5-dce8cb4173ac.png">
<img width="1440" alt="Screen Shot 2021-12-02 at 1 17 29 PM" src="https://user-images.githubusercontent.com/8112138/144504589-2c1ae3a3-5c98-4d3e-9563-9f77c50e62da.png">




