### PR TITLE
Update Arbitrum symbol

### DIFF
--- a/shared/constants/network.js
+++ b/shared/constants/network.js
@@ -75,7 +75,7 @@ export const MATIC_SYMBOL = 'MATIC';
 export const AVALANCHE_SYMBOL = 'AVAX';
 export const FANTOM_SYMBOL = 'FTM';
 export const CELO_SYMBOL = 'CELO';
-export const ARBITRUM_SYMBOL = 'AETH';
+export const ARBITRUM_SYMBOL = 'ETH';
 export const HARMONY_SYMBOL = 'ONE';
 export const PALM_SYMBOL = 'PALM';
 


### PR DESCRIPTION
## Explanation

The base currency symbol used in Arbitrum is ETH

## More Information

https://github.com/ethereum-lists/chains/pull/843
https://github.com/ethereum-lists/chains/pull/938

## Pre-Merge Checklist

- [x] PR template is filled out
- [ ] **IF** this PR fixes a bug, a test that _would have_ caught the bug has been added
- [ ] PR is linked to the appropriate GitHub issue
- [ ] PR has been added to the appropriate release Milestone

