### PR TITLE
Remove dupe Prettier config from ESLint config

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -39,13 +39,9 @@ module.exports = {
     'storybook-build/**',
   ],
 
-  extends: [
-    '@metamask/eslint-config',
-    '@metamask/eslint-config-nodejs',
-    'prettier',
-  ],
+  extends: ['@metamask/eslint-config', '@metamask/eslint-config-nodejs'],
 
-  plugins: ['@babel', 'import', 'prettier'],
+  plugins: ['@babel', 'import'],
 
   globals: {
     document: 'readonly',

--- a/app/scripts/controllers/transactions/tx-state-manager.test.js
+++ b/app/scripts/controllers/transactions/tx-state-manager.test.js
@@ -679,8 +679,11 @@ describe('TransactionStateManager', function () {
       // transaction
       const txs = generateTransactions(limit + 5, {
         chainId: (i) => {
-          if (i === 0 || i === 1) return MAINNET_CHAIN_ID;
-          else if (i === 4 || i === 5) return RINKEBY_CHAIN_ID;
+          if (i === 0 || i === 1) {
+            return MAINNET_CHAIN_ID;
+          } else if (i === 4 || i === 5) {
+            return RINKEBY_CHAIN_ID;
+          }
           return currentChainId;
         },
         to: VALID_ADDRESS,
@@ -726,8 +729,11 @@ describe('TransactionStateManager', function () {
         to: VALID_ADDRESS,
         from: VALID_ADDRESS_TWO,
         nonce: (i) => {
-          if (i === 1) return '0';
-          else if (i === 5) return '4';
+          if (i === 1) {
+            return '0';
+          } else if (i === 5) {
+            return '4';
+          }
           return `${i}`;
         },
         status: (i) =>

--- a/development/build/scripts.js
+++ b/development/build/scripts.js
@@ -450,7 +450,9 @@ function createFactoredBuild({
       // create entry points for each file
       for (const [groupLabel, groupSet] of sizeGroupMap.entries()) {
         // skip "common" group, they are added to all other groups
-        if (groupSet === commonSet) continue;
+        if (groupSet === commonSet) {
+          continue;
+        }
 
         switch (groupLabel) {
           case 'ui': {

--- a/development/highlights/storybook.js
+++ b/development/highlights/storybook.js
@@ -16,7 +16,9 @@ module.exports = {
 
 async function getHighlightAnnouncement({ changedFiles, artifactBase }) {
   const highlights = await getHighlights({ changedFiles });
-  if (!highlights.length) return null;
+  if (!highlights.length) {
+    return null;
+  }
   const highlightsBody = highlights
     .map((entry) => `\n- [${entry}](${urlForStoryFile(entry, artifactBase)})`)
     .join('');

--- a/ui/components/app/advanced-gas-fee-popover/advanced-gas-fee-inputs/priority-fee-input/priority-fee-input.js
+++ b/ui/components/app/advanced-gas-fee-popover/advanced-gas-fee-inputs/priority-fee-input/priority-fee-input.js
@@ -65,8 +65,9 @@ const PriorityFeeInput = () => {
     if (
       estimateUsed !== PRIORITY_LEVELS.CUSTOM &&
       advancedGasFeeValues?.priorityFee
-    )
+    ) {
       return advancedGasFeeValues.priorityFee;
+    }
     return maxPriorityFeePerGas;
   });
 

--- a/ui/components/app/advanced-gas-fee-popover/advanced-gas-fee-popover.js
+++ b/ui/components/app/advanced-gas-fee-popover/advanced-gas-fee-popover.js
@@ -19,7 +19,9 @@ const AdvancedGasFeePopover = () => {
     currentModal,
   } = useTransactionModalContext();
 
-  if (currentModal !== 'advancedGasFee') return null;
+  if (currentModal !== 'advancedGasFee') {
+    return null;
+  }
 
   return (
     <AdvancedGasFeePopoverContextProvider>

--- a/ui/components/app/edit-gas-fee-popover/edit-gas-fee-popover.js
+++ b/ui/components/app/edit-gas-fee-popover/edit-gas-fee-popover.js
@@ -28,7 +28,9 @@ const EditGasFeePopover = () => {
     openModalCount,
   } = useTransactionModalContext();
 
-  if (currentModal !== 'editGasFee') return null;
+  if (currentModal !== 'editGasFee') {
+    return null;
+  }
 
   let popupTitle = 'editGasFeeModalTitle';
   if (editGasMode === EDIT_GAS_MODES.CANCEL) {

--- a/ui/components/app/edit-gas-fee-popover/edit-gas-item/useCustomTimeEstimate.js
+++ b/ui/components/app/edit-gas-fee-popover/edit-gas-item/useCustomTimeEstimate.js
@@ -37,8 +37,9 @@ export const useCustomTimeEstimate = ({
       isGasEstimatesLoading ||
       gasEstimateType !== GAS_ESTIMATE_TYPES.FEE_MARKET ||
       !maxPriorityFeePerGas
-    )
+    ) {
       return;
+    }
     if (isUnknownLow) {
       // getGasFeeTimeEstimate requires parameters in string format
       getGasFeeTimeEstimate(

--- a/ui/components/app/gas-details-item/gas-details-item.js
+++ b/ui/components/app/gas-details-item/gas-details-item.js
@@ -28,7 +28,9 @@ const GasDetailsItem = ({ userAcknowledgedGasMissing = false }) => {
 
   const { useNativeCurrencyAsPrimaryCurrency } = useSelector(getPreferences);
 
-  if (hasSimulationError && !userAcknowledgedGasMissing) return null;
+  if (hasSimulationError && !userAcknowledgedGasMissing) {
+    return null;
+  }
 
   return (
     <TransactionDetailItem

--- a/ui/components/app/qr-hardware-popover/qr-hardware-sign-request/qr-hardware-sign-request.component.js
+++ b/ui/components/app/qr-hardware-popover/qr-hardware-sign-request/qr-hardware-sign-request.component.js
@@ -32,7 +32,9 @@ const QRHardwareSignRequest = ({ request, handleCancel, setErrorTitle }) => {
     );
   };
 
-  if (status === 'play') return renderPlayer();
+  if (status === 'play') {
+    return renderPlayer();
+  }
   return renderReader();
 };
 

--- a/ui/components/ui/loading-heartbeat/index.js
+++ b/ui/components/ui/loading-heartbeat/index.js
@@ -11,7 +11,9 @@ export default function LoadingHeartBeat() {
   useShouldAnimateGasEstimations();
   const active = useSelector(getGasLoadingAnimationIsShowing);
 
-  if (process.env.IN_TEST) return null;
+  if (process.env.IN_TEST) {
+    return null;
+  }
 
   return (
     <div

--- a/ui/components/ui/numeric-input/numeric-input.component.js
+++ b/ui/components/ui/numeric-input/numeric-input.component.js
@@ -30,7 +30,9 @@ export default function NumericInput({
         onChange={(e) => {
           const newValue = e.target.value;
           const match = DECIMAL_REGEX.exec(newValue);
-          if (match?.[1]?.length >= 15) return;
+          if (match?.[1]?.length >= 15) {
+            return;
+          }
           onChange?.(parseFloat(newValue || 0, 10));
         }}
         min="0"

--- a/ui/contexts/transaction-modal.js
+++ b/ui/contexts/transaction-modal.js
@@ -38,7 +38,9 @@ export const TransactionModalContextProvider = ({
 
   const closeModal = (modalName) => {
     const index = openModals.indexOf(modalName);
-    if (openModals < 0) return;
+    if (openModals < 0) {
+      return;
+    }
     const modals = [...openModals];
     modals.splice(index, 1);
     setOpenModals(modals);
@@ -49,7 +51,9 @@ export const TransactionModalContextProvider = ({
   };
 
   const openModal = (modalName) => {
-    if (openModals.includes(modalName)) return;
+    if (openModals.includes(modalName)) {
+      return;
+    }
     captureEventEnabled && captureEvent();
     const modals = [...openModals];
     modals.push(modalName);

--- a/ui/helpers/utils/gas.js
+++ b/ui/helpers/utils/gas.js
@@ -28,7 +28,9 @@ export const gasEstimateGreaterThanGasUsedPlusTenPercent = (
  * @returns {string | undefined} - hex value in WEI 10% higher than the param.
  */
 export function addTenPercent(hexStringValue, conversionOptions = {}) {
-  if (hexStringValue === undefined) return undefined;
+  if (hexStringValue === undefined) {
+    return undefined;
+  }
   return addHexPrefix(
     multiplyCurrencies(hexStringValue, 1.1, {
       toNumericBase: 'hex',

--- a/ui/helpers/utils/util.js
+++ b/ui/helpers/utils/util.js
@@ -64,7 +64,9 @@ export function isDefaultMetaMaskChain(chainId) {
 
 // Both inputs should be strings. This method is currently used to compare tokenAddress hex strings.
 export function isEqualCaseInsensitive(value1, value2) {
-  if (typeof value1 !== 'string' || typeof value2 !== 'string') return false;
+  if (typeof value1 !== 'string' || typeof value2 !== 'string') {
+    return false;
+  }
   return value1.toLowerCase() === value2.toLowerCase();
 }
 
@@ -430,7 +432,9 @@ const MINUTE_CUTOFF = 90 * 60;
 const SECOND_CUTOFF = 90;
 
 export const toHumanReadableTime = (t, milliseconds) => {
-  if (milliseconds === undefined || milliseconds === null) return '';
+  if (milliseconds === undefined || milliseconds === null) {
+    return '';
+  }
   const seconds = Math.ceil(milliseconds / 1000);
   if (seconds <= SECOND_CUTOFF) {
     return t('gasTimingSecondsShort', [seconds]);

--- a/ui/hooks/gasFeeInput/useGasFeeErrors.js
+++ b/ui/hooks/gasFeeInput/useGasFeeErrors.js
@@ -26,12 +26,16 @@ const validateGasLimit = (gasLimit, minimumGasLimit) => {
     { value: minimumGasLimit || GAS_LIMITS.SIMPLE, fromNumericBase: 'hex' },
   );
 
-  if (gasLimitTooLow) return GAS_FORM_ERRORS.GAS_LIMIT_OUT_OF_BOUNDS;
+  if (gasLimitTooLow) {
+    return GAS_FORM_ERRORS.GAS_LIMIT_OUT_OF_BOUNDS;
+  }
   return undefined;
 };
 
 const validateMaxPriorityFee = (maxPriorityFeePerGas, supportsEIP1559) => {
-  if (!supportsEIP1559) return undefined;
+  if (!supportsEIP1559) {
+    return undefined;
+  }
   if (bnLessThanEqualTo(maxPriorityFeePerGas, 0)) {
     return GAS_FORM_ERRORS.MAX_PRIORITY_FEE_BELOW_MINIMUM;
   }
@@ -44,7 +48,9 @@ const validateMaxFee = (
   maxPriorityFeePerGas,
   supportsEIP1559,
 ) => {
-  if (maxPriorityFeeError || !supportsEIP1559) return undefined;
+  if (maxPriorityFeeError || !supportsEIP1559) {
+    return undefined;
+  }
   if (bnGreaterThan(maxPriorityFeePerGas, maxFeePerGas)) {
     return GAS_FORM_ERRORS.MAX_FEE_IMBALANCE;
   }
@@ -57,7 +63,9 @@ const validateGasPrice = (
   supportsEIP1559,
   transaction,
 ) => {
-  if (supportsEIP1559 && isFeeMarketGasEstimate) return undefined;
+  if (supportsEIP1559 && isFeeMarketGasEstimate) {
+    return undefined;
+  }
   if (
     (!supportsEIP1559 || transaction?.txParams?.gasPrice) &&
     bnLessThanEqualTo(gasPrice, 0)
@@ -74,8 +82,9 @@ const getMaxPriorityFeeWarning = (
   maxPriorityFeePerGas,
   supportsEIP1559,
 ) => {
-  if (!supportsEIP1559 || !isFeeMarketGasEstimate || isGasEstimatesLoading)
+  if (!supportsEIP1559 || !isFeeMarketGasEstimate || isGasEstimatesLoading) {
     return undefined;
+  }
   if (
     bnLessThan(
       maxPriorityFeePerGas,
@@ -219,17 +228,29 @@ export function useGasFeeErrors({
 
   const gasErrors = useMemo(() => {
     const errors = {};
-    if (gasLimitError) errors.gasLimit = gasLimitError;
-    if (maxPriorityFeeError) errors.maxPriorityFee = maxPriorityFeeError;
-    if (maxFeeError) errors.maxFee = maxFeeError;
-    if (gasPriceError) errors.gasPrice = gasPriceError;
+    if (gasLimitError) {
+      errors.gasLimit = gasLimitError;
+    }
+    if (maxPriorityFeeError) {
+      errors.maxPriorityFee = maxPriorityFeeError;
+    }
+    if (maxFeeError) {
+      errors.maxFee = maxFeeError;
+    }
+    if (gasPriceError) {
+      errors.gasPrice = gasPriceError;
+    }
     return errors;
   }, [gasLimitError, maxPriorityFeeError, maxFeeError, gasPriceError]);
 
   const gasWarnings = useMemo(() => {
     const warnings = {};
-    if (maxPriorityFeeWarning) warnings.maxPriorityFee = maxPriorityFeeWarning;
-    if (maxFeeWarning) warnings.maxFee = maxFeeWarning;
+    if (maxPriorityFeeWarning) {
+      warnings.maxPriorityFee = maxPriorityFeeWarning;
+    }
+    if (maxFeeWarning) {
+      warnings.maxFee = maxFeeWarning;
+    }
     return warnings;
   }, [maxPriorityFeeWarning, maxFeeWarning]);
 

--- a/ui/hooks/gasFeeInput/useGasFeeInputs.js
+++ b/ui/hooks/gasFeeInput/useGasFeeInputs.js
@@ -116,9 +116,12 @@ export function useGasFeeInputs(
       userPrefersAdvancedGas &&
       transaction?.txParams?.maxPriorityFeePerGas &&
       transaction?.txParams?.maxFeePerGas
-    )
+    ) {
       return null;
-    if (transaction) return transaction?.userFeeLevel || null;
+    }
+    if (transaction) {
+      return transaction?.userFeeLevel || null;
+    }
     return defaultEstimateToUse;
   });
 

--- a/ui/hooks/gasFeeInput/useMaxFeePerGasInput.js
+++ b/ui/hooks/gasFeeInput/useMaxFeePerGasInput.js
@@ -61,8 +61,9 @@ export function useMaxFeePerGasInput({
   // transitional because it is only used to modify a transaction in the
   // metamask (background) state tree.
   const [maxFeePerGas, setMaxFeePerGas] = useState(() => {
-    if (initialMaxFeePerGas && feeParamsAreCustom(transaction))
+    if (initialMaxFeePerGas && feeParamsAreCustom(transaction)) {
       return initialMaxFeePerGas;
+    }
     return null;
   });
 

--- a/ui/hooks/gasFeeInput/useMaxPriorityFeePerGasInput.js
+++ b/ui/hooks/gasFeeInput/useMaxPriorityFeePerGasInput.js
@@ -57,8 +57,9 @@ export function useMaxPriorityFeePerGasInput({
     : 0;
 
   const [maxPriorityFeePerGas, setMaxPriorityFeePerGas] = useState(() => {
-    if (initialMaxPriorityFeePerGas && feeParamsAreCustom(transaction))
+    if (initialMaxPriorityFeePerGas && feeParamsAreCustom(transaction)) {
       return initialMaxPriorityFeePerGas;
+    }
     return null;
   });
 

--- a/ui/hooks/useGasFeeErrors.js
+++ b/ui/hooks/useGasFeeErrors.js
@@ -26,7 +26,9 @@ const validateGasLimit = (gasLimit, minimumGasLimit) => {
     { value: minimumGasLimit || GAS_LIMITS.SIMPLE, fromNumericBase: 'hex' },
   );
 
-  if (gasLimitTooLow) return GAS_FORM_ERRORS.GAS_LIMIT_OUT_OF_BOUNDS;
+  if (gasLimitTooLow) {
+    return GAS_FORM_ERRORS.GAS_LIMIT_OUT_OF_BOUNDS;
+  }
   return undefined;
 };
 
@@ -43,7 +45,9 @@ const validateMaxFee = (
   maxPriorityFeePerGasToUse,
   supportsEIP1559,
 ) => {
-  if (maxPriorityFeeError) return undefined;
+  if (maxPriorityFeeError) {
+    return undefined;
+  }
   if (
     supportsEIP1559 &&
     bnGreaterThan(maxPriorityFeePerGasToUse, maxFeePerGasToUse)
@@ -76,8 +80,9 @@ const getMaxPriorityFeeWarning = (
   maxPriorityFeePerGasToUse,
   supportsEIP1559,
 ) => {
-  if (!supportsEIP1559 || !isFeeMarketGasEstimate || isGasEstimatesLoading)
+  if (!supportsEIP1559 || !isFeeMarketGasEstimate || isGasEstimatesLoading) {
     return undefined;
+  }
   if (
     bnLessThan(
       maxPriorityFeePerGasToUse,
@@ -220,17 +225,29 @@ export function useGasFeeErrors({
 
   const gasErrors = useMemo(() => {
     const errors = {};
-    if (gasLimitError) errors.gasLimit = gasLimitError;
-    if (maxPriorityFeeError) errors.maxPriorityFee = maxPriorityFeeError;
-    if (maxFeeError) errors.maxFee = maxFeeError;
-    if (gasPriceError) errors.gasPrice = gasPriceError;
+    if (gasLimitError) {
+      errors.gasLimit = gasLimitError;
+    }
+    if (maxPriorityFeeError) {
+      errors.maxPriorityFee = maxPriorityFeeError;
+    }
+    if (maxFeeError) {
+      errors.maxFee = maxFeeError;
+    }
+    if (gasPriceError) {
+      errors.gasPrice = gasPriceError;
+    }
     return errors;
   }, [gasLimitError, maxPriorityFeeError, maxFeeError, gasPriceError]);
 
   const gasWarnings = useMemo(() => {
     const warnings = {};
-    if (maxPriorityFeeWarning) warnings.maxPriorityFee = maxPriorityFeeWarning;
-    if (maxFeeWarning) warnings.maxFee = maxFeeWarning;
+    if (maxPriorityFeeWarning) {
+      warnings.maxPriorityFee = maxPriorityFeeWarning;
+    }
+    if (maxFeeWarning) {
+      warnings.maxFee = maxFeeWarning;
+    }
     return warnings;
   }, [maxPriorityFeeWarning, maxFeeWarning]);
 

--- a/ui/pages/confirm-transaction-base/transaction-alerts/transaction-alerts.js
+++ b/ui/pages/confirm-transaction-base/transaction-alerts/transaction-alerts.js
@@ -26,7 +26,9 @@ const TransactionAlerts = ({
   const pendingTransactions = useSelector(submittedPendingTransactionsSelector);
   const t = useI18nContext();
 
-  if (!supportsEIP1559V2) return null;
+  if (!supportsEIP1559V2) {
+    return null;
+  }
 
   return (
     <div className="transaction-alerts">

--- a/ui/pages/keychains/restore-vault.js
+++ b/ui/pages/keychains/restore-vault.js
@@ -89,7 +89,9 @@ class RestoreVaultPage extends Component {
   handleImport = (event) => {
     event.preventDefault();
     const { password, seedPhrase, disabled } = this.state;
-    if (disabled) return;
+    if (disabled) {
+      return;
+    }
     const {
       // eslint-disable-next-line no-shadow
       createNewVaultAndRestore,

--- a/ui/pages/send/send-content/send-content.component.js
+++ b/ui/pages/send/send-content/send-content.component.js
@@ -55,10 +55,13 @@ export default class SendContent extends Component {
     } = this.props;
 
     let gasError;
-    if (gasIsExcessive) gasError = GAS_PRICE_EXCESSIVE_ERROR_KEY;
-    else if (noGasPrice) gasError = GAS_PRICE_FETCH_FAILURE_ERROR_KEY;
-    else if (getIsBalanceInsufficient)
+    if (gasIsExcessive) {
+      gasError = GAS_PRICE_EXCESSIVE_ERROR_KEY;
+    } else if (noGasPrice) {
+      gasError = GAS_PRICE_FETCH_FAILURE_ERROR_KEY;
+    } else if (getIsBalanceInsufficient) {
       gasError = INSUFFICIENT_FUNDS_FOR_GAS_ERROR_KEY;
+    }
     const showHexData =
       this.props.showHexData && asset.type !== ASSET_TYPES.TOKEN;
 

--- a/ui/pages/send/send-footer/send-footer.component.js
+++ b/ui/pages/send/send-footer/send-footer.component.js
@@ -40,7 +40,9 @@ export default class SendFooter extends Component {
       sendStage,
     } = this.props;
 
-    if (draftTransactionID) cancelTx({ id: draftTransactionID });
+    if (draftTransactionID) {
+      cancelTx({ id: draftTransactionID });
+    }
     resetSendState();
 
     const nextRoute =

--- a/ui/pages/swaps/swaps.util.js
+++ b/ui/pages/swaps/swaps.util.js
@@ -836,6 +836,8 @@ export const getSwapsLivenessForNetwork = (swapsFeatureFlags = {}, chainId) => {
  * @returns number
  */
 export const countDecimals = (value) => {
-  if (!value || Math.floor(value) === value) return 0;
+  if (!value || Math.floor(value) === value) {
+    return 0;
+  }
   return value.toString().split('.')[1]?.length || 0;
 };

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -90,11 +90,15 @@ export function getCurrentQRHardwareState(state) {
 
 export function hasUnsignedQRHardwareTransaction(state) {
   const { txParams } = state.confirmTransaction.txData;
-  if (!txParams) return false;
+  if (!txParams) {
+    return false;
+  }
   const { from } = txParams;
   const { keyrings } = state.metamask;
   const qrKeyring = keyrings.find((kr) => kr.type === KEYRING_TYPES.QR);
-  if (!qrKeyring) return false;
+  if (!qrKeyring) {
+    return false;
+  }
   return Boolean(
     qrKeyring.accounts.find(
       (account) => account.toLowerCase() === from.toLowerCase(),
@@ -110,7 +114,9 @@ export function hasUnsignedQRHardwareMessage(state) {
   const { from } = msgParams;
   const { keyrings } = state.metamask;
   const qrKeyring = keyrings.find((kr) => kr.type === KEYRING_TYPES.QR);
-  if (!qrKeyring) return false;
+  if (!qrKeyring) {
+    return false;
+  }
   switch (type) {
     case MESSAGE_TYPE.ETH_SIGN_TYPED_DATA:
     case MESSAGE_TYPE.ETH_SIGN:

--- a/ui/store/actions.js
+++ b/ui/store/actions.js
@@ -431,8 +431,9 @@ export function connectHardware(deviceName, page, hdPath, t) {
         dispatch(displayWarning(t('ledgerDeviceOpenFailureMessage')));
         throw new Error(t('ledgerDeviceOpenFailureMessage'));
       } else {
-        if (deviceName !== DEVICE_NAMES.QR)
+        if (deviceName !== DEVICE_NAMES.QR) {
           dispatch(displayWarning(error.message));
+        }
         throw error;
       }
     } finally {


### PR DESCRIPTION
The ESLint config for the extension explicitly includes support for
Prettier. However, this is already being provided by our global ESLint
config (`@metamask/eslint-config`). Therefore there is no need to
include it here. In fact, this is causing weird issues where the `curly`
option is getting overridden somehow. After this change, these syntaxes
are invalid:

``` javascript
if (foo) return;
```

``` javascript
if (foo) return 'bar';
```

---

Related to https://github.com/MetaMask/metamask-extension/pull/12578. 