### PR TITLE
Token Detection clean up - Fixing swaps performance slow down

### DIFF
--- a/ui/hooks/useTokensToSearch.js
+++ b/ui/hooks/useTokensToSearch.js
@@ -8,6 +8,7 @@ import {
   getCurrentCurrency,
   getSwapsDefaultToken,
   getCurrentChainId,
+  getTokenList,
 } from '../selectors';
 import { getConversionRate } from '../ducks/metamask/metamask';
 
@@ -23,7 +24,7 @@ export function getRenderableTokenData(
   conversionRate,
   currentCurrency,
   chainId,
-  shuffledTokenList,
+  tokenList,
 ) {
   const { symbol, name, address, iconUrl, string, balance, decimals } = token;
   let contractExchangeRate;
@@ -54,15 +55,12 @@ export function getRenderableTokenData(
       )
     : '';
 
-  const tokenMetadata = shuffledTokenList.find(
-    (tokenData) => tokenData.address === address?.toLowerCase(),
-  );
-
-  const usedIconUrl = iconUrl || tokenMetadata?.iconUrl || token?.image;
+  const usedIconUrl =
+    iconUrl || tokenList[address?.toLowerCase()]?.iconUrl || token?.image;
   return {
     ...token,
     primaryLabel: symbol,
-    secondaryLabel: name || tokenMetadata?.name,
+    secondaryLabel: name || tokenList[address?.toLowerCase()]?.name,
     rightPrimaryLabel:
       string && `${new BigNumber(string).round(6).toString()} ${symbol}`,
     rightSecondaryLabel: formattedFiat,
@@ -70,7 +68,7 @@ export function getRenderableTokenData(
     identiconAddress: usedIconUrl ? null : address,
     balance,
     decimals,
-    name: name || tokenMetadata?.name,
+    name: name || tokenList[address?.toLowerCase()]?.name,
     rawFiat,
   };
 }
@@ -86,6 +84,7 @@ export function useTokensToSearch({
   const conversionRate = useSelector(getConversionRate);
   const currentCurrency = useSelector(getCurrentCurrency);
   const defaultSwapsToken = useSelector(getSwapsDefaultToken, shallowEqual);
+  const tokenList = useSelector(getTokenList, isEqual);
 
   const memoizedTopTokens = useEqualityCheck(topTokens);
   const memoizedUsersToken = useEqualityCheck(usersTokens);
@@ -96,7 +95,7 @@ export function useTokensToSearch({
     conversionRate,
     currentCurrency,
     chainId,
-    shuffledTokensList,
+    tokenList,
   );
   const memoizedDefaultToken = useEqualityCheck(defaultToken);
 
@@ -136,7 +135,7 @@ export function useTokensToSearch({
         conversionRate,
         currentCurrency,
         chainId,
-        shuffledTokensList,
+        tokenList,
       );
       if (tokenBucketPriority === TOKEN_BUCKET_PRIORITY.OWNED) {
         if (
@@ -192,7 +191,7 @@ export function useTokensToSearch({
     currentCurrency,
     memoizedDefaultToken,
     chainId,
-    shuffledTokensList,
+    tokenList,
     tokenBucketPriority,
   ]);
 }

--- a/ui/pages/swaps/build-quote/build-quote.js
+++ b/ui/pages/swaps/build-quote/build-quote.js
@@ -66,7 +66,7 @@ import {
   getCurrentCurrency,
   getCurrentChainId,
   getRpcPrefsForCurrentProvider,
-  getUseTokenDetection,
+  getTokenList,
   isHardwareWallet,
   getHardwareWalletType,
 } from '../../../selectors';
@@ -150,7 +150,7 @@ export default function BuildQuote({
   const defaultSwapsToken = useSelector(getSwapsDefaultToken, isEqual);
   const chainId = useSelector(getCurrentChainId);
   const rpcPrefs = useSelector(getRpcPrefsForCurrentProvider, shallowEqual);
-  const useTokenDetection = useSelector(getUseTokenDetection);
+  const tokenList = useSelector(getTokenList, isEqual);
   const quotes = useSelector(getQuotes, isEqual);
   const areQuotesPresent = Object.keys(quotes).length > 0;
 
@@ -212,8 +212,7 @@ export default function BuildQuote({
     conversionRate,
     currentCurrency,
     chainId,
-    shuffledTokensList,
-    useTokenDetection,
+    tokenList,
   );
 
   const tokensToSearchSwapFrom = useTokensToSearch({


### PR DESCRIPTION
During Token detection an object was replaced with an array while we try to use the same data for shuffledtokenList and  getRenderableTokenData slowing down Swaps, in this PR we are separating the data to speedup swaps again.