### PR TITLE
[Hotfix] track anonymous events appropriately

### DIFF
--- a/shared/constants/metametrics.js
+++ b/shared/constants/metametrics.js
@@ -110,9 +110,9 @@
  *  the page view
  */
 
-// An empty string is a, currently undocumented, way of telling mixpanel
-// that these events are meant to be anonymous and not identified to any user
-export const METAMETRICS_ANONYMOUS_ID = '';
+// Mixpanel converts the zero address value to a truly anonymous event, which
+// speeds up reporting
+export const METAMETRICS_ANONYMOUS_ID = '0x0000000000000000';
 
 /**
  * This object is used to identify events that are triggered by the background


### PR DESCRIPTION
in #12503 i changed the `METAMETRICS_ANONYMOUS_ID` value to `''` from `'""'` under the advisement of Mixpanel. This resulted in the unforeseen consequence of segment stripping the id field from the payload as an `undefined` value. This resulted in a large number of `userId or anonymousId` must be provided errors. Which was cared for in https://github.com/MetaMask/metamask-extension/commit/c9baf39c4da063a7f1722fc11ca009ec67fcbf73#diff-7b8d320333af0791e309c08599608d1e6f9a97e19792e32cf7a058c4f35a6022R18-R74 -- but the unfortunate result of that is that all sensitiveProperties in event payloads have not resulted in tracked anonymous events since my change went into place. Those events have been lost forever. 

Mixpanel is now properly transforming the `0x00` id to the appropriate anonymous event so we can rely upon it again. this change should get us back to tracking that sensitive data on anonymous events. 
