### PR TITLE
Ensure that editing a tx from a transfer to a simple send resets data and updates type

### DIFF
--- a/app/scripts/controllers/transactions/index.js
+++ b/app/scripts/controllers/transactions/index.js
@@ -462,7 +462,10 @@ export default class TransactionController extends EventEmitter {
     };
 
     // only update what is defined
-    editableParams.txParams = pickBy(editableParams.txParams);
+    editableParams.txParams = pickBy(
+      editableParams.txParams,
+      (prop) => prop !== undefined,
+    );
 
     // update transaction type in case it has changes
     const transactionBeforeEdit = this._getTransaction(txId);

--- a/ui/ducks/send/send.js
+++ b/ui/ducks/send/send.js
@@ -1992,9 +1992,12 @@ export function updateSendAsset(
         }),
       );
 
-      // If there is an unapprovedTx in background state and its type was a token method,
+      // This is meant to handle cases where we are editing an unapprovedTx from the background state
+      // and its type is a token method. In such a case, the hex data will be the necessary hex data
+      // for calling the contract transfer method.
+      // Now that we are updating the transaction to be a send of a native asset type, we should
+      // set the hex data of the transaction being editing to be empty.
       // then the user will not want to send any hex data now that they have change the
-      // transaction from being a token transfer to a simple send.
       if (
         unapprovedTx?.type === TRANSACTION_TYPES.TOKEN_METHOD_TRANSFER_FROM ||
         unapprovedTx?.type === TRANSACTION_TYPES.TOKEN_METHOD_TRANSFER

--- a/ui/ducks/send/send.js
+++ b/ui/ducks/send/send.js
@@ -1994,7 +1994,8 @@ export function updateSendAsset(
       // then the user will not want to send any hex data now that they have change the
       if (
         unapprovedTx?.type === TRANSACTION_TYPES.TOKEN_METHOD_TRANSFER_FROM ||
-        unapprovedTx?.type === TRANSACTION_TYPES.TOKEN_METHOD_TRANSFER
+        unapprovedTx?.type === TRANSACTION_TYPES.TOKEN_METHOD_TRANSFER ||
+        unapprovedTx?.type === TRANSACTION_TYPES.TOKEN_METHOD_SAFE_TRANSFER_FROM
       ) {
         await dispatch(actions.updateUserInputHexData(''));
       }

--- a/ui/ducks/send/send.js
+++ b/ui/ducks/send/send.js
@@ -1971,7 +1971,7 @@ export function updateSendAsset(
     const account = getTargetAccount(state, sendingAddress);
     if (type === ASSET_TYPES.NATIVE) {
       const unapprovedTxs = getUnapprovedTxs(state);
-      const unapprovedTx = unapprovedTxs[draftTransaction.id];
+      const unapprovedTx = unapprovedTxs?.[draftTransaction.id];
 
       await dispatch(
         addHistoryEntry(

--- a/ui/ducks/send/send.js
+++ b/ui/ducks/send/send.js
@@ -938,12 +938,6 @@ const slice = createSlice({
       draftTransaction.asset.balance = asset.balance;
       draftTransaction.asset.error = asset.error;
 
-      // If an asset update occurs that changes the type from 'NATIVE' to
-      // 'NATIVE' then this is likely the initial asset set of an edit
-      // transaction. We don't need to set the amount to zero in this case.
-      // The only times where an update would occur of this nature that we
-      // would want to set the amount to zero is on a network or account change
-      // but that update is handled elsewhere.
       if (
         draftTransaction.asset.type === ASSET_TYPES.TOKEN ||
         draftTransaction.asset.type === ASSET_TYPES.COLLECTIBLE

--- a/ui/ducks/send/send.js
+++ b/ui/ducks/send/send.js
@@ -2229,27 +2229,6 @@ export function signTransaction() {
         ),
       };
 
-      // If, after edit, we are sending the native asset,
-      //   and if the send duck hex data was reset on this edit,
-      //   and if the hex data from the tx's background state matches
-      //   one of the special token methods that we handle,
-      //   then we conclude that the user does not want to send hex data,
-      //   and ensure it gets reset in the background state as well.
-      const sendingNativeAsset =
-        draftTransaction.asset.type === ASSET_TYPES.NATIVE;
-      const userInputHexDataHasBeenReset =
-        draftTransaction.userInputHexData === '';
-      const priorHexDataMatchesSpecialTokenTxSignatures =
-        parseStandardTokenTransactionData(editingTx.txParams.data) !==
-        undefined;
-      if (
-        sendingNativeAsset &&
-        userInputHexDataHasBeenReset &&
-        priorHexDataMatchesSpecialTokenTxSignatures
-      ) {
-        editingTx.txParams.data = '';
-      }
-
       await dispatch(
         addHistoryEntry(
           `sendFlow - user clicked next and transaction should be updated in controller`,

--- a/ui/store/actions.js
+++ b/ui/store/actions.js
@@ -745,7 +745,7 @@ export function updateEditableParams(txId, editableParams) {
       log.error(error.message);
       throw error;
     }
-
+    await forceUpdateMetamaskState(dispatch);
     return updatedTransaction;
   };
 }


### PR DESCRIPTION
Fixes https://github.com/MetaMask/metamask-extension/issues/15184

Preceding v10.18.0 there was a problem whereby changing from a token transfer to a simple send on the send edit screen would not change the transaction data. This would incorrectly leave the rendered type as transfer and incorrectly leave hex data on the transaction.

With v10.18.0, this could cause an unhandled error when trying to edit a transaction in this state of faulty data, because we would attempt to parse the recipient address of a simple send as if it were a token address.

The solution requires two parts:
1. Ensure that the transaction data gets correctly reset when changing a transaction from a transfer to a simple send
2. Ensure that we wait for the background state update to complete and be reflected in the UI state before returning to the confirm screen after editing a transaction