### PR TITLE
Show 3box deprecation message in whats new

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -2348,7 +2348,7 @@
     "message": "Show backup settings"
   },
   "notifications14Description": {
-    "message": "We're deprecating our 3Box data feature soon. To backup and restore your wallet manually, use the \"Backup now\" button in Advanced Settings.",
+    "message": "We're deprecating our 3Box data feature in early October. To backup and restore your wallet manually, use the \"Backup now\" button in Advanced Settings.",
     "description": "Description of a notification in the 'See What's New' popup. Describes 3box deprecation."
   },
   "notifications14Title": {

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -2344,6 +2344,16 @@
   "notifications13Title": {
     "message": "Add Popular Networks"
   },
+  "notifications14ActionText": {
+    "message": "Show backup settings"
+  },
+  "notifications14Description": {
+    "message": "We're deprecating our 3Box data feature soon. To backup and restore your wallet manually, use the \"Backup now\" button in Advanced Settings",
+    "description": "Description of a notification in the 'See What's New' popup. Describes 3box deprecation."
+  },
+  "notifications14Title": {
+    "message": "3Box Deprecation"
+  },
   "notifications1Description": {
     "message": "MetaMask Mobile users can now swap tokens inside their mobile wallet. Scan the QR code to get the mobile app and start swapping.",
     "description": "Description of a notification in the 'See What's New' popup. Describes the swapping on mobile feature."

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -2348,7 +2348,7 @@
     "message": "Show backup settings"
   },
   "notifications14Description": {
-    "message": "We're deprecating our 3Box data feature soon. To backup and restore your wallet manually, use the \"Backup now\" button in Advanced Settings",
+    "message": "We're deprecating our 3Box data feature soon. To backup and restore your wallet manually, use the \"Backup now\" button in Advanced Settings.",
     "description": "Description of a notification in the 'See What's New' popup. Describes 3box deprecation."
   },
   "notifications14Title": {

--- a/shared/notifications/index.js
+++ b/shared/notifications/index.js
@@ -72,7 +72,7 @@ export const UI_NOTIFICATIONS = {
   },
   14: {
     id: 14,
-    date: '2022-10-12',
+    date: null,
   },
 };
 
@@ -204,9 +204,11 @@ export const getTranslatedUINotifications = (t, locale) => {
       title: t('notifications14Title'),
       description: t('notifications14Description'),
       actionText: t('notifications14ActionText'),
-      date: new Intl.DateTimeFormat(formattedLocale).format(
-        new Date(UI_NOTIFICATIONS[14].date),
-      ),
+      date: UI_NOTIFICATIONS[14].date
+        ? new Intl.DateTimeFormat(formattedLocale).format(
+            new Date(UI_NOTIFICATIONS[14].date),
+          )
+        : '',
     },
   };
 };

--- a/shared/notifications/index.js
+++ b/shared/notifications/index.js
@@ -70,6 +70,10 @@ export const UI_NOTIFICATIONS = {
     id: 13,
     date: '2022-09-15',
   },
+  14: {
+    id: 14,
+    date: '2022-10-12',
+  },
 };
 
 export const getTranslatedUINotifications = (t, locale) => {
@@ -193,6 +197,15 @@ export const getTranslatedUINotifications = (t, locale) => {
       actionText: t('notifications13ActionText'),
       date: new Intl.DateTimeFormat(formattedLocale).format(
         new Date(UI_NOTIFICATIONS[13].date),
+      ),
+    },
+    14: {
+      ...UI_NOTIFICATIONS[14],
+      title: t('notifications14Title'),
+      description: t('notifications14Description'),
+      actionText: t('notifications14ActionText'),
+      date: new Intl.DateTimeFormat(formattedLocale).format(
+        new Date(UI_NOTIFICATIONS[14].date),
       ),
     },
   };

--- a/test/e2e/fixtures/address-entry/state.json
+++ b/test/e2e/fixtures/address-entry/state.json
@@ -79,6 +79,9 @@
         },
         "13": {
           "isShown": true
+        },
+        "14": {
+          "isShown": true
         }
       }
     },

--- a/test/e2e/fixtures/connected-state/state.json
+++ b/test/e2e/fixtures/connected-state/state.json
@@ -69,6 +69,9 @@
         },
         "13": {
           "isShown": true
+        },
+        "14": {
+          "isShown": true
         }
       }
     },

--- a/test/e2e/fixtures/custom-rpc/state.json
+++ b/test/e2e/fixtures/custom-rpc/state.json
@@ -65,6 +65,9 @@
         },
         "13": {
           "isShown": true
+        },
+        "14": {
+          "isShown": true
         }
       }
     },

--- a/test/e2e/fixtures/custom-token/state.json
+++ b/test/e2e/fixtures/custom-token/state.json
@@ -83,6 +83,9 @@
         },
         "13": {
           "isShown": true
+        },
+        "14": {
+          "isShown": true
         }
       }
     },

--- a/test/e2e/fixtures/eip-1559-v2-dapp/state.json
+++ b/test/e2e/fixtures/eip-1559-v2-dapp/state.json
@@ -66,6 +66,9 @@
         },
         "13": {
           "isShown": true
+        },
+        "14": {
+          "isShown": true
         }
       }
     },

