### PR TITLE
Fix: advance defaults should never be used for swaps

### DIFF
--- a/app/scripts/controllers/transactions/index.js
+++ b/app/scripts/controllers/transactions/index.js
@@ -55,6 +55,11 @@ const hstInterface = new ethers.utils.Interface(abi);
 
 const MAX_MEMSTORE_TX_LIST_SIZE = 100; // Number of transactions (by unique nonces) to keep in memory
 
+const SWAP_TRANSACTION_TYPES = [
+  TRANSACTION_TYPES.SWAP,
+  TRANSACTION_TYPES.SWAP_APPROVAL,
+];
+
 /**
  * @typedef {import('../../../../shared/constants/transaction').TransactionMeta} TransactionMeta
  * @typedef {import('../../../../shared/constants/transaction').TransactionMetaMetricsEventString} TransactionMetaMetricsEventString
@@ -341,13 +346,9 @@ export default class TransactionController extends EventEmitter {
    * @returns {txMeta}
    */
   async addUnapprovedTransaction(txParams, origin, transactionType) {
-    const allowedTransactionTypes = [
-      TRANSACTION_TYPES.SWAP,
-      TRANSACTION_TYPES.SWAP_APPROVAL,
-    ];
     if (
       transactionType !== undefined &&
-      !allowedTransactionTypes.includes(transactionType)
+      !SWAP_TRANSACTION_TYPES.includes(transactionType)
     ) {
       throw new Error(
         `TransactionController - invalid transactionType value: ${transactionType}`,
@@ -461,8 +462,7 @@ export default class TransactionController extends EventEmitter {
       if (
         eip1559V2Enabled &&
         Boolean(advancedGasFeeDefaultValues) &&
-        txMeta.type !== TRANSACTION_TYPES.SWAP &&
-        txMeta.type !== TRANSACTION_TYPES.SWAP_APPROVAL
+        !SWAP_TRANSACTION_TYPES.includes(transactionType)
       ) {
         txMeta.userFeeLevel = CUSTOM_GAS_ESTIMATE;
         txMeta.txParams.maxFeePerGas = decGWEIToHexWEI(

--- a/app/scripts/controllers/transactions/index.js
+++ b/app/scripts/controllers/transactions/index.js
@@ -341,15 +341,19 @@ export default class TransactionController extends EventEmitter {
    * @returns {txMeta}
    */
   async addUnapprovedTransaction(txParams, origin, transactionType) {
+    const allowedTransactionTypes = [
+      TRANSACTION_TYPES.SWAP,
+      TRANSACTION_TYPES.SWAP_APPROVAL,
+    ];
     if (
       transactionType !== undefined &&
-      transactionType !== TRANSACTION_TYPES.SWAP &&
-      transactionType !== TRANSACTION_TYPES.SWAP_APPROVAL
+      !allowedTransactionTypes.includes(transactionType)
     ) {
       throw new Error(
         `TransactionController - invalid transactionType value: ${transactionType}`,
       );
     }
+
     // validate
     const normalizedTxParams = txUtils.normalizeTxParams(txParams);
     const eip1559Compatibility = await this.getEIP1559Compatibility();

--- a/app/scripts/controllers/transactions/index.js
+++ b/app/scripts/controllers/transactions/index.js
@@ -462,7 +462,7 @@ export default class TransactionController extends EventEmitter {
       if (
         eip1559V2Enabled &&
         Boolean(advancedGasFeeDefaultValues) &&
-        !SWAP_TRANSACTION_TYPES.includes(transactionType)
+        !SWAP_TRANSACTION_TYPES.includes(txMeta.type)
       ) {
         txMeta.userFeeLevel = CUSTOM_GAS_ESTIMATE;
         txMeta.txParams.maxFeePerGas = decGWEIToHexWEI(

--- a/ui/components/app/advanced-gas-fee-popover/advanced-gas-fee-defaults/advanced-gas-fee-defaults.js
+++ b/ui/components/app/advanced-gas-fee-popover/advanced-gas-fee-defaults/advanced-gas-fee-defaults.js
@@ -23,7 +23,7 @@ const AdvancedGasFeeDefaults = () => {
   const t = useI18nContext();
   const dispatch = useDispatch();
   const {
-    hasErrors,
+    gasErrors,
     maxBaseFee,
     maxPriorityFeePerGas,
   } = useAdvancedGasFeePopoverContext();
@@ -86,7 +86,7 @@ const AdvancedGasFeeDefaults = () => {
           checked={isDefaultSettingsSelected}
           className="advanced-gas-fee-defaults__checkbox"
           onClick={handleUpdateDefaultSettings}
-          disabled={hasErrors}
+          disabled={gasErrors.maxFeePerGas || gasErrors.maxPriorityFeePerGas}
         />
         <Typography variant={TYPOGRAPHY.H7} color={COLORS.UI4} margin={0}>
           {isDefaultSettingsSelected

--- a/ui/components/app/advanced-gas-fee-popover/advanced-gas-fee-inputs/base-fee-input/base-fee-input.js
+++ b/ui/components/app/advanced-gas-fee-popover/advanced-gas-fee-inputs/base-fee-input/base-fee-input.js
@@ -2,7 +2,10 @@ import React, { useCallback, useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 
 import { HIGH_FEE_WARNING_MULTIPLIER } from '../../../../../pages/send/send.constants';
-import { PRIORITY_LEVELS } from '../../../../../../shared/constants/gas';
+import {
+  EDIT_GAS_MODES,
+  PRIORITY_LEVELS,
+} from '../../../../../../shared/constants/gas';
 import { SECONDARY } from '../../../../../helpers/constants/common';
 import {
   bnGreaterThan,
@@ -47,7 +50,12 @@ const validateBaseFee = (value, gasFeeEstimates, maxPriorityFeePerGas) => {
 const BaseFeeInput = () => {
   const t = useI18nContext();
 
-  const { gasFeeEstimates, estimateUsed, maxFeePerGas } = useGasFeeContext();
+  const {
+    gasFeeEstimates,
+    estimateUsed,
+    maxFeePerGas,
+    editGasMode,
+  } = useGasFeeContext();
   const {
     maxPriorityFeePerGas,
     setErrorValue,
@@ -68,7 +76,8 @@ const BaseFeeInput = () => {
   const [baseFee, setBaseFee] = useState(() => {
     if (
       estimateUsed !== PRIORITY_LEVELS.CUSTOM &&
-      advancedGasFeeValues?.maxBaseFee
+      advancedGasFeeValues?.maxBaseFee &&
+      editGasMode !== EDIT_GAS_MODES.SWAPS
     ) {
       return advancedGasFeeValues.maxBaseFee;
     }

--- a/ui/components/app/advanced-gas-fee-popover/advanced-gas-fee-inputs/base-fee-input/base-fee-input.test.js
+++ b/ui/components/app/advanced-gas-fee-popover/advanced-gas-fee-inputs/base-fee-input/base-fee-input.test.js
@@ -1,7 +1,10 @@
 import React from 'react';
 import { fireEvent, screen } from '@testing-library/react';
 
-import { GAS_ESTIMATE_TYPES } from '../../../../../../shared/constants/gas';
+import {
+  EDIT_GAS_MODES,
+  GAS_ESTIMATE_TYPES,
+} from '../../../../../../shared/constants/gas';
 import { renderWithProvider } from '../../../../../../test/lib/render-helpers';
 import mockEstimates from '../../../../../../test/data/mock-estimates.json';
 import mockState from '../../../../../../test/data/mock-state.json';
@@ -20,7 +23,7 @@ jest.mock('../../../../../store/actions', () => ({
   removePollingTokenFromAppState: jest.fn(),
 }));
 
-const render = (txProps) => {
+const render = (txProps, contextProps) => {
   const store = configureStore({
     metamask: {
       ...mockState.metamask,
@@ -43,6 +46,7 @@ const render = (txProps) => {
         userFeeLevel: 'custom',
         ...txProps,
       }}
+      {...contextProps}
     >
       <AdvancedGasFeePopoverContextProvider>
         <BaseFeeInput />
@@ -56,17 +60,33 @@ describe('BaseFeeInput', () => {
   it('should renders advancedGasFee.baseFee value if current estimate used is not custom', () => {
     render({
       userFeeLevel: 'high',
+      txParams: {
+        maxFeePerGas: '0x2E90EDD000',
+      },
     });
     expect(document.getElementsByTagName('input')[0]).toHaveValue(100);
+  });
+
+  it('should not advancedGasFee.baseFee value for swaps', () => {
+    render(
+      {
+        userFeeLevel: 'high',
+        txParams: {
+          maxFeePerGas: '0x2E90EDD000',
+        },
+      },
+      { editGasMode: EDIT_GAS_MODES.SWAPS },
+    );
+    expect(document.getElementsByTagName('input')[0]).toHaveValue(200);
   });
 
   it('should renders baseFee values from transaction if current estimate used is custom', () => {
     render({
       txParams: {
-        maxFeePerGas: '0x174876E800',
+        maxFeePerGas: '0x2E90EDD000',
       },
     });
-    expect(document.getElementsByTagName('input')[0]).toHaveValue(100);
+    expect(document.getElementsByTagName('input')[0]).toHaveValue(200);
   });
   it('should show current value of estimatedBaseFee in subtext', () => {
     render({

--- a/ui/components/app/advanced-gas-fee-popover/advanced-gas-fee-inputs/priority-fee-input/priority-fee-input.js
+++ b/ui/components/app/advanced-gas-fee-popover/advanced-gas-fee-inputs/priority-fee-input/priority-fee-input.js
@@ -2,7 +2,10 @@ import React, { useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 
 import { HIGH_FEE_WARNING_MULTIPLIER } from '../../../../../pages/send/send.constants';
-import { PRIORITY_LEVELS } from '../../../../../../shared/constants/gas';
+import {
+  EDIT_GAS_MODES,
+  PRIORITY_LEVELS,
+} from '../../../../../../shared/constants/gas';
 import { SECONDARY } from '../../../../../helpers/constants/common';
 import { decGWEIToHexWEI } from '../../../../../helpers/utils/conversions.util';
 import { getAdvancedGasFeeValues } from '../../../../../selectors';
@@ -49,6 +52,7 @@ const PriorityFeeInput = () => {
     setMaxPriorityFeePerGas,
   } = useAdvancedGasFeePopoverContext();
   const {
+    editGasMode,
     estimateUsed,
     gasFeeEstimates,
     maxPriorityFeePerGas,
@@ -63,7 +67,8 @@ const PriorityFeeInput = () => {
   const [priorityFee, setPriorityFee] = useState(() => {
     if (
       estimateUsed !== PRIORITY_LEVELS.CUSTOM &&
-      advancedGasFeeValues?.priorityFee
+      advancedGasFeeValues?.priorityFee &&
+      editGasMode !== EDIT_GAS_MODES.SWAPS
     ) {
       return advancedGasFeeValues.priorityFee;
     }

--- a/ui/components/app/advanced-gas-fee-popover/advanced-gas-fee-inputs/priority-fee-input/priority-fee-input.test.js
+++ b/ui/components/app/advanced-gas-fee-popover/advanced-gas-fee-inputs/priority-fee-input/priority-fee-input.test.js
@@ -1,7 +1,10 @@
 import React from 'react';
 import { fireEvent, screen } from '@testing-library/react';
 
-import { GAS_ESTIMATE_TYPES } from '../../../../../../shared/constants/gas';
+import {
+  EDIT_GAS_MODES,
+  GAS_ESTIMATE_TYPES,
+} from '../../../../../../shared/constants/gas';
 import { renderWithProvider } from '../../../../../../test/lib/render-helpers';
 import mockEstimates from '../../../../../../test/data/mock-estimates.json';
 import mockState from '../../../../../../test/data/mock-state.json';
@@ -20,7 +23,7 @@ jest.mock('../../../../../store/actions', () => ({
   removePollingTokenFromAppState: jest.fn(),
 }));
 
-const render = (txProps) => {
+const render = (txProps, contextProps) => {
   const store = configureStore({
     metamask: {
       ...mockState.metamask,
@@ -43,6 +46,7 @@ const render = (txProps) => {
         userFeeLevel: 'custom',
         ...txProps,
       }}
+      {...contextProps}
     >
       <AdvancedGasFeePopoverContextProvider>
         <PriorityfeeInput />
@@ -56,8 +60,24 @@ describe('PriorityfeeInput', () => {
   it('should renders advancedGasFee.priorityfee value if current estimate used is not custom', () => {
     render({
       userFeeLevel: 'high',
+      txParams: {
+        maxFeePerGas: '0x2E90EDD000',
+      },
     });
     expect(document.getElementsByTagName('input')[0]).toHaveValue(100);
+  });
+
+  it('should not advancedGasFee.baseFee value for swaps', () => {
+    render(
+      {
+        userFeeLevel: 'high',
+        txParams: {
+          maxFeePerGas: '0x2E90EDD000',
+        },
+      },
+      { editGasMode: EDIT_GAS_MODES.SWAPS },
+    );
+    expect(document.getElementsByTagName('input')[0]).toHaveValue(200);
   });
 
   it('should renders priorityfee value from transaction if current estimate used is custom', () => {

--- a/ui/components/app/advanced-gas-fee-popover/context/advancedGasFeePopover.js
+++ b/ui/components/app/advanced-gas-fee-popover/context/advancedGasFeePopover.js
@@ -29,6 +29,7 @@ export const AdvancedGasFeePopoverContextProvider = ({ children }) => {
         gasLimit,
         hasErrors:
           errors.maxFeePerGas || errors.maxPriorityFeePerGas || errors.gasLimit,
+        gasErrors: errors,
         maxFeePerGas,
         maxPriorityFeePerGas,
         setErrorValue,

--- a/ui/components/app/edit-gas-fee-popover/edit-gas-item/useGasItemFeeDetails.js
+++ b/ui/components/app/edit-gas-fee-popover/edit-gas-item/useGasItemFeeDetails.js
@@ -58,7 +58,7 @@ export const useGasItemFeeDetails = (priorityLevel) => {
     if (estimateUsed === PRIORITY_LEVELS.CUSTOM) {
       maxFeePerGas = maxFeePerGasValue;
       maxPriorityFeePerGas = maxPriorityFeePerGasValue;
-    } else if (advancedGasFeeValues) {
+    } else if (advancedGasFeeValues && editGasMode !== EDIT_GAS_MODES.SWAPS) {
       maxFeePerGas = advancedGasFeeValues.maxBaseFee;
       maxPriorityFeePerGas = advancedGasFeeValues.priorityFee;
     }

--- a/ui/ducks/swaps/swaps.js
+++ b/ui/ducks/swaps/swaps.js
@@ -857,7 +857,7 @@ export const signAndSendTransactions = (history, metaMetricsEvent) => {
         addUnapprovedTransaction(
           { ...approveTxParams, amount: '0x0' },
           'metamask',
-          TRANSACTION_TYPES.SWAP,
+          TRANSACTION_TYPES.SWAP_APPROVAL,
         ),
       );
       await dispatch(setApproveTxId(approveTxMeta.id));

--- a/ui/ducks/swaps/swaps.js
+++ b/ui/ducks/swaps/swaps.js
@@ -857,6 +857,7 @@ export const signAndSendTransactions = (history, metaMetricsEvent) => {
         addUnapprovedTransaction(
           { ...approveTxParams, amount: '0x0' },
           'metamask',
+          TRANSACTION_TYPES.SWAP,
         ),
       );
       await dispatch(setApproveTxId(approveTxMeta.id));
@@ -881,7 +882,11 @@ export const signAndSendTransactions = (history, metaMetricsEvent) => {
     }
 
     const tradeTxMeta = await dispatch(
-      addUnapprovedTransaction(usedTradeTxParams, 'metamask'),
+      addUnapprovedTransaction(
+        usedTradeTxParams,
+        'metamask',
+        TRANSACTION_TYPES.SWAP,
+      ),
     );
     dispatch(setTradeTxId(tradeTxMeta.id));
 

--- a/ui/store/actions.js
+++ b/ui/store/actions.js
@@ -698,18 +698,23 @@ export function updateTransaction(txData, dontShowLoadingIndicator) {
   };
 }
 
-export function addUnapprovedTransaction(txParams, origin) {
+export function addUnapprovedTransaction(txParams, origin, type) {
   log.debug('background.addUnapprovedTransaction');
 
   return () => {
     return new Promise((resolve, reject) => {
-      background.addUnapprovedTransaction(txParams, origin, (err, txMeta) => {
-        if (err) {
-          reject(err);
-          return;
-        }
-        resolve(txMeta);
-      });
+      background.addUnapprovedTransaction(
+        txParams,
+        origin,
+        type,
+        (err, txMeta) => {
+          if (err) {
+            reject(err);
+            return;
+          }
+          resolve(txMeta);
+        },
+      );
     });
   };
 }


### PR DESCRIPTION
Fixes: RC v10.10.0 RC issue: The advanced gas fee default setting is used instead of swap suggested as displayed