### PR TITLE
Pass phishfort specific new issue url to phishing-warning page.

### DIFF
--- a/app/scripts/contentscript.js
+++ b/app/scripts/contentscript.js
@@ -367,6 +367,6 @@ function redirectToPhishingWarning(data) {
   window.location.href = `${baseUrl}#${querystring.stringify({
     hostname: window.location.hostname,
     href: window.location.href,
-    newIssueUrl: data.newIssueUrl,
+    newIssueUrl: data?.newIssueUrl,
   })}`;
 }

--- a/app/scripts/contentscript.js
+++ b/app/scripts/contentscript.js
@@ -358,12 +358,15 @@ function blockedDomainCheck() {
 
 /**
  * Redirects the current page to a phishing information page
+ *
+ * @param data
  */
-function redirectToPhishingWarning() {
+function redirectToPhishingWarning(data) {
   console.debug('MetaMask: Routing to Phishing Warning page.');
   const baseUrl = process.env.PHISHING_WARNING_PAGE_URL;
   window.location.href = `${baseUrl}#${querystring.stringify({
     hostname: window.location.hostname,
     href: window.location.href,
+    newIssueUrl: data.newIssueUrl,
   })}`;
 }

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -58,6 +58,7 @@ import {
   TRANSACTION_STATUSES,
   TRANSACTION_TYPES,
 } from '../../shared/constants/transaction';
+import { PHISHING_NEW_ISSUE_URLS } from '../../shared/constants/phishing';
 import {
   GAS_API_BASE_URL,
   GAS_DEV_API_BASE_URL,
@@ -3286,9 +3287,13 @@ export default class MetamaskController extends EventEmitter {
     if (sender.url) {
       const { hostname } = new URL(sender.url);
       // Check if new connection is blocked if phishing detection is on
-      if (usePhishDetect && this.phishingController.test(hostname)?.result) {
-        log.debug('MetaMask - sending phishing warning for', hostname);
-        this.sendPhishingWarning(connectionStream, hostname);
+      const phishingTestResponse = this.phishingController.test(hostname);
+      if (usePhishDetect && phishingTestResponse?.result) {
+        this.sendPhishingWarning(
+          connectionStream,
+          hostname,
+          phishingTestResponse,
+        );
         return;
       }
     }
@@ -3366,11 +3371,15 @@ export default class MetamaskController extends EventEmitter {
    * @param {*} connectionStream - The duplex stream to the per-page script,
    * for sending the reload attempt to.
    * @param {string} hostname - The hostname that triggered the suspicion.
+   * @param {object} phishingTestResponse - Result of calling `phishingController.test`,
+   * which is the result of calling eth-phishing-detects detector.check method https://github.com/MetaMask/eth-phishing-detect/blob/master/src/detector.js#L55-L112
    */
-  sendPhishingWarning(connectionStream, hostname) {
+  sendPhishingWarning(connectionStream, hostname, phishingTestResponse) {
+    const newIssueUrl = PHISHING_NEW_ISSUE_URLS[phishingTestResponse?.name];
+
     const mux = setupMultiplex(connectionStream);
     const phishingStream = mux.createStream('phishing');
-    phishingStream.write({ hostname });
+    phishingStream.write({ hostname, newIssueUrl });
   }
 
   /**

--- a/package.json
+++ b/package.json
@@ -251,7 +251,7 @@
     "@metamask/eslint-config-nodejs": "^9.0.0",
     "@metamask/eslint-config-typescript": "^9.0.1",
     "@metamask/forwarder": "^1.1.0",
-    "@metamask/phishing-warning": "^1.1.0",
+    "@metamask/phishing-warning": "^1.2.1",
     "@metamask/test-dapp": "^5.1.1",
     "@sentry/cli": "^1.58.0",
     "@storybook/addon-a11y": "^6.3.12",

--- a/shared/constants/phishing.js
+++ b/shared/constants/phishing.js
@@ -1,0 +1,4 @@
+export const PHISHING_NEW_ISSUE_URLS = {
+  MetaMask: 'https://github.com/metamask/eth-phishing-detect/issues/new',
+  PhishFort: 'https://github.com/phishfort/phishfort-lists/issues/new',
+};

--- a/test/e2e/tests/phishing-detection.spec.js
+++ b/test/e2e/tests/phishing-detection.spec.js
@@ -27,13 +27,7 @@ describe('Phishing Detection', function () {
     await mockServer.forGet(PHISHFORT_CDN_URL).thenCallback(() => {
       return {
         statusCode: 200,
-        json: {
-          version: 2,
-          tolerance: 2,
-          fuzzylist: [],
-          whitelist: [],
-          blacklist: ['127.0.0.1'],
-        },
+        json: ['127.0.0.1'],
       };
     });
   }

--- a/test/e2e/tests/phishing-detection.spec.js
+++ b/test/e2e/tests/phishing-detection.spec.js
@@ -157,10 +157,8 @@ describe('Phishing Detection', function () {
         const newIssueLink = await driver.findElement({
           text: 'please file an issue',
         });
-        assert.equal(
-          await newIssueLink.getAttribute('href'),
-          PHISHFORT_CDN_URL,
-        );
+        await newIssueLink.click();
+        assert.ok(/https:\/\/github\.com\.*/u.test(await driver.getCurrentUrl()));
       },
     );
   });

--- a/test/e2e/tests/phishing-detection.spec.js
+++ b/test/e2e/tests/phishing-detection.spec.js
@@ -154,11 +154,10 @@ describe('Phishing Detection', function () {
         await driver.fill('#password', 'correct horse battery staple');
         await driver.press('#password', driver.Key.ENTER);
         await driver.openNewPage('http://127.0.0.1:8080');
-        const newIssueLink = await driver.findElement({
-          text: 'please file an issue',
-        });
-        await newIssueLink.click();
-        assert.ok(/https:\/\/github\.com\.*/u.test(await driver.getCurrentUrl()));
+        const newIssueLink = await driver.findElements(
+          "a[href='https://github.com/phishfort/phishfort-lists/issues/new?title=[Legitimate%20Site%20Blocked]%20127.0.0.1&body=http%3A%2F%2F127.0.0.1%3A8080%2F']",
+        );
+        assert.equal(newIssueLink.length, 1);
       },
     );
   });

