### PR TITLE
[e2e] Add parallelism on e2e test run for Chrome and Firefox

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -516,6 +516,7 @@ jobs:
 
   test-e2e-chrome:
     executor: node-browsers
+    parallelism: 10
     steps:
       - checkout
       - run:
@@ -534,7 +535,7 @@ jobs:
           command: |
             if .circleci/scripts/test-run-e2e.sh
             then
-              yarn test:e2e:chrome --retries 2
+              yarn test:e2e:chrome --retries 2 | circleci tests split --split-by=timings
             fi
           no_output_timeout: 20m
       - store_artifacts:
@@ -624,6 +625,7 @@ jobs:
 
   test-e2e-firefox:
     executor: node-browsers-medium-plus
+    parallelism: 10
     steps:
       - checkout
       - run:
@@ -642,7 +644,7 @@ jobs:
           command: |
             if .circleci/scripts/test-run-e2e.sh
             then
-              yarn test:e2e:firefox --retries 2
+              yarn test:e2e:firefox --retries 2 | circleci tests split --split-by=timings
             fi
           no_output_timeout: 20m
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -516,7 +516,7 @@ jobs:
 
   test-e2e-chrome:
     executor: node-browsers
-    parallelism: 5
+    parallelism: 3
     steps:
       - checkout
       - run:
@@ -625,7 +625,7 @@ jobs:
 
   test-e2e-firefox:
     executor: node-browsers-medium-plus
-    parallelism: 5
+    parallelism: 3
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -516,7 +516,7 @@ jobs:
 
   test-e2e-chrome:
     executor: node-browsers
-    parallelism: 10
+    parallelism: 5
     steps:
       - checkout
       - run:
@@ -625,7 +625,7 @@ jobs:
 
   test-e2e-firefox:
     executor: node-browsers-medium-plus
-    parallelism: 10
+    parallelism: 5
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -516,7 +516,7 @@ jobs:
 
   test-e2e-chrome:
     executor: node-browsers
-    parallelism: 3
+    parallelism: 2
     steps:
       - checkout
       - run:
@@ -571,6 +571,7 @@ jobs:
 
   test-e2e-firefox-snaps:
     executor: node-browsers
+    parallelism: 2
     steps:
       - checkout
       - run:
@@ -589,7 +590,7 @@ jobs:
           command: |
             if .circleci/scripts/test-run-e2e.sh
             then
-              yarn test:e2e:firefox:snaps --retries 2
+              yarn test:e2e:firefox:snaps --retries 2 | circleci tests split --split-by=timings
             fi
           no_output_timeout: 20m
       - store_artifacts:
@@ -598,6 +599,7 @@ jobs:
 
   test-e2e-chrome-snaps:
     executor: node-browsers
+    parallelism: 2
     steps:
       - checkout
       - run:
@@ -616,7 +618,7 @@ jobs:
           command: |
             if .circleci/scripts/test-run-e2e.sh
             then
-              yarn test:e2e:chrome:snaps --retries 2
+              yarn test:e2e:chrome:snaps --retries 2 | circleci tests split --split-by=timings
             fi
           no_output_timeout: 20m
       - store_artifacts:
@@ -625,7 +627,7 @@ jobs:
 
   test-e2e-firefox:
     executor: node-browsers-medium-plus
-    parallelism: 3
+    parallelism: 2
     steps:
       - checkout
       - run:


### PR DESCRIPTION
## Explanation
Running the e2e tests sequentially results in having long jobs, with approximately this numbers:
- **e2e chrome tests**: ~24min
- **e2e firefox tests**: ~30-35min

In this PR, parallelism is added so the e2e test time is reduced to:
- **e2e chrome tests**: min
- **e2e firefox tests**: min

The chosen approach is timing-based test splitting, and the reason are below explained (from circle ci):

- Using timing-based test splitting takes the timing data from the previous test run to split a test suite as evenly as possible over a specified number of test environments running in parallel, to give the lowest possible test time for the compute power in use.
- Using timings-based test splitting gives the most accurate split, and is guaranteed to optimize with each test suite run. The most recent timings data is always used to define where splits are made.


## More Information
- [Circle ci documentation](https://circleci.com/docs/parallelism-faster-jobs/)

## Screenshots/Screencaps

### Before
All tests in 1 bucket:
![image](https://user-images.githubusercontent.com/54408225/198566126-895b6909-22c5-4bfc-83b3-ec4c17f3ea7f.png)


### After
10 buckets:
![image](https://user-images.githubusercontent.com/54408225/198565274-2898f8c7-78be-4951-9e6b-4cac16d22a26.png)


## Manual Testing Steps

<!--
How should reviewers and QA manually test your changes? For instance:

- Go to this screen
- Do this
- Then do this
-->

## Pre-Merge Checklist

- [ ] PR template is filled out
- [ ] **IF** this PR fixes a bug, a test that _would have_ caught the bug has been added
- [ ] PR is linked to the appropriate GitHub issue
- [ ] PR has been added to the appropriate release Milestone

### + If there are functional changes:

- [ ] Manual testing complete & passed
- [ ] "Extension QA Board" label has been applied
