### PR TITLE
Update manual build instructions in documentation

### DIFF
--- a/docs/add-to-chrome.md
+++ b/docs/add-to-chrome.md
@@ -11,6 +11,6 @@
 * Navigate to your `metamask-extension/dist/chrome` folder.
 * Click `Select`.
 * Change to your locale via `chrome://settings/languages`
-* Restart the browser and test the plugin in your locale
+* Restart the browser and test the extension in your locale
 
 Your dev build is now added to Chrome, and you can click 'inspect views: background plugin' to view its dev console.

--- a/docs/add-to-chrome.md
+++ b/docs/add-to-chrome.md
@@ -2,6 +2,8 @@
 
 ![Load dev build](./load-dev-build-chrome.gif)
 
+* Create a local build of MetaMask using your preferred method.
+  * You can find build instructions in the [readme](https://github.com/MetaMask/metamask-extension#readme).
 * Open `Settings` > `Extensions`.
   * Or go straight to [chrome://extensions](chrome://extensions).
 * Check "Developer mode".

--- a/docs/add-to-chrome.md
+++ b/docs/add-to-chrome.md
@@ -3,12 +3,12 @@
 ![Load dev build](./load-dev-build-chrome.gif)
 
 * Open `Settings` > `Extensions`.
+  * Or go straight to [chrome://extensions](chrome://extensions).
 * Check "Developer mode".
-* Alternatively, use the URL `chrome://extensions/` in your address bar
 * At the top, click `Load Unpacked Extension`.
-* Navigate to your `metamask-plugin/dist/chrome` folder.
+* Navigate to your `metamask-extension/dist/chrome` folder.
 * Click `Select`.
 * Change to your locale via `chrome://settings/languages`
 * Restart the browser and test the plugin in your locale
 
-You now have the plugin, and can click 'inspect views: background plugin' to view its dev console.
+Your dev build is now added to Chrome, and you can click 'inspect views: background plugin' to view its dev console.

--- a/docs/add-to-chrome.md
+++ b/docs/add-to-chrome.md
@@ -13,4 +13,5 @@
 * Change to your locale via `chrome://settings/languages`
 * Restart the browser and test the extension in your locale
 
-Your dev build is now added to Chrome, and you can click 'inspect views: background plugin' to view its dev console.
+Your dev build is now added to Chrome, and you can click `Inspect views
+background.html` in its card on the extension settings page to view its dev console.

--- a/docs/add-to-firefox.md
+++ b/docs/add-to-firefox.md
@@ -9,4 +9,3 @@
 
 If you have problems debugging, try connecting to the IRC channel `#webextensions` on `irc.mozilla.org`.
 For longer questions, use the StackOverflow tag `firefox-addons`.
-

--- a/docs/add-to-firefox.md
+++ b/docs/add-to-firefox.md
@@ -1,14 +1,12 @@
 # Add Custom Build to Firefox
 
-Go to the url `about:debugging#addons`.
-
-Click the button `Load Temporary Add-On`.
-
-Select the file `dist/firefox/manifest.json`.
-
-You can optionally enable debugging, and click `Debug`, for a console window that logs all of Metamask's processes to a single console.
+* Create a local build of MetaMask using your preferred method.
+  * You can find build instructions in the [readme](https://github.com/MetaMask/metamask-extension#readme).
+* Go to the url `about:debugging#addons`.
+* Click the button `Load Temporary Add-On`.
+* Select the file `metamask-extension/dist/firefox/manifest.json`.
+* You can optionally enable debugging, and click `Debug`, for a console window that logs all of Metamask's processes to a single console.
 
 If you have problems debugging, try connecting to the IRC channel `#webextensions` on `irc.mozilla.org`.
-
 For longer questions, use the StackOverflow tag `firefox-addons`.
 


### PR DESCRIPTION
The "add custom build" instructions for Chrome and Firefox were outdated and/or poorly written.