### PR TITLE
[E2E] Install Firefox extension from dist folder

### DIFF
--- a/package.json
+++ b/package.json
@@ -355,7 +355,7 @@
     "resolve-url-loader": "^3.1.2",
     "sass": "^1.32.4",
     "sass-loader": "^10.1.1",
-    "selenium-webdriver": "^4.1.0",
+    "selenium-webdriver": "^4.3.1",
     "semver": "^7.3.5",
     "serve-handler": "^6.1.2",
     "sinon": "^9.0.0",

--- a/test/e2e/snaps/test-snap-bip-44.spec.js
+++ b/test/e2e/snaps/test-snap-bip-44.spec.js
@@ -18,9 +18,6 @@ describe('Test Snap bip-44', function () {
         fixtures: 'imported-account',
         ganacheOptions,
         title: this.test.title,
-        driverOptions: {
-          type: 'flask',
-        },
       },
       async ({ driver }) => {
         await driver.navigate();

--- a/test/e2e/snaps/test-snap-confirm.spec.js
+++ b/test/e2e/snaps/test-snap-confirm.spec.js
@@ -18,9 +18,6 @@ describe('Test Snap Confirm', function () {
         fixtures: 'imported-account',
         ganacheOptions,
         title: this.test.title,
-        driverOptions: {
-          type: 'flask',
-        },
       },
       async ({ driver }) => {
         await driver.navigate();

--- a/test/e2e/snaps/test-snap-error.spec.js
+++ b/test/e2e/snaps/test-snap-error.spec.js
@@ -19,7 +19,6 @@ describe('Test Snap Error', function () {
         fixtures: 'imported-account',
         ganacheOptions,
         title: this.test.title,
-        driverOptions: { type: 'flask' },
       },
       async ({ driver }) => {
         await driver.navigate();

--- a/test/e2e/snaps/test-snap-managestate.spec.js
+++ b/test/e2e/snaps/test-snap-managestate.spec.js
@@ -19,9 +19,6 @@ describe('Test Snap manageState', function () {
         fixtures: 'imported-account',
         ganacheOptions,
         title: this.test.title,
-        driverOptions: {
-          type: 'flask',
-        },
       },
       async ({ driver }) => {
         await driver.navigate();

--- a/test/e2e/snaps/test-snap-notification.spec.js
+++ b/test/e2e/snaps/test-snap-notification.spec.js
@@ -19,9 +19,6 @@ describe('Test Snap Notification', function () {
         fixtures: 'imported-account',
         ganacheOptions,
         title: this.test.title,
-        driverOptions: {
-          type: 'flask',
-        },
       },
       async ({ driver }) => {
         await driver.navigate();

--- a/test/e2e/webdriver/firefox.js
+++ b/test/e2e/webdriver/firefox.js
@@ -4,8 +4,6 @@ const path = require('path');
 const { Builder, By, until } = require('selenium-webdriver');
 const firefox = require('selenium-webdriver/firefox');
 const proxy = require('selenium-webdriver/proxy');
-const { getVersion } = require('../../../development/lib/get-version');
-const { BuildType } = require('../../../development/lib/build-type');
 
 /**
  * The prefix for temporary Firefox profiles. All Firefox profiles used for e2e tests
@@ -32,10 +30,9 @@ class FirefoxDriver {
    * @param {Object} options - the options for the build
    * @param options.responsive
    * @param options.port
-   * @param options.type
    * @returns {Promise<{driver: !ThenableWebDriver, extensionUrl: string, extensionId: string}>}
    */
-  static async build({ responsive, port, type }) {
+  static async build({ responsive, port }) {
     const templateProfile = fs.mkdtempSync(TEMP_PROFILE_PATH_PREFIX);
     const options = new firefox.Options().setProfile(templateProfile);
     options.setProxy(proxy.manual({ https: HTTPS_PROXY_HOST }));
@@ -55,14 +52,7 @@ class FirefoxDriver {
     const driver = builder.build();
     const fxDriver = new FirefoxDriver(driver);
 
-    const version = getVersion(type || BuildType.main, 0);
-    let extensionString = `builds/metamask-firefox-${version}.zip`;
-
-    if (type) {
-      extensionString = `builds/metamask-${type}-firefox-${version}.zip`;
-    }
-
-    const extensionId = await fxDriver.installExtension(extensionString);
+    const extensionId = await fxDriver.installExtension('dist/firefox');
     const internalExtensionId = await fxDriver.getInternalId();
 
     if (responsive) {

--- a/test/e2e/webdriver/index.js
+++ b/test/e2e/webdriver/index.js
@@ -3,14 +3,14 @@ const Driver = require('./driver');
 const ChromeDriver = require('./chrome');
 const FirefoxDriver = require('./firefox');
 
-async function buildWebDriver({ responsive, port, type } = {}) {
+async function buildWebDriver({ responsive, port } = {}) {
   const browser = process.env.SELENIUM_BROWSER;
 
   const {
     driver: seleniumDriver,
     extensionId,
     extensionUrl,
-  } = await buildBrowserWebDriver(browser, { responsive, port, type });
+  } = await buildBrowserWebDriver(browser, { responsive, port });
   const driver = new Driver(seleniumDriver, browser, extensionUrl);
 
   return {

--- a/yarn.lock
+++ b/yarn.lock
@@ -16692,15 +16692,15 @@ jss@^10.0.3, jss@^10.3.0:
     array-includes "^3.1.2"
     object.assign "^4.1.2"
 
-jszip@^3.6.0:
-  version "3.7.1"
-  resolved "https://registry.yarnpkg.com/jszip/-/jszip-3.7.1.tgz#bd63401221c15625a1228c556ca8a68da6fda3d9"
-  integrity sha512-ghL0tz1XG9ZEmRMcEN2vt7xabrDdqHHeykgARpmZ0BiIctWxM47Vt63ZO2dnp4QYt/xJVLLy5Zv1l/xRdh2byg==
+jszip@^3.10.0:
+  version "3.10.0"
+  resolved "https://registry.yarnpkg.com/jszip/-/jszip-3.10.0.tgz#faf3db2b4b8515425e34effcdbb086750a346061"
+  integrity sha512-LDfVtOLtOxb9RXkYOwPyNBTQDL4eUbqahtoY6x07GiDJHwSYvn8sHHIw8wINImV3MqbMNve2gSuM1DDqEKk09Q==
   dependencies:
     lie "~3.3.0"
     pako "~1.0.2"
     readable-stream "~2.3.6"
-    set-immediate-shim "~1.0.1"
+    setimmediate "^1.0.5"
 
 junk@^3.1.0:
   version "3.1.0"
@@ -24120,14 +24120,14 @@ select@^1.1.2:
   resolved "https://registry.yarnpkg.com/select/-/select-1.1.2.tgz#0e7350acdec80b1108528786ec1d4418d11b396d"
   integrity sha1-DnNQrN7ICxEIUoeG7B1EGNEbOW0=
 
-selenium-webdriver@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/selenium-webdriver/-/selenium-webdriver-4.1.0.tgz#d11e5d43674e2718265a30684bcbf6ec734fd3bd"
-  integrity sha512-kUDH4N8WruYprTzvug4Pl73Th+WKb5YiLz8z/anOpHyUNUdM3UzrdTOxmSNaf9AczzBeY+qXihzku8D1lMaKOg==
+selenium-webdriver@^4.3.1:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/selenium-webdriver/-/selenium-webdriver-4.3.1.tgz#5e9c6c4adee65e57776b5bd4c07c59b65b8f056d"
+  integrity sha512-TjH/ls1WKRQoFEHcqtn6UtwcLnA3yvx08v9cSSFYvyhp8hJWRtbe9ae2I8uXPisEZ2EaGKKoxBZ4EHv0BJM15g==
   dependencies:
-    jszip "^3.6.0"
+    jszip "^3.10.0"
     tmp "^0.2.1"
-    ws ">=7.4.6"
+    ws ">=8.7.0"
 
 semaphore@>=1.0.1, semaphore@^1.0.3:
   version "1.1.0"
@@ -24282,7 +24282,7 @@ set-blocking@^2.0.0, set-blocking@~2.0.0:
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
   integrity sha1-BF+XgtARrppoA93TgrJDkrPYkPc=
 
-set-immediate-shim@^1.0.1, set-immediate-shim@~1.0.1:
+set-immediate-shim@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz#4b2b1b27eb808a9f8dcc481a58e5e56f599f3f61"
   integrity sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=
@@ -27712,7 +27712,7 @@ write@1.0.3:
   dependencies:
     mkdirp "^0.5.1"
 
-ws@*, ws@7.1.0, ws@7.4.6, ws@>=7.4.6, ws@^1.1.0, ws@^5.1.1, ws@^7, ws@^7.2.0, ws@^7.3.1, ws@^7.4.0, ws@^7.4.6, ws@~7.4.2:
+ws@*, ws@7.1.0, ws@7.4.6, ws@>=8.7.0, ws@^1.1.0, ws@^5.1.1, ws@^7, ws@^7.2.0, ws@^7.3.1, ws@^7.4.0, ws@^7.4.6, ws@~7.4.2:
   version "7.4.6"
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.4.6.tgz#5654ca8ecdeee47c33a9a4bf6d28e2be2980377c"
   integrity sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==


### PR DESCRIPTION
## Explanation

<!--
Thanks for the pull request. Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Below is a template to give you some ideas. Feel free to use your own words!

Currently, ...

This is a problem because ...

In order to solve this problem, this pull request ...
-->

- Update Selenium Webdriver from v4.1.0 to v4.3.1, to be able to [install unpacked addons at runtime in FF](https://github.com/SeleniumHQ/selenium/pull/10216), which was introduced in [v4.2.0](https://github.com/SeleniumHQ/selenium/releases/tag/selenium-4.2.0)
- Updated the framework to install the extension in Firefox from the dist folder similar to chrome, rather than using the zip in the build folder.
- Removed some code from the Snaps tests which became redundant after the above change
