### PR TITLE
Fix Signature Request styles

### DIFF
--- a/ui/components/app/signature-request-original/index.scss
+++ b/ui/components/app/signature-request-original/index.scss
@@ -167,6 +167,10 @@
     margin-right: 5px;
   }
 
+  &__origin-icon {
+    flex: 0 0 24px;
+  }
+
   &__origin {
     margin-left: 5px;
   }

--- a/ui/components/app/signature-request-original/index.scss
+++ b/ui/components/app/signature-request-original/index.scss
@@ -153,7 +153,6 @@
     display: flex;
     flex-flow: column;
     flex: 1 1 auto;
-    height: 0;
   }
 
   &__origin-row {
@@ -193,7 +192,7 @@
 
   &__rows {
     height: 100%;
-    overflow-y: scroll;
+    overflow-y: auto;
     overflow-x: hidden;
     border-top: 1px solid var(--color-border-default);
     display: flex;

--- a/ui/components/app/signature-request-original/signature-request-original.component.js
+++ b/ui/components/app/signature-request-original/signature-request-original.component.js
@@ -141,6 +141,7 @@ export default class SignatureRequestOriginal extends Component {
         </div>
         {targetSubjectMetadata?.iconUrl ? (
           <SiteIcon
+            className="request-signature__origin-icon"
             icon={targetSubjectMetadata.iconUrl}
             name={
               getURLHostName(targetSubjectMetadata.origin) ||


### PR DESCRIPTION
## Explanation

Fixes 2 style bugs on the Signature Request Original component: 

**Before Fix:**
1. When issuing a signature request using a hardware wallet, the message is hidden, and text overlaps.
2. When the request origin URL is lengthy, the icon shrinks.

**After Fix:**
1. When issuing a signature request using a hardware wallet, the message is not hidden, and there is no text overlap.
2. When the request origin URL is lengthy, the icon does not shrink.

## More Information

## Screenshots/Screencaps

### Before
<img width="384" alt="Screenshot 2022-08-17 at 7 40 00 PM" src="https://user-images.githubusercontent.com/20778143/185174044-4cecb2ee-b79f-49fe-9f4a-8e0f9175468a.png">

<img width="456" alt="Screenshot 2022-08-17 at 8 12 16 PM" src="https://user-images.githubusercontent.com/20778143/185174138-eded3aaa-8330-4a32-b2f6-bc6b6dbb3957.png">


### After
<img width="382" alt="Screenshot 2022-08-17 at 11 11 52 PM" src="https://user-images.githubusercontent.com/20778143/185176450-2915ebd7-9007-4306-be44-abc25a2bc7da.png">

<img width="376" alt="Screenshot 2022-08-17 at 8 23 53 PM" src="https://user-images.githubusercontent.com/20778143/185174893-f54a732a-c41c-4246-b340-b462c5c29954.png">

<img width="386" alt="Screenshot 2022-08-17 at 8 22 44 PM" src="https://user-images.githubusercontent.com/20778143/185174973-5d85ad3a-4d5e-4956-bd38-8c26d4149fdc.png">

## Manual Testing Steps
(Steps to reproduce the bug shown with `eth_sign` request)
1. Go to a dapp or [test dapp](https://metamask.github.io/test-dapp/) that can perform sign transactions
3. Create an `eth_sign` request
4. Observe the UI renders as expected

