### PR TITLE
Update Redux DevTools README instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,13 +33,22 @@ See the [build system readme](./development/build/README.md) for build system us
 
 To start a development build (e.g. with logging and file watching) run `yarn start`.
 
-To start the [React DevTools](https://github.com/facebook/react-devtools) and [Redux DevTools Extension](https://github.com/reduxjs/redux-devtools/tree/main/extension)
-  alongside the app, use `yarn start:dev`.
-  - React DevTools will open in a separate window; no browser extension is required
-  - Redux DevTools will need to be installed as a browser extension. Open the Redux Remote Devtools to access Redux state logs. This can be done by either right clicking within the web browser to bring up the context menu, expanding the Redux DevTools panel and clicking Open Remote DevTools OR clicking the Redux DevTools extension icon and clicking Open Remote DevTools.
-    - You will also need to check the "Use custom (local) server" checkbox in the Remote DevTools Settings, using the default server configuration (host `localhost`, port `8000`, secure connection checkbox unchecked)
+#### React and Redux DevTools
 
-[Test site](https://metamask.github.io/test-dapp/) can be used to execute different user flows.
+To start the [React DevTools](https://github.com/facebook/react-devtools), run `yarn devtools:react` with a development build installed in a browser. This will open in a separate window; no browser extension is required.
+
+To start the [Redux DevTools Extension](https://github.com/reduxjs/redux-devtools/tree/main/extension):
+- Install the package `remotedev-server` globally (e.g. `yarn global add remotedev-server`)
+- Install the Redux Devtools extension.
+- Open the Redux DevTools extension and check the "Use custom (local) server" checkbox in the Remote DevTools Settings, using the default server configuration (host `localhost`, port `8000`, secure connection checkbox unchecked).
+
+Then run the command `yarn devtools:redux` with a development build installed in a browser. This will enable you to use the Redux DevTools extension to inspect MetaMask.
+
+To create a development build and run both of these tools simultaneously, run `yarn start:dev`.
+
+#### Test Dapp
+
+[This test site](https://metamask.github.io/test-dapp/) can be used to execute different user flows.
 
 ### Running Unit Tests and Linting
 


### PR DESCRIPTION
The instructions in the README about how to use Redux DevTools with MetaMask have been incorrect since #10687, which removed the dependency `remotedev-server` that this integration requires.

The instructions have been updated to explain that this now must be installed globally for Redux DevTools to work, and for the command `yarn start:dev` to work.

Fixes #10770

Manual testing steps:  
  - Follow the instructions in the README for using the Redux DevTools
  - Run `yarn start:dev`
  - Verify that the Redux DevTools extension functions correctly with MetaMask.