### PR TITLE
Ensuring Blockies Icon is used in nickname popup when enabled

### DIFF
--- a/ui/components/ui/update-nickname-popover/update-nickname-popover.js
+++ b/ui/components/ui/update-nickname-popover/update-nickname-popover.js
@@ -8,7 +8,7 @@ import TextField from '../text-field';
 
 import { I18nContext } from '../../../contexts/i18n';
 
-import Identicon from '../identicon/identicon.component';
+import Identicon from '../identicon';
 import { getTokenList } from '../../../selectors';
 
 export default function UpdateNicknamePopover({


### PR DESCRIPTION
Fixes: https://github.com/MetaMask/metamask-extension/issues/15764

Component was being directly imported as opposed to the containerized import

## Test Plan
Defined in issue

<img width="369" alt="Screen Shot 2022-09-08 at 10 57 09 AM" src="https://user-images.githubusercontent.com/8732757/189193057-20e76f6d-9466-452a-819b-509acaa070c3.png">

<img width="455" alt="Screen Shot 2022-09-08 at 10 56 37 AM" src="https://user-images.githubusercontent.com/8732757/189193060-b1ec91a8-93f2-485e-bf8d-6d16539e81c2.png">
