### PR TITLE
Fixing sign type data message formatting, requiring content scroll before sign

### DIFF
--- a/test/e2e/tests/signature-request.spec.js
+++ b/test/e2e/tests/signature-request.spec.js
@@ -65,11 +65,10 @@ describe('Sign Typed Data V4 Signature Request', function () {
           )}`,
         );
         assert.equal(await message.getText(), 'Hello, Bob!');
-
         // Approve signing typed data
         await driver.executeScript(`
-          const messagePane = document.querySelector('.signature-request-message');
-          messagePane.style.maxHeight = 'inherit';
+          const lastNodeInMessage = document.querySelectorAll('.signature-request-message--node')[7];
+          lastNodeInMessage.scrollIntoView();
         `);
         await driver.delay(regularDelayMs);
         await driver.clickElement({ text: 'Sign', tag: 'button' });

--- a/test/e2e/tests/signature-request.spec.js
+++ b/test/e2e/tests/signature-request.spec.js
@@ -1,5 +1,9 @@
 const { strict: assert } = require('assert');
-const { convertToHexValue, withFixtures } = require('../helpers');
+const {
+  convertToHexValue,
+  withFixtures,
+  regularDelayMs,
+} = require('../helpers');
 
 describe('Sign Typed Data V4 Signature Request', function () {
   it('can initiate and confirm a Signature Request', async function () {
@@ -63,6 +67,11 @@ describe('Sign Typed Data V4 Signature Request', function () {
         assert.equal(await message.getText(), 'Hello, Bob!');
 
         // Approve signing typed data
+        await driver.executeScript(`
+          const messagePane = document.querySelector('.signature-request-message');
+          messagePane.style.maxHeight = 'inherit';
+        `);
+        await driver.delay(regularDelayMs);
         await driver.clickElement({ text: 'Sign', tag: 'button' });
         await driver.waitUntilXWindowHandles(2);
         windowHandles = await driver.getAllWindowHandles();

--- a/ui/components/app/signature-request/signature-request-message/index.scss
+++ b/ui/components/app/signature-request/signature-request-message/index.scss
@@ -1,6 +1,7 @@
 .signature-request-message {
   flex: 1 60%;
   display: flex;
+  max-height: 250px;
   flex-direction: column;
 
   &__title {

--- a/ui/components/app/signature-request/signature-request-message/signature-request-message.component.js
+++ b/ui/components/app/signature-request/signature-request-message/signature-request-message.component.js
@@ -1,15 +1,39 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
+import { debounce } from 'lodash';
 import classnames from 'classnames';
 
 export default class SignatureRequestMessage extends PureComponent {
   static propTypes = {
     data: PropTypes.object.isRequired,
+    onMessageScrolled: PropTypes.func,
   };
 
   static contextTypes = {
     t: PropTypes.func,
   };
+
+  messageAreaRef;
+
+  state = {
+    messageIsScrolled: false,
+  };
+
+  setMessageIsScrolled = () => {
+    if (!this.messageAreaRef || this.state.messageIsScrolled) {
+      return;
+    }
+
+    const { scrollTop, offsetHeight, scrollHeight } = this.messageAreaRef;
+    const isAtBottom = scrollTop + offsetHeight >= scrollHeight;
+
+    if (isAtBottom) {
+      this.setState({ messageIsScrolled: true });
+      this.props.onMessageScrolled();
+    }
+  };
+
+  onScroll = debounce(this.setMessageIsScrolled, 25);
 
   renderNode(data) {
     return (
@@ -42,7 +66,13 @@ export default class SignatureRequestMessage extends PureComponent {
     const { data } = this.props;
 
     return (
-      <div className="signature-request-message">
+      <div
+        onScroll={this.onScroll}
+        ref={(ref) => {
+          this.messageAreaRef = ref;
+        }}
+        className="signature-request-message"
+      >
         <div className="signature-request-message__title">
           {this.context.t('signatureRequest1')}
         </div>

--- a/ui/components/app/signature-request/signature-request-message/signature-request-message.component.js
+++ b/ui/components/app/signature-request/signature-request-message/signature-request-message.component.js
@@ -7,6 +7,7 @@ export default class SignatureRequestMessage extends PureComponent {
   static propTypes = {
     data: PropTypes.object.isRequired,
     onMessageScrolled: PropTypes.func,
+    setMessageRootRef: PropTypes.func,
   };
 
   static contextTypes = {
@@ -76,7 +77,10 @@ export default class SignatureRequestMessage extends PureComponent {
         <div className="signature-request-message__title">
           {this.context.t('signatureRequest1')}
         </div>
-        <div className="signature-request-message--root">
+        <div
+          className="signature-request-message--root"
+          ref={this.props.setMessageRootRef}
+        >
           {this.renderNode(data)}
         </div>
       </div>

--- a/ui/components/app/signature-request/signature-request.component.js
+++ b/ui/components/app/signature-request/signature-request.component.js
@@ -48,6 +48,10 @@ export default class SignatureRequest extends PureComponent {
     hasScrolledMessage: false,
   };
 
+  setMessageRootRef(ref) {
+    this.messageRootRef = ref;
+  }
+
   formatWallet(wallet) {
     return `${wallet.slice(0, 8)}...${wallet.slice(
       wallet.length - 8,
@@ -101,6 +105,9 @@ export default class SignatureRequest extends PureComponent {
       });
     };
 
