### PR TITLE
Only send the rpc origin to segment when calling trackevent for newly added custom networks

### DIFF
--- a/app/scripts/lib/rpc-method-middleware/handlers/add-ethereum-chain.js
+++ b/app/scripts/lib/rpc-method-middleware/handlers/add-ethereum-chain.js
@@ -261,7 +261,13 @@ async function addEthereumChainHandler(
       }),
     );
 
-    const rpcUrlOrigin = new URL(firstValidRPCUrl).origin;
+    let rpcUrlOrigin;
+    try {
+      rpcUrlOrigin = new URL(firstValidRPCUrl).origin;
+    } catch {
+      // ignore
+    }
+
     sendMetrics({
       event: 'Custom Network Added',
       category: EVENT.CATEGORIES.NETWORK,

--- a/app/scripts/lib/rpc-method-middleware/handlers/add-ethereum-chain.js
+++ b/app/scripts/lib/rpc-method-middleware/handlers/add-ethereum-chain.js
@@ -261,6 +261,7 @@ async function addEthereumChainHandler(
       }),
     );
 
+    const rpcUrlOrigin = new URL(firstValidRPCUrl).origin;
     sendMetrics({
       event: 'Custom Network Added',
       category: EVENT.CATEGORIES.NETWORK,
@@ -274,13 +275,13 @@ async function addEthereumChainHandler(
         // property included in all events. For RPC type networks
         // the MetaMetrics controller uses the rpcUrl for the network
         // property.
-        network: firstValidRPCUrl,
+        network: rpcUrlOrigin,
         symbol: ticker,
         block_explorer_url: firstValidBlockExplorerUrl,
         source: EVENT.SOURCE.TRANSACTION.DAPP,
       },
       sensitiveProperties: {
-        rpc_url: firstValidRPCUrl,
+        rpc_url: rpcUrlOrigin,
       },
     });
 

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -2065,22 +2065,23 @@ export default class MetamaskController extends EventEmitter {
       },
     );
 
+    const rpcUrlOrigin = new URL(rpcUrl).origin;
     this.metaMetricsController.trackEvent({
       event: 'Custom Network Added',
       category: EVENT.CATEGORIES.NETWORK,
       referrer: {
-        url: rpcUrl,
+        url: rpcUrlOrigin,
       },
       properties: {
         chain_id: chainId,
         network_name: chainName,
-        network: rpcUrl,
+        network: rpcUrlOrigin,
         symbol: ticker,
         block_explorer_url: blockExplorerUrl,
         source: EVENT.SOURCE.NETWORK.POPULAR_NETWORK_LIST,
       },
       sensitiveProperties: {
-        rpc_url: rpcUrl,
+        rpc_url: rpcUrlOrigin,
       },
     });
   }

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -2065,7 +2065,12 @@ export default class MetamaskController extends EventEmitter {
       },
     );
 
-    const rpcUrlOrigin = new URL(rpcUrl).origin;
+    let rpcUrlOrigin;
+    try {
+      rpcUrlOrigin = new URL(rpcUrl).origin;
+    } catch {
+      // ignore
+    }
     this.metaMetricsController.trackEvent({
       event: 'Custom Network Added',
       category: EVENT.CATEGORIES.NETWORK,

--- a/ui/pages/settings/networks-tab/networks-form/networks-form.js
+++ b/ui/pages/settings/networks-tab/networks-form/networks-form.js
@@ -512,7 +512,12 @@ const NetworksForm = ({
       }
 
       if (addNewNetwork) {
-        const rpcUrlOrigin = new URL(rpcUrl).origin;
+        let rpcUrlOrigin;
+        try {
+          rpcUrlOrigin = new URL(rpcUrl).origin;
+        } catch {
+          // error
+        }
         trackEvent({
           event: 'Custom Network Added',
           category: EVENT.CATEGORIES.NETWORK,

--- a/ui/pages/settings/networks-tab/networks-form/networks-form.js
+++ b/ui/pages/settings/networks-tab/networks-form/networks-form.js
@@ -512,22 +512,23 @@ const NetworksForm = ({
       }
 
       if (addNewNetwork) {
+        const rpcUrlOrigin = new URL(rpcUrl).origin;
         trackEvent({
           event: 'Custom Network Added',
           category: EVENT.CATEGORIES.NETWORK,
           referrer: {
-            url: rpcUrl,
+            url: rpcUrlOrigin,
           },
           properties: {
             chain_id: chainId,
             network_name: networkName,
-            network: rpcUrl,
+            network: rpcUrlOrigin,
             symbol: ticker,
             block_explorer_url: blockExplorerUrl,
             source: EVENT.SOURCE.NETWORK.CUSTOM_NETWORK_FORM,
           },
           sensitiveProperties: {
-            rpc_url: rpcUrl,
+            rpc_url: rpcUrlOrigin,
           },
         });
         dispatch(setNewNetworkAdded(networkName));


### PR DESCRIPTION
We should only send the origin of the rpc url to segment for newly added custom networks.

Was attempting to add tests to guarantee we are calling `trackEvent` with the correct values, but mocking `useContext` is not easily achieved, and perhaps not advisable, so will leave that for a later PR.