### PR TITLE
Fix a propType warning on the Flask welcome screen

### DIFF
--- a/ui/components/app/flask/experimental-area/experimental-area.js
+++ b/ui/components/app/flask/experimental-area/experimental-area.js
@@ -1,16 +1,16 @@
-import React, { useContext } from 'react';
+import React, { Fragment, useContext } from 'react';
 import { useHistory } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import { I18nContext } from '../../../../contexts/i18n';
 import Button from '../../../ui/button';
 
 function lineBreaksToBr(source) {
-  return source.split('\n').map((value) => {
+  return source.split('\n').map((value, index) => {
     return (
-      <>
+      <Fragment key={index}>
         {value}
         <br />
-      </>
+      </Fragment>
     );
   });
 }


### PR DESCRIPTION
The first page of the Flask onboarding was causing a propType warning to appear in the console. It was caused by the array of React Fragments used to construct the ASCII fox; they were missing the `key` prop.

These fragments are static content, so React doesn't really need to worry about what to do in the event they are re-ordered. The array index has been used as the key to silence the warning.

Manual testing steps:  
  - Create a Flask build (`yarn start --build-type flask`) and look at the dev console on the first page of onboarding