### PR TITLE
Destroy ledger keyring when removing last account in ledger keyring

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -2673,8 +2673,17 @@ export default class MetamaskController extends EventEmitter {
     // Remove account from the account tracker controller
     this.accountTracker.removeAccount([address]);
 
+    const keyring = await this.keyringController.getKeyringForAccount(address);
+
     // Remove account from the keyring
     await this.keyringController.removeAccount(address);
+
+    const updatedKeyringAccounts = await keyring.getAccounts();
+
+    if (updatedKeyringAccounts.length === 0) {
+      keyring.destroy?.();
+    }
+
     return address;
   }
 

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -2674,13 +2674,10 @@ export default class MetamaskController extends EventEmitter {
     this.accountTracker.removeAccount([address]);
 
     const keyring = await this.keyringController.getKeyringForAccount(address);
-
     // Remove account from the keyring
     await this.keyringController.removeAccount(address);
-
-    const updatedKeyringAccounts = await keyring.getAccounts();
-
-    if (updatedKeyringAccounts.length === 0) {
+    const updatedKeyringAccounts = keyring ? await keyring.getAccounts() : {};
+    if (updatedKeyringAccounts?.length === 0) {
       keyring.destroy?.();
     }
 

--- a/app/scripts/metamask-controller.test.js
+++ b/app/scripts/metamask-controller.test.js
@@ -782,12 +782,20 @@ describe('MetaMaskController', function () {
   describe('#removeAccount', function () {
     let ret;
     const addressToRemove = '0x1';
+    let mockKeyring;
 
     beforeEach(async function () {
+      mockKeyring = {
+        getAccounts: sinon.stub().returns(Promise.resolve([])),
+        destroy: sinon.stub(),
+      };
       sinon.stub(metamaskController.preferencesController, 'removeAddress');
       sinon.stub(metamaskController.accountTracker, 'removeAccount');
       sinon.stub(metamaskController.keyringController, 'removeAccount');
       sinon.stub(metamaskController, 'removeAllAccountPermissions');
+      sinon
+        .stub(metamaskController.keyringController, 'getKeyringForAccount')
+        .returns(Promise.resolve(mockKeyring));
 
       ret = await metamaskController.removeAccount(addressToRemove);
     });
@@ -797,6 +805,9 @@ describe('MetaMaskController', function () {
       metamaskController.accountTracker.removeAccount.restore();
       metamaskController.preferencesController.removeAddress.restore();
       metamaskController.removeAllAccountPermissions.restore();
+
+      mockKeyring.getAccounts.resetHistory();
+      mockKeyring.destroy.resetHistory();
     });
 
     it('should call preferencesController.removeAddress', async function () {
@@ -829,6 +840,16 @@ describe('MetaMaskController', function () {
     });
     it('should return address', async function () {
       assert.equal(ret, '0x1');
+    });
+    it('should call keyringController.getKeyringForAccount', async function () {
+      assert(
+        metamaskController.keyringController.getKeyringForAccount.calledWith(
+          addressToRemove,
+        ),
+      );
+    });
+    it('should call keyring.destroy', async function () {
+      assert(mockKeyring.destroy.calledOnce);
     });
   });
 


### PR DESCRIPTION
Fixes https://github.com/MetaMask/metamask-extension/issues/14954

Whenever the user enters the connect hardware flow, `addNewKeyring` is called if no keyring for a given advice exists in the keyring controller. This will instantiate a ledger keyring, which sets up listeners (within the ledger keyring class). When removing the last account from a ledger keyring, the eth-keyring-controller will remove that keyring from its store of keyrings, but the listeners instantiated by the keyring class will not be removed. This can result in multiple listeners being created if further ledger keyrings are instantiated in the future. This will result in listeners handling events incorrectly, as each listener will match messages with handlers according to previously set ids, and ids and handlers across keyrings instances will not match correctly.

The fix is to `destroy` the ledger keyring if it no longer contains any accounts, which will result in all listeners being removed.