### PR TITLE
Remove invalid `disableRipple` prop

### DIFF
--- a/ui/pages/unlock-page/unlock-page.component.js
+++ b/ui/pages/unlock-page/unlock-page.component.js
@@ -126,7 +126,6 @@ export default class UnlockPage extends Component {
         variant="contained"
         size="large"
         onClick={this.handleSubmit}
-        disableRipple
       >
         {this.context.t('unlock')}
       </Button>


### PR DESCRIPTION
The `disableRipple` prop was resulting in a React error in development builds because it was unrecognized by React. This prop dates back to when we were using the `@material-ui` Button class. It no longer serves any purpose, so it has been removed.

<details>
<summary>Here is what the warning looked like:</summary>

```
[425531:425531:1201/230226.519867:INFO:CONSOLE(14112)] "Warning: React does not recognize the `%s` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `%s` instead. If you accidentally passed it from a parent component, remove it from the DOM element.%s disableRipple disableripple             in button (created by Button)                                                                                                                                                     in Button (created by UnlockPage)                                                                                                                                             
    in div (created by UnlockPage)                                                       
    in div (created by UnlockPage)                                                                                                                                                
    in UnlockPage (created by ConnectFunction)                                                                                                                                    
    in ConnectFunction (created by Context.Consumer)                                                                                                                              
    in withRouter(Connect(UnlockPage)) (created by Context.Consumer)                                                                                                              
    in Route (created by Initialized)                                                                                                                                             
    in Initialized (created by ConnectFunction)                                                                                                                                   
    in ConnectFunction (created by Routes)                                                                                                                                        
    in Switch (created by Routes)                                                                                                                                                 
    in div (created by Routes)                                                                                                                                                    
    in div (created by Routes)                                                                                                                                                    
    in Routes (created by ConnectFunction)                                                                                                                                            in ConnectFunction (created by Context.Consumer)                                                                                                                                  in withRouter(Connect(Routes)) (created by Index)                                                                                                                                 in LegacyI18nProvider (created by Index)                                                                                                                                      
    in I18nProvider (created by Index)                                                                                                                                            
    in LegacyMetaMetricsProvider (created by Index)                                                                                                                               
    in MetaMetricsProvider (created by Index)                                                                                                                                     
    in LegacyMetaMetricsProvider (created by Index)                                                                                                                               
    in MetaMetricsProvider (created by Index)                                                                                                                                     
    in Router (created by HashRouter)                                                                                                                                             
    in HashRouter (created by Index)                                                                                                                                              
    in Provider (created by Index)                                                                                                                                                
    in Index", source: chrome-extension://mpogmfdbabklafjoodlkjbmfnnlplald/ui-0.js (14112)
```
</details>

Manual testing steps:  
  - Create a development test build (`yarn build testDev`) and run any e2e test (e.g. `yarn test:e2e:single --browser chrome ./test/e2e/tests/signature-request.test.js`). See that the error resulting from `disableRipple` is no longer present in the console.