### PR TITLE
Remove the useSegmentContext function from metametrics.new.js

### DIFF
--- a/ui/contexts/metametrics.new.js
+++ b/ui/contexts/metametrics.new.js
@@ -10,15 +10,14 @@ import React, {
   useRef,
   useCallback,
 } from 'react';
-import { useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
-import { matchPath, useLocation, useRouteMatch } from 'react-router-dom';
+import { matchPath, useLocation } from 'react-router-dom';
 import { captureException, captureMessage } from '@sentry/browser';
 
 import { omit } from 'lodash';
 import { getEnvironmentType } from '../../app/scripts/lib/util';
 import { PATH_NAME_MAP } from '../helpers/constants/routes';
-import { txDataSelector } from '../selectors';
+import { useMetaMetrics } from '../hooks/useMetaMetrics';
 
 import { trackMetaMetricsEvent, trackMetaMetricsPage } from '../store/actions';
 
@@ -54,47 +53,9 @@ export const MetaMetricsContext = createContext(() => {
 
 const PATHS_TO_CHECK = Object.keys(PATH_NAME_MAP);
 
-/**
- * Returns the current page if it matches out route map, as well as the origin
- * if there is a confirmation that was triggered by a dapp
- *
- * @returns {{
- *  page?: MetaMetricsPageObject
- *  referrer?: MetaMetricsReferrerObject
- * }}
- */
-function useSegmentContext() {
-  const match = useRouteMatch({
-    path: PATHS_TO_CHECK,
-    exact: true,
-    strict: true,
-  });
-  const txData = useSelector(txDataSelector) || {};
-  const confirmTransactionOrigin = txData.origin;
-
-  const referrer = confirmTransactionOrigin
-    ? {
-        url: confirmTransactionOrigin,
-      }
-    : undefined;
-
-  const page = match
-    ? {
-        path: match.path,
-        title: PATH_NAME_MAP[match.path],
-        url: match.path,
-      }
-    : undefined;
-
-  return {
-    page,
-    referrer,
-  };
-}
-
 export function MetaMetricsProvider({ children }) {
   const location = useLocation();
-  const context = useSegmentContext();
+  const context = useMetaMetrics();
 
   /**
    * @type {UITrackEventMethod}

--- a/ui/contexts/metametrics.new.js
+++ b/ui/contexts/metametrics.new.js
@@ -17,7 +17,7 @@ import { captureException, captureMessage } from '@sentry/browser';
 import { omit } from 'lodash';
 import { getEnvironmentType } from '../../app/scripts/lib/util';
 import { PATH_NAME_MAP } from '../helpers/constants/routes';
-import { useMetaMetrics } from '../hooks/useMetaMetrics';
+import { useSegmentContext } from '../hooks/useSegmentContext';
 
 import { trackMetaMetricsEvent, trackMetaMetricsPage } from '../store/actions';
 
@@ -55,7 +55,7 @@ const PATHS_TO_CHECK = Object.keys(PATH_NAME_MAP);
 
 export function MetaMetricsProvider({ children }) {
   const location = useLocation();
-  const context = useMetaMetrics();
+  const context = useSegmentContext();
 
   /**
    * @type {UITrackEventMethod}

--- a/ui/hooks/useEventFragment.js
+++ b/ui/hooks/useEventFragment.js
@@ -7,7 +7,7 @@ import {
   createEventFragment,
   updateEventFragment,
 } from '../store/actions';
-import { useMetaMetricsContext } from './useMetricEvent';
+import { useMetaMetrics } from './useMetaMetrics';
 
 /**
  * Retrieves a fragment from memory or initializes new fragment if one does not
@@ -59,7 +59,7 @@ export function useEventFragment(existingId, fragmentOptions = {}) {
     }
   }, [fragment, fragmentOptions]);
 
-  const context = useMetaMetricsContext();
+  const context = useMetaMetrics();
 
   /**
    * trackSuccess is used to close a fragment with the affirmative action. This

--- a/ui/hooks/useEventFragment.js
+++ b/ui/hooks/useEventFragment.js
@@ -7,7 +7,7 @@ import {
   createEventFragment,
   updateEventFragment,
 } from '../store/actions';
-import { useMetaMetrics } from './useMetaMetrics';
+import { useSegmentContext } from './useSegmentContext';
 
 /**
  * Retrieves a fragment from memory or initializes new fragment if one does not
@@ -59,7 +59,7 @@ export function useEventFragment(existingId, fragmentOptions = {}) {
     }
   }, [fragment, fragmentOptions]);
 
-  const context = useMetaMetrics();
+  const context = useSegmentContext();
 
   /**
    * trackSuccess is used to close a fragment with the affirmative action. This

--- a/ui/hooks/useEventFragment.test.js
+++ b/ui/hooks/useEventFragment.test.js
@@ -13,8 +13,8 @@ jest.mock('../store/actions', () => ({
   createEventFragment: jest.fn(),
 }));
 
-jest.mock('./useMetricEvent', () => ({
-  useMetaMetricsContext: jest.fn(() => ({ page: '/' })),
+jest.mock('./useMetaMetrics', () => ({
+  useMetaMetrics: jest.fn(() => ({ page: '/' })),
 }));
 
 jest.mock('react-redux', () => ({

--- a/ui/hooks/useEventFragment.test.js
+++ b/ui/hooks/useEventFragment.test.js
@@ -13,8 +13,8 @@ jest.mock('../store/actions', () => ({
   createEventFragment: jest.fn(),
 }));
 
-jest.mock('./useMetaMetrics', () => ({
-  useMetaMetrics: jest.fn(() => ({ page: '/' })),
+jest.mock('./useSegmentContext', () => ({
+  useSegmentContext: jest.fn(() => ({ page: '/' })),
 }));
 
 jest.mock('react-redux', () => ({

--- a/ui/hooks/useMetaMetrics.js
+++ b/ui/hooks/useMetaMetrics.js
@@ -16,7 +16,7 @@ const PATHS_TO_CHECK = Object.keys(PATH_NAME_MAP);
  *  referrer?: MetaMetricsReferrerObject
  * }}
  */
-export function useMetaMetricsContext() {
+export function useMetaMetrics() {
   const match = useRouteMatch({
     path: PATHS_TO_CHECK,
     exact: true,

--- a/ui/hooks/useSegmentContext.js
+++ b/ui/hooks/useSegmentContext.js
@@ -16,7 +16,7 @@ const PATHS_TO_CHECK = Object.keys(PATH_NAME_MAP);
  *  referrer?: MetaMetricsReferrerObject
  * }}
  */
-export function useMetaMetrics() {
+export function useSegmentContext() {
   const match = useRouteMatch({
     path: PATHS_TO_CHECK,
     exact: true,


### PR DESCRIPTION
fixes: #13768

## Explanation
Remove the `useSegmentContext` function from `metametrics.new.js` and create new file for `useMetaMetrics` hook.