### PR TITLE
Fix state creation in setupSentryGetStateGlobal

### DIFF
--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -360,7 +360,7 @@ function setupController(initState, initLangCode, remoteSourcePort) {
     },
   );
 
-  setupSentryGetStateGlobal(controller.store);
+  setupSentryGetStateGlobal(controller);
 
   /**
    * Assigns the given state to the versioned object (with metadata), and returns that.
@@ -788,11 +788,11 @@ browser.runtime.onInstalled.addListener(({ reason }) => {
 function setupSentryGetStateGlobal(store) {
   global.getSentryState = function () {
     const fullState = store.getState();
-    const debugState = maskObject(fullState, SENTRY_STATE);
+    const debugState = maskObject({ metamask: fullState }, SENTRY_STATE);
     return {
       browser: window.navigator.userAgent,
       store: debugState,
-      version: global.platform.getVersion(),
+      version: platform.getVersion(),
     };
   };
 }


### PR DESCRIPTION
This PR fixes reporting of errors in sentry, which has not been working since v10.18.1

These issues were introduced in https://github.com/MetaMask/metamask-extension/pull/15313

