### PR TITLE
remove unnecessary usage of renderableGasButton logic

### DIFF
--- a/ui/pages/send/send-footer/send-footer.component.js
+++ b/ui/pages/send/send-footer/send-footer.component.js
@@ -20,7 +20,6 @@ export default class SendFooter extends Component {
     toAccounts: PropTypes.array,
     sendStage: PropTypes.string,
     sendErrors: PropTypes.object,
-    gasEstimateType: PropTypes.string,
     mostRecentOverviewPage: PropTypes.string.isRequired,
     cancelTx: PropTypes.func,
     draftTransactionID: PropTypes.string,
@@ -53,14 +52,7 @@ export default class SendFooter extends Component {
 
   async onSubmit(event) {
     event.preventDefault();
-    const {
-      addToAddressBookIfNew,
-      sign,
-      to,
-      toAccounts,
-      history,
-      gasEstimateType,
-    } = this.props;
+    const { addToAddressBookIfNew, sign, to, toAccounts, history } = this.props;
     const { trackEvent } = this.context;
 
     // TODO: add nickname functionality
@@ -74,7 +66,6 @@ export default class SendFooter extends Component {
         properties: {
           action: 'Edit Screen',
           legacy_event: true,
-          gasChanged: gasEstimateType,
         },
       });
       history.push(CONFIRM_TRANSACTION_ROUTE);

--- a/ui/pages/send/send-footer/send-footer.container.js
+++ b/ui/pages/send/send-footer/send-footer.container.js
@@ -1,12 +1,7 @@
 import { connect } from 'react-redux';
 import { addToAddressBook, cancelTx } from '../../../store/actions';
 import {
-  getRenderableEstimateDataForSmallButtonsFromGWEI,
-  getDefaultActiveButtonIndex,
-} from '../../../selectors';
-import {
   resetSendState,
-  getGasPrice,
   getSendStage,
   getSendTo,
   getSendErrors,
@@ -17,7 +12,6 @@ import {
 import { getMostRecentOverviewPage } from '../../../ducks/history/history';
 import { addHexPrefix } from '../../../../app/scripts/lib/util';
 import { getSendToAccounts } from '../../../ducks/metamask/metamask';
-import { CUSTOM_GAS_ESTIMATE } from '../../../../shared/constants/gas';
 import SendFooter from './send-footer.component';
 
 export default connect(mapStateToProps, mapDispatchToProps)(SendFooter);
@@ -31,17 +25,6 @@ function addressIsNew(toAccounts, newAddress) {
 }
 
 function mapStateToProps(state) {
-  const gasButtonInfo = getRenderableEstimateDataForSmallButtonsFromGWEI(state);
-  const gasPrice = getGasPrice(state);
-  const activeButtonIndex = getDefaultActiveButtonIndex(
-    gasButtonInfo,
-    gasPrice,
-  );
-  const gasEstimateType =
-    activeButtonIndex >= 0
-      ? gasButtonInfo[activeButtonIndex].gasEstimateType
-      : CUSTOM_GAS_ESTIMATE;
-
   return {
     disabled: isSendFormInvalid(state),
     to: getSendTo(state),
@@ -49,7 +32,6 @@ function mapStateToProps(state) {
     sendStage: getSendStage(state),
     sendErrors: getSendErrors(state),
     draftTransactionID: getDraftTransactionID(state),
-    gasEstimateType,
     mostRecentOverviewPage: getMostRecentOverviewPage(state),
   };
 }

--- a/ui/pages/send/send-footer/send-footer.container.test.js
+++ b/ui/pages/send/send-footer/send-footer.container.test.js
@@ -31,11 +31,6 @@ jest.mock('../../../ducks/send', () => ({
   signTransaction: jest.fn(),
 }));
 
-jest.mock('../../../selectors/custom-gas', () => ({
-  getRenderableEstimateDataForSmallButtonsFromGWEI: (s) => [
-    { gasEstimateType: `mockGasEstimateType:${s}` },
-  ],
-}));
 require('./send-footer.container');
 
 describe('send-footer container', () => {


### PR DESCRIPTION
## Explanation
We are getting gasEstimateType by examining which button of the old gas buttons UI was selected. We only used this value for a legacy metric event for transactions we no longer use. 

## More Information
Fixes #15415

