### PR TITLE
Fix the alerts toggles in settings

### DIFF
--- a/ui/pages/settings/alerts-tab/alerts-tab.js
+++ b/ui/pages/settings/alerts-tab/alerts-tab.js
@@ -69,6 +69,7 @@ const AlertsTab = () => {
       {Object.entries(alertConfig).map(
         ([alertId, { title, description }], _) => (
           <AlertSettingsEntry
+            alertId={alertId}
             description={description}
             key={alertId}
             title={title}

--- a/ui/pages/settings/alerts-tab/alerts-tab.test.js
+++ b/ui/pages/settings/alerts-tab/alerts-tab.test.js
@@ -1,0 +1,42 @@
+import React from 'react';
+import { fireEvent, screen } from '@testing-library/react';
+import configureMockStore from 'redux-mock-store';
+import { renderWithProvider } from '../../../../test/jest/rendering';
+import { ALERT_TYPES } from '../../../../shared/constants/alerts';
+import AlertsTab from '.';
+
+const mockSetAlertEnabledness = jest.fn();
+
+jest.mock('../../../store/actions', () => ({
+  setAlertEnabledness: (...args) => mockSetAlertEnabledness(...args),
+}));
+
+describe('Alerts Tab', () => {
+  const store = configureMockStore([])({
+    metamask: {
+      alertEnabledness: {
+        unconnectedAccount: false,
+        web3ShimUsage: false,
+      },
+    },
+  });
+
+  it('calls setAlertEnabledness with the correct params method when the toggles are clicked', () => {
+    renderWithProvider(<AlertsTab />, store);
+
+    expect(mockSetAlertEnabledness.mock.calls).toHaveLength(0);
+    fireEvent.click(screen.getAllByRole('checkbox')[0]);
+    expect(mockSetAlertEnabledness.mock.calls).toHaveLength(1);
+    expect(mockSetAlertEnabledness.mock.calls[0][0]).toBe(
+      ALERT_TYPES.unconnectedAccount,
+    );
+    expect(mockSetAlertEnabledness.mock.calls[0][1]).toBe(true);
+
+    fireEvent.click(screen.getAllByRole('checkbox')[1]);
+    expect(mockSetAlertEnabledness.mock.calls).toHaveLength(2);
+    expect(mockSetAlertEnabledness.mock.calls[1][0]).toBe(
+      ALERT_TYPES.web3ShimUsage,
+    );
+    expect(mockSetAlertEnabledness.mock.calls[1][1]).toBe(true);
+  });
+});


### PR DESCRIPTION
Fixes #14492

A line of code was inadvertently removed here https://github.com/MetaMask/metamask-extension/pull/14350/files#diff-2098a4c441a5e191f9ac7d25758cf035b3f0937885b5468849e3358135b598a9L73

This resulted in a breaking of the alert toggles

This PR re-adds that line of code and adds a unit test that would have caught this bug