### PR TITLE
fix: patch borc to avoid v8 bailing out of caching bytecode for the entire bundle chunk

### DIFF
--- a/patches/borc+2.1.2.patch
+++ b/patches/borc+2.1.2.patch
@@ -1,0 +1,13 @@
+diff --git a/node_modules/borc/src/decoder.asm.js b/node_modules/borc/src/decoder.asm.js
+index d77a3c2..dc70f6b 100644
+--- a/node_modules/borc/src/decoder.asm.js
++++ b/node_modules/borc/src/decoder.asm.js
+@@ -1,7 +1,7 @@
+ /* eslint-disable */
+ 
+ module.exports = function decodeAsm (stdlib, foreign, buffer) {
+-  'use asm'
++  // 'use asm' //causes v8 to not cache bytecode
+ 
+   // -- Imports
+ 


### PR DESCRIPTION
Here's a comparison of tracing results from reviving the mv3 service worker (starting it after it's been running and stopped) before and after removing the 'use asm' line.
![compile-before-after](https://user-images.githubusercontent.com/509375/181771194-8a00fcff-d9d6-4099-a1bc-d4554543000b.png)



The gain on my machine is a bit under 100ms out of about 1 second, but chunks can get split differently or we might decide to increase the chunk size and both of those situations may increase the impact of this.