### PR TITLE
rename crowdin-bot to github-actions

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -22,6 +22,6 @@ jobs:
           url-to-cladocument: 'https://metamask.io/cla.html'
           # This branch can't have protections, commits are made directly to the specified branch.
           branch: 'cla-signatures'
-          allowlist: 'dependabot[bot],metamaskbot,crowdin-bot'
+          allowlist: 'dependabot[bot],metamaskbot,github-actions'
           allow-organization-members: true
           blockchain-storage-flag: false


### PR DESCRIPTION
add `github-actions` to allowlist for cla

I think `crowdin-bot` is incorrect since the PRs are opened via `github-actions`

![image](https://user-images.githubusercontent.com/675259/148105817-4fa6fc9c-dedc-4ea4-a7d2-aebb76b4c1ce.png)

cc @adonesky1 @Gudahtt 