### PR TITLE
Format shared/modules/*.tests

### DIFF
--- a/shared/modules/fetch-with-timeout.test.js
+++ b/shared/modules/fetch-with-timeout.test.js
@@ -2,8 +2,8 @@ import nock from 'nock';
 import { MILLISECOND, SECOND } from '../constants/time';
 import getFetchWithTimeout from './fetch-with-timeout';
 
-describe('getFetchWithTimeout', function () {
-  it('fetches a url', async function () {
+describe('getFetchWithTimeout', () => {
+  it('fetches a url', async () => {
     nock('https://api.infura.io').get('/money').reply(200, '{"hodl": false}');
 
     const fetchWithTimeout = getFetchWithTimeout(SECOND * 30);
@@ -15,7 +15,7 @@ describe('getFetchWithTimeout', function () {
     });
   });
 
-  it('throws when the request hits a custom timeout', async function () {
+  it('throws when the request hits a custom timeout', async () => {
     nock('https://api.infura.io')
       .get('/moon')
       .delay(SECOND * 2)
@@ -23,19 +23,14 @@ describe('getFetchWithTimeout', function () {
 
     const fetchWithTimeout = getFetchWithTimeout(MILLISECOND * 123);
 
-    const fetchWithTimeoutThrowsError = async () => {
+    await expect(async () => {
       await fetchWithTimeout('https://api.infura.io/moon').then((r) =>
         r.json(),
       );
-      throw new Error('Request should throw');
-    };
-
-    await expect(fetchWithTimeoutThrowsError()).rejects.toThrow(
-      'The user aborted a request.',
-    );
+    }).rejects.toThrow('The user aborted a request.');
   });
 
-  it('should abort the request when the custom timeout is hit', async function () {
+  it('should abort the request when the custom timeout is hit', async () => {
     nock('https://api.infura.io')
       .get('/moon')
       .delay(SECOND * 2)
@@ -43,29 +38,24 @@ describe('getFetchWithTimeout', function () {
 
     const fetchWithTimeout = getFetchWithTimeout(MILLISECOND * 123);
 
-    const fetchWithTimeoutThrowsError = async () => {
+    await expect(async () => {
       await fetchWithTimeout('https://api.infura.io/moon').then((r) =>
         r.json(),
       );
-      throw new Error('Request should be aborted');
-    };
-
-    await expect(fetchWithTimeoutThrowsError()).rejects.toThrow(
-      'The user aborted a request.',
-    );
+    }).rejects.toThrow('The user aborted a request.');
   });
 
-  it('throws on invalid timeout', async function () {
-    expect(() => getFetchWithTimeout()).toThrow(
+  it('throws on invalid timeout', async () => {
+    await expect(() => getFetchWithTimeout()).toThrow(
       'Must specify positive integer timeout.',
     );
-    expect(() => getFetchWithTimeout(-1)).toThrow(
+    await expect(() => getFetchWithTimeout(-1)).toThrow(
       'Must specify positive integer timeout.',
     );
-    expect(() => getFetchWithTimeout({})).toThrow(
+    await expect(() => getFetchWithTimeout({})).toThrow(
       'Must specify positive integer timeout.',
     );
-    expect(() => getFetchWithTimeout(true)).toThrow(
+    await expect(() => getFetchWithTimeout(true)).toThrow(
       'Must specify positive integer timeout.',
     );
   });

--- a/shared/modules/hexstring-utils.test.js
+++ b/shared/modules/hexstring-utils.test.js
@@ -6,51 +6,51 @@ describe('hexstring utils', function () {
     it('should allow 40-char non-prefixed hex', function () {
       const address = 'fdea65c8e26263f6d9a1b5de9555d2931a33b825';
       const result = isValidHexAddress(address);
-      expect(result).toBe(true);
+      expect(result).toStrictEqual(true);
     });
 
     it('should allow 42-char prefixed hex', function () {
       const address = '0xfdea65c8e26263f6d9a1b5de9555d2931a33b825';
       const result = isValidHexAddress(address);
-      expect(result).toBe(true);
+      expect(result).toStrictEqual(true);
     });
 
     it('should NOT allow 40-char non-prefixed hex when allowNonPrefixed is false', function () {
       const address = 'fdea65c8e26263f6d9a1b5de9555d2931a33b825';
       const result = isValidHexAddress(address, { allowNonPrefixed: false });
-      expect(result).toBe(false);
+      expect(result).toStrictEqual(false);
     });
 
     it('should NOT allow any length of non hex-prefixed string', function () {
       const address = 'fdea65c8e26263f6d9a1b5de9555d2931a33b85';
       const result = isValidHexAddress(address);
-      expect(result).toBe(false);
+      expect(result).toStrictEqual(false);
     });
 
     it('should NOT allow less than 42 character hex-prefixed string', function () {
       const address = '0xfdea65ce26263f6d9a1b5de9555d2931a33b85';
       const result = isValidHexAddress(address);
-      expect(result).toBe(false);
+      expect(result).toStrictEqual(false);
     });
 
     it('should recognize correct capitalized checksum', function () {
       const address = '0xFDEa65C8e26263F6d9A1B5de9555D2931A33b825';
       const result = isValidHexAddress(address, { mixedCaseUseChecksum: true });
-      expect(result).toBe(true);
+      expect(result).toStrictEqual(true);
     });
 
     it('should recognize incorrect capitalized checksum', function () {
       const address = '0xFDea65C8e26263F6d9A1B5de9555D2931A33b825';
       const result = isValidHexAddress(address, { mixedCaseUseChecksum: true });
-      expect(result).toBe(false);
+      expect(result).toStrictEqual(false);
     });
 
     it('should recognize this sample hashed address', function () {
       const address = '0x5Fda30Bb72B8Dfe20e48A00dFc108d0915BE9Bb0';
       const result = isValidHexAddress(address, { mixedCaseUseChecksum: true });
       const hashed = toChecksumAddress(address.toLowerCase());
-      expect(hashed).toBe(address);
-      expect(result).toBe(true);
+      expect(hashed).toStrictEqual(address);
+      expect(result).toStrictEqual(true);
     });
   });
 });


### PR DESCRIPTION
Format shared/modules/*.tests to use jest arrow functions and use stricter comparative matcher.