### PR TITLE
Fix spelling of 'Ethereum' in German translation

### DIFF
--- a/app/_locales/de/messages.json
+++ b/app/_locales/de/messages.json
@@ -1525,7 +1525,7 @@
     "message": "niedrig"
   },
   "mainnet": {
-    "message": "Athereum Hauptnetz"
+    "message": "Ethereum Hauptnetz"
   },
   "makeAnotherSwap": {
     "message": "Eine neue Wallet erstellen"


### PR DESCRIPTION
This is a typo in the German translation, reported in Slack here: https://consensys.slack.com/archives/C01DRUWDCFQ/p1647016689295609