### PR TITLE
fix broken e2e test from out of sync test merged

### DIFF
--- a/test/e2e/tests/add-account.spec.js
+++ b/test/e2e/tests/add-account.spec.js
@@ -123,7 +123,7 @@ describe('Add account', function () {
 
         // restore same seed phrase
         const restoreSeedLink = await driver.findClickableElement(
-          '.unlock-page__link--import',
+          '.unlock-page__link',
         );
 
         await restoreSeedLink.click();


### PR DESCRIPTION
Fixes: Broken e2e test `should add the same account addresses when a secret recovery phrase is imported, the account is locked, and the same secret recovery phrase is imported again` in `add-account.spec.js` on develop

Explanation:  I merged https://github.com/MetaMask/metamask-extension/pull/13668 without updating the branch. https://github.com/MetaMask/metamask-extension/pull/13493 had been merged since I had started my branch and caused a bug in my test. This fixes that bug.

