### PR TITLE
ConfirmImportToken: rm unused .token-balance style

### DIFF
--- a/ui/pages/confirm-import-token/index.scss
+++ b/ui/pages/confirm-import-token/index.scss
@@ -20,25 +20,6 @@
   &__token-list {
     display: flex;
     flex-flow: column nowrap;
-
-    .token-balance {
-      display: flex;
-      flex-flow: row nowrap;
-      align-items: flex-start;
-
-      &__amount {
-        @include H1;
-
-        color: var(--scorpion);
-        margin-right: 8px;
-      }
-
-      &__symbol {
-        @include H5;
-
-        color: var(--scorpion);
-      }
-    }
   }
 
   &__token-list-item {


### PR DESCRIPTION
Fixes: # n/a

clean-up ticket

Explanation:  

`.token-balance` class does not show on the ConfirmImportToken page. The TokenBalance component is rendered on this page, but it does not have the `.token-balance` class.

Manual testing steps:  
- On the main page and underneath the list of accounts, click "import tokens"
- Search any token and select it
- Click "Next"
- Test this "Import Tokens" page works as expected