### PR TITLE
Fix how `version_name` manifest field is used

### DIFF
--- a/app/scripts/platforms/extension.js
+++ b/app/scripts/platforms/extension.js
@@ -86,15 +86,12 @@ export default class ExtensionPlatform {
 
     const versionParts = version.split('.');
     if (versionName) {
-      // On Chrome, the build type is stored as `version_name` in the manifest, and the fourth part
-      // of the version is the build version.
-      const buildType = versionName;
       if (versionParts.length < 4) {
         throw new Error(`Version missing build number: '${version}'`);
       }
-      const [major, minor, patch, buildVersion] = versionParts;
-
-      return `${major}.${minor}.${patch}-${buildType}.${buildVersion}`;
+      // On Chrome, a more descriptive representation of the version is stored
+      // in the `version_name` field for display purposes.
+      return versionName;
     } else if (versionParts.length === 4) {
       // On Firefox, the build type and build version are in the fourth part of the version.
       const [major, minor, patch, prerelease] = versionParts;

--- a/app/scripts/platforms/extension.test.js
+++ b/app/scripts/platforms/extension.test.js
@@ -28,7 +28,7 @@ describe('extension platform', () => {
     it('should return SemVer-formatted version for Chrome style manifest of prerelease', () => {
       extension.runtime.getManifest.mockReturnValue({
         version: '1.2.3.0',
-        version_name: 'beta',
+        version_name: '1.2.3-beta.0',
       });
       const extensionPlatform = new ExtensionPlatform();
 
@@ -51,7 +51,7 @@ describe('extension platform', () => {
     it('should throw error if build version is missing from Chrome style prerelease manifest', () => {
       extension.runtime.getManifest.mockReturnValue({
         version: '1.2.3',
-        version_name: 'beta',
+        version_name: '1.2.3-beta.0',
       });
       const extensionPlatform = new ExtensionPlatform();
 
@@ -60,7 +60,7 @@ describe('extension platform', () => {
       );
     });
 
-    it('should throw error if build type is missing from Chrome style prerelease manifest', () => {
+    it('should throw error if version name is missing from Chrome style prerelease manifest', () => {
       extension.runtime.getManifest.mockReturnValue({
         version: '1.2.3.0',
       });

--- a/development/build/utils.js
+++ b/development/build/utils.js
@@ -23,7 +23,7 @@ const BuildType = {
  * @param {string[]} platforms - A list of browsers to generate versions for.
  * @returns {Object} An object with the browser as the key and the browser-specific version object
  * as the value.  For example, the version `9.6.0-beta.1` would return the object
- * `{ firefox: { version: '9.6.0.beta1' }, chrome: { version: '9.6.0.1', version_name: 'beta' } }`.
+ * `{ firefox: { version: '9.6.0.beta1' }, chrome: { version: '9.6.0.1', version_name: '9.6.0-beta.1' } }`.
  */
 function getBrowserVersionMap(platforms) {
   const major = semver.major(version);
@@ -53,7 +53,7 @@ function getBrowserVersionMap(platforms) {
         versionParts.push(`${buildType}${buildVersion}`);
       } else {
         versionParts.push(buildVersion);
-        browserSpecificVersion.version_name = buildType;
+        browserSpecificVersion.version_name = version;
       }
     }
     browserSpecificVersion.version = versionParts.join('.');


### PR DESCRIPTION
The `version_name` manifest field was being used on Chrome to store the build type. However, Chrome intended this field to be a full representation of the version, for display purposes. This was evident when uploading this version to the Chrome Web Store, because it used `flask` as the entire version.

Instead the `version_name` field now includes the full SemVer version string. The version parsing code within the build script and in the wallet itself have been updated accordingly.

Manual testing steps:  
  - Update the `version` field in `package.json` to include a valid prerelease suffix (e.g. `-beta.0`).
  - Run the build (`yarn start --build-type beta`)
  - See that the version is displayed properly on the "About" page, and in the extension settings "Details" page.