### PR TITLE
Updating Box to remove color prop default (Fixes develop)

### DIFF
--- a/ui/components/ui/box/box.js
+++ b/ui/components/ui/box/box.js
@@ -185,7 +185,7 @@ export default function Box({
   children,
   className,
   backgroundColor,
-  color = TEXT_COLORS.TEXT_DEFAULT,
+  color,
   as = 'div',
   ...props
 }) {

--- a/ui/pages/swaps/view-on-block-explorer/__snapshots__/view-on-block-explorer.test.js.snap
+++ b/ui/pages/swaps/view-on-block-explorer/__snapshots__/view-on-block-explorer.test.js.snap
@@ -3,7 +3,7 @@
 exports[`ViewOnBlockExplorer renders the component with initial props 1`] = `
 <div>
   <div
-    class="box view-on-block-explorer box--margin-top-6 box--flex-direction-row box--color-text-default"
+    class="box view-on-block-explorer box--margin-top-6 box--flex-direction-row"
   >
     <button>
       View Swap at etherscan.io


### PR DESCRIPTION
## Explanation

Currently `develop` is failing because of some snapshot tests. [I added the `color` prop to the `Box` component and set a default](https://github.com/MetaMask/metamask-extension/pull/15565/files#r944009513) which is creating the `box--color-text-default` prop. And although would make sense may have some unexpected outcomes if some of the components that use the Box component are setting the font color using the parent element. This was an oversight on my part.

This PR removes the default prop which should prevent the color class being added and fix tests. It will also prevent any unexpected colors being set by parent CSS

## Pre-Merge Checklist

- [x] PR template is filled out
- ~[x] **IF** this PR fixes a bug, a test that _would have_ caught the bug has been added~ some snapshot tests already exists
- ~[x] PR is linked to the appropriate GitHub issue~ N/A
- ~[x] PR has been added to the appropriate release Milestone~ N/A

### + If there are functional changes:

- ~[x] Manual testing complete & passed~ N/A
- ~[x] "Extension QA Board" label has been applied~ N/A
