### PR TITLE
Fixes display of avatar in flex container

### DIFF
--- a/ui/components/component-library/base-avatar/base-avatar.scss
+++ b/ui/components/component-library/base-avatar/base-avatar.scss
@@ -23,6 +23,8 @@
 
   height: var(--avatar-size);
   width: var(--avatar-size);
+  max-width: var(--avatar-size);
+  flex: 0 0 var(--avatar-size);
   border-radius: 100%;
   overflow: hidden;
   display: flex;


### PR DESCRIPTION
## Explanation

Currently, the BaseAvatar breaks if the flex container is smaller than the children and will try to squeeze the avatar into the space available. 

This is a problem because the BaseAvatar should always be the same ratio

In order to solve this problem, this pull request add flex property to the BaseAvatar to fix this

## Screenshots/Screencaps

### Before

https://user-images.githubusercontent.com/8112138/193362921-5de11e31-34ab-4562-9ebd-adaa1cb2e39c.mov

### After

https://user-images.githubusercontent.com/8112138/193362935-8b0f9bb5-6a6d-41da-9db1-02e696f2246c.mov

## Manual Testing Steps

- Go to the latest build of storybook in this PR
- Search for AvatarTokem and find the Size story
- Resize the browser so it is smaller than the Avatars
