### PR TITLE
Yet more NFT UX cleanups

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -1640,6 +1640,9 @@
   "loading": {
     "message": "Loading..."
   },
+  "loadingNFTs": {
+    "message": "Loading NFTs..."
+  },
   "loadingTokens": {
     "message": "Loading Tokens..."
   },

--- a/app/scripts/controllers/preferences.js
+++ b/app/scripts/controllers/preferences.js
@@ -137,12 +137,6 @@ export default class PreferencesController {
    * @param {boolean} val - Whether or not the user prefers to autodetect collectibles.
    */
   setUseCollectibleDetection(val) {
-    const { openSeaEnabled } = this.store.getState();
-    if (val && !openSeaEnabled) {
-      throw new Error(
-        'useCollectibleDetection cannot be enabled if openSeaEnabled is false',
-      );
-    }
     this.store.updateState({ useCollectibleDetection: val });
   }
 

--- a/app/scripts/controllers/preferences.js
+++ b/app/scripts/controllers/preferences.js
@@ -134,10 +134,10 @@ export default class PreferencesController {
   /**
    * Setter for the `useCollectibleDetection` property
    *
-   * @param {boolean} val - Whether or not the user prefers to autodetect collectibles.
+   * @param {boolean} useCollectibleDetection - Whether or not the user prefers to autodetect collectibles.
    */
-  setUseCollectibleDetection(val) {
-    this.store.updateState({ useCollectibleDetection: val });
+  setUseCollectibleDetection(useCollectibleDetection) {
+    this.store.updateState({ useCollectibleDetection });
   }
 
   /**

--- a/ui/components/app/collectibles-items/collectibles-items.js
+++ b/ui/components/app/collectibles-items/collectibles-items.js
@@ -17,7 +17,11 @@ import {
 } from '../../../helpers/constants/design-system';
 import { ENVIRONMENT_TYPE_POPUP } from '../../../../shared/constants/app';
 import { getEnvironmentType } from '../../../../app/scripts/lib/util';
-import { getIpfsGateway } from '../../../selectors';
+import {
+  getCurrentChainId,
+  getIpfsGateway,
+  getSelectedAddress,
+} from '../../../selectors';
 import { ASSET_ROUTE } from '../../../helpers/constants/routes';
 import { getAssetImageURL } from '../../../helpers/utils/util';
 import { updateCollectibleDropDownState } from '../../../store/actions';
@@ -39,22 +43,40 @@ export default function CollectiblesItems({
   const collectionsKeys = Object.keys(collections);
   const collectiblesDropdownState = useSelector(getCollectiblesDropdownState);
   const previousCollectionKeys = usePrevious(collectionsKeys);
+  const selectedAddress = useSelector(getSelectedAddress);
+  const chainId = useSelector(getCurrentChainId);
 
   useEffect(() => {
+    if (collectiblesDropdownState?.[selectedAddress] === undefined) {
+      collectiblesDropdownState[selectedAddress] = {};
+    }
     if (
-      Object.keys(collectiblesDropdownState).length === 0 &&
+      (collectiblesDropdownState?.[selectedAddress]?.[chainId] === undefined ||
+        Object.keys(collectiblesDropdownState?.[selectedAddress]?.[chainId])
+          .length === 0) &&
       previousCollectionKeys !== collectionsKeys
     ) {
       const initState = {};
       collectionsKeys.forEach((key) => {
         initState[key] = true;
       });
-      dispatch(updateCollectibleDropDownState(initState));
+
+      const newCollectibleDropdownState = {
+        ...collectiblesDropdownState,
+        [selectedAddress]: {
+          ...collectiblesDropdownState[selectedAddress],
+          [chainId]: initState,
+        },
+      };
+
+      dispatch(updateCollectibleDropDownState(newCollectibleDropdownState));
     }
   }, [
     collectionsKeys,
     previousCollectionKeys,
     collectiblesDropdownState,
+    selectedAddress,
+    chainId,
     dispatch,
   ]);
 
@@ -84,6 +106,22 @@ export default function CollectiblesItems({
     );
   };
 
+  const updateCollectibleDropDownStateKey = (key, isExpanded) => {
+    const currentAccountCollectibleDropdownState =
+      collectiblesDropdownState[selectedAddress][chainId];
+
+    const newCurrentAccountState = {
+      ...currentAccountCollectibleDropdownState,
+      [key]: !isExpanded,
+    };
+
+    collectiblesDropdownState[selectedAddress][
+      chainId
+    ] = newCurrentAccountState;
+
+    dispatch(updateCollectibleDropDownState(collectiblesDropdownState));
+  };
+
   const renderCollection = ({
     collectibles,
     collectionName,
@@ -95,17 +133,13 @@ export default function CollectiblesItems({
       return null;
     }
 
-    const isExpanded = collectiblesDropdownState[key];
+    const isExpanded =
+      collectiblesDropdownState[selectedAddress]?.[chainId]?.[key];
     return (
       <div className="collectibles-items__collection" key={`collection-${key}`}>
         <button
           onClick={() => {
-            dispatch(
-              updateCollectibleDropDownState({
-                ...collectiblesDropdownState,
-                [key]: !isExpanded,
-              }),
-            );
+            updateCollectibleDropDownStateKey(key, isExpanded);
           }}
           className="collectibles-items__collection-wrapper"
         >

--- a/ui/components/app/collectibles-items/collectibles-items.js
+++ b/ui/components/app/collectibles-items/collectibles-items.js
@@ -47,14 +47,18 @@ export default function CollectiblesItems({
   const chainId = useSelector(getCurrentChainId);
 
   useEffect(() => {
-    if (collectiblesDropdownState?.[selectedAddress] === undefined) {
+    if (
+      selectedAddress !== undefined &&
+      collectiblesDropdownState?.[selectedAddress] === undefined
+    ) {
       collectiblesDropdownState[selectedAddress] = {};
     }
     if (
+      chainId !== undefined &&
+      previousCollectionKeys !== collectionsKeys &&
       (collectiblesDropdownState[selectedAddress]?.[chainId] === undefined ||
         Object.keys(collectiblesDropdownState?.[selectedAddress]?.[chainId])
-          .length === 0) &&
-      previousCollectionKeys !== collectionsKeys
+          .length === 0)
     ) {
       const initState = {};
       collectionsKeys.forEach((key) => {

--- a/ui/components/app/collectibles-items/collectibles-items.js
+++ b/ui/components/app/collectibles-items/collectibles-items.js
@@ -51,7 +51,7 @@ export default function CollectiblesItems({
       collectiblesDropdownState[selectedAddress] = {};
     }
     if (
-      (collectiblesDropdownState?.[selectedAddress]?.[chainId] === undefined ||
+      (collectiblesDropdownState[selectedAddress]?.[chainId] === undefined ||
         Object.keys(collectiblesDropdownState?.[selectedAddress]?.[chainId])
           .length === 0) &&
       previousCollectionKeys !== collectionsKeys

--- a/ui/components/app/collectibles-items/collectibles-items.js
+++ b/ui/components/app/collectibles-items/collectibles-items.js
@@ -42,7 +42,7 @@ export default function CollectiblesItems({
 
   useEffect(() => {
     if (
-      !Object.keys(collectiblesDropdownState).length &&
+      Object.keys(collectiblesDropdownState).length === 0 &&
       previousCollectionKeys !== collectionsKeys
     ) {
       const initState = {};

--- a/ui/components/app/collectibles-items/collectibles-items.js
+++ b/ui/components/app/collectibles-items/collectibles-items.js
@@ -48,15 +48,10 @@ export default function CollectiblesItems({
 
   useEffect(() => {
     if (
-      selectedAddress !== undefined &&
-      collectiblesDropdownState?.[selectedAddress] === undefined
-    ) {
-      collectiblesDropdownState[selectedAddress] = {};
-    }
-    if (
       chainId !== undefined &&
+      selectedAddress !== undefined &&
       previousCollectionKeys !== collectionsKeys &&
-      (collectiblesDropdownState[selectedAddress]?.[chainId] === undefined ||
+      (collectiblesDropdownState?.[selectedAddress]?.[chainId] === undefined ||
         Object.keys(collectiblesDropdownState?.[selectedAddress]?.[chainId])
           .length === 0)
     ) {
@@ -68,7 +63,7 @@ export default function CollectiblesItems({
       const newCollectibleDropdownState = {
         ...collectiblesDropdownState,
         [selectedAddress]: {
-          ...collectiblesDropdownState[selectedAddress],
+          ...collectiblesDropdownState?.[selectedAddress],
           [chainId]: initState,
         },
       };

--- a/ui/components/app/collectibles-items/index.scss
+++ b/ui/components/app/collectibles-items/index.scss
@@ -26,7 +26,6 @@
       background: var(--ui-4);
       color: var(--ui-white);
       text-align: center;
-      line-height: 1;
     }
 
     &-item-wrapper {

--- a/ui/components/app/collectibles-tab/collectibles-tab.js
+++ b/ui/components/app/collectibles-tab/collectibles-tab.js
@@ -1,8 +1,7 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import { useDispatch, useSelector } from 'react-redux';
 import { useHistory } from 'react-router-dom';
-import { isEqual } from 'lodash';
 import Box from '../../ui/box';
 import Button from '../../ui/button';
 import Typography from '../../ui/typography/typography';
@@ -18,100 +17,30 @@ import {
   ALIGN_ITEMS,
 } from '../../../helpers/constants/design-system';
 import { useI18nContext } from '../../../hooks/useI18nContext';
-import {
-  getCollectibles,
-  getCollectibleContracts,
-  getCollectiblesDetectionNoticeDismissed,
-} from '../../../ducks/metamask/metamask';
-import {
-  getCurrentChainId,
-  getIsMainnet,
-  getSelectedAddress,
-  getUseCollectibleDetection,
-} from '../../../selectors';
+import { getCollectiblesDetectionNoticeDismissed } from '../../../ducks/metamask/metamask';
+import { getIsMainnet, getUseCollectibleDetection } from '../../../selectors';
 import { EXPERIMENTAL_ROUTE } from '../../../helpers/constants/routes';
 import {
   checkAndUpdateAllCollectiblesOwnershipStatus,
   detectCollectibles,
 } from '../../../store/actions';
-import { usePrevious } from '../../../hooks/usePrevious';
+import { useCollectiblesCollections } from '../../../hooks/useCollectiblesCollections';
 
 export default function CollectiblesTab({ onAddNFT }) {
-  const collectibles = useSelector(getCollectibles);
-  const collectibleContracts = useSelector(getCollectibleContracts);
   const useCollectibleDetection = useSelector(getUseCollectibleDetection);
   const isMainnet = useSelector(getIsMainnet);
-  const selectedAddress = useSelector(getSelectedAddress);
-  const chainId = useSelector(getCurrentChainId);
   const collectibleDetectionNoticeDismissed = useSelector(
     getCollectiblesDetectionNoticeDismissed,
-  );
-  const [collectiblesLoading, setCollectiblesLoading] = useState(
-    () => collectibles?.length >= 0,
   );
   const history = useHistory();
   const t = useI18nContext();
   const dispatch = useDispatch();
-  const [collections, setCollections] = useState({});
-  const [previouslyOwnedCollection, setPreviouslyOwnedCollection] = useState({
-    collectionName: 'Previously Owned',
-    collectibles: [],
-  });
 
-  const prevCollectibles = usePrevious(collectibles);
-  const prevChainId = usePrevious(chainId);
-  const prevSelectedAddress = usePrevious(selectedAddress);
-  useEffect(() => {
-    const getCollections = () => {
-      setCollectiblesLoading(true);
-      if (selectedAddress === undefined || chainId === undefined) {
-        return;
-      }
-      const newCollections = {};
-      const newPreviouslyOwnedCollections = {
-        collectionName: 'Previously Owned',
-        collectibles: [],
-      };
-
-      collectibles.forEach((collectible) => {
-        if (collectible?.isCurrentlyOwned === false) {
-          newPreviouslyOwnedCollections.collectibles.push(collectible);
-        } else if (newCollections[collectible.address]) {
-          newCollections[collectible.address].collectibles.push(collectible);
-        } else {
-          const collectionContract = collectibleContracts.find(
-            ({ address }) => address === collectible.address,
-          );
-          newCollections[collectible.address] = {
-            collectionName: collectionContract?.name || collectible.name,
-            collectionImage:
-              collectionContract?.logo || collectible.collectionImage,
-            collectibles: [collectible],
-          };
-        }
-      });
-      setCollections(newCollections);
-      setPreviouslyOwnedCollection(newPreviouslyOwnedCollections);
-      setCollectiblesLoading(false);
-    };
-
-    if (
-      !isEqual(prevCollectibles, collectibles) ||
-      !isEqual(prevSelectedAddress, selectedAddress) ||
-      !isEqual(prevChainId, chainId)
-    ) {
-      getCollections();
-    }
-  }, [
-    collectibles,
-    prevCollectibles,
-    collectibleContracts,
-    setCollectiblesLoading,
-    chainId,
-    prevChainId,
-    selectedAddress,
-    prevSelectedAddress,
-  ]);
+  const {
+    collectiblesLoading,
+    collections,
+    previouslyOwnedCollection,
+  } = useCollectiblesCollections();
 
   const onEnableAutoDetect = () => {
     history.push(EXPERIMENTAL_ROUTE);

--- a/ui/components/app/collectibles-tab/collectibles-tab.test.js
+++ b/ui/components/app/collectibles-tab/collectibles-tab.test.js
@@ -180,11 +180,13 @@ describe('Collectible Items', () => {
   const setCollectiblesDetectionNoticeDismissedStub = jest.fn();
   const getStateStub = jest.fn();
   const checkAndUpdateAllCollectiblesOwnershipStatusStub = jest.fn();
+  const updateCollectibleDropDownStateStub = jest.fn();
   setBackgroundConnection({
     setCollectiblesDetectionNoticeDismissed: setCollectiblesDetectionNoticeDismissedStub,
     detectCollectibles: detectCollectiblesStub,
     getState: getStateStub,
     checkAndUpdateAllCollectiblesOwnershipStatus: checkAndUpdateAllCollectiblesOwnershipStatusStub,
+    updateCollectibleDropDownState: updateCollectibleDropDownStateStub,
   });
   const historyPushMock = jest.fn();
 

--- a/ui/components/app/collectibles-tab/index.scss
+++ b/ui/components/app/collectibles-tab/index.scss
@@ -5,4 +5,12 @@
       font-size: 0.875rem;
     }
   }
+
+  &__loading {
+    display: flex;
+    height: 250px;
+    align-items: center;
+    justify-content: center;
+    padding: 30px;
+  }
 }

--- a/ui/hooks/useCollectiblesCollections.js
+++ b/ui/hooks/useCollectiblesCollections.js
@@ -1,0 +1,80 @@
+import { useEffect, useState } from 'react';
+import { useSelector } from 'react-redux';
+import { isEqual } from 'lodash';
+import {
+  getCollectibles,
+  getCollectibleContracts,
+} from '../ducks/metamask/metamask';
+import { getCurrentChainId, getSelectedAddress } from '../selectors';
+import { usePrevious } from './usePrevious';
+
+export function useCollectiblesCollections() {
+  const [collections, setCollections] = useState({});
+  const [previouslyOwnedCollection, setPreviouslyOwnedCollection] = useState({
+    collectionName: 'Previously Owned',
+    collectibles: [],
+  });
+  const collectibles = useSelector(getCollectibles);
+  const [collectiblesLoading, setCollectiblesLoading] = useState(
+    () => collectibles?.length >= 0,
+  );
+  const selectedAddress = useSelector(getSelectedAddress);
+  const chainId = useSelector(getCurrentChainId);
+  const collectibleContracts = useSelector(getCollectibleContracts);
+  const prevCollectibles = usePrevious(collectibles);
+  const prevChainId = usePrevious(chainId);
+  const prevSelectedAddress = usePrevious(selectedAddress);
+  useEffect(() => {
+    const getCollections = () => {
+      setCollectiblesLoading(true);
+      if (selectedAddress === undefined || chainId === undefined) {
+        return;
+      }
+      const newCollections = {};
+      const newPreviouslyOwnedCollections = {
+        collectionName: 'Previously Owned',
+        collectibles: [],
+      };
+
+      collectibles.forEach((collectible) => {
+        if (collectible?.isCurrentlyOwned === false) {
+          newPreviouslyOwnedCollections.collectibles.push(collectible);
+        } else if (newCollections[collectible.address]) {
+          newCollections[collectible.address].collectibles.push(collectible);
+        } else {
+          const collectionContract = collectibleContracts.find(
+            ({ address }) => address === collectible.address,
+          );
+          newCollections[collectible.address] = {
+            collectionName: collectionContract?.name || collectible.name,
+            collectionImage:
+              collectionContract?.logo || collectible.collectionImage,
+            collectibles: [collectible],
+          };
+        }
+      });
+      setCollections(newCollections);
+      setPreviouslyOwnedCollection(newPreviouslyOwnedCollections);
+      setCollectiblesLoading(false);
+    };
+
+    if (
+      !isEqual(prevCollectibles, collectibles) ||
+      !isEqual(prevSelectedAddress, selectedAddress) ||
+      !isEqual(prevChainId, chainId)
+    ) {
+      getCollections();
+    }
+  }, [
+    collectibles,
+    prevCollectibles,
+    collectibleContracts,
+    setCollectiblesLoading,
+    chainId,
+    prevChainId,
+    selectedAddress,
+    prevSelectedAddress,
+  ]);
+
+  return { collectiblesLoading, collections, previouslyOwnedCollection };
+}


### PR DESCRIPTION
- Organize NFT collection collapse/opened state by account/chainId to consistently preserve this state across accounts which may hold NFTs from the same contracts
- Add functionality/messaging for loading NFT collections when user changes accounts/chainIds, and wrap it in a hook
  before:
  https://user-images.githubusercontent.com/34557516/151612992-b6c9e5bc-b723-499b-b820-28ef02d776cf.mov
  after:
  https://user-images.githubusercontent.com/34557516/151611919-6a17ff8a-772b-4171-8be2-7d99b64221f1.mov


- Centers letter logo for collections without a proper logo:
before:
![Screen Shot 2022-01-28 at 1 49 45 PM](https://user-images.githubusercontent.com/34557516/151612096-d171249b-75b9-4310-9e26-282c822ff563.png)
after:
![Screen Shot 2022-01-28 at 1 47 39 PM](https://user-images.githubusercontent.com/34557516/151611845-d091b5ce-7900-4477-bd99-431c8446b92b.png)

