### PR TITLE
Add token standard to Token Added event.

### DIFF
--- a/ui/pages/confirm-add-suggested-token/confirm-add-suggested-token.js
+++ b/ui/pages/confirm-add-suggested-token/confirm-add-suggested-token.js
@@ -13,6 +13,7 @@ import ZENDESK_URLS from '../../helpers/constants/zendesk-url';
 import { isEqualCaseInsensitive } from '../../../shared/modules/string-utils';
 import { getSuggestedAssets } from '../../selectors';
 import { rejectWatchAsset, acceptWatchAsset } from '../../store/actions';
+import { TOKEN_STANDARDS } from '../../helpers/constants/common';
 
 function getTokenName(name, symbol) {
   return name === undefined ? symbol : `${name} (${symbol})`;
@@ -120,6 +121,7 @@ const ConfirmAddSuggestedToken = () => {
             token_decimal_precision: asset.decimals,
             unlisted: asset.unlisted,
             source: 'dapp',
+            token_standard: TOKEN_STANDARDS.ERC20,
           },
         });
       }),

--- a/ui/pages/confirm-import-token/confirm-import-token.js
+++ b/ui/pages/confirm-import-token/confirm-import-token.js
@@ -13,6 +13,7 @@ import { MetaMetricsContext as NewMetaMetricsContext } from '../../contexts/meta
 import { getMostRecentOverviewPage } from '../../ducks/history/history';
 import { getPendingTokens } from '../../ducks/metamask/metamask';
 import { addTokens, clearPendingTokens } from '../../store/actions';
+import { TOKEN_STANDARDS } from '../../helpers/constants/common';
 
 const getTokenName = (name, symbol) => {
   return name === undefined ? symbol : `${name} (${symbol})`;
@@ -43,6 +44,7 @@ const ConfirmImportToken = () => {
           token_decimal_precision: pendingToken.decimals,
           unlisted: pendingToken.unlisted,
           source: pendingToken.isCustom ? 'custom' : 'list',
+          token_standard: TOKEN_STANDARDS.ERC20,
         },
       });
     });


### PR DESCRIPTION
## Explanation

Modify existing token added events to record the token_standard using TOKEN_STANDARDS from 'ui/helpers/constants/common'

## More information

Fixes #13477
