### PR TITLE
[FLASK] Fix some issues with installing snaps that request eth_accounts

### DIFF
--- a/ui/pages/permissions-connect/permissions-connect.component.js
+++ b/ui/pages/permissions-connect/permissions-connect.component.js
@@ -164,11 +164,33 @@ export default class PermissionConnect extends Component {
   }
 
   selectAccounts = (addresses) => {
+    const {
+      confirmPermissionPath,
+      ///: BEGIN:ONLY_INCLUDE_IN(flask)
+      snapInstallPath,
+      snapUpdatePath,
+      isSnap,
+      permissionsRequest,
+      ///: END:ONLY_INCLUDE_IN
+    } = this.props;
     this.setState(
       {
         selectedAccountAddresses: addresses,
       },
-      () => this.props.history.push(this.props.confirmPermissionPath),
+      ///: BEGIN:ONLY_INCLUDE_IN(main,beta)
+      () => this.props.history.push(confirmPermissionPath),
+      ///: END:ONLY_INCLUDE_IN
+      ///: BEGIN:ONLY_INCLUDE_IN(flask)
+      () =>
+        this.props.history.push(
+          // eslint-disable-next-line no-nested-ternary
+          isSnap
+            ? permissionsRequest.newPermissions
+              ? snapUpdatePath
+              : snapInstallPath
+            : confirmPermissionPath,
+        ),
+      ///: END:ONLY_INCLUDE_IN
     );
   };
 
@@ -315,7 +337,7 @@ export default class PermissionConnect extends Component {
                   approveSnapInstall={(requestId) => {
                     approvePendingApproval(requestId, {
                       ...permissionsRequest,
-                      approvedAccounts: selectedAccountAddresses,
+                      approvedAccounts: [...selectedAccountAddresses],
                     });
                     this.redirect(true);
                   }}
@@ -345,7 +367,7 @@ export default class PermissionConnect extends Component {
                   approveSnapUpdate={(requestId) => {
                     approvePendingApproval(requestId, {
                       ...permissionsRequest,
-                      approvedAccounts: selectedAccountAddresses,
+                      approvedAccounts: [...selectedAccountAddresses],
                     });
                     this.redirect(true);
                   }}


### PR DESCRIPTION
## Explanation

Fixes some issues with installing snaps that request the `eth_accounts` permission AND other permissions. Reported by a user in Discord.

## Manual Testing Steps

1. Create a snap with the following permissions
```
  "initialPermissions": {
    "eth_accounts": {
      "requiredMethods": []
    },
    "snap_confirm": {},
    "snap_manageState": {},
    "endowment:network-access": {},
    "snap_getBip44Entropy": [
      {
        "coinType": 60
      }
    ]
  },
```
2. Verify that the snap can install successfully