### PR TITLE
Remove redundant `EIP_1559_V2_ENABLED` comparison

### DIFF
--- a/ui/hooks/gasFeeInput/useGasFeeInputs.js
+++ b/ui/hooks/gasFeeInput/useGasFeeInputs.js
@@ -77,8 +77,8 @@ export function useGasFeeInputs(
   minimumGasLimit = '0x5208',
   editGasMode = EDIT_GAS_MODES.MODIFY_IN_PLACE,
 ) {
-  // eslint-disable-next-line prefer-destructuring
   const EIP_1559_V2_ENABLED =
+    // This is a string in unit tests but is a boolean in the browser
     process.env.EIP_1559_V2 === true || process.env.EIP_1559_V2 === 'true';
 
   const supportsEIP1559 =

--- a/ui/pages/confirm-transaction-base/confirm-transaction-base.component.js
+++ b/ui/pages/confirm-transaction-base/confirm-transaction-base.component.js
@@ -64,8 +64,7 @@ import GasDetailsItem from './gas-details-item';
 import TransactionAlerts from './transaction-alerts';
 
 // eslint-disable-next-line prefer-destructuring
-const EIP_1559_V2_ENABLED =
-  process.env.EIP_1559_V2 === true || process.env.EIP_1559_V2 === 'true';
+const EIP_1559_V2_ENABLED = process.env.EIP_1559_V2;
 
 const renderHeartBeatIfNotInTest = () =>
   process.env.IN_TEST === 'true' ? null : <LoadingHeartBeat />;


### PR DESCRIPTION
A redundant comparison for the `EIP_1559_V2_ENABLED` variable has been removed. This variable is a boolean, so it can be treated as a boolean directly.

One such comparison has been preserved for the purpose of allowing unit testing, because `process.env` entries are always strings in Node.js. A comment was added to explain this.

Manual testing steps:  
  - This should have no functional impact