### PR TITLE
Fixing Blockies identicon option alignment

### DIFF
--- a/ui/pages/settings/settings-tab/settings-tab.component.js
+++ b/ui/pages/settings/settings-tab/settings-tab.component.js
@@ -248,8 +248,10 @@ export default class SettingsTab extends PureComponent {
               <Typography
                 color={COLORS.TEXT_DEFAULT}
                 variant={TYPOGRAPHY.H7}
-                margin={0}
+                marginTop={3}
+                marginRight={0}
                 marginBottom={3}
+                marginLeft={3}
               >
                 {t('blockies')}
               </Typography>


### PR DESCRIPTION
Fixes: https://github.com/MetaMask/metamask-extension/issues/15618

<img width="344" alt="Screen Shot 2022-08-19 at 10 11 15 AM" src="https://user-images.githubusercontent.com/8732757/185672111-d385edc0-4825-402a-b965-0181929ba566.png">
<img width="344" alt="Screen Shot 2022-08-19 at 10 11 07 AM" src="https://user-images.githubusercontent.com/8732757/185672115-7ec9f7ed-ded2-4b77-90bd-0dc5187f411b.png">

<img width="672" alt="Screen Shot 2022-08-19 at 10 10 45 AM" src="https://user-images.githubusercontent.com/8732757/185672118-9af30e4f-dac6-4ba0-89eb-d46a0644a0a2.png">
<img width="690" alt="Screen Shot 2022-08-19 at 10 10 38 AM" src="https://user-images.githubusercontent.com/8732757/185672120-9ae17807-96d7-4267-ab02-08ba09f99f88.png">

