### PR TITLE
Add test: Import Account using private key of an already active account should result in an error

### DIFF
--- a/test/e2e/tests/from-import-ui.spec.js
+++ b/test/e2e/tests/from-import-ui.spec.js
@@ -293,6 +293,47 @@ describe('Metamask Import UI', function () {
       },
     );
   });
+
+  it('Import Account using private key of an already active account should result in an error', async function () {
+    const testPrivateKey =
+      '0x53CB0AB5226EEBF4D872113D98332C1555DC304443BEE1CF759D15798D3C55A9';
+    const ganacheOptions = {
+      accounts: [
+        {
+          secretKey: testPrivateKey,
+          balance: convertToHexValue(25000000000000000000),
+        },
+      ],
+    };
+
+    await withFixtures(
+      {
+        fixtures: 'import-ui',
+        ganacheOptions,
+        title: this.test.title,
+      },
+      async ({ driver }) => {
+        await driver.navigate();
+        await driver.fill('#password', 'correct horse battery staple');
+        await driver.press('#password', driver.Key.ENTER);
+
+        // choose Import Account from the account menu
+        await driver.clickElement('.account-menu__icon');
+        await driver.clickElement({ text: 'Import Account', tag: 'div' });
+
+        // enter private key',
+        await driver.fill('#private-key-box', testPrivateKey);
+        await driver.clickElement({ text: 'Import', tag: 'button' });
+
+        // error should occur
+        await driver.waitForSelector({
+          css: '.error',
+          text: "The account you're are trying to import is a duplicate",
+        });
+      },
+    );
+  });
+
   it('Connects to a Hardware wallet', async function () {
     const ganacheOptions = {
       accounts: [


### PR DESCRIPTION
Fixes: One test coverage improvement raised [here](https://github.com/MetaMask/pm-security/issues/38):
> It should not be possible to import an existing account