### PR TITLE
Put new collectibles related preferences behind feature flag

### DIFF
--- a/ui/pages/settings/experimental-tab/experimental-tab.component.js
+++ b/ui/pages/settings/experimental-tab/experimental-tab.component.js
@@ -53,6 +53,10 @@ export default class ExperimentalTab extends PureComponent {
   }
 
   renderCollectibleDetectionToggle() {
+    if (!process.env.COLLECTIBLES_V1) {
+      return null;
+    }
+
     const { t } = this.context;
     const {
       useCollectibleDetection,
@@ -93,6 +97,9 @@ export default class ExperimentalTab extends PureComponent {
   }
 
   renderOpenSeaEnabledToggle() {
+    if (!process.env.COLLECTIBLES_V1) {
+      return null;
+    }
     const { t } = this.context;
     const { openSeaEnabled, setOpenSeaEnabled } = this.props;
 


### PR DESCRIPTION
Explanation:  Put new collectibles related preferences introduced in https://github.com/MetaMask/metamask-extension/pull/12909 behind COLLECTIBLES_V1 feature flag 

Manual testing steps:  
  - Make sure COLLECTIBLES_V1 is not set in .metamaskrc
  - Navigate to experimental tab of settings. 
  - Make sure that "AutoDetect NFTs" and "Use OpenSea API" preference toggles are not present
  