### PR TITLE
Fix account-list-item component for new Storybook format

### DIFF
--- a/ui/components/app/account-list-item/README.mdx
+++ b/ui/components/app/account-list-item/README.mdx
@@ -1,0 +1,14 @@
+import { Story, Canvas, ArgsTable } from '@storybook/addon-docs';
+import AccountListItem from '.';
+
+# Account List Item
+
+Account List Item is referred for each account item on the Account List's component
+
+<Canvas>
+  <Story id="ui-components-app-account-list-item-account-list-item-stories-js--default-story" />
+</Canvas>
+
+## Component API
+
+<ArgsTable of={AccountListItem} />

--- a/ui/components/app/account-list-item/account-list-item.js
+++ b/ui/components/app/account-list-item/account-list-item.js
@@ -39,9 +39,24 @@ export default function AccountListItem({
 }
 
 AccountListItem.propTypes = {
+  /**
+   * an account data that have name, address, and balance inside it
+   */
   account: PropTypes.object,
+  /**
+   * adding css class for account list item
+   */
   className: PropTypes.string,
+  /**
+   * show address of the account
+   */
   displayAddress: PropTypes.bool,
+  /**
+   * give expected behavior as function after the button clicked
+   */
   handleClick: PropTypes.func,
+  /**
+   * display icon content on the right side of the component
+   */
   icon: PropTypes.node,
 };

--- a/ui/components/app/account-list-item/account-list-item.js
+++ b/ui/components/app/account-list-item/account-list-item.js
@@ -40,23 +40,27 @@ export default function AccountListItem({
 
 AccountListItem.propTypes = {
   /**
-   * an account data that have name, address, and balance inside it
+   * An account object that has name, address, and balance data
    */
-  account: PropTypes.object,
+  account: PropTypes.shape({
+    address: PropTypes.string.isRequired,
+    balance: PropTypes.string,
+    name: PropTypes.string,
+  }),
   /**
-   * adding css class for account list item
+   * Additional className to add to the root div element of AccountListItem
    */
   className: PropTypes.string,
   /**
-   * show address of the account
+   * Display the address of the account object
    */
   displayAddress: PropTypes.bool,
   /**
-   * give expected behavior as function after the button clicked
+   * The onClick handler of the AccountListItem
    */
   handleClick: PropTypes.func,
   /**
-   * display icon content on the right side of the component
+   * Pass icon component to be displayed. Currently not used
    */
   icon: PropTypes.node,
 };

--- a/ui/components/app/account-list-item/account-list-item.stories.js
+++ b/ui/components/app/account-list-item/account-list-item.stories.js
@@ -1,13 +1,39 @@
 import React from 'react';
+import { store } from '../../../../.storybook/preview';
+import README from './README.mdx';
 import AccountListItem from './account-list-item';
+
+const { metamask } = store.getState();
+const { addresses } = metamask;
 
 export default {
   title: 'Components/App/AccountListItem',
   id: __filename,
+  component: AccountListItem,
+  parameters: {
+    docs: {
+      page: README,
+    },
+  },
+  argTypes: {
+    account: {
+      control: 'object',
+    },
+    className: { control: 'text' },
+    displayAddress: { control: 'boolean' },
+    handleClick: { action: 'clicked' },
+    icon: { control: 'object' },
+  },
 };
 
-export const DefaultStory = () => {
-  return <AccountListItem />;
+export const DefaultStory = (args) => {
+  return <AccountListItem {...args} />;
+};
+
+DefaultStory.storyName = 'Default';
+DefaultStory.args = {
+  account: Object.values(addresses)[0],
+  displayAddress: false,
 };
 
 DefaultStory.storyName = 'Default';

--- a/ui/components/app/account-list-item/account-list-item.stories.js
+++ b/ui/components/app/account-list-item/account-list-item.stories.js
@@ -1,10 +1,6 @@
 import React from 'react';
-import { store } from '../../../../.storybook/preview';
 import README from './README.mdx';
 import AccountListItem from './account-list-item';
-
-const { metamask } = store.getState();
-const { addresses } = metamask;
 
 export default {
   title: 'Components/App/AccountListItem',
@@ -21,9 +17,14 @@ export default {
     },
     className: { control: 'text' },
     displayAddress: { control: 'boolean' },
-    handleClick: { action: 'clicked' },
-    icon: { control: 'object' },
+    handleClick: { action: 'handleClick' },
   },
+};
+
+const account = {
+  name: 'Account 2',
+  address: '0xb19ac54efa18cc3a14a5b821bfec73d284bf0c5e',
+  balance: '0x2d3142f5000',
 };
 
 export const DefaultStory = (args) => {
@@ -32,7 +33,7 @@ export const DefaultStory = (args) => {
 
 DefaultStory.storyName = 'Default';
 DefaultStory.args = {
-  account: Object.values(addresses)[0],
+  account,
   displayAddress: false,
 };
 


### PR DESCRIPTION
`ArgsTable` doesn't work because of #12994. Will automatically be fixed once issue is fixed

Updating `AccountListItem` story:
- Add js doc comments to proptypes to allow ArgsTable to show up
- Add `README.MDX`
- Add controls for interaction of component

**Manual testing steps**
- Go to latest CI build of storybook or run `yarn storybook`
- Search "AccountListItem" in storybook
- Use Controls to interact with component
- Check docs page to see Props table

**Images**
<img width="1439" alt="Screen Shot 2021-12-04 at 7 23 50 PM" src="https://user-images.githubusercontent.com/8112138/144732177-aa2bbc52-8e99-46eb-83e4-f262b2fad03b.png">
<img width="1439" alt="Screen Shot 2021-12-04 at 7 23 58 PM" src="https://user-images.githubusercontent.com/8112138/144732180-637c4869-82a4-47ad-9bdf-e636f967206d.png">
