### PR TITLE
Fixing 'Learn more' casing on import token screen

### DIFF
--- a/ui/pages/import-token/token-list/token-list-placeholder/token-list-placeholder.component.js
+++ b/ui/pages/import-token/token-list/token-list-placeholder/token-list-placeholder.component.js
@@ -22,7 +22,7 @@ export default class TokenListPlaceholder extends Component {
           target="_blank"
           rel="noopener noreferrer"
         >
-          {this.context.t('learnMore')}
+          {this.context.t('learnMoreUpperCase')}
         </Button>
       </div>
     );


### PR DESCRIPTION
`learn more` -> `Learn more`
<img width="427" alt="Screen Shot 2022-04-25 at 10 10 02 PM" src="https://user-images.githubusercontent.com/8732757/165226140-c4221c3c-6852-4b4c-8c53-ee3ad76031f5.png">