### PR TITLE
Showing new message while converting token to NFT

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -635,7 +635,7 @@
     "message": "We've detected that this asset is an NFT. Metamask now has full native support for NFTs. Would you like to remove it from your token list and add it as an NFT?"
   },
   "convertTokenToNFTExistDescription": {
-    "message": "We’ve detected that this asset is an NFT and has been added as an NFT. Would you like to remove it from your token list?"
+    "message": "We’ve detected that this asset has been added as an NFT. Would you like to remove it from your token list?"
   },
   "copiedExclamation": {
     "message": "Copied!"

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -634,6 +634,9 @@
   "convertTokenToNFTDescription": {
     "message": "We've detected that this asset is an NFT. Metamask now has full native support for NFTs. Would you like to remove it from your token list and add it as an NFT?"
   },
+  "convertTokenToNFTExistDescription": {
+    "message": "We’ve detected that this asset is an NFT and has been added as an NFT. Would you like to remove it from your token list?"
+  },
   "copiedExclamation": {
     "message": "Copied!"
   },

--- a/ui/components/app/modals/convert-token-to-nft-modal/convert-token-to-nft-modal.js
+++ b/ui/components/app/modals/convert-token-to-nft-modal/convert-token-to-nft-modal.js
@@ -1,23 +1,44 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { useHistory } from 'react-router-dom';
+import { useDispatch, useSelector } from 'react-redux';
 import Modal from '../../modal';
 import Typography from '../../../ui/typography';
 import { TYPOGRAPHY } from '../../../../helpers/constants/design-system';
 import withModalProps from '../../../../helpers/higher-order-components/with-modal-props';
 import { useI18nContext } from '../../../../hooks/useI18nContext';
-import { ADD_COLLECTIBLE_ROUTE } from '../../../../helpers/constants/routes';
+import {
+  ADD_COLLECTIBLE_ROUTE,
+  ASSET_ROUTE,
+} from '../../../../helpers/constants/routes';
+import { getCollectibles } from '../../../../ducks/metamask/metamask';
+import { isEqualCaseInsensitive } from '../../../../helpers/utils/util';
+import { removeToken } from '../../../../store/actions';
 
 const ConvertTokenToNFTModal = ({ hideModal, tokenAddress }) => {
   const history = useHistory();
   const t = useI18nContext();
+  const dispatch = useDispatch();
+  const allCollectibles = useSelector(getCollectibles);
+  const tokenAddedAsNFT = allCollectibles.find(({ address }) =>
+    isEqualCaseInsensitive(address, tokenAddress),
+  );
+
   return (
     <Modal
-      onSubmit={() => {
-        history.push({
-          pathname: ADD_COLLECTIBLE_ROUTE,
-          state: { tokenAddress },
-        });
+      onSubmit={async () => {
+        if (tokenAddedAsNFT) {
+          await dispatch(removeToken(tokenAddress));
+          const { tokenId } = tokenAddedAsNFT;
+          history.push({
+            pathname: `${ASSET_ROUTE}/${tokenAddress}/${tokenId}`,
+          });
+        } else {
+          history.push({
+            pathname: ADD_COLLECTIBLE_ROUTE,
+            state: { tokenAddress },
+          });
+        }
         hideModal();
       }}
       submitText={t('yes')}
@@ -31,7 +52,9 @@ const ConvertTokenToNFTModal = ({ hideModal, tokenAddress }) => {
             marginTop: 2,
           }}
         >
-          {t('convertTokenToNFTDescription')}
+          {tokenAddedAsNFT
+            ? t('convertTokenToNFTExistDescription')
+            : t('convertTokenToNFTDescription')}
         </Typography>
       </div>
     </Modal>

--- a/ui/pages/add-collectible/add-collectible.js
+++ b/ui/pages/add-collectible/add-collectible.js
@@ -102,7 +102,7 @@ export default function AddCollectible() {
           {collectibleAddFailed && (
             <ActionableMessage
               type="danger"
-              useIcon="true"
+              useIcon
               iconFillColor="#d73a49"
               message={
                 <Box display={DISPLAY.INLINE_FLEX}>


### PR DESCRIPTION
Fixes: #13837 

If a user clicks on the token in the assets tab and the same NFT is already imported via the import NFT page, then a new copy is displayed on the modal, and upon clicking `yes` the entry from the Asset tab will be deleted and the user will be redirected to the NFT first entry with the token Address.

https://user-images.githubusercontent.com/43930900/156698180-cc0fa0ba-2187-42aa-a0cc-f017f16421db.mov

