### PR TITLE
Fix `isMainnet` propType error

### DIFF
--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -56,7 +56,7 @@ const openMetamaskTabsIDs = {};
 const requestAccountTabIds = {};
 
 // state persistence
-const inTest = process.env.IN_TEST === 'true';
+const inTest = process.env.IN_TEST;
 const localStore = inTest ? new ReadOnlyNetworkStore() : new LocalStore();
 let versionedData;
 

--- a/app/scripts/controllers/network/createJsonRpcClient.js
+++ b/app/scripts/controllers/network/createJsonRpcClient.js
@@ -10,7 +10,7 @@ import {
 import { PollingBlockTracker } from 'eth-block-tracker';
 import { SECOND } from '../../../../shared/constants/time';
 
-const inTest = process.env.IN_TEST === 'true';
+const inTest = process.env.IN_TEST;
 const blockTrackerOpts = inTest ? { pollingInterval: SECOND } : {};
 const getTestMiddlewares = () => {
   return inTest ? [createEstimateGasDelayTestMiddleware()] : [];

--- a/app/scripts/controllers/network/network.js
+++ b/app/scripts/controllers/network/network.js
@@ -33,7 +33,7 @@ const env = process.env.METAMASK_ENV;
 const fetchWithTimeout = getFetchWithTimeout(SECOND * 30);
 
 let defaultProviderConfigOpts;
-if (process.env.IN_TEST === 'true') {
+if (process.env.IN_TEST) {
   defaultProviderConfigOpts = {
     type: NETWORK_TYPE_RPC,
     rpcUrl: 'http://localhost:8545',

--- a/development/build/scripts.js
+++ b/development/build/scripts.js
@@ -779,7 +779,7 @@ function getEnvironmentVariables({ buildType, devMode, testing }) {
     METAMASK_VERSION: version,
     METAMASK_BUILD_TYPE: buildType,
     NODE_ENV: devMode ? ENVIRONMENT.DEVELOPMENT : ENVIRONMENT.PRODUCTION,
-    IN_TEST: testing ? 'true' : false,
+    IN_TEST: testing,
     PUBNUB_SUB_KEY: process.env.PUBNUB_SUB_KEY || '',
     PUBNUB_PUB_KEY: process.env.PUBNUB_PUB_KEY || '',
     CONF: devMode ? metamaskrc : {},

--- a/ui/components/app/edit-gas-fee-popover/edit-gas-fee-popover.js
+++ b/ui/components/app/edit-gas-fee-popover/edit-gas-fee-popover.js
@@ -29,7 +29,7 @@ const EditGasFeePopover = () => {
       className="edit-gas-fee-popover"
     >
       <>
-        {process.env.IN_TEST === 'true' ? null : <LoadingHeartBeat />}
+        {process.env.IN_TEST ? null : <LoadingHeartBeat />}
         <div className="edit-gas-fee-popover__wrapper">
           <div className="edit-gas-fee-popover__content">
             {balanceError && (

--- a/ui/components/app/edit-gas-popover/edit-gas-popover.component.js
+++ b/ui/components/app/edit-gas-popover/edit-gas-popover.component.js
@@ -261,7 +261,7 @@ export default function EditGasPopover({
           <EditGasDisplayEducation />
         ) : (
           <>
-            {process.env.IN_TEST === 'true' ? null : <LoadingHeartBeat />}
+            {process.env.IN_TEST ? null : <LoadingHeartBeat />}
             <EditGasDisplay
               showEducationButton={showEducationButton}
               warning={warning}

--- a/ui/helpers/utils/i18n-helper.js
+++ b/ui/helpers/utils/i18n-helper.js
@@ -32,7 +32,7 @@ export const getMessage = (localeCode, localeMessages, key, substitutions) => {
         );
         Sentry.captureException(missingMessageErrors[key]);
         log.error(missingMessageErrors[key]);
-        if (process.env.IN_TEST === 'true') {
+        if (process.env.IN_TEST) {
           throw missingMessageErrors[key];
         }
       }

--- a/ui/pages/confirm-transaction-base/confirm-transaction-base.component.js
+++ b/ui/pages/confirm-transaction-base/confirm-transaction-base.component.js
@@ -68,7 +68,7 @@ const EIP_1559_V2_ENABLED =
   process.env.EIP_1559_V2 === true || process.env.EIP_1559_V2 === 'true';
 
 const renderHeartBeatIfNotInTest = () =>
-  process.env.IN_TEST === 'true' ? null : <LoadingHeartBeat />;
+  process.env.IN_TEST ? null : <LoadingHeartBeat />;
 
 export default class ConfirmTransactionBase extends Component {
   static contextTypes = {

--- a/ui/pages/confirm-transaction-base/gas-details-item/gas-details-item.js
+++ b/ui/pages/confirm-transaction-base/gas-details-item/gas-details-item.js
@@ -17,8 +17,7 @@ import TransactionDetailItem from '../../../components/app/transaction-detail-it
 import UserPreferencedCurrencyDisplay from '../../../components/app/user-preferenced-currency-display';
 import { useGasFeeContext } from '../../../contexts/gasFee';
 
-const HeartBeat = () =>
-  process.env.IN_TEST === 'true' ? null : <LoadingHeartBeat />;
+const HeartBeat = () => (process.env.IN_TEST ? null : <LoadingHeartBeat />);
 
 const GasDetailsItem = ({
   hexMaximumTransactionFee,

--- a/ui/pages/import-token/import-token.container.js
+++ b/ui/pages/import-token/import-token.container.js
@@ -22,9 +22,7 @@ const mapStateToProps = (state) => {
   const showSearchTabCustomNetwork =
     useTokenDetection && Boolean(Object.keys(tokenList).length);
   const showSearchTab =
-    getIsMainnet(state) ||
-    showSearchTabCustomNetwork ||
-    process.env.IN_TEST === 'true';
+    getIsMainnet(state) || showSearchTabCustomNetwork || process.env.IN_TEST;
   return {
     identities,
     mostRecentOverviewPage: getMostRecentOverviewPage(state),


### PR DESCRIPTION
A propType error was showing up during e2e tests with a `testDev` build. It was caused by `process.env.IN_TEST` being treated as a boolean, when in fact it is either the string `'true'` or a boolean.

`IN_TEST` has been updated to always be a boolean. `loose-envify` has no trouble injecting boolean values, so there's no reason to treat this as a string.

<details>
<summary>Here is the propType error:</summary>

```
[469511:469511:1202/124122.394917:INFO:CONSOLE(14112)] "Warning: Failed prop type: Invalid prop `isMainnet` of type `string` supplied to `ImportTokenLink`, expected `boolean`.       in ImportTokenLink (created by AssetList)                                                                                                                                     
    in AssetList (created by Home)                                                                                                                                                
    in div (created by Tabs)                                                                                                                                                      
    in div (created by Tabs)                                                                                                                                                      
    in Tabs (created by Home)                                                                                                                                                         in div (created by Home)                                                                                                                                                          in div (created by Home)                                                                                                                                                          in div (created by Home)                                                                                                                                                          in Home (created by ConnectFunction)                                                                                                                                              in ConnectFunction (created by Context.Consumer)                                                                                                                                  in withRouter(Connect(Home)) (created by Context.Consumer)                                                                                                                        in Route (created by Authenticated)                                                                                                                                               in Authenticated (created by ConnectFunction)                                                                                                                                 
    in ConnectFunction (created by Routes)                                                                                                                                            in Switch (created by Routes)                                                                                                                                                     in div (created by Routes)                                                                                                                                                        in div (created by Routes)                                                                                                                                                        in Routes (created by ConnectFunction)                                                                                                                                            in ConnectFunction (created by Context.Consumer)                                                                                                                                  in withRouter(Connect(Routes)) (created by Index)                                                                                                                                 in LegacyI18nProvider (created by Index)                                                                                                                                          in I18nProvider (created by Index)                                                                                                                                                in LegacyMetaMetricsProvider (created by Index)                                                                                                                               
    in MetaMetricsProvider (created by Index)                                                                                                                                     
    in LegacyMetaMetricsProvider (created by Index)                                                                                                                               
    in MetaMetricsProvider (created by Index)                                            
    in Router (created by HashRouter)                                                                                                                                             
    in HashRouter (created by Index)                                                                                                                                              
    in Provider (created by Index)                                                       
    in Index", source: chrome-extension://mpogmfdbabklafjoodlkjbmfnnlplald/ui-0.js (14112)
```
</details>

Manual testing steps:  
  - Create a development test build (`yarn build testDev`), and run the signature request e2e test (`yarn test:e2e:single --browser chrome ./test/e2e/tests/signature-request.spec.js`). See that the propType error is not printed to the console.