### PR TITLE
Lock button active state fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- [#13089](https://github.com/MetaMask/metamask-extension/issues/13089): Active State for Lock Button is Incorrect Color.
 
 ## [10.8.0]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-### Fixed
-- [#13089](https://github.com/MetaMask/metamask-extension/issues/13089): Active State for Lock Button is Incorrect Color.
 
 ## [10.8.0]
 ### Added

--- a/ui/components/app/account-menu/index.scss
+++ b/ui/components/app/account-menu/index.scss
@@ -41,11 +41,11 @@
       cursor: pointer;
 
       &:hover {
-        background-color: rgba($dusty-gray, 0.05);
+        background-color: rgba($white, 0.05);
       }
 
       &:active {
-        background-color: rgba($dusty-gray, 0.1);
+        background-color: rgba($white, 0.1);
       }
     }
 

--- a/ui/components/app/account-menu/index.scss
+++ b/ui/components/app/account-menu/index.scss
@@ -41,11 +41,11 @@
       cursor: pointer;
 
       &:hover {
-        background-color: rgba($white, 0.05);
+        background-color: rgba($dusty-gray, 0.05);
       }
 
       &:active {
-        background-color: rgba($white, 0.1);
+        background-color: rgba($dusty-gray, 0.1);
       }
     }
 
@@ -105,6 +105,14 @@
     color: $white;
     padding: 3.5px 24px;
     width: 59px;
+  
+    &:hover {
+      background-color: rgba($dusty-gray, 0.05);
+    }
+
+    &:active {
+      background-color: rgba($dusty-gray, 0.1);
+    }
   }
 
   &__item-icon {


### PR DESCRIPTION
Fixes: #13089 

Explanation:  Simple CSS change to make lock button not be white when in active state.

Manual testing steps:  
  - Tested on Chrome version 96.0.4664.93 Ubuntu 21.04
  - Tested on Firefox version 95.0 Ubuntu 21.04
  - Tested on Brave version V1.33.106 Ubuntu 21.04