### PR TITLE
Send to contract e2e

### DIFF
--- a/test/e2e/mock-e2e.js
+++ b/test/e2e/mock-e2e.js
@@ -155,6 +155,15 @@ async function setupMocking(server, testSpecificMock) {
     });
 
   await server
+    .forGet('https://token-api.metaswap.codefi.network/token/0x539')
+    .thenCallback(() => {
+      return {
+        statusCode: 200,
+        json: {},
+      };
+    });
+
+  await server
     .forGet(
       'https://static.metaswap.codefi.network/api/v1/tokenIcons/1337/0x0d8775f648430679a709e98d2b0cb6250d2887ef.png',
     )

--- a/test/e2e/run-e2e-test.js
+++ b/test/e2e/run-e2e-test.js
@@ -70,10 +70,12 @@ async function main() {
   }
 
   let testTimeoutInMilliseconds = 60 * 1000;
+  let exit = '--exit';
 
   if (leaveRunning) {
     process.env.E2E_LEAVE_RUNNING = 'true';
     testTimeoutInMilliseconds = 0;
+    exit = '--no-exit';
   }
 
   await retry({ retries }, async () => {
@@ -83,7 +85,7 @@ async function main() {
       '--timeout',
       testTimeoutInMilliseconds,
       e2eTestPath,
-      '--exit',
+      exit,
     ]);
   });
 }

--- a/test/e2e/tests/send-hex-address.spec.js
+++ b/test/e2e/tests/send-hex-address.spec.js
@@ -119,16 +119,6 @@ describe('Send ETH to a 40 character hexadecimal address', function () {
 });
 
 describe('Send ERC20 to a 40 character hexadecimal address', function () {
-  async function mockTstToken(server) {
-    await server
-      .forGet('https://token-api.metaswap.codefi.network/token/0x539')
-      .thenCallback(() => {
-        return {
-          statusCode: 200,
-          json: {},
-        };
-      });
-  }
   const ganacheOptions = {
     accounts: [
       {
@@ -147,8 +137,7 @@ describe('Send ERC20 to a 40 character hexadecimal address', function () {
         title: this.test.title,
         failOnConsoleError: false,
       },
-      async ({ driver, mockServer }) => {
-        await mockTstToken(mockServer);
+      async ({ driver }) => {
         await driver.navigate();
         await driver.fill('#password', 'correct horse battery staple');
         await driver.press('#password', driver.Key.ENTER);
@@ -247,8 +236,7 @@ describe('Send ERC20 to a 40 character hexadecimal address', function () {
         title: this.test.title,
         failOnConsoleError: false,
       },
-      async ({ driver, mockServer }) => {
-        await mockTstToken(mockServer);
+      async ({ driver }) => {
         await driver.navigate();
         await driver.fill('#password', 'correct horse battery staple');
         await driver.press('#password', driver.Key.ENTER);

--- a/test/e2e/tests/send-to-contract.spec.js
+++ b/test/e2e/tests/send-to-contract.spec.js
@@ -1,0 +1,83 @@
+const { strict: assert } = require('assert');
+const { convertToHexValue, withFixtures } = require('../helpers');
+
+describe('Send ERC20 token to contract address', function () {
+  const ganacheOptions = {
+    accounts: [
+      {
+        secretKey:
+          '0x7C9529A67102755B7E6102D6D950AC5D5863C98713805CEC576B945B15B71EAC',
+        balance: convertToHexValue(25000000000000000000),
+      },
+    ],
+  };
+  it('should display the token contract warning to the user', async function () {
+    await withFixtures(
+      {
+        dapp: true,
+        fixtures: 'connected-state',
+        ganacheOptions,
+        title: this.test.title,
+        failOnConsoleError: false,
+      },
+      async ({ driver }) => {
+        await driver.navigate();
+        await driver.fill('#password', 'correct horse battery staple');
+        await driver.press('#password', driver.Key.ENTER);
+
+        // Create TST
+        await driver.openNewPage('http://127.0.0.1:8080/');
+        await driver.clickElement('#createToken');
+        await driver.waitUntilXWindowHandles(3);
+        let windowHandles = await driver.getAllWindowHandles();
+        const extension = windowHandles[0];
+        const dapp = await driver.switchToWindowWithTitle(
+          'E2E Test Dapp',
+          windowHandles,
+        );
+        await driver.switchToWindowWithTitle(
+          'MetaMask Notification',
+          windowHandles,
+        );
+        await driver.clickElement({ text: 'Confirm', tag: 'button' });
+        await driver.waitUntilXWindowHandles(2);
+        await driver.switchToWindow(dapp);
+        const tokenAddress = await driver.waitForSelector({
+          css: '#tokenAddress',
+          text: '0x',
+        });
+        const tokenAddressText = await tokenAddress.getText();
+
+        // Add token
+        await driver.switchToWindow(dapp);
+        await driver.clickElement('#watchAsset');
+        await driver.waitUntilXWindowHandles(3);
+        windowHandles = await driver.getAllWindowHandles();
+        await driver.switchToWindowWithTitle(
+          'MetaMask Notification',
+          windowHandles,
+        );
+        await driver.clickElement({ text: 'Add Token', tag: 'button' });
+        await driver.waitUntilXWindowHandles(2);
+        await driver.switchToWindow(extension);
+
+        // Send TST
+        await driver.clickElement('[data-testid="home__asset-tab"]');
+        await driver.clickElement('.token-cell');
+        await driver.clickElement('[data-testid="eth-overview-send"]');
+
+        // Type contract address
+        await driver.fill(
+          'input[placeholder="Search, public address (0x), or ENS"]',
+          tokenAddressText,
+        );
+
+        // Verify warning
+        const warningText =
+          'Warning: you are about to send to a token contract which could result in a loss of funds. Learn more\nI understand';
+        const warning = await driver.findElement('.send__warning-container');
+        assert.equal(await warning.getText(), warningText);
+      },
+    );
+  });
+});


### PR DESCRIPTION
## Explanation

<!--
Thanks for the pull request. Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Below is a template to give you some ideas. Feel free to use your own words!

Currently, ...

This is a problem because ...

In order to solve this problem, this pull request ...
-->

This PR add e2e test coverage for the token contract warning

See #13588 

<img width="430" alt="Token contract warning" src="https://user-images.githubusercontent.com/53189696/179726781-8bbeb7b4-609b-4fc4-ac7b-e4b229a09e1d.png">

## More Information

<!--
Are there any issues, Slack conversations, Zendesk issues, user stories, etc. reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

As part of the tests i've moved the mock token api call from being test specific to global to ensure all tests can take advantage of it.

Iv'e also add the `--no-exit` flag to the test runner so the leaveRunning command works as it did before #15253 