### PR TITLE
Keep imported tokens in the Assets list

### DIFF
--- a/ui/ducks/swaps/swaps.js
+++ b/ui/ducks/swaps/swaps.js
@@ -83,7 +83,7 @@ import {
   IN_PROGRESS_TRANSACTION_STATUSES,
   SMART_TRANSACTION_STATUSES,
 } from '../../../shared/constants/transaction';
-import { getGasFeeEstimates } from '../metamask/metamask';
+import { getGasFeeEstimates, getTokens } from '../metamask/metamask';
 import { ORIGIN_METAMASK } from '../../../shared/constants/app';
 import {
   calcGasTotal,
@@ -606,6 +606,14 @@ export const fetchSwapsLivenessAndFeatureFlags = () => {
   };
 };
 
+const isTokenAlreadyAdded = (tokenAddress, state) => {
+  const tokens = getTokens(state);
+  if (!Array.isArray(tokens)) {
+    return false;
+  }
+  return tokens.find((token) => token.address.toLowerCase() === tokenAddress);
+};
+
 export const fetchQuotesAndSetQuoteState = (
   history,
   inputValue,
@@ -674,7 +682,8 @@ export const fetchQuotesAndSetQuoteState = (
     if (
       toTokenAddress &&
       toTokenSymbol !== swapsDefaultToken.symbol &&
-      contractExchangeRates[toTokenAddress] === undefined
+      contractExchangeRates[toTokenAddress] === undefined &&
+      !isTokenAlreadyAdded(toTokenAddress, state)
     ) {
       destinationTokenAddedForSwap = true;
       await dispatch(

--- a/ui/ducks/swaps/swaps.js
+++ b/ui/ducks/swaps/swaps.js
@@ -610,7 +610,9 @@ const isTokenAlreadyAdded = (tokenAddress, tokens) => {
   if (!Array.isArray(tokens)) {
     return false;
   }
-  return tokens.find((token) => token.address.toLowerCase() === tokenAddress);
+  return tokens.find(
+    (token) => token.address.toLowerCase() === tokenAddress.toLowerCase(),
+  );
 };
 
 export const fetchQuotesAndSetQuoteState = (

--- a/ui/ducks/swaps/swaps.js
+++ b/ui/ducks/swaps/swaps.js
@@ -606,8 +606,7 @@ export const fetchSwapsLivenessAndFeatureFlags = () => {
   };
 };
 
-const isTokenAlreadyAdded = (tokenAddress, state) => {
-  const tokens = getTokens(state);
+const isTokenAlreadyAdded = (tokenAddress, tokens) => {
   if (!Array.isArray(tokens)) {
     return false;
   }
@@ -683,7 +682,7 @@ export const fetchQuotesAndSetQuoteState = (
       toTokenAddress &&
       toTokenSymbol !== swapsDefaultToken.symbol &&
       contractExchangeRates[toTokenAddress] === undefined &&
-      !isTokenAlreadyAdded(toTokenAddress, state)
+      !isTokenAlreadyAdded(toTokenAddress, getTokens(state))
     ) {
       destinationTokenAddedForSwap = true;
       await dispatch(


### PR DESCRIPTION
## Explanation
When a user imported a token on the main page, tried to use it in the `Swap to` field and clicked on the `Cancel` link, the token they imported disappeared from the Assets list on the main page. This PR makes sure it stays there when a user cancels a swap.

## Manual Testing Steps
- On the main page click on `import tokens`
- Import a token where you have 0 balance by contract address
- Try to use it in the `Swap to` field and cancel the Swap via the `Cancel` link on the top
- Go to the Assets list on the main page, the imported token will be there