### PR TITLE
Make environment variables higher precedence than config

### DIFF
--- a/app/scripts/lib/setupSentry.js
+++ b/app/scripts/lib/setupSentry.js
@@ -9,7 +9,9 @@ import extractEthjsErrorMessage from './extractEthjsErrorMessage';
 // Destructuring breaks the inlining of the environment variables
 const METAMASK_DEBUG = process.env.METAMASK_DEBUG;
 const METAMASK_ENVIRONMENT = process.env.METAMASK_ENVIRONMENT;
-const SENTRY_DSN_DEV = process.env.SENTRY_DSN_DEV;
+const SENTRY_DSN_DEV =
+  process.env.SENTRY_DSN_DEV ||
+  'https://f59f3dd640d2429d9d0e2445a87ea8e1@sentry.io/273496';
 const METAMASK_BUILD_TYPE = process.env.METAMASK_BUILD_TYPE;
 const IN_TEST = process.env.IN_TEST;
 /* eslint-enable prefer-destructuring */

--- a/development/build/config.js
+++ b/development/build/config.js
@@ -3,6 +3,33 @@ const { readFile } = require('fs/promises');
 const ini = require('ini');
 const { BuildType } = require('../lib/build-type');
 
+const commonConfigurationPropertyNames = ['PUBNUB_PUB_KEY', 'PUBNUB_SUB_KEY'];
+
+const configurationPropertyNames = [
+  ...commonConfigurationPropertyNames,
+  'COLLECTIBLES_V1',
+  'INFURA_PROJECT_ID',
+  'ONBOARDING_V2',
+  'PHISHING_WARNING_PAGE_URL',
+  'PORTFOLIO_URL',
+  'SEGMENT_HOST',
+  'SEGMENT_WRITE_KEY',
+  'SENTRY_DSN_DEV',
+  'SIWE_V1',
+  'SWAPS_USE_DEV_APIS',
+];
+
+const productionConfigurationPropertyNames = [
+  ...commonConfigurationPropertyNames,
+  'INFURA_BETA_PROJECT_ID',
+  'INFURA_FLASK_PROJECT_ID',
+  'INFURA_PROD_PROJECT_ID',
+  'SEGMENT_BETA_WRITE_KEY',
+  'SEGMENT_FLASK_WRITE_KEY',
+  'SEGMENT_PROD_WRITE_KEY',
+  'SENTRY_DSN',
+];
+
 /**
  * Get configuration for non-production builds.
  *
@@ -20,22 +47,17 @@ async function getConfig() {
       throw error;
     }
   }
+
+  const environmentVariables = {};
+  for (const propertyName of configurationPropertyNames) {
+    if (process.env[propertyName]) {
+      environmentVariables[propertyName] = process.env[propertyName];
+    }
+  }
+
   return {
-    COLLECTIBLES_V1: process.env.COLLECTIBLES_V1,
-    INFURA_PROJECT_ID: process.env.INFURA_PROJECT_ID,
-    ONBOARDING_V2: process.env.ONBOARDING_V2,
-    PHISHING_WARNING_PAGE_URL: process.env.PHISHING_WARNING_PAGE_URL,
-    PORTFOLIO_URL: process.env.PORTFOLIO_URL,
-    PUBNUB_PUB_KEY: process.env.PUBNUB_PUB_KEY,
-    PUBNUB_SUB_KEY: process.env.PUBNUB_SUB_KEY,
-    SEGMENT_HOST: process.env.SEGMENT_HOST,
-    SEGMENT_WRITE_KEY: process.env.SEGMENT_WRITE_KEY,
-    SENTRY_DSN_DEV:
-      process.env.SENTRY_DSN_DEV ??
-      'https://f59f3dd640d2429d9d0e2445a87ea8e1@sentry.io/273496',
-    SIWE_V1: process.env.SIWE_V1,
-    SWAPS_USE_DEV_APIS: process.env.SWAPS_USE_DEV_APIS,
     ...ini.parse(configContents),
+    ...environmentVariables,
   };
 }
 
@@ -61,17 +83,17 @@ async function getProductionConfig(buildType) {
       throw error;
     }
   }
+
+  const environmentVariables = {};
+  for (const propertyName of productionConfigurationPropertyNames) {
+    if (process.env[propertyName]) {
+      environmentVariables[propertyName] = process.env[propertyName];
+    }
+  }
+
   const prodConfig = {
-    INFURA_BETA_PROJECT_ID: process.env.INFURA_BETA_PROJECT_ID,
-    INFURA_FLASK_PROJECT_ID: process.env.INFURA_FLASK_PROJECT_ID,
-    INFURA_PROD_PROJECT_ID: process.env.INFURA_PROD_PROJECT_ID,
-    PUBNUB_PUB_KEY: process.env.PUBNUB_PUB_KEY,
-    PUBNUB_SUB_KEY: process.env.PUBNUB_SUB_KEY,
-    SEGMENT_BETA_WRITE_KEY: process.env.SEGMENT_BETA_WRITE_KEY,
-    SEGMENT_FLASK_WRITE_KEY: process.env.SEGMENT_FLASK_WRITE_KEY,
-    SEGMENT_PROD_WRITE_KEY: process.env.SEGMENT_PROD_WRITE_KEY,
-    SENTRY_DSN: process.env.SENTRY_DSN,
     ...ini.parse(prodConfigContents),
+    ...environmentVariables,
   };
 
   const requiredEnvironmentVariables = {


### PR DESCRIPTION
Environment variables are now considered as higher-precedence than configuration by our build system. This means that if the same value is set in `.metamaskrc` and in an environment variable, the environment variable is what will be used. Previously the reverse was true, the configuration would take precedence.

It is conventional for CLI tools to consider environment variables as higher precedence than configuration. This makes our build system less surprising for most people.

## Manual Testing Steps

* Set the entry `PORTFOLIO_URL` in `.metamaskrc` to the value `https://metamask.io`
* Create a build, and ensure the portfolio URL links to `https://metamask.io`
* Create a build with the environment variable `PORTFOLIO_URL` set to `https://google.com`, and ensure the portfolio URL links to `https://google.com` now instead.
  * e.g. `PORTFOLIO_URL='https://metamask.io' yarn start`
* Remove the `PORTFOLIO_URL` entry from `.metamaskrc` and repeat the last step.

You could also try this with a production build (i.e. `yarn build prod`), but you will also need to ensure every single environment variable used by a prod build is set in the production configuration file as well (`.metamaskprodrc`).

## Pre-Merge Checklist

- [x] PR template is filled out
- [x] **IF** this PR fixes a bug, a test that _would have_ caught the bug has been added
- [x] PR is linked to the appropriate GitHub issue
- [x] PR has been added to the appropriate release Milestone

### + If there are functional changes:

- [ ] Manual testing complete & passed
- [ ] "Extension QA Board" label has been applied
