### PR TITLE
manifest.json: add https://chainid.network/chains.json to permissions

### DIFF
--- a/app/manifest/v2/_base.json
+++ b/app/manifest/v2/_base.json
@@ -66,6 +66,7 @@
     "clipboardWrite",
     "http://localhost:8545/",
     "https://*.infura.io/",
+    "https://chainid.network/chains.json",
     "https://lattice.gridplus.io/*",
     "activeTab",
     "webRequest",

--- a/app/manifest/v3/_base.json
+++ b/app/manifest/v3/_base.json
@@ -65,6 +65,7 @@
     "clipboardWrite",
     "http://localhost:8545/",
     "https://*.infura.io/",
+    "https://chainid.network/chains.json",
     "https://lattice.gridplus.io/*",
     "activeTab",
     "webRequest",


### PR DESCRIPTION
## Explanation

Currently, Firefox blocks resources from `https://chainid.network/chains.json` because we have not added permissions for the URL in our `manifest.json` file. This PR adds this specific file permission to fix the CORS request.

We should be moving relevant permissions to host_permissions for the manifest.json mv3. This will happen in a future PR. 

## More Information

* Partial Fix https://github.com/MetaMask/metamask-extension/issues/10557
  * This should reduce most of the related Sentry error count 
  * See https://sentry.io/organizations/metamask/issues/828905785/events/02bce1840a3c45419be38aceeccaf542/?project=273505&referrer=github_integration

* Related https://github.com/MetaMask/metamask-extension/pull/10310 & https://github.com/MetaMask/metamask-extension/pull/12431 where the URLs have been added

* Related Info:
  * https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#host_permissions (See "The extra privileges include:")
  * https://developer.chrome.com/docs/extensions/mv3/intro/mv3-migration/#host-permissions
  * https://developer.chrome.com/docs/extensions/mv3/declare_permissions/
  * https://developer.chrome.com/docs/extensions/mv3/xhr/#requesting-permission
  * https://developer.chrome.com/docs/extensions/mv3/match_patterns/
  * https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS/Errors
  * https://support.google.com/chrome/a/answer/9897812?hl=en (See Permission Risk whitepaper PDF)
  

## Screenshots/Screencaps

### Before

<img width="1680" alt="Screenshot 2022-06-01 at 11 54 35 AM" src="https://user-images.githubusercontent.com/20778143/171529717-4f614c11-a12a-4abd-a478-ca502cfb32ba.png">


## Manual Testing Steps

1. Open MM in FireFox
2. Open Networks dropdown
3. Click "Add Network" 
4. Observe Browser console 