### PR TITLE
Make Edit Gas Fee testcase independent of arbitrary Wait time for Gas Editing

### DIFF
--- a/test/e2e/tests/edit-gas-fee.spec.js
+++ b/test/e2e/tests/edit-gas-fee.spec.js
@@ -40,9 +40,12 @@ describe('Editing Confirm Transaction', function () {
 
         // update estimates to high
         await driver.clickElement('[data-testid="edit-gas-fee-button"]');
-        await driver.delay(regularDelayMs);
+        const timeElement = await driver.findElement({
+          text: '--',
+          tag: 'span',
+        });
+        await driver.waitForElementContainingValue(timeElement, 'sec');
         await driver.clickElement('[data-testid="edit-gas-fee-item-high"]');
-        await driver.delay(regularDelayMs);
         await driver.waitForSelector({ text: '🦍' });
         await driver.waitForSelector({
           text: 'Aggressive',
@@ -50,9 +53,7 @@ describe('Editing Confirm Transaction', function () {
 
         // update estimates to medium
         await driver.clickElement('[data-testid="edit-gas-fee-button"]');
-        await driver.delay(regularDelayMs);
         await driver.clickElement('[data-testid="edit-gas-fee-item-medium"]');
-        await driver.delay(regularDelayMs);
         await driver.waitForSelector({ text: '🦊' });
         await driver.waitForSelector({
           text: 'Market',
@@ -60,9 +61,7 @@ describe('Editing Confirm Transaction', function () {
 
         // update estimates to low
         await driver.clickElement('[data-testid="edit-gas-fee-button"]');
-        await driver.delay(regularDelayMs);
         await driver.clickElement('[data-testid="edit-gas-fee-item-low"]');
-        await driver.delay(regularDelayMs);
         await driver.waitForSelector({ text: '🐢' });
         await driver.waitForSelector({
           text: 'Low',

--- a/test/e2e/tests/edit-gas-fee.spec.js
+++ b/test/e2e/tests/edit-gas-fee.spec.js
@@ -40,11 +40,10 @@ describe('Editing Confirm Transaction', function () {
 
         // update estimates to high
         await driver.clickElement('[data-testid="edit-gas-fee-button"]');
-        const timeElement = await driver.findElement({
-          text: '--',
+        await driver.waitForSelector({
+          text: 'sec',
           tag: 'span',
         });
-        await driver.waitForElementContainingValue(timeElement, 'sec');
         await driver.clickElement('[data-testid="edit-gas-fee-item-high"]');
         await driver.waitForSelector({ text: '🦍' });
         await driver.waitForSelector({
@@ -120,7 +119,10 @@ describe('Editing Confirm Transaction', function () {
 
         // update estimates to high
         await driver.clickElement('[data-testid="edit-gas-fee-button"]');
-        await driver.delay(regularDelayMs);
+        await driver.waitForSelector({
+          text: 'sec',
+          tag: 'span',
+        });
         await driver.clickElement('[data-testid="edit-gas-fee-item-custom"]');
         await driver.delay(regularDelayMs);
 
@@ -230,7 +232,10 @@ describe('Editing Confirm Transaction', function () {
         });
 
         await driver.clickElement('[data-testid="edit-gas-fee-button"]');
-        await driver.delay(regularDelayMs);
+        await driver.waitForSelector({
+          text: 'sec',
+          tag: 'span',
+        });
         await driver.clickElement(
           '[data-testid="edit-gas-fee-item-dappSuggested"]',
         );

--- a/test/e2e/webdriver/driver.js
+++ b/test/e2e/webdriver/driver.js
@@ -256,7 +256,7 @@ class Driver {
       return false;
     }
   }
-  
+
   // Navigation
 
   async navigate(page = Driver.PAGES.HOME) {

--- a/test/e2e/webdriver/driver.js
+++ b/test/e2e/webdriver/driver.js
@@ -256,11 +256,7 @@ class Driver {
       return false;
     }
   }
-
-  async waitForElementContainingValue(element, value) {
-    await this.driver.wait(until.elementTextContains(element, value));
-  }
-
+  
   // Navigation
 
   async navigate(page = Driver.PAGES.HOME) {

--- a/test/e2e/webdriver/driver.js
+++ b/test/e2e/webdriver/driver.js
@@ -257,6 +257,10 @@ class Driver {
     }
   }
 
+  async waitForElementContainingValue(element, value) {
+    await this.driver.wait(until.elementTextContains(element, value));
+  }
+
   // Navigation
 
   async navigate(page = Driver.PAGES.HOME) {


### PR DESCRIPTION
**What:** Make Edit Gas Fee testcase independent of arbitrary Wait time for Gas Editing

**Fixes:** Edit Gas Fee testcase was not robust, and sometimes failed due to wait times issues. See example of a run on Linux env:
![image](https://user-images.githubusercontent.com/54408225/157468828-0c4504b3-d2c3-489c-b60c-1654a465ecd5.png)

**Explanation:**  arbitrary wait times were used in between changing gas preferences, which made that the test failed at some runs. Now this arbitrary wait times have been replaced by a waiting for a certain value ("sec"), which means that API response has been received and rendered to the UI

**Note:** this testcase will be further improved by adding a mock API response, for making sure we get a response. This is being developed in another branch