### PR TITLE
Adding `TextFieldBase` component

### DIFF
--- a/ui/components/component-library/component-library-components.scss
+++ b/ui/components/component-library/component-library-components.scss
@@ -5,3 +5,4 @@
 @import 'button-base/button-base';
 @import 'icon/icon';
 @import 'text/text';
+@import 'text-field-base/text-field-base';

--- a/ui/components/component-library/text-field-base/README.mdx
+++ b/ui/components/component-library/text-field-base/README.mdx
@@ -1,0 +1,298 @@
+import { Story, Canvas, ArgsTable } from '@storybook/addon-docs';
+
+import { TextFieldBase } from './text-field-base';
+
+### This is a base component. It should not be used in your feature code directly but as a "base" for other UI components
+
+# TextFieldBase
+
+The `TextFieldBase` is the base component for all text fields. It should not be used directly.
+
+<Canvas>
+  <Story id="ui-components-component-library-text-field-base-text-field-base-stories-js--default-story" />
+</Canvas>
+
+## Props
+
+The `TextFieldBase` accepts all props below as well as all [Box](/docs/ui-components-ui-box-box-stories-js--default-story#props) component props
+
+<ArgsTable of={TextFieldBase} />
+
+### Size
+
+Use the `size` prop to set the height of the `TextFieldBase`.
+
+Possible sizes include:
+
+- `sm` 32px
+- `md` 40px
+- `lg` 48px
+
+Defaults to `md`
+
+<Canvas>
+  <Story id="ui-components-component-library-text-field-base-text-field-base-stories-js--size" />
+</Canvas>
+
+```jsx
+import { TextFieldBase } from '../../ui/component-library/text-field-base';
+import { SIZES } from '../../../helpers/constants/design-system';
+
+<TextFieldBase size={SIZES.SM} />
+<TextFieldBase size={SIZES.MD} />
+<TextFieldBase size={SIZES.LG} />
+```
+
+### Type
+
+Use the `type` prop to change the type of input.
+
+Possible types include:
+
+- `text`
+- `number`
+- `password`
+
+Defaults to `text`.
+
+<Canvas>
+  <Story id="ui-components-component-library-text-field-base-text-field-base-stories-js--type" />
+</Canvas>
+
+```jsx
+import { TextFieldBase } from '../../ui/component-library/text-field-base';
+
+<TextFieldBase type="text" /> // (Default)
+<TextFieldBase type="number" />
+<TextFieldBase type="password" />
+```
+
+### Truncate
+
+Use the `truncate` prop to truncate the text of the the `TextFieldBase`
+
+<Canvas>
+  <Story id="ui-components-component-library-text-field-base-text-field-base-stories-js--truncate" />
+</Canvas>
+
+```jsx
+import { TextFieldBase } from '../../ui/component-library/text-field-base';
+
+<TextFieldBase truncate />;
+```
+
+### Left Accessory Right Accessory
+
+Use the `leftAccessory` and `rightAccessory` props to add components such as icons or buttons to either side of the `TextFieldBase`.
+
+<Canvas>
+  <Story id="ui-components-component-library-text-field-base-text-field-base-stories-js--left-accessory-right-accessory" />
+</Canvas>
+
+```jsx
+import { COLORS, SIZES } from '../../../helpers/constants/design-system';
+import { Icon, ICON_NAMES } from '../../ui/component-library/icons';
+
+import { TextFieldBase } from '../../ui/component-library/text-field-base';
+
+<TextFieldBase
+  placeholder="Search"
+  leftAccessory={
+    <Icon
+      color={COLORS.ICON_ALTERNATIVE}
+      name={ICON_NAMES.SEARCH_FILLED}
+    />
+  }
+/>
+
+<TextFieldBase
+  placeholder="MetaMask"
+  rightAccessory={
+    // TODO: replace with ButtonIcon
+    <button>
+      <Icon name={ICON_NAMES.CLOSE_OUTLINE} size={SIZES.SM} />
+    </button>
+  }
+/>
+
+<TextFieldBase
+  truncate
+  leftAccessory={<AvatarToken tokenName="ast" size={SIZES.SM} />}
+  rightAccessory={
+    // TODO: replace with ButtonIcon
+    <button>
+      <Icon name={ICON_NAMES.CLOSE_OUTLINE} size={SIZES.SM} />
+    </button>
+  }
+/>
+
+<TextFieldBase
+  placeholder="Enter amount"
+  type="number"
+  leftAccessory={
+    <AvatarToken
+      tokenName="ast"
+      tokenImageUrl="./AST.png"
+      size={SIZES.SM}
+    />
+  }
+  rightAccessory={
+    // TODO: replace with ButtonLink
+    <button>Max</button>
+  }
+/>
+```
+
+### Input Ref
+
+Use the `inputRef` prop to access the ref of the `<input />` html element of `TextFieldBase`. This is useful for focusing the input from a button or other component.
+
+<Canvas>
+  <Story id="ui-components-component-library-text-field-base-text-field-base-stories-js--input-ref" />
+</Canvas>
+
+```jsx
+import { TextFieldBase } from '../../ui/component-library/text-field-base';
+
+const inputRef = useRef(null);
+const [value, setValue] = useState('');
+const handleOnClick = () => {
+  inputRef.current.focus();
+};
+const handleOnChange = (e) => {
+  setValue(e.target.value);
+};
+
+<TextFieldBase
+  inputRef={inputRef}
+  value={value}
+  onChange={handleOnChange}
+/>
+// TODO: replace with Button component
+<Box
+  as="button"
+  backgroundColor={COLORS.BACKGROUND_ALTERNATIVE}
+  color={COLORS.TEXT_DEFAULT}
+  borderColor={COLORS.BORDER_DEFAULT}
+  borderRadius={SIZES.XL}
+  marginLeft={1}
+  paddingLeft={2}
+  paddingRight={2}
+  onClick={handleOnClick}
+>
+  Edit
+</Box>
+```
+
+### Auto Complete
+
+Use the `autoComplete` prop to set the autocomplete html attribute. It allows the browser to predict the value based on earlier typed values.
+
+<Canvas>
+  <Story id="ui-components-component-library-text-field-base-text-field-base-stories-js--auto-complete" />
+</Canvas>
+
+```jsx
+import { TextFieldBase } from '../../ui/component-library/text-field-base';
+
+<TextFieldBase type="password" autoComplete />;
+```
+
+### Auto Focus
+
+Use the `autoFocus` prop to focus the `TextFieldBase` during the first mount
+
+<Canvas>
+  <Story id="ui-components-component-library-text-field-base-text-field-base-stories-js--auto-focus" />
+</Canvas>
+
+```jsx
+import { TextFieldBase } from '../../ui/component-library/text-field-base';
+
+<TextFieldBase autoFocus />;
+```
+
+### Default Value
+
+Use the `defaultValue` prop to set the default value of the `TextFieldBase`
+
+<Canvas>
+  <Story id="ui-components-component-library-text-field-base-text-field-base-stories-js--default-value" />
+</Canvas>
+
+```jsx
+import { TextFieldBase } from '../../ui/component-library/text-field-base';
+
+<TextFieldBase defaultValue="default value" />;
+```
+
+### Disabled
+
+Use the `disabled` prop to set the disabled state of the `TextFieldBase`
+
+<Canvas>
+  <Story id="ui-components-component-library-text-field-base-text-field-base-stories-js--disabled" />
+</Canvas>
+
+```jsx
+import { TextFieldBase } from '../../ui/component-library/text-field-base';
+
+<TextFieldBase disabled />;
+```
+
+### Error
+
+Use the `error` prop to set the error state of the `TextFieldBase`
+
+<Canvas>
+  <Story id="ui-components-component-library-text-field-base-text-field-base-stories-js--error-story" />
+</Canvas>
+
+```jsx
+import { TextFieldBase } from '../../ui/component-library/text-field-base';
+
+<TextFieldBase error />;
+```
+
+### Max Length
+
+Use the `maxLength` prop to set the maximum allowed input characters for the `TextFieldBase`
+
+<Canvas>
+  <Story id="ui-components-component-library-text-field-base-text-field-base-stories-js--max-length" />
+</Canvas>
+
+```jsx
+import { TextFieldBase } from '../../ui/component-library/text-field-base';
+
+<TextFieldBase maxLength={10} />;
+```
+
+### Read Only
+
+Use the `readOnly` prop to set the `TextFieldBase` to read only
+
+<Canvas>
+  <Story id="ui-components-component-library-text-field-base-text-field-base-stories-js--read-only" />
+</Canvas>
+
+```jsx
+import { TextFieldBase } from '../../ui/component-library/text-field-base';
+
+<TextFieldBase readOnly />;
+```
+
+### Required
+
+Use the `required` prop to set the `TextFieldBase` to required. Currently there is no visual difference to the `TextFieldBase` when required.
+
+<Canvas>
+  <Story id="ui-components-component-library-text-field-base-text-field-base-stories-js--required" />
+</Canvas>
+
+```jsx
+import { TextFieldBase } from '../../ui/component-library/text-field-base';
+
+// Currently no visual difference
+<TextFieldBase required />;
+```

--- a/ui/components/component-library/text-field-base/README.mdx
+++ b/ui/components/component-library/text-field-base/README.mdx
@@ -6,7 +6,7 @@ import { TextFieldBase } from './text-field-base';
 
 # TextFieldBase
 
-The `TextFieldBase` is the base component for all text fields. It should not be used directly.
+The `TextFieldBase` is the base component for all text fields. It should not be used directly. It functions as both a uncontrolled and controlled input.
 
 <Canvas>
   <Story id="ui-components-component-library-text-field-base-text-field-base-stories-js--default-story" />

--- a/ui/components/component-library/text-field-base/index.js
+++ b/ui/components/component-library/text-field-base/index.js
@@ -1,5 +1,5 @@
 export { TextFieldBase } from './text-field-base';
 export {
-  TEXT_FIELD_SIZES,
-  TEXT_FIELD_TYPES,
+  TEXT_FIELD_BASE_SIZES,
+  TEXT_FIELD_BASE_TYPES,
 } from './text-field-base.constants';

--- a/ui/components/component-library/text-field-base/index.js
+++ b/ui/components/component-library/text-field-base/index.js
@@ -1,0 +1,5 @@
+export { TextFieldBase } from './text-field-base';
+export {
+  TEXT_FIELD_SIZES,
+  TEXT_FIELD_TYPES,
+} from './text-field-base.constants';

--- a/ui/components/component-library/text-field-base/text-field-base.constants.js
+++ b/ui/components/component-library/text-field-base/text-field-base.constants.js
@@ -1,7 +1,11 @@
 import { SIZES } from '../../../helpers/constants/design-system';
 
-export const TEXT_FIELD_SIZES = { SM: SIZES.SM, MD: SIZES.MD, LG: SIZES.LG };
-export const TEXT_FIELD_TYPES = {
+export const TEXT_FIELD_BASE_SIZES = {
+  SM: SIZES.SM,
+  MD: SIZES.MD,
+  LG: SIZES.LG,
+};
+export const TEXT_FIELD_BASE_TYPES = {
   TEXT: 'text',
   NUMBER: 'number',
   PASSWORD: 'password',

--- a/ui/components/component-library/text-field-base/text-field-base.constants.js
+++ b/ui/components/component-library/text-field-base/text-field-base.constants.js
@@ -1,0 +1,8 @@
+import { SIZES } from '../../../helpers/constants/design-system';
+
+export const TEXT_FIELD_SIZES = { SM: SIZES.SM, MD: SIZES.MD, LG: SIZES.LG };
+export const TEXT_FIELD_TYPES = {
+  TEXT: 'text',
+  NUMBER: 'number',
+  PASSWORD: 'password',
+};

--- a/ui/components/component-library/text-field-base/text-field-base.js
+++ b/ui/components/component-library/text-field-base/text-field-base.js
@@ -36,8 +36,6 @@ export const TextFieldBase = ({
   onChange,
   onClick,
   onFocus,
-  onKeyDown,
-  onKeyUp,
   placeholder,
   readOnly,
   required,
@@ -94,14 +92,6 @@ export const TextFieldBase = ({
     onBlur && onBlur(event);
   };
 
-  const handleKeyDown = (event) => {
-    onKeyDown && onKeyDown(event);
-  };
-
-  const handleKeyUp = (event) => {
-    onKeyUp && onKeyUp(event);
-  };
-
   const handleInputRef = (ref) => {
     internalInputRef.current = ref;
     if (inputRef && inputRef.current !== undefined) {
@@ -149,8 +139,6 @@ export const TextFieldBase = ({
         onBlur={handleBlur}
         onChange={handleChange}
         onFocus={handleFocus}
-        onKeyDown={handleKeyDown}
-        onKeyUp={handleKeyUp}
         padding={0}
         paddingLeft={leftAccessory ? 2 : null}
         paddingRight={leftAccessory ? 2 : null}
@@ -235,14 +223,6 @@ TextFieldBase.propTypes = {
    * Callback fired on focus
    */
   onFocus: PropTypes.func,
-  /**
-   * Callback fired on key down
-   */
-  onKeyDown: PropTypes.func,
-  /**
-   * Callback fired on key up
-   */
-  onKeyUp: PropTypes.func,
   /**
    * The short hint displayed in the input before the user enters a value.
    */

--- a/ui/components/component-library/text-field-base/text-field-base.js
+++ b/ui/components/component-library/text-field-base/text-field-base.js
@@ -118,6 +118,7 @@ export const TextFieldBase = ({
         as="input"
         autoComplete={autoComplete ? 'on' : 'off'}
         autoFocus={autoFocus}
+        backgroundColor={COLORS.TRANSPARENT}
         defaultValue={defaultValue}
         disabled={disabled}
         focused={focused.toString()}

--- a/ui/components/component-library/text-field-base/text-field-base.js
+++ b/ui/components/component-library/text-field-base/text-field-base.js
@@ -14,8 +14,8 @@ import Box from '../../ui/box';
 import { Text } from '../text';
 
 import {
-  TEXT_FIELD_SIZES,
-  TEXT_FIELD_TYPES,
+  TEXT_FIELD_BASE_SIZES,
+  TEXT_FIELD_BASE_TYPES,
 } from './text-field-base.constants';
 
 export const TextFieldBase = ({
@@ -228,12 +228,12 @@ TextFieldBase.propTypes = {
    * The size of the text field. Changes the height of the component
    * Accepts SM(32px), MD(40px), LG(48px)
    */
-  size: PropTypes.oneOf(Object.values(TEXT_FIELD_SIZES)),
+  size: PropTypes.oneOf(Object.values(TEXT_FIELD_BASE_SIZES)),
   /**
-   * Type of the input element. Can be TEXT_FIELD_TYPES.TEXT, TEXT_FIELD_TYPES.PASSWORD, TEXT_FIELD_TYPES.NUMBER
-   * Defaults to TEXT_FIELD_TYPES.TEXT ('text')
+   * Type of the input element. Can be TEXT_FIELD_BASE_TYPES.TEXT, TEXT_FIELD_BASE_TYPES.PASSWORD, TEXT_FIELD_BASE_TYPES.NUMBER
+   * Defaults to TEXT_FIELD_BASE_TYPES.TEXT ('text')
    */
-  type: PropTypes.oneOf(Object.values(TEXT_FIELD_TYPES)),
+  type: PropTypes.oneOf(Object.values(TEXT_FIELD_BASE_TYPES)),
   /**
    * The input value, required for a controlled component.
    */

--- a/ui/components/component-library/text-field-base/text-field-base.js
+++ b/ui/components/component-library/text-field-base/text-field-base.js
@@ -7,6 +7,7 @@ import {
   SIZES,
   ALIGN_ITEMS,
   TEXT,
+  COLORS,
 } from '../../../helpers/constants/design-system';
 
 import Box from '../../ui/box';
@@ -90,9 +91,6 @@ export const TextFieldBase = ({
 
   return (
     <Box
-      alignItems={ALIGN_ITEMS.CENTER}
-      borderWidth={1}
-      borderRadius={SIZES.SM}
       className={classnames(
         'mm-text-field-base',
         `mm-text-field-base--size-${size}`,
@@ -105,6 +103,10 @@ export const TextFieldBase = ({
         className,
       )}
       display={DISPLAY.INLINE_FLEX}
+      backgroundColor={COLORS.BACKGROUND_DEFAULT}
+      alignItems={ALIGN_ITEMS.CENTER}
+      borderWidth={1}
+      borderRadius={SIZES.SM}
       paddingLeft={4}
       paddingRight={4}
       onClick={handleClick}

--- a/ui/components/component-library/text-field-base/text-field-base.js
+++ b/ui/components/component-library/text-field-base/text-field-base.js
@@ -116,7 +116,6 @@ export const TextFieldBase = ({
         as="input"
         autoComplete={autoComplete ? 'on' : 'off'}
         autoFocus={autoFocus}
-        className="mm-text-field-base__input"
         defaultValue={defaultValue}
         disabled={disabled}
         focused={focused.toString()}
@@ -136,10 +135,12 @@ export const TextFieldBase = ({
         required={required}
         value={value}
         variant={TEXT.BODY_MD}
-        {...{
-          ...inputProps,
-          type,
-        }}
+        type={type}
+        {...inputProps} // before className so input className isn't overridden
+        className={classnames(
+          'mm-text-field-base__input',
+          inputProps?.className,
+        )}
       />
       {rightAccessory}
     </Box>

--- a/ui/components/component-library/text-field-base/text-field-base.js
+++ b/ui/components/component-library/text-field-base/text-field-base.js
@@ -46,13 +46,7 @@ export const TextFieldBase = ({
   ...props
 }) => {
   const internalInputRef = useRef(null);
-
-  const [inputValue, setInputValue] = useState(defaultValue || value || '');
   const [focused, setFocused] = useState(false);
-
-  useEffect(() => {
-    setInputValue(inputValue);
-  }, [inputValue]);
 
   useEffect(() => {
     // The blur won't fire when the disabled state is set on a focused input.
@@ -73,13 +67,6 @@ export const TextFieldBase = ({
     if (onClick) {
       onClick(event);
     }
-  };
-
-  const handleChange = (event) => {
-    // setState handles the use case of an uncontrolled component
-    setInputValue(event.target.value);
-    // onChange will be used for controlled components
-    onChange && onChange(event);
   };
 
   const handleFocus = (event) => {
@@ -130,6 +117,7 @@ export const TextFieldBase = ({
         autoComplete={autoComplete ? 'on' : 'off'}
         autoFocus={autoFocus}
         className="mm-text-field-base__input"
+        defaultValue={defaultValue}
         disabled={disabled}
         focused={focused.toString()}
         id={id}
@@ -137,7 +125,7 @@ export const TextFieldBase = ({
         maxLength={maxLength}
         name={name}
         onBlur={handleBlur}
-        onChange={handleChange}
+        onChange={onChange}
         onFocus={handleFocus}
         padding={0}
         paddingLeft={leftAccessory ? 2 : null}
@@ -146,7 +134,7 @@ export const TextFieldBase = ({
         readOnly={readOnly}
         ref={handleInputRef}
         required={required}
-        value={inputValue}
+        value={value}
         variant={TEXT.BODY_MD}
         {...{
           ...inputProps,

--- a/ui/components/component-library/text-field-base/text-field-base.js
+++ b/ui/components/component-library/text-field-base/text-field-base.js
@@ -1,0 +1,278 @@
+import React, { useState, useRef, useEffect } from 'react';
+import PropTypes from 'prop-types';
+import classnames from 'classnames';
+
+import {
+  DISPLAY,
+  SIZES,
+  ALIGN_ITEMS,
+  TEXT,
+} from '../../../helpers/constants/design-system';
+
+import Box from '../../ui/box';
+
+import { Text } from '../text';
+
+import {
+  TEXT_FIELD_SIZES,
+  TEXT_FIELD_TYPES,
+} from './text-field-base.constants';
+
+export const TextFieldBase = ({
+  autoComplete,
+  autoFocus,
+  className,
+  defaultValue,
+  disabled,
+  error,
+  id,
+  inputProps,
+  inputRef,
+  leftAccessory,
+  rightAccessory,
+  maxLength,
+  name,
+  onBlur,
+  onChange,
+  onClick,
+  onFocus,
+  onKeyDown,
+  onKeyUp,
+  placeholder,
+  readOnly,
+  required,
+  size = SIZES.MD,
+  type = 'text',
+  truncate,
+  value,
+  ...props
+}) => {
+  const internalInputRef = useRef(null);
+
+  const [inputValue, setInputValue] = useState(defaultValue || value || '');
+  const [focused, setFocused] = useState(false);
+
+  useEffect(() => {
+    setInputValue(inputValue);
+  }, [inputValue]);
+
+  useEffect(() => {
+    // The blur won't fire when the disabled state is set on a focused input.
+    // We need to set the focused state manually.
+    if (disabled) {
+      setFocused(false);
+    }
+  }, [disabled]);
+
+  const handleClick = (event) => {
+    const { current } = internalInputRef;
+
+    if (current) {
+      current.focus();
+      setFocused(true);
+    }
+
+    if (onClick) {
+      onClick(event);
+    }
+  };
+
+  const handleChange = (event) => {
+    // setState handles the use case of an uncontrolled component
+    setInputValue(event.target.value);
+    // onChange will be used for controlled components
+    onChange && onChange(event);
+  };
+
+  const handleFocus = (event) => {
+    setFocused(true);
+    onFocus && onFocus(event);
+  };
+
+  const handleBlur = (event) => {
+    setFocused(false);
+    onBlur && onBlur(event);
+  };
+
+  const handleKeyDown = (event) => {
+    onKeyDown && onKeyDown(event);
+  };
+
+  const handleKeyUp = (event) => {
+    onKeyUp && onKeyUp(event);
+  };
+
+  const handleInputRef = (ref) => {
+    internalInputRef.current = ref;
+    if (inputRef && inputRef.current !== undefined) {
+      inputRef.current = ref;
+    } else if (typeof inputRef === 'function') {
+      inputRef(ref);
+    }
+  };
+
+  return (
+    <Box
+      alignItems={ALIGN_ITEMS.CENTER}
+      borderWidth={1}
+      borderRadius={SIZES.SM}
+      className={classnames(
+        'mm-text-field-base',
+        `mm-text-field-base--size-${size}`,
+        {
+          'mm-text-field-base--focused': focused && !disabled,
+          'mm-text-field-base--error': error,
+          'mm-text-field-base--disabled': disabled,
+          'mm-text-field-base--truncate': truncate,
+        },
+        className,
+      )}
+      display={DISPLAY.INLINE_FLEX}
+      paddingLeft={4}
+      paddingRight={4}
+      onClick={handleClick}
+      {...props}
+    >
+      {leftAccessory}
+      <Text
+        aria-invalid={error}
+        as="input"
+        autoComplete={autoComplete ? 'on' : 'off'}
+        autoFocus={autoFocus}
+        className="mm-text-field-base__input"
+        disabled={disabled}
+        focused={focused.toString()}
+        id={id}
+        margin={0}
+        maxLength={maxLength}
+        name={name}
+        onBlur={handleBlur}
+        onChange={handleChange}
+        onFocus={handleFocus}
+        onKeyDown={handleKeyDown}
+        onKeyUp={handleKeyUp}
+        padding={0}
+        paddingLeft={leftAccessory ? 2 : null}
+        paddingRight={leftAccessory ? 2 : null}
+        placeholder={placeholder}
+        readOnly={readOnly}
+        ref={handleInputRef}
+        required={required}
+        value={inputValue}
+        variant={TEXT.BODY_MD}
+        {...{
+          ...inputProps,
+          type,
+        }}
+      />
+      {rightAccessory}
+    </Box>
+  );
+};
+
+TextFieldBase.propTypes = {
+  /**
+   * Autocomplete allows the browser to predict the value based on earlier typed values
+   */
+  autoComplete: PropTypes.string,
+  /**
+   * If `true`, the input will be focused during the first mount.
+   */
+  autoFocus: PropTypes.bool,
+  /**
+   * An additional className to apply to the text-field-base
+   */
+  className: PropTypes.string,
+  /**
+   * The default input value, useful when not controlling the component.
+   */
+  defaultValue: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  /**
+   * If `true`, the input will be disabled.
+   */
+  disabled: PropTypes.bool,
+  /**
+   * If `true`, the input will indicate an error
+   */
+  error: PropTypes.bool,
+  /**
+   * The id of the `input` element.
+   */
+  id: PropTypes.string,
+  /**
+   * Attributes applied to the `input` element.
+   */
+  inputProps: PropTypes.object,
+  /**
+   * Component to appear on the left side of the input
+   */
+  leftAccessory: PropTypes.node,
+  /**
+   * Component to appear on the right side of the input
+   */
+  rightAccessory: PropTypes.node,
+  /**
+   * Use inputRef to pass a ref to the html input element.
+   */
+  inputRef: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
+  /**
+   * Max number of characters to allow
+   */
+  maxLength: PropTypes.number,
+  /**
+   * Name attribute of the `input` element.
+   */
+  name: PropTypes.string,
+  /**
+   * Callback fired on blur
+   */
+  onBlur: PropTypes.func,
+  /**
+   * Callback fired when the value is changed.
+   */
+  onChange: PropTypes.func,
+  /**
+   * Callback fired on focus
+   */
+  onFocus: PropTypes.func,
+  /**
+   * Callback fired on key down
+   */
+  onKeyDown: PropTypes.func,
+  /**
+   * Callback fired on key up
+   */
+  onKeyUp: PropTypes.func,
+  /**
+   * The short hint displayed in the input before the user enters a value.
+   */
+  placeholder: PropTypes.string,
+  /**
+   * It prevents the user from changing the value of the field (not from interacting with the field).
+   */
+  readOnly: PropTypes.bool,
+  /**
+   * If `true`, the input will be required. Currently no visual difference is shown.
+   */
+  required: PropTypes.bool,
+  /**
+   * The size of the text field. Changes the height of the component
+   * Accepts SM(32px), MD(40px), LG(48px)
+   */
+  size: PropTypes.oneOf(Object.values(TEXT_FIELD_SIZES)),
+  /**
+   * Type of the input element. Can be TEXT_FIELD_TYPES.TEXT, TEXT_FIELD_TYPES.PASSWORD, TEXT_FIELD_TYPES.NUMBER
+   * Defaults to TEXT_FIELD_TYPES.TEXT ('text')
+   */
+  type: PropTypes.oneOf(Object.values(TEXT_FIELD_TYPES)),
+  /**
+   * The input value, required for a controlled component.
+   */
+  value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  /**
+   * TextFieldBase accepts all the props from Box
+   */
+  ...Box.propTypes,
+};
+
+TextFieldBase.displayName = 'TextFieldBase';

--- a/ui/components/component-library/text-field-base/text-field-base.scss
+++ b/ui/components/component-library/text-field-base/text-field-base.scss
@@ -14,7 +14,6 @@
   }
 
   height: var(--text-field-base-height);
-  font-size: var(--typography-l-body-md-font-size);
   border-color: var(--color-border-default);
 
   &--focused {

--- a/ui/components/component-library/text-field-base/text-field-base.scss
+++ b/ui/components/component-library/text-field-base/text-field-base.scss
@@ -40,7 +40,7 @@
     background-color: transparent;
     border: none;
     height: 100%;
-    width: 100%;
+    flex-grow: 1;
     box-sizing: content-box;
     margin: 0;
     padding: 0;

--- a/ui/components/component-library/text-field-base/text-field-base.scss
+++ b/ui/components/component-library/text-field-base/text-field-base.scss
@@ -1,0 +1,54 @@
+.mm-text-field-base {
+  --text-field-base-height: var(--size, 40px);
+
+  &--size-sm {
+    --size: 32px;
+  }
+
+  &--size-md {
+    --size: 40px;
+  }
+
+  &--size-lg {
+    --size: 48px;
+  }
+
+  height: var(--text-field-base-height);
+  font-size: var(--typography-l-body-md-font-size);
+  border-color: var(--color-border-default);
+
+  &--focused {
+    border-color: var(--color-primary-default);
+  }
+
+  &--error {
+    border-color: var(--color-error-default);
+  }
+
+  &--disabled {
+    opacity: 0.5;
+    border-color: var(--color-border-default);
+  }
+
+  // truncates text with ellipsis
+  &--truncate .mm-text-field-base__input {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  &__input {
+    background-color: transparent;
+    border: none;
+    height: 100%;
+    width: 100%;
+    box-sizing: content-box;
+    margin: 0;
+    padding: 0;
+
+    &:focus,
+    &:focus-visible {
+      outline: none;
+    }
+  }
+}

--- a/ui/components/component-library/text-field-base/text-field-base.scss
+++ b/ui/components/component-library/text-field-base/text-field-base.scss
@@ -37,7 +37,6 @@
   }
 
   &__input {
-    background-color: transparent;
     border: none;
     height: 100%;
     flex-grow: 1;

--- a/ui/components/component-library/text-field-base/text-field-base.stories.js
+++ b/ui/components/component-library/text-field-base/text-field-base.stories.js
@@ -12,8 +12,8 @@ import { Icon, ICON_NAMES } from '../icon';
 import { AvatarToken } from '../avatar-token';
 
 import {
-  TEXT_FIELD_SIZES,
-  TEXT_FIELD_TYPES,
+  TEXT_FIELD_BASE_SIZES,
+  TEXT_FIELD_BASE_TYPES,
 } from './text-field-base.constants';
 import { TextFieldBase } from './text-field-base';
 import README from './README.mdx';
@@ -105,11 +105,11 @@ export default {
     },
     size: {
       control: 'select',
-      options: Object.values(TEXT_FIELD_SIZES),
+      options: Object.values(TEXT_FIELD_BASE_SIZES),
     },
     type: {
       control: 'select',
-      options: Object.values(TEXT_FIELD_TYPES),
+      options: Object.values(TEXT_FIELD_BASE_TYPES),
     },
     value: {
       control: 'text',
@@ -190,12 +190,12 @@ export const Type = (args) => (
     <TextFieldBase {...args} placeholder="Default" />
     <TextFieldBase
       {...args}
-      type={TEXT_FIELD_TYPES.PASSWORD}
+      type={TEXT_FIELD_BASE_TYPES.PASSWORD}
       placeholder="Password"
     />
     <TextFieldBase
       {...args}
-      type={TEXT_FIELD_TYPES.NUMBER}
+      type={TEXT_FIELD_BASE_TYPES.NUMBER}
       placeholder="Number"
     />
   </Box>

--- a/ui/components/component-library/text-field-base/text-field-base.stories.js
+++ b/ui/components/component-library/text-field-base/text-field-base.stories.js
@@ -1,0 +1,370 @@
+import React, { useState, useRef } from 'react';
+
+import {
+  SIZES,
+  DISPLAY,
+  COLORS,
+  FLEX_DIRECTION,
+} from '../../../helpers/constants/design-system';
+import Box from '../../ui/box/box';
+
+import { Icon, ICON_NAMES } from '../icon';
+import { AvatarToken } from '../avatar-token';
+
+import {
+  TEXT_FIELD_SIZES,
+  TEXT_FIELD_TYPES,
+} from './text-field-base.constants';
+import { TextFieldBase } from './text-field-base';
+import README from './README.mdx';
+
+const marginSizeControlOptions = [
+  undefined,
+  0,
+  1,
+  2,
+  3,
+  4,
+  5,
+  6,
+  7,
+  8,
+  9,
+  10,
+  11,
+  12,
+  'auto',
+];
+
+export default {
+  title: 'Components/ComponentLibrary/TextFieldBase',
+  id: __filename,
+  component: TextFieldBase,
+  parameters: {
+    docs: {
+      page: README,
+    },
+  },
+  argTypes: {
+    autoComplete: {
+      control: 'boolean',
+    },
+    autoFocus: {
+      control: 'boolean',
+    },
+    className: {
+      control: 'text',
+    },
+    defaultValue: {
+      control: 'text',
+    },
+    disabled: {
+      control: 'boolean',
+    },
+    error: {
+      control: 'boolean',
+    },
+    id: {
+      control: 'text',
+    },
+    inputProps: {
+      control: 'object',
+    },
+    leftAccessory: {
+      control: 'text',
+    },
+    maxLength: {
+      control: 'number',
+    },
+    name: {
+      control: 'text',
+    },
+    onBlur: {
+      action: 'onBlur',
+    },
+    onChange: {
+      action: 'onChange',
+    },
+    onClick: {
+      action: 'onClick',
+    },
+    onFocus: {
+      action: 'onFocus',
+    },
+    onKeyDown: {
+      action: 'onKeyDown',
+    },
+    onKeyUp: {
+      action: 'onKeyUp',
+    },
+    placeholder: {
+      control: 'text',
+    },
+    readOnly: {
+      control: 'boolean',
+    },
+    required: {
+      control: 'boolean',
+    },
+    rightAccessory: {
+      control: 'text',
+    },
+    showClear: {
+      control: 'boolean',
+    },
+    size: {
+      control: 'select',
+      options: Object.values(TEXT_FIELD_SIZES),
+    },
+    type: {
+      control: 'select',
+      options: Object.values(TEXT_FIELD_TYPES),
+    },
+    value: {
+      control: 'text',
+    },
+    marginTop: {
+      options: marginSizeControlOptions,
+      control: 'select',
+      table: { category: 'box props' },
+    },
+    marginRight: {
+      options: marginSizeControlOptions,
+      control: 'select',
+      table: { category: 'box props' },
+    },
+    marginBottom: {
+      options: marginSizeControlOptions,
+      control: 'select',
+      table: { category: 'box props' },
+    },
+    marginLeft: {
+      options: marginSizeControlOptions,
+      control: 'select',
+      table: { category: 'box props' },
+    },
+  },
+  args: {
+    placeholder: 'Placeholder...',
+    autoFocus: false,
+    defaultValue: '',
+    disabled: false,
+    error: false,
+    id: '',
+    readOnly: false,
+    required: false,
+    size: SIZES.MD,
+    type: 'text',
+    truncate: false,
+  },
+};
+
+const Template = (args) => <TextFieldBase {...args} />;
+
+export const DefaultStory = Template.bind({});
+DefaultStory.storyName = 'Default';
+
+export const Size = (args) => {
+  return (
+    <Box
+      display={DISPLAY.INLINE_FLEX}
+      flexDirection={FLEX_DIRECTION.COLUMN}
+      gap={4}
+    >
+      <TextFieldBase
+        {...args}
+        placeholder="SIZES.SM (height: 32px)"
+        size={SIZES.SM}
+      />
+      <TextFieldBase
+        {...args}
+        placeholder="SIZES.MD (height: 40px)"
+        size={SIZES.MD}
+      />
+      <TextFieldBase
+        {...args}
+        placeholder="SIZES.LG (height: 48px)"
+        size={SIZES.LG}
+      />
+    </Box>
+  );
+};
+
+export const Type = (args) => (
+  <Box
+    display={DISPLAY.INLINE_FLEX}
+    flexDirection={FLEX_DIRECTION.COLUMN}
+    gap={4}
+  >
+    <TextFieldBase {...args} placeholder="Default" />
+    <TextFieldBase
+      {...args}
+      type={TEXT_FIELD_TYPES.PASSWORD}
+      placeholder="Password"
+    />
+    <TextFieldBase
+      {...args}
+      type={TEXT_FIELD_TYPES.NUMBER}
+      placeholder="Number"
+    />
+  </Box>
+);
+
+export const Truncate = Template.bind({});
+Truncate.args = {
+  placeholder: 'Truncate',
+  value: 'Truncated text when truncate and width is set',
+  truncate: true,
+  style: { width: 240 },
+};
+
+export const LeftAccessoryRightAccessory = (args) => {
+  const [value, setValue] = useState({
+    search: '',
+    metaMask: '',
+    address: '0x514910771af9ca656af840dff83e8264ecf986ca',
+    amount: 1,
+  });
+  return (
+    <Box
+      display={DISPLAY.INLINE_FLEX}
+      flexDirection={FLEX_DIRECTION.COLUMN}
+      gap={4}
+    >
+      <TextFieldBase
+        {...args}
+        placeholder="Search"
+        value={value.search}
+        onChange={(e) => setValue({ ...value, search: e.target.value })}
+        leftAccessory={
+          <Icon
+            color={COLORS.ICON_ALTERNATIVE}
+            name={ICON_NAMES.SEARCH_FILLED}
+          />
+        }
+      />
+      <TextFieldBase
+        {...args}
+        value={value.metaMask}
+        onChange={(e) => setValue({ ...value, metaMask: e.target.value })}
+        placeholder="MetaMask"
+        rightAccessory={
+          <button
+            style={{
+              padding: 0,
+              background: 'transparent',
+              margin: 0,
+              display: 'flex',
+            }}
+            onClick={() => setValue({ ...value, metaMask: '' })}
+          >
+            <Icon name={ICON_NAMES.CLOSE_OUTLINE} size={SIZES.SM} />
+          </button>
+        }
+      />
+      <TextFieldBase
+        {...args}
+        placeholder="Enter address"
+        value={value.address}
+        onChange={(e) => setValue({ ...value, address: e.target.value })}
+        truncate
+        leftAccessory={<AvatarToken tokenName="ast" size={SIZES.SM} />}
+        rightAccessory={
+          <button
+            style={{
+              padding: 0,
+              background: 'transparent',
+              margin: 0,
+              display: 'flex',
+            }}
+            onClick={() => setValue({ ...value, address: '' })}
+          >
+            <Icon name={ICON_NAMES.CLOSE_OUTLINE} size={SIZES.SM} />
+          </button>
+        }
+      />
+      <TextFieldBase
+        {...args}
+        placeholder="Enter amount"
+        value={value.amount}
+        onChange={(e) => setValue({ ...value, amount: e.target.value })}
+        type="number"
+        leftAccessory={
+          <AvatarToken
+            tokenName="ast"
+            tokenImageUrl="./AST.png"
+            size={SIZES.SM}
+          />
+        }
+        rightAccessory={
+          <button onClick={() => setValue({ ...value, amount: 100000 })}>
+            Max
+          </button>
+        }
+      />
+    </Box>
+  );
+};
+
+export const InputRef = (args) => {
+  const inputRef = useRef(null);
+  const [value, setValue] = useState('');
+  const handleOnClick = () => {
+    inputRef.current.focus();
+  };
+  const handleOnChange = (e) => {
+    setValue(e.target.value);
+  };
+  return (
+    <>
+      <TextFieldBase
+        {...args}
+        inputRef={inputRef}
+        value={value}
+        onChange={handleOnChange}
+      />
+      <Box
+        as="button"
+        backgroundColor={COLORS.BACKGROUND_ALTERNATIVE}
+        color={COLORS.TEXT_DEFAULT}
+        borderColor={COLORS.BORDER_DEFAULT}
+        borderRadius={SIZES.XL}
+        marginLeft={1}
+        paddingLeft={2}
+        paddingRight={2}
+        onClick={handleOnClick}
+      >
+        Edit
+      </Box>
+    </>
+  );
+};
+
+export const AutoComplete = Template.bind({});
+AutoComplete.args = {
+  autoComplete: true,
+  type: 'password',
+  placeholder: 'Enter password',
+};
+
+export const AutoFocus = Template.bind({});
+AutoFocus.args = { autoFocus: true };
+
+export const DefaultValue = Template.bind({});
+DefaultValue.args = { defaultValue: 'Default value' };
+
+export const Disabled = Template.bind({});
+Disabled.args = { disabled: true };
+
+export const ErrorStory = Template.bind({});
+ErrorStory.args = { error: true };
+ErrorStory.storyName = 'Error';
+
+export const MaxLength = Template.bind({});
+MaxLength.args = { maxLength: 10, placeholder: 'Max length 10' };
+
+export const ReadOnly = Template.bind({});
+ReadOnly.args = { readOnly: true, value: 'Read only' };
+
+export const Required = Template.bind({});
+Required.args = { required: true, placeholder: 'Required' };

--- a/ui/components/component-library/text-field-base/text-field-base.stories.js
+++ b/ui/components/component-library/text-field-base/text-field-base.stories.js
@@ -103,9 +103,6 @@ export default {
     rightAccessory: {
       control: 'text',
     },
-    showClear: {
-      control: 'boolean',
-    },
     size: {
       control: 'select',
       options: Object.values(TEXT_FIELD_SIZES),

--- a/ui/components/component-library/text-field-base/text-field-base.stories.js
+++ b/ui/components/component-library/text-field-base/text-field-base.stories.js
@@ -91,12 +91,6 @@ export default {
     onFocus: {
       action: 'onFocus',
     },
-    onKeyDown: {
-      action: 'onKeyDown',
-    },
-    onKeyUp: {
-      action: 'onKeyUp',
-    },
     placeholder: {
       control: 'text',
     },

--- a/ui/components/component-library/text-field-base/text-field-base.test.js
+++ b/ui/components/component-library/text-field-base/text-field-base.test.js
@@ -1,6 +1,8 @@
 /* eslint-disable jest/require-top-level-describe */
 import React from 'react';
 import { fireEvent, render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
 import { SIZES } from '../../../helpers/constants/design-system';
 
 import { TextFieldBase } from './text-field-base';
@@ -175,17 +177,14 @@ describe('TextFieldBase', () => {
       'mm-text-field-base--error',
     );
   });
-  it('should render with maxLength and not allow more than the set characters', () => {
-    const { getByTestId } = render(
-      <TextFieldBase
-        maxLength={5}
-        inputProps={{ 'data-testid': 'text-field-base-max-length' }}
-      />,
-    );
-    const textFieldBase = getByTestId('text-field-base-max-length');
-    expect(textFieldBase).toHaveAttribute('maxLength', '5');
-    fireEvent.change(textFieldBase, { target: { value: 'five' } });
-    expect(textFieldBase).toHaveAttribute('value', 'five');
+  it('should render with maxLength and not allow more than the set characters', async () => {
+    const { getByRole } = render(<TextFieldBase maxLength={5} />);
+    const textFieldBase = getByRole('textbox');
+    await userEvent.type(textFieldBase, '1234567890');
+    expect(getByRole('textbox')).toBeDefined();
+    expect(textFieldBase.maxLength).toBe(5);
+    expect(textFieldBase.value).toBe('12345');
+    expect(textFieldBase.value.length).toBe(5);
   });
   it('should render with readOnly attr when readOnly is true', () => {
     const { getByTestId } = render(

--- a/ui/components/component-library/text-field-base/text-field-base.test.js
+++ b/ui/components/component-library/text-field-base/text-field-base.test.js
@@ -184,7 +184,7 @@ describe('TextFieldBase', () => {
     expect(getByRole('textbox')).toBeDefined();
     expect(textFieldBase.maxLength).toBe(5);
     expect(textFieldBase.value).toBe('12345');
-    expect(textFieldBase.value.length).toBe(5);
+    expect(textFieldBase.value).toHaveLength(5);
   });
   it('should render with readOnly attr when readOnly is true', () => {
     const { getByTestId } = render(

--- a/ui/components/component-library/text-field-base/text-field-base.test.js
+++ b/ui/components/component-library/text-field-base/text-field-base.test.js
@@ -1,0 +1,231 @@
+/* eslint-disable jest/require-top-level-describe */
+import React from 'react';
+import { fireEvent, render } from '@testing-library/react';
+import { SIZES } from '../../../helpers/constants/design-system';
+
+import { TextFieldBase } from './text-field-base';
+
+describe('TextFieldBase', () => {
+  it('should render correctly', () => {
+    const { getByRole } = render(<TextFieldBase />);
+    expect(getByRole('textbox')).toBeDefined();
+  });
+  it('should render and be able to input text', () => {
+    const { getByTestId } = render(
+      <TextFieldBase inputProps={{ 'data-testid': 'text-field-base' }} />,
+    );
+    const textFieldBase = getByTestId('text-field-base');
+
+    expect(textFieldBase.value).toBe(''); // initial value is empty string
+    fireEvent.change(textFieldBase, { target: { value: 'text value' } });
+    expect(textFieldBase.value).toBe('text value');
+    fireEvent.change(textFieldBase, { target: { value: '' } }); // reset value
+    expect(textFieldBase.value).toBe(''); // value is empty string after reset
+  });
+  it('should render and fire onFocus and onBlur events', () => {
+    const onFocus = jest.fn();
+    const onBlur = jest.fn();
+    const { getByTestId } = render(
+      <TextFieldBase
+        inputProps={{ 'data-testid': 'text-field-base' }}
+        onFocus={onFocus}
+        onBlur={onBlur}
+      />,
+    );
+    const textFieldBase = getByTestId('text-field-base');
+
+    fireEvent.focus(textFieldBase);
+    expect(onFocus).toHaveBeenCalledTimes(1);
+    fireEvent.blur(textFieldBase);
+    expect(onBlur).toHaveBeenCalledTimes(1);
+  });
+  it('should render and fire onChange event', () => {
+    const onChange = jest.fn();
+    const { getByTestId } = render(
+      <TextFieldBase
+        inputProps={{ 'data-testid': 'text-field-base' }}
+        onChange={onChange}
+      />,
+    );
+    const textFieldBase = getByTestId('text-field-base');
+
+    fireEvent.change(textFieldBase, { target: { value: 'text value' } });
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+  it('should render and fire onKeyDown and onKeyUp events', () => {
+    const onKeyDown = jest.fn();
+    const onKeyUp = jest.fn();
+    const { getByTestId } = render(
+      <TextFieldBase
+        inputProps={{ 'data-testid': 'text-field-base' }}
+        onKeyDown={onKeyDown}
+        onKeyUp={onKeyUp}
+      />,
+    );
+    const textFieldBase = getByTestId('text-field-base');
+
+    fireEvent.keyDown(textFieldBase, { key: 'Enter', code: 'Enter' });
+    expect(onKeyDown).toHaveBeenCalledTimes(1);
+    fireEvent.keyUp(textFieldBase, { key: 'Enter', code: 'Enter' });
+    expect(onKeyUp).toHaveBeenCalledTimes(1);
+  });
+  it('should render and fire onClick event', () => {
+    const onClick = jest.fn();
+    const { getByTestId } = render(
+      <TextFieldBase
+        inputProps={{ 'data-testid': 'text-field-base' }}
+        onClick={onClick}
+      />,
+    );
+    const textFieldBase = getByTestId('text-field-base');
+
+    fireEvent.click(textFieldBase);
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+  it('should render with different size classes', () => {
+    const { getByTestId } = render(
+      <>
+        <TextFieldBase size={SIZES.SM} data-testid="sm" />
+        <TextFieldBase size={SIZES.MD} data-testid="md" />
+        <TextFieldBase size={SIZES.LG} data-testid="lg" />
+      </>,
+    );
+    expect(getByTestId('sm')).toHaveClass('mm-text-field-base--size-sm');
+    expect(getByTestId('md')).toHaveClass('mm-text-field-base--size-md');
+    expect(getByTestId('lg')).toHaveClass('mm-text-field-base--size-lg');
+  });
+  it('should render with different types', () => {
+    const { getByTestId } = render(
+      <>
+        <TextFieldBase inputProps={{ 'data-testid': 'text-field-base-text' }} />
+        <TextFieldBase
+          type="number"
+          inputProps={{ 'data-testid': 'text-field-base-number' }}
+        />
+        <TextFieldBase
+          type="password"
+          inputProps={{ 'data-testid': 'text-field-base-password' }}
+        />
+      </>,
+    );
+    expect(getByTestId('text-field-base-text')).toHaveAttribute('type', 'text');
+    expect(getByTestId('text-field-base-number')).toHaveAttribute(
+      'type',
+      'number',
+    );
+    expect(getByTestId('text-field-base-password')).toHaveAttribute(
+      'type',
+      'password',
+    );
+  });
+  it('should render with truncate class', () => {
+    const { getByTestId } = render(
+      <TextFieldBase truncate data-testid="truncate" />,
+    );
+    expect(getByTestId('truncate')).toHaveClass('mm-text-field-base--truncate');
+  });
+  it('should render with right and left accessories', () => {
+    const { getByRole, getByText } = render(
+      <TextFieldBase
+        leftAccessory={<div>left accessory</div>}
+        rightAccessory={<div>right accessory</div>}
+      />,
+    );
+    expect(getByRole('textbox')).toBeDefined();
+    expect(getByText('left accessory')).toBeDefined();
+    expect(getByText('right accessory')).toBeDefined();
+  });
+  it('should render with working ref using inputRef prop', () => {
+    // Because the 'ref' attribute wont flow down to the DOM
+    // I'm not exactly sure how to test this?
+    const mockRef = jest.fn();
+    const { getByRole } = render(<TextFieldBase inputRef={mockRef} />);
+    expect(getByRole('textbox')).toBeDefined();
+    expect(mockRef).toHaveBeenCalledTimes(1);
+  });
+  it('should render with autoComplete', () => {
+    const { getByTestId } = render(
+      <TextFieldBase
+        autoComplete
+        inputProps={{ 'data-testid': 'text-field-base-auto-complete' }}
+      />,
+    );
+    expect(getByTestId('text-field-base-auto-complete')).toHaveAttribute(
+      'autocomplete',
+      'on',
+    );
+  });
+  it('should render with autoFocus', () => {
+    const { getByRole } = render(<TextFieldBase autoFocus />);
+    expect(getByRole('textbox')).toHaveFocus();
+  });
+  it('should render with a defaultValue', () => {
+    const { getByRole } = render(
+      <TextFieldBase
+        defaultValue="default value"
+        inputProps={{ 'data-testid': 'text-field-base-default-value' }}
+      />,
+    );
+    expect(getByRole('textbox').value).toBe('default value');
+  });
+  it('should render in disabled state and not focus or be clickable', () => {
+    const mockOnClick = jest.fn();
+    const mockOnFocus = jest.fn();
+    const { getByRole } = render(
+      <TextFieldBase disabled onFocus={mockOnFocus} onClick={mockOnClick} />,
+    );
+
+    getByRole('textbox').focus();
+    expect(getByRole('textbox')).toBeDisabled();
+    expect(mockOnClick).toHaveBeenCalledTimes(0);
+    expect(mockOnFocus).toHaveBeenCalledTimes(0);
+  });
+  it('should render with error className when error is true', () => {
+    const { getByTestId } = render(
+      <TextFieldBase
+        error
+        value="error value"
+        data-testid="text-field-base-error"
+      />,
+    );
+    expect(getByTestId('text-field-base-error')).toHaveClass(
+      'mm-text-field-base--error',
+    );
+  });
+  it('should render with maxLength and not allow more than the set characters', () => {
+    const { getByTestId } = render(
+      <TextFieldBase
+        maxLength={5}
+        inputProps={{ 'data-testid': 'text-field-base-max-length' }}
+      />,
+    );
+    const textFieldBase = getByTestId('text-field-base-max-length');
+    expect(textFieldBase).toHaveAttribute('maxLength', '5');
+    fireEvent.change(textFieldBase, { target: { value: 'five' } });
+    expect(textFieldBase).toHaveAttribute('value', 'five');
+  });
+  it('should render with readOnly attr when readOnly is true', () => {
+    const { getByTestId } = render(
+      <TextFieldBase
+        readOnly
+        inputProps={{ 'data-testid': 'text-field-base-readonly' }}
+      />,
+    );
+    expect(getByTestId('text-field-base-readonly')).toHaveAttribute(
+      'readonly',
+      '',
+    );
+  });
+  it('should render with required attr when required is true', () => {
+    const { getByTestId } = render(
+      <TextFieldBase
+        required
+        inputProps={{ 'data-testid': 'text-field-base-required' }}
+      />,
+    );
+    expect(getByTestId('text-field-base-required')).toHaveAttribute(
+      'required',
+      '',
+    );
+  });
+});

--- a/ui/components/component-library/text-field-base/text-field-base.test.js
+++ b/ui/components/component-library/text-field-base/text-field-base.test.js
@@ -52,23 +52,6 @@ describe('TextFieldBase', () => {
     fireEvent.change(textFieldBase, { target: { value: 'text value' } });
     expect(onChange).toHaveBeenCalledTimes(1);
   });
-  it('should render and fire onKeyDown and onKeyUp events', () => {
-    const onKeyDown = jest.fn();
-    const onKeyUp = jest.fn();
-    const { getByTestId } = render(
-      <TextFieldBase
-        inputProps={{ 'data-testid': 'text-field-base' }}
-        onKeyDown={onKeyDown}
-        onKeyUp={onKeyUp}
-      />,
-    );
-    const textFieldBase = getByTestId('text-field-base');
-
-    fireEvent.keyDown(textFieldBase, { key: 'Enter', code: 'Enter' });
-    expect(onKeyDown).toHaveBeenCalledTimes(1);
-    fireEvent.keyUp(textFieldBase, { key: 'Enter', code: 'Enter' });
-    expect(onKeyUp).toHaveBeenCalledTimes(1);
-  });
   it('should render and fire onClick event', () => {
     const onClick = jest.fn();
     const { getByTestId } = render(


### PR DESCRIPTION
## Explanation

Adding `TextFieldBase` component as a base for all text type components. Borrowed some architectural decisions [from material ui](https://github.com/mui/material-ui/blob/78fc73ccb93628f0a7a762f1023de896c1be36f4/packages/mui-material/src/TextField/TextField.js)

### Architecture
The `TextFieldBase` component is made up of 2 components the wrapping `<Box />` and `<Text />` components. The Box contains all of the visual css and allows for right and left accessories to be placed outside of the html input element. The html input element is the root element of the Text component. In a previous PR I forwarded refs to both Box and Text to allow for focusing during the onClick on the wrapping Box component. This allows for the input to look focused while maintaining the left and right accessories to be focusable using the keyboard and maintaining accessibility

![Screen Shot 2022-10-04 at 1 52 54 PM](https://user-images.githubusercontent.com/8112138/193925728-dd13b976-62b2-4a97-b036-2bc87649071e.png)

https://user-images.githubusercontent.com/8112138/193925236-eeb91023-51ab-437a-bf84-4e7d01c75825.mov

## More Information
Fixes #15099 
[Figma link](https://www.figma.com/file/HKpPKij9V3TpsyMV1TpV7C/DS-Components?node-id=1244%3A11663)

## Screenshots/Screencaps

https://user-images.githubusercontent.com/8112138/193337278-96da5319-37dc-4f92-8402-97eb79b1bbe3.mov

## Manual Testing Steps

- Go to the latest build of storybook on this PR

## Pre-Merge Checklist

- [x] PR template is filled out
- [x] **IF** this PR fixes a bug, a test that _would have_ caught the bug has been added
- [x] PR is linked to the appropriate GitHub issue
- [x] PR has been added to the appropriate release Milestone

### + If there are functional changes:

- [x] Manual testing complete & passed
- [x] "Extension QA Board" label has been applied
