### PR TITLE
Fix connect permission bottom buttons overlap

### DIFF
--- a/ui/css/itcss/components/newui-sections.scss
+++ b/ui/css/itcss/components/newui-sections.scss
@@ -97,10 +97,6 @@ $sub-mid-size-breakpoint-range: "screen and (min-width: #{$break-large}) and (ma
     overflow-y: auto;
     background-color: var(--white);
   }
-
-  .main-container-wrapper {
-    flex: 1;
-  }
 }
 
 .fiat-amount {


### PR DESCRIPTION
Fixes: #13506 

Explanation:  Fix the bottom buttons overlaping with the account list on the permission screen.

Manual testing steps:  
  - Add ~15 accounts
  - Request connection to one of the accounts

Old buttons behavior :
![image](https://user-images.githubusercontent.com/13910212/152815608-c28d9ca8-cff5-48c0-a15d-8301ca333288.png)

New buttons behavior :
![image](https://user-images.githubusercontent.com/13910212/152815811-7b00a049-a979-494a-a4e8-c5aa7ee1cec8.png)
