### PR TITLE
Fixed eth_getTransactionCount pending to return hex

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -15,7 +15,7 @@ import {
   ethErrors,
 } from 'eth-rpc-errors';
 import { Mutex } from 'await-semaphore';
-import { stripHexPrefix } from 'ethereumjs-util';
+import { bnToHex, stripHexPrefix } from 'ethereumjs-util';
 import log from 'loglevel';
 import TrezorKeyring from 'eth-trezor-keyring';
 import LedgerBridgeKeyring from '@metamask/eth-ledger-bridge-keyring';
@@ -53,6 +53,7 @@ import {
 } from '@metamask/snap-controllers';
 ///: END:ONLY_INCLUDE_IN
 
+import { BN } from 'bn.js';
 import {
   TRANSACTION_STATUSES,
   TRANSACTION_TYPES,
@@ -3895,7 +3896,7 @@ export default class MetamaskController extends EventEmitter {
     const pendingNonce = nonceDetails.params.highestSuggested;
 
     releaseLock();
-    return pendingNonce;
+    return bnToHex(new BN(pendingNonce));
   }
 
   /**


### PR DESCRIPTION
## Explanation
`eth_getTransactionCount` had an issue where only for `"pending"` it was returning our internal nonce which is fine, but it was returning it as a number not as hex as described in the [spec](https://metamask.github.io/api-playground/api-documentation/#eth_getTransactionCount)

Fixes #5845 