### PR TITLE
Flask devx fix

### DIFF
--- a/development/build/transforms/remove-fenced-code.js
+++ b/development/build/transforms/remove-fenced-code.js
@@ -200,6 +200,9 @@ const directiveParsingRegex = /^([A-Z]+):([A-Z_]+)(?:\(((?:\w+,)*\w+)\))?$/u;
  * a boolean indicating whether they were modified.
  */
 function removeFencedCode(filePath, typeOfCurrentBuild, fileContent) {
+  if (/^\/\/# sourceMappingURL=/gmu.test(fileContent)) {
+    return [fileContent, false];
+  }
   const matchedLines = [...fileContent.matchAll(linesWithFenceRegex)];
 
   // If we didn't match any lines, return the unmodified file contents.

--- a/development/build/transforms/remove-fenced-code.js
+++ b/development/build/transforms/remove-fenced-code.js
@@ -203,9 +203,10 @@ function removeFencedCode(filePath, typeOfCurrentBuild, fileContent) {
   if (/^\/\/# sourceMappingURL=/gmu.test(fileContent)) {
     return [fileContent, false];
   }
-  const matchedLines = [...fileContent.matchAll(linesWithFenceRegex)];
 
   // If we didn't match any lines, return the unmodified file contents.
+  const matchedLines = [...fileContent.matchAll(linesWithFenceRegex)];
+
   if (matchedLines.length === 0) {
     return [fileContent, false];
   }

--- a/development/build/transforms/remove-fenced-code.js
+++ b/development/build/transforms/remove-fenced-code.js
@@ -200,6 +200,12 @@ const directiveParsingRegex = /^([A-Z]+):([A-Z_]+)(?:\(((?:\w+,)*\w+)\))?$/u;
  * a boolean indicating whether they were modified.
  */
 function removeFencedCode(filePath, typeOfCurrentBuild, fileContent) {
+  // Do not modify the file if we detect an inline sourcemap. For reasons
+  // yet to be determined, the transform receives every file twice while in
+  // watch mode, the second after Babel has transpiled the file. Babel adds
+  // inline source maps to the file, something we will never do in our own
+  // source files, so we use the existence of inline source maps to determine
+  // whether we should ignore the file.
   if (/^\/\/# sourceMappingURL=/gmu.test(fileContent)) {
     return [fileContent, false];
   }

--- a/development/build/transforms/remove-fenced-code.test.js
+++ b/development/build/transforms/remove-fenced-code.test.js
@@ -610,6 +610,18 @@ describe('build/transforms/remove-fenced-code', () => {
       });
     });
 
+    it('rejects files with sourceMap inclusion', () => {
+      // This is so that there isn't an unnecessary second execution of
+      // removeFencedCode with a transpiled version of the same file
+      const input = getTestData().validInputs.extraContentWithFences;
+      input.concat(
+        '\n//# sourceMappingURL=as32e32wcwc2234f2ew32cnin4243f4nv9nsdoivnxzoivnd',
+      );
+      expect(
+        removeFencedCode(mockFileName, BuildType.flask, input),
+      ).toStrictEqual([input, false]);
+    });
+
     // We can't do this until there's more than one command
     it.todo('rejects directive pairs with mismatched commands');
   });

--- a/development/build/transforms/remove-fenced-code.test.js
+++ b/development/build/transforms/remove-fenced-code.test.js
@@ -610,7 +610,7 @@ describe('build/transforms/remove-fenced-code', () => {
       });
     });
 
-    it('rejects files with sourceMap inclusion', () => {
+    it('ignores files with inline source maps', () => {
       // This is so that there isn't an unnecessary second execution of
       // removeFencedCode with a transpiled version of the same file
       const input = getTestData().validInputs.extraContentWithFences.concat(

--- a/development/build/transforms/remove-fenced-code.test.js
+++ b/development/build/transforms/remove-fenced-code.test.js
@@ -613,8 +613,7 @@ describe('build/transforms/remove-fenced-code', () => {
     it('rejects files with sourceMap inclusion', () => {
       // This is so that there isn't an unnecessary second execution of
       // removeFencedCode with a transpiled version of the same file
-      const input = getTestData().validInputs.extraContentWithFences;
-      input.concat(
+      const input = getTestData().validInputs.extraContentWithFences.concat(
         '\n//# sourceMappingURL=as32e32wcwc2234f2ew32cnin4243f4nv9nsdoivnxzoivnd',
       );
       expect(


### PR DESCRIPTION
Fixes: #13011 

Explanation:  This fixes a devx issue when running a build-type of 'flask' in dev mode. On reload, the build process would break if there were updates made to a file that had code fences. The reason was that the `removeFencedCode` transform stream was being called on twice, the first time it works fine and transforms properly, however the second time is done on a transpiled version of the same file and the code fencing regex does not sit well with this hence the various thrown errors. Regex was added to check for if file content had a source map inclusion and the function execution is halted at this point.

Manual testing steps:  
  -  Run `yarn start --build-type flask`
  -  Make changes in a file with code fencing and observe that the build process reloads properly.