### PR TITLE
Add argTypes for color-indicator

### DIFF
--- a/ui/components/ui/color-indicator/color-indicator.stories.js
+++ b/ui/components/ui/color-indicator/color-indicator.stories.js
@@ -11,30 +11,30 @@ export default {
         type: 'select',
       },
       options: SIZES,
-      defaultValue: SIZES.LG
+      defaultValue: SIZES.LG,
     },
     type: {
       control: {
-        type: 'select'
+        type: 'select',
       },
       options: ColorIndicator.TYPES,
-      defaultValue: ColorIndicator.TYPES.FILLED
+      defaultValue: ColorIndicator.TYPES.FILLED,
     },
     color: {
       control: {
         type: 'select',
       },
       options: COLORS,
-      defaultValue: COLORS.PRIMARY1
+      defaultValue: COLORS.PRIMARY1,
     },
     borderColor: {
       control: {
         type: 'select',
       },
       options: { NONE: undefined, ...COLORS },
-      defaultValue: undefined
+      defaultValue: undefined,
     },
-  }
+  },
 };
 
 export const DefaultStory = (args) => (

--- a/ui/components/ui/color-indicator/color-indicator.stories.js
+++ b/ui/components/ui/color-indicator/color-indicator.stories.js
@@ -1,30 +1,59 @@
 import React from 'react';
-import { select } from '@storybook/addon-knobs';
 import { COLORS, SIZES } from '../../../helpers/constants/design-system';
 import ColorIndicator from './color-indicator';
 
 export default {
   title: 'Components/UI/ColorIndicator',
   id: __filename,
+  argTypes: {
+    size: {
+      control: {
+        type: 'select',
+      },
+      options: SIZES,
+      defaultValue: SIZES.LG
+    },
+    type: {
+      control: {
+        type: 'select'
+      },
+      options: ColorIndicator.TYPES,
+      defaultValue: ColorIndicator.TYPES.FILLED
+    },
+    color: {
+      control: {
+        type: 'select',
+      },
+      options: COLORS,
+      defaultValue: COLORS.PRIMARY1
+    },
+    borderColor: {
+      control: {
+        type: 'select',
+      },
+      options: { NONE: undefined, ...COLORS },
+      defaultValue: undefined
+    },
+  }
 };
 
-export const DefaultStory = () => (
+export const DefaultStory = (args) => (
   <ColorIndicator
-    size={select('size', SIZES, SIZES.LG)}
-    type={select('type', ColorIndicator.TYPES, ColorIndicator.TYPES.FILLED)}
-    color={select('color', COLORS, COLORS.PRIMARY1)}
-    borderColor={select('borderColor', { NONE: undefined, ...COLORS })}
+    size={args.size}
+    type={args.type}
+    color={args.color}
+    borderColor={args.borderColor}
   />
 );
 
 DefaultStory.storyName = 'Default';
 
-export const WithIcon = () => (
+export const WithIcon = (args) => (
   <ColorIndicator
-    size={select('size', SIZES, SIZES.LG)}
-    type={select('type', ColorIndicator.TYPES, ColorIndicator.TYPES.FILLED)}
-    color={select('color', COLORS, COLORS.PRIMARY1)}
+    size={args.size}
+    type={args.type}
+    color={args.color}
     iconClassName="fa fa-question"
-    borderColor={select('borderColor', { NONE: undefined, ...COLORS })}
+    borderColor={args.borderColor}
   />
 );


### PR DESCRIPTION
Fixes: #13059

Explanation:  
- [x] Story has argTypes that align with component api / props
- [x] All instances of @storybook/addon-knobs have been removed in favour of control args
- [x] All instances of @storybook/addon-actions have been removed in favour of [action argType annotation](https://storybook.js.org/docs/react/essentials/actions#action-argtype-annotation)

Manual testing steps:  
  1. Run a local build with `yarn start`
  2. Run Storybook with `yarn storybook`
  3. Navigate to `ui-components-ui-color-indicator-color-indicator-stories-js--default-story` and observe controls.
  
 Screenshot:
![Color-Indicator](https://user-images.githubusercontent.com/26950305/154409342-4bd3ad04-2d14-4eae-a3be-ddba24252ae6.png)
 