### PR TITLE
Disable React dev tools in `testDev` builds

### DIFF
--- a/development/build/scripts.js
+++ b/development/build/scripts.js
@@ -366,6 +366,7 @@ function createFactoredBuild({
       minify,
       reloadOnChange,
       shouldLintFenceFiles,
+      testing,
     });
 
     // set bundle entries
@@ -543,6 +544,7 @@ function createNormalBundle({
       minify,
       reloadOnChange,
       shouldLintFenceFiles,
+      testing,
     });
 
     // set bundle entries
@@ -599,6 +601,7 @@ function setupBundlerDefaults(
     minify,
     reloadOnChange,
     shouldLintFenceFiles,
+    testing,
   },
 ) {
   const { bundlerOpts } = buildConfiguration;
@@ -620,7 +623,7 @@ function setupBundlerDefaults(
   });
 
   // Ensure react-devtools are not included in non-dev builds
-  if (!devMode) {
+  if (!devMode || testing) {
     bundlerOpts.manualIgnore.push('react-devtools');
   }
 


### PR DESCRIPTION
The React dev tools can result in console errors if dev tools is not open during the test. Some of our e2e tests fail if there are any console errors, so these errors break those tests.

`react-devtools` has been completely disabled for `testDev` builds to make debugging e2e tests easier. The React dev tools can still be used from development builds.

Manual testing steps:  
  - Create a `testDev` build (`yarn build testDev`)
  - Open the extension build in a browser, and check that there are no Websocket failure console messages from React dev tools
    - The errors are depicted here: https://github.com/facebook/react/issues/20095
  - Ensure that React dev tools still work for development builds