### PR TITLE
ConfirmPage: update setApprovalForAll dialog copy

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -606,7 +606,14 @@
     "message": "Confirm"
   },
   "confirmPageDialogSetApprovalForAll": {
-    "message": "By clicking approve, you are granting access to all of the NFTs you currently own on this contract and any NFTs on this contract you may acquire in the future until you revoke this approval. The party to whom you're granting approval will be able to transfer your NFTs from your wallet without further notice. Proceed with caution."
+    "message": "You're granting access to $1, including any you might own in the future. The party on the other end can transfer NFTs from your wallet at any time without asking you until you revoke this approval. $2",
+    "description": "$1 and $2 are bolded translations 'confirmPageDialogSetApprovalForAllPlaceholder1' and 'confirmPageDialogSetApprovalForAllPlaceholder2'"
+  },
+  "confirmPageDialogSetApprovalForAllPlaceholder1": {
+    "message": "all the NFTs on this contract"
+  },
+  "confirmPageDialogSetApprovalForAllPlaceholder2": {
+    "message": "Proceed with caution."
   },
   "confirmPassword": {
     "message": "Confirm password"

--- a/ui/components/app/confirm-page-container/confirm-page-container.component.js
+++ b/ui/components/app/confirm-page-container/confirm-page-container.component.js
@@ -308,7 +308,21 @@ export default class ConfirmPageContainer extends Component {
           )}
           {isSetApproveForAll && (
             <Dialog type="error" className="confirm-page-container__dialog">
-              {t('confirmPageDialogSetApprovalForAll')}
+              {/* style={{ fontWeight: 'bold' }} because reset.scss removes font-weight from b. We should fix this. */}
+              {t('confirmPageDialogSetApprovalForAll', [
+                <b
+                  key="confirm-page-container__dialog-placeholder-1"
+                  style={{ fontWeight: 'bold' }}
+                >
+                  {t('confirmPageDialogSetApprovalForAllPlaceholder1')}
+                </b>,
+                <b
+                  key="confirm-page-container__dialog-placeholder-2"
+                  style={{ fontWeight: 'bold' }}
+                >
+                  {t('confirmPageDialogSetApprovalForAllPlaceholder2')}
+                </b>,
+              ])}
             </Dialog>
           )}
           {contentComponent && (

--- a/ui/components/app/confirm-page-container/confirm-page-container.component.js
+++ b/ui/components/app/confirm-page-container/confirm-page-container.component.js
@@ -308,7 +308,10 @@ export default class ConfirmPageContainer extends Component {
           )}
           {isSetApproveForAll && (
             <Dialog type="error" className="confirm-page-container__dialog">
-              {/* style={{ fontWeight: 'bold' }} because reset.scss removes font-weight from b. We should fix this. */}
+              {/*
+                TODO: https://github.com/MetaMask/metamask-extension/issues/15745
+                style={{ fontWeight: 'bold' }} because reset.scss removes font-weight from b. We should fix this.
+              */}
               {t('confirmPageDialogSetApprovalForAll', [
                 <b
                   key="confirm-page-container__dialog-placeholder-1"


### PR DESCRIPTION
## Explanation

Updates ConfirmPage setApprovalForAll warning dialog copy. See https://github.com/MetaMask/metamask-extension/pull/15512#issuecomment-1237445315 for details

## More Information

Follow-up: https://github.com/MetaMask/metamask-extension/pull/15512

## Screenshots/Screencaps

### Before
<img width="467" alt="183882919-ca3f15b4-dd5e-4751-a9bb-07d91567fa30" src="https://user-images.githubusercontent.com/20778143/188616592-ce8963a4-7681-4d1a-8b16-fc86ca2a2a02.png">

### After

<img width="467" alt="Screenshot 2022-09-06 at 6 44 02 PM" src="https://user-images.githubusercontent.com/20778143/188616574-906fa62a-ffc1-4679-817a-0fe1ff4206c8.png">

## Manual Testing Steps

- send a setApprovalForAll transaction and observe warning dialog copy
