### PR TITLE
Swapping the order of ui and app stylesheets

### DIFF
--- a/ui/css/index.scss
+++ b/ui/css/index.scss
@@ -8,8 +8,8 @@
 @import './design-system/index';
 @import './utilities/colors.scss';
 @import './base-styles.scss';
-@import '../components/app/app-components';
 @import '../components/ui/ui-components';
+@import '../components/app/app-components';
 @import '../pages/pages';
 
 /*


### PR DESCRIPTION
Fixes: #13744 

Explanation:  Swaps the order of imports of the `ui` and `app` component stylesheets to improve css class order and overriding styles. This saves devs from using `!important` in their `app` component styles when trying to override some UI component styles.

This **needs be thoroughly tested** but I can't see when there would be a case that a `ui` component styles should override an `app` components styles.

Manual testing steps:  
  - This is kind of hard because it effects all `ui/components/ui` and `ui/components/app` component styles.
  - Run `yarn storybook`
  - Check if any `UI` or `App` component styles look broken?
  
## Screenshots
**BEFORE** Example of custom `app` component styles being overwritten by a `ui` component styles

<img width="1440" alt="Screen Shot 2022-02-24 at 3 33 20 PM" src="https://user-images.githubusercontent.com/8112138/155462509-8134e4f3-922c-4aa3-91ff-2e83ef1de8cf.png">

**AFTER** Custom styles move up in order

<img width="1437" alt="Screen Shot 2022-02-24 at 3 36 30 PM" src="https://user-images.githubusercontent.com/8112138/155462642-8103f351-3ca2-4752-95a7-503589eec4e7.png">
