### PR TITLE
Ignore 4Byte 502 errors during e2e tests

### DIFF
--- a/test/e2e/webdriver/driver.js
+++ b/test/e2e/webdriver/driver.js
@@ -361,6 +361,8 @@ class Driver {
       'favicon.ico - Failed to load resource: the server responded with a status of 404 (Not Found)',
       // Sentry rate limiting
       'Failed to load resource: the server responded with a status of 429',
+      // 4Byte
+      'Failed to load resource: the server responded with a status of 502 (Bad Gateway)',
     ];
     const browserLogs = await this.driver.manage().logs().get('browser');
     const errorEntries = browserLogs.filter(


### PR DESCRIPTION
The 4Byte API can sometimes fail during e2e tests with a 502 error. Ideally we would avoid calling it at all during e2e tests, but in the meantime we shouldn't treat this as a reason to fail the e2e test. We have multiple fallbacks for 4Byte, it isn't relied upon by any tests.

Manual testing steps:  
  - Create a test build (`yarn build test`) 
  - Run the "Contract interactions" e2e test suite (`yarn test:e2e:single --leave-running --browser chrome ./test/e2e/tests/contract-interactions.spec.js`)
  - See that it does not fail with a 4Byte error when 4Byte is down (it's down at time of writing).