### PR TITLE
Support EIP-1559 on Trezor Model One

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -2519,20 +2519,9 @@ export default class MetamaskController extends EventEmitter {
   }
 
   /**
-   * Method to return a boolean if the keyring for the currently selected
-   * account is a ledger or trezor keyring.
-   * TODO: remove this method when Ledger and Trezor release their supported
-   * client utilities for EIP-1559
    * @returns {boolean} true if the keyring type supports EIP-1559
    */
-  async getCurrentAccountEIP1559Compatibility(fromAddress) {
-    const address =
-      fromAddress || this.preferencesController.getSelectedAddress();
-    const keyring = await this.keyringController.getKeyringForAccount(address);
-    if (keyring.type === KEYRING_TYPES.TREZOR) {
-      const model = keyring.getModel();
-      return model === 'T';
-    }
+  async getCurrentAccountEIP1559Compatibility() {
     return true;
   }
 

--- a/lavamoat/browserify/beta/policy.json
+++ b/lavamoat/browserify/beta/policy.json
@@ -679,21 +679,8 @@
         "events": true
       }
     },
-    "@ngraveio/bc-ur": {
-      "packages": {
-        "@apocentre/alias-sampling": true,
-        "assert": true,
-        "bignumber.js": true,
-        "buffer": true,
-        "cbor-sync": true,
-        "crc": true,
-        "jsbi": true,
-        "sha.js": true
-      }
-    },
     "@metamask/snap-controllers": {
       "globals": {
-        "URL": true,
         "Worker": true,
         "clearTimeout": true,
         "console.error": true,
@@ -717,6 +704,18 @@
         "json-rpc-middleware-stream": true,
         "nanoid": true,
         "pump": true
+      }
+    },
+    "@ngraveio/bc-ur": {
+      "packages": {
+        "@apocentre/alias-sampling": true,
+        "assert": true,
+        "bignumber.js": true,
+        "buffer": true,
+        "cbor-sync": true,
+        "crc": true,
+        "jsbi": true,
+        "sha.js": true
       }
     },
     "@popperjs/core": {
@@ -836,6 +835,66 @@
       "packages": {
         "is-buffer": true,
         "util": true
+      }
+    },
+    "@truffle/abi-utils": {
+      "packages": {
+        "change-case": true,
+        "faker": true,
+        "fast-check": true
+      }
+    },
+    "@truffle/code-utils": {
+      "packages": {
+        "buffer": true,
+        "cbor": true
+      }
+    },
+    "@truffle/codec": {
+      "packages": {
+        "@truffle/abi-utils": true,
+        "@truffle/compile-common": true,
+        "big.js": true,
+        "bn.js": true,
+        "buffer": true,
+        "cbor": true,
+        "debug": true,
+        "lodash.clonedeep": true,
+        "lodash.escaperegexp": true,
+        "lodash.partition": true,
+        "lodash.sum": true,
+        "semver": true,
+        "utf8": true,
+        "util": true,
+        "web3-utils": true
+      }
+    },
+    "@truffle/compile-common": {
+      "packages": {
+        "@truffle/error": true,
+        "colors": true,
+        "path-browserify": true
+      }
+    },
+    "@truffle/decoder": {
+      "packages": {
+        "@truffle/abi-utils": true,
+        "@truffle/codec": true,
+        "@truffle/compile-common": true,
+        "@truffle/source-map-utils": true,
+        "bn.js": true,
+        "debug": true,
+        "web3-utils": true
+      }
+    },
+    "@truffle/source-map-utils": {
+      "packages": {
+        "@truffle/code-utils": true,
+        "@truffle/codec": true,
+        "debug": true,
+        "json-pointer": true,
+        "node-interval-tree": true,
+        "web3-utils": true
       }
     },
     "@zxing/browser": {
@@ -1040,6 +1099,11 @@
         "buffer": true
       }
     },
+    "big.js": {
+      "globals": {
+        "define": true
+      }
+    },
     "bignumber.js": {
       "globals": {
         "crypto": true,
@@ -1225,12 +1289,54 @@
         "get-intrinsic": true
       }
     },
+    "camel-case": {
+      "packages": {
+        "no-case": true,
+        "upper-case": true
+      }
+    },
+    "cbor": {
+      "globals": {
+        "TextDecoder": true
+      },
+      "packages": {
+        "bignumber.js": true,
+        "buffer": true,
+        "is-buffer": true,
+        "nofilter": true,
+        "stream-browserify": true,
+        "url": true,
+        "util": true
+      }
+    },
     "cbor-sync": {
       "globals": {
         "define": true
       },
       "packages": {
         "buffer": true
+      }
+    },
+    "change-case": {
+      "packages": {
+        "camel-case": true,
+        "constant-case": true,
+        "dot-case": true,
+        "header-case": true,
+        "is-lower-case": true,
+        "is-upper-case": true,
+        "lower-case": true,
+        "lower-case-first": true,
+        "no-case": true,
+        "param-case": true,
+        "pascal-case": true,
+        "path-case": true,
+        "sentence-case": true,
+        "snake-case": true,
+        "swap-case": true,
+        "title-case": true,
+        "upper-case": true,
+        "upper-case-first": true
       }
     },
     "cids": {
@@ -1285,6 +1391,22 @@
     "color-string": {
       "packages": {
         "color-name": true
+      }
+    },
+    "colors": {
+      "globals": {
+        "console.log": true
+      },
+      "packages": {
+        "os-browserify": true,
+        "process": true,
+        "util": true
+      }
+    },
+    "constant-case": {
+      "packages": {
+        "snake-case": true,
+        "upper-case": true
       }
     },
     "cookiejar": {
@@ -1546,6 +1668,11 @@
         "@babel/runtime": true
       }
     },
+    "dot-case": {
+      "packages": {
+        "no-case": true
+      }
+    },
     "drbg.js": {
       "packages": {
         "buffer": true,
@@ -1796,6 +1923,11 @@
         "trezor-connect": true
       }
     },
+    "ethereum-bloom-filters": {
+      "packages": {
+        "js-sha3": true
+      }
+    },
     "ethereum-cryptography": {
       "packages": {
         "assert": true,
@@ -2013,6 +2145,24 @@
         "chrome": true
       }
     },
+    "faker": {
+      "globals": {
+        "console.error": true,
+        "console.log": true,
+        "dbg": "write"
+      }
+    },
+    "fast-check": {
+      "globals": {
+        "clearTimeout": true,
+        "console.log": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "buffer": true,
+        "pure-rand": true
+      }
+    },
     "fast-json-patch": {
       "globals": {
         "addEventListener": true,
@@ -2070,11 +2220,6 @@
         "function-bind": true,
         "has": true,
         "has-symbols": true
-      }
-    },
-    "get-params": {
-      "globals": {
-        "GetParams": "write"
       }
     },
     "graphql-request": {
@@ -2155,6 +2300,12 @@
         "crypto-browserify": true,
         "safe-buffer": true,
         "secp256k1": true
+      }
+    },
+    "header-case": {
+      "packages": {
+        "no-case": true,
+        "upper-case": true
       }
     },
     "heap": {
@@ -2640,10 +2791,20 @@
         "multihashes": true
       }
     },
+    "is-lower-case": {
+      "packages": {
+        "lower-case": true
+      }
+    },
     "is-regex": {
       "packages": {
         "call-bind": true,
         "has-symbols": true
+      }
+    },
+    "is-upper-case": {
+      "packages": {
+        "upper-case": true
       }
     },
     "iso-random-stream": {
@@ -2699,14 +2860,14 @@
         "process": true
       }
     },
-    "jsan": {
-      "globals": {
-        "console.warn": true
-      }
-    },
     "jsbi": {
       "globals": {
         "define": true
+      }
+    },
+    "json-pointer": {
+      "packages": {
+        "foreach": true
       }
     },
     "json-rpc-engine": {
@@ -2800,6 +2961,7 @@
       "packages": {
         "buffer": true,
         "inherits": true,
+        "readable-stream": true,
         "safe-buffer": true,
         "stream-browserify": true
       }
@@ -3254,10 +3416,20 @@
         "util": true
       }
     },
+    "lower-case-first": {
+      "packages": {
+        "lower-case": true
+      }
+    },
     "lru": {
       "packages": {
         "events": true,
         "inherits": true
+      }
+    },
+    "lru-cache": {
+      "packages": {
+        "yallist": true
       }
     },
     "ltgt": {
@@ -3423,10 +3595,11 @@
         "crypto": true,
         "msCrypto": true,
         "navigator": true
-      },
+      }
+    },
+    "no-case": {
       "packages": {
-        "buffer": true,
-        "crypto-browserify": true
+        "lower-case": true
       }
     },
     "node-forge": {
@@ -3453,6 +3626,11 @@
         "timers-browserify": true
       }
     },
+    "node-interval-tree": {
+      "packages": {
+        "shallowequal": true
+      }
+    },
     "nodeify": {
       "globals": {
         "setTimeout": true
@@ -3462,6 +3640,13 @@
         "process": true,
         "promise": true,
         "timers-browserify": true
+      }
+    },
+    "nofilter": {
+      "packages": {
+        "buffer": true,
+        "stream-browserify": true,
+        "util": true
       }
     },
     "nonce-tracker": {
@@ -3659,6 +3844,11 @@
         "p-map": true
       }
     },
+    "param-case": {
+      "packages": {
+        "no-case": true
+      }
+    },
     "parse-asn1": {
       "packages": {
         "asn1.js": true,
@@ -3668,9 +3858,20 @@
         "pbkdf2": true
       }
     },
+    "pascal-case": {
+      "packages": {
+        "camel-case": true,
+        "upper-case-first": true
+      }
+    },
     "path-browserify": {
       "packages": {
         "process": true
+      }
+    },
+    "path-case": {
+      "packages": {
+        "no-case": true
       }
     },
     "path-to-regexp": {
@@ -4243,35 +4444,6 @@
         "@babel/runtime": true
       }
     },
-    "redux-devtools-core": {
-      "globals": {
-        "ErrorUtils": true,
-        "console": true,
-        "devToolsOptions": true,
-        "onerror": "write",
-        "serializeState": true
-      },
-      "packages": {
-        "get-params": true,
-        "jsan": true,
-        "lodash": true,
-        "nanoid": true,
-        "remotedev-serialize": true
-      }
-    },
-    "redux-devtools-instrument": {
-      "globals": {
-        "chrome": true,
-        "console.error": true,
-        "process": true,
-        "setTimeout": true
-      },
-      "packages": {
-        "lodash": true,
-        "process": true,
-        "symbol-observable": true
-      }
-    },
     "regenerator-runtime": {
       "globals": {
         "regeneratorRuntime": "write"
@@ -4286,21 +4458,6 @@
     "relative-url": {
       "packages": {
         "url": true
-      }
-    },
-    "remote-redux-devtools": {
-      "globals": {
-        "console.log": true,
-        "console.warn": true,
-        "fetch": true,
-        "setTimeout": true
-      },
-      "packages": {
-        "jsan": true,
-        "redux-devtools-core": true,
-        "redux-devtools-instrument": true,
-        "rn-host-detect": true,
-        "socketcluster-client": true
       }
     },
     "retimer": {
@@ -4328,13 +4485,6 @@
         "buffer": true
       }
     },
-    "rn-host-detect": {
-      "globals": {
-        "__DEV__": true,
-        "__fbBatchedBridgeConfig": true,
-        "console": true
-      }
-    },
     "safe-buffer": {
       "packages": {
         "buffer": true
@@ -4352,16 +4502,6 @@
     "sanitize-filename": {
       "packages": {
         "truncate-utf8-bytes": true
-      }
-    },
-    "sc-channel": {
-      "packages": {
-        "component-emitter": true
-      }
-    },
-    "sc-formatter": {
-      "globals": {
-        "Buffer": true
       }
     },
     "scheduler": {
@@ -4416,7 +4556,14 @@
         "console": true
       },
       "packages": {
+        "lru-cache": true,
         "process": true
+      }
+    },
+    "sentence-case": {
+      "packages": {
+        "no-case": true,
+        "upper-case-first": true
       }
     },
     "set-immediate-shim": {
@@ -4463,6 +4610,11 @@
         "readable-stream": true
       }
     },
+    "snake-case": {
+      "packages": {
+        "no-case": true
+      }
+    },
     "socket.io-client": {
       "globals": {
         "clearTimeout": true,
@@ -4505,29 +4657,6 @@
         "data-queue": true,
         "debug": true,
         "pull-stream": true,
-        "uuid": true
-      }
-    },
-    "socketcluster-client": {
-      "globals": {
-        "WebSocket": true,
-        "WorkerGlobalScope": true,
-        "addEventListener": true,
-        "clearTimeout": true,
-        "localStorage": true,
-        "location": true,
-        "removeEventListener": true,
-        "setTimeout": true
-      },
-      "packages": {
-        "buffer": true,
-        "clone": true,
-        "component-emitter": true,
-        "linked-list": true,
-        "querystring-es3": true,
-        "sc-channel": true,
-        "sc-errors": true,
-        "sc-formatter": true,
         "uuid": true
       }
     },
@@ -4613,6 +4742,12 @@
         "component-emitter": true
       }
     },
