### PR TITLE
E2e infura requests

### DIFF
--- a/test/e2e/mock-e2e.js
+++ b/test/e2e/mock-e2e.js
@@ -1,8 +1,16 @@
+const blacklistedHosts = [
+  'goerli.infura.io',
+  'kovan.infura.io',
+  'mainnet.infura.io',
+  'rinkeby.infura.io',
+  'ropsten.infura.io',
+];
+
 async function setupMocking(server, testSpecificMock) {
   await server.forAnyRequest().thenPassThrough({
     beforeRequest: (req) => {
       const { host } = req.headers;
-      if (host.endsWith('infura.io')) {
+      if (blacklistedHosts.includes(host)) {
         return {
           url: 'http://localhost:8545',
         };

--- a/test/e2e/mock-e2e.js
+++ b/test/e2e/mock-e2e.js
@@ -1,12 +1,13 @@
 const blacklistedUrls = [
-  'mainnet.infura.io',
-  'ropsten.infura.io',
-  'kovan.infura.io',
-  'rinkeby.infura.io',
-  'goerli.infura.io',
-  'polygon-rpc.com',
-  'mainnet.optimism.io',
   'api.avax.network/ext/bc/C/rpc',
+  'goerli.infura.io',
+  'kovan.infura.io',
+  'mainnet.infura.io',
+  'mainnet.optimism.io',
+  'polygon-rpc.com',
+  'rinkeby.infura.io',
+  'ropsten.infura.io',
+  'rpc.gnosischain.com'
 ];
 
 async function setupMocking(server, testSpecificMock) {

--- a/test/e2e/mock-e2e.js
+++ b/test/e2e/mock-e2e.js
@@ -7,7 +7,7 @@ const blacklistedUrls = [
   'polygon-rpc.com',
   'rinkeby.infura.io',
   'ropsten.infura.io',
-  'rpc.gnosischain.com'
+  'rpc.gnosischain.com',
 ];
 
 async function setupMocking(server, testSpecificMock) {

--- a/test/e2e/mock-e2e.js
+++ b/test/e2e/mock-e2e.js
@@ -7,21 +7,21 @@ const blacklistedUrls = [
   'polygon-rpc.com',
   'mainnet.optimism.io',
   'api.avax.network/ext/bc/C/rpc',
-]
+];
 
 async function setupMocking(server, testSpecificMock) {
   await server.forAnyRequest().thenPassThrough();
 
-  await server
-    .forAnyRequest()
-    .forHost('mainnet.infura.io')
-    .thenPassThrough({
-      beforeRequest: () => {
+  await server.forAnyRequest().thenPassThrough({
+    beforeRequest: (req) => {
+      if (blacklistedUrls.includes(req.headers.host)) {
         return {
           url: 'http://localhost:8545',
         };
-      },
-    });
+      }
+      return {};
+    },
+  });
 
   await server.forPost('https://api.segment.io/v1/batch').thenCallback(() => {
     return {

--- a/test/e2e/mock-e2e.js
+++ b/test/e2e/mock-e2e.js
@@ -136,6 +136,10 @@ async function setupMocking(server, testSpecificMock) {
       };
     });
 
+  await server.forAnyRequest()
+    .forHost('mainnet.infura.io')
+    .thenForwardTo('127.0.0.1:8545')
+
   testSpecificMock(server);
 }
 

--- a/test/e2e/mock-e2e.js
+++ b/test/e2e/mock-e2e.js
@@ -1,31 +1,27 @@
+const blacklistedUrls = [
+  'mainnet.infura.io',
+  'ropsten.infura.io',
+  'kovan.infura.io',
+  'rinkeby.infura.io',
+  'goerli.infura.io',
+  'polygon-rpc.com',
+  'mainnet.optimism.io',
+  'api.avax.network/ext/bc/C/rpc',
+]
+
 async function setupMocking(server, testSpecificMock) {
   await server.forAnyRequest().thenPassThrough();
 
-  await server.forAnyRequest()
-  .forHost('mainnet.infura.io')
-  .thenPassThrough({
-    beforeRequest: () => { 
-      {
+  await server
+    .forAnyRequest()
+    .forHost('mainnet.infura.io')
+    .thenPassThrough({
+      beforeRequest: () => {
         return {
           url: 'http://localhost:8545',
-        }
-      }
-    }
-  })
-
-  /*
-  await server.forAnyRequest()
-  .forHost('mainnet.infura.io')
-  .thenCallback(() => {
-    return {
-      statusCode: 404,
-      json:
-        {
-          error: 'You are not on the correct Network'
-        }
-      }
-    })
-  */
+        };
+      },
+    });
 
   await server.forPost('https://api.segment.io/v1/batch').thenCallback(() => {
     return {

--- a/test/e2e/mock-e2e.js
+++ b/test/e2e/mock-e2e.js
@@ -1,19 +1,8 @@
-const blacklistedUrls = [
-  'api.avax.network/ext/bc/C/rpc',
-  'goerli.infura.io',
-  'kovan.infura.io',
-  'mainnet.infura.io',
-  'mainnet.optimism.io',
-  'polygon-rpc.com',
-  'rinkeby.infura.io',
-  'ropsten.infura.io',
-  'rpc.gnosischain.com',
-];
-
 async function setupMocking(server, testSpecificMock) {
   await server.forAnyRequest().thenPassThrough({
     beforeRequest: (req) => {
-      if (blacklistedUrls.includes(req.headers.host)) {
+      const { host } = req.headers;
+      if (host.includes('infura.io')) {
         return {
           url: 'http://localhost:8545',
         };

--- a/test/e2e/mock-e2e.js
+++ b/test/e2e/mock-e2e.js
@@ -1,6 +1,32 @@
 async function setupMocking(server, testSpecificMock) {
   await server.forAnyRequest().thenPassThrough();
 
+  await server.forAnyRequest()
+  .forHost('mainnet.infura.io')
+  .thenPassThrough({
+    beforeRequest: () => { 
+      {
+        return {
+          url: 'http://localhost:8545',
+        }
+      }
+    }
+  })
+
+  /*
+  await server.forAnyRequest()
+  .forHost('mainnet.infura.io')
+  .thenCallback(() => {
+    return {
+      statusCode: 404,
+      json:
+        {
+          error: 'You are not on the correct Network'
+        }
+      }
+    })
+  */
+
   await server.forPost('https://api.segment.io/v1/batch').thenCallback(() => {
     return {
       statusCode: 200,
@@ -135,10 +161,6 @@ async function setupMocking(server, testSpecificMock) {
         ],
       };
     });
-
-  await server.forAnyRequest()
-    .forHost('mainnet.infura.io')
-    .thenForwardTo('127.0.0.1:8545')
 
   testSpecificMock(server);
 }

--- a/test/e2e/mock-e2e.js
+++ b/test/e2e/mock-e2e.js
@@ -2,7 +2,7 @@ async function setupMocking(server, testSpecificMock) {
   await server.forAnyRequest().thenPassThrough({
     beforeRequest: (req) => {
       const { host } = req.headers;
-      if (host.includes('infura.io')) {
+      if (host.endsWith('infura.io')) {
         return {
           url: 'http://localhost:8545',
         };

--- a/test/e2e/mock-e2e.js
+++ b/test/e2e/mock-e2e.js
@@ -11,8 +11,6 @@ const blacklistedUrls = [
 ];
 
 async function setupMocking(server, testSpecificMock) {
-  await server.forAnyRequest().thenPassThrough();
-
   await server.forAnyRequest().thenPassThrough({
     beforeRequest: (req) => {
       if (blacklistedUrls.includes(req.headers.host)) {


### PR DESCRIPTION
## Explanation
The ultimate goal is get rid of the `setupFetchMocking` server function on the `webdriver/index.js` file, so we get all the API mocking centralized in the `mock-e2e.js` file.

Following the first task, https://github.com/MetaMask/metamask-extension/pull/14353 in this PR we are intercepting all the external calls to different blockchain providers like Infura. Before requests are send, URL is changed to point to Ganache.

- **Before Intercepting**: requests fail when changing to another network different from localhost (test build)

https://user-images.githubusercontent.com/54408225/162262261-3c121b3d-fd4a-493b-8ef6-0426285e3377.mp4

- **After Intercepting**: all requests are intercepted, now pointing Ganache and returning data

https://user-images.githubusercontent.com/54408225/162262292-9586485b-8988-4e8f-96f4-f82b0bcf84b9.mp4

**Note**: data received from these requests is not reliable (as the request body is not updated) and should not be used in replacement of localhost. We are just avoiding making external calls.
