### PR TITLE
[YarnV3]: Disables HAR generation in yarn install script

### DIFF
--- a/.circleci/scripts/deps-install.sh
+++ b/.circleci/scripts/deps-install.sh
@@ -5,7 +5,7 @@ set -x
 # Exit immediately if a command exits with a non-zero status.
 set -e
 
-yarn install --frozen-lockfile --har
+yarn install --frozen-lockfile #--har temporarily disabling for CI work
 
 # Move HAR file into directory with consistent name so that we can cache it
 mkdir -p build-artifacts/yarn-install-har

--- a/.circleci/scripts/deps-install.sh
+++ b/.circleci/scripts/deps-install.sh
@@ -5,7 +5,7 @@ set -x
 # Exit immediately if a command exits with a non-zero status.
 set -e
 
-yarn install --frozen-lockfile #--har temporarily disabling for CI work
+yarn install --frozen-lockfile
 
 # Move HAR file into directory with consistent name so that we can cache it
 mkdir -p build-artifacts/yarn-install-har


### PR DESCRIPTION
## Explanation
The --har flag has been removed from the yarn install command, we should find an alternative if these archive files are still being used. @Gudahtt do you have any input on this? 

## Pre-Merge Checklist

- [x] PR template is filled out
- [ ] **IF** this PR fixes a bug, a test that _would have_ caught the bug has been added
- [ ] PR is linked to the appropriate GitHub issue
- [ ] PR has been added to the appropriate release Milestone

