### PR TITLE
Bundle Optimization

### DIFF
--- a/app/scripts/lib/typed-message-manager.test.js
+++ b/app/scripts/lib/typed-message-manager.test.js
@@ -26,7 +26,7 @@ describe('Typed Message Manager', () => {
         {
           type: 'uint32',
           name: 'A number, but not really a number',
-          value: '$$$',
+          value: '1234',
         },
       ],
     };

--- a/lavamoat/browserify/beta/policy.json
+++ b/lavamoat/browserify/beta/policy.json
@@ -126,13 +126,13 @@
         "@ethersproject/bignumber": true,
         "@ethersproject/bignumber>@ethersproject/bytes": true,
         "@ethersproject/bignumber>@ethersproject/logger": true,
-        "ethers>@ethersproject/wallet>@ethersproject/properties": true
+        "ethers>@ethersproject/hash>@ethersproject/properties": true
       }
     },
     "@eth-optimism/contracts>@ethersproject/abstract-signer": {
       "packages": {
         "@ethersproject/bignumber>@ethersproject/logger": true,
-        "ethers>@ethersproject/wallet>@ethersproject/properties": true
+        "ethers>@ethersproject/hash>@ethersproject/properties": true
       }
     },
     "@ethereumjs/common": {
@@ -512,12 +512,12 @@
         "@ethersproject/bignumber": true,
         "@ethersproject/bignumber>@ethersproject/bytes": true,
         "@ethersproject/bignumber>@ethersproject/logger": true,
-        "ethers>@ethersproject/hdnode>@ethersproject/strings": true,
-        "ethers>@ethersproject/units>@ethersproject/constants": true,
-        "ethers>@ethersproject/wallet>@ethersproject/address": true,
-        "ethers>@ethersproject/wallet>@ethersproject/hash": true,
-        "ethers>@ethersproject/wallet>@ethersproject/keccak256": true,
-        "ethers>@ethersproject/wallet>@ethersproject/properties": true
+        "ethers>@ethersproject/hash": true,
+        "ethers>@ethersproject/hash>@ethersproject/address": true,
+        "ethers>@ethersproject/hash>@ethersproject/keccak256": true,
+        "ethers>@ethersproject/hash>@ethersproject/properties": true,
+        "ethers>@ethersproject/hash>@ethersproject/strings": true,
+        "ethers>@ethersproject/units>@ethersproject/constants": true
       }
     },
     "@metamask/controllers>@ethersproject/contracts": {
@@ -531,8 +531,8 @@
         "@ethersproject/bignumber>@ethersproject/bytes": true,
         "@ethersproject/bignumber>@ethersproject/logger": true,
         "@metamask/controllers>@ethersproject/abi": true,
-        "ethers>@ethersproject/wallet>@ethersproject/address": true,
-        "ethers>@ethersproject/wallet>@ethersproject/properties": true,
+        "ethers>@ethersproject/hash>@ethersproject/address": true,
+        "ethers>@ethersproject/hash>@ethersproject/properties": true,
         "ethers>@ethersproject/wallet>@ethersproject/transactions": true
       }
     },
@@ -552,28 +552,19 @@
         "@ethersproject/bignumber": true,
         "@ethersproject/bignumber>@ethersproject/bytes": true,
         "@ethersproject/bignumber>@ethersproject/logger": true,
-        "@metamask/controllers>@ethersproject/providers>@ethersproject/base64": true,
         "@metamask/controllers>@ethersproject/providers>@ethersproject/networks": true,
         "@metamask/controllers>@ethersproject/providers>@ethersproject/web": true,
+        "ethers>@ethersproject/hash": true,
+        "ethers>@ethersproject/hash>@ethersproject/address": true,
+        "ethers>@ethersproject/hash>@ethersproject/base64": true,
+        "ethers>@ethersproject/hash>@ethersproject/properties": true,
+        "ethers>@ethersproject/hash>@ethersproject/strings": true,
         "ethers>@ethersproject/hdnode>@ethersproject/basex": true,
-        "ethers>@ethersproject/hdnode>@ethersproject/strings": true,
         "ethers>@ethersproject/pbkdf2>@ethersproject/sha2": true,
         "ethers>@ethersproject/providers>bech32": true,
         "ethers>@ethersproject/units>@ethersproject/constants": true,
-        "ethers>@ethersproject/wallet>@ethersproject/address": true,
-        "ethers>@ethersproject/wallet>@ethersproject/hash": true,
-        "ethers>@ethersproject/wallet>@ethersproject/properties": true,
         "ethers>@ethersproject/wallet>@ethersproject/random": true,
         "ethers>@ethersproject/wallet>@ethersproject/transactions": true
-      }
-    },
-    "@metamask/controllers>@ethersproject/providers>@ethersproject/base64": {
-      "globals": {
-        "atob": true,
-        "btoa": true
-      },
-      "packages": {
-        "@ethersproject/bignumber>@ethersproject/bytes": true
       }
     },
     "@metamask/controllers>@ethersproject/providers>@ethersproject/networks": {
@@ -596,9 +587,9 @@
       "packages": {
         "@ethersproject/bignumber>@ethersproject/bytes": true,
         "@ethersproject/bignumber>@ethersproject/logger": true,
-        "@metamask/controllers>@ethersproject/providers>@ethersproject/base64": true,
-        "ethers>@ethersproject/hdnode>@ethersproject/strings": true,
-        "ethers>@ethersproject/wallet>@ethersproject/properties": true
+        "ethers>@ethersproject/hash>@ethersproject/base64": true,
+        "ethers>@ethersproject/hash>@ethersproject/properties": true,
+        "ethers>@ethersproject/hash>@ethersproject/strings": true
       }
     },
     "@metamask/controllers>abort-controller": {
@@ -3237,11 +3228,11 @@
         "ethers>@ethersproject/abi>@ethersproject/bignumber": true,
         "ethers>@ethersproject/abi>@ethersproject/bytes": true,
         "ethers>@ethersproject/abi>@ethersproject/constants": true,
-        "ethers>@ethersproject/abi>@ethersproject/hash": true,
         "ethers>@ethersproject/abi>@ethersproject/keccak256": true,
         "ethers>@ethersproject/abi>@ethersproject/logger": true,
         "ethers>@ethersproject/abi>@ethersproject/properties": true,
-        "ethers>@ethersproject/abi>@ethersproject/strings": true
+        "ethers>@ethersproject/abi>@ethersproject/strings": true,
+        "ethers>@ethersproject/hash": true
       }
     },
     "ethers>@ethersproject/abi>@ethersproject/address": {
@@ -3282,27 +3273,6 @@
     "ethers>@ethersproject/abi>@ethersproject/constants": {
       "packages": {
         "ethers>@ethersproject/abi>@ethersproject/bignumber": true
-      }
-    },
-    "ethers>@ethersproject/abi>@ethersproject/hash": {
-      "packages": {
-        "ethers>@ethersproject/abi>@ethersproject/address": true,
-        "ethers>@ethersproject/abi>@ethersproject/bignumber": true,
-        "ethers>@ethersproject/abi>@ethersproject/bytes": true,
-        "ethers>@ethersproject/abi>@ethersproject/hash>@ethersproject/base64": true,
-        "ethers>@ethersproject/abi>@ethersproject/keccak256": true,
-        "ethers>@ethersproject/abi>@ethersproject/logger": true,
-        "ethers>@ethersproject/abi>@ethersproject/properties": true,
-        "ethers>@ethersproject/abi>@ethersproject/strings": true
-      }
-    },
-    "ethers>@ethersproject/abi>@ethersproject/hash>@ethersproject/base64": {
-      "globals": {
-        "atob": true,
-        "btoa": true
-      },
-      "packages": {
-        "ethers>@ethersproject/abi>@ethersproject/bytes": true
       }
     },
     "ethers>@ethersproject/abi>@ethersproject/keccak256": {
@@ -3508,7 +3478,6 @@
         "console.log": true
       },
       "packages": {
-        "ethers>@ethersproject/contracts>@ethersproject/abi>@ethersproject/hash": true,
         "ethers>@ethersproject/contracts>@ethersproject/abi>@ethersproject/keccak256": true,
         "ethers>@ethersproject/contracts>@ethersproject/abi>@ethersproject/strings": true,
         "ethers>@ethersproject/contracts>@ethersproject/address": true,
@@ -3516,28 +3485,8 @@
         "ethers>@ethersproject/contracts>@ethersproject/bytes": true,
         "ethers>@ethersproject/contracts>@ethersproject/constants": true,
         "ethers>@ethersproject/contracts>@ethersproject/logger": true,
-        "ethers>@ethersproject/contracts>@ethersproject/properties": true
-      }
-    },
-    "ethers>@ethersproject/contracts>@ethersproject/abi>@ethersproject/hash": {
-      "packages": {
-        "ethers>@ethersproject/contracts>@ethersproject/abi>@ethersproject/hash>@ethersproject/base64": true,
-        "ethers>@ethersproject/contracts>@ethersproject/abi>@ethersproject/keccak256": true,
-        "ethers>@ethersproject/contracts>@ethersproject/abi>@ethersproject/strings": true,
-        "ethers>@ethersproject/contracts>@ethersproject/address": true,
-        "ethers>@ethersproject/contracts>@ethersproject/bignumber": true,
-        "ethers>@ethersproject/contracts>@ethersproject/bytes": true,
-        "ethers>@ethersproject/contracts>@ethersproject/logger": true,
-        "ethers>@ethersproject/contracts>@ethersproject/properties": true
-      }
-    },
-    "ethers>@ethersproject/contracts>@ethersproject/abi>@ethersproject/hash>@ethersproject/base64": {
-      "globals": {
-        "atob": true,
-        "btoa": true
-      },
-      "packages": {
-        "ethers>@ethersproject/contracts>@ethersproject/bytes": true
+        "ethers>@ethersproject/contracts>@ethersproject/properties": true,
+        "ethers>@ethersproject/hash": true
       }
     },
     "ethers>@ethersproject/contracts>@ethersproject/abi>@ethersproject/keccak256": {
@@ -3640,76 +3589,58 @@
     },
     "ethers>@ethersproject/hash": {
       "packages": {
+        "@ethersproject/bignumber": true,
+        "@ethersproject/bignumber>@ethersproject/bytes": true,
+        "@ethersproject/bignumber>@ethersproject/logger": true,
         "ethers>@ethersproject/hash>@ethersproject/address": true,
-        "ethers>@ethersproject/hash>@ethersproject/bignumber": true,
-        "ethers>@ethersproject/hash>@ethersproject/bytes": true,
+        "ethers>@ethersproject/hash>@ethersproject/base64": true,
         "ethers>@ethersproject/hash>@ethersproject/keccak256": true,
-        "ethers>@ethersproject/hash>@ethersproject/logger": true,
         "ethers>@ethersproject/hash>@ethersproject/properties": true,
         "ethers>@ethersproject/hash>@ethersproject/strings": true
       }
     },
     "ethers>@ethersproject/hash>@ethersproject/address": {
       "packages": {
-        "ethers>@ethersproject/hash>@ethersproject/address>@ethersproject/rlp": true,
-        "ethers>@ethersproject/hash>@ethersproject/bignumber": true,
-        "ethers>@ethersproject/hash>@ethersproject/bytes": true,
-        "ethers>@ethersproject/hash>@ethersproject/keccak256": true,
-        "ethers>@ethersproject/hash>@ethersproject/logger": true
+        "@ethersproject/bignumber": true,
+        "@ethersproject/bignumber>@ethersproject/bytes": true,
+        "@ethersproject/bignumber>@ethersproject/logger": true,
+        "@metamask/controllers>@ethersproject/providers>@ethersproject/rlp": true,
+        "ethers>@ethersproject/hash>@ethersproject/keccak256": true
       }
     },
