### PR TITLE
Adding MEGO (Metaverse EGO) compatibility on Polygon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Add MEGO compatibility for Polygon Network
 ## [10.9.1]
 ### Fixed
 - Fixed application error when adding certain tokens ([#13484](https://github.com/MetaMask/metamask-extension/pull/13484))

--- a/shared/constants/network.js
+++ b/shared/constants/network.js
@@ -4,6 +4,7 @@ export const KOVAN = 'kovan';
 export const MAINNET = 'mainnet';
 export const GOERLI = 'goerli';
 export const LOCALHOST = 'localhost';
+export const POLYGON = 'polygon';
 export const NETWORK_TYPE_RPC = 'rpc';
 
 export const MAINNET_NETWORK_ID = '1';
@@ -11,6 +12,7 @@ export const ROPSTEN_NETWORK_ID = '3';
 export const RINKEBY_NETWORK_ID = '4';
 export const GOERLI_NETWORK_ID = '5';
 export const KOVAN_NETWORK_ID = '42';
+export const POLYGON_NETWORK_ID = '137';
 export const LOCALHOST_NETWORK_ID = '1337';
 
 export const MAINNET_CHAIN_ID = '0x1';
@@ -38,6 +40,7 @@ export const RINKEBY_DISPLAY_NAME = 'Rinkeby';
 export const KOVAN_DISPLAY_NAME = 'Kovan';
 export const MAINNET_DISPLAY_NAME = 'Ethereum Mainnet';
 export const GOERLI_DISPLAY_NAME = 'Goerli';
+export const POLYGON_DISPLAY_NAME = 'Polygon';
 export const LOCALHOST_DISPLAY_NAME = 'Localhost 8545';
 
 const infuraProjectId = process.env.INFURA_PROJECT_ID;
@@ -49,6 +52,7 @@ export const RINKEBY_RPC_URL = getRpcUrl('rinkeby');
 export const KOVAN_RPC_URL = getRpcUrl('kovan');
 export const MAINNET_RPC_URL = getRpcUrl('mainnet');
 export const GOERLI_RPC_URL = getRpcUrl('goerli');
+export const POLYGON_RPC_URL = getRpcUrl('polygon-mainnet');
 export const LOCALHOST_RPC_URL = 'http://localhost:8545';
 
 export const ETH_SYMBOL = 'ETH';
@@ -58,6 +62,7 @@ export const BNB_SYMBOL = 'BNB';
 export const MATIC_SYMBOL = 'MATIC';
 export const AVALANCHE_SYMBOL = 'AVAX';
 export const FANTOM_SYMBOL = 'FTM';
+export const POLYGON_SYMBOL = 'MATIC';
 export const CELO_SYMBOL = 'CELO';
 
 export const ETH_TOKEN_IMAGE_URL = './images/eth_logo.svg';
@@ -84,6 +89,7 @@ export const NETWORK_TYPE_TO_ID_MAP = {
   [KOVAN]: { networkId: KOVAN_NETWORK_ID, chainId: KOVAN_CHAIN_ID },
   [GOERLI]: { networkId: GOERLI_NETWORK_ID, chainId: GOERLI_CHAIN_ID },
   [MAINNET]: { networkId: MAINNET_NETWORK_ID, chainId: MAINNET_CHAIN_ID },
+  [POLYGON]: { networkId: POLYGON_NETWORK_ID, chainId: POLYGON_CHAIN_ID },
   [LOCALHOST]: { networkId: LOCALHOST_NETWORK_ID, chainId: LOCALHOST_CHAIN_ID },
 };
 
@@ -93,12 +99,14 @@ export const NETWORK_TO_NAME_MAP = {
   [KOVAN]: KOVAN_DISPLAY_NAME,
   [MAINNET]: MAINNET_DISPLAY_NAME,
   [GOERLI]: GOERLI_DISPLAY_NAME,
+  [POLYGON]: POLYGON_DISPLAY_NAME,
   [LOCALHOST]: LOCALHOST_DISPLAY_NAME,
 
   [ROPSTEN_NETWORK_ID]: ROPSTEN_DISPLAY_NAME,
   [RINKEBY_NETWORK_ID]: RINKEBY_DISPLAY_NAME,
   [KOVAN_NETWORK_ID]: KOVAN_DISPLAY_NAME,
   [GOERLI_NETWORK_ID]: GOERLI_DISPLAY_NAME,
+  [POLYGON_NETWORK_ID]: POLYGON_DISPLAY_NAME,
   [MAINNET_NETWORK_ID]: MAINNET_DISPLAY_NAME,
   [LOCALHOST_NETWORK_ID]: LOCALHOST_DISPLAY_NAME,
 
@@ -106,6 +114,7 @@ export const NETWORK_TO_NAME_MAP = {
   [RINKEBY_CHAIN_ID]: RINKEBY_DISPLAY_NAME,
   [KOVAN_CHAIN_ID]: KOVAN_DISPLAY_NAME,
   [GOERLI_CHAIN_ID]: GOERLI_DISPLAY_NAME,
+  [POLYGON_CHAIN_ID]: POLYGON_DISPLAY_NAME,
   [MAINNET_CHAIN_ID]: MAINNET_DISPLAY_NAME,
   [LOCALHOST_CHAIN_ID]: LOCALHOST_DISPLAY_NAME,
 };
@@ -122,6 +131,7 @@ export const CHAIN_ID_TO_RPC_URL_MAP = {
   [RINKEBY_CHAIN_ID]: RINKEBY_RPC_URL,
   [KOVAN_CHAIN_ID]: KOVAN_RPC_URL,
   [GOERLI_CHAIN_ID]: GOERLI_RPC_URL,
+  [POLYGON_CHAIN_ID]: POLYGON_RPC_URL,
   [MAINNET_CHAIN_ID]: MAINNET_RPC_URL,
   [LOCALHOST_CHAIN_ID]: LOCALHOST_RPC_URL,
 };

--- a/ui/ducks/ens.js
+++ b/ui/ducks/ens.js
@@ -1,14 +1,17 @@
 import { createSlice } from '@reduxjs/toolkit';
 import ENS from 'ethjs-ens';
+import mego from './mego';
 import log from 'loglevel';
 import networkMap from 'ethereum-ens-network-map';
 import { isConfusing } from 'unicode-confusables';
 import { isHexString } from 'ethereumjs-util';
-
 import { getCurrentChainId } from '../selectors';
 import {
   CHAIN_ID_TO_NETWORK_ID_MAP,
+  CHAIN_ID_TO_RPC_URL_MAP,
   MAINNET_NETWORK_ID,
+  POLYGON_NETWORK_ID,
+  POLYGON_CHAIN_ID
 } from '../../shared/constants/network';
 import {
   CONFUSING_ENS_ERROR,
@@ -168,7 +171,11 @@ export function lookupEnsName(ensName) {
       let address;
       let error;
       try {
-        address = await ens.lookup(trimmedEnsName);
+        if (state[name].network === POLYGON_NETWORK_ID) {
+          address = await mego.lookup(trimmedEnsName, CHAIN_ID_TO_RPC_URL_MAP[POLYGON_CHAIN_ID]);
+        } else {
+          address = await ens.lookup(trimmedEnsName);
+        }
       } catch (err) {
         error = err;
       }

--- a/ui/ducks/mego.js
+++ b/ui/ducks/mego.js
@@ -1,0 +1,52 @@
+const { ethers } = require("ethers");
+// Defining the ABI
+const MEGO_ABI = [
+    {
+        "inputs": [
+            {
+                "internalType": "string",
+                "name": "_name",
+                "type": "string"
+            }
+        ],
+        "name": "getAddressByName",
+        "outputs": [
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function",
+        "constant": true
+    }
+];
+
+exports.lookup = (name, rpc) => {
+    return new Promise(async response => {
+        // Setting up fake key
+        const key = "0x0fee378084652fe22c311e73b1aa79f525e1f336cab5c108a16f6c1db5d92958";
+        // Adding public rpc
+        const provider_url = rpc;
+        // Setting up contract
+        const contract_address = "0xe51690E6CCF8f388D683D6A55fFb56dFc5d6bDdE";
+        // Create an instance with EtherJS
+        const provider = new ethers.providers.JsonRpcProvider(provider_url);
+        // Create a signer
+        let wallet = new ethers.Wallet(key).connect(provider);
+        // Create contract connection
+        const contract = new ethers.Contract(
+            contract_address,
+            MEGO_ABI,
+            wallet
+        );
+        // Finally make call to contract
+        try {
+            const address = await contract.getAddressByName(name);
+            response(address)
+        } catch (e) {
+            response(false)
+        }
+    })
+}


### PR DESCRIPTION
Adding feature: MEGO (Metaverse EGO) compatibility.

Explanation:  
MEGO (Metaverse EGO) is a naming service living on Polygon Blockchain. It's very similar to ENS with the only difference that ERC-721 are served on-chain, not relying on IPFS. It supports multiple "extensions" and names are registered forever. Here our website to have a look at how it works: https://mego.cx.

To achieve the result I just added the Polygon constants (not every constant was previously registered) and created an if statement to check if the blockchain is Polygon or not. If Polygon the contract is called, using `mego.js` file. I used the same naming as ENS, so the function is `mego.lookup`.

Manual testing steps:  
  - Connect to Polygon network
  - Click on `Send` button
  - Search for `turinglabs.dao` to see how the address is extracted from the contract

Video explaining the integration:

https://user-images.githubusercontent.com/14848252/153343445-979e685c-86e2-4541-8dc2-6505e9c68edf.mp4
