### PR TITLE
Fix error that occurs when attempting to display transaction value for a transaction with no value argument in the transaction data (in this case `approve()`)

### DIFF
--- a/ui/hooks/useTokenDisplayValue.js
+++ b/ui/hooks/useTokenDisplayValue.js
@@ -35,6 +35,8 @@ export function useTokenDisplayValue(
   isTokenTransaction = true,
 ) {
   const tokenData = useTokenData(transactionData, isTokenTransaction);
+  const tokenValue = getTokenValueParam(tokenData);
+
   const shouldCalculateTokenValue = Boolean(
     // If we are currently processing a token transaction
     isTokenTransaction &&
@@ -42,15 +44,17 @@ export function useTokenDisplayValue(
       transactionData &&
       // and a token object has been provided
       token &&
-      // and we are able to parse the token details from the raw data
-      tokenData?.args?.length,
+      // and the provided token object contains a defined decimal value we need to calculate amount
+      token.decimals &&
+      // and we are able to parse the token detail we to calculate amount from the raw data
+      tokenValue,
   );
 
   const displayValue = useMemo(() => {
     if (!shouldCalculateTokenValue) {
       return null;
     }
-    const tokenValue = getTokenValueParam(tokenData);
+
     return calcTokenAmount(tokenValue, token.decimals).toString(10);
   }, [shouldCalculateTokenValue, tokenData, token]);
 


### PR DESCRIPTION
Fixes: [Issue reported by multiple users to support over the weekend](https://consensys.slack.com/archives/G8RSKCNCD/p1659269491451729)

**The issue:** When users approve an asset and then go to the home screen for that asset (or the `activity` tab on the home screen without clicking into the asset) they get `BigNumber` error:
https://user-images.githubusercontent.com/34557516/182171511-8f252132-b826-42a5-a982-dc3a1e8ef5ca.mp4

This issue appears to have been introduced [here](https://github.com/MetaMask/metamask-extension/pull/15010/files#diff-566f3f9284972168eb2714bfb0e73c85c19d89dfd535fbe58d06ed4cda90c45eR20), since after this change a truthy value was passed to `useTokenDisplay` [here](https://github.com/MetaMask/metamask-extension/blob/develop/ui/hooks/useTransactionDisplayData.js#L159), and so `shouldCalculateTokenValue` gets set to true [here](https://github.com/MetaMask/metamask-extension/blob/bca9a61d6b9f8cb604d4d3a7eb3adfe6b87c1297/ui/hooks/useTokenDisplayValue.js#L38), and then we attempt to calculate the `tokenAmount` even though the transaction data does not contain a `_value` arg.

**The Fix:**
modify the `shouldCalculateTokenValue` conditional to only move on to calculating the amount if we are able to extract the `_value` arg required to successful/safely calculate the amount.