### PR TITLE
Simplify the `removeSnapError` function

### DIFF
--- a/ui/pages/home/home.component.js
+++ b/ui/pages/home/home.component.js
@@ -274,8 +274,8 @@ export default class Home extends PureComponent {
                         </Typography>
                       </>
                     }
-                    onIgnore={() => {
-                      removeSnapError(errorId);
+                    onIgnore={async () => {
+                      await removeSnapError(errorId);
                     }}
                     ignoreText="Dismiss"
                     key="home-error-message"

--- a/ui/pages/home/home.container.js
+++ b/ui/pages/home/home.container.js
@@ -146,7 +146,7 @@ const mapDispatchToProps = (dispatch) => ({
     });
   },
   ///: BEGIN:ONLY_INCLUDE_IN(flask)
-  removeSnapError: (id) => dispatch(removeSnapError(id)),
+  removeSnapError: async (id) => await removeSnapError(id),
   ///: END:ONLY_INCLUDE_IN
   restoreFromThreeBox: (address) => dispatch(restoreFromThreeBox(address)),
   setShowRestorePromptToFalse: () => dispatch(setShowRestorePromptToFalse()),

--- a/ui/store/actions.js
+++ b/ui/store/actions.js
@@ -812,13 +812,8 @@ export function txError(err) {
 }
 
 ///: BEGIN:ONLY_INCLUDE_IN(flask)
-export function removeSnapError(msgData) {
-  return (dispatch) => {
-    return promisifiedBackground
-      .removeSnapError(msgData)
-      .then(() => updateMetamaskStateFromBackground())
-      .then((newState) => dispatch(updateMetamaskState(newState)));
-  };
+export async function removeSnapError(msgData) {
+  return promisifiedBackground.removeSnapError(msgData);
 }
 ///: END:ONLY_INCLUDE_IN
 


### PR DESCRIPTION
The `removeSnapError` function has been changed from an action creator to a normal function, as the only actions dispatched were unnecessary. It was dispatching actions to update the `metamask` state, but the background state will automatically update on its own.

It also uses `async/await` rather than `.then` now, and the callsites have been updated to use `async/await`. Platforms that support async stack traces rely upon `async/await` for that enhancement to errors, so this will result in better stack traces on those platforms.