### PR TITLE
[FLASK] Add changes to support blocking Snaps by source shasum

### DIFF
--- a/app/scripts/flask/snaps-blocklist.js
+++ b/app/scripts/flask/snaps-blocklist.js
@@ -1,0 +1,24 @@
+/**
+ * Represents a list of Snaps that are not allowed to be used.
+ * Can be blocked by [ID, VERSION] or SHASUM of a source code (or both).
+ *
+ * Example:
+ * {
+ *    id: 'npm:@consensys/snap-id',
+ *    versionRange: '<0.1.11',
+ *    shasum: 'TEIbWsAyQe/8rBNXOHx3bOP9YF61PIPP/YHeokLchJE=',
+ * },
+ * {
+ *    shasum: 'eCYGZiYvZ3/uxkKI3npfl79kTQXS/5iD9ojsBS4A3rI=',
+ * },
+ */
+export const SNAP_BLOCKLIST = [
+  {
+    id: 'npm:@consensys/starknet-snap',
+    versionRange: '<0.1.11',
+  },
+  {
+    // @consensys/starknet-snap v:0.1.10
+    shasum: 'A83r5/ZIcKuKwuAnQHHByVFCuofj7jGK5hOStmHY6A0=',
+  },
+];

--- a/app/scripts/flask/snaps-utilities.js
+++ b/app/scripts/flask/snaps-utilities.js
@@ -1,0 +1,35 @@
+import { satisfies as satisfiesSemver } from 'semver';
+
+/**
+ * Checks if provided snaps are on the block list.
+ *
+ * @param snapsToCheck - An object containing snap ids and other information.
+ * @param blocklist - An object containing snap ids, version or shasum of the blocked snaps.
+ * @returns An object structure containing snaps block information.
+ */
+async function checkSnapsBlockList(snapsToCheck, blocklist) {
+  return Object.entries(snapsToCheck).reduce((acc, [snapId, snapInfo]) => {
+    const blockInfo = blocklist.find(
+      (blocked) =>
+        (blocked.id === snapId &&
+          satisfiesSemver(snapInfo.version, blocked.versionRange, {
+            includePrerelease: true,
+          })) ||
+        // Check for null/undefined for a case in which SnapController did not return
+        // a valid message. This will avoid blocking all snaps in the given case.
+        // Avoid having (undefined === undefined).
+        (blocked.shasum ? blocked.shasum === snapInfo.shasum : false),
+    );
+
+    acc[snapId] = blockInfo
+      ? {
+          blocked: true,
+          reason: blockInfo.reason,
+          infoUrl: blockInfo.infoUrl,
+        }
+      : { blocked: false };
+    return acc;
+  }, {});
+}
+
+export { checkSnapsBlockList };

