### PR TITLE
Hide DetectedTokenAggregators if token.aggregators lists are empty

### DIFF
--- a/ui/components/app/detected-token/detected-token-details/detected-token-details.js
+++ b/ui/components/app/detected-token/detected-token-details/detected-token-details.js
@@ -35,7 +35,9 @@ const DetectedTokenDetails = ({
           tokensListDetected={tokensListDetected}
         />
         <DetectedTokenAddress tokenAddress={token.address} />
-        <DetectedTokenAggregators aggregators={token.aggregators} />
+        {token.aggregators.length && (
+          <DetectedTokenAggregators aggregators={token.aggregators} />
+        )}
       </Box>
     </Box>
   );


### PR DESCRIPTION
Fixes https://github.com/MetaMask/metamask-extension/issues/15792

If there are no aggregators to display, we can simply hide the whole component used to display them, thereby avoiding the error described in the ticket.