### PR TITLE
Fixing ENS input styling for confusable chars

### DIFF
--- a/ui/components/ui/confusable/confusable.component.js
+++ b/ui/components/ui/confusable/confusable.component.js
@@ -18,7 +18,7 @@ const Confusable = ({ input }) => {
     return (
       <Tooltip
         key={index.toString()}
-        as="span"
+        tag="span"
         position="top"
         title={
           zeroWidth


### PR DESCRIPTION
Fixes: https://github.com/MetaMask/metamask-extension/issues/15886

## Test Plan
Defined in issue

By designating the `<Tooltip/>` wrapper tag as a `span` we get inline behavior for confusable chars.

<img width="414" alt="Screen Shot 2022-09-20 at 9 03 40 AM" src="https://user-images.githubusercontent.com/8732757/191309145-c810c8dd-f5f1-465d-b1ed-9e2aa67d1965.png">

<img width="413" alt="Screen Shot 2022-09-20 at 9 04 44 AM" src="https://user-images.githubusercontent.com/8732757/191309150-f3106443-ef42-4693-93c6-cff798cf6621.png">
