### PR TITLE
Fixed serialization of error parameter for `rejectPendingApproval` across JSON-RPC

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -9,7 +9,11 @@ import createFilterMiddleware from 'eth-json-rpc-filters';
 import createSubscriptionManager from 'eth-json-rpc-filters/subscriptionManager';
 import { providerAsMiddleware } from 'eth-json-rpc-middleware';
 import KeyringController from 'eth-keyring-controller';
-import { errorCodes as rpcErrorCodes, EthereumRpcError, ethErrors } from 'eth-rpc-errors';
+import {
+  errorCodes as rpcErrorCodes,
+  EthereumRpcError,
+  ethErrors,
+} from 'eth-rpc-errors';
 import { Mutex } from 'await-semaphore';
 import { stripHexPrefix } from 'ethereumjs-util';
 import log from 'loglevel';

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -9,7 +9,7 @@ import createFilterMiddleware from 'eth-json-rpc-filters';
 import createSubscriptionManager from 'eth-json-rpc-filters/subscriptionManager';
 import { providerAsMiddleware } from 'eth-json-rpc-middleware';
 import KeyringController from 'eth-keyring-controller';
-import { errorCodes as rpcErrorCodes, ethErrors } from 'eth-rpc-errors';
+import { errorCodes as rpcErrorCodes, EthereumRpcError, ethErrors } from 'eth-rpc-errors';
 import { Mutex } from 'await-semaphore';
 import { stripHexPrefix } from 'ethereumjs-util';
 import log from 'loglevel';
@@ -1705,7 +1705,12 @@ export default class MetamaskController extends EventEmitter {
       resolvePendingApproval: approvalController.accept.bind(
         approvalController,
       ),
-      rejectPendingApproval: approvalController.reject.bind(approvalController),
+      rejectPendingApproval: async (id, error) => {
+        approvalController.reject(
+          id,
+          new EthereumRpcError(error.code, error.message, error.data),
+        );
+      },
 
       // Notifications
       updateViewedNotifications: notificationController.updateViewed.bind(

--- a/ui/pages/confirmation/templates/add-ethereum-chain.js
+++ b/ui/pages/confirmation/templates/add-ethereum-chain.js
@@ -204,7 +204,7 @@ function getValues(pendingApproval, t, actions) {
     onCancel: () =>
       actions.rejectPendingApproval(
         pendingApproval.id,
-        ethErrors.provider.userRejectedRequest(),
+        ethErrors.provider.userRejectedRequest().serialize(),
       ),
     networkDisplay: true,
   };

--- a/ui/pages/confirmation/templates/switch-ethereum-chain.js
+++ b/ui/pages/confirmation/templates/switch-ethereum-chain.js
@@ -83,7 +83,7 @@ function getValues(pendingApproval, t, actions) {
     onCancel: () =>
       actions.rejectPendingApproval(
         pendingApproval.id,
-        ethErrors.provider.userRejectedRequest(),
+        ethErrors.provider.userRejectedRequest().serialize(),
       ),
     networkDisplay: true,
   };


### PR DESCRIPTION
Fixes: #11383

Explanation:  
Looks like sending `Error` objects across postMessage on firefox kills the `port` connection, this properly serializes the error which is a parameter to `rejectPendingApproval(id, error)` on both sides


I'm sure this isn't the only place where we do this that needs to be fixed.