### PR TITLE
Adjust the padding of lock button

### DIFF
--- a/ui/components/app/account-menu/index.scss
+++ b/ui/components/app/account-menu/index.scss
@@ -103,7 +103,7 @@
     border: 1px solid $ui-white;
     background-color: transparent;
     color: $white;
-    padding: 3.5px 24px;
+    padding: 3.5px 5px;
     width: 59px;
   }
 


### PR DESCRIPTION
The padding of lock button is too big，causes the text of lock button to be displayed as multiple lines，especially in Chinese and Japanese. Although it only optimizes the details, but it does improve the beauty of the page. Please support, thanks.

before fixed：
![beforefixed](https://user-images.githubusercontent.com/28339041/145213968-7666b624-4849-4382-969c-f5abf9fc1292.png)
![beforefixed2](https://user-images.githubusercontent.com/28339041/145213986-9f041b2c-609c-45ff-b56b-057bf06f1d90.png)
after fixed：
![afterfixed](https://user-images.githubusercontent.com/28339041/145214024-2f14c82a-f3f8-48ba-846f-13345bbcc6b4.png)
