### PR TITLE
fixbug: adding network overwrite the existed network

### DIFF
--- a/ui/pages/settings/networks-tab/networks-form/networks-form.js
+++ b/ui/pages/settings/networks-tab/networks-form/networks-form.js
@@ -186,7 +186,7 @@ const NetworksForm = ({
     // Do not factor in duplicate chain id error for submission disabling
     return (
       (Boolean(chainIdError?.key) &&
-        chainIdError.key === 'chainIdExistsErrorMsg') ||
+        chainIdError.key !== 'chainIdExistsErrorMsg') ||
       Boolean(blockExplorerUrlError?.key) ||
       Boolean(rpcUrlError?.key)
     );

--- a/ui/pages/settings/networks-tab/networks-form/networks-form.test.js
+++ b/ui/pages/settings/networks-tab/networks-form/networks-form.test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import configureMockStore from 'redux-mock-store';
 import { fireEvent } from '@testing-library/react';
+import { tick } from '../../../../../test/lib/tick';
 import { renderWithProvider } from '../../../../../test/jest/rendering';
 import { defaultNetworksData } from '../networks-tab.constants';
 import NetworksForm from '.';
@@ -107,5 +108,51 @@ describe('NetworkForm Component', () => {
     expect(
       queryByText('URLs require the appropriate HTTP/HTTPS prefix.'),
     ).toBeInTheDocument();
+  });
+
+  it('should button Save in the correct state', async () => {
+    const { queryByText, getByLabelText } = renderComponent(propNewNetwork);
+    const saveButton = queryByText('Save');
+    const networkNameText = getByLabelText('Network Name');
+    const rpcUrlText = getByLabelText('New RPC URL');
+    const chainIdText = getByLabelText('Chain ID');
+
+    expect(queryByText('Save')).toBeDisabled();
+    fireEvent.change(networkNameText, {
+      target: { value: 'TEST' },
+    });
+    expect(saveButton).toBeDisabled();
+    fireEvent.change(rpcUrlText, {
+      target: {
+        value: 'https://mainnet.infura.io/v3/undefined',
+      },
+    });
+    expect(saveButton).toBeDisabled();
+    expect(
+      queryByText('This URL is currently used by the mainnet network.'),
+    ).toBeInTheDocument();
+    fireEvent.change(chainIdText, {
+      target: { value: '1' },
+    });
+    expect(saveButton).toBeDisabled();
+    fireEvent.change(rpcUrlText, {
+      target: {
+        value: 'https://mainnet.infura.io/v3/fake',
+      },
+    });
+    expect(saveButton).toBeEnabled();
+
+    fireEvent.click(saveButton);
+    await tick();
+
+    expect(
+      queryByText('Could not fetch chain ID. Is your RPC URL correct?'),
+    ).toBeInTheDocument();
+    fireEvent.change(rpcUrlText, {
+      target: {
+        value: 'https://mainnet.infura.io/v3/undefined',
+      },
+    });
+    expect(saveButton).toBeDisabled();
   });
 });

--- a/ui/pages/settings/networks-tab/networks-form/networks-form.test.js
+++ b/ui/pages/settings/networks-tab/networks-form/networks-form.test.js
@@ -110,18 +110,48 @@ describe('NetworkForm Component', () => {
     ).toBeInTheDocument();
   });
 
-  it('should button Save in the correct state', async () => {
+  it('should render "Save" button in the correct state when adding new network', async () => {
     const { queryByText, getByLabelText } = renderComponent(propNewNetwork);
     const saveButton = queryByText('Save');
     const networkNameText = getByLabelText('Network Name');
     const rpcUrlText = getByLabelText('New RPC URL');
     const chainIdText = getByLabelText('Chain ID');
 
+    // At beginning RPC URL and Chain ID are empty
     expect(queryByText('Save')).toBeDisabled();
+
+    // Add Binance Smart Chain Mainnet
+    fireEvent.change(networkNameText, {
+      target: { value: 'Binance Smart Chain Mainnet' },
+    });
+    fireEvent.change(rpcUrlText, {
+      target: {
+        value: 'https://bsc-dataseed1.ninicoin.io',
+      },
+    });
+    fireEvent.change(chainIdText, {
+      target: { value: '56' },
+    });
+
+    expect(saveButton).toBeEnabled();
+  });
+
+  it('should render "Save" button in the correct state when adding existed network', async () => {
+    const { queryByText, getByLabelText } = renderComponent(propNewNetwork);
+    const saveButton = queryByText('Save');
+    const networkNameText = getByLabelText('Network Name');
+    const rpcUrlText = getByLabelText('New RPC URL');
+    const chainIdText = getByLabelText('Chain ID');
+
+    // At beginning RPC URL and Chain ID are empty
+    expect(queryByText('Save')).toBeDisabled();
+
     fireEvent.change(networkNameText, {
       target: { value: 'TEST' },
     });
     expect(saveButton).toBeDisabled();
+
+    // input RPC URL, the same as mainnet network
     fireEvent.change(rpcUrlText, {
       target: {
         value: 'https://mainnet.infura.io/v3/undefined',
@@ -131,23 +161,32 @@ describe('NetworkForm Component', () => {
     expect(
       queryByText('This URL is currently used by the mainnet network.'),
     ).toBeInTheDocument();
+
+    // input Chain ID, the same as mainnet network
     fireEvent.change(chainIdText, {
       target: { value: '1' },
     });
     expect(saveButton).toBeDisabled();
+
+    // input different RPC URL
     fireEvent.change(rpcUrlText, {
       target: {
         value: 'https://mainnet.infura.io/v3/fake',
       },
     });
+
+    // different RPC URL and same Chain ID are allowed to be commited
     expect(saveButton).toBeEnabled();
 
     fireEvent.click(saveButton);
     await tick();
 
+    // the RPC URL is invalid, so could not fetch Chain ID
     expect(
       queryByText('Could not fetch chain ID. Is your RPC URL correct?'),
     ).toBeInTheDocument();
+
+    // input the same RPC URL
     fireEvent.change(rpcUrlText, {
       target: {
         value: 'https://mainnet.infura.io/v3/undefined',


### PR DESCRIPTION
Fixes:  
When i add a new custom network，the new nework can overwrite the existed network in extreme cases.

step1：Add Binance Smart Chain Mainnet
![bsc](https://user-images.githubusercontent.com/35363592/150644800-416b31bd-cbda-4c06-86c3-228e33c900c1.png)

step2:  Add  TEST network with wrong rpc url and same chainid
![2](https://user-images.githubusercontent.com/35363592/150644830-ca9e9b37-9f06-4219-aae3-fa84743d5033.png)

step3:  Click "Save", the error is "Could not fetch chain ID, is your RPC URL correct?"
![3](https://user-images.githubusercontent.com/35363592/150644857-34263f60-4e3d-45e6-a54f-2968cb32ab27.png)

step4: input the same rpc url
![4](https://user-images.githubusercontent.com/35363592/150644865-07c8fbc2-0f3d-4b9c-a513-8d36b8b40c12.png)

step5: Click "Save", overwrite the Binance Smart Chain Mainnet
![5](https://user-images.githubusercontent.com/35363592/150644880-9373522d-f11b-4b5e-acd6-b101eecd6700.png)

Explanation:  
The cause of the error:   In an event(such as Onclick) , modify the usestate variable multiple times, and only the last time is valid. In the function validateUrlRpcUrl modify errors twice, the urlExistsErrorMsg was ignored（step4）, so the "Save" button is enabled. I split "errors" into three variables to avoid this problem.