--- a/test/e2e/fixtures/eip-1559-v2/state.json
+++ b/test/e2e/fixtures/eip-1559-v2/state.json
@@ -66,6 +66,9 @@
         },
         "13": {
           "isShown": true
+        },
+        "14": {
+          "isShown": true
         }
       }
     },

--- a/test/e2e/fixtures/import-ui/state.json
+++ b/test/e2e/fixtures/import-ui/state.json
@@ -119,6 +119,9 @@
         },
         "13": {
           "isShown": true
+        },
+        "14": {
+          "isShown": true
         }
       }
     },

--- a/test/e2e/fixtures/imported-account/state.json
+++ b/test/e2e/fixtures/imported-account/state.json
@@ -65,6 +65,9 @@
         },
         "13": {
           "isShown": true
+        },
+        "14": {
+          "isShown": true
         }
       }
     },

--- a/test/e2e/fixtures/localization/state.json
+++ b/test/e2e/fixtures/localization/state.json
@@ -65,6 +65,9 @@
         },
         "13": {
           "isShown": true
+        },
+        "14": {
+          "isShown": true
         }
       }
     },

--- a/test/e2e/fixtures/metrics-enabled/state.json
+++ b/test/e2e/fixtures/metrics-enabled/state.json
@@ -69,6 +69,9 @@
         },
         "13": {
           "isShown": true
+        },
+        "14": {
+          "isShown": true
         }
       }
     },

--- a/test/e2e/fixtures/navigate-transactions/state.json
+++ b/test/e2e/fixtures/navigate-transactions/state.json
@@ -65,6 +65,9 @@
         },
         "13": {
           "isShown": true
+        },
+        "14": {
+          "isShown": true
         }
       }
     },

--- a/test/e2e/fixtures/onboarding/state.json
+++ b/test/e2e/fixtures/onboarding/state.json
@@ -39,6 +39,9 @@
         },
         "13": {
           "isShown": true
+        },
+        "14": {
+          "isShown": true
         }
       }
     },

--- a/test/e2e/fixtures/send-edit-v2/state.json
+++ b/test/e2e/fixtures/send-edit-v2/state.json
@@ -66,6 +66,9 @@
         },
         "13": {
           "isShown": true
+        },
+        "14": {
+          "isShown": true
         }
       }
     },

--- a/test/e2e/fixtures/send-edit/state.json
+++ b/test/e2e/fixtures/send-edit/state.json
@@ -66,6 +66,9 @@
         },
         "13": {
           "isShown": true
+        },
+        "14": {
+          "isShown": true
         }
       }
     },

--- a/test/e2e/fixtures/special-settings/state.json
+++ b/test/e2e/fixtures/special-settings/state.json
@@ -59,6 +59,9 @@
         },
         "13": {
           "isShown": true
+        },
+        "14": {
+          "isShown": true
         }
       }
     },

--- a/test/e2e/fixtures/threebox-enabled/state.json
+++ b/test/e2e/fixtures/threebox-enabled/state.json
@@ -76,6 +76,9 @@
         },
         "13": {
           "isShown": true
+        },
+        "14": {
+          "isShown": true
         }
       }
     },

--- a/ui/components/app/whats-new-popup/whats-new-popup.js
+++ b/ui/components/app/whats-new-popup/whats-new-popup.js
@@ -58,6 +58,10 @@ function getActionFunctionById(id, history) {
       updateViewedNotifications({ 13: true });
       history.push(`${EXPERIMENTAL_ROUTE}#show-custom-network`);
     },
+    14: () => {
+      updateViewedNotifications({ 14: true });
+      history.push(`${ADVANCED_ROUTE}#backup-userdata`);
+    },
   };
 
   return actionFunctions[id];

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -817,6 +817,7 @@ function getAllowedAnnouncementIds(state) {
   const supportsWebHid = window.navigator.hid !== undefined;
   const currentlyUsingLedgerLive =
     getLedgerTransportType(state) === LEDGER_TRANSPORT_TYPES.LIVE;
+  const { threeBoxSyncingAllowed } = state.metamask;
 
   return {
     1: false,
@@ -832,6 +833,7 @@ function getAllowedAnnouncementIds(state) {
     11: true,
     12: false,
     13: true,
+    14: threeBoxSyncingAllowed,
   };
 }
 


### PR DESCRIPTION
## Explanation

3Box is being deprecated, this PR shows a message to 3box users that it will be deprecated, directing them to the replacement (Backup/Restore) functionality

## More Information

* Fixes #15595

## Screenshots/Screencaps

<img width="512" alt="Screenshot 2022-09-12 at 02 31 28" src="https://user-images.githubusercontent.com/44811/189551635-a6764c47-e6f4-4faf-abd5-89c245a20acd.png">

## Manual Testing Steps

- Launch MetaMask
- If you have 3box syncing enabled, you should see the above in What's New Popup
- Else go to Settings > Advanced Settings > Sync data with 3Box (experimental) (Enable the toggle)
- Quit Browser
- Relaunch Browser
- Launch MetaMask
- You should see the above in What's New Popup

## Pre-Merge Checklist

- [ ] PR template is filled out
- [ ] **IF** this PR fixes a bug, a test that _would have_ caught the bug has been added
- [ ] PR is linked to the appropriate GitHub issue
- [ ] PR has been added to the appropriate release Milestone

### + If there are functional changes:

- [ ] Manual testing complete & passed
- [ ] "Extension QA Board" label has been applied
