### PR TITLE
Update package.json: contract-metadata to newest release 1.31.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "@keystonehq/bc-ur-registry-eth": "^0.6.8",
     "@keystonehq/metamask-airgapped-keyring": "0.2.1",
     "@material-ui/core": "^4.11.0",
-    "@metamask/contract-metadata": "^1.28.0",
+    "@metamask/contract-metadata": "^1.31.0",
     "@metamask/controllers": "^20.0.0",
     "@metamask/eth-ledger-bridge-keyring": "^0.10.0",
     "@metamask/eth-token-tracker": "^3.0.1",


### PR DESCRIPTION
Fixes: 
Bump the contract-metadata version to newest release in package.json file

Explanation:  
The contract-metadata repository has been updated and released over past months with several new currency logo's. This update will include those new entries in the next metamask release.

Manual testing steps:  
n/a