### PR TITLE
Wire up stability slider in new 'edit gas fee' modal

### DIFF
--- a/ui/components/app/edit-gas-fee-popover/network-statistics/status-slider/index.scss
+++ b/ui/components/app/edit-gas-fee-popover/network-statistics/status-slider/index.scss
@@ -1,7 +1,6 @@
 .status-slider {
   display: flex;
   flex-direction: column;
-  align-items: center;
   justify-content: center;
   width: 56px;
 
@@ -17,6 +16,12 @@
     font-size: 10px;
     font-weight: bold;
     margin-top: 4px;
+    text-align: center;
+  }
+
+  &__arrow-container {
+    margin-left: -10px;
+    width: 100%;
   }
 
   &__arrow-border {

--- a/ui/components/app/edit-gas-fee-popover/network-statistics/tooltips.js
+++ b/ui/components/app/edit-gas-fee-popover/network-statistics/tooltips.js
@@ -57,7 +57,7 @@ PriorityFeeTooltip.propTypes = {
   children: PropTypes.node.isRequired,
 };
 
-export const NetworkStabilityTooltip = ({ children, statusInfo }) => {
+export const NetworkStabilityTooltip = ({ children, color, tooltipLabel }) => {
   const t = useI18nContext();
 
   return (
@@ -66,9 +66,9 @@ export const NetworkStabilityTooltip = ({ children, statusInfo }) => {
         <strong
           key="network-status__tooltip"
           className="network-status__tooltip-label"
-          style={{ color: statusInfo.color }}
+          style={{ color }}
         >
-          {t(statusInfo.tooltipLabel)}
+          {t(tooltipLabel)}
         </strong>,
       ])}
     >
@@ -79,5 +79,6 @@ export const NetworkStabilityTooltip = ({ children, statusInfo }) => {
 
 NetworkStabilityTooltip.propTypes = {
   children: PropTypes.node.isRequired,
-  statusInfo: PropTypes.object,
+  color: PropTypes.string.isRequired,
+  tooltipLabel: PropTypes.string.isRequired,
 };


### PR DESCRIPTION
Use the new `networkCongestion` property available when we fetch gas fee
estimates.

References #12473.

Manual testing steps:  

* Open `.metamaskrc` and set `EIP_1559_V2` to `1`.
* Go to Send.
* Enter an address, an amount, and press Next.
* Click on the "Market" button.
* Look at the bottom row of the modal. You should see a base fee section, a priority fee section, and a colored slider. Usually the text underneath the slider will read "Stable". Note the base fee. If it gets high relative to historical fees (currently the threshold is 100-120 GWEI) then the text underneath the slider will read "Busy"; conversely, if the base fee is low, then the text will read "Not busy".

The demo below uses a dashboard I built you can feel free to use to check this by hand: https://observablehq.com/@mcmire/realtime-ethereum-gas-fees

https://user-images.githubusercontent.com/7371/145310712-9ad1b3a0-0985-4425-b5c9-4aa42c95339d.mov
