### PR TITLE
Include transactions from all networks in state logs

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -1325,6 +1325,7 @@ export default class MetamaskController extends EventEmitter {
       createTransactionEventFragment: txController.createTransactionEventFragment.bind(
         txController,
       ),
+      getTransactions: txController.getTransactions.bind(txController),
 
       // messageManager
       signMessage: this.signMessage.bind(this),

--- a/ui/index.js
+++ b/ui/index.js
@@ -184,7 +184,6 @@ function maskObject(object, mask) {
 
 function setupDebuggingHelpers(store) {
   window.getCleanAppState = async function () {
-    console.log(store.getState());
     const state = clone(store.getState());
     state.version = global.platform.getVersion();
     state.browser = window.navigator.userAgent;

--- a/ui/index.js
+++ b/ui/index.js
@@ -183,10 +183,14 @@ function maskObject(object, mask) {
 }
 
 function setupDebuggingHelpers(store) {
-  window.getCleanAppState = function () {
+  window.getCleanAppState = async function () {
+    console.log(store.getState());
     const state = clone(store.getState());
     state.version = global.platform.getVersion();
     state.browser = window.navigator.userAgent;
+    state.completeTxList = await actions.getTransactions({
+      filterToCurrentNetwork: false,
+    });
     return state;
   };
   window.getSentryState = function () {
@@ -200,8 +204,8 @@ function setupDebuggingHelpers(store) {
   };
 }
 
-window.logStateString = function (cb) {
-  const state = window.getCleanAppState();
+window.logStateString = async function (cb) {
+  const state = await window.getCleanAppState();
   global.platform.getPlatformInfo((err, platform) => {
     if (err) {
       cb(err);

--- a/ui/store/actions.js
+++ b/ui/store/actions.js
@@ -751,6 +751,10 @@ export function updateAndApproveTx(txData, dontShowLoadingIndicator) {
   };
 }
 
+export async function getTransactions(filters = {}) {
+  return await promisifiedBackground.getTransactions(filters);
+}
+
 export function completedTx(id) {
   return (dispatch, getState) => {
     const state = getState();


### PR DESCRIPTION
Fixes: #13548 

Explanation:  Adding a new property `completeTxList` to the state log, which holds the list of all transactions done by the user irrespective of chainId.

Manual testing steps:  
  - Open the Extension application; right-click and select inspect.
  - In the console, type in `copy(await logState(true))` to copy the state log to clipboard.
  - Search for `completeTxList` and verify all your transactions are present on the list irrespective of the chainId.