### PR TITLE
Updating text/muted to text/alternative for select text on home screen

### DIFF
--- a/ui/components/app/selected-account/index.scss
+++ b/ui/components/app/selected-account/index.scss
@@ -25,7 +25,7 @@
   &__address {
     @include H7;
 
-    color: var(--color-text-muted);
+    color: var(--color-text-alternative);
     display: flex;
     align-items: center;
   }

--- a/ui/components/app/wallet-overview/index.scss
+++ b/ui/components/app/wallet-overview/index.scss
@@ -79,7 +79,7 @@
   &__secondary-balance {
     @include Paragraph;
 
-    color: var(--color-text-muted);
+    color: var(--color-text-alternative);
   }
 
   &__button {
@@ -125,7 +125,7 @@
   &__secondary-balance {
     @include H5;
 
-    color: var(--color-text-muted);
+    color: var(--color-text-alternative);
   }
 
   &__button {

--- a/ui/components/ui/list-item/index.scss
+++ b/ui/components/ui/list-item/index.scss
@@ -67,7 +67,7 @@
     @include H7;
 
     grid-area: sub;
-    color: var(--color-text-muted);
+    color: var(--color-text-alternative);
     margin-top: 4px;
     // all direct descendants should be truncated with ellipses
     // allows flexibility in consuming components to use h3/other tag

--- a/ui/pages/home/home.component.js
+++ b/ui/pages/home/home.component.js
@@ -281,14 +281,14 @@ export default class Home extends PureComponent {
                     descriptionText={
                       <>
                         <Typography
-                          color={COLORS.TEXT_MUTED}
+                          color={COLORS.TEXT_ALTERNATIVE}
                           variant={TYPOGRAPHY.H5}
                           fontWeight={FONT_WEIGHT.NORMAL}
                         >
                           {t('somethingWentWrong')}
                         </Typography>
                         <Typography
-                          color={COLORS.TEXT_MUTED}
+                          color={COLORS.TEXT_ALTERNATIVE}
                           variant={TYPOGRAPHY.H7}
                           fontWeight={FONT_WEIGHT.NORMAL}
                         >


### PR DESCRIPTION
## Explanation

Updates very light grey text(`var(--color-text-muted)` on home screen to darker grey(`var(--color-text-alternative)`)

## More information
[Slack thread](https://consensys.slack.com/archives/C029JG63136/p1651069716227309?thread_ts=1650880834.175159&cid=C029JG63136)
* Fixes #14528

## Screenshots/Screencaps

### Before

<img width="963" alt="Screen Shot 2022-04-27 at 3 51 52 PM" src="https://user-images.githubusercontent.com/8112138/165645536-2f07e987-a6b3-4bc5-9d7b-4906a7b44732.png">
<img width="959" alt="Screen Shot 2022-04-27 at 3 51 24 PM" src="https://user-images.githubusercontent.com/8112138/165645545-b1a75cb1-2dea-44ef-bcf7-f6bc8ac37e95.png">


### After

<img width="959" alt="Screen Shot 2022-04-27 at 3 49 41 PM" src="https://user-images.githubusercontent.com/8112138/165645565-0843c4dd-9588-4ca6-bfc9-bf3461557c89.png">
<img width="957" alt="Screen Shot 2022-04-27 at 3 50 13 PM" src="https://user-images.githubusercontent.com/8112138/165645566-129be555-7a51-4325-b56f-35d0d8814d17.png">


## Manual testing steps

- Go to home screen
- See updates