### PR TITLE
Show fiat conversion by default on custom networks

### DIFF
--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -543,9 +543,12 @@ export function getShowTestNetworks(state) {
 
 export function getShouldShowFiat(state) {
   const isMainNet = getIsMainnet(state);
+  const isCustomNetwork = getIsCustomNetwork(state);
   const conversionRate = getConversionRate(state);
   const { showFiatInTestnets } = getPreferences(state);
-  return Boolean((isMainNet || showFiatInTestnets) && conversionRate);
+  return Boolean(
+    (isMainNet || isCustomNetwork || showFiatInTestnets) && conversionRate,
+  );
 }
 
 export function getShouldHideZeroBalanceTokens(state) {


### PR DESCRIPTION
Fixes: https://github.com/MetaMask/metamask-extension/issues/16129
Fixes: https://github.com/MetaMask/metamask-extension/issues/13546

## Screenshots/Screencaps
https://user-images.githubusercontent.com/8732757/194804039-d0cf74e5-f5f4-4269-9c71-1c99425ab912.mov

## Manual Testing Steps
1. Ensure that the `Show conversion on test networks` settings under advanced settings is toggled off
2. Add/Switch to a custom network with some assets in it
3. Ensure that the fiat conversion is displayed.
4. Spot check and ensure mainnet still shows the conversion, and that the test networks do when the option is toggled on.

<!--
How should reviewers and QA manually test your changes? For instance:

- Go to this screen
- Do this
- Then do this
-->

## Pre-Merge Checklist

- [X] PR template is filled out
- [ ] **IF** this PR fixes a bug, a test that _would have_ caught the bug has been added
- [X] PR is linked to the appropriate GitHub issue
- [ ] PR has been added to the appropriate release Milestone

### + If there are functional changes:

- [ ] Manual testing complete & passed
- [ ] "Extension QA Board" label has been applied
