### PR TITLE
Adding option to update lavamoat policies in parallel

### DIFF
--- a/development/generate-lavamoat-policies.sh
+++ b/development/generate-lavamoat-policies.sh
@@ -7,6 +7,21 @@ set -o pipefail
 # Generate LavaMoat policies for the extension background script for each build
 # type.
 # ATTN: This may tax your device when running it locally.
-WRITE_AUTO_POLICY=1 yarn build scripts:prod --policy-only &&
-WRITE_AUTO_POLICY=1 yarn build scripts:prod --policy-only --build-type beta &&
-WRITE_AUTO_POLICY=1 yarn build scripts:prod --policy-only --build-type flask
+
+function run_sequentially() {
+  WRITE_AUTO_POLICY=1 yarn build scripts:prod --policy-only &&
+  WRITE_AUTO_POLICY=1 yarn build scripts:prod --policy-only --build-type beta &&
+  WRITE_AUTO_POLICY=1 yarn build scripts:prod --policy-only --build-type flask
+}
+
+function run_parallel() {
+  concurrently --kill-others-on-fail -n main,beta,flask \
+    "WRITE_AUTO_POLICY=1 yarn build scripts:prod --policy-only" \
+    "WRITE_AUTO_POLICY=1 yarn build scripts:prod --policy-only --build-type beta" \
+    "WRITE_AUTO_POLICY=1 yarn build scripts:prod --policy-only --build-type flask"
+}
+
+if [[ $# -gt 0 ]]
+  then run_parallel
+  else run_sequentially
+fi

--- a/development/generate-lavamoat-policies.sh
+++ b/development/generate-lavamoat-policies.sh
@@ -4,24 +4,16 @@ set -e
 set -u
 set -o pipefail
 
+extraArgs=()
+if [[ $# -lt 1 ]]; then
+    extraArgs+=(-m 1)
+fi
+
 # Generate LavaMoat policies for the extension background script for each build
 # type.
 # ATTN: This may tax your device when running it locally.
-
-function run_sequentially() {
-  WRITE_AUTO_POLICY=1 yarn build scripts:prod --policy-only &&
-  WRITE_AUTO_POLICY=1 yarn build scripts:prod --policy-only --build-type beta &&
-  WRITE_AUTO_POLICY=1 yarn build scripts:prod --policy-only --build-type flask
-}
-
-function run_parallel() {
-  concurrently --kill-others-on-fail -n main,beta,flask \
+concurrently --kill-others-on-fail -n main,beta,flask \
+    "${extraArgs[@]}" \
     "WRITE_AUTO_POLICY=1 yarn build scripts:prod --policy-only" \
     "WRITE_AUTO_POLICY=1 yarn build scripts:prod --policy-only --build-type beta" \
     "WRITE_AUTO_POLICY=1 yarn build scripts:prod --policy-only --build-type flask"
-}
-
-if [[ $# -gt 0 ]]
-  then run_parallel
-  else run_sequentially
-fi

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "lavamoat:build:auto": "yarn lavamoat:build --writeAutoPolicy",
     "lavamoat:debug:build": "yarn lavamoat:build --writeAutoPolicyDebug --policydebug lavamoat/build-system/policy-debug.json",
     "lavamoat:background:auto": "./development/generate-lavamoat-policies.sh",
+    "lavamoat:background:auto:dev": "./development/generate-lavamoat-policies.sh --dev",
     "lavamoat:auto": "yarn lavamoat:build:auto && yarn lavamoat:background:auto"
   },
   "resolutions": {


### PR DESCRIPTION
Recently on CI, the scripts to update lavamoat policies changed to run sequentially: https://github.com/MetaMask/metamask-extension/pull/14470

This is fine for CI, but can be very slow for local development. This change adds an additional command, `yarn lavamoat:background:auto:dev` to run the jobs in parallel.