### PR TITLE
Update copy on token detection title and desc in advanced settings

### DIFF
--- a/app/_locales/de/messages.json
+++ b/app/_locales/de/messages.json
@@ -3658,12 +3658,6 @@
   "tokenDetails": {
     "message": "Token-Details"
   },
-  "tokenDetection": {
-    "message": "Token-Erkennung"
-  },
-  "tokenDetectionAlertMessage": {
-    "message": "Die Token-Erkennung ist derzeit für $1 verfügbar. $2"
-  },
   "tokenId": {
     "message": "Token-ID"
   },

--- a/app/_locales/el/messages.json
+++ b/app/_locales/el/messages.json
@@ -3714,12 +3714,6 @@
   "tokenDetails": {
     "message": "Λεπτομέρειες token"
   },
-  "tokenDetection": {
-    "message": "Εντοπισμός token"
-  },
-  "tokenDetectionAlertMessage": {
-    "message": "Ο εντοπισμός token είναι επί του παρόντος διαθέσιμος στο $1. $2"
-  },
   "tokenId": {
     "message": "Αναγνωριστικό token"
   },

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -1235,6 +1235,15 @@
     "message": "The RPC URL you have entered returned a different chain ID ($1). Please update the Chain ID to match the RPC URL of the network you are trying to add.",
     "description": "$1 is the return value of eth_chainId from an RPC endpoint"
   },
+  "enhancedTokenDetection": {
+    "message": "Enhanced token detection"
+  },
+  "enhancedTokenDetectionAlertMessage": {
+    "message": "Enhanced token detection is currently available on $1. $2"
+  },
+  "enhancedTokenDetectionDescription": {
+    "message": "ConsenSys' token API aggregates a list of tokens from various third party token lists. When turned on, tokens will be automatically detected, and searchable, on Ethereum mainnet, Binance, Polygon and Avalanche. When turned off, automatic detection and search can only be done on Ethereum mainnet."
+  },
   "ensIllegalCharacter": {
     "message": "Illegal character for ENS."
   },
