### PR TITLE
Fix permission site origin overflow

### DIFF
--- a/ui/components/app/permissions-connect-header/index.scss
+++ b/ui/components/app/permissions-connect-header/index.scss
@@ -2,6 +2,7 @@
   flex: 0;
 
   &__icon {
+    width: 100%;
     display: flex;
     flex-direction: column;
     align-items: center;

--- a/ui/components/app/permissions-connect-header/index.scss
+++ b/ui/components/app/permissions-connect-header/index.scss
@@ -1,5 +1,6 @@
 .permissions-connect-header {
   flex: 0;
+  width: 100%;
 
   &__icon {
     width: 100%;

--- a/ui/components/ui/account-list/index.scss
+++ b/ui/components/ui/account-list/index.scss
@@ -36,6 +36,7 @@
   &__wrapper {
     display: flex;
     overflow: hidden;
+    width: 100%;
   }
 
   &__list {

--- a/ui/components/ui/account-list/index.scss
+++ b/ui/components/ui/account-list/index.scss
@@ -34,7 +34,6 @@
   }
 
   &__wrapper {
-    width: 92%;
     display: flex;
     overflow: hidden;
   }

--- a/ui/components/ui/site-origin/index.scss
+++ b/ui/components/ui/site-origin/index.scss
@@ -1,4 +1,6 @@
 .site-origin {
+  width: 100%;
+  
   .chip__left-icon {
     padding: 4px 0 4px 8px;
   }

--- a/ui/components/ui/site-origin/index.scss
+++ b/ui/components/ui/site-origin/index.scss
@@ -1,6 +1,6 @@
 .site-origin {
   max-width: 100%;
-  
+
   .chip {
     max-width: 100%;
   }

--- a/ui/components/ui/site-origin/index.scss
+++ b/ui/components/ui/site-origin/index.scss
@@ -1,6 +1,10 @@
 .site-origin {
-  width: 100%;
+  max-width: 100%;
   
+  .chip {
+    max-width: 100%;
+  }
+
   .chip__left-icon {
     padding: 4px 0 4px 8px;
   }

--- a/ui/pages/permissions-connect/choose-account/choose-account.js
+++ b/ui/pages/permissions-connect/choose-account/choose-account.js
@@ -49,28 +49,30 @@ const ChooseAccount = ({
 
   return (
     <>
-      <PermissionsConnectHeader
-        iconUrl={targetSubjectMetadata?.iconUrl}
-        iconName={targetSubjectMetadata?.name}
-        headerTitle={t('connectWithMetaMask')}
-        headerText={
-          accounts.length > 0
-            ? t('selectAccounts')
-            : t('connectAccountOrCreate')
-        }
-        siteOrigin={targetSubjectMetadata?.origin}
-      />
-      <AccountList
-        accounts={accounts}
-        selectNewAccountViaModal={selectNewAccountViaModal}
-        addressLastConnectedMap={addressLastConnectedMap}
-        nativeCurrency={nativeCurrency}
-        selectedAccounts={selectedAccounts}
-        allAreSelected={allAreSelected}
-        deselectAll={deselectAll}
-        selectAll={selectAll}
-        handleAccountClick={handleAccountClick}
-      />
+      <div className="permissions-connect-choose-account__content">
+        <PermissionsConnectHeader
+          iconUrl={targetSubjectMetadata?.iconUrl}
+          iconName={targetSubjectMetadata?.name}
+          headerTitle={t('connectWithMetaMask')}
+          headerText={
+            accounts.length > 0
+              ? t('selectAccounts')
+              : t('connectAccountOrCreate')
+          }
+          siteOrigin={targetSubjectMetadata?.origin}
+        />
+        <AccountList
+          accounts={accounts}
+          selectNewAccountViaModal={selectNewAccountViaModal}
+          addressLastConnectedMap={addressLastConnectedMap}
+          nativeCurrency={nativeCurrency}
+          selectedAccounts={selectedAccounts}
+          allAreSelected={allAreSelected}
+          deselectAll={deselectAll}
+          selectAll={selectAll}
+          handleAccountClick={handleAccountClick}
+        />
+      </div>
       <div className="permissions-connect-choose-account__footer-container">
         <PermissionsConnectFooter />
         <div className="permissions-connect-choose-account__bottom-buttons">

--- a/ui/pages/permissions-connect/choose-account/index.scss
+++ b/ui/pages/permissions-connect/choose-account/index.scss
@@ -7,6 +7,15 @@
     color: var(--Red-400);
   }
 
+  &__content {
+    display: flex;
+    overflow-y: auto;
+    flex-direction: column;
+    width: 100%;
+    padding-left: 24px;
+    padding-right: 24px;
+  }
+
   &__footer-container {
     width: 100%;
     flex: 1;
@@ -27,7 +36,7 @@
     width: 100%;
     padding-top: 16px;
     padding-bottom: 16px;
-    margin-top: 8px;
+    margin-top: 12px;
     border-top: 1px solid #d6d9dc;
 
     @media screen and (min-width: $break-large) {

--- a/ui/pages/permissions-connect/choose-account/index.scss
+++ b/ui/pages/permissions-connect/choose-account/index.scss
@@ -14,6 +14,7 @@
     width: 100%;
     padding-left: 24px;
     padding-right: 24px;
+    margin-top: 2px;
   }
 
   &__footer-container {

--- a/ui/pages/permissions-connect/flask/snap-install/index.scss
+++ b/ui/pages/permissions-connect/flask/snap-install/index.scss
@@ -24,5 +24,6 @@
 
   .page-container__footer {
     width: 100%;
+    margin-top: 12px;
   }
 }


### PR DESCRIPTION
Fixes: https://github.com/MetaMask/snaps-skunkworks/issues/260

Explanation:  

Content would overflow when an origins URL was longer than could fit in the viewport. Was originally reported as a Snaps bug, but seems to be present in the regular connect flow as well.

**When working on this PR I also noticed other inconsistencies in the connect flow that I fixed.**

Manual testing steps:  
  - Go to https://deploy-preview-3--evm-chainlist.netlify.app/ (or some other site with a long URL) and connect
  - Make sure there is no overflow
  - Go to https://app.uniswap.org/ and connect
  - See that the "chip" shrinks
  - Go to https://filsnap.chainsafe.io/ and connect
  - See that there are no overflows