### PR TITLE
[FLASK] Backport "Fix eth_accounts permission for Snaps"

### DIFF
--- a/patches/@metamask+snap-controllers+0.21.0.patch
+++ b/patches/@metamask+snap-controllers+0.21.0.patch
@@ -1,0 +1,85 @@
+diff --git a/node_modules/@metamask/snap-controllers/dist/snaps/SnapController.js b/node_modules/@metamask/snap-controllers/dist/snaps/SnapController.js
+index cc6857b..c2eeb0a 100644
+--- a/node_modules/@metamask/snap-controllers/dist/snaps/SnapController.js
++++ b/node_modules/@metamask/snap-controllers/dist/snaps/SnapController.js
+@@ -797,7 +797,7 @@ class SnapController extends controllers_1.BaseControllerV2 {
+         const newSnap = await this._fetchSnap(snapId, newVersionRange);
+         const newVersion = newSnap.manifest.version;
+         if (!(0, snap_utils_1.gtVersion)(newVersion, snap.version)) {
+-            console.warn(`Tried updating snap "${snapId}" within "${newVersionRange}" version range, but newer version "${newVersion}" is already installed`);
++            console.warn(`Tried updating snap "${snapId}" within "${newVersionRange}" version range, but newer version "${snap.version}" is already installed`);
+             return null;
+         }
+         await this._assertIsUnblocked(snapId, {
+@@ -807,7 +807,7 @@ class SnapController extends controllers_1.BaseControllerV2 {
+         const processedPermissions = this.processSnapPermissions(newSnap.manifest.initialPermissions);
+         const { newPermissions, unusedPermissions, approvedPermissions } = await this.calculatePermissionsChange(snapId, processedPermissions);
+         const id = (0, nanoid_1.nanoid)();
+-        const isApproved = await this.messagingSystem.call('ApprovalController:addRequest', {
++        const _a = (await this.messagingSystem.call('ApprovalController:addRequest', {
+             origin,
+             id,
+             type: exports.SNAP_APPROVAL_UPDATE,
+@@ -821,10 +821,7 @@ class SnapController extends controllers_1.BaseControllerV2 {
+                 approvedPermissions,
+                 unusedPermissions,
+             },
+-        }, true);
+-        if (!isApproved) {
+-            return null;
+-        }
++        }, true)), { permissions: approvedNewPermissions } = _a, requestData = __rest(_a, ["permissions"]);
+         if (this.isRunning(snapId)) {
+             await this.stopSnap(snapId, snap_utils_1.SnapStatusEvents.Stop);
+         }
+@@ -842,10 +839,11 @@ class SnapController extends controllers_1.BaseControllerV2 {
+                 [snapId]: unusedPermissionsKeys,
+             });
+         }
+-        if ((0, utils_1.isNonEmptyArray)(Object.keys(newPermissions))) {
++        if ((0, utils_1.isNonEmptyArray)(Object.keys(approvedNewPermissions))) {
+             await this.messagingSystem.call('PermissionController:grantPermissions', {
+-                approvedPermissions: newPermissions,
++                approvedPermissions: approvedNewPermissions,
+                 subject: { origin: snapId },
++                requestData,
+             });
+         }
+         await this._startSnap({ snapId, sourceCode: newSnap.sourceCode });
+@@ -1098,7 +1096,7 @@ class SnapController extends controllers_1.BaseControllerV2 {
+      * @param snapId - The id of the Snap.
+      * @returns The snap's approvedPermissions.
+      */
+-    async authorize(origin, snapId) {
++     async authorize(origin, snapId) {
+         console.info(`Authorizing snap: ${snapId}`);
+         const snapsState = this.state.snaps;
+         const snap = snapsState[snapId];
+@@ -1106,7 +1104,7 @@ class SnapController extends controllers_1.BaseControllerV2 {
+         try {
+             const processedPermissions = this.processSnapPermissions(initialPermissions);
+             const id = (0, nanoid_1.nanoid)();
+-            const isApproved = await this.messagingSystem.call('ApprovalController:addRequest', {
++            const _a = (await this.messagingSystem.call('ApprovalController:addRequest', {
+                 origin,
+                 id,
+                 type: exports.SNAP_APPROVAL_INSTALL,
+@@ -1116,14 +1114,12 @@ class SnapController extends controllers_1.BaseControllerV2 {
+                     permissions: processedPermissions,
+                     snapId,
+                 },
+-            }, true);
+-            if (!isApproved) {
+-                throw eth_rpc_errors_1.ethErrors.provider.userRejectedRequest();
+-            }
+-            if ((0, utils_1.isNonEmptyArray)(Object.keys(processedPermissions))) {
++            }, true)), { permissions: approvedPermissions } = _a, requestData = __rest(_a, ["permissions"]);
++            if ((0, utils_1.isNonEmptyArray)(Object.keys(approvedPermissions))) {
+                 await this.messagingSystem.call('PermissionController:grantPermissions', {
+-                    approvedPermissions: processedPermissions,
++                    approvedPermissions,
+                     subject: { origin: snapId },
++                    requestData,
+                 });
+             }
+         }

--- a/ui/pages/permissions-connect/permissions-connect.component.js
+++ b/ui/pages/permissions-connect/permissions-connect.component.js
@@ -313,7 +313,11 @@ export default class PermissionConnect extends Component {
                 <SnapInstall
                   request={permissionsRequest || {}}
                   approveSnapInstall={(requestId) => {
-                    approvePendingApproval(requestId, true);
+                    approvePendingApproval(requestId, {
+                      ...permissionsRequest,
+                      permissions: { ...permissionsRequest.permissions },
+                      approvedAccounts: selectedAccountAddresses,
+                    });
                     this.redirect(true);
                   }}
                   rejectSnapInstall={(requestId) => {
@@ -340,7 +344,11 @@ export default class PermissionConnect extends Component {
                 <SnapUpdate
                   request={permissionsRequest || {}}
                   approveSnapUpdate={(requestId) => {
-                    approvePendingApproval(requestId, true);
+                    approvePendingApproval(requestId, {
+                      ...permissionsRequest,
+                      permissions: { ...permissionsRequest.permissions },
+                      approvedAccounts: selectedAccountAddresses,
+                    });
                     this.redirect(true);
                   }}
                   rejectSnapUpdate={(requestId) => {

--- a/ui/pages/permissions-connect/permissions-connect.component.js
+++ b/ui/pages/permissions-connect/permissions-connect.component.js
@@ -315,7 +315,6 @@ export default class PermissionConnect extends Component {
                   approveSnapInstall={(requestId) => {
                     approvePendingApproval(requestId, {
                       ...permissionsRequest,
-                      permissions: { ...permissionsRequest.permissions },
                       approvedAccounts: selectedAccountAddresses,
                     });
                     this.redirect(true);
@@ -346,7 +345,6 @@ export default class PermissionConnect extends Component {
                   approveSnapUpdate={(requestId) => {
                     approvePendingApproval(requestId, {
                       ...permissionsRequest,
-                      permissions: { ...permissionsRequest.permissions },
                       approvedAccounts: selectedAccountAddresses,
                     });
                     this.redirect(true);


### PR DESCRIPTION
## Explanation

Backport of https://github.com/MetaMask/metamask-extension/pull/16158 to Version 10.21.0, since the release uses a different version of `@metamask/snap-controllers`.
