### PR TITLE
Ability to buy native currency and tokens on Optimism and Arbitrum

### DIFF
--- a/shared/constants/network.ts
+++ b/shared/constants/network.ts
@@ -374,6 +374,7 @@ const SUPPORTED_CURRENCY_SYMBOLS = {
   SHIB: 'SHIB',
   SKL: 'SKL',
   SNX: 'SNX',
+  SPA: 'SPA',
   STETH: 'STETH',
   STORJ: 'STORJ',
   SUKU: 'SUKU',
@@ -577,9 +578,7 @@ export const BUYABLE_CHAINS_MAP: {
     | typeof CHAIN_IDS.LOCALHOST
     | typeof CHAIN_IDS.PALM
     | typeof CHAIN_IDS.HARMONY
-    | typeof CHAIN_IDS.OPTIMISM
     | typeof CHAIN_IDS.OPTIMISM_TESTNET
-    | typeof CHAIN_IDS.ARBITRUM
   >]: BuyableChainSettings;
 } = {
   [CHAIN_IDS.MAINNET]: {
@@ -843,6 +842,24 @@ export const BUYABLE_CHAINS_MAP: {
       defaultCurrencyCode: SUPPORTED_CURRENCY_SYMBOLS.CELO,
       showOnlyCurrencies: [SUPPORTED_CURRENCY_SYMBOLS.CELO],
     },
+  },
+  [CHAIN_IDS.OPTIMISM]: {
+    nativeCurrency: CURRENCY_SYMBOLS.ETH,
+    network: 'optimism',
+    transakCurrencies: [
+      SUPPORTED_CURRENCY_SYMBOLS.ETH,
+      SUPPORTED_CURRENCY_SYMBOLS.USDC,
+    ],
+  },
+  [CHAIN_IDS.ARBITRUM]: {
+    nativeCurrency: CURRENCY_SYMBOLS.ARBITRUM,
+    network: 'arbitrum',
+    transakCurrencies: [
+      SUPPORTED_CURRENCY_SYMBOLS.ARBITRUM,
+      SUPPORTED_CURRENCY_SYMBOLS.SPA,
+      SUPPORTED_CURRENCY_SYMBOLS.USDC,
+      SUPPORTED_CURRENCY_SYMBOLS.USDS,
+    ],
   },
 };
 

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -721,7 +721,7 @@ export function getIsBuyableMoonpayToken(state, symbol) {
   const chainId = getCurrentChainId(state);
   const _symbol = formatMoonpaySymbol(symbol, chainId);
   return Boolean(
-    BUYABLE_CHAINS_MAP?.[chainId]?.moonPay.showOnlyCurrencies?.includes(
+    BUYABLE_CHAINS_MAP?.[chainId]?.moonPay?.showOnlyCurrencies?.includes(
       _symbol,
     ),
   );


### PR DESCRIPTION
## Explanation

Currently, Transak is the only provider offering on-ramps to these networks.

Before: no on ramp on Optimism and/or Arbitrum
After: ability to purchase ETH and supported tokens on these L2
<!--
Thanks for the pull request. Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Below is a template to give you some ideas. Feel free to use your own words!

Currently, ...

This is a problem because ...

In order to solve this problem, this pull request ...
-->

## More Information

See ONRAMP-191
<!--
Are there any issues, Slack conversations, Zendesk issues, user stories, etc. reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

## Screenshots/Screencaps

<img width="355" alt="Screenshot 2022-09-29 at 14 03 33" src="https://user-images.githubusercontent.com/8658960/193026394-0ea44ed3-ecb7-4883-bea2-27c1c33cd894.png">

## Manual Testing Steps

1- Switch network to Optimism
2- Check if possible to buy ETH and USDC through Transak

1- Switch network to Arbitrum
2- Check if possible to buy ETH, SPA, USDC, USDS through Transak

<!--
How should reviewers and QA manually test your changes? For instance:

- Go to this screen
- Do this
- Then do this
-->

## Pre-Merge Checklist

- [x] PR template is filled out
- [ ] **IF** this PR fixes a bug, a test that _would have_ caught the bug has been added
- [ ] PR is linked to the appropriate GitHub issue
- [ ] PR has been added to the appropriate release Milestone

### + If there are functional changes:

- [ ] Manual testing complete & passed
- [ ] "Extension QA Board" label has been applied
