### PR TITLE
Fixed issues in v10.11.0

### DIFF
--- a/ui/components/ui/typography/typography.js
+++ b/ui/components/ui/typography/typography.js
@@ -86,5 +86,6 @@ Typography.propTypes = {
     'div',
     'dt',
     'dd',
+    'ul',
   ]),
 };

--- a/ui/pages/swaps/slippage-buttons/slippage-buttons.js
+++ b/ui/pages/swaps/slippage-buttons/slippage-buttons.js
@@ -238,7 +238,7 @@ SlippageButtons.propTypes = {
   maxAllowedSlippage: PropTypes.number.isRequired,
   currentSlippage: PropTypes.number,
   smartTransactionsEnabled: PropTypes.bool.isRequired,
-  smartTransactionsOptInStatus: PropTypes.object,
+  smartTransactionsOptInStatus: PropTypes.bool,
   setSmartTransactionsOptInStatus: PropTypes.func,
   currentSmartTransactionsError: PropTypes.string,
 };


### PR DESCRIPTION
Fixed these issues in v10.11.0 
1. After landing on Swap, a disclaimer of Smart Transactions appear, and an error on devTools shows the following: “invalid prop ‘type’ of value ‘ul’” supplied to ‘Typography’
2. After enabling Smart Transactions, an error on devTools shows the following: “invalid prop ‘smartTransactionsOptInSatus’ of type ‘boolean supplied to ‘SlippageButtons’

Signed-off-by: Akintayo A. Olusegun <akintayo.segun@gmail.com>

Fixes: #

Explanation:  

Manual testing steps:  
  - 
  - 
  - 