### PR TITLE
Fix manually connecting sites

### DIFF
--- a/app/scripts/controllers/permissions/background-api.js
+++ b/app/scripts/controllers/permissions/background-api.js
@@ -1,3 +1,4 @@
+import nanoid from 'nanoid';
 import {
   CaveatTypes,
   RestrictedMethods,
@@ -59,11 +60,13 @@ export function getPermissionBackgroundApiMethods(permissionController) {
     },
 
     requestAccountsPermissionWithId: async (origin) => {
-      const [, { id }] = await permissionController.requestPermissions(
+      const id = nanoid();
+      permissionController.requestPermissions(
         { origin },
         {
           eth_accounts: {},
         },
+        { id },
       );
       return id;
     },

--- a/app/scripts/controllers/permissions/background-api.test.js
+++ b/app/scripts/controllers/permissions/background-api.test.js
@@ -160,9 +160,11 @@ describe('permission background API methods', () => {
   describe('requestAccountsPermissionWithId', () => {
     it('request an accounts permission and returns the request id', async () => {
       const permissionController = {
-        requestPermissions: jest.fn().mockImplementationOnce(async () => {
-          return [null, { id: 'arbitraryId' }];
-        }),
+        requestPermissions: jest
+          .fn()
+          .mockImplementationOnce(async (_, __, { id }) => {
+            return [null, { id }];
+          }),
       };
 
       const id = await getPermissionBackgroundApiMethods(
@@ -173,9 +175,13 @@ describe('permission background API methods', () => {
       expect(permissionController.requestPermissions).toHaveBeenCalledWith(
         { origin: 'foo.com' },
         { eth_accounts: {} },
+        { id: expect.any(String) },
       );
 
-      expect(id).toStrictEqual('arbitraryId');
+      expect(id.length > 0).toBe(true);
+      expect(id).toStrictEqual(
+        permissionController.requestPermissions.mock.calls[0][2].id,
+      );
     });
   });
 });


### PR DESCRIPTION
The manual site connection flow was broken due to an incorrectly implemented background API hook. This PR restores the manual site connection functionality.

To test manually, try connecting to an unconnected site manually via the UI.