### PR TITLE
Dark Mode: Import account text field

### DIFF
--- a/ui/pages/create-account/import-account/index.scss
+++ b/ui/pages/create-account/import-account/index.scss
@@ -65,11 +65,11 @@
 
     height: 54px;
     width: 315px;
-    border: 1px solid var(--geyser);
+    border: 1px solid var(--color-border-default);
     border-radius: 4px;
-    background-color: var(--white);
+    background-color: var(--color-background-default);
+    color: var(--color-text-default);
     margin-top: 16px;
-    color: var(--scorpion);
     padding: 0 20px;
   }
 


### PR DESCRIPTION
The `Import Account`'s text field was hardcoded to its own colors, not the TextField, so fixing those colors.
<img width="434" alt="key-input" src="https://user-images.githubusercontent.com/46655/157754133-eb02bc43-abc6-4366-837e-a784c2482cdb.png">

