### PR TITLE
Fix test dep warning for got package in 3box dependency tree

### DIFF
--- a/.iyarc
+++ b/.iyarc
@@ -2,3 +2,4 @@
 GHSA-93q8-gq69-wqmw
 GHSA-257v-vj4p-3w2h
 GHSA-wm7h-9275-46v2
+GHSA-pfrx-2q88-qq97


### PR DESCRIPTION
Adds https://github.com/advisories/GHSA-pfrx-2q88-qq97 to our ignore list

The affected package is in the dependency tree of 3box. It is only used in the cli of ipfs, which MetaMask does not depend on.