### PR TITLE
Fix false positives in blockedDomainCheck (Provider Injection)

### DIFF
--- a/shared/modules/provider-injection.js
+++ b/shared/modules/provider-injection.js
@@ -8,7 +8,7 @@ export default function shouldInjectProvider() {
     doctypeCheck() &&
     suffixCheck() &&
     documentElementCheck() &&
-    !blockedDomainCheck()
+    !blockedDomainCheck(window.location.href)
   );
 }
 
@@ -61,9 +61,10 @@ function documentElementCheck() {
 /**
  * Checks if the current domain is blocked
  *
+ * @param currentUrl
  * @returns {boolean} {@code true} if the current domain is blocked
  */
-function blockedDomainCheck() {
+export function blockedDomainCheck(currentUrl) {
   const blockedDomains = [
     'uscourts.gov',
     'dropbox.com',
@@ -77,15 +78,11 @@ function blockedDomainCheck() {
     'blueskybooking.com',
     'sharefile.com',
   ];
-  const currentUrl = window.location.href;
   let currentRegex;
   for (let i = 0; i < blockedDomains.length; i++) {
     const blockedDomain = blockedDomains[i].replace('.', '\\.');
-    currentRegex = new RegExp(
-      `(?:https?:\\/\\/)(?:(?!${blockedDomain}).)*$`,
-      'u',
-    );
-    if (!currentRegex.test(currentUrl)) {
+    currentRegex = new RegExp(`(?:https?:\\/\\/)${blockedDomain}.*$`, 'u');
+    if (currentRegex.test(currentUrl)) {
       return true;
     }
   }

--- a/shared/modules/provider-injection.test.js
+++ b/shared/modules/provider-injection.test.js
@@ -1,0 +1,27 @@
+import { blockedDomainCheck } from './provider-injection';
+
+describe('provider injection', function () {
+  describe('blockedDomainCheck', function () {
+    it('should return true for blocked urls', function () {
+      expect(blockedDomainCheck('https://docs.google.com')).toStrictEqual(true);
+      expect(
+        blockedDomainCheck(
+          'https://cdn.shopify.com/s/javascripts/tricorder/xtld-read-only-frame.html',
+        ),
+      ).toStrictEqual(true);
+      expect(blockedDomainCheck('https://dropbox.com')).toStrictEqual(true);
+      expect(blockedDomainCheck('https://uscourts.gov')).toStrictEqual(true);
+    });
+
+    it('should return false for allowed urls', function () {
+      expect(blockedDomainCheck('https://test.com')).toStrictEqual(false);
+      expect(blockedDomainCheck('https://metamask.io/')).toStrictEqual(false);
+      expect(
+        blockedDomainCheck('https://test.com?test=docs.google.com'),
+      ).toStrictEqual(false);
+      expect(
+        blockedDomainCheck('https://test.com?test=dropbox.com'),
+      ).toStrictEqual(false);
+    });
+  });
+});


### PR DESCRIPTION
Fixes: https://github.com/MetaMask/metamask-extension/issues/16059

## Explanation
The Regex that was previously used to check for a blocked domain was too over-encompassing, and would produce false positives in the case that a blocked host was part of a path or query string. This PR adjusts that regex, and in addition makes `blockedDomainCheck` exportable for testing. 

## Manual Testing Steps
1. Ensure that that the provider is not injected on the blocked domains listed in `shared/modules/provider-injection.js`
2. Ensure that the provider is injected on sites where a blocked host, (such as https://example.com?test=docs.google.com) is part of the query paramers

## Pre-Merge Checklist

- [X] PR template is filled out
- [X] **IF** this PR fixes a bug, a test that _would have_ caught the bug has been added
- [X] PR is linked to the appropriate GitHub issue
- [ ] PR has been added to the appropriate release Milestone

### + If there are functional changes:

- [ ] Manual testing complete & passed
- [ ] "Extension QA Board" label has been applied
