### PR TITLE
Remove decentralized 4byte function signature registry since it contains incorrect signatures and we can't algorithmically check for best option when 4byte.directory is down

### DIFF
--- a/app/scripts/migrations/073.js
+++ b/app/scripts/migrations/073.js
@@ -1,0 +1,30 @@
+import { cloneDeep } from 'lodash';
+
+const version = 73;
+
+/**
+ * Should empty the `knownMethodData` object in PreferencesController
+ */
+export default {
+  version,
+  async migrate(originalVersionedData) {
+    const versionedData = cloneDeep(originalVersionedData);
+    versionedData.meta.version = version;
+    const state = versionedData.data;
+    const newState = transformState(state);
+    versionedData.data = newState;
+    return versionedData;
+  },
+};
+
+function transformState(state) {
+  const PreferencesController = state?.PreferencesController || {};
+
+  return {
+    ...state,
+    PreferencesController: {
+      ...PreferencesController,
+      knownMethodData: {},
+    },
+  };
+}

--- a/app/scripts/migrations/073.test.js
+++ b/app/scripts/migrations/073.test.js
@@ -1,0 +1,427 @@
+import migration73 from './073';
+
+describe('migration #73', () => {
+  it('should update the version metadata', async () => {
+    const oldStorage = {
+      meta: {
+        version: 72,
+      },
+      data: {},
+    };
+
+    const newStorage = await migration73.migrate(oldStorage);
+    expect(newStorage.meta).toStrictEqual({
+      version: 73,
+    });
+  });
+
+  it('should empty knownMethodData object in PreferencesController', async () => {
+    const oldStorage = {
+      meta: {
+        version: 72,
+      },
+      data: {
+        PreferencesController: {
+          knownMethodData: {
+            '0x095ea7b3': {
+              name: 'Approve',
+              params: [
+                {
+                  type: 'address',
+                },
+                {
+                  type: 'uint256',
+                },
+              ],
+            },
+            '0x1249c58b': {
+              name: 'Mint',
+              params: [],
+            },
+            '0x1688f0b9': {
+              name: 'Create Proxy With Nonce',
+              params: [
+                {
+                  type: 'address',
+                },
+                {
+                  type: 'bytes',
+                },
+                {
+                  type: 'uint256',
+                },
+              ],
+            },
+            '0x18cbafe5': {
+              name: 'Swap Exact Tokens For E T H',
+              params: [
+                {
+                  type: 'uint256',
+                },
+                {
+                  type: 'uint256',
+                },
+                {
+                  type: 'address[]',
+                },
+                {
+                  type: 'address',
+                },
+                {
+                  type: 'uint256',
+                },
+              ],
+            },
+            '0x23b872dd': {
+              name: 'Transfer From',
+              params: [
+                {
+                  type: 'address',
+                },
+                {
+                  type: 'address',
+                },
+                {
+                  type: 'uint256',
+                },
+              ],
+            },
+            '0x2e1a7d4d': {
+              name: 'Withdraw',
+              params: [
+                {
+                  type: 'uint256',
+                },
+              ],
+            },
+            '0x2e7ba6ef': {
+              name: 'Claim',
+              params: [
+                {
+                  type: 'uint256',
+                },
+                {
+                  type: 'address',
+                },
+                {
+                  type: 'uint256',
+                },
+                {
+                  type: 'bytes32[]',
+                },
+              ],
+            },
+            '0x2eb2c2d6': {
+              name: 'Safe Batch Transfer From',
+              params: [
+                {
+                  type: 'address',
+                },
+                {
+                  type: 'address',
+                },
+                {
+                  type: 'uint256[]',
+                },
+                {
+                  type: 'uint256[]',
+                },
+                {
+                  type: 'bytes',
+                },
+              ],
+            },
+            '0x3671f8cf': {},
+            '0x41441d3b': {
+              name: 'Enter Staking',
+              params: [
+                {
+                  type: 'uint256',
+                },
+              ],
+            },
+            '0x441a3e70': {
+              name: 'Withdraw',
+              params: [
+                {
+                  type: 'uint256',
+                },
+                {
+                  type: 'uint256',
+                },
+              ],
+            },
+            '0x6f652e1a': {
+              name: 'Create Order',
+              params: [
+                {
+                  type: 'address',
+                },
+                {
+                  type: 'uint256',
+                },
+                {
+                  type: 'uint256',
+                },
+                {
+                  type: 'uint256',
+                },
+              ],
+            },
+            '0x8dbdbe6d': {
+              name: 'Deposit',
+              params: [
+                {
+                  type: 'uint256',
+                },
+                {
+                  type: 'uint256',
+                },
+                {
+                  type: 'address',
+                },
+              ],
+            },
+            '0x8ed955b9': {
+              name: 'Harvest All',
+              params: [],
+            },
+            '0xa22cb465': {
+              name: 'Set Approval For All',
+              params: [
+                {
+                  type: 'address',
+                },
+                {
+                  type: 'bool',
+                },
+              ],
+            },
+            '0xa9059cbb': {
+              name: 'Transfer',
+              params: [
+                {
+                  type: 'address',
+                },
+                {
+                  type: 'uint256',
+                },
+              ],
+            },
+            '0xab834bab': {
+              name: 'Atomic Match_',
+              params: [
+                {
+                  type: 'address[14]',
+                },
+                {
+                  type: 'uint256[18]',
+                },
+                {
+                  type: 'uint8[8]',
+                },
+                {
+                  type: 'bytes',
+                },
+                {
+                  type: 'bytes',
+                },
+                {
+                  type: 'bytes',
+                },
+                {
+                  type: 'bytes',
+                },
+                {
+                  type: 'bytes',
+                },
+                {
+                  type: 'bytes',
+                },
+                {
+                  type: 'uint8[2]',
+                },
+                {
+                  type: 'bytes32[5]',
+                },
+              ],
+            },
+            '0xd0e30db0': {
+              name: 'Deposit',
+              params: [],
+            },
+            '0xddd81f82': {
+              name: 'Register Proxy',
+              params: [],
+            },
+            '0xded9382a': {
+              name: 'Remove Liquidity E T H With Permit',
+              params: [
+                {
+                  type: 'address',
+                },
+                {
+                  type: 'uint256',
+                },
+                {
+                  type: 'uint256',
+                },
+                {
+                  type: 'uint256',
+                },
+                {
+                  type: 'address',
+                },
+                {
+                  type: 'uint256',
+                },
+                {
+                  type: 'bool',
+                },
+                {
+                  type: 'uint8',
+                },
+                {
+                  type: 'bytes32',
+                },
+                {
+                  type: 'bytes32',
+                },
+              ],
+            },
+            '0xe2bbb158': {
+              name: 'Deposit',
+              params: [
+                {
+                  type: 'uint256',
+                },
+                {
+                  type: 'uint256',
+                },
+              ],
+            },
+            '0xf305d719': {
+              name: 'Add Liquidity E T H',
+              params: [
+                {
+                  type: 'address',
+                },
+                {
+                  type: 'uint256',
+                },
+                {
+                  type: 'uint256',
+                },
+                {
+                  type: 'uint256',
+                },
+                {
+                  type: 'address',
+                },
+                {
+                  type: 'uint256',
+                },
+              ],
+            },
+          },
+        },
+      },
+    };
+
+    const newStorage = await migration73.migrate(oldStorage);
+    expect(newStorage).toStrictEqual({
+      meta: {
+        version: 73,
+      },
+      data: {
+        PreferencesController: {
+          knownMethodData: {},
+        },
+      },
+    });
+  });
+
+  it('should preserve other PreferencesController state', async () => {
+    const oldStorage = {
+      meta: {
+        version: 72,
+      },
+      data: {
+        PreferencesController: {
+          currentLocale: 'en',
+          dismissSeedBackUpReminder: false,
+          ipfsGateway: 'dweb.link',
+          knownMethodData: {
+            '0xd0e30db0': {
+              name: 'Deposit',
+              params: [],
+            },
+            '0xddd81f82': {
+              name: 'Register Proxy',
+              params: [],
+            },
+          },
+          openSeaEnabled: false,
+          useTokenDetection: false,
+        },
+      },
+    };
+
+    const newStorage = await migration73.migrate(oldStorage);
+    expect(newStorage).toStrictEqual({
+      meta: {
+        version: 73,
+      },
+      data: {
+        PreferencesController: {
+          currentLocale: 'en',
+          dismissSeedBackUpReminder: false,
+          ipfsGateway: 'dweb.link',
+          knownMethodData: {},
+          openSeaEnabled: false,
+          useTokenDetection: false,
+        },
+      },
+    });
+  });
+
+  it('should not change state in controllers other than PreferencesController', async () => {
+    const oldStorage = {
+      meta: {
+        version: 71,
+      },
+      data: {
+        PreferencesController: {
+          knownMethodData: {
+            '0xd0e30db0': {
+              name: 'Deposit',
+              params: [],
+            },
+            '0xddd81f82': {
+              name: 'Register Proxy',
+              params: [],
+            },
+          },
+        },
+        data: {
+          FooController: { a: 'b' },
+        },
+      },
+    };
+
+    const newStorage = await migration73.migrate(oldStorage);
+    expect(newStorage).toStrictEqual({
+      meta: {
+        version: 73,
+      },
+      data: {
+        PreferencesController: {
+          knownMethodData: {},
+        },
+        data: {
+          FooController: { a: 'b' },
+        },
+      },
+    });
+  });
+});

