### PR TITLE
Fix propType validation warning

### DIFF
--- a/ui/pages/confirmation/templates/flask/snap-confirm/snap-confirm.js
+++ b/ui/pages/confirmation/templates/flask/snap-confirm/snap-confirm.js
@@ -47,6 +47,7 @@ function getValues(pendingApproval, t, actions) {
                 props: {
                   height: '400px',
                   value: textAreaContent,
+                  readOnly: true,
                   resize: RESIZE.VERTICAL,
                   scrollable: true,
                   className: 'text',


### PR DESCRIPTION
A propType validation warning was shown when the snap confirmation text area was rendered because a `value` prop was set without `onChange` being set, which is often a mistake. In our case we don't want to allow user interaction with this text area, but we forgot to mark it as read-only.

The text area is now set as read-only, which silences the error.

<details>
<summary>Here is the error:</summary>

```
backend.js:12979 Warning: Failed prop type: You provided a `value` prop to a form field without an `onChange` handler. This will render a read-only field. If the field should be mutable use `defaultValue`. Otherwise, set either `onChange` or `readOnly`.
    in textarea (created by Box)
    in Box (created by TextArea)
    in TextArea (created by MetaMaskTemplateRenderer)
    in MetaMaskTemplateRenderer (created by MetaMaskTemplateRenderer)
    in div (created by MetaMaskTemplateRenderer)
    in MetaMaskTemplateRenderer (created by MetaMaskTemplateRenderer)
    in MetaMaskTemplateRenderer
    in MetaMaskTemplateRenderer (created by ConfirmationPage)
    in div (created by ConfirmationPage)
    in div (created by ConfirmationPage)
    in ConfirmationPage (created by Context.Consumer)
    in Route (created by Authenticated)
    in Authenticated (created by ConnectFunction)
    in ConnectFunction (created by Routes)
    in Switch (created by Routes)
    in div (created by Routes)
    in div (created by Routes)
    in Routes (created by ConnectFunction)
    in ConnectFunction (created by Context.Consumer)
    in withRouter(Connect(Routes)) (created by Index)
    in LegacyI18nProvider (created by Index)
    in I18nProvider (created by Index)
    in LegacyMetaMetricsProvider (created by Index)
    in MetaMetricsProvider (created by Index)
    in LegacyMetaMetricsProvider (created by Index)
    in MetaMetricsProvider (created by Index)
    in Router (created by HashRouter)
    in HashRouter (created by Index)
    in Provider (created by Index)
    in Index
```

</details>