### PR TITLE
Prevent confirm screen from showing method name from contract registry for txes created within MetaMask

### DIFF
--- a/ui/pages/confirm-transaction-base/confirm-transaction-base.component.js
+++ b/ui/pages/confirm-transaction-base/confirm-transaction-base.component.js
@@ -1054,7 +1054,10 @@ export default class ConfirmTransactionBase extends Component {
     } = this.getNavigateTxData();
 
     let functionType;
-    if (txData.type === TRANSACTION_TYPES.CONTRACT_INTERACTION) {
+    if (
+      txData.type === TRANSACTION_TYPES.CONTRACT_INTERACTION &&
+      txData.origin !== 'metamask'
+    ) {
       functionType = getMethodName(name);
     }
 

--- a/ui/pages/confirm-transaction/confirm-transaction.component.js
+++ b/ui/pages/confirm-transaction/confirm-transaction.component.js
@@ -68,7 +68,7 @@ export default class ConfirmTransaction extends Component {
       sendTo,
       history,
       mostRecentOverviewPage,
-      transaction: { txParams: { data } = {} } = {},
+      transaction: { txParams: { data } = {}, origin } = {},
       getContractMethodData,
       transactionId,
       paramsTransactionId,
@@ -91,7 +91,9 @@ export default class ConfirmTransaction extends Component {
       return;
     }
 
-    getContractMethodData(data);
+    if (origin !== 'metamask') {
+      getContractMethodData(data);
+    }
 
     const txId = transactionId || paramsTransactionId;
     if (txId) {
@@ -107,7 +109,7 @@ export default class ConfirmTransaction extends Component {
   componentDidUpdate(prevProps) {
     const {
       setTransactionToConfirm,
-      transaction: { txData: { txParams: { data } = {} } = {} },
+      transaction: { txData: { txParams: { data } = {}, origin } = {} },
       clearConfirmTransaction,
       getContractMethodData,
       paramsTransactionId,
@@ -124,8 +126,10 @@ export default class ConfirmTransaction extends Component {
       prevProps.paramsTransactionId !== paramsTransactionId
     ) {
       clearConfirmTransaction();
-      getContractMethodData(data);
       setTransactionToConfirm(paramsTransactionId);
+      if (origin !== 'metamask') {
+        getContractMethodData(data);
+      }
     } else if (
       prevProps.transactionId &&
       !transactionId &&


### PR DESCRIPTION
Explanation:

Prior to v10.18.2, if we edited hex data on the send screen and sent to a contract address, we incorrectly identified it as a simple send. On 10.18.2 we correctly represent it as a contract interaction, but by doing so we show the name of the method associated with that 4-byte signature from the registry.

This PR maintains the representation of these transactions as contract interactions, but ensures that if they are created from within MetaMask, we don't show any specific names, to avoid any possibility of showing incorrect or malicious info to the user in these cases.

before:
![Screenshot from 2022-08-04 16-08-10](https://user-images.githubusercontent.com/7499938/182928314-fd310e4e-2162-44d5-83ae-ac2e679a6b79.png)

after:
![Screenshot from 2022-08-04 16-06-16](https://user-images.githubusercontent.com/7499938/182928272-18ba9542-3a08-43d4-9c2c-4f02c91cbd78.png)
