### PR TITLE
[MV3] Fix e2e `encrypt-decrypt` test for MV3 test build

### DIFF
--- a/test/e2e/tests/encrypt-decrypt.spec.js
+++ b/test/e2e/tests/encrypt-decrypt.spec.js
@@ -71,10 +71,11 @@ describe('Encrypt Decrypt', function () {
 
         // Verify message in MetaMask Notification
         await driver.clickElement({ text: 'Decrypt message', tag: 'div' });
-        const notificationMessage = await driver.findElement(
-          '.request-decrypt-message__message-text',
-        );
-        assert.equal(await notificationMessage.getText(), message);
+        const notificationMessage = await driver.isElementPresent({
+          text: message,
+          tag: 'div',
+        });
+        assert.equal(await notificationMessage, true);
         await driver.clickElement({ text: 'Decrypt', tag: 'button' });
 
         // Verify message in Test Dapp

--- a/test/e2e/tests/encrypt-decrypt.spec.js
+++ b/test/e2e/tests/encrypt-decrypt.spec.js
@@ -75,7 +75,7 @@ describe('Encrypt Decrypt', function () {
           text: message,
           tag: 'div',
         });
-        assert.equal(await notificationMessage, true);
+        assert.equal(notificationMessage, true);
         await driver.clickElement({ text: 'Decrypt', tag: 'button' });
 
         // Verify message in Test Dapp


### PR DESCRIPTION
## Explanation
On the mv3 test build, the e2e test for `encrypt-decrypt` is failing due to a tiny delay when we render the decrypted text inside MetaMask popup.
This fixes the issue by grabbing the element by its content. This way we make sure the element is there when we make the assertion.

**Note**: in MV2 this error does not surface as it's slightly faster on rendering the decrypted message. Though tiny delay is not visible on the naked eye, we'll introduce performance metrics for calculating these delays introduced on the MV3 build.

## More Information
* Fixes https://github.com/MetaMask/metamask-extension/issues/16210
* Relates to https://github.com/MetaMask/metamask-extension/compare/e2e-mv3-incremental?expand=1

## Screenshots/Screencaps
### Before
![image](https://user-images.githubusercontent.com/54408225/197730342-275694f8-cb5d-42b2-835f-bf59e6b7538f.png)



### After
![image](https://user-images.githubusercontent.com/54408225/197730281-9ef6002a-2696-48e7-acc5-6ca4c10164a0.png)



## Manual Testing Steps
1. Build the mv3 test `yarn build:test:mv3`
2. Run the failing test and check it's working `yarn test:e2e:single test/e2e/tests/encrypt-decrypt.spec.js --browser=chrome`

## Pre-Merge Checklist

- [X] PR template is filled out
- [ ] **IF** this PR fixes a bug, a test that _would have_ caught the bug has been added
- [X] PR is linked to the appropriate GitHub issue
- [ ] PR has been added to the appropriate release Milestone

### + If there are functional changes:

- [ ] Manual testing complete & passed
- [X] "Extension QA Board" label has been applied
