### PR TITLE
Fix failing test:unit pipeline

### DIFF
--- a/ui/components/app/edit-gas-display/edit-gas-display.component.js
+++ b/ui/components/app/edit-gas-display/edit-gas-display.component.js
@@ -110,7 +110,11 @@ export default function EditGasDisplay({
   );
 
   let warningMessage;
-  if (new BigNumber(gasLimit).lessThan(new BigNumber(properGasLimit))) {
+  if (
+    gasLimit &&
+    properGasLimit &&
+    new BigNumber(gasLimit).lessThan(new BigNumber(properGasLimit))
+  ) {
     warningMessage = t('gasLimitRecommended', [properGasLimit]);
   }
 

--- a/ui/components/app/edit-gas-display/edit-gas-display.component.js
+++ b/ui/components/app/edit-gas-display/edit-gas-display.component.js
@@ -111,8 +111,8 @@ export default function EditGasDisplay({
 
   let warningMessage;
   if (
-    gasLimit &&
-    properGasLimit &&
+    gasLimit !== undefined &&
+    properGasLimit !== undefined &&
     new BigNumber(gasLimit).lessThan(new BigNumber(properGasLimit))
   ) {
     warningMessage = t('gasLimitRecommended', [properGasLimit]);


### PR DESCRIPTION
This PR fixes failing `test:unit` on pipeline. Added some more checks to the `edit-gas-display.component.js` to ensure that errors are not thrown in case `gasLimit` or `properGasLimit` are not defined.