### PR TITLE
Ensure only letters, numbers and spaces can be entered in settings search input

### DIFF
--- a/ui/pages/settings/settings-search/settings-search.js
+++ b/ui/pages/settings/settings-search/settings-search.js
@@ -31,24 +31,26 @@ export default function SettingsSearch({
   });
 
   // eslint-disable-next-line no-shadow
-  const handleSearch = (searchQuery) => {
-    setSearchQuery(searchQuery);
-    if (searchQuery === '') {
+  const handleSearch = (_searchQuery) => {
+    const sanitizedSearchQuery = _searchQuery.replace(/[^A-z0-9\s]|[\\]/gu, '');
+    setSearchQuery(sanitizedSearchQuery);
+    if (sanitizedSearchQuery === '') {
       setSearchIconColor('var(--color-icon-muted)');
     } else {
       setSearchIconColor('var(--color-icon-default)');
     }
-    const fuseSearchResult = settingsSearchFuse.search(searchQuery);
+
+    const fuseSearchResult = settingsSearchFuse.search(sanitizedSearchQuery);
     const addressSearchResult = settingsRoutesListArray.filter((routes) => {
       return (
         routes.tab &&
-        searchQuery &&
-        isEqualCaseInsensitive(routes.tab, searchQuery)
+        sanitizedSearchQuery &&
+        isEqualCaseInsensitive(routes.tab, sanitizedSearchQuery)
       );
     });
 
     const results = [...addressSearchResult, ...fuseSearchResult];
-    onSearch({ searchQuery, results });
+    onSearch({ searchQuery: sanitizedSearchQuery, results });
   };
 
   const renderStartAdornment = () => {


### PR DESCRIPTION
Fixes https://github.com/MetaMask/metamask-extension/issues/14221

The fix simply ensures that only alphanumeric characters and spaces can be entered in the search input