### PR TITLE
Swaps select quote highlight fix

### DIFF
--- a/ui/pages/swaps/select-quote-popover/index.scss
+++ b/ui/pages/swaps/select-quote-popover/index.scss
@@ -96,8 +96,8 @@
     }
 
     &--selected {
-      color: var(--color-text-default);
-      background: linear-gradient(90deg, var(--color-primary-default) 0%, var(--primary-alternative) 101.32%);
+      color: var(--color-primary-inverse);
+      background: linear-gradient(90deg, var(--color-primary-default) 0%, var(--color-primary-alternative) 101.32%);
       box-shadow: 0 10px 39px rgba(3, 125, 214, 0.15);
       border-radius: 8px;
       height: 64px;


### PR DESCRIPTION
## Explanation

Fixes #14266 blue highlight of selected quote in swaps. Was mainly a syntax error.

## Screenshots

<img width="667" alt="Screen Shot 2022-03-30 at 10 17 52 AM" src="https://user-images.githubusercontent.com/8112138/160894222-bef635f2-d3d4-4f8d-a46f-ee93f3f0221d.png">
<img width="664" alt="Screen Shot 2022-03-30 at 10 19 12 AM" src="https://user-images.githubusercontent.com/8112138/160894224-75567e5c-5f29-4c9c-837a-8329f59e6625.png">

