### PR TITLE
[FLASK] Catch and display error in snaps insight

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -3257,6 +3257,10 @@
   "snaps": {
     "message": "Snaps"
   },
+  "snapsInsightError": {
+    "message": "An error occured with $1: $2",
+    "description": "This is shown when the insight snap throws an error. $1 is the snap name, $2 is the error message."
+  },
   "snapsInsightLoading": {
     "message": "Loading transaction insight..."
   },

--- a/ui/components/app/confirm-page-container/flask/snap-insight.js
+++ b/ui/components/app/confirm-page-container/flask/snap-insight.js
@@ -50,7 +50,7 @@ export const SnapInsight = ({ transaction, chainId, selectedSnap }) => {
           flexDirection={FLEX_DIRECTION.COLUMN}
           className="snap-insight__container"
         >
-          {data && Object.keys(data).length ? (
+          {data && Object.keys(data).length > 0 ? (
             <>
               <Box
                 flexDirection={FLEX_DIRECTION.COLUMN}

--- a/ui/components/app/confirm-page-container/flask/snap-insight.js
+++ b/ui/components/app/confirm-page-container/flask/snap-insight.js
@@ -15,10 +15,11 @@ import { useI18nContext } from '../../../../hooks/useI18nContext';
 import { useTransactionInsightSnap } from '../../../../hooks/flask/useTransactionInsightSnap';
 import SnapContentFooter from '../../flask/snap-content-footer/snap-content-footer';
 import Box from '../../../ui/box/box';
+import ActionableMessage from '../../../ui/actionable-message/actionable-message';
 
 export const SnapInsight = ({ transaction, chainId, selectedSnap }) => {
   const t = useI18nContext();
-  const response = useTransactionInsightSnap({
+  const { data: response, error } = useTransactionInsightSnap({
     transaction,
     chainId,
     snapId: selectedSnap.id,
@@ -26,7 +27,7 @@ export const SnapInsight = ({ transaction, chainId, selectedSnap }) => {
 
   const data = response?.insights;
 
-  const hasNoData = !data || !Object.keys(data).length;
+  const hasNoData = (!data || !Object.keys(data).length) && !error;
 
   return (
     <Box
@@ -39,7 +40,7 @@ export const SnapInsight = ({ transaction, chainId, selectedSnap }) => {
       textAlign={hasNoData && TEXT_ALIGN.CENTER}
       className="snap-insight"
     >
-      {data ? (
+      {data && !error && (
         <Box
           height="full"
           flexDirection={FLEX_DIRECTION.COLUMN}
@@ -94,7 +95,8 @@ export const SnapInsight = ({ transaction, chainId, selectedSnap }) => {
             </Typography>
           )}
         </Box>
-      ) : (
+      )}
+      {!data && !error && (
         <>
           <Preloader size={40} />
           <Typography
@@ -105,6 +107,25 @@ export const SnapInsight = ({ transaction, chainId, selectedSnap }) => {
             {t('snapsInsightLoading')}
           </Typography>
         </>
+      )}
+      {!data && error && (
+        <Box
+          paddingTop={0}
+          paddingRight={6}
+          paddingBottom={3}
+          paddingLeft={6}
+          className="snap-insight__container__error"
+        >
+          <ActionableMessage
+            message={t('snapsInsightError', [
+              selectedSnap.manifest.proposedName,
+              error.message,
+            ])}
+            type="danger"
+            useIcon
+            iconFillColor="var(--color-error-default)"
+          />
+        </Box>
       )}
     </Box>
   );

--- a/ui/components/app/confirm-page-container/flask/snap-insight.js
+++ b/ui/components/app/confirm-page-container/flask/snap-insight.js
@@ -32,7 +32,7 @@ export const SnapInsight = ({ transaction, chainId, selectedSnap }) => {
   const data = response?.insights;
 
   const hasNoData =
-    !error && (loading || !data || (data && !Object.keys(data).length));
+    !error && (loading || !data || (data && Object.keys(data).length === 0));
   return (
     <Box
       flexDirection={FLEX_DIRECTION.COLUMN}

--- a/ui/components/app/confirm-page-container/flask/snap-insight.js
+++ b/ui/components/app/confirm-page-container/flask/snap-insight.js
@@ -19,7 +19,11 @@ import ActionableMessage from '../../../ui/actionable-message/actionable-message
 
 export const SnapInsight = ({ transaction, chainId, selectedSnap }) => {
   const t = useI18nContext();
-  const { data: response, error } = useTransactionInsightSnap({
+  const {
+    data: response,
+    error,
+    loading,
+  } = useTransactionInsightSnap({
     transaction,
     chainId,
     snapId: selectedSnap.id,
@@ -27,8 +31,8 @@ export const SnapInsight = ({ transaction, chainId, selectedSnap }) => {
 
   const data = response?.insights;
 
-  const hasNoData = (!data || (data && !Object.keys(data).length)) && !error;
-
+  const hasNoData =
+    !error && (loading || !data || (data && !Object.keys(data).length));
   return (
     <Box
       flexDirection={FLEX_DIRECTION.COLUMN}
@@ -40,7 +44,7 @@ export const SnapInsight = ({ transaction, chainId, selectedSnap }) => {
       textAlign={hasNoData && TEXT_ALIGN.CENTER}
       className="snap-insight"
     >
-      {response && !error && (
+      {!loading && !error && (
         <Box
           height="full"
           flexDirection={FLEX_DIRECTION.COLUMN}
@@ -96,19 +100,8 @@ export const SnapInsight = ({ transaction, chainId, selectedSnap }) => {
           )}
         </Box>
       )}
-      {!response && !error && (
-        <>
-          <Preloader size={40} />
-          <Typography
-            marginTop={3}
-            color={COLORS.TEXT_ALTERNATIVE}
-            variant={TYPOGRAPHY.H6}
-          >
-            {t('snapsInsightLoading')}
-          </Typography>
-        </>
-      )}
-      {!response && error && (
+
+      {!loading && error && (
         <Box
           paddingTop={0}
           paddingRight={6}
@@ -126,6 +119,19 @@ export const SnapInsight = ({ transaction, chainId, selectedSnap }) => {
             iconFillColor="var(--color-error-default)"
           />
         </Box>
+      )}
+
+      {loading && (
+        <>
+          <Preloader size={40} />
+          <Typography
+            marginTop={3}
+            color={COLORS.TEXT_ALTERNATIVE}
+            variant={TYPOGRAPHY.H6}
+          >
+            {t('snapsInsightLoading')}
+          </Typography>
+        </>
       )}
     </Box>
   );

--- a/ui/components/app/confirm-page-container/flask/snap-insight.js
+++ b/ui/components/app/confirm-page-container/flask/snap-insight.js
@@ -27,7 +27,7 @@ export const SnapInsight = ({ transaction, chainId, selectedSnap }) => {
 
   const data = response?.insights;
 
-  const hasNoData = (!data || !Object.keys(data).length) && !error;
+  const hasNoData = (!data || (data && !Object.keys(data).length)) && !error;
 
   return (
     <Box
@@ -40,13 +40,13 @@ export const SnapInsight = ({ transaction, chainId, selectedSnap }) => {
       textAlign={hasNoData && TEXT_ALIGN.CENTER}
       className="snap-insight"
     >
-      {data && !error && (
+      {response && !error && (
         <Box
           height="full"
           flexDirection={FLEX_DIRECTION.COLUMN}
           className="snap-insight__container"
         >
-          {Object.keys(data).length ? (
+          {data && Object.keys(data).length ? (
             <>
               <Box
                 flexDirection={FLEX_DIRECTION.COLUMN}
@@ -96,7 +96,7 @@ export const SnapInsight = ({ transaction, chainId, selectedSnap }) => {
           )}
         </Box>
       )}
-      {!data && !error && (
+      {!response && !error && (
         <>
           <Preloader size={40} />
           <Typography
@@ -108,7 +108,7 @@ export const SnapInsight = ({ transaction, chainId, selectedSnap }) => {
           </Typography>
         </>
       )}
-      {!data && error && (
+      {!response && error && (
         <Box
           paddingTop={0}
           paddingRight={6}

--- a/ui/hooks/flask/useTransactionInsightSnap.js
+++ b/ui/hooks/flask/useTransactionInsightSnap.js
@@ -13,25 +13,30 @@ export function useTransactionInsightSnap({ transaction, chainId, snapId }) {
     );
   }
   const [data, setData] = useState(undefined);
+  const [error, setError] = useState(undefined);
 
   useEffect(() => {
     async function fetchInsight() {
-      const d = await handleSnapRequest({
-        snapId,
-        origin: '',
-        handler: 'onTransaction',
-        request: {
-          jsonrpc: '2.0',
-          method: ' ',
-          params: { transaction, chainId },
-        },
-      });
-      setData(d);
+      try {
+        const d = await handleSnapRequest({
+          snapId,
+          origin: '',
+          handler: 'onTransaction',
+          request: {
+            jsonrpc: '2.0',
+            method: ' ',
+            params: { transaction, chainId },
+          },
+        });
+        setData(d);
+      } catch (err) {
+        setError(err);
+      }
     }
     if (transaction) {
       fetchInsight();
     }
   }, [snapId, transaction, chainId]);
 
-  return data;
+  return { data, error };
 }

--- a/ui/hooks/flask/useTransactionInsightSnap.js
+++ b/ui/hooks/flask/useTransactionInsightSnap.js
@@ -20,6 +20,9 @@ export function useTransactionInsightSnap({ transaction, chainId, snapId }) {
   useEffect(() => {
     async function fetchInsight() {
       try {
+        setError(undefined);
+        setLoading(true);
+
         const d = await handleSnapRequest({
           snapId,
           origin: '',

--- a/ui/hooks/flask/useTransactionInsightSnap.js
+++ b/ui/hooks/flask/useTransactionInsightSnap.js
@@ -12,6 +12,8 @@ export function useTransactionInsightSnap({ transaction, chainId, snapId }) {
       'This snap does not have the transaction insight endowment.',
     );
   }
+
+  const [loading, setLoading] = useState(true);
   const [data, setData] = useState(undefined);
   const [error, setError] = useState(undefined);
 
@@ -31,6 +33,8 @@ export function useTransactionInsightSnap({ transaction, chainId, snapId }) {
         setData(d);
       } catch (err) {
         setError(err);
+      } finally {
+        setLoading(false);
       }
     }
     if (transaction) {
@@ -38,5 +42,5 @@ export function useTransactionInsightSnap({ transaction, chainId, snapId }) {
     }
   }, [snapId, transaction, chainId]);
 
-  return { data, error };
+  return { data, error, loading };
 }

--- a/ui/pages/confirm-transaction-base/confirm-transaction-base.component.js
+++ b/ui/pages/confirm-transaction-base/confirm-transaction-base.component.js
@@ -764,10 +764,17 @@ export default class ConfirmTransactionBase extends Component {
       ({ id }) => id === selectedInsightSnapId,
     );
 
+    const allowedTransactionTypes =
+      txData.type === TRANSACTION_TYPES.CONTRACT_INTERACTION ||
+      txData.type === TRANSACTION_TYPES.SIMPLE_SEND ||
+      txData.type === TRANSACTION_TYPES.TOKEN_METHOD_SAFE_TRANSFER_FROM ||
+      txData.type === TRANSACTION_TYPES.TOKEN_METHOD_TRANSFER_FROM ||
+      txData.type === TRANSACTION_TYPES.TOKEN_METHOD_TRANSFER;
+
     const networkId = CHAIN_ID_TO_NETWORK_ID_MAP[chainId];
     const caip2ChainId = `eip155:${networkId ?? stripHexPrefix(chainId)}`;
 
-    if (!insightSnaps.length) {
+    if (!allowedTransactionTypes || !insightSnaps.length) {
       return null;
     }
 

--- a/ui/pages/confirm-transaction-base/confirm-transaction-base.component.js
+++ b/ui/pages/confirm-transaction-base/confirm-transaction-base.component.js
@@ -764,17 +764,10 @@ export default class ConfirmTransactionBase extends Component {
       ({ id }) => id === selectedInsightSnapId,
     );
 
-    const allowedTransactionTypes =
-      txData.type === TRANSACTION_TYPES.CONTRACT_INTERACTION ||
-      txData.type === TRANSACTION_TYPES.SIMPLE_SEND ||
-      txData.type === TRANSACTION_TYPES.TOKEN_METHOD_SAFE_TRANSFER_FROM ||
-      txData.type === TRANSACTION_TYPES.TOKEN_METHOD_TRANSFER_FROM ||
-      txData.type === TRANSACTION_TYPES.TOKEN_METHOD_TRANSFER;
-
     const networkId = CHAIN_ID_TO_NETWORK_ID_MAP[chainId];
     const caip2ChainId = `eip155:${networkId ?? stripHexPrefix(chainId)}`;
 
-    if (!allowedTransactionTypes || !insightSnaps.length) {
+    if (!insightSnaps.length) {
       return null;
     }
 


### PR DESCRIPTION
## Explanation

Allow snaps insight to catch errors thrown by the snap and display them in an error state. It also allows the empty state to display if the data is null

* Fixes https://github.com/MetaMask/snaps-monorepo/issues/901

## Screenshots/Screencaps

![image](https://user-images.githubusercontent.com/13910212/200544932-1d83f135-f9a8-4486-b21f-8235eda76aed.png)


## Manual Testing Steps

- create a snap exporting `onTransaction` and make that function throw an error.
- Initiate a transaction and look at the snap insight tab