### PR TITLE
Automate the Flask release process

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -160,6 +160,7 @@ workflows:
           requires:
             - prep-deps
             - prep-build
+            - prep-build-flask
             - all-tests-pass
       - job-publish-storybook:
           filters:
@@ -371,7 +372,7 @@ jobs:
           root: .
           paths:
             - storybook-build
-  
+
   test-storybook:
     executor: node-browsers
     steps:
@@ -718,8 +719,11 @@ jobs:
       - attach_workspace:
           at: .
       - run:
-          name: sentry sourcemaps upload
-          command: SENTRY_ORG=metamask SENTRY_PROJECT=metamask yarn sentry:publish
+          name: Publish main release to Sentry
+          command: yarn sentry:publish
+      - run:
+          name: Publish Flask release to Sentry
+          command: yarn sentry:publish --build-type flask
       - run:
           name: Create GitHub release
           command: |

--- a/.circleci/scripts/release-create-gh-release.sh
+++ b/.circleci/scripts/release-create-gh-release.sh
@@ -26,25 +26,36 @@ function install_github_cli ()
     popd
 }
 
+function print_flask_version ()
+{
+  local flask_filename
+  flask_filename="$(find ./builds-flask -type f -name 'metamask-flask-chrome-*.zip' -exec basename {} .zip \;)"
+
+  # Use substring parameter expansion to remove the first 22 characters ("metamask-extension-flask-")
+  echo "${flask_filename:22}"
+}
+
 current_commit_msg=$(git show -s --format='%s' HEAD)
 
 if [[ $current_commit_msg =~ Version[-[:space:]](v[[:digit:]]+.[[:digit:]]+.[[:digit:]]+) ]]
 then
     tag="${BASH_REMATCH[1]}"
+    flask_version="$(print_flask_version)"
 
     install_github_cli
 
     printf '%s\n' 'Creating GitHub Release'
     release_body="$(awk -v version="${tag##v}" -f .circleci/scripts/show-changelog.awk CHANGELOG.md)"
-    pushd builds
-        hub release create \
-            --attach metamask-chrome-*.zip \
-            --attach metamask-firefox-*.zip \
-            --message "Version ${tag##v}" \
-            --message "$release_body" \
-            --commitish "$CIRCLE_SHA1" \
-            "$tag"
-    popd
+    hub release create \
+        --attach builds/metamask-chrome-*.zip \
+        --attach builds/metamask-firefox-*.zip \
+        --attach builds-flask/metamask-flask-chrome-*.zip \
+        --attach builds-flask/metamask-flask-firefox-*.zip \
+        --message "Version ${tag##v}" \
+        --message "$release_body" \
+        --commitish "$CIRCLE_SHA1" \
+        "$tag"
+    git tag -a "v${flask_version}" -m "Flask version ${flask_version}"
 else
     printf '%s\n' 'Version not found in commit message; skipping GitHub Release'
     exit 0

--- a/.circleci/scripts/release-create-gh-release.sh
+++ b/.circleci/scripts/release-create-gh-release.sh
@@ -40,6 +40,17 @@ function print_flask_version ()
   echo "${flask_filename:$flask_build_filename_prefix_size}"
 }
 
+function publish_flask_tag ()
+{
+    local flask_version="${1}"; shift
+
+    git config user.email "metamaskbot@users.noreply.github.com"
+    git config user.name "MetaMask Bot"
+    git tag -a "v${flask_version}" -m "Flask version ${flask_version}"
+    repo_slug="$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME"
+    git push "https://$GITHUB_TOKEN@github.com/$repo_slug" "v${flask_version}"
+}
+
 current_commit_msg=$(git show -s --format='%s' HEAD)
 
 if [[ $current_commit_msg =~ Version[-[:space:]](v[[:digit:]]+.[[:digit:]]+.[[:digit:]]+) ]]
@@ -60,7 +71,8 @@ then
         --message "$release_body" \
         --commitish "$CIRCLE_SHA1" \
         "$tag"
-    git tag -a "v${flask_version}" -m "Flask version ${flask_version}"
+
+    publish_flask_tag "${flask_version}"
 else
     printf '%s\n' 'Version not found in commit message; skipping GitHub Release'
     exit 0

--- a/.circleci/scripts/release-create-gh-release.sh
+++ b/.circleci/scripts/release-create-gh-release.sh
@@ -31,8 +31,13 @@ function print_flask_version ()
   local flask_filename
   flask_filename="$(find ./builds-flask -type f -name 'metamask-flask-chrome-*.zip' -exec basename {} .zip \;)"
 
