### PR TITLE
Add snaps view search

### DIFF
--- a/ui/helpers/utils/settings-search.js
+++ b/ui/helpers/utils/settings-search.js
@@ -15,9 +15,7 @@ export function getSettingsRoutes() {
 
 function getFilteredSettingsRoutes(t, tabMessage) {
   return getSettingsRoutes().filter((routeObject) => {
-    return typeof routeObject.tabMessage === 'function'
-      ? routeObject.tabMessage(t) === tabMessage
-      : routeObject.tabMessage === tabMessage;
+    return routeObject.tabMessage(t) === tabMessage;
   });
 }
 

--- a/ui/helpers/utils/settings-search.js
+++ b/ui/helpers/utils/settings-search.js
@@ -15,10 +15,9 @@ export function getSettingsRoutes() {
 
 function getFilteredSettingsRoutes(t, tabMessage) {
   return getSettingsRoutes().filter((routeObject) => {
-    if (typeof routeObject.tabMessage === 'function') {
-      return routeObject.tabMessage(t) === tabMessage;
-    }
-    return routeObject.tabMessage === tabMessage;
+    return typeof routeObject.tabMessage === 'function'
+      ? routeObject.tabMessage(t) === tabMessage
+      : routeObject.tabMessage === tabMessage;
   });
 }
 

--- a/ui/helpers/utils/settings-search.js
+++ b/ui/helpers/utils/settings-search.js
@@ -14,15 +14,16 @@ export function getSettingsRoutes() {
 }
 
 function getFilteredSettingsRoutes(t, tabMessage) {
-  return getSettingsRoutes().filter(
-    (routeObject) => routeObject.tabMessage(t) === tabMessage,
-  );
+  return getSettingsRoutes().filter((routeObject) => {
+    if (typeof routeObject.tabMessage === 'function') {
+      return routeObject.tabMessage(t) === tabMessage;
+    }
+    return routeObject.tabMessage === tabMessage;
+  });
 }
 
 export function getNumberOfSettingsInSection(t, tabMessage) {
-  return getSettingsRoutes().filter(
-    (routeObject) => routeObject.tabMessage(t) === tabMessage,
-  ).length;
+  return getFilteredSettingsRoutes(t, tabMessage).length;
 }
 
 export function handleSettingsRefs(t, tabMessage, settingsRefs) {

--- a/ui/pages/settings/settings-search-list/settings-search-list.js
+++ b/ui/pages/settings/settings-search-list/settings-search-list.js
@@ -13,11 +13,9 @@ export default function SettingsSearchList({ results, onClickSetting }) {
   return (
     <div className="settings-page__header__search__list">
       {results.slice(0, 5).map((result) => {
-        const { icon, tabMessage, sectionMessage, route, isSnap } = result;
-        const tab = isSnap ? tabMessage : tabMessage(t);
-        const section = isSnap ? sectionMessage : sectionMessage(t);
+        const { icon, tabMessage, sectionMessage, route } = result;
         return (
-          Boolean(icon || tab || section) && (
+          Boolean(icon || tabMessage || sectionMessage) && (
             <div key={`settings_${route}`}>
               <div
                 className="settings-page__header__search__list__item"
@@ -36,11 +34,11 @@ export default function SettingsSearchList({ results, onClickSetting }) {
                     'settings-page__header__search__list__item__tab',
                     {
                       'settings-page__header__search__list__item__tab-multiple-lines':
-                        tab === t('securityAndPrivacy'),
+                        tabMessage(t) === t('securityAndPrivacy'),
                     },
                   )}
                 >
-                  {tab}
+                  {tabMessage(t)}
                 </span>
                 <IconCaretRight
                   size={16}
@@ -52,11 +50,12 @@ export default function SettingsSearchList({ results, onClickSetting }) {
                     'settings-page__header__search__list__item__section',
                     {
                       'settings-page__header__search__list__item__section-multiple-lines':
-                        tab === t('securityAndPrivacy') || tab === t('alerts'),
+                        tabMessage(t) === t('securityAndPrivacy') ||
+                        tabMessage(t) === t('alerts'),
                     },
                   )}
                 >
-                  {section}
+                  {sectionMessage(t)}
                 </span>
               </div>
             </div>

--- a/ui/pages/settings/settings-search-list/settings-search-list.js
+++ b/ui/pages/settings/settings-search-list/settings-search-list.js
@@ -13,9 +13,11 @@ export default function SettingsSearchList({ results, onClickSetting }) {
   return (
     <div className="settings-page__header__search__list">
       {results.slice(0, 5).map((result) => {
-        const { icon, tabMessage, sectionMessage, route } = result;
+        const { icon, tabMessage, sectionMessage, route, isSnap } = result;
+        const tab = isSnap ? tabMessage : tabMessage(t);
+        const section = isSnap ? sectionMessage : sectionMessage(t);
         return (
-          Boolean(icon || tabMessage || sectionMessage) && (
+          Boolean(icon || tab || section) && (
             <div key={`settings_${route}`}>
               <div
                 className="settings-page__header__search__list__item"
@@ -34,11 +36,11 @@ export default function SettingsSearchList({ results, onClickSetting }) {
                     'settings-page__header__search__list__item__tab',
                     {
                       'settings-page__header__search__list__item__tab-multiple-lines':
-                        tabMessage(t) === t('securityAndPrivacy'),
+                        tab === t('securityAndPrivacy'),
                     },
                   )}
                 >
-                  {tabMessage(t)}
+                  {tab}
                 </span>
                 <IconCaretRight
                   size={16}
@@ -50,12 +52,11 @@ export default function SettingsSearchList({ results, onClickSetting }) {
                     'settings-page__header__search__list__item__section',
                     {
                       'settings-page__header__search__list__item__section-multiple-lines':
-                        tabMessage(t) === t('securityAndPrivacy') ||
-                        tabMessage(t) === t('alerts'),
+                        tab === t('securityAndPrivacy') || tab === t('alerts'),
                     },
                   )}
                 >
-                  {sectionMessage(t)}
+                  {section}
                 </span>
               </div>
             </div>

--- a/ui/pages/settings/settings-search/settings-search.js
+++ b/ui/pages/settings/settings-search/settings-search.js
@@ -25,10 +25,10 @@ export default function SettingsSearch({
     'var(--color-icon-muted)',
   );
 
-  let settingsRoutesListArray = Object.values(settingsRoutesList);
+  const settingsRoutesListArray = Object.values(settingsRoutesList);
   ///: BEGIN:ONLY_INCLUDE_IN(flask)
   const snaps = useSelector(getSnapsRouteObjects);
-  settingsRoutesListArray = [...settingsRoutesListArray, ...snaps];
+  settingsRoutesListArray.push(...snaps);
   ///: END:ONLY_INCLUDE_IN
   const settingsSearchFuse = new Fuse(settingsRoutesListArray, {
     shouldSort: true,
@@ -38,10 +38,7 @@ export default function SettingsSearch({
     maxPatternLength: 32,
     minMatchCharLength: 1,
     keys: ['tabMessage', 'sectionMessage', 'descriptionMessage'],
-    getFn: (routeObject, path) =>
-      typeof routeObject[path] === 'function'
-        ? routeObject[path](t)
-        : routeObject[path],
+    getFn: (routeObject, path) => routeObject[path](t),
   });
 
   const handleSearch = (_searchQuery) => {
@@ -59,7 +56,7 @@ export default function SettingsSearch({
     const fuseSearchResult = settingsSearchFuse.search(sanitizedSearchQuery);
     const addressSearchResult = settingsRoutesListArray.filter((routes) => {
       return (
-        routes.tab &&
+        routes.tabMessage &&
         sanitizedSearchQuery &&
         isEqualCaseInsensitive(routes.tab, sanitizedSearchQuery)
       );

--- a/ui/pages/settings/settings-search/settings-search.js
+++ b/ui/pages/settings/settings-search/settings-search.js
@@ -24,7 +24,7 @@ export default function SettingsSearch({
   let settingsRoutesListArray = Object.values(settingsRoutesList);
   ///: BEGIN:ONLY_INCLUDE_IN(flask)
   const snaps = useSelector(getSnapsRouteObjects);
-  settingsRoutesListArray = [settingsRoutesListArray, ...snaps];
+  settingsRoutesListArray = [...settingsRoutesListArray, ...snaps];
   ///: END:ONLY_INCLUDE_IN
   const settingsSearchFuse = new Fuse(settingsRoutesListArray, {
     shouldSort: true,

--- a/ui/pages/settings/settings-search/settings-search.js
+++ b/ui/pages/settings/settings-search/settings-search.js
@@ -1,5 +1,7 @@
 import React, { useState, useContext } from 'react';
+///: BEGIN:ONLY_INCLUDE_IN(flask)
 import { useSelector } from 'react-redux';
+///: END:ONLY_INCLUDE_IN
 import PropTypes from 'prop-types';
 import Fuse from 'fuse.js';
 import InputAdornment from '@material-ui/core/InputAdornment';
@@ -7,7 +9,9 @@ import TextField from '../../../components/ui/text-field';
 import { I18nContext } from '../../../contexts/i18n';
 import SearchIcon from '../../../components/ui/search-icon';
 import { isEqualCaseInsensitive } from '../../../../shared/modules/string-utils';
+///: BEGIN:ONLY_INCLUDE_IN(flask)
 import { getSnapsRouteObjects } from '../../../selectors';
+///: END:ONLY_INCLUDE_IN
 
 export default function SettingsSearch({
   onSearch,

--- a/ui/pages/settings/settings-search/settings-search.js
+++ b/ui/pages/settings/settings-search/settings-search.js
@@ -1,4 +1,5 @@
 import React, { useState, useContext } from 'react';
+import { useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
 import Fuse from 'fuse.js';
 import InputAdornment from '@material-ui/core/InputAdornment';
@@ -6,6 +7,7 @@ import TextField from '../../../components/ui/text-field';
 import { I18nContext } from '../../../contexts/i18n';
 import SearchIcon from '../../../components/ui/search-icon';
 import { isEqualCaseInsensitive } from '../../../../shared/modules/string-utils';
+import { getSnapsRouteObjects } from '../../../selectors';
 
 export default function SettingsSearch({
   onSearch,
@@ -19,7 +21,11 @@ export default function SettingsSearch({
     'var(--color-icon-muted)',
   );
 
-  const settingsRoutesListArray = Object.values(settingsRoutesList);
+  let settingsRoutesListArray = Object.values(settingsRoutesList);
+  ///: BEGIN:ONLY_INCLUDE_IN(flask)
+  const snaps = useSelector(getSnapsRouteObjects);
+  settingsRoutesListArray = [settingsRoutesListArray, ...snaps];
+  ///: END:ONLY_INCLUDE_IN
   const settingsSearchFuse = new Fuse(settingsRoutesListArray, {
     shouldSort: true,
     threshold: 0.2,
@@ -28,7 +34,10 @@ export default function SettingsSearch({
     maxPatternLength: 32,
     minMatchCharLength: 1,
     keys: ['tabMessage', 'sectionMessage', 'descriptionMessage'],
-    getFn: (routeObject, path) => routeObject[path](t),
+    getFn: (routeObject, path) =>
+      typeof routeObject[path] === 'function'
+        ? routeObject[path](t)
+        : routeObject[path],
   });
 
   const handleSearch = (_searchQuery) => {

--- a/ui/pages/settings/settings.component.test.js
+++ b/ui/pages/settings/settings.component.test.js
@@ -1,6 +1,8 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { mount, shallow } from 'enzyme';
+import { Provider } from 'react-redux';
 import TextField from '../../components/ui/text-field';
+import configureStore from '../../store/store';
 import Settings from './settings.container';
 import SettingsSearch from './settings-search';
 
@@ -37,8 +39,15 @@ describe('SettingsPage', () => {
   });
 
   it('should render search correctly', () => {
-    wrapper = shallow(
-      <SettingsSearch onSearch={() => undefined} settingsRoutesList={[]} />,
+    const store = configureStore({
+      metamask: {
+        snaps: {},
+      },
+    });
+    wrapper = mount(
+      <Provider store={store}>
+        <SettingsSearch onSearch={() => undefined} settingsRoutesList={[]} />
+      </Provider>,
       {
         context: {
           t: (s) => `${s}`,

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -65,6 +65,7 @@ import {
   getLedgerTransportStatus,
 } from '../ducks/app/app';
 import { isEqualCaseInsensitive } from '../../shared/modules/string-utils';
+import { SNAPS_VIEW_ROUTE } from '../helpers/constants/routes';
 
 /**
  * One of the only remaining valid uses of selecting the network subkey of the
@@ -705,6 +706,21 @@ export function getShowWhatsNewPopup(state) {
 export function getSnaps(state) {
   return state.metamask.snaps;
 }
+
+export const getSnapsRouteObjects = createSelector(getSnaps, (snaps) => {
+  Object.values(snaps).map((snap) => {
+    return {
+      isSnap: true,
+      tabMessage: snap.manifest.proposedName,
+      descriptionMessage: snap.manifest.description,
+      sectionMessage: snap.manifest.description,
+      route: `${SNAPS_VIEW_ROUTE}/${window.btoa(
+        unescape(encodeURIComponent(snap.id)),
+      )}`,
+      icon: 'fa fa-flask',
+    };
+  });
+});
 ///: END:ONLY_INCLUDE_IN
 
 /**

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -66,6 +66,7 @@ import {
 } from '../ducks/app/app';
 import { isEqualCaseInsensitive } from '../../shared/modules/string-utils';
 import { SNAPS_VIEW_ROUTE } from '../helpers/constants/routes';
+import { getSettingsRoutes } from '../helpers/utils/settings-search';
 
 /**
  * One of the only remaining valid uses of selecting the network subkey of the
@@ -708,18 +709,20 @@ export function getSnaps(state) {
 }
 
 export const getSnapsRouteObjects = createSelector(getSnaps, (snaps) => {
-  Object.values(snaps).map((snap) => {
-    return {
-      isSnap: true,
-      tabMessage: snap.manifest.proposedName,
-      descriptionMessage: snap.manifest.description,
-      sectionMessage: snap.manifest.description,
-      route: `${SNAPS_VIEW_ROUTE}/${window.btoa(
-        unescape(encodeURIComponent(snap.id)),
-      )}`,
-      icon: 'fa fa-flask',
-    };
-  });
+  return [
+    ...Object.values(snaps).map((snap) => {
+      return {
+        isSnap: true,
+        tabMessage: snap.manifest.proposedName,
+        descriptionMessage: snap.manifest.description,
+        sectionMessage: snap.manifest.description,
+        route: `${SNAPS_VIEW_ROUTE}/${window.btoa(
+          unescape(encodeURIComponent(snap.id)),
+        )}`,
+        icon: 'fa fa-flask',
+      };
+    }),
+  ];
 });
 ///: END:ONLY_INCLUDE_IN
 

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -66,7 +66,6 @@ import {
 } from '../ducks/app/app';
 import { isEqualCaseInsensitive } from '../../shared/modules/string-utils';
 import { SNAPS_VIEW_ROUTE } from '../helpers/constants/routes';
-import { getSettingsRoutes } from '../helpers/utils/settings-search';
 
 /**
  * One of the only remaining valid uses of selecting the network subkey of the

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -712,10 +712,9 @@ export function getSnaps(state) {
 export const getSnapsRouteObjects = createSelector(getSnaps, (snaps) => {
   return Object.values(snaps).map((snap) => {
     return {
-      isSnap: true,
-      tabMessage: snap.manifest.proposedName,
-      descriptionMessage: snap.manifest.description,
-      sectionMessage: snap.manifest.description,
+      tabMessage: () => snap.manifest.proposedName,
+      descriptionMessage: () => snap.manifest.description,
+      sectionMessage: () => snap.manifest.description,
       route: `${SNAPS_VIEW_ROUTE}/${window.btoa(
         unescape(encodeURIComponent(snap.id)),
       )}`,

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -65,7 +65,9 @@ import {
   getLedgerTransportStatus,
 } from '../ducks/app/app';
 import { isEqualCaseInsensitive } from '../../shared/modules/string-utils';
+///: BEGIN:ONLY_INCLUDE_IN(flask)
 import { SNAPS_VIEW_ROUTE } from '../helpers/constants/routes';
+///: END:ONLY_INCLUDE_IN
 
 /**
  * One of the only remaining valid uses of selecting the network subkey of the

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -709,20 +709,18 @@ export function getSnaps(state) {
 }
 
 export const getSnapsRouteObjects = createSelector(getSnaps, (snaps) => {
-  return [
-    ...Object.values(snaps).map((snap) => {
-      return {
-        isSnap: true,
-        tabMessage: snap.manifest.proposedName,
-        descriptionMessage: snap.manifest.description,
-        sectionMessage: snap.manifest.description,
-        route: `${SNAPS_VIEW_ROUTE}/${window.btoa(
-          unescape(encodeURIComponent(snap.id)),
-        )}`,
-        icon: 'fa fa-flask',
-      };
-    }),
-  ];
+  return Object.values(snaps).map((snap) => {
+    return {
+      isSnap: true,
+      tabMessage: snap.manifest.proposedName,
+      descriptionMessage: snap.manifest.description,
+      sectionMessage: snap.manifest.description,
+      route: `${SNAPS_VIEW_ROUTE}/${window.btoa(
+        unescape(encodeURIComponent(snap.id)),
+      )}`,
+      icon: 'fa fa-flask',
+    };
+  });
 });
 ///: END:ONLY_INCLUDE_IN
 


### PR DESCRIPTION
Search for individual snaps is added with this PR. Route objects are created and merged with `SETTINGS_CONSTANTS` to create a list that includes snaps for the search list to display. No refs were used in this implementation as we're simply routing to the page itself, specific section search within a snap view page will be added in future iterations.

Testing:
- Run `yarn start --build-type flask` to create a build
- Load into chrome
- Install a snap (or more) via [snaplist](snaplist.org)
- In settings search, search for an installed snap using its name
- Observe changes
