### PR TITLE
Identicon size fix

### DIFF
--- a/ui/components/ui/identicon/identicon.component.js
+++ b/ui/components/ui/identicon/identicon.component.js
@@ -144,8 +144,8 @@ export default class Identicon extends PureComponent {
 
       return (
         <div
-          className={classnames({ 'identicon__address-wrapper': addBorder })}
-          style={getStyles(size)}
+          className={addBorder ? 'identicon__address-wrapper' : null}
+          style={addBorder ? getStyles(size) : null}
         >
           {useBlockie ? this.renderBlockie() : this.renderJazzicon()}
         </div>

--- a/ui/components/ui/identicon/identicon.component.js
+++ b/ui/components/ui/identicon/identicon.component.js
@@ -144,7 +144,7 @@ export default class Identicon extends PureComponent {
 
       return (
         <div
-          className={addBorder ? 'identicon__address-wrapper' : null}
+          className={classnames({ 'identicon__address-wrapper': addBorder })}
           style={addBorder ? getStyles(size) : null}
         >
           {useBlockie ? this.renderBlockie() : this.renderJazzicon()}


### PR DESCRIPTION
Explanation: Fixes previously merged PR that's intention was to make the `addBorder` option dynamic to the size of the Identicon but it was being added regardless. Making the Identicon an incorrect size.

Manual testing steps:  
  -  Go latest storybook CI build 
  -  Search "Identicon"
  -  Inspect Default or Blockie version with dev tools
  - See that there are no inline styles

**Images**

Before
<img width="917" alt="Screen Shot 2021-12-08 at 6 34 28 PM" src="https://user-images.githubusercontent.com/8112138/145154078-3fdabaaa-f6ec-413f-a664-cb17d4610b7e.png">

After
<img width="926" alt="Screen Shot 2021-12-08 at 6 33 34 PM" src="https://user-images.githubusercontent.com/8112138/145154110-15d59985-dfd0-4d7e-b74f-f71d36a8da96.png">

