### PR TITLE
chore: add bundle size diff to metamaskbot

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -540,7 +540,7 @@ jobs:
       - store_artifacts:
           path: test-artifacts
           destination: test-artifacts
-    
+
   test-e2e-chrome-mv3:
     executor: node-browsers
     steps:
@@ -795,7 +795,7 @@ jobs:
       - run:
           name: Set branch parent commit env var
           command: |
-            echo "export PARENT_COMMIT=$(git rev-parse HEAD^)" >> $BASH_ENV
+            echo "export PARENT_COMMIT=$(git rev-parse origin/HEAD)" >> $BASH_ENV
             source $BASH_ENV
       - run:
           name: build:announce

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -795,8 +795,7 @@ jobs:
       - run:
           name: Set branch parent commit env var
           command: |
-            git fetch
-            echo "export PARENT_COMMIT=$(git merge-base --fork-point origin/HEAD HEAD)" >> $BASH_ENV
+            echo "export PARENT_COMMIT=$(git merge-base origin/HEAD HEAD)" >> $BASH_ENV
             source $BASH_ENV
       - run:
           name: build:announce

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -793,6 +793,11 @@ jobs:
           path: development/ts-migration-dashboard/build
           destination: ts-migration-dashboard
       - run:
+          name: Set branch parent commit env var
+          command: |
+            echo "export PARENT_COMMIT=$(git rev-parse HEAD^)" >> $BASH_ENV
+            source $BASH_ENV
+      - run:
           name: build:announce
           command: ./development/metamaskbot-build-announce.js
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -794,7 +794,9 @@ jobs:
           destination: ts-migration-dashboard
       - run:
           name: Set branch parent commit env var
-          command: export PARENT_COMMIT=$(git merge-base --fork-point origin/HEAD HEAD)
+          command: |
+            echo "export PARENT_COMMIT=$(git merge-base --fork-point origin/HEAD HEAD)" >> $BASH_ENV
+            source $BASH_ENV
       - run:
           name: build:announce
           command: ./development/metamaskbot-build-announce.js

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -795,6 +795,7 @@ jobs:
       - run:
           name: Set branch parent commit env var
           command: |
+            git fetch
             echo "export PARENT_COMMIT=$(git merge-base --fork-point origin/HEAD HEAD)" >> $BASH_ENV
             source $BASH_ENV
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -794,9 +794,7 @@ jobs:
           destination: ts-migration-dashboard
       - run:
           name: Set branch parent commit env var
-          command: |
-            echo "export PARENT_COMMIT=$(git rev-parse origin/HEAD)" >> $BASH_ENV
-            source $BASH_ENV
+          command: export PARENT_COMMIT=$(git merge-base --fork-point origin/HEAD HEAD)
       - run:
           name: build:announce
           command: ./development/metamaskbot-build-announce.js

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -795,7 +795,7 @@ jobs:
       - run:
           name: Set branch parent commit env var
           command: |
-            echo "export PARENT_COMMIT=$(diff -u <(git rev-list --first-parent "${1:-origin/HEAD}") <(git rev-list --first-parent "${2:-HEAD}") | sed -ne "s/^ //p" | head -1)" >> $BASH_ENV
+            echo "export PARENT_COMMIT=$(git rev-parse "$(git rev-list --topo-order --reverse HEAD ^origin/develop | head -1)"^)" >> $BASH_ENV
             source $BASH_ENV
       - run:
           name: build:announce

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -795,7 +795,7 @@ jobs:
       - run:
           name: Set branch parent commit env var
           command: |
-            echo "export PARENT_COMMIT=$(git merge-base origin/HEAD HEAD)" >> $BASH_ENV
+            echo "export PARENT_COMMIT=$(diff -u <(git rev-list --first-parent "${1:-origin/HEAD}") <(git rev-list --first-parent "${2:-HEAD}") | sed -ne "s/^ //p" | head -1)" >> $BASH_ENV
             source $BASH_ENV
       - run:
           name: build:announce

