### PR TITLE
[FLASK] Fix missing snap hook

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -3728,6 +3728,9 @@ export default class MetamaskController extends EventEmitter {
     engine.push(
       createSnapMethodMiddleware(subjectType === SUBJECT_TYPES.SNAP, {
         getAppKey: this.getAppKeyForSubject.bind(this, origin),
+        getUnlockPromise: this.appStateController.getUnlockPromise.bind(
+          this.appStateController,
+        ),
         getSnaps: this.snapController.getPermittedSnaps.bind(
           this.snapController,
           origin,


### PR DESCRIPTION
## Explanation
@hmalik88 Discovered that we were missing the `getUnlockPromise` hook for `getAppKey`, breaking some of our snap examples. This PR addresses this.

## Manual Testing Steps
1. Run the following snap: https://github.com/MetaMask/snaps-skunkworks/tree/main/packages/examples/examples/bls-signer
2. Click "get public key" on the snap DApp and see that it works!
