### PR TITLE
Restore `version` missing from certain build steps

### DIFF
--- a/app/scripts/lib/setupSentry.js
+++ b/app/scripts/lib/setupSentry.js
@@ -68,9 +68,9 @@ export const SENTRY_STATE = {
 };
 
 export default function setupSentry({ release, getState }) {
-  let sentryTarget;
-
-  if (METAMASK_DEBUG) {
+  if (!release) {
+    throw new Error('Missing release');
+  } else if (METAMASK_DEBUG) {
     return undefined;
   }
 
@@ -79,6 +79,7 @@ export default function setupSentry({ release, getState }) {
       ? METAMASK_ENVIRONMENT
       : `${METAMASK_ENVIRONMENT}-${METAMASK_BUILD_TYPE}`;
 
+  let sentryTarget;
   if (METAMASK_ENVIRONMENT === 'production') {
     if (!process.env.SENTRY_DSN) {
       throw new Error(

--- a/development/build/scripts.js
+++ b/development/build/scripts.js
@@ -269,6 +269,7 @@ function createScriptTasks({
       testing,
       policyOnly,
       shouldLintFenceFiles,
+      version,
     });
   }
 
@@ -285,6 +286,7 @@ function createScriptTasks({
       testing,
       policyOnly,
       shouldLintFenceFiles,
+      version,
     });
   }
 
@@ -301,6 +303,7 @@ function createScriptTasks({
       testing,
       policyOnly,
       shouldLintFenceFiles,
+      version,
     });
   }
 
@@ -320,6 +323,7 @@ function createScriptTasks({
         policyOnly,
         shouldLintFenceFiles,
         testing,
+        version,
       }),
       createNormalBundle({
         buildType,
@@ -332,6 +336,7 @@ function createScriptTasks({
         policyOnly,
         shouldLintFenceFiles,
         testing,
+        version,
       }),
     );
   }
@@ -532,6 +537,7 @@ function createNormalBundle({
   modulesToExpose,
   shouldLintFenceFiles,
   testing,
+  version,
 }) {
   return async function () {
     // create bundler setup and apply defaults
@@ -543,7 +549,12 @@ function createNormalBundle({
     const reloadOnChange = Boolean(devMode);
     const minify = Boolean(devMode) === false;
 
-    const envVars = getEnvironmentVariables({ buildType, devMode, testing });
+    const envVars = getEnvironmentVariables({
+      buildType,
+      devMode,
+      testing,
+      version,
+    });
     setupBundlerDefaults(buildConfiguration, {
       buildType,
       devMode,


### PR DESCRIPTION
Certain build steps accidentally omitted the `version` variable. It has now been restored to all steps, ensuring that all environment variables are correctly injected into all bundles.

A check has been added to the Sentry setup module to ensure the release is not omitted in the future.

Manual testing steps:
* Build the extension (try different kinds of builds, e.g. dev, prod, flask, beta)
* Check the `background.html` console to ensure there is no error about the release being missing.