### PR TITLE
Fix deployment of TS migration dashboard (again)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -754,7 +754,7 @@ jobs:
     steps:
       - add_ssh_keys:
           fingerprints:
-            - "3d:49:29:f4:b2:e8:ea:af:d1:32:eb:2a:fc:15:85:d8"
+            - "8b:21:e3:20:7c:c9:db:82:74:2d:86:d6:11:a7:2f:49"
       - checkout
       - attach_workspace:
           at: .


### PR DESCRIPTION
## Explanation

An improper deploy key was used to deploy the TypeScript
migration dashboard. A new key has been created on the GitHub side for
the `metamask-extension-ts-migration-dashboard` repo and also added to
CircleCI. The new fingerprint for this key is provided in this commit.
This should hopefully make it possible for us to deploy to this repo
from CircleCI.

## More Information

See #15516, as well as #13820.

## Manual Testing Steps

There isn't anything to test here, but the [`job-publish-ts-migration-dashboard` step in CircleCI](https://app.circleci.com/pipelines/github/MetaMask/metamask-extension/26125/workflows/a734e031-85e0-416d-b214-3fdbedc326f9/jobs/672585) should not fail. This step will only get run when this PR is merged, so a subsequent PR will be needed if this one doesn't fix it.

## Pre-Merge Checklist

- [ ] PR template is filled out
- [ ] **IF** this PR fixes a bug, a test that _would have_ caught the bug has been added
- [ ] PR is linked to the appropriate GitHub issue
- [ ] PR has been added to the appropriate release Milestone

### + If there are functional changes:

- [ ] Manual testing complete & passed
- [ ] "Extension QA Board" label has been applied
