### PR TITLE
Warning on a Send transaction request

### DIFF
--- a/ui/components/app/confirm-page-container/confirm-page-container-content/confirm-page-container-content.component.js
+++ b/ui/components/app/confirm-page-container/confirm-page-container-content/confirm-page-container-content.component.js
@@ -198,7 +198,8 @@ export default class ConfirmPageContainerContent extends Component {
         {this.renderContent()}
         {!supportsEIP1559V2 &&
           (errorKey || errorMessage) &&
-          currentTransaction.type !== TRANSACTION_TYPES.SIMPLE_SEND && (
+          (currentTransaction.type !== TRANSACTION_TYPES.SIMPLE_SEND ||
+            currentTransaction.type === TRANSACTION_TYPES.SIMPLE_SEND) && (
             <div className="confirm-page-container-content__error-container">
               <ErrorMessage errorMessage={errorMessage} errorKey={errorKey} />
             </div>

--- a/ui/components/app/confirm-page-container/confirm-page-container-content/confirm-page-container-content.component.js
+++ b/ui/components/app/confirm-page-container/confirm-page-container-content/confirm-page-container-content.component.js
@@ -9,7 +9,6 @@ import ErrorMessage from '../../../ui/error-message';
 import { INSUFFICIENT_FUNDS_ERROR_KEY } from '../../../../helpers/constants/error-keys';
 import Typography from '../../../ui/typography';
 import { TYPOGRAPHY } from '../../../../helpers/constants/design-system';
-import { TRANSACTION_TYPES } from '../../../../../shared/constants/transaction';
 
 import { ConfirmPageContainerSummary, ConfirmPageContainerWarning } from '.';
 
@@ -50,7 +49,6 @@ export default class ConfirmPageContainerContent extends Component {
     hideTitle: PropTypes.bool,
     supportsEIP1559V2: PropTypes.bool,
     hasTopBorder: PropTypes.bool,
-    currentTransaction: PropTypes.object,
     nativeCurrency: PropTypes.string,
     networkName: PropTypes.string,
     showBuyModal: PropTypes.func,
@@ -151,7 +149,6 @@ export default class ConfirmPageContainerContent extends Component {
       hideTitle,
       supportsEIP1559V2,
       hasTopBorder,
-      currentTransaction,
       nativeCurrency,
       networkName,
       showBuyModal,
@@ -196,14 +193,11 @@ export default class ConfirmPageContainerContent extends Component {
           transactionType={transactionType}
         />
         {this.renderContent()}
-        {!supportsEIP1559V2 &&
-          (errorKey || errorMessage) &&
-          (currentTransaction.type !== TRANSACTION_TYPES.SIMPLE_SEND ||
-            currentTransaction.type === TRANSACTION_TYPES.SIMPLE_SEND) && (
-            <div className="confirm-page-container-content__error-container">
-              <ErrorMessage errorMessage={errorMessage} errorKey={errorKey} />
-            </div>
-          )}
+        {!supportsEIP1559V2 && (errorKey || errorMessage) && (
+          <div className="confirm-page-container-content__error-container">
+            <ErrorMessage errorMessage={errorMessage} errorKey={errorKey} />
+          </div>
+        )}
         {showInsuffienctFundsError && (
           <div className="confirm-page-container-content__error-container">
             <ActionableMessage

--- a/ui/components/app/confirm-page-container/confirm-page-container-content/confirm-page-container-content.component.js
+++ b/ui/components/app/confirm-page-container/confirm-page-container-content/confirm-page-container-content.component.js
@@ -9,6 +9,7 @@ import ErrorMessage from '../../../ui/error-message';
 import { INSUFFICIENT_FUNDS_ERROR_KEY } from '../../../../helpers/constants/error-keys';
 import Typography from '../../../ui/typography';
 import { TYPOGRAPHY } from '../../../../helpers/constants/design-system';
+import DepositPopover from '../../deposit-popover/deposit-popover';
 
 import { ConfirmPageContainerSummary, ConfirmPageContainerWarning } from '.';
 
@@ -51,10 +52,13 @@ export default class ConfirmPageContainerContent extends Component {
     hasTopBorder: PropTypes.bool,
     nativeCurrency: PropTypes.string,
     networkName: PropTypes.string,
-    showBuyModal: PropTypes.func,
     toAddress: PropTypes.string,
     transactionType: PropTypes.string,
     isBuyableChain: PropTypes.bool,
+  };
+
+  state = {
+    setShowDepositPopover: false,
   };
 
   renderContent() {
@@ -151,7 +155,6 @@ export default class ConfirmPageContainerContent extends Component {
       hasTopBorder,
       nativeCurrency,
       networkName,
-      showBuyModal,
       toAddress,
       transactionType,
       isBuyableChain,
@@ -163,6 +166,8 @@ export default class ConfirmPageContainerContent extends Component {
       supportsEIP1559V2 &&
       (errorKey || errorMessage) &&
       errorKey === INSUFFICIENT_FUNDS_ERROR_KEY;
+
+    const { setShowDepositPopover } = this.state;
 
     return (
       <div
@@ -212,7 +217,9 @@ export default class ConfirmPageContainerContent extends Component {
                       <Button
                         type="inline"
                         className="confirm-page-container-content__link"
-                        onClick={showBuyModal}
+                        onClick={() =>
+                          this.setState({ setShowDepositPopover: true })
+                        }
                         key={`${nativeCurrency}-buy-button`}
                       >
                         {t('buyAsset', [nativeCurrency])}
@@ -234,7 +241,11 @@ export default class ConfirmPageContainerContent extends Component {
             />
           </div>
         )}
-
+        {setShowDepositPopover && (
+          <DepositPopover
+            onClose={() => this.setState({ setShowDepositPopover: false })}
+          />
+        )}
         <PageContainerFooter
           onCancel={onCancel}
           cancelText={cancelText}

--- a/ui/components/app/confirm-page-container/confirm-page-container.component.js
+++ b/ui/components/app/confirm-page-container/confirm-page-container.component.js
@@ -28,6 +28,7 @@ import Typography from '../../ui/typography';
 import { TYPOGRAPHY } from '../../../helpers/constants/design-system';
 
 import NetworkAccountBalanceHeader from '../network-account-balance-header/network-account-balance-header';
+import DepositPopover from '../deposit-popover/deposit-popover';
 import EnableEIP1559V2Notice from './enableEIP1559V2-notice';
 import {
   ConfirmPageContainerHeader,
@@ -38,6 +39,7 @@ import {
 export default class ConfirmPageContainer extends Component {
   state = {
     showNicknamePopovers: false,
+    setShowDepositPopover: false,
   };
 
   static contextTypes = {
@@ -106,7 +108,6 @@ export default class ConfirmPageContainer extends Component {
     isOwnedAccount: PropTypes.bool,
     supportsEIP1559V2: PropTypes.bool,
     nativeCurrency: PropTypes.string,
-    showBuyModal: PropTypes.func,
     isBuyableChain: PropTypes.bool,
     isApprovalOrRejection: PropTypes.bool,
   };
@@ -162,7 +163,6 @@ export default class ConfirmPageContainer extends Component {
       isOwnedAccount,
       supportsEIP1559V2,
       nativeCurrency,
-      showBuyModal,
       isBuyableChain,
       networkIdentifier,
       isApprovalOrRejection,
@@ -190,6 +190,8 @@ export default class ConfirmPageContainer extends Component {
     const isSetApproveForAll =
       currentTransaction.type ===
       TRANSACTION_TYPES.TOKEN_METHOD_SET_APPROVAL_FOR_ALL;
+
+    const { setShowDepositPopover } = this.state;
 
     const { t } = this.context;
 
@@ -294,7 +296,6 @@ export default class ConfirmPageContainer extends Component {
               currentTransaction={currentTransaction}
               nativeCurrency={nativeCurrency}
               networkName={networkName}
-              showBuyModal={showBuyModal}
               toAddress={toAddress}
               transactionType={currentTransaction.type}
               isBuyableChain={isBuyableChain}
@@ -312,7 +313,9 @@ export default class ConfirmPageContainer extends Component {
                         <Button
                           type="inline"
                           className="confirm-page-container-content__link"
-                          onClick={showBuyModal}
+                          onClick={() =>
+                            this.setState({ setShowDepositPopover: true })
+                          }
                           key={`${nativeCurrency}-buy-button`}
                         >
                           {t('buyAsset', [nativeCurrency])}
@@ -333,6 +336,11 @@ export default class ConfirmPageContainer extends Component {
                 type="danger"
               />
             </div>
+          )}
+          {setShowDepositPopover && (
+            <DepositPopover
+              onClose={() => this.setState({ setShowDepositPopover: false })}
+            />
           )}
           {shouldDisplayWarning && errorKey !== INSUFFICIENT_FUNDS_ERROR_KEY && (
             <div className="confirm-approve-content__warning">

--- a/ui/components/app/confirm-page-container/confirm-page-container.container.js
+++ b/ui/components/app/confirm-page-container/confirm-page-container.container.js
@@ -6,7 +6,6 @@ import {
   getNetworkIdentifier,
   getSwapsDefaultToken,
 } from '../../../selectors';
-import { showModal } from '../../../store/actions';
 import ConfirmPageContainer from './confirm-page-container.component';
 
 function mapStateToProps(state, ownProps) {
@@ -30,13 +29,4 @@ function mapStateToProps(state, ownProps) {
   };
 }
 
-const mapDispatchToProps = (dispatch) => {
-  return {
-    showBuyModal: () => dispatch(showModal({ name: 'DEPOSIT_ETHER' })),
-  };
-};
-
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps,
-)(ConfirmPageContainer);
+export default connect(mapStateToProps)(ConfirmPageContainer);

--- a/ui/pages/confirm-transaction-base/confirm-transaction-base.component.js
+++ b/ui/pages/confirm-transaction-base/confirm-transaction-base.component.js
@@ -159,7 +159,6 @@ export default class ConfirmTransactionBase extends Component {
     hardwareWalletRequiresConnection: PropTypes.bool,
     isMultiLayerFeeNetwork: PropTypes.bool,
     eip1559V2Enabled: PropTypes.bool,
-    showBuyModal: PropTypes.func,
     isBuyableChain: PropTypes.bool,
     isApprovalOrRejection: PropTypes.bool,
     ///: BEGIN:ONLY_INCLUDE_IN(flask)
@@ -353,7 +352,6 @@ export default class ConfirmTransactionBase extends Component {
       supportsEIP1559,
       isMultiLayerFeeNetwork,
       nativeCurrency,
-      showBuyModal,
       isBuyableChain,
     } = this.props;
     const { t } = this.context;
@@ -614,7 +612,6 @@ export default class ConfirmTransactionBase extends Component {
           userAcknowledgedGasMissing={userAcknowledgedGasMissing}
           nativeCurrency={nativeCurrency}
           networkName={networkName}
-          showBuyModal={showBuyModal}
           type={txData.type}
           isBuyableChain={isBuyableChain}
         />

--- a/ui/pages/confirm-transaction-base/confirm-transaction-base.container.js
+++ b/ui/pages/confirm-transaction-base/confirm-transaction-base.container.js
@@ -294,7 +294,6 @@ export const mapDispatchToProps = (dispatch) => {
     updateTransactionGasFees: (gasFees) => {
       dispatch(updateGasFees({ ...gasFees, expectHexWei: true }));
     },
-    showBuyModal: () => dispatch(showModal({ name: 'DEPOSIT_ETHER' })),
   };
 };
 

--- a/ui/pages/confirm-transaction-base/transaction-alerts/transaction-alerts.js
+++ b/ui/pages/confirm-transaction-base/transaction-alerts/transaction-alerts.js
@@ -7,28 +7,16 @@ import { submittedPendingTransactionsSelector } from '../../../selectors/transac
 import { useGasFeeContext } from '../../../contexts/gasFee';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import ActionableMessage from '../../../components/ui/actionable-message/actionable-message';
-import Button from '../../../components/ui/button';
 import Typography from '../../../components/ui/typography';
 import { TYPOGRAPHY } from '../../../helpers/constants/design-system';
-import { TRANSACTION_TYPES } from '../../../../shared/constants/transaction';
 import ZENDESK_URLS from '../../../helpers/constants/zendesk-url';
 
 const TransactionAlerts = ({
   userAcknowledgedGasMissing,
   setUserAcknowledgedGasMissing,
-  isBuyableChain,
-  nativeCurrency,
-  networkName,
-  showBuyModal,
-  type,
 }) => {
-  const {
-    balanceError,
-    estimateUsed,
-    hasSimulationError,
-    supportsEIP1559V2,
-    isNetworkBusy,
-  } = useGasFeeContext();
+  const { estimateUsed, hasSimulationError, supportsEIP1559V2, isNetworkBusy } =
+    useGasFeeContext();
   const pendingTransactions = useSelector(submittedPendingTransactionsSelector);
   const t = useI18nContext();
 
@@ -89,39 +77,6 @@ const TransactionAlerts = ({
           type="warning"
         />
       )}
-      {balanceError && type === TRANSACTION_TYPES.DEPLOY_CONTRACT ? (
-        <ActionableMessage
-          className="actionable-message--warning"
-          message={
-            isBuyableChain ? (
-              <Typography variant={TYPOGRAPHY.H7} align="left">
-                {t('insufficientCurrencyBuyOrDeposit', [
-                  nativeCurrency,
-                  networkName,
-                  <Button
-                    type="inline"
-                    className="confirm-page-container-content__link"
-                    onClick={showBuyModal}
-                    key={`${nativeCurrency}-buy-button`}
-                  >
-                    {t('buyAsset', [nativeCurrency])}
-                  </Button>,
-                ])}
-              </Typography>
-            ) : (
-              <Typography variant={TYPOGRAPHY.H7} align="left">
-                {t('insufficientCurrencyDeposit', [
-                  nativeCurrency,
-                  networkName,
-                ])}
-              </Typography>
-            )
-          }
-          useIcon
-          iconFillColor="var(--color-error-default)"
-          type="danger"
-        />
-      ) : null}
       {estimateUsed === PRIORITY_LEVELS.LOW && (
         <ActionableMessage
           dataTestId="low-gas-fee-alert"
@@ -164,11 +119,6 @@ const TransactionAlerts = ({
 TransactionAlerts.propTypes = {
   userAcknowledgedGasMissing: PropTypes.bool,
   setUserAcknowledgedGasMissing: PropTypes.func,
-  nativeCurrency: PropTypes.string,
-  networkName: PropTypes.string,
-  showBuyModal: PropTypes.func,
-  type: PropTypes.string,
-  isBuyableChain: PropTypes.bool,
 };
 
 export default TransactionAlerts;

--- a/ui/pages/confirm-transaction-base/transaction-alerts/transaction-alerts.test.js
+++ b/ui/pages/confirm-transaction-base/transaction-alerts/transaction-alerts.test.js
@@ -2,7 +2,6 @@ import React from 'react';
 import { fireEvent } from '@testing-library/react';
 import { renderWithProvider } from '../../../../test/jest';
 import { submittedPendingTransactionsSelector } from '../../../selectors/transactions';
-import { TRANSACTION_TYPES } from '../../../../shared/constants/transaction';
 import { useGasFeeContext } from '../../../contexts/gasFee';
 import configureStore from '../../../store/store';
 import TransactionAlerts from './transaction-alerts';
@@ -139,29 +138,6 @@ describe('TransactionAlerts', () => {
         expect(
           queryByText('You have (0) pending transactions.'),
         ).not.toBeInTheDocument();
-      });
-    });
-
-    describe('if balanceError from useGasFeeContext is true', () => {
-      it('informs the user that they have insufficient funds', () => {
-        const { getByText } = render({
-          useGasFeeContextValue: {
-            supportsEIP1559V2: true,
-            balanceError: true,
-          },
-          componentProps: {
-            nativeCurrency: 'ETH',
-            networkName: 'Goerli',
-            showBuyModal: jest.fn(),
-            chainId: '0x5',
-            type: TRANSACTION_TYPES.DEPLOY_CONTRACT,
-          },
-        });
-        expect(
-          getByText(
-            /You do not have enough ETH in your account to pay for transaction fees on Goerli network./u,
-          ),
-        ).toBeInTheDocument();
       });
     });
 


### PR DESCRIPTION
## Explanation

Added insufficient funds warning on a Send transaction request when user doesn't have funds.


## More Information


* Fixes #16028

## Screenshots/Screencaps

### Before


https://user-images.githubusercontent.com/63151811/196176320-1aa57779-662d-4702-b52b-ff1c8c42a57b.mov


https://user-images.githubusercontent.com/63151811/196659934-7d71c552-9634-4491-93d3-e50ab57a59a3.mov



### After

https://user-images.githubusercontent.com/63151811/196176361-2a39529a-2c5e-47db-8baa-731b692407e9.mov


https://user-images.githubusercontent.com/63151811/196656766-8945873a-27a3-4000-ac28-6bf240e74d5c.mov





## Manual Testing Steps

1. Open https://metamask.github.io/test-dapp/
2. Have no funds in your account
3. Change to a network that supports EIP 1559 (e.g. Rinkeby, Ethereum, Polygon)
4. Click on Send Legacy Transaction
5. Click on Send EIP 1559 Transaction
6. Change to a network that does not support EIP 1559 (e.g. BSC)
7. Click on Send

