### PR TITLE
Update `TextFieldBase` to include InputComponent prop

### DIFF
--- a/ui/components/component-library/text-field-base/README.mdx
+++ b/ui/components/component-library/text-field-base/README.mdx
@@ -192,6 +192,8 @@ const handleOnChange = (e) => {
 
 Use the `InputComponent` prop change the component used for the input element. This is useful for replacing the base input with a custom input while retaining the functionality of the `TextFieldBase`.
 
+Defaults to the [Text](/docs/ui-components-component-library-text-text-stories-js--default-story) component
+
 To function fully the custom component should accept the following props:
 
 - `aria-invalid`

--- a/ui/components/component-library/text-field-base/README.mdx
+++ b/ui/components/component-library/text-field-base/README.mdx
@@ -188,6 +188,42 @@ const handleOnChange = (e) => {
 </Box>
 ```
 
+### Input Component
+
+Use the `InputComponent` prop change the component used for the input element. This is useful for replacing the base input with a custom input while retaining the functionality of the `TextFieldBase`.
+
+To function fully the custom component should accept the following props:
+
+- `aria-invalid`
+- `as`
+- `autoComplete`
+- `autoFocus`
+- ` backgroundColor`
+- `defaultValue`
+- `disabled`
+- ` focused`
+- `id`
+- `margin`
+- ` maxLength`
+- `name`
+- `onBlur`
+- ` onChange`
+- `onFocus`
+- `padding`
+- ` paddingLeft`
+- `paddingRight`
+- `placeholder`
+- ` readOnly`
+- `ref`
+- `required`
+- ` value`
+- `variant`
+- `type`
+
+<Canvas>
+  <Story id="ui-components-component-library-text-field-base-text-field-base-stories-js--input-component" />
+</Canvas>
+
 ### Auto Complete
 
 Use the `autoComplete` prop to set the autocomplete html attribute. It allows the browser to predict the value based on earlier typed values.

--- a/ui/components/component-library/text-field-base/README.mdx
+++ b/ui/components/component-library/text-field-base/README.mdx
@@ -224,6 +224,23 @@ To function fully the custom component should accept the following props:
   <Story id="ui-components-component-library-text-field-base-text-field-base-stories-js--input-component" />
 </Canvas>
 
+```jsx
+import { TextFieldBase, Icon, ICON_NAMES } from '../../ui/component-library';
+
+// should map the props to the custom input component
+const CustomInputComponent = () => <div>{/* Custom input component */}</div>;
+
+const TextFieldCustomInput = (args) => (
+  <TextFieldBase
+    size={SIZES.LG}
+    InputComponent={CustomInputComponent}
+    leftAccessory={
+      <Icon color={COLORS.ICON_ALTERNATIVE} name={ICON_NAMES.WALLET_FILLED} />
+    }
+  />
+);
+```
+
 ### Auto Complete
 
 Use the `autoComplete` prop to set the autocomplete html attribute. It allows the browser to predict the value based on earlier typed values.

--- a/ui/components/component-library/text-field-base/README.mdx
+++ b/ui/components/component-library/text-field-base/README.mdx
@@ -200,25 +200,25 @@ To function fully the custom component should accept the following props:
 - `as`
 - `autoComplete`
 - `autoFocus`
-- ` backgroundColor`
+- `backgroundColor`
 - `defaultValue`
 - `disabled`
-- ` focused`
+- `focused`
 - `id`
 - `margin`
-- ` maxLength`
+- `maxLength`
 - `name`
 - `onBlur`
-- ` onChange`
+- `onChange`
 - `onFocus`
 - `padding`
-- ` paddingLeft`
+- `paddingLeft`
 - `paddingRight`
 - `placeholder`
-- ` readOnly`
+- `readOnly`
 - `ref`
 - `required`
-- ` value`
+- `value`
 - `variant`
 - `type`
 

--- a/ui/components/component-library/text-field-base/text-field-base.js
+++ b/ui/components/component-library/text-field-base/text-field-base.js
@@ -44,6 +44,7 @@ export const TextFieldBase = ({
   type = 'text',
   truncate = true,
   value,
+  InputComponent = Text,
   ...props
 }) => {
   const internalInputRef = useRef(null);
@@ -107,13 +108,13 @@ export const TextFieldBase = ({
       alignItems={ALIGN_ITEMS.CENTER}
       borderWidth={1}
       borderRadius={SIZES.SM}
-      paddingLeft={4}
-      paddingRight={4}
+      paddingLeft={leftAccessory ? 4 : 0}
+      paddingRight={rightAccessory ? 4 : 0}
       onClick={handleClick}
       {...props}
     >
       {leftAccessory}
-      <Text
+      <InputComponent
         aria-invalid={error}
         as="input"
         autoComplete={autoComplete ? 'on' : 'off'}
@@ -130,8 +131,8 @@ export const TextFieldBase = ({
         onChange={onChange}
         onFocus={handleFocus}
         padding={0}
-        paddingLeft={leftAccessory ? 2 : null}
-        paddingRight={leftAccessory ? 2 : null}
+        paddingLeft={leftAccessory ? 2 : 4}
+        paddingRight={rightAccessory ? 2 : 4}
         placeholder={placeholder}
         readOnly={readOnly}
         ref={handleInputRef}
@@ -179,6 +180,11 @@ TextFieldBase.propTypes = {
    * The id of the `input` element.
    */
   id: PropTypes.string,
+  /**
+   * The the component that is rendered as the input
+   * Defaults to the Text component
+   */
+  InputComponent: PropTypes.elementType,
   /**
    * Attributes applied to the `input` element.
    */

--- a/ui/components/component-library/text-field-base/text-field-base.stories.js
+++ b/ui/components/component-library/text-field-base/text-field-base.stories.js
@@ -6,7 +6,6 @@ import {
   COLORS,
   FLEX_DIRECTION,
   ALIGN_ITEMS,
-  BORDER_STYLE,
   TEXT,
 } from '../../../helpers/constants/design-system';
 import Box from '../../ui/box/box';
@@ -351,16 +350,15 @@ export const InputRef = (args) => {
     </>
   );
 };
+
 const CustomInputComponent = ({
   as,
   autoComplete,
   autoFocus,
-  backgroundColor,
   defaultValue,
   disabled,
   focused,
   id,
-  margin,
   maxLength,
   name,
   onBlur,
@@ -421,6 +419,8 @@ const CustomInputComponent = ({
     </Box>
   );
 };
+
+CustomInputComponent.propTypes = { ...TextFieldBase.propTypes };
 
 export const InputComponent = (args) => (
   <TextFieldBase

--- a/ui/components/component-library/text-field-base/text-field-base.stories.js
+++ b/ui/components/component-library/text-field-base/text-field-base.stories.js
@@ -6,6 +6,7 @@ import {
   COLORS,
   FLEX_DIRECTION,
   ALIGN_ITEMS,
+  BORDER_STYLE,
   TEXT,
 } from '../../../helpers/constants/design-system';
 import Box from '../../ui/box/box';
@@ -347,6 +348,94 @@ export const InputRef = (args) => {
       >
         Edit
       </Box>
+    </>
+  );
+};
+const CustomInputComponent = ({
+  as,
+  autoComplete,
+  autoFocus,
+  backgroundColor,
+  defaultValue,
+  disabled,
+  focused,
+  id,
+  margin,
+  maxLength,
+  name,
+  onBlur,
+  onChange,
+  onFocus,
+  padding,
+  paddingLeft,
+  paddingRight,
+  placeholder,
+  readOnly,
+  ref,
+  required,
+  value,
+  variant,
+  type,
+  className,
+  'aria-invalid': ariaInvalid,
+  ...props
+}) => {
+  return (
+    <Box
+      display={DISPLAY.FLEX}
+      flexDirection={FLEX_DIRECTION.COLUMN}
+      {...{ padding, paddingLeft, paddingRight, ...props }}
+    >
+      <Box display={DISPLAY.INLINE_FLEX}>
+        <Text
+          style={{ padding: 0 }}
+          aria-invalid={ariaInvalid}
+          {...{
+            as,
+            className,
+            autoComplete,
+            autoFocus,
+            defaultValue,
+            disabled,
+            focused,
+            id,
+            maxLength,
+            name,
+            onBlur,
+            onChange,
+            onFocus,
+            placeholder,
+            readOnly,
+            ref,
+            required,
+            value,
+            variant,
+            type,
+          }}
+        />
+        <Text variant={TEXT.BODY_XS} color={COLORS.TEXT_ALTERNATIVE}>
+          GoerliETH
+        </Text>
+      </Box>
+      <Text variant={TEXT.BODY_XS}>No conversion rate available</Text>
+    </Box>
+  );
+};
+
+export const InputComponent = (args) => {
+  return (
+    <>
+      <TextFieldBase
+        {...args}
+        size={SIZES.LG}
+        InputComponent={CustomInputComponent}
+        leftAccessory={
+          <Icon
+            color={COLORS.ICON_ALTERNATIVE}
+            name={ICON_NAMES.WALLET_FILLED}
+          />
+        }
+      />
     </>
   );
 };

--- a/ui/components/component-library/text-field-base/text-field-base.stories.js
+++ b/ui/components/component-library/text-field-base/text-field-base.stories.js
@@ -422,23 +422,18 @@ const CustomInputComponent = ({
   );
 };
 
-export const InputComponent = (args) => {
-  return (
-    <>
-      <TextFieldBase
-        {...args}
-        size={SIZES.LG}
-        InputComponent={CustomInputComponent}
-        leftAccessory={
-          <Icon
-            color={COLORS.ICON_ALTERNATIVE}
-            name={ICON_NAMES.WALLET_FILLED}
-          />
-        }
-      />
-    </>
-  );
-};
+export const InputComponent = (args) => (
+  <TextFieldBase
+    {...args}
+    placeholder="0"
+    type="number"
+    size={SIZES.LG}
+    InputComponent={CustomInputComponent}
+    leftAccessory={
+      <Icon color={COLORS.ICON_ALTERNATIVE} name={ICON_NAMES.WALLET_FILLED} />
+    }
+  />
+);
 
 export const AutoComplete = Template.bind({});
 AutoComplete.args = {

--- a/ui/components/component-library/text-field-base/text-field-base.test.js
+++ b/ui/components/component-library/text-field-base/text-field-base.test.js
@@ -235,4 +235,20 @@ describe('TextFieldBase', () => {
       '',
     );
   });
+  it('should render with a custom input and still work', () => {
+    const CustomInputComponent = (props) => <input {...props} />;
+    const { getByTestId } = render(
+      <TextFieldBase
+        InputComponent={CustomInputComponent}
+        inputProps={{ 'data-testid': 'text-field-base', className: 'test' }}
+      />,
+    );
+    const textFieldBase = getByTestId('text-field-base');
+
+    expect(textFieldBase.value).toBe(''); // initial value is empty string
+    fireEvent.change(textFieldBase, { target: { value: 'text value' } });
+    expect(textFieldBase.value).toBe('text value');
+    fireEvent.change(textFieldBase, { target: { value: '' } }); // reset value
+    expect(textFieldBase.value).toBe(''); // value is empty string after reset
+  });
 });


### PR DESCRIPTION
## Explanation

* What is the current state of things and why does it need to change?
The current `TextFieldBase` doesn't allow for custom input components. This limits the usage of the component and prevents it being used for custom input components that still need to retain some of the `TextFieldBase` attributes.

* What is the solution your changes offer and how does it work?
To improve the inversion of control of this component I have replaced the static `Text` component with a prop and set a default component to be rendered. I have also provided documentation and an example of how one might use the `TextFieldBase` to create a new variant.

## Screenshots/Screencaps

### Before

Functionality, story and docs didn't exist 

https://user-images.githubusercontent.com/8112138/200714563-0bde1a4a-5833-43a1-927b-c74ac59f8d3c.mov



### After

https://user-images.githubusercontent.com/8112138/200429521-7f2a9a39-5c95-476e-8324-18e7e64d8233.mov

## Manual Testing Steps

- Go to the storybook build of this PR
- Search `TextFieldBase` in the search bar
- Check the InputComponent story and docs

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
