### PR TITLE
Ignore advisory GHSA-wm7h-9275-46v2

### DIFF
--- a/.iyarc
+++ b/.iyarc
@@ -2,3 +2,4 @@
 GHSA-93q8-gq69-wqmw
 GHSA-257v-vj4p-3w2h
 GHSA-fwr7-v2mv-hh25
+GHSA-wm7h-9275-46v2


### PR DESCRIPTION
* We can safely ignore this advisory because the affected package is only used in the ipfs cli, which our use of 3box does not use, therefore the vulnerable code is not included in our build.

Edit: actually, it is also used in the filesMFS modules from ipfs, but again 3box does not use this