### PR TITLE
Ensure state updates after accepting or rejecting a watched asset

### DIFF
--- a/ui/store/actions.js
+++ b/ui/store/actions.js
@@ -1566,6 +1566,7 @@ export function rejectWatchAsset(suggestedAssetID) {
     dispatch(showLoadingIndication());
     try {
       await promisifiedBackground.rejectWatchAsset(suggestedAssetID);
+      await forceUpdateMetamaskState(dispatch);
     } catch (error) {
       log.error(error);
       dispatch(displayWarning(error.message));
@@ -1582,6 +1583,7 @@ export function acceptWatchAsset(suggestedAssetID) {
     dispatch(showLoadingIndication());
     try {
       await promisifiedBackground.acceptWatchAsset(suggestedAssetID);
+      await forceUpdateMetamaskState(dispatch);
     } catch (error) {
       log.error(error);
       dispatch(displayWarning(error.message));


### PR DESCRIPTION
fixes this issue found in QA:

Issues with dismissing the add suggested token confirmation window, see attached [add token](https://drive.google.com/file/d/1VisY4yq7VpwtGnXjUCHoMRmWKkQ5_me-/view?usp=sharing) & [cancel token](https://drive.google.com/file/d/1xuBAYbNc_Dk25FUjy2i47loWifCVX550/view?usp=sharing)

This PR corrects this by ensuring state is updated immediate after calls to accept or reject watch asset are resolved. This ensures that any routing based on asset state will respond to the updated state after these calls