### PR TITLE
Fix 14802 - Prevent children error in page container

### DIFF
--- a/ui/components/ui/page-container/page-container.component.js
+++ b/ui/components/ui/page-container/page-container.component.js
@@ -74,11 +74,7 @@ export default class PageContainer extends PureComponent {
     children = children.filter(Boolean);
     const { activeTabIndex } = this.state;
 
-    if (Array.isArray(children)) {
-      children = children[activeTabIndex] || children[0];
-    }
-
-    return children.props.children;
+    return (children[activeTabIndex] || children[0]).props.children;
   }
 
   renderContent() {

--- a/ui/components/ui/page-container/page-container.component.js
+++ b/ui/components/ui/page-container/page-container.component.js
@@ -74,9 +74,11 @@ export default class PageContainer extends PureComponent {
     children = children.filter(Boolean);
     const { activeTabIndex } = this.state;
 
-    return children[activeTabIndex]
-      ? children[activeTabIndex].props.children
-      : children.props.children;
+    if (Array.isArray(children)) {
+      children = children[activeTabIndex] || children[0];
+    }
+
+    return children.props.children;
   }
 
   renderContent() {


### PR DESCRIPTION
## Explanation

This error occurs because the `activeTabIndex` is `1`; when switching to another network, we remove the first tab, and thus `children[activeTabIndex]` doesn't exist and thus bombs the extension UI.

## More Information

* Fixes [#12345](https://github.com/MetaMask/metamask-extension/issues/14802)

## Manual Testing Steps

1.  Unlock Metamask
2.  Select Mainnet Network
3.  Click Import Tokens
4.  Click Custom Token
5.  Introduce a token address (i.e. `0xB8c77482e45F1F44dE1745F52C74426C631bDD52`)
6.  Change the Network to Rinkeby -- notice the page looking correct
7.  Switch back to Mainnet -- notice the page looking correct

## Pre-Merge Checklist

- [ ] PR template is filled out
- [ ] Manual testing complete & passed
- [ ] **IF** this PR fixes a bug, a test that _would have_ caught the bug has been added
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** QA attention is required, "QA Board" label has been applied
- [ ] PR has been added to the appropriate release Milestone
