### PR TITLE
Ensuring Blockies icon is used in recipient details when enabled

### DIFF
--- a/ui/components/ui/nickname-popover/nickname-popover.component.js
+++ b/ui/components/ui/nickname-popover/nickname-popover.component.js
@@ -6,7 +6,7 @@ import { I18nContext } from '../../../contexts/i18n';
 import Tooltip from '../tooltip';
 import Popover from '../popover';
 import Button from '../button';
-import Identicon from '../identicon/identicon.component';
+import Identicon from '../identicon';
 import { shortenAddress } from '../../../helpers/utils/util';
 import CopyIcon from '../icon/copy-icon.component';
 import { useCopyToClipboard } from '../../../hooks/useCopyToClipboard';


### PR DESCRIPTION
Fixes: https://github.com/MetaMask/metamask-extension/issues/15196 

The issue was that the full component container was not being included, just the component itself, therefore `Identicon` was not receiving the appropriate props

<img width="332" alt="Screen Shot 2022-08-21 at 3 15 00 PM" src="https://user-images.githubusercontent.com/8732757/185813121-1ef9190f-3c9f-40ad-9c13-0c6706522fd7.png">

<img width="325" alt="Screen Shot 2022-08-21 at 3 15 11 PM" src="https://user-images.githubusercontent.com/8732757/185813120-8d05796f-41a0-43e5-b1b7-64aca2745297.png">

<img width="341" alt="Screen Shot 2022-08-21 at 3 18 48 PM" src="https://user-images.githubusercontent.com/8732757/185813140-0bdbd51f-ebc9-408c-9ee6-5a1009975123.png">

