### PR TITLE
Dark Mode: Select Account Hardware Wallets

### DIFF
--- a/ui/pages/create-account/connect-hardware/index.scss
+++ b/ui/pages/create-account/connect-hardware/index.scss
@@ -178,11 +178,11 @@
   }
 
   &__item:nth-of-type(even) {
-    background-color: #fbfbfb;
+    background-color: var(--color-background-default);
   }
 
   &__item:nth-of-type(odd) {
-    background: rgba(0, 0, 0, 0.03);
+    background: var(--color-background-alternative);
   }
 
   &__item:hover {
@@ -236,10 +236,10 @@
   &__button {
     @include H6;
 
-    background: #fff;
+    background: var(--color-background-default);
     height: 19px;
     display: flex;
-    color: #33a4e7;
+    color: var(--color-primary-default);
     border: none;
     min-width: 46px;
     margin-right: 0;
@@ -292,7 +292,7 @@
   a {
     @include H6;
 
-    color: #2f9ae0;
+    color: var(--color-primary-default);
     cursor: pointer;
   }
 }


### PR DESCRIPTION
Fixes color for the screen that displays immediately after connecting a hardware wallet (Trezor in this case):
<img width="380" alt="SelectLight" src="https://user-images.githubusercontent.com/46655/157924790-d246af24-4846-4d1d-b3ff-673bb29d7ff3.png">
<img width="398" alt="SelectDark" src="https://user-images.githubusercontent.com/46655/157924794-d294d266-d2fc-4190-922d-db419fcf58f9.png">

