### PR TITLE
[FLASK] Fix crash on snaps settings page if snap has no permissions

### DIFF
--- a/ui/selectors/permissions.js
+++ b/ui/selectors/permissions.js
@@ -307,5 +307,5 @@ export function getFirstPermissionRequest(state) {
 }
 
 export function getPermissions(state, origin) {
-  return getPermissionSubjects(state)[origin].permissions;
+  return getPermissionSubjects(state)[origin]?.permissions;
 }


### PR DESCRIPTION
## Explanation

Fixes a crash on the snaps settings page that only happened if a snap had zero permissions.

## More Information
Fixes #16333

## Manual Testing Steps
1. Create a snap with 0 permissions
2. Install the snap
3. Find the snap in the settings page and "view details"
4. Confirm that this doesn't crash the extension