### PR TITLE
Use a new service for serving token images

### DIFF
--- a/ui/hooks/useTokensToSearch.js
+++ b/ui/hooks/useTokensToSearch.js
@@ -57,7 +57,7 @@ export function getRenderableTokenData(
     (tokenData) => tokenData.address === address?.toLowerCase(),
   );
 
-  const usedIconUrl = iconUrl || tokenMetadata?.iconUrl || token?.image;
+  const usedIconUrl = tokenMetadata?.iconUrl || iconUrl || token?.image;
   return {
     ...token,
     primaryLabel: symbol,

--- a/ui/hooks/useTokensToSearch.js
+++ b/ui/hooks/useTokensToSearch.js
@@ -8,6 +8,7 @@ import {
   getCurrentCurrency,
   getSwapsDefaultToken,
   getCurrentChainId,
+  getUseTokenDetection,
 } from '../selectors';
 import { getConversionRate } from '../ducks/metamask/metamask';
 
@@ -24,6 +25,7 @@ export function getRenderableTokenData(
   currentCurrency,
   chainId,
   shuffledTokenList,
+  useTokenDetection,
 ) {
   const { symbol, name, address, iconUrl, string, balance, decimals } = token;
   let contractExchangeRate;
@@ -57,7 +59,10 @@ export function getRenderableTokenData(
     (tokenData) => tokenData.address === address?.toLowerCase(),
   );
 
-  const usedIconUrl = tokenMetadata?.iconUrl || iconUrl || token?.image;
+  const tokenIconUrl = useTokenDetection
+    ? tokenMetadata?.iconUrl || iconUrl
+    : iconUrl || tokenMetadata?.iconUrl;
+  const usedIconUrl = tokenIconUrl || token?.image;
   return {
     ...token,
     primaryLabel: symbol,
@@ -84,6 +89,7 @@ export function useTokensToSearch({
   const tokenConversionRates = useSelector(getTokenExchangeRates, isEqual);
   const conversionRate = useSelector(getConversionRate);
   const currentCurrency = useSelector(getCurrentCurrency);
+  const useTokenDetection = useSelector(getUseTokenDetection);
   const defaultSwapsToken = useSelector(getSwapsDefaultToken, shallowEqual);
 
   const memoizedTopTokens = useEqualityCheck(topTokens);
@@ -96,6 +102,7 @@ export function useTokensToSearch({
     currentCurrency,
     chainId,
     shuffledTokensList,
+    useTokenDetection,
   );
   const memoizedDefaultToken = useEqualityCheck(defaultToken);
 
@@ -136,6 +143,7 @@ export function useTokensToSearch({
         currentCurrency,
         chainId,
         shuffledTokensList,
+        useTokenDetection,
       );
       if (tokenBucketPriority === TOKEN_BUCKET_PRIORITY.OWNED) {
         if (


### PR DESCRIPTION
## Explanation
Use a new service for serving token images. 

In some future iteration we will probably use this service always, not only when token detection is on.

## Screenshots
Token images when token detection is turned on:
![image](https://user-images.githubusercontent.com/80175477/184169980-bacc718d-2a7a-402c-aa6c-723822d549b5.png)

## Manual Testing Steps
- Enable token detection in Advanced settings
- Go to Swaps on Ethereum mainnet
- Check the URLs of token images, they should use a URL like this: `https://static.metaswap.codefi.network/api/v1/tokenIcons/1/0x6b175474e89094c44da98b954eedeac495271d0f.png`