### PR TITLE
Expand error details before taking screenshot when a test fails with a Page Error

### DIFF
--- a/test/e2e/webdriver/driver.js
+++ b/test/e2e/webdriver/driver.js
@@ -382,6 +382,10 @@ class Driver {
     const artifactDir = `./test-artifacts/${this.browser}/${title}`;
     const filepathBase = `${artifactDir}/test-failure`;
     await fs.mkdir(artifactDir, { recursive: true });
+    const isPageError = await this.isElementPresent('.error-page__details');
+    if (isPageError) {
+      await this.clickElement('.error-page__details');
+    }
     const screenshot = await this.driver.takeScreenshot();
     await fs.writeFile(`${filepathBase}-screenshot.png`, screenshot, {
       encoding: 'base64',


### PR DESCRIPTION
## Explanation
When the e2e tests fail, a screenshot is taken and uploaded as Artifacts in circle ci. The problem is that when we reach an error page, the Error details are hiden and the screenshot does not captures valuable info.

For improving this behaviour, we now check if we reach a Page error and we expand the error details before taking the screenshot.

- Closes #15511

## Screenshots/Screencaps

### Before

Artifacts screenshot with Page Errors looked like:

![image](https://user-images.githubusercontent.com/54408225/189334494-6cfd2028-04b9-4278-bf4f-b2361593192e.png)



### After
Now, Error is expanded and screenshot looks like:

![image](https://user-images.githubusercontent.com/54408225/189334739-5b963bfd-f8f2-4b1f-90d2-7d906d9b5c97.png)

## Manual Testing Steps
For testing this manually, you can trigger the Page error during a test (this will make it fail) and check that the screenshot is taken after page details are expanded.

1. Pick any e2e test and add a delay, so you have a bit of time to perform step 2: `await driver.delay(3000)`
2. Change the URL to `home.html#settings/contact-list/view-contact/`
3. Wait until test fails

See test effectively expands the error details and screenshot is taken after this step.

## Pre-Merge Checklist

- [X] PR template is filled out
- [ ] **IF** this PR fixes a bug, a test that _would have_ caught the bug has been added
- [X] PR is linked to the appropriate GitHub issue
- [ ] PR has been added to the appropriate release Milestone

### + If there are functional changes:

- [ ] Manual testing complete & passed
- [ ] "Extension QA Board" label has been applied
