### PR TITLE
Token allowance i18n interpolation system

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -2989,7 +2989,8 @@
     "description": "$1 is either key 'account' or 'contract', and $2 is either a string or link of a given token symbol or name"
   },
   "revokeSpendingCap": {
-    "message": "Revoke spending cap for your"
+    "message": "Revoke spending cap for your $1",
+    "description": "$1 is a token symbol"
   },
   "revokeSpendingCapTooltipText": {
     "message": "This contract will be unable to spend any more of your current or future tokens."

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -3179,7 +3179,8 @@
     "description": "The token symbol that is being approved"
   },
   "setSpendingCap": {
-    "message": "Set a spending cap for your"
+    "message": "Set a spending cap for your $1",
+    "description": "$1 is a token symbol"
   },
   "settings": {
     "message": "Settings"

--- a/ui/pages/token-allowance/token-allowance.js
+++ b/ui/pages/token-allowance/token-allowance.js
@@ -184,7 +184,7 @@ export default function TokenAllowance({
   };
 
   const isEmpty = customTokenAmount === '';
-  
+
   const renderContractTokenValues = (
     <Box marginTop={4} key={tokenAddress}>
       <ContractTokenValues
@@ -284,7 +284,7 @@ export default function TokenAllowance({
             t('setSpendingCap', [renderContractTokenValues])
           ) : (
             <Box>
-              {customTokenAmount === '0' ? (
+              {customTokenAmount === '0' || isEmpty ? (
                 t('revokeSpendingCap', [renderContractTokenValues])
               ) : (
                 <Box>

--- a/ui/pages/token-allowance/token-allowance.js
+++ b/ui/pages/token-allowance/token-allowance.js
@@ -184,6 +184,17 @@ export default function TokenAllowance({
   };
 
   const isEmpty = customTokenAmount === '';
+  
+  const renderContractTokenValues = (
+    <Box marginTop={4} key={tokenAddress}>
+      <ContractTokenValues
+        tokenName={tokenSymbol}
+        address={tokenAddress}
+        chainId={fullTxData.chainId}
+        rpcPrefs={rpcPrefs}
+      />
+    </Box>
+  );
 
   return (
     <Box className="token-allowance-container page-container">
@@ -270,27 +281,17 @@ export default function TokenAllowance({
           align={TEXT_ALIGN.CENTER}
         >
           {isFirstPage ? (
-            t('setSpendingCap', [
-              <Box marginTop={4} key={tokenAddress}>
-                <ContractTokenValues
-                  tokenName={tokenSymbol}
-                  address={tokenAddress}
-                  chainId={fullTxData.chainId}
-                  rpcPrefs={rpcPrefs}
-                />
-              </Box>,
-            ])
+            t('setSpendingCap', [renderContractTokenValues])
           ) : (
             <Box>
-             {customTokenAmount === '0' ? t('revokeSpendingCap') : t('reviewSpendingCap')}
-              <Box marginTop={4} key={tokenAddress}>
-                <ContractTokenValues
-                  tokenName={tokenSymbol}
-                  address={tokenAddress}
-                  chainId={fullTxData.chainId}
-                  rpcPrefs={rpcPrefs}
-                />
-              </Box>
+              {customTokenAmount === 0 ? (
+                t('revokeSpendingCap', [renderContractTokenValues])
+              ) : (
+                <Box>
+                  {t('reviewSpendingCap')}
+                  {renderContractTokenValues}
+                </Box>
+              )}
             </Box>
           )}
         </Typography>

--- a/ui/pages/token-allowance/token-allowance.js
+++ b/ui/pages/token-allowance/token-allowance.js
@@ -284,7 +284,7 @@ export default function TokenAllowance({
             t('setSpendingCap', [renderContractTokenValues])
           ) : (
             <Box>
-              {customTokenAmount === 0 ? (
+              {customTokenAmount === '0' ? (
                 t('revokeSpendingCap', [renderContractTokenValues])
               ) : (
                 <Box>

--- a/ui/pages/token-allowance/token-allowance.js
+++ b/ui/pages/token-allowance/token-allowance.js
@@ -263,26 +263,37 @@ export default function TokenAllowance({
           </Typography>
         </Box>
       </Box>
-      <Box marginBottom={5} marginLeft={4} marginRight={4}>
+      <Box marginLeft={4} marginRight={4}>
         <Typography
           variant={TYPOGRAPHY.H3}
           fontWeight={FONT_WEIGHT.BOLD}
           align={TEXT_ALIGN.CENTER}
         >
-          {isFirstPage && t('setSpendingCap')}
-          {!isFirstPage &&
-            (customTokenAmount === '0' || isEmpty
-              ? t('revokeSpendingCap')
-              : t('reviewSpendingCap'))}
+          {isFirstPage ? (
+            t('setSpendingCap', [
+              <Box marginTop={4} key={tokenAddress}>
+                <ContractTokenValues
+                  tokenName={tokenSymbol}
+                  address={tokenAddress}
+                  chainId={fullTxData.chainId}
+                  rpcPrefs={rpcPrefs}
+                />
+              </Box>,
+            ])
+          ) : (
+            <Box>
+             {customTokenAmount === '0' ? t('revokeSpendingCap') : t('reviewSpendingCap')}
+              <Box marginTop={4} key={tokenAddress}>
+                <ContractTokenValues
+                  tokenName={tokenSymbol}
+                  address={tokenAddress}
+                  chainId={fullTxData.chainId}
+                  rpcPrefs={rpcPrefs}
+                />
+              </Box>
+            </Box>
+          )}
         </Typography>
-      </Box>
-      <Box>
-        <ContractTokenValues
-          tokenName={tokenSymbol}
-          address={tokenAddress}
-          chainId={fullTxData.chainId}
-          rpcPrefs={rpcPrefs}
-        />
       </Box>
       <Box
         marginTop={1}


### PR DESCRIPTION
## Explanation
Fixed setSpendingCap and revokeSpendingCap(https://github.com/MetaMask/metamask-extension/pull/16157#pullrequestreview-1147622672) locale string using the i18n interpolation system.


## More Information

* Fixes #16234


## Manual Testing Steps
**BEFORE TESTING** - in your .metamaskrc file, set TOKEN_ALLOWANCE_IMPROVEMENTS=1 and then start the app

1. Open the Test Dapp: https://metamask.github.io/test-dapp/
2. Under the section Send Tokens click on CREATE TOKEN
3. Wait for the token to be created and then, under the same section, click on APPROVE TOKENS or APPROVE TOKENS WITHOUT GAS in order to see the newly created screen

To see how the screen looks like when the enhanced gas fee is enabled, go to Settings (Experimental tab) and enable it (Enable enhanced gas fee UI toggle)