### PR TITLE
Fix `@hapi/hoek` audit failure

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
     "3box/**/libp2p-crypto/node-forge": "^1.3.0",
     "3box/**/libp2p-keychain/node-forge": "^1.3.0",
     "3box/ipfs/libp2p-webrtc-star/socket.io/engine.io": "^4.0.0",
+    "3box/**/@hapi/hoek": "^8.5.1",
     "analytics-node/axios": "^0.21.2",
     "ganache-core/lodash": "^4.17.21",
     "netmask": "^2.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2265,15 +2265,10 @@
     "@hapi/hoek" "6.x.x"
     "@hapi/joi" "15.x.x"
 
-"@hapi/hoek@6.x.x", "@hapi/hoek@^6.2.0":
-  version "6.2.4"
-  resolved "https://registry.yarnpkg.com/@hapi/hoek/-/hoek-6.2.4.tgz#4b95fbaccbfba90185690890bdf1a2fbbda10595"
-  integrity sha512-HOJ20Kc93DkDVvjwHyHawPwPkX44sIrbXazAUDiUXaY2R9JwQGo2PhFfnQtdrsIe4igjG2fPgMra7NYw7qhy0A==
-
-"@hapi/hoek@8.x.x":
-  version "8.1.0"
-  resolved "https://registry.yarnpkg.com/@hapi/hoek/-/hoek-8.1.0.tgz#8f7627b23ed9bf67088fc7f9669e48c63ad421bd"
-  integrity sha512-b1J4jxYnW+n6lC91V6Pqg9imP9BZq0HNCeM+3sbXg05rQsE9cGYrKFpZjyztVesGmNRE6R+QaEoWGATeIiUVjA==
+"@hapi/hoek@6.x.x", "@hapi/hoek@8.x.x", "@hapi/hoek@^6.2.0", "@hapi/hoek@^8.5.1":
+  version "8.5.1"
+  resolved "https://registry.yarnpkg.com/@hapi/hoek/-/hoek-8.5.1.tgz#fde96064ca446dec8c55a8c2f130957b070c6e06"
+  integrity sha512-yN7kbciD87WzLGc5539Tn0sApjyiGHAJgKvG9W8C7O+6c7qmoQMfVs0W4bX17eqz6C78QJqqFrtgdK5EWf6Qow==
 
 "@hapi/inert@^5.2.0":
   version "5.2.1"


### PR DESCRIPTION
Fix `@hapi/hoek` by bumping to `8.5.1`. We should verify whether this breaks `3box`.