### PR TITLE
Only render tooltip component if swap network is disabled

### DIFF
--- a/ui/components/app/wallet-overview/eth-overview.js
+++ b/ui/components/app/wallet-overview/eth-overview.js
@@ -165,15 +165,18 @@ const EthOverview = ({ className }) => {
               }
             }}
             label={t('swap')}
-            tooltipRender={(contents) => (
-              <Tooltip
-                title={t('currentlyUnavailable')}
-                position="bottom"
-                disabled={isSwapsChain}
-              >
-                {contents}
-              </Tooltip>
-            )}
+            tooltipRender={
+              isSwapsChain
+                ? null
+                : (contents) => (
+                    <Tooltip
+                      title={t('currentlyUnavailable')}
+                      position="bottom"
+                    >
+                      {contents}
+                    </Tooltip>
+                  )
+            }
           />
         </>
       }

--- a/ui/components/app/wallet-overview/token-overview.js
+++ b/ui/components/app/wallet-overview/token-overview.js
@@ -143,15 +143,19 @@ const TokenOverview = ({ className, token }) => {
               }
             }}
             label={t('swap')}
-            tooltipRender={(contents) => (
-              <Tooltip
-                title={t('currentlyUnavailable')}
-                position="bottom"
-                disabled={isSwapsChain}
-              >
-                {contents}
-              </Tooltip>
-            )}
+            tooltipRender={
+              isSwapsChain
+                ? null
+                : (contents) => (
+                    <Tooltip
+                      title={t('currentlyUnavailable')}
+                      position="bottom"
+                      disabled={isSwapsChain}
+                    >
+                      {contents}
+                    </Tooltip>
+                  )
+            }
           />
         </>
       }


### PR DESCRIPTION
The "swaps" button on the home and token overview screens focus twice on Swap, which is sort of annoying.  This PR fixes the issue

## Screenshots/Screencaps

![tabindex](https://user-images.githubusercontent.com/46655/187958996-fc7e99be-80af-42b2-9da4-55c5c986e391.gif)

## Manual Testing Steps

Tab through the home screen, ensure Swaps is only focused once.

## Pre-Merge Checklist

- [x] PR template is filled out
- [ ] **IF** this PR fixes a bug, a test that _would have_ caught the bug has been added
- [ ] PR is linked to the appropriate GitHub issue
- [ ] PR has been added to the appropriate release Milestone

### + If there are functional changes:

- [x] Manual testing complete & passed
- [ ] "Extension QA Board" label has been applied
