### PR TITLE
Moving incorrectly ordered page component to correct pages category

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -33,7 +33,7 @@ addParameters({
         'Foundations',
         ['Color', 'Shadow', 'Breakpoints'],
         'Components',
-        ['UI', 'App'],
+        ['UI', 'App', 'Component Library'],
         'Pages',
       ],
     },

--- a/ui/pages/confirmation/components/confirmation-network-switch/confirmation-network-switch.stories.js
+++ b/ui/pages/confirmation/components/confirmation-network-switch/confirmation-network-switch.stories.js
@@ -2,7 +2,7 @@ import React from 'react';
 import ConfirmationNetworkSwitch from '.';
 
 export default {
-  title: 'Components/Pages/Confirmation/Components/ConfirmationNetworkSwitch', // ui/pages/confirmation/components/confirmation-network-switch/confirmation-network-switch.js
+  title: 'Pages/Confirmation/Components/ConfirmationNetworkSwitch',
   id: __filename,
   argTypes: {
     newNetwork: {


### PR DESCRIPTION
## Explanation

Currently, there is an incorrectly ordered page component in the components folder. This pull request moves it to it's correct category


## Screenshots/Screencaps

<!-- If you're making a change to the UI, make sure to capture a screenshot or a short video showing off your work! -->

### Before

<img width="1365" alt="Screen Shot 2022-08-02 at 3 37 53 PM" src="https://user-images.githubusercontent.com/8112138/182485518-0690c83c-b1c7-437e-90a2-5129827716db.png">


### After

<img width="1041" alt="Screen Shot 2022-08-02 at 3 38 19 PM" src="https://user-images.githubusercontent.com/8112138/182485539-cdc41549-ed16-47af-949a-02e4cd3dc091.png">


## Manual Testing Steps
- Go to the [storybook build in this PR](https://output.circle-artifacts.com/output/job/5de52b95-801b-4707-892b-2777fb32633a/artifacts/0/storybook/index.html?path=/story/ui-pages-confirmation-components-confirmation-network-switch-confirmation-network-switch-stories-js--default-story)
- Search `ConfirmationNetworkSwitch` in the search bar
- Click on the result
- See story in it's correct location following the folder structure convention

## Pre-Merge Checklist

- [x] PR template is filled out
- [x] ~**IF** this PR fixes a bug, a test that _would have_ caught the bug has been added~ N/A
- [] PR is linked to the appropriate GitHub issue
- [x] ~PR has been added to the appropriate release Milestone~ N/A

### + If there are functional changes:

- [x] ~Manual testing complete & passed~ N/A
- [x] ~"Extension QA Board" label has been applied~ N/A
