### PR TITLE
GridPlus: `eth-lattice-keyring` `0.4.0` -> `0.4.2`

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -11347,9 +11347,9 @@ eth-keyring-controller@^6.1.0, eth-keyring-controller@^6.2.0, eth-keyring-contro
     obs-store "^4.0.3"
 
 eth-lattice-keyring@^0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/eth-lattice-keyring/-/eth-lattice-keyring-0.4.0.tgz#0afab94fe1c9b13377e1c78660a725c9bc0639a0"
-  integrity sha512-AB+FzgnyqapcZmdLeVMUDGZqA09yRQZxoVm/qZaT3kb5e4jhWon4BGRo/g65JuNagC8SltIQY6fpDh/q5gXNTQ==
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/eth-lattice-keyring/-/eth-lattice-keyring-0.4.2.tgz#38c9f7170aca3b35b7923fa9d17f3dbf46985fd4"
+  integrity sha512-h93tgOUJv9P9o83uNcALJsy1MBrirSNAxZY602TxDt1ozDCa56KpiEhTRmRcMlkDRMHjXK9nBbpg9ipc4U/esA==
   dependencies:
     "@ethereumjs/common" "^2.4.0"
     "@ethereumjs/tx" "^3.1.1"


### PR DESCRIPTION
Small changes to the GridPlus Lattice Keyring module:
* https://github.com/GridPlus/eth-lattice-keyring/pull/22
* https://github.com/GridPlus/eth-lattice-keyring/pull/23