### PR TITLE
Dark Mode: Remove Malibu

### DIFF
--- a/ui/css/design-system/deprecated-colors.scss
+++ b/ui/css/design-system/deprecated-colors.scss
@@ -5,7 +5,6 @@
 
 // These are declared as variables and hoisted because they are
 // used as rgba's and native rgba doesn't accept var()
-$malibu-blue: #7ac9fd;
 $alto: #dedede;
 $black: #000;
 $white: #fff;

--- a/ui/pages/import-token/token-list/index.scss
+++ b/ui/pages/import-token/token-list/index.scss
@@ -25,11 +25,11 @@
 
     &:hover,
     &:focus {
-      border-color: rgba($malibu-blue, 0.5);
+      border-color: var(--color-primary-muted);
     }
 
     &--selected {
-      border-color: var(--malibu-blue) !important;
+      border-color: var(--color-primary-default) !important;
     }
 
     &--disabled {
@@ -45,7 +45,7 @@
     background-size: contain;
     background-position: center;
     border-radius: 50%;
-    background-color: var(--white);
+    background-color: var(--color-background-default);
     box-shadow: 0 2px 4px 0 rgba($black, 0.24);
     margin-right: 12px;
     flex: 0 0 auto;


### PR DESCRIPTION
Removes the `malibu` colors and replaces with new, existing colors.
<img width="449" alt="bu" src="https://user-images.githubusercontent.com/46655/159829706-62f5383f-c448-4ceb-a43b-deb1f698bb4e.png">