-  # Use substring parameter expansion to remove the first 22 characters ("metamask-extension-flask-")
-  echo "${flask_filename:22}"
+  local flask_build_filename_prefix
+  flask_build_filename_prefix='metamask-flask-chrome-'
+  local flask_build_filename_prefix_size
+  flask_build_filename_prefix_size="${#flask_build_filename_prefix}"
+
+  # Use substring parameter expansion to remove the filename prefix, leaving just the version
+  echo "${flask_filename:$flask_build_filename_prefix_size}"
 }
 
 current_commit_msg=$(git show -s --format='%s' HEAD)

--- a/development/metamaskbot-build-announce.js
+++ b/development/metamaskbot-build-announce.js
@@ -3,7 +3,7 @@ const { promises: fs } = require('fs');
 const path = require('path');
 const fetch = require('node-fetch');
 const glob = require('fast-glob');
-const VERSION = require('../dist/chrome/manifest.json').version; // eslint-disable-line import/no-unresolved
+const VERSION = require('../package.json').version;
 const { getHighlights } = require('./highlights');
 
 start().catch(console.error);

--- a/development/sentry-upload-artifacts.sh
+++ b/development/sentry-upload-artifacts.sh
@@ -23,17 +23,20 @@ Upload JavaScript bundles and sourcemaps to Sentry
 Options:
   -h, --help               Show help text
   -r, --release <release>  Sentry release to upload files to (defaults to 'VERSION' environment variable)
+  --dist-directory <path>  The 'dist' directory to use. Defaults to 'dist'.
 EOF
 }
 
 function upload_sourcemaps {
   local release="${1}"; shift
+  local dist_directory="${1}"; shift
 
-  sentry-cli releases files "${release}" upload-sourcemaps ./dist/chrome/*.js ./dist/sourcemaps/ --rewrite --url-prefix 'metamask'
+  sentry-cli releases files "${release}" upload-sourcemaps "${dist_directory}"/chrome/*.js "${dist_directory}"/sourcemaps/ --rewrite --url-prefix 'metamask'
 }
 
 function main {
   local release=VERSION
+  local dist_directory='dist'
 
   while :; do
     case "${1-default}" in
@@ -49,6 +52,16 @@ function main {
           exit 1
         fi
         release="${2}"
+        shift
+        ;;
+      --dist-directory)
+        if [[ -z $2 ]]
+        then
+          printf "'dist-directory' option requires an argument.\\n" >&2
+          printf '%s\n' "${__SEE_HELP_MESSAGE__}" >&2
+          exit 1
+        fi
+        dist_directory="${2}"
         shift
         ;;
       *)
@@ -70,7 +83,7 @@ function main {
   fi
 
   printf 'uploading source files and sourcemaps for Sentry release "%s"...\n' "${release}"
-  upload_sourcemaps "${release}"
+  upload_sourcemaps "${release}" "${dist_directory}"
   printf 'all done!\n'
 }
 


### PR DESCRIPTION
A Flask release will now be published alongside each main extension release. The version of each Flask release will be the same as the extension version except it will have the suffix `-flask.0`.

The `sentry-publish.js` script was updated to support publishing non-main builds. It now takes additional `build-type` and `build-version` parameters, though only the former is used right now (the `build-version` parameter will be used for beta). It was converted to use `yargs` so that adding the new parameters would be easier.

Rather than create a separate release page for Flask, the Flask build is included alongside the main build in the main release page. We can integrate the changelog entries as well, prefixing any Flask-specific changes with `[Flask]`. This seemed easier than maintaining separate changelog, or doing any additional complex changelog parsing.

The Flask release will still get its own separate tag though. Just so it's totally clear which commit the release was created from.

Manual testing steps:
This is quite difficult to test manually, and I don't expect reviewers to do this. I can document my manual testing though.

I tested this by creating a new repository and going through the release process. The repository is here: https://github.com/Gudahtt/test-metamask-release

Here is the final successful workflow: https://app.circleci.com/pipelines/github/Gudahtt/test-metamask-release/36/workflows/07222244-3d62-491d-a967-6f7d0988678f
Here is the release page: https://github.com/Gudahtt/test-metamask-release/releases/tag/v11.0.5 (it's supposed to have the changelog as the body, but that's currently broken. Long-standing unrelated problem. We've been manually fixing it for each release.)
Here is the Flask tag: https://github.com/Gudahtt/test-metamask-release/releases/tag/v11.0.5-flask.0

Closes #13427