### PR TITLE
Resolve inconsistency between browsers

### DIFF
--- a/app/manifest/v2/chrome.json
+++ b/app/manifest/v2/chrome.json
@@ -1,4 +1,5 @@
 {
+  "content_security_policy": "frame-ancestors 'none'",
   "externally_connectable": {
     "matches": ["https://metamask.io/*"],
     "ids": ["*"]

--- a/app/manifest/v3/chrome.json
+++ b/app/manifest/v3/chrome.json
@@ -1,4 +1,7 @@
 {
+  "content_security_policy": {
+    "extension_pages": "default-src 'self'; frame-ancestors 'none'"
+  },
   "externally_connectable": {
     "matches": ["https://metamask.io/*"],
     "ids": ["*"]


### PR DESCRIPTION
Resolve an inconsistency between Chrome and Firefox with how the contentscript runs in an iframe.

This should have no user-facing impact, it's just meant as a safeguard in case something unintentionally gets included in the contentscript.

## Manual Testing Steps

Standard regression testing, no functional changes.

## Pre-Merge Checklist

- [x] PR template is filled out
- [x] **IF** this PR fixes a bug, a test that _would have_ caught the bug has been added
- [x] PR is linked to the appropriate GitHub issue
- [ ] PR has been added to the appropriate release Milestone

### + If there are functional changes:

- [x] Manual testing complete & passed
- [x] "Extension QA Board" label has been applied
