### PR TITLE
UpdateNickname story : convert knobs and actions to controls/args

### DIFF
--- a/ui/components/ui/update-nickname-popover/README.mdx
+++ b/ui/components/ui/update-nickname-popover/README.mdx
@@ -1,0 +1,14 @@
+import { Story, Canvas, ArgsTable } from '@storybook/addon-docs';
+import UpdateNicknamePopover from '.';
+
+# UpdateNicknamePopover
+
+Popover to update nickname of an address
+
+<Canvas>
+  <Story id="ui-components-ui-update-nickname-popover-update-nickname-popover-stories-js--default-story" />
+</Canvas>
+
+## Component API
+
+<ArgsTable of={UpdateNicknamePopover} />

--- a/ui/components/ui/update-nickname-popover/update-nickname-popover.stories.js
+++ b/ui/components/ui/update-nickname-popover/update-nickname-popover.stories.js
@@ -1,32 +1,26 @@
 import React, { useState } from 'react';
-import { action } from '@storybook/addon-actions';
-import { text } from '@storybook/addon-knobs';
 import Button from '../button';
+import README from './README.mdx';
 import UpdateNicknamePopover from '.';
 
 export default {
   title: 'Components/UI/UpdateNickname',
   id: __filename,
+  parameters: {
+    docs: {
+      page: README,
+    },
+  },
+  argTypes: {
+    address: { control: 'text' },
+    onClose: { action: 'Close Update Nickname Popover' },
+    onAdd: { action: 'Submit Nickname' },
+  },
 };
 
-export const AddNickname = () => {
-  const [showPopover, setShowPopover] = useState(false);
-  return (
-    <div style={{ width: '600px' }}>
-      <Button onClick={() => setShowPopover(true)}>
-        Open Add Nickname Popover
-      </Button>
-      {showPopover && (
-        <UpdateNicknamePopover
-          address={text('address', '0x0011244f50ff4')}
-          onClose={() => action(`Close Update Nickname Popover`)()}
-        />
-      )}
-    </div>
-  );
-};
+const address = '0x0011244f50ff4';
 
-export const UpdateNickname = () => {
+export const DefaultStory = (args) => {
   const [showPopover, setShowPopover] = useState(false);
   return (
     <div style={{ width: '600px' }}>
@@ -35,11 +29,33 @@ export const UpdateNickname = () => {
       </Button>
       {showPopover && (
         <UpdateNicknamePopover
-          address={text('address', '0x0011244f50ff4')}
-          nickname={text('nickname', 'user_nickname')}
-          onClose={() => action(`Close Update Nickname Popover`)()}
+          {...args}
+          nickname="user_nickname"
+          memo="This is a memo"
         />
       )}
     </div>
   );
+};
+
+DefaultStory.storyName = 'UpdateNickname';
+
+DefaultStory.args = {
+  address,
+};
+
+export const AddNickname = (args) => {
+  const [showPopover, setShowPopover] = useState(false);
+  return (
+    <div style={{ width: '600px' }}>
+      <Button onClick={() => setShowPopover(true)}>
+        Open Add Nickname Popover
+      </Button>
+      {showPopover && <UpdateNicknamePopover {...args} />}
+    </div>
+  );
+};
+
+AddNickname.args = {
+  address,
 };

--- a/ui/components/ui/update-nickname-popover/update-nickname-popover.stories.js
+++ b/ui/components/ui/update-nickname-popover/update-nickname-popover.stories.js
@@ -13,8 +13,8 @@ export default {
   },
   argTypes: {
     address: { control: 'text' },
-    onClose: { action: 'Close Update Nickname Popover' },
-    onAdd: { action: 'Submit Nickname' },
+    onClose: { action: 'onClose' },
+    onAdd: { action: 'onAdd' },
   },
 };
 

--- a/ui/components/ui/update-nickname-popover/update-nickname-popover.stories.js
+++ b/ui/components/ui/update-nickname-popover/update-nickname-popover.stories.js
@@ -5,7 +5,7 @@ import README from './README.mdx';
 import UpdateNicknamePopover from '.';
 
 export default {
-  title: 'Components/UI/UpdateNickname',
+  title: 'Components/UI/UpdateNicknamePopover',
   id: __filename,
   parameters: {
     docs: {
@@ -22,6 +22,7 @@ export default {
       defaultValue: false,
     },
     onAdd: { action: 'onAdd' },
+    onClose: { action: 'onClose' },
   },
 };
 

--- a/ui/components/ui/update-nickname-popover/update-nickname-popover.stories.js
+++ b/ui/components/ui/update-nickname-popover/update-nickname-popover.stories.js
@@ -18,7 +18,7 @@ export default {
   },
 };
 
-const address = '0x0011244f50ff4';
+const address = '0xdeDbcA0156308960E3bBa2f5a273E72179940788';
 
 export const DefaultStory = (args) => {
   const [showPopover, setShowPopover] = useState(false);

--- a/ui/components/ui/update-nickname-popover/update-nickname-popover.stories.js
+++ b/ui/components/ui/update-nickname-popover/update-nickname-popover.stories.js
@@ -1,4 +1,5 @@
-import React, { useState } from 'react';
+import { useArgs } from '@storybook/client-api';
+import React from 'react';
 import Button from '../button';
 import README from './README.mdx';
 import UpdateNicknamePopover from '.';
@@ -12,26 +13,36 @@ export default {
     },
   },
   argTypes: {
-    address: { control: 'text' },
-    onClose: { action: 'onClose' },
+    address: {
+      control: { type: 'text' },
+      defaultValue: '0xdeDbcA0156308960E3bBa2f5a273E72179940788',
+    },
+    showPopover: {
+      control: { type: 'boolean' },
+      defaultValue: false,
+    },
     onAdd: { action: 'onAdd' },
   },
 };
 
