### PR TITLE
Updating AccountList to use darkmode colors

### DIFF
--- a/ui/components/ui/account-list/account-list.js
+++ b/ui/components/ui/account-list/account-list.js
@@ -21,7 +21,6 @@ const AccountList = ({
 }) => {
   const t = useI18nContext();
   const selectedAccountScrollRef = useRef(null);
-
   useLayoutEffect(() => {
     selectedAccountScrollRef.current?.scrollIntoView({ behavior: 'smooth' });
   }, []);
@@ -103,7 +102,7 @@ const AccountList = ({
                       className="choose-account-list__account__balance"
                       type={PRIMARY}
                       value={balance}
-                      style={{ color: '#6A737D' }}
+                      style={{ color: 'var(--color-text-alternative)' }}
                       suffix={nativeCurrency}
                     />
                   </div>

--- a/ui/components/ui/account-list/account-list.stories.js
+++ b/ui/components/ui/account-list/account-list.stories.js
@@ -1,0 +1,67 @@
+import React from 'react';
+import AccountList from '.';
+
+export default {
+  title: 'Components/UI/AccountList', // title should follow the folder structure location of the component. Don't use spaces.
+  id: __filename,
+  argTypes: {
+    accounts: {
+      control: 'object',
+    },
+    selectNewAccountViaModal: {
+      action: 'selectNewAccountViaModal',
+    },
+    addressLastConnectedMap: {
+      control: 'object',
+    },
+    nativeCurrency: {
+      control: 'text',
+    },
+    selectedAccounts: {
+      control: 'object',
+    },
+    allAreSelected: {
+      action: 'allAreSelected',
+    },
+    deselectAll: {
+      action: 'deselectAll',
+    },
+    selectAll: {
+      action: 'selectAll',
+    },
+    handleAccountClick: {
+      action: 'handleAccountClick',
+    },
+  },
+  args: {
+    accounts: [
+      {
+        address: '0x64a845a5b02460acf8a3d84503b0d68d028b4bb4',
+        addressLabel: 'Account 1',
+        lastConnectedDate: 'Feb-22-2022',
+        balance: '8.7a73149c048545a3fe58',
+        has: () => {
+          /**  nothing to do */
+        },
+      },
+    ],
+    selectedAccounts: {
+      address: '0x64a845a5b02460acf8a3d84503b0d68d028b4bb4',
+      addressLabel: 'Account 2',
+      lastConnectedDate: 'Feb-22-2022',
+      balance: '8.7a73149c048545a3fe58',
+      has: () => {
+        /** nothing to do */
+      },
+    },
+    addressLastConnectedMap: {
+      '0x64a845a5b02460acf8a3d84503b0d68d028b4bb4': 'Feb-22-2022',
+    },
+    allAreSelected: () => true,
+    nativeCurrency: 'USD',
+  },
+};
+
+export const DefaultStory = (args) => <AccountList {...args} />;
+
+DefaultStory.storyName = 'Default';

--- a/ui/components/ui/account-list/index.scss
+++ b/ui/components/ui/account-list/index.scss
@@ -42,7 +42,7 @@
     flex: 2 1 0;
     width: 100%;
     max-height: max-content;
-    border: 1px solid #d0d5da;
+    border: 1px solid var(--color-border-muted);
     box-sizing: border-box;
     border-radius: 8px;
     margin-top: 8px;
@@ -53,7 +53,7 @@
     display: flex;
     align-items: center;
     padding: 16px;
-    border-bottom: 1px solid #d2d8dd;
+    border-bottom: 1px solid var(--color-border-muted);
     justify-content: space-between;
 
     &:last-of-type {
@@ -61,7 +61,7 @@
     }
 
     &:hover {
-      background: var(--Grey-000);
+      background: var(--color-background-alternative);
       cursor: pointer;
     }
 
@@ -75,7 +75,7 @@
     &__label {
       @include H6;
 
-      color: var(--Black-100);
+      color: var(--color-text-default);
       text-overflow: ellipsis;
       overflow: hidden;
       white-space: nowrap;
@@ -84,7 +84,7 @@
     &__balance {
       @include H7;
 
-      color: var(--Grey-500);
+      color: var(--color-text-default);
     }
 
     &__last-connected {
@@ -93,7 +93,7 @@
       display: flex;
       flex-direction: column;
       align-items: flex-end;
-      color: var(--primary-blue);
+      color: var(--color-primary-default);
     }
   }
 
@@ -113,14 +113,14 @@
   }
 
   .fa-info-circle {
-    color: var(--Grey-200);
+    color: var(--color-icon-muted);
     cursor: pointer;
     margin-inline-start: 8px;
     font-size: 0.9rem;
   }
 
   .fa-info-circle:hover {
-    color: var(--Grey-300);
+    color: var(--color-icon-default);
   }
 
   &__text,
@@ -130,11 +130,11 @@
   }
 
   &__text-blue {
-    color: var(--primary-blue);
+    color: var(--color-primary-default);
     cursor: pointer;
   }
 
   &__text-grey {
-    color: var(--Grey-500);
+    color: var(--color-text-default);
   }
 }


### PR DESCRIPTION
Explanation: Updating AccountList to use darkmode colors
- Updated static HEX values
- Updated all css variables 
- Created stories for AccountList for easier visual review

Manual testing steps:  
  - Go to latest build of storybook in this PR 👇 
  - Search `AccountList`
  - Check dark mode by clicking the 🌙  icon in the toolbar of storybook

## Screenshots
<img width="1440" alt="Screen Shot 2022-03-07 at 4 11 16 PM" src="https://user-images.githubusercontent.com/8112138/157140149-823f9c38-9eee-43f8-b7e0-068f6cedb751.png">
<img width="1440" alt="Screen Shot 2022-03-07 at 4 11 23 PM" src="https://user-images.githubusercontent.com/8112138/157140156-a6a71f0f-92b0-4c1b-abb5-7a51cea97c1b.png">
david
