### PR TITLE
Update snap install warning per designs and fix for popover component

### DIFF
--- a/ui/components/app/flask/snap-install-warning/index.scss
+++ b/ui/components/app/flask/snap-install-warning/index.scss
@@ -7,10 +7,6 @@
     gap: 0 16px;
   }
 
-  &__content {
-    padding: 0 16px 24px;
-  }
-
   &__footer {
     display: flex;
     flex-flow: row;

--- a/ui/components/app/flask/snap-install-warning/snap-install-warning.js
+++ b/ui/components/app/flask/snap-install-warning/snap-install-warning.js
@@ -43,21 +43,22 @@ export default function SnapInstallWarning({ onCancel, onSubmit, snapName }) {
       className="snap-install-warning"
       title={t('areYouSure')}
       footer={<SnapInstallWarningFooter />}
+      headerProps={{ padding: [6, 6, 0] }}
+      contentProps={{ padding: [0, 6, 4] }}
+      footerProps={{ padding: [4, 6] }}
     >
-      <div className="snap-install-warning__content">
-        <Typography variant={TYPOGRAPHY.H6} boxProps={{ paddingBottom: 4 }}>
-          {t('snapInstallWarningCheck')}
-        </Typography>
-        <div className="checkbox-label">
-          <CheckBox
-            checked={isConfirmed}
-            id="warning-accept"
-            onClick={onCheckboxClicked}
-          />
-          <label htmlFor="warning-accept">
-            {t('snapInstallWarningKeyAccess', [snapName])}
-          </label>
-        </div>
+      <Typography variant={TYPOGRAPHY.H6} boxProps={{ paddingBottom: 4 }}>
+        {t('snapInstallWarningCheck')}
+      </Typography>
+      <div className="checkbox-label">
+        <CheckBox
+          checked={isConfirmed}
+          id="warning-accept"
+          onClick={onCheckboxClicked}
+        />
+        <label htmlFor="warning-accept">
+          {t('snapInstallWarningKeyAccess', [snapName])}
+        </label>
       </div>
     </Popover>
   );

--- a/ui/components/ui/popover/index.scss
+++ b/ui/components/ui/popover/index.scss
@@ -21,12 +21,7 @@
   }
 
   &-header {
-    display: flex;
-    padding: 24px 16px 16px;
-    flex-direction: column;
-    background: white;
     position: relative;
-    border-radius: 10px;
 
     &__title {
       display: flex;
@@ -78,13 +73,8 @@
   &-content {
     overflow-y: auto;
     position: relative;
-    display: flex;
     flex: 1;
-    flex-direction: column;
-    justify-content: flex-start;
-    align-items: stretch;
     align-content: stretch;
-    border-radius: 10px;
   }
 
   &-container {
@@ -100,11 +90,7 @@
   }
 
   &-footer {
-    display: flex;
-    flex-direction: row;
-    justify-content: space-between;
     border-top: 1px solid #d2d8dd;
-    padding: 16px 24px 24px;
 
     > :only-child {
       margin: 0 auto;

--- a/ui/components/ui/popover/popover.component.js
+++ b/ui/components/ui/popover/popover.component.js
@@ -29,7 +29,7 @@ const defaultContentProps = {
 const defaultFooterProps = {
   display: 'flex',
   justifyContent: JUSTIFY_CONTENT.SPACE_BETWEEN,
-  padding: [4, 6],
+  padding: [4, 6, 6],
 };
 
 const Popover = ({
@@ -114,7 +114,7 @@ const Popover = ({
         {footer ? (
           <Box
             className={classnames('popover-footer', footerClassName)}
-            {...{ ...defaultFooterProps, footerProps }}
+            {...{ ...defaultFooterProps, ...footerProps }}
           >
             {footer}
           </Box>

--- a/ui/components/ui/popover/popover.component.js
+++ b/ui/components/ui/popover/popover.component.js
@@ -4,6 +4,33 @@ import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import Box from '../box';
+import {
+  ALIGN_ITEMS,
+  FLEX_DIRECTION,
+  JUSTIFY_CONTENT,
+} from '../../../helpers/constants/design-system';
+
+const defaultHeaderProps = {
+  padding: [6, 4, 4],
+  display: 'flex',
+  flexDirection: FLEX_DIRECTION.COLUMN,
+  backgroundColor: 'white',
+  borderRadius: 'xl',
+};
+
+const defaultContentProps = {
+  display: 'flex',
+  flexDirection: FLEX_DIRECTION.COLUMN,
+  justifyContent: JUSTIFY_CONTENT.FLEX_START,
+  alignItems: ALIGN_ITEMS.STRETCH,
+  borderRadius: 'xl',
+};
+
+const defaultFooterProps = {
+  display: 'flex',
+  justifyContent: JUSTIFY_CONTENT.SPACE_BETWEEN,
+  padding: [4, 6],
+};
 
 const Popover = ({
   title,
@@ -19,15 +46,18 @@ const Popover = ({
   CustomBackground,
   popoverRef,
   centerTitle,
-  headerProps = {},
-  contentProps = {},
-  footerProps = {},
+  headerProps = defaultHeaderProps,
+  contentProps = defaultContentProps,
+  footerProps = defaultFooterProps,
 }) => {
   const t = useI18nContext();
   const showHeader = title || onBack || subtitle || onClose;
   const Header = () => {
     return (
-      <Box {...headerProps} className="popover-header">
+      <Box
+        {...{ ...defaultHeaderProps, ...headerProps }}
+        className="popover-header"
+      >
         <div
           className={classnames(
             'popover-header__title',
@@ -76,7 +106,7 @@ const Popover = ({
         {children ? (
           <Box
             className={classnames('popover-content', contentClassName)}
-            {...contentProps}
+            {...{ ...defaultContentProps, ...contentProps }}
           >
             {children}
           </Box>
@@ -84,7 +114,7 @@ const Popover = ({
         {footer ? (
           <Box
             className={classnames('popover-footer', footerClassName)}
-            {...footerProps}
+            {...{ ...defaultFooterProps, footerProps }}
           >
             {footer}
           </Box>


### PR DESCRIPTION
With custom CSS ability merged for `Popover`, I decided to update `SnapInstallWarning` to use these new props and have it in line with its [design](https://www.figma.com/file/nBKUQx0btfQiqVf30UA6KD/Flask-MVP?node-id=336%3A6344). This PR also addresses the fact that `headerProps`, `contentProps`, `footerProps` being passed to the `Popover` component were being overwritten because of selector specificity. I moved whatever CSS rules that were conflicting with the `Box` component's props out of the `.popover-header`, `.popover-content` and `.popover-footer` classes and into the `Popover` component as `defaultHeaderProps`, `defaultContentProps` and `defaultFooterProps`.

**Thoughts:** In removing some of these CSS rules from `Popover`, it made me think how much we want to allow customizing a component? I think allowing for `Box` props for these containers is cool since having some inline styling would be better than none. When we start looking to customize header, content and footer's children then that might be a bit too flexible...I suppose with design there needs to be _some_ rigidity.

**Before:** 

<img width="367" src="https://user-images.githubusercontent.com/41640681/156849048-0c556d1f-f9f3-4f40-8395-782712a0a0ed.png">

**After:**

<img width="367" alt="Screen Shot 2022-03-04 at 5 14 33 PM" src="https://user-images.githubusercontent.com/41640681/156849140-9e0015e4-5706-4eb6-90d6-0a283959a923.png">

Manual testing steps:  
  - Run `yarn start --build-type flask`
  - To test a snap with the key access permissions, you can clone our fork of the filecoin snap at: [Filecoin snap](https://github.com/MetaMask/filsnap/tree/prerelease)
  - Checkout the `prerelease` branch and then run `yarn && yarn demo`
  - Follow the install flow for the filecoin snap from the locally hosted dapp and observe the changes when the snap install warning pops up