### PR TITLE
Sign button is enabled after scrolling all the way to the bottom

### DIFF
--- a/ui/components/app/signature-request/index.scss
+++ b/ui/components/app/signature-request/index.scss
@@ -87,6 +87,3 @@
   .identicon {}
 }
 
-.signature-request-footer {
-  flex: 1 1 auto;
-}

--- a/ui/components/app/signature-request/signature-request-footer/signature-request-footer.component.js
+++ b/ui/components/app/signature-request/signature-request-footer/signature-request-footer.component.js
@@ -17,10 +17,10 @@ export default class SignatureRequestFooter extends PureComponent {
     const { cancelAction, signAction, disabled = false } = this.props;
     return (
       <div className="signature-request-footer">
-        <Button onClick={cancelAction} type="secondary" large>
+        <Button onClick={cancelAction} type="secondary">
           {this.context.t('cancel')}
         </Button>
-        <Button onClick={signAction} type="primary" disabled={disabled} large>
+        <Button onClick={signAction} type="primary" disabled={disabled}>
           {this.context.t('sign')}
         </Button>
       </div>

--- a/ui/components/app/signature-request/signature-request-message/index.scss
+++ b/ui/components/app/signature-request/signature-request-message/index.scss
@@ -1,7 +1,7 @@
 .signature-request-message {
   flex: 1 60%;
   display: flex;
-  max-height: 230px;
+  max-height: 231px;
   flex-direction: column;
   position: relative;
 

--- a/ui/components/app/signature-request/signature-request-message/signature-request-message.component.js
+++ b/ui/components/app/signature-request/signature-request-message/signature-request-message.component.js
@@ -26,12 +26,12 @@ export default class SignatureRequestMessage extends PureComponent {
     }
 
     const { scrollTop, offsetHeight, scrollHeight } = this.props.messageRootRef;
+    const canScroll = scrollHeight > offsetHeight;
     const isAtBottom = scrollTop + offsetHeight >= scrollHeight;
+    const messageIsScrolled = canScroll && !isAtBottom;
 
-    if (isAtBottom) {
-      this.setState({ messageIsScrolled: true });
-      this.props.onMessageScrolled();
-    }
+    this.setState({ messageIsScrolled });
+    this.props.onMessageScrolled();
   };
 
   onScroll = debounce(this.setMessageIsScrolled, 25);

--- a/ui/components/app/signature-request/signature-request-message/signature-request-message.component.js
+++ b/ui/components/app/signature-request/signature-request-message/signature-request-message.component.js
@@ -26,12 +26,12 @@ export default class SignatureRequestMessage extends PureComponent {
     }
 
     const { scrollTop, offsetHeight, scrollHeight } = this.props.messageRootRef;
-    const canScroll = scrollHeight > offsetHeight;
-    const isAtBottom = scrollTop + offsetHeight >= scrollHeight;
-    const messageIsScrolled = canScroll && !isAtBottom;
+    const isAtBottom = Math.round(scrollTop) + offsetHeight >= scrollHeight;
 
-    this.setState({ messageIsScrolled });
-    this.props.onMessageScrolled();
+    if (isAtBottom) {
+      this.setState({ messageIsScrolled: true });
+      this.props.onMessageScrolled();
+    }
   };
 
   onScroll = debounce(this.setMessageIsScrolled, 25);


### PR DESCRIPTION
## Explanation

This fix represents when the scroll hits the bottom of the module window or hits the down arrow icon to get there, the `sign` button is enabled.

## More Information

* Fixes #14666

## Screenshots/Screencaps

### Before

#### Larger screen (monitor)

https://user-images.githubusercontent.com/92527393/169318812-999c8964-c0f2-4885-b380-1b222d968d9e.mov

#### Small screen (laptop)

https://user-images.githubusercontent.com/92527393/169319395-5fcbd32c-3d99-4bc0-ac92-0d4954a17ab4.mov

### After

#### Larger screen (monitor)

https://user-images.githubusercontent.com/92527393/169320519-91444d06-f46a-4e6f-a00e-e194e88161d6.mov

## Manual Testing Steps

1. Open chrome and go to: https://metamask.github.io/test-dapp/
2. Click on `Connect` and connect your wallet to the `test-dapp`
3. Click on `Sign` under `Sign Typed Data V4`
4. Notice how the `Sign` button on MM pop up is disabled
5. After scrolling all the way to the bottom of the pop up notice how the `Sign` button is now enabled
6. Click on the arrow symbol and notice how the `Sign` button is now enabled


