### PR TITLE
Storybook: add SignatureRequestOriginal

### DIFF
--- a/ui/components/app/signature-request-original/README.mdx
+++ b/ui/components/app/signature-request-original/README.mdx
@@ -1,0 +1,15 @@
+import { Story, Canvas, ArgsTable } from '@storybook/addon-docs';
+
+import SignatureRequestOriginal from '.';
+
+# Signature Request
+
+dApp requesting a signature from the user. This component appears for signatures that are not v3 or v4, so it will show when signatures are v1 or v2. For v3 or v4 signatures, please see SignatureRequest.
+
+<Canvas>
+  <Story id="ui-components-app-signature-request-signature-request-original-stories-js--default-story" />
+</Canvas>
+
+## Component API
+
+<ArgsTable of={SignatureRequestOriginal} />

--- a/ui/components/app/signature-request-original/README.mdx
+++ b/ui/components/app/signature-request-original/README.mdx
@@ -4,7 +4,7 @@ import SignatureRequestOriginal from '.';
 
 # Signature Request
 
-dApp requesting a signature from the user. This component appears for signatures that are not v3 or v4, so it will show when signatures are v1 or v2. For v3 or v4 signatures, please see SignatureRequest.
+dApp requesting a signature from the user. This component appears for signatures that are not v3 or v4. For v3 or v4 signatures, please see SignatureRequest.
 
 <Canvas>
   <Story id="ui-components-app-signature-request-signature-request-original-stories-js--default-story" />

--- a/ui/components/app/signature-request-original/README.mdx
+++ b/ui/components/app/signature-request-original/README.mdx
@@ -4,7 +4,7 @@ import SignatureRequestOriginal from '.';
 
 # Signature Request
 
-dApp requesting a signature from the user. This component appears for signatures that are not v3 or v4. For v3 or v4 signatures, please see SignatureRequest.
+dApp requesting a signature from the user. This component appears for eth_signTypedData signatures are not v3 or v4. For other signatures, please see SignatureRequest.
 
 <Canvas>
   <Story id="ui-components-app-signature-request-signature-request-original-stories-js--default-story" />

--- a/ui/components/app/signature-request-original/signature-request-original.stories.js
+++ b/ui/components/app/signature-request-original/signature-request-original.stories.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { action } from '@storybook/addon-actions';
 import { MESSAGE_TYPE } from '../../../../shared/constants/app';
 import testData from '../../../../.storybook/test-data';
 import README from './README.mdx';
@@ -51,7 +52,6 @@ export default {
     },
   },
   argTypes: {
-    txData: { control: 'object' },
     fromAccount: {
       table: {
         address: { control: 'text' },
@@ -61,9 +61,19 @@ export default {
     },
     hardwareWalletRequiresConnection: { control: 'boolean' },
     isLedgerWallet: { control: 'boolean' },
+    nativeCurrency: { control: 'text' },
+    txData: { control: 'object' },
     clearConfirmTransaction: { action: 'Clean Confirm' },
     cancel: { action: 'Cancel' },
     sign: { action: 'Sign' },
+  },
+  args: {
+    fromAccount: MOCK_PRIMARY_IDENTITY,
+    history: {
+      push: action('history.push()'),
+    },
+    mostRecentOverviewPage: '/',
+    nativeCurrency: 'ETH',
   },
 };
 
@@ -80,7 +90,6 @@ DefaultStory.args = {
     msgParams: { ...MOCK_TX_MSG_PARAMS },
     type: MESSAGE_TYPE.PERSONAL_SIGN,
   },
-  fromAccount: MOCK_PRIMARY_IDENTITY,
 };
 
 export const ETHSignStory = Template.bind({});
@@ -92,5 +101,4 @@ ETHSignStory.args = {
     msgParams: { ...MOCK_TX_MSG_PARAMS },
     type: MESSAGE_TYPE.ETH_SIGN,
   },
-  fromAccount: MOCK_PRIMARY_IDENTITY,
 };

--- a/ui/components/app/signature-request-original/signature-request-original.stories.js
+++ b/ui/components/app/signature-request-original/signature-request-original.stories.js
@@ -5,7 +5,7 @@ import testData from '../../../../.storybook/test-data';
 import README from './README.mdx';
 import SignatureRequestOriginal from './signature-request-original.component';
 
