### PR TITLE
Change setApproval message to be red font

### DIFF
--- a/ui/pages/confirm-approve/confirm-approve-content/confirm-approve-content.component.js
+++ b/ui/pages/confirm-approve/confirm-approve-content/confirm-approve-content.component.js
@@ -636,6 +636,7 @@ export default class ConfirmApproveContent extends Component {
         <div
           className="confirm-approve-content__title"
           data-testid="confirm-approve-title"
+          style={{ color: 'var(--color-error-default)' }}
         >
           {this.renderTitle()}
         </div>


### PR DESCRIPTION
## Explanation
I've received feedback from many ppl that the new setApproval warning message still isn't obvious enough. In an attempt to try to warn users even more, I've changed the font of the warning to be red so it's more clear that this is a potentially dangerous txn to approve.

Here's a thread I made and some feedback I received: https://twitter.com/cygaar_dev/status/1555027036783222784

## Screenshots/Screencaps

![Screen Shot 2022-08-07 at 9 56 53 AM](https://user-images.githubusercontent.com/97691933/183302471-e2ef0678-d3df-40ae-960a-93d4b7a61075.png)

## Manual Testing Steps

Build the extension, load unpacked, sell an NFT on Opensea that you previously did not set approvals for.

## Pre-Merge Checklist

- [x] PR template is filled out
- [ ] **IF** this PR fixes a bug, a test that _would have_ caught the bug has been added
- [ ] PR is linked to the appropriate GitHub issue
- [ ] PR has been added to the appropriate release Milestone

### + If there are functional changes:

- [ ] Manual testing complete & passed
- [ ] "Extension QA Board" label has been applied
