### PR TITLE
Fix account name duplicates

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -74,7 +74,8 @@
     "message": "Account Name"
   },
   "accountNameDuplicate": {
-    "message": "This account name already exists"
+    "message": "This account name already exists",
+    "description": "This is an error message shown when the user enters a new account name that matches an existing account name"
   },
   "accountOptions": {
     "message": "Account Options"

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -73,6 +73,9 @@
   "accountName": {
     "message": "Account Name"
   },
+  "accountNameDuplicate": {
+    "message": "This account name already exists"
+  },
   "accountOptions": {
     "message": "Account Options"
   },

--- a/ui/components/app/modals/account-details-modal/account-details-modal.component.js
+++ b/ui/components/app/modals/account-details-modal/account-details-modal.component.js
@@ -8,6 +8,7 @@ import EditableLabel from '../../../ui/editable-label';
 import Button from '../../../ui/button';
 import { getURLHostName } from '../../../../helpers/utils/util';
 import { isHardwareKeyring } from '../../../../helpers/utils/hardware';
+import { getAccountsNames } from '../../../../selectors';
 
 export default class AccountDetailsModal extends Component {
   static propTypes = {
@@ -37,10 +38,6 @@ export default class AccountDetailsModal extends Component {
     } = this.props;
     const { name, address } = selectedIdentity;
 
-    const accountsNames = Object.values(accounts)
-      .map((item) => item.name)
-      .filter((itemName) => itemName !== name);
-
     const keyring = keyrings.find((kr) => {
       return kr.accounts.includes(address);
     });
@@ -57,7 +54,7 @@ export default class AccountDetailsModal extends Component {
           className="account-details-modal__name"
           defaultValue={name}
           onSubmit={(label) => setAccountLabel(address, label)}
-          accountsNames={accountsNames}
+          accountsNames={getAccountsNames(accounts, name)}
         />
 
         <QrView

--- a/ui/components/app/modals/account-details-modal/account-details-modal.component.js
+++ b/ui/components/app/modals/account-details-modal/account-details-modal.component.js
@@ -8,7 +8,6 @@ import EditableLabel from '../../../ui/editable-label';
 import Button from '../../../ui/button';
 import { getURLHostName } from '../../../../helpers/utils/util';
 import { isHardwareKeyring } from '../../../../helpers/utils/hardware';
-import { getAccountsNames } from '../../../../selectors';
 
 export default class AccountDetailsModal extends Component {
   static propTypes = {
@@ -41,6 +40,12 @@ export default class AccountDetailsModal extends Component {
     const keyring = keyrings.find((kr) => {
       return kr.accounts.includes(address);
     });
+
+    const getAccountsNames = (allAccounts, currentName) => {
+      return Object.values(allAccounts)
+        .map((item) => item.name)
+        .filter((itemName) => itemName !== currentName);
+    };
 
     let exportPrivateKeyFeatureEnabled = true;
     // This feature is disabled for hardware wallets

--- a/ui/components/app/modals/account-details-modal/account-details-modal.component.js
+++ b/ui/components/app/modals/account-details-modal/account-details-modal.component.js
@@ -17,6 +17,7 @@ export default class AccountDetailsModal extends Component {
     setAccountLabel: PropTypes.func,
     keyrings: PropTypes.array,
     rpcPrefs: PropTypes.object,
+    accounts: PropTypes.array,
   };
 
   static contextTypes = {
@@ -32,8 +33,13 @@ export default class AccountDetailsModal extends Component {
       setAccountLabel,
       keyrings,
       rpcPrefs,
+      accounts,
     } = this.props;
     const { name, address } = selectedIdentity;
+
+    const accountsNames = Object.values(accounts)
+      .map((item) => item.name)
+      .filter((itemName) => itemName !== name);
 
     const keyring = keyrings.find((kr) => {
       return kr.accounts.includes(address);
@@ -51,6 +57,7 @@ export default class AccountDetailsModal extends Component {
           className="account-details-modal__name"
           defaultValue={name}
           onSubmit={(label) => setAccountLabel(address, label)}
+          accountsNames={accountsNames}
         />
 
         <QrView

--- a/ui/components/app/modals/account-details-modal/account-details-modal.container.js
+++ b/ui/components/app/modals/account-details-modal/account-details-modal.container.js
@@ -4,6 +4,7 @@ import {
   getSelectedIdentity,
   getRpcPrefsForCurrentProvider,
   getCurrentChainId,
+  getMetaMaskAccountsOrdered,
 } from '../../../../selectors';
 import AccountDetailsModal from './account-details-modal.component';
 
@@ -13,6 +14,7 @@ const mapStateToProps = (state) => {
     selectedIdentity: getSelectedIdentity(state),
     keyrings: state.metamask.keyrings,
     rpcPrefs: getRpcPrefsForCurrentProvider(state),
+    accounts: getMetaMaskAccountsOrdered(state),
   };
 };
 

--- a/ui/components/app/modals/account-details-modal/account-details-modal.test.js
+++ b/ui/components/app/modals/account-details-modal/account-details-modal.test.js
@@ -30,6 +30,12 @@ describe('Account Details Modal', () => {
         name: 'Account 1',
       },
     },
+    accounts: {
+      address: '0xAddress',
+      lastSelected: 1637764711510,
+      name: 'Account 1',
+      balance: '0x543a5fb6caccf599',
+    },
   };
 
   beforeEach(() => {

--- a/ui/components/ui/editable-label/editable-label.js
+++ b/ui/components/ui/editable-label/editable-label.js
@@ -85,18 +85,21 @@ class EditableLabel extends Component {
     const { className, accountsNames } = this.props;
 
     return (
-      <div>
+      <>
         <div className={classnames('editable-label', className)}>
           {isEditing ? this.renderEditing() : this.renderReadonly()}
         </div>
         {accountsNames.includes(value) ? (
           <div
-            className={classnames('send-v2__error', 'send-v2__error-amount')}
+            className={classnames(
+              'editable-label__error',
+              'editable-label__error-amount',
+            )}
           >
             {this.context.t('accountNameDuplicate')}
           </div>
         ) : null}
-      </div>
+      </>
     );
   }
 }

--- a/ui/components/ui/editable-label/editable-label.js
+++ b/ui/components/ui/editable-label/editable-label.js
@@ -7,6 +7,11 @@ class EditableLabel extends Component {
     onSubmit: PropTypes.func.isRequired,
     defaultValue: PropTypes.string,
     className: PropTypes.string,
+    accountsNames: PropTypes.array,
+  };
+
+  static contextTypes = {
+    t: PropTypes.func,
   };
 
   state = {
@@ -16,8 +21,9 @@ class EditableLabel extends Component {
 
   handleSubmit() {
     const { value } = this.state;
+    const { accountsNames } = this.props;
 
-    if (value === '') {
+    if (value === '' || accountsNames.includes(value)) {
       return;
     }
 
@@ -28,6 +34,7 @@ class EditableLabel extends Component {
 
   renderEditing() {
     const { value } = this.state;
+    const { accountsNames } = this.props;
 
     return [
       <input
@@ -43,7 +50,8 @@ class EditableLabel extends Component {
         }}
         onChange={(event) => this.setState({ value: event.target.value })}
         className={classnames('large-input', 'editable-label__input', {
-          'editable-label__input--error': value === '',
+          'editable-label__input--error':
+            value === '' || accountsNames.includes(value),
         })}
         autoFocus
       />,
@@ -73,12 +81,21 @@ class EditableLabel extends Component {
   }
 
   render() {
-    const { isEditing } = this.state;
-    const { className } = this.props;
+    const { isEditing, value } = this.state;
+    const { className, accountsNames } = this.props;
 
     return (
-      <div className={classnames('editable-label', className)}>
-        {isEditing ? this.renderEditing() : this.renderReadonly()}
+      <div>
+        <div className={classnames('editable-label', className)}>
+          {isEditing ? this.renderEditing() : this.renderReadonly()}
+        </div>
+        {accountsNames.includes(value) ? (
+          <div
+            className={classnames('send-v2__error', 'send-v2__error-amount')}
+          >
+            {this.context.t('accountNameDuplicate')}
+          </div>
+        ) : null}
       </div>
     );
   }

--- a/ui/components/ui/editable-label/index.scss
+++ b/ui/components/ui/editable-label/index.scss
@@ -34,4 +34,15 @@
     cursor: pointer;
     color: $dusty-gray;
   }
+
+  &__error {
+    @include H7;
+
+    left: 8px;
+    color: $red;
+  }
+
+  &__error-amount {
+    margin-top: 5px;
+  }
 }

--- a/ui/pages/create-account/index.scss
+++ b/ui/pages/create-account/index.scss
@@ -89,8 +89,19 @@
     padding: 0 20px;
 
     &__error {
-      border: 1px solid $monzo;
+      border: 1px solid $error-3;
     }
+  }
+
+  &__error {
+    @include H7;
+
+    left: 8px;
+    color: $red;
+  }
+
+  &__error-amount {
+    margin-top: 5px;
   }
 
   &__buttons {

--- a/ui/pages/create-account/index.scss
+++ b/ui/pages/create-account/index.scss
@@ -87,6 +87,10 @@
     color: $scorpion;
     margin-top: 15px;
     padding: 0 20px;
+
+    &__error {
+      border: 1px solid $monzo;
+    }
   }
 
   &__buttons {

--- a/ui/pages/create-account/new-account.component.js
+++ b/ui/pages/create-account/new-account.component.js
@@ -56,6 +56,8 @@ export default class NewAccountCreateForm extends Component {
       return accountsNames.includes(accountName);
     };
 
+    const existingAccountName = accountNameExists(accounts, newAccountName);
+
     return (
       <div className="new-account-create-form">
         <div className="new-account-create-form__input-label">
@@ -64,10 +66,7 @@ export default class NewAccountCreateForm extends Component {
         <div>
           <input
             className={classnames('new-account-create-form__input', {
-              'new-account-create-form__input__error': accountNameExists(
-                accounts,
-                newAccountName,
-              ),
+              'new-account-create-form__input__error': existingAccountName,
             })}
             value={newAccountName}
             placeholder={defaultAccountName}
@@ -76,9 +75,12 @@ export default class NewAccountCreateForm extends Component {
             }
             autoFocus
           />
-          {accountNameExists(accounts, newAccountName) ? (
+          {existingAccountName ? (
             <div
-              className={classnames('send-v2__error', 'send-v2__error-amount')}
+              className={classnames(
+                ' new-account-create-form__error',
+                ' new-account-create-form__error-amount',
+              )}
             >
               {this.context.t('accountNameDuplicate')}
             </div>
@@ -97,7 +99,7 @@ export default class NewAccountCreateForm extends Component {
               large
               className="new-account-create-form__button"
               onClick={createClick}
-              disabled={accountNameExists(accounts, newAccountName)}
+              disabled={existingAccountName}
             >
               {this.context.t('create')}
             </Button>

--- a/ui/pages/create-account/new-account.component.js
+++ b/ui/pages/create-account/new-account.component.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import classnames from 'classnames';
 import Button from '../../components/ui/button';
 
 export default class NewAccountCreateForm extends Component {
@@ -16,7 +17,15 @@ export default class NewAccountCreateForm extends Component {
 
   render() {
     const { newAccountName, defaultAccountName } = this.state;
-    const { history, createAccount, mostRecentOverviewPage } = this.props;
+    const {
+      history,
+      createAccount,
+      mostRecentOverviewPage,
+      accounts,
+    } = this.props;
+
+    const accountsNames = accounts.map((item) => item.name);
+
     const createClick = (_) => {
       createAccount(newAccountName || defaultAccountName)
         .then(() => {
@@ -50,7 +59,11 @@ export default class NewAccountCreateForm extends Component {
         </div>
         <div>
           <input
-            className="new-account-create-form__input"
+            className={classnames('new-account-create-form__input', {
+              'new-account-create-form__input__error': accountsNames.includes(
+                newAccountName,
+              ),
+            })}
             value={newAccountName}
             placeholder={defaultAccountName}
             onChange={(event) =>
@@ -58,6 +71,13 @@ export default class NewAccountCreateForm extends Component {
             }
             autoFocus
           />
+          {accountsNames.includes(newAccountName) ? (
+            <div
+              className={classnames('send-v2__error', 'send-v2__error-amount')}
+            >
+              {this.context.t('accountNameDuplicate')}
+            </div>
+          ) : null}
           <div className="new-account-create-form__buttons">
             <Button
               type="secondary"
@@ -72,6 +92,7 @@ export default class NewAccountCreateForm extends Component {
               large
               className="new-account-create-form__button"
               onClick={createClick}
+              disabled={Boolean(accountsNames.includes(newAccountName))}
             >
               {this.context.t('create')}
             </Button>
@@ -87,6 +108,7 @@ NewAccountCreateForm.propTypes = {
   newAccountNumber: PropTypes.number,
   history: PropTypes.object,
   mostRecentOverviewPage: PropTypes.string.isRequired,
+  accounts: PropTypes.array,
 };
 
 NewAccountCreateForm.contextTypes = {

--- a/ui/pages/create-account/new-account.component.js
+++ b/ui/pages/create-account/new-account.component.js
@@ -96,7 +96,7 @@ export default class NewAccountCreateForm extends Component {
               large
               className="new-account-create-form__button"
               onClick={createClick}
-              disabled={accountCreateButtonDisabled}
+              disabled={accountCreateButtonDisabled()}
             >
               {this.context.t('create')}
             </Button>

--- a/ui/pages/create-account/new-account.component.js
+++ b/ui/pages/create-account/new-account.component.js
@@ -2,7 +2,6 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import Button from '../../components/ui/button';
-import { accountNameExists } from '../../selectors';
 
 export default class NewAccountCreateForm extends Component {
   static defaultProps = {
@@ -49,6 +48,12 @@ export default class NewAccountCreateForm extends Component {
             },
           });
         });
+    };
+
+    const accountNameExists = (allAccounts, accountName) => {
+      const accountsNames = allAccounts.map((item) => item.name);
+
+      return accountsNames.includes(accountName);
     };
 
     return (

--- a/ui/pages/create-account/new-account.component.js
+++ b/ui/pages/create-account/new-account.component.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import Button from '../../components/ui/button';
+import { accountNameExists } from '../../selectors';
 
 export default class NewAccountCreateForm extends Component {
   static defaultProps = {
@@ -23,12 +24,6 @@ export default class NewAccountCreateForm extends Component {
       mostRecentOverviewPage,
       accounts,
     } = this.props;
-
-    const accountsNames = accounts.map((item) => item.name);
-
-    const accountCreateButtonDisabled = () => {
-      return Boolean(accountsNames.includes(newAccountName));
-    };
 
     const createClick = (_) => {
       createAccount(newAccountName || defaultAccountName)
@@ -64,7 +59,8 @@ export default class NewAccountCreateForm extends Component {
         <div>
           <input
             className={classnames('new-account-create-form__input', {
-              'new-account-create-form__input__error': accountsNames.includes(
+              'new-account-create-form__input__error': accountNameExists(
+                accounts,
                 newAccountName,
               ),
             })}
@@ -75,7 +71,7 @@ export default class NewAccountCreateForm extends Component {
             }
             autoFocus
           />
-          {accountsNames.includes(newAccountName) ? (
+          {accountNameExists(accounts, newAccountName) ? (
             <div
               className={classnames('send-v2__error', 'send-v2__error-amount')}
             >
@@ -96,7 +92,7 @@ export default class NewAccountCreateForm extends Component {
               large
               className="new-account-create-form__button"
               onClick={createClick}
-              disabled={accountCreateButtonDisabled()}
+              disabled={accountNameExists(accounts, newAccountName)}
             >
               {this.context.t('create')}
             </Button>

--- a/ui/pages/create-account/new-account.component.js
+++ b/ui/pages/create-account/new-account.component.js
@@ -26,6 +26,10 @@ export default class NewAccountCreateForm extends Component {
 
     const accountsNames = accounts.map((item) => item.name);
 
+    const accountCreateButtonDisabled = () => {
+      return Boolean(accountsNames.includes(newAccountName));
+    };
+
     const createClick = (_) => {
       createAccount(newAccountName || defaultAccountName)
         .then(() => {
@@ -92,7 +96,7 @@ export default class NewAccountCreateForm extends Component {
               large
               className="new-account-create-form__button"
               onClick={createClick}
-              disabled={Boolean(accountsNames.includes(newAccountName))}
+              disabled={accountCreateButtonDisabled}
             >
               {this.context.t('create')}
             </Button>

--- a/ui/pages/create-account/new-account.container.js
+++ b/ui/pages/create-account/new-account.container.js
@@ -1,6 +1,7 @@
 import { connect } from 'react-redux';
 import * as actions from '../../store/actions';
 import { getMostRecentOverviewPage } from '../../ducks/history/history';
+import { getMetaMaskAccountsOrdered } from '../../selectors';
 import NewAccountCreateForm from './new-account.component';
 
 const mapStateToProps = (state) => {
@@ -13,6 +14,7 @@ const mapStateToProps = (state) => {
   return {
     newAccountNumber,
     mostRecentOverviewPage: getMostRecentOverviewPage(state),
+    accounts: getMetaMaskAccountsOrdered(state),
   };
 };
 

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -802,3 +802,25 @@ export function getIsAdvancedGasFeeDefault(state) {
     Boolean(advancedGasFee?.maxBaseFee) && Boolean(advancedGasFee?.priorityFee)
   );
 }
+
+/**
+ *  To check if the specific accountName is included in the accountsNames array which is consisted of the current user's accounts
+ *  @returns Boolean
+ */
+
+export function accountNameExists(accounts, accountName) {
+  const accountsNames = accounts.map((item) => item.name);
+
+  return accountsNames.includes(accountName);
+}
+
+/**
+ *  To get the current user's account names not including the current checked one
+ *  @returns Array
+ */
+
+export function getAccountsNames(accounts, name) {
+  return Object.values(accounts)
+    .map((item) => item.name)
+    .filter((itemName) => itemName !== name);
+}

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -802,25 +802,3 @@ export function getIsAdvancedGasFeeDefault(state) {
     Boolean(advancedGasFee?.maxBaseFee) && Boolean(advancedGasFee?.priorityFee)
   );
 }
-
-/**
- *  To check if the specific accountName is included in the accountsNames array which is consisted of the current user's accounts
- *  @returns Boolean
- */
-
-export function accountNameExists(accounts, accountName) {
-  const accountsNames = accounts.map((item) => item.name);
-
-  return accountsNames.includes(accountName);
-}
-
-/**
- *  To get the current user's account names not including the current checked one
- *  @returns Array
- */
-
-export function getAccountsNames(accounts, name) {
-  return Object.values(accounts)
-    .map((item) => item.name)
-    .filter((itemName) => itemName !== name);
-}


### PR DESCRIPTION
**Fixes**: https://github.com/MetaMask/metamask-extension/issues/12421

**Explanation**:  
When editing an existing account name or adding a new account, the user is not allowed to repeat an account name that already exists.

**Screencast**:

https://user-images.githubusercontent.com/92310504/143558318-628d2e15-4e2f-43f7-8b37-53db9a7fcdce.mp4

