### PR TITLE
Changed accounts fuzzy search threshhold to match all

### DIFF
--- a/ui/components/app/account-menu/account-menu.component.js
+++ b/ui/components/app/account-menu/account-menu.component.js
@@ -100,11 +100,12 @@ export default class AccountMenu extends Component {
   };
 
   addressFuse = new Fuse([], {
-    threshold: 0.45,
+    threshold: 0.55,
     location: 0,
     distance: 100,
     maxPatternLength: 32,
     minMatchCharLength: 1,
+    ignoreFieldNorm: true,
     keys: [
       { name: 'name', weight: 0.5 },
       { name: 'address', weight: 0.5 },

--- a/ui/components/app/account-menu/account-menu.component.js
+++ b/ui/components/app/account-menu/account-menu.component.js
@@ -132,7 +132,7 @@ export default class AccountMenu extends Component {
 
   renderAccountsSearch() {
     const handleChange = (e) => {
-      const val = e.target.value.length > 1 ? e.target.value : "";
+      const val = e.target.value.length > 1 ? e.target.value : '';
       this.setSearchQuery(val);
     };
 

--- a/ui/components/app/account-menu/account-menu.component.js
+++ b/ui/components/app/account-menu/account-menu.component.js
@@ -150,8 +150,7 @@ export default class AccountMenu extends Component {
         id="search-accounts"
         placeholder={this.context.t('searchAccounts')}
         type="text"
-        value={this.state.searchQuery}
-        onChange={(e) => this.setSearchQuery(e.target.value)}
+        onChange={(e) => e.target.value.length > 1 ? this.setSearchQuery(e.target.value) : this.setSearchQuery("")}
         startAdornment={inputAdornment}
         fullWidth
         theme="material-white-padded"

--- a/ui/components/app/account-menu/account-menu.component.js
+++ b/ui/components/app/account-menu/account-menu.component.js
@@ -131,6 +131,11 @@ export default class AccountMenu extends Component {
   }
 
   renderAccountsSearch() {
+    const handleChange = (e) => {
+      const val = e.target.value.length > 1 ? e.target.value : "";
+      this.setSearchQuery(val);
+    };
+
     const inputAdornment = (
       <InputAdornment
         position="start"
@@ -150,7 +155,7 @@ export default class AccountMenu extends Component {
         id="search-accounts"
         placeholder={this.context.t('searchAccounts')}
         type="text"
-        onChange={(e) => e.target.value.length > 1 ? this.setSearchQuery(e.target.value) : this.setSearchQuery("")}
+        onChange={handleChange}
         startAdornment={inputAdornment}
         fullWidth
         theme="material-white-padded"


### PR DESCRIPTION
## Explanation

This PR is to resolve https://github.com/MetaMask/metamask-extension/issues/14899

I've taken a look at [the fuzzy search options provided to fuse](https://fusejs.io/api/options.html) vs. [what is being used in the extension](https://github.com/MetaMask/metamask-extension/blob/b599035a12010e31b85c3733fb573ba05b840b3c/ui/components/app/account-menu/account-menu.component.js#L102), and tried a couple variations. 

A more detailed explanation of the way fuse ranks searches can be found [here](https://fusejs.io/concepts/scoring-theory.html#scoring-theory)

From what I can tell, this issue creeps up as a result of having the search scoring weighted across 2 fields. When you add a 3rd character, you get more search matches which are above the threshold provided. Secondly, it's a little extra odd because the fuse lib normalizes the scores based on the length of the searched strings. In our case, this means that if you use the default title or anything shorter than the address, matches for title end up scored higher. 

I've adjusted the settings slightly, and tested against some addresses of my own. @seaona if you could please check it against your example and let me know if its better for you, that would be greatly appreciated :).