### PR TITLE
Created the NFT component for single NFT allowance

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -4250,6 +4250,9 @@
     "message": "Verify this token on $1 and make sure this is the token you want to trade.",
     "description": "Points the user to etherscan as a place they can verify information about a token. $1 is replaced with the translation for \"etherscan\""
   },
+  "view": {
+    "message": "View"
+  },
   "viewAccount": {
     "message": "View account"
   },

--- a/ui/components/ui/nft-info/index.js
+++ b/ui/components/ui/nft-info/index.js
@@ -1,0 +1,1 @@
+export { default } from './nft-info';

--- a/ui/components/ui/nft-info/index.scss
+++ b/ui/components/ui/nft-info/index.scss
@@ -1,0 +1,14 @@
+.nft-info {
+  &__content {
+    width: 100%;
+
+    &__view {
+      flex-grow: 1;
+
+      &__button {
+        background: none;
+        color: var(--color-primary-default);
+      }
+    }
+  }
+}

--- a/ui/components/ui/nft-info/index.scss
+++ b/ui/components/ui/nft-info/index.scss
@@ -1,14 +1,9 @@
 .nft-info {
   &__content {
     width: 100%;
+  }
 
-    &__view {
-      flex-grow: 1;
-
-      &__button {
-        background: none;
-        color: var(--color-primary-default);
-      }
-    }
+  &__button {
+    padding: 0;
   }
 }

--- a/ui/components/ui/nft-info/nft-info.js
+++ b/ui/components/ui/nft-info/nft-info.js
@@ -8,10 +8,9 @@ import {
   DISPLAY,
   FONT_WEIGHT,
   TYPOGRAPHY,
-  TEXT_ALIGN,
-  JUSTIFY_CONTENT,
 } from '../../../helpers/constants/design-system';
 import Identicon from '../identicon';
