### PR TITLE
Updating useMemo dependency list

### DIFF
--- a/ui/hooks/useTokenDisplayValue.js
+++ b/ui/hooks/useTokenDisplayValue.js
@@ -56,7 +56,7 @@ export function useTokenDisplayValue(
     }
 
     return calcTokenAmount(tokenValue, token.decimals).toString(10);
-  }, [shouldCalculateTokenValue, tokenData, token]);
+  }, [shouldCalculateTokenValue, tokenValue, token]);
 
   return displayValue;
 }


### PR DESCRIPTION
This PR is fixing the `useMemo` dependency list which was using `tokenData` instead of `tokenValue`.