### PR TITLE
Dark Mode: Implement 3-Dot Menu Hover

### DIFF
--- a/ui/components/ui/menu/menu.scss
+++ b/ui/components/ui/menu/menu.scss
@@ -10,7 +10,6 @@
     display: flex;
     flex-direction: column;
     align-items: center;
-    padding: 0 16px;
     z-index: 1050;
   }
 
@@ -32,9 +31,14 @@
   text-align: start;
   align-items: center;
   width: 100%;
-  padding: 14px 0;
+  padding: 14px 16px;
   cursor: pointer;
   color: inherit;
+
+  &:hover,
+  &:active {
+    background: var(--color-background-alternative);
+  }
 
   &__icon {
     margin-right: 8px;


### PR DESCRIPTION
Right now there's no menu hover effect which isn't great; this hover is an improvement:
<img width="543" alt="hovers" src="https://user-images.githubusercontent.com/46655/158881192-fced17af-c2f3-4c5f-85bd-85ec89ef3123.png">

