### PR TITLE
Add e2e testcase for Settings Search functionality

### DIFF
--- a/test/e2e/tests/settings-search.spec.js
+++ b/test/e2e/tests/settings-search.spec.js
@@ -21,7 +21,6 @@ describe('Settings Search', function () {
     experimental: 'Token Detection',
     about: 'Terms of Use',
   };
-  let found;
 
   it('should find element inside the General tab', async function () {
     await withFixtures(
@@ -255,7 +254,7 @@ describe('Settings Search', function () {
         await driver.clickElement({ text: 'Settings', tag: 'div' });
         await driver.fill('#search-settings', 'Lorem ipsum');
 
-        found = await driver.isElementPresent({
+        const found = await driver.isElementPresent({
           text: 'No matching results found',
           tag: 'span',
         });

--- a/test/e2e/tests/settings-search.spec.js
+++ b/test/e2e/tests/settings-search.spec.js
@@ -65,11 +65,6 @@ describe('Settings Search', function () {
         await driver.clickElement({ text: 'Settings', tag: 'div' });
         await driver.fill('#search-settings', settings.general.target);
 
-        // Check if element was found
-        found = await driver.isElementPresent({ text: 'General', tag: 'span' });
-        assert.equal(found, true, 'Element was not found');
-
-        // Check if element redirects to the correct page
         await driver.clickElement({ text: 'General', tag: 'span' });
         url = await driver.getUrl();
         assert.equal(
@@ -96,13 +91,6 @@ describe('Settings Search', function () {
         await driver.clickElement('.account-menu__icon');
         await driver.clickElement({ text: 'Settings', tag: 'div' });
         await driver.fill('#search-settings', settings.advanced.target);
-
-        // Check if element was found
-        found = await driver.isElementPresent({
-          text: 'Advanced',
-          tag: 'span',
-        });
-        assert.equal(found, true, 'Element was not found');
 
         // Check if element redirects to the correct page
         await driver.clickElement({ text: 'Advanced', tag: 'span' });
@@ -132,13 +120,6 @@ describe('Settings Search', function () {
         await driver.clickElement({ text: 'Settings', tag: 'div' });
         await driver.fill('#search-settings', settings.contacts.target);
 
-        // Check if element was found
-        found = await driver.isElementPresent({
-          text: 'Contacts',
-          tag: 'span',
-        });
-        assert.equal(found, true, 'Element was not found');
-
         // Check if element redirects to the correct page
         await driver.clickElement({ text: 'Contacts', tag: 'span' });
         url = await driver.getUrl();
@@ -166,13 +147,6 @@ describe('Settings Search', function () {
         await driver.clickElement('.account-menu__icon');
         await driver.clickElement({ text: 'Settings', tag: 'div' });
         await driver.fill('#search-settings', settings.security.target);
-
-        // Check if element was found
-        found = await driver.isElementPresent({
-          text: 'Security',
-          tag: 'span',
-        });
-        assert.equal(found, true, 'Element was not found');
 
         // Check if element redirects to the correct page
         await driver.clickElement({ text: 'Security', tag: 'span' });
@@ -202,10 +176,6 @@ describe('Settings Search', function () {
         await driver.clickElement({ text: 'Settings', tag: 'div' });
         await driver.fill('#search-settings', settings.alerts.target);
 
-        // Check if element was found
-        found = await driver.isElementPresent({ text: 'Alerts', tag: 'span' });
-        assert.equal(found, true, 'Element was not found');
-
         // Check if element redirects to the correct page
         await driver.clickElement({ text: 'Alerts', tag: 'span' });
         url = await driver.getUrl();
@@ -233,13 +203,6 @@ describe('Settings Search', function () {
         await driver.clickElement('.account-menu__icon');
         await driver.clickElement({ text: 'Settings', tag: 'div' });
         await driver.fill('#search-settings', settings.networks.target);
-
-        // Check if element was found
-        found = await driver.isElementPresent({
-          text: 'Networks',
-          tag: 'span',
-        });
-        assert.equal(found, true, 'Element was not found');
 
         // Check if element redirects to the correct page
         await driver.clickElement({ text: 'Networks', tag: 'span' });
@@ -269,13 +232,6 @@ describe('Settings Search', function () {
         await driver.clickElement({ text: 'Settings', tag: 'div' });
         await driver.fill('#search-settings', settings.experimental.target);
 
-        // Check if element was found
-        found = await driver.isElementPresent({
-          text: 'Experimental',
-          tag: 'span',
-        });
-        assert.equal(found, true, 'Element was not found');
-
         // Check if element redirects to the correct page
         await driver.clickElement({ text: 'Experimental', tag: 'span' });
         url = await driver.getUrl();
@@ -303,10 +259,6 @@ describe('Settings Search', function () {
         await driver.clickElement('.account-menu__icon');
         await driver.clickElement({ text: 'Settings', tag: 'div' });
         await driver.fill('#search-settings', settings.about.target);
-
-        // Check if element was found
-        found = await driver.isElementPresent({ text: 'About', tag: 'span' });
-        assert.equal(found, true, 'Element was not found');
 
         // Check if element redirects to the correct page
         await driver.clickElement({ text: 'About', tag: 'span' });

--- a/test/e2e/tests/settings-search.spec.js
+++ b/test/e2e/tests/settings-search.spec.js
@@ -46,7 +46,6 @@ describe('Settings Search', function () {
     },
   };
   let found;
-  let url;
 
   it('should find element inside the General tab', async function () {
     await withFixtures(
@@ -66,9 +65,8 @@ describe('Settings Search', function () {
         await driver.fill('#search-settings', settings.general.target);
 
         await driver.clickElement({ text: 'General', tag: 'span' });
-        url = await driver.getUrl();
         assert.equal(
-          url.includes(settings.general.urlSubstring),
+          await driver.isElementPresent({ text: 'General', tag: 'div' }),
           true,
           'Item does not redirect to correct page',
         );
@@ -94,9 +92,8 @@ describe('Settings Search', function () {
 
         // Check if element redirects to the correct page
         await driver.clickElement({ text: 'Advanced', tag: 'span' });
-        url = await driver.getUrl();
         assert.equal(
-          url.includes(settings.advanced.urlSubstring),
+          await driver.isElementPresent({ text: 'Advanced', tag: 'div' }),
           true,
           'Item does not redirect to correct page',
         );
@@ -122,9 +119,8 @@ describe('Settings Search', function () {
 
         // Check if element redirects to the correct page
         await driver.clickElement({ text: 'Contacts', tag: 'span' });
-        url = await driver.getUrl();
         assert.equal(
-          url.includes(settings.contacts.urlSubstring),
+          await driver.isElementPresent({ text: 'Contacts', tag: 'div' }),
           true,
           'Item does not redirect to correct page',
         );
@@ -150,9 +146,8 @@ describe('Settings Search', function () {
 
         // Check if element redirects to the correct page
         await driver.clickElement({ text: 'Security', tag: 'span' });
-        url = await driver.getUrl();
         assert.equal(
-          url.includes(settings.security.urlSubstring),
+          await driver.isElementPresent({ text: 'Security', tag: 'div' }),
           true,
           'Item does not redirect to correct page',
         );
@@ -178,9 +173,8 @@ describe('Settings Search', function () {
 
         // Check if element redirects to the correct page
         await driver.clickElement({ text: 'Alerts', tag: 'span' });
-        url = await driver.getUrl();
         assert.equal(
-          url.includes(settings.alerts.urlSubstring),
+          await driver.isElementPresent({ text: 'Alerts', tag: 'div' }),
           true,
           'Item does not redirect to correct page',
         );
@@ -206,9 +200,8 @@ describe('Settings Search', function () {
 
         // Check if element redirects to the correct page
         await driver.clickElement({ text: 'Networks', tag: 'span' });
-        url = await driver.getUrl();
         assert.equal(
-          url.includes(settings.networks.urlSubstring),
+          await driver.isElementPresent({ text: 'Networks', tag: 'div' }),
           true,
           'Item does not redirect to correct page',
         );
@@ -234,9 +227,8 @@ describe('Settings Search', function () {
 
         // Check if element redirects to the correct page
         await driver.clickElement({ text: 'Experimental', tag: 'span' });
-        url = await driver.getUrl();
         assert.equal(
-          url.includes(settings.experimental.urlSubstring),
+          await driver.isElementPresent({ text: 'Experimental', tag: 'div' }),
           true,
           'Item does not redirect to correct page',
         );
@@ -262,9 +254,8 @@ describe('Settings Search', function () {
 
         // Check if element redirects to the correct page
         await driver.clickElement({ text: 'About', tag: 'span' });
-        url = await driver.getUrl();
         assert.equal(
-          url.includes(settings.about.urlSubstring),
+          await driver.isElementPresent({ text: 'About', tag: 'div' }),
           true,
           'Item does not redirect to correct page',
         );

--- a/test/e2e/tests/settings-search.spec.js
+++ b/test/e2e/tests/settings-search.spec.js
@@ -1,0 +1,243 @@
+const { strict: assert } = require('assert');
+const { convertToHexValue, withFixtures } = require('../helpers');
+
+describe('Settings Search', function () {
+  const ganacheOptions = {
+    accounts: [
+      {
+        secretKey:
+          '0x7C9529A67102755B7E6102D6D950AC5D5863C98713805CEC576B945B15B71EAC',
+        balance: convertToHexValue(25000000000000000000),
+      },
+    ],
+  };
+  const searchableItems = {
+    general: 'Primary Currency',
+    advanced: 'State Logs',
+    contacts: 'Contacts',
+    security: 'Reveal Secret',
+    alerts: 'Browsing a website',
+    networks: 'Ethereum Mainnet',
+    experimental: 'Token Detection',
+    about: 'Terms of Use',
+  };
+  let found;
+  let notFound;
+
+  it('should find element inside the General tab', async function () {
+    await withFixtures(
+      {
+        dapp: true,
+        fixtures: 'imported-account',
+        ganacheOptions,
+        title: this.test.title,
+      },
+      async ({ driver }) => {
+        await driver.navigate();
+        await driver.fill('#password', 'correct horse battery staple');
+        await driver.press('#password', driver.Key.ENTER);
+
+        await driver.clickElement('.account-menu__icon');
+        await driver.clickElement({ text: 'Settings', tag: 'div' });
+        await driver.fill('#search-settings', searchableItems.general);
+
+        found = await driver.isElementPresent({ text: 'General', tag: 'span' });
+        assert.equal(found, true, 'Element was not found');
+      },
+    );
+  });
+  it('should find element inside the Advanced tab', async function () {
+    await withFixtures(
+      {
+        dapp: true,
+        fixtures: 'imported-account',
+        ganacheOptions,
+        title: this.test.title,
+      },
+      async ({ driver }) => {
+        await driver.navigate();
+        await driver.fill('#password', 'correct horse battery staple');
+        await driver.press('#password', driver.Key.ENTER);
+
+        await driver.clickElement('.account-menu__icon');
+        await driver.clickElement({ text: 'Settings', tag: 'div' });
+        await driver.fill('#search-settings', searchableItems.advanced);
+
+        found = await driver.isElementPresent({
+          text: 'Advanced',
+          tag: 'span',
+        });
+        assert.equal(found, true, 'Element was not found');
+      },
+    );
+  });
+  it('should find element inside the Contacts tab', async function () {
+    await withFixtures(
+      {
+        dapp: true,
+        fixtures: 'imported-account',
+        ganacheOptions,
+        title: this.test.title,
+      },
+      async ({ driver }) => {
+        await driver.navigate();
+        await driver.fill('#password', 'correct horse battery staple');
+        await driver.press('#password', driver.Key.ENTER);
+
+        await driver.clickElement('.account-menu__icon');
+        await driver.clickElement({ text: 'Settings', tag: 'div' });
+        await driver.fill('#search-settings', searchableItems.contacts);
+
+        found = await driver.isElementPresent({
+          text: 'Contacts',
+          tag: 'span',
+        });
+        assert.equal(found, true, 'Element was not found');
+      },
+    );
+  });
+  it('should find element inside the Security tab', async function () {
+    await withFixtures(
+      {
+        dapp: true,
+        fixtures: 'imported-account',
+        ganacheOptions,
+        title: this.test.title,
+      },
+      async ({ driver }) => {
+        await driver.navigate();
+        await driver.fill('#password', 'correct horse battery staple');
+        await driver.press('#password', driver.Key.ENTER);
+
+        await driver.clickElement('.account-menu__icon');
+        await driver.clickElement({ text: 'Settings', tag: 'div' });
+        await driver.fill('#search-settings', searchableItems.security);
+
+        found = await driver.isElementPresent({
+          text: 'Security',
+          tag: 'span',
+        });
+        assert.equal(found, true, 'Element was not found');
+      },
+    );
+  });
+  it('should find element inside the Alerts tab', async function () {
+    await withFixtures(
+      {
+        dapp: true,
+        fixtures: 'imported-account',
+        ganacheOptions,
+        title: this.test.title,
+      },
+      async ({ driver }) => {
+        await driver.navigate();
+        await driver.fill('#password', 'correct horse battery staple');
+        await driver.press('#password', driver.Key.ENTER);
+
+        await driver.clickElement('.account-menu__icon');
+        await driver.clickElement({ text: 'Settings', tag: 'div' });
+        await driver.fill('#search-settings', searchableItems.alerts);
+
+        found = await driver.isElementPresent({ text: 'Alerts', tag: 'span' });
+        assert.equal(found, true, 'Element was not found');
+      },
+    );
+  });
+  it('should find element inside the Networks tab', async function () {
+    await withFixtures(
+      {
+        dapp: true,
+        fixtures: 'imported-account',
+        ganacheOptions,
+        title: this.test.title,
+      },
+      async ({ driver }) => {
+        await driver.navigate();
+        await driver.fill('#password', 'correct horse battery staple');
+        await driver.press('#password', driver.Key.ENTER);
+
+        await driver.clickElement('.account-menu__icon');
+        await driver.clickElement({ text: 'Settings', tag: 'div' });
+        await driver.fill('#search-settings', searchableItems.networks);
+
+        found = await driver.isElementPresent({
+          text: 'Networks',
+          tag: 'span',
+        });
+        assert.equal(found, true, 'Element was not found');
+      },
+    );
+  });
+  it('should find element inside the Experimental tab', async function () {
+    await withFixtures(
+      {
+        dapp: true,
+        fixtures: 'imported-account',
+        ganacheOptions,
+        title: this.test.title,
+      },
+      async ({ driver }) => {
+        await driver.navigate();
+        await driver.fill('#password', 'correct horse battery staple');
+        await driver.press('#password', driver.Key.ENTER);
+
+        await driver.clickElement('.account-menu__icon');
+        await driver.clickElement({ text: 'Settings', tag: 'div' });
+        await driver.fill('#search-settings', searchableItems.experimental);
+
+        found = await driver.isElementPresent({
+          text: 'Experimental',
+          tag: 'span',
+        });
+        assert.equal(found, true, 'Element was not found');
+      },
+    );
+  });
+  it('should find element inside the About tab', async function () {
+    await withFixtures(
+      {
+        dapp: true,
+        fixtures: 'imported-account',
+        ganacheOptions,
+        title: this.test.title,
+      },
+      async ({ driver }) => {
+        await driver.navigate();
+        await driver.fill('#password', 'correct horse battery staple');
+        await driver.press('#password', driver.Key.ENTER);
+
+        await driver.clickElement('.account-menu__icon');
+        await driver.clickElement({ text: 'Settings', tag: 'div' });
+        await driver.fill('#search-settings', searchableItems.about);
+
+        found = await driver.isElementPresent({ text: 'About', tag: 'span' });
+        assert.equal(found, true, 'Element was not found');
+      },
+    );
+  });
+  it('should display "Element not found" for a non-existing element', async function () {
+    await withFixtures(
+      {
+        dapp: true,
+        fixtures: 'imported-account',
+        ganacheOptions,
+        title: this.test.title,
+      },
+      async ({ driver }) => {
+        await driver.navigate();
+        await driver.fill('#password', 'correct horse battery staple');
+        await driver.press('#password', driver.Key.ENTER);
+
+        await driver.clickElement('.account-menu__icon');
+        await driver.clickElement({ text: 'Settings', tag: 'div' });
+        await driver.fill('#search-settings', 'Lorem ipsum');
+
+        notFound = await driver.isElementPresent({
+          text: 'Lorem ipsum',
+          tag: 'span',
+        });
+        assert.equal(notFound, false, 'Non existent element was found');
+      },
+    );
+  });
+});

--- a/test/e2e/tests/settings-search.spec.js
+++ b/test/e2e/tests/settings-search.spec.js
@@ -22,7 +22,6 @@ describe('Settings Search', function () {
     about: 'Terms of Use',
   };
   let found;
-  let notFound;
 
   it('should find element inside the General tab', async function () {
     await withFixtures(
@@ -232,11 +231,11 @@ describe('Settings Search', function () {
         await driver.clickElement({ text: 'Settings', tag: 'div' });
         await driver.fill('#search-settings', 'Lorem ipsum');
 
-        notFound = await driver.isElementPresent({
+        found = await driver.isElementPresent({
           text: 'Lorem ipsum',
           tag: 'span',
         });
-        assert.equal(notFound, false, 'Non existent element was found');
+        assert.equal(found, false, 'Non existent element was found');
       },
     );
   });

--- a/test/e2e/tests/settings-search.spec.js
+++ b/test/e2e/tests/settings-search.spec.js
@@ -11,39 +11,15 @@ describe('Settings Search', function () {
       },
     ],
   };
-  const settings = {
-    general: {
-      urlSubstring: 'general',
-      target: 'Primary Currency',
-    },
-    advanced: {
-      urlSubstring: 'advanced',
-      target: 'State Logs',
-    },
-    contacts: {
-      urlSubstring: 'contact-list',
-      target: 'Contacts',
-    },
-    security: {
-      urlSubstring: 'security',
-      target: 'Reveal Secret',
-    },
-    alerts: {
-      urlSubstring: 'alerts',
-      target: 'Browsing a website',
-    },
-    networks: {
-      urlSubstring: 'networks',
-      target: 'Ethereum Mainnet',
-    },
-    experimental: {
-      urlSubstring: 'experimental',
-      target: 'Token Detection',
-    },
-    about: {
-      urlSubstring: 'about-us',
-      target: 'Terms of Use',
-    },
+  const settingsSearch = {
+    general: 'Primary Currency',
+    advanced: 'State Logs',
+    contacts: 'Contacts',
+    security: 'Reveal Secret',
+    alerts: 'Browsing a website',
+    networks: 'Ethereum Mainnet',
+    experimental: 'Token Detection',
+    about: 'Terms of Use',
   };
   let found;
 
@@ -62,7 +38,7 @@ describe('Settings Search', function () {
 
         await driver.clickElement('.account-menu__icon');
         await driver.clickElement({ text: 'Settings', tag: 'div' });
-        await driver.fill('#search-settings', settings.general.target);
+        await driver.fill('#search-settings', settingsSearch.general);
 
         await driver.clickElement({ text: 'General', tag: 'span' });
         assert.equal(
@@ -88,7 +64,7 @@ describe('Settings Search', function () {
 
         await driver.clickElement('.account-menu__icon');
         await driver.clickElement({ text: 'Settings', tag: 'div' });
-        await driver.fill('#search-settings', settings.advanced.target);
+        await driver.fill('#search-settings', settingsSearch.advanced);
 
         // Check if element redirects to the correct page
         await driver.clickElement({ text: 'Advanced', tag: 'span' });
@@ -115,7 +91,7 @@ describe('Settings Search', function () {
 
         await driver.clickElement('.account-menu__icon');
         await driver.clickElement({ text: 'Settings', tag: 'div' });
-        await driver.fill('#search-settings', settings.contacts.target);
+        await driver.fill('#search-settings', settingsSearch.contacts);
 
         // Check if element redirects to the correct page
         await driver.clickElement({ text: 'Contacts', tag: 'span' });
@@ -142,7 +118,7 @@ describe('Settings Search', function () {
 
         await driver.clickElement('.account-menu__icon');
         await driver.clickElement({ text: 'Settings', tag: 'div' });
-        await driver.fill('#search-settings', settings.security.target);
+        await driver.fill('#search-settings', settingsSearch.security);
 
         // Check if element redirects to the correct page
         await driver.clickElement({ text: 'Security', tag: 'span' });
@@ -169,7 +145,7 @@ describe('Settings Search', function () {
 
         await driver.clickElement('.account-menu__icon');
         await driver.clickElement({ text: 'Settings', tag: 'div' });
-        await driver.fill('#search-settings', settings.alerts.target);
+        await driver.fill('#search-settings', settingsSearch.alerts);
 
         // Check if element redirects to the correct page
         await driver.clickElement({ text: 'Alerts', tag: 'span' });
@@ -196,7 +172,7 @@ describe('Settings Search', function () {
 
         await driver.clickElement('.account-menu__icon');
         await driver.clickElement({ text: 'Settings', tag: 'div' });
-        await driver.fill('#search-settings', settings.networks.target);
+        await driver.fill('#search-settings', settingsSearch.networks);
 
         // Check if element redirects to the correct page
         await driver.clickElement({ text: 'Networks', tag: 'span' });
@@ -223,7 +199,7 @@ describe('Settings Search', function () {
 
         await driver.clickElement('.account-menu__icon');
         await driver.clickElement({ text: 'Settings', tag: 'div' });
-        await driver.fill('#search-settings', settings.experimental.target);
+        await driver.fill('#search-settings', settingsSearch.experimental);
 
         // Check if element redirects to the correct page
         await driver.clickElement({ text: 'Experimental', tag: 'span' });
@@ -250,7 +226,7 @@ describe('Settings Search', function () {
 
         await driver.clickElement('.account-menu__icon');
         await driver.clickElement({ text: 'Settings', tag: 'div' });
-        await driver.fill('#search-settings', settings.about.target);
+        await driver.fill('#search-settings', settingsSearch.about);
 
         // Check if element redirects to the correct page
         await driver.clickElement({ text: 'About', tag: 'span' });

--- a/test/e2e/tests/settings-search.spec.js
+++ b/test/e2e/tests/settings-search.spec.js
@@ -11,17 +11,42 @@ describe('Settings Search', function () {
       },
     ],
   };
-  const searchableItems = {
-    general: 'Primary Currency',
-    advanced: 'State Logs',
-    contacts: 'Contacts',
-    security: 'Reveal Secret',
-    alerts: 'Browsing a website',
-    networks: 'Ethereum Mainnet',
-    experimental: 'Token Detection',
-    about: 'Terms of Use',
+  const settings = {
+    general: {
+      urlSubstring: 'general',
+      target: 'Primary Currency',
+    },
+    advanced: {
+      urlSubstring: 'advanced',
+      target: 'State Logs',
+    },
+    contacts: {
+      urlSubstring: 'contact-list',
+      target: 'Contacts',
+    },
+    security: {
+      urlSubstring: 'security',
+      target: 'Reveal Secret',
+    },
+    alerts: {
+      urlSubstring: 'alerts',
+      target: 'Browsing a website',
+    },
+    networks: {
+      urlSubstring: 'networks',
+      target: 'Ethereum Mainnet',
+    },
+    experimental: {
+      urlSubstring: 'experimental',
+      target: 'Token Detection',
+    },
+    about: {
+      urlSubstring: 'about-us',
+      target: 'Terms of Use',
+    },
   };
   let found;
+  let url;
 
   it('should find element inside the General tab', async function () {
     await withFixtures(
@@ -38,10 +63,20 @@ describe('Settings Search', function () {
 
         await driver.clickElement('.account-menu__icon');
         await driver.clickElement({ text: 'Settings', tag: 'div' });
-        await driver.fill('#search-settings', searchableItems.general);
+        await driver.fill('#search-settings', settings.general.target);
 
+        // Check if element was found
         found = await driver.isElementPresent({ text: 'General', tag: 'span' });
         assert.equal(found, true, 'Element was not found');
+
+        // Check if element redirects to the correct page
+        await driver.clickElement({ text: 'General', tag: 'span' });
+        url = await driver.getUrl();
+        assert.equal(
+          url.includes(settings.general.urlSubstring),
+          true,
+          'Item does not redirect to correct page',
+        );
       },
     );
   });
@@ -60,13 +95,23 @@ describe('Settings Search', function () {
 
         await driver.clickElement('.account-menu__icon');
         await driver.clickElement({ text: 'Settings', tag: 'div' });
-        await driver.fill('#search-settings', searchableItems.advanced);
+        await driver.fill('#search-settings', settings.advanced.target);
 
+        // Check if element was found
         found = await driver.isElementPresent({
           text: 'Advanced',
           tag: 'span',
         });
         assert.equal(found, true, 'Element was not found');
+
+        // Check if element redirects to the correct page
+        await driver.clickElement({ text: 'Advanced', tag: 'span' });
+        url = await driver.getUrl();
+        assert.equal(
+          url.includes(settings.advanced.urlSubstring),
+          true,
+          'Item does not redirect to correct page',
+        );
       },
     );
   });
@@ -85,13 +130,23 @@ describe('Settings Search', function () {
 
         await driver.clickElement('.account-menu__icon');
         await driver.clickElement({ text: 'Settings', tag: 'div' });
-        await driver.fill('#search-settings', searchableItems.contacts);
+        await driver.fill('#search-settings', settings.contacts.target);
 
+        // Check if element was found
         found = await driver.isElementPresent({
           text: 'Contacts',
           tag: 'span',
         });
         assert.equal(found, true, 'Element was not found');
+
+        // Check if element redirects to the correct page
+        await driver.clickElement({ text: 'Contacts', tag: 'span' });
+        url = await driver.getUrl();
+        assert.equal(
+          url.includes(settings.contacts.urlSubstring),
+          true,
+          'Item does not redirect to correct page',
+        );
       },
     );
   });
@@ -110,13 +165,23 @@ describe('Settings Search', function () {
 
         await driver.clickElement('.account-menu__icon');
         await driver.clickElement({ text: 'Settings', tag: 'div' });
-        await driver.fill('#search-settings', searchableItems.security);
+        await driver.fill('#search-settings', settings.security.target);
 
+        // Check if element was found
         found = await driver.isElementPresent({
           text: 'Security',
           tag: 'span',
         });
         assert.equal(found, true, 'Element was not found');
+
+        // Check if element redirects to the correct page
+        await driver.clickElement({ text: 'Security', tag: 'span' });
+        url = await driver.getUrl();
+        assert.equal(
+          url.includes(settings.security.urlSubstring),
+          true,
+          'Item does not redirect to correct page',
+        );
       },
     );
   });
@@ -135,10 +200,20 @@ describe('Settings Search', function () {
 
         await driver.clickElement('.account-menu__icon');
         await driver.clickElement({ text: 'Settings', tag: 'div' });
-        await driver.fill('#search-settings', searchableItems.alerts);
+        await driver.fill('#search-settings', settings.alerts.target);
 
+        // Check if element was found
         found = await driver.isElementPresent({ text: 'Alerts', tag: 'span' });
         assert.equal(found, true, 'Element was not found');
+
+        // Check if element redirects to the correct page
+        await driver.clickElement({ text: 'Alerts', tag: 'span' });
+        url = await driver.getUrl();
+        assert.equal(
+          url.includes(settings.alerts.urlSubstring),
+          true,
+          'Item does not redirect to correct page',
+        );
       },
     );
   });
@@ -157,13 +232,23 @@ describe('Settings Search', function () {
 
         await driver.clickElement('.account-menu__icon');
         await driver.clickElement({ text: 'Settings', tag: 'div' });
-        await driver.fill('#search-settings', searchableItems.networks);
+        await driver.fill('#search-settings', settings.networks.target);
 
+        // Check if element was found
         found = await driver.isElementPresent({
           text: 'Networks',
           tag: 'span',
         });
         assert.equal(found, true, 'Element was not found');
+
+        // Check if element redirects to the correct page
+        await driver.clickElement({ text: 'Networks', tag: 'span' });
+        url = await driver.getUrl();
+        assert.equal(
+          url.includes(settings.networks.urlSubstring),
+          true,
+          'Item does not redirect to correct page',
+        );
       },
     );
   });
@@ -182,13 +267,23 @@ describe('Settings Search', function () {
 
         await driver.clickElement('.account-menu__icon');
         await driver.clickElement({ text: 'Settings', tag: 'div' });
-        await driver.fill('#search-settings', searchableItems.experimental);
+        await driver.fill('#search-settings', settings.experimental.target);
 
+        // Check if element was found
         found = await driver.isElementPresent({
           text: 'Experimental',
           tag: 'span',
         });
         assert.equal(found, true, 'Element was not found');
+
+        // Check if element redirects to the correct page
+        await driver.clickElement({ text: 'Experimental', tag: 'span' });
+        url = await driver.getUrl();
+        assert.equal(
+          url.includes(settings.experimental.urlSubstring),
+          true,
+          'Item does not redirect to correct page',
+        );
       },
     );
   });
@@ -207,10 +302,20 @@ describe('Settings Search', function () {
 
         await driver.clickElement('.account-menu__icon');
         await driver.clickElement({ text: 'Settings', tag: 'div' });
-        await driver.fill('#search-settings', searchableItems.about);
+        await driver.fill('#search-settings', settings.about.target);
 
+        // Check if element was found
         found = await driver.isElementPresent({ text: 'About', tag: 'span' });
         assert.equal(found, true, 'Element was not found');
+
+        // Check if element redirects to the correct page
+        await driver.clickElement({ text: 'About', tag: 'span' });
+        url = await driver.getUrl();
+        assert.equal(
+          url.includes(settings.about.urlSubstring),
+          true,
+          'Item does not redirect to correct page',
+        );
       },
     );
   });
@@ -232,10 +337,10 @@ describe('Settings Search', function () {
         await driver.fill('#search-settings', 'Lorem ipsum');
 
         found = await driver.isElementPresent({
-          text: 'Lorem ipsum',
+          text: 'No matching results found',
           tag: 'span',
         });
-        assert.equal(found, false, 'Non existent element was found');
+        assert.equal(found, true, 'Non existent element was found');
       },
     );
   });

--- a/test/e2e/webdriver/driver.js
+++ b/test/e2e/webdriver/driver.js
@@ -285,9 +285,6 @@ class Driver {
     return await this.driver.get(`${this.extensionUrl}/${page}.html`);
   }
 
-  async getUrl() {
-    return await this.driver.getCurrentUrl();
-  }
   // Metrics
 
   async collectMetrics() {

--- a/test/e2e/webdriver/driver.js
+++ b/test/e2e/webdriver/driver.js
@@ -285,6 +285,9 @@ class Driver {
     return await this.driver.get(`${this.extensionUrl}/${page}.html`);
   }
 
+  async getUrl() {
+    return await this.driver.getCurrentUrl();
+  }
   // Metrics
 
   async collectMetrics() {


### PR DESCRIPTION
## Explanation
This testcase covers the Settings Search functionality, asserting the following cases:
- `should find element inside the General tab`
- `should find element inside the Advanced tab`
- `should find element inside the Contacts tab`
- `should find element inside the Security tab`
- `should find element inside the Alerts tab`
- `should find element inside the Networks tab`
- `should find element inside the Experimental tab`
- `should find element inside the About tab`
- `should display "Element not found" for a non-existing element`

Furthermore, it checks that the found elements redirect you to the correct Settings page.

## Context
- Feature specs #13214
- Closes #14190 