### PR TITLE
Chain ID field use the same color pattern as the currency symbol field warning message below

### DIFF
--- a/ui/pages/settings/networks-tab/networks-form/networks-form.js
+++ b/ui/pages/settings/networks-tab/networks-form/networks-form.js
@@ -577,7 +577,7 @@ const NetworksForm = ({
           disabled={viewOnly}
         />
         <FormField
-          error={errors.chainId?.msg || ''}
+          warning={errors.chainId?.msg || ''}
           onChange={setChainId}
           titleText={t('chainId')}
           value={chainId}

--- a/ui/pages/settings/networks-tab/networks-form/networks-form.js
+++ b/ui/pages/settings/networks-tab/networks-form/networks-form.js
@@ -436,12 +436,12 @@ const NetworksForm = ({
       const rpcUrlError = validateRPCUrl(rpcUrl);
       setErrors({
         ...errors,
-        chainId: chainIdError,
         blockExplorerUrl: blockExplorerError,
         rpcUrl: rpcUrlError,
       });
       setWarnings({
         ...warnings,
+        chainId: chainIdError,
         ticker: tickerWarning,
       });
     }
@@ -577,7 +577,7 @@ const NetworksForm = ({
           disabled={viewOnly}
         />
         <FormField
-          warning={errors.chainId?.msg || ''}
+          warning={warnings.chainId?.msg || ''}
           onChange={setChainId}
           titleText={t('chainId')}
           value={chainId}


### PR DESCRIPTION
## Explanation

Fixing `chain ID` field to use the same color pattern as the `currency symbol` field warning message below.

## More Information

* Fixes #13249

## Screenshots/Screencaps

### Before

![Screenshot 2022-05-09 at 11 53 52](https://user-images.githubusercontent.com/92527393/167394819-f320001f-6474-44f2-a733-c7ce68ba558f.png)

### After

![Screenshot 2022-05-09 at 11 54 44](https://user-images.githubusercontent.com/92527393/167394864-2e8ac477-bfeb-452c-b013-55931bb1c055.png)

## Manual Testing Steps

1. Unlock MetaMask
2. Go to Settings // Networks // Add network
3. Insert the same chain ID for some specific custom network
