### PR TITLE
Revert #15823

### DIFF
--- a/ui/components/app/asset-list/asset-list.js
+++ b/ui/components/app/asset-list/asset-list.js
@@ -11,7 +11,7 @@ import {
   getShouldShowFiat,
   getNativeCurrencyImage,
   getDetectedTokensInCurrentNetwork,
-  getDisplayDetectedTokensLink,
+  getIstokenDetectionInactiveOnNonMainnetSupportedNetwork,
 } from '../../../selectors';
 import { getNativeCurrency } from '../../../ducks/metamask/metamask';
 import { useCurrencyDisplay } from '../../../hooks/useCurrencyDisplay';
@@ -66,7 +66,9 @@ const AssetList = ({ onClickAsset }) => {
 
   const primaryTokenImage = useSelector(getNativeCurrencyImage);
   const detectedTokens = useSelector(getDetectedTokensInCurrentNetwork) || [];
-  const displayDetectedTokensLink = useSelector(getDisplayDetectedTokensLink);
+  const istokenDetectionInactiveOnNonMainnetSupportedNetwork = useSelector(
+    getIstokenDetectionInactiveOnNonMainnetSupportedNetwork,
+  );
 
   return (
     <>
@@ -94,9 +96,10 @@ const AssetList = ({ onClickAsset }) => {
           });
         }}
       />
-      {detectedTokens.length > 0 && displayDetectedTokensLink && (
-        <DetectedTokensLink setShowDetectedTokens={setShowDetectedTokens} />
-      )}
+      {detectedTokens.length > 0 &&
+        !istokenDetectionInactiveOnNonMainnetSupportedNetwork && (
+          <DetectedTokensLink setShowDetectedTokens={setShowDetectedTokens} />
+        )}
       <Box marginTop={detectedTokens.length > 0 ? 0 : 4}>
         <Box justifyContent={JUSTIFY_CONTENT.CENTER}>
           <Typography

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -1136,21 +1136,6 @@ export function getIstokenDetectionInactiveOnNonMainnetSupportedNetwork(state) {
 }
 
 /**
- * To check if the token detection is ON and either a dynamic list is available
- * or the user is on mainnet
- *
- * @param {*} state
- * @returns Boolean
- */
-export function getDisplayDetectedTokensLink(state) {
-  const useTokenDetection = getUseTokenDetection(state);
-  const isMainnet = getIsMainnet(state);
-  const isDynamicTokenListAvailable = getIsDynamicTokenListAvailable(state);
-
-  return (isDynamicTokenListAvailable || isMainnet) && useTokenDetection;
-}
-
-/**
  * To get the `customNetworkListEnabled` value which determines whether we use the custom network list
  *
  * @param {*} state


### PR DESCRIPTION
Reverts #15823

That PR was an attempt to fix [MetaMask/metamask-extension#15790](https://github.com/MetaMask/metamask-extension/issues/15790)

But as @NiranjanaBinoy explained:

> we are turning OFF token detection when the toggle is OFF. During the development phase, we decided to keep token detection running for Mainnet (using static token list) alone when the toggle is OFF to preserve the existing functionality. If we are deciding to turn Token detection altogether when the toggle is OFF, then at the least:
we need to update the description copy at the token detection toggle as the current one is saying we have token detection running the Mainnet when the toggle is OFF
A few tweaks in the detect-token controller otherwise there might be inconsistent behaviour when the user turns the toggle on based on the difference in tokens available in the static list and dynamic list.

Instead, we will revert these changes, and then just change the copy of the token detection toggle, to make clear that when the toggle is off, detection still happens on maintain with the static list tokens. This is consistent with todays behaviour and original specs for token detection