### PR TITLE
Capitalize Activity log

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -86,7 +86,7 @@
     "message": "Activity"
   },
   "activityLog": {
-    "message": "Activity Log"
+    "message": "Activity log"
   },
   "add": {
     "message": "Add"

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -86,7 +86,7 @@
     "message": "Activity"
   },
   "activityLog": {
-    "message": "activity log"
+    "message": "Activity Log"
   },
   "add": {
     "message": "Add"


### PR DESCRIPTION
Explanation:  Capitalizes Activity Log locale string
 
Before
<img width="259" alt="image" src="https://user-images.githubusercontent.com/13376180/145057414-0341f517-0d4d-4793-b759-995dcb56cade.png">

After
<img width="259" alt="image" src="https://user-images.githubusercontent.com/13376180/145056722-8a223b46-f367-486e-b596-72a7bb08b33a.png">
