### PR TITLE
[FLASK] disable "Mark all as read button" when there are no notifications

### DIFF
--- a/ui/pages/notifications/notification.test.js
+++ b/ui/pages/notifications/notification.test.js
@@ -64,9 +64,10 @@ describe('Notifications', () => {
       },
     };
 
-    const { getByText } = render(mockStore);
+    const { getByText, getByRole } = render(mockStore);
 
     expect(getByText('Nothing to see here.')).toBeDefined();
+    expect(getByRole('button', { name: 'Mark all as read' })).toBeDisabled();
   });
 });
 

--- a/ui/pages/notifications/notifications.js
+++ b/ui/pages/notifications/notifications.js
@@ -99,7 +99,7 @@ export default function Notifications() {
           type="secondary"
           className="notifications__header_button"
           onClick={markAllAsRead}
-          disabled={notifications.length === 0}
+          disabled={unreadNotifications.length === 0}
         >
           {t('notificationsMarkAllAsRead')}
         </Button>

--- a/ui/pages/notifications/notifications.js
+++ b/ui/pages/notifications/notifications.js
@@ -99,6 +99,7 @@ export default function Notifications() {
           type="secondary"
           className="notifications__header_button"
           onClick={markAllAsRead}
+          disabled={notifications.length === 0}
         >
           {t('notificationsMarkAllAsRead')}
         </Button>


### PR DESCRIPTION
Fixes: https://github.com/MetaMask/metamask-extension/issues/15327