### PR TITLE
Adding custom component props to FormField component

### DIFF
--- a/ui/components/ui/form-field/README.mdx
+++ b/ui/components/ui/form-field/README.mdx
@@ -29,3 +29,12 @@ Show form fields with error state
 <Canvas>
   <Story id="ui-components-ui-form-field-form-field-stories-js--form-field-with-error" />
 </Canvas>
+
+### Custom Components
+
+Use the custom component props `TitleTextCustomComponent`, `TitleUnitCustomComponent` and `TooltipCustomComponent` to replace the default components.
+If these props exists they will replace their respective text props.
+
+<Canvas>
+  <Story id="ui-components-ui-form-field-form-field-stories-js--custom-components" />
+</Canvas>

--- a/ui/components/ui/form-field/README.mdx
+++ b/ui/components/ui/form-field/README.mdx
@@ -33,7 +33,8 @@ Show form fields with error state
 ### Custom Components
 
 Use the custom component props `TitleTextCustomComponent`, `TitleUnitCustomComponent` and `TooltipCustomComponent` to replace the default components.
-If these props exists they will replace their respective text props.
+If these props exists they will replace their respective text props. The FormField is wrapped in a Box component that renders as a `<label />` element.
+To change the element type, use the `wrappingLabelProps` and polymorphic `as` prop. e.g `wrappingLabelProps={{ as: 'div' }}`. Make sure to provide your own `<label />` element combined with the `id` prop and `htmlFor` to ensure accessibility
 
 <Canvas>
   <Story id="ui-components-ui-form-field-form-field-stories-js--custom-components" />

