### PR TITLE
Dark Mode: Ensure actionable message button colors are the same color as previously

### DIFF
--- a/ui/components/ui/actionable-message/index.scss
+++ b/ui/components/ui/actionable-message/index.scss
@@ -107,6 +107,11 @@
     .actionable-message__action--secondary {
       text-decoration: underline;
     }
+
+    button {
+      background: var(--color-warning-default);
+      color: var(--color-warning-inverse);
+    }
   }
 
   &--danger {
@@ -120,6 +125,11 @@
     .actionable-message__message {
       text-align: left;
     }
+
+    button {
+      background: var(--color-error-default);
+      color: var(--color-error-inverse);
+    }
   }
 
   &--success {
@@ -127,6 +137,11 @@
 
     &::before {
       background: var(--color-success-muted);
+    }
+
+    button {
+      background: var(--color-success-default);
+      color: var(--color-success-inverse);
     }
   }
 


### PR DESCRIPTION
This is number one in the feedback document.


<img width="473" alt="ButtonsColors" src="https://user-images.githubusercontent.com/46655/160895317-47283ea1-68de-4bec-8380-a2f58c90d86e.png">

