### PR TITLE
[e2e] Refactor failing-contract spec using Ganache seeder

### DIFF
--- a/test/e2e/tests/failing-contract.spec.js
+++ b/test/e2e/tests/failing-contract.spec.js
@@ -1,7 +1,9 @@
 const { strict: assert } = require('assert');
 const { convertToHexValue, withFixtures } = require('../helpers');
+const { SMART_CONTRACTS } = require('../seeder/smart-contracts');
 
 describe('Failing contract interaction ', function () {
+  const smartContract = SMART_CONTRACTS.FAILING;
   const ganacheOptions = {
     hardfork: 'london',
     accounts: [
@@ -18,41 +20,25 @@ describe('Failing contract interaction ', function () {
         dapp: true,
         fixtures: 'connected-state',
         ganacheOptions,
+        smartContract,
         title: this.test.title,
       },
-      async ({ driver }) => {
+      async ({ driver, contractRegistry }) => {
+        const contractAddress = await contractRegistry.getContractAddress(
+          smartContract,
+        );
         await driver.navigate();
         await driver.fill('#password', 'correct horse battery staple');
         await driver.press('#password', driver.Key.ENTER);
 
-        // deploy contract
-        await driver.openNewPage('http://127.0.0.1:8080/');
-        await driver.clickElement('#deployFailingButton');
-        await driver.waitUntilXWindowHandles(3);
+        await driver.openNewPage(
+          `http://127.0.0.1:8080/?contract=${contractAddress}`,
+        );
         let windowHandles = await driver.getAllWindowHandles();
         const extension = windowHandles[0];
-        const dapp = await driver.switchToWindowWithTitle(
-          'E2E Test Dapp',
-          windowHandles,
-        );
-        await driver.switchToWindowWithTitle(
-          'MetaMask Notification',
-          windowHandles,
-        );
-        await driver.clickElement({ text: 'Confirm', tag: 'button' });
-        await driver.waitUntilXWindowHandles(2);
-        await driver.switchToWindow(extension);
-        await driver.clickElement('[data-testid="home__activity-tab"]');
-        await driver.waitForSelector(
-          '.transaction-list__completed-transactions .transaction-list-item:nth-of-type(1)',
-          { timeout: 10000 },
-        );
-        const completedTx = await driver.findElement('.list-item__title');
-        const completedTxText = await completedTx.getText();
-        assert.equal(completedTxText, 'Contract deployment');
 
-        // calls failing contract method
-        await driver.switchToWindow(dapp);
+        // waits for deployed contract and calls failing contract method
+        await driver.findClickableElement('#deployButton');
         await driver.clickElement('#sendFailingButton');
         await driver.waitUntilXWindowHandles(3);
         windowHandles = await driver.getAllWindowHandles();
@@ -81,8 +67,9 @@ describe('Failing contract interaction ', function () {
         await driver.clickElement({ text: 'Confirm', tag: 'button' });
         await driver.waitUntilXWindowHandles(2);
         await driver.switchToWindow(extension);
+        await driver.clickElement({ text: 'Activity', tag: 'button' });
         await driver.waitForSelector(
-          '.transaction-list__completed-transactions .transaction-list-item:nth-of-type(2)',
+          '.transaction-list__completed-transactions .transaction-list-item:nth-of-type(1)',
           { timeout: 10000 },
         );
 


### PR DESCRIPTION
## Explanation

The main goal is to deploy the e2e smart contracts directly on Ganache, instead of using the Dapp Test interface for achieving the same actions.
These smart contracts can be used later within the e2e tests in order to reduce the amount of code needed to be written in order to execute the same action every time for each of the tests (i.e. contract deployment). This would also reduce the time needed for e2e tests execution because waiting for the UI action response will be eliminated.

## More Information
The first task took care of preparing the contracts and the seeder, so it deploys correctly any contract we pass them into Ganache, from the background. First PR is already merged here https://github.com/MetaMask/metamask-extension/pull/14631

The second part will take care of the refactor of the e2e testcases, in order to use the smart contract deployer, instead of deploying each contract manually, using the Dapp UI.

- Subtask of [15417]( https://github.com/MetaMask/metamask-extension/issues/15417)


## Manual Testing Steps

Run testcase locally or check ci pipeline and ensure that it continues to work normally:
`yarn test:e2e:single test/e2e/tests/failing-contract.spec.js`

## Pre-Merge Checklist

- [x] PR template is filled out
- [ ] **IF** this PR fixes a bug, a test that _would have_ caught the bug has been added
- [x] PR is linked to the appropriate GitHub issue
- [ ] PR has been added to the appropriate release Milestone

### + If there are functional changes:

- [ ] Manual testing complete & passed
- [ ] "Extension QA Board" label has been applied
