### PR TITLE
ensure phishing-detection page preload works in MV3

### DIFF
--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -172,7 +172,9 @@ async function initialize(remotePort) {
   const initState = await loadStateFromPersistence();
   const initLangCode = await getFirstPreferredLangCode();
   await setupController(initState, initLangCode, remotePort);
-  await loadPhishingWarningPage();
+  if (!isManifestV3) {
+    await loadPhishingWarningPage();
+  }
   log.info('MetaMask initialization complete.');
 }
 

--- a/app/scripts/ui.js
+++ b/app/scripts/ui.js
@@ -15,19 +15,27 @@ import launchMetaMaskUi, { updateBackgroundConnection } from '../../ui';
 import {
   ENVIRONMENT_TYPE_FULLSCREEN,
   ENVIRONMENT_TYPE_POPUP,
+  PLATFORM_FIREFOX,
 } from '../../shared/constants/app';
 import { isManifestV3 } from '../../shared/modules/mv3.utils';
 import { SUPPORT_LINK } from '../../shared/lib/ui-utils';
 import { getErrorHtml } from '../../shared/lib/error-utils';
 import ExtensionPlatform from './platforms/extension';
 import { setupMultiplex } from './lib/stream-utils';
-import { getEnvironmentType } from './lib/util';
+import { getEnvironmentType, getPlatform } from './lib/util';
 import metaRPCClientFactory from './lib/metaRPCClientFactory';
 
 const container = document.getElementById('app-content');
 
-const WORKER_KEEP_ALIVE_INTERVAL = 1000;
+const ONE_SECOND_IN_MILLISECONDS = 1_000;
+
+const WORKER_KEEP_ALIVE_INTERVAL = ONE_SECOND_IN_MILLISECONDS;
 const WORKER_KEEP_ALIVE_MESSAGE = 'WORKER_KEEP_ALIVE_MESSAGE';
+
+// Timeout for initializing phishing warning page.
+const PHISHING_WARNING_PAGE_TIMEOUT = ONE_SECOND_IN_MILLISECONDS;
+
+const PHISHING_WARNING_SW_STORAGE_KEY = 'phishing-warning-sw-registered';
 
 /*
  * As long as UI is open it will keep sending messages to service worker
@@ -58,6 +66,7 @@ async function start() {
 
   const activeTab = await queryCurrentActiveTab(windowType);
 
+  let loadPhishingWarningPage;
   /**
    * In case of MV3 the issue of blank screen was very frequent, it is caused by UI initialising before background is ready to send state.
    * Code below ensures that UI is rendered only after background is ready.
@@ -68,7 +77,7 @@ async function start() {
      * Code below ensures that UI is rendered only after CONNECTION_READY message is received thus background is ready.
      * In case the UI is already rendered, only update the streams.
      */
