### PR TITLE
Added a 'Verify contract details' link to SetApprovalForAll confirmation screens

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -758,6 +758,12 @@
   "contractInteraction": {
     "message": "Contract interaction"
   },
+  "contractNFT": {
+    "message": "NFT contract"
+  },
+  "contractRequestingAccess": {
+    "message": "Contract requesting access"
+  },
   "contractRequestingSpendingCap": {
     "message": "Contract requesting spending cap"
   },

--- a/ui/components/app/modals/contract-details-modal/contract-details-modal.js
+++ b/ui/components/app/modals/contract-details-modal/contract-details-modal.js
@@ -56,16 +56,6 @@ export default function ContractDetailsModal({
     (assetName && tokenId) ||
     (tokenName && tokenId);
 
-  let contractTitle;
-  let contractRequesting;
-  if (nft) {
-    contractTitle = t('contractNFT');
-    contractRequesting = t('contractRequestingAccess');
-  } else {
-    contractTitle = t('contractToken');
-    contractRequesting = t('contractRequestingSpendingCap');
-  }
-
   const tokenList = useSelector(getTokenList);
 
   const nftTokenListImage = tokenList[tokenAddress.toLowerCase()]?.iconUrl;
@@ -133,7 +123,7 @@ export default function ContractDetailsModal({
           marginTop={4}
           marginBottom={2}
         >
-          {contractTitle}
+          {nft ? t('contractNFT') : t('contractToken')}
         </Typography>
         <Box
           display={DISPLAY.FLEX}
@@ -237,7 +227,9 @@ export default function ContractDetailsModal({
           marginTop={4}
           marginBottom={2}
         >
-          {contractRequesting}
+          {nft
+            ? t('contractRequestingAccess')
+            : t('contractRequestingSpendingCap')}
         </Typography>
         <Box
           display={DISPLAY.FLEX}

--- a/ui/components/app/modals/contract-details-modal/contract-details-modal.js
+++ b/ui/components/app/modals/contract-details-modal/contract-details-modal.js
@@ -21,12 +21,12 @@ import {
   JUSTIFY_CONTENT,
   SIZES,
   BORDER_STYLE,
-  TEXT_ALIGN,
 } from '../../../../helpers/constants/design-system';
 import { useCopyToClipboard } from '../../../../hooks/useCopyToClipboard';
 import UrlIcon from '../../../ui/url-icon/url-icon';
-import { getAddressBookEntry, getTokenList } from '../../../../selectors';
+import { getAddressBookEntry } from '../../../../selectors';
 import { ERC1155, ERC721 } from '../../../../../shared/constants/transaction';
+import NftCollectionImage from '../../../ui/nft-collection-image/nft-collection-image';
 
 export default function ContractDetailsModal({
   onClose,
@@ -40,7 +40,6 @@ export default function ContractDetailsModal({
   tokenId,
   assetName,
   assetStandard,
-  collections = {},
 }) {
   const t = useI18nContext();
   const [copiedTokenAddress, handleCopyTokenAddress] = useCopyToClipboard();
@@ -55,42 +54,6 @@ export default function ContractDetailsModal({
     // if we don't have an asset standard but we do have either both an assetname and a tokenID or both a tokenName and tokenId we assume its an NFT
     (assetName && tokenId) ||
     (tokenName && tokenId);
-
-  const tokenList = useSelector(getTokenList);
-
-  const nftTokenListImage = tokenList[tokenAddress.toLowerCase()]?.iconUrl;
-
-  let nftCollectionNameExist;
-  let nftCollectionImageExist;
-
-  Object.values(collections).forEach((nftCollections) => {
-    if (nftCollections.collectionName === assetName) {
-      nftCollectionNameExist = nftCollections.collectionName;
-      nftCollectionImageExist = nftCollections.collectionImage;
-    }
-  });
-
-  const renderCollectionImage = (collectionImage, collectionName, key) => {
-    if (collectionImage) {
-      return (
-        <Identicon
-          className="contract-details-modal__content__contract__identicon"
-          diameter={24}
-          image={collectionImage}
-        />
-      );
-    }
-    return (
-      <Box
-        key={key}
-        color={COLORS.OVERLAY_INVERSE}
-        textAlign={TEXT_ALIGN.CENTER}
-        className="contract-details-modal__content__contract__collection"
-      >
-        {collectionName?.[0]?.toUpperCase() ?? null}
-      </Box>
-    );
-  };
 
   return (
     <Popover className="contract-details-modal">
@@ -133,14 +96,12 @@ export default function ContractDetailsModal({
           className="contract-details-modal__content__contract"
         >
           {nft ? (
-            <>
-              {Object.keys(collections).length > 0 && nftCollectionNameExist
-                ? renderCollectionImage(
-                    nftCollectionImageExist,
-                    nftCollectionNameExist,
-                  )
-                : renderCollectionImage(nftTokenListImage, assetName)}
-            </>
+            <Box margin={4}>
+              <NftCollectionImage
+                assetName={assetName}
+                tokenAddress={tokenAddress}
+              />
+            </Box>
           ) : (
             <Identicon
               className="contract-details-modal__content__contract__identicon"
@@ -395,28 +356,4 @@ ContractDetailsModal.propTypes = {
    * The name of the collection
    */
   assetName: PropTypes.string,
-  /**
-   * NFTs Collection
-   */
-  collections: PropTypes.shape({
-    collectibles: PropTypes.arrayOf(
-      PropTypes.shape({
-        address: PropTypes.string.isRequired,
-        tokenId: PropTypes.string.isRequired,
-        name: PropTypes.string,
-        description: PropTypes.string,
-        image: PropTypes.string,
-        standard: PropTypes.string,
-        imageThumbnail: PropTypes.string,
-        imagePreview: PropTypes.string,
-        creator: PropTypes.shape({
-          address: PropTypes.string,
-          config: PropTypes.string,
-          profile_img_url: PropTypes.string,
-        }),
-      }),
-    ),
-    collectionImage: PropTypes.string,
-    collectionName: PropTypes.string,
-  }),
 };

--- a/ui/components/app/modals/contract-details-modal/index.scss
+++ b/ui/components/app/modals/contract-details-modal/index.scss
@@ -1,12 +1,24 @@
 .contract-details-modal {
-  width: 360px !important;
+  width: 100% !important;
+  max-width: 408px;
 
   &__content {
     border-bottom: 1px solid var(--color-border-muted);
 
     &__contract {
       &__identicon {
-        margin: 16px 16px 38px 16px;
+        margin: 16px;
+        box-shadow: none;
+        background: none;
+      }
+
+      &__collection {
+        border-radius: 50%;
+        width: 24px;
+        height: 24px;
+        padding: 2px;
+        margin: 16px;
+        background: var(--color-overlay-alternative);
       }
 
       &__identicon-for-unknown-contact {

--- a/ui/components/app/modals/contract-details-modal/index.scss
+++ b/ui/components/app/modals/contract-details-modal/index.scss
@@ -12,15 +12,6 @@
         background: none;
       }
 
-      &__collection {
-        border-radius: 50%;
-        width: 24px;
-        height: 24px;
-        padding: 2px;
-        margin: 16px;
-        background: var(--color-overlay-alternative);
-      }
-
       &__identicon-for-unknown-contact {
         margin: 16px;
       }

--- a/ui/components/ui/nft-collection-image/index.js
+++ b/ui/components/ui/nft-collection-image/index.js
@@ -1,0 +1,1 @@
+export { default } from './nft-collection-image';

--- a/ui/components/ui/nft-collection-image/index.scss
+++ b/ui/components/ui/nft-collection-image/index.scss
@@ -1,0 +1,7 @@
+.collection-image-alt {
+  border-radius: 50%;
+  width: 24px;
+  height: 24px;
+  padding: 2px;
+  background: var(--color-overlay-alternative);
+}

--- a/ui/components/ui/nft-collection-image/nft-collection-image.js
+++ b/ui/components/ui/nft-collection-image/nft-collection-image.js
@@ -1,0 +1,45 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { useSelector } from 'react-redux';
+import Box from '../box';
+import { COLORS, TEXT_ALIGN } from '../../../helpers/constants/design-system';
+import Identicon from '../identicon';
+import { getTokenList } from '../../../selectors';
+import { useCollectiblesCollections } from '../../../hooks/useCollectiblesCollections';
+
+export default function NftCollectionImage({ assetName, tokenAddress }) {
+  const { collections } = useCollectiblesCollections();
+  const tokenList = useSelector(getTokenList);
+  const nftTokenListImage = tokenList[tokenAddress.toLowerCase()]?.iconUrl;
+
+  const renderCollectionImageOrName = () => {
+    const collection = Object.values(collections).find(
+      ({ collectionName }) => collectionName === assetName,
+    );
+
+    if (collection?.collectionImage || nftTokenListImage) {
+      return (
+        <Identicon
+          diameter={24}
+          image={collection?.collectionImage || nftTokenListImage}
+        />
+      );
+    }
+    return (
+      <Box
+        color={COLORS.OVERLAY_INVERSE}
+        textAlign={TEXT_ALIGN.CENTER}
+        className="collection-image-alt"
+      >
+        {assetName?.[0]?.toUpperCase() ?? null}
+      </Box>
+    );
+  };
+
+  return <Box>{renderCollectionImageOrName()}</Box>;
+}
+
+NftCollectionImage.propTypes = {
+  assetName: PropTypes.string,
+  tokenAddress: PropTypes.string,
+};

--- a/ui/components/ui/ui-components.scss
+++ b/ui/components/ui/ui-components.scss
@@ -63,3 +63,5 @@
 @import 'deprecated-test-networks/index.scss';
 @import 'contract-token-values/index.scss';
 @import 'nft-info/index.scss';
+@import 'nft-collection-image/index';
+

--- a/ui/pages/confirm-approve/confirm-approve-content/confirm-approve-content.component.js
+++ b/ui/pages/confirm-approve/confirm-approve-content/confirm-approve-content.component.js
@@ -32,6 +32,7 @@ import {
   ERC721,
 } from '../../../../shared/constants/transaction';
 import { CHAIN_IDS, TEST_CHAINS } from '../../../../shared/constants/network';
+import ContractDetailsModal from '../../../components/app/modals/contract-details-modal/contract-details-modal';
 
 export default class ConfirmApproveContent extends Component {
   static contextTypes = {
@@ -77,11 +78,33 @@ export default class ConfirmApproveContent extends Component {
     isSetApproveForAll: PropTypes.bool,
     isApprovalOrRejection: PropTypes.bool,
     userAddress: PropTypes.string,
+    collections: PropTypes.shape({
+      collectibles: PropTypes.arrayOf(
+        PropTypes.shape({
+          address: PropTypes.string.isRequired,
+          tokenId: PropTypes.string.isRequired,
+          name: PropTypes.string,
+          description: PropTypes.string,
+          image: PropTypes.string,
+          standard: PropTypes.string,
+          imageThumbnail: PropTypes.string,
+          imagePreview: PropTypes.string,
+          creator: PropTypes.shape({
+            address: PropTypes.string,
+            config: PropTypes.string,
+            profile_img_url: PropTypes.string,
+          }),
+        }),
+      ),
+      collectionImage: PropTypes.string,
+      collectionName: PropTypes.string,
+    }),
   };
 
   state = {
     showFullTxDetails: false,
     copied: false,
+    setshowContractDetails: false,
   };
 
   renderApproveContentCard({
@@ -588,8 +611,12 @@ export default class ConfirmApproveContent extends Component {
       isContract,
       assetStandard,
       userAddress,
+      tokenId,
+      tokenAddress,
+      assetName,
+      collections,
     } = this.props;
-    const { showFullTxDetails } = this.state;
+    const { showFullTxDetails, setshowContractDetails } = this.state;
 
     return (
       <div
@@ -632,6 +659,34 @@ export default class ConfirmApproveContent extends Component {
         <div className="confirm-approve-content__description">
           {this.renderDescription()}
         </div>
+        {(assetStandard === ERC721 ||
+          assetStandard === ERC1155 ||
+          (assetName && tokenId) ||
+          (tokenSymbol && tokenId)) && (
+          <Box marginBottom={4} marginTop={2}>
+            <Button
+              type="link"
+              className="confirm-approve-content__verify-contract-details"
+              onClick={() => this.setState({ setshowContractDetails: true })}
+            >
+              {t('verifyContractDetails')}
+            </Button>
+            {setshowContractDetails && (
+              <ContractDetailsModal
+                onClose={() => this.setState({ setshowContractDetails: false })}
+                tokenName={tokenSymbol}
+                tokenAddress={tokenAddress}
+                toAddress={toAddress}
+                chainId={chainId}
+                rpcPrefs={rpcPrefs}
+                tokenId={tokenId}
+                assetName={assetName}
+                assetStandard={assetStandard}
+                collections={collections}
+              />
+            )}
+          </Box>
+        )}
         <Box className="confirm-approve-content__address-display-content">
           <Box display={DISPLAY.FLEX}>
             <Identicon

--- a/ui/pages/confirm-approve/confirm-approve-content/confirm-approve-content.component.js
+++ b/ui/pages/confirm-approve/confirm-approve-content/confirm-approve-content.component.js
@@ -78,27 +78,6 @@ export default class ConfirmApproveContent extends Component {
     isSetApproveForAll: PropTypes.bool,
     isApprovalOrRejection: PropTypes.bool,
     userAddress: PropTypes.string,
-    collections: PropTypes.shape({
-      collectibles: PropTypes.arrayOf(
-        PropTypes.shape({
-          address: PropTypes.string.isRequired,
-          tokenId: PropTypes.string.isRequired,
-          name: PropTypes.string,
-          description: PropTypes.string,
-          image: PropTypes.string,
-          standard: PropTypes.string,
-          imageThumbnail: PropTypes.string,
-          imagePreview: PropTypes.string,
-          creator: PropTypes.shape({
-            address: PropTypes.string,
-            config: PropTypes.string,
-            profile_img_url: PropTypes.string,
-          }),
-        }),
-      ),
-      collectionImage: PropTypes.string,
-      collectionName: PropTypes.string,
-    }),
   };
 
   state = {
@@ -614,7 +593,6 @@ export default class ConfirmApproveContent extends Component {
       tokenId,
       tokenAddress,
       assetName,
-      collections,
     } = this.props;
     const { showFullTxDetails, setshowContractDetails } = this.state;
 
@@ -682,7 +660,6 @@ export default class ConfirmApproveContent extends Component {
                 tokenId={tokenId}
                 assetName={assetName}
                 assetStandard={assetStandard}
-                collections={collections}
               />
             )}
           </Box>

--- a/ui/pages/confirm-approve/confirm-approve-content/index.scss
+++ b/ui/pages/confirm-approve/confirm-approve-content/index.scss
@@ -102,7 +102,6 @@
     @include H6;
 
     margin-top: 16px;
-    margin-bottom: 16px;
     color: var(--color-text-alternative);
     text-align: center;
     padding-left: 24px;
@@ -335,6 +334,13 @@
 
   &__small-blue-text {
     color: var(--color-primary-default);
+  }
+
+  &__verify-contract-details {
+    @include H6;
+
+    color: var(--color-primary-default);
+    padding: 0;
   }
 
   &__info-row {

--- a/ui/pages/confirm-approve/confirm-approve.js
+++ b/ui/pages/confirm-approve/confirm-approve.js
@@ -37,6 +37,7 @@ import { parseStandardTokenTransactionData } from '../../../shared/modules/trans
 import { ERC1155, ERC20, ERC721 } from '../../../shared/constants/transaction';
 import { calcTokenAmount } from '../../../shared/lib/transactions-controller-utils';
 import TokenAllowance from '../token-allowance/token-allowance';
+import { useCollectiblesCollections } from '../../hooks/useCollectiblesCollections';
 import { getCustomTxParamsData } from './confirm-approve.util';
 import ConfirmApproveContent from './confirm-approve-content';
 
@@ -93,6 +94,8 @@ export default function ConfirmApprove({
     showCustomizeGasPopover,
     closeCustomizeGasPopover,
   } = useApproveTransaction();
+
+  const { collections } = useCollectiblesCollections();
 
   useEffect(() => {
     if (customPermissionAmount && previousTokenAmount.current !== tokenAmount) {
@@ -220,6 +223,7 @@ export default function ConfirmApprove({
         contentComponent={
           <TransactionModalContextProvider>
             <ConfirmApproveContent
+              collections={collections}
               userAddress={userAddress}
               isSetApproveForAll={isSetApproveForAll}
               isApprovalOrRejection={isApprovalOrRejection}

--- a/ui/pages/confirm-approve/confirm-approve.js
+++ b/ui/pages/confirm-approve/confirm-approve.js
@@ -37,7 +37,6 @@ import { parseStandardTokenTransactionData } from '../../../shared/modules/trans
 import { ERC1155, ERC20, ERC721 } from '../../../shared/constants/transaction';
 import { calcTokenAmount } from '../../../shared/lib/transactions-controller-utils';
 import TokenAllowance from '../token-allowance/token-allowance';
-import { useCollectiblesCollections } from '../../hooks/useCollectiblesCollections';
 import { getCustomTxParamsData } from './confirm-approve.util';
 import ConfirmApproveContent from './confirm-approve-content';
 
@@ -94,8 +93,6 @@ export default function ConfirmApprove({
     showCustomizeGasPopover,
     closeCustomizeGasPopover,
   } = useApproveTransaction();
-
-  const { collections } = useCollectiblesCollections();
 
   useEffect(() => {
     if (customPermissionAmount && previousTokenAmount.current !== tokenAmount) {
@@ -223,7 +220,6 @@ export default function ConfirmApprove({
         contentComponent={
           <TransactionModalContextProvider>
             <ConfirmApproveContent
-              collections={collections}
               userAddress={userAddress}
               isSetApproveForAll={isSetApproveForAll}
               isApprovalOrRejection={isApprovalOrRejection}


### PR DESCRIPTION
## Explanation

Added a 'Verify contract details' link to SetApprovalForAll and NFT Allowance confirmation screens. Clicking on this link will take you to new contract detail modal. On the contract detail modal the `NFT contract` is the NFT contract that the user is granting allowance for, and the `Contract requesting access` is the address that being granted access to the NFTs (we currently show it as "Granted to" under permission request).

## More Information

* Fixes #15697


## Screenshots/Screencaps


<img width="352" alt="Screenshot 2022-10-14 at 01 32 26" src="https://user-images.githubusercontent.com/63151811/195729602-c8ed537b-449d-42f8-81a1-d4bb24b469a0.png">




https://user-images.githubusercontent.com/63151811/195730243-b3d2257b-4e5b-498f-bd4e-a0e81ad027c9.mov







## Manual Testing Steps

- Open the test dapp https://metamask.github.io/test-dapp/
- Under the collectibles section, click on "Deploy"
- Wait for transaction to be confirmed and click on "Mint"
- Wait for transaction to be confirmed and click on "Set Approval For All" or "Approve"

