### PR TITLE
ImportToken does not clear up the page when going back

### DIFF
--- a/ui/pages/confirm-import-token/confirm-import-token.js
+++ b/ui/pages/confirm-import-token/confirm-import-token.js
@@ -113,7 +113,10 @@ const ConfirmImportToken = () => {
             type="secondary"
             large
             className="page-container__footer-button"
-            onClick={() => history.push(IMPORT_TOKEN_ROUTE)}
+            onClick={() => {
+              dispatch(clearPendingTokens());
+              history.push(IMPORT_TOKEN_ROUTE);
+            }}
           >
             {t('back')}
           </Button>


### PR DESCRIPTION
Fixes issue 4 of [QA: Release candidate rolling doc](https://docs.google.com/document/d/1OvpkZbvRet33XQVplIc32zlm-6PgSasJcj1XFv9kh9s/edit)

Issue:
The confirm import token page does not clear up when the user travels back to the import page by clicking the `Back` button.

Steps:
1. Go to Import Token.
2. Search and select an existing token.
3. Click Next.
4. Now click “Back” from confirm import page.
5. Click “Next” again without selecting any token.
6. Click the “Back” button again.
7. Click “Custom Token”
8. Click “Add Custom Token” button with an empty form

Current Behaviour :
- After step 5 I can see the previous “Add token page” with the token I selected before
- After step 8 I can see the previous “Add token page” with the token I selected before

Expected Behaviour :
Once I click “Back” the token I selected is cleared out, so I cannot proceed with an empty form or without selecting any token again


Fix:
The reason for the issue was the `pendingTokens` from the state was not getting cleared when the `Back` button is clicked, when pendingTokens object is cleared the `Next` button on the import token page, and the `Add Custom Token` button in the custom token page will be disabled.