### PR TITLE
MetaMetrics: Identify 'number_of_tokens' user trait

### DIFF
--- a/app/scripts/controllers/metametrics.js
+++ b/app/scripts/controllers/metametrics.js
@@ -625,20 +625,12 @@ export default class MetaMetricsController {
    * @returns number of unique token addresses
    */
   _getNumberOfTokens(metamaskState) {
-    const allUniqueAddresses = Object.values(metamaskState.allTokens).reduce(
-      (result, tokensByAccountByChain) => {
-        Object.values(tokensByAccountByChain).forEach((tokensByAccount) => {
-          tokensByAccount.forEach((token) => {
-            result.add(token.address);
-          });
-        });
-
-        return result;
+    return Object.values(metamaskState.allTokens).reduce(
+      (result, accountsByChain) => {
+        return result + sum(Object.values(accountsByChain).map(size));
       },
-      new Set(),
+      0,
     );
-
-    return allUniqueAddresses.size;
   }
 
   /**

--- a/app/scripts/controllers/metametrics.js
+++ b/app/scripts/controllers/metametrics.js
@@ -554,10 +554,10 @@ export default class MetaMetricsController {
       [TRAITS.NFT_AUTODETECTION_ENABLED]: metamaskState.useCollectibleDetection,
       [TRAITS.NUMBER_OF_ACCOUNTS]: Object.values(metamaskState.identities)
         .length,
-      [TRAITS.NUMBER_OF_TOKENS]: this._getNumberOfTokens(metamaskState),
       [TRAITS.NUMBER_OF_NFT_COLLECTIONS]: this._getNumberOfNFtCollection(
         metamaskState,
       ),
+      [TRAITS.NUMBER_OF_TOKENS]: this._getNumberOfTokens(metamaskState),
       [TRAITS.OPENSEA_API_ENABLED]: metamaskState.openSeaEnabled,
       [TRAITS.THREE_BOX_ENABLED]: metamaskState.threeBoxSyncingAllowed,
     };

--- a/app/scripts/controllers/metametrics.js
+++ b/app/scripts/controllers/metametrics.js
@@ -554,6 +554,7 @@ export default class MetaMetricsController {
       [TRAITS.NFT_AUTODETECTION_ENABLED]: metamaskState.useCollectibleDetection,
       [TRAITS.NUMBER_OF_ACCOUNTS]: Object.values(metamaskState.identities)
         .length,
+      [TRAITS.NUMBER_OF_TOKENS]: this._getNumberOfTokens(metamaskState),
       [TRAITS.NUMBER_OF_NFT_COLLECTIONS]: this._getNumberOfNFtCollection(
         metamaskState,
       ),
@@ -617,6 +618,27 @@ export default class MetaMetricsController {
       .map((collectible) => collectible.address);
     const unique = [...new Set(allAddresses)];
     return unique.length;
+  }
+
+  /**
+   * @param {object} metamaskState
+   * @returns number of unique token addresses
+   */
+  _getNumberOfTokens(metamaskState) {
+    const allUniqueAddresses = Object.values(metamaskState.allTokens).reduce(
+      (result, tokensByAccountByChain) => {
+        Object.values(tokensByAccountByChain).forEach((tokensByAccount) => {
+          tokensByAccount.forEach((token) => {
+            result.add(token.address);
+          });
+        });
+
+        return result;
+      },
+      new Set(),
+    );
+
+    return allUniqueAddresses.size;
   }
 
   /**

--- a/app/scripts/controllers/metametrics.test.js
+++ b/app/scripts/controllers/metametrics.test.js
@@ -737,8 +737,8 @@ describe('MetaMetricsController', function () {
       assert.deepEqual(updatedTraits, {
         [TRAITS.ADDRESS_BOOK_ENTRIES]: 4,
         [TRAITS.NUMBER_OF_ACCOUNTS]: 3,
-        [TRAITS.OPENSEA_API_ENABLED]: false,
         [TRAITS.NUMBER_OF_TOKENS]: 1,
+        [TRAITS.OPENSEA_API_ENABLED]: false,
       });
     });
 

--- a/app/scripts/controllers/metametrics.test.js
+++ b/app/scripts/controllers/metametrics.test.js
@@ -690,7 +690,7 @@ describe('MetaMetricsController', function () {
         [TRAITS.NFT_AUTODETECTION_ENABLED]: false,
         [TRAITS.NUMBER_OF_ACCOUNTS]: 2,
         [TRAITS.NUMBER_OF_NFT_COLLECTIONS]: 3,
-        [TRAITS.NUMBER_OF_TOKENS]: 3,
+        [TRAITS.NUMBER_OF_TOKENS]: 5,
         [TRAITS.OPENSEA_API_ENABLED]: true,
         [TRAITS.THREE_BOX_ENABLED]: false,
       });

--- a/app/scripts/controllers/metametrics.test.js
+++ b/app/scripts/controllers/metametrics.test.js
@@ -611,6 +611,34 @@ describe('MetaMetricsController', function () {
 
   describe('_buildUserTraitsObject', function () {
     it('should return full user traits object on first call', function () {
+      const MOCK_ALL_TOKENS = {
+        '0x1': {
+          '0x1235ce91d74254f29d4609f25932fe6d97bf4842': [
+            {
+              address: '0xd2cea331e5f5d8ee9fb1055c297795937645de91',
+            },
+            {
+              address: '0xabc66500c84A76Ad7e9c93437bFc5Ac33E2DDaE9',
+            },
+          ],
+          '0xe364b0f9d1879e53e8183055c9d7dd2b7375d86b': [
+            {
+              address: '0xd2cea331e5f5d8ee9fb1055c297795937645de91',
+            },
+          ],
+        },
+        '0x4': {
+          '0x1235ce91d74254f29d4609f25932fe6d97bf4842': [
+            {
+              address: '0xd2cea331e5f5d8ee9fb1055c297795937645de91',
+            },
+            {
+              address: '0x12317F958D2ee523a2206206994597C13D831ec7',
+            },
+          ],
+        },
+      };
+
       const metaMetricsController = getMetaMetricsController();
       const traits = metaMetricsController._buildUserTraitsObject({
         addressBook: {
@@ -643,6 +671,7 @@ describe('MetaMetricsController', function () {
             ],
           },
         },
+        allTokens: MOCK_ALL_TOKENS,
         frequentRpcListDetail: [
           { chainId: MAINNET_CHAIN_ID },
           { chainId: ROPSTEN_CHAIN_ID },
@@ -661,6 +690,7 @@ describe('MetaMetricsController', function () {
         [TRAITS.NFT_AUTODETECTION_ENABLED]: false,
         [TRAITS.NUMBER_OF_ACCOUNTS]: 2,
         [TRAITS.NUMBER_OF_NFT_COLLECTIONS]: 3,
+        [TRAITS.NUMBER_OF_TOKENS]: 3,
         [TRAITS.OPENSEA_API_ENABLED]: true,
         [TRAITS.THREE_BOX_ENABLED]: false,
       });
@@ -673,6 +703,7 @@ describe('MetaMetricsController', function () {
           [MAINNET_CHAIN_ID]: [{ address: '0x' }],
           [ROPSTEN_CHAIN_ID]: [{ address: '0x' }, { address: '0x0' }],
         },
+        allTokens: {},
         frequentRpcListDetail: [
           { chainId: MAINNET_CHAIN_ID },
           { chainId: ROPSTEN_CHAIN_ID },
@@ -689,6 +720,9 @@ describe('MetaMetricsController', function () {
           [MAINNET_CHAIN_ID]: [{ address: '0x' }, { address: '0x1' }],
           [ROPSTEN_CHAIN_ID]: [{ address: '0x' }, { address: '0x0' }],
         },
+        allTokens: {
+          '0x1': { '0xabcde': [{ '0x12345': { address: '0xtestAddress' } }] },
+        },
         frequentRpcListDetail: [
           { chainId: MAINNET_CHAIN_ID },
           { chainId: ROPSTEN_CHAIN_ID },
@@ -704,6 +738,7 @@ describe('MetaMetricsController', function () {
         [TRAITS.ADDRESS_BOOK_ENTRIES]: 4,
         [TRAITS.NUMBER_OF_ACCOUNTS]: 3,
         [TRAITS.OPENSEA_API_ENABLED]: false,
+        [TRAITS.NUMBER_OF_TOKENS]: 1,
       });
     });
 
@@ -714,6 +749,7 @@ describe('MetaMetricsController', function () {
           [MAINNET_CHAIN_ID]: [{ address: '0x' }],
           [ROPSTEN_CHAIN_ID]: [{ address: '0x' }, { address: '0x0' }],
         },
+        allTokens: {},
         frequentRpcListDetail: [
           { chainId: MAINNET_CHAIN_ID },
           { chainId: ROPSTEN_CHAIN_ID },
@@ -730,6 +766,7 @@ describe('MetaMetricsController', function () {
           [MAINNET_CHAIN_ID]: [{ address: '0x' }],
           [ROPSTEN_CHAIN_ID]: [{ address: '0x' }, { address: '0x0' }],
         },
+        allTokens: {},
         frequentRpcListDetail: [
           { chainId: MAINNET_CHAIN_ID },
           { chainId: ROPSTEN_CHAIN_ID },

--- a/shared/constants/metametrics.js
+++ b/shared/constants/metametrics.js
@@ -209,6 +209,8 @@ export const TRAITS = {
  *  of identities(accounts) added to the user's MetaMask.
  * @property {number} [number_of_nft_collections] - A number representing the
  *  amount of different NFT collections the user possesses an NFT from.
+ * @property {number} [number_of_tokens] - The total number of token contracts
+ *  the user has across all networks and accounts.
  * @property {boolean} [opensea_api_enabled] - does the user have the OpenSea
  *  API enabled?
  * @property {boolean} [three_box_enabled] - does the user have 3box sync

--- a/shared/constants/metametrics.js
+++ b/shared/constants/metametrics.js
@@ -170,7 +170,7 @@
  *  change, we identify the new number_of_accounts trait
  * @property {'number_of_nft_collections'} NUMBER_OF_NFT_COLLECTIONS - user
  *  trait for number of unique NFT addresses
- * @property {'number_of_tokens'} [NUMBER_OF_TOKENS] - when the number of tokens change, we
+ * @property {'number_of_tokens'} NUMBER_OF_TOKENS - when the number of tokens change, we
  * identify the new number_of_tokens trait
  * @property {'opensea_api_enabled'} OPENSEA_API_ENABLED - when the OpenSea API is enabled
  * we identify the opensea_api_enabled trait

--- a/shared/constants/metametrics.js
+++ b/shared/constants/metametrics.js
@@ -170,6 +170,8 @@
  *  change, we identify the new number_of_accounts trait
  * @property {'number_of_nft_collections'} NUMBER_OF_NFT_COLLECTIONS - user
  *  trait for number of unique NFT addresses
+ * @property {'number_of_tokens'} [NUMBER_OF_TOKENS] - when the number of tokens change, we
+ * identify the new number_of_tokens trait
  * @property {'opensea_api_enabled'} OPENSEA_API_ENABLED - when the OpenSea API is enabled
  * we identify the opensea_api_enabled trait
  * @property {'three_box_enabled'} THREE_BOX_ENABLED - when 3box feature is
@@ -188,6 +190,7 @@ export const TRAITS = {
   NFT_AUTODETECTION_ENABLED: 'nft_autodetection_enabled',
   NUMBER_OF_ACCOUNTS: 'number_of_accounts',
   NUMBER_OF_NFT_COLLECTIONS: 'number_of_nft_collections',
+  NUMBER_OF_TOKENS: 'number_of_tokens',
   OPENSEA_API_ENABLED: 'opensea_api_enabled',
   THREE_BOX_ENABLED: 'three_box_enabled',
 };


### PR DESCRIPTION
## Explanation

Add two new user traits to Segment:

number_of_tokens - Number of Tokens

**Note:** We want the count of all of the tokens across all of the chains as mentioned by @brad-decker  here: https://github.com/MetaMask/metamask-extension/pull/14421#discussion_r847346696

## More information

Progresses https://github.com/MetaMask/metamask-extension/issues/13477
