### PR TITLE
Fixing account details label colors

### DIFF
--- a/ui/components/ui/editable-label/editable-label.stories.js
+++ b/ui/components/ui/editable-label/editable-label.stories.js
@@ -1,0 +1,33 @@
+import React from 'react';
+import EditableLabel from '.';
+
+export default {
+  title: 'Components/UI/EditableLabel',
+  id: __filename,
+  argTypes: {
+    onSubmit: {
+      action: 'onSubmit',
+    },
+    defaultValue: {
+      control: 'text',
+    },
+    className: {
+      control: 'text',
+    },
+    accountsNames: {
+      control: 'array',
+    },
+  },
+  args: {
+    defaultValue: 'Account 3',
+    accountsNames: ['Account 1', 'Account 2'],
+  },
+};
+
+export const DefaultStory = (args) => (
+  <div style={{ position: 'relative', width: 335 }}>
+    <EditableLabel {...args} />
+  </div>
+);
+
+DefaultStory.storyName = 'Default';

--- a/ui/components/ui/editable-label/index.scss
+++ b/ui/components/ui/editable-label/index.scss
@@ -14,6 +14,8 @@
   &__input {
     @include H6;
 
+    color: var(--color-text-default);
+    background-color: var(--color-background-default);
     width: 250px;
     text-align: center;
     border: 1px solid var(--color-border-default);


### PR DESCRIPTION
## Explanation

Fixing account label colors

Fixes: https://github.com/MetaMask/metamask-extension/issues/14307

## Screenshots

### Before
<img width="422" alt="Screen Shot 2022-03-31 at 1 42 27 PM" src="https://user-images.githubusercontent.com/8112138/161148122-fdbbb6c9-2648-46fa-b71d-cbabe3768b25.png">

### After
<img width="365" alt="Screen Shot 2022-03-31 at 1 43 25 PM" src="https://user-images.githubusercontent.com/8112138/161148192-98a18f1e-f705-4362-81e4-7c9270f2f1d8.png">


Storybook

<img width="1440" alt="Screen Shot 2022-03-31 at 1 55 55 PM" src="https://user-images.githubusercontent.com/8112138/161148350-c2a590e9-9725-4a8c-a06b-89907032818b.png">
<img width="1440" alt="Screen Shot 2022-03-31 at 1 56 16 PM" src="https://user-images.githubusercontent.com/8112138/161148351-9a05f619-8d5e-4a13-8698-9f26c60633f4.png">
