### PR TITLE
ConfirmImportToken: Update Metrics Logic

### DIFF
--- a/ui/pages/confirm-import-token/confirm-import-token.js
+++ b/ui/pages/confirm-import-token/confirm-import-token.js
@@ -1,4 +1,4 @@
-import React, { useCallback, useContext, useEffect, useState } from 'react';
+import React, { useCallback, useContext, useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useHistory } from 'react-router-dom';
 import {
@@ -9,9 +9,9 @@ import Button from '../../components/ui/button';
 import Identicon from '../../components/ui/identicon';
 import TokenBalance from '../../components/ui/token-balance';
 import { I18nContext } from '../../contexts/i18n';
+import { MetaMetricsContext as NewMetaMetricsContext } from '../../contexts/metametrics.new';
 import { getMostRecentOverviewPage } from '../../ducks/history/history';
 import { getPendingTokens } from '../../ducks/metamask/metamask';
-import { useNewMetricEvent } from '../../hooks/useMetricEvent';
 import { addTokens, clearPendingTokens } from '../../store/actions';
 
 const getTokenName = (name, symbol) => {
@@ -22,23 +22,10 @@ const ConfirmImportToken = () => {
   const t = useContext(I18nContext);
   const dispatch = useDispatch();
   const history = useHistory();
+  const trackEvent = useContext(NewMetaMetricsContext);
 
   const mostRecentOverviewPage = useSelector(getMostRecentOverviewPage);
   const pendingTokens = useSelector(getPendingTokens);
-
-  const [addedToken, setAddedToken] = useState({});
-
-  const trackTokenAddedEvent = useNewMetricEvent({
-    event: 'Token Added',
-    category: 'Wallet',
-    sensitiveProperties: {
-      token_symbol: addedToken.symbol,
-      token_contract_address: addedToken.address,
-      token_decimal_precision: addedToken.decimals,
-      unlisted: addedToken.unlisted,
-      source: addedToken.isCustom ? 'custom' : 'list',
-    },
-  });
 
   const handleAddTokens = useCallback(async () => {
     await dispatch(addTokens(pendingTokens));
@@ -47,8 +34,19 @@ const ConfirmImportToken = () => {
     const firstTokenAddress = addedTokenValues?.[0].address?.toLowerCase();
 
     addedTokenValues.forEach((pendingToken) => {
-      setAddedToken({ ...pendingToken });
+      trackEvent({
+        event: 'Token Added',
+        category: 'Wallet',
+        sensitiveProperties: {
+          token_symbol: pendingToken.symbol,
+          token_contract_address: pendingToken.address,
+          token_decimal_precision: pendingToken.decimals,
+          unlisted: pendingToken.unlisted,
+          source: pendingToken.isCustom ? 'custom' : 'list',
+        },
+      });
     });
+
     dispatch(clearPendingTokens());
 
     if (firstTokenAddress) {
@@ -56,13 +54,7 @@ const ConfirmImportToken = () => {
     } else {
       history.push(mostRecentOverviewPage);
     }
-  }, [dispatch, history, mostRecentOverviewPage, pendingTokens]);
-
-  useEffect(() => {
-    if (Object.keys(addedToken).length) {
-      trackTokenAddedEvent();
-    }
-  }, [addedToken, trackTokenAddedEvent]);
+  }, [dispatch, history, mostRecentOverviewPage, pendingTokens, trackEvent]);
 
   useEffect(() => {
     if (Object.keys(pendingTokens).length === 0) {


### PR DESCRIPTION
Fixes: # 
follow-up for https://github.com/MetaMask/metamask-extension/pull/13594

Explanation:  
We want to make the metrics logic in the ConfirmImportToken component more robust. Currently, it is using a solution that is susceptible to breaking changes. We are using `useEffect` to call `useNewMetricsEvent`. This change removes to use of `useEffect` and `useNewMetricsEvents` by calling `trackEvent` directly.

Manual testing steps:  
- On the main page and underneath the list of accounts, click "import tokens"
- Search any token and select it
- Click "Next"
- Test this "Import Tokens" page works as expected
- Check "Token Added" event in Mixpanel is being tracked as expected