### PR TITLE
Removed the Infura v3 key from rpcUrl display

### DIFF
--- a/shared/constants/network.js
+++ b/shared/constants/network.js
@@ -56,7 +56,7 @@ export const FANTOM_DISPLAY_NAME = 'Fantom Opera';
 export const HARMONY_DISPLAY_NAME = 'Harmony Mainnet Shard 0';
 export const PALM_DISPLAY_NAME = 'Palm';
 
-const infuraProjectId = process.env.INFURA_PROJECT_ID;
+export const infuraProjectId = process.env.INFURA_PROJECT_ID;
 export const getRpcUrl = ({ network, excludeProjectId = false }) =>
   `https://${network}.infura.io/v3/${excludeProjectId ? '' : infuraProjectId}`;
 

--- a/ui/pages/confirmation/templates/add-ethereum-chain.js
+++ b/ui/pages/confirmation/templates/add-ethereum-chain.js
@@ -1,5 +1,6 @@
 import { ethErrors } from 'eth-rpc-errors';
 import React from 'react';
+import { infuraProjectId } from '../../../../shared/constants/network';
 import {
   SEVERITIES,
   TYPOGRAPHY,
@@ -268,10 +269,10 @@ function getValues(pendingApproval, t, actions) {
           dictionary: {
             [t('networkName')]: pendingApproval.requestData.chainName,
             [t('networkURL')]: pendingApproval.requestData.rpcUrl.includes(
-              `/v3/${process.env.INFURA_PROJECT_ID}`,
+              `/v3/${infuraProjectId}`,
             )
               ? pendingApproval.requestData.rpcUrl.replace(
-                  `/v3/${process.env.INFURA_PROJECT_ID}`,
+                  `/v3/${infuraProjectId}`,
                   '',
                 )
               : pendingApproval.requestData.rpcUrl,

--- a/ui/pages/confirmation/templates/add-ethereum-chain.js
+++ b/ui/pages/confirmation/templates/add-ethereum-chain.js
@@ -267,7 +267,14 @@ function getValues(pendingApproval, t, actions) {
           },
           dictionary: {
             [t('networkName')]: pendingApproval.requestData.chainName,
-            [t('networkURL')]: pendingApproval.requestData.rpcUrl,
+            [t('networkURL')]: pendingApproval.requestData.rpcUrl.includes(
+              'infura.io',
+            )
+              ? pendingApproval.requestData.rpcUrl.substring(
+                  0,
+                  pendingApproval.requestData.rpcUrl.indexOf('infura.io') + 9,
+                )
+              : pendingApproval.requestData.rpcUrl,
             [t('chainId')]: parseInt(pendingApproval.requestData.chainId, 16),
             [t('currencySymbol')]: pendingApproval.requestData.ticker,
             [t('blockExplorerUrl')]: pendingApproval.requestData

--- a/ui/pages/confirmation/templates/add-ethereum-chain.js
+++ b/ui/pages/confirmation/templates/add-ethereum-chain.js
@@ -268,11 +268,11 @@ function getValues(pendingApproval, t, actions) {
           dictionary: {
             [t('networkName')]: pendingApproval.requestData.chainName,
             [t('networkURL')]: pendingApproval.requestData.rpcUrl.includes(
-              'infura.io',
+              `/v3/${process.env.INFURA_PROJECT_ID}`,
             )
-              ? pendingApproval.requestData.rpcUrl.substring(
-                  0,
-                  pendingApproval.requestData.rpcUrl.indexOf('infura.io') + 9,
+              ? pendingApproval.requestData.rpcUrl.replace(
+                  `/v3/${process.env.INFURA_PROJECT_ID}`,
+                  '',
                 )
               : pendingApproval.requestData.rpcUrl,
             [t('chainId')]: parseInt(pendingApproval.requestData.chainId, 16),

--- a/ui/pages/confirmation/templates/add-ethereum-chain.js
+++ b/ui/pages/confirmation/templates/add-ethereum-chain.js
@@ -268,7 +268,7 @@ function getValues(pendingApproval, t, actions) {
           },
           dictionary: {
             [t('networkName')]: pendingApproval.requestData.chainName,
-            [t('networkURL')]: pendingApproval.requestData.rpcUrl.includes(
+            [t('networkURL')]: pendingApproval.requestData.rpcUrl?.includes(
               `/v3/${infuraProjectId}`,
             )
               ? pendingApproval.requestData.rpcUrl.replace(

--- a/ui/pages/settings/networks-tab/networks-form/networks-form.js
+++ b/ui/pages/settings/networks-tab/networks-form/networks-form.js
@@ -610,7 +610,7 @@ const NetworksForm = ({
           onChange={setRpcUrl}
           titleText={t('rpcUrl')}
           value={
-            rpcUrl.includes(`/v3/${infuraProjectId}`)
+            rpcUrl?.includes(`/v3/${infuraProjectId}`)
               ? rpcUrl.replace(`/v3/${infuraProjectId}`, '')
               : rpcUrl
           }

--- a/ui/pages/settings/networks-tab/networks-form/networks-form.js
+++ b/ui/pages/settings/networks-tab/networks-form/networks-form.js
@@ -36,7 +36,10 @@ import fetchWithCache from '../../../../helpers/utils/fetch-with-cache';
 import { usePrevious } from '../../../../hooks/usePrevious';
 import { MetaMetricsContext } from '../../../../contexts/metametrics';
 import { EVENT } from '../../../../../shared/constants/metametrics';
-import { infuraProjectId } from '../../../../../shared/constants/network';
+import {
+  infuraProjectId,
+  FEATURED_RPCS,
+} from '../../../../../shared/constants/network';
 
 /**
  * Attempts to convert the given chainId to a decimal string, for display
@@ -97,6 +100,9 @@ const NetworksForm = ({
   const [errors, setErrors] = useState({});
   const [warnings, setWarnings] = useState({});
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const chainIdMatchesFeaturedRPC = FEATURED_RPCS.some(
+    (featuredRpc) => Number(featuredRpc.chainId) === Number(chainId),
+  );
 
   const resetForm = useCallback(() => {
     setNetworkName(selectedNetworkName || '');
@@ -556,10 +562,13 @@ const NetworksForm = ({
   };
   const deletable = !isCurrentRpcTarget && !viewOnly && !addNewNetwork;
   const stateUnchanged = stateIsUnchanged();
+  const chainIdErrorOnFeaturedRpcDuringEdit =
+    selectedNetwork?.rpcUrl && warnings.chainId && chainIdMatchesFeaturedRPC;
   const isSubmitDisabled =
     hasErrors() ||
     isSubmitting ||
     stateUnchanged ||
+    chainIdErrorOnFeaturedRpcDuringEdit ||
     !rpcUrl ||
     !chainId ||
     !ticker;

--- a/ui/pages/settings/networks-tab/networks-form/networks-form.js
+++ b/ui/pages/settings/networks-tab/networks-form/networks-form.js
@@ -36,6 +36,7 @@ import fetchWithCache from '../../../../helpers/utils/fetch-with-cache';
 import { usePrevious } from '../../../../hooks/usePrevious';
 import { MetaMetricsContext } from '../../../../contexts/metametrics';
 import { EVENT } from '../../../../../shared/constants/metametrics';
+import { infuraProjectId } from '../../../../../shared/constants/network';
 
 /**
  * Attempts to convert the given chainId to a decimal string, for display
@@ -600,8 +601,8 @@ const NetworksForm = ({
           onChange={setRpcUrl}
           titleText={t('rpcUrl')}
           value={
-            rpcUrl.includes(`/v3/${process.env.INFURA_PROJECT_ID}`)
-              ? rpcUrl.replace(`/v3/${process.env.INFURA_PROJECT_ID}`, '')
+            rpcUrl.includes(`/v3/${infuraProjectId}`)
+              ? rpcUrl.replace(`/v3/${infuraProjectId}`, '')
               : rpcUrl
           }
           disabled={viewOnly}

--- a/ui/pages/settings/networks-tab/networks-form/networks-form.js
+++ b/ui/pages/settings/networks-tab/networks-form/networks-form.js
@@ -600,8 +600,8 @@ const NetworksForm = ({
           onChange={setRpcUrl}
           titleText={t('rpcUrl')}
           value={
-            rpcUrl.includes('infura.io')
-              ? rpcUrl.substring(0, rpcUrl.indexOf('infura.io') + 9)
+            rpcUrl.includes(`/v3/${process.env.INFURA_PROJECT_ID}`)
+              ? rpcUrl.replace(`/v3/${process.env.INFURA_PROJECT_ID}`, '')
               : rpcUrl
           }
           disabled={viewOnly}

--- a/ui/pages/settings/networks-tab/networks-form/networks-form.js
+++ b/ui/pages/settings/networks-tab/networks-form/networks-form.js
@@ -599,7 +599,11 @@ const NetworksForm = ({
           error={errors.rpcUrl?.msg || ''}
           onChange={setRpcUrl}
           titleText={t('rpcUrl')}
-          value={rpcUrl}
+          value={
+            rpcUrl.includes('infura.io')
+              ? rpcUrl.substring(0, rpcUrl.indexOf('infura.io') + 9)
+              : rpcUrl
+          }
           disabled={viewOnly}
         />
         <FormField


### PR DESCRIPTION
## Explanation

Removed `Infura project ID` from displaying when adding a popular custom network (add network modal) and when editing network details.

<!--
Thanks for the pull request. Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Below is a template to give you some ideas. Feel free to use your own words!

Currently, ...

This is a problem because ...

In order to solve this problem, this pull request ...
-->

## More Information

Fixes: https://github.com/MetaMask/metamask-extension/issues/15174
<!--
Are there any issues, Slack conversations, Zendesk issues, user stories, etc. reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

## Screenshots/Screencaps

<!-- If you're making a change to the UI, make sure to capture a screenshot or a short video showing off your work! -->

### Before

<img width="974" alt="Screenshot 2022-07-12 at 11 20 41" src="https://user-images.githubusercontent.com/92310504/178458656-6b1b2b53-5c3e-435c-b738-87483e5b6508.png">


<!-- How did the UI you changed look before your changes? Drag your file(s) below this line: -->


<img width="1124" alt="Screenshot 2022-07-12 at 11 22 23" src="https://user-images.githubusercontent.com/92310504/178458671-604bb843-ec6e-46ca-9601-4d8b05097855.png">


### After

<img width="988" alt="Screenshot 2022-07-12 at 11 10 01" src="https://user-images.githubusercontent.com/92310504/178458773-e78e3f94-9544-43d7-ac81-4c5c9038d1d1.png">
<img width="991" alt="Screenshot 2022-07-12 at 11 11 08" src="https://user-images.githubusercontent.com/92310504/178458779-6f254f0d-6a6a-4432-9b9d-85d614d678cd.png">


<!-- How does it look now? Drag your file(s) below this line: -->

## Manual Testing Steps
`1st case`

1. From experimental tab enable showing the popular custom network list.
2. Go to networks tab.
3. Add a network.
4. Click to add a network that relies on Infura ID (without the warning icon).
5. When a popup shows up, `Network URL` contains the Infura ID (after infura.io/v3/).

`2nd case`

1. Go to networks tab.
2. See `New RPC URL` box which contains the Infura ID (after infura.io/v3/).

