### PR TITLE
Only have timeout for when payload is getState

### DIFF
--- a/app/scripts/lib/metaRPCClientFactory.js
+++ b/app/scripts/lib/metaRPCClientFactory.js
@@ -18,16 +18,18 @@ class MetaRPCClient {
     this.requests.set(id, cb);
     this.connectionStream.write(payload);
     this.responseHandled[id] = false;
-    setTimeout(() => {
-      if (!this.responseHandled[id] && cb) {
-        delete this.responseHandled[id];
-        return cb(new Error('No response from RPC'), null);
-      }
+    if (payload.method === 'getState') {
+      setTimeout(() => {
+        if (!this.responseHandled[id] && cb) {
+          delete this.responseHandled[id];
+          return cb(new Error('No response from RPC'), null);
+        }
 
-      delete this.responseHandled[id];
-      // needed for linter to pass
-      return true;
-    }, TEN_SECONDS_IN_MILLISECONDS);
+        delete this.responseHandled[id];
+        // needed for linter to pass
+        return true;
+      }, TEN_SECONDS_IN_MILLISECONDS);
+    }
   }
 
   onNotification(handler) {

--- a/app/scripts/lib/metaRPCClientFactory.test.js
+++ b/app/scripts/lib/metaRPCClientFactory.test.js
@@ -138,7 +138,7 @@ describe('metaRPCClientFactory', () => {
     const metaRPCClient = metaRPCClientFactory(streamTest);
 
     const errorPromise = new Promise((_resolve, reject) =>
-      metaRPCClient.foo('bad', (error, _) => {
+      metaRPCClient.getState('bad', (error, _) => {
         reject(error);
       }),
     );


### PR DESCRIPTION
## Explanation
To fix the `blank screen of death` on MetaMask, we added a loading screen and a timeout on the UI startup, so when MetaMask starts up, is shows a loading screen and waits for 10s for the background to startup and respond to the `getState` request, if the background doesn't respond within that timeframe, the timeout kicks in and the UI shows an error to the user.

The problem is that the timeout is in place for every request to the background and this is generally OK as the background responds within 10s, but for hardware, this is an issue because the user might not be able to complete the signing process on the hardware in 10s as in this case #14970 or the hardware connectivity itself might take longer than 10s as in this case #14968.

The fix as suggested by @danjm [here](https://consensys.slack.com/archives/C029JG63136/p1655386318719959?thread_ts=1655373624.323409&cid=C029JG63136) is to only have the timeout in place until the UI is loaded...this basically translates to having the timeout for `getState` requests only because once we have state UI is initialised and the timeout error will not be shown anyways.

The PR makes sure timeout is setup only for `getState`

## More Information

* Fixes #14970
* See: #14968

## Manual Testing Steps

The issues linked have videos and steps on how to reproduce the bug.

## Pre-Merge Checklist

- [x] PR template is filled out
- [x] **IF** this PR fixes a bug, a test that _would have_ caught the bug has been added
- [x] PR is linked to the appropriate GitHub issue
- [ ] PR has been added to the appropriate release Milestone

### + If there are functional changes:

- [ ] Manual testing complete & passed
- [ ] "Extension QA Board" label has been applied
