### PR TITLE
Fix dropdown-input-pair component to for new Storybook format

### DIFF
--- a/ui/pages/swaps/dropdown-input-pair/README.mdx
+++ b/ui/pages/swaps/dropdown-input-pair/README.mdx
@@ -1,0 +1,15 @@
+import { Story, Canvas, ArgsTable } from '@storybook/addon-docs';
+
+import DropdownInputPair from '.';
+
+# Dropdown Input Pair
+
+Dropdown to choose cryptocurrency with amount input field.
+
+<Canvas>
+  <Story id="ui-pages-swaps-dropdown-input-pair-dropdown-input-pair-stories-js--default-story" />
+</Canvas>
+
+## Component API
+
+<ArgsTable of={DropdownInputPair} />

--- a/ui/pages/swaps/dropdown-input-pair/dropdown-input-pair.js
+++ b/ui/pages/swaps/dropdown-input-pair/dropdown-input-pair.js
@@ -147,7 +147,7 @@ DropdownInputPair.propTypes = {
    */
   selectedItem: PropTypes.object,
   /**
-   * Handler for SearchListPlaceholder
+   * Doesn't look like this is used
    */
   SearchListPlaceholder: PropTypes.func,
   /**

--- a/ui/pages/swaps/dropdown-input-pair/dropdown-input-pair.js
+++ b/ui/pages/swaps/dropdown-input-pair/dropdown-input-pair.js
@@ -122,17 +122,56 @@ export default function DropdownInputPair({
 }
 
 DropdownInputPair.propTypes = {
+  /**
+   * Give items data for the component
+   */
   itemsToSearch: PropTypes.array,
+  /**
+   * Handler for input change
+   */
   onInputChange: PropTypes.func,
+  /**
+   * Show input value content
+   */
   inputValue: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+  /**
+   * Handler for onSelect
+   */
   onSelect: PropTypes.func,
+  /**
+   * Set value to left
+   */
   leftValue: PropTypes.string,
+  /**
+   * Show selected item
+   */
   selectedItem: PropTypes.object,
+  /**
+   * Handler for SearchListPlaceholder
+   */
   SearchListPlaceholder: PropTypes.func,
+  /**
+   * Define maximum item per list
+   */
   maxListItems: PropTypes.number,
+  /**
+   * Show select placeholder text
+   */
   selectPlaceHolderText: PropTypes.string,
+  /**
+   * Check if the component is loading
+   */
   loading: PropTypes.bool,
+  /**
+   * Handler for hide item
+   */
   hideItemIf: PropTypes.func,
+  /**
+   * Add custom CSS class for list container
+   */
   listContainerClassName: PropTypes.string,
+  /**
+   * Check if the component is auto focus
+   */
   autoFocus: PropTypes.bool,
 };

