### PR TITLE
[lint fix] i18n - remove unused locale strings

### DIFF
--- a/app/_locales/de/messages.json
+++ b/app/_locales/de/messages.json
@@ -727,9 +727,6 @@
   "customGasSubTitle": {
     "message": "Höhere Gebühren können Bearbeitungszeiten verkürzen, wofür es allerdings keine Garantie gibt."
   },
-  "customNetworks": {
-    "message": "Netzwerke anpassen"
-  },
   "customSpendLimit": {
     "message": "Benutzerdefiniertes Ausgabelimit"
   },
@@ -2300,9 +2297,6 @@
   },
   "onlyConnectTrust": {
     "message": "Verbinden Sie sich nur mit Sites, denen Sie vertrauen."
-  },
-  "onlyInteractWith": {
-    "message": "Interagieren Sie nur mit Organisationen, denen Sie vertrauen."
   },
   "openFullScreenForLedgerWebHid": {
     "message": "Öffnen Sie MetaMask im Vollbildmodus, um Ihren Ledger über WebHID zu verbinden.",

--- a/app/_locales/el/messages.json
+++ b/app/_locales/el/messages.json
@@ -727,9 +727,6 @@
   "customGasSubTitle": {
     "message": "Η αύξηση των τελών μπορεί να μειώσει τους χρόνους επεξεργασίας, αλλά αυτό δεν είναι εγγυημένο."
   },
-  "customNetworks": {
-    "message": "Προσαρμοσμένα δίκτυα"
-  },
   "customSpendLimit": {
     "message": "Προσαρμοσμένο Όριο Δαπάνης"
   },
@@ -2300,9 +2297,6 @@
   },
   "onlyConnectTrust": {
     "message": "Συνδεθείτε μόνο με ιστότοπους που εμπιστεύεστε."
-  },
-  "onlyInteractWith": {
-    "message": "Να αλληλεπιδράτε μόνο με άτομα/οργανισμούς που εμπιστεύεστε."
   },
   "openFullScreenForLedgerWebHid": {
     "message": "Ανοίξτε το MetaMask σε πλήρη οθόνη για να συνδέσετε το ledger σας μέσω WebHID.",

--- a/app/_locales/es/messages.json
+++ b/app/_locales/es/messages.json
@@ -727,9 +727,6 @@
   "customGasSubTitle": {
     "message": "Aumentar la cuota puede disminuir los tiempos de procesamiento, pero no está garantizado."
   },
-  "customNetworks": {
-    "message": "Redes personalizadas"
-  },
   "customSpendLimit": {
     "message": "Límite de gastos personalizado"
   },
@@ -2300,9 +2297,6 @@
   },
   "onlyConnectTrust": {
     "message": "Conéctese solo con sitios de confianza."
-  },
-  "onlyInteractWith": {
-    "message": "Solo interactúe con entidades en las que confíe."
   },
   "openFullScreenForLedgerWebHid": {
     "message": "Abra MetaMask en pantalla completa para conectar su Ledger a través de WebHID.",

--- a/app/_locales/fr/messages.json
+++ b/app/_locales/fr/messages.json
@@ -727,9 +727,6 @@
   "customGasSubTitle": {
     "message": "Augmenter le tarif peut faire baisser le temps de traitement, mais cela n’est pas garanti."
   },
-  "customNetworks": {
-    "message": "Réseaux personnalisés"
-  },
   "customSpendLimit": {
     "message": "Limite de dépenses personnalisée"
   },
@@ -2300,9 +2297,6 @@
   },
   "onlyConnectTrust": {
     "message": "Ne vous connectez qu’aux sites auxquels vous faites confiance."
-  },
-  "onlyInteractWith": {
-    "message": "Interagissez uniquement avec les entités auxquelles vous faites confiance."
   },
   "openFullScreenForLedgerWebHid": {
     "message": "Ouvrez MetaMask en mode plein écran pour connecter votre Ledger via WebHID.",

--- a/app/_locales/hi/messages.json
+++ b/app/_locales/hi/messages.json
@@ -727,9 +727,6 @@
   "customGasSubTitle": {
     "message": "शुल्क बढ़ाने से प्रसंस्करण समय में कमी हो सकती है, लेकिन इसकी गारंटी नहीं होती है।"
   },
-  "customNetworks": {
-    "message": "कस्टम नेटवर्क्स"
-  },
   "customSpendLimit": {
     "message": "खर्च सीमा कस्टम करें"
   },
@@ -2300,9 +2297,6 @@
   },
   "onlyConnectTrust": {
     "message": "केवल उन साइटों से कनेक्ट करें, जिन पर आप भरोसा करते हैं।"
-  },
-  "onlyInteractWith": {
-    "message": "सिर्फ उन्हीं संस्थाओं से इंटरैक्ट करें जिनपर आप भरोसा करते हैं।"
   },
   "openFullScreenForLedgerWebHid": {
     "message": "अपने लेजर को WebHID के माध्यम से कनेक्ट करने के लिए MetaMask को पूर्ण स्क्रीन में खोलें।",

--- a/app/_locales/id/messages.json
+++ b/app/_locales/id/messages.json
@@ -727,9 +727,6 @@
   "customGasSubTitle": {
     "message": "Menaikkan biaya dapat mengurangi waktu pemrosesan, namun tidak ada jaminan."
   },
-  "customNetworks": {
-    "message": "Jaringan khusus"
-  },
   "customSpendLimit": {
     "message": "Batas Penggunaan Kustom"
   },
@@ -2300,9 +2297,6 @@
   },
   "onlyConnectTrust": {
     "message": "Hanya hubungkan ke situs yang Anda percayai."
-  },
-  "onlyInteractWith": {
-    "message": "Lakukan interaksi hanya dengan entitas yang aman."
   },
   "openFullScreenForLedgerWebHid": {
     "message": "Buka MetaMask dalam layar penuh untuk menghubungkan ledger Anda melalui WebHID.",

--- a/app/_locales/ja/messages.json
+++ b/app/_locales/ja/messages.json
@@ -727,9 +727,6 @@
   "customGasSubTitle": {
     "message": "手数料を増やすと処理時間は短くなる可能性がありますが、必ずそうなるとは限りません。"
   },
-  "customNetworks": {
-    "message": "カスタムネットワーク"
-  },
   "customSpendLimit": {
     "message": "カスタム使用限度額"
   },
@@ -2300,9 +2297,6 @@
   },
   "onlyConnectTrust": {
     "message": "信頼するサイトにのみ接続してください。"
-  },
-  "onlyInteractWith": {
-    "message": "信頼できる相手と以外やり取りしないでください。"
   },
   "openFullScreenForLedgerWebHid": {
     "message": "WebHIDでLedgerを接続するには、MetaMaskを全画面モードで開いてください。",

--- a/app/_locales/ko/messages.json
+++ b/app/_locales/ko/messages.json
@@ -727,9 +727,6 @@
   "customGasSubTitle": {
     "message": "수수료를 올리면 처리 시간이 단축되기도 하지만 항상 그렇지는 않습니다."
   },
-  "customNetworks": {
-    "message": "사용자 정의 네트워크"
-  },
   "customSpendLimit": {
     "message": "맞춤형 지출 한도"
   },
@@ -2300,9 +2297,6 @@
   },
   "onlyConnectTrust": {
     "message": "신뢰하는 사이트만 연결하세요."
-  },
-  "onlyInteractWith": {
-    "message": "신뢰할 수 있는 엔터티만 이용하세요."
   },
   "openFullScreenForLedgerWebHid": {
     "message": "전체 화면에서 MetaMask를 열어 WebHID를 통해 Ledger를 연결합니다.",

--- a/app/_locales/pt/messages.json
+++ b/app/_locales/pt/messages.json
@@ -727,9 +727,6 @@
   "customGasSubTitle": {
     "message": "Aumentar a taxa pode diminuir o tempo de processamento, mas isso não é garantido."
   },
-  "customNetworks": {
-    "message": "Redes personalizadas"
-  },
   "customSpendLimit": {
     "message": "Limite de gastos personalizado"
   },
@@ -2300,9 +2297,6 @@
   },
   "onlyConnectTrust": {
     "message": "Conecte-se somente com sites em que você confia."
-  },
-  "onlyInteractWith": {
-    "message": "Interaja apenas com entidades de sua confiança."
   },
   "openFullScreenForLedgerWebHid": {
     "message": "Abra a MetaMask em tela cheia para conectar sua ledger por meio do WebHID.",

--- a/app/_locales/ru/messages.json
+++ b/app/_locales/ru/messages.json
@@ -727,9 +727,6 @@
   "customGasSubTitle": {
     "message": "Увеличение комиссии может сократить время обработки, но это не гарантируется."
   },
-  "customNetworks": {
-    "message": "Пользовательские сети"
-  },
   "customSpendLimit": {
     "message": "Пользовательский лимит расходов"
   },
@@ -2300,9 +2297,6 @@
   },
   "onlyConnectTrust": {
     "message": "Подключайтесь только к сайтам, которым доверяете."
-  },
-  "onlyInteractWith": {
-    "message": "Взаимодействуйте только с объектами, которым вы доверяете."
   },
   "openFullScreenForLedgerWebHid": {
     "message": "Откройте MetaMask в полноэкранном режиме, чтобы подключить свой леджер через WebHID.",

--- a/app/_locales/tl/messages.json
+++ b/app/_locales/tl/messages.json
@@ -727,9 +727,6 @@
   "customGasSubTitle": {
     "message": "Kapag dinagdagan ang bayarin, mababawasan ang mga oras ng pagproseso, pero hindi ito garantisado."
   },
-  "customNetworks": {
-    "message": "Custom na mga network"
-  },
   "customSpendLimit": {
     "message": "Custom na Limitasyon sa Paggastos"
   },
@@ -2300,9 +2297,6 @@
   },
   "onlyConnectTrust": {
     "message": "Kumonekta lang sa mga site na pinagkakatiwalaan mo."
-  },
-  "onlyInteractWith": {
-    "message": "Makipag-ugnayan lamang sa mga entidad na iyong pinagkakatiwalaan."
   },
   "openFullScreenForLedgerWebHid": {
     "message": "Buksan ang MetaMask sa buong screen para ikonekta ang ledger mo sa pamamagitan ng WebHID.",

--- a/app/_locales/tr/messages.json
+++ b/app/_locales/tr/messages.json
@@ -727,9 +727,6 @@
   "customGasSubTitle": {
     "message": "Ücretin artırılması işlem süresini kısaltabilir ancak bu garanti edilmez."
   },
-  "customNetworks": {
-    "message": "Özel ağlar"
-  },
   "customSpendLimit": {
     "message": "Özel Harcama Limiti"
   },
@@ -2300,9 +2297,6 @@
   },
   "onlyConnectTrust": {
     "message": "Sadece güvendiğiniz sitelere bağlayın."
-  },
-  "onlyInteractWith": {
-    "message": "Yalnızca güvendiğin varlıklarla etkileşim kur."
   },
   "openFullScreenForLedgerWebHid": {
     "message": "Kayıt defterinizi WebHID üzerinden bağlamak için MetaMask'i tam ekran açın.",

--- a/app/_locales/vi/messages.json
+++ b/app/_locales/vi/messages.json
@@ -727,9 +727,6 @@
   "customGasSubTitle": {
     "message": "Việc tăng phí có thể giúp giảm thời gian xử lý, nhưng điều này không được đảm bảo."
   },
-  "customNetworks": {
-    "message": "Mạng tùy chỉnh"
-  },
   "customSpendLimit": {
     "message": "Giới hạn chi tiêu tùy chỉnh"
   },
@@ -2300,9 +2297,6 @@
   },
   "onlyConnectTrust": {
     "message": "Chỉ kết nối với các trang web mà bạn tin tưởng."
-  },
-  "onlyInteractWith": {
-    "message": "Chỉ tương tác với các đối tượng mà bạn tin tưởng."
   },
   "openFullScreenForLedgerWebHid": {
     "message": "Mở MetaMask ở chế độ toàn màn hình để kết nối thiết bị Ledger của bạn qua WebHID.",


### PR DESCRIPTION
due to 2 overlapping but unsynced PRs we got a lint failure in `develop`

special thanks to @Gudahtt for the `--fix` flag on this linter!