### PR TITLE
Fix build script errors

### DIFF
--- a/development/build/scripts.js
+++ b/development/build/scripts.js
@@ -63,6 +63,7 @@ const metamaskrc = {
 const { streamFlatMap } = require('../stream-flat-map');
 const { BuildType } = require('../lib/build-type');
 const { BUILD_TARGETS } = require('./constants');
+const { logError } = require('./utils');
 
 const {
   createTask,
@@ -1053,7 +1054,7 @@ async function createBundle(buildConfiguration, { reloadOnChange }) {
     if (!reloadOnChange) {
       bundleStream.on('error', (error) => {
         console.error('Bundling failed! See details below.');
-        console.error(error.stack || error);
+        logError(error);
         process.exit(1);
       });
     }

--- a/development/build/task.js
+++ b/development/build/task.js
@@ -15,6 +15,7 @@ module.exports = {
 };
 
 const { setupTaskDisplay } = require('./display');
+const { logError } = require('./utils');
 
 async function runTask(taskName, { skipStats } = {}) {
   if (!(taskName in tasks)) {
@@ -30,7 +31,7 @@ async function runTask(taskName, { skipStats } = {}) {
     console.error(
       `MetaMask build: Encountered an error while running task "${taskName}".`,
     );
-    console.error(err);
+    logError(err);
     process.exit(1);
   }
   taskEvents.emit('complete');

--- a/development/build/utils.js
+++ b/development/build/utils.js
@@ -51,6 +51,21 @@ function getBrowserVersionMap(platforms, version) {
   }, {});
 }
 
+/**
+ * Log an error to the console.
+ *
+ * This function includes a workaround for a SES bug that results in errors
+ * being printed to the console as `{}`. The workaround is to print the stack
+ * instead, which does work correctly.
+ *
+ * @see {@link https://github.com/endojs/endo/issues/944}
+ * @param {Error} error - The error to print
+ */
+function logError(error) {
+  console.error(error.stack || error);
+}
+
 module.exports = {
   getBrowserVersionMap,
+  logError,
 };


### PR DESCRIPTION
There is a SES bug that results in [errors being printed to the console as `{}`](https://github.com/endojs/endo/issues/944). The known workaround is to print the error stack rather than printing the error directly. This affects our build script when it is run with LavaMoat.

We used this workaround in one place in the build script already, but not in the handler for task errors. We now use it in both places.

The workaround has been moved to a function that we can use throughout the build script.

## Manual Testing Steps

* Introduce an error somewhere within a task (e.g. [on this line](https://github.com/MetaMask/metamask-extension/blob/42c8703f3e3e0fbfddcc9faa4ddb49045ce9631a/development/build/scripts.js#L815))
* Ensure the error is printed to the error when LavaMoat is used to run the build script (e.g. on `yarn dist`).

## Pre-Merge Checklist

- [x] PR template is filled out
- [x] **IF** this PR fixes a bug, a test that _would have_ caught the bug has been added
- [x] PR is linked to the appropriate GitHub issue
- [x] PR has been added to the appropriate release Milestone

### + If there are functional changes:

- [ ] Manual testing complete & passed
- [ ] "Extension QA Board" label has been applied
