### PR TITLE
Deleting transactions from `currentNetworkTxnList` based on unique address along with nonce and chainId

### DIFF
--- a/app/scripts/controllers/transactions/tx-state-manager.js
+++ b/app/scripts/controllers/transactions/tx-state-manager.js
@@ -245,9 +245,9 @@ export default class TransactionStateManager extends EventEmitter {
     const txsToDelete = transactions
       .reverse()
       .filter((tx) => {
-        const { nonce } = tx.txParams;
+        const { nonce, from } = tx.txParams;
         const { chainId, metamaskNetworkId, status } = tx;
-        const key = `${nonce}-${chainId ?? metamaskNetworkId}`;
+        const key = `${nonce}-${chainId ?? metamaskNetworkId}-${from}`;
         if (nonceNetworkSet.has(key)) {
           return false;
         } else if (


### PR DESCRIPTION
Fixes: #13550 

Explanation:  
Adding `from` address will prevent a transaction from being deleted if it shares the same nonce and chainId with another transaction. Suppose a user creates transactions on two or more accounts, and any two transactions from different accounts share nonces. In that case, the old transaction stays longer in our state unnecessarily until the new old reaches the end of the list. This was never intended, and there is no good reason for it. By adding the `from` account address, more individual transactions will be preserved for longer in the state, while transactions of different accounts that share nonces won't be unnecessarily preserved in the state forever.
