### PR TITLE
fix: send tokens with decimals > 20

### DIFF
--- a/shared/modules/conversion.utils.js
+++ b/shared/modules/conversion.utils.js
@@ -26,6 +26,10 @@ import BigNumber from 'bignumber.js';
 
 import { stripHexPrefix, BN } from 'ethereumjs-util';
 
+BigNumber.config({
+  DECIMAL_PLACES: 32,
+});
+
 // Big Number Constants
 const BIG_NUMBER_WEI_MULTIPLIER = new BigNumber('1000000000000000000');
 const BIG_NUMBER_GWEI_MULTIPLIER = new BigNumber('1000000000');


### PR DESCRIPTION
## Explanation

<!--
Thanks for the pull request. Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Below is a template to give you some ideas. Feel free to use your own words!

Currently, ...

This is a problem because ...

In order to solve this problem, this pull request ...
-->

Now MetaMask cannot send tokens with decimals larger than 20, this fix allows MetaMask to send tokens with tokens whose decimals <= 32.

## More information

<!--
Are there any issues, Slack conversations, Zendesk issues, user stories, etc. reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

Fixes: #14481

## Manual testing steps

<!--
How should reviewers and QA manually test your changes? For instance:

- Go to this screen
- Do this
- Then do this
-->

Please test following the reproduce steps in #14481
