### PR TITLE
Fix for: Invalid transaction envelope type: specified type "0x0" but including...requires type: "0x2"

### DIFF
--- a/app/scripts/controllers/transactions/pending-tx-tracker.js
+++ b/app/scripts/controllers/transactions/pending-tx-tracker.js
@@ -2,6 +2,7 @@ import EventEmitter from 'safe-event-emitter';
 import log from 'loglevel';
 import EthQuery from 'ethjs-query';
 import { TRANSACTION_STATUSES } from '../../../../shared/constants/transaction';
+import { ERROR_SUBMITTING } from './tx-state-manager';
 
 /**
  * Event emitter utility class for tracking the transactions as they
@@ -106,7 +107,7 @@ export default class PendingTransactionTracker extends EventEmitter {
         // encountered real error - transition to error state
         txMeta.warning = {
           error: errorMessage,
-          message: 'There was an error when resubmitting this transaction.',
+          message: ERROR_SUBMITTING,
         };
         this.emit('tx:warning', txMeta, err);
       }

--- a/app/scripts/controllers/transactions/tx-state-manager.js
+++ b/app/scripts/controllers/transactions/tx-state-manager.js
@@ -302,15 +302,12 @@ export default class TransactionStateManager extends EventEmitter {
    *
    * @param {Object} txMeta - the txMeta to update
    * @param {string} [note] - a note about the update for history
-   * @param {string} shouldNormalize - this variable is used to turn off call to normalizeAndValidateTxParams
    */
