### PR TITLE
[e2e] Fix Dapp interactions flaky test on chrome

### DIFF
--- a/test/e2e/tests/dapp-interactions.spec.js
+++ b/test/e2e/tests/dapp-interactions.spec.js
@@ -80,7 +80,7 @@ describe('Dapp interactions', function () {
 
         // Connect to Dapp0
         await connectDappWithExtensionPopup(driver, 0);
-        windowHandles = await driver.getAllWindowHandles();      
+        windowHandles = await driver.getAllWindowHandles();
         extension = windowHandles[0];
 
         // Lock Account

--- a/test/e2e/tests/dapp-interactions.spec.js
+++ b/test/e2e/tests/dapp-interactions.spec.js
@@ -80,7 +80,7 @@ describe('Dapp interactions', function () {
 
         // Connect to Dapp0
         await connectDappWithExtensionPopup(driver, 0);
-        windowHandles = await driver.getAllWindowHandles();
+        windowHandles = await driver.getAllWindowHandles();      
         extension = windowHandles[0];
 
         // Lock Account
@@ -91,7 +91,7 @@ describe('Dapp interactions', function () {
         // Connect to Dapp1
         await driver.openNewPage('http://127.0.0.1:8081/');
         await driver.clickElement({ text: 'Connect', tag: 'button' });
-
+        await driver.waitUntilXWindowHandles(4);
         windowHandles = await driver.getAllWindowHandles();
 
         popup = await driver.switchToWindowWithTitle(


### PR DESCRIPTION
## Explanation
Dapp interactions testcase is flaky and failing more often recently on chrome, due to trying to switch to MM Notification popup before being displayed.

This PR fixes it by waiting until we have 4 windows on the `getAllWindowsHandles`.

## Screenshots/Screencaps

<!-- If you're making a change to the UI, make sure to capture a screenshot or a short video showing off your work! -->

### Before
See failures, as only 3 windows were present at that time (added logs for clarity)
![image](https://user-images.githubusercontent.com/54408225/198024160-979f078a-20a8-4476-8cdd-3215d5cd88e5.png)


### After
See successful test, now waits for 4 windows.
![image](https://user-images.githubusercontent.com/54408225/198023933-5599c0e4-5d81-4f08-8d51-990af1782723.png)


## Manual Testing Steps
1. Build test `yarn build:test`
2. Run the flaky test on chrome `yarn test:e2e:single test/e2e/tests/dapp-interactions.spec.js --browser=chrome`

## Pre-Merge Checklist

- [X] PR template is filled out
- [ ] **IF** this PR fixes a bug, a test that _would have_ caught the bug has been added
- [ ] PR is linked to the appropriate GitHub issue
- [ ] PR has been added to the appropriate release Milestone

### + If there are functional changes:
- [ ] Manual testing complete & passed
- [X] "Extension QA Board" label has been applied
