### PR TITLE
Fixing dropdown caret

### DIFF
--- a/ui/components/ui/dropdown/dropdown.js
+++ b/ui/components/ui/dropdown/dropdown.js
@@ -22,9 +22,9 @@ const Dropdown = ({
   );
 
   return (
-    <div className="dropdown-container">
+    <div className={classnames('dropdown', className)}>
       <select
-        className={classnames('dropdown', className)}
+        className="dropdown__select"
         disabled={disabled}
         title={title}
         onChange={_onChange}
@@ -39,10 +39,7 @@ const Dropdown = ({
           );
         })}
       </select>
-      <IconCaretDown
-        size={16}
-        className="dropdown-container__icon-caret-down"
-      />
+      <IconCaretDown size={16} className="dropdown__icon-caret-down" />
     </div>
   );
 };

--- a/ui/components/ui/dropdown/dropdown.scss
+++ b/ui/components/ui/dropdown/dropdown.scss
@@ -9,8 +9,8 @@
     -webkit-appearance: none;
 
     @include H6;
-    color: var(--color-text-default);
 
+    color: var(--color-text-default);
     border: 1px solid var(--color-border-default);
     border-radius: 4px;
     background-color: var(--color-background-default);

--- a/ui/components/ui/dropdown/dropdown.scss
+++ b/ui/components/ui/dropdown/dropdown.scss
@@ -3,11 +3,11 @@
   display: inline-block;
 
   &__select {
-    appearance: none;  
+    appearance: none;
     // TODO: remove these after getting autoprefixer working in Storybook
     -moz-appearance: none;
     -webkit-appearance: none;
-    
+
     @include H6;
     color: var(--color-text-default);
 
@@ -16,7 +16,7 @@
     background-color: var(--color-background-default);
     padding: 8px 40px 8px 16px;
     width: 100%;
-  
+
     [dir='rtl'] & {
       padding: 8px 16px 8px 40px;
     }

--- a/ui/components/ui/dropdown/dropdown.scss
+++ b/ui/components/ui/dropdown/dropdown.scss
@@ -1,32 +1,33 @@
 .dropdown {
-  @include H6;
-
-  appearance: none;
-  color: var(--color-text-default);
-
-  // TODO: remove these after getting autoprefixer working in Storybook
-  -moz-appearance: none;
-  -webkit-appearance: none;
-  border: 1px solid var(--color-border-default);
-  border-radius: 4px;
-  background-color: var(--color-background-default);
-  color: var(--color-text-default);
-  padding: 8px 32px 8px 16px;
-
-  [dir='rtl'] & {
-    padding: 8px 16px 8px 32px;
-  }
-}
-
-.dropdown-container {
   position: relative;
   display: inline-block;
+
+  &__select {
+    appearance: none;  
+    // TODO: remove these after getting autoprefixer working in Storybook
+    -moz-appearance: none;
+    -webkit-appearance: none;
+    
+    @include H6;
+    color: var(--color-text-default);
+
+    border: 1px solid var(--color-border-default);
+    border-radius: 4px;
+    background-color: var(--color-background-default);
+    padding: 8px 40px 8px 16px;
+    width: 100%;
+  
+    [dir='rtl'] & {
+      padding: 8px 16px 8px 40px;
+    }
+  }
 
   &__icon-caret-down {
     position: absolute;
     right: 16px;
     top: 50%;
     transform: translateY(-50%);
+    pointer-events: none;
 
     [dir='rtl'] & {
       left: 16px;

--- a/ui/pages/settings/advanced-tab/advanced-tab.component.js
+++ b/ui/pages/settings/advanced-tab/advanced-tab.component.js
@@ -172,7 +172,7 @@ export default class AdvancedTab extends PureComponent {
         <div className="settings-page__content-item">
           <div className="settings-page__content-item-col">
             <Button
-              type="warning"
+              type="danger"
               large
               className="settings-tab__button--red"
               onClick={(event) => {


### PR DESCRIPTION
Fixes: #13910

Explanation: Fixes issue with the dropdown caret that I introduced when updated the caret icons 🤦 
- Also fixing button for reset account

Manual testing steps:  
  - Go to Settings > General > Under "Currency Conversion" dropdown caret is fixed
  - Also check latest storybook build and go to the `Dropdown` story

Everywhere the `Dropdown` component is used apart from onboarding screen

<img width="655" alt="Screen Shot 2022-03-10 at 1 35 08 PM" src="https://user-images.githubusercontent.com/8112138/157759787-54489255-a5cd-49da-b71a-c6b0872020cf.png">
<img width="656" alt="Screen Shot 2022-03-10 at 1 36 38 PM" src="https://user-images.githubusercontent.com/8112138/157759789-6e142751-1bb4-41d0-9993-8e8d04e86bc1.png">
<img width="651" alt="Screen Shot 2022-03-10 at 1 38 01 PM" src="https://user-images.githubusercontent.com/8112138/157759790-e9d6c912-24a4-439c-8f86-92826c099ed2.png">
<img width="643" alt="Screen Shot 2022-03-10 at 1 38 22 PM" src="https://user-images.githubusercontent.com/8112138/157759791-5949318a-121d-4022-98a4-a711df4edc4d.png">
<img width="631" alt="Screen Shot 2022-03-10 at 1 38 53 PM" src="https://user-images.githubusercontent.com/8112138/157759793-8f8d284e-9cb3-4ce7-bed9-0872f6916566.png">

Reset account button

Before
<img width="984" alt="Screen Shot 2022-03-10 at 2 18 36 PM" src="https://user-images.githubusercontent.com/8112138/157771459-cc6ffbb2-2dad-469c-842f-5ea7c67280c5.png">

After
<img width="974" alt="Screen Shot 2022-03-10 at 3 17 42 PM" src="https://user-images.githubusercontent.com/8112138/157771468-b56035da-b0b2-497a-888c-bbda98f29621.png">

