### PR TITLE
Add hideEstimatedGasFee prop to sort-list and select-quote-popover tests

### DIFF
--- a/ui/pages/swaps/select-quote-popover/select-quote-popover.test.js
+++ b/ui/pages/swaps/select-quote-popover/select-quote-popover.test.js
@@ -10,6 +10,7 @@ const createProps = (customProps = {}) => {
     swapToSymbol: 'ETH',
     initialAggId: 'initialAggId',
     onQuoteDetailsIsOpened: jest.fn(),
+    hideEstimatedGasFee: false,
     ...customProps,
   };
 };

--- a/ui/pages/swaps/select-quote-popover/sort-list/sort-list.test.js
+++ b/ui/pages/swaps/select-quote-popover/sort-list/sort-list.test.js
@@ -10,6 +10,7 @@ jest.mock(
 
 const createProps = (customProps = {}) => {
   return {
+    hideEstimatedGasFee: false,
     selectedAggId: 'Agg2',
     onSelect: jest.fn(),
     onCaretClick: jest.fn(),


### PR DESCRIPTION
Add the hideEstimatedGasFee prop to `select-quote-popover.test.js` and `sort-list.test.js` to remove the react prop warning in those tests.