### PR TITLE
speedup transaction: save on advance gas modal should not close speed…

### DIFF
--- a/ui/components/app/advanced-gas-fee-popover/advanced-gas-fee-save/advanced-gas-fee-save.js
+++ b/ui/components/app/advanced-gas-fee-popover/advanced-gas-fee-save/advanced-gas-fee-save.js
@@ -11,7 +11,7 @@ import I18nValue from '../../../ui/i18n-value';
 import { useAdvancedGasFeePopoverContext } from '../context';
 
 const AdvancedGasFeeSaveButton = () => {
-  const { closeAllModals } = useTransactionModalContext();
+  const { closeModal } = useTransactionModalContext();
   const { updateTransactionEventFragment } = useTransactionEventFragment();
   const { updateTransaction } = useGasFeeContext();
   const {
@@ -33,7 +33,8 @@ const AdvancedGasFeeSaveButton = () => {
         gas_edit_type: 'advanced',
       },
     });
-    closeAllModals();
+    closeModal('editGasFee');
+    closeModal('advancedGasFee');
   };
 
   return (

--- a/ui/components/app/advanced-gas-fee-popover/advanced-gas-fee-save/advanced-gas-fee-save.js
+++ b/ui/components/app/advanced-gas-fee-popover/advanced-gas-fee-save/advanced-gas-fee-save.js
@@ -33,8 +33,7 @@ const AdvancedGasFeeSaveButton = () => {
         gas_edit_type: 'advanced',
       },
     });
-    closeModal('editGasFee');
-    closeModal('advancedGasFee');
+    closeModal(['advancedGasFee', 'editGasFee']);
   };
 
   return (

--- a/ui/components/app/cancel-speedup-popover/cancel-speedup-popover.js
+++ b/ui/components/app/cancel-speedup-popover/cancel-speedup-popover.js
@@ -84,7 +84,7 @@ const CancelSpeedupPopover = () => {
     } else {
       speedUpTransaction();
     }
-    closeModal('cancelSpeedUpTransaction');
+    closeModal(['cancelSpeedUpTransaction']);
   };
 
   return (

--- a/ui/components/app/edit-gas-fee-popover/edit-gas-item/edit-gas-item.js
+++ b/ui/components/app/edit-gas-fee-popover/edit-gas-item/edit-gas-item.js
@@ -87,7 +87,7 @@ const EditGasItem = ({ priorityLevel }) => {
         },
       });
 
-      closeModal('editGasFee');
+      closeModal(['editGasFee']);
 
       if (priorityLevel === PRIORITY_LEVELS.TEN_PERCENT_INCREASED) {
         updateTransactionToTenPercentIncreasedGasFee();

--- a/ui/contexts/transaction-modal.js
+++ b/ui/contexts/transaction-modal.js
@@ -6,13 +6,15 @@ export const TransactionModalContext = createContext({});
 export const TransactionModalContextProvider = ({ children }) => {
   const [openModals, setOpenModals] = useState([]);
 
-  const closeModal = (modalName) => {
-    const index = openModals.indexOf(modalName);
+  const closeModal = (modalNames) => {
     if (openModals < 0) {
       return;
     }
     const modals = [...openModals];
-    modals.splice(index, 1);
+    modalNames.forEach((modal) => {
+      const index = openModals.indexOf(modal);
+      modals.splice(index, 1);
+    });
     setOpenModals(modals);
   };
 


### PR DESCRIPTION
Fixes: #14068

Fix issue with closing advance gas editing modal on speedup gas modal.