### PR TITLE
add crowdin-bot to the CLA allowlist

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -22,6 +22,6 @@ jobs:
           url-to-cladocument: 'https://metamask.io/cla.html'
           # This branch can't have protections, commits are made directly to the specified branch.
           branch: 'cla-signatures'
-          allowlist: 'dependabot[bot],metamaskbot'
+          allowlist: 'dependabot[bot],metamaskbot,crowdin-bot'
           allow-organization-members: true
           blockchain-storage-flag: false


### PR DESCRIPTION
Explanation:  Adds `@crowdin-bot` to the CLA allowlist. Required in order to merge [PRs](https://github.com/MetaMask/metamask-extension/pull/12730) from the Crowdin action we've recently added to integrate our translation vendors with our repo.
