### PR TITLE
Allow templates without alerts

### DIFF
--- a/ui/pages/confirmation/confirmation.js
+++ b/ui/pages/confirmation/confirmation.js
@@ -83,7 +83,7 @@ function useAlertState(pendingConfirmation) {
     let isMounted = true;
     if (pendingConfirmation) {
       getTemplateAlerts(pendingConfirmation).then((alerts) => {
-        if (isMounted && alerts) {
+        if (isMounted && alerts.length > 0) {
           dispatch({
             type: 'set',
             confirmationId: pendingConfirmation.id,

--- a/ui/pages/confirmation/templates/index.js
+++ b/ui/pages/confirmation/templates/index.js
@@ -43,7 +43,7 @@ const ALLOWED_TEMPLATE_KEYS = [
  */
 export async function getTemplateAlerts(pendingApproval) {
   const fn = APPROVAL_TEMPLATES[pendingApproval.type]?.getAlerts;
-  const results = fn ? await fn(pendingApproval) : undefined;
+  const results = fn ? await fn(pendingApproval) : [];
   if (!Array.isArray(results)) {
     throw new Error(`Template alerts must be an array, received: ${results}`);
   }


### PR DESCRIPTION
The confirmation page template system allows templates to have alerts, but it throws an uncaught Promise rejection if a template has no alerts. This is the unintended side-effect of input validation.

The `getTemplateAlerts` function was updated to always return an array. The one callsite was updated to expect an empty array if there were no alerts to render, rather than expecting `undefined`.

<details>
<summary>Here is the console error:</summary>

```
Uncaught (in promise) Error: Template alerts must be an array, received: undefined
  at getTemplateAlerts (common-3.js:47580)
  at ui-1.js:19161
  at commitHookEffectList (ui-0.js:40207)
  at commitPassiveHookEffects (ui-0.js:40241)
  at HTMLUnknownElement.callCallback (ui-0.js:18513)
  at Object.invokeGuardedCallbackDev (ui-0.js:18562)
  at invokeGuardedCallback (ui-0.js:18617)
  at flushPassiveEffectsImpl (ui-0.js:43569)
  at unstable_runWithPriority (ui-1.js:4302)
  at runWithPriority$2 (ui-0.js:30326)
e @ lockdown-install.js:1
getTemplateAlerts @ index.js:55
(anonymous) @ confirmation.js:83
commitHookEffectList @ react-dom.development.js:22030
commitPassiveHookEffects @ react-dom.development.js:22064
callCallback @ react-dom.development.js:336
invokeGuardedCallbackDev @ react-dom.development.js:385
invokeGuardedCallback @ react-dom.development.js:440
flushPassiveEffectsImpl @ react-dom.development.js:25392
unstable_runWithPriority @ scheduler.development.js:697
runWithPriority$2 @ react-dom.development.js:12149
flushPassiveEffects @ react-dom.development.js:25361
performSyncWorkOnRoot @ react-dom.development.js:24251
(anonymous) @ react-dom.development.js:12199
unstable_runWithPriority @ scheduler.development.js:697
runWithPriority$2 @ react-dom.development.js:12149
flushSyncCallbackQueueImpl @ react-dom.development.js:12194
flushSyncCallbackQueue @ react-dom.development.js:12182
unbatchedUpdates @ react-dom.development.js:24439
legacyRenderSubtreeIntoContainer @ react-dom.development.js:27527
render @ react-dom.development.js:27608
startApp @ index.js:157
Promise.then (async)
(anonymous) @ confirmation.js:83
commitHookEffectList @ react-dom.development.js:22030
commitPassiveHookEffects @ react-dom.development.js:22064
callCallback @ react-dom.development.js:336
invokeGuardedCallbackDev @ react-dom.development.js:385
invokeGuardedCallback @ react-dom.development.js:440
flushPassiveEffectsImpl @ react-dom.development.js:25392
unstable_runWithPriority @ scheduler.development.js:697
runWithPriority$2 @ react-dom.development.js:12149
flushPassiveEffects @ react-dom.development.js:25361
performSyncWorkOnRoot @ react-dom.development.js:24251
(anonymous) @ react-dom.development.js:12199
unstable_runWithPriority @ scheduler.development.js:697
runWithPriority$2 @ react-dom.development.js:12149
flushSyncCallbackQueueImpl @ react-dom.development.js:12194
flushSyncCallbackQueue @ react-dom.development.js:12182
unbatchedUpdates @ react-dom.development.js:24439
legacyRenderSubtreeIntoContainer @ react-dom.development.js:27527
render @ react-dom.development.js:27608
startApp @ index.js:157
await in startApp (async)
(anonymous) @ index.js:40
handleResponse @ metaRPCClientFactory.js:67
emitOne @ events.js:106
emit @ events.js:184
addChunk @ _stream_readable.js:291
readableAddChunk @ _stream_readable.js:278
Readable.push @ _stream_readable.js:245
_write @ index.js:68
doWrite @ _stream_writable.js:428
writeOrBuffer @ _stream_writable.js:417
Writable.write @ _stream_writable.js:334
ondata @ _stream_readable.js:619
emitOne @ events.js:106
emit @ events.js:184
addChunk @ _stream_readable.js:291
readableAddChunk @ _stream_readable.js:278
Readable.push @ _stream_readable.js:245
_onMessage @ index.js:26
(anonymous) @ index.js:11

```

</details>

Manual testing steps:  
  - This can't be tested at the moment because all templates have alerts. But if you cherry pick this onto the `snaps` branch, you can test this with the snap confirmation template by following these steps:
    - Create a Flask build (`yarn start --build-type flask`), install the build, and complete onboarding
    - Navigate to https://metamask.github.io/snap-template/
    - Connect
    - Press the "Send Hello" button. Beforehand you should see the error listed above. After, it should not show that error.