### PR TITLE
batch fix misspelling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -387,7 +387,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#11093](https://github.com/MetaMask/metamask-extension/pull/11093): Update all uses of "Seed Phrase" to "Secret Recovery Phrase"
 
 ### Fixed
-- [#11025](https://github.com/MetaMask/metamask-extension/pull/11025): Fixed redirection to the build quotes page from the swaps page when failure has occured
+- [#11025](https://github.com/MetaMask/metamask-extension/pull/11025): Fixed redirection to the build quotes page from the swaps page when failure has occurred
 - [#11015](https://github.com/MetaMask/metamask-extension/pull/11015): Prevent an undefined gas price from breaking the transaction list
 - [#11013](https://github.com/MetaMask/metamask-extension/pull/11013): Prevent signature request component from canceling hardware wallet signing
 - [#10982](https://github.com/MetaMask/metamask-extension/pull/10982): Re-validating chain id when rpc url changes [custom network form]
@@ -441,7 +441,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [9.5.1]
 ### Fixed
 - Fixed icon on approval screen ([#11048](https://github.com/MetaMask/metamask-extension/pull/11048))
-- Fixed broken app state for some users with Chinese, Portugese or Spanish browser language settings. ([#11036](https://github.com/MetaMask/metamask-extension/pull/11036))
+- Fixed broken app state for some users with Chinese, Portuguese or Spanish browser language settings. ([#11036](https://github.com/MetaMask/metamask-extension/pull/11036))
 
 ## [9.5.0] - 2021-04-28
 ### Added
@@ -530,7 +530,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update Japanese translations. ([#10265](https://github.com/MetaMask/metamask-extension/pull/10265))
 - Update Chinese(Simplified) translations. ([#9388](https://github.com/MetaMask/metamask-extension/pull/9388))
 - Update Vietnamese translations. ([#10270](https://github.com/MetaMask/metamask-extension/pull/10270))
-- Update Spanish and Spanish(Latin American and Carribean) translations. ([#10258](https://github.com/MetaMask/metamask-extension/pull/10258))
+- Update Spanish and Spanish(Latin American and Caribbean) translations. ([#10258](https://github.com/MetaMask/metamask-extension/pull/10258))
 - Update Russian translations. ([#10268](https://github.com/MetaMask/metamask-extension/pull/10268))
 - Update Tagalog localized messages. ([#10269](https://github.com/MetaMask/metamask-extension/pull/10269))
 - Fix 'imported' translation use case for Dutch. ([#10448](https://github.com/MetaMask/metamask-extension/pull/10448))

--- a/app/scripts/controllers/metametrics.js
+++ b/app/scripts/controllers/metametrics.js
@@ -11,7 +11,7 @@ import { SECOND } from '../../../shared/constants/time';
 
 const defaultCaptureException = (err) => {
   // throw error on clean stack so its captured by platform integrations (eg sentry)
-  // but does not interupt the call stack
+  // but does not interrupt the call stack
   setTimeout(() => {
     throw err;
   });

--- a/ui/components/app/edit-gas-fee-button/edit-gas-fee-button.test.js
+++ b/ui/components/app/edit-gas-fee-button/edit-gas-fee-button.test.js
@@ -60,7 +60,7 @@ describe('EditGasFeeButton', () => {
     expect(screen.queryByText('Market')).toBeInTheDocument();
   });
 
-  it('should render edit link with text agressive if high gas estimates are selected', () => {
+  it('should render edit link with text aggressive if high gas estimates are selected', () => {
     render({ contextProps: { transaction: { userFeeLevel: 'high' } } });
     expect(screen.queryByText('🦍')).toBeInTheDocument();
     expect(screen.queryByText('Aggressive')).toBeInTheDocument();

--- a/ui/ducks/send/send.js
+++ b/ui/ducks/send/send.js
@@ -581,7 +581,7 @@ export const initialState = {
   gas: {
     // indicate whether the gas estimate is loading
     isGasEstimateLoading: true,
-    // String token indentifying a listener for polling on the gasFeeController
+    // String token identifying a listener for polling on the gasFeeController
     gasEstimatePollToken: null,
     // has the user set custom gas in the custom gas modal
     isCustomGasSet: false,


### PR DESCRIPTION
Found a lot of misspelling in the code and documents， I tried to find a batch processing method.
（1）collect common misspelling of English words，such as agressive（aggressive）、indentify（identify），
         Write to misspelling_list.txt
（2）bash shell file detect_misspelling.sh
        for line in `cat misspelling_list.txt`
        do
            echo "detect misspelling $line"
            find -type f | grep -v misspelling_list | grep -v git | xargs grep -in $line
        done
  (3)  bash detect_misspelling.sh, and fix it.

I found six misspellings:
  agressive->aggressive
  indentify->identify
  occured->occurred
  Portugese->Portuguese
  Carribean->Caribbean
  interupt->interrupt