### PR TITLE
Remove unnecessary Yarn resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,6 @@
     "3box/**/libp2p-crypto/node-forge": "^0.10.0",
     "3box/**/libp2p-keychain/node-forge": "^0.10.0",
     "analytics-node/axios": "^0.21.2",
-    "analytics-node/axios/follow-redirects": "^1.14.7",
     "ganache-core/lodash": "^4.17.21",
     "netmask": "^2.0.1",
     "pubnub/superagent-proxy": "^3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13027,7 +13027,7 @@ fnv1a@^1.0.1:
   resolved "https://registry.yarnpkg.com/fnv1a/-/fnv1a-1.0.1.tgz#915e2d6d023c43d5224ad9f6d2a3c4156f5712f5"
   integrity sha1-kV4tbQI8Q9UiStn20qPEFW9XEvU=
 
-follow-redirects@^1.14.0, follow-redirects@^1.14.7:
+follow-redirects@^1.14.0:
   version "1.14.7"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.7.tgz#2004c02eb9436eee9a21446a6477debf17e81685"
   integrity sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ==


### PR DESCRIPTION
This resolution was used to force a transitive dependency to be updated to a specific version. But this target version was within the range that was already requested, so a resolution is not needed. Yarn resolutions are used for forcing a package to update to something _outside_ of the requested range. For in-range updates, a Yarn lockfile update is all we need, and it leaves us with less of a maintenance burden (the resolution can clobber future updates).