### PR TITLE
Remove additional_removeBeforeUnload calls

### DIFF
--- a/ui/pages/confirm-decrypt-message/confirm-decrypt-message.component.js
+++ b/ui/pages/confirm-decrypt-message/confirm-decrypt-message.component.js
@@ -260,7 +260,6 @@ export default class ConfirmDecryptMessage extends Component {
           large
           className="request-decrypt-message__footer__cancel-button"
           onClick={async (event) => {
-            this._removeBeforeUnload();
             await cancelDecryptMessage(txData, event);
             metricsEvent({
               eventOpts: {
@@ -280,7 +279,6 @@ export default class ConfirmDecryptMessage extends Component {
           large
           className="request-decrypt-message__footer__sign-button"
           onClick={async (event) => {
-            this._removeBeforeUnload();
             await decryptMessage(txData, event);
             metricsEvent({
               eventOpts: {

--- a/ui/pages/confirm-encryption-public-key/confirm-encryption-public-key.component.js
+++ b/ui/pages/confirm-encryption-public-key/confirm-encryption-public-key.component.js
@@ -163,7 +163,6 @@ export default class ConfirmEncryptionPublicKey extends Component {
           large
           className="request-encryption-public-key__footer__cancel-button"
           onClick={async (event) => {
-            this._removeBeforeUnload();
             await cancelEncryptionPublicKey(txData, event);
             metricsEvent({
               eventOpts: {
@@ -183,7 +182,6 @@ export default class ConfirmEncryptionPublicKey extends Component {
           large
           className="request-encryption-public-key__footer__sign-button"
           onClick={async (event) => {
-            this._removeBeforeUnload();
             await encryptionPublicKey(txData, event);
             this.context.metricsEvent({
               eventOpts: {


### PR DESCRIPTION
These should have been removed as part of https://github.com/MetaMask/metamask-extension/pull/12643

This fixes an issue found in QA of 10.7.0:

> Encrypt/Decrypt flow - Test Dapp
> Click Cancel or Provide
> Uncaught (in promise) TypeError: this._removeBeforeUnload is not a function