### PR TITLE
changed icon to button for connected-sites-list

### DIFF
--- a/ui/components/app/connected-sites-list/connected-sites-list.component.js
+++ b/ui/components/app/connected-sites-list/connected-sites-list.component.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import Button from '../../ui/button';
 import SiteIcon from '../../ui/site-icon';
 import { stripHttpsSchemeWithoutPort } from '../../../helpers/utils/util';
 
@@ -39,11 +40,13 @@ export default class ConnectedSitesList extends Component {
                 {this.getSubjectDisplayName(subject)}
               </span>
             </div>
-            <i
-              className="fas fa-trash-alt connected-sites-list__trash"
-              title={t('disconnect')}
+            <Button
+              className="connected-sites-list__content-row-link-button"
               onClick={() => onDisconnect(subject.origin)}
-            />
+              type="link"
+            >
+              {t('disconnect')}
+            </Button>
           </div>
         ))}
       </main>

--- a/ui/components/app/connected-sites-list/index.scss
+++ b/ui/components/app/connected-sites-list/index.scss
@@ -13,6 +13,14 @@
     align-items: center;
     border-top: 1px solid #d2d8dd;
     padding: 16px 24px;
+
+    & &-link-button {
+      @include H7;
+
+      padding: 0;
+      width: auto;
+      padding-inline-start: 24px;
+    }
   }
 
   &__subject-info {
@@ -31,9 +39,5 @@
     direction: rtl;
     text-overflow: ellipsis;
     margin-left: 6px;
-  }
-
-  &__trash {
-    cursor: pointer;
   }
 }


### PR DESCRIPTION
This PR splits a change from the `snaps` branch. In Snaps UI development, it was decided to change the connected site removal button from a trash icon to a disconnect button. The button was changed to a div at first and then in PR #13381 it was changed to use the `Button` component.