### PR TITLE
Update `@babel/runtime` patch to fix lockdown error

### DIFF
--- a/patches/@babel+runtime+7.16.3.patch
+++ b/patches/@babel+runtime+7.16.3.patch
@@ -1,3 +1,53 @@
+diff --git a/node_modules/@babel/runtime/helpers/construct.js b/node_modules/@babel/runtime/helpers/construct.js
+index 108b39a..e3c769b 100644
+--- a/node_modules/@babel/runtime/helpers/construct.js
++++ b/node_modules/@babel/runtime/helpers/construct.js
+@@ -1,26 +1,21 @@
+-var setPrototypeOf = require("./setPrototypeOf.js");
++// All of MetaMask's supported browsers include `Reflect.construct` support, so
++// we don't need this polyfill.
+ 
+-var isNativeReflectConstruct = require("./isNativeReflectConstruct.js");
+-
+-function _construct(Parent, args, Class) {
+-  if (isNativeReflectConstruct()) {
+-    module.exports = _construct = Reflect.construct;
+-    module.exports["default"] = module.exports, module.exports.__esModule = true;
+-  } else {
+-    module.exports = _construct = function _construct(Parent, args, Class) {
+-      var a = [null];
+-      a.push.apply(a, args);
+-      var Constructor = Function.bind.apply(Parent, a);
+-      var instance = new Constructor();
+-      if (Class) setPrototypeOf(instance, Class.prototype);
+-      return instance;
+-    };
+-
+-    module.exports["default"] = module.exports, module.exports.__esModule = true;
++// This Proxy preseves the two properties that were added by `@babel/runtime`.
++// I am not entire sure what these properties are for (maybe ES5/ES6
++// interoperability?) but they have been preserved just in case.
++const reflectProxy =  new Proxy(
++  Reflect.construct,
++  {
++    get: function (target, property) {
++      if (property === 'default') {
++        return target;
++      } else if (property === '__esModule') {
++        return true;
++      }
++      return Reflect.get(...arguments);
++    }
+   }
++);
+ 
+-  return _construct.apply(null, arguments);
+-}
+-
+-module.exports = _construct;
+-module.exports["default"] = module.exports, module.exports.__esModule = true;
+\ No newline at end of file
++module.exports = reflectProxy;
 diff --git a/node_modules/@babel/runtime/helpers/extends.js b/node_modules/@babel/runtime/helpers/extends.js
 index eaf9547..d0474f5 100644
 --- a/node_modules/@babel/runtime/helpers/extends.js


### PR DESCRIPTION
We are currently patching `@babel/runtime` to fix various lockdown errors caused by `@babel/runtime` modifying globals as part of various polyfills. There was one lockdown error that was showing up in Sentry error reports, which is the polyfill used for `Reflect.construct`.

All of our supported browsers include this API, so the polyfill has been replaced with a Proxy that returns the `Reflect.construct`
function directly, except with the addition of the `default` and `__esModule` properties. I don't know what these properties are for (maybe ES5/ES6 interoperability?) but I left them just in case they were being relied upon.

Manual testing steps:  

I don't know of any easy way to reproduce this problem. But here is at least one method that has been shown to work:
  - Revert these two changes:
    - https://github.com/MetaMask/eth-trezor-keyring/pull/113
    - https://github.com/MetaMask/metamask-extension/pull/13018
  - Connect a Trezor account
  - Lock the extension
  - Unlock the extension
  - Before this patch, you should see the error `Cannot add property default, object is not extensible`. After this patch, you should see the error `Error: TrezorConnect has been already initialized` instead (which is fixed by the two changes reverted in the first step).