### PR TITLE
Ensure network name in confirm page container is defined

### DIFF
--- a/ui/components/app/confirm-page-container/confirm-page-container.component.js
+++ b/ui/components/app/confirm-page-container/confirm-page-container.component.js
@@ -70,6 +70,7 @@ export default class ConfirmPageContainer extends Component {
     unapprovedTxCount: PropTypes.number,
     origin: PropTypes.string.isRequired,
     ethGasPriceWarning: PropTypes.string,
+    networkIdentifier: PropTypes.string,
     // Navigation
     totalTx: PropTypes.number,
     positionOfCurrentTx: PropTypes.number,
@@ -151,6 +152,7 @@ export default class ConfirmPageContainer extends Component {
       nativeCurrency,
       showBuyModal,
       isBuyableChain,
+      networkIdentifier,
     } = this.props;
 
     const showAddToAddressDialog =
@@ -164,7 +166,8 @@ export default class ConfirmPageContainer extends Component {
         currentTransaction.type === TRANSACTION_TYPES.DEPLOY_CONTRACT) &&
       currentTransaction.txParams?.value === '0x0';
 
-    const networkName = NETWORK_TO_NAME_MAP[currentTransaction.chainId];
+    const networkName =
+      NETWORK_TO_NAME_MAP[currentTransaction.chainId] || networkIdentifier;
 
     const { t } = this.context;
 

--- a/ui/components/app/confirm-page-container/confirm-page-container.container.js
+++ b/ui/components/app/confirm-page-container/confirm-page-container.container.js
@@ -3,6 +3,7 @@ import {
   getAccountsWithLabels,
   getAddressBookEntry,
   getIsBuyableChain,
+  getNetworkIdentifier,
 } from '../../../selectors';
 import { showModal } from '../../../store/actions';
 import ConfirmPageContainer from './confirm-page-container.component';
@@ -11,6 +12,7 @@ function mapStateToProps(state, ownProps) {
   const to = ownProps.toAddress;
   const isBuyableChain = getIsBuyableChain(state);
   const contact = getAddressBookEntry(state, to);
+  const networkIdentifier = getNetworkIdentifier(state);
   return {
     isBuyableChain,
     contact,
@@ -19,6 +21,7 @@ function mapStateToProps(state, ownProps) {
       .map((accountWithLabel) => accountWithLabel.address)
       .includes(to),
     to,
+    networkIdentifier,
   };
 }
 


### PR DESCRIPTION
Fixes https://github.com/MetaMask/metamask-extension/issues/14446

The network name being used in the message translation was undefined on non-default infura networks. This PR corrects that by pulling a name for the network from state, if our defaults are unavailable.

Before:
![Screenshot from 2022-04-25 10-05-55](https://user-images.githubusercontent.com/7499938/165090096-a8f3a20d-1f44-4513-8223-c6eb3ad66e3d.png)

After:
![Screenshot from 2022-04-25 10-03-58](https://user-images.githubusercontent.com/7499938/165090123-7bd01549-22e3-4b49-88f4-6d35e34135f1.png)


In additon to the before/after screenshot, this PR makes the following error go away: `Error: Insufficient number of substitutions for key "insufficientCurrency" with locale "en"`