### PR TITLE
Fix flaky test: add account

### DIFF
--- a/test/e2e/tests/add-account.spec.js
+++ b/test/e2e/tests/add-account.spec.js
@@ -78,6 +78,7 @@ describe('Add account', function () {
 
         const detailsModal = await driver.findVisibleElement('span .modal');
         // get the public address for the "second account"
+        await driver.waitForSelector('.qr-code__address');
         const secondAccountAddress = await driver.findElement(
           '.qr-code__address',
         );
@@ -103,6 +104,7 @@ describe('Add account', function () {
         const secondDetailsModal = await driver.findVisibleElement(
           'span .modal',
         );
+        await driver.waitForSelector('.qr-code__address');
         const thirdAccountAddress = await driver.findElement(
           '.qr-code__address',
         );
@@ -158,6 +160,7 @@ describe('Add account', function () {
           'span .modal',
         );
         // get the public address for the "second account"
+        await driver.waitForSelector('.qr-code__address');
         const recreatedSecondAccountAddress = await driver.findElement(
           '.qr-code__address',
         );
@@ -184,6 +187,7 @@ describe('Add account', function () {
         );
 
         // get the public address for the "third account"
+        await driver.waitForSelector('.qr-code__address');
         const recreatedThirdAccountAddress = await driver.findElement(
           '.qr-code__address',
         );


### PR DESCRIPTION
## Problem
- Add Account is a flaky test, that sometimes fails on our circleCI and local runs

## Solution
- Included `waitForSelectors` before grabbing the Account addresses, for avoiding intermitent failures, as we ensure that the element is there, before accessing to its value.

## Screenshots/Screencaps
![image](https://user-images.githubusercontent.com/54408225/159038872-a126032e-fe9e-43fb-b93d-9020a441b9d7.png)

