### PR TITLE
Ensure that if max is selected in send flow, the correct value is set after network switch

### DIFF
--- a/ui/ducks/send/send.js
+++ b/ui/ducks/send/send.js
@@ -1563,6 +1563,9 @@ const slice = createSlice({
             },
           });
         }
+        if (state.amountMode === AMOUNT_MODES.MAX) {
+          slice.caseReducers.updateAmountToMax(state);
+        }
         slice.caseReducers.validateAmountField(state);
         slice.caseReducers.validateGasField(state);
         slice.caseReducers.validateSendState(state);

--- a/ui/store/actions.js
+++ b/ui/store/actions.js
@@ -1444,6 +1444,10 @@ export function updateMetamaskState(newState) {
         },
       });
     }
+    dispatch({
+      type: actionConstants.UPDATE_METAMASK_STATE,
+      value: newState,
+    });
     if (provider.chainId !== newProvider.chainId) {
       dispatch({
         type: actionConstants.CHAIN_CHANGED,
@@ -1455,10 +1459,6 @@ export function updateMetamaskState(newState) {
       // progress.
       dispatch(initializeSendState({ chainHasChanged: true }));
     }
-    dispatch({
-      type: actionConstants.UPDATE_METAMASK_STATE,
-      value: newState,
-    });
   };
 }
 


### PR DESCRIPTION
Fixes https://github.com/MetaMask/metamask-extension/issues/15405

Explanation:

After switching networks, if max amount is selected on the send flow, the amount needs to be updated to reflect the new balance.