### PR TITLE
Using Object.values for shuffle token list for swaps

### DIFF
--- a/ui/pages/swaps/index.js
+++ b/ui/pages/swaps/index.js
@@ -137,7 +137,7 @@ export default function Swap() {
   );
   const defaultSwapsToken = useSelector(getSwapsDefaultToken, isEqual);
   const tokenList = useSelector(getTokenList);
-  const shuffledTokensList = shuffle(Object.entries(tokenList));
+  const shuffledTokensList = shuffle(Object.values(tokenList));
   const reviewSwapClickedTimestamp = useSelector(getReviewSwapClickedTimestamp);
   const pendingSmartTransactions = useSelector(getPendingSmartTransactions);
   const reviewSwapClicked = Boolean(reviewSwapClickedTimestamp);

--- a/ui/pages/swaps/index.js
+++ b/ui/pages/swaps/index.js
@@ -136,7 +136,7 @@ export default function Swap() {
     checkNetworkAndAccountSupports1559,
   );
   const defaultSwapsToken = useSelector(getSwapsDefaultToken, isEqual);
-  const tokenList = useSelector(getTokenList);
+  const tokenList = useSelector(getTokenList, isEqual);
   const shuffledTokensList = shuffle(Object.values(tokenList));
   const reviewSwapClickedTimestamp = useSelector(getReviewSwapClickedTimestamp);
   const pendingSmartTransactions = useSelector(getPendingSmartTransactions);


### PR DESCRIPTION
Swaps is currently broken because `Object.entries` return both key and values of the tokenList object when called and we are expecting only a list of values. In this Pr, we are changing `Object.entries(tokenList)` to `Object.values(tokenList)` while creating the token Metadata array to be used in the swap.