### PR TITLE
warning for deprecated Rinkeby, Ropsten and Kovan test networks

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -942,7 +942,7 @@
     "message": "Learn more"
   },
   "deprecatedTestNetworksMsg": {
-    "message": "Due to the protocol changes of Ethereum: Rinkeby, Ropsten, Kovan test networks may not work as reliably and will be deprecated soon."
+    "message": "Due to the protocol changes of Ethereum: Rinkeby, Ropsten and Kovan test networks may not work as reliably and will be deprecated soon."
   },
   "description": {
     "message": "Description"

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -938,6 +938,12 @@
     "message": "Deposit $1",
     "description": "$1 represents the crypto symbol to be purchased"
   },
+  "deprecatedTestNetworksLink": {
+    "message": "Learn more"
+  },
+  "deprecatedTestNetworksMsg": {
+    "message": "Due to the protocol changes of Ethereum: Rinkeby, Ropsten, Kovan test networks may not work as reliably and will be deprecated soon."
+  },
   "description": {
     "message": "Description"
   },

--- a/ui/components/ui/deprecated-test-networks/deprecated-test-networks.js
+++ b/ui/components/ui/deprecated-test-networks/deprecated-test-networks.js
@@ -1,4 +1,5 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
+import { useSelector } from 'react-redux';
 import Button from '../button';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import {
@@ -10,10 +11,24 @@ import {
 import Box from '../box/box';
 import Typography from '../typography/typography';
 import ActionableMessage from '../actionable-message/actionable-message';
+import { getCurrentChainId } from '../../../selectors';
 
 export default function DeprecatedTestNetworks() {
-  const [isShowingWarning, setIsShowingWarning] = useState(true);
+  const currentChainID = useSelector(getCurrentChainId);
+  const [isShowingWarning, setIsShowingWarning] = useState(false);
   const t = useI18nContext();
+
+  useEffect(() => {
+    if (
+      currentChainID === '0x3' ||
+      currentChainID === '0x2a' ||
+      currentChainID === '0x4'
+    ) {
+      setIsShowingWarning(true);
+    } else {
+      setIsShowingWarning(false);
+    }
+  }, [currentChainID]);
 
   return (
     isShowingWarning && (

--- a/ui/components/ui/deprecated-test-networks/deprecated-test-networks.js
+++ b/ui/components/ui/deprecated-test-networks/deprecated-test-networks.js
@@ -12,23 +12,26 @@ import Box from '../box/box';
 import Typography from '../typography/typography';
 import ActionableMessage from '../actionable-message/actionable-message';
 import { getCurrentChainId } from '../../../selectors';
+import { getCompletedOnboarding } from '../../../ducks/metamask/metamask';
 
 export default function DeprecatedTestNetworks() {
   const currentChainID = useSelector(getCurrentChainId);
   const [isShowingWarning, setIsShowingWarning] = useState(false);
+  const completedOnboarding = useSelector(getCompletedOnboarding);
   const t = useI18nContext();
 
   useEffect(() => {
     if (
-      currentChainID === '0x3' ||
-      currentChainID === '0x2a' ||
-      currentChainID === '0x4'
+      completedOnboarding &&
+      (currentChainID === '0x3' ||
+        currentChainID === '0x2a' ||
+        currentChainID === '0x4')
     ) {
       setIsShowingWarning(true);
     } else {
       setIsShowingWarning(false);
     }
-  }, [currentChainID]);
+  }, [currentChainID, completedOnboarding]);
 
   return (
     isShowingWarning && (

--- a/ui/components/ui/deprecated-test-networks/deprecated-test-networks.js
+++ b/ui/components/ui/deprecated-test-networks/deprecated-test-networks.js
@@ -1,0 +1,64 @@
+import React, { useState } from 'react';
+import Button from '../button';
+import { useI18nContext } from '../../../hooks/useI18nContext';
+import {
+  DISPLAY,
+  JUSTIFY_CONTENT,
+  TYPOGRAPHY,
+  COLORS,
+} from '../../../helpers/constants/design-system';
+import Box from '../box/box';
+import Typography from '../typography/typography';
+import ActionableMessage from '../actionable-message/actionable-message';
+
+export default function DeprecatedTestNetworks() {
+  const [isShowingWarning, setIsShowingWarning] = useState(true);
+  const t = useI18nContext();
+
+  return (
+    isShowingWarning && (
+      <ActionableMessage
+        type="warning"
+        className="deprecated-test-networks"
+        withRightButton
+        message={
+          <Box
+            display={DISPLAY.FLEX}
+            className="deprecated-test-networks__content"
+          >
+            <Box marginRight={2} color={COLORS.WARNING_DEFAULT}>
+              <i className="fa fa-info-circle deprecated-test-networks__content__icon" />
+            </Box>
+            <Box justifyContent={JUSTIFY_CONTENT.SPACE_BETWEEN}>
+              <Typography
+                variant={TYPOGRAPHY.H7}
+                marginTop={0}
+                marginBottom={0}
+              >
+                {t('deprecatedTestNetworksMsg')}
+
+                <Button
+                  className="deprecated-test-networks__content__inline-link"
+                  type="link"
+                  target="_blank"
+                  href="https://blog.ethereum.org/2022/06/21/testnet-deprecation/"
+                >
+                  {' '}
+                  {t('deprecatedTestNetworksLink')}
+                </Button>
+              </Typography>
+
+              <Box
+                className="deprecated-test-networks__content__close"
+                marginLeft={2}
+                marginTop={0}
+                color={COLORS.ICON_ALTERNATIVE}
+                onClick={() => setIsShowingWarning(false)}
+              />
+            </Box>
+          </Box>
+        }
+      />
+    )
+  );
+}

--- a/ui/components/ui/deprecated-test-networks/deprecated-test-networks.stories.js
+++ b/ui/components/ui/deprecated-test-networks/deprecated-test-networks.stories.js
@@ -1,0 +1,11 @@
+import React from 'react';
+import DeprecatedTestNetworks from './deprecated-test-networks';
+
+export default {
+  title: 'Components/UI/DeprecatedTestNetworks',
+  id: __filename,
+};
+
+export const DefaultStory = () => <DeprecatedTestNetworks />;
+
+DefaultStory.storyName = 'Default';

--- a/ui/components/ui/deprecated-test-networks/index.js
+++ b/ui/components/ui/deprecated-test-networks/index.js
@@ -1,0 +1,1 @@
+export { default } from './deprecated-test-networks';

--- a/ui/components/ui/deprecated-test-networks/index.scss
+++ b/ui/components/ui/deprecated-test-networks/index.scss
@@ -1,0 +1,25 @@
+.deprecated-test-networks {
+  position: fixed;
+  bottom: 0;
+  margin: 8px;
+  z-index: 1050;
+
+  &__content {
+    &__icon {
+      font-size: 16px;
+    }
+
+    &__inline-link {
+      @include H7;
+
+      display: initial;
+      padding: 0;
+    }
+
+    &__close::after {
+      content: '\00D7';
+      font-size: 24px;
+      cursor: pointer;
+    }
+  }
+}

--- a/ui/components/ui/ui-components.scss
+++ b/ui/components/ui/ui-components.scss
@@ -60,4 +60,5 @@
 @import 'url-icon/index';
 @import 'update-nickname-popover/index';
 @import 'disclosure/disclosure';
+@import 'deprecated-test-networks/index.scss';
 @import 'contract-token-values/index.scss';

--- a/ui/pages/routes/routes.component.js
+++ b/ui/pages/routes/routes.component.js
@@ -373,6 +373,8 @@ export default class Routes extends Component {
     const shouldShowNetworkInfo =
       isUnlocked && !isNetworkUsed && hasAnAccountWithNoFundsOnNetwork;
 
+    const windowType = getEnvironmentType();
+
     return (
       <div
         className={classnames('app', {
@@ -388,7 +390,9 @@ export default class Routes extends Component {
           }
         }}
       >
-        {isUnlocked && <DeprecatedTestNetworks />}
+        {windowType !== ENVIRONMENT_TYPE_NOTIFICATION && isUnlocked && (
+          <DeprecatedTestNetworks />
+        )}
         {shouldShowNetworkInfo && <NewNetworkInfo />}
         <QRHardwarePopover />
         <Modal />

--- a/ui/pages/routes/routes.component.js
+++ b/ui/pages/routes/routes.component.js
@@ -77,6 +77,7 @@ import OnboardingFlow from '../onboarding-flow/onboarding-flow';
 import QRHardwarePopover from '../../components/app/qr-hardware-popover';
 import { SEND_STAGES } from '../../ducks/send';
 import { THEME_TYPE } from '../settings/experimental-tab/experimental-tab.constant';
+import DeprecatedTestNetworks from '../../components/ui/deprecated-test-networks/deprecated-test-networks';
 import NewNetworkInfo from '../../components/ui/new-network-info/new-network-info';
 
 export default class Routes extends Component {
@@ -363,11 +364,18 @@ export default class Routes extends Component {
       browserEnvironmentBrowser: browser,
       isNetworkUsed,
       hasAnAccountWithNoFundsOnNetwork,
+      providerType,
     } = this.props;
     const loadMessage =
       loadingMessage || isNetworkLoading
         ? this.getConnectingLabel(loadingMessage)
         : null;
+
+    const showWarning =
+      isUnlocked &&
+      (providerType === 'ropsten' ||
+        providerType === 'kovan' ||
+        providerType === 'rinkeby');
 
     const shouldShowNetworkInfo =
       isUnlocked && !isNetworkUsed && hasAnAccountWithNoFundsOnNetwork;
@@ -387,6 +395,7 @@ export default class Routes extends Component {
           }
         }}
       >
+        {showWarning && <DeprecatedTestNetworks />}
         {shouldShowNetworkInfo && <NewNetworkInfo />}
         <QRHardwarePopover />
         <Modal />

--- a/ui/pages/routes/routes.component.js
+++ b/ui/pages/routes/routes.component.js
@@ -364,18 +364,11 @@ export default class Routes extends Component {
       browserEnvironmentBrowser: browser,
       isNetworkUsed,
       hasAnAccountWithNoFundsOnNetwork,
-      providerType,
     } = this.props;
     const loadMessage =
       loadingMessage || isNetworkLoading
         ? this.getConnectingLabel(loadingMessage)
         : null;
-
-    const showWarning =
-      isUnlocked &&
-      (providerType === 'ropsten' ||
-        providerType === 'kovan' ||
-        providerType === 'rinkeby');
 
     const shouldShowNetworkInfo =
       isUnlocked && !isNetworkUsed && hasAnAccountWithNoFundsOnNetwork;
@@ -395,7 +388,7 @@ export default class Routes extends Component {
           }
         }}
       >
-        {showWarning && <DeprecatedTestNetworks />}
+        {isUnlocked && <DeprecatedTestNetworks />}
         {shouldShowNetworkInfo && <NewNetworkInfo />}
         <QRHardwarePopover />
         <Modal />


### PR DESCRIPTION
## Explanation
Infura is currently planning on deprecating their Rinkeby, Ropsten and Kovan RPC endpoints almost immediately after the Merge. Once that happens, users won't be able to use these default networks as is in MM. Rinkeby won't be formally demised until Q2/Q3 2023 so users might still want to use those in the meantime. Proposed solution: Created a warning with the information when the user change for one of these three networks.

## More Information

* Fixes #15295


## Screenshots/Screencaps

https://user-images.githubusercontent.com/63151811/187148515-9baae9f6-780e-4e8e-878e-0fa9f1abcffb.mov


https://user-images.githubusercontent.com/63151811/188476694-a9cd0ada-6bd9-49f8-b0d5-707d7624717f.mov



## Manual Testing Steps
Show the message every time a user switches to one of the three test networks (Rinkeby, Ropsten and Kovan). If the user closes the message, we won't show it again until the user switches back to one of the three test networks again. If the user switches back to one of three test networks, we'll show them the message again even thought they might have closed it previously. If the user switches to a different network (that's not one of these three test networks), the warning should not be shown anymore too.
