### PR TITLE
Alter broken identicon images when the image errors

### DIFF
--- a/ui/components/app/asset-list-item/asset-list-item.js
+++ b/ui/components/app/asset-list-item/asset-list-item.js
@@ -131,6 +131,7 @@ const AssetListItem = ({
           image={tokenImage}
           alt={`${primary} ${tokenSymbol}`}
           imageBorder={identiconBorder}
+          tokenSymbol={tokenSymbol}
         />
       }
       midContent={midContent}

--- a/ui/components/ui/identicon/identicon.component.js
+++ b/ui/components/ui/identicon/identicon.component.js
@@ -72,9 +72,14 @@ export default class Identicon extends PureComponent {
     tokenList: {},
   };
 
+  state = {
+    isError: false,
+  };
+
   renderImage() {
     const { className, diameter, alt, imageBorder, ipfsGateway } = this.props;
     let { image } = this.props;
+    const { isError } = this.state;
 
     if (Array.isArray(image) && image.length) {
       image = image[0];
@@ -91,9 +96,11 @@ export default class Identicon extends PureComponent {
       <img
         className={classnames('identicon', className, {
           'identicon__image-border': imageBorder,
+          'identicon__image--error': isError,
         })}
         src={image}
         style={getStyles(diameter)}
+        onError={() => this.setState({ isError: true })}
         alt={alt}
       />
     );

--- a/ui/components/ui/identicon/identicon.component.js
+++ b/ui/components/ui/identicon/identicon.component.js
@@ -60,6 +60,7 @@ export default class Identicon extends PureComponent {
      * User preferred IPFS gateway
      */
     ipfsGateway: PropTypes.string,
+    tokenSymbol: PropTypes.string,
   };
 
   static defaultProps = {
@@ -71,6 +72,7 @@ export default class Identicon extends PureComponent {
     useBlockie: false,
     alt: '',
     tokenList: {},
+    tokenSymbol: undefined,
   };
 
   state = {
@@ -78,7 +80,14 @@ export default class Identicon extends PureComponent {
   };
 
   renderImage() {
-    const { className, diameter, alt, imageBorder, ipfsGateway } = this.props;
+    const {
+      className,
+      diameter,
+      alt,
+      imageBorder,
+      ipfsGateway,
+      tokenSymbol,
+    } = this.props;
     let { image } = this.props;
     const { isError } = this.state;
 
@@ -97,12 +106,11 @@ export default class Identicon extends PureComponent {
       return (
         <UrlIcon
           className={classnames('identicon', className, {
-            'identicon__image-border': imageBorder,
+            'identicon__image-border': imageBorder || isError,
             'identicon__image--error': isError,
           })}
-          icon={undefined}
-          name="David"
-          fallbackClassName="boo"
+          icon={null}
+          name={tokenSymbol}
         />
       );
     }
@@ -111,7 +119,6 @@ export default class Identicon extends PureComponent {
       <img
         className={classnames('identicon', className, {
           'identicon__image-border': imageBorder,
-          'identicon__image--error': isError,
         })}
         src={image}
         style={getStyles(diameter)}

--- a/ui/components/ui/identicon/identicon.component.js
+++ b/ui/components/ui/identicon/identicon.component.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import Jazzicon from '../jazzicon';
 import { getAssetImageURL } from '../../../helpers/utils/util';
+import UrlIcon from '../url-icon';
 import BlockieIdenticon from './blockieIdenticon';
 
 const getStyles = (diameter) => ({
@@ -90,6 +91,20 @@ export default class Identicon extends PureComponent {
       image.toLowerCase().startsWith('ipfs://')
     ) {
       image = getAssetImageURL(image, ipfsGateway);
+    }
+
+    if (isError) {
+      return (
+        <UrlIcon
+          className={classnames('identicon', className, {
+            'identicon__image-border': imageBorder,
+            'identicon__image--error': isError,
+          })}
+          icon={undefined}
+          name="David"
+          fallbackClassName="boo"
+        />
+      );
     }
 
     return (

--- a/ui/components/ui/identicon/index.scss
+++ b/ui/components/ui/identicon/index.scss
@@ -22,7 +22,3 @@
     background: var(--color-background-default);
   }
 }
-
-.identicon__image--error {
-  background: var(--black);
-}

--- a/ui/components/ui/identicon/index.scss
+++ b/ui/components/ui/identicon/index.scss
@@ -22,3 +22,7 @@
     background: var(--color-background-default);
   }
 }
+
+.identicon__image--error {
+  background: var(--black);
+}


### PR DESCRIPTION
This is sort of a conversation starter.  Right now, in Firefox, a broken identicon image shows the alt text, which looks kinda gross:

<img width="372" alt="boooo" src="https://user-images.githubusercontent.com/46655/152556912-0fef7837-2365-4b17-a8da-ce73cdc0ceee.png">


Instead we could do something like:
<img width="360" alt="Broken" src="https://user-images.githubusercontent.com/46655/152556483-699e6aec-3653-4510-bf84-b88f45a371c4.png">

Happy for design and others to weigh in!