### PR TITLE
fix minor german translation issue. connected=verbunden

### DIFF
--- a/app/_locales/de/messages.json
+++ b/app/_locales/de/messages.json
@@ -3082,7 +3082,7 @@
     "message": "Status"
   },
   "statusConnected": {
-    "message": "Verbinden"
+    "message": "Verbunden"
   },
   "statusNotConnected": {
     "message": "Nicht verbunden"


### PR DESCRIPTION
Issue: #14996 

Fix minor german translation issue.

Before:
  "statusConnected": {
    "message": "Verbinden"

After:
  "statusConnected": {
    "message": "Verbunden"

Why?
Connect (for example used on a button) -> verbinden
Connecting -> verbinden, verbinde, verbindet
Connected -> verbunden