### PR TITLE
Dark Mode: ENS Input

### DIFF
--- a/ui/pages/send/send.scss
+++ b/ui/pages/send/send.scss
@@ -182,6 +182,10 @@
       height: 1.125rem;
       margin: 0.25rem 0.5rem 0.25rem 0.25rem;
 
+      [data-theme='dark'] & {
+        background-image: url('/images/search.svg');
+      }
+
       &--valid {
         background-image: url('/images/check-green-solid.svg');
       }
@@ -194,6 +198,8 @@
       width: 0;
       border: 0;
       outline: none;
+      color: var(--color-text-default);
+      background-color: var(--color-background-default);
 
       &::placeholder {
         color: var(--Grey-200);


### PR DESCRIPTION
Supercedes: https://github.com/MetaMask/metamask-extension/pull/13916

Fixes the ENS input for dark mode.

<img width="459" alt="ENSInput" src="https://user-images.githubusercontent.com/46655/157921662-b35b7e84-a299-4d1f-835e-03738bfb3a5d.png">

You can see this component after clicking the SEND button.