+    const messageIsScrollable =
+      this.messageRootRef?.scrollHeight > this.messageRootRef?.clientHeight;
+
     return (
       <div className="signature-request page-container">
         <Header fromAccount={fromAccount} />
@@ -131,12 +138,14 @@ export default class SignatureRequest extends PureComponent {
         <Message
           data={sanitizeMessage(message, primaryType, types)}
           onMessageScrolled={() => this.setState({ hasScrolledMessage: true })}
+          setMessageRootRef={this.setMessageRootRef.bind(this)}
         />
         <Footer
           cancelAction={onCancel}
           signAction={onSign}
           disabled={
-            hardwareWalletRequiresConnection || !this.state.hasScrolledMessage
+            hardwareWalletRequiresConnection ||
+            (messageIsScrollable && !this.state.hasScrolledMessage)
           }
         />
       </div>

--- a/ui/components/app/signature-request/signature-request.component.js
+++ b/ui/components/app/signature-request/signature-request.component.js
@@ -44,6 +44,10 @@ export default class SignatureRequest extends PureComponent {
     metricsEvent: PropTypes.func,
   };
 
+  state = {
+    hasScrolledMessage: false,
+  };
+
   formatWallet(wallet) {
     return `${wallet.slice(0, 8)}...${wallet.slice(
       wallet.length - 8,
@@ -124,11 +128,16 @@ export default class SignatureRequest extends PureComponent {
             <LedgerInstructionField showDataInstruction />
           </div>
         ) : null}
-        <Message data={sanitizeMessage(message, primaryType, types)} />
+        <Message
+          data={sanitizeMessage(message, primaryType, types)}
+          onMessageScrolled={() => this.setState({ hasScrolledMessage: true })}
+        />
         <Footer
           cancelAction={onCancel}
           signAction={onSign}
-          disabled={hardwareWalletRequiresConnection}
+          disabled={
+            hardwareWalletRequiresConnection || !this.state.hasScrolledMessage
+          }
         />
       </div>
     );


### PR DESCRIPTION
Test Plan:
1. Connect an account to https://metamask.github.io/test-dapp/
2. Initiate a Sign Typed Data V3 signature
3. Ensure the sign can be completed without issue
4. Initiate a Sign Typed Data V4 signature
5. Ensure the "Sign" button is disabled
6. Ensure that the message content area is scrollable
7. Confirm that the "Sign" button becomes enabled once the content area is scrolled through

https://user-images.githubusercontent.com/8732757/154115538-7b53a7f5-a7e9-4e76-a70c-b8c4c75869fa.mov
