### PR TITLE
ensure that we default users with browser language code 'zh' to the supported 'zh_CN' language code

### DIFF
--- a/app/scripts/lib/get-first-preferred-lang-code.js
+++ b/app/scripts/lib/get-first-preferred-lang-code.js
@@ -1,8 +1,10 @@
 import browser from 'webextension-polyfill';
 import allLocales from '../../_locales/index.json';
 
+// ensure that we default users with browser language code 'zh' to the supported 'zh_CN' language code
+const existingLocaleCodes = { zh: 'zh_CN' };
+
 // mapping some browsers return hyphen instead underscore in locale codes (e.g. zh_TW -> zh-tw)
-const existingLocaleCodes = {};
 allLocales.forEach((locale) => {
   if (locale && locale.code) {
     existingLocaleCodes[locale.code.toLowerCase().replace('_', '-')] =


### PR DESCRIPTION
## Explanation

Add logic to the function we use to determine a users preferred language code such that we default users with language codes set as the generic (and unsupported) `zh` language code to use the supported zh_CN language code.

## Pre-Merge Checklist

- [ ] PR template is filled out
- [ ] **IF** this PR fixes a bug, a test that _would have_ caught the bug has been added
- [ ] PR is linked to the appropriate GitHub issue
- [ ] PR has been added to the appropriate release Milestone

### + If there are functional changes:

- [ ] Manual testing complete & passed
- [ ] "Extension QA Board" label has been applied