--- a/development/metamaskbot-build-announce.js
+++ b/development/metamaskbot-build-announce.js
@@ -249,13 +249,15 @@ async function start() {
   }
 
   try {
-    const prBundleSizeStats = await fs.readFile(
-      path.resolve(
-        __dirname,
-        '..',
-        path.join('test-artifacts', 'chrome', 'mv3', 'bundle_size.json'),
+    const prBundleSizeStats = JSON.parse(
+      await fs.readFile(
+        path.resolve(
+          __dirname,
+          '..',
+          path.join('test-artifacts', 'chrome', 'mv3', 'bundle_size.json'),
+        ),
+        'utf-8',
       ),
-      'utf-8',
     );
 
     const devBundleSizeStats = await (

--- a/development/metamaskbot-build-announce.js
+++ b/development/metamaskbot-build-announce.js
@@ -262,7 +262,7 @@ async function start() {
       await fetch(bundleSizeDataUrl, {
         method: 'GET',
       })
-    ).text();
+    ).json();
 
     const prSizes = {
       background: prBundleSizeStats.background.size,

--- a/development/metamaskbot-build-announce.js
+++ b/development/metamaskbot-build-announce.js
@@ -252,7 +252,6 @@ async function start() {
         method: 'GET',
         headers: {
           'User-Agent': 'metamaskbot',
-          Authorization: `token ${GITHUB_COMMENT_TOKEN}`,
         },
       })
     ).json();

--- a/development/metamaskbot-build-announce.js
+++ b/development/metamaskbot-build-announce.js
@@ -249,14 +249,14 @@ async function start() {
   }
 
   try {
-    const prBundleSizeStats = await (
-      await fetch(bundleSizeStatsUrl, {
-        method: 'GET',
-        headers: {
-          'User-Agent': 'metamaskbot',
-        },
-      })
-    ).json();
+    const prBundleSizeStats = await fs.readFile(
+      path.resolve(
+        __dirname,
+        '..',
+        path.join('test-artifacts', 'chrome', 'mv3', 'bundle_size.json'),
+      ),
+      'utf-8',
+    );
 
     const devBundleSizeStats = await (
       await fetch(bundleSizeDataUrl, {

--- a/development/metamaskbot-build-announce.js
+++ b/development/metamaskbot-build-announce.js
@@ -290,11 +290,18 @@ async function start() {
       .map((row) => `<li>${row}</li>`)
       .join('\n')}</ul>`;
 
+    const sizeDiff = diffs.background + diffs.common;
+
     const sizeDiffWarning =
-      diffs.background + diffs.common > 0
+      sizeDiff > 0
         ? `🚨 Warning! Bundle size has increased!`
         : `🚀 Bundle size reduced!`;
-    const sizeDiffExposedContent = `Bundle size diffs [${sizeDiffWarning}]`;
+
+    const sizeDiffExposedContent =
+      sizeDiff === 0
+        ? `Bundle size diffs`
+        : `Bundle size diffs [${sizeDiffWarning}]`;
+
     const sizeDiffBody = `<details><summary>${sizeDiffExposedContent}</summary>${sizeDiffHiddenContent}</details>\n\n`;
 
     commentBody += sizeDiffBody;


### PR DESCRIPTION
## Explanation

This PR adds Bundle size diff between the `PR branch` and latest on `develop` and shows an alert if the bundle size of `common` + `background` is increased since last version on develop.

## More Information

* Fixes #16070 

## Manual Testing Steps

After pushing to a PR, if the build is successful the Metamask bot should also show the following section:

<details><summary>Bundle size diffs [🚀 Bundle size reduced! 🚀]</summary><ul><li>background: -4</li>
<li>ui: -37940</li>
<li>common: -4</li></ul></details>

## Pre-Merge Checklist

- [x] PR template is filled out
- [ ] **IF** this PR fixes a bug, a test that _would have_ caught the bug has been added
- [x] PR is linked to the appropriate GitHub issue
- [ ] PR has been added to the appropriate release Milestone

### + If there are functional changes:

- [x] Manual testing complete & passed
- [ ] "Extension QA Board" label has been applied