### PR TITLE
Fix the rendering of certain domain names in connected-sites list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fix issue where domain names were not always beign rendered correctly in the connected sites list ([#16074](https://github.com/MetaMask/metamask-extension/pull/16074))
 
 ## [10.20.0]
 ### Changed

--- a/test/e2e/tests/dapp-interactions.spec.js
+++ b/test/e2e/tests/dapp-interactions.spec.js
@@ -115,11 +115,11 @@ describe('Dapp interactions', function () {
         await driver.clickElement({ text: 'Connected sites', tag: 'span' });
         const connectedDapp1 = await driver.isElementPresent({
           text: 'http://127.0.0.1:8080',
-          tag: 'span',
+          tag: 'bdi',
         });
         const connectedDapp2 = await driver.isElementPresent({
           text: 'http://127.0.0.1:8081',
-          tag: 'span',
+          tag: 'bdi',
         });
 
         assert.ok(connectedDapp1, 'Account not connected to Dapp1');

--- a/ui/components/app/signature-request-original/__snapshots__/signature-request-original.test.js.snap
+++ b/ui/components/app/signature-request-original/__snapshots__/signature-request-original.test.js.snap
@@ -135,9 +135,11 @@ exports[`SignatureRequestOriginal should match snapshot 1`] = `
         <div
           class="site-origin request-signature__origin"
         >
-          <span>
+          <bdi
+            dir="ltr"
+          >
             https://happydapp.website/governance?futarchy=true
-          </span>
+          </bdi>
         </div>
       </div>
       <div

--- a/ui/components/ui/site-origin/site-origin.js
+++ b/ui/components/ui/site-origin/site-origin.js
@@ -30,7 +30,7 @@ export default function SiteOrigin({
           rightIcon={rightIcon}
         />
       ) : (
-        <span>{siteOrigin}</span>
+        <bdi dir="ltr">{siteOrigin}</bdi>
       )}
     </div>
   );

--- a/ui/components/ui/site-origin/site-origin.test.js
+++ b/ui/components/ui/site-origin/site-origin.test.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import SiteOrigin from './site-origin';
+
+describe('SiteOrigin', () => {
+  const defaultProps = {
+    siteOrigin: 'https://example.com',
+    iconSrc: 'https://example.com/icon.png',
+    iconName: 'icon',
+    chip: false,
+    className: '',
+    rightIcon: false,
+  };
+
+  it('renders number and hyphen prefixed domains correctly', () => {
+    const numberHyphenPrefixOrigin = '0-example.com';
+    const wrapper = shallow(
+      <SiteOrigin {...defaultProps} siteOrigin={numberHyphenPrefixOrigin} />,
+    );
+    const bdiElement = wrapper.find('bdi');
+
+    expect(bdiElement.text()).toBe('0-example.com');
+  });
+});


### PR DESCRIPTION
## Summary 

When a site connected to MetaMask is prefixed with a digit and a hyphen (ex: `123-github.com`), it is displayed incorrectly in the connected sites page. 

<img width="600" alt="Screen Shot 2022-10-04 at 11 12 26 AM" src="https://user-images.githubusercontent.com/15018469/193857592-88701735-fd3d-4d6e-834a-3c727fcf438a.png">

## Why does this happen?

The root cause of this issue has to do with the BIDI (bidirectional)  algorithm used to display text in a right-to-left direction as denoted by the `direction: rtl;` CSS property. 

When this CSS property is applied to text, the BIDI text algorithm is run to display the content in the correct format for right-to-left languages. However, this results in special behaviour to occur when a number followed by a hyphen is included in the text. This is explained in point number 3 on the following [w3 article](https://www.w3.org/International/articles/strings-and-bidi/#tcy) which notes:


> The hyphen, and a few other characters, have special properties when used as a number separator, or in mathematical expressions in Arabic, Thaana, or Syriac. If the bidi algorithm identifies a character from those scripts prior to a sequence of numbers separated by hyphens, it orders the sequence right-to-left. This is how an Arabic user would normally expect to read a range or mathematical expression. So a range such as 10-12 in English, where the hyphen means 'to', would look like this in Arabic: 12-10.
> You can see this right-to-left order applied correctly in the Availability field near the bottom of the form, which indicates a range of 1-3 days by showing "3-1".

## Solution

Wrapping the content in a `<bdi dir="ltr">` ensures that the origin gets treated as a single entity, and does not get incorrectly manipulated by the [unicode bidirectional algorithm](https://www.w3.org/International/articles/inline-bidi-markup/uba-basics). This stays consistent with Google's [recommendation](https://chromium.googlesource.com/chromium/src/+/master/docs/security/url_display_guidelines/url_display_guidelines.md#eliding-urls) as well to ensure that we always see the TLD of long domains. 

## Manual Testing Steps

* Visit a site with a long domain name such as https://llanfairpwllgwyngyllgogerychwyrndrobwllllantysiliogogogoch.co.uk/
* Manually connect your MetaMask dev wallet to the site.
* Visit your connected sites tab within MetaMask and see that we continue to show the rightmost part of the domain name.
* Next inspect the domain you are connected to, and edit it to have `123-` as a prefix so it becomes: `123-llanfairpwllgwyngyllgogerychwyrndrobwllllantysiliogogogoch.co.uk`. 
* See that we no longer move the digits  to the end of the domain name

## Pre-Merge Checklist

- [x] PR template is filled out
- [x] **IF** this PR fixes a bug, a test that _would have_ caught the bug has been added
- [x] PR is linked to the appropriate GitHub issue
- [x] PR has been added to the appropriate release Milestone
