### PR TITLE
Fix network edition error

### DIFF
--- a/ui/pages/settings/networks-tab/networks-form/networks-form.js
+++ b/ui/pages/settings/networks-tab/networks-form/networks-form.js
@@ -93,7 +93,7 @@ const NetworksForm = ({
     setRpcUrl(selectedNetwork.rpcUrl);
     setChainId(getDisplayChainId(selectedNetwork.chainId));
     setTicker(selectedNetwork?.ticker);
-    setBlockExplorerUrl(selectedNetwork?.blockExplorerUrl || '');
+    setBlockExplorerUrl(selectedNetwork?.blockExplorerUrl);
     setErrors({});
     setWarnings({});
     setIsSubmitting(false);

--- a/ui/pages/settings/networks-tab/networks-form/networks-form.js
+++ b/ui/pages/settings/networks-tab/networks-form/networks-form.js
@@ -93,7 +93,7 @@ const NetworksForm = ({
     setRpcUrl(selectedNetwork.rpcUrl);
     setChainId(getDisplayChainId(selectedNetwork.chainId));
     setTicker(selectedNetwork?.ticker);
-    setBlockExplorerUrl(selectedNetwork?.blockExplorerUrl);
+    setBlockExplorerUrl(selectedNetwork?.blockExplorerUrl || '');
     setErrors({});
     setWarnings({});
     setIsSubmitting(false);
@@ -483,7 +483,7 @@ const NetworksForm = ({
             networkName,
             {
               ...rpcPrefs,
-              blockExplorerUrl: blockExplorerUrl || rpcPrefs.blockExplorerUrl,
+              blockExplorerUrl: blockExplorerUrl || rpcPrefs?.blockExplorerUrl,
             },
           ),
         );


### PR DESCRIPTION
Fixes: #13515

Explanation:  Fix error that shows up when you try to edit a network with no block explorer

Manual testing steps:  
  - Add a new network without a block explorer
  - Try to edit the network (eg. change the RPC URL)
  - (optional) Look at the console