### PR TITLE
Disable swaps whenever the environment is not development or testing

### DIFF
--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -670,8 +670,10 @@ export function getSwapsDefaultToken(state) {
 
 export function getIsSwapsChain(state) {
   const chainId = getCurrentChainId(state);
-  const isProduction = process.env.METAMASK_ENVIRONMENT === 'production';
-  return isProduction
+  const isNotDevelopment =
+    process.env.METAMASK_ENVIRONMENT !== 'development' ||
+    process.env.METAMASK_ENVIRONMENT !== 'testing';
+  return isNotDevelopment
     ? ALLOWED_PROD_SWAPS_CHAIN_IDS.includes(chainId)
     : ALLOWED_DEV_SWAPS_CHAIN_IDS.includes(chainId);
 }


### PR DESCRIPTION
Fixes #14491

That PR disabled swaps when the environment is production. But it should be disabled for builds that are meant to mimic production as well (e.g. RC builds). This PR changes it so that swaps is only enabled when the environment is development or testing, and disabled in all other environments