### PR TITLE
Ensure transaction type is correctly updated on edit

### DIFF
--- a/app/scripts/controllers/transactions/index.js
+++ b/app/scripts/controllers/transactions/index.js
@@ -445,7 +445,7 @@ export default class TransactionController extends EventEmitter {
    * @param {string} editableParams.gasPrice
    * @returns {TransactionMeta} the txMeta of the updated transaction
    */
-  updateEditableParams(txId, { data, from, to, value, gas, gasPrice }) {
+  async updateEditableParams(txId, { data, from, to, value, gas, gasPrice }) {
     this._throwErrorIfNotUnapprovedTx(txId, 'updateEditableParams');
 
     const editableParams = {
@@ -461,6 +461,14 @@ export default class TransactionController extends EventEmitter {
 
     // only update what is defined
     editableParams.txParams = pickBy(editableParams.txParams);
+
+    // update transaction type in case it has changes
+    const { type } = await determineTransactionType(
+      editableParams.txParams,
+      this.query,
+    );
+    editableParams.type = type;
+
     const note = `Update Editable Params for ${txId}`;
     this._updateTransaction(txId, editableParams, note);
     return this._getTransaction(txId);

--- a/app/scripts/controllers/transactions/index.js
+++ b/app/scripts/controllers/transactions/index.js
@@ -463,13 +463,18 @@ export default class TransactionController extends EventEmitter {
     editableParams.txParams = pickBy(editableParams.txParams);
 
     // update transaction type in case it has changes
+    const transactionBeforeEdit = this._getTransaction(txId);
     const { type } = await determineTransactionType(
-      editableParams.txParams,
+      {
+        ...transactionBeforeEdit.txParams,
+        ...editableParams.txParams,
+      },
       this.query,
     );
     editableParams.type = type;
 
     const note = `Update Editable Params for ${txId}`;
+
     this._updateTransaction(txId, editableParams, note);
     return this._getTransaction(txId);
   }

--- a/app/scripts/controllers/transactions/index.test.js
+++ b/app/scripts/controllers/transactions/index.test.js
@@ -2256,7 +2256,7 @@ describe('Transaction Controller', function () {
         status: TRANSACTION_STATUSES.UNAPPROVED,
         metamaskNetworkId: currentNetworkId,
         txParams: {
-          gasLimit: '0x001',
+          gas: '0x001',
           gasPrice: '0x002',
           // max fees can not be mixed with gasPrice
           // maxPriorityFeePerGas: '0x003',
@@ -2273,7 +2273,7 @@ describe('Transaction Controller', function () {
       });
     });
 
-    it('updates editible params when type changes', async function () {
+    it('updates editible params when type changes from simple send to token transfer', async function () {
       // test update gasFees
       await txController.updateEditableParams('1', {
         data:
@@ -2287,15 +2287,82 @@ describe('Transaction Controller', function () {
       assert.equal(result.type, TRANSACTION_TYPES.TOKEN_METHOD_TRANSFER);
     });
 
+    it('updates editible params when type changes from token transfer to simple send', async function () {
+      // test update gasFees
+      txStateManager.addTransaction({
+        id: '2',
+        status: TRANSACTION_STATUSES.UNAPPROVED,
+        metamaskNetworkId: currentNetworkId,
+        txParams: {
+          gas: '0x001',
+          gasPrice: '0x002',
+          // max fees can not be mixed with gasPrice
+          // maxPriorityFeePerGas: '0x003',
+          // maxFeePerGas: '0x004',
+          to: VALID_ADDRESS,
+          from: VALID_ADDRESS,
+          data:
+            '0xa9059cbb000000000000000000000000e18035bf8712672935fdb4e5e431b1a0183d2dfc0000000000000000000000000000000000000000000000000de0b6b3a7640000',
+        },
+        estimateUsed: '0x005',
+        estimatedBaseFee: '0x006',
+        decEstimatedBaseFee: '6',
+        type: TRANSACTION_TYPES.TOKEN_METHOD_TRANSFER,
+        userEditedGasLimit: '0x008',
+        userFeeLevel: 'medium',
+      });
+      await txController.updateEditableParams('2', {
+        data: '0x',
+      });
+      const result = txStateManager.getTransaction('2');
+      assert.equal(result.txParams.data, '0x');
+      assert.equal(result.type, TRANSACTION_TYPES.SIMPLE_SEND);
+    });
+
+    it('updates editible params when type changes from simpleSend to contract interaction', async function () {
+      // test update gasFees
+      txStateManager.addTransaction({
+        id: '3',
+        status: TRANSACTION_STATUSES.UNAPPROVED,
+        metamaskNetworkId: currentNetworkId,
+        txParams: {
+          gas: '0x001',
+          gasPrice: '0x002',
+          // max fees can not be mixed with gasPrice
+          // maxPriorityFeePerGas: '0x003',
+          // maxFeePerGas: '0x004',
+          to: VALID_ADDRESS,
+          from: VALID_ADDRESS,
+        },
+        estimateUsed: '0x005',
+        estimatedBaseFee: '0x006',
+        decEstimatedBaseFee: '6',
+        type: TRANSACTION_TYPES.TOKEN_METHOD_TRANSFER,
+        userEditedGasLimit: '0x008',
+        userFeeLevel: 'medium',
+      });
+      providerResultStub.eth_getCode = '0x5';
+      await txController.updateEditableParams('3', {
+        data: '0x123',
+      });
+      const result = txStateManager.getTransaction('3');
+      assert.equal(result.txParams.data, '0x123');
+      assert.equal(result.type, TRANSACTION_TYPES.CONTRACT_INTERACTION);
+    });
+
     it('updates editible params when type does not change', async function () {
       // test update gasFees
       await txController.updateEditableParams('1', {
         data: '0x123',
-        gasLimit: '0xabc',
+        gas: '0xabc',
+        from: VALID_ADDRESS_TWO,
       });
       const result = txStateManager.getTransaction('1');
       assert.equal(result.txParams.data, '0x123');
-      assert.equal(result.txParams.gasLimit, '0xabc');
+      assert.equal(result.txParams.gas, '0xabc');
+      assert.equal(result.txParams.from, VALID_ADDRESS_TWO);
+      assert.equal(result.txParams.to, VALID_ADDRESS);
+      assert.equal(result.txParams.gasPrice, '0x002');
       assert.equal(result.type, TRANSACTION_TYPES.SIMPLE_SEND);
     });
   });

--- a/app/scripts/controllers/transactions/index.test.js
+++ b/app/scripts/controllers/transactions/index.test.js
@@ -2273,9 +2273,9 @@ describe('Transaction Controller', function () {
       });
     });
 
-    it('updates editible params when type changes', function () {
+    it('updates editible params when type changes', async function () {
       // test update gasFees
-      txController.updateEditableParams('1', {
+      await txController.updateEditableParams('1', {
         data:
           '0xa9059cbb000000000000000000000000e18035bf8712672935fdb4e5e431b1a0183d2dfc0000000000000000000000000000000000000000000000000de0b6b3a7640000',
       });
@@ -2287,9 +2287,9 @@ describe('Transaction Controller', function () {
       assert.equal(result.type, TRANSACTION_TYPES.TOKEN_METHOD_TRANSFER);
     });
 
-    it('updates editible params when type does not change', function () {
+    it('updates editible params when type does not change', async function () {
       // test update gasFees
-      txController.updateEditableParams('1', {
+      await txController.updateEditableParams('1', {
         data: '0x123',
         gasLimit: '0xabc',
       });

--- a/app/scripts/controllers/transactions/index.test.js
+++ b/app/scripts/controllers/transactions/index.test.js
@@ -2245,4 +2245,58 @@ describe('Transaction Controller', function () {
       assert.equal(result.destinationTokenAddress, VALID_ADDRESS_TWO); // not updated even though it's passed in to update
     });
   });
+
+  describe('updateEditableParams', function () {
+    let txStateManager;
+
+    beforeEach(function () {
+      txStateManager = txController.txStateManager;
+      txStateManager.addTransaction({
+        id: '1',
+        status: TRANSACTION_STATUSES.UNAPPROVED,
+        metamaskNetworkId: currentNetworkId,
+        txParams: {
+          gasLimit: '0x001',
+          gasPrice: '0x002',
+          // max fees can not be mixed with gasPrice
+          // maxPriorityFeePerGas: '0x003',
+          // maxFeePerGas: '0x004',
+          to: VALID_ADDRESS,
+          from: VALID_ADDRESS,
+        },
+        estimateUsed: '0x005',
+        estimatedBaseFee: '0x006',
+        decEstimatedBaseFee: '6',
+        type: 'simpleSend',
+        userEditedGasLimit: '0x008',
+        userFeeLevel: 'medium',
+      });
+    });
+
+    it('updates editible params when type changes', function () {
+      // test update gasFees
+      txController.updateEditableParams('1', {
+        data:
+          '0xa9059cbb000000000000000000000000e18035bf8712672935fdb4e5e431b1a0183d2dfc0000000000000000000000000000000000000000000000000de0b6b3a7640000',
+      });
+      const result = txStateManager.getTransaction('1');
+      assert.equal(
+        result.txParams.data,
+        '0xa9059cbb000000000000000000000000e18035bf8712672935fdb4e5e431b1a0183d2dfc0000000000000000000000000000000000000000000000000de0b6b3a7640000',
+      );
+      assert.equal(result.type, TRANSACTION_TYPES.TOKEN_METHOD_TRANSFER);
+    });
+
+    it('updates editible params when type does not change', function () {
+      // test update gasFees
+      txController.updateEditableParams('1', {
+        data: '0x123',
+        gasLimit: '0xabc',
+      });
+      const result = txStateManager.getTransaction('1');
+      assert.equal(result.txParams.data, '0x123');
+      assert.equal(result.txParams.data, '0xabc');
+      assert.equal(result.type, TRANSACTION_TYPES.SIMPLE_SEND);
+    });
+  });
 });

--- a/app/scripts/controllers/transactions/index.test.js
+++ b/app/scripts/controllers/transactions/index.test.js
@@ -2295,7 +2295,7 @@ describe('Transaction Controller', function () {
       });
       const result = txStateManager.getTransaction('1');
       assert.equal(result.txParams.data, '0x123');
-      assert.equal(result.txParams.data, '0xabc');
+      assert.equal(result.txParams.gasLimit, '0xabc');
       assert.equal(result.type, TRANSACTION_TYPES.SIMPLE_SEND);
     });
   });

--- a/ui/ducks/send/send.js
+++ b/ui/ducks/send/send.js
@@ -1824,6 +1824,8 @@ export function signTransaction() {
           eip1559support ? eip1559OnlyTxParamsToUpdate : txParams,
         ),
       };
+      const { type } = await getTransactionType(editingTx.txParams);
+      editingTx.type = type;
       await dispatch(
         addHistoryEntry(
           `sendFlow - user clicked next and transaction should be updated in controller`,

--- a/ui/ducks/send/send.js
+++ b/ui/ducks/send/send.js
@@ -1824,8 +1824,7 @@ export function signTransaction() {
           eip1559support ? eip1559OnlyTxParamsToUpdate : txParams,
         ),
       };
-      const { type } = await getTransactionType(editingTx.txParams);
-      editingTx.type = type;
+
       await dispatch(
         addHistoryEntry(
           `sendFlow - user clicked next and transaction should be updated in controller`,


### PR DESCRIPTION
This PR corrects the following bug, reported by support:

1. Press send.
2. Pick address from address book (or transfer between accounts), likely any address
3. Enter amount and Press next
4. Press edit
5. Change token
6. Enter amount and press next
7. Press edit again. The coin you selected is not selected anymore. Destination address will have changed to the TOKEN CONTRACT address of the second token you selected.

Replaces https://github.com/MetaMask/metamask-extension/pull/13328

Explanation:

Prior to this PR, changing the asset on the send screen during the edit flow would not result in a change of transaction type on txMeta, if that was appropriate. This would cause the transaction data to be incorrectly read in both the send duck and in the confirmation components. This PR ensures that the transaction type data is properly updated.