### PR TITLE
State logs e2e

### DIFF
--- a/.circleci/scripts/firefox-install.sh
+++ b/.circleci/scripts/firefox-install.sh
@@ -4,7 +4,7 @@ set -e
 set -u
 set -o pipefail
 
-FIREFOX_VERSION='83.0'
+FIREFOX_VERSION='102.0'
 FIREFOX_BINARY="firefox-${FIREFOX_VERSION}.tar.bz2"
 FIREFOX_BINARY_URL="https://ftp.mozilla.org/pub/firefox/releases/${FIREFOX_VERSION}/linux-x86_64/en-US/${FIREFOX_BINARY}"
 FIREFOX_PATH='/opt/firefox'

--- a/test/e2e/tests/state-logs.spec.js
+++ b/test/e2e/tests/state-logs.spec.js
@@ -1,0 +1,65 @@
+const { strict: assert } = require('assert');
+const { promises: fs } = require('fs');
+const { convertToHexValue, withFixtures } = require('../helpers');
+
+const downloadsFolder = `${process.cwd()}/test-artifacts/downloads`;
+
+const createDownloadFolder = async () => {
+  await fs.rm(downloadsFolder, { recursive: true, force: true });
+  await fs.mkdir(downloadsFolder, { recursive: true });
+};
+
+const stateLogsExist = async () => {
+  try {
+    const stateLogs = `${downloadsFolder}/MetaMask State Logs.json`;
+    await fs.access(stateLogs);
+    return true;
+  } catch (e) {
+    return false;
+  }
+};
+
+describe('State logs', function () {
+  const ganacheOptions = {
+    accounts: [
+      {
+        secretKey:
+          '0x7C9529A67102755B7E6102D6D950AC5D5863C98713805CEC576B945B15B71EAC',
+        balance: convertToHexValue(25000000000000000000),
+      },
+    ],
+  };
+  it('should download state logs for the account', async function () {
+    await withFixtures(
+      {
+        fixtures: 'imported-account',
+        ganacheOptions,
+        title: this.test.title,
+        failOnConsoleError: false,
+      },
+      async ({ driver }) => {
+        await createDownloadFolder();
+        await driver.navigate();
+        await driver.fill('#password', 'correct horse battery staple');
+        await driver.press('#password', driver.Key.ENTER);
+
+        // Download State Logs
+        await driver.clickElement('.account-menu__icon');
+        await driver.clickElement({ text: 'Settings', tag: 'div' });
+        await driver.clickElement({ text: 'Advanced', tag: 'div' });
+        await driver.clickElement({
+          text: 'Download State Logs',
+          tag: 'button',
+        });
+
+        // Verify download
+        let fileExists;
+        await driver.wait(async () => {
+          fileExists = await stateLogsExist();
+          return fileExists === true;
+        }, 10000);
+        assert.equal(fileExists, true);
+      },
+    );
+  });
+});

--- a/test/e2e/webdriver/chrome.js
+++ b/test/e2e/webdriver/chrome.js
@@ -22,6 +22,9 @@ class ChromeDriver {
     const options = new chrome.Options().addArguments(args);
     options.setProxy(proxy.manual({ https: HTTPS_PROXY_HOST }));
     options.setAcceptInsecureCerts(true);
+    options.setUserPreferences({
+      'download.default_directory': `${process.cwd()}/test-artifacts/downloads`,
+    });
     const builder = new Builder()
       .forBrowser('chrome')
       .setChromeOptions(options);

--- a/test/e2e/webdriver/firefox.js
+++ b/test/e2e/webdriver/firefox.js
@@ -40,6 +40,11 @@ class FirefoxDriver {
     const options = new firefox.Options().setProfile(templateProfile);
     options.setProxy(proxy.manual({ https: HTTPS_PROXY_HOST }));
     options.setAcceptInsecureCerts(true);
+    options.setPreference('browser.download.folderList', 2);
+    options.setPreference(
+      'browser.download.dir',
+      `${process.cwd()}/test-artifacts/downloads`,
+    );
     const builder = new Builder()
       .forBrowser('firefox')
       .setFirefoxOptions(options);


### PR DESCRIPTION
## Explanation

<!--
Thanks for the pull request. Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Below is a template to give you some ideas. Feel free to use your own words!

Currently, ...

This is a problem because ...

In order to solve this problem, this pull request ...
-->

This PR adds an e2e test to ensure that the state logs can be downloaded from Settings -> Advanced

## More Information

<!--
Are there any issues, Slack conversations, Zendesk issues, user stories, etc. reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

See: https://github.com/MetaMask/metamask-extension/pull/14171

## Screenshot

Screenshot showing the downloaded file in the CI pipeline

Chrome
<img width="1104" alt="State Logs" src="https://user-images.githubusercontent.com/53189696/176872657-8e5c80b3-24c6-43fb-854c-74690c94c486.png">

Firefox
<img width="1100" alt="State Logs FF" src="https://user-images.githubusercontent.com/53189696/176882558-fbb90c67-d3af-41ae-995a-1bbc03579722.png">