### PR TITLE
MetaMetrics: deprecate lodash#flatMap

### DIFF
--- a/app/scripts/controllers/metametrics.js
+++ b/app/scripts/controllers/metametrics.js
@@ -621,7 +621,9 @@ export default class MetaMetricsController {
    */
   _getAllNFTsFlattened = memoize((allCollectibles = {}) => {
     return Object.values(allCollectibles)
-      .flatMap((chainNFTs) => Object.values(chainNFTs))
+      .reduce((result, chainNFTs) => {
+        return result.concat(Object.values(chainNFTs));
+      }, [])
       .flat();
   });
 


### PR DESCRIPTION
## Explanation

> We need to replace the flatmap call with something that would be supported in older browsers

## More Information

* See: https://sentry.io/organizations/metamask/issues/3243390556/?project=273505