### PR TITLE
Feat/check update collectible ownership

### DIFF
--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -11,6 +11,7 @@ import { storeAsStream, storeTransformStream } from '@metamask/obs-store';
 import PortStream from 'extension-port-stream';
 import { captureException } from '@sentry/browser';
 
+import { ethErrors } from 'eth-rpc-errors';
 import {
   ENVIRONMENT_TYPE_POPUP,
   ENVIRONMENT_TYPE_NOTIFICATION,
@@ -534,7 +535,9 @@ function setupController(initState, initLangCode) {
       );
 
     // Finally, reject all approvals managed by the ApprovalController
-    controller.approvalController.clear();
+    controller.approvalController.clear(
+      ethErrors.provider.userRejectedRequest(),
+    );
 
     updateBadge();
   }

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -1161,6 +1161,10 @@ export default class MetamaskController extends EventEmitter {
         collectiblesController,
       ),
 
+      checkAndUpdateCollectiblesOwnershipStatus: collectiblesController.checkAndUpdateCollectiblesOwnershipStatus.bind(
+        collectiblesController,
+      )
+
       // AddressController
       setAddressBook: addressBookController.set.bind(addressBookController),
       removeFromAddressBook: addressBookController.delete.bind(

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -1163,7 +1163,7 @@ export default class MetamaskController extends EventEmitter {
 
       checkAndUpdateCollectiblesOwnershipStatus: collectiblesController.checkAndUpdateCollectiblesOwnershipStatus.bind(
         collectiblesController,
-      )
+      ),
 
       // AddressController
       setAddressBook: addressBookController.set.bind(addressBookController),

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "@keystonehq/metamask-airgapped-keyring": "0.2.1",
     "@material-ui/core": "^4.11.0",
     "@metamask/contract-metadata": "^1.31.0",
-    "@metamask/controllers": "^22.0.0",
+    "@metamask/controllers": "^23.0.0",
     "@metamask/eth-ledger-bridge-keyring": "^0.10.0",
     "@metamask/eth-token-tracker": "^3.0.1",
     "@metamask/etherscan-link": "^2.1.0",

--- a/ui/components/app/collectibles-items/collectibles-items.js
+++ b/ui/components/app/collectibles-items/collectibles-items.js
@@ -120,7 +120,11 @@ export default function CollectiblesItems({
               const { image, address, tokenId, backgroundColor } = collectible;
               const collectibleImage = getAssetImageURL(image, ipfsGateway);
               return (
-                <Box width={width} key={`collectible-${i}`} className="collectibles-items__collection-item-wrapper">
+                <Box
+                  width={width}
+                  key={`collectible-${i}`}
+                  className="collectibles-items__collection-item-wrapper"
+                >
                   <div
                     className="collectibles-items__collection-item"
                     style={{

--- a/ui/components/app/collectibles-items/collectibles-items.js
+++ b/ui/components/app/collectibles-items/collectibles-items.js
@@ -31,6 +31,7 @@ export default function CollectiblesItems({
   previouslyOwnedCollection = {},
 }) {
   const defaultDropdownState = { [PREVIOUSLY_OWNED_KEY]: false };
+  const [dropdownState, setDropdownState] = useState(defaultDropdownState);
   const ipfsGateway = useSelector(getIpfsGateway);
 
   Object.keys(collections).forEach((key) => {
@@ -142,7 +143,6 @@ export default function CollectiblesItems({
     );
   };
 
-  const [dropdownState, setDropdownState] = useState(defaultDropdownState);
   return (
     <div className="collectibles-items">
       <Box padding={[6, 4]} flexDirection={FLEX_DIRECTION.COLUMN}>
@@ -175,6 +175,26 @@ export default function CollectiblesItems({
 }
 
 CollectiblesItems.propTypes = {
+  previouslyOwnedCollection: PropTypes.shape({
+    collectibles: PropTypes.arrayOf(
+      PropTypes.shape({
+        address: PropTypes.string.isRequired,
+        tokenId: PropTypes.string.isRequired,
+        name: PropTypes.string,
+        description: PropTypes.string,
+        image: PropTypes.string,
+        standard: PropTypes.string,
+        imageThumbnail: PropTypes.string,
+        imagePreview: PropTypes.string,
+        creator: PropTypes.shape({
+          address: PropTypes.string,
+          config: PropTypes.string,
+          profile_img_url: PropTypes.string,
+        }),
+      }),
+    ),
+    collectionName: PropTypes.string,
+  }),
   collections: PropTypes.shape({
     collectibles: PropTypes.arrayOf(
       PropTypes.shape({

--- a/ui/components/app/collectibles-items/collectibles-items.js
+++ b/ui/components/app/collectibles-items/collectibles-items.js
@@ -26,6 +26,7 @@ const width =
     : BLOCK_SIZES.ONE_SIXTH;
 
 const PREVIOUSLY_OWNED_KEY = 'previouslyOwned';
+
 export default function CollectiblesItems({
   collections = {},
   previouslyOwnedCollection = {},

--- a/ui/components/app/collectibles-items/collectibles-items.js
+++ b/ui/components/app/collectibles-items/collectibles-items.js
@@ -24,8 +24,13 @@ const width =
   getEnvironmentType() === ENVIRONMENT_TYPE_POPUP
     ? BLOCK_SIZES.ONE_THIRD
     : BLOCK_SIZES.ONE_SIXTH;
-export default function CollectiblesItems({ collections = {} }) {
-  const defaultDropdownState = {};
+
+const PREVIOUSLY_OWNED_KEY = 'previouslyOwned';
+export default function CollectiblesItems({
+  collections = {},
+  previouslyOwnedCollection = {},
+}) {
+  const defaultDropdownState = { [PREVIOUSLY_OWNED_KEY]: false };
   const ipfsGateway = useSelector(getIpfsGateway);
 
   Object.keys(collections).forEach((key) => {
@@ -33,109 +38,135 @@ export default function CollectiblesItems({ collections = {} }) {
   });
   const history = useHistory();
 
+  const renderCollectionImage = (
+    isPreviouslyOwnedCollection,
+    collectionImage,
+    collectionName,
+  ) => {
+    if (isPreviouslyOwnedCollection) {
+      return null;
+    }
+    if (collectionImage) {
+      return (
+        <img
+          src={collectionImage}
+          className="collectibles-items__collection-image"
+        />
+      );
+    }
+    return (
+      <div className="collectibles-items__collection-image-alt">
+        {collectionName[0]}
+      </div>
+    );
+  };
+
+  const renderCollection = ({
+    collectibles,
+    collectionName,
+    collectionImage,
+    key,
+    isPreviouslyOwnedCollection,
+  }) => {
+    if (!collectibles.length) {
+      return null;
+    }
+
+    const isExpanded = dropdownState[key];
+    return (
+      <div
+        className="collectibles-items__collection"
+        key={`collection-${key}`}
+        onClick={() => {
+          setDropdownState((_dropdownState) => ({
+            ..._dropdownState,
+            [key]: !isExpanded,
+          }));
+        }}
+      >
+        <Box
+          marginBottom={2}
+          display={DISPLAY.FLEX}
+          alignItems={ALIGN_ITEMS.CENTER}
+          justifyContent={JUSTIFY_CONTENT.SPACE_BETWEEN}
+          className="collectibles-items__collection-accordion-title"
+        >
+          <Box
+            alignItems={ALIGN_ITEMS.CENTER}
+            className="collectibles-items__collection-header"
+          >
+            {renderCollectionImage(
+              isPreviouslyOwnedCollection,
+              collectionImage,
+              collectionName,
+            )}
+            <Typography
+              color={COLORS.BLACK}
+              variant={TYPOGRAPHY.H5}
+              margin={[0, 0, 0, 2]}
+            >
+              {`${collectionName} (${collectibles.length})`}
+            </Typography>
+          </Box>
+          <Box alignItems={ALIGN_ITEMS.FLEX_END}>
+            <i className={`fa fa-chevron-${isExpanded ? 'down' : 'right'}`} />
+          </Box>
+        </Box>
+        {isExpanded ? (
+          <Box display={DISPLAY.FLEX} flexWrap={FLEX_WRAP.WRAP} gap={4}>
+            {collectibles.map((collectible, i) => {
+              const { image, address, tokenId, backgroundColor } = collectible;
+              const collectibleImage = getAssetImageURL(image, ipfsGateway);
+              return (
+                <Box width={width} key={`collectible-${i}`} className="collectibles-items__collection-item-wrapper">
+                  <div
+                    className="collectibles-items__collection-item"
+                    style={{
+                      backgroundColor,
+                    }}
+                  >
+                    <img
+                      onClick={() =>
+                        history.push(`${ASSET_ROUTE}/${address}/${tokenId}`)
+                      }
+                      className="collectibles-items__collection-item-image"
+                      src={collectibleImage}
+                    />
+                  </div>
+                </Box>
+              );
+            })}
+          </Box>
+        ) : null}
+      </div>
+    );
+  };
+
   const [dropdownState, setDropdownState] = useState(defaultDropdownState);
   return (
     <div className="collectibles-items">
       <Box padding={[6, 4]} flexDirection={FLEX_DIRECTION.COLUMN}>
         <>
-          {Object.keys(collections).map((key, index) => {
+          {Object.keys(collections).map((key) => {
             const {
               collectibles,
               collectionName,
               collectionImage,
             } = collections[key];
 
-            const isExpanded = dropdownState[key];
-            return (
-              <div
-                className="collectibles-items__collection"
-                key={`collection-${index}`}
-                onClick={() => {
-                  setDropdownState((_dropdownState) => ({
-                    ..._dropdownState,
-                    [key]: !isExpanded,
-                  }));
-                }}
-              >
-                <Box
-                  marginBottom={2}
-                  display={DISPLAY.FLEX}
-                  alignItems={ALIGN_ITEMS.CENTER}
-                  justifyContent={JUSTIFY_CONTENT.SPACE_BETWEEN}
-                  className="collectibles-items__collection-accordion-title"
-                >
-                  <Box
-                    alignItems={ALIGN_ITEMS.CENTER}
-                    className="collectibles-items__collection-header"
-                  >
-                    {collectionImage ? (
-                      <img
-                        src={collectionImage}
-                        className="collectibles-items__collection-image"
-                      />
-                    ) : (
-                      <div className="collectibles-items__collection-image-alt">
-                        {collectionName[0]}
-                      </div>
-                    )}
-                    <Typography
-                      color={COLORS.BLACK}
-                      variant={TYPOGRAPHY.H5}
-                      margin={[0, 0, 0, 2]}
-                    >
-                      {`${collectionName} (${collectibles.length})`}
-                    </Typography>
-                  </Box>
-                  <Box alignItems={ALIGN_ITEMS.FLEX_END}>
-                    <i
-                      className={`fa fa-chevron-${
-                        isExpanded ? 'down' : 'right'
-                      }`}
-                    />
-                  </Box>
-                </Box>
-                {isExpanded ? (
-                  <Box display={DISPLAY.FLEX} flexWrap={FLEX_WRAP.WRAP} gap={4}>
-                    {collectibles.map((collectible, i) => {
-                      const {
-                        image,
-                        address,
-                        tokenId,
-                        backgroundColor,
-                      } = collectible;
-                      const collectibleImage = getAssetImageURL(
-                        image,
-                        ipfsGateway,
-                      );
-                      return (
-                        <Box
-                          width={width}
-                          key={`collectible-${i}`}
-                          className="collectibles-items__collection-item-wrapper"
-                        >
-                          <div
-                            className="collectibles-items__collection-item"
-                            style={{
-                              backgroundColor,
-                            }}
-                          >
-                            <img
-                              onClick={() =>
-                                history.push(
-                                  `${ASSET_ROUTE}/${address}/${tokenId}`,
-                                )
-                              }
-                              className="collectibles-items__collection-item-image"
-                              src={collectibleImage}
-                            />
-                          </div>
-                        </Box>
-                      );
-                    })}
-                  </Box>
-                ) : null}
-              </div>
-            );
+            return renderCollection({
+              collectibles,
+              collectionName,
+              collectionImage,
+              key,
+              isPreviouslyOwnedCollection: false,
+            });
+          })}
+          {renderCollection({
+            collectibles: previouslyOwnedCollection.collectibles,
+            collectionName: previouslyOwnedCollection.collectionName,
+            isPreviouslyOwnedCollection: true,
+            key: PREVIOUSLY_OWNED_KEY,
           })}
         </>
       </Box>

--- a/ui/components/app/collectibles-tab/collectibles-tab.js
+++ b/ui/components/app/collectibles-tab/collectibles-tab.js
@@ -77,7 +77,7 @@ export default function CollectiblesTab({ onAddNFT }) {
     if (isMainnet) {
       dispatch(detectCollectibles());
     }
-    dispatch(checkAndUpdateCollectiblesOwnershipStatus());
+    checkAndUpdateCollectiblesOwnershipStatus();
   };
 
   return (

--- a/ui/components/app/collectibles-tab/collectibles-tab.js
+++ b/ui/components/app/collectibles-tab/collectibles-tab.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import { useDispatch, useSelector } from 'react-redux';
 import { useHistory } from 'react-router-dom';
@@ -67,11 +67,6 @@ export default function CollectiblesTab({ onAddNFT }) {
     return [collections, previouslyOwnedCollection];
   };
 
-  // const [collections, previouslyOwnedCollection] = useMemo(
-  //   () => getCollections(),
-  //   [collectibles, collectibleContracts],
-  // ); 
-  
   const [collections, previouslyOwnedCollection] = getCollections();
 
   const onEnableAutoDetect = () => {

--- a/ui/components/app/collectibles-tab/collectibles-tab.js
+++ b/ui/components/app/collectibles-tab/collectibles-tab.js
@@ -42,15 +42,14 @@ export default function CollectiblesTab({ onAddNFT }) {
   const dispatch = useDispatch();
 
   const getCollections = () => {
-    const collections = {
-      previouslyOwned: {
-        collectionName: 'Previously Owned',
-        collectibles: [],
-      },
+    const collections = {};
+    const previouslyOwnedCollection = {
+      collectionName: 'Previously Owned',
+      collectibles: [],
     };
     collectibles.forEach((collectible) => {
       if (collectible?.isCurrentlyOwned === false) {
-        collections.previouslyOwned.push(collectible);
+        previouslyOwnedCollection.collectibles.push(collectible);
       } else if (collections[collectible.address]) {
         collections[collectible.address].collectibles.push(collectible);
       } else {
@@ -65,27 +64,34 @@ export default function CollectiblesTab({ onAddNFT }) {
         };
       }
     });
-    return collections;
+    return [collections, previouslyOwnedCollection];
   };
 
-  const collections = useMemo(() => getCollections, [
-    collectibles,
-    collectibleContracts,
-  ]);
+  // const [collections, previouslyOwnedCollection] = useMemo(
+  //   () => getCollections(),
+  //   [collectibles, collectibleContracts],
+  // ); 
+  
+  const [collections, previouslyOwnedCollection] = getCollections();
 
   const onEnableAutoDetect = () => {
     history.push(EXPERIMENTAL_ROUTE);
   };
 
   const onRefresh = () => {
-    dispatch(detectCollectibles());
+    if (isMainnet) {
+      dispatch(detectCollectibles());
+    }
     dispatch(checkAndUpdateCollectiblesOwnershipStatus());
   };
 
   return (
     <div className="collectibles-tab">
       {collectibles.length > 0 ? (
-        <CollectiblesItems collections={collections} />
+        <CollectiblesItems
+          collections={collections}
+          previouslyOwnedCollection={previouslyOwnedCollection}
+        />
       ) : (
         <Box padding={[6, 12, 6, 12]}>
           {isMainnet &&
@@ -138,31 +144,27 @@ export default function CollectiblesTab({ onAddNFT }) {
           alignItems={ALIGN_ITEMS.CENTER}
           justifyContent={JUSTIFY_CONTENT.CENTER}
         >
-          {isMainnet ? (
-            <>
-              <Box
-                className="collectibles-tab__link"
-                justifyContent={JUSTIFY_CONTENT.FLEX_END}
-              >
-                {useCollectibleDetection ? (
-                  <Button type="link" onClick={onRefresh}>
-                    {t('refreshList')}
-                  </Button>
-                ) : (
-                  <Button type="link" onClick={onEnableAutoDetect}>
-                    {t('enableAutoDetect')}
-                  </Button>
-                )}
-              </Box>
-              <Typography
-                color={COLORS.UI3}
-                variant={TYPOGRAPHY.H4}
-                align={TEXT_ALIGN.CENTER}
-              >
-                {t('or')}
-              </Typography>
-            </>
-          ) : null}
+          <Box
+            className="collectibles-tab__link"
+            justifyContent={JUSTIFY_CONTENT.FLEX_END}
+          >
+            {isMainnet && !useCollectibleDetection ? (
+              <Button type="link" onClick={onEnableAutoDetect}>
+                {t('enableAutoDetect')}
+              </Button>
+            ) : (
+              <Button type="link" onClick={onRefresh}>
+                {t('refreshList')}
+              </Button>
+            )}
+          </Box>
+          <Typography
+            color={COLORS.UI3}
+            variant={TYPOGRAPHY.H4}
+            align={TEXT_ALIGN.CENTER}
+          >
+            {t('or')}
+          </Typography>
           <Box
             justifyContent={JUSTIFY_CONTENT.FLEX_START}
             className="collectibles-tab__link"

--- a/ui/components/app/collectibles-tab/collectibles-tab.test.js
+++ b/ui/components/app/collectibles-tab/collectibles-tab.test.js
@@ -172,9 +172,13 @@ const render = ({
 describe('Collectible Items', () => {
   const detectCollectiblesStub = jest.fn();
   const setCollectiblesDetectionNoticeDismissedStub = jest.fn();
+  const getStateStub = jest.fn();
+  const checkAndUpdateCollectiblesOwnershipStatusStub = jest.fn();
   setBackgroundConnection({
     setCollectiblesDetectionNoticeDismissed: setCollectiblesDetectionNoticeDismissedStub,
     detectCollectibles: detectCollectiblesStub,
+    getState: getStateStub,
+    checkAndUpdateCollectiblesOwnershipStatus: checkAndUpdateCollectiblesOwnershipStatusStub,
   });
   const historyPushMock = jest.fn();
 
@@ -264,15 +268,33 @@ describe('Collectible Items', () => {
     });
   });
   describe('Collectibles options', () => {
-    it('should render a link "Refresh list" when some collectibles are present and collectible auto-detection preference is set to true, which, when clicked calls a method DetectCollectibles', () => {
+    it('should render a link "Refresh list" when some collectibles are present on mainnet and collectible auto-detection preference is set to true, which, when clicked calls methods DetectCollectibles and checkAndUpdateCollectiblesOwnershipStatus', () => {
       render({
         selectedAddress: ACCOUNT_1,
         collectibles: COLLECTIBLES,
         useCollectibleDetection: true,
       });
       expect(detectCollectiblesStub).not.toHaveBeenCalled();
+      expect(
+        checkAndUpdateCollectiblesOwnershipStatusStub,
+      ).not.toHaveBeenCalled();
       fireEvent.click(screen.queryByText('Refresh list'));
       expect(detectCollectiblesStub).toHaveBeenCalled();
+      expect(checkAndUpdateCollectiblesOwnershipStatusStub).toHaveBeenCalled();
+    });
+
+    it('should render a link "Refresh list" when some collectibles are present on a non-mainnet chain, which, when clicked calls a method checkAndUpdateCollectiblesOwnershipStatus', () => {
+      render({
+        chainId: '0x4',
+        selectedAddress: ACCOUNT_1,
+        collectibles: COLLECTIBLES,
+        useCollectibleDetection: true,
+      });
+      expect(
+        checkAndUpdateCollectiblesOwnershipStatusStub,
+      ).not.toHaveBeenCalled();
+      fireEvent.click(screen.queryByText('Refresh list'));
+      expect(checkAndUpdateCollectiblesOwnershipStatusStub).toHaveBeenCalled();
     });
 
     it('should render a link "Enable Autodetect" when some collectibles are present and collectible auto-detection preference is set to false, which, when clicked sends user to the experimental tab of settings', () => {

--- a/ui/store/actions.js
+++ b/ui/store/actions.js
@@ -1391,6 +1391,19 @@ export function removeCollectible(address, tokenID, dontShowLoadingIndicator) {
   };
 }
 
+export function checkAndUpdateCollectiblesOwnershipStatus() {
+  return async (dispatch) => {
+    try {
+      await promisifiedBackground.checkAndUpdateCollectiblesOwnershipStatus();
+    } catch (error) {
+      log.error(error);
+      dispatch(displayWarning(error.message));
+    } finally {
+      await forceUpdateMetamaskState(dispatch);
+    }
+  };
+}
+
 export function removeToken(address) {
   return async (dispatch) => {
     dispatch(showLoadingIndication());

--- a/ui/store/actions.js
+++ b/ui/store/actions.js
@@ -1392,14 +1392,11 @@ export function removeCollectible(address, tokenID, dontShowLoadingIndicator) {
 }
 
 export function checkAndUpdateCollectiblesOwnershipStatus() {
-  return async (dispatch) => {
+  return async () => {
     try {
       await promisifiedBackground.checkAndUpdateCollectiblesOwnershipStatus();
     } catch (error) {
       log.error(error);
-      dispatch(displayWarning(error.message));
-    } finally {
-      await forceUpdateMetamaskState(dispatch);
     }
   };
 }

--- a/ui/store/actions.js
+++ b/ui/store/actions.js
@@ -1391,14 +1391,8 @@ export function removeCollectible(address, tokenID, dontShowLoadingIndicator) {
   };
 }
 
-export function checkAndUpdateCollectiblesOwnershipStatus() {
-  return async () => {
-    try {
-      await promisifiedBackground.checkAndUpdateCollectiblesOwnershipStatus();
-    } catch (error) {
-      log.error(error);
-    }
-  };
+export async function checkAndUpdateCollectiblesOwnershipStatus() {
+  await promisifiedBackground.checkAndUpdateCollectiblesOwnershipStatus();
 }
 
 export function removeToken(address) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2643,10 +2643,10 @@
     web3 "^0.20.7"
     web3-provider-engine "^16.0.3"
 
-"@metamask/controllers@^22.0.0":
-  version "22.0.0"
-  resolved "https://registry.yarnpkg.com/@metamask/controllers/-/controllers-22.0.0.tgz#54f172be2ae7e32ce47536a1ff06e35cc6ee3c80"
-  integrity sha512-5m4aT+B87IOAvvlbfgqI5n7Pd6VSQUjHBfm34qMBBL5jjUFUSfK6BL0h6ef2jxTE2VCuyBibQ8A7sETQ1+Hd+Q==
+"@metamask/controllers@^23.0.0":
+  version "23.0.0"
+  resolved "https://registry.yarnpkg.com/@metamask/controllers/-/controllers-23.0.0.tgz#81ea9fa37924a14b08668f37e7e31f46091aa610"
+  integrity sha512-6hKh5H0HM1YLTOdfuD8gRXGCG3brEhTagup204SrlmwabTReaIIb/zXTat7jCs6ZvN362a44GO5mboZ6W9MhIA==
   dependencies:
     "@ethereumjs/common" "^2.3.1"
     "@ethereumjs/tx" "^3.2.1"
@@ -2667,7 +2667,6 @@
     ethereumjs-wallet "^1.0.1"
     ethers "^5.4.1"
     ethjs-unit "^0.1.6"
-    ethjs-util "^0.1.6"
     human-standard-collectible-abi "^1.0.2"
     human-standard-multi-collectible-abi "^1.0.4"
     human-standard-token-abi "^2.0.0"


### PR DESCRIPTION
Explanation:  Adds use of the `checkAndUpdateCollectiblesOwnershipStatus` method, added to the CollectibleController in this [PR](https://github.com/MetaMask/controllers/pull/664). When a user clicks the "Refresh List" button
<img width="437" alt="Screen Shot 2021-12-22 at 9 00 56 AM" src="https://user-images.githubusercontent.com/34557516/147112455-f607eb2c-2020-4878-a858-c889d8407413.png">
at the bottom of the NFT tab, this method will query the contract of each the NFTs the user currently has in their collection and check whether they still own each. In the case that they do not still own it, a value on the collectible object `isCurrentlyOwned` will be set to false, and in the UI this collectible will be moved to a **newly added** previously owned section.

Manual testing steps:  
  - Get an NFT on a test network (this [faucet](https://faucet.paradigm.xyz/) will add NFTs to many testnets)
  - Manually add the NFT via the Import NFTs flow 
<img width="305" alt="Screen Shot 2021-12-22 at 9 08 06 AM" src="https://user-images.githubusercontent.com/34557516/147113379-df25ec95-c3d7-4094-b74e-318f6868bdc2.png">
  - Make sure its been correctly added as a collection in the NFTs tabs
  - Send the NFT using Etherscan:

https://user-images.githubusercontent.com/34557516/147114538-f32db2ad-afe8-4638-882c-6c95a0b63219.mov

- Once the transaction has been confirmed hit "refresh list". You should see that the NFT has now been moved to a "Previously Owned" Collection.
