### PR TITLE
Increase the txHistoryLimit in the transaction controller to 60

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -671,7 +671,7 @@ export default class MetamaskController extends EventEmitter {
         this.networkController,
       ),
       preferencesStore: this.preferencesController.store,
-      txHistoryLimit: 40,
+      txHistoryLimit: 60,
       signTransaction: this.keyringController.signTransaction.bind(
         this.keyringController,
       ),


### PR DESCRIPTION
Fixes: #13551 

Currently, the txHistoryLimit is 40. We are increasing this to 60 to make our state logs more robust and more likely to capture transactions with errors we need to investigate.