### PR TITLE
Updated Signature Request Warning Message

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -3149,7 +3149,7 @@
     "message": "Sign"
   },
   "signNotice": {
-    "message": "Signing this message can be dangerous. This signature could potentially perform any operation on your account's behalf, including granting complete control of your account and all of its assets to the requesting site. Only sign this message if you know what you're doing or completely trust the requesting site."
+    "message": "WARNING: Only sign this request if you completely trust the requesting site. Signing this request could potentially allow the requesting site to take complete control of your account and all of its assets."
   },
   "signatureRequest": {
     "message": "Signature request"


### PR DESCRIPTION
Updated Signature Request Warning Message for #11337

Theft of assets by signature requests are becoming a big problem. I believe my wording to the signature request warning will help make the risks clear to less sophisticated and non-native English speaking users and help prevent thefts from signature requests.

### Before

"Signing this message can be dangerous. This signature could potentially perform any operation on your account's behalf, including granting complete control of your account and all of its assets to the requesting site. Only sign this message if you know what you're doing or completely trust the requesting site."

### After

"WARNING: Only sign this request if you completely trust the requesting site. Signing this request could potentially allow the requesting site to take complete control of your account and all of its assets."


