### PR TITLE
Typography stories : convert knobs and actions to controls / args

### DIFF
--- a/ui/components/ui/typography/README.mdx
+++ b/ui/components/ui/typography/README.mdx
@@ -1,7 +1,7 @@
 import { Story, Canvas, ArgsTable } from '@storybook/addon-docs';
-import List from '.';
+import Typography from '.';
 
-# List
+# Typography
 
 <Canvas>
   <Story id="ui-components-ui-typography-typography-stories-js--default-story" />
@@ -13,4 +13,4 @@ import List from '.';
 
 ## Component API
 
-<ArgsTable of={List} />
+<ArgsTable of={Typography} />

--- a/ui/components/ui/typography/README.mdx
+++ b/ui/components/ui/typography/README.mdx
@@ -1,0 +1,16 @@
+import { Story, Canvas, ArgsTable } from '@storybook/addon-docs';
+import List from '.';
+
+# List
+
+<Canvas>
+  <Story id="ui-components-ui-typography-typography-stories-js--default-story" />
+</Canvas>
+
+<Canvas>
+  <Story id="ui-components-ui-typography-typography-stories-js--the-quick-orange-fox" />
+</Canvas>
+
+## Component API
+
+<ArgsTable of={List} />

--- a/ui/components/ui/typography/typography.stories.js
+++ b/ui/components/ui/typography/typography.stories.js
@@ -1,52 +1,69 @@
 import React from 'react';
-import { number, select, text } from '@storybook/addon-knobs';
 import {
   COLORS,
   FONT_WEIGHT,
   TEXT_ALIGN,
   TYPOGRAPHY,
 } from '../../../helpers/constants/design-system';
+import README from './README.mdx';
 import Typography from '.';
 
 export default {
   title: 'Components/UI/Typography',
   id: __filename,
+  parameters: {
+    docs: {
+      page: README,
+    },
+  },
+  argTypes: {
+    color: {
+      control: { type: 'select' },
+      options: COLORS,
+      defaultValue: COLORS.BLACK,
+    },
+    align: {
+      control: { type: 'select' },
+      options: TEXT_ALIGN,
+      defaultValue: TEXT_ALIGN.LEFT,
+    },
+    fontWeight: {
+      control: { type: 'select' },
+      options: FONT_WEIGHT,
+      defaultValue: FONT_WEIGHT.NORMAL,
+    },
+    spacing: {
+      control: { type: 'range', min: 1, max: 8 },
+      defaultValue: 1,
+    },
+    variant: {
+      control: { type: 'select' },
+      options: TYPOGRAPHY,
+      defaultValue: TYPOGRAPHY.Paragraph,
+    },
+    content: {
+      control: { type: 'text' },
+      defaultValue: 'The quick orange fox jumped over the lazy dog.',
+    },
+  },
 };
 
-export const List = () => (
+export const DefaultStory = (args) => (
   <div style={{ width: '80%', flexDirection: 'column' }}>
     {Object.values(TYPOGRAPHY).map((variant) => (
       <div key={variant} style={{ width: '100%' }}>
-        <Typography
-          variant={variant}
-          color={select('color', COLORS, COLORS.BLACK)}
-          spacing={number('spacing', 1, { range: true, min: 1, max: 8 })}
-          align={select('align', TEXT_ALIGN, undefined)}
-          fontWeight={select(
-            'font weight',
-            Object.values(FONT_WEIGHT),
-            FONT_WEIGHT.NORMAL,
-          )}
-        >
-          {variant}
-        </Typography>
+        <Typography {...args}>{variant}</Typography>
       </div>
     ))}
   </div>
 );
 
-export const TheQuickOrangeFox = () => (
+DefaultStory.storyName = 'List';
+
+export const TheQuickOrangeFox = (args) => (
   <div style={{ width: '80%', flexDirection: 'column' }}>
     <div style={{ width: '100%' }}>
-      <Typography
-        color={select('color', COLORS, COLORS.BLACK)}
-        variant={select('variant', TYPOGRAPHY, TYPOGRAPHY.Paragraph)}
-        spacing={number('spacing', 1, { range: true, min: 1, max: 8 })}
-        align={select('align', TEXT_ALIGN, undefined)}
-        fontWeight={select('font weight', FONT_WEIGHT, FONT_WEIGHT.NORMAL)}
-      >
-        {text('content', 'The quick orange fox jumped over the lazy dog.')}
-      </Typography>
+      <Typography {...args}>{args.content}</Typography>
     </div>
   </div>
 );

--- a/ui/components/ui/typography/typography.stories.js
+++ b/ui/components/ui/typography/typography.stories.js
@@ -32,10 +32,6 @@ export default {
       options: FONT_WEIGHT,
       defaultValue: FONT_WEIGHT.NORMAL,
     },
-    spacing: {
-      control: { type: 'range', min: 1, max: 8 },
-      defaultValue: 1,
-    },
     variant: {
       control: { type: 'select' },
       options: TYPOGRAPHY,


### PR DESCRIPTION
Fixes: #13065 

Explanation: Convert Typography story in ui/components/ui/typography/typography.stories.js to use controls argType annotation

- [x] Add README.MDX
- [x] Story has argTypes that align with component api / props
- [x] All instances of @storybook/addon-knobs have been removed in favour of control args
- [x] All instances of @storybook/addon-actions have been removed in favour of action argType annotation

Manual testing steps:
- Go to latest CI build of storybook or run yarn storybook
- Search "Typography" in storybook
- Use Controls to interact with component

![image](https://user-images.githubusercontent.com/20949060/148254696-7170ec49-5e31-4fc0-848c-883abfaf9e20.png)
