### PR TITLE
Add shell.nix for Nix environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ To learn how to contribute to the MetaMask project itself, visit our [Internal D
 
 - Install [Node.js](https://nodejs.org) version 14
     - If you are using [nvm](https://github.com/creationix/nvm#installation) (recommended) running `nvm use` will automatically choose the right node version for you.
+    - If you are using [Nix package manager](https://github.com/NixOS/nix) running `nix-shell` will put you in to new shell with the right yarn and node version.
 - Install [Yarn](https://yarnpkg.com/en/docs/install)
 - Install dependencies: `yarn setup` (not the usual install command)
 - Copy the `.metamaskrc.dist` file to `.metamaskrc`

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,16 @@
+{ pkgs ? import <nixpkgs> {
+  overlays = [ 
+    (self: super: {
+      yarn = super.yarn.override { 
+        nodejs = pkgs.nodejs-14_x;
+      };
+    })
+   ];
+} }:
+  pkgs.mkShell {
+    nativeBuildInputs = [ 
+      pkgs.nodejs-14_x
+      pkgs.yarn
+    ];
+}
+


### PR DESCRIPTION
Fixes: no issue opened

Explanation:  
Adds _shell.nix_ expression which allows to use `nix-shell` on system with Nix package manager to start an interactive shell in which the environment has corresponding dependencies.

Respectively:
Node.js 14_x
Yarn on Node.js 14_x

Adds the information about it into readme.

Manual testing steps:  
  1) Execute `nix-shell` in the project root
  2) yarn setup