### PR TITLE
disabled save button on add contact form if input fields are empty

### DIFF
--- a/ui/pages/settings/contact-list-tab/add-contact/add-contact.component.js
+++ b/ui/pages/settings/contact-list-tab/add-contact/add-contact.component.js
@@ -142,7 +142,7 @@ export default class AddContact extends PureComponent {
         </div>
         <PageContainerFooter
           cancelText={this.context.t('cancel')}
-          disabled={Boolean(this.state.error)}
+          disabled={Boolean(this.state.error || !this.state.ethAddress)}
           onSubmit={async () => {
             await addToAddressBook(
               ensResolution || this.state.ethAddress,


### PR DESCRIPTION
## Explanation
Disabled save button on add contact form if input field(address) are empty.

## More Information

* Fixes #16015

## Screenshots/Screencaps

### Before


https://user-images.githubusercontent.com/63151811/196678907-7b3e8bb5-fee0-4855-9491-8a64ebacaba0.mov


### After

https://user-images.githubusercontent.com/63151811/196678850-8055d05a-a287-4f37-93e1-97e3ca76ffd8.mov



## Manual Testing Steps

1. Unlock MM
2. Go to Settings -> Contacts -> Add contact
3. Don't populate address field and try click Save