+import Button from '../button';
 
 export default function NftInfo({ tokenName, tokenAddress, tokenId }) {
   const t = useContext(I18nContext);
@@ -22,11 +21,7 @@ export default function NftInfo({ tokenName, tokenAddress, tokenId }) {
       className="nft-info"
       backgroundColor={COLORS.BACKGROUND_ALTERNATIVE}
     >
-      <Box
-        display={DISPLAY.FLEX}
-        justifyContent={JUSTIFY_CONTENT.SPACE_BETWEEN}
-        className="nft-info__content"
-      >
+      <Box display={DISPLAY.FLEX} className="nft-info__content">
         <Box margin={4}>
           <Identicon address={tokenAddress} diameter={24} />
         </Box>
@@ -35,29 +30,28 @@ export default function NftInfo({ tokenName, tokenAddress, tokenId }) {
             fontWeight={FONT_WEIGHT.BOLD}
             variant={TYPOGRAPHY.H6}
             marginTop={4}
-            boxProps={{ display: DISPLAY.INLINE_BLOCK }}
           >
             {tokenName}
           </Typography>
           <Typography
             variant={TYPOGRAPHY.H7}
-            display={DISPLAY.FLEX}
             marginBottom={4}
             color={COLORS.TEXT_ALTERNATIVE}
           >
             {t('tokenId')} #{tokenId}
           </Typography>
         </Box>
-        <Box
-          textAlign={TEXT_ALIGN.END}
-          marginTop={4}
-          marginRight={4}
-          className="nft-info__content__view"
-        >
-          <button className="nft-info__content__view__button" type="link">
+      </Box>
+      <Box marginTop={4} marginRight={4}>
+        <Button className="nft-info__button" type="link">
+          <Typography
+            variant={TYPOGRAPHY.H6}
+            marginTop={0}
+            color={COLORS.PRIMARY_DEFAULT}
+          >
             {t('view')}
-          </button>
-        </Box>
+          </Typography>
+        </Button>
       </Box>
     </Box>
   );

--- a/ui/components/ui/nft-info/nft-info.js
+++ b/ui/components/ui/nft-info/nft-info.js
@@ -1,0 +1,70 @@
+import React, { useContext } from 'react';
+import PropTypes from 'prop-types';
+import { I18nContext } from '../../../contexts/i18n';
+import Box from '../box';
+import Typography from '../typography';
+import {
+  COLORS,
+  DISPLAY,
+  FONT_WEIGHT,
+  TYPOGRAPHY,
+  TEXT_ALIGN,
+  JUSTIFY_CONTENT,
+} from '../../../helpers/constants/design-system';
+import Identicon from '../identicon';
+
+export default function NftInfo({ tokenName, tokenAddress, tokenId }) {
+  const t = useContext(I18nContext);
+
+  return (
+    <Box
+      display={DISPLAY.FLEX}
+      className="nft-info"
+      backgroundColor={COLORS.BACKGROUND_ALTERNATIVE}
+    >
+      <Box
+        display={DISPLAY.FLEX}
+        justifyContent={JUSTIFY_CONTENT.SPACE_BETWEEN}
+        className="nft-info__content"
+      >
+        <Box margin={4}>
+          <Identicon address={tokenAddress} diameter={24} />
+        </Box>
+        <Box>
+          <Typography
+            fontWeight={FONT_WEIGHT.BOLD}
+            variant={TYPOGRAPHY.H6}
+            marginTop={4}
+            boxProps={{ display: DISPLAY.INLINE_BLOCK }}
+          >
+            {tokenName}
+          </Typography>
+          <Typography
+            variant={TYPOGRAPHY.H7}
+            display={DISPLAY.FLEX}
+            marginBottom={4}
+            color={COLORS.TEXT_ALTERNATIVE}
+          >
+            {t('tokenId')} #{tokenId}
+          </Typography>
+        </Box>
+        <Box
+          textAlign={TEXT_ALIGN.END}
+          marginTop={4}
+          marginRight={4}
+          className="nft-info__content__view"
+        >
+          <button className="nft-info__content__view__button" type="link">
+            {t('view')}
+          </button>
+        </Box>
+      </Box>
+    </Box>
+  );
+}
+
+NftInfo.propTypes = {
+  tokenName: PropTypes.string,
+  tokenAddress: PropTypes.string,
+  tokenId: PropTypes.string,
+};

--- a/ui/components/ui/nft-info/nft-info.js
+++ b/ui/components/ui/nft-info/nft-info.js
@@ -12,7 +12,7 @@ import {
 import Identicon from '../identicon';
 import Button from '../button';
 
-export default function NftInfo({ tokenName, tokenAddress, tokenId }) {
+export default function NftInfo({ assetName, tokenAddress, tokenId }) {
   const t = useContext(I18nContext);
 
   return (
@@ -31,7 +31,7 @@ export default function NftInfo({ tokenName, tokenAddress, tokenId }) {
             variant={TYPOGRAPHY.H6}
             marginTop={4}
           >
-            {tokenName}
+            {assetName}
           </Typography>
           <Typography
             variant={TYPOGRAPHY.H7}
@@ -58,7 +58,7 @@ export default function NftInfo({ tokenName, tokenAddress, tokenId }) {
 }
 
 NftInfo.propTypes = {
-  tokenName: PropTypes.string,
+  assetName: PropTypes.string,
   tokenAddress: PropTypes.string,
   tokenId: PropTypes.string,
 };

--- a/ui/components/ui/nft-info/nft-info.stories.js
+++ b/ui/components/ui/nft-info/nft-info.stories.js
@@ -1,0 +1,29 @@
+import React from 'react';
+import NftInfo from './nft-info';
+
+export default {
+  title: 'Components/UI/NftInfo',
+  id: __filename,
+  argTypes: {
+    tokenName: {
+      control: { type: 'text' },
+    },
+    tokenAddress: {
+      control: { type: 'text' },
+    },
+    tokenId: {
+      control: { type: 'text' },
+    },
+  },
+  args: {
+    tokenName: 'Catnip Spicewight',
+    tokenAddress: '0xa3aee8bce55beea1951ef834b99f3ac60d1abeeb',
+    tokenId: '112233',
+  },
+};
+
+export const DefaultStory = (args) => {
+  return <NftInfo {...args} />;
+};
+
+DefaultStory.storyName = 'Default';

--- a/ui/components/ui/nft-info/nft-info.stories.js
+++ b/ui/components/ui/nft-info/nft-info.stories.js
@@ -5,7 +5,7 @@ export default {
   title: 'Components/UI/NftInfo',
   id: __filename,
   argTypes: {
-    tokenName: {
+    assetName: {
       control: { type: 'text' },
     },
     tokenAddress: {
@@ -16,7 +16,7 @@ export default {
     },
   },
   args: {
-    tokenName: 'Catnip Spicewight',
+    assetName: 'Catnip Spicewight',
     tokenAddress: '0xa3aee8bce55beea1951ef834b99f3ac60d1abeeb',
     tokenId: '112233',
   },

--- a/ui/components/ui/ui-components.scss
+++ b/ui/components/ui/ui-components.scss
@@ -62,3 +62,4 @@
 @import 'disclosure/disclosure';
 @import 'deprecated-test-networks/index.scss';
 @import 'contract-token-values/index.scss';
+@import 'nft-info/index.scss';


### PR DESCRIPTION
## Explanation

Created the NFT component for single NFT allowance. This component can't yet be added to the app. Instead, I added a storybook that displays this component.

1. Icon displayed is the NFT collection icon
2. Copy in bold is the NFT collection name
3. Secondary copy is specific token ID for the NFT that is being request allowance for
4. Clicking on "View" opens up the "View NFTs" modal: https://github.com/MetaMask/metamask-extension/issues/15751

## More Information

* Fixes #15702


## Screenshots/Screencaps

<img width="369" alt="Screenshot 2022-09-14 at 10 02 04" src="https://user-images.githubusercontent.com/63151811/190096746-0487073e-45ab-4e20-bafe-5c1b0f98bcb3.png">


## Manual Testing Steps

This component can be tested by running storybook (yarn storybook) and then go to the COMPONENTS tab and open in UI/NftInfo.
