### PR TITLE
Removing iconClassName prop from NetworkDisplay

### DIFF
--- a/ui/components/app/network-display/network-display.js
+++ b/ui/components/app/network-display/network-display.js
@@ -22,7 +22,6 @@ import { isNetworkLoading } from '../../../selectors';
 export default function NetworkDisplay({
   colored,
   outline,
-  iconClassName,
   indicatorSize,
   disabled,
   labelProps,
@@ -61,14 +60,7 @@ export default function NetworkDisplay({
           />
         </LoadingIndicator>
       }
-      rightIcon={
-        iconClassName && (
-          <IconCaretDown
-            size={16}
-            className={classnames('network-display__icon', iconClassName)}
-          />
-        )
-      }
+      rightIcon={<IconCaretDown size={16} className="network-display__icon" />}
       label={
         networkType === NETWORK_TYPE_RPC
           ? networkNickname ?? t('privateNetwork')
@@ -100,7 +92,6 @@ NetworkDisplay.propTypes = {
   }),
   outline: PropTypes.bool,
   disabled: PropTypes.bool,
-  iconClassName: PropTypes.string,
   onClick: PropTypes.func,
 };
 

--- a/ui/components/app/network-display/network-display.stories.js
+++ b/ui/components/app/network-display/network-display.stories.js
@@ -23,15 +23,9 @@ export default {
     disabled: {
       control: 'boolean',
     },
-    iconClassName: {
-      control: 'text',
-    },
     onClick: {
       action: 'onClick',
     },
-  },
-  args: {
-    iconClassName: 'caret',
   },
 };
 


### PR DESCRIPTION
Fixes a regression found during the QA of `10.12.0`

As of https://github.com/MetaMask/metamask-extension/commit/55abc00c34edba31b3c194c0b9f887be0b11aeac#diff-60d49ffad9bfd44e4410e29edbe11cf01ec90c0db8997ab49744330afa69986fL127 - the `iconClassName` prop was no longer in use in the `NetworkDisplay` component. 

It's absence was causing the down caret icon to not render in the network dropdown

<img width="430" alt="Screen Shot 2022-03-17 at 8 55 33 PM" src="https://user-images.githubusercontent.com/8732757/158935486-043c420f-54b5-4779-a996-2d7657d5f880.png">
