### PR TITLE
Fix Jest storybook config

### DIFF
--- a/jest.stories.config.js
+++ b/jest.stories.config.js
@@ -1,17 +1,7 @@
 /* eslint-disable import/unambiguous */
 module.exports = {
-  collectCoverageFrom: ['<rootDir>/ui/**/*.js'],
-  coverageDirectory: './jest-coverage/main',
-  coveragePathIgnorePatterns: ['.stories.js', '.snap'],
+  coverageDirectory: './jest-coverage/storybook',
   coverageReporters: ['json', 'lcov', 'text', 'clover'],
-  coverageThreshold: {
-    global: {
-      branches: 35,
-      functions: 37,
-      lines: 43,
-      statements: 43,
-    },
-  },
   // TODO: enable resetMocks
   // resetMocks: true,
   restoreMocks: true,


### PR DESCRIPTION
The Jest storybook config was mistakenly set to overwrite the coverage report for our main set of Jest tests. It also had extremely high coverage thresholds set, and the `collectCoverageFrom` config was asking Jest to check that the storybook tests cover all of the UI code.

For now the `collectCoverageFrom` config has been removed. I don't understand why we'd want to use Storybook to unit test in the first place, so I don't understand what parts of the codebase we'd want to cover with these tests. So for the moment, only the files touched by the current tests are considered.

The coverage output directory is now set to `jest-coverage/storybook` so that it does not overlap with any other coverage reports.

Manual testing steps:  
  - Run `yarn storybook:test --coverage`
  - Check that it only considers the files that were run as part of the coverage report
  - Ensure that it has a zero exit code (there are no coverage thresholds, so it should never fail if tests pass)
  - See that the coverage report is written to `jest-coverage/storybook`.