### PR TITLE
Remove module paths from bundle

### DIFF
--- a/patches/@lavamoat+lavapack+3.1.0.patch
+++ b/patches/@lavamoat+lavapack+3.1.0.patch
@@ -1,0 +1,15 @@
+diff --git a/node_modules/@lavamoat/lavapack/src/pack.js b/node_modules/@lavamoat/lavapack/src/pack.js
+index eb41a0a..3f891ea 100644
+--- a/node_modules/@lavamoat/lavapack/src/pack.js
++++ b/node_modules/@lavamoat/lavapack/src/pack.js
+@@ -203,7 +203,9 @@ function createPacker({
+     const jsonSerializeableData = {
+       // id,
+       package: packageName,
+-      file,
++      // Omit this absolute filename from bundle so that builds are reproducible between environments
++      // TODO: update lavapack with an option to omit this, and/or make this filepath relative to the current working directory
++      // file,
+       // deps,
+       // source: sourceMeta.code
+     }


### PR DESCRIPTION
## Explanation

A patch has been added to ensure lavapack no longer includes the path for each module as part of each serialized module. This path was originally added for debugging purposes, and is not used for anything at runtime. The module path was an absolute path, not a relative one, so it was an obstacle to having reproducible builds between environments.

## Manual Testing Steps

This should have no functional impact upon the wallet, so the QA steps would be whatever is typically done for regression testing.

For ensuring the filename is no longer present in the bundle:
* Run `yarn dist`
* Look in any of the bundles created using lavapack (e.g. the factored bundles like `background-[number].js`, `ui-[number].js`, etc), and search for the directory the project is in on your local machine to ensure it's not included in the bundle.

## Pre-Merge Checklist

- [x] PR template is filled out
- [ ] Manual testing complete & passed
- [x] **IF** this PR fixes a bug, a test that _would have_ caught the bug has been added
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** QA attention is required, "QA Board" label has been applied
- [ ] PR has been added to the appropriate release Milestone
