### PR TITLE
Replaced use of PubNub for uuid method in app/ directory

### DIFF
--- a/app/scripts/controllers/metametrics.js
+++ b/app/scripts/controllers/metametrics.js
@@ -10,7 +10,7 @@ import {
 } from 'lodash';
 import { ObservableStore } from '@metamask/obs-store';
 import { bufferToHex, keccak } from 'ethereumjs-util';
-import { generateUUID } from 'pubnub';
+import { v4 as uuidv4 } from 'uuid';
 import { ENVIRONMENT_TYPE_BACKGROUND } from '../../../shared/constants/app';
 import {
   METAMETRICS_ANONYMOUS_ID,
@@ -190,7 +190,7 @@ export default class MetaMetricsController {
     }
     const { fragments } = this.store.getState();
 
-    const id = options.uniqueIdentifier ?? generateUUID();
+    const id = options.uniqueIdentifier ?? uuidv4();
     const fragment = {
       id,
       ...options,


### PR DESCRIPTION
## Explanation

We currently are importing `generateUUID` from PubNub in `app/scripts/controllers/metametrics.js`.

PubNub is a dependency that we primarily use in the UI. It gets included in the background as well because of that single line where `generateUUID` is imported.

We don't have tree shaking support in our build system yet so that single import brings in the entire package, even if that single function implementation is quite small.

This brings in `170kb` into our build. Replacing this import from PubNub with `import { v4 as uuidv4 } from 'uuid';` as is done in the ui/ can will be much better for our build size and it would no longer be included in our background bundle, improving initialization time. A `UUID (version 4)` is a universally unique identifier that is generated using random numbers.

## More Information

This PR fix `background` bundle size to be lower than it was, `ui` bundle size remains the same as it was.

* Fixes #15524 

## Screenshots/Screencaps

### Before (bundle size on `develop`):

"background": {
    "name": "background",
    "size": 11511860,

"ui": {
    "name": "ui",
    "size": 14683455,

### After (bunde size on `replace-pubnub-uuid-method-in-app-directory`):

"background": {
    "name": "background",
    "size": 11330377,

"ui": {
    "name": "ui",
    "size": 14683455,


## Manual Testing Steps

Check bundle size on `develop` and on this branch (`replace-pubnub-uuid-method-in-app-directory`). Run `yarn build:test:mv3` and when build is finished run `yarn mv3:stats:chrome`. You can see then bundle size for `background` and `ui`. 
