### PR TITLE
Fix UI issues at top of confirm page container

### DIFF
--- a/ui/components/app/confirm-page-container/confirm-page-container-content/confirm-page-container-content.component.js
+++ b/ui/components/app/confirm-page-container/confirm-page-container-content/confirm-page-container-content.component.js
@@ -43,6 +43,7 @@ export default class ConfirmPageContainerContent extends Component {
     rejectNText: PropTypes.string,
     hideTitle: PropTypes.bool,
     supportsEIP1559V2: PropTypes.bool,
+    hasTopBorder: PropTypes.bool,
   };
 
   renderContent() {
@@ -111,6 +112,7 @@ export default class ConfirmPageContainerContent extends Component {
       setUserAcknowledgedGasMissing,
       hideUserAcknowledgedGasMissing,
       supportsEIP1559V2,
+      hasTopBorder,
     } = this.props;
 
     const primaryAction = hideUserAcknowledgedGasMissing
@@ -121,7 +123,11 @@ export default class ConfirmPageContainerContent extends Component {
         };
 
     return (
-      <div className="confirm-page-container-content">
+      <div
+        className={classnames('confirm-page-container-content', {
+          'confirm-page-container-content--with-top-border': hasTopBorder,
+        })}
+      >
         {warning ? <ConfirmPageContainerWarning warning={warning} /> : null}
         {ethGasPriceWarning && (
           <ConfirmPageContainerWarning warning={ethGasPriceWarning} />

--- a/ui/components/app/confirm-page-container/confirm-page-container-content/confirm-page-container-summary/index.scss
+++ b/ui/components/app/confirm-page-container/confirm-page-container-content/confirm-page-container-summary/index.scss
@@ -1,16 +1,18 @@
 .confirm-page-container-summary {
-  padding: 0 24px;
+  padding: 16px 24px;
   background-color: #f9fafa;
-  height: 120px;
   box-sizing: border-box;
   display: flex;
   flex-direction: column;
   justify-content: space-evenly;
 
+  &__origin,
+  &__action-row {
+    padding-bottom: 8px;
+  }
+
   &__origin {
     @include H6;
-
-    padding-bottom: 10px;
   }
 
   &__action-row {
@@ -34,7 +36,6 @@
   }
 
   &__title {
-    padding: 4px 0;
     display: flex;
     align-items: center;
   }
@@ -45,7 +46,7 @@
   }
 
   &__title-text {
-    @include H2;
+    @include H1;
 
     white-space: nowrap;
     overflow: hidden;
@@ -53,13 +54,12 @@
   }
 
   &__subtitle {
-    @include H6;
+    @include H5;
 
     color: var(--oslo-gray);
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
-    margin-left: 42px;
   }
 
   &--border {

--- a/ui/components/app/confirm-page-container/confirm-page-container-content/index.scss
+++ b/ui/components/app/confirm-page-container/confirm-page-container-content/index.scss
@@ -8,6 +8,10 @@
   display: flex;
   flex-direction: column;
 
+  &--with-top-border {
+    border-top: 1px solid var(--geyser);
+  }
+
   &__error-container {
     padding: 0 16px 16px 16px;
   }

--- a/ui/components/app/confirm-page-container/confirm-page-container.component.js
+++ b/ui/components/app/confirm-page-container/confirm-page-container.component.js
@@ -234,6 +234,7 @@ export default class ConfirmPageContainer extends Component {
               ethGasPriceWarning={ethGasPriceWarning}
               hideTitle={hideTitle}
               supportsEIP1559V2={supportsEIP1559V2}
+              hasTopBorder={Boolean(showAddToAddressDialog)}
             />
           )}
           {shouldDisplayWarning && (

--- a/ui/components/app/confirm-page-container/confirm-page-container.component.js
+++ b/ui/components/app/confirm-page-container/confirm-page-container.component.js
@@ -234,7 +234,7 @@ export default class ConfirmPageContainer extends Component {
               ethGasPriceWarning={ethGasPriceWarning}
               hideTitle={hideTitle}
               supportsEIP1559V2={supportsEIP1559V2}
-              hasTopBorder={Boolean(showAddToAddressDialog)}
+              hasTopBorder={showAddToAddressDialog}
             />
           )}
           {shouldDisplayWarning && (

--- a/ui/pages/confirm-transaction-base/confirm-transaction-base.component.js
+++ b/ui/pages/confirm-transaction-base/confirm-transaction-base.component.js
@@ -861,7 +861,7 @@ export default class ConfirmTransactionBase extends Component {
         value={hexTransactionAmount}
         type={PRIMARY}
         showEthLogo
-        ethLogoHeight="36"
+        ethLogoHeight="28"
         hideLabel
       />
     );


### PR DESCRIPTION
This commit fixes a few issues with ConfirmPageContainerSummary (which
holds the contract being used or action being performed and the money
being sent):

* Remove fixed height so that the secondary currency doesn't get cut off
  or spill over
* Add missing padding
* Fix font size of primary and secondary currencies
* Add top border when there is a "address not in your address book"
  alert at the top

---

These are fixes for the v10.9.0 RC as listed here: https://docs.google.com/document/d/1auTBM4tzXVglp_gHjRywDAXljayWq5xe3jBZqtZVO1c/edit

## Before

<img width="716" alt="confirm-tx-summary-squashed" src="https://user-images.githubusercontent.com/7371/149425038-e17af50c-8ea7-48b4-91e5-2c02b6cdb156.png">

<img width="568" alt="confirm-tx-summary-fiat-offset" src="https://user-images.githubusercontent.com/7371/149425050-a7565539-3c2e-4131-928c-76d13fa67c97.png">

https://user-images.githubusercontent.com/7371/149425065-676fa5ac-b23b-4a0a-9f36-d6be8e81c246.mov

## After

<img width="359" alt="Screen Shot 2022-01-13 at 4 19 39 PM" src="https://user-images.githubusercontent.com/7371/149425089-b762a77a-aa8c-4767-a407-d620fa1b4db3.png">

https://user-images.githubusercontent.com/7371/149425098-7385343c-99b6-4597-ac9a-5fdb6db83458.mov


