### PR TITLE
Handling undefined case for token balance (Token Details)

### DIFF
--- a/ui/pages/token-details/token-details-page.js
+++ b/ui/pages/token-details/token-details-page.js
@@ -93,7 +93,7 @@ export default function TokenDetailsPage() {
             color={COLORS.BLACK}
             className="token-details__token-value"
           >
-            {tokenBalance}
+            {tokenBalance || ''}
           </Typography>
           <Box marginTop={1}>
             <Identicon


### PR DESCRIPTION
This produces a console error on the token details page:
<img width="263" alt="Screen Shot 2022-02-24 at 11 40 21 PM" src="https://user-images.githubusercontent.com/8732757/155667985-093f06f4-10e0-49dc-827e-86784489dd3b.png">

The initial value for `tokenBalance` can come in as `undefined` before being available with the correct value. This handles the display of this value similar to `tokenCurrencyBalance`: https://github.com/MetaMask/metamask-extension/blob/develop/ui/pages/token-details/token-details-page.js#L111 - so we don't have any undefined children

