### PR TITLE
Dark Mode: Fix currently selected network color

### DIFF
--- a/ui/pages/settings/networks-tab/index.scss
+++ b/ui/pages/settings/networks-tab/index.scss
@@ -239,7 +239,7 @@
 
   &__networks-list-name--selected {
     font-weight: bold;
-    color: #000;
+    color: var(--color-text-default);
   }
 
   &__networks-list-name--disabled {


### PR DESCRIPTION
Hardcoded black was a problem so I've changed to default color.
<img width="618" alt="SettingsMainnet" src="https://user-images.githubusercontent.com/46655/157928665-c8fbe81d-4b4b-4ad5-909e-4fbc573e49b0.png">

