### PR TITLE
Allow transactions that share a nonce+chainId to be deleted if status is DROPPED or REJECTED

### DIFF
--- a/app/scripts/controllers/transactions/tx-state-manager.js
+++ b/app/scripts/controllers/transactions/tx-state-manager.js
@@ -253,6 +253,12 @@ export default class TransactionStateManager extends EventEmitter {
         const { chainId, metamaskNetworkId, status } = tx;
         const key = `${nonce}-${chainId ?? metamaskNetworkId}-${from}`;
         if (nonceNetworkSet.has(key)) {
+          if (
+            status === TRANSACTION_STATUSES.DROPPED &&
+            status === TRANSACTION_STATUSES.REJECTED
+          ) {
+            return true;
+          }
           return false;
         } else if (
           nonceNetworkSet.size < txHistoryLimit - 1 ||


### PR DESCRIPTION
Fixes: #13549

The PR is POC for fixing issue: Deletion of transactions from state should include nonce grouped transactions with Dropped or Rejected statuses