### PR TITLE
add space between sentences in insufficient currency warning

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -420,18 +420,6 @@
     "message": "Transak supports debit card and bank transfers (depending on location) in 59+ countries. $1 deposits into your MetaMask account.",
     "description": "$1 represents the cypto symbol to be purchased"
   },
-  "insufficientCurrency": {
-    "message": "You do not have enough $1 in your account to pay for transaction fees on $2 network.",
-    "description": "$1 is the native currency of the network, $2 is the name of the current network"
-  },
-  "insufficientCurrencyBuyOrDeposit": {
-    "message": "You do not have enough $1 in your account to pay for transaction fees on $2 network. $3 Deposit from another account.",
-    "description": "$1 is the native currency of the network, $2 is the name of the current network, $3 is the key 'buy' + the ticker symbol of the native currency of the chain + the key 'or' all wrapped in a button"
-  },
-  "depositFromOtherAccount": {
-    "message": "Deposit $1 from another account.",
-    "description": "$1 is the ticker symbol of the native currency of the chain the user is currently on"
-  },
   "buyWithWyre": {
     "message": "Buy ETH with Wyre"
   },
@@ -1529,6 +1517,10 @@
   },
   "insufficientBalance": {
     "message": "Insufficient balance."
+  },
+  "insufficientCurrencyBuyOrDeposit": {
+    "message": "You do not have enough $1 in your account to pay for transaction fees on $2 network. $3 Deposit from another account.",
+    "description": "$1 is the native currency of the network, $2 is the name of the current network, $3 is the key 'buy' + the ticker symbol of the native currency of the chain + the key 'or' all wrapped in a button"
   },
   "insufficientFunds": {
     "message": "Insufficient funds."

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -420,12 +420,13 @@
     "message": "Transak supports debit card and bank transfers (depending on location) in 59+ countries. $1 deposits into your MetaMask account.",
     "description": "$1 represents the cypto symbol to be purchased"
   },
