### PR TITLE
Fixing Contacts breadcrumb when viewing contact details

### DIFF
--- a/ui/pages/settings/settings.component.js
+++ b/ui/pages/settings/settings.component.js
@@ -211,6 +211,8 @@ class SettingsPage extends PureComponent {
 
     if (isPopup && isAddressEntryPage) {
       subheaderText = t('settings');
+    } else if (isAddressEntryPage) {
+      subheaderText = t('contacts');
     } else if (initialBreadCrumbKey) {
       subheaderText = t(initialBreadCrumbKey);
     } else {


### PR DESCRIPTION
Fixes: https://github.com/MetaMask/metamask-extension/issues/15394

## Test Plan
Defined in issue

<img width="635" alt="Screen Shot 2022-08-21 at 6 58 11 PM" src="https://user-images.githubusercontent.com/8732757/185824327-d648658f-d5ff-4096-8945-66602a608c20.png">

