### PR TITLE
Fix eth_sign 'Learn more' dialog link

### DIFF
--- a/ui/components/app/signature-request-original/signature-request-original.component.js
+++ b/ui/components/app/signature-request-original/signature-request-original.component.js
@@ -224,11 +224,11 @@ export default class SignatureRequestOriginal extends Component {
               onClick={() => {
                 global.platform.openTab({
                   url:
-                    'https://metamask.zendesk.com/hc/en-us/articles/360015488751',
+                    'https://consensys.net/blog/metamask/the-seal-of-approval-know-what-youre-consenting-to-with-permissions-and-approvals-in-metamask/',
                 });
               }}
             >
-              {this.context.t('learnMore')}
+              {this.context.t('learnMoreUpperCase')}
             </span>
           ) : null}
         </div>


### PR DESCRIPTION
Fixes https://github.com/MetaMask/metamask-extension/issues/14638

<img width="358" alt="Screen Shot 2022-05-10 at 12 34 08 AM" src="https://user-images.githubusercontent.com/8732757/167574901-cafda38a-56fc-49c7-a351-d8034d7b1b4a.png">

