### PR TITLE
Change styles for the high price impact notification in Swaps

### DIFF
--- a/ui/pages/swaps/view-quote/index.scss
+++ b/ui/pages/swaps/view-quote/index.scss
@@ -96,12 +96,12 @@
 
       &.high {
         .actionable-message {
-          border-color: var(--color-warning-default);
-          background: var(--color-warning-muted);
+          border-color: var(--color-error-default);
+          background: var(--color-error-muted);
 
           button {
-            background: var(--color-warning-default);
-            color: var(--color-warning-inverse);
+            background: var(--color-error-default);
+            color: var(--color-error-inverse);
           }
         }
       }


### PR DESCRIPTION
## Explanation
In this [PR](https://github.com/MetaMask/metamask-extension/pull/14112/files#diff-02f3feef5ceb775d014fe40cdc00387cc61d87b00a077044f09dc6e6b1e74732R95) the color was changed from red to yellow. This PR fixes it.

## Screenshots
Before:
![image](https://user-images.githubusercontent.com/80175477/168065020-9799c3b6-a2f4-4dcb-9a81-759ccef9d0e8.png)

After:
![image](https://user-images.githubusercontent.com/80175477/168064968-27ca5f85-c814-4a77-a154-c084bd2c1b55.png)
