### PR TITLE
Add Snaps network access permission

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -1038,10 +1038,6 @@
   "ethGasPriceFetchWarning": {
     "message": "Backup gas price is provided as the main gas estimation service is unavailable right now."
   },
-  "eth_accounts": {
-    "message": "See address, account balance, activity and initiate transactions",
-    "description": "The description for the `eth_accounts` permission"
-  },
   "ethereumPublicAddress": {
     "message": "Ethereum Public Address"
   },
@@ -2142,6 +2138,34 @@
   "permissionRequest": {
     "message": "Permission request"
   },
+  "permission_accessNetwork": {
+    "message": "Access the Internet.",
+    "description": "The description of the `endowment:network-access` permission."
+  },
+  "permission_accessSnap": {
+    "message": "Connect to the $1 Snap.",
+    "description": "The description for the `wallet_snap_*` permission. $1 is the name of the Snap."
+  },
+  "permission_customConfirmation": {
+    "message": "Display a confirmation in MetaMask.",
+    "description": "The description for the `snap_confirm` permission"
+  },
+  "permission_ethereumAccounts": {
+    "message": "See address, account balance, activity and initiate transactions",
+    "description": "The description for the `eth_accounts` permission"
+  },
+  "permission_manageBip44Keys": {
+    "message": "Manage keys for the $1 protocol.",
+    "description": "The description for the `snap_getBip44Entropy_*` permission. $1 is the name of a protocol, e.g. 'Filecoin'."
+  },
+  "permission_manageState": {
+    "message": "Store and manage its data on your device.",
+    "description": "The description for the `snap_manageState` permission"
+  },
+  "permission_unknown": {
+    "message": "Unknown permission: $1",
+    "description": "$1 is the name of a requested permission that is not recognized."
+  },
   "permissions": {
     "message": "Permissions"
   },
