### PR TITLE
Mįgrated list item stories from addon knobs to use controls.

### DIFF
--- a/ui/components/ui/list-item/list-item.stories.js
+++ b/ui/components/ui/list-item/list-item.stories.js
@@ -14,20 +14,25 @@ export default {
   argTypes: {
     title: {
       control: 'text',
-      defaultValue: 'Send DAI',
     },
     subtitle: {
       control: 'text',
-      defaultValue: 'Sept 20 · To: 00X4...3058',
     },
     primaryCurrency: {
       control: 'text',
-      defaultValue: '2 ETH',
     },
     secondaryCurrency: {
       control: 'text',
-      defaultValue: '70 USD',
     },
+    className: {
+      control: 'text',
+    },
+  },
+  args: {
+    title: 'Send DAI',
+    subtitle: 'Sept 20 · To: 00X4...3058',
+    primaryCurrency: '2 ETH',
+    secondaryCurrency: '70 USD',
   },
 };
 
@@ -54,7 +59,7 @@ export const SendComponent = (args) => (
     titleIcon={<Preloader size={16} color={failColor} />}
     title={args.title}
     subtitle={args.subtitle}
-    className="list-item"
+    className={args.className}
     rightContent={
       <Currencies
         primary={args.primaryCurrency}
@@ -84,9 +89,10 @@ SendComponent.argTypes = {
 
 export const PendingComponent = (args) => (
   <ListItem
-    {...args}
+    title={args.title}
+    subtitle={args.subtitle}
     icon={<Interaction color={failColor} size={28} />}
-    className="list-item"
+    className={args.className}
     subtitleStatus={
       <span>
         <span style={{ color: 'var(--color-warning-default)' }}>
@@ -106,9 +112,10 @@ export const PendingComponent = (args) => (
 
 export const ApproveComponent = (args) => (
   <ListItem
-    {...args}
+    title={args.title}
+    subtitle={args.subtitle}
     icon={<Approve color={okColor} size={28} />}
-    className="list-item"
+    className={args.className}
     rightContent={
       <Currencies
         primary={args.primaryCurrency}
@@ -122,7 +129,7 @@ export const ReceiveComponent = (args) => (
   <ListItem
     {...args}
     icon={<Receive color={okColor} size={28} />}
-    className="list-item"
+    className={args.className}
     rightContent={
       <Currencies
         primary={args.primaryCurrency}

--- a/ui/components/ui/list-item/list-item.stories.js
+++ b/ui/components/ui/list-item/list-item.stories.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { text } from '@storybook/addon-knobs';
 import Send from '../icon/send-icon.component';
 import Interaction from '../icon/interaction-icon.component';
 import Approve from '../icon/approve-icon.component';
@@ -12,6 +11,24 @@ import ListItem from './list-item.component';
 export default {
   title: 'Components/UI/ListItem',
   id: __filename,
+  argTypes: {
+    title: {
+      control: 'text',
+      defaultValue: 'Send DAI',
+    },
+    subtitle: {
+      control: 'text',
+      defaultValue: 'Sept 20 · To: 00X4...3058',
+    },
+    primaryCurrency: {
+      control: 'text',
+      defaultValue: '2 ETH',
+    },
+    secondaryCurrency: {
+      control: 'text',
+      defaultValue: '70 USD',
+    },
+  },
 };
 
 function Currencies({ primary, secondary }) {
@@ -31,33 +48,44 @@ Currencies.propTypes = {
 const okColor = 'var(--color-primary-default)';
 const failColor = 'var(--color-error-default';
 
-export const SendComponent = () => (
+export const SendComponent = (args) => (
   <ListItem
     icon={<Send color={okColor} size={28} />}
     titleIcon={<Preloader size={16} color={failColor} />}
-    title={text('title', 'Send DAI')}
+    title={args.title}
+    subtitle={args.subtitle}
     className="list-item"
-    subtitle={text('subtitle', 'Sept 20 · To: 00X4...3058')}
     rightContent={
       <Currencies
-        primary={text('primaryCurrency', '- 0.0732 DAI')}
-        secondary={text('secondaryCurrency', '- $6.04 USD')}
+        primary={args.primaryCurrency}
+        secondary={args.secondaryCurrency}
       />
     }
   >
     <div style={{ display: 'flex', marginTop: 8 }}>
       <Button type="secondary" style={{ marginRight: 16, maxWidth: 150 }}>
-        {text('button1', 'Speed Up')}
+        {args.secondaryButtonText}
       </Button>
-      <Button style={{ maxWidth: 150 }}>{text('button2', 'Cancel')}</Button>
+      <Button style={{ maxWidth: 150 }}>{args.cancelButtonText}</Button>
     </div>
   </ListItem>
 );
 
-export const PendingComponent = () => (
+SendComponent.argTypes = {
+  secondaryButtonText: {
+    control: 'text',
+    defaultValue: 'Speed Up',
+  },
+  cancelButtonText: {
+    control: 'text',
+    defaultValue: 'Cancel',
+  },
+};
+
+export const PendingComponent = (args) => (
   <ListItem
+    {...args}
     icon={<Interaction color={failColor} size={28} />}
-    title={text('title', 'Hatch Turtles')}
     className="list-item"
     subtitleStatus={
       <span>
@@ -67,41 +95,38 @@ export const PendingComponent = () => (
         ·{' '}
       </span>
     }
-    subtitle={text('subtitle', 'Turtlefarm.com')}
     rightContent={
       <Currencies
-        primary={text('primaryCurrency', '- 0.0732 ETH')}
-        secondary={text('secondaryCurrency', '- $6.00 USD')}
+        primary={args.primaryCurrency}
+        secondary={args.secondaryCurrency}
       />
     }
   />
 );
 
-export const ApproveComponent = () => (
+export const ApproveComponent = (args) => (
   <ListItem
+    {...args}
     icon={<Approve color={okColor} size={28} />}
-    title={text('title', 'Approve spend limit')}
     className="list-item"
-    subtitle={text('subtitle', 'Sept 20 · oxuniverse.com')}
     rightContent={
       <Currencies
-        primary={text('primaryCurrency', '- 0 ETH')}
-        secondary={text('secondaryCurrency', '- $0.00 USD')}
+        primary={args.primaryCurrency}
+        secondary={args.secondaryCurrency}
       />
     }
   />
 );
 
-export const ReceiveComponent = () => (
+export const ReceiveComponent = (args) => (
   <ListItem
+    {...args}
     icon={<Receive color={okColor} size={28} />}
-    title={text('title', 'Hatch Turtles')}
     className="list-item"
-    subtitle={text('subtitle', 'Sept 20 · From: 00X4...3058')}
     rightContent={
       <Currencies
-        primary={text('primaryCurrency', '7.5 ETH')}
-        secondary={text('secondaryCurrency', '$1,425.00 USD')}
+        primary={args.primaryCurrency}
+        secondary={args.secondaryCurrency}
       />
     }
   />


### PR DESCRIPTION
Fixes: #13061

Explanation:  
Mįgrated list item stories from addon knobs to use controls.
Manual testing steps:  
  - run the storybook server with `yarn storybook`
  - Confirm that the controls exist on your server at -- /?path=/story/ui-components-ui-list-item-list-item-stories-js--send-component
 