### PR TITLE
Fix switching between ETH and USD

### DIFF
--- a/test/e2e/tests/send-eth.spec.js
+++ b/test/e2e/tests/send-eth.spec.js
@@ -104,7 +104,7 @@ describe('Send ETH from inside MetaMask using advanced gas modal', function () {
     ],
   };
   it('finds the transaction in the transactions list', async function () {
-    await withFixtures(
+    withFixtures(
       {
         fixtures: 'imported-account',
         ganacheOptions,

--- a/test/e2e/tests/send-eth.spec.js
+++ b/test/e2e/tests/send-eth.spec.js
@@ -104,7 +104,7 @@ describe('Send ETH from inside MetaMask using advanced gas modal', function () {
     ],
   };
   it('finds the transaction in the transactions list', async function () {
-    withFixtures(
+    await withFixtures(
       {
         fixtures: 'imported-account',
         ganacheOptions,

--- a/ui/components/app/currency-input/currency-input.js
+++ b/ui/components/app/currency-input/currency-input.js
@@ -44,7 +44,7 @@ export default function CurrencyInput({
 
   const [isSwapped, setSwapped] = useState(false);
   const [newHexValue, setNewHexValue] = useState(hexValue);
-  const [newFeatureSecondary, setNewFeatureSecondary] = useState(
+  const [shouldDisplayFiat, setShouldDisplayFiat] = useState(
     featureSecondary,
   );
 
@@ -53,7 +53,7 @@ export default function CurrencyInput({
       return false;
     }
 
-    return Boolean(newFeatureSecondary);
+    return Boolean(shouldDisplayFiat);
   };
 
   const getDecimalValue = () => {
@@ -78,7 +78,7 @@ export default function CurrencyInput({
   const swap = async () => {
     await onPreferenceToggle();
     setSwapped(!isSwapped);
-    setNewFeatureSecondary(!newFeatureSecondary);
+    setShouldDisplayFiat(!shouldDisplayFiat);
   };
 
   const handleChange = async (newDecimalValue) => {

--- a/ui/components/app/currency-input/currency-input.js
+++ b/ui/components/app/currency-input/currency-input.js
@@ -79,7 +79,7 @@ export default function CurrencyInput({
     setShouldDisplayFiat(!shouldDisplayFiat);
   };
 
-  const handleChange = async (newDecimalValue) => {
+  const handleChange = (newDecimalValue) => {
     const hexValueNew = shouldUseFiat()
       ? getWeiHexFromDecimalValue({
           value: newDecimalValue,
@@ -95,7 +95,7 @@ export default function CurrencyInput({
         });
 
     setNewHexValue(hexValueNew);
-    await onChange(hexValueNew);
+    onChange(hexValueNew);
     setSwapped(!isSwapped);
   };
 

--- a/ui/components/app/currency-input/currency-input.js
+++ b/ui/components/app/currency-input/currency-input.js
@@ -44,7 +44,7 @@ export default function CurrencyInput({
 
   const [isSwapped, setSwapped] = useState(false);
   const [newHexValue, setNewHexValue] = useState(hexValue);
-  const [newfeatureSecondary, setNewFeatureSecondary] = useState(
+  const [newFeatureSecondary, setNewFeatureSecondary] = useState(
     featureSecondary,
   );
 
@@ -53,7 +53,7 @@ export default function CurrencyInput({
       return false;
     }
 
-    return Boolean(featureSecondary);
+    return Boolean(newFeatureSecondary);
   };
 
   const getDecimalValue = () => {
@@ -74,12 +74,11 @@ export default function CurrencyInput({
   };
 
   const initialDecimalValue = hexValue ? getDecimalValue() : 0;
-  const [decimalValue, setDecimalValue] = useState(initialDecimalValue);
 
   const swap = async () => {
     await onPreferenceToggle();
     setSwapped(!isSwapped);
-    setNewFeatureSecondary(!newfeatureSecondary);
+    setNewFeatureSecondary(!newFeatureSecondary);
   };
 
   const handleChange = async (newDecimalValue) => {
@@ -98,24 +97,20 @@ export default function CurrencyInput({
         });
 
     setNewHexValue(hexValueNew);
-    setDecimalValue(newDecimalValue);
     await onChange(hexValueNew);
     setSwapped(!isSwapped);
   };
 
   useEffect(() => {
     setNewHexValue(hexValue);
-    const newDecimalValue = getDecimalValue();
-    setDecimalValue(newDecimalValue);
-    handleChange(decimalValue);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [hexValue]);
 
   useEffect(() => {
     if (featureSecondary) {
-      setNewFeatureSecondary(false);
+      handleChange(initialDecimalValue);
     }
-  }, [featureSecondary]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [featureSecondary, initialDecimalValue]);
 
   const renderConversionComponent = () => {
     let currency, numberOfDecimals;
@@ -162,7 +157,7 @@ export default function CurrencyInput({
       }}
       suffix={shouldUseFiat() ? secondarySuffix : primarySuffix}
       onChange={handleChange}
-      value={newfeatureSecondary ? initialDecimalValue : decimalValue}
+      value={initialDecimalValue}
       actionComponent={
         <button className="currency-input__swap-component" onClick={swap}>
           <i className="fa fa-retweet fa-lg" />

--- a/ui/components/app/currency-input/currency-input.js
+++ b/ui/components/app/currency-input/currency-input.js
@@ -44,9 +44,7 @@ export default function CurrencyInput({
 
   const [isSwapped, setSwapped] = useState(false);
   const [newHexValue, setNewHexValue] = useState(hexValue);
-  const [shouldDisplayFiat, setShouldDisplayFiat] = useState(
-    featureSecondary,
-  );
+  const [shouldDisplayFiat, setShouldDisplayFiat] = useState(featureSecondary);
 
   const shouldUseFiat = () => {
     if (hideSecondary) {

--- a/ui/components/app/currency-input/currency-input.js
+++ b/ui/components/app/currency-input/currency-input.js
@@ -44,6 +44,9 @@ export default function CurrencyInput({
 
   const [isSwapped, setSwapped] = useState(false);
   const [newHexValue, setNewHexValue] = useState(hexValue);
+  const [newfeatureSecondary, setNewFeatureSecondary] = useState(
+    featureSecondary,
+  );
 
   const shouldUseFiat = () => {
     if (hideSecondary) {
@@ -73,19 +76,13 @@ export default function CurrencyInput({
   const initialDecimalValue = hexValue ? getDecimalValue() : 0;
   const [decimalValue, setDecimalValue] = useState(initialDecimalValue);
 
-  useEffect(() => {
-    setNewHexValue(hexValue);
-    const newDecimalValue = getDecimalValue();
-    setDecimalValue(newDecimalValue);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [hexValue]);
-
   const swap = async () => {
     await onPreferenceToggle();
     setSwapped(!isSwapped);
+    setNewFeatureSecondary(!newfeatureSecondary);
   };
 
-  const handleChange = (newDecimalValue) => {
+  const handleChange = async (newDecimalValue) => {
     const hexValueNew = shouldUseFiat()
       ? getWeiHexFromDecimalValue({
           value: newDecimalValue,
@@ -102,16 +99,23 @@ export default function CurrencyInput({
 
     setNewHexValue(hexValueNew);
     setDecimalValue(newDecimalValue);
-    onChange(hexValueNew);
+    await onChange(hexValueNew);
     setSwapped(!isSwapped);
   };
 
   useEffect(() => {
-    if (isSwapped) {
-      handleChange(decimalValue);
-    }
+    setNewHexValue(hexValue);
+    const newDecimalValue = getDecimalValue();
+    setDecimalValue(newDecimalValue);
+    handleChange(decimalValue);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isSwapped]);
+  }, [hexValue]);
+
+  useEffect(() => {
+    if (featureSecondary) {
+      setNewFeatureSecondary(false);
+    }
+  }, [featureSecondary]);
 
   const renderConversionComponent = () => {
     let currency, numberOfDecimals;
@@ -158,7 +162,7 @@ export default function CurrencyInput({
       }}
       suffix={shouldUseFiat() ? secondarySuffix : primarySuffix}
       onChange={handleChange}
-      value={decimalValue}
+      value={newfeatureSecondary ? initialDecimalValue : decimalValue}
       actionComponent={
         <button className="currency-input__swap-component" onClick={swap}>
           <i className="fa fa-retweet fa-lg" />

--- a/ui/components/app/currency-input/currency-input.js
+++ b/ui/components/app/currency-input/currency-input.js
@@ -45,17 +45,10 @@ export default function CurrencyInput({
   const [isSwapped, setSwapped] = useState(false);
   const [newHexValue, setNewHexValue] = useState(hexValue);
   const [shouldDisplayFiat, setShouldDisplayFiat] = useState(featureSecondary);
-
-  const shouldUseFiat = () => {
-    if (hideSecondary) {
-      return false;
-    }
-
-    return Boolean(shouldDisplayFiat);
-  };
+  const shouldUseFiat = hideSecondary ? false : Boolean(shouldDisplayFiat);
 
   const getDecimalValue = () => {
-    const decimalValueString = shouldUseFiat()
+    const decimalValueString = shouldUseFiat
       ? getValueFromWeiHex({
           value: hexValue,
           toCurrency: secondaryCurrency,
@@ -80,7 +73,7 @@ export default function CurrencyInput({
   };
 
   const handleChange = (newDecimalValue) => {
-    const hexValueNew = shouldUseFiat()
+    const hexValueNew = shouldUseFiat
       ? getWeiHexFromDecimalValue({
           value: newDecimalValue,
           fromCurrency: secondaryCurrency,
@@ -121,7 +114,7 @@ export default function CurrencyInput({
       );
     }
 
-    if (shouldUseFiat()) {
+    if (shouldUseFiat) {
       // Display ETH
       currency = preferredCurrency || ETH;
       numberOfDecimals = 8;
@@ -153,7 +146,7 @@ export default function CurrencyInput({
         onChange,
         onPreferenceToggle,
       }}
-      suffix={shouldUseFiat() ? secondarySuffix : primarySuffix}
+      suffix={shouldUseFiat ? secondarySuffix : primarySuffix}
       onChange={handleChange}
       value={initialDecimalValue}
       actionComponent={

--- a/ui/components/app/currency-input/currency-input.test.js
+++ b/ui/components/app/currency-input/currency-input.test.js
@@ -109,10 +109,15 @@ describe('CurrencyInput Component', () => {
         },
       };
       const store = configureMockStore()(mockStore);
+      const handleChangeSpy = sinon.spy();
 
       const wrapper = mount(
         <Provider store={store}>
-          <CurrencyInput hexValue="f602f2234d0ea" featureSecondary />
+          <CurrencyInput
+            onChange={handleChangeSpy}
+            hexValue="f602f2234d0ea"
+            featureSecondary
+          />
         </Provider>,
       );
 
@@ -140,12 +145,16 @@ describe('CurrencyInput Component', () => {
         },
         hideSecondary: true,
       };
-
       const store = configureMockStore()(mockStore);
+      const handleChangeSpy = sinon.spy();
 
       const wrapper = mount(
         <Provider store={store}>
-          <CurrencyInput hexValue="f602f2234d0ea" featureSecondary />
+          <CurrencyInput
+            onChange={handleChangeSpy}
+            hexValue="f602f2234d0ea"
+            featureSecondary
+          />
         </Provider>,
         {
           context: { t: (str) => `${str}_t` },

--- a/ui/components/app/currency-input/currency-input.test.js
+++ b/ui/components/app/currency-input/currency-input.test.js
@@ -198,14 +198,14 @@ describe('CurrencyInput Component', () => {
       );
 
       expect(wrapper).toHaveLength(1);
-      expect(handleChangeSpy.callCount).toStrictEqual(1);
+      expect(handleChangeSpy.callCount).toStrictEqual(0);
       expect(handleBlurSpy.callCount).toStrictEqual(0);
 
       const input = wrapper.find('input');
       expect(input.props().value).toStrictEqual(0.00432788);
 
       input.simulate('change', { target: { value: 1 } });
-      expect(handleChangeSpy.callCount).toStrictEqual(2);
+      expect(handleChangeSpy.callCount).toStrictEqual(1);
       expect(handleChangeSpy.calledWith('de0b6b3a7640000')).toStrictEqual(true);
       expect(wrapper.find('.currency-display-component').text()).toStrictEqual(
         '$231.06USD',

--- a/ui/components/app/currency-input/currency-input.test.js
+++ b/ui/components/app/currency-input/currency-input.test.js
@@ -198,7 +198,7 @@ describe('CurrencyInput Component', () => {
       );
 
       expect(wrapper).toHaveLength(1);
-      expect(handleChangeSpy.callCount).toStrictEqual(0);
+      expect(handleChangeSpy.callCount).toStrictEqual(1);
       expect(handleBlurSpy.callCount).toStrictEqual(0);
 
       const input = wrapper.find('input');
@@ -234,7 +234,7 @@ describe('CurrencyInput Component', () => {
       );
 
       expect(wrapper).toHaveLength(1);
-      expect(handleChangeSpy.callCount).toStrictEqual(0);
+      expect(handleChangeSpy.callCount).toStrictEqual(1);
       expect(handleBlurSpy.callCount).toStrictEqual(0);
 
       expect(wrapper.find('.currency-display-component').text()).toStrictEqual(
@@ -307,7 +307,7 @@ describe('CurrencyInput Component', () => {
       );
 
       expect(wrapper).toHaveLength(1);
-      expect(handleChangeSpy.callCount).toStrictEqual(0);
+      expect(handleChangeSpy.callCount).toStrictEqual(1);
       expect(handleBlurSpy.callCount).toStrictEqual(0);
 
       expect(wrapper.find('.currency-display-component').text()).toStrictEqual(


### PR DESCRIPTION
fixes: #13275, #12811

**Explanation:**  Fix switching between ETH and USD and handling invalid prop `currentTransaction`. 

**Steps to Reproduce**

1. Click on Send
2. Enter an address or swap between accounts
3. Enter a value in Token (Like ETH)
4. Press the ^v icon to change to USD as the input

**Screencast (Fix switching between ETH and USD):**


https://user-images.githubusercontent.com/92527393/157023398-42190e7d-a88d-41e1-b034-672b02bac790.mov


Invalid prop `currentTransaction` produces a console error on the transaction confirmation page:

![Screenshot 2022-03-03 at 10 06 33](https://user-images.githubusercontent.com/92527393/156551934-b77f5058-1a2a-43c8-907d-3927255048bf.png)

This console error is now handled.

