### PR TITLE
Clear the clipboard after seed phrase is pasted (Restore vault)

### DIFF
--- a/ui/pages/keychains/restore-vault.js
+++ b/ui/pages/keychains/restore-vault.js
@@ -10,6 +10,7 @@ import {
 import { DEFAULT_ROUTE } from '../../helpers/constants/routes';
 import TextField from '../../components/ui/text-field';
 import Button from '../../components/ui/button';
+import { clearClipboard } from '../../helpers/utils/util';
 
 const { isValidMnemonic } = ethers.utils;
 
@@ -173,6 +174,7 @@ class RestoreVaultPage extends Component {
               {showSeedPhrase ? (
                 <textarea
                   className="import-account__secret-phrase"
+                  onPaste={clearClipboard}
                   onChange={(e) => this.handleSeedPhraseChange(e.target.value)}
                   value={seedPhrase}
                   autoFocus
@@ -182,6 +184,7 @@ class RestoreVaultPage extends Component {
                 <TextField
                   className="import-account__textarea import-account__seedphrase"
                   type="password"
+                  onPaste={clearClipboard}
                   onChange={(e) => this.handleSeedPhraseChange(e.target.value)}
                   value={seedPhrase}
                   autoFocus


### PR DESCRIPTION
Follow up to: https://github.com/MetaMask/metamask-extension/pull/12828

Testing steps:
1. Lock wallet
2. Click import using secret recovery phrase
3. Paste seed phrase in input

Expected:
Clipboard is cleared, similar to onboarding/first time flow
