### PR TITLE
remove draft transaction

### DIFF
--- a/ui/ducks/send/send.test.js
+++ b/ui/ducks/send/send.test.js
@@ -194,9 +194,7 @@ describe('Send Slice', () => {
         };
         const result = sendReducer(initialState, action);
 
-        expect(result.draftTransaction.userInputHexData).toStrictEqual(
-          action.payload,
-        );
+        expect(result.userInputHexData).toStrictEqual(action.payload);
       });
     });
 
@@ -217,9 +215,6 @@ describe('Send Slice', () => {
         );
 
         expect(result.gas.gasLimit).toStrictEqual(action.payload);
-        expect(result.draftTransaction.txParams.gas).toStrictEqual(
-          action.payload,
-        );
       });
 
       it('should recalculate gasTotal', () => {
@@ -385,203 +380,6 @@ describe('Send Slice', () => {
 
         expect(result.stage).toStrictEqual(SEND_STAGES.DRAFT);
         expect(result.recipient.address).toStrictEqual(action.payload.address);
-      });
-    });
-
-    describe('updateDraftTransaction', () => {
-      describe('with LEGACY transactions', () => {
-        it('should properly set fields', () => {
-          const detailsForDraftTransactionState = {
-            ...initialState,
-            status: SEND_STATUSES.VALID,
-            transactionType: TRANSACTION_ENVELOPE_TYPES.LEGACY,
-            account: {
-              address: '0xCurrentAddress',
-            },
-            asset: {
-              type: '',
-            },
-            recipient: {
-              address: '0xRecipientAddress',
-            },
-            amount: {
-              value: '0x1',
-            },
-            gas: {
-              gasPrice: '0x3b9aca00', // 1000000000
-              gasLimit: '0x5208', // 21000
-            },
-          };
-
-          const action = {
-            type: 'send/updateDraftTransaction',
-          };
-
-          const result = sendReducer(detailsForDraftTransactionState, action);
-
-          expect(result.draftTransaction.txParams.to).toStrictEqual(
-            detailsForDraftTransactionState.recipient.address,
-          );
-          expect(result.draftTransaction.txParams.value).toStrictEqual(
-            detailsForDraftTransactionState.amount.value,
-          );
-          expect(result.draftTransaction.txParams.gas).toStrictEqual(
-            detailsForDraftTransactionState.gas.gasLimit,
-          );
-          expect(result.draftTransaction.txParams.gasPrice).toStrictEqual(
-            detailsForDraftTransactionState.gas.gasPrice,
-          );
-        });
-
-        it('should update the draftTransaction txParams recipient to token address when asset is type TOKEN', () => {
-          const detailsForDraftTransactionState = {
-            ...initialState,
-            status: SEND_STATUSES.VALID,
-            transactionType: TRANSACTION_ENVELOPE_TYPES.LEGACY,
-            account: {
-              address: '0xCurrentAddress',
-            },
-            asset: {
-              type: ASSET_TYPES.TOKEN,
-              details: {
-                address: '0xTokenAddress',
-              },
-            },
-            amount: {
-              value: '0x1',
-            },
-            gas: {
-              gasPrice: '0x3b9aca00', // 1000000000
-              gasLimit: '0x5208', // 21000
-            },
-          };
-
-          const action = {
-            type: 'send/updateDraftTransaction',
-          };
-
-          const result = sendReducer(detailsForDraftTransactionState, action);
-
-          expect(result.draftTransaction.txParams.to).toStrictEqual(
-            detailsForDraftTransactionState.asset.details.address,
-          );
-          expect(result.draftTransaction.txParams.value).toStrictEqual('0x0');
-          expect(result.draftTransaction.txParams.gas).toStrictEqual(
-            detailsForDraftTransactionState.gas.gasLimit,
-          );
-          expect(result.draftTransaction.txParams.gasPrice).toStrictEqual(
-            detailsForDraftTransactionState.gas.gasPrice,
-          );
-          expect(result.draftTransaction.txParams.data).toStrictEqual(
-            '0xa9059cbb00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001',
-          );
-        });
-      });
-
-      describe('with FEE_MARKET transactions', () => {
-        it('should properly set fields', () => {
-          const detailsForDraftTransactionState = {
-            ...initialState,
-            status: SEND_STATUSES.VALID,
-            transactionType: TRANSACTION_ENVELOPE_TYPES.FEE_MARKET,
-            account: {
-              address: '0xCurrentAddress',
-            },
-            asset: {
-              type: '',
-            },
-            recipient: {
-              address: '0xRecipientAddress',
-            },
-            amount: {
-              value: '0x1',
-            },
-            gas: {
-              maxFeePerGas: '0x2540be400', // 10 GWEI
-              maxPriorityFeePerGas: '0x3b9aca00', // 1 GWEI
-              gasLimit: '0x5208', // 21000
-            },
-            eip1559support: true,
-          };
-
-          const action = {
-            type: 'send/updateDraftTransaction',
-          };
-
-          const result = sendReducer(detailsForDraftTransactionState, action);
-
-          expect(result.draftTransaction.txParams.to).toStrictEqual(
-            detailsForDraftTransactionState.recipient.address,
-          );
-          expect(result.draftTransaction.txParams.value).toStrictEqual(
-            detailsForDraftTransactionState.amount.value,
-          );
-          expect(result.draftTransaction.txParams.gas).toStrictEqual(
-            detailsForDraftTransactionState.gas.gasLimit,
-          );
-          expect(result.draftTransaction.txParams.gasPrice).toBeUndefined();
-          expect(result.draftTransaction.txParams.maxFeePerGas).toStrictEqual(
-            detailsForDraftTransactionState.gas.maxFeePerGas,
-          );
-          expect(
-            result.draftTransaction.txParams.maxPriorityFeePerGas,
-          ).toStrictEqual(
-            detailsForDraftTransactionState.gas.maxPriorityFeePerGas,
-          );
-        });
-
-        it('should update the draftTransaction txParams recipient to token address when asset is type TOKEN', () => {
-          const detailsForDraftTransactionState = {
-            ...initialState,
-            status: SEND_STATUSES.VALID,
-            transactionType: TRANSACTION_ENVELOPE_TYPES.FEE_MARKET,
-            account: {
-              address: '0xCurrentAddress',
-            },
-            asset: {
-              type: ASSET_TYPES.TOKEN,
-              details: {
-                address: '0xTokenAddress',
-              },
-            },
-            amount: {
-              value: '0x1',
-            },
-            gas: {
-              maxFeePerGas: '0x2540be400', // 10 GWEI
-              maxPriorityFeePerGas: '0x3b9aca00', // 1 GWEI
-              gasLimit: '0x5208', // 21000
-            },
-            eip1559support: true,
-          };
-
-          const action = {
-            type: 'send/updateDraftTransaction',
-          };
-
-          const result = sendReducer(detailsForDraftTransactionState, action);
-
-          expect(result.draftTransaction.txParams.to).toStrictEqual(
-            detailsForDraftTransactionState.asset.details.address,
-          );
-          expect(result.draftTransaction.txParams.value).toStrictEqual('0x0');
-          expect(result.draftTransaction.txParams.gas).toStrictEqual(
-            detailsForDraftTransactionState.gas.gasLimit,
-          );
-
-          expect(result.draftTransaction.txParams.maxFeePerGas).toStrictEqual(
-            detailsForDraftTransactionState.gas.maxFeePerGas,
-          );
-          expect(
-            result.draftTransaction.txParams.maxPriorityFeePerGas,
-          ).toStrictEqual(
-            detailsForDraftTransactionState.gas.maxPriorityFeePerGas,
-          );
-          expect(result.draftTransaction.txParams.gasPrice).toBeUndefined();
-          expect(result.draftTransaction.txParams.data).toStrictEqual(
-            '0xa9059cbb00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001',
-          );
-        });
       });
     });
 
