### PR TITLE
Fix imported component name and change size proptype type to string

### DIFF
--- a/ui/components/ui/icon/icon-token-search.js
+++ b/ui/components/ui/icon/icon-token-search.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const IconTokenSearch = ({
-  size = 24,
+  size = '24',
   color = 'currentColor',
   ariaLabel,
   className,
@@ -24,7 +24,7 @@ IconTokenSearch.propTypes = {
   /**
    * The size of the Icon follows an 8px grid 2 = 16px, 3 = 24px etc
    */
-  size: PropTypes.number,
+  size: PropTypes.string,
   /**
    * The color of the icon accepts design token css variables
    */

--- a/ui/components/ui/icon/icon-token-search.js
+++ b/ui/components/ui/icon/icon-token-search.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const IconTokenSearch = ({
-  size = '24',
+  size = 24,
   color = 'currentColor',
   ariaLabel,
   className,
@@ -24,7 +24,7 @@ IconTokenSearch.propTypes = {
   /**
    * The size of the Icon follows an 8px grid 2 = 16px, 3 = 24px etc
    */
-  size: PropTypes.string,
+  size: PropTypes.number,
   /**
    * The color of the icon accepts design token css variables
    */

--- a/ui/pages/import-token/token-list/token-list-placeholder/token-list-placeholder.component.js
+++ b/ui/pages/import-token/token-list/token-list-placeholder/token-list-placeholder.component.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import Button from '../../../../components/ui/button';
-import IconSearch from '../../../../components/ui/icon/icon-token-search';
+import IconTokenSearch from '../../../../components/ui/icon/icon-token-search';
 
 export default class TokenListPlaceholder extends Component {
   static contextTypes = {
@@ -11,7 +11,7 @@ export default class TokenListPlaceholder extends Component {
   render() {
     return (
       <div className="token-list-placeholder">
-        <IconSearch size="64" color="var(--color-icon-muted)" />
+        <IconTokenSearch size="64" color="var(--color-icon-muted)" />
         <div className="token-list-placeholder__text">
           {this.context.t('addAcquiredTokens')}
         </div>

--- a/ui/pages/import-token/token-list/token-list-placeholder/token-list-placeholder.component.js
+++ b/ui/pages/import-token/token-list/token-list-placeholder/token-list-placeholder.component.js
@@ -11,7 +11,7 @@ export default class TokenListPlaceholder extends Component {
   render() {
     return (
       <div className="token-list-placeholder">
-        <IconTokenSearch size="64" color="var(--color-icon-muted)" />
+        <IconTokenSearch size={64} color="var(--color-icon-muted)" />
         <div className="token-list-placeholder__text">
           {this.context.t('addAcquiredTokens')}
         </div>


### PR DESCRIPTION
## Explanation

Fixes imported component name to align with its exported name, and fixes size proptype warning by changing from number to string.

<!--
Thanks for the pull request. Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Below is a template to give you some ideas. Feel free to use your own words!

Currently, ...

This is a problem because ...

In order to solve this problem, this pull request ...
-->

## More information

Follow up PR for https://github.com/MetaMask/metamask-extension/pull/14213

<!--
Are there any issues, Slack conversations, Zendesk issues, user stories, etc. reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

## Screenshots/Screencaps
<img width="813" alt="Screen Shot 2022-03-28 at 4 06 30 PM" src="https://user-images.githubusercontent.com/13376180/160487328-6e98f844-4c92-4ed1-b8f4-0d5910cb176d.png">


<!-- If you're making a change to the UI, make sure to capture a screenshot or a short video showing off your work! -->
