### PR TITLE
Storybook updating styles so they don't override fontawesome

### DIFF
--- a/.storybook/metamask-storybook-theme.js
+++ b/.storybook/metamask-storybook-theme.js
@@ -7,4 +7,8 @@ export default create({
   base: 'light',
   brandTitle: 'MetaMask Storybook',
   brandImage: logo,
+
+  // Typography
+  fontBase: 'Euclid, Roboto, Helvetica, Arial, sans-serif',
+  fontCode: 'Inconsolata, monospace',
 });

--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -7,50 +7,21 @@
 
 <style>
   * {
-    --blue-500: #037dd6;
-    --blue-400: #1098fc;
     --gray-pre-bg: #f8f8f8;
-    --font-family-base: Euclid, Roboto, Helvetica, Arial, sans-serif;
     --font-family-monospace: Inconsolata, monospace;
     --font-size-code: 0.875rem;
-    --line-height-code: 19px;
-    --font-size-base: 1rem;
-    --line-height-base: 1.7;
-
-    font-family: var(--font-family-base) !important;
-  }
-
-  h1,
-  h2 {
-    font-weight: bold !important;
-  }
-
-  p,
-  li {
-    font-size: var(--font-size-base) !important;
-    line-height: var(--line-height-base) !important;
   }
 
   .docblock-source {
     background: var(--gray-pre-bg) !important;
   }
 
-  code {
+  .docblock-source code {
     font-family: var(--font-family-monospace) !important;
     font-size: var(--font-size-code) !important;
   }
-  code * {
+  .docblock-source code * {
     font-family: var(--font-family-monospace) !important;
     font-size: var(--font-size-code) !important;
-  }
-
-  a {
-    color: var(--blue-500) !important;
-  }
-
-  a:hover,
-  a:active,
-  a:focus {
-    color: var(--blue-400) !important;
   }
 </style>

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,7 +1,6 @@
 import React, { useEffect } from 'react';
 import { addDecorator, addParameters } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
-import { withKnobs } from '@storybook/addon-knobs';
 import { Provider } from 'react-redux';
 import configureStore from '../ui/store/store';
 import '../ui/css/index.scss';
@@ -13,6 +12,7 @@ import testData from './test-data.js';
 import { Router } from 'react-router-dom';
 import { createBrowserHistory } from 'history';
 import { _setBackgroundConnection } from '../ui/store/actions';
+import MetaMaskStorybookTheme from './metamask-storybook-theme';
 
 addParameters({
   backgrounds: {
@@ -21,6 +21,9 @@ addParameters({
       { name: 'light', value: '#FFFFFF' },
       { name: 'dark', value: '#333333' },
     ],
+  },
+  docs: {
+    theme: MetaMaskStorybookTheme,
   },
   options: {
     storySort: {
@@ -82,5 +85,4 @@ const metamaskDecorator = (story, context) => {
   );
 };
 
-addDecorator(withKnobs);
 addDecorator(metamaskDecorator);


### PR DESCRIPTION
Explanation: Previous storybook styles pr overrides fontawesome fonts so this reverts those changes and uses storybook theme api

Manual testing steps:  
  -  Run `yarn storybook`
  -  See documentation guidelines brand fonts still work and code still formatted
  - Go to component that uses fontawesome e.g. "PermissionsConnect" see fontawesome icons work

**Images**

*Fontawesome icons work*
<img width="1439" alt="Screen Shot 2021-12-03 at 12 49 12 PM" src="https://user-images.githubusercontent.com/8112138/144671379-9851edcc-997e-4460-a24c-ddc3ee893b33.png">

*Also removing duplicate knobs warning from console*
<img width="1435" alt="Screen Shot 2021-12-03 at 12 53 31 PM" src="https://user-images.githubusercontent.com/8112138/144671483-c9e0f963-22dc-4ae2-9cdf-d7275be07ff0.png">

*Docs codeblocks still use the monospace font*
![docs](https://user-images.githubusercontent.com/8112138/144671853-6100e346-7342-4f75-b57a-512a5cc6482a.png)