-const address = '0xdeDbcA0156308960E3bBa2f5a273E72179940788';
-
 export const DefaultStory = (args) => {
-  const [showPopover, setShowPopover] = useState(false);
+  const [{ showPopover }, updateArgs] = useArgs();
+
+  const handlePopoverState = () => {
+    updateArgs({
+      showPopover: !showPopover,
+    });
+  };
+
   return (
     <div style={{ width: '600px' }}>
-      <Button onClick={() => setShowPopover(true)}>
-        Open Update Nickname Popover
-      </Button>
+      <Button onClick={handlePopoverState}>Open Update Nickname Popover</Button>
       {showPopover && (
         <UpdateNicknamePopover
           {...args}
           nickname="user_nickname"
           memo="This is a memo"
+          onClose={handlePopoverState}
         />
       )}
     </div>
@@ -40,22 +51,21 @@ export const DefaultStory = (args) => {
 
 DefaultStory.storyName = 'UpdateNickname';
 
-DefaultStory.args = {
-  address,
-};
-
 export const AddNickname = (args) => {
-  const [showPopover, setShowPopover] = useState(false);
+  const [{ showPopover }, updateArgs] = useArgs();
+
+  const handlePopoverState = () => {
+    updateArgs({
+      showPopover: !showPopover,
+    });
+  };
+
   return (
     <div style={{ width: '600px' }}>
-      <Button onClick={() => setShowPopover(true)}>
-        Open Add Nickname Popover
-      </Button>
-      {showPopover && <UpdateNicknamePopover {...args} />}
+      <Button onClick={handlePopoverState}>Open Add Nickname Popover</Button>
+      {showPopover && (
+        <UpdateNicknamePopover {...args} onClose={handlePopoverState} />
+      )}
     </div>
   );
-};
-
-AddNickname.args = {
-  address,
 };


### PR DESCRIPTION
Fixes: #13066

Explanation:  Convert UpdateNicknamePopover story in ui/components/ui/update-nickname-popover/update-nickname-popover.stories.js to use controls and action argType annotation

- [x] Add README.MDX
- [x] Story has argTypes that align with component api / props
- [x] All instances of @storybook/addon-knobs have been removed in favour of control args
- [x] All instances of @storybook/addon-actions have been removed in favour of action argType annotation

Manual testing steps:  
- Go to latest CI build of storybook or run yarn storybook
- Search "UpdateNickname" in storybook
- Use Controls to interact with component

![image](https://user-images.githubusercontent.com/20949060/147851221-c771d535-1246-490c-8aac-ff5f732d0cf3.png)
