### PR TITLE
Skip searching 4byte directory if we don't have a full 4 bytes of data

### DIFF
--- a/ui/store/actions.js
+++ b/ui/store/actions.js
@@ -3264,8 +3264,7 @@ export function getContractMethodData(data = '') {
     if (
       (knownMethodData &&
         knownMethodData[fourBytePrefix] &&
-        Object.keys(knownMethodData[fourBytePrefix]).length !== 0) ||
-      fourBytePrefix === '0x'
+        Object.keys(knownMethodData[fourBytePrefix]).length !== 0)
     ) {
       return Promise.resolve(knownMethodData[fourBytePrefix]);
     }

--- a/ui/store/actions.js
+++ b/ui/store/actions.js
@@ -3262,9 +3262,9 @@ export function getContractMethodData(data = '') {
     }
     const { knownMethodData } = getState().metamask;
     if (
-      (knownMethodData &&
-        knownMethodData[fourBytePrefix] &&
-        Object.keys(knownMethodData[fourBytePrefix]).length !== 0)
+      knownMethodData &&
+      knownMethodData[fourBytePrefix] &&
+      Object.keys(knownMethodData[fourBytePrefix]).length !== 0
     ) {
       return Promise.resolve(knownMethodData[fourBytePrefix]);
     }

--- a/ui/store/actions.js
+++ b/ui/store/actions.js
@@ -3257,8 +3257,10 @@ export function getContractMethodData(data = '') {
   return (dispatch, getState) => {
     const prefixedData = addHexPrefix(data);
     const fourBytePrefix = prefixedData.slice(0, 10);
+    if (fourBytePrefix.length < 10) {
+      return Promise.resolve({});
+    }
     const { knownMethodData } = getState().metamask;
-
     if (
       (knownMethodData &&
         knownMethodData[fourBytePrefix] &&


### PR DESCRIPTION
We should only query `4byte.directory` if we have a full 4bytes of data in hex-string form to query against. 4byte.directory will return an unfiltered list of signatures without a full valid query: https://www.4byte.directory/api/v1/signatures/?hex_signature=0x0.
Discovered as part of this [thread](https://consensys.slack.com/archives/GTQAGKY5V/p1659636499104129?thread_ts=1659566138.744119&cid=GTQAGKY5V).

Before:
https://user-images.githubusercontent.com/34557516/182933602-1b3925e9-4e88-40f8-a2d9-566c1f56a2a0.mp4

https://user-images.githubusercontent.com/34557516/182933715-b29ed147-251b-4344-a6ce-b68ebd184583.mp4

After:
https://user-images.githubusercontent.com/34557516/182933915-b5854ed7-2c4f-4b38-8586-99fd797fd6e9.mov