### PR TITLE
WIP: Pending transactions dropped timeout

### DIFF
--- a/app/scripts/controllers/transactions/pending-tx-tracker.js
+++ b/app/scripts/controllers/transactions/pending-tx-tracker.js
@@ -238,7 +238,7 @@ export default class PendingTransactionTracker extends EventEmitter {
     } = txMeta;
     const networkNextNonce = await this.query.getTransactionCount(from);
 
-    if (parseInt(nonce, 16) >= networkNextNonce.toNumber()) {
+    if (parseInt(nonce, 16) > networkNextNonce.toNumber()) {
       return false;
     }
 

--- a/app/scripts/controllers/transactions/pending-tx-tracker.test.js
+++ b/app/scripts/controllers/transactions/pending-tx-tracker.test.js
@@ -759,7 +759,7 @@ describe('PendingTransactionTracker', function () {
     });
 
     it("should emit 'tx:dropped' with the txMetas id only after the fourth call", async function () {
-      const nonceBN = new BN(2);
+      const nonceBN = new BN(1);
       const txMeta = {
         id: 1,
         hash: '0x0593ee121b92e10d63150ad08b4b8f9c7857d1bd160195ee648fb9a0f8d00eeb',


### PR DESCRIPTION
## Explanation

<!--
Thanks for the pull request. Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Below is a template to give you some ideas. Feel free to use your own words!

Currently, ...

This is a problem because ...

In order to solve this problem, this pull request ...
-->

Pending transactions are never dropped. When sending a transaction to a rollup service or an uncompetitive transaction to a congested network, the transaction never becomes dropped. I saw the logic behind it in app/scripts/controllers/transactions/pending-tx-tracker.js that should make the transaction drop if it's waiting for more than 3 blocks, but that does not happen.

Now, the transaction won't enter dropped timeout unless the transaction nonce is smaller than the next network nonce. So if the user does not send a transaction after a pending transaction that will raise the next network nonce up, the transaction will forever be pending.

This fix makes the transaction enter dropped timeout as soon as the next network nonce is equal to or smaller than the transaction nonce. With this, the pending transaction enters dropped timeout immediately and is dropped if not included in the chain after three blocks.

## More Information

<!--
Are there any issues, Slack conversations, Zendesk issues, user stories, etc. reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

SEE #16251 

## Manual Testing Steps

<!--
How should reviewers and QA manually test your changes? For instance:

- Go to this screen
- Do this
- Then do this
-->

FIRST CASE

1. Send the super uncompetitive transaction to a super congested network.

SECOND CASE
Send the transaction to some rollup service (eg. Milkomeda A1) that will be filtered out and never submitted to the block.

1. Let's say we have an account balance of 20ETH
2. Send transaction with a value of 3 ETH
3. Before the first transaction is processed, quickly send a transaction of 19 ETH.
4. Second transaction will be filtered out due to insufficient balance and will never reach the chain
5. Second transaction will forever stay pending if no successful transaction is sent after it.

## Pre-Merge Checklist

- [x] PR template is filled out
- [x] **IF** this PR fixes a bug, a test that _would have_ caught the bug has been added
- [x] PR is linked to the appropriate GitHub issue
- [ ] PR has been added to the appropriate release Milestone

### + If there are functional changes:

- [x] Manual testing complete & passed
- [ ] "Extension QA Board" label has been applied
