### PR TITLE
Fix missing insufficient funds error for token sends

### DIFF
--- a/ui/components/app/confirm-page-container/confirm-page-container-content/confirm-page-container-content.component.js
+++ b/ui/components/app/confirm-page-container/confirm-page-container-content/confirm-page-container-content.component.js
@@ -146,8 +146,7 @@ export default class ConfirmPageContainerContent extends Component {
       supportsEIP1559V2 &&
       !hasSimulationError &&
       (errorKey || errorMessage) &&
-      errorKey === INSUFFICIENT_FUNDS_ERROR_KEY &&
-      currentTransaction.type === TRANSACTION_TYPES.SIMPLE_SEND;
+      errorKey === INSUFFICIENT_FUNDS_ERROR_KEY;
 
     return (
       <div


### PR DESCRIPTION
Fixes this issue https://docs.google.com/document/d/1OvpkZbvRet33XQVplIc32zlm-6PgSasJcj1XFv9kh9s/edit?disco=AAAAV_JqXcw on 10.11.2 release QA doc.