### PR TITLE
Fix missing `targetSubjectMetadata.name` propType error

### DIFF
--- a/ui/components/app/permission-page-container/permission-page-container.component.js
+++ b/ui/components/app/permission-page-container/permission-page-container.component.js
@@ -14,7 +14,7 @@ export default class PermissionPageContainer extends Component {
     request: PropTypes.object,
     requestMetadata: PropTypes.object,
     targetSubjectMetadata: PropTypes.shape({
-      name: PropTypes.string.isRequired,
+      name: PropTypes.string,
       origin: PropTypes.string.isRequired,
       subjectType: PropTypes.string.isRequired,
       extensionId: PropTypes.string,

--- a/ui/pages/permissions-connect/choose-account/choose-account.js
+++ b/ui/pages/permissions-connect/choose-account/choose-account.js
@@ -139,7 +139,7 @@ ChooseAccount.propTypes = {
   targetSubjectMetadata: PropTypes.shape({
     extensionId: PropTypes.string,
     iconUrl: PropTypes.string,
-    name: PropTypes.string.isRequired,
+    name: PropTypes.string,
     origin: PropTypes.string.isRequired,
     subjectType: PropTypes.string,
   }),

--- a/ui/pages/permissions-connect/permissions-connect.component.js
+++ b/ui/pages/permissions-connect/permissions-connect.component.js
@@ -34,7 +34,7 @@ export default class PermissionConnect extends Component {
     targetSubjectMetadata: PropTypes.shape({
       extensionId: PropTypes.string,
       iconUrl: PropTypes.string,
-      name: PropTypes.string.isRequired,
+      name: PropTypes.string,
       origin: PropTypes.string.isRequired,
       subjectType: PropTypes.string,
     }),


### PR DESCRIPTION
There was a propType error shown during the connect flow about the `name` property of `targetSubjectMetadata` being missing despite it being marked as required. This property should not have been required, it does not always exist.

Manual testing steps: 
 - This cannot be easily tested right now because our inpage provider always sets the `name` property, but snaps and sites that use their own provider might not. I tested this by rebasing this onto the `snaps` branch and connecting to our template snap, using these steps:
   - Create a Flask build (`yarn start --build-type flask`), then install the build and complete onboarding.
   - Visit https://metamask.github.io/snap-template/ and connect.
   - See that there is no propType error in the developer console on the snap install page.