### PR TITLE
metaMetricsEvent -> trackEvent

### DIFF
--- a/ui/ducks/swaps/swaps.js
+++ b/ui/ducks/swaps/swaps.js
@@ -595,7 +595,7 @@ export const fetchQuotesAndSetQuoteState = (
   history,
   inputValue,
   maxSlippage,
-  metaMetricsEvent,
+  trackEvent,
   pageRedirectionDisabled,
 ) => {
   return async (dispatch, getState) => {
@@ -711,7 +711,7 @@ export const fetchQuotesAndSetQuoteState = (
     const currentSmartTransactionsEnabled = getCurrentSmartTransactionsEnabled(
       state,
     );
-    metaMetricsEvent({
+    trackEvent({
       event: 'Quotes Requested',
       category: 'swaps',
       sensitiveProperties: {
@@ -765,7 +765,7 @@ export const fetchQuotesAndSetQuoteState = (
       ]);
 
       if (Object.values(fetchedQuotes)?.length === 0) {
-        metaMetricsEvent({
+        trackEvent({
           event: 'No Quotes Available',
           category: 'swaps',
           sensitiveProperties: {
@@ -786,7 +786,7 @@ export const fetchQuotesAndSetQuoteState = (
       } else {
         const newSelectedQuote = fetchedQuotes[selectedAggId];
 
-        metaMetricsEvent({
+        trackEvent({
           event: 'Quotes Received',
           category: 'swaps',
           sensitiveProperties: {
@@ -832,7 +832,7 @@ export const fetchQuotesAndSetQuoteState = (
 
 export const signAndSendSwapsSmartTransaction = ({
   unsignedTransaction,
-  metaMetricsEvent,
+  trackEvent,
   history,
   additionalTrackingParams,
 }) => {
@@ -888,7 +888,7 @@ export const signAndSendSwapsSmartTransaction = ({
       stx_user_opt_in: smartTransactionsOptInStatus,
       ...additionalTrackingParams,
     };
-    metaMetricsEvent({
+    trackEvent({
       event: 'STX Swap Started',
       category: 'swaps',
       sensitiveProperties: swapMetaData,
@@ -984,7 +984,7 @@ export const signAndSendSwapsSmartTransaction = ({
 
 export const signAndSendTransactions = (
   history,
-  metaMetricsEvent,
+  trackEvent,
   additionalTrackingParams,
 ) => {
   return async (dispatch, getState) => {
@@ -1138,7 +1138,7 @@ export const signAndSendTransactions = (
       swapMetaData.base_and_priority_fee_per_gas = baseAndPriorityFeePerGas;
     }
 
-    metaMetricsEvent({
+    trackEvent({
       event: 'Swap Started',
       category: 'swaps',
       sensitiveProperties: swapMetaData,

--- a/ui/pages/swaps/loading-swaps-quotes/loading-swaps-quotes.js
+++ b/ui/pages/swaps/loading-swaps-quotes/loading-swaps-quotes.js
@@ -29,7 +29,7 @@ export default function LoadingSwapsQuotes({
   onDone,
 }) {
   const t = useContext(I18nContext);
-  const metaMetricsEvent = useContext(MetaMetricsContext);
+  const trackEvent = useContext(MetaMetricsContext);
   const dispatch = useDispatch();
   const history = useHistory();
   const animationEventEmitter = useRef(new EventEmitter());
@@ -158,7 +158,7 @@ export default function LoadingSwapsQuotes({
       <SwapsFooter
         submitText={t('back')}
         onSubmit={async () => {
-          metaMetricsEvent(quotesRequestCancelledEventConfig);
+          trackEvent(quotesRequestCancelledEventConfig);
           await dispatch(navigateBackToBuildQuote(history));
         }}
         hideCancel


### PR DESCRIPTION
## Explanation

Smart Transactions are not working because of this: `TypeError: metaMetricsEvent is not a function`. It was introduced in this PR: https://github.com/MetaMask/metamask-extension/pull/13955/files#diff-c4b49d1f16536bcba5526f6c86db0ec4c4fdaaf1867df467305c9dae71dc99f5R1039

This PR fixes it.