@@ -1300,9 +1098,7 @@ describe('Send Slice', () => {
             amount: {
               value: '',
             },
-            draftTransaction: {
-              userInputHexData: '',
-            },
+            userInputHexData: '',
           },
         };
         const store = mockStore(sendState);
@@ -1356,9 +1152,7 @@ describe('Send Slice', () => {
             amount: {
               value: '',
             },
-            draftTransaction: {
-              userInputHexData: '',
-            },
+            userInputHexData: '',
           },
         };
 
@@ -1412,9 +1206,7 @@ describe('Send Slice', () => {
             amount: {
               value: '',
             },
-            draftTransaction: {
-              userInputHexData: '',
-            },
+            userInputHexData: '',
           },
         };
 
@@ -1462,9 +1254,7 @@ describe('Send Slice', () => {
           amount: {
             value: '',
           },
-          draftTransaction: {
-            userInputHexData: '',
-          },
+          userInputHexData: '',
         },
       };
 
@@ -1766,9 +1556,7 @@ describe('Send Slice', () => {
             amount: {
               value: '',
             },
-            draftTransaction: {
-              userInputHexData: '',
-            },
+            userInputHexData: '',
           },
         };
 
@@ -1827,9 +1615,7 @@ describe('Send Slice', () => {
             amount: {
               value: '',
             },
-            draftTransaction: {
-              userInputHexData: '',
-            },
+            userInputHexData: '',
           },
         };
 
