### PR TITLE
Make this.store is defined during onBootCleanup in tx-controller

### DIFF
--- a/app/scripts/controllers/transactions/index.js
+++ b/app/scripts/controllers/transactions/index.js
@@ -2117,7 +2117,6 @@ export default class TransactionController extends EventEmitter {
 
   async _buildEventFragmentProperties(txMeta, extraParams) {
     const {
-      id,
       type,
       time,
       status,
@@ -2135,8 +2134,14 @@ export default class TransactionController extends EventEmitter {
       originalType,
       replacedById,
       metamaskNetworkId: network,
+      customTokenAmount,
+      dappProposedTokenAmount,
+      currentTokenBalance,
+      originalApprovalAmount,
+      finalApprovalAmount,
+      contractMethodName,
     } = txMeta;
-    const { transactions } = this.store.getState();
+
     const source = referrer === ORIGIN_METAMASK ? 'user' : 'dapp';
 
     const { assetType, tokenStandard } = await determineTransactionAssetType(
@@ -2228,11 +2233,6 @@ export default class TransactionController extends EventEmitter {
       APPROVE: 'Approve',
     };
 
-    const customTokenAmount = transactions[id]?.customTokenAmount;
-    const dappProposedTokenAmount = transactions[id]?.dappProposedTokenAmount;
-    const currentTokenBalance = transactions[id]?.currentTokenBalance;
-    const originalApprovalAmount = transactions[id]?.originalApprovalAmount;
-    const finalApprovalAmount = transactions[id]?.finalApprovalAmount;
     let transactionApprovalAmountType;
     let transactionContractMethod;
     let transactionApprovalAmountVsProposedRatio;
@@ -2246,7 +2246,7 @@ export default class TransactionController extends EventEmitter {
       transactionType = TRANSACTION_TYPES.DEPLOY_CONTRACT;
     } else if (contractInteractionTypes) {
       transactionType = TRANSACTION_TYPES.CONTRACT_INTERACTION;
-      transactionContractMethod = transactions[id]?.contractMethodName;
+      transactionContractMethod = contractMethodName;
       if (
         transactionContractMethod === contractMethodNames.APPROVE &&
         tokenStandard === TOKEN_STANDARDS.ERC20


### PR DESCRIPTION
Fixes #16000

## Info on that bug

The error Peter shared above was introduced with this line of code https://github.com/MetaMask/metamask-extension/pull/15175/files#diff-675c437262d906486cf5436c0b64535347286cc4d1081dbd863fb45b8a01b81aR2011

It will occur if a transaction gets stuck in the approved state, the user closes the browser or stops metamask, and then restarts MetaMask. This is a rare scenario... but I don't know how rare... I'd guess that it affects less than 0.1% of users daily, but that's just a guess. In particular, this will affect any user that has a transaction stuck in approved state, closes browser / stops MetaMask, then their browser version updates to 10.19.0, then they open browser / restart MetaMask

Repro steps:

1. Connect ledger
2. go through the tx send flow with a ledger account
3. on the confirm screen click "Confirm" in MetaMask BUT DON'T confirm on your ledger device
4. Close the browser while MetaMask is waiting for you to confirm on the device
5. Open the browser and the background console. You should the error

## Explanation

The code here https://github.com/MetaMask/metamask-extension/pull/15175/files#diff-675c437262d906486cf5436c0b64535347286cc4d1081dbd863fb45b8a01b81aR2011 can be called during the call to `onBootCleanup`, which is called in the constructor before `this.store` is defined.

This PR avoids the error by getting the data we need from the store from the txMeta object which is already available in onBootCleanup because it comes from the txStateManager, which has already been initialized