### PR TITLE
Fix issue where token details page unnecessarily relies on send asset state

### DIFF
--- a/ui/pages/asset/components/token-asset.js
+++ b/ui/pages/asset/components/token-asset.js
@@ -17,8 +17,6 @@ import {
 import { getURLHostName } from '../../../helpers/utils/util';
 import { showModal } from '../../../store/actions';
 import { useNewMetricEvent } from '../../../hooks/useMetricEvent';
-import { ASSET_TYPES, updateSendAsset } from '../../../ducks/send';
-
 import AssetNavigation from './asset-navigation';
 import AssetOptions from './asset-options';
 
@@ -70,13 +68,9 @@ export default function TokenAsset({ token }) {
               dispatch(showModal({ name: 'ACCOUNT_DETAILS' }));
             }}
             onViewTokenDetails={() => {
-              dispatch(
-                updateSendAsset({
-                  type: ASSET_TYPES.TOKEN,
-                  details: { ...token },
-                }),
-              ).then(() => {
-                history.push(TOKEN_DETAILS);
+              history.push({
+                pathname: TOKEN_DETAILS,
+                state: { tokenAddress: token.address },
               });
             }}
             tokenSymbol={token.symbol}

--- a/ui/pages/token-details/token-details-page.js
+++ b/ui/pages/token-details/token-details-page.js
@@ -2,7 +2,6 @@ import React, { useContext } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { Redirect, useHistory } from 'react-router-dom';
 import { getTokens } from '../../ducks/metamask/metamask';
-import { getSendAssetAddress } from '../../ducks/send';
 import { getUseTokenDetection, getTokenList } from '../../selectors';
 import { useCopyToClipboard } from '../../hooks/useCopyToClipboard';
 import { isEqualCaseInsensitive } from '../../helpers/utils/util';
@@ -31,18 +30,13 @@ export default function TokenDetailsPage() {
   const dispatch = useDispatch();
   const history = useHistory();
   const t = useContext(I18nContext);
-
   const tokens = useSelector(getTokens);
   const tokenList = useSelector(getTokenList);
   const useTokenDetection = useSelector(getUseTokenDetection);
 
-  const assetAddress = useSelector((state) => ({
-    asset: getSendAssetAddress(state),
-  }));
+  const tokenAddress = history?.location?.state?.tokenAddress;
 
-  const { asset: tokenAddress } = assetAddress;
-
-  const tokenMetadata = tokenList[tokenAddress];
+  const tokenMetadata = tokenList?.[tokenAddress];
   const fileName = tokenMetadata?.iconUrl;
   const imagePath = useTokenDetection
     ? fileName


### PR DESCRIPTION
Fixes: [This issue](https://docs.google.com/document/d/1OvpkZbvRet33XQVplIc32zlm-6PgSasJcj1XFv9kh9s/edit?disco=AAAAU7k9FMs) in the 10.11.0 RC

Explanation:  In its initial implementation the TokenDetails page unnecessarily uses the `sendAsset` state in the `send duck` to determine which asset to show details for. This change simply pushes the `tokenAddress` to use to fetch the token state for this page in the history object when the user navigates to this page.

Manual testing steps:  
- Switch to Rinkeby
- Complete a swap, so you have a mainnet token add to your token list
- Select the asset
- Select the three dots, then click Token details
- The token details page should show correctly
 