### PR TITLE
Emit tx:dropped when pending-tx-tracker.js gets transaction receipt w…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add a way to manually make pending transaction dropped ([#16226](https://github.com/MetaMask/metamask-extension/pull/16226))
 
 ## [10.20.0]
 ### Changed

--- a/app/scripts/controllers/transactions/pending-tx-tracker.js
+++ b/app/scripts/controllers/transactions/pending-tx-tracker.js
@@ -201,6 +201,11 @@ export default class PendingTransactionTracker extends EventEmitter {
         const { baseFeePerGas, timestamp: blockTimestamp } =
           await this.query.getBlockByHash(transactionReceipt?.blockHash, false);
 
+        if (transactionReceipt.status === '0x2') {
+          this.emit('tx:dropped', txId);
+          return;
+        }
+
         this.emit(
           'tx:confirmed',
           txId,


### PR DESCRIPTION
## Explanation

<!--
Thanks for the pull request. Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Below is a template to give you some ideas. Feel free to use your own words!

Currently, ...

This is a problem because ...

In order to solve this problem, this pull request ...
-->

We at Milkomeda created rollups which allow Apps to work in multiple blockchains.
Before we write transaction to a chain, we pretest it and if it fails filter out so that save our and user's resources
and don't post transactions that would fail on the chain. Problem with this is that Metamask can't know that
transaction failed unless it's written on chain.

Solution that I implemented requires our rollup (or any other dApp) to establish a proxy that on
eth_getTransactionReceipt returns a fake receipt (real is impossible to return as transaction was never written on chain)
with blockNumber and blockHash being real values from the latest block and block status with value "0x2" that represents 
status dropped. Now when receipt is asked for transaction that has failed in the app and was never written on the chain, 
Metamask marks transaction dropped.

Why dropped and not failed?
- Transaction never reached the chain
- Nonce for sending next Transaction trough MetaMask won't go up a number and then result in nonce too high error but will stay the same

## More Information

<!--
Are there any issues, Slack conversations, Zendesk issues, user stories, etc. reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

SEE #16251 

## Manual Testing Steps
There is unittest written for this. Unfortunately, as our rollup is not open source identical steps to reproduce can't be made.
What can be done is set up proxy for returning fake receipt for failed transactions and some localhost evm node that filters out transaction if it has eg. too high nonce. 
Then send transaction that would result in nonce too high error.
Eg. Start nonce is 0. Trough MetaMask send transaction with nonce 5. 
Transaction should be filtered out in the evm node and MetaMask should mark it as dropped.
<!--
How should reviewers and QA manually test your changes? For instance:

- Go to this screen
- Do this
- Then do this
-->

## Pre-Merge Checklist

- [ ] PR template is filled out
- [ ] **IF** this PR fixes a bug, a test that _would have_ caught the bug has been added
- [ ] PR is linked to the appropriate GitHub issue
- [ ] PR has been added to the appropriate release Milestone

### + If there are functional changes:

- [ ] Manual testing complete & passed
- [ ] "Extension QA Board" label has been applied
