### PR TITLE
Get ether from a faucet - fix message

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -1526,7 +1526,7 @@
     "message": "Get Ether"
   },
   "getEtherFromFaucet": {
-    "message": "Get Ether from a faucet for the $1",
+    "message": "Get Ether from a faucet for the $1 network.",
     "description": "Displays network name for Ether faucet"
   },
   "getStarted": {


### PR DESCRIPTION
## Explanation
On the Buy prompt for test networks, we see an unfinished message saying `Get Ether from a faucet for the $Network`. This PR adds the end of the sentence and a full stop.

## Screenshots/Screencaps

<!-- If you're making a change to the UI, make sure to capture a screenshot or a short video showing off your work! -->

### Before

<!-- How did the UI you changed look before your changes? Drag your file(s) below this line: -->

![get-ether-from-faucet-before](https://user-images.githubusercontent.com/54408225/191010552-50e094f9-d2c0-42ec-9b52-106f6ecf8855.png)


### After

![get-ether-from-faucet-after](https://user-images.githubusercontent.com/54408225/191010587-a4e21bb4-197d-4f23-b224-fa16d8f40804.png)



<!-- How does it look now? Drag your file(s) below this line: -->

## Manual Testing Steps

<!--
How should reviewers and QA manually test your changes? For instance:

- Go to this screen
- Do this
- Then do this
-->

## Pre-Merge Checklist

- [ ] PR template is filled out
- [ ] **IF** this PR fixes a bug, a test that _would have_ caught the bug has been added
- [ ] PR is linked to the appropriate GitHub issue
- [ ] PR has been added to the appropriate release Milestone

### + If there are functional changes:

- [ ] Manual testing complete & passed
- [ ] "Extension QA Board" label has been applied
