### PR TITLE
Fixing design system icon alternative color const

### DIFF
--- a/ui/helpers/constants/design-system.js
+++ b/ui/helpers/constants/design-system.js
@@ -11,7 +11,7 @@ export const COLORS = {
   TEXT_ALTERNATIVE: 'text-alternative',
   TEXT_MUTED: 'text-muted',
   ICON_DEFAULT: 'icon-default',
-  ICON_ALTERNATIVE: 'text-alternative',
+  ICON_ALTERNATIVE: 'icon-alternative',
   ICON_MUTED: 'icon-muted',
   BORDER_DEFAULT: 'border-default',
   BORDER_MUTED: 'border-muted',


### PR DESCRIPTION
## Explanation
Updating `ICON_ALTERNATIVE` to use the correct string.

I don't think this option was used anywhere in the codebase so this won't effect any of the current icon colors. I found it building the new icon component.

![Screen Shot 2022-08-09 at 10 45 31 AM](https://user-images.githubusercontent.com/8112138/183723559-0dcee8bc-db70-4370-9e4f-7db920cce57a.png)

## Pre-Merge Checklist

- [x] PR template is filled out
- ~[x] **IF** this PR fixes a bug, a test that _would have_ caught the bug has been added~ N/A
- ~[x] PR is linked to the appropriate GitHub issue~ N/A
- ~[x] PR has been added to the appropriate release Milestone~ N/A

### + If there are functional changes:

- [x] ~Manual testing complete & passed~ N/A
- [x] ~"Extension QA Board" label has been applied~ N/A
