### PR TITLE
[YarnV3]: patch improved-yarn-audit for use in yarn3

### DIFF
--- a/.circleci/scripts/yarn-audit.sh
+++ b/.circleci/scripts/yarn-audit.sh
@@ -16,7 +16,7 @@ audit_status="$?"
 
 if [[ "$audit_status" != 0 ]]
 then
-    count="$(yarn npm audit --level moderate --groups dependencies --json | tail -1 | jq '.data.vulnerabilities.moderate + .data.vulnerabilities.high + .data.vulnerabilities.critical')"
+    count="$(yarn npm audit --severity moderate --environment production --json | tail -1 | jq '.data.vulnerabilities.moderate + .data.vulnerabilities.high + .data.vulnerabilities.critical')"
     printf "Audit shows %s moderate or high severity advisories _in the production dependencies_\n" "$count"
     exit 1
 else

--- a/.circleci/scripts/yarn-audit.sh
+++ b/.circleci/scripts/yarn-audit.sh
@@ -16,7 +16,7 @@ audit_status="$?"
 
 if [[ "$audit_status" != 0 ]]
 then
-    count="$(yarn audit --level moderate --groups dependencies --json | tail -1 | jq '.data.vulnerabilities.moderate + .data.vulnerabilities.high + .data.vulnerabilities.critical')"
+    count="$(yarn npm audit --level moderate --groups dependencies --json | tail -1 | jq '.data.vulnerabilities.moderate + .data.vulnerabilities.high + .data.vulnerabilities.critical')"
     printf "Audit shows %s moderate or high severity advisories _in the production dependencies_\n" "$count"
     exit 1
 else

--- a/.iyarc
+++ b/.iyarc
@@ -1,2 +1,3 @@
 # improved-yarn-audit advisory exclusions
 GHSA-257v-vj4p-3w2h
+GHSA-6fc8-4gx4-v693

