### PR TITLE
fix instance of browser.extension.getURL()

### DIFF
--- a/app/scripts/platforms/extension.js
+++ b/app/scripts/platforms/extension.js
@@ -256,7 +256,7 @@ export default class ExtensionPlatform {
     browser.notifications.create(url, {
       type: 'basic',
       title,
-      iconUrl: browser.extension.getURL('../../images/icon-64.png'),
+      iconUrl: browser.runtime.getURL('../../images/icon-64.png'),
       message,
     });
   }


### PR DESCRIPTION
`browser.extension.getURL()` is deprecated and should be replaced with `browser.runtime.getURL()`: https://developer.chrome.com/docs/extensions/reference/extension/#method-getURL

Currently this is causing an error
<img width="1102" alt="Screen Shot 2022-03-23 at 4 43 50 PM" src="https://user-images.githubusercontent.com/34557516/159801559-183cd1ba-b089-4446-9afb-3eb5ccdb4b89.png">
: