### PR TITLE
Feat/15951/add button secondary

### DIFF
--- a/.storybook/4.SHADOW.stories.mdx
+++ b/.storybook/4.SHADOW.stories.mdx
@@ -236,12 +236,12 @@ Using both size and color tokens, different shadows can be applied to components
         spanAlign: 'center',
         height: 100,
         textAlign: 'center',
-        boxShadow: 'var(--component-button-secondary-shadow)',
+        boxShadow: 'var(--component-button-primary-shadow)',
         backgroundColor: 'var(--color-primary-default)',
         color: 'var(--color-primary-inverse)',
       }}
     >
-      <span>Button Secondary Hover</span>
+      <span>Button Primary Hover</span>
     </div>
     <div
       style={{
@@ -262,14 +262,14 @@ Using both size and color tokens, different shadows can be applied to components
   </div>
 </div>
 
-| Component                  | JS                                                               | CSS |
-| -------------------------- | ---------------------------------------------------------------- | --- |
-| **Card**                   | `box-shadow: var(--shadow-size-xs) var(--color-shadow-default);` |
-| **Dropdown**               | `box-shadow: var(--shadow-size-sm) var(--color-shadow-default);` |
-| **Toast**                  | `box-shadow: var(--shadow-size-md) var(--color-shadow-default);` |
-| **Modal**                  | `box-shadow: var(--shadow-size-lg) var(--color-shadow-default);` |
-| **Button Secondary Hover** | `box-shadow: var(--shadow-size-sm) var(--color-primary-shadow);` |
-| **Button Danger Hover**    | `box-shadow: var(--shadow-size-sm) var(--color-error-shadow);`   |
+| Component                | JS                                                               | CSS |
+| ------------------------ | ---------------------------------------------------------------- | --- |
+| **Card**                 | `box-shadow: var(--shadow-size-xs) var(--color-shadow-default);` |
+| **Dropdown**             | `box-shadow: var(--shadow-size-sm) var(--color-shadow-default);` |
+| **Toast**                | `box-shadow: var(--shadow-size-md) var(--color-shadow-default);` |
+| **Modal**                | `box-shadow: var(--shadow-size-lg) var(--color-shadow-default);` |
+| **Button Primary Hover** | `box-shadow: var(--shadow-size-sm) var(--color-primary-shadow);` |
+| **Button Danger Hover**  | `box-shadow: var(--shadow-size-sm) var(--color-error-shadow);`   |
 
 ## Takeaways
 

--- a/.storybook/4.SHADOW.stories.mdx
+++ b/.storybook/4.SHADOW.stories.mdx
@@ -236,12 +236,12 @@ Using both size and color tokens, different shadows can be applied to components
         spanAlign: 'center',
         height: 100,
         textAlign: 'center',
-        boxShadow: 'var(--component-button-primary-shadow)',
+        boxShadow: 'var(--component-button-secondary-shadow)',
         backgroundColor: 'var(--color-primary-default)',
         color: 'var(--color-primary-inverse)',
       }}
     >
