### PR TITLE
Fix an issue with "No tokens available matching"

### DIFF
--- a/ui/pages/swaps/searchable-item-list/searchable-item-list.js
+++ b/ui/pages/swaps/searchable-item-list/searchable-item-list.js
@@ -1,4 +1,4 @@
-import React, { useState, useRef } from 'react';
+import React, { useState, useRef, useMemo, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import ItemList from './item-list';
 import ListItemSearch from './list-item-search';
@@ -22,7 +22,14 @@ export default function SearchableItemList({
 }) {
   const itemListRef = useRef();
 
-  const [results, setResults] = useState(defaultToAll ? itemsToSearch : []);
+  const initialResultsState = useMemo(() => {
+    return defaultToAll ? itemsToSearch : [];
+  }, [defaultToAll, itemsToSearch]);
+  const [results, setResults] = useState(initialResultsState);
+  useEffect(() => {
+    setResults(initialResultsState);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [initialResultsState.length]);
   const [searchQuery, setSearchQuery] = useState('');
 
   return (


### PR DESCRIPTION
## Explanation
There was an issue in Swaps that was happening in a small amount of cases when a user clicked into the `Swap to` field, it showed: `Fetching tokens...` and then it showed no results (see the first screenshot below). 

The `SearchableItemListcomponent` was accepting a list of tokens as a prop (`itemsToSearch`) and setting it into results as a default component state. At first the list was empty. However, when the list in props changed from an empty array to a list of tokens, it didn't update the `results` state here: https://github.com/MetaMask/metamask-extension/blob/develop/ui/pages/swaps/searchable-item-list/searchable-item-list.js#L25

This PR updates the "results" state if "initialResultsState" array length is different.

## Screenshots/Screencaps
Before: 
![image](https://user-images.githubusercontent.com/80175477/179507645-8cd6cf8a-875d-4eee-af38-dc91a97bad75.png)

After:
![image](https://user-images.githubusercontent.com/80175477/179507715-5c8e03c6-358f-4dda-ab3a-b58d63eb4796.png)

## Manual Testing Steps
- Open the MM extension in the Expanded view
- Click on "Swap" on the main page
- Refresh the Build Quote page in your browser
- Keep clicking in the area where the `Swap to` field will be rendered. When it's rendered, you should briefly see the `Fetching tokens...` text, which should quickly change to a list of tokens