### PR TITLE
[e2e] Add option for continue running e2e testcases after failure

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -561,7 +561,7 @@ jobs:
           command: |
             if .circleci/scripts/test-run-e2e.sh
             then
-              yarn test:e2e:chrome --retries 2 || echo "Temporarily suppressing MV3 e2e test failures"
+              yarn test:e2e:chrome --retries 2 --resume || echo "Temporarily suppressing MV3 e2e test failures"
             fi
           no_output_timeout: 20m
       - store_artifacts:

--- a/test/e2e/run-all.js
+++ b/test/e2e/run-all.js
@@ -25,12 +25,16 @@ async function main() {
             description:
               'Set how many times the test should be retried upon failure.',
             type: 'number',
+          })
+          .option('resume', {
+            description: `Continue running testcases after failure.`,
+            type: 'boolean',
           }),
     )
     .strict()
     .help('help');
 
-  const { browser, retries, snaps } = argv;
+  const { browser, retries, snaps, resume } = argv;
 
   let testDir = path.join(__dirname, 'tests');
 
@@ -56,9 +60,20 @@ async function main() {
   if (retries) {
     args.push('--retries', retries);
   }
+  if (resume) {
+    args.push('--resume', resume);
+  }
 
   for (const testPath of testPaths) {
-    await runInShell('node', [...args, testPath]);
+    try {
+      await runInShell('node', [...args, testPath]);
+    } catch (e) {
+      if (resume) {
+        continue;
+      } else {
+        break;
+      }
+    }
   }
 }
 

--- a/test/e2e/run-e2e-test.js
+++ b/test/e2e/run-e2e-test.js
@@ -34,6 +34,10 @@ async function main() {
             describe: 'The path for the E2E test to run.',
             type: 'string',
             normalize: true,
+          })
+          .option('resume', {
+            description: `Continue running testcases after failure.`,
+            type: 'boolean',
           }),
     )
     .strict()


### PR DESCRIPTION
## Explanation

**Why**: currently when we run the script for executing all e2e tests, they are stopped and script is terminated if a failure is encountered. There are certain occasions that we want to continue them running. 
For example, on the MV3 job, we want to run all the tests to see all failing tests. Or a developer might want to run them all to see all the failures at once.
There are also cases when we want the tests to fail fast, i.e. capture errors fast on a circle ci run, or avoid spending too much resources on circle ci.
For this reason we'll include this change as an option.

**What**: we'll include an option for running all e2e tests no matter if they fail.

**How**:

- We'll make it the default option for the MV3 run, for now, as it is convenient to see ALL the failing tests.
- Anyone can add this option flag when running their tests locally by adding the `--resume` flag.


## More Information
Resolves https://github.com/MetaMask/metamask-extension/issues/16192

## Screenshots/Screencaps

### Before
- `Run-all` script terminated on failure

### After
- `Run-all` script continues after failure if `--resume` option is passed

## Manual Testing Steps

**Locally**
1. Change last assertion on the `account-details.spec.js` file in order to make it fail:
`assert.equal(await qrCode.isDisplayed(), "sdkfha");`
2. Run all tests and see how they continue running after failure if `resume` option is passed
`yarn test:e2e:chrome --resume `


**On Circle CI**
Check that MV3 e2e testcases continue after failure, on circle ci job.
https://app.circleci.com/pipelines/github/MetaMask/metamask-extension/29114/workflows/dc9db3da-099a-44a5-8896-dad6aa71b091/jobs/756717

## Pre-Merge Checklist

- [X] PR template is filled out
- [ ] **IF** this PR fixes a bug, a test that _would have_ caught the bug has been added
- [X] PR is linked to the appropriate GitHub issue
- [ ] PR has been added to the appropriate release Milestone

### + If there are functional changes:

- [ ] Manual testing complete & passed
- [ ] "Extension QA Board" label has been applied
