### PR TITLE
Enhance approval screen title logic

### DIFF
--- a/ui/pages/confirm-approve/confirm-approve-content/confirm-approve-content.component.js
+++ b/ui/pages/confirm-approve/confirm-approve-content/confirm-approve-content.component.js
@@ -471,6 +471,7 @@ export default class ConfirmApproveContent extends Component {
       [...TEST_CHAINS, MAINNET_CHAIN_ID].includes(chainId);
 
     let titleTokenDescription = t('token');
+    const tokenIdWrapped = tokenId ? ` (#${tokenId})` : '';
     if (
       assetStandard === ERC20 ||
       (tokenSymbol && !tokenId && !isSetApproveForAll)
@@ -483,9 +484,8 @@ export default class ConfirmApproveContent extends Component {
       (assetName && tokenId) ||
       (tokenSymbol && tokenId)
     ) {
-      const tokenIdWrapped = tokenId ? ` (#${tokenId})` : '';
       if (assetName || tokenSymbol) {
-        titleTokenDescription = `${assetName ?? tokenSymbol}${tokenIdWrapped}`;
+        titleTokenDescription = `${assetName ?? tokenSymbol}`;
       } else {
         titleTokenDescription = t('nft');
       }
@@ -519,15 +519,18 @@ export default class ConfirmApproveContent extends Component {
     }
 
     return (
-      <span
-        className="confirm-approve-content__approval-asset-title"
-        onClick={() => {
-          copyToClipboard(tokenAddress);
-        }}
-        title={tokenAddress}
-      >
-        {titleTokenDescription}
-      </span>
+      <>
+        <span
+          className="confirm-approve-content__approval-asset-title"
+          onClick={() => {
+            copyToClipboard(tokenAddress);
+          }}
+          title={tokenAddress}
+        >
+          {titleTokenDescription}
+        </span>
+        {tokenIdWrapped && <span>{tokenIdWrapped}</span>}
+      </>
     );
   }
 

--- a/ui/pages/confirm-approve/confirm-approve-content/confirm-approve-content.component.test.js
+++ b/ui/pages/confirm-approve/confirm-approve-content/confirm-approve-content.component.test.js
@@ -39,11 +39,12 @@ const props = {
 
 describe('ConfirmApproveContent Component', () => {
   it('should render Confirm approve page correctly', () => {
-    const { queryByText, getByText, getAllByText } = renderComponent(props);
+    const { queryByText, getByText, getAllByText, getByTestId } =
+      renderComponent(props);
     expect(queryByText('metamask.github.io')).toBeInTheDocument();
-    expect(
-      queryByText('Give permission to access your TST?'),
-    ).toBeInTheDocument();
+    expect(getByTestId('confirm-approve-title').textContent).toStrictEqual(
+      ' Give permission to access your TST? ',
+    );
     expect(
       queryByText(
         'By granting permission, you are allowing the following contract to access your funds',

--- a/ui/pages/confirm-approve/confirm-approve-content/index.scss
+++ b/ui/pages/confirm-approve/confirm-approve-content/index.scss
@@ -9,8 +9,12 @@
     padding: 0 24px 16px 24px;
   }
 
-  &__unknown-asset {
+  &__approval-asset-link {
     color: var(--color-primary-default);
+  }
+
+  &__approval-asset-title {
+    cursor: pointer;
   }
 
   &__icon-display-content {


### PR DESCRIPTION
Fixes: https://github.com/MetaMask/metamask-extension/issues/15377

A minor refactor/enhancement of some of the logic introduced in the [`setApprovalForAll` screen PR](https://github.com/MetaMask/metamask-extension/pull/15010).

Changes:
1. I realized it probably doesn't make sense to only make the title contain a link to the blockExplorer if we don't know the name or symbol of the token, so this makes the name, symbol, or generic "NFT" or "Token" title a link if there is a block explorer available:
          -**setApprovalForAll** : https://user-images.githubusercontent.com/34557516/182232491-e3b9cd7f-6ff7-4acc-8608-f28c977266e0.mov
          -**approve**: https://user-images.githubusercontent.com/34557516/182249887-7d72b514-42e0-4597-b5ea-c136bf4a9c95.mov
2. Fixes a bug where for NFTs (ERC721 or ERC1155) we showed the title (the name, symbol or "NFT") as a link even when we didn't have a block explorer available - meaning the link didn't work.
Before:
https://user-images.githubusercontent.com/34557516/182234026-910793c6-0a75-4ce6-81d8-d1d692e195d6.mov
After:
https://user-images.githubusercontent.com/34557516/182248156-b8852ccb-f3a0-4901-9c42-f111d999c6b5.mov

3. In the case where no block explorer is available, makes the contract address copy to the clipboard when the name/symbol/"NFT" or "Token" label is clicked in the title (cc @SayaGT @rachelcope, not sure if there is some better pattern for making it clear this will copy, tried adding the copy icon, but it looked wrong in this context) :
https://user-images.githubusercontent.com/34557516/182231811-abf183ea-1c0b-4e54-8983-ffe84b19826b.mov

4. Makes the contract address show on hover over the name/symbol/"NFT" or "Token" label in the title (whether or not there is a block explorer link). (Depicted in videos above)