### PR TITLE
Removed UI related code from shared directory

### DIFF
--- a/app/scripts/controllers/detect-tokens.js
+++ b/app/scripts/controllers/detect-tokens.js
@@ -6,8 +6,10 @@ import { MINUTE } from '../../../shared/constants/time';
 import { MAINNET_CHAIN_ID } from '../../../shared/constants/network';
 import { isTokenDetectionEnabledForNetwork } from '../../../shared/modules/network.utils';
 import { isEqualCaseInsensitive } from '../../../shared/modules/string-utils';
-import { TOKEN_STANDARDS } from '../../../ui/helpers/constants/common';
-import { ASSET_TYPES } from '../../../shared/constants/transaction';
+import {
+  ASSET_TYPES,
+  TOKEN_STANDARDS,
+} from '../../../shared/constants/transaction';
 import { EVENT, EVENT_NAMES } from '../../../shared/constants/metametrics';
 
 // By default, poll every 3 minutes

--- a/app/scripts/controllers/transactions/index.test.js
+++ b/app/scripts/controllers/transactions/index.test.js
@@ -17,6 +17,7 @@ import {
   TRANSACTION_ENVELOPE_TYPES,
   TRANSACTION_EVENTS,
   ASSET_TYPES,
+  TOKEN_STANDARDS,
 } from '../../../../shared/constants/transaction';
 
 import { SECOND } from '../../../../shared/constants/time';
@@ -26,7 +27,6 @@ import {
 } from '../../../../shared/constants/gas';
 import { TRANSACTION_ENVELOPE_TYPE_NAMES } from '../../../../ui/helpers/constants/transactions';
 import { METAMASK_CONTROLLER_EVENTS } from '../../metamask-controller';
-import { TOKEN_STANDARDS } from '../../../../ui/helpers/constants/common';
 import { ORIGIN_METAMASK } from '../../../../shared/constants/app';
 import TransactionController from '.';
 

--- a/shared/constants/gas.js
+++ b/shared/constants/gas.js
@@ -1,7 +1,9 @@
 import { addHexPrefix } from 'ethereumjs-util';
-import { MIN_GAS_LIMIT_HEX } from '../../ui/pages/send/send.constants';
 
 const ONE_HUNDRED_THOUSAND = 100000;
