### PR TITLE
Handling array type values for image in Identicon component

### DIFF
--- a/ui/components/ui/identicon/identicon.component.js
+++ b/ui/components/ui/identicon/identicon.component.js
@@ -34,7 +34,7 @@ export default class Identicon extends PureComponent {
     /**
      * Used as the image source of the Identicon
      */
-    image: PropTypes.string,
+    image: PropTypes.oneOfType([PropTypes.string, PropTypes.array]),
     /**
      * Use the blockie type random image generator
      */
@@ -75,6 +75,10 @@ export default class Identicon extends PureComponent {
   renderImage() {
     const { className, diameter, alt, imageBorder, ipfsGateway } = this.props;
     let { image } = this.props;
+
+    if (Array.isArray(image) && image.length) {
+      image = image[0];
+    }
 
     if (image.toLowerCase().startsWith('ipfs://')) {
       image = getAssetImageURL(image, ipfsGateway);

--- a/ui/components/ui/identicon/identicon.component.js
+++ b/ui/components/ui/identicon/identicon.component.js
@@ -80,7 +80,10 @@ export default class Identicon extends PureComponent {
       image = image[0];
     }
 
-    if (image.toLowerCase().startsWith('ipfs://')) {
+    if (
+      typeof image === 'string' &&
+      image.toLowerCase().startsWith('ipfs://')
+    ) {
       image = getAssetImageURL(image, ipfsGateway);
     }
 


### PR DESCRIPTION
Sentry error: https://sentry.io/organizations/metamask/issues/2977654075/?project=273505&query=is%3Aunresolved+release%3A10.9.0+toLowerCase&sort=new&statsPeriod=14d

It is possible that some assets will supply an array of images for the `asset.image` property. In the case of ONE (Harmony):

<img width="345" alt="Screen Shot 2022-02-01 at 1 37 34 PM" src="https://user-images.githubusercontent.com/8732757/152049753-271bdd75-bd4c-46be-932c-2ef74e5720ed.png">

Rather than just type check and ignore, this PR modifies the `Identicon` component to make use of the first image in the list.

Test plan:
1. Via sushiswap, initiate an ETH -> ONE swap
2. Add the ONE token to metamask
3. Open the Assets tab
4. Observe the app error state

With the fix:
<img width="356" alt="Screen Shot 2022-02-01 at 1 44 16 PM" src="https://user-images.githubusercontent.com/8732757/152050103-8699398c-9ec4-4a46-b7ed-cd8b79853ee0.png">



