### PR TITLE
Remove unused localized messages

### DIFF
--- a/app/_locales/el/messages.json
+++ b/app/_locales/el/messages.json
@@ -1099,21 +1099,6 @@
     "message": "Η εισαγωγή αρχείων δεν λειτουργεί; Κάντε κλικ εδώ!",
     "description": "Helps user import their account from a JSON file"
   },
-  "flaskExperimentalText1": {
-    "message": "Χρησιμοποιώντας το Flask μπορείτε να αυξήσετε σημαντικά τον κίνδυνο απώλειας κεφαλαίων:"
-  },
-  "flaskExperimentalText2": {
-    "message": "εάν το χρησιμοποιείτε για να εγκαταστήσετε μη αξιόπιστα Snap"
-  },
-  "flaskExperimentalText3": {
-    "message": "αν δεν επανεξετάσετε τις επιβεβαιώσεις πριν από την έγκριση αλλαγών"
-  },
-  "flaskExperimentalText4": {
-    "message": "αν αλληλεπιδράσετε με έξυπνα συμβόλαια με τα οποία δεν είστε εξοικειωμένοι"
-  },
-  "flaskExperimentalText5": {
-    "message": "Χρησιμοποιώντας το Flask σας δίνεται πολύ μεγαλύτερη διακριτική ευχέρεια στη χρήση της δύναμης του MetaMask, και αυτή η διακριτική ευχέρεια είναι όλη δική σας. Αποδέχεστε αυτούς τους κινδύνους καθώς και επιπλέον ευθύνη για την ασφάλεια του πορτοφολιού σας;"
-  },
   "flaskSnapSettingsCardButtonCta": {
     "message": "Προβολή λεπτομερειών",
     "description": "Call to action a user can take to see more information about the Snap that is installed"
@@ -3336,9 +3321,6 @@
   },
   "usedByClients": {
     "message": "Χρησιμοποιείται από μια ποικιλία διαφορετικών πελατών"
-  },
-  "userAccepts": {
-    "message": "Αποδέχομαι"
   },
   "userName": {
     "message": "Όνομα χρήστη"

--- a/app/_locales/fr/messages.json
+++ b/app/_locales/fr/messages.json
@@ -1099,21 +1099,6 @@
     "message": "L'importation de fichier ne fonctionne pas? Cliquez ici!",
     "description": "Helps user import their account from a JSON file"
   },
-  "flaskExperimentalText1": {
-    "message": "L’utilisation de Flask peut augmenter considérablement votre risque de perte de fonds :"
-  },
-  "flaskExperimentalText2": {
-    "message": "si vous l’utilisez pour installer des Snaps non dignes de confiance ;"
-  },
-  "flaskExperimentalText3": {
-    "message": "si vous ne vérifiez pas les confirmations avant d’approuver des changements ;"
-  },
-  "flaskExperimentalText4": {
-    "message": "si vous utilisez des contrats intelligents non familiers."
-  },
-  "flaskExperimentalText5": {
-    "message": "L’utilisation de Flask vous offre une plus grande discrétion quant à l’utilisation de la puissance de MetaMask. Cette discrétion vous appartient. Acceptez-vous ces risques ainsi que de prendre la responsabilité supplémentaire de la sécurité de votre portefeuille ?"
-  },
   "flaskSnapSettingsCardButtonCta": {
     "message": "Voir les détails",
     "description": "Call to action a user can take to see more information about the Snap that is installed"
@@ -3336,9 +3321,6 @@
   },
   "usedByClients": {
     "message": "Utilisé par une variété de clients différents"
-  },
-  "userAccepts": {
-    "message": "J’accepte"
   },
   "userName": {
     "message": "Nom d'utilisateur"

--- a/app/_locales/hi/messages.json
+++ b/app/_locales/hi/messages.json
@@ -1099,21 +1099,6 @@
     "message": "फ़ाइल आयात काम नहीं कर रहा है? यहाँ क्लिक करें!",
     "description": "Helps user import their account from a JSON file"
   },
