### PR TITLE
[GridPlus] Updates SDK to v0.9.8

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -13434,9 +13434,9 @@ graphql-subscriptions@^1.1.0:
   integrity sha512-5gghUc24tP9HRznNpV2+FIoq3xKkj5dTQqf4v0CpdPbFVwFkWoxOM+o+2OC9ZSvjEMTjfmG9QT+gcvggTwW1zw==
 
 gridplus-sdk@^0.9.7:
-  version "0.9.7"
-  resolved "https://registry.yarnpkg.com/gridplus-sdk/-/gridplus-sdk-0.9.7.tgz#fefa45c4373d02e351ea18059b49429b903d6cf5"
-  integrity sha512-n6dG93XYGplDctUaBMyDsBQzi9kWMB+/2XBzNr2uaHVBpXv8SFPSbYD+uPRUwbjIb8xcRsN0RzHL9QqMO+2vOQ==
+  version "0.9.8"
+  resolved "https://registry.yarnpkg.com/gridplus-sdk/-/gridplus-sdk-0.9.8.tgz#d6ac04c9c76dd0914023303ae03eef6c1b78e562"
+  integrity sha512-fDf6sDQVCz+T20cbh0UoZp3KqILNOLgi9wSpf6DePCiGdLtfz/F/ShXAi6MUYfOeEfoH7+5dUNh1XoaPFjAI4Q==
   dependencies:
     aes-js "^3.1.1"
     bech32 "^2.0.0"


### PR DESCRIPTION
Hotfix added in response to new Opensea EIP712 structure, which
is too large to display on the Lattice.
https://github.com/GridPlus/gridplus-sdk/releases/tag/v0.9.8-hotfix

We will have a more permanent solution in firmware but we wanted to get this fix out for people who are unable to sell NFTs on OpenSea