### PR TITLE
@metamask/providers@9.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
     "@metamask/metamask-eth-abis": "^3.0.0",
     "@metamask/obs-store": "^5.0.0",
     "@metamask/post-message-stream": "^4.0.0",
-    "@metamask/providers": "^8.1.1",
+    "@metamask/providers": "^9.0.0",
     "@metamask/rpc-methods": "^0.15.0",
     "@metamask/slip44": "^2.1.0",
     "@metamask/smart-transactions-controller": "^2.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3043,6 +3043,24 @@
     pump "^3.0.0"
     webextension-polyfill-ts "^0.25.0"
 
+"@metamask/providers@^9.0.0":
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/@metamask/providers/-/providers-9.0.0.tgz#644684f9eceb952138e80afb9103c7e39d8350fe"
+  integrity sha512-9qUkaFafZUROK0CAUBqjsut+7mqKOXFhBCpAhAPVRBqj5TfUTdPI4t8S7GYzPVaDbC7M6kH/YLNCgcfaFWAS+w==
+  dependencies:
+    "@metamask/object-multiplex" "^1.1.0"
+    "@metamask/safe-event-emitter" "^2.0.0"
+    "@types/chrome" "^0.0.136"
+    detect-browser "^5.2.0"
+    eth-rpc-errors "^4.0.2"
+    extension-port-stream "^2.0.1"
+    fast-deep-equal "^2.0.1"
+    is-stream "^2.0.0"
+    json-rpc-engine "^6.1.0"
+    json-rpc-middleware-stream "^3.0.0"
+    pump "^3.0.0"
+    webextension-polyfill-ts "^0.25.0"
+
 "@metamask/rpc-methods@^0.15.0":
   version "0.15.0"
   resolved "https://registry.yarnpkg.com/@metamask/rpc-methods/-/rpc-methods-0.15.0.tgz#3bdfbf620d1ab328ff4d26f6a9c293136a50e51e"


### PR DESCRIPTION
Bump `@metamask/providers` to `9.0.0`. Should be completely non-breaking for our purposes.