### PR TITLE
Stop injecting provider on docs.google.com

### DIFF
--- a/app/scripts/contentscript.js
+++ b/app/scripts/contentscript.js
@@ -329,16 +329,17 @@ function documentElementCheck() {
  */
 function blockedDomainCheck() {
   const blockedDomains = [
-    'uscourts.gov',
-    'dropbox.com',
-    'webbyawards.com',
-    'cdn.shopify.com/s/javascripts/tricorder/xtld-read-only-frame.html',
     'adyen.com',
-    'gravityforms.com',
-    'harbourair.com',
     'ani.gamer.com.tw',
     'blueskybooking.com',
+    'cdn.shopify.com/s/javascripts/tricorder/xtld-read-only-frame.html',
+    'docs.google.com',
+    'dropbox.com',
+    'gravityforms.com',
+    'harbourair.com',
     'sharefile.com',
+    'uscourts.gov',
+    'webbyawards.com',
   ];
   const currentUrl = window.location.href;
   let currentRegex;


### PR DESCRIPTION
Per #15374, injecting `window.ethereum` on `docs.google.com` can prevent the user from opening Google docs. I have reproduced this locally myself, and could only fix this by disabling the extension in the browser. I think we can rest assured that our provider is of no use on the Google docs website, and we can always revert this if that should change.

Fixes #15374 

