### PR TITLE
Update `protobufjs` and remove obsolete advisory exclusion

### DIFF
--- a/.iyarc
+++ b/.iyarc
@@ -1,5 +1,4 @@
 # improved-yarn-audit advisory exclusions
 GHSA-93q8-gq69-wqmw
 GHSA-257v-vj4p-3w2h
-GHSA-fwr7-v2mv-hh25
 GHSA-wm7h-9275-46v2

--- a/yarn.lock
+++ b/yarn.lock
@@ -21882,9 +21882,9 @@ proto-list@~1.2.1:
   integrity sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=
 
 protobufjs@^6.11.2:
-  version "6.11.2"
-  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-6.11.2.tgz#de39fabd4ed32beaa08e9bb1e30d08544c1edf8b"
-  integrity sha512-4BQJoPooKJl2G9j3XftkIXjoC9C0Av2NOrWmbLWT1vH32GcSUHjM0Arra6UfTsVyfMAuFzaLucXn1sadxJydAw==
+  version "6.11.3"
+  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-6.11.3.tgz#637a527205a35caa4f3e2a9a4a13ddffe0e7af74"
+  integrity sha512-xL96WDdCZYdU7Slin569tFX712BxsxslWwAfAhCYjQKGTq7dAU91Lomy6nLLhh/dyGhk/YH4TwTSRxTzhuHyZg==
   dependencies:
     "@protobufjs/aspromise" "^1.1.2"
     "@protobufjs/base64" "^1.1.2"


### PR DESCRIPTION
The package `protobufjs` has been updated from v6.11.2 to v6.11.3. This addresses a security advisory.

The advisory `https://github.com/advisories/GHSA-fwr7-v2mv-hh25` has also been removed from our list of ignored advisories.

These two changes should fix the `test-deps-audit` failures.