--- a/app/scripts/migrations/index.js
+++ b/app/scripts/migrations/index.js
@@ -76,6 +76,7 @@ import m069 from './069';
 import m070 from './070';
 import m071 from './071';
 import m072 from './072';
+import m073 from './073';
 
 const migrations = [
   m002,
@@ -149,6 +150,7 @@ const migrations = [
   m070,
   m071,
   m072,
+  m073,
 ];
 
 export default migrations;

--- a/ui/helpers/utils/transactions.util.js
+++ b/ui/helpers/utils/transactions.util.js
@@ -43,15 +43,6 @@ async function getMethodFrom4Byte(fourBytePrefix) {
   return fourByteResponse.results[0].text_signature;
 }
 
-function pickShortest(registrySig, fourByteSig) {
-  if (!registrySig) {
-    return fourByteSig;
-  } else if (!fourByteSig) {
-    return registrySig;
-  }
-  return fourByteSig.length < registrySig.length ? fourByteSig : registrySig;
-}
-
 let registry;
 
 /**
@@ -71,18 +62,11 @@ export async function getMethodDataAsync(fourBytePrefix) {
       registry = new MethodRegistry({ provider: global.ethereumProvider });
     }
 
-    const registrySig = await registry.lookup(fourBytePrefix).catch((e) => {
-      log.error(e);
-      return null;
-    });
-
-    const sig = pickShortest(registrySig, fourByteSig);
-
-    if (!sig) {
+    if (!fourByteSig) {
       return {};
     }
 
-    const parsedResult = registry.parse(sig);
+    const parsedResult = registry.parse(fourByteSig);
 
     return {
       name: parsedResult.name,

--- a/ui/helpers/utils/transactions.util.test.js
+++ b/ui/helpers/utils/transactions.util.test.js
@@ -87,14 +87,6 @@ describe('Transactions utils', () => {
             },
           ],
         });
-      nock('https://mainnet.infura.io:443', { encodedQueryParams: true })
-        .post('/v3/341eacb578dd44a1a049cbc5f6fd4035')
-        .reply(200, (_, requestBody) => ({
-          id: requestBody.id,
-          jsonrpc: '2.0',
-          result:
-            '0x0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000002f6e69636546756e6374696f6e48657265506c7a436c69636b39343332333030383928616464726573732c626f6f6c290000000000000000000000000000000000',
-        }));
       expect(await utils.getMethodDataAsync('0xa22cb465')).toStrictEqual({
         name: 'Set Approval For All',
         params: [{ type: 'address' }, { type: 'bool' }],


### PR DESCRIPTION
Despite [recent efforts](https://github.com/MetaMask/metamask-extension/pull/14937) to override incorrect signatures being published to the 4byte signature directories that we use to determine smart contract method names, [users are still experiencing this issue.](https://consensys.slack.com/archives/GTQAGKY5V/p1658329871193219). This time the issue appears to have resurfaced because 4byte.directory was down meaning that we could only look to the on-chain parity signature registry (via [eth-method-registry](https://github.com/MetaMask/eth-method-registry)) which unfortunately doesn't provide any metadata about date of the entry so we can't choose the earliest entry (which is likely to be the most valid) as we can with 4byte.directory.