### PR TITLE
Add missing permissions middleware hook

### DIFF
--- a/app/scripts/lib/rpc-method-middleware/createMethodMiddleware.js
+++ b/app/scripts/lib/rpc-method-middleware/createMethodMiddleware.js
@@ -15,10 +15,7 @@ const handlerMap = allHandlers.reduce((map, handler) => {
 
 const expectedHookNames = Array.from(
   new Set(
-    Array.from(handlerMap.values()).reduce(
-      (allHooks, { hookNames = {} }) => allHooks.concat(Object.keys(hookNames)),
-      [],
-    ),
+    allHandlers.map(({ hookNames }) => Object.keys(hookNames)).flat(),
   ).values(),
 );
 

--- a/app/scripts/lib/rpc-method-middleware/createMethodMiddleware.js
+++ b/app/scripts/lib/rpc-method-middleware/createMethodMiddleware.js
@@ -13,6 +13,15 @@ const handlerMap = allHandlers.reduce((map, handler) => {
   return map;
 }, new Map());
 
+const expectedHookNames = Array.from(
+  new Set(
+    Array.from(handlerMap.values()).reduce(
+      (acc, { hookNames = {} }) => acc.concat(Object.keys(hookNames)),
+      [],
+    ),
+  ).values(),
+);
+
 /**
  * Creates a json-rpc-engine middleware of RPC method implementations.
  *
@@ -24,6 +33,16 @@ const handlerMap = allHandlers.reduce((map, handler) => {
  * @returns {(req: Object, res: Object, next: Function, end: Function) => void}
  */
 export default function createMethodMiddleware(hooks) {
+  // Fail immediately if we forgot to provide any expected hooks.
+  const missingHookNames = expectedHookNames.filter(
+    (hookName) => !Object.hasOwnProperty.call(hooks, hookName),
+  );
+  if (missingHookNames.length > 0) {
+    throw new Error(
+      `Missing expected hooks:\n\n${missingHookNames.join('\n')}\n`,
+    );
+  }
+
   return async function methodMiddleware(req, res, next, end) {
     // Reject unsupported methods.
     if (UNSUPPORTED_RPC_METHODS.has(req.method)) {

--- a/app/scripts/lib/rpc-method-middleware/createMethodMiddleware.js
+++ b/app/scripts/lib/rpc-method-middleware/createMethodMiddleware.js
@@ -16,7 +16,7 @@ const handlerMap = allHandlers.reduce((map, handler) => {
 const expectedHookNames = Array.from(
   new Set(
     Array.from(handlerMap.values()).reduce(
-      (acc, { hookNames = {} }) => acc.concat(Object.keys(hookNames)),
+      (allHooks, { hookNames = {} }) => allHooks.concat(Object.keys(hookNames)),
       [],
     ),
   ).values(),

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -2759,6 +2759,10 @@ export default class MetamaskController extends EventEmitter {
           { origin },
           { eth_accounts: {} },
         ),
+        requestPermissionsForOrigin: this.permissionController.requestPermissions.bind(
+          this.permissionController,
+          { origin },
+        ),
 
         // Custom RPC-related
         addCustomRpc: async ({


### PR DESCRIPTION
Adds a missing middleware hook for `wallet_requestPermissions` that we failed to add in #12243. Also adds a runtime check that throws an error if any expected hooks are not provided to `createMethodMiddleware`.