### PR TITLE
Fix 3box replacement for MV3

### DIFF
--- a/app/scripts/controllers/backup.js
+++ b/app/scripts/controllers/backup.js
@@ -1,4 +1,3 @@
-import { exportAsFile } from '../../../shared/modules/export-utils';
 import { prependZero } from '../../../shared/modules/string-utils';
 
 export default class BackupController {
@@ -65,13 +64,6 @@ export default class BackupController {
       date.getMinutes(),
     )}_${prefixZero(date.getDay())}.json`;
 
-    exportAsFile(userDataFileName, result);
-
-    this._trackMetaMetricsEvent({
-      event: 'User Data Exported',
-      category: 'Backup',
-    });
-
-    return result;
+    return { fileName: userDataFileName, data: result };
   }
 }

--- a/ui/components/ui/export-text-container/export-text-container.component.js
+++ b/ui/components/ui/export-text-container/export-text-container.component.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import Copy from '../icon/copy-icon.component';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import { useCopyToClipboard } from '../../../hooks/useCopyToClipboard';
-import { exportAsFile } from '../../../../shared/modules/export-utils';
+import { exportAsFile } from '../../../helpers/utils/export-utils';
 
 function ExportTextContainer({
   text = '',

--- a/ui/helpers/utils/export-utils.js
+++ b/ui/helpers/utils/export-utils.js
@@ -1,4 +1,4 @@
-import { getRandomFileName } from '../../ui/helpers/utils/util';
+import { getRandomFileName } from './util';
 
 export function exportAsFile(filename, data, type = 'text/csv') {
   // eslint-disable-next-line no-param-reassign

--- a/ui/pages/first-time-flow/seed-phrase/confirm-seed-phrase/confirm-seed-phrase.component.js
+++ b/ui/pages/first-time-flow/seed-phrase/confirm-seed-phrase/confirm-seed-phrase.component.js
@@ -10,7 +10,7 @@ import {
   EVENT,
   EVENT_NAMES,
 } from '../../../../../shared/constants/metametrics';
-import { exportAsFile } from '../../../../../shared/modules/export-utils';
+import { exportAsFile } from '../../../../helpers/utils/export-utils';
 import DraggableSeed from './draggable-seed.component';
 
 const EMPTY_SEEDS = Array(12).fill(null);

--- a/ui/pages/first-time-flow/seed-phrase/reveal-seed-phrase/reveal-seed-phrase.component.js
+++ b/ui/pages/first-time-flow/seed-phrase/reveal-seed-phrase/reveal-seed-phrase.component.js
@@ -15,7 +15,7 @@ import {
   EVENT_NAMES,
 } from '../../../../../shared/constants/metametrics';
 import { returnToOnboardingInitiatorTab } from '../../onboarding-initiator-util';
-import { exportAsFile } from '../../../../../shared/modules/export-utils';
+import { exportAsFile } from '../../../../helpers/utils/export-utils';
 
 export default class RevealSeedPhrase extends PureComponent {
   static contextTypes = {

--- a/ui/pages/settings/advanced-tab/advanced-tab.component.js
+++ b/ui/pages/settings/advanced-tab/advanced-tab.component.js
@@ -21,7 +21,7 @@ import {
   LEDGER_USB_VENDOR_ID,
 } from '../../../../shared/constants/hardware-wallets';
 import { EVENT, EVENT_NAMES } from '../../../../shared/constants/metametrics';
-import { exportAsFile } from '../../../../shared/modules/export-utils';
+import { exportAsFile } from '../../../helpers/utils/export-utils';
 import ActionableMessage from '../../../components/ui/actionable-message';
 import ZENDESK_URLS from '../../../helpers/constants/zendesk-url';
 

--- a/ui/pages/settings/advanced-tab/advanced-tab.component.js
+++ b/ui/pages/settings/advanced-tab/advanced-tab.component.js
@@ -256,8 +256,14 @@ export default class AdvancedTab extends PureComponent {
             <Button
               type="secondary"
               large
-              onClick={() => {
-                this.props.backupUserData();
+              onClick={async () => {
+                const { fileName, data } = await this.props.backupUserData();
+                exportAsFile(fileName, data);
+
+                this._trackMetaMetricsEvent({
+                  event: 'User Data Exported',
+                  category: 'Backup',
+                });
               }}
             >
               {t('backup')}

--- a/ui/pages/settings/advanced-tab/advanced-tab.component.js
+++ b/ui/pages/settings/advanced-tab/advanced-tab.component.js
@@ -155,7 +155,6 @@ export default class AdvancedTab extends PureComponent {
     /**
      * so that we can restore same file again if we want to.
      * chrome blocks uploading same file twice.
-     *
      */
     event.target.value = '';
     try {
@@ -260,9 +259,10 @@ export default class AdvancedTab extends PureComponent {
                 const { fileName, data } = await this.props.backupUserData();
                 exportAsFile(fileName, data);
 
-                this._trackMetaMetricsEvent({
+                this.context.trackEvent({
                   event: 'User Data Exported',
                   category: 'Backup',
+                  properties: {},
                 });
               }}
             >

--- a/ui/pages/settings/advanced-tab/advanced-tab.component.js
+++ b/ui/pages/settings/advanced-tab/advanced-tab.component.js
@@ -236,6 +236,17 @@ export default class AdvancedTab extends PureComponent {
     );
   }
 
+  backupUserData = async () => {
+    const { fileName, data } = await this.props.backupUserData();
+    exportAsFile(fileName, data);
+
+    this.context.trackEvent({
+      event: 'User Data Exported',
+      category: 'Backup',
+      properties: {},
+    });
+  };
+
   renderUserDataBackup() {
     const { t } = this.context;
     return (
@@ -255,16 +266,7 @@ export default class AdvancedTab extends PureComponent {
             <Button
               type="secondary"
               large
-              onClick={async () => {
-                const { fileName, data } = await this.props.backupUserData();
-                exportAsFile(fileName, data);
-
-                this.context.trackEvent({
-                  event: 'User Data Exported',
-                  category: 'Backup',
-                  properties: {},
-                });
-              }}
+              onClick={() => this.backupUserData()}
             >
               {t('backup')}
             </Button>


### PR DESCRIPTION
Fixes #15969

## Explanation

The 3box replacement is calling some `window` functions in backup controller. In MV3, these functions are not available in service worker, so we need to move the functions to the ui and backup controller should just return the data to be backed up and the actual backup (where the `window` functions are used should happen in the UI

## More Information

* See: [more details](https://github.com/MetaMask/metamask-extension/issues/14888#issuecomment-1241330206)

## Manual Testing Steps

**Before this change**
Start extension using `yarn start:mv3` 
Go to Advanced Settings -> Backup your data
Open console
Click Backup
You should see error in the console saying window.xxx is undefined and the backup should fail

**Apply this change**
Start extension using `yarn start:mv3` 
Go to Advanced Settings -> Backup your data
Open console
Click Backup
You should **NOT** see error in the console saying window.xxx is undefined and the backup should succeed

- [x] PR template is filled out
- [ ] **IF** this PR fixes a bug, a test that _would have_ caught the bug has been added
- [ ] PR is linked to the appropriate GitHub issue
- [ ] PR has been added to the appropriate release Milestone

### + If there are functional changes:

- [ ] Manual testing complete & passed
- [ ] "Extension QA Board" label has been applied
