### PR TITLE
Dark Mode: Fix Onboarding image text color

### DIFF
--- a/ui/pages/onboarding-flow/pin-extension/pin-billboard.js
+++ b/ui/pages/onboarding-flow/pin-extension/pin-billboard.js
@@ -43,7 +43,7 @@ export default function OnboardingPinBillboard() {
         </tspan>
       </text>
       <text
-        fill="black"
+        fill="var(--color-text-default)"
         xmlSpace="preserve"
         style={{ 'white-space': 'pre' }}
         fontFamily="Euclid Circular B"
@@ -74,7 +74,7 @@ export default function OnboardingPinBillboard() {
         </tspan>
       </text>
       <text
-        fill="black"
+        fill="var(--color-text-default)"
         xmlSpace="preserve"
         style={{ 'white-space': 'pre' }}
         fontFamily="Euclid Circular B"


### PR DESCRIPTION
Simply fixes the color of the text in the image:
<img width="809" alt="WasBlack" src="https://user-images.githubusercontent.com/46655/158563644-241bdfa8-e488-495b-b298-a633d8ca4aee.png">

