### PR TITLE
Fixing tooltip theming by enforcing default theme

### DIFF
--- a/ui/components/app/edit-gas-fee-popover/network-statistics/tooltips.js
+++ b/ui/components/app/edit-gas-fee-popover/network-statistics/tooltips.js
@@ -11,7 +11,7 @@ import {
 } from '../../../../helpers/constants/design-system';
 
 const NetworkStatusTooltip = ({ children, html, title }) => (
-  <Tooltip position="top" html={html} title={title} theme="tippy-tooltip-info">
+  <Tooltip position="top" html={html} title={title}>
     <Box display={DISPLAY.FLEX} flexDirection={FLEX_DIRECTION.COLUMN}>
       {children}
     </Box>

--- a/ui/components/ui/info-tooltip/index.scss
+++ b/ui/components/ui/info-tooltip/index.scss
@@ -11,58 +11,10 @@
   }
 }
 
-.tippy-popper[x-placement^=top] .tippy-tooltip-info-theme [x-arrow],
-.tippy-popper[x-placement^=top] .tippy-tooltip-wideInfo-theme [x-arrow] {
-  border-top-color: var(--color-background-default);
-}
-
-.tippy-popper[x-placement^=right] .tippy-tooltip-info-theme [x-arrow],
-.tippy-popper[x-placement^=right] .tippy-tooltip-wideInfo-theme [x-arrow] {
-  border-right-color: var(--color-background-default);
-}
-
-.tippy-popper[x-placement^=left] .tippy-tooltip-info-theme [x-arrow],
-.tippy-popper[x-placement^=left] .tippy-tooltip-wideInfo-theme [x-arrow] {
-  border-left-color: var(--color-background-default);
-}
-
-.tippy-popper[x-placement^=bottom] .tippy-tooltip-info-theme [x-arrow],
-.tippy-popper[x-placement^=bottom] .tippy-tooltip-wideInfo-theme [x-arrow] {
-  border-bottom-color: var(--color-background-default);
-}
-
 .tippy-tooltip {
-  &#{&}-info-theme,
-  &#{&}-wideInfo-theme {
-    background: var(--color-background-default);
-    color: var(--color-text-default);
-    box-shadow: 0 0 14px rgba(0, 0, 0, 0.18);
-    border-radius: 8px;
-    max-width: 203px;
+  &#{&}-info-theme {
+    max-width: 200px;
     padding: 16px;
-    padding-bottom: 15px;
-
-    .tippy-tooltip-content {
-      @include H7;
-
-      text-align: left;
-      color: var(--color-text-alternative);
-
-      a {
-        color: var(--color-primary-default);
-      }
-
-      p {
-        margin-bottom: 12px;
-
-        &:last-child {
-          margin-bottom: 0;
-        }
-      }
-    }
-  }
-
-  &#{&}-wideInfo-theme {
-    max-width: 260px;
+    padding-bottom: 16px;
   }
 }