@@ -2591,26 +2615,6 @@
   },
   "slow": {
     "message": "Slow"
-  },
-  "snap_clearState": {
-    "message": "Clear its stored data from your device.",
-    "description": "The description for the `snap_clearState` permission"
-  },
-  "snap_confirm": {
-    "message": "Display a confirmation in MetaMask.",
-    "description": "The description for the `snap_confirm` permission"
-  },
-  "snap_getBip44Entropy_": {
-    "message": "Manage keys for the $1 protocol.",
-    "description": "The description for the `snap_getBip44Entropy_*` permission. $1 is the name of a protocol, e.g. 'Filecoin'."
-  },
-  "snap_getState": {
-    "message": "Access its stored data on your device.",
-    "description": "The description for the `snap_updateState` permission"
-  },
-  "snap_updateState": {
-    "message": "Store data on your device.",
-    "description": "The description for the `snap_updateState` permission"
   },
   "somethingWentWrong": {
     "message": "Oops! Something went wrong."
@@ -3306,10 +3310,6 @@
   "unknownNetwork": {
     "message": "Unknown Private Network"
   },
-  "unknownPermission": {
-    "message": "Unknown permission: $1",
-    "description": "$1 is the name of a requested permission that is not recognized."
-  },
   "unknownQrCode": {
     "message": "Error: We couldn't identify that QR code"
   },
@@ -3443,10 +3443,6 @@
   },
   "walletSeedRestore": {
     "message": "Wallet Secret Recovery Phrase"
-  },
-  "wallet_snap_": {
-    "message": "Connect to the $1 Snap.",
-    "description": "The description for the `wallet_snap_*` permission. $1 is the name of the Snap."
   },
   "web3ShimUsageNotification": {
     "message": "We noticed that the current website tried to use the removed window.web3 API. If the site appears to be broken, please click $1 for more information.",

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -2155,7 +2155,7 @@
     "description": "The description for the `eth_accounts` permission"
   },
   "permission_manageBip44Keys": {
-    "message": "Manage keys for the $1 protocol.",
+    "message": "Manage your \"$1\" keys.",
     "description": "The description for the `snap_getBip44Entropy_*` permission. $1 is the name of a protocol, e.g. 'Filecoin'."
   },
   "permission_manageState": {

--- a/app/_locales/es/messages.json
+++ b/app/_locales/es/messages.json
@@ -681,10 +681,6 @@
   "ethGasPriceFetchWarning": {
     "message": "Se muestra el precio del gas de respaldo, ya que el servicio para calcular el precio del gas principal no se encuentra disponible en este momento."
   },
-  "eth_accounts": {
-    "message": "Ver las direcciones de las cuentas permitidas (requerido)",
-    "description": "The description for the `eth_accounts` permission"
-  },
   "ethereumPublicAddress": {
     "message": "Dirección pública de Ethereum"
   },
@@ -1342,6 +1338,10 @@
   },
   "pending": {
     "message": "Pendiente"
+  },
+  "permission_ethereumAccounts": {
+    "message": "Ver las direcciones de las cuentas permitidas (requerido)",
+    "description": "The description for the `eth_accounts` permission"
   },
   "permissions": {
     "message": "Permisos"

--- a/app/_locales/es_419/messages.json
+++ b/app/_locales/es_419/messages.json
@@ -681,10 +681,6 @@
   "ethGasPriceFetchWarning": {
     "message": "Se muestra el precio del gas de respaldo, ya que el servicio para calcular el precio del gas principal no se encuentra disponible en este momento."
   },
-  "eth_accounts": {
-    "message": "Ver las direcciones de las cuentas permitidas (requerido)",
-    "description": "The description for the `eth_accounts` permission"
-  },
   "ethereumPublicAddress": {
     "message": "Dirección pública de Ethereum"
   },
@@ -1342,6 +1338,10 @@
   },
   "pending": {
     "message": "Pendiente"
+  },
+  "permission_ethereumAccounts": {
+    "message": "Ver las direcciones de las cuentas permitidas (requerido)",
+    "description": "The description for the `eth_accounts` permission"
   },
   "permissions": {
     "message": "Permisos"

--- a/app/_locales/hi/messages.json
+++ b/app/_locales/hi/messages.json
@@ -681,10 +681,6 @@
   "ethGasPriceFetchWarning": {
     "message": "बैकअप गैस की कीमत प्रदान की जाती है क्योंकि मुख्य गैस अनुमान सर्विस अभी उपलब्ध नहीं है।"
   },
-  "eth_accounts": {
-    "message": "अपने अनुमत खातों के पते देखें (आवश्यक)",
-    "description": "The description for the `eth_accounts` permission"
-  },
   "ethereumPublicAddress": {
     "message": "Ethereum सार्वजनिक पता"
   },
@@ -1342,6 +1338,10 @@
   },
   "pending": {
     "message": "लंबित"
+  },
+  "permission_ethereumAccounts": {
+    "message": "अपने अनुमत खातों के पते देखें (आवश्यक)",
+    "description": "The description for the `eth_accounts` permission"
   },
   "permissions": {
     "message": "अनुमतियाँ"

--- a/app/_locales/id/messages.json
+++ b/app/_locales/id/messages.json
@@ -681,10 +681,6 @@
   "ethGasPriceFetchWarning": {
     "message": "Biaya jaringan cadangan diberikan karena layanan estimasi biaya jaringan utama tidak tersedia saat ini."
   },
-  "eth_accounts": {
-    "message": "Lihat alamat akun Anda yang diizinkan (wajib)",
-    "description": "The description for the `eth_accounts` permission"
-  },
   "ethereumPublicAddress": {
     "message": "Alamat Publik Ethereum"
   },
@@ -1342,6 +1338,10 @@
   },
   "pending": {
     "message": "Tunda"
+  },
+  "permission_ethereumAccounts": {
+    "message": "Lihat alamat akun Anda yang diizinkan (wajib)",
+    "description": "The description for the `eth_accounts` permission"
   },
   "permissions": {
     "message": "Izin"

--- a/app/_locales/it/messages.json
+++ b/app/_locales/it/messages.json
@@ -585,10 +585,6 @@
   "estimatedProcessingTimes": {
     "message": "Tempi di Elaborazione Stimati"
   },
-  "eth_accounts": {
-    "message": "Accesso agli indirizzi dei tuoi account autorizzati (richiesto)",
-    "description": "The description for the `eth_accounts` permission"
-  },
   "ethereumPublicAddress": {
     "message": "Indirizzo pubblico Ethereum "
   },
@@ -1101,6 +1097,10 @@
   },
   "pending": {
     "message": "in corso"
+  },
+  "permission_ethereumAccounts": {
+    "message": "Accesso agli indirizzi dei tuoi account autorizzati (richiesto)",
+    "description": "The description for the `eth_accounts` permission"
   },
   "permissions": {
     "message": "Permessi"

--- a/app/_locales/ja/messages.json
+++ b/app/_locales/ja/messages.json
@@ -681,10 +681,6 @@
   "ethGasPriceFetchWarning": {
     "message": "現在、主なガスの見積もりサービスは行っていないので、バックアップのガス料金を提供しています。"
   },
-  "eth_accounts": {
-    "message": "許可されたアカウントのアドレスを表示してください (必須)",
-    "description": "The description for the `eth_accounts` permission"
-  },
   "ethereumPublicAddress": {
     "message": "パブリック イーサリアム アドレス"
   },
@@ -1342,6 +1338,10 @@
   },
   "pending": {
     "message": "処理"
+  },
+  "permission_ethereumAccounts": {
+    "message": "許可されたアカウントのアドレスを表示してください (必須)",
+    "description": "The description for the `eth_accounts` permission"
   },
   "permissions": {
     "message": "許可"

--- a/app/_locales/ko/messages.json
+++ b/app/_locales/ko/messages.json
@@ -681,10 +681,6 @@
   "ethGasPriceFetchWarning": {
     "message": "현재 주요 Gas 견적 서비스를 사용할 수 없으므로 백업 Gas 가격을 제공합니다."
   },
-  "eth_accounts": {
-    "message": "허용되는 계정의 주소 보기(필수)",
-    "description": "The description for the `eth_accounts` permission"
-  },
   "ethereumPublicAddress": {
     "message": "이더리움 공개 주소"
   },
@@ -1342,6 +1338,10 @@
   },
   "pending": {
     "message": "보류 중"
+  },
+  "permission_ethereumAccounts": {
+    "message": "허용되는 계정의 주소 보기(필수)",
+    "description": "The description for the `eth_accounts` permission"
   },
   "permissions": {
     "message": "권한"

--- a/app/_locales/ph/messages.json
+++ b/app/_locales/ph/messages.json
@@ -681,10 +681,6 @@
   "ethGasPriceFetchWarning": {
     "message": "Ibinibigay ang backup na presyo ng gas dahil hindi available ang pangunahing serbisyo sa pagtatantya ng gas sa ngayon."
   },
-  "eth_accounts": {
-    "message": "Tingnan ang mga address ng iyong mga pinapayagang account (kinakailangan)",
-    "description": "The description for the `eth_accounts` permission"
-  },
   "ethereumPublicAddress": {
     "message": "Pampublikong Address ng Ethereum"
   },
@@ -1342,6 +1338,10 @@
   },
   "pending": {
     "message": "Nakabinbin"
+  },
+  "permission_ethereumAccounts": {
+    "message": "Tingnan ang mga address ng iyong mga pinapayagang account (kinakailangan)",
+    "description": "The description for the `eth_accounts` permission"
   },
   "permissions": {
     "message": "Mga Pahintulot"

--- a/app/_locales/pt_BR/messages.json
+++ b/app/_locales/pt_BR/messages.json
@@ -681,10 +681,6 @@
   "ethGasPriceFetchWarning": {
     "message": "Serviço de preço back-up do gas ser fornecido como a estimativa de gas principal está indisponível no momento."
   },
-  "eth_accounts": {
-    "message": "Exibir os endereços das suas contas permitidas (obrigatório)",
-    "description": "The description for the `eth_accounts` permission"
-  },
   "ethereumPublicAddress": {
     "message": "Endereço público do Ethereum"
   },
@@ -1342,6 +1338,10 @@
   },
   "pending": {
     "message": "Pendente"
+  },
+  "permission_ethereumAccounts": {
+    "message": "Exibir os endereços das suas contas permitidas (obrigatório)",
+    "description": "The description for the `eth_accounts` permission"
   },
   "permissions": {
     "message": "Permissões"

--- a/app/_locales/ru/messages.json
+++ b/app/_locales/ru/messages.json
@@ -681,10 +681,6 @@
   "ethGasPriceFetchWarning": {
     "message": "Указана вспомогательная цена газа, поскольку сервис определения основной стоимости сейчас недоступен."
   },
-  "eth_accounts": {
-    "message": "Просмотр адресов ваших разрешенных счетов (обязательно)",
-    "description": "The description for the `eth_accounts` permission"
-  },
   "ethereumPublicAddress": {
     "message": "Публичный адрес Ethereum"
   },
@@ -1342,6 +1338,10 @@
   },
   "pending": {
     "message": "В ожидании"
+  },
+  "permission_ethereumAccounts": {
+    "message": "Просмотр адресов ваших разрешенных счетов (обязательно)",
+    "description": "The description for the `eth_accounts` permission"
   },
   "permissions": {
     "message": "Разрешения"

--- a/app/_locales/tl/messages.json
+++ b/app/_locales/tl/messages.json
@@ -576,10 +576,6 @@
   "estimatedProcessingTimes": {
     "message": "Mga Tinatantyang Tagal ng Pagproseso"
   },
-  "eth_accounts": {
-    "message": "Tingnan ang mga address ng iyong mga pinapayagang account (kinakailangan)",
-    "description": "The description for the `eth_accounts` permission"
-  },
   "ethereumPublicAddress": {
     "message": "Pampublikong Address ng Ethereum"
   },
@@ -1092,6 +1088,10 @@
   },
   "pending": {
     "message": "Nakabinbin"
+  },
+  "permission_ethereumAccounts": {
+    "message": "Tingnan ang mga address ng iyong mga pinapayagang account (kinakailangan)",
+    "description": "The description for the `eth_accounts` permission"
   },
   "permissions": {
     "message": "Mga Pahintulot"

--- a/app/_locales/vi/messages.json
+++ b/app/_locales/vi/messages.json
@@ -681,10 +681,6 @@
   "ethGasPriceFetchWarning": {
     "message": "Giá gas dự phòng được cung cấp vì dịch vụ ước tính giá gas chính hiện không hoạt động."
   },
-  "eth_accounts": {
-    "message": "Xem địa chỉ của các tài khoản được cho phép của bạn (bắt buộc)",
-    "description": "The description for the `eth_accounts` permission"
-  },
   "ethereumPublicAddress": {
     "message": "Địa chỉ công khai trên Ethereum"
   },
@@ -1342,6 +1338,10 @@
   },
   "pending": {
     "message": "Đang chờ xử lý"
+  },
+  "permission_ethereumAccounts": {
+    "message": "Xem địa chỉ của các tài khoản được cho phép của bạn (bắt buộc)",
+    "description": "The description for the `eth_accounts` permission"
   },
   "permissions": {
     "message": "Quyền"

--- a/app/_locales/zh_CN/messages.json
+++ b/app/_locales/zh_CN/messages.json
@@ -624,10 +624,6 @@
   "estimatedProcessingTimes": {
     "message": "预计处理时间"
   },
-  "eth_accounts": {
-    "message": "查看您允许的账户的地址（必填）",
-    "description": "The description for the `eth_accounts` permission"
-  },
   "ethereumPublicAddress": {
     "message": "以太坊 Ethereum 公开地址"
   },
@@ -1143,6 +1139,10 @@
   },
   "pending": {
     "message": "待处理"
+  },
+  "permission_ethereumAccounts": {
+    "message": "查看您允许的账户的地址（必填）",
+    "description": "The description for the `eth_accounts` permission"
   },
   "permissions": {
     "message": "权限"

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -152,10 +152,6 @@ export default class MetamaskController extends EventEmitter {
     this.extension = opts.extension;
     this.platform = opts.platform;
     const initState = opts.initState || {};
-    // TODO:temp
-    delete initState.PermissionController;
-    delete initState.SnapController;
-    delete initState.SubjectMetadataController;
     const version = this.platform.getVersion();
     this.recordFirstTimeInfo(initState);
 

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -152,6 +152,10 @@ export default class MetamaskController extends EventEmitter {
     this.extension = opts.extension;
     this.platform = opts.platform;
     const initState = opts.initState || {};
+    // TODO:temp
+    delete initState.PermissionController;
+    delete initState.SnapController;
+    delete initState.SubjectMetadataController;
     const version = this.platform.getVersion();
     this.recordFirstTimeInfo(initState);
 
@@ -565,7 +569,7 @@ export default class MetamaskController extends EventEmitter {
     });
 
     this.snapController = new SnapController({
-      endowmentPermissionNames: Object.keys(EndowmentPermissions),
+      endowmentPermissionNames: Object.values(EndowmentPermissions),
       terminateAllSnaps: this.workerController.terminateAllSnaps.bind(
         this.workerController,
       ),

--- a/package.json
+++ b/package.json
@@ -118,6 +118,7 @@
     "@metamask/post-message-stream": "^4.0.0",
     "@metamask/providers": "^8.1.1",
     "@metamask/rpc-methods": "^0.6.1",
+    "@metamask/slip44": "^1.0.0",
     "@metamask/snap-controllers": "^0.6.1",
     "@ngraveio/bc-ur": "^1.1.6",
     "@popperjs/core": "^2.4.0",

--- a/shared/constants/permissions.js
+++ b/shared/constants/permissions.js
@@ -13,6 +13,11 @@ export const RestrictedMethods = Object.freeze({
 });
 
 ///: BEGIN:ONLY_INCLUDE_IN(flask)
+export const PermissionNamespaces = Object.freeze({
+  snap_getBip44Entropy_: 'snap_getBip44Entropy_*',
+  wallet_snap_: 'wallet_snap_*',
+});
+
 export const EndowmentPermissions = Object.freeze({
   'endowment:network-access': 'endowment:network-access',
 });

--- a/ui/components/app/permissions-connect-permission-list/permissions-connect-permission-list.js
+++ b/ui/components/app/permissions-connect-permission-list/permissions-connect-permission-list.js
@@ -1,72 +1,110 @@
 import React, { useMemo } from 'react';
 import PropTypes from 'prop-types';
+import {
+  RestrictedMethods,
+  EndowmentPermissions,
+  ///: BEGIN:ONLY_INCLUDE_IN(flask)
+  PermissionNamespaces,
+  ///: END:ONLY_INCLUDE_IN
+} from '../../../../shared/constants/permissions';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 
 const UNKNOWN_PERMISSION = Symbol('unknown');
 
+/**
+ * @typedef {Object} PermissionLabelObject
+ * @property {string} label - The text label.
+ * @property {string} leftIcon - The left icon.
+ * @property {string} rightIcon - The right icon.
+ */
+
+/**
+ * Gets the permission list label dictionary key for the specified permission
+ * name.
+ *
+ * @param {string} permissionName - The name of the permission whose key to
+ * retrieve.
+ * @param {Record<string, PermissionLabelObject>} permissionDictionary - The
+ * dictionary object mapping permission keys to label objects.
+ */
+function getPermissionKey(permissionName, permissionDictionary) {
+  if (Object.hasOwnProperty.call(permissionDictionary, permissionName)) {
+    return permissionName;
+  }
+  ///: BEGIN:ONLY_INCLUDE_IN(flask)
+  for (const namespace of Object.keys(PermissionNamespaces)) {
+    if (permissionName.startsWith(namespace)) {
+      return PermissionNamespaces[namespace];
+    }
+  }
+  ///: END:ONLY_INCLUDE_IN
+
+  return UNKNOWN_PERMISSION;
+}
+
 export default function PermissionsConnectPermissionList({ permissions }) {
   const t = useI18nContext();
 
-  // TODO:flask Fix Snap permission labels and support namespaced permissions
-  const PERMISSION_TYPES = useMemo(() => {
+  const PERMISSION_LIST_VALUES = useMemo(() => {
     return {
-      eth_accounts: {
+      [RestrictedMethods.eth_accounts]: {
         leftIcon: 'fas fa-eye',
-        label: t('eth_accounts'),
+        label: t('permission_ethereumAccounts'),
         rightIcon: null,
       },
       ///: BEGIN:ONLY_INCLUDE_IN(flask)
-      snap_confirm: {
-        leftIcon: 'fas fa-eye',
-        label: 'snap_confirm',
+      [RestrictedMethods.snap_confirm]: {
+        leftIcon: 'fas fa-user-check',
+        label: t('permission_customConfirmation'),
         rightIcon: null,
       },
-      // TODO: We need a function to pass substitutions to `t` for this.
-      'snap_getBip44Entropy_*': {
-        leftIcon: 'fas fa-eye',
-        label: 'snap_getBip44Entropy_*',
+      [RestrictedMethods['snap_getBip44Entropy_*']]: (permissionName) => {
+        const coinType = permissionName.split('_').slice(-1);
+        return {
+          leftIcon: 'fas fa-door-open',
+          label: t('permission_manageBip44Keys', [coinType]),
+          rightIcon: null,
+        };
+      },
+      [RestrictedMethods.snap_manageState]: {
+        leftIcon: 'fas fa-download',
+        label: t('permission_manageState'),
         rightIcon: null,
       },
-      snap_manageState: {
-        leftIcon: 'fas fa-eye',
-        label: 'snap_manageState',
-        rightIcon: null,
+      [RestrictedMethods['wallet_snap_*']]: (permissionName) => {
+        const snapId = permissionName.split('_').slice(-1);
+        return {
+          leftIcon: 'fas fa-bolt',
+          label: t('permission_accessSnap', [snapId]),
+          rightIcon: null,
+        };
       },
-      'wallet_snap_*': {
-        leftIcon: 'fas fa-eye',
-        label: 'wallet_snap_*',
+      [EndowmentPermissions['endowment:network-access']]: {
+        leftIcon: 'fas fa-wifi',
+        label: t('permission_accessNetwork'),
         rightIcon: null,
       },
       ///: END:ONLY_INCLUDE_IN
-      [UNKNOWN_PERMISSION]: {
-        leftIcon: null,
-        label: 'Unknown Permission',
-        rightIcon: null,
+      [UNKNOWN_PERMISSION]: (permissionName) => {
+        return {
+          leftIcon: 'fas fa-times-circle',
+          label: t('permission_unknown', [permissionName ?? 'undefined']),
+          rightIcon: null,
+        };
       },
     };
   }, [t]);
 
-  function getPermissionKey(permissionName) {
-    if (PERMISSION_TYPES[permissionName]) {
-      return permissionName;
-    }
-    ///: BEGIN:ONLY_INCLUDE_IN(flask)
-    else if (permissionName.startsWith('wallet_snap_')) {
-      return 'wallet_snap_*';
-    } else if (permissionName.startsWith('snap_getBip44Entropy_')) {
-      return 'snap_getBip44Entropy_*';
-    }
-    ///: END:ONLY_INCLUDE_IN
-
-    return UNKNOWN_PERMISSION;
-  }
-
   return (
     <div className="permissions-connect-permission-list">
       {Object.keys(permissions).map((permission) => {
-        const { label, leftIcon, rightIcon } = PERMISSION_TYPES[
-          getPermissionKey(permission)
-        ];
+        const listValue =
+          PERMISSION_LIST_VALUES[
+            getPermissionKey(permission, PERMISSION_LIST_VALUES)
+          ];
+
+        const { label, leftIcon, rightIcon } =
+          typeof listValue === 'function' ? listValue(permission) : listValue;
 
         return (
           <div className="permission" key={label}>

--- a/ui/components/app/permissions-connect-permission-list/permissions-connect-permission-list.js
+++ b/ui/components/app/permissions-connect-permission-list/permissions-connect-permission-list.js
@@ -2,13 +2,15 @@ import React, { useMemo } from 'react';
 import PropTypes from 'prop-types';
 import {
   RestrictedMethods,
-  EndowmentPermissions,
   ///: BEGIN:ONLY_INCLUDE_IN(flask)
+  EndowmentPermissions,
   PermissionNamespaces,
   ///: END:ONLY_INCLUDE_IN
 } from '../../../../shared/constants/permissions';
 import { useI18nContext } from '../../../hooks/useI18nContext';
+///: BEGIN:ONLY_INCLUDE_IN(flask)
 import { coinTypeToProtocolName } from '../../../helpers/utils/util';
+///: END:ONLY_INCLUDE_IN
 
 const UNKNOWN_PERMISSION = Symbol('unknown');
 

--- a/ui/components/app/permissions-connect-permission-list/permissions-connect-permission-list.js
+++ b/ui/components/app/permissions-connect-permission-list/permissions-connect-permission-list.js
@@ -8,6 +8,7 @@ import {
   ///: END:ONLY_INCLUDE_IN
 } from '../../../../shared/constants/permissions';
 import { useI18nContext } from '../../../hooks/useI18nContext';
+import { coinTypeToProtocolName } from '../../../helpers/utils/util';
 
 const UNKNOWN_PERMISSION = Symbol('unknown');
 
@@ -62,7 +63,10 @@ export default function PermissionsConnectPermissionList({ permissions }) {
         const coinType = permissionName.split('_').slice(-1);
         return {
           leftIcon: 'fas fa-door-open',
-          label: t('permission_manageBip44Keys', [coinType]),
+          label: t('permission_manageBip44Keys', [
+            coinTypeToProtocolName(coinType) ||
+              `${coinType} (Unrecognized protocol)`,
+          ]),
           rightIcon: null,
         };
       },

--- a/ui/contexts/i18n.js
+++ b/ui/contexts/i18n.js
@@ -16,13 +16,9 @@ export const I18nProvider = (props) => {
   const en = useSelector(getEnLocaleMessages);
 
   const t = useMemo(() => {
-    return (key, ...args) => {
-      const _key = key && key.endsWith('*') ? key.slice(0, -1) : key;
-      return (
-        getMessage(currentLocale, current, _key, ...args) ||
-        getMessage(currentLocale, en, _key, ...args)
-      );
-    };
+    return (key, ...args) =>
+      getMessage(currentLocale, current, key, ...args) ||
+      getMessage(currentLocale, en, key, ...args);
   }, [currentLocale, current, en]);
 
   return (

--- a/ui/contexts/i18n.js
+++ b/ui/contexts/i18n.js
@@ -16,9 +16,13 @@ export const I18nProvider = (props) => {
   const en = useSelector(getEnLocaleMessages);
 
   const t = useMemo(() => {
-    return (key, ...args) =>
-      getMessage(currentLocale, current, key, ...args) ||
-      getMessage(currentLocale, en, key, ...args);
+    return (key, ...args) => {
+      const _key = key && key.endsWith('*') ? key.slice(0, -1) : key;
+      return (
+        getMessage(currentLocale, current, _key, ...args) ||
+        getMessage(currentLocale, en, _key, ...args)
+      );
+    };
   }, [currentLocale, current, en]);
 
   return (

--- a/ui/helpers/utils/util.js
+++ b/ui/helpers/utils/util.js
@@ -4,6 +4,7 @@ import BigNumber from 'bignumber.js';
 import * as ethUtil from 'ethereumjs-util';
 import { DateTime } from 'luxon';
 import { util } from '@metamask/controllers';
+import slip44 from '@metamask/slip44';
 import { addHexPrefix } from '../../../app/scripts/lib/util';
 import {
   GOERLI_CHAIN_ID,
@@ -557,4 +558,19 @@ export function getAssetImageURL(image, ipfsGateway) {
     return util.getFormattedIpfsUrl(ipfsGateway, image, true);
   }
   return image;
+}
+
+/**
+ * Gets the name of the SLIP-44 protocol corresponding to the specified
+ * `coin_type`.
+ *
+ * @param {string | number} coinType - The SLIP-44 `coin_type` value whose name
+ * to retrieve.
+ * @returns {string | undefined} The name of the protocol if found.
+ */
+export function coinTypeToProtocolName(coinType) {
+  if (String(coinType) === '1') {
+    return 'Test Networks';
+  }
+  return slip44[coinType]?.name || undefined;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2843,6 +2843,11 @@
   resolved "https://registry.yarnpkg.com/@metamask/safe-event-emitter/-/safe-event-emitter-2.0.0.tgz#af577b477c683fad17c619a78208cede06f9605c"
   integrity sha512-/kSXhY692qiV1MXu6EeOZvg5nECLclxNXcKCxJ3cXQgYuRymRHpdx/t7JXfsK+JLjwA1e1c1/SBrlQYpusC29Q==
 
+"@metamask/slip44@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@metamask/slip44/-/slip44-1.0.0.tgz#62197528352332d821e4f5a632945270548600fc"
+  integrity sha512-NRZNGKls+KCsnC4sb25Kc151DkLxbMaoqmqM4ITD5H9A+LQL3bJhYHD3l/hA54EVkWt3D1+PGPKfpXxsr9id1g==
+
 "@metamask/snap-controllers@^0.6.1":
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/@metamask/snap-controllers/-/snap-controllers-0.6.1.tgz#8f7094f3c00294155c7f7b6902be0d34ded56a25"


### PR DESCRIPTION
Adds the ability for Snaps to access the Internet via the `endowment:network-access` permission. Also adds permission icons, renames permission locale message keys, and fixes Snap permission locale message retrieval. As part of fixing Snap permission locale messages, adds `@metamask/slip44` as a production dependency in order to display the English names of SLIP-44 protocols in our UI.

<img src="https://user-images.githubusercontent.com/25517051/146631270-983c1839-e141-4767-a313-53fbb23cfeef.png" width=350 />