+    "swap-case": {
+      "packages": {
+        "lower-case": true,
+        "upper-case": true
+      }
+    },
     "textarea-caret": {
       "globals": {
         "document.body.appendChild": true,
@@ -4657,6 +4792,12 @@
     "tiny-warning": {
       "globals": {
         "console": true
+      }
+    },
+    "title-case": {
+      "packages": {
+        "no-case": true,
+        "upper-case": true
       }
     },
     "toggle-selection": {
@@ -4751,6 +4892,11 @@
     "uport-base64url": {
       "packages": {
         "buffer": true
+      }
+    },
+    "upper-case-first": {
+      "packages": {
+        "upper-case": true
       }
     },
     "url": {
@@ -4865,6 +5011,21 @@
         "readable-stream": true,
         "util": true,
         "uuid": true
+      }
+    },
+    "web3-utils": {
+      "globals": {
+        "setTimeout": true
+      },
+      "packages": {
+        "bn.js": true,
+        "eth-lib": true,
+        "ethereum-bloom-filters": true,
+        "ethjs-unit": true,
+        "is-buffer": true,
+        "number-to-bn": true,
+        "randombytes": true,
+        "utf8": true
       }
     },
     "webrtcsupport": {

--- a/lavamoat/browserify/flask/policy.json
+++ b/lavamoat/browserify/flask/policy.json
@@ -679,21 +679,8 @@
         "events": true
       }
     },
-    "@ngraveio/bc-ur": {
-      "packages": {
-        "@apocentre/alias-sampling": true,
-        "assert": true,
-        "bignumber.js": true,
-        "buffer": true,
-        "cbor-sync": true,
-        "crc": true,
-        "jsbi": true,
-        "sha.js": true
-      }
-    },
     "@metamask/snap-controllers": {
       "globals": {
-        "URL": true,
         "Worker": true,
         "clearTimeout": true,
         "console.error": true,
@@ -717,6 +704,18 @@
         "json-rpc-middleware-stream": true,
         "nanoid": true,
         "pump": true
+      }
+    },
+    "@ngraveio/bc-ur": {
+      "packages": {
+        "@apocentre/alias-sampling": true,
+        "assert": true,
+        "bignumber.js": true,
+        "buffer": true,
+        "cbor-sync": true,
+        "crc": true,
+        "jsbi": true,
+        "sha.js": true
       }
     },
     "@popperjs/core": {
@@ -836,6 +835,66 @@
       "packages": {
         "is-buffer": true,
         "util": true
+      }
+    },
+    "@truffle/abi-utils": {
+      "packages": {
+        "change-case": true,
+        "faker": true,
+        "fast-check": true
+      }
+    },
+    "@truffle/code-utils": {
+      "packages": {
+        "buffer": true,
+        "cbor": true
+      }
+    },
+    "@truffle/codec": {
+      "packages": {
+        "@truffle/abi-utils": true,
+        "@truffle/compile-common": true,
+        "big.js": true,
+        "bn.js": true,
+        "buffer": true,
+        "cbor": true,
+        "debug": true,
+        "lodash.clonedeep": true,
+        "lodash.escaperegexp": true,
+        "lodash.partition": true,
+        "lodash.sum": true,
+        "semver": true,
+        "utf8": true,
+        "util": true,
+        "web3-utils": true
+      }
+    },
+    "@truffle/compile-common": {
+      "packages": {
+        "@truffle/error": true,
+        "colors": true,
+        "path-browserify": true
+      }
+    },
+    "@truffle/decoder": {
+      "packages": {
+        "@truffle/abi-utils": true,
+        "@truffle/codec": true,
+        "@truffle/compile-common": true,
+        "@truffle/source-map-utils": true,
+        "bn.js": true,
+        "debug": true,
+        "web3-utils": true
+      }
+    },
+    "@truffle/source-map-utils": {
+      "packages": {
+        "@truffle/code-utils": true,
+        "@truffle/codec": true,
+        "debug": true,
+        "json-pointer": true,
+        "node-interval-tree": true,
+        "web3-utils": true
       }
     },
     "@zxing/browser": {
@@ -1040,6 +1099,11 @@
         "buffer": true
       }
     },
+    "big.js": {
+      "globals": {
+        "define": true
+      }
+    },
     "bignumber.js": {
       "globals": {
         "crypto": true,
@@ -1225,12 +1289,54 @@
         "get-intrinsic": true
       }
     },
+    "camel-case": {
+      "packages": {
+        "no-case": true,
+        "upper-case": true
+      }
+    },
+    "cbor": {
+      "globals": {
+        "TextDecoder": true
+      },
+      "packages": {
+        "bignumber.js": true,
+        "buffer": true,
+        "is-buffer": true,
+        "nofilter": true,
+        "stream-browserify": true,
+        "url": true,
+        "util": true
+      }
+    },
     "cbor-sync": {
       "globals": {
         "define": true
       },
       "packages": {
         "buffer": true
+      }
+    },
+    "change-case": {
+      "packages": {
+        "camel-case": true,
+        "constant-case": true,
+        "dot-case": true,
+        "header-case": true,
+        "is-lower-case": true,
+        "is-upper-case": true,
+        "lower-case": true,
+        "lower-case-first": true,
+        "no-case": true,
+        "param-case": true,
+        "pascal-case": true,
+        "path-case": true,
+        "sentence-case": true,
+        "snake-case": true,
+        "swap-case": true,
+        "title-case": true,
+        "upper-case": true,
+        "upper-case-first": true
       }
     },
     "cids": {
@@ -1285,6 +1391,22 @@
     "color-string": {
       "packages": {
         "color-name": true
+      }
+    },
+    "colors": {
+      "globals": {
+        "console.log": true
+      },
+      "packages": {
+        "os-browserify": true,
+        "process": true,
+        "util": true
+      }
+    },
+    "constant-case": {
+      "packages": {
+        "snake-case": true,
+        "upper-case": true
       }
     },
     "cookiejar": {
@@ -1546,6 +1668,11 @@
         "@babel/runtime": true
       }
     },
+    "dot-case": {
+      "packages": {
+        "no-case": true
+      }
+    },
     "drbg.js": {
       "packages": {
         "buffer": true,
@@ -1796,6 +1923,11 @@
         "trezor-connect": true
       }
     },
+    "ethereum-bloom-filters": {
+      "packages": {
+        "js-sha3": true
+      }
+    },
     "ethereum-cryptography": {
       "packages": {
         "assert": true,
@@ -2013,6 +2145,24 @@
         "chrome": true
       }
     },
+    "faker": {
+      "globals": {
+        "console.error": true,
+        "console.log": true,
+        "dbg": "write"
+      }
+    },
+    "fast-check": {
+      "globals": {
+        "clearTimeout": true,
+        "console.log": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "buffer": true,
+        "pure-rand": true
+      }
+    },
     "fast-json-patch": {
       "globals": {
         "addEventListener": true,
@@ -2070,11 +2220,6 @@
         "function-bind": true,
         "has": true,
         "has-symbols": true
-      }
-    },
-    "get-params": {
-      "globals": {
-        "GetParams": "write"
       }
     },
     "graphql-request": {
@@ -2155,6 +2300,12 @@
         "crypto-browserify": true,
         "safe-buffer": true,
         "secp256k1": true
+      }
+    },
+    "header-case": {
+      "packages": {
+        "no-case": true,
+        "upper-case": true
       }
     },
     "heap": {
@@ -2640,10 +2791,20 @@
         "multihashes": true
       }
     },
+    "is-lower-case": {
+      "packages": {
+        "lower-case": true
+      }
+    },
     "is-regex": {
       "packages": {
         "call-bind": true,
         "has-symbols": true
+      }
+    },
+    "is-upper-case": {
+      "packages": {
+        "upper-case": true
       }
     },
     "iso-random-stream": {
@@ -2699,14 +2860,14 @@
         "process": true
       }
     },
-    "jsan": {
-      "globals": {
-        "console.warn": true
-      }
-    },
     "jsbi": {
       "globals": {
         "define": true
+      }
+    },
+    "json-pointer": {
+      "packages": {
+        "foreach": true
       }
     },
     "json-rpc-engine": {
@@ -2800,6 +2961,7 @@
       "packages": {
         "buffer": true,
         "inherits": true,
+        "readable-stream": true,
         "safe-buffer": true,
         "stream-browserify": true
       }
@@ -3254,10 +3416,20 @@
         "util": true
       }
     },
+    "lower-case-first": {
+      "packages": {
+        "lower-case": true
+      }
+    },
     "lru": {
       "packages": {
         "events": true,
         "inherits": true
+      }
+    },
+    "lru-cache": {
+      "packages": {
+        "yallist": true
       }
     },
     "ltgt": {
@@ -3423,10 +3595,11 @@
         "crypto": true,
         "msCrypto": true,
         "navigator": true
-      },
+      }
+    },
+    "no-case": {
       "packages": {
-        "buffer": true,
-        "crypto-browserify": true
+        "lower-case": true
       }
     },
     "node-forge": {
@@ -3453,6 +3626,11 @@
         "timers-browserify": true
       }
     },
+    "node-interval-tree": {
+      "packages": {
+        "shallowequal": true
+      }
+    },
     "nodeify": {
       "globals": {
         "setTimeout": true
@@ -3462,6 +3640,13 @@
         "process": true,
         "promise": true,
         "timers-browserify": true
+      }
+    },
+    "nofilter": {
+      "packages": {
+        "buffer": true,
+        "stream-browserify": true,
+        "util": true
       }
     },
     "nonce-tracker": {
@@ -3659,6 +3844,11 @@
         "p-map": true
       }
     },
+    "param-case": {
+      "packages": {
+        "no-case": true
+      }
+    },
     "parse-asn1": {
       "packages": {
         "asn1.js": true,
@@ -3668,9 +3858,20 @@
         "pbkdf2": true
       }
     },
+    "pascal-case": {
+      "packages": {
+        "camel-case": true,
+        "upper-case-first": true
+      }
+    },
     "path-browserify": {
       "packages": {
         "process": true
+      }
+    },
+    "path-case": {
+      "packages": {
+        "no-case": true
       }
     },
     "path-to-regexp": {
@@ -4243,35 +4444,6 @@
         "@babel/runtime": true
       }
     },
