### PR TITLE
Error page and story

### DIFF
--- a/ui/pages/error/error.stories.js
+++ b/ui/pages/error/error.stories.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import ErrorPage from '.';
+
+export default {
+  title: 'Pages/Error',
+  id: __filename,
+  argTypes: {
+    error: {
+      control: 'object',
+    },
+  },
+  args: {
+    error: {
+      message: 'message',
+      code: 'code',
+      name: 'name',
+      stack: 'stack',
+    },
+  },
+};
+
+export const DefaultStory = (args) => <ErrorPage {...args} />;
+
+DefaultStory.storyName = 'Default';

--- a/ui/pages/error/index.scss
+++ b/ui/pages/error/index.scss
@@ -4,7 +4,7 @@
   align-items: center;
   font-style: normal;
   font-weight: normal;
-  padding: 35px 10px 10px 10px;
+  padding: 32px 8px 8px 8px;
   height: 100%;
 
   &__header {
@@ -12,14 +12,14 @@
 
     display: flex;
     justify-content: center;
-    padding: 10px 0;
+    padding: 8px 0;
     text-align: center;
   }
 
   &__subheader {
     @include H4;
 
-    padding: 10px 0;
+    padding: 8px 0;
     width: 100%;
     max-width: 720px;
     text-align: center;
@@ -31,15 +31,15 @@
     overflow-y: auto;
     width: 100%;
     max-width: 720px;
-    padding-top: 10px;
+    padding-top: 8px;
   }
 
   &__stack {
     overflow-x: auto;
-    background-color: #eee;
+    background-color: var(--color-background-alternative);
   }
 
   &__link-text {
-    color: #037dd6;
+    color: var(--color-primary-default);
   }
 }


### PR DESCRIPTION
Error page and story for dark mode

Manual testing steps
- Go to the latest storybook build in this PR
- Search Error (Pages/Error) in the search bar

<img width="1440" alt="Screen Shot 2022-03-21 at 9 12 57 PM" src="https://user-images.githubusercontent.com/8112138/159406830-02cd0bfa-b99d-4fc2-9e2c-04488955246f.png">

<img width="1440" alt="Screen Shot 2022-03-21 at 9 13 05 PM" src="https://user-images.githubusercontent.com/8112138/159406857-c98c5f33-b558-4025-a6ab-c257ba1b72d8.png">


