### PR TITLE
Fix/14230 dark mode fixes

### DIFF
--- a/app/images/warning.svg
+++ b/app/images/warning.svg
@@ -1,8 +1,0 @@
-<svg height="32" width="33" xmlns="http://www.w3.org/2000/svg">
-    <g fill="none" fill-rule="evenodd">
-        <path d="M19.132 2.854l12.44 22.748a3 3 0 01-2.632 4.44H4.06a3 3 0 01-2.632-4.44l12.44-22.748a3 3 0 015.264 0z" stroke="#ff001f" stroke-width="2"/>
-        <g fill="#ff001f">
-            <path d="M15 8h3v13h-3zM15 23h3v3h-3z"/>
-        </g>
-    </g>
-</svg>

--- a/ui/components/app/app-header/app-header.component.js
+++ b/ui/components/app/app-header/app-header.component.js
@@ -97,7 +97,6 @@ export default class AppHeader extends PureComponent {
   render() {
     const {
       history,
-      isUnlocked,
       hideNetworkIndicator,
       disableNetworkIndicator,
       disabled,
@@ -105,11 +104,7 @@ export default class AppHeader extends PureComponent {
     } = this.props;
 
     return (
-      <div
-        className={classnames('app-header', {
-          'app-header--back-drop': isUnlocked,
-        })}
-      >
+      <div className="app-header">
         <div className="app-header__contents">
           <MetaFoxLogo
             unsetIconHeight

--- a/ui/components/app/app-header/app-header.stories.js
+++ b/ui/components/app/app-header/app-header.stories.js
@@ -1,0 +1,49 @@
+import React from 'react';
+import AppHeader from '.';
+
+export default {
+  title: 'Components/App/AppHeader',
+  id: __filename,
+  argTypes: {
+    history: {
+      control: 'object',
+    },
+    networkDropdownOpen: {
+      control: 'boolean',
+    },
+    showNetworkDropdown: {
+      action: 'showNetworkDropdown',
+    },
+    hideNetworkDropdown: {
+      action: 'hideNetworkDropdown',
+    },
+    toggleAccountMenu: {
+      action: 'toggleAccountMenu',
+    },
+    selectedAddress: {
+      control: 'text',
+    },
+    isUnlocked: {
+      control: 'boolean',
+    },
+    hideNetworkIndicator: {
+      control: 'boolean',
+    },
+    disabled: {
+      control: 'boolean',
+    },
+    disableNetworkIndicator: {
+      control: 'boolean',
+    },
+    isAccountMenuOpen: {
+      control: 'boolean',
+    },
+    onClick: {
+      action: 'onClick',
+    },
+  },
+};
+
+export const DefaultStory = (args) => <AppHeader {...args} />;
+
+DefaultStory.storyName = 'Default';

--- a/ui/components/app/app-header/index.scss
+++ b/ui/components/app/app-header/index.scss
@@ -16,17 +16,6 @@
   @media screen and (min-width: $break-large) {
     height: 75px;
     justify-content: center;
-
-    &--back-drop {
-      &::after {
-        content: '';
-        position: absolute;
-        width: 100%;
-        height: 32px;
-        background: var(--color-background-alternative);
-        bottom: -32px;
-      }
-    }
   }
 
   &__metafox-logo {

--- a/ui/components/ui/page-container/index.scss
+++ b/ui/components/ui/page-container/index.scss
@@ -152,7 +152,7 @@
   }
 
   &__warning-container {
-    background: var(--color-warning-muted);
+    background: var(--color-error-muted);
     padding: 20px;
     display: flex;
     align-items: start;
@@ -168,6 +168,7 @@
 
   &__warning-icon {
     padding-top: 5px;
+    color: var(--color-error-default);
   }
 }
 

--- a/ui/css/base-styles.scss
+++ b/ui/css/base-styles.scss
@@ -89,29 +89,30 @@ input.form-control {
   padding-left: 10px;
   font-size: 14px;
   height: 40px;
-  border: 1px solid var(--color-border-muted);
+  border: 1px solid var(--color-border-default);
+  color: 1px solid var(--color-text-default);
   background: transparent;
   border-radius: 3px;
   width: 100%;
 
   &::-webkit-input-placeholder {
     font-weight: 100;
-    color: var(--color-text-alternative);
+    color: var(--color-text-muted);
   }
 
   &::-moz-placeholder {
     font-weight: 100;
-    color: var(--color-text-alternative);
+    color: var(--color-text-muted);
   }
 
   &:-ms-input-placeholder {
     font-weight: 100;
-    color: var(--color-text-alternative);
+    color: var(--color-text-muted);
   }
 
   &:-moz-placeholder {
     font-weight: 100;
-    color: var(--color-text-alternative);
+    color: var(--color-text-muted);
   }
 
   &--error {

--- a/ui/pages/keychains/reveal-seed.js
+++ b/ui/pages/keychains/reveal-seed.js
@@ -40,11 +40,7 @@ class RevealSeedPage extends Component {
   renderWarning() {
     return (
       <div className="page-container__warning-container">
-        <img
-          className="page-container__warning-icon"
-          src="images/warning.svg"
-          alt=""
-        />
+        <i className="fa fa-exclamation-triangle fa-2x page-container__warning-icon" />
         <div className="page-container__warning-message">
           <div className="page-container__warning-title">
             {this.context.t('revealSeedWordsWarningTitle')}

--- a/ui/pages/keychains/reveal-seed.stories.js
+++ b/ui/pages/keychains/reveal-seed.stories.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import RevealSeedPage from './reveal-seed';
+
+export default {
+  title: 'Pages/Keychains/RevealSeedPage',
+  id: __filename,
+  argTypes: {
+    requestRevealSeedWords: {
+      action: 'requestRevealSeedWords',
+    },
+    history: {
+      control: 'object',
+    },
+    mostRecentOverviewPage: {
+      control: 'text',
+    },
+  },
+};
+
+export const DefaultStory = (args) => <RevealSeedPage {...args} />;
+
+DefaultStory.storyName = 'Default';


### PR DESCRIPTION
## Explanation

Some fixes for release and dark mode as well as adding some stories

Fixes: https://github.com/MetaMask/metamask-extension/issues/14230
Fixes: https://github.com/MetaMask/metamask-extension/issues/14299
Fixes: https://github.com/MetaMask/metamask-extension/issues/14301

## Screenshots

### AppHeader

### Before
There was a psuedo element that is no longer a different color so I removed it. 
<img width="1437" alt="Screen Shot 2022-03-31 at 9 31 09 AM" src="https://user-images.githubusercontent.com/8112138/161109501-dee5d7e9-732b-4f3e-8684-b7ac44358a66.png">

### After (no changes)
<img width="1440" alt="Screen Shot 2022-03-31 at 9 40 44 AM" src="https://user-images.githubusercontent.com/8112138/161109507-add30018-1443-44a5-96e2-633fbb29430b.png">
<img width="1440" alt="Screen Shot 2022-03-31 at 9 40 57 AM" src="https://user-images.githubusercontent.com/8112138/161109508-3abe6655-77a2-44f9-8ed2-f0d0859df23c.png">

Added a story for the component 
<img width="1440" alt="Screen Shot 2022-03-31 at 9 41 14 AM" src="https://user-images.githubusercontent.com/8112138/161109509-d2eafa41-405b-477d-bcb2-4f53d3d2160c.png">
<img width="1440" alt="Screen Shot 2022-03-31 at 9 41 19 AM" src="https://user-images.githubusercontent.com/8112138/161109512-40a69b0f-2c04-46fe-ba6a-406098043546.png">

### RevealSeedPage and Mobile Sync

### Before
danger/critical message was yellow
<img width="622" alt="Screen Shot 2022-03-31 at 9 48 57 AM" src="https://user-images.githubusercontent.com/8112138/161109517-2c0eb2ab-610c-4d8f-986e-77948be579f6.png">

### After 
danger/critical message is red also fixing input color in dark mode 
<img width="620" alt="Screen Shot 2022-03-31 at 9 51 05 AM" src="https://user-images.githubusercontent.com/8112138/161109521-e8ba2139-fe97-4b77-b3cf-eebfb53897c4.png">
<img width="618" alt="Screen Shot 2022-03-31 at 9 51 14 AM" src="https://user-images.githubusercontent.com/8112138/161109522-fafe0d7c-7bef-4d18-8b45-e11aa4a22d7f.png">
<img width="622" alt="Screen Shot 2022-03-31 at 9 51 38 AM" src="https://user-images.githubusercontent.com/8112138/161109523-99328e3f-2136-45a4-84a5-f2a18db6ee3b.png">
<img width="626" alt="Screen Shot 2022-03-31 at 9 52 12 AM" src="https://user-images.githubusercontent.com/8112138/161109528-8fbfd7ba-122e-4e8b-9e95-d90f51f22426.png">
<img width="620" alt="Screen Shot 2022-03-31 at 9 52 29 AM" src="https://user-images.githubusercontent.com/8112138/161109530-2f5fe96f-cbe8-4632-b5da-2d1aa19d01c3.png">

Adding stories for RevealSeedPage component for easier future updates to UI

<img width="1440" alt="Screen Shot 2022-03-31 at 9 52 39 AM" src="https://user-images.githubusercontent.com/8112138/161109536-1e54c630-257c-4bfe-9099-227cc19e1b71.png">
<img width="1433" alt="Screen Shot 2022-03-31 at 9 52 45 AM" src="https://user-images.githubusercontent.com/8112138/161109538-cbb3b97d-fdcd-4022-8c68-6985295657f9.png">


## Manual testing steps


**Show RevealSeedPage in dev build**
- Go to Settings > Security & Privacy > Reveal Secret Recovery Phrase > See page

https://user-images.githubusercontent.com/8112138/161110193-9e6c4515-23ae-4591-a54b-9e38f3ea216d.mov

**Sync with mobile in dev build**
- Go to Settings > Advanced > Sync with mobile > See page

https://user-images.githubusercontent.com/8112138/161110576-5f0ffbaf-47c7-4ac2-8373-a11b1aabe622.mov


**Storybook stories**

RevealSeedPage
- Go to latest build of storybook in this PR and search `RevealSeedPage`



AppHeader
- Go to latest build of storybook in this PR and search `AppHeader`

