### PR TITLE
Call metrics event for wallet type selection at the right time

### DIFF
--- a/ui/pages/first-time-flow/metametrics-opt-in/metametrics-opt-in.component.js
+++ b/ui/pages/first-time-flow/metametrics-opt-in/metametrics-opt-in.component.js
@@ -9,7 +9,6 @@ export default class MetaMetricsOptIn extends Component {
   static propTypes = {
     history: PropTypes.object,
     setParticipateInMetaMetrics: PropTypes.func,
-    firstTimeSelectionMetaMetricsName: PropTypes.string,
     participateInMetaMetrics: PropTypes.bool,
   };
 
@@ -20,12 +19,8 @@ export default class MetaMetricsOptIn extends Component {
 
   render() {
     const { trackEvent, t } = this.context;
-    const {
-      history,
-      setParticipateInMetaMetrics,
-      firstTimeSelectionMetaMetricsName,
-      participateInMetaMetrics,
-    } = this.props;
+    const { history, setParticipateInMetaMetrics, participateInMetaMetrics } =
+      this.props;
 
     return (
       <div className="metametrics-opt-in">
@@ -109,50 +104,27 @@ export default class MetaMetricsOptIn extends Component {
               cancelText={t('noThanks')}
               hideCancel={false}
               onSubmit={async () => {
-                const [, metaMetricsId] = await setParticipateInMetaMetrics(
-                  true,
-                );
+                await setParticipateInMetaMetrics(true);
                 try {
-                  const metrics = [];
                   if (
                     participateInMetaMetrics === null ||
                     participateInMetaMetrics === false
                   ) {
-                    metrics.push(
-                      trackEvent(
-                        {
-                          category: EVENT.CATEGORIES.ONBOARDING,
-                          event: 'Metrics Opt In',
-                          properties: {
-                            action: 'Metrics Option',
-                            legacy_event: true,
-                          },
-                        },
-                        {
-                          isOptIn: true,
-                          flushImmediately: true,
-                        },
-                      ),
-                    );
-                  }
-                  metrics.push(
-                    trackEvent(
+                    await trackEvent(
                       {
                         category: EVENT.CATEGORIES.ONBOARDING,
-                        event: firstTimeSelectionMetaMetricsName,
+                        event: 'Metrics Opt In',
                         properties: {
-                          action: 'Import or Create',
+                          action: 'Metrics Option',
                           legacy_event: true,
                         },
                       },
                       {
                         isOptIn: true,
-                        metaMetricsId,
                         flushImmediately: true,
                       },
-                    ),
-                  );
-                  await Promise.all(metrics);
+                    );
+                  }
                 } finally {
                   history.push(INITIALIZE_SELECT_ACTION_ROUTE);
                 }

--- a/ui/pages/first-time-flow/select-action/select-action.component.js
+++ b/ui/pages/first-time-flow/select-action/select-action.component.js
@@ -2,6 +2,7 @@ import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import Button from '../../../components/ui/button';
 import MetaFoxLogo from '../../../components/ui/metafox-logo';
+import { EVENT } from '../../../../shared/constants/metametrics';
 import {
   INITIALIZE_CREATE_PASSWORD_ROUTE,
   INITIALIZE_IMPORT_WITH_SEED_PHRASE_ROUTE,
@@ -13,9 +14,11 @@ export default class SelectAction extends PureComponent {
     isInitialized: PropTypes.bool,
     setFirstTimeFlowType: PropTypes.func,
     nextRoute: PropTypes.string,
+    metaMetricsId: PropTypes.string,
   };
 
   static contextTypes = {
+    trackEvent: PropTypes.func,
     t: PropTypes.func,
   };
 
@@ -28,12 +31,46 @@ export default class SelectAction extends PureComponent {
   }
 
   handleCreate = () => {
+    const { metaMetricsId } = this.props;
+    const { trackEvent } = this.context;
     this.props.setFirstTimeFlowType('create');
+    trackEvent(
+      {
+        category: EVENT.CATEGORIES.ONBOARDING,
+        event: 'Selected Create New Wallet',
+        properties: {
+          action: 'Import or Create',
+          legacy_event: true,
+        },
+      },
+      {
+        isOptIn: true,
+        metaMetricsId,
+        flushImmediately: true,
+      },
+    );
     this.props.history.push(INITIALIZE_CREATE_PASSWORD_ROUTE);
   };
 
   handleImport = () => {
+    const { metaMetricsId } = this.props;
+    const { trackEvent } = this.context;
     this.props.setFirstTimeFlowType('import');
+    trackEvent(
+      {
+        category: EVENT.CATEGORIES.ONBOARDING,
+        event: 'Selected Import Wallet',
+        properties: {
+          action: 'Import or Create',
+          legacy_event: true,
+        },
+      },
+      {
+        isOptIn: true,
+        metaMetricsId,
+        flushImmediately: true,
+      },
+    );
     this.props.history.push(INITIALIZE_IMPORT_WITH_SEED_PHRASE_ROUTE);
   };
 

--- a/ui/pages/first-time-flow/select-action/select-action.container.js
+++ b/ui/pages/first-time-flow/select-action/select-action.container.js
@@ -8,6 +8,7 @@ import Welcome from './select-action.component';
 const mapStateToProps = (state) => {
   return {
     nextRoute: getFirstTimeFlowTypeRoute(state),
+    metaMetricsId: state.metamask.metaMetricsId,
   };
 };
 


### PR DESCRIPTION
Fixes https://github.com/MetaMask/metamask-extension/issues/15375

In https://github.com/MetaMask/metamask-extension/pull/15313, we changed the flow of metrics opt in. That created a bug whereby we were trying to capture the event for type of wallet creation before that step had happened. This PR fixes that by moving the metrics event for wallet creation type to after the choice between import and create has been made