### PR TITLE
Don’t show ‘What’s new’ pop up to new users

### DIFF
--- a/ui/pages/home/home.component.js
+++ b/ui/pages/home/home.component.js
@@ -98,6 +98,7 @@ export default class Home extends PureComponent {
     setConnectedStatusPopoverHasBeenShown: PropTypes.func,
     connectedStatusPopoverHasBeenShown: PropTypes.bool,
     defaultHomeActiveTabName: PropTypes.string,
+    firstTimeFlowType: PropTypes.string,
     onTabClick: PropTypes.func.isRequired,
     haveSwapsQuotes: PropTypes.bool.isRequired,
     showAwaitingSwapScreen: PropTypes.bool.isRequired,
@@ -496,6 +497,7 @@ export default class Home extends PureComponent {
       hideWhatsNewPopup,
       seedPhraseBackedUp,
       showRecoveryPhraseReminder,
+      firstTimeFlowType,
     } = this.props;
 
     if (forgottenPassword) {
@@ -504,7 +506,10 @@ export default class Home extends PureComponent {
       return null;
     }
 
-    const showWhatsNew = notificationsToShow && showWhatsNewPopup;
+    const showWhatsNew =
+      firstTimeFlowType === 'import' &&
+      notificationsToShow &&
+      showWhatsNewPopup;
 
     return (
       <div className="main-container">

--- a/ui/pages/home/home.component.js
+++ b/ui/pages/home/home.component.js
@@ -99,6 +99,7 @@ export default class Home extends PureComponent {
     connectedStatusPopoverHasBeenShown: PropTypes.bool,
     defaultHomeActiveTabName: PropTypes.string,
     firstTimeFlowType: PropTypes.string,
+    completedOnboarding: PropTypes.bool,
     onTabClick: PropTypes.func.isRequired,
     haveSwapsQuotes: PropTypes.bool.isRequired,
     showAwaitingSwapScreen: PropTypes.bool.isRequired,
@@ -498,6 +499,7 @@ export default class Home extends PureComponent {
       seedPhraseBackedUp,
       showRecoveryPhraseReminder,
       firstTimeFlowType,
+      completedOnboarding,
     } = this.props;
 
     if (forgottenPassword) {
@@ -507,7 +509,8 @@ export default class Home extends PureComponent {
     }
 
     const showWhatsNew =
-      firstTimeFlowType === 'import' &&
+      ((completedOnboarding && firstTimeFlowType === 'import') ||
+        !completedOnboarding) &&
       notificationsToShow &&
       showWhatsNewPopup;
 

--- a/ui/pages/home/home.container.js
+++ b/ui/pages/home/home.container.js
@@ -67,6 +67,7 @@ const mapStateToProps = (state) => {
     swapsState,
     dismissSeedBackUpReminder,
     firstTimeFlowType,
+    completedOnboarding,
   } = metamask;
   const accountBalance = getCurrentEthBalance(state);
   const { forgottenPassword, threeBoxLastUpdated } = appState;
@@ -114,6 +115,7 @@ const mapStateToProps = (state) => {
     connectedStatusPopoverHasBeenShown,
     defaultHomeActiveTabName,
     firstTimeFlowType,
+    completedOnboarding,
     haveSwapsQuotes: Boolean(Object.values(swapsState.quotes || {}).length),
     swapsFetchParams: swapsState.fetchParams,
     showAwaitingSwapScreen: swapsState.routeState === 'awaiting',

--- a/ui/pages/home/home.container.js
+++ b/ui/pages/home/home.container.js
@@ -66,6 +66,7 @@ const mapStateToProps = (state) => {
     defaultHomeActiveTabName,
     swapsState,
     dismissSeedBackUpReminder,
+    firstTimeFlowType,
   } = metamask;
   const accountBalance = getCurrentEthBalance(state);
   const { forgottenPassword, threeBoxLastUpdated } = appState;
@@ -112,6 +113,7 @@ const mapStateToProps = (state) => {
     totalUnapprovedCount,
     connectedStatusPopoverHasBeenShown,
     defaultHomeActiveTabName,
+    firstTimeFlowType,
     haveSwapsQuotes: Boolean(Object.values(swapsState.quotes || {}).length),
     swapsFetchParams: swapsState.fetchParams,
     showAwaitingSwapScreen: swapsState.routeState === 'awaiting',


### PR DESCRIPTION
fixes: #13278

**Explanation:**  Don’t show ‘What’s new’ pop up to user that have just finished onboarding. New user is the user which have created a new seed phrase. User who imported or pasted the seed phrase has been considered as an existing user and the ‘What’s new’ pop up will be shown to him.

**Screencast for new user (create a new wallet):**

https://user-images.githubusercontent.com/92527393/157413304-f273e61f-1ab4-4bca-8b86-e2b9b3d1d728.mov

**Screencast for existing user (import a wallet):**

https://user-images.githubusercontent.com/92527393/157413512-331abf51-6fec-4235-bcd3-7d19ed2f839e.mov

