### PR TITLE
Convert nonce background calls to async/await

### DIFF
--- a/ui/store/actions.js
+++ b/ui/store/actions.js
@@ -2111,15 +2111,15 @@ export function setUseBlockie(val) {
 }
 
 export function setUseNonceField(val) {
-  return (dispatch) => {
+  return async (dispatch) => {
     dispatch(showLoadingIndication());
     log.debug(`background.setUseNonceField`);
-    background.setUseNonceField(val, (err) => {
-      dispatch(hideLoadingIndication());
-      if (err) {
-        dispatch(displayWarning(err.message));
-      }
-    });
+    try {
+      await background.setUseNonceField(val);
+    } catch (error) {
+      dispatch(displayWarning(error.message));
+    }
+    dispatch(hideLoadingIndication());
     dispatch({
       type: actionConstants.SET_USE_NONCEFIELD,
       value: val,
@@ -2790,19 +2790,17 @@ export function setNextNonce(nextNonce) {
 }
 
 export function getNextNonce() {
-  return (dispatch, getState) => {
+  return async (dispatch, getState) => {
     const address = getState().metamask.selectedAddress;
-    return new Promise((resolve, reject) => {
-      background.getNextNonce(address, (err, nextNonce) => {
-        if (err) {
-          dispatch(displayWarning(err.message));
-          reject(err);
-          return;
-        }
-        dispatch(setNextNonce(nextNonce));
-        resolve(nextNonce);
-      });
-    });
+    let nextNonce;
+    try {
+      nextNonce = await promisifiedBackground.getNextNonce(address);
+    } catch (error) {
+      dispatch(displayWarning(error.message));
+      throw error;
+    }
+    dispatch(setNextNonce(nextNonce));
+    return nextNonce;
   };
 }
 


### PR DESCRIPTION
The calls to the background in `actions.js` that relate to the custom nonce feature now use `async/await` and `promisifiedBackground`.

The behaviour should be unchanged except that when setting the nonce field, the warning is shown in case of error before the loading indicator drops, which seems like it would be a minor improvement (if it has any user-facing impact at all).

Manual testing steps:  
  - Toggle "Customize transaction nonce"  under the advanced settings, and see that it makes the custom nonce field appear on transaction confirmations.
  - Try setting a custom nonce on a transaction, and confirm that it works.