### PR TITLE
Fix the close button in the speed up and cancel popovers

### DIFF
--- a/ui/components/app/cancel-speedup-popover/cancel-speedup-popover.js
+++ b/ui/components/app/cancel-speedup-popover/cancel-speedup-popover.js
@@ -96,7 +96,7 @@ const CancelSpeedupPopover = () => {
             : `🚀${t('speedUp')}`}
         </>
       }
-      onClose={() => closeModal('cancelSpeedUpTransaction')}
+      onClose={() => closeModal(['cancelSpeedUpTransaction'])}
       className="cancel-speedup-popover"
     >
       <AppLoadingSpinner className="cancel-speedup-popover__spinner" />

--- a/ui/components/app/edit-gas-fee-popover/edit-gas-fee-popover.js
+++ b/ui/components/app/edit-gas-fee-popover/edit-gas-fee-popover.js
@@ -44,7 +44,9 @@ const EditGasFeePopover = () => {
     <Popover
       title={t(popupTitle)}
       // below logic ensures that back button is visible only if there are other modals open before this.
-      onBack={openModalCount === 1 ? undefined : () => closeModal('editGasFee')}
+      onBack={
+        openModalCount === 1 ? undefined : () => closeModal(['editGasFee'])
+      }
       onClose={closeAllModals}
       className="edit-gas-fee-popover"
     >


### PR DESCRIPTION
Fixes https://github.com/MetaMask/metamask-extension/issues/14293

The `closeModal` method in `transaction-modal.js` expects an array, but was being passed a string in a couple of places, causing a bug where the modal would not close.