### PR TITLE
Added Controls and Action ArgType, took out @storybook/addon-knobs 

### DIFF
--- a/ui/pages/swaps/exchange-rate-display/exchange-rate-display.stories.js
+++ b/ui/pages/swaps/exchange-rate-display/exchange-rate-display.stories.js
@@ -7,9 +7,7 @@ export default {
 };
 
 export const DefaultStory = (args) => {
-  return (
-    <ExchangeRateDisplay {...args} />
-  );
+  return <ExchangeRateDisplay {...args} />;
 };
 
 DefaultStory.storyName = 'Default';
@@ -17,25 +15,25 @@ DefaultStory.storyName = 'Default';
 DefaultStory.argTypes = {
   primaryTokenValue: {
     control: {
-      type: 'text'
+      type: 'text',
     },
     defaultValue: '2000000000000000000',
   },
   primaryTokenDecimals: {
     control: {
-      type: 'number'
+      type: 'number',
     },
     defaultValue: 18,
   },
   primaryTokenSymbol: {
     control: {
-      type: 'text'
+      type: 'text',
     },
     defaultValue: 'ETH',
   },
   secondaryTokenValue: {
     control: {
-      type: 'text'
+      type: 'text',
     },
     defaultValue: '200000000000000000',
   },
@@ -45,10 +43,10 @@ DefaultStory.argTypes = {
   },
   secondaryTokenSymbol: {
     control: {
-      type: 'text'
+      type: 'text',
     },
-    defaultValue: 'ABC'
-  }
+    defaultValue: 'ABC',
+  },
 };
 
 export const WhiteOnBlue = (args) => {
@@ -72,38 +70,38 @@ export const WhiteOnBlue = (args) => {
 WhiteOnBlue.argTypes = {
   primaryTokenValue: {
     control: {
-      type: 'text'
+      type: 'text',
     },
     defaultValue: '2000000000000000000',
   },
   primaryTokenDecimals: {
     control: {
-      type: 'number'
+      type: 'number',
     },
     defaultValue: 18,
   },
   primaryTokenSymbol: {
     control: {
-      type: 'text'
+      type: 'text',
     },
     defaultValue: 'ETH',
   },
   secondaryTokenValue: {
     control: {
-      type: 'text'
+      type: 'text',
     },
     defaultValue: '200000000000000000',
   },
   secondaryTokenDecimals: {
     control: {
-      type: 'number'
+      type: 'number',
     },
     defaultValue: 18,
   },
   secondaryTokenSymbol: {
     control: {
-      type: 'text'
+      type: 'text',
     },
-    defaultValue: 'ABC'
-  }
+    defaultValue: 'ABC',
+  },
 };

--- a/ui/pages/swaps/exchange-rate-display/exchange-rate-display.stories.js
+++ b/ui/pages/swaps/exchange-rate-display/exchange-rate-display.stories.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { text, number } from '@storybook/addon-knobs';
 import ExchangeRateDisplay from './exchange-rate-display';
 
 export default {
@@ -7,22 +6,52 @@ export default {
   id: __filename,
 };
 
-export const DefaultStory = () => {
+export const DefaultStory = (args) => {
   return (
-    <ExchangeRateDisplay
-      primaryTokenValue={text('primaryTokenValue', '2000000000000000000')}
-      primaryTokenDecimals={number('primaryTokenDecimals', 18)}
-      primaryTokenSymbol={text('primaryTokenSymbol', 'ETH')}
-      secondaryTokenValue={text('secondaryTokenValue', '200000000000000000')}
-      secondaryTokenDecimals={number('secondaryTokenDecimals', 18)}
-      secondaryTokenSymbol={text('secondaryTokenSymbol', 'ABC')}
-    />
+    <ExchangeRateDisplay {...args} />
   );
 };
 
 DefaultStory.storyName = 'Default';
 
-export const WhiteOnBlue = () => {
+DefaultStory.argTypes = {
+  primaryTokenValue: {
+    control: {
+      type: 'text'
+    },
+    defaultValue: '2000000000000000000',
+  },
+  primaryTokenDecimals: {
+    control: {
+      type: 'number'
+    },
+    defaultValue: 18,
+  },
+  primaryTokenSymbol: {
+    control: {
+      type: 'text'
+    },
+    defaultValue: 'ETH',
+  },
+  secondaryTokenValue: {
+    control: {
+      type: 'text'
+    },
+    defaultValue: '200000000000000000',
+  },
+  secondaryTokenDecimals: {
+    control: 'number',
+    defaultValue: 18,
+  },
+  secondaryTokenSymbol: {
+    control: {
+      type: 'text'
+    },
+    defaultValue: 'ABC'
+  }
+};
+
+export const WhiteOnBlue = (args) => {
   return (
     <div
       style={{
@@ -35,16 +64,46 @@ export const WhiteOnBlue = () => {
         background: 'linear-gradient(90deg, #037DD6 0%, #1098FC 101.32%)',
       }}
     >
-      <ExchangeRateDisplay
-        primaryTokenValue={text('primaryTokenValue', '2000000000000000000')}
-        primaryTokenDecimals={number('primaryTokenDecimals', 18)}
-        primaryTokenSymbol={text('primaryTokenSymbol', 'ETH')}
-        secondaryTokenValue={text('secondaryTokenValue', '200000000000000000')}
-        secondaryTokenDecimals={number('secondaryTokenDecimals', 18)}
-        secondaryTokenSymbol={text('secondaryTokenSymbol', 'ABC')}
-        className="exchange-rate-display--white"
-        arrowColor="white"
-      />
+      <ExchangeRateDisplay {...args} />
     </div>
   );
+};
+
+WhiteOnBlue.argTypes = {
+  primaryTokenValue: {
+    control: {
+      type: 'text'
+    },
+    defaultValue: '2000000000000000000',
+  },
+  primaryTokenDecimals: {
+    control: {
+      type: 'number'
+    },
+    defaultValue: 18,
+  },
+  primaryTokenSymbol: {
+    control: {
+      type: 'text'
+    },
+    defaultValue: 'ETH',
+  },
+  secondaryTokenValue: {
+    control: {
+      type: 'text'
+    },
+    defaultValue: '200000000000000000',
+  },
+  secondaryTokenDecimals: {
+    control: {
+      type: 'number'
+    },
+    defaultValue: 18,
+  },
+  secondaryTokenSymbol: {
+    control: {
+      type: 'text'
+    },
+    defaultValue: 'ABC'
+  }
 };


### PR DESCRIPTION
Fixes: # 13173

- [x] Story has argTypes that align with component api / props
- [x] All instances of @storybook/addon-knobs have been removed in favour of control args
- [x] All instances of @storybook/addon-actions have been removed in favour of action argType annotation

Proof of Work
![OpenSource-MetaMask](https://user-images.githubusercontent.com/82005916/154409057-dfde6fb5-d535-4a27-86e9-30fdbc86c6a0.png)
Explanation:  

Changed all storybook knobs to control/action argTypes. 

Manual testing steps:  
- Run a local build with `yarn start`
- Run Storybook with `yarn storybook`
- Navigate to `ui-components-ui-color-indicator-color-indicator-stories-js--default-story` and observe controls.

I have read and agreed to the CLA and sign my name Charlie Fadness