### PR TITLE
Fix speed-up/cancel: don't update existing transaction data

### DIFF
--- a/ui/components/app/cancel-speedup-popover/cancel-speedup-popover.test.js
+++ b/ui/components/app/cancel-speedup-popover/cancel-speedup-popover.test.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { act, screen } from '@testing-library/react';
+import BigNumber from 'bignumber.js';
 
 import {
   EDIT_GAS_MODES,
@@ -10,8 +11,46 @@ import mockEstimates from '../../../../test/data/mock-estimates.json';
 import mockState from '../../../../test/data/mock-state.json';
 import { GasFeeContextProvider } from '../../../contexts/gasFee';
 import configureStore from '../../../store/store';
+import {
+  hexWEIToDecETH,
+  decGWEIToHexWEI,
+} from '../../../helpers/utils/conversions.util';
 
 import CancelSpeedupPopover from './cancel-speedup-popover';
+
+const MAXFEEPERGAS_ABOVE_MOCK_MEDIUM_HEX = '0x174876e800';
+const MAXGASCOST_ABOVE_MOCK_MEDIUM_BN = new BigNumber(
+  MAXFEEPERGAS_ABOVE_MOCK_MEDIUM_HEX,
+  16,
+).times(21000, 10);
+const MAXGASCOST_ABOVE_MOCK_MEDIUM_BN_PLUS_TEN_PCT_HEX = MAXGASCOST_ABOVE_MOCK_MEDIUM_BN.times(
+  1.1,
+  10,
+).toString(16);
+
+const EXPECTED_ETH_FEE_1 = hexWEIToDecETH(
+  MAXGASCOST_ABOVE_MOCK_MEDIUM_BN_PLUS_TEN_PCT_HEX,
+);
+
+const MOCK_SUGGESTED_MEDIUM_MAXFEEPERGAS_DEC_GWEI =
+  mockEstimates[GAS_ESTIMATE_TYPES.FEE_MARKET].gasFeeEstimates.medium
+    .suggestedMaxFeePerGas;
+const MOCK_SUGGESTED_MEDIUM_MAXFEEPERGAS_BN_WEI = new BigNumber(
+  decGWEIToHexWEI(MOCK_SUGGESTED_MEDIUM_MAXFEEPERGAS_DEC_GWEI),
+  16,
+);
+const MAXFEEPERGAS_BELOW_MOCK_MEDIUM_HEX = MOCK_SUGGESTED_MEDIUM_MAXFEEPERGAS_BN_WEI.div(
+  10,
+  10,
+).toString(16);
+
+const EXPECTED_ETH_FEE_2 = hexWEIToDecETH(
+  MOCK_SUGGESTED_MEDIUM_MAXFEEPERGAS_BN_WEI.times(21000, 10).toString(16),
+);
+
+const MOCK_SUGGESTED_MEDIUM_MAXFEEPERGAS_HEX_WEI = MOCK_SUGGESTED_MEDIUM_MAXFEEPERGAS_BN_WEI.toString(
+  16,
+);
 
 jest.mock('../../../store/actions', () => ({
   disconnectGasFeeEstimatePoller: jest.fn(),
@@ -21,7 +60,6 @@ jest.mock('../../../store/actions', () => ({
     .mockImplementation(() => Promise.resolve()),
   addPollingTokenToAppState: jest.fn(),
   removePollingTokenFromAppState: jest.fn(),
-  updateTransaction: () => ({ type: 'UPDATE_TRANSACTION_PARAMS' }),
   updateTransactionGasFees: () => ({ type: 'UPDATE_TRANSACTION_PARAMS' }),
   updatePreviousGasParams: () => ({ type: 'UPDATE_TRANSACTION_PARAMS' }),
   createTransactionEventFragment: jest.fn(),
@@ -34,7 +72,10 @@ jest.mock('../../../contexts/transaction-modal', () => ({
   }),
 }));
 
-const render = (props) => {
+const render = (
+  props,
+  maxFeePerGas = MOCK_SUGGESTED_MEDIUM_MAXFEEPERGAS_HEX_WEI,
+) => {
   const store = configureStore({
     metamask: {
       ...mockState.metamask,
@@ -56,7 +97,7 @@ const render = (props) => {
         userFeeLevel: 'tenPercentIncreased',
         txParams: {
           gas: '0x5208',
-          maxFeePerGas: '0x59682f10',
+          maxFeePerGas,
           maxPriorityFeePerGas: '0x59682f00',
         },
       }}
@@ -80,12 +121,32 @@ describe('CancelSpeedupPopover', () => {
     expect(screen.queryByText('🚀Speed Up')).toBeInTheDocument();
   });
 
-  it('should show correct gas values', async () => {
+  it('should show correct gas values, increased by 10%, when initial initial gas value is above estimated medium', async () => {
     await act(async () =>
-      render({
-        editGasMode: EDIT_GAS_MODES.SPEED_UP,
-      }),
+      render(
+        {
+          editGasMode: EDIT_GAS_MODES.SPEED_UP,
+        },
+        MAXFEEPERGAS_ABOVE_MOCK_MEDIUM_HEX,
+      ),
     );
-    expect(screen.queryAllByTitle('0.0000315 ETH').length).toBeGreaterThan(0);
+    expect(
+      screen.queryAllByTitle(`${EXPECTED_ETH_FEE_1} ETH`).length,
+    ).toBeGreaterThan(0);
+  });
+
+  it('should show correct gas values, set to the estimated medium, when initial initial gas value is below estimated medium', async () => {
+    await act(async () =>
+      render(
+        {
+          editGasMode: EDIT_GAS_MODES.SPEED_UP,
+        },
+        `0x${MAXFEEPERGAS_BELOW_MOCK_MEDIUM_HEX}`,
+      ),
+    );
+
+    expect(
+      screen.queryAllByTitle(`${EXPECTED_ETH_FEE_2} ETH`).length,
+    ).toBeGreaterThan(0);
   });
 });

--- a/ui/contexts/gasFee.js
+++ b/ui/contexts/gasFee.js
@@ -1,6 +1,7 @@
-import React, { createContext, useContext } from 'react';
+import React, { createContext, useContext, useState } from 'react';
 import PropTypes from 'prop-types';
 import { useGasFeeInputs } from '../hooks/gasFeeInput/useGasFeeInputs';
+import { editGasModeIsSpeedUpOrCancel } from '../helpers/utils/gas';
 
 export const GasFeeContext = createContext({});
 
@@ -11,11 +12,24 @@ export const GasFeeContextProvider = ({
   minimumGasLimit,
   editGasMode,
 }) => {
+  const [retryTxMeta, setRetryTxMeta] = useState({
+    txParams: transaction.txParams,
+    id: transaction.id,
+    userFeeLevel: transaction.userFeeLevel,
+    originalGasEstimate: transaction.originalGasEstimate,
+    userEditedGasLimit: transaction.userEditedGasLimit,
+  });
+
+  const transactionToUse = editGasModeIsSpeedUpOrCancel(editGasMode)
+    ? retryTxMeta
+    : transaction;
+
   const gasFeeDetails = useGasFeeInputs(
     defaultEstimateToUse,
-    transaction,
+    transactionToUse,
     minimumGasLimit,
     editGasMode,
+    setRetryTxMeta,
   );
   return (
     <GasFeeContext.Provider value={gasFeeDetails}>

--- a/ui/contexts/gasFee.js
+++ b/ui/contexts/gasFee.js
@@ -1,7 +1,6 @@
-import React, { createContext, useContext, useState } from 'react';
+import React, { createContext, useContext } from 'react';
 import PropTypes from 'prop-types';
 import { useGasFeeInputs } from '../hooks/gasFeeInput/useGasFeeInputs';
-import { editGasModeIsSpeedUpOrCancel } from '../helpers/utils/gas';
 
 export const GasFeeContext = createContext({});
 
@@ -12,24 +11,11 @@ export const GasFeeContextProvider = ({
   minimumGasLimit,
   editGasMode,
 }) => {
-  const [retryTxMeta, setRetryTxMeta] = useState({
-    txParams: transaction.txParams,
-    id: transaction.id,
-    userFeeLevel: transaction.userFeeLevel,
-    originalGasEstimate: transaction.originalGasEstimate,
-    userEditedGasLimit: transaction.userEditedGasLimit,
-  });
-
-  const transactionToUse = editGasModeIsSpeedUpOrCancel(editGasMode)
-    ? retryTxMeta
-    : transaction;
-
   const gasFeeDetails = useGasFeeInputs(
     defaultEstimateToUse,
-    transactionToUse,
+    transaction,
     minimumGasLimit,
     editGasMode,
-    setRetryTxMeta,
   );
   return (
     <GasFeeContext.Provider value={gasFeeDetails}>

--- a/ui/helpers/utils/gas.js
+++ b/ui/helpers/utils/gas.js
@@ -1,7 +1,10 @@
 import { constant, times, uniq, zip } from 'lodash';
 import BigNumber from 'bignumber.js';
 import { addHexPrefix } from 'ethereumjs-util';
-import { GAS_RECOMMENDATIONS } from '../../../shared/constants/gas';
+import {
+  GAS_RECOMMENDATIONS,
+  EDIT_GAS_MODES,
+} from '../../../shared/constants/gas';
 import { multiplyCurrencies } from '../../../shared/modules/conversion.utils';
 import {
   bnGreaterThan,
@@ -105,4 +108,17 @@ export function formatGasFeeOrFeeRange(
   ).join(' - ');
 
   return `${formattedRange} GWEI`;
+}
+
+/**
+ * Helper method for determining whether an edit gas mode is either a speed up or cancel transaction
+ *
+ * @param {string | undefined} editGasMode - One of 'speed-up', 'cancel', 'modify-in-place', or 'swaps'
+ * @returns boolean
+ */
+export function editGasModeIsSpeedUpOrCancel(editGasMode) {
+  return (
+    editGasMode === EDIT_GAS_MODES.CANCEL ||
+    editGasMode === EDIT_GAS_MODES.SPEED_UP
+  );
 }

--- a/ui/hooks/gasFeeInput/useGasFeeInputs.js
+++ b/ui/hooks/gasFeeInput/useGasFeeInputs.js
@@ -17,6 +17,7 @@ import { hexToDecimal } from '../../helpers/utils/conversions.util';
 import { isLegacyTransaction } from '../../helpers/utils/transactions.util';
 import { useGasFeeEstimates } from '../useGasFeeEstimates';
 
+import { editGasModeIsSpeedUpOrCancel } from '../../helpers/utils/gas';
 import { useGasFeeErrors } from './useGasFeeErrors';
 import { useGasPriceInput } from './useGasPriceInput';
 import { useMaxFeePerGasInput } from './useMaxFeePerGasInput';
@@ -81,21 +82,31 @@ import { useTransactionFunctions } from './useTransactionFunctions';
  *
  * @param {EstimateLevel} [defaultEstimateToUse] - which estimate
  *  level to default the 'estimateToUse' state variable to.
- * @param {object} [transaction]
+ * @param {object} [_transaction]
  * @param {string} [minimumGasLimit]
  * @param {EDIT_GAS_MODES[keyof EDIT_GAS_MODES]} editGasMode
- * @param setRetryTxMeta
  * @returns {GasFeeInputReturnType & import(
  *  './useGasFeeEstimates'
  * ).GasEstimates} gas fee input state and the GasFeeEstimates object
  */
 export function useGasFeeInputs(
   defaultEstimateToUse = GAS_RECOMMENDATIONS.MEDIUM,
-  transaction,
+  _transaction,
   minimumGasLimit = '0x5208',
   editGasMode = EDIT_GAS_MODES.MODIFY_IN_PLACE,
-  setRetryTxMeta,
 ) {
+  const [retryTxMeta, setRetryTxMeta] = useState({
+    txParams: _transaction.txParams,
+    id: _transaction.id,
+    userFeeLevel: _transaction.userFeeLevel,
+    originalGasEstimate: _transaction.originalGasEstimate,
+    userEditedGasLimit: _transaction.userEditedGasLimit,
+  });
+
+  const transaction = editGasModeIsSpeedUpOrCancel(editGasMode)
+    ? retryTxMeta
+    : _transaction;
+
   const eip1559V2Enabled = useSelector(getEIP1559V2Enabled);
 
   const supportsEIP1559 =

--- a/ui/hooks/gasFeeInput/useGasFeeInputs.js
+++ b/ui/hooks/gasFeeInput/useGasFeeInputs.js
@@ -95,13 +95,19 @@ export function useGasFeeInputs(
   minimumGasLimit = '0x5208',
   editGasMode = EDIT_GAS_MODES.MODIFY_IN_PLACE,
 ) {
-  const [retryTxMeta, setRetryTxMeta] = useState({
+  const initialRetryTxMeta = {
     txParams: _transaction?.txParams,
     id: _transaction?.id,
     userFeeLevel: _transaction?.userFeeLevel,
     originalGasEstimate: _transaction?.originalGasEstimate,
     userEditedGasLimit: _transaction?.userEditedGasLimit,
-  });
+  };
+
+  if (_transaction?.previousGas) {
+    initialRetryTxMeta.previousGas = _transaction?.previousGas;
+  }
+
+  const [retryTxMeta, setRetryTxMeta] = useState(initialRetryTxMeta);
 
   const transaction = editGasModeIsSpeedUpOrCancel(editGasMode)
     ? retryTxMeta

--- a/ui/hooks/gasFeeInput/useGasFeeInputs.js
+++ b/ui/hooks/gasFeeInput/useGasFeeInputs.js
@@ -96,11 +96,11 @@ export function useGasFeeInputs(
   editGasMode = EDIT_GAS_MODES.MODIFY_IN_PLACE,
 ) {
   const [retryTxMeta, setRetryTxMeta] = useState({
-    txParams: _transaction.txParams,
-    id: _transaction.id,
-    userFeeLevel: _transaction.userFeeLevel,
-    originalGasEstimate: _transaction.originalGasEstimate,
-    userEditedGasLimit: _transaction.userEditedGasLimit,
+    txParams: _transaction?.txParams,
+    id: _transaction?.id,
+    userFeeLevel: _transaction?.userFeeLevel,
+    originalGasEstimate: _transaction?.originalGasEstimate,
+    userEditedGasLimit: _transaction?.userEditedGasLimit,
   });
 
   const transaction = editGasModeIsSpeedUpOrCancel(editGasMode)

--- a/ui/hooks/gasFeeInput/useGasFeeInputs.js
+++ b/ui/hooks/gasFeeInput/useGasFeeInputs.js
@@ -84,6 +84,7 @@ import { useTransactionFunctions } from './useTransactionFunctions';
  * @param {object} [transaction]
  * @param {string} [minimumGasLimit]
  * @param {EDIT_GAS_MODES[keyof EDIT_GAS_MODES]} editGasMode
+ * @param setRetryTxMeta
  * @returns {GasFeeInputReturnType & import(
  *  './useGasFeeEstimates'
  * ).GasEstimates} gas fee input state and the GasFeeEstimates object
@@ -93,6 +94,7 @@ export function useGasFeeInputs(
   transaction,
   minimumGasLimit = '0x5208',
   editGasMode = EDIT_GAS_MODES.MODIFY_IN_PLACE,
+  setRetryTxMeta,
 ) {
   const eip1559V2Enabled = useSelector(getEIP1559V2Enabled);
 
@@ -272,6 +274,7 @@ export function useGasFeeInputs(
     maxPriorityFeePerGas,
     minimumGasLimit,
     transaction,
+    setRetryTxMeta,
   });
 
   // When a user selects an estimate level, it will wipe out what they have

--- a/ui/hooks/gasFeeInput/useTransactionFunctions.js
+++ b/ui/hooks/gasFeeInput/useTransactionFunctions.js
@@ -6,7 +6,10 @@ import {
   decimalToHex,
   decGWEIToHexWEI,
 } from '../../helpers/utils/conversions.util';
-import { addTenPercentAndRound } from '../../helpers/utils/gas';
+import {
+  addTenPercentAndRound,
+  editGasModeIsSpeedUpOrCancel,
+} from '../../helpers/utils/gas';
 import {
   createCancelTransaction,
   createSpeedUpTransaction,
@@ -24,6 +27,7 @@ export const useTransactionFunctions = ({
   gasLimit: gasLimitValue,
   maxPriorityFeePerGas: maxPriorityFeePerGasValue,
   transaction,
+  setRetryTxMeta,
 }) => {
   const dispatch = useDispatch();
 
@@ -87,6 +91,8 @@ export const useTransactionFunctions = ({
           updateSwapsUserFeeLevel(estimateUsed || PRIORITY_LEVELS.CUSTOM),
         );
         dispatch(updateCustomSwapsEIP1559GasParams(newGasSettings));
+      } else if (editGasModeIsSpeedUpOrCancel(editGasMode)) {
+        setRetryTxMeta(updatedTxMeta);
       } else {
         newGasSettings.userEditedGasLimit = updatedTxMeta.userEditedGasLimit;
         newGasSettings.userFeeLevel = updatedTxMeta.userFeeLevel;
@@ -110,6 +116,7 @@ export const useTransactionFunctions = ({
       getTxMeta,
       maxPriorityFeePerGasValue,
       transaction,
+      setRetryTxMeta,
     ],
   );
 


### PR DESCRIPTION
Fixes https://github.com/MetaMask/metamask-extension/issues/14284

Explanation:

EIP-1559 v2 introduced new logic for speed up and cancellation. This new logic updates metamask state data of the existing transaction (the one being replaced / "sped up" / "cancelled"). We should not do this. Instead, we should use the data of the existing transaction (in particular the nonce) to create an entirely new transaction.

The error was caught because of the new transaction update methods introduced in https://github.com/MetaMask/metamask-extension/pull/13646. Those methods (correctly) throw an error when attempting to update a transaction that is not in an "unapproved" state.

This PR fixes this by maintaining transaction data for speed ups and cancels in front-end / react state, instead of modifying the background transaction.