### PR TITLE
Restoring create password form layout

### DIFF
--- a/ui/pages/first-time-flow/index.scss
+++ b/ui/pages/first-time-flow/index.scss
@@ -29,7 +29,8 @@
     }
   }
 
-  &__import {
+  &__import,
+  &__form {
     display: flex;
     flex-direction: column;
   }


### PR DESCRIPTION
Fixes an issue identified during the QA of `10.11.0`

This regressed as a result of: https://github.com/MetaMask/metamask-extension/commit/429451de236b28cf30b53362a07bad58b7b3a22a#diff-e90c7ae0e2b4f4aeeb7f21124d526aef1058a4d49be2c47d878a259f0bc088deR32

<img width="332" alt="Screen Shot 2022-03-02 at 7 06 48 PM" src="https://user-images.githubusercontent.com/8732757/156482742-232a8999-371b-4b5c-a25e-ad66580fd792.png">

