### PR TITLE
Jest configuration fix

### DIFF
--- a/test/jest/setup.js
+++ b/test/jest/setup.js
@@ -1,2 +1,10 @@
 // This file is for Jest-specific setup only and runs before our Jest tests.
 import '@testing-library/jest-dom';
+
+jest.mock('webextension-polyfill', () => {
+  return {
+    runtime: {
+      getManifest: () => ({ manifest_version: 2 }),
+    },
+  };
+});


### PR DESCRIPTION
This fixes issue with some jest test cases breaking locally in latest code

```
[production]   ● Test suite failed to run
[production] 
[production]     TypeError: _webextensionPolyfill.default.runtime.getManifest is not a function
[production] 
[production]       2 |
[production]       3 | export const isManifestV3 =
[production]     > 4 |   browser.runtime.getManifest().manifest_version === 3;
```