### PR TITLE
Fix invalid build timestamp on certain timezones

### DIFF
--- a/development/build/etc.js
+++ b/development/build/etc.js
@@ -49,6 +49,9 @@ function createZipTask(platform, buildType, version) {
       gulp.src(`dist/${platform}/**`),
       // sort files and set `mtime` to epoch to ensure zip build is deterministic
       sort(),
+      // Modified time set to an arbitrary static date to ensure build the is reproducible.
+      // The date chosen is MetaMask's birthday. Originally we chose the Unix epoch, but this
+      // resulted in invalid dates on certain timezones/operating systems.
       gulpZip(`${path}.zip`, { modifiedTime: new Date('2016-07-14T00:00:00') }),
       gulp.dest('builds'),
     );

--- a/development/build/etc.js
+++ b/development/build/etc.js
@@ -49,7 +49,7 @@ function createZipTask(platform, buildType, version) {
       gulp.src(`dist/${platform}/**`),
       // sort files and set `mtime` to epoch to ensure zip build is deterministic
       sort(),
-      gulpZip(`${path}.zip`, { modifiedTime: new Date(0) }),
+      gulpZip(`${path}.zip`, { modifiedTime: new Date('2016-07-14T00:00:00') }),
       gulp.dest('builds'),
     );
   };


### PR DESCRIPTION
Currently the build .zip has its time set to the Unix epoch, which apparently causes problems on certain operating systems when in a timezone that is ahead of GMT.

The build timestamp has been changed to MetaMask's birthday. Time zone adjustments will no longer result in invalid dates.

## Manual Testing Steps

Note that these steps are Windows only, and only if your time zone is ahead of GMT. They may or may not work on other operating systems.

* Build the extension (`yarn dist`)
* Open the resulting .zip file (in the `builds` directory) in the file explorer
* See that the "Date modified" column of the file explorer shows a time within 24 hours of 2016-07-14, rather than showing a date in the year 2097.

## Pre-Merge Checklist

- [x] PR template is filled out
- [ ] **IF** this PR fixes a bug, a test that _would have_ caught the bug has been added
- [ ] PR is linked to the appropriate GitHub issue
- [ ] PR has been added to the appropriate release Milestone

### + If there are functional changes:

- [x] Manual testing complete & passed
- [x] "Extension QA Board" label has been applied
