### PR TITLE
Use correct casing for "learn more"

### DIFF
--- a/ui/pages/confirmation/templates/flask/snap-confirm/snap-confirm.js
+++ b/ui/pages/confirmation/templates/flask/snap-confirm/snap-confirm.js
@@ -73,7 +73,7 @@ function getValues(pendingApproval, t, actions) {
           },
           {
             element: 'a',
-            children: t('learnMore'),
+            children: t('learnMoreUpperCase'),
             key: 'learnMore-a-href',
             props: {
               href:


### PR DESCRIPTION
## Explanation
Uses the correct "Learn more" casing for snaps.

## Screenshots/Screencaps

<!-- If you're making a change to the UI, make sure to capture a screenshot or a short video showing off your work! -->

### Before

![image](https://user-images.githubusercontent.com/1561200/162468868-0074ee4a-7945-4549-8d1c-85aeb3f08826.png)

### After

![image](https://user-images.githubusercontent.com/1561200/162468584-a0f778e5-27ca-4aa6-a836-26c1de3f5344.png)

## Manual testing steps

- Go to https://filsnap.chainsafe.io/
- Connect
- Try to sign a message
- See that "learn more" is now cased correctly
