### PR TITLE
Fix environment variables used during test builds

### DIFF
--- a/development/build/scripts.js
+++ b/development/build/scripts.js
@@ -200,18 +200,18 @@ function createScriptTasks({
     // this can run whenever
     const disableConsoleSubtask = createTask(
       `${taskPrefix}:disable-console`,
-      createTaskForBundleDisableConsole({ devMode }),
+      createTaskForBundleDisableConsole({ devMode, testing }),
     );
 
     // this can run whenever
     const installSentrySubtask = createTask(
       `${taskPrefix}:sentry`,
-      createTaskForBundleSentry({ devMode }),
+      createTaskForBundleSentry({ devMode, testing }),
     );
 
     const phishingDetectSubtask = createTask(
       `${taskPrefix}:phishing-detect`,
-      createTaskForBundlePhishingDetect({ devMode }),
+      createTaskForBundlePhishingDetect({ devMode, testing }),
     );
 
     // task for initiating browser livereload
@@ -248,7 +248,7 @@ function createScriptTasks({
     return composeParallel(initiateLiveReload, ...allSubtasks);
   }
 
-  function createTaskForBundleDisableConsole({ devMode }) {
+  function createTaskForBundleDisableConsole({ devMode, testing }) {
     const label = 'disable-console';
     return createNormalBundle({
       browserPlatforms,
@@ -258,11 +258,12 @@ function createScriptTasks({
       entryFilepath: `./app/scripts/${label}.js`,
       ignoredFiles,
       label,
+      testing,
       shouldLintFenceFiles,
     });
   }
 
-  function createTaskForBundleSentry({ devMode }) {
+  function createTaskForBundleSentry({ devMode, testing }) {
     const label = 'sentry-install';
     return createNormalBundle({
       browserPlatforms,
@@ -272,11 +273,12 @@ function createScriptTasks({
       entryFilepath: `./app/scripts/${label}.js`,
       ignoredFiles,
       label,
+      testing,
       shouldLintFenceFiles,
     });
   }
 
-  function createTaskForBundlePhishingDetect({ devMode }) {
+  function createTaskForBundlePhishingDetect({ devMode, testing }) {
     const label = 'phishing-detect';
     return createNormalBundle({
       buildType,
@@ -286,6 +288,7 @@ function createScriptTasks({
       entryFilepath: `./app/scripts/${label}.js`,
       ignoredFiles,
       label,
+      testing,
       shouldLintFenceFiles,
     });
   }


### PR DESCRIPTION
The environment variables used for test builds was wrong for certain bundles because the `testing` flag wasn't passed through to the function that determines which environment variables to inject. Effectively this means that test builds on `master` were going to the production `metamask` Sentry project rather than the `test-metamask` project. This has been the case since #11080.

The `testing` flag is now included for all bundles, and test builds now use the `test-metamask` Sentry project in all cases.

Manual testing steps:  
  - Create a test build (`yarn build test`) with the `CIRCLE_BRANCH` environment variable set to various values (e.g. `master`, `Version-v10.8.0`, `feature-branch`, `develop`). Ensure that the environment is always set to `testing` in the Sentry initialization console message in the background.