### PR TITLE
Implement specific network currency insufficient warning - follow up

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -419,12 +419,13 @@
     "message": "Transak supports debit card and bank transfers (depending on location) in 59+ countries. $1 deposits into your MetaMask account.",
     "description": "$1 represents the cypto symbol to be purchased"
   },
-  "buyEth": {
-    "message": "Buy ETH"
-  },
   "buyOther": {
     "message": "Buy $1 or deposit from another account.",
     "description": "$1 is a token symbol"
+  },
+  "buyToken": {
+    "message": "Buy $1",
+    "description": "$1 represents currency for the current network"
   },
   "buyWithWyre": {
     "message": "Buy ETH with Wyre"
@@ -2279,7 +2280,7 @@
     "message": "or"
   },
   "orDeposit": {
-    "message": "or deposit from another account."
+    "message": " or deposit from another account."
   },
   "origin": {
     "message": "Origin"

--- a/ui/components/app/confirm-page-container/confirm-page-container-content/confirm-page-container-content.component.js
+++ b/ui/components/app/confirm-page-container/confirm-page-container-content/confirm-page-container-content.component.js
@@ -10,7 +10,6 @@ import { INSUFFICIENT_FUNDS_ERROR_KEY } from '../../../../helpers/constants/erro
 import Typography from '../../../ui/typography';
 import { TYPOGRAPHY } from '../../../../helpers/constants/design-system';
 import { TRANSACTION_TYPES } from '../../../../../shared/constants/transaction';
-import { MAINNET_CHAIN_ID } from '../../../../../shared/constants/network';
 
 import { ConfirmPageContainerSummary, ConfirmPageContainerWarning } from '.';
 
@@ -57,6 +56,7 @@ export default class ConfirmPageContainerContent extends Component {
     showBuyModal: PropTypes.func,
     toAddress: PropTypes.string,
     transactionType: PropTypes.string,
+    isBuyableTransakChain: PropTypes.bool,
   };
 
   renderContent() {
@@ -132,6 +132,7 @@ export default class ConfirmPageContainerContent extends Component {
       showBuyModal,
       toAddress,
       transactionType,
+      isBuyableTransakChain,
     } = this.props;
 
     const primaryAction = hideUserAcknowledgedGasMissing
@@ -187,7 +188,8 @@ export default class ConfirmPageContainerContent extends Component {
           transactionType={transactionType}
         />
         {this.renderContent()}
-        {!supportsEIP1559V2 &&
+        {!isBuyableTransakChain &&
+          !supportsEIP1559V2 &&
           !hasSimulationError &&
           (errorKey || errorMessage) &&
           currentTransaction.type !== TRANSACTION_TYPES.SIMPLE_SEND && (
@@ -197,21 +199,19 @@ export default class ConfirmPageContainerContent extends Component {
           )}
         {showInsuffienctFundsError && (
           <div className="confirm-page-container-content__error-container">
-            {currentTransaction.chainId === MAINNET_CHAIN_ID ? (
+            {isBuyableTransakChain ? (
               <ActionableMessage
                 className="actionable-message--warning"
                 message={
                   <Typography variant={TYPOGRAPHY.H7} align="left">
                     {t('insufficientCurrency', [nativeCurrency, networkName])}
                     <Button
-                      key="link"
-                      type="secondary"
+                      type="link"
                       className="confirm-page-container-content__link"
                       onClick={showBuyModal}
                     >
-                      {t('buyEth')}
+                      {t('buyToken', [nativeCurrency])}
                     </Button>
-
                     {t('orDeposit')}
                   </Typography>
                 }

--- a/ui/components/app/confirm-page-container/confirm-page-container-content/confirm-page-container-content.component.js
+++ b/ui/components/app/confirm-page-container/confirm-page-container-content/confirm-page-container-content.component.js
@@ -144,7 +144,6 @@ export default class ConfirmPageContainerContent extends Component {
     const { t } = this.context;
 
     const showInsuffienctFundsError =
-      supportsEIP1559V2 &&
       !hasSimulationError &&
       (errorKey || errorMessage) &&
       errorKey === INSUFFICIENT_FUNDS_ERROR_KEY &&

--- a/ui/components/app/confirm-page-container/confirm-page-container-content/index.scss
+++ b/ui/components/app/confirm-page-container/confirm-page-container-content/index.scss
@@ -101,12 +101,11 @@
     position: relative;
   }
 
-  &__link {
+  &__link.button {
     background: transparent;
     border: 0 transparent;
-    display: inline !important;
-    padding: 0 !important;
-    margin: 0 !important;
-    font-size: $font-size-h7 !important;
+    display: inline;
+    padding: 0;
+    font-size: $font-size-h7;
   }
 }

--- a/ui/components/app/confirm-page-container/confirm-page-container-content/index.scss
+++ b/ui/components/app/confirm-page-container/confirm-page-container-content/index.scss
@@ -104,8 +104,9 @@
   &__link {
     background: transparent;
     border: 0 transparent;
-    display: inline;
-    padding: 0;
-    font-size: $font-size-h7;
+    display: inline !important;
+    padding: 0 !important;
+    margin: 0 !important;
+    font-size: $font-size-h7 !important;
   }
 }

--- a/ui/components/app/confirm-page-container/confirm-page-container.component.js
+++ b/ui/components/app/confirm-page-container/confirm-page-container.component.js
@@ -4,10 +4,7 @@ import PropTypes from 'prop-types';
 import { EDIT_GAS_MODES } from '../../../../shared/constants/gas';
 import { GasFeeContextProvider } from '../../../contexts/gasFee';
 import { TRANSACTION_TYPES } from '../../../../shared/constants/transaction';
-import {
-  NETWORK_TO_NAME_MAP,
-  MAINNET_CHAIN_ID,
-} from '../../../../shared/constants/network';
+import { NETWORK_TO_NAME_MAP } from '../../../../shared/constants/network';
 
 import { PageContainerFooter } from '../../ui/page-container';
 import Dialog from '../../ui/dialog';
@@ -98,6 +95,7 @@ export default class ConfirmPageContainer extends Component {
     supportsEIP1559V2: PropTypes.bool,
     nativeCurrency: PropTypes.string,
     showBuyModal: PropTypes.func,
+    isBuyableTransakChain: PropTypes.bool,
   };
 
   render() {
@@ -152,6 +150,7 @@ export default class ConfirmPageContainer extends Component {
       supportsEIP1559V2,
       nativeCurrency,
       showBuyModal,
+      isBuyableTransakChain,
     } = this.props;
 
     const showAddToAddressDialog =
@@ -258,11 +257,12 @@ export default class ConfirmPageContainer extends Component {
               showBuyModal={showBuyModal}
               toAddress={toAddress}
               transactionType={currentTransaction.type}
+              isBuyableTransakChain={isBuyableTransakChain}
             />
           )}
           {shouldDisplayWarning && errorKey === INSUFFICIENT_FUNDS_ERROR_KEY && (
             <div className="confirm-approve-content__warning">
-              {currentTransaction.chainId === MAINNET_CHAIN_ID ? (
+              {isBuyableTransakChain ? (
                 <ActionableMessage
                   message={
                     <Typography variant={TYPOGRAPHY.H7} align="left">
@@ -272,9 +272,8 @@ export default class ConfirmPageContainer extends Component {
                         className="page-container__link"
                         onClick={showBuyModal}
                       >
-                        {t('buyEth')}
+                        {t('buyToken', [nativeCurrency])}
                       </Button>
-
                       {t('orDeposit')}
                     </Typography>
                   }

--- a/ui/components/app/confirm-page-container/confirm-page-container.container.js
+++ b/ui/components/app/confirm-page-container/confirm-page-container.container.js
@@ -1,10 +1,15 @@
 import { connect } from 'react-redux';
-import { getAccountsWithLabels, getAddressBookEntry } from '../../../selectors';
+import {
+  getAccountsWithLabels,
+  getAddressBookEntry,
+  getIsBuyableTransakChain,
+} from '../../../selectors';
 import { showModal } from '../../../store/actions';
 import ConfirmPageContainer from './confirm-page-container.component';
 
 function mapStateToProps(state, ownProps) {
   const to = ownProps.toAddress;
+  const isBuyableTransakChain = getIsBuyableTransakChain(state);
 
   const contact = getAddressBookEntry(state, to);
   return {
@@ -14,6 +19,7 @@ function mapStateToProps(state, ownProps) {
       .map((accountWithLabel) => accountWithLabel.address)
       .includes(to),
     to,
+    isBuyableTransakChain,
   };
 }
 

--- a/ui/pages/confirm-transaction-base/confirm-transaction-base.component.js
+++ b/ui/pages/confirm-transaction-base/confirm-transaction-base.component.js
@@ -586,7 +586,6 @@ export default class ConfirmTransactionBase extends Component {
             this.setUserAcknowledgedGasMissing()
           }
           userAcknowledgedGasMissing={userAcknowledgedGasMissing}
-          chainId={txData.chainId}
           nativeCurrency={nativeCurrency}
           networkName={networkName}
           showBuyModal={showBuyModal}

--- a/ui/pages/confirm-transaction-base/transaction-alerts/transaction-alerts.js
+++ b/ui/pages/confirm-transaction-base/transaction-alerts/transaction-alerts.js
@@ -12,12 +12,11 @@ import Button from '../../../components/ui/button';
 import Typography from '../../../components/ui/typography';
 import { TYPOGRAPHY } from '../../../helpers/constants/design-system';
 import { TRANSACTION_TYPES } from '../../../../shared/constants/transaction';
-import { MAINNET_CHAIN_ID } from '../../../../shared/constants/network';
+import { getIsBuyableTransakChain } from '../../../selectors';
 
 const TransactionAlerts = ({
   userAcknowledgedGasMissing,
   setUserAcknowledgedGasMissing,
-  chainId,
   nativeCurrency,
   networkName,
   showBuyModal,
@@ -31,9 +30,10 @@ const TransactionAlerts = ({
     isNetworkBusy,
   } = useGasFeeContext();
   const pendingTransactions = useSelector(submittedPendingTransactionsSelector);
+  const isBuyableTransakChain = useSelector(getIsBuyableTransakChain);
   const t = useI18nContext();
 
-  if (!supportsEIP1559V2) {
+  if (!supportsEIP1559V2 && !isBuyableTransakChain) {
     return null;
   }
 
@@ -97,7 +97,7 @@ const TransactionAlerts = ({
         />
       )}
       {balanceError &&
-      chainId === MAINNET_CHAIN_ID &&
+      isBuyableTransakChain &&
       type === TRANSACTION_TYPES.DEPLOY_CONTRACT ? (
         <ActionableMessage
           className="actionable-message--warning"
@@ -109,8 +109,8 @@ const TransactionAlerts = ({
                 className="transaction-alerts__link"
                 onClick={showBuyModal}
               >
-                {t('buyEth')}
-              </Button>{' '}
+                {t('buyToken', [nativeCurrency])}
+              </Button>
               {t('orDeposit')}
             </Typography>
           }
@@ -120,7 +120,7 @@ const TransactionAlerts = ({
         />
       ) : null}
       {balanceError &&
-      chainId !== MAINNET_CHAIN_ID &&
+      !isBuyableTransakChain &&
       type === TRANSACTION_TYPES.DEPLOY_CONTRACT ? (
         <ActionableMessage
           className="actionable-message--warning"
@@ -177,7 +177,6 @@ const TransactionAlerts = ({
 TransactionAlerts.propTypes = {
   userAcknowledgedGasMissing: PropTypes.bool,
   setUserAcknowledgedGasMissing: PropTypes.func,
-  chainId: PropTypes.string,
   nativeCurrency: PropTypes.string,
   networkName: PropTypes.string,
   showBuyModal: PropTypes.func,

--- a/ui/pages/confirm-transaction-base/transaction-alerts/transaction-alerts.test.js
+++ b/ui/pages/confirm-transaction-base/transaction-alerts/transaction-alerts.test.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { fireEvent } from '@testing-library/react';
 import { renderWithProvider } from '../../../../test/jest';
 import { submittedPendingTransactionsSelector } from '../../../selectors/transactions';
+import { getIsBuyableTransakChain } from '../../../selectors';
 import { TRANSACTION_TYPES } from '../../../../shared/constants/transaction';
 import { useGasFeeContext } from '../../../contexts/gasFee';
 import configureStore from '../../../store/store';
@@ -14,17 +15,26 @@ jest.mock('../../../selectors/transactions', () => {
   };
 });
 
+jest.mock('../../../selectors', () => {
+  return {
+    ...jest.requireActual('../../../selectors'),
+    getIsBuyableTransakChain: jest.fn(),
+  };
+});
+
 jest.mock('../../../contexts/gasFee');
 
 function render({
   componentProps = {},
   useGasFeeContextValue = {},
   submittedPendingTransactionsSelectorValue = null,
+  getIsBuyableTransakChainValue = null,
 }) {
   useGasFeeContext.mockReturnValue(useGasFeeContextValue);
   submittedPendingTransactionsSelector.mockReturnValue(
     submittedPendingTransactionsSelectorValue,
   );
+  getIsBuyableTransakChain.mockReturnValue(getIsBuyableTransakChainValue);
   const store = configureStore({});
   return renderWithProvider(<TransactionAlerts {...componentProps} />, store);
 }
@@ -153,7 +163,6 @@ describe('TransactionAlerts', () => {
             nativeCurrency: 'ETH',
             networkName: 'Ropsten',
             showBuyModal: jest.fn(),
-            chainId: '0x1',
             type: TRANSACTION_TYPES.DEPLOY_CONTRACT,
           },
         });


### PR DESCRIPTION
**Explanation**: Implemented the link button "Buy token", for all the networks where the buy option is enabled. Starting with the version 10.10.0 those are Ethereum Mainnet, Polygon, Avalanche, Celo and Fantom.
"Buy token" text is a text where the token is the network's main token (native currency) - ETH, MATIC etc.

**Fixes**:  https://github.com/MetaMask/metamask-extension/issues/13680

**Screencast**: 
https://user-images.githubusercontent.com/92310504/158404881-802cee59-a0b9-407c-9cb9-d29233f20bf6.mov

