### PR TITLE
SendHeader, ContactListTab and AdvancedTab story: converted knobs and actions to controls / args

### DIFF
--- a/ui/pages/send/send-header/send-header.stories.js
+++ b/ui/pages/send/send-header/send-header.stories.js
@@ -2,7 +2,6 @@ import React, { useEffect } from 'react';
 import { combineReducers, createStore } from 'redux';
 import { Provider } from 'react-redux';
 
-import { select } from '@storybook/addon-knobs';
 import {
   updateSendStage,
   updateSendAsset,
@@ -17,40 +16,44 @@ import SendHeader from './send-header.component';
 export default {
   title: 'Pages/Send/SendHeader',
   id: __filename,
+  argsTypes: {
+    asset: { control: 'select' },
+    stage: { control: 'select' },
+  },
 };
 
-export const DefaultStory = () => {
-  const store = createStore(
-    combineReducers({ send: sendSBReducer, history: historySBReducer }),
-  );
-  const state = store.getState();
-  const { send } = state;
-  const asset =
-    select('Asset', [ASSET_TYPES.NATIVE, ASSET_TYPES.TOKEN]) || send.asset;
+const store = createStore(
+  combineReducers({ send: sendSBReducer, history: historySBReducer }),
+);
+const state = store.getState();
+const { send } = state;
 
-  const stage =
-    select('Stage', [
-      SEND_STAGES.ADD_RECIPIENT,
-      SEND_STAGES.DRAFT,
-      SEND_STAGES.EDIT,
-      SEND_STAGES.INACTIVE,
-    ]) || send.stage;
+export const DefaultStory = (args) => {
+  useEffect(() => {
+    store.dispatch(updateSendAsset(args.asset));
+  }, [args.asset]);
 
   useEffect(() => {
-    store.dispatch(updateSendAsset(asset));
-  }, [store, asset]);
-
-  useEffect(() => {
-    store.dispatch(updateSendStage(stage));
-  }, [store, stage]);
+    store.dispatch(updateSendStage(args.stage));
+  }, [args.stage]);
 
   return (
     <Provider store={store}>
       <div style={{ width: 600 }}>
-        <SendHeader />
+        <SendHeader {...args} />
       </div>
     </Provider>
   );
 };
 
 DefaultStory.storyName = 'Default';
+DefaultStory.args = {
+  asset: [ASSET_TYPES.NATIVE, ASSET_TYPES.TOKEN] || send.asset,
+  stage:
+    [
+      SEND_STAGES.ADD_RECIPIENT,
+      SEND_STAGES.DRAFT,
+      SEND_STAGES.EDIT,
+      SEND_STAGES.INACTIVE,
+    ] || send.stage,
+};

