### PR TITLE
Show snap version on install

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -2769,6 +2769,10 @@
   "settingsSearchMatchingNotFound": {
     "message": "No matching results found"
   },
+  "shorthandVersion": {
+    "message": "v$1",
+    "description": "$1 is replaced by a version string (e.g. 1.2.3)"
+  },
   "show": {
     "message": "Show"
   },

--- a/ui/components/app/flask/snap-settings-card/snap-settings-card.js
+++ b/ui/components/app/flask/snap-settings-card/snap-settings-card.js
@@ -180,7 +180,7 @@ const SnapSettingsCard = ({
                 tag="span"
                 className="snap-settings-card__version"
               >
-                v {version}
+                {t('shorthandVersion', [version])}
               </Typography>
             </>
           )}

--- a/ui/components/app/permissions-connect-header/permissions-connect-header.component.js
+++ b/ui/components/app/permissions-connect-header/permissions-connect-header.component.js
@@ -5,9 +5,15 @@ import Box from '../../ui/box';
 import {
   FLEX_DIRECTION,
   JUSTIFY_CONTENT,
+  ///: BEGIN:ONLY_INCLUDE_IN(flask)
+  COLORS,
+  TYPOGRAPHY,
+  TEXT_ALIGN,
+  ///: END:ONLY_INCLUDE_IN
 } from '../../../helpers/constants/design-system';
 ///: BEGIN:ONLY_INCLUDE_IN(flask)
 import SnapsAuthorshipPill from '../flask/snaps-authorship-pill';
+import Typography from '../../ui/typography';
 ///: END:ONLY_INCLUDE_IN
 
 export default class PermissionsConnectHeader extends Component {
@@ -20,6 +26,7 @@ export default class PermissionsConnectHeader extends Component {
     headerText: PropTypes.string,
     ///: BEGIN:ONLY_INCLUDE_IN(flask)
     npmPackageName: PropTypes.string,
+    snapVersion: PropTypes.string,
     ///: END:ONLY_INCLUDE_IN
   };
 
@@ -47,6 +54,7 @@ export default class PermissionsConnectHeader extends Component {
       headerText,
       ///: BEGIN:ONLY_INCLUDE_IN(flask)
       npmPackageName,
+      snapVersion,
       ///: END:ONLY_INCLUDE_IN
     } = this.props;
     ///: BEGIN:ONLY_INCLUDE_IN(flask)
@@ -69,6 +77,24 @@ export default class PermissionsConnectHeader extends Component {
               url={npmPackageUrl}
             />
           ) : null
+          ///: END:ONLY_INCLUDE_IN
+        }
+        {
+          ///: BEGIN:ONLY_INCLUDE_IN(flask)
+          snapVersion && (
+            <Typography
+              boxProps={{
+                margin: [2, 0],
+              }}
+              color={COLORS.TEXT_MUTED}
+              variant={TYPOGRAPHY.H7}
+              align={TEXT_ALIGN.CENTER}
+              tag="span"
+              className="version"
+            >
+              v{snapVersion}
+            </Typography>
+          )
           ///: END:ONLY_INCLUDE_IN
         }
         <div className="permissions-connect-header__subtitle">{headerText}</div>

--- a/ui/components/app/permissions-connect-header/permissions-connect-header.component.js
+++ b/ui/components/app/permissions-connect-header/permissions-connect-header.component.js
@@ -17,6 +17,12 @@ import Typography from '../../ui/typography';
 ///: END:ONLY_INCLUDE_IN
 
 export default class PermissionsConnectHeader extends Component {
+  ///: BEGIN:ONLY_INCLUDE_IN(flask)
+  static contextTypes = {
+    t: PropTypes.func,
+  };
+  ///: END:ONLY_INCLUDE_IN
+
   static propTypes = {
     iconUrl: PropTypes.string,
     iconName: PropTypes.string.isRequired,
@@ -59,6 +65,7 @@ export default class PermissionsConnectHeader extends Component {
     } = this.props;
     ///: BEGIN:ONLY_INCLUDE_IN(flask)
     const npmPackageUrl = `https://www.npmjs.com/package/${npmPackageName}`;
+    const { t } = this.context;
     ///: END:ONLY_INCLUDE_IN
     return (
       <Box
@@ -92,7 +99,7 @@ export default class PermissionsConnectHeader extends Component {
               tag="span"
               className="version"
             >
-              v{snapVersion}
+              {t('shorthandVersion', [snapVersion])}
             </Typography>
           )
           ///: END:ONLY_INCLUDE_IN

--- a/ui/pages/permissions-connect/flask/snap-install/index.scss
+++ b/ui/pages/permissions-connect/flask/snap-install/index.scss
@@ -22,6 +22,10 @@
     }
   }
 
+  .version {
+    font-family: monospace;
+  }
+
   .page-container__footer {
     width: 100%;
     margin-top: 12px;

--- a/ui/pages/permissions-connect/flask/snap-install/snap-install.js
+++ b/ui/pages/permissions-connect/flask/snap-install/snap-install.js
@@ -75,6 +75,7 @@ export default function SnapInstall({
           headerText={null} // TODO(ritave): Add header text when snaps support description
           siteOrigin={targetSubjectMetadata.origin}
           npmPackageName={npmId}
+          snapVersion={targetSubjectMetadata.version}
           boxProps={{ alignItems: ALIGN_ITEMS.CENTER }}
         />
         <Typography></Typography>

--- a/ui/pages/permissions-connect/flask/snap-install/snap-install.js
+++ b/ui/pages/permissions-connect/flask/snap-install/snap-install.js
@@ -78,14 +78,15 @@ export default function SnapInstall({
           snapVersion={targetSubjectMetadata.version}
           boxProps={{ alignItems: ALIGN_ITEMS.CENTER }}
         />
-        <Typography></Typography>
-        <Box
-          className="snap-requests-permission"
-          padding={4}
-          tag={TYPOGRAPHY.H7}
+        <Typography
+          boxProps={{
+            padding: [4, 4, 0, 4],
+          }}
+          variant={TYPOGRAPHY.H7}
+          tag="span"
         >
-          <span>{t('snapRequestsPermission')}</span>
-        </Box>
+          {t('snapRequestsPermission')}
+        </Typography>
         <PermissionsConnectPermissionList
           permissions={request.permissions || {}}
         />
@@ -150,5 +151,6 @@ SnapInstall.propTypes = {
     name: PropTypes.string,
     origin: PropTypes.string.isRequired,
     sourceCode: PropTypes.string,
+    version: PropTypes.string,
   }).isRequired,
 };


### PR DESCRIPTION
Fixes: #

Explanation: 
- Added the snap version to the Snap Install UI
- Fixed a text sizing and spacing issue

Manual testing steps:  
  - Use the Flask build
  - Visit https://filsnap.chainsafe.io/
  - Hit Connect
  - Accept the permissions request
  - See that the Snap install popup has the version number on it