### PR TITLE
show token approval details on confirm approve screen by default

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -1442,6 +1442,9 @@
   "hide": {
     "message": "Hide"
   },
+  "hideFullTransactionDetails": {
+    "message": "Hide full transaction details"
+  },
   "hideSeedPhrase": {
     "message": "Hide seed phrase"
   },

--- a/test/e2e/metamask-ui.spec.js
+++ b/test/e2e/metamask-ui.spec.js
@@ -555,11 +555,6 @@ describe('MetaMask', function () {
     });
 
     it('displays the token approval data', async function () {
-      await driver.clickElement(
-        '.confirm-approve-content__view-full-tx-button',
-      );
-      await driver.delay(regularDelayMs);
-
       const functionType = await driver.findElement(
         '.confirm-approve-content__data .confirm-approve-content__small-text',
       );
@@ -750,11 +745,6 @@ describe('MetaMask', function () {
     });
 
     it('shows the correct recipient', async function () {
-      await driver.clickElement(
-        '.confirm-approve-content__view-full-tx-button',
-      );
-      await driver.delay(regularDelayMs);
-
       const permissionInfo = await driver.findElements(
         '.confirm-approve-content__medium-text',
       );

--- a/ui/pages/confirm-approve/confirm-approve-content/confirm-approve-content.component.js
+++ b/ui/pages/confirm-approve/confirm-approve-content/confirm-approve-content.component.js
@@ -73,7 +73,7 @@ export default class ConfirmApproveContent extends Component {
   };
 
   state = {
-    showFullTxDetails: false,
+    showFullTxDetails: true,
     copied: false,
   };
 
@@ -613,7 +613,9 @@ export default class ConfirmApproveContent extends Component {
               >
                 <div className="confirm-approve-content__view-full-tx-button cursor-pointer">
                   <div className="confirm-approve-content__small-blue-text">
-                    {t('viewFullTransactionDetails')}
+                    {this.state.showFullTxDetails
+                      ? t('hideFullTransactionDetails')
+                      : t('viewFullTransactionDetails')}
                   </div>
                   <i
                     className={classnames({
@@ -642,7 +644,9 @@ export default class ConfirmApproveContent extends Component {
                 >
                   <div className="confirm-approve-content__view-full-tx-button cursor-pointer">
                     <div className="confirm-approve-content__small-blue-text">
-                      {t('viewFullTransactionDetails')}
+                      {this.state.showFullTxDetails
+                        ? t('hideFullTransactionDetails')
+                        : t('viewFullTransactionDetails')}
                     </div>
                     <i
                       className={classnames({

--- a/ui/pages/confirm-approve/confirm-approve-content/confirm-approve-content.component.test.js
+++ b/ui/pages/confirm-approve/confirm-approve-content/confirm-approve-content.component.test.js
@@ -51,7 +51,7 @@ describe('ConfirmApproveContent Component', () => {
       ),
     ).toBeInTheDocument();
     expect(queryByText('0x9bc5...fef4')).toBeInTheDocument();
-    expect(queryByText('View full transaction details')).toBeInTheDocument();
+    expect(queryByText('Hide full transaction details')).toBeInTheDocument();
 
     expect(queryByText('Edit Permission')).toBeInTheDocument();
     const editPermission = getByText('Edit Permission');
@@ -73,14 +73,15 @@ describe('ConfirmApproveContent Component', () => {
     fireEvent.click(editButtons[1]);
     expect(props.showCustomizeNonceModal).toHaveBeenCalledTimes(1);
 
-    const showHideTxDetails = getByText('View full transaction details');
-    expect(queryByText('Permission request')).not.toBeInTheDocument();
-    expect(queryByText('Approved amount:')).not.toBeInTheDocument();
-    expect(queryByText('Granted to:')).not.toBeInTheDocument();
-    fireEvent.click(showHideTxDetails);
+    const showHideTxDetails = getByText('Hide full transaction details');
     expect(getByText('Permission request')).toBeInTheDocument();
     expect(getByText('Approved amount:')).toBeInTheDocument();
     expect(getByText('Granted to:')).toBeInTheDocument();
+    fireEvent.click(showHideTxDetails);
+    expect(getByText('View full transaction details')).toBeInTheDocument();
+    expect(queryByText('Permission request')).not.toBeInTheDocument();
+    expect(queryByText('Approved amount:')).not.toBeInTheDocument();
+    expect(queryByText('Granted to:')).not.toBeInTheDocument();
     expect(getByText('0x9bc5...fef4')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
Fixes #14521

- Currently we hide transaction details, including `allowance amount` behind a click on the Confirm Approval screen. This change sets the default to show these details without a click.