### PR TITLE
Harden keyring type check in EthOverview

### DIFF
--- a/ui/components/app/wallet-overview/eth-overview.js
+++ b/ui/components/app/wallet-overview/eth-overview.js
@@ -55,7 +55,7 @@ const EthOverview = ({ className }) => {
   });
   const history = useHistory();
   const keyring = useSelector(getCurrentKeyring);
-  const usingHardwareWallet = isHardwareKeyring(keyring.type);
+  const usingHardwareWallet = isHardwareKeyring(keyring?.type);
   const balanceIsCached = useSelector(isBalanceCached);
   const showFiat = useSelector(getShouldShowFiat);
   const selectedAccount = useSelector(getSelectedAccount);


### PR DESCRIPTION
Sentry Error: https://sentry.io/organizations/metamask/issues/2213773716
Related: https://github.com/MetaMask/metamask-extension/issues/13425

It is possible or `getCurrentKeyring` to return `null` or `undefined`: https://github.com/MetaMask/metamask-extension/blob/develop/ui/selectors/selectors.js#L145

By adding a chain check to `keyring` as it's passed in to `isHardwareKeyring`, it can be allowed to gracefully produce `false` in the case of no keyring
