### PR TITLE
Parallelize E2E tests to cut CI time in half

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -516,6 +516,7 @@ jobs:
 
   test-e2e-chrome:
     executor: node-browsers
+    parallelism: 4
     steps:
       - checkout
       - run:
@@ -543,6 +544,7 @@ jobs:
     
   test-e2e-chrome-mv3:
     executor: node-browsers
+    parallelism: 4
     steps:
       - checkout
       - run:
@@ -570,6 +572,7 @@ jobs:
 
   test-e2e-firefox-snaps:
     executor: node-browsers
+    parallelism: 4
     steps:
       - checkout
       - run:
@@ -597,6 +600,7 @@ jobs:
 
   test-e2e-chrome-snaps:
     executor: node-browsers
+    parallelism: 4
     steps:
       - checkout
       - run:
@@ -624,6 +628,7 @@ jobs:
 
   test-e2e-firefox:
     executor: node-browsers-medium-plus
+    parallelism: 4
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -516,7 +516,7 @@ jobs:
 
   test-e2e-chrome:
     executor: node-browsers
-    parallelism: 4
+    parallelism: 8
     steps:
       - checkout
       - run:
@@ -544,7 +544,7 @@ jobs:
     
   test-e2e-chrome-mv3:
     executor: node-browsers
-    parallelism: 4
+    parallelism: 8
     steps:
       - checkout
       - run:
@@ -572,7 +572,7 @@ jobs:
 
   test-e2e-firefox-snaps:
     executor: node-browsers
-    parallelism: 4
+    parallelism: 2
     steps:
       - checkout
       - run:
@@ -600,7 +600,7 @@ jobs:
 
   test-e2e-chrome-snaps:
     executor: node-browsers
-    parallelism: 4
+    parallelism: 2
     steps:
       - checkout
       - run:
@@ -628,7 +628,7 @@ jobs:
 
   test-e2e-firefox:
     executor: node-browsers-medium-plus
-    parallelism: 4
+    parallelism: 8
     steps:
       - checkout
       - run:

--- a/test/e2e/run-all.js
+++ b/test/e2e/run-all.js
@@ -17,7 +17,7 @@ const getTestPathsForTestDir = async (testDir) => {
 function chunk(array, chunkSize) {
   const result = [];
   for (let i = 0; i < array.length; i += chunkSize) {
-      result.push(array.slice(i, i + chunkSize));
+    result.push(array.slice(i, i + chunkSize));
   }
   return result;
 }

--- a/test/e2e/run-all.js
+++ b/test/e2e/run-all.js
@@ -13,6 +13,15 @@ const getTestPathsForTestDir = async (testDir) => {
   return testPaths;
 };
 
+// TODO: Simplify?
+function chunk(array, chunkSize) {
+  const result = [];
+  for (let i = 0; i < array.length; i += chunkSize) {
+      result.push(array.slice(i, i + chunkSize));
+  }
+  return result;
+}
+
 async function main() {
   const { argv } = yargs(hideBin(process.argv))
     .usage(
@@ -66,7 +75,14 @@ async function main() {
     args.push('--retries', retries);
   }
 
-  for (const testPath of testPaths) {
+  // For running E2Es in parallel in CI
+  const currentChunkIndex = process.env.CIRCLE_NODE_INDEX ?? 0;
+  const totalChunks = process.env.CIRCLE_NODE_TOTAL ?? 1;
+  const chunkSize = testPaths.length / totalChunks;
+  const chunks = chunk(testPaths, chunkSize);
+  const currentChunk = chunks[currentChunkIndex];
+
+  for (const testPath of currentChunk) {
     await runInShell('node', [...args, testPath]);
   }
 }

--- a/test/e2e/run-all.js
+++ b/test/e2e/run-all.js
@@ -13,7 +13,6 @@ const getTestPathsForTestDir = async (testDir) => {
   return testPaths;
 };
 
-// TODO: Simplify?
 function chunk(array, chunkSize) {
   const result = [];
   for (let i = 0; i < array.length; i += chunkSize) {
@@ -78,7 +77,7 @@ async function main() {
   // For running E2Es in parallel in CI
   const currentChunkIndex = process.env.CIRCLE_NODE_INDEX ?? 0;
   const totalChunks = process.env.CIRCLE_NODE_TOTAL ?? 1;
-  const chunkSize = testPaths.length / totalChunks;
+  const chunkSize = Math.ceil(testPaths.length / totalChunks);
   const chunks = chunk(testPaths, chunkSize);
   const currentChunk = chunks[currentChunkIndex];
 


### PR DESCRIPTION
## Explanation

Adds logic in `run-all.js` to allow for running E2E tests in parallel and enables parallelism in Circle CI.

Assuming the old configuration runs at around 60 minutes:
- With `parallelism: 4`, the CI now runs a full **22 minutes** faster than the old configuration.
- With `parallelism: 8`, the CI now runs a full **28 minutes** faster than the old configuration.

This means we can **effectively cut CI time in half with this PR**.
