### PR TITLE
Bump @metmamask/logo to v3.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "@metamask/eth-token-tracker": "^3.0.1",
     "@metamask/etherscan-link": "^2.1.0",
     "@metamask/jazzicon": "^2.0.0",
-    "@metamask/logo": "^3.1.0",
+    "@metamask/logo": "^3.1.1",
     "@metamask/obs-store": "^5.0.0",
     "@metamask/post-message-stream": "^4.0.0",
     "@metamask/providers": "^8.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4315,10 +4315,10 @@
     color "^0.11.3"
     mersenne-twister "^1.1.0"
 
-"@metamask/logo@^3.1.0":
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/@metamask/logo/-/logo-3.1.0.tgz#6b7b9b90b6d846583558de855511d34796735855"
-  integrity sha512-W0FBwIaG1pC4Vk/ZdUJYv7PDjnAbQJro3yhEXN7WXEdz8kyVcxFb6dj0Dpe6ytaveYiqIL6+iDDWMevzU2MpVw==
+"@metamask/logo@^3.1.1":
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/@metamask/logo/-/logo-3.1.1.tgz#0a40bcfc462a70aa2110efc737767ca7ba188fa3"
+  integrity sha512-8/ObOWyBtwbe3/r9QbXMs+aKK2EgcYp2NiF4fm1xIO/c3aBMN5wBc2zUnl1lpHU71l70/OH5cxHbyDYoEgdMoA==
   dependencies:
     gl-mat4 "1.1.4"
     gl-vec3 "1.0.3"


### PR DESCRIPTION
Fixes https://github.com/MetaMask/metamask-extension/issues/12810

There is an api used in @metamask/logo that is not supported on older browsers. This could cause MetaMask to break on older browsers. This version update fixes that.