### PR TITLE
TextFieldBase updates after design reveiw

### DIFF
--- a/ui/components/component-library/text-field-base/README.mdx
+++ b/ui/components/component-library/text-field-base/README.mdx
@@ -69,7 +69,7 @@ import { TextFieldBase } from '../../ui/component-library/text-field-base';
 
 ### Truncate
 
-Use the `truncate` prop to truncate the text of the the `TextFieldBase`
+Use the `truncate` prop to truncate the text of the the `TextFieldBase`. Defaults to `true`.
 
 <Canvas>
   <Story id="ui-components-component-library-text-field-base-text-field-base-stories-js--truncate" />
@@ -78,7 +78,8 @@ Use the `truncate` prop to truncate the text of the the `TextFieldBase`
 ```jsx
 import { TextFieldBase } from '../../ui/component-library/text-field-base';
 
-<TextFieldBase truncate />;
+<TextFieldBase truncate />; // truncate is set to `true` by default
+<TextFieldBase truncate={false} />;
 ```
 
 ### Left Accessory Right Accessory

--- a/ui/components/component-library/text-field-base/README.mdx
+++ b/ui/components/component-library/text-field-base/README.mdx
@@ -274,7 +274,7 @@ import { TextFieldBase } from '../../ui/component-library/text-field-base';
 
 ### Read Only
 
-Use the `readOnly` prop to set the `TextFieldBase` to read only
+Use the `readOnly` prop to set the `TextFieldBase` to read only. When `readOnly` is true `TextFieldBase` will not have a focus state.
 
 <Canvas>
   <Story id="ui-components-component-library-text-field-base-text-field-base-stories-js--read-only" />

