### PR TITLE
Restore SiteOrigin chip on permission screen

### DIFF
--- a/ui/components/app/permissions-connect-header/permissions-connect-header.component.js
+++ b/ui/components/app/permissions-connect-header/permissions-connect-header.component.js
@@ -48,7 +48,7 @@ export default class PermissionsConnectHeader extends Component {
 
     return (
       <div className="permissions-connect-header__icon">
-        <SiteOrigin siteOrigin={siteOrigin} iconSrc={iconUrl} name={iconName} />
+        <SiteOrigin chip siteOrigin={siteOrigin} iconSrc={iconUrl} name={iconName} />
       </div>
     );
   }

--- a/ui/components/app/permissions-connect-header/permissions-connect-header.component.js
+++ b/ui/components/app/permissions-connect-header/permissions-connect-header.component.js
@@ -48,7 +48,12 @@ export default class PermissionsConnectHeader extends Component {
 
     return (
       <div className="permissions-connect-header__icon">
-        <SiteOrigin chip siteOrigin={siteOrigin} iconSrc={iconUrl} name={iconName} />
+        <SiteOrigin
+          chip
+          siteOrigin={siteOrigin}
+          iconSrc={iconUrl}
+          name={iconName}
+        />
       </div>
     );
   }


### PR DESCRIPTION
## Explanation
Solves an accidental change to `SiteOrigin` on the permission screen.

cc @adonesky1 

## Manual Testing Steps

1. Connect to a DApp or Snap
2. Notice that the site origin on the request is chip

## Pre-Merge Checklist

- [ ] PR template is filled out
- [ ] Manual testing complete & passed
- [ ] **IF** this PR fixes a bug, a test that _would have_ caught the bug has been added
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** QA attention is required, "QA Board" label has been applied
- [ ] PR has been added to the appropriate release Milestone
