### PR TITLE
Dark Mode: Snackbar component

### DIFF
--- a/ui/components/ui/snackbar/index.scss
+++ b/ui/components/ui/snackbar/index.scss
@@ -2,10 +2,10 @@
   @include H7;
 
   padding: 0.75rem 1rem;
-  color: var(--Blue-600);
+  color: var(--color-text-default);
   min-width: 360px;
   width: fit-content;
-  background: var(--Blue-000);
-  border: 1px solid var(--Blue-200);
+  background: var(--color-info-muted);
+  border: 1px solid var(--color-info-default);
   border-radius: 6px;
 }

--- a/ui/css/utilities/colors.scss
+++ b/ui/css/utilities/colors.scss
@@ -1,12 +1,9 @@
 :root {
   // These are the colors of the MetaMask design system
   // Only design system colors should be added, no superfluous variables
-  --Blue-000: #eaf6ff;
-  --Blue-200: #75c4fd;
   --Blue-300: #43aefc;
   --Blue-400: #1098fc;
   --Blue-500: #037dd6;
-  --Blue-600: #0260a4;
   // Greys
   --Grey-000: #f2f3f4;
   --Grey-100: #d6d9dc;


### PR DESCRIPTION
Use in onboarding:
<img width="554" alt="Snackbar" src="https://user-images.githubusercontent.com/46655/159329353-d33ab7be-a9af-4e0c-a4b1-7d3b333a73b2.png">