--- a/ui/pages/swaps/dropdown-input-pair/dropdown-input-pair.stories.js
+++ b/ui/pages/swaps/dropdown-input-pair/dropdown-input-pair.stories.js
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import README from './README.mdx';
 import DropdownInputPair from '.';
 
 const tokens = [
@@ -115,6 +116,27 @@ const tokens = [
 export default {
   title: 'Pages/Swaps/DropdownInputPair',
   id: __filename,
+  component: DropdownInputPair,
+  parameters: {
+    docs: {
+      page: README,
+    },
+  },
+  argTypes: {
+    itemsToSearch: { control: 'array' },
+    onInputChange: { action: 'onInputChange' },
+    inputValue: { control: 'text' },
+    onSelect: { action: 'onSelect' },
+    leftValue: { control: 'text' },
+    selectedItem: { control: 'object' },
+    SearchListPlaceholder: { action: 'SearchListPlaceHolder' },
+    maxListItems: { control: 'number' },
+    selectPlaceHolderText: { control: 'text' },
+    loading: { control: 'boolean' },
+    hideItemIf: { action: 'hideItemIf' },
+    listContainerClassName: { control: 'text' },
+    autoFocus: { control: 'boolean' },
+  },
 };
 
 const tokensToSearch = tokens.map((token) => ({
@@ -127,9 +149,8 @@ const tokensToSearch = tokens.map((token) => ({
   rightSecondaryLabel: `$${(Math.random() * 1000).toFixed(2)}`,
 }));
 
-export const DefaultStory = () => {
+export const DefaultStory = (args) => {
   const [inputValue, setInputValue] = useState();
-
   return (
     <div
       style={{
@@ -141,15 +162,19 @@ export const DefaultStory = () => {
       }}
     >
       <DropdownInputPair
-        startingItem={tokensToSearch[0]}
-        itemsToSearch={tokensToSearch}
-        maxListItems={tokensToSearch.length}
-        defaultToAll
-        onInputChange={(value) => setInputValue(value)}
+        {...args}
         inputValue={inputValue}
+        onInputChange={(value) => setInputValue(value)}
       />
     </div>
   );
 };
 
 DefaultStory.storyName = 'Default';
+
+DefaultStory.args = {
+  startingItem: tokensToSearch[0],
+  itemsToSearch: tokensToSearch,
+  maxListItems: tokensToSearch.length,
+  selectedItem: tokensToSearch[0],
+};

--- a/ui/pages/swaps/dropdown-input-pair/dropdown-input-pair.stories.js
+++ b/ui/pages/swaps/dropdown-input-pair/dropdown-input-pair.stories.js
@@ -1,4 +1,6 @@
-import React, { useState } from 'react';
+import React from 'react';
+import { useArgs } from '@storybook/client-api';
+
 import README from './README.mdx';
 import DropdownInputPair from '.';
 
@@ -129,11 +131,9 @@ export default {
     onSelect: { action: 'onSelect' },
     leftValue: { control: 'text' },
     selectedItem: { control: 'object' },
-    SearchListPlaceholder: { action: 'SearchListPlaceHolder' },
     maxListItems: { control: 'number' },
     selectPlaceHolderText: { control: 'text' },
     loading: { control: 'boolean' },
-    hideItemIf: { action: 'hideItemIf' },
     listContainerClassName: { control: 'text' },
     autoFocus: { control: 'boolean' },
   },
@@ -150,31 +150,26 @@ const tokensToSearch = tokens.map((token) => ({
 }));
 
 export const DefaultStory = (args) => {
-  const [inputValue, setInputValue] = useState();
+  const [
+    { inputValue, selectedItem = tokensToSearch[0] },
+    updateArgs,
+  ] = useArgs();
   return (
-    <div
-      style={{
-        height: '600px',
-        width: '357px',
-        display: 'flex',
-        justifyContent: 'center',
-        flexFlow: 'column',
+    <DropdownInputPair
+      {...args}
+      inputValue={inputValue}
+      onInputChange={(value) => {
+        updateArgs({ ...args, inputValue: value });
       }}
-    >
-      <DropdownInputPair
-        {...args}
-        inputValue={inputValue}
-        onInputChange={(value) => setInputValue(value)}
-      />
-    </div>
+      selectedItem={selectedItem}
+    />
   );
 };
 
 DefaultStory.storyName = 'Default';
 
 DefaultStory.args = {
-  startingItem: tokensToSearch[0],
   itemsToSearch: tokensToSearch,
   maxListItems: tokensToSearch.length,
-  selectedItem: tokensToSearch[0],
+  loading: false,
 };


### PR DESCRIPTION
`ArgsTable` doesn't work because of #12994. Will automatically be fixed once issue is fixed

Updating `DropdownInputPair` story:
- Add js doc comments to proptypes to allow ArgsTable to show up
- Add `README.MDX`
- Add controls for interaction of component

**Manual testing steps**
- Go to latest CI build of storybook or run `yarn storybook`
- Search "DropdownInputPair" in storybook
- Use Controls to interact with component

**Images**
<img width="1440" alt="Screen Shot 2021-12-07 at 3 38 45 PM" src="https://user-images.githubusercontent.com/8112138/144956090-450fc686-e4fc-457c-bc88-9b5594448105.png">

