### PR TITLE
update order of accounts list

### DIFF
--- a/ui/pages/send/send-content/add-recipient/add-recipient.container.js
+++ b/ui/pages/send/send-content/add-recipient/add-recipient.container.js
@@ -34,9 +34,7 @@ function mapStateToProps(state) {
 
   const addressBook = getAddressBook(state);
 
-  const ownedAccounts = accountsWithSendEtherInfoSelector(state).sort((a, b) =>
-    a.name.localeCompare(b.name),
-  );
+  const ownedAccounts = accountsWithSendEtherInfoSelector(state);
 
   return {
     addressBook,


### PR DESCRIPTION
Fixes: #12960 

Explanation:  I removed some of the array sort code so that the accounts come out in order. Dowe need a sort code?

`
  const ownedAccounts = accountsWithSendEtherInfoSelector(state).sort((a, b) =>
    a.name.localeCompare(b.name),
  );
`
