### PR TITLE
add openSeaEnabled preference

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -876,6 +876,9 @@
   "enableOpenSeaAPI": {
     "message": "Enable OpenSea API"
   },
+  "enableOpenSeaAPIDescription": {
+    "message": "Enable OpenSea API Description (TODO)"
+  },
   "encryptionPublicKeyNotice": {
     "message": "$1 would like your public encryption key. By consenting, this site will be able to compose encrypted messages to you.",
     "description": "$1 is the web3 site name"

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -877,7 +877,7 @@
     "message": "Enable OpenSea API"
   },
   "enableOpenSeaAPIDescription": {
-    "message": "Enable OpenSea API Description (TODO)"
+    "message": "Use OpenSea's API to fetch NFT data. NFT auto-detection relies on OpenSea's API, and will not be available when this is turned off."
   },
   "encryptionPublicKeyNotice": {
     "message": "$1 would like your public encryption key. By consenting, this site will be able to compose encrypted messages to you.",

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -873,6 +873,9 @@
   "enableFromSettings": {
     "message": " Enable it from Settings."
   },
+  "enableOpenSeaAPI": {
+    "message": "Enable OpenSea API"
+  },
   "encryptionPublicKeyNotice": {
     "message": "$1 would like your public encryption key. By consenting, this site will be able to compose encrypted messages to you.",
     "description": "$1 is the web3 site name"

--- a/app/scripts/controllers/preferences.js
+++ b/app/scripts/controllers/preferences.js
@@ -38,6 +38,7 @@ export default class PreferencesController {
       // set to false will be using the static list from contract-metadata
       useTokenDetection: false,
       useCollectibleDetection: false,
+      openSeaEnabled: false,
       advancedGasFee: null,
 
       // WARNING: Do not use feature flags for security-sensitive things.
@@ -138,7 +139,26 @@ export default class PreferencesController {
    *
    */
   setUseCollectibleDetection(val) {
+    const { openSeaEnabled } = this.store.getState();
+    if (val && !openSeaEnabled) {
+      throw new Error(
+        'useCollectibleDetection cannot be enabled if openSeaEnabled is false',
+      );
+    }
     this.store.updateState({ useCollectibleDetection: val });
+  }
+
+  /**
+   * Setter for the `openSeaEnabled` property
+   *
+   * @param {boolean} val - Whether or not the user prefers to use the OpenSea API for collectibles data.
+   *
+   */
+  setOpenSeaEnabled(val) {
+    this.store.updateState({ openSeaEnabled: val });
+    if (!val) {
+      this.store.updateState({ useCollectibleDetection: false });
+    }
   }
 
   /**

--- a/app/scripts/controllers/preferences.test.js
+++ b/app/scripts/controllers/preferences.test.js
@@ -286,6 +286,22 @@ describe('preferences controller', function () {
     });
   });
 
+  describe('setOpenSeaEnabled', function () {
+    it('should default to false', function () {
+      const state = preferencesController.store.getState();
+      assert.equal(state.openSeaEnabled, false);
+    });
+
+    it('should set the openSeaEnabled property in state', function () {
+      assert.equal(
+        preferencesController.store.getState().openSeaEnabled,
+        false,
+      );
+      preferencesController.setOpenSeaEnabled(true);
+      assert.equal(preferencesController.store.getState().openSeaEnabled, true);
+    });
+  });
+
   describe('setAdvancedGasFee', function () {
     it('should default to null', function () {
       const state = preferencesController.store.getState();

--- a/app/scripts/controllers/preferences.test.js
+++ b/app/scripts/controllers/preferences.test.js
@@ -278,6 +278,7 @@ describe('preferences controller', function () {
         preferencesController.store.getState().useCollectibleDetection,
         false,
       );
+      preferencesController.setOpenSeaEnabled(true);
       preferencesController.setUseCollectibleDetection(true);
       assert.equal(
         preferencesController.store.getState().useCollectibleDetection,

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -916,6 +916,10 @@ export default class MetamaskController extends EventEmitter {
         this.preferencesController.setUseCollectibleDetection,
         this.preferencesController,
       ),
+      setOpenSeaEnabled: nodeify(
+        this.preferencesController.setOpenSeaEnabled,
+        this.preferencesController,
+      ),
       setIpfsGateway: this.setIpfsGateway.bind(this),
       setParticipateInMetaMetrics: this.setParticipateInMetaMetrics.bind(this),
       setCurrentLocale: this.setCurrentLocale.bind(this),

--- a/ui/pages/settings/experimental-tab/experimental-tab.component.js
+++ b/ui/pages/settings/experimental-tab/experimental-tab.component.js
@@ -13,6 +13,8 @@ export default class ExperimentalTab extends PureComponent {
     setUseTokenDetection: PropTypes.func,
     useCollectibleDetection: PropTypes.bool,
     setUseCollectibleDetection: PropTypes.func,
+    setOpenSeaEnabled: PropTypes.func,
+    openSeaEnabled: PropTypes.func,
   };
 
   renderTokenDetectionToggle() {
@@ -52,7 +54,11 @@ export default class ExperimentalTab extends PureComponent {
 
   renderCollectibleDetectionToggle() {
     const { t } = this.context;
-    const { useCollectibleDetection, setUseCollectibleDetection } = this.props;
+    const {
+      useCollectibleDetection,
+      setUseCollectibleDetection,
+      openSeaEnabled,
+    } = this.props;
 
     return (
       <div className="settings-page__content-row">
@@ -65,6 +71,7 @@ export default class ExperimentalTab extends PureComponent {
         <div className="settings-page__content-item">
           <div className="settings-page__content-item-col">
             <ToggleButton
+              disabled={!openSeaEnabled}
               value={useCollectibleDetection}
               onToggle={(value) => {
                 this.context.metricsEvent({
@@ -85,10 +92,46 @@ export default class ExperimentalTab extends PureComponent {
     );
   }
 
+  renderOpenSeaEnabledToggle() {
+    const { t } = this.context;
+    const { openSeaEnabled, setOpenSeaEnabled } = this.props;
+
+    return (
+      <div className="settings-page__content-row">
+        <div className="settings-page__content-item">
+          <span>{t('enableOpenSeaAPI')}</span>
+          <div className="settings-page__content-description">
+            {t('enableOpenSeaAPIDescription')}
+          </div>
+        </div>
+        <div className="settings-page__content-item">
+          <div className="settings-page__content-item-col">
+            <ToggleButton
+              value={openSeaEnabled}
+              onToggle={(value) => {
+                this.context.metricsEvent({
+                  eventOpts: {
+                    category: 'Settings',
+                    action: 'Enabled/Disable OpenSea',
+                    name: 'Enabled/Disable OpenSea',
+                  },
+                });
+                setOpenSeaEnabled(!value);
+              }}
+              offLabel={t('off')}
+              onLabel={t('on')}
+            />
+          </div>
+        </div>
+      </div>
+    );
+  }
+
   render() {
     return (
       <div className="settings-page__body">
         {this.renderTokenDetectionToggle()}
+        {this.renderOpenSeaEnabledToggle()}
         {this.renderCollectibleDetectionToggle()}
       </div>
     );

--- a/ui/pages/settings/experimental-tab/experimental-tab.container.js
+++ b/ui/pages/settings/experimental-tab/experimental-tab.container.js
@@ -4,10 +4,12 @@ import { withRouter } from 'react-router-dom';
 import {
   setUseTokenDetection,
   setUseCollectibleDetection,
+  setOpenSeaEnabled,
 } from '../../../store/actions';
 import {
   getUseTokenDetection,
   getUseCollectibleDetection,
+  getOpenSeaEnabled,
 } from '../../../selectors';
 import ExperimentalTab from './experimental-tab.component';
 
@@ -15,6 +17,7 @@ const mapStateToProps = (state) => {
   return {
     useTokenDetection: getUseTokenDetection(state),
     useCollectibleDetection: getUseCollectibleDetection(state),
+    openSeaEnabled: getOpenSeaEnabled(state),
   };
 };
 
@@ -23,6 +26,7 @@ const mapDispatchToProps = (dispatch) => {
     setUseTokenDetection: (val) => dispatch(setUseTokenDetection(val)),
     setUseCollectibleDetection: (val) =>
       dispatch(setUseCollectibleDetection(val)),
+    setOpenSeaEnabled: (val) => dispatch(setOpenSeaEnabled(val)),
   };
 };
 

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -712,6 +712,15 @@ export function getUseCollectibleDetection(state) {
 }
 
 /**
+ * To get the openSeaEnabled flag which determines whether we use OpenSea's API
+ * @param {*} state
+ * @returns Boolean
+ */
+export function getOpenSeaEnabled(state) {
+  return Boolean(state.metamask.openSeaEnabled);
+}
+
+/**
  * To retrieve the tokenList produced by TokenListcontroller
  * @param {*} state
  * @returns {Object}

--- a/ui/store/actions.js
+++ b/ui/store/actions.js
@@ -2190,6 +2190,19 @@ export function setUseCollectibleDetection(val) {
   };
 }
 
+export function setOpenSeaEnabled(val) {
+  return (dispatch) => {
+    dispatch(showLoadingIndication());
+    log.debug(`background.setOpenSeaEnabled`);
+    background.setOpenSeaEnabled(val, (err) => {
+      dispatch(hideLoadingIndication());
+      if (err) {
+        dispatch(displayWarning(err.message));
+      }
+    });
+  };
+}
+
 export function setAdvancedGasFee(val) {
   return (dispatch) => {
     dispatch(showLoadingIndication());


### PR DESCRIPTION
Explanation:  Adds a new preference that allows users to toggle on/off the use of the OpenSea API for fetching NFT data. When this new "Use OpenSea API" preference is toggled off, the option to auto-detect is turned off and disabled. 

Possible states:
<img width="411" alt="Screen Shot 2021-11-30 at 2 45 14 PM" src="https://user-images.githubusercontent.com/34557516/144125380-d376c6a0-0913-4cf1-8cd6-c1b524bf35bf.png">
<img width="404" alt="Screen Shot 2021-11-30 at 2 45 26 PM" src="https://user-images.githubusercontent.com/34557516/144125391-a826ec27-8f4c-4f12-84f6-1c3904e5f6fa.png">
<img width="388" alt="Screen Shot 2021-11-30 at 2 45 30 PM" src="https://user-images.githubusercontent.com/34557516/144125403-c9b18a72-b112-41aa-86db-9060ea05a322.png">


TODO:
- [ ] Need copy for the preference description
 (My attempt):
<img width="591" alt="Screen Shot 2021-11-30 at 2 52 25 PM" src="https://user-images.githubusercontent.com/34557516/144126149-392e4804-bdc9-486c-a5f5-d7943cd62546.png">

