### PR TITLE
Fixes optional chaining bug in storybook

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,7 +106,8 @@
     "pubnub/superagent-proxy": "^3.0.0",
     "pull-ws": "^3.3.2",
     "json-schema": "^0.4.0",
-    "simple-get": "^4.0.1"
+    "simple-get": "^4.0.1",
+    "@storybook/**/ast-types": "^0.14.2"
   },
   "dependencies": {
     "3box": "^1.10.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7129,12 +7129,7 @@ ast-module-types@^2.3.2, ast-module-types@^2.4.0, ast-module-types@^2.7.0, ast-m
   resolved "https://registry.yarnpkg.com/ast-module-types/-/ast-module-types-2.7.1.tgz#3f7989ef8dfa1fdb82dfe0ab02bdfc7c77a57dd3"
   integrity sha512-Rnnx/4Dus6fn7fTqdeLEAn5vUll5w7/vts0RN608yFa6si/rDOUonlIIiwugHBFWjylHjxm9owoSZn71KwG4gw==
 
-ast-types@^0.13.2:
-  version "0.13.2"
-  resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.13.2.tgz#df39b677a911a83f3a049644fb74fdded23cea48"
-  integrity sha512-uWMHxJxtfj/1oZClOxDEV1sQ1HCDkA4MG8Gr69KKeBjEVH0R84WlejZ0y2DcwyBlpAEMltmVYkVgqfLFb2oyiA==
-
-ast-types@^0.14.2:
+ast-types@^0.13.2, ast-types@^0.14.2:
   version "0.14.2"
   resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.14.2.tgz#600b882df8583e3cd4f2df5fa20fa83759d4bdfd"
   integrity sha512-O0yuUDnZeQDL+ncNGlJ78BiO4jnYI3bvMsD5prT0/nsgijG/LpNBIr63gTjVTNsiGkgQhiyCShTgxt8oXOrklA==


### PR DESCRIPTION
## Explanation

Currently, if a UI component uses optional chaining `?.` in it's component code or stoybook files it will break the args table that shows all of the proptypes that can be rendered from the README.mdx file

This is a problem because you can't read the props table :) 

This adds a resolution for ast-types to `package.json` file. We can remove this resolution once we upgrade to Webpack 5

## More Information

* Fixes #12994
https://github.com/reactjs/react-docgen/issues/463#issuecomment-698769524

## Screenshots/Screencaps

### Before

<img width="1438" alt="Screen Shot 2022-10-05 at 8 29 16 PM" src="https://user-images.githubusercontent.com/8112138/194208209-5ecb3e33-ac76-4bf8-9a95-1b7e63ce5cd4.png">

### After

<img width="1440" alt="Screen Shot 2022-10-05 at 8 28 50 PM" src="https://user-images.githubusercontent.com/8112138/194208223-2e71600b-c67b-4e5f-a888-3bcbdd328338.png">


## Manual Testing Steps

- [Go to the latest build of storybook in this PR](https://output.circle-artifacts.com/output/job/74176b0b-95ff-4577-83b5-38129825ec09/artifacts/0/storybook/index.html?path=/docs/ui-components-ui-update-nickname-popover-update-nickname-popover-stories-js--default-story)
- Search for `UpdateNicknamePopover` in the search bar (it uses optional chaining in it's component code)
- Click the Docs tab
- See that the props table displays

## Pre-Merge Checklist

- [x] PR template is filled out
- [x] **IF** this PR fixes a bug, a test that _would have_ caught the bug has been added
- [x] PR is linked to the appropriate GitHub issue
- [x] PR has been added to the appropriate release Milestone

### + If there are functional changes:

- [x] Manual testing complete & passed
- [x] "Extension QA Board" label has been applied