-    "redux-devtools-core": {
-      "globals": {
-        "ErrorUtils": true,
-        "console": true,
-        "devToolsOptions": true,
-        "onerror": "write",
-        "serializeState": true
-      },
-      "packages": {
-        "get-params": true,
-        "jsan": true,
-        "lodash": true,
-        "nanoid": true,
-        "remotedev-serialize": true
-      }
-    },
-    "redux-devtools-instrument": {
-      "globals": {
-        "chrome": true,
-        "console.error": true,
-        "process": true,
-        "setTimeout": true
-      },
-      "packages": {
-        "lodash": true,
-        "process": true,
-        "symbol-observable": true
-      }
-    },
     "regenerator-runtime": {
       "globals": {
         "regeneratorRuntime": "write"
@@ -4286,21 +4458,6 @@
     "relative-url": {
       "packages": {
         "url": true
-      }
-    },
-    "remote-redux-devtools": {
-      "globals": {
-        "console.log": true,
-        "console.warn": true,
-        "fetch": true,
-        "setTimeout": true
-      },
-      "packages": {
-        "jsan": true,
-        "redux-devtools-core": true,
-        "redux-devtools-instrument": true,
-        "rn-host-detect": true,
-        "socketcluster-client": true
       }
     },
     "retimer": {
@@ -4328,13 +4485,6 @@
         "buffer": true
       }
     },
-    "rn-host-detect": {
-      "globals": {
-        "__DEV__": true,
-        "__fbBatchedBridgeConfig": true,
-        "console": true
-      }
-    },
     "safe-buffer": {
       "packages": {
         "buffer": true
@@ -4352,16 +4502,6 @@
     "sanitize-filename": {
       "packages": {
         "truncate-utf8-bytes": true
-      }
-    },
-    "sc-channel": {
-      "packages": {
-        "component-emitter": true
-      }
-    },
-    "sc-formatter": {
-      "globals": {
-        "Buffer": true
       }
     },
     "scheduler": {
@@ -4416,7 +4556,14 @@
         "console": true
       },
       "packages": {
+        "lru-cache": true,
         "process": true
+      }
+    },
+    "sentence-case": {
+      "packages": {
+        "no-case": true,
+        "upper-case-first": true
       }
     },
     "set-immediate-shim": {
@@ -4463,6 +4610,11 @@
         "readable-stream": true
       }
     },
+    "snake-case": {
+      "packages": {
+        "no-case": true
+      }
+    },
     "socket.io-client": {
       "globals": {
         "clearTimeout": true,
@@ -4505,29 +4657,6 @@
         "data-queue": true,
         "debug": true,
         "pull-stream": true,
-        "uuid": true
-      }
-    },
-    "socketcluster-client": {
-      "globals": {
-        "WebSocket": true,
-        "WorkerGlobalScope": true,
-        "addEventListener": true,
-        "clearTimeout": true,
-        "localStorage": true,
-        "location": true,
-        "removeEventListener": true,
-        "setTimeout": true
-      },
-      "packages": {
-        "buffer": true,
-        "clone": true,
-        "component-emitter": true,
-        "linked-list": true,
-        "querystring-es3": true,
-        "sc-channel": true,
-        "sc-errors": true,
-        "sc-formatter": true,
         "uuid": true
       }
     },
@@ -4613,6 +4742,12 @@
         "component-emitter": true
       }
     },
+    "swap-case": {
+      "packages": {
+        "lower-case": true,
+        "upper-case": true
+      }
+    },
     "textarea-caret": {
       "globals": {
         "document.body.appendChild": true,
@@ -4657,6 +4792,12 @@
     "tiny-warning": {
       "globals": {
         "console": true
+      }
+    },
+    "title-case": {
+      "packages": {
+        "no-case": true,
+        "upper-case": true
       }
     },
     "toggle-selection": {
@@ -4751,6 +4892,11 @@
     "uport-base64url": {
       "packages": {
         "buffer": true
+      }
+    },
+    "upper-case-first": {
+      "packages": {
+        "upper-case": true
       }
     },
     "url": {
@@ -4865,6 +5011,21 @@
         "readable-stream": true,
         "util": true,
         "uuid": true
+      }
+    },
+    "web3-utils": {
+      "globals": {
+        "setTimeout": true
+      },
+      "packages": {
+        "bn.js": true,
+        "eth-lib": true,
+        "ethereum-bloom-filters": true,
+        "ethjs-unit": true,
+        "is-buffer": true,
+        "number-to-bn": true,
+        "randombytes": true,
+        "utf8": true
       }
     },
     "webrtcsupport": {

--- a/lavamoat/browserify/main/policy.json
+++ b/lavamoat/browserify/main/policy.json
@@ -679,21 +679,8 @@
         "events": true
       }
     },
-    "@ngraveio/bc-ur": {
-      "packages": {
-        "@apocentre/alias-sampling": true,
-        "assert": true,
-        "bignumber.js": true,
-        "buffer": true,
-        "cbor-sync": true,
-        "crc": true,
-        "jsbi": true,
-        "sha.js": true
-      }
-    },
     "@metamask/snap-controllers": {
       "globals": {
-        "URL": true,
         "Worker": true,
         "clearTimeout": true,
         "console.error": true,
@@ -717,6 +704,18 @@
         "json-rpc-middleware-stream": true,
         "nanoid": true,
         "pump": true
+      }
+    },
+    "@ngraveio/bc-ur": {
+      "packages": {
+        "@apocentre/alias-sampling": true,
+        "assert": true,
+        "bignumber.js": true,
+        "buffer": true,
+        "cbor-sync": true,
+        "crc": true,
+        "jsbi": true,
+        "sha.js": true
       }
     },
     "@popperjs/core": {
@@ -836,6 +835,66 @@
       "packages": {
         "is-buffer": true,
         "util": true
+      }
+    },
+    "@truffle/abi-utils": {
+      "packages": {
+        "change-case": true,
+        "faker": true,
+        "fast-check": true
+      }
+    },
+    "@truffle/code-utils": {
+      "packages": {
+        "buffer": true,
+        "cbor": true
+      }
+    },
+    "@truffle/codec": {
+      "packages": {
+        "@truffle/abi-utils": true,
+        "@truffle/compile-common": true,
+        "big.js": true,
+        "bn.js": true,
+        "buffer": true,
+        "cbor": true,
+        "debug": true,
+        "lodash.clonedeep": true,
+        "lodash.escaperegexp": true,
+        "lodash.partition": true,
+        "lodash.sum": true,
+        "semver": true,
+        "utf8": true,
+        "util": true,
+        "web3-utils": true
+      }
+    },
+    "@truffle/compile-common": {
+      "packages": {
+        "@truffle/error": true,
+        "colors": true,
+        "path-browserify": true
+      }
+    },
+    "@truffle/decoder": {
+      "packages": {
+        "@truffle/abi-utils": true,
+        "@truffle/codec": true,
+        "@truffle/compile-common": true,
+        "@truffle/source-map-utils": true,
+        "bn.js": true,
+        "debug": true,
+        "web3-utils": true
+      }
+    },
+    "@truffle/source-map-utils": {
+      "packages": {
+        "@truffle/code-utils": true,
+        "@truffle/codec": true,
+        "debug": true,
+        "json-pointer": true,
+        "node-interval-tree": true,
+        "web3-utils": true
       }
     },
     "@zxing/browser": {
@@ -1040,6 +1099,11 @@
         "buffer": true
       }
     },
+    "big.js": {
+      "globals": {
+        "define": true
+      }
+    },
     "bignumber.js": {
       "globals": {
         "crypto": true,
@@ -1225,12 +1289,54 @@
         "get-intrinsic": true
       }
     },
+    "camel-case": {
+      "packages": {
+        "no-case": true,
+        "upper-case": true
+      }
+    },
+    "cbor": {
+      "globals": {
+        "TextDecoder": true
+      },
+      "packages": {
+        "bignumber.js": true,
+        "buffer": true,
+        "is-buffer": true,
+        "nofilter": true,
+        "stream-browserify": true,
+        "url": true,
+        "util": true
+      }
+    },
     "cbor-sync": {
       "globals": {
         "define": true
       },
       "packages": {
         "buffer": true
+      }
+    },
+    "change-case": {
+      "packages": {
+        "camel-case": true,
+        "constant-case": true,
+        "dot-case": true,
+        "header-case": true,
+        "is-lower-case": true,
+        "is-upper-case": true,
+        "lower-case": true,
+        "lower-case-first": true,
+        "no-case": true,
+        "param-case": true,
+        "pascal-case": true,
+        "path-case": true,
+        "sentence-case": true,
+        "snake-case": true,
+        "swap-case": true,
+        "title-case": true,
+        "upper-case": true,
+        "upper-case-first": true
       }
     },
     "cids": {
@@ -1285,6 +1391,22 @@
     "color-string": {
       "packages": {
         "color-name": true
+      }
+    },
+    "colors": {
+      "globals": {
+        "console.log": true
+      },
+      "packages": {
+        "os-browserify": true,
+        "process": true,
+        "util": true
+      }
+    },
+    "constant-case": {
+      "packages": {
+        "snake-case": true,
+        "upper-case": true
       }
     },
     "cookiejar": {
@@ -1546,6 +1668,11 @@
         "@babel/runtime": true
       }
     },
+    "dot-case": {
+      "packages": {
+        "no-case": true
+      }
+    },
     "drbg.js": {
       "packages": {
         "buffer": true,
@@ -1796,6 +1923,11 @@
         "trezor-connect": true
       }
     },
+    "ethereum-bloom-filters": {
+      "packages": {
+        "js-sha3": true
+      }
+    },
     "ethereum-cryptography": {
       "packages": {
         "assert": true,
@@ -2013,6 +2145,24 @@
         "chrome": true
       }
     },
+    "faker": {
+      "globals": {
+        "console.error": true,
+        "console.log": true,
+        "dbg": "write"
+      }
+    },
+    "fast-check": {
+      "globals": {
+        "clearTimeout": true,
+        "console.log": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "buffer": true,
+        "pure-rand": true
+      }
+    },
     "fast-json-patch": {
       "globals": {
         "addEventListener": true,
@@ -2070,11 +2220,6 @@
         "function-bind": true,
         "has": true,
         "has-symbols": true
-      }
-    },
-    "get-params": {
-      "globals": {
-        "GetParams": "write"
       }
     },
     "graphql-request": {
@@ -2155,6 +2300,12 @@
         "crypto-browserify": true,
         "safe-buffer": true,
         "secp256k1": true
+      }
+    },
+    "header-case": {
+      "packages": {
+        "no-case": true,
+        "upper-case": true
       }
     },
     "heap": {
@@ -2640,10 +2791,20 @@
         "multihashes": true
       }
     },
+    "is-lower-case": {
+      "packages": {
+        "lower-case": true
+      }
+    },
     "is-regex": {
       "packages": {
         "call-bind": true,
         "has-symbols": true
+      }
+    },
+    "is-upper-case": {
+      "packages": {
+        "upper-case": true
       }
     },
     "iso-random-stream": {
@@ -2699,14 +2860,14 @@
         "process": true
       }
     },
-    "jsan": {
-      "globals": {
-        "console.warn": true
-      }
-    },
     "jsbi": {
       "globals": {
         "define": true
+      }
+    },
+    "json-pointer": {
+      "packages": {
+        "foreach": true
       }
     },
     "json-rpc-engine": {
@@ -2800,6 +2961,7 @@
       "packages": {
         "buffer": true,
         "inherits": true,
+        "readable-stream": true,
         "safe-buffer": true,
         "stream-browserify": true
       }
@@ -3254,10 +3416,20 @@
         "util": true
       }
     },
+    "lower-case-first": {
+      "packages": {
+        "lower-case": true
+      }
+    },
     "lru": {
       "packages": {
         "events": true,
         "inherits": true
+      }
+    },
+    "lru-cache": {
+      "packages": {
+        "yallist": true
       }
     },
     "ltgt": {
@@ -3423,10 +3595,11 @@
         "crypto": true,
         "msCrypto": true,
         "navigator": true
-      },
+      }
+    },
+    "no-case": {
       "packages": {
-        "buffer": true,
-        "crypto-browserify": true
+        "lower-case": true
       }
     },
     "node-forge": {
@@ -3453,6 +3626,11 @@
         "timers-browserify": true
       }
     },
+    "node-interval-tree": {
+      "packages": {
+        "shallowequal": true
+      }
+    },
     "nodeify": {
       "globals": {
         "setTimeout": true
@@ -3462,6 +3640,13 @@
         "process": true,
         "promise": true,
         "timers-browserify": true
+      }
+    },
+    "nofilter": {
+      "packages": {
+        "buffer": true,
+        "stream-browserify": true,
+        "util": true
       }
     },
     "nonce-tracker": {
@@ -3659,6 +3844,11 @@
         "p-map": true
       }
     },
+    "param-case": {
+      "packages": {
+        "no-case": true
+      }
+    },
     "parse-asn1": {
       "packages": {
         "asn1.js": true,
@@ -3668,9 +3858,20 @@
         "pbkdf2": true
       }
     },
+    "pascal-case": {
+      "packages": {
+        "camel-case": true,
+        "upper-case-first": true
+      }
+    },
     "path-browserify": {
       "packages": {
         "process": true
+      }
+    },
+    "path-case": {
+      "packages": {
+        "no-case": true
       }
     },
     "path-to-regexp": {
@@ -4243,35 +4444,6 @@
         "@babel/runtime": true
       }
     },
