### PR TITLE
Ensure accounts still line up in dropdown

### DIFF
--- a/ui/components/app/account-menu/index.scss
+++ b/ui/components/app/account-menu/index.scss
@@ -198,6 +198,7 @@
   &__check-mark {
     margin-right: 8px;
     flex: 0 0 auto;
+    min-width: 24px;
   }
 
   .identicon {


### PR DESCRIPTION
We recently changed the selected account checkmark in from static image to `<IconCheck />` in `ui/components/app/account-menu/account-menu.component.js`.  Unfortunately accounts don't line up when one is checked; this fixes that issue.
<img width="229" alt="LineUp" src="https://user-images.githubusercontent.com/46655/158574056-f47f87dd-3722-4d2f-a49f-29efe74ef598.png">

