### PR TITLE
Only use advancedGasFeeDefaultValues as backup defaults if gasFees are not already set

### DIFF
--- a/app/scripts/controllers/transactions/index.js
+++ b/app/scripts/controllers/transactions/index.js
@@ -443,21 +443,7 @@ export default class TransactionController extends EventEmitter {
 
     if (eip1559Compatibility) {
       const { eip1559V2Enabled } = this.preferencesStore.getState();
-      const advancedGasFeeDefaultValues = this.getAdvancedGasFee();
       if (
-        eip1559V2Enabled &&
-        Boolean(advancedGasFeeDefaultValues) &&
-        !txMeta.txParams.maxFeePerGas &&
-        !txMeta.txParams.maxPriorityFeePerGas
-      ) {
-        txMeta.userFeeLevel = CUSTOM_GAS_ESTIMATE;
-        txMeta.txParams.maxFeePerGas = decGWEIToHexWEI(
-          advancedGasFeeDefaultValues.maxBaseFee,
-        );
-        txMeta.txParams.maxPriorityFeePerGas = decGWEIToHexWEI(
-          advancedGasFeeDefaultValues.priorityFee,
-        );
-      } else if (
         txMeta.txParams.gasPrice &&
         !txMeta.txParams.maxFeePerGas &&
         !txMeta.txParams.maxPriorityFeePerGas
@@ -473,14 +459,13 @@ export default class TransactionController extends EventEmitter {
         }
       } else {
         if (
-          (defaultMaxFeePerGas &&
-            defaultMaxPriorityFeePerGas &&
-            !txMeta.txParams.maxFeePerGas &&
-            !txMeta.txParams.maxPriorityFeePerGas) ||
-          txMeta.origin === 'metamask'
+          defaultMaxFeePerGas &&
+          defaultMaxPriorityFeePerGas &&
+          !txMeta.txParams.maxFeePerGas &&
+          !txMeta.txParams.maxPriorityFeePerGas
         ) {
           txMeta.userFeeLevel = GAS_RECOMMENDATIONS.MEDIUM;
-        } else if (eip1559V2Enabled) {
+        } else if (eip1559V2Enabled && txMeta.origin !== 'metamask') {
           txMeta.userFeeLevel = PRIORITY_LEVELS.DAPP_SUGGESTED;
         } else {
           txMeta.userFeeLevel = CUSTOM_GAS_ESTIMATE;

--- a/app/scripts/controllers/transactions/index.js
+++ b/app/scripts/controllers/transactions/index.js
@@ -444,7 +444,12 @@ export default class TransactionController extends EventEmitter {
     if (eip1559Compatibility) {
       const { eip1559V2Enabled } = this.preferencesStore.getState();
       const advancedGasFeeDefaultValues = this.getAdvancedGasFee();
-      if (eip1559V2Enabled && Boolean(advancedGasFeeDefaultValues)) {
+      if (
+        eip1559V2Enabled &&
+        Boolean(advancedGasFeeDefaultValues) &&
+        !txMeta.txParams.maxFeePerGas &&
+        !txMeta.txParams.maxPriorityFeePerGas
+      ) {
         txMeta.userFeeLevel = CUSTOM_GAS_ESTIMATE;
         txMeta.txParams.maxFeePerGas = decGWEIToHexWEI(
           advancedGasFeeDefaultValues.maxBaseFee,


### PR DESCRIPTION
Fixes: number 6 [10.10.0 RC bugs document](https://docs.google.com/document/d/1i2xw4U8qJSf9v_MbzBtH154F9_DYbR-4nR79CCAWhHI/edit)

Explanation:  We should not overwrite the `maxBaseFee` and `priorityFee` txParams just because `eip1559V2Enabled` === `true` and `Boolean(advancedGasFeeDefaultValues)` === `true`. We should only do so if `maxBaseFee` and `priorityFee` are not already set on the `txParams` object.

**Manual testing steps:**  
1. Settings -> Experimental -> Enable Enhanced Gas Fee UI
2. Setup default gas values in the send flow
3. Click Send, Select a contact, enter an amount, click Next
4. Click Edit gas fee button, click Advanced, enter gas values, check Advanced setting as default, Click Save
5. Reject the transaction to go back to the overview page
6. Click Swap, enter from amount, Select Swap to Uni, Click Review Swap
7. Click Edit gas fee button, hover over the Swap suggested tooltip to confirm gas values
Click Swap, click view swap at etherscan…

You should see that the Transaction is submitted correctly with Swap suggested gas fee values
