### PR TITLE
add safegaurd for missing account in action

### DIFF
--- a/ui/ducks/send/send.js
+++ b/ui/ducks/send/send.js
@@ -1568,11 +1568,11 @@ const slice = createSlice({
         slice.caseReducers.validateSendState(state);
       })
       .addCase(SELECTED_ACCOUNT_CHANGED, (state, action) => {
-        // If we are on the edit flow the account we are keyed into will be the
-        // original 'from' account, which may differ from the selected account
-        if (state.stage !== SEND_STAGES.EDIT) {
-          // This event occurs when the user selects a new account from the
-          // account menu, or the currently active account's balance updates.
+        // This event occurs when the user selects a new account from the
+        // account menu, or the currently active account's balance updates.
+        // We only care about new transactions, not edits, here, because we use
+        // the fromAccount and ACCOUNT_CHANGED action for that.
+        if (state.stage !== SEND_STAGES.EDIT && action.payload.account) {
           state.selectedAccount.balance = action.payload.account.balance;
           state.selectedAccount.address = action.payload.account.address;
           const draftTransaction =

--- a/ui/ducks/send/send.test.js
+++ b/ui/ducks/send/send.test.js
@@ -1139,6 +1139,28 @@ describe('Send Slice', () => {
           action.payload.account.address,
         );
       });
+
+      it('should gracefully handle missing account in payload', () => {
+        const olderState = {
+          ...INITIAL_SEND_STATE_FOR_EXISTING_DRAFT,
+          selectedAccount: {
+            balance: '0x0',
+            address: '0xAddress',
+          },
+        };
+
+        const action = {
+          type: 'SELECTED_ACCOUNT_CHANGED',
+          payload: {
+            account: undefined,
+          },
+        };
+
+        const result = sendReducer(olderState, action);
+
+        expect(result.selectedAccount.balance).toStrictEqual('0x0');
+        expect(result.selectedAccount.address).toStrictEqual('0xAddress');
+      });
     });
 
     describe('Account Changed', () => {


### PR DESCRIPTION
## Explanation
There seems to be a case (report happened after user imported seed phrase) where an action can be dispatched but 'undefined' is the value for account. This adds a safety check to prevent attempting to set values from an erroneous payload.