### PR TITLE
Add token standard to custom token details

### DIFF
--- a/ui/pages/confirm-import-token/confirm-import-token.js
+++ b/ui/pages/confirm-import-token/confirm-import-token.js
@@ -33,7 +33,6 @@ const ConfirmImportToken = () => {
     await dispatch(addTokens(pendingTokens));
 
     const addedTokenValues = Object.values(pendingTokens);
-    console.log(addedTokenValues);
     const firstTokenAddress = addedTokenValues?.[0].address?.toLowerCase();
 
     addedTokenValues.forEach((pendingToken) => {

--- a/ui/pages/confirm-import-token/confirm-import-token.js
+++ b/ui/pages/confirm-import-token/confirm-import-token.js
@@ -37,7 +37,6 @@ const ConfirmImportToken = () => {
     const firstTokenAddress = addedTokenValues?.[0].address?.toLowerCase();
 
     addedTokenValues.forEach((pendingToken) => {
-      console.log(pendingToken);
       trackEvent({
         event: 'Token Added',
         category: EVENT.CATEGORIES.WALLET,

--- a/ui/pages/confirm-import-token/confirm-import-token.js
+++ b/ui/pages/confirm-import-token/confirm-import-token.js
@@ -13,7 +13,6 @@ import { MetaMetricsContext } from '../../contexts/metametrics';
 import { getMostRecentOverviewPage } from '../../ducks/history/history';
 import { getPendingTokens } from '../../ducks/metamask/metamask';
 import { addTokens, clearPendingTokens } from '../../store/actions';
-import { TOKEN_STANDARDS } from '../../helpers/constants/common';
 import { EVENT } from '../../../shared/constants/metametrics';
 import { ASSET_TYPES } from '../../../shared/constants/transaction';
 
@@ -34,9 +33,11 @@ const ConfirmImportToken = () => {
     await dispatch(addTokens(pendingTokens));
 
     const addedTokenValues = Object.values(pendingTokens);
+    console.log(addedTokenValues);
     const firstTokenAddress = addedTokenValues?.[0].address?.toLowerCase();
 
     addedTokenValues.forEach((pendingToken) => {
+      console.log(pendingToken);
       trackEvent({
         event: 'Token Added',
         category: EVENT.CATEGORIES.WALLET,
@@ -46,7 +47,7 @@ const ConfirmImportToken = () => {
           token_decimal_precision: pendingToken.decimals,
           unlisted: pendingToken.unlisted,
           source: pendingToken.isCustom ? 'custom' : 'list',
-          token_standard: TOKEN_STANDARDS.ERC20,
+          token_standard: pendingToken.standard,
           asset_type: ASSET_TYPES.TOKEN,
         },
       });

--- a/ui/pages/import-token/import-token.component.js
+++ b/ui/pages/import-token/import-token.component.js
@@ -23,6 +23,7 @@ import ActionableMessage from '../../components/ui/actionable-message/actionable
 import Typography from '../../components/ui/typography';
 import { TYPOGRAPHY, FONT_WEIGHT } from '../../helpers/constants/design-system';
 import Button from '../../components/ui/button';
+import { TOKEN_STANDARDS } from '../../helpers/constants/common';
 import TokenSearch from './token-search';
 import TokenList from './token-list';
 
@@ -126,6 +127,7 @@ class ImportToken extends Component {
     customDecimals: 0,
     searchResults: [],
     selectedTokens: {},
+    standard: TOKEN_STANDARDS.NONE,
     tokenSelectorError: null,
     customAddressError: null,
     customSymbolError: null,
@@ -231,12 +233,14 @@ class ImportToken extends Component {
       customSymbol: symbol,
       customDecimals: decimals,
       selectedTokens,
+      standard,
     } = this.state;
 
     const customToken = {
       address,
       symbol,
       decimals,
+      standard,
     };
 
     setPendingTokens({ customToken, selectedTokens, tokenAddressList });
@@ -281,7 +285,7 @@ class ImportToken extends Component {
     const isMainnetNetwork = this.props.chainId === '0x1';
 
     let standard;
-    if (addressIsValid && process.env.COLLECTIBLES_V1) {
+    if (addressIsValid) {
       try {
         ({ standard } = await this.props.getTokenStandardAndDetails(
           standardAddress,
@@ -353,6 +357,9 @@ class ImportToken extends Component {
       default:
         if (!addressIsEmpty) {
           this.attemptToAutoFillTokenParams(customAddress);
+          if (standard) {
+            this.setState({ standard });
+          }
         }
     }
   }

--- a/ui/pages/import-token/import-token.test.js
+++ b/ui/pages/import-token/import-token.test.js
@@ -132,6 +132,7 @@ describe('Import Token', () => {
         customToken: {
           address: tokenAddress,
           decimals: Number(tokenPrecision),
+          standard: 'ERC20',
           symbol: tokenSymbol,
         },
         selectedTokens: {},


### PR DESCRIPTION
## Explanation

Use getTokenStandardAndDetails to get token standard while adding a custom token. This will be passed to metrics:

- Try to get token standard using `getTokenStandardAndDetails`
- set standard to returned value
- default to `NONE` if no standard can be found

## More information

* Fixes #14503