### PR TITLE
Added metrics for adding a new network

### DIFF
--- a/app/scripts/lib/rpc-method-middleware/handlers/add-ethereum-chain.js
+++ b/app/scripts/lib/rpc-method-middleware/handlers/add-ethereum-chain.js
@@ -267,9 +267,8 @@ async function addEthereumChainHandler(
       referrer: {
         url: origin,
       },
-      sensitiveProperties: {
+      properties: {
         chain_id: _chainId,
-        rpc_url: firstValidRPCUrl,
         network_name: _chainName,
         // Including network to override the default network
         // property included in all events. For RPC type networks
@@ -279,6 +278,9 @@ async function addEthereumChainHandler(
         symbol: ticker,
         block_explorer_url: firstValidBlockExplorerUrl,
         source: EVENT.SOURCE.TRANSACTION.DAPP,
+      },
+      sensitiveProperties: {
+        rpc_url: firstValidRPCUrl,
       },
     });
 

--- a/app/scripts/lib/rpc-method-middleware/handlers/add-ethereum-chain.js
+++ b/app/scripts/lib/rpc-method-middleware/handlers/add-ethereum-chain.js
@@ -278,7 +278,7 @@ async function addEthereumChainHandler(
         network: firstValidRPCUrl,
         symbol: ticker,
         block_explorer_url: firstValidBlockExplorerUrl,
-        source: EVENT.SOURCE.NETWORK.DAPP_API,
+        source: EVENT.SOURCE.TRANSACTION.DAPP,
       },
     });
 

--- a/app/scripts/lib/rpc-method-middleware/handlers/add-ethereum-chain.js
+++ b/app/scripts/lib/rpc-method-middleware/handlers/add-ethereum-chain.js
@@ -278,7 +278,7 @@ async function addEthereumChainHandler(
         network: firstValidRPCUrl,
         symbol: ticker,
         block_explorer_url: firstValidBlockExplorerUrl,
-        source: EVENT.SOURCE.TRANSACTION.DAPP,
+        source: EVENT.SOURCE.NETWORK.DAPP_API,
       },
     });
 

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -2071,14 +2071,16 @@ export default class MetamaskController extends EventEmitter {
       referrer: {
         url: rpcUrl,
       },
-      sensitiveProperties: {
+      properties: {
         chain_id: chainId,
-        rpc_url: rpcUrl,
         network_name: chainName,
         network: rpcUrl,
         symbol: ticker,
         block_explorer_url: blockExplorerUrl,
         source: EVENT.SOURCE.NETWORK.POPULAR_NETWORK_LIST,
+      },
+      sensitiveProperties: {
+        rpc_url: rpcUrl,
       },
     });
   }

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -2064,6 +2064,23 @@ export default class MetamaskController extends EventEmitter {
         blockExplorerUrl,
       },
     );
+
+    this.metaMetricsController.trackEvent({
+      event: 'Custom Network Added',
+      category: EVENT.CATEGORIES.NETWORK,
+      referrer: {
+        url: rpcUrl,
+      },
+      sensitiveProperties: {
+        chain_id: chainId,
+        rpc_url: rpcUrl,
+        network_name: chainName,
+        network: rpcUrl,
+        symbol: ticker,
+        block_explorer_url: blockExplorerUrl,
+        source: EVENT.SOURCE.NETWORK.POPULAR_NETWORK_LIST,
+      },
+    });
   }
 
   /**

--- a/shared/constants/metametrics.js
+++ b/shared/constants/metametrics.js
@@ -306,7 +306,6 @@ export const EVENT = {
   },
   SOURCE: {
     NETWORK: {
-      DAPP_API: 'dApp_API',
       POPULAR_NETWORK_LIST: 'popular_network_list',
       CUSTOM_NETWORK_FORM: 'custom_network_form',
     },

--- a/shared/constants/metametrics.js
+++ b/shared/constants/metametrics.js
@@ -305,6 +305,11 @@ export const EVENT = {
     WALLET: 'Wallet',
   },
   SOURCE: {
+    NETWORK: {
+      DAPP_API: 'dApp_API',
+      POPULAR_NETWORK_LIST: 'popular_network_list',
+      CUSTOM_NETWORK_FORM: 'custom_network_form',
+    },
     SWAPS: {
       MAIN_VIEW: 'Main View',
       TOKEN_VIEW: 'Token View',

--- a/ui/pages/settings/networks-tab/networks-form/networks-form.js
+++ b/ui/pages/settings/networks-tab/networks-form/networks-form.js
@@ -511,14 +511,16 @@ const NetworksForm = ({
           referrer: {
             url: rpcUrl,
           },
-          sensitiveProperties: {
+          properties: {
             chain_id: chainId,
-            rpc_url: rpcUrl,
             network_name: networkName,
             network: rpcUrl,
             symbol: ticker,
             block_explorer_url: blockExplorerUrl,
             source: EVENT.SOURCE.NETWORK.CUSTOM_NETWORK_FORM,
+          },
+          sensitiveProperties: {
+            rpc_url: rpcUrl,
           },
         });
         dispatch(setNewNetworkAdded(networkName));

--- a/ui/pages/settings/networks-tab/networks-form/networks-form.js
+++ b/ui/pages/settings/networks-tab/networks-form/networks-form.js
@@ -1,4 +1,10 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, {
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
 import { useHistory } from 'react-router-dom';
 import { useDispatch } from 'react-redux';
 import PropTypes from 'prop-types';
@@ -28,6 +34,8 @@ import {
 } from '../../../../helpers/constants/routes';
 import fetchWithCache from '../../../../helpers/utils/fetch-with-cache';
 import { usePrevious } from '../../../../hooks/usePrevious';
+import { MetaMetricsContext } from '../../../../contexts/metametrics';
+import { EVENT } from '../../../../../shared/constants/metametrics';
 
 /**
  * Attempts to convert the given chainId to a decimal string, for display
@@ -73,6 +81,7 @@ const NetworksForm = ({
   selectedNetwork,
 }) => {
   const t = useI18nContext();
+  const trackEvent = useContext(MetaMetricsContext);
   const history = useHistory();
   const dispatch = useDispatch();
   const { label, labelKey, viewOnly, rpcPrefs } = selectedNetwork;
@@ -496,6 +505,22 @@ const NetworksForm = ({
       }
 
       if (addNewNetwork) {
+        trackEvent({
+          event: 'Custom Network Added',
+          category: EVENT.CATEGORIES.NETWORK,
+          referrer: {
+            url: rpcUrl,
+          },
+          sensitiveProperties: {
+            chain_id: chainId,
+            rpc_url: rpcUrl,
+            network_name: networkName,
+            network: rpcUrl,
+            symbol: ticker,
+            block_explorer_url: blockExplorerUrl,
+            source: EVENT.SOURCE.NETWORK.CUSTOM_NETWORK_FORM,
+          },
+        });
         dispatch(setNewNetworkAdded(networkName));
         history.push(DEFAULT_ROUTE);
       }


### PR DESCRIPTION
## Explanation

Added a metrics mechanism when adding a new network.
Updated the `Custom Network Added`  event to include a source (string) property, which options will be `dApp API`, `popular network list` or `custom network form`:

- `dApp_API` is used when the network was added after a dApp prompt the user to do so (e. g. http://chainlist.org/).
- `popular_network_list` is used when the user adds a network by using the new feature for adding the popular custom network
- `custom_network_form` is used when the user adds a network manually by filling the add a network form

Fixes: https://github.com/MetaMask/metamask-extension/issues/13887