### PR TITLE
On send/edit page, disable app header so that networks can't be changed

### DIFF
--- a/ui/pages/routes/routes.component.js
+++ b/ui/pages/routes/routes.component.js
@@ -242,6 +242,16 @@ export default class Routes extends Component {
     );
   }
 
+  onEditTransactionPage() {
+    const { location } = this.props;
+    return Boolean(
+      matchPath(location.pathname, {
+        path: SEND_ROUTE,
+        exact: false,
+      }),
+    );
+  }
+
   onSwapsPage() {
     const { location } = this.props;
     return Boolean(
@@ -359,6 +369,7 @@ export default class Routes extends Component {
             onClick={this.onAppHeaderClick}
             disabled={
               this.onConfirmPage() ||
+              this.onEditTransactionPage() ||
               (this.onSwapsPage() && !this.onSwapsBuildQuotePage())
             }
           />

--- a/ui/pages/routes/routes.component.js
+++ b/ui/pages/routes/routes.component.js
@@ -69,6 +69,7 @@ import { getEnvironmentType } from '../../../app/scripts/lib/util';
 import ConfirmationPage from '../confirmation';
 import OnboardingFlow from '../onboarding-flow/onboarding-flow';
 import QRHardwarePopover from '../../components/app/qr-hardware-popover';
+import { SEND_STAGES } from '../../ducks/send';
 
 export default class Routes extends Component {
   static propTypes = {
@@ -95,6 +96,7 @@ export default class Routes extends Component {
     browserEnvironmentOs: PropTypes.string,
     browserEnvironmentBrowser: PropTypes.string,
     theme: PropTypes.string,
+    sendStage: PropTypes.string,
   };
 
   static contextTypes = {
@@ -243,13 +245,7 @@ export default class Routes extends Component {
   }
 
   onEditTransactionPage() {
-    const { location } = this.props;
-    return Boolean(
-      matchPath(location.pathname, {
-        path: SEND_ROUTE,
-        exact: false,
-      }),
-    );
+    return this.props.sendStage === SEND_STAGES.EDIT;
   }
 
   onSwapsPage() {

--- a/ui/pages/routes/routes.container.js
+++ b/ui/pages/routes/routes.container.js
@@ -15,6 +15,7 @@ import {
 } from '../../store/actions';
 import { pageChanged } from '../../ducks/history/history';
 import { prepareToLeaveSwaps } from '../../ducks/swaps/swaps';
+import { getSendStage } from '../../ducks/send';
 import Routes from './routes.component';
 
 function mapStateToProps(state) {
@@ -38,6 +39,7 @@ function mapStateToProps(state) {
     providerId: getNetworkIdentifier(state),
     providerType: state.metamask.provider?.type,
     theme: getTheme(state),
+    sendStage: getSendStage(state),
   };
 }
 


### PR DESCRIPTION
## Explanation
Disabled app header in send.edit page, so that users can't change networks when editing a transaction.

Currently, I’m able to change the Network while I’m editing a transaction, leading to a workflow break, not being able to move forward again. [See video](https://drive.google.com/file/d/18yn5bnhxBvOy5IPd-ynLAmf9CZx5THFn/view?usp=sharing)

## Screenshots/Screencaps

### Before
[See video](https://drive.google.com/file/d/18yn5bnhxBvOy5IPd-ynLAmf9CZx5THFn/view?usp=sharing)

### After

https://user-images.githubusercontent.com/44811/159545345-a03ea016-bf90-4c49-9a5d-0a62ed30a2ca.mov

## Manual testing steps

1. Go to Send
2. Introduce an amount of ETH
3. Click on change network
4. Click on Edit Transaction
5. Click on change network
6. Change the network to a different one
7. Click Next
8. Change network back the the original one

Actual:
After “v” and “vi” network is changed
After “Next”, console log error appears “Uncaught (in promise) TypeError: t is undefined”
After “viii” I cannot continue to the next screen, for confirming the Transaction

Expected:
I should not be able to change network in the middle of the “Edit Transaction” screen