### PR TITLE
Make Snaps icons visible in UI

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -2592,10 +2592,6 @@
   "slow": {
     "message": "Slow"
   },
-  "snap_clearState": {
-    "message": "Clear its stored data from your device.",
-    "description": "The description for the `snap_clearState` permission"
-  },
   "snap_confirm": {
     "message": "Display a confirmation in MetaMask.",
     "description": "The description for the `snap_confirm` permission"
@@ -2604,13 +2600,9 @@
     "message": "Manage keys for the $1 protocol.",
     "description": "The description for the `snap_getBip44Entropy_*` permission. $1 is the name of a protocol, e.g. 'Filecoin'."
   },
-  "snap_getState": {
-    "message": "Access its stored data on your device.",
-    "description": "The description for the `snap_updateState` permission"
-  },
-  "snap_updateState": {
-    "message": "Store data on your device.",
-    "description": "The description for the `snap_updateState` permission"
+  "snap_manageState": {
+    "message": "Store and manage data on your device.",
+    "description": "The description for the `snap_manageState` permission"
   },
   "somethingWentWrong": {
     "message": "Oops! Something went wrong."
@@ -3305,10 +3297,6 @@
   },
   "unknownNetwork": {
     "message": "Unknown Private Network"
-  },
-  "unknownPermission": {
-    "message": "Unknown permission: $1",
-    "description": "$1 is the name of a requested permission that is not recognized."
   },
   "unknownQrCode": {
     "message": "Error: We couldn't identify that QR code"

--- a/ui/hooks/useOriginMetadata.js
+++ b/ui/hooks/useOriginMetadata.js
@@ -1,5 +1,5 @@
 import { useSelector } from 'react-redux';
-import { getSubjectMetadata } from '../selectors';
+import { getTargetSubjectMetadata } from '../selectors';
 import { SUBJECT_TYPES } from '../../shared/constants/app';
 
 /**
@@ -18,8 +18,9 @@ import { SUBJECT_TYPES } from '../../shared/constants/app';
  *  current origin
  */
 export function useOriginMetadata(origin) {
-  const subjectMetadata = useSelector(getSubjectMetadata);
-  const targetSubjectMetadata = subjectMetadata?.[origin];
+  const targetSubjectMetadata = useSelector((state) =>
+    getTargetSubjectMetadata(state, origin),
+  );
 
   if (!origin) {
     return null;
@@ -40,7 +41,7 @@ export function useOriginMetadata(origin) {
   if (targetSubjectMetadata && minimumOriginMetadata) {
     return {
       ...minimumOriginMetadata,
-      ...subjectMetadata[origin],
+      ...targetSubjectMetadata,
     };
   } else if (targetSubjectMetadata) {
     return targetSubjectMetadata;

--- a/ui/pages/permissions-connect/permissions-connect.container.js
+++ b/ui/pages/permissions-connect/permissions-connect.container.js
@@ -1,15 +1,15 @@
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import {
-  getPermissionsRequests,
   getAccountsWithLabels,
   getLastConnectedInfo,
-  getSubjectMetadata,
+  getPermissionsRequests,
   getSelectedAddress,
+  getTargetSubjectMetadata,
 } from '../../selectors';
 import { getNativeCurrency } from '../../ducks/metamask/metamask';
 
-import { formatDate } from '../../helpers/utils/util';
+import { formatDate, getURLHostName } from '../../helpers/utils/util';
 import {
   approvePermissionsRequest,
   rejectPermissionsRequest,
@@ -46,23 +46,13 @@ const mapStateToProps = (state, ownProps) => {
   const { origin } = metadata;
   const nativeCurrency = getNativeCurrency(state);
 
-  const subjectMetadata = getSubjectMetadata(state);
-
-  let targetSubjectMetadata = null;
-  if (origin) {
-    if (subjectMetadata[origin]) {
-      targetSubjectMetadata = subjectMetadata[origin];
-    } else {
-      const targetUrl = new URL(origin);
-      targetSubjectMetadata = {
-        name: targetUrl.hostname,
-        origin,
-        iconUrl: null,
-        extensionId: null,
-        subjectType: SUBJECT_TYPES.UNKNOWN,
-      };
-    }
-  }
+  const targetSubjectMetadata = getTargetSubjectMetadata(state, origin) ?? {
+    name: getURLHostName(origin) || origin,
+    origin,
+    iconUrl: null,
+    extensionId: null,
+    subjectType: SUBJECT_TYPES.UNKNOWN,
+  };
 
   const accountsWithLabels = getAccountsWithLabels(state);
 

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -16,7 +16,12 @@ import {
   TRANSPORT_STATES,
 } from '../../shared/constants/hardware-wallets';
 
-import { SUBJECT_TYPES, MESSAGE_TYPE } from '../../shared/constants/app';
+import {
+  MESSAGE_TYPE,
+  ///: BEGIN:ONLY_INCLUDE_IN(flask)
+  SUBJECT_TYPES,
+  ///: END:ONLY_INCLUDE_IN
+} from '../../shared/constants/app';
 
 import { TRUNCATED_NAME_CHAR_LIMIT } from '../../shared/constants/labels';
 
@@ -509,6 +514,7 @@ export function getSubjectMetadata(state) {
   return state.metamask.subjectMetadata;
 }
 
+///: BEGIN:ONLY_INCLUDE_IN(flask)
 /**
  * @param {string} svgString - The raw SVG string to make embeddable.
  * @returns {string} The embeddable SVG string.
@@ -516,6 +522,7 @@ export function getSubjectMetadata(state) {
 const getEmbeddableSvg = memoize(
   (svgString) => `data:image/svg+xml;utf8,${encodeURIComponent(svgString)}`,
 );
+///: END:ONLY_INCLUDE_IN
 
 export function getTargetSubjectMetadata(state, origin) {
   const metadata = getSubjectMetadata(state)[origin];

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -1,5 +1,7 @@
 import { createSelector } from 'reselect';
+///: BEGIN:ONLY_INCLUDE_IN(flask)
 import { memoize } from 'lodash';
+///: END:ONLY_INCLUDE_IN
 import { addHexPrefix } from '../../app/scripts/lib/util';
 import {
   MAINNET_CHAIN_ID,


### PR DESCRIPTION
We previously added Snap SVG icons to controller state. This PR makes their icons visible in our UI by converting their raw SVG contents to embeddable strings that we use as the `src` property of `img` tags. A new selector, `getTargetSubjectMetadata` is added to support this use case in a memoized fashion.