### PR TITLE
Show correct base asset in Decrypt Request view

### DIFF
--- a/ui/pages/confirm-decrypt-message/confirm-decrypt-message.component.js
+++ b/ui/pages/confirm-decrypt-message/confirm-decrypt-message.component.js
@@ -35,6 +35,7 @@ export default class ConfirmDecryptMessage extends Component {
     requesterAddress: PropTypes.string,
     txData: PropTypes.object,
     subjectMetadata: PropTypes.object,
+    nativeCurrency: PropTypes.string.isRequired,
   };
 
   state = {
@@ -91,13 +92,13 @@ export default class ConfirmDecryptMessage extends Component {
   };
 
   renderBalance = () => {
-    const { conversionRate } = this.props;
+    const { conversionRate, nativeCurrency } = this.props;
     const {
       fromAccount: { balance },
     } = this.state;
     const { t } = this.context;
 
-    const balanceInEther = conversionUtil(balance, {
+    const nativeCurrencyBalance = conversionUtil(balance, {
       fromNumericBase: 'hex',
       toNumericBase: 'dec',
       fromDenomination: 'WEI',
@@ -111,7 +112,7 @@ export default class ConfirmDecryptMessage extends Component {
           {`${t('balance')}:`}
         </div>
         <div className="request-decrypt-message__balance-value">
-          {`${balanceInEther} ETH`}
+          {`${nativeCurrencyBalance} ${nativeCurrency}`}
         </div>
       </div>
     );

--- a/ui/pages/confirm-decrypt-message/confirm-decrypt-message.container.js
+++ b/ui/pages/confirm-decrypt-message/confirm-decrypt-message.container.js
@@ -15,6 +15,7 @@ import {
 } from '../../selectors';
 import { clearConfirmTransaction } from '../../ducks/confirm-transaction/confirm-transaction.duck';
 import { getMostRecentOverviewPage } from '../../ducks/history/history';
+import { getNativeCurrency } from '../../ducks/metamask/metamask';
 import ConfirmDecryptMessage from './confirm-decrypt-message.component';
 
 function mapStateToProps(state) {
@@ -40,6 +41,7 @@ function mapStateToProps(state) {
     requesterAddress: null,
     conversionRate: conversionRateSelector(state),
     mostRecentOverviewPage: getMostRecentOverviewPage(state),
+    nativeCurrency: getNativeCurrency(state),
   };
 }
 


### PR DESCRIPTION
Fixes: https://github.com/MetaMask/metamask-extension/issues/15866

## Test Plan
Defined in issue

On Polygon:
<img width="364" alt="Screen Shot 2022-09-19 at 10 37 31 PM" src="https://user-images.githubusercontent.com/8732757/191176536-b3c01d45-43f7-4562-b2a9-2284d3f19658.png">

<img width="359" alt="Screen Shot 2022-09-19 at 10 38 00 PM" src="https://user-images.githubusercontent.com/8732757/191176539-7b92aed9-e897-40a3-b0d8-d47ca6050311.png">

On ETH net (Rinkeby):
<img width="361" alt="Screen Shot 2022-09-19 at 10 38 42 PM" src="https://user-images.githubusercontent.com/8732757/191176641-638c0781-92bb-491b-979c-819660675442.png">