--- a/app/scripts/flask/snaps-utilities.test.js
+++ b/app/scripts/flask/snaps-utilities.test.js
@@ -1,0 +1,127 @@
+import { strict as assert } from 'assert';
+import { checkSnapsBlockList } from './snaps-utilities';
+
+describe('Snaps Controller utilities', function () {
+  describe('checkSnapsBlockList', function () {
+    it('returns one of the given snaps as blocked by its version', async function () {
+      const mockBlocklist = [
+        {
+          id: 'npm:@consensys/starknet-snap',
+          versionRange: '<0.1.11',
+        },
+      ];
+      const mockSnapsToBeChecked = {
+        'npm:exampleA': {
+          version: '1.0.0',
+          shasum: 'F5IapP6v1Bp7bl16NkCszfOhtVSZAm362X5zl7wgMhI=',
+        },
+        'npm:exampleB': {
+          version: '1.0.0',
+          shasum: 'eCYGZiYvZ3/uxkKI3npfl79kTQXS/5iD9ojsBS4A3rI=',
+        },
+        'npm:@consensys/starknet-snap': {
+          version: '0.1.10',
+          shasum: 'A83r5/ZIcKuKwuAnQHHByVFCuofj7jGK5hOStmHY6A0=',
+        },
+      };
+
+      const blockedSnaps = await checkSnapsBlockList(
+        mockSnapsToBeChecked,
+        mockBlocklist,
+      );
+      assert.deepEqual(blockedSnaps, {
+        'npm:exampleA': { blocked: false },
+        'npm:exampleB': { blocked: false },
+        'npm:@consensys/starknet-snap': {
+          blocked: true,
+          reason: undefined,
+          infoUrl: undefined,
+        },
+      });
+    });
+
+    it('returns given snap as blocked by its shasum', async function () {
+      const mockBlocklist = [
+        {
+          shasum: 'A83r5/ZIcKuKwuAnQHHByVFCuofj7jGK5hOStmHY6A0=',
+        },
+      ];
+      const mockSnapsToBeChecked = {
+        'npm:@consensys/starknet-snap': {
+          version: '0.3.15', // try to fake version with the same source sha
+          shasum: 'A83r5/ZIcKuKwuAnQHHByVFCuofj7jGK5hOStmHY6A0=',
+        },
+      };
+
+      const blockedSnaps = await checkSnapsBlockList(
+        mockSnapsToBeChecked,
+        mockBlocklist,
+      );
+      assert.deepEqual(blockedSnaps, {
+        'npm:@consensys/starknet-snap': {
+          blocked: true,
+          reason: undefined,
+          infoUrl: undefined,
+        },
+      });
+    });
+
+    it('returns false for blocked for the same blocklisted snap but different version', async function () {
+      const mockBlocklist = [
+        {
+          id: 'npm:@consensys/starknet-snap',
+          versionRange: '<0.1.11',
+        },
+      ];
+      const mockSnapsToBeChecked = {
+        'npm:@consensys/starknet-snap': {
+          version: '0.2.1',
+          shasum: 'Z4jo37WG1E2rxqF05WaXOSUDxR5upUmOdaTvmgVY/L0=',
+        },
+      };
+
+      const blockedSnaps = await checkSnapsBlockList(
+        mockSnapsToBeChecked,
+        mockBlocklist,
+      );
+      assert.deepEqual(blockedSnaps, {
+        'npm:@consensys/starknet-snap': {
+          blocked: false,
+        },
+      });
+    });
+
+    it('returns false for blocked for multiple snaps that are not on the blocklist', async function () {
+      const mockBlocklist = [
+        {
+          id: 'npm:@consensys/starknet-snap',
+          versionRange: '<0.1.11',
+        },
+      ];
+      const mockSnapsToBeChecked = {
+        'npm:exampleA': {
+          version: '1.0.0',
+          shasum: 'F5IapP6v1Bp7bl16NkCszfOhtVSZAm362X5zl7wgMhI=',
+        },
+        'npm:exampleB': {
+          version: '2.1.3',
+          shasum: 'eCYGZiYvZ3/uxkKI3npfl79kTQXS/5iD9ojsBS4A3rI=',
+        },
+        'npm:exampleC': {
+          version: '3.7.9',
+          shasum: '2QqUxo5joo4kKKr7yiCjdYsZOZcIFBnIBEdwU9Yx7+M=',
+        },
+      };
+
+      const blockedSnaps = await checkSnapsBlockList(
+        mockSnapsToBeChecked,
+        mockBlocklist,
+      );
+      assert.deepEqual(blockedSnaps, {
+        'npm:exampleA': { blocked: false },
+        'npm:exampleB': { blocked: false },
+        'npm:exampleC': { blocked: false },
+      });
+    });
+  });
+});

--- a/jest.config.js
+++ b/jest.config.js
@@ -51,6 +51,7 @@ module.exports = {
     '<rootDir>/app/scripts/platforms/*.test.js',
     '<rootDir>app/scripts/controllers/network/**/*.test.js',
     '<rootDir>/app/scripts/controllers/permissions/**/*.test.js',
+    '<rootDir>/app/scripts/flask/**/*.test.js',
     '<rootDir>/app/scripts/lib/createRPCMethodTrackingMiddleware.test.js',
     '<rootDir>/app/scripts/constants/error-utils.test.js',
   ],


### PR DESCRIPTION
## Explanation
This PR will add some small changes to the `MetamaskController` `->` `SnapController` which would make possible to block Snaps by shasum of its source code. This PR extends the initial version of Snaps Blocklist functionality.

## More Information
Fix: https://github.com/MetaMask/snaps-skunkworks/issues/620

Required merge of: https://github.com/MetaMask/snaps-skunkworks/pull/767 (Update version of `@metamask/snap-controllers`)

* Snaps blocklist is extracted and moved from MetaMask Controller to separate directory and file `app/scripts//flask/snaps-blocklist.js`, for easier maintenance, import and testing.
* Function `checkBlockList` is now handling blocked snap by using utility function `checkSnapsBlockList` instead of having all the logic inline. Utility function is extracted to `app/scripts/flask/snaps-utilities.js`.
* Unit tests are added to ensure functionality of the previous and new features.

## Screenshots/Screencaps
No UI changes. Snaps blocklist structure now can look like the example below and can handle the cases specified in this PR.
```javascript
export const SNAP_BLOCKLIST = [
  {
    id: 'npm:@consensys/starknet-snap',
    versionRange: '<0.1.11',
  },
  {
    // @consensys/starknet-snap v:0.1.10
    shasum: 'A83r5/ZIcKuKwuAnQHHByVFCuofj7jGK5hOStmHY6A0=',
  },
];
```

### Before
Snaps blocklist supported only blocking snap by its `ID:VERSION`.

### After
Snaps blocklist supports blocking snaps by `ID:VERSION` plus `SHASUM` of the source code.

## Pre-Merge Checklist

- [x] Snaps Controller package is updated