### PR TITLE
tag component housekeeping

### DIFF
--- a/ui/components/component-library/tag/README.mdx
+++ b/ui/components/component-library/tag/README.mdx
@@ -19,3 +19,7 @@ The `Tag` accepts all props below as well as all [Box](/docs/ui-components-ui-bo
 ### Label
 
 The text content of the `Tag` component
+
+<Canvas>
+  <Story id="ui-components-component-library-tag-tag-stories-js--label" />
+</Canvas>

--- a/ui/components/component-library/tag/__snapshots__/tag.test.js.snap
+++ b/ui/components/component-library/tag/__snapshots__/tag.test.js.snap
@@ -1,0 +1,16 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Tag should render the label inside the tag and match snapshot 1`] = `
+<div>
+  <div
+    class="box mm-tag box--padding-right-1 box--padding-left-1 box--display-inline-block box--flex-direction-row box--justify-content-center box--align-items-center box--background-color-background-default box--rounded-pill box--border-color-border-default box--border-width-1 box--border-style-solid"
+    data-testid="tag"
+  >
+    <p
+      class="box text text--body-sm text--color-text-default box--flex-direction-row"
+    >
+      Imported
+    </p>
+  </div>
+</div>
+`;

--- a/ui/components/component-library/tag/tag.js
+++ b/ui/components/component-library/tag/tag.js
@@ -15,7 +15,7 @@ import {
 export const Tag = ({ label, className, labelProps, ...props }) => {
   return (
     <Box
-      className={classnames('tag', className)}
+      className={classnames('mm-tag', className)}
       backgroundColor={COLORS.BACKGROUND_DEFAULT}
       borderColor={COLORS.BORDER_DEFAULT}
       borderWidth={1}
@@ -47,4 +47,8 @@ Tag.propTypes = {
    * Additional classNames to be added to the Tag component
    */
   className: PropTypes.string,
+  /**
+   * Tag also accepts all props from Box
+   */
+  ...Box.propTypes,
 };

--- a/ui/components/component-library/tag/tag.scss
+++ b/ui/components/component-library/tag/tag.scss
@@ -1,4 +1,4 @@
-.tag {
+.mm-tag {
   height: auto;
   width: max-content;
   padding-top: 1px;

--- a/ui/components/component-library/tag/tag.stories.js
+++ b/ui/components/component-library/tag/tag.stories.js
@@ -24,3 +24,9 @@ export default {
 export const DefaultStory = (args) => <Tag {...args} />;
 
 DefaultStory.storyName = 'Default';
+
+export const Label = (args) => <Tag {...args}>Anchor Element</Tag>;
+
+Label.args = {
+  label: 'Label Story',
+};

--- a/ui/components/component-library/tag/tag.test.js
+++ b/ui/components/component-library/tag/tag.test.js
@@ -5,9 +5,12 @@ import React from 'react';
 import { Tag } from './tag';
 
 describe('Tag', () => {
-  it('should render the label inside the tag', () => {
-    const { getByTestId } = render(<Tag data-testid="tag" label="Imported" />);
+  it('should render the label inside the tag and match snapshot', () => {
+    const { getByTestId, container } = render(
+      <Tag data-testid="tag" label="Imported" />,
+    );
     expect(getByTestId('tag')).toBeDefined();
     expect(getByTestId('tag')).toHaveTextContent('Imported');
+    expect(container).toMatchSnapshot();
   });
 });


### PR DESCRIPTION
## Explanation

### Housekeeping Checklist
- [x] Has a `className` prop and the PropType descriptions are all the same
- [x] Prop table in MDX docs have the "Accepts all Box component props" description and link
- [ ] We are consistent when using the same prop names like `size` and are suggesting the use of the generalized `design-system.js` constants e.g. `SIZES` as the primary option but noting the component consts in the documentation and using them for propType validation and storybook controls only
- [x] Standardize all similar prop names for images `imgSrc`, `imgAlt`(html element + attribute) (needs audit)
- [x] We have a story for each component prop and we use the prop name verbatim e.g. `size` prop would be `export const Size = (args) => (`
- [ ] Are multiple props stories allowed? e.g. `Color, Background Color And Border Color` story in `base-avatar` - [ ] yes when it makes sense to
- [x] We have the accompanying documentation for each component prop and we use the prop name verbatim e.g. `size` prop would be `### Size`
- [x] All Base components follow the suffix convention e.g. `ButtonBase`
- [x] All Base component MDX documentation have the base component notification at the top
- [x] Add `mm-` prefix to all classNames
- [x] className is kebab case version of the component name
- [ ] Spread base components props and reduce duplication of props when props aren't being changed and remain the same for both variant and base components
- [ ] Remove `Component.displayName` not needed
- [x] Add component to root `index.js` file in component-library
- [ ] Add locals for any default text I18nContext as default context 
- [ ] Add any "to dos" with a `// TODO:` comment so we can search for them at a later date e.g. blocking components etc
- [x] Add snapshot testing
- [ ] Add pixel values to propType descriptions if we use abstracted prop types that relate to pixel values e.g. `SIZE.MD (32px)`


## More Information

Fixes: #16180

## Manual Testing Steps

```yarn test:unit:jest .ui/components/component-library/tag/tag.test.js```

## Pre-Merge Checklist

- [x] PR template is filled out
- [ ] **IF** this PR fixes a bug, a test that _would have_ caught the bug has been added
- [x] PR is linked to the appropriate GitHub issue
- [x] PR has been added to the appropriate release Milestone

### + If there are functional changes:

- [x] Manual testing complete & passed
- [ ] "Extension QA Board" label has been applied