### PR TITLE
Remove unnecessary `!important`

### DIFF
--- a/ui/pages/confirmation/templates/flask/snap-confirm/index.scss
+++ b/ui/pages/confirmation/templates/flask/snap-confirm/index.scss
@@ -5,6 +5,6 @@
   margin: 24px 0 16px 0;
 
   .text {
-    font-family: monospace !important;
+    font-family: monospace;
   }
 }


### PR DESCRIPTION
This rule was applied just fine without `!important` being present. Better to avoid using `!important` if we can to make it easier to
understand how these styles are applied, and to allow overriding this if necessary.

<details>
<summary>Screenshot:</summary>

![still-monospace](https://user-images.githubusercontent.com/2459287/147158724-afc0c532-d7e7-4bfb-9d29-df0a2469018e.png)
This shows that even after this is removed, the monospace font is used. I also checked in devtools that it was being applied from this specific class.

</details>