### PR TITLE
[FLASK] Rename `workerController` to `snapExecutionService`

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -640,7 +640,7 @@ export default class MetamaskController extends EventEmitter {
     });
 
     ///: BEGIN:ONLY_INCLUDE_IN(flask)
-    this.workerController = new IframeExecutionService({
+    this.snapExecutionService = new IframeExecutionService({
       iframeUrl: new URL(
         'https://metamask.github.io/iframe-execution-environment/0.4.6',
       ),
@@ -669,17 +669,17 @@ export default class MetamaskController extends EventEmitter {
 
     this.snapController = new SnapController({
       environmentEndowmentPermissions: Object.values(EndowmentPermissions),
-      terminateAllSnaps: this.workerController.terminateAllSnaps.bind(
-        this.workerController,
+      terminateAllSnaps: this.snapExecutionService.terminateAllSnaps.bind(
+        this.snapExecutionService,
       ),
-      terminateSnap: this.workerController.terminateSnap.bind(
-        this.workerController,
+      terminateSnap: this.snapExecutionService.terminateSnap.bind(
+        this.snapExecutionService,
       ),
-      executeSnap: this.workerController.executeSnap.bind(
-        this.workerController,
+      executeSnap: this.snapExecutionService.executeSnap.bind(
+        this.snapExecutionService,
       ),
-      getRpcMessageHandler: this.workerController.getRpcMessageHandler.bind(
-        this.workerController,
+      getRpcMessageHandler: this.snapExecutionService.getRpcMessageHandler.bind(
+        this.snapExecutionService,
       ),
       closeAllConnections: this.removeAllConnections.bind(this),
       state: initState.SnapController,


### PR DESCRIPTION
Renames the `MetaMaskController.workerController` property to `snapExecutionService`, which better matches the naming scheme used throughout the Snaps codebase. No functional changes.