### PR TITLE
Block Explorer URL work correctly

### DIFF
--- a/ui/components/app/transaction-list-item-details/transaction-list-item-details.component.js
+++ b/ui/components/app/transaction-list-item-details/transaction-list-item-details.component.js
@@ -13,7 +13,7 @@ import CancelButton from '../cancel-button';
 import Popover from '../../ui/popover';
 import { SECOND } from '../../../../shared/constants/time';
 import { TRANSACTION_TYPES } from '../../../../shared/constants/transaction';
-import { getURLHostName } from '../../../helpers/utils/util';
+import { getURLHostName, getURLWithHash } from '../../../helpers/utils/util';
 
 export default class TransactionListItemDetails extends PureComponent {
   static contextTypes = {
@@ -69,6 +69,15 @@ export default class TransactionListItemDetails extends PureComponent {
         block_explorer_domain: getURLHostName(blockExplorerLink),
       },
     });
+
+    if (rpcPrefs?.blockExplorerUrl) {
+      if (rpcPrefs?.blockExplorerUrl.match(/\/#/u)) {
+        global.platform.openTab({
+          url: getURLWithHash(blockExplorerLink),
+        });
+        return;
+      }
+    }
 
     global.platform.openTab({
       url: blockExplorerLink,

--- a/ui/helpers/utils/util.js
+++ b/ui/helpers/utils/util.js
@@ -405,6 +405,10 @@ export function getURLHost(url) {
   return getURL(url)?.host || '';
 }
 
+export function getURLWithHash(url) {
+  return `${getURL(url)?.origin}/#${getURL(url)?.pathname}` || '';
+}
+
 export function getURLHostName(url) {
   return getURL(url)?.hostname || '';
 }


### PR DESCRIPTION
Fixes: #12465

**Explanation:**  When user want's to create network (example - not real) and insert into the `Block Explorer URL (optional):` field some URL with the `#/`, for example `https://testnet.bscscan.com/#/`, expected behavior will be like this `https://testnet.bscscan.com/#/tx/<hash>`. 

I added function `getURLWithHash` and check the case if block explorer url has that `#/`, if he has then call function `getURLWithHash` and navigate to that URL, if he hasn't expected behavior will be like this, for example, `https://testnet.bscscan.com/tx/<hash>`. 

In the screencast you can see I try this behavior on different test networks (`Ropsten Test Network`, `Smart Chain - Testnet` and `Mumbai TestNet`) 

**Screencast:** 


https://user-images.githubusercontent.com/92527393/144251843-49a017d3-828c-44fc-8b70-03f8abc2b673.mp4

