### PR TITLE
Update global link hover color from orange to blue (--Blue-400)

### DIFF
--- a/ui/css/base-styles.scss
+++ b/ui/css/base-styles.scss
@@ -52,10 +52,6 @@ html {
   color: #ffae00;
 }
 
-a.warning:hover {
-  color: var(--Orange-500);
-}
-
 /* stylelint-disable */
 #app-content {
   overflow-x: hidden;

--- a/ui/css/base-styles.scss
+++ b/ui/css/base-styles.scss
@@ -45,7 +45,6 @@ html {
 
 /*
   This warning class is used in the following files still:
-  /ui/pages/create-account/import-account/json.js
   /ui/pages/confirm-add-suggested-token/confirm-add-suggested-token.component.js
 */
 .warning {

--- a/ui/css/base-styles.scss
+++ b/ui/css/base-styles.scss
@@ -72,7 +72,7 @@ a {
 }
 
 a:hover {
-  color: #df6b0e;
+  color: var(--Blue-400);
 }
 
 input.large-input,

--- a/ui/css/base-styles.scss
+++ b/ui/css/base-styles.scss
@@ -52,6 +52,10 @@ html {
   color: #ffae00;
 }
 
+a.warning:hover {
+  color: var(--Orange-500);
+}
+
 /* stylelint-disable */
 #app-content {
   overflow-x: hidden;

--- a/ui/pages/create-account/import-account/index.scss
+++ b/ui/pages/create-account/import-account/index.scss
@@ -56,6 +56,10 @@
     margin-top: 34px;
   }
 
+  &__help-link {
+    color: var(--primary-blue);
+  }
+
   &__input-password {
     @include Paragraph;
 

--- a/ui/pages/create-account/import-account/json.js
+++ b/ui/pages/create-account/import-account/json.js
@@ -28,7 +28,7 @@ class JsonImportSubview extends Component {
       <div className="new-account-import-form__json">
         <p>{this.context.t('usedByClients')}</p>
         <a
-          className="warning"
+          className="new-account-import-form__help-link"
           href={HELP_LINK}
           target="_blank"
           rel="noopener noreferrer"


### PR DESCRIPTION
Fixes: https://github.com/MetaMask/metamask-extension/issues/13335

Explanation: Updates the global `a:hover` color from `#df6b0e` to `--Blue-400` (`#1098fc`). This deprecates `#df6b0e`. 

----
This affects one `a.warning` instance. We will remove the `.warning` class from this link instance and replace it with the `--primary-blue` color we use for other links. Please see George's comment below for more details about this decision: https://github.com/MetaMask/metamask-extension/pull/13344#pullrequestreview-856143632.

Manual testing steps:
  - Click on Profile Icon
  - Click on "Import Account"
  - Change "Select Type" option to "JSON File"
  - Hover over "File import not working? Click here!"
  - Observe hovered text

**Original (`#df6b0e`):**
![MM original](https://user-images.githubusercontent.com/20778143/150028031-b0538097-835c-4621-be6d-17552a4e34e4.gif)

**After applying `--Blue-400` (`#1098fc`) to the hover state:**
![MM Import Account hover on warning](https://user-images.githubusercontent.com/20778143/150028210-aa15bb35-8cd8-4d41-9414-751b292cd77e.gif)

**After removing the `.warning` class and setting the default state to `--primary-blue` (`#037dd6`):**
![MM use regular blue link](https://user-images.githubusercontent.com/20778143/150050899-b913ae87-628e-4545-84eb-ed61056e3592.gif)