### PR TITLE
The Japanese word for sign is "署名"

### DIFF
--- a/app/_locales/ja/messages.json
+++ b/app/_locales/ja/messages.json
@@ -4061,7 +4061,7 @@
     "message": "この機能を使用するには、カメラへのアクセスを許可する必要があります。"
   },
   "youSign": {
-    "message": "著名しています"
+    "message": "署名しています"
   },
   "yourPrivateSeedPhrase": {
     "message": "秘密のシークレットリカバリーフレーズ"


### PR DESCRIPTION
## Explanation

Correct the Japanese translation file.

🙅 著名 (This is "prominent" in English)
🙆 署名 (This is "sign" in English)

Corrected to word "署名 (Sign)".

## More Information

<!--
Are there any issues, Slack conversations, Zendesk issues, user stories, etc. reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

## Screenshots/Screencaps


### Before

<img width="355" alt="スクリーンショット 2022-06-29 9 32 07" src="https://user-images.githubusercontent.com/866589/176401429-d3efb78d-a46f-48eb-8625-864f85621b50.png">

### After

<!-- How does it look now? Drag your file(s) below this line: -->

## Manual Testing Steps

<!--
How should reviewers and QA manually test your changes? For instance:

- Go to this screen
- Do this
- Then do this
-->

## Pre-Merge Checklist

- [ ] PR template is filled out
- [ ] **IF** this PR fixes a bug, a test that _would have_ caught the bug has been added
- [ ] PR is linked to the appropriate GitHub issue
- [ ] PR has been added to the appropriate release Milestone

### + If there are functional changes:

- [ ] Manual testing complete & passed
- [ ] "Extension QA Board" label has been applied
