### PR TITLE
Replace use of .flat with _.flatten, to accomodate our minimum chrome version (66)

### DIFF
--- a/app/scripts/lib/rpc-method-middleware/createMethodMiddleware.js
+++ b/app/scripts/lib/rpc-method-middleware/createMethodMiddleware.js
@@ -1,3 +1,4 @@
+import { flatten } from 'lodash';
 import { permissionRpcMethods } from '@metamask/snap-controllers';
 import { selectHooks } from '@metamask/rpc-methods';
 import { ethErrors } from 'eth-rpc-errors';
@@ -15,7 +16,7 @@ const handlerMap = allHandlers.reduce((map, handler) => {
 
 const expectedHookNames = Array.from(
   new Set(
-    allHandlers.map(({ hookNames }) => Object.keys(hookNames)).flat(),
+    flatten(allHandlers.map(({ hookNames }) => Object.keys(hookNames))),
   ).values(),
 );
 


### PR DESCRIPTION
As of v10.9.0 we started getting an error in sentry "u.map(...).flat is not a function"

This was coming from this line https://github.com/MetaMask/metamask-extension/blob/develop/app/scripts/lib/rpc-method-middleware/createMethodMiddleware.js#L18

The error is happening on versions of chrome that are lower than 69. This is because `Array.prototype.flat` wasn't supported until version 69. [Our minimum chrome version is currently 66,](https://github.com/MetaMask/metamask-extension/pull/11995) so we cannot use `.flat`.

This PR replaces it's usage with the `flatten` method from lodash