### PR TITLE
Dark Mode: Fix Actionable Message Error Text

### DIFF
--- a/ui/components/ui/actionable-message/index.scss
+++ b/ui/components/ui/actionable-message/index.scss
@@ -119,6 +119,7 @@
 
     .actionable-message__message {
       text-align: left;
+      color: var(--color-error-default);
     }
   }
 


### PR DESCRIPTION
## Before:

<img width="329" alt="error-before" src="https://user-images.githubusercontent.com/46655/159384799-dfe349d1-59a3-4f2f-b1a9-afa1310f0e08.png">


## After:

<img width="390" alt="error-after" src="https://user-images.githubusercontent.com/46655/159384807-27ef245e-735e-4da0-aa22-d379ec3688f9.png">

