### PR TITLE
Dark Mode: Set to default based on user preferred scheme

### DIFF
--- a/app/scripts/controllers/preferences.js
+++ b/app/scripts/controllers/preferences.js
@@ -9,8 +9,8 @@ import {
 } from '../../../shared/constants/network';
 import { isPrefixedFormattedHexString } from '../../../shared/modules/network.utils';
 import { LEDGER_TRANSPORT_TYPES } from '../../../shared/constants/hardware-wallets';
-import { NETWORK_EVENTS } from './network';
 import { THEME_TYPE } from '../../../ui/pages/settings/experimental-tab/experimental-tab.constant';
+import { NETWORK_EVENTS } from './network';
 
 export default class PreferencesController {
   /**

--- a/app/scripts/controllers/preferences.js
+++ b/app/scripts/controllers/preferences.js
@@ -9,7 +9,7 @@ import {
 } from '../../../shared/constants/network';
 import { isPrefixedFormattedHexString } from '../../../shared/modules/network.utils';
 import { LEDGER_TRANSPORT_TYPES } from '../../../shared/constants/hardware-wallets';
-import { THEME_TYPE } from '../../../ui/pages/settings/experimental-tab/experimental-tab.constant';
+import { THEME_TYPE } from '../../../ui/pages/settings/settings-tab/settings-tab.constant';
 import { NETWORK_EVENTS } from './network';
 
 export default class PreferencesController {

--- a/app/scripts/controllers/preferences.js
+++ b/app/scripts/controllers/preferences.js
@@ -10,6 +10,7 @@ import {
 import { isPrefixedFormattedHexString } from '../../../shared/modules/network.utils';
 import { LEDGER_TRANSPORT_TYPES } from '../../../shared/constants/hardware-wallets';
 import { NETWORK_EVENTS } from './network';
+import { THEME_TYPE } from '../../../ui/pages/settings/experimental-tab/experimental-tab.constant';
 
 export default class PreferencesController {
   /**
@@ -69,9 +70,9 @@ export default class PreferencesController {
       ledgerTransportType: window.navigator.hid
         ? LEDGER_TRANSPORT_TYPES.WEBHID
         : LEDGER_TRANSPORT_TYPES.U2F,
-      theme: 'light',
       improvedTokenAllowanceEnabled: false,
       transactionSecurityCheckEnabled: false,
+      theme: THEME_TYPE.OS,
       ...opts.initState,
     };
 

--- a/app/scripts/controllers/preferences.test.js
+++ b/app/scripts/controllers/preferences.test.js
@@ -388,14 +388,14 @@ describe('preferences controller', function () {
   });
 
   describe('setTheme', function () {
-    it('should default to value "light"', function () {
+    it('should default to value "OS"', function () {
       const state = preferencesController.store.getState();
-      assert.equal(state.theme, 'light');
+      assert.equal(state.theme, 'os');
     });
 
     it('should set the setTheme property in state', function () {
       const state = preferencesController.store.getState();
-      assert.equal(state.theme, 'light');
+      assert.equal(state.theme, 'os');
       preferencesController.setTheme('dark');
       assert.equal(preferencesController.store.getState().theme, 'dark');
     });


### PR DESCRIPTION
This code sets the default theme to dark if the user's system signals it prefers dark.

## Manual testing
1. Set your OS system preference to dark mode
2. Install MM
3. See dark onboarding
4. Set your OS system preference to light mode
5. Install MM
6. See light onboarding