### PR TITLE
Update package.json + yarn.lock with contract-metadata version 1.31.0 

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "@keystonehq/bc-ur-registry-eth": "^0.6.8",
     "@keystonehq/metamask-airgapped-keyring": "0.2.1",
     "@material-ui/core": "^4.11.0",
-    "@metamask/contract-metadata": "^1.28.0",
+    "@metamask/contract-metadata": "^1.31.0",
     "@metamask/controllers": "^20.1.0",
     "@metamask/eth-ledger-bridge-keyring": "^0.10.0",
     "@metamask/eth-token-tracker": "^3.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2601,12 +2601,7 @@
     semver "^7.3.5"
     yargs "^17.0.1"
 
-"@metamask/contract-metadata@^1.19.0", "@metamask/contract-metadata@^1.30.0":
-  version "1.30.0"
-  resolved "https://registry.yarnpkg.com/@metamask/contract-metadata/-/contract-metadata-1.30.0.tgz#fa8e1b0c3e7aaa963986088f691fb553ffbe3904"
-  integrity sha512-b2usYW/ptQYnE6zhUmr4T+nvOAQJK5ABcpKudyQANpy4K099elpv4aN0WcrcOcwV99NHOdMzFP3ZuG0HoAyOBQ==
-
-"@metamask/contract-metadata@^1.31.0":
+"@metamask/contract-metadata@^1.19.0", "@metamask/contract-metadata@^1.30.0", "@metamask/contract-metadata@^1.31.0":
   version "1.31.0"
   resolved "https://registry.yarnpkg.com/@metamask/contract-metadata/-/contract-metadata-1.31.0.tgz#9e3e46de7a955ea1ca61f7db20d9a17b5e91d3d0"
   integrity sha512-4FBJkg/vDiYp/thIiZknxrJ0lfsj2eWIPenwlNZmoqOhoL4VqhK5eKWxi+EuGMvv9taP+QBRk6Key7wC1uL78A==

--- a/yarn.lock
+++ b/yarn.lock
@@ -2601,10 +2601,15 @@
     semver "^7.3.5"
     yargs "^17.0.1"
 
-"@metamask/contract-metadata@^1.19.0", "@metamask/contract-metadata@^1.28.0", "@metamask/contract-metadata@^1.30.0":
+"@metamask/contract-metadata@^1.19.0", "@metamask/contract-metadata@^1.30.0":
   version "1.30.0"
   resolved "https://registry.yarnpkg.com/@metamask/contract-metadata/-/contract-metadata-1.30.0.tgz#fa8e1b0c3e7aaa963986088f691fb553ffbe3904"
   integrity sha512-b2usYW/ptQYnE6zhUmr4T+nvOAQJK5ABcpKudyQANpy4K099elpv4aN0WcrcOcwV99NHOdMzFP3ZuG0HoAyOBQ==
+
+"@metamask/contract-metadata@^1.31.0":
+  version "1.31.0"
+  resolved "https://registry.yarnpkg.com/@metamask/contract-metadata/-/contract-metadata-1.31.0.tgz#9e3e46de7a955ea1ca61f7db20d9a17b5e91d3d0"
+  integrity sha512-4FBJkg/vDiYp/thIiZknxrJ0lfsj2eWIPenwlNZmoqOhoL4VqhK5eKWxi+EuGMvv9taP+QBRk6Key7wC1uL78A==
 
 "@metamask/controllers@^20.1.0":
   version "20.1.0"


### PR DESCRIPTION
Fixes:
Bump the contract-metadata version to 1.31.0 in package.json file and updated yarn.lock.

Explanation:
The contract-metadata repository has been updated and released over past months with several new currency logo's. This update will include those new entries in the next metamask release.

Manual testing steps:
n/a