### PR TITLE
Fix recent recipient order

### DIFF
--- a/ui/pages/confirm-transaction-base/confirm-transaction-base.component.js
+++ b/ui/pages/confirm-transaction-base/confirm-transaction-base.component.js
@@ -93,6 +93,7 @@ export default class ConfirmTransactionBase extends Component {
     sendTransaction: PropTypes.func,
     showTransactionConfirmedModal: PropTypes.func,
     showRejectTransactionsConfirmationModal: PropTypes.func,
+    toAccounts: PropTypes.object,
     toAddress: PropTypes.string,
     tokenData: PropTypes.object,
     tokenProps: PropTypes.object,
@@ -103,6 +104,7 @@ export default class ConfirmTransactionBase extends Component {
     txData: PropTypes.object,
     unapprovedTxCount: PropTypes.number,
     customGas: PropTypes.object,
+    addToAddressBookIfNew: PropTypes.func,
     // Component props
     actionKey: PropTypes.string,
     contentComponent: PropTypes.node,
@@ -803,10 +805,16 @@ export default class ConfirmTransactionBase extends Component {
       maxPriorityFeePerGas,
       baseFeePerGas,
       methodData,
+      addToAddressBookIfNew,
+      toAccounts,
+      toAddress,
     } = this.props;
     const { submitting } = this.state;
     const { name } = methodData;
 
+    if (txData.type === 'simpleSend') {
+      addToAddressBookIfNew(toAddress, toAccounts);
+    }
     if (submitting) {
       return;
     }

--- a/ui/pages/confirm-transaction-base/confirm-transaction-base.component.js
+++ b/ui/pages/confirm-transaction-base/confirm-transaction-base.component.js
@@ -812,7 +812,7 @@ export default class ConfirmTransactionBase extends Component {
     const { submitting } = this.state;
     const { name } = methodData;
 
-    if (txData.type === 'simpleSend') {
+    if (txData.type === TRANSACTION_TYPES.SIMPLE_SEND) {
       addToAddressBookIfNew(toAddress, toAccounts);
     }
     if (submitting) {

--- a/ui/pages/confirm-transaction-base/confirm-transaction-base.component.js
+++ b/ui/pages/confirm-transaction-base/confirm-transaction-base.component.js
@@ -812,7 +812,7 @@ export default class ConfirmTransactionBase extends Component {
     const { submitting } = this.state;
     const { name } = methodData;
 
-    if (txData.type === TRANSACTION_TYPES.SIMPLE_SEND) {
+    if (txData.type === TransactionType.simpleSend) {
       addToAddressBookIfNew(toAddress, toAccounts);
     }
     if (submitting) {

--- a/ui/pages/send/send-content/add-recipient/add-recipient.component.test.js
+++ b/ui/pages/send/send-content/add-recipient/add-recipient.component.test.js
@@ -58,4 +58,71 @@ describe('Add Recipient Component', () => {
       expect(container).toMatchSnapshot();
     });
   });
+
+  describe('Recent recipient order', () => {
+    const recentRecipientState = {
+      ...mockState,
+      metamask: {
+        ...mockState.metamask,
+        addressBook: {
+          '0x5': {
+            '0x0000000000000000000000000000000000000001': {
+              address: '0x0000000000000000000000000000000000000001',
+              chainId: '0x5',
+              isEns: false,
+              memo: '',
+              name: '',
+            },
+            '0x0000000000000000000000000000000000000002': {
+              address: '0x0000000000000000000000000000000000000002',
+              chainId: '0x5',
+              isEns: false,
+              memo: '',
+              name: '',
+            },
+            '0x0000000000000000000000000000000000000003': {
+              address: '0x0000000000000000000000000000000000000003',
+              chainId: '0x5',
+              isEns: false,
+              memo: '',
+              name: '',
+            },
+          },
+        },
+        currentNetworkTxList: [
+          {
+            time: 1674425700001,
+            txParams: {
+              to: '0x0000000000000000000000000000000000000001',
+            },
+          },
+          {
+            time: 1674425700002,
+            txParams: {
+              to: '0x0000000000000000000000000000000000000002',
+            },
+          },
+          {
+            time: 1674425700003,
+            txParams: {
+              to: '0x0000000000000000000000000000000000000003',
+            },
+          },
+        ],
+      },
+    };
+    const mockStore = configureMockStore()(recentRecipientState);
+
+    it('should render latest used recipient first', () => {
+      const { getAllByTestId } = renderWithProvider(
+        <AddRecipient />,
+        mockStore,
+      );
+
+      const recipientList = getAllByTestId('recipient');
+
+      expect(recipientList[0]).toHaveTextContent('0x0000...0003');
+      expect(recipientList[1]).toHaveTextContent('0x0000...0002');
+    });
+  });
 });

--- a/ui/pages/send/send-content/add-recipient/add-recipient.container.js
+++ b/ui/pages/send/send-content/add-recipient/add-recipient.container.js
@@ -36,7 +36,7 @@ function mapStateToProps(state) {
 
   const addressBook = getAddressBook(state);
 
-  const txList = currentNetworkTxListSelector(state).reverse();
+  const txList = [...currentNetworkTxListSelector(state)].reverse();
 
   const nonContacts = addressBook
     .filter(({ name }) => !name)
@@ -45,7 +45,7 @@ function mapStateToProps(state) {
         (transaction) =>
           transaction.txParams.to === nonContact.address.toLowerCase(),
       );
-      return { ...nonContact, timestamp: nonContactTx.time };
+      return { ...nonContact, timestamp: nonContactTx?.time };
     });
 
   nonContacts.sort((a, b) => {

--- a/ui/pages/send/send-content/add-recipient/add-recipient.container.js
+++ b/ui/pages/send/send-content/add-recipient/add-recipient.container.js
@@ -3,6 +3,7 @@ import {
   getAddressBook,
   getAddressBookEntry,
   getMetaMaskAccountsOrdered,
+  currentNetworkTxListSelector,
 } from '../../../../selectors';
 
 import {
@@ -35,6 +36,22 @@ function mapStateToProps(state) {
 
   const addressBook = getAddressBook(state);
 
+  const txList = currentNetworkTxListSelector(state).reverse();
+
+  const nonContacts = addressBook
+    .filter(({ name }) => !name)
+    .map((nonContact) => {
+      const nonContactTx = txList.find(
+        (transaction) =>
+          transaction.txParams.to === nonContact.address.toLowerCase(),
+      );
+      return { ...nonContact, timestamp: nonContactTx.time };
+    });
+
+  nonContacts.sort((a, b) => {
+    return b.timestamp - a.timestamp;
+  });
+
   const ownedAccounts = getMetaMaskAccountsOrdered(state);
 
   return {
@@ -44,7 +61,7 @@ function mapStateToProps(state) {
     domainResolution,
     domainError: getDomainError(state),
     domainWarning: getDomainWarning(state),
-    nonContacts: addressBook.filter(({ name }) => !name),
+    nonContacts,
     ownedAccounts,
     isUsingMyAccountsForRecipientSearch:
       getIsUsingMyAccountForRecipientSearch(state),

--- a/ui/pages/send/send-content/add-recipient/add-recipient.container.test.js
+++ b/ui/pages/send/send-content/add-recipient/add-recipient.container.test.js
@@ -16,6 +16,7 @@ jest.mock('../../../../selectors', () => ({
     { name: `account1:mockState` },
     { name: `account2:mockState` },
   ],
+  currentNetworkTxListSelector: (s) => `currentNetworkTxListSelector:${s}`,
 }));
 
 jest.mock('../../../../ducks/domains', () => ({

--- a/ui/pages/send/send-footer/send-footer.component.js
+++ b/ui/pages/send/send-footer/send-footer.component.js
@@ -11,13 +11,10 @@ import { SEND_STAGES } from '../../../ducks/send';
 
 export default class SendFooter extends Component {
   static propTypes = {
-    addToAddressBookIfNew: PropTypes.func,
     resetSendState: PropTypes.func,
     disabled: PropTypes.bool.isRequired,
     history: PropTypes.object,
     sign: PropTypes.func,
-    to: PropTypes.string,
-    toAccounts: PropTypes.array,
     sendStage: PropTypes.string,
     sendErrors: PropTypes.object,
     mostRecentOverviewPage: PropTypes.string.isRequired,
@@ -52,11 +49,9 @@ export default class SendFooter extends Component {
 
   async onSubmit(event) {
     event.preventDefault();
-    const { addToAddressBookIfNew, sign, to, toAccounts, history } = this.props;
+    const { sign, history } = this.props;
     const { trackEvent } = this.context;
 
-    // TODO: add nickname functionality
-    await addToAddressBookIfNew(to, toAccounts);
     const promise = sign();
 
     Promise.resolve(promise).then(() => {

--- a/ui/pages/send/send-footer/send-footer.container.js
+++ b/ui/pages/send/send-footer/send-footer.container.js
@@ -1,5 +1,5 @@
 import { connect } from 'react-redux';
-import { addToAddressBook, cancelTx } from '../../../store/actions';
+import { cancelTx } from '../../../store/actions';
 import {
   resetSendState,
   getSendStage,
@@ -10,19 +10,10 @@ import {
   getDraftTransactionID,
 } from '../../../ducks/send';
 import { getMostRecentOverviewPage } from '../../../ducks/history/history';
-import { addHexPrefix } from '../../../../app/scripts/lib/util';
 import { getSendToAccounts } from '../../../ducks/metamask/metamask';
 import SendFooter from './send-footer.component';
 
 export default connect(mapStateToProps, mapDispatchToProps)(SendFooter);
-
-function addressIsNew(toAccounts, newAddress) {
-  const newAddressNormalized = newAddress.toLowerCase();
-  const foundMatching = toAccounts.some(
-    ({ address }) => address.toLowerCase() === newAddressNormalized,
-  );
-  return !foundMatching;
-}
 
 function mapStateToProps(state) {
   return {
@@ -41,12 +32,5 @@ function mapDispatchToProps(dispatch) {
     resetSendState: () => dispatch(resetSendState()),
     cancelTx: (t) => dispatch(cancelTx(t)),
     sign: () => dispatch(signTransaction()),
-    addToAddressBookIfNew: (newAddress, toAccounts, nickname = '') => {
-      const hexPrefixedAddress = addHexPrefix(newAddress);
-      if (addressIsNew(toAccounts, hexPrefixedAddress)) {
-        // TODO: nickname, i.e. addToAddressBook(recipient, nickname)
-        dispatch(addToAddressBook(hexPrefixedAddress, nickname));
-      }
-    },
   };
 }

--- a/ui/pages/send/send-footer/send-footer.stories.js
+++ b/ui/pages/send/send-footer/send-footer.stories.js
@@ -13,7 +13,6 @@ export default {
     mostRecentOverviewPage: { control: 'text' },
     sendErrors: { control: 'object' },
     history: { action: 'history' },
-    addToAddressBookIfNew: { action: 'addToAddressBookIfNew' },
     resetSendState: { action: 'resetSendState' },
   },
 };

--- a/ui/pages/send/send-footer/send-footer.test.js
+++ b/ui/pages/send/send-footer/send-footer.test.js
@@ -13,7 +13,6 @@ import SendFooter from '.';
 
 const mockResetSendState = jest.fn();
 const mockSendTransaction = jest.fn();
-const mockAddtoAddressBook = jest.fn();
 const mockCancelTx = jest.fn();
 
 jest.mock('../../../ducks/send/index.js', () => ({
@@ -23,7 +22,6 @@ jest.mock('../../../ducks/send/index.js', () => ({
 }));
 
 jest.mock('../../../store/actions.ts', () => ({
-  addToAddressBook: () => mockAddtoAddressBook,
   cancelTx: () => mockCancelTx,
 }));
 
@@ -108,7 +106,6 @@ describe('SendFooter Component', () => {
       fireEvent.click(nextText);
 
       await waitFor(() => {
-        expect(mockAddtoAddressBook).toHaveBeenCalled();
         expect(mockSendTransaction).toHaveBeenCalled();
         expect(props.history.push).toHaveBeenCalledWith(
           CONFIRM_TRANSACTION_ROUTE,

--- a/ui/pages/send/send.test.js
+++ b/ui/pages/send/send.test.js
@@ -103,6 +103,7 @@ const baseStore = {
     addressBook: {
       [CHAIN_IDS.GOERLI]: [],
     },
+    currentNetworkTxList: [],
     cachedBalances: {
       [CHAIN_IDS.GOERLI]: {},
     },


### PR DESCRIPTION
## Explanation

<!--
Thanks for the pull request. Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Below is a template to give you some ideas. Feel free to use your own words!

Currently, ...

This is a problem because ...

In order to solve this problem, this pull request ...
-->

Currently, we have an issue with recent recipients displayed in send flow. The recently used address will be added at the end of the list.

With this PR, the recently used recipients will be at the top of the list.

NOTE: https://github.com/MetaMask/metamask-extension/issues/14647#issuecomment-1310260985

<!--
This PR also fixes the issue where recipients are sorted by address alphabetically after we shut down a browser or restart MetaMask.
-->

## More Information

<!--
Are there any issues, Slack conversations, Zendesk issues, user stories, etc. reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

Fixes #14647 

## Screenshots/Screencaps

<!-- If you're making a change to the UI, make sure to capture a screenshot or a short video showing off your work! -->

### Before

<!-- How did the UI you changed look before your changes? Drag your file(s) below this line: -->
<img width="817" alt="image" src="https://user-images.githubusercontent.com/97883527/199434183-6cd885db-bdfe-43e6-b82d-5ce462a4687f.png">


### After

<!-- How does it look now? Drag your file(s) below this line: -->

Address sorted by the timestamp
<img width="817" alt="image" src="https://user-images.githubusercontent.com/97883527/199432615-cf1d53af-dc0c-433a-8345-2540fd4e023d.png">


## Manual Testing Steps

<!--
How should reviewers and QA manually test your changes? For instance:

- Go to this screen
- Do this
- Then do this
-->

- Send funds to a random address that will be added in recent recipient automatically 
- Send funds to another random address
- Notice that the last used address will be at the top of the list in the send flow recent recipients list.

## Pre-Merge Checklist

- [x] PR template is filled out
- [ ] **IF** this PR fixes a bug, a test that _would have_ caught the bug has been added
- [x] PR is linked to the appropriate GitHub issue
- [ ] PR has been added to the appropriate release Milestone

### + If there are functional changes:

- [ ] Manual testing complete & passed
- [ ] "Extension QA Board" label has been applied
