### PR TITLE
Fix: To differentiate between which chrome alarm is triggered

### DIFF
--- a/app/scripts/controllers/app-state.js
+++ b/app/scripts/controllers/app-state.js
@@ -191,11 +191,9 @@ export default class AppStateController extends EventEmitter {
     const { timeoutMinutes } = this.store.getState();
 
     if (this.timer) {
-      if (isManifestV3) {
-        chrome.alarms.clear(AUTO_LOCK_TIMEOUT_ALARM);
-      } else {
-        clearTimeout(this.timer);
-      }
+      clearTimeout(this.timer);
+    } else if (isManifestV3) {
+      chrome.alarms.clear(AUTO_LOCK_TIMEOUT_ALARM);
     }
 
     if (!timeoutMinutes) {
@@ -207,16 +205,11 @@ export default class AppStateController extends EventEmitter {
         delayInMinutes: timeoutMinutes,
         periodInMinutes: timeoutMinutes,
       });
-      chrome.alarms.onAlarm.addListener(() => {
-        chrome.alarms.getAll((alarms) => {
-          const hasAlarm = alarms.find(
-            (alarm) => alarm.name === AUTO_LOCK_TIMEOUT_ALARM,
-          );
-          if (hasAlarm) {
-            this.onInactiveTimeout();
-            chrome.alarms.clear(AUTO_LOCK_TIMEOUT_ALARM);
-          }
-        });
+      chrome.alarms.onAlarm.addListener((alarmInfo) => {
+        if (alarmInfo.name === AUTO_LOCK_TIMEOUT_ALARM) {
+          this.onInactiveTimeout();
+          chrome.alarms.clear(AUTO_LOCK_TIMEOUT_ALARM);
+        }
       });
     } else {
       this.timer = setTimeout(

--- a/app/scripts/controllers/metametrics.js
+++ b/app/scripts/controllers/metametrics.js
@@ -162,17 +162,10 @@ export default class MetaMetricsController {
           });
         }
       });
-      chrome.alarms.onAlarm.addListener(() => {
-        chrome.alarms.getAll((alarms) => {
-          const hasAlarm = checkAlarmExists(
-            alarms,
-            METAMETRICS_FINALIZE_EVENT_FRAGMENT_ALARM,
-          );
-
-          if (hasAlarm) {
-            this.finalizeAbandonedFragments();
-          }
-        });
+      chrome.alarms.onAlarm.addListener((alarmInfo) => {
+        if (alarmInfo.name === METAMETRICS_FINALIZE_EVENT_FRAGMENT_ALARM) {
+          this.finalizeAbandonedFragments();
+        }
       });
     } else {
       setInterval(() => {


### PR DESCRIPTION
#16359
With the `chrome.alarms.getAll`, we are getting the list of all the alarms currently active, and it is not the right way to get which alarm that was triggered at that moment; for that, we can use the alarm information from `addListener`  prop. 

Manual testing:

1. Log in to the application
2. Go to settings >> search for `Auto-lock timer (minutes)` 
3. Set a timer value; A value greater than 1 minute will be easier to test as the second alarm we have is for a 1 min window.
4. Breakpoint at line 210 in app-state and check if it goes off at the interval you have defined at `Auto-lock timer (minutes)`
5. Breakpoint at line 167 metametrics.js and check if it goes off every minute. 
