### PR TITLE
Dispose the trezor connect iframe upon lock

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -3519,7 +3519,7 @@ export default class MetamaskController extends EventEmitter {
    */
   setLocked() {
     const [trezorKeyring] = this.keyringController.getKeyringsByType(
-      'Trezor Hardware',
+      KEYRING_TYPES.TREZOR,
     );
     if (trezorKeyring) {
       trezorKeyring.dispose();

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -3518,6 +3518,12 @@ export default class MetamaskController extends EventEmitter {
    * Locks MetaMask
    */
   setLocked() {
+    const [trezorKeyring] = this.keyringController.getKeyringsByType(
+      'Trezor Hardware',
+    );
+    if (trezorKeyring) {
+      trezorKeyring.dispose();
+    }
     return this.keyringController.setLocked();
   }
 }

--- a/package.json
+++ b/package.json
@@ -149,7 +149,7 @@
     "eth-query": "^2.1.2",
     "eth-rpc-errors": "^4.0.2",
     "eth-sig-util": "^3.0.0",
-    "eth-trezor-keyring": "^0.8.0",
+    "eth-trezor-keyring": "^0.9.0",
     "ethereum-ens-network-map": "^1.0.2",
     "ethereumjs-abi": "^0.6.4",
     "ethereumjs-util": "^7.0.10",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11509,10 +11509,10 @@ eth-simple-keyring@^4.2.0:
     ethereumjs-wallet "^1.0.1"
     events "^1.1.1"
 
-eth-trezor-keyring@^0.8.0:
-  version "0.8.0"
-  resolved "https://registry.yarnpkg.com/eth-trezor-keyring/-/eth-trezor-keyring-0.8.0.tgz#e0a40ab24954ba637946ce3848b15df6dd7a8bde"
-  integrity sha512-++u/9/OkQ+NkFcGDwhabpJkcYlCWQYcVLejWvDoKCNHNSjBUxa99tI9kg2wdf/ZoFKMOekbK6/WYlXJYCHMnrQ==
+eth-trezor-keyring@^0.9.0:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/eth-trezor-keyring/-/eth-trezor-keyring-0.9.0.tgz#06b0f2f4c072651c0944a0dfbfa7b2b0c9987433"
+  integrity sha512-Rg9XUiYIOs7Ulz0ODc/udouM7276fCQhTnYhJC9OJTWrz6U5tAkdqnmTsZNMS2sdMWzuFhGz0+pQz9yTIryGQA==
   dependencies:
     "@ethereumjs/tx" "^3.2.1"
     ethereumjs-util "^7.0.9"


### PR DESCRIPTION
Blocked by merge and release of https://github.com/MetaMask/eth-trezor-keyring/pull/113

This PR addresses an error that would occur if MetaMask is locked and then unlocked, when a Trezor account has been added.

While the error was obscured by an issue with Lavamoat, we were able to determine that it was an error being thrown from within TrezorConnect: `TypeError: Cannot add property default, object is not extensible`

This error is thrown when trying to call `TrezorConnect.init` (within the trezor keyring constructor) if the Trezor iframe already exists. We instantiate a new Trezor keyring whenever we unlock, so if a user was to lock and unlock without closing the browser, this issue could happen.

The `TrezorConnect.dispose` method removes the iframe from the dom. That method is exposed on the keyring in the PR linked above.

This PR makes it so that we call that method upon locking MetaMask.