### PR TITLE
Update minimum browser versions

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,1 +1,1 @@
-chrome >= 66, firefox >= 68
+chrome >= 80, firefox >= 78

--- a/app/manifest/v2/chrome.json
+++ b/app/manifest/v2/chrome.json
@@ -4,5 +4,5 @@
     "matches": ["https://metamask.io/*"],
     "ids": ["*"]
   },
-  "minimum_chrome_version": "66"
+  "minimum_chrome_version": "80"
 }

--- a/app/manifest/v2/firefox.json
+++ b/app/manifest/v2/firefox.json
@@ -2,7 +2,7 @@
   "applications": {
     "gecko": {
       "id": "webextension@metamask.io",
-      "strict_min_version": "68.0"
+      "strict_min_version": "78.0"
     }
   }
 }

--- a/app/manifest/v3/chrome.json
+++ b/app/manifest/v3/chrome.json
@@ -6,5 +6,5 @@
     "matches": ["https://metamask.io/*"],
     "ids": ["*"]
   },
-  "minimum_chrome_version": "66"
+  "minimum_chrome_version": "80"
 }

--- a/app/manifest/v3/firefox.json
+++ b/app/manifest/v3/firefox.json
@@ -2,7 +2,7 @@
   "applications": {
     "gecko": {
       "id": "webextension@metamask.io",
-      "strict_min_version": "68.0"
+      "strict_min_version": "78.0"
     }
   },
   "background": {

--- a/babel.config.js
+++ b/babel.config.js
@@ -5,7 +5,7 @@ module.exports = function (api) {
       strictMode: true,
     },
     targets: {
-      browsers: ['chrome >= 66', 'firefox >= 68'],
+      browsers: ['chrome >= 80', 'firefox >= 78'],
     },
     presets: [
       '@babel/preset-typescript',


### PR DESCRIPTION
The minimum browser versions have been updated to Chromium v80 and Firefox v78.

~Chromium v78 is >2 years old, and very few users use older versions than that.~
Updated to v80 to provide support for optional chaining

Firefox v78 is the _previous_ extended support release. The current Firefox extended support release is v91.

Related: #6805

Manual testing steps:  
  - Ensure that the extension still works on versions equal to or above the new minimum versions.