-  "flaskExperimentalText1": {
-    "message": "फ्लास्क का उपयोग आपके फंड के नुकसान के जोखिम को काफी ज्यादा बढ़ा सकता है।"
-  },
-  "flaskExperimentalText2": {
-    "message": "यदि आप इसका उपयोग गैर-भरोसेमंद स्नैप इंस्टॉल करने के लिए करते हैं"
-  },
-  "flaskExperimentalText3": {
-    "message": "बदलाव को स्वीकृति देने से पहले यदि आप पुष्टिकरण की समीक्षा नहीं करते हैं"
-  },
-  "flaskExperimentalText4": {
-    "message": "यदि आप अपरिचित स्मार्ट अनुबंधों के साथ बातचीत करते हैं"
-  },
-  "flaskExperimentalText5": {
-    "message": "मेटामास्क की शक्ति का इस्तेमाल करने में फ्लास्क का उपयोग आपको ज़्यादा समझदारी देता है, और वो समझदारी आपकी है। अपने वॉलेट की सुरक्षा के लिए क्या आप इन जोखिमों के साथ साथ अतिरिक्त ज़िम्मेदारियों को भी स्वीकार करते हैं?"
-  },
   "flaskSnapSettingsCardButtonCta": {
     "message": "विवरण देखें",
     "description": "Call to action a user can take to see more information about the Snap that is installed"
@@ -3336,9 +3321,6 @@
   },
   "usedByClients": {
     "message": "विभिन्न क्लाइंट द्वारा उपयोग किया जाता है"
-  },
-  "userAccepts": {
-    "message": "मुझे स्वीकार है"
   },
   "userName": {
     "message": "उपयोगकर्ता"

--- a/app/_locales/id/messages.json
+++ b/app/_locales/id/messages.json
@@ -1099,21 +1099,6 @@
     "message": "Impor file tidak bekerja? Klik di sini!",
     "description": "Helps user import their account from a JSON file"
   },
-  "flaskExperimentalText1": {
-    "message": "Menggunakan Flask dapat sangat meningkatkan risiko kehilangan dana:"
-  },
-  "flaskExperimentalText2": {
-    "message": "jika Anda menggunakannya untuk memasang Snaps yang tidak tepercaya"
-  },
-  "flaskExperimentalText3": {
-    "message": "jika Anda tidak meninjau konfirmasi sebelum menyetujui perubahan"
-  },
-  "flaskExperimentalText4": {
-    "message": "jika Anda berinteraksi dengan kontrak pintar yang tak dikenal"
-  },
-  "flaskExperimentalText5": {
-    "message": "Menggunakan Flask memberi Anda keleluasaan yang jauh lebih besar dalam menggunakan kekuatan MetaMask, dan keleluasaan itu adalah milik Anda. Apakah Anda menerima risiko ini serta tanggung jawab ekstra untuk keamanan dompet Anda?"
-  },
   "flaskSnapSettingsCardButtonCta": {
     "message": "Lihat detailnya",
     "description": "Call to action a user can take to see more information about the Snap that is installed"
@@ -3336,9 +3321,6 @@
   },
   "usedByClients": {
     "message": "Digunakan oleh berbagai klien yang berbeda"
-  },
-  "userAccepts": {
-    "message": "Saya menerima"
   },
   "userName": {
     "message": "Nama pengguna"

--- a/app/_locales/ja/messages.json
+++ b/app/_locales/ja/messages.json
@@ -1099,21 +1099,6 @@
     "message": "ファイルのインポートが機能していない場合ここをクリック!",
     "description": "Helps user import their account from a JSON file"
   },
-  "flaskExperimentalText1": {
-    "message": "Flaskを使用すると、次の場合に資金が失われるリスクが大幅に増加します。"
-  },
-  "flaskExperimentalText2": {
-    "message": "信頼できないスナップをインストールするために使用する場合"
-  },
-  "flaskExperimentalText3": {
-    "message": "変更を承認する前に確認を行わない場合"
-  },
-  "flaskExperimentalText4": {
-    "message": "不慣れなスマートコントラクトを扱った場合"
-  },
-  "flaskExperimentalText5": {
-    "message": "Flaskを使用することで、MetaMaskをより自由に使用し、より多くの決定権を握ることができます。これらのリスクと、ウォレットの安全性に対する追加の責任を受け入れますか？"
-  },
   "flaskSnapSettingsCardButtonCta": {
     "message": "詳細を表示",
     "description": "Call to action a user can take to see more information about the Snap that is installed"
@@ -3336,9 +3321,6 @@
   },
   "usedByClients": {
     "message": "さまざまな異なるクライアントによって使用されています"
-  },
-  "userAccepts": {
-    "message": "同意する"
   },
   "userName": {
     "message": "ユーザー名"

--- a/app/_locales/ko/messages.json
+++ b/app/_locales/ko/messages.json
@@ -1099,21 +1099,6 @@
     "message": "파일 가져오기가 작동하지 않나요? 여기를 클릭하세요.",
     "description": "Helps user import their account from a JSON file"
   },
