### PR TITLE
Revert "#10168 - Fix to Can't open settings if browser zoom level > 100%"

### DIFF
--- a/ui/components/app/account-menu/index.scss
+++ b/ui/components/app/account-menu/index.scss
@@ -10,9 +10,7 @@
   color: var(--white);
 
   @media screen and (max-width: $break-small) {
-    position: initial;
-    margin-top: -10px;
-    margin-left: calc(((100vw - 100%) / 2) + 8px);
+    right: calc(((100vw - 100%) / 2) + 8px);
   }
 
   @media screen and (min-width: $break-large) {


### PR DESCRIPTION
Reverts MetaMask/metamask-extension#13281

Reverting this PR because it created a new bug which pushes the content down when the media screen width is `(max-width: $break-small)`: 
<img src="https://user-images.githubusercontent.com/20778143/151607603-1971d1eb-ebf0-46c3-94e1-998f3cbf6028.png" width="300">

Follow-up fix for issue is here: https://github.com/MetaMask/metamask-extension/pull/13460