### PR TITLE
Updated the main copy on SetApprovalForAll confirmation screen

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -328,7 +328,7 @@
     "message": "Approve spend limit"
   },
   "approveAllTokensTitle": {
-    "message": "Give permission to access all of your $1?",
+    "message": "Allow access to and transfer of all your $1?",
     "description": "$1 is the symbol of the token for which the user is granting approval"
   },
   "approveAndInstall": {

--- a/test/e2e/tests/collectibles.spec.js
+++ b/test/e2e/tests/collectibles.spec.js
@@ -175,7 +175,7 @@ describe('Collectibles', function () {
         );
         assert.equal(
           await title.getText(),
-          'Give permission to access all of your TestDappCollectibles?',
+          'Allow access to and transfer of all your TestDappCollectibles?',
         );
         assert.equal(await data[0].getText(), 'Function: SetApprovalForAll');
         assert.equal(await data[1].getText(), 'Parameters: true');


### PR DESCRIPTION
## Explanation

The main copy is updated to `Allow access to and transfer of all your {NFTCollectionName}` (before this update was `Give permission to access all your {NFTCollectionName}`).

## More Information

* Fixes #15698 

## Screenshots/Screencaps

### Before

https://user-images.githubusercontent.com/92527393/187150225-89898eba-7b16-480a-8ff6-72b14c72761f.mov

### After

https://user-images.githubusercontent.com/92527393/187150593-fc54fc95-489d-450e-9441-a377f03e4b04.mov

## Manual Testing Steps

1. Unlock MetaMask
2. Open the `test dapp`: [https://metamask.github.io/test-dapp/](https://metamask.github.io/test-dapp/)
3. Under the collectibles section, click on `Deploy`
4. Wait for transaction to be confirmed and click on `Mint`
5. Wait for transaction to be confirmed and click on `Set Approval For All`