### PR TITLE
Fix to infinite loading on approve screen

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -2066,6 +2066,9 @@
     "message": "Nonce is higher than suggested nonce of $1",
     "description": "The next nonce according to MetaMask's internal logic"
   },
+  "nft": {
+    "message": "NFT"
+  },
   "nftTokenIdPlaceholder": {
     "message": "Enter the Token ID"
   },

--- a/ui/hooks/useAssetDetails.js
+++ b/ui/hooks/useAssetDetails.js
@@ -86,7 +86,7 @@ export function useAssetDetails(tokenAddress, userAddress, transactionData) {
     const tokenData = parseStandardTokenTransactionData(transactionData);
     assetStandard = standard;
     assetAddress = tokenAddress;
-    tokenSymbol = symbol;
+    tokenSymbol = symbol ?? '';
     tokenImage = image;
     toAddress = getTokenAddressParam(tokenData);
     if (assetStandard === ERC721 || assetStandard === ERC1155) {

--- a/ui/hooks/useAssetDetails.js
+++ b/ui/hooks/useAssetDetails.js
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { parseStandardTokenTransactionData } from '../../shared/modules/transaction.utils';
-import { getCollectibles, getTokens } from '../ducks/metamask/metamask';
+import { getCollectibles } from '../ducks/metamask/metamask';
 import { ERC1155, ERC721, ERC20 } from '../helpers/constants/common';
 import {
   calcTokenAmount,

--- a/ui/hooks/useAssetDetails.js
+++ b/ui/hooks/useAssetDetails.js
@@ -9,16 +9,13 @@ import {
   getTokenAddressParam,
   getTokenValueParam,
 } from '../helpers/utils/token-util';
-import { getTokenList } from '../selectors';
 import { hideLoadingIndication, showLoadingIndication } from '../store/actions';
 import { usePrevious } from './usePrevious';
 
 export function useAssetDetails(tokenAddress, userAddress, transactionData) {
   const dispatch = useDispatch();
   // state selectors
-  const tokens = useSelector(getTokens);
   const collectibles = useSelector(getCollectibles);
-  const tokenList = useSelector(getTokenList);
 
   // in-hook state
   const [currentAsset, setCurrentAsset] = useState(null);
@@ -36,8 +33,6 @@ export function useAssetDetails(tokenAddress, userAddress, transactionData) {
         userAddress,
         transactionData,
         collectibles,
-        tokens,
-        tokenList,
       );
       setCurrentAsset(assetDetails);
       dispatch(hideLoadingIndication());
@@ -58,8 +53,6 @@ export function useAssetDetails(tokenAddress, userAddress, transactionData) {
     userAddress,
     transactionData,
     collectibles,
-    tokens,
-    tokenList,
   ]);
 
   let assetStandard,
@@ -83,11 +76,13 @@ export function useAssetDetails(tokenAddress, userAddress, transactionData) {
       balance,
       decimals: currentAssetDecimals,
     } = currentAsset;
+
     const tokenData = parseStandardTokenTransactionData(transactionData);
     assetStandard = standard;
     assetAddress = tokenAddress;
     tokenSymbol = symbol ?? '';
     tokenImage = image;
+
     toAddress = getTokenAddressParam(tokenData);
     if (assetStandard === ERC721 || assetStandard === ERC1155) {
       assetName = name;
@@ -101,6 +96,7 @@ export function useAssetDetails(tokenAddress, userAddress, transactionData) {
         calcTokenAmount(getTokenValueParam(tokenData), decimals).toString(10);
     }
   }
+
   return {
     assetStandard,
     assetName,

--- a/ui/hooks/useAssetDetails.test.js
+++ b/ui/hooks/useAssetDetails.test.js
@@ -1,0 +1,151 @@
+import React from 'react';
+import { Provider } from 'react-redux';
+import { renderHook } from '@testing-library/react-hooks';
+
+import configureStore from '../store/store';
+import { useAssetDetails } from './useAssetDetails';
+import * as tokenUtils from '../helpers/utils/token-util';
+import { ERC20, ERC721 } from '../helpers/constants/common';
+
+// jest.mock('react-redux', () => {
+//     const actual = jest.requireActual('react-redux');
+//     return {
+//       ...actual,
+//       useSelector: jest.fn(),
+//       useDispatch: () => jest.fn(),
+//     };
+//   });
+
+const renderUseAssetDetails = ({
+  tokenAddress,
+  userAddress,
+  transactionData,
+}) => {
+  const mockState = {
+    metamask: {
+      provider: {
+        type: 'test',
+        chainId: '0x3',
+      },
+      tokenList: {},
+    },
+  };
+
+  const wrapper = ({ children }) => (
+    <Provider store={configureStore(mockState)}>{children}</Provider>
+  );
+
+  return renderHook(
+    () => useAssetDetails(tokenAddress, userAddress, transactionData),
+    { wrapper },
+  );
+};
+
+describe('useAssetDetails', () => {
+  let getAssetDetailsStub;
+  beforeEach(() => {
+    jest.useFakeTimers();
+    getAssetDetailsStub = jest
+      .spyOn(tokenUtils, 'getAssetDetails')
+      .mockImplementation(() => Promise.resolve({}));
+  });
+  it('should return object with tokenSymbol set to and empty string, when getAssetDetails returns and empty object', async () => {
+    const toAddress = '000000000000000000000000000000000000dead';
+    const tokenAddress = '0x1';
+
+    const transactionData = `0xa9059cbb000000000000000000000000${toAddress}000000000000000000000000000000000000000000000000016345785d8a0000`;
+
+    const { result } = await renderUseAssetDetails({
+      tokenAddress,
+      userAddress: '0x111',
+      transactionData,
+    });
+
+    expect(result.current).toStrictEqual({
+      assetAddress: tokenAddress,
+      assetName: undefined,
+      assetStandard: undefined,
+      decimals: undefined,
+      toAddress: `0x${toAddress}`,
+      tokenAmount: undefined,
+      tokenId: undefined,
+      tokenImage: undefined,
+      tokenSymbol: '',
+      tokenValue: undefined,
+      userBalance: undefined,
+    });
+  });
+
+  it('should return object with correct tokenValues for an ERC20 token', async () => {
+    const userAddress = '0xf04a5cc80b1e94c69b48f5ee68a08cd2f09a7c3e';
+    const tokenAddress = '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2';
+    const toAddress = '000000000000000000000000000000000000dead';
+    const transactionData = `0xa9059cbb000000000000000000000000${toAddress}00000000000000000000000000000000000000000000000000000000000001f4`;
+
+    getAssetDetailsStub.mockImplementation(() =>
+      Promise.resolve({
+        standard: ERC20,
+        symbol: 'WETH',
+        balance: '1',
+        decimals: 18,
+      }),
+    );
+
+    const { result } = await renderUseAssetDetails({
+      tokenAddress,
+      userAddress,
+      transactionData,
+    });
+
+    expect(result.current).toStrictEqual({
+      assetAddress: tokenAddress,
+      assetName: undefined,
+      assetStandard: ERC20,
+      decimals: 18,
+      toAddress: `0x${toAddress}`,
+      tokenAmount: '0.0000000000000005',
+      tokenId: undefined,
+      tokenImage: undefined,
+      tokenSymbol: 'WETH',
+      tokenValue: undefined,
+      userBalance: '1',
+    });
+  });
+
+  it('should return object with correct tokenValues for an ERC721 token', async () => {
+    const tokenAddress = '0xBC4CA0EdA7647A8aB7C2061c2E118A18a936f13D';
+    const toAddress = '000000000000000000000000000000000000dead';
+    const transactionData = `0x23b872dd000000000000000000000000a544eebe103733f22ef62af556023bc918b73d36000000000000000000000000${toAddress}000000000000000000000000000000000000000000000000000000000000000c`;
+
+    getAssetDetailsStub.mockImplementation(() =>
+      Promise.resolve({
+        standard: ERC721,
+        symbol: 'BAYC',
+        name: 'BoredApeYachtClub',
+        tokenId: '12',
+        image:
+          'https://bafybeihw3gvmthmvrenfmcvagtais5tv7r4nmiezgsv7nyknjubxw4lite.ipfs.dweb.link',
+      }),
+    );
+
+    const { result } = await renderUseAssetDetails({
+      tokenAddress,
+      transactionData,
+    });
+
+    expect(result.current).toStrictEqual({
+      assetAddress: tokenAddress,
+      assetName: 'BoredApeYachtClub',
+      assetStandard: ERC721,
+      decimals: undefined,
+      toAddress: `0x${toAddress}`,
+      tokenId: '12',
+      tokenImage:
+        'https://bafybeihw3gvmthmvrenfmcvagtais5tv7r4nmiezgsv7nyknjubxw4lite.ipfs.dweb.link',
+      tokenSymbol: 'BAYC',
+      tokenValue: undefined,
+      userBalance: undefined,
+      tokenAmount: undefined,
+    });
+  });
+});

--- a/ui/hooks/useAssetDetails.test.js
+++ b/ui/hooks/useAssetDetails.test.js
@@ -1,20 +1,11 @@
 import React from 'react';
 import { Provider } from 'react-redux';
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook, act } from '@testing-library/react-hooks';
 
 import configureStore from '../store/store';
 import * as tokenUtils from '../helpers/utils/token-util';
 import { ERC20, ERC721 } from '../helpers/constants/common';
 import { useAssetDetails } from './useAssetDetails';
-
-// jest.mock('react-redux', () => {
-//     const actual = jest.requireActual('react-redux');
-//     return {
-//       ...actual,
-//       useSelector: jest.fn(),
-//       useDispatch: () => jest.fn(),
-//     };
-//   });
 
 const renderUseAssetDetails = ({
   tokenAddress,
@@ -60,7 +51,9 @@ describe('useAssetDetails', () => {
       transactionData,
     });
 
-    await waitForNextUpdate;
+    await act(async () => {
+      await waitForNextUpdate;
+    });
 
     expect(result.current).toStrictEqual({
       assetAddress: tokenAddress,
@@ -83,12 +76,17 @@ describe('useAssetDetails', () => {
     const toAddress = '000000000000000000000000000000000000dead';
     const transactionData = `0xa9059cbb000000000000000000000000${toAddress}00000000000000000000000000000000000000000000000000000000000001f4`;
 
+    const standard = ERC20;
+    const symbol = 'WETH';
+    const balance = '1';
+    const decimals = 18;
+
     getAssetDetailsStub.mockImplementation(() =>
       Promise.resolve({
-        standard: ERC20,
-        symbol: 'WETH',
-        balance: '1',
-        decimals: 18,
+        standard,
+        symbol,
+        balance,
+        decimals,
       }),
     );
 
@@ -98,20 +96,22 @@ describe('useAssetDetails', () => {
       transactionData,
     });
 
-    await waitForNextUpdate;
+    await act(async () => {
+      await waitForNextUpdate;
+    });
 
     expect(result.current).toStrictEqual({
       assetAddress: tokenAddress,
       assetName: undefined,
-      assetStandard: ERC20,
-      decimals: 18,
+      assetStandard: standard,
+      decimals: decimals,
       toAddress: `0x${toAddress}`,
       tokenAmount: '0.0000000000000005',
       tokenId: undefined,
       tokenImage: undefined,
-      tokenSymbol: 'WETH',
+      tokenSymbol: symbol,
       tokenValue: undefined,
-      userBalance: '1',
+      userBalance: balance,
     });
   });
 
@@ -120,14 +120,20 @@ describe('useAssetDetails', () => {
     const toAddress = '000000000000000000000000000000000000dead';
     const transactionData = `0x23b872dd000000000000000000000000a544eebe103733f22ef62af556023bc918b73d36000000000000000000000000${toAddress}000000000000000000000000000000000000000000000000000000000000000c`;
 
+    const symbol = 'BAYC';
+    const tokenId = '12';
+    const name = 'BoredApeYachtClub';
+    const image =
+      'https://bafybeihw3gvmthmvrenfmcvagtais5tv7r4nmiezgsv7nyknjubxw4lite.ipfs.dweb.link';
+    const standard = ERC721;
+
     getAssetDetailsStub.mockImplementation(() =>
       Promise.resolve({
-        standard: ERC721,
-        symbol: 'BAYC',
-        name: 'BoredApeYachtClub',
-        tokenId: '12',
-        image:
-          'https://bafybeihw3gvmthmvrenfmcvagtais5tv7r4nmiezgsv7nyknjubxw4lite.ipfs.dweb.link',
+        standard,
+        symbol,
+        name,
+        tokenId,
+        image,
       }),
     );
 
@@ -136,18 +142,65 @@ describe('useAssetDetails', () => {
       transactionData,
     });
 
-    await waitForNextUpdate;
+    await act(async () => {
+      await waitForNextUpdate;
+    });
 
     expect(result.current).toStrictEqual({
       assetAddress: tokenAddress,
-      assetName: 'BoredApeYachtClub',
-      assetStandard: ERC721,
+      assetName: name,
+      assetStandard: standard,
       decimals: undefined,
       toAddress: `0x${toAddress}`,
-      tokenId: '12',
-      tokenImage:
-        'https://bafybeihw3gvmthmvrenfmcvagtais5tv7r4nmiezgsv7nyknjubxw4lite.ipfs.dweb.link',
-      tokenSymbol: 'BAYC',
+      tokenId: tokenId,
+      tokenImage: image,
+      tokenSymbol: symbol,
+      tokenValue: undefined,
+      userBalance: undefined,
+      tokenAmount: undefined,
+    });
+  });
+
+  it('should return object with correct tokenValues for an ERC1155 token', async () => {
+    const tokenAddress = '0x76BE3b62873462d2142405439777e971754E8E77';
+    const toAddress = '000000000000000000000000000000000000dead';
+    const transactionData = `0x23b872dd000000000000000000000000a544eebe103733f22ef62af556023bc918b73d36000000000000000000000000${toAddress}000000000000000000000000000000000000000000000000000000000000000c`;
+
+    const symbol = 'BAYC';
+    const tokenId = '12';
+    const name = 'BoredApeYachtClub';
+    const image =
+      'https://bafybeihw3gvmthmvrenfmcvagtais5tv7r4nmiezgsv7nyknjubxw4lite.ipfs.dweb.link';
+    const standard = ERC721;
+
+    getAssetDetailsStub.mockImplementation(() =>
+      Promise.resolve({
+        standard,
+        symbol,
+        name,
+        tokenId,
+        image,
+      }),
+    );
+
+    const { result, waitForNextUpdate } = renderUseAssetDetails({
+      tokenAddress,
+      transactionData,
+    });
+
+    await act(async () => {
+      await waitForNextUpdate;
+    });
+
+    expect(result.current).toStrictEqual({
+      assetAddress: tokenAddress,
+      assetName: name,
+      assetStandard: standard,
+      decimals: undefined,
+      toAddress: `0x${toAddress}`,
+      tokenId: tokenId,
+      tokenImage: image,
+      tokenSymbol: symbol,
       tokenValue: undefined,
       userBalance: undefined,
       tokenAmount: undefined,

--- a/ui/hooks/useAssetDetails.test.js
+++ b/ui/hooks/useAssetDetails.test.js
@@ -3,9 +3,9 @@ import { Provider } from 'react-redux';
 import { renderHook } from '@testing-library/react-hooks';
 
 import configureStore from '../store/store';
-import { useAssetDetails } from './useAssetDetails';
 import * as tokenUtils from '../helpers/utils/token-util';
 import { ERC20, ERC721 } from '../helpers/constants/common';
+import { useAssetDetails } from './useAssetDetails';
 
 // jest.mock('react-redux', () => {
 //     const actual = jest.requireActual('react-redux');
@@ -44,7 +44,6 @@ const renderUseAssetDetails = ({
 describe('useAssetDetails', () => {
   let getAssetDetailsStub;
   beforeEach(() => {
-    jest.useFakeTimers();
     getAssetDetailsStub = jest
       .spyOn(tokenUtils, 'getAssetDetails')
       .mockImplementation(() => Promise.resolve({}));
@@ -55,11 +54,13 @@ describe('useAssetDetails', () => {
 
     const transactionData = `0xa9059cbb000000000000000000000000${toAddress}000000000000000000000000000000000000000000000000016345785d8a0000`;
 
-    const { result } = await renderUseAssetDetails({
+    const { result, waitForNextUpdate } = renderUseAssetDetails({
       tokenAddress,
       userAddress: '0x111',
       transactionData,
     });
+
+    await waitForNextUpdate;
 
     expect(result.current).toStrictEqual({
       assetAddress: tokenAddress,
@@ -91,11 +92,13 @@ describe('useAssetDetails', () => {
       }),
     );
 
-    const { result } = await renderUseAssetDetails({
+    const { result, waitForNextUpdate } = renderUseAssetDetails({
       tokenAddress,
       userAddress,
       transactionData,
     });
+
+    await waitForNextUpdate;
 
     expect(result.current).toStrictEqual({
       assetAddress: tokenAddress,
@@ -128,10 +131,12 @@ describe('useAssetDetails', () => {
       }),
     );
 
-    const { result } = await renderUseAssetDetails({
+    const { result, waitForNextUpdate } = renderUseAssetDetails({
       tokenAddress,
       transactionData,
     });
+
+    await waitForNextUpdate;
 
     expect(result.current).toStrictEqual({
       assetAddress: tokenAddress,

--- a/ui/hooks/useAssetDetails.test.js
+++ b/ui/hooks/useAssetDetails.test.js
@@ -1,10 +1,10 @@
 import React from 'react';
 import { Provider } from 'react-redux';
-import { renderHook, act } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react-hooks';
 
 import configureStore from '../store/store';
 import * as tokenUtils from '../helpers/utils/token-util';
-import { ERC20, ERC721 } from '../helpers/constants/common';
+import { ERC1155, ERC20, ERC721 } from '../helpers/constants/common';
 import { useAssetDetails } from './useAssetDetails';
 
 const renderUseAssetDetails = ({
@@ -51,9 +51,7 @@ describe('useAssetDetails', () => {
       transactionData,
     });
 
-    await act(async () => {
-      await waitForNextUpdate;
-    });
+    await waitForNextUpdate();
 
     expect(result.current).toStrictEqual({
       assetAddress: tokenAddress,
@@ -96,15 +94,13 @@ describe('useAssetDetails', () => {
       transactionData,
     });
 
-    await act(async () => {
-      await waitForNextUpdate;
-    });
+    await waitForNextUpdate();
 
     expect(result.current).toStrictEqual({
       assetAddress: tokenAddress,
       assetName: undefined,
       assetStandard: standard,
-      decimals: decimals,
+      decimals,
       toAddress: `0x${toAddress}`,
       tokenAmount: '0.0000000000000005',
       tokenId: undefined,
@@ -142,9 +138,7 @@ describe('useAssetDetails', () => {
       transactionData,
     });
 
-    await act(async () => {
-      await waitForNextUpdate;
-    });
+    await waitForNextUpdate();
 
     expect(result.current).toStrictEqual({
       assetAddress: tokenAddress,
@@ -152,7 +146,7 @@ describe('useAssetDetails', () => {
       assetStandard: standard,
       decimals: undefined,
       toAddress: `0x${toAddress}`,
-      tokenId: tokenId,
+      tokenId,
       tokenImage: image,
       tokenSymbol: symbol,
       tokenValue: undefined,
@@ -164,20 +158,16 @@ describe('useAssetDetails', () => {
   it('should return object with correct tokenValues for an ERC1155 token', async () => {
     const tokenAddress = '0x76BE3b62873462d2142405439777e971754E8E77';
     const toAddress = '000000000000000000000000000000000000dead';
-    const transactionData = `0x23b872dd000000000000000000000000a544eebe103733f22ef62af556023bc918b73d36000000000000000000000000${toAddress}000000000000000000000000000000000000000000000000000000000000000c`;
+    const transactionData = `0xf242432a000000000000000000000000a544eebe103733f22ef62af556023bc918b73d36000000000000000000000000000000000000000000000000000000000000dead0000000000000000000000000000000000000000000000000000000000000322000000000000000000000000000000000000000000000000000000000000009c00000000000000000000000000000000000000000000000000000000000000a000000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000000`;
 
-    const symbol = 'BAYC';
-    const tokenId = '12';
-    const name = 'BoredApeYachtClub';
+    const tokenId = '121';
     const image =
       'https://bafybeihw3gvmthmvrenfmcvagtais5tv7r4nmiezgsv7nyknjubxw4lite.ipfs.dweb.link';
-    const standard = ERC721;
+    const standard = ERC1155;
 
     getAssetDetailsStub.mockImplementation(() =>
       Promise.resolve({
         standard,
-        symbol,
-        name,
         tokenId,
         image,
       }),
@@ -188,19 +178,17 @@ describe('useAssetDetails', () => {
       transactionData,
     });
 
-    await act(async () => {
-      await waitForNextUpdate;
-    });
+    await waitForNextUpdate();
 
     expect(result.current).toStrictEqual({
       assetAddress: tokenAddress,
-      assetName: name,
+      assetName: undefined,
       assetStandard: standard,
       decimals: undefined,
       toAddress: `0x${toAddress}`,
-      tokenId: tokenId,
+      tokenId: undefined,
       tokenImage: image,
-      tokenSymbol: symbol,
+      tokenSymbol: '',
       tokenValue: undefined,
       userBalance: undefined,
       tokenAmount: undefined,

--- a/ui/pages/confirm-approve/confirm-approve-content/confirm-approve-content.component.js
+++ b/ui/pages/confirm-approve/confirm-approve-content/confirm-approve-content.component.js
@@ -62,6 +62,7 @@ export default class ConfirmApproveContent extends Component {
     txData: PropTypes.object,
     fromAddressIsLedger: PropTypes.bool,
     chainId: PropTypes.string,
+    tokenAddress: PropTypes.string,
     rpcPrefs: PropTypes.object,
     isContract: PropTypes.bool,
     hexTransactionTotal: PropTypes.string,
@@ -183,7 +184,9 @@ export default class ConfirmApproveContent extends Component {
 
   renderERC721OrERC1155PermissionContent() {
     const { t } = this.context;
-    const { origin, toAddress, isContract, assetName, tokenId } = this.props;
+    const { origin, toAddress, isContract } = this.props;
+
+    const titleTokenDescription = this.getTitleTokenDescription();
 
     const displayedAddress = isContract
       ? `${t('contract')} (${addressSummary(toAddress)})`
@@ -198,7 +201,7 @@ export default class ConfirmApproveContent extends Component {
             {t('approvedAsset')}:
           </div>
           <div className="confirm-approve-content__medium-text">
-            {`${assetName} #${tokenId}`}
+            {titleTokenDescription}
           </div>
         </div>
         <div className="flex-row">
@@ -430,6 +433,82 @@ export default class ConfirmApproveContent extends Component {
     );
   }
 
+  getTitleTokenDescription() {
+    const {
+      tokenId,
+      assetName,
+      tokenAddress,
+      rpcPrefs,
+      chainId,
+      assetStandard,
+      tokenSymbol,
+    } = this.props;
+    const { t } = this.context;
+    let titleTokenDescription = t('token');
+    if (rpcPrefs?.blockExplorerUrl || chainId) {
+      const unknownTokenBlockExplorerLink = getTokenTrackerLink(
+        tokenAddress,
+        chainId,
+        null,
+        {
+          blockExplorerUrl: rpcPrefs?.blockExplorerUrl ?? null,
+        },
+      );
+
+      const unknownTokenLink = (
+        <a
+          href={unknownTokenBlockExplorerLink}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="confirm-approve-content__unknown-asset"
+        >
+          {t('token')}
+        </a>
+      );
+      titleTokenDescription = unknownTokenLink;
+    }
+
+    if (assetStandard === ERC20 || (tokenSymbol && !tokenId)) {
+      titleTokenDescription = tokenSymbol;
+    } else if (
+      assetStandard === ERC721 ||
+      assetStandard === ERC1155 ||
+      // if we don't have an asset standard but we do have either both an assetname and a tokenID or both a tokenSymbol and tokenId we assume its an NFT
+      (assetName && tokenId) ||
+      (tokenSymbol && tokenId)
+    ) {
+      const tokenIdWrapped = tokenId ? ` (#${tokenId})` : null;
+      if (assetName || tokenSymbol) {
+        titleTokenDescription = `${assetName ?? tokenSymbol} ${tokenIdWrapped}`;
+      } else {
+        const unknownNFTBlockExplorerLink = getTokenTrackerLink(
+          tokenAddress,
+          chainId,
+          null,
+          {
+            blockExplorerUrl: rpcPrefs?.blockExplorerUrl ?? null,
+          },
+        );
+        const unknownNFTLink = (
+          <>
+            <a
+              href={unknownNFTBlockExplorerLink}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="confirm-approve-content__unknown-asset"
+            >
+              {t('nft')}
+            </a>
+            {tokenIdWrapped && <span>{tokenIdWrapped}</span>}
+          </>
+        );
+        titleTokenDescription = unknownNFTLink;
+      }
+    }
+
+    return titleTokenDescription;
+  }
+
   render() {
     const { t } = this.context;
     const {
@@ -452,10 +531,10 @@ export default class ConfirmApproveContent extends Component {
       rpcPrefs,
       isContract,
       assetStandard,
-      tokenId,
-      assetName,
     } = this.props;
     const { showFullTxDetails } = this.state;
+
+    const titleTokenDescription = this.getTitleTokenDescription();
 
     return (
       <div
@@ -496,11 +575,7 @@ export default class ConfirmApproveContent extends Component {
           </Box>
         </Box>
         <div className="confirm-approve-content__title">
-          {t('allowSpendToken', [
-            assetStandard === ERC20
-              ? tokenSymbol
-              : `${assetName} (#${tokenId})`,
-          ])}
+          {t('allowSpendToken', [titleTokenDescription])}
         </div>
         <div className="confirm-approve-content__description">
           {t('trustSiteApprovePermission', [
@@ -554,7 +629,9 @@ export default class ConfirmApproveContent extends Component {
                   : getAccountLink(
                       toAddress,
                       chainId,
-                      { blockExplorerUrl: rpcPrefs?.blockExplorerUrl ?? null },
+                      {
+                        blockExplorerUrl: rpcPrefs?.blockExplorerUrl ?? null,
+                      },
                       null,
                     );
                 global.platform.openTab({

--- a/ui/pages/confirm-approve/confirm-approve-content/index.scss
+++ b/ui/pages/confirm-approve/confirm-approve-content/index.scss
@@ -9,6 +9,10 @@
     padding: 0 24px 16px 24px;
   }
 
+  &__unknown-asset {
+    color: var(--color-primary-default);
+  }
+
   &__icon-display-content {
     display: flex;
     height: 51px;

--- a/ui/pages/confirm-approve/confirm-approve.js
+++ b/ui/pages/confirm-approve/confirm-approve.js
@@ -52,6 +52,7 @@ export default function ConfirmApprove({
   tokenId,
   userAddress,
   toAddress,
+  tokenAddress,
   transaction,
   ethTransactionTotal,
   fiatTransactionTotal,
@@ -173,6 +174,7 @@ export default function ConfirmApprove({
               tokenId={tokenId}
               assetName={assetName}
               assetStandard={assetStandard}
+              tokenAddress={tokenAddress}
               showCustomizeGasModal={approveTransaction}
               showEditApprovalPermissionModal={({
                 /* eslint-disable no-shadow */
@@ -268,6 +270,7 @@ export default function ConfirmApprove({
 ConfirmApprove.propTypes = {
   assetStandard: PropTypes.string,
   assetName: PropTypes.string,
+  tokenAddress: PropTypes.string,
   userBalance: PropTypes.string,
   tokenSymbol: PropTypes.string,
   decimals: PropTypes.string,


### PR DESCRIPTION
Fixes issue where screen for confirming `approve()` method calls gets stuck in infinite loading (https://github.com/MetaMask/metamask-extension/issues/14459 & https://github.com/MetaMask/metamask-extension/issues/14589 & https://github.com/MetaMask/metamask-extension/issues/14518). This is set to be partially addressed when the commit associated with this [PR](https://github.com/MetaMask/controllers/pull/834) is merged into the extension. It will be further addressed something like this [WIP PR](https://github.com/MetaMask/controllers/pull/838) (the exact form of which is still being discussed). Even with these fixes however, there are still contracts for which the issue will not be resolved. The ENS ERC721 contract for example does not implement either a `symbol()` or `name()` method the result of which the approve screen currently relies upon. This PR simply adds a fallback value of `""` for the symbol so that once we're done loading contract data the symbol will not be undefined no matter what, [allowing us to move past the loading screen.](https://github.com/MetaMask/metamask-extension/blob/634cf70a71f63ec98ff7efbc081620480efa8a58/ui/pages/confirm-approve/confirm-approve.js#L152)
 
This fixes a regression introduced in this PR: https://github.com/MetaMask/metamask-extension/pull/13788