### PR TITLE
Fix "app-init" injection

### DIFF
--- a/app/scripts/app-init.js
+++ b/app/scripts/app-init.js
@@ -50,8 +50,12 @@ function importAllScripts() {
   };
 
   const startImportScriptsTime = Date.now();
+
   // value of applyLavaMoat below is dynamically replaced at build time with actual value
   const applyLavaMoat = process.env.APPLY_LAVAMOAT;
+  if (typeof applyLavaMoat !== 'boolean') {
+    throw new Error('Missing APPLY_LAVAMOAT environment variable');
+  }
 
   loadFile('./globalthis.js');
   loadFile('./sentry-install.js');

--- a/development/build/scripts.js
+++ b/development/build/scripts.js
@@ -438,30 +438,6 @@ function createScriptTasks({
   }
 }
 
-const postProcessServiceWorker = (
-  mv3BrowserPlatforms,
-  fileList,
-  applyLavaMoat,
-  testing,
-) => {
-  mv3BrowserPlatforms.forEach((browser) => {
-    const appInitFile = `./dist/${browser}/app-init.js`;
-    const fileContent = readFileSync('./app/scripts/app-init.js', 'utf8');
-    let fileOutput = fileContent.replace('/** FILE NAMES */', fileList);
-    if (testing) {
-      fileOutput = fileOutput.replace('testMode = false', 'testMode = true');
-    } else {
-      // Setting applyLavaMoat to true in testing mode
-      // This is to enable capturing initialisation time stats using e2e with lavamoat statsMode enabled
-      fileOutput = fileOutput.replace(
-        'const applyLavaMoat = true;',
-        `const applyLavaMoat = ${applyLavaMoat};`,
-      );
-    }
-    writeFileSync(appInitFile, fileOutput);
-  });
-};
-
 /**
  * Create the bundle for the app initialization module used in manifest v3
  * builds.
@@ -509,10 +485,19 @@ async function createManifestV3AppInitializationBundle({
   const mv3BrowserPlatforms = browserPlatforms.filter(
     (platform) => platform !== 'firefox',
   );
-  const fileList = jsBundles.reduce(
-    (result, file) => `${result}'${file}',\n    `,
-    '',
-  );
+
+  for (const filename of jsBundles) {
+    if (filename.includes(',')) {
+      throw new Error(
+        `Invalid filename "${filename}", not allowed to contain comma.`,
+      );
+    }
+  }
+
+  const extraEnvironmentVariables = {
+    APPLY_LAVAMOAT: applyLavaMoat,
+    FILE_NAMES: jsBundles.join(','),
+  };
 
   await createNormalBundle({
     browserPlatforms: mv3BrowserPlatforms,
@@ -520,6 +505,7 @@ async function createManifestV3AppInitializationBundle({
     destFilepath: 'app-init.js',
     devMode,
     entryFilepath: './app/scripts/app-init.js',
+    extraEnvironmentVariables,
     ignoredFiles,
     label,
     testing,
@@ -527,29 +513,6 @@ async function createManifestV3AppInitializationBundle({
     shouldLintFenceFiles,
     version,
   })();
-
-  postProcessServiceWorker(
-    mv3BrowserPlatforms,
-    fileList,
-    applyLavaMoat,
-    testing,
-  );
-
-  // If the application is running in development mode, we watch service worker file to
-  // in case the file is changes we need to process it again to replace "/** FILE NAMES */", "testMode" etc.
-  if (devMode && !testing) {
-    let prevChromeFileContent;
-    watch('./dist/chrome/app-init.js', () => {
-      const chromeFileContent = readFileSync(
-        './dist/chrome/app-init.js',
-        'utf8',
-      );
-      if (chromeFileContent !== prevChromeFileContent) {
-        prevChromeFileContent = chromeFileContent;
-        postProcessServiceWorker(mv3BrowserPlatforms, fileList, applyLavaMoat);
-      }
-    });
-  }
 
   // Code below is used to set statsMode to true when testing in MV3
   // This is used to capture module initialisation stats using lavamoat.
@@ -810,6 +773,8 @@ function createFactoredBuild({
  * development.
  * @param {string[]} options.entryFilepath - The entry point file path,
  * relative to the repository root directory.
+ * @param {Record<string, unknown>} options.extraEnvironmentVariables - Extra
+ * environment variables to inject just into this bundle.
  * @param {string[] | null} options.ignoredFiles - A list of files to exclude
  * from the current build.
  * @param {string} options.label - A label used to describe this bundle in any
@@ -830,6 +795,7 @@ function createNormalBundle({
   destFilepath,
   devMode,
   entryFilepath,
+  extraEnvironmentVariables,
   ignoredFiles,
   label,
   policyOnly,
@@ -847,12 +813,15 @@ function createNormalBundle({
     const reloadOnChange = Boolean(devMode);
     const minify = Boolean(devMode) === false;
 
-    const envVars = getEnvironmentVariables({
-      buildType,
-      devMode,
-      testing,
-      version,
-    });
+    const envVars = {
+      ...getEnvironmentVariables({
+        buildType,
+        devMode,
+        testing,
+        version,
+      }),
+      ...extraEnvironmentVariables,
+    };
     setupBundlerDefaults(buildConfiguration, {
       buildType,
       devMode,


### PR DESCRIPTION
## Explanation

The way we were injecting variables into the `app-init.js` bundle was accidentally overwriting the bundle output with the raw `app-init.js` source file. This is a problem because the bundling process handles a lot of things we care about like source maps, polyfills and other necessary Babel transformations, environment variable injection, and minification.

Instead of using string replacement to inject variables, we are now using environment variables. The old string replacement strategy has been removed, and the `app-init.js` module is now generated using the same process as our other bundles.

A new option, "extraEnvironmentVariables", was added to allow us to inject environment variables specifically for this bundle.

## More Information

This string replacement strategy for injection was originally introduced in #14762, and later expanded in #14795.

## Manual Testing Steps

When running `ENABLE_MV3=true yarn dist`, you should now see that `dist/chrome/app-init.js` is minified and includes polyfills. Previously it included no polyfills and was not minified.

I do not expect this to have any user-facing changes. It should work the same as it did before.

## Pre-Merge Checklist

- [x] PR template is filled out
- [ ] **IF** this PR fixes a bug, a test that _would have_ caught the bug has been added
- [ ] PR is linked to the appropriate GitHub issue
- [ ] PR has been added to the appropriate release Milestone

### + If there are functional changes:

- [ ] Manual testing complete & passed
- [ ] "Extension QA Board" label has been applied
