### PR TITLE
"eth_signTypedData" presents fields that do not appear in 'types' filed

### DIFF
--- a/ui/components/app/signature-request/signature-request.component.js
+++ b/ui/components/app/signature-request/signature-request.component.js
@@ -5,8 +5,6 @@ import LedgerInstructionField from '../ledger-instruction-field';
 import Header from './signature-request-header';
 import Footer from './signature-request-footer';
 import Message from './signature-request-message';
-import { TypedDataUtils } from 'eth-sig-util';
-import { MESSAGE_TYPE } from '../../../../shared/constants/app';
 
 export default class SignatureRequest extends PureComponent {
   static propTypes = {
@@ -53,39 +51,48 @@ export default class SignatureRequest extends PureComponent {
     const mapType = (msgType, definedType) => {
       // try and map it to a solidity type
       if (
-        (
-          definedType.type.indexOf("int") >= 0 ||
-          definedType.type.indexOf("fixed") >= 0
-        ) && msgType === "number") {
+        (definedType.type.indexOf('int') >= 0 ||
+          definedType.type.indexOf('fixed') >= 0) &&
+        msgType === 'number'
+      ) {
         return true;
       } else if (
-        (
-          definedType.type.indexOf("bytes") >= 0 ||
-          definedType.type === "address"
-        ) && msgType === "string") {
+        (definedType.type.indexOf('bytes') >= 0 ||
+          definedType.type === 'address') &&
+        msgType === 'string'
+      ) {
         return true;
       }
 
       return false;
-    }
+    };
 
     const sanitizeMessage = (msg, baseType) => {
-      let sanitizedMessage = {};
+      const sanitizedMessage = {};
       const msgKeys = Object.keys(msg);
-      const msgTypes = Object.values(msg).map(value => typeof (value));
+      const msgTypes = Object.values(msg).map((value) => typeof value);
       const baseTypeType = types[baseType];
       msgKeys.forEach((msgKey, index) => {
         const valueType = msgTypes[index];
         if (baseTypeType) {
-          const definedType = Object.values(baseTypeType).find(ptt => ptt.name === msgKey);          
+          const definedType = Object.values(baseTypeType).find(
+            (ptt) => ptt.name === msgKey,
+          );
 
           if (definedType) {
             if (definedType.type === valueType) {
               sanitizedMessage[msgKey] = msg[msgKey];
-            } else if (definedType.type.indexOf("[]") && valueType === "object" && Array.isArray(msg[msgKey])) {
+            } else if (
+              definedType.type.indexOf('[]') &&
+              valueType === 'object' &&
+              Array.isArray(msg[msgKey])
+            ) {
               sanitizedMessage[msgKey] = msg[msgKey];
-            } else if (valueType === "object") {
-              sanitizedMessage[msgKey] = sanitizeMessage(msg[msgKey], definedType.type);
+            } else if (valueType === 'object') {
+              sanitizedMessage[msgKey] = sanitizeMessage(
+                msg[msgKey],
+                definedType.type,
+              );
             } else if (mapType(valueType, definedType)) {
               sanitizedMessage[msgKey] = msg[msgKey];
             }
@@ -94,7 +101,7 @@ export default class SignatureRequest extends PureComponent {
       });
 
       return sanitizedMessage;
-    }
+    };
 
     const onSign = (event) => {
       sign(event);
@@ -127,7 +134,7 @@ export default class SignatureRequest extends PureComponent {
     };
 
     return (
-      <div className="signature-request page-container" >
+      <div className="signature-request page-container">
         <Header fromAccount={fromAccount} />
         <div className="signature-request-content">
           <div className="signature-request-content__title">
@@ -159,7 +166,7 @@ export default class SignatureRequest extends PureComponent {
           signAction={onSign}
           disabled={hardwareWalletRequiresConnection}
         />
-      </div >
+      </div>
     );
   }
 }

--- a/ui/components/app/signature-request/signature-request.component.js
+++ b/ui/components/app/signature-request/signature-request.component.js
@@ -68,39 +68,43 @@ export default class SignatureRequest extends PureComponent {
     };
 
     const sanitizeMessage = (msg, baseType) => {
-      const sanitizedMessage = {};
-      const msgKeys = Object.keys(msg);
-      const msgTypes = Object.values(msg).map((value) => typeof value);
-      const baseTypeType = types[baseType];
-      msgKeys.forEach((msgKey, index) => {
-        const valueType = msgTypes[index];
-        if (baseTypeType) {
-          const definedType = Object.values(baseTypeType).find(
-            (ptt) => ptt.name === msgKey,
-          );
+      if (version === 'V4') {
+        const sanitizedMessage = {};
+        console.log(version);
+        const msgKeys = Object.keys(msg);
+        const msgTypes = Object.values(msg).map((value) => typeof value);
+        const baseTypeType = types[baseType];
+        msgKeys.forEach((msgKey, index) => {
+          const valueType = msgTypes[index];
+          if (baseTypeType) {
+            const definedType = Object.values(baseTypeType).find(
+              (ptt) => ptt.name === msgKey,
+            );
 
-          if (definedType) {
-            if (definedType.type === valueType) {
-              sanitizedMessage[msgKey] = msg[msgKey];
-            } else if (
-              definedType.type.indexOf('[]') &&
-              valueType === 'object' &&
-              Array.isArray(msg[msgKey])
-            ) {
-              sanitizedMessage[msgKey] = msg[msgKey];
-            } else if (valueType === 'object') {
-              sanitizedMessage[msgKey] = sanitizeMessage(
-                msg[msgKey],
-                definedType.type,
-              );
-            } else if (mapType(valueType, definedType)) {
-              sanitizedMessage[msgKey] = msg[msgKey];
+            if (definedType) {
+              if (definedType.type === valueType) {
+                sanitizedMessage[msgKey] = msg[msgKey];
+              } else if (
+                definedType.type.indexOf('[]') &&
+                valueType === 'object' &&
+                Array.isArray(msg[msgKey])
+              ) {
+                sanitizedMessage[msgKey] = msg[msgKey];
+              } else if (valueType === 'object') {
+                sanitizedMessage[msgKey] = sanitizeMessage(
+                  msg[msgKey],
+                  definedType.type,
+                );
+              } else if (mapType(valueType, definedType)) {
+                sanitizedMessage[msgKey] = msg[msgKey];
+              }
             }
           }
-        }
-      });
+        });
 
-      return sanitizedMessage;
+        return sanitizedMessage;
+      }
+      return msg;
     };
 
     const onSign = (event) => {

--- a/ui/components/app/signature-request/signature-request.component.js
+++ b/ui/components/app/signature-request/signature-request.component.js
@@ -182,7 +182,7 @@ export default class SignatureRequest extends PureComponent {
         <Footer
           cancelAction={onCancel}
           signAction={onSign}
-          disabled={hardwareWalletRequiresConnection}
+          disabled={hardwareWalletRequiresConnection()}
         />
       </div>
     );

--- a/ui/components/app/signature-request/signature-request.component.js
+++ b/ui/components/app/signature-request/signature-request.component.js
@@ -67,10 +67,24 @@ export default class SignatureRequest extends PureComponent {
       return false;
     };
 
+    const sanitizeArray = (arrayMsg, baseType) => {
+      const sanitizedMessage = {};
+
+      arrayMsg.forEach((msg, index) => {
+        let valueType = typeof msg;
+        if (valueType === "object") {
+          sanitizedMessage[index] = sanitizeMessage(msg, baseType);
+        } else if (mapType(valueType, {type: baseType})) {
+          sanitizedMessage[index] = msg;
+        }
+      });
+
+      return sanitizedMessage;
+    }
+
     const sanitizeMessage = (msg, baseType) => {
       if (version === 'V4') {
         const sanitizedMessage = {};
-        console.log(version);
         const msgKeys = Object.keys(msg);
         const msgTypes = Object.values(msg).map((value) => typeof value);
         const baseTypeType = types[baseType];
@@ -89,7 +103,7 @@ export default class SignatureRequest extends PureComponent {
                 valueType === 'object' &&
                 Array.isArray(msg[msgKey])
               ) {
-                sanitizedMessage[msgKey] = msg[msgKey];
+                sanitizedMessage[msgKey] = sanitizeArray(msg[msgKey], definedType.type.replace('[]', ''));
               } else if (valueType === 'object') {
                 sanitizedMessage[msgKey] = sanitizeMessage(
                   msg[msgKey],

--- a/ui/components/app/signature-request/signature-request.component.js
+++ b/ui/components/app/signature-request/signature-request.component.js
@@ -48,7 +48,14 @@ export default class SignatureRequest extends PureComponent {
     const { message, domain = {}, types, primaryType } = JSON.parse(data);
     const { metricsEvent } = this.context;
 
-    const solidityTypes = ['bool', 'int', 'fixed', 'address', 'bytes', 'string'];
+    const solidityTypes = [
+      'bool',
+      'int',
+      'fixed',
+      'address',
+      'bytes',
+      'string',
+    ];
     const sanitizeMessage = (msg, baseType) => {
       if (version === 'V4') {
         const sanitizedMessage = {};
@@ -79,23 +86,28 @@ export default class SignatureRequest extends PureComponent {
                   sanitizedMessage[msgKey] = sanitizedArrayMessage;
                 } else {
                   // nested object
-                  sanitizedMessage[msgKey] = sanitizeMessage(msg[msgKey], definedType.type);
+                  sanitizedMessage[msgKey] = sanitizeMessage(
+                    msg[msgKey],
+                    definedType.type,
+                  );
                 }
               } else {
-                // check if it's a valid solidity type                
-                const isSolidityType = solidityTypes.some(solidityType => definedType.type.indexOf(solidityType) >= 0);
+                // check if it's a valid solidity type
+                const isSolidityType = solidityTypes.some(
+                  (solidityType) => definedType.type.indexOf(solidityType) >= 0,
+                );
                 if (isSolidityType) {
                   sanitizedMessage[msgKey] = msg[msgKey];
                 }
-              }  // endif (nestedType)     
-            } // endif (definedType)     
-          } // endif (baseTypeType)     
+              } // endif (nestedType)
+            } // endif (definedType)
+          } // endif (baseTypeType)
         });
         return sanitizedMessage;
       } // end if (version === 'V4')
 
       return msg;
-    }
+    };
 
     const onSign = (event) => {
       sign(event);

--- a/ui/components/app/signature-request/signature-request.component.js
+++ b/ui/components/app/signature-request/signature-request.component.js
@@ -47,75 +47,46 @@ export default class SignatureRequest extends PureComponent {
       hardwareWalletRequiresConnection,
     } = this.props;
     const { address: fromAddress } = fromAccount;
-    const { message, domain = {} } = JSON.parse(data);
+    const { message, domain = {}, types, pri } = JSON.parse(data);
     const { metricsEvent } = this.context;
 
-    const mapType = (msgType, definedType, types) => {
-      if (msgType === definedType.type) {
-        // if the javascript type is the same as defined type, return the js type
-        return msgType;
-      } else if (types[definedType.type.replace("[]", "")] !== undefined) {
-        // if the type is defined in types, return it
-        return definedType.type;
-      } else {
-        // try and map it to a solidity type
-        if (
-          (
-            definedType.type.indexOf("int") >= 0 ||
-            definedType.type.indexOf("fixed") >= 0
-          ) && msgType === "number") {
-          return msgType;
-        } else if (
-          (
-            definedType.type.indexOf("bytes") >= 0 ||
-            definedType.type === "address"
-          ) && msgType === "string") {
-          return msgType;
-        }
+    const mapType = (msgType, definedType) => {
+      // try and map it to a solidity type
+      if (
+        (
+          definedType.type.indexOf("int") >= 0 ||
+          definedType.type.indexOf("fixed") >= 0
+        ) && msgType === "number") {
+        return true;
+      } else if (
+        (
+          definedType.type.indexOf("bytes") >= 0 ||
+          definedType.type === "address"
+        ) && msgType === "string") {
+        return true;
       }
-
-      // if we get here we can't find or map the type....what should we do
-      throw Error("Unknwn type found in message: " + definedType.type);
+      
+      return false;
     }
 
-    const sanitizeMessage = (msg, primaryType, types, sanitizedMessage = {}) => {
-      const msgKeys = Object.keys(msg);
-      const msgTypes = Object.values(msg).map(value => typeof (value));
+    const sanitizeMessage = () => {
+      let sanitizedMessage = TypedDataUtils.sanitizeData(JSON.parse(data));
+      const msgKeys = Object.keys(message);
+      const msgTypes = Object.values(message).map(value => typeof (value));
+      msgKeys.forEach((msgKey, index) => {        
+        const definedType = types.find(type => type.name === msgKey);
+        const valueType = msgTypes[index];
 
-      msgKeys.forEach((msgKey, index) => {
-        const msgType = msgTypes[index];
-        const definedType = primaryType.find(type => type.name === msgKey);
-        if (msgType === "object") {
-          const newPrimaryType = types[definedType.type];
-          sanitizedMessage[msgKey] = {};
-          sanitizeMessage(msg[msgKey], newPrimaryType, types, sanitizedMessage);
-        } else if (msgType === "array") {
-          const messages = sanitizedMessage[msgKey];
-          messages.forEach(msg => {
-            const type = typeof()
-          })
-          const newPrimaryType = mapType(msgType, definedType. types);
-          sanitizedMessage[msgKey] = [];
-          sanitizeMessage(msg[msgKey], newPrimaryType, types, sanitizedMessage);
+        if (definedType === valueType) {
+          sanitizedMessage[msgKey] = message[msgKey];
+        } else if (definedType.indexOf("[]") && valueType === "array") {
+          sanitizedMessage[msgKey] = message[msgKey];
+        } else if(mapType(valueType, definedType)) {
+          sanitizedMessage[msgKey] = message[msgKey];
         } else {
-          const newPrimaryType = mapType(msgType, definedType. types);
-
+          // if we get here we can't find or map the type....what should we do ??
         }
       });
-    }
-
-    const sanitizeData = (msg, msgType, msgVersion) => {
-      if (
-        msgType === MESSAGE_TYPE.ETH_SIGN_TYPED_DATA &&
-        (msgVersion === 'V3' || msgVersion === 'V4')
-      ) {
-        const parsed = JSON.parse(data);
-        parsed.message.uselessValue = 1;
-        parsed.message.uselessName = "two";
-        return TypedDataUtils.sanitizeData(parsed);
-      }
-
-      return msg;
     }
 
     const onSign = (event) => {
@@ -175,7 +146,7 @@ export default class SignatureRequest extends PureComponent {
             <LedgerInstructionField showDataInstruction />
           </div>
         ) : null}
-        <Message data={sanitizeMessage(message, type, version)} />
+        <Message data={sanitizeMessage()} />
         <Footer
           cancelAction={onCancel}
           signAction={onSign}

--- a/ui/components/app/signature-request/signature-request.component.js
+++ b/ui/components/app/signature-request/signature-request.component.js
@@ -46,7 +46,7 @@ export default class SignatureRequest extends PureComponent {
       hardwareWalletRequiresConnection,
     } = this.props;
     const { address: fromAddress } = fromAccount;
-    const { message, domain = {}, primaryType } = JSON.parse(data);
+    const { message, domain = {}, primaryType, types } = JSON.parse(data);
     const { metricsEvent } = this.context;
 
     const onSign = (event) => {
@@ -106,7 +106,7 @@ export default class SignatureRequest extends PureComponent {
             <LedgerInstructionField showDataInstruction />
           </div>
         ) : null}
-        <Message data={sanitizeMessage(message, primaryType)} />
+        <Message data={sanitizeMessage(message, primaryType, types)} />
         <Footer
           cancelAction={onCancel}
           signAction={onSign}

--- a/ui/components/app/signature-request/signature-request.component.js
+++ b/ui/components/app/signature-request/signature-request.component.js
@@ -5,6 +5,8 @@ import LedgerInstructionField from '../ledger-instruction-field';
 import Header from './signature-request-header';
 import Footer from './signature-request-footer';
 import Message from './signature-request-message';
+import { TypedDataUtils } from 'eth-sig-util';
+import { MESSAGE_TYPE } from '../../../../shared/constants/app';
 
 export default class SignatureRequest extends PureComponent {
   static propTypes = {
@@ -48,6 +50,74 @@ export default class SignatureRequest extends PureComponent {
     const { message, domain = {} } = JSON.parse(data);
     const { metricsEvent } = this.context;
 
+    const mapType = (msgType, definedType, types) => {
+      if (msgType === definedType.type) {
+        // if the javascript type is the same as defined type, return the js type
+        return msgType;
+      } else if (types[definedType.type.replace("[]", "")] !== undefined) {
+        // if the type is defined in types, return it
+        return definedType.type;
+      } else {
+        // try and map it to a solidity type
+        if (
+          (
+            definedType.type.indexOf("int") >= 0 ||
+            definedType.type.indexOf("fixed") >= 0
+          ) && msgType === "number") {
+          return msgType;
+        } else if (
+          (
+            definedType.type.indexOf("bytes") >= 0 ||
+            definedType.type === "address"
+          ) && msgType === "string") {
+          return msgType;
+        }
+      }
+
+      // if we get here we can't find or map the type....what should we do
+      throw Error("Unknwn type found in message: " + definedType.type);
+    }
+
+    const sanitizeMessage = (msg, primaryType, types, sanitizedMessage = {}) => {
+      const msgKeys = Object.keys(msg);
+      const msgTypes = Object.values(msg).map(value => typeof (value));
+
+      msgKeys.forEach((msgKey, index) => {
+        const msgType = msgTypes[index];
+        const definedType = primaryType.find(type => type.name === msgKey);
+        if (msgType === "object") {
+          const newPrimaryType = types[definedType.type];
+          sanitizedMessage[msgKey] = {};
+          sanitizeMessage(msg[msgKey], newPrimaryType, types, sanitizedMessage);
+        } else if (msgType === "array") {
+          const messages = sanitizedMessage[msgKey];
+          messages.forEach(msg => {
+            const type = typeof()
+          })
+          const newPrimaryType = mapType(msgType, definedType. types);
+          sanitizedMessage[msgKey] = [];
+          sanitizeMessage(msg[msgKey], newPrimaryType, types, sanitizedMessage);
+        } else {
+          const newPrimaryType = mapType(msgType, definedType. types);
+
+        }
+      });
+    }
+
+    const sanitizeData = (msg, msgType, msgVersion) => {
+      if (
+        msgType === MESSAGE_TYPE.ETH_SIGN_TYPED_DATA &&
+        (msgVersion === 'V3' || msgVersion === 'V4')
+      ) {
+        const parsed = JSON.parse(data);
+        parsed.message.uselessValue = 1;
+        parsed.message.uselessName = "two";
+        return TypedDataUtils.sanitizeData(parsed);
+      }
+
+      return msg;
+    }
+
     const onSign = (event) => {
       sign(event);
       metricsEvent({
@@ -79,7 +149,7 @@ export default class SignatureRequest extends PureComponent {
     };
 
     return (
-      <div className="signature-request page-container">
+      <div className="signature-request page-container" >
         <Header fromAccount={fromAccount} />
         <div className="signature-request-content">
           <div className="signature-request-content__title">
@@ -105,13 +175,13 @@ export default class SignatureRequest extends PureComponent {
             <LedgerInstructionField showDataInstruction />
           </div>
         ) : null}
-        <Message data={message} />
+        <Message data={sanitizeMessage(message, type, version)} />
         <Footer
           cancelAction={onCancel}
           signAction={onSign}
           disabled={hardwareWalletRequiresConnection}
         />
-      </div>
+      </div >
     );
   }
 }

--- a/ui/components/app/signature-request/signature-request.component.js
+++ b/ui/components/app/signature-request/signature-request.component.js
@@ -2,10 +2,10 @@ import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import Identicon from '../../ui/identicon';
 import LedgerInstructionField from '../ledger-instruction-field';
+import { sanitizeMessage } from '../../../helpers/utils/util';
 import Header from './signature-request-header';
 import Footer from './signature-request-footer';
 import Message from './signature-request-message';
-import { sanitizeMessage } from '../../../helpers/utils/util';
 
 export default class SignatureRequest extends PureComponent {
   static propTypes = {
@@ -46,7 +46,7 @@ export default class SignatureRequest extends PureComponent {
       hardwareWalletRequiresConnection,
     } = this.props;
     const { address: fromAddress } = fromAccount;
-    const { message, domain = {}, types, primaryType } = JSON.parse(data);
+    const { message, domain = {}, primaryType } = JSON.parse(data);
     const { metricsEvent } = this.context;
 
     const onSign = (event) => {

--- a/ui/components/app/signature-request/signature-request.component.js
+++ b/ui/components/app/signature-request/signature-request.component.js
@@ -47,7 +47,7 @@ export default class SignatureRequest extends PureComponent {
       hardwareWalletRequiresConnection,
     } = this.props;
     const { address: fromAddress } = fromAccount;
-    const { message, domain = {}, types, pri } = JSON.parse(data);
+    const { message, domain = {}, types, primaryType } = JSON.parse(data);
     const { metricsEvent } = this.context;
 
     const mapType = (msgType, definedType) => {
@@ -65,28 +65,36 @@ export default class SignatureRequest extends PureComponent {
         ) && msgType === "string") {
         return true;
       }
-      
+
       return false;
     }
 
     const sanitizeMessage = () => {
       let sanitizedMessage = TypedDataUtils.sanitizeData(JSON.parse(data));
-      const msgKeys = Object.keys(message);
-      const msgTypes = Object.values(message).map(value => typeof (value));
-      msgKeys.forEach((msgKey, index) => {        
-        const definedType = types.find(type => type.name === msgKey);
+      const msgKeys = Object.keys(message);      
+      const msgTypes = Object.values(message).map(value => typeof (value));            
+      const primaryTypeType = types[primaryType];
+      msgKeys.forEach((msgKey, index) => {
+        const definedType = Object.values(primaryTypeType).find(ptt => ptt.name === msgKey);        
         const valueType = msgTypes[index];
+        alert(definedType.type);
+        alert(valueType);
 
-        if (definedType === valueType) {
-          sanitizedMessage[msgKey] = message[msgKey];
-        } else if (definedType.indexOf("[]") && valueType === "array") {
-          sanitizedMessage[msgKey] = message[msgKey];
-        } else if(mapType(valueType, definedType)) {
-          sanitizedMessage[msgKey] = message[msgKey];
-        } else {
-          // if we get here we can't find or map the type....what should we do ??
+        if (definedType) {
+          if (definedType === valueType) {
+            sanitizedMessage[msgKey] = message[msgKey];
+          } else if (definedType.indexOf("[]") && valueType === "array") {
+            sanitizedMessage[msgKey] = message[msgKey];
+          } else if (mapType(valueType, definedType)) {
+            sanitizedMessage[msgKey] = message[msgKey];
+          }
         }
+
+        alert(definedType.type);
+        // if we get here we can't find or map the type....what should we do ??        
       });
+
+      return sanitizedMessage;
     }
 
     const onSign = (event) => {

--- a/ui/components/app/signature-request/signature-request.component.test.js
+++ b/ui/components/app/signature-request/signature-request.component.test.js
@@ -4,9 +4,8 @@ import SignatureRequest from './signature-request.component';
 import Message from './signature-request-message';
 
 describe('Signature Request Component', () => {
-
   describe('render', () => {
-    const fromAddress = '0x123456789abcdef';    
+    const fromAddress = '0x123456789abcdef';
     const messageData = {
       domain: {
         chainId: 97,
@@ -55,8 +54,8 @@ describe('Signature Request Component', () => {
           { name: 'name', type: 'string' },
           { name: 'wallets', type: 'address[]' },
         ],
-      }
-    }
+      },
+    };
 
     it('should render a div with one child', () => {
       const wrapper = shallowWithContext(
@@ -83,8 +82,8 @@ describe('Signature Request Component', () => {
     it('should render a div message parsed', () => {
       const msgParams = {
         data: JSON.stringify(messageData),
-        version: "V4",
-        origin: "test",
+        version: 'V4',
+        origin: 'test',
       };
       const wrapper = shallowWithContext(
         <SignatureRequest
@@ -93,7 +92,7 @@ describe('Signature Request Component', () => {
           cancel={() => undefined}
           sign={() => undefined}
           txData={{
-            msgParams: msgParams
+            msgParams,
           }}
           fromAccount={{ address: fromAddress }}
         />,
@@ -104,22 +103,22 @@ describe('Signature Request Component', () => {
       expect(wrapper.hasClass('signature-request')).toStrictEqual(true);
       const messageWrapper = wrapper.find(Message);
       expect(messageWrapper).toHaveLength(1);
-      const data = messageWrapper.props().data;
-      expect(data.contents).toEqual("Hello, Bob!");
-      expect(data.from.name).toEqual("Cow");
+      const { data } = messageWrapper.props();
+      expect(data.contents).toStrictEqual('Hello, Bob!');
+      expect(data.from.name).toStrictEqual('Cow');
       expect(data.from.wallets).toBeDefined();
-      expect(data.to).toBeDefined();      
+      expect(data.to).toBeDefined();
     });
 
     it('should render a div message parsed without typeless data', () => {
-      messageData['do_not_display'] = "one";
-      messageData['do_not_display_2'] = {
-        'do_not_display': 'two'
+      messageData.do_not_display = 'one';
+      messageData.do_not_display_2 = {
+        do_not_display: 'two',
       };
       const msgParams = {
         data: JSON.stringify(messageData),
-        version: "V4",
-        origin: "test",
+        version: 'V4',
+        origin: 'test',
       };
       const wrapper = shallowWithContext(
         <SignatureRequest
@@ -128,7 +127,7 @@ describe('Signature Request Component', () => {
           cancel={() => undefined}
           sign={() => undefined}
           txData={{
-            msgParams: msgParams
+            msgParams,
           }}
           fromAccount={{ address: fromAddress }}
         />,
@@ -139,14 +138,14 @@ describe('Signature Request Component', () => {
       expect(wrapper.hasClass('signature-request')).toStrictEqual(true);
       const messageWrapper = wrapper.find(Message);
       expect(messageWrapper).toHaveLength(1);
-      const data = messageWrapper.props().data;
-      expect(data.contents).toEqual("Hello, Bob!");
-      expect(data.from.name).toEqual("Cow");
+      const { data } = messageWrapper.props();
+      expect(data.contents).toStrictEqual('Hello, Bob!');
+      expect(data.from.name).toStrictEqual('Cow');
       expect(data.from.wallets).toBeDefined();
-      expect(data.to).toBeDefined();      
+      expect(data.to).toBeDefined();
 
       expect(data.do_not_display).toBeUndefined();
       expect(data.do_not_display2).toBeUndefined();
-    });    
+    });
   });
 });

--- a/ui/components/app/signature-request/signature-request.component.test.js
+++ b/ui/components/app/signature-request/signature-request.component.test.js
@@ -109,7 +109,6 @@ describe('Signature Request Component', () => {
       expect(data.from.wallets).toBeDefined();
       expect(data.from.wallets).toHaveLength(2);
       expect(data.to).toBeDefined();
-      expect(data.to).toHaveLength(1);
       const dataTo = data.to;
       expect(dataTo[0].name).toStrictEqual('Bob');;
       expect(dataTo[0].wallets).toHaveLength(3);
@@ -149,7 +148,6 @@ describe('Signature Request Component', () => {
       expect(data.from.wallets).toBeDefined();
       expect(data.from.wallets).toHaveLength(2);
       expect(data.to).toBeDefined();
-      expect(data.to).toHaveLength(1);
       const dataTo = data.to;
       expect(dataTo[0].name).toStrictEqual('Bob');;
       expect(dataTo[0].wallets).toHaveLength(3);

--- a/ui/components/app/signature-request/signature-request.component.test.js
+++ b/ui/components/app/signature-request/signature-request.component.test.js
@@ -110,7 +110,7 @@ describe('Signature Request Component', () => {
       expect(data.from.wallets).toHaveLength(2);
       expect(data.to).toBeDefined();
       const dataTo = data.to;
-      expect(dataTo[0].name).toStrictEqual('Bob');;
+      expect(dataTo[0].name).toStrictEqual('Bob');
       expect(dataTo[0].wallets).toHaveLength(3);
     });
 
@@ -149,7 +149,7 @@ describe('Signature Request Component', () => {
       expect(data.from.wallets).toHaveLength(2);
       expect(data.to).toBeDefined();
       const dataTo = data.to;
-      expect(dataTo[0].name).toStrictEqual('Bob');;
+      expect(dataTo[0].name).toStrictEqual('Bob');
       expect(dataTo[0].wallets).toHaveLength(3);
 
       expect(data.do_not_display).toBeUndefined();

--- a/ui/components/app/signature-request/signature-request.component.test.js
+++ b/ui/components/app/signature-request/signature-request.component.test.js
@@ -107,12 +107,17 @@ describe('Signature Request Component', () => {
       expect(data.contents).toStrictEqual('Hello, Bob!');
       expect(data.from.name).toStrictEqual('Cow');
       expect(data.from.wallets).toBeDefined();
+      expect(data.from.wallets).toHaveLength(2);
       expect(data.to).toBeDefined();
+      expect(data.to).toHaveLength(1);
+      const dataTo = data.to;
+      expect(dataTo[0].name).toStrictEqual('Bob');;
+      expect(dataTo[0].wallets).toHaveLength(3);
     });
 
     it('should render a div message parsed without typeless data', () => {
-      messageData.do_not_display = 'one';
-      messageData.do_not_display_2 = {
+      messageData.message.do_not_display = 'one';
+      messageData.message.do_not_display_2 = {
         do_not_display: 'two',
       };
       const msgParams = {
@@ -142,7 +147,12 @@ describe('Signature Request Component', () => {
       expect(data.contents).toStrictEqual('Hello, Bob!');
       expect(data.from.name).toStrictEqual('Cow');
       expect(data.from.wallets).toBeDefined();
+      expect(data.from.wallets).toHaveLength(2);
       expect(data.to).toBeDefined();
+      expect(data.to).toHaveLength(1);
+      const dataTo = data.to;
+      expect(dataTo[0].name).toStrictEqual('Bob');;
+      expect(dataTo[0].wallets).toHaveLength(3);
 
       expect(data.do_not_display).toBeUndefined();
       expect(data.do_not_display2).toBeUndefined();

--- a/ui/components/app/signature-request/signature-request.component.test.js
+++ b/ui/components/app/signature-request/signature-request.component.test.js
@@ -41,10 +41,6 @@ describe('Signature Request Component', () => {
           { name: 'chainId', type: 'uint256' },
           { name: 'verifyingContract', type: 'address' },
         ],
-        Group: [
-          { name: 'name', type: 'string' },
-          { name: 'members', type: 'Person[]' },
-        ],
         Mail: [
           { name: 'from', type: 'Person' },
           { name: 'to', type: 'Person[]' },

--- a/ui/components/app/signature-request/signature-request.component.test.js
+++ b/ui/components/app/signature-request/signature-request.component.test.js
@@ -58,28 +58,6 @@ describe('Signature Request Component', () => {
       };
     });
 
-    it('should render a div with one child', () => {
-      const wrapper = shallowWithContext(
-        <SignatureRequest
-          hardwareWalletRequiresConnection={() => false}
-          clearConfirmTransaction={() => undefined}
-          cancel={() => undefined}
-          sign={() => undefined}
-          txData={{
-            msgParams: {
-              data: '{"message": {"from": {"name": "hello"}}}',
-              from: fromAddress,
-            },
-          }}
-          fromAccount={{ address: fromAddress }}
-        />,
-      );
-
-      expect(wrapper.is('div')).toStrictEqual(true);
-      expect(wrapper).toHaveLength(1);
-      expect(wrapper.hasClass('signature-request')).toStrictEqual(true);
-    });
-
     it('should render a div message parsed', () => {
       const msgParams = {
         data: JSON.stringify(messageData),

--- a/ui/components/app/signature-request/signature-request.component.test.js
+++ b/ui/components/app/signature-request/signature-request.component.test.js
@@ -5,53 +5,58 @@ import Message from './signature-request-message';
 
 describe('Signature Request Component', () => {
   describe('render', () => {
-    const fromAddress = '0x123456789abcdef';
-    const messageData = {
-      domain: {
-        chainId: 97,
-        name: 'Ether Mail',
-        verifyingContract: '0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC',
-        version: '1',
-      },
-      message: {
-        contents: 'Hello, Bob!',
-        from: {
-          name: 'Cow',
-          wallets: [
-            '0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826',
-            '0xDeaDbeefdEAdbeefdEadbEEFdeadbeEFdEaDbeeF',
-          ],
+    let fromAddress;
+    let messageData;
+
+    beforeEach(() => {
+      fromAddress = '0x123456789abcdef';
+      messageData = {
+        domain: {
+          chainId: 97,
+          name: 'Ether Mail',
+          verifyingContract: '0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC',
+          version: '1',
         },
-        to: [
-          {
-            name: 'Bob',
+        message: {
+          contents: 'Hello, Bob!',
+          from: {
+            name: 'Cow',
             wallets: [
-              '0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB',
-              '0xB0BdaBea57B0BDABeA57b0bdABEA57b0BDabEa57',
-              '0xB0B0b0b0b0b0B000000000000000000000000000',
+              '0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826',
+              '0xDeaDbeefdEAdbeefdEadbEEFdeadbeEFdEaDbeeF',
             ],
           },
-        ],
-      },
-      primaryType: 'Mail',
-      types: {
-        EIP712Domain: [
-          { name: 'name', type: 'string' },
-          { name: 'version', type: 'string' },
-          { name: 'chainId', type: 'uint256' },
-          { name: 'verifyingContract', type: 'address' },
-        ],
-        Mail: [
-          { name: 'from', type: 'Person' },
-          { name: 'to', type: 'Person[]' },
-          { name: 'contents', type: 'string' },
-        ],
-        Person: [
-          { name: 'name', type: 'string' },
-          { name: 'wallets', type: 'address[]' },
-        ],
-      },
-    };
+          to: [
+            {
+              name: 'Bob',
+              wallets: [
+                '0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB',
+                '0xB0BdaBea57B0BDABeA57b0bdABEA57b0BDabEa57',
+                '0xB0B0b0b0b0b0B000000000000000000000000000',
+              ],
+            },
+          ],
+        },
+        primaryType: 'Mail',
+        types: {
+          EIP712Domain: [
+            { name: 'name', type: 'string' },
+            { name: 'version', type: 'string' },
+            { name: 'chainId', type: 'uint256' },
+            { name: 'verifyingContract', type: 'address' },
+          ],
+          Mail: [
+            { name: 'from', type: 'Person' },
+            { name: 'to', type: 'Person[]' },
+            { name: 'contents', type: 'string' },
+          ],
+          Person: [
+            { name: 'name', type: 'string' },
+            { name: 'wallets', type: 'address[]' },
+          ],
+        },
+      };
+    });
 
     it('should render a div with one child', () => {
       const wrapper = shallowWithContext(

--- a/ui/helpers/utils/util.js
+++ b/ui/helpers/utils/util.js
@@ -520,14 +520,14 @@ export const sanitizeMessage = (msg, baseType, types) => {
     }
 
     // key has a type. check if the definedType is also a type
-    const nestedTypeDefinition = types[definedType.type.replace('[]', '')];
+    const nestedType = definedType.type.replace(/\[\]$/u, '');
+    const nestedTypeDefinition = types[nestedType];
 
     if (nestedTypeDefinition) {
-      if (definedType.type.indexOf('[]') > 0) {
+      if (definedType.type.endsWith('[]') > 0) {
         // nested array
-        const definedArrayType = definedType.type.replace('[]', '');
         sanitizedMessage[msgKey] = msg[msgKey].map((value) =>
-          sanitizeMessage(value, definedArrayType, types),
+          sanitizeMessage(value, nestedType, types),
         );
       } else {
         // nested object
@@ -539,9 +539,7 @@ export const sanitizeMessage = (msg, baseType, types) => {
       }
     } else {
       // check if it's a valid solidity type
-      const isSolidityType = solidityTypes().includes(
-        definedType.type.replace(/\[\]$/u, ''),
-      );
+      const isSolidityType = solidityTypes().includes(nestedType);
       if (isSolidityType) {
         sanitizedMessage[msgKey] = msg[msgKey];
       }

--- a/ui/helpers/utils/util.js
+++ b/ui/helpers/utils/util.js
@@ -540,7 +540,7 @@ export const sanitizeMessage = (msg, baseType, types) => {
     } else {
       // check if it's a valid solidity type
       const isSolidityType = solidityTypes().includes(
-        definedType.type.replace('[]', ''),
+        definedType.type.replace(/\[\]$/u, ''),
       );
       if (isSolidityType) {
         sanitizedMessage[msgKey] = msg[msgKey];

--- a/ui/helpers/utils/util.js
+++ b/ui/helpers/utils/util.js
@@ -91,8 +91,8 @@ export function addressSummary(
   }
   return checked
     ? `${checked.slice(0, firstSegLength)}...${checked.slice(
-      checked.length - lastSegLength,
-    )}`
+        checked.length - lastSegLength,
+      )}`
     : '...';
 }
 
@@ -445,7 +445,16 @@ export function clearClipboard() {
 }
 
 const solidityTypes = () => {
-  const types = ['bool', 'address', 'string', 'bytes', 'int', 'uint', 'fixed', 'ufixed'];
+  const types = [
+    'bool',
+    'address',
+    'string',
+    'bytes',
+    'int',
+    'uint',
+    'fixed',
+    'ufixed',
+  ];
 
   const ints = Array.from(new Array(32)).map(
     (_, index) => `int${(index + 1) * 8}`,
@@ -457,7 +466,7 @@ const solidityTypes = () => {
     (_, index) => `bytes${index + 1}`,
   );
   return [...types, ...ints, ...uints, ...bytes];
-}
+};
 
 export const sanitizeMessage = (msg, baseType, types) => {
   let baseTypeDefinitions;
@@ -484,18 +493,22 @@ export const sanitizeMessage = (msg, baseType, types) => {
         if (definedType.type.indexOf('[]') > 0) {
           // nested array
           const definedArrayType = definedType.type.replace('[]', '');
-          sanitizedMessage[msgKey] = msg[msgKey].map((value) => sanitizeMessage(value, definedArrayType, types));
+          sanitizedMessage[msgKey] = msg[msgKey].map((value) =>
+            sanitizeMessage(value, definedArrayType, types),
+          );
         } else {
           // nested object
           sanitizedMessage[msgKey] = sanitizeMessage(
             msg[msgKey],
             definedType.type,
-            types
+            types,
           );
         }
       } else {
         // check if it's a valid solidity type
-        const isSolidityType = solidityTypes().includes(definedType.type.replace('[]', ''));
+        const isSolidityType = solidityTypes().includes(
+          definedType.type.replace('[]', ''),
+        );
         if (isSolidityType) {
           sanitizedMessage[msgKey] = msg[msgKey];
         }

--- a/ui/helpers/utils/util.js
+++ b/ui/helpers/utils/util.js
@@ -91,8 +91,8 @@ export function addressSummary(
   }
   return checked
     ? `${checked.slice(0, firstSegLength)}...${checked.slice(
-      checked.length - lastSegLength,
-    )}`
+        checked.length - lastSegLength,
+      )}`
     : '...';
 }
 
@@ -516,7 +516,7 @@ export const sanitizeMessage = (msg, baseType, types) => {
     );
 
     if (!definedType) {
-      return sanitizedMessage;
+      return;
     }
 
     // key has a type. check if the definedType is also a type

--- a/ui/helpers/utils/util.js
+++ b/ui/helpers/utils/util.js
@@ -465,7 +465,36 @@ const solidityTypes = () => {
   const bytes = Array.from(new Array(32)).map(
     (_, index) => `bytes${index + 1}`,
   );
-  return [...types, ...ints, ...uints, ...bytes];
+
+  /**
+   * fixed and ufixed
+   * This value type also can be declared keywords such as ufixedMxN and fixedMxN.
+   * The M represents the amount of bits that the type takes,
+   * with N representing the number of decimal points that are available.
+   *  M has to be divisible by 8, and a number from 8 to 256.
+   * N has to be a value between 0 and 80, also being inclusive.
+   */
+  const fixedM = Array.from(new Array(32)).map(
+    (_, index) => `fixed${(index + 1) * 8}`,
+  );
+  const ufixedM = Array.from(new Array(32)).map(
+    (_, index) => `ufixed${(index + 1) * 8}`,
+  );
+  const fixed = Array.from(new Array(80)).map((_, index) =>
+    fixedM.map((aFixedM) => `${aFixedM}x${index + 1}`),
+  );
+  const ufixed = Array.from(new Array(80)).map((_, index) =>
+    ufixedM.map((auFixedM) => `${auFixedM}x${index + 1}`),
+  );
+
+  return [
+    ...types,
+    ...ints,
+    ...uints,
+    ...bytes,
+    ...fixed.flat(),
+    ...ufixed.flat(),
+  ];
 };
 
 export const sanitizeMessage = (msg, baseType, types) => {

--- a/ui/helpers/utils/util.js
+++ b/ui/helpers/utils/util.js
@@ -498,14 +498,13 @@ const solidityTypes = () => {
 };
 
 export const sanitizeMessage = (msg, baseType, types) => {
-  let baseTypeDefinitions;
-  if (types) {
-    baseTypeDefinitions = types[baseType];
-    if (!baseTypeDefinitions) {
-      throw new Error(`Invalid types definition found for msg: ${msg}`);
-    }
-  } else {
-    return msg;
+  if (!types) {
+    throw new Error(`Invalid types definition`);
+  }
+
+  const baseTypeDefinitions = types[baseType];
+  if (!baseTypeDefinitions) {
+    throw new Error(`Invalid primary type definition`);
   }
 
   const sanitizedMessage = {};

--- a/ui/helpers/utils/util.js
+++ b/ui/helpers/utils/util.js
@@ -91,8 +91,8 @@ export function addressSummary(
   }
   return checked
     ? `${checked.slice(0, firstSegLength)}...${checked.slice(
-        checked.length - lastSegLength,
-      )}`
+      checked.length - lastSegLength,
+    )}`
     : '...';
 }
 
@@ -515,34 +515,37 @@ export const sanitizeMessage = (msg, baseType, types) => {
       (baseTypeDefinition) => baseTypeDefinition.name === msgKey,
     );
 
-    if (definedType) {
-      // key has a type. check if the definedType is also a type
-      const nestedTypeDefinition = types[definedType.type.replace('[]', '')];
-      if (nestedTypeDefinition) {
-        if (definedType.type.indexOf('[]') > 0) {
-          // nested array
-          const definedArrayType = definedType.type.replace('[]', '');
-          sanitizedMessage[msgKey] = msg[msgKey].map((value) =>
-            sanitizeMessage(value, definedArrayType, types),
-          );
-        } else {
-          // nested object
-          sanitizedMessage[msgKey] = sanitizeMessage(
-            msg[msgKey],
-            definedType.type,
-            types,
-          );
-        }
-      } else {
-        // check if it's a valid solidity type
-        const isSolidityType = solidityTypes().includes(
-          definedType.type.replace('[]', ''),
+    if (!definedType) {
+      return sanitizedMessage;
+    }
+
+    // key has a type. check if the definedType is also a type
+    const nestedTypeDefinition = types[definedType.type.replace('[]', '')];
+
+    if (nestedTypeDefinition) {
+      if (definedType.type.indexOf('[]') > 0) {
+        // nested array
+        const definedArrayType = definedType.type.replace('[]', '');
+        sanitizedMessage[msgKey] = msg[msgKey].map((value) =>
+          sanitizeMessage(value, definedArrayType, types),
         );
-        if (isSolidityType) {
-          sanitizedMessage[msgKey] = msg[msgKey];
-        }
-      } // endif (nestedType)
-    } // endif (definedType)
+      } else {
+        // nested object
+        sanitizedMessage[msgKey] = sanitizeMessage(
+          msg[msgKey],
+          definedType.type,
+          types,
+        );
+      }
+    } else {
+      // check if it's a valid solidity type
+      const isSolidityType = solidityTypes().includes(
+        definedType.type.replace('[]', ''),
+      );
+      if (isSolidityType) {
+        sanitizedMessage[msgKey] = msg[msgKey];
+      }
+    }
   });
   return sanitizedMessage;
 };

--- a/ui/helpers/utils/util.js
+++ b/ui/helpers/utils/util.js
@@ -502,7 +502,7 @@ export const sanitizeMessage = (msg, baseType, types) => {
   if (types) {
     baseTypeDefinitions = types[baseType];
     if (!baseTypeDefinitions) {
-      return msg;
+      throw new Error(`Invalid types definition found for msg: ${msg}`);
     }
   } else {
     return msg;

--- a/ui/helpers/utils/util.test.js
+++ b/ui/helpers/utils/util.test.js
@@ -369,10 +369,6 @@ describe('util', () => {
         { name: 'chainId', type: 'uint256' },
         { name: 'verifyingContract', type: 'address' },
       ],
-      Group: [
-        { name: 'name', type: 'string' },
-        { name: 'members', type: 'Person[]' },
-      ],
       Mail: [
         { name: 'from', type: 'Person' },
         { name: 'to', type: 'Person[]' },

--- a/ui/helpers/utils/util.test.js
+++ b/ui/helpers/utils/util.test.js
@@ -386,24 +386,16 @@ describe('util', () => {
       };
     });
 
-    it('should return same message if types is not defined', () => {
-      const result = util.sanitizeMessage(message, primaryType, null);
-      expect(result.contents).toStrictEqual('Hello, Bob!');
-      expect(result.from.name).toStrictEqual('Cow');
-      expect(result.from.wallets).toHaveLength(2);
-      expect(result.to).toHaveLength(1);
-      expect(result.to[0].name).toStrictEqual('Bob');
-      expect(result.to[0].wallets).toHaveLength(3);
+    it('should throw an error if types is undefined', () => {
+      expect(() =>
+        util.sanitizeMessage(message, primaryType, undefined),
+      ).toThrow('Invalid types definition');
     });
 
-    it('should return same message if base type is not defined', () => {
-      const result = util.sanitizeMessage(message, null, types);
-      expect(result.contents).toStrictEqual('Hello, Bob!');
-      expect(result.from.name).toStrictEqual('Cow');
-      expect(result.from.wallets).toHaveLength(2);
-      expect(result.to).toHaveLength(1);
-      expect(result.to[0].name).toStrictEqual('Bob');
-      expect(result.to[0].wallets).toHaveLength(3);
+    it('should throw an error if base type is not defined', () => {
+      expect(() => util.sanitizeMessage(message, undefined, types)).toThrow(
+        'Invalid primary type definition',
+      );
     });
 
     it('should return parsed message if types is defined', () => {
@@ -422,13 +414,8 @@ describe('util', () => {
         do_not_display: 'two',
       };
 
-      // result will contain the do_not_displays because no type definition
-      let result = util.sanitizeMessage(message, primaryType, null);
-      expect(result.do_not_display).toStrictEqual('one');
-      expect(result.do_not_display_2.do_not_display).toStrictEqual('two');
-
       // result will NOT contain the do_not_displays because type definition
-      result = util.sanitizeMessage(message, primaryType, types);
+      const result = util.sanitizeMessage(message, primaryType, types);
       expect(result.contents).toStrictEqual('Hello, Bob!');
       expect(result.from.name).toStrictEqual('Cow');
       expect(result.from.wallets).toHaveLength(2);

--- a/ui/helpers/utils/util.test.js
+++ b/ui/helpers/utils/util.test.js
@@ -341,44 +341,50 @@ describe('util', () => {
     });
   });
   describe('sanitizeMessage', () => {
-    const message = {
-      contents: 'Hello, Bob!',
-      from: {
-        name: 'Cow',
-        wallets: [
-          '0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826',
-          '0xDeaDbeefdEAdbeefdEadbEEFdeadbeEFdEaDbeeF',
-        ],
-      },
-      to: [
-        {
-          name: 'Bob',
+    let message;
+    let primaryType;
+    let types;
+
+    beforeEach(() => {
+      message = {
+        contents: 'Hello, Bob!',
+        from: {
+          name: 'Cow',
           wallets: [
-            '0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB',
-            '0xB0BdaBea57B0BDABeA57b0bdABEA57b0BDabEa57',
-            '0xB0B0b0b0b0b0B000000000000000000000000000',
+            '0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826',
+            '0xDeaDbeefdEAdbeefdEadbEEFdeadbeEFdEaDbeeF',
           ],
         },
-      ],
-    };
-    const primaryType = 'Mail';
-    const types = {
-      EIP712Domain: [
-        { name: 'name', type: 'string' },
-        { name: 'version', type: 'string' },
-        { name: 'chainId', type: 'uint256' },
-        { name: 'verifyingContract', type: 'address' },
-      ],
-      Mail: [
-        { name: 'from', type: 'Person' },
-        { name: 'to', type: 'Person[]' },
-        { name: 'contents', type: 'string' },
-      ],
-      Person: [
-        { name: 'name', type: 'string' },
-        { name: 'wallets', type: 'address[]' },
-      ],
-    };
+        to: [
+          {
+            name: 'Bob',
+            wallets: [
+              '0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB',
+              '0xB0BdaBea57B0BDABeA57b0bdABEA57b0BDabEa57',
+              '0xB0B0b0b0b0b0B000000000000000000000000000',
+            ],
+          },
+        ],
+      };
+      primaryType = 'Mail';
+      types = {
+        EIP712Domain: [
+          { name: 'name', type: 'string' },
+          { name: 'version', type: 'string' },
+          { name: 'chainId', type: 'uint256' },
+          { name: 'verifyingContract', type: 'address' },
+        ],
+        Mail: [
+          { name: 'from', type: 'Person' },
+          { name: 'to', type: 'Person[]' },
+          { name: 'contents', type: 'string' },
+        ],
+        Person: [
+          { name: 'name', type: 'string' },
+          { name: 'wallets', type: 'address[]' },
+        ],
+      };
+    });
 
     it('should return same message if types is not defined', () => {
       const result = util.sanitizeMessage(message, primaryType, null);


### PR DESCRIPTION
Fixes: #11457 

Explanation:  
When executing a call to 'eth_signTypedData', the expectation is that the message that is presented to the user and the data that will be signed must match exactly. In fact, what seems to happen is that MetaMask presents the entire 'message' field, including fields that do not appear in the 'types' field. If that is in fact what is happening, it seems to present some security risk as clients can be expecting to sign on some fields, such as "expirationBlock" and such, but in fact these fields are not part of EIP-712 signature created.

Manual testing steps:  
see #11457 
  - 
  - 
  - 