### PR TITLE
skip tests & fix build

### DIFF
--- a/test/e2e/tests/custom-token-add-approve.spec.js
+++ b/test/e2e/tests/custom-token-add-approve.spec.js
@@ -1,3 +1,4 @@
+/* eslint-disable mocha/no-skipped-tests */
 const { strict: assert } = require('assert');
 
 const {

--- a/test/e2e/tests/custom-token-add-approve.spec.js
+++ b/test/e2e/tests/custom-token-add-approve.spec.js
@@ -6,7 +6,7 @@ const {
   getWindowHandles,
 } = require('../helpers');
 
-describe('Create token, approve token and approve token without gas', function () {
+describe.skip('Create token, approve token and approve token without gas', function () {
   describe('Add a custom token from a dapp', function () {
     const ganacheOptions = {
       accounts: [


### PR DESCRIPTION
## Explanation

<!--
Thanks for the pull request. Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Below is a template to give you some ideas. Feel free to use your own words!

Currently, ...

This is a problem because ...

In order to solve this problem, this pull request ...
-->

Skips e2e tests introduced in #13797 

The PR mentioned above should of had the `Do not merge` label, as it was not intended to be merged at this time.

These tests are part of the work included to refactor the metamask-ui.spec.js to use fixtures.

We can enable these tests later when we are ready to remove the tests from metamask-ui.spec.js, to avoid duplicate tests being run.

## More Information

<!--
Are there any issues, Slack conversations, Zendesk issues, user stories, etc. reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

## Screenshots/Screencaps

<!-- If you're making a change to the UI, make sure to capture a screenshot or a short video showing off your work! -->

### Before

<!-- How did the UI you changed look before your changes? Drag your file(s) below this line: -->

### After

<!-- How does it look now? Drag your file(s) below this line: -->

## Manual Testing Steps

<!--
How should reviewers and QA manually test your changes? For instance:

- Go to this screen
- Do this
- Then do this
-->

## Pre-Merge Checklist

- [ ] PR template is filled out
- [ ] **IF** this PR fixes a bug, a test that _would have_ caught the bug has been added
- [ ] PR is linked to the appropriate GitHub issue
- [ ] PR has been added to the appropriate release Milestone

### + If there are functional changes:

- [ ] Manual testing complete & passed
- [ ] "Extension QA Board" label has been applied
