### PR TITLE
Bump @metamask/etherscan-link from 2.1.0 to 2.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
     "@metamask/eth-ledger-bridge-keyring": "^0.13.0",
     "@metamask/eth-json-rpc-infura": "^7.0.0",
     "@metamask/eth-token-tracker": "^4.0.0",
-    "@metamask/etherscan-link": "^2.1.0",
+    "@metamask/etherscan-link": "^2.2.0",
     "@metamask/jazzicon": "^2.0.0",
     "@metamask/logo": "^3.1.1",
     "@metamask/metamask-eth-abis": "^3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3019,10 +3019,10 @@
     human-standard-token-abi "^1.0.2"
     safe-event-emitter "^1.0.1"
 
-"@metamask/etherscan-link@^2.1.0":
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/@metamask/etherscan-link/-/etherscan-link-2.1.0.tgz#c0be8e68445b7b83cf85bcc03a56cdf8e256c973"
-  integrity sha512-ADuWlTUkFfN2vXlz81Bg/0BA+XRor+CdK1055p6k7H6BLIPoDKn9SBOFld9haQFuR9cKh/JYHcnlSIv5R4fUEw==
+"@metamask/etherscan-link@^2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@metamask/etherscan-link/-/etherscan-link-2.2.0.tgz#76314d0c1405a0669fc4a0a19e0877bd3d0c389f"
+  integrity sha512-xUgehvgU+ZbzeJ44m4sUtsyf6Dwou+SlYhiKfi6lkRcbWh6Jl3TCi0YM9C7XWgxfnLSdQBO1ndvcp0kslKgMsA==
 
 "@metamask/execution-environments@^0.20.0":
   version "0.20.0"


### PR DESCRIPTION
Adds support for the Sepolia network (etherscan): https://github.com/MetaMask/etherscan-link/pull/60

https://github.com/MetaMask/etherscan-link/releases/tag/v2.2.0

Related issue: https://github.com/MetaMask/metamask-extension/issues/15853