### PR TITLE
Extending Box component to allow style prop

### DIFF
--- a/ui/components/ui/box/box.js
+++ b/ui/components/ui/box/box.js
@@ -86,6 +86,7 @@ export default function Box({
   children,
   className,
   backgroundColor,
+  style,
 }) {
   const boxClassName = classnames('box', className, {
     // ---Borders---
@@ -141,7 +142,11 @@ export default function Box({
   if (typeof children === 'function') {
     return children(boxClassName);
   }
-  return <div className={boxClassName}>{children}</div>;
+  return (
+    <div className={boxClassName} style={style}>
+      {children}
+    </div>
+  );
 }
 
 Box.propTypes = {
@@ -171,4 +176,8 @@ Box.propTypes = {
   height: PropTypes.oneOf(Object.values(BLOCK_SIZES)),
   backgroundColor: PropTypes.oneOf(Object.values(COLORS)),
   className: PropTypes.string,
+  /**
+   * The inline style object to pass to the root element of the Box component
+   */
+  style: PropTypes.object,
 };


### PR DESCRIPTION
Fixes: #NAN

Explanation: Extending the `Box` component to allow for style prop. This provides an escape hatch for developers to use if the current prop selection does not meet their needs. It should be used as a last resort and allows things like background colors from third party providers. An example of this is the NFT feature and using background colors from opensea. [Relevant discussion at the bottom of this comment in this PR](https://github.com/MetaMask/metamask-extension/pull/12970#discussion_r768144267)

Example of third party background colors: 
<img width="712" alt="Screen Shot 2021-12-14 at 10 38 48 AM" src="https://user-images.githubusercontent.com/8112138/145897705-aa81771b-2e97-442c-91f5-4afa9b23e038.png">


Need to add story and docs

Manual testing steps:  TBD
  - 
  - 
  - 