### PR TITLE
Simplify `removeSnap` functionality after `snaps-skunkworks` update

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -1731,7 +1731,7 @@ export default class MetamaskController extends EventEmitter {
       ),
       disableSnap: this.snapController.disableSnap.bind(this.snapController),
       enableSnap: this.snapController.enableSnap.bind(this.snapController),
-      removeSnap: this.removeSnap.bind(this),
+      removeSnap: this.snapController.removeSnap.bind(this.snapController),
       ///: END:ONLY_INCLUDE_IN
 
       // swaps
@@ -4121,23 +4121,4 @@ export default class MetamaskController extends EventEmitter {
     }
     return this.keyringController.setLocked();
   }
-
-  ///: BEGIN:ONLY_INCLUDE_IN(flask)
-  // SNAPS
-  /**
-   * Removes the specified snap, and all of its associated permissions.
-   * If we didn't revoke the permission to access the snap from all subjects,
-   * they could just reinstall without any confirmation.
-   *
-   * TODO: This should be implemented in `SnapController.removeSnap` via a controller action.
-   *
-   * @param {{ id: string, permissionName: string }} snap - The wrapper object of the snap to remove.
-   */
-  removeSnap(snap) {
-    this.snapController.removeSnap(snap.id);
-    this.permissionController.revokePermissionForAllSubjects(
-      snap.permissionName,
-    );
-  }
-  ///: END:ONLY_INCLUDE_IN
 }

--- a/ui/pages/settings/flask/view-snap/view-snap.js
+++ b/ui/pages/settings/flask/view-snap/view-snap.js
@@ -190,7 +190,7 @@ function ViewSnap() {
               <SnapRemoveWarning
                 onCancel={() => setIsShowingRemoveWarning(false)}
                 onSubmit={async () => {
-                  await dispatch(removeSnap(snap));
+                  await dispatch(removeSnap(snap.id));
                 }}
                 snapName={snap.manifest.proposedName}
               />

--- a/ui/store/actions.js
+++ b/ui/store/actions.js
@@ -991,9 +991,9 @@ export function enableSnap(snapId) {
   };
 }
 
-export function removeSnap(snap) {
+export function removeSnap(snapId) {
   return async (dispatch) => {
-    await promisifiedBackground.removeSnap(snap);
+    await promisifiedBackground.removeSnap(snapId);
     await forceUpdateMetamaskState(dispatch);
   };
 }


### PR DESCRIPTION
## Explanation

Simplified `removeSnap` after changes in `snaps-skunkworks` to add `PermissionController:revokePermissionForAllSubjects`. This was done in https://github.com/MetaMask/snaps-skunkworks/releases/tag/v0.11.0

## Manual Testing Steps

1. Connect and install https://filsnap.chainsafe.io/
2. Go to settings -> snaps
3. Remove the snap and see that it is removed successfully

## Pre-Merge Checklist

- [ ] PR template is filled out
- [ ] Manual testing complete & passed
- [ ] **IF** this PR fixes a bug, a test that _would have_ caught the bug has been added
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** QA attention is required, "QA Board" label has been applied
- [ ] PR has been added to the appropriate release Milestone
