### PR TITLE
NFT UX cleanup grab-bag

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -243,6 +243,8 @@ export default class MetamaskController extends EventEmitter {
       initState.CollectiblesController,
     );
 
+    this.collectiblesController.setApiKey(process.env.OPENSEA_KEY);
+
     process.env.COLLECTIBLES_V1 &&
       (this.collectibleDetectionController = new CollectibleDetectionController(
         {

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -636,8 +636,7 @@ export default class MetamaskController extends EventEmitter {
             this.collectiblesController.checkAndUpdateSingleCollectibleOwnershipStatus(
               knownCollectible,
               false,
-              // TODO add this when checkAndUpdateSingleCollectibleOwnershipStatus is updated
-              // { userAddress, chainId },
+              { userAddress, chainId },
             );
           }
         }

--- a/ui/components/app/collectible-details/collectible-details.js
+++ b/ui/components/app/collectible-details/collectible-details.js
@@ -244,13 +244,13 @@ export default function CollectibleDetails({ collectible }) {
                 margin: 0,
                 marginBottom: 4,
               }}
-              overflowWrap={OVERFLOW_WRAP.BREAK_WORD}
+              className="collectible-details__image-link"
             >
               <a
                 target="_blank"
-                href={collectibleImageURL}
                 rel="noopener noreferrer"
-                className="collectible-details__image-link"
+                href={collectibleImageURL}
+                title={collectibleImageURL}
               >
                 {image}
               </a>
@@ -271,17 +271,18 @@ export default function CollectibleDetails({ collectible }) {
               {t('contractAddress')}
             </Typography>
             <Typography
-              color={COLORS.UI3}
+              color={COLORS.PRIMARY1}
               variant={TYPOGRAPHY.H6}
               overflowWrap={OVERFLOW_WRAP.BREAK_WORD}
               boxProps={{
                 margin: 0,
                 marginBottom: 4,
               }}
+              className="collectible-details__contract-link"
             >
               <a
                 target="_blank"
-                className="collectible-details__contract-link"
+                rel="noopener noreferrer"
                 href={getTokenTrackerLink(
                   address,
                   currentNetwork,
@@ -289,11 +290,9 @@ export default function CollectibleDetails({ collectible }) {
                   null,
                   rpcPrefs,
                 )}
-                rel="noopener noreferrer"
+                title={address}
               >
-                {getEnvironmentType() === ENVIRONMENT_TYPE_POPUP
-                  ? shortenAddress(address)
-                  : address}
+                {inPopUp ? shortenAddress(address) : address}
               </a>
             </Typography>
           </Box>

--- a/ui/components/app/collectible-details/collectible-details.js
+++ b/ui/components/app/collectible-details/collectible-details.js
@@ -185,37 +185,39 @@ export default function CollectibleDetails({ collectible }) {
                 color={COLORS.BLACK}
                 variant={TYPOGRAPHY.H4}
                 fontWeight={FONT_WEIGHT.BOLD}
-                boxProps={{ margin: 0, marginBottom: 4 }}
+                boxProps={{ margin: 0, marginBottom: 2 }}
               >
                 {name}
               </Typography>
               <Typography
                 color={COLORS.UI3}
                 variant={TYPOGRAPHY.H5}
-                boxProps={{ margin: 0 }}
+                boxProps={{ margin: 0, marginBottom: 4 }}
                 overflowWrap={OVERFLOW_WRAP.BREAK_WORD}
               >
                 #{tokenId}
               </Typography>
             </div>
-            <div>
-              <Typography
-                color={COLORS.BLACK}
-                variant={TYPOGRAPHY.H6}
-                fontWeight={FONT_WEIGHT.BOLD}
-                className="collectible-details__description"
-                boxProps={{ margin: 0, marginBottom: 2 }}
-              >
-                {t('description')}
-              </Typography>
-              <Typography
-                color={COLORS.UI4}
-                variant={TYPOGRAPHY.H6}
-                boxProps={{ margin: 0, marginBottom: 4 }}
-              >
-                {description}
-              </Typography>
-            </div>
+            {description ? (
+              <div>
+                <Typography
+                  color={COLORS.BLACK}
+                  variant={TYPOGRAPHY.H6}
+                  fontWeight={FONT_WEIGHT.BOLD}
+                  className="collectible-details__description"
+                  boxProps={{ margin: 0, marginBottom: 2 }}
+                >
+                  {t('description')}
+                </Typography>
+                <Typography
+                  color={COLORS.UI4}
+                  variant={TYPOGRAPHY.H6}
+                  boxProps={{ margin: 0, marginBottom: 4 }}
+                >
+                  {description}
+                </Typography>
+              </div>
+            ) : null}
             {inPopUp ? null : renderSendButton()}
           </Box>
         </div>

--- a/ui/components/app/collectible-details/collectible-details.js
+++ b/ui/components/app/collectible-details/collectible-details.js
@@ -130,6 +130,7 @@ export default function CollectibleDetails({ collectible }) {
       <Box
         display={DISPLAY.FLEX}
         width={inPopUp ? BLOCK_SIZES.FULL : BLOCK_SIZES.HALF}
+        margin={inPopUp ? [4, 0] : null}
       >
         <Button
           type="primary"

--- a/ui/components/app/collectible-details/index.scss
+++ b/ui/components/app/collectible-details/index.scss
@@ -55,13 +55,13 @@ $spacer-break-small: 16px;
 
   &__contract-link,
   &__image-link {
-    color: var(--primary-1);
-    overflow: hidden;
-    text-overflow: ellipsis;
     word-break: break-all;
 
-    &:hover {
-      color: var(--primary-3);
+    @media screen and (max-width: $break-small) {
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      width: 90%;
     }
   }
 

--- a/ui/components/app/collectibles-tab/collectibles-tab.js
+++ b/ui/components/app/collectibles-tab/collectibles-tab.js
@@ -117,6 +117,7 @@ export default function CollectiblesTab({ onAddNFT }) {
             marginBottom={12}
             justifyContent={JUSTIFY_CONTENT.CENTER}
             flexDirection={FLEX_DIRECTION.COLUMN}
+            className="collectibles-tab__link"
           >
             <Typography
               color={COLORS.UI3}
@@ -131,7 +132,6 @@ export default function CollectiblesTab({ onAddNFT }) {
               target="_blank"
               rel="noopener noreferrer"
               href="https://metamask.zendesk.com/hc/en-us/articles/360058238591-NFT-tokens-in-MetaMask-wallet"
-              style={{ padding: 0, fontSize: '1rem' }}
             >
               {t('learnMoreUpperCase')}
             </Button>
@@ -154,27 +154,31 @@ export default function CollectiblesTab({ onAddNFT }) {
           alignItems={ALIGN_ITEMS.CENTER}
           justifyContent={JUSTIFY_CONTENT.CENTER}
         >
-          <Box
-            className="collectibles-tab__link"
-            justifyContent={JUSTIFY_CONTENT.FLEX_END}
-          >
-            {isMainnet && !useCollectibleDetection ? (
-              <Button type="link" onClick={onEnableAutoDetect}>
-                {t('enableAutoDetect')}
-              </Button>
-            ) : (
-              <Button type="link" onClick={onRefresh}>
-                {t('refreshList')}
-              </Button>
-            )}
-          </Box>
-          <Typography
-            color={COLORS.UI3}
-            variant={TYPOGRAPHY.H4}
-            align={TEXT_ALIGN.CENTER}
-          >
-            {t('or')}
-          </Typography>
+          {!isMainnet && Object.keys(collections).length < 1 ? null : (
+            <>
+              <Box
+                className="collectibles-tab__link"
+                justifyContent={JUSTIFY_CONTENT.FLEX_END}
+              >
+                {isMainnet && !useCollectibleDetection ? (
+                  <Button type="link" onClick={onEnableAutoDetect}>
+                    {t('enableAutoDetect')}
+                  </Button>
+                ) : (
+                  <Button type="link" onClick={onRefresh}>
+                    {t('refreshList')}
+                  </Button>
+                )}
+              </Box>
+              <Typography
+                color={COLORS.UI3}
+                variant={TYPOGRAPHY.H6}
+                align={TEXT_ALIGN.CENTER}
+              >
+                {t('or')}
+              </Typography>
+            </>
+          )}
           <Box
             justifyContent={JUSTIFY_CONTENT.FLEX_START}
             className="collectibles-tab__link"

--- a/ui/components/app/collectibles-tab/index.scss
+++ b/ui/components/app/collectibles-tab/index.scss
@@ -2,7 +2,7 @@
   &__link {
     a {
       padding: 4px;
-      font-size: 1rem;
+      font-size: 0.875rem;
     }
   }
 }

--- a/ui/components/app/wallet-overview/token-overview.js
+++ b/ui/components/app/wallet-overview/token-overview.js
@@ -62,7 +62,7 @@ const TokenOverview = ({ className, token }) => {
   });
 
   useEffect(() => {
-    if (token.isERC721) {
+    if (token.isERC721 && process.env.COLLECTIBLES_V1) {
       dispatch(
         showModal({
           name: 'CONVERT_TOKEN_TO_NFT',

--- a/ui/components/app/wallet-overview/token-overview.test.js
+++ b/ui/components/app/wallet-overview/token-overview.test.js
@@ -54,6 +54,7 @@ describe('TokenOverview', () => {
     });
 
     it('should show ConvertTokenToNFT modal when token passed in props is an ERC721', () => {
+      process.env.COLLECTIBLES_V1 = true;
       const token = {
         name: 'test',
         isERC721: true,

--- a/ui/components/app/wallet-overview/token-overview.test.js
+++ b/ui/components/app/wallet-overview/token-overview.test.js
@@ -70,6 +70,7 @@ describe('TokenOverview', () => {
         name: 'CONVERT_TOKEN_TO_NFT',
         tokenAddress: '0x01',
       });
+      process.env.COLLECTIBLES_V1 = false;
     });
   });
 });

--- a/ui/css/itcss/components/send.scss
+++ b/ui/css/itcss/components/send.scss
@@ -684,6 +684,12 @@
       flex-grow: 1;
     }
 
+    @media screen and (max-width: $break-small) {
+      &__asset-data {
+        width: 60%;
+      }
+    }
+
     &__symbol {
       @include Paragraph;
 
@@ -691,7 +697,6 @@
       overflow: hidden;
       text-overflow: ellipsis;
       white-space: nowrap;
-      width: 90%;
     }
 
     &__name {

--- a/ui/css/itcss/components/send.scss
+++ b/ui/css/itcss/components/send.scss
@@ -203,12 +203,14 @@
   box-shadow: 2px 2px 2px var(--alto);
 }
 
-.customize-gas-tooltip-container input[type="number"]::-webkit-inner-spin-button {
+.customize-gas-tooltip-container
+  input[type='number']::-webkit-inner-spin-button {
   -webkit-appearance: none;
   display: none;
 }
 
-.customize-gas-tooltip-container input[type="number"]:hover::-webkit-inner-spin-button {
+.customize-gas-tooltip-container
+  input[type='number']:hover::-webkit-inner-spin-button {
   -webkit-appearance: none;
   display: none;
 }
@@ -688,6 +690,10 @@
       @include Paragraph;
 
       margin-bottom: 2px;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      width: 90%;
     }
 
     &__name {
@@ -1061,12 +1067,12 @@
       justify-content: center;
     }
 
-    input[type="number"]::-webkit-inner-spin-button {
+    input[type='number']::-webkit-inner-spin-button {
       -webkit-appearance: none;
       display: none;
     }
 
-    input[type="number"]:hover::-webkit-inner-spin-button {
+    input[type='number']:hover::-webkit-inner-spin-button {
       -webkit-appearance: none;
       display: none;
     }

--- a/ui/css/itcss/components/send.scss
+++ b/ui/css/itcss/components/send.scss
@@ -203,14 +203,12 @@
   box-shadow: 2px 2px 2px var(--alto);
 }
 
-.customize-gas-tooltip-container
-  input[type='number']::-webkit-inner-spin-button {
+.customize-gas-tooltip-container input[type='number']::-webkit-inner-spin-button {
   -webkit-appearance: none;
   display: none;
 }
 
-.customize-gas-tooltip-container
-  input[type='number']:hover::-webkit-inner-spin-button {
+.customize-gas-tooltip-container input[type='number']:hover::-webkit-inner-spin-button {
   -webkit-appearance: none;
   display: none;
 }

--- a/ui/ducks/send/send.js
+++ b/ui/ducks/send/send.js
@@ -1438,7 +1438,10 @@ export function updateSendAsset({ type, details }) {
             details.address,
             userAddress,
           );
-          if (standard === ERC721 || standard === ERC1155) {
+          if (
+            process.env.COLLECTIBLES_V1 &&
+            (standard === ERC721 || standard === ERC1155)
+          ) {
             await dispatch(hideLoadingIndication());
             dispatch(
               showModal({

--- a/ui/ducks/send/send.test.js
+++ b/ui/ducks/send/send.test.js
@@ -1553,6 +1553,7 @@ describe('Send Slice', () => {
           },
           type: 'UI_MODAL_OPEN',
         });
+        process.env.COLLECTIBLES_V1 = false;
       });
     });
 

--- a/ui/ducks/send/send.test.js
+++ b/ui/ducks/send/send.test.js
@@ -1524,6 +1524,7 @@ describe('Send Slice', () => {
       });
 
       it('should show ConvertTokenToNFT modal and throw "invalidAssetType" error when token passed in props is an ERC721 or ERC1155', async () => {
+        process.env.COLLECTIBLES_V1 = true;
         getTokenStandardAndDetailsStub.mockImplementation(() =>
           Promise.resolve({ standard: 'ERC1155' }),
         );

--- a/ui/store/actions.js
+++ b/ui/store/actions.js
@@ -2767,13 +2767,26 @@ export function loadingTokenParamsFinished() {
   };
 }
 
-export function getTokenParams(tokenAddress) {
+export function getTokenParams(address) {
   return (dispatch, getState) => {
     const tokenList = getTokenList(getState());
     const existingTokens = getState().metamask.tokens;
-    const existingToken = existingTokens.find(({ address }) =>
-      isEqualCaseInsensitive(tokenAddress, address),
+    const { selectedAddress } = getState().metamask;
+    const { chainId } = getState().metamask.provider;
+    const existingCollectibles = getState().metamask?.allCollectibles?.[
+      selectedAddress
+    ]?.[chainId];
+    const existingToken = existingTokens.find(({ address: tokenAddress }) =>
+      isEqualCaseInsensitive(address, tokenAddress),
     );
+    const existingCollectible = existingCollectibles?.find(
+      ({ address: collectibleAddress }) =>
+        isEqualCaseInsensitive(address, collectibleAddress),
+    );
+
+    if (existingCollectible) {
+      return null;
+    }
 
     if (existingToken) {
       return Promise.resolve({
@@ -2785,9 +2798,9 @@ export function getTokenParams(tokenAddress) {
     dispatch(loadingTokenParamsStarted());
     log.debug(`loadingTokenParams`);
 
-    return getSymbolAndDecimals(tokenAddress, tokenList).then(
+    return getSymbolAndDecimals(address, tokenList).then(
       ({ symbol, decimals }) => {
-        dispatch(addToken(tokenAddress, symbol, Number(decimals)));
+        dispatch(addToken(address, symbol, Number(decimals)));
         dispatch(loadingTokenParamsFinished());
       },
     );


### PR DESCRIPTION
Some small UX cleanups for all the recently added NFT functionality:
1. Fonts in the NFT tab: ([figma](https://www.figma.com/file/8Xe22jEPgcElS5tWPw8AGM/NFTs-in-extension-(MVP)?node-id=772%3A9744))
Before:
![Screen Shot 2022-01-19 at 11 49 00 AM](https://user-images.githubusercontent.com/34557516/150186038-6edeebb7-b385-4557-b651-055840322ebd.png)
After:
![Screen Shot 2022-01-19 at 11 54 43 AM](https://user-images.githubusercontent.com/34557516/150187038-bfa230ea-6b7a-4f36-8589-da644471028d.png)


2. `Refresh list` button should not be present on networks that are not mainnet when no NFT's are present:
Before:
![Screen Shot 2022-01-19 at 11 50 06 AM](https://user-images.githubusercontent.com/34557516/150186289-a48de8cb-1320-46e3-9286-7a6d02b5b9e1.png)
After: (no refresh button on non-mainnet network)
![Screen Shot 2022-01-19 at 11 56 48 AM](https://user-images.githubusercontent.com/34557516/150187132-1530283e-af7d-4310-bd19-6d84f9a1ef28.png)


3. [Enables](https://github.com/MetaMask/metamask-extension/pull/13352/files#diff-6fbff2cfe97ac01b77296ef2122c7e0a5b3ff6a84b584b4d1a87482f35eea3d6R639) correct CollectiblesController state updates when collectibles are sent in app and user changes accounts or networks before transaction is confirmed. Without the change linked, the CollectibelsController will attempt to update the sent collectibles' ownership status for the account/chainId that the user is on, rather than the one from which it was sent.

4. Prevents NFTs from being added to TokensController state when interacting with an NFT contract. Before the change [here](https://github.com/MetaMask/metamask-extension/pull/13352/files#diff-3c58b916cefff81e4927a9afd392acadbf4515f99f41783964a9851b7774791bR2782), this can happen as a a by product [here](https://github.com/MetaMask/metamask-extension/blob/af848dec9b50e5a23ae8190223fe8390f211a30e/ui/store/actions.js#L2790). I have a [larger refactor](https://github.com/MetaMask/metamask-extension/pull/13131) in the works to fix this long standing issue more thoroughly.

5. Puts NFT related features added [here](https://github.com/MetaMask/metamask-extension/pull/13291) behind feature flags.
6. Fixes spacing and removes empty description from collectible-details page:
before:
![Screen Shot 2022-01-19 at 2 19 16 PM](https://user-images.githubusercontent.com/34557516/150207623-59ae2a5e-f91a-49ee-ad7e-3a7bf30394bc.png)
after:
![Screen Shot 2022-01-19 at 2 17 20 PM](https://user-images.githubusercontent.com/34557516/150207640-68fa8306-0762-473e-a8e7-aa0511821659.png)

7. Fixes overflowing text of collectible in send flow:
before:
![Screen Shot 2022-01-19 at 2 16 43 PM](https://user-images.githubusercontent.com/34557516/150207707-471739f7-aade-41dc-b12e-4113d8e5a7a5.png)
after: 
![Screen Shot 2022-01-19 at 4 28 03 PM](https://user-images.githubusercontent.com/34557516/150227905-b42803ec-3796-474d-bdc2-ef2219fb4c20.png)

8. Adds margin to the send button on the collectible-details page in a pop-up context:
before:
![Screen Shot 2022-01-19 at 5 17 10 PM](https://user-images.githubusercontent.com/34557516/150233733-72745d56-cbe4-471f-b96a-7b7f0557b3fe.png)

after:
![Screen Shot 2022-01-19 at 5 13 18 PM](https://user-images.githubusercontent.com/34557516/150233592-d9a6b524-f1bc-40c9-959c-664baadfe7ad.png)

9. Adds method call to set OpenSea API key on the CollectiblesController 

10. Truncates image source URL in popup (but not in full screen), and adds a title so that full url is viewable on hover.
before:
![Screen Shot 2022-01-19 at 5 14 45 PM](https://user-images.githubusercontent.com/34557516/150377794-2180fe20-dbe0-438f-95c0-3bed2fb9436c.png)

after:
![Screen Shot 2022-01-20 at 10 26 35 AM](https://user-images.githubusercontent.com/34557516/150379959-daf4b296-ac57-410d-8009-fb84ae535f43.png)

