### PR TITLE
Fixing hex address display bug when editing transaction

### DIFF
--- a/ui/ducks/send/send.js
+++ b/ui/ducks/send/send.js
@@ -1714,8 +1714,10 @@ export function editExistingTransaction(assetType, transactionId) {
             ...draftTransactionInitialState.recipient,
             address: transaction.txParams.to,
             nickname:
-              getAddressBookEntryOrAccountName(state, transaction.txParams.to)
-                ?.name ?? '',
+              getAddressBookEntryOrAccountName(
+                state,
+                transaction.txParams.to,
+              ) ?? '',
           },
           amount: {
             ...draftTransactionInitialState.amount,
@@ -1739,8 +1741,7 @@ export function editExistingTransaction(assetType, transactionId) {
       const tokenAmountInDec =
         assetType === ASSET_TYPES.TOKEN ? getTokenValueParam(tokenData) : '1';
       const address = getTokenAddressParam(tokenData);
-      const nickname =
-        getAddressBookEntryOrAccountName(state, address)?.name ?? '';
+      const nickname = getAddressBookEntryOrAccountName(state, address) ?? '';
 
       const tokenAmountInHex = addHexPrefix(
         conversionUtil(tokenAmountInDec, {

--- a/ui/ducks/send/send.test.js
+++ b/ui/ducks/send/send.test.js
@@ -2460,7 +2460,7 @@ describe('Send Slice', () => {
             recipient: {
               address: '0xRecipientAddress',
               error: null,
-              nickname: '',
+              nickname: '0xRecipientAddress',
               warning: null,
               recipientWarningAcknowledged: false,
               type: '',
@@ -2605,7 +2605,7 @@ describe('Send Slice', () => {
             recipient: {
               address: BURN_ADDRESS,
               error: null,
-              nickname: '',
+              nickname: BURN_ADDRESS,
               warning: null,
               type: '',
               recipientWarningAcknowledged: false,
@@ -2797,7 +2797,7 @@ describe('Send Slice', () => {
             address: BURN_ADDRESS,
             error: null,
             warning: null,
-            nickname: '',
+            nickname: BURN_ADDRESS,
             type: '',
             recipientWarningAcknowledged: false,
           },

--- a/ui/pages/send/send-content/add-recipient/add-recipient.component.js
+++ b/ui/pages/send/send-content/add-recipient/add-recipient.component.js
@@ -28,7 +28,7 @@ export default class AddRecipient extends Component {
     isUsingMyAccountsForRecipientSearch: PropTypes.bool,
     recipient: PropTypes.shape({
       address: PropTypes.string,
-      nickname: PropTypes.nickname,
+      nickname: PropTypes.string,
       error: PropTypes.string,
       warning: PropTypes.string,
     }),


### PR DESCRIPTION
Fixes: https://github.com/MetaMask/metamask-extension/issues/15841

## Test plan
Defined in issue

## Explanation
When updating a draft transaction, the function `getAddressBookEntryOrAccountName` was being incorrectly used, as a `name` property was expected to be returned. The function returns a string that is either the name if available, or the address:

https://github.com/MetaMask/metamask-extension/blob/789c06a5b7aaa477b25ccce966d2aebd5eb25118/ui/selectors/selectors.js#L394

## Video
https://user-images.githubusercontent.com/8732757/190955514-1617c482-c976-4aac-a213-5508105cc7d2.mov

