### PR TITLE
Fixed API for watchAsset

### DIFF
--- a/app/scripts/lib/rpc-method-middleware/handlers/watch-asset.js
+++ b/app/scripts/lib/rpc-method-middleware/handlers/watch-asset.js
@@ -1,3 +1,4 @@
+import { ethErrors } from 'eth-rpc-errors';
 import { MESSAGE_TYPE } from '../../../../../shared/constants/app';
 
 const watchAsset = {
@@ -36,9 +37,11 @@ async function watchAssetHandler(
 ) {
   try {
     const { options: asset, type } = req.params;
-    res.result = await handleWatchAssetRequest(asset, type);
+    const handleWatchAssetResult = await handleWatchAssetRequest(asset, type);
+    const result = await handleWatchAssetResult.result;
+    res.result = Boolean(result);
     return end();
   } catch (error) {
-    return end(error);
+    return end(ethErrors.provider.userRejectedRequest());
   }
 }

--- a/app/scripts/lib/rpc-method-middleware/handlers/watch-asset.js
+++ b/app/scripts/lib/rpc-method-middleware/handlers/watch-asset.js
@@ -38,10 +38,13 @@ async function watchAssetHandler(
   try {
     const { options: asset, type } = req.params;
     const handleWatchAssetResult = await handleWatchAssetRequest(asset, type);
-    const result = await handleWatchAssetResult.result;
-    res.result = Boolean(result);
+    await handleWatchAssetResult.result;
+    res.result = true;
     return end();
   } catch (error) {
-    return end(ethErrors.provider.userRejectedRequest());
+    if (error.message === 'User rejected to watch the asset.') {
+      return end(ethErrors.provider.userRejectedRequest());
+    }
+    return end(error);
   }
 }


### PR DESCRIPTION
fixes #12416 
may also fix #14656


This just fixes the API. the controller seems to return a promise for `result` so trying to pass that across the background JSON-RPC errors or has unexpected behaviour on different browsers.

It was also passing `result: {result, suggestedAssetMeta}` to go across the wire when the API should just be result: boolean. (spec: https://eips.ethereum.org/EIPS/eip-747)


This PR fixes it inside the extension. Another approach would be returning something close to the current API from the controller instead.