### PR TITLE
Adding media query sass vars, mixins and docs

### DIFF
--- a/.storybook/3.COLORS.stories.mdx
+++ b/.storybook/3.COLORS.stories.mdx
@@ -1,19 +1,11 @@
 import { Meta } from '@storybook/addon-docs';
-import ActionaleMessage from '../ui/components/ui/actionable-message';
 import designTokenDiagramImage from './images/design.token.graphic.svg';
 
-<Meta title="Design Tokens / Color" />
+<Meta title="Foundations / Color" />
 
 # Color
 
 Color is used to express style and communicate meaning.
-
-<ActionaleMessage
-  type="warning"
-  message="We are in the process of consolidating all of our colors, making them accessible and enabling theming. Many of the colors used throughout the codebase are deprecated please follow the guide below to ensure you are using the correct colors when building MetaMask UI"
-/>
-
-<br />
 
 ## Design tokens
 

--- a/.storybook/4.BREAKPOINTS.stories.mdx
+++ b/.storybook/4.BREAKPOINTS.stories.mdx
@@ -1,0 +1,123 @@
+import { Meta } from '@storybook/addon-docs';
+
+<Meta title="Foundations / Breakpoints" />
+
+# Breakpoints
+
+Breakpoints are used for responsive layout
+
+## Screen Sizes
+
+There are 4 screen sizes that make up the breakpoints for the MetaMask extension
+
+- base: `0px`
+- sm: `576px`
+- md: `768px`
+- lg: `1280px`
+
+### SCSS
+
+There are Sass variables and mixins available for use for both min and max screens sizes
+
+#### Variables
+
+```css
+$screen-sm-min /* 576px */
+$screen-md-min /* 768px */
+$screen-lg-min /* 1280px */
+
+$screen-sm-max /* 575px */
+$screen-md-max /* 767px */
+$screen-lg-max /* 1279px */
+```
+
+#### Mixins
+
+```css
+/* Min screen size */
+@include screen-sm-min {
+  /* equivalent css @media screen and (min-width: 576px) */
+}
+@include screen-md-min {
+  /* equivalent css @media screen and (min-width: 768px) */
+}
+@include screen-lg-min {
+  /* equivalent css @media screen and (min-width: 1280px) */
+}
+
+/* Max screen size */
+@include screen-sm-max {
+  /* equivalent css @media screen and (max-width: 575px) */
+}
+@include screen-md-max {
+  /* equivalent css @media screen and (max-width: 767px) */
+}
+@include screen-lg-max {
+  /* equivalent css @media screen and (max-width: 1279px) */
+}
+```
+
+Migrating from the old sass variables to the new mixins looks like this
+
+```css
+/* Instead of the media query and sass variable */
+@media screen and (max-width: $break-small) {
+  right: 16px;
+}
+
+/* Use the sass mixin */
+@include screen-sm-max {
+  right: 16px;
+}
+
+/* Instead of the media query and sass variable */
+@media screen and (min-width: $break-large) {
+  left: 16px;
+}
+
+/* Use the sass mixin */
+@include screen-sm-min {
+  left: 16px;
+}
+```
+
+### Takeaways
+
+- Try to avoid using static media queries in your code.
+- Try to use the provided SCSS mixins
+
+### ❌ Don't do this
+
+Don't use static media queries in your code.
+
+```css
+/**
+* Don't do this
+* Static media queries create inconsistency and will break UI if we want to update them in future
+**/
+.account-menu {
+  @media screen and (min-width: 769px) {
+    right: calc((100vw - 80vw) / 2);
+  }
+
+  @media screen and (min-width: 1281px) {
+    right: calc((100vw - 65vw) / 2);
+  }
+}
+```
+
+### ✅ Do this
+
+Do use the provided Sass mixins
+
+```css
+.account-menu {
+  @include screen-md-min {
+    right: calc((100vw - 80vw) / 2);
+  }
+
+  @include screen-lg-min {
+    right: calc((100vw - 65vw) / 2);
+  }
+}
+```

--- a/.storybook/4.BREAKPOINTS.stories.mdx
+++ b/.storybook/4.BREAKPOINTS.stories.mdx
@@ -19,32 +19,21 @@ There are 4 screen sizes that make up the breakpoints for the MetaMask extension
 
 There are Sass variables and mixins available for use for both min and max screens sizes
 
-#### Variables
+### Variables
 
 ```css
-$screen-sm-min /* 576px */
-$screen-md-min /* 768px */
-$screen-lg-min /* 1280px */
-
 $screen-sm-max /* 575px */
 $screen-md-max /* 767px */
 $screen-lg-max /* 1279px */
+
+$screen-sm-min /* 576px */
+$screen-md-min /* 768px */
+$screen-lg-min /* 1280px */
 ```
 
-#### Mixins
+### Mixins
 
 ```css
-/* Min screen size */
-@include screen-sm-min {
-  /* equivalent css @media screen and (min-width: 576px) */
-}
-@include screen-md-min {
-  /* equivalent css @media screen and (min-width: 768px) */
-}
-@include screen-lg-min {
-  /* equivalent css @media screen and (min-width: 1280px) */
-}
-
 /* Max screen size */
 @include screen-sm-max {
   /* equivalent css @media screen and (max-width: 575px) */
@@ -55,11 +44,23 @@ $screen-lg-max /* 1279px */
 @include screen-lg-max {
   /* equivalent css @media screen and (max-width: 1279px) */
 }
+
+/* Min screen size */
+@include screen-sm-min {
+  /* equivalent css @media screen and (min-width: 576px) */
+}
+@include screen-md-min {
+  /* equivalent css @media screen and (min-width: 768px) */
+}
+@include screen-lg-min {
+  /* equivalent css @media screen and (min-width: 1280px) */
+}
 ```
 
 Migrating from the old sass variables to the new mixins looks like this
 
 ```css
+/* Max width */
 /* Instead of the media query and sass variable */
 @media screen and (max-width: $break-small) {
   right: 16px;
@@ -70,6 +71,7 @@ Migrating from the old sass variables to the new mixins looks like this
   right: 16px;
 }
 
+/* Min width */
 /* Instead of the media query and sass variable */
 @media screen and (min-width: $break-large) {
   left: 16px;
@@ -81,7 +83,7 @@ Migrating from the old sass variables to the new mixins looks like this
 }
 ```
 
