### PR TITLE
Updating alert text color

### DIFF
--- a/ui/components/app/confirm-page-container/confirm-detail-row/index.scss
+++ b/ui/components/app/confirm-page-container/confirm-detail-row/index.scss
@@ -9,7 +9,7 @@
     @include H7;
 
     font-weight: 500;
-    color: var(--color-text-allternative);
+    color: var(--color-text-alternative);
     text-transform: uppercase;
   }
 

--- a/ui/components/app/ledger-instruction-field/ledger-instruction-field.js
+++ b/ui/components/app/ledger-instruction-field/ledger-instruction-field.js
@@ -38,7 +38,7 @@ import { attemptLedgerTransportCreation } from '../../../store/actions';
 const renderInstructionStep = (
   text,
   show = true,
-  color = COLORS.PRIMARY_DEFAULT,
+  color = COLORS.TEXT_DEFAULT,
 ) => {
   return (
     show && (


### PR DESCRIPTION
## Explanation
Updates the color of the ledger alert text to adhere to design system guidelines.

[Slack thread](https://consensys.slack.com/archives/G4V2HTG0Y/p1652134867456119)

## Screenshots/Screencaps


### Before

<img width="368" alt="image" src="https://user-images.githubusercontent.com/8112138/167666397-083d813b-94a6-4e8f-acd4-eb0a34f0a055.png">


### After

<img width="697" alt="Screen Shot 2022-05-10 at 8 29 01 AM" src="https://user-images.githubusercontent.com/8112138/167666775-8c1c6234-cdd6-4b93-a2e7-a71b2e8b88a8.png">

## Manual Testing Steps

I created a story to get the screenshot. Could connect a ledger but this is a small enough change that I think it's ok to review with above screenshot and check code.

## Pre-Merge Checklist

- [x] PR template is filled out
- [x] Manual testing complete & passed
- [ ] ~**IF** this PR fixes a bug, a test that _would have_ caught the bug has been added~ NA
- [ ] ~!PR is linked to the appropriate GitHub issue~ NA
- [ ] ~**IF** QA attention is required, "QA Board" label has been applied~ NA
- [ ] ~PR has been added to the appropriate release Milestone~ NA
