### PR TITLE
Add e2e test delay to account for remote call made by trezor keyring

### DIFF
--- a/test/e2e/tests/from-import-ui.spec.js
+++ b/test/e2e/tests/from-import-ui.spec.js
@@ -1,5 +1,5 @@
 const { strict: assert } = require('assert');
-const { withFixtures, regularDelayMs } = require('../helpers');
+const { withFixtures, regularDelayMs, largeDelayMs } = require('../helpers');
 const enLocaleMessages = require('../../../app/_locales/en/messages.json');
 
 describe('Metamask Import UI', function () {
@@ -318,6 +318,7 @@ describe('Metamask Import UI', function () {
 
         // should open the TREZOR Connect popup
         await driver.clickElement('.hw-connect__btn:nth-of-type(2)');
+        await driver.delay(largeDelayMs * 2);
         await driver.clickElement({ text: 'Continue', tag: 'button' });
         await driver.waitUntilXWindowHandles(2);
         const allWindows = await driver.getAllWindowHandles();


### PR DESCRIPTION
It seems that with https://github.com/MetaMask/metamask-extension/pull/12627 some indeterminacy was introduced into our e2e tests

@meppsilon Did some good investigation into this:

- There is one e2e test (Connects to a Hardware wallet) that fails pretty consistently with TypeError: Cannot add property default, object is not extensible .
- It fails on both develop and other feature branches
- manually going through the flow on both branches, it behaves as expected: clicking "Trezor" icon and then "Continue" opens up the Trezor connect popup.

With some investigation this seems connected to this change: https://github.com/MetaMask/eth-trezor-keyring/pull/108/files#diff-e727e4bdf3657fd1d798edcd6b099d6e092f8573cba266154583a746bba0f346L39-R68

The method called there does do a remote call to a trezor endpoint. We should prevent that from happening within the e2e tests. I suspect that will resolve this issue. This is captured in this ticket https://github.com/MetaMask/metamask-extension/issues/12912

As a hotfix to get e2e passing before we fix the root cause, this PR just adds a delay to account for the async activity that needs to resolve before we can open the trezor modal