### PR TITLE
Ensure New Network Info popup doesn't show when switching to testnets

### DIFF
--- a/ui/pages/routes/routes.component.js
+++ b/ui/pages/routes/routes.component.js
@@ -367,7 +367,7 @@ export default class Routes extends Component {
       isNetworkUsed,
       allAccountsOnNetworkAreEmpty,
       isTestNet,
-      currrentChainId,
+      currentChainId,
     } = this.props;
     const loadMessage =
       loadingMessage || isNetworkLoading

--- a/ui/pages/routes/routes.component.js
+++ b/ui/pages/routes/routes.component.js
@@ -109,7 +109,7 @@ export default class Routes extends Component {
     isNetworkUsed: PropTypes.bool,
     allAccountsOnNetworkAreEmpty: PropTypes.bool,
     isTestNet: PropTypes.bool,
-    currrentChainId: PropTypes.string,
+    currentChainId: PropTypes.string,
   };
 
   static contextTypes = {
@@ -376,7 +376,7 @@ export default class Routes extends Component {
 
     const shouldShowNetworkInfo =
       isUnlocked &&
-      currrentChainId &&
+      currentChainId &&
       !isTestNet &&
       !isNetworkUsed &&
       allAccountsOnNetworkAreEmpty;

--- a/ui/pages/routes/routes.component.js
+++ b/ui/pages/routes/routes.component.js
@@ -109,6 +109,7 @@ export default class Routes extends Component {
     isNetworkUsed: PropTypes.bool,
     allAccountsOnNetworkAreEmpty: PropTypes.bool,
     isTestNet: PropTypes.bool,
+    currrentChainId: PropTypes.string,
   };
 
   static contextTypes = {
@@ -366,6 +367,7 @@ export default class Routes extends Component {
       isNetworkUsed,
       allAccountsOnNetworkAreEmpty,
       isTestNet,
+      currrentChainId,
     } = this.props;
     const loadMessage =
       loadingMessage || isNetworkLoading
@@ -374,6 +376,7 @@ export default class Routes extends Component {
 
     const shouldShowNetworkInfo =
       isUnlocked &&
+      currrentChainId &&
       !isTestNet &&
       !isNetworkUsed &&
       allAccountsOnNetworkAreEmpty;

--- a/ui/pages/routes/routes.container.js
+++ b/ui/pages/routes/routes.container.js
@@ -46,7 +46,7 @@ function mapStateToProps(state) {
     sendStage: getSendStage(state),
     isNetworkUsed: getIsNetworkUsed(state),
     allAccountsOnNetworkAreEmpty: getAllAccountsOnNetworkAreEmpty(state),
-    isTestnet: getIsTestnet(state),
+    isTestNet: getIsTestnet(state),
     currentChainId: getCurrentChainId(state),
   };
 }

--- a/ui/pages/routes/routes.container.js
+++ b/ui/pages/routes/routes.container.js
@@ -47,7 +47,7 @@ function mapStateToProps(state) {
     isNetworkUsed: getIsNetworkUsed(state),
     allAccountsOnNetworkAreEmpty: getAllAccountsOnNetworkAreEmpty(state),
     isTestnet: getIsTestnet(state),
-    currrentChainId: getCurrentChainId(state),
+    currentChainId: getCurrentChainId(state),
   };
 }
 

--- a/ui/pages/routes/routes.container.js
+++ b/ui/pages/routes/routes.container.js
@@ -9,6 +9,7 @@ import {
   isNetworkLoading,
   getTheme,
   getIsTestnet,
+  getCurrentChainId,
 } from '../../selectors';
 import {
   lockMetamask,
@@ -46,6 +47,7 @@ function mapStateToProps(state) {
     isNetworkUsed: getIsNetworkUsed(state),
     allAccountsOnNetworkAreEmpty: getAllAccountsOnNetworkAreEmpty(state),
     isTestnet: getIsTestnet(state),
+    currrentChainId: getCurrentChainId(state),
   };
 }
 


### PR DESCRIPTION
Fixes https://github.com/MetaMask/metamask-extension/issues/15854

For a brief period of time when swtiching networks, the `getIsTestnet` selector returns undefined because the chainId is undefined. This PR ensures the New Network Info popup does not display if the chainId is undefiend.