### PR TITLE
Add `data-testid` prop to `TextField` component

### DIFF
--- a/ui/components/ui/text-field/text-field.component.js
+++ b/ui/components/ui/text-field/text-field.component.js
@@ -204,6 +204,7 @@ const themeToInputProps = {
 };
 
 const TextField = ({
+  'data-testid': dataTestId,
   error,
   classes,
   theme,
@@ -228,7 +229,7 @@ const TextField = ({
     autoComplete,
   });
 
-  if (onPaste) {
+  if (onPaste || dataTestId) {
     if (!inputProps.InputProps) {
       inputProps.InputProps = {};
     }
@@ -236,6 +237,7 @@ const TextField = ({
       inputProps.InputProps.inputProps = {};
     }
     inputProps.InputProps.inputProps.onPaste = onPaste;
+    inputProps.InputProps.inputProps['data-testid'] = dataTestId;
   }
 
   return (
@@ -255,6 +257,10 @@ TextField.defaultProps = {
 };
 
 TextField.propTypes = {
+  /**
+   * A test ID that gets set on the input element
+   */
+  'data-testid': PropTypes.string,
   /**
    * Show error message
    */

--- a/ui/pages/swaps/searchable-item-list/__snapshots__/searchable-item-list.test.js.snap
+++ b/ui/pages/swaps/searchable-item-list/__snapshots__/searchable-item-list.test.js.snap
@@ -3,7 +3,6 @@
 exports[`SearchableItemList renders the component with initial props 1`] = `
 <div
   class="MuiFormControl-root MuiTextField-root searchable-item-list__search MuiFormControl-fullWidth"
-  data-testid="search-list-items"
 >
   <div
     class="MuiInputBase-root MuiInput-root TextField-inputRoot-12 MuiInputBase-fullWidth MuiInput-fullWidth Mui-focused Mui-focused TextField-inputFocused-11 MuiInputBase-formControl MuiInput-formControl MuiInputBase-adornedStart"
@@ -23,6 +22,7 @@ exports[`SearchableItemList renders the component with initial props 1`] = `
       aria-invalid="false"
       autocomplete="off"
       class="MuiInputBase-input MuiInput-input MuiInputBase-inputAdornedStart"
+      data-testid="search-list-items"
       dir="auto"
       type="text"
       value=""


### PR DESCRIPTION
## Explanation

The `data-testid` prop has been added to `TextField`. This prop allows selecting this component more easily from e2e and unit tests. This is required for a subsequent PR that includes a text field that cannot be selected for by placeholder or contents or label (any of which would have been preferable).