### PR TITLE
Dark Mode : Permission flow

### DIFF
--- a/ui/components/app/permissions-connect-footer/index.scss
+++ b/ui/components/app/permissions-connect-footer/index.scss
@@ -7,7 +7,7 @@
   &__text {
     @include H7;
 
-    color: var(--ui-4);
+    color: var(--color-text-alternative);
     display: flex;
     margin-top: 10px;
 

--- a/ui/components/ui/icon-border/icon-border.scss
+++ b/ui/components/ui/icon-border/icon-border.scss
@@ -1,7 +1,7 @@
 .icon-border {
   border-radius: 50%;
-  border: 1px solid var(--ui-1);
-  background: var(--ui-1);
+  border: 1px solid var(--color-background-alternative);
+  background: var(--color-background-alternative);
   display: flex;
   justify-content: center;
   align-items: center;

--- a/ui/pages/permissions-connect/redirect/index.scss
+++ b/ui/pages/permissions-connect/redirect/index.scss
@@ -31,7 +31,7 @@
   &__check {
     width: 40px;
     height: 40px;
-    background: white url("/images/permissions-check.svg") no-repeat;
+    background: var(--color-background-default) url("/images/permissions-check.svg") no-repeat;
     position: absolute;
   }
 }

--- a/ui/pages/permissions-connect/redirect/index.scss
+++ b/ui/pages/permissions-connect/redirect/index.scss
@@ -29,9 +29,14 @@
   }
 
   &__check {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 50%;
     width: 40px;
     height: 40px;
-    background: var(--color-background-default) url("/images/permissions-check.svg") no-repeat;
+    color: var(--color-success-inverse);
+    background-color: var(--color-success-default);
     position: absolute;
   }
 }

--- a/ui/pages/permissions-connect/redirect/permission-redirect.stories.js
+++ b/ui/pages/permissions-connect/redirect/permission-redirect.stories.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import PermissionsRedirect from './permissions-redirect.component';
+
+export default {
+  title: 'Pages/PermissionsRedirect',
+  id: __filename,
+};
+
+export const PermissionRedirectComponent = () => {
+  return (
+    <PermissionsRedirect
+      subjectMetadata={{
+        extensionId: '1',
+        iconUrl: '/images/logo/metamask-fox.svg',
+        subjectType: 'subjectType',
+        name: 'test',
+        origin: 'test',
+      }}
+    />
+  );
+};

--- a/ui/pages/permissions-connect/redirect/permissions-redirect.component.js
+++ b/ui/pages/permissions-connect/redirect/permissions-redirect.component.js
@@ -17,7 +17,7 @@ export default function PermissionsRedirect({ subjectMetadata }) {
             size={64}
           />
           <div className="permissions-redirect__center-icon">
-            <i className="fa fa-check fa-lg permissions-redirect__check"></i>
+            <i className="fa fa-check fa-lg permissions-redirect__check" />
             {renderBrokenLine()}
           </div>
           <SiteIcon icon="/images/logo/metamask-fox.svg" size={64} />

--- a/ui/pages/permissions-connect/redirect/permissions-redirect.component.js
+++ b/ui/pages/permissions-connect/redirect/permissions-redirect.component.js
@@ -17,7 +17,7 @@ export default function PermissionsRedirect({ subjectMetadata }) {
             size={64}
           />
           <div className="permissions-redirect__center-icon">
-            <span className="permissions-redirect__check" />
+            <i className="fa fa-check fa-lg permissions-redirect__check"></i>
             {renderBrokenLine()}
           </div>
           <SiteIcon icon="/images/logo/metamask-fox.svg" size={64} />


### PR DESCRIPTION
## Explanation

Switch all `--black-100` occurence to use `--color-text-default` and fix some permission flow colors

## More information

* Fixes #13719


## Screenshots/Screencaps

![dark](https://user-images.githubusercontent.com/13910212/159310538-1591c232-46b0-4aaa-ac2b-2fd547f68ff1.png)
![light](https://user-images.githubusercontent.com/13910212/159310542-56e603af-34b1-4a08-b8ad-6ab77894b63d.png)

