### PR TITLE
[GridPlus] Bumps `eth-lattice-keyring` to v0.11.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -161,7 +161,7 @@
     "eth-json-rpc-infura": "^5.1.0",
     "eth-json-rpc-middleware": "^8.0.0",
     "eth-keyring-controller": "^7.0.2",
-    "eth-lattice-keyring": "^0.10.0",
+    "eth-lattice-keyring": "^0.11.0",
     "eth-method-registry": "^2.0.0",
     "eth-query": "^2.1.2",
     "eth-rpc-errors": "^4.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11187,10 +11187,10 @@ eth-keyring-controller@^7.0.2:
     eth-simple-keyring "^4.2.0"
     obs-store "^4.0.3"
 
-eth-lattice-keyring@^0.10.0:
-  version "0.10.0"
-  resolved "https://registry.yarnpkg.com/eth-lattice-keyring/-/eth-lattice-keyring-0.10.0.tgz#58b2c324415e556b896695465dc433b7617b166f"
-  integrity sha512-7ACODPpysTgQcPNiXUeTs6+SUcyH3lRZhiLeB0OzpcIFsO8/xwmWUePU7xAcrSYHwgqcToM/U4TN9Rtfa+apAQ==
+eth-lattice-keyring@^0.11.0:
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/eth-lattice-keyring/-/eth-lattice-keyring-0.11.0.tgz#7df63dc55d168f2a104ef469db78687fc181cb66"
+  integrity sha512-eFVP4uTvnNYLI3KbpPxqVv/AY9swbCH4ZfqDMsYEZ+vg1UQjnsXAxy4iIUuKR+cF4e8kCKK6hFtALEGxuilcJA==
   dependencies:
     "@ethereumjs/common" "2.4.0"
     "@ethereumjs/tx" "3.3.0"


### PR DESCRIPTION
This fixes an edge case related to removing a connection with MetaMask
on the Lattice device side and not being able to connect.
We needed some way to force a `forgetDevice` call in a case where
no accounts had been added. Now if the request times out when
trying to fetch a page of accounts, it will force the user to
establish a new connection with the Lattice.
See: https://github.com/GridPlus/eth-lattice-keyring/compare/v0.10.0...v0.11.0