-const MOCK_PRIMARY_IDENTITY = Object.values(testData.metamask.identities)[0];
+const [MOCK_PRIMARY_IDENTITY] = Object.values(testData.metamask.identities);
 
 const MOCK_SIGN_DATA = JSON.stringify({
   domain: {

--- a/ui/components/app/signature-request-original/signature-request-original.stories.js
+++ b/ui/components/app/signature-request-original/signature-request-original.stories.js
@@ -1,0 +1,96 @@
+import React from 'react';
+import { MESSAGE_TYPE } from '../../../../shared/constants/app';
+import testData from '../../../../.storybook/test-data';
+import README from './README.mdx';
+import SignatureRequestOriginal from './signature-request-original.component';
+
+const MOCK_PRIMARY_IDENTITY = Object.values(testData.metamask.identities)[0];
+
+const MOCK_TX_MSG_PARAMS = {
+  data: JSON.stringify({
+    domain: {
+      name: 'happydapp.website',
+    },
+    message: {
+      string: 'haay wuurl',
+      number: 42,
+    },
+    primaryType: 'Mail',
+    types: {
+      EIP712Domain: [
+        { name: 'name', type: 'string' },
+        { name: 'version', type: 'string' },
+        { name: 'chainId', type: 'uint256' },
+        { name: 'verifyingContract', type: 'address' },
+      ],
+      Group: [
+        { name: 'name', type: 'string' },
+        { name: 'members', type: 'Person[]' },
+      ],
+      Mail: [
+        { name: 'from', type: 'Person' },
+        { name: 'to', type: 'Person[]' },
+        { name: 'contents', type: 'string' },
+      ],
+      Person: [
+        { name: 'name', type: 'string' },
+        { name: 'wallets', type: 'address[]' },
+      ],
+    },
+  }),
+  origin: 'https://happydapp.website/governance?futarchy=true',
+};
+
+export default {
+  title: 'Components/App/SignatureRequestOriginal',
+  id: __filename,
+  component: SignatureRequestOriginal,
+  parameters: {
+    docs: {
+      page: README,
+    },
+  },
+  argTypes: {
+    txData: { control: 'object' },
+    fromAccount: {
+      table: {
+        address: { control: 'text' },
+        balance: { control: 'text' },
+        name: { control: 'text' },
+      },
+    },
+    hardwareWalletRequiresConnection: { control: 'boolean' },
+    isLedgerWallet: { control: 'boolean' },
+    clearConfirmTransaction: { action: 'Clean Confirm' },
+    cancel: { action: 'Cancel' },
+    sign: { action: 'Sign' },
+  },
+};
+
+export const DefaultStory = (args) => {
+  return <SignatureRequestOriginal {...args} />;
+};
+
+DefaultStory.storyName = 'personal_sign Type';
+
+DefaultStory.args = {
+  txData: {
+    msgParams: { ...MOCK_TX_MSG_PARAMS },
+    type: MESSAGE_TYPE.PERSONAL_SIGN,
+  },
+  fromAccount: MOCK_PRIMARY_IDENTITY,
+};
+
+export const ETHSignStory = (args) => {
+  return <SignatureRequestOriginal {...args} />;
+};
+
+ETHSignStory.storyName = 'eth_sign Type';
+
+ETHSignStory.args = {
+  txData: {
+    msgParams: { ...MOCK_TX_MSG_PARAMS },
+    type: MESSAGE_TYPE.ETH_SIGN,
+  },
+  fromAccount: MOCK_PRIMARY_IDENTITY,
+};

--- a/ui/components/app/signature-request-original/signature-request-original.stories.js
+++ b/ui/components/app/signature-request-original/signature-request-original.stories.js
@@ -7,40 +7,37 @@ import SignatureRequestOriginal from './signature-request-original.component';
 
 const MOCK_PRIMARY_IDENTITY = Object.values(testData.metamask.identities)[0];
 
-const MOCK_TX_MSG_PARAMS = {
-  data: JSON.stringify({
-    domain: {
-      name: 'happydapp.website',
-    },
-    message: {
-      string: 'haay wuurl',
-      number: 42,
-    },
-    primaryType: 'Mail',
-    types: {
-      EIP712Domain: [
-        { name: 'name', type: 'string' },
-        { name: 'version', type: 'string' },
-        { name: 'chainId', type: 'uint256' },
-        { name: 'verifyingContract', type: 'address' },
-      ],
-      Group: [
-        { name: 'name', type: 'string' },
-        { name: 'members', type: 'Person[]' },
-      ],
-      Mail: [
-        { name: 'from', type: 'Person' },
-        { name: 'to', type: 'Person[]' },
-        { name: 'contents', type: 'string' },
-      ],
-      Person: [
-        { name: 'name', type: 'string' },
-        { name: 'wallets', type: 'address[]' },
-      ],
-    },
-  }),
-  origin: 'https://happydapp.website/governance?futarchy=true',
-};
+const MOCK_SIGN_DATA = JSON.stringify({
+  domain: {
+    name: 'happydapp.website',
+  },
+  message: {
+    string: 'haay wuurl',
+    number: 42,
+  },
+  primaryType: 'Mail',
+  types: {
+    EIP712Domain: [
+      { name: 'name', type: 'string' },
+      { name: 'version', type: 'string' },
+      { name: 'chainId', type: 'uint256' },
+      { name: 'verifyingContract', type: 'address' },
+    ],
+    Group: [
+      { name: 'name', type: 'string' },
+      { name: 'members', type: 'Person[]' },
+    ],
+    Mail: [
+      { name: 'from', type: 'Person' },
+      { name: 'to', type: 'Person[]' },
+      { name: 'contents', type: 'string' },
+    ],
+    Person: [
+      { name: 'name', type: 'string' },
+      { name: 'wallets', type: 'address[]' },
+    ],
+  },
+});
 
 export default {
   title: 'Components/App/SignatureRequestOriginal',
@@ -87,7 +84,10 @@ DefaultStory.storyName = 'personal_sign Type';
 
 DefaultStory.args = {
   txData: {
-    msgParams: { ...MOCK_TX_MSG_PARAMS },
+    msgParams: {
+      data: MOCK_SIGN_DATA,
+      origin: 'https://happydapp.website/governance?futarchy=true',
+    },
     type: MESSAGE_TYPE.PERSONAL_SIGN,
   },
 };
@@ -98,7 +98,35 @@ ETHSignStory.storyName = 'eth_sign Type';
 
 ETHSignStory.args = {
   txData: {
-    msgParams: { ...MOCK_TX_MSG_PARAMS },
+    msgParams: {
+      data: MOCK_SIGN_DATA,
+      origin: 'https://happydapp.website/governance?futarchy=true',
+    },
     type: MESSAGE_TYPE.ETH_SIGN,
+  },
+};
+
+export const ETHSignTypedStory = Template.bind({});
+
+ETHSignTypedStory.storyName = 'eth_signTypedData Type';
+
+ETHSignTypedStory.args = {
+  txData: {
+    msgParams: {
+      data: [
+        {
+          type: 'string',
+          name: 'Message',
+          value: 'Hi, Alice!',
+        },
+        {
+          type: 'uint32',
+          name: 'A number',
+          value: '1337',
+        },
+      ],
+      origin: 'https://happydapp.website/governance?futarchy=true',
+    },
+    type: MESSAGE_TYPE.ETH_SIGN_TYPED_DATA,
   },
 };

--- a/ui/components/app/signature-request-original/signature-request-original.stories.js
+++ b/ui/components/app/signature-request-original/signature-request-original.stories.js
@@ -67,9 +67,11 @@ export default {
   },
 };
 
-export const DefaultStory = (args) => {
+const Template = (args) => {
   return <SignatureRequestOriginal {...args} />;
 };
+
+export const DefaultStory = Template.bind({});
 
 DefaultStory.storyName = 'personal_sign Type';
 
@@ -81,9 +83,7 @@ DefaultStory.args = {
   fromAccount: MOCK_PRIMARY_IDENTITY,
 };
 
-export const ETHSignStory = (args) => {
-  return <SignatureRequestOriginal {...args} />;
-};
+export const ETHSignStory = Template.bind({});
 
 ETHSignStory.storyName = 'eth_sign Type';
 


### PR DESCRIPTION
## Explanation

Adding a storybook page for the SignatureRequestOriginal component. This component appears when a user attempts to signTypedData transaction where the Signed Typed Data is neither v3 nor v4.

The logic mostly mirrors the storybook page for the SignatureRequest component.

## More information

Sibling PR: https://github.com/MetaMask/metamask-extension/pull/14706

## Screenshots/Screencaps
<img width="1060" alt="Screenshot 2022-05-13 at 8 04 23 PM" src="https://user-images.githubusercontent.com/20778143/168405171-2f9f2d80-3818-446f-9d95-4843cbb68c5b.png">

<img width="1056" alt="Screenshot 2022-05-13 at 8 04 30 PM" src="https://user-images.githubusercontent.com/20778143/168405173-4b284d99-8790-419a-8d88-654886246bde.png">

<img width="922" alt="Screenshot 2022-05-13 at 9 30 40 PM" src="https://user-images.githubusercontent.com/20778143/168407611-046aa2ba-b377-4772-8260-540f59f4e63b.png">
