### PR TITLE
Prevent Browserify error from being swallowed

### DIFF
--- a/development/build/scripts.js
+++ b/development/build/scripts.js
@@ -507,7 +507,7 @@ function createFactoredBuild({
       }
     });
 
-    await bundleIt(buildConfiguration);
+    await bundleIt(buildConfiguration, { reloadOnChange });
   };
 }
 
@@ -572,7 +572,7 @@ function createNormalBundle({
       });
     });
 
-    await bundleIt(buildConfiguration);
+    await bundleIt(buildConfiguration, { reloadOnChange });
   };
 }
 
@@ -720,7 +720,7 @@ function setupSourcemaps(buildConfiguration, { devMode }) {
   });
 }
 
-async function bundleIt(buildConfiguration) {
+async function bundleIt(buildConfiguration, { reloadOnChange }) {
   const { label, bundlerOpts, events } = buildConfiguration;
   const bundler = browserify(bundlerOpts);
 
@@ -759,6 +759,13 @@ async function bundleIt(buildConfiguration) {
       [],
     ]);
     const bundleStream = bundler.bundle();
+    if (!reloadOnChange) {
+      bundleStream.on('error', (error) => {
+        console.error('Bundling failed! See details below.');
+        console.error(error.stack || error);
+        process.exit(1);
+      });
+    }
     // trigger build pipeline instrumentations
     events.emit('configurePipeline', { pipeline, bundleStream });
     // start bundle, send into pipeline


### PR DESCRIPTION
If an error occurs while running Browserify, the stream that Browserify
creates will emit an `error` event. However, this event is not being
handled, so Node will catch it instead. But the error message it
produces is very nebulous, as it merely spits out the stream object and
completely ignores the actual error that occurred. So this commit
listens for the `error` event and outputs the error.

One note here is that when we are outputting the error, we must get
around a bug that exists in Endo where if you pass an Error object to
`console.{log,error,info,debug}` then you will just see `{}` on-screen.
We get around this by printing `err.stack`.