### PR TITLE
#10168 - Fix to Can't open settings if browser zoom level > 100%

### DIFF
--- a/ui/components/app/account-menu/index.scss
+++ b/ui/components/app/account-menu/index.scss
@@ -12,6 +12,7 @@
   @media screen and (max-width: $break-small) {
     position: initial;
     margin-top: -10px;
+    margin-left: calc(((100vw - 100%) / 2) + 8px);
   }
 
   @media screen and (min-width: $break-large) {

--- a/ui/components/app/account-menu/index.scss
+++ b/ui/components/app/account-menu/index.scss
@@ -10,7 +10,8 @@
   color: var(--white);
 
   @media screen and (max-width: $break-small) {
-    right: calc(((100vw - 100%) / 2) + 8px);
+    position: initial;
+    margin-top: -10px;
   }
 
   @media screen and (min-width: $break-large) {


### PR DESCRIPTION
Fixes: #
10168

Explanation:  
When browser setting was set > 100% the bottom part of the accounts menu was cut off preventing users from clicking settings tab (I could only reproduce this on Chrome). 
I added a fix (for dropdown extension only) to remove the `position:fixed` part, so now users can scroll all the way down.

Manual testing steps:  
Tested on Chrome (full screen view + extension dropdown view). Created multiple accounts to extend that accounts list.
Tested on Firefox (full screen view + extension dropdown view). Created multiple accounts to extend that accounts list.

  Before (first screenshot is zoom 100% on Chrome and second zoom 125% where the bug happens):

 
<img width="513" alt="before_fix_1" src="https://user-images.githubusercontent.com/5368363/148988562-48abbaaa-c438-47de-80d8-6bd21e1df2b2.png">
<img width="620" alt="before_fix_2" src="https://user-images.githubusercontent.com/5368363/148988583-cf4ac957-53df-47af-b231-0c197f29b913.png">

After:

<img width="431" alt="after_1" src="https://user-images.githubusercontent.com/5368363/148988863-aa3dc5c4-4400-4327-a042-d37f6221a182.png">


<img width="585" alt="after_2" src="https://user-images.githubusercontent.com/5368363/148988890-92b3142f-f756-410d-8877-0687c9acc54b.png">