+const MIN_GAS_LIMIT_DEC = '21000';
+
+export const MIN_GAS_LIMIT_HEX = parseInt(MIN_GAS_LIMIT_DEC, 10).toString(16);
 
 export const GAS_LIMITS = {
   // maximum gasLimit of a simple send

--- a/shared/constants/transaction.js
+++ b/shared/constants/transaction.js
@@ -355,3 +355,36 @@ export const ASSET_TYPES = {
   COLLECTIBLE: 'COLLECTIBLE',
   UNKNOWN: 'UNKNOWN',
 };
+
+export const ERC20 = 'ERC20';
+export const ERC721 = 'ERC721';
+export const ERC1155 = 'ERC1155';
+
+/**
+ * @typedef {Object} TokenStandards
+ * @property {'ERC20'} ERC20 - A token that conforms to the ERC20 standard.
+ * @property {'ERC721'} ERC721 - A token that conforms to the ERC721 standard.
+ * @property {'ERC1155'} ERC1155 - A token that conforms to the ERC1155
+ *  standard.
+ * @property {'NONE'} NONE - Not a token, but rather the base asset of the
+ *  selected chain.
+ */
+
+/**
+ * This type will work anywhere you expect a string that can be one of the
+ * above statuses
+ *
+ * @typedef {TokenStandards[keyof TokenStandards]} TokenStandardStrings
+ */
+
+/**
+ * Describes the standard which a token conforms to.
+ *
+ * @type {TokenStandards}
+ */
+export const TOKEN_STANDARDS = {
+  ERC20,
+  ERC721,
+  ERC1155,
+  NONE: 'NONE',
+};

--- a/shared/modules/transaction.utils.js
+++ b/shared/modules/transaction.utils.js
@@ -2,8 +2,11 @@ import { isHexString } from 'ethereumjs-util';
 import { ethers } from 'ethers';
 import { abiERC721, abiERC20, abiERC1155 } from '@metamask/metamask-eth-abis';
 import log from 'loglevel';
-import { TOKEN_STANDARDS } from '../../ui/helpers/constants/common';
-import { ASSET_TYPES, TRANSACTION_TYPES } from '../constants/transaction';
+import {
+  ASSET_TYPES,
+  TOKEN_STANDARDS,
+  TRANSACTION_TYPES,
+} from '../constants/transaction';
 import { readAddressAsContract } from './contract-utils';
 import { isEqualCaseInsensitive } from './string-utils';
 

--- a/ui/components/app/collectible-details/collectible-details.js
+++ b/ui/components/app/collectible-details/collectible-details.js
@@ -47,11 +47,10 @@ import CollectibleOptions from '../collectible-options/collectible-options';
 import Button from '../../ui/button';
 import { startNewDraftTransaction } from '../../../ducks/send';
 import InfoTooltip from '../../ui/info-tooltip';
-import { ERC721 } from '../../../helpers/constants/common';
 import { usePrevious } from '../../../hooks/usePrevious';
 import { useCopyToClipboard } from '../../../hooks/useCopyToClipboard';
 import { isEqualCaseInsensitive } from '../../../../shared/modules/string-utils';
-import { ASSET_TYPES } from '../../../../shared/constants/transaction';
+import { ASSET_TYPES, ERC721 } from '../../../../shared/constants/transaction';
 import CollectibleDefaultImage from '../collectible-default-image';
 
 export default function CollectibleDetails({ collectible }) {

--- a/ui/components/app/detected-token/detected-token.js
+++ b/ui/components/app/detected-token/detected-token.js
@@ -11,8 +11,10 @@ import {
 import { getDetectedTokensInCurrentNetwork } from '../../../selectors';
 import { MetaMetricsContext } from '../../../contexts/metametrics';
 
-import { TOKEN_STANDARDS } from '../../../helpers/constants/common';
-import { ASSET_TYPES } from '../../../../shared/constants/transaction';
+import {
+  ASSET_TYPES,
+  TOKEN_STANDARDS,
+} from '../../../../shared/constants/transaction';
 import { EVENT, EVENT_NAMES } from '../../../../shared/constants/metametrics';
 import DetectedTokenSelectionPopover from './detected-token-selection-popover/detected-token-selection-popover';
 import DetectedTokenIgnoredPopover from './detected-token-ignored-popover/detected-token-ignored-popover';

--- a/ui/ducks/send/helpers.js
+++ b/ui/ducks/send/helpers.js
@@ -1,6 +1,6 @@
 import { addHexPrefix } from 'ethereumjs-util';
 import abi from 'human-standard-token-abi';
-import { GAS_LIMITS } from '../../../shared/constants/gas';
+import { GAS_LIMITS, MIN_GAS_LIMIT_HEX } from '../../../shared/constants/gas';
 import { CHAIN_ID_TO_GAS_LIMIT_BUFFER_MAP } from '../../../shared/constants/network';
 import {
   ASSET_TYPES,
@@ -13,7 +13,6 @@ import {
 } from '../../../shared/modules/conversion.utils';
 import { ETH, GWEI } from '../../helpers/constants/common';
 import { calcTokenAmount } from '../../helpers/utils/token-util';
-import { MIN_GAS_LIMIT_HEX } from '../../pages/send/send.constants';
 import {
   addGasBuffer,
   generateERC20TransferData,

--- a/ui/ducks/send/helpers.test.js
+++ b/ui/ducks/send/helpers.test.js
@@ -2,11 +2,11 @@ import { ethers } from 'ethers';
 import { GAS_LIMITS } from '../../../shared/constants/gas';
 import {
   ASSET_TYPES,
+  TOKEN_STANDARDS,
   TRANSACTION_ENVELOPE_TYPES,
 } from '../../../shared/constants/transaction';
 import { BURN_ADDRESS } from '../../../shared/modules/hexstring-utils';
 import { getInitialSendStateWithExistingTxState } from '../../../test/jest/mocks';
-import { TOKEN_STANDARDS } from '../../helpers/constants/common';
 import {
   generateERC20TransferData,
   generateERC721TransferData,

--- a/ui/ducks/send/send.js
+++ b/ui/ducks/send/send.js
@@ -91,9 +91,10 @@ import {
 import { sumHexes } from '../../helpers/utils/transactions.util';
 import fetchEstimatedL1Fee from '../../helpers/utils/optimism/fetchEstimatedL1Fee';
 
-import { TOKEN_STANDARDS, ETH } from '../../helpers/constants/common';
+import { ETH } from '../../helpers/constants/common';
 import {
   ASSET_TYPES,
+  TOKEN_STANDARDS,
   TRANSACTION_ENVELOPE_TYPES,
   TRANSACTION_TYPES,
 } from '../../../shared/constants/transaction';

--- a/ui/ducks/send/send.test.js
+++ b/ui/ducks/send/send.test.js
@@ -17,6 +17,7 @@ import {
 import { GAS_ESTIMATE_TYPES, GAS_LIMITS } from '../../../shared/constants/gas';
 import {
   ASSET_TYPES,
+  TOKEN_STANDARDS,
   TRANSACTION_ENVELOPE_TYPES,
 } from '../../../shared/constants/transaction';
 import * as Actions from '../../store/actions';
@@ -26,7 +27,6 @@ import {
   generateERC721TransferData,
 } from '../../pages/send/send.utils';
 import { BURN_ADDRESS } from '../../../shared/modules/hexstring-utils';
-import { TOKEN_STANDARDS } from '../../helpers/constants/common';
 import {
   getInitialSendStateWithExistingTxState,
   INITIAL_SEND_STATE_FOR_EXISTING_DRAFT,

--- a/ui/helpers/constants/common.js
+++ b/ui/helpers/constants/common.js
@@ -5,39 +5,6 @@ export const WEI = 'WEI';
 export const PRIMARY = 'PRIMARY';
 export const SECONDARY = 'SECONDARY';
 
-export const ERC20 = 'ERC20';
-export const ERC721 = 'ERC721';
-export const ERC1155 = 'ERC1155';
-
-/**
- * @typedef {Object} TokenStandards
- * @property {'ERC20'} ERC20 - A token that conforms to the ERC20 standard.
- * @property {'ERC721'} ERC721 - A token that conforms to the ERC721 standard.
- * @property {'ERC1155'} ERC1155 - A token that conforms to the ERC1155
- *  standard.
- * @property {'NONE'} NONE - Not a token, but rather the base asset of the
- *  selected chain.
- */
-
-/**
- * This type will work anywhere you expect a string that can be one of the
- * above statuses
- *
- * @typedef {TokenStandards[keyof TokenStandards]} TokenStandardStrings
- */
-
-/**
- * Describes the standard which a token conforms to.
- *
- * @type {TokenStandards}
- */
-export const TOKEN_STANDARDS = {
-  ERC20,
-  ERC721,
-  ERC1155,
-  NONE: 'NONE',
-};
-
 export const GAS_ESTIMATE_TYPES = {
   SLOW: 'SLOW',
   AVERAGE: 'AVERAGE',

--- a/ui/helpers/utils/token-util.js
+++ b/ui/helpers/utils/token-util.js
@@ -5,9 +5,9 @@ import {
   multiplyCurrencies,
 } from '../../../shared/modules/conversion.utils';
 import { getTokenStandardAndDetails } from '../../store/actions';
-import { ERC1155, ERC721 } from '../constants/common';
 import { isEqualCaseInsensitive } from '../../../shared/modules/string-utils';
 import { parseStandardTokenTransactionData } from '../../../shared/modules/transaction.utils';
+import { ERC1155, ERC721 } from '../../../shared/constants/transaction';
 import * as util from './util';
 import { formatCurrency } from './confirm-tx.util';
 

--- a/ui/hooks/useAssetDetails.js
+++ b/ui/hooks/useAssetDetails.js
@@ -1,8 +1,8 @@
 import { useState, useEffect } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
+import { ERC1155, ERC20, ERC721 } from '../../shared/constants/transaction';
 import { parseStandardTokenTransactionData } from '../../shared/modules/transaction.utils';
 import { getCollectibles } from '../ducks/metamask/metamask';
-import { ERC1155, ERC721, ERC20 } from '../helpers/constants/common';
 import {
   calcTokenAmount,
   getAssetDetails,

--- a/ui/hooks/useAssetDetails.test.js
+++ b/ui/hooks/useAssetDetails.test.js
@@ -4,7 +4,7 @@ import { renderHook } from '@testing-library/react-hooks';
 
 import configureStore from '../store/store';
 import * as tokenUtils from '../helpers/utils/token-util';
-import { ERC1155, ERC20, ERC721 } from '../helpers/constants/common';
+import { ERC1155, ERC20, ERC721 } from '../../shared/constants/transaction';
 import { useAssetDetails } from './useAssetDetails';
 
 const renderUseAssetDetails = ({

--- a/ui/pages/confirm-add-suggested-token/confirm-add-suggested-token.js
+++ b/ui/pages/confirm-add-suggested-token/confirm-add-suggested-token.js
@@ -13,9 +13,11 @@ import ZENDESK_URLS from '../../helpers/constants/zendesk-url';
 import { isEqualCaseInsensitive } from '../../../shared/modules/string-utils';
 import { getSuggestedAssets } from '../../selectors';
 import { rejectWatchAsset, acceptWatchAsset } from '../../store/actions';
-import { TOKEN_STANDARDS } from '../../helpers/constants/common';
 import { EVENT, EVENT_NAMES } from '../../../shared/constants/metametrics';
-import { ASSET_TYPES } from '../../../shared/constants/transaction';
+import {
+  ASSET_TYPES,
+  TOKEN_STANDARDS,
+} from '../../../shared/constants/transaction';
 
 function getTokenName(name, symbol) {
   return name === undefined ? symbol : `${name} (${symbol})`;

--- a/ui/pages/confirm-approve/confirm-approve-content/confirm-approve-content.component.js
+++ b/ui/pages/confirm-approve/confirm-approve-content/confirm-approve-content.component.js
@@ -28,7 +28,11 @@ import { SECOND } from '../../../../shared/constants/time';
 import { ConfirmPageContainerWarning } from '../../../components/app/confirm-page-container/confirm-page-container-content';
 import GasDetailsItem from '../../../components/app/gas-details-item';
 import LedgerInstructionField from '../../../components/app/ledger-instruction-field';
-import { ERC1155, ERC20, ERC721 } from '../../../helpers/constants/common';
+import {
+  ERC1155,
+  ERC20,
+  ERC721,
+} from '../../../../shared/constants/transaction';
 
 export default class ConfirmApproveContent extends Component {
   static contextTypes = {

--- a/ui/pages/confirm-approve/confirm-approve-content/confirm-approve-content.component.test.js
+++ b/ui/pages/confirm-approve/confirm-approve-content/confirm-approve-content.component.test.js
@@ -2,7 +2,7 @@ import React from 'react';
 import configureMockStore from 'redux-mock-store';
 import { fireEvent } from '@testing-library/react';
 import { renderWithProvider } from '../../../../test/jest/rendering';
-import { ERC20 } from '../../../helpers/constants/common';
+import { ERC20 } from '../../../../shared/constants/transaction';
 import ConfirmApproveContent from '.';
 
 const renderComponent = (props) => {

--- a/ui/pages/confirm-approve/confirm-approve-content/confirm-approve-content.stories.js
+++ b/ui/pages/confirm-approve/confirm-approve-content/confirm-approve-content.stories.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ERC20 } from '../../../helpers/constants/common';
+import { ERC20 } from '../../../../shared/constants/transaction';
 import ConfirmApproveContent from '.';
 
 export default {

--- a/ui/pages/confirm-approve/confirm-approve.js
+++ b/ui/pages/confirm-approve/confirm-approve.js
@@ -36,8 +36,8 @@ import AdvancedGasFeePopover from '../../components/app/advanced-gas-fee-popover
 import EditGasFeePopover from '../../components/app/edit-gas-fee-popover';
 import EditGasPopover from '../../components/app/edit-gas-popover/edit-gas-popover.component';
 import Loading from '../../components/ui/loading-screen';
-import { ERC20, ERC1155, ERC721 } from '../../helpers/constants/common';
 import { parseStandardTokenTransactionData } from '../../../shared/modules/transaction.utils';
+import { ERC1155, ERC20, ERC721 } from '../../../shared/constants/transaction';
 import { getCustomTxParamsData } from './confirm-approve.util';
 import ConfirmApproveContent from './confirm-approve-content';
 

--- a/ui/pages/confirm-import-token/confirm-import-token.js
+++ b/ui/pages/confirm-import-token/confirm-import-token.js
@@ -13,9 +13,11 @@ import { MetaMetricsContext } from '../../contexts/metametrics';
 import { getMostRecentOverviewPage } from '../../ducks/history/history';
 import { getPendingTokens } from '../../ducks/metamask/metamask';
 import { addTokens, clearPendingTokens } from '../../store/actions';
-import { TOKEN_STANDARDS } from '../../helpers/constants/common';
 import { EVENT, EVENT_NAMES } from '../../../shared/constants/metametrics';
-import { ASSET_TYPES } from '../../../shared/constants/transaction';
+import {
+  ASSET_TYPES,
+  TOKEN_STANDARDS,
+} from '../../../shared/constants/transaction';
 
 const getTokenName = (name, symbol) => {
   return name === undefined ? symbol : `${name} (${symbol})`;

--- a/ui/pages/confirm-send-token/confirm-send-token.js
+++ b/ui/pages/confirm-send-token/confirm-send-token.js
@@ -13,10 +13,13 @@ import {
   getConversionRate,
   getNativeCurrency,
 } from '../../ducks/metamask/metamask';
-import { ERC20, ERC721 } from '../../helpers/constants/common';
 import { clearConfirmTransaction } from '../../ducks/confirm-transaction/confirm-transaction.duck';
 import { showSendTokenPage } from '../../store/actions';
-import { ASSET_TYPES } from '../../../shared/constants/transaction';
+import {
+  ASSET_TYPES,
+  ERC20,
+  ERC721,
+} from '../../../shared/constants/transaction';
 
 export default function ConfirmSendToken({
   assetStandard,

--- a/ui/pages/confirm-token-transaction-base/confirm-token-transaction-base.js
+++ b/ui/pages/confirm-token-transaction-base/confirm-token-transaction-base.js
@@ -15,13 +15,7 @@ import {
   getWeiHexFromDecimalValue,
   hexWEIToDecETH,
 } from '../../helpers/utils/conversions.util';
-import {
-  ERC1155,
-  ERC20,
-  ERC721,
-  ETH,
-  PRIMARY,
-} from '../../helpers/constants/common';
+import { ETH, PRIMARY } from '../../helpers/constants/common';
 import {
   contractExchangeRateSelector,
   getCurrentCurrency,
@@ -30,6 +24,7 @@ import {
   getConversionRate,
   getNativeCurrency,
 } from '../../ducks/metamask/metamask';
+import { ERC1155, ERC20, ERC721 } from '../../../shared/constants/transaction';
 
 export default function ConfirmTokenTransactionBase({
   image = '',

--- a/ui/pages/import-token/import-token.component.js
+++ b/ui/pages/import-token/import-token.component.js
@@ -23,7 +23,7 @@ import ActionableMessage from '../../components/ui/actionable-message/actionable
 import Typography from '../../components/ui/typography';
 import { TYPOGRAPHY, FONT_WEIGHT } from '../../helpers/constants/design-system';
 import Button from '../../components/ui/button';
-import { TOKEN_STANDARDS } from '../../helpers/constants/common';
+import { TOKEN_STANDARDS } from '../../../shared/constants/transaction';
 import TokenSearch from './token-search';
 import TokenList from './token-list';
 

--- a/ui/pages/send/send-content/send-asset-row/send-asset-row.component.js
+++ b/ui/pages/send/send-content/send-asset-row/send-asset-row.component.js
@@ -5,10 +5,14 @@ import Identicon from '../../../../components/ui/identicon';
 import TokenBalance from '../../../../components/ui/token-balance';
 import TokenListDisplay from '../../../../components/app/token-list-display';
 import UserPreferencedCurrencyDisplay from '../../../../components/app/user-preferenced-currency-display';
-import { ERC20, ERC721, PRIMARY } from '../../../../helpers/constants/common';
+import { PRIMARY } from '../../../../helpers/constants/common';
 import { isEqualCaseInsensitive } from '../../../../../shared/modules/string-utils';
 import { EVENT } from '../../../../../shared/constants/metametrics';
-import { ASSET_TYPES } from '../../../../../shared/constants/transaction';
+import {
+  ASSET_TYPES,
+  ERC20,
+  ERC721,
+} from '../../../../../shared/constants/transaction';
 
 export default class SendAssetRow extends Component {
   static propTypes = {

--- a/ui/pages/send/send.constants.js
+++ b/ui/pages/send/send.constants.js
@@ -3,12 +3,12 @@ import {
   multiplyCurrencies,
 } from '../../../shared/modules/conversion.utils';
 import { addHexPrefix } from '../../../app/scripts/lib/util';
+import { MIN_GAS_LIMIT_HEX } from '../../../shared/constants/gas';
 
 const MIN_GAS_PRICE_DEC = '0';
 const MIN_GAS_PRICE_HEX = parseInt(MIN_GAS_PRICE_DEC, 10).toString(16);
 const MIN_GAS_LIMIT_DEC = '21000';
 const MAX_GAS_LIMIT_DEC = '7920027';
-const MIN_GAS_LIMIT_HEX = parseInt(MIN_GAS_LIMIT_DEC, 10).toString(16);
 
 const HIGH_FEE_WARNING_MULTIPLIER = 1.5;
 const MIN_GAS_PRICE_GWEI = addHexPrefix(
@@ -63,7 +63,6 @@ export {
   ENS_UNKNOWN_ERROR,
   ENS_REGISTRATION_ERROR,
   MIN_GAS_LIMIT_DEC,
-  MIN_GAS_LIMIT_HEX,
   MIN_GAS_PRICE_DEC,
   MIN_GAS_PRICE_GWEI,
   MIN_GAS_PRICE_HEX,

--- a/ui/pages/send/send.utils.js
+++ b/ui/pages/send/send.utils.js
@@ -10,7 +10,7 @@ import {
 
 import { calcTokenAmount } from '../../helpers/utils/token-util';
 import { addHexPrefix } from '../../../app/scripts/lib/util';
-import { ERC20, ERC721 } from '../../helpers/constants/common';
+import { ERC20, ERC721 } from '../../../shared/constants/transaction';
 import {
   TOKEN_TRANSFER_FUNCTION_SIGNATURE,
   COLLECTIBLE_TRANSFER_FROM_FUNCTION_SIGNATURE,


### PR DESCRIPTION
## Explanation

Removed all the `ui` references within the shared module and refactored the shared module.
Moved those references into the shared directory (`shared/constants/`) so they are now being imported from that place in both the `ui` and `shared` directory in order to prevent redundancy.  

<!--
Thanks for the pull request. Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Below is a template to give you some ideas. Feel free to use your own words!

Currently, ...

This is a problem because ...

In order to solve this problem, this pull request ...
-->

## More Information

Fixes https://github.com/MetaMask/metamask-extension/issues/15020 (1st part of the ticket)