### PR TITLE
Ensure ledger keyring message event listener are removed on metamask lock

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -3766,7 +3766,7 @@ export default class MetamaskController extends EventEmitter {
    * Handle global application lock.
    * Notifies all connections that the extension is locked.
    */
-  _onLock() {
+  async _onLock() {
     this.notifyAllConnections({
       method: NOTIFICATION_NAMES.unlockStateChanged,
       params: {
@@ -4120,6 +4120,13 @@ export default class MetamaskController extends EventEmitter {
     );
     if (trezorKeyring) {
       trezorKeyring.dispose();
+    }
+
+    const [ledgerKeyring] = this.keyringController.getKeyringsByType(
+      KEYRING_TYPES.LEDGER,
+    );
+    if (ledgerKeyring?.destroy) {
+      ledgerKeyring.destroy();
     }
     return this.keyringController.setLocked();
   }

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -3766,7 +3766,7 @@ export default class MetamaskController extends EventEmitter {
    * Handle global application lock.
    * Notifies all connections that the extension is locked.
    */
-  async _onLock() {
+  _onLock() {
     this.notifyAllConnections({
       method: NOTIFICATION_NAMES.unlockStateChanged,
       params: {
@@ -4125,9 +4125,8 @@ export default class MetamaskController extends EventEmitter {
     const [ledgerKeyring] = this.keyringController.getKeyringsByType(
       KEYRING_TYPES.LEDGER,
     );
-    if (ledgerKeyring?.destroy) {
-      ledgerKeyring.destroy();
-    }
+    ledgerKeyring?.destroy?.();
+
     return this.keyringController.setLocked();
   }
 }

--- a/lavamoat/browserify/beta/policy.json
+++ b/lavamoat/browserify/beta/policy.json
@@ -2961,7 +2961,8 @@
         "console.log": true,
         "document.createElement": true,
         "document.head.appendChild": true,
-        "fetch": true
+        "fetch": true,
+        "removeEventListener": true
       },
       "packages": {
         "@ethereumjs/tx": true,

--- a/lavamoat/browserify/flask/policy.json
+++ b/lavamoat/browserify/flask/policy.json
@@ -2961,7 +2961,8 @@
         "console.log": true,
         "document.createElement": true,
         "document.head.appendChild": true,
-        "fetch": true
+        "fetch": true,
+        "removeEventListener": true
       },
       "packages": {
         "@ethereumjs/tx": true,

--- a/lavamoat/browserify/main/policy.json
+++ b/lavamoat/browserify/main/policy.json
@@ -2961,7 +2961,8 @@
         "console.log": true,
         "document.createElement": true,
         "document.head.appendChild": true,
-        "fetch": true
+        "fetch": true,
+        "removeEventListener": true
       },
       "packages": {
         "@ethereumjs/tx": true,

--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "@metamask/contract-metadata": "^1.31.0",
     "@metamask/controllers": "^28.0.0",
     "@metamask/design-tokens": "^1.5.1",
-    "@metamask/eth-ledger-bridge-keyring": "^0.11.0",
+    "@metamask/eth-ledger-bridge-keyring": "^0.12.0",
     "@metamask/eth-token-tracker": "^4.0.0",
     "@metamask/etherscan-link": "^2.1.0",
     "@metamask/jazzicon": "^2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2875,10 +2875,10 @@
   resolved "https://registry.yarnpkg.com/@metamask/eslint-config/-/eslint-config-9.0.0.tgz#22d4911b705f7e4e566efbdda0e37912da33e30f"
   integrity sha512-mWlLGQKjXXFOj9EtDClKSoTLeQuPW2kM1w3EpUMf4goYAQ+kLXCCa8pEff6h8ApWAnjhYmXydA1znQ2J4XvD+A==
 
-"@metamask/eth-ledger-bridge-keyring@^0.11.0":
-  version "0.11.0"
-  resolved "https://registry.yarnpkg.com/@metamask/eth-ledger-bridge-keyring/-/eth-ledger-bridge-keyring-0.11.0.tgz#8502e2fd36c89aff7de6724354217274917cecd3"
-  integrity sha512-fCwM8LYC6SXLfsKc4oNiAatz2X8p/pjbM5zMfm4nb4sZPshBAWU32M4vnB3BSVeQEsisGuLfOWCOWhxmq25n+Q==
+"@metamask/eth-ledger-bridge-keyring@^0.12.0":
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/@metamask/eth-ledger-bridge-keyring/-/eth-ledger-bridge-keyring-0.12.0.tgz#d3986e0dbbfeab713f4e0338bf4e5c74a2265bdd"
+  integrity sha512-kceBQc/wKCAdChZeI1P0Fs0FS15WtiD2Q87MqmfuJYpOriWRx/RmjKZoa6EJe2vy20KurlZRcKIiU8nFQ0e/ag==
   dependencies:
     "@ethereumjs/tx" "^3.2.0"
     eth-sig-util "^2.0.0"


### PR DESCRIPTION
Resolves https://sentry.io/organizations/metamask/issues/3244288756/?project=273505

Uses the method added in https://github.com/MetaMask/eth-ledger-bridge-keyring/pull/145 to ensure that event listeners are removed when metamask is locked. This prevents problems caused by the fact that the keyring is instantiated on unlock. This would lead to multiple listeners being registered for the same event, which could cause the payloads being received in the ledger keyring (from the ledger bridge) to be incorrect.