### PR TITLE
track rpc method usage

### DIFF
--- a/app/scripts/lib/createRPCMethodTrackingMiddleware.js
+++ b/app/scripts/lib/createRPCMethodTrackingMiddleware.js
@@ -1,0 +1,81 @@
+import { SECOND } from '../../../shared/constants/time';
+
+const USER_PROMPTED_EVENT_NAME_MAP = {
+  eth_signTypedData_v4: 'Signature Requested',
+  eth_signTypedData_v3: 'Signature Requested',
+  eth_signTypedData: 'Signature Requested',
+  eth_personal_sign: 'Signature Requested',
+  eth_sign: 'Signature Requested',
+  eth_getEncryptionPublicKey: 'Encryption Public Key Requested',
+  eth_decrypt: 'Decryption Requsted',
+  wallet_requestPermissions: 'Permissions Requested',
+  eth_requestAccounts: 'Permissions Requested',
+};
+
+const samplingTimeouts = {};
+
+/**
+ * Returns a middleware that tracks inpage_provider usage using sampling for
+ * each type of event except those that require user interaction, such as
+ * signature requests
+ *
+ * @param {object} opts - options for the rpc method tracking middleware
+ * @param {Function} opts.trackEvent - trackEvent method from MetaMetricsController
+ * @param {Function} opts.getMetricsState - get the state of MetaMetricsController
+ * @returns {Function}
+ */
+export default function createRPCMethodTrackingMiddleware({
+  trackEvent,
+  getMetricsState,
+}) {
+  return function rpcMethodTrackingMiddleware(
+    /** @type {any} */ req,
+    /** @type {any} */ res,
+    /** @type {Function} */ next,
+  ) {
+    const { origin } = req;
+
+    next((callback) => {
+      if (!getMetricsState().participateInMetaMetrics) {
+        return callback();
+      }
+      if (USER_PROMPTED_EVENT_NAME_MAP[req.method]) {
+        const userRejected = res.error?.code === 4001;
+        trackEvent({
+          event: USER_PROMPTED_EVENT_NAME_MAP[req.method],
+          category: 'inpage_provider',
+          referrer: {
+            url: origin,
+          },
+          properties: {
+            method: req.method,
+            status: userRejected ? 'rejected' : 'approved',
+            error_code: res.error?.code,
+            error_message: res.error?.message,
+            has_result: typeof res.result !== 'undefined',
+          },
+        });
+      } else if (typeof samplingTimeouts[req.method] === 'undefined') {
+        trackEvent({
+          event: 'Provider Method Called',
+          category: 'inpage_provider',
+          referrer: {
+            url: origin,
+          },
+          properties: {
+            method: req.method,
+            error_code: res.error?.code,
+            error_message: res.error?.message,
+            has_result: typeof res.result !== 'undefined',
+          },
+        });
+        // Only record one call to this method every ten seconds to avoid
+        // overloading network requests.
+        samplingTimeouts[req.method] = setTimeout(() => {
+          delete samplingTimeouts[req.method];
+        }, SECOND * 10);
+      }
+      return callback();
+    });
+  };
+}

--- a/app/scripts/lib/createRPCMethodTrackingMiddleware.js
+++ b/app/scripts/lib/createRPCMethodTrackingMiddleware.js
@@ -1,15 +1,16 @@
+import { EVENT_NAMES } from '../../../shared/constants/metametrics';
 import { SECOND } from '../../../shared/constants/time';
 
 const USER_PROMPTED_EVENT_NAME_MAP = {
-  eth_signTypedData_v4: 'Signature Requested',
-  eth_signTypedData_v3: 'Signature Requested',
-  eth_signTypedData: 'Signature Requested',
-  eth_personal_sign: 'Signature Requested',
-  eth_sign: 'Signature Requested',
-  eth_getEncryptionPublicKey: 'Encryption Public Key Requested',
-  eth_decrypt: 'Decryption Requsted',
-  wallet_requestPermissions: 'Permissions Requested',
-  eth_requestAccounts: 'Permissions Requested',
+  eth_signTypedData_v4: EVENT_NAMES.SIGNATURE_REQUESTED,
+  eth_signTypedData_v3: EVENT_NAMES.SIGNATURE_REQUESTED,
+  eth_signTypedData: EVENT_NAMES.SIGNATURE_REQUESTED,
+  eth_personal_sign: EVENT_NAMES.SIGNATURE_REQUESTED,
+  eth_sign: EVENT_NAMES.SIGNATURE_REQUESTED,
+  eth_getEncryptionPublicKey: EVENT_NAMES.ENCRYPTION_PUBLIC_KEY_REQUESTED,
+  eth_decrypt: EVENT_NAMES.DECRYPTION_REQUESTED,
+  wallet_requestPermissions: EVENT_NAMES.PERMISSIONS_REQUESTED,
+  eth_requestAccounts: EVENT_NAMES.PERMISSIONS_REQUESTED,
 };
 
 const samplingTimeouts = {};

