### PR TITLE
MetaMetrics: fix 'Metrics Opt Out' trackEvent in onboarding-flow/metametrics component

### DIFF
--- a/ui/pages/onboarding-flow/metametrics/metametrics.js
+++ b/ui/pages/onboarding-flow/metametrics/metametrics.js
@@ -43,8 +43,10 @@ export default function OnboardingMetametrics() {
   const onConfirm = async () => {
     const [, metaMetricsId] = await dispatch(setParticipateInMetaMetrics(true));
 
+    const isInitiallyNotParticipating = !participateInMetaMetrics;
+
     try {
-      if (!participateInMetaMetrics) {
+      if (isInitiallyNotParticipating) {
         trackEvent(
           {
             category: EVENT.CATEGORIES.ONBOARDING,
@@ -83,8 +85,11 @@ export default function OnboardingMetametrics() {
   const onCancel = async () => {
     await dispatch(setParticipateInMetaMetrics(false));
 
+    const isInitiallyParticipatingOrNotSet =
+      participateInMetaMetrics === null || participateInMetaMetrics;
+
     try {
-      if (!participateInMetaMetrics) {
+      if (isInitiallyParticipatingOrNotSet) {
         trackEvent(
           {
             category: EVENT.CATEGORIES.ONBOARDING,


### PR DESCRIPTION
## Explanation

In an [internal Slack thread](https://consensys.slack.com/archives/G01FXS64DFA/p1654656946247669), our fellow colleague, John, questioned the `!participiateInMetaMetrics` logic here. 

The name of the variable confused us with its purpose, so I have updated the variable name in this PR. I also believe that the `onCancel` logic to call `trackEvent` has a bug since it is supposed to mirror the logic in `ui/pages/first-time-flow/metametrics-opt-in/metametrics-opt-in.component.js` (explained in these PR comments: https://github.com/MetaMask/metamask-extension/pull/12282#discussion_r728494962 and https://github.com/MetaMask/metamask-extension/pull/12282#discussion_r726543450). `onCancel` now checks for `participatedInMetaMetrics === true` instead of `participatedInMetaMetrics === false` prior to calling `trackEvent`

## More Information

Related: https://github.com/MetaMask/metamask-extension/pull/12282
See (internal): https://consensys.slack.com/archives/G01FXS64DFA/p1654656946247669