### PR TITLE
Revert "filter breadcrumbs for improved clarity while debugging sentry errors (#15639)

### DIFF
--- a/app/scripts/lib/setupSentry.js
+++ b/app/scripts/lib/setupSentry.js
@@ -114,22 +114,6 @@ export default function setupSentry({ release, getState }) {
       }
       return rewriteReport(report);
     },
-    beforeBreadcrumb(breadcrumb) {
-      if (getState) {
-        const appState = getState();
-        if (
-          Object.values(appState).length &&
-          (!appState?.store?.metamask?.participateInMetaMetrics ||
-            !appState?.store?.metamask?.completedOnboarding ||
-            breadcrumb?.category === 'ui.input')
-        ) {
-          return null;
-        }
-      } else {
-        return null;
-      }
-      return breadcrumb;
-    },
   });
 
   function rewriteReport(report) {


### PR DESCRIPTION
Temporarily reverting #15639 because it is contributing to the breaking of sentry error handling. We will revert this revert when we solve the underlying issue.