### PR TITLE
Feature/remove bitmask

### DIFF
--- a/.circleci/scripts/yarn-audit.sh
+++ b/.circleci/scripts/yarn-audit.sh
@@ -10,9 +10,7 @@ set -o pipefail
 yarn run improved-yarn-audit --ignore-dev-deps --min-severity moderate --exclude GHSA-93q8-gq69-wqmw,GHSA-257v-vj4p-3w2h,GHSA-fwr7-v2mv-hh25
 audit_status="$?"
 
-# Use a bitmask to ignore INFO and LOW severity audit results
-# See here: https://yarnpkg.com/lang/en/docs/cli/audit/
-audit_status="$(( audit_status & 11100 ))"
+audit_status="$?"
 
 if [[ "$audit_status" != 0 ]]
 then

--- a/.circleci/scripts/yarn-audit.sh
+++ b/.circleci/scripts/yarn-audit.sh
@@ -6,9 +6,11 @@ set -x
 set -o pipefail
 
 # use `improved-yarn-audit` since that allows for exclude
-# exclude 1002401 until we remove use of 3Box, 1002581 until we can find a better solution
-yarn run improved-yarn-audit --ignore-dev-deps --min-severity moderate --exclude GHSA-93q8-gq69-wqmw,GHSA-257v-vj4p-3w2h,GHSA-fwr7-v2mv-hh25
-audit_status="$?"
+# exclusions are in .iyarc now
+yarn run improved-yarn-audit \
+    --ignore-dev-deps \
+    --min-severity moderate \
+    --fail-on-missing-exclusions
 
 audit_status="$?"
 

--- a/.iyarc
+++ b/.iyarc
@@ -1,0 +1,4 @@
+# improved-yarn-audit advisory exclusions
+GHSA-93q8-gq69-wqmw
+GHSA-257v-vj4p-3w2h
+GHSA-fwr7-v2mv-hh25


### PR DESCRIPTION
I recently discovered that the bitmask that was here had the unintentional effect of [skipping some high and critical vulnerabilities in mobile](https://github.com/MetaMask/metamask-mobile/pull/4134).

This PR makes the same changes here.

Thankfully, there weren't any vulnerabilities being unintentionally skipped here.