### PR TITLE
remove audit exclusion

### DIFF
--- a/.iyarc
+++ b/.iyarc
@@ -3,4 +3,3 @@ GHSA-93q8-gq69-wqmw
 GHSA-257v-vj4p-3w2h
 GHSA-wm7h-9275-46v2
 GHSA-pfrx-2q88-qq97
-GHSA-mhxj-85r3-2x55


### PR DESCRIPTION
In a previous PR an audit exclusion was added to prevent failures in the build process. That pr passed checks and was merged but now develop is failing because the audit failure doesnt show the exclusion anymore. This PR attempts to correct the build