### PR TITLE
change getMethodFrom4Byte to return oldest entry when multiple exist for a given 4byte key

### DIFF
--- a/ui/helpers/utils/transactions.util.js
+++ b/ui/helpers/utils/transactions.util.js
@@ -38,7 +38,13 @@ async function getMethodFrom4Byte(fourBytePrefix) {
 
   if (fourByteResponse.count === 1) {
     return fourByteResponse.results[0].text_signature;
+  } else if (fourByteResponse.count > 1) {
+    const oldestEntry = fourByteResponse.results.reduce((prev, curr) =>
+      new Date(prev?.created_at) < new Date(curr?.created_at) ? prev : curr,
+    );
+    return oldestEntry.text_signature;
   }
+
   return null;
 }
 let registry;


### PR DESCRIPTION
## Explanation
Currently when we query [4byte.directory](https://www.4byte.directory/) for the name of a method associated with the 4byte hex string in the data of a given transaction, we only return a value if only one entry is returned. This directory is public and appears to be manipulated at times: 

## Pre-Merge Checklist

- [ ] PR template is filled out
- [ ] **IF** this PR fixes a bug, a test that _would have_ caught the bug has been added
- [ ] PR is linked to the appropriate GitHub issue
- [ ] PR has been added to the appropriate release Milestone

### + If there are functional changes:

- [ ] Manual testing complete & passed
- [ ] "Extension QA Board" label has been applied