@@ -3947,15 +3956,6 @@
   },
   "tokenDetails": {
     "message": "Token details"
-  },
-  "tokenDetection": {
-    "message": "Token detection"
-  },
-  "tokenDetectionAlertMessage": {
-    "message": "Token detection is currently available on $1. $2"
-  },
-  "tokenDetectionDescription": {
-    "message": "ConsenSys' token API aggregates a list of tokens from various third party token lists. When turned on, tokens will be automatically detected, and searchable, on  Ethereum mainnet, Binance, Polygon and Avalanche. When turned off, you will still be able to search for tokens on Ethereum mainnet using MetaMask's legacy token list."
   },
   "tokenFoundTitle": {
     "message": "1 new token found"

--- a/app/_locales/es/messages.json
+++ b/app/_locales/es/messages.json
@@ -3714,12 +3714,6 @@
   "tokenDetails": {
     "message": "Detalles del token"
   },
-  "tokenDetection": {
-    "message": "Detección del token"
-  },
-  "tokenDetectionAlertMessage": {
-    "message": "La detección de tókens está actualmente disponible en $1. $2"
-  },
   "tokenId": {
     "message": "Identificador de Token"
   },

--- a/app/_locales/fr/messages.json
+++ b/app/_locales/fr/messages.json
@@ -3714,12 +3714,6 @@
   "tokenDetails": {
     "message": "Détails du token"
   },
-  "tokenDetection": {
-    "message": "Détection du token"
-  },
-  "tokenDetectionAlertMessage": {
-    "message": "La détection du token est actuellement disponible sur $1. $2"
-  },
   "tokenId": {
     "message": "ID de token"
   },

--- a/app/_locales/hi/messages.json
+++ b/app/_locales/hi/messages.json
@@ -3714,12 +3714,6 @@
   "tokenDetails": {
     "message": "टोकन विवरण"
   },
-  "tokenDetection": {
-    "message": "टोकन डिटेक्शन"
-  },
-  "tokenDetectionAlertMessage": {
-    "message": "फिलहाल टोकन डिटेक्शन $1 पर उपलब्ध है। $2"
-  },
   "tokenId": {
     "message": "टोकन आइडी"
   },

--- a/app/_locales/id/messages.json
+++ b/app/_locales/id/messages.json
@@ -3714,12 +3714,6 @@
   "tokenDetails": {
     "message": "Detail token"
   },
-  "tokenDetection": {
-    "message": "Deteksi token"
-  },
-  "tokenDetectionAlertMessage": {
-    "message": "Saat ini deteksi token tersedia di $1. $2"
-  },
   "tokenId": {
     "message": "ID token"
   },

--- a/app/_locales/ja/messages.json
+++ b/app/_locales/ja/messages.json
@@ -3714,12 +3714,6 @@
   "tokenDetails": {
     "message": "トークンの詳細"
   },
-  "tokenDetection": {
-    "message": "トークン検出"
-  },
-  "tokenDetectionAlertMessage": {
-    "message": "トークン検出は現在 $1 で利用可能です。$2"
-  },
   "tokenId": {
     "message": "トークン ID"
   },

--- a/app/_locales/ko/messages.json
+++ b/app/_locales/ko/messages.json
@@ -3714,12 +3714,6 @@
   "tokenDetails": {
     "message": "토큰 상세 정보"
   },
-  "tokenDetection": {
-    "message": "토큰 감지"
-  },
-  "tokenDetectionAlertMessage": {
-    "message": "토큰 감지 기능은 현재 $1. $2에서 사용할 수 있습니다."
-  },
   "tokenId": {
     "message": "토큰 ID"
   },

--- a/app/_locales/pt/messages.json
+++ b/app/_locales/pt/messages.json
@@ -3714,12 +3714,6 @@
   "tokenDetails": {
     "message": "Dados do token"
   },
-  "tokenDetection": {
-    "message": "Detecção de token"
-  },
-  "tokenDetectionAlertMessage": {
-    "message": "A detecção de tokens está atualmente disponível em $1. $2"
-  },
   "tokenId": {
     "message": "ID do token"
   },

--- a/app/_locales/ru/messages.json
+++ b/app/_locales/ru/messages.json
@@ -3714,12 +3714,6 @@
   "tokenDetails": {
     "message": "Сведения о токене"
   },
-  "tokenDetection": {
-    "message": "Обнаружение токена"
-  },
-  "tokenDetectionAlertMessage": {
-    "message": "Обнаружение токена в настоящее время доступно на $1. $2"
-  },
   "tokenId": {
     "message": "Ид. токена"
   },

--- a/app/_locales/tl/messages.json
+++ b/app/_locales/tl/messages.json
@@ -3714,12 +3714,6 @@
   "tokenDetails": {
     "message": "Mga detalye ng token"
   },
-  "tokenDetection": {
-    "message": "Pagtuklas sa token"
-  },
-  "tokenDetectionAlertMessage": {
-    "message": "Ang pagtukoy ng token ay kasalukuyang magagamit sa $1. $2"
-  },
   "tokenId": {
     "message": "Token ID"
   },

--- a/app/_locales/tr/messages.json
+++ b/app/_locales/tr/messages.json
@@ -3714,12 +3714,6 @@
   "tokenDetails": {
     "message": "Token bilgileri"
   },
-  "tokenDetection": {
-    "message": "Token algılama"
-  },
-  "tokenDetectionAlertMessage": {
-    "message": "Token algılama şu anda $1 üzerinden kullanılabilir. $2"
-  },
   "tokenId": {
     "message": "Token Kimliği"
   },

--- a/app/_locales/vi/messages.json
+++ b/app/_locales/vi/messages.json
@@ -3714,12 +3714,6 @@
   "tokenDetails": {
     "message": "Chi tiết token"
   },
-  "tokenDetection": {
-    "message": "Phát hiện token"
-  },
-  "tokenDetectionAlertMessage": {
-    "message": "Tính năng phát hiện token hiện có sẵn trên $1. $2"
-  },
   "tokenId": {
     "message": "ID Token"
   },

--- a/ui/helpers/constants/settings.js
+++ b/ui/helpers/constants/settings.js
@@ -322,8 +322,8 @@ export const SETTINGS_CONSTANTS = [
   },
   {
     tabMessage: (t) => t('advanced'),
-    sectionMessage: (t) => t('tokenDetection'),
-    descriptionMessage: (t) => t('tokenDetectionDescription'),
+    sectionMessage: (t) => t('enhancedTokenDetection'),
+    descriptionMessage: (t) => t('enhancedTokenDetectionDescription'),
     route: `${ADVANCED_ROUTE}#token-description`,
     icon: 'fas fa-sliders-h',
   },

--- a/ui/helpers/utils/settings-search.test.js
+++ b/ui/helpers/utils/settings-search.test.js
@@ -113,10 +113,10 @@ const t = (key) => {
       return 'Localhost 8545';
     case 'experimental':
       return 'Experimental';
-    case 'tokenDetection':
-      return 'Token detection';
-    case 'tokenDetectionDescription':
-      return "ConsenSys' token API aggregates a list of tokens from various third party token lists. When turned on, tokens will be automatically detected, and searchable, on  Ethereum mainnet, Binance, Polygon and Avalanche. When turned off, you will still be able to search for tokens on Ethereum mainnet using MetaMask's legacy token list.";
+    case 'enhancedTokenDetection':
+      return 'Enhanced token detection';
+    case 'enhancedTokenDetectionDescription':
+      return "ConsenSys' token API aggregates a list of tokens from various third party token lists. When turned on, tokens will be automatically detected, and searchable, on Ethereum mainnet, Binance, Polygon and Avalanche. When turned off, automatic detection and search can only be done on Ethereum mainnet.";
     case 'enableEIP1559V2':
       return 'Enable enhanced gas fee UI';
     case 'enableEIP1559V2Description':

--- a/ui/pages/import-token/import-token.component.js
+++ b/ui/pages/import-token/import-token.component.js
@@ -581,7 +581,7 @@ class ImportToken extends Component {
       <div className="import-token__search-token">
         {!useTokenDetection && (
           <ActionableMessage
-            message={t('tokenDetectionAlertMessage', [
+            message={t('enhancedTokenDetectionAlertMessage', [
               networkName,
               <Button
                 type="link"

--- a/ui/pages/settings/advanced-tab/advanced-tab.component.js
+++ b/ui/pages/settings/advanced-tab/advanced-tab.component.js
@@ -827,9 +827,9 @@ export default class AdvancedTab extends PureComponent {
         data-testid="advanced-setting-token-detection"
       >
         <div className="settings-page__content-item">
-          <span>{t('tokenDetection')}</span>
+          <span>{t('enhancedTokenDetection')}</span>
           <div className="settings-page__content-description">
-            {t('tokenDetectionDescription')}
+            {t('enhancedTokenDetectionDescription')}
           </div>
         </div>
         <div className="settings-page__content-item">


### PR DESCRIPTION
- Updating copy on token detection title to `Enhanced token detection`
- Updating the copy on token detection desc to explain token detection will be working on Mainnet using legacy token list when token detection toggle is OFF.
- Updating the token detection alert on the Search tab of import tokens to show that you can enable enhanced token detection on the dynamic token list from settings for Mainnet.