### PR TITLE
Data from TokenListController gets cleared when the service worker restarts

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -247,7 +247,9 @@ export default class MetamaskController extends EventEmitter {
 
     this.tokenListController = new TokenListController({
       chainId: hexToDecimal(this.networkController.getCurrentChainId()),
-      preventPollingOnNetworkRestart: true,
+      preventPollingOnNetworkRestart: initState.TokenListController
+        ? initState.TokenListController.preventPollingOnNetworkRestart
+        : true,
       onNetworkStateChange: (cb) => {
         this.networkController.store.subscribe((networkState) => {
           const modifiedNetworkState = {


### PR DESCRIPTION
## Explanation
`preventPollingOnNetworkRestart` should not get reset on service worker restart. 

In this PR while initiating TokenListCobtroller, instead of using the true value, we are passing in `preventPollingOnNetworkRestart` from initstate to preserve the value of `preventPollingOnNetworkRestart`, which has to be false if token detection is ON.

<!--
Thanks for the pull request. Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Below is a template to give you some ideas. Feel free to use your own words!

Currently, ...

This is a problem because ...

In order to solve this problem, this pull request ...
-->

## More Information

<!--
Are there any issues, Slack conversations, Zendesk issues, user stories, etc. reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->
Fixes #16099 
## Screenshots/Screencaps

<!-- If you're making a change to the UI, make sure to capture a screenshot or a short video showing off your work! -->

### Before

<!-- How did the UI you changed look before your changes? Drag your file(s) below this line: -->

### After

<!-- How does it look now? Drag your file(s) below this line: -->

## Manual Testing Steps
1. Turn on Token detection and go to a supported network (Mainnet, Binance, Polygon, or Avalanche)
2. In console type `logState(true)` to get the state 
3. In state, search for `preventPollingOnNetworkRestart` at this point, the value should be false, and tokenList, and tokensChainsCache to be non-empty; this should have token details from the corresponding network.
4. Now stop and start the service worker, go to the application tab in the console and click the stop link.
5. Upon service worker restart, repeat step 2 to get the new state.
6. Verify the `preventPollingOnNetworkRestart` to be false and tokenList, and tokensChainsCache to be non-empty; this should have token details from the corresponding network.
<!--
How should reviewers and QA manually test your changes? For instance:

- Go to this screen
- Do this
- Then do this
-->

## Pre-Merge Checklist

- [x] PR template is filled out
- [ ] **IF** this PR fixes a bug, a test that _would have_ caught the bug has been added
- [x] PR is linked to the appropriate GitHub issue
- [ ] PR has been added to the appropriate release Milestone

### + If there are functional changes:

- [ ] Manual testing complete & passed
- [ ] "Extension QA Board" label has been applied
