### PR TITLE
Make "Try Again" button on the loading network screen work for RPC providers

### DIFF
--- a/ui/components/app/loading-network-screen/loading-network-screen.container.js
+++ b/ui/components/app/loading-network-screen/loading-network-screen.container.js
@@ -25,8 +25,12 @@ const mapStateToProps = (state) => {
 
 const mapDispatchToProps = (dispatch) => {
   return {
-    setProviderType: (type) => {
-      dispatch(actions.setProviderType(type));
+    setProviderType: (...args) => {
+      if (args.length === 1) {
+        dispatch(actions.setProviderType(...args));
+      } else {
+        dispatch(actions.setRpcTarget(...args));
+      }
     },
     rollbackToPreviousProvider: () =>
       dispatch(actions.rollbackToPreviousProvider()),


### PR DESCRIPTION
The "Try Again" button was wired to only correctly work for named, hard-coded, network providers. This meant that hitting the button for RPC providers didn't correctly "reset" the provider for another try.

Expressed as implementation details: When hitting the "Try Again" button, only the setProviderType action could be dispatched (correctly for "named" providers like "mainnet", "ropsten", etc). For RPC providers, however, resetting the provider requires the setRpcTarget action to be dispatched.

setProviderType is called with a single argument for "named" providers, while for RPC providers setProviderType is called with more than one argument. We use this arg count different to correctly dispatch the correct action.

After this change, hitting "Try Again" when a RPC provider fails with correctly reset the provider and reconnect.
