### PR TITLE
Exclude E2E tests for swaps until they are stabilised

### DIFF
--- a/test/e2e/run-all.js
+++ b/test/e2e/run-all.js
@@ -51,7 +51,8 @@ async function main() {
   if (!snaps) {
     testPaths = [
       ...testPaths,
-      ...(await getTestPathsForTestDir(path.join(__dirname, 'swaps'))),
+      // TODO: Enable the next line once the Swaps E2E tests are stable.
+      // ...(await getTestPathsForTestDir(path.join(__dirname, 'swaps'))),
       path.join(__dirname, 'metamask-ui.spec.js'),
     ];
   }


### PR DESCRIPTION
## Explanation
Temporarily exclude E2E tests for Swaps until they are stabilised, which will likely happen next week.

Related PR: https://github.com/MetaMask/metamask-extension/pull/16202