### PR TITLE
build: run scss pipelines synchronously

### DIFF
--- a/development/build/styles.js
+++ b/development/build/styles.js
@@ -58,10 +58,8 @@ function createStyleTasks({ livereload }) {
     };
 
     async function buildScss() {
-      await Promise.all([
-        buildScssPipeline(src, dest, devMode, false),
-        buildScssPipeline(src, dest, devMode, true),
-      ]);
+      await buildScssPipeline(src, dest, devMode, false);
+      await buildScssPipeline(src, dest, devMode, true);
     }
   }
 }


### PR DESCRIPTION
This resolves a race condition in live-reload when editing scss files.

## Explanation

Steps to reproduce issue:

1. Clone `metamask-extension`
2. `yarn setup`
3. `yarn start`, wait for initial build to complete
4. Edit a scss file
5. process exits with `ENOENT` when operating on a target file

## Pre-Merge Checklist

- [x] PR template is filled out
- [ ] **IF** this PR fixes a bug, a test that _would have_ caught the bug has been added
- [ ] PR is linked to the appropriate GitHub issue
- [ ] PR has been added to the appropriate release Milestone

### + If there are functional changes:

- [x] Manual testing complete & passed
- [ ] "Extension QA Board" label has been applied
