### PR TITLE
Update the Sentry setup log with the build type

### DIFF
--- a/app/scripts/lib/setupSentry.js
+++ b/app/scripts/lib/setupSentry.js
@@ -72,27 +72,29 @@ export default function setupSentry({ release, getState }) {
 
   if (METAMASK_DEBUG) {
     return undefined;
-  } else if (METAMASK_ENVIRONMENT === 'production') {
-    if (!process.env.SENTRY_DSN) {
-      throw new Error(
-        `Missing SENTRY_DSN environment variable in production environment`,
-      );
-    }
-    console.log(
-      `Setting up Sentry Remote Error Reporting for '${METAMASK_ENVIRONMENT}': SENTRY_DSN`,
-    );
-    sentryTarget = process.env.SENTRY_DSN;
-  } else {
-    console.log(
-      `Setting up Sentry Remote Error Reporting for '${METAMASK_ENVIRONMENT}': SENTRY_DSN_DEV`,
-    );
-    sentryTarget = SENTRY_DSN_DEV;
   }
 
   const environment =
     METAMASK_BUILD_TYPE === BuildType.main
       ? METAMASK_ENVIRONMENT
       : `${METAMASK_ENVIRONMENT}-${METAMASK_BUILD_TYPE}`;
+
+  if (METAMASK_ENVIRONMENT === 'production') {
+    if (!process.env.SENTRY_DSN) {
+      throw new Error(
+        `Missing SENTRY_DSN environment variable in production environment`,
+      );
+    }
+    console.log(
+      `Setting up Sentry Remote Error Reporting for '${environment}': SENTRY_DSN`,
+    );
+    sentryTarget = process.env.SENTRY_DSN;
+  } else {
+    console.log(
+      `Setting up Sentry Remote Error Reporting for '${environment}': SENTRY_DSN_DEV`,
+    );
+    sentryTarget = SENTRY_DSN_DEV;
+  }
 
   Sentry.init({
     dsn: sentryTarget,


### PR DESCRIPTION
The `environment` field we use for Sentry includes the build type for all build types except `main`, but the log message indicating that Sentry did not include this. This log message is useful for ensuring that Sentry is setup correctly, so it should display the same environment that Sentry is using. It has been updated to do just that.

Manual testing steps:  
  - Create a build with any non-main build type (e.g. `yarn start --build-type beta`)
  - Open the background console, and:
    - On Chrome, ensure "Verbose" logs are enabled. (by default Verbose logs are disabled). The log levels can be adjusted in the dropdown to the right of the filter.
    - On Firefox, ensure "Debug logs are enabled. The "Debug" shown to the right of the filter should be highlighted.
  - Restart the extension, and see that the build type is included in the Sentry setup log in the background console