### PR TITLE
Convert ConfirmAddSuggestedToken to a functional component + cleanup

### DIFF
--- a/ui/pages/confirm-add-suggested-token/confirm-add-suggested-token.component.js
+++ b/ui/pages/confirm-add-suggested-token/confirm-add-suggested-token.component.js
@@ -67,11 +67,7 @@ export default function ConfirmAddSuggestedToken(props) {
     return dupes.length > 0;
   }
 
-  function getTokenName(name, symbol) {
-    return typeof name === 'undefined' ? symbol : `${name} (${symbol})`;
-  }
-
-  function _checksuggestedAssets() {
+  function checkSuggestedAssets() {
     if (suggestedAssets.length > 0) {
       return;
     }
@@ -79,8 +75,12 @@ export default function ConfirmAddSuggestedToken(props) {
     history.push(mostRecentOverviewPage);
   }
 
+  function getTokenName(name, symbol) {
+    return typeof name === 'undefined' ? symbol : `${name} (${symbol})`;
+  }
+
   useEffect(() => {
-    _checksuggestedAssets();
+    checkSuggestedAssets();
   });
 
   return (

--- a/ui/pages/confirm-add-suggested-token/confirm-add-suggested-token.component.js
+++ b/ui/pages/confirm-add-suggested-token/confirm-add-suggested-token.component.js
@@ -1,40 +1,24 @@
-import React, { Component } from 'react';
+import React, { useContext, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import Button from '../../components/ui/button';
 import Identicon from '../../components/ui/identicon';
 import TokenBalance from '../../components/ui/token-balance';
+import { I18nContext } from '../../contexts/i18n';
 import { isEqualCaseInsensitive } from '../../helpers/utils/util';
 
-export default class ConfirmAddSuggestedToken extends Component {
-  static contextTypes = {
-    t: PropTypes.func,
-    trackEvent: PropTypes.func,
-  };
+export default function ConfirmAddSuggestedToken(props) {
+  const {
+    history,
+    acceptWatchAsset,
+    rejectWatchAsset,
+    mostRecentOverviewPage,
+    suggestedAssets,
+    tokens,
+  } = props;
 
-  static propTypes = {
-    history: PropTypes.object,
-    acceptWatchAsset: PropTypes.func,
-    rejectWatchAsset: PropTypes.func,
-    mostRecentOverviewPage: PropTypes.string.isRequired,
-    suggestedAssets: PropTypes.array,
-    tokens: PropTypes.array,
-  };
+  const t = useContext(I18nContext);
 
-  componentDidMount() {
-    this._checksuggestedAssets();
-  }
-
-  componentDidUpdate() {
-    this._checksuggestedAssets();
-  }
-
-  _checksuggestedAssets() {
-    const {
-      mostRecentOverviewPage,
-      suggestedAssets = [],
-      history,
-    } = this.props;
-
+  function _checksuggestedAssets() {
     if (suggestedAssets.length > 0) {
       return;
     }
@@ -42,130 +26,115 @@ export default class ConfirmAddSuggestedToken extends Component {
     history.push(mostRecentOverviewPage);
   }
 
-  getTokenName(name, symbol) {
+  useEffect(() => {
+    _checksuggestedAssets();
+  });
+
+  function getTokenName(name, symbol) {
     return typeof name === 'undefined' ? symbol : `${name} (${symbol})`;
   }
 
-  render() {
-    const {
-      suggestedAssets,
-      tokens,
-      rejectWatchAsset,
-      history,
-      mostRecentOverviewPage,
-      acceptWatchAsset,
-    } = this.props;
+  const hasTokenDuplicates = checkTokenDuplicates(suggestedAssets, tokens);
+  const reusesName = checkNameReuse(suggestedAssets, tokens);
 
-    const hasTokenDuplicates = this.checkTokenDuplicates(
-      suggestedAssets,
-      tokens,
-    );
-    const reusesName = this.checkNameReuse(suggestedAssets, tokens);
-
-    return (
-      <div className="page-container">
-        <div className="page-container__header">
-          <div className="page-container__title">
-            {this.context.t('addSuggestedTokens')}
-          </div>
-          <div className="page-container__subtitle">
-            {this.context.t('likeToImportTokens')}
-          </div>
-          {hasTokenDuplicates ? (
-            <div className="warning">{this.context.t('knownTokenWarning')}</div>
-          ) : null}
-          {reusesName ? (
-            <div className="warning">
-              {this.context.t('reusedTokenNameWarning')}
-            </div>
-          ) : null}
+  return (
+    <div className="page-container">
+      <div className="page-container__header">
+        <div className="page-container__title">{t('addSuggestedTokens')}</div>
+        <div className="page-container__subtitle">
+          {t('likeToImportTokens')}
         </div>
-        <div className="page-container__content">
-          <div className="confirm-import-token">
-            <div className="confirm-import-token__header">
-              <div className="confirm-import-token__token">
-                {this.context.t('token')}
-              </div>
-              <div className="confirm-import-token__balance">
-                {this.context.t('balance')}
-              </div>
-            </div>
-            <div className="confirm-import-token__token-list">
-              {suggestedAssets.map(({ asset }) => {
-                return (
-                  <div
-                    className="confirm-import-token__token-list-item"
-                    key={asset.address}
-                  >
-                    <div className="confirm-import-token__token confirm-import-token__data">
-                      <Identicon
-                        className="confirm-import-token__token-icon"
-                        diameter={48}
-                        address={asset.address}
-                        image={asset.image}
-                      />
-                      <div className="confirm-import-token__name">
-                        {this.getTokenName(asset.name, asset.symbol)}
-                      </div>
-                    </div>
-                    <div className="confirm-import-token__balance">
-                      <TokenBalance token={asset} />
+        {hasTokenDuplicates ? (
+          <div className="warning">{t('knownTokenWarning')}</div>
+        ) : null}
+        {reusesName ? (
+          <div className="warning">{t('reusedTokenNameWarning')}</div>
+        ) : null}
+      </div>
+      <div className="page-container__content">
+        <div className="confirm-import-token">
+          <div className="confirm-import-token__header">
+            <div className="confirm-import-token__token">{t('token')}</div>
+            <div className="confirm-import-token__balance">{t('balance')}</div>
+          </div>
+          <div className="confirm-import-token__token-list">
+            {suggestedAssets.map(({ asset }) => {
+              return (
+                <div
+                  className="confirm-import-token__token-list-item"
+                  key={asset.address}
+                >
+                  <div className="confirm-import-token__token confirm-import-token__data">
+                    <Identicon
+                      className="confirm-import-token__token-icon"
+                      diameter={48}
+                      address={asset.address}
+                      image={asset.image}
+                    />
+                    <div className="confirm-import-token__name">
+                      {getTokenName(asset.name, asset.symbol)}
                     </div>
                   </div>
-                );
-              })}
-            </div>
+                  <div className="confirm-import-token__balance">
+                    <TokenBalance token={asset} />
+                  </div>
+                </div>
+              );
+            })}
           </div>
         </div>
-        <div className="page-container__footer">
-          <footer>
-            <Button
-              type="secondary"
-              large
-              className="page-container__footer-button"
-              onClick={async () => {
-                await Promise.all(
-                  suggestedAssets.map(async ({ id }) => rejectWatchAsset(id)),
-                );
-                history.push(mostRecentOverviewPage);
-              }}
-            >
-              {this.context.t('cancel')}
-            </Button>
-            <Button
-              type="primary"
-              large
-              className="page-container__footer-button"
-              disabled={suggestedAssets.length === 0}
-              onClick={async () => {
-                await Promise.all(
-                  suggestedAssets.map(async ({ asset, id }) => {
-                    await acceptWatchAsset(id);
-                    this.context.trackEvent({
-                      event: 'Token Added',
-                      category: 'Wallet',
-                      sensitiveProperties: {
-                        token_symbol: asset.symbol,
-                        token_contract_address: asset.address,
-                        token_decimal_precision: asset.decimals,
-                        unlisted: asset.unlisted,
-                        source: 'dapp',
-                      },
-                    });
-                  }),
-                );
-                history.push(mostRecentOverviewPage);
-              }}
-            >
-              {this.context.t('addToken')}
-            </Button>
-          </footer>
-        </div>
       </div>
-    );
-  }
+      <div className="page-container__footer">
+        <footer>
+          <Button
+            type="secondary"
+            large
+            className="page-container__footer-button"
+            onClick={async () => {
+              await Promise.all(
+                suggestedAssets.map(async ({ id }) => rejectWatchAsset(id)),
+              );
+              history.push(mostRecentOverviewPage);
+            }}
+          >
+            {t('cancel')}
+          </Button>
+          <Button
+            type="primary"
+            large
+            className="page-container__footer-button"
+            disabled={suggestedAssets.length === 0}
+            onClick={async () => {
+              await Promise.all(
+                suggestedAssets.map(async ({ /* asset ,*/ id }) => {
+                  await acceptWatchAsset(id);
 
-  checkTokenDuplicates(suggestedAssets, tokens) {
+                  /** @todo restore with up-to-date metric tracking before merging PR */
+
+                  // this.context.trackEvent({
+                  //   event: 'Token Added',
+                  //   category: 'Wallet',
+                  //   sensitiveProperties: {
+                  //     token_symbol: asset.symbol,
+                  //     token_contract_address: asset.address,
+                  //     token_decimal_precision: asset.decimals,
+                  //     unlisted: asset.unlisted,
+                  //     source: 'dapp',
+                  //   },
+                  // });
+                }),
+              );
+              history.push(mostRecentOverviewPage);
+            }}
+          >
+            {t('addToken')}
+          </Button>
+        </footer>
+      </div>
+    </div>
+  );
+
+  function checkTokenDuplicates() {
     const pending = suggestedAssets.map(({ asset }) =>
       asset.address.toUpperCase(),
     );
@@ -178,15 +147,16 @@ export default class ConfirmAddSuggestedToken extends Component {
   }
 
   /**
+   * @FIXME only keeping these functions below the return method to keep commit cleaner.
+   * Fixing in next commit.
+   */
+  /**
    * Returns true if any suggestedAssets both:
    * - Share a symbol with an existing `tokens` member.
    * - Does not share an address with that same `tokens` member.
    * This should be flagged as possibly deceptive or confusing.
-   *
-   * @param suggestedAssets
-   * @param tokens
    */
-  checkNameReuse(suggestedAssets, tokens) {
+  function checkNameReuse() {
     const duplicates = suggestedAssets.filter(({ asset }) => {
       const dupes = tokens.filter(
         (old) =>
@@ -198,3 +168,12 @@ export default class ConfirmAddSuggestedToken extends Component {
     return duplicates.length > 0;
   }
 }
+
+ConfirmAddSuggestedToken.propTypes = {
+  history: PropTypes.object,
+  acceptWatchAsset: PropTypes.func,
+  rejectWatchAsset: PropTypes.func,
+  mostRecentOverviewPage: PropTypes.string.isRequired,
+  suggestedAssets: PropTypes.array,
+  tokens: PropTypes.array,
+};

--- a/ui/pages/confirm-add-suggested-token/confirm-add-suggested-token.component.js
+++ b/ui/pages/confirm-add-suggested-token/confirm-add-suggested-token.component.js
@@ -9,12 +9,12 @@ import { isEqualCaseInsensitive } from '../../helpers/utils/util';
 
 export default function ConfirmAddSuggestedToken(props) {
   const {
-    suggestedAssets,
-    tokens,
-    rejectWatchAsset,
+    acceptWatchAsset,
     history,
     mostRecentOverviewPage,
-    acceptWatchAsset,
+    rejectWatchAsset,
+    suggestedAssets,
+    tokens,
   } = props;
 
   const metricsEvent = useContext(MetaMetricsContext);
@@ -163,10 +163,10 @@ export default function ConfirmAddSuggestedToken(props) {
 }
 
 ConfirmAddSuggestedToken.propTypes = {
-  history: PropTypes.object,
   acceptWatchAsset: PropTypes.func,
-  rejectWatchAsset: PropTypes.func,
+  history: PropTypes.object,
   mostRecentOverviewPage: PropTypes.string.isRequired,
+  rejectWatchAsset: PropTypes.func,
   suggestedAssets: PropTypes.array,
   tokens: PropTypes.array,
 };

--- a/ui/pages/confirm-add-suggested-token/confirm-add-suggested-token.component.js
+++ b/ui/pages/confirm-add-suggested-token/confirm-add-suggested-token.component.js
@@ -67,21 +67,15 @@ export default function ConfirmAddSuggestedToken(props) {
     return dupes.length > 0;
   }
 
-  function checkSuggestedAssets() {
-    if (suggestedAssets.length > 0) {
-      return;
-    }
-
-    history.push(mostRecentOverviewPage);
-  }
-
   function getTokenName(name, symbol) {
     return typeof name === 'undefined' ? symbol : `${name} (${symbol})`;
   }
 
   useEffect(() => {
-    checkSuggestedAssets();
-  });
+    if (!suggestedAssets.length) {
+      history.push(mostRecentOverviewPage);
+    }
+  }, [history, suggestedAssets, mostRecentOverviewPage]);
 
   return (
     <div className="page-container">

--- a/ui/pages/confirm-add-suggested-token/confirm-add-suggested-token.component.js
+++ b/ui/pages/confirm-add-suggested-token/confirm-add-suggested-token.component.js
@@ -10,7 +10,7 @@ import { isEqualCaseInsensitive } from '../../helpers/utils/util';
 function getTokenName(name, symbol) {
   return typeof name === 'undefined' ? symbol : `${name} (${symbol})`;
 }
-export default function ConfirmAddSuggestedToken(props) {
+const ConfirmAddSuggestedToken = (props) => {
   const {
     acceptWatchAsset,
     history,
@@ -159,7 +159,7 @@ export default function ConfirmAddSuggestedToken(props) {
       </div>
     </div>
   );
-}
+};
 
 ConfirmAddSuggestedToken.propTypes = {
   acceptWatchAsset: PropTypes.func,
@@ -169,3 +169,5 @@ ConfirmAddSuggestedToken.propTypes = {
   suggestedAssets: PropTypes.array,
   tokens: PropTypes.array,
 };
+
+export default ConfirmAddSuggestedToken;

--- a/ui/pages/confirm-add-suggested-token/confirm-add-suggested-token.component.js
+++ b/ui/pages/confirm-add-suggested-token/confirm-add-suggested-token.component.js
@@ -7,6 +7,9 @@ import { I18nContext } from '../../contexts/i18n';
 import { MetaMetricsContext } from '../../contexts/metametrics';
 import { isEqualCaseInsensitive } from '../../helpers/utils/util';
 
+function getTokenName(name, symbol) {
+  return typeof name === 'undefined' ? symbol : `${name} (${symbol})`;
+}
 export default function ConfirmAddSuggestedToken(props) {
   const {
     acceptWatchAsset,
@@ -19,9 +22,6 @@ export default function ConfirmAddSuggestedToken(props) {
 
   const metricsEvent = useContext(MetaMetricsContext);
   const t = useContext(I18nContext);
-
-  const hasTokenDuplicates = checkTokenDuplicates(suggestedAssets, tokens);
-  const reusesName = checkNameReuse(suggestedAssets, tokens);
 
   const tokenAddedEvent = (asset) => {
     metricsEvent({
@@ -43,7 +43,7 @@ export default function ConfirmAddSuggestedToken(props) {
    * - Does not share an address with that same `tokens` member.
    * This should be flagged as possibly deceptive or confusing.
    */
-  function checkNameReuse() {
+  const checkNameReuse = () => {
     const duplicates = suggestedAssets.filter(({ asset }) => {
       const dupes = tokens.filter(
         (old) =>
@@ -53,9 +53,9 @@ export default function ConfirmAddSuggestedToken(props) {
       return dupes.length > 0;
     });
     return duplicates.length > 0;
-  }
+  };
 
-  function checkTokenDuplicates() {
+  const checkTokenDuplicates = () => {
     const pending = suggestedAssets.map(({ asset }) =>
       asset.address.toUpperCase(),
     );
@@ -65,11 +65,10 @@ export default function ConfirmAddSuggestedToken(props) {
     });
 
     return dupes.length > 0;
-  }
+  };
 
-  function getTokenName(name, symbol) {
-    return typeof name === 'undefined' ? symbol : `${name} (${symbol})`;
-  }
+  const hasTokenDuplicates = checkTokenDuplicates();
+  const reusesName = checkNameReuse();
 
   useEffect(() => {
     if (!suggestedAssets.length) {


### PR DESCRIPTION
**Fixes:** n/a
This is cleanup before fixing https://github.com/MetaMask/metamask-extension/issues/13347

Follow-up PR: https://github.com/MetaMask/metamask-extension/pull/13402

**Explanation:**  
Convert ConfirmAddSuggestedToken component to functional component. I did a slight cleanup, but I didn't want to do too much to mitigate risk.

**For reviewers:**
I think it might be easier to walk through each commit and hide whitespace changes in the first commit. Please feel free to suggest more updates! 

The `checkTokenDuplicates` and `checkNameReuse` logic will be updated in a a follow-up PR to fix: https://github.com/MetaMask/metamask-extension/issues/13347

**Manual testing steps (For EtherScan. Can replicate on another platform e.g. CoinGecko):**  
  - View an ERC20 token on EtherScan ([example](https://etherscan.io/token/0xdac17f958d2ee523a2206206994597c13d831ec7))
  - Click on the "More" dropdown in "Profile Summary"
  - Click on "Add Token to MetaMask (Web3)"
  - Test "Add Suggested Token" modal works as expected