### PR TITLE
Fixing warnings in unit test cases

### DIFF
--- a/ui/components/app/edit-gas-fee-popover/edit-gas-tooltip/edit-gas-tooltip.js
+++ b/ui/components/app/edit-gas-fee-popover/edit-gas-tooltip/edit-gas-tooltip.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import PropTypes from 'prop-types';
 import {
   EDIT_GAS_MODES,
@@ -24,7 +24,7 @@ const EditGasToolTip = ({
   transaction,
   t,
 }) => {
-  const toolTipMessage = () => {
+  const toolTipMessage = useMemo(() => {
     switch (priorityLevel) {
       case PRIORITY_LEVELS.LOW:
         return t('lowGasSettingToolTipMessage', [
@@ -76,7 +76,8 @@ const EditGasToolTip = ({
       default:
         return '';
     }
-  };
+  }, [editGasMode, estimateGreaterThanGasUse, priorityLevel, transaction, t]);
+
   return (
     <div className="edit-gas-tooltip__container">
       {priorityLevel !== PRIORITY_LEVELS.CUSTOM &&
@@ -97,9 +98,11 @@ const EditGasToolTip = ({
           </Typography>
         </div>
       ) : null}
-      <div className="edit-gas-tooltip__container__message">
-        <Typography variant={TYPOGRAPHY.H7}>{toolTipMessage()}</Typography>
-      </div>
+      {toolTipMessage && (
+        <div className="edit-gas-tooltip__container__message">
+          <Typography variant={TYPOGRAPHY.H7}>{toolTipMessage}</Typography>
+        </div>
+      )}
       {priorityLevel === PRIORITY_LEVELS.CUSTOM ||
       estimateGreaterThanGasUse ? null : (
         <div className="edit-gas-tooltip__container__values">
@@ -111,13 +114,15 @@ const EditGasToolTip = ({
             >
               {t('maxBaseFee')}
             </Typography>
-            <Typography
-              variant={TYPOGRAPHY.H7}
-              color={COLORS.NEUTRAL_GREY}
-              className="edit-gas-tooltip__container__value"
-            >
-              {maxFeePerGas}
-            </Typography>
+            {maxFeePerGas && (
+              <Typography
+                variant={TYPOGRAPHY.H7}
+                color={COLORS.NEUTRAL_GREY}
+                className="edit-gas-tooltip__container__value"
+              >
+                {maxFeePerGas}
+              </Typography>
+            )}
           </div>
           <div>
             <Typography
@@ -127,13 +132,15 @@ const EditGasToolTip = ({
             >
               {t('priorityFeeProperCase')}
             </Typography>
-            <Typography
-              variant={TYPOGRAPHY.H7}
-              color={COLORS.NEUTRAL_GREY}
-              className="edit-gas-tooltip__container__value"
-            >
-              {maxPriorityFeePerGas}
-            </Typography>
+            {maxPriorityFeePerGas && (
+              <Typography
+                variant={TYPOGRAPHY.H7}
+                color={COLORS.NEUTRAL_GREY}
+                className="edit-gas-tooltip__container__value"
+              >
+                {maxPriorityFeePerGas}
+              </Typography>
+            )}
           </div>
           <div>
             <Typography
@@ -143,13 +150,15 @@ const EditGasToolTip = ({
             >
               {t('gasLimit')}
             </Typography>
-            <Typography
-              variant={TYPOGRAPHY.H7}
-              color={COLORS.NEUTRAL_GREY}
-              className="edit-gas-tooltip__container__value"
-            >
-              {gasLimit}
-            </Typography>
+            {gasLimit && (
+              <Typography
+                variant={TYPOGRAPHY.H7}
+                color={COLORS.NEUTRAL_GREY}
+                className="edit-gas-tooltip__container__value"
+              >
+                {gasLimit}
+              </Typography>
+            )}
           </div>
         </div>
       )}

--- a/ui/components/app/edit-gas-fee-popover/network-statistics/latest-priority-fee-field/latest-priority-fee-field.js
+++ b/ui/components/app/edit-gas-fee-popover/network-statistics/latest-priority-fee-field/latest-priority-fee-field.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { uniq } from 'lodash';
 import { roundToDecimalPlacesRemovingExtraZeroes } from '../../../../../helpers/utils/util';
 import { useGasFeeContext } from '../../../../../contexts/gasFee';
@@ -8,7 +8,7 @@ import { PriorityFeeTooltip } from '../tooltips';
 export default function LatestPriorityFeeField() {
   const { gasFeeEstimates } = useGasFeeContext();
 
-  const renderPriorityFeeRange = () => {
+  const priorityFeeRange = useMemo(() => {
     const { latestPriorityFeeRange } = gasFeeEstimates;
     if (latestPriorityFeeRange) {
       const formattedRange = uniq([
@@ -18,12 +18,14 @@ export default function LatestPriorityFeeField() {
       return `${formattedRange} GWEI`;
     }
     return null;
-  };
+  }, [gasFeeEstimates]);
 
   return (
     <div className="network-statistics__info__field latest-priority-fee-field">
       <span className="network-statistics__info__field-data">
-        <PriorityFeeTooltip>{renderPriorityFeeRange()}</PriorityFeeTooltip>
+        {priorityFeeRange && (
+          <PriorityFeeTooltip>{priorityFeeRange}</PriorityFeeTooltip>
+        )}
       </span>
       <span className="network-statistics__info__field-label">
         <I18nValue messageKey="priorityFee" />

--- a/ui/components/app/edit-gas-fee-popover/network-statistics/network-statistics.js
+++ b/ui/components/app/edit-gas-fee-popover/network-statistics/network-statistics.js
@@ -30,13 +30,12 @@ const NetworkStatistics = () => {
       <div className="network-statistics__info">
         <div className="network-statistics__info__field">
           <span className="network-statistics__info__field-data">
-            <BaseFeeTooltip>
-              {gasFeeEstimates?.estimatedBaseFee &&
-                `${roundToDecimalPlacesRemovingExtraZeroes(
-                  gasFeeEstimates?.estimatedBaseFee,
-                  0,
-                )} GWEI`}
-            </BaseFeeTooltip>
+            {gasFeeEstimates?.estimatedBaseFee && (
+              <BaseFeeTooltip>{`${roundToDecimalPlacesRemovingExtraZeroes(
+                gasFeeEstimates?.estimatedBaseFee,
+                0,
+              )} GWEI`}</BaseFeeTooltip>
+            )}
           </span>
           <span className="network-statistics__info__field-label">
             <I18nValue messageKey="baseFee" />

--- a/ui/pages/swaps/fee-card/fee-card.js
+++ b/ui/pages/swaps/fee-card/fee-card.js
@@ -35,7 +35,7 @@ export default function FeeCard({
   onQuotesClick,
   chainId,
   isBestQuote,
-  supportsEIP1559V2,
+  supportsEIP1559V2 = false,
 }) {
   const t = useContext(I18nContext);
 
@@ -211,5 +211,5 @@ FeeCard.propTypes = {
   numberOfQuotes: PropTypes.number.isRequired,
   chainId: PropTypes.string.isRequired,
   isBestQuote: PropTypes.bool.isRequired,
-  supportsEIP1559V2: PropTypes.bool.isRequired,
+  supportsEIP1559V2: PropTypes.bool,
 };


### PR DESCRIPTION
I found there were couple of warnings while running unit test cases for `children` being a `required` property but getting no value. PR addresses those.