### PR TITLE
[GridPlus] Updates Lattice dependencies

### DIFF
--- a/app/manifest/_base.json
+++ b/app/manifest/_base.json
@@ -66,7 +66,7 @@
     "clipboardWrite",
     "http://localhost:8545/",
     "https://*.infura.io/",
-    "https://wallet.gridplus.io/*",
+    "https://lattice.gridplus.io/*",
     "activeTab",
     "webRequest",
     "*://*.eth/",

--- a/lavamoat/browserify/beta/policy.json
+++ b/lavamoat/browserify/beta/policy.json
@@ -2340,6 +2340,7 @@
     "gridplus-sdk": {
       "globals": {
         "console.error": true,
+        "console.warn": true,
         "setTimeout": true
       },
       "packages": {
@@ -2353,6 +2354,7 @@
         "crc-32": true,
         "elliptic": true,
         "eth-eip712-util-browser": true,
+        "hash.js": true,
         "js-sha3": true,
         "rlp-browser": true,
         "secp256k1": true,

--- a/lavamoat/browserify/flask/policy.json
+++ b/lavamoat/browserify/flask/policy.json
@@ -2359,6 +2359,7 @@
     "gridplus-sdk": {
       "globals": {
         "console.error": true,
+        "console.warn": true,
         "setTimeout": true
       },
       "packages": {
@@ -2372,6 +2373,7 @@
         "crc-32": true,
         "elliptic": true,
         "eth-eip712-util-browser": true,
+        "hash.js": true,
         "js-sha3": true,
         "rlp-browser": true,
         "secp256k1": true,

--- a/lavamoat/browserify/main/policy.json
+++ b/lavamoat/browserify/main/policy.json
@@ -2340,6 +2340,7 @@
     "gridplus-sdk": {
       "globals": {
         "console.error": true,
+        "console.warn": true,
         "setTimeout": true
       },
       "packages": {
@@ -2353,6 +2354,7 @@
         "crc-32": true,
         "elliptic": true,
         "eth-eip712-util-browser": true,
+        "hash.js": true,
         "js-sha3": true,
         "rlp-browser": true,
         "secp256k1": true,

--- a/package.json
+++ b/package.json
@@ -151,7 +151,7 @@
     "eth-json-rpc-infura": "^5.1.0",
     "eth-json-rpc-middleware": "^8.0.0",
     "eth-keyring-controller": "^6.2.0",
-    "eth-lattice-keyring": "^0.4.0",
+    "eth-lattice-keyring": "^0.5.0",
     "eth-method-registry": "^2.0.0",
     "eth-query": "^2.1.2",
     "eth-rpc-errors": "^4.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11096,16 +11096,16 @@ eth-keyring-controller@^6.2.0, eth-keyring-controller@^6.2.1:
     loglevel "^1.5.0"
     obs-store "^4.0.3"
 
-eth-lattice-keyring@^0.4.0:
-  version "0.4.9"
-  resolved "https://registry.yarnpkg.com/eth-lattice-keyring/-/eth-lattice-keyring-0.4.9.tgz#327a41fa25ef28dfc9fe87f2ce11e95139adfd67"
-  integrity sha512-ZflOgYrbuGJGPSDWgDA6PndCIlYRS2M+/bxKsJupbPgz/O8XwQdTGttszp0mHwOqPdvUULUmW08QCqd8trnuVg==
+eth-lattice-keyring@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/eth-lattice-keyring/-/eth-lattice-keyring-0.5.0.tgz#19dbbc2de31008dfd576531fa44a5d34061e61c8"
+  integrity sha512-+6iTQqrAqneUDfLR5aLVmYtys++a8C5N6F/9ibEtGT3YNYUE0NLZMI/DvFz/JhjpHhTjSXXtSb3yUajW6liAaQ==
   dependencies:
     "@ethereumjs/common" "^2.4.0"
     "@ethereumjs/tx" "^3.1.1"
     bignumber.js "^9.0.1"
     ethereumjs-util "^7.0.10"
-    gridplus-sdk "^0.9.7"
+    gridplus-sdk "^1.0.0"
 
 eth-lib@0.2.8:
   version "0.2.8"
@@ -13480,10 +13480,10 @@ graphql-subscriptions@^1.1.0:
   resolved "https://registry.yarnpkg.com/graphql/-/graphql-15.8.0.tgz#33410e96b012fa3bdb1091cc99a94769db212b38"
   integrity sha512-5gghUc24tP9HRznNpV2+FIoq3xKkj5dTQqf4v0CpdPbFVwFkWoxOM+o+2OC9ZSvjEMTjfmG9QT+gcvggTwW1zw==
 
-gridplus-sdk@^0.9.7:
-  version "0.9.10"
-  resolved "https://registry.yarnpkg.com/gridplus-sdk/-/gridplus-sdk-0.9.10.tgz#8835e8bc9a2ca7ae163520ddcc0b313350e67dd2"
-  integrity sha512-CNvhyaz3F8UvlHqihFJlOt+FenmFkb2dFrbBTyRth/nlzD8Tm0HjW+uyY1W0ekDp45Exz9l0VY0EmdvjphBe1w==
+gridplus-sdk@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/gridplus-sdk/-/gridplus-sdk-1.0.0.tgz#008a24a8ec5b50a6fdb8005723a77f5d24fc88cd"
+  integrity sha512-vVyLyAY7Ockkf8hv+em1KkjPwvKkLmb7mYZFY2Vtt60+qpmPut1S2/WjrZGdNGGawWAKAmpw8WKdw5MSg2UkpA==
   dependencies:
     aes-js "^3.1.1"
     bech32 "^2.0.0"
@@ -13495,6 +13495,7 @@ gridplus-sdk@^0.9.7:
     crc-32 "^1.2.0"
     elliptic "6.5.4"
     eth-eip712-util-browser "^0.0.3"
+    hash.js "^1.1.7"
     js-sha3 "^0.8.0"
     rlp-browser "^1.0.1"
     secp256k1 "4.0.2"


### PR DESCRIPTION
Changes:

* Updates gridplus.io url in manifest file (previous subdomain was outdated and therefore breaks on Firefox)
* Updates `gridplus-sdk` to `v1.0.0` ([release](https://github.com/GridPlus/gridplus-sdk/releases/tag/v1.0.0))
* Updates `eth-lattice-keyring` to `v0.5.0` ([diff](https://github.com/GridPlus/eth-lattice-keyring/compare/v0.4.9...v0.5.0))

These updates allow the following:
* Exposure to new functionality in Lattice firmware `v0.14.0` (backwards compatible)
* Much better state management of the SDK session, including the ability to dry out a session and rehydrate it synchronously
* Fixes a bug introduced in previous keyring version related to switching wallets