### PR TITLE
Rename various build script functions

### DIFF
--- a/development/build/scripts.js
+++ b/development/build/scripts.js
@@ -196,22 +196,22 @@ function createScriptTasks({
   // internal tasks
   const core = {
     // dev tasks (live reload)
-    dev: createTasksForBuildJsExtension({
+    dev: createTasksForScriptBundles({
       taskPrefix: 'scripts:core:dev',
       devMode: true,
     }),
-    testDev: createTasksForBuildJsExtension({
+    testDev: createTasksForScriptBundles({
       taskPrefix: 'scripts:core:test-live',
       devMode: true,
       testing: true,
     }),
     // built for CI tests
-    test: createTasksForBuildJsExtension({
+    test: createTasksForScriptBundles({
       taskPrefix: 'scripts:core:test',
       testing: true,
     }),
     // production
-    prod: createTasksForBuildJsExtension({ taskPrefix: 'scripts:core:prod' }),
+    prod: createTasksForScriptBundles({ taskPrefix: 'scripts:core:prod' }),
   };
 
   // high level tasks
@@ -219,7 +219,7 @@ function createScriptTasks({
   const { dev, test, testDev, prod } = core;
   return { dev, test, testDev, prod };
 
-  function createTasksForBuildJsExtension({ taskPrefix, devMode, testing }) {
+  function createTasksForScriptBundles({ taskPrefix, devMode, testing }) {
     const standardEntryPoints = ['background', 'ui', 'content-script'];
     const standardSubtask = createTask(
       `${taskPrefix}:standardEntryPoints`,
@@ -246,19 +246,19 @@ function createScriptTasks({
     // because inpage bundle result is included inside contentscript
     const contentscriptSubtask = createTask(
       `${taskPrefix}:contentscript`,
-      createTaskForBundleContentscript({ devMode, testing }),
+      createContentscriptBundle({ devMode, testing }),
     );
 
     // this can run whenever
     const disableConsoleSubtask = createTask(
       `${taskPrefix}:disable-console`,
-      createTaskForBundleDisableConsole({ devMode, testing }),
+      createDisableConsoleBundle({ devMode, testing }),
     );
 
     // this can run whenever
     const installSentrySubtask = createTask(
       `${taskPrefix}:sentry`,
-      createTaskForBundleSentry({ devMode, testing }),
+      createSentryBundle({ devMode, testing }),
     );
 
     // task for initiating browser livereload
@@ -296,7 +296,7 @@ function createScriptTasks({
     return composeParallel(initiateLiveReload, ...allSubtasks);
   }
 
-  function createTaskForBundleDisableConsole({ devMode, testing }) {
+  function createDisableConsoleBundle({ devMode, testing }) {
     const label = 'disable-console';
     return createNormalBundle({
       browserPlatforms,
@@ -313,7 +313,7 @@ function createScriptTasks({
     });
   }
 
-  function createTaskForBundleSentry({ devMode, testing }) {
+  function createSentryBundle({ devMode, testing }) {
     const label = 'sentry-install';
     return createNormalBundle({
       browserPlatforms,
@@ -331,7 +331,7 @@ function createScriptTasks({
   }
 
   // the "contentscript" bundle contains the "inpage" bundle
-  function createTaskForBundleContentscript({ devMode, testing }) {
+  function createContentscriptBundle({ devMode, testing }) {
     const inpage = 'inpage';
     const contentscript = 'contentscript';
     return composeSeries(
@@ -391,7 +391,7 @@ const postProcessServiceWorker = (
 
 // Function generates app-init.js for browsers chrome, brave and opera.
 // It dynamically injects list of files generated in the build.
-async function bundleMV3AppInitialiser({
+async function createManifestV3AppInitializationBundle({
   jsBundles,
   browserPlatforms,
   buildType,
@@ -622,7 +622,7 @@ function createFactoredBuild({
                 ...commonSet.values(),
                 ...groupSet.values(),
               ].map((label) => `./${label}.js`);
-              await bundleMV3AppInitialiser({
+              await createManifestV3AppInitializationBundle({
                 jsBundles,
                 browserPlatforms,
                 buildType,
@@ -655,7 +655,7 @@ function createFactoredBuild({
       }
     });
 
-    await bundleIt(buildConfiguration, { reloadOnChange });
+    await createBundle(buildConfiguration, { reloadOnChange });
   };
 }
 
@@ -726,7 +726,7 @@ function createNormalBundle({
       });
     });
 
-    await bundleIt(buildConfiguration, { reloadOnChange });
+    await createBundle(buildConfiguration, { reloadOnChange });
   };
 }
 
@@ -881,7 +881,7 @@ function setupSourcemaps(buildConfiguration, { devMode }) {
   });
 }
 
-async function bundleIt(buildConfiguration, { reloadOnChange }) {
+async function createBundle(buildConfiguration, { reloadOnChange }) {
   const { label, bundlerOpts, events } = buildConfiguration;
   const bundler = browserify(bundlerOpts);
 


### PR DESCRIPTION
Some of the functions in `development/build/scripts.js` have been renamed to better describe their function, and to be more consistent with other similar functions.