### PR TITLE
Ensure only accounts list scrolls in Permissions popup

### DIFF
--- a/ui/components/app/permissions-connect-header/index.scss
+++ b/ui/components/app/permissions-connect-header/index.scss
@@ -1,6 +1,5 @@
 .permissions-connect-header {
   flex: 0;
-  width: 92%;
 
   &__icon {
     display: flex;

--- a/ui/components/ui/account-list/index.scss
+++ b/ui/components/ui/account-list/index.scss
@@ -3,6 +3,7 @@
   flex-direction: column;
   width: 100%;
   align-items: center;
+  overflow-y: auto;
 
   &__header--one-item,
   &__header--multiple-items {

--- a/ui/pages/permissions-connect/choose-account/choose-account.js
+++ b/ui/pages/permissions-connect/choose-account/choose-account.js
@@ -48,7 +48,7 @@ const ChooseAccount = ({
   };
 
   return (
-    <div className="permissions-connect-choose-account">
+    <>
       <PermissionsConnectHeader
         iconUrl={targetSubjectMetadata?.iconUrl}
         iconName={targetSubjectMetadata?.name}
@@ -89,7 +89,7 @@ const ChooseAccount = ({
           </Button>
         </div>
       </div>
-    </div>
+    </>
   );
 };
 

--- a/ui/pages/permissions-connect/choose-account/index.scss
+++ b/ui/pages/permissions-connect/choose-account/index.scss
@@ -1,4 +1,5 @@
 .permissions-connect-choose-account {
+  position: fixed;
   display: flex;
   flex-direction: column;
   align-items: center;

--- a/ui/pages/permissions-connect/choose-account/index.scss
+++ b/ui/pages/permissions-connect/choose-account/index.scss
@@ -1,13 +1,4 @@
 .permissions-connect-choose-account {
-  position: fixed;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  width: 100%;
-  margin-left: auto;
-  margin-right: auto;
-  height: 100%;
-
   @media screen and (min-width: $break-large) {
     width: 426px;
   }

--- a/ui/pages/permissions-connect/choose-account/index.scss
+++ b/ui/pages/permissions-connect/choose-account/index.scss
@@ -1,8 +1,4 @@
 .permissions-connect-choose-account {
-  @media screen and (min-width: $break-large) {
-    width: 426px;
-  }
-
   &__title {
     @include H4;
   }


### PR DESCRIPTION
Supercedes: https://github.com/MetaMask/metamask-extension/pull/13780

Fixes: https://github.com/MetaMask/metamask-extension/issues/13763

Explanation:  The permissions popup now ensures scrolling happens on the account list, not the entire contents of the popup.

Manual testing steps:  
  - Create 10 accounts in. MM
  - Go to the test dapp (https://metamask.github.io/test-dapp/)
  - Click "Request Permissions"
  - See that only account list scrolls