### PR TITLE
Fix permissions-connect-footer learn more link casing

### DIFF
--- a/ui/components/app/permissions-connect-footer/permissions-connect-footer.component.js
+++ b/ui/components/app/permissions-connect-footer/permissions-connect-footer.component.js
@@ -21,7 +21,7 @@ export default class PermissionsConnectFooter extends Component {
               });
             }}
           >
-            {t('learnMore')}
+            {t('learnMoreUpperCase')}
           </div>
         </div>
       </div>


### PR DESCRIPTION
"Learn more" should be uppercase. Current state: 
![image](https://user-images.githubusercontent.com/25517051/145924529-0a8741f3-e638-4c3d-ba17-c6a99d2a0af2.png)
