### PR TITLE
Add build stats history json file

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -728,6 +728,9 @@ jobs:
           name: Run page load benchmark
           command: yarn mv3:stats:chrome --out test-artifacts/chrome/mv3
       - run:
+          name: Install jq
+          command: sudo apt install jq -y
+      - run:
           name: Record bundle size at commit
           command: ./.circleci/scripts/bundle-stats-commit.sh
       - store_artifacts:

--- a/.circleci/scripts/bundle-stats-commit.sh
+++ b/.circleci/scripts/bundle-stats-commit.sh
@@ -50,6 +50,28 @@ cp temp/stats/bundle_size_data.temp.js temp/stats/bundle_size_data.js
 
 echo " }" >> temp/stats/bundle_size_data.js
 
+if [ -f temp/stats/bundle_size_data.json ]; then
+  # copy bundle_size_data.json in bundle_size_data.temp.json without last 2 lines
+  head -$(($(wc -l < temp/stats/bundle_size_data.json) - 2)) temp/stats/bundle_size_data.json > bundle_size_stats.temp.json
+
+  {
+    echo "},";
+    echo "\"$CIRCLE_SHA1\":";
+    cat test-artifacts/chrome/mv3/bundle_size_stats.json;
+    echo "}";
+  } >> bundle_size_stats.temp.json
+else
+  {
+    echo "{";
+    echo "\"$CIRCLE_SHA1\":";
+    cat test-artifacts/chrome/mv3/bundle_size_stats.json;
+    echo "}";
+  } > bundle_size_stats.temp.json
+fi
+
+jq < bundle_size_stats.temp.json > temp/stats/bundle_size_data.json
+rm bundle_size_stats.temp.json
+
 cd temp
 
 git add .


### PR DESCRIPTION
## Explanation

This PR edits the `stats-module-load-init` step of the circleci pipeline, extending `bundle-stats-commit.sh` to update also a JSON version of the historical bundle size file, along with the JS one we currently update on each commit on develop.

This is needed by #16098 as metamaskbot will need to get the size of the bundle at a specific commit. See [this comment](https://github.com/MetaMask/metamask-extension/pull/16098#discussion_r992386162) for more info.

**Node**: The PR also installs `jq` on the `node-browsers-medium-plus` executor to be able to format the JSON output. 

## More Information

* See #16098 
