### PR TITLE
Add search information for Theme dropdown

### DIFF
--- a/ui/helpers/constants/settings.js
+++ b/ui/helpers/constants/settings.js
@@ -307,6 +307,13 @@ export const SETTINGS_CONSTANTS = [
     icon: 'fa fa-flask',
   },
   {
+    tabMessage: (t) => t('experimental'),
+    sectionMessage: (t) => t('theme'),
+    descriptionMessage: (t) => t('themeDescriptions'),
+    route: `${EXPERIMENTAL_ROUTE}#theme`,
+    icon: 'fa fa-flask',
+  },
+  {
     // TODO: Remove during TOKEN_DETECTION_V2 feature flag clean up
     tabMessage: (t) => t('advanced'),
     sectionMessage: (t) => t('tokenDetection'),

--- a/ui/helpers/constants/settings.js
+++ b/ui/helpers/constants/settings.js
@@ -309,7 +309,7 @@ export const SETTINGS_CONSTANTS = [
   {
     tabMessage: (t) => t('experimental'),
     sectionMessage: (t) => t('theme'),
-    descriptionMessage: (t) => t('themeDescriptions'),
+    descriptionMessage: (t) => t('themeDescription'),
     route: `${EXPERIMENTAL_ROUTE}#theme`,
     icon: 'fa fa-flask',
   },

--- a/ui/helpers/utils/settings-search.test.js
+++ b/ui/helpers/utils/settings-search.test.js
@@ -195,7 +195,7 @@ describe('Settings Search Utils', () => {
 
     it('should get good experimental section number', () => {
       expect(getNumberOfSettingsInSection(t, t('experimental'))).toStrictEqual(
-        2,
+        3,
       );
     });
 

--- a/ui/pages/settings/experimental-tab/experimental-tab.component.js
+++ b/ui/pages/settings/experimental-tab/experimental-tab.component.js
@@ -263,7 +263,7 @@ export default class ExperimentalTab extends PureComponent {
     };
 
     return (
-      <div className="settings-page__content-row">
+      <div ref={this.settingsRefs[4]} className="settings-page__content-row">
         <div className="settings-page__content-item">
           <span>{this.context.t('theme')}</span>
           <div className="settings-page__content-description">


### PR DESCRIPTION
We did the initial settings work before we had search, so we didn't catch that we didn't have search details.  This fixes said problem.