### PR TITLE
enable direct routing to the send page

### DIFF
--- a/ui/ducks/send/send.js
+++ b/ui/ducks/send/send.js
@@ -1078,8 +1078,10 @@ const slice = createSlice({
     updateGasLimit: (state, action) => {
       const draftTransaction =
         state.draftTransactions[state.currentTransactionUUID];
-      draftTransaction.gas.gasLimit = addHexPrefix(action.payload);
-      slice.caseReducers.calculateGasTotal(state);
+      if (draftTransaction) {
+        draftTransaction.gas.gasLimit = addHexPrefix(action.payload);
+        slice.caseReducers.calculateGasTotal(state);
+      }
     },
     /**
      * sets the layer 1 fees total (for a multi-layer fee network)
@@ -2324,6 +2326,19 @@ export function getCurrentTransactionUUID(state) {
  */
 export function getCurrentDraftTransaction(state) {
   return state[name].draftTransactions[getCurrentTransactionUUID(state)] ?? {};
+}
+
+/**
+ * Selector that returns true if a draft transaction exists.
+ *
+ * @type {Selector<boolean>}
+ */
+export function getDraftTransactionExists(state) {
+  const draftTransaction = getCurrentDraftTransaction(state);
+  if (Object.keys(draftTransaction).length === 0) {
+    return false;
+  }
+  return true;
 }
 
 // Gas selectors

--- a/ui/pages/send/send-header/send-header.component.js
+++ b/ui/pages/send/send-header/send-header.component.js
@@ -30,8 +30,7 @@ export default function SendHeader() {
 
   if (
     draftTransactionExists === false ||
-    stage === SEND_STAGES.ADD_RECIPIENT ||
-    stage === SEND_STAGES.INACTIVE
+    [SEND_STAGES.ADD_RECIPIENT, SEND_STAGES.INACTIVE].includes(stage)
   ) {
     title = t('sendTo');
   } else if (stage === SEND_STAGES.EDIT) {

--- a/ui/pages/send/send-header/send-header.component.js
+++ b/ui/pages/send/send-header/send-header.component.js
@@ -5,6 +5,7 @@ import PageContainerHeader from '../../../components/ui/page-container/page-cont
 import { getMostRecentOverviewPage } from '../../../ducks/history/history';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import {
+  getDraftTransactionExists,
   getSendAsset,
   getSendStage,
   resetSendState,
@@ -19,15 +20,19 @@ export default function SendHeader() {
   const stage = useSelector(getSendStage);
   const asset = useSelector(getSendAsset);
   const t = useI18nContext();
-
+  const draftTransactionExists = useSelector(getDraftTransactionExists);
   const onClose = () => {
     dispatch(resetSendState());
     history.push(mostRecentOverviewPage);
   };
 
-  let title = asset.type === ASSET_TYPES.NATIVE ? t('send') : t('sendTokens');
+  let title = asset?.type === ASSET_TYPES.NATIVE ? t('send') : t('sendTokens');
 
-  if (stage === SEND_STAGES.ADD_RECIPIENT || stage === SEND_STAGES.INACTIVE) {
+  if (
+    draftTransactionExists === false ||
+    stage === SEND_STAGES.ADD_RECIPIENT ||
+    stage === SEND_STAGES.INACTIVE
+  ) {
     title = t('sendTo');
   } else if (stage === SEND_STAGES.EDIT) {
     title = t('edit');


### PR DESCRIPTION
## Explanation
When we refactored to not use global state for transaction data in the send flow, we made it a requirement to start a new draft transaction PRIOR to entering the send flow. This change allows us to gracefully handle situations that are edge cases such as when routing to the send screen directly, or if the user is in full screen mode and clicks back after moving to the confirm screen. Also added a test to cover this scenario.

## More Information
Fixes #15188 #15183 

## Manual Testing Steps

1. Start a send in full screen mode
2. Fill in amount and click next to move to confirmation screen
3. Click  browser back button
4. Send screen does not error. 
5. Pick a different recipient
6. Add an amount
7. Click next
8. See 2 confirmations, each of which is a fully formed transaction reflecting user's intent

## Pre-Merge Checklist

- [x] PR template is filled out
- [x] **IF** this PR fixes a bug, a test that _would have_ caught the bug has been added
- [x] PR is linked to the appropriate GitHub issue
- [ ] PR has been added to the appropriate release Milestone

### + If there are functional changes:

- [x] Manual testing complete & passed
- [x] "Extension QA Board" label has been applied
