### PR TITLE
Fixing Identicon import paths

### DIFF
--- a/ui/components/app/modals/contract-details-modal/contract-details-modal.js
+++ b/ui/components/app/modals/contract-details-modal/contract-details-modal.js
@@ -9,7 +9,7 @@ import IconBlockExplorer from '../../../ui/icon/icon-block-explorer';
 import Button from '../../../ui/button/button.component';
 import Tooltip from '../../../ui/tooltip/tooltip';
 import { useI18nContext } from '../../../../hooks/useI18nContext';
-import Identicon from '../../../ui/identicon/identicon.component';
+import Identicon from '../../../ui/identicon';
 import { ellipsify } from '../../../../pages/send/send.utils';
 import Popover from '../../../ui/popover';
 import Typography from '../../../ui/typography';

--- a/ui/components/app/network-account-balance-header/network-account-balance-header.js
+++ b/ui/components/app/network-account-balance-header/network-account-balance-header.js
@@ -1,6 +1,6 @@
 import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
-import Identicon from '../../ui/identicon/identicon.component';
+import Identicon from '../../ui/identicon';
 import {
   DISPLAY,
   FLEX_DIRECTION,

--- a/ui/components/ui/contract-token-values/contract-token-values.js
+++ b/ui/components/ui/contract-token-values/contract-token-values.js
@@ -6,7 +6,7 @@ import IconBlockExplorer from '../icon/icon-block-explorer';
 import Box from '../box/box';
 import Tooltip from '../tooltip/tooltip';
 import { useI18nContext } from '../../../hooks/useI18nContext';
-import Identicon from '../identicon/identicon.component';
+import Identicon from '../identicon';
 import Typography from '../typography/typography';
 import {
   FONT_WEIGHT,

--- a/ui/components/ui/new-network-info/new-network-info.js
+++ b/ui/components/ui/new-network-info/new-network-info.js
@@ -4,7 +4,7 @@ import { useHistory } from 'react-router-dom';
 import { I18nContext } from '../../../contexts/i18n';
 import Popover from '../popover';
 import Button from '../button';
-import Identicon from '../identicon/identicon.component';
+import Identicon from '../identicon';
 import Box from '../box';
 import {
   ALIGN_ITEMS,

--- a/ui/pages/token-details/token-details-page.test.js
+++ b/ui/pages/token-details/token-details-page.test.js
@@ -2,7 +2,7 @@ import React from 'react';
 import configureMockStore from 'redux-mock-store';
 import { fireEvent } from '@testing-library/react';
 import { renderWithProvider } from '../../../test/lib/render-helpers';
-import Identicon from '../../components/ui/identicon/identicon.component';
+import Identicon from '../../components/ui/identicon';
 import { isEqualCaseInsensitive } from '../../../shared/modules/string-utils';
 import TokenDetailsPage from './token-details-page';
 


### PR DESCRIPTION
The `Identicon` component is incorrectly imported in a few places, as it is a connected component, it should be imported from the folder root. 