### PR TITLE
Ensure that 'tokens found in this account' message is only shown when token detection activated

### DIFF
--- a/ui/components/app/asset-list/asset-list.js
+++ b/ui/components/app/asset-list/asset-list.js
@@ -11,7 +11,7 @@ import {
   getShouldShowFiat,
   getNativeCurrencyImage,
   getDetectedTokensInCurrentNetwork,
-  getIstokenDetectionInactiveOnNonMainnetSupportedNetwork,
+  getDisplayDetectedTokensLink,
 } from '../../../selectors';
 import { getNativeCurrency } from '../../../ducks/metamask/metamask';
 import { useCurrencyDisplay } from '../../../hooks/useCurrencyDisplay';
@@ -66,9 +66,7 @@ const AssetList = ({ onClickAsset }) => {
 
   const primaryTokenImage = useSelector(getNativeCurrencyImage);
   const detectedTokens = useSelector(getDetectedTokensInCurrentNetwork) || [];
-  const istokenDetectionInactiveOnNonMainnetSupportedNetwork = useSelector(
-    getIstokenDetectionInactiveOnNonMainnetSupportedNetwork,
-  );
+  const displayDetectedTokensLink = useSelector(getDisplayDetectedTokensLink);
 
   return (
     <>
@@ -96,10 +94,9 @@ const AssetList = ({ onClickAsset }) => {
           });
         }}
       />
-      {detectedTokens.length > 0 &&
-        !istokenDetectionInactiveOnNonMainnetSupportedNetwork && (
-          <DetectedTokensLink setShowDetectedTokens={setShowDetectedTokens} />
-        )}
+      {detectedTokens.length > 0 && displayDetectedTokensLink && (
+        <DetectedTokensLink setShowDetectedTokens={setShowDetectedTokens} />
+      )}
       <Box marginTop={detectedTokens.length > 0 ? 0 : 4}>
         <Box justifyContent={JUSTIFY_CONTENT.CENTER}>
           <Typography

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -1122,6 +1122,21 @@ export function getIstokenDetectionInactiveOnNonMainnetSupportedNetwork(state) {
 }
 
 /**
+ * To check if the token detection is ON and either a dynamic list is available
+ * or the user is on mainnet
+ *
+ * @param {*} state
+ * @returns Boolean
+ */
+export function getDisplayDetectedTokensLink(state) {
+  const useTokenDetection = getUseTokenDetection(state);
+  const isMainnet = getIsMainnet(state);
+  const isDynamicTokenListAvailable = getIsDynamicTokenListAvailable(state);
+
+  return (isDynamicTokenListAvailable || isMainnet) && useTokenDetection;
+}
+
+/**
  * To get the `customNetworkListEnabled` value which determines whether we use the custom network list
  *
  * @param {*} state


### PR DESCRIPTION
Fixes https://github.com/MetaMask/metamask-extension/issues/15790

Previously, we were deciding whether to show `DetectedTokensLink` by checking (effectively) `!(isDynamicTokenListAvailable && !useTokenDetection && !isMainnet)`, which would be `!isDynamicTokenListAvailable || useTokenDetection || isMainnet`. This was erroneous in two cases: (a) if `useTokenDetection` is false, we shouldn't show the think, (b) if it is true, but we are not on mainnet and no dynamic list is available, then we shouldn't show the link.

This PR corrects this to only showing the link if  `useTokenDetection` is true, and only if either `isDynamicTokenListAvailable' or `isMainnet` are true.