### PR TITLE
Dark Mode : Fix connected account permission icon color

### DIFF
--- a/ui/components/app/connected-accounts-permissions/index.scss
+++ b/ui/components/app/connected-accounts-permissions/index.scss
@@ -28,6 +28,7 @@
       background: none;
       padding: 0;
       margin-left: 8px;
+      color: var(--color-icon-default)
     }
   }
 

--- a/ui/components/app/connected-accounts-permissions/index.scss
+++ b/ui/components/app/connected-accounts-permissions/index.scss
@@ -28,7 +28,7 @@
       background: none;
       padding: 0;
       margin-left: 8px;
-      color: var(--color-icon-default)
+      color: var(--color-icon-default);
     }
   }
 


### PR DESCRIPTION
## More information

* Fixes #14374

## Screenshots/Screencaps

### Before

![image](https://user-images.githubusercontent.com/13910212/162279785-7760843b-fc4b-43b8-b382-77af4cb34680.png)


### After

![image](https://user-images.githubusercontent.com/13910212/162279920-ae751f28-271d-47c9-be36-3f996cb1c696.png)
