### PR TITLE
Adding check for transaction.id in useTransactionEventFragment hook

### DIFF
--- a/ui/hooks/useTransactionEventFragment.js
+++ b/ui/hooks/useTransactionEventFragment.js
@@ -1,4 +1,4 @@
-import { useCallback, useEffect } from 'react';
+import { useCallback } from 'react';
 import { useSelector } from 'react-redux';
 
 import { useGasFeeContext } from '../contexts/gasFee';
@@ -18,23 +18,20 @@ export const useTransactionEventFragment = () => {
     }),
   );
 
-  useEffect(() => {
-    if (!fragment && transaction) {
-      createTransactionEventFragment(
-        transaction.id,
-        TRANSACTION_EVENTS.APPROVED,
-      );
-    }
-  }, [fragment, transaction]);
-
   const updateTransactionEventFragment = useCallback(
-    (params) => {
-      if (!transaction) {
+    async (params) => {
+      if (!transaction || !transaction.id) {
         return;
+      }
+      if (!fragment) {
+        await createTransactionEventFragment(
+          transaction.id,
+          TRANSACTION_EVENTS.APPROVED,
+        );
       }
       updateEventFragment(`transaction-added-${transaction.id}`, params);
     },
-    [transaction],
+    [fragment, transaction],
   );
 
   return {


### PR DESCRIPTION
PR addresses issue-4 detailed here: https://docs.google.com/document/d/1i2xw4U8qJSf9v_MbzBtH154F9_DYbR-4nR79CCAWhHI/edit

Reason of the issue is that as part of 1559 V2 we have added more metrics event capturing to transaction flow, swap transaction on transaction confirmation page still does not have a transaction_id which was causing this exception.