### PR TITLE
[BUILD FIX #12920] Updated style for full screen mode in settings page

### DIFF
--- a/test/e2e/tests/send-eth.spec.js
+++ b/test/e2e/tests/send-eth.spec.js
@@ -187,7 +187,7 @@ describe('Send ETH from dapp using advanced gas controls', function () {
         // goes to the settings screen
         await driver.clickElement('.account-menu__icon');
         await driver.clickElement({ text: 'Settings', tag: 'div' });
-        await driver.clickElement({ text: 'Advanced', tag: 'h4' });
+        await driver.clickElement({ text: 'Advanced', tag: 'div' });
         await driver.clickElement(
           '[data-testid="advanced-setting-show-testnet-conversion"] .settings-page__content-item-col > div > div',
         );

--- a/test/e2e/tests/threebox.spec.js
+++ b/test/e2e/tests/threebox.spec.js
@@ -37,20 +37,20 @@ describe('Threebox', function () {
         await driver.clickElement({ text: 'Settings', tag: 'div' });
 
         // turns on threebox syncing
-        await driver.clickElement({ text: 'Advanced', tag: 'h4' });
+        await driver.clickElement({ text: 'Advanced', tag: 'div' });
         await driver.clickElement(
           '[data-testid="advanced-setting-3box"] .toggle-button div',
         );
 
         // updates settings and address book
         // navigates to General settings
-        await driver.clickElement({ text: 'General', tag: 'h4' });
+        await driver.clickElement({ text: 'General', tag: 'div' });
 
         // turns on use of blockies
         await driver.clickElement('.toggle-button > div');
 
         // adds an address to the contact list
-        await driver.clickElement({ text: 'Contacts', tag: 'h4' });
+        await driver.clickElement({ text: 'Contacts', tag: 'div' });
 
         await driver.clickElement('.address-book__link');
         await driver.fill('#nickname', 'Test User Name 11');
@@ -89,7 +89,7 @@ describe('Threebox', function () {
         assert.equal(toggleLabelText, 'ON');
 
         // finds the restored address in the contact list
-        await driver.clickElement({ text: 'Contacts', tag: 'h4' });
+        await driver.clickElement({ text: 'Contacts', tag: 'div' });
         await driver.findElement({ text: 'Test User Name 11', tag: 'div' });
       },
     );

--- a/ui/components/app/tab-bar/index.scss
+++ b/ui/components/app/tab-bar/index.scss
@@ -36,12 +36,20 @@
     }
 
     &__content {
-      padding: 16px;
+      padding: 12px 18px;
       display: flex;
       flex-flow: row wrap;
       align-items: center;
       position: relative;
       z-index: 201;
+
+      &__title {
+        @include H4;
+
+        @media screen and (min-width: $break-large) {
+          @include H6;
+        }
+      }
 
       &__description {
         display: none;

--- a/ui/components/app/tab-bar/tab-bar.js
+++ b/ui/components/app/tab-bar/tab-bar.js
@@ -1,8 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
-import Typography from '../../ui/typography/typography';
-import { TYPOGRAPHY } from '../../../helpers/constants/design-system';
 
 const TabBar = (props) => {
   const { tabs = [], onSelect, isActive } = props;
@@ -19,7 +17,7 @@ const TabBar = (props) => {
         >
           <div className="tab-bar__tab__content">
             <div className="tab-bar__tab__content__icon">{icon}</div>
-            <Typography variant={TYPOGRAPHY.H4}>{content}</Typography>
+            <div className="tab-bar__tab__content__title">{content}</div>
           </div>
           <div className="tab-bar__tab__caret" />
         </button>

--- a/ui/pages/settings/index.scss
+++ b/ui/pages/settings/index.scss
@@ -133,13 +133,13 @@
 
       @media screen and (min-width: $break-large) {
         flex: 0 0 40%;
-        min-width: 264px;
+        max-width: 197px;
         padding-top: 8px;
       }
 
       .tab-bar__tab {
         @media screen and (min-width: $break-large) {
-          padding: 16px 24px 0;
+          max-height: 50px;
         }
       }
     }

--- a/ui/pages/settings/index.scss
+++ b/ui/pages/settings/index.scss
@@ -134,7 +134,7 @@
       @media screen and (min-width: $break-large) {
         flex: 0 0 40%;
         max-width: 197px;
-        padding-top: 8px;
+        padding-top: 13px;
       }
 
       .tab-bar__tab {


### PR DESCRIPTION
Fixes: #12761

Explanation:  We discovered that current design is not up to date with Figma and this PR fixes it.
It is related to this issue https://github.com/MetaMask/metamask-extension/issues/12761 and PR: https://github.com/MetaMask/metamask-extension/pull/12920
Updated version:
<img width="1067" alt="Screenshot 2022-02-09 at 15 06 13" src="https://user-images.githubusercontent.com/92531782/153217544-e33d2249-639c-48e1-b508-3dbca60c7e39.png">




Current version: 
![Screenshot 2022-02-09 at 14 22 24](https://user-images.githubusercontent.com/92531782/153210083-99619adf-f9dc-457b-8b5c-2fce6e9f4fda.png)

