### PR TITLE
e2e test for gas API fallback

### DIFF
--- a/test/e2e/tests/gas-api-fallback.spec.js
+++ b/test/e2e/tests/gas-api-fallback.spec.js
@@ -1,0 +1,69 @@
+const { strict: assert } = require('assert');
+const { convertToHexValue, withFixtures } = require('../helpers');
+
+describe('Gas API fallback', function () {
+  async function mockGasApiDown(mockServer) {
+    await mockServer
+      .forGet(
+        'https://gas-api.metaswap.codefi.network/networks/1/suggestedGasFees',
+      )
+      .thenCallback(() => {
+        return {
+          statusCode: 500,
+          json: {},
+        };
+      });
+  }
+
+  const ganacheOptions = {
+    hardfork: 'london',
+    accounts: [
+      {
+        secretKey:
+          '0x7C9529A67102755B7E6102D6D950AC5D5863C98713805CEC576B945B15B71EAC',
+        balance: convertToHexValue(25000000000000000000),
+      },
+    ],
+  };
+
+  it('error message is displayed but gas recommendation is not displayed', async function () {
+    await withFixtures(
+      {
+        fixtures: 'imported-account',
+        testSpecificMock: mockGasApiDown,
+        ganacheOptions,
+        title: this.test.title,
+      },
+      async ({ driver }) => {
+        await driver.navigate();
+        await driver.fill('#password', 'correct horse battery staple');
+        await driver.press('#password', driver.Key.ENTER);
+
+        await driver.clickElement('[data-testid="eth-overview-send"]');
+
+        await driver.fill(
+          'input[placeholder="Search, public address (0x), or ENS"]',
+          '0x2f318C334780961FB129D2a6c30D0763d9a5C970',
+        );
+
+        const inputAmount = await driver.findElement('.unit-input__input');
+        await inputAmount.fill('1');
+
+        await driver.clickElement({ text: 'Next', tag: 'button' });
+        await driver.clickElement({ text: 'Edit', tag: 'button' });
+
+        const error = await driver.isElementPresent('.error-message__text');
+        const gasRecommendation = await driver.isElementPresent(
+          '[data-testid="gas-recommendation"]',
+        );
+
+        assert.equal(error, true, 'Error message is not displayed');
+        assert.equal(
+          gasRecommendation,
+          false,
+          'Gas recommendation is displayed',
+        );
+      },
+    );
+  });
+});

--- a/ui/components/app/edit-gas-display/edit-gas-display.component.js
+++ b/ui/components/app/edit-gas-display/edit-gas-display.component.js
@@ -244,6 +244,7 @@ export default function EditGasDisplay({
           )}
         {radioButtonsEnabled && !hideRadioButtons && (
           <RadioGroup
+            dataTestId="gas-recommendation"
             name="gas-recommendation"
             options={[
               {


### PR DESCRIPTION
## Explanation
This e2e testcase checks for a correct fallback implementation when the Gas API is down. In this event, no gas recommendation should be shown (no High/Medium/Low gas options) and a warning error should displayed.

## More Information
Resolves https://github.com/MetaMask/metamask-extension/issues/16136

## Screenshots/Screencaps
When Gas API is operating normally we see this screen on Edit Gas fees:

![image](https://user-images.githubusercontent.com/54408225/194876632-1dbbe2ef-2e63-481e-b38a-188eb3ad1a47.png)

When Gas API is down, we should see this screen on Edit Gas fees:
![image](https://user-images.githubusercontent.com/54408225/194876862-ffa2594e-0c72-445b-9e9b-fe83366f62ce.png)


## Manual Testing Steps
Compile the test build and run:
- `yarn test:e2e:single test/e2e/tests/gas-api-fallback.spec.js --browser=chrome`
- `yarn test:e2e:single test/e2e/tests/gas-api-fallback.spec.js --browser=firefox`

## Pre-Merge Checklist

- [X] PR template is filled out
- [ ] **IF** this PR fixes a bug, a test that _would have_ caught the bug has been added
- [X] PR is linked to the appropriate GitHub issue
- [ ] PR has been added to the appropriate release Milestone

### + If there are functional changes:

- [ ] Manual testing complete & passed
- [ ] "Extension QA Board" label has been applied