-    const messageListener = (message) => {
+    const messageListener = async (message) => {
       if (message?.name === 'CONNECTION_READY') {
         if (isUIInitialised) {
           // Currently when service worker is revived we create new streams
@@ -76,6 +85,100 @@ async function start() {
           updateUiStreams();
         } else {
           initializeUiWithTab(activeTab);
+        }
+        await loadPhishingWarningPage();
+      }
+    };
+
+    /**
+     * An error thrown if the phishing warning page takes too long to load.
+     */
+    class PhishingWarningPageTimeoutError extends Error {
+      constructor() {
+        super('Timeout failed');
+      }
+    }
+
+    /**
+     * Load the phishing warning page temporarily to ensure the service
+     * worker has been registered, so that the warning page works offline.
+     */
+    loadPhishingWarningPage = async function () {
+      const currentPlatform = getPlatform();
+      let isSWAlreadyRegistered;
+
+      if (currentPlatform === PLATFORM_FIREFOX) {
+        isSWAlreadyRegistered = window.sessionStorage.getItem(
+          PHISHING_WARNING_SW_STORAGE_KEY,
+        );
+      } else {
+        const phishingSWGet = await browser.storage.session.get(
+          PHISHING_WARNING_SW_STORAGE_KEY,
+        );
+        isSWAlreadyRegistered = phishingSWGet[PHISHING_WARNING_SW_STORAGE_KEY];
+      }
+
+      if (isSWAlreadyRegistered) {
+        return;
+      }
+
+      let iframe;
+      try {
+        const extensionStartupPhishingPageUrl = new URL(
+          process.env.PHISHING_WARNING_PAGE_URL,
+        );
+        // The `extensionStartup` hash signals to the phishing warning page that it should not bother
+        // setting up streams for user interaction. Otherwise this page load would cause a console
+        // error.
+        extensionStartupPhishingPageUrl.hash = '#extensionStartup';
+
+        iframe = window.document.createElement('iframe');
+        iframe.setAttribute('src', extensionStartupPhishingPageUrl.href);
+        iframe.setAttribute('sandbox', 'allow-scripts allow-same-origin');
+
+        // Create "deferred Promise" to allow passing resolve/reject to event handlers
+        let deferredResolve;
+        let deferredReject;
+        const loadComplete = new Promise((resolve, reject) => {
+          deferredResolve = resolve;
+          deferredReject = reject;
+        });
+
+        // The load event is emitted once loading has completed, even if the loading failed.
+        // If loading failed we can't do anything about it, so we don't need to check.
+        iframe.addEventListener('load', deferredResolve);
+
+        // This step initiates the page loading.
+        window.document.body.appendChild(iframe);
+
+        // This timeout ensures that this iframe gets cleaned up in a reasonable
+        // timeframe, and ensures that the "initialization complete" message
+        // doesn't get delayed too long.
+        setTimeout(
+          () => deferredReject(new PhishingWarningPageTimeoutError()),
+          PHISHING_WARNING_PAGE_TIMEOUT,
+        );
+        await loadComplete;
+        // store a flag in sessions storage that we've already loaded the service worker
+        // and don't need to try again
+        if (currentPlatform === PLATFORM_FIREFOX) {
+          window.sessionStorage.setItem(PHISHING_WARNING_SW_STORAGE_KEY, true);
+        } else {
+          browser.storage.session.set({
+            [PHISHING_WARNING_SW_STORAGE_KEY]: true,
+          });
+        }
+      } catch (error) {
+        if (error instanceof PhishingWarningPageTimeoutError) {
+          console.warn(
+            'Phishing warning page timeout; page not guaranteed to work offline.',
+          );
+        } else {
+          console.error('Failed to initialize phishing warning page', error);
+        }
+      } finally {
+        if (iframe) {
+          iframe.remove();
         }
       }
     };


### PR DESCRIPTION
## Explanation
Currently (in MV2) we load the [`phishing-warning` page](https://github.com/MetaMask/phishing-warning)in an `Iframe` on the background page, in order to register a service worker which caches the phishing page's assets and serves them if/when the hosted instance of the phishing page is down. Because in MV3 our background process becomes a service worker which does not support `Iframes` we must move this flow to the UI.

Unfortunately moving this flow to the UI does remove phishing warning coverage for some cases. Now, if the user has started a new browser session after having the browser closed for some while (giving time for the service worker to become unregistered) and has not yet opened the MetaMask UI, the user may not see the phishing warning page if they navigate to a page on our phishing detection list.

While MV2 is still supported I am leaving the background version of this flow intact, to run only when in an MV2 build.

## More Information

* Fixes #15049

## Manual Testing Steps

- Clone and build and serve the `phishing-warning` page [locally](https://github.com/MetaMask/phishing-warning). 
   - `npx static-server ./dist` after building
   - Check which port it serves to - I believe its configured to serve to 9080 by default
   
- Add `phishingWarningPageUrl = 'http://localhost:9080/'` [here](https://github.com/MetaMask/metamask-extension/blob/develop/development/build/scripts.js#L117) 
- Start MV3 build of the extension
- Open the MetaMask UI
- Navigate to one of the sites on this [blacklist](https://github.com/MetaMask/eth-phishing-detect/blob/master/src/config.json#L1238) - you may want to go to the recently close PRs to find one that's still live
- You should see the MetaMask Phishing Warning Page.
- Close that page

Now stop the server serving the phishing-warning page locally

- go back to that page (or another one on the blacklist) and you should see that the Phishing Warning page is still shown.


## Pre-Merge Checklist

- [x] PR template is filled out
- [ ] **IF** this PR fixes a bug, a test that _would have_ caught the bug has been added
- [x] PR is linked to the appropriate GitHub issue
- [ ] PR has been added to the appropriate release Milestone

### + If there are functional changes:

- [x] Manual testing complete & passed
- [ ] "Extension QA Board" label has been applied
