### PR TITLE
Fix uncaught promise using optional chaining

### DIFF
--- a/app/scripts/lib/account-tracker.js
+++ b/app/scripts/lib/account-tracker.js
@@ -312,7 +312,7 @@ export default class AccountTracker {
     try {
       balance = await this._query.getBalance(address);
     } catch (error) {
-      if (error.data.request.method !== 'eth_getBalance') {
+      if (error.data.request?.method !== 'eth_getBalance') {
         throw error;
       }
     }

--- a/app/scripts/lib/account-tracker.js
+++ b/app/scripts/lib/account-tracker.js
@@ -312,7 +312,7 @@ export default class AccountTracker {
     try {
       balance = await this._query.getBalance(address);
     } catch (error) {
-      if (error.data.request?.method !== 'eth_getBalance') {
+      if (error?.data?.request?.method !== 'eth_getBalance') {
         throw error;
       }
     }


### PR DESCRIPTION
## Explanation

Currently, when switching networks in Metamask the following error is thrown, the data object in the error sometimes does not have a request property.

`{"code":-32603,"data":{"code":-32602,"message":"Unknown block number"}}`

In the event that an unresolved promise is caught and undefined is returned on the request property, this pull request uses [optional chaining](https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#prod-OptionalExpression) to read the value of the property without having to craft additional validity checks.