### PR TITLE
Replace `lavamoat-runtime.js` patch

### DIFF
--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -786,10 +786,7 @@ browser.runtime.onInstalled.addListener(({ reason }) => {
 });
 
 function setupSentryGetStateGlobal(store) {
-  if (!global.rootGlobals) {
-    global.rootGlobals = {};
-  }
-  global.rootGlobals.getSentryState = function () {
+  global.sentryHooks.getSentryState = function () {
     const fullState = store.getState();
     const debugState = maskObject({ metamask: fullState }, SENTRY_STATE);
     return {

--- a/app/scripts/sentry-install.js
+++ b/app/scripts/sentry-install.js
@@ -1,7 +1,10 @@
 import setupSentry from './lib/setupSentry';
 
+// The root compartment will populate this with hooks
+global.sentryHooks = {};
+
 // setup sentry error reporting
 global.sentry = setupSentry({
   release: process.env.METAMASK_VERSION,
-  getState: () => global.rootGlobals?.getSentryState?.() || {},
+  getState: () => global.sentryHooks?.getSentryState?.() || {},
 });

--- a/patches/@lavamoat+lavapack+3.1.0.patch
+++ b/patches/@lavamoat+lavapack+3.1.0.patch
@@ -13,19 +13,3 @@ index eb41a0a..3f891ea 100644
        // deps,
        // source: sourceMeta.code
      }
-diff --git a/node_modules/@lavamoat/lavapack/src/runtime.js b/node_modules/@lavamoat/lavapack/src/runtime.js
-index 58f76f3..53df0e7 100644
---- a/node_modules/@lavamoat/lavapack/src/runtime.js
-+++ b/node_modules/@lavamoat/lavapack/src/runtime.js
-@@ -11160,6 +11160,11 @@ function makePrepareRealmGlobalFromConfig ({ createFunctionWrapper }) {
-         rootPackageCompartment.globalThis[ref] = rootPackageCompartment.globalThis
-       }
- 
-+      // Allow root compartment to expose things to the initial execution environment of the realm.
-+      // This is intended to support passing data to shims run before lockdown.
-+      globalThis.rootGlobals = {}
-+      rootPackageCompartment.globalThis.rootGlobals = globalThis.rootGlobals
-+
-       // save the compartment for use by other modules in the package
-       packageCompartmentCache.set(rootPackageName, rootPackageCompartment)
- 

--- a/ui/index.js
+++ b/ui/index.js
@@ -191,10 +191,7 @@ function setupDebuggingHelpers(store) {
     });
     return state;
   };
-  if (!window.rootGlobals) {
-    window.rootGlobals = {};
-  }
-  window.rootGlobals.getSentryState = function () {
+  window.sentryHooks.getSentryState = function () {
     const fullState = store.getState();
     const debugState = maskObject(fullState, SENTRY_STATE);
     return {


### PR DESCRIPTION
A patch made in #15672 was found to be unnecessary. Instead of setting a `rootGlobals` object upon construction of the root compartment, we are now creating a `sentryHooks` object in the initial top-level compartment. I hadn't realized at the time that the root compartment would inherit all properties of the initial compartment `globalThis`.

This accomplishes the same goals as #15672 except without needing a patch.

## Manual Testing Steps


1. Setup errors for testing
  Before testing, ensure you know of a reliable way to trigger a Sentry error. If not, introduce an error somewhere in the codebase for testing purposes. We will want to test errors thrown in both the background and the UI, so we'll want a way to test both.
Typically my solution for the background error is to add `setImmediate(() => { throw new Error('test') })` in one of the setters in the preferences controller, as those are easy to trigger. The `setImmediate` ensures that the error stays in the background context, rather than being returned to the UI.
For the UI function, I throw an error in the `render` function for a page.
2. Set `SENTRY_DSN_DEV` environment variable or `.metamaskrc` entry to the Sentry DSN for either the test MetaMask account or your personal Sentry account. I've found personal accounts to be more reliable for testing, so that's what I'd recommend.
3. Comment out [this line](https://github.com/MetaMask/metamask-extension/blob/develop/app/scripts/lib/setupSentry.js#L74) if testing with a dev build
We will want to test both prod and dev builds. That line disables Sentry on dev builds.
4. Build and install MetaMask
5. Open the background dev console to the network tab
6. Trigger the background error, and ensure there is a corresponding Sentry network request containing the error report.
7. Open the fullscreen UI, and open the dev console for that page to the network tab.
8. Trigger the UI error, and ensure there is a corresponding Sentry network request containing the error report.
9. Check the Sentry dashboard corresponding to the `SENTRY_DSN_DEV` you set, and ensure both errors are shown.

## Pre-Merge Checklist

- [x] PR template is filled out
- [x] **IF** this PR fixes a bug, a test that _would have_ caught the bug has been added
- [x] PR is linked to the appropriate GitHub issue
- [x] PR has been added to the appropriate release Milestone

### + If there are functional changes:

- [ ] Manual testing complete & passed
- [ ] "Extension QA Board" label has been applied
