### PR TITLE
Handling invalid prop `loading` console warning

### DIFF
--- a/ui/components/app/wallet-overview/wallet-overview.js
+++ b/ui/components/app/wallet-overview/wallet-overview.js
@@ -19,7 +19,7 @@ WalletOverview.propTypes = {
   buttons: PropTypes.element.isRequired,
   className: PropTypes.string,
   icon: PropTypes.element.isRequired,
-  loading: PropTypes.boolean,
+  loading: PropTypes.bool,
 };
 
 WalletOverview.defaultProps = {


### PR DESCRIPTION
## Explanation

Invalid prop `loading` produces a console warning on the home screen. 

## More Information

It is now handled only with changing `boolean` to `bool` in `WalletOverview`.

## Screenshots/Screencaps

![Screenshot 2022-07-11 at 16 10 58](https://user-images.githubusercontent.com/92527393/178285263-665100cb-3ba6-4132-acb8-50897ba1fa8f.png)

### Before

### After

## Manual Testing Steps

1. Unlock MetaMask
2. Check the console
