### PR TITLE
Shows the sign and cancel button fully in signature page

### DIFF
--- a/ui/components/app/signature-request/signature-request-message/index.scss
+++ b/ui/components/app/signature-request/signature-request-message/index.scss
@@ -1,7 +1,7 @@
 .signature-request-message {
   flex: 1 60%;
   display: flex;
-  max-height: 250px;
+  max-height: 230px;
   flex-direction: column;
   position: relative;
 


### PR DESCRIPTION
Fixes: #
Fixed showing Sign and Cancel button in the signature footer fully without scrolling. 

![image](https://user-images.githubusercontent.com/2153660/154780886-9e7cc668-f1de-4d6f-acaa-4b113a4a4550.png)

Explanation:  
Reduced the max-height on the message container to be 230px. With this fix it shows sign and cancel without having to scroll. 

Recommendation: 
This is a good candidate for using CSS grids to fix different sections. I didn't venture it to avoid inadvertently breaking parts I don't know about. Happy to take a stab in a future PR. 

Manual testing steps:  
  - any signature request page.

Test Plan:
- Tested signatures through OpenSea on Chrome and Firefox. 