### PR TITLE
Fix transaction-detail-item for new Storybook format

### DIFF
--- a/ui/components/app/transaction-detail-item/README.mdx
+++ b/ui/components/app/transaction-detail-item/README.mdx
@@ -4,7 +4,7 @@ import TransactionDetailItem from '.';
 
 # Transaction Detail Item
 
-Show item of transaction detail that includes estimated gas fee details
+Transaction detail that includes estimated gas fees. Intended to be used as an array item in the array passed to the `rows` prop of `<TransactionDetail />`
 
 <Canvas>
   <Story id="ui-components-app-transaction-detail-item-transaction-detail-item-stories-js--default-story" />

--- a/ui/components/app/transaction-detail-item/README.mdx
+++ b/ui/components/app/transaction-detail-item/README.mdx
@@ -1,0 +1,15 @@
+import { Story, Canvas, ArgsTable } from '@storybook/addon-docs';
+
+import TransactionDetailItem from '.';
+
+# Transaction Detail Item
+
+Show item of transaction detail that includes estimated gas fee details
+
+<Canvas>
+  <Story id="ui-components-app-transaction-detail-item-transaction-detail-item-stories-js--default-story" />
+</Canvas>
+
+## Component API
+
+<ArgsTable of={TransactionDetailItem} />

--- a/ui/components/app/transaction-detail-item/transaction-detail-item.component.js
+++ b/ui/components/app/transaction-detail-item/transaction-detail-item.component.js
@@ -72,11 +72,29 @@ export default function TransactionDetailItem({
 }
 
 TransactionDetailItem.propTypes = {
+  /**
+   * Show title with text or react child
+   */
   detailTitle: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
+  /**
+   * Customize color of the title
+   */
   detailTitleColor: PropTypes.string,
+  /**
+   * Show amount on the left
+   */
   detailText: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
+  /**
+   * Show total amount
+   */
   detailTotal: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
+  /**
+   * Add subtitle could be react child or text
+   */
   subTitle: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
+  /**
+   * Show subtitle text could be react child or text
+   */
   subText: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
   boldHeadings: PropTypes.bool,
   flexWidthValues: PropTypes.bool,

--- a/ui/components/app/transaction-detail-item/transaction-detail-item.component.js
+++ b/ui/components/app/transaction-detail-item/transaction-detail-item.component.js
@@ -73,29 +73,35 @@ export default function TransactionDetailItem({
 
 TransactionDetailItem.propTypes = {
   /**
-   * Show title with text or react child
+   * Detail title text wrapped in Typography component.
    */
   detailTitle: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
   /**
-   * Customize color of the title
+   * The color of the detailTitle text accepts all Typography color props
    */
   detailTitleColor: PropTypes.string,
   /**
-   * Show amount on the left
+   * Text to show on the left of the detailTotal. Wrapped in Typography component.
    */
   detailText: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
   /**
-   * Show total amount
+   * Total amount to show. Wrapped in Typography component. Will be bold if boldHeadings is true
    */
   detailTotal: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
   /**
-   * Add subtitle could be react child or text
+   * Subtitle text. Checks if React.isValidElement before displaying. Displays under detailTitle
    */
   subTitle: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
   /**
-   * Show subtitle text could be react child or text
+   * Text to show under detailTotal. Wrapped in Typography component.
    */
   subText: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
+  /**
+   * Whether detailTotal is bold or not. Defaults to true
+   */
   boldHeadings: PropTypes.bool,
+  /**
+   * Changes width to auto for transaction-detail-item__detail-values
+   */
   flexWidthValues: PropTypes.bool,
 };

--- a/ui/components/app/transaction-detail-item/transaction-detail-item.stories.js
+++ b/ui/components/app/transaction-detail-item/transaction-detail-item.stories.js
@@ -1,36 +1,53 @@
 import React from 'react';
 import InfoTooltip from '../../ui/info-tooltip/info-tooltip';
 import GasTiming from '../gas-timing/gas-timing.component';
+import README from './README.mdx';
 import TransactionDetailItem from '.';
 
 export default {
   title: 'Components/App/TransactionDetailItem',
   id: __filename,
+  component: TransactionDetailItem,
+  parameters: {
+    docs: {
+      page: README,
+    },
+  },
+  argTypes: {
+    detailTitle: { control: 'object' },
+    detailTitleColor: { control: 'text' },
+    detailText: { control: 'text' },
+    detailTotal: { control: 'text' },
+    subTitle: { control: 'object' },
+    subText: { control: 'object' },
+  },
 };
 
-export const DefaultStory = () => {
+export const DefaultStory = (args) => {
   return (
     <div style={{ width: '400px' }}>
-      <TransactionDetailItem
-        detailTitle={
-          <>
-            <strong>Estimated gas fee</strong>
-            <InfoTooltip contentText="This is the tooltip text" position="top">
-              <i className="fa fa-info-circle" />
-            </InfoTooltip>
-          </>
-        }
-        detailText="16565.30"
-        detailTotal="0.0089 ETH"
-        subTitle={<GasTiming maxPriorityFeePerGas="1" />}
-        subText={
-          <>
-            From <strong>$16565 - $19000</strong>
-          </>
-        }
-      />
+      <TransactionDetailItem {...args} />
     </div>
   );
 };
 
 DefaultStory.storyName = 'Default';
+
+DefaultStory.args = {
+  detailTitle: (
+    <>
+      <strong>Estimated gas fee</strong>
+      <InfoTooltip contentText="This is the tooltip text" position="top">
+        <i className="fa fa-info-circle" />
+      </InfoTooltip>
+    </>
+  ),
+  detailText: '16565.30',
+  detailTotal: '0.0089 ETH',
+  subTitle: <GasTiming maxPriorityFeePerGas="1" />,
+  subText: (
+    <>
+      From <strong>$16565 - $19000</strong>
+    </>
+  ),
+};

--- a/ui/components/app/transaction-detail-item/transaction-detail-item.stories.js
+++ b/ui/components/app/transaction-detail-item/transaction-detail-item.stories.js
@@ -1,6 +1,8 @@
 import React from 'react';
 import InfoTooltip from '../../ui/info-tooltip/info-tooltip';
-import GasTiming from '../gas-timing/gas-timing.component';
+
+import { COLORS } from '../../../helpers/constants/design-system';
+
 import README from './README.mdx';
 import TransactionDetailItem from '.';
 
@@ -15,7 +17,12 @@ export default {
   },
   argTypes: {
     detailTitle: { control: 'object' },
-    detailTitleColor: { control: 'text' },
+    detailTitleColor: {
+      control: {
+        type: 'select',
+      },
+      options: Object.values(COLORS),
+    },
     detailText: { control: 'text' },
     detailTotal: { control: 'text' },
     subTitle: { control: 'object' },
@@ -44,10 +51,12 @@ DefaultStory.args = {
   ),
   detailText: '16565.30',
   detailTotal: '0.0089 ETH',
-  subTitle: <GasTiming maxPriorityFeePerGas="1" />,
+  subTitle: 'Likely in < 30 seconds',
+  boldHeadings: true,
+  flexWidthValues: false,
   subText: (
-    <>
+    <span>
       From <strong>$16565 - $19000</strong>
-    </>
+    </span>
   ),
 };


### PR DESCRIPTION
Updating `TransactionDetailItem` story:
- Add js doc comments to proptypes to allow ArgsTable to show up
- Add `README.MDX`
- Add controls for interaction of component

**Manual testing steps**
- Go to latest CI build of storybook or run `yarn storybook`
- Search "TransactionDetailItem" in storybook
- Use Controls to interact with component
- Check docs page to see Props table

**Images**

<img width="1436" alt="Screen Shot 2021-12-02 at 2 37 34 PM" src="https://user-images.githubusercontent.com/8112138/144514417-afec47ca-be50-41ca-8285-5b85264a3e75.png">

![screencapture-localhost-6006-2021-12-02-14_37_38](https://user-images.githubusercontent.com/8112138/144514420-f4cf008d-0cf3-443e-bc65-bce0af744bdb.png)



