### PR TITLE
[FLASK] Fix wrong action name for `wallet_getSnaps` hook

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -3744,7 +3744,7 @@ export default class MetamaskController extends EventEmitter {
         ),
         getSnaps: this.controllerMessenger.call.bind(
           this.controllerMessenger,
-          'SnapController:getPermittedSnaps',
+          'SnapController:getPermitted',
           origin,
         ),
         requestPermissions: async (requestedPermissions) => {


### PR DESCRIPTION
## Explanation

Fixes a regression introduced in the `snaps-skunkworks@0.22.0` commit that typoed the action name. The correct action name to get permitted snaps is `SnapController:getPermitted`.