-  "flaskExperimentalText1": {
-    "message": "Flask를 사용하면 자금 손실 위험이 크게 증가할 수 있습니다."
-  },
-  "flaskExperimentalText2": {
-    "message": "신뢰할 수 없는 Snap을 설치하는 데 사용하는 경우"
-  },
-  "flaskExperimentalText3": {
-    "message": "변경을 승인하기 전에 확인을 검토하지 않는 경우"
-  },
-  "flaskExperimentalText4": {
-    "message": "익숙하지 않은 스마트 계약과 상호 작용하는 경우"
-  },
-  "flaskExperimentalText5": {
-    "message": "Flask를 사용하면 메타마스크의 기능을 사용하는 데 있어 훨씬 더 큰 재량권을 갖게 되며 그 재량권은 사용자의 몫입니다. 이러한 위험과 지갑의 안전에 대한 추가 책임을 받아들이십니까?"
-  },
   "flaskSnapSettingsCardButtonCta": {
     "message": "세부 정보 보기",
     "description": "Call to action a user can take to see more information about the Snap that is installed"
@@ -3336,9 +3321,6 @@
   },
   "usedByClients": {
     "message": "다양한 클라이언트에서 사용합니다."
-  },
-  "userAccepts": {
-    "message": "수락합니다."
   },
   "userName": {
     "message": "사용자 이름"

--- a/app/_locales/ru/messages.json
+++ b/app/_locales/ru/messages.json
@@ -1099,21 +1099,6 @@
     "message": "Импорт файлов не работает? Нажмите здесь!",
     "description": "Helps user import their account from a JSON file"
   },
-  "flaskExperimentalText1": {
-    "message": "Использование Flask может значительно увеличить риск потери средств:"
-  },
-  "flaskExperimentalText2": {
-    "message": "если вы используете его для установки ненадежных привязок;"
-  },
-  "flaskExperimentalText3": {
-    "message": "если вы не просматриваете подтверждения перед утверждением изменений;"
-  },
-  "flaskExperimentalText4": {
-    "message": "если вы взаимодействуете с незнакомыми смарт-контрактами."
-  },
-  "flaskExperimentalText5": {
-    "message": "Flask дает вам гораздо большую свободу действий при использовании возможностей MetaMask, но вы применяете Flask на свой страх и риск. Принимаете ли вы эти риски, а также дополнительную ответственность за безопасность своего кошелька?"
-  },
   "flaskSnapSettingsCardButtonCta": {
     "message": "См. подробности",
     "description": "Call to action a user can take to see more information about the Snap that is installed"
@@ -3336,9 +3321,6 @@
   },
   "usedByClients": {
     "message": "Используется множеством разных клиентов"
-  },
-  "userAccepts": {
-    "message": "Я согласен(-на)"
   },
   "userName": {
     "message": "Имя пользователя"

--- a/app/_locales/tl/messages.json
+++ b/app/_locales/tl/messages.json
@@ -1099,21 +1099,6 @@
     "message": "Hindi gumagana ang pag-import ng file? Mag-click dito!",
     "description": "Helps user import their account from a JSON file"
   },
-  "flaskExperimentalText1": {
-    "message": "Ang paggamit ng Flask ay maaaring lubos na magpataas ang iyong panganib ng pagkawala ng pondo:"
-  },
-  "flaskExperimentalText2": {
-    "message": "kung ginagamit mo ito para mag-install ng mga hindi mapagkakatiwalaang Snap"
-  },
-  "flaskExperimentalText3": {
-    "message": "kung ayaw mong i-review ang mga kumpirmasyon bago maaprubahan ang mga pagbabago"
-  },
-  "flaskExperimentalText4": {
-    "message": "kapag nakipag-usap ka sa di kilalang mga smart contract"
-  },
-  "flaskExperimentalText5": {
-    "message": "Ang paggamit ng Flask ay nagbibigay sa iyo ng higit na pagpapasya sa paggamit ng kapangyarihan ng MetaMask, at ang pagpapasya na iyon ay sa iyo. Tinatanggap mo ba ang mga panganib na ito pati na rin ang karagdagang responsibilidad para sa kaligtasan ng iyong wallet?"
-  },
   "flaskSnapSettingsCardButtonCta": {
     "message": "Tingnan ang mga detalye",
     "description": "Call to action a user can take to see more information about the Snap that is installed"
@@ -3336,9 +3321,6 @@
   },
   "usedByClients": {
     "message": "Ginagamit ng iba't ibang client"
-  },
-  "userAccepts": {
-    "message": "Tinatanggap ko"
   },
   "userName": {
     "message": "Username"

--- a/app/_locales/tr/messages.json
+++ b/app/_locales/tr/messages.json
@@ -1099,21 +1099,6 @@
     "message": "Dosya alma çalışmıyor mu? Buraya tıklayın!",
     "description": "Helps user import their account from a JSON file"
   },
