### PR TITLE
ToggleButton: Use label so users can click text

### DIFF
--- a/test/e2e/tests/send-eth.spec.js
+++ b/test/e2e/tests/send-eth.spec.js
@@ -190,7 +190,7 @@ describe('Send ETH from dapp using advanced gas controls', function () {
         await driver.clickElement({ text: 'Settings', tag: 'div' });
         await driver.clickElement({ text: 'Advanced', tag: 'div' });
         await driver.clickElement(
-          '[data-testid="advanced-setting-show-testnet-conversion"] .settings-page__content-item-col > div > div',
+          '[data-testid="advanced-setting-show-testnet-conversion"] .settings-page__content-item-col > label > div',
         );
         const advancedGasTitle = await driver.findElement({
           text: 'Advanced gas controls',
@@ -198,7 +198,7 @@ describe('Send ETH from dapp using advanced gas controls', function () {
         });
         await driver.scrollToElement(advancedGasTitle);
         await driver.clickElement(
-          '[data-testid="advanced-setting-advanced-gas-inline"] .settings-page__content-item-col > div > div',
+          '[data-testid="advanced-setting-advanced-gas-inline"] .settings-page__content-item-col > label > div',
         );
         windowHandles = await driver.getAllWindowHandles();
         extension = windowHandles[0];

--- a/ui/components/ui/toggle-button/index.scss
+++ b/ui/components/ui/toggle-button/index.scss
@@ -1,5 +1,7 @@
 .toggle-button {
   display: flex;
+  cursor: pointer;
+
   $self: &;
 
   &__status {

--- a/ui/components/ui/toggle-button/toggle-button.component.js
+++ b/ui/components/ui/toggle-button/toggle-button.component.js
@@ -52,7 +52,7 @@ const ToggleButton = (props) => {
   const modifier = value ? 'on' : 'off';
 
   return (
-    <div
+    <label
       tabIndex="0"
       onKeyDown={(e) => {
         if (e.key === 'Enter') {
@@ -82,7 +82,7 @@ const ToggleButton = (props) => {
         <span className="toggle-button__label-off">{offLabel}</span>
         <span className="toggle-button__label-on">{onLabel}</span>
       </div>
-    </div>
+    </label>
   );
 };
 


### PR DESCRIPTION
At present you need to click the literal ToggleButton to update the value, and clicking the text does nothing, which is bad.  With this PR, you can click the text next to the ToggleButton and the value changes

Explanation:  

Manual testing steps:  
  - Go to Settings
  - Click toggle button text at the bottom of the screen
  - Value should change!