### PR TITLE
Add more missing `appName` messages

### DIFF
--- a/app/_locales/hn/messages.json
+++ b/app/_locales/hn/messages.json
@@ -22,6 +22,14 @@
     "message": "मेटामास्क/MetaMask",
     "description": "The name of the application"
   },
+  "appNameBeta": {
+    "message": "MetaMask Beta",
+    "description": "The name of the application (Beta)"
+  },
+  "appNameFlask": {
+    "message": "MetaMask Flask",
+    "description": "The name of the application (Flask)"
+  },
   "approve": {
     "message": "मंजूर"
   },

--- a/app/_locales/lt/messages.json
+++ b/app/_locales/lt/messages.json
@@ -70,6 +70,14 @@
     "message": "„MetaMask“",
     "description": "The name of the application"
   },
+  "appNameBeta": {
+    "message": "MetaMask Beta",
+    "description": "The name of the application (Beta)"
+  },
+  "appNameFlask": {
+    "message": "MetaMask Flask",
+    "description": "The name of the application (Flask)"
+  },
   "approve": {
     "message": "Patvirtinti"
   },

--- a/app/_locales/ta/messages.json
+++ b/app/_locales/ta/messages.json
@@ -28,6 +28,14 @@
     "message": "மேடமஸ்க் ",
     "description": "The name of the application"
   },
+  "appNameBeta": {
+    "message": "MetaMask Beta",
+    "description": "The name of the application (Beta)"
+  },
+  "appNameFlask": {
+    "message": "MetaMask Flask",
+    "description": "The name of the application (Flask)"
+  },
   "approve": {
     "message": "ஒப்புதல்"
   },


### PR DESCRIPTION
Three locales were missing the `appNameBeta` and `appNameFlask` localized messages. These were missed in the previous PR (#13138).