### PR TITLE
V10.9.0: Disconnect all accounts flow

### DIFF
--- a/ui/pages/connected-sites/connected-sites.container.js
+++ b/ui/pages/connected-sites/connected-sites.container.js
@@ -53,7 +53,7 @@ const mapDispatchToProps = (dispatch) => {
       dispatch(removePermittedAccount(subjectKey, address));
     },
     disconnectAllAccounts: (subjectKey, subject) => {
-      const permissionMethodNames = subject.permissions.map(
+      const permissionMethodNames = Object.values(subject.permissions).map(
         ({ parentCapability }) => parentCapability,
       );
       dispatch(


### PR DESCRIPTION
Manual testing steps:  

1. Navigate to the test dapp E2E Test Dapp
2. Click Connect
3. Click the Select all checkbox to select all your accounts then click Next
4. Click Connect
5. Open Metamask popup, Click the ellipsis to open the account options
6. Click Connected Sites, then click the Trash Can icon next to the Test Dapp
7. Click Disconnect all accounts

Issue:

- Uncaught TypeError: subject.permissions.map is not a function
- The account is still connected

Correct Behavior:

- Disconnect from the dapp
