### PR TITLE
ci: fix stats-module-load-init step

### DIFF
--- a/.circleci/scripts/bundle-stats-commit.sh
+++ b/.circleci/scripts/bundle-stats-commit.sh
@@ -69,7 +69,7 @@ else
   } > bundle_size_stats.temp.json
 fi
 
-jq < bundle_size_stats.temp.json > temp/stats/bundle_size_data.json
+jq . bundle_size_stats.temp.json > temp/stats/bundle_size_data.json
 rm bundle_size_stats.temp.json
 
 cd temp


### PR DESCRIPTION
## Explanation

After merging #16168 ci step running `bundle-stats-commit.sh` started failing.
This is due to a version of `jq` installed in the `circleci/node:16-browsers` docker image that is using this syntax: 
`jq [filter] [file]`
and doesn't support the `jq < [file]` syntax that correctly works on MacOS.

## Manual Testing Steps

The syntax used can be tested building a container with docker image `circleci/node:16-browsers` and installing jq to parse an unprettified json:

**`test.json`**
```json
{"hello":"world"}
```

```dockerfile
FROM circleci/node:16-browsers
USER root

COPY ./test.json ./test.json

RUN sudo apt install jq &&\
    jq . test.json > test.pretty.json

CMD ["cat", "test.pretty.json"]
```

**Expected `test.pretty.json`**
```json
{ 
    "hello": "world" 
}
```