### PR TITLE
fix issue where transaction items without a TRANSACTION_CONFIRMED_EVENT have unhandled error when clicking into activity log

### DIFF
--- a/ui/components/app/transaction-activity-log/transaction-activity-log.util.js
+++ b/ui/components/app/transaction-activity-log/transaction-activity-log.util.js
@@ -196,9 +196,11 @@ export function getActivities(transaction, isFirstTransaction = false) {
               const filteredAcc = acc.find(
                 (ac) => ac.eventKey === TRANSACTION_CONFIRMED_EVENT,
               );
-              filteredAcc.timestamp = new Date(
-                parseInt(entry.value, 16) * 1000,
-              ).getTime();
+              if (filteredAcc !== undefined) {
+                filteredAcc.timestamp = new Date(
+                  parseInt(entry.value, 16) * 1000,
+                ).getTime();
+              }
               break;
             }
 


### PR DESCRIPTION
Fixes: #13219 

Explanation:  Fix bug introduced in https://github.com/MetaMask/metamask-extension/pull/12633 where transaction items without a TRANSACTION_CONFIRMED_EVENT have unhandled error when clicking into activity log.

Manual testing steps:  
- Create a send transaction on any network
- Cancel the transaction before it completes
- Click into the cancelled transaction list item.
- Activity log should pop without any errors.
