### PR TITLE
Set Chrome logger to level 3: Log_Fatal

### DIFF
--- a/test/e2e/webdriver/chrome.js
+++ b/test/e2e/webdriver/chrome.js
@@ -18,6 +18,7 @@ class ChromeDriver {
     if (responsive) {
       args.push('--auto-open-devtools-for-tabs');
     }
+    args.push('--log-level=3');
     const options = new chrome.Options().addArguments(args);
     options.setProxy(proxy.manual({ https: HTTPS_PROXY_HOST }));
     options.setAcceptInsecureCerts(true);


### PR DESCRIPTION
## Why
- E2e tests on Chrome display a huge amount of unnecessary info on the console, which makes it hard to follow testcase steps on the console.

## Approach
- Setting `--log-level `to the minimum log level (3). Valid values are from 0 to 3: `INFO = 0`, `WARNING = 1`, `LOG_ERROR = 2`, `LOG_FATAL = 3`

## Screenshots
Here you can compare the logs without level 3 (logging everything by default) and with level 3 enabled.
### Before: Sample Testcase run with default Logging
![image](https://user-images.githubusercontent.com/54408225/159032889-306347cf-d8b4-40df-a1cf-89b8df3f9c8f.png)
![image](https://user-images.githubusercontent.com/54408225/159032945-c758b86b-a48b-49ab-88c5-1739c6725dab.png)
![image](https://user-images.githubusercontent.com/54408225/159032988-f5e24091-b713-4725-b6d1-b663fdfb1d81.png)

### Sample Testcase run with Level 3 Logging
![image](https://user-images.githubusercontent.com/54408225/159032612-b765bd4b-1c41-4304-b911-57ee5f09e69c.png)