-    "redux-devtools-core": {
-      "globals": {
-        "ErrorUtils": true,
-        "console": true,
-        "devToolsOptions": true,
-        "onerror": "write",
-        "serializeState": true
-      },
-      "packages": {
-        "get-params": true,
-        "jsan": true,
-        "lodash": true,
-        "nanoid": true,
-        "remotedev-serialize": true
-      }
-    },
-    "redux-devtools-instrument": {
-      "globals": {
-        "chrome": true,
-        "console.error": true,
-        "process": true,
-        "setTimeout": true
-      },
-      "packages": {
-        "lodash": true,
-        "process": true,
-        "symbol-observable": true
-      }
-    },
     "regenerator-runtime": {
       "globals": {
         "regeneratorRuntime": "write"
@@ -4286,21 +4458,6 @@
     "relative-url": {
       "packages": {
         "url": true
-      }
-    },
-    "remote-redux-devtools": {
-      "globals": {
-        "console.log": true,
-        "console.warn": true,
-        "fetch": true,
-        "setTimeout": true
-      },
-      "packages": {
-        "jsan": true,
-        "redux-devtools-core": true,
-        "redux-devtools-instrument": true,
-        "rn-host-detect": true,
-        "socketcluster-client": true
       }
     },
     "retimer": {
@@ -4328,13 +4485,6 @@
         "buffer": true
       }
     },
-    "rn-host-detect": {
-      "globals": {
-        "__DEV__": true,
-        "__fbBatchedBridgeConfig": true,
-        "console": true
-      }
-    },
     "safe-buffer": {
       "packages": {
         "buffer": true
@@ -4352,16 +4502,6 @@
     "sanitize-filename": {
       "packages": {
         "truncate-utf8-bytes": true
-      }
-    },
-    "sc-channel": {
-      "packages": {
-        "component-emitter": true
-      }
-    },
-    "sc-formatter": {
-      "globals": {
-        "Buffer": true
       }
     },
     "scheduler": {
@@ -4416,7 +4556,14 @@
         "console": true
       },
       "packages": {
+        "lru-cache": true,
         "process": true
+      }
+    },
+    "sentence-case": {
+      "packages": {
+        "no-case": true,
+        "upper-case-first": true
       }
     },
     "set-immediate-shim": {
@@ -4463,6 +4610,11 @@
         "readable-stream": true
       }
     },
+    "snake-case": {
+      "packages": {
+        "no-case": true
+      }
+    },
     "socket.io-client": {
       "globals": {
         "clearTimeout": true,
@@ -4505,29 +4657,6 @@
         "data-queue": true,
         "debug": true,
         "pull-stream": true,
-        "uuid": true
-      }
-    },
-    "socketcluster-client": {
-      "globals": {
-        "WebSocket": true,
-        "WorkerGlobalScope": true,
-        "addEventListener": true,
-        "clearTimeout": true,
-        "localStorage": true,
-        "location": true,
-        "removeEventListener": true,
-        "setTimeout": true
-      },
-      "packages": {
-        "buffer": true,
-        "clone": true,
-        "component-emitter": true,
-        "linked-list": true,
-        "querystring-es3": true,
-        "sc-channel": true,
-        "sc-errors": true,
-        "sc-formatter": true,
         "uuid": true
       }
     },
@@ -4613,6 +4742,12 @@
         "component-emitter": true
       }
     },
+    "swap-case": {
+      "packages": {
+        "lower-case": true,
+        "upper-case": true
+      }
+    },
     "textarea-caret": {
       "globals": {
         "document.body.appendChild": true,
@@ -4657,6 +4792,12 @@
     "tiny-warning": {
       "globals": {
         "console": true
+      }
+    },
+    "title-case": {
+      "packages": {
+        "no-case": true,
+        "upper-case": true
       }
     },
     "toggle-selection": {
@@ -4751,6 +4892,11 @@
     "uport-base64url": {
       "packages": {
         "buffer": true
+      }
+    },
+    "upper-case-first": {
+      "packages": {
+        "upper-case": true
       }
     },
     "url": {
@@ -4865,6 +5011,21 @@
         "readable-stream": true,
         "util": true,
         "uuid": true
+      }
+    },
+    "web3-utils": {
+      "globals": {
+        "setTimeout": true
+      },
+      "packages": {
+        "bn.js": true,
+        "eth-lib": true,
+        "ethereum-bloom-filters": true,
+        "ethjs-unit": true,
+        "is-buffer": true,
+        "number-to-bn": true,
+        "randombytes": true,
+        "utf8": true
       }
     },
     "webrtcsupport": {

--- a/lavamoat/build-system/policy.json
+++ b/lavamoat/build-system/policy.json
@@ -1045,16 +1045,6 @@
         "buffer-equal": true
       }
     },
-    "are-we-there-yet": {
-      "builtin": {
-        "events.EventEmitter": true,
-        "util.inherits": true
-      },
-      "packages": {
-        "delegates": true,
-        "readable-stream": true
-      }
-    },
     "arr-diff": {
       "packages": {
         "arr-flatten": true,
@@ -1463,7 +1453,6 @@
         "anymatch": true,
         "async-each": true,
         "braces": true,
-        "fsevents": true,
         "glob-parent": true,
         "inherits": true,
         "is-binary-path": true,
@@ -1728,16 +1717,6 @@
       "packages": {
         "shasum-object": true,
         "through2": true
-      }
-    },
-    "detect-libc": {
-      "builtin": {
-        "child_process.spawnSync": true,
-        "fs.readdirSync": true,
-        "os.platform": true
-      },
-      "globals": {
-        "process.env": true
       }
     },
     "detective": {
@@ -2430,45 +2409,6 @@
         "process.version": true
       }
     },
-    "fsevents": {
-      "builtin": {
-        "events.EventEmitter": true,
-        "fs.stat": true,
-        "path.join": true,
-        "util.inherits": true
-      },
-      "globals": {
-        "__dirname": true,
-        "process.nextTick": true,
-        "process.platform": true,
-        "setImmediate": true
-      },
-      "native": true,
-      "packages": {
-        "node-pre-gyp": true
-      }
-    },
-    "gauge": {
-      "builtin": {
-        "util.format": true
-      },
-      "globals": {
-        "clearInterval": true,
-        "process": true,
-        "setImmediate": true,
-        "setInterval": true
-      },
-      "packages": {
-        "aproba": true,
-        "console-control-strings": true,
-        "has-unicode": true,
-        "object-assign": true,
-        "signal-exit": true,
-        "string-width": true,
-        "strip-ansi": true,
-        "wide-align": true
-      }
-    },
     "get-assigned-identifiers": {
       "builtin": {
         "assert.equal": true
@@ -2842,16 +2782,6 @@
         "process.argv": true
       }
     },
-    "has-unicode": {
-      "builtin": {
-        "os.type": true
-      },
-      "globals": {
-        "process.env.LANG": true,
-        "process.env.LC_ALL": true,
-        "process.env.LC_CTYPE": true
-      }
-    },
     "has-value": {
       "packages": {
         "get-value": true,
@@ -3021,11 +2951,6 @@
     "is-extendable": {
       "packages": {
         "is-plain-object": true
-      }
-    },
-    "is-fullwidth-code-point": {
-      "packages": {
-        "number-is-nan": true
       }
     },
     "is-glob": {
@@ -3553,56 +3478,6 @@
         "setTimeout": true
       }
     },
-    "node-pre-gyp": {
-      "builtin": {
-        "events.EventEmitter": true,
-        "fs.existsSync": true,
-        "fs.readFileSync": true,
-        "fs.renameSync": true,
-        "path.dirname": true,
-        "path.existsSync": true,
-        "path.join": true,
-        "path.resolve": true,
-        "url.parse": true,
-        "url.resolve": true,
-        "util.inherits": true
-      },
-      "globals": {
-        "__dirname": true,
-        "console.log": true,
-        "process.arch": true,
-        "process.cwd": true,
-        "process.env": true,
-        "process.platform": true,
-        "process.version.substr": true,
-        "process.versions": true
-      },
-      "packages": {
-        "detect-libc": true,
-        "nopt": true,
-        "npmlog": true,
-        "rimraf": true,
-        "semver": true
-      }
-    },
-    "nopt": {
-      "builtin": {
-        "path": true,
-        "stream.Stream": true,
-        "url": true
-      },
-      "globals": {
-        "console": true,
-        "process.argv": true,
-        "process.env.DEBUG_NOPT": true,
-        "process.env.NOPT_DEBUG": true,
-        "process.platform": true
-      },
-      "packages": {
-        "abbrev": true,
-        "osenv": true
-      }
-    },
     "normalize-package-data": {
       "builtin": {
         "url.parse": true,
@@ -3628,22 +3503,6 @@
     "now-and-later": {
       "packages": {
         "once": true
-      }
-    },
-    "npmlog": {
-      "builtin": {
-        "events.EventEmitter": true,
-        "util": true
-      },
-      "globals": {
-        "process.nextTick": true,
-        "process.stderr": true
-      },
-      "packages": {
-        "are-we-there-yet": true,
-        "console-control-strings": true,
-        "gauge": true,
-        "set-blocking": true
       }
     },
     "object-copy": {
@@ -3725,54 +3584,6 @@
       },
       "packages": {
         "readable-stream": true
-      }
-    },
-    "os-homedir": {
-      "builtin": {
-        "os.homedir": true
-      },
-      "globals": {
-        "process.env": true,
-        "process.getuid": true,
-        "process.platform": true
-      }
-    },
-    "os-tmpdir": {
-      "globals": {
-        "process.env.SystemRoot": true,
-        "process.env.TEMP": true,
-        "process.env.TMP": true,
-        "process.env.TMPDIR": true,
-        "process.env.windir": true,
-        "process.platform": true
-      }
-    },
-    "osenv": {
-      "builtin": {
-        "child_process.exec": true,
-        "path": true
-      },
-      "globals": {
-        "process.env.COMPUTERNAME": true,
-        "process.env.ComSpec": true,
-        "process.env.EDITOR": true,
-        "process.env.HOSTNAME": true,
-        "process.env.PATH": true,
-        "process.env.PROMPT": true,
-        "process.env.PS1": true,
-        "process.env.Path": true,
-        "process.env.SHELL": true,
-        "process.env.USER": true,
-        "process.env.USERDOMAIN": true,
-        "process.env.USERNAME": true,
-        "process.env.VISUAL": true,
-        "process.env.path": true,
-        "process.nextTick": true,
-        "process.platform": true
-      },
-      "packages": {
-        "os-homedir": true,
-        "os-tmpdir": true
       }
     },
     "p-limit": {
@@ -4479,12 +4290,6 @@
         "lru-cache": true
       }
     },
-    "set-blocking": {
-      "globals": {
-        "process.stderr": true,
-        "process.stdout": true
-      }
-    },
     "set-value": {
       "packages": {
         "extend-shallow": true,
@@ -4744,7 +4549,6 @@
     },
     "string-width": {
       "packages": {
-        "code-point-at": true,
         "emoji-regex": true,
         "is-fullwidth-code-point": true,
         "strip-ansi": true
@@ -5395,11 +5199,6 @@
       },
       "packages": {
         "isexe": true
-      }
-    },
-    "wide-align": {
-      "packages": {
-        "string-width": true
       }
     },
     "write": {

--- a/package.json
+++ b/package.json
@@ -149,7 +149,7 @@
     "eth-query": "^2.1.2",
     "eth-rpc-errors": "^4.0.2",
     "eth-sig-util": "^3.0.0",
-    "eth-trezor-keyring": "^0.9.0",
+    "eth-trezor-keyring": "^0.9.1",
     "ethereum-ens-network-map": "^1.0.2",
     "ethereumjs-abi": "^0.6.4",
     "ethereumjs-util": "^7.0.10",
@@ -380,7 +380,9 @@
       "@lavamoat/preinstall-always-fail": false,
       "fsevents": false,
       "node-hid": false,
-      "usb": false
+      "usb": false,
+      "blake-hash": false,
+      "protobufjs": false
     }
   }
 }

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -141,12 +141,7 @@ export function getParticipateInMetaMetrics(state) {
   return Boolean(state.metamask.participateInMetaMetrics);
 }
 
-export function isEIP1559Account(state) {
-  const keyring = getCurrentKeyring(state);
-
-  if (keyring?.type === KEYRING_TYPES.TREZOR) {
-    return state.metamask.trezorModel === 'T';
-  }
+export function isEIP1559Account() {
   return true;
 }
 

--- a/ui/selectors/selectors.test.js
+++ b/ui/selectors/selectors.test.js
@@ -118,24 +118,6 @@ describe('Selectors', () => {
       });
       expect(not1559Network).toStrictEqual(true);
     });
