### PR TITLE
Fix redundant entry in lockfile

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -15845,7 +15845,7 @@ is-primitive@^2.0.0:
   resolved "https://registry.yarnpkg.com/is-primitive/-/is-primitive-2.0.0.tgz#207bab91638499c07b2adf240a41a87210034575"
   integrity sha1-IHurkWOEmcB7Kt8kCkGochADRXU=
 
-is-promise@^2.1, is-promise@^2.1.0:
+is-promise@^2.1:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-2.1.0.tgz#79a2a9ece7f096e80f36d2b2f3bc16c1ff4bf3fa"
   integrity sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=


### PR DESCRIPTION
The lockfile would change upon install due to a redundant entry. This seems to have been introduced in #14612 as a result of running `yarn-deduplicate`.