### PR TITLE
[FLASK] Fix crash with certain permissions on the snap settings page

### DIFF
--- a/ui/pages/settings/flask/view-snap/view-snap.js
+++ b/ui/pages/settings/flask/view-snap/view-snap.js
@@ -24,7 +24,11 @@ import {
   removeSnap,
   removePermissionsFor,
 } from '../../../../store/actions';
-import { getSnaps, getSubjectsWithPermission } from '../../../../selectors';
+import {
+  getSnaps,
+  getSubjectsWithPermission,
+  getPermissions,
+} from '../../../../selectors';
 import { formatDate } from '../../../../helpers/utils/util';
 
 function ViewSnap() {
@@ -50,6 +54,7 @@ function ViewSnap() {
   const connectedSubjects = useSelector((state) =>
     getSubjectsWithPermission(state, snap?.permissionName),
   );
+  const permissions = useSelector((state) => getPermissions(state, snap?.id));
   const dispatch = useDispatch();
   const onDisconnect = (connectedOrigin, snapPermissionName) => {
     dispatch(
@@ -137,9 +142,7 @@ function ViewSnap() {
               {t('snapAccess', [snap.manifest.proposedName])}
             </Typography>
             <Box width={FRACTIONS.TEN_TWELFTHS}>
-              <PermissionsConnectPermissionList
-                permissions={snap.manifest.initialPermissions}
-              />
+              <PermissionsConnectPermissionList permissions={permissions} />
             </Box>
           </div>
           <div className="view-snap__section">


### PR DESCRIPTION
## Explanation
Fixes a crash that would happen when viewing the settings page with a snap that uses `snap_getBip32Entropy`.

## Manual Testing Steps
1. Install a snap that uses `snap_getBip32Entropy`
2. Visit its settings page
3. Verify that you can see the snap permissions
