### PR TITLE
Remove ETH badge from NetworkAccountBalanceHeader when on non-ETH net…

### DIFF
--- a/ui/components/app/confirm-page-container/confirm-page-container.component.js
+++ b/ui/components/app/confirm-page-container/confirm-page-container.component.js
@@ -217,6 +217,7 @@ export default class ConfirmPageContainer extends Component {
               tokenName={nativeCurrency}
               accountAddress={fromAddress}
               networkName={networkName}
+              chainId={currentTransaction.chainId}
             />
           ) : (
             <ConfirmPageContainerHeader

--- a/ui/components/app/network-account-balance-header/index.scss
+++ b/ui/components/app/network-account-balance-header/index.scss
@@ -3,10 +3,25 @@
   border-bottom: 1px solid var(--color-border-muted);
 
   &__network-account {
-    &__ident-icon-ethereum {
+    &__ident-icon-ethereum,
+    &__ident-icon-ethereum--gray {
+      height: 18px;
+      width: 18px;
+      border-radius: 50%;
+      border: 1px solid var(--color-background-default);
+      background: var(--color-background-default);
       margin-inline-start: -10px;
       margin-top: -20px;
-      border: none !important;
+
+      > span {
+        display: flex;
+        justify-content: center;
+        line-height: 18px;
+      }
+    }
+
+    &__ident-icon-ethereum--gray {
+      border: 1px solid var(--color-border-default);
     }
   }
 }

--- a/ui/components/app/network-account-balance-header/network-account-balance-header.js
+++ b/ui/components/app/network-account-balance-header/network-account-balance-header.js
@@ -14,12 +14,13 @@ import {
 import Box from '../../ui/box/box';
 import { I18nContext } from '../../../contexts/i18n';
 import Typography from '../../ui/typography';
+import { CURRENCY_SYMBOLS } from '../../../../shared/constants/network';
 
 export default function NetworkAccountBalanceHeader({
   networkName,
   accountName,
   accountBalance,
-  tokenName,
+  tokenName, // Derived from nativeCurrency
   accountAddress,
 }) {
   const t = useContext(I18nContext);
@@ -45,13 +46,15 @@ export default function NetworkAccountBalanceHeader({
           alignItems={ALIGN_ITEMS.CENTER}
         >
           <Identicon address={accountAddress} diameter={32} />
-          <Identicon
-            address={accountAddress}
-            diameter={16}
-            imageBorder
-            image="./images/eth_badge.svg"
-            className="network-account-balance-header__network-account__ident-icon-ethereum"
-          />
+          {tokenName === CURRENCY_SYMBOLS.ETH ? (
+            <Identicon
+              address={accountAddress}
+              diameter={16}
+              imageBorder
+              image="./images/eth_badge.svg"
+              className="network-account-balance-header__network-account__ident-icon-ethereum"
+            />
+          ) : null}
         </Box>
         <Box
           display={DISPLAY.FLEX}

--- a/ui/components/app/network-account-balance-header/network-account-balance-header.js
+++ b/ui/components/app/network-account-balance-header/network-account-balance-header.js
@@ -1,5 +1,6 @@
 import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
+import IconWithFallback from '../../ui/icon-with-fallback';
 import Identicon from '../../ui/identicon';
 import {
   DISPLAY,
@@ -14,7 +15,7 @@ import {
 import Box from '../../ui/box/box';
 import { I18nContext } from '../../../contexts/i18n';
 import Typography from '../../ui/typography';
-import { CURRENCY_SYMBOLS } from '../../../../shared/constants/network';
+import { CHAIN_ID_TO_NETWORK_IMAGE_URL_MAP } from '../../../../shared/constants/network';
 
 export default function NetworkAccountBalanceHeader({
   networkName,
@@ -22,8 +23,13 @@ export default function NetworkAccountBalanceHeader({
   accountBalance,
   tokenName, // Derived from nativeCurrency
   accountAddress,
+  chainId,
 }) {
   const t = useContext(I18nContext);
+  const networkIcon = CHAIN_ID_TO_NETWORK_IMAGE_URL_MAP[chainId];
+  const networkIconWrapperClass = networkIcon
+    ? 'network-account-balance-header__network-account__ident-icon-ethereum'
+    : 'network-account-balance-header__network-account__ident-icon-ethereum--gray';
 
   return (
     <Box
@@ -46,15 +52,12 @@ export default function NetworkAccountBalanceHeader({
           alignItems={ALIGN_ITEMS.CENTER}
         >
           <Identicon address={accountAddress} diameter={32} />
-          {tokenName === CURRENCY_SYMBOLS.ETH ? (
-            <Identicon
-              address={accountAddress}
-              diameter={16}
-              imageBorder
-              image="./images/eth_badge.svg"
-              className="network-account-balance-header__network-account__ident-icon-ethereum"
-            />
-          ) : null}
+          <IconWithFallback
+            name={networkName}
+            size={16}
+            icon={networkIcon}
+            wrapperClassName={networkIconWrapperClass}
+          />
         </Box>
         <Box
           display={DISPLAY.FLEX}
@@ -112,4 +115,5 @@ NetworkAccountBalanceHeader.propTypes = {
   accountBalance: PropTypes.string,
   tokenName: PropTypes.string,
   accountAddress: PropTypes.string,
+  chainId: PropTypes.string,
 };

--- a/ui/components/ui/icon-with-fallback/icon-with-fallback.component.js
+++ b/ui/components/ui/icon-with-fallback/icon-with-fallback.component.js
@@ -36,7 +36,7 @@ const IconWithFallback = ({
             fallbackClassName,
           )}
         >
-          {name && name.length ? name.charAt(0).toUpperCase() : ''}
+          {name?.charAt(0).toUpperCase() || ''}
         </span>
       )}
     </div>

--- a/ui/components/ui/icon-with-fallback/icon-with-fallback.component.js
+++ b/ui/components/ui/icon-with-fallback/icon-with-fallback.component.js
@@ -8,6 +8,7 @@ const IconWithFallback = ({
   size,
   className,
   fallbackClassName,
+  wrapperClassName,
   ...props
 }) => {
   const [iconError, setIconError] = useState(false);
@@ -17,21 +18,28 @@ const IconWithFallback = ({
     setIconError(true);
   };
 
-  return !iconError && icon ? (
-    <img
-      onError={handleOnError}
-      src={icon}
-      style={style}
-      className={className}
-      alt={name || 'icon'}
-      {...props}
-    />
-  ) : (
-    <span
-      className={classnames('icon-with-fallback__fallback', fallbackClassName)}
-    >
-      {name && name.length ? name.charAt(0).toUpperCase() : ''}
-    </span>
+  return (
+    <div className={classnames(wrapperClassName)}>
+      {!iconError && icon ? (
+        <img
+          onError={handleOnError}
+          src={icon}
+          style={style}
+          className={className}
+          alt={name || 'icon'}
+          {...props}
+        />
+      ) : (
+        <span
+          className={classnames(
+            'icon-with-fallback__fallback',
+            fallbackClassName,
+          )}
+        >
+          {name && name.length ? name.charAt(0).toUpperCase() : ''}
+        </span>
+      )}
+    </div>
   );
 };
 
@@ -52,6 +60,10 @@ IconWithFallback.propTypes = {
    * className to apply to the image tag
    */
   className: PropTypes.string,
+  /**
+   * className to apply to the div that wraps the icon
+   */
+  wrapperClassName: PropTypes.string,
   /**
    * Additional className to apply to the fallback span tag
    */

--- a/ui/pages/swaps/dropdown-search-list/__snapshots__/dropdown-search-list.test.js.snap
+++ b/ui/pages/swaps/dropdown-search-list/__snapshots__/dropdown-search-list.test.js.snap
@@ -13,11 +13,15 @@ exports[`DropdownSearchList renders the component with initial props 1`] = `
       <div
         class="dropdown-search-list__selector-closed"
       >
-        <img
-          alt="symbol"
-          class="url-icon dropdown-search-list__selector-closed-icon"
-          src="iconUrl"
-        />
+        <div
+          class=""
+        >
+          <img
+            alt="symbol"
+            class="url-icon dropdown-search-list__selector-closed-icon"
+            src="iconUrl"
+          />
+        </div>
         <div
           class="dropdown-search-list__labels"
         >

--- a/ui/pages/swaps/main-quote-summary/__snapshots__/main-quote-summary.test.js.snap
+++ b/ui/pages/swaps/main-quote-summary/__snapshots__/main-quote-summary.test.js.snap
@@ -11,11 +11,15 @@ exports[`MainQuoteSummary renders the component with initial props 1`] = `
   >
     2
   </span>
-  <span
-    class="icon-with-fallback__fallback url-icon__fallback main-quote-summary__icon-fallback"
+  <div
+    class=""
   >
-    E
-  </span>
+    <span
+      class="icon-with-fallback__fallback url-icon__fallback main-quote-summary__icon-fallback"
+    >
+      E
+    </span>
+  </div>
   <span
     class="main-quote-summary__source-row-symbol"
     title="ETH"
@@ -29,11 +33,15 @@ exports[`MainQuoteSummary renders the component with initial props 2`] = `
 <div
   class="main-quote-summary__destination-row"
 >
-  <span
-    class="icon-with-fallback__fallback url-icon__fallback main-quote-summary__icon-fallback"
+  <div
+    class=""
   >
-    B
-  </span>
+    <span
+      class="icon-with-fallback__fallback url-icon__fallback main-quote-summary__icon-fallback"
+    >
+      B
+    </span>
+  </div>
   <span
     class="main-quote-summary__destination-row-symbol"
   >

--- a/ui/pages/swaps/searchable-item-list/__snapshots__/searchable-item-list.test.js.snap
+++ b/ui/pages/swaps/searchable-item-list/__snapshots__/searchable-item-list.test.js.snap
@@ -42,11 +42,15 @@ exports[`SearchableItemList renders the component with initial props 2`] = `
   data-testid="searchable-item-list__item"
   tabindex="0"
 >
-  <img
-    alt="primaryLabel"
-    class="url-icon"
-    src="iconUrl"
-  />
+  <div
+    class=""
+  >
+    <img
+      alt="primaryLabel"
+      class="url-icon"
+      src="iconUrl"
+    />
+  </div>
   <div
     class="searchable-item-list__labels"
   >

--- a/ui/pages/swaps/searchable-item-list/item-list/__snapshots__/item-list.component.test.js.snap
+++ b/ui/pages/swaps/searchable-item-list/item-list/__snapshots__/item-list.component.test.js.snap
@@ -6,11 +6,15 @@ exports[`ItemList renders the component with initial props 1`] = `
   data-testid="searchable-item-list__item"
   tabindex="0"
 >
-  <img
-    alt="primaryLabel"
-    class="url-icon"
-    src="iconUrl"
-  />
+  <div
+    class=""
+  >
+    <img
+      alt="primaryLabel"
+      class="url-icon"
+      src="iconUrl"
+    />
+  </div>
   <div
     class="searchable-item-list__labels"
   >

--- a/ui/pages/swaps/view-quote/__snapshots__/view-quote.test.js.snap
+++ b/ui/pages/swaps/view-quote/__snapshots__/view-quote.test.js.snap
@@ -11,11 +11,15 @@ exports[`ViewQuote renders the component with EIP-1559 enabled 1`] = `
   >
     10
   </span>
-  <img
-    alt="DAI"
-    class="url-icon main-quote-summary__icon"
-    src="https://foo.bar/logo.png"
-  />
+  <div
+    class=""
+  >
+    <img
+      alt="DAI"
+      class="url-icon main-quote-summary__icon"
+      src="https://foo.bar/logo.png"
+    />
+  </div>
   <span
     class="main-quote-summary__source-row-symbol"
     title="DAI"
@@ -85,11 +89,15 @@ exports[`ViewQuote renders the component with initial props 1`] = `
   >
     10
   </span>
-  <img
-    alt="DAI"
-    class="url-icon main-quote-summary__icon"
-    src="https://foo.bar/logo.png"
-  />
+  <div
+    class=""
+  >
+    <img
+      alt="DAI"
+      class="url-icon main-quote-summary__icon"
+      src="https://foo.bar/logo.png"
+    />
+  </div>
   <span
     class="main-quote-summary__source-row-symbol"
     title="DAI"

--- a/ui/pages/token-allowance/token-allowance.js
+++ b/ui/pages/token-allowance/token-allowance.js
@@ -178,6 +178,7 @@ export default function TokenAllowance({
         accountBalance={currentTokenBalance}
         tokenName={tokenSymbol}
         accountAddress={userAddress}
+        chainId={fullTxData.chainId}
       />
       <Box
         display={DISPLAY.FLEX}


### PR DESCRIPTION
Fixes: https://github.com/MetaMask/metamask-extension/issues/16082

This removes the ETH badge in the account balance header when ETH is not the default currency for the current network.

## Test Plan
1. login to the extension
2. Switch networks to a custom network (e.g. Fantom)
3. navigate to the test dapp
4. deploy collectibles
5. mint collectibles
6. set approval for all
7. Confirm the ETH badge is not shown
8. Switch networks to mainnet or a local ETH network
9. Repeat steps 3 - 7
10. Confirm the ETH badge is shown