-  updateTransaction(txMeta, note, shouldNormalize = true) {
+  updateTransaction(txMeta, note) {
     // normalize and validate txParams if present
     if (txMeta.txParams) {
       try {
-        txMeta.txParams =
-          shouldNormalize &&
-          normalizeAndValidateTxParams(txMeta.txParams, false);
+        txMeta.txParams = normalizeAndValidateTxParams(txMeta.txParams, false);
       } catch (error) {
         if (txMeta.warning.message === ERROR_SUBMITTING) {
           this.setTxStatusFailed(txMeta.id, error);
@@ -658,15 +655,9 @@ export default class TransactionStateManager extends EventEmitter {
 
     txMeta.status = status;
     try {
-      // we should not call normalizeAndValidateTxParams if we're failing the transaction.
-      let shouldNormalize = true;
-      if (status === TRANSACTION_STATUSES.FAILED) {
-        shouldNormalize = false;
-      }
-      this.updateTransaction(
+      this._updateTransactionHistory(
         txMeta,
         `txStateManager: setting status to ${status}`,
-        shouldNormalize,
       );
       this.emit(`${txMeta.id}:${status}`, txId);
       this.emit(`tx:status-update`, txId, status);

--- a/app/scripts/controllers/transactions/tx-state-manager.test.js
+++ b/app/scripts/controllers/transactions/tx-state-manager.test.js
@@ -971,18 +971,14 @@ describe('TransactionStateManager', function () {
         'Invalid transaction envelope type: specified type "0x0" but including maxFeePerGas and maxPriorityFeePerGas requires type: "0x2"',
       );
 
-      // history[2] should contain 2 entries
-      assert.equal(result.history[2].length, 2);
+      assert.equal(result.history[2].length, 1);
       assert.equal(
         result.history[2][0].note,
         'txStateManager: setting status to failed',
       );
       assert.equal(result.history[2][0].op, 'replace');
-      assert.equal(result.history[2][0].path, '/txParams');
-
-      assert.equal(result.history[2][1].op, 'replace');
-      assert.equal(result.history[2][1].path, '/status');
-      assert.equal(result.history[2][1].value, 'failed');
+      assert.equal(result.history[2][0].path, '/status');
+      assert.equal(result.history[2][0].value, 'failed');
     });
 
     it('should set transaction status to failed', function () {
@@ -1020,19 +1016,14 @@ describe('TransactionStateManager', function () {
         result.history[1][0].value.message,
         'Testing tx status failed with arbitrary error',
       );
-
-      // history[2] should contain 2 entries
-      assert.equal(result.history[2].length, 2);
+      assert.equal(result.history[2].length, 1);
       assert.equal(
         result.history[2][0].note,
         'txStateManager: setting status to failed',
       );
       assert.equal(result.history[2][0].op, 'replace');
-      assert.equal(result.history[2][0].path, '/txParams');
-
-      assert.equal(result.history[2][1].op, 'replace');
-      assert.equal(result.history[2][1].path, '/status');
-      assert.equal(result.history[2][1].value, 'failed');
+      assert.equal(result.history[2][0].path, '/status');
+      assert.equal(result.history[2][0].value, 'failed');
     });
   });
 

--- a/app/scripts/controllers/transactions/tx-state-manager.test.js
+++ b/app/scripts/controllers/transactions/tx-state-manager.test.js
@@ -12,7 +12,7 @@ import {
 } from '../../../../shared/constants/network';
 import { GAS_LIMITS } from '../../../../shared/constants/gas';
 import { ORIGIN_METAMASK } from '../../../../shared/constants/app';
-import TxStateManager from './tx-state-manager';
+import TxStateManager, { ERROR_SUBMITTING } from './tx-state-manager';
 import { snapshotFromTxMeta } from './lib/tx-state-history-helpers';
 
 const VALID_ADDRESS = '0x0000000000000000000000000000000000000000';
@@ -917,6 +917,122 @@ describe('TransactionStateManager', function () {
 
       const { history } = txStateManager.getTransaction('1');
       assert.equal(history.length, 1, 'two history items (initial + diff)');
+    });
+
+    it('should set tx status to failed if updating after error submitting', function () {
+      const txMeta = {
+        id: '1',
+        status: TRANSACTION_STATUSES.UNAPPROVED,
+        metamaskNetworkId: currentNetworkId,
+        txParams: {
+          from: VALID_ADDRESS_TWO,
+          to: VALID_ADDRESS,
+          gasLimit: '0x5028',
+          maxFeePerGas: '0x2540be400',
+          maxPriorityFeePerGas: '0x3b9aca00',
+        },
+      };
+
+      txStateManager.addTransaction(txMeta);
+      const { history } = txStateManager.getTransaction('1');
+      assert.equal(history.length, 1);
+
+      txMeta.txParams.type = '0x0';
+      txMeta.warning = {
+        message: ERROR_SUBMITTING,
+        error: 'Testing tx status failed with arbitrary error',
+      };
+
+      // should result in additional 2 history entries
+      txStateManager.updateTransaction(txMeta);
+
+      const result = txStateManager.getTransaction('1');
+
+      assert.equal(result.history.length, 3);
+
+      // history[1] should contain 3 entries
+      assert.equal(result.history[1].length, 3);
+      assert.equal(
+        result.history[1][0].note,
+        'transactions:tx-state-manager#fail - add error',
+      );
+      assert.equal(result.history[1][0].op, 'add');
+      assert.equal(result.history[1][0].path, '/txParams/type');
+      assert.equal(result.history[1][0].value, '0x0');
+
+      assert.equal(result.history[1][1].op, 'add');
+      assert.equal(result.history[1][1].path, '/warning');
+      assert.equal(result.history[1][1].value.message, ERROR_SUBMITTING);
+
+      assert.equal(result.history[1][2].op, 'add');
+      assert.equal(result.history[1][2].path, '/err');
+      assert.equal(
+        result.history[1][2].value.message,
+        'Invalid transaction envelope type: specified type "0x0" but including maxFeePerGas and maxPriorityFeePerGas requires type: "0x2"',
+      );
+
+      // history[2] should contain 2 entries
+      assert.equal(result.history[2].length, 2);
+      assert.equal(
+        result.history[2][0].note,
+        'txStateManager: setting status to failed',
+      );
+      assert.equal(result.history[2][0].op, 'replace');
+      assert.equal(result.history[2][0].path, '/txParams');
+
+      assert.equal(result.history[2][1].op, 'replace');
+      assert.equal(result.history[2][1].path, '/status');
+      assert.equal(result.history[2][1].value, 'failed');
+    });
+
+    it('should set transaction status to failed', function () {
+      const txMeta = {
+        id: '1',
+        status: TRANSACTION_STATUSES.UNAPPROVED,
+        metamaskNetworkId: currentNetworkId,
+        txParams: {
+          from: VALID_ADDRESS_TWO,
+          to: VALID_ADDRESS,
+          gasPrice: '0x01',
+        },
+      };
+
+      txStateManager.addTransaction(txMeta);
+      const { history } = txStateManager.getTransaction('1');
+      assert.equal(history.length, 1);
+
+      // should result in additional 2 history entries
+      txStateManager.setTxStatusFailed(
+        txMeta.id,
+        new Error('Testing tx status failed with arbitrary error'),
+      );
+
+      const result = txStateManager.getTransaction('1');
+      assert.equal(result.history.length, 3);
+
+      assert.equal(
+        result.history[1][0].note,
+        'transactions:tx-state-manager#fail - add error',
+      );
+      assert.equal(result.history[1][0].op, 'add');
+      assert.equal(result.history[1][0].path, '/err');
+      assert.equal(
+        result.history[1][0].value.message,
+        'Testing tx status failed with arbitrary error',
+      );
+
+      // history[2] should contain 2 entries
+      assert.equal(result.history[2].length, 2);
+      assert.equal(
+        result.history[2][0].note,
+        'txStateManager: setting status to failed',
+      );
+      assert.equal(result.history[2][0].op, 'replace');
+      assert.equal(result.history[2][0].path, '/txParams');
+
+      assert.equal(result.history[2][1].op, 'replace');
+      assert.equal(result.history[2][1].path, '/status');
+      assert.equal(result.history[2][1].value, 'failed');
     });
   });
 


### PR DESCRIPTION
## Explanation
This PR fixes sentry issue #14761 

# Description of the problem
We now have validations in place that checks that transaction params are "proper" before adding them to the pending tx list. But for some clients (mostly edge browsers), there were some transactions in pending without "proper" tx params but these clients have the new validations. Best guess is that they have these transactions in the pending list before updating to the latest client with validations.

Extension `app/scripts/controllers/transactions/pending-tx-tracker.js` will then try to re-submit these transactions which will fail validations then try again which will fail and so on and so forth, in my test, I was able to retry about 2K times before unit tests timed out.

The fix for this is in multiple layers

1. If we try to update a transaction (update calls `normalizeAndValidateTxParams`), and there's an error, we just don't throw the error, we first check if the txMeta warning message is `There was an error when resubmitting this transaction.` which means the transaction has been sent for resubmission and failed. In this case, we set transaction status to failed.

2. `setTxStatusFailed` calls `updateTransaction`, this will then call `normalizeAndValidateTxParams` and fail and we are stuck in an endless loop again. So we need to refactor out the parts really needed for update (`_updateTransactionHistory`). so `setTxStatusFailed` will call `_updateTransactionHistory` instead.

3. `setTxStatusFailed` also calls `_setTransactionStatus` which also calls `updateTransaction`. Again we are stuck in an endless loop, so we call our refactored `_updateTransactionHistory` from `_setTransactionStatus` instead.

## More Information

"proper" txParams
```
 {
            from: '0xe04ab39684a24d8d4124b114f3bd6fbeb779caca',
            to: '0x0c54FcCd2e384b4BB6f2E405Bf5Cbc15a017AaFb',
            value: '0x0',
            gasLimit: '0x5028',
            maxFeePerGas: '0x2540be400',
            maxPriorityFeePerGas: '0x3b9aca00',
          },
```

"failing" txParams
```
 {
            from: '0xe04ab39684a24d8d4124b114f3bd6fbeb779caca',
            to: '0x0c54FcCd2e384b4BB6f2E405Bf5Cbc15a017AaFb',
            value: '0x0',
            gasLimit: '0x5028',
            maxFeePerGas: '0x2540be400',
            maxPriorityFeePerGas: '0x3b9aca00',
            type: '0x0',
 },
```

Fixes #14761

I couldn't replicate this issue because there's currently no way to get a tx with an "improper" tx params into state. But I have included unit tests to cover this scenario.

## Pre-Merge Checklist

- [ ] PR template is filled out
- [ ] **IF** this PR fixes a bug, a test that _would have_ caught the bug has been added
- [ ] PR is linked to the appropriate GitHub issue
- [ ] PR has been added to the appropriate release Milestone

### + If there are functional changes:

- [ ] Manual testing complete & passed
- [ ] "Extension QA Board" label has been applied
