### PR TITLE
Add `@metamask/rpc-methods` package

### DIFF
--- a/app/scripts/lib/rpc-method-middleware/createMethodMiddleware.js
+++ b/app/scripts/lib/rpc-method-middleware/createMethodMiddleware.js
@@ -1,4 +1,5 @@
 import { permissionRpcMethods } from '@metamask/snap-controllers';
+import { selectHooks } from '@metamask/rpc-methods';
 import { ethErrors } from 'eth-rpc-errors';
 import { UNSUPPORTED_RPC_METHODS } from '../../../../shared/constants/network';
 import localHandlers from './handlers';
@@ -48,24 +49,4 @@ export default function createMethodMiddleware(hooks) {
 
     return next();
   };
-}
-
-/**
- * Returns the subset of the specified `hooks` that are included in the
- * `hookNames` object. This is a Principle of Least Authority (POLA) measure
- * to ensure that each RPC method implementation only has access to the
- * API "hooks" it needs to do its job.
- *
- * @param {Record<string, unknown>} hooks - The hooks to select from.
- * @param {Record<string, true>} hookNames - The names of the hooks to select.
- * @returns {Record<string, unknown> | undefined} The selected hooks.
- */
-function selectHooks(hooks, hookNames) {
-  if (hookNames) {
-    return Object.keys(hookNames).reduce((hookSubset, hookName) => {
-      hookSubset[hookName] = hooks[hookName];
-      return hookSubset;
-    }, {});
-  }
-  return undefined;
 }

--- a/lavamoat/browserify/beta/policy.json
+++ b/lavamoat/browserify/beta/policy.json
@@ -625,6 +625,16 @@
         "mersenne-twister": true
       }
     },
+    "@metamask/key-tree": {
+      "packages": {
+        "bip39": true,
+        "buffer": true,
+        "crypto-browserify": true,
+        "is-buffer": true,
+        "keccak": true,
+        "secp256k1": true
+      }
+    },
     "@metamask/logo": {
       "globals": {
         "addEventListener": true,
@@ -669,6 +679,13 @@
       },
       "packages": {
         "readable-stream": true
+      }
+    },
+    "@metamask/rpc-methods": {
+      "packages": {
+        "@metamask/key-tree": true,
+        "@metamask/snap-controllers": true,
+        "eth-rpc-errors": true
       }
     },
     "@metamask/safe-event-emitter": {
@@ -1115,6 +1132,7 @@
     },
     "bip39": {
       "packages": {
+        "buffer": true,
         "create-hash": true,
         "pbkdf2": true,
         "randombytes": true,

--- a/lavamoat/browserify/flask/policy.json
+++ b/lavamoat/browserify/flask/policy.json
@@ -625,6 +625,16 @@
         "mersenne-twister": true
       }
     },
+    "@metamask/key-tree": {
+      "packages": {
+        "bip39": true,
+        "buffer": true,
+        "crypto-browserify": true,
+        "is-buffer": true,
+        "keccak": true,
+        "secp256k1": true
+      }
+    },
     "@metamask/logo": {
       "globals": {
         "addEventListener": true,
@@ -669,6 +679,13 @@
       },
       "packages": {
         "readable-stream": true
+      }
+    },
+    "@metamask/rpc-methods": {
+      "packages": {
+        "@metamask/key-tree": true,
+        "@metamask/snap-controllers": true,
+        "eth-rpc-errors": true
       }
     },
     "@metamask/safe-event-emitter": {
@@ -1115,6 +1132,7 @@
     },
     "bip39": {
       "packages": {
+        "buffer": true,
         "create-hash": true,
         "pbkdf2": true,
         "randombytes": true,

--- a/lavamoat/browserify/main/policy.json
+++ b/lavamoat/browserify/main/policy.json
@@ -625,6 +625,16 @@
         "mersenne-twister": true
       }
     },
