### PR TITLE
Fix: update URL for adding custom build on Firefox

### DIFF
--- a/docs/add-to-firefox.md
+++ b/docs/add-to-firefox.md
@@ -1,6 +1,6 @@
 # Add Custom Build to Firefox
 
-Go to the url `about:debugging`.
+Go to the url `about:debugging#addons`.
 
 Click the button `Load Temporary Add-On`.
 


### PR DESCRIPTION
Fixes: N/A

Explanation:  the URL indicated on the docs, for loading the custom build to Firefox is deprecated, as it redirects to 
`about:debugging#/setup`. Therefore I cannot continue with the next step.

![image](https://user-images.githubusercontent.com/54408225/144704802-2de456f7-5619-45a1-9fae-1e74fabba950.png)

The fix updates the URL to the correct path `about:debugging#addons`, which redirects me to the correct place and from there I can continue with the documentation instructions of "Loading a Temporary Add-on".

![image](https://user-images.githubusercontent.com/54408225/144704832-59a6a348-bc33-419d-b35f-561f342fe2fd.png)

Manual testing steps:  
  - N/A