-      <span>Button Primary Hover</span>
+      <span>Button Secondary Hover</span>
     </div>
     <div
       style={{
@@ -262,14 +262,14 @@ Using both size and color tokens, different shadows can be applied to components
   </div>
 </div>
 
-| Component                | JS                                                               | CSS |
-| ------------------------ | ---------------------------------------------------------------- | --- |
-| **Card**                 | `box-shadow: var(--shadow-size-xs) var(--color-shadow-default);` |
-| **Dropdown**             | `box-shadow: var(--shadow-size-sm) var(--color-shadow-default);` |
-| **Toast**                | `box-shadow: var(--shadow-size-md) var(--color-shadow-default);` |
-| **Modal**                | `box-shadow: var(--shadow-size-lg) var(--color-shadow-default);` |
-| **Button Primary Hover** | `box-shadow: var(--shadow-size-sm) var(--color-primary-shadow);` |
-| **Button Danger Hover**  | `box-shadow: var(--shadow-size-sm) var(--color-error-shadow);`   |
+| Component                  | JS                                                               | CSS |
+| -------------------------- | ---------------------------------------------------------------- | --- |
+| **Card**                   | `box-shadow: var(--shadow-size-xs) var(--color-shadow-default);` |
+| **Dropdown**               | `box-shadow: var(--shadow-size-sm) var(--color-shadow-default);` |
+| **Toast**                  | `box-shadow: var(--shadow-size-md) var(--color-shadow-default);` |
+| **Modal**                  | `box-shadow: var(--shadow-size-lg) var(--color-shadow-default);` |
+| **Button Secondary Hover** | `box-shadow: var(--shadow-size-sm) var(--color-primary-shadow);` |
+| **Button Danger Hover**    | `box-shadow: var(--shadow-size-sm) var(--color-error-shadow);`   |
 
 ## Takeaways
 

--- a/ui/components/component-library/button-primary/button-primary.stories.js
+++ b/ui/components/component-library/button-primary/button-primary.stories.js
@@ -104,11 +104,7 @@ export default {
   },
 };
 
-export const DefaultStory = (args) => (
-  <>
-    <ButtonPrimary {...args} />
-  </>
-);
+export const DefaultStory = (args) => <ButtonPrimary {...args} />;
 
 DefaultStory.storyName = 'Default';
 

--- a/ui/components/component-library/button-secondary/README.mdx
+++ b/ui/components/component-library/button-secondary/README.mdx
@@ -4,7 +4,7 @@ import { ButtonSecondary } from './button-secondary';
 
 # ButtonSecondary
 
-The `ButtonSecondary` is an extension of `ButtonBase` to support primary styles.
+The `ButtonSecondary` is an extension of `ButtonBase` to support secondary styles.
 
 <Canvas>
   <Story id="ui-components-component-library-button-secondary-button-secondary-stories-js--default-story" />

--- a/ui/components/component-library/button-secondary/README.mdx
+++ b/ui/components/component-library/button-secondary/README.mdx
@@ -1,0 +1,57 @@
+import { Story, Canvas, ArgsTable } from '@storybook/addon-docs';
+
+import { ButtonSecondary } from './button-secondary';
+
+# ButtonSecondary
+
+The `ButtonSecondary` is an extension of `ButtonBase` to support primary styles.
+
+<Canvas>
+  <Story id="ui-components-component-library-button-secondary-button-secondary-stories-js--default-story" />
+</Canvas>
+
+## Props
+
+The `ButtonSecondary` accepts all props below as well as all [Box](/docs/ui-components-ui-box-box-stories-js--default-story#props) and [ButtonBase](/docs/ui-components-component-library-button-base-button-base-stories-js--default-story#props) component props
+
+<ArgsTable of={ButtonSecondary} />
+
+### Size
+
+Use the `size` prop and the `SIZES` object from `./ui/helpers/constants/design-system.js` to change the size of `ButtonSecondary`. Defaults to `SIZES.MD`
+
+Optional: `BUTTON_SIZES` from `./button-base` object can be used instead of `SIZES`.
+
+Possible sizes include:
+
+- `SIZES.SM` 32px
+- `SIZES.MD` 40px
+- `SIZES.LG` 48px
+
+<Canvas>
+  <Story id="ui-components-component-library-button-secondary-button-secondary-stories-js--size" />
+</Canvas>
+
+```jsx
+import { SIZES } from '../../../helpers/constants/design-system';
+import { ButtonSecondary } from '../ui/component-library/button/button-secondary/button-secondary';
+
+<ButtonSecondary size={SIZES.SM} />
+<ButtonSecondary size={SIZES.MD} />
+<ButtonSecondary size={SIZES.LG} />
+```
+
+### Type
+
+Use the `type` prop and the `BUTTON_TYPES` object from `./ui/helpers/constants/design-system.js` to change the context of `ButtonSecondary`.
+
+<Canvas>
+  <Story id="ui-components-component-library-button-secondary-button-secondary-stories-js--type" />
+</Canvas>
+
+```jsx
+import { ButtonSecondary } from '../ui/component-library/button/button-secondary/button-secondary';
+
+<ButtonSecondary>Normal</ButtonSecondary>
+<ButtonSecondary danger>Danger</ButtonSecondary>
+```

--- a/ui/components/component-library/button-secondary/button-secondary.constants.js
+++ b/ui/components/component-library/button-secondary/button-secondary.constants.js
@@ -1,0 +1,7 @@
+import { SIZES } from '../../../helpers/constants/design-system';
+
+export const BUTTON_SECONDARY_SIZES = {
+  SM: SIZES.SM,
+  MD: SIZES.MD,
+  LG: SIZES.LG,
+};

--- a/ui/components/component-library/button-secondary/button-secondary.js
+++ b/ui/components/component-library/button-secondary/button-secondary.js
@@ -1,0 +1,46 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classnames from 'classnames';
+
+import { ButtonBase } from '../button-base';
+import { BUTTON_SECONDARY_SIZES } from './button-secondary.constants';
+
+export const ButtonSecondary = ({
+  className,
+  danger,
+  size = BUTTON_SECONDARY_SIZES.MD,
+
+  ...props
+}) => {
+  return (
+    <ButtonBase
+      className={classnames(className, 'mm-button-secondary', {
+        'mm-button-secondary--type-danger': danger,
+      })}
+      size={size}
+      {...props}
+    />
+  );
+};
+
+ButtonSecondary.propTypes = {
+  /**
+   * An additional className to apply to the ButtonSecondary.
+   */
+  className: PropTypes.string,
+  /**
+   * Boolean to change button type to Danger when true
+   */
+  danger: PropTypes.bool,
+  /**
+   * The possible size values for ButtonSecondary: 'BUTTON_SECONDARY_SIZES.SM', 'BUTTON_SECONDARY_SIZES.MD', 'BUTTON_SECONDARY_SIZES.LG',
+   * Default value is 'BUTTON_SECONDARY_SIZES.MD'.
+   */
+  size: PropTypes.oneOf(Object.values(BUTTON_SECONDARY_SIZES)),
+  /**
+   * ButtonSecondary accepts all the props from ButtonBase
+   */
+  ...ButtonBase.propTypes,
+};
+
+export default ButtonSecondary;

--- a/ui/components/component-library/button-secondary/button-secondary.js
+++ b/ui/components/component-library/button-secondary/button-secondary.js
@@ -9,7 +9,6 @@ export const ButtonSecondary = ({
   className,
   danger,
   size = BUTTON_SECONDARY_SIZES.MD,
-
   ...props
 }) => {
   return (
@@ -33,8 +32,8 @@ ButtonSecondary.propTypes = {
    */
   danger: PropTypes.bool,
   /**
-   * The possible size values for ButtonSecondary: 'BUTTON_SECONDARY_SIZES.SM', 'BUTTON_SECONDARY_SIZES.MD', 'BUTTON_SECONDARY_SIZES.LG',
-   * Default value is 'BUTTON_SECONDARY_SIZES.MD'.
+   * The possible size values for ButtonSecondary: 'SIZES.SM', 'SIZES.MD', 'SIZES.LG',
+   * Default value is 'SIZES.MD'.
    */
   size: PropTypes.oneOf(Object.values(BUTTON_SECONDARY_SIZES)),
   /**

--- a/ui/components/component-library/button-secondary/button-secondary.scss
+++ b/ui/components/component-library/button-secondary/button-secondary.scss
@@ -1,0 +1,51 @@
+.mm-button-secondary {
+  color: var(--color-primary-default);
+  border: 1px solid var(--color-primary-default);
+  background-color: transparent;
+
+  &:hover {
+    color: var(--color-primary-inverse);
+    background-color: var(--color-primary-default);
+    box-shadow: var(--component-button-primary-shadow);
+  }
+
+  &:active {
+    color: var(--color-primary-inverse);
+    background-color: var(--color-primary-alternative);
+    border-color: var(--color-primary-alternative);
+  }
+
+  &--type-danger {
+    color: var(--color-error-default);
+    border: 1px solid var(--color-error-default);
+    background-color: transparent;
+
+    &:hover {
+      color: var(--color-error-inverse);
+      background-color: var(--color-error-default);
+      box-shadow: var(--component-button-danger-shadow);
+    }
+
+    &:active {
+      color: var(--color-error-inverse);
+      background-color: var(--color-error-alternative);
+      border-color: var(--color-error-alternative);
+    }
+  }
+}
+
+.mm-button-secondary.mm-button--disabled {
+  &:hover {
+    color: var(--color-primary-default);
+    box-shadow: none;
+    background-color: transparent;
+  }
+
+  &:active {
+    background-color: transparent;
+  }
+}
+
+.mm-button-secondary--type-danger.mm-button--disabled:hover {
+  color: var(--color-error-default);
+}

--- a/ui/components/component-library/button-secondary/button-secondary.scss
+++ b/ui/components/component-library/button-secondary/button-secondary.scss
@@ -15,6 +15,18 @@
     border-color: var(--color-primary-alternative);
   }
 
+  &.mm-button--disabled {
+    &:hover {
+      color: var(--color-primary-default);
+      box-shadow: none;
+      background-color: transparent;
+    }
+
+    &:active {
+      background-color: transparent;
+    }
+  }
+
   &--type-danger {
     color: var(--color-error-default);
     border: 1px solid var(--color-error-default);
@@ -31,21 +43,9 @@
       background-color: var(--color-error-alternative);
       border-color: var(--color-error-alternative);
     }
-  }
-}
 
-.mm-button-secondary.mm-button--disabled {
-  &:hover {
-    color: var(--color-primary-default);
-    box-shadow: none;
-    background-color: transparent;
+    &.mm-button--disabled:hover {
+      color: var(--color-error-default);
+    }
   }
-
-  &:active {
-    background-color: transparent;
-  }
-}
-
-.mm-button-secondary--type-danger.mm-button--disabled:hover {
-  color: var(--color-error-default);
 }

--- a/ui/components/component-library/button-secondary/button-secondary.stories.js
+++ b/ui/components/component-library/button-secondary/button-secondary.stories.js
@@ -1,0 +1,137 @@
+import React from 'react';
+import { ALIGN_ITEMS, DISPLAY } from '../../../helpers/constants/design-system';
+import Box from '../../ui/box/box';
+import { ICON_NAMES } from '../icon';
+import { ButtonSecondary } from './button-secondary';
+import { BUTTON_SECONDARY_SIZES } from './button-secondary.constants';
+import README from './README.mdx';
+
+const marginSizeControlOptions = [
+  undefined,
+  0,
+  1,
+  2,
+  3,
+  4,
+  5,
+  6,
+  7,
+  8,
+  9,
+  10,
+  11,
+  12,
+  'auto',
+];
+
+export default {
+  title: 'Components/ComponentLibrary/ButtonSecondary',
+  id: __filename,
+  component: ButtonSecondary,
+  parameters: {
+    docs: {
+      page: README,
+    },
+  },
+  argTypes: {
+    as: {
+      control: 'select',
+      options: ['button', 'a'],
+      table: { category: 'button base props' },
+    },
+    block: {
+      control: 'boolean',
+      table: { category: 'button base props' },
+    },
+    children: {
+      control: 'text',
+    },
+    className: {
+      control: 'text',
+    },
+    danger: {
+      control: 'boolean',
+    },
+    disabled: {
+      control: 'boolean',
+      table: { category: 'button base props' },
+    },
+    icon: {
+      control: 'select',
+      options: Object.values(ICON_NAMES),
+      table: { category: 'button base props' },
+    },
+    iconPositionRight: {
+      control: 'boolean',
+      table: { category: 'button base props' },
+    },
+    iconProps: {
+      control: 'object',
+      table: { category: 'button base props' },
+    },
+
+    loading: {
+      control: 'boolean',
+      table: { category: 'button base props' },
+    },
+    size: {
+      control: 'select',
+      options: Object.values(BUTTON_SECONDARY_SIZES),
+    },
+    marginTop: {
+      options: marginSizeControlOptions,
+      control: 'select',
+      table: { category: 'box props' },
+    },
+    marginRight: {
+      options: marginSizeControlOptions,
+      control: 'select',
+      table: { category: 'box props' },
+    },
+    marginBottom: {
+      options: marginSizeControlOptions,
+      control: 'select',
+      table: { category: 'box props' },
+    },
+    marginLeft: {
+      options: marginSizeControlOptions,
+      control: 'select',
+      table: { category: 'box props' },
+    },
+  },
+  args: {
+    children: 'Button Secondary',
+  },
+};
+
+export const DefaultStory = (args) => (
+  <>
+    <ButtonSecondary {...args} />
+  </>
+);
+
+DefaultStory.storyName = 'Default';
+
+export const Size = (args) => (
+  <Box display={DISPLAY.FLEX} alignItems={ALIGN_ITEMS.BASELINE} gap={1}>
+    <ButtonSecondary {...args} size={BUTTON_SECONDARY_SIZES.SM}>
+      Small Button
+    </ButtonSecondary>
+    <ButtonSecondary {...args} size={BUTTON_SECONDARY_SIZES.MD}>
+      Medium (Default) Button
+    </ButtonSecondary>
+    <ButtonSecondary {...args} size={BUTTON_SECONDARY_SIZES.LG}>
+      Large Button
+    </ButtonSecondary>
+  </Box>
+);
+
+export const Type = (args) => (
+  <Box display={DISPLAY.FLEX} gap={1}>
+    <ButtonSecondary {...args}>Normal</ButtonSecondary>
+    {/* Test Anchor tag to match exactly as button */}
+    <ButtonSecondary as="a" {...args} href="#" danger>
+      Danger
+    </ButtonSecondary>
+  </Box>
+);

--- a/ui/components/component-library/button-secondary/button-secondary.stories.js
+++ b/ui/components/component-library/button-secondary/button-secondary.stories.js
@@ -104,11 +104,7 @@ export default {
   },
 };
 
-export const DefaultStory = (args) => (
-  <>
-    <ButtonSecondary {...args} />
-  </>
-);
+export const DefaultStory = (args) => <ButtonSecondary {...args} />;
 
 DefaultStory.storyName = 'Default';
 

--- a/ui/components/component-library/button-secondary/button-secondary.test.js
+++ b/ui/components/component-library/button-secondary/button-secondary.test.js
@@ -1,0 +1,101 @@
+/* eslint-disable jest/require-top-level-describe */
+import { render } from '@testing-library/react';
+import React from 'react';
+import { ButtonSecondary } from './button-secondary';
+import { BUTTON_SECONDARY_SIZES } from './button-secondary.constants';
+
+describe('ButtonSecondary', () => {
+  it('should render button element correctly', () => {
+    const { getByText, getByTestId, container } = render(
+      <ButtonSecondary data-testid="button-secondary">
+        Button Secondary
+      </ButtonSecondary>,
+    );
+    expect(getByText('Button Secondary')).toBeDefined();
+    expect(container.querySelector('button')).toBeDefined();
+    expect(getByTestId('button-secondary')).toHaveClass('mm-button');
+  });
+
+  it('should render anchor element correctly', () => {
+    const { getByTestId, container } = render(
+      <ButtonSecondary as="a" data-testid="button-secondary" />,
+    );
+    expect(getByTestId('button-secondary')).toBeDefined();
+    expect(container.querySelector('button')).toBeDefined();
+    expect(getByTestId('button-secondary')).toHaveClass('mm-button');
+  });
+
+  it('should render button as block', () => {
+    const { getByTestId } = render(
+      <ButtonSecondary block data-testid="block" />,
+    );
+    expect(getByTestId('block')).toHaveClass(`mm-button--block`);
+  });
+
+  it('should render with added classname', () => {
+    const { getByTestId } = render(
+      <ButtonSecondary data-testid="classname" className="mm-button--test" />,
+    );
+    expect(getByTestId('classname')).toHaveClass('mm-button--test');
+  });
+
+  it('should render with different size classes', () => {
+    const { getByTestId } = render(
+      <>
+        <ButtonSecondary
+          size={BUTTON_SECONDARY_SIZES.SM}
+          data-testid={BUTTON_SECONDARY_SIZES.SM}
+        />
+        <ButtonSecondary
+          size={BUTTON_SECONDARY_SIZES.MD}
+          data-testid={BUTTON_SECONDARY_SIZES.MD}
+        />
+        <ButtonSecondary
+          size={BUTTON_SECONDARY_SIZES.LG}
+          data-testid={BUTTON_SECONDARY_SIZES.LG}
+        />
+      </>,
+    );
+
+    expect(getByTestId(BUTTON_SECONDARY_SIZES.SM)).toHaveClass(
+      `mm-button--size-${BUTTON_SECONDARY_SIZES.SM}`,
+    );
+    expect(getByTestId(BUTTON_SECONDARY_SIZES.MD)).toHaveClass(
+      `mm-button--size-${BUTTON_SECONDARY_SIZES.MD}`,
+    );
+    expect(getByTestId(BUTTON_SECONDARY_SIZES.LG)).toHaveClass(
+      `mm-button--size-${BUTTON_SECONDARY_SIZES.LG}`,
+    );
+  });
+
+  it('should render with different types', () => {
+    const { getByTestId } = render(
+      <>
+        <ButtonSecondary danger data-testid="danger" />
+      </>,
+    );
+
+    expect(getByTestId('danger')).toHaveClass(
+      'mm-button-secondary--type-danger',
+    );
+  });
+
+  it('should render with different button states', () => {
+    const { getByTestId } = render(
+      <>
+        <ButtonSecondary loading data-testid="loading" />
+        <ButtonSecondary disabled data-testid="disabled" />
+      </>,
+    );
+    expect(getByTestId('loading')).toHaveClass(`mm-button--loading`);
+    expect(getByTestId('disabled')).toHaveClass(`mm-button--disabled`);
+  });
+  it('should render with icon', () => {
+    const { container } = render(
+      <ButtonSecondary data-testid="icon" icon="add-square-filled" />,
+    );
+
+    const icons = container.getElementsByClassName('icon').length;
+    expect(icons).toBe(1);
+  });
+});

--- a/ui/components/component-library/button-secondary/button-secondary.test.js
+++ b/ui/components/component-library/button-secondary/button-secondary.test.js
@@ -20,9 +20,9 @@ describe('ButtonSecondary', () => {
     const { getByTestId, container } = render(
       <ButtonSecondary as="a" data-testid="button-secondary" />,
     );
-    expect(getByTestId('button-secondary')).toBeDefined();
-    expect(container.querySelector('button')).toBeDefined();
     expect(getByTestId('button-secondary')).toHaveClass('mm-button');
+    const anchor = container.getElementsByTagName('a').length;
+    expect(anchor).toBe(1);
   });
 
   it('should render button as block', () => {

--- a/ui/components/component-library/button-secondary/index.js
+++ b/ui/components/component-library/button-secondary/index.js
@@ -1,0 +1,1 @@
+export { ButtonSecondary } from './button-secondary';

--- a/ui/components/component-library/component-library-components.scss
+++ b/ui/components/component-library/component-library-components.scss
@@ -3,5 +3,6 @@
 @import 'avatar-token/avatar-token';
 @import 'base-avatar/base-avatar';
 @import 'button-base/button-base';
+@import 'button-secondary/button-secondary';
 @import 'icon/icon';
 @import 'text/text';


### PR DESCRIPTION
## Explanation

Adding ButtonSecondary built off of ButtonBase. 

(similar to ButtonPrimary)

Sizes: SM, MD, & LG
Types: Normal (default) and Danger (enabled with danger prop = true) 

[Figma](https://www.figma.com/file/HKpPKij9V3TpsyMV1TpV7C/DS-Components?node-id=2939%3A20593)

## More Information

- Fixes #15092 

## Screenshots/Screencaps

<img width="542" alt="Screen Shot 2022-10-05 at 11 51 24 AM" src="https://user-images.githubusercontent.com/26469696/194140851-8dc8f8dd-49e9-48a8-8c5c-e1425076492f.png">
<img width="222" alt="Screen Shot 2022-10-05 at 12 02 27 PM" src="https://user-images.githubusercontent.com/26469696/194141285-a357cf31-79e6-4be5-8d8a-4091d67e4076.png">



## Manual Testing Steps

`yarn test:unit:jest .ui/components/component-library/button-secondary/button-secondary.test.js`

## Pre-Merge Checklist

- [x] PR template is filled out
- [ ] **IF** this PR fixes a bug, a test that _would have_ caught the bug has been added
- [x] PR is linked to the appropriate GitHub issue
- [x] PR has been added to the appropriate release Milestone

### + If there are functional changes:

- [x] Manual testing complete & passed
- [ ] "Extension QA Board" label has been applied
