### PR TITLE
deps - ensure only minimal metamask/rpc-methods import

### DIFF
--- a/app/scripts/lib/rpc-method-middleware/createMethodMiddleware.js
+++ b/app/scripts/lib/rpc-method-middleware/createMethodMiddleware.js
@@ -2,7 +2,7 @@
 import { handlers as permittedSnapMethods } from '@metamask/rpc-methods/dist/permitted';
 ///: END:ONLY_INCLUDE_IN
 import { permissionRpcMethods } from '@metamask/controllers';
-import { selectHooks } from '@metamask/rpc-methods';
+import { selectHooks } from '@metamask/rpc-methods/dist/utils';
 import { ethErrors } from 'eth-rpc-errors';
 import { flatten } from 'lodash';
 import { UNSUPPORTED_RPC_METHODS } from '../../../../shared/constants/network';


### PR DESCRIPTION
4.2mB background before
3.7mB background after
12% background size reduction