### PR TITLE
Properly handle JSON errors when restoring data in advanced settings

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -900,6 +900,9 @@
   "dataBackupFoundInfo": {
     "message": "Some of your account data was backed up during a previous installation of MetaMask. This could include your settings, contacts, and tokens. Would you like to restore this data now?"
   },
+  "dataBackupSeemsCorrupt": {
+    "message": "Can not restore your data. The file appears to be corrupt."
+  },
   "dataHex": {
     "message": "Hex"
   },


### PR DESCRIPTION
Fixes https://github.com/MetaMask/metamask-extension/issues/15778

This fix involves wrapping the call to restore the file in a try catch, and then showing a slightly customized message for the case of known corrupt JSON issues