### PR TITLE
[MV3] Fix e2e incremental security test for MV3 test build

### DIFF
--- a/test/e2e/tests/incremental-security.spec.js
+++ b/test/e2e/tests/incremental-security.spec.js
@@ -130,6 +130,7 @@ describe('Incremental Security', function () {
         const revealedSeedPhrase = await driver.findElement(
           '.reveal-seed-phrase__secret-words',
         );
+        await driver.waitForNonEmptyElement(revealedSeedPhrase);
         const seedPhrase = await revealedSeedPhrase.getText();
         assert.equal(seedPhrase.split(' ').length, 12);
 

--- a/test/e2e/webdriver/driver.js
+++ b/test/e2e/webdriver/driver.js
@@ -161,6 +161,14 @@ class Driver {
     return wrapElementWithAPI(element, this);
   }
 
+  async waitForNonEmptyElement(element) {
+    await this.driver.wait(async () => {
+      const elemText = await element.getText();
+      const empty = elemText === '';
+      return !empty;
+    }, this.timeout);
+  }
+
   async quit() {
     await this.driver.quit();
   }


### PR DESCRIPTION
## Explanation
On the mv3 test build, the e2e test for incremental security is failing due to a tiny delay when we render the seed phrase inside the div box.
This fixes the issue by waiting until the element is not empty. This way we make sure the seed phrase is rendered when we make the assertion.

Note: in MV2 this error does not surface as it's slightly faster on rendering the seed phrase. We'll introduce performance metrics for calculating these delays introduced on the MV3 build.

## More Information
* Fixes https://github.com/MetaMask/metamask-extension/issues/16212
* Relates to https://github.com/MetaMask/metamask-extension/pull/16264

## Screenshots/Screencaps
### Before
![image](https://user-images.githubusercontent.com/54408225/197750824-4626ef5a-9cd7-491a-a256-666fc01b92a4.png)


### After
![image](https://user-images.githubusercontent.com/54408225/197750778-9d250fb4-1707-45bf-bcf9-a3bb53d2afe9.png)


## Manual Testing Steps
1. Build the mv3 test yarn build:test:mv3
2. Run the failing test and check it's working `yarn test:e2e:single test/e2e/tests/incremental-security.spec.js --browser=chrome`


## Pre-Merge Checklist

- [X] PR template is filled out
- [ ] **IF** this PR fixes a bug, a test that _would have_ caught the bug has been added
- [X] PR is linked to the appropriate GitHub issue
- [ ] PR has been added to the appropriate release Milestone

### + If there are functional changes:

- [ ] Manual testing complete & passed
- [ ] "Extension QA Board" label has been applied
