### PR TITLE
Ensure the seed phrase reminder is displayed with precedence over the network deprecation warning

### DIFF
--- a/ui/pages/home/home.component.js
+++ b/ui/pages/home/home.component.js
@@ -612,6 +612,7 @@ export default class Home extends PureComponent {
       showRecoveryPhraseReminder,
       firstTimeFlowType,
       completedOnboarding,
+      shouldShowSeedPhraseReminder,
     } = this.props;
 
     if (forgottenPassword) {
@@ -658,7 +659,11 @@ export default class Home extends PureComponent {
               subHeader={
                 <Tooltip
                   position="bottom"
-                  open={!process.env.IN_TEST && showPortfolioTooltip}
+                  open={
+                    !process.env.IN_TEST &&
+                    !shouldShowSeedPhraseReminder &&
+                    showPortfolioTooltip
+                  }
                   interactive
                   theme="home__subheader-link--tooltip"
                   html={

--- a/ui/pages/home/home.container.js
+++ b/ui/pages/home/home.container.js
@@ -3,7 +3,6 @@ import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
 import {
   activeTabHasPermissions,
-  getCurrentEthBalance,
   getFirstPermissionRequest,
   ///: BEGIN:ONLY_INCLUDE_IN(flask)
   getFirstSnapUpdateRequest,
@@ -24,6 +23,7 @@ import {
   getNewCollectibleAddedMessage,
   getNewTokensImported,
   getShowPortfolioTooltip,
+  getShouldShowSeedPhraseReminder,
 } from '../../selectors';
 
 import {
@@ -72,18 +72,15 @@ const mapStateToProps = (state) => {
   const {
     suggestedAssets,
     seedPhraseBackedUp,
-    tokens,
     threeBoxSynced,
     showRestorePrompt,
     selectedAddress,
     connectedStatusPopoverHasBeenShown,
     defaultHomeActiveTabName,
     swapsState,
-    dismissSeedBackUpReminder,
     firstTimeFlowType,
     completedOnboarding,
   } = metamask;
-  const accountBalance = getCurrentEthBalance(state);
   const { forgottenPassword, threeBoxLastUpdated } = appState;
   const totalUnapprovedCount = getTotalUnapprovedCount(state);
   const swapsEnabled = getSwapsFeatureIsLive(state);
@@ -123,10 +120,7 @@ const mapStateToProps = (state) => {
     suggestedAssets,
     swapsEnabled,
     unconfirmedTransactionsCount: unconfirmedTransactionsCountSelector(state),
-    shouldShowSeedPhraseReminder:
-      seedPhraseBackedUp === false &&
-      (parseInt(accountBalance, 16) > 0 || tokens.length > 0) &&
-      dismissSeedBackUpReminder === false,
+    shouldShowSeedPhraseReminder: getShouldShowSeedPhraseReminder(state),
     isPopup,
     isNotification,
     threeBoxSynced,

--- a/ui/pages/routes/routes.component.js
+++ b/ui/pages/routes/routes.component.js
@@ -110,6 +110,7 @@ export default class Routes extends Component {
     allAccountsOnNetworkAreEmpty: PropTypes.bool,
     isTestNet: PropTypes.bool,
     currentChainId: PropTypes.string,
+    shouldShowSeedPhraseReminder: PropTypes.bool,
   };
 
   static contextTypes = {
@@ -368,6 +369,7 @@ export default class Routes extends Component {
       allAccountsOnNetworkAreEmpty,
       isTestNet,
       currentChainId,
+      shouldShowSeedPhraseReminder,
     } = this.props;
     const loadMessage =
       loadingMessage || isNetworkLoading
@@ -379,6 +381,7 @@ export default class Routes extends Component {
       currentChainId &&
       !isTestNet &&
       !isNetworkUsed &&
+      !shouldShowSeedPhraseReminder &&
       allAccountsOnNetworkAreEmpty;
 
     const windowType = getEnvironmentType();

--- a/ui/pages/routes/routes.component.js
+++ b/ui/pages/routes/routes.component.js
@@ -381,10 +381,14 @@ export default class Routes extends Component {
       currentChainId &&
       !isTestNet &&
       !isNetworkUsed &&
-      !shouldShowSeedPhraseReminder &&
       allAccountsOnNetworkAreEmpty;
 
     const windowType = getEnvironmentType();
+
+    const shouldShowNetworkDeprecationWarning =
+      windowType !== ENVIRONMENT_TYPE_NOTIFICATION &&
+      isUnlocked &&
+      !shouldShowSeedPhraseReminder;
 
     return (
       <div
@@ -401,9 +405,7 @@ export default class Routes extends Component {
           }
         }}
       >
-        {windowType !== ENVIRONMENT_TYPE_NOTIFICATION && isUnlocked && (
-          <DeprecatedTestNetworks />
-        )}
+        {shouldShowNetworkDeprecationWarning && <DeprecatedTestNetworks />}
         {shouldShowNetworkInfo && <NewNetworkInfo />}
         <QRHardwarePopover />
         <Modal />

--- a/ui/pages/routes/routes.component.js
+++ b/ui/pages/routes/routes.component.js
@@ -111,6 +111,7 @@ export default class Routes extends Component {
     isTestNet: PropTypes.bool,
     currentChainId: PropTypes.string,
     shouldShowSeedPhraseReminder: PropTypes.bool,
+    portfolioTooltipIsBeingShown: PropTypes.bool,
   };
 
   static contextTypes = {
@@ -370,6 +371,7 @@ export default class Routes extends Component {
       isTestNet,
       currentChainId,
       shouldShowSeedPhraseReminder,
+      portfolioTooltipIsBeingShown,
     } = this.props;
     const loadMessage =
       loadingMessage || isNetworkLoading
@@ -388,7 +390,8 @@ export default class Routes extends Component {
     const shouldShowNetworkDeprecationWarning =
       windowType !== ENVIRONMENT_TYPE_NOTIFICATION &&
       isUnlocked &&
-      !shouldShowSeedPhraseReminder;
+      !shouldShowSeedPhraseReminder &&
+      !portfolioTooltipIsBeingShown;
 
     return (
       <div

--- a/ui/pages/routes/routes.container.js
+++ b/ui/pages/routes/routes.container.js
@@ -10,6 +10,7 @@ import {
   getTheme,
   getIsTestnet,
   getCurrentChainId,
+  getShouldShowSeedPhraseReminder,
 } from '../../selectors';
 import {
   lockMetamask,
@@ -48,6 +49,7 @@ function mapStateToProps(state) {
     allAccountsOnNetworkAreEmpty: getAllAccountsOnNetworkAreEmpty(state),
     isTestNet: getIsTestnet(state),
     currentChainId: getCurrentChainId(state),
+    shouldShowSeedPhraseReminder: getShouldShowSeedPhraseReminder(state),
   };
 }
 

--- a/ui/pages/routes/routes.container.js
+++ b/ui/pages/routes/routes.container.js
@@ -11,6 +11,7 @@ import {
   getIsTestnet,
   getCurrentChainId,
   getShouldShowSeedPhraseReminder,
+  getShowPortfolioTooltip,
 } from '../../selectors';
 import {
   lockMetamask,
@@ -50,6 +51,7 @@ function mapStateToProps(state) {
     isTestNet: getIsTestnet(state),
     currentChainId: getCurrentChainId(state),
     shouldShowSeedPhraseReminder: getShouldShowSeedPhraseReminder(state),
+    portfolioTooltipIsBeingShown: getShowPortfolioTooltip(state),
   };
 }
 

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -1218,7 +1218,8 @@ export function getAllAccountsOnNetworkAreEmpty(state) {
 }
 
 export function getShouldShowSeedPhraseReminder(state) {
-  const { tokens, seedPhraseBackedUp, dismissSeedBackUpReminder } = state;
+  const { tokens, seedPhraseBackedUp, dismissSeedBackUpReminder } =
+    state.metamask;
   const accountBalance = getCurrentEthBalance(state) ?? 0;
   return (
     seedPhraseBackedUp === false &&

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -1216,3 +1216,13 @@ export function getAllAccountsOnNetworkAreEmpty(state) {
 
   return hasNoNativeFundsOnAnyAccounts && hasNoTokens;
 }
+
+export function getShouldShowSeedPhraseReminder(state) {
+  const { tokens, seedPhraseBackedUp, dismissSeedBackUpReminder } = state;
+  const accountBalance = getCurrentEthBalance(state);
+  return (
+    seedPhraseBackedUp === false &&
+    (parseInt(accountBalance, 16) > 0 || tokens.length > 0) &&
+    dismissSeedBackUpReminder === false
+  );
+}

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -435,7 +435,7 @@ export function getTargetAccountWithSendEtherInfo(state, targetAddress) {
 }
 
 export function getCurrentEthBalance(state) {
-  return getCurrentAccountWithSendEtherInfo(state).balance;
+  return getCurrentAccountWithSendEtherInfo(state)?.balance;
 }
 
 export function getGasIsLoading(state) {
@@ -1219,7 +1219,7 @@ export function getAllAccountsOnNetworkAreEmpty(state) {
 
 export function getShouldShowSeedPhraseReminder(state) {
   const { tokens, seedPhraseBackedUp, dismissSeedBackUpReminder } = state;
-  const accountBalance = getCurrentEthBalance(state);
+  const accountBalance = getCurrentEthBalance(state) ?? 0;
   return (
     seedPhraseBackedUp === false &&
     (parseInt(accountBalance, 16) > 0 || tokens.length > 0) &&


### PR DESCRIPTION
Fixes https://github.com/MetaMask/metamask-extension/issues/15859
Fixes https://github.com/MetaMask/metamask-extension/issues/15872

If the seed phrase backup reminder is shown, we shouldn't show the network deprecation warning or the portfolio tooltip, and the portfolio tooltip will take precedence over the network deprecation warning (because it is permanently dismissible, but the network deprecation warning is not). This PR updates the logic controlling the display of these notifications accordingly