### PR TITLE
Make restore vault a form so an user can submit via keyboard

### DIFF
--- a/test/e2e/tests/metamask-responsive-ui.spec.js
+++ b/test/e2e/tests/metamask-responsive-ui.spec.js
@@ -178,10 +178,7 @@ describe('Metamask Responsive UI', function () {
 
         await driver.fill('#password', 'correct horse battery staple');
         await driver.fill('#confirm-password', 'correct horse battery staple');
-        await driver.clickElement({
-          text: enLocaleMessages.restore.message,
-          tag: 'button',
-        });
+        await driver.press('#confirm-password', driver.Key.ENTER);
 
         // balance renders
         await driver.waitForSelector({

--- a/ui/pages/keychains/restore-vault.js
+++ b/ui/pages/keychains/restore-vault.js
@@ -85,7 +85,8 @@ class RestoreVaultPage extends Component {
     this.setState({ confirmPassword, confirmPasswordError });
   }
 
-  handleImport = () => {
+  handleImport = (event) => {
+    event.preventDefault();
     const { password, seedPhrase, disabled } = this.state;
     if (disabled) return;
     const {

--- a/ui/pages/keychains/restore-vault.js
+++ b/ui/pages/keychains/restore-vault.js
@@ -85,8 +85,9 @@ class RestoreVaultPage extends Component {
     this.setState({ confirmPassword, confirmPasswordError });
   }
 
-  onClick = () => {
-    const { password, seedPhrase } = this.state;
+  handleImport = () => {
+    const { password, seedPhrase, disabled } = this.state;
+    if (disabled) return;
     const {
       // eslint-disable-next-line no-shadow
       createNewVaultAndRestore,
@@ -166,7 +167,10 @@ class RestoreVaultPage extends Component {
             <div className="import-account__selector-typography">
               {this.context.t('secretPhraseWarning')}
             </div>
-            <div className="import-account__input-wrapper">
+            <form
+              className="import-account__input-wrapper"
+              onSubmit={this.handleImport}
+            >
               <label className="import-account__input-label">
                 {this.context.t('walletSeedRestore')}
               </label>
@@ -212,43 +216,43 @@ class RestoreVaultPage extends Component {
                   {t('showSeedPhrase')}
                 </label>
               </div>
-            </div>
-            <TextField
-              id="password"
-              label={t('newPassword')}
-              type="password"
-              className="first-time-flow__input"
-              value={this.state.password}
-              onChange={(event) =>
-                this.handlePasswordChange(event.target.value)
-              }
-              error={passwordError}
-              autoComplete="new-password"
-              margin="normal"
-              largeLabel
-            />
-            <TextField
-              id="confirm-password"
-              label={t('confirmPassword')}
-              type="password"
-              className="first-time-flow__input"
-              value={this.state.confirmPassword}
-              onChange={(event) =>
-                this.handleConfirmPasswordChange(event.target.value)
-              }
-              error={confirmPasswordError}
-              autoComplete="confirm-password"
-              margin="normal"
-              largeLabel
-            />
-            <Button
-              type="primary"
-              className="first-time-flow__button"
-              onClick={() => !disabled && this.onClick()}
-              disabled={disabled}
-            >
-              {this.context.t('restore')}
-            </Button>
+              <TextField
+                id="password"
+                label={t('newPassword')}
+                type="password"
+                className="first-time-flow__input"
+                value={this.state.password}
+                onChange={(event) =>
+                  this.handlePasswordChange(event.target.value)
+                }
+                error={passwordError}
+                autoComplete="new-password"
+                margin="normal"
+                largeLabel
+              />
+              <TextField
+                id="confirm-password"
+                label={t('confirmPassword')}
+                type="password"
+                className="first-time-flow__input"
+                value={this.state.confirmPassword}
+                onChange={(event) =>
+                  this.handleConfirmPasswordChange(event.target.value)
+                }
+                error={confirmPasswordError}
+                autoComplete="confirm-password"
+                margin="normal"
+                largeLabel
+              />
+              <Button
+                type="primary"
+                submit
+                className="first-time-flow__button"
+                disabled={disabled}
+              >
+                {this.context.t('restore')}
+              </Button>
+            </form>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Similar to "import-with-seed-phrase" I would like to be able to restore my vault by pressing `<enter>` on my keyboard.

Explanation: I noticed the other day that you can't restore from vault using keyboard. We do something similar in `import-with-seed-phrase.component.js`. this should be made keyboard accessible as well.

Manual testing steps:  
  - try to restore vault by filling in seedphrase + passwords.
  - when clicking enter nothing happens