### PR TITLE
Dark Mode: Update the loading screen colors

### DIFF
--- a/ui/components/ui/loading-screen/index.scss
+++ b/ui/components/ui/loading-screen/index.scss
@@ -9,7 +9,8 @@
   flex: 1 1 auto;
   width: 100%;
   height: 100%;
-  background: rgba(255, 255, 255, 0.8);
+  background: var(--color-background-alternative);
+  opacity: 0.8;
 
   &__screen-content {
     display: flex;


### PR DESCRIPTION
Updates the loading overlay colors to look good in dark mode:
<img width="521" alt="Loading" src="https://user-images.githubusercontent.com/46655/158575542-e46590e2-946b-4f1c-803b-d5f2155929fd.png">

