### PR TITLE
fix issues relating to race conditions where draftTx does not exist

### DIFF
--- a/ui/ducks/send/send.js
+++ b/ui/ducks/send/send.js
@@ -603,7 +603,7 @@ export const initializeSendState = createAsyncThunk(
     // For instance, in the actions.js file we dispatch this action anytime the
     // chain changes.
     if (!draftTransaction) {
-      thunkApi.rejectWithValue(
+      return thunkApi.rejectWithValue(
         'draftTransaction not found, possibly not on send flow',
       );
     }
@@ -1396,28 +1396,30 @@ const slice = createSlice({
     validateSendState: (state) => {
       const draftTransaction =
         state.draftTransactions[state.currentTransactionUUID];
-      switch (true) {
-        case Boolean(draftTransaction.amount.error):
-        case Boolean(draftTransaction.gas.error):
-        case Boolean(draftTransaction.asset.error):
-        case draftTransaction.asset.type === ASSET_TYPES.TOKEN &&
-          draftTransaction.asset.details === null:
-        case state.stage === SEND_STAGES.ADD_RECIPIENT:
-        case state.stage === SEND_STAGES.INACTIVE:
-        case state.gasEstimateIsLoading:
-        case new BigNumber(draftTransaction.gas.gasLimit, 16).lessThan(
-          new BigNumber(state.gasLimitMinimum),
-        ):
-          draftTransaction.status = SEND_STATUSES.INVALID;
-          break;
-        case draftTransaction.recipient.warning === 'loading':
-        case draftTransaction.recipient.warning ===
-          KNOWN_RECIPIENT_ADDRESS_WARNING &&
-          draftTransaction.recipient.recipientWarningAcknowledged === false:
-          draftTransaction.status = SEND_STATUSES.INVALID;
-          break;
-        default:
-          draftTransaction.status = SEND_STATUSES.VALID;
+      if (draftTransaction) {
+        switch (true) {
+          case Boolean(draftTransaction.amount.error):
+          case Boolean(draftTransaction.gas.error):
+          case Boolean(draftTransaction.asset.error):
+          case draftTransaction.asset.type === ASSET_TYPES.TOKEN &&
+            draftTransaction.asset.details === null:
+          case state.stage === SEND_STAGES.ADD_RECIPIENT:
+          case state.stage === SEND_STAGES.INACTIVE:
+          case state.gasEstimateIsLoading:
+          case new BigNumber(draftTransaction.gas.gasLimit, 16).lessThan(
+            new BigNumber(state.gasLimitMinimum),
+          ):
+            draftTransaction.status = SEND_STATUSES.INVALID;
+            break;
+          case draftTransaction.recipient.warning === 'loading':
+          case draftTransaction.recipient.warning ===
+            KNOWN_RECIPIENT_ADDRESS_WARNING &&
+            draftTransaction.recipient.recipientWarningAcknowledged === false:
+            draftTransaction.status = SEND_STATUSES.INVALID;
+            break;
+          default:
+            draftTransaction.status = SEND_STATUSES.VALID;
+        }
       }
     },
   },
@@ -1512,26 +1514,28 @@ const slice = createSlice({
         state.selectedAccount.balance = action.payload.account.balance;
         const draftTransaction =
           state.draftTransactions[state.currentTransactionUUID];
-        draftTransaction.gas.gasLimit = action.payload.gasLimit;
+        if (draftTransaction) {
+          draftTransaction.gas.gasLimit = action.payload.gasLimit;
+          draftTransaction.gas.gasTotal = action.payload.gasTotal;
+          if (action.payload.chainHasChanged) {
+            // If the state was reinitialized as a result of the user changing
+            // the network from the network dropdown, then the selected asset is
+            // no longer valid and should be set to the native asset for the
+            // network.
+            draftTransaction.asset.type = ASSET_TYPES.NATIVE;
+            draftTransaction.asset.balance =
+              draftTransaction.fromAccount?.balance ??
+              state.selectedAccount.balance;
+            draftTransaction.asset.details = null;
+          }
+        }
         slice.caseReducers.updateGasFeeEstimates(state, {
           payload: {
             gasFeeEstimates: action.payload.gasFeeEstimates,
             gasEstimateType: action.payload.gasEstimateType,
           },
         });
-        draftTransaction.gas.gasTotal = action.payload.gasTotal;
         state.gasEstimatePollToken = action.payload.gasEstimatePollToken;
-        if (action.payload.chainHasChanged) {
-          // If the state was reinitialized as a result of the user changing
-          // the network from the network dropdown, then the selected asset is
-          // no longer valid and should be set to the native asset for the
-          // network.
-          draftTransaction.asset.type = ASSET_TYPES.NATIVE;
-          draftTransaction.asset.balance =
-            draftTransaction.fromAccount?.balance ??
-            state.selectedAccount.balance;
-          draftTransaction.asset.details = null;
-        }
         if (action.payload.gasEstimatePollToken) {
           state.gasEstimateIsLoading = false;
         }
@@ -2641,7 +2645,11 @@ export function isSendStateInitialized(state) {
  * @type {Selector<boolean>}
  */
 export function isSendFormInvalid(state) {
-  return getCurrentDraftTransaction(state).status === SEND_STATUSES.INVALID;
+  const draftTransaction = getCurrentDraftTransaction(state);
+  if (!draftTransaction) {
+    return true;
+  }
+  return draftTransaction.status === SEND_STATUSES.INVALID;
 }
 
 /**

--- a/ui/ducks/send/send.js
+++ b/ui/ducks/send/send.js
@@ -678,6 +678,20 @@ export const initializeSendState = createAsyncThunk(
     // We have to keep the gas slice in sync with the send slice state
     // so that it'll be initialized correctly if the gas modal is opened.
     await thunkApi.dispatch(setCustomGasLimit(gasLimit));
+
+    // There may be a case where the send has been canceled by the user while
+    // the gas estimate is being computed. So we check again to make sure that
+    // a currentTransactionUUID exists and matches the previous tx.
+    const newState = thunkApi.getState();
+    if (
+      newState.send.currentTransactionUUID !== sendState.currentTransactionUUID
+    ) {
+      return thunkApi.rejectWithValue(
+        `draftTransaction changed during initialization.
+        A new initializeSendState action must be dispatched.`,
+      );
+    }
+
     return {
       account,
       chainId: getCurrentChainId(state),


### PR DESCRIPTION
## Explanation
This PR adds additional safety to the send duck when draftTransaction is not present. It does this in a few ways:
1. Only attempts to update draftTransaction.status if a draftTransaction exists. To make sure we reflect the appropriate status we also return 'true' for isSendFormInvalid when draftTransaction does not exist.
2. In the case for 'initializeSendState.fulfilled' we only update draftTransaction values if it exists, but the very possibility that we hit this `fulfilled` condition without a valid draftTransaction implies that we have a race condition, so...
3. An additional failsafe is added to the end of the initialize thunk that re-checks state to see if the draftTransaction has changed. This check happens after the async methods that are awaited in this initialize method. 

## More Information
Fixes #15403 
Fixes #15401

<!--
Are there any issues, Slack conversations, Zendesk issues, user stories, etc. reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

## Screenshots/Screencaps

<!-- If you're making a change to the UI, make sure to capture a screenshot or a short video showing off your work! -->

### Before

<!-- How did the UI you changed look before your changes? Drag your file(s) below this line: -->

### After

<!-- How does it look now? Drag your file(s) below this line: -->

## Manual Testing Steps

<!--
How should reviewers and QA manually test your changes? For instance:

- Go to this screen
- Do this
- Then do this
-->

## Pre-Merge Checklist

- [ ] PR template is filled out
- [ ] **IF** this PR fixes a bug, a test that _would have_ caught the bug has been added
- [ ] PR is linked to the appropriate GitHub issue
- [ ] PR has been added to the appropriate release Milestone

### + If there are functional changes:

- [ ] Manual testing complete & passed
- [ ] "Extension QA Board" label has been applied
