### PR TITLE
Fix `account-menu` styles lint failure

### DIFF
--- a/ui/components/app/account-menu/index.scss
+++ b/ui/components/app/account-menu/index.scss
@@ -105,7 +105,7 @@
     color: $white;
     padding: 3.5px 24px;
     width: 59px;
-  
+
     &:hover {
       background-color: rgba($dusty-gray, 0.05);
     }


### PR DESCRIPTION
This error was introduced with #13100, which was merged without CI checks because CircleCI was not running on that branch for some reason. This error was fixed with `yarn lint:styles --fix`.