### PR TITLE
[FLASK] Allow snaps insights to show on regular EOA transactions

### DIFF
--- a/ui/components/app/confirm-page-container/confirm-page-container-content/confirm-page-container-content.component.js
+++ b/ui/components/app/confirm-page-container/confirm-page-container-content/confirm-page-container-content.component.js
@@ -102,9 +102,11 @@ export default class ConfirmPageContainerContent extends Component {
         >
           {detailsComponent}
         </Tab>
-        <Tab className="confirm-page-container-content__tab" name={t('data')}>
-          {dataComponent}
-        </Tab>
+        {dataComponent && (
+          <Tab className="confirm-page-container-content__tab" name={t('data')}>
+            {dataComponent}
+          </Tab>
+        )}
         {dataHexComponent && (
           <Tab
             className="confirm-page-container-content__tab"

--- a/ui/pages/confirm-transaction-base/confirm-transaction-base.component.js
+++ b/ui/pages/confirm-transaction-base/confirm-transaction-base.component.js
@@ -764,13 +764,17 @@ export default class ConfirmTransactionBase extends Component {
       ({ id }) => id === selectedInsightSnapId,
     );
 
+    const allowedTransactionTypes =
+      txData.type === TRANSACTION_TYPES.CONTRACT_INTERACTION ||
+      txData.type === TRANSACTION_TYPES.SIMPLE_SEND ||
+      txData.type === TRANSACTION_TYPES.TOKEN_METHOD_SAFE_TRANSFER_FROM ||
+      txData.type === TRANSACTION_TYPES.TOKEN_METHOD_TRANSFER_FROM ||
+      txData.type === TRANSACTION_TYPES.TOKEN_METHOD_TRANSFER;
+
     const networkId = CHAIN_ID_TO_NETWORK_ID_MAP[chainId];
     const caip2ChainId = `eip155:${networkId ?? stripHexPrefix(chainId)}`;
 
-    if (
-      txData.type !== TRANSACTION_TYPES.CONTRACT_INTERACTION ||
-      !insightSnaps.length
-    ) {
+    if (!allowedTransactionTypes || !insightSnaps.length) {
       return null;
     }
 


### PR DESCRIPTION
## Explanation

Allow regular EOA transactions to display Snap TX insights on confirmation screen.

## Manual Testing Steps

- Clone https://github.com/GuillaumeRx/snap-tx-insight
- yarn install && yarn start in the snap-tx-insight repo
- connect the snap
- Do a regular transaction
- Look at the tx insight tab in the tx confirmation screen

Fixes https://github.com/MetaMask/snaps-skunkworks/issues/805