### PR TITLE
Preserve send amount when editing an ERC20 transaction

### DIFF
--- a/ui/ducks/send/send.js
+++ b/ui/ducks/send/send.js
@@ -924,31 +924,23 @@ const slice = createSlice({
      *
      * @param {SendStateDraft} state - A writable draft of the send state to be
      *  updated.
-     * @param {UpdateAssetPayload} action - The asest to set in the
+     * @param {UpdateAssetPayload} action - The asset to set in the
      *  draftTransaction.
      * @returns {void}
      */
     updateAsset: (state, action) => {
+      const { asset, initialAssetSet } = action.payload;
       const draftTransaction =
         state.draftTransactions[state.currentTransactionUUID];
 
-      // If an asset update occurs that changes the type from 'NATIVE' to
-      // 'NATIVE' then this is likely the initial asset set of an edit
-      // transaction. We don't need to set the amount to zero in this case.
-      // The only times where an update would occur of this nature that we
-      // would want to set the amount to zero is on a network or account change
-      // but that update is handled elsewhere.
-      const skipAmountUpdate =
-        action.payload.type === ASSET_TYPES.NATIVE &&
-        draftTransaction.asset.type === ASSET_TYPES.NATIVE;
-      draftTransaction.asset.type = action.payload.type;
-      draftTransaction.asset.balance = action.payload.balance;
-      draftTransaction.asset.error = action.payload.error;
+      draftTransaction.asset.type = asset.type;
+      draftTransaction.asset.balance = asset.balance;
+      draftTransaction.asset.error = asset.error;
       if (
         draftTransaction.asset.type === ASSET_TYPES.TOKEN ||
         draftTransaction.asset.type === ASSET_TYPES.COLLECTIBLE
       ) {
-        draftTransaction.asset.details = action.payload.details;
+        draftTransaction.asset.details = asset.details;
       } else {
         // clear the details object when sending native currency
         draftTransaction.asset.details = null;
@@ -962,7 +954,7 @@ const slice = createSlice({
       // to zero. This will revalidate the send amount field.
       if (state.amountMode === AMOUNT_MODES.MAX) {
         slice.caseReducers.updateAmountToMax(state);
-      } else if (skipAmountUpdate === false) {
+      } else if (initialAssetSet === false) {
         slice.caseReducers.updateSendAmount(state, { payload: '0x0' });
       }
       // validate send state
@@ -1700,7 +1692,7 @@ export function editExistingTransaction(assetType, transactionId) {
       await dispatch(
         updateSendAsset(
           { type: ASSET_TYPES.NATIVE },
-          { skipComputeEstimatedGasLimit: true },
+          { initialAssetSet: true },
         ),
       );
     } else {
@@ -1757,7 +1749,7 @@ export function editExistingTransaction(assetType, transactionId) {
                 : {}),
             },
           },
-          { skipComputeEstimatedGasLimit: true },
+          { initialAssetSet: true },
         ),
       );
     }
@@ -1956,7 +1948,7 @@ export function updateSendAmount(amount) {
  */
 export function updateSendAsset(
   { type, details: providedDetails },
-  { skipComputeEstimatedGasLimit = false } = {},
+  { initialAssetSet = false } = {},
 ) {
   return async (dispatch, getState) => {
     const state = getState();
@@ -1977,10 +1969,13 @@ export function updateSendAsset(
       );
       await dispatch(
         actions.updateAsset({
-          type,
-          details: null,
-          balance: account.balance,
-          error: null,
+          asset: {
+            type,
+            details: null,
+            balance: account.balance,
+            error: null,
+          },
+          initialAssetSet,
         }),
       );
     } else {
@@ -2063,9 +2058,9 @@ export function updateSendAsset(
         }
       }
 
-      await dispatch(actions.updateAsset(asset));
+      await dispatch(actions.updateAsset({ asset, initialAssetSet }));
     }
-    if (skipComputeEstimatedGasLimit === false) {
+    if (initialAssetSet === false) {
       await dispatch(computeEstimatedGasLimit());
     }
   };

--- a/ui/ducks/send/send.test.js
+++ b/ui/ducks/send/send.test.js
@@ -458,8 +458,10 @@ describe('Send Slice', () => {
         const action = {
           type: 'send/updateAsset',
           payload: {
-            type: 'new type',
-            balance: 'new balance',
+            asset: {
+              type: 'new type',
+              balance: 'new balance',
+            },
           },
         };
 
@@ -467,9 +469,11 @@ describe('Send Slice', () => {
 
         const draftTransaction = getTestUUIDTx(result);
 
-        expect(draftTransaction.asset.type).toStrictEqual(action.payload.type);
+        expect(draftTransaction.asset.type).toStrictEqual(
+          action.payload.asset.type,
+        );
         expect(draftTransaction.asset.balance).toStrictEqual(
-          action.payload.balance,
+          action.payload.asset.balance,
         );
       });
 
@@ -486,7 +490,9 @@ describe('Send Slice', () => {
         const action = {
           type: 'send/updateAsset',
           payload: {
-            type: 'New Type',
+            asset: {
+              type: 'New Type',
+            },
           },
         };
 
@@ -504,11 +510,13 @@ describe('Send Slice', () => {
         const action = {
           type: 'send/updateAsset',
           payload: {
-            type: ASSET_TYPES.TOKEN,
-            details: {
-              address: '0xTokenAddress',
-              decimals: 0,
-              symbol: 'TKN',
+            asset: {
+              type: ASSET_TYPES.TOKEN,
+              details: {
+                address: '0xTokenAddress',
+                decimals: 0,
+                symbol: 'TKN',
+              },
             },
           },
         };
@@ -520,9 +528,11 @@ describe('Send Slice', () => {
 
         const draftTransaction = getTestUUIDTx(result);
 
-        expect(draftTransaction.asset.type).toStrictEqual(action.payload.type);
+        expect(draftTransaction.asset.type).toStrictEqual(
+          action.payload.asset.type,
+        );
         expect(draftTransaction.asset.details).toStrictEqual(
-          action.payload.details,
+          action.payload.asset.details,
         );
       });
     });
@@ -1563,10 +1573,13 @@ describe('Send Slice', () => {
         });
         expect(actionResult[1].type).toStrictEqual('send/updateAsset');
         expect(actionResult[1].payload).toStrictEqual({
-          type: ASSET_TYPES.NATIVE,
-          balance: '0x0',
-          error: null,
-          details: null,
+          asset: {
+            type: ASSET_TYPES.NATIVE,
+            balance: '0x0',
+            error: null,
+            details: null,
+          },
+          initialAssetSet: false,
         });
 
         expect(actionResult[2].type).toStrictEqual(
@@ -1616,16 +1629,19 @@ describe('Send Slice', () => {
           payload: `sendFlow - user set asset to ERC20 token with symbol TokenSymbol and address tokenAddress`,
         });
         expect(actionResult[3].payload).toStrictEqual({
-          type: ASSET_TYPES.TOKEN,
-          details: {
-            address: 'tokenAddress',
-            symbol: 'TokenSymbol',
-            decimals: 18,
-            standard: 'ERC20',
+          asset: {
+            type: ASSET_TYPES.TOKEN,
+            details: {
+              address: 'tokenAddress',
+              symbol: 'TokenSymbol',
+              decimals: 18,
+              standard: 'ERC20',
+              balance: '0x0',
+            },
             balance: '0x0',
+            error: null,
           },
-          balance: '0x0',
-          error: null,
+          initialAssetSet: false,
         });
 
         expect(actionResult[4].type).toStrictEqual(
@@ -2550,15 +2566,18 @@ describe('Send Slice', () => {
         expect(actionResult[5]).toStrictEqual({
           type: 'send/updateAsset',
           payload: {
-            balance: '0x1',
-            details: {
-              address: '0xCollectibleAddress',
+            asset: {
               balance: '0x1',
-              standard: TOKEN_STANDARDS.ERC721,
-              tokenId: '15000',
+              details: {
+                address: '0xCollectibleAddress',
+                balance: '0x1',
+                standard: TOKEN_STANDARDS.ERC721,
+                tokenId: '15000',
+              },
+              error: null,
+              type: ASSET_TYPES.COLLECTIBLE,
             },
-            error: null,
-            type: ASSET_TYPES.COLLECTIBLE,
+            initialAssetSet: true,
           },
         });
         expect(actionResult[6].type).toStrictEqual(
@@ -2736,16 +2755,19 @@ describe('Send Slice', () => {
       expect(actionResult[5]).toStrictEqual({
         type: 'send/updateAsset',
         payload: {
-          balance: '0x0',
-          type: ASSET_TYPES.TOKEN,
-          error: null,
-          details: {
+          asset: {
             balance: '0x0',
-            address: '0xTokenAddress',
-            decimals: 18,
-            symbol: 'SYMB',
-            standard: 'ERC20',
+            type: ASSET_TYPES.TOKEN,
+            error: null,
+            details: {
+              balance: '0x0',
+              address: '0xTokenAddress',
+              decimals: 18,
+              symbol: 'SYMB',
+              standard: 'ERC20',
+            },
           },
+          initialAssetSet: true,
         },
       });
       expect(actionResult[6].type).toStrictEqual(


### PR DESCRIPTION
Fixes: #15249

Repurpose `skipComputeEstimatedGasLimit` value passed to `updateSendAsset` action creator on send duck, to a more general purpose `initialAssetSet` pointer, then use this pointer to determine whether we need to reset the sendAmount to 0 in the `updateAsset` action handler (only need to reset it to 0 if `initialAssetSet` is false, which will be the case [when `updateSendAsset` is called in `startNewDraftTransaction`](https://github.com/MetaMask/metamask-extension/blob/d8a1b3bcc71898348f133a65cb242b77e34a0c35/ui/ducks/send/send.js#L2292)).