### PR TITLE
Updating design-tokens to 1.5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "@material-ui/core": "^4.11.0",
     "@metamask/contract-metadata": "^1.31.0",
     "@metamask/controllers": "^27.0.0",
-    "@metamask/design-tokens": "^1.4.2",
+    "@metamask/design-tokens": "^1.5.1",
     "@metamask/eth-ledger-bridge-keyring": "^0.10.0",
     "@metamask/eth-token-tracker": "^4.0.0",
     "@metamask/etherscan-link": "^2.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2797,10 +2797,10 @@
     web3 "^0.20.7"
     web3-provider-engine "^16.0.3"
 
-"@metamask/design-tokens@^1.4.2":
-  version "1.4.4"
-  resolved "https://registry.yarnpkg.com/@metamask/design-tokens/-/design-tokens-1.4.4.tgz#85a80f0ba5ff34a595bd1d879dbf4219c0fbfe7a"
-  integrity sha512-OzlUv3GSBbmVlO4EcFrkK2/InxaBMH31O2ncVabJvySc/HbhpXMEm7ZtowPqxlBI05V0WdVxSv/0MZtRkbIyXA==
+"@metamask/design-tokens@^1.5.1":
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/@metamask/design-tokens/-/design-tokens-1.5.1.tgz#723f10bc5fe03ce14d47b1ad6190a835df62745a"
+  integrity sha512-HLXpuzQGnVPZHOvHpzOVQoe/1mvjNOTNxvAgR1na3BAUiO3NhnUxhYE2RzV0rpbc3UUUGbjVB+dceMZ4FtFfRw==
 
 "@metamask/eslint-config-jest@^9.0.0":
   version "9.0.0"


### PR DESCRIPTION
## Explanation

Updating `@metamask/design-tokens` to `v1.5.1` which includes these updates:

- dark theme background.default and background.alternative values are swapped
- dark theme overlay colors are black instead of white. Same as light mode

**NOTE: This does not effect any default theme / light theme colors ONLY dark theme**

## Screenshots

### Before

<img width="1440" alt="Screen Shot 2022-03-30 at 3 52 53 PM" src="https://user-images.githubusercontent.com/8112138/160944262-93e6b962-8c35-4758-a8f2-33253ad96778.png">


### After

<img width="1440" alt="Screen Shot 2022-03-30 at 3 57 07 PM" src="https://user-images.githubusercontent.com/8112138/160944358-02d957a0-f9e1-44d6-8bf5-454231e30ee4.png">
