### PR TITLE
Add e2e testcase for token details functionality

### DIFF
--- a/test/e2e/helpers.js
+++ b/test/e2e/helpers.js
@@ -273,6 +273,15 @@ const completeImportSRPOnboardingFlow = async (
   }
 };
 
+const elementExists = async (driver, element) => {
+  try {
+    await driver.findElement(element);
+    return true;
+  } catch (NoSuchElementException) {
+    return false;
+  }
+};
+
 module.exports = {
   getWindowHandles,
   convertToHexValue,
@@ -282,4 +291,5 @@ module.exports = {
   withFixtures,
   connectDappWithExtensionPopup,
   completeImportSRPOnboardingFlow,
+  elementExists,
 };

--- a/test/e2e/helpers.js
+++ b/test/e2e/helpers.js
@@ -273,15 +273,6 @@ const completeImportSRPOnboardingFlow = async (
   }
 };
 
-const elementExists = async (driver, element) => {
-  try {
-    await driver.findElement(element);
-    return true;
-  } catch (NoSuchElementException) {
-    return false;
-  }
-};
-
 module.exports = {
   getWindowHandles,
   convertToHexValue,
@@ -291,5 +282,4 @@ module.exports = {
   withFixtures,
   connectDappWithExtensionPopup,
   completeImportSRPOnboardingFlow,
-  elementExists,
 };

--- a/test/e2e/tests/token-details.spec.js
+++ b/test/e2e/tests/token-details.spec.js
@@ -1,0 +1,56 @@
+const { strict: assert } = require('assert');
+const {
+  convertToHexValue,
+  withFixtures,
+  regularDelayMs,
+} = require('../helpers');
+
+describe('Token Details', function () {
+  const ganacheOptions = {
+    accounts: [
+      {
+        secretKey:
+          '0x7C9529A67102755B7E6102D6D950AC5D5863C98713805CEC576B945B15B71EAC',
+        balance: convertToHexValue(25000000000000000000),
+      },
+    ],
+  };
+  it('should show token details for an imported token', async function () {
+    await withFixtures(
+      {
+        fixtures: 'imported-account',
+        ganacheOptions,
+        title: this.test.title,
+      },
+      async ({ driver }) => {
+        await driver.navigate();
+        await driver.fill('#password', 'correct horse battery staple');
+        await driver.press('#password', driver.Key.ENTER);
+
+        await driver.clickElement({ text: 'import tokens', tag: 'a' });
+        await driver.clickElement({ text: 'Custom Token', tag: 'button' });
+
+        const tokenAddress = '0x2EFA2Cb29C2341d8E5Ba7D3262C9e9d6f1Bf3711';
+        const tokenSymbol = 'AAVE';
+
+        await driver.fill('#custom-address', tokenAddress);
+        await driver.delay(regularDelayMs);
+        await driver.fill('#custom-symbol', tokenSymbol);
+        await driver.clickElement({ text: 'Add Custom Token', tag: 'button' });
+        await driver.clickElement({ text: 'Import Tokens', tag: 'button' });
+        await driver.waitForSelector('[title="Asset options"]');
+        await driver.clickElement('[title="Asset options"]');
+        await driver.waitForSelector({ text: 'Token details', tag: 'span' });
+        await driver.clickElement({ text: 'Token details', tag: 'span' });
+
+        // Using findElements for avoiding error handling, if element is not present
+        const tokenAddressFound = await driver.findElements({
+          text: tokenAddress,
+        });
+
+        // If element was not found, array length would be 0
+        assert.equal(tokenAddressFound.length, 1);
+      },
+    );
+  });
+});

--- a/test/e2e/tests/token-details.spec.js
+++ b/test/e2e/tests/token-details.spec.js
@@ -1,9 +1,5 @@
 const { strict: assert } = require('assert');
-const {
-  convertToHexValue,
-  withFixtures,
-  elementExists,
-} = require('../helpers');
+const { convertToHexValue, withFixtures } = require('../helpers');
 
 describe('Token Details', function () {
   const ganacheOptions = {
@@ -45,9 +41,9 @@ describe('Token Details', function () {
           text: tokenAddress,
         };
 
-        const exists = await elementExists(driver, tokenAddressFound);
+        const exists = await driver.assertElementPresent(tokenAddressFound);
 
-        assert.equal(exists, true);
+        assert.ok(exists, 'Token details are not correct.');
       },
     );
   });

--- a/test/e2e/tests/token-details.spec.js
+++ b/test/e2e/tests/token-details.spec.js
@@ -1,5 +1,9 @@
 const { strict: assert } = require('assert');
-const { convertToHexValue, withFixtures } = require('../helpers');
+const {
+  convertToHexValue,
+  withFixtures,
+  elementExists,
+} = require('../helpers');
 
 describe('Token Details', function () {
   const ganacheOptions = {
@@ -37,13 +41,13 @@ describe('Token Details', function () {
         await driver.clickElement('[title="Asset options"]');
         await driver.clickElement({ text: 'Token details', tag: 'span' });
 
-        // Using findElements for avoiding error handling, if element is not present
-        const tokenAddressFound = await driver.findElements({
+        const tokenAddressFound = {
           text: tokenAddress,
-        });
+        };
 
-        // If element was not found, array length would be 0
-        assert.equal(tokenAddressFound.length, 1);
+        const exists = await elementExists(driver, tokenAddressFound);
+
+        assert.equal(exists, true);
       },
     );
   });

--- a/test/e2e/tests/token-details.spec.js
+++ b/test/e2e/tests/token-details.spec.js
@@ -41,7 +41,7 @@ describe('Token Details', function () {
           text: tokenAddress,
         };
 
-        const exists = await driver.assertElementPresent(tokenAddressFound);
+        const exists = await driver.isElementPresent(tokenAddressFound);
 
         assert.ok(exists, 'Token details are not correct.');
       },

--- a/test/e2e/tests/token-details.spec.js
+++ b/test/e2e/tests/token-details.spec.js
@@ -1,9 +1,5 @@
 const { strict: assert } = require('assert');
-const {
-  convertToHexValue,
-  withFixtures,
-  regularDelayMs,
-} = require('../helpers');
+const { convertToHexValue, withFixtures } = require('../helpers');
 
 describe('Token Details', function () {
   const ganacheOptions = {
@@ -34,13 +30,11 @@ describe('Token Details', function () {
         const tokenSymbol = 'AAVE';
 
         await driver.fill('#custom-address', tokenAddress);
-        await driver.delay(regularDelayMs);
+        await driver.waitForSelector('#custom-symbol-helper-text');
         await driver.fill('#custom-symbol', tokenSymbol);
         await driver.clickElement({ text: 'Add Custom Token', tag: 'button' });
         await driver.clickElement({ text: 'Import Tokens', tag: 'button' });
-        await driver.waitForSelector('[title="Asset options"]');
         await driver.clickElement('[title="Asset options"]');
-        await driver.waitForSelector({ text: 'Token details', tag: 'span' });
         await driver.clickElement({ text: 'Token details', tag: 'span' });
 
         // Using findElements for avoiding error handling, if element is not present

--- a/test/e2e/webdriver/driver.js
+++ b/test/e2e/webdriver/driver.js
@@ -248,6 +248,15 @@ class Driver {
     assert.ok(!dataTab, 'Found element that should not be present');
   }
 
+  async assertElementPresent(element) {
+    try {
+      await this.findElement(element);
+      return true;
+    } catch (err) {
+      return false;
+    }
+  }
+
   // Navigation
 
   async navigate(page = Driver.PAGES.HOME) {

--- a/test/e2e/webdriver/driver.js
+++ b/test/e2e/webdriver/driver.js
@@ -248,7 +248,7 @@ class Driver {
     assert.ok(!dataTab, 'Found element that should not be present');
   }
 
-  async assertElementPresent(element) {
+  async isElementPresent(element) {
     try {
       await this.findElement(element);
       return true;


### PR DESCRIPTION
**Explanation**:  
After [Token Details](https://github.com/MetaMask/metamask-extension/pull/13216) page has been added, we are increasing e2e coverage, for testing token details functionality.
This testcase imports a token and checks that token details page is correctly loaded, by looking at the contract address field on the token Details page.