### PR TITLE
Improve the flex property of network form

### DIFF
--- a/ui/pages/settings/networks-tab/index.scss
+++ b/ui/pages/settings/networks-tab/index.scss
@@ -48,7 +48,7 @@
 
   &__network-form {
     display: flex;
-    flex: 1 0;
+    flex: 1 0 auto;
     flex-direction: column;
     justify-content: space-between;
     max-height: 465px;


### PR DESCRIPTION
Explanation:  
When editing the network, the text of "Delete" “Cancel” “Save” button is displayed as multiple lines,  such as Chinese and Japanese.  I improve the flex property of network form  from "flex: 1 0" to "flex: 1 0 auto".  Although it can not completely solve this problem, it has improved a lot.

Before modified：
![813f4194d6b518adf579bd5d52a7ba0](https://user-images.githubusercontent.com/35363592/155884757-44255a2d-e883-4f0c-af32-28f3b38c7ee6.png)
![281d2a1b61058c89fbbdbfed35914a3](https://user-images.githubusercontent.com/35363592/155884776-3625e2e8-b245-4085-858c-51045569110d.png)
After modified：
![220ee5d3a69ae5aeefe75114e834f78](https://user-images.githubusercontent.com/35363592/155884789-860c6c18-a9bf-436b-b27b-0039704abe16.png)
![26f0b68af5a533d4f0f7175985176a4](https://user-images.githubusercontent.com/35363592/155884797-6455c0ae-a0c2-4bdb-bcff-4700347ea6c4.png)
