### PR TITLE
Fix color in v2 gas fee modal

### DIFF
--- a/ui/components/app/edit-gas-fee-popover/edit-gas-item/index.scss
+++ b/ui/components/app/edit-gas-fee-popover/edit-gas-item/index.scss
@@ -83,6 +83,6 @@
 
   &__time-estimate-medium,
   &__time-estimate-high {
-    color: var(--color-success-muted);
+    color: var(--color-success-default);
   }
 }


### PR DESCRIPTION
Fixes https://github.com/MetaMask/metamask-extension/issues/14223

Before:
![green-gas-fees-now](https://user-images.githubusercontent.com/54408225/160384225-9e5394f0-7129-4203-b7b0-13cc18cd0f97.png)

After:
![Screenshot from 2022-03-28 09-48-06](https://user-images.githubusercontent.com/7499938/160396471-d2bccd71-e642-4367-97c1-f5dc7d99ff22.png)

