### PR TITLE
Build user traits object when metamask state changes

### DIFF
--- a/app/scripts/controllers/metametrics.test.js
+++ b/app/scripts/controllers/metametrics.test.js
@@ -8,12 +8,12 @@ import {
   TRAITS,
 } from '../../../shared/constants/metametrics';
 import waitUntilCalled from '../../../test/lib/wait-until-called';
-import MetaMetricsController from './metametrics';
-import { NETWORK_EVENTS } from './network';
 import {
   MAINNET_CHAIN_ID,
   ROPSTEN_CHAIN_ID,
 } from '../../../shared/constants/network';
+import MetaMetricsController from './metametrics';
+import { NETWORK_EVENTS } from './network';
 
 const segment = createSegmentMock(2, 10000);
 
@@ -524,7 +524,7 @@ describe('MetaMetricsController', function () {
   });
 
   describe('_buildUserTraitsObject', function () {
-    it('should return full user traits object on first call', () => {
+    it('should return full user traits object on first call', function () {
       const metaMetricsController = getMetaMetricsController();
       const traits = metaMetricsController._buildUserTraitsObject({
         frequentRpcListDetail: [
@@ -544,7 +544,7 @@ describe('MetaMetricsController', function () {
       });
     });
 
-    it('should return only changed traits object on subsequent calls', () => {
+    it('should return only changed traits object on subsequent calls', function () {
       const metaMetricsController = getMetaMetricsController();
       metaMetricsController._buildUserTraitsObject({
         frequentRpcListDetail: [
@@ -571,7 +571,7 @@ describe('MetaMetricsController', function () {
       });
     });
 
-    it('should return null if no traits changed', () => {
+    it('should return null if no traits changed', function () {
       const metaMetricsController = getMetaMetricsController();
       metaMetricsController._buildUserTraitsObject({
         frequentRpcListDetail: [

--- a/app/scripts/controllers/metametrics.test.js
+++ b/app/scripts/controllers/metametrics.test.js
@@ -5,10 +5,15 @@ import { createSegmentMock } from '../lib/segment';
 import {
   METAMETRICS_ANONYMOUS_ID,
   METAMETRICS_BACKGROUND_PAGE_OBJECT,
+  TRAITS,
 } from '../../../shared/constants/metametrics';
 import waitUntilCalled from '../../../test/lib/wait-until-called';
 import MetaMetricsController from './metametrics';
 import { NETWORK_EVENTS } from './network';
+import {
+  MAINNET_CHAIN_ID,
+  ROPSTEN_CHAIN_ID,
+} from '../../../shared/constants/network';
 
 const segment = createSegmentMock(2, 10000);
 
@@ -515,6 +520,80 @@ describe('MetaMetricsController', function () {
         { isOptInPath: true },
       );
       mock.verify();
+    });
+  });
+
+  describe('_buildUserTraitsObject', function () {
+    it('should return full user traits object on first call', () => {
+      const metaMetricsController = getMetaMetricsController();
+      const traits = metaMetricsController._buildUserTraitsObject({
+        frequentRpcListDetail: [
+          { chainId: MAINNET_CHAIN_ID },
+          { chainId: ROPSTEN_CHAIN_ID },
+        ],
+        ledgerTransportType: 'web-hid',
+        identities: [{}, {}],
+        threeBoxSyncingAllowed: false,
+      });
+
+      assert.deepEqual(traits, {
+        [TRAITS.THREE_BOX_ENABLED]: false,
+        [TRAITS.LEDGER_CONNECTION_TYPE]: 'web-hid',
+        [TRAITS.NUMBER_OF_ACCOUNTS]: 2,
+        [TRAITS.NETWORKS_ADDED]: [MAINNET_CHAIN_ID, ROPSTEN_CHAIN_ID],
+      });
+    });
+
+    it('should return only changed traits object on subsequent calls', () => {
+      const metaMetricsController = getMetaMetricsController();
+      metaMetricsController._buildUserTraitsObject({
+        frequentRpcListDetail: [
+          { chainId: MAINNET_CHAIN_ID },
+          { chainId: ROPSTEN_CHAIN_ID },
+        ],
+        ledgerTransportType: 'web-hid',
+        identities: [{}, {}],
+        threeBoxSyncingAllowed: false,
+      });
+
+      const updatedTraits = metaMetricsController._buildUserTraitsObject({
+        frequentRpcListDetail: [
+          { chainId: MAINNET_CHAIN_ID },
+          { chainId: ROPSTEN_CHAIN_ID },
+        ],
+        ledgerTransportType: 'web-hid',
+        identities: [{}, {}, {}],
+        threeBoxSyncingAllowed: false,
+      });
+
+      assert.deepEqual(updatedTraits, {
+        [TRAITS.NUMBER_OF_ACCOUNTS]: 3,
+      });
+    });
+
+    it('should return null if no traits changed', () => {
+      const metaMetricsController = getMetaMetricsController();
+      metaMetricsController._buildUserTraitsObject({
+        frequentRpcListDetail: [
+          { chainId: MAINNET_CHAIN_ID },
+          { chainId: ROPSTEN_CHAIN_ID },
+        ],
+        ledgerTransportType: 'web-hid',
+        identities: [{}, {}],
+        threeBoxSyncingAllowed: false,
+      });
+
+      const updatedTraits = metaMetricsController._buildUserTraitsObject({
+        frequentRpcListDetail: [
+          { chainId: MAINNET_CHAIN_ID },
+          { chainId: ROPSTEN_CHAIN_ID },
+        ],
+        ledgerTransportType: 'web-hid',
+        identities: [{}, {}],
+        threeBoxSyncingAllowed: false,
+      });
+
+      assert.equal(updatedTraits, null);
     });
   });
 

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -322,6 +322,10 @@ export default class MetamaskController extends EventEmitter {
       captureException,
     });
 
+    this.on('update', (update) => {
+      this.metaMetricsController.handleMetaMaskStateUpdate(update);
+    });
+
     const gasFeeMessenger = this.controllerMessenger.getRestricted({
       name: 'GasFeeController',
     });


### PR DESCRIPTION
## Explanation

* Adds a listener to MetaMask state tree changes and calls into the MetaMetrics controller. Originally I had intended this to be only the preferences controller but @danjm suggested all of MetaMask state. I agreed, but said for MVP just preferences store. However, three box state is stored on three box controller. This necessitated changing the strategy. Instead of hooking into preferences store we let the MetaMask controller tell the metametrics controller that state changed.
* This method handles caching the previous user traits, and compares them to the new one so that we only call .identify with new traits

## More information
* Fixes #14048, #13532, #13559, #13557, #13534, #13531, #13533

### Remaining items:
- [x] Tests