### PR TITLE
Adding the link component to load Tokens found page

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -2220,6 +2220,10 @@
   "notifications9Title": {
     "message": "👓 We are making transactions easier to read."
   },
+  "numberOfNewTokensDetected": {
+    "message": "$1 new tokens found in this account",
+    "description": "$1 is the number of new tokens detected"
+  },
   "ofTextNofM": {
     "message": "of"
   },

--- a/ui/components/app/app-components.scss
+++ b/ui/components/app/app-components.scss
@@ -84,5 +84,6 @@
 @import 'advanced-gas-fee-popover/advanced-gas-fee-input-subtext/index';
 @import 'advanced-gas-fee-popover/advanced-gas-fee-defaults/index';
 @import 'currency-input/index';
+@import 'asset-list/detetcted-tokens-link/index';
 @import 'detected-token/detected-token-address/index';
 @import 'detected-token/detected-token-aggregators/index';

--- a/ui/components/app/asset-list/detetcted-tokens-link/detected-tokens-link.js
+++ b/ui/components/app/asset-list/detetcted-tokens-link/detected-tokens-link.js
@@ -1,0 +1,29 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { useSelector } from 'react-redux';
+
+import Box from '../../../ui/box/box';
+import Button from '../../../ui/button';
+import { useI18nContext } from '../../../../hooks/useI18nContext';
+import { getDetectedTokensInCurrentNetwork } from '../../../../selectors';
+
+const DetectedTokensLink = ({ onClick }) => {
+  const t = useI18nContext();
+  const detectedTokens = useSelector(getDetectedTokensInCurrentNetwork);
+  return (
+    <Box className="detected-tokens-link">
+      <Button
+        type="link"
+        className="detected-tokens-link__link"
+        onClick={onClick}
+      >
+        {t('numberOfNewTokensDetected', [detectedTokens.length])}
+      </Button>
+    </Box>
+  );
+};
+
+DetectedTokensLink.propTypes = {
+  onClick: PropTypes.func.isRequired,
+};
+export default DetectedTokensLink;

--- a/ui/components/app/asset-list/detetcted-tokens-link/detected-tokens-link.js
+++ b/ui/components/app/asset-list/detetcted-tokens-link/detected-tokens-link.js
@@ -1,17 +1,22 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import { useSelector } from 'react-redux';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
 
 import Box from '../../../ui/box/box';
 import Button from '../../../ui/button';
 import { useI18nContext } from '../../../../hooks/useI18nContext';
 import { getDetectedTokensInCurrentNetwork } from '../../../../selectors';
 
-const DetectedTokensLink = ({ onClick }) => {
+const DetectedTokensLink = ({ className = '', onClick }) => {
   const t = useI18nContext();
   const detectedTokens = useSelector(getDetectedTokensInCurrentNetwork);
+
   return (
-    <Box className="detected-tokens-link">
+    <Box
+      className={classNames('detected-tokens-link', className)}
+      marginTop={1}
+    >
       <Button
         type="link"
         className="detected-tokens-link__link"
@@ -25,5 +30,7 @@ const DetectedTokensLink = ({ onClick }) => {
 
 DetectedTokensLink.propTypes = {
   onClick: PropTypes.func.isRequired,
+  className: PropTypes.string,
 };
+
 export default DetectedTokensLink;

--- a/ui/components/app/asset-list/detetcted-tokens-link/index.scss
+++ b/ui/components/app/asset-list/detetcted-tokens-link/index.scss
@@ -1,0 +1,5 @@
+.detected-tokens-link {
+  & &__link {
+    @include H6;
+  }
+}

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -945,10 +945,6 @@ export function getIsTokenDetectionSupported(state) {
   ].includes(chainId);
 }
 
-export function getTokenDetectionNoticeDismissed(state) {
-  return state.metamask.tokenDetectionNoticeDismissed;
-}
-
-export function getTokenDetectionWarningDismissed(state) {
-  return state.metamask.tokenDetectionWarningDismissed;
+export function getDetectedTokensInCurrentNetwork(state) {
+  return state.metamask.detectedTokens;
 }


### PR DESCRIPTION
Fix #13949 

Adding a new link with number of tokens detected is added to the Home page.

<img width="174" alt="Screen Shot 2022-03-31 at 5 06 18 PM" src="https://user-images.githubusercontent.com/43930900/161149370-16fb4928-8088-4b6d-a5dd-3649ea566080.png">
.