### PR TITLE
Added `subjectType` to `setupProviderConnection` and `setupUntrustedCommunication`

### DIFF
--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -414,7 +414,10 @@ function setupController(initState, initLangCode) {
   // communication with page or other extension
   function connectExternal(remotePort) {
     const portStream = new PortStream(remotePort);
-    controller.setupUntrustedCommunication(portStream, remotePort.sender);
+    controller.setupUntrustedCommunication({
+      connectionStream: portStream,
+      sender: remotePort.sender,
+    });
   }
 
   //

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -2650,28 +2650,47 @@ export default class MetamaskController extends EventEmitter {
    * Used to create a multiplexed stream for connecting to an untrusted context
    * like a Dapp or other extension.
    *
-   * @param {*} connectionStream - The Duplex stream to connect to.
-   * @param {MessageSender} sender - The sender of the messages on this stream
+   * @param options - Options bag.
+   * @param {ReadableStream} options.connectionStream - The Duplex stream to connect to.
+   * @param {MessageSender | SnapSender} options.sender - The sender of the messages on this stream.
+   * @param {string} [options.subjectType] - The type of the sender, i.e. subject.
    */
-  setupUntrustedCommunication(connectionStream, sender) {
+  setupUntrustedCommunication({ connectionStream, sender, subjectType }) {
     const { usePhishDetect } = this.preferencesController.store.getState();
-    const { hostname } = new URL(sender.url);
-    // Check if new connection is blocked if phishing detection is on
-    if (usePhishDetect && this.phishingController.test(hostname)) {
-      log.debug('MetaMask - sending phishing warning for', hostname);
-      this.sendPhishingWarning(connectionStream, hostname);
-      return;
+    let _subjectType;
+    if (subjectType) {
+      _subjectType = subjectType;
+    } else if (sender.id && sender.id !== this.extension.runtime.id) {
+      _subjectType = SUBJECT_TYPES.EXTENSION;
+    } else {
+      _subjectType = SUBJECT_TYPES.WEBSITE;
+    }
+
+    if (sender.url) {
+      const { hostname } = new URL(sender.url);
+      // Check if new connection is blocked if phishing detection is on
+      if (usePhishDetect && this.phishingController.test(hostname)) {
+        log.debug('MetaMask - sending phishing warning for', hostname);
+        this.sendPhishingWarning(connectionStream, hostname);
+        return;
+      }
     }
 
     // setup multiplexing
     const mux = setupMultiplex(connectionStream);
 
     // messages between inpage and background
-    this.setupProviderConnection(mux.createStream('metamask-provider'), sender);
+    this.setupProviderConnection(
+      mux.createStream('metamask-provider'),
+      sender,
+      _subjectType,
+    );
 
     // TODO:LegacyProvider: Delete
-    // legacy streams
-    this.setupPublicConfig(mux.createStream('publicConfig'));
+    if (sender.url) {
+      // legacy streams
+      this.setupPublicConfig(mux.createStream('publicConfig'));
+    }
   }
 
   /**
@@ -2688,7 +2707,11 @@ export default class MetamaskController extends EventEmitter {
     const mux = setupMultiplex(connectionStream);
     // connect features
     this.setupControllerConnection(mux.createStream('controller'));
-    this.setupProviderConnection(mux.createStream('provider'), sender, true);
+    this.setupProviderConnection(
+      mux.createStream('provider'),
+      sender,
+      SUBJECT_TYPES.INTERNAL,
+    );
   }
 
   /**
@@ -2747,17 +2770,19 @@ export default class MetamaskController extends EventEmitter {
    *
    * @param {*} outStream - The stream to provide over.
    * @param {MessageSender} sender - The sender of the messages on this stream
-   * @param {boolean} isInternal - True if this is a connection with an internal process
+   * @param {string} subjectType - The type of the sender, i.e. subject.
    */
-  setupProviderConnection(outStream, sender, isInternal) {
-    const origin = isInternal ? 'metamask' : new URL(sender.url).origin;
-    let subjectType = isInternal
-      ? SUBJECT_TYPES.INTERNAL
-      : SUBJECT_TYPES.WEBSITE;
+  setupProviderConnection(outStream, sender, subjectType) {
+    let origin;
+    if (subjectType === SUBJECT_TYPES.INTERNAL) {
+      origin = 'metamask';
+    } else {
+      origin = new URL(sender.url).origin;
+    }
 
-    if (sender.id !== this.extension.runtime.id) {
-      subjectType = SUBJECT_TYPES.EXTENSION;
-      this.subjectMetadataController.addSubjectMetadata(origin, {
+    if (sender.id && sender.id !== this.extension.runtime.id) {
+      this.subjectMetadataController.addSubjectMetadata({
+        origin,
         extensionId: sender.id,
         subjectType: SUBJECT_TYPES.EXTENSION,
       });
@@ -2770,8 +2795,8 @@ export default class MetamaskController extends EventEmitter {
 
     const engine = this.setupProviderEngine({
       origin,
-      location: sender.url,
       tabId,
+      sender,
       subjectType,
     });
 
@@ -2799,14 +2824,14 @@ export default class MetamaskController extends EventEmitter {
    *
    * @param {Object} options - Provider engine options
    * @param {string} options.origin - The origin of the sender
-   * @param {string} options.location - The full URL of the sender
+   * @param {MessageSender | SnapSender} options.sender - The sender object.   * @param {string} options.subjectType - The type of the sender subject.
    * @param {string} options.subjectType - The type of the sender subject.
    * @param {tabId} [options.tabId] - The tab ID of the sender - if the sender is within a tab
    */
-  setupProviderEngine({ origin, location, subjectType, tabId }) {
+  setupProviderEngine({ origin, subjectType, sender, tabId }) {
     // setup json rpc engine stack
     const engine = new JsonRpcEngine();
-    const { provider, blockTracker } = this;
+    const { blockTracker, provider } = this;
 
     // create filter polyfill middleware
     const filterMiddleware = createFilterMiddleware({ provider, blockTracker });
@@ -2828,13 +2853,16 @@ export default class MetamaskController extends EventEmitter {
     }
     // logging
     engine.push(createLoggerMiddleware({ origin }));
-    engine.push(
-      createOnboardingMiddleware({
-        location,
-        registerOnboarding: this.onboardingController.registerOnboarding,
-      }),
-    );
     engine.push(this.permissionLogController.createMiddleware());
+    // onboarding
+    if (subjectType === SUBJECT_TYPES.WEBSITE) {
+      engine.push(
+        createOnboardingMiddleware({
+          location: sender.url,
+          registerOnboarding: this.onboardingController.registerOnboarding,
+        }),
+      );
+    }
     engine.push(
       createMethodMiddleware({
         origin,

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -2824,7 +2824,8 @@ export default class MetamaskController extends EventEmitter {
    *
    * @param {Object} options - Provider engine options
    * @param {string} options.origin - The origin of the sender
-   * @param {MessageSender | SnapSender} options.sender - The sender object.   * @param {string} options.subjectType - The type of the sender subject.
+   * @param {MessageSender | SnapSender} options.sender - The sender object.
+   * @param {string} options.subjectType - The type of the sender subject.
    * @param {string} options.subjectType - The type of the sender subject.
    * @param {tabId} [options.tabId] - The tab ID of the sender - if the sender is within a tab
    */

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -2826,7 +2826,6 @@ export default class MetamaskController extends EventEmitter {
    * @param {string} options.origin - The origin of the sender
    * @param {MessageSender | SnapSender} options.sender - The sender object.
    * @param {string} options.subjectType - The type of the sender subject.
-   * @param {string} options.subjectType - The type of the sender subject.
    * @param {tabId} [options.tabId] - The tab ID of the sender - if the sender is within a tab
    */
   setupProviderEngine({ origin, subjectType, sender, tabId }) {

--- a/app/scripts/metamask-controller.test.js
+++ b/app/scripts/metamask-controller.test.js
@@ -1060,7 +1060,7 @@ describe('MetaMaskController', function () {
 
       metamaskController.setupUntrustedCommunication({
         connectionStream: streamTest,
-        sender: messageSender
+        sender: messageSender,
       });
 
       const message = {

--- a/app/scripts/metamask-controller.test.js
+++ b/app/scripts/metamask-controller.test.js
@@ -995,10 +995,10 @@ describe('MetaMaskController', function () {
         cb();
       });
 
-      metamaskController.setupUntrustedCommunication(
-        streamTest,
-        phishingMessageSender,
-      );
+      metamaskController.setupUntrustedCommunication({
+        connectionStream: streamTest,
+        sender: phishingMessageSender,
+      });
       await promise;
       streamTest.end();
     });
@@ -1016,7 +1016,10 @@ describe('MetaMaskController', function () {
         cb();
       });
 
-      metamaskController.setupUntrustedCommunication(streamTest, messageSender);
+      metamaskController.setupUntrustedCommunication({
+        connectionStream: streamTest,
+        sender: messageSender,
+      });
 
       const message = {
         id: 1999133338649204,
@@ -1055,7 +1058,10 @@ describe('MetaMaskController', function () {
         cb();
       });
 
-      metamaskController.setupUntrustedCommunication(streamTest, messageSender);
+      metamaskController.setupUntrustedCommunication({
+        connectionStream: streamTest,
+        sender: messageSender
+      });
 
       const message = {
         id: 1999133338649204,

--- a/test/e2e/run-all.js
+++ b/test/e2e/run-all.js
@@ -17,12 +17,6 @@ async function main() {
             type: 'string',
             choices: ['chrome', 'firefox'],
           })
-          .option('leave-running', {
-            default: false,
-            description:
-              'Leaves the browser running after a test fails, along with anything else that the test used (ganache, the test dapp, etc.)',
-            type: 'boolean',
-          })
           .option('retries', {
             description:
               'Set how many times the test should be retried upon failure.',
@@ -32,7 +26,7 @@ async function main() {
     .strict()
     .help('help');
 
-  const { browser, retries, leaveRunning } = argv;
+  const { browser, retries } = argv;
 
   const testDir = path.join(__dirname, 'tests');
   const metamaskUiTest = path.join(__dirname, 'metamask-ui.spec.js');
@@ -52,12 +46,6 @@ async function main() {
   if (retries) {
     args.push('--retries', retries);
   }
-
-
-  if (leaveRunning) {
-    process.env.E2E_LEAVE_RUNNING = 'true';
-  }
-
 
   for (const testPath of allE2eTestPaths) {
     await runInShell('node', [...args, testPath]);

--- a/test/e2e/run-all.js
+++ b/test/e2e/run-all.js
@@ -17,6 +17,12 @@ async function main() {
             type: 'string',
             choices: ['chrome', 'firefox'],
           })
+          .option('leave-running', {
+            default: false,
+            description:
+              'Leaves the browser running after a test fails, along with anything else that the test used (ganache, the test dapp, etc.)',
+            type: 'boolean',
+          })
           .option('retries', {
             description:
               'Set how many times the test should be retried upon failure.',
@@ -26,7 +32,7 @@ async function main() {
     .strict()
     .help('help');
 
-  const { browser, retries } = argv;
+  const { browser, retries, leaveRunning } = argv;
 
   const testDir = path.join(__dirname, 'tests');
   const metamaskUiTest = path.join(__dirname, 'metamask-ui.spec.js');
@@ -46,6 +52,12 @@ async function main() {
   if (retries) {
     args.push('--retries', retries);
   }
+
+
+  if (leaveRunning) {
+    process.env.E2E_LEAVE_RUNNING = 'true';
+  }
+
 
   for (const testPath of allE2eTestPaths) {
     await runInShell('node', [...args, testPath]);


### PR DESCRIPTION
These changes were split off from the snaps branch [here](https://github.com/MetaMask/metamask-extension/pull/11837#discussion_r792942834).

The `subjectType` is necessary to handle connecting to snaps using these methods.