### PR TITLE
add gas_used to gasParams for conversion

### DIFF
--- a/app/scripts/controllers/transactions/index.js
+++ b/app/scripts/controllers/transactions/index.js
@@ -2040,8 +2040,8 @@ export default class TransactionController extends EventEmitter {
       gasParams.estimate_used = estimateUsed;
     }
 
-    if (extraParams.gasUsed) {
-      gasParams.gas_used = extraParams.gasUsed;
+    if (extraParams?.gas_used) {
+      gasParams.gas_used = extraParams.gas_used;
     }
 
     const gasParamsInGwei = this._getGasValuesInGWEI(gasParams);

--- a/app/scripts/controllers/transactions/index.js
+++ b/app/scripts/controllers/transactions/index.js
@@ -2040,6 +2040,10 @@ export default class TransactionController extends EventEmitter {
       gasParams.estimate_used = estimateUsed;
     }
 
+    if (extraParams.gasUsed) {
+      gasParams.gas_used = extraParams.gasUsed;
+    }
+
     const gasParamsInGwei = this._getGasValuesInGWEI(gasParams);
 
     let eip1559Version = '0';
@@ -2070,8 +2074,8 @@ export default class TransactionController extends EventEmitter {
         : TRANSACTION_ENVELOPE_TYPE_NAMES.LEGACY,
       first_seen: time,
       gas_limit: gasLimit,
-      ...gasParamsInGwei,
       ...extraParams,
+      ...gasParamsInGwei,
     };
 
     return { properties, sensitiveProperties };


### PR DESCRIPTION
## Explanation

Current analytics record this value as a hex string, which is useless for graphs. We are attempting to compare actual gas used versus fees suggested to the user to better tune our recommendations. This PR just adds gas_used to the gasParams object which gets converted to decimal gwei. It also moves the spread of the gasParams to be below the extraParams so that you can pass gasParams in extraParams and have the decimal gwei values take precedent. 

