### PR TITLE
Case insensitive modifier for Firefox errors

### DIFF
--- a/ui/pages/settings/advanced-tab/advanced-tab.component.js
+++ b/ui/pages/settings/advanced-tab/advanced-tab.component.js
@@ -166,7 +166,7 @@ export default class AdvancedTab extends PureComponent {
         restoreMessage: null,
       });
     } catch (e) {
-      if (e.message.match(/Unexpected.+JSON/u)) {
+      if (e.message.match(/Unexpected.+JSON/iu)) {
         this.setState({
           showResultMessage: true,
           restoreSuccessful: false,


### PR DESCRIPTION
This change ensure's the restore failed message is shown in Firefox also. 

Continuation of work done in #15815

See: #15778 

Firefox errors below (lowercase u in unexpected):
- JSON.parse: unexpected character at line 1 column 1 of the JSON data
- JSON.parse: unexpected end of data at line 1 column 1 of the JSON data

## Explanation

<!--
Thanks for the pull request. Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Below is a template to give you some ideas. Feel free to use your own words!

Currently, ...

This is a problem because ...

In order to solve this problem, this pull request ...
-->

## More Information

<!--
Are there any issues, Slack conversations, Zendesk issues, user stories, etc. reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

## Screenshots/Screencaps

<!-- If you're making a change to the UI, make sure to capture a screenshot or a short video showing off your work! -->

### Before

<!-- How did the UI you changed look before your changes? Drag your file(s) below this line: -->

Actionable message not shown in Firefox, only shown in Chrome 

### After

<!-- How does it look now? Drag your file(s) below this line: -->

Actionable message shown in Firefox also

<img width="1616" alt="corrupt file" src="https://user-images.githubusercontent.com/53189696/190183658-86fc182f-961e-4feb-8d76-2db336495f2d.png">


## Manual Testing Steps

<!--
How should reviewers and QA manually test your changes? For instance:

- Go to this screen
- Do this
- Then do this
-->

## Pre-Merge Checklist

- [ ] PR template is filled out
- [ ] **IF** this PR fixes a bug, a test that _would have_ caught the bug has been added
- [ ] PR is linked to the appropriate GitHub issue
- [ ] PR has been added to the appropriate release Milestone

### + If there are functional changes:

- [ ] Manual testing complete & passed
- [ ] "Extension QA Board" label has been applied
