### PR TITLE
Improve `tokenId` parsing and clean up `useAssetDetails` hook

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -91,7 +91,10 @@ import {
 import { EVENT, EVENT_NAMES } from '../../shared/constants/metametrics';
 
 import { hexToDecimal } from '../../ui/helpers/utils/conversions.util';
-import { getTokenValueParam } from '../../ui/helpers/utils/token-util';
+import {
+  getTokenIdParam,
+  getTokenValueParam,
+} from '../../ui/helpers/utils/token-util';
 import { isEqualCaseInsensitive } from '../../shared/modules/string-utils';
 import { parseStandardTokenTransactionData } from '../../shared/modules/transaction.utils';
 import {
@@ -866,7 +869,11 @@ export default class MetamaskController extends EventEmitter {
           } = txMeta.txParams;
           const { chainId } = txMeta;
           const transactionData = parseStandardTokenTransactionData(data);
-          const tokenAmountOrTokenId = getTokenValueParam(transactionData);
+          // in the past I've seen the tokenId value show up in the _value param of the parsed tokenData
+          // not seeing this any more, but in an abundance of caution I will leave it as a fallback here.
+          const transactionDataTokenId =
+            getTokenIdParam(transactionData) ??
+            getTokenValueParam(transactionData);
           const { allCollectibles } = this.collectiblesController.state;
 
           // check if its a known collectible
@@ -875,7 +882,7 @@ export default class MetamaskController extends EventEmitter {
           ].find(
             ({ address, tokenId }) =>
               isEqualCaseInsensitive(address, contractAddress) &&
-              tokenId === tokenAmountOrTokenId,
+              tokenId === transactionDataTokenId,
           );
 
           // if it is we check and update ownership status.

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -869,8 +869,9 @@ export default class MetamaskController extends EventEmitter {
           } = txMeta.txParams;
           const { chainId } = txMeta;
           const transactionData = parseStandardTokenTransactionData(data);
-          // in the past I've seen the tokenId value show up in the _value param of the parsed tokenData
-          // not seeing this any more, but in an abundance of caution I will leave it as a fallback here.
+          // Sometimes the tokenId value is parsed as "_value" param. Not seeing this often any more, but still occasionally:
+          // i.e. call approve() on BAYC contract - https://etherscan.io/token/0xbc4ca0eda7647a8ab7c2061c2e118a18a936f13d#writeContract, and tokenId shows up as _value,
+          // not sure why since it doesn't match the ERC721 ABI spec we use to parse these transactions - https://github.com/MetaMask/metamask-eth-abis/blob/d0474308a288f9252597b7c93a3a8deaad19e1b2/src/abis/abiERC721.ts#L62.
           const transactionDataTokenId =
             getTokenIdParam(transactionData) ??
             getTokenValueParam(transactionData);

--- a/ui/ducks/send/send.js
+++ b/ui/ducks/send/send.js
@@ -70,6 +70,7 @@ import {
   getTokenAddressParam,
   getTokenValueParam,
   getTokenMetadata,
+  getTokenIdParam,
 } from '../../helpers/utils/token-util';
 import {
   checkExistingAddresses,
@@ -1749,7 +1750,11 @@ export function editExistingTransaction(assetType, transactionId) {
             details: {
               address: transaction.txParams.to,
               ...(assetType === ASSET_TYPES.COLLECTIBLE
-                ? { tokenId: getTokenValueParam(tokenData) }
+                ? {
+                    tokenId:
+                      getTokenIdParam(tokenData) ??
+                      getTokenValueParam(tokenData),
+                  }
                 : {}),
             },
           },

--- a/ui/helpers/utils/token-util.js
+++ b/ui/helpers/utils/token-util.js
@@ -7,7 +7,7 @@ import {
 import { getTokenStandardAndDetails } from '../../store/actions';
 import { isEqualCaseInsensitive } from '../../../shared/modules/string-utils';
 import { parseStandardTokenTransactionData } from '../../../shared/modules/transaction.utils';
-import { ERC1155, ERC721 } from '../../../shared/constants/transaction';
+import { ERC1155, ERC20, ERC721 } from '../../../shared/constants/transaction';
 import * as util from './util';
 import { formatCurrency } from './confirm-tx.util';
 
@@ -250,7 +250,7 @@ export async function getAssetDetails(
 
   // in the past I've seen the tokenId value show up in the _value param of the parsed tokenData
   // not seeing this any more, but in an abundance of caution I will leave it as a fallback here.
-  const tokenId =
+  let tokenId =
     getTokenIdParam(tokenData)?.toString() ?? getTokenValueParam(tokenData);
 
   const toAddress = getTokenAddressParam(tokenData);
@@ -293,6 +293,8 @@ export async function getAssetDetails(
           standard,
         };
       }
+    } else if (standard === ERC20) {
+      tokenId = undefined;
     }
   }
 

--- a/ui/helpers/utils/token-util.js
+++ b/ui/helpers/utils/token-util.js
@@ -7,7 +7,7 @@ import {
 import { getTokenStandardAndDetails } from '../../store/actions';
 import { isEqualCaseInsensitive } from '../../../shared/modules/string-utils';
 import { parseStandardTokenTransactionData } from '../../../shared/modules/transaction.utils';
-import { ERC1155, ERC20, ERC721 } from '../../../shared/constants/transaction';
+import { ERC20 } from '../../../shared/constants/transaction';
 import * as util from './util';
 import { formatCurrency } from './confirm-tx.util';
 

--- a/ui/helpers/utils/token-util.js
+++ b/ui/helpers/utils/token-util.js
@@ -251,9 +251,9 @@ export async function getAssetDetails(
   // in the past I've seen the tokenId value show up in the _value param of the parsed tokenData
   // not seeing this any more, but in an abundance of caution I will leave it as a fallback here.
   const transactionDataTokenId =
-    getTokenIdParam(tokenData).toString() ?? getTokenValueParam(tokenData);
+    getTokenIdParam(tokenData)?.toString() ?? getTokenValueParam(tokenData);
 
-  const tokenAmount = getTokenValueParam(token);
+  const tokenAmount = getTokenValueParam(tokenData);
   let tokenDetails;
   try {
     tokenDetails = await getTokenStandardAndDetails(
@@ -308,24 +308,24 @@ export async function getAssetDetails(
     }
 
     // else if not a collectible already in state or standard === ERC20 return tokenDetails and tokenId
-    console.log(
-      `{
-      tokenAmount,
-      toAddress,
-      tokenId: transactionDataTokenId.toString(),
-      ...tokenDetails,
-    }`,
-      {
-        tokenAmount,
-        toAddress,
-        tokenId: transactionDataTokenId.toString(),
-        ...tokenDetails,
-      },
-    );
+    // console.log(
+    //   `{
+    //   tokenAmount,
+    //   toAddress,
+    //   tokenId: transactionDataTokenId.toString(),
+    //   ...tokenDetails,
+    // }`,
+    //   {
+    //     tokenAmount,
+    //     toAddress,
+    //     tokenId: transactionDataTokenId.toString(),
+    //     ...tokenDetails,
+    //   },
+    // );
     return {
       tokenAmount,
       toAddress,
-      tokenId: transactionDataTokenId.toString(),
+      tokenId: transactionDataTokenId?.toString(),
       decimals:
         tokenDetails.decimals && Number(tokenDetails.decimals?.toString(10)),
       ...tokenDetails,

--- a/ui/helpers/utils/token-util.js
+++ b/ui/helpers/utils/token-util.js
@@ -7,7 +7,7 @@ import {
 import { getTokenStandardAndDetails } from '../../store/actions';
 import { isEqualCaseInsensitive } from '../../../shared/modules/string-utils';
 import { parseStandardTokenTransactionData } from '../../../shared/modules/transaction.utils';
-import { ERC1155, ERC721 } from '../../../shared/constants/transaction';
+import { ERC1155, ERC20, ERC721 } from '../../../shared/constants/transaction';
 import * as util from './util';
 import { formatCurrency } from './confirm-tx.util';
 
@@ -248,24 +248,48 @@ export async function getAssetDetails(
     throw new Error('Unable to detect valid token data');
   }
 
-  const tokenId = getTokenIdParam(tokenData);
+  // in the past I've seen the tokenId value show up in the _value param of the parsed tokenData
+  // not seeing this any more, but in an abundance of caution I will leave it as a fallback here.
+  const transactionDataTokenId =
+    getTokenIdParam(tokenData).toString() ?? getTokenValueParam(tokenData);
+
+  const tokenAmount = getTokenValueParam(token);
   let tokenDetails;
   try {
     tokenDetails = await getTokenStandardAndDetails(
       tokenAddress,
       currentUserAddress,
-      tokenId,
+      transactionDataTokenId,
     );
   } catch (error) {
     log.warn(error);
     return {};
   }
 
+  // assetStandard = standard;
+  // assetAddress = tokenAddress;
+  // tokenSymbol = symbol ?? '';
+  // tokenImage = image;
+
+  const toAddress = getTokenAddressParam(tokenData);
+  // if (assetStandard === ERC721 || assetStandard === ERC1155) {
+  //   assetName = name;
+  // }
+  // if (assetStandard === ERC20) {
+  //   userBalance = balance;
+  //   decimals = Number(currentAssetDecimals?.toString(10));
+  //   tokenAmount =
+  //     tokenData &&
+  //     calcTokenAmount(getTokenValueParam(tokenData), decimals).toString(10);
+  // }
+
   if (tokenDetails?.standard) {
     const { standard } = tokenDetails;
     if (standard === ERC721 || standard === ERC1155) {
-      const existingCollectible = existingCollectibles.find(({ address }) =>
-        isEqualCaseInsensitive(tokenAddress, address),
+      const existingCollectible = existingCollectibles.find(
+        ({ address, tokenId }) =>
+          isEqualCaseInsensitive(tokenAddress, address) &&
+          tokenId === transactionDataTokenId,
       );
 
       if (existingCollectible) {
@@ -274,9 +298,38 @@ export async function getAssetDetails(
           standard,
         };
       }
+    } else if (standard === ERC20) {
+      tokenAmount =
+        tokenData &&
+        calcTokenAmount(
+          getTokenValueParam(tokenData),
+          tokenDetails?.decimals,
+        ).toString(10);
     }
-    // else if not a collectible already in state or standard === ERC20 just return tokenDetails as it contains all required data
-    return tokenDetails;
+
+    // else if not a collectible already in state or standard === ERC20 return tokenDetails and tokenId
+    console.log(
+      `{
+      tokenAmount,
+      toAddress,
+      tokenId: transactionDataTokenId.toString(),
+      ...tokenDetails,
+    }`,
+      {
+        tokenAmount,
+        toAddress,
+        tokenId: transactionDataTokenId.toString(),
+        ...tokenDetails,
+      },
+    );
+    return {
+      tokenAmount,
+      toAddress,
+      tokenId: transactionDataTokenId.toString(),
+      decimals:
+        tokenDetails.decimals && Number(tokenDetails.decimals?.toString(10)),
+      ...tokenDetails,
+    };
   }
 
   return {};

--- a/ui/helpers/utils/token-util.js
+++ b/ui/helpers/utils/token-util.js
@@ -151,13 +151,29 @@ export function getTokenValueParam(tokenData = {}) {
   return tokenData?.args?._value?.toString();
 }
 
-export function getTokenApprovedParam(tokenData = {}) {
-  return tokenData?.args?._approved;
+/**
+ * Gets either the '_tokenId' parameter or the 'id' param of the passed token transaction data.,
+ * These are the parsed tokenId values returned by `parseStandardTokenTransactionData` as defined
+ * in the ERC721 and ERC1155 ABIs from metamask-eth-abis (https://github.com/MetaMask/metamask-eth-abis/tree/main/src/abis)
+ *
+ * @param {Object} tokenData - ethers Interface token data.
+ * @returns {string | undefined} A decimal string value.
+ */
+export function getTokenIdParam(tokenData = {}) {
+  return (
+    tokenData?.args?._tokenId?.toString() ?? tokenData?.args?.id?.toString()
+  );
 }
 
-export function getTokenValue(tokenParams = []) {
-  const valueData = tokenParams.find((param) => param.name === '_value');
-  return valueData && valueData.value;
+/**
+ * Gets the '_approved' parameter of the given token transaction data
+ * (i.e function call) per the Human Standard Token ABI, if present.
+ *
+ * @param {Object} tokenData - ethers Interface token data.
+ * @returns {boolean | undefined} A boolean indicating whether the function is being called to approve or revoke access.
+ */
+export function getTokenApprovedParam(tokenData = {}) {
+  return tokenData?.args?._approved;
 }
 
 /**
@@ -232,7 +248,7 @@ export async function getAssetDetails(
     throw new Error('Unable to detect valid token data');
   }
 
-  const tokenId = getTokenValueParam(tokenData);
+  const tokenId = getTokenIdParam(tokenData);
   let tokenDetails;
   try {
     tokenDetails = await getTokenStandardAndDetails(

--- a/ui/hooks/useAssetDetails.js
+++ b/ui/hooks/useAssetDetails.js
@@ -7,6 +7,7 @@ import {
   calcTokenAmount,
   getAssetDetails,
   getTokenAddressParam,
+  getTokenIdParam,
   getTokenValueParam,
 } from '../helpers/utils/token-util';
 import { hideLoadingIndication, showLoadingIndication } from '../store/actions';
@@ -86,7 +87,9 @@ export function useAssetDetails(tokenAddress, userAddress, transactionData) {
     toAddress = getTokenAddressParam(tokenData);
     if (assetStandard === ERC721 || assetStandard === ERC1155) {
       assetName = name;
-      tokenId = getTokenValueParam(tokenData);
+      // in the past I've seen the tokenId value show up in the _value param of the parsed tokenData
+      // not seeing this any more, but in an abundance of caution I will leave it as a fallback here.
+      tokenId = getTokenIdParam(tokenData) ?? getTokenValueParam(tokenData);
     }
     if (assetStandard === ERC20) {
       userBalance = balance;

--- a/ui/hooks/useAssetDetails.js
+++ b/ui/hooks/useAssetDetails.js
@@ -56,17 +56,16 @@ export function useAssetDetails(tokenAddress, userAddress, transactionData) {
     collectibles,
   ]);
 
-  let assetStandard,
-    assetName,
-    assetAddress,
-    tokenSymbol,
-    decimals,
-    tokenImage,
-    userBalance,
-    tokenValue,
-    toAddress,
-    tokenAmount,
-    tokenId;
+  // let assetStandard,
+  //   assetName,
+  //   assetAddress,
+  //   tokenSymbol,
+  //   decimals,
+  //   tokenImage,
+  //   userBalance,
+  //   toAddress,
+  //   tokenAmount,
+  //   tokenId;
 
   if (currentAsset) {
     const {
@@ -75,42 +74,34 @@ export function useAssetDetails(tokenAddress, userAddress, transactionData) {
       image,
       name,
       balance,
-      decimals: currentAssetDecimals,
+      tokenId,
+      toAddress,
+      tokenAmount,
+      decimals,
     } = currentAsset;
 
-    const tokenData = parseStandardTokenTransactionData(transactionData);
-    assetStandard = standard;
-    assetAddress = tokenAddress;
-    tokenSymbol = symbol ?? '';
-    tokenImage = image;
+    // assetStandard = standard;
+    // assetAddress = tokenAddress;
+    // tokenSymbol = symbol ?? '';
+    // tokenImage = image;
+    // tokenId = tokenId;
+    // toAddress = toAddress;
+    // userBalance = balance;
+    // assetName = name;
+    // tokenAmount = tokenAmount;
+    // decimals = Number(currentAssetDecimals?.toString(10));
 
-    toAddress = getTokenAddressParam(tokenData);
-    if (assetStandard === ERC721 || assetStandard === ERC1155) {
-      assetName = name;
-      // in the past I've seen the tokenId value show up in the _value param of the parsed tokenData
-      // not seeing this any more, but in an abundance of caution I will leave it as a fallback here.
-      tokenId = getTokenIdParam(tokenData) ?? getTokenValueParam(tokenData);
-    }
-    if (assetStandard === ERC20) {
-      userBalance = balance;
-      decimals = Number(currentAssetDecimals?.toString(10));
-      tokenAmount =
-        tokenData &&
-        calcTokenAmount(getTokenValueParam(tokenData), decimals).toString(10);
-    }
+    return {
+      toAddress,
+      tokenId,
+      decimals,
+      tokenAmount,
+      assetAddress: tokenAddress,
+      assetStandard: standard,
+      tokenSymbol: symbol ?? '',
+      tokenImage: image,
+      userBalance: balance,
+      assetName: name,
+    };
   }
-
-  return {
-    assetStandard,
-    assetName,
-    assetAddress,
-    userBalance,
-    tokenSymbol,
-    decimals,
-    tokenImage,
-    tokenValue,
-    toAddress,
-    tokenAmount,
-    tokenId,
-  };
 }

--- a/ui/hooks/useAssetDetails.js
+++ b/ui/hooks/useAssetDetails.js
@@ -56,16 +56,16 @@ export function useAssetDetails(tokenAddress, userAddress, transactionData) {
     collectibles,
   ]);
 
-  // let assetStandard,
-  //   assetName,
-  //   assetAddress,
-  //   tokenSymbol,
-  //   decimals,
-  //   tokenImage,
-  //   userBalance,
-  //   toAddress,
-  //   tokenAmount,
-  //   tokenId;
+  let assetStandard,
+    assetName,
+    assetAddress,
+    tokenSymbol,
+    decimals,
+    tokenImage,
+    userBalance,
+    toAddress,
+    tokenAmount,
+    tokenId;
 
   if (currentAsset) {
     const {
@@ -74,34 +74,34 @@ export function useAssetDetails(tokenAddress, userAddress, transactionData) {
       image,
       name,
       balance,
-      tokenId,
-      toAddress,
-      tokenAmount,
-      decimals,
+      tokenId: _tokenId,
+      toAddress: _toAddress,
+      tokenAmount: _tokenAmount,
+      decimals: _decimals,
     } = currentAsset;
 
-    // assetStandard = standard;
-    // assetAddress = tokenAddress;
-    // tokenSymbol = symbol ?? '';
-    // tokenImage = image;
-    // tokenId = tokenId;
-    // toAddress = toAddress;
-    // userBalance = balance;
-    // assetName = name;
-    // tokenAmount = tokenAmount;
-    // decimals = Number(currentAssetDecimals?.toString(10));
-
-    return {
-      toAddress,
-      tokenId,
-      decimals,
-      tokenAmount,
-      assetAddress: tokenAddress,
-      assetStandard: standard,
-      tokenSymbol: symbol ?? '',
-      tokenImage: image,
-      userBalance: balance,
-      assetName: name,
-    };
+    assetStandard = standard;
+    assetAddress = tokenAddress;
+    tokenSymbol = symbol ?? '';
+    tokenImage = image;
+    tokenId = _tokenId;
+    toAddress = _toAddress;
+    tokenAmount = _tokenAmount;
+    decimals = _decimals;
+    userBalance = balance;
+    assetName = name;
   }
+
+  return {
+    toAddress,
+    tokenId,
+    decimals,
+    tokenAmount,
+    assetAddress,
+    assetStandard,
+    tokenSymbol,
+    tokenImage,
+    userBalance,
+    assetName,
+  };
 }

--- a/ui/hooks/useAssetDetails.js
+++ b/ui/hooks/useAssetDetails.js
@@ -1,15 +1,7 @@
 import { useState, useEffect } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
-import { ERC1155, ERC20, ERC721 } from '../../shared/constants/transaction';
-import { parseStandardTokenTransactionData } from '../../shared/modules/transaction.utils';
 import { getCollectibles } from '../ducks/metamask/metamask';
-import {
-  calcTokenAmount,
-  getAssetDetails,
-  getTokenAddressParam,
-  getTokenIdParam,
-  getTokenValueParam,
-} from '../helpers/utils/token-util';
+import { getAssetDetails } from '../helpers/utils/token-util';
 import { hideLoadingIndication, showLoadingIndication } from '../store/actions';
 import { usePrevious } from './usePrevious';
 
@@ -56,17 +48,6 @@ export function useAssetDetails(tokenAddress, userAddress, transactionData) {
     collectibles,
   ]);
 
-  let assetStandard,
-    assetName,
-    assetAddress,
-    tokenSymbol,
-    decimals,
-    tokenImage,
-    userBalance,
-    toAddress,
-    tokenAmount,
-    tokenId;
-
   if (currentAsset) {
     const {
       standard,
@@ -74,34 +55,25 @@ export function useAssetDetails(tokenAddress, userAddress, transactionData) {
       image,
       name,
       balance,
-      tokenId: _tokenId,
-      toAddress: _toAddress,
-      tokenAmount: _tokenAmount,
-      decimals: _decimals,
+      tokenId,
+      toAddress,
+      tokenAmount,
+      decimals,
     } = currentAsset;
 
-    assetStandard = standard;
-    assetAddress = tokenAddress;
-    tokenSymbol = symbol ?? '';
-    tokenImage = image;
-    tokenId = _tokenId;
-    toAddress = _toAddress;
-    tokenAmount = _tokenAmount;
-    decimals = _decimals;
-    userBalance = balance;
-    assetName = name;
+    return {
+      toAddress,
+      tokenId,
+      decimals,
+      tokenAmount,
+      assetAddress: tokenAddress,
+      assetStandard: standard,
+      tokenSymbol: symbol ?? '',
+      tokenImage: image,
+      userBalance: balance,
+      assetName: name,
+    };
   }
 
-  return {
-    toAddress,
-    tokenId,
-    decimals,
-    tokenAmount,
-    assetAddress,
-    assetStandard,
-    tokenSymbol,
-    tokenImage,
-    userBalance,
-    assetName,
-  };
+  return {};
 }

--- a/ui/hooks/useAssetDetails.test.js
+++ b/ui/hooks/useAssetDetails.test.js
@@ -3,7 +3,7 @@ import { Provider } from 'react-redux';
 import { renderHook } from '@testing-library/react-hooks';
 
 import configureStore from '../store/store';
-import * as tokenUtils from '../helpers/utils/token-util';
+import * as Actions from '../store/actions';
 import { ERC1155, ERC20, ERC721 } from '../../shared/constants/transaction';
 import { useAssetDetails } from './useAssetDetails';
 
@@ -33,12 +33,14 @@ const renderUseAssetDetails = ({
 };
 
 describe('useAssetDetails', () => {
-  let getAssetDetailsStub;
+  let getTokenStandardAndDetailsStub;
+
   beforeEach(() => {
-    getAssetDetailsStub = jest
-      .spyOn(tokenUtils, 'getAssetDetails')
+    getTokenStandardAndDetailsStub = jest
+      .spyOn(Actions, 'getTokenStandardAndDetails')
       .mockImplementation(() => Promise.resolve({}));
   });
+
   it('should return object with tokenSymbol set to an empty string, when getAssetDetails returns and empty object', async () => {
     const toAddress = '000000000000000000000000000000000000dead';
     const tokenAddress = '0x1';
@@ -65,7 +67,6 @@ describe('useAssetDetails', () => {
     const userAddress = '0xf04a5cc80b1e94c69b48f5ee68a08cd2f09a7c3e';
     const tokenAddress = '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2';
     const toAddress = '000000000000000000000000000000000000dead';
-    const tokenAmount = '0.0000000000000005';
     const transactionData = `0xa9059cbb000000000000000000000000${toAddress}00000000000000000000000000000000000000000000000000000000000001f4`;
 
     const standard = ERC20;
@@ -73,14 +74,12 @@ describe('useAssetDetails', () => {
     const balance = '1';
     const decimals = 18;
 
-    getAssetDetailsStub.mockImplementation(() =>
+    getTokenStandardAndDetailsStub.mockImplementation(() =>
       Promise.resolve({
         standard,
-        symbol,
         balance,
+        symbol,
         decimals,
-        tokenAmount,
-        toAddress: `0x${toAddress}`,
       }),
     );
 
@@ -120,14 +119,12 @@ describe('useAssetDetails', () => {
       'https://bafybeihw3gvmthmvrenfmcvagtais5tv7r4nmiezgsv7nyknjubxw4lite.ipfs.dweb.link';
     const standard = ERC721;
 
-    getAssetDetailsStub.mockImplementation(() =>
+    getTokenStandardAndDetailsStub.mockImplementation(() =>
       Promise.resolve({
         standard,
         symbol,
         name,
-        tokenId,
         image,
-        toAddress: `0x${toAddress}`,
       }),
     );
 
@@ -166,12 +163,10 @@ describe('useAssetDetails', () => {
       'https://bafybeihw3gvmthmvrenfmcvagtais5tv7r4nmiezgsv7nyknjubxw4lite.ipfs.dweb.link';
     const standard = ERC1155;
 
-    getAssetDetailsStub.mockImplementation(() =>
+    getTokenStandardAndDetailsStub.mockImplementation(() =>
       Promise.resolve({
         standard,
-        tokenId,
         image,
-        toAddress: `0x${toAddress}`,
       }),
     );
 

--- a/ui/hooks/useAssetDetails.test.js
+++ b/ui/hooks/useAssetDetails.test.js
@@ -53,7 +53,7 @@ describe('useAssetDetails', () => {
 
     await waitForNextUpdate();
 
-    expect(result.current).toEqual(
+    expect(result.current).toStrictEqual(
       expect.objectContaining({
         assetAddress: tokenAddress,
         tokenSymbol: '',

--- a/ui/hooks/useAssetDetails.test.js
+++ b/ui/hooks/useAssetDetails.test.js
@@ -39,7 +39,7 @@ describe('useAssetDetails', () => {
       .spyOn(tokenUtils, 'getAssetDetails')
       .mockImplementation(() => Promise.resolve({}));
   });
-  it('should return object with tokenSymbol set to and empty string, when getAssetDetails returns and empty object', async () => {
+  it('should return object with tokenSymbol set to an empty string, when getAssetDetails returns and empty object', async () => {
     const toAddress = '000000000000000000000000000000000000dead';
     const tokenAddress = '0x1';
 
@@ -53,25 +53,19 @@ describe('useAssetDetails', () => {
 
     await waitForNextUpdate();
 
-    expect(result.current).toStrictEqual({
-      assetAddress: tokenAddress,
-      assetName: undefined,
-      assetStandard: undefined,
-      decimals: undefined,
-      toAddress: `0x${toAddress}`,
-      tokenAmount: undefined,
-      tokenId: undefined,
-      tokenImage: undefined,
-      tokenSymbol: '',
-      tokenValue: undefined,
-      userBalance: undefined,
-    });
+    expect(result.current).toEqual(
+      expect.objectContaining({
+        assetAddress: tokenAddress,
+        tokenSymbol: '',
+      }),
+    );
   });
 
   it('should return object with correct tokenValues for an ERC20 token', async () => {
     const userAddress = '0xf04a5cc80b1e94c69b48f5ee68a08cd2f09a7c3e';
     const tokenAddress = '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2';
     const toAddress = '000000000000000000000000000000000000dead';
+    const tokenAmount = '0.0000000000000005';
     const transactionData = `0xa9059cbb000000000000000000000000${toAddress}00000000000000000000000000000000000000000000000000000000000001f4`;
 
     const standard = ERC20;
@@ -85,6 +79,8 @@ describe('useAssetDetails', () => {
         symbol,
         balance,
         decimals,
+        tokenAmount,
+        toAddress: `0x${toAddress}`,
       }),
     );
 
@@ -106,7 +102,6 @@ describe('useAssetDetails', () => {
       tokenId: undefined,
       tokenImage: undefined,
       tokenSymbol: symbol,
-      tokenValue: undefined,
       userBalance: balance,
     });
   });
@@ -114,10 +109,10 @@ describe('useAssetDetails', () => {
   it('should return object with correct tokenValues for an ERC721 token', async () => {
     const tokenAddress = '0xBC4CA0EdA7647A8aB7C2061c2E118A18a936f13D';
     const toAddress = '000000000000000000000000000000000000dead';
-    const tokenId = 12;
-    const transactionData = `0x23b872dd000000000000000000000000a544eebe103733f22ef62af556023bc918b73d36000000000000000000000000${toAddress}000000000000000000000000000000000000000000000000000000000000000${tokenId.toString(
-      16,
-    )}`;
+    const tokenId = '12';
+    const transactionData = `0x23b872dd000000000000000000000000a544eebe103733f22ef62af556023bc918b73d36000000000000000000000000${toAddress}000000000000000000000000000000000000000000000000000000000000000${Number(
+      tokenId,
+    ).toString(16)}`;
 
     const symbol = 'BAYC';
     const name = 'BoredApeYachtClub';
@@ -132,6 +127,7 @@ describe('useAssetDetails', () => {
         name,
         tokenId,
         image,
+        toAddress: `0x${toAddress}`,
       }),
     );
 
@@ -148,10 +144,9 @@ describe('useAssetDetails', () => {
       assetStandard: standard,
       decimals: undefined,
       toAddress: `0x${toAddress}`,
-      tokenId: tokenId.toString(),
+      tokenId,
       tokenImage: image,
       tokenSymbol: symbol,
-      tokenValue: undefined,
       userBalance: undefined,
       tokenAmount: undefined,
     });
@@ -160,8 +155,10 @@ describe('useAssetDetails', () => {
   it('should return object with correct tokenValues for an ERC1155 token', async () => {
     const tokenAddress = '0x76BE3b62873462d2142405439777e971754E8E77';
     const toAddress = '000000000000000000000000000000000000dead';
-    const tokenId = 802;
-    const transactionData = `0xf242432a000000000000000000000000a544eebe103733f22ef62af556023bc918b73d36000000000000000000000000000000000000000000000000000000000000dead0000000000000000000000000000000000000000000000000000000000000${tokenId.toString(
+    const tokenId = '802';
+    const transactionData = `0xf242432a000000000000000000000000a544eebe103733f22ef62af556023bc918b73d36000000000000000000000000000000000000000000000000000000000000dead0000000000000000000000000000000000000000000000000000000000000${Number(
+      tokenId,
+    ).toString(
       16,
     )}000000000000000000000000000000000000000000000000000000000000009c00000000000000000000000000000000000000000000000000000000000000a000000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000000`;
 
@@ -174,6 +171,7 @@ describe('useAssetDetails', () => {
         standard,
         tokenId,
         image,
+        toAddress: `0x${toAddress}`,
       }),
     );
 
@@ -190,10 +188,9 @@ describe('useAssetDetails', () => {
       assetStandard: standard,
       decimals: undefined,
       toAddress: `0x${toAddress}`,
-      tokenId: tokenId.toString(),
+      tokenId,
       tokenImage: image,
       tokenSymbol: '',
-      tokenValue: undefined,
       userBalance: undefined,
       tokenAmount: undefined,
     });

--- a/ui/hooks/useAssetDetails.test.js
+++ b/ui/hooks/useAssetDetails.test.js
@@ -114,10 +114,12 @@ describe('useAssetDetails', () => {
   it('should return object with correct tokenValues for an ERC721 token', async () => {
     const tokenAddress = '0xBC4CA0EdA7647A8aB7C2061c2E118A18a936f13D';
     const toAddress = '000000000000000000000000000000000000dead';
-    const transactionData = `0x23b872dd000000000000000000000000a544eebe103733f22ef62af556023bc918b73d36000000000000000000000000${toAddress}000000000000000000000000000000000000000000000000000000000000000c`;
+    const tokenId = 12;
+    const transactionData = `0x23b872dd000000000000000000000000a544eebe103733f22ef62af556023bc918b73d36000000000000000000000000${toAddress}000000000000000000000000000000000000000000000000000000000000000${tokenId.toString(
+      16,
+    )}`;
 
     const symbol = 'BAYC';
-    const tokenId = '12';
     const name = 'BoredApeYachtClub';
     const image =
       'https://bafybeihw3gvmthmvrenfmcvagtais5tv7r4nmiezgsv7nyknjubxw4lite.ipfs.dweb.link';
@@ -146,7 +148,7 @@ describe('useAssetDetails', () => {
       assetStandard: standard,
       decimals: undefined,
       toAddress: `0x${toAddress}`,
-      tokenId,
+      tokenId: tokenId.toString(),
       tokenImage: image,
       tokenSymbol: symbol,
       tokenValue: undefined,
@@ -158,9 +160,11 @@ describe('useAssetDetails', () => {
   it('should return object with correct tokenValues for an ERC1155 token', async () => {
     const tokenAddress = '0x76BE3b62873462d2142405439777e971754E8E77';
     const toAddress = '000000000000000000000000000000000000dead';
-    const transactionData = `0xf242432a000000000000000000000000a544eebe103733f22ef62af556023bc918b73d36000000000000000000000000000000000000000000000000000000000000dead0000000000000000000000000000000000000000000000000000000000000322000000000000000000000000000000000000000000000000000000000000009c00000000000000000000000000000000000000000000000000000000000000a000000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000000`;
+    const tokenId = 802;
+    const transactionData = `0xf242432a000000000000000000000000a544eebe103733f22ef62af556023bc918b73d36000000000000000000000000000000000000000000000000000000000000dead0000000000000000000000000000000000000000000000000000000000000${tokenId.toString(
+      16,
+    )}000000000000000000000000000000000000000000000000000000000000009c00000000000000000000000000000000000000000000000000000000000000a000000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000000`;
 
-    const tokenId = '121';
     const image =
       'https://bafybeihw3gvmthmvrenfmcvagtais5tv7r4nmiezgsv7nyknjubxw4lite.ipfs.dweb.link';
     const standard = ERC1155;
@@ -186,7 +190,7 @@ describe('useAssetDetails', () => {
       assetStandard: standard,
       decimals: undefined,
       toAddress: `0x${toAddress}`,
-      tokenId: undefined,
+      tokenId: tokenId.toString(),
       tokenImage: image,
       tokenSymbol: '',
       tokenValue: undefined,

--- a/ui/hooks/useTransactionDisplayData.js
+++ b/ui/hooks/useTransactionDisplayData.js
@@ -8,6 +8,7 @@ import { camelCaseToCapitalize } from '../helpers/utils/common.util';
 import { PRIMARY, SECONDARY } from '../helpers/constants/common';
 import {
   getTokenAddressParam,
+  getTokenIdParam,
   getTokenValueParam,
 } from '../helpers/utils/token-util';
 import {
@@ -138,16 +139,17 @@ export function useTransactionDisplayData(transactionGroup) {
     isTokenCategory,
   );
 
-  // If this is an ERC20 token transaction this value is equal to the amount sent
-  // If it is an ERC721 token transaction it is the tokenId being sent
-  const tokenAmountOrTokenId = getTokenValueParam(tokenData);
+  // in the past I've seen the tokenId value show up in the _value param of the parsed tokenData
+  // not seeing this any more, but in an abundance of caution I will leave it as a fallback here.
+  const transactionDataTokenId =
+    getTokenIdParam(tokenData) ?? getTokenValueParam(tokenData);
 
   const collectible =
     isTokenCategory &&
     knownCollectibles.find(
       ({ address, tokenId }) =>
         isEqualCaseInsensitive(address, recipientAddress) &&
-        tokenId === tokenAmountOrTokenId,
+        tokenId === transactionDataTokenId,
     );
 
   const tokenDisplayValue = useTokenDisplayValue(

--- a/ui/hooks/useTransactionDisplayData.js
+++ b/ui/hooks/useTransactionDisplayData.js
@@ -139,8 +139,9 @@ export function useTransactionDisplayData(transactionGroup) {
     isTokenCategory,
   );
 
-  // in the past I've seen the tokenId value show up in the _value param of the parsed tokenData
-  // not seeing this any more, but in an abundance of caution I will leave it as a fallback here.
+  // Sometimes the tokenId value is parsed as "_value" param. Not seeing this often any more, but still occasionally:
+  // i.e. call approve() on BAYC contract - https://etherscan.io/token/0xbc4ca0eda7647a8ab7c2061c2e118a18a936f13d#writeContract, and tokenId shows up as _value,
+  // not sure why since it doesn't match the ERC721 ABI spec we use to parse these transactions - https://github.com/MetaMask/metamask-eth-abis/blob/d0474308a288f9252597b7c93a3a8deaad19e1b2/src/abis/abiERC721.ts#L62.
   const transactionDataTokenId =
     getTokenIdParam(tokenData) ?? getTokenValueParam(tokenData);
 


### PR DESCRIPTION
There are 2 chunks of work included in this PR to improve the accuracy and code legibility of how we extract and use `tokenId` values from parsed transaction data when showing users confirmations related to NFT transactions:

1. Adds `getTokenIdParam` function to pull values `_tokenId` (in the case of supported ERC721 transactions- [here](https://github.com/MetaMask/metamask-eth-abis/blob/d0474308a288f9252597b7c93a3a8deaad19e1b2/src/abis/abiERC721.ts#L62), [here](https://github.com/MetaMask/metamask-eth-abis/blob/d0474308a288f9252597b7c93a3a8deaad19e1b2/src/abis/abiERC721.ts#L143) & [here](https://github.com/MetaMask/metamask-eth-abis/blob/d0474308a288f9252597b7c93a3a8deaad19e1b2/src/abis/abiERC721.ts#L62)) and `id` (in the case of supported [ERC1155 transactions](https://github.com/MetaMask/metamask-eth-abis/blob/d0474308a288f9252597b7c93a3a8deaad19e1b2/src/abis/abiERC1155.ts#L250)) from transaction data. We previously relied only on the `_value` param, but after further digging it appears `_value` is only how `tokenId` is parameterized in the transaction data in some cases... (see comment [here](https://github.com/MetaMask/metamask-extension/blob/cb5252d84735522cbe8d0bc2dbf6be2dc8b478c6/ui/helpers/utils/token-util.js#L251) for further details)

2.  Refactors `useAssetDetails` and `getAssetDetails` to [avoid unnecessary network calls where possible](https://github.com/MetaMask/metamask-extension/pull/15304/files#diff-df0b6edfb26c6bba935a578c7457bfc1c55fd54a8f81613c7882a80fab892363R262), and improve overall legibility.

## ERC721
**Before:**
![Screen Shot 2022-07-21 at 5 16 03 PM](https://user-images.githubusercontent.com/34557516/180324260-8838c442-01ac-4e40-bfad-c581541a8fba.png)

**After:**
![Screen Shot 2022-07-21 at 5 12 07 PM](https://user-images.githubusercontent.com/34557516/180323795-242c9ffa-7bc2-4b16-abab-6f5e776c3f17.png)

## ERC1155
**Before:**
![Screen Shot 2022-07-21 at 5 20 39 PM](https://user-images.githubusercontent.com/34557516/180324754-ac7d6d49-8332-480d-b957-75bb88367987.png)

**After:**
![Screen Shot 2022-07-21 at 5 23 45 PM](https://user-images.githubusercontent.com/34557516/180325157-6592fbcb-6587-4cc0-b4a0-0c1ced56a303.png)