@@ -1881,9 +1667,7 @@ describe('Send Slice', () => {
             amount: {
               value: '',
             },
-            draftTransaction: {
-              userInputHexData: '',
-            },
+            userInputHexData: '',
           },
         };
 
@@ -1955,7 +1739,6 @@ describe('Send Slice', () => {
             amount: {
               value: '0x1',
             },
-            draftTransaction: {},
           },
         };
 
@@ -2035,9 +1818,7 @@ describe('Send Slice', () => {
               mode: '',
               value: '',
             },
-            draftTransaction: {
-              userInputHexData: '',
-            },
+            userInputHexData: '',
           },
           metamask: {
             provider: {
@@ -2084,9 +1865,7 @@ describe('Send Slice', () => {
               mode: AMOUNT_MODES.MAX,
               value: '',
             },
-            draftTransaction: {
-              userInputHexData: '',
-            },
+            userInputHexData: '',
           },
           metamask: {
             provider: {
@@ -2121,10 +1900,12 @@ describe('Send Slice', () => {
         send: {
           asset: {},
           stage: '',
-          draftTransaction: {},
           recipient: {},
           amount: {},
           account: {},
+          gas: {
+            gasLimit: GAS_LIMITS.SIMPLE,
+          },
         },
       };
 
@@ -2159,12 +1940,7 @@ describe('Send Slice', () => {
           send: {
             ...signTransactionState.send,
             stage: SEND_STAGES.EDIT,
-            draftTransaction: {
-              id: 1,
-              txParams: {
-                value: 'newTxValue',
-              },
-            },
+            id: 1,
           },
         };
 
@@ -2258,19 +2034,6 @@ describe('Send Slice', () => {
         expect(result.gas.gasPrice).toStrictEqual(action.payload.gasPrice);
 
         expect(result.amount.value).toStrictEqual(action.payload.amount);
-
-        expect(result.draftTransaction.txParams.to).toStrictEqual(
-          action.payload.address,
-        );
-        expect(result.draftTransaction.txParams.value).toStrictEqual(
-          action.payload.amount,
-        );
-        expect(result.draftTransaction.txParams.gasPrice).toStrictEqual(
-          action.payload.gasPrice,
-        );
-        expect(result.draftTransaction.txParams.gas).toStrictEqual(
-          action.payload.gasLimit,
-        );
       });
 
       it('should set up the appropriate state for editing a collectible asset transaction', async () => {
@@ -2314,9 +2077,8 @@ describe('Send Slice', () => {
             amount: {
               value: '',
             },
-            draftTransaction: {
-              userInputHexData: '',
-            },
+            userInputHexData: '',
+
             recipient: {
               address: 'Address',
               nickname: 'NickName',
@@ -2408,19 +2170,6 @@ describe('Send Slice', () => {
         expect(result.gas.gasPrice).toStrictEqual(action.payload.gasPrice);
 
         expect(result.amount.value).toStrictEqual(action.payload.amount);
-
-        expect(result.draftTransaction.txParams.to).toStrictEqual(
-          action.payload.address,
-        );
-        expect(result.draftTransaction.txParams.value).toStrictEqual(
-          action.payload.amount,
-        );
-        expect(result.draftTransaction.txParams.gasPrice).toStrictEqual(
-          action.payload.gasPrice,
-        );
-        expect(result.draftTransaction.txParams.gas).toStrictEqual(
-          action.payload.gasLimit,
-        );
       });
     });
 
@@ -2465,9 +2214,7 @@ describe('Send Slice', () => {
           amount: {
             value: '',
           },
-          draftTransaction: {
-            userInputHexData: '',
-          },
+          userInputHexData: '',
           recipient: {
             address: 'Address',
             nickname: 'NickName',
@@ -2562,19 +2309,6 @@ describe('Send Slice', () => {
       expect(result.gas.gasPrice).toStrictEqual(action.payload.gasPrice);
 
       expect(result.amount.value).toStrictEqual(action.payload.amount);
-
-      expect(result.draftTransaction.txParams.to).toStrictEqual(
-        action.payload.address,
-      );
-      expect(result.draftTransaction.txParams.value).toStrictEqual(
-        action.payload.amount,
-      );
-      expect(result.draftTransaction.txParams.gasPrice).toStrictEqual(
-        action.payload.gasPrice,
-      );
-      expect(result.draftTransaction.txParams.gas).toStrictEqual(
-        action.payload.gasLimit,
-      );
     });
   });
 
@@ -2774,10 +2508,7 @@ describe('Send Slice', () => {
           getDraftTransactionID({
             send: {
               ...initialState,
-              draftTransaction: {
-                ...initialState.draftTransaction,
-                id: 'ID',
-              },
+              id: 'ID',
             },
           }),
         ).toBe('ID');
@@ -2789,10 +2520,7 @@ describe('Send Slice', () => {
           getSendHexData({
             send: {
               ...initialState,
-              draftTransaction: {
-                ...initialState.draftTransaction,
-                userInputHexData: '0x0',
-              },
+              userInputHexData: '0x0',
             },
           }),
         ).toBe('0x0');


### PR DESCRIPTION
## Explanation
Removes the draft transaction object from the send slice. This object is derived from the other keys in state, and is updated after every modification of the send slice. This is not necessary and it is plausible that the draftTransaction might get out of sync with the rest of the slice in various corner cases. 

## More Information
Fixes #14696 
Progresses #11677

At least two additional PRs will follow this one:
1. Add full types to the send slice using jsdoc.
2. Move state that details the transaction to a keyed object instead of "global". (this might become multiple prs)


## Manual Testing Steps
1. Full regression testing of the send flow needs to occur.
2. For each type of send (TOKEN, NATIVE, COLLECTIBLE) confirm that every detail matches the actual transaction created.
3. Enable all the various advanced options for send flow (nonce, custom data, etc) and make sure those are respected in the newly created tx. 
4. Test editing transactions to make sure send flow behaves for each transaction type that can be edited


## Pre-Merge Checklist

- [x] PR template is filled out
- [x] Manual testing complete & passed
- [x] ~**IF** this PR fixes a bug, a test that _would have_ caught the bug has been added~
- [x] PR is linked to the appropriate GitHub issue
- [x] **IF** QA attention is required, "QA Board" label has been applied
- [ ] PR has been added to the appropriate release Milestone
