### PR TITLE
fix small bug where max transaction fee isn't properly passed through confirmation flow

### DIFF
--- a/ui/pages/confirm-transaction/confirm-token-transaction-switch.js
+++ b/ui/pages/confirm-transaction/confirm-token-transaction-switch.js
@@ -84,7 +84,7 @@ export default function ConfirmTokenTransactionSwitch({ transaction }) {
             transaction={transaction}
             ethTransactionTotal={ethTransactionTotal}
             fiatTransactionTotal={fiatTransactionTotal}
-            hexTransactionTotal={hexTransactionTotal}
+            hexMaximumTransactionFee={hexMaximumTransactionFee}
           />
         )}
       />


### PR DESCRIPTION
Fixes: A small bug I introduced in https://github.com/MetaMask/metamask-extension/pull/13788

Explanation:  [ConfirmTokenTransactionBase](https://github.com/MetaMask/metamask-extension/blob/fa4d884a87920c3db705f985dd32daf1172612f3/ui/pages/confirm-token-transaction-base/confirm-token-transaction-base.js#L46) should be passed `hexMaximumTransactionFee` instead of `hexTransactionTotal`

Manual testing steps:  
  - Attempt to transfer an NFT
  - Check that the max transaction fee amount in the confirmation data is correct:
  ![Screen Shot 2022-03-09 at 12 15 02 PM](https://user-images.githubusercontent.com/34557516/157505217-e3a03968-a8ab-4d6a-812c-a5356203fa51.png)