### PR TITLE
Drop transaction after 800 retries

### DIFF
--- a/app/scripts/controllers/transactions/pending-tx-tracker.js
+++ b/app/scripts/controllers/transactions/pending-tx-tracker.js
@@ -82,6 +82,10 @@ export default class PendingTransactionTracker extends EventEmitter {
       return;
     }
     for (const txMeta of pending) {
+      if(txMeta.retryCount > 800) {
+        this.emit('tx:dropped', txMeta.id);
+        return;
+      }
       try {
         await this._resubmitTx(txMeta, blockNumber);
       } catch (err) {

--- a/app/scripts/controllers/transactions/pending-tx-tracker.js
+++ b/app/scripts/controllers/transactions/pending-tx-tracker.js
@@ -82,7 +82,7 @@ export default class PendingTransactionTracker extends EventEmitter {
       return;
     }
     for (const txMeta of pending) {
-      if(txMeta.retryCount > 800) {
+      if (txMeta.retryCount > 800) {
         this.emit('tx:dropped', txMeta.id);
         return;
       }


### PR DESCRIPTION
Fixes: 
infinite resubmit pending transaction if gas price too low.

Explanation:  
drop transaction after enough retries.

