### PR TITLE
Add AirGap Vault

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -89,6 +89,7 @@ body:
        - Trezor
        - Keystone
        - GridPlus Lattice1
+       - AirGap Vault
        - Other (please elaborate in the "Additional Context" section)
  - type: textarea
    id: additional

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -42,7 +42,7 @@
     "message": "QR-based HW Wallet"
   },
   "QRHardwareWalletSteps2Description": {
-    "message": "AirGap Vault & Ngrave (Coming Soon)"
+    "message": "Ngrave (Coming Soon)"
   },
   "about": {
     "message": "About"
@@ -1542,6 +1542,12 @@
     "message": "Keystone"
   },
   "keystoneTutorial": {
+    "message": " (Tutorials)"
+  },
+  "airgapVault": {
+    "message": "AirGap Vault"
+  },
+  "airgapVaultTutorial": {
     "message": " (Tutorials)"
   },
   "knownAddressRecipient": {

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -188,6 +188,12 @@
   "aggregatorFeeCost": {
     "message": "Aggregator network fee"
   },
+  "airgapVault": {
+    "message": "AirGap Vault"
+  },
+  "airgapVaultTutorial": {
+    "message": " (Tutorials)"
+  },
   "alertDisableTooltip": {
     "message": "This can be changed in \"Settings > Alerts\""
   },
@@ -1542,12 +1548,6 @@
     "message": "Keystone"
   },
   "keystoneTutorial": {
-    "message": " (Tutorials)"
-  },
-  "airgapVault": {
-    "message": "AirGap Vault"
-  },
-  "airgapVaultTutorial": {
     "message": " (Tutorials)"
   },
   "knownAddressRecipient": {

--- a/ui/pages/create-account/connect-hardware/select-hardware.js
+++ b/ui/pages/create-account/connect-hardware/select-hardware.js
@@ -351,6 +351,30 @@ export default class SelectHardware extends Component {
         ),
       },
       {
+        message: (
+          <>
+            <a
+              className="hw-connect__msg-link"
+              href="https://airgap.it/metamask"
+              rel="noopener noreferrer"
+              target="_blank"
+              key="airgap-vault-support-link"
+            >
+              {this.context.t('airgapVault')}
+            </a>
+            <a
+              className="hw-connect__msg-link"
+              href="https://support.airgap.it/guides/metamask"
+              rel="noopener noreferrer"
+              target="_blank"
+              key="airgap-vault-tutorial-link"
+            >
+              {this.context.t('airgapVaultTutorial')}
+            </a>
+          </>
+        ),
+      },
+      {
         message: this.context.t('QRHardwareWalletSteps2Description'),
       },
       {


### PR DESCRIPTION
Explanation:  MetaMask is now fully supported in AirGap Vault, so we can remove the "coming soon" and replace it with a link plus tutorials.

Manual testing steps: 
  - Check if the 2 links on the "connect HW wallet" screen are displayed correctly and lead to the right page.
  - This change is only UI related, the functionality with AirGap Vault is exactly the same and does not have to be tested again.
  
Regarding translations, I only adjusted the english language file. Is that ok?