### PR TITLE
Ensure 0x-prefixed addresses in send input

### DIFF
--- a/ui/pages/send/send-content/add-recipient/ens-input.component.js
+++ b/ui/pages/send/send-content/add-recipient/ens-input.component.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 
+import { addHexPrefix } from '../../../../../app/scripts/lib/util';
 import { isValidDomainName } from '../../../../helpers/utils/util';
 import {
   isBurnAddress,
@@ -36,6 +37,7 @@ export default class EnsInput extends Component {
 
   onPaste = (event) => {
     if (event.clipboardData.items?.length) {
+      event.preventDefault();
       const clipboardItem = event.clipboardData.items[0];
       clipboardItem?.getAsString((text) => {
         const input = text.trim();
@@ -43,7 +45,7 @@ export default class EnsInput extends Component {
           !isBurnAddress(input) &&
           isValidHexAddress(input, { mixedCaseUseChecksum: true })
         ) {
-          this.props.onPaste(input);
+          this.props.onPaste(addHexPrefix(input));
         }
       });
     }
@@ -74,7 +76,7 @@ export default class EnsInput extends Component {
         !isBurnAddress(input) &&
         isValidHexAddress(input, { mixedCaseUseChecksum: true })
       ) {
-        onValidAddressTyped(input);
+        onValidAddressTyped(addHexPrefix(input));
       }
     }
 


### PR DESCRIPTION
## Explanation

Ensures hex-prefixed addresses in send input.

## More Information
TBD

## Manual Testing Steps
1. Paste a non `0x` prefixed address in the send input
2. Try to send a token to that address
3. See that this works

## Pre-Merge Checklist

- [ ] PR template is filled out
- [ ] **IF** this PR fixes a bug, a test that _would have_ caught the bug has been added
- [ ] PR is linked to the appropriate GitHub issue
- [ ] PR has been added to the appropriate release Milestone

### + If there are functional changes:

- [ ] Manual testing complete & passed
- [ ] "Extension QA Board" label has been applied
