### PR TITLE
fix: chooseAccountList will be scrollable on overflow

### DIFF
--- a/ui/components/ui/account-list/index.scss
+++ b/ui/components/ui/account-list/index.scss
@@ -3,6 +3,7 @@
   flex-direction: column;
   width: 100%;
   align-items: center;
+  overflow-y: auto;
 
   &__header--one-item,
   &__header--multiple-items {

--- a/ui/pages/permissions-connect/choose-account/index.scss
+++ b/ui/pages/permissions-connect/choose-account/index.scss
@@ -1,4 +1,5 @@
 .permissions-connect-choose-account {
+  position: fixed;
   display: flex;
   flex-direction: column;
   align-items: center;


### PR DESCRIPTION
Fixes: #

This PR will be fixing the overflow issue on connecting an account if there is a long list of available accounts.

Issue: 
![image](https://user-images.githubusercontent.com/18554425/155879816-aa75d251-1493-47fa-bcde-09c089f930ba.png)

Proposed fix:
![image](https://user-images.githubusercontent.com/18554425/155879841-972e05ed-a94b-4ac6-b90f-241ab381c509.png)


Explanation:  
Account list component's last child gets under the action buttons if the list's height is larger than the pop-up window. To fix the issue, I propose to make the account list component overflow if its height is greater than its container

Manual testing steps:  
  - A metamask account that has 7+ accounts in it
  - Try to connect your account to a web3 application
  - Check the bottom action buttons to see the last account on the list is under the action buttons