### PR TITLE
Update vulnerability ignore list

### DIFF
--- a/.circleci/scripts/yarn-audit.sh
+++ b/.circleci/scripts/yarn-audit.sh
@@ -7,7 +7,7 @@ set -o pipefail
 
 # use `improved-yarn-audit` since that allows for exclude
 # exclude 1002401 until we remove use of 3Box, 1002581 until we can find a better solution
-yarn run improved-yarn-audit --ignore-dev-deps --min-severity moderate --exclude 1002401,1002581,GHSA-93q8-gq69-wqmw,GHSA-257v-vj4p-3w2h
+yarn run improved-yarn-audit --ignore-dev-deps --min-severity moderate --exclude 1002401,1002581,GHSA-93q8-gq69-wqmw,GHSA-257v-vj4p-3w2h,GHSA-qrpm-p2h7-hrv2
 audit_status="$?"
 
 # Use a bitmask to ignore INFO and LOW severity audit results


### PR DESCRIPTION
I tried to get the nanoid version updated but I first ran into yarn resolution issues, then lavamoat policy update issues, and finally when I did have nanoid updated new e2e test failures. This is just suppressing the audit failure so that other work can happen in parallel