### PR TITLE
Updatin contract deployment text label to be darker

### DIFF
--- a/ui/components/app/confirm-page-container/confirm-page-container-content/confirm-page-container-summary/index.scss
+++ b/ui/components/app/confirm-page-container/confirm-page-container-content/confirm-page-container-summary/index.scss
@@ -23,7 +23,7 @@
   &__action {
     @include H7;
 
-    color: var(--color-text-muted);
+    color: var(--color-text-alternative);
     padding: 3px 8px;
     border: 1px solid var(--color-border-default);
     border-radius: 4px;


### PR DESCRIPTION
## Explanation

Making the text darker/more contrasting for the contract label

## Screenshots

### Before
<img width="370" alt="Screen Shot 2022-04-01 at 11 59 19 AM" src="https://user-images.githubusercontent.com/8112138/161325295-9059df2d-c339-457d-a559-eafe4f07f232.png">


### After
<img width="320" alt="Screen Shot 2022-04-01 at 11 53 27 AM" src="https://user-images.githubusercontent.com/8112138/161324734-cc7398b8-393f-4c27-87cd-a0867fb609d1.png"><img width="320" alt="Screen Shot 2022-04-01 at 11 54 01 AM" src="https://user-images.githubusercontent.com/8112138/161324741-e9960049-78db-4926-abbd-51c9b1dcd3e2.png">