--- a/ui/components/ui/info-tooltip/info-tooltip.js
+++ b/ui/components/ui/info-tooltip/info-tooltip.js
@@ -16,7 +16,6 @@ export default function InfoTooltip({
   position = '',
   containerClassName,
   wrapperClassName,
-  wide,
   iconFillColor = 'var(--color-icon-alternative)',
 }) {
   return (
@@ -32,7 +31,7 @@ export default function InfoTooltip({
         tooltipInnerClassName="info-tooltip__tooltip-content"
         tooltipArrowClassName={positionArrowClassMap[position]}
         html={contentText}
-        theme={wide ? 'tippy-tooltip-wideInfo' : 'tippy-tooltip-info'}
+        theme="tippy-tooltip-info"
       >
         <InfoTooltipIcon fillColor={iconFillColor} />
       </Tooltip>
@@ -49,10 +48,6 @@ InfoTooltip.propTypes = {
    * Shows position of the tooltip
    */
   position: PropTypes.oneOf(['top', 'left', 'bottom', 'right']),
-  /**
-   * Set if the tooltip wide
-   */
-  wide: PropTypes.bool,
   /**
    * Add custom CSS class for container
    */

--- a/ui/components/ui/info-tooltip/info-tooltip.stories.js
+++ b/ui/components/ui/info-tooltip/info-tooltip.stories.js
@@ -17,7 +17,6 @@ export default {
       control: 'select',
       options: ['top', 'left', 'bottom', 'right'],
     },
-    wide: { control: 'boolean' },
     containerClassName: { control: 'text' },
     wrapperClassName: { control: 'text' },
     iconFillColor: { control: 'text' },

--- a/ui/components/ui/tooltip/index.scss
+++ b/ui/components/ui/tooltip/index.scss
@@ -1,30 +1,44 @@
-.tippy-tooltip.white-theme {
-  background: var(--color-background-default);
-  color: var(--color-text-default);
-  box-shadow: 0 0 14px rgba(0, 0, 0, 0.18);
-  padding: 12px 16px;
-  padding-bottom: 11px;
+.tippy-popper {
+  .tippy-tooltip.tippy-tooltip--mm-custom-theme {
+    background: var(--color-background-default);
+    color: var(--color-text-default);
+    box-shadow: 0 0 14px rgba(0, 0, 0, 0.18);
+    padding: 12px 16px;
+    padding-bottom: 11px;
 
-  .tippy-tooltip-content {
-    @include H7;
+    .tippy-tooltip-content {
+      @include H7;
 
-    text-align: left;
-    color: var(--color-text-alternative);
+      text-align: left;
+      color: var(--color-text-alternative);
+
+      a {
+        color: var(--color-primary-default);
+      }
+
+      p {
+        margin-bottom: 16px;
+
+        &:last-child {
+          margin-bottom: 0;
+        }
+      }
+    }
   }
-}
 
-.tippy-popper[x-placement^=top] .white-theme [x-arrow] {
-  border-top-color: var(--color-background-default);
-}
+  &[x-placement^=top] .tippy-tooltip.tippy-tooltip--mm-custom-theme [x-arrow] {
+    border-top-color: var(--color-background-default);
+  }
 
-.tippy-popper[x-placement^=right] .white-theme [x-arrow] {
-  border-right-color: var(--color-background-default);
-}
+  &[x-placement^=right] .tippy-tooltip.tippy-tooltip--mm-custom-theme [x-arrow] {
+    border-right-color: var(--color-background-default);
+  }
 
-.tippy-popper[x-placement^=left] .white-theme [x-arrow] {
-  border-left-color: var(--color-background-default);
-}
+  &[x-placement^=left] .tippy-tooltip.tippy-tooltip--mm-custom-theme [x-arrow] {
+    border-left-color: var(--color-background-default);
+  }
 
-.tippy-popper[x-placement^=bottom] .white-theme [x-arrow] {
-  border-bottom-color: var(--color-background-default);
+  &[x-placement^=bottom] .tippy-tooltip.tippy-tooltip--mm-custom-theme [x-arrow] {
+    border-bottom-color: var(--color-background-default);
+  }
 }

--- a/ui/components/ui/tooltip/tooltip.js
+++ b/ui/components/ui/tooltip/tooltip.js
@@ -82,7 +82,7 @@ export default class Tooltip extends PureComponent {
         style={style}
         title={disabled ? '' : title}
         trigger={trigger}
-        theme={theme}
+        theme={`tippy-tooltip--mm-custom ${theme}`} // Required for correct theming
         tabIndex={tabIndex || 0}
         tag={tag}
       >

--- a/ui/components/ui/tooltip/tooltip.stories.js
+++ b/ui/components/ui/tooltip/tooltip.stories.js
@@ -1,0 +1,92 @@
+import React from 'react';
+import Box from '../box/box';
+import Typography from '../typography/typography';
+import Tooltip from '.';
+
+export default {
+  title: 'Components/UI/Tooltip',
+  id: __filename,
+  argTypes: {
+    containerClassName: {
+      control: 'text',
+    },
+    disabled: {
+      control: 'boolean',
+    },
+    html: {
+      control: 'html',
+    },
+    interactive: {
+      control: 'boolean',
+    },
+    onHidden: {
+      action: 'onHidden',
+    },
+    position: {
+      control: 'select',
+      options: ['top', 'right', 'bottom', 'left'],
+    },
+    size: {
+      control: 'select',
+      options: ['small', 'regular', 'big'],
+    },
+    title: {
+      control: 'text',
+    },
+    trigger: {
+      control: 'any',
+    },
+    wrapperClassName: {
+      control: 'text',
+    },
+    style: {
+      control: 'object',
+    },
+    tabIndex: {
+      control: 'number',
+    },
+    tag: {
+      control: 'text',
+    },
+  },
+  args: {
+    position: 'top',
+    title: 'Title of the tooltip',
+    trigger: 'mouseenter',
+  },
+};
+
+export const DefaultStory = (args) => (
+  <Box display="flex">
+    <Typography>Hover over the info icon to see the tooltip</Typography>
+    <Tooltip {...args}>
+      <i
+        className="fa fa-sm fa-info-circle"
+        style={{ color: 'var(--color-icon-alternative)' }}
+      />
+    </Tooltip>
+  </Box>
+);
+
+DefaultStory.storyName = 'Default';
+
+export const HTML = (args) => (
+  <Box display="flex">
+    <Typography>This tooltips content is html</Typography>
+    <Tooltip {...args}>
+      <i
+        className="fa fa-sm fa-info-circle"
+        style={{ color: 'var(--color-icon-alternative)' }}
+      />
+    </Tooltip>
+  </Box>
+);
+
+HTML.args = {
+  interactive: true,
+  html: (
+    <Box>
+      And includes a <a href="#">link</a>
+    </Box>
+  ),
+};

--- a/ui/pages/swaps/fee-card/fee-card.js
+++ b/ui/pages/swaps/fee-card/fee-card.js
@@ -109,7 +109,6 @@ export default function FeeCard({
                     }
                     containerClassName="fee-card__info-tooltip-content-container"
                     wrapperClassName="fee-card__row-label fee-card__info-tooltip-container"
-                    wide
                   />
                 </>
               }

--- a/ui/pages/swaps/main-quote-summary/main-quote-summary.js
+++ b/ui/pages/swaps/main-quote-summary/main-quote-summary.js
@@ -93,7 +93,6 @@ export default function MainQuoteSummary({
               position="bottom"
               html={amountToDisplay}
               disabled={ellipsedAmountToDisplay === amountToDisplay}
-              theme="white"
             >
               <span
                 className="main-quote-summary__quote-large-number"

--- a/ui/pages/swaps/view-quote/view-quote-price-difference.js
+++ b/ui/pages/swaps/view-quote/view-quote-price-difference.js
@@ -73,11 +73,7 @@ export default function ViewQuotePriceDifference(props) {
                 <div className="view-quote__price-difference-warning-contents-title">
                   {priceDifferenceTitle}
                 </div>
-                <Tooltip
-                  position="bottom"
-                  theme="white"
-                  title={t('swapPriceImpactTooltip')}
-                >
+                <Tooltip position="bottom" title={t('swapPriceImpactTooltip')}>
                   <i className="fa fa-info-circle" />
                 </Tooltip>
               </Box>


### PR DESCRIPTION
## Explanation

Currently, theme has to be passed to the tooltip to allow for darkmode.

This is a problem because every time an engineer uses a Tooltip component they have to pass it the theme logic. It would be much more convenient if the Tooltip component handled this logic itself.

In order to solve this problem, this pull request enforces some styling that includes the design tokens to handle the theme logic.
- It also removes the `arrow` prop functionality as all of our tooltips should use an arrow.
- Updates the `InfoTooltip` component and removes duplicate styles
- Removes unused themes in other instances of the tooltip component throughout the codebase
- Created Tooltip story
- Removes `wide` prop form InfoTooltip as did a search and it's only used in one instance that probably isn't needed

## More Information

* Fixes #14990 
* See PR with theme logic https://github.com/MetaMask/metamask-extension/pull/14557/files#r896059292


## Screenshots/Screencaps

### After
Tooltip story in storybook

<img width="1440" alt="Screen Shot 2022-06-20 at 1 20 49 PM" src="https://user-images.githubusercontent.com/8112138/174673489-794b202b-9d2c-4ff8-8971-c76cd5ec44df.png">
<img width="721" alt="Screen Shot 2022-06-20 at 1 21 35 PM" src="https://user-images.githubusercontent.com/8112138/174673494-6d903fab-41be-4369-be8d-9ecd1f7d55d2.png">

InfoTooltip in storybook

<img width="1440" alt="Screen Shot 2022-06-20 at 1 22 13 PM" src="https://user-images.githubusercontent.com/8112138/174673495-315fc220-0c7d-4c59-a563-797a3d7200a7.png">
<img width="1437" alt="Screen Shot 2022-06-20 at 1 22 36 PM" src="https://user-images.githubusercontent.com/8112138/174673496-b038c179-14cf-4349-a9ab-701f563871a4.png">



## Manual Testing Steps
- Go to this screen
- Do this
- Then do this

## Pre-Merge Checklist

- [x] PR template is filled out
- ~[x] **IF** this PR fixes a bug, a test that _would have_ caught the bug has been added~ N/A
- [x] PR is linked to the appropriate GitHub issue
- ~[x] PR has been added to the appropriate release Milestone~ N/A

### + If there are functional changes:

- ~[x] Manual testing complete & passed~ N/A
- [ ] "Extension QA Board" label has been applied - Not sure?? May need some visual testing
