### PR TITLE
Updating info ActionableMessage type to default

### DIFF
--- a/ui/pages/import-token/import-token.component.js
+++ b/ui/pages/import-token/import-token.component.js
@@ -419,7 +419,7 @@ class ImportToken extends Component {
       <div className="import-token__custom-token-form">
         {TOKEN_DETECTION_V2 ? (
           <ActionableMessage
-            type={isTokenDetectionSupported ? 'warning' : 'info'}
+            type={isTokenDetectionSupported ? 'warning' : 'default'}
             message={t(
               isTokenDetectionSupported
                 ? 'customTokenWarningInTokenDetectionNetwork'

--- a/ui/pages/import-token/import-token.component.js
+++ b/ui/pages/import-token/import-token.component.js
@@ -73,7 +73,7 @@ class ImportToken extends Component {
     /**
      * Boolean flag that shows/hides the search tab.
      */
-    showSearchTab: PropTypes.bool.isRequired,
+    showSearchTab: PropTypes.bool,
 
     /**
      * The most recent overview page route, which is 'navigated' to when closing the modal.

--- a/ui/pages/import-token/import-token.component.js
+++ b/ui/pages/import-token/import-token.component.js
@@ -73,7 +73,7 @@ class ImportToken extends Component {
     /**
      * Boolean flag that shows/hides the search tab.
      */
-    showSearchTab: PropTypes.bool,
+    showSearchTab: PropTypes.bool.isRequired,
 
     /**
      * The most recent overview page route, which is 'navigated' to when closing the modal.

--- a/ui/pages/import-token/import-token.container.js
+++ b/ui/pages/import-token/import-token.container.js
@@ -29,7 +29,7 @@ const mapStateToProps = (state) => {
 
   const tokenDetectionV2Supported =
     process.env.TOKEN_DETECTION_V2 && getIsTokenDetectionSupported(state);
-    const showSearchTab =
+  const showSearchTab =
     getIsMainnet(state) || tokenDetectionV2Supported || process.env.IN_TEST;
 
   return {

--- a/ui/pages/import-token/import-token.container.js
+++ b/ui/pages/import-token/import-token.container.js
@@ -30,7 +30,9 @@ const mapStateToProps = (state) => {
   const tokenDetectionV2Supported =
     process.env.TOKEN_DETECTION_V2 && getIsTokenDetectionSupported(state);
   const showSearchTab =
-    getIsMainnet(state) || tokenDetectionV2Supported || process.env.IN_TEST;
+    getIsMainnet(state) ||
+    tokenDetectionV2Supported ||
+    Boolean(process.env.IN_TEST);
 
   return {
     identities,

--- a/ui/pages/import-token/import-token.container.js
+++ b/ui/pages/import-token/import-token.container.js
@@ -10,6 +10,7 @@ import {
   getRpcPrefsForCurrentProvider,
   getIsTokenDetectionSupported,
   getTokenDetectionSupportNetworkByChainId,
+  getIsMainnet,
 } from '../../selectors/selectors';
 import ImportToken from './import-token.component';
 
@@ -25,8 +26,12 @@ const mapStateToProps = (state) => {
       selectedAddress,
     },
   } = state;
-  const showSearchTab =
-    getIsTokenDetectionSupported(state) || process.env.IN_TEST;
+
+  const tokenDetectionV2Supported =
+    process.env.TOKEN_DETECTION_V2 && getIsTokenDetectionSupported(state);
+    const showSearchTab =
+    getIsMainnet(state) || tokenDetectionV2Supported || process.env.IN_TEST;
+
   return {
     identities,
     mostRecentOverviewPage: getMostRecentOverviewPage(state),


### PR DESCRIPTION
- Updating ActionableMessage for the token detection message to use the `default` type instead of the old `info` type.
- Removing the `showSearchTab` prop from required as the non-supported networks ended up getting the value undefined and errors are thrown on the console.
- Updating the `showSearchTab` to show only on Ethereum Mainnet when TOKEN_DETECTION_V2 is disabled.