### PR TITLE
Maintain leading whitespace in sig req window

### DIFF
--- a/ui/components/app/signature-request-original/index.scss
+++ b/ui/components/app/signature-request-original/index.scss
@@ -222,7 +222,7 @@
     overflow-wrap: break-word;
     border-bottom: 1px solid #d2d8dd;
     padding: 6px 18px 15px;
-    white-space: pre-line;
+    white-space: pre;
   }
 
   &__help-link {


### PR DESCRIPTION
Fixes: #13251

Explanation:  According to @danfinlay, the signature request window unintentionally trims leading whitespace for new lines. This is misleading for what is actually being signed (indented json).

Manual testing steps:  
  - Sign a message containing indentation, ensure whitespace is maintained