### PR TITLE
Fix text alignment in Add a Network popup view

### DIFF
--- a/ui/pages/confirmation/templates/add-ethereum-chain.js
+++ b/ui/pages/confirmation/templates/add-ethereum-chain.js
@@ -8,6 +8,8 @@ import {
   JUSTIFY_CONTENT,
   DISPLAY,
   COLORS,
+  FLEX_DIRECTION,
+  ALIGN_ITEMS,
 } from '../../../helpers/constants/design-system';
 import { DEFAULT_ROUTE } from '../../../helpers/constants/routes';
 
@@ -276,9 +278,11 @@ function getValues(pendingApproval, t, actions, history) {
         ],
         props: {
           variant: TYPOGRAPHY.H7,
-          align: 'center',
           boxProps: {
             margin: originIsMetaMask ? [0, 8] : 0,
+            display: DISPLAY.FLEX,
+            flexDirection: FLEX_DIRECTION.COLUMN,
+            alignItems: ALIGN_ITEMS.CENTER,
           },
         },
       },


### PR DESCRIPTION
Fixes: https://github.com/MetaMask/metamask-extension/issues/15356

Test plan described in issue

<img width="626" alt="Screen Shot 2022-08-09 at 11 54 29 PM" src="https://user-images.githubusercontent.com/8732757/183839430-35a6c2e8-f07b-47ed-bd75-5b621f4d5549.png">

<img width="624" alt="Screen Shot 2022-08-10 at 12 21 12 AM" src="https://user-images.githubusercontent.com/8732757/183839742-9c83e031-b766-4be7-90ba-052456d73717.png">

