### PR TITLE
Deprecate snake case from feature flags

### DIFF
--- a/test/e2e/mock-e2e.js
+++ b/test/e2e/mock-e2e.js
@@ -124,36 +124,24 @@ async function setupMocking(server, testSpecificMock) {
         json: [
           {
             ethereum: {
-              mobile_active: true,
-              extension_active: true,
-              fallback_to_v1: false,
+              fallbackToV1: false,
               mobileActive: true,
               extensionActive: true,
             },
             bsc: {
-              mobile_active: true,
-              extension_active: true,
-              fallback_to_v1: false,
+              fallbackToV1: false,
               mobileActive: true,
               extensionActive: true,
             },
             polygon: {
-              mobile_active: true,
-              extension_active: true,
-              fallback_to_v1: false,
+              fallbackToV1: false,
               mobileActive: true,
               extensionActive: true,
             },
             avalanche: {
-              mobile_active: true,
-              extension_active: true,
-              fallback_to_v1: false,
+              fallbackToV1: false,
               mobileActive: true,
               extensionActive: true,
-            },
-            smart_transactions: {
-              mobile_active: false,
-              extension_active: false,
             },
             smartTransactions: {
               mobileActive: false,

--- a/test/jest/mocks.js
+++ b/test/jest/mocks.js
@@ -68,19 +68,19 @@ export const TOKENS_GET_RESPONSE = [
 export const createFeatureFlagsResponse = () => {
   return {
     bsc: {
-      mobile_active: false,
-      extension_active: true,
-      fallback_to_v1: true,
+      mobileActive: false,
+      extensionActive: true,
+      fallbackToV1: true,
     },
     ethereum: {
-      mobile_active: false,
-      extension_active: true,
-      fallback_to_v1: true,
+      mobileActive: false,
+      extensionActive: true,
+      fallbackToV1: true,
     },
     polygon: {
-      mobile_active: false,
-      extension_active: true,
-      fallback_to_v1: false,
+      mobileActive: false,
+      extensionActive: true,
+      fallbackToV1: false,
     },
   };
 };

--- a/ui/ducks/swaps/swaps.test.js
+++ b/ui/ducks/swaps/swaps.test.js
@@ -92,7 +92,7 @@ describe('Ducks - Swaps', () => {
         swapsFeatureIsLive: true,
       };
       const featureFlagsResponse = MOCKS.createFeatureFlagsResponse();
-      featureFlagsResponse.ethereum.extension_active = false;
+      featureFlagsResponse.ethereum.extensionActive = false;
       const featureFlagApiNock = mockFeatureFlagsApiResponse({
         featureFlagsResponse,
       });
@@ -113,8 +113,8 @@ describe('Ducks - Swaps', () => {
         swapsFeatureIsLive: false,
       };
       const featureFlagsResponse = MOCKS.createFeatureFlagsResponse();
-      featureFlagsResponse.ethereum.extension_active = false;
-      featureFlagsResponse.ethereum.fallback_to_v1 = false;
+      featureFlagsResponse.ethereum.extensionActive = false;
+      featureFlagsResponse.ethereum.fallbackToV1 = false;
       const featureFlagApiNock = mockFeatureFlagsApiResponse({
         featureFlagsResponse,
       });

--- a/ui/pages/swaps/swaps.util.js
+++ b/ui/pages/swaps/swaps.util.js
@@ -638,14 +638,14 @@ export const getSwapsLivenessForNetwork = (swapsFeatureFlags = {}, chainId) => {
     };
   }
   const isNetworkEnabledForNewApi =
-    swapsFeatureFlags[networkName].extension_active;
+    swapsFeatureFlags[networkName].extensionActive;
   if (isNetworkEnabledForNewApi) {
     return {
       swapsFeatureIsLive: true,
     };
   }
   return {
-    swapsFeatureIsLive: swapsFeatureFlags[networkName].fallback_to_v1,
+    swapsFeatureIsLive: swapsFeatureFlags[networkName].fallbackToV1,
   };
 };
 

--- a/ui/pages/swaps/swaps.util.test.js
+++ b/ui/pages/swaps/swaps.util.test.js
@@ -377,7 +377,7 @@ describe('Swaps Util', () => {
         swapsFeatureIsLive: true,
       };
       const swapsFeatureFlags = MOCKS.createFeatureFlagsResponse();
-      swapsFeatureFlags[ETHEREUM].extension_active = false;
+      swapsFeatureFlags[ETHEREUM].extensionActive = false;
       expect(
         getSwapsLivenessForNetwork(swapsFeatureFlags, CHAIN_IDS.MAINNET),
       ).toMatchObject(expectedSwapsLiveness);


### PR DESCRIPTION
## Explanation

This change deprecates the use of snake case keys on feature flags on swaps. 
For this the swaps-api has been updated to return both snake case and camel case values.

Once this PR on the extension and a similar one on mobile are merged, snake case values can be safely removed from swaps api
<!--
Thanks for the pull request. Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Below is a template to give you some ideas. Feel free to use your own words!

Currently, ...

This is a problem because ...

In order to solve this problem, this pull request ...
-->

## More Information

See MMS-255

<!--
Are there any issues, Slack conversations, Zendesk issues, user stories, etc. reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

## Screenshots/Screencaps
<img width="552" alt="Screenshot 2022-09-27 at 13 18 41" src="https://user-images.githubusercontent.com/8658960/192511917-0a120f73-dcf3-43c8-832a-cd2b90a9fc0e.png">

<!-- If you're making a change to the UI, make sure to capture a screenshot or a short video showing off your work! -->

## Manual Testing Steps

<!--
How should reviewers and QA manually test your changes? For instance:

- Go to this screen
- Do this
- Then do this
-->

## Pre-Merge Checklist

- [x] PR template is filled out
- [ ] **IF** this PR fixes a bug, a test that _would have_ caught the bug has been added
- [ ] PR is linked to the appropriate GitHub issue
- [ ] PR has been added to the appropriate release Milestone

### + If there are functional changes:

- [ ] Manual testing complete & passed
- [ ] "Extension QA Board" label has been applied
