### PR TITLE
Lower coverage requirement

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -11,7 +11,7 @@ module.exports = {
   coverageThreshold: {
     global: {
       branches: 44,
-      functions: 46.8,
+      functions: 46,
       lines: 52,
       statements: 52,
     },


### PR DESCRIPTION
The function coverage requirement was raised too high in #16040, breaking CI on `develop` and in any new branches. This PR removes the decimal, lowering the coverage requirement slightly and fixing CI.