### PR TITLE
Fix deploying the TS migration dashboard

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -762,6 +762,8 @@ jobs:
           name: ts-migration-dashboard:deploy
           command: |
             git remote add ts-migration-dashboard git@github.com:MetaMask/metamask-extension-ts-migration-dashboard.git
+            git config user.name "MetaMask Bot"
+            git config user.email metamaskbot@users.noreply.github.com
             yarn ts-migration:dashboard:deploy
 
   test-unit:


### PR DESCRIPTION
## Explanation

When the TypeScript migration dashboard is updated, it is built and
deployed in another repo, which is then deployed via GitHub Pages. To
push to this repo we have to set a Git username and email. This is
missing from the CircleCI config, so this commit uses the metamaskbot
GitHub account to do that.

## More Information

See the [PR introducing the TypeScript migration dashboard](https://github.com/MetaMask/metamask-extension/pull/13820) for more context.

Also see Storybook, which takes a [similar approach](https://github.com/storybookjs/storybook-deployer/blob/f5cad558082d734028ce55f10ebe5442478d7d2d/bin/storybook_to_ghpages#L48).

## Manual Testing Steps

There isn't anything to test here, but the [`job-publish-ts-migration-dashboard` step in CircleCI](https://app.circleci.com/pipelines/github/MetaMask/metamask-extension/26125/workflows/a734e031-85e0-416d-b214-3fdbedc326f9/jobs/672585) should not fail. This step will only get run when this PR is merged, so a subsequent PR will be needed if this one doesn't fix it.

## Pre-Merge Checklist

- [ ] PR template is filled out
- [ ] **IF** this PR fixes a bug, a test that _would have_ caught the bug has been added
- [ ] PR is linked to the appropriate GitHub issue
- [ ] PR has been added to the appropriate release Milestone

### + If there are functional changes:

- [ ] Manual testing complete & passed
- [ ] "Extension QA Board" label has been applied
