### PR TITLE
Fix Settings Header Back Button and update "Add Contacts" position

### DIFF
--- a/ui/components/ui/icon/icon-caret-left.js
+++ b/ui/components/ui/icon/icon-caret-left.js
@@ -6,6 +6,7 @@ const IconCaretLeft = ({
   color = 'currentColor',
   ariaLabel,
   className,
+  onClick,
 }) => (
   <svg
     width={size}
@@ -13,6 +14,7 @@ const IconCaretLeft = ({
     fill={color}
     className={className}
     aria-label={ariaLabel}
+    onClick={onClick}
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"
   >
@@ -33,6 +35,10 @@ IconCaretLeft.propTypes = {
    * An additional className to assign the Icon
    */
   className: PropTypes.string,
+  /**
+   * The onClick handler
+   */
+  onClick: PropTypes.func,
   /**
    * The aria-label of the icon for accessibility purposes
    */

--- a/ui/pages/settings/contact-list-tab/index.scss
+++ b/ui/pages/settings/contact-list-tab/index.scss
@@ -227,12 +227,12 @@
 .address-book-add-button {
   &__button {
     position: absolute;
-    top: 85px;
+    top: 80px;
     right: 16px;
     width: auto;
 
     @media screen and (max-width: $break-small) {
-      top: 16px;
+      top: 8px;
       right: 60px;
 
       &--hidden {

--- a/ui/pages/settings/index.scss
+++ b/ui/pages/settings/index.scss
@@ -193,13 +193,6 @@
 
     @media screen and (max-width: $break-small) {
       display: block;
-      background-image: url('/images/caret-left-black.svg');
-      width: 18px;
-      height: 18px;
-      opacity: 0.5;
-      background-size: contain;
-      background-repeat: no-repeat;
-      background-position: center;
       margin-right: 16px;
       cursor: pointer;
 

--- a/ui/pages/settings/index.scss
+++ b/ui/pages/settings/index.scss
@@ -193,10 +193,11 @@
 
     @media screen and (max-width: $break-small) {
       display: block;
-      margin-right: 16px;
+      margin-right: 8px;
       cursor: pointer;
 
       [dir='rtl'] & {
+        margin: 0 0 0 8px;
         transform: rotate(180deg);
       }
     }

--- a/ui/pages/settings/settings.component.js
+++ b/ui/pages/settings/settings.component.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { Switch, Route, matchPath } from 'react-router-dom';
 import classnames from 'classnames';
 import TabBar from '../../components/app/tab-bar';
+import IconCaretLeft from '../../components/ui/icon/icon-caret-left';
 
 import {
   ALERTS_ROUTE,
@@ -113,13 +114,16 @@ class SettingsPage extends PureComponent {
         })}
       >
         <div className="settings-page__header">
-          {currentPath !== SETTINGS_ROUTE && (
-            <div
-              className="settings-page__back-button"
-              onClick={() => history.push(backRoute)}
-            />
-          )}
           <div className="settings-page__header__title-container">
+            {currentPath !== SETTINGS_ROUTE && (
+              <IconCaretLeft
+                className="settings-page__back-button"
+                color="var(--color-icon-default)"
+                size={32}
+                onClick={() => history.push(backRoute)}
+              />
+            )}
+
             {this.renderTitle()}
 
             <div


### PR DESCRIPTION
## Explanation

2 things related to the Settings Header:
1. Add missed caret 🥕 following `IconCaretLeft` addition related to Dark Mode. 
- Updated `IconCaretLeft` to use `onClick`
- Related to https://github.com/MetaMask/metamask-extension/pull/13861
2. Update "Add Contacts" button position on Settings > Contacts page

## More information

Fixes: V10.12.0
QA: Release Candidate Rolling Doc:  https://docs.google.com/document/d/1OvpkZbvRet33XQVplIc32zlm-6PgSasJcj1XFv9kh9s/edit#
Slack thread: https://consensys.slack.com/archives/GTQAGKY5V/p1647884761174739?thread_ts=1647856853.318179&cid=GTQAGKY5V

### Before
<img width="360" alt="Screenshot 2022-03-21 at 10 51 04 PM" src="https://user-images.githubusercontent.com/20778143/159391356-4bce9689-3a58-4446-82d3-67e454d735c1.png">
<img width="743" alt="Screenshot 2022-03-21 at 10 52 34 PM" src="https://user-images.githubusercontent.com/20778143/159391509-c1ff1058-ac09-4f76-9c54-af644b5baca9.png">


### After
(Search bar should have a white background here. This is
<img width="451" alt="Screenshot 2022-03-21 at 10 30 32 PM" src="https://user-images.githubusercontent.com/20778143/159390394-e3671f9d-bef8-470c-902d-80d92e2006aa.png">
<img width="741" alt="Screenshot 2022-03-21 at 10 31 40 PM" src="https://user-images.githubusercontent.com/20778143/159390398-58425388-2051-4f1a-aee2-4adbd9757223.png">


## Manual testing steps

<!--
How should reviewers and QA manually test your changes? For instance:

- Go to this screen
- Do this
- Then do this
-->
