### PR TITLE
Fix snap e2e tests

### DIFF
--- a/test/e2e/webdriver/firefox.js
+++ b/test/e2e/webdriver/firefox.js
@@ -4,7 +4,8 @@ const path = require('path');
 const { Builder, By, until } = require('selenium-webdriver');
 const firefox = require('selenium-webdriver/firefox');
 const proxy = require('selenium-webdriver/proxy');
-const { version } = require('../../../package.json');
+const { getVersion } = require('../../../development/lib/get-version');
+const { BuildType } = require('../../../development/lib/build-type');
 
 /**
  * The prefix for temporary Firefox profiles. All Firefox profiles used for e2e tests
@@ -49,6 +50,7 @@ class FirefoxDriver {
     const driver = builder.build();
     const fxDriver = new FirefoxDriver(driver);
 
+    const version = getVersion(type || BuildType.main, 0);
     let extensionString = `builds/metamask-firefox-${version}.zip`;
 
     if (type) {


### PR DESCRIPTION
The snap e2e tests introduced in #13671 were broken due to a conflict with the changes in #13895. The latter PR changed the version name for non-main builds so that it always includes the build type.

The Firefox webdriver has been updated to use the new `getVersion` utility, ensuring that it always looks for the correct build filename.