### PR TITLE
Updating storybook documentation guidelines

### DIFF
--- a/ui/2.DOCUMENTATION.stories.mdx
+++ b/ui/2.DOCUMENTATION.stories.mdx
@@ -41,8 +41,8 @@ export const DefaultStory = () => <MyComponent />;
 DefaultStory.storyName = 'Default';
 ```
 
-For a more in-depth and higher quality form of story and documentation you can use controls and MDX docs.
-The below example is of the Button component and it explains how we should write our stories.
+For a more in-depth and higher quality form of story and documentation, you can use controls and MDX docs.
+The example below displays the Button component and it explains how we should write our stories:
 
 ```jsx
 // Button component example story

--- a/ui/2.DOCUMENTATION.stories.mdx
+++ b/ui/2.DOCUMENTATION.stories.mdx
@@ -23,7 +23,26 @@ See the [Button](https://metamask.github.io/metamask-storybook/index.html?path=/
 
 ## Creating a Story
 
-[Component Story Format (CSF)](https://storybook.js.org/docs/react/api/csf) is the recommended way to write stories. It's an open standard based on ES6 modules. The below example is of the Button component and it explains how we should write our stories.
+[Component Story Format (CSF)](https://storybook.js.org/docs/react/api/csf) is the recommended way to write stories. It's an open standard based on ES6 modules.
+
+A story can be as simple as:
+
+```jsx
+import React from 'react';
+import MyComponent from '.';
+
+export default {
+  title: 'Components/UI/MyComponent', // title should follow the folder structure location of the component. Don't use spaces.
+  id: __filename,
+};
+
+export const DefaultStory = () => <MyComponent />;
+
+DefaultStory.storyName = 'Default';
+```
+
+For a more in-depth and higher quality form of story and documentation you can use controls and MDX docs.
+The below example is of the Button component and it explains how we should write our stories.
 
 ```jsx
 // Button component example story
@@ -38,12 +57,14 @@ import Button from '.';
 
 // The default storybook component export should always follow the same template
 export default {
-  title: 'Button', // The `title` effects the components tile and location in storybook
+  // The `title` effects the components tile and location in storybook
+  // It should follow the folder structure location of the component. Don't use spaces.
+  title: 'Components/UI/Button',
   id: __filename, // The file name id is used to track what storybook files have changed in CI
   component: Button, // The component you are documenting
   parameters: {
     docs: {
-      page: README, // Reference to the mdx file docs page
+      page: README, // Reference to the docs page MDX file
     },
   },
   // the controls plugin argTypes are used for the interactivity of the component
@@ -148,7 +169,7 @@ Buttons communicate actions that users can take.
 
 ## Component API
 
-<!-- Display the component api using the ArgsTable  -->
+<!-- Display the component api using the ArgsTable. Use JSDoc style comments in the PropTypes of your component to add descriptions for props  -->
 
 <ArgsTable of={Button} />
 


### PR DESCRIPTION
Fixes: #NAN

Explanation: Updating storybook documentation guidelines example to follow naming convention. Also adding simplified story option for easy copy and paste.

Manual testing steps:  
  - Go to latest CI build of storybook or run `yarn storybook`
  - Go to Documentation Guidelines page
  - See updated documentation

**Images**

<img width="1437" alt="Screen Shot 2021-12-02 at 9 57 39 AM" src="https://user-images.githubusercontent.com/8112138/144477727-41048a43-3812-4a37-a689-9dbd86a4eaa2.png">
<img width="722" alt="Screen Shot 2021-12-02 at 9 58 01 AM" src="https://user-images.githubusercontent.com/8112138/144477735-898e9ef3-c4ce-468b-9734-9751d7d9c1e4.png">
