### PR TITLE
Add labels to provide better accessibility during onboarding v2

### DIFF
--- a/ui/pages/onboarding-flow/create-password/create-password.js
+++ b/ui/pages/onboarding-flow/create-password/create-password.js
@@ -208,26 +208,28 @@ export default function CreatePassword({
             justifyContent={JUSTIFY_CONTENT.SPACE_BETWEEN}
             marginBottom={4}
           >
-            <CheckBox
-              dataTestId="create-password-terms"
-              onClick={() => setTermsChecked(!termsChecked)}
-              checked={termsChecked}
-            />
-            <Typography variant={TYPOGRAPHY.H5} boxProps={{ marginLeft: 3 }}>
-              {t('passwordTermsWarning', [
-                <a
-                  onClick={(e) => e.stopPropagation()}
-                  key="create-password__link-text"
-                  href={ZENDESK_URLS.PASSWORD_ARTICLE}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  <span className="create-password__link-text">
-                    {t('learnMoreUpperCase')}
-                  </span>
-                </a>,
-              ])}
-            </Typography>
+            <label className="create-password__form__terms-label">
+              <CheckBox
+                dataTestId="create-password-terms"
+                onClick={() => setTermsChecked(!termsChecked)}
+                checked={termsChecked}
+              />
+              <Typography variant={TYPOGRAPHY.H5} boxProps={{ marginLeft: 3 }}>
+                {t('passwordTermsWarning', [
+                  <a
+                    onClick={(e) => e.stopPropagation()}
+                    key="create-password__link-text"
+                    href={ZENDESK_URLS.PASSWORD_ARTICLE}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    <span className="create-password__link-text">
+                      {t('learnMoreUpperCase')}
+                    </span>
+                  </a>,
+                ])}
+              </Typography>
+            </label>
           </Box>
           <Button
             data-testid={

--- a/ui/pages/onboarding-flow/create-password/index.scss
+++ b/ui/pages/onboarding-flow/create-password/index.scss
@@ -41,6 +41,10 @@
       }
     }
 
+    &__terms-label {
+      display: flex;
+    }
+
     .form-field__input {
       height: 50px;
     }

--- a/ui/pages/onboarding-flow/secure-your-wallet/index.scss
+++ b/ui/pages/onboarding-flow/secure-your-wallet/index.scss
@@ -39,6 +39,10 @@
     margin: 8px 12px 0 0;
   }
 
+  &__label {
+    display: flex;
+  }
+
   &__footer {
     button {
       width: 140px;

--- a/ui/pages/onboarding-flow/secure-your-wallet/skip-srp-backup-popover.js
+++ b/ui/pages/onboarding-flow/secure-your-wallet/skip-srp-backup-popover.js
@@ -58,9 +58,7 @@ export default function SkipSRPBackup({ handleClose }) {
           <label className="skip-srp-backup-popover__label">
             <Checkbox
               className="skip-srp-backup-popover__checkbox"
-              onClick={() => {
-                setChecked(!checked);
-              }}
+              onClick={() => setChecked(!checked)}
               checked={checked}
               dataTestId="skip-srp-backup-popover-checkbox"
             />

--- a/ui/pages/onboarding-flow/secure-your-wallet/skip-srp-backup-popover.js
+++ b/ui/pages/onboarding-flow/secure-your-wallet/skip-srp-backup-popover.js
@@ -55,20 +55,22 @@ export default function SkipSRPBackup({ handleClose }) {
           {t('skipAccountSecurity')}
         </Typography>
         <Box justifyContent={JUSTIFY_CONTENT.CENTER} margin={3}>
-          <Checkbox
-            className="skip-srp-backup-popover__checkbox"
-            onClick={() => {
-              setChecked(!checked);
-            }}
-            checked={checked}
-            dataTestId="skip-srp-backup-popover-checkbox"
-          />
-          <Typography
-            className="skip-srp-backup-popover__details"
-            variant={TYPOGRAPHY.h7}
-          >
-            {t('skipAccountSecurityDetails')}
-          </Typography>
+          <label className="skip-srp-backup-popover__label">
+            <Checkbox
+              className="skip-srp-backup-popover__checkbox"
+              onClick={() => {
+                setChecked(!checked);
+              }}
+              checked={checked}
+              dataTestId="skip-srp-backup-popover-checkbox"
+            />
+            <Typography
+              className="skip-srp-backup-popover__details"
+              variant={TYPOGRAPHY.h7}
+            >
+              {t('skipAccountSecurityDetails')}
+            </Typography>
+          </label>
         </Box>
       </Box>
     </Popover>


### PR DESCRIPTION
Fixes: #13889

Explanation:  Users expect to be able to click the text next to a checkbox to adjust the checked status.

Manual testing steps:  
  - `ONBOARDING_V2=1 yarn start`
  - Start the onboarding process
  - Click the checkbox text during password creation, see checkbox checked
