### PR TITLE
Updating title case to sentence case and other conventions

### DIFF
--- a/app/_locales/de/messages.json
+++ b/app/_locales/de/messages.json
@@ -739,7 +739,7 @@
   },
   "customGasSettingToolTipMessage": {
     "message": "$1 verwenden, um den Gaspreis anzupassen. Das kann verwirrend sein, wenn Sie damit nicht vertraut sind. Interaktion auf eigene Gefahr.",
-    "description": "$1 is key 'advanced' (text: 'Advanced') separated here so that it can be passed in with bold fontweight"
+    "description": "$1 is key 'advanced' (text: 'Advanced') separated here so that it can be passed in with bold font-weight"
   },
   "customGasSubTitle": {
     "message": "Höhere Gebühren können Bearbeitungszeiten verkürzen, wofür es allerdings keine Garantie gibt."
@@ -825,7 +825,7 @@
   },
   "depositCrypto": {
     "message": "$1 einzahlen",
-    "description": "$1 represents the cypto symbol to be purchased"
+    "description": "$1 represents the crypto symbol to be purchased"
   },
   "description": {
     "message": "Beschreibung"
@@ -1470,7 +1470,7 @@
   },
   "highGasSettingToolTipMessage": {
     "message": "Hohe Wahrscheinlichkeit, auch in volatilen Märkten. Verwenden Sie $1, um Schwankungen im Netzwerkverkehr, die z. B. durch den Ausfall beliebter NFTs entstehen, abzudecken.",
-    "description": "$1 is key 'high' (text: 'Aggressive') separated here so that it can be passed in with bold fontweight"
+    "description": "$1 is key 'high' (text: 'Aggressive') separated here so that it can be passed in with bold font-weight"
   },
   "highLowercase": {
     "message": "hoch"
@@ -1773,7 +1773,7 @@
   },
   "lowGasSettingToolTipMessage": {
     "message": "Verwenden Sie $1, um auf einen günstigeren Preis zu warten. Zeitschätzungen sind viel ungenauer, da die Preise nicht vorhersehbar sind.",
-    "description": "$1 is key 'low' separated here so that it can be passed in with bold fontweight"
+    "description": "$1 is key 'low' separated here so that it can be passed in with bold font-weight"
   },
   "lowLowercase": {
     "message": "niedrig"
@@ -1817,7 +1817,7 @@
   },
   "mediumGasSettingToolTipMessage": {
     "message": "Verwenden Sie $1 für schnelle Verarbeitung zum aktuellen Marktpreis.",
-    "description": "$1 is key 'medium' (text: 'Market') separated here so that it can be passed in with bold fontweight"
+    "description": "$1 is key 'medium' (text: 'Market') separated here so that it can be passed in with bold font-weight"
   },
   "memo": {
     "message": " Memo"
@@ -2143,7 +2143,7 @@
   },
   "notifications10ActionText": {
     "message": "Einstellungen ansehen",
-    "description": "The 'call to action' on the button, or link, of the 'Visit in settings' notification. Upon clicking, users will be taken to settings page."
+    "description": "The 'call to action' on the button, or link, of the 'Visit in Settings' notification. Upon clicking, users will be taken to Settings page."
   },
   "notifications10DescriptionOne": {
     "message": "Die verbesserte Token-Erkennung ist derzeit in den Netzwerken Ethereum Mainnet, Polygon, BSC und Avalanche verfügbar. Es gibt bald mehr!"
@@ -2238,7 +2238,7 @@
   },
   "notifications8ActionText": {
     "message": "Zu den erweiterten Einstellungen gehen",
-    "description": "Description on an action button that appears in the What's New popup. Tells the user that if they click it, they will go to our Advanced Settings page."
+    "description": "Description on an action button that appears in the What's New popup. Tells the user that if they click it, they will go to our Advanced settings page."
   },
   "notifications8DescriptionOne": {
     "message": "Ab MetaMask v10.4.0 benötigen Sie kein Ledger Live mehr, um Ihr Ledger Gerät mit MetaMask zu verbinden.",
@@ -2483,7 +2483,7 @@
   },
   "preferredLedgerConnectionType": {
     "message": "Bevorzugter Ledger-Verbindungstyp",
-    "description": "A header for a dropdown in the advanced section of settings. Appears above the ledgerConnectionPreferenceDescription message"
+    "description": "A header for a dropdown in Settings > Advanced. Appears above the ledgerConnectionPreferenceDescription message"
   },
   "preparingSwap": {
     "message": "Swap wird vorbereitet ..."
@@ -3654,7 +3654,7 @@
   },
   "toggleTestNetworks": {
     "message": "$1 Test-Netzwerke",
-    "description": "$1 is a clickable link with text defined by the 'showHide' key. The link will open to the advanced settings where users can enable the display of test networks in the network dropdown."
+    "description": "$1 is a clickable link with text defined by the 'showHide' key. The link will open Settings > Advanced where users can enable the display of test networks in the network dropdown."
   },
   "token": {
     "message": "Token"

--- a/app/_locales/el/messages.json
+++ b/app/_locales/el/messages.json
@@ -747,7 +747,7 @@
   },
   "customGasSettingToolTipMessage": {
     "message": "Χρησιμοποιήστε 1 $ για να προσαρμόσετε την τιμή του τέλους συναλλαγής. Αυτό μπορεί να προκαλέσει σύγχυση, αν δεν είστε εξοικειωμένοι. Επεξεργαστείτε το με δικό σας ρίσκο.",
-    "description": "$1 is key 'advanced' (text: 'Advanced') separated here so that it can be passed in with bold fontweight"
+    "description": "$1 is key 'advanced' (text: 'Advanced') separated here so that it can be passed in with bold font-weight"
   },
   "customGasSubTitle": {
     "message": "Η αύξηση των τελών μπορεί να μειώσει τους χρόνους επεξεργασίας, αλλά αυτό δεν είναι εγγυημένο."
@@ -833,7 +833,7 @@
   },
   "depositCrypto": {
     "message": "Κατάθεση $1",
-    "description": "$1 represents the cypto symbol to be purchased"
+    "description": "$1 represents the crypto symbol to be purchased"
   },
   "description": {
     "message": "Περιγραφή"
@@ -1481,7 +1481,7 @@
   },
   "highGasSettingToolTipMessage": {
     "message": "Χρησιμοποιήστε $1 για να καλύψετε απότομες αυξήσεις της κίνησης του δικτύου λόγω των δημοφιλών ξεκινημάτων NFT.",
-    "description": "$1 is key 'high' (text: 'Aggressive') separated here so that it can be passed in with bold fontweight"
+    "description": "$1 is key 'high' (text: 'Aggressive') separated here so that it can be passed in with bold font-weight"
   },
   "highLowercase": {
     "message": "υψηλό"
@@ -1787,7 +1787,7 @@
   },
   "lowGasSettingToolTipMessage": {
     "message": "Χρησιμοποιήστε 1 $ για να περιμένετε για μια φθηνότερη τιμή. Οι εκτιμήσεις του χρόνου είναι πολύ λιγότερο ακριβείς καθώς οι τιμές είναι κάπως απρόβλεπτες.",
-    "description": "$1 is key 'low' separated here so that it can be passed in with bold fontweight"
+    "description": "$1 is key 'low' separated here so that it can be passed in with bold font-weight"
   },
   "lowLowercase": {
     "message": "χαμηλό"
@@ -1831,7 +1831,7 @@
   },
   "mediumGasSettingToolTipMessage": {
     "message": "Χρησιμοποιήστε $1 για γρήγορη επεξεργασία στην τρέχουσα τιμή της αγοράς.",
-    "description": "$1 is key 'medium' (text: 'Market') separated here so that it can be passed in with bold fontweight"
+    "description": "$1 is key 'medium' (text: 'Market') separated here so that it can be passed in with bold font-weight"
   },
   "memo": {
     "message": "σημείωμα"
@@ -2170,7 +2170,7 @@
   },
   "notifications10ActionText": {
     "message": "Μετάβαση στις Ρυθμίσεις",
-    "description": "The 'call to action' on the button, or link, of the 'Visit in settings' notification. Upon clicking, users will be taken to settings page."
+    "description": "The 'call to action' on the button, or link, of the 'Visit in Settings' notification. Upon clicking, users will be taken to Settings page."
   },
   "notifications10DescriptionOne": {
     "message": "Ο βελτιωμένος εντοπισμός token είναι προς το παρόν διαθέσιμος στα δίκτυα Ethereum Mainnet, Polygon, BSC και Avalanche. Περισσότερα προσεχώς!"
@@ -2275,7 +2275,7 @@
   },
   "notifications8ActionText": {
     "message": "Μεταβείτε στις Ρυθμίσεις για Προχωρημένους",
-    "description": "Description on an action button that appears in the What's New popup. Tells the user that if they click it, they will go to our Advanced Settings page."
+    "description": "Description on an action button that appears in the What's New popup. Tells the user that if they click it, they will go to our Advanced settings page."
   },
   "notifications8DescriptionOne": {
     "message": "Από τη MetaMask v10.4.0 και μετά, δεν χρειάζεστε πλέον το Ledger Live για να συνδέσετε τη συσκευή Ledger με το MetaMask.",
@@ -2520,7 +2520,7 @@
   },
   "preferredLedgerConnectionType": {
     "message": "Προτιμώμενος Τύπος Σύνδεσης Ledger",
-    "description": "A header for a dropdown in the advanced section of settings. Appears above the ledgerConnectionPreferenceDescription message"
+    "description": "A header for a dropdown in Settings > Advanced. Appears above the ledgerConnectionPreferenceDescription message"
   },
   "preparingSwap": {
     "message": "Προετοιμασία ανταλλαγής..."
@@ -3710,7 +3710,7 @@
   },
   "toggleTestNetworks": {
     "message": "$1 δοκιμαστικά δίκτυα",
-    "description": "$1 is a clickable link with text defined by the 'showHide' key. The link will open to the advanced settings where users can enable the display of test networks in the network dropdown."
+    "description": "$1 is a clickable link with text defined by the 'showHide' key. The link will open Settings > Advanced where users can enable the display of test networks in the network dropdown."
   },
   "token": {
     "message": "Διακριτικό"

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -18,13 +18,13 @@
     "message": "After you’ve signed with your wallet, click on 'Get Signature' to receive the signature"
   },
   "QRHardwareSignRequestGetSignature": {
-    "message": "Get Signature"
+    "message": "Get signature"
   },
   "QRHardwareSignRequestSubtitle": {
     "message": "Scan the QR code with your wallet"
   },
   "QRHardwareSignRequestTitle": {
-    "message": "Request Signature"
+    "message": "Request signature"
   },
   "QRHardwareUnknownQRCodeTitle": {
     "message": "Error"
@@ -33,16 +33,16 @@
     "message": "Invalid QR code. Please scan the sync QR code of the hardware wallet."
   },
   "QRHardwareWalletImporterTitle": {
-    "message": "Scan QR Code"
+    "message": "Scan QR code"
   },
   "QRHardwareWalletSteps1Description": {
     "message": "Connect an airgapped hardware wallet that communicates through QR-codes. Officially supported airgapped hardware wallets include:"
   },
   "QRHardwareWalletSteps1Title": {
-    "message": "QR-based HW Wallet"
+    "message": "QR-based HW wallet"
   },
   "QRHardwareWalletSteps2Description": {
-    "message": "Ngrave (Coming Soon)"
+    "message": "Ngrave (coming soon)"
   },
   "SIWEAddressInvalid": {
     "message": "The address in the sign-in request does not match the address of the account you are using to sign in."
@@ -133,17 +133,17 @@
     "message": "Account details"
   },
   "accountIdenticon": {
-    "message": "Account Identicon"
+    "message": "Account identicon"
   },
   "accountName": {
-    "message": "Account Name"
+    "message": "Account name"
   },
   "accountNameDuplicate": {
     "message": "This account name already exists",
     "description": "This is an error message shown when the user enters a new account name that matches an existing account name"
   },
   "accountOptions": {
-    "message": "Account Options"
+    "message": "Account options"
   },
   "accountSelectionRequired": {
     "message": "You need to select an account!"
@@ -182,7 +182,7 @@
     "message": "Add contact"
   },
   "addCustomToken": {
-    "message": "Add Custom Token"
+    "message": "Add custom token"
   },
   "addCustomTokenByContractAddress": {
     "message": "Can’t find a token? You can manually add any token by pasting its address. Token contract addresses can be found on $1.",
@@ -218,17 +218,17 @@
     "message": "add more networks manually"
   },
   "addNetwork": {
-    "message": "Add Network"
+    "message": "Add network"
   },
   "addNetworkTooltipWarning": {
     "message": "This network connection relies on third parties. This connection may be less reliable or enable third-parties to track activity. $1",
     "description": "$1 is Learn more link"
   },
   "addSuggestedTokens": {
-    "message": "Add Suggested Tokens"
+    "message": "Add suggested tokens"
   },
   "addToken": {
-    "message": "Add Token"
+    "message": "Add token"
   },
   "address": {
     "message": "Address"
@@ -255,13 +255,13 @@
     "message": "Gas price"
   },
   "advancedOptions": {
-    "message": "Advanced Options"
+    "message": "Advanced options"
   },
   "advancedPriorityFeeToolTip": {
     "message": "Priority fee (aka “miner tip”) goes directly to miners and incentivizes them to prioritize your transaction."
   },
   "affirmAgree": {
-    "message": "I Agree"
+    "message": "I agree"
   },
   "airgapVault": {
     "message": "AirGap Vault"
@@ -370,7 +370,7 @@
     "message": "Assets"
   },
   "attemptToCancel": {
-    "message": "Attempt to Cancel?"
+    "message": "Attempt to cancel?"
   },
   "attemptToCancelDescription": {
     "message": "Submitting this attempt does not guarantee your original transaction will be cancelled. If the cancellation attempt is successful, you will be charged the transaction fee above."
@@ -385,7 +385,7 @@
     "message": "You have authorized the following permissions"
   },
   "autoLockTimeLimit": {
-    "message": "Auto-Lock Timer (minutes)"
+    "message": "Auto-lock timer (minutes)"
   },
   "autoLockTimeLimitDescription": {
     "message": "Set the idle time in minutes before MetaMask will become locked."
@@ -397,7 +397,7 @@
     "message": "Back"
   },
   "backToAll": {
-    "message": "Back to All"
+    "message": "Back to all"
   },
   "backupApprovalInfo": {
     "message": "This secret code is required to recover your wallet in case you lose your device, forget your password, have to re-install MetaMask, or want to access your wallet on another device."
@@ -452,7 +452,7 @@
     "description": "This is used with viewOnEtherscan e.g View Swap on Etherscan"
   },
   "blockExplorerUrl": {
-    "message": "Block Explorer URL"
+    "message": "Block explorer URL"
   },
   "blockExplorerUrlDefinition": {
     "message": "The URL used as the block explorer for this network."
@@ -465,7 +465,7 @@
     "message": "Blockies"
   },
   "browserNotSupported": {
-    "message": "Your Browser is not supported..."
+    "message": "Your browser is not supported..."
   },
   "buildContactList": {
     "message": "Build your contact list"
@@ -516,13 +516,13 @@
     "message": "Bytes"
   },
   "canToggleInSettings": {
-    "message": "You can re-enable this notification in Settings -> Alerts."
+    "message": "You can re-enable this notification in Settings > Alerts."
   },
   "cancel": {
     "message": "Cancel"
   },
   "cancelEdit": {
-    "message": "Cancel Edit"
+    "message": "Cancel edit"
   },
   "cancelPopoverTitle": {
     "message": "Cancel transaction"
@@ -546,7 +546,7 @@
     "message": "Cancel swap for free"
   },
   "cancellationGasFee": {
-    "message": "Cancellation Gas Fee"
+    "message": "Cancellation gas fee"
   },
   "cancelled": {
     "message": "Cancelled"
@@ -618,7 +618,7 @@
     "message": "Connect account or create new"
   },
   "connectHardwareWallet": {
-    "message": "Connect Hardware Wallet"
+    "message": "Connect hardware wallet"
   },
   "connectManually": {
     "message": "Manually connect to current site"
@@ -644,7 +644,7 @@
     "description": "$1 is the number of accounts to which the web3 site/application is asking to connect; this will substitute $1 in connectToMultiple"
   },
   "connectWithMetaMask": {
-    "message": "Connect With MetaMask"
+    "message": "Connect with MetaMask"
   },
   "connectedAccountsDescriptionPlural": {
     "message": "You have $1 accounts connected to this site.",
@@ -678,19 +678,19 @@
     "message": "Connecting to $1"
   },
   "connectingToGoerli": {
-    "message": "Connecting to Goerli Test Network"
+    "message": "Connecting to Goerli test network"
   },
   "connectingToKovan": {
-    "message": "Connecting to Kovan Test Network"
+    "message": "Connecting to Kovan test network"
   },
   "connectingToMainnet": {
     "message": "Connecting to Ethereum Mainnet"
   },
   "connectingToRinkeby": {
-    "message": "Connecting to Rinkeby Test Network"
+    "message": "Connecting to Rinkeby test network"
   },
   "connectingToRopsten": {
-    "message": "Connecting to Ropsten Test Network"
+    "message": "Connecting to Ropsten test network"
   },
   "contactUs": {
     "message": "Contact us"
@@ -723,10 +723,10 @@
     "message": "You are sending tokens to the token's contract address. This may result in the loss of these tokens."
   },
   "contractDeployment": {
-    "message": "Contract Deployment"
+    "message": "Contract deployment"
   },
   "contractInteraction": {
-    "message": "Contract Interaction"
+    "message": "Contract interaction"
   },
   "convertTokenToNFTDescription": {
     "message": "We've detected that this asset is an NFT. MetaMask now has full native support for NFTs. Would you like to remove it from your token list and add it as an NFT?"
@@ -750,28 +750,28 @@
     "message": "Copy to clipboard"
   },
   "copyTransactionId": {
-    "message": "Copy Transaction ID"
+    "message": "Copy transaction ID"
   },
   "create": {
     "message": "Create"
   },
   "createAWallet": {
-    "message": "Create a Wallet"
+    "message": "Create a wallet"
   },
   "createAccount": {
-    "message": "Create Account"
+    "message": "Create account"
   },
   "createNewWallet": {
     "message": "Create a new wallet"
   },
   "createPassword": {
-    "message": "Create Password"
+    "message": "Create password"
   },
   "currencyConversion": {
-    "message": "Currency Conversion"
+    "message": "Currency conversion"
   },
   "currencySymbol": {
-    "message": "Currency Symbol"
+    "message": "Currency symbol"
   },
   "currencySymbolDefinition": {
     "message": "The ticker symbol displayed for this network’s currency."
@@ -783,7 +783,7 @@
     "message": "Current extension page"
   },
   "currentLanguage": {
-    "message": "Current Language"
+    "message": "Current language"
   },
   "currentTitle": {
     "message": "Current:"
@@ -807,20 +807,20 @@
     "message": "Search for a previously added network"
   },
   "customGas": {
-    "message": "Customize Gas"
+    "message": "Customize gas"
   },
   "customGasSettingToolTipMessage": {
     "message": "Use $1 to customize the gas price. This can be confusing if you aren’t familiar. Interact at your own risk.",
-    "description": "$1 is key 'advanced' (text: 'Advanced') separated here so that it can be passed in with bold fontweight"
+    "description": "$1 is key 'advanced' (text: 'Advanced') separated here so that it can be passed in with bold font-weight"
   },
   "customGasSubTitle": {
     "message": "Increasing fee may decrease processing times, but it is not guaranteed."
   },
   "customSpendLimit": {
-    "message": "Custom Spend Limit"
+    "message": "Custom spend limit"
   },
   "customToken": {
-    "message": "Custom Token"
+    "message": "Custom token"
   },
   "customTokenWarningInNonTokenDetectionNetwork": {
     "message": "Token detection is not available on this network yet. Please import token manually and make sure you trust it. Learn about $1"
@@ -858,7 +858,7 @@
     "message": "Hex"
   },
   "decimal": {
-    "message": "Token Decimal"
+    "message": "Token decimal"
   },
   "decimalsMustZerotoTen": {
     "message": "Decimals must be at least 0, and not over 36."
@@ -887,17 +887,17 @@
     "message": "Delete"
   },
   "deleteAccount": {
-    "message": "Delete Account"
+    "message": "Delete account"
   },
   "deleteNetwork": {
-    "message": "Delete Network?"
+    "message": "Delete network?"
   },
   "deleteNetworkDescription": {
     "message": "Are you sure you want to delete this network?"
   },
   "depositCrypto": {
     "message": "Deposit $1",
-    "description": "$1 represents the cypto symbol to be purchased"
+    "description": "$1 represents the crypto symbol to be purchased"
   },
   "description": {
     "message": "Description"
@@ -906,7 +906,7 @@
     "message": "Details"
   },
   "directDepositCrypto": {
-    "message": "Directly Deposit $1"
+    "message": "Directly deposit $1"
   },
   "directDepositCryptoExplainer": {
     "message": "If you already have some $1, the quickest way to get $1 in your new wallet by direct deposit."
@@ -958,7 +958,7 @@
     "message": "Download this Secret Recovery Phrase and keep it stored safely on an external encrypted hard drive or storage medium."
   },
   "downloadStateLogs": {
-    "message": "Download State Logs"
+    "message": "Download state logs"
   },
   "dropped": {
     "message": "Dropped"
@@ -976,7 +976,7 @@
     "message": "Edit cancellation gas fee"
   },
   "editContact": {
-    "message": "Edit Contact"
+    "message": "Edit contact"
   },
   "editGasEducationButtonText": {
     "message": "How should I choose?"
@@ -1086,28 +1086,28 @@
     "message": "This lowers your maximum fee but if network traffic increases your transaction may be delayed or fail."
   },
   "editNonceField": {
-    "message": "Edit Nonce"
+    "message": "Edit nonce"
   },
   "editNonceMessage": {
     "message": "This is an advanced feature, use cautiously."
   },
   "editPermission": {
-    "message": "Edit Permission"
+    "message": "Edit permission"
   },
   "editSpeedUpEditGasFeeModalTitle": {
     "message": "Edit speed up gas fee"
   },
   "enableAutoDetect": {
-    "message": " Enable Autodetect"
+    "message": " Enable autodetect"
   },
   "enableEIP1559V2": {
-    "message": "Enable Enhanced Gas Fee UI"
+    "message": "Enable enhanced gas fee UI"
   },
   "enableEIP1559V2AlertMessage": {
     "message": "We've updated how gas fee estimation and customization works."
   },
   "enableEIP1559V2ButtonText": {
-    "message": "Turn on Enhanced Gas Fee UI in Settings"
+    "message": "Turn on enhanced gas fee UI in Settings"
   },
   "enableEIP1559V2Description": {
     "message": "We've updated how gas estimation and customization works. Turn on if you'd like to use the new gas experience. $1",
@@ -1126,7 +1126,7 @@
     "message": "Use OpenSea's API to fetch NFT data. NFT auto-detection relies on OpenSea's API, and will not be available when this is turned off."
   },
   "enableSmartTransactions": {
-    "message": "Enable Smart Transactions"
+    "message": "Enable smart transactions"
   },
   "enableToken": {
     "message": "enable $1",
@@ -1143,7 +1143,7 @@
     "message": "You passed the test - keep your Secret Recovery Phrase safe, it's your responsibility!"
   },
   "endOfFlowMessage10": {
-    "message": "All Done"
+    "message": "All done"
   },
   "endOfFlowMessage2": {
     "message": "Tips on storing it safely"
@@ -1158,7 +1158,7 @@
     "message": "Be careful of phishing! MetaMask will never spontaneously ask for your Secret Recovery Phrase."
   },
   "endOfFlowMessage6": {
-    "message": "If you need to back up your Secret Recovery Phrase again, you can find it in Settings -> Security."
+    "message": "If you need to back up your Secret Recovery Phrase again, you can find it in Settings > Security."
   },
   "endOfFlowMessage7": {
     "message": "If you ever have questions or see something fishy, contact our support $1.",
@@ -1175,7 +1175,7 @@
     "description": "$1 is the return value of eth_chainId from an RPC endpoint"
   },
   "ensIllegalCharacter": {
-    "message": "Illegal Character for ENS."
+    "message": "Illegal character for ENS."
   },
   "ensNotFoundOnCurrentNetwork": {
     "message": "ENS name not found on the current network. Try switching to Ethereum Mainnet."
@@ -1187,10 +1187,10 @@
     "message": "Error in ENS name registration"
   },
   "ensUnknownError": {
-    "message": "ENS Lookup failed."
+    "message": "ENS lookup failed."
   },
   "enterMaxSpendLimit": {
-    "message": "Enter Max Spend Limit"
+    "message": "Enter max spend limit"
   },
   "enterPassword": {
     "message": "Enter password"
@@ -1203,7 +1203,7 @@
     "description": "Displayed error code for debugging purposes. $1 is the error code"
   },
   "errorDetails": {
-    "message": "Error Details",
+    "message": "Error details",
     "description": "Title for collapsible section that displays error details for debugging purposes"
   },
   "errorMessage": {
@@ -1231,13 +1231,13 @@
     "description": "Title for error stack, which is displayed for debugging purposes"
   },
   "estimatedProcessingTimes": {
-    "message": "Estimated Processing Times"
+    "message": "Estimated processing times"
   },
   "ethGasPriceFetchWarning": {
     "message": "Backup gas price is provided as the main gas estimation service is unavailable right now."
   },
   "ethereumPublicAddress": {
-    "message": "Ethereum Public Address"
+    "message": "Ethereum public address"
   },
   "etherscan": {
     "message": "Etherscan"
@@ -1258,10 +1258,10 @@
     "message": "Experimental"
   },
   "exportPrivateKey": {
-    "message": "Export Private Key"
+    "message": "Export private key"
   },
   "externalExtension": {
-    "message": "External Extension"
+    "message": "External extension"
   },
   "failed": {
     "message": "Failed"
@@ -1360,7 +1360,7 @@
     "message": "Function: SetApprovalForAll"
   },
   "functionType": {
-    "message": "Function Type"
+    "message": "Function type"
   },
   "gas": {
     "message": "Gas"
@@ -1376,10 +1376,10 @@
     "message": "Our low, medium and high estimates are not available."
   },
   "gasFee": {
-    "message": "Gas Fee"
+    "message": "Gas fee"
   },
   "gasLimit": {
-    "message": "Gas Limit"
+    "message": "Gas limit"
   },
   "gasLimitInfoTooltipContent": {
     "message": "Gas limit is the maximum amount of units of gas you are willing to spend."
@@ -1401,16 +1401,16 @@
     "message": "Gas option"
   },
   "gasPrice": {
-    "message": "Gas Price (GWEI)"
+    "message": "Gas price (GWEI)"
   },
   "gasPriceExcessive": {
     "message": "Your gas fee is set unnecessarily high. Consider lowering the amount."
   },
   "gasPriceExcessiveInput": {
-    "message": "Gas Price Is Excessive"
+    "message": "Gas price is excessive"
   },
   "gasPriceExtremelyLow": {
-    "message": "Gas Price Extremely Low"
+    "message": "Gas price extremely low"
   },
   "gasPriceFetchFailed": {
     "message": "Gas price estimation failed due to network error."
@@ -1451,14 +1451,14 @@
     "description": "$1 represents an amount of time"
   },
   "gasUsed": {
-    "message": "Gas Used"
+    "message": "Gas used"
   },
   "gdprMessage": {
     "message": "This data is aggregated and is therefore anonymous for the purposes of General Data Protection Regulation (EU) 2016/679. For more information in relation to our privacy practices, please see our $1.",
     "description": "$1 refers to the gdprMessagePrivacyPolicy message, the translation of which is meant to be used exclusively in the context of gdprMessage"
   },
   "gdprMessagePrivacyPolicy": {
-    "message": "Privacy Policy here",
+    "message": "Privacy policy here",
     "description": "this translation is intended to be exclusively used as the replacement for the $1 in the gdprMessage translation"
   },
   "general": {
@@ -1472,13 +1472,13 @@
     "description": "Displays network name for Ether faucet"
   },
   "getStarted": {
-    "message": "Get Started"
+    "message": "Get started"
   },
   "goBack": {
-    "message": "Go Back"
+    "message": "Go back"
   },
   "goerli": {
-    "message": "Goerli Test Network"
+    "message": "Goerli test network"
   },
   "gotIt": {
     "message": "Got it!"
@@ -1516,7 +1516,7 @@
     "description": "as in -click here- for more information (goes with troubleTokenBalances)"
   },
   "hexData": {
-    "message": "Hex Data"
+    "message": "Hex data"
   },
   "hide": {
     "message": "Hide"
@@ -1531,21 +1531,21 @@
     "message": "Hide token"
   },
   "hideTokenPrompt": {
-    "message": "Hide Token?"
+    "message": "Hide token?"
   },
   "hideTokenSymbol": {
     "message": "Hide $1",
     "description": "$1 is the symbol for a token (e.g. 'DAI')"
   },
   "hideZeroBalanceTokens": {
-    "message": "Hide Tokens Without Balance"
+    "message": "Hide tokens without balance"
   },
   "high": {
     "message": "Aggressive"
   },
   "highGasSettingToolTipMessage": {
     "message": "High probability, even in volatile markets. Use $1 to cover surges in network traffic due to things like popular NFT drops.",
-    "description": "$1 is key 'high' (text: 'Aggressive') separated here so that it can be passed in with bold fontweight"
+    "description": "$1 is key 'high' (text: 'Aggressive') separated here so that it can be passed in with bold font-weight"
   },
   "highLowercase": {
     "message": "high"
@@ -1564,7 +1564,7 @@
     "description": "Button to import an account from a selected file"
   },
   "importAccount": {
-    "message": "Import Account"
+    "message": "Import account"
   },
   "importAccountError": {
     "message": "Error importing account."
@@ -1576,7 +1576,7 @@
     "message": "Import a wallet with Secret Recovery Phrase"
   },
   "importMyWallet": {
-    "message": "Import My Wallet"
+    "message": "Import my wallet"
   },
   "importNFT": {
     "message": "Import NFT"
@@ -1603,7 +1603,7 @@
     "message": "import tokens"
   },
   "importTokensCamelCase": {
-    "message": "Import Tokens"
+    "message": "Import tokens"
   },
   "importWallet": {
     "message": "Import wallet"
@@ -1659,7 +1659,7 @@
     "message": "This asset is an NFT and needs to be re-added on the Import NFTs page found under the NFTs tab"
   },
   "invalidBlockExplorerURL": {
-    "message": "Invalid Block Explorer URL"
+    "message": "Invalid block explorer URL"
   },
   "invalidChainIdTooBig": {
     "message": "Invalid chain ID. The chain ID is too big."
@@ -1676,7 +1676,7 @@
     "description": "$1 is a link to https://chainid.network"
   },
   "invalidCustomNetworkAlertTitle": {
-    "message": "Invalid Custom Network"
+    "message": "Invalid custom network"
   },
   "invalidHexNumber": {
     "message": "Invalid hexadecimal number."
@@ -1734,10 +1734,10 @@
     "message": "This action will edit tokens that are already listed in your wallet, which can be used to phish you. Only approve if you are certain that you mean to change what these tokens represent. Learn more about $1"
   },
   "kovan": {
-    "message": "Kovan Test Network"
+    "message": "Kovan test network"
   },
   "lastConnected": {
-    "message": "Last Connected"
+    "message": "Last connected"
   },
   "learmMoreAboutGas": {
     "message": "Want to $1 about gas?"
@@ -1822,7 +1822,7 @@
     "message": "Links"
   },
   "loadMore": {
-    "message": "Load More"
+    "message": "Load more"
   },
   "loading": {
     "message": "Loading..."
@@ -1831,7 +1831,7 @@
     "message": "Loading NFTs..."
   },
   "loadingTokens": {
-    "message": "Loading Tokens..."
+    "message": "Loading tokens..."
   },
   "localhost": {
     "message": "Localhost 8545"
@@ -1851,7 +1851,7 @@
   },
   "lowGasSettingToolTipMessage": {
     "message": "Use $1 to wait for a cheaper price. Time estimates are much less accurate as prices are somewhat unpredictable.",
-    "description": "$1 is key 'low' separated here so that it can be passed in with bold fontweight"
+    "description": "$1 is key 'low' separated here so that it can be passed in with bold font-weight"
   },
   "lowLowercase": {
     "message": "low"
@@ -1895,7 +1895,7 @@
   },
   "mediumGasSettingToolTipMessage": {
     "message": "Use $1 for fast processing at current market price.",
-    "description": "$1 is key 'medium' (text: 'Market') separated here so that it can be passed in with bold fontweight"
+    "description": "$1 is key 'medium' (text: 'Market') separated here so that it can be passed in with bold font-weight"
   },
   "memo": {
     "message": "memo"
@@ -2009,7 +2009,7 @@
     "message": "Must select at least 1 token."
   },
   "myAccounts": {
-    "message": "My Accounts"
+    "message": "My accounts"
   },
   "name": {
     "message": "Name"
@@ -2023,13 +2023,13 @@
     "description": "$1 represents `needHelpLinkText`, the text which goes in the help link"
   },
   "needHelpFeedback": {
-    "message": "Share your Feedback"
+    "message": "Share your feedback"
   },
   "needHelpLinkText": {
-    "message": "MetaMask Support"
+    "message": "MetaMask support"
   },
   "needHelpSubmitTicket": {
-    "message": "Submit a Ticket"
+    "message": "Submit a ticket"
   },
   "needImportFile": {
     "message": "You must select a file to import.",
@@ -2045,13 +2045,13 @@
     "message": "Network added successfully!"
   },
   "networkDetails": {
-    "message": "Network Details"
+    "message": "Network details"
   },
   "networkIsBusy": {
     "message": "Network is busy. Gas prices are high and estimates are less accurate."
   },
   "networkName": {
-    "message": "Network Name"
+    "message": "Network name"
   },
   "networkNameAvalanche": {
     "message": "Avalanche"
@@ -2104,7 +2104,7 @@
     "message": "Nevermind"
   },
   "newAccount": {
-    "message": "New Account"
+    "message": "New account"
   },
   "newAccountDetectedDialogMessage": {
     "message": "New address detected! Click here to add to your address book."
@@ -2117,10 +2117,10 @@
     "message": "Collectible was successfully added!"
   },
   "newContact": {
-    "message": "New Contact"
+    "message": "New contact"
   },
   "newContract": {
-    "message": "New Contract"
+    "message": "New contract"
   },
   "newNFTDetectedMessage": {
     "message": "Allow MetaMask to automatically detect NFTs from Opensea and display in your wallet."
@@ -2145,10 +2145,10 @@
     "message": "Token imported"
   },
   "newTotal": {
-    "message": "New Total"
+    "message": "New total"
   },
   "newTransactionFee": {
-    "message": "New Transaction Fee"
+    "message": "New transaction fee"
   },
   "newValues": {
     "message": "new values"
@@ -2164,7 +2164,7 @@
     "message": "NFT"
   },
   "nftTokenIdPlaceholder": {
-    "message": "Enter the Token ID"
+    "message": "Enter the token id"
   },
   "nfts": {
     "message": "NFTs"
@@ -2182,10 +2182,10 @@
     "message": "No, I already have a Secret Recovery Phrase"
   },
   "noConversionDateAvailable": {
-    "message": "No Currency Conversion Date Available"
+    "message": "No currency conversion date available"
   },
   "noConversionRateAvailable": {
-    "message": "No Conversion Rate Available"
+    "message": "No conversion rate available"
   },
   "noNFTs": {
     "message": "No NFTs yet"
@@ -2194,7 +2194,7 @@
     "message": "No Snaps installed"
   },
   "noThanks": {
-    "message": "No Thanks"
+    "message": "No thanks"
   },
   "noThanksVariant2": {
     "message": "No, thanks."
@@ -2218,7 +2218,7 @@
     "message": "Turn this on to change the nonce (transaction number) on confirmation screens. This is an advanced feature, use cautiously."
   },
   "nonceFieldHeading": {
-    "message": "Custom Nonce"
+    "message": "Custom nonce"
   },
   "notBusy": {
     "message": "Not busy"
@@ -2227,14 +2227,14 @@
     "message": "Is this the correct account? It's different from the currently selected account in your wallet"
   },
   "notEnoughGas": {
-    "message": "Not Enough Gas"
+    "message": "Not enough gas"
   },
   "notifications": {
     "message": "Notifications"
   },
   "notifications10ActionText": {
-    "message": "Visit in settings",
-    "description": "The 'call to action' on the button, or link, of the 'Visit in settings' notification. Upon clicking, users will be taken to settings page."
+    "message": "Visit in Settings",
+    "description": "The 'call to action' on the button, or link, of the 'Visit in Settings' notification. Upon clicking, users will be taken to Settings page."
   },
   "notifications10DescriptionOne": {
     "message": "Improved token detection is currently available on Ethereum Mainnet, Polygon, BSC, and Avalanche networks. More to come!"
@@ -2258,7 +2258,7 @@
     "message": "Enable dark mode"
   },
   "notifications12Description": {
-    "message": "Dark mode on Extension is finally here! To turn it on, go to Settings -> Experimental and select one of the display options: Light, Dark, System."
+    "message": "Dark mode on Extension is finally here! To turn it on, go to Settings > Experimental and select one of the display options: Light, Dark, System."
   },
   "notifications12Title": {
     "message": "Wen dark mode? Now dark mode! 🕶️🦊"
@@ -2267,7 +2267,7 @@
     "message": "Show custom network list"
   },
   "notifications13Description": {
-    "message": "You can now add the following popular custom networks easily: Arbitrum, Avalanche, Binance Smart Chain, Fantom, Harmony, Optimism, Palm and Polygon! To enable this feature, go to Settings -> Experimental and turn \"Show custom network list\" on!",
+    "message": "You can now add the following popular custom networks easily: Arbitrum, Avalanche, Binance Smart Chain, Fantom, Harmony, Optimism, Palm and Polygon! To enable this feature, go to Settings > Experimental and turn \"Show custom network list\" on!",
     "description": "Description of a notification in the 'See What's New' popup. Describes popular network feature."
   },
   "notifications13Title": {
@@ -2322,7 +2322,7 @@
     "description": "Description of a notification in the 'See What's New' popup. Describes the Ledger support update."
   },
   "notifications6Title": {
-    "message": "Ledger Support Update for Chrome Users",
+    "message": "Ledger support update for Chrome users",
     "description": "Title for a notification in the 'See What's New' popup. Lets users know about the Ledger support update"
   },
   "notifications7DescriptionOne": {
@@ -2338,15 +2338,15 @@
     "description": "Title for a notification in the 'See What's New' popup. Notifies ledger users of the need to update firmware."
   },
   "notifications8ActionText": {
-    "message": "Go to Advanced Settings",
-    "description": "Description on an action button that appears in the What's New popup. Tells the user that if they click it, they will go to our Advanced Settings page."
+    "message": "Go to Settings > Advanced",
+    "description": "Description on an action button that appears in the What's New popup. Tells the user that if they click it, they will go to our Advanced settings page."
   },
   "notifications8DescriptionOne": {
     "message": "As of MetaMask v10.4.0, you no longer need Ledger Live to connect your Ledger device to MetaMask.",
     "description": "Description of a notification in the 'See What's New' popup. Describes changes for how Ledger Live is no longer needed to connect the device."
   },
   "notifications8DescriptionTwo": {
-    "message": "For an easier and more stable ledger experience, go to the Advanced tab of settings and switch the 'Preferred Ledger Connection Type' to 'WebHID'.",
+    "message": "For an easier and more stable ledger experience, go to Settings > Advanced and switch the 'Preferred Ledger Connection Type' to 'WebHID'.",
     "description": "Description of a notification in the 'See What's New' popup. Describes how the user can turn off the Ledger Live setting."
   },
   "notifications8Title": {
@@ -2401,7 +2401,7 @@
     "message": "Import an existing wallet"
   },
   "onboardingPinExtensionBillboardAccess": {
-    "message": "Full Access"
+    "message": "Full access"
   },
   "onboardingPinExtensionBillboardDescription": {
     "message": "These extensions can see and change information"
@@ -2528,7 +2528,7 @@
     "message": "Permission request"
   },
   "permissionRequestCapitalized": {
-    "message": "Permission Request"
+    "message": "Permission request"
   },
   "permissionRequested": {
     "message": "Requested now"
@@ -2537,7 +2537,7 @@
     "message": "Revoked in this update"
   },
   "permission_accessNetwork": {
-    "message": "Access the Internet.",
+    "message": "Access the internet.",
     "description": "The description of the `endowment:network-access` permission."
   },
   "permission_accessSnap": {
@@ -2589,8 +2589,8 @@
     "message": "Popular custom networks"
   },
   "preferredLedgerConnectionType": {
-    "message": "Preferred Ledger Connection Type",
-    "description": "A header for a dropdown in the advanced section of settings. Appears above the ledgerConnectionPreferenceDescription message"
+    "message": "Preferred Ledger connection type",
+    "description": "A header for a dropdown in Settings > Advanced. Appears above the ledgerConnectionPreferenceDescription message"
   },
   "preparingSwap": {
     "message": "Preparing swap..."
@@ -2599,7 +2599,7 @@
     "message": "Prev"
   },
   "primaryCurrencySetting": {
-    "message": "Primary Currency"
+    "message": "Primary currency"
   },
   "primaryCurrencySettingDescription": {
     "message": "Select native to prioritize displaying values in the native currency of the chain (e.g. ETH). Select Fiat to prioritize displaying values in your selected fiat currency."
@@ -2611,7 +2611,7 @@
     "message": "Priority Fee"
   },
   "privacyMsg": {
-    "message": "Privacy Policy"
+    "message": "Privacy policy"
   },
   "privateKey": {
     "message": "Private Key",
@@ -2621,19 +2621,19 @@
     "message": "Warning: Never disclose this key. Anyone with your private keys can steal any assets held in your account."
   },
   "privateNetwork": {
-    "message": "Private Network"
+    "message": "Private network"
   },
   "proceedWithTransaction": {
     "message": "I want to proceed anyway"
   },
   "proposedApprovalLimit": {
-    "message": "Proposed Approval Limit"
+    "message": "Proposed approval limit"
   },
   "provide": {
     "message": "Provide"
   },
   "publicAddress": {
-    "message": "Public Address"
+    "message": "Public address"
   },
   "queue": {
     "message": "Queue"
@@ -2693,7 +2693,7 @@
     "message": "Reject"
   },
   "rejectAll": {
-    "message": "Reject All"
+    "message": "Reject all"
   },
   "rejectTxsDescription": {
     "message": "You are about to batch reject $1 transactions."
@@ -2745,13 +2745,13 @@
     "message": "Reset"
   },
   "resetAccount": {
-    "message": "Reset Account"
+    "message": "Reset account"
   },
   "resetAccountDescription": {
     "message": "Resetting your account will clear your transaction history. This will not change the balances in your accounts or require you to re-enter your Secret Recovery Phrase."
   },
   "resetWallet": {
-    "message": "Reset Wallet"
+    "message": "Reset wallet"
   },
   "resetWalletSubHeader": {
     "message": "MetaMask does not keep a copy of your password. If you’re having trouble unlocking your account, you will need to reset your wallet. You can do this by providing the Secret Recovery Phrase you used when you set up your wallet."
@@ -2773,7 +2773,7 @@
     "description": "$1 is the date at which the data was backed up"
   },
   "retryTransaction": {
-    "message": "Retry Transaction"
+    "message": "Retry transaction"
   },
   "reusedTokenNameWarning": {
     "message": "A token here reuses a symbol from another token you watch, this can be confusing or deceptive."
@@ -2802,28 +2802,28 @@
     "description": "$1 is either key 'account' or 'contract', and $2 is either a string or link of a given token symbol or name"
   },
   "rinkeby": {
-    "message": "Rinkeby Test Network"
+    "message": "Rinkeby test network"
   },
   "ropsten": {
-    "message": "Ropsten Test Network"
+    "message": "Ropsten test network"
   },
   "rpcUrl": {
     "message": "New RPC URL"
   },
   "safeTransferFrom": {
-    "message": "Safe Transfer From"
+    "message": "Safe transfer from"
   },
   "save": {
     "message": "Save"
   },
   "saveAsCsvFile": {
-    "message": "Save as CSV File"
+    "message": "Save as CSV file"
   },
   "scanInstructions": {
     "message": "Place the QR code in front of your camera"
   },
   "scanQrCode": {
-    "message": "Scan QR Code"
+    "message": "Scan QR code"
   },
   "scrollDown": {
     "message": "Scroll down"
@@ -2832,16 +2832,16 @@
     "message": "Search"
   },
   "searchAccounts": {
-    "message": "Search Accounts"
+    "message": "Search accounts"
   },
   "searchResults": {
-    "message": "Search Results"
+    "message": "Search results"
   },
   "searchSettings": {
-    "message": "Search in settings"
+    "message": "Search in Settings"
   },
   "searchTokens": {
-    "message": "Search Tokens"
+    "message": "Search tokens"
   },
   "secretBackupPhraseDescription": {
     "message": "Your Secret Recovery Phrase makes it easy to back up and restore your account."
@@ -2856,10 +2856,10 @@
     "message": "Secret Recovery Phrase"
   },
   "secureWallet": {
-    "message": "Secure Wallet"
+    "message": "Secure wallet"
   },
   "securityAndPrivacy": {
-    "message": "Security & Privacy"
+    "message": "Security & privacy"
   },
   "seedPhraseConfirm": {
     "message": "Confirm Secret Recovery Phrase"
@@ -2928,7 +2928,7 @@
     "message": "Select all"
   },
   "selectAnAccount": {
-    "message": "Select an Account"
+    "message": "Select an account"
   },
   "selectAnAccountAlreadyConnected": {
     "message": "This account has already been connected to MetaMask"
@@ -2937,7 +2937,7 @@
     "message": "Please select each phrase in order to make sure it is correct."
   },
   "selectHdPath": {
-    "message": "Select HD Path"
+    "message": "Select HD path"
   },
   "selectNFTPrivacyPreference": {
     "message": "Turn on NFT detection in Settings"
@@ -2955,7 +2955,7 @@
     "message": "Send"
   },
   "sendAmount": {
-    "message": "Send Amount"
+    "message": "Send amount"
   },
   "sendBugReport": {
     "message": "Send us a bug report."
@@ -2968,7 +2968,7 @@
     "message": "Send to"
   },
   "sendTokens": {
-    "message": "Send Tokens"
+    "message": "Send tokens"
   },
   "sendingDisabled": {
     "message": "Sending of ERC-1155 NFT assets is not yet supported."
@@ -2988,7 +2988,7 @@
     "message": "MetaMask uses these trusted third-party services to enhance product usability and safety."
   },
   "setApprovalForAll": {
-    "message": "Set Approval for All"
+    "message": "Set approval for all"
   },
   "setApprovalForAllTitle": {
     "message": "Approve $1 with no spend limit",
@@ -3014,19 +3014,19 @@
     "message": "Select this to show gas price and limit controls directly on the send and confirm screens."
   },
   "showCustomNetworkList": {
-    "message": "Show Custom Network List"
+    "message": "Show custom network list"
   },
   "showCustomNetworkListDescription": {
     "message": "Select this to show a list of networks with prefilled details when adding a new network."
   },
   "showFiatConversionInTestnets": {
-    "message": "Show Conversion on test networks"
+    "message": "Show conversion on test networks"
   },
   "showFiatConversionInTestnetsDescription": {
     "message": "Select this to show fiat conversion on test networks"
   },
   "showHexData": {
-    "message": "Show Hex Data"
+    "message": "Show hex data"
   },
   "showHexDataDescription": {
     "message": "Select this to show the hex data field on the send screen"
@@ -3035,7 +3035,7 @@
     "message": "Show/hide"
   },
   "showIncomingTransactions": {
-    "message": "Show Incoming Transactions"
+    "message": "Show incoming transactions"
   },
   "showIncomingTransactionsDescription": {
     "message": "Select this to use Etherscan to show incoming transactions in the transactions list"
@@ -3047,7 +3047,7 @@
     "message": "Show Private Keys"
   },
   "showRecommendations": {
-    "message": "Show Recommendations"
+    "message": "Show recommendations"
   },
   "showTestnetNetworks": {
     "message": "Show test networks"
@@ -3056,7 +3056,7 @@
     "message": "Select this to show test networks in network list"
   },
   "sigRequest": {
-    "message": "Signature Request"
+    "message": "Signature request"
   },
   "sign": {
     "message": "Sign"
@@ -3065,7 +3065,7 @@
     "message": "Signing this message can be dangerous. This signature could potentially perform any operation on your account's behalf, including granting complete control of your account and all of its assets to the requesting site. Only sign this message if you know what you're doing or completely trust the requesting site."
   },
   "signatureRequest": {
-    "message": "Signature Request"
+    "message": "Signature request"
   },
   "signatureRequest1": {
     "message": "Message"
@@ -3083,7 +3083,7 @@
     "message": "Skip"
   },
   "skipAccountSecurity": {
-    "message": "Skip Account Security?"
+    "message": "Skip account security?"
   },
   "skipAccountSecurityDetails": {
     "message": "I understand that until I back up my Secret Recovery Phrase, I may lose my accounts and all of their assets."
@@ -3092,7 +3092,7 @@
     "message": "Slow"
   },
   "smartTransaction": {
-    "message": "Smart Transaction"
+    "message": "Smart transaction"
   },
   "snapAccess": {
     "message": "$1 snap has access to:",
@@ -3151,7 +3151,7 @@
     "message": "Source"
   },
   "speedUp": {
-    "message": "Speed Up"
+    "message": "Speed up"
   },
   "speedUpCancellation": {
     "message": "Speed up this cancellation"
@@ -3221,10 +3221,10 @@
     "message": "Error in retrieving state logs."
   },
   "stateLogFileName": {
-    "message": "MetaMask State Logs"
+    "message": "MetaMask state logs"
   },
   "stateLogs": {
-    "message": "State Logs"
+    "message": "State logs"
   },
   "stateLogsDescription": {
     "message": "State logs contain your public account addresses and sent transactions."
@@ -3378,7 +3378,7 @@
     "message": "Support"
   },
   "supportCenter": {
-    "message": "Visit our Support Center"
+    "message": "Visit our support center"
   },
   "swap": {
     "message": "Swap"
@@ -3580,7 +3580,7 @@
     "message": "Request for quotation"
   },
   "swapReviewSwap": {
-    "message": "Review Swap"
+    "message": "Review swap"
   },
   "swapSearchForAToken": {
     "message": "Search for a token"
@@ -3679,13 +3679,13 @@
     "message": "0% Slippage"
   },
   "swapsAdvancedOptions": {
-    "message": "Advanced Options"
+    "message": "Advanced options"
   },
   "swapsExcessiveSlippageWarning": {
     "message": "Slippage amount is too high and will result in a bad rate. Please reduce your slippage tolerance to a value below 15%."
   },
   "swapsMaxSlippage": {
-    "message": "Slippage Tolerance"
+    "message": "Slippage tolerance"
   },
   "swapsNotEnoughForTx": {
     "message": "Not enough $1 to complete this transaction",
@@ -3704,7 +3704,7 @@
     "message": "Switch network"
   },
   "switchNetworks": {
-    "message": "Switch Networks"
+    "message": "Switch networks"
   },
   "switchToNetwork": {
     "message": "Switch to $1",
@@ -3762,13 +3762,13 @@
     "message": "10% increase"
   },
   "terms": {
-    "message": "Terms of Use"
+    "message": "Terms of use"
   },
   "termsOfService": {
-    "message": "Terms of Service"
+    "message": "Terms of service"
   },
   "testFaucet": {
-    "message": "Test Faucet"
+    "message": "Test faucet"
   },
   "testNetworks": {
     "message": "Test networks"
@@ -3797,7 +3797,7 @@
   },
   "toggleTestNetworks": {
     "message": "$1 test networks",
-    "description": "$1 is a clickable link with text defined by the 'showHide' key. The link will open to the advanced settings where users can enable the display of test networks in the network dropdown."
+    "description": "$1 is a clickable link with text defined by the 'showHide' key. The link will open Settings > Advanced where users can enable the display of test networks in the network dropdown."
   },
   "token": {
     "message": "Token"
@@ -3809,13 +3809,13 @@
     "message": "Token has already been added."
   },
   "tokenContractAddress": {
-    "message": "Token Contract Address"
+    "message": "Token contract address"
   },
   "tokenDecimalFetchFailed": {
     "message": "Token decimal required."
   },
   "tokenDecimalTitle": {
-    "message": "Token Decimal:"
+    "message": "Token decimal:"
   },
   "tokenDetails": {
     "message": "Token details"
@@ -3839,7 +3839,7 @@
     "message": "Token lists:"
   },
   "tokenSymbol": {
-    "message": "Token Symbol"
+    "message": "Token symbol"
   },
   "tokensFoundTitle": {
     "message": "$1 new tokens found",
@@ -3912,7 +3912,7 @@
     "message": "Transaction dropped at $2."
   },
   "transactionError": {
-    "message": "Transaction Error. Exception thrown in contract code."
+    "message": "Transaction error. Exception thrown in contract code."
   },
   "transactionErrorNoContract": {
     "message": "Trying to call a function on a non-contract address."
@@ -3924,25 +3924,25 @@
     "message": "Transaction fee"
   },
   "transactionHistoryBaseFee": {
-    "message": "Base Fee (GWEI)"
+    "message": "Base fee (GWEI)"
   },
   "transactionHistoryL1GasLabel": {
-    "message": "Total L1 Gas Fee"
+    "message": "Total L1 gas fee"
   },
   "transactionHistoryL2GasLimitLabel": {
-    "message": "L2 Gas Limit"
+    "message": "L2 gas limit"
   },
   "transactionHistoryL2GasPriceLabel": {
-    "message": "L2 Gas Price"
+    "message": "L2 gas price"
   },
   "transactionHistoryMaxFeePerGas": {
-    "message": "Max Fee Per Gas"
+    "message": "Max fee per gas"
   },
   "transactionHistoryPriorityFee": {
-    "message": "Priority Fee (GWEI)"
+    "message": "Priority fee (GWEI)"
   },
   "transactionHistoryTotalGasFee": {
-    "message": "Total Gas Fee"
+    "message": "Total gas fee"
   },
   "transactionResubmitted": {
     "message": "Transaction resubmitted with estimated gas fee increased to $1 at $2"
@@ -3960,7 +3960,7 @@
     "message": "Transfer between my accounts"
   },
   "transferFrom": {
-    "message": "Transfer From"
+    "message": "Transfer from"
   },
   "troubleConnectingToWallet": {
     "message": "We had trouble connecting to your $1, try reviewing $2 and try again.",
@@ -4017,7 +4017,7 @@
     "message": "Unnamed collection"
   },
   "unknownNetwork": {
-    "message": "Unknown Private Network"
+    "message": "Unknown private network"
   },
   "unknownQrCode": {
     "message": "Error: We couldn't identify that QR code"
@@ -4065,13 +4065,13 @@
     "message": "Displaying NFTs media & data may expose your IP address to centralized servers. Third-party APIs (like OpenSea) are used to detect NFTs in your wallet. This exposes your account address with those services. Leave this disabled if you don’t want the app to pull data from those those services."
   },
   "usePhishingDetection": {
-    "message": "Use Phishing Detection"
+    "message": "Use phishing detection"
   },
   "usePhishingDetectionDescription": {
     "message": "Display a warning for phishing domains targeting Ethereum users"
   },
   "useTokenDetection": {
-    "message": "Use Token Detection"
+    "message": "Use token detection"
   },
   "useTokenDetectionDescription": {
     "message": "We use third-party APIs to detect and display new tokens sent to your wallet. Turn off if you don’t want MetaMask to pull data from those services."
@@ -4098,19 +4098,19 @@
     "description": "Points the user to etherscan as a place they can verify information about a token. $1 is replaced with the translation for \"etherscan\""
   },
   "viewAccount": {
-    "message": "View Account"
+    "message": "View account"
   },
   "viewAllDetails": {
     "message": "View all details"
   },
   "viewContact": {
-    "message": "View Contact"
+    "message": "View contact"
   },
   "viewFullTransactionDetails": {
     "message": "View full transaction details"
   },
   "viewMore": {
-    "message": "View More"
+    "message": "View more"
   },
   "viewOnBlockExplorer": {
     "message": "View on block explorer"
@@ -4127,7 +4127,7 @@
     "message": "View on Opensea"
   },
   "viewinExplorer": {
-    "message": "View $1 in Explorer",
+    "message": "View $1 in explorer",
     "description": "$1 is the action type. e.g (Account, Transaction, Swap)"
   },
   "visitWebSite": {
@@ -4177,7 +4177,7 @@
     "message": "Welcome to MetaMask"
   },
   "welcomeBack": {
-    "message": "Welcome Back!"
+    "message": "Welcome back!"
   },
   "welcomeExploreDescription": {
     "message": "Store, send and spend crypto currencies and assets."

--- a/app/_locales/es/messages.json
+++ b/app/_locales/es/messages.json
@@ -747,7 +747,7 @@
   },
   "customGasSettingToolTipMessage": {
     "message": "Use $1 para personalizar el precio de gas. Esto puede ser confuso si no está familiarizado. Interactúe bajo su propio riesgo.",
-    "description": "$1 is key 'advanced' (text: 'Advanced') separated here so that it can be passed in with bold fontweight"
+    "description": "$1 is key 'advanced' (text: 'Advanced') separated here so that it can be passed in with bold font-weight"
   },
   "customGasSubTitle": {
     "message": "Aumentar la cuota puede disminuir los tiempos de procesamiento, pero no está garantizado."
@@ -833,7 +833,7 @@
   },
   "depositCrypto": {
     "message": "Deposite $1",
-    "description": "$1 represents the cypto symbol to be purchased"
+    "description": "$1 represents the crypto symbol to be purchased"
   },
   "description": {
     "message": "Descripción"
@@ -1481,7 +1481,7 @@
   },
   "highGasSettingToolTipMessage": {
     "message": "Alta probabilidad, incluso en mercados volátiles. Use $1 para cubrir aumentos repentinos en el tráfico de la red debido a cosas como caídas de NFT populares.",
-    "description": "$1 is key 'high' (text: 'Aggressive') separated here so that it can be passed in with bold fontweight"
+    "description": "$1 is key 'high' (text: 'Aggressive') separated here so that it can be passed in with bold font-weight"
   },
   "highLowercase": {
     "message": "alto"
@@ -1787,7 +1787,7 @@
   },
   "lowGasSettingToolTipMessage": {
     "message": "Utilice $1 para esperar un precio más bajo. Las estimaciones de tiempo son mucho menos precisas ya que los precios son algo imprevisibles.",
-    "description": "$1 is key 'low' separated here so that it can be passed in with bold fontweight"
+    "description": "$1 is key 'low' separated here so that it can be passed in with bold font-weight"
   },
   "lowLowercase": {
     "message": "bajo"
@@ -1831,7 +1831,7 @@
   },
   "mediumGasSettingToolTipMessage": {
     "message": "Utilice $1 para un procesamiento rápido al precio actual del mercado.",
-    "description": "$1 is key 'medium' (text: 'Market') separated here so that it can be passed in with bold fontweight"
+    "description": "$1 is key 'medium' (text: 'Market') separated here so that it can be passed in with bold font-weight"
   },
   "memo": {
     "message": "memorándum"
@@ -2170,7 +2170,7 @@
   },
   "notifications10ActionText": {
     "message": "Vaya a configuración",
-    "description": "The 'call to action' on the button, or link, of the 'Visit in settings' notification. Upon clicking, users will be taken to settings page."
+    "description": "The 'call to action' on the button, or link, of the 'Visit in Settings' notification. Upon clicking, users will be taken to Settings page."
   },
   "notifications10DescriptionOne": {
     "message": "En este momento, la detección mejorada de token está disponible en las redes Ethereum Mainnet, Polygon, BSC y Avalanche. ¡Y habrá más!"
@@ -2275,7 +2275,7 @@
   },
   "notifications8ActionText": {
     "message": "Ir a Configuración Avanzada",
-    "description": "Description on an action button that appears in the What's New popup. Tells the user that if they click it, they will go to our Advanced Settings page."
+    "description": "Description on an action button that appears in the What's New popup. Tells the user that if they click it, they will go to our Advanced settings page."
   },
   "notifications8DescriptionOne": {
     "message": "A partir de MetaMask v10.4.0, ya no necesita Ledger Live para conectar su dispositivo Ledger a MetaMask.",
@@ -2520,7 +2520,7 @@
   },
   "preferredLedgerConnectionType": {
     "message": "Tipo de conexión de Ledger preferida",
-    "description": "A header for a dropdown in the advanced section of settings. Appears above the ledgerConnectionPreferenceDescription message"
+    "description": "A header for a dropdown in Settings > Advanced. Appears above the ledgerConnectionPreferenceDescription message"
   },
   "preparingSwap": {
     "message": "Preparando swap..."
@@ -3710,7 +3710,7 @@
   },
   "toggleTestNetworks": {
     "message": "$1 redes de prueba",
-    "description": "$1 is a clickable link with text defined by the 'showHide' key. The link will open to the advanced settings where users can enable the display of test networks in the network dropdown."
+    "description": "$1 is a clickable link with text defined by the 'showHide' key. The link will open Settings > Advanced where users can enable the display of test networks in the network dropdown."
   },
   "token": {
     "message": "Token"

--- a/app/_locales/es_419/messages.json
+++ b/app/_locales/es_419/messages.json
@@ -1533,7 +1533,7 @@
   },
   "lowGasSettingToolTipMessage": {
     "message": "Utilice $1 para esperar un precio más bajo. Las estimaciones de tiempo son mucho menos precisas ya que los precios son algo imprevisibles.",
-    "description": "$1 is key 'low' separated here so that it can be passed in with bold fontweight"
+    "description": "$1 is key 'low' separated here so that it can be passed in with bold font-weight"
   },
   "lowLowercase": {
     "message": "baja"
@@ -1565,7 +1565,7 @@
   },
   "mediumGasSettingToolTipMessage": {
     "message": "Utilice $1 para un procesamiento rápido al precio actual del mercado.",
-    "description": "$1 is key 'medium' (text: 'Market') separated here so that it can be passed in with bold fontweight"
+    "description": "$1 is key 'medium' (text: 'Market') separated here so that it can be passed in with bold font-weight"
   },
   "memo": {
     "message": "nota"
@@ -1911,7 +1911,7 @@
   },
   "notifications8ActionText": {
     "message": "Ir a Configuración Avanzada",
-    "description": "Description on an action button that appears in the What's New popup. Tells the user that if they click it, they will go to our Advanced Settings page."
+    "description": "Description on an action button that appears in the What's New popup. Tells the user that if they click it, they will go to our Advanced settings page."
   },
   "notifications8DescriptionOne": {
     "message": "A partir de MetaMask v10.4.0, ya no necesita Ledger Live para conectar su dispositivo Ledger a MetaMask.",
@@ -2085,7 +2085,7 @@
   },
   "preferredLedgerConnectionType": {
     "message": "Tipo de conexión de Ledger preferida",
-    "description": "A header for a dropdown in the advanced section of settings. Appears above the ledgerConnectionPreferenceDescription message"
+    "description": "A header for a dropdown in Settings > Advanced. Appears above the ledgerConnectionPreferenceDescription message"
   },
   "prev": {
     "message": "Ant."
@@ -3007,7 +3007,7 @@
   },
   "toggleTestNetworks": {
     "message": "$1 redes de prueba",
-    "description": "$1 is a clickable link with text defined by the 'showHide' key. The link will open to the advanced settings where users can enable the display of test networks in the network dropdown."
+    "description": "$1 is a clickable link with text defined by the 'showHide' key. The link will open Settings > Advanced where users can enable the display of test networks in the network dropdown."
   },
   "token": {
     "message": "Token"

--- a/app/_locales/fr/messages.json
+++ b/app/_locales/fr/messages.json
@@ -746,8 +746,8 @@
     "message": "Personnaliser le gaz"
   },
   "customGasSettingToolTipMessage": {
-    "message": "Utilisez $1 pour personnaliser le prix du carburant. Cela peut porter à confusion si vous n’en avez pas l’habitude. Agissez avec prudence !",
-    "description": "$1 is key 'advanced' (text: 'Advanced') separated here so that it can be passed in with bold fontweight"
+    "message": "Utilisez $1 pour personnaliser le prix du carburant. Cela peut porter à confusion si vous n’en avez pas l’habitude. Agissez avec prudence !",
+    "description": "$1 is key 'advanced' (text: 'Advanced') separated here so that it can be passed in with bold font-weight"
   },
   "customGasSubTitle": {
     "message": "Augmenter le tarif peut faire baisser le temps de traitement, mais cela n’est pas garanti."
@@ -833,7 +833,7 @@
   },
   "depositCrypto": {
     "message": "Effectuer un dépôt de $1",
-    "description": "$1 represents the cypto symbol to be purchased"
+    "description": "$1 represents the crypto symbol to be purchased"
   },
   "description": {
     "message": "Description"
@@ -1481,7 +1481,7 @@
   },
   "highGasSettingToolTipMessage": {
     "message": "Utilisez $1 pour couvrir les envolées du trafic réseau dues à des événements tels que les chutes de NFT populaires.",
-    "description": "$1 is key 'high' (text: 'Aggressive') separated here so that it can be passed in with bold fontweight"
+    "description": "$1 is key 'high' (text: 'Aggressive') separated here so that it can be passed in with bold font-weight"
   },
   "highLowercase": {
     "message": "élevé"
@@ -1787,7 +1787,7 @@
   },
   "lowGasSettingToolTipMessage": {
     "message": "Utilisez $1 pour attendre un prix inférieur. Les estimations de temps sont nettement moins précises, car les prix sont relativement imprévisibles.",
-    "description": "$1 is key 'low' separated here so that it can be passed in with bold fontweight"
+    "description": "$1 is key 'low' separated here so that it can be passed in with bold font-weight"
   },
   "lowLowercase": {
     "message": "bas"
@@ -1831,7 +1831,7 @@
   },
   "mediumGasSettingToolTipMessage": {
     "message": "Utilisez $1 pour un traitement rapide au prix actuel du marché.",
-    "description": "$1 is key 'medium' (text: 'Market') separated here so that it can be passed in with bold fontweight"
+    "description": "$1 is key 'medium' (text: 'Market') separated here so that it can be passed in with bold font-weight"
   },
   "memo": {
     "message": "note"
@@ -2170,7 +2170,7 @@
   },
   "notifications10ActionText": {
     "message": "Ouvrir les paramètres",
-    "description": "The 'call to action' on the button, or link, of the 'Visit in settings' notification. Upon clicking, users will be taken to settings page."
+    "description": "The 'call to action' on the button, or link, of the 'Visit in Settings' notification. Upon clicking, users will be taken to Settings page."
   },
   "notifications10DescriptionOne": {
     "message": "Une détection améliorée des tokens est actuellement disponible sur les réseaux Ethereum Mainnet, Polygon, BSC et Avalanche. Il y aura bientôt d’autres nouveautés !"
@@ -2275,7 +2275,7 @@
   },
   "notifications8ActionText": {
     "message": "Accédez aux Paramètres avancés",
-    "description": "Description on an action button that appears in the What's New popup. Tells the user that if they click it, they will go to our Advanced Settings page."
+    "description": "Description on an action button that appears in the What's New popup. Tells the user that if they click it, they will go to our Advanced settings page."
   },
   "notifications8DescriptionOne": {
     "message": "Depuis MetaMask v10.4.0, vous n’avez plus besoin de Ledger Live pour connecter votre appareil Ledger à MetaMask.",
@@ -2520,7 +2520,7 @@
   },
   "preferredLedgerConnectionType": {
     "message": "Type de connexion Ledger préféré",
-    "description": "A header for a dropdown in the advanced section of settings. Appears above the ledgerConnectionPreferenceDescription message"
+    "description": "A header for a dropdown in Settings > Advanced. Appears above the ledgerConnectionPreferenceDescription message"
   },
   "preparingSwap": {
     "message": "Préparation du swap..."
@@ -3709,8 +3709,8 @@
     "description": "$1 is the address to include in the To label. It is typically shortened first using shortenAddress"
   },
   "toggleTestNetworks": {
-    "message": "$1 réseaux de test",
-    "description": "$1 is a clickable link with text defined by the 'showHide' key. The link will open to the advanced settings where users can enable the display of test networks in the network dropdown."
+    "message": "$1 réseaux de test",
+    "description": "$1 is a clickable link with text defined by the 'showHide' key. The link will open Settings > Advanced where users can enable the display of test networks in the network dropdown."
   },
   "token": {
     "message": "Jeton"

--- a/app/_locales/hi/messages.json
+++ b/app/_locales/hi/messages.json
@@ -747,7 +747,7 @@
   },
   "customGasSettingToolTipMessage": {
     "message": "गैस की कीमत को अनुकूलित करने के लिए $1 का उपयोग करें। यदि आप परिचित नहीं हैं तो ये भ्रामक हो सकता है। अपनी ज़िम्मेदारी पर बातचीत करें।",
-    "description": "$1 is key 'advanced' (text: 'Advanced') separated here so that it can be passed in with bold fontweight"
+    "description": "$1 is key 'advanced' (text: 'Advanced') separated here so that it can be passed in with bold font-weight"
   },
   "customGasSubTitle": {
     "message": "शुल्क बढ़ाने से प्रसंस्करण समय में कमी हो सकती है, लेकिन इसकी गारंटी नहीं होती है।"
@@ -833,7 +833,7 @@
   },
   "depositCrypto": {
     "message": "$1 जमा करें",
-    "description": "$1 represents the cypto symbol to be purchased"
+    "description": "$1 represents the crypto symbol to be purchased"
   },
   "description": {
     "message": "विवरण"
@@ -1481,7 +1481,7 @@
   },
   "highGasSettingToolTipMessage": {
     "message": "लोकप्रिय NFT ड्रॉप जैसी चीज़ों की वजह से नेटवर्क ट्रैफिक में वृद्धि को कवर करने के लिए $1 का उपयोग करें।",
-    "description": "$1 is key 'high' (text: 'Aggressive') separated here so that it can be passed in with bold fontweight"
+    "description": "$1 is key 'high' (text: 'Aggressive') separated here so that it can be passed in with bold font-weight"
   },
   "highLowercase": {
     "message": "उच्च"
@@ -1787,7 +1787,7 @@
   },
   "lowGasSettingToolTipMessage": {
     "message": "एक सस्ती कीमत की प्रतीक्षा के लिए $1 का उपयोग करें। समय का अनुमान बहुत कम सही होता है क्योंकि कीमतें कुछ हद तक अप्रत्याशित होती हैं।",
-    "description": "$1 is key 'low' separated here so that it can be passed in with bold fontweight"
+    "description": "$1 is key 'low' separated here so that it can be passed in with bold font-weight"
   },
   "lowLowercase": {
     "message": "निम्न"
@@ -1831,7 +1831,7 @@
   },
   "mediumGasSettingToolTipMessage": {
     "message": "मौजूदा बाजार मूल्य पर तेजी से प्रोसेस करने के लिए $1का उपयोग करें।",
-    "description": "$1 is key 'medium' (text: 'Market') separated here so that it can be passed in with bold fontweight"
+    "description": "$1 is key 'medium' (text: 'Market') separated here so that it can be passed in with bold font-weight"
   },
   "memo": {
     "message": "मेमो"
@@ -2170,7 +2170,7 @@
   },
   "notifications10ActionText": {
     "message": "सेटिंग्स में जाएं",
-    "description": "The 'call to action' on the button, or link, of the 'Visit in settings' notification. Upon clicking, users will be taken to settings page."
+    "description": "The 'call to action' on the button, or link, of the 'Visit in Settings' notification. Upon clicking, users will be taken to Settings page."
   },
   "notifications10DescriptionOne": {
     "message": "बेहतर टोकन डिटेक्शन वर्तमान में Ethereum Mainnet, Polygon, BSC और Avalanche के नेटवर्कों पर उपलब्ध है। और भी आने वाला है!"
@@ -2275,7 +2275,7 @@
   },
   "notifications8ActionText": {
     "message": "एडवांस सेटिंग्स पर जाएं",
-    "description": "Description on an action button that appears in the What's New popup. Tells the user that if they click it, they will go to our Advanced Settings page."
+    "description": "Description on an action button that appears in the What's New popup. Tells the user that if they click it, they will go to our Advanced settings page."
   },
   "notifications8DescriptionOne": {
     "message": "MetaMask v10.4.0 के अनुसार, अब आपको अपने लेजर डिवाइस को मेटामास्क से कनेक्ट करने के लिए लेजर लाइव की आवश्यकता नहीं है।",
@@ -2520,7 +2520,7 @@
   },
   "preferredLedgerConnectionType": {
     "message": "वरीयता वाले लेजर कनेक्शन के प्रकार",
-    "description": "A header for a dropdown in the advanced section of settings. Appears above the ledgerConnectionPreferenceDescription message"
+    "description": "A header for a dropdown in Settings > Advanced. Appears above the ledgerConnectionPreferenceDescription message"
   },
   "preparingSwap": {
     "message": "स्वैप की तैयारी कर रहा है..."
@@ -3710,7 +3710,7 @@
   },
   "toggleTestNetworks": {
     "message": "$1 परीक्षण नेटवर्क",
-    "description": "$1 is a clickable link with text defined by the 'showHide' key. The link will open to the advanced settings where users can enable the display of test networks in the network dropdown."
+    "description": "$1 is a clickable link with text defined by the 'showHide' key. The link will open Settings > Advanced where users can enable the display of test networks in the network dropdown."
   },
   "token": {
     "message": "टोकन"

--- a/app/_locales/id/messages.json
+++ b/app/_locales/id/messages.json
@@ -747,7 +747,7 @@
   },
   "customGasSettingToolTipMessage": {
     "message": "Gunakan $1 untuk menyesuaikan harga gas. Anda akan bingung jika tidak terbiasa. Berinteraksi dengan risiko Anda sendiri.",
-    "description": "$1 is key 'advanced' (text: 'Advanced') separated here so that it can be passed in with bold fontweight"
+    "description": "$1 is key 'advanced' (text: 'Advanced') separated here so that it can be passed in with bold font-weight"
   },
   "customGasSubTitle": {
     "message": "Menaikkan biaya dapat mengurangi waktu pemrosesan, namun tidak ada jaminan."
@@ -833,7 +833,7 @@
   },
   "depositCrypto": {
     "message": "Deposit $1",
-    "description": "$1 represents the cypto symbol to be purchased"
+    "description": "$1 represents the crypto symbol to be purchased"
   },
   "description": {
     "message": "Deskripsi"
@@ -1481,7 +1481,7 @@
   },
   "highGasSettingToolTipMessage": {
     "message": "Gunakan $1 untuk menutupi lonjakan lalu lintas jaringan karena hal-hal seperti penurunan NFT populer.",
-    "description": "$1 is key 'high' (text: 'Aggressive') separated here so that it can be passed in with bold fontweight"
+    "description": "$1 is key 'high' (text: 'Aggressive') separated here so that it can be passed in with bold font-weight"
   },
   "highLowercase": {
     "message": "tinggi"
@@ -1787,7 +1787,7 @@
   },
   "lowGasSettingToolTipMessage": {
     "message": "Gunakan $1 untuk menunggu harga yang lebih murah. Estimasi waktu kurang akurat karena harga sedang tidak dapat diprediksi.",
-    "description": "$1 is key 'low' separated here so that it can be passed in with bold fontweight"
+    "description": "$1 is key 'low' separated here so that it can be passed in with bold font-weight"
   },
   "lowLowercase": {
     "message": "rendah"
@@ -1831,7 +1831,7 @@
   },
   "mediumGasSettingToolTipMessage": {
     "message": "Gunakan $1 untuk pemrosesan cepat dengan harga pasar saat ini.",
-    "description": "$1 is key 'medium' (text: 'Market') separated here so that it can be passed in with bold fontweight"
+    "description": "$1 is key 'medium' (text: 'Market') separated here so that it can be passed in with bold font-weight"
   },
   "memo": {
     "message": "memo"
@@ -2170,7 +2170,7 @@
   },
   "notifications10ActionText": {
     "message": "Lihat di pengaturan",
-    "description": "The 'call to action' on the button, or link, of the 'Visit in settings' notification. Upon clicking, users will be taken to settings page."
+    "description": "The 'call to action' on the button, or link, of the 'Visit in Settings' notification. Upon clicking, users will be taken to Settings page."
   },
   "notifications10DescriptionOne": {
     "message": "Deteksi token yang ditingkatkan saat ini tersedia di jaringan Ethereum Mainnet, Polygon, BSC, dan Avalanche. Nantikan selengkapnya!"
@@ -2275,7 +2275,7 @@
   },
   "notifications8ActionText": {
     "message": "Buka Pengaturan Lanjutan",
-    "description": "Description on an action button that appears in the What's New popup. Tells the user that if they click it, they will go to our Advanced Settings page."
+    "description": "Description on an action button that appears in the What's New popup. Tells the user that if they click it, they will go to our Advanced settings page."
   },
   "notifications8DescriptionOne": {
     "message": "Pada MetaMask v10.4.0, Anda tidak lagi memerlukan Ledger Live untuk menghubungkan perangkat Ledger Anda ke MetaMask.",
@@ -2520,7 +2520,7 @@
   },
   "preferredLedgerConnectionType": {
     "message": "Jenis Koneksi Ledger Pilihan",
-    "description": "A header for a dropdown in the advanced section of settings. Appears above the ledgerConnectionPreferenceDescription message"
+    "description": "A header for a dropdown in Settings > Advanced. Appears above the ledgerConnectionPreferenceDescription message"
   },
   "preparingSwap": {
     "message": "Mempersiapkan pertukaran..."
@@ -3710,7 +3710,7 @@
   },
   "toggleTestNetworks": {
     "message": "$1 jaringan pengujian",
-    "description": "$1 is a clickable link with text defined by the 'showHide' key. The link will open to the advanced settings where users can enable the display of test networks in the network dropdown."
+    "description": "$1 is a clickable link with text defined by the 'showHide' key. The link will open Settings > Advanced where users can enable the display of test networks in the network dropdown."
   },
   "token": {
     "message": "Token"

--- a/app/_locales/ja/messages.json
+++ b/app/_locales/ja/messages.json
@@ -747,7 +747,7 @@
   },
   "customGasSettingToolTipMessage": {
     "message": "ガス代をカスタマイズするには$1を使用します。慣れていない場合はわかりにくい可能性があります。自己責任で操作してください。",
-    "description": "$1 is key 'advanced' (text: 'Advanced') separated here so that it can be passed in with bold fontweight"
+    "description": "$1 is key 'advanced' (text: 'Advanced') separated here so that it can be passed in with bold font-weight"
   },
   "customGasSubTitle": {
     "message": "手数料を増やすと処理時間は短くなる可能性がありますが、必ずそうなるとは限りません。"
@@ -833,7 +833,7 @@
   },
   "depositCrypto": {
     "message": "$1 を入金",
-    "description": "$1 represents the cypto symbol to be purchased"
+    "description": "$1 represents the crypto symbol to be purchased"
   },
   "description": {
     "message": "説明"
@@ -1481,7 +1481,7 @@
   },
   "highGasSettingToolTipMessage": {
     "message": "人気のNFTドロップなどによるネットワークトラフィックの急増に備えるため、$1を使用してください。",
-    "description": "$1 is key 'high' (text: 'Aggressive') separated here so that it can be passed in with bold fontweight"
+    "description": "$1 is key 'high' (text: 'Aggressive') separated here so that it can be passed in with bold font-weight"
   },
   "highLowercase": {
     "message": "高"
@@ -1787,7 +1787,7 @@
   },
   "lowGasSettingToolTipMessage": {
     "message": "値下がりを待つには$1を使用してください。価格がやや予測不能なため、予想時間はあまり正確ではありません。",
-    "description": "$1 is key 'low' separated here so that it can be passed in with bold fontweight"
+    "description": "$1 is key 'low' separated here so that it can be passed in with bold font-weight"
   },
   "lowLowercase": {
     "message": "低"
@@ -1831,7 +1831,7 @@
   },
   "mediumGasSettingToolTipMessage": {
     "message": "現在の市場価格での迅速な処理には、$1を使用してください。",
-    "description": "$1 is key 'medium' (text: 'Market') separated here so that it can be passed in with bold fontweight"
+    "description": "$1 is key 'medium' (text: 'Market') separated here so that it can be passed in with bold font-weight"
   },
   "memo": {
     "message": "メモ"
@@ -2170,7 +2170,7 @@
   },
   "notifications10ActionText": {
     "message": "設定に移動",
-    "description": "The 'call to action' on the button, or link, of the 'Visit in settings' notification. Upon clicking, users will be taken to settings page."
+    "description": "The 'call to action' on the button, or link, of the 'Visit in Settings' notification. Upon clicking, users will be taken to Settings page."
   },
   "notifications10DescriptionOne": {
     "message": "改善されたトークン検出は、現在 Ethereum Mainnet、Polygon、BSC、Avalanche ネットワークで利用できます。他のネットワークも追加される予定です！"
@@ -2275,7 +2275,7 @@
   },
   "notifications8ActionText": {
     "message": "高度な設定に移動",
-    "description": "Description on an action button that appears in the What's New popup. Tells the user that if they click it, they will go to our Advanced Settings page."
+    "description": "Description on an action button that appears in the What's New popup. Tells the user that if they click it, they will go to our Advanced settings page."
   },
   "notifications8DescriptionOne": {
     "message": "MetaMask v10.4.0以降では、LedgerデバイスのMetaMaskへの接続にLedger Liveが不要になりました。",
@@ -2520,7 +2520,7 @@
   },
   "preferredLedgerConnectionType": {
     "message": "優先Ledger接続タイプ",
-    "description": "A header for a dropdown in the advanced section of settings. Appears above the ledgerConnectionPreferenceDescription message"
+    "description": "A header for a dropdown in Settings > Advanced. Appears above the ledgerConnectionPreferenceDescription message"
   },
   "preparingSwap": {
     "message": "スワップを準備しています..."
@@ -3710,7 +3710,7 @@
   },
   "toggleTestNetworks": {
     "message": "$1テストネットワーク",
-    "description": "$1 is a clickable link with text defined by the 'showHide' key. The link will open to the advanced settings where users can enable the display of test networks in the network dropdown."
+    "description": "$1 is a clickable link with text defined by the 'showHide' key. The link will open Settings > Advanced where users can enable the display of test networks in the network dropdown."
   },
   "token": {
     "message": "トークン"

--- a/app/_locales/ko/messages.json
+++ b/app/_locales/ko/messages.json
@@ -747,7 +747,7 @@
   },
   "customGasSettingToolTipMessage": {
     "message": "$1을(를) 사용하여 가스 가격을 맞춤설정하세요. 익숙하지 않은 경우 혼동될 수 있습니다. 자신의 책임하에 상호 작용하세요.",
-    "description": "$1 is key 'advanced' (text: 'Advanced') separated here so that it can be passed in with bold fontweight"
+    "description": "$1 is key 'advanced' (text: 'Advanced') separated here so that it can be passed in with bold font-weight"
   },
   "customGasSubTitle": {
     "message": "수수료를 올리면 처리 시간이 단축되기도 하지만 항상 그렇지는 않습니다."
@@ -833,7 +833,7 @@
   },
   "depositCrypto": {
     "message": "$1 입금",
-    "description": "$1 represents the cypto symbol to be purchased"
+    "description": "$1 represents the crypto symbol to be purchased"
   },
   "description": {
     "message": "설명"
@@ -1481,7 +1481,7 @@
   },
   "highGasSettingToolTipMessage": {
     "message": "인기 있는 NFT의 하락 등으로 인한 네트워크 트래픽 급증을 커버하려면 $1을 사용하세요.",
-    "description": "$1 is key 'high' (text: 'Aggressive') separated here so that it can be passed in with bold fontweight"
+    "description": "$1 is key 'high' (text: 'Aggressive') separated here so that it can be passed in with bold font-weight"
   },
   "highLowercase": {
     "message": "높음"
@@ -1787,7 +1787,7 @@
   },
   "lowGasSettingToolTipMessage": {
     "message": "$1 사용을 통해 더 저렴한 가격을 기다리세요. 가격 예측이 힘들기 때문에 시간 추정은 더욱 부정확합니다.",
-    "description": "$1 is key 'low' separated here so that it can be passed in with bold fontweight"
+    "description": "$1 is key 'low' separated here so that it can be passed in with bold font-weight"
   },
   "lowLowercase": {
     "message": "낮음"
@@ -1831,7 +1831,7 @@
   },
   "mediumGasSettingToolTipMessage": {
     "message": "현재 시장 가격으로 빠르게 처리할 수 있도록 $1을(를) 사용하세요.",
-    "description": "$1 is key 'medium' (text: 'Market') separated here so that it can be passed in with bold fontweight"
+    "description": "$1 is key 'medium' (text: 'Market') separated here so that it can be passed in with bold font-weight"
   },
   "memo": {
     "message": "메모"
@@ -2170,7 +2170,7 @@
   },
   "notifications10ActionText": {
     "message": "설정으로 이동하기",
-    "description": "The 'call to action' on the button, or link, of the 'Visit in settings' notification. Upon clicking, users will be taken to settings page."
+    "description": "The 'call to action' on the button, or link, of the 'Visit in Settings' notification. Upon clicking, users will be taken to Settings page."
   },
   "notifications10DescriptionOne": {
     "message": "향상된 토큰 감지 기능을 현재 이더리움 메인넷과 Polygon, BSC, Avalanche 네트워크에서 이용할 수 있습니다. 더 많은 기능이 준비 중입니다!"
@@ -2275,7 +2275,7 @@
   },
   "notifications8ActionText": {
     "message": "고급 설정으로 이동하기",
-    "description": "Description on an action button that appears in the What's New popup. Tells the user that if they click it, they will go to our Advanced Settings page."
+    "description": "Description on an action button that appears in the What's New popup. Tells the user that if they click it, they will go to our Advanced settings page."
   },
   "notifications8DescriptionOne": {
     "message": "MetaMask v10.4.0부터는 Ledger 장치를 MetaMask에 연결할 때 더 이상 Ledger Live를 사용하지 않아도 됩니다.",
@@ -2520,7 +2520,7 @@
   },
   "preferredLedgerConnectionType": {
     "message": "선호하는 Ledger 연결 유형",
-    "description": "A header for a dropdown in the advanced section of settings. Appears above the ledgerConnectionPreferenceDescription message"
+    "description": "A header for a dropdown in Settings > Advanced. Appears above the ledgerConnectionPreferenceDescription message"
   },
   "preparingSwap": {
     "message": "스왑 준비 중..."
@@ -3710,7 +3710,7 @@
   },
   "toggleTestNetworks": {
     "message": "$1 테스트 네트워크",
-    "description": "$1 is a clickable link with text defined by the 'showHide' key. The link will open to the advanced settings where users can enable the display of test networks in the network dropdown."
+    "description": "$1 is a clickable link with text defined by the 'showHide' key. The link will open Settings > Advanced where users can enable the display of test networks in the network dropdown."
   },
   "token": {
     "message": "토큰"

--- a/app/_locales/ph/messages.json
+++ b/app/_locales/ph/messages.json
@@ -2216,7 +2216,7 @@
     "message": "Welcome sa MetaMask"
   },
   "welcomeBack": {
-    "message": "Welcome Back!"
+    "message": "Welcome back!"
   },
   "whatsNew": {
     "message": "Ano'ng bago",

--- a/app/_locales/pt/messages.json
+++ b/app/_locales/pt/messages.json
@@ -747,7 +747,7 @@
   },
   "customGasSettingToolTipMessage": {
     "message": "Use $1 para personalizar o preço do gás. Isso pode parecer confuso se você não estiver familiarizado. Interaja por sua conta e risco.",
-    "description": "$1 is key 'advanced' (text: 'Advanced') separated here so that it can be passed in with bold fontweight"
+    "description": "$1 is key 'advanced' (text: 'Advanced') separated here so that it can be passed in with bold font-weight"
   },
   "customGasSubTitle": {
     "message": "Aumentar a taxa pode diminuir o tempo de processamento, mas isso não é garantido."
@@ -833,7 +833,7 @@
   },
   "depositCrypto": {
     "message": "Depositar $1",
-    "description": "$1 represents the cypto symbol to be purchased"
+    "description": "$1 represents the crypto symbol to be purchased"
   },
   "description": {
     "message": "Descrição"
@@ -1481,7 +1481,7 @@
   },
   "highGasSettingToolTipMessage": {
     "message": "Alta probabilidade, mesmo em mercados voláteis. Use $1 para cobrir picos no tráfego de rede em razão de coisas como quedas em NFTs populares.",
-    "description": "$1 is key 'high' (text: 'Aggressive') separated here so that it can be passed in with bold fontweight"
+    "description": "$1 is key 'high' (text: 'Aggressive') separated here so that it can be passed in with bold font-weight"
   },
   "highLowercase": {
     "message": "alta"
@@ -1787,7 +1787,7 @@
   },
   "lowGasSettingToolTipMessage": {
     "message": "Use $1 para aguardar um preço mais baixo. As estimativas de tempo são muito menos exatas, pois os preços são relativamente imprevisíveis.",
-    "description": "$1 is key 'low' separated here so that it can be passed in with bold fontweight"
+    "description": "$1 is key 'low' separated here so that it can be passed in with bold font-weight"
   },
   "lowLowercase": {
     "message": "baixa"
@@ -1831,7 +1831,7 @@
   },
   "mediumGasSettingToolTipMessage": {
     "message": "Use $1 para um processamento rápido pelo preço atual de mercado.",
-    "description": "$1 is key 'medium' (text: 'Market') separated here so that it can be passed in with bold fontweight"
+    "description": "$1 is key 'medium' (text: 'Market') separated here so that it can be passed in with bold font-weight"
   },
   "memo": {
     "message": "memorando"
@@ -2170,7 +2170,7 @@
   },
   "notifications10ActionText": {
     "message": "Veja em configurações",
-    "description": "The 'call to action' on the button, or link, of the 'Visit in settings' notification. Upon clicking, users will be taken to settings page."
+    "description": "The 'call to action' on the button, or link, of the 'Visit in Settings' notification. Upon clicking, users will be taken to Settings page."
   },
   "notifications10DescriptionOne": {
     "message": "A detecção aperfeiçoada de tokens está atualmente disponível nas redes Ethereum Mainnet, Polygon, BSC e Avalanche. Há outras por vir!"
@@ -2275,7 +2275,7 @@
   },
   "notifications8ActionText": {
     "message": "Ir para Configurações Avançadas",
-    "description": "Description on an action button that appears in the What's New popup. Tells the user that if they click it, they will go to our Advanced Settings page."
+    "description": "Description on an action button that appears in the What's New popup. Tells the user that if they click it, they will go to our Advanced settings page."
   },
   "notifications8DescriptionOne": {
     "message": "A partir da MetaMask v10.4.0, não é mais necessário o Ledger Live para conectar o seu dispositivo Ledger à MetaMask.",
@@ -2520,7 +2520,7 @@
   },
   "preferredLedgerConnectionType": {
     "message": "Tipo de conexão preferencial com o Ledger",
-    "description": "A header for a dropdown in the advanced section of settings. Appears above the ledgerConnectionPreferenceDescription message"
+    "description": "A header for a dropdown in Settings > Advanced. Appears above the ledgerConnectionPreferenceDescription message"
   },
   "preparingSwap": {
     "message": "Preparando swap..."
@@ -3710,7 +3710,7 @@
   },
   "toggleTestNetworks": {
     "message": "$1 redes de teste",
-    "description": "$1 is a clickable link with text defined by the 'showHide' key. The link will open to the advanced settings where users can enable the display of test networks in the network dropdown."
+    "description": "$1 is a clickable link with text defined by the 'showHide' key. The link will open Settings > Advanced where users can enable the display of test networks in the network dropdown."
   },
   "token": {
     "message": "Token"

--- a/app/_locales/pt_BR/messages.json
+++ b/app/_locales/pt_BR/messages.json
@@ -1517,7 +1517,7 @@
   },
   "lowGasSettingToolTipMessage": {
     "message": "Use $1 para aguardar um preço mais baixo. As estimativas de tempo são muito menos exatas, pois os preços são relativamente imprevisíveis.",
-    "description": "$1 is key 'low' separated here so that it can be passed in with bold fontweight"
+    "description": "$1 is key 'low' separated here so that it can be passed in with bold font-weight"
   },
   "lowLowercase": {
     "message": "baixa"
@@ -1549,7 +1549,7 @@
   },
   "mediumGasSettingToolTipMessage": {
     "message": "Use $1 para um processamento rápido pelo preço atual de mercado.",
-    "description": "$1 is key 'medium' (text: 'Market') separated here so that it can be passed in with bold fontweight"
+    "description": "$1 is key 'medium' (text: 'Market') separated here so that it can be passed in with bold font-weight"
   },
   "memo": {
     "message": "nota"
@@ -1895,7 +1895,7 @@
   },
   "notifications8ActionText": {
     "message": "Ir para Configurações Avançadas",
-    "description": "Description on an action button that appears in the What's New popup. Tells the user that if they click it, they will go to our Advanced Settings page."
+    "description": "Description on an action button that appears in the What's New popup. Tells the user that if they click it, they will go to our Advanced settings page."
   },
   "notifications8DescriptionOne": {
     "message": "A partir da MetaMask v10.4.0, não é mais necessário o Ledger Live para conectar o seu dispositivo Ledger à MetaMask.",
@@ -2069,7 +2069,7 @@
   },
   "preferredLedgerConnectionType": {
     "message": "Tipo de conexão preferencial com o Ledger",
-    "description": "A header for a dropdown in the advanced section of settings. Appears above the ledgerConnectionPreferenceDescription message"
+    "description": "A header for a dropdown in Settings > Advanced. Appears above the ledgerConnectionPreferenceDescription message"
   },
   "prev": {
     "message": "Anterior"
@@ -2991,7 +2991,7 @@
   },
   "toggleTestNetworks": {
     "message": "$1 redes de teste",
-    "description": "$1 is a clickable link with text defined by the 'showHide' key. The link will open to the advanced settings where users can enable the display of test networks in the network dropdown."
+    "description": "$1 is a clickable link with text defined by the 'showHide' key. The link will open Settings > Advanced where users can enable the display of test networks in the network dropdown."
   },
   "token": {
     "message": "Token"

--- a/app/_locales/ru/messages.json
+++ b/app/_locales/ru/messages.json
@@ -747,7 +747,7 @@
   },
   "customGasSettingToolTipMessage": {
     "message": "Использовать $1, чтобы настроить цену на газ. Это может сбивать с толку, если вы не знакомы с этим. Взаимодействуйте на свой страх и риск.",
-    "description": "$1 is key 'advanced' (text: 'Advanced') separated here so that it can be passed in with bold fontweight"
+    "description": "$1 is key 'advanced' (text: 'Advanced') separated here so that it can be passed in with bold font-weight"
   },
   "customGasSubTitle": {
     "message": "Увеличение комиссии может сократить время обработки, но это не гарантируется."
@@ -833,7 +833,7 @@
   },
   "depositCrypto": {
     "message": "Внесите $1",
-    "description": "$1 represents the cypto symbol to be purchased"
+    "description": "$1 represents the crypto symbol to be purchased"
   },
   "description": {
     "message": "Описание"
@@ -1481,7 +1481,7 @@
   },
   "highGasSettingToolTipMessage": {
     "message": "Используйте $1, чтобы компенсировать скачки сетевого трафика из-за таких событий, как дропы популярных NFT.",
-    "description": "$1 is key 'high' (text: 'Aggressive') separated here so that it can be passed in with bold fontweight"
+    "description": "$1 is key 'high' (text: 'Aggressive') separated here so that it can be passed in with bold font-weight"
   },
   "highLowercase": {
     "message": "высокая"
@@ -1787,7 +1787,7 @@
   },
   "lowGasSettingToolTipMessage": {
     "message": "Используйте $1, чтобы дождаться более низкой цены. Оценки времени намного менее точны, поскольку цены в некоторой степени непредсказуемы.",
-    "description": "$1 is key 'low' separated here so that it can be passed in with bold fontweight"
+    "description": "$1 is key 'low' separated here so that it can be passed in with bold font-weight"
   },
   "lowLowercase": {
     "message": "низкая"
@@ -1831,7 +1831,7 @@
   },
   "mediumGasSettingToolTipMessage": {
     "message": "Используйте $1 для быстрой обработки по текущей рыночной цене.",
-    "description": "$1 is key 'medium' (text: 'Market') separated here so that it can be passed in with bold fontweight"
+    "description": "$1 is key 'medium' (text: 'Market') separated here so that it can be passed in with bold font-weight"
   },
   "memo": {
     "message": "заметка"
@@ -2170,7 +2170,7 @@
   },
   "notifications10ActionText": {
     "message": "Смотреть в настройках",
-    "description": "The 'call to action' on the button, or link, of the 'Visit in settings' notification. Upon clicking, users will be taken to settings page."
+    "description": "The 'call to action' on the button, or link, of the 'Visit in Settings' notification. Upon clicking, users will be taken to Settings page."
   },
   "notifications10DescriptionOne": {
     "message": "Улучшенное обнаружение токенов в настоящее время доступно в сетях Ethereum Mainnet, Polygon, BSC и Avalanche. Это еще не все!"
@@ -2275,7 +2275,7 @@
   },
   "notifications8ActionText": {
     "message": "Перейти в Дополнительные настройки",
-    "description": "Description on an action button that appears in the What's New popup. Tells the user that if they click it, they will go to our Advanced Settings page."
+    "description": "Description on an action button that appears in the What's New popup. Tells the user that if they click it, they will go to our Advanced settings page."
   },
   "notifications8DescriptionOne": {
     "message": "Начиная с версии MetaMask 10.4.0, вам больше не требуется Ledger Live для подключения леджера к MetaMask.",
@@ -2520,7 +2520,7 @@
   },
   "preferredLedgerConnectionType": {
     "message": "Предпочтительный тип подключения к леджеру",
-    "description": "A header for a dropdown in the advanced section of settings. Appears above the ledgerConnectionPreferenceDescription message"
+    "description": "A header for a dropdown in Settings > Advanced. Appears above the ledgerConnectionPreferenceDescription message"
   },
   "preparingSwap": {
     "message": "Подготовка обмена..."
@@ -3710,7 +3710,7 @@
   },
   "toggleTestNetworks": {
     "message": "$1 тестовые сети",
-    "description": "$1 is a clickable link with text defined by the 'showHide' key. The link will open to the advanced settings where users can enable the display of test networks in the network dropdown."
+    "description": "$1 is a clickable link with text defined by the 'showHide' key. The link will open Settings > Advanced where users can enable the display of test networks in the network dropdown."
   },
   "token": {
     "message": "Токен"

--- a/app/_locales/tl/messages.json
+++ b/app/_locales/tl/messages.json
@@ -747,7 +747,7 @@
   },
   "customGasSettingToolTipMessage": {
     "message": "Gamitin ang $1 para i-customize ang presyo ng gas. Ito ay maaaring nakakalito kung hindi ka pamilyar. Harapin ang sarili mong panganib.",
-    "description": "$1 is key 'advanced' (text: 'Advanced') separated here so that it can be passed in with bold fontweight"
+    "description": "$1 is key 'advanced' (text: 'Advanced') separated here so that it can be passed in with bold font-weight"
   },
   "customGasSubTitle": {
     "message": "Kapag dinagdagan ang bayarin, mababawasan ang mga oras ng pagproseso, pero hindi ito garantisado."
@@ -833,7 +833,7 @@
   },
   "depositCrypto": {
     "message": "Magdeposito ng $1",
-    "description": "$1 represents the cypto symbol to be purchased"
+    "description": "$1 represents the crypto symbol to be purchased"
   },
   "description": {
     "message": "Deskripsyon"
@@ -1481,7 +1481,7 @@
   },
   "highGasSettingToolTipMessage": {
     "message": "Gamitin ang $1 upang pagtakpan ang mga surge sa network traffic dahil sa mga bagay tulad ng popular na pagbagsak ng NFT.",
-    "description": "$1 is key 'high' (text: 'Aggressive') separated here so that it can be passed in with bold fontweight"
+    "description": "$1 is key 'high' (text: 'Aggressive') separated here so that it can be passed in with bold font-weight"
   },
   "highLowercase": {
     "message": "mataas"
@@ -1787,7 +1787,7 @@
   },
   "lowGasSettingToolTipMessage": {
     "message": "Gamitin ang $1 para maghintay ng mas murang presyo. Ang mga pagtatantya sa oras ay hindi gaanong tumpak dahil ang mga presyo ay medyo hindi mahuhulaan.",
-    "description": "$1 is key 'low' separated here so that it can be passed in with bold fontweight"
+    "description": "$1 is key 'low' separated here so that it can be passed in with bold font-weight"
   },
   "lowLowercase": {
     "message": "mababa"
@@ -1831,7 +1831,7 @@
   },
   "mediumGasSettingToolTipMessage": {
     "message": "Gamitin ang $1 para sa pagproseso sa kasalukuyang market price.",
-    "description": "$1 is key 'medium' (text: 'Market') separated here so that it can be passed in with bold fontweight"
+    "description": "$1 is key 'medium' (text: 'Market') separated here so that it can be passed in with bold font-weight"
   },
   "memo": {
     "message": "memo"
@@ -2170,7 +2170,7 @@
   },
   "notifications10ActionText": {
     "message": "Bisitahin sa mga setting",
-    "description": "The 'call to action' on the button, or link, of the 'Visit in settings' notification. Upon clicking, users will be taken to settings page."
+    "description": "The 'call to action' on the button, or link, of the 'Visit in Settings' notification. Upon clicking, users will be taken to Settings page."
   },
   "notifications10DescriptionOne": {
     "message": "Ang pinahusay na pagtukoy ng token ay kasalukuyang magagamit sa Ethereum Mainnet, Polygon, BSC, at mga Avalanche network. Marami pang darating!"
@@ -2275,7 +2275,7 @@
   },
   "notifications8ActionText": {
     "message": "Magpunta sa Advanced Settings",
-    "description": "Description on an action button that appears in the What's New popup. Tells the user that if they click it, they will go to our Advanced Settings page."
+    "description": "Description on an action button that appears in the What's New popup. Tells the user that if they click it, they will go to our Advanced settings page."
   },
   "notifications8DescriptionOne": {
     "message": "Para sa MetaMask v10.4.0, hindi mo na kailangang ikonekta ang Ledger Live sa iyong Ledger device sa MetaMask.",
@@ -2520,7 +2520,7 @@
   },
   "preferredLedgerConnectionType": {
     "message": "Napiling Uri ng Ledger Connection",
-    "description": "A header for a dropdown in the advanced section of settings. Appears above the ledgerConnectionPreferenceDescription message"
+    "description": "A header for a dropdown in Settings > Advanced. Appears above the ledgerConnectionPreferenceDescription message"
   },
   "preparingSwap": {
     "message": "Inihahanda ang pagpapalit..."
@@ -3710,7 +3710,7 @@
   },
   "toggleTestNetworks": {
     "message": "$1 na test network",
-    "description": "$1 is a clickable link with text defined by the 'showHide' key. The link will open to the advanced settings where users can enable the display of test networks in the network dropdown."
+    "description": "$1 is a clickable link with text defined by the 'showHide' key. The link will open Settings > Advanced where users can enable the display of test networks in the network dropdown."
   },
   "token": {
     "message": "Token"

--- a/app/_locales/tr/messages.json
+++ b/app/_locales/tr/messages.json
@@ -747,7 +747,7 @@
   },
   "customGasSettingToolTipMessage": {
     "message": "Gaz fiyatını özelleştirmek için $1 kullanın. Bu, bilgi sahibi değilseniz kafa karıştırıcı olabilir. Riski size ait olmak üzere kullanın.",
-    "description": "$1 is key 'advanced' (text: 'Advanced') separated here so that it can be passed in with bold fontweight"
+    "description": "$1 is key 'advanced' (text: 'Advanced') separated here so that it can be passed in with bold font-weight"
   },
   "customGasSubTitle": {
     "message": "Ücretin artırılması işlem süresini kısaltabilir ancak bu garanti edilmez."
@@ -833,7 +833,7 @@
   },
   "depositCrypto": {
     "message": "$1 yatır",
-    "description": "$1 represents the cypto symbol to be purchased"
+    "description": "$1 represents the crypto symbol to be purchased"
   },
   "description": {
     "message": "Açıklama"
@@ -1481,7 +1481,7 @@
   },
   "highGasSettingToolTipMessage": {
     "message": "Popüler NFT düşüşleri gibi şeyler nedeniyle ağ trafiğindeki dalgalanmaları kapsayacak şekilde $1 kullanın.",
-    "description": "$1 is key 'high' (text: 'Aggressive') separated here so that it can be passed in with bold fontweight"
+    "description": "$1 is key 'high' (text: 'Aggressive') separated here so that it can be passed in with bold font-weight"
   },
   "highLowercase": {
     "message": "yüksek"
@@ -1787,7 +1787,7 @@
   },
   "lowGasSettingToolTipMessage": {
     "message": "Daha ucuz bir fiyat için beklemek için $1 kullanın. Fiyatlar bir şekilde öngörülemez oldukları için süre tahminleri çok daha az kesindir.",
-    "description": "$1 is key 'low' separated here so that it can be passed in with bold fontweight"
+    "description": "$1 is key 'low' separated here so that it can be passed in with bold font-weight"
   },
   "lowLowercase": {
     "message": "düşük"
@@ -1831,7 +1831,7 @@
   },
   "mediumGasSettingToolTipMessage": {
     "message": "Mevcut piyasa fiyatında hızlı işleme almak için $1 kullanın.",
-    "description": "$1 is key 'medium' (text: 'Market') separated here so that it can be passed in with bold fontweight"
+    "description": "$1 is key 'medium' (text: 'Market') separated here so that it can be passed in with bold font-weight"
   },
   "memo": {
     "message": "not"
@@ -2170,7 +2170,7 @@
   },
   "notifications10ActionText": {
     "message": "Ayarlarda ziyaret et",
-    "description": "The 'call to action' on the button, or link, of the 'Visit in settings' notification. Upon clicking, users will be taken to settings page."
+    "description": "The 'call to action' on the button, or link, of the 'Visit in Settings' notification. Upon clicking, users will be taken to Settings page."
   },
   "notifications10DescriptionOne": {
     "message": "Geliştirilmiş token algılama şu anda Ethereum Mainnet, Polygon, BSC ve Avalanche ağlarında mevcut. Daha fazlası gelecek!"
@@ -2275,7 +2275,7 @@
   },
   "notifications8ActionText": {
     "message": "Gelişmiş ayarlara git",
-    "description": "Description on an action button that appears in the What's New popup. Tells the user that if they click it, they will go to our Advanced Settings page."
+    "description": "Description on an action button that appears in the What's New popup. Tells the user that if they click it, they will go to our Advanced settings page."
   },
   "notifications8DescriptionOne": {
     "message": "MetaMask 10.4.0 sürümü itibariyle Kayıt Defteri cihazınızı Metamask'e bağlamak için artık Ledger Live'e ihtiyacınız yok.",
@@ -2520,7 +2520,7 @@
   },
   "preferredLedgerConnectionType": {
     "message": "Tercih Edilen Kayıt Defteri Bağlantı Türü",
-    "description": "A header for a dropdown in the advanced section of settings. Appears above the ledgerConnectionPreferenceDescription message"
+    "description": "A header for a dropdown in Settings > Advanced. Appears above the ledgerConnectionPreferenceDescription message"
   },
   "preparingSwap": {
     "message": "Takas hazırlanıyor..."
@@ -3710,7 +3710,7 @@
   },
   "toggleTestNetworks": {
     "message": "Test ağlarını $1",
-    "description": "$1 is a clickable link with text defined by the 'showHide' key. The link will open to the advanced settings where users can enable the display of test networks in the network dropdown."
+    "description": "$1 is a clickable link with text defined by the 'showHide' key. The link will open Settings > Advanced where users can enable the display of test networks in the network dropdown."
   },
   "token": {
     "message": "Token"

--- a/app/_locales/vi/messages.json
+++ b/app/_locales/vi/messages.json
@@ -747,7 +747,7 @@
   },
   "customGasSettingToolTipMessage": {
     "message": "Sử dụng $1 để tùy chỉnh giá gas. Việc này có thể gây nhầm lẫn nếu bạn không quen thuộc. Bạn phải tự chịu trách nhiệm nếu thực hiện.",
-    "description": "$1 is key 'advanced' (text: 'Advanced') separated here so that it can be passed in with bold fontweight"
+    "description": "$1 is key 'advanced' (text: 'Advanced') separated here so that it can be passed in with bold font-weight"
   },
   "customGasSubTitle": {
     "message": "Việc tăng phí có thể giúp giảm thời gian xử lý, nhưng điều này không được đảm bảo."
@@ -833,7 +833,7 @@
   },
   "depositCrypto": {
     "message": "Nạp $1",
-    "description": "$1 represents the cypto symbol to be purchased"
+    "description": "$1 represents the crypto symbol to be purchased"
   },
   "description": {
     "message": "Mô tả"
@@ -1481,7 +1481,7 @@
   },
   "highGasSettingToolTipMessage": {
     "message": "Sử dụng $1 để bù đắp khi lưu lượng mạng lưới tăng vọt trong những trường hợp như phát hành NFT nổi tiếng.",
-    "description": "$1 is key 'high' (text: 'Aggressive') separated here so that it can be passed in with bold fontweight"
+    "description": "$1 is key 'high' (text: 'Aggressive') separated here so that it can be passed in with bold font-weight"
   },
   "highLowercase": {
     "message": "cao"
@@ -1787,7 +1787,7 @@
   },
   "lowGasSettingToolTipMessage": {
     "message": "Sử dụng $1 để chờ mức giá rẻ hơn. Thời gian dự kiến sẽ kém chính xác hơn nhiều do mức giá tương đối khó dự đoán.",
-    "description": "$1 is key 'low' separated here so that it can be passed in with bold fontweight"
+    "description": "$1 is key 'low' separated here so that it can be passed in with bold font-weight"
   },
   "lowLowercase": {
     "message": "thấp"
@@ -1831,7 +1831,7 @@
   },
   "mediumGasSettingToolTipMessage": {
     "message": "Sử dụng $1 để xử lý nhanh theo giá thị trường hiện tại.",
-    "description": "$1 is key 'medium' (text: 'Market') separated here so that it can be passed in with bold fontweight"
+    "description": "$1 is key 'medium' (text: 'Market') separated here so that it can be passed in with bold font-weight"
   },
   "memo": {
     "message": "bản ghi nhớ"
@@ -2170,7 +2170,7 @@
   },
   "notifications10ActionText": {
     "message": "Xem trong cài đặt",
-    "description": "The 'call to action' on the button, or link, of the 'Visit in settings' notification. Upon clicking, users will be taken to settings page."
+    "description": "The 'call to action' on the button, or link, of the 'Visit in Settings' notification. Upon clicking, users will be taken to Settings page."
   },
   "notifications10DescriptionOne": {
     "message": "Tính năng phát hiện token cải tiến hiện đã có sẵn trên Mạng chính thức của Ethereum, mạng Polygon, BSC và Avalanche. Sẽ sớm có thêm nhiều mạng khác!"
@@ -2275,7 +2275,7 @@
   },
   "notifications8ActionText": {
     "message": "Đến Cài Đặt Nâng Cao",
-    "description": "Description on an action button that appears in the What's New popup. Tells the user that if they click it, they will go to our Advanced Settings page."
+    "description": "Description on an action button that appears in the What's New popup. Tells the user that if they click it, they will go to our Advanced settings page."
   },
   "notifications8DescriptionOne": {
     "message": "Kể từ phiên bản MetaMask v10.4.0, bạn không cần phần mềm Ledger Live để kết nối thiết bị Ledger của mình với MetaMask nữa.",
@@ -2520,7 +2520,7 @@
   },
   "preferredLedgerConnectionType": {
     "message": "Dạng Kết Nối Ledger Ưu Tiên",
-    "description": "A header for a dropdown in the advanced section of settings. Appears above the ledgerConnectionPreferenceDescription message"
+    "description": "A header for a dropdown in Settings > Advanced. Appears above the ledgerConnectionPreferenceDescription message"
   },
   "preparingSwap": {
     "message": "Đang chuẩn bị hoán đổi..."
@@ -3710,7 +3710,7 @@
   },
   "toggleTestNetworks": {
     "message": "$1 mạng thử nghiệm",
-    "description": "$1 is a clickable link with text defined by the 'showHide' key. The link will open to the advanced settings where users can enable the display of test networks in the network dropdown."
+    "description": "$1 is a clickable link with text defined by the 'showHide' key. The link will open Settings > Advanced where users can enable the display of test networks in the network dropdown."
   },
   "token": {
     "message": "Token"

--- a/app/_locales/zh_CN/messages.json
+++ b/app/_locales/zh_CN/messages.json
@@ -613,7 +613,7 @@
   },
   "customGasSettingToolTipMessage": {
     "message": "使用$1来定制燃料价格。如果您不熟悉这可能会引起混淆。操作风险自付。",
-    "description": "$1 is key 'advanced' (text: 'Advanced') separated here so that it can be passed in with bold fontweight"
+    "description": "$1 is key 'advanced' (text: 'Advanced') separated here so that it can be passed in with bold font-weight"
   },
   "customGasSubTitle": {
     "message": "提升费用可能会缩短处理时间，但不保证绝对有效。"
@@ -1233,7 +1233,7 @@
   },
   "highGasSettingToolTipMessage": {
     "message": "使用$1来覆盖网络流量因像流行的 NFT 丢弃而出现的剧增。",
-    "description": "$1 is key 'high' (text: 'Aggressive') separated here so that it can be passed in with bold fontweight"
+    "description": "$1 is key 'high' (text: 'Aggressive') separated here so that it can be passed in with bold font-weight"
   },
   "highLowercase": {
     "message": "高"
@@ -1484,7 +1484,7 @@
   },
   "lowGasSettingToolTipMessage": {
     "message": "使用$1等待较便宜的价格。时间估计远不准确，因为价格有些难以预测。",
-    "description": "$1 is key 'low' separated here so that it can be passed in with bold fontweight"
+    "description": "$1 is key 'low' separated here so that it can be passed in with bold font-weight"
   },
   "lowLowercase": {
     "message": "低"
@@ -1519,7 +1519,7 @@
   },
   "mediumGasSettingToolTipMessage": {
     "message": "使用$1按当前市场价格快速处理。",
-    "description": "$1 is key 'medium' (text: 'Market') separated here so that it can be passed in with bold fontweight"
+    "description": "$1 is key 'medium' (text: 'Market') separated here so that it can be passed in with bold font-weight"
   },
   "memo": {
     "message": "备忘"
@@ -1865,7 +1865,7 @@
   },
   "notifications8ActionText": {
     "message": "转到高级设置",
-    "description": "Description on an action button that appears in the What's New popup. Tells the user that if they click it, they will go to our Advanced Settings page."
+    "description": "Description on an action button that appears in the What's New popup. Tells the user that if they click it, they will go to our Advanced settings page."
   },
   "notifications8DescriptionOne": {
     "message": "从MetaMaskv10.4.0开始，您不再需要Ledger Live连接您的Ledger设备到Metamask。",
@@ -2039,7 +2039,7 @@
   },
   "preferredLedgerConnectionType": {
     "message": "首选Ledger连接类型",
-    "description": "A header for a dropdown in the advanced section of settings. Appears above the ledgerConnectionPreferenceDescription message"
+    "description": "A header for a dropdown in Settings > Advanced. Appears above the ledgerConnectionPreferenceDescription message"
   },
   "prev": {
     "message": "上一个"
@@ -2952,7 +2952,7 @@
   },
   "toggleTestNetworks": {
     "message": "$1 测试网络",
-    "description": "$1 is a clickable link with text defined by the 'showHide' key. The link will open to the advanced settings where users can enable the display of test networks in the network dropdown."
+    "description": "$1 is a clickable link with text defined by the 'showHide' key. The link will open Settings > Advanced where users can enable the display of test networks in the network dropdown."
   },
   "token": {
     "message": "代币"

--- a/test/e2e/metamask-ui.spec.js
+++ b/test/e2e/metamask-ui.spec.js
@@ -105,7 +105,7 @@ describe('MetaMask', function () {
     });
 
     it('clicks the "Create New Wallet" option', async function () {
-      await driver.clickElement({ text: 'Create a Wallet', tag: 'button' });
+      await driver.clickElement({ text: 'Create a wallet', tag: 'button' });
       await driver.delay(largeDelayMs);
     });
 
@@ -307,7 +307,7 @@ describe('MetaMask', function () {
 
     it('picks the newly created Test token', async function () {
       await driver.clickElement({
-        text: 'Custom Token',
+        text: 'Custom token',
         tag: 'button',
       });
       await driver.delay(regularDelayMs);
@@ -315,10 +315,10 @@ describe('MetaMask', function () {
       await driver.fill('#custom-address', tokenAddress);
       await driver.delay(regularDelayMs);
 
-      await driver.clickElement({ text: 'Add Custom Token', tag: 'button' });
+      await driver.clickElement({ text: 'Add custom token', tag: 'button' });
       await driver.delay(regularDelayMs);
 
-      await driver.clickElement({ text: 'Import Tokens', tag: 'button' });
+      await driver.clickElement({ text: 'Import tokens', tag: 'button' });
       await driver.delay(regularDelayMs);
     });
 

--- a/test/e2e/tests/add-account.spec.js
+++ b/test/e2e/tests/add-account.spec.js
@@ -34,7 +34,7 @@ describe('Add account', function () {
         await driver.press('#password', driver.Key.ENTER);
 
         await driver.clickElement('.account-menu__icon');
-        await driver.clickElement({ text: 'Create Account', tag: 'div' });
+        await driver.clickElement({ text: 'Create account', tag: 'div' });
         await driver.fill('.new-account-create-form input', '2nd account');
         await driver.clickElement({ text: 'Create', tag: 'button' });
 
@@ -65,7 +65,7 @@ describe('Add account', function () {
         );
 
         await driver.clickElement('.account-menu__icon');
-        await driver.clickElement({ text: 'Create Account', tag: 'div' });
+        await driver.clickElement({ text: 'Create account', tag: 'div' });
         await driver.fill('.new-account-create-form input', '2nd account');
         await driver.clickElement({ text: 'Create', tag: 'button' });
 
@@ -89,7 +89,7 @@ describe('Add account', function () {
 
         // generate a third accound
         await driver.clickElement('.account-menu__icon');
-        await driver.clickElement({ text: 'Create Account', tag: 'div' });
+        await driver.clickElement({ text: 'Create account', tag: 'div' });
         await driver.fill('.new-account-create-form input', '3rd account');
         await driver.clickElement({ text: 'Create', tag: 'button' });
 
@@ -146,7 +146,7 @@ describe('Add account', function () {
 
         // recreate a "2nd account"
         await driver.clickElement('.account-menu__icon');
-        await driver.clickElement({ text: 'Create Account', tag: 'div' });
+        await driver.clickElement({ text: 'Create account', tag: 'div' });
         await driver.fill('.new-account-create-form input', '2nd account');
         await driver.clickElement({ text: 'Create', tag: 'button' });
 
@@ -175,7 +175,7 @@ describe('Add account', function () {
 
         // re-generate a third accound
         await driver.clickElement('.account-menu__icon');
-        await driver.clickElement({ text: 'Create Account', tag: 'div' });
+        await driver.clickElement({ text: 'Create account', tag: 'div' });
         await driver.fill('.new-account-create-form input', '3rd account');
         await driver.clickElement({ text: 'Create', tag: 'button' });
 
@@ -217,7 +217,7 @@ describe('Add account', function () {
         await driver.delay(regularDelayMs);
 
         await driver.clickElement('.account-menu__icon');
-        await driver.clickElement({ text: 'Create Account', tag: 'div' });
+        await driver.clickElement({ text: 'Create account', tag: 'div' });
         await driver.fill('.new-account-create-form input', '2nd account');
         await driver.clickElement({ text: 'Create', tag: 'button' });
 
@@ -233,7 +233,7 @@ describe('Add account', function () {
 
         // import with private key
         await driver.clickElement('.account-menu__icon');
-        await driver.clickElement({ text: 'Import Account', tag: 'div' });
+        await driver.clickElement({ text: 'Import account', tag: 'div' });
 
         // enter private key',
         await driver.fill('#private-key-box', testPrivateKey);

--- a/test/e2e/tests/add-hide-token.spec.js
+++ b/test/e2e/tests/add-hide-token.spec.js
@@ -88,7 +88,7 @@ describe('Add existing token using search', function () {
           tag: 'span',
         });
         await driver.clickElement({ text: 'Next', tag: 'button' });
-        await driver.clickElement({ text: 'Import Tokens', tag: 'button' });
+        await driver.clickElement({ text: 'Import tokens', tag: 'button' });
 
         await driver.waitForSelector({
           css: '.token-overview__primary-balance',

--- a/test/e2e/tests/auto-lock.spec.js
+++ b/test/e2e/tests/auto-lock.spec.js
@@ -45,7 +45,7 @@ describe('Auto-Lock Timer', function () {
         // Verify the wallet is loccked
         const pageTitle = await driver.findElement('.unlock-page__title');
         const unlockButton = await driver.findElement('.unlock-page button');
-        assert.equal(await pageTitle.getText(), 'Welcome Back!');
+        assert.equal(await pageTitle.getText(), 'Welcome back!');
         assert.equal(await unlockButton.isDisplayed(), true);
       },
     );

--- a/test/e2e/tests/contract-interactions.spec.js
+++ b/test/e2e/tests/contract-interactions.spec.js
@@ -62,7 +62,7 @@ describe('Deploy contract and call contract methods', function () {
         );
         const completedTx = await driver.findElement('.list-item__title');
         const completedTxText = await completedTx.getText();
-        assert.equal(completedTxText, 'Contract Deployment');
+        assert.equal(completedTxText, 'Contract deployment');
 
         // calls and confirms a contract method where ETH is sent
         await driver.switchToWindow(dapp);

--- a/test/e2e/tests/custom-rpc-history.spec.js
+++ b/test/e2e/tests/custom-rpc-history.spec.js
@@ -33,7 +33,7 @@ describe('Stores custom RPC history', function () {
 
         await driver.clickElement('.network-display');
 
-        await driver.clickElement({ text: 'Add Network', tag: 'button' });
+        await driver.clickElement({ text: 'Add network', tag: 'button' });
 
         await driver.findElement('.networks-tab__sub-header-text');
 
@@ -83,7 +83,7 @@ describe('Stores custom RPC history', function () {
 
         await driver.clickElement('.network-display');
 
-        await driver.clickElement({ text: 'Add Network', tag: 'button' });
+        await driver.clickElement({ text: 'Add network', tag: 'button' });
 
         await driver.findElement('.networks-tab__sub-header-text');
 
@@ -121,7 +121,7 @@ describe('Stores custom RPC history', function () {
 
         await driver.clickElement('.network-display');
 
-        await driver.clickElement({ text: 'Add Network', tag: 'button' });
+        await driver.clickElement({ text: 'Add network', tag: 'button' });
 
         await driver.findElement('.networks-tab__sub-header-text');
 
@@ -213,7 +213,7 @@ describe('Stores custom RPC history', function () {
         await driver.delay(largeDelayMs);
         await driver.clickElement('.network-display');
 
-        await driver.clickElement({ text: 'Add Network', tag: 'button' });
+        await driver.clickElement({ text: 'Add network', tag: 'button' });
 
         await driver.findVisibleElement('.settings-page__content');
         // // cancel new custom rpc

--- a/test/e2e/tests/custom-token-add-approve.spec.js
+++ b/test/e2e/tests/custom-token-add-approve.spec.js
@@ -64,7 +64,7 @@ describe.skip('Create token, approve token and approve token without gas', funct
 
           await driver.clickElement({ text: 'import tokens', tag: 'a' });
           await driver.clickElement({
-            text: 'Custom Token',
+            text: 'Custom token',
             tag: 'button',
           });
           await driver.waitForSelector('#custom-address');
@@ -74,13 +74,13 @@ describe.skip('Create token, approve token and approve token without gas', funct
           await driver.delay(2000);
 
           await driver.clickElement({
-            text: 'Add Custom Token',
+            text: 'Add custom token',
             tag: 'button',
           });
 
           await driver.delay(2000);
           await driver.clickElement({
-            text: 'Import Tokens',
+            text: 'Import tokens',
             tag: 'button',
           });
 

--- a/test/e2e/tests/eth-sign.spec.js
+++ b/test/e2e/tests/eth-sign.spec.js
@@ -42,7 +42,7 @@ describe('Eth sign', function () {
           '.request-signature__header__text',
         );
         const origin = await driver.findElement('.request-signature__origin');
-        assert.equal(await title.getText(), 'Signature Request');
+        assert.equal(await title.getText(), 'Signature request');
         assert.equal(await origin.getText(), 'http://127.0.0.1:8080');
 
         const personalMessageRow = await driver.findElement(

--- a/test/e2e/tests/failing-contract.spec.js
+++ b/test/e2e/tests/failing-contract.spec.js
@@ -49,7 +49,7 @@ describe('Failing contract interaction ', function () {
         );
         const completedTx = await driver.findElement('.list-item__title');
         const completedTxText = await completedTx.getText();
-        assert.equal(completedTxText, 'Contract Deployment');
+        assert.equal(completedTxText, 'Contract deployment');
 
         // calls failing contract method
         await driver.switchToWindow(dapp);

--- a/test/e2e/tests/from-import-ui.spec.js
+++ b/test/e2e/tests/from-import-ui.spec.js
@@ -77,9 +77,9 @@ describe('MetaMask Import UI', function () {
         await driver.clickElement('.network-display');
         await driver.clickElement({ text: 'Localhost', tag: 'span' });
 
-        // choose Create Account from the account menu
+        // choose Create account from the account menu
         await driver.clickElement('.account-menu__icon');
-        await driver.clickElement({ text: 'Create Account', tag: 'div' });
+        await driver.clickElement({ text: 'Create account', tag: 'div' });
 
         // set account name
         await driver.fill('.new-account-create-form input', '2nd account');
@@ -202,9 +202,9 @@ describe('MetaMask Import UI', function () {
         await driver.press('#password', driver.Key.ENTER);
 
         // Imports an account with private key
-        // choose Create Account from the account menu
+        // choose Create account from the account menu
         await driver.clickElement('.account-menu__icon');
-        await driver.clickElement({ text: 'Import Account', tag: 'div' });
+        await driver.clickElement({ text: 'Import account', tag: 'div' });
 
         // enter private key',
         await driver.fill('#private-key-box', testPrivateKey1);
@@ -231,8 +231,8 @@ describe('MetaMask Import UI', function () {
         assert.equal(await importedLabel.getText(), 'IMPORTED');
 
         // Imports and removes an account
-        // choose Create Account from the account menu
-        await driver.clickElement({ text: 'Import Account', tag: 'div' });
+        // choose Create account from the account menu
+        await driver.clickElement({ text: 'Import account', tag: 'div' });
         // enter private key
         await driver.fill('#private-key-box', testPrivateKey2);
         await driver.clickElement({ text: 'Import', tag: 'button' });
@@ -306,7 +306,7 @@ describe('MetaMask Import UI', function () {
 
         // Imports an account with JSON file
         await driver.clickElement('.account-menu__icon');
-        await driver.clickElement({ text: 'Import Account', tag: 'div' });
+        await driver.clickElement({ text: 'Import account', tag: 'div' });
 
         await driver.clickElement('.new-account-import-form__select');
         await driver.clickElement({ text: 'JSON File', tag: 'option' });
@@ -379,7 +379,7 @@ describe('MetaMask Import UI', function () {
 
         // choose Import Account from the account menu
         await driver.clickElement('.account-menu__icon');
-        await driver.clickElement({ text: 'Import Account', tag: 'div' });
+        await driver.clickElement({ text: 'Import account', tag: 'div' });
 
         // enter private key',
         await driver.fill('#private-key-box', testPrivateKey);
@@ -416,10 +416,10 @@ describe('MetaMask Import UI', function () {
         await driver.fill('#password', 'correct horse battery staple');
         await driver.press('#password', driver.Key.ENTER);
 
-        // choose Connect Hardware Wallet from the account menu
+        // choose Connect hardware wallet from the account menu
         await driver.clickElement('.account-menu__icon');
         await driver.clickElement({
-          text: 'Connect Hardware Wallet',
+          text: 'Connect hardware wallet',
           tag: 'div',
         });
         await driver.delay(regularDelayMs);

--- a/test/e2e/tests/incremental-security.spec.js
+++ b/test/e2e/tests/incremental-security.spec.js
@@ -42,7 +42,7 @@ describe('Incremental Security', function () {
         await driver.clickElement('.btn-secondary');
 
         // clicks the "Create New Wallet" option
-        await driver.clickElement({ text: 'Create a Wallet', tag: 'button' });
+        await driver.clickElement({ text: 'Create a wallet', tag: 'button' });
 
         // accepts a secure password
         await driver.fill(
@@ -156,7 +156,7 @@ describe('Incremental Security', function () {
         await driver.clickElement({ text: 'Confirm', tag: 'button' });
 
         // can click through the success screen
-        await driver.clickElement({ text: 'All Done', tag: 'button' });
+        await driver.clickElement({ text: 'All done', tag: 'button' });
 
         // should have the correct amount of eth
         currencyDisplay = await driver.waitForSelector({

--- a/test/e2e/tests/metamask-responsive-ui.spec.js
+++ b/test/e2e/tests/metamask-responsive-ui.spec.js
@@ -87,11 +87,11 @@ describe('MetaMask Responsive UI', function () {
           });
           await driver.delay(tinyDelayMs);
 
-          // clicks the "I Agree" option on the metametrics opt-in screen
+          // clicks the "I agree" option on the metametrics opt-in screen
           await driver.clickElement('.btn-primary');
 
           // clicks the "Create New Wallet" option
-          await driver.clickElement({ text: 'Create a Wallet', tag: 'button' });
+          await driver.clickElement({ text: 'Create a wallet', tag: 'button' });
 
           // accepts a secure password
           await driver.fill(

--- a/test/e2e/tests/navigate-transactions.spec.js
+++ b/test/e2e/tests/navigate-transactions.spec.js
@@ -222,7 +222,7 @@ describe('Navigate transactions', function () {
 
         // reject transactions
         await driver.clickElement({ text: 'Reject 4', tag: 'a' });
-        await driver.clickElement({ text: 'Reject All', tag: 'button' });
+        await driver.clickElement({ text: 'Reject all', tag: 'button' });
         const balance = await driver.findElement(
           '[data-testid="eth-overview__primary-currency"]',
         );

--- a/test/e2e/tests/send-hex-address.spec.js
+++ b/test/e2e/tests/send-hex-address.spec.js
@@ -174,7 +174,7 @@ describe('Send ERC20 to a 40 character hexadecimal address', function () {
           'MetaMask Notification',
           windowHandles,
         );
-        await driver.clickElement({ text: 'Add Token', tag: 'button' });
+        await driver.clickElement({ text: 'Add token', tag: 'button' });
         await driver.waitUntilXWindowHandles(2);
         await driver.switchToWindow(extension);
 
@@ -273,7 +273,7 @@ describe('Send ERC20 to a 40 character hexadecimal address', function () {
           'MetaMask Notification',
           windowHandles,
         );
-        await driver.clickElement({ text: 'Add Token', tag: 'button' });
+        await driver.clickElement({ text: 'Add token', tag: 'button' });
         await driver.waitUntilXWindowHandles(2);
         await driver.switchToWindow(extension);
 

--- a/test/e2e/tests/send-to-contract.spec.js
+++ b/test/e2e/tests/send-to-contract.spec.js
@@ -57,7 +57,7 @@ describe('Send ERC20 token to contract address', function () {
           'MetaMask Notification',
           windowHandles,
         );
-        await driver.clickElement({ text: 'Add Token', tag: 'button' });
+        await driver.clickElement({ text: 'Add token', tag: 'button' });
         await driver.waitUntilXWindowHandles(2);
         await driver.switchToWindow(extension);
 

--- a/test/e2e/tests/settings-search.spec.js
+++ b/test/e2e/tests/settings-search.spec.js
@@ -12,14 +12,14 @@ describe('Settings Search', function () {
     ],
   };
   const settingsSearch = {
-    general: 'Primary Currency',
-    advanced: 'State Logs',
+    general: 'Primary currency',
+    advanced: 'State logs',
     contacts: 'Contacts',
     security: 'Reveal Secret',
     alerts: 'Browsing a website',
     networks: 'Ethereum Mainnet',
     experimental: 'Token Detection',
-    about: 'Terms of Use',
+    about: 'Terms of use',
   };
 
   it('should find element inside the General tab', async function () {

--- a/test/e2e/tests/signature-request.spec.js
+++ b/test/e2e/tests/signature-request.spec.js
@@ -55,7 +55,7 @@ describe('Sign Typed Data V4 Signature Request', function () {
         const message = await driver.findElement(
           '.signature-request-message--node-value',
         );
-        assert.equal(await title.getText(), 'Signature Request');
+        assert.equal(await title.getText(), 'Signature request');
         assert.equal(await name.getText(), 'Ether Mail');
         assert.equal(await origin.getText(), 'http://127.0.0.1:8080');
         assert.equal(
@@ -137,7 +137,7 @@ describe('Sign Typed Data V3 Signature Request', function () {
         const messages = await driver.findElements(
           '.signature-request-message--node-value',
         );
-        assert.equal(await title.getText(), 'Signature Request');
+        assert.equal(await title.getText(), 'Signature request');
         assert.equal(await name.getText(), 'Ether Mail');
         assert.equal(await origin.getText(), 'http://127.0.0.1:8080');
         assert.equal(
@@ -208,7 +208,7 @@ describe('Sign Typed Data Signature Request', function () {
         const message = await driver.findElements(
           '.request-signature__row-value',
         );
-        assert.equal(await title.getText(), 'Signature Request');
+        assert.equal(await title.getText(), 'Signature request');
         assert.equal(await origin.getText(), 'http://127.0.0.1:8080');
         assert.equal(await message[0].getText(), 'Hi, Alice!');
         assert.equal(await message[1].getText(), '1337');

--- a/test/e2e/tests/state-logs.spec.js
+++ b/test/e2e/tests/state-logs.spec.js
@@ -11,7 +11,7 @@ const createDownloadFolder = async () => {
 
 const stateLogsExist = async () => {
   try {
-    const stateLogs = `${downloadsFolder}/MetaMask State Logs.json`;
+    const stateLogs = `${downloadsFolder}/MetaMask state logs.json`;
     await fs.access(stateLogs);
     return true;
   } catch (e) {
@@ -43,12 +43,12 @@ describe('State logs', function () {
         await driver.fill('#password', 'correct horse battery staple');
         await driver.press('#password', driver.Key.ENTER);
 
-        // Download State Logs
+        // Download state logs
         await driver.clickElement('.account-menu__icon');
         await driver.clickElement({ text: 'Settings', tag: 'div' });
         await driver.clickElement({ text: 'Advanced', tag: 'div' });
         await driver.clickElement({
-          text: 'Download State Logs',
+          text: 'Download state logs',
           tag: 'button',
         });
 

--- a/test/e2e/tests/swap-eth.spec.js
+++ b/test/e2e/tests/swap-eth.spec.js
@@ -47,7 +47,7 @@ describe('Swap Eth for another Token', function () {
         await driver.clickElement(
           '[class="searchable-item-list__primary-label"]',
         );
-        await driver.clickElement({ text: 'Review Swap', tag: 'button' });
+        await driver.clickElement({ text: 'Review swap', tag: 'button' });
         await driver.waitForSelector('[class*="box--align-items-center"]');
         const estimatedEth = await driver.waitForSelector({
           css: '[class*="box--align-items-center"]',

--- a/test/e2e/tests/token-details.spec.js
+++ b/test/e2e/tests/token-details.spec.js
@@ -24,7 +24,7 @@ describe('Token Details', function () {
         await driver.press('#password', driver.Key.ENTER);
 
         await driver.clickElement({ text: 'import tokens', tag: 'a' });
-        await driver.clickElement({ text: 'Custom Token', tag: 'button' });
+        await driver.clickElement({ text: 'Custom token', tag: 'button' });
 
         const tokenAddress = '0x2EFA2Cb29C2341d8E5Ba7D3262C9e9d6f1Bf3711';
         const tokenSymbol = 'AAVE';
@@ -32,8 +32,8 @@ describe('Token Details', function () {
         await driver.fill('#custom-address', tokenAddress);
         await driver.waitForSelector('#custom-symbol-helper-text');
         await driver.fill('#custom-symbol', tokenSymbol);
-        await driver.clickElement({ text: 'Add Custom Token', tag: 'button' });
-        await driver.clickElement({ text: 'Import Tokens', tag: 'button' });
+        await driver.clickElement({ text: 'Add custom token', tag: 'button' });
+        await driver.clickElement({ text: 'Import tokens', tag: 'button' });
         await driver.clickElement('[title="Asset options"]');
         await driver.clickElement({ text: 'Token details', tag: 'span' });
 

--- a/ui/components/app/account-menu/account-menu.component.js
+++ b/ui/components/app/account-menu/account-menu.component.js
@@ -358,7 +358,7 @@ export default class AccountMenu extends Component {
             toggleAccountMenu();
             trackEvent({
               category: EVENT.CATEGORIES.NAVIGATION,
-              event: 'Clicked Create Account',
+              event: 'Clicked Create account',
               properties: {
                 action: 'Main Menu',
                 legacy_event: true,

--- a/ui/components/app/account-menu/account-menu.test.js
+++ b/ui/components/app/account-menu/account-menu.test.js
@@ -105,12 +105,12 @@ describe('Account Menu', () => {
 
   describe('Create Account', () => {
     it('renders create account item', () => {
-      const createAccount = screen.getByText('Create Account');
+      const createAccount = screen.getByText('Create account');
       expect(createAccount).toBeInTheDocument();
     });
 
     it('calls toggle menu and push new-account route to history', () => {
-      const createAccount = screen.getByText('Create Account');
+      const createAccount = screen.getByText('Create account');
       fireEvent.click(createAccount);
       expect(props.toggleAccountMenu.calledOnce).toStrictEqual(true);
       expect(props.history.push.getCall(0).args[0]).toStrictEqual(
@@ -121,12 +121,12 @@ describe('Account Menu', () => {
 
   describe('Import Account', () => {
     it('renders import account item', () => {
-      const importAccount = screen.getByText('Import Account');
+      const importAccount = screen.getByText('Import account');
       expect(importAccount).toBeInTheDocument();
     });
 
     it('calls toggle menu and push /new-account/import route to history', () => {
-      const importAccount = screen.getByText('Import Account');
+      const importAccount = screen.getByText('Import account');
       fireEvent.click(importAccount);
       expect(props.toggleAccountMenu.calledOnce).toStrictEqual(true);
       expect(props.history.push.getCall(0).args[0]).toStrictEqual(
@@ -135,14 +135,14 @@ describe('Account Menu', () => {
     });
   });
 
-  describe('Connect Hardware Wallet', () => {
+  describe('Connect hardware wallet', () => {
     it('renders import account item', () => {
-      const connectHardwareWallet = screen.getByText('Connect Hardware Wallet');
+      const connectHardwareWallet = screen.getByText('Connect hardware wallet');
       expect(connectHardwareWallet).toBeInTheDocument();
     });
 
     it('calls toggle menu and push /new-account/connect route to history', () => {
-      const connectHardwareWallet = screen.getByText('Connect Hardware Wallet');
+      const connectHardwareWallet = screen.getByText('Connect hardware wallet');
       fireEvent.click(connectHardwareWallet);
       expect(props.toggleAccountMenu.calledOnce).toStrictEqual(true);
       expect(props.history.push.getCall(0).args[0]).toStrictEqual(
@@ -155,12 +155,12 @@ describe('Account Menu', () => {
     global.platform = { openTab: sinon.spy() };
 
     it('renders import account item', () => {
-      const support = screen.getByText('Submit a Ticket');
+      const support = screen.getByText('Submit a ticket');
       expect(support).toBeInTheDocument();
     });
 
     it('opens support link when clicked', () => {
-      const support = screen.getByText('Submit a Ticket');
+      const support = screen.getByText('Submit a ticket');
       fireEvent.click(support);
       expect(global.platform.openTab.calledOnce).toStrictEqual(true);
     });

--- a/ui/components/app/advanced-gas-controls/advanced-gas-controls.test.js
+++ b/ui/components/app/advanced-gas-controls/advanced-gas-controls.test.js
@@ -22,7 +22,7 @@ describe('AdvancedGasControls Component', () => {
 
   it('should not render maxFee and maxPriorityFee inputs if supportsEIP1559 is false', () => {
     const { queryByText } = renderComponent({ supportsEIP1559: false });
-    expect(queryByText('Gas Limit')).toBeInTheDocument();
+    expect(queryByText('Gas limit')).toBeInTheDocument();
     expect(queryByText('Gas price')).toBeInTheDocument();
     expect(queryByText('Max fee')).not.toBeInTheDocument();
     expect(queryByText('Max priority fee')).not.toBeInTheDocument();
@@ -34,7 +34,7 @@ describe('AdvancedGasControls Component', () => {
       supportsEIP1559: true,
     });
     expect(queryByText('Gas price')).not.toBeInTheDocument();
-    expect(queryByText('Gas Limit')).toBeInTheDocument();
+    expect(queryByText('Gas limit')).toBeInTheDocument();
     expect(queryByText('Max fee')).toBeInTheDocument();
     expect(queryByText('Max priority fee')).toBeInTheDocument();
   });

--- a/ui/components/app/cancel-speedup-popover/cancel-speedup-popover.test.js
+++ b/ui/components/app/cancel-speedup-popover/cancel-speedup-popover.test.js
@@ -118,9 +118,9 @@ describe('CancelSpeedupPopover', () => {
     expect(screen.queryByText('❌Cancel')).toBeInTheDocument();
   });
 
-  it('should have 🚀Speed Up in header if editGasMode is speedup', async () => {
+  it('should have 🚀Speed up in header if editGasMode is speedup', async () => {
     await act(async () => render({ editGasMode: EDIT_GAS_MODES.SPEED_UP }));
-    expect(screen.queryByText('🚀Speed Up')).toBeInTheDocument();
+    expect(screen.queryByText('🚀Speed up')).toBeInTheDocument();
   });
 
   it('information tooltip should contain the correct text if editGasMode is cancel', async () => {
@@ -137,7 +137,7 @@ describe('CancelSpeedupPopover', () => {
     expect(
       InfoTooltip.mock.calls[0][0].contentText.props.children[0],
     ).toStrictEqual(
-      'To Speed Up a transaction the gas fee must be increased by at least 10% for it to be recognized by the network.',
+      'To Speed up a transaction the gas fee must be increased by at least 10% for it to be recognized by the network.',
     );
   });
 

--- a/ui/components/app/collectibles-tab/collectibles-tab.test.js
+++ b/ui/components/app/collectibles-tab/collectibles-tab.test.js
@@ -313,13 +313,13 @@ describe('Collectible Items', () => {
       ).toHaveBeenCalled();
     });
 
-    it('should render a link "Enable Autodetect" when some collectibles are present and collectible auto-detection preference is set to false, which, when clicked sends user to the experimental tab of settings', () => {
+    it('should render a link "Enable autodetect" when some collectibles are present and collectible auto-detection preference is set to false, which, when clicked sends user to the experimental tab of settings', () => {
       render({
         selectedAddress: ACCOUNT_1,
         collectibles: COLLECTIBLES,
       });
       expect(historyPushMock).toHaveBeenCalledTimes(0);
-      fireEvent.click(screen.queryByText('Enable Autodetect'));
+      fireEvent.click(screen.queryByText('Enable autodetect'));
       expect(historyPushMock).toHaveBeenCalledTimes(1);
       expect(historyPushMock).toHaveBeenCalledWith(EXPERIMENTAL_ROUTE);
     });

--- a/ui/components/app/confirm-page-container/confirm-page-container-content/confirm-page-container-content.component.test.js
+++ b/ui/components/app/confirm-page-container/confirm-page-container-content/confirm-page-container-content.component.test.js
@@ -70,7 +70,7 @@ describe('Confirm Page Container Content', () => {
     expect(queryByText('I want to proceed anyway')).not.toBeInTheDocument();
     expect(getByText('Confirm').closest('button')).toBeDisabled();
     expect(
-      getByText('Transaction Error. Exception thrown in contract code.'),
+      getByText('Transaction error. Exception thrown in contract code.'),
     ).toBeInTheDocument();
 
     const cancelButton = getByText('Reject');
@@ -91,7 +91,7 @@ describe('Confirm Page Container Content', () => {
       ),
     ).not.toBeInTheDocument();
     expect(
-      queryByText('Transaction Error. Exception thrown in contract code.'),
+      queryByText('Transaction error. Exception thrown in contract code.'),
     ).not.toBeInTheDocument();
     expect(queryByText('I want to proceed anyway')).not.toBeInTheDocument();
 

--- a/ui/components/app/dropdowns/network-dropdown.test.js
+++ b/ui/components/app/dropdowns/network-dropdown.test.js
@@ -109,7 +109,7 @@ describe('Network Dropdown', () => {
     });
 
     it('checks that Add Network button is rendered', () => {
-      const addNetworkButton = screen.queryByText('Add Network');
+      const addNetworkButton = screen.queryByText('Add network');
       expect(addNetworkButton).toBeInTheDocument();
     });
 
@@ -157,7 +157,7 @@ describe('Network Dropdown', () => {
     });
 
     it('checks that Add Network button is rendered', () => {
-      const addNetworkButton = screen.queryByText('Add Network');
+      const addNetworkButton = screen.queryByText('Add network');
       expect(addNetworkButton).toBeInTheDocument();
     });
 

--- a/ui/components/app/edit-gas-display/edit-gas-display.component.js
+++ b/ui/components/app/edit-gas-display/edit-gas-display.component.js
@@ -279,7 +279,7 @@ export default function EditGasDisplay({
               onClick={() => {
                 setShowAdvancedForm(!showAdvancedForm);
                 trackEvent({
-                  event: 'Clicked "Advanced Options"',
+                  event: 'Clicked "Advanced options"',
                   category: EVENT.CATEGORIES.TRANSACTIONS,
                   properties: {
                     action: 'Edit Screen',

--- a/ui/components/app/gas-customization/advanced-gas-inputs/advanced-gas-inputs.test.js
+++ b/ui/components/app/gas-customization/advanced-gas-inputs/advanced-gas-inputs.test.js
@@ -105,7 +105,7 @@ describe('AdvancedGasInputs', () => {
       store,
     );
 
-    expect(queryByText('Gas Price Extremely Low')).toBeInTheDocument();
+    expect(queryByText('Gas price extremely low')).toBeInTheDocument();
   });
 
   it('errors when custom gas price is too excessive', () => {
@@ -114,6 +114,6 @@ describe('AdvancedGasInputs', () => {
       store,
     );
 
-    expect(queryByText('Gas Price Is Excessive')).toBeInTheDocument();
+    expect(queryByText('Gas price is excessive')).toBeInTheDocument();
   });
 });

--- a/ui/components/app/import-token-link/import-token-link.component.js
+++ b/ui/components/app/import-token-link/import-token-link.component.js
@@ -44,7 +44,7 @@ export default function ImportTokenLink() {
         onClick={() => {
           history.push(IMPORT_TOKEN_ROUTE);
           trackEvent({
-            event: 'Clicked "Add Token"',
+            event: 'Clicked "Add token"',
             category: EVENT.CATEGORIES.NAVIGATION,
             properties: {
               action: 'Token Menu',

--- a/ui/components/app/transaction-breakdown/transaction-breakdown.test.js
+++ b/ui/components/app/transaction-breakdown/transaction-breakdown.test.js
@@ -49,7 +49,7 @@ describe('TransactionBreakdown', () => {
       ).toStrictEqual([
         ['Nonce', '29'],
         ['Amount', '-0.01 ETH'],
-        ['Gas Limit (units)', '46890'],
+        ['Gas limit (units)', '46890'],
         ['Gas price', '2.467043803'],
         ['Total', '0.01011568ETH'],
       ]);
@@ -84,12 +84,12 @@ describe('TransactionBreakdown', () => {
       ).toStrictEqual([
         ['Nonce', '29'],
         ['Amount', '-0.01 ETH'],
-        ['Gas Limit (units)', '46890'],
-        ['Gas Used (units)', '31260'],
-        ['Base Fee (GWEI)', '0.000000007'],
-        ['Priority Fee (GWEI)', '2.467043796'],
-        ['Total Gas Fee', '0.000077ETH'],
-        ['Max Fee Per Gas', '0.000000003ETH'],
+        ['Gas limit (units)', '46890'],
+        ['Gas used (units)', '31260'],
+        ['Base fee (GWEI)', '0.000000007'],
+        ['Priority fee (GWEI)', '2.467043796'],
+        ['Total gas fee', '0.000077ETH'],
+        ['Max fee per gas', '0.000000003ETH'],
         ['Total', '0.01007712ETH'],
       ]);
     });

--- a/ui/components/ui/definition-list/definition-list.stories.js
+++ b/ui/components/ui/definition-list/definition-list.stories.js
@@ -16,13 +16,13 @@ const basic = {
 };
 
 const advanced = {
-  'Network Name': 'Ethereum Mainnet',
+  'Network name': 'Ethereum Mainnet',
   'Chain ID': '1',
   Ticker: 'ETH',
 };
 
 const tooltips = {
-  'Network Name': 'The name that is associated with this network',
+  'Network name': 'The name that is associated with this network',
   'Chain ID': 'The numeric value representing the ID of this network',
   Ticker: 'The currency symbol of the primary currency for this network',
 };

--- a/ui/components/ui/list-item/list-item.stories.js
+++ b/ui/components/ui/list-item/list-item.stories.js
@@ -79,7 +79,7 @@ export const SendComponent = (args) => (
 SendComponent.argTypes = {
   secondaryButtonText: {
     control: 'text',
-    defaultValue: 'Speed Up',
+    defaultValue: 'Speed up',
   },
   cancelButtonText: {
     control: 'text',

--- a/ui/components/ui/truncated-definition-list/truncated-definition-list.stories.js
+++ b/ui/components/ui/truncated-definition-list/truncated-definition-list.stories.js
@@ -19,13 +19,13 @@ const basic = {
 };
 
 const advanced = {
-  'Network Name': 'Ethereum Mainnet',
+  'Network name': 'Ethereum Mainnet',
   'Chain ID': '1',
   Ticker: 'ETH',
 };
 
 const tooltips = {
-  'Network Name': 'The name that is associated with this network',
+  'Network name': 'The name that is associated with this network',
   'Chain ID': 'The numeric value representing the ID of this network',
   Ticker: 'The currency symbol of the primary currency for this network',
 };

--- a/ui/ducks/ens.js
+++ b/ui/ducks/ens.js
@@ -65,7 +65,7 @@ const slice = createSlice({
             network === MAINNET_NETWORK_ID
               ? ENS_NO_ADDRESS_FOR_NAME
               : ENS_NOT_FOUND_ON_NETWORK;
-        } else if (error.message === 'Illegal Character for ENS.') {
+        } else if (error.message === 'Illegal character for ENS.') {
           state.error = ENS_ILLEGAL_CHARACTER;
         } else {
           log.error(error);

--- a/ui/helpers/utils/settings-search.test.js
+++ b/ui/helpers/utils/settings-search.test.js
@@ -10,27 +10,27 @@ const t = (key) => {
     case 'general':
       return 'General';
     case 'currencyConversion':
-      return 'Currency Conversion';
+      return 'Currency conversion';
     case 'primaryCurrencySetting':
-      return 'Primary Currency';
+      return 'Primary currency';
     case 'primaryCurrencySettingDescription':
       return 'Select native to prioritize displaying values in the native currency of the chain (e.g. ETH). Select Fiat to prioritize displaying values in your selected fiat currency.';
     case 'currentLanguage':
-      return 'Current Language';
+      return 'Current language';
     case 'accountIdenticon':
-      return 'Current Language"';
+      return 'Current language"';
     case 'hideZeroBalanceTokens':
-      return 'Hide Tokens Without Balance';
+      return 'Hide tokens without balance';
     case 'advanced':
       return 'Advanced';
     case 'stateLogs':
-      return 'State Logs';
+      return 'State logs';
     case 'stateLogsDescription':
       return 'State logs contain your public account addresses and sent transactions.';
     case 'syncWithMobile':
       return 'Sync with mobile';
     case 'resetAccount':
-      return 'Reset Account';
+      return 'Reset account';
     case 'resetAccountDescription':
       return 'Resetting your account will clear your transaction history. This will not change the balances in your accounts or require you to re-enter your Secret Recovery Phrase.';
     case 'showAdvancedGasInline':
@@ -38,11 +38,11 @@ const t = (key) => {
     case 'showAdvancedGasInlineDescription':
       return 'Select this to show gas price and limit controls directly on the send and confirm screens.';
     case 'showHexData':
-      return 'Show Hex Data';
+      return 'Show hex data';
     case 'showHexDataDescription':
       return 'Select this to show the hex data field on the send screen';
     case 'showFiatConversionInTestnets':
-      return 'Show Conversion on test networks';
+      return 'Show conversion on test networks';
     case 'showFiatConversionInTestnetsDescription':
       return 'Select this to show fiat conversion on test network';
     case 'showTestnetNetworks':
@@ -54,7 +54,7 @@ const t = (key) => {
     case 'nonceFieldDescription':
       return 'Turn this on to change the nonce (transaction number) on confirmation screens. This is an advanced feature, use cautiously.';
     case 'autoLockTimeLimit':
-      return 'Auto-Lock Timer (minutes)';
+      return 'Auto-lock timer (minutes)';
     case 'autoLockTimeLimitDescription':
       return 'Set the idle time in minutes before MetaMask will become locked.';
     case 'syncWithThreeBox':
@@ -66,7 +66,7 @@ const t = (key) => {
     case 'ipfsGatewayDescription':
       return 'Enter the URL of the IPFS CID gateway to use for ENS content resolution.';
     case 'preferredLedgerConnectionType':
-      return 'Preferred Ledger Connection Type';
+      return 'Preferred ledger connection type';
     case 'dismissReminderField':
       return 'Dismiss Secret Recovery Phrase backup reminder';
     case 'dismissReminderDescriptionField':
@@ -74,15 +74,15 @@ const t = (key) => {
     case 'Contacts':
       return 'Contacts';
     case 'securityAndPrivacy':
-      return 'Security & Privacy';
+      return 'Security & privacy';
     case 'revealSeedWords':
       return 'Reveal Secret Recovery Phrase';
     case 'showIncomingTransactions':
-      return 'Show Incoming Transactions';
+      return 'Show incoming transactions';
     case 'showIncomingTransactionsDescription':
       return 'Select this to use Etherscan to show incoming transactions in the transactions list';
     case 'usePhishingDetection':
-      return 'Use Phishing Detection';
+      return 'Use phishing detection';
     case 'usePhishingDetectionDescription':
       return 'Display a warning for phishing domains targeting Ethereum users';
     case 'participateInMetaMetrics':
@@ -102,18 +102,18 @@ const t = (key) => {
     case 'ropsten':
       return 'Ropsten Test Network';
     case 'rinkeby':
-      return 'Rinkeby Test Network';
+      return 'Rinkeby test network';
     case 'goerli':
-      return 'Goerli Test Network';
+      return 'Goerli test network';
     case 'kovan':
-      return 'Kovan Test Network';
+      return 'Kovan test network';
     case 'localhost':
       return 'Localhost 8545';
     case 'experimental':
       return 'Experimental';
     /** TODO: Remove during TOKEN_DETECTION_V2 feature flag clean up */
     case 'useTokenDetection':
-      return 'Use Token Detection';
+      return 'Use token detection';
     case 'useTokenDetectionDescription':
       return 'We use third-party APIs to detect and display new tokens sent to your wallet. Turn off if you don’t want MetaMask to pull data from those services.';
     case 'tokenDetection':
@@ -121,7 +121,7 @@ const t = (key) => {
     case 'tokenDetectionToggleDescription':
       return 'ConsenSys’ token API aggregates a list of tokens from various third party token lists. Turning it off will stop detecting new tokens added to your wallet, but will keep the option to search for tokens to import.';
     case 'enableEIP1559V2':
-      return 'Enable Enhanced Gas Fee UI';
+      return 'Enable enhanced gas fee UI';
     case 'enableEIP1559V2Description':
       return "We've updated how gas estimation and customization works. Turn on if you'd like to use the new gas experience. Learn more";
     case 'enableOpenSeaAPI':
@@ -141,13 +141,13 @@ const t = (key) => {
     case 'links':
       return 'Links';
     case 'privacyMsg':
-      return 'Privacy Policy';
+      return 'Privacy policy';
     case 'terms':
-      return 'Terms of Use';
+      return 'Terms of use';
     case 'attributions':
       return 'Attributions';
     case 'supportCenter':
-      return 'Visit our Support Center';
+      return 'Visit our support center';
     case 'visitWebSite':
       return 'Visit our web site';
     case 'contactUs':

--- a/ui/hooks/useTransactionDisplayData.test.js
+++ b/ui/hooks/useTransactionDisplayData.test.js
@@ -118,7 +118,7 @@ const expectedResults = [
     displayedStatusKey: TRANSACTION_STATUSES.CONFIRMED,
   },
   {
-    title: 'Contract Deployment',
+    title: 'Contract deployment',
     category: TRANSACTION_GROUP_CATEGORIES.INTERACTION,
     subtitle: 'metamask.github.io',
     subtitleContainsOrigin: true,
@@ -131,7 +131,7 @@ const expectedResults = [
     displayedStatusKey: TRANSACTION_STATUSES.CONFIRMED,
   },
   {
-    title: 'Safe Transfer From',
+    title: 'Safe transfer from',
     category: TRANSACTION_GROUP_CATEGORIES.SEND,
     subtitle: 'To: 0xe7d...dd98',
     subtitleContainsOrigin: true,

--- a/ui/pages/confirm-add-suggested-token/confirm-add-suggested-token.test.js
+++ b/ui/pages/confirm-add-suggested-token/confirm-add-suggested-token.test.js
@@ -57,7 +57,7 @@ describe('ConfirmAddSuggestedToken Component', () => {
   it('should render', () => {
     renderComponent();
 
-    expect(screen.getByText('Add Suggested Tokens')).toBeInTheDocument();
+    expect(screen.getByText('Add suggested tokens')).toBeInTheDocument();
     expect(
       screen.getByText('Would you like to import these tokens?'),
     ).toBeInTheDocument();
@@ -65,7 +65,7 @@ describe('ConfirmAddSuggestedToken Component', () => {
     expect(screen.getByText('Balance')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
     expect(
-      screen.getByRole('button', { name: 'Add Token' }),
+      screen.getByRole('button', { name: 'Add token' }),
     ).toBeInTheDocument();
   });
 
@@ -80,9 +80,9 @@ describe('ConfirmAddSuggestedToken Component', () => {
     );
   });
 
-  it('should dispatch acceptWatchAsset when clicking the "Add Token" button', () => {
+  it('should dispatch acceptWatchAsset when clicking the "Add token" button', () => {
     renderComponent();
-    const addTokenBtn = screen.getByRole('button', { name: 'Add Token' });
+    const addTokenBtn = screen.getByRole('button', { name: 'Add token' });
 
     fireEvent.click(addTokenBtn);
     expect(acceptWatchAsset).toHaveBeenCalled();

--- a/ui/pages/confirm-approve/confirm-approve-content/confirm-approve-content.component.test.js
+++ b/ui/pages/confirm-approve/confirm-approve-content/confirm-approve-content.component.test.js
@@ -53,8 +53,8 @@ describe('ConfirmApproveContent Component', () => {
     expect(queryByText('0x9bc5...fef4')).toBeInTheDocument();
     expect(queryByText('Hide full transaction details')).toBeInTheDocument();
 
-    expect(queryByText('Edit Permission')).toBeInTheDocument();
-    const editPermission = getByText('Edit Permission');
+    expect(queryByText('Edit permission')).toBeInTheDocument();
+    const editPermission = getByText('Edit permission');
     fireEvent.click(editPermission);
     expect(props.showEditApprovalPermissionModal).toHaveBeenCalledTimes(1);
 

--- a/ui/pages/confirm-import-token/confirm-import-token.test.js
+++ b/ui/pages/confirm-import-token/confirm-import-token.test.js
@@ -63,7 +63,7 @@ describe('ConfirmImportToken Component', () => {
   it('should render', () => {
     renderComponent();
 
-    const [title, importTokensBtn] = screen.queryAllByText('Import Tokens');
+    const [title, importTokensBtn] = screen.queryAllByText('Import tokens');
 
     expect(title).toBeInTheDocument(title);
     expect(
@@ -93,7 +93,7 @@ describe('ConfirmImportToken Component', () => {
     expect(mockHistoryPush).toHaveBeenCalledWith(IMPORT_TOKEN_ROUTE);
   });
 
-  it('should dispatch clearPendingTokens and redirect to the first token page when clicking the "Import Tokens" button', async () => {
+  it('should dispatch clearPendingTokens and redirect to the first token page when clicking the "Import tokens" button', async () => {
     const mockFirstPendingTokenAddress =
       '0xe83cccfabd4ed148903bf36d4283ee7c8b3494d1';
     const mockPendingTokens = {
@@ -113,7 +113,7 @@ describe('ConfirmImportToken Component', () => {
     renderComponent(mockPendingTokens);
 
     const importTokensBtn = screen.getByRole('button', {
-      name: 'Import Tokens',
+      name: 'Import tokens',
     });
 
     await fireEvent.click(importTokensBtn);

--- a/ui/pages/create-account/import-account/json.js
+++ b/ui/pages/create-account/import-account/json.js
@@ -121,7 +121,7 @@ class JsonImportSubview extends Component {
             category: EVENT.CATEGORIES.ACCOUNTS,
             event: 'Imported Account with JSON',
             properties: {
-              action: 'Import Account',
+              action: 'Import account',
               legacy_event: true,
             },
           });
@@ -132,7 +132,7 @@ class JsonImportSubview extends Component {
             category: EVENT.CATEGORIES.ACCOUNTS,
             event: 'Error importing JSON',
             properties: {
-              action: 'Import Account',
+              action: 'Import account',
               legacy_event: true,
             },
           });

--- a/ui/pages/create-account/import-account/private-key.js
+++ b/ui/pages/create-account/import-account/private-key.js
@@ -48,7 +48,7 @@ class PrivateKeyImportView extends Component {
             category: EVENT.CATEGORIES.ACCOUNTS,
             event: 'Imported Account with Private Key',
             properties: {
-              action: 'Import Account',
+              action: 'Import account',
               legacy_event: true,
             },
           });
@@ -60,7 +60,7 @@ class PrivateKeyImportView extends Component {
             category: EVENT.CATEGORIES.ACCOUNTS,
             event: 'Error importing with Private Key',
             properties: {
-              action: 'Import Account',
+              action: 'Import account',
               legacy_event: true,
             },
           });

--- a/ui/pages/first-time-flow/create-password/new-account/new-account.component.js
+++ b/ui/pages/first-time-flow/create-password/new-account/new-account.component.js
@@ -101,7 +101,7 @@ export default class NewAccount extends PureComponent {
         category: EVENT.CATEGORIES.ONBOARDING,
         event: 'Submit Password',
         properties: {
-          action: 'Create Password',
+          action: 'Create password',
           legacy_event: true,
         },
       });
@@ -117,7 +117,7 @@ export default class NewAccount extends PureComponent {
       category: EVENT.CATEGORIES.ONBOARDING,
       event: 'Check ToS',
       properties: {
-        action: 'Create Password',
+        action: 'Create password',
         legacy_event: true,
       },
     });
@@ -153,7 +153,7 @@ export default class NewAccount extends PureComponent {
                 category: EVENT.CATEGORIES.ONBOARDING,
                 event: 'Go Back from Onboarding Create',
                 properties: {
-                  action: 'Create Password',
+                  action: 'Create password',
                   legacy_event: true,
                 },
               });

--- a/ui/pages/import-token/README.mdx
+++ b/ui/pages/import-token/README.mdx
@@ -7,11 +7,12 @@ import configureStore from '../../store/store';
 const store = configureStore(testData);
 const { metamask } = store.getState();
 
-export const PersonalAddress = () => <code>{metamask.selectedAddress}</code>
+export const PersonalAddress = () => <code>{metamask.selectedAddress}</code>;
 
 # ImportToken
 
 The `ImportToken` component allows a user to import custom tokens in one of two ways:
+
 1. By searching for one
 2. By importing one by `Token Contract Address`
 
@@ -21,9 +22,10 @@ The `ImportToken` component allows a user to import custom tokens in one of two 
 
 ## Example inputs
 
-An example input that works, to enable the `Add Custom Token` button is `0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA`.
+An example input that works, to enable the `Add custom token` button is `0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA`.
 
 ### Personal address error
+
 To show the personal address detected error, input the address <PersonalAddress/> in the `Token Contract Address` field.
 
 ## Props

--- a/ui/pages/import-token/import-token.test.js
+++ b/ui/pages/import-token/import-token.test.js
@@ -51,18 +51,18 @@ describe('Import Token', () => {
   };
 
   describe('Import Token', () => {
-    it('add Custom Token button is disabled when no fields are populated', () => {
+    it('add custom token button is disabled when no fields are populated', () => {
       const { getByText } = render();
-      const customTokenButton = getByText('Custom Token');
+      const customTokenButton = getByText('Custom token');
       fireEvent.click(customTokenButton);
-      const submit = getByText('Add Custom Token');
+      const submit = getByText('Add custom token');
 
       expect(submit).toBeDisabled();
     });
 
     it('edits token address', () => {
       const { getByText } = render();
-      const customTokenButton = getByText('Custom Token');
+      const customTokenButton = getByText('Custom token');
       fireEvent.click(customTokenButton);
 
       const tokenAddress = '0x617b3f8050a0BD94b6b1da02B4384eE5B4DF13F4';
@@ -76,7 +76,7 @@ describe('Import Token', () => {
 
     it('edits token symbol', () => {
       const { getByText } = render();
-      const customTokenButton = getByText('Custom Token');
+      const customTokenButton = getByText('Custom token');
       fireEvent.click(customTokenButton);
 
       const tokenSymbol = 'META';
@@ -90,7 +90,7 @@ describe('Import Token', () => {
 
     it('edits token decimal precision', () => {
       const { getByText } = render();
-      const customTokenButton = getByText('Custom Token');
+      const customTokenButton = getByText('Custom token');
       fireEvent.click(customTokenButton);
 
       const tokenPrecision = '2';
@@ -104,10 +104,10 @@ describe('Import Token', () => {
 
     it('adds custom tokens successfully', async () => {
       const { getByText } = render();
-      const customTokenButton = getByText('Custom Token');
+      const customTokenButton = getByText('Custom token');
       fireEvent.click(customTokenButton);
 
-      const submit = getByText('Add Custom Token');
+      const submit = getByText('Add custom token');
       expect(submit).toBeDisabled();
 
       const tokenAddress = '0x617b3f8050a0BD94b6b1da02B4384eE5B4DF13F4';
@@ -157,10 +157,10 @@ describe('Import Token', () => {
       );
 
       const { getByText } = render();
-      const customTokenButton = getByText('Custom Token');
+      const customTokenButton = getByText('Custom token');
       fireEvent.click(customTokenButton);
 
-      const submit = getByText('Add Custom Token');
+      const submit = getByText('Add custom token');
       expect(submit).toBeDisabled();
 
       const tokenAddress = '0x617b3f8050a0BD94b6b1da02B4384eE5B4DF13F4';

--- a/ui/pages/keychains/restore-vault.test.js
+++ b/ui/pages/keychains/restore-vault.test.js
@@ -20,7 +20,7 @@ describe('Restore vault Component', () => {
       }),
     );
 
-    expect(getByText('Reset Wallet')).toBeInTheDocument();
+    expect(getByText('Reset wallet')).toBeInTheDocument();
     expect(
       getByText(
         'MetaMask does not keep a copy of your password. If you’re having trouble unlocking your account, you will need to reset your wallet. You can do this by providing the Secret Recovery Phrase you used when you set up your wallet.',

--- a/ui/pages/onboarding-flow/secure-your-wallet/secure-your-wallet.test.js
+++ b/ui/pages/onboarding-flow/secure-your-wallet/secure-your-wallet.test.js
@@ -35,9 +35,9 @@ describe('Secure Your Wallet Onboarding View', () => {
       store,
     );
     const remindMeLaterButton = getByText('Remind me later (not recommended)');
-    expect(queryAllByText('Skip Account Security?')).toHaveLength(0);
+    expect(queryAllByText('Skip account security?')).toHaveLength(0);
     fireEvent.click(remindMeLaterButton);
-    expect(queryAllByText('Skip Account Security?')).toHaveLength(1);
+    expect(queryAllByText('Skip account security?')).toHaveLength(1);
   });
 
   it('should not be able to click "skip" until "Skip Account Security" terms are agreed to', () => {

--- a/ui/pages/send/send-header/send-header.component.test.js
+++ b/ui/pages/send/send-header/send-header.component.test.js
@@ -85,7 +85,7 @@ describe('SendHeader Component', () => {
           history: { mostRecentOverviewPage: 'activity' },
         }),
       );
-      expect(getByText('Send Tokens')).toBeTruthy();
+      expect(getByText('Send tokens')).toBeTruthy();
     });
 
     it('should render "Edit" for EDIT stage', () => {
@@ -117,7 +117,7 @@ describe('SendHeader Component', () => {
       expect(getByText('Cancel')).toBeTruthy();
     });
 
-    it('has button label changed to Cancel Edit in editing stage', () => {
+    it('has button label changed to Cancel edit in editing stage', () => {
       const { getByText } = renderWithProvider(
         <SendHeader />,
         configureMockStore(middleware)({
@@ -129,7 +129,7 @@ describe('SendHeader Component', () => {
           history: { mostRecentOverviewPage: 'activity' },
         }),
       );
-      expect(getByText('Cancel Edit')).toBeTruthy();
+      expect(getByText('Cancel edit')).toBeTruthy();
     });
 
     it('resets send state when clicked', () => {

--- a/ui/pages/settings/experimental-tab/experimental-tab.component.test.js
+++ b/ui/pages/settings/experimental-tab/experimental-tab.component.test.js
@@ -11,7 +11,7 @@ describe('Experimental Tab', () => {
     setUseTokenDetection: sinon.spy(),
   };
 
-  it('toggles Use Token detection', () => {
+  it('toggles Use token detection', () => {
     wrapper = mount(<ExperimentalTab.WrappedComponent {...props} />, {
       context: {
         t: (str) => str,
@@ -32,7 +32,7 @@ describe('Experimental Tab', () => {
         trackEvent: () => undefined,
       },
     });
-    const useTokenDetectionText = wrapper.find({ text: 'Use Token Detection' });
+    const useTokenDetectionText = wrapper.find({ text: 'Use token detection' });
     expect(useTokenDetectionText).toHaveLength(0);
   });
 });

--- a/ui/pages/settings/networks-tab/networks-form/networks-form.test.js
+++ b/ui/pages/settings/networks-tab/networks-form/networks-form.test.js
@@ -89,11 +89,11 @@ describe('NetworkForm Component', () => {
         'A malicious network provider can lie about the state of the blockchain and record your network activity. Only add custom networks you trust.',
       ),
     ).toBeInTheDocument();
-    expect(queryByText('Network Name')).toBeInTheDocument();
+    expect(queryByText('Network name')).toBeInTheDocument();
     expect(queryByText('New RPC URL')).toBeInTheDocument();
     expect(queryByText('Chain ID')).toBeInTheDocument();
-    expect(queryByText('Currency Symbol')).toBeInTheDocument();
-    expect(queryByText('Block Explorer URL')).toBeInTheDocument();
+    expect(queryByText('Currency symbol')).toBeInTheDocument();
+    expect(queryByText('Block explorer URL')).toBeInTheDocument();
     expect(queryAllByText('(Optional)')).toHaveLength(1);
     expect(queryByText('Cancel')).toBeInTheDocument();
     expect(queryByText('Save')).toBeInTheDocument();
@@ -123,11 +123,11 @@ describe('NetworkForm Component', () => {
   it('should render network form correctly', () => {
     const { queryByText, getByDisplayValue } =
       renderComponent(propNetworkDisplay);
-    expect(queryByText('Network Name')).toBeInTheDocument();
+    expect(queryByText('Network name')).toBeInTheDocument();
     expect(queryByText('New RPC URL')).toBeInTheDocument();
     expect(queryByText('Chain ID')).toBeInTheDocument();
-    expect(queryByText('Currency Symbol')).toBeInTheDocument();
-    expect(queryByText('Block Explorer URL')).toBeInTheDocument();
+    expect(queryByText('Currency symbol')).toBeInTheDocument();
+    expect(queryByText('Block explorer URL')).toBeInTheDocument();
     expect(queryByText('Delete')).toBeInTheDocument();
     expect(queryByText('Cancel')).toBeInTheDocument();
     expect(queryByText('Save')).toBeInTheDocument();
@@ -229,7 +229,7 @@ describe('NetworkForm Component', () => {
     renderComponent(propNewNetwork);
     const chainIdField = screen.getByRole('textbox', { name: 'Chain ID' });
     const currencySymbolField = screen.getByRole('textbox', {
-      name: 'Currency Symbol',
+      name: 'Currency symbol',
     });
 
     fireEvent.change(chainIdField, {
@@ -252,10 +252,10 @@ describe('NetworkForm Component', () => {
     expect(await screen.findByText(secondExpectedWarning)).toBeInTheDocument();
   });
 
-  it('should validate block explorer url field correctly', async () => {
+  it('should validate block explorer URL field correctly', async () => {
     renderComponent(propNewNetwork);
     const blockExplorerUrlField = screen.getByRole('textbox', {
-      name: 'Block Explorer URL (Optional)',
+      name: 'Block explorer URL (Optional)',
     });
     fireEvent.change(blockExplorerUrlField, {
       target: { value: '1234' },

--- a/ui/pages/settings/networks-tab/networks-list-item/networks-list-item.test.js
+++ b/ui/pages/settings/networks-tab/networks-list-item/networks-list-item.test.js
@@ -46,6 +46,6 @@ describe('NetworksListItem Component', () => {
 
   it('should render a test network item correctly', () => {
     const { queryByText } = renderComponent(testNetProps);
-    expect(queryByText('Ropsten Test Network')).toBeInTheDocument();
+    expect(queryByText('Ropsten test network')).toBeInTheDocument();
   });
 });

--- a/ui/pages/settings/networks-tab/networks-list/networks-list.test.js
+++ b/ui/pages/settings/networks-tab/networks-list/networks-list.test.js
@@ -41,9 +41,9 @@ describe('NetworksList Component', () => {
     const { queryByText } = renderComponent(props);
 
     expect(queryByText('Ethereum Mainnet')).toBeInTheDocument();
-    expect(queryByText('Ropsten Test Network')).toBeInTheDocument();
-    expect(queryByText('Rinkeby Test Network')).toBeInTheDocument();
-    expect(queryByText('Goerli Test Network')).toBeInTheDocument();
-    expect(queryByText('Kovan Test Network')).toBeInTheDocument();
+    expect(queryByText('Ropsten test network')).toBeInTheDocument();
+    expect(queryByText('Rinkeby test network')).toBeInTheDocument();
+    expect(queryByText('Goerli test network')).toBeInTheDocument();
+    expect(queryByText('Kovan test network')).toBeInTheDocument();
   });
 });

--- a/ui/pages/settings/networks-tab/networks-tab-content/networks-tab-content.test.js
+++ b/ui/pages/settings/networks-tab/networks-tab-content/networks-tab-content.test.js
@@ -52,16 +52,16 @@ describe('NetworksTabContent Component', () => {
       renderComponent(props);
 
     expect(queryByText('Ethereum Mainnet')).toBeInTheDocument();
-    expect(queryByText('Ropsten Test Network')).toBeInTheDocument();
-    expect(queryByText('Rinkeby Test Network')).toBeInTheDocument();
-    expect(queryByText('Goerli Test Network')).toBeInTheDocument();
-    expect(queryByText('Kovan Test Network')).toBeInTheDocument();
+    expect(queryByText('Ropsten test network')).toBeInTheDocument();
+    expect(queryByText('Rinkeby test network')).toBeInTheDocument();
+    expect(queryByText('Goerli test network')).toBeInTheDocument();
+    expect(queryByText('Kovan test network')).toBeInTheDocument();
 
-    expect(queryByText('Network Name')).toBeInTheDocument();
+    expect(queryByText('Network name')).toBeInTheDocument();
     expect(queryByText('New RPC URL')).toBeInTheDocument();
     expect(queryByText('Chain ID')).toBeInTheDocument();
-    expect(queryByText('Currency Symbol')).toBeInTheDocument();
-    expect(queryByText('Block Explorer URL')).toBeInTheDocument();
+    expect(queryByText('Currency symbol')).toBeInTheDocument();
+    expect(queryByText('Block explorer URL')).toBeInTheDocument();
     expect(queryByText('Cancel')).toBeInTheDocument();
     expect(queryByText('Save')).toBeInTheDocument();
 

--- a/ui/pages/settings/networks-tab/networks-tab.test.js
+++ b/ui/pages/settings/networks-tab/networks-tab.test.js
@@ -32,21 +32,21 @@ describe('NetworksTab Component', () => {
     });
 
     expect(queryByText('Ethereum Mainnet')).toBeInTheDocument();
-    expect(queryByText('Ropsten Test Network')).toBeInTheDocument();
-    expect(queryByText('Rinkeby Test Network')).toBeInTheDocument();
-    expect(queryByText('Goerli Test Network')).toBeInTheDocument();
-    expect(queryByText('Kovan Test Network')).toBeInTheDocument();
-    expect(queryByText('Add Network')).toBeInTheDocument();
+    expect(queryByText('Ropsten test network')).toBeInTheDocument();
+    expect(queryByText('Rinkeby test network')).toBeInTheDocument();
+    expect(queryByText('Goerli test network')).toBeInTheDocument();
+    expect(queryByText('Kovan test network')).toBeInTheDocument();
+    expect(queryByText('Add network')).toBeInTheDocument();
   });
   it('should render add network form correctly', () => {
     const { queryByText } = renderComponent({
       addNewNetwork: true,
     });
-    expect(queryByText('Network Name')).toBeInTheDocument();
+    expect(queryByText('Network name')).toBeInTheDocument();
     expect(queryByText('New RPC URL')).toBeInTheDocument();
     expect(queryByText('Chain ID')).toBeInTheDocument();
-    expect(queryByText('Currency Symbol')).toBeInTheDocument();
-    expect(queryByText('Block Explorer URL')).toBeInTheDocument();
+    expect(queryByText('Currency symbol')).toBeInTheDocument();
+    expect(queryByText('Block explorer URL')).toBeInTheDocument();
     expect(queryByText('Cancel')).toBeInTheDocument();
     expect(queryByText('Save')).toBeInTheDocument();
   });

--- a/ui/pages/swaps/build-quote/build-quote.js
+++ b/ui/pages/swaps/build-quote/build-quote.js
@@ -276,7 +276,7 @@ export default function BuildQuote({
       const newBalanceError = new BigNumber(newInputValue || 0).gt(
         balance || 0,
       );
-      // "setBalanceError" is just a warning, a user can still click on the "Review Swap" button.
+      // "setBalanceError" is just a warning, a user can still click on the "Review swap" button.
       if (balanceError !== newBalanceError) {
         dispatch(setBalanceError(newBalanceError));
       }
@@ -551,7 +551,7 @@ export default function BuildQuote({
     timeoutIdForQuotesPrefetching = setTimeout(() => {
       timeoutIdForQuotesPrefetching = null;
       if (!isReviewSwapButtonDisabled) {
-        // Only do quotes prefetching if the Review Swap button is enabled.
+        // Only do quotes prefetching if the Review swap button is enabled.
         prefetchQuotesWithoutRedirecting();
       }
     }, 1000);
@@ -858,7 +858,7 @@ export default function BuildQuote({
       </div>
       <SwapsFooter
         onSubmit={async () => {
-          // We need this to know how long it took to go from clicking on the Review Swap button to rendered View Quote page.
+          // We need this to know how long it took to go from clicking on the Review swap button to rendered View Quote page.
           dispatch(setReviewSwapClickedTimestamp(Date.now()));
           // In case that quotes prefetching is waiting to be executed, but hasn't started yet,
           // we want to cancel it and fetch quotes from here.
@@ -876,7 +876,7 @@ export default function BuildQuote({
             // If there are prefetched quotes already, go directly to the View Quote page.
             history.push(VIEW_QUOTE_ROUTE);
           } else {
-            // If the "Review Swap" button was clicked while quotes are being fetched, go to the Loading Quotes page.
+            // If the "Review swap" button was clicked while quotes are being fetched, go to the Loading Quotes page.
             await dispatch(setBackgroundSwapRouteState('loading'));
             history.push(LOADING_QUOTES_ROUTE);
           }

--- a/ui/pages/swaps/build-quote/build-quote.test.js
+++ b/ui/pages/swaps/build-quote/build-quote.test.js
@@ -36,10 +36,10 @@ describe('BuildQuote', () => {
     expect(getByText('Swap from')).toBeInTheDocument();
     expect(getByText('Swap to')).toBeInTheDocument();
     expect(getByText('ETH')).toBeInTheDocument();
-    expect(getByText('Slippage Tolerance')).toBeInTheDocument();
+    expect(getByText('Slippage tolerance')).toBeInTheDocument();
     expect(getByText('2%')).toBeInTheDocument();
     expect(getByText('3%')).toBeInTheDocument();
-    expect(getByText('Review Swap')).toBeInTheDocument();
+    expect(getByText('Review swap')).toBeInTheDocument();
     expect(
       document.querySelector('.slippage-buttons__button-group'),
     ).toMatchSnapshot();

--- a/ui/pages/swaps/fee-card/fee-card.test.js
+++ b/ui/pages/swaps/fee-card/fee-card.test.js
@@ -126,7 +126,7 @@ describe('FeeCard', () => {
     ).toMatchSnapshot();
   });
 
-  it('renders the component with Smart Transactions enabled and user opted in', () => {
+  it('renders the component with smart transactions enabled and user opted in', () => {
     const store = configureMockStore(middleware)(createSwapsMockStore());
     const props = createProps({
       smartTransactionsOptInStatus: true,

--- a/ui/pages/swaps/slippage-buttons/__snapshots__/slippage-buttons.test.js.snap
+++ b/ui/pages/swaps/slippage-buttons/__snapshots__/slippage-buttons.test.js.snap
@@ -7,7 +7,7 @@ exports[`SlippageButtons renders the component with initial props 1`] = `
   <div
     class="slippage-buttons__header-text"
   >
-    Advanced Options
+    Advanced options
   </div>
   <i
     class="fa fa-angle-up"
@@ -47,14 +47,14 @@ exports[`SlippageButtons renders the component with initial props 2`] = `
 </div>
 `;
 
-exports[`SlippageButtons renders the component with the Smart Transaction opt-in button available 1`] = `
+exports[`SlippageButtons renders the component with the smart transaction opt-in button available 1`] = `
 <button
   class="slippage-buttons__header slippage-buttons__header--open"
 >
   <div
     class="slippage-buttons__header-text"
   >
-    Advanced Options
+    Advanced options
   </div>
   <i
     class="fa fa-angle-up"
@@ -62,7 +62,7 @@ exports[`SlippageButtons renders the component with the Smart Transaction opt-in
 </button>
 `;
 
-exports[`SlippageButtons renders the component with the Smart Transaction opt-in button available 2`] = `
+exports[`SlippageButtons renders the component with the smart transaction opt-in button available 2`] = `
 <div
   class="button-group slippage-buttons__button-group radio-button-group"
   role="radiogroup"

--- a/ui/pages/swaps/slippage-buttons/slippage-buttons.js
+++ b/ui/pages/swaps/slippage-buttons/slippage-buttons.js
@@ -49,7 +49,7 @@ export default function SlippageButtons({
     return 0;
   });
   const [open, setOpen] = useState(() => {
-    return currentSlippage !== SLIPPAGE.DEFAULT; // Only open Advanced Options by default if it's not default slippage.
+    return currentSlippage !== SLIPPAGE.DEFAULT; // Only open Advanced options by default if it's not default slippage.
   });
   const [inputRef, setInputRef] = useState(null);
 

--- a/ui/pages/swaps/slippage-buttons/slippage-buttons.test.js
+++ b/ui/pages/swaps/slippage-buttons/slippage-buttons.test.js
@@ -21,7 +21,7 @@ describe('SlippageButtons', () => {
     expect(getByText('2%')).toBeInTheDocument();
     expect(getByText('3%')).toBeInTheDocument();
     expect(getByText('custom')).toBeInTheDocument();
-    expect(getByText('Advanced Options')).toBeInTheDocument();
+    expect(getByText('Advanced options')).toBeInTheDocument();
     expect(
       document.querySelector('.slippage-buttons__header'),
     ).toMatchSnapshot();
@@ -31,20 +31,20 @@ describe('SlippageButtons', () => {
     expect(queryByText('Smart transaction')).not.toBeInTheDocument();
   });
 
-  it('renders the component with the Smart Transaction opt-in button available', () => {
+  it('renders the component with the smart transaction opt-in button available', () => {
     const { getByText } = renderWithProvider(
       <SlippageButtons {...createProps({ smartTransactionsEnabled: true })} />,
     );
     expect(getByText('2%')).toBeInTheDocument();
     expect(getByText('3%')).toBeInTheDocument();
     expect(getByText('custom')).toBeInTheDocument();
-    expect(getByText('Advanced Options')).toBeInTheDocument();
+    expect(getByText('Advanced options')).toBeInTheDocument();
     expect(
       document.querySelector('.slippage-buttons__header'),
     ).toMatchSnapshot();
     expect(
       document.querySelector('.slippage-buttons__button-group'),
     ).toMatchSnapshot();
-    expect(getByText('Smart Transaction')).toBeInTheDocument();
+    expect(getByText('Smart transaction')).toBeInTheDocument();
   });
 });

--- a/ui/pages/swaps/swaps-footer/__snapshots__/swaps-footer.test.js.snap
+++ b/ui/pages/swaps/swaps-footer/__snapshots__/swaps-footer.test.js.snap
@@ -34,7 +34,7 @@ exports[`SwapsFooter renders the component with initial props 1`] = `
     <div
       class="swaps-footer__bottom-text"
     >
-      Terms of Service
+      Terms of service
     </div>
   </div>
 </div>

--- a/ui/pages/swaps/swaps-footer/swaps-footer.test.js
+++ b/ui/pages/swaps/swaps-footer/swaps-footer.test.js
@@ -22,7 +22,7 @@ describe('SwapsFooter', () => {
     );
     expect(getByText(props.submitText)).toBeInTheDocument();
     expect(getByText('Back')).toBeInTheDocument();
-    expect(getByText('Terms of Service')).toBeInTheDocument();
+    expect(getByText('Terms of service')).toBeInTheDocument();
     expect(container).toMatchSnapshot();
   });
 });

--- a/ui/pages/token-details/token-details-page.test.js
+++ b/ui/pages/token-details/token-details-page.test.js
@@ -276,7 +276,7 @@ describe('TokenDetailsPage', () => {
   it('should render token contract address title in token details page', () => {
     const store = configureMockStore()(state);
     const { getByText } = renderWithProvider(<TokenDetailsPage />, store);
-    expect(getByText('Token Contract Address')).toBeInTheDocument();
+    expect(getByText('Token contract address')).toBeInTheDocument();
   });
 
   it('should render token contract address in token details page', () => {
@@ -296,7 +296,7 @@ describe('TokenDetailsPage', () => {
   it('should render token decimal title in token details page', () => {
     const store = configureMockStore()(state);
     const { getByText } = renderWithProvider(<TokenDetailsPage />, store);
-    expect(getByText('Token Decimal:')).toBeInTheDocument();
+    expect(getByText('Token decimal:')).toBeInTheDocument();
   });
 
   it('should render number of token decimals in token details page', () => {


### PR DESCRIPTION
## Explanation

Currently, we are inconsistent with our content casing conventions across the app.

This is a problem because although subtle it causes inconsistencies across our app and impacts our brand, accessibility and the message we convey to our users.

In order to solve this problem, this pull request updates all EN content to use sentence case with some exceptions and updates some other conventions.

### Exceptions to sentence case
**Names, companies, abbreviations or nouns**
e.g. “MetaMask”, “OpenSea”, “Google Chrome”, “Ledger Live”, “NFT”, “API”

**Special terms**
e.g. “Secret Recovery Phrase”, "Private Key"
"Secret Recovery Phrase' and "Private Key" an extremely important concepts that are critical to preventing users losing their funds. To convey the importance of these terms, they use title case.

**Page navigation**
When referring to the navigation route in the app we quote the page as its title appears e.g.
- "You can enable Ledger Live support by clicking Settings > Advanced > Use Ledger Live.”
- "Go to Settings > Advanced”
- “Go to Settings > Network and enter the chain ID. You can find the chain IDs of most popular networks on $1”

Reference

<img width="450" alt="Screen Shot 2022-07-19 at 1 46 21 PM" src="https://user-images.githubusercontent.com/8112138/179845293-6c367f8a-2272-4590-a5b8-18feccd5ee9b.png">

**Other content**
Other content which may raise questions as to whether they should be capitalized and that should also follow the sentence case convention include:

- Any special MetaMask feature e.g “smart transactions”, “enhanced gas fee”
- “support center”
- “explorer” (as in blockchain explorer)
- ~“mainnet” reason: [https://github.com/ethereum/ethereum-org-website/issues/1882](https://github.com/ethereum/ethereum-org-website/issues/1882)~ Going to open this can of worms in another PR
- “test network” (as in Rinkeby test network”)

## More Information

* Fixes #15039 
[Slack thread](https://consensys.slack.com/archives/G4V2HTG0Y/p1644264432332229)
[Notion doc](https://www.notion.so/Content-Copy-Style-Guide-9dd1a6f2d42f45598dc1f1454abd8688)

## Manual Testing Steps

This touches a lot of content so I would suggest just looking at the code changes to see if the conventions are correct.
- Only `app/_locales/en/messages.json` in locals needs to be thoroughly scrutinized. All other local files are description updates that were updated automatically using `yarn verify-locales:fix`
- Because this PR touches a lot of text and we use text to find nodes for e2e testing there are a lot of e2e test updates.
- No other content should be changed apart from the casing and conventions mentioned above.

## Pre-Merge Checklist

- [x] PR template is filled out
- [x] ~**IF** this PR fixes a bug, a test that _would have_ caught the bug has been added~ N/A
- [x] PR is linked to the appropriate GitHub issue
- [x] ~PR has been added to the appropriate release Milestone~ N/A

### + If there are functional changes:

- [x] ~Manual testing complete & passed~ N/A
- [x] ~"Extension QA Board" label has been applied~ N/A