-  "buyEth": {
-    "message": "Buy ETH"
+  "buyNativeCurrency": {
+    "message": "$1 or deposit from another account.",
+    "description": "$1 is the key 'buy' and the ticker symbol of the native currency of the chain the user is currently on wrapped in a button"
   },
-  "buyOther": {
-    "message": "Buy $1 or deposit from another account.",
-    "description": "$1 is a token symbol"
+  "depositFromOtherAccount": {
+    "message": "Deposit $1 from another account.",
+    "description": "$1 is the ticker symbol of the native currency of the chain the user is currently on"
   },
   "buyWithWyre": {
     "message": "Buy ETH with Wyre"

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -405,6 +405,10 @@
   "buy": {
     "message": "Buy"
   },
+  "buyAsset": {
+    "message": "Buy $1",
+    "description": "$1 is the ticker symbol of a an asset the user is being prompted to purchase"
+  },
   "buyCryptoWithMoonPay": {
     "message": "Buy $1 with MoonPay",
     "description": "$1 represents the cypto symbol to be purchased"
@@ -1519,8 +1523,12 @@
     "message": "Insufficient balance."
   },
   "insufficientCurrencyBuyOrDeposit": {
-    "message": "You do not have enough $1 in your account to pay for transaction fees on $2 network. $3 Deposit from another account.",
-    "description": "$1 is the native currency of the network, $2 is the name of the current network, $3 is the key 'buy' + the ticker symbol of the native currency of the chain + the key 'or' all wrapped in a button"
+    "message": "You do not have enough $1 in your account to pay for transaction fees on $2 network. $3 or deposit from another account.",
+    "description": "$1 is the native currency of the network, $2 is the name of the current network, $3 is the key 'buy' + the ticker symbol of the native currency of the chain wrapped in a button"
+  },
+  "insufficientCurrencyDeposit": {
+    "message": "You do not have enough $1 in your account to pay for transaction fees on $2 network. Deposit $1 from another account.",
+    "description": "$1 is the native currency of the network, $2 is the name of the current network"
   },
   "insufficientFunds": {
     "message": "Insufficient funds."
@@ -2271,9 +2279,6 @@
   },
   "or": {
     "message": "or"
-  },
-  "orDeposit": {
-    "message": "or deposit from another account."
   },
   "origin": {
     "message": "Origin"

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -420,9 +420,13 @@
     "message": "Transak supports debit card and bank transfers (depending on location) in 59+ countries. $1 deposits into your MetaMask account.",
     "description": "$1 represents the cypto symbol to be purchased"
   },
-  "buyNativeCurrency": {
-    "message": "$1 or deposit from another account.",
-    "description": "$1 is the key 'buy' and the ticker symbol of the native currency of the chain the user is currently on wrapped in a button"
+  "insufficientCurrency": {
+    "message": "You do not have enough $1 in your account to pay for transaction fees on $2 network.",
+    "description": "$1 is the native currency of the network, $2 is the name of the current network"
+  },
+  "insufficientCurrencyBuyOrDeposit": {
+    "message": "You do not have enough $1 in your account to pay for transaction fees on $2 network. $3 Deposit from another account.",
+    "description": "$1 is the native currency of the network, $2 is the name of the current network, $3 is the key 'buy' + the ticker symbol of the native currency of the chain + the key 'or' all wrapped in a button"
   },
   "depositFromOtherAccount": {
     "message": "Deposit $1 from another account.",
@@ -1525,10 +1529,6 @@
   },
   "insufficientBalance": {
     "message": "Insufficient balance."
-  },
-  "insufficientCurrency": {
-    "message": "You do not have enough $1 in your account to pay for transaction fees on $2 network.",
-    "description": "$1 is currency, $2 is network"
   },
   "insufficientFunds": {
     "message": "Insufficient funds."

--- a/ui/components/app/confirm-page-container/confirm-page-container-content/confirm-page-container-content.component.js
+++ b/ui/components/app/confirm-page-container/confirm-page-container-content/confirm-page-container-content.component.js
@@ -10,10 +10,7 @@ import { INSUFFICIENT_FUNDS_ERROR_KEY } from '../../../../helpers/constants/erro
 import Typography from '../../../ui/typography';
 import { TYPOGRAPHY } from '../../../../helpers/constants/design-system';
 import { TRANSACTION_TYPES } from '../../../../../shared/constants/transaction';
-import {
-  MAINNET_CHAIN_ID,
-  RINKEBY_CHAIN_ID,
-} from '../../../../../shared/constants/network';
+import { BUYABLE_CHAINS_MAP } from '../../../../../shared/constants/network';
 
 import { ConfirmPageContainerSummary, ConfirmPageContainerWarning } from '.';
 
@@ -206,33 +203,24 @@ export default class ConfirmPageContainerContent extends Component {
                   {t('insufficientCurrencyBuyOrDeposit', [
                     nativeCurrency,
                     networkName,
-                    [MAINNET_CHAIN_ID, RINKEBY_CHAIN_ID].includes(
+                    Object.keys(BUYABLE_CHAINS_MAP).includes(
                       currentTransaction.chainId,
                     ) ? (
-                      <Typography variant={TYPOGRAPHY.H7} align="left">
+                      <>
                         <Button
-                          type="link"
-                          className="page-container__link"
+                          type="inline"
+                          className="confirm-page-container-content__link"
                           onClick={showBuyModal}
                         >
                           {t('buy')}
-                          {nativeCurrency}{' '}
+                          {` ${nativeCurrency} `}
                         </Button>
                         {t('or')}
-                      </Typography>
+                      </>
                     ) : (
                       ''
                     ),
                   ])}
-                  {/* <Button
-                        type="link"
-                        className="page-container__link"
-                        onClick={showBuyModal}
-                      >
-                        {t('buyEth')}
-                      </Button>
-
-                      {t('orDeposit')} */}
                 </Typography>
               }
               useIcon

--- a/ui/components/app/confirm-page-container/confirm-page-container-content/confirm-page-container-content.component.js
+++ b/ui/components/app/confirm-page-container/confirm-page-container-content/confirm-page-container-content.component.js
@@ -10,7 +10,10 @@ import { INSUFFICIENT_FUNDS_ERROR_KEY } from '../../../../helpers/constants/erro
 import Typography from '../../../ui/typography';
 import { TYPOGRAPHY } from '../../../../helpers/constants/design-system';
 import { TRANSACTION_TYPES } from '../../../../../shared/constants/transaction';
-import { MAINNET_CHAIN_ID } from '../../../../../shared/constants/network';
+import {
+  MAINNET_CHAIN_ID,
+  RINKEBY_CHAIN_ID,
+} from '../../../../../shared/constants/network';
 
 import { ConfirmPageContainerSummary, ConfirmPageContainerWarning } from '.';
 
@@ -196,42 +199,46 @@ export default class ConfirmPageContainerContent extends Component {
           )}
         {showInsuffienctFundsError && (
           <div className="confirm-page-container-content__error-container">
-            {currentTransaction.chainId === MAINNET_CHAIN_ID ? (
-              <ActionableMessage
-                className="actionable-message--warning"
-                message={
-                  <Typography variant={TYPOGRAPHY.H7} align="left">
-                    {t('insufficientCurrency', [nativeCurrency, networkName])}
-                    <Button
-                      key="link"
-                      type="secondary"
-                      className="confirm-page-container-content__link"
-                      onClick={showBuyModal}
-                    >
-                      {t('buyEth')}
-                    </Button>
+            <ActionableMessage
+              className="actionable-message--warning"
+              message={
+                <Typography variant={TYPOGRAPHY.H7} align="left">
+                  {t('insufficientCurrencyBuyOrDeposit', [
+                    nativeCurrency,
+                    networkName,
+                    [MAINNET_CHAIN_ID, RINKEBY_CHAIN_ID].includes(
+                      currentTransaction.chainId,
+                    ) ? (
+                      <Typography variant={TYPOGRAPHY.H7} align="left">
+                        <Button
+                          type="link"
+                          className="page-container__link"
+                          onClick={showBuyModal}
+                        >
+                          {t('buy')}
+                          {nativeCurrency}{' '}
+                        </Button>
+                        {t('or')}
+                      </Typography>
+                    ) : (
+                      ''
+                    ),
+                  ])}
+                  {/* <Button
+                        type="link"
+                        className="page-container__link"
+                        onClick={showBuyModal}
+                      >
+                        {t('buyEth')}
+                      </Button>
 
-                    {t('orDeposit')}
-                  </Typography>
-                }
-                useIcon
-                iconFillColor="#d73a49"
-                type="danger"
-              />
-            ) : (
-              <ActionableMessage
-                className="actionable-message--warning"
-                message={
-                  <Typography variant={TYPOGRAPHY.H7} align="left">
-                    {t('insufficientCurrency', [nativeCurrency, networkName])}{' '}
-                    {t('buyOther', [nativeCurrency])}
-                  </Typography>
-                }
-                useIcon
-                iconFillColor="#d73a49"
-                type="danger"
-              />
-            )}
+                      {t('orDeposit')} */}
+                </Typography>
+              }
+              useIcon
+              iconFillColor="#d73a49"
+              type="danger"
+            />
           </div>
         )}
 

--- a/ui/components/app/confirm-page-container/confirm-page-container-content/confirm-page-container-content.component.js
+++ b/ui/components/app/confirm-page-container/confirm-page-container-content/confirm-page-container-content.component.js
@@ -226,7 +226,7 @@ export default class ConfirmPageContainerContent extends Component {
                 )
               }
               useIcon
-              iconFillColor="#d73a49"
+              iconFillColor="var(--color-error-default)"
               type="danger"
             />
           </div>

--- a/ui/components/app/confirm-page-container/confirm-page-container-content/confirm-page-container-content.component.js
+++ b/ui/components/app/confirm-page-container/confirm-page-container-content/confirm-page-container-content.component.js
@@ -223,7 +223,7 @@ export default class ConfirmPageContainerContent extends Component {
                 className="actionable-message--warning"
                 message={
                   <Typography variant={TYPOGRAPHY.H7} align="left">
-                    {t('insufficientCurrency', [nativeCurrency, networkName])}
+                    {t('insufficientCurrency', [nativeCurrency, networkName])}{' '}
                     {t('buyOther', [nativeCurrency])}
                   </Typography>
                 }

--- a/ui/components/app/confirm-page-container/confirm-page-container-content/confirm-page-container-content.component.js
+++ b/ui/components/app/confirm-page-container/confirm-page-container-content/confirm-page-container-content.component.js
@@ -10,7 +10,6 @@ import { INSUFFICIENT_FUNDS_ERROR_KEY } from '../../../../helpers/constants/erro
 import Typography from '../../../ui/typography';
 import { TYPOGRAPHY } from '../../../../helpers/constants/design-system';
 import { TRANSACTION_TYPES } from '../../../../../shared/constants/transaction';
-import { BUYABLE_CHAINS_MAP } from '../../../../../shared/constants/network';
 
 import { ConfirmPageContainerSummary, ConfirmPageContainerWarning } from '.';
 
@@ -57,6 +56,7 @@ export default class ConfirmPageContainerContent extends Component {
     showBuyModal: PropTypes.func,
     toAddress: PropTypes.string,
     transactionType: PropTypes.string,
+    isBuyableChain: PropTypes.bool,
   };
 
   renderContent() {
@@ -132,6 +132,7 @@ export default class ConfirmPageContainerContent extends Component {
       showBuyModal,
       toAddress,
       transactionType,
+      isBuyableChain,
     } = this.props;
 
     const primaryAction = hideUserAcknowledgedGasMissing
@@ -199,29 +200,30 @@ export default class ConfirmPageContainerContent extends Component {
             <ActionableMessage
               className="actionable-message--warning"
               message={
-                <Typography variant={TYPOGRAPHY.H7} align="left">
-                  {t('insufficientCurrencyBuyOrDeposit', [
-                    nativeCurrency,
-                    networkName,
-                    Object.keys(BUYABLE_CHAINS_MAP).includes(
-                      currentTransaction.chainId,
-                    ) ? (
-                      <>
-                        <Button
-                          type="inline"
-                          className="confirm-page-container-content__link"
-                          onClick={showBuyModal}
-                        >
-                          {t('buy')}
-                          {` ${nativeCurrency} `}
-                        </Button>
-                        {t('or')}
-                      </>
-                    ) : (
-                      ''
-                    ),
-                  ])}
-                </Typography>
+                isBuyableChain ? (
+                  <Typography variant={TYPOGRAPHY.H7} align="left">
+                    {t('insufficientCurrencyBuyOrDeposit', [
+                      nativeCurrency,
+                      networkName,
+
+                      <Button
+                        type="inline"
+                        className="confirm-page-container-content__link"
+                        onClick={showBuyModal}
+                        key={`${nativeCurrency}-buy-button`}
+                      >
+                        {t('buyAsset', [nativeCurrency])}
+                      </Button>,
+                    ])}
+                  </Typography>
+                ) : (
+                  <Typography variant={TYPOGRAPHY.H7} align="left">
+                    {t('insufficientCurrencyDeposit', [
+                      nativeCurrency,
+                      networkName,
+                    ])}
+                  </Typography>
+                )
               }
               useIcon
               iconFillColor="#d73a49"

--- a/ui/components/app/confirm-page-container/confirm-page-container-content/index.scss
+++ b/ui/components/app/confirm-page-container/confirm-page-container-content/index.scss
@@ -100,12 +100,4 @@
   &__total-value {
     position: relative;
   }
-
-  &__link {
-    background: transparent;
-    border: 0 transparent;
-    display: inline;
-    padding: 0;
-    font-size: $font-size-h7;
-  }
 }

--- a/ui/components/app/confirm-page-container/confirm-page-container.component.js
+++ b/ui/components/app/confirm-page-container/confirm-page-container.component.js
@@ -4,10 +4,7 @@ import PropTypes from 'prop-types';
 import { EDIT_GAS_MODES } from '../../../../shared/constants/gas';
 import { GasFeeContextProvider } from '../../../contexts/gasFee';
 import { TRANSACTION_TYPES } from '../../../../shared/constants/transaction';
-import {
-  NETWORK_TO_NAME_MAP,
-  MAINNET_CHAIN_ID,
-} from '../../../../shared/constants/network';
+import { NETWORK_TO_NAME_MAP } from '../../../../shared/constants/network';
 
 import { PageContainerFooter } from '../../ui/page-container';
 import Dialog from '../../ui/dialog';
@@ -262,55 +259,29 @@ export default class ConfirmPageContainer extends Component {
           )}
           {shouldDisplayWarning && errorKey === INSUFFICIENT_FUNDS_ERROR_KEY && (
             <div className="confirm-approve-content__warning">
-              {currentTransaction.chainId === MAINNET_CHAIN_ID ? (
-                <ActionableMessage
-                  message={
-                    <Typography variant={TYPOGRAPHY.H7} align="left">
-                      {t('insufficientCurrencyBuyOrDeposit', [
-                        nativeCurrency,
-                        networkName,
-                        <Button
-                          type="link"
-                          className="page-container__link"
-                          onClick={showBuyModal}
-                        >
-                          {t('buy')}
-                          {nativeCurrency}
-                          {t('or')}
-                        </Button>,
-                      ])}
-                      {/* <Button
-                        type="link"
+              <ActionableMessage
+                message={
+                  <Typography variant={TYPOGRAPHY.H7} align="left">
+                    {t('insufficientCurrencyBuyOrDeposit', [
+                      nativeCurrency,
+                      networkName,
+                      <Button
+                        key="buy-button"
+                        type="inline"
                         className="page-container__link"
                         onClick={showBuyModal}
                       >
-                        {t('buyEth')}
-                      </Button>
-
-                      {t('orDeposit')} */}
-                    </Typography>
-                  }
-                  useIcon
-                  iconFillColor="#d73a49"
-                  type="danger"
-                />
-              ) : (
-                <ActionableMessage
-                  message={
-                    <Typography
-                      variant={TYPOGRAPHY.H7}
-                      align="left"
-                      margin={[0, 0]}
-                    >
-                      {t('insufficientCurrency', [nativeCurrency, networkName])}{' '}
-                      {t('buyOther', [nativeCurrency])}
-                    </Typography>
-                  }
-                  useIcon
-                  iconFillColor="#d73a49"
-                  type="danger"
-                />
-              )}
+                        {t('buy')}
+                        {`${nativeCurrency} `}
+                        {t('or')}
+                      </Button>,
+                    ])}
+                  </Typography>
+                }
+                useIcon
+                iconFillColor="#d73a49"
+                type="danger"
+              />
             </div>
           )}
           {shouldDisplayWarning && errorKey !== INSUFFICIENT_FUNDS_ERROR_KEY && (

--- a/ui/components/app/confirm-page-container/confirm-page-container.component.js
+++ b/ui/components/app/confirm-page-container/confirm-page-container.component.js
@@ -95,6 +95,7 @@ export default class ConfirmPageContainer extends Component {
     supportsEIP1559V2: PropTypes.bool,
     nativeCurrency: PropTypes.string,
     showBuyModal: PropTypes.func,
+    isBuyableChain: PropTypes.bool,
   };
 
   render() {
@@ -149,6 +150,7 @@ export default class ConfirmPageContainer extends Component {
       supportsEIP1559V2,
       nativeCurrency,
       showBuyModal,
+      isBuyableChain,
     } = this.props;
 
     const showAddToAddressDialog =
@@ -255,28 +257,36 @@ export default class ConfirmPageContainer extends Component {
               showBuyModal={showBuyModal}
               toAddress={toAddress}
               transactionType={currentTransaction.type}
+              isBuyableChain={isBuyableChain}
             />
           )}
           {shouldDisplayWarning && errorKey === INSUFFICIENT_FUNDS_ERROR_KEY && (
             <div className="confirm-approve-content__warning">
               <ActionableMessage
                 message={
-                  <Typography variant={TYPOGRAPHY.H7} align="left">
-                    {t('insufficientCurrencyBuyOrDeposit', [
-                      nativeCurrency,
-                      networkName,
-                      <Button
-                        key="buy-button"
-                        type="inline"
-                        className="page-container__link"
-                        onClick={showBuyModal}
-                      >
-                        {t('buy')}
-                        {`${nativeCurrency} `}
-                        {t('or')}
-                      </Button>,
-                    ])}
-                  </Typography>
+                  isBuyableChain ? (
+                    <Typography variant={TYPOGRAPHY.H7} align="left">
+                      {t('insufficientCurrencyBuyOrDeposit', [
+                        nativeCurrency,
+                        networkName,
+                        <Button
+                          type="inline"
+                          className="confirm-page-container-content__link"
+                          onClick={showBuyModal}
+                          key={`${nativeCurrency}-buy-button`}
+                        >
+                          {t('buyAsset', [nativeCurrency])}
+                        </Button>,
+                      ])}
+                    </Typography>
+                  ) : (
+                    <Typography variant={TYPOGRAPHY.H7} align="left">
+                      {t('insufficientCurrencyDeposit', [
+                        nativeCurrency,
+                        networkName,
+                      ])}
+                    </Typography>
+                  )
                 }
                 useIcon
                 iconFillColor="#d73a49"

--- a/ui/components/app/confirm-page-container/confirm-page-container.component.js
+++ b/ui/components/app/confirm-page-container/confirm-page-container.component.js
@@ -290,7 +290,7 @@ export default class ConfirmPageContainer extends Component {
                       align="left"
                       margin={[0, 0]}
                     >
-                      {t('insufficientCurrency', [nativeCurrency, networkName])}
+                      {t('insufficientCurrency', [nativeCurrency, networkName])}{' '}
                       {t('buyOther', [nativeCurrency])}
                     </Typography>
                   }

--- a/ui/components/app/confirm-page-container/confirm-page-container.component.js
+++ b/ui/components/app/confirm-page-container/confirm-page-container.component.js
@@ -266,8 +266,20 @@ export default class ConfirmPageContainer extends Component {
                 <ActionableMessage
                   message={
                     <Typography variant={TYPOGRAPHY.H7} align="left">
-                      {t('insufficientCurrency', [nativeCurrency, networkName])}
-                      <Button
+                      {t('insufficientCurrencyBuyOrDeposit', [
+                        nativeCurrency,
+                        networkName,
+                        <Button
+                          type="link"
+                          className="page-container__link"
+                          onClick={showBuyModal}
+                        >
+                          {t('buy')}
+                          {nativeCurrency}
+                          {t('or')}
+                        </Button>,
+                      ])}
+                      {/* <Button
                         type="link"
                         className="page-container__link"
                         onClick={showBuyModal}
@@ -275,7 +287,7 @@ export default class ConfirmPageContainer extends Component {
                         {t('buyEth')}
                       </Button>
 
-                      {t('orDeposit')}
+                      {t('orDeposit')} */}
                     </Typography>
                   }
                   useIcon

--- a/ui/components/app/confirm-page-container/confirm-page-container.component.js
+++ b/ui/components/app/confirm-page-container/confirm-page-container.component.js
@@ -289,7 +289,7 @@ export default class ConfirmPageContainer extends Component {
                   )
                 }
                 useIcon
-                iconFillColor="#d73a49"
+                iconFillColor="var(--color-error-default)"
                 type="danger"
               />
             </div>

--- a/ui/components/app/confirm-page-container/confirm-page-container.container.js
+++ b/ui/components/app/confirm-page-container/confirm-page-container.container.js
@@ -1,13 +1,18 @@
 import { connect } from 'react-redux';
-import { getAccountsWithLabels, getAddressBookEntry } from '../../../selectors';
+import {
+  getAccountsWithLabels,
+  getAddressBookEntry,
+  getIsBuyableChain,
+} from '../../../selectors';
 import { showModal } from '../../../store/actions';
 import ConfirmPageContainer from './confirm-page-container.component';
 
 function mapStateToProps(state, ownProps) {
   const to = ownProps.toAddress;
-
+  const isBuyableChain = getIsBuyableChain(state);
   const contact = getAddressBookEntry(state, to);
   return {
+    isBuyableChain,
     contact,
     toName: contact?.name || ownProps.toName,
     isOwnedAccount: getAccountsWithLabels(state)

--- a/ui/components/ui/button/buttons.scss
+++ b/ui/components/ui/button/buttons.scss
@@ -302,7 +302,7 @@ input[type="submit"][disabled] {
 
 .btn--inline {
   display: inline;
-  padding: 0 4px;
+  padding: 0;
   font-size: inherit;
   width: auto;
   color: var(--color-primary-default);

--- a/ui/pages/confirm-transaction-base/confirm-transaction-base.component.js
+++ b/ui/pages/confirm-transaction-base/confirm-transaction-base.component.js
@@ -146,6 +146,7 @@ export default class ConfirmTransactionBase extends Component {
     isMultiLayerFeeNetwork: PropTypes.bool,
     eip1559V2Enabled: PropTypes.bool,
     showBuyModal: PropTypes.func,
+    isBuyableChain: PropTypes.bool,
   };
 
   state = {
@@ -326,6 +327,7 @@ export default class ConfirmTransactionBase extends Component {
       isMultiLayerFeeNetwork,
       nativeCurrency,
       showBuyModal,
+      isBuyableChain,
     } = this.props;
     const { t } = this.context;
     const { userAcknowledgedGasMissing } = this.state;
@@ -585,11 +587,11 @@ export default class ConfirmTransactionBase extends Component {
             this.setUserAcknowledgedGasMissing()
           }
           userAcknowledgedGasMissing={userAcknowledgedGasMissing}
-          chainId={txData.chainId}
           nativeCurrency={nativeCurrency}
           networkName={networkName}
           showBuyModal={showBuyModal}
           type={txData.type}
+          isBuyableChain={isBuyableChain}
         />
         <TransactionDetail
           disabled={isDisabled()}

--- a/ui/pages/confirm-transaction-base/confirm-transaction-base.container.js
+++ b/ui/pages/confirm-transaction-base/confirm-transaction-base.container.js
@@ -33,6 +33,7 @@ import {
   getTokenList,
   getIsMultiLayerFeeNetwork,
   getEIP1559V2Enabled,
+  getIsBuyableChain,
 } from '../../selectors';
 import { getMostRecentOverviewPage } from '../../ducks/history/history';
 import {
@@ -76,7 +77,7 @@ const mapStateToProps = (state, ownProps) => {
 
   const isGasEstimatesLoading = getIsGasEstimatesLoading(state);
   const gasLoadingAnimationIsShowing = getGasLoadingAnimationIsShowing(state);
-
+  const isBuyableChain = getIsBuyableChain(state);
   const { confirmTransaction, metamask } = state;
   const {
     ensResolutionsByAddress,
@@ -253,6 +254,7 @@ const mapStateToProps = (state, ownProps) => {
     isMultiLayerFeeNetwork,
     chainId,
     eip1559V2Enabled,
+    isBuyableChain,
   };
 };
 

--- a/ui/pages/confirm-transaction-base/transaction-alerts/transaction-alerts.js
+++ b/ui/pages/confirm-transaction-base/transaction-alerts/transaction-alerts.js
@@ -124,7 +124,7 @@ const TransactionAlerts = ({
             )
           }
           useIcon
-          iconFillColor="#d73a49"
+          iconFillColor="var(--color-error-default)"
           type="danger"
         />
       ) : null}

--- a/ui/pages/confirm-transaction-base/transaction-alerts/transaction-alerts.js
+++ b/ui/pages/confirm-transaction-base/transaction-alerts/transaction-alerts.js
@@ -12,7 +12,7 @@ import Button from '../../../components/ui/button';
 import Typography from '../../../components/ui/typography';
 import { TYPOGRAPHY } from '../../../helpers/constants/design-system';
 import { TRANSACTION_TYPES } from '../../../../shared/constants/transaction';
-import { MAINNET_CHAIN_ID } from '../../../../shared/constants/network';
+import { BUYABLE_CHAINS_MAP } from '../../../../shared/constants/network';
 
 const TransactionAlerts = ({
   userAcknowledgedGasMissing,
@@ -96,51 +96,30 @@ const TransactionAlerts = ({
           type="warning"
         />
       )}
-      {balanceError &&
-      chainId === MAINNET_CHAIN_ID &&
-      type === TRANSACTION_TYPES.DEPLOY_CONTRACT ? (
+      {balanceError && type === TRANSACTION_TYPES.DEPLOY_CONTRACT ? (
         <ActionableMessage
           className="actionable-message--warning"
           message={
             <Typography variant={TYPOGRAPHY.H7} align="left">
-                      {t('insufficientCurrencyBuyOrDeposit', [
-                        nativeCurrency,
-                        networkName,
-                        <Button
-                          type="link"
-                          className="page-container__link"
-                          onClick={showBuyModal}
-                        >
-                          {t('buy')}
-                          {nativeCurrency}
-                          {t('or')}
-                        </Button>,
-                      ])}
-                      {/* <Button
-                        type="link"
-                        className="page-container__link"
-                        onClick={showBuyModal}
-                      >
-                        {t('buyEth')}
-                      </Button>
-
-                      {t('orDeposit')} */}
-                    </Typography>
-          }
-          useIcon
-          iconFillColor="#d73a49"
-          type="danger"
-        />
-      ) : null}
-      {balanceError &&
-      chainId !== MAINNET_CHAIN_ID &&
-      type === TRANSACTION_TYPES.DEPLOY_CONTRACT ? (
-        <ActionableMessage
-          className="actionable-message--warning"
-          message={
-            <Typography variant={TYPOGRAPHY.H7} align="left">
-              {t('insufficientCurrency', [nativeCurrency, networkName])}{' '}
-              {t('buyOther', [nativeCurrency])}
+              {t('insufficientCurrencyBuyOrDeposit', [
+                nativeCurrency,
+                networkName,
+                Object.keys(BUYABLE_CHAINS_MAP).includes(chainId) ? (
+                  <>
+                    <Button
+                      type="inline"
+                      className="transaction-alerts__link"
+                      onClick={showBuyModal}
+                    >
+                      {t('buy')}
+                      {` ${nativeCurrency} `}
+                    </Button>
+                    {t('or')}
+                  </>
+                ) : (
+                  ''
+                ),
+              ])}
             </Typography>
           }
           useIcon

--- a/ui/pages/confirm-transaction-base/transaction-alerts/transaction-alerts.js
+++ b/ui/pages/confirm-transaction-base/transaction-alerts/transaction-alerts.js
@@ -12,12 +12,11 @@ import Button from '../../../components/ui/button';
 import Typography from '../../../components/ui/typography';
 import { TYPOGRAPHY } from '../../../helpers/constants/design-system';
 import { TRANSACTION_TYPES } from '../../../../shared/constants/transaction';
-import { BUYABLE_CHAINS_MAP } from '../../../../shared/constants/network';
 
 const TransactionAlerts = ({
   userAcknowledgedGasMissing,
   setUserAcknowledgedGasMissing,
-  chainId,
+  isBuyableChain,
   nativeCurrency,
   networkName,
   showBuyModal,
@@ -100,27 +99,29 @@ const TransactionAlerts = ({
         <ActionableMessage
           className="actionable-message--warning"
           message={
-            <Typography variant={TYPOGRAPHY.H7} align="left">
-              {t('insufficientCurrencyBuyOrDeposit', [
-                nativeCurrency,
-                networkName,
-                Object.keys(BUYABLE_CHAINS_MAP).includes(chainId) ? (
-                  <>
-                    <Button
-                      type="inline"
-                      className="transaction-alerts__link"
-                      onClick={showBuyModal}
-                    >
-                      {t('buy')}
-                      {` ${nativeCurrency} `}
-                    </Button>
-                    {t('or')}
-                  </>
-                ) : (
-                  ''
-                ),
-              ])}
-            </Typography>
+            isBuyableChain ? (
+              <Typography variant={TYPOGRAPHY.H7} align="left">
+                {t('insufficientCurrencyBuyOrDeposit', [
+                  nativeCurrency,
+                  networkName,
+                  <Button
+                    type="inline"
+                    className="confirm-page-container-content__link"
+                    onClick={showBuyModal}
+                    key={`${nativeCurrency}-buy-button`}
+                  >
+                    {t('buyAsset', [nativeCurrency])}
+                  </Button>,
+                ])}
+              </Typography>
+            ) : (
+              <Typography variant={TYPOGRAPHY.H7} align="left">
+                {t('insufficientCurrencyDeposit', [
+                  nativeCurrency,
+                  networkName,
+                ])}
+              </Typography>
+            )
           }
           useIcon
           iconFillColor="#d73a49"
@@ -169,11 +170,11 @@ const TransactionAlerts = ({
 TransactionAlerts.propTypes = {
   userAcknowledgedGasMissing: PropTypes.bool,
   setUserAcknowledgedGasMissing: PropTypes.func,
-  chainId: PropTypes.string,
   nativeCurrency: PropTypes.string,
   networkName: PropTypes.string,
   showBuyModal: PropTypes.func,
   type: PropTypes.string,
+  isBuyableChain: PropTypes.bool,
 };
 
 export default TransactionAlerts;

--- a/ui/pages/confirm-transaction-base/transaction-alerts/transaction-alerts.js
+++ b/ui/pages/confirm-transaction-base/transaction-alerts/transaction-alerts.js
@@ -103,16 +103,29 @@ const TransactionAlerts = ({
           className="actionable-message--warning"
           message={
             <Typography variant={TYPOGRAPHY.H7} align="left">
-              {t('insufficientCurrency', [nativeCurrency, networkName])}{' '}
-              <Button
-                type="link"
-                className="transaction-alerts__link"
-                onClick={showBuyModal}
-              >
-                {t('buyEth')}
-              </Button>{' '}
-              {t('orDeposit')}
-            </Typography>
+                      {t('insufficientCurrencyBuyOrDeposit', [
+                        nativeCurrency,
+                        networkName,
+                        <Button
+                          type="link"
+                          className="page-container__link"
+                          onClick={showBuyModal}
+                        >
+                          {t('buy')}
+                          {nativeCurrency}
+                          {t('or')}
+                        </Button>,
+                      ])}
+                      {/* <Button
+                        type="link"
+                        className="page-container__link"
+                        onClick={showBuyModal}
+                      >
+                        {t('buyEth')}
+                      </Button>
+
+                      {t('orDeposit')} */}
+                    </Typography>
           }
           useIcon
           iconFillColor="#d73a49"

--- a/ui/pages/confirm-transaction-base/transaction-alerts/transaction-alerts.js
+++ b/ui/pages/confirm-transaction-base/transaction-alerts/transaction-alerts.js
@@ -126,7 +126,7 @@ const TransactionAlerts = ({
           className="actionable-message--warning"
           message={
             <Typography variant={TYPOGRAPHY.H7} align="left">
-              {t('insufficientCurrency', [nativeCurrency, networkName])}
+              {t('insufficientCurrency', [nativeCurrency, networkName])}{' '}
               {t('buyOther', [nativeCurrency])}
             </Typography>
           }


### PR DESCRIPTION
Just noticed we need a space here:
![Screen Shot 2022-03-17 at 12 01 05 PM](https://user-images.githubusercontent.com/34557516/158856024-67bf5e8e-db8a-4023-a5e1-d3a6ce0340e3.png)

After these changes:
![Screen Shot 2022-03-17 at 12 10 42 PM](https://user-images.githubusercontent.com/34557516/158856130-737bf218-eeed-4365-b259-e3c4e9dc04e3.png)

After some further comments/discussion this PR grew to include the addition of the inline button/link 'Buy <nativeCurrent>' that pops the buy modal for **all chains on which we support a fiat onramp**. For instance on `polygon`:
![159537034-6506cfe6-1f56-4315-ba1e-4bd97c2da593](https://user-images.githubusercontent.com/34557516/159990885-f7722170-f448-4ef4-a4bf-383302d4c384.png)

