### PR TITLE
Only calculate "approvalGas" if the "approvalNeeded" param is truthy

### DIFF
--- a/app/scripts/controllers/swaps.js
+++ b/app/scripts/controllers/swaps.js
@@ -270,14 +270,16 @@ export default class SwapsController {
         fetchParams.fromAddress,
         chainId,
       );
+      const firstQuote = Object.values(newQuotes)[0];
 
       // For a user to be able to swap a token, they need to have approved the MetaSwap contract to withdraw that token.
       // _getERC20Allowance() returns the amount of the token they have approved for withdrawal. If that amount is greater
       // than 0, it means that approval has already occurred and is not needed. Otherwise, for tokens to be swapped, a new
       // call of the ERC-20 approve method is required.
       approvalRequired =
+        firstQuote.approvalNeeded &&
         allowance.eq(0) &&
-        Object.values(newQuotes)[0].aggregator !== 'wrappedNative';
+        firstQuote.aggregator !== 'wrappedNative';
       if (!approvalRequired) {
         newQuotes = mapValues(newQuotes, (quote) => ({
           ...quote,
@@ -285,7 +287,7 @@ export default class SwapsController {
         }));
       } else if (!isPolledRequest) {
         const { gasLimit: approvalGas } = await this.timedoutGasReturn(
-          Object.values(newQuotes)[0].approvalNeeded,
+          firstQuote.approvalNeeded,
         );
 
         newQuotes = mapValues(newQuotes, (quote) => ({


### PR DESCRIPTION
This change is already merged into develop, but it's not in 10.10.1. Feel free to close the PR if it's not needed.