### PR TITLE
Fixing forgot password action after wallet creation

### DIFF
--- a/ui/pages/routes/routes.component.js
+++ b/ui/pages/routes/routes.component.js
@@ -113,6 +113,7 @@ export default class Routes extends Component {
     currentChainId: PropTypes.string,
     shouldShowSeedPhraseReminder: PropTypes.bool,
     portfolioTooltipIsBeingShown: PropTypes.bool,
+    forgottenPassword: PropTypes.bool,
   };
 
   static contextTypes = {
@@ -165,7 +166,10 @@ export default class Routes extends Component {
   }
 
   renderRoutes() {
-    const { autoLockTimeLimit, setLastActiveTime } = this.props;
+    const { autoLockTimeLimit, setLastActiveTime, forgottenPassword } =
+      this.props;
+    const RestoreVaultComponent = forgottenPassword ? Route : Initialized;
+
     const routes = (
       <Switch>
         {process.env.ONBOARDING_V2 && (
@@ -174,7 +178,7 @@ export default class Routes extends Component {
         <Route path={LOCK_ROUTE} component={Lock} exact />
         <Route path={INITIALIZE_ROUTE} component={FirstTimeFlow} />
         <Initialized path={UNLOCK_ROUTE} component={UnlockPage} exact />
-        <Initialized
+        <RestoreVaultComponent
           path={RESTORE_VAULT_ROUTE}
           component={RestoreVaultPage}
           exact

--- a/ui/pages/routes/routes.container.js
+++ b/ui/pages/routes/routes.container.js
@@ -52,6 +52,7 @@ function mapStateToProps(state) {
     currentChainId: getCurrentChainId(state),
     shouldShowSeedPhraseReminder: getShouldShowSeedPhraseReminder(state),
     portfolioTooltipIsBeingShown: getShowPortfolioTooltip(state),
+    forgottenPassword: state.metamask.forgottenPassword,
   };
 }
 


### PR DESCRIPTION
Fixes: https://github.com/MetaMask/metamask-extension/issues/16138

## Screenshots/Screencaps
https://user-images.githubusercontent.com/8732757/195005768-9fb12eaa-ccc0-4784-9dfd-2e3832419290.mov

## Manual Testing Steps
1. Load MM for the first time
2. Accept/Decline MetaMetrics
3. Click Create Wallet
4. Introduce Password and proceed
5. Close tab
6. Open MM again
7. Click Forgot Password
8. Ensure that Restore Vault page is shown and able to be completed

## Pre-Merge Checklist

- [X] PR template is filled out
- [ ] **IF** this PR fixes a bug, a test that _would have_ caught the bug has been added
- [X] PR is linked to the appropriate GitHub issue
- [ ] PR has been added to the appropriate release Milestone

### + If there are functional changes:

- [ ] Manual testing complete & passed
- [ ] "Extension QA Board" label has been applied
