### PR TITLE
Added Japanese translation on test networks

### DIFF
--- a/app/_locales/ja/messages.json
+++ b/app/_locales/ja/messages.json
@@ -3133,6 +3133,12 @@
   "showTestnetNetworksDescription": {
     "message": "ネットワークリストにテストネットワークを表示するには、こちらを選択してください"
   },
+  "showTestnetNetworks": {
+    "message": "テストネットワークを表示する"
+  },
+  "showTestnetNetworksDescription": {
+    "message": "これを選択すると、テストネットワークがネットワークリストに表示されます"
+  },
   "sigRequest": {
     "message": "署名の要求"
   },


### PR DESCRIPTION
Explanation:  

<img width="323" alt="スクリーンショット 2021-12-12 0 18 42" src="https://user-images.githubusercontent.com/701242/145681743-cb72825a-5a9a-44cd-95ca-74c14b63eae1.png">

 Thank you for developing this wonderful software. I've updated the translation file because the English notation was still there when I was using it in Japanese.

I understand that this is part of what needs to be translated, but I couldn't check the other parts, so I just did it here.

If you don't like it, please feel free to close this.