### PR TITLE
Make cancel transaction idempotent

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -3278,18 +3278,14 @@ export default class MetamaskController extends EventEmitter {
    *  './controllers/transactions'
    * ).CustomGasSettings} [customGasSettings] - overrides to use for gas params
    *  instead of allowing this method to generate them
-   * @param newTxMetaProps
+   * @param options
    * @returns {object} MetaMask state
    */
-  async createCancelTransaction(
-    originalTxId,
-    customGasSettings,
-    newTxMetaProps,
-  ) {
+  async createCancelTransaction(originalTxId, customGasSettings, options) {
     await this.txController.createCancelTransaction(
       originalTxId,
       customGasSettings,
-      newTxMetaProps,
+      options,
     );
     const state = await this.getState();
     return state;

--- a/ui/store/actions.js
+++ b/ui/store/actions.js
@@ -1998,23 +1998,6 @@ export function createCancelTransaction(txId, customGasSettings, options) {
         },
         actionId,
       );
-      callBackgroundMethod(
-        'createCancelTransaction',
-        [txId, customGasSettings, { ...options, actionId }],
-        (err, newState) => {
-          if (err) {
-            dispatch(displayWarning(err.message));
-            reject(err);
-            return;
-          }
-
-          const { currentNetworkTxList } = newState;
-          const { id } = currentNetworkTxList[currentNetworkTxList.length - 1];
-          newTxId = id;
-          resolve(newState);
-        },
-        actionId,
-      );
     })
       .then((newState) => dispatch(updateMetamaskState(newState)))
       .then(() => newTxId);

--- a/ui/store/actions.js
+++ b/ui/store/actions.js
@@ -1974,19 +1974,16 @@ export function clearPendingTokens() {
   };
 }
 
-export function createCancelTransaction(
-  txId,
-  customGasSettings,
-  newTxMetaProps,
-) {
+export function createCancelTransaction(txId, customGasSettings, options) {
   log.debug('background.cancelTransaction');
   let newTxId;
 
   return (dispatch) => {
+    const actionId = Date.now() + Math.random();
     return new Promise((resolve, reject) => {
       callBackgroundMethod(
         'createCancelTransaction',
-        [txId, customGasSettings, newTxMetaProps],
+        [txId, customGasSettings, { ...options, actionId }],
         (err, newState) => {
           if (err) {
             dispatch(displayWarning(err.message));
@@ -1999,6 +1996,24 @@ export function createCancelTransaction(
           newTxId = id;
           resolve(newState);
         },
+        actionId,
+      );
+      callBackgroundMethod(
+        'createCancelTransaction',
+        [txId, customGasSettings, { ...options, actionId }],
+        (err, newState) => {
+          if (err) {
+            dispatch(displayWarning(err.message));
+            reject(err);
+            return;
+          }
+
+          const { currentNetworkTxList } = newState;
+          const { id } = currentNetworkTxList[currentNetworkTxList.length - 1];
+          newTxId = id;
+          resolve(newState);
+        },
+        actionId,
       );
     })
       .then((newState) => dispatch(updateMetamaskState(newState)))


### PR DESCRIPTION
Fixes: #15541

Related to PR: https://github.com/MetaMask/metamask-extension/pull/15667

Make action createCancelTransaction idempotent.