### PR TITLE
Adding new settings dropdown for Dark mode in Experimental tab

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -727,6 +727,9 @@
     "message": "$1 has recommended this price.",
     "description": "$1 represents the Dapp's origin"
   },
+  "darkTheme": {
+    "message": "Dark"
+  },
   "data": {
     "message": "Data"
   },
@@ -761,6 +764,9 @@
   },
   "decryptRequest": {
     "message": "Decrypt request"
+  },
+  "defaultTheme": {
+    "message": "Default"
   },
   "delete": {
     "message": "Delete"
@@ -3409,6 +3415,12 @@
   },
   "testFaucet": {
     "message": "Test Faucet"
+  },
+  "theme": {
+    "message": "Theme"
+  },
+  "themeDescription": {
+    "message": "Switch to the metamask dark mode."
   },
   "thisWillCreate": {
     "message": "This will create a new wallet and Secret Recovery Phrase"

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -3420,7 +3420,7 @@
     "message": "Theme"
   },
   "themeDescription": {
-    "message": "Switch to the metamask dark mode."
+    "message": "Switch to $1 mode"
   },
   "thisWillCreate": {
     "message": "This will create a new wallet and Secret Recovery Phrase"

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -3420,7 +3420,7 @@
     "message": "Theme"
   },
   "themeDescription": {
-    "message": "Switch to $1 mode"
+    "message": "Choose your preferred MetaMask theme."
   },
   "thisWillCreate": {
     "message": "This will create a new wallet and Secret Recovery Phrase"

--- a/app/scripts/controllers/preferences.js
+++ b/app/scripts/controllers/preferences.js
@@ -68,6 +68,7 @@ export default class PreferencesController {
       ledgerTransportType: window.navigator.hid
         ? LEDGER_TRANSPORT_TYPES.WEBHID
         : LEDGER_TRANSPORT_TYPES.U2F,
+      theme: 'default',
       ...opts.initState,
     };
 
@@ -167,6 +168,15 @@ export default class PreferencesController {
    */
   setEIP1559V2Enabled(val) {
     this.store.updateState({ eip1559V2Enabled: val });
+  }
+
+  /** Setter for the `theme` property
+   *
+   * @param {string} val - 'default' or 'dark' value based on the mode selected by user.
+   *
+   */
+  setTheme(val) {
+    this.store.updateState({ theme: val });
   }
 
   /**

--- a/app/scripts/controllers/preferences.js
+++ b/app/scripts/controllers/preferences.js
@@ -170,10 +170,10 @@ export default class PreferencesController {
     this.store.updateState({ eip1559V2Enabled: val });
   }
 
-  /** Setter for the `theme` property
+  /**
+   * Setter for the `theme` property
    *
    * @param {string} val - 'default' or 'dark' value based on the mode selected by user.
-   *
    */
   setTheme(val) {
     this.store.updateState({ theme: val });

--- a/app/scripts/controllers/preferences.test.js
+++ b/app/scripts/controllers/preferences.test.js
@@ -351,4 +351,18 @@ describe('preferences controller', function () {
       );
     });
   });
+
+  describe('setTheme', function () {
+    it('should default to value "default"', function () {
+      const state = preferencesController.store.getState();
+      assert.equal(state.theme, 'default');
+    });
+
+    it('should set the setTheme property in state', function () {
+      const state = preferencesController.store.getState();
+      assert.equal(state.theme, 'default');
+      preferencesController.setTheme('dark');
+      assert.equal(preferencesController.store.getState().theme, 'dark');
+    });
+  });
 });

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -1422,7 +1422,6 @@ export default class MetamaskController extends EventEmitter {
       ),
       setTheme: preferencesController.setTheme.bind(preferencesController),
 
