### PR TITLE
ErrorMessage: add @deprecated

### DIFF
--- a/ui/components/ui/error-message/error-message.component.js
+++ b/ui/components/ui/error-message/error-message.component.js
@@ -1,6 +1,14 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+/**
+ * @deprecated - Please use ActionableMessage type danger
+ * @see ActionableMessage
+ * @param {Object} props
+ * @param {string} props.errorMessage
+ * @param {string} props.errorKey
+ * @param {Object} context
+ */
 const ErrorMessage = (props, context) => {
   const { errorMessage, errorKey } = props;
   const error = errorKey ? context.t(errorKey) : errorMessage;


### PR DESCRIPTION
## Explanation

Currently, there are only 5 instances of the `ErrorMessage` component:
- ui/components/app/confirm-page-container/confirm-page-container.component.js
- ui/components/app/confirm-page-container/confirm-page-container-content/confirm-page-container-content.component.js
- ui/components/app/edit-gas-display/edit-gas-display.component.js
- ui/components/app/edit-gas-fee-popover/edit-gas-fee-popover.js
- ui/components/app/transaction-decoding/transaction-decoding.component.js

This PR proposes that we mark the `ErrorMessage` component as deprecated in favor of the `ActionableMessage` component. We currently have 35 instances of ActionableMessage and 11 of these are type="danger".

## More Information

top message is an `ErrorMessage`, bottom message is an `ActionableMessage`
<img width="640" alt="Screenshot 2022-06-14 at 10 39 13 AM" src="https://user-images.githubusercontent.com/20778143/173620193-b61e798d-0733-409c-bd82-c09dbfdab425.png">


## Screenshots/Screencaps

### After

<img width="456" alt="Screenshot 2022-06-14 at 9 55 57 AM" src="https://user-images.githubusercontent.com/20778143/173610557-6f420ede-d9c8-4727-8ce7-216c2e337459.png">


## Manual Testing Steps

<!--
How should reviewers and QA manually test your changes? For instance:

- Go to this screen
- Do this
- Then do this
-->

## Pre-Merge Checklist

- [ ] PR template is filled out
- [ ] **IF** this PR fixes a bug, a test that _would have_ caught the bug has been added
- [ ] PR is linked to the appropriate GitHub issue
- [ ] PR has been added to the appropriate release Milestone

### + If there are functional changes:

- [ ] Manual testing complete & passed
- [ ] "Extension QA Board" label has been applied
