### PR TITLE
MetaMetrics: add 'number_of_nfts' user trait

### DIFF
--- a/app/scripts/controllers/metametrics.js
+++ b/app/scripts/controllers/metametrics.js
@@ -540,9 +540,7 @@ export default class MetaMetricsController {
    * @returns {MetaMetricsTraits | null} traits that have changed since last update
    */
   _buildUserTraitsObject(metamaskState) {
-    /**
-     * @type {MetaMetricsTraits}
-     */
+    /** @type {MetaMetricsTraits} */
     const currentTraits = {
       [TRAITS.ADDRESS_BOOK_ENTRIES]: sum(
         Object.values(metamaskState.addressBook).map(size),
@@ -554,9 +552,12 @@ export default class MetaMetricsController {
       [TRAITS.NFT_AUTODETECTION_ENABLED]: metamaskState.useCollectibleDetection,
       [TRAITS.NUMBER_OF_ACCOUNTS]: Object.values(metamaskState.identities)
         .length,
-      [TRAITS.NUMBER_OF_NFT_COLLECTIONS]: this._getNumberOfNFtCollection(
-        metamaskState,
+      [TRAITS.NUMBER_OF_NFT_COLLECTIONS]: this._getAllUniqueNFTAddressesLength(
+        metamaskState.allCollectibles,
       ),
+      [TRAITS.NUMBER_OF_NFTS]: this._getAllNFTAddresses(
+        metamaskState.allCollectibles,
+      ).length,
       [TRAITS.NUMBER_OF_TOKENS]: this._getNumberOfTokens(metamaskState),
       [TRAITS.OPENSEA_API_ENABLED]: metamaskState.openSeaEnabled,
       [TRAITS.THREE_BOX_ENABLED]: metamaskState.threeBoxSyncingAllowed,
@@ -605,20 +606,26 @@ export default class MetaMetricsController {
   /**
    *
    * @param {object} metamaskState
-   * @returns number of unique collectible addresses
+   * @param allCollectibles
+   * @returns {[]} Array of all collectible/NFT addresses
    */
-  _getNumberOfNFtCollection(metamaskState) {
-    const { allCollectibles } = metamaskState;
-    if (!allCollectibles) {
-      return 0;
-    }
-
-    const allAddresses = Object.values(allCollectibles)
+  _getAllNFTAddresses(allCollectibles = {}) {
+    return Object.values(allCollectibles)
       .flatMap((chainCollectibles) => Object.values(chainCollectibles))
       .flat()
       .map((collectible) => collectible.address);
-    const unique = [...new Set(allAddresses)];
-    return unique.length;
+  }
+
+  /**
+   *
+   * @param {object} metamaskState
+   * @param allCollectibles
+   * @returns {[]} Array of unique collectible/NFT addresses
+   */
+  _getAllUniqueNFTAddressesLength(allCollectibles = {}) {
+    const allAddresses = this._getAllNFTAddresses(allCollectibles);
+    const uniqueAddresses = new Set(allAddresses);
+    return uniqueAddresses.size;
   }
 
   /**

--- a/app/scripts/controllers/metametrics.js
+++ b/app/scripts/controllers/metametrics.js
@@ -564,9 +564,8 @@ export default class MetaMetricsController {
       [TRAITS.NUMBER_OF_NFT_COLLECTIONS]: this._getAllUniqueNFTAddressesLength(
         metamaskState.allCollectibles,
       ),
-      [TRAITS.NUMBER_OF_NFTS]: this._getAllNFTAddresses(
-        metamaskState.allCollectibles,
-      ).length,
+      [TRAITS.NUMBER_OF_NFTS]: this._getAllNFTs(metamaskState.allCollectibles)
+        .length,
       [TRAITS.NUMBER_OF_TOKENS]: this._getNumberOfTokens(metamaskState),
       [TRAITS.OPENSEA_API_ENABLED]: metamaskState.openSeaEnabled,
       [TRAITS.THREE_BOX_ENABLED]: metamaskState.threeBoxSyncingAllowed,
@@ -613,17 +612,16 @@ export default class MetaMetricsController {
   }
 
   /**
-   * Returns an array of all of the collectible/NFT addresses the user
+   * Returns an array of all of the collectibles/NFTs the user
    * possesses across all networks and accounts.
    *
    * @param {Object} allCollectibles
    * @returns {[]}
    */
-  _getAllNFTAddresses = memoize((allCollectibles = {}) => {
+  _getAllNFTs = memoize((allCollectibles = {}) => {
     return Object.values(allCollectibles)
-      .flatMap((chainCollectibles) => Object.values(chainCollectibles))
-      .flat()
-      .map((collectible) => collectible.address);
+      .flatMap((chainNFTs) => Object.values(chainNFTs))
+      .flat();
   });
 
   /**
@@ -634,8 +632,10 @@ export default class MetaMetricsController {
    * @returns {number}
    */
   _getAllUniqueNFTAddressesLength(allCollectibles = {}) {
-    const allAddresses = this._getAllNFTAddresses(allCollectibles);
-    const uniqueAddresses = new Set(allAddresses);
+    const allNFTAddresses = this._getAllNFTs(allCollectibles).map(
+      (nft) => nft.address,
+    );
+    const uniqueAddresses = new Set(allNFTAddresses);
     return uniqueAddresses.size;
   }
 

--- a/app/scripts/controllers/metametrics.js
+++ b/app/scripts/controllers/metametrics.js
@@ -1,4 +1,13 @@
-import { isEqual, merge, omit, omitBy, pickBy, size, sum } from 'lodash';
+import {
+  isEqual,
+  memoize,
+  merge,
+  omit,
+  omitBy,
+  pickBy,
+  size,
+  sum,
+} from 'lodash';
 import { ObservableStore } from '@metamask/obs-store';
 import { bufferToHex, keccak } from 'ethereumjs-util';
 import { generateUUID } from 'pubnub';
@@ -609,12 +618,12 @@ export default class MetaMetricsController {
    * @param allCollectibles
    * @returns {[]} Array of all collectible/NFT addresses
    */
-  _getAllNFTAddresses(allCollectibles = {}) {
+  _getAllNFTAddresses = memoize((allCollectibles = {}) => {
     return Object.values(allCollectibles)
       .flatMap((chainCollectibles) => Object.values(chainCollectibles))
       .flat()
       .map((collectible) => collectible.address);
-  }
+  });
 
   /**
    *

--- a/app/scripts/controllers/metametrics.js
+++ b/app/scripts/controllers/metametrics.js
@@ -613,10 +613,11 @@ export default class MetaMetricsController {
   }
 
   /**
+   * Returns an array of all of the collectible/NFT addresses the user
+   * possesses across all networks and accounts.
    *
-   * @param {object} metamaskState
-   * @param allCollectibles
-   * @returns {[]} Array of all collectible/NFT addresses
+   * @param {Object} allCollectibles
+   * @returns {[]}
    */
   _getAllNFTAddresses = memoize((allCollectibles = {}) => {
     return Object.values(allCollectibles)
@@ -626,10 +627,11 @@ export default class MetaMetricsController {
   });
 
   /**
+   * Returns the number of unique collectible/NFT addresses the user
+   * possesses across all networks and accounts.
    *
-   * @param {object} metamaskState
-   * @param allCollectibles
-   * @returns {[]} Array of unique collectible/NFT addresses
+   * @param {Object} allCollectibles
+   * @returns {number}
    */
   _getAllUniqueNFTAddressesLength(allCollectibles = {}) {
     const allAddresses = this._getAllNFTAddresses(allCollectibles);

--- a/app/scripts/controllers/metametrics.js
+++ b/app/scripts/controllers/metametrics.js
@@ -564,8 +564,9 @@ export default class MetaMetricsController {
       [TRAITS.NUMBER_OF_NFT_COLLECTIONS]: this._getAllUniqueNFTAddressesLength(
         metamaskState.allCollectibles,
       ),
-      [TRAITS.NUMBER_OF_NFTS]: this._getAllNFTs(metamaskState.allCollectibles)
-        .length,
+      [TRAITS.NUMBER_OF_NFTS]: this._getAllNFTsFlattened(
+        metamaskState.allCollectibles,
+      ).length,
       [TRAITS.NUMBER_OF_TOKENS]: this._getNumberOfTokens(metamaskState),
       [TRAITS.OPENSEA_API_ENABLED]: metamaskState.openSeaEnabled,
       [TRAITS.THREE_BOX_ENABLED]: metamaskState.threeBoxSyncingAllowed,
@@ -618,7 +619,7 @@ export default class MetaMetricsController {
    * @param {Object} allCollectibles
    * @returns {[]}
    */
-  _getAllNFTs = memoize((allCollectibles = {}) => {
+  _getAllNFTsFlattened = memoize((allCollectibles = {}) => {
     return Object.values(allCollectibles)
       .flatMap((chainNFTs) => Object.values(chainNFTs))
       .flat();
@@ -632,7 +633,7 @@ export default class MetaMetricsController {
    * @returns {number}
    */
   _getAllUniqueNFTAddressesLength(allCollectibles = {}) {
-    const allNFTAddresses = this._getAllNFTs(allCollectibles).map(
+    const allNFTAddresses = this._getAllNFTsFlattened(allCollectibles).map(
       (nft) => nft.address,
     );
     const uniqueAddresses = new Set(allNFTAddresses);

--- a/app/scripts/controllers/metametrics.test.js
+++ b/app/scripts/controllers/metametrics.test.js
@@ -691,6 +691,7 @@ describe('MetaMetricsController', function () {
         [TRAITS.NFT_AUTODETECTION_ENABLED]: false,
         [TRAITS.NUMBER_OF_ACCOUNTS]: 2,
         [TRAITS.NUMBER_OF_NFT_COLLECTIONS]: 3,
+        [TRAITS.NUMBER_OF_NFTS]: 4,
         [TRAITS.NUMBER_OF_TOKENS]: 5,
         [TRAITS.OPENSEA_API_ENABLED]: true,
         [TRAITS.THREE_BOX_ENABLED]: false,

--- a/shared/constants/metametrics.js
+++ b/shared/constants/metametrics.js
@@ -170,6 +170,7 @@
  *  change, we identify the new number_of_accounts trait
  * @property {'number_of_nft_collections'} NUMBER_OF_NFT_COLLECTIONS - user
  *  trait for number of unique NFT addresses
+ * @property {'number_of_nfts'} NUMBER_OF_NFTS - user trait for number of all NFT addresses
  * @property {'number_of_tokens'} NUMBER_OF_TOKENS - when the number of tokens change, we
  * identify the new number_of_tokens trait
  * @property {'opensea_api_enabled'} OPENSEA_API_ENABLED - when the OpenSea API is enabled
@@ -191,6 +192,7 @@ export const TRAITS = {
   NFT_AUTODETECTION_ENABLED: 'nft_autodetection_enabled',
   NUMBER_OF_ACCOUNTS: 'number_of_accounts',
   NUMBER_OF_NFT_COLLECTIONS: 'number_of_nft_collections',
+  NUMBER_OF_NFTS: 'number_of_nfts',
   NUMBER_OF_TOKENS: 'number_of_tokens',
   OPENSEA_API_ENABLED: 'opensea_api_enabled',
   THREE_BOX_ENABLED: 'three_box_enabled',
@@ -211,6 +213,8 @@ export const TRAITS = {
  *  of identities(accounts) added to the user's MetaMask.
  * @property {number} [number_of_nft_collections] - A number representing the
  *  amount of different NFT collections the user possesses an NFT from.
+ * @property {number} [number_of_nfts] - A number representing the
+ *  amount of all NFTs the user possesses across all networks and accounts.
  * @property {number} [number_of_tokens] - The total number of token contracts
  *  the user has across all networks and accounts.
  * @property {boolean} [opensea_api_enabled] - does the user have the OpenSea


### PR DESCRIPTION
## Explanation
#13477 Task:
> Add new user trait for 'Number of NFTs'

New user trait: `number_of_nfts`

This involves a slight redesign to the code for `number_of_nft_collections`

## More information

Progresses #13477
Relates to #https://github.com/MetaMask/metamask-extension/pull/14377