### PR TITLE
captureKeyringTypesWithMissingIdentities() when 'Missing identity for address' in permissions/specifications

### DIFF
--- a/app/scripts/controllers/permissions/specifications.js
+++ b/app/scripts/controllers/permissions/specifications.js
@@ -78,11 +78,15 @@ export const getCaveatSpecifications = ({ getIdentities }) => {
  * in the current MetaMask instance.
  * @param options.getIdentities - A function that returns the
  * `PreferencesController` identity objects for all Ethereum accounts in the
+ * @param options.captureKeyringTypesWithMissingIdentities - A function that
+ * captures extra error information about the "Missing identity for address"
+ * error.
  * current MetaMask instance.
  */
 export const getPermissionSpecifications = ({
   getAllAccounts,
   getIdentities,
+  captureKeyringTypesWithMissingIdentities,
 }) => {
   return {
     [PermissionKeys.eth_accounts]: {
@@ -119,8 +123,10 @@ export const getPermissionSpecifications = ({
 
         return accounts.sort((firstAddress, secondAddress) => {
           if (!identities[firstAddress]) {
+            captureKeyringTypesWithMissingIdentities(identities, accounts);
             throw new Error(`Missing identity for address: "${firstAddress}".`);
           } else if (!identities[secondAddress]) {
+            captureKeyringTypesWithMissingIdentities(identities, accounts);
             throw new Error(
               `Missing identity for address: "${secondAddress}".`,
             );

--- a/app/scripts/controllers/permissions/specifications.test.js
+++ b/app/scripts/controllers/permissions/specifications.test.js
@@ -247,6 +247,7 @@ describe('PermissionController specifications', () => {
           const { methodImplementation } = getPermissionSpecifications({
             getIdentities,
             getAllAccounts,
+            captureKeyringTypesWithMissingIdentities: jest.fn(),
           })[RestrictedMethods.eth_accounts];
 
           await expect(() => methodImplementation()).rejects.toThrow(
@@ -272,6 +273,7 @@ describe('PermissionController specifications', () => {
           const { methodImplementation } = getPermissionSpecifications({
             getIdentities,
             getAllAccounts,
+            captureKeyringTypesWithMissingIdentities: jest.fn(),
           })[RestrictedMethods.eth_accounts];
 
           await expect(() => methodImplementation()).rejects.toThrow(

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -505,6 +505,30 @@ export default class MetamaskController extends EventEmitter {
         getAllAccounts: this.keyringController.getAccounts.bind(
           this.keyringController,
         ),
+        captureKeyringTypesWithMissingIdentities: (
+          identities = {},
+          accounts = [],
+        ) => {
+          const accountsMissingIdentities = accounts.filter(
+            (address) => !identities[address],
+          );
+          const keyringTypesWithMissingIdentities = accountsMissingIdentities.map(
+            (address) =>
+              this.keyringController.getKeyringForAccount(address)?.type,
+          );
+
+          const identitiesCount = Object.keys(identities || {}).length;
+
+          const accountTrackerCount = Object.keys(
+            this.accountTracker.store.getState().accounts || {},
+          ).length;
+
+          captureException(
+            new Error(
+              `Attempt to get permission specifications failed because their were ${accounts.length} accounts, but ${identitiesCount} identities, and the ${keyringTypesWithMissingIdentities} keyrings included accounts with missing identities. Meanwhile, there are ${accountTrackerCount} accounts in the account tracker.`,
+            ),
+          );
+        },
       }),
       unrestrictedMethods,
     });


### PR DESCRIPTION
This is in response to https://sentry.io/organizations/metamask/issues/2979064019

Which throws the error `Missing identity for address:` from here https://github.com/MetaMask/metamask-extension/blob/develop/app/scripts/controllers/permissions/specifications.js#L122

It seems that somehow it is possible for their to be accounts in the keyring that are not in the `identities` object. After a few hours of investigation, I have not been able to determine the cause of this.

I am adding this PR so that we can gather more information about this error case. The information captured as a result of this PR may tell us some important things:
- whether or not the accounts that cannot be found in the identities object are hardware wallet accounts, HD wallet accounts or imported accounts
- whether the accounts are also missing from the `AccountTracker` state
- an indication as to whether the account isn't missing, but perhaps its address is formatted differently

This should help us narrow the search for the root cause.

Note that this PR is intentionally not capturing any addresses with the capture error.

