### PR TITLE
Convert UrlIcon knobs and actions to controls / args

### DIFF
--- a/ui/components/ui/url-icon/url-icon.stories.js
+++ b/ui/components/ui/url-icon/url-icon.stories.js
@@ -19,7 +19,7 @@ export default {
 };
 
 export const DefaultStory = (args) => {
-  return <UrlIcon name={args.name} url={args.url} />;
+  return <UrlIcon name={args.name} url={args.url} className={args.className} fallbackClassName={fallbackClassName} />;
 };
 
 export const AST = () => {

--- a/ui/components/ui/url-icon/url-icon.stories.js
+++ b/ui/components/ui/url-icon/url-icon.stories.js
@@ -5,22 +5,22 @@ export default {
   title: 'Components/UI/UrlIcon',
   id: __filename,
   argType: {
-    name: { description:"Icon Name", control:"text"},
-    url: { description: "Icon File URL", control: "text" },
-    className: { control: "text" },
-    fallbackClassName: { control: "text" },
+    name: { description: 'Icon Name', control: 'text' },
+    url: { description: 'Icon File URL', control: 'text' },
+    className: { control: 'text' },
+    fallbackClassName: { control: 'text' },
   },
   args: {
-    name: "AST",
-    url: "AST.png",
-    className: "",
-    fallbackClassName:"",
-  }
+    name: 'AST',
+    url: 'AST.png',
+    className: '',
+    fallbackClassName: '',
+  },
 };
 
 export const DefaultStory = (args) => {
   return <UrlIcon name={args.name} url={args.url} />;
-}
+};
 
 export const AST = () => {
   return <UrlIcon name="AST" url="AST.png" />;

--- a/ui/components/ui/url-icon/url-icon.stories.js
+++ b/ui/components/ui/url-icon/url-icon.stories.js
@@ -19,7 +19,14 @@ export default {
 };
 
 export const DefaultStory = (args) => {
-  return <UrlIcon name={args.name} url={args.url} className={args.className} fallbackClassName={fallbackClassName} />;
+  return (
+    <UrlIcon
+      name={args.name}
+      url={args.url}
+      className={args.className}
+      fallbackClassName={args.fallbackClassName}
+    />
+  );
 };
 
 export const AST = () => {

--- a/ui/components/ui/url-icon/url-icon.stories.js
+++ b/ui/components/ui/url-icon/url-icon.stories.js
@@ -1,11 +1,26 @@
 import React from 'react';
-import { text } from '@storybook/addon-knobs';
 import UrlIcon from './url-icon';
 
 export default {
   title: 'Components/UI/UrlIcon',
   id: __filename,
+  argType: {
+    name: { description:"Icon Name", control:"text"},
+    url: { description: "Icon File URL", control: "text" },
+    className: { control: "text" },
+    fallbackClassName: { control: "text" },
+  },
+  args: {
+    name: "AST",
+    url: "AST.png",
+    className: "",
+    fallbackClassName:"",
+  }
 };
+
+export const DefaultStory = (args) => {
+  return <UrlIcon name={args.name} url={args.url} />;
+}
 
 export const AST = () => {
   return <UrlIcon name="AST" url="AST.png" />;
@@ -13,15 +28,4 @@ export const AST = () => {
 
 export const BAT = () => {
   return <UrlIcon name="BAT" url="BAT_icon.svg" />;
-};
-
-export const CustomProps = () => {
-  return (
-    <UrlIcon
-      name={text('Symbol', '')}
-      url={text('Icon URL', '')}
-      className={text('className', '')}
-      fallbackClassName={text('fallbackClassName', '')}
-    />
-  );
 };

--- a/ui/components/ui/url-icon/url-icon.stories.js
+++ b/ui/components/ui/url-icon/url-icon.stories.js
@@ -5,8 +5,8 @@ export default {
   title: 'Components/UI/UrlIcon',
   id: __filename,
   argType: {
-    name: { description: 'Icon Name', control: 'text' },
-    url: { description: 'Icon File URL', control: 'text' },
+    name: { control: 'text' },
+    url: { control: 'text' },
     className: { control: 'text' },
     fallbackClassName: { control: 'text' },
   },


### PR DESCRIPTION
## Explanation

Convert UrlIcon knobs and actions to controls / args

fixed #13067

## More information

* Fixes: #13067

## Screenshots/Screencaps

![image](https://user-images.githubusercontent.com/13283837/158543423-c4bea51c-6d29-496f-9e45-af1633bac888.png)

![image](https://user-images.githubusercontent.com/13283837/158543442-886da721-711b-4ac5-a182-dad4fbe8ee07.png)
