### PR TITLE
NetworksTab: make footer buttons nowrap

### DIFF
--- a/ui/pages/settings/networks-tab/index.scss
+++ b/ui/pages/settings/networks-tab/index.scss
@@ -297,6 +297,10 @@
       width: 93%;
     }
 
+    .btn--rounded {
+      white-space: nowrap;
+    }
+
     .btn-secondary {
       margin-right: 0.375rem;
     }


### PR DESCRIPTION
## Explanation

Currently, in certain languages, the network tab's footer buttons will render with line breaks. Other languages will render without line breaks while overflowing from the network form width and causing a scrollbar to appear. Based on this existing behavior, I think an acceptable fix would be to add `whitespace: nowrap;` to the buttons.

## More Information

Reported by @ForestTigerKing here: https://github.com/MetaMask/metamask-extension/pull/13781

## Screenshots/Screencaps

### Before

<img width="651" alt="Screenshot 2022-05-17 at 2 49 18 PM" src="https://user-images.githubusercontent.com/20778143/168905599-acf71d6e-fbad-4eee-826e-7b4ad02e8823.png">
<img width="651" alt="Screenshot 2022-05-17 at 3 15 45 PM" src="https://user-images.githubusercontent.com/20778143/168905602-82b5f762-5ff1-42cc-8f4c-7c0d9c55ad2a.png">
<img width="651" alt="Screenshot 2022-05-17 at 3 15 45 PM" src="https://user-images.githubusercontent.com/20778143/168906350-0fe9627c-d183-4004-b7b7-5581975ca3f0.png">
<img width="651" alt="Screenshot 2022-05-17 at 3 15 45 PM" src="https://user-images.githubusercontent.com/20778143/168906402-8316e121-f8e7-4231-934d-d8947edeca00.png">


### After

<img width="651" alt="Screenshot 2022-05-17 at 2 49 18 PM" src="https://user-images.githubusercontent.com/20778143/168905599-acf71d6e-fbad-4eee-826e-7b4ad02e8823.png">
<img width="651" alt="Screenshot 2022-05-17 at 3 17 34 PM" src="https://user-images.githubusercontent.com/20778143/168905650-1219fa07-2726-409e-88de-f7edd9601f3b.png">
<img width="651" alt="Screenshot 2022-05-17 at 3 31 10 PM" src="https://user-images.githubusercontent.com/20778143/168905654-7e86f4b1-209c-450e-8632-8382a0d24946.png">
<img width="651" alt="Screenshot 2022-05-17 at 3 31 30 PM" src="https://user-images.githubusercontent.com/20778143/168905655-6b07351e-977d-4860-8941-27cd95aa1fee.png">


## Manual Testing Steps

- Through Settings, add a custom network
- Go to Networks 
- Edit the custom network
- To see the "Delete" button, connect to a network that is not the network you are attempting to edit
- Observe form footer buttons

## Pre-Merge Checklist

- [x] PR template is filled out
- [x] Manual testing complete & passed
- [x] **IF** this PR fixes a bug, a test that _would have_ caught the bug has been added
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** QA attention is required, "QA Board" label has been applied
- [ ] PR has been added to the appropriate release Milestone