--- a/app/scripts/lib/createRPCMethodTrackingMiddleware.js
+++ b/app/scripts/lib/createRPCMethodTrackingMiddleware.js
@@ -33,9 +33,11 @@ export default function createRPCMethodTrackingMiddleware({
     /** @type {any} */ res,
     /** @type {Function} */ next,
   ) {
+    const startTime = Date.now();
     const { origin } = req;
 
     next((callback) => {
+      const endTime = Date.now();
       if (!getMetricsState().participateInMetaMetrics) {
         return callback();
       }
@@ -53,6 +55,7 @@ export default function createRPCMethodTrackingMiddleware({
             error_code: res.error?.code,
             error_message: res.error?.message,
             has_result: typeof res.result !== 'undefined',
+            duration: endTime - startTime,
           },
         });
       } else if (typeof samplingTimeouts[req.method] === 'undefined') {
@@ -67,6 +70,7 @@ export default function createRPCMethodTrackingMiddleware({
             error_code: res.error?.code,
             error_message: res.error?.message,
             has_result: typeof res.result !== 'undefined',
+            duration: endTime - startTime,
           },
         });
         // Only record one call to this method every ten seconds to avoid

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -137,6 +137,7 @@ import {
   buildSnapRestrictedMethodSpecifications,
   ///: END:ONLY_INCLUDE_IN
 } from './controllers/permissions';
+import createRPCMethodTrackingMiddleware from './lib/createRPCMethodTrackingMiddleware';
 
 ///: BEGIN:ONLY_INCLUDE_IN(flask)
 import { getPlatform } from './lib/util';
@@ -3331,6 +3332,17 @@ export default class MetamaskController extends EventEmitter {
     // logging
     engine.push(createLoggerMiddleware({ origin }));
     engine.push(this.permissionLogController.createMiddleware());
+
+    engine.push(
+      createRPCMethodTrackingMiddleware({
+        trackEvent: this.metaMetricsController.trackEvent.bind(
+          this.metaMetricsController,
+        ),
+        getMetricsState: this.metaMetricsController.store.getState.bind(
+          this.metaMetricsController.store,
+        ),
+      }),
+    );
 
     // onboarding
     if (subjectType === SUBJECT_TYPES.WEBSITE) {

--- a/shared/constants/metametrics.js
+++ b/shared/constants/metametrics.js
@@ -213,3 +213,10 @@ export const METAMETRICS_BACKGROUND_PAGE_OBJECT = {
 export const REJECT_NOTFICIATION_CLOSE = 'Cancel Via Notification Close';
 export const REJECT_NOTFICIATION_CLOSE_SIG =
   'Cancel Sig Request Via Notification Close';
+
+export const EVENT_NAMES = {
+  SIGNATURE_REQUESTED: 'Signature Requested',
+  ENCRYPTION_PUBLIC_KEY_REQUESTED: 'Encryption Public Key Requested',
+  DECRYPTION_REQUESTED: 'Decryption Requested',
+  PERMISSIONS_REQUESTED: 'Permissions Requested',
+};


### PR DESCRIPTION
## Explanation
This adds a new RPC method middleware that tracks the inpage provider usage. This will happen once every ten seconds *per method* unless the method is one of those that are special cased because they display prompts to the user. Note that tracking the adding/switching networks is handled in its RPC method handler. Note also that all transactions are already tracked in the transaction controller.

## More information
Fixes #13582
Fixes #7329

## Manual testing steps

<!--
How should reviewers and QA manually test your changes? For instance:

- Go to this screen
- Do this
- Then do this
-->
