### PR TITLE
Feature Flag Swap API mock

### DIFF
--- a/test/e2e/mock-e2e.js
+++ b/test/e2e/mock-e2e.js
@@ -1,6 +1,12 @@
 async function setupMocking(server, testSpecificMock) {
   await server.forAnyRequest().thenPassThrough();
 
+  await server.forPost('https://api.segment.io/v1/batch').thenCallback(() => {
+    return {
+      statusCode: 200,
+    };
+  });
+
   await server
     .forGet('https://gas-api.metaswap.codefi.network/networks/1/gasPrices')
     .thenCallback(() => {
@@ -13,12 +19,6 @@ async function setupMocking(server, testSpecificMock) {
         },
       };
     });
-
-  await server.forPost('https://api.segment.io/v1/batch').thenCallback(() => {
-    return {
-      statusCode: 200,
-    };
-  });
 
   await server
     .forGet(
@@ -54,36 +54,6 @@ async function setupMocking(server, testSpecificMock) {
           priorityFeeTrend: 'down',
           baseFeeTrend: 'up',
         },
-      };
-    });
-
-  await server
-    .forGet('https://token-api.metaswap.codefi.network/tokens/1337')
-    .thenCallback(() => {
-      return {
-        statusCode: 200,
-        json: [
-          {
-            address: '0x0d8775f648430679a709e98d2b0cb6250d2887ef',
-            symbol: 'BAT',
-            decimals: 18,
-            name: 'Basic Attention Token',
-            iconUrl:
-              'https://assets.coingecko.com/coins/images/677/thumb/basic-attention-token.png?1547034427',
-            aggregators: [
-              'aave',
-              'bancor',
-              'coinGecko',
-              'oneInch',
-              'paraswap',
-              'pmm',
-              'zapper',
-              'zerion',
-              'zeroEx',
-            ],
-            occurrences: 9,
-          },
-        ],
       };
     });
 
@@ -131,6 +101,36 @@ async function setupMocking(server, testSpecificMock) {
               extensionActive: false,
             },
             updated_at: '2022-03-17T15:54:00.360Z',
+          },
+        ],
+      };
+    });
+
+  await server
+    .forGet('https://token-api.metaswap.codefi.network/tokens/1337')
+    .thenCallback(() => {
+      return {
+        statusCode: 200,
+        json: [
+          {
+            address: '0x0d8775f648430679a709e98d2b0cb6250d2887ef',
+            symbol: 'BAT',
+            decimals: 18,
+            name: 'Basic Attention Token',
+            iconUrl:
+              'https://assets.coingecko.com/coins/images/677/thumb/basic-attention-token.png?1547034427',
+            aggregators: [
+              'aave',
+              'bancor',
+              'coinGecko',
+              'oneInch',
+              'paraswap',
+              'pmm',
+              'zapper',
+              'zerion',
+              'zeroEx',
+            ],
+            occurrences: 9,
           },
         ],
       };

--- a/test/e2e/mock-e2e.js
+++ b/test/e2e/mock-e2e.js
@@ -87,6 +87,55 @@ async function setupMocking(server, testSpecificMock) {
       };
     });
 
+  await server
+    .forGet('https://swap.metaswap.codefi.network/featureFlags')
+    .thenCallback(() => {
+      return {
+        statusCode: 200,
+        json: [
+          {
+            ethereum: {
+              mobile_active: true,
+              extension_active: true,
+              fallback_to_v1: false,
+              mobileActive: true,
+              extensionActive: true,
+            },
+            bsc: {
+              mobile_active: true,
+              extension_active: true,
+              fallback_to_v1: false,
+              mobileActive: true,
+              extensionActive: true,
+            },
+            polygon: {
+              mobile_active: true,
+              extension_active: true,
+              fallback_to_v1: false,
+              mobileActive: true,
+              extensionActive: true,
+            },
+            avalanche: {
+              mobile_active: true,
+              extension_active: true,
+              fallback_to_v1: false,
+              mobileActive: true,
+              extensionActive: true,
+            },
+            smart_transactions: {
+              mobile_active: false,
+              extension_active: false,
+            },
+            smartTransactions: {
+              mobileActive: false,
+              extensionActive: false,
+            },
+            updated_at: '2022-03-17T15:54:00.360Z',
+          },
+        ],
+      };
+    });
+
   testSpecificMock(server);
 }
 


### PR DESCRIPTION
## Context
The ultimate goal is get rid of the `setupFetchMocking` server function on the `webdriver/index.js` file, so we get all the API mocking centralized in the`mock-e2e.js` file.
    
## What
- The first step and the aim of this PR is to migrate the feature flag API call for swaps to `mock-e2e.js`

Next steps will be:
- Mock Infura Cancel Request -- tackled in 2nd PR
- Completly remove the `setupFetchMocking` function from `webdriver/index.js` --tackled on 3rd PR

Closes #14351 
