### PR TITLE
enable argv length of 2

### DIFF
--- a/development/build/index.js
+++ b/development/build/index.js
@@ -201,7 +201,7 @@ function parseArgv() {
     },
   });
 
-  if (argv._.length !== 1) {
+  if (argv._.length !== 1 && argv._.length !== 2) {
     throw new Error(
       `Metamask build: Expected a single positional argument, but received "${argv._.length}" arguments.`,
     );


### PR DESCRIPTION
## Explanation

<!--
Thanks for the pull request. Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Below is a template to give you some ideas. Feel free to use your own words!

Currently, ...

This is a problem because ...

In order to solve this problem, this pull request ...
-->

My local builds are crashing after https://github.com/MetaMask/metamask-extension/pull/14583. Seems that this PR added an additional argument (`dev`) to the `build:dev` command, which is causing crashes here -- https://github.com/MetaMask/metamask-extension/blob/develop/development/build/index.js#L204-L208

This PR fixes the issue by enabling 2 positional arguments in addition to a single positional argument.

## More information

<!--
Are there any issues, Slack conversations, Zendesk issues, user stories, etc. reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

## Screenshots/Screencaps

<!-- If you're making a change to the UI, make sure to capture a screenshot or a short video showing off your work! -->

### Before

<!-- How did the UI you changed look before your changes? Drag your file(s) below this line: -->

### After

<!-- How does it look now? Drag your file(s) below this line: -->

## Manual testing steps

<!--
How should reviewers and QA manually test your changes? For instance:

- Go to this screen
- Do this
- Then do this
-->

Run `yarn start` on the current `develop` branch, and observe how the build crashes.
Cherry-pick my commit and run `yarn start`, and observe how the build executes.
