### PR TITLE
Dark mode: Updating currency input icon

### DIFF
--- a/app/images/icons/swap.svg
+++ b/app/images/icons/swap.svg
@@ -1,1 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M16 17.01V10h-2v7.01h-3L15 21l4-3.99h-3zM9 3L5 6.99h3V14h2V6.99h3L9 3z"/><path d="M0 0h24v24H0z" fill="none"/></svg>

--- a/ui/components/app/currency-input/currency-input.js
+++ b/ui/components/app/currency-input/currency-input.js
@@ -160,7 +160,9 @@ export default function CurrencyInput({
       onChange={handleChange}
       value={decimalValue}
       actionComponent={
-        <div className="currency-input__swap-component" onClick={swap} />
+        <button className="currency-input__swap-component" onClick={swap}>
+          <i className="fa fa-retweet fa-lg" />
+        </button>
       }
     >
       {renderConversionComponent()}

--- a/ui/components/app/currency-input/currency-input.stories.js
+++ b/ui/components/app/currency-input/currency-input.stories.js
@@ -1,0 +1,25 @@
+import React from 'react';
+import CurrencyInput from '.';
+
+export default {
+  title: 'Components/App/CurrencyInput',
+  id: __filename,
+  argTypes: {
+    hexValue: {
+      control: 'text',
+    },
+    featureSecondary: {
+      control: 'boolean',
+    },
+    onChange: {
+      action: 'onChange',
+    },
+    onPreferenceToggle: {
+      action: 'onPreferenceToggle',
+    },
+  },
+};
+
+export const DefaultStory = (args) => <CurrencyInput {...args} />;
+
+DefaultStory.storyName = 'Default';

--- a/ui/components/app/currency-input/index.scss
+++ b/ui/components/app/currency-input/index.scss
@@ -7,20 +7,12 @@
 
   &__swap-component {
     flex: 0 0 auto;
-    height: 24px;
-    width: 24px;
-    background-image: url("images/icons/swap.svg");
-    background-size: contain;
-    background-repeat: no-repeat;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--color-icon-default);
     cursor: pointer;
-    opacity: 0.4;
-
-    &:hover {
-      opacity: 0.3;
-    }
-
-    &:active {
-      opacity: 0.5;
-    }
+    background: none;
+    border: none;
   }
 }


### PR DESCRIPTION
## Explanation

Removing svg image in favour of font awesome icon so colors are correct in dark mode

Can check in the latest build of storybook in this PR and searching `CurrencyInput`

## Screenshots

<img width="1440" alt="Screen Shot 2022-03-23 at 10 06 30 AM" src="https://user-images.githubusercontent.com/8112138/159756095-f83d72d6-93d3-4110-868e-905327bac448.png">
<img width="1440" alt="Screen Shot 2022-03-23 at 10 06 36 AM" src="https://user-images.githubusercontent.com/8112138/159756103-11df24ad-ac62-42e0-be96-c71c5592f633.png">
