### PR TITLE
Update permission confirmation window title

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -2211,6 +2211,9 @@
   "permissionRequest": {
     "message": "Permission request"
   },
+  "permissionRequestCapitalized": {
+    "message": "Permission Request"
+  },
   "permission_accessNetwork": {
     "message": "Access the Internet.",
     "description": "The description of the `endowment:network-access` permission."

--- a/ui/components/app/permission-page-container/permission-page-container-content/permission-page-container-content.component.js
+++ b/ui/components/app/permission-page-container/permission-page-container-content/permission-page-container-content.component.js
@@ -71,11 +71,14 @@ export default class PermissionPageContainerContent extends PureComponent {
       subjectMetadata,
       selectedIdentities,
       allIdentitiesSelected,
+      selectedPermissions,
     } = this.props;
     const { t } = this.context;
 
     if (subjectMetadata.extensionId) {
       return t('externalExtension', [subjectMetadata.extensionId]);
+    } else if (!selectedPermissions.eth_accounts) {
+      return t('permissionRequestCapitalized');
     } else if (allIdentitiesSelected) {
       return t('connectToAll', [
         this.renderAccountTooltip(t('connectToAllAccounts')),


### PR DESCRIPTION
Adds a generic "Permission Request" title to the permission confirmation that's applied when `eth_accounts` is not requested. This does not address the case when both `eth_accounts` _and_ other permissions are requested, in which case we should arguably fall back to the generic title as well. Either way, this improves upon the status quo.