--- a/.yarn/patches/improved-yarn-audit-npm-3.0.0-3e37ee431a.patch
+++ b/.yarn/patches/improved-yarn-audit-npm-3.0.0-3e37ee431a.patch
@@ -1,0 +1,65 @@
+diff --git a/bin/improved-yarn-audit b/bin/improved-yarn-audit
+index 52df548151aa28289565e3335b2cd7a92fa38325..7e058df6a4a159596df72c9475a36b747580cd98 100755
+--- a/bin/improved-yarn-audit
++++ b/bin/improved-yarn-audit
+@@ -15,6 +15,7 @@ const { tmpdir } = require("os")
+ const path = require("path")
+ const { env, exit, platform } = require("process")
+ const { createInterface } = require("readline")
++const { Stream } = require("stream")
+ 
+ const GITHUB_ADVISORY_CODE = "GHSA"
+ 
+@@ -250,7 +251,15 @@ async function iterateOverAuditResults(action) {
+   const auditResultsFileStream = getAuditResultsFileStream("r")
+   const iterator = createInterface(auditResultsFileStream)
+ 
+-  iterator.on("line", action)
++  iterator.on("line", async (result) => {
++    const parsed = parseAuditJson(result);
++    const advisories = Stream.Readable.from(
++      Object.values(parsed.advisories).map(advisory => JSON.stringify(advisory))
++    );
++    for await (const data of advisories) {
++      action(data);
++    }
++  });
+ 
+   await new Promise((resolve) => iterator.on("close", resolve))
+ 
+@@ -305,10 +314,10 @@ async function streamYarnAuditOutput(auditParams, auditResultsFileStream) {
+ }
+ 
+ async function invokeYarnAudit() {
+-  const auditParams = ["audit", "--json", `--level=${minSeverityName}`]
++  const auditParams = ["npm", "audit", "--recursive", "--json", `--severity=${minSeverityName}`]
+ 
+   if (ignoreDevDependencies) {
+-    auditParams.push("--groups=dependencies")
++    auditParams.push("--environment=production")
+   }
+ 
+   cleanupAuditResultsFile()
+@@ -420,17 +429,17 @@ async function runAuditReport() {
+   let devDependencyAdvisories = []
+   let devDependencyAdvisoryIds = []
+ 
+-  await iterateOverAuditResults((resultJson) => {
+-    const potentialResult = parseAuditJson(resultJson)
++  await iterateOverAuditResults((resultJsonString) => {
++    const potentialResult = parseAuditJson(resultJsonString);
+ 
+     if (
+-      typeof potentialResult.type !== "string" ||
+-      potentialResult.type !== "auditAdvisory"
++      typeof potentialResult.github_advisory_id !== "string"
+     ) {
+       return
+     }
+ 
+-    const result = potentialResult.data.advisory
++
++    const result = potentialResult;
+ 
+     allAdvisories.push(result)
+ 

--- a/package.json
+++ b/package.json
@@ -183,7 +183,8 @@
     "squirrelly@^8.0.8": "patch:squirrelly@npm%3A8.0.8#./.yarn/patches/squirrelly-npm-8.0.8-1d17420d8d.patch",
     "stylelint@^13.6.1": "patch:stylelint@npm%3A13.6.1#./.yarn/patches/stylelint-npm-13.6.1-47aaddf62b.patch",
     "luxon@^3.1.0": "patch:luxon@npm%3A3.1.0#./.yarn/patches/luxon-npm-3.1.0-16e2508500.patch",
-    "luxon@^3.0.1": "patch:luxon@npm%3A3.1.0#./.yarn/patches/luxon-npm-3.1.0-16e2508500.patch"
+    "luxon@^3.0.1": "patch:luxon@npm%3A3.1.0#./.yarn/patches/luxon-npm-3.1.0-16e2508500.patch",
+    "improved-yarn-audit@^3.0.0": "patch:improved-yarn-audit@npm%3A3.0.0#./.yarn/patches/improved-yarn-audit-npm-3.0.0-3e37ee431a.patch"
   },
   "dependencies": {
     "@babel/runtime": "^7.5.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -18843,12 +18843,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"improved-yarn-audit@npm:^3.0.0":
+"improved-yarn-audit@npm:3.0.0":
   version: 3.0.0
   resolution: "improved-yarn-audit@npm:3.0.0"
   bin:
     improved-yarn-audit: bin/improved-yarn-audit
   checksum: 5ca18647f138f435203b88b0f57334e088cc64567d51f9eff069026fcb4aebd0486e96d59f44ed91ed9f2df9f8b6cce683adba5e9e734bc37f11b9c11b8b64f2
+  languageName: node
+  linkType: hard
+
+"improved-yarn-audit@patch:improved-yarn-audit@npm%3A3.0.0#./.yarn/patches/improved-yarn-audit-npm-3.0.0-3e37ee431a.patch::locator=metamask-crx%40workspace%3A.":
+  version: 3.0.0
+  resolution: "improved-yarn-audit@patch:improved-yarn-audit@npm%3A3.0.0#./.yarn/patches/improved-yarn-audit-npm-3.0.0-3e37ee431a.patch::version=3.0.0&hash=1e7141&locator=metamask-crx%40workspace%3A."
+  bin:
+    improved-yarn-audit: bin/improved-yarn-audit
+  checksum: 688411fc37bdb417a23fb203968ca3db8f68bbffd8af4f3817c963d256bfb1675bfbb4d389bf4410a57e95dd55c98b7b6767c37a046c80b0c69b7dad279db915
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Explanation
improved-yarn-audit does not work with yarn 3 yet, this patch allows it to work. All it does is modify params and updates how dependencies are checked to match yarn3 requirements. 

## Manual testing steps
- add a known failing dependency
- run the .circleci audit script
- See that it errors out.
- Do the same by just removing one of the .iyarc entries, see that it fails

## Pre-Merge Checklist

- [x] PR template is filled out
- [ ] **IF** this PR fixes a bug, a test that _would have_ caught the bug has been added
- [ ] PR is linked to the appropriate GitHub issue
- [ ] PR has been added to the appropriate release Milestone

### + If there are functional changes:

- [ ] Manual testing complete & passed
- [ ] "Extension QA Board" label has been applied
