### PR TITLE
DarkMode: TextField: set bg color to default

### DIFF
--- a/ui/components/ui/text-field/text-field.component.js
+++ b/ui/components/ui/text-field/text-field.component.js
@@ -64,6 +64,7 @@ const styles = {
     'label + &': {
       marginTop: '9px',
     },
+    backgroundColor: 'var(--color-background-default)',
     border: '1px solid var(--color-border-default)',
     color: 'var(--color-text-default)',
     height: '48px',


### PR DESCRIPTION
## Explanation

Following Dark Mode changes, the settings search bar background appears transparent instead of white on light mode. Text boxes should have a background color instead of being transparent.

## More information

Fixes V 10.12.0

QA: Release Candidate Rolling Doc:  https://docs.google.com/document/d/1OvpkZbvRet33XQVplIc32zlm-6PgSasJcj1XFv9kh9s/edit#

Slack thread: https://consensys.slack.com/archives/GTQAGKY5V/p1647902689452959?thread_ts=1647856853.318179&cid=GTQAGKY5V

Related to https://github.com/MetaMask/metamask-extension/pull/13821

### Before
<img width="366" alt="Screenshot 2022-03-21 at 11 00 54 PM" src="https://user-images.githubusercontent.com/20778143/159392310-1d35310f-0541-48f0-9478-ea6f58f13d80.png">


### After
<img width="360" alt="Screenshot 2022-03-21 at 10 59 22 PM" src="https://user-images.githubusercontent.com/20778143/159392172-5fdffad6-b644-4495-9707-a67e07cdc963.png">

## Manual testing steps

Go to Setting pages