-    "ethers>@ethersproject/hash>@ethersproject/address>@ethersproject/rlp": {
-      "packages": {
-        "ethers>@ethersproject/hash>@ethersproject/bytes": true,
-        "ethers>@ethersproject/hash>@ethersproject/logger": true
-      }
-    },
-    "ethers>@ethersproject/hash>@ethersproject/bignumber": {
-      "packages": {
-        "ethers>@ethersproject/hash>@ethersproject/bignumber>bn.js": true,
-        "ethers>@ethersproject/hash>@ethersproject/bytes": true,
-        "ethers>@ethersproject/hash>@ethersproject/logger": true
-      }
-    },
-    "ethers>@ethersproject/hash>@ethersproject/bignumber>bn.js": {
+    "ethers>@ethersproject/hash>@ethersproject/base64": {
       "globals": {
-        "Buffer": true
+        "atob": true,
+        "btoa": true
       },
       "packages": {
-        "browserify>browser-resolve": true
-      }
-    },
-    "ethers>@ethersproject/hash>@ethersproject/bytes": {
-      "packages": {
-        "ethers>@ethersproject/hash>@ethersproject/logger": true
+        "@ethersproject/bignumber>@ethersproject/bytes": true
       }
     },
     "ethers>@ethersproject/hash>@ethersproject/keccak256": {
       "packages": {
-        "ethers>@ethersproject/hash>@ethersproject/bytes": true,
-        "ethers>@ethersproject/keccak256>js-sha3": true
+        "@ethersproject/bignumber>@ethersproject/bytes": true,
+        "ethers>@ethersproject/hash>@ethersproject/keccak256>js-sha3": true
       }
     },
-    "ethers>@ethersproject/hash>@ethersproject/logger": {
+    "ethers>@ethersproject/hash>@ethersproject/keccak256>js-sha3": {
       "globals": {
-        "console": true
+        "define": true
+      },
+      "packages": {
+        "browserify>process": true
       }
     },
     "ethers>@ethersproject/hash>@ethersproject/properties": {
       "packages": {
-        "ethers>@ethersproject/hash>@ethersproject/logger": true
+        "@ethersproject/bignumber>@ethersproject/logger": true
       }
     },
     "ethers>@ethersproject/hash>@ethersproject/strings": {
       "packages": {
-        "ethers>@ethersproject/hash>@ethersproject/bytes": true,
-        "ethers>@ethersproject/hash>@ethersproject/logger": true,
-        "ethers>@ethersproject/hash>@ethersproject/strings>@ethersproject/constants": true
-      }
-    },
-    "ethers>@ethersproject/hash>@ethersproject/strings>@ethersproject/constants": {
-      "packages": {
-        "ethers>@ethersproject/hash>@ethersproject/bignumber": true
+        "@ethersproject/bignumber>@ethersproject/bytes": true,
+        "@ethersproject/bignumber>@ethersproject/logger": true,
+        "ethers>@ethersproject/units>@ethersproject/constants": true
       }
     },
     "ethers>@ethersproject/hdnode": {
@@ -3717,11 +3648,11 @@
         "@ethersproject/bignumber": true,
         "@ethersproject/bignumber>@ethersproject/bytes": true,
         "@ethersproject/bignumber>@ethersproject/logger": true,
+        "ethers>@ethersproject/hash>@ethersproject/properties": true,
+        "ethers>@ethersproject/hash>@ethersproject/strings": true,
         "ethers>@ethersproject/hdnode>@ethersproject/basex": true,
-        "ethers>@ethersproject/hdnode>@ethersproject/strings": true,
         "ethers>@ethersproject/pbkdf2": true,
         "ethers>@ethersproject/pbkdf2>@ethersproject/sha2": true,
-        "ethers>@ethersproject/wallet>@ethersproject/properties": true,
         "ethers>@ethersproject/wallet>@ethersproject/signing-key": true,
         "ethers>@ethersproject/wallet>@ethersproject/transactions": true,
         "ethers>@ethersproject/wordlists": true
@@ -3730,28 +3661,21 @@
     "ethers>@ethersproject/hdnode>@ethersproject/basex": {
       "packages": {
         "@ethersproject/bignumber>@ethersproject/bytes": true,
-        "ethers>@ethersproject/wallet>@ethersproject/properties": true
-      }
-    },
-    "ethers>@ethersproject/hdnode>@ethersproject/strings": {
-      "packages": {
-        "@ethersproject/bignumber>@ethersproject/bytes": true,
-        "@ethersproject/bignumber>@ethersproject/logger": true,
-        "ethers>@ethersproject/units>@ethersproject/constants": true
+        "ethers>@ethersproject/hash>@ethersproject/properties": true
       }
     },
     "ethers>@ethersproject/json-wallets": {
       "packages": {
         "@ethersproject/bignumber>@ethersproject/bytes": true,
         "@ethersproject/bignumber>@ethersproject/logger": true,
+        "ethers>@ethersproject/hash>@ethersproject/address": true,
+        "ethers>@ethersproject/hash>@ethersproject/keccak256": true,
+        "ethers>@ethersproject/hash>@ethersproject/properties": true,
+        "ethers>@ethersproject/hash>@ethersproject/strings": true,
         "ethers>@ethersproject/hdnode": true,
-        "ethers>@ethersproject/hdnode>@ethersproject/strings": true,
         "ethers>@ethersproject/json-wallets>aes-js": true,
         "ethers>@ethersproject/json-wallets>scrypt-js": true,
         "ethers>@ethersproject/pbkdf2": true,
-        "ethers>@ethersproject/wallet>@ethersproject/address": true,
-        "ethers>@ethersproject/wallet>@ethersproject/keccak256": true,
-        "ethers>@ethersproject/wallet>@ethersproject/properties": true,
         "ethers>@ethersproject/wallet>@ethersproject/random": true,
         "ethers>@ethersproject/wallet>@ethersproject/transactions": true
       }
@@ -3834,6 +3758,7 @@
         "setTimeout": true
       },
       "packages": {
+        "ethers>@ethersproject/hash": true,
         "ethers>@ethersproject/providers>@ethersproject/abstract-provider": true,
         "ethers>@ethersproject/providers>@ethersproject/abstract-signer": true,
         "ethers>@ethersproject/providers>@ethersproject/address": true,
@@ -3841,7 +3766,6 @@
         "ethers>@ethersproject/providers>@ethersproject/bignumber": true,
         "ethers>@ethersproject/providers>@ethersproject/bytes": true,
         "ethers>@ethersproject/providers>@ethersproject/constants": true,
-        "ethers>@ethersproject/providers>@ethersproject/hash": true,
         "ethers>@ethersproject/providers>@ethersproject/logger": true,
         "ethers>@ethersproject/providers>@ethersproject/networks": true,
         "ethers>@ethersproject/providers>@ethersproject/properties": true,
@@ -3869,11 +3793,17 @@
     },
     "ethers>@ethersproject/providers>@ethersproject/address": {
       "packages": {
+        "ethers>@ethersproject/providers>@ethersproject/address>@ethersproject/keccak256": true,
         "ethers>@ethersproject/providers>@ethersproject/bignumber": true,
         "ethers>@ethersproject/providers>@ethersproject/bytes": true,
-        "ethers>@ethersproject/providers>@ethersproject/hash>@ethersproject/keccak256": true,
         "ethers>@ethersproject/providers>@ethersproject/logger": true,
         "ethers>@ethersproject/providers>@ethersproject/rlp": true
+      }
+    },
+    "ethers>@ethersproject/providers>@ethersproject/address>@ethersproject/keccak256": {
+      "packages": {
+        "ethers>@ethersproject/keccak256>js-sha3": true,
+        "ethers>@ethersproject/providers>@ethersproject/bytes": true
       }
     },
     "ethers>@ethersproject/providers>@ethersproject/basex": {
@@ -3905,24 +3835,6 @@
     "ethers>@ethersproject/providers>@ethersproject/constants": {
       "packages": {
         "ethers>@ethersproject/providers>@ethersproject/bignumber": true
-      }
-    },
-    "ethers>@ethersproject/providers>@ethersproject/hash": {
-      "packages": {
-        "ethers>@ethersproject/providers>@ethersproject/address": true,
-        "ethers>@ethersproject/providers>@ethersproject/bignumber": true,
-        "ethers>@ethersproject/providers>@ethersproject/bytes": true,
-        "ethers>@ethersproject/providers>@ethersproject/hash>@ethersproject/keccak256": true,
-        "ethers>@ethersproject/providers>@ethersproject/logger": true,
-        "ethers>@ethersproject/providers>@ethersproject/properties": true,
-        "ethers>@ethersproject/providers>@ethersproject/strings": true,
-        "ethers>@ethersproject/providers>@ethersproject/web>@ethersproject/base64": true
-      }
-    },
-    "ethers>@ethersproject/providers>@ethersproject/hash>@ethersproject/keccak256": {
-      "packages": {
-        "ethers>@ethersproject/keccak256>js-sha3": true,
-        "ethers>@ethersproject/providers>@ethersproject/bytes": true
       }
     },
     "ethers>@ethersproject/providers>@ethersproject/logger": {
@@ -3969,10 +3881,10 @@
     "ethers>@ethersproject/providers>@ethersproject/transactions": {
       "packages": {
         "ethers>@ethersproject/providers>@ethersproject/address": true,
+        "ethers>@ethersproject/providers>@ethersproject/address>@ethersproject/keccak256": true,
         "ethers>@ethersproject/providers>@ethersproject/bignumber": true,
         "ethers>@ethersproject/providers>@ethersproject/bytes": true,
         "ethers>@ethersproject/providers>@ethersproject/constants": true,
-        "ethers>@ethersproject/providers>@ethersproject/hash>@ethersproject/keccak256": true,
         "ethers>@ethersproject/providers>@ethersproject/logger": true,
         "ethers>@ethersproject/providers>@ethersproject/properties": true,
         "ethers>@ethersproject/providers>@ethersproject/rlp": true,
@@ -4123,9 +4035,9 @@
         "@ethersproject/bignumber": true,
         "@ethersproject/bignumber>@ethersproject/bytes": true,
         "@ethersproject/bignumber>@ethersproject/logger": true,
-        "ethers>@ethersproject/hdnode>@ethersproject/strings": true,
-        "ethers>@ethersproject/pbkdf2>@ethersproject/sha2": true,
-        "ethers>@ethersproject/wallet>@ethersproject/keccak256": true
+        "ethers>@ethersproject/hash>@ethersproject/keccak256": true,
+        "ethers>@ethersproject/hash>@ethersproject/strings": true,
+        "ethers>@ethersproject/pbkdf2>@ethersproject/sha2": true
       }
     },
     "ethers>@ethersproject/strings": {
@@ -4262,55 +4174,15 @@
         "@eth-optimism/contracts>@ethersproject/abstract-signer": true,
         "@ethersproject/bignumber>@ethersproject/bytes": true,
         "@ethersproject/bignumber>@ethersproject/logger": true,
+        "ethers>@ethersproject/hash": true,
+        "ethers>@ethersproject/hash>@ethersproject/address": true,
+        "ethers>@ethersproject/hash>@ethersproject/keccak256": true,
+        "ethers>@ethersproject/hash>@ethersproject/properties": true,
         "ethers>@ethersproject/hdnode": true,
         "ethers>@ethersproject/json-wallets": true,
-        "ethers>@ethersproject/wallet>@ethersproject/address": true,
-        "ethers>@ethersproject/wallet>@ethersproject/hash": true,
-        "ethers>@ethersproject/wallet>@ethersproject/keccak256": true,
-        "ethers>@ethersproject/wallet>@ethersproject/properties": true,
         "ethers>@ethersproject/wallet>@ethersproject/random": true,
         "ethers>@ethersproject/wallet>@ethersproject/signing-key": true,
         "ethers>@ethersproject/wallet>@ethersproject/transactions": true
-      }
-    },
-    "ethers>@ethersproject/wallet>@ethersproject/address": {
-      "packages": {
-        "@ethersproject/bignumber": true,
-        "@ethersproject/bignumber>@ethersproject/bytes": true,
-        "@ethersproject/bignumber>@ethersproject/logger": true,
-        "@metamask/controllers>@ethersproject/providers>@ethersproject/rlp": true,
-        "ethers>@ethersproject/wallet>@ethersproject/keccak256": true
-      }
-    },
-    "ethers>@ethersproject/wallet>@ethersproject/hash": {
-      "packages": {
-        "@ethersproject/bignumber": true,
-        "@ethersproject/bignumber>@ethersproject/bytes": true,
-        "@ethersproject/bignumber>@ethersproject/logger": true,
-        "@metamask/controllers>@ethersproject/providers>@ethersproject/base64": true,
-        "ethers>@ethersproject/hdnode>@ethersproject/strings": true,
-        "ethers>@ethersproject/wallet>@ethersproject/address": true,
-        "ethers>@ethersproject/wallet>@ethersproject/keccak256": true,
-        "ethers>@ethersproject/wallet>@ethersproject/properties": true
-      }
-    },
-    "ethers>@ethersproject/wallet>@ethersproject/keccak256": {
-      "packages": {
-        "@ethersproject/bignumber>@ethersproject/bytes": true,
-        "ethers>@ethersproject/wallet>@ethersproject/keccak256>js-sha3": true
-      }
-    },
-    "ethers>@ethersproject/wallet>@ethersproject/keccak256>js-sha3": {
-      "globals": {
-        "define": true
-      },
-      "packages": {
-        "browserify>process": true
-      }
-    },
-    "ethers>@ethersproject/wallet>@ethersproject/properties": {
-      "packages": {
-        "@ethersproject/bignumber>@ethersproject/logger": true
       }
     },
     "ethers>@ethersproject/wallet>@ethersproject/random": {
@@ -4323,8 +4195,8 @@
       "packages": {
         "@ethersproject/bignumber>@ethersproject/bytes": true,
         "@ethersproject/bignumber>@ethersproject/logger": true,
-        "ethers>@ethersproject/signing-key>elliptic": true,
-        "ethers>@ethersproject/wallet>@ethersproject/properties": true
+        "ethers>@ethersproject/hash>@ethersproject/properties": true,
+        "ethers>@ethersproject/signing-key>elliptic": true
       }
     },
     "ethers>@ethersproject/wallet>@ethersproject/transactions": {
@@ -4333,10 +4205,10 @@
         "@ethersproject/bignumber>@ethersproject/bytes": true,
         "@ethersproject/bignumber>@ethersproject/logger": true,
         "@metamask/controllers>@ethersproject/providers>@ethersproject/rlp": true,
+        "ethers>@ethersproject/hash>@ethersproject/address": true,
+        "ethers>@ethersproject/hash>@ethersproject/keccak256": true,
+        "ethers>@ethersproject/hash>@ethersproject/properties": true,
         "ethers>@ethersproject/units>@ethersproject/constants": true,
-        "ethers>@ethersproject/wallet>@ethersproject/address": true,
-        "ethers>@ethersproject/wallet>@ethersproject/keccak256": true,
-        "ethers>@ethersproject/wallet>@ethersproject/properties": true,
         "ethers>@ethersproject/wallet>@ethersproject/signing-key": true
       }
     },
@@ -4409,9 +4281,9 @@
       "packages": {
         "@ethersproject/bignumber>@ethersproject/bytes": true,
         "@ethersproject/bignumber>@ethersproject/logger": true,
-        "ethers>@ethersproject/hdnode>@ethersproject/strings": true,
-        "ethers>@ethersproject/wallet>@ethersproject/hash": true,
-        "ethers>@ethersproject/wallet>@ethersproject/properties": true
+        "ethers>@ethersproject/hash": true,
+        "ethers>@ethersproject/hash>@ethersproject/properties": true,
+        "ethers>@ethersproject/hash>@ethersproject/strings": true
       }
     },
     "ethjs": {

--- a/lavamoat/browserify/beta/policy.json
+++ b/lavamoat/browserify/beta/policy.json
@@ -161,7 +161,7 @@
       "packages": {
         "@ethersproject/bignumber>@ethersproject/bytes": true,
         "@ethersproject/bignumber>@ethersproject/logger": true,
-        "@ethersproject/bignumber>bn.js": true
+        "bn.js": true
       }
     },
     "@ethersproject/bignumber>@ethersproject/bytes": {
@@ -172,14 +172,6 @@
     "@ethersproject/bignumber>@ethersproject/logger": {
       "globals": {
         "console": true
-      }
-    },
-    "@ethersproject/bignumber>bn.js": {
-      "globals": {
-        "Buffer": true
-      },
-      "packages": {
-        "browserify>browser-resolve": true
       }
     },
     "@formatjs/intl-relativetimeformat": {
@@ -648,10 +640,10 @@
         "setInterval": true
       },
       "packages": {
-        "@metamask/controllers>eth-method-registry>ethjs>bn.js": true,
         "@metamask/controllers>eth-method-registry>ethjs>ethjs-abi": true,
         "@metamask/controllers>eth-method-registry>ethjs>ethjs-contract": true,
         "@metamask/controllers>eth-method-registry>ethjs>ethjs-query": true,
+        "bn.js": true,
         "browserify>buffer": true,
         "ethjs>ethjs-filter": true,
         "ethjs>ethjs-provider-http": true,
@@ -663,7 +655,7 @@
     },
     "@metamask/controllers>eth-method-registry>ethjs>ethjs-abi": {
       "packages": {
-        "@metamask/controllers>eth-method-registry>ethjs>bn.js": true,
+        "bn.js": true,
         "browserify>buffer": true,
         "ethjs>js-sha3": true,
         "ethjs>number-to-bn": true
@@ -681,7 +673,7 @@
     },
     "@metamask/controllers>eth-method-registry>ethjs>ethjs-contract>ethjs-abi": {
       "packages": {
-        "@metamask/controllers>eth-method-registry>ethjs>bn.js": true,
+        "bn.js": true,
         "browserify>buffer": true,
         "ethjs>js-sha3": true,
         "ethjs>number-to-bn": true
@@ -1098,10 +1090,10 @@
         "setInterval": true
       },
       "packages": {
-        "@metamask/eth-token-tracker>ethjs>bn.js": true,
         "@metamask/eth-token-tracker>ethjs>ethjs-abi": true,
         "@metamask/eth-token-tracker>ethjs>ethjs-contract": true,
         "@metamask/eth-token-tracker>ethjs>ethjs-query": true,
+        "bn.js": true,
         "browserify>buffer": true,
         "ethjs>ethjs-filter": true,
         "ethjs>ethjs-provider-http": true,
@@ -1113,7 +1105,7 @@
     },
     "@metamask/eth-token-tracker>ethjs>ethjs-abi": {
       "packages": {
-        "@metamask/eth-token-tracker>ethjs>bn.js": true,
+        "bn.js": true,
         "browserify>buffer": true,
         "ethjs>js-sha3": true,
         "ethjs>number-to-bn": true
@@ -1131,7 +1123,7 @@
     },
     "@metamask/eth-token-tracker>ethjs>ethjs-contract>ethjs-abi": {
       "packages": {
-        "@metamask/eth-token-tracker>ethjs>bn.js": true,
+        "bn.js": true,
         "browserify>buffer": true,
         "ethjs>js-sha3": true,
         "ethjs>number-to-bn": true
@@ -1301,10 +1293,10 @@
         "setInterval": true
       },
       "packages": {
-        "@metamask/smart-transactions-controller>@metamask/controllers>eth-method-registry>ethjs>bn.js": true,
         "@metamask/smart-transactions-controller>@metamask/controllers>eth-method-registry>ethjs>ethjs-abi": true,
         "@metamask/smart-transactions-controller>@metamask/controllers>eth-method-registry>ethjs>ethjs-contract": true,
         "@metamask/smart-transactions-controller>@metamask/controllers>eth-method-registry>ethjs>ethjs-query": true,
+        "bn.js": true,
         "browserify>buffer": true,
         "ethjs>ethjs-filter": true,
         "ethjs>ethjs-provider-http": true,
@@ -1316,7 +1308,7 @@
     },
     "@metamask/smart-transactions-controller>@metamask/controllers>eth-method-registry>ethjs>ethjs-abi": {
       "packages": {
-        "@metamask/smart-transactions-controller>@metamask/controllers>eth-method-registry>ethjs>bn.js": true,
+        "bn.js": true,
         "browserify>buffer": true,
         "ethjs>js-sha3": true,
         "ethjs>number-to-bn": true
@@ -1334,7 +1326,7 @@
     },
     "@metamask/smart-transactions-controller>@metamask/controllers>eth-method-registry>ethjs>ethjs-contract>ethjs-abi": {
       "packages": {
-        "@metamask/smart-transactions-controller>@metamask/controllers>eth-method-registry>ethjs>bn.js": true,
+        "bn.js": true,
         "browserify>buffer": true,
         "ethjs>js-sha3": true,
         "ethjs>number-to-bn": true
@@ -1576,13 +1568,13 @@
         "@truffle/codec>@truffle/abi-utils": true,
         "@truffle/codec>@truffle/compile-common": true,
         "@truffle/codec>big.js": true,
-        "@truffle/codec>bn.js": true,
         "@truffle/codec>cbor": true,
         "@truffle/codec>lodash.escaperegexp": true,
         "@truffle/codec>lodash.partition": true,
         "@truffle/codec>lodash.sum": true,
         "@truffle/codec>utf8": true,
         "@truffle/codec>web3-utils": true,
+        "bn.js": true,
         "browserify>buffer": true,
         "browserify>util": true,
         "gulp-dart-sass>lodash.clonedeep": true,
@@ -1746,14 +1738,6 @@
         "define": true
       }
     },
-    "@truffle/codec>bn.js": {
-      "globals": {
-        "Buffer": true
-      },
-      "packages": {
-        "browserify>browser-resolve": true
-      }
-    },
     "@truffle/codec>cbor": {
       "globals": {
         "TextDecoder": true
@@ -1816,7 +1800,7 @@
         "@truffle/codec>@truffle/compile-common": true,
         "@truffle/codec>web3-utils": true,
         "@truffle/decoder>@truffle/source-map-utils": true,
-        "@truffle/decoder>bn.js": true,
+        "bn.js": true,
         "nock>debug": true
       }
     },
@@ -1844,14 +1828,6 @@
     "@truffle/decoder>@truffle/source-map-utils>node-interval-tree": {
       "packages": {
         "react-dnd>shallowequal": true
-      }
-    },
-    "@truffle/decoder>bn.js": {
-      "globals": {
-        "Buffer": true
-      },
-      "packages": {
-        "browserify>browser-resolve": true
       }
     },
     "@zxing/browser": {
@@ -2418,18 +2394,13 @@
     },
     "eth-json-rpc-middleware>@metamask/eth-sig-util": {
       "packages": {
+        "bn.js": true,
         "browserify>buffer": true,
-        "eth-json-rpc-middleware>@metamask/eth-sig-util>bn.js": true,
         "eth-json-rpc-middleware>@metamask/eth-sig-util>ethereum-cryptography": true,
         "eth-json-rpc-middleware>@metamask/eth-sig-util>ethjs-util": true,
         "eth-lattice-keyring>@ethereumjs/util": true,
         "eth-sig-util>tweetnacl": true,
         "eth-sig-util>tweetnacl-util": true
-      }
-    },
-    "eth-json-rpc-middleware>@metamask/eth-sig-util>bn.js": {
-      "packages": {
-        "browserify>browser-resolve": true
       }
     },
     "eth-json-rpc-middleware>@metamask/eth-sig-util>ethereum-cryptography": {
@@ -2563,12 +2534,12 @@
         "setInterval": true
       },
       "packages": {
+        "bn.js": true,
         "browserify>buffer": true,
         "browserify>crypto-browserify": true,
         "browserify>events": true,
         "eth-lattice-keyring>@ethereumjs/tx": true,
         "eth-lattice-keyring>@ethereumjs/util": true,
-        "eth-lattice-keyring>bn.js": true,
         "eth-lattice-keyring>gridplus-sdk": true,
         "eth-lattice-keyring>rlp": true
       }
@@ -2613,14 +2584,6 @@
     "eth-lattice-keyring>@ethereumjs/util>ethereum-cryptography>@noble/secp256k1": {
       "globals": {
         "crypto": true
-      },
-      "packages": {
-        "browserify>browser-resolve": true
-      }
-    },
-    "eth-lattice-keyring>bn.js": {
-      "globals": {
-        "Buffer": true
       },
       "packages": {
         "browserify>browser-resolve": true
@@ -2726,17 +2689,9 @@
         "intToBuffer": true
       },
       "packages": {
-        "eth-lattice-keyring>gridplus-sdk>eth-eip712-util-browser>bn.js": true,
+        "bn.js": true,
         "eth-lattice-keyring>gridplus-sdk>eth-eip712-util-browser>buffer": true,
         "eth-lattice-keyring>gridplus-sdk>eth-eip712-util-browser>js-sha3": true
-      }
-    },
-    "eth-lattice-keyring>gridplus-sdk>eth-eip712-util-browser>bn.js": {
-      "globals": {
-        "Buffer": true
-      },
-      "packages": {
-        "browserify>browser-resolve": true
       }
     },
     "eth-lattice-keyring>gridplus-sdk>eth-eip712-util-browser>buffer": {
@@ -2977,21 +2932,13 @@
     },
     "ethereumjs-util": {
       "packages": {
+        "bn.js": true,
         "browserify>assert": true,
         "browserify>buffer": true,
         "browserify>insert-module-globals>is-buffer": true,
-        "ethereumjs-util>bn.js": true,
         "ethereumjs-util>create-hash": true,
         "ethereumjs-util>ethereum-cryptography": true,
         "ethereumjs-util>rlp": true
-      }
-    },
-    "ethereumjs-util>bn.js": {
-      "globals": {
-        "Buffer": true
-      },
-      "packages": {
-        "browserify>browser-resolve": true
       }
     },
     "ethereumjs-util>create-hash": {
@@ -3095,16 +3042,8 @@
     },
     "ethereumjs-util>rlp": {
       "packages": {
-        "browserify>buffer": true,
-        "ethereumjs-util>rlp>bn.js": true
-      }
-    },
-    "ethereumjs-util>rlp>bn.js": {
-      "globals": {
-        "Buffer": true
-      },
-      "packages": {
-        "browserify>browser-resolve": true
+        "bn.js": true,
+        "browserify>buffer": true
       }
     },
     "ethereumjs-wallet": {
@@ -3252,17 +3191,9 @@
     },
     "ethers>@ethersproject/abi>@ethersproject/bignumber": {
       "packages": {
-        "ethers>@ethersproject/abi>@ethersproject/bignumber>bn.js": true,
+        "bn.js": true,
         "ethers>@ethersproject/abi>@ethersproject/bytes": true,
         "ethers>@ethersproject/abi>@ethersproject/logger": true
-      }
-    },
-    "ethers>@ethersproject/abi>@ethersproject/bignumber>bn.js": {
-      "globals": {
-        "Buffer": true
-      },
-      "packages": {
-        "browserify>browser-resolve": true
       }
     },
     "ethers>@ethersproject/abi>@ethersproject/bytes": {
@@ -3325,17 +3256,9 @@
     },
     "ethers>@ethersproject/address>@ethersproject/bignumber": {
       "packages": {
-        "ethers>@ethersproject/address>@ethersproject/bignumber>bn.js": true,
+        "bn.js": true,
         "ethers>@ethersproject/address>@ethersproject/bytes": true,
         "ethers>@ethersproject/address>@ethersproject/logger": true
-      }
-    },
-    "ethers>@ethersproject/address>@ethersproject/bignumber>bn.js": {
-      "globals": {
-        "Buffer": true
-      },
-      "packages": {
-        "browserify>browser-resolve": true
       }
     },
     "ethers>@ethersproject/address>@ethersproject/bytes": {
@@ -3434,9 +3357,9 @@
     },
     "ethers>@ethersproject/constants>@ethersproject/bignumber": {
       "packages": {
+        "bn.js": true,
         "ethers>@ethersproject/constants>@ethersproject/bignumber>@ethersproject/bytes": true,
-        "ethers>@ethersproject/constants>@ethersproject/bignumber>@ethersproject/logger": true,
-        "ethers>@ethersproject/constants>@ethersproject/bignumber>bn.js": true
+        "ethers>@ethersproject/constants>@ethersproject/bignumber>@ethersproject/logger": true
       }
     },
     "ethers>@ethersproject/constants>@ethersproject/bignumber>@ethersproject/bytes": {
@@ -3447,14 +3370,6 @@
     "ethers>@ethersproject/constants>@ethersproject/bignumber>@ethersproject/logger": {
       "globals": {
         "console": true
-      }
-    },
-    "ethers>@ethersproject/constants>@ethersproject/bignumber>bn.js": {
-      "globals": {
-        "Buffer": true
-      },
-      "packages": {
-        "browserify>browser-resolve": true
       }
     },
     "ethers>@ethersproject/contracts": {
@@ -3533,17 +3448,9 @@
     },
     "ethers>@ethersproject/contracts>@ethersproject/bignumber": {
       "packages": {
-        "ethers>@ethersproject/contracts>@ethersproject/bignumber>bn.js": true,
+        "bn.js": true,
         "ethers>@ethersproject/contracts>@ethersproject/bytes": true,
         "ethers>@ethersproject/contracts>@ethersproject/logger": true
-      }
-    },
-    "ethers>@ethersproject/contracts>@ethersproject/bignumber>bn.js": {
-      "globals": {
-        "Buffer": true
-      },
-      "packages": {
-        "browserify>browser-resolve": true
       }
     },
     "ethers>@ethersproject/contracts>@ethersproject/bytes": {
@@ -3814,17 +3721,9 @@
     },
     "ethers>@ethersproject/providers>@ethersproject/bignumber": {
       "packages": {
-        "ethers>@ethersproject/providers>@ethersproject/bignumber>bn.js": true,
+        "bn.js": true,
         "ethers>@ethersproject/providers>@ethersproject/bytes": true,
         "ethers>@ethersproject/providers>@ethersproject/logger": true
-      }
-    },
-    "ethers>@ethersproject/providers>@ethersproject/bignumber>bn.js": {
-      "globals": {
-        "Buffer": true
-      },
-      "packages": {
-        "browserify>browser-resolve": true
       }
     },
     "ethers>@ethersproject/providers>@ethersproject/bytes": {
@@ -4059,17 +3958,9 @@
     },
     "ethers>@ethersproject/strings>@ethersproject/constants>@ethersproject/bignumber": {
       "packages": {
+        "bn.js": true,
         "ethers>@ethersproject/strings>@ethersproject/bytes": true,
-        "ethers>@ethersproject/strings>@ethersproject/constants>@ethersproject/bignumber>bn.js": true,
         "ethers>@ethersproject/strings>@ethersproject/logger": true
-      }
-    },
-    "ethers>@ethersproject/strings>@ethersproject/constants>@ethersproject/bignumber>bn.js": {
-      "globals": {
-        "Buffer": true
-      },
-      "packages": {
-        "browserify>browser-resolve": true
       }
     },
     "ethers>@ethersproject/strings>@ethersproject/logger": {
@@ -4104,17 +3995,9 @@
     },
     "ethers>@ethersproject/transactions>@ethersproject/bignumber": {
       "packages": {
-        "ethers>@ethersproject/transactions>@ethersproject/bignumber>bn.js": true,
+        "bn.js": true,
         "ethers>@ethersproject/transactions>@ethersproject/bytes": true,
         "ethers>@ethersproject/transactions>@ethersproject/logger": true
-      }
-    },
-    "ethers>@ethersproject/transactions>@ethersproject/bignumber>bn.js": {
-      "globals": {
-        "Buffer": true
-      },
-      "packages": {
-        "browserify>browser-resolve": true
       }
     },
     "ethers>@ethersproject/transactions>@ethersproject/bytes": {
@@ -4264,17 +4147,9 @@
     },
     "ethers>@ethersproject/web>@ethersproject/strings>@ethersproject/constants>@ethersproject/bignumber": {
       "packages": {
+        "bn.js": true,
         "ethers>@ethersproject/web>@ethersproject/bytes": true,
-        "ethers>@ethersproject/web>@ethersproject/logger": true,
-        "ethers>@ethersproject/web>@ethersproject/strings>@ethersproject/constants>@ethersproject/bignumber>bn.js": true
-      }
-    },
-    "ethers>@ethersproject/web>@ethersproject/strings>@ethersproject/constants>@ethersproject/bignumber>bn.js": {
-      "globals": {
-        "Buffer": true
-      },
-      "packages": {
-        "browserify>browser-resolve": true
+        "ethers>@ethersproject/web>@ethersproject/logger": true
       }
     },
     "ethers>@ethersproject/wordlists": {
@@ -4292,10 +4167,10 @@
         "setInterval": true
       },
       "packages": {
+        "bn.js": true,
         "browserify>buffer": true,
         "ethjs-contract": true,
         "ethjs-query": true,
-        "ethjs>bn.js": true,
         "ethjs>ethjs-abi": true,
         "ethjs>ethjs-filter": true,
         "ethjs>ethjs-provider-http": true,
@@ -4317,8 +4192,8 @@
     },
     "ethjs-contract>ethjs-abi": {
       "packages": {
+        "bn.js": true,
         "browserify>buffer": true,
-        "ethjs-contract>ethjs-abi>bn.js": true,
         "ethjs>js-sha3": true,
         "ethjs>number-to-bn": true
       }
@@ -4365,8 +4240,8 @@
     },
     "ethjs>ethjs-abi": {
       "packages": {
+        "bn.js": true,
         "browserify>buffer": true,
-        "ethjs>bn.js": true,
         "ethjs>js-sha3": true,
         "ethjs>number-to-bn": true
       }
@@ -4389,7 +4264,7 @@
     },
     "ethjs>ethjs-unit": {
       "packages": {
-        "ethjs>ethjs-unit>bn.js": true,
+        "bn.js": true,
         "ethjs>number-to-bn": true
       }
     },
@@ -4412,8 +4287,8 @@
     },
     "ethjs>number-to-bn": {
       "packages": {
-        "ethjs>ethjs-util>strip-hex-prefix": true,
-        "ethjs>number-to-bn>bn.js": true
+        "bn.js": true,
+        "ethjs>ethjs-util>strip-hex-prefix": true
       }
     },
     "extension-port-stream": {

--- a/lavamoat/browserify/flask/policy.json
+++ b/lavamoat/browserify/flask/policy.json
@@ -306,7 +306,7 @@
       "packages": {
         "@ethersproject/bignumber>@ethersproject/bytes": true,
         "@ethersproject/bignumber>@ethersproject/logger": true,
-        "@ethersproject/bignumber>bn.js": true
+        "bn.js": true
       }
     },
     "@ethersproject/bignumber>@ethersproject/bytes": {
@@ -317,14 +317,6 @@
     "@ethersproject/bignumber>@ethersproject/logger": {
       "globals": {
         "console": true
-      }
-    },
-    "@ethersproject/bignumber>bn.js": {
-      "globals": {
-        "Buffer": true
-      },
-      "packages": {
-        "browserify>browser-resolve": true
       }
     },
     "@formatjs/intl-relativetimeformat": {
@@ -793,10 +785,10 @@
         "setInterval": true
       },
       "packages": {
-        "@metamask/controllers>eth-method-registry>ethjs>bn.js": true,
         "@metamask/controllers>eth-method-registry>ethjs>ethjs-abi": true,
         "@metamask/controllers>eth-method-registry>ethjs>ethjs-contract": true,
         "@metamask/controllers>eth-method-registry>ethjs>ethjs-query": true,
+        "bn.js": true,
         "browserify>buffer": true,
         "ethjs>ethjs-filter": true,
         "ethjs>ethjs-provider-http": true,
@@ -808,7 +800,7 @@
     },
     "@metamask/controllers>eth-method-registry>ethjs>ethjs-abi": {
       "packages": {
-        "@metamask/controllers>eth-method-registry>ethjs>bn.js": true,
+        "bn.js": true,
         "browserify>buffer": true,
         "ethjs>js-sha3": true,
         "ethjs>number-to-bn": true
@@ -826,7 +818,7 @@
     },
     "@metamask/controllers>eth-method-registry>ethjs>ethjs-contract>ethjs-abi": {
       "packages": {
-        "@metamask/controllers>eth-method-registry>ethjs>bn.js": true,
+        "bn.js": true,
         "browserify>buffer": true,
         "ethjs>js-sha3": true,
         "ethjs>number-to-bn": true
@@ -1243,10 +1235,10 @@
         "setInterval": true
       },
       "packages": {
-        "@metamask/eth-token-tracker>ethjs>bn.js": true,
         "@metamask/eth-token-tracker>ethjs>ethjs-abi": true,
         "@metamask/eth-token-tracker>ethjs>ethjs-contract": true,
         "@metamask/eth-token-tracker>ethjs>ethjs-query": true,
+        "bn.js": true,
         "browserify>buffer": true,
         "ethjs>ethjs-filter": true,
         "ethjs>ethjs-provider-http": true,
@@ -1258,7 +1250,7 @@
     },
     "@metamask/eth-token-tracker>ethjs>ethjs-abi": {
       "packages": {
-        "@metamask/eth-token-tracker>ethjs>bn.js": true,
+        "bn.js": true,
         "browserify>buffer": true,
         "ethjs>js-sha3": true,
         "ethjs>number-to-bn": true
@@ -1276,7 +1268,7 @@
     },
     "@metamask/eth-token-tracker>ethjs>ethjs-contract>ethjs-abi": {
       "packages": {
-        "@metamask/eth-token-tracker>ethjs>bn.js": true,
+        "bn.js": true,
         "browserify>buffer": true,
         "ethjs>js-sha3": true,
         "ethjs>number-to-bn": true
@@ -1447,10 +1439,10 @@
         "setInterval": true
       },
       "packages": {
-        "@metamask/rpc-methods>@metamask/controllers>eth-method-registry>ethjs>bn.js": true,
         "@metamask/rpc-methods>@metamask/controllers>eth-method-registry>ethjs>ethjs-abi": true,
         "@metamask/rpc-methods>@metamask/controllers>eth-method-registry>ethjs>ethjs-contract": true,
         "@metamask/rpc-methods>@metamask/controllers>eth-method-registry>ethjs>ethjs-query": true,
+        "bn.js": true,
         "browserify>buffer": true,
         "ethjs>ethjs-filter": true,
         "ethjs>ethjs-provider-http": true,
@@ -1462,7 +1454,7 @@
     },
     "@metamask/rpc-methods>@metamask/controllers>eth-method-registry>ethjs>ethjs-abi": {
       "packages": {
-        "@metamask/rpc-methods>@metamask/controllers>eth-method-registry>ethjs>bn.js": true,
+        "bn.js": true,
         "browserify>buffer": true,
         "ethjs>js-sha3": true,
         "ethjs>number-to-bn": true
@@ -1480,7 +1472,7 @@
     },
     "@metamask/rpc-methods>@metamask/controllers>eth-method-registry>ethjs>ethjs-contract>ethjs-abi": {
       "packages": {
-        "@metamask/rpc-methods>@metamask/controllers>eth-method-registry>ethjs>bn.js": true,
+        "bn.js": true,
         "browserify>buffer": true,
         "ethjs>js-sha3": true,
         "ethjs>number-to-bn": true
@@ -1633,10 +1625,10 @@
         "setInterval": true
       },
       "packages": {
-        "@metamask/smart-transactions-controller>@metamask/controllers>eth-method-registry>ethjs>bn.js": true,
         "@metamask/smart-transactions-controller>@metamask/controllers>eth-method-registry>ethjs>ethjs-abi": true,
         "@metamask/smart-transactions-controller>@metamask/controllers>eth-method-registry>ethjs>ethjs-contract": true,
         "@metamask/smart-transactions-controller>@metamask/controllers>eth-method-registry>ethjs>ethjs-query": true,
+        "bn.js": true,
         "browserify>buffer": true,
         "ethjs>ethjs-filter": true,
         "ethjs>ethjs-provider-http": true,
@@ -1648,7 +1640,7 @@
     },
     "@metamask/smart-transactions-controller>@metamask/controllers>eth-method-registry>ethjs>ethjs-abi": {
       "packages": {
-        "@metamask/smart-transactions-controller>@metamask/controllers>eth-method-registry>ethjs>bn.js": true,
+        "bn.js": true,
         "browserify>buffer": true,
         "ethjs>js-sha3": true,
         "ethjs>number-to-bn": true
@@ -1666,7 +1658,7 @@
     },
     "@metamask/smart-transactions-controller>@metamask/controllers>eth-method-registry>ethjs>ethjs-contract>ethjs-abi": {
       "packages": {
-        "@metamask/smart-transactions-controller>@metamask/controllers>eth-method-registry>ethjs>bn.js": true,
+        "bn.js": true,
         "browserify>buffer": true,
         "ethjs>js-sha3": true,
         "ethjs>number-to-bn": true
@@ -1830,10 +1822,10 @@
         "setInterval": true
       },
       "packages": {
-        "@metamask/snap-controllers>@metamask/controllers>eth-method-registry>ethjs>bn.js": true,
         "@metamask/snap-controllers>@metamask/controllers>eth-method-registry>ethjs>ethjs-abi": true,
         "@metamask/snap-controllers>@metamask/controllers>eth-method-registry>ethjs>ethjs-contract": true,
         "@metamask/snap-controllers>@metamask/controllers>eth-method-registry>ethjs>ethjs-query": true,
+        "bn.js": true,
         "browserify>buffer": true,
         "ethjs>ethjs-filter": true,
         "ethjs>ethjs-provider-http": true,
@@ -1845,7 +1837,7 @@
     },
     "@metamask/snap-controllers>@metamask/controllers>eth-method-registry>ethjs>ethjs-abi": {
       "packages": {
-        "@metamask/snap-controllers>@metamask/controllers>eth-method-registry>ethjs>bn.js": true,
+        "bn.js": true,
         "browserify>buffer": true,
         "ethjs>js-sha3": true,
         "ethjs>number-to-bn": true
@@ -1863,7 +1855,7 @@
     },
     "@metamask/snap-controllers>@metamask/controllers>eth-method-registry>ethjs>ethjs-contract>ethjs-abi": {
       "packages": {
-        "@metamask/snap-controllers>@metamask/controllers>eth-method-registry>ethjs>bn.js": true,
+        "bn.js": true,
         "browserify>buffer": true,
         "ethjs>js-sha3": true,
         "ethjs>number-to-bn": true
@@ -2344,13 +2336,13 @@
         "@truffle/codec>@truffle/abi-utils": true,
         "@truffle/codec>@truffle/compile-common": true,
         "@truffle/codec>big.js": true,
-        "@truffle/codec>bn.js": true,
         "@truffle/codec>cbor": true,
         "@truffle/codec>lodash.escaperegexp": true,
         "@truffle/codec>lodash.partition": true,
         "@truffle/codec>lodash.sum": true,
         "@truffle/codec>utf8": true,
         "@truffle/codec>web3-utils": true,
+        "bn.js": true,
         "browserify>buffer": true,
         "browserify>util": true,
         "gulp-dart-sass>lodash.clonedeep": true,
@@ -2514,14 +2506,6 @@
         "define": true
       }
     },
-    "@truffle/codec>bn.js": {
-      "globals": {
-        "Buffer": true
-      },
-      "packages": {
-        "browserify>browser-resolve": true
-      }
-    },
     "@truffle/codec>cbor": {
       "globals": {
         "TextDecoder": true
@@ -2584,7 +2568,7 @@
         "@truffle/codec>@truffle/compile-common": true,
         "@truffle/codec>web3-utils": true,
         "@truffle/decoder>@truffle/source-map-utils": true,
-        "@truffle/decoder>bn.js": true,
+        "bn.js": true,
         "nock>debug": true
       }
     },
@@ -2612,14 +2596,6 @@
     "@truffle/decoder>@truffle/source-map-utils>node-interval-tree": {
       "packages": {
         "react-dnd>shallowequal": true
-      }
-    },
-    "@truffle/decoder>bn.js": {
-      "globals": {
-        "Buffer": true
-      },
-      "packages": {
-        "browserify>browser-resolve": true
       }
     },
     "@zxing/browser": {
@@ -3220,18 +3196,13 @@
     },
     "eth-json-rpc-middleware>@metamask/eth-sig-util": {
       "packages": {
+        "bn.js": true,
         "browserify>buffer": true,
-        "eth-json-rpc-middleware>@metamask/eth-sig-util>bn.js": true,
         "eth-json-rpc-middleware>@metamask/eth-sig-util>ethereum-cryptography": true,
         "eth-json-rpc-middleware>@metamask/eth-sig-util>ethjs-util": true,
         "eth-lattice-keyring>@ethereumjs/util": true,
         "eth-sig-util>tweetnacl": true,
         "eth-sig-util>tweetnacl-util": true
-      }
-    },
-    "eth-json-rpc-middleware>@metamask/eth-sig-util>bn.js": {
-      "packages": {
-        "browserify>browser-resolve": true
       }
     },
     "eth-json-rpc-middleware>@metamask/eth-sig-util>ethereum-cryptography": {
@@ -3365,12 +3336,12 @@
         "setInterval": true
       },
       "packages": {
+        "bn.js": true,
         "browserify>buffer": true,
         "browserify>crypto-browserify": true,
         "browserify>events": true,
         "eth-lattice-keyring>@ethereumjs/tx": true,
         "eth-lattice-keyring>@ethereumjs/util": true,
-        "eth-lattice-keyring>bn.js": true,
         "eth-lattice-keyring>gridplus-sdk": true,
         "eth-lattice-keyring>rlp": true
       }
@@ -3415,14 +3386,6 @@
     "eth-lattice-keyring>@ethereumjs/util>ethereum-cryptography>@noble/secp256k1": {
       "globals": {
         "crypto": true
-      },
-      "packages": {
-        "browserify>browser-resolve": true
-      }
-    },
-    "eth-lattice-keyring>bn.js": {
-      "globals": {
-        "Buffer": true
       },
       "packages": {
         "browserify>browser-resolve": true
@@ -3528,17 +3491,9 @@
         "intToBuffer": true
       },
       "packages": {
-        "eth-lattice-keyring>gridplus-sdk>eth-eip712-util-browser>bn.js": true,
+        "bn.js": true,
         "eth-lattice-keyring>gridplus-sdk>eth-eip712-util-browser>buffer": true,
         "eth-lattice-keyring>gridplus-sdk>eth-eip712-util-browser>js-sha3": true
-      }
-    },
-    "eth-lattice-keyring>gridplus-sdk>eth-eip712-util-browser>bn.js": {
-      "globals": {
-        "Buffer": true
-      },
-      "packages": {
-        "browserify>browser-resolve": true
       }
     },
     "eth-lattice-keyring>gridplus-sdk>eth-eip712-util-browser>buffer": {
@@ -3779,21 +3734,13 @@
     },
     "ethereumjs-util": {
       "packages": {
+        "bn.js": true,
         "browserify>assert": true,
         "browserify>buffer": true,
         "browserify>insert-module-globals>is-buffer": true,
-        "ethereumjs-util>bn.js": true,
         "ethereumjs-util>create-hash": true,
         "ethereumjs-util>ethereum-cryptography": true,
         "ethereumjs-util>rlp": true
-      }
-    },
-    "ethereumjs-util>bn.js": {
-      "globals": {
-        "Buffer": true
-      },
-      "packages": {
-        "browserify>browser-resolve": true
       }
     },
     "ethereumjs-util>create-hash": {
@@ -3897,16 +3844,8 @@
     },
     "ethereumjs-util>rlp": {
       "packages": {
-        "browserify>buffer": true,
-        "ethereumjs-util>rlp>bn.js": true
-      }
-    },
-    "ethereumjs-util>rlp>bn.js": {
-      "globals": {
-        "Buffer": true
-      },
-      "packages": {
-        "browserify>browser-resolve": true
+        "bn.js": true,
+        "browserify>buffer": true
       }
     },
     "ethereumjs-wallet": {
@@ -4054,17 +3993,9 @@
     },
     "ethers>@ethersproject/abi>@ethersproject/bignumber": {
       "packages": {
-        "ethers>@ethersproject/abi>@ethersproject/bignumber>bn.js": true,
+        "bn.js": true,
         "ethers>@ethersproject/abi>@ethersproject/bytes": true,
         "ethers>@ethersproject/abi>@ethersproject/logger": true
-      }
-    },
-    "ethers>@ethersproject/abi>@ethersproject/bignumber>bn.js": {
-      "globals": {
-        "Buffer": true
-      },
-      "packages": {
-        "browserify>browser-resolve": true
       }
     },
     "ethers>@ethersproject/abi>@ethersproject/bytes": {
@@ -4127,17 +4058,9 @@
     },
     "ethers>@ethersproject/address>@ethersproject/bignumber": {
       "packages": {
-        "ethers>@ethersproject/address>@ethersproject/bignumber>bn.js": true,
+        "bn.js": true,
         "ethers>@ethersproject/address>@ethersproject/bytes": true,
         "ethers>@ethersproject/address>@ethersproject/logger": true
-      }
-    },
-    "ethers>@ethersproject/address>@ethersproject/bignumber>bn.js": {
-      "globals": {
-        "Buffer": true
-      },
-      "packages": {
-        "browserify>browser-resolve": true
       }
     },
     "ethers>@ethersproject/address>@ethersproject/bytes": {
@@ -4236,9 +4159,9 @@
     },
     "ethers>@ethersproject/constants>@ethersproject/bignumber": {
       "packages": {
+        "bn.js": true,
         "ethers>@ethersproject/constants>@ethersproject/bignumber>@ethersproject/bytes": true,
-        "ethers>@ethersproject/constants>@ethersproject/bignumber>@ethersproject/logger": true,
-        "ethers>@ethersproject/constants>@ethersproject/bignumber>bn.js": true
+        "ethers>@ethersproject/constants>@ethersproject/bignumber>@ethersproject/logger": true
       }
     },
     "ethers>@ethersproject/constants>@ethersproject/bignumber>@ethersproject/bytes": {
@@ -4249,14 +4172,6 @@
     "ethers>@ethersproject/constants>@ethersproject/bignumber>@ethersproject/logger": {
       "globals": {
         "console": true
-      }
-    },
-    "ethers>@ethersproject/constants>@ethersproject/bignumber>bn.js": {
-      "globals": {
-        "Buffer": true
-      },
-      "packages": {
-        "browserify>browser-resolve": true
       }
     },
     "ethers>@ethersproject/contracts": {
@@ -4335,17 +4250,9 @@
     },
     "ethers>@ethersproject/contracts>@ethersproject/bignumber": {
       "packages": {
-        "ethers>@ethersproject/contracts>@ethersproject/bignumber>bn.js": true,
+        "bn.js": true,
         "ethers>@ethersproject/contracts>@ethersproject/bytes": true,
         "ethers>@ethersproject/contracts>@ethersproject/logger": true
-      }
-    },
-    "ethers>@ethersproject/contracts>@ethersproject/bignumber>bn.js": {
-      "globals": {
-        "Buffer": true
-      },
-      "packages": {
-        "browserify>browser-resolve": true
       }
     },
     "ethers>@ethersproject/contracts>@ethersproject/bytes": {
@@ -4616,17 +4523,9 @@
     },
     "ethers>@ethersproject/providers>@ethersproject/bignumber": {
       "packages": {
-        "ethers>@ethersproject/providers>@ethersproject/bignumber>bn.js": true,
+        "bn.js": true,
         "ethers>@ethersproject/providers>@ethersproject/bytes": true,
         "ethers>@ethersproject/providers>@ethersproject/logger": true
-      }
-    },
-    "ethers>@ethersproject/providers>@ethersproject/bignumber>bn.js": {
-      "globals": {
-        "Buffer": true
-      },
-      "packages": {
-        "browserify>browser-resolve": true
       }
     },
     "ethers>@ethersproject/providers>@ethersproject/bytes": {
@@ -4861,17 +4760,9 @@
     },
     "ethers>@ethersproject/strings>@ethersproject/constants>@ethersproject/bignumber": {
       "packages": {
+        "bn.js": true,
         "ethers>@ethersproject/strings>@ethersproject/bytes": true,
-        "ethers>@ethersproject/strings>@ethersproject/constants>@ethersproject/bignumber>bn.js": true,
         "ethers>@ethersproject/strings>@ethersproject/logger": true
-      }
-    },
-    "ethers>@ethersproject/strings>@ethersproject/constants>@ethersproject/bignumber>bn.js": {
-      "globals": {
-        "Buffer": true
-      },
-      "packages": {
-        "browserify>browser-resolve": true
       }
     },
     "ethers>@ethersproject/strings>@ethersproject/logger": {
@@ -4906,17 +4797,9 @@
     },
     "ethers>@ethersproject/transactions>@ethersproject/bignumber": {
       "packages": {
-        "ethers>@ethersproject/transactions>@ethersproject/bignumber>bn.js": true,
+        "bn.js": true,
         "ethers>@ethersproject/transactions>@ethersproject/bytes": true,
         "ethers>@ethersproject/transactions>@ethersproject/logger": true
-      }
-    },
-    "ethers>@ethersproject/transactions>@ethersproject/bignumber>bn.js": {
-      "globals": {
-        "Buffer": true
-      },
-      "packages": {
-        "browserify>browser-resolve": true
       }
     },
     "ethers>@ethersproject/transactions>@ethersproject/bytes": {
@@ -5066,17 +4949,9 @@
     },
     "ethers>@ethersproject/web>@ethersproject/strings>@ethersproject/constants>@ethersproject/bignumber": {
       "packages": {
+        "bn.js": true,
         "ethers>@ethersproject/web>@ethersproject/bytes": true,
-        "ethers>@ethersproject/web>@ethersproject/logger": true,
-        "ethers>@ethersproject/web>@ethersproject/strings>@ethersproject/constants>@ethersproject/bignumber>bn.js": true
-      }
-    },
-    "ethers>@ethersproject/web>@ethersproject/strings>@ethersproject/constants>@ethersproject/bignumber>bn.js": {
-      "globals": {
-        "Buffer": true
-      },
-      "packages": {
-        "browserify>browser-resolve": true
+        "ethers>@ethersproject/web>@ethersproject/logger": true
       }
     },
     "ethers>@ethersproject/wordlists": {
@@ -5094,10 +4969,10 @@
         "setInterval": true
       },
       "packages": {
+        "bn.js": true,
         "browserify>buffer": true,
         "ethjs-contract": true,
         "ethjs-query": true,
-        "ethjs>bn.js": true,
         "ethjs>ethjs-abi": true,
         "ethjs>ethjs-filter": true,
         "ethjs>ethjs-provider-http": true,
@@ -5119,8 +4994,8 @@
     },
     "ethjs-contract>ethjs-abi": {
       "packages": {
+        "bn.js": true,
         "browserify>buffer": true,
-        "ethjs-contract>ethjs-abi>bn.js": true,
         "ethjs>js-sha3": true,
         "ethjs>number-to-bn": true
       }
@@ -5167,8 +5042,8 @@
     },
     "ethjs>ethjs-abi": {
       "packages": {
+        "bn.js": true,
         "browserify>buffer": true,
-        "ethjs>bn.js": true,
         "ethjs>js-sha3": true,
         "ethjs>number-to-bn": true
       }
@@ -5191,7 +5066,7 @@
     },
     "ethjs>ethjs-unit": {
       "packages": {
-        "ethjs>ethjs-unit>bn.js": true,
+        "bn.js": true,
         "ethjs>number-to-bn": true
       }
     },
@@ -5214,8 +5089,8 @@
     },
     "ethjs>number-to-bn": {
       "packages": {
-        "ethjs>ethjs-util>strip-hex-prefix": true,
-        "ethjs>number-to-bn>bn.js": true
+        "bn.js": true,
+        "ethjs>ethjs-util>strip-hex-prefix": true
       }
     },
     "extension-port-stream": {

--- a/lavamoat/browserify/flask/policy.json
+++ b/lavamoat/browserify/flask/policy.json
@@ -271,13 +271,13 @@
         "@ethersproject/bignumber": true,
         "@ethersproject/bignumber>@ethersproject/bytes": true,
         "@ethersproject/bignumber>@ethersproject/logger": true,
-        "ethers>@ethersproject/wallet>@ethersproject/properties": true
+        "ethers>@ethersproject/hash>@ethersproject/properties": true
       }
     },
     "@eth-optimism/contracts>@ethersproject/abstract-signer": {
       "packages": {
         "@ethersproject/bignumber>@ethersproject/logger": true,
-        "ethers>@ethersproject/wallet>@ethersproject/properties": true
+        "ethers>@ethersproject/hash>@ethersproject/properties": true
       }
     },
     "@ethereumjs/common": {
@@ -657,12 +657,12 @@
         "@ethersproject/bignumber": true,
         "@ethersproject/bignumber>@ethersproject/bytes": true,
         "@ethersproject/bignumber>@ethersproject/logger": true,
-        "ethers>@ethersproject/hdnode>@ethersproject/strings": true,
-        "ethers>@ethersproject/units>@ethersproject/constants": true,
-        "ethers>@ethersproject/wallet>@ethersproject/address": true,
-        "ethers>@ethersproject/wallet>@ethersproject/hash": true,
-        "ethers>@ethersproject/wallet>@ethersproject/keccak256": true,
-        "ethers>@ethersproject/wallet>@ethersproject/properties": true
+        "ethers>@ethersproject/hash": true,
+        "ethers>@ethersproject/hash>@ethersproject/address": true,
+        "ethers>@ethersproject/hash>@ethersproject/keccak256": true,
+        "ethers>@ethersproject/hash>@ethersproject/properties": true,
+        "ethers>@ethersproject/hash>@ethersproject/strings": true,
+        "ethers>@ethersproject/units>@ethersproject/constants": true
       }
     },
     "@metamask/controllers>@ethersproject/contracts": {
@@ -676,8 +676,8 @@
         "@ethersproject/bignumber>@ethersproject/bytes": true,
         "@ethersproject/bignumber>@ethersproject/logger": true,
         "@metamask/controllers>@ethersproject/abi": true,
-        "ethers>@ethersproject/wallet>@ethersproject/address": true,
-        "ethers>@ethersproject/wallet>@ethersproject/properties": true,
+        "ethers>@ethersproject/hash>@ethersproject/address": true,
+        "ethers>@ethersproject/hash>@ethersproject/properties": true,
         "ethers>@ethersproject/wallet>@ethersproject/transactions": true
       }
     },
@@ -697,28 +697,19 @@
         "@ethersproject/bignumber": true,
         "@ethersproject/bignumber>@ethersproject/bytes": true,
         "@ethersproject/bignumber>@ethersproject/logger": true,
-        "@metamask/controllers>@ethersproject/providers>@ethersproject/base64": true,
         "@metamask/controllers>@ethersproject/providers>@ethersproject/networks": true,
         "@metamask/controllers>@ethersproject/providers>@ethersproject/web": true,
+        "ethers>@ethersproject/hash": true,
+        "ethers>@ethersproject/hash>@ethersproject/address": true,
+        "ethers>@ethersproject/hash>@ethersproject/base64": true,
+        "ethers>@ethersproject/hash>@ethersproject/properties": true,
+        "ethers>@ethersproject/hash>@ethersproject/strings": true,
         "ethers>@ethersproject/hdnode>@ethersproject/basex": true,
-        "ethers>@ethersproject/hdnode>@ethersproject/strings": true,
         "ethers>@ethersproject/pbkdf2>@ethersproject/sha2": true,
         "ethers>@ethersproject/providers>bech32": true,
         "ethers>@ethersproject/units>@ethersproject/constants": true,
-        "ethers>@ethersproject/wallet>@ethersproject/address": true,
-        "ethers>@ethersproject/wallet>@ethersproject/hash": true,
-        "ethers>@ethersproject/wallet>@ethersproject/properties": true,
         "ethers>@ethersproject/wallet>@ethersproject/random": true,
         "ethers>@ethersproject/wallet>@ethersproject/transactions": true
-      }
-    },
-    "@metamask/controllers>@ethersproject/providers>@ethersproject/base64": {
-      "globals": {
-        "atob": true,
-        "btoa": true
-      },
-      "packages": {
-        "@ethersproject/bignumber>@ethersproject/bytes": true
       }
     },
     "@metamask/controllers>@ethersproject/providers>@ethersproject/networks": {
@@ -741,9 +732,9 @@
       "packages": {
         "@ethersproject/bignumber>@ethersproject/bytes": true,
         "@ethersproject/bignumber>@ethersproject/logger": true,
-        "@metamask/controllers>@ethersproject/providers>@ethersproject/base64": true,
-        "ethers>@ethersproject/hdnode>@ethersproject/strings": true,
-        "ethers>@ethersproject/wallet>@ethersproject/properties": true
+        "ethers>@ethersproject/hash>@ethersproject/base64": true,
+        "ethers>@ethersproject/hash>@ethersproject/properties": true,
+        "ethers>@ethersproject/hash>@ethersproject/strings": true
       }
     },
     "@metamask/controllers>abort-controller": {
@@ -4039,11 +4030,11 @@
         "ethers>@ethersproject/abi>@ethersproject/bignumber": true,
         "ethers>@ethersproject/abi>@ethersproject/bytes": true,
         "ethers>@ethersproject/abi>@ethersproject/constants": true,
-        "ethers>@ethersproject/abi>@ethersproject/hash": true,
         "ethers>@ethersproject/abi>@ethersproject/keccak256": true,
         "ethers>@ethersproject/abi>@ethersproject/logger": true,
         "ethers>@ethersproject/abi>@ethersproject/properties": true,
-        "ethers>@ethersproject/abi>@ethersproject/strings": true
+        "ethers>@ethersproject/abi>@ethersproject/strings": true,
+        "ethers>@ethersproject/hash": true
       }
     },
     "ethers>@ethersproject/abi>@ethersproject/address": {
@@ -4084,27 +4075,6 @@
     "ethers>@ethersproject/abi>@ethersproject/constants": {
       "packages": {
         "ethers>@ethersproject/abi>@ethersproject/bignumber": true
-      }
-    },
-    "ethers>@ethersproject/abi>@ethersproject/hash": {
-      "packages": {
-        "ethers>@ethersproject/abi>@ethersproject/address": true,
-        "ethers>@ethersproject/abi>@ethersproject/bignumber": true,
-        "ethers>@ethersproject/abi>@ethersproject/bytes": true,
-        "ethers>@ethersproject/abi>@ethersproject/hash>@ethersproject/base64": true,
-        "ethers>@ethersproject/abi>@ethersproject/keccak256": true,
-        "ethers>@ethersproject/abi>@ethersproject/logger": true,
-        "ethers>@ethersproject/abi>@ethersproject/properties": true,
-        "ethers>@ethersproject/abi>@ethersproject/strings": true
-      }
-    },
-    "ethers>@ethersproject/abi>@ethersproject/hash>@ethersproject/base64": {
-      "globals": {
-        "atob": true,
-        "btoa": true
-      },
-      "packages": {
-        "ethers>@ethersproject/abi>@ethersproject/bytes": true
       }
     },
     "ethers>@ethersproject/abi>@ethersproject/keccak256": {
@@ -4310,7 +4280,6 @@
         "console.log": true
       },
       "packages": {
-        "ethers>@ethersproject/contracts>@ethersproject/abi>@ethersproject/hash": true,
         "ethers>@ethersproject/contracts>@ethersproject/abi>@ethersproject/keccak256": true,
         "ethers>@ethersproject/contracts>@ethersproject/abi>@ethersproject/strings": true,
         "ethers>@ethersproject/contracts>@ethersproject/address": true,
@@ -4318,28 +4287,8 @@
         "ethers>@ethersproject/contracts>@ethersproject/bytes": true,
         "ethers>@ethersproject/contracts>@ethersproject/constants": true,
         "ethers>@ethersproject/contracts>@ethersproject/logger": true,
-        "ethers>@ethersproject/contracts>@ethersproject/properties": true
-      }
-    },
-    "ethers>@ethersproject/contracts>@ethersproject/abi>@ethersproject/hash": {
-      "packages": {
-        "ethers>@ethersproject/contracts>@ethersproject/abi>@ethersproject/hash>@ethersproject/base64": true,
-        "ethers>@ethersproject/contracts>@ethersproject/abi>@ethersproject/keccak256": true,
-        "ethers>@ethersproject/contracts>@ethersproject/abi>@ethersproject/strings": true,
-        "ethers>@ethersproject/contracts>@ethersproject/address": true,
-        "ethers>@ethersproject/contracts>@ethersproject/bignumber": true,
-        "ethers>@ethersproject/contracts>@ethersproject/bytes": true,
-        "ethers>@ethersproject/contracts>@ethersproject/logger": true,
-        "ethers>@ethersproject/contracts>@ethersproject/properties": true
-      }
-    },
-    "ethers>@ethersproject/contracts>@ethersproject/abi>@ethersproject/hash>@ethersproject/base64": {
-      "globals": {
-        "atob": true,
-        "btoa": true
-      },
-      "packages": {
-        "ethers>@ethersproject/contracts>@ethersproject/bytes": true
+        "ethers>@ethersproject/contracts>@ethersproject/properties": true,
+        "ethers>@ethersproject/hash": true
       }
     },
     "ethers>@ethersproject/contracts>@ethersproject/abi>@ethersproject/keccak256": {
@@ -4442,76 +4391,58 @@
     },
     "ethers>@ethersproject/hash": {
       "packages": {
+        "@ethersproject/bignumber": true,
+        "@ethersproject/bignumber>@ethersproject/bytes": true,
+        "@ethersproject/bignumber>@ethersproject/logger": true,
         "ethers>@ethersproject/hash>@ethersproject/address": true,
-        "ethers>@ethersproject/hash>@ethersproject/bignumber": true,
-        "ethers>@ethersproject/hash>@ethersproject/bytes": true,
+        "ethers>@ethersproject/hash>@ethersproject/base64": true,
         "ethers>@ethersproject/hash>@ethersproject/keccak256": true,
-        "ethers>@ethersproject/hash>@ethersproject/logger": true,
         "ethers>@ethersproject/hash>@ethersproject/properties": true,
         "ethers>@ethersproject/hash>@ethersproject/strings": true
       }
     },
     "ethers>@ethersproject/hash>@ethersproject/address": {
       "packages": {
-        "ethers>@ethersproject/hash>@ethersproject/address>@ethersproject/rlp": true,
-        "ethers>@ethersproject/hash>@ethersproject/bignumber": true,
-        "ethers>@ethersproject/hash>@ethersproject/bytes": true,
-        "ethers>@ethersproject/hash>@ethersproject/keccak256": true,
-        "ethers>@ethersproject/hash>@ethersproject/logger": true
+        "@ethersproject/bignumber": true,
+        "@ethersproject/bignumber>@ethersproject/bytes": true,
+        "@ethersproject/bignumber>@ethersproject/logger": true,
+        "@metamask/controllers>@ethersproject/providers>@ethersproject/rlp": true,
+        "ethers>@ethersproject/hash>@ethersproject/keccak256": true
       }
     },
-    "ethers>@ethersproject/hash>@ethersproject/address>@ethersproject/rlp": {
-      "packages": {
-        "ethers>@ethersproject/hash>@ethersproject/bytes": true,
-        "ethers>@ethersproject/hash>@ethersproject/logger": true
-      }
-    },
-    "ethers>@ethersproject/hash>@ethersproject/bignumber": {
-      "packages": {
-        "ethers>@ethersproject/hash>@ethersproject/bignumber>bn.js": true,
-        "ethers>@ethersproject/hash>@ethersproject/bytes": true,
-        "ethers>@ethersproject/hash>@ethersproject/logger": true
-      }
-    },
-    "ethers>@ethersproject/hash>@ethersproject/bignumber>bn.js": {
+    "ethers>@ethersproject/hash>@ethersproject/base64": {
       "globals": {
-        "Buffer": true
+        "atob": true,
+        "btoa": true
       },
       "packages": {
-        "browserify>browser-resolve": true
-      }
-    },
-    "ethers>@ethersproject/hash>@ethersproject/bytes": {
-      "packages": {
-        "ethers>@ethersproject/hash>@ethersproject/logger": true
+        "@ethersproject/bignumber>@ethersproject/bytes": true
       }
     },
     "ethers>@ethersproject/hash>@ethersproject/keccak256": {
       "packages": {
-        "ethers>@ethersproject/hash>@ethersproject/bytes": true,
-        "ethers>@ethersproject/keccak256>js-sha3": true
+        "@ethersproject/bignumber>@ethersproject/bytes": true,
+        "ethers>@ethersproject/hash>@ethersproject/keccak256>js-sha3": true
       }
     },
-    "ethers>@ethersproject/hash>@ethersproject/logger": {
+    "ethers>@ethersproject/hash>@ethersproject/keccak256>js-sha3": {
       "globals": {
-        "console": true
+        "define": true
+      },
+      "packages": {
+        "browserify>process": true
       }
     },
     "ethers>@ethersproject/hash>@ethersproject/properties": {
       "packages": {
-        "ethers>@ethersproject/hash>@ethersproject/logger": true
+        "@ethersproject/bignumber>@ethersproject/logger": true
       }
     },
     "ethers>@ethersproject/hash>@ethersproject/strings": {
       "packages": {
-        "ethers>@ethersproject/hash>@ethersproject/bytes": true,
-        "ethers>@ethersproject/hash>@ethersproject/logger": true,
-        "ethers>@ethersproject/hash>@ethersproject/strings>@ethersproject/constants": true
-      }
-    },
-    "ethers>@ethersproject/hash>@ethersproject/strings>@ethersproject/constants": {
-      "packages": {
-        "ethers>@ethersproject/hash>@ethersproject/bignumber": true
+        "@ethersproject/bignumber>@ethersproject/bytes": true,
+        "@ethersproject/bignumber>@ethersproject/logger": true,
+        "ethers>@ethersproject/units>@ethersproject/constants": true
       }
     },
     "ethers>@ethersproject/hdnode": {
@@ -4519,11 +4450,11 @@
         "@ethersproject/bignumber": true,
         "@ethersproject/bignumber>@ethersproject/bytes": true,
         "@ethersproject/bignumber>@ethersproject/logger": true,
+        "ethers>@ethersproject/hash>@ethersproject/properties": true,
+        "ethers>@ethersproject/hash>@ethersproject/strings": true,
         "ethers>@ethersproject/hdnode>@ethersproject/basex": true,
-        "ethers>@ethersproject/hdnode>@ethersproject/strings": true,
         "ethers>@ethersproject/pbkdf2": true,
         "ethers>@ethersproject/pbkdf2>@ethersproject/sha2": true,
-        "ethers>@ethersproject/wallet>@ethersproject/properties": true,
         "ethers>@ethersproject/wallet>@ethersproject/signing-key": true,
         "ethers>@ethersproject/wallet>@ethersproject/transactions": true,
         "ethers>@ethersproject/wordlists": true
@@ -4532,28 +4463,21 @@
     "ethers>@ethersproject/hdnode>@ethersproject/basex": {
       "packages": {
         "@ethersproject/bignumber>@ethersproject/bytes": true,
-        "ethers>@ethersproject/wallet>@ethersproject/properties": true
-      }
-    },
-    "ethers>@ethersproject/hdnode>@ethersproject/strings": {
-      "packages": {
-        "@ethersproject/bignumber>@ethersproject/bytes": true,
-        "@ethersproject/bignumber>@ethersproject/logger": true,
-        "ethers>@ethersproject/units>@ethersproject/constants": true
+        "ethers>@ethersproject/hash>@ethersproject/properties": true
       }
     },
     "ethers>@ethersproject/json-wallets": {
       "packages": {
         "@ethersproject/bignumber>@ethersproject/bytes": true,
         "@ethersproject/bignumber>@ethersproject/logger": true,
+        "ethers>@ethersproject/hash>@ethersproject/address": true,
+        "ethers>@ethersproject/hash>@ethersproject/keccak256": true,
+        "ethers>@ethersproject/hash>@ethersproject/properties": true,
+        "ethers>@ethersproject/hash>@ethersproject/strings": true,
         "ethers>@ethersproject/hdnode": true,
-        "ethers>@ethersproject/hdnode>@ethersproject/strings": true,
         "ethers>@ethersproject/json-wallets>aes-js": true,
         "ethers>@ethersproject/json-wallets>scrypt-js": true,
         "ethers>@ethersproject/pbkdf2": true,
-        "ethers>@ethersproject/wallet>@ethersproject/address": true,
-        "ethers>@ethersproject/wallet>@ethersproject/keccak256": true,
-        "ethers>@ethersproject/wallet>@ethersproject/properties": true,
         "ethers>@ethersproject/wallet>@ethersproject/random": true,
         "ethers>@ethersproject/wallet>@ethersproject/transactions": true
       }
@@ -4636,6 +4560,7 @@
         "setTimeout": true
       },
       "packages": {
+        "ethers>@ethersproject/hash": true,
         "ethers>@ethersproject/providers>@ethersproject/abstract-provider": true,
         "ethers>@ethersproject/providers>@ethersproject/abstract-signer": true,
         "ethers>@ethersproject/providers>@ethersproject/address": true,
@@ -4643,7 +4568,6 @@
         "ethers>@ethersproject/providers>@ethersproject/bignumber": true,
         "ethers>@ethersproject/providers>@ethersproject/bytes": true,
         "ethers>@ethersproject/providers>@ethersproject/constants": true,
-        "ethers>@ethersproject/providers>@ethersproject/hash": true,
         "ethers>@ethersproject/providers>@ethersproject/logger": true,
         "ethers>@ethersproject/providers>@ethersproject/networks": true,
         "ethers>@ethersproject/providers>@ethersproject/properties": true,
@@ -4671,11 +4595,17 @@
     },
     "ethers>@ethersproject/providers>@ethersproject/address": {
       "packages": {
+        "ethers>@ethersproject/providers>@ethersproject/address>@ethersproject/keccak256": true,
         "ethers>@ethersproject/providers>@ethersproject/bignumber": true,
         "ethers>@ethersproject/providers>@ethersproject/bytes": true,
-        "ethers>@ethersproject/providers>@ethersproject/hash>@ethersproject/keccak256": true,
         "ethers>@ethersproject/providers>@ethersproject/logger": true,
         "ethers>@ethersproject/providers>@ethersproject/rlp": true
+      }
+    },
+    "ethers>@ethersproject/providers>@ethersproject/address>@ethersproject/keccak256": {
+      "packages": {
+        "ethers>@ethersproject/keccak256>js-sha3": true,
+        "ethers>@ethersproject/providers>@ethersproject/bytes": true
       }
     },
     "ethers>@ethersproject/providers>@ethersproject/basex": {
@@ -4707,24 +4637,6 @@
     "ethers>@ethersproject/providers>@ethersproject/constants": {
       "packages": {
         "ethers>@ethersproject/providers>@ethersproject/bignumber": true
-      }
-    },
-    "ethers>@ethersproject/providers>@ethersproject/hash": {
-      "packages": {
-        "ethers>@ethersproject/providers>@ethersproject/address": true,
-        "ethers>@ethersproject/providers>@ethersproject/bignumber": true,
-        "ethers>@ethersproject/providers>@ethersproject/bytes": true,
-        "ethers>@ethersproject/providers>@ethersproject/hash>@ethersproject/keccak256": true,
-        "ethers>@ethersproject/providers>@ethersproject/logger": true,
-        "ethers>@ethersproject/providers>@ethersproject/properties": true,
-        "ethers>@ethersproject/providers>@ethersproject/strings": true,
-        "ethers>@ethersproject/providers>@ethersproject/web>@ethersproject/base64": true
-      }
-    },
-    "ethers>@ethersproject/providers>@ethersproject/hash>@ethersproject/keccak256": {
-      "packages": {
-        "ethers>@ethersproject/keccak256>js-sha3": true,
-        "ethers>@ethersproject/providers>@ethersproject/bytes": true
       }
     },
     "ethers>@ethersproject/providers>@ethersproject/logger": {
@@ -4771,10 +4683,10 @@
     "ethers>@ethersproject/providers>@ethersproject/transactions": {
       "packages": {
         "ethers>@ethersproject/providers>@ethersproject/address": true,
+        "ethers>@ethersproject/providers>@ethersproject/address>@ethersproject/keccak256": true,
         "ethers>@ethersproject/providers>@ethersproject/bignumber": true,
         "ethers>@ethersproject/providers>@ethersproject/bytes": true,
         "ethers>@ethersproject/providers>@ethersproject/constants": true,
-        "ethers>@ethersproject/providers>@ethersproject/hash>@ethersproject/keccak256": true,
         "ethers>@ethersproject/providers>@ethersproject/logger": true,
         "ethers>@ethersproject/providers>@ethersproject/properties": true,
         "ethers>@ethersproject/providers>@ethersproject/rlp": true,
@@ -4925,9 +4837,9 @@
         "@ethersproject/bignumber": true,
         "@ethersproject/bignumber>@ethersproject/bytes": true,
         "@ethersproject/bignumber>@ethersproject/logger": true,
-        "ethers>@ethersproject/hdnode>@ethersproject/strings": true,
-        "ethers>@ethersproject/pbkdf2>@ethersproject/sha2": true,
-        "ethers>@ethersproject/wallet>@ethersproject/keccak256": true
+        "ethers>@ethersproject/hash>@ethersproject/keccak256": true,
+        "ethers>@ethersproject/hash>@ethersproject/strings": true,
+        "ethers>@ethersproject/pbkdf2>@ethersproject/sha2": true
       }
     },
     "ethers>@ethersproject/strings": {
@@ -5064,55 +4976,15 @@
         "@eth-optimism/contracts>@ethersproject/abstract-signer": true,
         "@ethersproject/bignumber>@ethersproject/bytes": true,
         "@ethersproject/bignumber>@ethersproject/logger": true,
+        "ethers>@ethersproject/hash": true,
+        "ethers>@ethersproject/hash>@ethersproject/address": true,
+        "ethers>@ethersproject/hash>@ethersproject/keccak256": true,
+        "ethers>@ethersproject/hash>@ethersproject/properties": true,
         "ethers>@ethersproject/hdnode": true,
         "ethers>@ethersproject/json-wallets": true,
-        "ethers>@ethersproject/wallet>@ethersproject/address": true,
-        "ethers>@ethersproject/wallet>@ethersproject/hash": true,
-        "ethers>@ethersproject/wallet>@ethersproject/keccak256": true,
-        "ethers>@ethersproject/wallet>@ethersproject/properties": true,
         "ethers>@ethersproject/wallet>@ethersproject/random": true,
         "ethers>@ethersproject/wallet>@ethersproject/signing-key": true,
         "ethers>@ethersproject/wallet>@ethersproject/transactions": true
-      }
-    },
-    "ethers>@ethersproject/wallet>@ethersproject/address": {
-      "packages": {
-        "@ethersproject/bignumber": true,
-        "@ethersproject/bignumber>@ethersproject/bytes": true,
-        "@ethersproject/bignumber>@ethersproject/logger": true,
-        "@metamask/controllers>@ethersproject/providers>@ethersproject/rlp": true,
-        "ethers>@ethersproject/wallet>@ethersproject/keccak256": true
-      }
-    },
-    "ethers>@ethersproject/wallet>@ethersproject/hash": {
-      "packages": {
-        "@ethersproject/bignumber": true,
-        "@ethersproject/bignumber>@ethersproject/bytes": true,
-        "@ethersproject/bignumber>@ethersproject/logger": true,
-        "@metamask/controllers>@ethersproject/providers>@ethersproject/base64": true,
-        "ethers>@ethersproject/hdnode>@ethersproject/strings": true,
-        "ethers>@ethersproject/wallet>@ethersproject/address": true,
-        "ethers>@ethersproject/wallet>@ethersproject/keccak256": true,
-        "ethers>@ethersproject/wallet>@ethersproject/properties": true
-      }
-    },
-    "ethers>@ethersproject/wallet>@ethersproject/keccak256": {
-      "packages": {
-        "@ethersproject/bignumber>@ethersproject/bytes": true,
-        "ethers>@ethersproject/wallet>@ethersproject/keccak256>js-sha3": true
-      }
-    },
-    "ethers>@ethersproject/wallet>@ethersproject/keccak256>js-sha3": {
-      "globals": {
-        "define": true
-      },
-      "packages": {
-        "browserify>process": true
-      }
-    },
-    "ethers>@ethersproject/wallet>@ethersproject/properties": {
-      "packages": {
-        "@ethersproject/bignumber>@ethersproject/logger": true
       }
     },
     "ethers>@ethersproject/wallet>@ethersproject/random": {
@@ -5125,8 +4997,8 @@
       "packages": {
         "@ethersproject/bignumber>@ethersproject/bytes": true,
         "@ethersproject/bignumber>@ethersproject/logger": true,
-        "ethers>@ethersproject/signing-key>elliptic": true,
-        "ethers>@ethersproject/wallet>@ethersproject/properties": true
+        "ethers>@ethersproject/hash>@ethersproject/properties": true,
+        "ethers>@ethersproject/signing-key>elliptic": true
       }
     },
     "ethers>@ethersproject/wallet>@ethersproject/transactions": {
@@ -5135,10 +5007,10 @@
         "@ethersproject/bignumber>@ethersproject/bytes": true,
         "@ethersproject/bignumber>@ethersproject/logger": true,
         "@metamask/controllers>@ethersproject/providers>@ethersproject/rlp": true,
+        "ethers>@ethersproject/hash>@ethersproject/address": true,
+        "ethers>@ethersproject/hash>@ethersproject/keccak256": true,
+        "ethers>@ethersproject/hash>@ethersproject/properties": true,
         "ethers>@ethersproject/units>@ethersproject/constants": true,
-        "ethers>@ethersproject/wallet>@ethersproject/address": true,
-        "ethers>@ethersproject/wallet>@ethersproject/keccak256": true,
-        "ethers>@ethersproject/wallet>@ethersproject/properties": true,
         "ethers>@ethersproject/wallet>@ethersproject/signing-key": true
       }
     },
@@ -5211,9 +5083,9 @@
       "packages": {
         "@ethersproject/bignumber>@ethersproject/bytes": true,
         "@ethersproject/bignumber>@ethersproject/logger": true,
-        "ethers>@ethersproject/hdnode>@ethersproject/strings": true,
-        "ethers>@ethersproject/wallet>@ethersproject/hash": true,
-        "ethers>@ethersproject/wallet>@ethersproject/properties": true
+        "ethers>@ethersproject/hash": true,
+        "ethers>@ethersproject/hash>@ethersproject/properties": true,
+        "ethers>@ethersproject/hash>@ethersproject/strings": true
       }
     },
     "ethjs": {

--- a/lavamoat/browserify/main/policy.json
+++ b/lavamoat/browserify/main/policy.json
@@ -126,13 +126,13 @@
         "@ethersproject/bignumber": true,
         "@ethersproject/bignumber>@ethersproject/bytes": true,
         "@ethersproject/bignumber>@ethersproject/logger": true,
-        "ethers>@ethersproject/wallet>@ethersproject/properties": true
+        "ethers>@ethersproject/hash>@ethersproject/properties": true
       }
     },
     "@eth-optimism/contracts>@ethersproject/abstract-signer": {
       "packages": {
         "@ethersproject/bignumber>@ethersproject/logger": true,
-        "ethers>@ethersproject/wallet>@ethersproject/properties": true
+        "ethers>@ethersproject/hash>@ethersproject/properties": true
       }
     },
     "@ethereumjs/common": {
@@ -512,12 +512,12 @@
         "@ethersproject/bignumber": true,
         "@ethersproject/bignumber>@ethersproject/bytes": true,
         "@ethersproject/bignumber>@ethersproject/logger": true,
-        "ethers>@ethersproject/hdnode>@ethersproject/strings": true,
-        "ethers>@ethersproject/units>@ethersproject/constants": true,
-        "ethers>@ethersproject/wallet>@ethersproject/address": true,
-        "ethers>@ethersproject/wallet>@ethersproject/hash": true,
-        "ethers>@ethersproject/wallet>@ethersproject/keccak256": true,
-        "ethers>@ethersproject/wallet>@ethersproject/properties": true
+        "ethers>@ethersproject/hash": true,
+        "ethers>@ethersproject/hash>@ethersproject/address": true,
+        "ethers>@ethersproject/hash>@ethersproject/keccak256": true,
+        "ethers>@ethersproject/hash>@ethersproject/properties": true,
+        "ethers>@ethersproject/hash>@ethersproject/strings": true,
+        "ethers>@ethersproject/units>@ethersproject/constants": true
       }
     },
     "@metamask/controllers>@ethersproject/contracts": {
@@ -531,8 +531,8 @@
         "@ethersproject/bignumber>@ethersproject/bytes": true,
         "@ethersproject/bignumber>@ethersproject/logger": true,
         "@metamask/controllers>@ethersproject/abi": true,
-        "ethers>@ethersproject/wallet>@ethersproject/address": true,
-        "ethers>@ethersproject/wallet>@ethersproject/properties": true,
+        "ethers>@ethersproject/hash>@ethersproject/address": true,
+        "ethers>@ethersproject/hash>@ethersproject/properties": true,
         "ethers>@ethersproject/wallet>@ethersproject/transactions": true
       }
     },
@@ -552,28 +552,19 @@
         "@ethersproject/bignumber": true,
         "@ethersproject/bignumber>@ethersproject/bytes": true,
         "@ethersproject/bignumber>@ethersproject/logger": true,
-        "@metamask/controllers>@ethersproject/providers>@ethersproject/base64": true,
         "@metamask/controllers>@ethersproject/providers>@ethersproject/networks": true,
         "@metamask/controllers>@ethersproject/providers>@ethersproject/web": true,
+        "ethers>@ethersproject/hash": true,
+        "ethers>@ethersproject/hash>@ethersproject/address": true,
+        "ethers>@ethersproject/hash>@ethersproject/base64": true,
+        "ethers>@ethersproject/hash>@ethersproject/properties": true,
+        "ethers>@ethersproject/hash>@ethersproject/strings": true,
         "ethers>@ethersproject/hdnode>@ethersproject/basex": true,
-        "ethers>@ethersproject/hdnode>@ethersproject/strings": true,
         "ethers>@ethersproject/pbkdf2>@ethersproject/sha2": true,
         "ethers>@ethersproject/providers>bech32": true,
         "ethers>@ethersproject/units>@ethersproject/constants": true,
-        "ethers>@ethersproject/wallet>@ethersproject/address": true,
-        "ethers>@ethersproject/wallet>@ethersproject/hash": true,
-        "ethers>@ethersproject/wallet>@ethersproject/properties": true,
         "ethers>@ethersproject/wallet>@ethersproject/random": true,
         "ethers>@ethersproject/wallet>@ethersproject/transactions": true
-      }
-    },
-    "@metamask/controllers>@ethersproject/providers>@ethersproject/base64": {
-      "globals": {
-        "atob": true,
-        "btoa": true
-      },
-      "packages": {
-        "@ethersproject/bignumber>@ethersproject/bytes": true
       }
     },
     "@metamask/controllers>@ethersproject/providers>@ethersproject/networks": {
@@ -596,9 +587,9 @@
       "packages": {
         "@ethersproject/bignumber>@ethersproject/bytes": true,
         "@ethersproject/bignumber>@ethersproject/logger": true,
-        "@metamask/controllers>@ethersproject/providers>@ethersproject/base64": true,
-        "ethers>@ethersproject/hdnode>@ethersproject/strings": true,
-        "ethers>@ethersproject/wallet>@ethersproject/properties": true
+        "ethers>@ethersproject/hash>@ethersproject/base64": true,
+        "ethers>@ethersproject/hash>@ethersproject/properties": true,
+        "ethers>@ethersproject/hash>@ethersproject/strings": true
       }
     },
     "@metamask/controllers>abort-controller": {
@@ -3237,11 +3228,11 @@
         "ethers>@ethersproject/abi>@ethersproject/bignumber": true,
         "ethers>@ethersproject/abi>@ethersproject/bytes": true,
         "ethers>@ethersproject/abi>@ethersproject/constants": true,
-        "ethers>@ethersproject/abi>@ethersproject/hash": true,
         "ethers>@ethersproject/abi>@ethersproject/keccak256": true,
         "ethers>@ethersproject/abi>@ethersproject/logger": true,
         "ethers>@ethersproject/abi>@ethersproject/properties": true,
-        "ethers>@ethersproject/abi>@ethersproject/strings": true
+        "ethers>@ethersproject/abi>@ethersproject/strings": true,
+        "ethers>@ethersproject/hash": true
       }
     },
     "ethers>@ethersproject/abi>@ethersproject/address": {
@@ -3282,27 +3273,6 @@
     "ethers>@ethersproject/abi>@ethersproject/constants": {
       "packages": {
         "ethers>@ethersproject/abi>@ethersproject/bignumber": true
-      }
-    },
-    "ethers>@ethersproject/abi>@ethersproject/hash": {
-      "packages": {
-        "ethers>@ethersproject/abi>@ethersproject/address": true,
-        "ethers>@ethersproject/abi>@ethersproject/bignumber": true,
-        "ethers>@ethersproject/abi>@ethersproject/bytes": true,
-        "ethers>@ethersproject/abi>@ethersproject/hash>@ethersproject/base64": true,
-        "ethers>@ethersproject/abi>@ethersproject/keccak256": true,
-        "ethers>@ethersproject/abi>@ethersproject/logger": true,
-        "ethers>@ethersproject/abi>@ethersproject/properties": true,
-        "ethers>@ethersproject/abi>@ethersproject/strings": true
-      }
-    },
-    "ethers>@ethersproject/abi>@ethersproject/hash>@ethersproject/base64": {
-      "globals": {
-        "atob": true,
-        "btoa": true
-      },
-      "packages": {
-        "ethers>@ethersproject/abi>@ethersproject/bytes": true
       }
     },
     "ethers>@ethersproject/abi>@ethersproject/keccak256": {
@@ -3508,7 +3478,6 @@
         "console.log": true
       },
       "packages": {
-        "ethers>@ethersproject/contracts>@ethersproject/abi>@ethersproject/hash": true,
         "ethers>@ethersproject/contracts>@ethersproject/abi>@ethersproject/keccak256": true,
         "ethers>@ethersproject/contracts>@ethersproject/abi>@ethersproject/strings": true,
         "ethers>@ethersproject/contracts>@ethersproject/address": true,
@@ -3516,28 +3485,8 @@
         "ethers>@ethersproject/contracts>@ethersproject/bytes": true,
         "ethers>@ethersproject/contracts>@ethersproject/constants": true,
         "ethers>@ethersproject/contracts>@ethersproject/logger": true,
-        "ethers>@ethersproject/contracts>@ethersproject/properties": true
-      }
-    },
-    "ethers>@ethersproject/contracts>@ethersproject/abi>@ethersproject/hash": {
-      "packages": {
-        "ethers>@ethersproject/contracts>@ethersproject/abi>@ethersproject/hash>@ethersproject/base64": true,
-        "ethers>@ethersproject/contracts>@ethersproject/abi>@ethersproject/keccak256": true,
-        "ethers>@ethersproject/contracts>@ethersproject/abi>@ethersproject/strings": true,
-        "ethers>@ethersproject/contracts>@ethersproject/address": true,
-        "ethers>@ethersproject/contracts>@ethersproject/bignumber": true,
-        "ethers>@ethersproject/contracts>@ethersproject/bytes": true,
-        "ethers>@ethersproject/contracts>@ethersproject/logger": true,
-        "ethers>@ethersproject/contracts>@ethersproject/properties": true
-      }
-    },
-    "ethers>@ethersproject/contracts>@ethersproject/abi>@ethersproject/hash>@ethersproject/base64": {
-      "globals": {
-        "atob": true,
-        "btoa": true
-      },
-      "packages": {
-        "ethers>@ethersproject/contracts>@ethersproject/bytes": true
+        "ethers>@ethersproject/contracts>@ethersproject/properties": true,
+        "ethers>@ethersproject/hash": true
       }
     },
     "ethers>@ethersproject/contracts>@ethersproject/abi>@ethersproject/keccak256": {
@@ -3640,76 +3589,58 @@
     },
     "ethers>@ethersproject/hash": {
       "packages": {
+        "@ethersproject/bignumber": true,
+        "@ethersproject/bignumber>@ethersproject/bytes": true,
+        "@ethersproject/bignumber>@ethersproject/logger": true,
         "ethers>@ethersproject/hash>@ethersproject/address": true,
-        "ethers>@ethersproject/hash>@ethersproject/bignumber": true,
-        "ethers>@ethersproject/hash>@ethersproject/bytes": true,
+        "ethers>@ethersproject/hash>@ethersproject/base64": true,
         "ethers>@ethersproject/hash>@ethersproject/keccak256": true,
-        "ethers>@ethersproject/hash>@ethersproject/logger": true,
         "ethers>@ethersproject/hash>@ethersproject/properties": true,
         "ethers>@ethersproject/hash>@ethersproject/strings": true
       }
     },
     "ethers>@ethersproject/hash>@ethersproject/address": {
       "packages": {
-        "ethers>@ethersproject/hash>@ethersproject/address>@ethersproject/rlp": true,
-        "ethers>@ethersproject/hash>@ethersproject/bignumber": true,
-        "ethers>@ethersproject/hash>@ethersproject/bytes": true,
-        "ethers>@ethersproject/hash>@ethersproject/keccak256": true,
-        "ethers>@ethersproject/hash>@ethersproject/logger": true
+        "@ethersproject/bignumber": true,
+        "@ethersproject/bignumber>@ethersproject/bytes": true,
+        "@ethersproject/bignumber>@ethersproject/logger": true,
+        "@metamask/controllers>@ethersproject/providers>@ethersproject/rlp": true,
+        "ethers>@ethersproject/hash>@ethersproject/keccak256": true
       }
     },
-    "ethers>@ethersproject/hash>@ethersproject/address>@ethersproject/rlp": {
-      "packages": {
-        "ethers>@ethersproject/hash>@ethersproject/bytes": true,
-        "ethers>@ethersproject/hash>@ethersproject/logger": true
-      }
-    },
-    "ethers>@ethersproject/hash>@ethersproject/bignumber": {
-      "packages": {
-        "ethers>@ethersproject/hash>@ethersproject/bignumber>bn.js": true,
-        "ethers>@ethersproject/hash>@ethersproject/bytes": true,
-        "ethers>@ethersproject/hash>@ethersproject/logger": true
-      }
-    },
-    "ethers>@ethersproject/hash>@ethersproject/bignumber>bn.js": {
+    "ethers>@ethersproject/hash>@ethersproject/base64": {
       "globals": {
-        "Buffer": true
+        "atob": true,
+        "btoa": true
       },
       "packages": {
-        "browserify>browser-resolve": true
-      }
-    },
-    "ethers>@ethersproject/hash>@ethersproject/bytes": {
-      "packages": {
-        "ethers>@ethersproject/hash>@ethersproject/logger": true
+        "@ethersproject/bignumber>@ethersproject/bytes": true
       }
     },
     "ethers>@ethersproject/hash>@ethersproject/keccak256": {
       "packages": {
-        "ethers>@ethersproject/hash>@ethersproject/bytes": true,
-        "ethers>@ethersproject/keccak256>js-sha3": true
+        "@ethersproject/bignumber>@ethersproject/bytes": true,
+        "ethers>@ethersproject/hash>@ethersproject/keccak256>js-sha3": true
       }
     },
-    "ethers>@ethersproject/hash>@ethersproject/logger": {
+    "ethers>@ethersproject/hash>@ethersproject/keccak256>js-sha3": {
       "globals": {
-        "console": true
+        "define": true
+      },
+      "packages": {
+        "browserify>process": true
       }
     },
     "ethers>@ethersproject/hash>@ethersproject/properties": {
       "packages": {
-        "ethers>@ethersproject/hash>@ethersproject/logger": true
+        "@ethersproject/bignumber>@ethersproject/logger": true
       }
     },
     "ethers>@ethersproject/hash>@ethersproject/strings": {
       "packages": {
-        "ethers>@ethersproject/hash>@ethersproject/bytes": true,
-        "ethers>@ethersproject/hash>@ethersproject/logger": true,
-        "ethers>@ethersproject/hash>@ethersproject/strings>@ethersproject/constants": true
-      }
-    },
-    "ethers>@ethersproject/hash>@ethersproject/strings>@ethersproject/constants": {
-      "packages": {
-        "ethers>@ethersproject/hash>@ethersproject/bignumber": true
+        "@ethersproject/bignumber>@ethersproject/bytes": true,
+        "@ethersproject/bignumber>@ethersproject/logger": true,
+        "ethers>@ethersproject/units>@ethersproject/constants": true
       }
     },
     "ethers>@ethersproject/hdnode": {
@@ -3717,11 +3648,11 @@
         "@ethersproject/bignumber": true,
         "@ethersproject/bignumber>@ethersproject/bytes": true,
         "@ethersproject/bignumber>@ethersproject/logger": true,
+        "ethers>@ethersproject/hash>@ethersproject/properties": true,
+        "ethers>@ethersproject/hash>@ethersproject/strings": true,
         "ethers>@ethersproject/hdnode>@ethersproject/basex": true,
-        "ethers>@ethersproject/hdnode>@ethersproject/strings": true,
         "ethers>@ethersproject/pbkdf2": true,
         "ethers>@ethersproject/pbkdf2>@ethersproject/sha2": true,
-        "ethers>@ethersproject/wallet>@ethersproject/properties": true,
         "ethers>@ethersproject/wallet>@ethersproject/signing-key": true,
         "ethers>@ethersproject/wallet>@ethersproject/transactions": true,
         "ethers>@ethersproject/wordlists": true
@@ -3730,28 +3661,21 @@
     "ethers>@ethersproject/hdnode>@ethersproject/basex": {
       "packages": {
         "@ethersproject/bignumber>@ethersproject/bytes": true,
-        "ethers>@ethersproject/wallet>@ethersproject/properties": true
-      }
-    },
-    "ethers>@ethersproject/hdnode>@ethersproject/strings": {
-      "packages": {
-        "@ethersproject/bignumber>@ethersproject/bytes": true,
-        "@ethersproject/bignumber>@ethersproject/logger": true,
-        "ethers>@ethersproject/units>@ethersproject/constants": true
+        "ethers>@ethersproject/hash>@ethersproject/properties": true
       }
     },
     "ethers>@ethersproject/json-wallets": {
       "packages": {
         "@ethersproject/bignumber>@ethersproject/bytes": true,
         "@ethersproject/bignumber>@ethersproject/logger": true,
+        "ethers>@ethersproject/hash>@ethersproject/address": true,
+        "ethers>@ethersproject/hash>@ethersproject/keccak256": true,
+        "ethers>@ethersproject/hash>@ethersproject/properties": true,
+        "ethers>@ethersproject/hash>@ethersproject/strings": true,
         "ethers>@ethersproject/hdnode": true,
-        "ethers>@ethersproject/hdnode>@ethersproject/strings": true,
         "ethers>@ethersproject/json-wallets>aes-js": true,
         "ethers>@ethersproject/json-wallets>scrypt-js": true,
         "ethers>@ethersproject/pbkdf2": true,
-        "ethers>@ethersproject/wallet>@ethersproject/address": true,
-        "ethers>@ethersproject/wallet>@ethersproject/keccak256": true,
-        "ethers>@ethersproject/wallet>@ethersproject/properties": true,
         "ethers>@ethersproject/wallet>@ethersproject/random": true,
         "ethers>@ethersproject/wallet>@ethersproject/transactions": true
       }
@@ -3834,6 +3758,7 @@
         "setTimeout": true
       },
       "packages": {
+        "ethers>@ethersproject/hash": true,
         "ethers>@ethersproject/providers>@ethersproject/abstract-provider": true,
         "ethers>@ethersproject/providers>@ethersproject/abstract-signer": true,
         "ethers>@ethersproject/providers>@ethersproject/address": true,
@@ -3841,7 +3766,6 @@
         "ethers>@ethersproject/providers>@ethersproject/bignumber": true,
         "ethers>@ethersproject/providers>@ethersproject/bytes": true,
         "ethers>@ethersproject/providers>@ethersproject/constants": true,
-        "ethers>@ethersproject/providers>@ethersproject/hash": true,
         "ethers>@ethersproject/providers>@ethersproject/logger": true,
         "ethers>@ethersproject/providers>@ethersproject/networks": true,
         "ethers>@ethersproject/providers>@ethersproject/properties": true,
@@ -3869,11 +3793,17 @@
     },
     "ethers>@ethersproject/providers>@ethersproject/address": {
       "packages": {
+        "ethers>@ethersproject/providers>@ethersproject/address>@ethersproject/keccak256": true,
         "ethers>@ethersproject/providers>@ethersproject/bignumber": true,
         "ethers>@ethersproject/providers>@ethersproject/bytes": true,
-        "ethers>@ethersproject/providers>@ethersproject/hash>@ethersproject/keccak256": true,
         "ethers>@ethersproject/providers>@ethersproject/logger": true,
         "ethers>@ethersproject/providers>@ethersproject/rlp": true
+      }
+    },
+    "ethers>@ethersproject/providers>@ethersproject/address>@ethersproject/keccak256": {
+      "packages": {
+        "ethers>@ethersproject/keccak256>js-sha3": true,
+        "ethers>@ethersproject/providers>@ethersproject/bytes": true
       }
     },
     "ethers>@ethersproject/providers>@ethersproject/basex": {
@@ -3905,24 +3835,6 @@
     "ethers>@ethersproject/providers>@ethersproject/constants": {
       "packages": {
         "ethers>@ethersproject/providers>@ethersproject/bignumber": true
-      }
-    },
-    "ethers>@ethersproject/providers>@ethersproject/hash": {
-      "packages": {
-        "ethers>@ethersproject/providers>@ethersproject/address": true,
-        "ethers>@ethersproject/providers>@ethersproject/bignumber": true,
-        "ethers>@ethersproject/providers>@ethersproject/bytes": true,
-        "ethers>@ethersproject/providers>@ethersproject/hash>@ethersproject/keccak256": true,
-        "ethers>@ethersproject/providers>@ethersproject/logger": true,
-        "ethers>@ethersproject/providers>@ethersproject/properties": true,
-        "ethers>@ethersproject/providers>@ethersproject/strings": true,
-        "ethers>@ethersproject/providers>@ethersproject/web>@ethersproject/base64": true
-      }
-    },
-    "ethers>@ethersproject/providers>@ethersproject/hash>@ethersproject/keccak256": {
-      "packages": {
-        "ethers>@ethersproject/keccak256>js-sha3": true,
-        "ethers>@ethersproject/providers>@ethersproject/bytes": true
       }
     },
     "ethers>@ethersproject/providers>@ethersproject/logger": {
@@ -3969,10 +3881,10 @@
     "ethers>@ethersproject/providers>@ethersproject/transactions": {
       "packages": {
         "ethers>@ethersproject/providers>@ethersproject/address": true,
+        "ethers>@ethersproject/providers>@ethersproject/address>@ethersproject/keccak256": true,
         "ethers>@ethersproject/providers>@ethersproject/bignumber": true,
         "ethers>@ethersproject/providers>@ethersproject/bytes": true,
         "ethers>@ethersproject/providers>@ethersproject/constants": true,
-        "ethers>@ethersproject/providers>@ethersproject/hash>@ethersproject/keccak256": true,
         "ethers>@ethersproject/providers>@ethersproject/logger": true,
         "ethers>@ethersproject/providers>@ethersproject/properties": true,
         "ethers>@ethersproject/providers>@ethersproject/rlp": true,
@@ -4123,9 +4035,9 @@
         "@ethersproject/bignumber": true,
         "@ethersproject/bignumber>@ethersproject/bytes": true,
         "@ethersproject/bignumber>@ethersproject/logger": true,
-        "ethers>@ethersproject/hdnode>@ethersproject/strings": true,
-        "ethers>@ethersproject/pbkdf2>@ethersproject/sha2": true,
-        "ethers>@ethersproject/wallet>@ethersproject/keccak256": true
+        "ethers>@ethersproject/hash>@ethersproject/keccak256": true,
+        "ethers>@ethersproject/hash>@ethersproject/strings": true,
+        "ethers>@ethersproject/pbkdf2>@ethersproject/sha2": true
       }
     },
     "ethers>@ethersproject/strings": {
@@ -4262,55 +4174,15 @@
         "@eth-optimism/contracts>@ethersproject/abstract-signer": true,
         "@ethersproject/bignumber>@ethersproject/bytes": true,
         "@ethersproject/bignumber>@ethersproject/logger": true,
+        "ethers>@ethersproject/hash": true,
+        "ethers>@ethersproject/hash>@ethersproject/address": true,
+        "ethers>@ethersproject/hash>@ethersproject/keccak256": true,
+        "ethers>@ethersproject/hash>@ethersproject/properties": true,
         "ethers>@ethersproject/hdnode": true,
         "ethers>@ethersproject/json-wallets": true,
-        "ethers>@ethersproject/wallet>@ethersproject/address": true,
-        "ethers>@ethersproject/wallet>@ethersproject/hash": true,
-        "ethers>@ethersproject/wallet>@ethersproject/keccak256": true,
-        "ethers>@ethersproject/wallet>@ethersproject/properties": true,
         "ethers>@ethersproject/wallet>@ethersproject/random": true,
         "ethers>@ethersproject/wallet>@ethersproject/signing-key": true,
         "ethers>@ethersproject/wallet>@ethersproject/transactions": true
-      }
-    },
-    "ethers>@ethersproject/wallet>@ethersproject/address": {
-      "packages": {
-        "@ethersproject/bignumber": true,
-        "@ethersproject/bignumber>@ethersproject/bytes": true,
-        "@ethersproject/bignumber>@ethersproject/logger": true,
-        "@metamask/controllers>@ethersproject/providers>@ethersproject/rlp": true,
-        "ethers>@ethersproject/wallet>@ethersproject/keccak256": true
-      }
-    },
-    "ethers>@ethersproject/wallet>@ethersproject/hash": {
-      "packages": {
-        "@ethersproject/bignumber": true,
-        "@ethersproject/bignumber>@ethersproject/bytes": true,
-        "@ethersproject/bignumber>@ethersproject/logger": true,
-        "@metamask/controllers>@ethersproject/providers>@ethersproject/base64": true,
-        "ethers>@ethersproject/hdnode>@ethersproject/strings": true,
-        "ethers>@ethersproject/wallet>@ethersproject/address": true,
-        "ethers>@ethersproject/wallet>@ethersproject/keccak256": true,
-        "ethers>@ethersproject/wallet>@ethersproject/properties": true
-      }
-    },
-    "ethers>@ethersproject/wallet>@ethersproject/keccak256": {
-      "packages": {
-        "@ethersproject/bignumber>@ethersproject/bytes": true,
-        "ethers>@ethersproject/wallet>@ethersproject/keccak256>js-sha3": true
-      }
-    },
-    "ethers>@ethersproject/wallet>@ethersproject/keccak256>js-sha3": {
-      "globals": {
-        "define": true
-      },
-      "packages": {
-        "browserify>process": true
-      }
-    },
-    "ethers>@ethersproject/wallet>@ethersproject/properties": {
-      "packages": {
-        "@ethersproject/bignumber>@ethersproject/logger": true
       }
     },
     "ethers>@ethersproject/wallet>@ethersproject/random": {
@@ -4323,8 +4195,8 @@
       "packages": {
         "@ethersproject/bignumber>@ethersproject/bytes": true,
         "@ethersproject/bignumber>@ethersproject/logger": true,
-        "ethers>@ethersproject/signing-key>elliptic": true,
-        "ethers>@ethersproject/wallet>@ethersproject/properties": true
+        "ethers>@ethersproject/hash>@ethersproject/properties": true,
+        "ethers>@ethersproject/signing-key>elliptic": true
       }
     },
     "ethers>@ethersproject/wallet>@ethersproject/transactions": {
@@ -4333,10 +4205,10 @@
         "@ethersproject/bignumber>@ethersproject/bytes": true,
         "@ethersproject/bignumber>@ethersproject/logger": true,
         "@metamask/controllers>@ethersproject/providers>@ethersproject/rlp": true,
+        "ethers>@ethersproject/hash>@ethersproject/address": true,
+        "ethers>@ethersproject/hash>@ethersproject/keccak256": true,
+        "ethers>@ethersproject/hash>@ethersproject/properties": true,
         "ethers>@ethersproject/units>@ethersproject/constants": true,
-        "ethers>@ethersproject/wallet>@ethersproject/address": true,
-        "ethers>@ethersproject/wallet>@ethersproject/keccak256": true,
-        "ethers>@ethersproject/wallet>@ethersproject/properties": true,
         "ethers>@ethersproject/wallet>@ethersproject/signing-key": true
       }
     },
@@ -4409,9 +4281,9 @@
       "packages": {
         "@ethersproject/bignumber>@ethersproject/bytes": true,
         "@ethersproject/bignumber>@ethersproject/logger": true,
-        "ethers>@ethersproject/hdnode>@ethersproject/strings": true,
-        "ethers>@ethersproject/wallet>@ethersproject/hash": true,
-        "ethers>@ethersproject/wallet>@ethersproject/properties": true
+        "ethers>@ethersproject/hash": true,
+        "ethers>@ethersproject/hash>@ethersproject/properties": true,
+        "ethers>@ethersproject/hash>@ethersproject/strings": true
       }
     },
     "ethjs": {

--- a/lavamoat/browserify/main/policy.json
+++ b/lavamoat/browserify/main/policy.json
@@ -161,7 +161,7 @@
       "packages": {
         "@ethersproject/bignumber>@ethersproject/bytes": true,
         "@ethersproject/bignumber>@ethersproject/logger": true,
-        "@ethersproject/bignumber>bn.js": true
+        "bn.js": true
       }
     },
     "@ethersproject/bignumber>@ethersproject/bytes": {
@@ -172,14 +172,6 @@
     "@ethersproject/bignumber>@ethersproject/logger": {
       "globals": {
         "console": true
-      }
-    },
-    "@ethersproject/bignumber>bn.js": {
-      "globals": {
-        "Buffer": true
-      },
-      "packages": {
-        "browserify>browser-resolve": true
       }
     },
     "@formatjs/intl-relativetimeformat": {
@@ -648,10 +640,10 @@
         "setInterval": true
       },
       "packages": {
-        "@metamask/controllers>eth-method-registry>ethjs>bn.js": true,
         "@metamask/controllers>eth-method-registry>ethjs>ethjs-abi": true,
         "@metamask/controllers>eth-method-registry>ethjs>ethjs-contract": true,
         "@metamask/controllers>eth-method-registry>ethjs>ethjs-query": true,
+        "bn.js": true,
         "browserify>buffer": true,
         "ethjs>ethjs-filter": true,
         "ethjs>ethjs-provider-http": true,
@@ -663,7 +655,7 @@
     },
     "@metamask/controllers>eth-method-registry>ethjs>ethjs-abi": {
       "packages": {
-        "@metamask/controllers>eth-method-registry>ethjs>bn.js": true,
+        "bn.js": true,
         "browserify>buffer": true,
         "ethjs>js-sha3": true,
         "ethjs>number-to-bn": true
@@ -681,7 +673,7 @@
     },
     "@metamask/controllers>eth-method-registry>ethjs>ethjs-contract>ethjs-abi": {
       "packages": {
-        "@metamask/controllers>eth-method-registry>ethjs>bn.js": true,
+        "bn.js": true,
         "browserify>buffer": true,
         "ethjs>js-sha3": true,
         "ethjs>number-to-bn": true
@@ -1098,10 +1090,10 @@
         "setInterval": true
       },
       "packages": {
-        "@metamask/eth-token-tracker>ethjs>bn.js": true,
         "@metamask/eth-token-tracker>ethjs>ethjs-abi": true,
         "@metamask/eth-token-tracker>ethjs>ethjs-contract": true,
         "@metamask/eth-token-tracker>ethjs>ethjs-query": true,
+        "bn.js": true,
         "browserify>buffer": true,
         "ethjs>ethjs-filter": true,
         "ethjs>ethjs-provider-http": true,
@@ -1113,7 +1105,7 @@
     },
     "@metamask/eth-token-tracker>ethjs>ethjs-abi": {
       "packages": {
-        "@metamask/eth-token-tracker>ethjs>bn.js": true,
+        "bn.js": true,
         "browserify>buffer": true,
         "ethjs>js-sha3": true,
         "ethjs>number-to-bn": true
@@ -1131,7 +1123,7 @@
     },
     "@metamask/eth-token-tracker>ethjs>ethjs-contract>ethjs-abi": {
       "packages": {
-        "@metamask/eth-token-tracker>ethjs>bn.js": true,
+        "bn.js": true,
         "browserify>buffer": true,
         "ethjs>js-sha3": true,
         "ethjs>number-to-bn": true
@@ -1301,10 +1293,10 @@
         "setInterval": true
       },
       "packages": {
-        "@metamask/smart-transactions-controller>@metamask/controllers>eth-method-registry>ethjs>bn.js": true,
         "@metamask/smart-transactions-controller>@metamask/controllers>eth-method-registry>ethjs>ethjs-abi": true,
         "@metamask/smart-transactions-controller>@metamask/controllers>eth-method-registry>ethjs>ethjs-contract": true,
         "@metamask/smart-transactions-controller>@metamask/controllers>eth-method-registry>ethjs>ethjs-query": true,
+        "bn.js": true,
         "browserify>buffer": true,
         "ethjs>ethjs-filter": true,
         "ethjs>ethjs-provider-http": true,
@@ -1316,7 +1308,7 @@
     },
     "@metamask/smart-transactions-controller>@metamask/controllers>eth-method-registry>ethjs>ethjs-abi": {
       "packages": {
-        "@metamask/smart-transactions-controller>@metamask/controllers>eth-method-registry>ethjs>bn.js": true,
+        "bn.js": true,
         "browserify>buffer": true,
         "ethjs>js-sha3": true,
         "ethjs>number-to-bn": true
@@ -1334,7 +1326,7 @@
     },
     "@metamask/smart-transactions-controller>@metamask/controllers>eth-method-registry>ethjs>ethjs-contract>ethjs-abi": {
       "packages": {
-        "@metamask/smart-transactions-controller>@metamask/controllers>eth-method-registry>ethjs>bn.js": true,
+        "bn.js": true,
         "browserify>buffer": true,
         "ethjs>js-sha3": true,
         "ethjs>number-to-bn": true
@@ -1576,13 +1568,13 @@
         "@truffle/codec>@truffle/abi-utils": true,
         "@truffle/codec>@truffle/compile-common": true,
         "@truffle/codec>big.js": true,
-        "@truffle/codec>bn.js": true,
         "@truffle/codec>cbor": true,
         "@truffle/codec>lodash.escaperegexp": true,
         "@truffle/codec>lodash.partition": true,
         "@truffle/codec>lodash.sum": true,
         "@truffle/codec>utf8": true,
         "@truffle/codec>web3-utils": true,
+        "bn.js": true,
         "browserify>buffer": true,
         "browserify>util": true,
         "gulp-dart-sass>lodash.clonedeep": true,
@@ -1746,14 +1738,6 @@
         "define": true
       }
     },
-    "@truffle/codec>bn.js": {
-      "globals": {
-        "Buffer": true
-      },
-      "packages": {
-        "browserify>browser-resolve": true
-      }
-    },
     "@truffle/codec>cbor": {
       "globals": {
         "TextDecoder": true
@@ -1816,7 +1800,7 @@
         "@truffle/codec>@truffle/compile-common": true,
         "@truffle/codec>web3-utils": true,
         "@truffle/decoder>@truffle/source-map-utils": true,
-        "@truffle/decoder>bn.js": true,
+        "bn.js": true,
         "nock>debug": true
       }
     },
@@ -1844,14 +1828,6 @@
     "@truffle/decoder>@truffle/source-map-utils>node-interval-tree": {
       "packages": {
         "react-dnd>shallowequal": true
-      }
-    },
-    "@truffle/decoder>bn.js": {
-      "globals": {
-        "Buffer": true
-      },
-      "packages": {
-        "browserify>browser-resolve": true
       }
     },
     "@zxing/browser": {
@@ -2418,18 +2394,13 @@
     },
     "eth-json-rpc-middleware>@metamask/eth-sig-util": {
       "packages": {
+        "bn.js": true,
         "browserify>buffer": true,
-        "eth-json-rpc-middleware>@metamask/eth-sig-util>bn.js": true,
         "eth-json-rpc-middleware>@metamask/eth-sig-util>ethereum-cryptography": true,
         "eth-json-rpc-middleware>@metamask/eth-sig-util>ethjs-util": true,
         "eth-lattice-keyring>@ethereumjs/util": true,
         "eth-sig-util>tweetnacl": true,
         "eth-sig-util>tweetnacl-util": true
-      }
-    },
-    "eth-json-rpc-middleware>@metamask/eth-sig-util>bn.js": {
-      "packages": {
-        "browserify>browser-resolve": true
       }
     },
     "eth-json-rpc-middleware>@metamask/eth-sig-util>ethereum-cryptography": {
@@ -2563,12 +2534,12 @@
         "setInterval": true
       },
       "packages": {
+        "bn.js": true,
         "browserify>buffer": true,
         "browserify>crypto-browserify": true,
         "browserify>events": true,
         "eth-lattice-keyring>@ethereumjs/tx": true,
         "eth-lattice-keyring>@ethereumjs/util": true,
-        "eth-lattice-keyring>bn.js": true,
         "eth-lattice-keyring>gridplus-sdk": true,
         "eth-lattice-keyring>rlp": true
       }
@@ -2613,14 +2584,6 @@
     "eth-lattice-keyring>@ethereumjs/util>ethereum-cryptography>@noble/secp256k1": {
       "globals": {
         "crypto": true
-      },
-      "packages": {
-        "browserify>browser-resolve": true
-      }
-    },
-    "eth-lattice-keyring>bn.js": {
-      "globals": {
-        "Buffer": true
       },
       "packages": {
         "browserify>browser-resolve": true
@@ -2726,17 +2689,9 @@
         "intToBuffer": true
       },
       "packages": {
-        "eth-lattice-keyring>gridplus-sdk>eth-eip712-util-browser>bn.js": true,
+        "bn.js": true,
         "eth-lattice-keyring>gridplus-sdk>eth-eip712-util-browser>buffer": true,
         "eth-lattice-keyring>gridplus-sdk>eth-eip712-util-browser>js-sha3": true
-      }
-    },
-    "eth-lattice-keyring>gridplus-sdk>eth-eip712-util-browser>bn.js": {
-      "globals": {
-        "Buffer": true
-      },
-      "packages": {
-        "browserify>browser-resolve": true
       }
     },
     "eth-lattice-keyring>gridplus-sdk>eth-eip712-util-browser>buffer": {
@@ -2977,21 +2932,13 @@
     },
     "ethereumjs-util": {
       "packages": {
+        "bn.js": true,
         "browserify>assert": true,
         "browserify>buffer": true,
         "browserify>insert-module-globals>is-buffer": true,
-        "ethereumjs-util>bn.js": true,
         "ethereumjs-util>create-hash": true,
         "ethereumjs-util>ethereum-cryptography": true,
         "ethereumjs-util>rlp": true
-      }
-    },
-    "ethereumjs-util>bn.js": {
-      "globals": {
-        "Buffer": true
-      },
-      "packages": {
-        "browserify>browser-resolve": true
       }
     },
     "ethereumjs-util>create-hash": {
@@ -3095,16 +3042,8 @@
     },
     "ethereumjs-util>rlp": {
       "packages": {
-        "browserify>buffer": true,
-        "ethereumjs-util>rlp>bn.js": true
-      }
-    },
-    "ethereumjs-util>rlp>bn.js": {
-      "globals": {
-        "Buffer": true
-      },
-      "packages": {
-        "browserify>browser-resolve": true
+        "bn.js": true,
+        "browserify>buffer": true
       }
     },
     "ethereumjs-wallet": {
@@ -3252,17 +3191,9 @@
     },
     "ethers>@ethersproject/abi>@ethersproject/bignumber": {
       "packages": {
-        "ethers>@ethersproject/abi>@ethersproject/bignumber>bn.js": true,
+        "bn.js": true,
         "ethers>@ethersproject/abi>@ethersproject/bytes": true,
         "ethers>@ethersproject/abi>@ethersproject/logger": true
-      }
-    },
-    "ethers>@ethersproject/abi>@ethersproject/bignumber>bn.js": {
-      "globals": {
-        "Buffer": true
-      },
-      "packages": {
-        "browserify>browser-resolve": true
       }
     },
     "ethers>@ethersproject/abi>@ethersproject/bytes": {
@@ -3325,17 +3256,9 @@
     },
     "ethers>@ethersproject/address>@ethersproject/bignumber": {
       "packages": {
-        "ethers>@ethersproject/address>@ethersproject/bignumber>bn.js": true,
+        "bn.js": true,
         "ethers>@ethersproject/address>@ethersproject/bytes": true,
         "ethers>@ethersproject/address>@ethersproject/logger": true
-      }
-    },
-    "ethers>@ethersproject/address>@ethersproject/bignumber>bn.js": {
-      "globals": {
-        "Buffer": true
-      },
-      "packages": {
-        "browserify>browser-resolve": true
       }
     },
     "ethers>@ethersproject/address>@ethersproject/bytes": {
@@ -3434,9 +3357,9 @@
     },
     "ethers>@ethersproject/constants>@ethersproject/bignumber": {
       "packages": {
+        "bn.js": true,
         "ethers>@ethersproject/constants>@ethersproject/bignumber>@ethersproject/bytes": true,
-        "ethers>@ethersproject/constants>@ethersproject/bignumber>@ethersproject/logger": true,
-        "ethers>@ethersproject/constants>@ethersproject/bignumber>bn.js": true
+        "ethers>@ethersproject/constants>@ethersproject/bignumber>@ethersproject/logger": true
       }
     },
     "ethers>@ethersproject/constants>@ethersproject/bignumber>@ethersproject/bytes": {
@@ -3447,14 +3370,6 @@
     "ethers>@ethersproject/constants>@ethersproject/bignumber>@ethersproject/logger": {
       "globals": {
         "console": true
-      }
-    },
-    "ethers>@ethersproject/constants>@ethersproject/bignumber>bn.js": {
-      "globals": {
-        "Buffer": true
-      },
-      "packages": {
-        "browserify>browser-resolve": true
       }
     },
     "ethers>@ethersproject/contracts": {
@@ -3533,17 +3448,9 @@
     },
     "ethers>@ethersproject/contracts>@ethersproject/bignumber": {
       "packages": {
-        "ethers>@ethersproject/contracts>@ethersproject/bignumber>bn.js": true,
+        "bn.js": true,
         "ethers>@ethersproject/contracts>@ethersproject/bytes": true,
         "ethers>@ethersproject/contracts>@ethersproject/logger": true
-      }
-    },
-    "ethers>@ethersproject/contracts>@ethersproject/bignumber>bn.js": {
-      "globals": {
-        "Buffer": true
-      },
-      "packages": {
-        "browserify>browser-resolve": true
       }
     },
     "ethers>@ethersproject/contracts>@ethersproject/bytes": {
@@ -3814,17 +3721,9 @@
     },
     "ethers>@ethersproject/providers>@ethersproject/bignumber": {
       "packages": {
-        "ethers>@ethersproject/providers>@ethersproject/bignumber>bn.js": true,
+        "bn.js": true,
         "ethers>@ethersproject/providers>@ethersproject/bytes": true,
         "ethers>@ethersproject/providers>@ethersproject/logger": true
-      }
-    },
-    "ethers>@ethersproject/providers>@ethersproject/bignumber>bn.js": {
-      "globals": {
-        "Buffer": true
-      },
-      "packages": {
-        "browserify>browser-resolve": true
       }
     },
     "ethers>@ethersproject/providers>@ethersproject/bytes": {
@@ -4059,17 +3958,9 @@
     },
     "ethers>@ethersproject/strings>@ethersproject/constants>@ethersproject/bignumber": {
       "packages": {
+        "bn.js": true,
         "ethers>@ethersproject/strings>@ethersproject/bytes": true,
-        "ethers>@ethersproject/strings>@ethersproject/constants>@ethersproject/bignumber>bn.js": true,
         "ethers>@ethersproject/strings>@ethersproject/logger": true
-      }
-    },
-    "ethers>@ethersproject/strings>@ethersproject/constants>@ethersproject/bignumber>bn.js": {
-      "globals": {
-        "Buffer": true
-      },
-      "packages": {
-        "browserify>browser-resolve": true
       }
     },
     "ethers>@ethersproject/strings>@ethersproject/logger": {
@@ -4104,17 +3995,9 @@
     },
     "ethers>@ethersproject/transactions>@ethersproject/bignumber": {
       "packages": {
-        "ethers>@ethersproject/transactions>@ethersproject/bignumber>bn.js": true,
+        "bn.js": true,
         "ethers>@ethersproject/transactions>@ethersproject/bytes": true,
         "ethers>@ethersproject/transactions>@ethersproject/logger": true
-      }
-    },
-    "ethers>@ethersproject/transactions>@ethersproject/bignumber>bn.js": {
-      "globals": {
-        "Buffer": true
-      },
-      "packages": {
-        "browserify>browser-resolve": true
       }
     },
     "ethers>@ethersproject/transactions>@ethersproject/bytes": {
@@ -4264,17 +4147,9 @@
     },
     "ethers>@ethersproject/web>@ethersproject/strings>@ethersproject/constants>@ethersproject/bignumber": {
       "packages": {
+        "bn.js": true,
         "ethers>@ethersproject/web>@ethersproject/bytes": true,
-        "ethers>@ethersproject/web>@ethersproject/logger": true,
-        "ethers>@ethersproject/web>@ethersproject/strings>@ethersproject/constants>@ethersproject/bignumber>bn.js": true
-      }
-    },
-    "ethers>@ethersproject/web>@ethersproject/strings>@ethersproject/constants>@ethersproject/bignumber>bn.js": {
-      "globals": {
-        "Buffer": true
-      },
-      "packages": {
-        "browserify>browser-resolve": true
+        "ethers>@ethersproject/web>@ethersproject/logger": true
       }
     },
     "ethers>@ethersproject/wordlists": {
@@ -4292,10 +4167,10 @@
         "setInterval": true
       },
       "packages": {
+        "bn.js": true,
         "browserify>buffer": true,
         "ethjs-contract": true,
         "ethjs-query": true,
-        "ethjs>bn.js": true,
         "ethjs>ethjs-abi": true,
         "ethjs>ethjs-filter": true,
         "ethjs>ethjs-provider-http": true,
@@ -4317,8 +4192,8 @@
     },
     "ethjs-contract>ethjs-abi": {
       "packages": {
+        "bn.js": true,
         "browserify>buffer": true,
-        "ethjs-contract>ethjs-abi>bn.js": true,
         "ethjs>js-sha3": true,
         "ethjs>number-to-bn": true
       }
@@ -4365,8 +4240,8 @@
     },
     "ethjs>ethjs-abi": {
       "packages": {
+        "bn.js": true,
         "browserify>buffer": true,
-        "ethjs>bn.js": true,
         "ethjs>js-sha3": true,
         "ethjs>number-to-bn": true
       }
@@ -4389,7 +4264,7 @@
     },
     "ethjs>ethjs-unit": {
       "packages": {
-        "ethjs>ethjs-unit>bn.js": true,
+        "bn.js": true,
         "ethjs>number-to-bn": true
       }
     },
@@ -4412,8 +4287,8 @@
     },
     "ethjs>number-to-bn": {
       "packages": {
-        "ethjs>ethjs-util>strip-hex-prefix": true,
-        "ethjs>number-to-bn>bn.js": true
+        "bn.js": true,
+        "ethjs>ethjs-util>strip-hex-prefix": true
       }
     },
     "extension-port-stream": {

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "ts-migration:dashboard:deploy": "gh-pages --dist development/ts-migration-dashboard/build --remote ts-migration-dashboard"
   },
   "resolutions": {
+    "@ethersproject/hash": "^5.7.0",
     "**/regenerator-runtime": "^0.13.7",
     "**/caniuse-lite": "^1.0.30001312",
     "**/cross-fetch": "^3.1.5",

--- a/package.json
+++ b/package.json
@@ -397,7 +397,7 @@
     "webextension-polyfill": "^0.8.0",
     "webpack": "^4.41.6",
     "yargs": "^17.0.1",
-    "yarn-deduplicate": "^3.1.0"
+    "yarn-deduplicate": "^6.0.0"
   },
   "engines": {
     "node": "^16.0.0",
@@ -454,7 +454,8 @@
       "web3>web3-core>web3-core-requestmanager>web3-providers-ws>websocket>bufferutil": false,
       "web3>web3-core>web3-core-requestmanager>web3-providers-ws>websocket>es5-ext": false,
       "web3>web3-core>web3-core-requestmanager>web3-providers-ws>websocket>utf-8-validate": false,
-      "web3>web3-shh": false
+      "web3>web3-shh": false,
+      "ts-node>@swc/core": false
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "ts-migration:dashboard:deploy": "gh-pages --dist development/ts-migration-dashboard/build --remote ts-migration-dashboard"
   },
   "resolutions": {
+    "bn.js": "^5.2.1",
     "@ethersproject/hash": "^5.7.0",
     "**/regenerator-runtime": "^0.13.7",
     "**/caniuse-lite": "^1.0.30001312",
@@ -147,7 +148,7 @@
     "base32-encode": "^1.2.0",
     "base64-js": "^1.5.1",
     "bignumber.js": "^4.1.0",
-    "bn.js": "^4.11.7",
+    "bn.js": "^5.2.1",
     "classnames": "^2.2.6",
     "copy-to-clipboard": "^3.0.8",
     "currency-formatter": "^1.4.2",

--- a/ui/components/app/transaction-decoding/transaction-decoding.component.js
+++ b/ui/components/app/transaction-decoding/transaction-decoding.component.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import inspect from 'browser-util-inspect';
 import { forAddress } from '@truffle/decoder';
 import { useSelector } from 'react-redux';
-import * as Codec from '@truffle/codec';
+import { ResultInspector } from '@truffle/codec/dist/lib/format/utils/inspect';
 import Spinner from '../../ui/spinner';
 import ErrorMessage from '../../ui/error-message';
 import fetchWithCache from '../../../../shared/lib/fetch-with-cache';
@@ -166,7 +166,7 @@ export default function TransactionDecoding({ to = '', inputData: data = '' }) {
           default:
             return (
               <pre className="sol-item solidity-raw">
-                {inspect(new Codec.Format.Utils.Inspect.ResultInspector(value))}
+                {inspect(new ResultInspector(value))}
               </pre>
             );
         }

--- a/ui/components/app/transaction-decoding/transaction-decoding.component.js
+++ b/ui/components/app/transaction-decoding/transaction-decoding.component.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import inspect from 'browser-util-inspect';
 import { forAddress } from '@truffle/decoder';
 import { useSelector } from 'react-redux';
-import { ResultInspector } from '@truffle/codec/dist/lib/format/utils/inspect';
+import * as Codec from '@truffle/codec';
 import Spinner from '../../ui/spinner';
 import ErrorMessage from '../../ui/error-message';
 import fetchWithCache from '../../../../shared/lib/fetch-with-cache';
@@ -166,7 +166,7 @@ export default function TransactionDecoding({ to = '', inputData: data = '' }) {
           default:
             return (
               <pre className="sol-item solidity-raw">
-                {inspect(new ResultInspector(value))}
+                {inspect(new Codec.Format.Utils.Inspect.ResultInspector(value))}
               </pre>
             );
         }

--- a/ui/ducks/send/send.test.js
+++ b/ui/ducks/send/send.test.js
@@ -75,6 +75,8 @@ import { draftTransactionInitialState, editExistingTransaction } from '.';
 
 const mockStore = createMockStore([thunk]);
 
+const mockAddress1 = '0xdafea492d9c6733ae3d56b7ed1adb60692c98123'
+
 jest.mock('./send', () => {
   const actual = jest.requireActual('./send');
   return {
@@ -1061,7 +1063,7 @@ describe('Send Slice', () => {
     describe('QR Code Detected', () => {
       const qrCodestate = getInitialSendStateWithExistingTxState({
         recipient: {
-          address: '0xAddress',
+          address: mockAddress1,
         },
       });
 
@@ -1100,7 +1102,7 @@ describe('Send Slice', () => {
 
         const draftTransaction = getTestUUIDTx(result);
 
-        expect(draftTransaction.recipient.address).toStrictEqual('0xAddress');
+        expect(draftTransaction.recipient.address).toStrictEqual(mockAddress1);
         expect(draftTransaction.recipient.error).toStrictEqual(
           INVALID_RECIPIENT_ADDRESS_ERROR,
         );
@@ -1113,7 +1115,7 @@ describe('Send Slice', () => {
           ...INITIAL_SEND_STATE_FOR_EXISTING_DRAFT,
           selectedAccount: {
             balance: '0x0',
-            address: '0xAddress',
+            address: mockAddress1,
           },
         };
 
@@ -1142,7 +1144,7 @@ describe('Send Slice', () => {
           ...INITIAL_SEND_STATE_FOR_EXISTING_DRAFT,
           selectedAccount: {
             balance: '0x0',
-            address: '0xAddress',
+            address: mockAddress1,
           },
         };
 
@@ -1156,7 +1158,7 @@ describe('Send Slice', () => {
         const result = sendReducer(olderState, action);
 
         expect(result.selectedAccount.balance).toStrictEqual('0x0');
-        expect(result.selectedAccount.address).toStrictEqual('0xAddress');
+        expect(result.selectedAccount.address).toStrictEqual(mockAddress1);
       });
     });
 
@@ -1165,13 +1167,13 @@ describe('Send Slice', () => {
         const accountsChangedState = {
           ...getInitialSendStateWithExistingTxState({
             fromAccount: {
-              address: '0xAddress',
+              address: mockAddress1,
               balance: '0x0',
             },
           }),
           stage: SEND_STAGES.EDIT,
           selectedAccount: {
-            address: '0xAddress',
+            address: mockAddress1,
             balance: '0x0',
           },
         };
@@ -1180,7 +1182,7 @@ describe('Send Slice', () => {
           type: 'ACCOUNT_CHANGED',
           payload: {
             account: {
-              address: '0xAddress',
+              address: mockAddress1,
               balance: '0x1',
             },
           },
@@ -1199,13 +1201,13 @@ describe('Send Slice', () => {
         const accountsChangedState = {
           ...getInitialSendStateWithExistingTxState({
             fromAccount: {
-              address: '0xAddress',
+              address: mockAddress1,
               balance: '0x0',
             },
           }),
           stage: SEND_STAGES.EDIT,
           selectedAccount: {
-            address: '0xAddress',
+            address: mockAddress1,
             balance: '0x0',
           },
         };
@@ -1229,7 +1231,7 @@ describe('Send Slice', () => {
           ...INITIAL_SEND_STATE_FOR_EXISTING_DRAFT,
           stage: SEND_STAGES.EDIT,
           selectedAccount: {
-            address: '0xAddress',
+            address: mockAddress1,
             balance: '0x0',
           },
         };
@@ -1272,23 +1274,23 @@ describe('Send Slice', () => {
                 1559: true,
               },
             },
-            selectedAddress: '0xAddress',
-            identities: { '0xAddress': { address: '0xAddress' } },
+            selectedAddress: mockAddress1,
+            identities: { [mockAddress1]: { address: mockAddress1 } },
             keyrings: [
               {
                 type: 'HD Key Tree',
-                accounts: ['0xAddress'],
+                accounts: [mockAddress1],
               },
             ],
             accounts: {
-              '0xAddress': {
-                address: '0xAddress',
+              [mockAddress1]: {
+                address: mockAddress1,
                 balance: '0x0',
               },
             },
             cachedBalances: {
               0x5: {
-                '0xAddress': '0x0',
+                [mockAddress1]: '0x0',
               },
             },
             provider: {
@@ -1578,12 +1580,12 @@ describe('Send Slice', () => {
           },
           cachedBalances: {
             [CHAIN_IDS.GOERLI]: {
-              '0xAddress': '0x0',
+              [mockAddress1]: '0x0',
             },
           },
           accounts: {
-            '0xAddress': {
-              address: '0xAddress',
+            [mockAddress1]: {
+              address: mockAddress1,
             },
           },
         },
@@ -1605,7 +1607,7 @@ describe('Send Slice', () => {
             userInputHexData: '',
           }),
           selectedAccount: {
-            address: '0xAddress',
+            address: mockAddress1,
           },
         },
       };
@@ -2381,14 +2383,14 @@ describe('Send Slice', () => {
             },
             identities: {},
             accounts: {
-              '0xAddress': {
-                address: '0xAddress',
+              [mockAddress1]: {
+                address: mockAddress1,
                 balance: '0x0',
               },
             },
             cachedBalances: {
               [CHAIN_IDS.GOERLI]: {
-                '0xAddress': '0x0',
+                [mockAddress1]: '0x0',
               },
             },
             tokenList: {},
@@ -2397,7 +2399,7 @@ describe('Send Slice', () => {
                 id: 1,
                 txParams: {
                   data: '',
-                  from: '0xAddress',
+                  from: mockAddress1,
                   to: '0xRecipientAddress',
                   gas: GAS_LIMITS.SIMPLE,
                   gasPrice: '0x3b9aca00', // 1000000000
@@ -2414,7 +2416,7 @@ describe('Send Slice', () => {
             ...getInitialSendStateWithExistingTxState({
               id: 1,
               fromAccount: {
-                address: '0xAddress',
+                address: mockAddress1,
               },
             }),
           },
@@ -2443,7 +2445,7 @@ describe('Send Slice', () => {
               type: ASSET_TYPES.NATIVE,
             },
             fromAccount: {
-              address: '0xAddress',
+              address: mockAddress1,
               balance: '0x0',
             },
             gas: {
@@ -2516,14 +2518,14 @@ describe('Send Slice', () => {
             },
             identities: {},
             accounts: {
-              '0xAddress': {
-                address: '0xAddress',
+              [mockAddress1]: {
+                address: mockAddress1,
                 balance: '0x0',
               },
             },
             cachedBalances: {
               [CHAIN_IDS.GOERLI]: {
-                '0xAddress': '0x0',
+                [mockAddress1]: '0x0',
               },
             },
             tokenList: {},
@@ -2533,10 +2535,10 @@ describe('Send Slice', () => {
                 txParams: {
                   data: generateERC721TransferData({
                     toAddress: BURN_ADDRESS,
-                    fromAddress: '0xAddress',
+                    fromAddress: mockAddress1,
                     tokenId: ethers.BigNumber.from(15000).toString(),
                   }),
-                  from: '0xAddress',
+                  from: mockAddress1,
                   to: '0xCollectibleAddress',
                   gas: GAS_LIMITS.BASE_TOKEN_ESTIMATE,
                   gasPrice: '0x3b9aca00', // 1000000000
@@ -2588,7 +2590,7 @@ describe('Send Slice', () => {
               type: ASSET_TYPES.NATIVE,
             },
             fromAccount: {
-              address: '0xAddress',
+              address: mockAddress1,
               balance: '0x0',
             },
             gas: {
@@ -2701,14 +2703,14 @@ describe('Send Slice', () => {
           },
           identities: {},
           accounts: {
-            '0xAddress': {
-              address: '0xAddress',
+            [mockAddress1]: {
+              address: mockAddress1,
               balance: '0x0',
             },
           },
           cachedBalances: {
             [CHAIN_IDS.GOERLI]: {
-              '0xAddress': '0x0',
+              [mockAddress1]: '0x0',
             },
           },
           unapprovedTxs: {
@@ -2724,7 +2726,7 @@ describe('Send Slice', () => {
                     decimals: 18,
                   },
                 }),
-                from: '0xAddress',
+                from: mockAddress1,
                 to: '0xTokenAddress',
                 gas: GAS_LIMITS.BASE_TOKEN_ESTIMATE,
                 gasPrice: '0x3b9aca00', // 1000000000
@@ -2742,7 +2744,7 @@ describe('Send Slice', () => {
             },
           }),
           selectedAccount: {
-            address: '0xAddress',
+            address: mockAddress1,
             balance: '0x0',
           },
           stage: SEND_STAGES.EDIT,
@@ -2779,7 +2781,7 @@ describe('Send Slice', () => {
             type: ASSET_TYPES.NATIVE,
           },
           fromAccount: {
-            address: '0xAddress',
+            address: mockAddress1,
             balance: '0x0',
           },
           gas: {

--- a/ui/ducks/send/send.test.js
+++ b/ui/ducks/send/send.test.js
@@ -75,7 +75,7 @@ import { draftTransactionInitialState, editExistingTransaction } from '.';
 
 const mockStore = createMockStore([thunk]);
 
-const mockAddress1 = '0xdafea492d9c6733ae3d56b7ed1adb60692c98123'
+const mockAddress1 = '0xdafea492d9c6733ae3d56b7ed1adb60692c98123';
 
 jest.mock('./send', () => {
   const actual = jest.requireActual('./send');

--- a/yarn.lock
+++ b/yarn.lock
@@ -1663,21 +1663,7 @@
   optionalDependencies:
     "@ledgerhq/hw-transport-node-hid" "5.26.0"
 
-"@ethersproject/hash@5.6.0":
-  version "5.6.0"
-  resolved "https://registry.yarnpkg.com/@ethersproject/hash/-/hash-5.6.0.tgz#d24446a5263e02492f9808baa99b6e2b4c3429a2"
-  integrity sha512-fFd+k9gtczqlr0/BruWLAu7UAOas1uRRJvOR84uDf4lNZ+bTkGl366qvniUZHKtlqxBRU65MkOobkmvmpHU+jA==
-  dependencies:
-    "@ethersproject/abstract-signer" "^5.6.0"
-    "@ethersproject/address" "^5.6.0"
-    "@ethersproject/bignumber" "^5.6.0"
-    "@ethersproject/bytes" "^5.6.0"
-    "@ethersproject/keccak256" "^5.6.0"
-    "@ethersproject/logger" "^5.6.0"
-    "@ethersproject/properties" "^5.6.0"
-    "@ethersproject/strings" "^5.6.0"
-
-"@ethersproject/hash@^5.6.0", "@ethersproject/hash@^5.7.0":
+"@ethersproject/hash@5.6.0", "@ethersproject/hash@^5.6.0", "@ethersproject/hash@^5.7.0":
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/hash/-/hash-5.7.0.tgz#eb7aca84a588508369562e16e514b539ba5240a7"
   integrity sha512-qX5WrQfnah1EFnO5zJv1v46a8HW0+E5xuBBDTwMFZLuVTx0tbU2kkx15NqdjxecrLGatQN9FGQKpb1FKdHCt+g==

--- a/yarn.lock
+++ b/yarn.lock
@@ -7325,25 +7325,10 @@ bluebird@3.7.2, bluebird@^3.3.5, bluebird@^3.5.5, bluebird@^3.7.2:
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.2.tgz#9f229c15be272454ffa973ace0dbee79a1b0c36f"
   integrity sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==
 
-bn.js@4.11.6:
-  version "4.11.6"
-  resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.11.6.tgz#53344adb14617a13f6e8dd2ce28905d1c0ba3215"
-  integrity sha1-UzRK2xRhehP26N0s4okF0cC6MhU=
-
-bn.js@4.11.8:
-  version "4.11.8"
-  resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.11.8.tgz#2cde09eb5ee341f484746bb0309b3253b1b1442f"
-  integrity sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==
-
-bn.js@>4.0.0, bn.js@^5.1.1, bn.js@^5.1.2, bn.js@^5.1.3, bn.js@^5.2.0, bn.js@^5.2.1:
+bn.js@4.11.6, bn.js@4.11.8, bn.js@>4.0.0, bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.1.1, bn.js@^4.11.0, bn.js@^4.11.6, bn.js@^4.11.8, bn.js@^4.11.9, bn.js@^5.1.1, bn.js@^5.1.2, bn.js@^5.1.3, bn.js@^5.2.0, bn.js@^5.2.1:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-5.2.1.tgz#0bc527a6a0d18d0aa8d5b0538ce4a77dccfa7b70"
   integrity sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ==
-
-bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.1.1, bn.js@^4.11.0, bn.js@^4.11.6, bn.js@^4.11.7, bn.js@^4.11.8, bn.js@^4.11.9:
-  version "4.12.0"
-  resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.12.0.tgz#775b3f278efbb9718eec7361f483fb36fbbfea88"
-  integrity sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==
 
 bo-selector@0.0.10:
   version "0.0.10"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8754,12 +8754,7 @@ commander@^7.2.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-7.2.0.tgz#a36cb57d0b501ce108e4d20559a150a391d97ab7"
   integrity sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==
 
-commander@^9.0.0:
-  version "9.2.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-9.2.0.tgz#6e21014b2ed90d8b7c9647230d8b7a94a4a419a9"
-  integrity sha512-e2i4wANQiSXgnrBlIatyHtP1odfUp0BbV5Y5nEGbxtIrStkEOAAzCUirvLBNXHLr7kwLvJl6V+4V3XV9x7Wd9w==
-
-commander@^9.4.0:
+commander@^9.0.0, commander@^9.4.0:
   version "9.4.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-9.4.1.tgz#d1dd8f2ce6faf93147295c0df13c7c21141cfbdd"
   integrity sha512-5EEkTNyHNGFPD2H+c/dXXfQZYa/scCKasxWcXJaWnNJ99pnQN9Vnmqow+p+PlFPE63Q6mThaZws1T+HxfpgtPw==
@@ -23807,12 +23802,7 @@ tslib@^1.10.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@^2.0.0, tslib@^2.0.1, tslib@^2.0.3, tslib@^2.2.0, tslib@^2.3.0:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.0.tgz#7cecaa7f073ce680a05847aa77be941098f36dc3"
-  integrity sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==
-
-tslib@^2.4.0:
+tslib@^2.0.0, tslib@^2.0.1, tslib@^2.0.3, tslib@^2.2.0, tslib@^2.3.0, tslib@^2.4.0:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.1.tgz#0d0bfbaac2880b91e22df0768e55be9753a5b17e"
   integrity sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -8744,7 +8744,7 @@ commander@^4.1.1:
   resolved "https://registry.yarnpkg.com/commander/-/commander-4.1.1.tgz#9fd602bd936294e9e9ef46a3f4d6964044b18068"
   integrity sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==
 
-commander@^6.1.0, commander@^6.2.1:
+commander@^6.2.1:
   version "6.2.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-6.2.1.tgz#0792eb682dfbc325999bb2b84fddddba110ac73c"
   integrity sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==
@@ -8758,6 +8758,11 @@ commander@^9.0.0:
   version "9.2.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-9.2.0.tgz#6e21014b2ed90d8b7c9647230d8b7a94a4a419a9"
   integrity sha512-e2i4wANQiSXgnrBlIatyHtP1odfUp0BbV5Y5nEGbxtIrStkEOAAzCUirvLBNXHLr7kwLvJl6V+4V3XV9x7Wd9w==
+
+commander@^9.4.0:
+  version "9.4.1"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-9.4.1.tgz#d1dd8f2ce6faf93147295c0df13c7c21141cfbdd"
+  integrity sha512-5EEkTNyHNGFPD2H+c/dXXfQZYa/scCKasxWcXJaWnNJ99pnQN9Vnmqow+p+PlFPE63Q6mThaZws1T+HxfpgtPw==
 
 comment-parser@1.3.1:
   version "1.3.1"
@@ -17443,8 +17448,6 @@ minimatch@^3.0.2, minimatch@^3.0.4, minimatch@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"
   integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
-  dependencies:
-    brace-expansion "^1.1.7"
 
 minimatch@^5.0.1:
   version "5.0.1"
@@ -23809,6 +23812,11 @@ tslib@^2.0.0, tslib@^2.0.1, tslib@^2.0.3, tslib@^2.2.0, tslib@^2.3.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.0.tgz#7cecaa7f073ce680a05847aa77be941098f36dc3"
   integrity sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==
 
+tslib@^2.4.0:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.1.tgz#0d0bfbaac2880b91e22df0768e55be9753a5b17e"
+  integrity sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==
+
 tslib@~2.0.1:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.0.3.tgz#8e0741ac45fc0c226e58a17bfc3e64b9bc6ca61c"
@@ -25510,14 +25518,15 @@ yargs@^7.1.0:
     y18n "^3.2.1"
     yargs-parser "5.0.0-security.0"
 
-yarn-deduplicate@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/yarn-deduplicate/-/yarn-deduplicate-3.1.0.tgz#3018d93e95f855f236a215b591fe8bc4bcabba3e"
-  integrity sha512-q2VZ6ThNzQpGfNpkPrkmV7x5HT9MOhCUsTxVTzyyZB0eSXz1NTodHn+r29DlLb+peKk8iXxzdUVhQG9pI7moFw==
+yarn-deduplicate@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/yarn-deduplicate/-/yarn-deduplicate-6.0.0.tgz#91bc0b7b374efe24796606df2c6b00eabb5aab62"
+  integrity sha512-HjGVvuy10hetOuXeexXXT77V+6FfgS+NiW3FsmQD88yfF2kBqTpChvMglyKUlQ0xXEcI77VJazll5qKKBl3ssw==
   dependencies:
     "@yarnpkg/lockfile" "^1.1.0"
-    commander "^6.1.0"
-    semver "^7.3.2"
+    commander "^9.4.0"
+    semver "^7.3.7"
+    tslib "^2.4.0"
 
 yauzl@2.10.0, yauzl@^2.10.0:
   version "2.10.0"


### PR DESCRIPTION
- dedupe`bn.js` (many many copies, ~1MB) and fix junk data we're passing to it in tests
- dedupe `@ethersproject/hash` (slow init time)
- update yarn-deduplicate (no reason in particular)
- ui/tx-decoding modified and reverted - a failed attempt to reduce bundle size