### PR TITLE
Fix issue with dapp suggested option being visible in edit gas fee popover even if dapp has no gas suggestion

### DIFF
--- a/ui/components/app/edit-gas-fee-popover/edit-gas-fee-popover.test.js
+++ b/ui/components/app/edit-gas-fee-popover/edit-gas-fee-popover.test.js
@@ -79,7 +79,7 @@ const render = ({ txProps, contextProps } = {}) => {
 
 describe('EditGasFeePopover', () => {
   it('should renders low / medium / high options', () => {
-    render({ txProps: { dappSuggestedGasFees: {} } });
+    render({ txProps: { dappSuggestedGasFees: { maxFeePerGas: '0x5208' } } });
 
     expect(screen.queryByText('🐢')).toBeInTheDocument();
     expect(screen.queryByText('🦊')).toBeInTheDocument();

--- a/ui/components/app/edit-gas-fee-popover/edit-gas-item/edit-gas-item.js
+++ b/ui/components/app/edit-gas-fee-popover/edit-gas-item/edit-gas-item.js
@@ -64,7 +64,8 @@ const EditGasItem = ({ priorityLevel }) => {
 
   if (
     priorityLevel === PRIORITY_LEVELS.DAPP_SUGGESTED &&
-    !dappSuggestedGasFees
+    !dappSuggestedGasFees?.maxFeePerGas &&
+    !dappSuggestedGasFees?.gasPrice
   ) {
     return null;
   }

--- a/ui/components/app/edit-gas-fee-popover/edit-gas-item/edit-gas-item.test.js
+++ b/ui/components/app/edit-gas-fee-popover/edit-gas-item/edit-gas-item.test.js
@@ -150,6 +150,23 @@ describe('EditGasItem', () => {
     expect(screen.queryByTitle('0.0000315 ETH')).toBeInTheDocument();
   });
 
+  it('should not renders site gas estimate option for priorityLevel dappSuggested if site does not provided gas estimates', () => {
+    renderComponent({
+      componentProps: { priorityLevel: 'dappSuggested' },
+      transactionProps: {},
+    });
+    expect(
+      screen.queryByRole('button', { name: 'dappSuggested' }),
+    ).not.toBeInTheDocument();
+    renderComponent({
+      componentProps: { priorityLevel: 'dappSuggested' },
+      transactionProps: { dappSuggestedGasFees: { gas: '0x59682f10' } },
+    });
+    expect(
+      screen.queryByRole('button', { name: 'dappSuggested' }),
+    ).not.toBeInTheDocument();
+  });
+
   it('should renders advance gas estimate option for priorityLevel custom', () => {
     renderComponent({
       componentProps: { priorityLevel: 'custom' },


### PR DESCRIPTION
Fixes: #13312

Explanation:  Dapp-Suggested option should not be visible in edit gas fee modal if dapp has not suggested any gas fee.

<img width="442" alt="Screenshot 2022-01-14 at 1 04 53 PM" src="https://user-images.githubusercontent.com/2182307/149469092-070b1af6-5be0-4f84-a669-5aff49b81d5d.png">
 
The option was hidden if there was no dapp suggestions, but I found scenario with uniswap where dapp is suggesting gasLimit but not price. Thus I have changed condition to check dapp suggested gas price to look for maxFeeParGas / gasPrice specifically.