### PR TITLE
Update eth-ledger-bridge-keyring to 0.11.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "@metamask/contract-metadata": "^1.31.0",
     "@metamask/controllers": "^27.0.0",
     "@metamask/design-tokens": "^1.5.1",
-    "@metamask/eth-ledger-bridge-keyring": "^0.10.0",
+    "@metamask/eth-ledger-bridge-keyring": "^0.11.0",
     "@metamask/eth-token-tracker": "^4.0.0",
     "@metamask/etherscan-link": "^2.1.0",
     "@metamask/iframe-execution-environment-service": "^0.10.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2827,10 +2827,10 @@
   resolved "https://registry.yarnpkg.com/@metamask/eslint-config/-/eslint-config-9.0.0.tgz#22d4911b705f7e4e566efbdda0e37912da33e30f"
   integrity sha512-mWlLGQKjXXFOj9EtDClKSoTLeQuPW2kM1w3EpUMf4goYAQ+kLXCCa8pEff6h8ApWAnjhYmXydA1znQ2J4XvD+A==
 
-"@metamask/eth-ledger-bridge-keyring@^0.10.0":
-  version "0.10.0"
-  resolved "https://registry.yarnpkg.com/@metamask/eth-ledger-bridge-keyring/-/eth-ledger-bridge-keyring-0.10.0.tgz#9d5103be22221f4ef71393a2e11f24b788e343a5"
-  integrity sha512-ewcnEFmIL2lkUta811yQeJVWhTjll9U62GdbuauvxdQ0c6VBGZnf02GU3gcxyMOcEvZBnlU+d5LWpURQA8iNZQ==
+"@metamask/eth-ledger-bridge-keyring@^0.11.0":
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/@metamask/eth-ledger-bridge-keyring/-/eth-ledger-bridge-keyring-0.11.0.tgz#8502e2fd36c89aff7de6724354217274917cecd3"
+  integrity sha512-fCwM8LYC6SXLfsKc4oNiAatz2X8p/pjbM5zMfm4nb4sZPshBAWU32M4vnB3BSVeQEsisGuLfOWCOWhxmq25n+Q==
   dependencies:
     "@ethereumjs/tx" "^3.2.0"
     eth-sig-util "^2.0.0"


### PR DESCRIPTION
Includes message queue and keyring side of hardware connectivity.