### PR TITLE
Update Jest coverage reporters

### DIFF
--- a/development/jest.config.js
+++ b/development/jest.config.js
@@ -2,7 +2,7 @@ module.exports = {
   displayName: '/development',
   collectCoverageFrom: ['<rootDir>/**/*.js'],
   coverageDirectory: '../jest-coverage/development/',
-  coverageReporters: ['json', 'lcov', 'text', 'clover'],
+  coverageReporters: ['html', 'text-summary'],
   coverageThreshold: {
     './development/build/transforms/**/*.js': {
       branches: 100,

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,7 +2,7 @@ module.exports = {
   collectCoverageFrom: ['<rootDir>/ui/**/*.js', '<rootDir>/shared/**/*.js'],
   coverageDirectory: './jest-coverage/main',
   coveragePathIgnorePatterns: ['.stories.js', '.snap'],
-  coverageReporters: ['json', 'lcov', 'text', 'clover'],
+  coverageReporters: ['html', 'text-summary'],
   coverageThreshold: {
     global: {
       branches: 35,

--- a/jest.stories.config.js
+++ b/jest.stories.config.js
@@ -1,7 +1,7 @@
 /* eslint-disable import/unambiguous */
 module.exports = {
   coverageDirectory: './jest-coverage/storybook',
-  coverageReporters: ['json', 'lcov', 'text', 'clover'],
+  coverageReporters: ['html', 'text-summary'],
   // TODO: enable resetMocks
   // resetMocks: true,
   restoreMocks: true,


### PR DESCRIPTION
The coverage reporter for the console has been changed from `text` to `text-summary` because `text` was too long. It exceeded the maximum length of the CircleCI terminal output shown on their jobs page, making it very difficult to see why the unit test coverage job failed.

The text summary only displays overall coverage metrics, but that is usually enough to indicate when the test fails due to a drop in coverage. The more detailed breakdown is still available as a HTML report linked in the `metamaskbot` comment, and in the `jest-coverage` directory when run locally.

The three on-disk coverage reports used previously (`lcov`, `json`, and `clover`) have been replaced with just `html`. The HTML report was part of the `lcov` report, and it was the only one we were using.

Manual testing steps:  
  - Run `yarn test:coverage:jest` and look at the CLI coverage report and the `jest-coverage` directory