### PR TITLE
Localize the snap error messages

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -2628,6 +2628,10 @@
   "slow": {
     "message": "Slow"
   },
+  "snapError": {
+    "message": "Snap Error: '$1'. Error Code: '$2'",
+    "description": "This is shown when a snap encounters an error. $1 is the error message from the snap, and $2 is the error code."
+  },
   "snapInstall": {
     "message": "Install Snap"
   },

--- a/ui/pages/home/home.component.js
+++ b/ui/pages/home/home.component.js
@@ -263,14 +263,14 @@ export default class Home extends PureComponent {
                           variant={TYPOGRAPHY.H5}
                           fontWeight={FONT_WEIGHT.NORMAL}
                         >
-                          Something Went Wrong
+                          {t('somethingWentWrong')}
                         </Typography>
                         <Typography
                           color={COLORS.UI1}
                           variant={TYPOGRAPHY.H7}
                           fontWeight={FONT_WEIGHT.NORMAL}
                         >
-                          Snap Error: {error.message}. Error Code: {error.code}
+                          {t('snapError', [error.message, error.code])}
                         </Typography>
                       </>
                     }


### PR DESCRIPTION
The messages shown when a snap encounters an error have been localized. A pre-existing "Something went wrong" message is used, and the message including the snap error itself was added.

The "Something went wrong" message is a little different in that it includes the word "Oops!" at the start. This doesn't seem great to me, but it's minor enough that we can adjust it later if necessary. We can probably remove the "Oops!" from all places rather than create a second localized message without it.  

Manual testing steps:  
  - Unfortunately I am unsure how to best create a snap error for testing this.