### PR TITLE
fix registerOnboarding method to correctly access completedOnboarding state value

### DIFF
--- a/app/scripts/controllers/onboarding.js
+++ b/app/scripts/controllers/onboarding.js
@@ -69,7 +69,7 @@ export default class OnboardingController {
    * @param {string} tabId - The id of the tab registering
    */
   registerOnboarding = async (location, tabId) => {
-    if (this.completedOnboarding) {
+    if (this.store.getState().completedOnboarding) {
       log.debug('Ignoring registerOnboarding; user already onboarded');
       return;
     }


### PR DESCRIPTION
Fixes: (https://github.com/MetaMask/pm-security/issues/36)

Explanation:  This simply fixes a small bug in the `registerOnboarding` method where the `completedOnboarding` state value is incorrectly accessed, which will lead us to push the tabId of a site - one that has prompted a user who is already onboarded to onboard again - to the `onboardingTabs` state in the onboarding controller. 

This issue appears largely inconsequential since the method itself does not re-initialize the onboarding flow as the LA security audit linked in the issue above seems to suggest. But we can and should fix the issue nonetheless.
