### PR TITLE
Fix SrpInput small viewport styles

### DIFF
--- a/ui/components/app/srp-input/srp-input.scss
+++ b/ui/components/app/srp-input/srp-input.scss
@@ -11,7 +11,13 @@
 
   @media (max-width: 767px) {
     &__container {
-      grid-template-areas: "title" "dropdown" "input" "error";
+      grid-template-areas:
+        "title"
+        "dropdown"
+        "paste-tip"
+        "input"
+        "error"
+        "too-many-words-error";
     }
   }
 
@@ -26,7 +32,7 @@
   &__paste-tip {
     margin-bottom: 8px;
     grid-area: paste-tip;
-    width: max-content;
+    width: auto;
     margin-left: auto;
     margin-right: auto;
   }


### PR DESCRIPTION
## Explanation

The styles for smaller viewports were broken because I forgot to update the small-screen grid template after adding the "paste-tip". The styles have now been updated to fit the content properly on all of our supported screen sizes.

## Screenshots/Screencaps

### Before

![before-srp](https://user-images.githubusercontent.com/2459287/159367689-84794b7e-489b-4d5b-a409-c6979d485b66.png)

### After

![srp-before](https://user-images.githubusercontent.com/2459287/159367700-76f58f74-f266-4089-8bb3-64c337087932.png)

## Manual testing steps

Use the `SrpInput` Storybook component and test various screen sizes.

Note that there is a known issue where the columns look too "spread out" on larger screens. I have intentionally ignored that problem because we constrain the maximum width enough on the pages where this component is used that it is never a problem in practice. If anyone has any suggestions on how to fix that, I'd be happy to apply them, but I was considering it as non-blocking.