### PR TITLE
Fix identicon component for new Storybook format

### DIFF
--- a/ui/components/ui/identicon/README.mdx
+++ b/ui/components/ui/identicon/README.mdx
@@ -4,7 +4,7 @@ import Identicon from './identicon.component';
 
 # Identicon
 
-Randomly generated profile icon for users
+An identifier component that can be supplied an image or randomly generates one based on the account address.
 
 <Canvas>
   <Story id="ui-components-ui-identicon-identicon-stories-js--default-story" />

--- a/ui/components/ui/identicon/README.mdx
+++ b/ui/components/ui/identicon/README.mdx
@@ -1,0 +1,37 @@
+import { Story, Canvas, ArgsTable } from '@storybook/addon-docs';
+
+import Identicon from './identicon.component';
+
+# Identicon
+
+Randomly generated profile icon for users
+
+<Canvas>
+  <Story id="ui-components-ui-identicon-identicon-stories-js--default-story" />
+</Canvas>
+
+## Component API
+
+<ArgsTable of={Identicon} />
+
+## Usage
+
+### With Image
+
+Use with custom image
+
+<Canvas>
+  <Story id="ui-components-ui-identicon-identicon-stories-js--with-image" />
+</Canvas>
+
+### With Blockie
+
+<Canvas>
+  <Story id="ui-components-ui-identicon-identicon-stories-js--with-blockie" />
+</Canvas>
+
+### With Border
+
+<Canvas>
+  <Story id="ui-components-ui-identicon-identicon-stories-js--with-border" />
+</Canvas>

