### PR TITLE
Fix to direct the token detection settings search to the correct row

### DIFF
--- a/ui/pages/settings/advanced-tab/advanced-tab.component.js
+++ b/ui/pages/settings/advanced-tab/advanced-tab.component.js
@@ -185,7 +185,7 @@ export default class AdvancedTab extends PureComponent {
 
     return (
       <div
-        ref={this.settingsRefs[15]}
+        ref={this.settingsRefs[14]}
         className="settings-page__content-row"
         data-testid="advanced-setting-data-restore"
       >
@@ -247,7 +247,7 @@ export default class AdvancedTab extends PureComponent {
     const { t } = this.context;
     return (
       <div
-        ref={this.settingsRefs[14]}
+        ref={this.settingsRefs[13]}
         className="settings-page__content-row"
         data-testid="advanced-setting-data-backup"
       >
@@ -605,7 +605,7 @@ export default class AdvancedTab extends PureComponent {
       : LEDGER_TRANSPORT_NAMES.U2F;
 
     return (
-      <div ref={this.settingsRefs[11]} className="settings-page__content-row">
+      <div ref={this.settingsRefs[10]} className="settings-page__content-row">
         <div className="settings-page__content-item">
           <span>{t('preferredLedgerConnectionType')}</span>
           <div className="settings-page__content-description">
@@ -704,7 +704,7 @@ export default class AdvancedTab extends PureComponent {
 
     return (
       <div
-        ref={this.settingsRefs[10]}
+        ref={this.settingsRefs[9]}
         className="settings-page__content-row"
         data-testid="advanced-setting-ipfs-gateway"
       >
@@ -747,7 +747,7 @@ export default class AdvancedTab extends PureComponent {
 
     return (
       <div
-        ref={this.settingsRefs[12]}
+        ref={this.settingsRefs[11]}
         className="settings-page__content-row"
         data-testid="advanced-setting-dismiss-reminder"
       >
@@ -777,7 +777,7 @@ export default class AdvancedTab extends PureComponent {
 
     return (
       <div
-        ref={this.settingsRefs[13]}
+        ref={this.settingsRefs[12]}
         className="settings-page__content-row"
         data-testid="advanced-setting-token-detection"
       >


### PR DESCRIPTION
The route `${ADVANCED_ROUTE}#token-description` was getting directed to the wrong row in the advanced tab after some recent changes. This PR reorders the index so that the route navigates to the correct row.