### PR TITLE
Fix broken error message UI on incorrect private key format

### DIFF
--- a/ui/css/base-styles.scss
+++ b/ui/css/base-styles.scss
@@ -31,16 +31,14 @@ html {
 
 /*
   This error class is used in the following files still:
-  /ui/pages/create-account/connect-hardware/index.js
   /ui/pages/create-account/import-account/json.js
   /ui/pages/create-account/import-account/private-key.js
-  /ui/pages/first-time-flow/create-password/import-with-seed-phrase/import-with-seed-phrase.component.js
-  /ui/pages/keychains/restore-vault.js
 */
 .error {
   color: var(--color-error-default);
   margin-top: 3px;
   margin-bottom: 9px;
+  overflow-wrap: anywhere;
 }
 
 /* stylelint-disable */


### PR DESCRIPTION
Partially resolves: https://github.com/MetaMask/metamask-extension/issues/15178

## Test plan
Defined in issue

<img width="358" alt="Screen Shot 2022-09-22 at 12 24 06 AM" src="https://user-images.githubusercontent.com/8732757/191684118-c95e7122-77d5-4fa4-bc36-449bec9a7c07.png">

<img width="361" alt="Screen Shot 2022-09-22 at 12 22 31 AM" src="https://user-images.githubusercontent.com/8732757/191683872-aa829820-d4a1-4651-9489-171f271fe790.png">

<img width="359" alt="Screen Shot 2022-09-22 at 12 23 31 AM" src="https://user-images.githubusercontent.com/8732757/191684029-d72a9812-6f15-4942-bf3c-5d08d7e22b78.png">

