### PR TITLE
Updated Avalanche RPC url endpoint

### DIFF
--- a/shared/constants/network.js
+++ b/shared/constants/network.js
@@ -356,7 +356,7 @@ export const FEATURED_RPCS = [
   {
     chainId: AVALANCHE_CHAIN_ID,
     nickname: AVALANCHE_DISPLAY_NAME,
-    rpcUrl: 'https://api.avax.network/ext/bc/C/rpc',
+    rpcUrl: `https://avalanche-mainnet.infura.io/v3/${infuraProjectId}`,
     ticker: AVALANCHE_SYMBOL,
     rpcPrefs: {
       blockExplorerUrl: 'https://snowtrace.io/',


### PR DESCRIPTION
## Explanation

Avalanche is now supported by `Infura` so we updated the Avalanche's RPC endpoint to use `Infura's` endpoint in the add popular networks feature as we always want to use RPC endpoints that we know comply to our privacy policy.

## More Information

**Note:** `Avalanche` is still in private beta state. You need to sign up to get an early access to `Avalanche` endpoint. To do so, you need to login to `Infura`, click on `Metamask` project, click on `Endpoints`, find `Avalanche C-Chain` network in list and click on `Sign up to get early access`. Then you need to fill the form and click `Submit`. You will get mail from `Team Infura` which is saying that `Avalanche C-Chain private beta endpoints are now live.`

* Fixes #15689 

## Screenshots/Screencaps

### Before

https://user-images.githubusercontent.com/92527393/186911217-2a2bb8d6-b53d-4809-b432-f377d5de4177.mov

### After

https://user-images.githubusercontent.com/92527393/186911355-d6f191f0-76f3-4a0b-96d9-c300fb326b45.mov

## Manual Testing Steps

1. Unlock MetaMask
2. Go to the `Settings`.
3. Click on the `Experimental`.
4. Enable the toggle switch `Show Custom Network List`.
5. From this step there are two ways to continue the flow:
        5.1. The first one is to click on the `Networks tab` within the `Settings` and then to click on the button `Add a network`.
        5.2. The second one is to open the network dropdown menu from the app header and then to click on the button `Add Network`.
6. See `Avalanche` network that has no tooltip warning
7. Click on `Add` button
8. See that `Network URL` has new endpoint `https://avalanche-mainnet.infura.io`
9. Click on `View all details`
10. See that `Network URL` has new endpoint `https://avalanche-mainnet.infura.io`
11. Click on `Approve` button is clicked, then the network will be added, the user will be taken to the `Home page` and the new popup will show up.
12. Click on `Switch to <network_name>`
