### PR TITLE
Settings:TabBar: Fix text wrap style

### DIFF
--- a/ui/components/app/tab-bar/index.scss
+++ b/ui/components/app/tab-bar/index.scss
@@ -38,7 +38,6 @@
     &__content {
       padding: 12px 18px;
       display: flex;
-      flex-flow: row wrap;
       align-items: center;
       position: relative;
 

--- a/ui/components/app/tab-bar/index.scss
+++ b/ui/components/app/tab-bar/index.scss
@@ -63,8 +63,14 @@
       }
 
       &__icon {
-        margin-inline-end: 16px;
         display: flex;
+        justify-content: center;
+        margin-inline-end: 16px;
+        flex: 0 0 18px;
+
+        @media screen and (min-width: $break-large) {
+          flex: 0 0 14px;
+        }
       }
     }
 


### PR DESCRIPTION
## Explanation

Fixes: https://github.com/MetaMask/metamask-extension/issues/13856 and [the icon and text misalignment mentioned in the comment below.](https://github.com/MetaMask/metamask-extension/pull/14348#issuecomment-1088187635)

### Before
<img width="240" alt="Screenshot 2022-04-04 at 2 08 00 PM" src="https://user-images.githubusercontent.com/20778143/161621021-216e36fa-2a2a-4b39-a0fb-400e23fa2ed1.png">
<img width="420" alt="Screenshot 2022-04-04 at 2 08 11 PM" src="https://user-images.githubusercontent.com/20778143/161621054-df651f43-202f-4bba-81ef-4b31554939f8.png">
<img width="240" alt="Screenshot 2022-04-04 at 2 08 00 PM" src="https://user-images.githubusercontent.com/20778143/161806142-25003fa1-3b22-413d-bdba-531040faa6cb.png">


### After
<img width="240" alt="Screenshot 2022-04-05 at 2 30 49 PM" src="https://user-images.githubusercontent.com/20778143/161815719-ae21bff2-0e73-41d7-afc0-cb1caba105d0.png">
<img width="420" alt="Screenshot 2022-04-05 at 2 31 01 PM" src="https://user-images.githubusercontent.com/20778143/161815727-2dab12a1-90e4-46c3-bea4-9649aa9dd9e9.png">

