### PR TITLE
Ensure that addresses are properly hex-prefixed in the generate ERC token transfer functions

### DIFF
--- a/ui/pages/send/send-content/add-recipient/ens-input.component.js
+++ b/ui/pages/send/send-content/add-recipient/ens-input.component.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 
+import { addHexPrefix } from '../../../../../app/scripts/lib/util';
 import { isValidDomainName } from '../../../../helpers/utils/util';
 import {
   isBurnAddress,
@@ -36,6 +37,7 @@ export default class EnsInput extends Component {
 
   onPaste = (event) => {
     if (event.clipboardData.items?.length) {
+      event.preventDefault();
       const clipboardItem = event.clipboardData.items[0];
       clipboardItem?.getAsString((text) => {
         const input = text.trim();
@@ -43,7 +45,7 @@ export default class EnsInput extends Component {
           !isBurnAddress(input) &&
           isValidHexAddress(input, { mixedCaseUseChecksum: true })
         ) {
-          this.props.onPaste(input);
+          this.props.onPaste(addHexPrefix(input));
         }
       });
     }
@@ -74,7 +76,7 @@ export default class EnsInput extends Component {
         !isBurnAddress(input) &&
         isValidHexAddress(input, { mixedCaseUseChecksum: true })
       ) {
-        onValidAddressTyped(input);
+        onValidAddressTyped(addHexPrefix(input));
       }
     }
 

--- a/ui/pages/send/send.utils.js
+++ b/ui/pages/send/send.utils.js
@@ -142,7 +142,7 @@ function generateERC20TransferData({
       .call(
         abi.rawEncode(
           ['address', 'uint256'],
-          [toAddress, addHexPrefix(amount)],
+          [addHexPrefix(toAddress), addHexPrefix(amount)],
         ),
         (x) => `00${x.toString(16)}`.slice(-2),
       )
@@ -164,7 +164,7 @@ function generateERC721TransferData({
       .call(
         abi.rawEncode(
           ['address', 'address', 'uint256'],
-          [fromAddress, toAddress, tokenId],
+          [addHexPrefix(fromAddress), addHexPrefix(toAddress), tokenId],
         ),
         (x) => `00${x.toString(16)}`.slice(-2),
       )

--- a/ui/pages/send/send.utils.test.js
+++ b/ui/pages/send/send.utils.test.js
@@ -73,7 +73,7 @@ describe('send utils', () => {
       expect(rawEncode.mock.calls[0].toString()).toStrictEqual(
         [
           ['address', 'uint256'],
-          ['mockAddress', '0xab'],
+          ['0xmockAddress', '0xab'],
         ].toString(),
       );
     });


### PR DESCRIPTION
Fixes https://github.com/MetaMask/metamask-extension/issues/15058

This PR is currently comparing to the branch for https://github.com/MetaMask/metamask-extension/pull/15063, we need to merge that PR first, and then rebase this PR's branch onto master.

we used to do this to create a token transfer transaction from the send screen:
https://github.com/MetaMask/metamask-extension/pull/14465/files#diff-bad76d7279418f3520a0ca93cfaeeb6fcbb1f0d4782f6ff942d422632a1c2780L1762-L1766
```
        token.transfer(address, value, {
          ...txParams,
          to: undefined,
          data: undefined,
        });
```

we now do this:
https://github.com/MetaMask/metamask-extension/pull/14465/files#diff-3c58b916cefff81e4927a9afd392acadbf4515f99f41783964a9851b7774791bR815-R833
```
const txMeta = await promisifiedBackground.addUnapprovedTransaction(
        txParams,
        ORIGIN_METAMASK,
        type,
      );
    });
```

previously we would create the token transfer via libraries that depend on this from ethjs-abi https://github.com/ethjs/ethjs-abi/blob/master/src/utils/index.js#L166, so validation of the hex string would fail there, and the user wouldn't be able to send the transaction, with the change referenced above, that validation stopped