### PR TITLE
Clear the clipboard after the seed phrase is pasted

### DIFF
--- a/ui/components/ui/text-field/text-field.component.js
+++ b/ui/components/ui/text-field/text-field.component.js
@@ -203,6 +203,7 @@ const TextField = ({
   min,
   max,
   autoComplete,
+  onPaste,
   ...textFieldProps
 }) => {
   const inputProps = themeToInputProps[theme]({
@@ -214,6 +215,16 @@ const TextField = ({
     max,
     autoComplete,
   });
+
+  if (onPaste) {
+    if (!inputProps.InputProps) {
+      inputProps.InputProps = {};
+    }
+    if (!inputProps.InputProps.inputProps) {
+      inputProps.InputProps.inputProps = {};
+    }
+    inputProps.InputProps.inputProps.onPaste = onPaste;
+  }
 
   return (
     <MaterialTextField
@@ -241,6 +252,7 @@ TextField.propTypes = {
   min: PropTypes.number,
   max: PropTypes.number,
   autoComplete: PropTypes.string,
+  onPaste: PropTypes.func,
 };
 
 export default withStyles(styles)(TextField);

--- a/ui/helpers/utils/util.js
+++ b/ui/helpers/utils/util.js
@@ -424,3 +424,7 @@ export const toHumanReadableTime = (t, milliseconds) => {
   }
   return t('gasTimingHoursShort', [Math.ceil(seconds / 3600)]);
 };
+
+export function clearClipboard() {
+  window.navigator.clipboard.writeText('');
+}

--- a/ui/pages/first-time-flow/create-password/import-with-seed-phrase/import-with-seed-phrase.component.js
+++ b/ui/pages/first-time-flow/create-password/import-with-seed-phrase/import-with-seed-phrase.component.js
@@ -10,6 +10,10 @@ import {
 
 const { isValidMnemonic } = ethers.utils;
 
+function clearClipboard() {
+  window.navigator.clipboard.writeText('');
+}
+
 export default class ImportWithSeedPhrase extends PureComponent {
   static contextTypes = {
     t: PropTypes.func,
@@ -244,6 +248,7 @@ export default class ImportWithSeedPhrase extends PureComponent {
             <textarea
               className="first-time-flow__textarea"
               onChange={(e) => this.handleSeedPhraseChange(e.target.value)}
+              onPaste={clearClipboard}
               value={this.state.seedPhrase}
               placeholder={t('seedPhrasePlaceholder')}
               autoComplete="off"
@@ -256,6 +261,7 @@ export default class ImportWithSeedPhrase extends PureComponent {
               value={this.state.seedPhrase}
               placeholder={t('seedPhrasePlaceholderPaste')}
               autoComplete="off"
+              onPaste={clearClipboard}
             />
           )}
           {seedPhraseError ? (

--- a/ui/pages/first-time-flow/create-password/import-with-seed-phrase/import-with-seed-phrase.component.js
+++ b/ui/pages/first-time-flow/create-password/import-with-seed-phrase/import-with-seed-phrase.component.js
@@ -7,12 +7,9 @@ import {
   INITIALIZE_SELECT_ACTION_ROUTE,
   INITIALIZE_END_OF_FLOW_ROUTE,
 } from '../../../../helpers/constants/routes';
+import { clearClipboard } from '../../../../helpers/utils/util';
 
 const { isValidMnemonic } = ethers.utils;
-
-function clearClipboard() {
-  window.navigator.clipboard.writeText('');
-}
 
 export default class ImportWithSeedPhrase extends PureComponent {
   static contextTypes = {

--- a/ui/pages/onboarding-flow/import-srp/import-srp.js
+++ b/ui/pages/onboarding-flow/import-srp/import-srp.js
@@ -16,6 +16,7 @@ import {
   TYPOGRAPHY,
 } from '../../../helpers/constants/design-system';
 import { ONBOARDING_CREATE_PASSWORD_ROUTE } from '../../../helpers/constants/routes';
+import { clearClipboard } from '../../../helpers/utils/util';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 
 export default function ImportSRP({ submitSecretRecoveryPhrase }) {
@@ -86,6 +87,7 @@ export default function ImportSRP({ submitSecretRecoveryPhrase }) {
               onChange={({ target: { value } }) =>
                 handleSecretRecoveryPhraseChange(value)
               }
+              onPaste={clearClipboard}
               autoComplete="off"
               autoCorrect="off"
             />


### PR DESCRIPTION
On the "Import" page of the import onboarding flow, we now clear the clipboard after the secret recovery phrase is pasted. This ensures that the SRP isn't accidentally pasted somewhere else by the user, which can be an easy and disastrous mistake to make.

Manual testing steps:  
  - On the "Import" screen of onboarding, paste your SRP into the box (with "Reveal seed phrase" disabled), and check that the clipboard has been cleared by trying to paste the SRP again somewhere else.
  - On the "Import" screen of onboarding, paste your SRP into the box (with "Reveal seed phrase" enabled), and check that the clipboard has been cleared by trying to paste the SRP again somewhere else.
 - Create a build with the environment variable `ONBOARDING_V2` set to `1`, and go through import onboarding. After pasting the SRP, check that the clipboard has been cleared by trying to paste the SRP again somewhere else.