### PR TITLE
Add access protection (optional-chaining) to the `getNativeCurrencyImage` selector in case it is the source of a mysterious bug on firefox

### DIFF
--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -725,7 +725,7 @@ export function getIsBuyableCoinbasePayChain(state) {
 }
 
 export function getNativeCurrencyImage(state) {
-  const nativeCurrency = getNativeCurrency(state).toUpperCase();
+  const nativeCurrency = getNativeCurrency(state)?.toUpperCase();
   return NATIVE_CURRENCY_TOKEN_IMAGE_MAP[nativeCurrency];
 }
 


### PR DESCRIPTION
I'm struggling to reproduce https://github.com/MetaMask/metamask-extension/issues/15397, but @danjm and I believe the attempt to call `toUpperCase()` without protecting against the case where what's returned by `getNativeCurrency(state)` is undefined (or is not a string?) may be the culprit. 