### PR TITLE
Opening Network Forms in full screen from the popup view

### DIFF
--- a/ui/pages/settings/networks-tab/networks-list-item/networks-list-item.js
+++ b/ui/pages/settings/networks-tab/networks-list-item/networks-list-item.js
@@ -2,7 +2,6 @@ import React, { useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { useDispatch, useSelector } from 'react-redux';
-import { useHistory } from 'react-router-dom';
 import { useI18nContext } from '../../../../hooks/useI18nContext';
 import {
   NETWORK_TYPE_RPC,
@@ -10,7 +9,7 @@ import {
 } from '../../../../../shared/constants/network';
 import LockIcon from '../../../../components/ui/lock-icon';
 import IconCheck from '../../../../components/ui/icon/icon-check';
-import { NETWORKS_FORM_ROUTE } from '../../../../helpers/constants/routes';
+import { NETWORKS_ROUTE } from '../../../../helpers/constants/routes';
 import { setSelectedSettingsRpcUrl } from '../../../../store/actions';
 import { getEnvironmentType } from '../../../../../app/scripts/lib/util';
 import { ENVIRONMENT_TYPE_FULLSCREEN } from '../../../../../shared/constants/app';
@@ -28,7 +27,6 @@ const NetworksListItem = ({
   setSearchedNetworks,
 }) => {
   const t = useI18nContext();
-  const history = useHistory();
   const dispatch = useDispatch();
   const environmentType = getEnvironmentType();
   const isFullScreen = environmentType === ENVIRONMENT_TYPE_FULLSCREEN;
@@ -68,7 +66,7 @@ const NetworksListItem = ({
         setSearchedNetworks([]);
         dispatch(setSelectedSettingsRpcUrl(rpcUrl));
         if (!isFullScreen) {
-          history.push(NETWORKS_FORM_ROUTE);
+          global.platform.openExtensionInBrowser(NETWORKS_ROUTE);
         }
       }}
     >


### PR DESCRIPTION
Fixes: https://github.com/MetaMask/metamask-extension/issues/15399

This restores the behavior of opening the Network form in full view when attempting to edit one via the popup window.

Testing involves a simple regression check in the full screen view and ensuring the aformentioned behavior in the popup