### PR TITLE
Fix token details icon when 'Use Token Detection' is enabled

### DIFF
--- a/ui/pages/token-details/token-details-page.js
+++ b/ui/pages/token-details/token-details-page.js
@@ -35,8 +35,9 @@ export default function TokenDetailsPage() {
   const useTokenDetection = useSelector(getUseTokenDetection);
 
   const tokenAddress = history?.location?.state?.tokenAddress;
-
-  const tokenMetadata = tokenList?.[tokenAddress];
+  const tokenMetadata = Object.values(tokenList).find((token) =>
+    isEqualCaseInsensitive(token.address, tokenAddress),
+  );
   const fileName = tokenMetadata?.iconUrl;
   const imagePath = useTokenDetection
     ? fileName


### PR DESCRIPTION
Fixes an issue found during the QA of `v10.11.0`

When searching the `tokenList` for `tokenMetadata`, a case insensitive address search should be performed. The behavior of the icon on the token details page is now consistent whether or not "Use Token Detection" is enabled