### PR TITLE
Dark Mode : Add OS option in theme selection dropdown

### DIFF
--- a/app/_locales/de/messages.json
+++ b/app/_locales/de/messages.json
@@ -797,9 +797,6 @@
   "decryptRequest": {
     "message": "Anfrage entschlüsseln"
   },
-  "defaultTheme": {
-    "message": "Standard"
-  },
   "delete": {
     "message": "Löschen"
   },

--- a/app/_locales/el/messages.json
+++ b/app/_locales/el/messages.json
@@ -797,9 +797,6 @@
   "decryptRequest": {
     "message": "Αίτημα αποκρυπτογράφησης"
   },
-  "defaultTheme": {
-    "message": "Προεπιλεγμένο"
-  },
   "delete": {
     "message": "Διαγραφή"
   },

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -804,9 +804,6 @@
   "decryptRequest": {
     "message": "Decrypt request"
   },
-  "defaultTheme": {
-    "message": "Default"
-  },
   "delete": {
     "message": "Delete"
   },
@@ -1713,6 +1710,9 @@
   },
   "levelArrow": {
     "message": "level arrow"
+  },
+  "lightTheme": {
+    "message": "Light"
   },
   "likeToImportTokens": {
     "message": "Would you like to import these tokens?"

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -2330,6 +2330,9 @@
   "origin": {
     "message": "Origin"
   },
+  "osTheme": {
+    "message": "OS"
+  },
   "padlock": {
     "message": "Padlock"
   },

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -2331,7 +2331,7 @@
     "message": "Origin"
   },
   "osTheme": {
-    "message": "OS"
+    "message": "Match system"
   },
   "padlock": {
     "message": "Padlock"

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -2331,7 +2331,7 @@
     "message": "Origin"
   },
   "osTheme": {
-    "message": "System Preference"
+    "message": "System"
   },
   "padlock": {
     "message": "Padlock"

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -2331,7 +2331,7 @@
     "message": "Origin"
   },
   "osTheme": {
-    "message": "Match system"
+    "message": "System Preference"
   },
   "padlock": {
     "message": "Padlock"

--- a/app/_locales/es/messages.json
+++ b/app/_locales/es/messages.json
@@ -797,9 +797,6 @@
   "decryptRequest": {
     "message": "Descifrar solicitud"
   },
-  "defaultTheme": {
-    "message": "Predeterminado"
-  },
   "delete": {
     "message": "Eliminar"
   },

--- a/app/_locales/fr/messages.json
+++ b/app/_locales/fr/messages.json
@@ -797,9 +797,6 @@
   "decryptRequest": {
     "message": "Décrypter la demande"
   },
-  "defaultTheme": {
-    "message": "Par défaut"
-  },
   "delete": {
     "message": "Supprimer"
   },

--- a/app/_locales/hi/messages.json
+++ b/app/_locales/hi/messages.json
@@ -797,9 +797,6 @@
   "decryptRequest": {
     "message": "अनुरोध डिक्रिप्ट करें"
   },
-  "defaultTheme": {
-    "message": "डिफ़ॉल्ट"
-  },
   "delete": {
     "message": "हटाएँ"
   },

--- a/app/_locales/id/messages.json
+++ b/app/_locales/id/messages.json
@@ -797,9 +797,6 @@
   "decryptRequest": {
     "message": "Dekrip permintaan"
   },
-  "defaultTheme": {
-    "message": "Awal"
-  },
   "delete": {
     "message": "Hapus"
   },

--- a/app/_locales/ja/messages.json
+++ b/app/_locales/ja/messages.json
@@ -797,9 +797,6 @@
   "decryptRequest": {
     "message": "リクエストを解読"
   },
-  "defaultTheme": {
-    "message": "デフォルト"
-  },
   "delete": {
     "message": "削除"
   },

--- a/app/_locales/ko/messages.json
+++ b/app/_locales/ko/messages.json
@@ -797,9 +797,6 @@
   "decryptRequest": {
     "message": "암호 해독 요청"
   },
-  "defaultTheme": {
-    "message": "기본값"
-  },
   "delete": {
     "message": "삭제"
   },

--- a/app/_locales/pt/messages.json
+++ b/app/_locales/pt/messages.json
@@ -797,9 +797,6 @@
   "decryptRequest": {
     "message": "Solicitação de descriptografia"
   },
-  "defaultTheme": {
-    "message": "Padrão"
-  },
   "delete": {
     "message": "Excluir"
   },

--- a/app/_locales/ru/messages.json
+++ b/app/_locales/ru/messages.json
@@ -797,9 +797,6 @@
   "decryptRequest": {
     "message": "Расшифровать запрос"
   },
-  "defaultTheme": {
-    "message": "По умолчанию"
-  },
   "delete": {
     "message": "Удалить"
   },

--- a/app/_locales/tl/messages.json
+++ b/app/_locales/tl/messages.json
@@ -797,9 +797,6 @@
   "decryptRequest": {
     "message": "I-decrypt ang request"
   },
-  "defaultTheme": {
-    "message": "Default"
-  },
   "delete": {
     "message": "I-delete"
   },

--- a/app/_locales/tr/messages.json
+++ b/app/_locales/tr/messages.json
@@ -797,9 +797,6 @@
   "decryptRequest": {
     "message": "Şifre çözme talebi"
   },
-  "defaultTheme": {
-    "message": "Varsayılan"
-  },
   "delete": {
     "message": "Sil"
   },

--- a/app/_locales/vi/messages.json
+++ b/app/_locales/vi/messages.json
@@ -797,9 +797,6 @@
   "decryptRequest": {
     "message": "Giải mã yêu cầu"
   },
-  "defaultTheme": {
-    "message": "Mặc định"
-  },
   "delete": {
     "message": "Xóa"
   },

--- a/app/_locales/zh/messages.json
+++ b/app/_locales/zh/messages.json
@@ -797,9 +797,6 @@
   "decryptRequest": {
     "message": "解密请求"
   },
-  "defaultTheme": {
-    "message": "默认"
-  },
   "delete": {
     "message": "删除"
   },

--- a/app/scripts/controllers/preferences.js
+++ b/app/scripts/controllers/preferences.js
@@ -68,7 +68,7 @@ export default class PreferencesController {
       ledgerTransportType: window.navigator.hid
         ? LEDGER_TRANSPORT_TYPES.WEBHID
         : LEDGER_TRANSPORT_TYPES.U2F,
-      theme: 'default',
+      theme: 'light',
       ...opts.initState,
     };
 

--- a/app/scripts/controllers/preferences.test.js
+++ b/app/scripts/controllers/preferences.test.js
@@ -353,14 +353,14 @@ describe('preferences controller', function () {
   });
 
   describe('setTheme', function () {
-    it('should default to value "default"', function () {
+    it('should default to value "light"', function () {
       const state = preferencesController.store.getState();
-      assert.equal(state.theme, 'default');
+      assert.equal(state.theme, 'light');
     });
 
     it('should set the setTheme property in state', function () {
       const state = preferencesController.store.getState();
-      assert.equal(state.theme, 'default');
+      assert.equal(state.theme, 'light');
       preferencesController.setTheme('dark');
       assert.equal(preferencesController.store.getState().theme, 'dark');
     });

--- a/test/helpers/setup-helper.js
+++ b/test/helpers/setup-helper.js
@@ -70,6 +70,10 @@ Object.assign(window, { fetch, Headers, Request, Response });
 window.localStorage = {
   removeItem: () => null,
 };
+
+// used for native dark/light mode detection
+window.matchMedia = () => true;
+
 // override @metamask/logo
 window.requestAnimationFrame = () => undefined;
 

--- a/ui/pages/routes/routes.component.js
+++ b/ui/pages/routes/routes.component.js
@@ -111,8 +111,8 @@ export default class Routes extends Component {
       if (theme === THEME_TYPE.OS) {
         const osTheme = window?.matchMedia('(prefers-color-scheme: dark)')
           ?.matches
-          ? 'dark'
-          : 'default';
+          ? THEME_TYPE.DARK
+          : THEME_TYPE.DEFAULT;
 
         document.documentElement.setAttribute('data-theme', osTheme);
       } else {

--- a/ui/pages/routes/routes.component.js
+++ b/ui/pages/routes/routes.component.js
@@ -105,16 +105,20 @@ export default class Routes extends Component {
     metricsEvent: PropTypes.func,
   };
 
+  handleOsTheme() {
+    const osTheme = window?.matchMedia('(prefers-color-scheme: dark)')?.matches
+      ? THEME_TYPE.DARK
+      : THEME_TYPE.LIGHT;
+
+    document.documentElement.setAttribute('data-theme', osTheme);
+  }
+
   componentDidUpdate(prevProps) {
     const { theme } = this.props;
+
     if (theme !== prevProps.theme) {
       if (theme === THEME_TYPE.OS) {
-        const osTheme = window?.matchMedia('(prefers-color-scheme: dark)')
-          ?.matches
-          ? THEME_TYPE.DARK
-          : THEME_TYPE.LIGHT;
-
-        document.documentElement.setAttribute('data-theme', osTheme);
+        this.handleOsTheme();
       } else {
         document.documentElement.setAttribute('data-theme', theme);
       }
@@ -138,7 +142,11 @@ export default class Routes extends Component {
         pageChanged(locationObj.pathname);
       }
     });
-    document.documentElement.setAttribute('data-theme', theme);
+    if (theme === THEME_TYPE.OS) {
+      this.handleOsTheme();
+    } else {
+      document.documentElement.setAttribute('data-theme', theme);
+    }
   }
 
   renderRoutes() {

--- a/ui/pages/routes/routes.component.js
+++ b/ui/pages/routes/routes.component.js
@@ -112,7 +112,7 @@ export default class Routes extends Component {
         const osTheme = window?.matchMedia('(prefers-color-scheme: dark)')
           ?.matches
           ? THEME_TYPE.DARK
-          : THEME_TYPE.DEFAULT;
+          : THEME_TYPE.LIGHT;
 
         document.documentElement.setAttribute('data-theme', osTheme);
       } else {

--- a/ui/pages/routes/routes.component.js
+++ b/ui/pages/routes/routes.component.js
@@ -70,6 +70,7 @@ import ConfirmationPage from '../confirmation';
 import OnboardingFlow from '../onboarding-flow/onboarding-flow';
 import QRHardwarePopover from '../../components/app/qr-hardware-popover';
 import { SEND_STAGES } from '../../ducks/send';
+import { THEME_TYPE } from '../settings/experimental-tab/experimental-tab.constant';
 
 export default class Routes extends Component {
   static propTypes = {
@@ -107,7 +108,16 @@ export default class Routes extends Component {
   componentDidUpdate(prevProps) {
     const { theme } = this.props;
     if (theme !== prevProps.theme) {
-      document.documentElement.setAttribute('data-theme', theme);
+      if (theme === THEME_TYPE.OS) {
+        const osTheme = window?.matchMedia('(prefers-color-scheme: dark)')
+          ?.matches
+          ? 'dark'
+          : 'default';
+
+        document.documentElement.setAttribute('data-theme', osTheme);
+      } else {
+        document.documentElement.setAttribute('data-theme', theme);
+      }
     }
   }
 

--- a/ui/pages/settings/experimental-tab/experimental-tab.component.js
+++ b/ui/pages/settings/experimental-tab/experimental-tab.component.js
@@ -7,7 +7,6 @@ import {
 } from '../../../helpers/utils/settings-search';
 import Dropdown from '../../../components/ui/dropdown';
 import { EVENT } from '../../../../shared/constants/metametrics';
-
 import { THEME_TYPE } from './experimental-tab.constant';
 
 export default class ExperimentalTab extends PureComponent {
@@ -245,6 +244,10 @@ export default class ExperimentalTab extends PureComponent {
       {
         name: t('darkTheme'),
         value: THEME_TYPE.DARK,
+      },
+      {
+        name: t('osTheme'),
+        value: THEME_TYPE.OS,
       },
     ];
 

--- a/ui/pages/settings/experimental-tab/experimental-tab.component.js
+++ b/ui/pages/settings/experimental-tab/experimental-tab.component.js
@@ -238,8 +238,8 @@ export default class ExperimentalTab extends PureComponent {
 
     const themesOptions = [
       {
-        name: t('defaultTheme'),
-        value: THEME_TYPE.DEFAULT,
+        name: t('lightTheme'),
+        value: THEME_TYPE.LIGHT,
       },
       {
         name: t('darkTheme'),

--- a/ui/pages/settings/experimental-tab/experimental-tab.constant.js
+++ b/ui/pages/settings/experimental-tab/experimental-tab.constant.js
@@ -1,4 +1,5 @@
 export const THEME_TYPE = {
   DEFAULT: 'default',
   DARK: 'dark',
+  OS: 'os',
 };

--- a/ui/pages/settings/experimental-tab/experimental-tab.constant.js
+++ b/ui/pages/settings/experimental-tab/experimental-tab.constant.js
@@ -1,5 +1,5 @@
 export const THEME_TYPE = {
-  DEFAULT: 'default',
+  LIGHT: 'light',
   DARK: 'dark',
   OS: 'os',
 };


### PR DESCRIPTION
## Explanation

Adds an OS option in the theme selection dropdown.

## Screenshots/Screencaps

![image](https://user-images.githubusercontent.com/13910212/162057691-44955888-d961-464f-a57b-147dd5720225.png)


## Manual testing steps

- Go to experimental tab
- Switch to `OS`
- Theme should match your OS theme

