### PR TITLE
Disable `remote-redux-devtools` in non-dev builds

### DIFF
--- a/development/build/scripts.js
+++ b/development/build/scripts.js
@@ -625,6 +625,7 @@ function setupBundlerDefaults(
   // Ensure react-devtools are not included in non-dev builds
   if (!devMode || testing) {
     bundlerOpts.manualIgnore.push('react-devtools');
+    bundlerOpts.manualIgnore.push('remote-redux-devtools');
   }
 
   // Inject environment variables via node-style `process.env`

--- a/ui/store/store.js
+++ b/ui/store/store.js
@@ -4,15 +4,17 @@ import { composeWithDevTools } from 'remote-redux-devtools';
 import rootReducer from '../ducks';
 
 export default function configureStore(initialState) {
-  const composeEnhancers = composeWithDevTools({
-    name: 'MetaMask',
-    hostname: 'localhost',
-    port: 8000,
-    realtime: Boolean(process.env.METAMASK_DEBUG),
-  });
-  return createStore(
-    rootReducer,
-    initialState,
-    composeEnhancers(applyMiddleware(thunkMiddleware)),
-  );
+  let storeEnhancers = applyMiddleware(thunkMiddleware);
+
+  if (process.env.METAMASK_DEBUG && !process.env.IN_TEST) {
+    const composeEnhancers = composeWithDevTools({
+      name: 'MetaMask',
+      hostname: 'localhost',
+      port: 8000,
+      realtime: Boolean(process.env.METAMASK_DEBUG),
+    });
+    storeEnhancers = composeEnhancers(storeEnhancers);
+  }
+
+  return createStore(rootReducer, initialState, storeEnhancers);
 }


### PR DESCRIPTION
`remote-redux-devtools` is now explicitly excluded and disabled in non-dev builds, and in the `testDev` build. This was causing console errors in the `testDev` build during e2e tests, which would cause certain tests to fail.

This was already only supposed to be enabled for development builds, but this library used the `NODE_ENV` environment variable to make that determination. This gives us more control over when it's disabled.

Manual testing steps:  
  - Create a `testDev` build (`yarn build testDev`)
  - Open the extension build in a browser, and check that there are no console errors from the remote Redux dev tools
  - Ensure that the Remote Redux dev tools still work for development builds