### PR TITLE
Use pre-wrap instead of pre for signature content

### DIFF
--- a/ui/components/app/signature-request-original/index.scss
+++ b/ui/components/app/signature-request-original/index.scss
@@ -222,7 +222,7 @@
     overflow-wrap: break-word;
     border-bottom: 1px solid #d2d8dd;
     padding: 6px 18px 15px;
-    white-space: pre;
+    white-space: pre-wrap;
   }
 
   &__help-link {


### PR DESCRIPTION
### Fixes
An issue where long signature text is not wrapping.

### Explanation
We have a use case where we want to display a long (non-standard) message for the user to sign. There was a change recently that changed the CSS `white-space` setting from `pre-line` to `pre` which causes our messages to no longer wrap and therefore become unreadable to the user. Horizontal scrolling to each the full message is also not available. See: https://github.com/MetaMask/metamask-extension/pull/13340 for the previously implemented change to `white-space: pre;`

I've updated the `white-space` setting again `pre-wrap` which appears to fix the issue. Vertical scrolling still works and long lines wrap correctly. `pre-wrap` is very similar to `pre` except that it will also wrap text when needed. Sources:

- https://www.digitalocean.com/community/tutorials/css-white-space-property
- https://developer.mozilla.org/en-US/docs/Web/CSS/white-space

### Manual testing steps
  - Enter a long string as a signature message

| With `pre`   |  With `pre-wrap`   |
|---|---|
| <img src="https://user-images.githubusercontent.com/4114009/156554073-654f4089-7e30-4a18-b76f-7fa4b4b1d94c.png" height=450></img>  |  <img src="https://user-images.githubusercontent.com/4114009/156554225-857311ff-d12b-49f8-871a-9688b4757b86.png" height=450></img>  |





