### PR TITLE
Using correct metricsEvent arg

### DIFF
--- a/app/scripts/lib/typed-message-manager.js
+++ b/app/scripts/lib/typed-message-manager.js
@@ -33,9 +33,9 @@ export default class TypedMessageManager extends EventEmitter {
    *
    * @param options
    * @param options.getCurrentChainId
-   * @param options.metricEvents
+   * @param options.metricsEvent
    */
-  constructor({ getCurrentChainId, metricEvents }) {
+  constructor({ getCurrentChainId, metricsEvent }) {
     super();
     this._getCurrentChainId = getCurrentChainId;
     this.memStore = new ObservableStore({
@@ -43,7 +43,7 @@ export default class TypedMessageManager extends EventEmitter {
       unapprovedTypedMessagesCount: 0,
     });
     this.messages = [];
-    this.metricEvents = metricEvents;
+    this.metricsEvent = metricsEvent;
   }
 
   /**


### PR DESCRIPTION
Fixes: https://sentry.io/organizations/metamask/issues/2977820175

The metrics argument being passed in to the constructor of `TypedMessageManager` was `metricsEvent`, not `metricEvents`
https://github.com/MetaMask/metamask-extension/blob/develop/app/scripts/metamask-controller.js#L816