### PR TITLE
Fix/16207/text component storybook

### DIFF
--- a/ui/components/component-library/text/README.mdx
+++ b/ui/components/component-library/text/README.mdx
@@ -269,6 +269,7 @@ import { Text } from '../../ui/component-library/text';
 <Text as="p">p</Text>
 <Text as="span">span</Text>
 <Text as="strong">strong</Text>
+<Text as="input" placeholder="input"></Text>
 ```
 
 Renders the html:
@@ -288,6 +289,7 @@ Renders the html:
 <p>p</p>
 <span>span</span>
 <strong>strong</strong>
+<input placeholder="input" />
 ```
 
 ### Box Props

--- a/ui/components/component-library/text/text.stories.js
+++ b/ui/components/component-library/text/text.stories.js
@@ -259,12 +259,17 @@ export const Ellipsis = (args) => (
 
 export const As = (args) => (
   <>
-    {Object.values(ValidTags).map((tag) => (
-      <div key={tag}>
-        <Text {...args} as={tag}>
-          {tag}
-        </Text>
-      </div>
-    ))}
+    {ValidTags.map((tag) => {
+      if (tag === 'input') {
+        return <Text key={tag} {...args} as={tag} placeholder={tag} />;
+      }
+      return (
+        <div key={tag}>
+          <Text {...args} as={tag}>
+            {tag}
+          </Text>
+        </div>
+      );
+    })}
   </>
 );


### PR DESCRIPTION
## Explanation
Text component Storybook was broken due to an addition of `input` to the `ValidTags` array. To fix the input example needs to be properly formatted as an input element in the example. 

## More Information

* Fixes #16207


## Screenshots/Screencaps

<!-- If you're making a change to the UI, make sure to capture a screenshot or a short video showing off your work! -->

### Before

<!-- How did the UI you changed look before your changes? Drag your file(s) below this line: -->
<img width="1440" alt="195865604-25b285ad-2222-4719-b0e1-b4378cea835d" src="https://user-images.githubusercontent.com/26469696/195911094-7d890773-fa89-4e95-b087-dcb213758743.png">

### After

<!-- How does it look now? Drag your file(s) below this line: -->
<img width="1047" alt="Screen Shot 2022-10-14 at 10 55 04 AM" src="https://user-images.githubusercontent.com/26469696/195911128-0eff8509-3d43-4be9-acc8-3bcf0a86bf0b.png">

## Manual Testing Steps

<!--
How should reviewers and QA manually test your changes? For instance:

- Go to this screen
- Do this
- Then do this
-->

## Pre-Merge Checklist

- [X] PR template is filled out
- [ ] **IF** this PR fixes a bug, a test that _would have_ caught the bug has been added _(Storybook render test still needed)_
- [X] PR is linked to the appropriate GitHub issue
- [X] PR has been added to the appropriate release Milestone

### + If there are functional changes:

- [X] Manual testing complete & passed
- [ ] "Extension QA Board" label has been applied
