### PR TITLE
Move updateBackgroundConnection call in ui/index.js to before the action calls

### DIFF
--- a/ui/index.js
+++ b/ui/index.js
@@ -114,6 +114,8 @@ async function startApp(metamaskState, backgroundConnection, opts) {
     },
   };
 
+  updateBackgroundConnection(backgroundConnection);
+
   if (getEnvironmentType() === ENVIRONMENT_TYPE_POPUP) {
     const { origin } = draftInitialState.activeTab;
     const permittedAccountsForCurrentTab =
@@ -160,8 +162,6 @@ async function startApp(metamaskState, backgroundConnection, opts) {
       }),
     );
   }
-
-  updateBackgroundConnection(backgroundConnection);
 
   // global metamask api - used by tooling
   global.metamask = {


### PR DESCRIPTION
Fixes https://github.com/MetaMask/metamask-extension/issues/15816

`actions.setUnconnectedAccountAlertShown(origin);` in ui/index.js was being called before `updateBackgroundConnection(backgroundConnection);`, resulting in `promisifiedBackground` being null when `submitRequestToBackground` was later called.

This is fixed by moving the `updateBackgroundConnection` to before the actions.* calls in ui/index.js 