### PR TITLE
Fix tx-insight accreditation styling

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -3100,7 +3100,7 @@
     "message": "Decoded by Truffle"
   },
   "transactionDecodingAccreditationVerified": {
-    "message": "Verified contract on"
+    "message": "Verified contract on $1"
   },
   "transactionDecodingUnsupportedNetworkError": {
     "message": "Transaction decoding is not available for chainId $1"

--- a/ui/components/app/transaction-decoding/components/ui/accreditation/accreditation.component.js
+++ b/ui/components/app/transaction-decoding/components/ui/accreditation/accreditation.component.js
@@ -27,22 +27,24 @@ const Accreditation = ({ fetchVia, address }) => {
           className="accreditation__prefix"
           boxProps={{ margin: 0 }}
         >
-          {t('transactionDecodingAccreditationVerified')}
+          {t('transactionDecodingAccreditationVerified', [
+            <Button
+              type="link"
+              className="accreditation__link"
+              onClick={() => {
+                global.platform.openTab({
+                  url: addressLink,
+                });
+              }}
+              target="_blank"
+              rel="noopener noreferrer"
+              title={t('etherscanView')}
+              key="accreditation-link-button"
+            >
+              {fetchVia}
+            </Button>,
+          ])}
         </Typography>
-        <Button
-          type="link"
-          className="accreditation__link"
-          onClick={() => {
-            global.platform.openTab({
-              url: addressLink,
-            });
-          }}
-          target="_blank"
-          rel="noopener noreferrer"
-          title={t('etherscanView')}
-        >
-          {fetchVia}
-        </Button>
         <Typography variant={TYPOGRAPHY.H7} boxProps={{ margin: 0 }}>
           {t('transactionDecodingAccreditationDecoded')}
         </Typography>

--- a/ui/components/app/transaction-decoding/components/ui/accreditation/accreditation.component.js
+++ b/ui/components/app/transaction-decoding/components/ui/accreditation/accreditation.component.js
@@ -19,7 +19,7 @@ const Accreditation = ({ fetchVia, address }) => {
   const rpcPrefs = useSelector(getRpcPrefsForCurrentProvider);
   const addressLink = getAccountLink(address, chainId, rpcPrefs);
 
-  const AccreditationLink = () => {
+  const EtherscanNotice = () => {
     return (
       <>
         <Typography
@@ -41,13 +41,35 @@ const Accreditation = ({ fetchVia, address }) => {
           rel="noopener noreferrer"
           title={t('etherscanView')}
         >
-          {fetchVia}
+          Etherscan
         </Button>
-        <Typography variant={TYPOGRAPHY.H7} boxProps={{ margin: 0 }}>
-          {t('transactionDecodingAccreditationDecoded')}
-        </Typography>
       </>
     );
+  };
+
+  const TruffleNotice = () => {
+    return (
+      <Typography variant={TYPOGRAPHY.H7} boxProps={{ margin: 0 }}>
+        {t('transactionDecodingAccreditationDecoded')}
+      </Typography>
+    );
+  };
+
+  const AccreditationLink = () => {
+    switch (fetchVia) {
+      case 'etherscan': {
+        return (
+          <>
+            <EtherscanNotice />
+            <br />
+            <TruffleNotice />
+          </>
+        );
+      }
+      default: {
+        return <TruffleNotice />;
+      }
+    }
   };
 
   return (

--- a/ui/components/app/transaction-decoding/components/ui/accreditation/accreditation.component.js
+++ b/ui/components/app/transaction-decoding/components/ui/accreditation/accreditation.component.js
@@ -19,7 +19,7 @@ const Accreditation = ({ fetchVia, address }) => {
   const rpcPrefs = useSelector(getRpcPrefsForCurrentProvider);
   const addressLink = getAccountLink(address, chainId, rpcPrefs);
 
-  const EtherscanNotice = () => {
+  const AccreditationLink = () => {
     return (
       <>
         <Typography
@@ -41,35 +41,13 @@ const Accreditation = ({ fetchVia, address }) => {
           rel="noopener noreferrer"
           title={t('etherscanView')}
         >
-          Etherscan
+          {fetchVia}
         </Button>
+        <Typography variant={TYPOGRAPHY.H7} boxProps={{ margin: 0 }}>
+          {t('transactionDecodingAccreditationDecoded')}
+        </Typography>
       </>
     );
-  };
-
-  const TruffleNotice = () => {
-    return (
-      <Typography variant={TYPOGRAPHY.H7} boxProps={{ margin: 0 }}>
-        {t('transactionDecodingAccreditationDecoded')}
-      </Typography>
-    );
-  };
-
-  const AccreditationLink = () => {
-    switch (fetchVia) {
-      case 'etherscan': {
-        return (
-          <>
-            <EtherscanNotice />
-            <br />
-            <TruffleNotice />
-          </>
-        );
-      }
-      default: {
-        return <TruffleNotice />;
-      }
-    }
   };
 
   return (

--- a/ui/components/app/transaction-decoding/components/ui/accreditation/index.scss
+++ b/ui/components/app/transaction-decoding/components/ui/accreditation/index.scss
@@ -10,14 +10,15 @@
   &__info {
     color: $ui-black;
     display: flex;
+    flex-flow: column;
     flex-wrap: wrap;
   }
 
   &__link.btn-link {
     @include H7;
 
+    display: inherit;
     padding: 0 4px;
-    width: auto;
   }
 }
 


### PR DESCRIPTION
## Explanation:  

Following on from #12918, this PR addresses a few style problems:

- Ensure "Etherscan" appears capitalized
- Ensure messages are separated by newline
- Handle case where server returns `fetchedVia` that frontend doesn't support

<details>
<summary>(See current appearance from the recent <code>develop</code> build)</summary>
<img width="472" alt="Screen Shot 2021-12-07 at 3 23 33 PM" src="https://user-images.githubusercontent.com/151065/145103074-68c5682a-af28-4f01-9730-a6b844080b33.png">
</details>


## Manual testing steps:  
  - Follow testing instructions in https://github.com/MetaMask/metamask-extension/pull/12881
  - Observe that both messages appear at bottom on separate lines
  - Observe that "Etherscan" is capitalized