-  "flaskExperimentalText1": {
-    "message": "Flask kullanmak para kaybı riskinizi yüksek oranda artırabilir:"
-  },
-  "flaskExperimentalText2": {
-    "message": "güvenilir olmayan Sanpl'leri yüklemek için kullanırsanız"
-  },
-  "flaskExperimentalText3": {
-    "message": "değişiklikleri kabul etmeden önce onayları incelemezseniz"
-  },
-  "flaskExperimentalText4": {
-    "message": "alışkın olmadığınız akıllı sözleşmelerle uğraşırsanız"
-  },
-  "flaskExperimentalText5": {
-    "message": "Flask kullanmak MetaMask'ın gücünü kullanmada size çok daha fazla gizlilik sağlar ve bu gizlilik tamamen size özeldir. Bu riskleri ve ayrıca cüzdanınızın güvenliği için ekstra sorumluluğu kabul ediyor musunuz?"
-  },
   "flaskSnapSettingsCardButtonCta": {
     "message": "Ayrıntılara bakın",
     "description": "Call to action a user can take to see more information about the Snap that is installed"
@@ -3336,9 +3321,6 @@
   },
   "usedByClients": {
     "message": "Farklı istemciler tarafından kullanılmakta"
-  },
-  "userAccepts": {
-    "message": "Kabul ediyorum"
   },
   "userName": {
     "message": "Kullanıcı adı"

--- a/app/_locales/vi/messages.json
+++ b/app/_locales/vi/messages.json
@@ -1099,21 +1099,6 @@
     "message": "Tính năng nhập tệp không hoạt động? Nhấp vào đây!",
     "description": "Helps user import their account from a JSON file"
   },
-  "flaskExperimentalText1": {
-    "message": "Sử dụng Flask có thể gia tăng đáng kể nguy cơ mất tiền của bạn:"
-  },
-  "flaskExperimentalText2": {
-    "message": "nếu bạn sử dụng để cài đặt Snaps không đáng tin cậy"
-  },
-  "flaskExperimentalText3": {
-    "message": "nếu bạn không xem lại xác nhận trước khi chấp thuận các thay đổi"
-  },
-  "flaskExperimentalText4": {
-    "message": "nếu bạn tương tác với những hợp đồng thông minh không quen thuộc"
-  },
-  "flaskExperimentalText5": {
-    "message": "Sử dụng Flask cho phép bạn toàn quyền quyết định trong việc sử dụng sức mạnh của MetaMask và quyền đó là của bạn. Bạn có chấp nhận những nguy cơ này cũng như phải chịu thêm trách nhiệm cho sự an toàn của ví không?"
-  },
   "flaskSnapSettingsCardButtonCta": {
     "message": "Xem chi tiết",
     "description": "Call to action a user can take to see more information about the Snap that is installed"
@@ -3336,9 +3321,6 @@
   },
   "usedByClients": {
     "message": "Được nhiều ví khác nhau sử dụng"
-  },
-  "userAccepts": {
-    "message": "Tôi chấp nhận"
   },
   "userName": {
     "message": "Tên người dùng"

--- a/app/_locales/zh_CN/messages.json
+++ b/app/_locales/zh_CN/messages.json
@@ -1099,21 +1099,6 @@
     "message": "文件导入失败？ 点击这里！",
     "description": "Helps user import their account from a JSON file"
   },
-  "flaskExperimentalText1": {
-    "message": "使用Flask可极大地增加您的资金损失风险："
-  },
-  "flaskExperimentalText2": {
-    "message": "如果您使用它来安装不可信的快照"
-  },
-  "flaskExperimentalText3": {
-    "message": "如果您在批准更改之前不审核确认"
-  },
-  "flaskExperimentalText4": {
-    "message": "如果您与不熟悉的智能合同发生交互作用"
-  },
-  "flaskExperimentalText5": {
-    "message": "使用Flask让您在使用Metamask的力量时拥有更大的自由裁量权，这个自由裁量权由您决定。 您是否接受这些风险以及您钱包安全的额外责任？"
-  },
   "flaskSnapSettingsCardButtonCta": {
     "message": "查看详细信息",
     "description": "Call to action a user can take to see more information about the Snap that is installed"
@@ -3336,9 +3321,6 @@
   },
   "usedByClients": {
     "message": "可用于各种不同的客户端"
-  },
-  "userAccepts": {
-    "message": "我接受"
   },
   "userName": {
     "message": "名称"


### PR DESCRIPTION
These messages were removed from the `en` locale in #13244, but they were not deleted because that branch was not up-to-date when it was merged, and the translations were recent additions (#13206)