--- a/ui/components/component-library/text-field-base/text-field-base.js
+++ b/ui/components/component-library/text-field-base/text-field-base.js
@@ -95,7 +95,7 @@ export const TextFieldBase = ({
         'mm-text-field-base',
         `mm-text-field-base--size-${size}`,
         {
-          'mm-text-field-base--focused': focused && !disabled,
+          'mm-text-field-base--focused': focused && !disabled && !readOnly,
           'mm-text-field-base--error': error,
           'mm-text-field-base--disabled': disabled,
           'mm-text-field-base--truncate': truncate,

--- a/ui/components/component-library/text-field-base/text-field-base.js
+++ b/ui/components/component-library/text-field-base/text-field-base.js
@@ -42,7 +42,7 @@ export const TextFieldBase = ({
   required,
   size = SIZES.MD,
   type = 'text',
-  truncate,
+  truncate = true,
   value,
   ...props
 }) => {
@@ -212,6 +212,10 @@ TextFieldBase.propTypes = {
    */
   onChange: PropTypes.func,
   /**
+   * Callback fired when the TextField is clicked on
+   */
+  onClick: PropTypes.func,
+  /**
    * Callback fired on focus
    */
   onFocus: PropTypes.func,
@@ -237,6 +241,11 @@ TextFieldBase.propTypes = {
    * Defaults to TEXT_FIELD_BASE_TYPES.TEXT ('text')
    */
   type: PropTypes.oneOf(Object.values(TEXT_FIELD_BASE_TYPES)),
+  /**
+   * If true will ellipse the text of the input
+   * Defaults to true
+   */
+  truncate: PropTypes.bool,
   /**
    * The input value, required for a controlled component.
    */

--- a/ui/components/component-library/text-field-base/text-field-base.scss
+++ b/ui/components/component-library/text-field-base/text-field-base.scss
@@ -17,7 +17,18 @@
   border-color: var(--color-border-default);
 
   &--focused {
-    border-color: var(--color-primary-default);
+    position: relative;
+
+    &::after {
+      content: '';
+      width: 100%;
+      height: 100%;
+      position: absolute;
+      left: 0;
+      top: 0;
+      outline: 5px auto Highlight; // firefox
+      outline: 5px auto -webkit-focus-ring-color; // chrome
+    }
   }
 
   &--error {

--- a/ui/components/component-library/text-field-base/text-field-base.scss
+++ b/ui/components/component-library/text-field-base/text-field-base.scss
@@ -17,18 +17,8 @@
   border-color: var(--color-border-default);
 
   &--focused {
-    position: relative;
-
-    &::after {
-      content: '';
-      width: 100%;
-      height: 100%;
-      position: absolute;
-      left: 0;
-      top: 0;
-      outline: 5px auto Highlight; // firefox
-      outline: 5px auto -webkit-focus-ring-color; // chrome
-    }
+    outline: 5px auto Highlight; // firefox
+    outline: 5px auto -webkit-focus-ring-color; // chrome
   }
 
   &--error {

--- a/ui/components/component-library/text-field-base/text-field-base.stories.js
+++ b/ui/components/component-library/text-field-base/text-field-base.stories.js
@@ -141,16 +141,6 @@ export default {
   },
   args: {
     placeholder: 'Placeholder...',
-    autoFocus: false,
-    defaultValue: '',
-    disabled: false,
-    error: false,
-    id: '',
-    readOnly: false,
-    required: false,
-    size: SIZES.MD,
-    type: 'text',
-    truncate: false,
   },
 };
 

--- a/ui/components/component-library/text-field-base/text-field-base.test.js
+++ b/ui/components/component-library/text-field-base/text-field-base.test.js
@@ -103,11 +103,17 @@ describe('TextFieldBase', () => {
       'password',
     );
   });
-  it('should render with truncate class', () => {
+  it('should render with truncate class as true by default and remove it when truncate is false', () => {
     const { getByTestId } = render(
-      <TextFieldBase truncate data-testid="truncate" />,
+      <>
+        <TextFieldBase data-testid="truncate" />
+        <TextFieldBase truncate={false} data-testid="no-truncate" />
+      </>,
     );
     expect(getByTestId('truncate')).toHaveClass('mm-text-field-base--truncate');
+    expect(getByTestId('no-truncate')).not.toHaveClass(
+      'mm-text-field-base--truncate',
+    );
   });
   it('should render with right and left accessories', () => {
     const { getByRole, getByText } = render(

--- a/ui/components/component-library/text-field-base/text-field-base.test.js
+++ b/ui/components/component-library/text-field-base/text-field-base.test.js
@@ -24,6 +24,21 @@ describe('TextFieldBase', () => {
     fireEvent.change(textFieldBase, { target: { value: '' } }); // reset value
     expect(textFieldBase.value).toBe(''); // value is empty string after reset
   });
+  it('should render with focused state when clicked', () => {
+    const { getByTestId } = render(
+      <TextFieldBase
+        data-testid="text-field-base"
+        inputProps={{ 'data-testid': 'input' }}
+      />,
+    );
+    const textFieldBase = getByTestId('text-field-base');
+
+    fireEvent.click(textFieldBase);
+    expect(getByTestId('input')).toHaveFocus();
+    expect(getByTestId('text-field-base')).toHaveClass(
+      'mm-text-field-base--focused ',
+    );
+  });
   it('should render and fire onFocus and onBlur events', () => {
     const onFocus = jest.fn();
     const onBlur = jest.fn();
@@ -196,8 +211,12 @@ describe('TextFieldBase', () => {
     const { getByTestId } = render(
       <TextFieldBase
         readOnly
+        data-testid="read-only"
         inputProps={{ 'data-testid': 'text-field-base-readonly' }}
       />,
+    );
+    expect(getByTestId('read-only')).not.toHaveClass(
+      'mm-text-field-base--focused ',
     );
     expect(getByTestId('text-field-base-readonly')).toHaveAttribute(
       'readonly',


### PR DESCRIPTION
## Explanation

Updates to the `TextFieldBase` component after technical design review. The following updates were made:

- update readonly to not a focus state (not sure if this hinders accessibility)
- update truncate to be true by default
- update focus border width to be `2px` 

## More Information

* Fixes #16200 

## Screenshots/Screencaps

### Before

https://user-images.githubusercontent.com/8112138/195802454-f18d4112-5679-49a8-badd-4e6c3af4be70.mov

### After

https://user-images.githubusercontent.com/8112138/195803138-1b99a19d-885b-4037-a7d4-e650afb53542.mov

## Manual Testing Steps

- Go to the latest build of Storybook on this PR
- Search `TextFieldBase` in the search bar
- See updates to focused state and default truncation
- Go to Read Only story
- See there is no focused state when text is selected

## Pre-Merge Checklist

- [x] PR template is filled out
- [x] **IF** this PR fixes a bug, a test that _would have_ caught the bug has been added
- [x] PR is linked to the appropriate GitHub issue
- [x] PR has been added to the appropriate release Milestone

### + If there are functional changes:

- [x] Manual testing complete & passed
- [x] "Extension QA Board" label has been applied
