### PR TITLE
Allow locally hosted RPC and Block Explorer Urls with `wallet_addEthereumChain`

### DIFF
--- a/app/scripts/lib/rpc-method-middleware/handlers/add-ethereum-chain.js
+++ b/app/scripts/lib/rpc-method-middleware/handlers/add-ethereum-chain.js
@@ -83,7 +83,9 @@ async function addEthereumChainHandler(
   };
 
   const firstValidRPCUrl = Array.isArray(rpcUrls)
-    ? rpcUrls.find((rpcUrl) => validUrl.isHttpsUri(rpcUrl))
+    ? rpcUrls.find(
+        (rpcUrl) => isLocalhost(rpcUrl) || validUrl.isHttpsUri(rpcUrl),
+      )
     : null;
 
   const firstValidBlockExplorerUrl =

--- a/app/scripts/lib/rpc-method-middleware/handlers/add-ethereum-chain.js
+++ b/app/scripts/lib/rpc-method-middleware/handlers/add-ethereum-chain.js
@@ -90,8 +90,10 @@ async function addEthereumChainHandler(
 
   const firstValidBlockExplorerUrl =
     blockExplorerUrls !== null && Array.isArray(blockExplorerUrls)
-      ? blockExplorerUrls.find((blockExplorerUrl) =>
-          validUrl.isHttpsUri(blockExplorerUrl),
+      ? blockExplorerUrls.find(
+          (blockExplorerUrl) =>
+            isLocalhost(blockExplorerUrl) ||
+            validUrl.isHttpsUri(blockExplorerUrl),
         )
       : null;
 

--- a/app/scripts/lib/rpc-method-middleware/handlers/add-ethereum-chain.js
+++ b/app/scripts/lib/rpc-method-middleware/handlers/add-ethereum-chain.js
@@ -78,8 +78,12 @@ async function addEthereumChainHandler(
   }
 
   const isLocalhost = (strUrl) => {
-    const url = new URL(strUrl);
-    return url.hostname === 'localhost' || url.hostname === '127.0.0.1';
+    try {
+      const url = new URL(strUrl);
+      return url.hostname === 'localhost' || url.hostname === '127.0.0.1';
+    } catch (error) {
+      return false;
+    }
   };
 
   const firstValidRPCUrl = Array.isArray(rpcUrls)

--- a/app/scripts/lib/rpc-method-middleware/handlers/add-ethereum-chain.js
+++ b/app/scripts/lib/rpc-method-middleware/handlers/add-ethereum-chain.js
@@ -77,6 +77,11 @@ async function addEthereumChainHandler(
     );
   }
 
+  const isLocalhost = (strUrl) => {
+    const url = new URL(strUrl);
+    return url.hostname === 'localhost' || url.hostname === '127.0.0.1';
+  };
+
   const firstValidRPCUrl = Array.isArray(rpcUrls)
     ? rpcUrls.find((rpcUrl) => validUrl.isHttpsUri(rpcUrl))
     : null;


### PR DESCRIPTION
## Explanation
Currently, adding a chain using the `wallet_addEthereumChain` RPC method requires that the supplied chain has an array of RPC urls, with at least one of them being an HTTPS url. 

This is a problem because locally hosted resources are [considered secure](https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts#when_is_a_context_considered_secure), and users may want to programmatically add their own local chains (e.g. Ganache) to MetaMask.

This change instead requires that at least one of the urls is either HTTPS or locally hosted (`url.hostname === "localhost" || url.hostname === "127.0.0.1"`).

The same change is made for the block explorer urls.


## Manual testing steps

To test, run MetaMask and run `ganache --port 8544 --chain.chainId 1338`. Send the `wallet_addEthereumChain` RPC method to MetaMask with the payload:
```
{
    chainId: "0x53A",
    chainName: 'Ganache Test',
    nativeCurrency: { symbol: 'ETH', decimals: 18 },
    rpcUrls: [ 'http://127.0.0.1:8544' ],
    blockExplorerUrls: [ 'http://localhost:3000' ]
  }
```
Verify that the chain is successfully added to MetaMask.
