### PR TITLE
Add native browser notification support for Snaps

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -2362,6 +2362,10 @@
     "message": "Store and manage its data on your device.",
     "description": "The description for the `snap_manageState` permission"
   },
+  "permission_notifications": {
+    "message": "Show notifications.",
+    "description": "The description for the `snap_notify` permission"
+  },
   "permission_unknown": {
     "message": "Unknown permission: $1",
     "description": "$1 is the name of a requested permission that is not recognized."

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -1033,14 +1033,10 @@ export default class MetamaskController extends EventEmitter {
             type: MESSAGE_TYPE.SNAP_CONFIRM,
             requestData: confirmationData,
           }),
-        showNotification: (origin, args) => {
-          const snap = this.snapController.get(origin);
-          this.platform._showNotification(
-            snap.manifest.proposedName,
-            args.message,
-          );
-          return true;
-        },
+        showNotification: this.controllerMessenger.call.bind(
+          this.controllerMessenger,
+          'NotificationControllerV2:show',
+        ),
         updateSnapState: this.controllerMessenger.call.bind(
           this.controllerMessenger,
           'SnapController:updateSnapState',

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -1033,6 +1033,14 @@ export default class MetamaskController extends EventEmitter {
             type: MESSAGE_TYPE.SNAP_CONFIRM,
             requestData: confirmationData,
           }),
+        showNotification: (origin, args) => {
+          const snap = this.snapController.get(origin);
+          this.platform._showNotification(
+            snap.manifest.proposedName,
+            args.message,
+          );
+          return true;
+        },
         updateSnapState: this.controllerMessenger.call.bind(
           this.controllerMessenger,
           'SnapController:updateSnapState',

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -40,6 +40,9 @@ import {
   CollectibleDetectionController,
   PermissionController,
   SubjectMetadataController,
+  ///: BEGIN:ONLY_INCLUDE_IN(flask)
+  RateLimitController,
+  ///: END:ONLY_INCLUDE_IN
 } from '@metamask/controllers';
 import SmartTransactionsController from '@metamask/smart-transactions-controller';
 ///: BEGIN:ONLY_INCLUDE_IN(flask)

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -654,6 +654,7 @@ export default class MetamaskController extends EventEmitter {
             originMetadata?.name ?? origin,
             message,
           );
+          return null;
         },
       },
     });
@@ -1057,10 +1058,12 @@ export default class MetamaskController extends EventEmitter {
             requestData: confirmationData,
           }),
         showNotification: (origin, args) =>
-          this.controllerMessenger.call.bind(
-            this.controllerMessenger,
+          this.controllerMessenger.call(
             'RateLimitController:call',
-            { type: 'showNativeNotification', args: [origin, args[1]] },
+            origin,
+            'showNativeNotification',
+            origin,
+            args.message,
           ),
         updateSnapState: this.controllerMessenger.call.bind(
           this.controllerMessenger,

--- a/shared/constants/permissions.js
+++ b/shared/constants/permissions.js
@@ -6,6 +6,7 @@ export const RestrictedMethods = Object.freeze({
   eth_accounts: 'eth_accounts',
   ///: BEGIN:ONLY_INCLUDE_IN(flask)
   snap_confirm: 'snap_confirm',
+  snap_notify: 'snap_notify',
   snap_manageState: 'snap_manageState',
   'snap_getBip44Entropy_*': 'snap_getBip44Entropy_*',
   'wallet_snap_*': 'wallet_snap_*',

--- a/shared/constants/permissions.js
+++ b/shared/constants/permissions.js
@@ -24,5 +24,5 @@ export const EndowmentPermissions = Object.freeze({
 });
 
 // Methods / permissions in external packages that we are temporarily excluding.
-export const ExcludedSnapPermissions = new Set(['snap_notify']);
+export const ExcludedSnapPermissions = new Set([]);
 ///: END:ONLY_INCLUDE_IN

--- a/ui/helpers/utils/permission.js
+++ b/ui/helpers/utils/permission.js
@@ -24,6 +24,11 @@ const PERMISSION_DESCRIPTIONS = deepFreeze({
     leftIcon: 'fas fa-user-check',
     rightIcon: null,
   },
+  [RestrictedMethods.snap_notify]: {
+    leftIcon: 'fas fa-bell',
+    label: (t) => t('permission_notifications'),
+    rightIcon: null,
+  },
   [RestrictedMethods['snap_getBip44Entropy_*']]: {
     label: (t, permissionName) => {
       const coinType = permissionName.split('_').slice(-1);


### PR DESCRIPTION
Fixes: https://github.com/MetaMask/snaps-skunkworks/issues/274

Explanation: 

Adds support for Snaps showing native browser support.
- Adds `snap_notify` permission
- Adds `showNotification` Snap hook
- Adds RateLimitController and uses it for showing notifications

Manual testing steps:  
  - Clone the skunkworks repo and use the following branch: https://github.com/MetaMask/snaps-skunkworks/pull/248
  - Change directory to the notification example snap
  - Run `yarn build && yarn serve`
  - Visit `localhost:8080`
  - Hit Connect
  - Validate that the connect/install flow looks fine
  - Hit "Send Hello"
  - Validate that a browser notification shows up
    - You can use them a few times, but might get automatically rate-limited by the browser at times