### PR TITLE
bump crowdin/github-action

### DIFF
--- a/.github/workflows/crowdin_action.yml
+++ b/.github/workflows/crowdin_action.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: crowdin action
-      uses: crowdin/github-action@9237b4cb361788dfce63feb2e2f15c09e2fe7415
+      uses: crowdin/github-action@a3160b9e5a9e00739392c23da5e580c6cabe526d
       with:
         upload_translations: true
         download_translations: true


### PR DESCRIPTION
This github action is currently failing: https://github.com/MetaMask/metamask-extension/actions/runs/2190513968

I've gotten the action bumped to latest now (`a3160b9e5a9e00739392c23da5e580c6cabe526d`) org wide.

This resolves the issue.

Same as: https://github.com/MetaMask/metamask-mobile/pull/4128