### PR TITLE
Dark mode: Replacing close icon with font awesome version in settings-search.js

### DIFF
--- a/ui/pages/settings/settings-search/settings-search.js
+++ b/ui/pages/settings/settings-search/settings-search.js
@@ -69,12 +69,9 @@ export default function SettingsSearch({
             onClick={() => handleSearch('')}
             style={{ cursor: 'pointer' }}
           >
-            <img
-              className="imageclose"
-              src="images/close-gray.svg"
-              width="17"
-              height="17"
-              alt=""
+            <i
+              className="fa fa-times"
+              style={{ color: 'var(--color-icon-default)' }}
             />
           </InputAdornment>
         )}


### PR DESCRIPTION
## Explanation

Removing svg image in favour of font awesome icon so colors are correct in dark mode

## Screenshots

<img width="1439" alt="Screen Shot 2022-03-22 at 3 33 40 PM" src="https://user-images.githubusercontent.com/8112138/159587597-9beba474-9188-4128-9eae-8cf5a9fc6964.png">
<img width="1439" alt="Screen Shot 2022-03-22 at 3 33 55 PM" src="https://user-images.githubusercontent.com/8112138/159587601-78a6dd64-bc9e-4a6d-8411-340cf7001d0c.png">