--- a/ui/components/ui/form-field/form-field.js
+++ b/ui/components/ui/form-field/form-field.js
@@ -53,35 +53,32 @@ export default function FormField({
             display={DISPLAY.FLEX}
             alignItems={ALIGN_ITEMS.CENTER}
           >
-            {TitleTextCustomComponent
-              ? TitleTextCustomComponent
-              : titleText && (
-                  <Typography
-                    tag={TYPOGRAPHY.H6}
-                    fontWeight={FONT_WEIGHT.BOLD}
-                    variant={TYPOGRAPHY.H6}
-                    boxProps={{ display: DISPLAY.INLINE_BLOCK }}
-                  >
-                    {titleText}
-                  </Typography>
-                )}
-            {TitleUnitCustomComponent
-              ? TitleUnitCustomComponent
-              : titleUnit && (
-                  <Typography
-                    tag={TYPOGRAPHY.H6}
-                    variant={TYPOGRAPHY.H6}
-                    color={COLORS.TEXT_ALTERNATIVE}
-                    boxProps={{ display: DISPLAY.INLINE_BLOCK }}
-                  >
-                    {titleUnit}
-                  </Typography>
-                )}
-            {TooltipCustomComponent
-              ? TooltipCustomComponent
-              : tooltipText && (
-                  <InfoTooltip position="top" contentText={tooltipText} />
-                )}
+            {TitleTextCustomComponent ||
+              (titleText && (
+                <Typography
+                  tag={TYPOGRAPHY.H6}
+                  fontWeight={FONT_WEIGHT.BOLD}
+                  variant={TYPOGRAPHY.H6}
+                  boxProps={{ display: DISPLAY.INLINE_BLOCK }}
+                >
+                  {titleText}
+                </Typography>
+              ))}
+            {TitleUnitCustomComponent ||
+              (titleUnit && (
+                <Typography
+                  tag={TYPOGRAPHY.H6}
+                  variant={TYPOGRAPHY.H6}
+                  color={COLORS.TEXT_ALTERNATIVE}
+                  boxProps={{ display: DISPLAY.INLINE_BLOCK }}
+                >
+                  {titleUnit}
+                </Typography>
+              ))}
+            {TooltipCustomComponent ||
+              (tooltipText && (
+                <InfoTooltip position="top" contentText={tooltipText} />
+              ))}
           </Box>
           {titleDetail && (
             <Box

--- a/ui/components/ui/form-field/form-field.js
+++ b/ui/components/ui/form-field/form-field.js
@@ -10,6 +10,7 @@ import {
   DISPLAY,
   TYPOGRAPHY,
   FONT_WEIGHT,
+  ALIGN_ITEMS,
 } from '../../../helpers/constants/design-system';
 
 import NumericInput from '../numeric-input/numeric-input.component';
@@ -18,9 +19,13 @@ import InfoTooltip from '../info-tooltip/info-tooltip';
 export default function FormField({
   dataTestId,
   titleText,
+  TitleTextCustomComponent,
   titleUnit,
+  TitleUnitCustomComponent,
   tooltipText,
+  TooltipCustomComponent,
   titleDetail,
+  titleDetailWrapperProps,
   error,
   onChange,
   value,
@@ -43,37 +48,48 @@ export default function FormField({
     >
       <label>
         <div className="form-field__heading">
-          <div className="form-field__heading-title">
-            {titleText && (
-              <Typography
-                tag={TYPOGRAPHY.H6}
-                fontWeight={FONT_WEIGHT.BOLD}
-                variant={TYPOGRAPHY.H6}
-                boxProps={{ display: DISPLAY.INLINE_BLOCK }}
-              >
-                {titleText}
-              </Typography>
-            )}
-            {titleUnit && (
-              <Typography
-                tag={TYPOGRAPHY.H6}
-                variant={TYPOGRAPHY.H6}
-                color={COLORS.TEXT_ALTERNATIVE}
-                boxProps={{ display: DISPLAY.INLINE_BLOCK }}
-              >
-                {titleUnit}
-              </Typography>
-            )}
-            {tooltipText && (
-              <InfoTooltip position="top" contentText={tooltipText} />
-            )}
-          </div>
+          <Box
+            className="form-field__heading-title"
+            display={DISPLAY.FLEX}
+            alignItems={ALIGN_ITEMS.CENTER}
+          >
+            {TitleTextCustomComponent
+              ? TitleTextCustomComponent
+              : titleText && (
+                  <Typography
+                    tag={TYPOGRAPHY.H6}
+                    fontWeight={FONT_WEIGHT.BOLD}
+                    variant={TYPOGRAPHY.H6}
+                    boxProps={{ display: DISPLAY.INLINE_BLOCK }}
+                  >
+                    {titleText}
+                  </Typography>
+                )}
+            {TitleUnitCustomComponent
+              ? TitleUnitCustomComponent
+              : titleUnit && (
+                  <Typography
+                    tag={TYPOGRAPHY.H6}
+                    variant={TYPOGRAPHY.H6}
+                    color={COLORS.TEXT_ALTERNATIVE}
+                    boxProps={{ display: DISPLAY.INLINE_BLOCK }}
+                  >
+                    {titleUnit}
+                  </Typography>
+                )}
+            {TooltipCustomComponent
+              ? TooltipCustomComponent
+              : tooltipText && (
+                  <InfoTooltip position="top" contentText={tooltipText} />
+                )}
+          </Box>
           {titleDetail && (
             <Box
               className="form-field__heading-detail"
               textAlign={TEXT_ALIGN.END}
               marginBottom={3}
               marginRight={2}
+              {...titleDetailWrapperProps}
             >
               {titleDetail}
             </Box>
@@ -157,17 +173,39 @@ FormField.propTypes = {
    */
   titleText: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
   /**
+   * A custom component to replace the title text Typography component
+   * titleText will be ignored if this is provided
+   */
+  TitleTextCustomComponent: PropTypes.node,
+  /**
    * Show unit (eg. ETH)
    */
   titleUnit: PropTypes.string,
+  /**
+   * A custom component to replace the title unit Typography component
+   * titleUnit will be ignored if this is provided
+   */
+  TitleUnitCustomComponent: PropTypes.node,
   /**
    * Add Tooltip and text content
    */
   tooltipText: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
   /**
+   * A custom component to replace the tooltip component
+   * tooltipText will be ignored if this is provided
+   */
+  TooltipCustomComponent: PropTypes.node,
+  /**
    * Show content (text, image, component) in title
    */
   titleDetail: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
+  /**
+   * Props to pass to wrapping Box component of the titleDetail component
+   * Accepts all props of the Box component
+   */
+  titleDetailWrapperProps: {
+    ...Box.PropTypes,
+  },
   /**
    * Show error message
    */

--- a/ui/components/ui/form-field/form-field.js
+++ b/ui/components/ui/form-field/form-field.js
@@ -46,116 +46,114 @@ export default function FormField({
         'form-field__row--error': error,
       })}
     >
-      <label>
-        <div className="form-field__heading">
+      <div className="form-field__heading">
+        <Box
+          className="form-field__heading-title"
+          display={DISPLAY.FLEX}
+          alignItems={ALIGN_ITEMS.CENTER}
+        >
+          {TitleTextCustomComponent ||
+            (titleText && (
+              <Typography
+                tag="label"
+                fontWeight={FONT_WEIGHT.BOLD}
+                variant={TYPOGRAPHY.H6}
+                boxProps={{ display: DISPLAY.INLINE_BLOCK }}
+              >
+                {titleText}
+              </Typography>
+            ))}
+          {TitleUnitCustomComponent ||
+            (titleUnit && (
+              <Typography
+                tag={TYPOGRAPHY.H6}
+                variant={TYPOGRAPHY.H6}
+                color={COLORS.TEXT_ALTERNATIVE}
+                boxProps={{ display: DISPLAY.INLINE_BLOCK }}
+              >
+                {titleUnit}
+              </Typography>
+            ))}
+          {TooltipCustomComponent ||
+            (tooltipText && (
+              <InfoTooltip position="top" contentText={tooltipText} />
+            ))}
+        </Box>
+        {titleDetail && (
           <Box
-            className="form-field__heading-title"
-            display={DISPLAY.FLEX}
-            alignItems={ALIGN_ITEMS.CENTER}
+            className="form-field__heading-detail"
+            textAlign={TEXT_ALIGN.END}
+            marginBottom={3}
+            marginRight={2}
+            {...titleDetailWrapperProps}
           >
-            {TitleTextCustomComponent ||
-              (titleText && (
-                <Typography
-                  tag={TYPOGRAPHY.H6}
-                  fontWeight={FONT_WEIGHT.BOLD}
-                  variant={TYPOGRAPHY.H6}
-                  boxProps={{ display: DISPLAY.INLINE_BLOCK }}
-                >
-                  {titleText}
-                </Typography>
-              ))}
-            {TitleUnitCustomComponent ||
-              (titleUnit && (
-                <Typography
-                  tag={TYPOGRAPHY.H6}
-                  variant={TYPOGRAPHY.H6}
-                  color={COLORS.TEXT_ALTERNATIVE}
-                  boxProps={{ display: DISPLAY.INLINE_BLOCK }}
-                >
-                  {titleUnit}
-                </Typography>
-              ))}
-            {TooltipCustomComponent ||
-              (tooltipText && (
-                <InfoTooltip position="top" contentText={tooltipText} />
-              ))}
+            {titleDetail}
           </Box>
-          {titleDetail && (
-            <Box
-              className="form-field__heading-detail"
-              textAlign={TEXT_ALIGN.END}
-              marginBottom={3}
-              marginRight={2}
-              {...titleDetailWrapperProps}
-            >
-              {titleDetail}
-            </Box>
-          )}
-        </div>
-        {numeric ? (
-          <NumericInput
-            error={error}
-            onChange={onChange}
-            value={value}
-            detailText={detailText}
-            autoFocus={autoFocus}
-            allowDecimals={allowDecimals}
-            disabled={disabled}
-            dataTestId={dataTestId}
-            placeholder={placeholder}
-          />
-        ) : (
-          <input
-            className={classNames('form-field__input', {
-              'form-field__input--error': error,
-              'form-field__input--warning': warning,
-            })}
-            onChange={(e) => onChange(e.target.value)}
-            value={value}
-            type={password ? 'password' : 'text'}
-            autoFocus={autoFocus}
-            disabled={disabled}
-            data-testid={dataTestId}
-            placeholder={placeholder}
-          />
         )}
-        {error && (
-          <Typography
-            color={COLORS.ERROR_DEFAULT}
-            variant={TYPOGRAPHY.H7}
-            className="form-field__error"
-          >
-            {error}
-          </Typography>
-        )}
-        {warning && (
-          <Typography
-            color={COLORS.TEXT_ALTERNATIVE}
-            variant={TYPOGRAPHY.H7}
-            className="form-field__warning"
-          >
-            {warning}
-          </Typography>
-        )}
-        {passwordStrength && (
-          <Typography
-            color={COLORS.TEXT_DEFAULT}
-            variant={TYPOGRAPHY.H7}
-            className="form-field__password-strength"
-          >
-            {passwordStrength}
-          </Typography>
-        )}
-        {passwordStrengthText && (
-          <Typography
-            color={COLORS.TEXT_ALTERNATIVE}
-            variant={TYPOGRAPHY.H8}
-            className="form-field__password-strength-text"
-          >
-            {passwordStrengthText}
-          </Typography>
-        )}
-      </label>
+      </div>
+      {numeric ? (
+        <NumericInput
+          error={error}
+          onChange={onChange}
+          value={value}
+          detailText={detailText}
+          autoFocus={autoFocus}
+          allowDecimals={allowDecimals}
+          disabled={disabled}
+          dataTestId={dataTestId}
+          placeholder={placeholder}
+        />
+      ) : (
+        <input
+          className={classNames('form-field__input', {
+            'form-field__input--error': error,
+            'form-field__input--warning': warning,
+          })}
+          onChange={(e) => onChange(e.target.value)}
+          value={value}
+          type={password ? 'password' : 'text'}
+          autoFocus={autoFocus}
+          disabled={disabled}
+          data-testid={dataTestId}
+          placeholder={placeholder}
+        />
+      )}
+      {error && (
+        <Typography
+          color={COLORS.ERROR_DEFAULT}
+          variant={TYPOGRAPHY.H7}
+          className="form-field__error"
+        >
+          {error}
+        </Typography>
+      )}
+      {warning && (
+        <Typography
+          color={COLORS.TEXT_ALTERNATIVE}
+          variant={TYPOGRAPHY.H7}
+          className="form-field__warning"
+        >
+          {warning}
+        </Typography>
+      )}
+      {passwordStrength && (
+        <Typography
+          color={COLORS.TEXT_DEFAULT}
+          variant={TYPOGRAPHY.H7}
+          className="form-field__password-strength"
+        >
+          {passwordStrength}
+        </Typography>
+      )}
+      {passwordStrengthText && (
+        <Typography
+          color={COLORS.TEXT_ALTERNATIVE}
+          variant={TYPOGRAPHY.H8}
+          className="form-field__password-strength-text"
+        >
+          {passwordStrengthText}
+        </Typography>
+      )}
     </div>
   );
 }

--- a/ui/components/ui/form-field/form-field.js
+++ b/ui/components/ui/form-field/form-field.js
@@ -18,27 +18,30 @@ import InfoTooltip from '../info-tooltip/info-tooltip';
 
 export default function FormField({
   dataTestId,
-  titleText,
+  titleText = '',
   TitleTextCustomComponent,
-  titleUnit,
+  titleUnit = '',
   TitleUnitCustomComponent,
-  tooltipText,
+  tooltipText = '',
   TooltipCustomComponent,
-  titleDetail,
+  titleDetail = '',
   titleDetailWrapperProps,
   error,
-  onChange,
-  value,
+  onChange = undefined,
+  value = 0,
   numeric,
-  detailText,
-  autoFocus,
-  password,
-  allowDecimals,
-  disabled,
+  detailText = '',
+  autoFocus = false,
+  password = false,
+  allowDecimals = false,
+  disabled = false,
   placeholder,
   warning,
   passwordStrength,
   passwordStrengthText,
+  id,
+  inputProps,
+  wrappingLabelProps,
 }) {
   return (
     <div
@@ -46,114 +49,121 @@ export default function FormField({
         'form-field__row--error': error,
       })}
     >
-      <div className="form-field__heading">
-        <Box
-          className="form-field__heading-title"
-          display={DISPLAY.FLEX}
-          alignItems={ALIGN_ITEMS.CENTER}
-        >
-          {TitleTextCustomComponent ||
-            (titleText && (
-              <Typography
-                tag="label"
-                fontWeight={FONT_WEIGHT.BOLD}
-                variant={TYPOGRAPHY.H6}
-                boxProps={{ display: DISPLAY.INLINE_BLOCK }}
-              >
-                {titleText}
-              </Typography>
-            ))}
-          {TitleUnitCustomComponent ||
-            (titleUnit && (
-              <Typography
-                tag={TYPOGRAPHY.H6}
-                variant={TYPOGRAPHY.H6}
-                color={COLORS.TEXT_ALTERNATIVE}
-                boxProps={{ display: DISPLAY.INLINE_BLOCK }}
-              >
-                {titleUnit}
-              </Typography>
-            ))}
-          {TooltipCustomComponent ||
-            (tooltipText && (
-              <InfoTooltip position="top" contentText={tooltipText} />
-            ))}
-        </Box>
-        {titleDetail && (
+      <Box as="label" {...wrappingLabelProps}>
+        <div className="form-field__heading">
           <Box
-            className="form-field__heading-detail"
-            textAlign={TEXT_ALIGN.END}
-            marginBottom={3}
-            marginRight={2}
-            {...titleDetailWrapperProps}
+            className="form-field__heading-title"
+            display={DISPLAY.FLEX}
+            alignItems={ALIGN_ITEMS.CENTER}
           >
-            {titleDetail}
+            {TitleTextCustomComponent ||
+              (titleText && (
+                <Typography
+                  tag="label"
+                  htmlFor={id}
+                  html
+                  fontWeight={FONT_WEIGHT.BOLD}
+                  variant={TYPOGRAPHY.H6}
+                  boxProps={{ display: DISPLAY.INLINE_BLOCK }}
+                >
+                  {titleText}
+                </Typography>
+              ))}
+            {TitleUnitCustomComponent ||
+              (titleUnit && (
+                <Typography
+                  tag={TYPOGRAPHY.H6}
+                  variant={TYPOGRAPHY.H6}
+                  color={COLORS.TEXT_ALTERNATIVE}
+                  boxProps={{ display: DISPLAY.INLINE_BLOCK }}
+                >
+                  {titleUnit}
+                </Typography>
+              ))}
+            {TooltipCustomComponent ||
+              (tooltipText && (
+                <InfoTooltip position="top" contentText={tooltipText} />
+              ))}
           </Box>
+          {titleDetail && (
+            <Box
+              className="form-field__heading-detail"
+              textAlign={TEXT_ALIGN.END}
+              marginBottom={3}
+              marginRight={2}
+              {...titleDetailWrapperProps}
+            >
+              {titleDetail}
+            </Box>
+          )}
+        </div>
+        {numeric ? (
+          <NumericInput
+            error={error}
+            onChange={onChange}
+            value={value}
+            detailText={detailText}
+            autoFocus={autoFocus}
+            allowDecimals={allowDecimals}
+            disabled={disabled}
+            dataTestId={dataTestId}
+            placeholder={placeholder}
+            id={id}
+          />
+        ) : (
+          <input
+            className={classNames('form-field__input', {
+              'form-field__input--error': error,
+              'form-field__input--warning': warning,
+            })}
+            onChange={(e) => onChange(e.target.value)}
+            value={value}
+            type={password ? 'password' : 'text'}
+            autoFocus={autoFocus}
+            disabled={disabled}
+            data-testid={dataTestId}
+            placeholder={placeholder}
+            id={id}
+            {...inputProps}
+          />
         )}
-      </div>
-      {numeric ? (
-        <NumericInput
-          error={error}
-          onChange={onChange}
-          value={value}
-          detailText={detailText}
-          autoFocus={autoFocus}
-          allowDecimals={allowDecimals}
-          disabled={disabled}
-          dataTestId={dataTestId}
-          placeholder={placeholder}
-        />
-      ) : (
-        <input
-          className={classNames('form-field__input', {
-            'form-field__input--error': error,
-            'form-field__input--warning': warning,
-          })}
-          onChange={(e) => onChange(e.target.value)}
-          value={value}
-          type={password ? 'password' : 'text'}
-          autoFocus={autoFocus}
-          disabled={disabled}
-          data-testid={dataTestId}
-          placeholder={placeholder}
-        />
-      )}
-      {error && (
-        <Typography
-          color={COLORS.ERROR_DEFAULT}
-          variant={TYPOGRAPHY.H7}
-          className="form-field__error"
-        >
-          {error}
-        </Typography>
-      )}
-      {warning && (
-        <Typography
-          color={COLORS.TEXT_ALTERNATIVE}
-          variant={TYPOGRAPHY.H7}
-          className="form-field__warning"
-        >
-          {warning}
-        </Typography>
-      )}
-      {passwordStrength && (
-        <Typography
-          color={COLORS.TEXT_DEFAULT}
-          variant={TYPOGRAPHY.H7}
-          className="form-field__password-strength"
-        >
-          {passwordStrength}
-        </Typography>
-      )}
-      {passwordStrengthText && (
-        <Typography
-          color={COLORS.TEXT_ALTERNATIVE}
-          variant={TYPOGRAPHY.H8}
-          className="form-field__password-strength-text"
-        >
-          {passwordStrengthText}
-        </Typography>
-      )}
+        {error && (
+          <Typography
+            color={COLORS.ERROR_DEFAULT}
+            variant={TYPOGRAPHY.H7}
+            className="form-field__error"
+          >
+            {error}
+          </Typography>
+        )}
+        {warning && (
+          <Typography
+            color={COLORS.TEXT_ALTERNATIVE}
+            variant={TYPOGRAPHY.H7}
+            className="form-field__warning"
+          >
+            {warning}
+          </Typography>
+        )}
+        {passwordStrength && (
+          <Typography
+            color={COLORS.TEXT_DEFAULT}
+            variant={TYPOGRAPHY.H7}
+            className="form-field__password-strength"
+          >
+            {passwordStrength}
+          </Typography>
+        )}
+        {passwordStrengthText && (
+          <Typography
+            color={COLORS.TEXT_ALTERNATIVE}
+            variant={TYPOGRAPHY.H8}
+            className="form-field__password-strength-text"
+          >
+            {passwordStrengthText}
+          </Typography>
+        )}
+      </Box>
     </div>
   );
 }
@@ -253,20 +263,18 @@ FormField.propTypes = {
    * Show password strength description
    */
   passwordStrengthText: PropTypes.string,
-};
-
-FormField.defaultProps = {
-  titleText: '',
-  titleUnit: '',
-  tooltipText: '',
-  titleDetail: '',
-  error: '',
-  onChange: undefined,
-  value: 0,
-  detailText: '',
-  autoFocus: false,
-  numeric: false,
-  password: false,
-  allowDecimals: true,
-  disabled: false,
+  /**
+   * The id of the input element. Should be used when the wrapping label is changed to a div to ensure accessibility.
+   */
+  id: PropTypes.string,
+  /**
+   * Any additional input attributes or overrides not provided by exposed props
+   */
+  inputProps: PropTypes.object,
+  /**
+   * The FormField is wrapped in a Box component that is rendered as a <label/> using the polymorphic "as" prop.
+   * This object allows you to override the rendering of the label by using the wrapperProps={{ as: 'div' }} prop.
+   * If used ensure the id prop is set on the input and a label element is present using htmlFor with the same id to ensure accessibility.
+   */
+  wrappingLabelProps: PropTypes.object,
 };

--- a/ui/components/ui/form-field/form-field.stories.js
+++ b/ui/components/ui/form-field/form-field.stories.js
@@ -1,6 +1,10 @@
 /* eslint-disable react/prop-types */
 
 import React, { useState } from 'react';
+import Typography from '../typography';
+import Tooltip from '../tooltip';
+import Box from '../box';
+
 import README from './README.mdx';
 import FormField from '.';
 
@@ -83,4 +87,31 @@ export const FormFieldWithError = (args) => {
 FormFieldWithError.args = {
   titleText: 'Title',
   error: 'Incorrect Format',
+};
+
+export const CustomComponents = (args) => {
+  return (
+    <div style={{ width: '600px' }}>
+      <FormField
+        {...args}
+        TitleTextCustomComponent={
+          <Typography>TitleTextCustomComponent</Typography>
+        }
+        TitleUnitCustomComponent={
+          <Typography marginLeft={2}>TitleUnitCustomComponent</Typography>
+        }
+        TooltipCustomComponent={
+          <Tooltip
+            interactive
+            position="top"
+            html={<Typography>Custom tooltip</Typography>}
+          >
+            <Box as="i" marginLeft={2} className="fa fa-question-circle" />
+          </Tooltip>
+        }
+        titleDetail={<Typography>TitleDetail</Typography>}
+        titleDetailWrapperProps={{ marginBottom: 0 }}
+      />
+    </div>
+  );
 };

--- a/ui/components/ui/numeric-input/numeric-input.component.js
+++ b/ui/components/ui/numeric-input/numeric-input.component.js
@@ -16,6 +16,8 @@ export default function NumericInput({
   disabled = false,
   dataTestId,
   placeholder,
+  id,
+  name,
 }) {
   return (
     <div
@@ -42,6 +44,8 @@ export default function NumericInput({
         disabled={disabled}
         data-testid={dataTestId}
         placeholder={placeholder}
+        id={id}
+        name={name}
       />
       {detailText && (
         <Typography
@@ -66,4 +70,12 @@ NumericInput.propTypes = {
   disabled: PropTypes.bool,
   dataTestId: PropTypes.string,
   placeholder: PropTypes.string,
+  /**
+   * The name of the input
+   */
+  name: PropTypes.string,
+  /**
+   * The id of the input element. Should be used with htmlFor with a label element.
+   */
+  id: PropTypes.string,
 };

--- a/ui/components/ui/typography/typography.js
+++ b/ui/components/ui/typography/typography.js
@@ -46,6 +46,7 @@ export const ValidTags = [
   'span',
   'strong',
   'ul',
+  'label',
 ];
 
 export default function Typography({

--- a/ui/components/ui/typography/typography.test.js
+++ b/ui/components/ui/typography/typography.test.js
@@ -24,6 +24,7 @@ describe('Typography', () => {
         <Typography as="div">div</Typography>
         <Typography as="dt">dt</Typography>
         <Typography as="dd">dd</Typography>
+        <Typography as="label">label</Typography>
       </>,
     );
     expect(container.querySelector('p')).toBeDefined();
@@ -54,5 +55,7 @@ describe('Typography', () => {
     expect(getByText('dt')).toBeDefined();
     expect(container.querySelector('dd')).toBeDefined();
     expect(getByText('dd')).toBeDefined();
+    expect(container.querySelector('label')).toBeDefined();
+    expect(getByText('label')).toBeDefined();
   });
 });


### PR DESCRIPTION
- [ ] Needs unit tests

## Explanation

Currently, the `FormField` component doesn't allow for any custom components.

This is a problem because if we want to extend the `FormField` components functionality by using a different type of label or unit or tooltip. It's not possible.

In order to solve this problem, this pull request adds custom component props to allow for the default components to be replaced.

## Screenshots/Screencaps
### After

<img width="1440" alt="Screen Shot 2022-08-23 at 9 29 47 AM" src="https://user-images.githubusercontent.com/8112138/186212158-1d84b73f-8e50-4a0a-9d10-2fcce8f6de30.png">


## Manual Testing Steps

- Go to the latest storybook build of this PR 
- Search `FormField`
- Look at the Custom Components story

## Pre-Merge Checklist

- [x] PR template is filled out
- ~[x] **IF** this PR fixes a bug, a test that _would have_ caught the bug has been added~ N/A
- ~[x] PR is linked to the appropriate GitHub issue~ N/A
- ~[x] PR has been added to the appropriate release Milestone~ N/A

### + If there are functional changes:

- [ ] Manual testing complete & passed
- ~[ ] "Extension QA Board" label has been applied~ N/A
