### PR TITLE
[FLASK] Add E2E for `wallet_getSnaps`

### DIFF
--- a/test/e2e/snaps/enums.js
+++ b/test/e2e/snaps/enums.js
@@ -1,3 +1,3 @@
 module.exports = {
-  TEST_SNAPS_WEBSITE_URL: 'https://metamask.github.io/test-snaps/3.0.1',
+  TEST_SNAPS_WEBSITE_URL: 'https://metamask.github.io/test-snaps/3.1.0',
 };

--- a/test/e2e/snaps/test-snap-get-snaps.spec.js
+++ b/test/e2e/snaps/test-snap-get-snaps.spec.js
@@ -103,14 +103,19 @@ describe('Test Snap Confirm', function () {
         windowHandles = await driver.getAllWindowHandles();
         await driver.switchToWindowWithTitle('Test Snaps', windowHandles);
 
-        const getInstalledSnapsButton = await driver.findElement('#getInstalledSnapsButton');
+        const getInstalledSnapsButton = await driver.findElement(
+          '#getInstalledSnapsButton',
+        );
         await driver.scrollToElement(getInstalledSnapsButton);
         await driver.delay(1000);
         await driver.clickElement('#getInstalledSnapsButton');
         await driver.delay(1000);
 
         const result = await driver.findElement('#getInstalledSnapsResult');
-        assert.equal(await result.getText(), 'npm:@metamask/test-snap-confirm, npm:@metamask/test-snap-error');
+        assert.equal(
+          await result.getText(),
+          'npm:@metamask/test-snap-confirm, npm:@metamask/test-snap-error',
+        );
       },
     );
   });

--- a/test/e2e/snaps/test-snap-get-snaps.spec.js
+++ b/test/e2e/snaps/test-snap-get-snaps.spec.js
@@ -1,0 +1,117 @@
+const { strict: assert } = require('assert');
+const { withFixtures } = require('../helpers');
+const { TEST_SNAPS_WEBSITE_URL } = require('./enums');
+
+describe('Test Snap Confirm', function () {
+  it('can pop up a snap confirm and get its result', async function () {
+    const ganacheOptions = {
+      accounts: [
+        {
+          secretKey:
+            '0x7C9529A67102755B7E6102D6D950AC5D5863C98713805CEC576B945B15B71EAC',
+          balance: 25000000000000000000,
+        },
+      ],
+    };
+    await withFixtures(
+      {
+        fixtures: 'imported-account',
+        ganacheOptions,
+        title: this.test.title,
+      },
+      async ({ driver }) => {
+        await driver.navigate();
+
+        // enter pw into extension
+        await driver.fill('#password', 'correct horse battery staple');
+        await driver.press('#password', driver.Key.ENTER);
+
+        // navigate to test snaps page and connect
+        await driver.driver.get(TEST_SNAPS_WEBSITE_URL);
+        await driver.fill('#snapId1', 'npm:@metamask/test-snap-confirm');
+        await driver.clickElement('#connectHello');
+
+        // switch to metamask extension and click connect
+        await driver.waitUntilXWindowHandles(2, 5000, 10000);
+        let windowHandles = await driver.getAllWindowHandles();
+        await driver.switchToWindowWithTitle(
+          'MetaMask Notification',
+          windowHandles,
+        );
+        await driver.clickElement(
+          {
+            text: 'Connect',
+            tag: 'button',
+          },
+          10000,
+        );
+
+        await driver.delay(2000);
+
+        // approve install of snap
+        await driver.waitUntilXWindowHandles(2, 5000, 10000);
+        windowHandles = await driver.getAllWindowHandles();
+        await driver.switchToWindowWithTitle(
+          'MetaMask Notification',
+          windowHandles,
+        );
+        await driver.clickElement({
+          text: 'Approve & install',
+          tag: 'button',
+        });
+
+        // click send inputs on test snap page
+        await driver.waitUntilXWindowHandles(1, 5000, 10000);
+        windowHandles = await driver.getAllWindowHandles();
+        await driver.switchToWindowWithTitle('Test Snaps', windowHandles);
+
+        const errorButton = await driver.findElement('#connectError');
+        await driver.scrollToElement(errorButton);
+        await driver.delay(1000);
+        await driver.fill('#snapId2', 'npm:@metamask/test-snap-error');
+        await driver.clickElement('#connectError');
+
+        // switch to metamask extension and click connect
+        await driver.waitUntilXWindowHandles(2, 5000, 10000);
+        windowHandles = await driver.getAllWindowHandles();
+        await driver.switchToWindowWithTitle(
+          'MetaMask Notification',
+          windowHandles,
+        );
+        await driver.clickElement(
+          {
+            text: 'Connect',
+            tag: 'button',
+          },
+          10000,
+        );
+
+        await driver.delay(2000);
+
+        // approve install of snap
+        windowHandles = await driver.getAllWindowHandles();
+        await driver.switchToWindowWithTitle(
+          'MetaMask Notification',
+          windowHandles,
+        );
+        await driver.clickElement({
+          text: 'Approve & install',
+          tag: 'button',
+        });
+
+        await driver.waitUntilXWindowHandles(1, 5000, 10000);
+        windowHandles = await driver.getAllWindowHandles();
+        await driver.switchToWindowWithTitle('Test Snaps', windowHandles);
+
+        const getInstalledSnapsButton = await driver.findElement('#getInstalledSnapsButton');
+        await driver.scrollToElement(getInstalledSnapsButton);
+        await driver.delay(1000);
+        await driver.clickElement('#getInstalledSnapsButton');
+        await driver.delay(1000);
+
+        const result = await driver.findElement('#getInstalledSnapsResult');
+        assert.equal(await result.getText(), 'npm:@metamask/test-snap-confirm, npm:@metamask/test-snap-error');
+      },
+    );
+  });
+});


### PR DESCRIPTION
## Explanation

Adds an E2E test for `wallet_getSnaps` because that RPC method has broken multiple times without anyone noticing. 

The test works by installing two snaps and then checking that they are both included in the output of `wallet_getSnaps`.

Fixes https://github.com/MetaMask/snaps-monorepo/issues/831