### PR TITLE
Remove unnecessary action text property from whats new notification 9

### DIFF
--- a/shared/notifications/index.js
+++ b/shared/notifications/index.js
@@ -131,7 +131,6 @@ export const getTranslatedUINoficiations = (t, locale) => {
       date: new Intl.DateTimeFormat(formattedLocale).format(
         new Date(UI_NOTIFICATIONS[9].date),
       ),
-      actionText: t('notifications9ActionText'),
     },
   };
 };


### PR DESCRIPTION
This removes unused code.