### PR TITLE
Enables the "Safe Transaction From" copy for safeTransferFrom transactions

### DIFF
--- a/ui/hooks/useTransactionDisplayData.js
+++ b/ui/hooks/useTransactionDisplayData.js
@@ -238,13 +238,17 @@ export function useTransactionDisplayData(transactionGroup) {
     subtitle = t('fromAddress', [shortenAddress(senderAddress)]);
   } else if (
     type === TRANSACTION_TYPES.TOKEN_METHOD_TRANSFER_FROM ||
-    type === TRANSACTION_TYPES.TOKEN_METHOD_TRANSFER ||
-    type === TRANSACTION_TYPES.TOKEN_METHOD_SAFE_TRANSFER_FROM
+    type === TRANSACTION_TYPES.TOKEN_METHOD_TRANSFER
   ) {
     category = TRANSACTION_GROUP_CATEGORIES.SEND;
     title = t('sendSpecifiedTokens', [
       token?.symbol || collectible?.name || t('token'),
     ]);
+    recipientAddress = getTokenAddressParam(tokenData);
+    subtitle = t('toAddress', [shortenAddress(recipientAddress)]);
+  } else if (type === TRANSACTION_TYPES.TOKEN_METHOD_SAFE_TRANSFER_FROM) {
+    category = TRANSACTION_GROUP_CATEGORIES.SEND;
+    title = t('safeTransferFrom');
     recipientAddress = getTokenAddressParam(tokenData);
     subtitle = t('toAddress', [shortenAddress(recipientAddress)]);
   } else if (type === TRANSACTION_TYPES.SIMPLE_SEND) {

--- a/ui/hooks/useTransactionDisplayData.test.js
+++ b/ui/hooks/useTransactionDisplayData.test.js
@@ -131,7 +131,7 @@ const expectedResults = [
     displayedStatusKey: TRANSACTION_STATUSES.CONFIRMED,
   },
   {
-    title: 'Send Token',
+    title: 'Safe Transfer From',
     category: TRANSACTION_GROUP_CATEGORIES.SEND,
     subtitle: 'To: 0xe7d...dd98',
     subtitleContainsOrigin: true,


### PR DESCRIPTION
## Explanation

The `safeTransferFrom` translation is currently not being used. This PR puts the `safeTransferFrom` translation to use. 

## More Information

* Further fix for https://github.com/MetaMask/metamask-extension/issues/14729  and https://github.com/MetaMask/metamask-extension/issues/14636 after  https://github.com/MetaMask/metamask-extension/pull/14678
* Related: https://github.com/MetaMask/metamask-extension/pull/13535 (original implementation of `t('safeTransferFrom')`

## Screenshots/Screencaps

<!-- If you're making a change to the UI, make sure to capture a screenshot or a short video showing off your work! -->

### Before

<img width="1094" alt="Screenshot 2022-05-24 at 10 35 56 AM" src="https://user-images.githubusercontent.com/20778143/170080023-70ab747d-9a7e-4a0d-8797-a1fe492862d8.png">


### After

<img width="508" alt="Screenshot 2022-05-24 at 1 45 44 PM" src="https://user-images.githubusercontent.com/20778143/170109900-dc7b933b-3ae8-4ac2-9865-0beeb1f3a85c.png">
<img width="509" alt="Screenshot 2022-05-24 at 11 14 09 AM" src="https://user-images.githubusercontent.com/20778143/170109948-b3131254-9cfc-4058-8b06-d0041da9367e.png">


## Manual Testing Steps

Instructions based off of: https://github.com/MetaMask/metamask-extension/issues/14729:
1. Go to [Remix](https://remix.ethereum.org/#code=Ly8gU1BEWC1MaWNlbnNlLUlkZW50aWZpZXI6IE1JVApwcmFnbWEgc29saWRpdHkgXjAuOC40OwoKaW1wb3J0ICJAb3BlbnplcHBlbGluL2NvbnRyYWN0c0A0LjYuMC90b2tlbi9FUkM3MjEvRVJDNzIxLnNvbCI7CmltcG9ydCAiQG9wZW56ZXBwZWxpbi9jb250cmFjdHNANC42LjAvYWNjZXNzL093bmFibGUuc29sIjsKCmNvbnRyYWN0IE15VG9rZW4gaXMgRVJDNzIxLCBPd25hYmxlIHsKICAgIGNvbnN0cnVjdG9yKCkgRVJDNzIxKCJNeVRva2VuIiwgIk1USyIpIHt9CgogICAgZnVuY3Rpb24gc2FmZU1pbnQoYWRkcmVzcyB0bywgdWludDI1NiB0b2tlbklkKSBwdWJsaWMgb25seU93bmVyIHsKICAgICAgICBfc2FmZU1pbnQodG8sIHRva2VuSWQpOwogICAgfQp9Cg&optimize=false&runs=200&evmVersion=null&version=soljson-v0.8.7+commit.e28d00a7.js)
2. Compile My Token contract
  a. Go to "Solidity Compiler" tab
  b. Click "Compile contract..."
3. Go to "Deploy & Run Transactions" tab
4. Connect Metamask (click on Injected Web3 Provider [under Environment])
  a. Under "Environment", select "Injected Web3"
  b. Connect account(s)
5. Deploy MyToken contract
  a. Under "Contract", select "MyToken ..."
  b. Click "Deploy" button
  c. Follow MM to "Confirm" "Contract Deployment" 
6. Once deployed, expand "MY TOKEN 0X..." contract under "Deployed Contracts"
7. "safeMint" one token with select owner address, and token id 1)
  a. input the owner address, token id  e.g. "0xabcdef, 1"
  b. click the orange "safeMint" button
  c. optionally, expand "safeMint" to enter via form fields
8. Once minted, "safeTransferFrom" the token
  a. input the owner address, target address, and the token id  e.g. "0xabcdef, 0x12345, 1"
  b. click the orange "safeTransferFrom" button
  c. optionally, expand "safeTransferFrom" to enter via form fields
9. See MM activity entries

Video or repo steps provided in https://github.com/MetaMask/metamask-extension/issues/14729

## Pre-Merge Checklist

- [x] PR template is filled out
- [x] Manual testing complete & passed
- [x] **IF** this PR fixes a bug, a test that _would have_ caught the bug has been added
- [x] PR is linked to the appropriate GitHub issue
- [x] **IF** QA attention is required, "QA Board" label has been applied
- [x] PR has been added to the appropriate release Milestone
