### PR TITLE
Remove site origin on snap install

### DIFF
--- a/ui/components/app/flask/snaps-authorship-pill/snaps-authorship-pill.js
+++ b/ui/components/app/flask/snaps-authorship-pill/snaps-authorship-pill.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
-import { getSnapPrefix } from '@metamask/snap-controllers';
 import Chip from '../../../ui/chip';
 import Box from '../../../ui/box';
 import Typography from '../../../ui/typography';
@@ -10,8 +9,11 @@ import {
   TYPOGRAPHY,
 } from '../../../../helpers/constants/design-system';
 
+const snapIdPrefixes = ['npm:', 'local:'];
+
 const SnapsAuthorshipPill = ({ snapId, className }) => {
-  const snapPrefix = getSnapPrefix(snapId);
+  // @todo Use getSnapPrefix from snaps-skunkworks when possible
+  const snapPrefix = snapIdPrefixes.find((prefix) => snapId.startsWith(prefix));
   const packageName = snapId.replace(snapPrefix, '');
   const isNPM = snapPrefix === 'npm:';
   const url = isNPM

--- a/ui/components/app/flask/snaps-authorship-pill/snaps-authorship-pill.js
+++ b/ui/components/app/flask/snaps-authorship-pill/snaps-authorship-pill.js
@@ -17,7 +17,7 @@ const SnapsAuthorshipPill = ({ snapId, className }) => {
   const url = isNPM
     ? `https://www.npmjs.com/package/${packageName}`
     : packageName;
-  const icon = isNPM ? 'fab fa-npm' : 'fas fa-desktop';
+  const icon = isNPM ? 'fab fa-npm fa-lg' : 'fas fa-code';
   return (
     <a
       href={url}
@@ -28,7 +28,7 @@ const SnapsAuthorshipPill = ({ snapId, className }) => {
       <Chip
         leftIcon={
           <Box paddingLeft={2}>
-            <i className={`${icon} fa-lg snaps-authorship-icon`} />
+            <i className={`${icon} snaps-authorship-icon`} />
           </Box>
         }
         backgroundColor={COLORS.BACKGROUND_DEFAULT}

--- a/ui/components/app/flask/snaps-authorship-pill/snaps-authorship-pill.js
+++ b/ui/components/app/flask/snaps-authorship-pill/snaps-authorship-pill.js
@@ -8,8 +8,14 @@ import {
   COLORS,
   TYPOGRAPHY,
 } from '../../../../helpers/constants/design-system';
+import { getSnapPrefix } from '@metamask/snap-controllers';
 
-const SnapsAuthorshipPill = ({ packageName, className, url }) => {
+const SnapsAuthorshipPill = ({ snapId, className }) => {
+  const snapPrefix = getSnapPrefix(snapId);
+  const packageName = snapId.replace(snapPrefix, "");
+  const isNPM = snapPrefix === 'npm:';
+  const url = isNPM ? `https://www.npmjs.com/package/${packageName}` : packageName;
+  const icon = isNPM ? 'fab fa-npm' : 'fas fa-desktop';
   return (
     <a
       href={url}
@@ -20,7 +26,7 @@ const SnapsAuthorshipPill = ({ packageName, className, url }) => {
       <Chip
         leftIcon={
           <Box paddingLeft={2}>
-            <i className="fab fa-npm fa-lg snaps-authorship-icon" />
+            <i className={`${icon} fa-lg snaps-authorship-icon`} />
           </Box>
         }
         backgroundColor={COLORS.BACKGROUND_DEFAULT}
@@ -40,17 +46,13 @@ const SnapsAuthorshipPill = ({ packageName, className, url }) => {
 
 SnapsAuthorshipPill.propTypes = {
   /**
-   * NPM package name of the snap
+   * The id of the snap
    */
-  packageName: PropTypes.string,
+  snapId: PropTypes.string,
   /**
    * The className of the SnapsAuthorshipPill
    */
   className: PropTypes.string,
-  /**
-   * The url of the snap's package
-   */
-  url: PropTypes.string,
 };
 
 export default SnapsAuthorshipPill;

--- a/ui/components/app/flask/snaps-authorship-pill/snaps-authorship-pill.js
+++ b/ui/components/app/flask/snaps-authorship-pill/snaps-authorship-pill.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
+import { getSnapPrefix } from '@metamask/snap-controllers';
 import Chip from '../../../ui/chip';
 import Box from '../../../ui/box';
 import Typography from '../../../ui/typography';
@@ -8,13 +9,14 @@ import {
   COLORS,
   TYPOGRAPHY,
 } from '../../../../helpers/constants/design-system';
-import { getSnapPrefix } from '@metamask/snap-controllers';
 
 const SnapsAuthorshipPill = ({ snapId, className }) => {
   const snapPrefix = getSnapPrefix(snapId);
-  const packageName = snapId.replace(snapPrefix, "");
+  const packageName = snapId.replace(snapPrefix, '');
   const isNPM = snapPrefix === 'npm:';
-  const url = isNPM ? `https://www.npmjs.com/package/${packageName}` : packageName;
+  const url = isNPM
+    ? `https://www.npmjs.com/package/${packageName}`
+    : packageName;
   const icon = isNPM ? 'fab fa-npm' : 'fas fa-desktop';
   return (
     <a

--- a/ui/components/app/flask/snaps-authorship-pill/snaps-authorship-pill.stories.js
+++ b/ui/components/app/flask/snaps-authorship-pill/snaps-authorship-pill.stories.js
@@ -6,10 +6,7 @@ export default {
   id: __filename,
   component: SnapsAuthorshipPill,
   argTypes: {
-    packageName: {
-      control: 'text',
-    },
-    url: {
+    snapId: {
       control: 'text',
     },
   },
@@ -20,6 +17,5 @@ export const DefaultStory = (args) => <SnapsAuthorshipPill {...args} />;
 DefaultStory.storyName = 'Default';
 
 DefaultStory.args = {
-  packageName: 'npm-package-name',
-  url: 'https://www.npmjs.com/package/@airswap/protocols',
+  snapId: 'npm:@metamask/test-snap-bip44',
 };

--- a/ui/components/app/permissions-connect-header/index.scss
+++ b/ui/components/app/permissions-connect-header/index.scss
@@ -7,6 +7,7 @@
     display: flex;
     flex-direction: column;
     align-items: center;
+    margin-bottom: 16px;
   }
 
   &__title {
@@ -14,7 +15,6 @@
 
     text-align: center;
     color: var(--color-text-default);
-    margin-top: 16px;
     font-weight: bold;
   }
 

--- a/ui/components/app/permissions-connect-header/permissions-connect-header.component.js
+++ b/ui/components/app/permissions-connect-header/permissions-connect-header.component.js
@@ -44,14 +44,20 @@ export default class PermissionsConnectHeader extends Component {
   };
 
   renderHeaderIcon() {
-    const { iconUrl, iconName, siteOrigin, isSnapInstall } = this.props;
+    const {
+      iconUrl,
+      iconName,
+      siteOrigin,
+      ///: BEGIN:ONLY_INCLUDE_IN(flask)
+      isSnapInstall,
+      ///: END:ONLY_INCLUDE_IN
+    } = this.props;
 
     ///: BEGIN:ONLY_INCLUDE_IN(flask)
     if (isSnapInstall) {
       return null;
     }
     ///: END:ONLY_INCLUDE_IN
-
 
     return (
       <div className="permissions-connect-header__icon">
@@ -85,10 +91,7 @@ export default class PermissionsConnectHeader extends Component {
         <div className="permissions-connect-header__title">{headerTitle}</div>
         {
           ///: BEGIN:ONLY_INCLUDE_IN(flask)
-          isSnapInstall &&
-          <SnapsAuthorshipPill
-            snapId={siteOrigin}
-          />
+          isSnapInstall && <SnapsAuthorshipPill snapId={siteOrigin} />
           ///: END:ONLY_INCLUDE_IN
         }
         {

--- a/ui/components/app/permissions-connect-header/permissions-connect-header.component.js
+++ b/ui/components/app/permissions-connect-header/permissions-connect-header.component.js
@@ -31,8 +31,8 @@ export default class PermissionsConnectHeader extends Component {
     boxProps: PropTypes.shape({ ...Box.propTypes }),
     headerText: PropTypes.string,
     ///: BEGIN:ONLY_INCLUDE_IN(flask)
-    npmPackageName: PropTypes.string,
     snapVersion: PropTypes.string,
+    isSnapInstall: PropTypes.bool,
     ///: END:ONLY_INCLUDE_IN
   };
 
@@ -44,7 +44,14 @@ export default class PermissionsConnectHeader extends Component {
   };
 
   renderHeaderIcon() {
-    const { iconUrl, iconName, siteOrigin } = this.props;
+    const { iconUrl, iconName, siteOrigin, isSnapInstall } = this.props;
+
+    ///: BEGIN:ONLY_INCLUDE_IN(flask)
+    if (isSnapInstall) {
+      return null;
+    }
+    ///: END:ONLY_INCLUDE_IN
+
 
     return (
       <div className="permissions-connect-header__icon">
@@ -59,12 +66,12 @@ export default class PermissionsConnectHeader extends Component {
       headerTitle,
       headerText,
       ///: BEGIN:ONLY_INCLUDE_IN(flask)
-      npmPackageName,
+      siteOrigin,
       snapVersion,
+      isSnapInstall,
       ///: END:ONLY_INCLUDE_IN
     } = this.props;
     ///: BEGIN:ONLY_INCLUDE_IN(flask)
-    const npmPackageUrl = `https://www.npmjs.com/package/${npmPackageName}`;
     const { t } = this.context;
     ///: END:ONLY_INCLUDE_IN
     return (
@@ -78,12 +85,10 @@ export default class PermissionsConnectHeader extends Component {
         <div className="permissions-connect-header__title">{headerTitle}</div>
         {
           ///: BEGIN:ONLY_INCLUDE_IN(flask)
-          npmPackageName ? (
-            <SnapsAuthorshipPill
-              packageName={npmPackageName}
-              url={npmPackageUrl}
-            />
-          ) : null
+          isSnapInstall &&
+          <SnapsAuthorshipPill
+            snapId={siteOrigin}
+          />
           ///: END:ONLY_INCLUDE_IN
         }
         {

--- a/ui/pages/permissions-connect/flask/snap-install/snap-install.js
+++ b/ui/pages/permissions-connect/flask/snap-install/snap-install.js
@@ -67,7 +67,7 @@ export default function SnapInstall({
           headerTitle={t('snapInstall')}
           headerText={null} // TODO(ritave): Add header text when snaps support description
           siteOrigin={targetSubjectMetadata.origin}
-          isSnapInstall={true}
+          isSnapInstall
           snapVersion={targetSubjectMetadata.version}
           boxProps={{ alignItems: ALIGN_ITEMS.CENTER }}
         />

--- a/ui/pages/permissions-connect/flask/snap-install/snap-install.js
+++ b/ui/pages/permissions-connect/flask/snap-install/snap-install.js
@@ -37,13 +37,6 @@ export default function SnapInstall({
     approveSnapInstall,
   ]);
 
-  const npmId = useMemo(() => {
-    if (!targetSubjectMetadata.origin.startsWith('npm:')) {
-      return undefined;
-    }
-    return targetSubjectMetadata.origin.substring(4);
-  }, [targetSubjectMetadata]);
-
   const shouldShowWarning = useMemo(
     () =>
       Boolean(
@@ -74,7 +67,7 @@ export default function SnapInstall({
           headerTitle={t('snapInstall')}
           headerText={null} // TODO(ritave): Add header text when snaps support description
           siteOrigin={targetSubjectMetadata.origin}
-          npmPackageName={npmId}
+          isSnapInstall={true}
           snapVersion={targetSubjectMetadata.version}
           boxProps={{ alignItems: ALIGN_ITEMS.CENTER }}
         />

--- a/ui/pages/settings/flask/view-snap/view-snap.js
+++ b/ui/pages/settings/flask/view-snap/view-snap.js
@@ -47,7 +47,6 @@ function ViewSnap() {
     }
   }, [history, snap]);
 
-  const authorshipPillUrl = `https://npmjs.com/package/${snap?.manifest.source.location.npm.packageName}`;
   const connectedSubjects = useSelector((state) =>
     getSubjectsWithPermission(state, snap?.permissionName),
   );
@@ -87,9 +86,7 @@ function ViewSnap() {
           </Typography>
           <Box className="view-snap__pill-toggle-container">
             <Box className="view-snap__pill-container" paddingLeft={2}>
-              <SnapsAuthorshipPill
-                snapId={snap.id}
-              />
+              <SnapsAuthorshipPill snapId={snap.id} />
             </Box>
             <Box paddingLeft={4} className="view-snap__toggle-container">
               <Tooltip interactive position="bottom" html={t('snapsToggle')}>

--- a/ui/pages/settings/flask/view-snap/view-snap.js
+++ b/ui/pages/settings/flask/view-snap/view-snap.js
@@ -88,8 +88,7 @@ function ViewSnap() {
           <Box className="view-snap__pill-toggle-container">
             <Box className="view-snap__pill-container" paddingLeft={2}>
               <SnapsAuthorshipPill
-                packageName={snap.id}
-                url={authorshipPillUrl}
+                snapId={snap.id}
               />
             </Box>
             <Box paddingLeft={4} className="view-snap__toggle-container">


### PR DESCRIPTION
## Explanation
Removes the site origin on the snap install page and tweaks the `SnapAuthorshipPill` to be shown as an alternative.

## More Information

Fixes #14746

## Screenshots/Screencaps

<!-- If you're making a change to the UI, make sure to capture a screenshot or a short video showing off your work! -->

### Before

<!-- How did the UI you changed look before your changes? Drag your file(s) below this line: -->

![image](https://user-images.githubusercontent.com/1561200/170223868-4e3a6b28-5c40-4be1-8912-1c8ac0e0faa3.png)
![image](https://user-images.githubusercontent.com/1561200/170223952-39e7f720-b1f7-45b2-87a6-866a540ffe0e.png)


### After

<!-- How does it look now? Drag your file(s) below this line: -->

![image](https://user-images.githubusercontent.com/1561200/170222550-ef8300ba-b153-40dd-9955-cebe8c7f5883.png)
![image](https://user-images.githubusercontent.com/1561200/170222907-08b3a608-a779-4083-bc14-5318f3b9f476.png)


## Manual Testing Steps

1. Go to https://metamask.github.io/test-snaps/0.3.0/
2. Connect and install a snap
3. See the new install snap screen for NPM snaps
4. Run a local snap
5. Connect and install the local snap
6. See the new install snap screen for local snaps
