### PR TITLE
Fix "Learn more" link on Connected Account notification

### DIFF
--- a/ui/pages/home/home.component.js
+++ b/ui/pages/home/home.component.js
@@ -58,9 +58,6 @@ import BetaHomeFooter from './beta/beta-home-footer.component';
 import FlaskHomeFooter from './flask/flask-home-footer.component';
 ///: END:ONLY_INCLUDE_IN
 
-const LEARN_MORE_URL =
-  'https://metamask.zendesk.com/hc/en-us/articles/360045129011-Intro-to-MetaMask-v8-extension';
-
 function shouldCloseNotificationPopup({
   isNotification,
   totalUnapprovedCount,
@@ -526,8 +523,12 @@ export default class Home extends PureComponent {
         }}
         footer={
           <>
-            <a href={LEARN_MORE_URL} target="_blank" rel="noopener noreferrer">
-              {t('learnMore')}
+            <a
+              href={ZENDESK_URLS.USER_GUIDE_DAPPS}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              {t('learnMoreUpperCase')}
             </a>
             <Button
               type="primary"


### PR DESCRIPTION
Fixes: https://github.com/MetaMask/metamask-extension/issues/16276

Also updates the casing of the "Learn more" text

## Manual Testing Steps

1. Unlock MM
2. Connect to Test Dapp
3. Open MM popup
4. Click "Learn more" from the Connected account notification
5. Ensure the user navigates to https://metamask.zendesk.com/hc/en-us/articles/4405506066331-User-guide-Dapps

## Pre-Merge Checklist

- [X] PR template is filled out
- [ ] **IF** this PR fixes a bug, a test that _would have_ caught the bug has been added
- [X] PR is linked to the appropriate GitHub issue
- [ ] PR has been added to the appropriate release Milestone

### + If there are functional changes:

- [ ] Manual testing complete & passed
- [ ] "Extension QA Board" label has been applied
