### PR TITLE
Fix Sentry in LavaMoat contexts

### DIFF
--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -786,7 +786,10 @@ browser.runtime.onInstalled.addListener(({ reason }) => {
 });
 
 function setupSentryGetStateGlobal(store) {
-  global.getSentryState = function () {
+  if (!global.rootGlobals) {
+    global.rootGlobals = {};
+  }
+  global.rootGlobals.getSentryState = function () {
     const fullState = store.getState();
     const debugState = maskObject({ metamask: fullState }, SENTRY_STATE);
     return {

--- a/app/scripts/sentry-install.js
+++ b/app/scripts/sentry-install.js
@@ -3,5 +3,5 @@ import setupSentry from './lib/setupSentry';
 // setup sentry error reporting
 global.sentry = setupSentry({
   release: process.env.METAMASK_VERSION,
-  getState: () => global.getSentryState?.() || {},
+  getState: () => global.rootGlobals?.getSentryState?.() || {},
 });

--- a/patches/@lavamoat+lavapack+3.1.0.patch
+++ b/patches/@lavamoat+lavapack+3.1.0.patch
@@ -13,3 +13,19 @@ index eb41a0a..3f891ea 100644
        // deps,
        // source: sourceMeta.code
      }
+diff --git a/node_modules/@lavamoat/lavapack/src/runtime.js b/node_modules/@lavamoat/lavapack/src/runtime.js
+index 58f76f3..53df0e7 100644
+--- a/node_modules/@lavamoat/lavapack/src/runtime.js
++++ b/node_modules/@lavamoat/lavapack/src/runtime.js
+@@ -11160,6 +11160,11 @@ function makePrepareRealmGlobalFromConfig ({ createFunctionWrapper }) {
+         rootPackageCompartment.globalThis[ref] = rootPackageCompartment.globalThis
+       }
+ 
++      // Allow root compartment to expose things to the initial execution environment of the realm.
++      // This is intended to support passing data to shims run before lockdown.
++      globalThis.rootGlobals = {}
++      rootPackageCompartment.globalThis.rootGlobals = globalThis.rootGlobals
++
+       // save the compartment for use by other modules in the package
+       packageCompartmentCache.set(rootPackageName, rootPackageCompartment)
+ 

--- a/ui/index.js
+++ b/ui/index.js
@@ -191,7 +191,10 @@ function setupDebuggingHelpers(store) {
     });
     return state;
   };
-  window.getSentryState = function () {
+  if (!window.rootGlobals) {
+    window.rootGlobals = {};
+  }
+  window.rootGlobals.getSentryState = function () {
     const fullState = store.getState();
     const debugState = maskObject(fullState, SENTRY_STATE);
     return {


### PR DESCRIPTION
Our Sentry setup relies upon application state, but it wasn't able to access it in LavaMoat builds because it's running in a separate Compartment.

A patch has been introduced to the LavaMoat runtime to allow the root Compartment to mutate the `rootGlobals` object, which is accessible from outside the compartment as well. This lets us expose application state to our Sentry integration.

## Manual Testing Steps

1. Setup errors for testing
  Before testing, ensure you know of a reliable way to trigger a Sentry error. If not, introduce an error somewhere in the codebase for testing purposes. We will want to test errors thrown in both the background and the UI, so we'll want a way to test both.
Typically my solution for the background error is to add `setImmediate(() => { throw new Error('test') })` in one of the setters in the preferences controller, as those are easy to trigger. The `setImmediate` ensures that the error stays in the background context, rather than being returned to the UI.
For the UI function, I throw an error in the `render` function for a page.
2. Set `SENTRY_DSN_DEV` environment variable or `.metamaskrc` entry to the Sentry DSN for either the test MetaMask account or your personal Sentry account. I've found personal accounts to be more reliable for testing, so that's what I'd recommend.
3. Comment out [this line](https://github.com/MetaMask/metamask-extension/blob/develop/app/scripts/lib/setupSentry.js#L74) if testing with a dev build
We will want to test both prod and dev builds. That line disables Sentry on dev builds.
4. Build and install MetaMask, making sure to enable MetaMetrics during onboarding.
We have found during testing that Sentry reports are being skipped in some cases if you initially left MetaMetrics disabled, even if you later opt-in. That will be resolved in a separate PR.
5. Open the background dev console to the network tab
6. Trigger the background error, and ensure there is a corresponding Sentry network request containing the error report.
7. Open the fullscreen UI, and open the dev console for that page to the network tab.
8. Trigger the UI error, and ensure there is a corresponding Sentry network request containing the error report.
9. Check the Sentry dashboard corresponding to the `SENTRY_DSN_DEV` you set, and ensure both errors are shown.

## Pre-Merge Checklist

- [x] PR template is filled out
- :x: **IF** this PR fixes a bug, a test that _would have_ caught the bug has been added
  - I don't know of any way to cover this with an automated test.
- [x] PR is linked to the appropriate GitHub issue
- [x] PR has been added to the appropriate release Milestone

### + If there are functional changes:

- [x] Manual testing complete & passed
- [x] "Extension QA Board" label has been applied
