### PR TITLE
cast chainId to hex for metrics

### DIFF
--- a/ui/pages/settings/networks-tab/networks-form/networks-form.js
+++ b/ui/pages/settings/networks-tab/networks-form/networks-form.js
@@ -11,6 +11,7 @@ import PropTypes from 'prop-types';
 import validUrl from 'valid-url';
 import log from 'loglevel';
 import classnames from 'classnames';
+import { addHexPrefix } from 'ethereumjs-util';
 import { useI18nContext } from '../../../../hooks/useI18nContext';
 import {
   isPrefixedFormattedHexString,
@@ -518,6 +519,7 @@ const NetworksForm = ({
         } catch {
           // error
         }
+        console.log(chainId);
         trackEvent({
           event: 'Custom Network Added',
           category: EVENT.CATEGORIES.NETWORK,
@@ -525,7 +527,7 @@ const NetworksForm = ({
             url: rpcUrlOrigin,
           },
           properties: {
-            chain_id: chainId,
+            chain_id: addHexPrefix(chainId.toString(16)),
             network_name: networkName,
             network: rpcUrlOrigin,
             symbol: ticker,

--- a/ui/pages/settings/networks-tab/networks-form/networks-form.js
+++ b/ui/pages/settings/networks-tab/networks-form/networks-form.js
@@ -519,7 +519,6 @@ const NetworksForm = ({
         } catch {
           // error
         }
-        console.log(chainId);
         trackEvent({
           event: 'Custom Network Added',
           category: EVENT.CATEGORIES.NETWORK,


### PR DESCRIPTION
## Explanation
@worldlyjohn called out in the  developer mixpanel that the chainId for this event was showing as a decimal. This only happens with one of the three cases where we fire the event, because in the advanced form the chainId variable is in decimal format. This PR simply casts it to hex format for the metric event. 
