### PR TITLE
Update confirmation screen styling

### DIFF
--- a/ui/pages/confirmation/confirmation.js
+++ b/ui/pages/confirmation/confirmation.js
@@ -11,7 +11,6 @@ import { isEqual } from 'lodash';
 import { produce } from 'immer';
 import Box from '../../components/ui/box';
 import MetaMaskTemplateRenderer from '../../components/app/metamask-template-renderer';
-import SiteIcon from '../../components/ui/site-icon';
 import { DEFAULT_ROUTE } from '../../helpers/constants/routes';
 import {
   COLORS,
@@ -192,7 +191,7 @@ export default function ConfirmationPage() {
       )}
       <div className="confirmation-page__content">
         {templatedValues.networkDisplay ? (
-          <Box justifyContent="center">
+          <Box justifyContent="center" marginTop={2}>
             <NetworkDisplay
               indicatorSize={SIZES.XS}
               labelProps={{ color: COLORS.TEXT_DEFAULT }}
@@ -206,15 +205,12 @@ export default function ConfirmationPage() {
             padding={[1, 4, 4]}
             flexDirection={FLEX_DIRECTION.COLUMN}
           >
-            <SiteIcon
-              icon={originMetadata.iconUrl}
-              name={originMetadata.hostname}
-              size={36}
-            />
             <SiteOrigin
               chip
               siteOrigin={stripHttpsScheme(originMetadata.origin)}
               title={stripHttpsScheme(originMetadata.origin)}
+              iconSrc={originMetadata.iconUrl}
+              iconName={originMetadata.hostname}
             />
           </Box>
         )}


### PR DESCRIPTION
## Explanation

* Added 8px of margin to the top of the network display as it was touching the edge of the view
* Removed the SiteIcon component and passed the icon url to the SiteOrigin to display the icon next to the origin. This is similar to PermissionsConnectHeader styling.

## Screenshots/Screencaps

### Before
<img width="360" alt="Screen Shot 2022-07-04 at 5 47 58 PM" src="https://user-images.githubusercontent.com/4406751/177219193-85197908-360d-443a-81a2-a960081048a8.png">

### After
<img width="358" alt="Screen Shot 2022-07-04 at 5 48 39 PM" src="https://user-images.githubusercontent.com/4406751/177219239-ec8c593d-e2c9-490c-b7bf-864dc5de6b91.png">



## Manual Testing Steps

- Connect wallet
- Prompt network switch

## Pre-Merge Checklist

- [x] PR template is filled out
- [ ] **IF** this PR fixes a bug, a test that _would have_ caught the bug has been added
- [ ] PR is linked to the appropriate GitHub issue
- [ ] PR has been added to the appropriate release Milestone

### + If there are functional changes:

- [ ] Manual testing complete & passed
- [ ] "Extension QA Board" label has been applied
