### PR TITLE
Wire up priority fee range in new gas modal

### DIFF
--- a/ui/components/app/edit-gas-fee-popover/network-statistics/latest-priority-fee-field/index.js
+++ b/ui/components/app/edit-gas-fee-popover/network-statistics/latest-priority-fee-field/index.js
@@ -1,0 +1,1 @@
+export { default } from './latest-priority-fee-field';

--- a/ui/components/app/edit-gas-fee-popover/network-statistics/latest-priority-fee-field/latest-priority-fee-field.js
+++ b/ui/components/app/edit-gas-fee-popover/network-statistics/latest-priority-fee-field/latest-priority-fee-field.js
@@ -1,20 +1,9 @@
 import React from 'react';
+import { uniq } from 'lodash';
 import { toBigNumber } from '../../../../../../shared/modules/conversion.utils';
 import { useGasFeeContext } from '../../../../../contexts/gasFee';
 import I18nValue from '../../../../ui/i18n-value';
 import { PriorityFeeTooltip } from '../tooltips';
-
-function uniq(values) {
-  const uniqueValues = [];
-  const seenValues = new Set();
-  values.forEach((value) => {
-    if (!seenValues.has(value)) {
-      uniqueValues.push(value);
-      seenValues.add(value);
-    }
-  });
-  return uniqueValues;
-}
 
 function roundToDecimalPlacesRemovingExtraZeroes(
   numberish,

--- a/ui/components/app/edit-gas-fee-popover/network-statistics/latest-priority-fee-field/latest-priority-fee-field.js
+++ b/ui/components/app/edit-gas-fee-popover/network-statistics/latest-priority-fee-field/latest-priority-fee-field.js
@@ -1,0 +1,54 @@
+import React from 'react';
+import { toBigNumber } from '../../../../../../shared/modules/conversion.utils';
+import { useGasFeeContext } from '../../../../../contexts/gasFee';
+import I18nValue from '../../../../ui/i18n-value';
+import { PriorityFeeTooltip } from '../tooltips';
+
+function uniq(values) {
+  const uniqueValues = [];
+  const seenValues = new Set();
+  values.forEach((value) => {
+    if (!seenValues.has(value)) {
+      uniqueValues.push(value);
+      seenValues.add(value);
+    }
+  });
+  return uniqueValues;
+}
+
+function roundToDecimalPlacesRemovingExtraZeroes(
+  numberish,
+  numberOfDecimalPlaces,
+) {
+  return toBigNumber.dec(
+    toBigNumber.dec(numberish).toFixed(numberOfDecimalPlaces),
+  );
+}
+
+export default function LatestPriorityFeeField() {
+  const { gasFeeEstimates } = useGasFeeContext();
+
+  const renderPriorityFeeRange = () => {
+    const { latestPriorityFeeRange } = gasFeeEstimates;
+    if (latestPriorityFeeRange) {
+      const formattedRange = uniq(
+        latestPriorityFeeRange.map((priorityFee) =>
+          roundToDecimalPlacesRemovingExtraZeroes(priorityFee, 1),
+        ),
+      ).join(' - ');
+      return `${formattedRange} GWEI`;
+    }
+    return null;
+  };
+
+  return (
+    <div className="network-statistics__info__field latest-priority-fee-field">
+      <span className="network-statistics__info__field-data">
+        <PriorityFeeTooltip>{renderPriorityFeeRange()}</PriorityFeeTooltip>
+      </span>
+      <span className="network-statistics__info__field-label">
+        <I18nValue messageKey="priorityFee" />
+      </span>
+    </div>
+  );
+}

--- a/ui/components/app/edit-gas-fee-popover/network-statistics/latest-priority-fee-field/latest-priority-fee-field.test.js
+++ b/ui/components/app/edit-gas-fee-popover/network-statistics/latest-priority-fee-field/latest-priority-fee-field.test.js
@@ -1,0 +1,31 @@
+import React from 'react';
+
+import { renderWithProvider } from '../../../../../../test/jest';
+import { GasFeeContext } from '../../../../../contexts/gasFee';
+import configureStore from '../../../../../store/store';
+
+import LatestPriorityFeeField from './latest-priority-fee-field';
+
+const renderComponent = (gasFeeEstimates) => {
+  const store = configureStore({});
+  return renderWithProvider(
+    <GasFeeContext.Provider value={{ gasFeeEstimates }}>
+      <LatestPriorityFeeField />
+    </GasFeeContext.Provider>,
+    store,
+  );
+};
+
+describe('LatestPriorityFeeField', () => {
+  it('should render a version of latest priority fee range pulled from context, rounded to 1 decimal place', () => {
+    const { getByText } = renderComponent({
+      latestPriorityFeeRange: ['1.000001668', '2.5634234'],
+    });
+    expect(getByText('1 - 2.6 GWEI')).toBeInTheDocument();
+  });
+
+  it('should render nothing if gasFeeEstimates are empty', () => {
+    const { queryByText } = renderComponent({});
+    expect(queryByText('GWEI')).not.toBeInTheDocument();
+  });
+});

--- a/ui/components/app/edit-gas-fee-popover/network-statistics/network-statistics.js
+++ b/ui/components/app/edit-gas-fee-popover/network-statistics/network-statistics.js
@@ -9,7 +9,8 @@ import { useGasFeeContext } from '../../../../contexts/gasFee';
 import I18nValue from '../../../ui/i18n-value';
 import Typography from '../../../ui/typography/typography';
 
-import { BaseFeeTooltip, PriorityFeeTooltip } from './tooltips';
+import { BaseFeeTooltip } from './tooltips';
+import LatestPriorityFeeField from './latest-priority-fee-field';
 import StatusSlider from './status-slider';
 
 const NetworkStatistics = () => {
@@ -38,14 +39,7 @@ const NetworkStatistics = () => {
           </span>
         </div>
         <div className="network-statistics__info__separator" />
-        <div className="network-statistics__info__field network-statistics__info__field--priority-fee">
-          <span className="network-statistics__info__field-data">
-            <PriorityFeeTooltip>0.5 - 22 GWEI</PriorityFeeTooltip>
-          </span>
-          <span className="network-statistics__info__field-label">
-            <I18nValue messageKey="priorityFee" />
-          </span>
-        </div>
+        <LatestPriorityFeeField />
         <div className="network-statistics__info__separator" />
         <div className="network-statistics__info__field">
           <StatusSlider />

--- a/ui/components/app/edit-gas-fee-popover/network-statistics/network-statistics.test.js
+++ b/ui/components/app/edit-gas-fee-popover/network-statistics/network-statistics.test.js
@@ -1,66 +1,33 @@
 import React from 'react';
-import { screen } from '@testing-library/react';
 
 import { renderWithProvider } from '../../../../../test/jest';
-import { ETH } from '../../../../helpers/constants/common';
-import { GasFeeContextProvider } from '../../../../contexts/gasFee';
+import { GasFeeContext } from '../../../../contexts/gasFee';
 import configureStore from '../../../../store/store';
 
 import NetworkStatistics from './network-statistics';
 
-jest.mock('../../../../store/actions', () => ({
-  disconnectGasFeeEstimatePoller: jest.fn(),
-  getGasFeeEstimatesAndStartPolling: jest
-    .fn()
-    .mockImplementation(() => Promise.resolve()),
-  addPollingTokenToAppState: jest.fn(),
-  getGasFeeTimeEstimate: jest
-    .fn()
-    .mockImplementation(() => Promise.resolve('unknown')),
-}));
-
-const MOCK_FEE_ESTIMATE = {
-  estimatedBaseFee: '50.0112',
-};
-
-const renderComponent = (props) => {
-  const store = configureStore({
-    metamask: {
-      nativeCurrency: ETH,
-      provider: {},
-      cachedBalances: {},
-      accounts: {
-        '0xAddress': {
-          address: '0xAddress',
-          balance: '0x176e5b6f173ebe66',
-        },
-      },
-      selectedAddress: '0xAddress',
-      featureFlags: { advancedInlineGas: true },
-      gasFeeEstimates: MOCK_FEE_ESTIMATE,
-      ...props,
-    },
-  });
-
+const renderComponent = (gasFeeEstimates) => {
+  const store = configureStore({});
   return renderWithProvider(
-    <GasFeeContextProvider>
+    <GasFeeContext.Provider value={{ gasFeeEstimates }}>
       <NetworkStatistics />
-    </GasFeeContextProvider>,
+    </GasFeeContext.Provider>,
     store,
   );
 };
 
 describe('NetworkStatistics', () => {
-  it('should renders labels', () => {
-    renderComponent();
-    expect(screen.queryByText('Base fee')).toBeInTheDocument();
-    expect(screen.queryByText('Priority fee')).toBeInTheDocument();
+  it('should render the latest base fee', () => {
+    const { getByText } = renderComponent({
+      estimatedBaseFee: '50.0112',
+    });
+    expect(getByText('50.0112 GWEI')).toBeInTheDocument();
   });
 
-  it('should renders current base fee value', () => {
-    renderComponent();
-    expect(
-      screen.queryByText(`${MOCK_FEE_ESTIMATE.estimatedBaseFee} GWEI`),
-    ).toBeInTheDocument();
+  it('should render the latest priority fee range', () => {
+    const { getByText } = renderComponent({
+      latestPriorityFeeRange: ['1.000001668', '2.5634234'],
+    });
+    expect(getByText('1 - 2.6 GWEI')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
Use the `priorityFeeRange` property which is now available in the gas
fee estimate data.

References #12473.

Manual testing steps:  

* Open `.metamaskrc` and set `EIP_1559_V2` to `1`.
* Go to Send.
* Enter an address, an amount, and press Next.
* Click on the "Market" button.
* Look at the bottom row of the modal. You should see a base fee section, a priority fee section, and a colored slider. The priority fee section should update as new estimates come in.

<img width="892" alt="Screen Shot 2021-12-09 at 5 07 25 PM" src="https://user-images.githubusercontent.com/7371/145495265-780a8e5b-8221-403c-bc6a-84a506fb6a00.png">

