### PR TITLE
Fix Personal Sign Display

### DIFF
--- a/ui/components/app/signature-request-original/signature-request-original.component.js
+++ b/ui/components/app/signature-request-original/signature-request-original.component.js
@@ -229,8 +229,7 @@ export default class SignatureRequestOriginal extends Component {
               className="request-signature__help-link"
               onClick={() => {
                 global.platform.openTab({
-                  url:
-                    'https://consensys.net/blog/metamask/the-seal-of-approval-know-what-youre-consenting-to-with-permissions-and-approvals-in-metamask/',
+                  url: 'https://consensys.net/blog/metamask/the-seal-of-approval-know-what-youre-consenting-to-with-permissions-and-approvals-in-metamask/',
                 });
               }}
             >

--- a/ui/components/app/signature-request-original/signature-request-original.component.js
+++ b/ui/components/app/signature-request-original/signature-request-original.component.js
@@ -32,7 +32,6 @@ export default class SignatureRequestOriginal extends Component {
     conversionRate: PropTypes.number,
     history: PropTypes.object.isRequired,
     mostRecentOverviewPage: PropTypes.string.isRequired,
-    requesterAddress: PropTypes.string,
     sign: PropTypes.func.isRequired,
     txData: PropTypes.object.isRequired,
     subjectMetadata: PropTypes.object,
@@ -107,11 +106,13 @@ export default class SignatureRequestOriginal extends Component {
   };
 
   renderRequestIcon = () => {
-    const { requesterAddress } = this.props;
+    const {
+      fromAccount: { address },
+    } = this.state;
 
     return (
       <div className="request-signature__request-icon">
-        <Identicon diameter={40} address={requesterAddress} />
+        <Identicon diameter={40} address={address} />
       </div>
     );
   };
@@ -228,7 +229,8 @@ export default class SignatureRequestOriginal extends Component {
               className="request-signature__help-link"
               onClick={() => {
                 global.platform.openTab({
-                  url: 'https://consensys.net/blog/metamask/the-seal-of-approval-know-what-youre-consenting-to-with-permissions-and-approvals-in-metamask/',
+                  url:
+                    'https://consensys.net/blog/metamask/the-seal-of-approval-know-what-youre-consenting-to-with-permissions-and-approvals-in-metamask/',
                 });
               }}
             >


### PR DESCRIPTION
## Explanation
This PR makes a change to the personal_sign page. Currently there is an icon that is rendered based on the address passed, but the address passed is `null`. This PR changes the address passed to use the same value that is used to select the account (`fromAccount`).

## More Information
Related to https://github.com/MetaMask/metamask-extension/pull/14438#issuecomment-1204225916

## Screenshots/Screencaps

<!-- If you're making a change to the UI, make sure to capture a screenshot or a short video showing off your work! -->

### Before

<img width="361" alt="Before" src="https://user-images.githubusercontent.com/5846858/182674282-d58506f6-f1f9-4288-a7db-0570fadacf94.jpeg">

<!-- How did the UI you changed look before your changes? Drag your file(s) below this line: -->

### After
<img width="361" alt="After" src="https://user-images.githubusercontent.com/5846858/182673617-cc22962c-ee3a-418b-9dd9-5284a9a7c494.png">

<!-- How does it look now? Drag your file(s) below this line: -->

## Manual Testing Steps
Go to the [test-dapp](https://metamask.github.io/test-dapp/) and hit personal sign

## Pre-Merge Checklist

- [ ] PR template is filled out
- [ ] **IF** this PR fixes a bug, a test that _would have_ caught the bug has been added
- [ ] PR is linked to the appropriate GitHub issue
- [ ] PR has been added to the appropriate release Milestone

### + If there are functional changes:

- [ ] Manual testing complete & passed
- [ ] "Extension QA Board" label has been applied
