### PR TITLE
Derive version suffix from build type and version

### DIFF
--- a/development/build/etc.js
+++ b/development/build/etc.js
@@ -4,13 +4,13 @@ const gulpZip = require('gulp-zip');
 const del = require('del');
 const pify = require('pify');
 const pump = pify(require('pump'));
-const { version } = require('../../package.json');
+
+const { BuildType } = require('../lib/build-type');
 const { createTask, composeParallel } = require('./task');
-const { BuildType } = require('./utils');
 
 module.exports = createEtcTasks;
 
-function createEtcTasks({ browserPlatforms, buildType, livereload }) {
+function createEtcTasks({ browserPlatforms, buildType, livereload, version }) {
   const clean = createTask('clean', async function clean() {
     await del(['./dist/*']);
     await Promise.all(
@@ -28,14 +28,16 @@ function createEtcTasks({ browserPlatforms, buildType, livereload }) {
   const zip = createTask(
     'zip',
     composeParallel(
-      ...browserPlatforms.map((platform) => createZipTask(platform, buildType)),
+      ...browserPlatforms.map((platform) =>
+        createZipTask(platform, buildType, version),
+      ),
     ),
   );
 
   return { clean, reload, zip };
 }
 
-function createZipTask(platform, buildType) {
+function createZipTask(platform, buildType, version) {
   return async () => {
     const path =
       buildType === BuildType.main

--- a/development/build/manifest.js
+++ b/development/build/manifest.js
@@ -3,9 +3,9 @@ const path = require('path');
 const { mergeWith, cloneDeep } = require('lodash');
 
 const baseManifest = require('../../app/manifest/_base.json');
+const { BuildType } = require('../lib/build-type');
 
 const { createTask, composeSeries } = require('./task');
-const { BuildType } = require('./utils');
 
 module.exports = createManifestTasks;
 

--- a/development/build/scripts.js
+++ b/development/build/scripts.js
@@ -46,7 +46,7 @@ const metamaskrc = require('rc')('metamask', {
 });
 
 const { streamFlatMap } = require('../stream-flat-map.js');
-const { version } = require('../../package.json');
+const { BuildType } = require('../lib/build-type');
 
 const {
   createTask,
@@ -57,7 +57,6 @@ const {
 const {
   createRemoveFencedCodeTransform,
 } = require('./transforms/remove-fenced-code');
-const { BuildType } = require('./utils');
 
 /**
  * The build environment. This describes the environment this build was produced in.
@@ -148,6 +147,7 @@ function createScriptTasks({
   livereload,
   shouldLintFenceFiles,
   policyOnly,
+  version,
 }) {
   // internal tasks
   const core = {
@@ -193,6 +193,7 @@ function createScriptTasks({
         policyOnly,
         shouldLintFenceFiles,
         testing,
+        version,
       }),
     );
 
@@ -345,6 +346,7 @@ function createFactoredBuild({
   policyOnly,
   shouldLintFenceFiles,
   testing,
+  version,
 }) {
   return async function () {
     // create bundler setup and apply defaults
@@ -356,7 +358,12 @@ function createFactoredBuild({
     const reloadOnChange = Boolean(devMode);
     const minify = Boolean(devMode) === false;
 
-    const envVars = getEnvironmentVariables({ buildType, devMode, testing });
+    const envVars = getEnvironmentVariables({
+      buildType,
+      devMode,
+      testing,
+      version,
+    });
     setupBundlerDefaults(buildConfiguration, {
       buildType,
       devMode,
@@ -781,7 +788,7 @@ async function bundleIt(buildConfiguration, { reloadOnChange }) {
   }
 }
 
-function getEnvironmentVariables({ buildType, devMode, testing }) {
+function getEnvironmentVariables({ buildType, devMode, testing, version }) {
   const environment = getEnvironment({ devMode, testing });
   if (environment === ENVIRONMENT.PRODUCTION && !process.env.SENTRY_DSN) {
     throw new Error('Missing SENTRY_DSN environment variable');

--- a/development/build/static.js
+++ b/development/build/static.js
@@ -4,9 +4,9 @@ const watch = require('gulp-watch');
 const glob = require('fast-glob');
 
 const locales = require('../../app/_locales/index.json');
+const { BuildType } = require('../lib/build-type');
 
 const { createTask, composeSeries } = require('./task');
-const { BuildType } = require('./utils');
 
 const EMPTY_JS_FILE = './development/empty.js';
 

--- a/development/build/transforms/remove-fenced-code.js
+++ b/development/build/transforms/remove-fenced-code.js
@@ -1,6 +1,6 @@
 const path = require('path');
 const { PassThrough, Transform } = require('stream');
-const { BuildType } = require('../utils');
+const { BuildType } = require('../../lib/build-type');
 const { lintTransformedFile } = require('./utils');
 
 const hasKey = (obj, key) => Reflect.hasOwnProperty.call(obj, key);

--- a/development/build/transforms/remove-fenced-code.test.js
+++ b/development/build/transforms/remove-fenced-code.test.js
@@ -1,5 +1,5 @@
 const deepFreeze = require('deep-freeze-strict');
-const { BuildType } = require('../utils');
+const { BuildType } = require('../../lib/build-type');
 const {
   createRemoveFencedCodeTransform,
   removeFencedCode,

--- a/development/build/utils.js
+++ b/development/build/utils.js
@@ -1,16 +1,5 @@
 const semver = require('semver');
-const { version } = require('../../package.json');
-
-/**
- * The distribution this build is intended for.
- *
- * This should be kept in-sync with the `BuildType` map in `shared/constants/app.js`.
- */
-const BuildType = {
-  beta: 'beta',
-  flask: 'flask',
-  main: 'main',
-};
+const { BuildType } = require('../lib/build-type');
 
 /**
  * Map the current version to a format that is compatible with each browser.
@@ -20,11 +9,12 @@ const BuildType = {
  * where the build version is a positive integer.
  *
  * @param {string[]} platforms - A list of browsers to generate versions for.
+ * @param {string} version - The current version.
  * @returns {Object} An object with the browser as the key and the browser-specific version object
  * as the value.  For example, the version `9.6.0-beta.1` would return the object
  * `{ firefox: { version: '9.6.0.beta1' }, chrome: { version: '9.6.0.1', version_name: '9.6.0-beta.1' } }`.
  */
-function getBrowserVersionMap(platforms) {
+function getBrowserVersionMap(platforms, version) {
   const major = semver.major(version);
   const minor = semver.minor(version);
   const patch = semver.patch(version);
@@ -62,6 +52,5 @@ function getBrowserVersionMap(platforms) {
 }
 
 module.exports = {
-  BuildType,
   getBrowserVersionMap,
 };

--- a/development/lib/build-type.js
+++ b/development/lib/build-type.js
@@ -1,0 +1,12 @@
+/**
+ * The distribution this build is intended for.
+ *
+ * This should be kept in-sync with the `BuildType` map in `shared/constants/app.js`.
+ */
+const BuildType = {
+  beta: 'beta',
+  flask: 'flask',
+  main: 'main',
+};
+
+module.exports = { BuildType };

--- a/development/lib/get-version.js
+++ b/development/lib/get-version.js
@@ -1,0 +1,21 @@
+const { version: manifestVersion } = require('../../package.json');
+const { BuildType } = require('./build-type');
+
+/**
+ * Get the current version of the MetaMask extension. The base manifest version
+ * is modified according to the build type and version.
+ *
+ * The build version is needed because certain build types (such as beta) may
+ * be released multiple times during the release process.
+ *
+ * @param {BuildType} buildType - The build type.
+ * @param {number} buildVersion - The build version.
+ * @returns {string} The MetaMask extension version.
+ */
+function getVersion(buildType, buildVersion) {
+  return buildType === BuildType.main
+    ? manifestVersion
+    : `${manifestVersion}-${buildType}.${buildVersion}`;
+}
+
+module.exports = { getVersion };


### PR DESCRIPTION
The version of a build is now derived from both the `version` field in `package.json` and the requested build type and version. The build type and version are added onto the manifest version as a suffix, according to the SemVer prerelease format.

We already have support in the extension for versions of this format, but to apply a Flask or Beta version required manual updates to `package.json`. Now it can be done just with build arguments.

A `get-version` module was created to make it easier to generate the version in the various places we do that during the build. It was created in the `development/lib` directory because it will be used by other non-build development scripts in a future PR.

The `BuildType` constant was extracted to its own module as well, and moved to the `development/lib` directory. This was to make it clear that it's used by various different development scripts, not just the build.

Manual testing steps:  
  - Check the "About" page of the extension to see that the version is set correctly. It should match the `package.json` version for main builds (i.e. not Flask or beta). For Flask and beta, it should be `${version}-${build type}.${build version}`
  - Check that a build version can be set as a build parameter (e.g. `yarn build prod --build-type beta --build-version 1`)
  - Ensure that a build version is not accepted it build type is not set
  - Ensure that only valid integers are accepted for the build version