### PR TITLE
[YarnV3]: Restore symbol observable resolution to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -186,7 +186,8 @@
     "luxon@^3.0.1": "patch:luxon@npm%3A3.1.0#./.yarn/patches/luxon-npm-3.1.0-16e2508500.patch",
     "improved-yarn-audit@^3.0.0": "patch:improved-yarn-audit@npm%3A3.0.0#./.yarn/patches/improved-yarn-audit-npm-3.0.0-3e37ee431a.patch",
     "lockfile-lint-api@^5.4.6": "patch:lockfile-lint-api@npm%3A5.4.6#./.yarn/patches/lockfile-lint-api-npm-5.4.6-dc86b73900.patch",
-    "@lavamoat/snow@^1.2.1": "patch:@lavamoat/snow@npm%3A1.2.1#./.yarn/patches/@lavamoat-snow-npm-1.2.1-6cb0e8f916.patch"
+    "@lavamoat/snow@^1.2.1": "patch:@lavamoat/snow@npm%3A1.2.1#./.yarn/patches/@lavamoat-snow-npm-1.2.1-6cb0e8f916.patch",
+    "symbol-observable": "^2.0.3"
   },
   "dependencies": {
     "@babel/runtime": "^7.5.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -31602,10 +31602,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"symbol-observable@npm:^1.0.4, symbol-observable@npm:^1.2.0":
-  version: 1.2.0
-  resolution: "symbol-observable@npm:1.2.0"
-  checksum: 48ffbc22e3d75f9853b3ff2ae94a44d84f386415110aea5effc24d84c502e03a4a6b7a8f75ebaf7b585780bda34eb5d6da3121f826a6f93398429d30032971b6
+"symbol-observable@npm:^2.0.3":
+  version: 2.0.3
+  resolution: "symbol-observable@npm:2.0.3"
+  checksum: 533dcf7a7925bada60dbaa06d678e7c4966dbf0959ccba7f60c22b0494ba5d9160d6a66f2951d45a80bf20e655a89f8b91c5f0458dd12faef28716b54f91f49c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Explanation
Running yarn install will remove resolutions that are no longer necessary, and is mostly accurate. Unfortunately this resolution was removed erroneously and the result was that dev builds were not working, at least on my machine. Restoring the resolution restored dev build functionality. 

## Pre-Merge Checklist

- [x] PR template is filled out
- [ ] **IF** this PR fixes a bug, a test that _would have_ caught the bug has been added
- [ ] PR is linked to the appropriate GitHub issue
- [ ] PR has been added to the appropriate release Milestone
