### PR TITLE
Remove unused bundling options in build script

### DIFF
--- a/development/build/scripts.js
+++ b/development/build/scripts.js
@@ -665,11 +665,9 @@ function createNormalBundle({
   destFilepath,
   devMode,
   entryFilepath,
-  extraEntries = [],
   ignoredFiles,
   label,
   policyOnly,
-  modulesToExpose,
   shouldLintFenceFiles,
   testing,
   version,
@@ -703,14 +701,7 @@ function createNormalBundle({
     });
 
     // set bundle entries
-    bundlerOpts.entries = [...extraEntries];
-    if (entryFilepath) {
-      bundlerOpts.entries.push(entryFilepath);
-    }
-
-    if (modulesToExpose) {
-      bundlerOpts.require = bundlerOpts.require.concat(modulesToExpose);
-    }
+    bundlerOpts.entries = [entryFilepath];
 
     // instrument pipeline
     events.on('configurePipeline', ({ pipeline }) => {


### PR DESCRIPTION
Two unused options have been removed from the `createNormalBundle` function in the build script: 'extraEntries` and `modulesToExpose`.'

Both of these options were used in the old "main" bundles, before we began using the "factored" bundles. They have been unused since #11080.