-### Takeaways
+## Takeaways
 
 - Try to avoid using static media queries in your code.
 - Try to use the provided SCSS mixins
@@ -93,7 +95,7 @@ Don't use static media queries in your code.
 ```css
 /**
 * Don't do this
-* Static media queries create inconsistency and will break UI if we want to update them in future
+* Static media queries create inconsistency and could break the UI if we want to update them in future
 **/
 .account-menu {
   @media screen and (min-width: 769px) {

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -30,7 +30,7 @@ addParameters({
     storySort: {
       order: [
         'Getting Started',
-        'Design Tokens',
+        'Foundations',
         'Components',
         ['UI', 'App'],
         'Pages',

--- a/ui/css/design-system/breakpoints.scss
+++ b/ui/css/design-system/breakpoints.scss
@@ -1,5 +1,66 @@
+@use "sass:map";
+
 /*
-Responsive Breakpoints
+Responsive breakpoints
+*/
+
+// Screen sizes
+$screen-sizes-map: (
+  'sm':  576px,
+  'md': 768px,
+  'lg': 1280px,
+);
+
+// Max width screen size
+$screen-sm-max: calc(#{map.get($screen-sizes-map, "sm")} - 1px);
+$screen-md-max: calc(#{map.get($screen-sizes-map, "md")} - 1px);
+$screen-lg-max: calc(#{map.get($screen-sizes-map, "lg")} - 1px);
+
+// Min width screen size
+$screen-sm-min: map.get($screen-sizes-map, "sm");
+$screen-md-min: map.get($screen-sizes-map, "md");
+$screen-lg-min: map.get($screen-sizes-map, "lg");
+
+// Max width media query mixins
+@mixin screen-sm-max {
+  @media screen and (max-width: $screen-sm-max) {
+    @content;
+  };
+}
+
+@mixin screen-md-max {
+  @media screen and (max-width: $screen-md-max) {
+    @content;
+  };
+}
+
+@mixin screen-lg-max {
+  @media screen and (max-width: $screen-lg-max) {
+    @content;
+  };
+}
+
+// Min width media query mixins
+@mixin screen-sm-min {
+  @media screen and (min-width: $screen-sm-min) {
+    @content;
+  };
+}
+
+@mixin screen-md-min {
+  @media screen and (min-width: $screen-md-min) {
+    @content;
+  };
+}
+
+@mixin screen-lg-min {
+  @media screen and (min-width: $screen-lg-min) {
+    @content;
+  };
+}
+
+/*
+DEPRECATED
 */
 $break-small: 575px;
 $break-midpoint: 780px;


### PR DESCRIPTION
## Explanation

Currently, we have a few static pixel values and 3 sass vars used with media queries:

```
$break-small: 575px;
$break-midpoint: 780px;
$break-large: 576px;
```

This above variables don't make a huge amount of sense and static media queries also encourage random grid layouts.

In order to solve this problem, this pull request creates a set of standardized screen size sass vars and mixins as well as documentation in storybook. It does not replace any of the current media queries. That will be handled in another PR https://github.com/MetaMask/metamask-extension/pull/15068

Migrating from the old sass variables to the new mixins looks like this

```css
/* MAX WIDTH */
/* Instead of the media query and sass variable */
@media screen and (max-width: $break-small) {
  right: 16px;
}
/* Use the sass mixin */
@include screen-sm-max {
  right: 16px;
}

/* MIN WIDTH */
/* Instead of the media query and sass variable */
@media screen and (min-width: $break-large) {
  left: 16px;
}
/* Use the sass mixin */
@include screen-sm-min {
  left: 16px;
}
```

## More Information

* Contributes to [13045](https://github.com/MetaMask/metamask-extension/issues/13045)

## Screenshots/Screencaps

### Test story that is not apart of this PR to test the sass mixins

https://user-images.githubusercontent.com/8112138/175666932-dc419be9-74a3-48d5-8e6a-18def872f0dd.mov

### Storybook documentation
![screencapture-localhost-6007-2022-06-27-09_22_08](https://user-images.githubusercontent.com/8112138/175988772-9a9442a4-7996-4375-a602-1873b4c8aac8.png)


## Manual Testing Steps

For storybook documentation go to the latest build of storybook in this PR and search "Breakpoints" in the search bar

For testing the created mixins I created a story in my local and have attached the video to this PR. This PR just adds the media queries I have another branch in my local to replace all the current instances that is working well.

## Pre-Merge Checklist

- [x] PR template is filled out
- ~[x] **IF** this PR fixes a bug, a test that _would have_ caught the bug has been added~ N/A
- [x] PR is linked to the appropriate GitHub issue
- ~[x] PR has been added to the appropriate release Milestone~ N/A

### + If there are functional changes:

- ~[x] Manual testing complete & passed~ N/A
- ~[x] "Extension QA Board" label has been applied~ N/A
