### PR TITLE
V10.9.0: Mainnet should have a capital `M` in the import token warning message 

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -1641,7 +1641,7 @@
     "message": "Ethereum Mainnet"
   },
   "mainnetToken": {
-    "message": "This address matches a known Mainnet token address. Recheck the contract address and network for the token you are trying to add."
+    "message": "This address matches a known Ethereum Mainnet token address. Recheck the contract address and network for the token you are trying to add."
   },
   "makeAnotherSwap": {
     "message": "Create a new swap"

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -1641,7 +1641,7 @@
     "message": "Ethereum Mainnet"
   },
   "mainnetToken": {
-    "message": "This address matches a known mainnet token address. Recheck the contract address and network for the token you are trying to add."
+    "message": "This address matches a known Mainnet token address. Recheck the contract address and network for the token you are trying to add."
   },
   "makeAnotherSwap": {
     "message": "Create a new swap"


### PR DESCRIPTION
Manual testing steps:

1. Switch to a test network
2. Click Import tokens
3. Enter the Token Contract Address: 0x1f9840a85d5af5bf1d1762f925bdaddc4201f984

Issue:
This address matches a known mainnet token address. Recheck the contract address and network for the token you are trying to add.

Correct Message:
This address matches a known Mainnet token address. Recheck the contract address and network for the token you are trying to add.