### PR TITLE
Added speed up metrics data for transaction events and properly track speed up type

### DIFF
--- a/app/scripts/controllers/transactions/index.js
+++ b/app/scripts/controllers/transactions/index.js
@@ -2007,6 +2007,7 @@ export default class TransactionController extends EventEmitter {
         estimateUsed,
       },
       defaultGasEstimates,
+      originalType,
       metamaskNetworkId: network,
     } = txMeta;
     const { transactions } = this.store.getState();
@@ -2101,7 +2102,7 @@ export default class TransactionController extends EventEmitter {
     if (type === TRANSACTION_TYPES.CANCEL) {
       transactionType = TRANSACTION_TYPES.CANCEL;
     } else if (type === TRANSACTION_TYPES.RETRY) {
-      transactionType = TRANSACTION_TYPES.RETRY;
+      transactionType = originalType;
     } else if (type === TRANSACTION_TYPES.DEPLOY_CONTRACT) {
       transactionType = TRANSACTION_TYPES.DEPLOY_CONTRACT;
     } else if (contractInteractionTypes) {

--- a/app/scripts/controllers/transactions/index.js
+++ b/app/scripts/controllers/transactions/index.js
@@ -2122,7 +2122,7 @@ export default class TransactionController extends EventEmitter {
       asset_type: assetType,
       token_standard: tokenStandard,
       transaction_type: transactionType,
-      transaction_speed_up: type === TRANSACTION_TYPES.RETRY && true,
+      transaction_speed_up: type === TRANSACTION_TYPES.RETRY,
     };
 
     const sensitiveProperties = {

--- a/app/scripts/controllers/transactions/index.js
+++ b/app/scripts/controllers/transactions/index.js
@@ -2123,10 +2123,7 @@ export default class TransactionController extends EventEmitter {
       asset_type: assetType,
       token_standard: tokenStandard,
       transaction_type: transactionType,
-<<<<<<< HEAD
       transaction_speed_up: type === TRANSACTION_TYPES.RETRY,
-=======
->>>>>>> develop
     };
 
     const sensitiveProperties = {

--- a/app/scripts/controllers/transactions/index.js
+++ b/app/scripts/controllers/transactions/index.js
@@ -1216,6 +1216,7 @@ export default class TransactionController extends EventEmitter {
       loadingDefaults: false,
       status: TRANSACTION_STATUSES.APPROVED,
       type: TRANSACTION_TYPES.RETRY,
+      originalType: originalTxMeta.type,
     });
 
     if (estimatedBaseFee) {
@@ -2121,6 +2122,7 @@ export default class TransactionController extends EventEmitter {
       asset_type: assetType,
       token_standard: tokenStandard,
       transaction_type: transactionType,
+      transaction_speed_up: type === TRANSACTION_TYPES.RETRY && true,
     };
 
     const sensitiveProperties = {

--- a/app/scripts/controllers/transactions/index.js
+++ b/app/scripts/controllers/transactions/index.js
@@ -2123,7 +2123,10 @@ export default class TransactionController extends EventEmitter {
       asset_type: assetType,
       token_standard: tokenStandard,
       transaction_type: transactionType,
+<<<<<<< HEAD
       transaction_speed_up: type === TRANSACTION_TYPES.RETRY,
+=======
+>>>>>>> develop
     };
 
     const sensitiveProperties = {

--- a/app/scripts/controllers/transactions/index.test.js
+++ b/app/scripts/controllers/transactions/index.test.js
@@ -1476,6 +1476,7 @@ describe('Transaction Controller', function () {
             asset_type: ASSET_TYPES.NATIVE,
             token_standard: TOKEN_STANDARDS.NONE,
             device_model: 'N/A',
+            transaction_speed_up: false,
           },
           sensitiveProperties: {
             default_gas: '0.000031501',
@@ -1556,6 +1557,7 @@ describe('Transaction Controller', function () {
             asset_type: ASSET_TYPES.NATIVE,
             token_standard: TOKEN_STANDARDS.NONE,
             device_model: 'N/A',
+            transaction_speed_up: false,
           },
           sensitiveProperties: {
             default_gas: '0.000031501',
@@ -1646,6 +1648,7 @@ describe('Transaction Controller', function () {
             asset_type: ASSET_TYPES.NATIVE,
             token_standard: TOKEN_STANDARDS.NONE,
             device_model: 'N/A',
+            transaction_speed_up: false,
           },
           sensitiveProperties: {
             default_gas: '0.000031501',
@@ -1728,6 +1731,7 @@ describe('Transaction Controller', function () {
             asset_type: ASSET_TYPES.NATIVE,
             token_standard: TOKEN_STANDARDS.NONE,
             device_model: 'N/A',
+            transaction_speed_up: false,
           },
           sensitiveProperties: {
             default_gas: '0.000031501',
@@ -1810,6 +1814,7 @@ describe('Transaction Controller', function () {
           asset_type: ASSET_TYPES.NATIVE,
           token_standard: TOKEN_STANDARDS.NONE,
           device_model: 'N/A',
+          transaction_speed_up: false,
         },
         sensitiveProperties: {
           gas_price: '2',
@@ -1874,6 +1879,7 @@ describe('Transaction Controller', function () {
           asset_type: ASSET_TYPES.NATIVE,
           token_standard: TOKEN_STANDARDS.NONE,
           device_model: 'N/A',
+          transaction_speed_up: false,
         },
         sensitiveProperties: {
           baz: 3.0,
@@ -1948,6 +1954,7 @@ describe('Transaction Controller', function () {
           asset_type: ASSET_TYPES.NATIVE,
           token_standard: TOKEN_STANDARDS.NONE,
           device_model: 'N/A',
+          transaction_speed_up: false,
         },
         sensitiveProperties: {
           baz: 3.0,

--- a/shared/constants/transaction.js
+++ b/shared/constants/transaction.js
@@ -256,6 +256,8 @@ export const TRANSACTION_GROUP_CATEGORIES = {
  * transaction contract method.
  * @property {TransactionTypeString} type - The type of transaction this txMeta
  *  represents.
+ * @property {string} originalType - The current original type of the
+ *  transaction.
  * @property {TransactionStatusString} status - The current status of the
  *  transaction.
  * @property {string} metamaskNetworkId - The transaction's network ID, used

--- a/shared/constants/transaction.js
+++ b/shared/constants/transaction.js
@@ -256,8 +256,9 @@ export const TRANSACTION_GROUP_CATEGORIES = {
  * transaction contract method.
  * @property {TransactionTypeString} type - The type of transaction this txMeta
  *  represents.
- * @property {string} originalType - The current original type of the
- *  transaction.
+ * @property {string} originalType - When we speed up a transaction,
+ *  we set the type as Retry and we lose information about type of transaction
+ *  that is being set up, so we use original type to track that information.
  * @property {TransactionStatusString} status - The current status of the
  *  transaction.
  * @property {string} metamaskNetworkId - The transaction's network ID, used


### PR DESCRIPTION
## Explanation

Added a new `originalType` property to `txMeta` in `createSpeedUpTransaction` and `transaction_speed_up` property is added in `properties` object in `_buildEventFragmentProperties`.  Transaction_speed_up is set to `true` when `txMeta.type` is `retry`, otherwise `transaction_speed_up` is set to `false`.

## More Information

* Fixes #15151

## Screenshots/Screencaps

### Before

### After

## Manual Testing Steps
