### PR TITLE
[FLASK] Fix crash when uninstalling snap

### DIFF
--- a/ui/pages/settings/flask/view-snap/view-snap.js
+++ b/ui/pages/settings/flask/view-snap/view-snap.js
@@ -54,7 +54,9 @@ function ViewSnap() {
   const connectedSubjects = useSelector((state) =>
     getSubjectsWithPermission(state, snap?.permissionName),
   );
-  const permissions = useSelector((state) => snap && getPermissions(state, snap.id));
+  const permissions = useSelector(
+    (state) => snap && getPermissions(state, snap.id),
+  );
   const dispatch = useDispatch();
   const onDisconnect = (connectedOrigin, snapPermissionName) => {
     dispatch(
@@ -142,7 +144,9 @@ function ViewSnap() {
               {t('snapAccess', [snap.manifest.proposedName])}
             </Typography>
             <Box width={FRACTIONS.TEN_TWELFTHS}>
-              <PermissionsConnectPermissionList permissions={permissions ?? {}} />
+              <PermissionsConnectPermissionList
+                permissions={permissions ?? {}}
+              />
             </Box>
           </div>
           <div className="view-snap__section">

--- a/ui/pages/settings/flask/view-snap/view-snap.js
+++ b/ui/pages/settings/flask/view-snap/view-snap.js
@@ -54,7 +54,7 @@ function ViewSnap() {
   const connectedSubjects = useSelector((state) =>
     getSubjectsWithPermission(state, snap?.permissionName),
   );
-  const permissions = useSelector((state) => getPermissions(state, snap?.id));
+  const permissions = useSelector((state) => snap && getPermissions(state, snap.id));
   const dispatch = useDispatch();
   const onDisconnect = (connectedOrigin, snapPermissionName) => {
     dispatch(
@@ -142,7 +142,7 @@ function ViewSnap() {
               {t('snapAccess', [snap.manifest.proposedName])}
             </Typography>
             <Box width={FRACTIONS.TEN_TWELFTHS}>
-              <PermissionsConnectPermissionList permissions={permissions} />
+              <PermissionsConnectPermissionList permissions={permissions ?? {}} />
             </Box>
           </div>
           <div className="view-snap__section">


### PR DESCRIPTION
## Explanation
Fixes a crash that would happen when uninstalling a snap from the settings page.

## Manual Testing Steps
1. Install any snap.
2. Visit its settings page
3. Uninstall the snap
4. Verify that MM has not crashed
