### PR TITLE
Remove docs.google.com from blocked domains list

### DIFF
--- a/shared/modules/provider-injection.js
+++ b/shared/modules/provider-injection.js
@@ -71,7 +71,6 @@ function blockedDomainCheck() {
     'cdn.shopify.com/s/javascripts/tricorder/xtld-read-only-frame.html',
     'adyen.com',
     'gravityforms.com',
-    'docs.google.com',
     'harbourair.com',
     'ani.gamer.com.tw',
     'blueskybooking.com',


### PR DESCRIPTION
Related: https://github.com/MetaMask/metamask-extension/issues/16059

The issue that originally necessitated `docs.google.com` being added to the blocked domain list has been fixed on the Brave side of things: https://github.com/brave/brave-core/pull/14483