### PR TITLE
Use enum for test snaps website URL

### DIFF
--- a/test/e2e/snaps/enums.js
+++ b/test/e2e/snaps/enums.js
@@ -1,0 +1,3 @@
+module.exports = {
+  TEST_SNAPS_WEBSITE_URL: 'https://metamask.github.io/test-snaps/0.2.0',
+};

--- a/test/e2e/snaps/test-snap-bip-44.spec.js
+++ b/test/e2e/snaps/test-snap-bip-44.spec.js
@@ -1,5 +1,6 @@
 const { strict: assert } = require('assert');
 const { withFixtures } = require('../helpers');
+const { TEST_SNAPS_WEBSITE_URL } = require('./enums');
 
 describe('Test Snap bip-44', function () {
   it('can pop up bip-44 snap and get private key result', async function () {
@@ -29,7 +30,7 @@ describe('Test Snap bip-44', function () {
         await driver.press('#password', driver.Key.ENTER);
 
         // navigate to test snaps page and connect
-        await driver.driver.get('https://metamask.github.io/test-snaps/0.1.3/');
+        await driver.driver.get(TEST_SNAPS_WEBSITE_URL);
         await driver.fill('.snapId3', 'npm:@metamask/test-snap-bip44');
         await driver.clickElement({
           text: 'Connect BIP-44 Snap',

--- a/test/e2e/snaps/test-snap-confirm.spec.js
+++ b/test/e2e/snaps/test-snap-confirm.spec.js
@@ -31,7 +31,7 @@ describe('Test Snap Confirm', function () {
 
         // navigate to test snaps page and connect
         await driver.driver.get(TEST_SNAPS_WEBSITE_URL);
-        await driver.fill('.snapId', 'npm:@metamask/test-snap-confirm');
+        await driver.fill('.snapId1', 'npm:@metamask/test-snap-confirm');
         await driver.clickElement({
           text: 'Connect To Confirm Snap',
           tag: 'button',
@@ -70,10 +70,7 @@ describe('Test Snap Confirm', function () {
         await driver.waitUntilXWindowHandles(1, 5000, 10000);
         windowHandles = await driver.getAllWindowHandles();
         await driver.switchToWindowWithTitle('Test Snaps', windowHandles);
-        await driver.clickElement({
-          text: 'Send Inputs to Hello Snap',
-          tag: 'button',
-        });
+        await driver.clickElement('.sendConfirmButton');
 
         // hit 'approve' on the custom confirm
         await driver.waitUntilXWindowHandles(2, 5000, 10000);
@@ -91,7 +88,7 @@ describe('Test Snap Confirm', function () {
         await driver.waitUntilXWindowHandles(1, 5000, 10000);
         windowHandles = await driver.getAllWindowHandles();
         await driver.switchToWindowWithTitle('Test Snaps', windowHandles);
-        const confirmResult = await driver.findElement('.sendResults');
+        const confirmResult = await driver.findElement('.confirmResult');
         assert.equal(await confirmResult.getText(), 'true');
       },
     );

--- a/test/e2e/snaps/test-snap-confirm.spec.js
+++ b/test/e2e/snaps/test-snap-confirm.spec.js
@@ -1,5 +1,6 @@
 const { strict: assert } = require('assert');
 const { withFixtures } = require('../helpers');
+const { TEST_SNAPS_WEBSITE_URL } = require('./enums');
 
 describe('Test Snap Confirm', function () {
   it('can pop up a snap confirm and get its result', async function () {
@@ -29,7 +30,7 @@ describe('Test Snap Confirm', function () {
         await driver.press('#password', driver.Key.ENTER);
 
         // navigate to test snaps page and connect
-        await driver.driver.get('https://metamask.github.io/test-snaps/');
+        await driver.driver.get(TEST_SNAPS_WEBSITE_URL);
         await driver.fill('.snapId', 'npm:@metamask/test-snap-confirm');
         await driver.clickElement({
           text: 'Connect To Confirm Snap',

--- a/test/e2e/snaps/test-snap-error.spec.js
+++ b/test/e2e/snaps/test-snap-error.spec.js
@@ -1,6 +1,7 @@
 const { strict: assert } = require('assert');
 const { withFixtures } = require('../helpers');
 const { PAGES } = require('../webdriver/driver');
+const { TEST_SNAPS_WEBSITE_URL } = require('./enums');
 
 describe('Test Snap Error', function () {
   it('can pop up a snap error and see the error', async function () {
@@ -28,7 +29,7 @@ describe('Test Snap Error', function () {
         await driver.press('#password', driver.Key.ENTER);
 
         // navigate to test snaps page and connect
-        await driver.driver.get('https://metamask.github.io/test-snaps/');
+        await driver.driver.get(TEST_SNAPS_WEBSITE_URL);
         await driver.fill('.snapId2', 'npm:@metamask/test-snap-error');
         await driver.clickElement({
           text: 'Connect Error Snap',

--- a/test/e2e/snaps/test-snap-managestate.spec.js
+++ b/test/e2e/snaps/test-snap-managestate.spec.js
@@ -1,5 +1,6 @@
 const { strict: assert } = require('assert');
 const { withFixtures } = require('../helpers');
+const { TEST_SNAPS_WEBSITE_URL } = require('./enums');
 
 describe('Test Snap manageState', function () {
   it('can pop up manageState snap and do update get and clear', async function () {
@@ -29,7 +30,7 @@ describe('Test Snap manageState', function () {
         await driver.press('#password', driver.Key.ENTER);
 
         // navigate to test snaps page and connect
-        await driver.driver.get('https://metamask.github.io/test-snaps/0.2.0/');
+        await driver.driver.get(TEST_SNAPS_WEBSITE_URL);
         await driver.fill('.snapId3', 'npm:@metamask/test-snap-managestate');
         await driver.clickElement({
           text: 'Connect manageState Snap',


### PR DESCRIPTION
This PR establishes an enum which contains the URL of the test snap website which will work with the current state of the extension. Whenever we want to increase this version, we will simply increment the version in this enum.

The "confirm" snap test was targeting an outdated version of the website, and some selectors were updated to make it compatible.