### PR TITLE
Add `pasteIntoField` webdriver method

### DIFF
--- a/test/e2e/helpers.js
+++ b/test/e2e/helpers.js
@@ -226,7 +226,7 @@ const completeImportSRPOnboardingFlow = async (
     await driver.clickElement('.btn-secondary');
 
     // Import Secret Recovery Phrase
-    await driver.fill(
+    await driver.pasteIntoField(
       'input[placeholder="Enter your Secret Recovery Phrase"]',
       seedPhrase,
     );

--- a/test/e2e/metamask-ui.spec.js
+++ b/test/e2e/metamask-ui.spec.js
@@ -202,11 +202,10 @@ describe('MetaMask', function () {
       await restoreSeedLink.click();
       await driver.delay(regularDelayMs);
 
-      await driver.fill(
+      await driver.pasteIntoField(
         'input[placeholder="Enter your Secret Recovery Phrase"]',
         testSeedPhrase,
       );
-      await driver.delay(regularDelayMs);
 
       await driver.fill('#password', 'correct horse battery staple');
       await driver.fill('#confirm-password', 'correct horse battery staple');

--- a/test/e2e/tests/add-account.spec.js
+++ b/test/e2e/tests/add-account.spec.js
@@ -129,11 +129,10 @@ describe('Add account', function () {
         await restoreSeedLink.click();
         await driver.delay(regularDelayMs);
 
-        await driver.fill(
+        await driver.pasteIntoField(
           'input[placeholder="Enter your Secret Recovery Phrase"]',
           testSeedPhrase,
         );
-        await driver.delay(regularDelayMs);
 
         await driver.fill('#password', 'correct horse battery staple');
         await driver.fill('#confirm-password', 'correct horse battery staple');

--- a/test/e2e/tests/metamask-responsive-ui.spec.js
+++ b/test/e2e/tests/metamask-responsive-ui.spec.js
@@ -169,7 +169,7 @@ describe('Metamask Responsive UI', function () {
         assert.equal(await restoreSeedLink.getText(), 'Forgot password?');
         await restoreSeedLink.click();
 
-        await driver.fill(
+        await driver.pasteIntoField(
           'input[placeholder="Enter your Secret Recovery Phrase"]',
           testSeedPhrase,
         );

--- a/test/e2e/webdriver/driver.js
+++ b/test/e2e/webdriver/driver.js
@@ -1,6 +1,6 @@
 const { promises: fs } = require('fs');
 const { strict: assert } = require('assert');
-const { until, error: webdriverError, By } = require('selenium-webdriver');
+const { until, error: webdriverError, By, Key } = require('selenium-webdriver');
 const cssToXPath = require('css-to-xpath');
 
 /**
@@ -255,6 +255,26 @@ class Driver {
     } catch (err) {
       return false;
     }
+  }
+
+  /**
+   * Paste a string into a field.
+   *
+   * @param {string} element - The element locator.
+   * @param {string} contentToPaste - The content to paste.
+   */
+  async pasteIntoField(element, contentToPaste) {
+    // Throw if double-quote is present in content to paste
+    // so that we don't have to worry about escaping double-quotes
+    if (contentToPaste.includes('"')) {
+      throw new Error('Cannot paste content with double-quote');
+    }
+    // Click to focus the field
+    await this.clickElement(element);
+    await this.executeScript(
+      `navigator.clipboard.writeText("${contentToPaste}")`,
+    );
+    await this.fill(element, Key.chord(Key.CONTROL, 'v'));
   }
 
   // Navigation


### PR DESCRIPTION
A new method has been added to the e2e webdriver for pasting text into a field. This will be required to properly test a change to the SRP input, which will be coming in a separate PR.

A few existing e2e tests have been updated to use this method to input the SRP, to show that it works properly.