### PR TITLE
MetaMetrics: Add EVENT.CATEGORIES const

### DIFF
--- a/app/scripts/controllers/transactions/index.js
+++ b/app/scripts/controllers/transactions/index.js
@@ -39,6 +39,7 @@ import {
   PRIORITY_LEVELS,
 } from '../../../../shared/constants/gas';
 import { decGWEIToHexWEI } from '../../../../shared/modules/conversion.utils';
+import { EVENT } from '../../../../shared/constants/metametrics';
 import {
   HARDFORKS,
   MAINNET,
@@ -1833,7 +1834,7 @@ export default class TransactionController extends EventEmitter {
         this._trackMetaMetricsEvent({
           event: 'Swap Failed',
           sensitiveProperties: { ...txMeta.swapMetaData },
-          category: 'swaps',
+          category: EVENT.CATEGORIES.SWAPS,
         });
       } else {
         const tokensReceived = getSwapsTokensReceivedFromTxMeta(
@@ -1863,7 +1864,7 @@ export default class TransactionController extends EventEmitter {
 
         this._trackMetaMetricsEvent({
           event: 'Swap Completed',
-          category: 'swaps',
+          category: EVENT.CATEGORIES.SWAPS,
           sensitiveProperties: {
             ...txMeta.swapMetaData,
             token_to_amount_received: tokensReceived,
@@ -2036,7 +2037,7 @@ export default class TransactionController extends EventEmitter {
       // occur.
       case TRANSACTION_EVENTS.ADDED:
         this.createEventFragment({
-          category: 'Transactions',
+          category: EVENT.CATEGORIES.TRANSACTIONS,
           initialEvent: TRANSACTION_EVENTS.ADDED,
           successEvent: TRANSACTION_EVENTS.APPROVED,
           failureEvent: TRANSACTION_EVENTS.REJECTED,
@@ -2057,7 +2058,7 @@ export default class TransactionController extends EventEmitter {
       case TRANSACTION_EVENTS.APPROVED:
       case TRANSACTION_EVENTS.REJECTED:
         this.createEventFragment({
-          category: 'Transactions',
+          category: EVENT.CATEGORIES.TRANSACTIONS,
           successEvent: TRANSACTION_EVENTS.APPROVED,
           failureEvent: TRANSACTION_EVENTS.REJECTED,
           properties,
@@ -2078,7 +2079,7 @@ export default class TransactionController extends EventEmitter {
       // properties to the transaction event.
       case TRANSACTION_EVENTS.SUBMITTED:
         this.createEventFragment({
-          category: 'Transactions',
+          category: EVENT.CATEGORIES.TRANSACTIONS,
           initialEvent: TRANSACTION_EVENTS.SUBMITTED,
           successEvent: TRANSACTION_EVENTS.FINALIZED,
           properties,
@@ -2097,7 +2098,7 @@ export default class TransactionController extends EventEmitter {
       // fragment does not exist.
       case TRANSACTION_EVENTS.FINALIZED:
         this.createEventFragment({
-          category: 'Transactions',
+          category: EVENT.CATEGORIES.TRANSACTIONS,
           successEvent: TRANSACTION_EVENTS.FINALIZED,
           properties,
           sensitiveProperties,

--- a/app/scripts/controllers/transactions/index.test.js
+++ b/app/scripts/controllers/transactions/index.test.js
@@ -10,6 +10,7 @@ import {
   getTestAccounts,
 } from '../../../../test/stub/provider';
 import mockEstimates from '../../../../test/data/mock-estimates.json';
+import { EVENT } from '../../../../shared/constants/metametrics';
 import {
   TRANSACTION_STATUSES,
   TRANSACTION_TYPES,
@@ -1459,7 +1460,7 @@ describe('Transaction Controller', function () {
           successEvent: 'Transaction Approved',
           failureEvent: 'Transaction Rejected',
           uniqueIdentifier: 'transaction-added-1',
-          category: 'Transactions',
+          category: EVENT.CATEGORIES.TRANSACTIONS,
           persist: true,
           properties: {
             chain_id: '0x2a',
@@ -1538,7 +1539,7 @@ describe('Transaction Controller', function () {
           initialEvent: 'Transaction Submitted',
           successEvent: 'Transaction Finalized',
           uniqueIdentifier: 'transaction-submitted-1',
-          category: 'Transactions',
+          category: EVENT.CATEGORIES.TRANSACTIONS,
           persist: true,
           properties: {
             chain_id: '0x2a',
@@ -1627,7 +1628,7 @@ describe('Transaction Controller', function () {
           successEvent: 'Transaction Approved',
           failureEvent: 'Transaction Rejected',
           uniqueIdentifier: 'transaction-added-1',
-          category: 'Transactions',
+          category: EVENT.CATEGORIES.TRANSACTIONS,
           persist: true,
           properties: {
             chain_id: '0x2a',
@@ -1708,7 +1709,7 @@ describe('Transaction Controller', function () {
           initialEvent: 'Transaction Submitted',
           successEvent: 'Transaction Finalized',
           uniqueIdentifier: 'transaction-submitted-1',
-          category: 'Transactions',
+          category: EVENT.CATEGORIES.TRANSACTIONS,
           persist: true,
           properties: {
             chain_id: '0x2a',
@@ -1789,7 +1790,7 @@ describe('Transaction Controller', function () {
         successEvent: 'Transaction Approved',
         failureEvent: 'Transaction Rejected',
         uniqueIdentifier: 'transaction-added-1',
-        category: 'Transactions',
+        category: EVENT.CATEGORIES.TRANSACTIONS,
         persist: true,
         properties: {
           chain_id: '0x2a',
@@ -1853,7 +1854,7 @@ describe('Transaction Controller', function () {
         failureEvent: 'Transaction Rejected',
         uniqueIdentifier: 'transaction-added-1',
         persist: true,
-        category: 'Transactions',
+        category: EVENT.CATEGORIES.TRANSACTIONS,
         properties: {
           network: '42',
           referrer: 'other',
@@ -1926,7 +1927,7 @@ describe('Transaction Controller', function () {
         failureEvent: 'Transaction Rejected',
         uniqueIdentifier: 'transaction-added-1',
         persist: true,
-        category: 'Transactions',
+        category: EVENT.CATEGORIES.TRANSACTIONS,
         properties: {
           chain_id: '0x2a',
           eip_1559_version: '1',

--- a/app/scripts/lib/createRPCMethodTrackingMiddleware.js
+++ b/app/scripts/lib/createRPCMethodTrackingMiddleware.js
@@ -1,4 +1,4 @@
-import { EVENT_NAMES } from '../../../shared/constants/metametrics';
+import { EVENT, EVENT_NAMES } from '../../../shared/constants/metametrics';
 import { SECOND } from '../../../shared/constants/time';
 
 const USER_PROMPTED_EVENT_NAME_MAP = {
@@ -46,7 +46,7 @@ export default function createRPCMethodTrackingMiddleware({
         const userRejected = res.error?.code === 4001;
         trackEvent({
           event: USER_PROMPTED_EVENT_NAME_MAP[req.method],
-          category: 'inpage_provider',
+          category: EVENT.CATEGORIES.INPAGE_PROVIDER,
           referrer: {
             url: origin,
           },
@@ -62,7 +62,7 @@ export default function createRPCMethodTrackingMiddleware({
       } else if (typeof samplingTimeouts[req.method] === 'undefined') {
         trackEvent({
           event: 'Provider Method Called',
-          category: 'inpage_provider',
+          category: EVENT.CATEGORIES.INPAGE_PROVIDER,
           referrer: {
             url: origin,
           },

--- a/app/scripts/lib/decrypt-message-manager.js
+++ b/app/scripts/lib/decrypt-message-manager.js
@@ -4,6 +4,7 @@ import { bufferToHex, stripHexPrefix } from 'ethereumjs-util';
 import { ethErrors } from 'eth-rpc-errors';
 import log from 'loglevel';
 import { MESSAGE_TYPE } from '../../../shared/constants/app';
+import { EVENT } from '../../../shared/constants/metametrics';
 import { METAMASK_CONTROLLER_EVENTS } from '../metamask-controller';
 import createId from '../../../shared/modules/random-id';
 import { addHexPrefix } from './util';
@@ -227,7 +228,7 @@ export default class DecryptMessageManager extends EventEmitter {
     if (reason) {
       this.metricsEvent({
         event: reason,
-        category: 'Messages',
+        category: EVENT.CATEGORIES.MESSAGES,
         properties: {
           action: 'Decrypt Message Request',
         },

--- a/app/scripts/lib/encryption-public-key-manager.js
+++ b/app/scripts/lib/encryption-public-key-manager.js
@@ -3,6 +3,7 @@ import { ObservableStore } from '@metamask/obs-store';
 import { ethErrors } from 'eth-rpc-errors';
 import log from 'loglevel';
 import { MESSAGE_TYPE } from '../../../shared/constants/app';
+import { EVENT } from '../../../shared/constants/metametrics';
 import { METAMASK_CONTROLLER_EVENTS } from '../metamask-controller';
 import createId from '../../../shared/modules/random-id';
 
@@ -216,7 +217,7 @@ export default class EncryptionPublicKeyManager extends EventEmitter {
     if (reason) {
       this.metricsEvent({
         event: reason,
-        category: 'Messages',
+        category: EVENT.CATEGORIES.MESSAGES,
         properties: {
           action: 'Encryption public key Request',
         },

--- a/app/scripts/lib/message-manager.js
+++ b/app/scripts/lib/message-manager.js
@@ -5,6 +5,7 @@ import { ethErrors } from 'eth-rpc-errors';
 import { MESSAGE_TYPE } from '../../../shared/constants/app';
 import { METAMASK_CONTROLLER_EVENTS } from '../metamask-controller';
 import createId from '../../../shared/modules/random-id';
+import { EVENT } from '../../../shared/constants/metametrics';
 
 /**
  * Represents, and contains data about, an 'eth_sign' type signature request. These are created when a signature for
@@ -211,7 +212,7 @@ export default class MessageManager extends EventEmitter {
       const msg = this.getMsg(msgId);
       this.metricsEvent({
         event: reason,
-        category: 'Transactions',
+        category: EVENT.CATEGORIES.TRANSACTIONS,
         properties: {
           action: 'Sign Request',
           type: msg.type,

--- a/app/scripts/lib/personal-message-manager.js
+++ b/app/scripts/lib/personal-message-manager.js
@@ -6,6 +6,7 @@ import log from 'loglevel';
 import { MESSAGE_TYPE } from '../../../shared/constants/app';
 import { METAMASK_CONTROLLER_EVENTS } from '../metamask-controller';
 import createId from '../../../shared/modules/random-id';
+import { EVENT } from '../../../shared/constants/metametrics';
 import { addHexPrefix } from './util';
 
 const hexRe = /^[0-9A-Fa-f]+$/gu;
@@ -231,7 +232,7 @@ export default class PersonalMessageManager extends EventEmitter {
       const msg = this.getMsg(msgId);
       this.metricsEvent({
         event: reason,
-        category: 'Transactions',
+        category: EVENT.CATEGORIES.TRANSACTIONS,
         properties: {
           action: 'Sign Request',
           type: msg.type,

--- a/app/scripts/lib/rpc-method-middleware/handlers/add-ethereum-chain.js
+++ b/app/scripts/lib/rpc-method-middleware/handlers/add-ethereum-chain.js
@@ -2,6 +2,7 @@ import { ethErrors, errorCodes } from 'eth-rpc-errors';
 import validUrl from 'valid-url';
 import { omit } from 'lodash';
 import { MESSAGE_TYPE } from '../../../../../shared/constants/app';
+import { EVENT } from '../../../../../shared/constants/metametrics';
 import {
   isPrefixedFormattedHexString,
   isSafeChainId,
@@ -249,7 +250,7 @@ async function addEthereumChainHandler(
 
     sendMetrics({
       event: 'Custom Network Added',
-      category: 'Network',
+      category: EVENT.CATEGORIES.NETWORK,
       referrer: {
         url: origin,
       },

--- a/app/scripts/lib/rpc-method-middleware/handlers/log-web3-shim-usage.js
+++ b/app/scripts/lib/rpc-method-middleware/handlers/log-web3-shim-usage.js
@@ -1,4 +1,5 @@
 import { MESSAGE_TYPE } from '../../../../../shared/constants/app';
+import { EVENT } from '../../../../../shared/constants/metametrics';
 
 /**
  * This RPC method is called by the inpage provider whenever it detects the
@@ -48,7 +49,7 @@ function logWeb3ShimUsageHandler(
     sendMetrics(
       {
         event: `Website Accessed window.web3 Shim`,
-        category: 'inpage_provider',
+        category: EVENT.CATEGORIES.INPAGE_PROVIDER,
         referrer: {
           url: origin,
         },

--- a/app/scripts/lib/typed-message-manager.js
+++ b/app/scripts/lib/typed-message-manager.js
@@ -8,6 +8,7 @@ import jsonschema from 'jsonschema';
 import { MESSAGE_TYPE } from '../../../shared/constants/app';
 import { METAMASK_CONTROLLER_EVENTS } from '../metamask-controller';
 import createId from '../../../shared/modules/random-id';
+import { EVENT } from '../../../shared/constants/metametrics';
 import { isValidHexAddress } from '../../../shared/modules/hexstring-utils';
 
 /**
@@ -303,7 +304,7 @@ export default class TypedMessageManager extends EventEmitter {
       const msg = this.getMsg(msgId);
       this.metricsEvent({
         event: reason,
-        category: 'Transactions',
+        category: EVENT.CATEGORIES.TRANSACTIONS,
         properties: {
           action: 'Sign Request',
           version: msg.msgParams.version,

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -81,6 +81,7 @@ import {
   POLLING_TOKEN_ENVIRONMENT_TYPES,
   SUBJECT_TYPES,
 } from '../../shared/constants/app';
+import { EVENT } from '../../shared/constants/metametrics';
 
 import { hexToDecimal } from '../../ui/helpers/utils/conversions.util';
 import { getTokenValueParam } from '../../ui/helpers/utils/token-util';
@@ -848,7 +849,7 @@ export default class MetamaskController extends EventEmitter {
           this.metaMetricsController.trackEvent(
             {
               event: 'Tx Status Update: On-Chain Failure',
-              category: 'Background',
+              category: EVENT.CATEGORIES.BACKGROUND,
               properties: {
                 action: 'Transactions',
                 errorMessage: txMeta.simulationFails?.reason,
@@ -1201,7 +1202,7 @@ export default class MetamaskController extends EventEmitter {
       (snapId) => {
         this.metaMetricsController.trackEvent({
           event: 'Snap Installed',
-          category: 'Snaps',
+          category: EVENT.CATEGORIES.SNAPS,
           properties: {
             snap_id: snapId,
           },

--- a/shared/constants/metametrics.js
+++ b/shared/constants/metametrics.js
@@ -274,10 +274,12 @@ export const EVENT = {
     BACKGROUND: 'Background',
     INPAGE_PROVIDER: 'inpage_provider',
     MESSAGES: 'Messages',
+    NAVIGATION: 'Navigation',
     ONBOARDING: 'Onboarding',
     RETENTION: 'Retention',
     SETTINGS: 'Settings',
     SNAPS: 'Snaps',
+    TRANSACTIONS: 'Transactions',
     WALLET: 'Wallet',
   },
 };

--- a/shared/constants/metametrics.js
+++ b/shared/constants/metametrics.js
@@ -277,5 +277,6 @@ export const EVENT = {
     RETENTION: 'Retention',
     SETTINGS: 'Settings',
     SNAPS: 'Snaps',
+    WALLET: 'Wallet',
   },
 };

--- a/shared/constants/metametrics.js
+++ b/shared/constants/metametrics.js
@@ -276,5 +276,6 @@ export const EVENT = {
     MESSAGES: 'Messages',
     RETENTION: 'Retention',
     SETTINGS: 'Settings',
+    SNAPS: 'Snaps',
   },
 };

--- a/shared/constants/metametrics.js
+++ b/shared/constants/metametrics.js
@@ -256,9 +256,19 @@ export const REJECT_NOTFICIATION_CLOSE = 'Cancel Via Notification Close';
 export const REJECT_NOTFICIATION_CLOSE_SIG =
   'Cancel Sig Request Via Notification Close';
 
+/**
+ * EVENTS
+ */
+
 export const EVENT_NAMES = {
   SIGNATURE_REQUESTED: 'Signature Requested',
   ENCRYPTION_PUBLIC_KEY_REQUESTED: 'Encryption Public Key Requested',
   DECRYPTION_REQUESTED: 'Decryption Requested',
   PERMISSIONS_REQUESTED: 'Permissions Requested',
+};
+
+export const EVENT = {
+  CATEGORIES: {
+    BACKGROUND: 'Background',
+  },
 };

--- a/shared/constants/metametrics.js
+++ b/shared/constants/metametrics.js
@@ -275,5 +275,6 @@ export const EVENT = {
     INPAGE_PROVIDER: 'inpage_provider',
     MESSAGES: 'Messages',
     RETENTION: 'Retention',
+    SETTINGS: 'Settings',
   },
 };

--- a/shared/constants/metametrics.js
+++ b/shared/constants/metametrics.js
@@ -270,5 +270,6 @@ export const EVENT_NAMES = {
 export const EVENT = {
   CATEGORIES: {
     BACKGROUND: 'Background',
+    INPAGE_PROVIDER: 'inpage_provider',
   },
 };

--- a/shared/constants/metametrics.js
+++ b/shared/constants/metametrics.js
@@ -273,5 +273,6 @@ export const EVENT = {
     AUTH: 'Auth',
     BACKGROUND: 'Background',
     INPAGE_PROVIDER: 'inpage_provider',
+    MESSAGES: 'Messages',
   },
 };

--- a/shared/constants/metametrics.js
+++ b/shared/constants/metametrics.js
@@ -274,5 +274,6 @@ export const EVENT = {
     BACKGROUND: 'Background',
     INPAGE_PROVIDER: 'inpage_provider',
     MESSAGES: 'Messages',
+    RETENTION: 'Retention',
   },
 };

--- a/shared/constants/metametrics.js
+++ b/shared/constants/metametrics.js
@@ -275,6 +275,7 @@ export const EVENT = {
     INPAGE_PROVIDER: 'inpage_provider',
     MESSAGES: 'Messages',
     NAVIGATION: 'Navigation',
+    NETWORK: 'Network',
     ONBOARDING: 'Onboarding',
     RETENTION: 'Retention',
     SETTINGS: 'Settings',

--- a/shared/constants/metametrics.js
+++ b/shared/constants/metametrics.js
@@ -269,6 +269,7 @@ export const EVENT_NAMES = {
 
 export const EVENT = {
   CATEGORIES: {
+    ACCOUNTS: 'Accounts',
     AUTH: 'Auth',
     BACKGROUND: 'Background',
     INPAGE_PROVIDER: 'inpage_provider',

--- a/shared/constants/metametrics.js
+++ b/shared/constants/metametrics.js
@@ -274,6 +274,7 @@ export const EVENT = {
     BACKGROUND: 'Background',
     INPAGE_PROVIDER: 'inpage_provider',
     MESSAGES: 'Messages',
+    ONBOARDING: 'Onboarding',
     RETENTION: 'Retention',
     SETTINGS: 'Settings',
     SNAPS: 'Snaps',

--- a/shared/constants/metametrics.js
+++ b/shared/constants/metametrics.js
@@ -269,6 +269,7 @@ export const EVENT_NAMES = {
 
 export const EVENT = {
   CATEGORIES: {
+    AUTH: 'Auth',
     BACKGROUND: 'Background',
     INPAGE_PROVIDER: 'inpage_provider',
   },

--- a/ui/components/app/account-menu/account-menu.component.js
+++ b/ui/components/app/account-menu/account-menu.component.js
@@ -5,6 +5,7 @@ import Fuse from 'fuse.js';
 import InputAdornment from '@material-ui/core/InputAdornment';
 import classnames from 'classnames';
 import { ENVIRONMENT_TYPE_POPUP } from '../../../../shared/constants/app';
+import { EVENT } from '../../../../shared/constants/metametrics';
 import { getEnvironmentType } from '../../../../app/scripts/lib/util';
 import Identicon from '../../ui/identicon';
 import SiteIcon from '../../ui/site-icon';
@@ -197,7 +198,7 @@ export default class AccountMenu extends Component {
           className="account-menu__account account-menu__item--clickable"
           onClick={() => {
             this.context.trackEvent({
-              category: 'Navigation',
+              category: EVENT.CATEGORIES.NAVIGATION,
               event: 'Switched Account',
               properties: {
                 action: 'Main Menu',
@@ -340,7 +341,7 @@ export default class AccountMenu extends Component {
           onClick={() => {
             toggleAccountMenu();
             trackEvent({
-              category: 'Navigation',
+              category: EVENT.CATEGORIES.NAVIGATION,
               event: 'Clicked Create Account',
               properties: {
                 action: 'Main Menu',
@@ -356,7 +357,7 @@ export default class AccountMenu extends Component {
           onClick={() => {
             toggleAccountMenu();
             trackEvent({
-              category: 'Navigation',
+              category: EVENT.CATEGORIES.NAVIGATION,
               event: 'Clicked Import Account',
               properties: {
                 action: 'Main Menu',
@@ -377,7 +378,7 @@ export default class AccountMenu extends Component {
           onClick={() => {
             toggleAccountMenu();
             trackEvent({
-              category: 'Navigation',
+              category: EVENT.CATEGORIES.NAVIGATION,
               event: 'Clicked Connect Hardware',
               properties: {
                 action: 'Main Menu',
@@ -417,7 +418,7 @@ export default class AccountMenu extends Component {
             toggleAccountMenu();
             history.push(SETTINGS_ROUTE);
             this.context.trackEvent({
-              category: 'Navigation',
+              category: EVENT.CATEGORIES.NAVIGATION,
               event: 'Opened Settings',
               properties: {
                 action: 'Main Menu',

--- a/ui/components/app/app-header/app-header.component.js
+++ b/ui/components/app/app-header/app-header.component.js
@@ -4,6 +4,7 @@ import classnames from 'classnames';
 import Identicon from '../../ui/identicon';
 import MetaFoxLogo from '../../ui/metafox-logo';
 import { DEFAULT_ROUTE } from '../../../helpers/constants/routes';
+import { EVENT } from '../../../../shared/constants/metametrics';
 import NetworkDisplay from '../network-display';
 
 export default class AppHeader extends PureComponent {
@@ -45,7 +46,7 @@ export default class AppHeader extends PureComponent {
 
     if (networkDropdownOpen === false) {
       this.context.trackEvent({
-        category: 'Navigation',
+        category: EVENT.CATEGORIES.NAVIGATION,
         event: 'Opened Network Menu',
         properties: {
           action: 'Home',
@@ -77,7 +78,7 @@ export default class AppHeader extends PureComponent {
             if (!disabled) {
               !isAccountMenuOpen &&
                 this.context.trackEvent({
-                  category: 'Navigation',
+                  category: EVENT.CATEGORIES.NAVIGATION,
                   event: 'Opened Main Menu',
                   properties: {
                     action: 'Home',

--- a/ui/components/app/asset-list-item/asset-list-item.js
+++ b/ui/components/app/asset-list-item/asset-list-item.js
@@ -13,6 +13,7 @@ import { updateSendAsset } from '../../../ducks/send';
 import { SEND_ROUTE } from '../../../helpers/constants/routes';
 import { SEVERITIES } from '../../../helpers/constants/design-system';
 import { INVALID_ASSET_TYPE } from '../../../helpers/constants/error-keys';
+import { EVENT } from '../../../../shared/constants/metametrics';
 import { ASSET_TYPES } from '../../../../shared/constants/transaction';
 import { MetaMetricsContext } from '../../../contexts/metametrics';
 
@@ -65,7 +66,7 @@ const AssetListItem = ({
           e.stopPropagation();
           trackEvent({
             event: 'Clicked Send: Token',
-            category: 'Navigation',
+            category: EVENT.CATEGORIES.NAVIGATION,
             properties: {
               action: 'Home',
               legacy_event: true,

--- a/ui/components/app/asset-list/asset-list.js
+++ b/ui/components/app/asset-list/asset-list.js
@@ -26,6 +26,7 @@ import {
 } from '../../../helpers/constants/design-system';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import { MetaMetricsContext } from '../../../contexts/metametrics';
+import { EVENT } from '../../../../shared/constants/metametrics';
 
 const AssetList = ({ onClickAsset }) => {
   const t = useI18nContext();
@@ -83,7 +84,7 @@ const AssetList = ({ onClickAsset }) => {
           onClickAsset(tokenAddress);
           trackEvent({
             event: 'Clicked Token',
-            category: 'Navigation',
+            category: EVENT.CATEGORIES.NAVIGATION,
             properties: {
               action: 'Token Menu',
               legacy_event: true,
@@ -107,7 +108,7 @@ const AssetList = ({ onClickAsset }) => {
             history.push(IMPORT_TOKEN_ROUTE);
             trackEvent({
               event: 'Clicked "Add Token"',
-              category: 'Navigation',
+              category: EVENT.CATEGORIES.NAVIGATION,
               properties: {
                 action: 'Token Menu',
                 legacy_event: true,

--- a/ui/components/app/create-new-vault/create-new-vault.js
+++ b/ui/components/app/create-new-vault/create-new-vault.js
@@ -1,5 +1,6 @@
 import React, { useCallback, useContext, useState } from 'react';
 import PropTypes from 'prop-types';
+import { EVENT } from '../../../../shared/constants/metametrics';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import { MetaMetricsContext } from '../../../contexts/metametrics';
 import TextField from '../../ui/text-field';
@@ -83,7 +84,7 @@ export default function CreateNewVault({
 
   const toggleTermsCheck = useCallback(() => {
     trackEvent({
-      category: 'Onboarding',
+      category: EVENT.CATEGORIES.ONBOARDING,
       event: 'Check ToS',
       properties: {
         action: 'Import Seed Phrase',

--- a/ui/components/app/dropdowns/network-dropdown.js
+++ b/ui/components/app/dropdowns/network-dropdown.js
@@ -17,6 +17,7 @@ import { COLORS, SIZES } from '../../../helpers/constants/design-system';
 import { getShowTestNetworks } from '../../../selectors';
 import { getEnvironmentType } from '../../../../app/scripts/lib/util';
 import { ENVIRONMENT_TYPE_POPUP } from '../../../../shared/constants/app';
+import { EVENT } from '../../../../shared/constants/metametrics';
 import {
   ADD_NETWORK_ROUTE,
   ADVANCED_ROUTE,
@@ -110,7 +111,7 @@ class NetworkDropdown extends Component {
     const { trackEvent } = this.context;
 
     trackEvent({
-      category: 'Navigation',
+      category: EVENT.CATEGORIES.NAVIGATION,
       event: 'Switched Networks',
       properties: {
         action: 'Home',

--- a/ui/components/app/edit-gas-display/edit-gas-display.component.js
+++ b/ui/components/app/edit-gas-display/edit-gas-display.component.js
@@ -9,6 +9,7 @@ import {
   GAS_ESTIMATE_TYPES,
   CUSTOM_GAS_ESTIMATE,
 } from '../../../../shared/constants/gas';
+import { EVENT } from '../../../../shared/constants/metametrics';
 
 import Button from '../../ui/button';
 import Typography from '../../ui/typography/typography';
@@ -280,7 +281,7 @@ export default function EditGasDisplay({
                 setShowAdvancedForm(!showAdvancedForm);
                 trackEvent({
                   event: 'Clicked "Advanced Options"',
-                  category: 'Transactions',
+                  category: EVENT.CATEGORIES.TRANSACTIONS,
                   properties: {
                     action: 'Edit Screen',
                     legacy_event: true,

--- a/ui/components/app/gas-customization/gas-modal-page-container/gas-modal-page-container.component.js
+++ b/ui/components/app/gas-customization/gas-modal-page-container/gas-modal-page-container.component.js
@@ -8,6 +8,7 @@ import {
   addPollingTokenToAppState,
   removePollingTokenFromAppState,
 } from '../../../../store/actions';
+import { EVENT } from '../../../../../shared/constants/metametrics';
 import AdvancedTabContent from './advanced-tab-content';
 import BasicTabContent from './basic-tab-content';
 
@@ -219,7 +220,7 @@ export default class GasModalPageContainer extends Component {
           onSubmit={() => {
             if (isSpeedUp) {
               this.context.trackEvent({
-                category: 'Navigation',
+                category: EVENT.CATEGORIES.NAVIGATION,
                 event: 'Saved "Speed Up"',
                 properties: {
                   action: 'Activity Log',

--- a/ui/components/app/import-token-link/import-token-link.component.js
+++ b/ui/components/app/import-token-link/import-token-link.component.js
@@ -8,6 +8,7 @@ import Box from '../../ui/box/box';
 import { TEXT_ALIGN } from '../../../helpers/constants/design-system';
 import { detectNewTokens } from '../../../store/actions';
 import { MetaMetricsContext } from '../../../contexts/metametrics';
+import { EVENT } from '../../../../shared/constants/metametrics';
 
 export default function ImportTokenLink({ isMainnet }) {
   const trackEvent = useContext(MetaMetricsContext);
@@ -35,7 +36,7 @@ export default function ImportTokenLink({ isMainnet }) {
           history.push(IMPORT_TOKEN_ROUTE);
           trackEvent({
             event: 'Clicked "Add Token"',
-            category: 'Navigation',
+            category: EVENT.CATEGORIES.NAVIGATION,
             properties: {
               action: 'Token Menu',
               legacy_event: true,

--- a/ui/components/app/menu-bar/account-options-menu.js
+++ b/ui/components/app/menu-bar/account-options-menu.js
@@ -17,6 +17,7 @@ import {
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import { getEnvironmentType } from '../../../../app/scripts/lib/util';
 import { ENVIRONMENT_TYPE_FULLSCREEN } from '../../../../shared/constants/app';
+import { EVENT } from '../../../../shared/constants/metametrics';
 import { MetaMetricsContext } from '../../../contexts/metametrics';
 
 export default function AccountOptionsMenu({ anchorElement, onClose }) {
@@ -46,7 +47,7 @@ export default function AccountOptionsMenu({ anchorElement, onClose }) {
         onClick={() => {
           trackEvent({
             event: 'Clicked Block Explorer Link',
-            category: 'Navigation',
+            category: EVENT.CATEGORIES.NAVIGATION,
             properties: {
               link_type: 'Account Tracker',
               action: 'Account Options',
@@ -76,7 +77,7 @@ export default function AccountOptionsMenu({ anchorElement, onClose }) {
           onClick={() => {
             trackEvent({
               event: 'Clicked Expand View',
-              category: 'Navigation',
+              category: EVENT.CATEGORIES.NAVIGATION,
               properties: {
                 action: 'Account Options',
                 legacy_event: true,
@@ -96,7 +97,7 @@ export default function AccountOptionsMenu({ anchorElement, onClose }) {
           dispatch(showModal({ name: 'ACCOUNT_DETAILS' }));
           trackEvent({
             event: 'Viewed Account Details',
-            category: 'Navigation',
+            category: EVENT.CATEGORIES.NAVIGATION,
             properties: {
               action: 'Account Options',
               legacy_event: true,
@@ -113,7 +114,7 @@ export default function AccountOptionsMenu({ anchorElement, onClose }) {
         onClick={() => {
           trackEvent({
             event: 'Opened Connected Sites',
-            category: 'Navigation',
+            category: EVENT.CATEGORIES.NAVIGATION,
             properties: {
               action: 'Account Options',
               legacy_event: true,

--- a/ui/components/app/menu-bar/menu-bar.js
+++ b/ui/components/app/menu-bar/menu-bar.js
@@ -6,6 +6,7 @@ import SelectedAccount from '../selected-account';
 import ConnectedStatusIndicator from '../connected-status-indicator';
 import { getEnvironmentType } from '../../../../app/scripts/lib/util';
 import { ENVIRONMENT_TYPE_POPUP } from '../../../../shared/constants/app';
+import { EVENT } from '../../../../shared/constants/metametrics';
 import { CONNECTED_ACCOUNTS_ROUTE } from '../../../helpers/constants/routes';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import { getOriginOfCurrentTab } from '../../../selectors';
@@ -46,7 +47,7 @@ export default function MenuBar() {
         onClick={() => {
           trackEvent({
             event: 'Opened Account Options',
-            category: 'Navigation',
+            category: EVENT.CATEGORIES.NAVIGATION,
             properties: {
               action: 'Home',
               legacy_event: true,

--- a/ui/components/app/modals/account-details-modal/account-details-modal.component.js
+++ b/ui/components/app/modals/account-details-modal/account-details-modal.component.js
@@ -8,6 +8,7 @@ import EditableLabel from '../../../ui/editable-label';
 import Button from '../../../ui/button';
 import { getURLHostName } from '../../../../helpers/utils/util';
 import { isHardwareKeyring } from '../../../../helpers/utils/hardware';
+import { EVENT } from '../../../../../shared/constants/metametrics';
 
 export default class AccountDetailsModal extends Component {
   static propTypes = {
@@ -76,7 +77,7 @@ export default class AccountDetailsModal extends Component {
           onClick={() => {
             const accountLink = getAccountLink(address, chainId, rpcPrefs);
             this.context.trackEvent({
-              category: 'Navigation',
+              category: EVENT.CATEGORIES.NAVIGATION,
               event: 'Clicked Block Explorer Link',
               properties: {
                 link_type: 'Account Tracker',

--- a/ui/components/app/modals/confirm-remove-account/confirm-remove-account.component.js
+++ b/ui/components/app/modals/confirm-remove-account/confirm-remove-account.component.js
@@ -4,6 +4,7 @@ import { getAccountLink } from '@metamask/etherscan-link';
 import Modal from '../../modal';
 import { addressSummary, getURLHostName } from '../../../../helpers/utils/util';
 import Identicon from '../../../ui/identicon';
+import { EVENT } from '../../../../../shared/constants/metametrics';
 
 export default class ConfirmRemoveAccount extends Component {
   static propTypes = {
@@ -60,7 +61,7 @@ export default class ConfirmRemoveAccount extends Component {
                 rpcPrefs,
               );
               this.context.trackEvent({
-                category: 'Accounts',
+                category: EVENT.CATEGORIES.ACCOUNTS,
                 event: 'Clicked Block Explorer Link',
                 properties: {
                   link_type: 'Account Tracker',

--- a/ui/components/app/modals/deposit-ether-modal/deposit-ether-modal.component.js
+++ b/ui/components/app/modals/deposit-ether-modal/deposit-ether-modal.component.js
@@ -4,6 +4,7 @@ import {
   NETWORK_TO_NAME_MAP,
   BUYABLE_CHAINS_MAP,
 } from '../../../../../shared/constants/network';
+import { EVENT } from '../../../../../shared/constants/metametrics';
 import Button from '../../../ui/button';
 import LogoMoonPay from '../../../ui/logo/logo-moonpay';
 import LogoWyre from '../../../ui/logo/logo-wyre';
@@ -137,7 +138,7 @@ export default class DepositEtherModal extends Component {
               buttonLabel: t('continueToTransak'),
               onButtonClick: () => {
                 this.context.trackEvent({
-                  category: 'Accounts',
+                  category: EVENT.CATEGORIES.ACCOUNTS,
                   event: 'Click buy Ether via Transak',
                   properties: {
                     action: 'Deposit Ether',
@@ -155,7 +156,7 @@ export default class DepositEtherModal extends Component {
               buttonLabel: t('continueToMoonPay'),
               onButtonClick: () => {
                 this.context.trackEvent({
-                  category: 'Accounts',
+                  category: EVENT.CATEGORIES.ACCOUNTS,
                   event: 'Click buy Ether via MoonPay',
                   properties: {
                     action: 'Deposit Ether',
@@ -173,7 +174,7 @@ export default class DepositEtherModal extends Component {
               buttonLabel: t('continueToWyre'),
               onButtonClick: () => {
                 this.context.trackEvent({
-                  category: 'Accounts',
+                  category: EVENT.CATEGORIES.ACCOUNTS,
                   event: 'Click buy Ether via Wyre',
                   properties: {
                     action: 'Deposit Ether',

--- a/ui/components/app/modals/metametrics-opt-in-modal/metametrics-opt-in-modal.component.js
+++ b/ui/components/app/modals/metametrics-opt-in-modal/metametrics-opt-in-modal.component.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import MetaFoxLogo from '../../../ui/metafox-logo';
 import PageContainerFooter from '../../../ui/page-container/page-container-footer';
+import { EVENT } from '../../../../../shared/constants/metametrics';
 
 export default class MetaMetricsOptInModal extends Component {
   static propTypes = {
@@ -110,7 +111,7 @@ export default class MetaMetricsOptInModal extends Component {
                 setParticipateInMetaMetrics(false).then(() => {
                   trackEvent(
                     {
-                      category: 'Onboarding',
+                      category: EVENT.CATEGORIES.ONBOARDING,
                       event: 'Metrics Opt Out',
                       properties: {
                         action: 'Metrics Option',
@@ -131,7 +132,7 @@ export default class MetaMetricsOptInModal extends Component {
                 setParticipateInMetaMetrics(true).then(() => {
                   trackEvent(
                     {
-                      category: 'Onboarding',
+                      category: EVENT.CATEGORIES.ONBOARDING,
                       event: 'Metrics Opt In',
                       properties: {
                         action: 'Metrics Option',

--- a/ui/components/app/permission-page-container/permission-page-container.component.js
+++ b/ui/components/app/permission-page-container/permission-page-container.component.js
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { isEqual } from 'lodash';
+import { EVENT } from '../../../../shared/constants/metametrics';
 import { PageContainerFooter } from '../../ui/page-container';
 import PermissionsConnectFooter from '../permissions-connect-footer';
 import { PermissionPageContainerContent } from '.';
@@ -64,7 +65,7 @@ export default class PermissionPageContainer extends Component {
 
   componentDidMount() {
     this.context.trackEvent({
-      category: 'Auth',
+      category: EVENT.CATEGORIES.AUTH,
       event: 'Tab Opened',
       properties: {
         action: 'Connect',

--- a/ui/components/app/signature-request-original/signature-request-original.component.js
+++ b/ui/components/app/signature-request-original/signature-request-original.component.js
@@ -6,6 +6,7 @@ import { ObjectInspector } from 'react-inspector';
 import LedgerInstructionField from '../ledger-instruction-field';
 
 import { MESSAGE_TYPE } from '../../../../shared/constants/app';
+import { EVENT } from '../../../../shared/constants/metametrics';
 import { getURLHostName } from '../../../helpers/utils/util';
 import Identicon from '../../ui/identicon';
 import AccountListItem from '../account-list-item';
@@ -273,7 +274,7 @@ export default class SignatureRequestOriginal extends Component {
           onClick={async (event) => {
             await cancel(event);
             trackEvent({
-              category: 'Transactions',
+              category: EVENT.CATEGORIES.TRANSACTIONS,
               event: 'Cancel',
               properties: {
                 action: 'Sign Request',
@@ -296,7 +297,7 @@ export default class SignatureRequestOriginal extends Component {
           onClick={async (event) => {
             await sign(event);
             trackEvent({
-              category: 'Transactions',
+              category: EVENT.CATEGORIES.TRANSACTIONS,
               event: 'Confirm',
               properties: {
                 action: 'Sign Request',

--- a/ui/components/app/signature-request/signature-request.component.js
+++ b/ui/components/app/signature-request/signature-request.component.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import Identicon from '../../ui/identicon';
 import LedgerInstructionField from '../ledger-instruction-field';
 import { sanitizeMessage } from '../../../helpers/utils/util';
+import { EVENT } from '../../../../shared/constants/metametrics';
 import Header from './signature-request-header';
 import Footer from './signature-request-footer';
 import Message from './signature-request-message';
@@ -78,7 +79,7 @@ export default class SignatureRequest extends PureComponent {
     const onSign = (event) => {
       sign(event);
       trackEvent({
-        category: 'Transactions',
+        category: EVENT.CATEGORIES.TRANSACTIONS,
         event: 'Confirm',
         properties: {
           action: 'Sign Request',
@@ -92,7 +93,7 @@ export default class SignatureRequest extends PureComponent {
     const onCancel = (event) => {
       cancel(event);
       trackEvent({
-        category: 'Transactions',
+        category: EVENT.CATEGORIES.TRANSACTIONS,
         event: 'Cancel',
         properties: {
           action: 'Sign Request',

--- a/ui/components/app/transaction-activity-log/transaction-activity-log.component.js
+++ b/ui/components/app/transaction-activity-log/transaction-activity-log.component.js
@@ -8,6 +8,7 @@ import {
   getValueFromWeiHex,
 } from '../../../helpers/utils/conversions.util';
 import { formatDate, getURLHostName } from '../../../helpers/utils/util';
+import { EVENT } from '../../../../shared/constants/metametrics';
 import TransactionActivityLogIcon from './transaction-activity-log-icon';
 import { CONFIRMED_STATUS } from './transaction-activity-log.constants';
 
@@ -36,7 +37,7 @@ export default class TransactionActivityLog extends PureComponent {
     const etherscanUrl = getBlockExplorerLink(activity, rpcPrefs);
 
     this.context.trackEvent({
-      category: 'Transactions',
+      category: EVENT.CATEGORIES.TRANSACTIONS,
       event: 'Clicked Block Explorer Link',
       properties: {
         link_type: 'Transaction Block Explorer',

--- a/ui/components/app/transaction-list-item-details/transaction-list-item-details.component.js
+++ b/ui/components/app/transaction-list-item-details/transaction-list-item-details.component.js
@@ -12,6 +12,7 @@ import Tooltip from '../../ui/tooltip';
 import CancelButton from '../cancel-button';
 import Popover from '../../ui/popover';
 import { SECOND } from '../../../../shared/constants/time';
+import { EVENT } from '../../../../shared/constants/metametrics';
 import { TRANSACTION_TYPES } from '../../../../shared/constants/transaction';
 import { getURLHostName } from '../../../helpers/utils/util';
 import TransactionDecoding from '../transaction-decoding';
@@ -62,7 +63,7 @@ export default class TransactionListItemDetails extends PureComponent {
     );
 
     this.context.trackEvent({
-      category: 'Transactions',
+      category: EVENT.CATEGORIES.TRANSACTIONS,
       event: 'Clicked Block Explorer Link',
       properties: {
         link_type: 'Transaction Block Explorer',
@@ -95,7 +96,7 @@ export default class TransactionListItemDetails extends PureComponent {
     const { hash } = transaction;
 
     this.context.trackEvent({
-      category: 'Navigation',
+      category: EVENT.CATEGORIES.NAVIGATION,
       event: 'Copied Transaction ID',
       properties: {
         action: 'Activity Log',
@@ -227,7 +228,7 @@ export default class TransactionListItemDetails extends PureComponent {
                 senderAddress={senderAddress}
                 onRecipientClick={() => {
                   this.context.trackEvent({
-                    category: 'Navigation',
+                    category: EVENT.CATEGORIES.NAVIGATION,
                     event: 'Copied "To" Address',
                     properties: {
                       action: 'Activity Log',
@@ -237,7 +238,7 @@ export default class TransactionListItemDetails extends PureComponent {
                 }}
                 onSenderClick={() => {
                   this.context.trackEvent({
-                    category: 'Navigation',
+                    category: EVENT.CATEGORIES.NAVIGATION,
                     event: 'Copied "From" Address',
                     properties: {
                       action: 'Activity Log',

--- a/ui/components/app/transaction-list-item/transaction-list-item.component.js
+++ b/ui/components/app/transaction-list-item/transaction-list-item.component.js
@@ -13,6 +13,7 @@ import { CONFIRM_TRANSACTION_ROUTE } from '../../../helpers/constants/routes';
 import { useShouldShowSpeedUp } from '../../../hooks/useShouldShowSpeedUp';
 import TransactionStatus from '../transaction-status/transaction-status.component';
 import TransactionIcon from '../transaction-icon';
+import { EVENT } from '../../../../shared/constants/metametrics';
 import {
   TRANSACTION_GROUP_CATEGORIES,
   TRANSACTION_STATUSES,
@@ -67,7 +68,7 @@ function TransactionListItemInner({
       event.stopPropagation();
       trackEvent({
         event: 'Clicked "Speed Up"',
-        category: 'Navigation',
+        category: EVENT.CATEGORIES.NAVIGATION,
         properties: {
           action: 'Activity Log',
           legacy_event: true,
@@ -88,7 +89,7 @@ function TransactionListItemInner({
       event.stopPropagation();
       trackEvent({
         event: 'Clicked "Cancel"',
-        category: 'Navigation',
+        category: EVENT.CATEGORIES.NAVIGATION,
         properties: {
           action: 'Activity Log',
           legacy_event: true,

--- a/ui/components/app/wallet-overview/eth-overview.js
+++ b/ui/components/app/wallet-overview/eth-overview.js
@@ -31,6 +31,7 @@ import { setSwapsFromToken } from '../../../ducks/swaps/swaps';
 import IconButton from '../../ui/icon-button';
 import { isHardwareKeyring } from '../../../helpers/utils/hardware';
 import { MetaMetricsContext } from '../../../contexts/metametrics';
+import { EVENT } from '../../../../shared/constants/metametrics';
 import WalletOverview from './wallet-overview';
 
 const EthOverview = ({ className }) => {
@@ -99,7 +100,7 @@ const EthOverview = ({ className }) => {
             onClick={() => {
               trackEvent({
                 event: 'Clicked Deposit',
-                category: 'Navigation',
+                category: EVENT.CATEGORIES.NAVIGATION,
                 properties: {
                   action: 'Home',
                   legacy_event: true,
@@ -116,7 +117,7 @@ const EthOverview = ({ className }) => {
             onClick={() => {
               trackEvent({
                 event: 'Clicked Send: Eth',
-                category: 'Navigation',
+                category: EVENT.CATEGORIES.NAVIGATION,
                 properties: {
                   action: 'Home',
                   legacy_event: true,

--- a/ui/components/app/wallet-overview/eth-overview.js
+++ b/ui/components/app/wallet-overview/eth-overview.js
@@ -134,7 +134,7 @@ const EthOverview = ({ className }) => {
               if (isSwapsChain) {
                 trackEvent({
                   event: 'Swaps Opened',
-                  category: 'swaps',
+                  category: EVENT.CATEGORIES.SWAPS,
                   properties: {
                     source: 'Main View',
                     active_currency: 'ETH',

--- a/ui/components/app/wallet-overview/token-overview.js
+++ b/ui/components/app/wallet-overview/token-overview.js
@@ -28,6 +28,7 @@ import IconButton from '../../ui/icon-button';
 import { INVALID_ASSET_TYPE } from '../../../helpers/constants/error-keys';
 import { showModal } from '../../../store/actions';
 import { MetaMetricsContext } from '../../../contexts/metametrics';
+import { EVENT } from '../../../../shared/constants/metametrics';
 import { ASSET_TYPES } from '../../../../shared/constants/transaction';
 import WalletOverview from './wallet-overview';
 
@@ -84,7 +85,7 @@ const TokenOverview = ({ className, token }) => {
             onClick={async () => {
               trackEvent({
                 event: 'Clicked Send: Token',
-                category: 'Navigation',
+                category: EVENT.CATEGORIES.NAVIGATION,
                 properties: {
                   action: 'Home',
                   legacy_event: true,
@@ -117,7 +118,7 @@ const TokenOverview = ({ className, token }) => {
               if (isSwapsChain) {
                 trackEvent({
                   event: 'Swaps Opened',
-                  category: 'swaps',
+                  category: EVENT.CATEGORIES.SWAPS,
                   properties: {
                     source: 'Token View',
                     active_currency: token.symbol,

--- a/ui/ducks/swaps/swaps.js
+++ b/ui/ducks/swaps/swaps.js
@@ -126,7 +126,7 @@ const initialState = {
 };
 
 const slice = createSlice({
-  name: EVENT.CATEGORIES.SWAPS,
+  name: 'swaps',
   initialState,
   reducers: {
     clearSwapsState: () => initialState,

--- a/ui/ducks/swaps/swaps.js
+++ b/ui/ducks/swaps/swaps.js
@@ -72,6 +72,8 @@ import {
   getHardwareWalletType,
   checkNetworkAndAccountSupports1559,
 } from '../../selectors';
+
+import { EVENT } from '../../../shared/constants/metametrics';
 import {
   ERROR_FETCHING_QUOTES,
   QUOTES_NOT_AVAILABLE_ERROR,
@@ -124,7 +126,7 @@ const initialState = {
 };
 
 const slice = createSlice({
-  name: 'swaps',
+  name: EVENT.CATEGORIES.SWAPS,
   initialState,
   reducers: {
     clearSwapsState: () => initialState,
@@ -713,7 +715,7 @@ export const fetchQuotesAndSetQuoteState = (
     );
     trackEvent({
       event: 'Quotes Requested',
-      category: 'swaps',
+      category: EVENT.CATEGORIES.SWAPS,
       sensitiveProperties: {
         token_from: fromTokenSymbol,
         token_from_amount: String(inputValue),
@@ -767,7 +769,7 @@ export const fetchQuotesAndSetQuoteState = (
       if (Object.values(fetchedQuotes)?.length === 0) {
         trackEvent({
           event: 'No Quotes Available',
-          category: 'swaps',
+          category: EVENT.CATEGORIES.SWAPS,
           sensitiveProperties: {
             token_from: fromTokenSymbol,
             token_from_amount: String(inputValue),
@@ -788,7 +790,7 @@ export const fetchQuotesAndSetQuoteState = (
 
         trackEvent({
           event: 'Quotes Received',
-          category: 'swaps',
+          category: EVENT.CATEGORIES.SWAPS,
           sensitiveProperties: {
             token_from: fromTokenSymbol,
             token_from_amount: String(inputValue),
@@ -890,7 +892,7 @@ export const signAndSendSwapsSmartTransaction = ({
     };
     trackEvent({
       event: 'STX Swap Started',
-      category: 'swaps',
+      category: EVENT.CATEGORIES.SWAPS,
       sensitiveProperties: swapMetaData,
     });
 
@@ -1140,7 +1142,7 @@ export const signAndSendTransactions = (
 
     trackEvent({
       event: 'Swap Started',
-      category: 'swaps',
+      category: EVENT.CATEGORIES.SWAPS,
       sensitiveProperties: swapMetaData,
     });
 

--- a/ui/pages/asset/components/native-asset.js
+++ b/ui/pages/asset/components/native-asset.js
@@ -15,6 +15,7 @@ import { showModal } from '../../../store/actions';
 import { DEFAULT_ROUTE } from '../../../helpers/constants/routes';
 import { getURLHostName } from '../../../helpers/utils/util';
 import { MetaMetricsContext } from '../../../contexts/metametrics';
+import { EVENT } from '../../../../shared/constants/metametrics';
 import AssetNavigation from './asset-navigation';
 import AssetOptions from './asset-options';
 
@@ -44,7 +45,7 @@ export default function NativeAsset({ nativeCurrency }) {
             onClickBlockExplorer={() => {
               trackEvent({
                 event: 'Clicked Block Explorer Link',
-                category: 'Navigation',
+                category: EVENT.CATEGORIES.NAVIGATION,
                 properties: {
                   link_type: 'Account Tracker',
                   action: 'Asset Options',

--- a/ui/pages/asset/components/token-asset.js
+++ b/ui/pages/asset/components/token-asset.js
@@ -17,6 +17,7 @@ import {
 import { getURLHostName } from '../../../helpers/utils/util';
 import { showModal } from '../../../store/actions';
 import { MetaMetricsContext } from '../../../contexts/metametrics';
+import { EVENT } from '../../../../shared/constants/metametrics';
 import AssetNavigation from './asset-navigation';
 import AssetOptions from './asset-options';
 
@@ -54,7 +55,7 @@ export default function TokenAsset({ token }) {
             onClickBlockExplorer={() => {
               trackEvent({
                 event: 'Clicked Block Explorer Link',
-                category: 'Navigation',
+                category: EVENT.CATEGORIES.NAVIGATION,
                 properties: {
                   link_type: 'Token Tracker',
                   action: 'Token Options',

--- a/ui/pages/confirm-add-suggested-token/confirm-add-suggested-token.js
+++ b/ui/pages/confirm-add-suggested-token/confirm-add-suggested-token.js
@@ -14,6 +14,7 @@ import { isEqualCaseInsensitive } from '../../../shared/modules/string-utils';
 import { getSuggestedAssets } from '../../selectors';
 import { rejectWatchAsset, acceptWatchAsset } from '../../store/actions';
 import { TOKEN_STANDARDS } from '../../helpers/constants/common';
+import { EVENT } from '../../../shared/constants/metametrics';
 import { ASSET_TYPES } from '../../../shared/constants/transaction';
 
 function getTokenName(name, symbol) {
@@ -115,7 +116,7 @@ const ConfirmAddSuggestedToken = () => {
 
         trackEvent({
           event: 'Token Added',
-          category: 'Wallet',
+          category: EVENT.CATEGORIES.WALLET,
           sensitiveProperties: {
             token_symbol: asset.symbol,
             token_contract_address: asset.address,

--- a/ui/pages/confirm-decrypt-message/confirm-decrypt-message.component.js
+++ b/ui/pages/confirm-decrypt-message/confirm-decrypt-message.component.js
@@ -9,6 +9,7 @@ import Identicon from '../../components/ui/identicon';
 import Tooltip from '../../components/ui/tooltip';
 import Copy from '../../components/ui/icon/copy-icon.component';
 
+import { EVENT } from '../../../shared/constants/metametrics';
 import { SECOND } from '../../../shared/constants/time';
 import { conversionUtil } from '../../../shared/modules/conversion.utils';
 
@@ -45,7 +46,7 @@ export default class ConfirmDecryptMessage extends Component {
   copyMessage = () => {
     copyToClipboard(this.state.rawMessage);
     this.context.trackEvent({
-      category: 'Messages',
+      category: EVENT.CATEGORIES.MESSAGES,
       event: 'Copy',
       properties: {
         action: 'Decrypt Message Copy',
@@ -263,7 +264,7 @@ export default class ConfirmDecryptMessage extends Component {
           onClick={async (event) => {
             await cancelDecryptMessage(txData, event);
             trackEvent({
-              category: 'Messages',
+              category: EVENT.CATEGORIES.MESSAGES,
               event: 'Cancel',
               properties: {
                 action: 'Decrypt Message Request',
@@ -283,7 +284,7 @@ export default class ConfirmDecryptMessage extends Component {
           onClick={async (event) => {
             await decryptMessage(txData, event);
             trackEvent({
-              category: 'Messages',
+              category: EVENT.CATEGORIES.MESSAGES,
               event: 'Confirm',
               properties: {
                 action: 'Decrypt Message Request',

--- a/ui/pages/confirm-encryption-public-key/confirm-encryption-public-key.component.js
+++ b/ui/pages/confirm-encryption-public-key/confirm-encryption-public-key.component.js
@@ -5,6 +5,7 @@ import AccountListItem from '../../components/app/account-list-item';
 import Button from '../../components/ui/button';
 import Identicon from '../../components/ui/identicon';
 
+import { EVENT } from '../../../shared/constants/metametrics';
 import { conversionUtil } from '../../../shared/modules/conversion.utils';
 
 export default class ConfirmEncryptionPublicKey extends Component {
@@ -165,7 +166,7 @@ export default class ConfirmEncryptionPublicKey extends Component {
           onClick={async (event) => {
             await cancelEncryptionPublicKey(txData, event);
             trackEvent({
-              category: 'Messages',
+              category: EVENT.CATEGORIES.MESSAGES,
               event: 'Cancel',
               properties: {
                 action: 'Encryption public key Request',
@@ -185,7 +186,7 @@ export default class ConfirmEncryptionPublicKey extends Component {
           onClick={async (event) => {
             await encryptionPublicKey(txData, event);
             this.context.trackEvent({
-              category: 'Messages',
+              category: EVENT.CATEGORIES.MESSAGES,
               event: 'Confirm',
               properties: {
                 action: 'Encryption public key Request',

--- a/ui/pages/confirm-import-token/confirm-import-token.js
+++ b/ui/pages/confirm-import-token/confirm-import-token.js
@@ -14,6 +14,7 @@ import { getMostRecentOverviewPage } from '../../ducks/history/history';
 import { getPendingTokens } from '../../ducks/metamask/metamask';
 import { addTokens, clearPendingTokens } from '../../store/actions';
 import { TOKEN_STANDARDS } from '../../helpers/constants/common';
+import { EVENT } from '../../../shared/constants/metametrics';
 import { ASSET_TYPES } from '../../../shared/constants/transaction';
 
 const getTokenName = (name, symbol) => {
@@ -38,7 +39,7 @@ const ConfirmImportToken = () => {
     addedTokenValues.forEach((pendingToken) => {
       trackEvent({
         event: 'Token Added',
-        category: 'Wallet',
+        category: EVENT.CATEGORIES.WALLET,
         sensitiveProperties: {
           token_symbol: pendingToken.symbol,
           token_contract_address: pendingToken.address,

--- a/ui/pages/confirm-transaction-base/confirm-transaction-base.component.js
+++ b/ui/pages/confirm-transaction-base/confirm-transaction-base.component.js
@@ -25,6 +25,7 @@ import { PRIMARY, SECONDARY } from '../../helpers/constants/common';
 import TextField from '../../components/ui/text-field';
 import ActionableMessage from '../../components/ui/actionable-message';
 import Disclosure from '../../components/ui/disclosure';
+import { EVENT } from '../../../shared/constants/metametrics';
 import {
   TRANSACTION_TYPES,
   TRANSACTION_STATUSES,
@@ -278,7 +279,7 @@ export default class ConfirmTransactionBase extends Component {
     } = this.props;
 
     this.context.trackEvent({
-      category: 'Transactions',
+      category: EVENT.CATEGORIES.TRANSACTIONS,
       event: 'User clicks "Edit" on gas',
       properties: {
         action: 'Confirm Screen',
@@ -737,7 +738,7 @@ export default class ConfirmTransactionBase extends Component {
     } = this.props;
 
     this.context.trackEvent({
-      category: 'Transactions',
+      category: EVENT.CATEGORIES.TRANSACTIONS,
       event: 'Edit Transaction',
       properties: {
         action: 'Confirm Screen',
@@ -944,7 +945,7 @@ export default class ConfirmTransactionBase extends Component {
     } = this.props;
     const { trackEvent } = this.context;
     trackEvent({
-      category: 'Transactions',
+      category: EVENT.CATEGORIES.TRANSACTIONS,
       event: 'Confirm: Started',
       properties: {
         action: 'Confirm Screen',

--- a/ui/pages/create-account/connect-hardware/account-list.js
+++ b/ui/pages/create-account/connect-hardware/account-list.js
@@ -9,6 +9,7 @@ import Dropdown from '../../../components/ui/dropdown';
 import { getURLHostName } from '../../../helpers/utils/util';
 
 import { DEVICE_NAMES } from '../../../../shared/constants/hardware-wallets';
+import { EVENT } from '../../../../shared/constants/metametrics';
 
 class AccountList extends Component {
   state = {
@@ -136,7 +137,7 @@ class AccountList extends Component {
                     rpcPrefs,
                   );
                   this.context.trackEvent({
-                    category: 'Account',
+                    category: EVENT.CATEGORIES.ACCOUNTS,
                     event: 'Clicked Block Explorer Link',
                     properties: {
                       actions: 'Hardware Connect',

--- a/ui/pages/create-account/connect-hardware/index.js
+++ b/ui/pages/create-account/connect-hardware/index.js
@@ -10,6 +10,7 @@ import {
 } from '../../../selectors';
 import { formatBalance } from '../../../helpers/utils/util';
 import { getMostRecentOverviewPage } from '../../../ducks/history/history';
+import { EVENT } from '../../../../shared/constants/metametrics';
 import { SECOND } from '../../../../shared/constants/time';
 import {
   DEVICE_NAMES,
@@ -254,7 +255,7 @@ class ConnectHardwareForm extends Component {
     )
       .then((_) => {
         this.context.trackEvent({
-          category: 'Accounts',
+          category: EVENT.CATEGORIES.ACCOUNTS,
           event: `Connected Account with: ${device}`,
           properties: {
             action: 'Connected Hardware Wallet',
@@ -265,7 +266,7 @@ class ConnectHardwareForm extends Component {
       })
       .catch((e) => {
         this.context.trackEvent({
-          category: 'Accounts',
+          category: EVENT.CATEGORIES.ACCOUNTS,
           event: 'Error connecting hardware wallet',
           properties: {
             action: 'Connected Hardware Wallet',

--- a/ui/pages/create-account/import-account/json.js
+++ b/ui/pages/create-account/import-account/json.js
@@ -7,6 +7,7 @@ import FileInput from 'react-simple-file-input';
 import * as actions from '../../../store/actions';
 import { getMetaMaskAccounts } from '../../../selectors';
 import Button from '../../../components/ui/button';
+import { EVENT } from '../../../../shared/constants/metametrics';
 import { getMostRecentOverviewPage } from '../../../ducks/history/history';
 
 const HELP_LINK =
@@ -117,7 +118,7 @@ class JsonImportSubview extends Component {
         if (selectedAddress) {
           history.push(mostRecentOverviewPage);
           this.context.trackEvent({
-            category: 'Accounts',
+            category: EVENT.CATEGORIES.ACCOUNTS,
             event: 'Imported Account with JSON',
             properties: {
               action: 'Import Account',
@@ -128,7 +129,7 @@ class JsonImportSubview extends Component {
         } else {
           displayWarning(t('importAccountError'));
           this.context.trackEvent({
-            category: 'Accounts',
+            category: EVENT.CATEGORIES.ACCOUNTS,
             event: 'Error importing JSON',
             properties: {
               action: 'Import Account',

--- a/ui/pages/create-account/import-account/private-key.js
+++ b/ui/pages/create-account/import-account/private-key.js
@@ -7,6 +7,7 @@ import * as actions from '../../../store/actions';
 import { getMetaMaskAccounts } from '../../../selectors';
 import Button from '../../../components/ui/button';
 import { getMostRecentOverviewPage } from '../../../ducks/history/history';
+import { EVENT } from '../../../../shared/constants/metametrics';
 
 class PrivateKeyImportView extends Component {
   static contextTypes = {
@@ -44,7 +45,7 @@ class PrivateKeyImportView extends Component {
       .then(({ selectedAddress }) => {
         if (selectedAddress) {
           this.context.trackEvent({
-            category: 'Accounts',
+            category: EVENT.CATEGORIES.ACCOUNTS,
             event: 'Imported Account with Private Key',
             properties: {
               action: 'Import Account',
@@ -56,7 +57,7 @@ class PrivateKeyImportView extends Component {
         } else {
           displayWarning(t('importAccountError'));
           this.context.trackEvent({
-            category: 'Accounts',
+            category: EVENT.CATEGORIES.ACCOUNTS,
             event: 'Error importing with Private Key',
             properties: {
               action: 'Import Account',

--- a/ui/pages/create-account/new-account.component.js
+++ b/ui/pages/create-account/new-account.component.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import Button from '../../components/ui/button';
+import { EVENT } from '../../../shared/constants/metametrics';
 
 export default class NewAccountCreateForm extends Component {
   static defaultProps = {
@@ -28,7 +29,7 @@ export default class NewAccountCreateForm extends Component {
       createAccount(newAccountName || defaultAccountName)
         .then(() => {
           this.context.trackEvent({
-            category: 'Accounts',
+            category: EVENT.CATEGORIES.ACCOUNTS,
             event: 'Added New Account',
             properties: {
               action: 'Add New Account',
@@ -39,7 +40,7 @@ export default class NewAccountCreateForm extends Component {
         })
         .catch((e) => {
           this.context.trackEvent({
-            category: 'Accounts',
+            category: EVENT.CATEGORIES.ACCOUNTS,
             event: 'Error',
             properties: {
               action: 'Add New Account',

--- a/ui/pages/first-time-flow/create-password/import-with-seed-phrase/import-with-seed-phrase.component.js
+++ b/ui/pages/first-time-flow/create-password/import-with-seed-phrase/import-with-seed-phrase.component.js
@@ -5,6 +5,7 @@ import {
   INITIALIZE_END_OF_FLOW_ROUTE,
 } from '../../../../helpers/constants/routes';
 import CreateNewVault from '../../../../components/app/create-new-vault';
+import { EVENT } from '../../../../../shared/constants/metametrics';
 
 export default class ImportWithSeedPhrase extends PureComponent {
   static contextTypes = {
@@ -22,7 +23,7 @@ export default class ImportWithSeedPhrase extends PureComponent {
   UNSAFE_componentWillMount() {
     this._onBeforeUnload = () =>
       this.context.trackEvent({
-        category: 'Onboarding',
+        category: EVENT.CATEGORIES.ONBOARDING,
         event: 'Close window on import screen',
         properties: {
           action: 'Import Seed Phrase',
@@ -48,7 +49,7 @@ export default class ImportWithSeedPhrase extends PureComponent {
 
     await onSubmit(password, seedPhrase);
     this.context.trackEvent({
-      category: 'Onboarding',
+      category: EVENT.CATEGORIES.ONBOARDING,
       event: 'Import Complete',
       properties: {
         action: 'Import Seed Phrase',
@@ -71,7 +72,7 @@ export default class ImportWithSeedPhrase extends PureComponent {
             onClick={(e) => {
               e.preventDefault();
               this.context.trackEvent({
-                category: 'Onboarding',
+                category: EVENT.CATEGORIES.ONBOARDING,
                 event: 'Go Back from Onboarding Import',
                 properties: {
                   action: 'Import Seed Phrase',

--- a/ui/pages/first-time-flow/create-password/new-account/new-account.component.js
+++ b/ui/pages/first-time-flow/create-password/new-account/new-account.component.js
@@ -6,6 +6,7 @@ import {
   INITIALIZE_SELECT_ACTION_ROUTE,
 } from '../../../../helpers/constants/routes';
 import TextField from '../../../../components/ui/text-field';
+import { EVENT } from '../../../../../shared/constants/metametrics';
 
 export default class NewAccount extends PureComponent {
   static contextTypes = {
@@ -101,7 +102,7 @@ export default class NewAccount extends PureComponent {
       await onSubmit(password);
 
       this.context.trackEvent({
-        category: 'Onboarding',
+        category: EVENT.CATEGORIES.ONBOARDING,
         event: 'Submit Password',
         properties: {
           action: 'Create Password',
@@ -117,7 +118,7 @@ export default class NewAccount extends PureComponent {
 
   toggleTermsCheck = () => {
     this.context.trackEvent({
-      category: 'Onboarding',
+      category: EVENT.CATEGORIES.ONBOARDING,
       event: 'Check ToS',
       properties: {
         action: 'Create Password',
@@ -153,7 +154,7 @@ export default class NewAccount extends PureComponent {
             onClick={(e) => {
               e.preventDefault();
               this.context.trackEvent({
-                category: 'Onboarding',
+                category: EVENT.CATEGORIES.ONBOARDING,
                 event: 'Go Back from Onboarding Create',
                 properties: {
                   action: 'Create Password',

--- a/ui/pages/first-time-flow/end-of-flow/end-of-flow.component.js
+++ b/ui/pages/first-time-flow/end-of-flow/end-of-flow.component.js
@@ -6,6 +6,7 @@ import MetaFoxLogo from '../../../components/ui/metafox-logo';
 import { SUPPORT_REQUEST_LINK } from '../../../helpers/constants/common';
 import { DEFAULT_ROUTE } from '../../../helpers/constants/routes';
 import { returnToOnboardingInitiator } from '../onboarding-initiator-util';
+import { EVENT } from '../../../../shared/constants/metametrics';
 
 export default class EndOfFlowScreen extends PureComponent {
   static contextTypes = {
@@ -35,7 +36,7 @@ export default class EndOfFlowScreen extends PureComponent {
     const { setCompletedOnboarding, completionMetaMetricsName } = this.props;
     await setCompletedOnboarding();
     this.context.trackEvent({
-      category: 'Onboarding',
+      category: EVENT.CATEGORIES.ONBOARDING,
       event: completionMetaMetricsName,
       properties: {
         action: 'Onboarding Complete',

--- a/ui/pages/first-time-flow/metametrics-opt-in/metametrics-opt-in.component.js
+++ b/ui/pages/first-time-flow/metametrics-opt-in/metametrics-opt-in.component.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import MetaFoxLogo from '../../../components/ui/metafox-logo';
 import PageContainerFooter from '../../../components/ui/page-container/page-container-footer';
+import { EVENT } from '../../../../shared/constants/metametrics';
 
 export default class MetaMetricsOptIn extends Component {
   static propTypes = {
@@ -111,7 +112,7 @@ export default class MetaMetricsOptIn extends Component {
                   ) {
                     await trackEvent(
                       {
-                        category: 'Onboarding',
+                        category: EVENT.CATEGORIES.ONBOARDING,
                         event: 'Metrics Opt Out',
                         properties: {
                           action: 'Metrics Option',
@@ -143,7 +144,7 @@ export default class MetaMetricsOptIn extends Component {
                     metrics.push(
                       trackEvent(
                         {
-                          category: 'Onboarding',
+                          category: EVENT.CATEGORIES.ONBOARDING,
                           event: 'Metrics Opt In',
                           properties: {
                             action: 'Metrics Option',
@@ -160,7 +161,7 @@ export default class MetaMetricsOptIn extends Component {
                   metrics.push(
                     trackEvent(
                       {
-                        category: 'Onboarding',
+                        category: EVENT.CATEGORIES.ONBOARDING,
                         event: firstTimeSelectionMetaMetricsName,
                         properties: {
                           action: 'Import or Create',

--- a/ui/pages/first-time-flow/seed-phrase/confirm-seed-phrase/confirm-seed-phrase.component.js
+++ b/ui/pages/first-time-flow/seed-phrase/confirm-seed-phrase/confirm-seed-phrase.component.js
@@ -7,6 +7,7 @@ import {
   INITIALIZE_SEED_PHRASE_ROUTE,
 } from '../../../../helpers/constants/routes';
 import { exportAsFile } from '../../../../helpers/utils/util';
+import { EVENT } from '../../../../../shared/constants/metametrics';
 import DraggableSeed from './draggable-seed.component';
 
 const EMPTY_SEEDS = Array(12).fill(null);
@@ -78,7 +79,7 @@ export default class ConfirmSeedPhrase extends PureComponent {
 
     try {
       this.context.trackEvent({
-        category: 'Onboarding',
+        category: EVENT.CATEGORIES.ONBOARDING,
         event: 'Verify Complete',
         properties: {
           action: 'Seed Phrase Setup',

--- a/ui/pages/first-time-flow/seed-phrase/reveal-seed-phrase/reveal-seed-phrase.component.js
+++ b/ui/pages/first-time-flow/seed-phrase/reveal-seed-phrase/reveal-seed-phrase.component.js
@@ -11,6 +11,7 @@ import {
   INITIALIZE_SEED_PHRASE_INTRO_ROUTE,
 } from '../../../../helpers/constants/routes';
 import { exportAsFile } from '../../../../helpers/utils/util';
+import { EVENT } from '../../../../../shared/constants/metametrics';
 import { returnToOnboardingInitiator } from '../../onboarding-initiator-util';
 
 export default class RevealSeedPhrase extends PureComponent {
@@ -43,7 +44,7 @@ export default class RevealSeedPhrase extends PureComponent {
     const { history } = this.props;
 
     this.context.trackEvent({
-      category: 'Onboarding',
+      category: EVENT.CATEGORIES.ONBOARDING,
       event: 'Advance to Verify',
       properties: {
         action: 'Seed Phrase Setup',
@@ -67,7 +68,7 @@ export default class RevealSeedPhrase extends PureComponent {
     } = this.props;
 
     this.context.trackEvent({
-      category: 'Onboarding',
+      category: EVENT.CATEGORIES.ONBOARDING,
       event: 'Remind me later',
       properties: {
         action: 'Seed Phrase Setup',
@@ -105,7 +106,7 @@ export default class RevealSeedPhrase extends PureComponent {
             className="reveal-seed-phrase__secret-blocker"
             onClick={() => {
               this.context.trackEvent({
-                category: 'Onboarding',
+                category: EVENT.CATEGORIES.ONBOARDING,
                 event: 'Revealed Words',
                 properties: {
                   action: 'Seed Phrase Setup',

--- a/ui/pages/keychains/restore-vault.js
+++ b/ui/pages/keychains/restore-vault.js
@@ -13,6 +13,7 @@ import Box from '../../components/ui/box';
 import Typography from '../../components/ui/typography';
 import ZENDESK_URLS from '../../helpers/constants/zendesk-url';
 import { TYPOGRAPHY, COLORS } from '../../helpers/constants/design-system';
+import { EVENT } from '../../../shared/constants/metametrics';
 
 class RestoreVaultPage extends Component {
   static contextTypes = {
@@ -41,7 +42,7 @@ class RestoreVaultPage extends Component {
     leaveImportSeedScreenState();
     await createNewVaultAndRestore(password, seedPhrase);
     this.context.trackEvent({
-      category: 'Retention',
+      category: EVENT.CATEGORIES.RETENTION,
       event: 'onboardingRestoredVault',
       properties: {
         action: 'userEntersSeedPhrase',

--- a/ui/pages/onboarding-flow/create-password/create-password.js
+++ b/ui/pages/onboarding-flow/create-password/create-password.js
@@ -30,6 +30,7 @@ import ZENDESK_URLS from '../../../helpers/constants/zendesk-url';
 import { getFirstTimeFlowType } from '../../../selectors';
 import { FIRST_TIME_FLOW_TYPES } from '../../../helpers/constants/onboarding';
 import { MetaMetricsContext } from '../../../contexts/metametrics';
+import { EVENT } from '../../../../shared/constants/metametrics';
 
 export default function CreatePassword({
   createNewAccount,
@@ -140,7 +141,7 @@ export default function CreatePassword({
         }
         trackEvent({
           event: 'Submit Password',
-          category: 'Onboarding',
+          category: EVENT.CATEGORIES.ONBOARDING,
         });
         history.push(ONBOARDING_SECURE_YOUR_WALLET_ROUTE);
       } catch (error) {

--- a/ui/pages/onboarding-flow/creation-successful/creation-successful.js
+++ b/ui/pages/onboarding-flow/creation-successful/creation-successful.js
@@ -17,6 +17,7 @@ import {
 import { setCompletedOnboarding } from '../../../store/actions';
 import { getFirstTimeFlowType } from '../../../selectors';
 import { MetaMetricsContext } from '../../../contexts/metametrics';
+import { EVENT } from '../../../../shared/constants/metametrics';
 
 export default function CreationSuccessful() {
   const firstTimeFlowTypeNameMap = {
@@ -34,7 +35,7 @@ export default function CreationSuccessful() {
     await dispatch(setCompletedOnboarding());
     trackEvent({
       event: firstTimeFlowTypeNameMap[firstTimeFlowType],
-      category: 'Onboarding',
+      category: EVENT.CATEGORIES.ONBOARDING,
       properties: {
         action: 'Onboarding Complete',
         legacy_event: true,

--- a/ui/pages/onboarding-flow/metametrics/metametrics.js
+++ b/ui/pages/onboarding-flow/metametrics/metametrics.js
@@ -17,6 +17,8 @@ import {
   getParticipateInMetaMetrics,
 } from '../../../selectors';
 
+import { EVENT } from '../../../../shared/constants/metametrics';
+
 import { MetaMetricsContext } from '../../../contexts/metametrics';
 
 const firstTimeFlowTypeNameMap = {
@@ -45,7 +47,7 @@ export default function OnboardingMetametrics() {
       if (!participateInMetaMetrics) {
         trackEvent(
           {
-            category: 'Onboarding',
+            category: EVENT.CATEGORIES.ONBOARDING,
             event: 'Metrics Opt In',
             properties: {
               action: 'Metrics Option',
@@ -60,7 +62,7 @@ export default function OnboardingMetametrics() {
       }
       trackEvent(
         {
-          category: 'Onboarding',
+          category: EVENT.CATEGORIES.ONBOARDING,
           event: firstTimeSelectionMetaMetricsName,
           properties: {
             action: 'Import or Create',
@@ -85,7 +87,7 @@ export default function OnboardingMetametrics() {
       if (!participateInMetaMetrics) {
         trackEvent(
           {
-            category: 'Onboarding',
+            category: EVENT.CATEGORIES.ONBOARDING,
             event: 'Metrics Opt Out',
             properties: {
               action: 'Metrics Option',

--- a/ui/pages/send/send-content/send-amount-row/amount-max-button/amount-max-button.js
+++ b/ui/pages/send/send-content/send-amount-row/amount-max-button/amount-max-button.js
@@ -8,6 +8,7 @@ import {
 } from '../../../../../ducks/send';
 import { useI18nContext } from '../../../../../hooks/useI18nContext';
 import { MetaMetricsContext } from '../../../../../contexts/metametrics';
+import { EVENT } from '../../../../../../shared/constants/metametrics';
 
 export default function AmountMaxButton() {
   const isDraftTransactionInvalid = useSelector(isSendFormInvalid);
@@ -19,7 +20,7 @@ export default function AmountMaxButton() {
   const onMaxClick = () => {
     trackEvent({
       event: 'Clicked "Amount Max"',
-      category: 'Transactions',
+      category: EVENT.CATEGORIES.TRANSACTIONS,
       properties: {
         action: 'Edit Screen',
         legacy_event: true,

--- a/ui/pages/send/send-content/send-asset-row/send-asset-row.component.js
+++ b/ui/pages/send/send-content/send-asset-row/send-asset-row.component.js
@@ -7,6 +7,7 @@ import TokenListDisplay from '../../../../components/app/token-list-display';
 import UserPreferencedCurrencyDisplay from '../../../../components/app/user-preferenced-currency-display';
 import { ERC20, ERC721, PRIMARY } from '../../../../helpers/constants/common';
 import { isEqualCaseInsensitive } from '../../../../../shared/modules/string-utils';
+import { EVENT } from '../../../../../shared/constants/metametrics';
 import { ASSET_TYPES } from '../../../../../shared/constants/transaction';
 
 export default class SendAssetRow extends Component {
@@ -88,7 +89,7 @@ export default class SendAssetRow extends Component {
       },
       () => {
         this.context.trackEvent({
-          category: 'Transactions',
+          category: EVENT.CATEGORIES.TRANSACTIONS,
           event: 'User clicks "Assets" dropdown',
           properties: {
             action: 'Send Screen',

--- a/ui/pages/send/send-footer/send-footer.component.js
+++ b/ui/pages/send/send-footer/send-footer.component.js
@@ -6,6 +6,7 @@ import {
   CONFIRM_TRANSACTION_ROUTE,
   DEFAULT_ROUTE,
 } from '../../../helpers/constants/routes';
+import { EVENT } from '../../../../shared/constants/metametrics';
 import { SEND_STAGES } from '../../../ducks/send';
 
 export default class SendFooter extends Component {
@@ -68,7 +69,7 @@ export default class SendFooter extends Component {
 
     Promise.resolve(promise).then(() => {
       trackEvent({
-        category: 'Transactions',
+        category: EVENT.CATEGORIES.TRANSACTIONS,
         event: 'Complete',
         properties: {
           action: 'Edit Screen',
@@ -91,7 +92,7 @@ export default class SendFooter extends Component {
       const errorMessage = sendErrors[errorField];
 
       trackEvent({
-        category: 'Transactions',
+        category: EVENT.CATEGORIES.TRANSACTIONS,
         event: 'Error',
         properties: {
           action: 'Edit Screen',

--- a/ui/pages/send/send.js
+++ b/ui/pages/send/send.js
@@ -17,6 +17,7 @@ import { getCurrentChainId, isCustomPriceExcessive } from '../../selectors';
 import { getSendHexDataFeatureFlagState } from '../../ducks/metamask/metamask';
 import { showQrScanner } from '../../store/actions';
 import { MetaMetricsContext } from '../../contexts/metametrics';
+import { EVENT } from '../../../shared/constants/metametrics';
 import SendHeader from './send-header';
 import AddRecipient from './send-content/add-recipient';
 import SendContent from './send-content';
@@ -105,7 +106,7 @@ export default function SendTransactionScreen() {
         scanQrCode={() => {
           trackEvent({
             event: 'Used QR scanner',
-            category: 'Transactions',
+            category: EVENT.CATEGORIES.TRANSACTIONS,
             properties: {
               action: 'Edit Screen',
               legacy_event: true,

--- a/ui/pages/settings/advanced-tab/advanced-tab.component.js
+++ b/ui/pages/settings/advanced-tab/advanced-tab.component.js
@@ -21,6 +21,7 @@ import {
   LEDGER_TRANSPORT_TYPES,
   LEDGER_USB_VENDOR_ID,
 } from '../../../../shared/constants/hardware-wallets';
+import { EVENT } from '../../../../shared/constants/metametrics';
 
 export default class AdvancedTab extends PureComponent {
   static contextTypes = {
@@ -180,7 +181,7 @@ export default class AdvancedTab extends PureComponent {
               onClick={(event) => {
                 event.preventDefault();
                 this.context.trackEvent({
-                  category: 'Settings',
+                  category: EVENT.CATEGORIES.SETTINGS,
                   event: 'Reset Account',
                   properties: {
                     action: 'Reset Account',
@@ -698,7 +699,7 @@ export default class AdvancedTab extends PureComponent {
               value={useTokenDetection}
               onToggle={(value) => {
                 this.context.trackEvent({
-                  category: 'Settings',
+                  category: EVENT.CATEGORIES.SETTINGS,
                   event: 'Token Detection',
                   properties: {
                     action: 'Token Detection',

--- a/ui/pages/settings/experimental-tab/experimental-tab.component.js
+++ b/ui/pages/settings/experimental-tab/experimental-tab.component.js
@@ -6,6 +6,7 @@ import {
   handleSettingsRefs,
 } from '../../../helpers/utils/settings-search';
 import Dropdown from '../../../components/ui/dropdown';
+import { EVENT } from '../../../../shared/constants/metametrics';
 
 import { THEME_TYPE } from './experimental-tab.constant';
 
@@ -67,7 +68,7 @@ export default class ExperimentalTab extends PureComponent {
               value={useTokenDetection}
               onToggle={(value) => {
                 this.context.trackEvent({
-                  category: 'Settings',
+                  category: EVENT.CATEGORIES.SETTINGS,
                   event: 'Token Detection',
                   properties: {
                     action: 'Token Detection',
@@ -115,7 +116,7 @@ export default class ExperimentalTab extends PureComponent {
               value={useCollectibleDetection}
               onToggle={(value) => {
                 this.context.trackEvent({
-                  category: 'Settings',
+                  category: EVENT.CATEGORIES.SETTINGS,
                   event: 'Collectible Detection',
                   properties: {
                     action: 'Collectible Detection',
@@ -165,7 +166,7 @@ export default class ExperimentalTab extends PureComponent {
               value={openSeaEnabled}
               onToggle={(value) => {
                 this.context.trackEvent({
-                  category: 'Settings',
+                  category: EVENT.CATEGORIES.SETTINGS,
                   event: 'Enabled/Disable OpenSea',
                   properties: {
                     action: 'Enabled/Disable OpenSea',
@@ -214,7 +215,7 @@ export default class ExperimentalTab extends PureComponent {
               value={eip1559V2Enabled}
               onToggle={(value) => {
                 this.context.trackEvent({
-                  category: 'Settings',
+                  category: EVENT.CATEGORIES.SETTINGS,
                   event: 'Enabled/Disable OpenSea',
                   properties: {
                     action: 'Enabled/Disable OpenSea',
@@ -249,7 +250,7 @@ export default class ExperimentalTab extends PureComponent {
 
     const onChange = (newTheme) => {
       this.context.trackEvent({
-        category: 'Settings',
+        category: EVENT.CATEGORIES.SETTINGS,
         event: 'Theme Changed',
         properties: {
           theme_selected: newTheme,

--- a/ui/pages/settings/security-tab/security-tab.component.js
+++ b/ui/pages/settings/security-tab/security-tab.component.js
@@ -7,6 +7,7 @@ import {
   getNumberOfSettingsInSection,
   handleSettingsRefs,
 } from '../../../helpers/utils/settings-search';
+import { EVENT } from '../../../../shared/constants/metametrics';
 
 export default class SecurityTab extends PureComponent {
   static contextTypes = {
@@ -63,7 +64,7 @@ export default class SecurityTab extends PureComponent {
               onClick={(event) => {
                 event.preventDefault();
                 this.context.trackEvent({
-                  category: 'Settings',
+                  category: EVENT.CATEGORIES.SETTINGS,
                   event: 'Reveal Seed Phrase',
                   properties: {
                     action: 'Reveal Seed Phrase',

--- a/ui/pages/swaps/awaiting-signatures/awaiting-signatures.js
+++ b/ui/pages/swaps/awaiting-signatures/awaiting-signatures.js
@@ -33,6 +33,7 @@ import {
 } from '../../../helpers/constants/design-system';
 import SwapsFooter from '../swaps-footer';
 import { MetaMetricsContext } from '../../../contexts/metametrics';
+import { EVENT } from '../../../../shared/constants/metametrics';
 import SwapStepIcon from './swap-step-icon';
 
 export default function AwaitingSignatures() {
@@ -57,7 +58,7 @@ export default function AwaitingSignatures() {
   useEffect(() => {
     trackEvent({
       event: 'Awaiting Signature(s) on a HW wallet',
-      category: 'swaps',
+      category: EVENT.CATEGORIES.SWAPS,
       sensitiveProperties: {
         needs_two_confirmations: needsTwoConfirmations,
         token_from: sourceTokenInfo?.symbol,

--- a/ui/pages/swaps/awaiting-swap/awaiting-swap.js
+++ b/ui/pages/swaps/awaiting-swap/awaiting-swap.js
@@ -8,6 +8,7 @@ import { getBlockExplorerLink } from '@metamask/etherscan-link';
 import { I18nContext } from '../../../contexts/i18n';
 import { SUPPORT_LINK } from '../../../helpers/constants/common';
 import { MetaMetricsContext } from '../../../contexts/metametrics';
+import { EVENT } from '../../../../shared/constants/metametrics';
 
 import {
   getCurrentChainId,
@@ -188,7 +189,7 @@ export default function AwaitingSwap({
       setTrackedQuotesExpiredEvent(true);
       trackEvent({
         event: 'Quotes Timed Out',
-        category: 'swaps',
+        category: EVENT.CATEGORIES.SWAPS,
         sensitiveProperties,
       });
     }
@@ -255,7 +256,7 @@ export default function AwaitingSwap({
           onClick={async () => {
             trackEvent({
               event: 'Make Another Swap',
-              category: 'swaps',
+              category: EVENT.CATEGORIES.SWAPS,
               sensitiveProperties,
             });
             await dispatch(navigateBackToBuildQuote(history));

--- a/ui/pages/swaps/awaiting-swap/view-on-ether-scan-link/view-on-ether-scan-link.js
+++ b/ui/pages/swaps/awaiting-swap/view-on-ether-scan-link/view-on-ether-scan-link.js
@@ -4,6 +4,7 @@ import classnames from 'classnames';
 import { I18nContext } from '../../../../contexts/i18n';
 import { getURLHostName } from '../../../../helpers/utils/util';
 import { MetaMetricsContext } from '../../../../contexts/metametrics';
+import { EVENT } from '../../../../../shared/constants/metametrics';
 
 export default function ViewOnEtherScanLink({
   txHash,
@@ -22,7 +23,7 @@ export default function ViewOnEtherScanLink({
       onClick={() => {
         trackEvent({
           event: 'Clicked Block Explorer Link',
-          category: 'Swaps',
+          category: EVENT.CATEGORIES.SWAPS,
           properties: {
             link_type: 'Transaction Block Explorer',
             action: 'Swap Transaction',

--- a/ui/pages/swaps/build-quote/build-quote.js
+++ b/ui/pages/swaps/build-quote/build-quote.js
@@ -86,6 +86,7 @@ import {
   isSwapsDefaultTokenAddress,
   isSwapsDefaultTokenSymbol,
 } from '../../../../shared/modules/swaps.utils';
+import { EVENT } from '../../../../shared/constants/metametrics';
 import {
   SWAPS_CHAINID_DEFAULT_BLOCK_EXPLORER_URL_MAP,
   SWAPS_CHAINID_DEFAULT_TOKEN_MAP,
@@ -441,7 +442,7 @@ export default function BuildQuote({
   const trackBuildQuotePageLoadedEvent = useCallback(() => {
     trackEvent({
       event: 'Build Quote Page Loaded',
-      category: 'swaps',
+      category: EVENT.CATEGORIES.SWAPS,
       sensitiveProperties: {
         is_hardware_wallet: hardwareWalletUsed,
         hardware_wallet_type: hardwareWalletType,
@@ -473,7 +474,7 @@ export default function BuildQuote({
         onClick={() => {
           trackEvent({
             event: 'Clicked Block Explorer Link',
-            category: 'Swaps',
+            category: EVENT.CATEGORIES.SWAPS,
             properties: {
               link_type: 'Token Tracker',
               action: 'Swaps Confirmation',
@@ -802,7 +803,7 @@ export default function BuildQuote({
                       onClick={() => {
                         trackEvent({
                           event: 'Clicked Block Explorer Link',
-                          category: 'Swaps',
+                          category: EVENT.CATEGORIES.SWAPS,
                           properties: {
                             link_type: 'Token Tracker',
                             action: 'Swaps Confirmation',

--- a/ui/pages/swaps/dropdown-search-list/dropdown-search-list.js
+++ b/ui/pages/swaps/dropdown-search-list/dropdown-search-list.js
@@ -29,6 +29,7 @@ import {
   getCurrentSmartTransactionsEnabled,
 } from '../../../ducks/swaps/swaps';
 import { MetaMetricsContext } from '../../../contexts/metametrics';
+import { EVENT } from '../../../../shared/constants/metametrics';
 
 export default function DropdownSearchList({
   searchListClassName,
@@ -92,7 +93,7 @@ export default function DropdownSearchList({
   const onImportTokenClick = () => {
     trackEvent({
       event: 'Token Imported',
-      category: 'swaps',
+      category: EVENT.CATEGORIES.SWAPS,
       sensitiveProperties: {
         symbol: tokenForImport?.symbol,
         address: tokenForImport?.address,

--- a/ui/pages/swaps/dropdown-search-list/dropdown-search-list.js
+++ b/ui/pages/swaps/dropdown-search-list/dropdown-search-list.js
@@ -242,7 +242,7 @@ export default function DropdownSearchList({
                             onClick={() => {
                               trackEvent({
                                 event: 'Clicked Block Explorer Link',
-                                category: 'Swaps',
+                                category: EVENT.CATEGORIES.SWAPS,
                                 properties: {
                                   link_type: 'Token Tracker',
                                   action: 'Verify Contract Address',

--- a/ui/pages/swaps/fee-card/fee-card.js
+++ b/ui/pages/swaps/fee-card/fee-card.js
@@ -20,6 +20,7 @@ import {
 } from '../../../helpers/constants/design-system';
 import GasDetailsItemTitle from '../../../components/app/gas-details-item/gas-details-item-title';
 import { MetaMetricsContext } from '../../../contexts/metametrics';
+import { EVENT } from '../../../../shared/constants/metametrics';
 
 const GAS_FEES_LEARN_MORE_URL =
   'https://community.metamask.io/t/what-is-gas-why-do-transactions-take-so-long/3172';
@@ -103,7 +104,7 @@ export default function FeeCard({
                               onClick={() => {
                                 trackEvent({
                                   event: 'Clicked "Gas Fees: Learn More" Link',
-                                  category: 'Swaps',
+                                  category: EVENT.CATEGORIES.SWAPS,
                                 });
                                 global.platform.openTab({
                                   url: GAS_FEES_LEARN_MORE_URL,

--- a/ui/pages/swaps/index.js
+++ b/ui/pages/swaps/index.js
@@ -83,6 +83,7 @@ import {
 
 import { useGasFeeEstimates } from '../../hooks/useGasFeeEstimates';
 import FeatureToggledRoute from '../../helpers/higher-order-components/feature-toggled-route';
+import { EVENT } from '../../../shared/constants/metametrics';
 import { TRANSACTION_STATUSES } from '../../../shared/constants/transaction';
 import ActionableMessage from '../../components/ui/actionable-message';
 import { MetaMetricsContext } from '../../contexts/metametrics';
@@ -246,7 +247,7 @@ export default function Swap() {
   const trackExitedSwapsEvent = () => {
     trackEvent({
       event: 'Exited Swaps',
-      category: 'swaps',
+      category: EVENT.CATEGORIES.SWAPS,
       sensitiveProperties: {
         token_from: fetchParams?.sourceTokenInfo?.symbol,
         token_from_amount: fetchParams?.value,
@@ -307,7 +308,7 @@ export default function Swap() {
   const trackErrorStxEvent = useCallback(() => {
     trackEvent({
       event: 'Error Smart Transactions',
-      category: 'swaps',
+      category: EVENT.CATEGORIES.SWAPS,
       sensitiveProperties: {
         token_from: fetchParams?.sourceTokenInfo?.symbol,
         token_from_amount: fetchParams?.value,

--- a/ui/pages/swaps/loading-swaps-quotes/loading-swaps-quotes.js
+++ b/ui/pages/swaps/loading-swaps-quotes/loading-swaps-quotes.js
@@ -20,6 +20,7 @@ import {
 import { I18nContext } from '../../../contexts/i18n';
 import { MetaMetricsContext } from '../../../contexts/metametrics';
 import Mascot from '../../../components/ui/mascot';
+import { EVENT } from '../../../../shared/constants/metametrics';
 import SwapsFooter from '../swaps-footer';
 import BackgroundAnimation from './background-animation';
 
@@ -47,7 +48,7 @@ export default function LoadingSwapsQuotes({
   );
   const quotesRequestCancelledEventConfig = {
     event: 'Quotes Request Cancelled',
-    category: 'swaps',
+    category: EVENT.CATEGORIES.SWAPS,
     sensitiveProperties: {
       token_from: fetchParams?.sourceTokenInfo?.symbol,
       token_from_amount: fetchParams?.value,

--- a/ui/pages/swaps/searchable-item-list/item-list/item-list.component.js
+++ b/ui/pages/swaps/searchable-item-list/item-list/item-list.component.js
@@ -11,6 +11,7 @@ import {
   getCurrentChainId,
   getRpcPrefsForCurrentProvider,
 } from '../../../../selectors';
+import { EVENT } from '../../../../../shared/constants/metametrics';
 import { SWAPS_CHAINID_DEFAULT_BLOCK_EXPLORER_URL_MAP } from '../../../../../shared/constants/swaps';
 import { getURLHostName } from '../../../../helpers/utils/util';
 import { MetaMetricsContext } from '../../../../contexts/metametrics';
@@ -155,7 +156,7 @@ export default function ItemList({
                     onClick={() => {
                       trackEvent({
                         event: 'Clicked Block Explorer Link',
-                        category: 'Swaps',
+                        category: EVENT.CATEGORIES.SWAPS,
                         properties: {
                           link_type: 'Token Tracker',
                           action: 'Verify Contract Address',

--- a/ui/pages/swaps/smart-transaction-status/smart-transaction-status.js
+++ b/ui/pages/swaps/smart-transaction-status/smart-transaction-status.js
@@ -39,6 +39,7 @@ import {
   stopPollingForQuotes,
   setBackgroundSwapRouteState,
 } from '../../../store/actions';
+import { EVENT } from '../../../../shared/constants/metametrics';
 import { SMART_TRANSACTION_STATUSES } from '../../../../shared/constants/transaction';
 
 import SwapsFooter from '../swaps-footer';
@@ -125,7 +126,7 @@ export default function SmartTransactionStatus() {
   useEffect(() => {
     trackEvent({
       event: 'STX Status Page Loaded',
-      category: 'swaps',
+      category: EVENT.CATEGORIES.SWAPS,
       sensitiveProperties,
     });
     // eslint-disable-next-line
@@ -237,7 +238,7 @@ export default function SmartTransactionStatus() {
             setCancelSwapLinkClicked(true); // We want to hide it after a user clicks on it.
             trackEvent({
               event: 'Cancel STX',
-              category: 'swaps',
+              category: EVENT.CATEGORIES.SWAPS,
               sensitiveProperties,
             });
             dispatch(cancelSwapsSmartTransaction(latestSmartTransactionUuid));

--- a/ui/pages/swaps/swaps-gas-customization-modal/swaps-gas-customization-modal.component.js
+++ b/ui/pages/swaps/swaps-gas-customization-modal/swaps-gas-customization-modal.component.js
@@ -8,6 +8,7 @@ import AdvancedGasInputs from '../../../components/app/gas-customization/advance
 import BasicTabContent from '../../../components/app/gas-customization/gas-modal-page-container/basic-tab-content';
 import { GAS_ESTIMATE_TYPES } from '../../../helpers/constants/common';
 import { CUSTOM_GAS_ESTIMATE } from '../../../../shared/constants/gas';
+import { EVENT } from '../../../../shared/constants/metametrics';
 
 export default class GasModalPageContainer extends Component {
   static contextTypes = {
@@ -258,7 +259,7 @@ export default class GasModalPageContainer extends Component {
 
             this.context.trackEvent({
               event: 'Gas Fees Changed',
-              category: 'swaps',
+              category: EVENT.CATEGORIES.SWAPS,
               properties: {
                 speed_set: this.state.gasSpeedType,
                 gas_fees: sumHexWEIsToUnformattedFiat(

--- a/ui/pages/swaps/view-quote/view-quote.js
+++ b/ui/pages/swaps/view-quote/view-quote.js
@@ -117,6 +117,7 @@ import CountdownTimer from '../countdown-timer';
 import SwapsFooter from '../swaps-footer';
 import PulseLoader from '../../../components/ui/pulse-loader'; // TODO: Replace this with a different loading component.
 import Box from '../../../components/ui/box';
+import { EVENT } from '../../../../shared/constants/metametrics';
 import { isEqualCaseInsensitive } from '../../../../shared/modules/string-utils';
 import { parseStandardTokenTransactionData } from '../../../../shared/modules/transaction.utils';
 import ViewQuotePriceDifference from './view-quote-price-difference';
@@ -539,7 +540,7 @@ export default function ViewQuote() {
   const trackAllAvailableQuotesOpened = () => {
     trackEvent({
       event: 'All Available Quotes Opened',
-      category: 'swaps',
+      category: EVENT.CATEGORIES.SWAPS,
       sensitiveProperties: {
         ...eventObjectBase,
         other_quote_selected: usedQuote?.aggregator !== topQuote?.aggregator,
@@ -553,7 +554,7 @@ export default function ViewQuote() {
   const trackQuoteDetailsOpened = () => {
     trackEvent({
       event: 'Quote Details Opened',
-      category: 'swaps',
+      category: EVENT.CATEGORIES.SWAPS,
       sensitiveProperties: {
         ...eventObjectBase,
         other_quote_selected: usedQuote?.aggregator !== topQuote?.aggregator,
@@ -567,7 +568,7 @@ export default function ViewQuote() {
   const trackEditSpendLimitOpened = () => {
     trackEvent({
       event: 'Edit Spend Limit Opened',
-      category: 'swaps',
+      category: EVENT.CATEGORIES.SWAPS,
       sensitiveProperties: {
         ...eventObjectBase,
         custom_spend_limit_set: originalApproveAmount === approveAmount,
@@ -579,7 +580,7 @@ export default function ViewQuote() {
   const trackBestQuoteReviewedEvent = useCallback(() => {
     trackEvent({
       event: 'Best Quote Reviewed',
-      category: 'swaps',
+      category: EVENT.CATEGORIES.SWAPS,
       sensitiveProperties: {
         ...eventObjectBase,
         network_fees: feeInFiat,
@@ -589,7 +590,7 @@ export default function ViewQuote() {
   const trackViewQuotePageLoadedEvent = useCallback(() => {
     trackEvent({
       event: 'View Quote Page Loaded',
-      category: 'swaps',
+      category: EVENT.CATEGORIES.SWAPS,
       sensitiveProperties: {
         ...eventObjectBase,
         response_time: currentTimestamp - reviewSwapClickedTimestamp,

--- a/ui/pages/unlock-page/unlock-page.component.js
+++ b/ui/pages/unlock-page/unlock-page.component.js
@@ -7,6 +7,7 @@ import TextField from '../../components/ui/text-field';
 import Mascot from '../../components/ui/mascot';
 import { SUPPORT_LINK } from '../../helpers/constants/common';
 import { DEFAULT_ROUTE } from '../../helpers/constants/routes';
+import { EVENT } from '../../../shared/constants/metametrics';
 
 export default class UnlockPage extends Component {
   static contextTypes = {
@@ -77,7 +78,7 @@ export default class UnlockPage extends Component {
       const newState = await forceUpdateMetamaskState();
       this.context.trackEvent(
         {
-          category: 'Navigation',
+          category: EVENT.CATEGORIES.NAVIGATION,
           event: 'Success',
           properties: {
             action: 'Unlock',
@@ -99,7 +100,7 @@ export default class UnlockPage extends Component {
       if (message === 'Incorrect password') {
         const newState = await forceUpdateMetamaskState();
         this.context.trackEvent({
-          category: 'Navigation',
+          category: EVENT.CATEGORIES.NAVIGATION,
           event: 'Incorrect Password',
           properties: {
             action: 'Unlock',

--- a/ui/store/actions.js
+++ b/ui/store/actions.js
@@ -31,6 +31,7 @@ import {
   LEDGER_TRANSPORT_TYPES,
   LEDGER_USB_VENDOR_ID,
 } from '../../shared/constants/hardware-wallets';
+import { EVENT } from '../../shared/constants/metametrics';
 import { parseSmartTransactionsError } from '../pages/swaps/swaps.util';
 import { isEqualCaseInsensitive } from '../../shared/modules/string-utils';
 import * as actionConstants from './actionConstants';
@@ -3335,7 +3336,7 @@ export async function setSmartTransactionsOptInStatus(
 ) {
   trackMetaMetricsEvent({
     event: 'STX OptIn',
-    category: 'swaps',
+    category: EVENT.CATEGORIES.SWAPS,
     sensitiveProperties: {
       stx_enabled: true,
       current_stx_enabled: true,


### PR DESCRIPTION
## Explanation

Adding a constant to use for our Segment event.category values. This will prevent unwanted typos and avoid misaligned letter cases.

2 category names were changed here:
1. "Account" -> "Accounts" - swapped for the more common option
2. "swaps" -> "Swaps - swapped to use Title Case

## Screenshots
Notice currently, both Account and Accounts exist: 
<img width="386" alt="Screenshot 2022-04-19 at 10 49 49 AM" src="https://user-images.githubusercontent.com/20778143/164021501-9376e4e2-6ecd-411c-9bc3-22813e234783.png">

Notice currently, both swaps and Swaps exist:
<img width="387" alt="Screenshot 2022-04-19 at 10 49 43 AM" src="https://user-images.githubusercontent.com/20778143/164021484-ed14a9a6-c9d8-4739-8317-c9d51e32d13b.png">

