### PR TITLE
Storybook: Fixing font paths for storybook CI builds and storybook github page

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -30,7 +30,6 @@ module.exports = {
             url: false,
           },
         },
-        'resolve-url-loader',
         {
           loader: 'sass-loader',
           options: {

--- a/ui/css/design-system/typography.scss
+++ b/ui/css/design-system/typography.scss
@@ -1,4 +1,4 @@
-$fa-font-path: '/fonts/fontawesome';
+$fa-font-path: 'fonts/fontawesome';
 
 @import '../../../node_modules/@fortawesome/fontawesome-free/scss/fontawesome';
 @import '../../../node_modules/@fortawesome/fontawesome-free/scss/brands';
@@ -9,63 +9,63 @@ $fa-font-path: '/fonts/fontawesome';
   font-family: 'Roboto';
   font-style: normal;
   font-weight: 100;
-  src: local('Roboto Thin'), local('Roboto-Thin'), url('/fonts/Roboto/Roboto-Thin.ttf') format('truetype');
+  src: local('Roboto Thin'), local('Roboto-Thin'), url('fonts/Roboto/Roboto-Thin.ttf') format('truetype');
 }
 
 @font-face {
   font-family: 'Roboto';
   font-style: normal;
   font-weight: 300;
-  src: local('Roboto Light'), local('Roboto-Light'), url('/fonts/Roboto/Roboto-Light.ttf') format('truetype');
+  src: local('Roboto Light'), local('Roboto-Light'), url('fonts/Roboto/Roboto-Light.ttf') format('truetype');
 }
 
 @font-face {
   font-family: 'Roboto';
   font-style: normal;
   font-weight: 400;
-  src: local('Roboto'), local('Roboto-Regular'), url('/fonts/Roboto/Roboto-Regular.ttf') format('truetype');
+  src: local('Roboto'), local('Roboto-Regular'), url('fonts/Roboto/Roboto-Regular.ttf') format('truetype');
 }
 
 @font-face {
   font-family: 'Roboto';
   font-style: normal;
   font-weight: 500;
-  src: local('Roboto Medium'), local('Roboto-Medium'), url('/fonts/Roboto/Roboto-Medium.ttf') format('truetype');
+  src: local('Roboto Medium'), local('Roboto-Medium'), url('fonts/Roboto/Roboto-Medium.ttf') format('truetype');
 }
 
 @font-face {
   font-family: 'Roboto';
   font-style: normal;
   font-weight: 700;
-  src: local('Roboto Bold'), local('Roboto-Bold'), url('/fonts/Roboto/Roboto-Bold.ttf') format('truetype');
+  src: local('Roboto Bold'), local('Roboto-Bold'), url('fonts/Roboto/Roboto-Bold.ttf') format('truetype');
 }
 
 @font-face {
   font-family: 'Roboto';
   font-style: normal;
   font-weight: 900;
-  src: local('Roboto Black'), local('Roboto-Black'), url('/fonts/Roboto/Roboto-Black.ttf') format('truetype');
+  src: local('Roboto Black'), local('Roboto-Black'), url('fonts/Roboto/Roboto-Black.ttf') format('truetype');
 }
 
 @font-face {
   font-family: 'Euclid';
   font-style: normal;
   font-weight: 400;
-  src: url('/fonts/Euclid/EuclidCircularB-Regular-WebXL.ttf') format('truetype');
+  src: url('fonts/Euclid/EuclidCircularB-Regular-WebXL.ttf') format('truetype');
 }
 
 @font-face {
   font-family: 'Euclid';
   font-style: italic;
   font-weight: 400;
-  src: url('/fonts/Euclid/EuclidCircularB-RegularItalic-WebXL.ttf') format('truetype');
+  src: url('fonts/Euclid/EuclidCircularB-RegularItalic-WebXL.ttf') format('truetype');
 }
 
 @font-face {
   font-family: 'Euclid';
   font-style: normal;
   font-weight: 700;
-  src: url('/fonts/Euclid/EuclidCircularB-Bold-WebXL.ttf') format('truetype');
+  src: url('fonts/Euclid/EuclidCircularB-Bold-WebXL.ttf') format('truetype');
 }
 
 $font-family: Euclid, Roboto, Helvetica, Arial, sans-serif;


### PR DESCRIPTION
Fixes: #12863

Explanation: Fixes font paths in storybook for CI builds and storybook github page by removing [`resolve-url-loader`](https://github.com/bholloway/resolve-url-loader) and changing @font-face imports from absolute paths to relative paths. This will greatly improve UI reviews so devs can share CI build storybook links with designers ensuring UI has the correct fonts displayed. [Related conversation in previous PR](https://github.com/MetaMask/metamask-extension/pull/10209#discussion_r561343595)

> To be fair I'm not sure how to ensure this fix will work on the storybook github page but I assume it will if it's working on the CI builds because they have a similar URL strucutre.

Manual testing steps:

- Go to latest CI build of storybook
- See that brand fonts are working compared to current builds or the [storybook gihtub page](https://metamask.github.io/metamask-storybook/index.html)
- Run `yarn start` check fonts are still working locally

Checks that:
1. Euclid and Roboto fonts work
2. fontawesome fonts work
3. images and other static assets work in storybook
4. Sass imports are still working in storybook

- [x] Works in CI builds of storybook
- [x] Works in local storybook `yarn storybook`
- [x] Works in local builds of the extension

### Images

**Local Storybook**

<img width="1440" alt="Screen Shot 2021-12-14 at 6 50 37 AM" src="https://user-images.githubusercontent.com/8112138/145863097-4a08c6dd-5cad-4118-b00d-9f22ed34ff74.png">
<img width="1440" alt="Screen Shot 2021-12-14 at 6 51 20 AM" src="https://user-images.githubusercontent.com/8112138/145863127-1c831027-fc99-4492-810a-2589a4f9e25f.png">


**CI builds storybook**

<img width="1440" alt="Screen Shot 2021-12-14 at 6 39 57 AM" src="https://user-images.githubusercontent.com/8112138/145861688-2174bedc-7081-4cb4-b1d4-36b434c47f2a.png">
<img width="1440" alt="Screen Shot 2021-12-14 at 6 40 45 AM" src="https://user-images.githubusercontent.com/8112138/145861702-8b999c3f-37d8-47fb-bb4a-a69a375baa29.png">
<img width="1440" alt="Screen Shot 2021-12-14 at 6 48 54 AM" src="https://user-images.githubusercontent.com/8112138/145862839-e502ea67-a863-4023-a9ec-06f69a5bdf4c.png">


**Local dev build of extension**
<img width="1440" alt="Screen Shot 2021-12-14 at 6 42 38 AM" src="https://user-images.githubusercontent.com/8112138/145862300-d6ec3495-0e6d-4f28-8b25-ee67b15bcd12.png">


**react-gallery carousel.css.min stylesheet is an existing issue will fix in another PR**
<img width="1440" alt="Screen Shot 2021-12-14 at 6 44 19 AM" src="https://user-images.githubusercontent.com/8112138/145862238-291513d4-2f2d-4f66-b604-3e13ee375dd2.png">
