### PR TITLE
Fix Secret Recovery Phrase video clipping issue for smaller viewports

### DIFF
--- a/ui/pages/first-time-flow/seed-phrase/seed-phrase-intro/index.scss
+++ b/ui/pages/first-time-flow/seed-phrase/seed-phrase-intro/index.scss
@@ -27,10 +27,7 @@
 
   video {
     border-radius: 8px;
-
-    @include screen-md-max {
-      width: 95%;
-    }
+    width: calc(100% - 16px);
   }
 
   &__copy {


### PR DESCRIPTION
Fixes: https://github.com/MetaMask/metamask-extension/issues/16206

## Manual Testing Steps

1. Load MM for the first time
2. Click Create Wallet
3. Enter Password and go to Next screen
4. Click Backup later
5. Resize screen to smaller viewports and ensure the video and the right hand text content don't clip in to eachother

## Pre-Merge Checklist

- [X] PR template is filled out
- [ ] **IF** this PR fixes a bug, a test that _would have_ caught the bug has been added
- [X] PR is linked to the appropriate GitHub issue
- [ ] PR has been added to the appropriate release Milestone

### + If there are functional changes:

- [ ] Manual testing complete & passed
- [ ] "Extension QA Board" label has been applied
