### PR TITLE
Use node-browsers-medium-plus executor for validate-lavamoat-config job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -203,7 +203,7 @@ jobs:
           - build-artifacts
 
   validate-lavamoat-config:
-    executor: node-browsers
+    executor: node-browsers-medium-plus
     steps:
       - checkout
       - attach_workspace:


### PR DESCRIPTION
The `validate-lavamoat-config` job was failing on the v10.7.0 branch, which is the first RC it's been included in. It seems that the job was taking a long time, so we needed to increase the runner size. I tested this by temporarily pushing it to the Version-v10.7.0 branch