### PR TITLE
[MV3] Add Segment, Sentry and Portfolio URLs on `build:test:mv3` script

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "benchmark:firefox": "SELENIUM_BROWSER=firefox node test/e2e/benchmark.js",
     "build:test": "SEGMENT_HOST='https://api.segment.io' SEGMENT_WRITE_KEY='FAKE' SENTRY_DSN_DEV=https://fake@sentry.io/0000000 PORTFOLIO_URL=http://127.0.0.1:8080 yarn build test",
     "build:test:flask": "yarn build test --build-type flask",
-    "build:test:mv3": "ENABLE_MV3=true yarn build test",
+    "build:test:mv3": "ENABLE_MV3=true SEGMENT_HOST='https://api.segment.io' SEGMENT_WRITE_KEY='FAKE' SENTRY_DSN_DEV=https://fake@sentry.io/0000000 PORTFOLIO_URL=http://127.0.0.1:8080 yarn build test",
     "test": "yarn lint && yarn test:unit && yarn test:unit:jest",
     "dapp": "node development/static-server.js node_modules/@metamask/test-dapp/dist --port 8080",
     "dapp-chain": "GANACHE_ARGS='-b 2' concurrently -k -n ganache,dapp -p '[{time}][{name}]' 'yarn ganache:start' 'sleep 5 && yarn dapp'",


### PR DESCRIPTION
## Explanation
The `build:test:mv3` script for e2e testing against MV3 is missing some variables, compared to the `build:test` (MV2 version). This cause failures when tests are run against MV3. Example of failing tests for this reason:

- `portfolio-site.spec.js`

This PR adds the missing variables, following the same `build:test` script for MV2.


## More Information

- Portfolio test has been fixed

Note: Segment / Metrics is not working at the moment, as no requests are sent to Segment due to some kind of Service Worker incompatibility. It will be handled in [this other PR/issue](https://github.com/MetaMask/metamask-extension/issues/15972)

- Resolves https://github.com/MetaMask/metamask-extension/issues/16008

## Screenshots/Screencaps

<!-- If you're making a change to the UI, make sure to capture a screenshot or a short video showing off your work! -->

### Before

![image](https://user-images.githubusercontent.com/54408225/191739872-6940c38d-4ef6-4b21-815d-6b0bc812e8b2.png)


### After

![image](https://user-images.githubusercontent.com/54408225/191739924-c8078aca-4235-43fa-97b8-42bf5b0d26b5.png)

## Manual Testing Steps
- Run `yarn build:test:mv3`
- Run `yarn test:e2e:single test/e2e/tests/portfolio-site.spec.js --browser=chrome`

## Pre-Merge Checklist

- [X] PR template is filled out
- [ ] **IF** this PR fixes a bug, a test that _would have_ caught the bug has been added
- [x] PR is linked to the appropriate GitHub issue
- [X] PR has been added to the appropriate release Milestone

### + If there are functional changes:

- [ ] Manual testing complete & passed
- [ ] "Extension QA Board" label has been applied
