### PR TITLE
Fix #12345: MV3: Implement content script within manifest.json

### DIFF
--- a/app/manifest/v3/_base.json
+++ b/app/manifest/v3/_base.json
@@ -46,7 +46,7 @@
     },
     {
       "matches": ["file://*/*", "http://*/*", "https://*/*"],
-      "js": ["in-page.js"],
+      "js": ["inpage.js"],
       "run_at": "document_start",
       "world": "MAIN"
     }

--- a/app/manifest/v3/_base.json
+++ b/app/manifest/v3/_base.json
@@ -48,7 +48,7 @@
       "matches": ["file://*/*", "http://*/*", "https://*/*"],
       "js": ["in-page.js"],
       "run_at": "document_start",
-      "world": "main"
+      "world": "MAIN"
     }
   ],
   "default_locale": "en",

--- a/app/manifest/v3/_base.json
+++ b/app/manifest/v3/_base.json
@@ -43,6 +43,12 @@
     {
       "matches": ["*://connect.trezor.io/*/popup.html"],
       "js": ["vendor/trezor/content-script.js"]
+    },
+    {
+      "matches": ["file://*/*", "http://*/*", "https://*/*"],
+      "js": ["in-page.js"],
+      "run_at": "document_start",
+      "world": "main"
     }
   ],
   "default_locale": "en",

--- a/app/manifest/v3/_base.json
+++ b/app/manifest/v3/_base.json
@@ -45,7 +45,7 @@
     },
     {
       "matches": ["file://*/*", "http://*/*", "https://*/*"],
-      "js": ["inpage.js", "contentscript.js"],
+      "js": ["contentscript.js", "inpage.js"],
       "run_at": "document_start",
       "world": "MAIN"
     }

--- a/app/manifest/v3/_base.json
+++ b/app/manifest/v3/_base.json
@@ -34,8 +34,7 @@
         "globalthis.js",
         "lockdown-install.js",
         "lockdown-run.js",
-        "lockdown-more.js",
-        "contentscript.js"
+        "lockdown-more.js"
       ],
       "run_at": "document_start",
       "all_frames": true
@@ -46,7 +45,7 @@
     },
     {
       "matches": ["file://*/*", "http://*/*", "https://*/*"],
-      "js": ["inpage.js"],
+      "js": ["inpage.js", "contentscript.js"],
       "run_at": "document_start",
       "world": "MAIN"
     }

--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -168,7 +168,7 @@ async function initialize(remotePort) {
   const initState = await loadStateFromPersistence();
   const initLangCode = await getFirstPreferredLangCode();
   await setupController(initState, initLangCode, remotePort);
-  await loadPhishingWarningPage();
+  // await loadPhishingWarningPage();
   log.info('MetaMask initialization complete.');
 }
 

--- a/app/scripts/contentscript.js
+++ b/app/scripts/contentscript.js
@@ -41,7 +41,9 @@ if (
 ) {
   setupPhishingStream();
 } else if (shouldInjectProvider()) {
-  injectScript(inpageBundle);
+  if (!isManifestV3()) {
+    injectScript(inpageBundle);
+  }
   setupStreams();
 }
 
@@ -55,12 +57,7 @@ function injectScript(content) {
     const container = document.head || document.documentElement;
     const scriptTag = document.createElement('script');
     scriptTag.setAttribute('async', 'false');
-    // Inline scripts do not work in MV3 due to more strict security policy
-    if (isManifestV3()) {
-      scriptTag.setAttribute('src', browser.runtime.getURL('inpage.js'));
-    } else {
-      scriptTag.textContent = content;
-    }
+    scriptTag.textContent = content;
     container.insertBefore(scriptTag, container.children[0]);
     container.removeChild(scriptTag);
   } catch (error) {

--- a/app/scripts/contentscript.js
+++ b/app/scripts/contentscript.js
@@ -7,6 +7,8 @@ import { obj as createThoughStream } from 'through2';
 
 import { isManifestV3 } from '../../shared/modules/mv3.utils';
 
+console.log("STARTING contentscript.js")
+
 // These require calls need to use require to be statically recognized by browserify
 const fs = require('fs');
 const path = require('path');

--- a/app/scripts/contentscript.js
+++ b/app/scripts/contentscript.js
@@ -7,7 +7,7 @@ import { obj as createThoughStream } from 'through2';
 
 import { isManifestV3 } from '../../shared/modules/mv3.utils';
 
-console.log("STARTING contentscript.js")
+console.log('STARTING contentscript.js');
 
 // These require calls need to use require to be statically recognized by browserify
 const fs = require('fs');
@@ -35,7 +35,8 @@ const LEGACY_INPAGE = 'inpage';
 const LEGACY_PROVIDER = 'provider';
 const LEGACY_PUBLIC_CONFIG = 'publicConfig';
 
-const phishingPageUrl = new URL(process.env.PHISHING_WARNING_PAGE_URL);
+// const phishingPageUrl = new URL(process.env.PHISHING_WARNING_PAGE_URL);
+const phishingPageUrl = {};
 
 if (
   window.location.origin === phishingPageUrl.origin &&

--- a/app/scripts/inpage.js
+++ b/app/scripts/inpage.js
@@ -54,3 +54,7 @@ initializeProvider({
   logger: log,
   shouldShimWeb3: true,
 });
+
+alert('GETS HERE');
+console.log("HEREERERERERE!")
+console.log("window.ethereum: ", window.ethereum, window, this);

--- a/app/scripts/inpage.js
+++ b/app/scripts/inpage.js
@@ -3,6 +3,8 @@
 // mostly a fix for web3's BigNumber if AMD's "define" is defined...
 let __define;
 
+console.log('STARTING inpage.js');
+
 /**
  * Caches reference to global define object and deletes it to
  * avoid conflicts with other global define objects, such as
@@ -53,8 +55,20 @@ initializeProvider({
   connectionStream: metamaskStream,
   logger: log,
   shouldShimWeb3: true,
+  shouldSetOnWindow: true,
 });
 
 alert('GETS HERE');
-console.log("HEREERERERERE!")
-console.log("window.ethereum: ", window.ethereum, window, this);
+console.log('HEREERERERERE!');
+console.log('window.ethereum: ', window.ethereum, window, this, globalThis);
+console.table([
+  ['window', window],
+  ['window.ethereum', window.ethereum],
+  ['this', this],
+  ['globalThis', globalThis],
+  ['document', window.document],
+]);
+
+if (window.document) {
+  window.document.MY_PROP = 'Blah';
+}


### PR DESCRIPTION
## Explanation

If we use the `src` of `<script>` to inject our inpage provider, the code is async and won't be initialized immediately in the page.  By using the new `world: MAIN` property for content scripts, we can ensure the script is injected at the correct time.

## More Information

* Fixes [#12345](https://github.com/MetaMask/metamask-extension/issues/14846)
* Requires https://github.com/MetaMask/metamask-extension/pull/14781 to be merged first

## Manual Testing Steps

1.  Check out this PR on top of #14781 
2.  Open app/scripts/inpage.js
3.  Add an `alert('HERE')` call in `inpage.js`
4.  Open any new browser tab, go to https://davidwalsh.name
5.  See the alert is called immediately

## Pre-Merge Checklist

- [ ] PR template is filled out
- [ ] **IF** this PR fixes a bug, a test that _would have_ caught the bug has been added
- [ ] PR is linked to the appropriate GitHub issue
- [ ] PR has been added to the appropriate release Milestone

### + If there are functional changes:

- [ ] Manual testing complete & passed
- [ ] "Extension QA Board" label has been applied
