### PR TITLE
SendGasRow story : convert knobs and actions to controls/args

### DIFF
--- a/ui/pages/send/send-content/send-gas-row/README.mdx
+++ b/ui/pages/send/send-content/send-gas-row/README.mdx
@@ -1,0 +1,12 @@
+import { Story, Canvas, ArgsTable } from '@storybook/addon-docs';
+import SendGasRow from '.';
+
+# SendGasRow
+
+<Canvas>
+  <Story id="ui-pages-send-send-content-send-gas-row-send-gas-row-stories-js--default-story" />
+</Canvas>
+
+## Component API
+
+<ArgsTable of={SendGasRow} />

--- a/ui/pages/send/send-content/send-gas-row/send-gas-row.stories.js
+++ b/ui/pages/send/send-content/send-gas-row/send-gas-row.stories.js
@@ -2,13 +2,12 @@
 
 import React, { useEffect, useState } from 'react';
 import { Provider } from 'react-redux';
-import { boolean } from '@storybook/addon-knobs';
 import testData from '../../../../../.storybook/test-data';
-
+import { GAS_INPUT_MODES } from '../../../../ducks/send';
+import { updateMetamaskState } from '../../../../store/actions';
 import configureStore from '../../../../store/store';
 import { calcGasTotal } from '../../send.utils';
-import { updateMetamaskState } from '../../../../store/actions';
-import { GAS_INPUT_MODES } from '../../../../ducks/send';
+import README from './README.mdx';
 import SendGasRow from './send-gas-row.component';
 
 const store = configureStore(testData);
@@ -17,15 +16,25 @@ export default {
   title: 'Pages/Send/SendContent/SendGasRow',
   id: __filename,
   decorators: [(story) => <Provider store={store}>{story()}</Provider>],
+  parameters: {
+    docs: {
+      page: README,
+    },
+  },
+  argTypes: {
+    insufficientBalance: {
+      name: 'Is Insufficient Balance',
+      control: { type: 'boolean' },
+      defaultValue: false,
+    },
+  },
 };
 
-export const DefaultStory = () => {
+export const DefaultStory = (args) => {
   const state = store.getState();
   const { metamask } = state;
   const { send } = metamask;
   const [sendState, setSendState] = useState(send);
-
-  const insufficientBalance = boolean('Is Insufficient Balance', false);
 
   useEffect(() => {
     const newState = Object.assign(metamask, {
@@ -65,7 +74,7 @@ export const DefaultStory = () => {
   return (
     <div style={{ width: 500 }}>
       <SendGasRow
-        insufficientBalance={insufficientBalance}
+        {...args}
         updateGasPrice={updateGasPrice}
         updateGasLimit={updateGasLimit}
         gasPrice={send.gasPrice}
@@ -76,4 +85,4 @@ export const DefaultStory = () => {
   );
 };
 
-DefaultStory.storyName = 'Default';
+DefaultStory.storyName = 'SendGasRow';


### PR DESCRIPTION
Fixes: #13078

Explanation: Convert SendGasRow story in Pages/Send/SendContent/SendGasRow/send-gas-row.stories.js to use controls and action argType annotation

- [x] Add README.MDX
- [x] Story has argTypes that align with component api / props
- [x] All instances of @storybook/addon-knobs have been removed in favour of control args
- [x] All instances of @storybook/addon-actions have been removed in favour of action argType annotation

<img width="1427" alt="image" src="https://user-images.githubusercontent.com/20949060/152973712-fca6daeb-f27f-4be4-bd80-1d1bd82d58e2.png">
