### PR TITLE
EIP-1559 V2: Adding default settings to advanced gas modal

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -171,7 +171,7 @@
     "message": "When your transaction gets included in the block, any difference between your max base fee and the actual base fee will be refunded. Total amount is calculated as max base fee (in GWEI) * gas limit."
   },
   "advancedGasFeeDefaultOptIn": {
-    "message": "Use the “new values” and advanced setting as default."
+    "message": "Update the values used by advanced settings by default."
   },
   "advancedGasFeeDefaultOptOut": {
     "message": "Always use these values and advanced setting as default."

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -171,7 +171,7 @@
     "message": "When your transaction gets included in the block, any difference between your max base fee and the actual base fee will be refunded. Total amount is calculated as max base fee (in GWEI) * gas limit."
   },
   "advancedGasFeeDefaultOptIn": {
-    "message": "Update the values used by advanced settings by default."
+    "message": "Save these $1 as my default for \"Advanced\""
   },
   "advancedGasFeeDefaultOptOut": {
     "message": "Always use these values and advanced setting as default."
@@ -1856,6 +1856,9 @@
   },
   "newTransactionFee": {
     "message": "New Transaction Fee"
+  },
+  "newValues": {
+    "message": "new values"
   },
   "next": {
     "message": "Next"

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -176,6 +176,12 @@
   "advancedGasPriceTitle": {
     "message": "Gas price"
   },
+  "advancedGassFeeDefaultOptIn": {
+    "message": "Use the “new values” and advanced setting as default."
+  },
+  "advancedGassFeeDefaultOptOut": {
+    "message": "Always use these values and advanced setting as default."
+  },
   "advancedOptions": {
     "message": "Advanced Options"
   },

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -170,17 +170,17 @@
   "advancedBaseGasFeeToolTip": {
     "message": "When your transaction gets included in the block, any difference between your max base fee and the actual base fee will be refunded. Total amount is calculated as max base fee (in GWEI) * gas limit."
   },
+  "advancedGasFeeDefaultOptIn": {
+    "message": "Use the “new values” and advanced setting as default."
+  },
+  "advancedGasFeeDefaultOptOut": {
+    "message": "Always use these values and advanced setting as default."
+  },
   "advancedGasFeeModalTitle": {
     "message": "Advanced gas fee"
   },
   "advancedGasPriceTitle": {
     "message": "Gas price"
-  },
-  "advancedGassFeeDefaultOptIn": {
-    "message": "Use the “new values” and advanced setting as default."
-  },
-  "advancedGassFeeDefaultOptOut": {
-    "message": "Always use these values and advanced setting as default."
   },
   "advancedOptions": {
     "message": "Advanced Options"

--- a/ui/components/app/advanced-gas-fee-popover/advanced-gas-fee-defaults/advanced-gas-fee-defaults.js
+++ b/ui/components/app/advanced-gas-fee-popover/advanced-gas-fee-defaults/advanced-gas-fee-defaults.js
@@ -1,5 +1,5 @@
-import React, { useState } from 'react';
-import { useSelector } from 'react-redux';
+import React, { useCallback, useState } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
 import Box from '../../../ui/box';
 import Typography from '../../../ui/typography';
 import CheckBox from '../../../ui/check-box';
@@ -10,12 +10,38 @@ import {
   FLEX_DIRECTION,
   TYPOGRAPHY,
 } from '../../../../helpers/constants/design-system';
-
+import { useAdvanceGasFeePopoverContext } from '../context';
 import { getIsAdvancedGasFeeDefault } from '../../../../selectors';
+import { setAdvancedGasFee } from '../../../../store/actions';
 
 const AdvancedGasFeeDefaults = () => {
+  const dispatch = useDispatch();
+
   const isAdvancedGasFeeDefault = useSelector(getIsAdvancedGasFeeDefault);
   const [defaultValues, setDefaultValues] = useState(isAdvancedGasFeeDefault);
+
+  const {
+    maxFeePerGas,
+    maxPriorityFeePerGas,
+  } = useAdvanceGasFeePopoverContext();
+
+  const updateDefaultSettings = useCallback(
+    (value) => {
+      setDefaultValues(value);
+      if (value) {
+        dispatch(
+          setAdvancedGasFee({
+            maxBaseFee: maxFeePerGas,
+            priorityFee: maxPriorityFeePerGas,
+          }),
+        );
+      } else {
+        dispatch(setAdvancedGasFee(null));
+      }
+    },
+    [maxFeePerGas, maxPriorityFeePerGas, setDefaultValues, dispatch],
+  );
+
   return (
     <Box
       display={DISPLAY.FLEX}
@@ -31,7 +57,7 @@ const AdvancedGasFeeDefaults = () => {
         <CheckBox
           checked={defaultValues}
           className="advanced-gas-fee-defaults__checkbox"
-          onClick={() => setDefaultValues((checked) => !checked)}
+          onClick={() => updateDefaultSettings(!defaultValues)}
         />
         <Typography variant={TYPOGRAPHY.H7} color={COLORS.UI4}>
           {defaultValues ? (

--- a/ui/components/app/advanced-gas-fee-popover/advanced-gas-fee-defaults/advanced-gas-fee-defaults.js
+++ b/ui/components/app/advanced-gas-fee-popover/advanced-gas-fee-defaults/advanced-gas-fee-defaults.js
@@ -1,5 +1,6 @@
-import React, { useCallback, useState, useEffect } from 'react';
+import React from 'react';
 import { useSelector, useDispatch } from 'react-redux';
+
 import Box from '../../../ui/box';
 import Typography from '../../../ui/typography';
 import CheckBox from '../../../ui/check-box';
@@ -10,12 +11,13 @@ import {
   FLEX_DIRECTION,
   TYPOGRAPHY,
 } from '../../../../helpers/constants/design-system';
-import { useAdvanceGasFeePopoverContext } from '../context';
 import {
   getIsAdvancedGasFeeDefault,
   getAdvancedGasFeeValues,
 } from '../../../../selectors';
 import { setAdvancedGasFee } from '../../../../store/actions';
+
+import { useAdvanceGasFeePopoverContext } from '../context';
 
 const AdvancedGasFeeDefaults = () => {
   const dispatch = useDispatch();
@@ -26,41 +28,23 @@ const AdvancedGasFeeDefaults = () => {
   } = useAdvanceGasFeePopoverContext();
   const isAdvancedGasFeeDefault = useSelector(getIsAdvancedGasFeeDefault);
   const advancedGasFeeValues = useSelector(getAdvancedGasFeeValues);
-  const [defaultValues, setDefaultValues] = useState(isAdvancedGasFeeDefault);
 
-  const updateDefaultSettings = useCallback(
-    (value) => {
-      setDefaultValues(value);
-      if (value) {
-        dispatch(
-          setAdvancedGasFee({
-            maxBaseFee: baseFeeMultiplier,
-            priorityFee: maxPriorityFeePerGas,
-          }),
-        );
-      } else {
-        dispatch(setAdvancedGasFee(null));
-      }
-    },
-    [baseFeeMultiplier, maxPriorityFeePerGas, setDefaultValues, dispatch],
-  );
-
-  useEffect(() => {
-    if (
-      !isAdvancedGasFeeDefault ||
-      advancedGasFeeValues.maxBaseFee !== baseFeeMultiplier ||
-      advancedGasFeeValues.priorityFee !== maxPriorityFeePerGas
-    ) {
-      setDefaultValues(false);
+  const updateDefaultSettings = (value) => {
+    if (value) {
+      dispatch(
+        setAdvancedGasFee({
+          maxBaseFee: baseFeeMultiplier,
+          priorityFee: maxPriorityFeePerGas,
+        }),
+      );
     } else {
-      setDefaultValues(true);
+      dispatch(setAdvancedGasFee(null));
     }
-  }, [
-    baseFeeMultiplier,
-    maxPriorityFeePerGas,
-    advancedGasFeeValues,
-    isAdvancedGasFeeDefault,
-  ]);
+  };
+  const defaultPreference =
+    isAdvancedGasFeeDefault &&
+    advancedGasFeeValues.maxBaseFee === baseFeeMultiplier &&
+    advancedGasFeeValues.priorityFee === maxPriorityFeePerGas;
 
   return (
     <Box
@@ -69,16 +53,18 @@ const AdvancedGasFeeDefaults = () => {
       className="advanced-gas-fee-defaults"
     >
       <CheckBox
-        checked={defaultValues}
+        checked={defaultPreference}
         className="advanced-gas-fee-defaults__checkbox"
-        onClick={() => updateDefaultSettings(!defaultValues)}
+        onClick={() => updateDefaultSettings(!defaultPreference)}
       />
       <Typography variant={TYPOGRAPHY.H7} color={COLORS.UI4}>
-        {defaultValues ? (
-          <I18nValue messageKey="advancedGassFeeDefaultOptOut" />
-        ) : (
-          <I18nValue messageKey="advancedGassFeeDefaultOptIn" />
-        )}
+        <I18nValue
+          messageKey={
+            defaultPreference
+              ? 'advancedGasFeeDefaultOptOut'
+              : 'advancedGasFeeDefaultOptIn'
+          }
+        />
       </Typography>
     </Box>
   );

--- a/ui/components/app/advanced-gas-fee-popover/advanced-gas-fee-defaults/advanced-gas-fee-defaults.js
+++ b/ui/components/app/advanced-gas-fee-popover/advanced-gas-fee-defaults/advanced-gas-fee-defaults.js
@@ -54,7 +54,7 @@ const AdvancedGasFeeDefaults = () => {
         className="advanced-gas-fee-defaults__checkbox"
         onClick={() => updateDefaultSettings(!defaultPreference)}
       />
-      <Typography variant={TYPOGRAPHY.H7} color={COLORS.UI4}>
+      <Typography variant={TYPOGRAPHY.H7} color={COLORS.UI4} margin={0}>
         <I18nValue
           messageKey={
             defaultPreference

--- a/ui/components/app/advanced-gas-fee-popover/advanced-gas-fee-defaults/advanced-gas-fee-defaults.js
+++ b/ui/components/app/advanced-gas-fee-popover/advanced-gas-fee-defaults/advanced-gas-fee-defaults.js
@@ -40,13 +40,13 @@ const AdvancedGasFeeDefaults = () => {
       dispatch(setAdvancedGasFee(null));
     }
   };
-  const defaultPreference =
+  const isDefaultSettingsSelected =
     Boolean(advancedGasFeeValues) &&
     advancedGasFeeValues.maxBaseFee === baseFeeMultiplier &&
     advancedGasFeeValues.priorityFee === maxPriorityFeePerGas;
 
   const handleUpdateDefaultSettings = () =>
-    updateDefaultSettings(!defaultPreference);
+    updateDefaultSettings(!isDefaultSettingsSelected);
 
   return (
     <Box
@@ -56,13 +56,13 @@ const AdvancedGasFeeDefaults = () => {
       className="advanced-gas-fee-defaults"
     >
       <CheckBox
-        checked={defaultPreference}
+        checked={isDefaultSettingsSelected}
         className="advanced-gas-fee-defaults__checkbox"
         onClick={handleUpdateDefaultSettings}
         disabled={hasErrors}
       />
       <Typography variant={TYPOGRAPHY.H7} color={COLORS.UI4} margin={0}>
-        {!defaultPreference && Boolean(advancedGasFeeValues) ? (
+        {!isDefaultSettingsSelected && Boolean(advancedGasFeeValues) ? (
           <I18nValue
             messageKey="advancedGasFeeDefaultOptIn"
             options={[

--- a/ui/components/app/advanced-gas-fee-popover/advanced-gas-fee-defaults/advanced-gas-fee-defaults.js
+++ b/ui/components/app/advanced-gas-fee-popover/advanced-gas-fee-defaults/advanced-gas-fee-defaults.js
@@ -37,11 +37,13 @@ const AdvancedGasFeeDefaults = () => {
       dispatch(setAdvancedGasFee(null));
     }
   };
-  const handleUpdateDefaultSettings = () => updateDefaultSettings(!defaultPreference);
   const defaultPreference =
     Boolean(advancedGasFeeValues) &&
     advancedGasFeeValues.maxBaseFee === baseFeeMultiplier &&
     advancedGasFeeValues.priorityFee === maxPriorityFeePerGas;
+
+  const handleUpdateDefaultSettings = () =>
+    updateDefaultSettings(!defaultPreference);
 
   return (
     <Box

--- a/ui/components/app/advanced-gas-fee-popover/advanced-gas-fee-defaults/advanced-gas-fee-defaults.js
+++ b/ui/components/app/advanced-gas-fee-popover/advanced-gas-fee-defaults/advanced-gas-fee-defaults.js
@@ -20,10 +20,7 @@ const AdvancedGasFeeDefaults = () => {
   const isAdvancedGasFeeDefault = useSelector(getIsAdvancedGasFeeDefault);
   const [defaultValues, setDefaultValues] = useState(isAdvancedGasFeeDefault);
 
-  const {
-    maxFeePerGas,
-    maxPriorityFeePerGas,
-  } = useAdvanceGasFeePopoverContext();
+  const { maxBaseFee, maxPriorityFeePerGas } = useAdvanceGasFeePopoverContext();
 
   const updateDefaultSettings = useCallback(
     (value) => {
@@ -31,7 +28,7 @@ const AdvancedGasFeeDefaults = () => {
       if (value) {
         dispatch(
           setAdvancedGasFee({
-            maxBaseFee: maxFeePerGas,
+            maxBaseFee,
             priorityFee: maxPriorityFeePerGas,
           }),
         );
@@ -39,7 +36,7 @@ const AdvancedGasFeeDefaults = () => {
         dispatch(setAdvancedGasFee(null));
       }
     },
-    [maxFeePerGas, maxPriorityFeePerGas, setDefaultValues, dispatch],
+    [maxBaseFee, maxPriorityFeePerGas, setDefaultValues, dispatch],
   );
 
   return (

--- a/ui/components/app/advanced-gas-fee-popover/advanced-gas-fee-defaults/advanced-gas-fee-defaults.js
+++ b/ui/components/app/advanced-gas-fee-popover/advanced-gas-fee-defaults/advanced-gas-fee-defaults.js
@@ -22,6 +22,7 @@ const AdvancedGasFeeDefaults = () => {
   const dispatch = useDispatch();
 
   const {
+    hasErrors,
     baseFeeMultiplier,
     maxPriorityFeePerGas,
   } = useAdvancedGasFeePopoverContext();
@@ -58,6 +59,7 @@ const AdvancedGasFeeDefaults = () => {
         checked={defaultPreference}
         className="advanced-gas-fee-defaults__checkbox"
         onClick={handleUpdateDefaultSettings}
+        disabled={hasErrors}
       />
       <Typography variant={TYPOGRAPHY.H7} color={COLORS.UI4} margin={0}>
         {!defaultPreference && Boolean(advancedGasFeeValues) ? (

--- a/ui/components/app/advanced-gas-fee-popover/advanced-gas-fee-defaults/advanced-gas-fee-defaults.js
+++ b/ui/components/app/advanced-gas-fee-popover/advanced-gas-fee-defaults/advanced-gas-fee-defaults.js
@@ -60,9 +60,9 @@ const AdvancedGasFeeDefaults = () => {
       <Typography variant={TYPOGRAPHY.H7} color={COLORS.UI4} margin={0}>
         <I18nValue
           messageKey={
-            defaultPreference
-              ? 'advancedGasFeeDefaultOptOut'
-              : 'advancedGasFeeDefaultOptIn'
+            !defaultPreference && Boolean(advancedGasFeeValues)
+              ? 'advancedGasFeeDefaultOptIn'
+              : 'advancedGasFeeDefaultOptOut'
           }
         />
       </Typography>

--- a/ui/components/app/advanced-gas-fee-popover/advanced-gas-fee-defaults/advanced-gas-fee-defaults.js
+++ b/ui/components/app/advanced-gas-fee-popover/advanced-gas-fee-defaults/advanced-gas-fee-defaults.js
@@ -20,7 +20,10 @@ const AdvancedGasFeeDefaults = () => {
   const isAdvancedGasFeeDefault = useSelector(getIsAdvancedGasFeeDefault);
   const [defaultValues, setDefaultValues] = useState(isAdvancedGasFeeDefault);
 
-  const { maxBaseFee, maxPriorityFeePerGas } = useAdvanceGasFeePopoverContext();
+  const {
+    baseFeeMultiplier,
+    maxPriorityFeePerGas,
+  } = useAdvanceGasFeePopoverContext();
 
   const updateDefaultSettings = useCallback(
     (value) => {
@@ -28,7 +31,7 @@ const AdvancedGasFeeDefaults = () => {
       if (value) {
         dispatch(
           setAdvancedGasFee({
-            maxBaseFee,
+            maxBaseFee: baseFeeMultiplier,
             priorityFee: maxPriorityFeePerGas,
           }),
         );
@@ -36,7 +39,7 @@ const AdvancedGasFeeDefaults = () => {
         dispatch(setAdvancedGasFee(null));
       }
     },
-    [maxBaseFee, maxPriorityFeePerGas, setDefaultValues, dispatch],
+    [baseFeeMultiplier, maxPriorityFeePerGas, setDefaultValues, dispatch],
   );
 
   return (

--- a/ui/components/app/advanced-gas-fee-popover/advanced-gas-fee-defaults/advanced-gas-fee-defaults.js
+++ b/ui/components/app/advanced-gas-fee-popover/advanced-gas-fee-defaults/advanced-gas-fee-defaults.js
@@ -15,8 +15,10 @@ import { getAdvancedGasFeeValues } from '../../../../selectors';
 import { setAdvancedGasFee } from '../../../../store/actions';
 
 import { useAdvancedGasFeePopoverContext } from '../context';
+import { useI18nContext } from '../../../../hooks/useI18nContext';
 
 const AdvancedGasFeeDefaults = () => {
+  const t = useI18nContext();
   const dispatch = useDispatch();
 
   const {
@@ -58,13 +60,16 @@ const AdvancedGasFeeDefaults = () => {
         onClick={handleUpdateDefaultSettings}
       />
       <Typography variant={TYPOGRAPHY.H7} color={COLORS.UI4} margin={0}>
-        <I18nValue
-          messageKey={
-            !defaultPreference && Boolean(advancedGasFeeValues)
-              ? 'advancedGasFeeDefaultOptIn'
-              : 'advancedGasFeeDefaultOptOut'
-          }
-        />
+        {!defaultPreference && Boolean(advancedGasFeeValues) ? (
+          <I18nValue
+            messageKey="advancedGasFeeDefaultOptIn"
+            options={[
+              <strong key="default-value-change">{t('newValues')}</strong>,
+            ]}
+          />
+        ) : (
+          <I18nValue messageKey="advancedGasFeeDefaultOptOut" />
+        )}
       </Typography>
     </Box>
   );

--- a/ui/components/app/advanced-gas-fee-popover/advanced-gas-fee-defaults/advanced-gas-fee-defaults.js
+++ b/ui/components/app/advanced-gas-fee-popover/advanced-gas-fee-defaults/advanced-gas-fee-defaults.js
@@ -50,6 +50,7 @@ const AdvancedGasFeeDefaults = () => {
     <Box
       display={DISPLAY.FLEX}
       flexDirection={FLEX_DIRECTION.ROW}
+      marginRight={4}
       className="advanced-gas-fee-defaults"
     >
       <CheckBox

--- a/ui/components/app/advanced-gas-fee-popover/advanced-gas-fee-defaults/advanced-gas-fee-defaults.js
+++ b/ui/components/app/advanced-gas-fee-popover/advanced-gas-fee-defaults/advanced-gas-fee-defaults.js
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useState, useEffect } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import Box from '../../../ui/box';
 import Typography from '../../../ui/typography';
@@ -26,12 +26,6 @@ const AdvancedGasFeeDefaults = () => {
   } = useAdvanceGasFeePopoverContext();
   const isAdvancedGasFeeDefault = useSelector(getIsAdvancedGasFeeDefault);
   const advancedGasFeeValues = useSelector(getAdvancedGasFeeValues);
-  console.log(
-    isAdvancedGasFeeDefault,
-    advancedGasFeeValues,
-    baseFeeMultiplier,
-    maxPriorityFeePerGas,
-  );
   const [defaultValues, setDefaultValues] = useState(isAdvancedGasFeeDefault);
 
   const updateDefaultSettings = useCallback(
@@ -50,6 +44,23 @@ const AdvancedGasFeeDefaults = () => {
     },
     [baseFeeMultiplier, maxPriorityFeePerGas, setDefaultValues, dispatch],
   );
+
+  useEffect(() => {
+    if (
+      !isAdvancedGasFeeDefault ||
+      advancedGasFeeValues.maxBaseFee !== baseFeeMultiplier ||
+      advancedGasFeeValues.priorityFee !== maxPriorityFeePerGas
+    ) {
+      setDefaultValues(false);
+    } else {
+      setDefaultValues(true);
+    }
+  }, [
+    baseFeeMultiplier,
+    maxPriorityFeePerGas,
+    advancedGasFeeValues,
+    isAdvancedGasFeeDefault,
+  ]);
 
   return (
     <Box

--- a/ui/components/app/advanced-gas-fee-popover/advanced-gas-fee-defaults/advanced-gas-fee-defaults.js
+++ b/ui/components/app/advanced-gas-fee-popover/advanced-gas-fee-defaults/advanced-gas-fee-defaults.js
@@ -17,7 +17,7 @@ import {
 } from '../../../../selectors';
 import { setAdvancedGasFee } from '../../../../store/actions';
 
-import { useAdvanceGasFeePopoverContext } from '../context';
+import { useAdvancedGasFeePopoverContext } from '../context';
 
 const AdvancedGasFeeDefaults = () => {
   const dispatch = useDispatch();
@@ -25,7 +25,7 @@ const AdvancedGasFeeDefaults = () => {
   const {
     baseFeeMultiplier,
     maxPriorityFeePerGas,
-  } = useAdvanceGasFeePopoverContext();
+  } = useAdvancedGasFeePopoverContext();
   const isAdvancedGasFeeDefault = useSelector(getIsAdvancedGasFeeDefault);
   const advancedGasFeeValues = useSelector(getAdvancedGasFeeValues);
 

--- a/ui/components/app/advanced-gas-fee-popover/advanced-gas-fee-defaults/advanced-gas-fee-defaults.js
+++ b/ui/components/app/advanced-gas-fee-popover/advanced-gas-fee-defaults/advanced-gas-fee-defaults.js
@@ -11,10 +11,7 @@ import {
   FLEX_DIRECTION,
   TYPOGRAPHY,
 } from '../../../../helpers/constants/design-system';
-import {
-  getIsAdvancedGasFeeDefault,
-  getAdvancedGasFeeValues,
-} from '../../../../selectors';
+import { getAdvancedGasFeeValues } from '../../../../selectors';
 import { setAdvancedGasFee } from '../../../../store/actions';
 
 import { useAdvancedGasFeePopoverContext } from '../context';
@@ -26,7 +23,6 @@ const AdvancedGasFeeDefaults = () => {
     baseFeeMultiplier,
     maxPriorityFeePerGas,
   } = useAdvancedGasFeePopoverContext();
-  const isAdvancedGasFeeDefault = useSelector(getIsAdvancedGasFeeDefault);
   const advancedGasFeeValues = useSelector(getAdvancedGasFeeValues);
 
   const updateDefaultSettings = (value) => {
@@ -42,7 +38,7 @@ const AdvancedGasFeeDefaults = () => {
     }
   };
   const defaultPreference =
-    isAdvancedGasFeeDefault &&
+    Boolean(advancedGasFeeValues) &&
     advancedGasFeeValues.maxBaseFee === baseFeeMultiplier &&
     advancedGasFeeValues.priorityFee === maxPriorityFeePerGas;
 

--- a/ui/components/app/advanced-gas-fee-popover/advanced-gas-fee-defaults/advanced-gas-fee-defaults.js
+++ b/ui/components/app/advanced-gas-fee-popover/advanced-gas-fee-defaults/advanced-gas-fee-defaults.js
@@ -37,6 +37,7 @@ const AdvancedGasFeeDefaults = () => {
       dispatch(setAdvancedGasFee(null));
     }
   };
+  const handleUpdateDefaultSettings = () => updateDefaultSettings(!defaultPreference);
   const defaultPreference =
     Boolean(advancedGasFeeValues) &&
     advancedGasFeeValues.maxBaseFee === baseFeeMultiplier &&
@@ -52,7 +53,7 @@ const AdvancedGasFeeDefaults = () => {
       <CheckBox
         checked={defaultPreference}
         className="advanced-gas-fee-defaults__checkbox"
-        onClick={() => updateDefaultSettings(!defaultPreference)}
+        onClick={handleUpdateDefaultSettings}
       />
       <Typography variant={TYPOGRAPHY.H7} color={COLORS.UI4} margin={0}>
         <I18nValue

--- a/ui/components/app/advanced-gas-fee-popover/advanced-gas-fee-defaults/advanced-gas-fee-defaults.js
+++ b/ui/components/app/advanced-gas-fee-popover/advanced-gas-fee-defaults/advanced-gas-fee-defaults.js
@@ -1,0 +1,48 @@
+import React, { useState } from 'react';
+import { useSelector } from 'react-redux';
+import Box from '../../../ui/box';
+import Typography from '../../../ui/typography';
+import CheckBox from '../../../ui/check-box';
+import I18nValue from '../../../ui/i18n-value';
+import {
+  COLORS,
+  DISPLAY,
+  FLEX_DIRECTION,
+  TYPOGRAPHY,
+} from '../../../../helpers/constants/design-system';
+
+import { getIsAdvancedGasFeeDefault } from '../../../../selectors';
+
+const AdvancedGasFeeDefaults = () => {
+  const isAdvancedGasFeeDefault = useSelector(getIsAdvancedGasFeeDefault);
+  const [defaultValues, setDefaultValues] = useState(isAdvancedGasFeeDefault);
+  return (
+    <Box
+      display={DISPLAY.FLEX}
+      flexDirection={FLEX_DIRECTION.COLUMN}
+      margin={4}
+    >
+      <div className="advanced-gas-fee-defaults__separator" />
+      <Box
+        display={DISPLAY.FLEX}
+        flexDirection={FLEX_DIRECTION.ROW}
+        className="advanced-gas-fee-defaults"
+      >
+        <CheckBox
+          checked={defaultValues}
+          className="advanced-gas-fee-defaults__checkbox"
+          onClick={() => setDefaultValues((checked) => !checked)}
+        />
+        <Typography variant={TYPOGRAPHY.H7} color={COLORS.UI4}>
+          {defaultValues ? (
+            <I18nValue messageKey="advancedGassFeeDefaultOptOut" />
+          ) : (
+            <I18nValue messageKey="advancedGassFeeDefaultOptIn" />
+          )}
+        </Typography>
+      </Box>
+    </Box>
+  );
+};
+
+export default AdvancedGasFeeDefaults;

--- a/ui/components/app/advanced-gas-fee-popover/advanced-gas-fee-defaults/advanced-gas-fee-defaults.js
+++ b/ui/components/app/advanced-gas-fee-popover/advanced-gas-fee-defaults/advanced-gas-fee-defaults.js
@@ -11,19 +11,28 @@ import {
   TYPOGRAPHY,
 } from '../../../../helpers/constants/design-system';
 import { useAdvanceGasFeePopoverContext } from '../context';
-import { getIsAdvancedGasFeeDefault } from '../../../../selectors';
+import {
+  getIsAdvancedGasFeeDefault,
+  getAdvancedGasFeeValues,
+} from '../../../../selectors';
 import { setAdvancedGasFee } from '../../../../store/actions';
 
 const AdvancedGasFeeDefaults = () => {
   const dispatch = useDispatch();
 
-  const isAdvancedGasFeeDefault = useSelector(getIsAdvancedGasFeeDefault);
-  const [defaultValues, setDefaultValues] = useState(isAdvancedGasFeeDefault);
-
   const {
     baseFeeMultiplier,
     maxPriorityFeePerGas,
   } = useAdvanceGasFeePopoverContext();
+  const isAdvancedGasFeeDefault = useSelector(getIsAdvancedGasFeeDefault);
+  const advancedGasFeeValues = useSelector(getAdvancedGasFeeValues);
+  console.log(
+    isAdvancedGasFeeDefault,
+    advancedGasFeeValues,
+    baseFeeMultiplier,
+    maxPriorityFeePerGas,
+  );
+  const [defaultValues, setDefaultValues] = useState(isAdvancedGasFeeDefault);
 
   const updateDefaultSettings = useCallback(
     (value) => {
@@ -45,28 +54,21 @@ const AdvancedGasFeeDefaults = () => {
   return (
     <Box
       display={DISPLAY.FLEX}
-      flexDirection={FLEX_DIRECTION.COLUMN}
-      margin={4}
+      flexDirection={FLEX_DIRECTION.ROW}
+      className="advanced-gas-fee-defaults"
     >
-      <div className="advanced-gas-fee-defaults__separator" />
-      <Box
-        display={DISPLAY.FLEX}
-        flexDirection={FLEX_DIRECTION.ROW}
-        className="advanced-gas-fee-defaults"
-      >
-        <CheckBox
-          checked={defaultValues}
-          className="advanced-gas-fee-defaults__checkbox"
-          onClick={() => updateDefaultSettings(!defaultValues)}
-        />
-        <Typography variant={TYPOGRAPHY.H7} color={COLORS.UI4}>
-          {defaultValues ? (
-            <I18nValue messageKey="advancedGassFeeDefaultOptOut" />
-          ) : (
-            <I18nValue messageKey="advancedGassFeeDefaultOptIn" />
-          )}
-        </Typography>
-      </Box>
+      <CheckBox
+        checked={defaultValues}
+        className="advanced-gas-fee-defaults__checkbox"
+        onClick={() => updateDefaultSettings(!defaultValues)}
+      />
+      <Typography variant={TYPOGRAPHY.H7} color={COLORS.UI4}>
+        {defaultValues ? (
+          <I18nValue messageKey="advancedGassFeeDefaultOptOut" />
+        ) : (
+          <I18nValue messageKey="advancedGassFeeDefaultOptIn" />
+        )}
+      </Typography>
     </Box>
   );
 };

--- a/ui/components/app/advanced-gas-fee-popover/advanced-gas-fee-defaults/advanced-gas-fee-defaults.test.js
+++ b/ui/components/app/advanced-gas-fee-popover/advanced-gas-fee-defaults/advanced-gas-fee-defaults.test.js
@@ -10,6 +10,7 @@ import { AdvanceGasFeePopoverContextProvider } from '../context';
 import { GasFeeContextProvider } from '../../../../contexts/gasFee';
 import configureStore from '../../../../store/store';
 
+import AdvancedGasFeeInputs from '../advanced-gas-fee-inputs';
 import AdvancedGasFeeDefaults from './advanced-gas-fee-defaults';
 
 jest.mock('../../../../store/actions', () => ({
@@ -41,9 +42,14 @@ const render = (defaultGasParams) => {
     <GasFeeContextProvider
       transaction={{
         userFeeLevel: 'custom',
+        txParams: {
+          maxFeePerGas: '0x174876E800',
+          maxPriorityFeePerGas: '0x77359400',
+        },
       }}
     >
       <AdvanceGasFeePopoverContextProvider>
+        <AdvancedGasFeeInputs />
         <AdvancedGasFeeDefaults />
       </AdvanceGasFeePopoverContextProvider>
     </GasFeeContextProvider>,
@@ -61,7 +67,9 @@ describe('AdvancedGasFeeDefaults', () => {
     ).toBeInTheDocument();
   });
   it('should renders correct message when the default values are set', () => {
-    render({ advancedGasFee: { maxBaseFee: 2, priorityFee: 1.5 } });
+    render({
+      advancedGasFee: { maxBaseFee: 2, priorityFee: 2 },
+    });
 
     expect(
       screen.queryByText(

--- a/ui/components/app/advanced-gas-fee-popover/advanced-gas-fee-defaults/advanced-gas-fee-defaults.test.js
+++ b/ui/components/app/advanced-gas-fee-popover/advanced-gas-fee-defaults/advanced-gas-fee-defaults.test.js
@@ -1,0 +1,72 @@
+import React from 'react';
+import { screen } from '@testing-library/react';
+
+import { GAS_ESTIMATE_TYPES } from '../../../../../shared/constants/gas';
+import { renderWithProvider } from '../../../../../test/lib/render-helpers';
+import mockEstimates from '../../../../../test/data/mock-estimates.json';
+import mockState from '../../../../../test/data/mock-state.json';
+
+import { AdvanceGasFeePopoverContextProvider } from '../context';
+import { GasFeeContextProvider } from '../../../../contexts/gasFee';
+import configureStore from '../../../../store/store';
+
+import AdvancedGasFeeDefaults from './advanced-gas-fee-defaults';
+
+jest.mock('../../../../store/actions', () => ({
+  disconnectGasFeeEstimatePoller: jest.fn(),
+  getGasFeeEstimatesAndStartPolling: jest
+    .fn()
+    .mockImplementation(() => Promise.resolve()),
+  addPollingTokenToAppState: jest.fn(),
+  removePollingTokenFromAppState: jest.fn(),
+}));
+
+const render = (defaultGasParams) => {
+  const store = configureStore({
+    metamask: {
+      ...mockState.metamask,
+      ...defaultGasParams,
+      accounts: {
+        [mockState.metamask.selectedAddress]: {
+          address: mockState.metamask.selectedAddress,
+          balance: '0x1F4',
+        },
+      },
+      featureFlags: { advancedInlineGas: true },
+      gasFeeEstimates:
+        mockEstimates[GAS_ESTIMATE_TYPES.FEE_MARKET].gasFeeEstimates,
+    },
+  });
+  return renderWithProvider(
+    <GasFeeContextProvider
+      transaction={{
+        userFeeLevel: 'custom',
+      }}
+    >
+      <AdvanceGasFeePopoverContextProvider>
+        <AdvancedGasFeeDefaults />
+      </AdvanceGasFeePopoverContextProvider>
+    </GasFeeContextProvider>,
+    store,
+  );
+};
+describe('AdvancedGasFeeDefaults', () => {
+  it('should renders correct message when the default is not set', () => {
+    render({ advancedGasFee: null });
+
+    expect(
+      screen.queryByText(
+        'Use the “new values” and advanced setting as default.',
+      ),
+    ).toBeInTheDocument();
+  });
+  it('should renders correct message when the default values are set', () => {
+    render({ advancedGasFee: { maxBaseFee: 2, priorityFee: 1.5 } });
+
+    expect(
+      screen.queryByText(
+        'Always use these values and advanced setting as default.',
+      ),
+    ).toBeInTheDocument();
+  });
+});

--- a/ui/components/app/advanced-gas-fee-popover/advanced-gas-fee-defaults/advanced-gas-fee-defaults.test.js
+++ b/ui/components/app/advanced-gas-fee-popover/advanced-gas-fee-defaults/advanced-gas-fee-defaults.test.js
@@ -105,10 +105,9 @@ describe('AdvancedGasFeeDefaults', () => {
       target: { value: 4 },
     });
     expect(document.getElementsByTagName('input')[0]).toHaveValue(4);
+    expect(screen.queryByText('new values')).toBeInTheDocument();
     expect(
-      screen.queryByText(
-        'Update the values used by advanced settings by default.',
-      ),
+      screen.queryByText('Save these as my default for "Advanced"'),
     ).toBeInTheDocument();
   });
   it('should renders correct message when the default values are set and the priorityFee values are updated', () => {
@@ -125,10 +124,9 @@ describe('AdvancedGasFeeDefaults', () => {
       target: { value: 4 },
     });
     expect(document.getElementsByTagName('input')[1]).toHaveValue(4);
+    expect(screen.queryByText('new values')).toBeInTheDocument();
     expect(
-      screen.queryByText(
-        'Update the values used by advanced settings by default.',
-      ),
+      screen.queryByText('Save these as my default for "Advanced"'),
     ).toBeInTheDocument();
   });
 });

--- a/ui/components/app/advanced-gas-fee-popover/advanced-gas-fee-defaults/advanced-gas-fee-defaults.test.js
+++ b/ui/components/app/advanced-gas-fee-popover/advanced-gas-fee-defaults/advanced-gas-fee-defaults.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { screen } from '@testing-library/react';
+import { fireEvent, screen } from '@testing-library/react';
 
 import { GAS_ESTIMATE_TYPES } from '../../../../../shared/constants/gas';
 import { renderWithProvider } from '../../../../../test/lib/render-helpers';
@@ -59,10 +59,9 @@ const render = (defaultGasParams) => {
 describe('AdvancedGasFeeDefaults', () => {
   it('should renders correct message when the default is not set', () => {
     render({ advancedGasFee: null });
-
     expect(
       screen.queryByText(
-        'Use the “new values” and advanced setting as default.',
+        'Always use these values and advanced setting as default.',
       ),
     ).toBeInTheDocument();
   });
@@ -70,10 +69,65 @@ describe('AdvancedGasFeeDefaults', () => {
     render({
       advancedGasFee: { maxBaseFee: 2, priorityFee: 2 },
     });
-
     expect(
       screen.queryByText(
         'Always use these values and advanced setting as default.',
+      ),
+    ).toBeInTheDocument();
+  });
+  it('should renders correct message when checkbox is selected and default values are saved', () => {
+    render({
+      advancedGasFee: null,
+    });
+    expect(
+      screen.queryByText(
+        'Always use these values and advanced setting as default.',
+      ),
+    ).toBeInTheDocument();
+    fireEvent.change(document.getElementsByTagName('input')[0], {
+      target: { value: 3 },
+    });
+    fireEvent.change(document.getElementsByTagName('input')[1], {
+      target: { value: 4 },
+    });
+  });
+  it('should renders correct message when the default values are set and the maxBaseFee values are updated', () => {
+    render({
+      advancedGasFee: { maxBaseFee: 2, priorityFee: 2 },
+    });
+    expect(document.getElementsByTagName('input')[2]).toBeChecked();
+    expect(
+      screen.queryByText(
+        'Always use these values and advanced setting as default.',
+      ),
+    ).toBeInTheDocument();
+    fireEvent.change(document.getElementsByTagName('input')[0], {
+      target: { value: 4 },
+    });
+    expect(document.getElementsByTagName('input')[0]).toHaveValue(4);
+    expect(
+      screen.queryByText(
+        'Update the values used by advanced settings by default.',
+      ),
+    ).toBeInTheDocument();
+  });
+  it('should renders correct message when the default values are set and the priorityFee values are updated', () => {
+    render({
+      advancedGasFee: { maxBaseFee: 2, priorityFee: 2 },
+    });
+    expect(document.getElementsByTagName('input')[2]).toBeChecked();
+    expect(
+      screen.queryByText(
+        'Always use these values and advanced setting as default.',
+      ),
+    ).toBeInTheDocument();
+    fireEvent.change(document.getElementsByTagName('input')[1], {
+      target: { value: 4 },
+    });
+    expect(document.getElementsByTagName('input')[1]).toHaveValue(4);
+    expect(
+      screen.queryByText(
+        'Update the values used by advanced settings by default.',
       ),
     ).toBeInTheDocument();
   });

--- a/ui/components/app/advanced-gas-fee-popover/advanced-gas-fee-defaults/advanced-gas-fee-defaults.test.js
+++ b/ui/components/app/advanced-gas-fee-popover/advanced-gas-fee-defaults/advanced-gas-fee-defaults.test.js
@@ -6,7 +6,7 @@ import { renderWithProvider } from '../../../../../test/lib/render-helpers';
 import mockEstimates from '../../../../../test/data/mock-estimates.json';
 import mockState from '../../../../../test/data/mock-state.json';
 
-import { AdvanceGasFeePopoverContextProvider } from '../context';
+import { AdvancedGasFeePopoverContextProvider } from '../context';
 import { GasFeeContextProvider } from '../../../../contexts/gasFee';
 import configureStore from '../../../../store/store';
 
@@ -48,10 +48,10 @@ const render = (defaultGasParams) => {
         },
       }}
     >
-      <AdvanceGasFeePopoverContextProvider>
+      <AdvancedGasFeePopoverContextProvider>
         <AdvancedGasFeeInputs />
         <AdvancedGasFeeDefaults />
-      </AdvanceGasFeePopoverContextProvider>
+      </AdvancedGasFeePopoverContextProvider>
     </GasFeeContextProvider>,
     store,
   );

--- a/ui/components/app/advanced-gas-fee-popover/advanced-gas-fee-defaults/index.js
+++ b/ui/components/app/advanced-gas-fee-popover/advanced-gas-fee-defaults/index.js
@@ -1,0 +1,1 @@
+export { default } from './advanced-gas-fee-defaults';

--- a/ui/components/app/advanced-gas-fee-popover/advanced-gas-fee-defaults/index.scss
+++ b/ui/components/app/advanced-gas-fee-popover/advanced-gas-fee-defaults/index.scss
@@ -1,0 +1,13 @@
+.advanced-gas-fee-defaults {
+  &__separator {
+    border-top: 1px solid $ui-grey;
+    margin: 0 0 16px 0;
+  }
+
+  & &__checkbox {
+    color: $ui-4;
+    font-size: $font-size-h4;
+    margin: 0 8px 0 8px;
+    border-width: 1px;
+  }
+}

--- a/ui/components/app/advanced-gas-fee-popover/advanced-gas-fee-defaults/index.scss
+++ b/ui/components/app/advanced-gas-fee-popover/advanced-gas-fee-defaults/index.scss
@@ -5,9 +5,7 @@
   }
 
   & &__checkbox {
-    color: $ui-4;
     font-size: $font-size-h4;
     margin: 0 8px 0 8px;
-    border-width: 1px;
   }
 }

--- a/ui/components/app/advanced-gas-fee-popover/advanced-gas-fee-defaults/index.scss
+++ b/ui/components/app/advanced-gas-fee-popover/advanced-gas-fee-defaults/index.scss
@@ -1,9 +1,4 @@
 .advanced-gas-fee-defaults {
-  &__separator {
-    border-top: 1px solid $ui-grey;
-    margin: 0 0 16px 0;
-  }
-
   & &__checkbox {
     font-size: $font-size-h4;
     margin: 0 8px 0 8px;

--- a/ui/components/app/advanced-gas-fee-popover/advanced-gas-fee-gas-limit/advanced-gas-fee-gas-limit.js
+++ b/ui/components/app/advanced-gas-fee-popover/advanced-gas-fee-gas-limit/advanced-gas-fee-gas-limit.js
@@ -63,6 +63,7 @@ const AdvancedGasFeeGasLimit = () => {
       tag={TYPOGRAPHY.Paragraph}
       variant={TYPOGRAPHY.H7}
       className="advanced-gas-fee-gas-limit"
+      margin={[0, 2]}
     >
       <strong>
         <I18nValue messageKey="gasLimitV2" />

--- a/ui/components/app/advanced-gas-fee-popover/advanced-gas-fee-inputs/advanced-gas-fee-inputs.js
+++ b/ui/components/app/advanced-gas-fee-popover/advanced-gas-fee-inputs/advanced-gas-fee-inputs.js
@@ -6,7 +6,7 @@ import PriorityFeeInput from './priority-fee-input';
 
 const AdvancedGasFeeInputs = () => {
   return (
-    <Box className="advanced-gas-fee-inputs" margin={[4, 0]}>
+    <Box className="advanced-gas-fee-inputs">
       <BaseFeeInput />
       <div className="advanced-gas-fee-inputs__separator" />
       <PriorityFeeInput />

--- a/ui/components/app/advanced-gas-fee-popover/advanced-gas-fee-inputs/base-fee-input/base-fee-input.js
+++ b/ui/components/app/advanced-gas-fee-popover/advanced-gas-fee-inputs/base-fee-input/base-fee-input.js
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useState } from 'react';
-import { useSelector, useDispatch } from 'react-redux';
+import { useSelector } from 'react-redux';
 
 import { HIGH_FEE_WARNING_MULTIPLIER } from '../../../../../pages/send/send.constants';
 import { PRIORITY_LEVELS } from '../../../../../../shared/constants/gas';
@@ -10,7 +10,6 @@ import {
 import { PRIMARY, SECONDARY } from '../../../../../helpers/constants/common';
 import { bnGreaterThan, bnLessThan } from '../../../../../helpers/utils/util';
 import { decGWEIToHexWEI } from '../../../../../helpers/utils/conversions.util';
-
 import { getAdvancedGasFeeValues } from '../../../../../selectors';
 import { useGasFeeContext } from '../../../../../contexts/gasFee';
 import { useI18nContext } from '../../../../../hooks/useI18nContext';
@@ -77,7 +76,6 @@ const validateBaseFee = (
 
 const BaseFeeInput = () => {
   const t = useI18nContext();
-  const dispatch = useDispatch();
 
   const { gasFeeEstimates, estimateUsed, maxFeePerGas } = useGasFeeContext();
   const {

--- a/ui/components/app/advanced-gas-fee-popover/advanced-gas-fee-inputs/base-fee-input/base-fee-input.js
+++ b/ui/components/app/advanced-gas-fee-popover/advanced-gas-fee-inputs/base-fee-input/base-fee-input.js
@@ -195,7 +195,7 @@ const BaseFeeInput = () => {
   ]);
 
   return (
-    <Box className="base-fee-input">
+    <Box className="base-fee-input" margin={[0, 2]}>
       <FormField
         error={baseFeeError ? t(baseFeeError) : ''}
         onChange={updateBaseFee}

--- a/ui/components/app/advanced-gas-fee-popover/advanced-gas-fee-inputs/base-fee-input/base-fee-input.js
+++ b/ui/components/app/advanced-gas-fee-popover/advanced-gas-fee-inputs/base-fee-input/base-fee-input.js
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useState } from 'react';
-import { useSelector } from 'react-redux';
+import { useSelector, useDispatch } from 'react-redux';
 
 import { HIGH_FEE_WARNING_MULTIPLIER } from '../../../../../pages/send/send.constants';
 import { PRIORITY_LEVELS } from '../../../../../../shared/constants/gas';
@@ -77,6 +77,8 @@ const validateBaseFee = (
 
 const BaseFeeInput = () => {
   const t = useI18nContext();
+  const dispatch = useDispatch();
+
   const { gasFeeEstimates, estimateUsed, maxFeePerGas } = useGasFeeContext();
   const {
     maxPriorityFeePerGas,
@@ -101,6 +103,7 @@ const BaseFeeInput = () => {
   } = useUserPreferencedCurrency(SECONDARY);
 
   const advancedGasFeeValues = useSelector(getAdvancedGasFeeValues);
+  const isAdvancedGasFeeDefault = useSelector(getIsAdvancedGasFeeDefault);
 
   const [editingInGwei, setEditingInGwei] = useState(false);
 

--- a/ui/components/app/advanced-gas-fee-popover/advanced-gas-fee-inputs/base-fee-input/base-fee-input.js
+++ b/ui/components/app/advanced-gas-fee-popover/advanced-gas-fee-inputs/base-fee-input/base-fee-input.js
@@ -84,7 +84,7 @@ const BaseFeeInput = () => {
     maxPriorityFeePerGas,
     setErrorValue,
     setMaxFeePerGas,
-    setMaxBaseFee,
+    setBaseFeeMultiplier,
   } = useAdvancedGasFeePopoverContext();
 
   const {
@@ -103,7 +103,6 @@ const BaseFeeInput = () => {
   } = useUserPreferencedCurrency(SECONDARY);
 
   const advancedGasFeeValues = useSelector(getAdvancedGasFeeValues);
-  const isAdvancedGasFeeDefault = useSelector(getIsAdvancedGasFeeDefault);
 
   const [editingInGwei, setEditingInGwei] = useState(false);
 
@@ -181,7 +180,7 @@ const BaseFeeInput = () => {
     if (baseFeeTrend !== 'level' && baseFeeTrend !== feeTrend) {
       setFeeTrend(baseFeeTrend);
     }
-    setMaxBaseFee(maxBaseFeeMultiplier);
+    setBaseFeeMultiplier(maxBaseFeeMultiplier);
   }, [
     feeTrend,
     editingInGwei,
@@ -194,7 +193,7 @@ const BaseFeeInput = () => {
     setErrorValue,
     setMaxFeePerGas,
     setFeeTrend,
-    setMaxBaseFee,
+    setBaseFeeMultiplier,
   ]);
 
   return (

--- a/ui/components/app/advanced-gas-fee-popover/advanced-gas-fee-inputs/base-fee-input/base-fee-input.js
+++ b/ui/components/app/advanced-gas-fee-popover/advanced-gas-fee-inputs/base-fee-input/base-fee-input.js
@@ -82,6 +82,7 @@ const BaseFeeInput = () => {
     maxPriorityFeePerGas,
     setErrorValue,
     setMaxFeePerGas,
+    setMaxBaseFee,
   } = useAdvancedGasFeePopoverContext();
 
   const {
@@ -177,6 +178,7 @@ const BaseFeeInput = () => {
     if (baseFeeTrend !== 'level' && baseFeeTrend !== feeTrend) {
       setFeeTrend(baseFeeTrend);
     }
+    setMaxBaseFee(maxBaseFeeMultiplier);
   }, [
     feeTrend,
     editingInGwei,
@@ -184,10 +186,12 @@ const BaseFeeInput = () => {
     gasFeeEstimates,
     maxBaseFeeGWEI,
     maxPriorityFeePerGas,
+    maxBaseFeeMultiplier,
     setBaseFeeError,
     setErrorValue,
     setMaxFeePerGas,
     setFeeTrend,
+    setMaxBaseFee,
   ]);
 
   return (

--- a/ui/components/app/advanced-gas-fee-popover/advanced-gas-fee-inputs/index.scss
+++ b/ui/components/app/advanced-gas-fee-popover/advanced-gas-fee-inputs/index.scss
@@ -9,6 +9,6 @@
 
   &__separator {
     border-top: 1px solid $ui-grey;
-    margin: 20px 0;
+    margin: 16px 0;
   }
 }

--- a/ui/components/app/advanced-gas-fee-popover/advanced-gas-fee-inputs/index.scss
+++ b/ui/components/app/advanced-gas-fee-popover/advanced-gas-fee-inputs/index.scss
@@ -9,6 +9,6 @@
 
   &__separator {
     border-top: 1px solid $ui-grey;
-    margin: 24px 0 16px 0;
+    margin: 20px 0;
   }
 }

--- a/ui/components/app/advanced-gas-fee-popover/advanced-gas-fee-inputs/priority-fee-input/priority-fee-input.js
+++ b/ui/components/app/advanced-gas-fee-popover/advanced-gas-fee-inputs/priority-fee-input/priority-fee-input.js
@@ -1,11 +1,15 @@
 import React, { useEffect, useState } from 'react';
-import { useSelector } from 'react-redux';
+import { useSelector, useDispatch } from 'react-redux';
 
 import { HIGH_FEE_WARNING_MULTIPLIER } from '../../../../../pages/send/send.constants';
 import { PRIORITY_LEVELS } from '../../../../../../shared/constants/gas';
 import { SECONDARY } from '../../../../../helpers/constants/common';
 import { decGWEIToHexWEI } from '../../../../../helpers/utils/conversions.util';
-import { getAdvancedGasFeeValues } from '../../../../../selectors';
+import {
+  getAdvancedGasFeeValues,
+  getIsAdvancedGasFeeDefault,
+} from '../../../../../selectors';
+import { setAdvancedGasFee } from '../../../../../store/actions';
 import { useCurrencyDisplay } from '../../../../../hooks/useCurrencyDisplay';
 import { useGasFeeContext } from '../../../../../contexts/gasFee';
 import { useI18nContext } from '../../../../../hooks/useI18nContext';
@@ -42,7 +46,10 @@ const validatePriorityFee = (value, gasFeeEstimates) => {
 
 const PriorityFeeInput = () => {
   const t = useI18nContext();
+  const dispatch = useDispatch();
+
   const advancedGasFeeValues = useSelector(getAdvancedGasFeeValues);
+  const isAdvancedGasFeeDefault = useSelector(getIsAdvancedGasFeeDefault);
   const {
     setErrorValue,
     setMaxPriorityFeePerGas,

--- a/ui/components/app/advanced-gas-fee-popover/advanced-gas-fee-inputs/priority-fee-input/priority-fee-input.js
+++ b/ui/components/app/advanced-gas-fee-popover/advanced-gas-fee-inputs/priority-fee-input/priority-fee-input.js
@@ -1,15 +1,11 @@
 import React, { useEffect, useState } from 'react';
-import { useSelector, useDispatch } from 'react-redux';
+import { useSelector } from 'react-redux';
 
 import { HIGH_FEE_WARNING_MULTIPLIER } from '../../../../../pages/send/send.constants';
 import { PRIORITY_LEVELS } from '../../../../../../shared/constants/gas';
 import { SECONDARY } from '../../../../../helpers/constants/common';
 import { decGWEIToHexWEI } from '../../../../../helpers/utils/conversions.util';
-import {
-  getAdvancedGasFeeValues,
-  getIsAdvancedGasFeeDefault,
-} from '../../../../../selectors';
-import { setAdvancedGasFee } from '../../../../../store/actions';
+import { getAdvancedGasFeeValues } from '../../../../../selectors';
 import { useCurrencyDisplay } from '../../../../../hooks/useCurrencyDisplay';
 import { useGasFeeContext } from '../../../../../contexts/gasFee';
 import { useI18nContext } from '../../../../../hooks/useI18nContext';
@@ -46,10 +42,7 @@ const validatePriorityFee = (value, gasFeeEstimates) => {
 
 const PriorityFeeInput = () => {
   const t = useI18nContext();
-  const dispatch = useDispatch();
-
   const advancedGasFeeValues = useSelector(getAdvancedGasFeeValues);
-  const isAdvancedGasFeeDefault = useSelector(getIsAdvancedGasFeeDefault);
   const {
     setErrorValue,
     setMaxPriorityFeePerGas,

--- a/ui/components/app/advanced-gas-fee-popover/advanced-gas-fee-inputs/priority-fee-input/priority-fee-input.js
+++ b/ui/components/app/advanced-gas-fee-popover/advanced-gas-fee-inputs/priority-fee-input/priority-fee-input.js
@@ -11,6 +11,7 @@ import { useGasFeeContext } from '../../../../../contexts/gasFee';
 import { useI18nContext } from '../../../../../hooks/useI18nContext';
 import { useUserPreferencedCurrency } from '../../../../../hooks/useUserPreferencedCurrency';
 import FormField from '../../../../ui/form-field';
+import Box from '../../../../ui/box';
 import { bnGreaterThan, bnLessThan } from '../../../../../helpers/utils/util';
 
 import { useAdvancedGasFeePopoverContext } from '../../context';
@@ -103,7 +104,7 @@ const PriorityFeeInput = () => {
   ]);
 
   return (
-    <>
+    <Box margin={[0, 2]}>
       <FormField
         error={priorityFeeError ? t(priorityFeeError) : ''}
         onChange={updatePriorityFee}
@@ -119,7 +120,7 @@ const PriorityFeeInput = () => {
         historical={renderFeeRange(historicalPriorityFeeRange)}
         feeTrend={feeTrend}
       />
-    </>
+    </Box>
   );
 };
 

--- a/ui/components/app/advanced-gas-fee-popover/advanced-gas-fee-popover.js
+++ b/ui/components/app/advanced-gas-fee-popover/advanced-gas-fee-popover.js
@@ -9,6 +9,7 @@ import { AdvancedGasFeePopoverContextProvider } from './context';
 import AdvancedGasFeeInputs from './advanced-gas-fee-inputs';
 import AdvancedGasFeeGasLimit from './advanced-gas-fee-gas-limit';
 import AdvancedGasFeeSaveButton from './advanced-gas-fee-save';
+import AdvancedGasFeeDefaults from './advanced-gas-fee-defaults';
 
 const AdvancedGasFeePopover = () => {
   const t = useI18nContext();
@@ -31,6 +32,8 @@ const AdvancedGasFeePopover = () => {
       >
         <Box className="advanced-gas-fee-popover__wrapper" margin={4}>
           <AdvancedGasFeeInputs />
+          <div className="advanced-gas-fee-popover__separator" />
+          <AdvancedGasFeeDefaults />
           <div className="advanced-gas-fee-popover__separator" />
           <AdvancedGasFeeGasLimit />
         </Box>

--- a/ui/components/app/advanced-gas-fee-popover/advanced-gas-fee-popover.js
+++ b/ui/components/app/advanced-gas-fee-popover/advanced-gas-fee-popover.js
@@ -30,7 +30,7 @@ const AdvancedGasFeePopover = () => {
         onClose={closeAllModals}
         footer={<AdvancedGasFeeSaveButton />}
       >
-        <Box className="advanced-gas-fee-popover__wrapper" margin={4}>
+        <Box margin={4}>
           <AdvancedGasFeeInputs />
           <div className="advanced-gas-fee-popover__separator" />
           <AdvancedGasFeeDefaults />

--- a/ui/components/app/advanced-gas-fee-popover/context/advancedGasFeePopover.js
+++ b/ui/components/app/advanced-gas-fee-popover/context/advancedGasFeePopover.js
@@ -20,7 +20,7 @@ export const AdvancedGasFeePopoverContextProvider = ({ children }) => {
     },
     [errors, setErrors],
   );
-  const [maxBaseFee, setMaxBaseFee] = useState();
+  const [baseFeeMultiplier, setBaseFeeMultiplier] = useState();
 
   return (
     <AdvancedGasFeePopoverContext.Provider
@@ -30,11 +30,11 @@ export const AdvancedGasFeePopoverContextProvider = ({ children }) => {
         maxFeePerGas,
         maxPriorityFeePerGas,
         setErrorValue,
-        maxBaseFee,
+        baseFeeMultiplier,
         setGasLimit,
         setMaxPriorityFeePerGas,
         setMaxFeePerGas,
-        setMaxBaseFee,
+        setBaseFeeMultiplier,
       }}
     >
       {children}

--- a/ui/components/app/advanced-gas-fee-popover/context/advancedGasFeePopover.js
+++ b/ui/components/app/advanced-gas-fee-popover/context/advancedGasFeePopover.js
@@ -20,6 +20,7 @@ export const AdvancedGasFeePopoverContextProvider = ({ children }) => {
     },
     [errors, setErrors],
   );
+  const [maxBaseFee, setMaxBaseFee] = useState();
 
   return (
     <AdvancedGasFeePopoverContext.Provider
@@ -29,9 +30,11 @@ export const AdvancedGasFeePopoverContextProvider = ({ children }) => {
         maxFeePerGas,
         maxPriorityFeePerGas,
         setErrorValue,
+        maxBaseFee,
         setGasLimit,
         setMaxPriorityFeePerGas,
         setMaxFeePerGas,
+        setMaxBaseFee,
       }}
     >
       {children}

--- a/ui/components/app/advanced-gas-fee-popover/index.scss
+++ b/ui/components/app/advanced-gas-fee-popover/index.scss
@@ -1,7 +1,7 @@
 .advanced-gas-fee-popover {
   &__separator {
     border-top: 1px solid $ui-grey;
-    margin: 20px 0;
+    margin: 16px 0;
   }
 
   .form-field__heading-title > h6 {

--- a/ui/components/app/advanced-gas-fee-popover/index.scss
+++ b/ui/components/app/advanced-gas-fee-popover/index.scss
@@ -1,14 +1,21 @@
 .advanced-gas-fee-popover {
-  &__wrapper {
-    border-top: 1px solid $ui-grey;
-  }
-
   &__separator {
     border-top: 1px solid $ui-grey;
-    margin: 24px 0 16px 0;
+    margin: 20px 0;
   }
 
   .form-field__heading-title > h6 {
     font-size: $font-size-h7;
+  }
+
+  .popover-header {
+    border-radius: 0;
+    border-top-left-radius: 10px;
+    border-top-right-radius: 10px;
+    border-bottom: 1px solid $ui-grey;
+  }
+
+  .popover-footer {
+    border-top: none;
   }
 }

--- a/ui/components/app/app-components.scss
+++ b/ui/components/app/app-components.scss
@@ -68,4 +68,4 @@
 @import 'advanced-gas-fee-popover/advanced-gas-fee-inputs/index';
 @import 'advanced-gas-fee-popover/advanced-gas-fee-inputs/base-fee-input/index';
 @import 'advanced-gas-fee-popover/advanced-gas-fee-input-subtext/index';
-@import 'advanced-gas-fee-popover/advanced-gas-fee-defaults/index.scss';
+@import 'advanced-gas-fee-popover/advanced-gas-fee-defaults/index';

--- a/ui/components/app/app-components.scss
+++ b/ui/components/app/app-components.scss
@@ -62,9 +62,10 @@
 @import 'whats-new-popup/index';
 @import 'loading-network-screen/index';
 @import 'flask/experimental-area/index';
+@import 'transaction-decoding/index';
 @import 'advanced-gas-fee-popover/index';
 @import 'advanced-gas-fee-popover/advanced-gas-fee-gas-limit/index';
 @import 'advanced-gas-fee-popover/advanced-gas-fee-inputs/index';
 @import 'advanced-gas-fee-popover/advanced-gas-fee-inputs/base-fee-input/index';
 @import 'advanced-gas-fee-popover/advanced-gas-fee-input-subtext/index';
-@import 'transaction-decoding/index';
+@import 'advanced-gas-fee-popover/advanced-gas-fee-defaults/index.scss';


### PR DESCRIPTION
Fixes: #12469 

Enabling the default settings will save the `maxBaseFee` (multiplier value) and `priorityFee` to the state so that they can be used as a user preference in future transactions.

Scenarios covered:

- Checking the checkbox will save the current `maxBaseFee` and `priorityFee` to advancedGasFee and the message will be updated to `Always use these values and advanced setting as default.` 
- Updating any of the `maxBaseFee` and `priorityFee`  while the checkbox is checked will uncheck the box and update the message to `Use the “new values” and advanced setting as default.`, but will retain the existing default preference values.
- Rechecking the checkbox after updating the values will save the new values.
- Unchecking the checkbox manually will remove the existing default preference values.

Screenshot:
<img width="336" alt="Screen Shot 2021-12-03 at 9 39 39 PM" src="https://user-images.githubusercontent.com/43930900/144694008-d3f4c673-cbe7-4cf9-90e4-17aba3f5658a.png">

Screen recording:


https://user-images.githubusercontent.com/43930900/146818352-fd92558d-444f-4278-b899-f571f823d646.mov




