### PR TITLE
add account_type and device_model to tx metrics

### DIFF
--- a/app/scripts/controllers/transactions/index.js
+++ b/app/scripts/controllers/transactions/index.js
@@ -130,6 +130,8 @@ export default class TransactionController extends EventEmitter {
     this.updateEventFragment = opts.updateEventFragment;
     this.finalizeEventFragment = opts.finalizeEventFragment;
     this.getEventFragmentById = opts.getEventFragmentById;
+    this.getDeviceModel = opts.getDeviceModel;
+    this.getAccountType = opts.getAccountType;
 
     this.memStore = new ObservableStore({});
     this.query = new EthQuery(this.provider);
@@ -1735,6 +1737,8 @@ export default class TransactionController extends EventEmitter {
       eip_1559_version: eip1559Version,
       gas_edit_type: 'none',
       gas_edit_attempted: 'none',
+      account_type: await this.getAccountType(this.getSelectedAddress()),
+      device_model: await this.getDeviceModel(this.getSelectedAddress()),
     };
 
     const sensitiveProperties = {

--- a/app/scripts/controllers/transactions/index.test.js
+++ b/app/scripts/controllers/transactions/index.test.js
@@ -82,6 +82,8 @@ describe('Transaction Controller', function () {
       getEventFragmentById: () =>
         fragmentExists === false ? undefined : { id: 0 },
       getEIP1559GasFeeEstimates: () => undefined,
+      getAccountType: () => 'MetaMask',
+      getDeviceModel: () => 'N/A',
     });
     txController.nonceTracker.getNonceLock = () =>
       Promise.resolve({ nextNonce: 0, releaseLock: noop });
@@ -1616,6 +1618,8 @@ describe('Transaction Controller', function () {
             referrer: 'metamask',
             source: 'user',
             type: TRANSACTION_TYPES.SIMPLE_SEND,
+            account_type: 'MetaMask',
+            device_model: 'N/A',
           },
           sensitiveProperties: {
             default_gas: '0.000031501',
@@ -1691,6 +1695,8 @@ describe('Transaction Controller', function () {
             referrer: 'metamask',
             source: 'user',
             type: TRANSACTION_TYPES.SIMPLE_SEND,
+            account_type: 'MetaMask',
+            device_model: 'N/A',
           },
           sensitiveProperties: {
             default_gas: '0.000031501',
@@ -1776,6 +1782,8 @@ describe('Transaction Controller', function () {
             referrer: 'other',
             source: 'dapp',
             type: TRANSACTION_TYPES.SIMPLE_SEND,
+            account_type: 'MetaMask',
+            device_model: 'N/A',
           },
           sensitiveProperties: {
             default_gas: '0.000031501',
@@ -1853,6 +1861,8 @@ describe('Transaction Controller', function () {
             referrer: 'other',
             source: 'dapp',
             type: TRANSACTION_TYPES.SIMPLE_SEND,
+            account_type: 'MetaMask',
+            device_model: 'N/A',
           },
           sensitiveProperties: {
             default_gas: '0.000031501',
@@ -1930,6 +1940,8 @@ describe('Transaction Controller', function () {
           referrer: 'other',
           source: 'dapp',
           type: TRANSACTION_TYPES.SIMPLE_SEND,
+          account_type: 'MetaMask',
+          device_model: 'N/A',
         },
         sensitiveProperties: {
           gas_price: '2',
@@ -1989,6 +2001,8 @@ describe('Transaction Controller', function () {
           eip_1559_version: '0',
           gas_edit_attempted: 'none',
           gas_edit_type: 'none',
+          account_type: 'MetaMask',
+          device_model: 'N/A',
         },
         sensitiveProperties: {
           baz: 3.0,
@@ -2058,6 +2072,8 @@ describe('Transaction Controller', function () {
           referrer: 'other',
           source: 'dapp',
           type: TRANSACTION_TYPES.SIMPLE_SEND,
+          account_type: 'MetaMask',
+          device_model: 'N/A',
         },
         sensitiveProperties: {
           baz: 3.0,

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -700,6 +700,8 @@ export default class MetamaskController extends EventEmitter {
       getExternalPendingTransactions: this.getExternalPendingTransactions.bind(
         this,
       ),
+      getAccountType: this.getAccountType.bind(this),
+      getDeviceModel: this.getDeviceModel.bind(this),
     });
     this.txController.on('newUnapprovedTx', () => opts.showUserConfirmation());
 
@@ -2180,6 +2182,54 @@ export default class MetamaskController extends EventEmitter {
     const keyring = await this.getKeyringForDevice(deviceName);
     keyring.forgetDevice();
     return true;
+  }
+
+  /**
+   * Retrieves the keyring for the selected address and using the .type returns
+   * a subtype for the account. Either 'hardware', 'imported' or 'MetaMask'.
+   *
+   * @param {string} address - Address to retrieve keyring for
+   * @returns {'hardware' | 'imported' | 'MetaMask'}
+   */
+  async getAccountType(address) {
+    const keyring = await this.keyringController.getKeyringForAccount(address);
+    switch (keyring.type) {
+      case KEYRING_TYPES.TREZOR:
+      case KEYRING_TYPES.LATTICE:
+      case KEYRING_TYPES.QR:
+      case KEYRING_TYPES.LEDGER:
+        return 'hardware';
+      case KEYRING_TYPES.IMPORTED:
+        return 'imported';
+      default:
+        return 'MetaMask';
+    }
+  }
+
+  /**
+   * Retrieves the keyring for the selected address and using the .type
+   * determines if a more specific name for the device is available. Returns
+   * 'N/A' for non hardware wallets.
+   *
+   * @param {string} address - Address to retrieve keyring for
+   * @returns {'ledger' | 'lattice' | 'N/A' | string}
+   */
+  async getDeviceModel(address) {
+    const keyring = await this.keyringController.getKeyringForAccount(address);
+    switch (keyring.type) {
+      case KEYRING_TYPES.TREZOR:
+        return keyring.getModel();
+      case KEYRING_TYPES.QR:
+        return keyring.getName();
+      case KEYRING_TYPES.LEDGER:
+        // TODO: get model after ledger keyring exposes method
+        return DEVICE_NAMES.LEDGER;
+      case KEYRING_TYPES.LATTICE:
+        // TODO: get model after lattice keyring exposes method
+        return DEVICE_NAMES.LATTICE;
+      default:
+        return 'N/A';
+    }
   }
 
   /**

--- a/shared/constants/hardware-wallets.js
+++ b/shared/constants/hardware-wallets.js
@@ -8,6 +8,7 @@ export const KEYRING_TYPES = {
   TREZOR: 'Trezor Hardware',
   LATTICE: 'Lattice Hardware',
   QR: 'QR Hardware Wallet Device',
+  IMPORTED: 'Simple Key Pair',
 };
 
 export const DEVICE_NAMES = {

--- a/ui/components/app/account-menu/keyring-label.js
+++ b/ui/components/app/account-menu/keyring-label.js
@@ -22,7 +22,7 @@ export default function KeyRingLabel({ keyring }) {
     case KEYRING_TYPES.QR:
       label = KEYRING_NAMES.QR;
       break;
-    case 'Simple Key Pair':
+    case KEYRING_TYPES.IMPORTED:
       label = t('imported');
       break;
     case KEYRING_TYPES.TREZOR:


### PR DESCRIPTION
Fixes: #13357 

Explanation:  adds account_type and device_model to the metrics payload. 

Manual testing steps:  
  - set the environment variables for segment to point to development segment source
  - test with each type of account sending a transaction
  - check segment debugger to confirm that tx properties includes account_type and device_model
