### PR TITLE
Fix #14846 - Inject provider for MV3 via app-init

### DIFF
--- a/app/manifest/v3/_base.json
+++ b/app/manifest/v3/_base.json
@@ -47,6 +47,7 @@
   ],
   "default_locale": "en",
   "description": "__MSG_appDescription__",
+  "host_permissions": ["file://*/*", "http://*/*", "https://*/*"],
   "icons": {
     "16": "images/icon-16.png",
     "19": "images/icon-19.png",
@@ -61,6 +62,7 @@
   "name": "__MSG_appName__",
   "permissions": [
     "storage",
+    "scripting",
     "unlimitedStorage",
     "clipboardWrite",
     "http://localhost:8545/",

--- a/app/manifest/v3/_base.json
+++ b/app/manifest/v3/_base.json
@@ -28,7 +28,7 @@
   },
   "content_scripts": [
     {
-      "matches": ["http://*/*", "https://*/*"],
+      "matches": ["file://*/*", "http://*/*", "https://*/*"],
       "js": [
         "disable-console.js",
         "globalthis.js",

--- a/app/manifest/v3/_base.json
+++ b/app/manifest/v3/_base.json
@@ -28,7 +28,7 @@
   },
   "content_scripts": [
     {
-      "matches": ["file://*/*", "http://*/*", "https://*/*"],
+      "matches": ["http://*/*", "https://*/*"],
       "js": [
         "disable-console.js",
         "globalthis.js",

--- a/app/scripts/app-init.js
+++ b/app/scripts/app-init.js
@@ -135,7 +135,7 @@ chrome.runtime.onMessage.addListener(() => {
 chrome.scripting.registerContentScripts([
   {
     id: 'inpage',
-    matches: ['file://*/*', 'http://*/*', 'https://*/*'],
+    matches: ['http://*/*', 'https://*/*'],
     js: ['inpage.js'],
     runAt: 'document_start',
     world: 'MAIN',

--- a/app/scripts/app-init.js
+++ b/app/scripts/app-init.js
@@ -126,3 +126,18 @@ chrome.runtime.onMessage.addListener(() => {
   importAllScripts();
   return false;
 });
+
+/*
+ * This content script is injected programmatically because
+ * MAIN world injection does not work properly via manifest
+ * https://bugs.chromium.org/p/chromium/issues/detail?id=634381
+ */
+chrome.scripting.registerContentScripts([
+  {
+    id: 'inpage',
+    matches: ['file://*/*', 'http://*/*', 'https://*/*'],
+    js: ['inpage.js'],
+    runAt: 'document_start',
+    world: 'MAIN',
+  },
+]);

--- a/app/scripts/app-init.js
+++ b/app/scripts/app-init.js
@@ -135,7 +135,7 @@ chrome.runtime.onMessage.addListener(() => {
 chrome.scripting.registerContentScripts([
   {
     id: 'inpage',
-    matches: ['http://*/*', 'https://*/*'],
+    matches: ['file://*/*', 'http://*/*', 'https://*/*'],
     js: ['inpage.js'],
     runAt: 'document_start',
     world: 'MAIN',

--- a/app/scripts/contentscript.js
+++ b/app/scripts/contentscript.js
@@ -43,7 +43,9 @@ if (
 ) {
   setupPhishingStream();
 } else if (shouldInjectProvider()) {
-  injectScript(inpageBundle);
+  if (!isManifestV3()) {
+    injectScript(inpageBundle);
+  }
   setupStreams();
 }
 
@@ -57,12 +59,7 @@ function injectScript(content) {
     const container = document.head || document.documentElement;
     const scriptTag = document.createElement('script');
     scriptTag.setAttribute('async', 'false');
-    // Inline scripts do not work in MV3 due to more strict security policy
-    if (isManifestV3()) {
-      scriptTag.setAttribute('src', browser.runtime.getURL('inpage.js'));
-    } else {
-      scriptTag.textContent = content;
-    }
+    scriptTag.textContent = content;
     container.insertBefore(scriptTag, container.children[0]);
     container.removeChild(scriptTag);
   } catch (error) {

--- a/app/scripts/contentscript.js
+++ b/app/scripts/contentscript.js
@@ -6,6 +6,7 @@ import PortStream from 'extension-port-stream';
 import { obj as createThoughStream } from 'through2';
 
 import { isManifestV3 } from '../../shared/modules/mv3.utils';
+import shouldInjectProvider from '../../shared/modules/provider-injection';
 
 // These require calls need to use require to be statically recognized by browserify
 const fs = require('fs');
@@ -259,100 +260,6 @@ function notifyInpageOfStreamFailure() {
     },
     window.location.origin,
   );
-}
-
-/**
- * Determines if the provider should be injected
- *
- * @returns {boolean} {@code true} Whether the provider should be injected
- */
-function shouldInjectProvider() {
-  return (
-    doctypeCheck() &&
-    suffixCheck() &&
-    documentElementCheck() &&
-    !blockedDomainCheck()
-  );
-}
-
-/**
- * Checks the doctype of the current document if it exists
- *
- * @returns {boolean} {@code true} if the doctype is html or if none exists
- */
-function doctypeCheck() {
-  const { doctype } = window.document;
-  if (doctype) {
-    return doctype.name === 'html';
-  }
-  return true;
-}
-
-/**
- * Returns whether or not the extension (suffix) of the current document is prohibited
- *
- * This checks {@code window.location.pathname} against a set of file extensions
- * that we should not inject the provider into. This check is indifferent of
- * query parameters in the location.
- *
- * @returns {boolean} whether or not the extension of the current document is prohibited
- */
-function suffixCheck() {
-  const prohibitedTypes = [/\.xml$/u, /\.pdf$/u];
-  const currentUrl = window.location.pathname;
-  for (let i = 0; i < prohibitedTypes.length; i++) {
-    if (prohibitedTypes[i].test(currentUrl)) {
-      return false;
-    }
-  }
-  return true;
-}
-
-/**
- * Checks the documentElement of the current document
- *
- * @returns {boolean} {@code true} if the documentElement is an html node or if none exists
- */
-function documentElementCheck() {
-  const documentElement = document.documentElement.nodeName;
-  if (documentElement) {
-    return documentElement.toLowerCase() === 'html';
-  }
-  return true;
-}
-
-/**
- * Checks if the current domain is blocked
- *
- * @returns {boolean} {@code true} if the current domain is blocked
- */
-function blockedDomainCheck() {
-  const blockedDomains = [
-    'adyen.com',
-    'ani.gamer.com.tw',
-    'blueskybooking.com',
-    'cdn.shopify.com/s/javascripts/tricorder/xtld-read-only-frame.html',
-    'docs.google.com',
-    'dropbox.com',
-    'gravityforms.com',
-    'harbourair.com',
-    'sharefile.com',
-    'uscourts.gov',
-    'webbyawards.com',
-  ];
-  const currentUrl = window.location.href;
-  let currentRegex;
-  for (let i = 0; i < blockedDomains.length; i++) {
-    const blockedDomain = blockedDomains[i].replace('.', '\\.');
-    currentRegex = new RegExp(
-      `(?:https?:\\/\\/)(?:(?!${blockedDomain}).)*$`,
-      'u',
-    );
-    if (!currentRegex.test(currentUrl)) {
-      return true;
-    }
-  }
-  return false;
 }
 
 /**

--- a/app/scripts/inpage.js
+++ b/app/scripts/inpage.js
@@ -1,9 +1,3 @@
-/* eslint-disable import/first */
-import log from 'loglevel';
-import { WindowPostMessageStream } from '@metamask/post-message-stream';
-import { initializeProvider } from '@metamask/providers/dist/initializeInpageProvider';
-import shouldInjectProvider from '../../shared/modules/provider-injection';
-
 // need to make sure we aren't affected by overlapping namespaces
 // and that we dont affect the app with our namespace
 // mostly a fix for web3's BigNumber if AMD's "define" is defined...
@@ -35,6 +29,12 @@ const restoreContextAfterImports = () => {
 };
 
 cleanContextForImports();
+
+/* eslint-disable import/first */
+import log from 'loglevel';
+import { WindowPostMessageStream } from '@metamask/post-message-stream';
+import { initializeProvider } from '@metamask/providers/dist/initializeInpageProvider';
+import shouldInjectProvider from '../../shared/modules/provider-injection';
 
 restoreContextAfterImports();
 

--- a/app/scripts/inpage.js
+++ b/app/scripts/inpage.js
@@ -2,152 +2,58 @@
 import log from 'loglevel';
 import { WindowPostMessageStream } from '@metamask/post-message-stream';
 import { initializeProvider } from '@metamask/providers/dist/initializeInpageProvider';
+import shouldInjectProvider from '../../shared/modules/provider-injection';
 
-(() => {
-  // need to make sure we aren't affected by overlapping namespaces
-  // and that we dont affect the app with our namespace
-  // mostly a fix for web3's BigNumber if AMD's "define" is defined...
-  let __define;
+// need to make sure we aren't affected by overlapping namespaces
+// and that we dont affect the app with our namespace
+// mostly a fix for web3's BigNumber if AMD's "define" is defined...
+let __define;
 
-  /**
-   * Caches reference to global define object and deletes it to
-   * avoid conflicts with other global define objects, such as
-   * AMD's define function
-   */
-  const cleanContextForImports = () => {
-    __define = global.define;
-    try {
-      global.define = undefined;
-    } catch (_) {
-      console.warn('MetaMask - global.define could not be deleted.');
-    }
-  };
-
-  /**
-   * Restores global define object from cached reference
-   */
-  const restoreContextAfterImports = () => {
-    try {
-      global.define = __define;
-    } catch (_) {
-      console.warn('MetaMask - global.define could not be overwritten.');
-    }
-  };
-
-  cleanContextForImports();
-
-  restoreContextAfterImports();
-
-  log.setDefaultLevel(process.env.METAMASK_DEBUG ? 'debug' : 'warn');
-
-  //
-  // setup plugin communication
-  //
-
-  if (shouldInjectProvider()) {
-    // setup background connection
-    const metamaskStream = new WindowPostMessageStream({
-      name: 'metamask-inpage',
-      target: 'metamask-contentscript',
-    });
-
-    initializeProvider({
-      connectionStream: metamaskStream,
-      logger: log,
-      shouldShimWeb3: true,
-    });
+/**
+ * Caches reference to global define object and deletes it to
+ * avoid conflicts with other global define objects, such as
+ * AMD's define function
+ */
+const cleanContextForImports = () => {
+  __define = global.define;
+  try {
+    global.define = undefined;
+  } catch (_) {
+    console.warn('MetaMask - global.define could not be deleted.');
   }
+};
 
-  /**
-   * Determines if the provider should be injected
-   *
-   * @returns {boolean} {@code true} Whether the provider should be injected
-   */
-  function shouldInjectProvider() {
-    return (
-      doctypeCheck() &&
-      suffixCheck() &&
-      documentElementCheck() &&
-      !blockedDomainCheck()
-    );
+/**
+ * Restores global define object from cached reference
+ */
+const restoreContextAfterImports = () => {
+  try {
+    global.define = __define;
+  } catch (_) {
+    console.warn('MetaMask - global.define could not be overwritten.');
   }
+};
 
-  /**
-   * Checks the doctype of the current document if it exists
-   *
-   * @returns {boolean} {@code true} if the doctype is html or if none exists
-   */
-  function doctypeCheck() {
-    const { doctype } = window.document;
-    if (doctype) {
-      return doctype.name === 'html';
-    }
-    return true;
-  }
+cleanContextForImports();
 
-  /**
-   * Returns whether or not the extension (suffix) of the current document is prohibited
-   *
-   * This checks {@code window.location.pathname} against a set of file extensions
-   * that we should not inject the provider into. This check is indifferent of
-   * query parameters in the location.
-   *
-   * @returns {boolean} whether or not the extension of the current document is prohibited
-   */
-  function suffixCheck() {
-    const prohibitedTypes = [/\.xml$/u, /\.pdf$/u];
-    const currentUrl = window.location.pathname;
-    for (let i = 0; i < prohibitedTypes.length; i++) {
-      if (prohibitedTypes[i].test(currentUrl)) {
-        return false;
-      }
-    }
-    return true;
-  }
+restoreContextAfterImports();
 
-  /**
-   * Checks the documentElement of the current document
-   *
-   * @returns {boolean} {@code true} if the documentElement is an html node or if none exists
-   */
-  function documentElementCheck() {
-    const documentElement = document.documentElement.nodeName;
-    if (documentElement) {
-      return documentElement.toLowerCase() === 'html';
-    }
-    return true;
-  }
+log.setDefaultLevel(process.env.METAMASK_DEBUG ? 'debug' : 'warn');
 
-  /**
-   * Checks if the current domain is blocked
-   *
-   * @returns {boolean} {@code true} if the current domain is blocked
-   */
-  function blockedDomainCheck() {
-    const blockedDomains = [
-      'uscourts.gov',
-      'dropbox.com',
-      'webbyawards.com',
-      'cdn.shopify.com/s/javascripts/tricorder/xtld-read-only-frame.html',
-      'adyen.com',
-      'gravityforms.com',
-      'harbourair.com',
-      'ani.gamer.com.tw',
-      'blueskybooking.com',
-      'sharefile.com',
-    ];
-    const currentUrl = window.location.href;
-    let currentRegex;
-    for (let i = 0; i < blockedDomains.length; i++) {
-      const blockedDomain = blockedDomains[i].replace('.', '\\.');
-      currentRegex = new RegExp(
-        `(?:https?:\\/\\/)(?:(?!${blockedDomain}).)*$`,
-        'u',
-      );
-      if (!currentRegex.test(currentUrl)) {
-        return true;
-      }
-    }
-    return false;
-  }
-})();
+//
+// setup plugin communication
+//
+
+if (shouldInjectProvider()) {
+  // setup background connection
+  const metamaskStream = new WindowPostMessageStream({
+    name: 'metamask-inpage',
+    target: 'metamask-contentscript',
+  });
+
+  initializeProvider({
+    connectionStream: metamaskStream,
+    logger: log,
+    shouldShimWeb3: true,
+  });
+}

--- a/app/scripts/inpage.js
+++ b/app/scripts/inpage.js
@@ -1,56 +1,153 @@
-// need to make sure we aren't affected by overlapping namespaces
-// and that we dont affect the app with our namespace
-// mostly a fix for web3's BigNumber if AMD's "define" is defined...
-let __define;
-
-/**
- * Caches reference to global define object and deletes it to
- * avoid conflicts with other global define objects, such as
- * AMD's define function
- */
-const cleanContextForImports = () => {
-  __define = global.define;
-  try {
-    global.define = undefined;
-  } catch (_) {
-    console.warn('MetaMask - global.define could not be deleted.');
-  }
-};
-
-/**
- * Restores global define object from cached reference
- */
-const restoreContextAfterImports = () => {
-  try {
-    global.define = __define;
-  } catch (_) {
-    console.warn('MetaMask - global.define could not be overwritten.');
-  }
-};
-
-cleanContextForImports();
-
 /* eslint-disable import/first */
 import log from 'loglevel';
 import { WindowPostMessageStream } from '@metamask/post-message-stream';
 import { initializeProvider } from '@metamask/providers/dist/initializeInpageProvider';
 
-restoreContextAfterImports();
+(() => {
+  // need to make sure we aren't affected by overlapping namespaces
+  // and that we dont affect the app with our namespace
+  // mostly a fix for web3's BigNumber if AMD's "define" is defined...
+  let __define;
 
-log.setDefaultLevel(process.env.METAMASK_DEBUG ? 'debug' : 'warn');
+  /**
+   * Caches reference to global define object and deletes it to
+   * avoid conflicts with other global define objects, such as
+   * AMD's define function
+   */
+  const cleanContextForImports = () => {
+    __define = global.define;
+    try {
+      global.define = undefined;
+    } catch (_) {
+      console.warn('MetaMask - global.define could not be deleted.');
+    }
+  };
 
-//
-// setup plugin communication
-//
+  /**
+   * Restores global define object from cached reference
+   */
+  const restoreContextAfterImports = () => {
+    try {
+      global.define = __define;
+    } catch (_) {
+      console.warn('MetaMask - global.define could not be overwritten.');
+    }
+  };
 
-// setup background connection
-const metamaskStream = new WindowPostMessageStream({
-  name: 'metamask-inpage',
-  target: 'metamask-contentscript',
-});
+  cleanContextForImports();
 
-initializeProvider({
-  connectionStream: metamaskStream,
-  logger: log,
-  shouldShimWeb3: true,
-});
+  restoreContextAfterImports();
+
+  log.setDefaultLevel(process.env.METAMASK_DEBUG ? 'debug' : 'warn');
+
+  //
+  // setup plugin communication
+  //
+
+  if (shouldInjectProvider()) {
+    // setup background connection
+    const metamaskStream = new WindowPostMessageStream({
+      name: 'metamask-inpage',
+      target: 'metamask-contentscript',
+    });
+
+    initializeProvider({
+      connectionStream: metamaskStream,
+      logger: log,
+      shouldShimWeb3: true,
+    });
+  }
+
+  /**
+   * Determines if the provider should be injected
+   *
+   * @returns {boolean} {@code true} Whether the provider should be injected
+   */
+  function shouldInjectProvider() {
+    return (
+      doctypeCheck() &&
+      suffixCheck() &&
+      documentElementCheck() &&
+      !blockedDomainCheck()
+    );
+  }
+
+  /**
+   * Checks the doctype of the current document if it exists
+   *
+   * @returns {boolean} {@code true} if the doctype is html or if none exists
+   */
+  function doctypeCheck() {
+    const { doctype } = window.document;
+    if (doctype) {
+      return doctype.name === 'html';
+    }
+    return true;
+  }
+
+  /**
+   * Returns whether or not the extension (suffix) of the current document is prohibited
+   *
+   * This checks {@code window.location.pathname} against a set of file extensions
+   * that we should not inject the provider into. This check is indifferent of
+   * query parameters in the location.
+   *
+   * @returns {boolean} whether or not the extension of the current document is prohibited
+   */
+  function suffixCheck() {
+    const prohibitedTypes = [/\.xml$/u, /\.pdf$/u];
+    const currentUrl = window.location.pathname;
+    for (let i = 0; i < prohibitedTypes.length; i++) {
+      if (prohibitedTypes[i].test(currentUrl)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /**
+   * Checks the documentElement of the current document
+   *
+   * @returns {boolean} {@code true} if the documentElement is an html node or if none exists
+   */
+  function documentElementCheck() {
+    const documentElement = document.documentElement.nodeName;
+    if (documentElement) {
+      return documentElement.toLowerCase() === 'html';
+    }
+    return true;
+  }
+
+  /**
+   * Checks if the current domain is blocked
+   *
+   * @returns {boolean} {@code true} if the current domain is blocked
+   */
+  function blockedDomainCheck() {
+    const blockedDomains = [
+      'uscourts.gov',
+      'dropbox.com',
+      'webbyawards.com',
+      'cdn.shopify.com/s/javascripts/tricorder/xtld-read-only-frame.html',
+      'adyen.com',
+      'gravityforms.com',
+      'harbourair.com',
+      'ani.gamer.com.tw',
+      'blueskybooking.com',
+      'sharefile.com',
+    ];
+    const currentUrl = window.location.href;
+    let currentRegex;
+    for (let i = 0; i < blockedDomains.length; i++) {
+      const blockedDomain = blockedDomains[i].replace('.', '\\.');
+      currentRegex = new RegExp(
+        `(?:https?:\\/\\/)(?:(?!${blockedDomain}).)*$`,
+        'u',
+      );
+      if (!currentRegex.test(currentUrl)) {
+        return true;
+      }
+    }
+    return false;
+  }
+})();

--- a/shared/modules/provider-injection.js
+++ b/shared/modules/provider-injection.js
@@ -1,0 +1,93 @@
+/**
+ * Determines if the provider should be injected
+ *
+ * @returns {boolean} {@code true} Whether the provider should be injected
+ */
+export default function shouldInjectProvider() {
+  return (
+    doctypeCheck() &&
+    suffixCheck() &&
+    documentElementCheck() &&
+    !blockedDomainCheck()
+  );
+}
+
+/**
+ * Checks the doctype of the current document if it exists
+ *
+ * @returns {boolean} {@code true} if the doctype is html or if none exists
+ */
+function doctypeCheck() {
+  const { doctype } = window.document;
+  if (doctype) {
+    return doctype.name === 'html';
+  }
+  return true;
+}
+
+/**
+ * Returns whether or not the extension (suffix) of the current document is prohibited
+ *
+ * This checks {@code window.location.pathname} against a set of file extensions
+ * that we should not inject the provider into. This check is indifferent of
+ * query parameters in the location.
+ *
+ * @returns {boolean} whether or not the extension of the current document is prohibited
+ */
+function suffixCheck() {
+  const prohibitedTypes = [/\.xml$/u, /\.pdf$/u];
+  const currentUrl = window.location.pathname;
+  for (let i = 0; i < prohibitedTypes.length; i++) {
+    if (prohibitedTypes[i].test(currentUrl)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/**
+ * Checks the documentElement of the current document
+ *
+ * @returns {boolean} {@code true} if the documentElement is an html node or if none exists
+ */
+function documentElementCheck() {
+  const documentElement = document.documentElement.nodeName;
+  if (documentElement) {
+    return documentElement.toLowerCase() === 'html';
+  }
+  return true;
+}
+
+/**
+ * Checks if the current domain is blocked
+ *
+ * @returns {boolean} {@code true} if the current domain is blocked
+ */
+function blockedDomainCheck() {
+  const blockedDomains = [
+    'uscourts.gov',
+    'dropbox.com',
+    'webbyawards.com',
+    'cdn.shopify.com/s/javascripts/tricorder/xtld-read-only-frame.html',
+    'adyen.com',
+    'gravityforms.com',
+    'docs.google.com',
+    'harbourair.com',
+    'ani.gamer.com.tw',
+    'blueskybooking.com',
+    'sharefile.com',
+  ];
+  const currentUrl = window.location.href;
+  let currentRegex;
+  for (let i = 0; i < blockedDomains.length; i++) {
+    const blockedDomain = blockedDomains[i].replace('.', '\\.');
+    currentRegex = new RegExp(
+      `(?:https?:\\/\\/)(?:(?!${blockedDomain}).)*$`,
+      'u',
+    );
+    if (!currentRegex.test(currentUrl)) {
+      return true;
+    }
+  }
+  return false;
+}


### PR DESCRIPTION
Supercedes https://github.com/MetaMask/metamask-extension/pull/15262

## Explanation

If we use the `src` of `<script>` to inject our inpage provider, the code is async and won't be initialized immediately in the page.  By using the new `world: MAIN` property for content scripts, we can ensure the script is injected at the correct time.

## More Information

* Fixes [#14846](https://github.com/MetaMask/metamask-extension/issues/14846)

## Manual Testing Steps

1.  Start via `yarn start:mv3`
2.  Refresh the extension in the Extension Manager, which ensures flushing cache
3.  Open the test dapp
4. Type `window.ethereum` in the console, ensure it's there
5. Use the test dapp buttons, ensure the popup appears

## Pre-Merge Checklist

- [ ] PR template is filled out
- [ ] **IF** this PR fixes a bug, a test that _would have_ caught the bug has been added
- [ ] PR is linked to the appropriate GitHub issue
- [ ] PR has been added to the appropriate release Milestone

### + If there are functional changes:

- [ ] Manual testing complete & passed
- [ ] "Extension QA Board" label has been applied


