### PR TITLE
TransactionListItemDetails: fix "Speed Up" and "Cancel" button styles

### DIFF
--- a/ui/components/app/transaction-list-item-details/index.scss
+++ b/ui/components/app/transaction-list-item-details/index.scss
@@ -86,7 +86,8 @@
     &-rounded-button {
       @include H8;
 
-      padding: 0 16px;
+      padding: 8px;
+      min-width: 75px;
       margin-right: 8px;
     }
 


### PR DESCRIPTION
## Explanation

The "Speed Up" and "Cancel" buttons on the TransactionListItemDetails do not match the "Speed Up" and "Cancel" buttons on the TransactionListItem component. This PR fixes this by copying styles from the TransactionListItem buttons to the TransactionListItemDetails buttons.

## More Information


## Screenshots/Screencaps

### Current Speed and Cancel buttons on TransactionListItem
<img width="358" alt="Screenshot 2022-05-07 at 11 29 08 PM" src="https://user-images.githubusercontent.com/20778143/167439060-e2f77bbb-f3a7-4c47-8108-ef230d5da012.png">


### Before (TransactionListItemDetails)

<img width="355" alt="Screenshot 2022-05-07 at 11 41 26 PM" src="https://user-images.githubusercontent.com/20778143/167438484-29b1b2f1-af70-41c9-b83d-f2e429f1da72.png">
<img width="362" alt="Screenshot 2022-05-09 at 10 26 56 AM" src="https://user-images.githubusercontent.com/20778143/167443818-315fff93-8526-4e49-add8-38b8e8a04da6.png">


### After (TransactionListItemDetails)

<img width="359" alt="Screenshot 2022-05-07 at 11 41 55 PM" src="https://user-images.githubusercontent.com/20778143/167438824-58546fe1-7c78-4eb1-b075-704706684fd7.png">
<img width="366" alt="Screenshot 2022-05-07 at 11 32 33 PM" src="https://user-images.githubusercontent.com/20778143/167438872-fc378a34-d86e-4aff-ab2d-68d3d0071eeb.png">


## Manual Testing Steps

1. Create a transaction with low gas fees
2. Click on the TransactionListItem to open the details in the modal (TransactionListItemDetails)
3. Observe "Speed Up" and "Cancel" buttons