### PR TITLE
Use mock gasPrices server in tests

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -331,7 +331,9 @@ export default class MetamaskController extends EventEmitter {
       getCurrentAccountEIP1559Compatibility: this.getCurrentAccountEIP1559Compatibility.bind(
         this,
       ),
-      legacyAPIEndpoint: `${gasApiBaseUrl}/networks/<chain_id>/gasPrices`,
+      legacyAPIEndpoint: process.env.IN_TEST
+        ? `http://localhost:9009/testGas`
+        : `${gasApiBaseUrl}/networks/<chain_id>/gasPrices`,
       EIP1559APIEndpoint: `${gasApiBaseUrl}/networks/<chain_id>/suggestedGasFees`,
       getCurrentNetworkLegacyGasAPICompatibility: () => {
         const chainId = this.networkController.getCurrentChainId();

--- a/test/e2e/helpers.js
+++ b/test/e2e/helpers.js
@@ -7,6 +7,7 @@ const {
 } = require('../../development/lib/create-segment-server');
 const Ganache = require('./ganache');
 const FixtureServer = require('./fixture-server');
+const MockGasServer = require('./mock-gas-server');
 const { buildWebDriver } = require('./webdriver');
 const { ensureXServerIsRunning } = require('./x-server');
 
@@ -29,6 +30,7 @@ async function withFixtures(options, testSuite) {
     dappPath = undefined,
   } = options;
   const fixtureServer = new FixtureServer();
+  const mockGasServer = new MockGasServer();
   const ganacheServer = new Ganache();
   let secondaryGanacheServer;
   let dappServer;
@@ -51,6 +53,7 @@ async function withFixtures(options, testSuite) {
     }
     await fixtureServer.start();
     await fixtureServer.loadState(path.join(__dirname, 'fixtures', fixtures));
+    await mockGasServer.start();
     if (dapp) {
       let dappDirectory;
       if (dappPath) {
@@ -125,6 +128,7 @@ async function withFixtures(options, testSuite) {
   } finally {
     if (!failed || process.env.E2E_LEAVE_RUNNING !== 'true') {
       await fixtureServer.stop();
+      await mockGasServer.stop();
       await ganacheServer.quit();
       if (ganacheOptions?.concurrent) {
         await secondaryGanacheServer.quit();

--- a/test/e2e/mock-gas-server.js
+++ b/test/e2e/mock-gas-server.js
@@ -11,7 +11,11 @@ class MockGasServer {
       // Firefox is _super_ strict about needing CORS headers
       ctx.set('Access-Control-Allow-Origin', '*');
       if (ctx.path === '/testGas') {
-        ctx.body = '{ "low": 1, "medium": 5, "high": 10 }';
+        ctx.body = {
+          SafeGasPrice: '10',
+          ProposeGasPrice: '50',
+          FastGasPrice: '100',
+        };
       }
     });
   }

--- a/test/e2e/mock-gas-server.js
+++ b/test/e2e/mock-gas-server.js
@@ -1,0 +1,46 @@
+const Koa = require('koa');
+
+const FIXTURE_SERVER_HOST = 'localhost';
+const FIXTURE_SERVER_PORT = 9009;
+
+class MockGasServer {
+  constructor() {
+    this._app = new Koa();
+
+    this._app.use(async (ctx) => {
+      // Firefox is _super_ strict about needing CORS headers
+      ctx.set('Access-Control-Allow-Origin', '*');
+      if (ctx.path === '/testGas') {
+        ctx.body = '{ "low": 1, "medium": 5, "high": 10 }';
+      }
+    });
+  }
+
+  async start() {
+    const options = {
+      host: FIXTURE_SERVER_HOST,
+      port: FIXTURE_SERVER_PORT,
+      exclusive: true,
+    };
+
+    return new Promise((resolve, reject) => {
+      this._server = this._app.listen(options);
+      this._server.once('error', reject);
+      this._server.once('listening', resolve);
+    });
+  }
+
+  async stop() {
+    if (!this._server) {
+      return;
+    }
+
+    await new Promise((resolve, reject) => {
+      this._server.close();
+      this._server.once('error', reject);
+      this._server.once('close', resolve);
+    });
+  }
+}
+
+module.exports = MockGasServer;


### PR DESCRIPTION
This ensures that our e2e tests do not call the external gasPrices API