### PR TITLE
Better 712 errors

### DIFF
--- a/app/scripts/lib/typed-message-manager.js
+++ b/app/scripts/lib/typed-message-manager.js
@@ -1,7 +1,7 @@
 import EventEmitter from 'events';
 import { strict as assert } from 'assert';
 import { ObservableStore } from '@metamask/obs-store';
-import { errorCodes, EthereumProviderError, ethErrors } from 'eth-rpc-errors';
+import { EthereumRpcError, ethErrors } from 'eth-rpc-errors';
 import { typedSignatureHash, TYPED_MESSAGE_SCHEMA } from 'eth-sig-util';
 import log from 'loglevel';
 import jsonschema from 'jsonschema';
@@ -193,17 +193,12 @@ export default class TypedMessageManager extends EventEmitter {
           `Primary type of "${data.primaryType}" has no type definition.`,
         );
         if (validation.errors.length !== 0) {
-          throw new EthereumProviderError(
-            4009,
+          throw new EthereumRpcError(
+            -32602,
             'Signing data must conform to EIP-712 schema. See https://git.io/fNtcx.',
             validation.errors.map((v) => v.message.toString()),
           );
         }
-        // assert.equal(
-        //   validation.errors.length,
-        //   0,
-        //   `Signing data must conform to EIP-712 schema. See https://git.io/fNtcx. \n Errors: ${validation.errors.join('\n')}`,
-        // );
         let { chainId } = data.domain;
         if (chainId) {
           const activeChainId = parseInt(this._getCurrentChainId(), 16);

--- a/app/scripts/lib/typed-message-manager.js
+++ b/app/scripts/lib/typed-message-manager.js
@@ -194,7 +194,7 @@ export default class TypedMessageManager extends EventEmitter {
         );
         if (validation.errors.length !== 0) {
           throw new EthereumRpcError(
-            -32602,
+            ethErrors.rpc.invalidParams,
             'Signing data must conform to EIP-712 schema. See https://git.io/fNtcx.',
             validation.errors.map((v) => v.message.toString()),
           );


### PR DESCRIPTION
fixes #5690 

to test:

you can use the playground to make an invalid 712 request (make sure you use your own `address`):

```
{
    "jsonrpc": "2.0",
    "method": "eth_signTypedData_v4",
    "params": [
        "0x30746D407B71C1CBc159dC6355D1B949F2F3e2Cf",
        "{\"types\":{\"EIP712Domain\":[{\"name\":\"name\",\"type\":\"string\"},{\"name\":\"version\",\"type\":\"string\"},{\"name\":\"chainId\",\"type\":\"uint256\"},{\"name\":\"verifyingContract\",\"type\":\"address\"}],\"Person\":[{\"name\":\"name\",\"type\":\"string\"},{\"name\":\"wallet\",\"type\":\"address\"}],\"Mail\":[{\"name\":\"from\",\"type\":\"Person\"},{\"name\":\"to\",\"type\":\"Person\"},{\"name\":\"contents\",\"type\":\"string\"}]},\"primaryType\":\"Mail\",\"domain\":{\"name\":\"Ether Mail\",\"version\":\"1\",\"chainId\":1,\"verifyingContract\":\"0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC\"},\"messages\":{\"from\":{\"name\":\"Cow\",\"wallet\":\"0x30746D407B71C1CBc159dC6355D1B949F2F3e2Cf\"},\"to\":{\"name\":\"Bob\",\"wallet\":\"0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB\"},\"contents\":\"Hello, Bob!\"}}"
    ],
    "id": 0
}
```

<img width="1670" alt="image" src="https://user-images.githubusercontent.com/364566/158266634-0e3965d2-deff-455a-9b58-7270275a9c1d.png">
