### PR TITLE
Fix intermittent storybook build failure

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -386,7 +386,7 @@ jobs:
             - builds-test
 
   prep-build-storybook:
-    executor: node-browsers
+    executor: node-browsers-medium-plus
     steps:
       - checkout
       - attach_workspace:
@@ -644,7 +644,7 @@ jobs:
           root: .
           paths:
             - test-artifacts
-    
+
   user-actions-benchmark:
     executor: node-browsers-medium-plus
     steps:


### PR DESCRIPTION
The CI job for building storybook will fail occasionally, presumably due to a Node.js process running out of heap memory. This job is the only build job that runs with default Node.js memory settings.

It has been updated to use a larger instance size and to set the heap size to 2GB, matching our other build jobs.

## Pre-Merge Checklist

- [x] PR template is filled out
- [ ] **IF** this PR fixes a bug, a test that _would have_ caught the bug has been added
- [ ] PR is linked to the appropriate GitHub issue
- [ ] PR has been added to the appropriate release Milestone

### + If there are functional changes:

- [x] Manual testing complete & passed
- [ ] "Extension QA Board" label has been applied
