### PR TITLE
Update the Firefox prerelease version format

### DIFF
--- a/app/scripts/platforms/extension.js
+++ b/app/scripts/platforms/extension.js
@@ -92,14 +92,16 @@ export default class ExtensionPlatform {
       // On Chrome, a more descriptive representation of the version is stored
       // in the `version_name` field for display purposes.
       return versionName;
-    } else if (versionParts.length === 4) {
+    } else if (versionParts.length !== 3) {
+      throw new Error(`Invalid version: ${version}`);
+    } else if (versionParts[2].match(/[^\d]/u)) {
       // On Firefox, the build type and build version are in the fourth part of the version.
-      const [major, minor, patch, prerelease] = versionParts;
-      const matches = prerelease.match(/^(\w+)(\d)+$/u);
+      const [major, minor, patchAndPrerelease] = versionParts;
+      const matches = patchAndPrerelease.match(/^(\d+)([A-Za-z]+)(\d)+$/u);
       if (matches === null) {
         throw new Error(`Version contains invalid prerelease: ${version}`);
       }
-      const [, buildType, buildVersion] = matches;
+      const [, patch, buildType, buildVersion] = matches;
       return `${major}.${minor}.${patch}-${buildType}.${buildVersion}`;
     }
 

--- a/app/scripts/platforms/extension.test.js
+++ b/app/scripts/platforms/extension.test.js
@@ -39,7 +39,7 @@ describe('extension platform', () => {
 
     it('should return SemVer-formatted version for Firefox style manifest of prerelease', () => {
       extension.runtime.getManifest.mockReturnValue({
-        version: '1.2.3.beta0',
+        version: '1.2.3beta0',
       });
       const extensionPlatform = new ExtensionPlatform();
 
@@ -66,14 +66,21 @@ describe('extension platform', () => {
       });
       const extensionPlatform = new ExtensionPlatform();
 
-      expect(() => extensionPlatform.getVersion()).toThrow(
-        'Version contains invalid prerelease:',
-      );
+      expect(() => extensionPlatform.getVersion()).toThrow('Invalid version:');
+    });
+
+    it('should throw error if version includes four parts in a Firefox style manifest', () => {
+      extension.runtime.getManifest.mockReturnValue({
+        version: '1.2.3.4',
+      });
+      const extensionPlatform = new ExtensionPlatform();
+
+      expect(() => extensionPlatform.getVersion()).toThrow('Invalid version:');
     });
 
     it('should throw error if build version is missing from Firefox style prerelease manifest', () => {
       extension.runtime.getManifest.mockReturnValue({
-        version: '1.2.3.beta',
+        version: '1.2.3beta',
       });
       const extensionPlatform = new ExtensionPlatform();
 
@@ -82,9 +89,9 @@ describe('extension platform', () => {
       );
     });
 
-    it('should throw error if build type is missing from Firefox style prerelease manifest', () => {
+    it('should throw error if patch is missing from Firefox style prerelease manifest', () => {
       extension.runtime.getManifest.mockReturnValue({
-        version: '1.2.3.0',
+        version: '1.2.beta0',
       });
       const extensionPlatform = new ExtensionPlatform();
 

--- a/development/build/utils.js
+++ b/development/build/utils.js
@@ -50,7 +50,7 @@ function getBrowserVersionMap(platforms) {
     const browserSpecificVersion = {};
     if (prerelease) {
       if (platform === 'firefox') {
-        versionParts.push(`${buildType}${buildVersion}`);
+        versionParts[2] = `${versionParts[2]}${buildType}${buildVersion}`;
       } else {
         versionParts.push(buildVersion);
         browserSpecificVersion.version_name = version;


### PR DESCRIPTION
The Firefox extension version format does not support the version format we use (SemVer), so we have to specially format the extension version to be compatible. The format we chose was `[major].[minor].[patch].[buildType][buildVersion]`. But when we tried to submit a build with a version in that format, it was rejected as invalid for unknown reasons.

The Firefox extension format has been updated to `[major].[minor].[patch][buildType][buildVersion]`. This seems to pass validation.

Manual testing steps:  
  - Update the `version` field of the `package.json` to include a prerelease verison (e.g. `10.8.1-flask.0`).
  - Run `yarn dist`
  - Try to upload the resulting build to Firefox as a new extension (just to see if it passes validation, you don't need to complete the upload)
  - See that the error it shows you is that the addon ID has already been used. If you try before this change, the error would say the version is invalid.