### PR TITLE
Fix browser.tab.get call

### DIFF
--- a/ui/pages/first-time-flow/end-of-flow/end-of-flow.component.js
+++ b/ui/pages/first-time-flow/end-of-flow/end-of-flow.component.js
@@ -5,7 +5,7 @@ import Snackbar from '../../../components/ui/snackbar';
 import MetaFoxLogo from '../../../components/ui/metafox-logo';
 import { SUPPORT_REQUEST_LINK } from '../../../helpers/constants/common';
 import { DEFAULT_ROUTE } from '../../../helpers/constants/routes';
-import { returnToOnboardingInitiator } from '../onboarding-initiator-util';
+import { returnToOnboardingInitiatorTab } from '../onboarding-initiator-util';
 import { EVENT } from '../../../../shared/constants/metametrics';
 
 export default class EndOfFlowScreen extends PureComponent {
@@ -51,7 +51,7 @@ export default class EndOfFlowScreen extends PureComponent {
     this._removeBeforeUnload();
     await this._onOnboardingComplete();
     if (onboardingInitiator) {
-      await returnToOnboardingInitiator(onboardingInitiator);
+      await returnToOnboardingInitiatorTab(onboardingInitiator);
     }
     history.push(DEFAULT_ROUTE);
   };

--- a/ui/pages/first-time-flow/onboarding-initiator-util.js
+++ b/ui/pages/first-time-flow/onboarding-initiator-util.js
@@ -2,21 +2,8 @@ import browser from 'webextension-polyfill';
 import log from 'loglevel';
 
 const returnToOnboardingInitiatorTab = async (onboardingInitiator) => {
-  const tab = await new Promise((resolve) => {
-    browser.tabs.update(onboardingInitiator.tabId, { active: true }).then(
-      // eslint-disable-next-line no-shadow
-      (tab) => {
-        if (tab) {
-          resolve(tab);
-        } else {
-          // silence console message about unchecked error
-          if (browser.runtime.lastError) {
-            log.debug(browser.runtime.lastError);
-          }
-          resolve();
-        }
-      },
-    );
+  const tab = await browser.tabs.update(onboardingInitiator.tabId, {
+    active: true,
   });
 
   if (tab) {
@@ -26,29 +13,22 @@ const returnToOnboardingInitiatorTab = async (onboardingInitiator) => {
     log.warn(
       `Setting current tab to onboarding initiator has failed; falling back to redirect`,
     );
+
+    if (browser.runtime.lastError) {
+      log.debug(browser.runtime.lastError);
+    }
     window.location.assign(onboardingInitiator.location);
   }
 };
 
 export const returnToOnboardingInitiator = async (onboardingInitiator) => {
-  const tab = await new Promise((resolve) => {
-    // eslint-disable-next-line no-shadow
-    browser.tabs.get(onboardingInitiator.tabId).then((tab) => {
-      if (tab) {
-        resolve(tab);
-      } else {
-        // silence console message about unchecked error
-        if (browser.runtime.lastError) {
-          log.debug(browser.runtime.lastError);
-        }
-        resolve();
-      }
-    });
-  });
-
+  const tab = await browser.tabs.get(onboardingInitiator.tabId);
   if (tab) {
     await returnToOnboardingInitiatorTab(onboardingInitiator);
   } else {
+    if (browser.runtime.lastError) {
+      log.debug(browser.runtime.lastError);
+    }
     window.location.assign(onboardingInitiator.location);
   }
 };

--- a/ui/pages/first-time-flow/onboarding-initiator-util.js
+++ b/ui/pages/first-time-flow/onboarding-initiator-util.js
@@ -3,9 +3,7 @@ import log from 'loglevel';
 
 const returnToOnboardingInitiatorTab = async (onboardingInitiator) => {
   const tab = await new Promise((resolve) => {
-    browser.tabs.update(
-      onboardingInitiator.tabId,
-      { active: true },
+    browser.tabs.update(onboardingInitiator.tabId, { active: true }).then(
       // eslint-disable-next-line no-shadow
       (tab) => {
         if (tab) {
@@ -35,7 +33,7 @@ const returnToOnboardingInitiatorTab = async (onboardingInitiator) => {
 export const returnToOnboardingInitiator = async (onboardingInitiator) => {
   const tab = await new Promise((resolve) => {
     // eslint-disable-next-line no-shadow
-    browser.tabs.get(onboardingInitiator.tabId, (tab) => {
+    browser.tabs.get(onboardingInitiator.tabId).then((tab) => {
       if (tab) {
         resolve(tab);
       } else {

--- a/ui/pages/first-time-flow/onboarding-initiator-util.js
+++ b/ui/pages/first-time-flow/onboarding-initiator-util.js
@@ -1,10 +1,17 @@
 import browser from 'webextension-polyfill';
 import log from 'loglevel';
 
-const returnToOnboardingInitiatorTab = async (onboardingInitiator) => {
-  const tab = await browser.tabs.update(onboardingInitiator.tabId, {
-    active: true,
-  });
+export const returnToOnboardingInitiatorTab = async (onboardingInitiator) => {
+  let tab;
+  try {
+    tab = await browser.tabs.update(onboardingInitiator.id, {
+      active: true,
+    });
+  } catch (error) {
+    log.debug(
+      `An error occurred while updating tabs in returnToOnboardingInitiatorTab: ${error.message}`,
+    );
+  }
 
   if (tab) {
     window.close();
@@ -14,21 +21,6 @@ const returnToOnboardingInitiatorTab = async (onboardingInitiator) => {
       `Setting current tab to onboarding initiator has failed; falling back to redirect`,
     );
 
-    if (browser.runtime.lastError) {
-      log.debug(browser.runtime.lastError);
-    }
-    window.location.assign(onboardingInitiator.location);
-  }
-};
-
-export const returnToOnboardingInitiator = async (onboardingInitiator) => {
-  const tab = await browser.tabs.get(onboardingInitiator.tabId);
-  if (tab) {
-    await returnToOnboardingInitiatorTab(onboardingInitiator);
-  } else {
-    if (browser.runtime.lastError) {
-      log.debug(browser.runtime.lastError);
-    }
     window.location.assign(onboardingInitiator.location);
   }
 };

--- a/ui/pages/first-time-flow/seed-phrase/reveal-seed-phrase/reveal-seed-phrase.component.js
+++ b/ui/pages/first-time-flow/seed-phrase/reveal-seed-phrase/reveal-seed-phrase.component.js
@@ -12,7 +12,7 @@ import {
 } from '../../../../helpers/constants/routes';
 import { exportAsFile } from '../../../../helpers/utils/util';
 import { EVENT } from '../../../../../shared/constants/metametrics';
-import { returnToOnboardingInitiator } from '../../onboarding-initiator-util';
+import { returnToOnboardingInitiatorTab } from '../../onboarding-initiator-util';
 
 export default class RevealSeedPhrase extends PureComponent {
   static contextTypes = {
@@ -79,7 +79,7 @@ export default class RevealSeedPhrase extends PureComponent {
     await Promise.all([setCompletedOnboarding(), setSeedPhraseBackedUp(false)]);
 
     if (onboardingInitiator) {
-      await returnToOnboardingInitiator(onboardingInitiator);
+      await returnToOnboardingInitiatorTab(onboardingInitiator);
     }
     history.replace(DEFAULT_ROUTE);
   };


### PR DESCRIPTION
Fix bug introduced when we [deprecated our `extensionizer` package for a `webextension-polyfill`
](https://github.com/MetaMask/metamask-extension/pull/13960) where browser API calls are promisified instead of taking callbacks. In this particular instance we were getting a [sentry error](https://sentry.io/organizations/metamask/issues/3219266910/?project=273505&query=is%3Aunresolved+firstRelease%3Alatest&sort=freq&statsPeriod=14d) that the browser api method we were calling didn't expect the extra (callback) argument.

Removes method `returnToOnboardingInitiator` because it is redundant. `returnToOnboardingInitiatorTab` can achieve the same behavior by itself.