### PR TITLE
TabBar: prevent text from wrapping early

### DIFF
--- a/ui/components/app/tab-bar/index.scss
+++ b/ui/components/app/tab-bar/index.scss
@@ -38,6 +38,7 @@
     &__content {
       padding: 12px 18px;
       display: flex;
+      flex: 1 1 auto;
       align-items: center;
       position: relative;
 


### PR DESCRIPTION
## Explanation

Following https://github.com/MetaMask/metamask-extension/pull/14348, some text is now wrapping too early. This PR fixes the early text wrap.

## More information

See: [#67890](https://github.com/MetaMask/metamask-extension/pull/14348)

### Before

<img width="364" alt="Screenshot 2022-04-05 at 11 03 27 PM" src="https://user-images.githubusercontent.com/20778143/161881892-7be0afb4-c8ab-44f6-b846-15d871f16eb6.png">

### After

<img width="362" alt="Screenshot 2022-04-05 at 11 03 33 PM" src="https://user-images.githubusercontent.com/20778143/161881967-d13ed430-2f72-440a-b1bc-c9d0e2f60a92.png">