-
-    it('returns true if account does not support EIP-1559', () => {
-      const networkOrAccountNotSupports1559 = selectors.checkNetworkOrAccountNotSupports1559(
-        {
-          ...mockState,
-          metamask: {
-            ...mockState.metamask,
-            keyrings: [
-              {
-                type: KEYRING_TYPES.TREZOR,
-                accounts: ['0x0dcd5d886577d5081b0c52e242ef29e70be3e7bc'],
-              },
-            ],
-          },
-        },
-      );
-      expect(networkOrAccountNotSupports1559).toStrictEqual(true);
-    });
   });
 
   describe('#getAddressBook', () => {

--- a/ui/selectors/selectors.test.js
+++ b/ui/selectors/selectors.test.js
@@ -102,7 +102,7 @@ describe('Selectors', () => {
         metamask: {
           ...mockState.metamask,
           networkDetails: {
-            EIPS: { 1559: undefined },
+            EIPS: { 1559: false },
           },
         },
       });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1155,10 +1155,10 @@
     core-js-pure "^3.0.0"
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.10.2", "@babel/runtime@^7.10.3", "@babel/runtime@^7.12.5", "@babel/runtime@^7.14.0", "@babel/runtime@^7.14.8", "@babel/runtime@^7.3.1", "@babel/runtime@^7.4.0", "@babel/runtime@^7.4.4", "@babel/runtime@^7.4.5", "@babel/runtime@^7.5.0", "@babel/runtime@^7.5.4", "@babel/runtime@^7.5.5", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.3", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2":
-  version "7.15.4"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.15.4.tgz#fd17d16bfdf878e6dd02d19753a39fa8a8d9c84a"
-  integrity sha512-99catp6bHCaxr4sJ/DbTGgHS4+Rs2RVd2g7iOap6SLGPDknRK9ztKNsE/Fg6QhSeh1FGE5f6gHGQmvvn3I3xhw==
+"@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.10.2", "@babel/runtime@^7.10.3", "@babel/runtime@^7.12.5", "@babel/runtime@^7.14.0", "@babel/runtime@^7.14.8", "@babel/runtime@^7.15.4", "@babel/runtime@^7.3.1", "@babel/runtime@^7.4.0", "@babel/runtime@^7.4.4", "@babel/runtime@^7.4.5", "@babel/runtime@^7.5.0", "@babel/runtime@^7.5.4", "@babel/runtime@^7.5.5", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.3", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2":
+  version "7.16.3"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.16.3.tgz#b86f0db02a04187a3c17caa77de69840165d42d5"
+  integrity sha512-WBwekcqacdY2e9AF/Q7WLFUWmdJGJTkbjqTjoMDgXkVZ3ZRUvOPsLb5KdwISoQVsbP+DQzVZW4Zhci0DvpbNTQ==
   dependencies:
     regenerator-runtime "^0.13.4"
 
@@ -2946,6 +2946,54 @@
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.9.2.tgz#adea7b6953cbb34651766b0548468e743c6a2353"
   integrity sha512-VZMYa7+fXHdwIq1TDhSXoVmSPEGM/aa+6Aiq3nVVJ9bXr24zScr+NlKFKC3iPljA7ho/GAZr+d2jOf5GIRC30Q==
 
+"@protobufjs/aspromise@^1.1.1", "@protobufjs/aspromise@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@protobufjs/aspromise/-/aspromise-1.1.2.tgz#9b8b0cc663d669a7d8f6f5d0893a14d348f30fbf"
+  integrity sha1-m4sMxmPWaafY9vXQiToU00jzD78=
+
+"@protobufjs/base64@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@protobufjs/base64/-/base64-1.1.2.tgz#4c85730e59b9a1f1f349047dbf24296034bb2735"
+  integrity sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==
+
+"@protobufjs/codegen@^2.0.4":
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/@protobufjs/codegen/-/codegen-2.0.4.tgz#7ef37f0d010fb028ad1ad59722e506d9262815cb"
+  integrity sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==
+
+"@protobufjs/eventemitter@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz#355cbc98bafad5978f9ed095f397621f1d066b70"
+  integrity sha1-NVy8mLr61ZePntCV85diHx0Ga3A=
+
+"@protobufjs/fetch@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@protobufjs/fetch/-/fetch-1.1.0.tgz#ba99fb598614af65700c1619ff06d454b0d84c45"
+  integrity sha1-upn7WYYUr2VwDBYZ/wbUVLDYTEU=
+  dependencies:
+    "@protobufjs/aspromise" "^1.1.1"
+    "@protobufjs/inquire" "^1.1.0"
+
+"@protobufjs/float@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@protobufjs/float/-/float-1.0.2.tgz#5e9e1abdcb73fc0a7cb8b291df78c8cbd97b87d1"
+  integrity sha1-Xp4avctz/Ap8uLKR33jIy9l7h9E=
+
+"@protobufjs/inquire@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@protobufjs/inquire/-/inquire-1.1.0.tgz#ff200e3e7cf2429e2dcafc1140828e8cc638f089"
+  integrity sha1-/yAOPnzyQp4tyvwRQIKOjMY48Ik=
+
+"@protobufjs/path@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@protobufjs/path/-/path-1.1.2.tgz#6cc2b20c5c9ad6ad0dccfd21ca7673d8d7fbf68d"
+  integrity sha1-bMKyDFya1q0NzP0hynZz2Nf79o0=
+
+"@protobufjs/pool@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@protobufjs/pool/-/pool-1.1.0.tgz#09fd15f2d6d3abfa9b65bc366506d6ad7846ff54"
+  integrity sha1-Cf0V8tbTq/qbZbw2ZQbWrXhG/1Q=
+
 "@protobufjs/utf8@^1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
@@ -3098,11 +3146,6 @@
   version "0.7.1"
   resolved "https://registry.yarnpkg.com/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz#8da5c6530915653f3a1f38fd5f101d8c3f8079c5"
   integrity sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==
-
-"@socket.io/component-emitter@~3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@socket.io/component-emitter/-/component-emitter-3.0.0.tgz#8863915676f837d9dad7b76f50cb500c1e9422e9"
-  integrity sha512-2pTGuibAXJswAPJjaKisthqS/NOK5ypG4LYT6tEAV0S/mxW0zOIvYvGK0V8w8+SHxAm6vRMSjqSalFXeBAqs+Q==
 
 "@stablelib/utf8@^0.10.1":
   version "0.10.1"
@@ -3960,10 +4003,10 @@
     tiny-worker "^2.3.0"
     ws "^7.4.0"
 
-"@trezor/connect-common@^0.0.2":
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/@trezor/connect-common/-/connect-common-0.0.2.tgz#d2bb1e90de6be2895b7f44215f09b52db361aaf4"
-  integrity sha512-b0R/HfA10mH2CR0BoPkKUs/2TC5Bf4MSGBFRF+1Q4tluQfSRzongQEZivg09vbBQEZBD1Ora3Oikn74zqsW4Aw==
+"@trezor/connect-common@^0.0.3":
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/@trezor/connect-common/-/connect-common-0.0.3.tgz#d136453d259d24f9200daf72d0184594d56e92e2"
+  integrity sha512-oc4K/Ve2e1o3R1M0QAexLYN7aOepeSlcO5NVP/cfxBA+36cApZrRSy6kbs3OB2uc15tua5qkmYEDpJ3QSnZarg==
 
 "@trezor/rollout@^1.2.0":
   version "1.2.0"
@@ -3973,31 +4016,27 @@
     cross-fetch "^3.0.6"
     runtypes "^5.0.1"
 
-"@trezor/utxo-lib@0.1.2", "@trezor/utxo-lib@^0.1.2":
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/@trezor/utxo-lib/-/utxo-lib-0.1.2.tgz#19319a424b0d0c648b0df456f1849eb08697fb44"
-  integrity sha512-ONAsg8LAyZY9g6X/qgqloUHwWsqtRmrx2Wt3wkz+7LO2VdE69HktAHWUjJLK9drskNwly3Fp0GKK6ZbbtX+Ghw==
+"@trezor/utxo-lib@1.0.0-beta.10":
+  version "1.0.0-beta.10"
+  resolved "https://registry.yarnpkg.com/@trezor/utxo-lib/-/utxo-lib-1.0.0-beta.10.tgz#93f16ce607d94e50f8338a75ca8a3710f106c20e"
+  integrity sha512-osQwFYe/xC9TeRzuUXqVjZPHwBziN0vioYTPq95xgAAZZ9fCWjgJdL98rLLBgFJd0sOz/JwUdLefNGS257YYUQ==
   dependencies:
-    bech32 "0.0.3"
-    bigi "^1.4.0"
-    bip66 "^1.1.0"
-    bitcoin-ops "^1.3.0"
-    blake2b "https://github.com/BitGo/blake2b#6268e6dd678661e0acc4359e9171b97eb1ebf8ac"
-    bs58check "^2.0.0"
-    create-hash "^1.1.0"
-    create-hmac "^1.1.3"
-    debug "~3.1.0"
-    ecurve "^1.0.0"
-    int64-buffer "0.99.1007"
-    merkle-lib "^2.0.10"
+    bchaddrjs "^0.5.2"
+    bech32 "^2.0.0"
+    bip66 "^1.1.5"
+    bitcoin-ops "^1.4.1"
+    blake-hash "^2.0.0"
+    bn.js "^4.0.0"
+    bs58 "^4.0.1"
+    bs58check "^2.1.2"
+    create-hash "^1.2.0"
+    create-hmac "^1.1.7"
+    int64-buffer "^1.0.1"
     pushdata-bitcoin "^1.0.1"
-    randombytes "^2.0.1"
-    safe-buffer "^5.0.1"
-    typeforce "^1.11.3"
-    varuint-bitcoin "^1.0.4"
-    wif "^2.0.1"
-  optionalDependencies:
-    secp256k1 "^3.5.2"
+    tiny-secp256k1 "^1.1.6"
+    typeforce "^1.18.0"
+    varuint-bitcoin "^1.1.2"
+    wif "^2.0.6"
 
 "@truffle/abi-utils@^0.2.4":
   version "0.2.4"
@@ -4268,6 +4307,11 @@
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.168.tgz#fe24632e79b7ade3f132891afff86caa5e5ce008"
   integrity sha512-oVfRvqHV/V6D1yifJbVRU3TMp8OT6o6BG+U9MkwuJ3U8/CsDHvalRpsxBqivn71ztOFZBTfJMvETbqHiaNSj7Q==
 
+"@types/long@^4.0.1":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@types/long/-/long-4.0.1.tgz#459c65fa1867dafe6a8f322c4c51695663cc55e9"
+  integrity sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w==
+
 "@types/markdown-to-jsx@^6.11.3":
   version "6.11.3"
   resolved "https://registry.yarnpkg.com/@types/markdown-to-jsx/-/markdown-to-jsx-6.11.3.tgz#cdd1619308fecbc8be7e6a26f3751260249b020e"
@@ -4307,10 +4351,10 @@
     "@types/node" "*"
     form-data "^3.0.0"
 
-"@types/node@*", "@types/node@^14.0.10":
-  version "14.17.27"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.17.27.tgz#5054610d37bb5f6e21342d0e6d24c494231f3b85"
-  integrity sha512-94+Ahf9IcaDuJTle/2b+wzvjmutxXAEXU6O81JHblYXUg2BDG+dnBy7VxIPHKAyEEDHzCMQydTJuWvrE+Aanzw==
+"@types/node@*", "@types/node@>=13.7.0":
+  version "16.11.12"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.11.12.tgz#ac7fb693ac587ee182c3780c26eb65546a1a3c10"
+  integrity sha512-+2Iggwg7PxoO5Kyhvsq9VarmPbIelXP070HMImEpbtGCoyWNINQj4wzjbQCXzdHTRXnqufutJb5KAURZANNBAw==
 
 "@types/node@10.12.18":
   version "10.12.18"
@@ -4321,6 +4365,11 @@
   version "12.19.15"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.19.15.tgz#0de7e978fb43db62da369db18ea088a63673c182"
   integrity sha512-lowukE3GUI+VSYSu6VcBXl14d61Rp5hA1D+61r16qnwC0lYNSqdxcvRh0pswejorHfS+HgwBasM8jLXz0/aOsw==
+
+"@types/node@^14.0.10":
+  version "14.17.27"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.17.27.tgz#5054610d37bb5f6e21342d0e6d24c494231f3b85"
+  integrity sha512-94+Ahf9IcaDuJTle/2b+wzvjmutxXAEXU6O81JHblYXUg2BDG+dnBy7VxIPHKAyEEDHzCMQydTJuWvrE+Aanzw==
 
 "@types/node@^8.10.11":
   version "8.10.48"
@@ -5662,14 +5711,6 @@ asap@^2.0.0, asap@^2.0.6:
   resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
   integrity sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=
 
-ascli@~0.3:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/ascli/-/ascli-0.3.0.tgz#5e66230e5219fe3e8952a4efb4f20fae596a813a"
-  integrity sha1-XmYjDlIZ/j6JUqTvtPIPrllqgTo=
-  dependencies:
-    colour latest
-    optjs latest
-
 asmcrypto.js@^2.3.2:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/asmcrypto.js/-/asmcrypto.js-2.3.2.tgz#b9f84bd0a1fb82f21f8c29cc284a707ad17bba2e"
@@ -6682,7 +6723,7 @@ bach@^1.0.0:
     async-settle "^1.0.0"
     now-and-later "^2.0.0"
 
-backo2@1.0.2, backo2@~1.0.2:
+backo2@1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/backo2/-/backo2-1.0.2.tgz#31ab1ac8b129363463e35b3ebb69f4dfcfba7947"
   integrity sha1-MasayLEpNjRj41s+u2n038+6eUc=
@@ -6747,11 +6788,6 @@ base64-arraybuffer@0.1.4:
   resolved "https://registry.yarnpkg.com/base64-arraybuffer/-/base64-arraybuffer-0.1.4.tgz#9818c79e059b1355f97e0428a017c838e90ba812"
   integrity sha1-mBjHngWbE1X5fgQooBfIOOkLqBI=
 
-base64-arraybuffer@~1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/base64-arraybuffer/-/base64-arraybuffer-1.0.1.tgz#87bd13525626db4a9838e00a508c2b73efcf348c"
-  integrity sha512-vFIUq7FdLtjZMhATwDul5RZWv2jpXQ09Pd6jcVEOvIsqCWTRFD/ONHNfyOS8dA/Ippi5dsIgpyKWKZaAKZltbA==
-
 base64-js@^1.0.2, base64-js@^1.3.1, base64-js@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
@@ -6802,11 +6838,6 @@ bcrypt-pbkdf@^1.0.0:
   dependencies:
     tweetnacl "^0.14.3"
 
-bech32@0.0.3:
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/bech32/-/bech32-0.0.3.tgz#736747c4a6531c5d8937d0400498de30e93b2f9c"
-  integrity sha512-O+K1w8P/aAOLcYwwQ4sbiPYZ51ZIW95lnS4/6nE8Aib/z+OOddQIIPdu2qi94qGDp4HhYy/wJotttXKkak1lXg==
-
 bech32@1.1.4, bech32@^1.1.2:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/bech32/-/bech32-1.1.4.tgz#e38c9f37bf179b8eb16ae3a772b40c356d4832e9"
@@ -6851,11 +6882,6 @@ big.js@^5.1.2, big.js@^5.2.2:
   version "5.2.2"
   resolved "https://registry.yarnpkg.com/big.js/-/big.js-5.2.2.tgz#65f0af382f578bcdc742bd9c281e9cb2d7768328"
   integrity sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==
-
-bigi@^1.1.0, bigi@^1.4.0, bigi@^1.4.1:
-  version "1.4.2"
-  resolved "https://registry.yarnpkg.com/bigi/-/bigi-1.4.2.tgz#9c665a95f88b8b08fc05cfd731f561859d725825"
-  integrity sha1-nGZalfiLiwj8Bc/XMfVhhZ1yWCU=
 
 bignumber.js@^4.1.0:
   version "4.1.0"
@@ -6944,7 +6970,7 @@ bip66@^1.1.0, bip66@^1.1.5:
   dependencies:
     safe-buffer "^5.0.1"
 
-bitcoin-ops@^1.3.0, bitcoin-ops@^1.4.0:
+bitcoin-ops@^1.3.0, bitcoin-ops@^1.4.0, bitcoin-ops@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/bitcoin-ops/-/bitcoin-ops-1.4.1.tgz#e45de620398e22fd4ca6023de43974ff42240278"
   integrity sha512-pef6gxZFztEhaE9RY9HmWVmiIHqCb2OyS4HPKkpc6CIiiOa3Qmuoylxc5P2EkU3w+5eTSifI9SEZC88idAIGow==
@@ -7000,18 +7026,14 @@ bl@^4.0.3:
     inherits "^2.0.4"
     readable-stream "^3.4.0"
 
-"blake2b-wasm@https://github.com/BitGo/blake2b-wasm#193cdb71656c1a6c7f89b05d0327bb9b758d071b":
+blake-hash@^2.0.0:
   version "2.0.0"
-  resolved "https://github.com/BitGo/blake2b-wasm#193cdb71656c1a6c7f89b05d0327bb9b758d071b"
+  resolved "https://registry.yarnpkg.com/blake-hash/-/blake-hash-2.0.0.tgz#af184dce641951126d05b7d1c3de3224f538d66e"
+  integrity sha512-Igj8YowDu1PRkRsxZA7NVkdFNxH5rKv5cpLxQ0CVXSIA77pVYwCPRQJ2sMew/oneUpfuYRyjG6r8SmmmnbZb1w==
   dependencies:
-    nanoassert "^1.0.0"
-
-"blake2b@https://github.com/BitGo/blake2b#6268e6dd678661e0acc4359e9171b97eb1ebf8ac":
-  version "2.1.3"
-  resolved "https://github.com/BitGo/blake2b#6268e6dd678661e0acc4359e9171b97eb1ebf8ac"
-  dependencies:
-    blake2b-wasm "https://github.com/BitGo/blake2b-wasm#193cdb71656c1a6c7f89b05d0327bb9b758d071b"
-    nanoassert "^1.0.0"
+    node-addon-api "^3.0.0"
+    node-gyp-build "^4.2.2"
+    readable-stream "^3.6.0"
 
 blakejs@^1.1.0:
   version "1.1.0"
@@ -7630,23 +7652,17 @@ bufferutil@^4.0.1:
   dependencies:
     node-gyp-build "~3.7.0"
 
-bufferview@~1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/bufferview/-/bufferview-1.0.1.tgz#7afd74a45f937fa422a1d338c08bbfdc76cd725d"
-  integrity sha1-ev10pF+Tf6QiodM4wIu/3HbNcl0=
-
 builtin-status-codes@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz#85982878e21b98e1c66425e03d0174788f569ee8"
   integrity sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=
 
-bytebuffer-old-fixed-webpack@3.5.6:
-  version "3.5.6"
-  resolved "https://registry.yarnpkg.com/bytebuffer-old-fixed-webpack/-/bytebuffer-old-fixed-webpack-3.5.6.tgz#5adc419c6a9b4692f217206703ec7431c759aa3f"
-  integrity sha1-WtxBnGqbRpLyFyBnA+x0McdZqj8=
+bytebuffer@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/bytebuffer/-/bytebuffer-5.0.1.tgz#582eea4b1a873b6d020a48d58df85f0bba6cfddd"
+  integrity sha1-WC7qSxqHO20CCkjVjfhfC7ps/d0=
   dependencies:
-    bufferview "~1"
-    long "~2 >=2.2.3"
+    long "~3"
 
 byteman@^1.3.5:
   version "1.3.5"
@@ -8545,11 +8561,6 @@ colors@^1.1.2, colors@^1.4.0:
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.4.0.tgz#c50491479d4c1bdaed2c9ced32cf7c7dc2360f78"
   integrity sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==
 
-colour@latest:
-  version "0.7.1"
-  resolved "https://registry.yarnpkg.com/colour/-/colour-0.7.1.tgz#9cb169917ec5d12c0736d3e8685746df1cadf778"
-  integrity sha1-nLFpkX7F0SwHNtPoaFdG3xyt93g=
-
 columnify@1.5.4:
   version "1.5.4"
   resolved "https://registry.yarnpkg.com/columnify/-/columnify-1.5.4.tgz#4737ddf1c7b69a8a7c340570782e947eec8e78bb"
@@ -9425,7 +9436,7 @@ debug@3.2.6, debug@3.X, debug@^3.0.0, debug@^3.1.0, debug@^3.2.6:
   dependencies:
     ms "^2.1.1"
 
-debug@4, debug@^4.0.0, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@^4.2.0, debug@^4.3.1, debug@^4.3.2, debug@~4.3.1, debug@~4.3.2:
+debug@4, debug@^4.0.0, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@^4.2.0, debug@^4.3.1, debug@^4.3.2:
   version "4.3.2"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.2.tgz#f0a49c18ac8779e31d4a0c6029dfb76873c7428b"
   integrity sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==
@@ -10338,14 +10349,6 @@ ecc-jsbn@~0.1.1:
     jsbn "~0.1.0"
     safer-buffer "^2.1.0"
 
-ecurve@^1.0.0, ecurve@^1.0.3:
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/ecurve/-/ecurve-1.0.6.tgz#dfdabbb7149f8d8b78816be5a7d5b83fcf6de797"
-  integrity sha512-/BzEjNfiSuB7jIWKcS/z8FK9jNjmEWvUV2YZ4RLSmcDtP7Lq0m6FvDuSnJpBlDpGRpfRQeTLGLBI8H+kEv0r+w==
-  dependencies:
-    bigi "^1.1.0"
-    safe-buffer "^5.0.1"
-
 ee-first@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
@@ -10492,21 +10495,6 @@ engine.io-client@~3.5.0:
     xmlhttprequest-ssl "~1.5.4"
     yeast "0.1.2"
 
-engine.io-client@~6.0.1:
-  version "6.0.2"
-  resolved "https://registry.yarnpkg.com/engine.io-client/-/engine.io-client-6.0.2.tgz#ccfc059051e65ca63845e65929184757754cc34e"
-  integrity sha512-cAep9lhZV6Q8jMXx3TNSU5cydMzMed8/O7Tz5uzyqZvpNPtQ3WQXrLYGADxlsuaFmOLN7wZLmT7ImiFhUOku8g==
-  dependencies:
-    "@socket.io/component-emitter" "~3.0.0"
-    debug "~4.3.1"
-    engine.io-parser "~5.0.0"
-    has-cors "1.1.0"
-    parseqs "0.0.6"
-    parseuri "0.0.6"
-    ws "~8.2.3"
-    xmlhttprequest-ssl "~2.0.0"
-    yeast "0.1.2"
-
 engine.io-parser@~2.2.0:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/engine.io-parser/-/engine.io-parser-2.2.1.tgz#57ce5611d9370ee94f99641b589f94c97e4f5da7"
@@ -10517,13 +10505,6 @@ engine.io-parser@~2.2.0:
     base64-arraybuffer "0.1.4"
     blob "0.0.5"
     has-binary2 "~1.0.2"
-
-engine.io-parser@~5.0.0:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/engine.io-parser/-/engine.io-parser-5.0.1.tgz#6695fc0f1e6d76ad4a48300ff80db5f6b3654939"
-  integrity sha512-j4p3WwJrG2k92VISM0op7wiq60vO92MlF3CRGxhKHy9ywG1/Dkc72g0dXeDQ+//hrcDn8gqQzoEkdO9FN0d9AA==
-  dependencies:
-    base64-arraybuffer "~1.0.1"
 
 engine.io@~3.5.0:
   version "3.5.0"
@@ -11509,15 +11490,15 @@ eth-simple-keyring@^4.2.0:
     ethereumjs-wallet "^1.0.1"
     events "^1.1.1"
 
-eth-trezor-keyring@^0.9.0:
-  version "0.9.0"
-  resolved "https://registry.yarnpkg.com/eth-trezor-keyring/-/eth-trezor-keyring-0.9.0.tgz#06b0f2f4c072651c0944a0dfbfa7b2b0c9987433"
-  integrity sha512-Rg9XUiYIOs7Ulz0ODc/udouM7276fCQhTnYhJC9OJTWrz6U5tAkdqnmTsZNMS2sdMWzuFhGz0+pQz9yTIryGQA==
+eth-trezor-keyring@^0.9.1:
+  version "0.9.1"
+  resolved "https://registry.yarnpkg.com/eth-trezor-keyring/-/eth-trezor-keyring-0.9.1.tgz#10d78308c71966eadf94acc8acf7f7136311f31f"
+  integrity sha512-27k4pjHFG6z5F1dhpTfORONgtAPrF0BR+Qr+ygjYrjchmERJKkrgyqnJqkSGtHF6+XrgI8pKYiDTjo6CBPHVKw==
   dependencies:
     "@ethereumjs/tx" "^3.2.1"
     ethereumjs-util "^7.0.9"
     hdkey "0.8.0"
-    trezor-connect "8.2.1-extended"
+    trezor-connect "8.2.3-extended"
 
 eth-tx-summary@^3.1.2:
   version "3.2.4"
@@ -14396,17 +14377,6 @@ hastscript@^6.0.0:
     property-information "^5.0.0"
     space-separated-tokens "^1.0.0"
 
-hd-wallet@9.1.2:
-  version "9.1.2"
-  resolved "https://registry.yarnpkg.com/hd-wallet/-/hd-wallet-9.1.2.tgz#510f35ffb6666d0af7472d5b2c6580c32a85b36e"
-  integrity sha512-IkjLUqAI4kkkVUP9I1caCTdbaiQ1Ma0JbjoBzwL9RCc7/qHrYGh8Zu6b1xfTQNCMr0ctj3tzoXr2XDJ5wsOy1Q==
-  dependencies:
-    "@trezor/utxo-lib" "0.1.2"
-    bchaddrjs "^0.5.2"
-    bignumber.js "^9.0.1"
-    queue "^6.0.2"
-    socket.io-client "^4.1.2"
-
 hdkey@0.8.0:
   version "0.8.0"
   resolved "https://registry.yarnpkg.com/hdkey/-/hdkey-0.8.0.tgz#08c9a9fcb6a42d9724d669f81c53a3c507f87bf1"
@@ -14992,10 +14962,10 @@ insert-module-globals@^7.0.0, insert-module-globals@^7.2.1:
     undeclared-identifiers "^1.1.2"
     xtend "^4.0.0"
 
-int64-buffer@0.99.1007:
-  version "0.99.1007"
-  resolved "https://registry.yarnpkg.com/int64-buffer/-/int64-buffer-0.99.1007.tgz#211ea089a2fdb960070a2e77cd6d17dc456a5220"
-  integrity sha512-XDBEu44oSTqlvCSiOZ/0FoUkpWu/vwjJLGSKDabNISPQNZ5wub1FodGHBljRsrR0IXRPq7SslshZYMuA55CgTQ==
+int64-buffer@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/int64-buffer/-/int64-buffer-1.0.1.tgz#c78d841b444cadf036cd04f8683696c740f15dca"
+  integrity sha512-+3azY4pXrjAupJHU1V9uGERWlhoqNswJNji6aD/02xac7oxol508AsMC5lxKhEqyZeDFy3enq5OGWXF4u75hiw==
 
 interface-connection@~0.3.2, interface-connection@~0.3.3:
   version "0.3.3"
@@ -17367,7 +17337,7 @@ k-bucket@^5.0.0:
   dependencies:
     randombytes "^2.0.3"
 
-keccak@3.0.1, keccak@^3.0.0, keccak@^3.0.1:
+keccak@3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/keccak/-/keccak-3.0.1.tgz#ae30a0e94dbe43414f741375cff6d64c8bea0bff"
   integrity sha512-epq90L9jlFWCW7+pQa6JOnKn2Xgl2mtI664seYR6MHskvI9agt7AnDqmAlp9TqU4/caMYbA08Hi5DMZAl5zdkA==
@@ -17384,6 +17354,15 @@ keccak@^1.0.2:
     inherits "^2.0.3"
     nan "^2.2.1"
     safe-buffer "^5.1.0"
+
+keccak@^3.0.0, keccak@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/keccak/-/keccak-3.0.2.tgz#4c2c6e8c54e04f2670ee49fa734eb9da152206e0"
+  integrity sha512-PyKKjkH53wDMLGrvmRGSNWgmSxZOUqbnXwKL9tmgbFYA1iAYqW21kfR7mZXV0MlESiefxQQE9X9fTa3X+2MPDQ==
+  dependencies:
+    node-addon-api "^2.0.0"
+    node-gyp-build "^4.2.0"
+    readable-stream "^3.6.0"
 
 keccakjs@^0.2.1:
   version "0.2.3"
@@ -18700,10 +18679,10 @@ long@^4.0.0:
   resolved "https://registry.yarnpkg.com/long/-/long-4.0.0.tgz#9a7b71cfb7d361a194ea555241c92f7468d5bf28"
   integrity sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==
 
-"long@~2 >=2.2.3":
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/long/-/long-2.4.0.tgz#9fa180bb1d9500cdc29c4156766a1995e1f4524f"
-  integrity sha1-n6GAux2VAM3CnEFWdmoZleH0Uk8=
+long@~3:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/long/-/long-3.2.0.tgz#d821b7138ca1cb581c172990ef14db200b5c474b"
+  integrity sha1-2CG3E4yhy1gcFymQ7xTbIAtcR0s=
 
 longest-streak@^2.0.1:
   version "2.0.3"
@@ -19923,11 +19902,6 @@ nano-json-stream-parser@^0.1.2:
   resolved "https://registry.yarnpkg.com/nano-json-stream-parser/-/nano-json-stream-parser-0.1.2.tgz#0cc8f6d0e2b622b479c40d499c46d64b755c6f5f"
   integrity sha1-DMj20OK2IrR5xA1JnEbWS3Vcb18=
 
-nanoassert@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/nanoassert/-/nanoassert-1.1.0.tgz#4f3152e09540fde28c76f44b19bbcd1d5a42478d"
-  integrity sha1-TzFS4JVA/eKMdvRLGbvNHVpCR40=
-
 nanoid@^2.0.0, nanoid@^2.1.6:
   version "2.1.11"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-2.1.11.tgz#ec24b8a758d591561531b4176a01e3ab4f0f0280"
@@ -20101,7 +20075,7 @@ node-addon-api@^2.0.0:
   resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-2.0.2.tgz#432cfa82962ce494b132e9d72a15b29f71ff5d32"
   integrity sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA==
 
-node-addon-api@^3.0.2:
+node-addon-api@^3.0.0, node-addon-api@^3.0.2:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-3.2.1.tgz#81325e0a2117789c0128dab65e7e38f07ceba161"
   integrity sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A==
@@ -20149,7 +20123,7 @@ node-forge@^0.10.0, node-forge@^0.7.1, node-forge@^0.7.5, node-forge@~0.7.6:
   resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.10.0.tgz#32dea2afb3e9926f02ee5ce8794902691a676bf3"
   integrity sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==
 
-node-gyp-build@^4.2.0, node-gyp-build@^4.2.3, node-gyp-build@^4.3.0:
+node-gyp-build@^4.2.0, node-gyp-build@^4.2.2, node-gyp-build@^4.2.3, node-gyp-build@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/node-gyp-build/-/node-gyp-build-4.3.0.tgz#9f256b03e5826150be39c764bf51e993946d71a3"
   integrity sha512-iWjXZvmboq0ja1pUGULQBexmxq8CV4xBhX7VDOTbL7ZR4FOowwY/VOtRxBN/yKxmdGoIp4j5ysNT4u3S2pDQ3Q==
@@ -20713,7 +20687,7 @@ object.reduce@^1.0.0:
     for-own "^1.0.0"
     make-iterator "^1.0.0"
 
-object.values@^1.0.4, object.values@^1.1.0, object.values@^1.1.1, object.values@^1.1.2, object.values@^1.1.3:
+object.values@^1.0.4, object.values@^1.1.0, object.values@^1.1.1, object.values@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/object.values/-/object.values-1.1.3.tgz#eaa8b1e17589f02f698db093f7c62ee1699742ee"
   integrity sha512-nkF6PfDB9alkOUxpf1HNm/QlkeW3SReqL5WXeBLpEJJnlPSvRaDQpW3gQTksTN3fgJX4hL42RzKyOin6ff3tyw==
@@ -20848,11 +20822,6 @@ optionator@^0.9.1:
     prelude-ls "^1.2.1"
     type-check "^0.4.0"
     word-wrap "^1.2.3"
-
-optjs@latest:
-  version "3.2.2"
-  resolved "https://registry.yarnpkg.com/optjs/-/optjs-3.2.2.tgz#69a6ce89c442a44403141ad2f9b370bd5bb6f4ee"
-  integrity sha1-aabOicRCpEQDFBrS+bNwvVu29O4=
 
 orbit-db-access-controllers@^0.2.0, orbit-db-access-controllers@~0.2.0:
   version "0.2.2"
@@ -22595,13 +22564,24 @@ proto-list@~1.2.1:
   resolved "https://registry.yarnpkg.com/proto-list/-/proto-list-1.2.4.tgz#212d5bfe1318306a420f6402b8e26ff39647a849"
   integrity sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=
 
-protobufjs-old-fixed-webpack@3.8.5:
-  version "3.8.5"
-  resolved "https://registry.yarnpkg.com/protobufjs-old-fixed-webpack/-/protobufjs-old-fixed-webpack-3.8.5.tgz#5813c1af9f1d136bbf39f4f9f2e6f3e43c389d06"
-  integrity sha1-WBPBr58dE2u/OfT58ubz5Dw4nQY=
+protobufjs@^6.11.2:
+  version "6.11.2"
+  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-6.11.2.tgz#de39fabd4ed32beaa08e9bb1e30d08544c1edf8b"
+  integrity sha512-4BQJoPooKJl2G9j3XftkIXjoC9C0Av2NOrWmbLWT1vH32GcSUHjM0Arra6UfTsVyfMAuFzaLucXn1sadxJydAw==
   dependencies:
-    ascli "~0.3"
-    bytebuffer-old-fixed-webpack "3.5.6"
+    "@protobufjs/aspromise" "^1.1.2"
+    "@protobufjs/base64" "^1.1.2"
+    "@protobufjs/codegen" "^2.0.4"
+    "@protobufjs/eventemitter" "^1.1.0"
+    "@protobufjs/fetch" "^1.1.0"
+    "@protobufjs/float" "^1.0.2"
+    "@protobufjs/inquire" "^1.1.0"
+    "@protobufjs/path" "^1.1.2"
+    "@protobufjs/pool" "^1.1.0"
+    "@protobufjs/utf8" "^1.1.0"
+    "@types/long" "^4.0.1"
+    "@types/node" ">=13.7.0"
+    long "^4.0.0"
 
 protocol-buffers-schema@^3.3.1:
   version "3.3.2"
@@ -23032,13 +23012,6 @@ querystring@0.2.0, querystring@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
   integrity sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=
-
-queue@^6.0.2:
-  version "6.0.2"
-  resolved "https://registry.yarnpkg.com/queue/-/queue-6.0.2.tgz#b91525283e2315c7553d2efa18d83e76432fed65"
-  integrity sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==
-  dependencies:
-    inherits "~2.0.3"
 
 quick-format-unescaped@^3.0.2:
   version "3.0.2"
@@ -24887,7 +24860,7 @@ secp256k1@4.0.2, secp256k1@^4.0.0, secp256k1@^4.0.1:
     node-addon-api "^2.0.0"
     node-gyp-build "^4.2.0"
 
-secp256k1@^3.0.1, secp256k1@^3.5.2, secp256k1@^3.6.1, secp256k1@^3.6.2:
+secp256k1@^3.0.1, secp256k1@^3.6.1, secp256k1@^3.6.2:
   version "3.8.0"
   resolved "https://registry.yarnpkg.com/secp256k1/-/secp256k1-3.8.0.tgz#28f59f4b01dbee9575f56a47034b7d2e3b3b352d"
   integrity sha512-k5ke5avRZbtl9Tqx/SA7CbY3NF6Ro+Sj9cZxezFzuBlLDmyqPiL8hJJ+EmzD8Ig4LUDByHJ3/iPOVoRixs/hmw==
@@ -25412,18 +25385,6 @@ socket.io-client@2.4.0, socket.io-client@^2.1.1:
     socket.io-parser "~3.3.0"
     to-array "0.1.4"
 
-socket.io-client@^4.1.2:
-  version "4.3.2"
-  resolved "https://registry.yarnpkg.com/socket.io-client/-/socket.io-client-4.3.2.tgz#9cfdb8fecac8a24d5723daf8c8749e70c8fdeb25"
-  integrity sha512-2B9LqSunN60yV8F7S84CCEEcgbYNfrn7ejIInZtLZ7ppWtiX8rGZAjvdCvbnC8bqo/9RlCNOUsORLyskxSFP1g==
-  dependencies:
-    "@socket.io/component-emitter" "~3.0.0"
-    backo2 "~1.0.2"
-    debug "~4.3.2"
-    engine.io-client "~6.0.1"
-    parseuri "0.0.6"
-    socket.io-parser "~4.1.1"
-
 socket.io-parser@~3.3.0:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/socket.io-parser/-/socket.io-parser-3.3.2.tgz#ef872009d0adcf704f2fbe830191a14752ad50b6"
@@ -25441,14 +25402,6 @@ socket.io-parser@~3.4.0:
     component-emitter "1.2.1"
     debug "~4.1.0"
     isarray "2.0.1"
-
-socket.io-parser@~4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/socket.io-parser/-/socket.io-parser-4.1.1.tgz#0ad53d980781cab1eabe320417d8480c0133e62d"
-  integrity sha512-USQVLSkDWE5nbcY760ExdKaJxCE65kcsG/8k5FDGZVVxpD1pA7hABYXYkCUvxUuYYh/+uQw0N/fvBzfT8o07KA==
-  dependencies:
-    "@socket.io/component-emitter" "~3.0.0"
-    debug "~4.3.1"
 
 socket.io-pull-stream@~0.1.5:
   version "0.1.5"
@@ -26878,10 +26831,10 @@ tiny-queue@0.2.0:
   resolved "https://registry.yarnpkg.com/tiny-queue/-/tiny-queue-0.2.0.tgz#c49fcb5c87555be1b4a5df7eb87101d5b78bc9dc"
   integrity sha1-xJ/LXIdVW+G0pd9+uHEB1beLydw=
 
-tiny-secp256k1@^1.1.0, tiny-secp256k1@^1.1.1:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/tiny-secp256k1/-/tiny-secp256k1-1.1.3.tgz#e93b1e1bf62e9bd1ad3ab24af27ff6127ce0e077"
-  integrity sha512-ZpobrhOtHP98VYEN51IYQH1YcrbFpnxFhI6ceWa3OEbJn7eHvSd8YFjGPxbedGCy7PNYU1v/+BRsdvyr5uRd4g==
+tiny-secp256k1@^1.1.0, tiny-secp256k1@^1.1.1, tiny-secp256k1@^1.1.6:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/tiny-secp256k1/-/tiny-secp256k1-1.1.6.tgz#7e224d2bee8ab8283f284e40e6b4acb74ffe047c"
+  integrity sha512-FmqJZGduTyvsr2cF3375fqGHUovSwDi/QytexX1Se4BPuPZpTE5Ftp5fg+EFSuEf3lhZqgCRjEG3ydUQ/aNiwA==
   dependencies:
     bindings "^1.3.0"
     bn.js "^4.11.8"
@@ -27063,42 +27016,36 @@ tree-kill@^1.2.2:
   resolved "https://registry.yarnpkg.com/tree-kill/-/tree-kill-1.2.2.tgz#4ca09a9092c88b73a7cdc5e8a01b507b0790a0cc"
   integrity sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==
 
-trezor-connect@8.2.1-extended:
-  version "8.2.1-extended"
-  resolved "https://registry.yarnpkg.com/trezor-connect/-/trezor-connect-8.2.1-extended.tgz#83f4f28bdaf6253c87c59dfb77b769823428da2d"
-  integrity sha512-U5OKXG2MBrKEvAEyloDYyqpWZpg5nvZrjE3RsAO/Slmk0ZI22VZZbKAiCbQZsAv2s5OV6PNn4uVyPmUztnS6uQ==
+trezor-connect@8.2.3-extended:
+  version "8.2.3-extended"
+  resolved "https://registry.yarnpkg.com/trezor-connect/-/trezor-connect-8.2.3-extended.tgz#597e985bacd9ebc0ab61b031fffc21c96515546e"
+  integrity sha512-nGgkvE25rKW7SQaz5hOo5hgsx8US0L1piTWu5WFzC5PIz6R+yCyN+SeSeKlYRJ7t9VdzTC77cYu3fklxJHJzCA==
   dependencies:
-    "@babel/runtime" "^7.12.5"
+    "@babel/runtime" "^7.15.4"
     "@trezor/blockchain-link" "^1.0.17"
-    "@trezor/connect-common" "^0.0.2"
+    "@trezor/connect-common" "^0.0.3"
     "@trezor/rollout" "^1.2.0"
-    "@trezor/utxo-lib" "^0.1.2"
-    bchaddrjs "^0.5.2"
+    "@trezor/utxo-lib" "1.0.0-beta.10"
     bignumber.js "^9.0.1"
     bowser "^2.11.0"
     cbor-web "^7.0.6"
-    events "^3.2.0"
-    hd-wallet "9.1.2"
-    keccak "^3.0.1"
+    events "^3.3.0"
+    keccak "^3.0.2"
     node-fetch "^2.6.1"
     parse-uri "^1.0.3"
     tiny-worker "^2.3.0"
-    trezor-link "1.7.3"
-    whatwg-fetch "^3.5.0"
+    trezor-link "2.0.0-beta.6"
+    whatwg-fetch "^3.6.2"
 
-trezor-link@1.7.3:
-  version "1.7.3"
-  resolved "https://registry.yarnpkg.com/trezor-link/-/trezor-link-1.7.3.tgz#33c4b558913a3da395243018c04ee1804affcdc3"
-  integrity sha512-KaVYcK96BLD+cBuYmJmsxr6G9Z0ZeO6VYPhcYQyFxJ7jvc6/UvTmdACZdHjlUD7U5VuJEGMI4G8L3IGxFTFv4Q==
+trezor-link@2.0.0-beta.6:
+  version "2.0.0-beta.6"
+  resolved "https://registry.yarnpkg.com/trezor-link/-/trezor-link-2.0.0-beta.6.tgz#e727890a539ee1b6ff109a0227c38328d42d95c7"
+  integrity sha512-DwmbKV434Vx7RmuPxcZzABTLFK5n5mZ+5+UjQ8tA0lLx41NstRJ+/OKO0b8qMJOv1ZnoQ87dfu5LtI7o9EXKuw==
   dependencies:
-    bigi "^1.4.1"
-    ecurve "^1.0.3"
+    bytebuffer "^5.0.1"
     json-stable-stringify "^1.0.1"
-    node-fetch "^2.6.1"
-    object.values "^1.1.2"
-    protobufjs-old-fixed-webpack "3.8.5"
-    semver-compare "^1.0.0"
-    whatwg-fetch "^3.5.0"
+    long "^4.0.0"
+    protobufjs "^6.11.2"
 
 trim-newlines@^3.0.0:
   version "3.0.1"
@@ -27310,7 +27257,7 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typeforce@^1.11.3, typeforce@^1.11.5:
+typeforce@^1.11.3, typeforce@^1.11.5, typeforce@^1.18.0:
   version "1.18.0"
   resolved "https://registry.yarnpkg.com/typeforce/-/typeforce-1.18.0.tgz#d7416a2c5845e085034d70fcc5b6cc4a90edbfdc"
   integrity sha512-7uc1O8h1M1g0rArakJdf0uLRSSgFcYexrVoKo+bzJd32gd4gDy2L/Z+8/FjPnU9ydY3pEnVPtr9FyscYY60K1g==
@@ -27982,10 +27929,10 @@ varint@^6.0.0:
   resolved "https://registry.yarnpkg.com/varint/-/varint-6.0.0.tgz#9881eb0ce8feaea6512439d19ddf84bf551661d0"
   integrity sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg==
 
-varuint-bitcoin@^1.0.4:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/varuint-bitcoin/-/varuint-bitcoin-1.1.0.tgz#7a343f50537607af6a3059312b9782a170894540"
-  integrity sha512-jCEPG+COU/1Rp84neKTyDJQr478/hAfVp5xxYn09QEH0yBjbmPeMfuuQIrp+BUD83hybtYZKhr5elV3bvdV1bA==
+varuint-bitcoin@^1.0.4, varuint-bitcoin@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/varuint-bitcoin/-/varuint-bitcoin-1.1.2.tgz#e76c138249d06138b480d4c5b40ef53693e24e92"
+  integrity sha512-4EVb+w4rx+YfVM32HQX42AbbT7/1f5zwAYhIujKXKk8NQK+JfRVl3pqT3hjNn/L+RstigmGGKVwHA/P0wgITZw==
   dependencies:
     safe-buffer "^5.1.1"
 
@@ -28698,10 +28645,10 @@ whatwg-fetch@2.0.4:
   resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz#dde6a5df315f9d39991aa17621853d720b85566f"
   integrity sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng==
 
-whatwg-fetch@^3.4.1, whatwg-fetch@^3.5.0:
-  version "3.5.0"
-  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.5.0.tgz#605a2cd0a7146e5db141e29d1c62ab84c0c4c868"
-  integrity sha512-jXkLtsR42xhXg7akoDKvKWE40eJeI+2KZqcp2h3NsOrRnDvtWX36KcKl30dy+hxECivdk2BVUHVNrPtoMBUx6A==
+whatwg-fetch@^3.4.1, whatwg-fetch@^3.6.2:
+  version "3.6.2"
+  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz#dced24f37f2624ed0281725d51d0e2e3fe677f8c"
+  integrity sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA==
 
 whatwg-mimetype@^2.3.0:
   version "2.3.0"
@@ -28918,7 +28865,7 @@ write@^0.2.1:
   dependencies:
     mkdirp "^0.5.1"
 
-ws@7.1.0, ws@7.4.6, ws@>=7.4.6, ws@^1.1.0, ws@^3.0.0, ws@^5.1.1, ws@^7, ws@^7.2.0, ws@^7.4.0, ws@^7.4.6, ws@~7.4.2, ws@~8.2.3:
+ws@7.1.0, ws@7.4.6, ws@>=7.4.6, ws@^1.1.0, ws@^3.0.0, ws@^5.1.1, ws@^7, ws@^7.2.0, ws@^7.4.0, ws@^7.4.6, ws@~7.4.2:
   version "7.4.6"
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.4.6.tgz#5654ca8ecdeee47c33a9a4bf6d28e2be2980377c"
   integrity sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==
@@ -28985,7 +28932,7 @@ xmlchars@^2.2.0:
   resolved "https://registry.yarnpkg.com/xmlchars/-/xmlchars-2.2.0.tgz#060fe1bcb7f9c76fe2a17db86a9bc3ab894210cb"
   integrity sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==
 
-xmlhttprequest-ssl@^1.6.2, xmlhttprequest-ssl@~1.5.4, xmlhttprequest-ssl@~2.0.0:
+xmlhttprequest-ssl@^1.6.2, xmlhttprequest-ssl@~1.5.4:
   version "1.6.2"
   resolved "https://registry.yarnpkg.com/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.6.2.tgz#dd6899bfbcf684b554e393c30b13b9f3b001a7ee"
   integrity sha512-tYOaldF/0BLfKuoA39QMwD4j2m8lq4DIncqj1yuNELX4vz9+z/ieG/vwmctjJce+boFHXstqhWnHSxc4W8f4qg==


### PR DESCRIPTION
This PR brings in the version of eth-trezor-keyring (and thereby trezor-connect) that allows EIP-1559 transactions to work on the Trezor Model One.

I will prepare a proper PR later today to remove all dead code, and make the associated changes in the controllers repo, but in the interest of unblocking v10.8.0 I am doing this the most simple way possible right now