### PR TITLE
Fix unlock-page component for new Storybook format 

### DIFF
--- a/ui/pages/unlock-page/README.mdx
+++ b/ui/pages/unlock-page/README.mdx
@@ -1,0 +1,15 @@
+import { Story, Canvas, ArgsTable } from '@storybook/addon-docs';
+
+import UnlockPage from '.';
+
+# Unlock Page
+
+Portal page for user to auth the access of their account
+
+<Canvas>
+  <Story id="ui-pages-unlock-page-unlock-page-stories-js--default-story" />
+</Canvas>
+
+## Component API
+
+<ArgsTable of={UnlockPage} />

--- a/ui/pages/unlock-page/README.mdx
+++ b/ui/pages/unlock-page/README.mdx
@@ -12,4 +12,16 @@ Portal page for user to auth the access of their account
 
 ## Component API
 
-<ArgsTable of={UnlockPage} />
+<!--
+ArgsTable doesn't work with SectionShape
+<ArgsTable of={MetaMaskTranslation} />
+-->
+
+| Name                       | Description                                                                |
+| -------------------------- | -------------------------------------------------------------------------- |
+| `history`                  | History router for redirect after action `object`                          |
+| `isUnlocked`               | If isUnlocked is true will redirect to most recent route in history `bool` |
+| `onRestore`                | onClick handler for "import using Secret Recovery Phrase" link `func`      |
+| `onSubmit`                 | onSumbit handler when form is submitted `func`                             |
+| `forceUpdateMetamaskState` | Force update metamask data state `func`                                    |
+| `showOptInModal`           | Event handler to show metametrics modal `func`                             |

--- a/ui/pages/unlock-page/unlock-page.component.js
+++ b/ui/pages/unlock-page/unlock-page.component.js
@@ -14,11 +14,29 @@ export default class UnlockPage extends Component {
   };
 
   static propTypes = {
+    /**
+     * History router for redirect after action
+     */
     history: PropTypes.object.isRequired,
+    /**
+     * Check if account is unlocked
+     */
     isUnlocked: PropTypes.bool,
+    /**
+     * Restore account button handler
+     */
     onRestore: PropTypes.func,
+    /**
+     * Submit button handler
+     */
     onSubmit: PropTypes.func,
+    /**
+     * Force update metamask data state
+     */
     forceUpdateMetamaskState: PropTypes.func,
+    /**
+     * Show options in modal handler
+     */
     showOptInModal: PropTypes.func,
   };
 

--- a/ui/pages/unlock-page/unlock-page.component.js
+++ b/ui/pages/unlock-page/unlock-page.component.js
@@ -19,15 +19,15 @@ export default class UnlockPage extends Component {
      */
     history: PropTypes.object.isRequired,
     /**
-     * Check if account is unlocked
+     * If isUnlocked is true will redirect to most recent route in history
      */
     isUnlocked: PropTypes.bool,
     /**
-     * Restore account button handler
+     * onClick handler for "import using Secret Recovery Phrase" link
      */
     onRestore: PropTypes.func,
     /**
-     * Submit button handler
+     * onSumbit handler when form is submitted
      */
     onSubmit: PropTypes.func,
     /**
@@ -35,7 +35,7 @@ export default class UnlockPage extends Component {
      */
     forceUpdateMetamaskState: PropTypes.func,
     /**
-     * Show options in modal handler
+     * Event handler to show metametrics modal
      */
     showOptInModal: PropTypes.func,
   };

--- a/ui/pages/unlock-page/unlock-page.stories.js
+++ b/ui/pages/unlock-page/unlock-page.stories.js
@@ -1,23 +1,38 @@
+import { createBrowserHistory } from 'history';
 import React from 'react';
-import { action } from '@storybook/addon-actions';
+import README from './README.mdx';
 import UnlockPage from './unlock-page.component';
 
 export default {
   title: 'Pages/UnlockPage',
   id: __filename,
+  component: UnlockPage,
+  parameters: {
+    docs: {
+      page: README,
+    },
+  },
+  argTypes: {
+    history: { control: 'object' },
+    isUnlocked: { control: 'boolean' },
+    onRestore: { action: 'onRestore' },
+    onSubmit: { action: 'onSubmit' },
+    forceUpdateMetamaskState: { action: 'forceUpdateMetamaskState' },
+    showOptInModal: { action: 'showOptInModal' },
+  },
 };
 
-export const DefaultStory = () => {
-  return (
-    <UnlockPage
-      onSubmit={action('Login')}
-      forceUpdateMetamaskState={() => ({
-        participateInMetaMetrics: true,
-      })}
-      showOptInModal={() => null}
-      history={{}}
-    />
-  );
+export const DefaultStory = (args) => {
+  const history = createBrowserHistory();
+  return <UnlockPage {...args} history={history} />;
+};
+
+DefaultStory.storyName = 'Default';
+
+DefaultStory.args = {
+  forceUpdateMetamaskState: () => ({
+    participateInMetaMetrics: true,
+  }),
 };
 
 DefaultStory.storyName = 'Default';


### PR DESCRIPTION
Updating `UnlockPage` story:
- Manually adding ArgsTable
- Add `README.MDX`
- Add controls for interaction of component

**Manual testing steps**
- Go to latest CI build of storybook or run `yarn storybook`
- Search "UnlockPage" in storybook
- Use Controls to interact with component
- Check docs page to see Props table

**Images**
<img width="1440" alt="Screen Shot 2021-12-04 at 7 43 08 PM" src="https://user-images.githubusercontent.com/8112138/144732584-5dd20805-38b7-420b-9e2e-6174513ee772.png">

![screencapture-localhost-6006-2021-12-04-19_43_30](https://user-images.githubusercontent.com/8112138/144732588-fa3c32ee-b9d5-474b-9e52-c4bc07ae0465.png)

