### PR TITLE
build - add treeshaking

### DIFF
--- a/development/build/scripts.js
+++ b/development/build/scripts.js
@@ -697,11 +697,16 @@ function setupBundlerDefaults(
     transform: [
       // Remove code that should be excluded from builds of the current type
       createRemoveFencedCodeTransform(buildType, shouldLintFenceFiles),
-      // Transpile top-level code
+      // Transpile top-level code (will be run first, before common-shake)
       [
         babelify,
         // Run TypeScript files through Babel
         { extensions },
+      ],
+      // run babelify on all files (will be run last, after common-shake)
+      [
+        babelify,
+        { global: true }
       ],
       // Inline `fs.readFileSync` files
       brfs,

--- a/development/build/scripts.js
+++ b/development/build/scripts.js
@@ -796,7 +796,19 @@ function setupMinification(buildConfiguration) {
             },
             ...minifyOpts,
           };
-          const res = await terser.minify(input, opts);
+          let res
+          try {
+            res = await terser.minify(input, opts);
+          } catch (err) {
+            const { codeFrameColumns } = require('@babel/code-frame')
+            // codeFrameColumns
+            const location = { start: { line: err.line, column: err.col } };
+            const result = codeFrameColumns(file.contents.toString(), location, {
+              highlightCode: true,
+            })
+            console.log(result)
+            throw err
+          }
           file.contents = Buffer.from(res.code);
           applySourceMap(file, res.map);
           return file;

--- a/development/build/scripts.js
+++ b/development/build/scripts.js
@@ -24,6 +24,7 @@ const Sqrl = require('squirrelly');
 const lavapack = require('@lavamoat/lavapack');
 const lavamoatBrowserify = require('lavamoat-browserify');
 const terser = require('terser');
+const commonShake = require('common-shakeify')
 
 const bifyModuleGroups = require('bify-module-groups');
 
@@ -704,6 +705,12 @@ function setupBundlerDefaults(
       ],
       // Inline `fs.readFileSync` files
       brfs,
+    ],
+    plugin: [
+      [
+        commonShake,
+        { verbose: true },
+      ],
     ],
     // Look for TypeScript files when walking the dependency tree
     extensions,

--- a/package.json
+++ b/package.json
@@ -282,6 +282,7 @@
     "browserify": "^16.5.1",
     "chalk": "^3.0.0",
     "chromedriver": "^101.0.0",
+    "common-shakeify": "^0.6.2",
     "concurrently": "^5.2.0",
     "copy-webpack-plugin": "^6.0.3",
     "cross-spawn": "^7.0.3",

--- a/patches/common-shakeify+0.6.2.patch
+++ b/patches/common-shakeify+0.6.2.patch
@@ -1,5 +1,5 @@
 diff --git a/node_modules/common-shakeify/index.js b/node_modules/common-shakeify/index.js
-index 1e86067..a5640e6 100644
+index 1e86067..c4fcee3 100644
 --- a/node_modules/common-shakeify/index.js
 +++ b/node_modules/common-shakeify/index.js
 @@ -1,5 +1,13 @@
@@ -17,3 +17,12 @@ index 1e86067..a5640e6 100644
  const Analyzer = require('@goto-bus-stop/common-shake').Analyzer
  const transformAst = require('transform-ast')
  const wrapComment = require('wrap-comment')