+    "@metamask/key-tree": {
+      "packages": {
+        "bip39": true,
+        "buffer": true,
+        "crypto-browserify": true,
+        "is-buffer": true,
+        "keccak": true,
+        "secp256k1": true
+      }
+    },
     "@metamask/logo": {
       "globals": {
         "addEventListener": true,
@@ -669,6 +679,13 @@
       },
       "packages": {
         "readable-stream": true
+      }
+    },
+    "@metamask/rpc-methods": {
+      "packages": {
+        "@metamask/key-tree": true,
+        "@metamask/snap-controllers": true,
+        "eth-rpc-errors": true
       }
     },
     "@metamask/safe-event-emitter": {
@@ -1115,6 +1132,7 @@
     },
     "bip39": {
       "packages": {
+        "buffer": true,
         "create-hash": true,
         "pbkdf2": true,
         "randombytes": true,

--- a/package.json
+++ b/package.json
@@ -116,6 +116,7 @@
     "@metamask/obs-store": "^5.0.0",
     "@metamask/post-message-stream": "^4.0.0",
     "@metamask/providers": "^8.1.1",
+    "@metamask/rpc-methods": "^0.5.0",
     "@metamask/snap-controllers": "^0.4.0",
     "@ngraveio/bc-ur": "^1.1.6",
     "@popperjs/core": "^2.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2742,6 +2742,15 @@
     color "^0.11.3"
     mersenne-twister "^1.1.0"
 
+"@metamask/key-tree@^3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@metamask/key-tree/-/key-tree-3.0.1.tgz#e59b6c9c124c74382477f51a389815e849a16de7"
+  integrity sha512-CcpbQua96/CF+KKItrfw9Y6azrlkzFhoVAkyfUl7iq5qldA8xi4CilNjzIqnK8YJcLU44d7nRs5i5/9atY4Beg==
+  dependencies:
+    bip39 "^3.0.4"
+    keccak "^3.0.2"
+    secp256k1 "^4.0.2"
+
 "@metamask/logo@^3.1.1":
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/@metamask/logo/-/logo-3.1.1.tgz#0a40bcfc462a70aa2110efc737767ca7ba188fa3"
@@ -2810,6 +2819,15 @@
     pump "^3.0.0"
     webextension-polyfill-ts "^0.25.0"
 
+"@metamask/rpc-methods@^0.5.0":
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/@metamask/rpc-methods/-/rpc-methods-0.5.0.tgz#3c0073d80e68eceb8b9fa19bea0b2daef8638a42"
+  integrity sha512-OFGd4T20dYTYxdB8WK0xa6FXRaNmJR5mAS7Wp7+6n8rqKljKJ0jDyfpGia1YKI6gKsB7Xdn5efnWxviuF/XQXQ==
+  dependencies:
+    "@metamask/key-tree" "^3.0.1"
+    "@metamask/snap-controllers" "^0.5.0"
+    eth-rpc-errors "^4.0.2"
+
 "@metamask/safe-event-emitter@^2.0.0":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@metamask/safe-event-emitter/-/safe-event-emitter-2.0.0.tgz#af577b477c683fad17c619a78208cede06f9605c"
@@ -2836,10 +2854,36 @@
     nanoid "^3.1.28"
     pump "^3.0.0"
 
+"@metamask/snap-controllers@^0.5.0":
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/@metamask/snap-controllers/-/snap-controllers-0.5.0.tgz#a77563ea7bea0ba7c6fd73059f9ecbf86be16fd4"
+  integrity sha512-eKuKQh17LrHfkpk8T5J87jg4TTmnoG65JpPHgpV+GLyohF4CMEtyK6uJYoPcm5c3z7IArcYbuucc1bqLbz9JoA==
+  dependencies:
+    "@metamask/controllers" "^17.0.0"
+    "@metamask/object-multiplex" "^1.1.0"
+    "@metamask/obs-store" "^7.0.0"
+    "@metamask/post-message-stream" "4.0.0"
+    "@metamask/safe-event-emitter" "^2.0.0"
+    "@metamask/snap-workers" "^0.5.0"
+    "@types/deep-freeze-strict" "^1.1.0"
+    deep-freeze-strict "^1.1.1"
+    eth-rpc-errors "^4.0.2"
+    fast-deep-equal "^3.1.3"
+    immer "^9.0.6"
+    json-rpc-engine "^6.1.0"
+    json-rpc-middleware-stream "^3.0.0"
+    nanoid "^3.1.28"
+    pump "^3.0.0"
+
 "@metamask/snap-workers@^0.4.0":
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/@metamask/snap-workers/-/snap-workers-0.4.0.tgz#ba561eb15a7b7e7b353738ad5635a68c03cf64b0"
   integrity sha512-usPEnwRXIwaDc06f8Jis4/CxXzmZJpPOLucOMqkxGAAz3hepA/T5fbfus12sibo5h6QsG0VTqBQ5AqKFlTr0zQ==
+
+"@metamask/snap-workers@^0.5.0":
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/@metamask/snap-workers/-/snap-workers-0.5.0.tgz#9f1b8243f64819e40d66e659d580b6da59cb8015"
+  integrity sha512-sR30/nmkndPeLox282BdTNnU3g6Mo5Gt8rdr6PUSyfosbwrYtrbZcXFqR+ozK/gNhJ3de7hpjLXKNkVSF8OjOQ==
 
 "@metamask/test-dapp@^4.0.1":
   version "4.0.1"
@@ -4360,6 +4404,11 @@
   version "10.12.18"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.12.18.tgz#1d3ca764718915584fcd9f6344621b7672665c67"
   integrity sha512-fh+pAqt4xRzPfqA6eh3Z2y6fyZavRIumvjhaCL753+TVkGKGhpPeyrJG2JftD0T9q4GF00KjefsQ+PQNDdWQaQ==
+
+"@types/node@11.11.6":
+  version "11.11.6"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-11.11.6.tgz#df929d1bb2eee5afdda598a41930fe50b43eaa6a"
+  integrity sha512-Exw4yUWMBXM3X+8oqzJNRqZSwUAaS4+7NdvHqQuFi/d+synz++xmX3QIf+BFqneW8N31R8Ky+sikfZUXq07ggQ==
 
 "@types/node@^12.0.12", "@types/node@^12.12.6":
   version "12.19.15"
@@ -6962,6 +7011,16 @@ bip39@2.5.0, bip39@^2.2.0, bip39@^2.4.0:
     randombytes "^2.0.1"
     safe-buffer "^5.0.1"
     unorm "^1.3.3"
+
+bip39@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/bip39/-/bip39-3.0.4.tgz#5b11fed966840b5e1b8539f0f54ab6392969b2a0"
+  integrity sha512-YZKQlb752TrUWqHWj7XAwCSjYEgGAk+/Aas3V7NyjQeZYsztO8JnQUaCWhcnL4T+jL8nvB8typ2jRPzTlgugNw==
+  dependencies:
+    "@types/node" "11.11.6"
+    create-hash "^1.1.0"
+    pbkdf2 "^3.0.9"
+    randombytes "^2.0.1"
 
 bip66@^1.1.0, bip66@^1.1.5:
   version "1.1.5"
@@ -24851,7 +24910,7 @@ scss-parser@^1.0.4:
   dependencies:
     invariant "2.2.4"
 
-secp256k1@4.0.2, secp256k1@^4.0.0, secp256k1@^4.0.1:
+secp256k1@4.0.2, secp256k1@^4.0.0, secp256k1@^4.0.1, secp256k1@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/secp256k1/-/secp256k1-4.0.2.tgz#15dd57d0f0b9fdb54ac1fa1694f40e5e9a54f4a1"
   integrity sha512-UDar4sKvWAksIlfX3xIaQReADn+WFnHvbVujpcbr+9Sf/69odMwy2MUsz5CKLQgX9nsIyrjuxL2imVyoNHa3fg==


### PR DESCRIPTION
The `selectHooks` function has been replaced with the equivalent function from the `@metamask/rpc-methods` package, which is functionally equivalent.

The function was included in that package so that it could be used elsewhere in the `snaps-skunkworks` repo. Eventually the goal is to migrate much of our RPC logic into this package so that it can be shared across products, and by our libraries as needed.

Manual testing steps:  
  - This should include no functional changes