### PR TITLE
Handle missing eth_accounts permission history in getLastConnectedInfo

### DIFF
--- a/ui/selectors/permissions.js
+++ b/ui/selectors/permissions.js
@@ -238,16 +238,23 @@ export function activeTabHasPermissions(state) {
   );
 }
 
+/**
+ * Get the connected accounts history for all origins.
+ *
+ * @param {Record<string, unknown>} state - The MetaMask state.
+ * @returns {Record<string, { accounts: Record<string, number> }>} An object
+ * with account connection histories by origin.
+ */
 export function getLastConnectedInfo(state) {
   const { permissionHistory = {} } = state.metamask;
-  return Object.keys(permissionHistory).reduce((acc, origin) => {
-    const ethAccountsHistory = JSON.parse(
-      JSON.stringify(permissionHistory[origin].eth_accounts),
-    );
-    return {
-      ...acc,
-      [origin]: ethAccountsHistory,
-    };
+  return Object.keys(permissionHistory).reduce((lastConnectedInfo, origin) => {
+    if (permissionHistory[origin].eth_accounts) {
+      lastConnectedInfo[origin] = JSON.parse(
+        JSON.stringify(permissionHistory[origin].eth_accounts),
+      );
+    }
+
+    return lastConnectedInfo;
   }, {});
 }
 

--- a/ui/selectors/permissions.test.js
+++ b/ui/selectors/permissions.test.js
@@ -1,6 +1,7 @@
 import { KOVAN_CHAIN_ID } from '../../shared/constants/network';
 import {
   getConnectedSubjectsForSelectedAddress,
+  getLastConnectedInfo,
   getOrderedConnectedAccountsForActiveTab,
   getPermissionsForActiveTab,
 } from './permissions';
@@ -293,6 +294,30 @@ describe('selectors', () => {
           lastActive: 1586359844192,
         },
       ]);
+    });
+  });
+
+  describe('getLastConnectedInfo', () => {
+    it('retrieves the last connected info', () => {
+      const mockState = {
+        metamask: {
+          permissionHistory: {
+            a: {
+              foo: {},
+              eth_accounts: { accounts: { 0x1: 1, 0x2: 2 } },
+            },
+            b: {
+              foo: {},
+              eth_accounts: { accounts: { 0x2: 2 } },
+            },
+          },
+        },
+      };
+
+      expect(getLastConnectedInfo(mockState)).toStrictEqual({
+        a: { accounts: { 0x1: 1, 0x2: 2 } },
+        b: { accounts: { 0x2: 2 } },
+      });
     });
   });
 

--- a/ui/selectors/permissions.test.js
+++ b/ui/selectors/permissions.test.js
@@ -310,6 +310,9 @@ describe('selectors', () => {
               foo: {},
               eth_accounts: { accounts: { 0x2: 2 } },
             },
+            c: {
+              foo: {},
+            },
           },
         },
       };


### PR DESCRIPTION
This PR ensures that the `getLastConnectedInfo` selector handles missing `eth_accounts` permission history. Historically, `eth_accounts` was the only permission in existence, and the only way that a permission subject ended up with a permission history in the first place. This will no longer the case as of #11837, and we were perhaps never right to bake in this assumption to begin with.

The first commit adds a unit test for `getLastConnectedInfo`, without modifying the selector. Running this test locally should suffice as manual testing. The second commit modifies the selector and updates the unit test to handle the case of missing `eth_accounts` history.