### PR TITLE
Enhanced Gas Fee UI : Fix gas values overlaping with labels

### DIFF
--- a/ui/components/app/edit-gas-fee-popover/edit-gas-tooltip/index.scss
+++ b/ui/components/app/edit-gas-fee-popover/edit-gas-tooltip/index.scss
@@ -26,11 +26,11 @@
 
     &__label {
       white-space: nowrap;
-      width: 50%;
+      min-width: 50%;
     }
 
     &__value {
-      width: 50%;
+      min-width: 50%;
     }
 
     p {
@@ -44,6 +44,7 @@
       div {
         display: flex;
         flex-direction: row;
+        flex-wrap: wrap;
         text-align: left;
       }
     }


### PR DESCRIPTION
## Explanation

Fix the gas values overlaping with the labels while using french lang. on the enhanced gas fee UI.

The text can now wrap next line if it's larger than the parent div.

## More information

* Fixes #14007

## Screenshots/Screencaps

### Before

![image](https://user-images.githubusercontent.com/13910212/162235598-a5ea844b-0137-4bce-b76f-96fe6379c68d.png)


### After

![image](https://user-images.githubusercontent.com/13910212/162235483-bb2608d1-b649-45a5-8428-321bb18c614a.png)
![image](https://user-images.githubusercontent.com/13910212/162236522-4fe64819-695e-470c-abe9-616d38ad9ab5.png)


## Manual testing steps

- Enable the Enhanced Gas Fee UI
- Switch to French
- Try to send a transaction and edit the gas fees

