### PR TITLE
Dark mode: Removing unused SUCCESS, ERROR and ALERT colors from codebase

### DIFF
--- a/ui/components/ui/box/README.mdx
+++ b/ui/components/ui/box/README.mdx
@@ -109,8 +109,4 @@ PRIMARY1: 'primary-1',
 PRIMARY3: 'primary-3',
 SECONDARY1: 'secondary-1',
 SECONDARY3: 'secondary-3',
-SUCCESS1: 'success-1',
-SUCCESS3: 'success-3',
-ERROR1: 'error-1',
-ALERT1: 'alert-1',
 ```

--- a/ui/components/ui/typography/README.mdx
+++ b/ui/components/ui/typography/README.mdx
@@ -125,10 +125,6 @@ PRIMARY1: 'primary-1',
 PRIMARY3: 'primary-3',
 SECONDARY1: 'secondary-1',
 SECONDARY3: 'secondary-3',
-SUCCESS1: 'success-1',
-SUCCESS3: 'success-3',
-ERROR1: 'error-1',
-ALERT1: 'alert-1',
 ```
 
 ### Font Weight

--- a/ui/components/ui/typography/typography.js
+++ b/ui/components/ui/typography/typography.js
@@ -43,10 +43,6 @@ export const ValidColors = [
   COLORS.PRIMARY3,
   COLORS.SECONDARY1,
   COLORS.SECONDARY3,
-  COLORS.SUCCESS1,
-  COLORS.SUCCESS3,
-  COLORS.ERROR1,
-  COLORS.ALERT1,
 ];
 
 export const ValidTags = [

--- a/ui/helpers/constants/design-system.js
+++ b/ui/helpers/constants/design-system.js
@@ -67,10 +67,6 @@ export const COLORS = {
   PRIMARY3: 'primary-3',
   SECONDARY1: 'secondary-1',
   SECONDARY3: 'secondary-3',
-  SUCCESS1: 'success-1',
-  SUCCESS3: 'success-3',
-  ERROR1: 'error-1',
-  ALERT1: 'alert-1',
 };
 
 export const TYPOGRAPHY = {


### PR DESCRIPTION
## Explanation

Replacing and removing in favor of new color design tokens:
```
SUCCESS1
SUCCESS3
ERROR1
ALERT1
```
