### PR TITLE
[FLASK] Fix snaps authorship pill

### DIFF
--- a/ui/components/app/flask/snaps-authorship-pill/index.scss
+++ b/ui/components/app/flask/snaps-authorship-pill/index.scss
@@ -1,14 +1,18 @@
 @import "design-system";
 
 .snaps-authorship-pill {
-  display: inline-block;
+  width: 100%;
+  display: inline-flex;
+  justify-content: center;
 
   .chip {
     padding-right: 8px;
+    max-width: 100%;
+    margin-left: 0;
+    margin-right: 0;
   }
 
   .chip__label {
-    max-width: 136px;
     text-overflow: ellipsis;
     overflow: hidden;
   }

--- a/ui/components/app/flask/snaps-authorship-pill/index.scss
+++ b/ui/components/app/flask/snaps-authorship-pill/index.scss
@@ -7,6 +7,12 @@
     padding-right: 8px;
   }
 
+  .chip__label {
+    max-width: 136px;
+    text-overflow: ellipsis;
+    overflow: hidden;
+  }
+
   &:hover,
   &:focus {
     .chip {

--- a/ui/components/app/flask/snaps-authorship-pill/index.scss
+++ b/ui/components/app/flask/snaps-authorship-pill/index.scss
@@ -14,7 +14,7 @@
   }
 
   .chip__label {
-    max-width: 256px;
+    max-width: 168px;
     text-overflow: ellipsis;
     overflow: hidden;
     white-space: nowrap;

--- a/ui/components/app/flask/snaps-authorship-pill/index.scss
+++ b/ui/components/app/flask/snaps-authorship-pill/index.scss
@@ -1,15 +1,10 @@
 @import "design-system";
 
 .snaps-authorship-pill {
-  width: 100%;
-  display: inline-flex;
-  justify-content: center;
+  display: inline-block;
 
   .chip {
     padding-right: 8px;
-    max-width: 100%;
-    margin-left: 0;
-    margin-right: 0;
     margin-top: 4px;
   }
 

--- a/ui/components/app/flask/snaps-authorship-pill/index.scss
+++ b/ui/components/app/flask/snaps-authorship-pill/index.scss
@@ -10,11 +10,14 @@
     max-width: 100%;
     margin-left: 0;
     margin-right: 0;
+    margin-top: 4px;
   }
 
   .chip__label {
+    max-width: 256px;
     text-overflow: ellipsis;
     overflow: hidden;
+    white-space: nowrap;
   }
 
   &:hover,

--- a/ui/components/app/flask/snaps-authorship-pill/snaps-authorship-pill.js
+++ b/ui/components/app/flask/snaps-authorship-pill/snaps-authorship-pill.js
@@ -63,6 +63,7 @@ const SnapsAuthorshipPill = ({ snapId, version, className }) => {
           variant={TYPOGRAPHY.H7}
           tag="span"
           color={COLORS.TEXT_ALTERNATIVE}
+          title={packageName}
         >
           {packageName}
         </Typography>

--- a/ui/pages/permissions-connect/flask/snap-install/index.scss
+++ b/ui/pages/permissions-connect/flask/snap-install/index.scss
@@ -1,11 +1,9 @@
 .snap-install {
   box-shadow: none;
 
-  .headers {
-    padding: 0 24px;
-  }
-
   .permissions-connect-permission-list {
+    padding: 0 24px;
+
     .permission {
       padding: 8px 0;
     }

--- a/ui/pages/permissions-connect/flask/snap-install/index.scss
+++ b/ui/pages/permissions-connect/flask/snap-install/index.scss
@@ -1,9 +1,11 @@
 .snap-install {
   box-shadow: none;
 
-  .permissions-connect-permission-list {
+  .headers {
     padding: 0 24px;
+  }
 
+  .permissions-connect-permission-list {
     .permission {
       padding: 8px 0;
     }


### PR DESCRIPTION
Fixes #15161 

An arbitrary `max-width` was chosen to enforce a limit at which a snap's package name is truncated in the pill. A title was added so that a user can still hover and view the complete package name.

Steps to reproduce:

1. Run a flask build using `yarn start --build-type flask` and add it to chrome.
2. Go to `snaplist.org` to test out the install flow.
3. Once you get to the install screen, you can inspect the page and change the package name in the DOM to a length that would typically offset the UI.
4. Observe that the pill truncates the package name.

Screenshot:
<img width="361" alt="Screen Shot 2022-07-12 at 12 05 31 AM" src="https://user-images.githubusercontent.com/41640681/178406674-b624d2dd-2d7a-4e3d-89d1-706202d71dbd.png">





