### PR TITLE
don't run CLA bot on `l10n_crowdin_action` branch

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -9,7 +9,7 @@ jobs:
   CLABot:
     if: |
       (github.event_name == 'pull_request_target' || contains(github.event.comment.html_url, '/pull/')) &&
-      github.ref != 'refs/heads/l10n_crowdin_action'
+      (github.ref != 'refs/heads/l10n_crowdin_action' && github.event.issue.user.login != 'github-actions')
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -9,7 +9,7 @@ jobs:
   CLABot:
     if: |
       (github.event_name == 'pull_request_target' || contains(github.event.comment.html_url, '/pull/')) &&
-      (github.ref != 'refs/heads/l10n_crowdin_action' && github.event.issue.user.login != 'github-actions')
+      !(github.ref == 'refs/heads/l10n_crowdin_action' && github.event.issue.user.login == 'github-actions')
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -7,7 +7,9 @@ on:
 
 jobs:
   CLABot:
-    if: github.event_name == 'pull_request_target' || contains(github.event.comment.html_url, '/pull/')
+    if: |
+      (github.event_name == 'pull_request_target' || contains(github.event.comment.html_url, '/pull/')) &&
+      github.ref != 'refs/heads/l10n_crowdin_action'
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write


### PR DESCRIPTION
since we're having issues getting the status check back from the CLA bot (and we're all scratching our heads) maybe for these PRs we could just not run the CLA bot on that branch? Curious to hear other people's thoughts.

/cc @adonesky1 @Gudahtt 