### PR TITLE
maintain nft image aspect ratios and center images in collection view

### DIFF
--- a/ui/components/app/collectible-details/index.scss
+++ b/ui/components/app/collectible-details/index.scss
@@ -43,10 +43,7 @@ $spacer-break-small: 16px;
 
   &__image {
     width: 100%;
-
-    @media screen and (min-width: $break-large) {
-      width: $card-width-break-large;
-    }
+    object-fit: contain;
   }
 
   &__address {

--- a/ui/components/app/collectibles-items/collectibles-items.js
+++ b/ui/components/app/collectibles-items/collectibles-items.js
@@ -48,7 +48,7 @@ export default function CollectiblesItems({ collections = {} }) {
             const isExpanded = dropdownState[key];
             return (
               <div
-                className="collectibles-items__item"
+                className="collectibles-items__collection"
                 key={`collection-${index}`}
                 onClick={() => {
                   setDropdownState((_dropdownState) => ({
@@ -62,19 +62,19 @@ export default function CollectiblesItems({ collections = {} }) {
                   display={DISPLAY.FLEX}
                   alignItems={ALIGN_ITEMS.CENTER}
                   justifyContent={JUSTIFY_CONTENT.SPACE_BETWEEN}
-                  className="collectibles-items__item__accordion-title"
+                  className="collectibles-items__collection__accordion-title"
                 >
                   <Box
                     alignItems={ALIGN_ITEMS.CENTER}
-                    className="collectibles-items__item__collection-header"
+                    className="collectibles-items__collection__collection-header"
                   >
                     {collectionImage ? (
                       <img
                         src={collectionImage}
-                        className="collectibles-items__item__collection-image"
+                        className="collectibles-items__collection__collection-image"
                       />
                     ) : (
-                      <div className="collectibles-items__item__collection-image-alt">
+                      <div className="collectibles-items__collection__collection-image-alt">
                         {collectionName[0]}
                       </div>
                     )}
@@ -108,9 +108,13 @@ export default function CollectiblesItems({ collections = {} }) {
                         ipfsGateway,
                       );
                       return (
-                        <Box width={width} key={`collectible-${i}`}>
+                        <Box
+                          width={width}
+                          key={`collectible-${i}`}
+                          className="collectibles-items__collection__item"
+                        >
                           <div
-                            className="collectibles-items__image__wrapper"
+                            className="collectibles-items__collection__item__wrapper"
                             style={{
                               backgroundColor,
                             }}
@@ -121,7 +125,7 @@ export default function CollectiblesItems({ collections = {} }) {
                                   `${ASSET_ROUTE}/${address}/${tokenId}`,
                                 )
                               }
-                              className="collectibles-items__image"
+                              className="collectibles-items__collection__item__image"
                               src={collectibleImage}
                             />
                           </div>

--- a/ui/components/app/collectibles-items/collectibles-items.js
+++ b/ui/components/app/collectibles-items/collectibles-items.js
@@ -111,10 +111,10 @@ export default function CollectiblesItems({ collections = {} }) {
                         <Box
                           width={width}
                           key={`collectible-${i}`}
-                          className="collectibles-items__collection__item"
+                          className="collectibles-items__collection-item-wrapper"
                         >
                           <div
-                            className="collectibles-items__collection__item__wrapper"
+                            className="collectibles-items__collection-item"
                             style={{
                               backgroundColor,
                             }}
@@ -125,7 +125,7 @@ export default function CollectiblesItems({ collections = {} }) {
                                   `${ASSET_ROUTE}/${address}/${tokenId}`,
                                 )
                               }
-                              className="collectibles-items__collection__item__image"
+                              className="collectibles-items__collection-item-image"
                               src={collectibleImage}
                             />
                           </div>

--- a/ui/components/app/collectibles-items/collectibles-items.js
+++ b/ui/components/app/collectibles-items/collectibles-items.js
@@ -62,19 +62,19 @@ export default function CollectiblesItems({ collections = {} }) {
                   display={DISPLAY.FLEX}
                   alignItems={ALIGN_ITEMS.CENTER}
                   justifyContent={JUSTIFY_CONTENT.SPACE_BETWEEN}
-                  className="collectibles-items__collection__accordion-title"
+                  className="collectibles-items__collection-accordion-title"
                 >
                   <Box
                     alignItems={ALIGN_ITEMS.CENTER}
-                    className="collectibles-items__collection__collection-header"
+                    className="collectibles-items__collection-header"
                   >
                     {collectionImage ? (
                       <img
                         src={collectionImage}
-                        className="collectibles-items__collection__collection-image"
+                        className="collectibles-items__collection-image"
                       />
                     ) : (
-                      <div className="collectibles-items__collection__collection-image-alt">
+                      <div className="collectibles-items__collection-image-alt">
                         {collectionName[0]}
                       </div>
                     )}

--- a/ui/components/app/collectibles-items/index.scss
+++ b/ui/components/app/collectibles-items/index.scss
@@ -1,20 +1,5 @@
 .collectibles-items {
-  &__image__wrapper {
-    border-radius: 4px;
-    width: 100%;
-    display: flex;
-    justify-content: center;
-    cursor: pointer;
-  }
-
-  &__image {
-    border-radius: 4px;
-    width: 100%;
-    height: 100%;
-    cursor: pointer;
-  }
-
-  &__item {
+  &__collection {
     margin-bottom: 24px;
 
     &__accordion-title {
@@ -36,6 +21,25 @@
       color: $ui-white;
       text-align: center;
       line-height: 1;
+    }
+
+    &__item {
+      align-self: center;
+
+      &__wrapper {
+        border-radius: 4px;
+        width: 100%;
+        display: flex;
+        justify-content: center;
+        cursor: pointer;
+      }
+
+      &__image {
+        border-radius: 4px;
+        width: 100%;
+        height: 100%;
+        cursor: pointer;
+      }
     }
   }
 }

--- a/ui/components/app/collectibles-items/index.scss
+++ b/ui/components/app/collectibles-items/index.scss
@@ -23,23 +23,24 @@
       line-height: 1;
     }
 
-    &__item {
+    &-item-wrapper {
       align-self: center;
+    }
 
-      &__wrapper {
-        border-radius: 4px;
-        width: 100%;
-        display: flex;
-        justify-content: center;
-        cursor: pointer;
-      }
+    &-item {
+      border-radius: 4px;
+      width: 100%;
+      display: flex;
+      justify-content: center;
+      cursor: pointer;
+      align-self: center;
+    }
 
-      &__image {
-        border-radius: 4px;
-        width: 100%;
-        height: 100%;
-        cursor: pointer;
-      }
+    &-item-image {
+      border-radius: 4px;
+      width: 100%;
+      height: 100%;
+      cursor: pointer;
     }
   }
 }

--- a/ui/components/app/collectibles-items/index.scss
+++ b/ui/components/app/collectibles-items/index.scss
@@ -2,17 +2,17 @@
   &__collection {
     margin-bottom: 24px;
 
-    &__accordion-title {
+    &-accordion-title {
       cursor: pointer;
     }
 
-    &__collection-image {
+    &-image {
       width: 32px;
       height: 32px;
       border-radius: 50%;
     }
 
-    &__collection-image-alt {
+    &-image-alt {
       border-radius: 50%;
       width: 32px;
       height: 32px;


### PR DESCRIPTION
Explanation: 
- Add CSS to preserve aspect ratio of image in details view and center (non-square) images in collection view.
- Also reorganize classnames hierarchy for improved semantic legibility.

Before:
<img width="944" alt="Screen Shot 2021-12-21 at 11 19 40 AM" src="https://user-images.githubusercontent.com/34557516/146971996-a7f46a9c-e5b7-49e7-8cb8-52862532c8be.png">
After:
<img width="1025" alt="Screen Shot 2021-12-21 at 10 50 09 AM" src="https://user-images.githubusercontent.com/34557516/146967878-d02f448b-f2fd-4421-91d4-ccddd2d0d4f4.png">

Before: 
<img width="997" alt="Screen Shot 2021-12-21 at 11 20 08 AM" src="https://user-images.githubusercontent.com/34557516/146972036-7429b081-cc8c-4f30-8071-1f48992f84f6.png">
After:
<img width="868" alt="Screen Shot 2021-12-21 at 10 50 22 AM" src="https://user-images.githubusercontent.com/34557516/146967913-2bdb26ad-5294-4536-9519-62a994af922b.png">

