### PR TITLE
Run main, flask and beta in sequence in generate-lavamoat-policies.sh

### DIFF
--- a/development/generate-lavamoat-policies.sh
+++ b/development/generate-lavamoat-policies.sh
@@ -7,7 +7,6 @@ set -o pipefail
 # Generate LavaMoat policies for the extension background script for each build
 # type.
 # ATTN: This may tax your device when running it locally.
-concurrently --kill-others-on-fail -n main,beta,flask \
-  "WRITE_AUTO_POLICY=1 yarn build scripts:prod --policy-only" \
-  "WRITE_AUTO_POLICY=1 yarn build scripts:prod --policy-only --build-type beta" \
-  "WRITE_AUTO_POLICY=1 yarn build scripts:prod --policy-only --build-type flask"
+WRITE_AUTO_POLICY=1 yarn build scripts:prod --policy-only &&
+WRITE_AUTO_POLICY=1 yarn build scripts:prod --policy-only --build-type beta &&
+WRITE_AUTO_POLICY=1 yarn build scripts:prod --policy-only --build-type flask


### PR DESCRIPTION
Aims to fix the build failures in https://github.com/MetaMask/metamask-extension/pull/14254

It seems that recent changes have caused memory usage issues in our CI builds. Likely introduced in this commit https://github.com/MetaMask/metamask-extension/pull/14254/commits/4447727eb62f72943caf0ab1dfb80bfc17e4a7fa

As a temporary workaround, this PR reduces the number of memory intensive processes running in parallel, specifically for the job that is failing on the v10.13.0 branch 