### PR TITLE
Disable Seedphrase import button if any of the characters is in uppercase

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -1627,6 +1627,9 @@
   "invalidSeedPhrase": {
     "message": "Invalid Secret Recovery Phrase"
   },
+  "invalidSeedPhraseCaseSensitive": {
+    "message": "Invalid input! Secret Recovery Phrase is case sensitive."
+  },
   "ipfsGateway": {
     "message": "IPFS Gateway"
   },

--- a/ui/components/app/srp-input/srp-input.js
+++ b/ui/components/app/srp-input/srp-input.js
@@ -44,10 +44,9 @@ export default function SrpInput({ onChange, srpText }) {
       if (newDraftSrp.some((word) => word !== '')) {
         if (newDraftSrp.some((word) => word === '')) {
           newSrpError = t('seedPhraseReq');
-        } else if (
-          isLowerCase(joinedDraftSrp) ||
-          !isValidMnemonic(joinedDraftSrp)
-        ) {
+        } else if (isLowerCase(joinedDraftSrp)) {
+          newSrpError = t('invalidSeedPhraseCaseSensitive');
+        } else if (!isValidMnemonic(joinedDraftSrp)) {
           newSrpError = t('invalidSeedPhrase');
         }
       }

--- a/ui/components/app/srp-input/srp-input.js
+++ b/ui/components/app/srp-input/srp-input.js
@@ -19,6 +19,10 @@ const { isValidMnemonic } = ethers.utils;
 
 const defaultNumberOfWords = 12;
 
+const isLowerCase = (draftSrp) => {
+  return draftSrp !== draftSrp.toLowerCase();
+};
+
 export default function SrpInput({ onChange, srpText }) {
   const [srpError, setSrpError] = useState('');
   const [pasteFailed, setPasteFailed] = useState(false);
@@ -40,7 +44,10 @@ export default function SrpInput({ onChange, srpText }) {
       if (newDraftSrp.some((word) => word !== '')) {
         if (newDraftSrp.some((word) => word === '')) {
           newSrpError = t('seedPhraseReq');
-        } else if (!isValidMnemonic(joinedDraftSrp)) {
+        } else if (
+          isLowerCase(joinedDraftSrp) ||
+          !isValidMnemonic(joinedDraftSrp)
+        ) {
           newSrpError = t('invalidSeedPhrase');
         }
       }

--- a/ui/components/app/srp-input/srp-input.js
+++ b/ui/components/app/srp-input/srp-input.js
@@ -19,7 +19,7 @@ const { isValidMnemonic } = ethers.utils;
 
 const defaultNumberOfWords = 12;
 
-const isLowerCase = (draftSrp) => {
+const hasUpperCase = (draftSrp) => {
   return draftSrp !== draftSrp.toLowerCase();
 };
 
@@ -44,7 +44,7 @@ export default function SrpInput({ onChange, srpText }) {
       if (newDraftSrp.some((word) => word !== '')) {
         if (newDraftSrp.some((word) => word === '')) {
           newSrpError = t('seedPhraseReq');
-        } else if (isLowerCase(joinedDraftSrp)) {
+        } else if (hasUpperCase(joinedDraftSrp)) {
           newSrpError = t('invalidSeedPhraseCaseSensitive');
         } else if (!isValidMnemonic(joinedDraftSrp)) {
           newSrpError = t('invalidSeedPhrase');


### PR DESCRIPTION
Part of https://github.com/MetaMask/metamask-extension/issues/14657

The main reason behind the `Seed phrase invalid` error seems to be that some cases accepted by `isValidMnemonic` from ethers.utils in srp-inpiut.js are rejected when the SRP is revalidated at bip39.validateMnemonic in the createNewVaultandRestore method.
One of the scenarios is covered in #15139 

Second scenario: 
As mentioned in the comment https://github.com/MetaMask/metamask-extension/issues/14657#issuecomment-1158845402 by @seaona, when a user enters an uppercase letter by mistake it will be accepted by `isValidMnemonic` in srp-input but reject at `validateMnemonic` during revalidation.

Solution:
To enable the import button only if all the words on the SRP are in lower case.

Test steps:

1. Load a complete new Metamask extension
2. Click Import Wallet
3. Accept/Decline Metametrics
4. Type-in/copy-paste a valid seedphrase and then change any of the letters to uppercase
5.  Verify that the Import button is disabled with the error message `Invalid Secret Recovery Phrase` showing (with and without entering the password and checking the terms & conditions checkbox). 