--- a/ui/pages/send/send-header/send-header.stories.js
+++ b/ui/pages/send/send-header/send-header.stories.js
@@ -9,16 +9,24 @@ import {
 
 import sendSBReducer from '../../../../.storybook/reducers/sb-send-reducer';
 import historySBReducer from '../../../../.storybook/reducers/sb-history-reducer';
-
-import { ASSET_TYPES, SEND_STAGES } from '../../../ducks/send';
 import SendHeader from './send-header.component';
 
 export default {
   title: 'Pages/Send/SendHeader',
   id: __filename,
-  argsTypes: {
-    asset: { control: 'select' },
-    stage: { control: 'select' },
+  argTypes: {
+    asset: {
+      control: {
+        type: 'select',
+      },
+      options: ['NATIVE', 'TOKEN'],
+    },
+    stage: {
+      control: {
+        type: 'select',
+      },
+      options: ['ADD_RECIPIENT', 'DRAFT', 'EDIT', 'INACTIVE'],
+    },
   },
 };
 
@@ -48,12 +56,6 @@ export const DefaultStory = (args) => {
 
 DefaultStory.storyName = 'Default';
 DefaultStory.args = {
-  asset: [ASSET_TYPES.NATIVE, ASSET_TYPES.TOKEN] || send.asset,
-  stage:
-    [
-      SEND_STAGES.ADD_RECIPIENT,
-      SEND_STAGES.DRAFT,
-      SEND_STAGES.EDIT,
-      SEND_STAGES.INACTIVE,
-    ] || send.stage,
+  asset: 'NATIVE' || send.asset,
+  stage: 'ADD_RECIPIENT' || send.stage,
 };

--- a/ui/pages/settings/advanced-tab/advanced-tab.stories.js
+++ b/ui/pages/settings/advanced-tab/advanced-tab.stories.js
@@ -1,13 +1,23 @@
 import React from 'react';
-import { text, boolean } from '@storybook/addon-knobs';
 import AdvancedTab from './advanced-tab.component';
 
 export default {
   title: 'Pages/Settings/AdvancedTab',
   id: __filename,
+  argTypes: {
+    warning: { control: 'text' },
+    useNonceField: { control: 'boolean' },
+    sendHexData: { control: 'boolean' },
+    advancedInlineGas: { control: 'boolean' },
+    showFiatInTestnets: { control: 'boolean' },
+    threeBoxSyncingAllowed: { control: 'boolean' },
+    threeBoxDisabled: { control: 'boolean' },
+    useLedgerLive: { control: 'boolean' },
+    dismissSeedBackUpReminder: { control: 'boolean' },
+  },
 };
 
-export const DefaultStory = () => {
+export const DefaultStory = (args) => {
   return (
     <div style={{ flex: 1, height: 500 }}>
       <AdvancedTab
@@ -24,25 +34,22 @@ export const DefaultStory = () => {
         history={{ push: () => undefined }}
         showResetAccountConfirmationModal={() => undefined}
         setAdvancedInlineGasFeatureFlag={() => undefined}
-        warning={text('Warning', 'Warning Sample')}
         ipfsGateway="ipfs-gateway"
-        useNonceField={boolean('Customize Transaction Nonce', false)}
-        sendHexData={boolean('Show Hex Data', false)}
-        advancedInlineGas={boolean('Advanced Inline Gas', false)}
-        showFiatInTestnets={boolean('Show Conversion on Testnets', false)}
-        threeBoxSyncingAllowed={boolean(
-          'Sync data with 3Box (experimental)',
-          false,
-        )}
-        threeBoxDisabled={boolean('3Box Disabled', false)}
-        useLedgerLive={boolean('Use Ledger Live', false)}
-        dismissSeedBackUpReminder={boolean(
-          'Dismiss recovery phrase backup reminder',
-          false,
-        )}
+        {...args}
       />
     </div>
   );
 };
 
 DefaultStory.storyName = 'Default';
+DefaultStory.args = {
+  warning: 'Warning Sample',
+  useNonceField: false,
+  sendHexData: false,
+  advancedInlineGas: false,
+  showFiatInTestnets: false,
+  threeBoxSyncingAllowed: false,
+  threeBoxDisabled: false,
+  useLedgerLive: false,
+  dismissSeedBackUpReminder: false,
+};

--- a/ui/pages/settings/advanced-tab/advanced-tab.stories.js
+++ b/ui/pages/settings/advanced-tab/advanced-tab.stories.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useArgs } from '@storybook/client-api';
 import AdvancedTab from './advanced-tab.component';
 
 export default {
@@ -37,9 +38,71 @@ export default {
 };
 
 export const DefaultStory = (args) => {
+  const [
+    {
+      useNonceField,
+      sendHexData,
+      advancedInlineGas,
+      showFiatInTestnets,
+      threeBoxSyncingAllowed,
+      dismissSeedBackUpReminder,
+    },
+    updateArgs,
+  ] = useArgs();
+
+  const handleUseNonceField = () => {
+    updateArgs({
+      useNonceField: !useNonceField,
+    });
+  };
+
+  const handleSendHexData = () => {
+    updateArgs({
+      sendHexData: !sendHexData,
+    });
+  };
+
+  const handleAdvancedInlineGas = () => {
+    updateArgs({
+      advancedInlineGas: !advancedInlineGas,
+    });
+  };
+
+  const handleShowFiatInTestnets = () => {
+    updateArgs({
+      showFiatInTestnets: !showFiatInTestnets,
+    });
+  };
+
+  const handleThreeBoxSyncingAllowed = () => {
+    updateArgs({
+      threeBoxSyncingAllowed: !threeBoxSyncingAllowed,
+    });
+  };
+
+  const handleDismissSeedBackUpReminder = () => {
+    updateArgs({
+      dismissSeedBackUpReminder: !dismissSeedBackUpReminder,
+    });
+  };
   return (
     <div style={{ flex: 1, height: 500 }}>
-      <AdvancedTab ipfsGateway="ipfs-gateway" {...args} />
+      <AdvancedTab
+        {...args}
+        useNonceField={useNonceField}
+        setUseNonceField={handleUseNonceField}
+        sendHexData={sendHexData}
+        setHexDataFeatureFlag={handleSendHexData}
+        advancedInlineGas={advancedInlineGas}
+        setAdvancedInlineGasFeatureFlag={handleAdvancedInlineGas}
+        showFiatInTestnets={showFiatInTestnets}
+        setShowFiatConversionOnTestnetsPreference={handleShowFiatInTestnets}
+        threeBoxSyncingAllowed={threeBoxSyncingAllowed}
+        setThreeBoxSyncingPermission={handleThreeBoxSyncingAllowed}
+        dismissSeedBackUpReminder={dismissSeedBackUpReminder}
+        setDismissSeedBackUpReminder={handleDismissSeedBackUpReminder}
+        ipfsGateway="ipfs-gateway"
+      />
     </div>
   );
 };

--- a/ui/pages/settings/advanced-tab/advanced-tab.stories.js
+++ b/ui/pages/settings/advanced-tab/advanced-tab.stories.js
@@ -14,29 +14,32 @@ export default {
     threeBoxDisabled: { control: 'boolean' },
     useLedgerLive: { control: 'boolean' },
     dismissSeedBackUpReminder: { control: 'boolean' },
+    setAutoLockTimeLimit: { action: 'setAutoLockTimeLimit' },
+    setShowFiatConversionOnTestnetsPreference: {
+      action: 'setShowFiatConversionOnTestnetsPreference',
+    },
+    setShowTestNetworks: { action: 'setShowTestNetworks' },
+    setThreeBoxSyncingPermission: { action: 'setThreeBoxSyncingPermission' },
+    setIpfsGateway: { action: 'setIpfsGateway' },
+    setLedgerTransportPreference: { action: 'setLedgerTransportPreference' },
+    setDismissSeedBackUpReminder: { action: 'setDismissSeedBackUpReminder' },
+    setUseNonceField: { action: 'setUseNonceField' },
+    setHexDataFeatureFlag: { action: 'setHexDataFeatureFlag' },
+    displayWarning: { action: 'displayWarning' },
+    history: { action: 'history' },
+    showResetAccountConfirmationModal: {
+      action: 'showResetAccountConfirmationModal',
+    },
+    setAdvancedInlineGasFeatureFlag: {
+      action: 'setAdvancedInlineGasFeatureFlag',
+    },
   },
 };
 
 export const DefaultStory = (args) => {
   return (
     <div style={{ flex: 1, height: 500 }}>
-      <AdvancedTab
-        setAutoLockTimeLimit={() => undefined}
-        setShowFiatConversionOnTestnetsPreference={() => undefined}
-        setShowTestNetworks={() => undefined}
-        setThreeBoxSyncingPermission={() => undefined}
-        setIpfsGateway={() => undefined}
-        setLedgerTransportPreference={() => undefined}
-        setDismissSeedBackUpReminder={() => undefined}
-        setUseNonceField={() => undefined}
-        setHexDataFeatureFlag={() => undefined}
-        displayWarning={() => undefined}
-        history={{ push: () => undefined }}
-        showResetAccountConfirmationModal={() => undefined}
-        setAdvancedInlineGasFeatureFlag={() => undefined}
-        ipfsGateway="ipfs-gateway"
-        {...args}
-      />
+      <AdvancedTab ipfsGateway="ipfs-gateway" {...args} />
     </div>
   );
 };

--- a/ui/pages/settings/contact-list-tab/contact-list-tab.stories.js
+++ b/ui/pages/settings/contact-list-tab/contact-list-tab.stories.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import { Provider } from 'react-redux';
-import { object, boolean, select } from '@storybook/addon-knobs';
 
 import configureStore from '../../../store/store';
 import testData from '../../../../.storybook/test-data';
@@ -13,28 +12,27 @@ export default {
   title: 'Pages/Settings/ContactListTab',
   id: __filename,
   decorators: [(story) => <Provider store={store}>{story()}</Provider>],
+  argsTypes: {
+    addressBook: { control: 'object' },
+    hideAddressBook: { control: 'boolean' },
+    selectedAddress: { control: 'select' },
+  },
 };
 
-export const DefaultStory = () => {
-  const { metamask } = store.getState();
-  const { addresses } = metamask;
-  const addressBook = object('Address Book', addresses);
-  const hideAddressBook = boolean('Hide Address Book', false);
-  const selectedAddress = select(
-    'Selected Address',
-    addresses.map(({ address }) => address),
-  );
+const { metamask } = store.getState();
+const { addresses } = metamask;
 
+export const DefaultStory = (args) => {
   return (
     <div style={{ width: 300 }}>
-      <ContactListTab
-        addressBook={addressBook}
-        history={{ push: () => undefined }}
-        hideAddressBook={hideAddressBook}
-        selectedAddress={selectedAddress}
-      />
+      <ContactListTab {...args} history={{ push: () => undefined }} />
     </div>
   );
 };
 
 DefaultStory.storyName = 'Default';
+DefaultStory.args = {
+  addressBook: addresses,
+  hideAddressBook: false,
+  selectedAddress: addresses.map(({ address }) => address),
+};

--- a/ui/pages/settings/contact-list-tab/contact-list-tab.stories.js
+++ b/ui/pages/settings/contact-list-tab/contact-list-tab.stories.js
@@ -16,6 +16,7 @@ export default {
     addressBook: { control: 'object' },
     hideAddressBook: { control: 'boolean' },
     selectedAddress: { control: 'select' },
+    history: { action: 'history' },
   },
 };
 
@@ -25,7 +26,7 @@ const { addresses } = metamask;
 export const DefaultStory = (args) => {
   return (
     <div style={{ width: 300 }}>
-      <ContactListTab {...args} history={{ push: () => undefined }} />
+      <ContactListTab {...args} />
     </div>
   );
 };


### PR DESCRIPTION
**Fixes:** #13082, #13083 and #13084

**Explanation:**  Converted knobs and actions to controls / args

**SendHeader storybook screenshot:**

![Screenshot from 2022-01-06 13-46-24](https://user-images.githubusercontent.com/92527393/148386051-236accf9-a3c7-4ec6-8a7e-a455031f565b.png)

**AdvancedTab storybook screenshot:**

![Screenshot from 2022-01-06 13-47-17](https://user-images.githubusercontent.com/92527393/148386119-d354600e-5fe3-4505-99ea-5db631f5b5bb.png)

**ContactListTab storybook screenshot:**

![Screenshot from 2022-01-06 13-46-55](https://user-images.githubusercontent.com/92527393/148386241-e88d529e-5d01-4871-b804-0f56eac78810.png)


