### PR TITLE
Allow Flask prerelease versions

### DIFF
--- a/development/build/utils.js
+++ b/development/build/utils.js
@@ -40,7 +40,7 @@ function getBrowserVersionMap(platforms) {
     [buildType, buildVersion] = prerelease;
     if (!String(buildVersion).match(/^\d+$/u)) {
       throw new Error(`Invalid prerelease build version: '${buildVersion}'`);
-    } else if (buildType !== BuildType.beta) {
+    } else if (![BuildType.beta, BuildType.flask].includes(buildType)) {
       throw new Error(`Invalid prerelease build type: ${buildType}`);
     }
   }


### PR DESCRIPTION
The build script only allowed prerelease versions for the "beta" build type (e.g. `X.Y.Z-beta.0`). Now it allows Flask prerelease versions as well.

This is required for the Flask release, where the prerelease version helps distinguish the Flask error reports and metrics.

Manual testing steps:  
  - Add `-flask.0` to the `version` field in the `package.json` file
  - See that the build succeeds (e.g. `yarn start`).