### PR TITLE
Fix info-tooltip component to for new Storybook format

### DIFF
--- a/ui/components/ui/info-tooltip/README.mdx
+++ b/ui/components/ui/info-tooltip/README.mdx
@@ -1,0 +1,37 @@
+import { Story, Canvas, ArgsTable } from '@storybook/addon-docs';
+
+import InfoTooltip from './info-tooltip';
+
+# Info Tooltip
+
+Text labels that appear when the user hovers over
+
+<Canvas>
+  <Story id="ui-components-ui-info-tooltip-info-tooltip-stories-js--default-story" />
+</Canvas>
+
+## Component API
+
+<ArgsTable of={InfoTooltip} />
+
+## Usage
+
+The following describes the props and example usage for this component.
+
+### Bottom
+
+<Canvas>
+  <Story id="ui-components-ui-info-tooltip-info-tooltip-stories-js--bottom" />
+</Canvas>
+
+### Left
+
+<Canvas>
+  <Story id="ui-components-ui-info-tooltip-info-tooltip-stories-js--left" />
+</Canvas>
+
+### Right
+
+<Canvas>
+  <Story id="ui-components-ui-info-tooltip-info-tooltip-stories-js--right" />
+</Canvas>

--- a/ui/components/ui/info-tooltip/info-tooltip.js
+++ b/ui/components/ui/info-tooltip/info-tooltip.js
@@ -41,10 +41,28 @@ export default function InfoTooltip({
 }
 
 InfoTooltip.propTypes = {
+  /**
+   * Text label that shows up after hover
+   */
   contentText: PropTypes.node,
+  /**
+   * Shows position of the tooltip
+   */
   position: PropTypes.oneOf(['top', 'left', 'bottom', 'right']),
+  /**
+   * Set if the tooltip wide
+   */
   wide: PropTypes.bool,
+  /**
+   * Add custom CSS class for container
+   */
   containerClassName: PropTypes.string,
+  /**
+   * Add custom CSS class for the wrapper
+   */
   wrapperClassName: PropTypes.string,
+  /**
+   * Add color for the icon
+   */
   iconFillColor: PropTypes.string,
 };

--- a/ui/components/ui/info-tooltip/info-tooltip.stories.js
+++ b/ui/components/ui/info-tooltip/info-tooltip.stories.js
@@ -1,48 +1,54 @@
 import React from 'react';
-import { text } from '@storybook/addon-knobs';
+import README from './README.mdx';
 import InfoTooltip from './info-tooltip';
 
 export default {
   title: 'Components/UI/InfoTooltip',
   id: __filename,
+  component: InfoTooltip,
+  parameters: {
+    docs: {
+      page: README,
+    },
+  },
+  argTypes: {
+    contentText: { control: 'text' },
+    position: {
+      control: 'select',
+      options: ['top', 'left', 'bottom', 'right'],
+    },
+    wide: { control: 'boolean' },
+    containerClassName: { control: 'text' },
+    wrapperClassName: { control: 'text' },
+    iconFillColor: { control: 'text' },
+  },
 };
 
-export const Top = () => (
-  <InfoTooltip
-    position="top"
-    contentText={text(
-      'top',
-      'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut gravida dictum diam et sagittis. Sed lorem arcu, consectetur consectetur et, lacinia hendrerit sapien.',
-    )}
-  />
-);
+export const DefaultStory = (args) => <InfoTooltip {...args} />;
+DefaultStory.storyName = 'Default';
+DefaultStory.args = {
+  position: 'top',
+  contentText:
+    'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut gravida dictum diam et sagittis. Sed lorem arcu, consectetur consectetur et, lacinia hendrerit sapien.',
+};
 
-export const Bottom = () => (
-  <InfoTooltip
-    position="bottom"
-    contentText={text(
-      'bottom',
-      'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut gravida dictum diam et sagittis. Sed lorem arcu, consectetur consectetur et, lacinia hendrerit sapien.',
-    )}
-  />
-);
+export const Bottom = (args) => <InfoTooltip {...args} />;
+Bottom.args = {
+  position: 'bottom',
+  contentText:
+    'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut gravida dictum diam et sagittis. Sed lorem arcu, consectetur consectetur et, lacinia hendrerit sapien.',
+};
 
-export const Left = () => (
-  <InfoTooltip
-    position="left"
-    contentText={text(
-      'left',
-      'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut gravida dictum diam et sagittis. Sed lorem arcu, consectetur consectetur et, lacinia hendrerit sapien.',
-    )}
-  />
-);
+export const Left = (args) => <InfoTooltip {...args} />;
+Left.args = {
+  position: 'left',
+  contentText:
+    'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut gravida dictum diam et sagittis. Sed lorem arcu, consectetur consectetur et, lacinia hendrerit sapien.',
+};
 
-export const Right = () => (
-  <InfoTooltip
-    position="right"
-    contentText={text(
-      'right',
-      'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut gravida dictum diam et sagittis. Sed lorem arcu, consectetur consectetur et, lacinia hendrerit sapien.',
-    )}
-  />
-);
+export const Right = (args) => <InfoTooltip {...args} />;
+Right.args = {
+  position: 'right',
+  contentText:
+    'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut gravida dictum diam et sagittis. Sed lorem arcu, consectetur consectetur et, lacinia hendrerit sapien.',
+};


### PR DESCRIPTION
Updating `InfoTooltip` story:
- Add js doc comments to proptypes to allow ArgsTable to show up
- Add README.MDX
- Add controls for interaction of component

**Manual testing steps**
- Go to latest CI build of storybook
- Search "InfoTooltip"
- Use Controls to interact with component
- Check docs page to see Props table

**Images**
<img width="1440" alt="Screen Shot 2021-12-07 at 8 04 54 PM" src="https://user-images.githubusercontent.com/8112138/144982437-5ff67991-7aa7-4ebf-a533-768cc5484ca4.png">

![screencapture-localhost-6006-2021-12-07-20_05_02](https://user-images.githubusercontent.com/8112138/144982447-a9db53a1-32bc-4281-a3ec-1d13643de230.png)
