### PR TITLE
Fix token icon when going from token detail to swaps

### DIFF
--- a/ui/components/app/wallet-overview/token-overview.js
+++ b/ui/components/app/wallet-overview/token-overview.js
@@ -125,6 +125,7 @@ const TokenOverview = ({ className, token }) => {
                 dispatch(
                   setSwapsFromToken({
                     ...token,
+                    address: token.address.toLowerCase(),
                     iconUrl: token.image,
                     balance,
                     string: balanceToRender,


### PR DESCRIPTION
I brought up to @dan437 that I had noticed that clicking "Swap" from a token screen *does* show the correct "From" token name but not the correct icon.  I suspected the issue was a token address mismatch and I was right.

## Steps to reproduce
1.  Add a token beside ETH to your MetaMask
2. On the main screen, click into the the token's list item
3. Click the "Swap" icon
4. See the correct icon in the dropdown

At present, I don't believe this is the optimal solution, but it's a starting point.

https://user-images.githubusercontent.com/46655/159097450-1b0d4909-79c1-4368-8d8e-93c2dcfc579a.mp4


