### PR TITLE
[e2e] Refactor send-hex-address spec using Ganache seeder

### DIFF
--- a/test/e2e/tests/send-hex-address.spec.js
+++ b/test/e2e/tests/send-hex-address.spec.js
@@ -1,5 +1,6 @@
 const { strict: assert } = require('assert');
 const { convertToHexValue, withFixtures } = require('../helpers');
+const { SMART_CONTRACTS } = require('../seeder/smart-contracts');
 
 const hexPrefixedAddress = '0x2f318C334780961FB129D2a6c30D0763d9a5C970';
 const nonHexPrefixedAddress = hexPrefixedAddress.substring(2);
@@ -119,6 +120,7 @@ describe('Send ETH to a 40 character hexadecimal address', function () {
 });
 
 describe('Send ERC20 to a 40 character hexadecimal address', function () {
+  const smartContract = SMART_CONTRACTS.HST;
   const ganacheOptions = {
     accounts: [
       {
@@ -134,39 +136,26 @@ describe('Send ERC20 to a 40 character hexadecimal address', function () {
         dapp: true,
         fixtures: 'connected-state',
         ganacheOptions,
+        smartContract,
         title: this.test.title,
         failOnConsoleError: false,
       },
-      async ({ driver }) => {
+      async ({ driver, contractRegistry }) => {
+        const contractAddress = await contractRegistry.getContractAddress(
+          smartContract,
+        );
         await driver.navigate();
         await driver.fill('#password', 'correct horse battery staple');
         await driver.press('#password', driver.Key.ENTER);
 
-        // Create TST
-        await driver.openNewPage('http://127.0.0.1:8080/');
-        await driver.clickElement('#createToken');
-        await driver.waitUntilXWindowHandles(3);
+        await driver.openNewPage(
+          `http://127.0.0.1:8080/?contract=${contractAddress}`,
+        );
         let windowHandles = await driver.getAllWindowHandles();
         const extension = windowHandles[0];
-        const dapp = await driver.switchToWindowWithTitle(
-          'E2E Test Dapp',
-          windowHandles,
-        );
-        await driver.switchToWindowWithTitle(
-          'MetaMask Notification',
-          windowHandles,
-        );
-        await driver.clickElement({ text: 'Confirm', tag: 'button' });
-        await driver.waitUntilXWindowHandles(2);
-        await driver.switchToWindow(extension);
-        await driver.clickElement('[data-testid="home__activity-tab"]');
-        await driver.waitForSelector(
-          '.transaction-list__completed-transactions .transaction-list-item:nth-of-type(1)',
-          { timeout: 10000 },
-        );
+        await driver.findClickableElement('#deployButton');
 
         // Add token
-        await driver.switchToWindow(dapp);
         await driver.clickElement('#watchAsset');
         await driver.waitUntilXWindowHandles(3);
         windowHandles = await driver.getAllWindowHandles();
@@ -209,7 +198,7 @@ describe('Send ERC20 to a 40 character hexadecimal address', function () {
         await driver.clickElement({ text: 'Confirm', tag: 'button' });
         await driver.clickElement('[data-testid="home__activity-tab"]');
         await driver.waitForSelector(
-          '.transaction-list__completed-transactions .transaction-list-item:nth-of-type(2)',
+          '.transaction-list__completed-transactions .transaction-list-item:nth-of-type(1)',
           { timeout: 10000 },
         );
         const sendTransactionListItem = await driver.waitForSelector(
@@ -233,39 +222,28 @@ describe('Send ERC20 to a 40 character hexadecimal address', function () {
         dapp: true,
         fixtures: 'connected-state',
         ganacheOptions,
+        smartContract,
         title: this.test.title,
         failOnConsoleError: false,
       },
-      async ({ driver }) => {
+      async ({ driver, contractRegistry }) => {
+        const contractAddress = await contractRegistry.getContractAddress(
+          smartContract,
+        );
         await driver.navigate();
         await driver.fill('#password', 'correct horse battery staple');
         await driver.press('#password', driver.Key.ENTER);
 
         // Create TST
-        await driver.openNewPage('http://127.0.0.1:8080/');
-        await driver.clickElement('#createToken');
-        await driver.waitUntilXWindowHandles(3);
-        let windowHandles = await driver.getAllWindowHandles();
-        const extension = windowHandles[0];
-        const dapp = await driver.switchToWindowWithTitle(
-          'E2E Test Dapp',
-          windowHandles,
-        );
-        await driver.switchToWindowWithTitle(
-          'MetaMask Notification',
-          windowHandles,
-        );
-        await driver.clickElement({ text: 'Confirm', tag: 'button' });
-        await driver.waitUntilXWindowHandles(2);
-        await driver.switchToWindow(extension);
-        await driver.clickElement('[data-testid="home__activity-tab"]');
-        await driver.waitForSelector(
-          '.transaction-list__completed-transactions .transaction-list-item:nth-of-type(1)',
-          { timeout: 10000 },
+        await driver.openNewPage(
+          `http://127.0.0.1:8080/?contract=${contractAddress}`,
         );
 
+        let windowHandles = await driver.getAllWindowHandles();
+        const extension = windowHandles[0];
+
         // Add token
-        await driver.switchToWindow(dapp);
+        await driver.findClickableElement('#deployButton');
         await driver.clickElement('#watchAsset');
         await driver.waitUntilXWindowHandles(3);
         windowHandles = await driver.getAllWindowHandles();
@@ -308,7 +286,7 @@ describe('Send ERC20 to a 40 character hexadecimal address', function () {
         await driver.clickElement({ text: 'Confirm', tag: 'button' });
         await driver.clickElement('[data-testid="home__activity-tab"]');
         await driver.waitForSelector(
-          '.transaction-list__completed-transactions .transaction-list-item:nth-of-type(2)',
+          '.transaction-list__completed-transactions .transaction-list-item:nth-of-type(1)',
           { timeout: 10000 },
         );
         const sendTransactionListItem = await driver.waitForSelector(

--- a/test/e2e/tests/send-hex-address.spec.js
+++ b/test/e2e/tests/send-hex-address.spec.js
@@ -153,6 +153,9 @@ describe('Send ERC20 to a 40 character hexadecimal address', function () {
         );
         let windowHandles = await driver.getAllWindowHandles();
         const extension = windowHandles[0];
+
+        // Using the line below to make wait time deterministic and avoid using a delay
+        // See more here https://github.com/MetaMask/metamask-extension/pull/15604/files#r949300551
         await driver.findClickableElement('#deployButton');
 
         // Add token


### PR DESCRIPTION
## Explanation

The main goal is to deploy the e2e smart contracts directly on Ganache, instead of using the Dapp Test interface for achieving the same actions.
These smart contracts can be used later within the e2e tests in order to reduce the amount of code needed to be written in order to execute the same action every time for each of the tests (i.e. contract deployment). This would also reduce the time needed for e2e tests execution because waiting for the UI action response will be eliminated.

## More Information
The first task took care of preparing the contracts and the seeder, so it deploys correctly any contract we pass them into Ganache, from the background. First PR is already merged here https://github.com/MetaMask/metamask-extension/pull/14631

The second part will take care of the refactor of the e2e testcases, in order to use the smart contract deployer, instead of deploying each contract manually, using the Dapp UI.

- Subtask of [15417](https://github.com/MetaMask/metamask-extension/issues/15417)

## Manual Testing Steps

Run testcase locally or check ci pipeline and ensure that it continues to work normally:
`yarn test:e2e:single test/e2e/tests/send-hex-address.spec.js`

## Pre-Merge Checklist

- [x] PR template is filled out
- [ ] **IF** this PR fixes a bug, a test that _would have_ caught the bug has been added
- [x] PR is linked to the appropriate GitHub issue
- [ ] PR has been added to the appropriate release Milestone

### + If there are functional changes:

- [ ] Manual testing complete & passed
- [ ] "Extension QA Board" label has been applied
