### PR TITLE
Fix Snaps view search

### DIFF
--- a/ui/pages/settings/flask/snaps-list-tab/snap-list-tab.js
+++ b/ui/pages/settings/flask/snaps-list-tab/snap-list-tab.js
@@ -24,10 +24,7 @@ const SnapListTab = () => {
   const snaps = useSelector(getSnaps);
   const settingsRef = useRef();
   const onClick = (snap) => {
-    const route = `${SNAPS_VIEW_ROUTE}/${window.btoa(
-      unescape(encodeURIComponent(snap.id)),
-    )}`;
-    history.push(route);
+    history.push(`${SNAPS_VIEW_ROUTE}/${encodeURIComponent(snap.id)}`);
   };
   const onToggle = (snap) => {
     if (snap.enabled) {

--- a/ui/pages/settings/flask/view-snap/view-snap.js
+++ b/ui/pages/settings/flask/view-snap/view-snap.js
@@ -37,7 +37,7 @@ function ViewSnap() {
   const snap = Object.entries(snaps)
     .map(([_, snapState]) => snapState)
     .find((snapState) => {
-      const decoded = decodeURIComponent(escape(window.atob(pathNameTail)));
+      const decoded = decodeURIComponent(pathNameTail);
       return snapState.id === decoded;
     });
 

--- a/ui/pages/settings/flask/view-snap/view-snap.js
+++ b/ui/pages/settings/flask/view-snap/view-snap.js
@@ -32,14 +32,12 @@ function ViewSnap() {
   const history = useHistory();
   const location = useLocation();
   const { pathname } = location;
-  const pathNameTail = pathname.match(/[^/]+$/u)[0];
+  // The snap ID is in URI-encoded form in the last path segment of the URL.
+  const decodedSnapId = decodeURIComponent(pathname.match(/[^/]+$/u)[0]);
   const snaps = useSelector(getSnaps);
   const snap = Object.entries(snaps)
     .map(([_, snapState]) => snapState)
-    .find((snapState) => {
-      const decoded = decodeURIComponent(pathNameTail);
-      return snapState.id === decoded;
-    });
+    .find((snapState) => snapState.id === decodedSnapId);
 
   const [isShowingRemoveWarning, setIsShowingRemoveWarning] = useState(false);
 

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -717,9 +717,7 @@ export const getSnapsRouteObjects = createSelector(getSnaps, (snaps) => {
       tabMessage: () => snap.manifest.proposedName,
       descriptionMessage: () => snap.manifest.description,
       sectionMessage: () => snap.manifest.description,
-      route: `${SNAPS_VIEW_ROUTE}/${window.btoa(
-        unescape(encodeURIComponent(snap.id)),
-      )}`,
+      route: `${SNAPS_VIEW_ROUTE}/${encodeURIComponent(snap.id)}`,
       icon: 'fa fa-flask',
     };
   });


### PR DESCRIPTION
Closes #14687

Snap IDs were not properly encoded (and decoded) as URI components in the Snaps view search implementation. This ensures that they are.