### PR TITLE
Fix send duck standard setting bug in updateSendAsset

### DIFF
--- a/ui/ducks/send/send.js
+++ b/ui/ducks/send/send.js
@@ -1434,11 +1434,15 @@ export function updateSendAsset({ type, details }) {
         state.send.account.address ?? getSelectedAddress(state),
       );
       // TODO remove along with migration of isERC721 tokens and stripping away this designation
-      if (details && details.isERC721 === undefined) {
-        const updatedAssetDetails = await updateTokenType(details.address);
-        details.isERC721 = updatedAssetDetails.isERC721;
+      if (details) {
+        if (details.isERC721 === undefined) {
+          const updatedAssetDetails = await updateTokenType(details.address);
+          details.isERC721 = updatedAssetDetails.isERC721;
+        }
+        if (details.standard === undefined) {
+          details.standard = ERC20;
+        }
       }
-      details.standard = ERC20;
       await dispatch(hideLoadingIndication());
     } else if (type === ASSET_TYPES.COLLECTIBLE) {
       let isCurrentOwner = true;


### PR DESCRIPTION
Fixes: #13288

Explanation:  Fix bug where `updateSendAsset` errors when switching between send assets on the Send Token selection stage of the send flow.

Manual testing steps:  
  - Start a send flow.
  - On the select asset to send stage select an ERC20 token, then an ERC721 token and then back to an ERC20 token
  - you should no longer see an error.
