### PR TITLE
fix filetype audit

### DIFF
--- a/.iyarc
+++ b/.iyarc
@@ -3,3 +3,4 @@ GHSA-93q8-gq69-wqmw
 GHSA-257v-vj4p-3w2h
 GHSA-wm7h-9275-46v2
 GHSA-pfrx-2q88-qq97
+GHSA-mhxj-85r3-2x55


### PR DESCRIPTION
## Explanation
The place in which the dependency is used in the 3box-js repo is in creating a server locally for testing purposes (it seems) I am fairly confident our code never invokes the gateway module inside the 3box dependency. 