### PR TITLE
Show a block explorer URL hostname, hide the "add token" notification if block explorer URL is not available

### DIFF
--- a/ui/pages/swaps/dropdown-search-list/dropdown-search-list.js
+++ b/ui/pages/swaps/dropdown-search-list/dropdown-search-list.js
@@ -154,9 +154,7 @@ export default function DropdownSearchList({
     SWAPS_CHAINID_DEFAULT_BLOCK_EXPLORER_URL_MAP[chainId] ??
     null;
 
-  const blockExplorerLabel = rpcPrefs.blockExplorerUrl
-    ? getURLHostName(blockExplorerLink)
-    : t('etherscan');
+  const blockExplorerHostName = getURLHostName(blockExplorerLink);
 
   const importTokenProps = {
     onImportTokenCloseClick,
@@ -228,15 +226,14 @@ export default function DropdownSearchList({
               ) : (
                 <div className="dropdown-search-list__placeholder">
                   {t('swapBuildQuotePlaceHolderText', [searchQuery])}
-                  <div
-                    tabIndex="0"
-                    className="searchable-item-list__item searchable-item-list__item--add-token"
-                    key="searchable-item-list-item-last"
-                  >
-                    <ActionableMessage
-                      message={
-                        blockExplorerLink &&
-                        t('addCustomTokenByContractAddress', [
+                  {blockExplorerLink && (
+                    <div
+                      tabIndex="0"
+                      className="searchable-item-list__item searchable-item-list__item--add-token"
+                      key="searchable-item-list-item-last"
+                    >
+                      <ActionableMessage
+                        message={t('addCustomTokenByContractAddress', [
                           <a
                             key="dropdown-search-list__etherscan-link"
                             onClick={() => {
@@ -246,9 +243,7 @@ export default function DropdownSearchList({
                                 properties: {
                                   link_type: 'Token Tracker',
                                   action: 'Verify Contract Address',
-                                  block_explorer_domain: getURLHostName(
-                                    blockExplorerLink,
-                                  ),
+                                  block_explorer_domain: blockExplorerHostName,
                                 },
                               });
                               global.platform.openTab({
@@ -258,12 +253,12 @@ export default function DropdownSearchList({
                             target="_blank"
                             rel="noopener noreferrer"
                           >
-                            {blockExplorerLabel}
+                            {blockExplorerHostName}
                           </a>,
-                        ])
-                      }
-                    />
-                  </div>
+                        ])}
+                      />
+                    </div>
+                  )}
                 </div>
               )
             }

--- a/ui/pages/swaps/searchable-item-list/item-list/item-list.component.js
+++ b/ui/pages/swaps/searchable-item-list/item-list/item-list.component.js
@@ -37,9 +37,7 @@ export default function ItemList({
     SWAPS_CHAINID_DEFAULT_BLOCK_EXPLORER_URL_MAP[chainId] ??
     null;
 
-  const blockExplorerLabel = rpcPrefs.blockExplorerUrl
-    ? getURLHostName(blockExplorerLink)
-    : t('etherscan');
+  const blockExplorerHostName = getURLHostName(blockExplorerLink);
   const trackEvent = useContext(MetaMetricsContext);
 
   // If there is a token for import based on a contract address, it's the only one in the list.
@@ -141,41 +139,36 @@ export default function ItemList({
             </div>
           );
         })}
-        {!hasTokenForImport && (
+        {!hasTokenForImport && blockExplorerLink && (
           <div
             tabIndex="0"
             className="searchable-item-list__item searchable-item-list__item--add-token"
             key="searchable-item-list-item-last"
           >
             <ActionableMessage
-              message={
-                blockExplorerLink &&
-                t('addCustomTokenByContractAddress', [
-                  <a
-                    key="searchable-item-list__etherscan-link"
-                    onClick={() => {
-                      trackEvent({
-                        event: 'Clicked Block Explorer Link',
-                        category: EVENT.CATEGORIES.SWAPS,
-                        properties: {
-                          link_type: 'Token Tracker',
-                          action: 'Verify Contract Address',
-                          block_explorer_domain: getURLHostName(
-                            blockExplorerLink,
-                          ),
-                        },
-                      });
-                      global.platform.openTab({
-                        url: blockExplorerLink,
-                      });
-                    }}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    {blockExplorerLabel}
-                  </a>,
-                ])
-              }
+              message={t('addCustomTokenByContractAddress', [
+                <a
+                  key="searchable-item-list__etherscan-link"
+                  onClick={() => {
+                    trackEvent({
+                      event: 'Clicked Block Explorer Link',
+                      category: EVENT.CATEGORIES.SWAPS,
+                      properties: {
+                        link_type: 'Token Tracker',
+                        action: 'Verify Contract Address',
+                        block_explorer_domain: blockExplorerHostName,
+                      },
+                    });
+                    global.platform.openTab({
+                      url: blockExplorerLink,
+                    });
+                  }}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  {blockExplorerHostName}
+                </a>,
+              ])}
             />
           </div>
         )}


### PR DESCRIPTION
## Explanation
Show a block explorer URL hostname, hide the "add token" notification if block explorer URL is not available

## Screenshots/Screencaps
Show a block explorer URL hostname:
![image](https://user-images.githubusercontent.com/80175477/178507658-0e695f5e-0482-4289-a634-34b6e359d852.png)

Hide the "add token" notification if block explorer URL is not available:
![image](https://user-images.githubusercontent.com/80175477/178507720-039b43f1-e26e-4069-9fb2-6a0ea6773d1e.png)