### PR TITLE
Improve accessibility of Spend Limit Permission screen options

### DIFF
--- a/ui/components/app/modals/edit-approval-permission/edit-approval-permission.component.js
+++ b/ui/components/app/modals/edit-approval-permission/edit-approval-permission.component.js
@@ -80,11 +80,11 @@ export default class EditApprovalPermission extends PureComponent {
           <div className="edit-approval-permission__edit-section__description">
             {t('allowWithdrawAndSpend', [origin])}
           </div>
-          <div className="edit-approval-permission__edit-section__option">
-            <div
-              className="edit-approval-permission__edit-section__radio-button"
-              onClick={() => this.setState({ selectedOptionIsUnlimited: true })}
-            >
+          <button
+            className="edit-approval-permission__edit-section__option"
+            onClick={() => this.setState({ selectedOptionIsUnlimited: true })}
+          >
+            <div className="edit-approval-permission__edit-section__radio-button">
               <div
                 className={classnames({
                   'edit-approval-permission__edit-section__radio-button-outline': !selectedOptionIsUnlimited,
@@ -116,14 +116,12 @@ export default class EditApprovalPermission extends PureComponent {
                 {`${Number(tokenAmount)} ${tokenSymbol}`}
               </div>
             </div>
-          </div>
-          <div className="edit-approval-permission__edit-section__option">
-            <div
-              className="edit-approval-permission__edit-section__radio-button"
-              onClick={() =>
-                this.setState({ selectedOptionIsUnlimited: false })
-              }
-            >
+          </button>
+          <button
+            className="edit-approval-permission__edit-section__option"
+            onClick={() => this.setState({ selectedOptionIsUnlimited: false })}
+          >
+            <div className="edit-approval-permission__edit-section__radio-button">
               <div
                 className={classnames({
                   'edit-approval-permission__edit-section__radio-button-outline': selectedOptionIsUnlimited,
@@ -166,7 +164,7 @@ export default class EditApprovalPermission extends PureComponent {
                 />
               </div>
             </div>
-          </div>
+          </button>
         </div>
       </div>
     );

--- a/ui/components/app/modals/edit-approval-permission/index.scss
+++ b/ui/components/app/modals/edit-approval-permission/index.scss
@@ -75,8 +75,9 @@
 
     &__option {
       display: flex;
-      align-items: flex-start;
       margin-top: 20px;
+      text-align: left;
+      background: none;
     }
 
     &__radio-button {


### PR DESCRIPTION
Fixes: https://github.com/MetaMask/metamask-extension/issues/14883

## Explanation
Explanation in issue

## More Information
This also makes the spend limit options keyboard accessible

### After
https://user-images.githubusercontent.com/8732757/173735041-08d5f5e5-9962-49d9-b68b-3fe75ea3beae.mov

## Manual Testing Steps
1. Follow steps in issue to find spend limit permission screen
2. Ensure the options can be selected by clicking the radio button, clicking the accompanying text, and by tabbing through elements and clicking "Enter"
