### PR TITLE
Adjusting the height of account menu nav items to expand scroll area

### DIFF
--- a/ui/components/app/account-menu/index.scss
+++ b/ui/components/app/account-menu/index.scss
@@ -38,7 +38,7 @@
 
     @media screen and (max-width: $break-small) {
       padding: 0 14px;
-      height: 48px;
+      height: 40px;
     }
 
     &--clickable {
@@ -65,7 +65,11 @@
     }
 
     &__text {
-      @include Paragraph;
+      @include H6;
+
+      @include screen-md-min {
+        @include Paragraph;
+      }
 
       color: var(--color-text-default);
     }
@@ -121,10 +125,6 @@
     position: relative;
     flex-direction: column;
     z-index: 200;
-
-    @media (max-height: 600px) {
-      max-height: 236px;
-    }
   }
 
   &__accounts {
@@ -134,7 +134,7 @@
     scrollbar-width: auto;
 
     @media screen and (max-width: $break-small) {
-      max-height: 200px;
+      max-height: 240px;
     }
 
     .keyring-label {
@@ -231,7 +231,11 @@
   }
 
   &__name {
-    @include H4;
+    @include H6;
+
+    @include screen-md-min {
+      @include Paragraph;
+    }
 
     color: var(--color-text-default);
     text-overflow: ellipsis;

--- a/ui/components/app/account-menu/index.scss
+++ b/ui/components/app/account-menu/index.scss
@@ -37,8 +37,8 @@
     width: 100%;
 
     @media screen and (max-width: $break-small) {
-      padding: 14px;
-      height: 54px;
+      padding: 0 14px;
+      height: 48px;
     }
 
     &--clickable {
@@ -134,7 +134,7 @@
     scrollbar-width: auto;
 
     @media screen and (max-width: $break-small) {
-      max-height: 156px;
+      max-height: 200px;
     }
 
     .keyring-label {

--- a/ui/components/app/account-menu/index.scss
+++ b/ui/components/app/account-menu/index.scss
@@ -133,8 +133,14 @@
     max-height: 256px;
     scrollbar-width: auto;
 
-    @media screen and (max-width: $break-small) {
+    @include screen-sm-max {
       max-height: 240px;
+    }
+
+    // If window is smaller than extension popover height
+    // reduce scrollable accounts window height
+    @media screen and (max-height: 600px) {
+      max-height: 130px;
     }
 
     .keyring-label {


### PR DESCRIPTION
## Explanation

Currently, the scrollable area in the account menu is quite tight 

This is a problem because it makes it tedious to scroll through your account list if it is numerous

In order to solve this problem, this pull request adjusts the font-size and size of the menu items in the account menu.

There are further improvements we can make to the account menu but that will be included in the redesign

## More Information

* Fixes #15298


## Screenshots/Screencaps

### Before
<img width="383" alt="Screen Shot 2022-07-20 at 1 12 49 PM" src="https://user-images.githubusercontent.com/8112138/180074986-2b0f2833-ba60-4454-a1fa-3344d88f97a3.png"><img width="385" alt="Screen Shot 2022-07-20 at 12 56 32 PM" src="https://user-images.githubusercontent.com/8112138/180074994-707de126-e218-4d5e-8597-5822e2335480.png">

### After
<img width="373" alt="Screen Shot 2022-07-21 at 1 48 36 PM" src="https://user-images.githubusercontent.com/8112138/180313082-c445b783-6d9d-466f-b953-01564b4ce4e4.png"><img width="381" alt="Screen Shot 2022-07-21 at 1 49 17 PM" src="https://user-images.githubusercontent.com/8112138/180313091-7de1231c-4689-461b-93c7-848873c0cc33.png">
<img width="372" alt="Screen Shot 2022-07-21 at 1 49 38 PM" src="https://user-images.githubusercontent.com/8112138/180313094-82d38c02-ce1e-48b8-b814-03d93a507500.png"><img width="381" alt="Screen Shot 2022-07-21 at 1 50 06 PM" src="https://user-images.githubusercontent.com/8112138/180313095-b4d301d7-704d-4e30-9f38-a63bd214faa9.png">
<img width="952" alt="Screen Shot 2022-07-21 at 1 51 20 PM" src="https://user-images.githubusercontent.com/8112138/180313098-5face54d-2ea7-4e35-bfbf-a74c20cc9011.png">


## Manual Testing Steps
- Download and install the build on this PR
<img width="931" alt="Screen Shot 2022-07-22 at 10 18 47 AM" src="https://user-images.githubusercontent.com/8112138/180491424-f9584f5a-f82a-4588-8c77-149bf9c5db30.png">

- Go to the account menu
- Have less than 5 accounts. See scrollable area with a little more space
- Have more 5 accounts the search bar will display

## Pre-Merge Checklist

- [x] PR template is filled out
- [x] ~**IF** this PR fixes a bug, a test that _would have_ caught the bug has been added~ N/A
- [x] PR is linked to the appropriate GitHub issue
- [x] ~PR has been added to the appropriate release Milestone~ N/A

### + If there are functional changes:

- [x] ~Manual testing complete & passed~ N/A
- [x] ~"Extension QA Board" label has been applied~ N/A
