### PR TITLE
Updating Storybook base styles

### DIFF
--- a/.storybook/manager.js
+++ b/.storybook/manager.js
@@ -1,0 +1,6 @@
+import { addons } from '@storybook/addons';
+import MetaMaskStorybookTheme from './metamask-storybook-theme';
+
+addons.setConfig({
+  theme: MetaMaskStorybookTheme,
+});

--- a/.storybook/metamask-storybook-theme.js
+++ b/.storybook/metamask-storybook-theme.js
@@ -1,0 +1,10 @@
+// .storybook/YourTheme.js
+
+import { create } from '@storybook/theming';
+import logo from '../app/images/logo/metamask-logo-horizontal.svg';
+
+export default create({
+  base: 'light',
+  brandTitle: 'MetaMask Storybook',
+  brandImage: logo,
+});

--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -9,6 +9,7 @@
   * {
     --blue-500: #037dd6;
     --blue-400: #1098fc;
+    --gray-pre-bg: #f8f8f8;
     --font-family-base: Euclid, Roboto, Helvetica, Arial, sans-serif;
     --font-family-monospace: Inconsolata, monospace;
     --font-size-code: 0.875rem;
@@ -28,6 +29,10 @@
   li {
     font-size: var(--font-size-base) !important;
     line-height: var(--line-height-base) !important;
+  }
+
+  .docblock-source {
+    background: var(--gray-pre-bg) !important;
   }
 
   code {

--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,0 +1,51 @@
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link
+  href="https://fonts.googleapis.com/css2?family=Inconsolata&display=swap"
+  rel="stylesheet"
+/>
+
+<style>
+  * {
+    --blue-500: #037dd6;
+    --blue-400: #1098fc;
+    --font-family-base: Euclid, Roboto, Helvetica, Arial, sans-serif;
+    --font-family-monospace: Inconsolata, monospace;
+    --font-size-code: 0.875rem;
+    --line-height-code: 19px;
+    --font-size-base: 1rem;
+    --line-height-base: 1.7;
+
+    font-family: var(--font-family-base) !important;
+  }
+
+  h1,
+  h2 {
+    font-weight: bold !important;
+  }
+
+  p,
+  li {
+    font-size: var(--font-size-base) !important;
+    line-height: var(--line-height-base) !important;
+  }
+
+  code {
+    font-family: var(--font-family-monospace) !important;
+    font-size: var(--font-size-code) !important;
+  }
+  code * {
+    font-family: var(--font-family-monospace) !important;
+    font-size: var(--font-size-code) !important;
+  }
+
+  a {
+    color: var(--blue-500) !important;
+  }
+
+  a:hover,
+  a:active,
+  a:focus {
+    color: var(--blue-400) !important;
+  }
+</style>


### PR DESCRIPTION
*Hmm having issues with fonts not loading on production build of storybook #12863* 
*Will address in a different PR. Use local storybook to see font changes.*

Fixes: #12499 

Explanation: The docs for storybook could use some style adjustments to improve readability.

- Adding custom theme using [storybook docs](https://storybook.js.org/docs/react/configure/theming)
- Updated brand logo
- Overwriting storybook styles to add brand fonts and improve readability

For some reason not all of the themeability options worked so had to overwrite using `preview-head.html` method which is also a recommended option in storybook.

Manual testing steps:  
  - Go to most recent [build of storybook](https://398815-42009758-gh.circle-artifacts.com/0/storybook/index.html?path=/story/getting-started-documentation-guidelines--page)(Use local build `yarn storybook`
  - Check out the Documentation Guidelines page and look at the code examples
  - See logo has changed to Metamask Logo
  - Compare it with [current/old storybook](https://metamask.github.io/metamask-storybook/index.html?path=/story/getting-started-documentation-guidelines--page)

**Images**

<img width="1440" alt="Screen Shot 2021-11-25 at 12 10 17 PM" src="https://user-images.githubusercontent.com/8112138/143496456-37401d88-f225-42c3-9d59-ab0612e80fdc.png">
<img width="1439" alt="Screen Shot 2021-11-25 at 12 12 34 PM" src="https://user-images.githubusercontent.com/8112138/143496466-af472b06-fc1d-4678-bd39-4800ac6a3771.png">

*Updating code blocks to be a light gray*

<img width="1437" alt="Screen Shot 2021-11-25 at 12 43 48 PM" src="https://user-images.githubusercontent.com/8112138/143498343-e4ce9488-2e05-4f05-8db6-173faab9dd58.png">
