### PR TITLE
Dark Mode: Fix colors in threedot asset menu

### DIFF
--- a/ui/components/ui/menu/menu.scss
+++ b/ui/components/ui/menu/menu.scss
@@ -34,6 +34,7 @@
   width: 100%;
   padding: 14px 0;
   cursor: pointer;
+  color: inherit;
 
   &__icon {
     margin-right: 8px;


### PR DESCRIPTION
In dark mode the menu items were displaying as black 
<img width="739" alt="ColorInherit" src="https://user-images.githubusercontent.com/46655/158584244-475258d7-a656-4e49-8b91-e13d999f2945.png">