+@@ -82,7 +90,7 @@ function createStream (opts) {
+     let ast
+     const string = transformAst(source, {
+       locations: true,
+-      ecmaVersion: 9,
++      // ecmaVersion: 9,
+       inputFilename: row.file
+     }, (node) => {
+       if (node.type === 'Program') ast = node

--- a/patches/common-shakeify+0.6.2.patch
+++ b/patches/common-shakeify+0.6.2.patch
@@ -1,23 +1,62 @@
 diff --git a/node_modules/common-shakeify/index.js b/node_modules/common-shakeify/index.js
-index 1e86067..c4fcee3 100644
+index 1e86067..6a7a835 100644
 --- a/node_modules/common-shakeify/index.js
 +++ b/node_modules/common-shakeify/index.js
-@@ -1,5 +1,13 @@
- 'use strict'
--const relative = require('path').relative
-+const _relative = require('path').relative
-+const relative = (...args) => {
-+  // console.warn('relative', args)
-+  try {
-+    return _relative(...args)
-+  } catch (err) {
-+    return `relative-failed:args=${args}`
-+  }
-+}
- const Analyzer = require('@goto-bus-stop/common-shake').Analyzer
- const transformAst = require('transform-ast')
- const wrapComment = require('wrap-comment')
-@@ -82,7 +90,7 @@ function createStream (opts) {
+@@ -11,13 +11,15 @@ module.exports = function commonShake (b, opts) {
+     throw new Error('common-shakeify: must be used as a plugin, not a transform')
+   }
+ 
++  const rows = new Map()
+   const basedir = b._options.basedir || process.cwd()
+   const seen = {}
+   opts = Object.assign({
+     verbose: false,
+     onExportDelete (path, name) {
+       if (opts.verbose || opts.v) {
+-        console.warn('common-shake: removed', `\`${name}\``, 'in', relative(basedir, path))
++        const file = rows.get(path).file
++        console.warn('common-shake: removed', `\`${name}\``, 'in', relative(basedir, file))
+       }
+     },
+     onModuleBailout (resource, reasons) {
+@@ -27,7 +29,8 @@ module.exports = function commonShake (b, opts) {
+           seen[resource.resource + reason.reason] = true
+           const loc = reason.loc.start
+           const source = reason.source || resource.resource
+-          console.warn('common-shake: bailed out: ', reason.reason, 'in', `${relative(basedir, source)}:${loc.line}:${loc.column}`)
++          const file = rows.get(source).file
++          console.warn('common-shake: bailed out: ', reason.reason, 'in', `${relative(basedir, file)}:${loc.line}:${loc.column}`)
+         })
+       }
+     },
+@@ -35,7 +38,8 @@ module.exports = function commonShake (b, opts) {
+       if (opts.verbose || opts.v) {
+         reasons.forEach((reason) => {
+           const loc = reason.loc.start
+-          console.warn('common-shake: GLOBAL BAILOUT:', reason.reason, 'in', `${relative(basedir, reason.source)}:${loc.line}:${loc.column}`)
++          const file = rows.get(reason.source).file
++          console.warn('common-shake: GLOBAL BAILOUT:', reason.reason, 'in', `${relative(basedir, file)}:${loc.line}:${loc.column}`)
+         })
+       }
+     }
+@@ -47,14 +51,13 @@ module.exports = function commonShake (b, opts) {
+   addHooks()
+   b.on('reset', addHooks)
+   function addHooks () {
+-    b.pipeline.get('label').unshift(createStream(opts))
++    b.pipeline.get('label').unshift(createStream(opts, rows))
+   }
+ }
+ 
+-function createStream (opts) {
++function createStream (opts, rows) {
+   const analyzer = new Analyzer()
+ 
+-  const rows = new Map()
+   const strings = new Map()
+   const duplicates = new Map()
+ 
+@@ -82,11 +85,12 @@ function createStream (opts) {
      let ast
      const string = transformAst(source, {
        locations: true,
@@ -26,3 +65,19 @@ index 1e86067..c4fcee3 100644
        inputFilename: row.file
      }, (node) => {
        if (node.type === 'Program') ast = node
+     })
++
+     analyzer.run(ast, index)
+ 
+     const deps = opts.fullPaths ? row.deps : row.indexDeps
+@@ -107,7 +111,9 @@ function createStream (opts) {
+   }
+ 
+   function onend (next) {
+-    if (!analyzer.isSuccess()) {
++    // ignore global bailouts
++    // if (!analyzer.isSuccess()) {
++    if (false) {
+       opts.onGlobalBailout(analyzer.bailouts)
+ 
+       rows.forEach((row) => {

--- a/patches/common-shakeify+0.6.2.patch
+++ b/patches/common-shakeify+0.6.2.patch
@@ -1,0 +1,19 @@
+diff --git a/node_modules/common-shakeify/index.js b/node_modules/common-shakeify/index.js
+index 1e86067..a5640e6 100644
+--- a/node_modules/common-shakeify/index.js
++++ b/node_modules/common-shakeify/index.js
+@@ -1,5 +1,13 @@
+ 'use strict'
+-const relative = require('path').relative
++const _relative = require('path').relative
++const relative = (...args) => {
++  // console.warn('relative', args)
++  try {
++    return _relative(...args)
++  } catch (err) {
++    return `relative-failed:args=${args}`
++  }
++}
+ const Analyzer = require('@goto-bus-stop/common-shake').Analyzer
+ const transformAst = require('transform-ast')
+ const wrapComment = require('wrap-comment')

--- a/patches/common-shakeify+0.6.2.patch
+++ b/patches/common-shakeify+0.6.2.patch
@@ -1,8 +1,8 @@
 diff --git a/node_modules/common-shakeify/index.js b/node_modules/common-shakeify/index.js
-index 1e86067..6a7a835 100644
+index 1e86067..851d5ce 100644
 --- a/node_modules/common-shakeify/index.js
 +++ b/node_modules/common-shakeify/index.js
-@@ -11,13 +11,15 @@ module.exports = function commonShake (b, opts) {
+@@ -11,12 +11,14 @@ module.exports = function commonShake (b, opts) {
      throw new Error('common-shakeify: must be used as a plugin, not a transform')
    }
  
@@ -13,12 +13,10 @@ index 1e86067..6a7a835 100644
      verbose: false,
      onExportDelete (path, name) {
        if (opts.verbose || opts.v) {
--        console.warn('common-shake: removed', `\`${name}\``, 'in', relative(basedir, path))
-+        const file = rows.get(path).file
-+        console.warn('common-shake: removed', `\`${name}\``, 'in', relative(basedir, file))
++        console.log('onExportsDelete', path)
+         console.warn('common-shake: removed', `\`${name}\``, 'in', relative(basedir, path))
        }
      },
-     onModuleBailout (resource, reasons) {
 @@ -27,7 +29,8 @@ module.exports = function commonShake (b, opts) {
            seen[resource.resource + reason.reason] = true
            const loc = reason.loc.start
@@ -81,3 +79,12 @@ index 1e86067..6a7a835 100644
        opts.onGlobalBailout(analyzer.bailouts)
  
        rows.forEach((row) => {
+@@ -201,7 +207,7 @@ function createStream (opts) {
+       // eg in `exports.a = [0]` the `[0]` could continue a previous statement if that
+       // did not have a semicolon. By putting `void ` in front we force a new statement.
+       else if (node.parent.type === 'ExpressionStatement') {
+-        prefix += 'void '
++        prefix += 'void 0, '
+       }
+ 
+       // Acorn silently strips parens, and node.right.start might be after one

--- a/yarn.lock
+++ b/yarn.lock
@@ -1843,6 +1843,15 @@
   resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-free/-/fontawesome-free-5.13.0.tgz#fcb113d1aca4b471b709e8c9c168674fbd6e06d9"
   integrity sha512-xKOeQEl5O47GPZYIMToj6uuA2syyFlq9EMSl2ui0uytjY9xbe8XS0pexNWmxrdcCyNGyDmLyYw5FtKsalBUeOg==
 
+"@goto-bus-stop/common-shake@^2.2.0":
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/@goto-bus-stop/common-shake/-/common-shake-2.4.0.tgz#7b29b093ed10d4075c061bf48905c02eb75d643c"
+  integrity sha512-LO+7v+UbxE3IyAS4Suf/KYB7Zq9DEIHibwDe6Wph4apNEfDyyxP7BSxzRS/Qa9lUH5gsm9eL9nF8EE1E0/nQkQ==
+  dependencies:
+    acorn-walk "^7.0.0"
+    debug "^3.2.6"
+    escope "^3.6.0"
+
 "@graphql-tools/schema@^7.1.5":
   version "7.1.5"
   resolved "https://registry.yarnpkg.com/@graphql-tools/schema/-/schema-7.1.5.tgz#07b24e52b182e736a6b77c829fc48b84d89aa711"
@@ -5699,6 +5708,11 @@ ansi-regex@^5.0.0, ansi-regex@^5.0.1:
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
   integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
 
+ansi-styles@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
+  integrity sha512-kmCevFghRiWM7HB5zTPULl4r9bVFSWjz62MhqizDGUrq2NWuNMQyuv4tHHoKJHs69M/MF64lEcHdYIocrdWQYA==
+
 ansi-styles@^3.2.0, ansi-styles@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.1.tgz#41fbb20243e50b12be0f04b8dedbf07520ce841d"
@@ -7793,6 +7807,17 @@ chalk@4.1.2, chalk@^4.0.0, chalk@^4.1.0, chalk@^4.1.1:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
+chalk@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
+  integrity sha512-U3lRVLMSlsCfjqYPbLyVv11M9CPW4I728d6TCKMAOJueEeB9/8o+eSsMnxPJD+Q+K909sdESg7C+tIkoH6on1A==
+  dependencies:
+    ansi-styles "^2.2.1"
+    escape-string-regexp "^1.0.2"
+    has-ansi "^2.0.0"
+    strip-ansi "^3.0.0"
+    supports-color "^2.0.0"
+
 chalk@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-3.0.0.tgz#3f73c2bf526591f574cc492c51e2456349f844e4"
@@ -8374,6 +8399,17 @@ comment-parser@1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/comment-parser/-/comment-parser-1.2.4.tgz#489f3ee55dfd184a6e4bffb31baba284453cb760"
   integrity sha512-pm0b+qv+CkWNriSTMsfnjChF9kH0kxz55y44Wo5le9qLxMj5xDQAaEd9ZN1ovSuk9CsrncWaFwgpOMg7ClJwkw==
+
+common-shakeify@^0.6.2:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/common-shakeify/-/common-shakeify-0.6.2.tgz#4663fe5ccda665d11ee4c77368b079a7df033d29"
+  integrity sha512-vxlXr26fqxm8ZJ0jh8MlvpeN6IbyUKqsVmgb4rAjDM/0f4nKebiHaAXpF/Mm86W9ENR5iSI7UOnUTylpVyplUA==
+  dependencies:
+    "@goto-bus-stop/common-shake" "^2.2.0"
+    convert-source-map "^1.5.1"
+    through2 "^2.0.3"
+    transform-ast "^2.4.3"
+    wrap-comment "^1.0.1"
 
 common-tags@1.8.2, common-tags@^1.8.0:
   version "1.8.2"
@@ -10509,7 +10545,7 @@ es6-iterator@2.0.3, es6-iterator@^2.0.1, es6-iterator@~2.0.1, es6-iterator@~2.0.
     es5-ext "^0.10.35"
     es6-symbol "^3.1.1"
 
-es6-map@^0.1.5:
+es6-map@^0.1.3, es6-map@^0.1.5:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/es6-map/-/es6-map-0.1.5.tgz#9136e0503dcc06a301690f0bb14ff4e364e949f0"
   integrity sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=
@@ -10613,6 +10649,16 @@ escodegen@^2.0.0:
     optionator "^0.8.1"
   optionalDependencies:
     source-map "~0.6.1"
+
+escope@^3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/escope/-/escope-3.6.0.tgz#e01975e812781a163a6dadfdd80398dc64c889c3"
+  integrity sha512-75IUQsusDdalQEW/G/2esa87J7raqdJF+Ca0/Xm5C3Q58Nr4yVYjZGp/P1+2xiEVgXRrA39dpRb8LcshajbqDQ==
+  dependencies:
+    es6-map "^0.1.3"
+    es6-weak-map "^2.0.1"
+    esrecurse "^4.1.0"
+    estraverse "^4.1.1"
 
 eslint-config-prettier@^8.1.0:
   version "8.1.0"
@@ -13633,6 +13679,13 @@ hard-rejection@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/hard-rejection/-/hard-rejection-2.1.0.tgz#1c6eda5c1685c63942766d79bb40ae773cecd883"
   integrity sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA==
+
+has-ansi@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/has-ansi/-/has-ansi-2.0.0.tgz#34f5049ce1ecdf2b0649af3ef24e45ed35416d91"
+  integrity sha512-C8vBJ8DwUCx19vhm7urhTuUsr4/IyP6l4VzNQDv+ryHQObW3TTTp9yB68WpYgRe2bbaGuZ/se74IqFeVnMnLZg==
+  dependencies:
+    ansi-regex "^2.0.0"
 
 has-bigints@^1.0.0:
   version "1.0.1"
@@ -18194,6 +18247,13 @@ magic-string@0.25.1:
   dependencies:
     sourcemap-codec "^1.4.1"
 
+magic-string@^0.23.2:
+  version "0.23.2"
+  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.23.2.tgz#204d7c3ea36c7d940209fcc54c39b9f243f13369"
+  integrity sha512-oIUZaAxbcxYIp4AyLafV6OVKoB3YouZs0UTCJ8mOKBHNyJgGDaMJ4TgA+VylJh6fx7EQCC52XkbURxxG9IoJXA==
+  dependencies:
+    sourcemap-codec "^1.4.1"
+
 magic-string@^0.25.7:
   version "0.25.7"
   resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.25.7.tgz#3f497d6fd34c669c6798dcb821f2ef31f5445051"
@@ -18739,8 +18799,6 @@ minimatch@^3.0.2, minimatch@^3.0.4, minimatch@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"
   integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
-  dependencies:
-    brace-expansion "^1.1.7"
 
 minimatch@^5.0.1:
   version "5.0.1"
@@ -19280,10 +19338,27 @@ mute-stream@^0.0.8:
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.8.tgz#1630c42b2251ff81e2a283de96a5497ea92e5e0d"
   integrity sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==
 
+mutexify@^1.1.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/mutexify/-/mutexify-1.4.0.tgz#b7f4ac0273c81824b840887c6a6e0bfab14bbe94"
+  integrity sha512-pbYSsOrSB/AKN5h/WzzLRMFgZhClWccf2XIB4RSMC8JbquiB0e0/SH5AIfdQMdyHmYtv4seU7yV/TvAwPLJ1Yg==
+  dependencies:
+    queue-tick "^1.0.0"
+
 nan@^2.11.1, nan@^2.12.1, nan@^2.13.2, nan@^2.14.0:
   version "2.15.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.15.0.tgz#3f34a473ff18e15c1b5626b62903b5ad6e665fee"
   integrity sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ==
+
+nanobench@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/nanobench/-/nanobench-2.1.1.tgz#c2f23fcce116d50b4998b1954ba114674c137269"
+  integrity sha512-z+Vv7zElcjN+OpzAxAquUayFLGK3JI/ubCl0Oh64YQqsTGG09CGqieJVQw4ui8huDnnAgrvTv93qi5UaOoNj8A==
+  dependencies:
+    browser-process-hrtime "^0.1.2"
+    chalk "^1.1.3"
+    mutexify "^1.1.0"
+    pretty-hrtime "^1.0.2"
 
 nanoid@^2.0.0, nanoid@^2.1.6:
   version "2.1.11"
@@ -21691,7 +21766,7 @@ pretty-format@^26.0.0, pretty-format@^26.6.2:
     ansi-styles "^4.0.0"
     react-is "^17.0.1"
 
-pretty-hrtime@^1.0.0, pretty-hrtime@^1.0.3:
+pretty-hrtime@^1.0.0, pretty-hrtime@^1.0.2, pretty-hrtime@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz#b7e3ea42435a4c9b2759d99e0f201eb195802ee1"
   integrity sha1-t+PqQkNaTJsnWdmeDyAesZWALuE=
@@ -22311,6 +22386,11 @@ queue-microtask@^1.2.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/queue-microtask/-/queue-microtask-1.2.3.tgz#4929228bbc724dfac43e0efb058caf7b6cfb6243"
   integrity sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==
+
+queue-tick@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/queue-tick/-/queue-tick-1.0.0.tgz#011104793a3309ae86bfeddd54e251dc94a36725"
+  integrity sha512-ULWhjjE8BmiICGn3G8+1L9wFpERNxkf8ysxkAer4+TFdRefDaXOCV5m92aMB9FtBVmn/8sETXLXY6BfW7hyaWQ==
 
 queue@6.0.2:
   version "6.0.2"
@@ -25554,6 +25634,11 @@ supports-color@6.0.0:
   dependencies:
     has-flag "^3.0.0"
 
+supports-color@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
+  integrity sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=
+
 supports-color@^5.3.0, supports-color@^5.4.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
@@ -26174,6 +26259,19 @@ tr46@~0.0.3:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
   integrity sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=
+
+transform-ast@^2.4.3:
+  version "2.4.4"
+  resolved "https://registry.yarnpkg.com/transform-ast/-/transform-ast-2.4.4.tgz#bebf494e2e73f024746f76348bc86a5992851d00"
+  integrity sha512-AxjeZAcIOUO2lev2GDe3/xZ1Q0cVGjIMk5IsriTy8zbWlsEnjeB025AhkhBJHoy997mXpLd4R+kRbvnnQVuQHQ==
+  dependencies:
+    acorn-node "^1.3.0"
+    convert-source-map "^1.5.1"
+    dash-ast "^1.0.0"
+    is-buffer "^2.0.0"
+    magic-string "^0.23.2"
+    merge-source-map "1.0.4"
+    nanobench "^2.1.1"
 
 tree-kill@^1.2.2:
   version "1.2.2"
@@ -27681,6 +27779,11 @@ wrap-ansi@^7.0.0:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"
     strip-ansi "^6.0.0"
+
+wrap-comment@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/wrap-comment/-/wrap-comment-1.0.1.tgz#941bb1400b9b590bc007599e79cacc0bb3ea62f3"
+  integrity sha512-APccrMwl/ont0RHFTXNAQfM647duYYEfs6cngrIyTByTI0xbWnDnPSptFZhS68L4WCjt2ZxuhCFwuY6Pe88KZQ==
 
 wrappy@1:
   version "1.0.2"


### PR DESCRIPTION
adds treeshaking

this sucks for a number of reasons:
- adds 2 full-graph string->ast->string steps (common-shakeify, babelify (again))
- doesnt remove unused parts of the dep graph
- does not include an improvement made to common-shake https://github.com/browserify/common-shakeify/pull/31