### PR TITLE
Fix stray space/period in Custom Token warning text

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -838,7 +838,7 @@
     "message": "Token detection is not available on this network yet. Please import token manually and make sure you trust it. Learn about $1"
   },
   "customTokenWarningInTokenDetectionNetwork": {
-    "message": "Before manually importing a token, make sure you trust it. Learn about $1."
+    "message": "Before manually importing a token, make sure you trust it. Learn about $1"
   },
   "customTokenWarningInTokenDetectionNetworkWithTDOFF": {
     "message": "Make sure you trust a token before you import it. Learn how to avoid $1. You can also enable token detection $2."


### PR DESCRIPTION
Fixes: https://github.com/MetaMask/metamask-extension/issues/15548

The second arg to `t('customTokenWarningInTokenDetectionNetwork', [..` is `'learnScamRisk'`, which is used in other places. This is the singular use of `customTokenWarningInTokenDetectionNetwork` so it does not need the trailing period in the translation.

<img width="404" alt="Screen Shot 2022-08-19 at 6 22 25 AM" src="https://user-images.githubusercontent.com/8732757/185628337-acee2317-d953-43fd-94d1-ec07100b0441.png">

