### PR TITLE
Use fromAccount instead of selectedAcccount for account updates on edit

### DIFF
--- a/ui/ducks/send/send.js
+++ b/ui/ducks/send/send.js
@@ -1450,7 +1450,7 @@ const slice = createSlice({
           if (
             draftTransaction &&
             draftTransaction.fromAccount &&
-            draftTransaction?.fromAccount.address ===
+            draftTransaction.fromAccount.address ===
               action.payload.account.address
           ) {
             draftTransaction.fromAccount.balance =

--- a/ui/ducks/send/send.test.js
+++ b/ui/ducks/send/send.test.js
@@ -1142,9 +1142,14 @@ describe('Send Slice', () => {
     });
 
     describe('Account Changed', () => {
-      it('should', () => {
+      it('should correctly update the fromAccount in an edit', () => {
         const accountsChangedState = {
-          ...INITIAL_SEND_STATE_FOR_EXISTING_DRAFT,
+          ...getInitialSendStateWithExistingTxState({
+            fromAccount: {
+              address: '0xAddress',
+              balance: '0x0',
+            },
+          }),
           stage: SEND_STAGES.EDIT,
           selectedAccount: {
             address: '0xAddress',
@@ -1164,9 +1169,40 @@ describe('Send Slice', () => {
 
         const result = sendReducer(accountsChangedState, action);
 
-        expect(result.selectedAccount.balance).toStrictEqual(
+        const draft = getTestUUIDTx(result);
+
+        expect(draft.fromAccount.balance).toStrictEqual(
           action.payload.account.balance,
         );
+      });
+
+      it('should gracefully handle missing account param in payload', () => {
+        const accountsChangedState = {
+          ...getInitialSendStateWithExistingTxState({
+            fromAccount: {
+              address: '0xAddress',
+              balance: '0x0',
+            },
+          }),
+          stage: SEND_STAGES.EDIT,
+          selectedAccount: {
+            address: '0xAddress',
+            balance: '0x0',
+          },
+        };
+
+        const action = {
+          type: 'ACCOUNT_CHANGED',
+          payload: {
+            account: undefined,
+          },
+        };
+
+        const result = sendReducer(accountsChangedState, action);
+
+        const draft = getTestUUIDTx(result);
+
+        expect(draft.fromAccount.balance).toStrictEqual('0x0');
       });
 
       it(`should not edit account balance if action payload address is not the same as state's address`, () => {


### PR DESCRIPTION
## Explanation
When converting to using fromAccount/selectedAccount the logic on the ACCOUNT_CHANGED case was incorrectly converted. It should be using the 'fromAccount' which is set by the editExistingTransaction method. I added additional safety here by checking for existence of both the payload.account and draftTransaction before doing anything. 

Fixes #15400 
