### PR TITLE
temporarily patch `ethereumjs-util` to use an implementation of `stripHexPrefix` that doesn't throw when pass a non string typed arg

### DIFF
--- a/patches/ethereumjs-util+7.1.5.patch
+++ b/patches/ethereumjs-util+7.1.5.patch
@@ -1,0 +1,48 @@
+diff --git a/node_modules/ethereumjs-util/dist.browser/internal.js b/node_modules/ethereumjs-util/dist.browser/internal.js
+index 9f3888b..3803958 100644
+--- a/node_modules/ethereumjs-util/dist.browser/internal.js
++++ b/node_modules/ethereumjs-util/dist.browser/internal.js
+@@ -43,8 +43,9 @@ exports.isHexPrefixed = isHexPrefixed;
+  * @returns the string without 0x prefix
+  */
+ var stripHexPrefix = function (str) {
+-    if (typeof str !== 'string')
+-        throw new Error("[stripHexPrefix] input must be type 'string', received ".concat(typeof str));
++    if (typeof str !== 'string'){
++        return str;
++    }
+     return isHexPrefixed(str) ? str.slice(2) : str;
+ };
+ exports.stripHexPrefix = stripHexPrefix;
+diff --git a/node_modules/ethereumjs-util/dist/internal.js b/node_modules/ethereumjs-util/dist/internal.js
+index 01a90a0..9f1d8cd 100644
+--- a/node_modules/ethereumjs-util/dist/internal.js
++++ b/node_modules/ethereumjs-util/dist/internal.js
+@@ -43,8 +43,9 @@ exports.isHexPrefixed = isHexPrefixed;
+  * @returns the string without 0x prefix
+  */
+ const stripHexPrefix = (str) => {
+-    if (typeof str !== 'string')
+-        throw new Error(`[stripHexPrefix] input must be type 'string', received ${typeof str}`);
++    if (typeof str !== 'string'){
++        return str;
++    }
+     return isHexPrefixed(str) ? str.slice(2) : str;
+ };
+ exports.stripHexPrefix = stripHexPrefix;
+diff --git a/node_modules/ethereumjs-util/src/internal.ts b/node_modules/ethereumjs-util/src/internal.ts
+index 52032f5..8f6f5f8 100644
+--- a/node_modules/ethereumjs-util/src/internal.ts
++++ b/node_modules/ethereumjs-util/src/internal.ts
+@@ -42,8 +42,9 @@ export function isHexPrefixed(str: string): boolean {
+  * @returns the string without 0x prefix
+  */
+ export const stripHexPrefix = (str: string): string => {
+-  if (typeof str !== 'string')
+-    throw new Error(`[stripHexPrefix] input must be type 'string', received ${typeof str}`)
++  if (typeof str !== 'string') {
++    return str;
++  }
+ 
+   return isHexPrefixed(str) ? str.slice(2) : str
+ }


### PR DESCRIPTION
## Explanation
Because we use a [yarn deduplication strategy](https://yarnpkg.com/package/yarn-deduplicate#deduplication-strategies) that will resolve the all packages with the carrot `^` to the highest minor version if it is shared across the dependency tree, [some recent updates ](https://github.com/MetaMask/metamask-extension/pull/15878) bumped the highest shared minor version of `ethereumjs-util` to `7.1.5` which (somewhere between 7.0.9 and 7.1.5) failed to acknowledge that it actually contains a breaking change: `stripHexPrefix` now throws an error if pass a non-string typed arg, where previously it would simply return the arg unaltered. We assume this latter behavior in a number of places, hence the addition of this older implementation to hexstring-utils [here](https://github.com/MetaMask/metamask-extension/pull/15878/files#diff-f6b120c1869bc7363902d972ebbc6b34fef85122aa58b606f5fdddec01dfb049R78).

This is a temporary patch to get this back to working, while some inflight work in the `eth-simple-keyring`, `eth-hd-keyring` and `eth-keyring-controller` gets resolved in such a way that we will have a more durable long term fix.

## More Information
* Fixes #16052 

## Manual Testing Steps
- Go to Test Dapp
- Attempt to Encrypt and then Decrypt
- You should see the message you passed to encrypt, correctly decrypted.


## Pre-Merge Checklist

- [x] PR template is filled out
- [ ] **IF** this PR fixes a bug, a test that _would have_ caught the bug has been added
- [x] PR is linked to the appropriate GitHub issue
- [ ] PR has been added to the appropriate release Milestone

### + If there are functional changes:

- [x] Manual testing complete & passed
- [ ] "Extension QA Board" label has been applied
