### PR TITLE
Disable Seedphrase import button after switching seedphrase length 

### DIFF
--- a/ui/components/app/srp-input/srp-input.js
+++ b/ui/components/app/srp-input/srp-input.js
@@ -35,7 +35,7 @@ export default function SrpInput({ onChange, srpText }) {
   const onSrpChange = useCallback(
     (newDraftSrp) => {
       let newSrpError = '';
-      const joinedDraftSrp = newDraftSrp.join(' ');
+      const joinedDraftSrp = newDraftSrp.join(' ').trim();
 
       if (newDraftSrp.some((word) => word !== '')) {
         if (newDraftSrp.some((word) => word === '')) {


### PR DESCRIPTION
Part of https://github.com/MetaMask/metamask-extension/issues/14657

This was actually addressed in #14751, but I accidentally messed up the PR; this new PR will have the changes based on the reviewer comments from the previous PR.

Scenario:
One of the reasons that are causing the SeedPhrase is invalid error seems to be because the import button gets enabled when the seed phrase boxes are all empty, and the user switches to a different seedphrase length via the drop-down after entering a valid password and confirm password and checking the terms and conditions, as mentioned in this comment (https://github.com/MetaMask/metamask-extension/issues/14657#issuecomment-1131570685). This will enable the user to submit an empty seed phrase which will throw the error when we try to re-validate by calling bip39.validateMnemonic in the createNewVaultandRestore method.

Solution:
This is happening because we are doing a .join('')) on the array holding the srp words, and when the srp array is empty, we generate a long string of white spaces that return true for a boolean value. The solution proposed here is to assign an empty string as the seedphrase if draft srp all the elements in the array are empty strings, by doing trim() on the string formed by joining the seedphrase words list.


Test steps:

1. Load a complete new Metamask extension
2. Click Import Wallet
3. Accept/Decline Metametrics
4. Introduce password + password confirmation without entering a seedphrase.
5. Try changing the seed phrase length using the dropdown
6. Verify that the Import button is disabled without the correct length and valid seed phrase.