--- a/test/e2e/tests/phishing-detection.spec.js
+++ b/test/e2e/tests/phishing-detection.spec.js
@@ -23,7 +23,7 @@ describe('Phishing Detection', function () {
         };
       });
   }
-  async function mockPhistfortPhishingDetection(mockServer) {
+  async function mockPhishfortPhishingDetection(mockServer) {
     await mockServer.forGet(PHISHFORT_CDN_URL).thenCallback(() => {
       return {
         statusCode: 200,
@@ -151,7 +151,7 @@ describe('Phishing Detection', function () {
         fixtures: 'imported-account',
         ganacheOptions,
         title: this.test.title,
-        testSpecificMock: mockPhistfortPhishingDetection,
+        testSpecificMock: mockPhishfortPhishingDetection,
         dapp: true,
         failOnConsoleError: false,
       },

--- a/test/e2e/webdriver/driver.js
+++ b/test/e2e/webdriver/driver.js
@@ -302,6 +302,10 @@ class Driver {
     await this.driver.get(url);
     return newHandle;
   }
+  
+  async getCurrentUrl() {
+    return await this.driver.getCurrentUrl();
+  }
 
   async switchToWindow(handle) {
     await this.driver.switchTo().window(handle);

--- a/test/e2e/webdriver/driver.js
+++ b/test/e2e/webdriver/driver.js
@@ -302,7 +302,7 @@ class Driver {
     await this.driver.get(url);
     return newHandle;
   }
-  
+
   async getCurrentUrl() {
     return await this.driver.getCurrentUrl();
   }

--- a/test/e2e/webdriver/driver.js
+++ b/test/e2e/webdriver/driver.js
@@ -303,10 +303,6 @@ class Driver {
     return newHandle;
   }
 
-  async getCurrentUrl() {
-    return await this.driver.getCurrentUrl();
-  }
-
   async switchToWindow(handle) {
     await this.driver.switchTo().window(handle);
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3011,13 +3011,13 @@
     "@metamask/safe-event-emitter" "^2.0.0"
     through2 "^2.0.3"
 
-"@metamask/phishing-warning@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@metamask/phishing-warning/-/phishing-warning-1.1.0.tgz#0d5764327c413dd1900db786e295bd729530ca66"
-  integrity sha512-39N7lU9fdkXZKHn/hbkiEhv1oJ3mabPjYMk22582a7XzdBD5wgxDf5qHsXXQlOq+uI3lBU9VVKD7K7Z2lcgapw==
+"@metamask/phishing-warning@^1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@metamask/phishing-warning/-/phishing-warning-1.2.1.tgz#75554f8653a32c8d101c5b315707dd7990daf156"
+  integrity sha512-VfQLwiQmXg9YrJzBmDKN6eknNEkxYEAssTpoObVrDYiS91LjuDU59IjoIc1SN9IzDNxIP6ZI95dOculsm/o4qw==
   dependencies:
     "@metamask/design-tokens" "^1.6.0"
-    "@metamask/post-message-stream" "^4.0.0"
+    "@metamask/post-message-stream" "^5.1.0"
     globalthis "1.0.1"
     obj-multiplex "^1.0.0"
     pump "^3.0.0"
@@ -3028,6 +3028,14 @@
   resolved "https://registry.yarnpkg.com/@metamask/post-message-stream/-/post-message-stream-4.0.0.tgz#72f120e562346ca86ccc9b3684023ad44265f0df"
   integrity sha512-r0JcoWXNuHycProx8ClxiIElJY/GVb/0/WWXTMsZu7qDejLo52VNXlwfydCdVjbMXeoT2nK1Yt3d5gjmHy5BWw==
   dependencies:
+    readable-stream "2.3.3"
+
+"@metamask/post-message-stream@^5.1.0":
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@metamask/post-message-stream/-/post-message-stream-5.1.0.tgz#3e9a2ed11b540b3868a0a28ffa8ec5a6e5fca29d"
+  integrity sha512-BQi/H67iM7wdtmvoPfgW9bazk/WjvRhXRa5lQ1FpgDlASv1bsCDJaQQ83Q3BwYyisnpnjgJRuC/2bRmas0LMxA==
+  dependencies:
+    "@metamask/utils" "^2.0.0"
     readable-stream "2.3.3"
 
 "@metamask/providers@^9.0.0":


### PR DESCRIPTION
Compares to https://github.com/MetaMask/metamask-extension/pull/14906. We will merge this into that before that is merged.

This PR is part of the resolution to this comment https://github.com/MetaMask/metamask-extension/pull/14906#issuecomment-1164472625 and https://github.com/MetaMask/phishing-warning/issues/15

Along with https://github.com/MetaMask/phishing-warning/pull/23, this PR ensures that users who land on the phishing warning page because they were attempting to access a url blocked by phishfort are redirected to the phishfort github issues page when clicking the "please file an issue" link