### PR TITLE
Fixing icon paths to work in github pages

### DIFF
--- a/ui/components/component-library/icon/icon.js
+++ b/ui/components/component-library/icon/icon.js
@@ -28,8 +28,8 @@ export const Icon = ({
          * the icon component uses mask-image instead of rendering
          * the svg directly.
          */
-        maskImage: `url('/images/icons/icon-${name}.svg`,
-        WebkitMaskImage: `url('/images/icons/icon-${name}.svg`,
+        maskImage: `url('./images/icons/icon-${name}.svg`,
+        WebkitMaskImage: `url('./images/icons/icon-${name}.svg`,
         ...style,
       }}
       {...props}

--- a/ui/components/component-library/icon/icon.test.js
+++ b/ui/components/component-library/icon/icon.test.js
@@ -44,16 +44,16 @@ describe('Icon', () => {
     );
     expect(
       window.getComputedStyle(getByTestId('icon-add-square-filled')).maskImage,
-    ).toBe(`url('/images/icons/icon-add-square-filled.svg`);
+    ).toBe(`url('./images/icons/icon-add-square-filled.svg`);
     expect(
       window.getComputedStyle(getByTestId('icon-bank-filled')).maskImage,
-    ).toBe(`url('/images/icons/icon-bank-filled.svg`);
+    ).toBe(`url('./images/icons/icon-bank-filled.svg`);
     expect(
       window.getComputedStyle(getByTestId('icon-bookmark-filled')).maskImage,
-    ).toBe(`url('/images/icons/icon-bookmark-filled.svg`);
+    ).toBe(`url('./images/icons/icon-bookmark-filled.svg`);
     expect(
       window.getComputedStyle(getByTestId('icon-calculator-filled')).maskImage,
-    ).toBe(`url('/images/icons/icon-calculator-filled.svg`);
+    ).toBe(`url('./images/icons/icon-calculator-filled.svg`);
   });
   it('should render with different size classes', () => {
     const { getByTestId } = render(


### PR DESCRIPTION
## Explanation

Currently, the image paths are broken for the icons on github pages. This fixes the github pages display of the new icons

## More Information

* Fixes #15974

## Screenshots/Screencaps

### Before

<img width="1440" alt="Screen Shot 2022-09-27 at 3 45 46 PM" src="https://user-images.githubusercontent.com/8112138/192650999-807b5cbe-fcda-483b-a192-89d67be5c233.png">

### After

Not sure how to test this on github pages before merging to `develop` but if I add the `.` to the path in github pages it fixes the path to the image

<img width="1440" alt="Screen Shot 2022-09-27 at 3 46 55 PM" src="https://user-images.githubusercontent.com/8112138/192651162-62b8e594-f534-4647-b262-79a6c9d25f73.png">

Icons still display in storybook on local

<img width="1438" alt="Screen Shot 2022-09-27 at 3 39 16 PM" src="https://user-images.githubusercontent.com/8112138/192650303-976e8537-afa1-4326-87b7-af0a6e4196b6.png">


## Manual Testing Steps
Can't really test if this will work on github pages until this has been merged but see image and description above
You can also test it still works in storybook by visiting the [latest build in this PR](https://output.circle-artifacts.com/output/job/a344506b-e836-492c-9ee2-6ed723ac49af/artifacts/0/storybook/index.html?path=/story/ui-components-component-library-icon-icon-stories-js--name)

## Pre-Merge Checklist

- [x] PR template is filled out
- [x] **IF** this PR fixes a bug, a test that _would have_ caught the bug has been added
- [x] PR is linked to the appropriate GitHub issue
- [x] PR has been added to the appropriate release Milestone

### + If there are functional changes:

- [x] Manual testing complete & passed
- [x] "Extension QA Board" label has been applied
