### PR TITLE
[Storybook] Fix error for EditGasDisplay component

### DIFF
--- a/ui/components/app/edit-gas-display/edit-gas-display.stories.js
+++ b/ui/components/app/edit-gas-display/edit-gas-display.stories.js
@@ -4,32 +4,36 @@ import EditGasDisplay from '.';
 export default {
   title: 'Components/App/EditGasDisplay',
   id: __filename,
+  args: {
+    transaction: {},
+  },
 };
 
-export const DefaultStory = () => {
+export const DefaultStory = (args) => {
   return (
     <div style={{ width: '600px' }}>
-      <EditGasDisplay />
+      <EditGasDisplay {...args} />
     </div>
   );
 };
 
 DefaultStory.storyName = 'Default';
 
-export const WithEducation = () => {
+export const WithEducation = (args) => {
   return (
     <div style={{ width: '600px' }}>
-      <EditGasDisplay showEducationButton />
+      <EditGasDisplay showEducationButton {...args} />
     </div>
   );
 };
 
-export const WithDappSuggestedGas = () => {
+export const WithDappSuggestedGas = (args) => {
   return (
     <div style={{ width: '600px' }}>
       <EditGasDisplay
         dappSuggestedGasFee="100000"
         dappOrigin="davidwalsh.name"
+        {...args}
       />
     </div>
   );


### PR DESCRIPTION
## Explanation

## Screenshots/Screencaps

### Before

<img width="961" alt="Screenshot 2022-06-14 at 10 33 46 AM" src="https://user-images.githubusercontent.com/20778143/173622562-1b185128-9a87-4031-8f7f-80b6f94104c1.png">


### After

<img width="958" alt="Screenshot 2022-06-14 at 10 55 39 AM" src="https://user-images.githubusercontent.com/20778143/173622612-f229cfea-a569-40f9-aa9d-282d5a1c86f2.png">


## Manual Testing Steps

1. run `yarn storybook`
2. visit http://localhost:6006/?path=/story/ui-components-app-edit-gas-display-edit-gas-display-stories-js--default-story