-
       // AssetsContractController
       getTokenStandardAndDetails: assetsContractController.getTokenStandardAndDetails.bind(
         assetsContractController,

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -1420,6 +1420,8 @@ export default class MetamaskController extends EventEmitter {
       setEIP1559V2Enabled: preferencesController.setEIP1559V2Enabled.bind(
         preferencesController,
       ),
+      setTheme: preferencesController.setTheme.bind(preferencesController),
+
 
       // AssetsContractController
       getTokenStandardAndDetails: assetsContractController.getTokenStandardAndDetails.bind(

--- a/development/build/scripts.js
+++ b/development/build/scripts.js
@@ -34,6 +34,11 @@ const metamaskrc = require('rc')('metamask', {
   INFURA_PROD_PROJECT_ID: process.env.INFURA_PROD_PROJECT_ID,
   ONBOARDING_V2: process.env.ONBOARDING_V2,
   COLLECTIBLES_V1: process.env.COLLECTIBLES_V1,
+<<<<<<< HEAD
+=======
+  EIP_1559_V2: process.env.EIP_1559_V2,
+  DARK_MODE_V1: process.env.DARK_MODE_V1,
+>>>>>>> 80f707288 (adding new dropdown to experimental setting for dark mode and related controller changes and feature flag)
   SEGMENT_HOST: process.env.SEGMENT_HOST,
   SEGMENT_WRITE_KEY: process.env.SEGMENT_WRITE_KEY,
   SEGMENT_BETA_WRITE_KEY: process.env.SEGMENT_BETA_WRITE_KEY,
@@ -803,6 +808,7 @@ function getEnvironmentVariables({ buildType, devMode, testing }) {
     SWAPS_USE_DEV_APIS: process.env.SWAPS_USE_DEV_APIS === '1',
     ONBOARDING_V2: metamaskrc.ONBOARDING_V2 === '1',
     COLLECTIBLES_V1: metamaskrc.COLLECTIBLES_V1 === '1',
+    DARK_MODE_V1: metamaskrc.DARK_MODE_V1 === '1',
   };
 }
 

--- a/development/build/scripts.js
+++ b/development/build/scripts.js
@@ -34,11 +34,7 @@ const metamaskrc = require('rc')('metamask', {
   INFURA_PROD_PROJECT_ID: process.env.INFURA_PROD_PROJECT_ID,
   ONBOARDING_V2: process.env.ONBOARDING_V2,
   COLLECTIBLES_V1: process.env.COLLECTIBLES_V1,
-<<<<<<< HEAD
-=======
-  EIP_1559_V2: process.env.EIP_1559_V2,
   DARK_MODE_V1: process.env.DARK_MODE_V1,
->>>>>>> 80f707288 (adding new dropdown to experimental setting for dark mode and related controller changes and feature flag)
   SEGMENT_HOST: process.env.SEGMENT_HOST,
   SEGMENT_WRITE_KEY: process.env.SEGMENT_WRITE_KEY,
   SEGMENT_BETA_WRITE_KEY: process.env.SEGMENT_BETA_WRITE_KEY,

--- a/ui/pages/routes/routes.component.js
+++ b/ui/pages/routes/routes.component.js
@@ -94,6 +94,7 @@ export default class Routes extends Component {
     prepareToLeaveSwaps: PropTypes.func,
     browserEnvironmentOs: PropTypes.string,
     browserEnvironmentBrowser: PropTypes.string,
+    theme: PropTypes.string,
   };
 
   static contextTypes = {
@@ -313,6 +314,7 @@ export default class Routes extends Component {
       isMouseUser,
       browserEnvironmentOs: os,
       browserEnvironmentBrowser: browser,
+      theme,
     } = this.props;
     const loadMessage =
       loadingMessage || isNetworkLoading
@@ -325,6 +327,7 @@ export default class Routes extends Component {
           [`os-${os}`]: os,
           [`browser-${browser}`]: browser,
           'mouse-user-styles': isMouseUser,
+          [`theme-${theme}`]: process.env.DARK_MODE_V1 && theme,
         })}
         dir={textDirection}
         onClick={() => setMouseUserState(true)}

--- a/ui/pages/routes/routes.component.js
+++ b/ui/pages/routes/routes.component.js
@@ -102,6 +102,16 @@ export default class Routes extends Component {
     metricsEvent: PropTypes.func,
   };
 
+  componentDidUpdate(prevProps) {
+    if (process.env.DARK_MODE_V1) {
+      const { theme } = this.props;
+      if (theme !== prevProps.theme) {
+        document.documentElement.classList.remove(`theme-${prevProps.theme}`);
+        document.documentElement.classList.add(`theme-${theme}`);
+      }
+    }
+  }
+
   UNSAFE_componentWillMount() {
     const {
       currentCurrency,
@@ -320,7 +330,6 @@ export default class Routes extends Component {
       loadingMessage || isNetworkLoading
         ? this.getConnectingLabel(loadingMessage)
         : null;
-
     return (
       <div
         className={classnames('app', {

--- a/ui/pages/routes/routes.component.js
+++ b/ui/pages/routes/routes.component.js
@@ -118,6 +118,7 @@ export default class Routes extends Component {
       pageChanged,
       setCurrentCurrencyToUSD,
       history,
+      theme,
     } = this.props;
     if (!currentCurrency) {
       setCurrentCurrencyToUSD();
@@ -128,6 +129,9 @@ export default class Routes extends Component {
         pageChanged(locationObj.pathname);
       }
     });
+    if (process.env.DARK_MODE_V1 && theme) {
+      document.documentElement.classList.add(`theme-${theme}`);
+    }
   }
 
   renderRoutes() {

--- a/ui/pages/routes/routes.component.js
+++ b/ui/pages/routes/routes.component.js
@@ -106,8 +106,7 @@ export default class Routes extends Component {
     if (process.env.DARK_MODE_V1) {
       const { theme } = this.props;
       if (theme !== prevProps.theme) {
-        document.documentElement.classList.remove(`theme-${prevProps.theme}`);
-        document.documentElement.classList.add(`theme-${theme}`);
+        document.documentElement.setAttribute('data-theme', theme);
       }
     }
   }
@@ -130,7 +129,7 @@ export default class Routes extends Component {
       }
     });
     if (process.env.DARK_MODE_V1 && theme) {
-      document.documentElement.classList.add(`theme-${theme}`);
+      document.documentElement.setAttribute('data-theme', theme);
     }
   }
 

--- a/ui/pages/routes/routes.container.js
+++ b/ui/pages/routes/routes.container.js
@@ -5,6 +5,7 @@ import {
   getNetworkIdentifier,
   getPreferences,
   isNetworkLoading,
+  getTheme,
 } from '../../selectors';
 import {
   lockMetamask,
@@ -36,6 +37,7 @@ function mapStateToProps(state) {
     browserEnvironmentContainter: state.metamask.browserEnvironment?.browser,
     providerId: getNetworkIdentifier(state),
     providerType: state.metamask.provider?.type,
+    theme: getTheme(state),
   };
 }
 

--- a/ui/pages/settings/experimental-tab/experimental-tab.component.js
+++ b/ui/pages/settings/experimental-tab/experimental-tab.component.js
@@ -1,10 +1,17 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
+import I18nValue from '../../../components/ui/i18n-value';
 import ToggleButton from '../../../components/ui/toggle-button';
 import {
   getSettingsSectionNumber,
   handleSettingsRefs,
 } from '../../../helpers/utils/settings-search';
+import Dropdown from '../../../components/ui/dropdown';
+
+import { THEME_NAMES, THEME_TYPE } from './experimental-tab.constant';
+
+/*eslint-disable prefer-destructuring*/
+const DARK_MODE_V1 = process.env.DARK_MODE_V1;
 
 export default class ExperimentalTab extends PureComponent {
   static contextTypes = {
@@ -21,6 +28,8 @@ export default class ExperimentalTab extends PureComponent {
     openSeaEnabled: PropTypes.bool,
     eip1559V2Enabled: PropTypes.bool,
     setEIP1559V2Enabled: PropTypes.func,
+    theme: PropTypes.string,
+    setTheme: PropTypes.func,
   };
 
   settingsRefs = Array(
@@ -220,6 +229,48 @@ export default class ExperimentalTab extends PureComponent {
     );
   }
 
+  renderTheme() {
+    if (!DARK_MODE_V1) {
+      return null;
+    }
+    const { t } = this.context;
+    const { theme, setTheme } = this.props;
+
+    const themesOptions = [
+      {
+        name: t('defaultTheme'),
+        value: THEME_TYPE.DEFAULT,
+      },
+      {
+        name: t('darkTheme'),
+        value: THEME_TYPE.DARK,
+      },
+    ];
+
+    return (
+      <div className="settings-page__content-row">
+        <div className="settings-page__content-item">
+          <span>
+            <I18nValue messageKey="theme" />
+          </span>
+          <div className="settings-page__content-description">
+            <I18nValue messageKey="themeDescription" />
+          </div>
+        </div>
+        <div className="settings-page__content-item">
+          <div className="settings-page__content-item-col">
+            <Dropdown
+              id="select-theme"
+              options={themesOptions}
+              selectedOption={theme}
+              onChange={async (newTheme) => setTheme(newTheme)}
+            />
+          </div>
+        </div>
+      </div>
+    );
+  }
+
   render() {
     return (
       <div className="settings-page__body">
@@ -227,6 +278,7 @@ export default class ExperimentalTab extends PureComponent {
         {this.renderOpenSeaEnabledToggle()}
         {this.renderCollectibleDetectionToggle()}
         {this.renderEIP1559V2EnabledToggle()}
+        {this.renderTheme()}
       </div>
     );
   }

--- a/ui/pages/settings/experimental-tab/experimental-tab.component.js
+++ b/ui/pages/settings/experimental-tab/experimental-tab.component.js
@@ -256,7 +256,9 @@ export default class ExperimentalTab extends PureComponent {
           <div className="settings-page__content-description">
             <I18nValue
               messageKey="themeDescription"
-              options={[Object.values(THEME_TYPE).filter(type => type !== theme),]}
+              options={[
+                Object.values(THEME_TYPE).filter((type) => type !== theme),
+              ]}
             />
           </div>
         </div>

--- a/ui/pages/settings/experimental-tab/experimental-tab.component.js
+++ b/ui/pages/settings/experimental-tab/experimental-tab.component.js
@@ -1,6 +1,5 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import I18nValue from '../../../components/ui/i18n-value';
 import ToggleButton from '../../../components/ui/toggle-button';
 import {
   getSettingsSectionNumber,
@@ -250,11 +249,9 @@ export default class ExperimentalTab extends PureComponent {
     return (
       <div className="settings-page__content-row">
         <div className="settings-page__content-item">
-          <span>
-            <I18nValue messageKey="theme" />
-          </span>
+          <span>{this.context.t('theme')}</span>
           <div className="settings-page__content-description">
-            <I18nValue messageKey="themeDescription" />
+            {this.context.t('themeDescription')}
           </div>
         </div>
         <div className="settings-page__content-item">

--- a/ui/pages/settings/experimental-tab/experimental-tab.component.js
+++ b/ui/pages/settings/experimental-tab/experimental-tab.component.js
@@ -254,7 +254,10 @@ export default class ExperimentalTab extends PureComponent {
             <I18nValue messageKey="theme" />
           </span>
           <div className="settings-page__content-description">
-            <I18nValue messageKey="themeDescription" />
+            <I18nValue
+              messageKey="themeDescription"
+              options={[Object.values(THEME_TYPE).filter(type => type !== theme),]}
+            />
           </div>
         </div>
         <div className="settings-page__content-item">

--- a/ui/pages/settings/experimental-tab/experimental-tab.component.js
+++ b/ui/pages/settings/experimental-tab/experimental-tab.component.js
@@ -8,7 +8,7 @@ import {
 } from '../../../helpers/utils/settings-search';
 import Dropdown from '../../../components/ui/dropdown';
 
-import { THEME_NAMES, THEME_TYPE } from './experimental-tab.constant';
+import { THEME_TYPE } from './experimental-tab.constant';
 
 /*eslint-disable prefer-destructuring*/
 const DARK_MODE_V1 = process.env.DARK_MODE_V1;

--- a/ui/pages/settings/experimental-tab/experimental-tab.component.js
+++ b/ui/pages/settings/experimental-tab/experimental-tab.component.js
@@ -254,12 +254,7 @@ export default class ExperimentalTab extends PureComponent {
             <I18nValue messageKey="theme" />
           </span>
           <div className="settings-page__content-description">
-            <I18nValue
-              messageKey="themeDescription"
-              options={[
-                Object.values(THEME_TYPE).filter((type) => type !== theme),
-              ]}
-            />
+            <I18nValue messageKey="themeDescription" />
           </div>
         </div>
         <div className="settings-page__content-item">

--- a/ui/pages/settings/experimental-tab/experimental-tab.constant.js
+++ b/ui/pages/settings/experimental-tab/experimental-tab.constant.js
@@ -1,0 +1,4 @@
+export const THEME_TYPE = {
+  DEFAULT: 'default',
+  DARK: 'dark',
+};

--- a/ui/pages/settings/experimental-tab/experimental-tab.container.js
+++ b/ui/pages/settings/experimental-tab/experimental-tab.container.js
@@ -6,12 +6,14 @@ import {
   setUseCollectibleDetection,
   setOpenSeaEnabled,
   setEIP1559V2Enabled,
+  setTheme,
 } from '../../../store/actions';
 import {
   getUseTokenDetection,
   getUseCollectibleDetection,
   getOpenSeaEnabled,
   getEIP1559V2Enabled,
+  getTheme,
 } from '../../../selectors';
 import ExperimentalTab from './experimental-tab.component';
 
@@ -21,6 +23,7 @@ const mapStateToProps = (state) => {
     useCollectibleDetection: getUseCollectibleDetection(state),
     openSeaEnabled: getOpenSeaEnabled(state),
     eip1559V2Enabled: getEIP1559V2Enabled(state),
+    theme: getTheme(state)
   };
 };
 
@@ -31,6 +34,7 @@ const mapDispatchToProps = (dispatch) => {
       dispatch(setUseCollectibleDetection(val)),
     setOpenSeaEnabled: (val) => dispatch(setOpenSeaEnabled(val)),
     setEIP1559V2Enabled: (val) => dispatch(setEIP1559V2Enabled(val)),
+    setTheme: (val) => dispatch(setTheme(val)),
   };
 };
 

--- a/ui/pages/settings/experimental-tab/experimental-tab.container.js
+++ b/ui/pages/settings/experimental-tab/experimental-tab.container.js
@@ -23,7 +23,7 @@ const mapStateToProps = (state) => {
     useCollectibleDetection: getUseCollectibleDetection(state),
     openSeaEnabled: getOpenSeaEnabled(state),
     eip1559V2Enabled: getEIP1559V2Enabled(state),
-    theme: getTheme(state)
+    theme: getTheme(state),
   };
 };
 

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -790,6 +790,15 @@ export function getOpenSeaEnabled(state) {
 }
 
 /**
+ * To get the `theme` value which determines which theme is selected
+ * @param {*} state
+ * @returns Boolean
+ */
+ export function getTheme(state) {
+  return state.metamask.theme;
+}
+
+/**
  * To retrieve the tokenList produced by TokenListcontroller
  *
  * @param {*} state

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -794,7 +794,7 @@ export function getOpenSeaEnabled(state) {
  * @param {*} state
  * @returns Boolean
  */
- export function getTheme(state) {
+export function getTheme(state) {
   return state.metamask.theme;
 }
 

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -791,6 +791,7 @@ export function getOpenSeaEnabled(state) {
 
 /**
  * To get the `theme` value which determines which theme is selected
+ *
  * @param {*} state
  * @returns Boolean
  */

--- a/ui/store/actions.js
+++ b/ui/store/actions.js
@@ -2322,19 +2322,19 @@ export function setEIP1559V2Enabled(val) {
     } finally {
       dispatch(hideLoadingIndication());
     }
-  }
+  };
 }
 
 export function setTheme(val) {
-  return (dispatch) => {
+  return async (dispatch) => {
     dispatch(showLoadingIndication());
-    log.debug(`background.setMetamaskThemes`);
-    background.setTheme(val, (err) => {
+    log.debug(`background.setTheme`);
+    try {
+      await promisifiedBackground.setTheme(val);
+      await forceUpdateMetamaskState(dispatch);
+    } finally {
       dispatch(hideLoadingIndication());
-      if (err) {
-        dispatch(displayWarning(err.message));
-      }
-    });
+    }
   };
 }
 

--- a/ui/store/actions.js
+++ b/ui/store/actions.js
@@ -2322,6 +2322,19 @@ export function setEIP1559V2Enabled(val) {
     } finally {
       dispatch(hideLoadingIndication());
     }
+  }
+}
+
+export function setTheme(val) {
+  return (dispatch) => {
+    dispatch(showLoadingIndication());
+    log.debug(`background.setMetamaskThemes`);
+    background.setTheme(val, (err) => {
+      dispatch(hideLoadingIndication());
+      if (err) {
+        dispatch(displayWarning(err.message));
+      }
+    });
   };
 }
 

--- a/ui/store/actions.js
+++ b/ui/store/actions.js
@@ -2331,7 +2331,6 @@ export function setTheme(val) {
     log.debug(`background.setTheme`);
     try {
       await promisifiedBackground.setTheme(val);
-      await forceUpdateMetamaskState(dispatch);
     } finally {
       dispatch(hideLoadingIndication());
     }


### PR DESCRIPTION
Adding a new setting with a dropdown in the Experimental Tab in order to enable Dark mode. Dropdown is populated with 2 modes currently `default` and `dark`.