### PR TITLE
Ensure that handleChange in token-input.component handles empty values

### DIFF
--- a/ui/components/ui/token-input/token-input.component.js
+++ b/ui/components/ui/token-input/token-input.component.js
@@ -82,7 +82,7 @@ export default class TokenInput extends PureComponent {
 
     let newDecimalValue = decimalValue;
 
-    if (decimals && applyDecimals) {
+    if (decimals && decimalValue && applyDecimals) {
       newDecimalValue = new BigNumber(decimalValue, 10).toFixed(decimals);
     }
 


### PR DESCRIPTION
Fixes an issue found in QA of 10.6.3