### PR TITLE
Empty balance while switching network

### DIFF
--- a/ui/components/app/asset-list/asset-list.js
+++ b/ui/components/app/asset-list/asset-list.js
@@ -68,19 +68,17 @@ const AssetList = ({ onClickAsset }) => {
 
   return (
     <>
-      {selectedAccountBalance ? (
-        <AssetListItem
-          onClick={() => onClickAsset(nativeCurrency)}
-          data-testid="wallet-balance"
-          primary={
-            primaryCurrencyProperties.value ?? secondaryCurrencyProperties.value
-          }
-          tokenSymbol={primaryCurrencyProperties.suffix}
-          secondary={showFiat ? secondaryCurrencyDisplay : undefined}
-          tokenImage={primaryTokenImage}
-          identiconBorder
-        />
-      ) : null}
+      <AssetListItem
+        onClick={() => onClickAsset(nativeCurrency)}
+        data-testid="wallet-balance"
+        primary={
+          primaryCurrencyProperties.value ?? secondaryCurrencyProperties.value
+        }
+        tokenSymbol={primaryCurrencyProperties.suffix}
+        secondary={showFiat ? secondaryCurrencyDisplay : undefined}
+        tokenImage={primaryTokenImage}
+        identiconBorder
+      />
       <TokenList
         onTokenClick={(tokenAddress) => {
           onClickAsset(tokenAddress);

--- a/ui/components/app/asset-list/asset-list.js
+++ b/ui/components/app/asset-list/asset-list.js
@@ -7,7 +7,7 @@ import AssetListItem from '../asset-list-item';
 import { PRIMARY, SECONDARY } from '../../../helpers/constants/common';
 import { useUserPreferencedCurrency } from '../../../hooks/useUserPreferencedCurrency';
 import {
-  getCurrentAccountWithSendEtherInfo,
+  getSelectedAccountCachedBalance,
   getShouldShowFiat,
   getNativeCurrencyImage,
   getDetectedTokensInCurrentNetwork,
@@ -33,9 +33,7 @@ const AssetList = ({ onClickAsset }) => {
 
   const [showDetectedTokens, setShowDetectedTokens] = useState(false);
 
-  const selectedAccountBalance = useSelector(
-    (state) => getCurrentAccountWithSendEtherInfo(state).balance,
-  );
+  const selectedAccountBalance = useSelector(getSelectedAccountCachedBalance);
   const nativeCurrency = useSelector(getNativeCurrency);
   const showFiat = useSelector(getShouldShowFiat);
   const trackEvent = useContext(MetaMetricsContext);
@@ -70,17 +68,19 @@ const AssetList = ({ onClickAsset }) => {
 
   return (
     <>
-      <AssetListItem
-        onClick={() => onClickAsset(nativeCurrency)}
-        data-testid="wallet-balance"
-        primary={
-          primaryCurrencyProperties.value ?? secondaryCurrencyProperties.value
-        }
-        tokenSymbol={primaryCurrencyProperties.suffix}
-        secondary={showFiat ? secondaryCurrencyDisplay : undefined}
-        tokenImage={primaryTokenImage}
-        identiconBorder
-      />
+      {selectedAccountBalance ? (
+        <AssetListItem
+          onClick={() => onClickAsset(nativeCurrency)}
+          data-testid="wallet-balance"
+          primary={
+            primaryCurrencyProperties.value ?? secondaryCurrencyProperties.value
+          }
+          tokenSymbol={primaryCurrencyProperties.suffix}
+          secondary={showFiat ? secondaryCurrencyDisplay : undefined}
+          tokenImage={primaryTokenImage}
+          identiconBorder
+        />
+      ) : null}
       <TokenList
         onTokenClick={(tokenAddress) => {
           onClickAsset(tokenAddress);

--- a/ui/components/app/wallet-overview/eth-overview.js
+++ b/ui/components/app/wallet-overview/eth-overview.js
@@ -32,6 +32,7 @@ import IconButton from '../../ui/icon-button';
 import { isHardwareKeyring } from '../../../helpers/utils/hardware';
 import { MetaMetricsContext } from '../../../contexts/metametrics';
 import { EVENT } from '../../../../shared/constants/metametrics';
+import Spinner from '../../ui/spinner';
 import WalletOverview from './wallet-overview';
 
 const EthOverview = ({ className }) => {
@@ -70,7 +71,12 @@ const EthOverview = ({ className }) => {
                   ethNumberOfDecimals={4}
                   hideTitle
                 />
-              ) : null}
+              ) : (
+                <Spinner
+                  color="var(--color-secondary-default)"
+                  className="loading-overlay__spinner"
+                />
+              )}
               {balanceIsCached ? (
                 <span className="eth-overview__cached-star">*</span>
               ) : null}
@@ -163,13 +169,7 @@ const EthOverview = ({ className }) => {
         </>
       }
       className={className}
-      icon={
-        balance ? (
-          <Identicon diameter={32} image={primaryTokenImage} imageBorder />
-        ) : (
-          <></>
-        )
-      }
+      icon={<Identicon diameter={32} image={primaryTokenImage} imageBorder />}
     />
   );
 };

--- a/ui/components/app/wallet-overview/eth-overview.js
+++ b/ui/components/app/wallet-overview/eth-overview.js
@@ -16,13 +16,13 @@ import { PRIMARY, SECONDARY } from '../../../helpers/constants/common';
 import { showModal } from '../../../store/actions';
 import {
   isBalanceCached,
-  getSelectedAccount,
   getShouldShowFiat,
   getCurrentKeyring,
   getSwapsDefaultToken,
   getIsSwapsChain,
   getIsBuyableChain,
   getNativeCurrencyImage,
+  getSelectedAccountCachedBalance,
 } from '../../../selectors/selectors';
 import SwapIcon from '../../ui/icon/swap-icon.component';
 import BuyIcon from '../../ui/icon/overview-buy-icon.component';
@@ -43,8 +43,7 @@ const EthOverview = ({ className }) => {
   const usingHardwareWallet = isHardwareKeyring(keyring?.type);
   const balanceIsCached = useSelector(isBalanceCached);
   const showFiat = useSelector(getShouldShowFiat);
-  const selectedAccount = useSelector(getSelectedAccount);
-  const { balance } = selectedAccount;
+  const balance = useSelector(getSelectedAccountCachedBalance);
   const isSwapsChain = useSelector(getIsSwapsChain);
   const isBuyableChain = useSelector(getIsBuyableChain);
   const primaryTokenImage = useSelector(getNativeCurrencyImage);
@@ -60,21 +59,23 @@ const EthOverview = ({ className }) => {
         >
           <div className="eth-overview__balance">
             <div className="eth-overview__primary-container">
-              <UserPreferencedCurrencyDisplay
-                className={classnames('eth-overview__primary-balance', {
-                  'eth-overview__cached-balance': balanceIsCached,
-                })}
-                data-testid="eth-overview__primary-currency"
-                value={balance}
-                type={PRIMARY}
-                ethNumberOfDecimals={4}
-                hideTitle
-              />
+              {balance ? (
+                <UserPreferencedCurrencyDisplay
+                  className={classnames('eth-overview__primary-balance', {
+                    'eth-overview__cached-balance': balanceIsCached,
+                  })}
+                  data-testid="eth-overview__primary-currency"
+                  value={balance}
+                  type={PRIMARY}
+                  ethNumberOfDecimals={4}
+                  hideTitle
+                />
+              ) : null}
               {balanceIsCached ? (
                 <span className="eth-overview__cached-star">*</span>
               ) : null}
             </div>
-            {showFiat && (
+            {showFiat && balance && (
               <UserPreferencedCurrencyDisplay
                 className={classnames({
                   'eth-overview__cached-secondary-balance': balanceIsCached,
@@ -162,7 +163,13 @@ const EthOverview = ({ className }) => {
         </>
       }
       className={className}
-      icon={<Identicon diameter={32} image={primaryTokenImage} imageBorder />}
+      icon={
+        balance ? (
+          <Identicon diameter={32} image={primaryTokenImage} imageBorder />
+        ) : (
+          <></>
+        )
+      }
     />
   );
 };


### PR DESCRIPTION
## Explanation

While reproduce this issue, we are using the network tools in the background console to fail requests from the different networks. 

While fixing this bug, we make the improvement tracked here: #14040. So we added loading spinner for balance display on main screen when we switching between networks (in this case from `Mubai` to `Ethereum Mainnet`).  You can check new design update [here](https://www.figma.com/file/UniC0neIae4IxKENQMVdEg/Balance-switching-networks?node-id=1%3A1602).

## More information

* Fixes:  #12495, #14040


## Screenshots/Screencaps

### Before

https://user-images.githubusercontent.com/92527393/161740818-4ebcaf27-d8b0-4ee3-846c-549560455c88.mov

## Manual testing steps

1. Go to Metamask wallet
2. Check amount of `MATIC` on `Mumbai` (test network)
3. Click on Network and change to `Ethereum Mainnet`
4. Check amount of `ETH` on `Ethereum Mainnet`

