### PR TITLE
Properly configure ethereumjs Common for Sepolia network

### DIFF
--- a/app/scripts/controllers/transactions/index.js
+++ b/app/scripts/controllers/transactions/index.js
@@ -256,7 +256,7 @@ export default class TransactionController extends EventEmitter {
     // type will be one of our default network names or 'rpc'. the default
     // network names are sufficient configuration, simply pass the name as the
     // chain argument in the constructor.
-    if (type !== NETWORK_TYPES.RPC) {
+    if (type !== NETWORK_TYPES.RPC && type !== NETWORK_TYPES.SEPOLIA) {
       return new Common({
         chain: type,
         hardfork,


### PR DESCRIPTION
~~This update includes the addition of sepolia to the ethereum-js configuration, allowing sepolia to work with ethereumjs-tx, thereby allowing transactions to work on sepolia.~~

Updating ethereum-js Common produce failures in our unit tests that I can't understand. I have now updated this for a simpler fix, but this fix will be temporary, to unblock v10.19.0. The fix simply treats sepolia as a custom network for the sake of configuring the chain in the transaction controller. In the future, we will update ethereumjs Common, resolve whatever is breaking in that update, and the remove the change in this PR.