--- a/ui/components/ui/identicon/identicon.component.js
+++ b/ui/components/ui/identicon/identicon.component.js
@@ -13,11 +13,12 @@ const getStyles = (diameter) => ({
 export default class Identicon extends PureComponent {
   static propTypes = {
     /**
-     * Check if adding border
+     * Adds blue border around the Identicon used for selected account.
+     * Increases the width and height of the Identicon by 8px
      */
     addBorder: PropTypes.bool,
     /**
-     * Add address for identicon user
+     * Address used for generating random image
      */
     address: PropTypes.string,
     /**
@@ -25,19 +26,20 @@ export default class Identicon extends PureComponent {
      */
     className: PropTypes.string,
     /**
-     * Add custom diameter
+     * Sets the width and height of the inner img element
+     * If addBorder is true will increase components height and width by 8px
      */
     diameter: PropTypes.number,
     /**
-     * Add custom image from file path
+     * Used as the image source of the Identicon
      */
     image: PropTypes.string,
     /**
-     * Check if use blockie
+     * Use the blockie type random image generator
      */
     useBlockie: PropTypes.bool,
     /**
-     * Show alt text content
+     * The alt text of the image
      */
     alt: PropTypes.string,
     /**
@@ -125,6 +127,8 @@ export default class Identicon extends PureComponent {
       useTokenDetection,
       tokenList,
     } = this.props;
+    const size = diameter + 8;
+
     if (image) {
       return this.renderImage();
     }
@@ -141,6 +145,7 @@ export default class Identicon extends PureComponent {
       return (
         <div
           className={classnames({ 'identicon__address-wrapper': addBorder })}
+          style={getStyles(size)}
         >
           {useBlockie ? this.renderBlockie() : this.renderJazzicon()}
         </div>

--- a/ui/components/ui/identicon/identicon.component.js
+++ b/ui/components/ui/identicon/identicon.component.js
@@ -12,15 +12,45 @@ const getStyles = (diameter) => ({
 
 export default class Identicon extends PureComponent {
   static propTypes = {
+    /**
+     * Check if adding border
+     */
     addBorder: PropTypes.bool,
+    /**
+     * Add address for identicon user
+     */
     address: PropTypes.string,
+    /**
+     * Add custom css class
+     */
     className: PropTypes.string,
+    /**
+     * Add custom diameter
+     */
     diameter: PropTypes.number,
+    /**
+     * Add custom image from file path
+     */
     image: PropTypes.string,
+    /**
+     * Check if use blockie
+     */
     useBlockie: PropTypes.bool,
+    /**
+     * Show alt text content
+     */
     alt: PropTypes.string,
+    /**
+     * Check if show image border
+     */
     imageBorder: PropTypes.bool,
+    /**
+     * Check if use token detection
+     */
     useTokenDetection: PropTypes.bool,
+    /**
+     * Add list of token in object
+     */
     tokenList: PropTypes.object,
   };
 

--- a/ui/components/ui/identicon/identicon.stories.js
+++ b/ui/components/ui/identicon/identicon.stories.js
@@ -1,49 +1,64 @@
 import React from 'react';
-import { text, boolean, number } from '@storybook/addon-knobs';
+import README from './README.mdx';
 import Identicon from './identicon.component';
 
 export default {
   title: 'Components/UI/Identicon',
   id: __filename,
+  component: Identicon,
+  parameters: {
+    docs: {
+      page: README,
+    },
+  },
+  argTypes: {
+    addBorder: { control: 'boolean' },
+    address: { control: 'text' },
+    className: { control: 'text' },
+    diameter: { control: 'number' },
+    image: { control: 'text' },
+    useBlockie: { control: 'boolean' },
+    alt: { control: 'boolean' },
+    imageBorder: { control: 'boolean' },
+    useTokenDetection: { control: 'boolean' },
+    tokenList: { control: 'object' },
+  },
 };
 
-const diameterOptions = {
-  range: true,
-  min: 10,
-  max: 200,
-  step: 1,
-};
-export const DefaultStory = () => (
-  <Identicon
-    addBorder={boolean('Add Border', Identicon.defaultProps.addBorder)}
-    address={text('Address', '0x5CfE73b6021E818B776b421B1c4Db2474086a7e1')}
-    diameter={number(
-      'Diameter',
-      Identicon.defaultProps.diameter,
-      diameterOptions,
-    )}
-    useBlockie={boolean('Use Blockie', Identicon.defaultProps.useBlockie)}
-  />
-);
+export const DefaultStory = (args) => <Identicon {...args} />;
 
 DefaultStory.storyName = 'Default';
+DefaultStory.args = {
+  addBorder: false,
+  address: '0x5CfE73b6021E818B776b421B1c4Db2474086a7e1',
+  diameter: 46,
+  useBlockie: false,
+};
 
-export const Image = () => <Identicon image="./images/eth_logo.svg" />;
+export const WithImage = (args) => <Identicon {...args} />;
+WithImage.args = {
+  addBorder: false,
+  address: '0x5CfE73b6021E818B776b421B1c4Db2474086a7e1',
+  diameter: 46,
+  useBlockie: false,
+  image: './images/eth_logo.svg',
+};
 
-export const Blockie = () => (
-  <Identicon
-    address={text('Address', '0x5CfE73b6021E818B776b421B1c4Db2474086a7e1')}
-    useBlockie={boolean('Use Blockie', true)}
-  />
-);
+export const WithBlockie = (args) => <Identicon {...args} />;
+WithBlockie.args = {
+  addBorder: false,
+  address: '0x5CfE73b6021E818B776b421B1c4Db2474086a7e1',
+  diameter: 46,
+  useBlockie: true,
+};
 
-// The border size is hard-coded in CSS, and was designed with this size identicon in mind
+// // The border size is hard-coded in CSS, and was designed with this size identicon in mind
 const withBorderDiameter = 32;
 
-export const WithBorder = () => (
-  <Identicon
-    addBorder={boolean('Add Border', true)}
-    address={text('Address', '0x5CfE73b6021E818B776b421B1c4Db2474086a7e1')}
-    diameter={number('Diameter', withBorderDiameter, diameterOptions)}
-  />
-);
+export const WithBorder = (args) => <Identicon {...args} />;
+WithBorder.args = {
+  addBorder: true,
+  address: '0x5CfE73b6021E818B776b421B1c4Db2474086a7e1',
+  diameter: withBorderDiameter,
+  useBlockie: false,
+};

--- a/ui/components/ui/identicon/identicon.stories.js
+++ b/ui/components/ui/identicon/identicon.stories.js
@@ -18,7 +18,7 @@ export default {
     diameter: { control: 'number' },
     image: { control: 'text' },
     useBlockie: { control: 'boolean' },
-    alt: { control: 'boolean' },
+    alt: { control: 'text' },
     imageBorder: { control: 'boolean' },
     useTokenDetection: { control: 'boolean' },
     tokenList: { control: 'object' },
@@ -31,34 +31,32 @@ DefaultStory.storyName = 'Default';
 DefaultStory.args = {
   addBorder: false,
   address: '0x5CfE73b6021E818B776b421B1c4Db2474086a7e1',
-  diameter: 46,
+  diameter: 32,
   useBlockie: false,
 };
 
 export const WithImage = (args) => <Identicon {...args} />;
 WithImage.args = {
   addBorder: false,
-  address: '0x5CfE73b6021E818B776b421B1c4Db2474086a7e1',
-  diameter: 46,
+  diameter: 32,
   useBlockie: false,
   image: './images/eth_logo.svg',
+  alt: 'Ethereum',
+  imageBorder: true,
 };
 
 export const WithBlockie = (args) => <Identicon {...args} />;
 WithBlockie.args = {
   addBorder: false,
   address: '0x5CfE73b6021E818B776b421B1c4Db2474086a7e1',
-  diameter: 46,
+  diameter: 32,
   useBlockie: true,
 };
-
-// // The border size is hard-coded in CSS, and was designed with this size identicon in mind
-const withBorderDiameter = 32;
 
 export const WithBorder = (args) => <Identicon {...args} />;
 WithBorder.args = {
   addBorder: true,
   address: '0x5CfE73b6021E818B776b421B1c4Db2474086a7e1',
-  diameter: withBorderDiameter,
+  diameter: 32,
   useBlockie: false,
 };

--- a/ui/components/ui/identicon/index.scss
+++ b/ui/components/ui/identicon/index.scss
@@ -8,9 +8,6 @@
   overflow: hidden;
 
   &__address-wrapper {
-    height: 40px;
-    width: 40px;
-    border-radius: 18px;
     display: flex;
     justify-content: center;
     align-items: center;


### PR DESCRIPTION
Updating `Identicon` component and story:
- Update `withBorder` to work at any size instead of hard coding the width, height and border-radius values
- Add js doc comments to proptypes to allow ArgsTable to show up
- Add `README.MDX`
- Add controls for interaction of component

**Manual testing steps**
- Go to latest CI build of storybook or run `yarn storybook`
- Search "Identicon" in storybook
- Use Controls to interact with component
- Check docs page to see Props table

**Images**
<img width="1440" alt="Screen Shot 2021-12-04 at 12 21 49 PM" src="https://user-images.githubusercontent.com/8112138/144723635-424a604e-f862-4f41-b592-3674b8f2dddd.png">

![screencapture-localhost-6006-2021-12-04-12_23_04](https://user-images.githubusercontent.com/8112138/144723637-6184753d-2879-4b02-9b64-68491d2e79e6.png)