### PR TITLE
Fix radio-group component to for new Storybook format

### DIFF
--- a/ui/components/ui/radio-group/README.mdx
+++ b/ui/components/ui/radio-group/README.mdx
@@ -1,0 +1,15 @@
+import { Story, Canvas, ArgsTable } from '@storybook/addon-docs';
+
+import RadioGroup from '.';
+
+# Radio Group
+
+A multiple-exclusion scope for a set of radio buttons.
+
+<Canvas>
+  <Story id="ui-components-ui-radio-group-radio-group-stories-js--default-story" />
+</Canvas>
+
+## Component API
+
+<ArgsTable of={RadioGroup} />

--- a/ui/components/ui/radio-group/radio-group.component.js
+++ b/ui/components/ui/radio-group/radio-group.component.js
@@ -85,9 +85,21 @@ export default function RadioGroup({ options, name, selectedValue, onChange }) {
 }
 
 RadioGroup.propTypes = {
+  /**
+   * Options for radio button group
+   */
   options: PropTypes.array,
+  /**
+   * Currently selected value
+   */
   selectedValue: PropTypes.string,
+  /**
+   * Name of radio group
+   */
   name: PropTypes.string,
+  /**
+   * Function to be called on radio change
+   */
   onChange: PropTypes.func,
 };
 

--- a/ui/components/ui/radio-group/radio-group.component.js
+++ b/ui/components/ui/radio-group/radio-group.component.js
@@ -86,19 +86,19 @@ export default function RadioGroup({ options, name, selectedValue, onChange }) {
 
 RadioGroup.propTypes = {
   /**
-   * Options for radio button group
+   * Predefined options for radio group
    */
   options: PropTypes.array,
   /**
-   * Currently selected value
+   * Show selected value
    */
   selectedValue: PropTypes.string,
   /**
-   * Name of radio group
+   * Show name as label
    */
   name: PropTypes.string,
   /**
-   * Function to be called on radio change
+   * Handler for onChange
    */
   onChange: PropTypes.func,
 };

--- a/ui/components/ui/radio-group/radio-group.stories.js
+++ b/ui/components/ui/radio-group/radio-group.stories.js
@@ -1,30 +1,43 @@
 import React from 'react';
 import { GAS_RECOMMENDATIONS } from '../../../../shared/constants/gas';
+import README from './README.mdx';
 import RadioGroup from '.';
 
 export default {
   title: 'Components/UI/RadioGroup',
   id: __filename,
+  component: RadioGroup,
+  parameters: {
+    docs: {
+      page: README,
+    },
+  },
+  argTypes: {
+    options: { control: 'array' },
+    selectedValue: { control: 'text' },
+    name: { control: 'text' },
+    onChange: { action: 'onChange' },
+  },
 };
 
-export const DefaultStory = () => {
+export const DefaultStory = (args) => {
   return (
     <div className="radio-group" style={{ minWidth: '600px' }}>
-      <RadioGroup
-        name="gas-recommendation"
-        options={[
-          { value: GAS_RECOMMENDATIONS.LOW, label: 'Low', recommended: false },
-          {
-            value: GAS_RECOMMENDATIONS.MEDIUM,
-            label: 'Medium',
-            recommended: false,
-          },
-          { value: GAS_RECOMMENDATIONS.HIGH, label: 'High', recommended: true },
-        ]}
-        selectedValue={GAS_RECOMMENDATIONS.HIGH}
-      />
+      <RadioGroup {...args} />
     </div>
   );
 };
-
 DefaultStory.storyName = 'Default';
+DefaultStory.args = {
+  name: 'gas-recommendation',
+  options: [
+    { value: GAS_RECOMMENDATIONS.LOW, label: 'Low', recommended: false },
+    {
+      value: GAS_RECOMMENDATIONS.MEDIUM,
+      label: 'Medium',
+      recommended: false,
+    },
+    { value: GAS_RECOMMENDATIONS.HIGH, label: 'High', recommended: true },
+  ],
+  selectedValue: GAS_RECOMMENDATIONS.HIGH,
+};


### PR DESCRIPTION
`ArgsTable` doesn't work because of #12994. Will automatically be fixed once issue is fixed

Updating `RadioGroup` story:
- Add js doc comments to proptypes to allow ArgsTable to show up
- Add `README.MDX`
- Add controls for interaction of component

**Manual testing steps**
- Go to latest CI build of storybook or run `yarn storybook`
- Search "RadioGroup" in storybook
- Use Controls to interact with component
- Check docs page to see Props table

**Images**

<img width="1401" alt="Screen Shot 2021-12-07 at 8 00 15 PM" src="https://user-images.githubusercontent.com/8112138/144981849-e2dd01b5-679c-45fa-b623-6feb3e8e8708.png">
<img width="1440" alt="Screen Shot 2021-12-07 at 8 00 19 PM" src="https://user-images.githubusercontent.com/8112138/144981859-6c8afedd-80a4-48f3-b167-08dee3921358.png">
