### PR TITLE
Fix orphaned data warning

### DIFF
--- a/app/scripts/lib/stream-utils.js
+++ b/app/scripts/lib/stream-utils.js
@@ -9,6 +9,13 @@ import pump from 'pump';
  */
 export function setupMultiplex(connectionStream) {
   const mux = new ObjectMultiplex();
+  /**
+   * We are using this streams to send keep alive message between backend/ui without setting up a multiplexer
+   * We need to tell the multiplexer to ignore them, else we get the " orphaned data for stream " warnings
+   */
+  mux.ignoreStream('CONNECTION_READY');
+  mux.ignoreStream('ACK_KEEP_ALIVE_MESSAGE');
+  mux.ignoreStream('WORKER_KEEP_ALIVE_MESSAGE');
   pump(connectionStream, mux, connectionStream, (err) => {
     if (err) {
       console.error(err);

--- a/app/scripts/lib/stream-utils.js
+++ b/app/scripts/lib/stream-utils.js
@@ -12,6 +12,7 @@ export function setupMultiplex(connectionStream) {
   /**
    * We are using this streams to send keep alive message between backend/ui without setting up a multiplexer
    * We need to tell the multiplexer to ignore them, else we get the " orphaned data for stream " warnings
+   * https://github.com/MetaMask/object-multiplex/blob/280385401de84f57ef57054d92cfeb8361ef2680/src/ObjectMultiplex.ts#L63
    */
   mux.ignoreStream('CONNECTION_READY');
   mux.ignoreStream('ACK_KEEP_ALIVE_MESSAGE');


### PR DESCRIPTION
## Explanation

We have some messages we send back/forth between UI and background without using the multiplexer, this generates lots of warnings in the console. `ObjectMultiplex - orphaned data for stream "${message}"`.

This PR fixes this by asking the multiplexer to [ignore these messages.](https://github.com/MetaMask/object-multiplex/blob/280385401de84f57ef57054d92cfeb8361ef2680/src/ObjectMultiplex.ts#L63)

* See: [thread](https://consensys.slack.com/archives/C02DUDT2WTU/p1667887408983649)

## Screenshots/Screencaps

![image](https://user-images.githubusercontent.com/44811/200538181-9896d2fe-9f42-4ea8-90aa-bb24f40fdc0b.png)


## Manual Testing Steps

1. Checkout develop branch
2. Start MetaMask in MV3 mode `yarn start:mv3`
3. Launch MetaMask
4. Launch dev-tools, set console level to warn
5. See the warnings in the console.
6. Checkout this PR
7. Do stem 2 to 4 again
8. See that the warnings no longer show.

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
