### PR TITLE
`TextField` component updates

### DIFF
--- a/ui/components/component-library/text-field/README.mdx
+++ b/ui/components/component-library/text-field/README.mdx
@@ -16,38 +16,39 @@ The `TextField` accepts all props below as well as all [Box](/docs/ui-components
 
 <ArgsTable of={TextField} />
 
-### Show Clear
+### Show Clear Button
 
-Use the `showClear` prop to display a clear button when `TextField` has a value. Clicking the button will clear the value.
-You can also attach an `onClear` handler to the `TextField` to perform additional actions when the clear button is clicked.
+Use the `showClearButton` prop to display a clear button when `TextField` has a value. Use the `clearButtonProps` to add an `onClick` handler to clear the value of the input.
 
 <Canvas>
-  <Story id="ui-components-component-library-text-field-text-field-stories-js--show-clear" />
+  <Story id="ui-components-component-library-text-field-text-field-stories-js--show-clear-button" />
 </Canvas>
 
 ```jsx
 import { TextField } from '../../ui/component-library/text-field';
 
-<TextField showClear />;
-```
+const [value, setValue] = useState('show clear');
 
-### On Clear
+const handleOnChange = (e) => {
+  setValue(e.target.value);
+};
 
-Use the `onClear` prop to perform additional actions when the clear button is clicked.
+const handleOnClear = () => {
+  setValue('');
+};
 
-<Canvas>
-  <Story id="ui-components-component-library-text-field-text-field-stories-js--on-clear" />
-</Canvas>
-
-```jsx
-import { TextField } from '../../ui/component-library/text-field';
-
-<TextField showClear onClear={() => console.log('cleared input')} />;
+<TextField
+  placeholder="Enter text to show clear"
+  value={value}
+  onChange={handleOnChange}
+  showClearButton
+  clearButtonProps={{ onClick: handleOnClear }}
+/>;
 ```
 
 ### Clear Button Props and Clear Button Icon Props
 
-Use the `clearButtonProps` and `clearButtonIconProps` props to pass props to the clear button and clear button icon respectively.
+Use the `clearButtonProps` props to pass props to the clear button.
 
 <Canvas>
   <Story id="ui-components-component-library-text-field-text-field-stories-js--clear-button-props-clear-button-icon-props" />
@@ -62,12 +63,11 @@ import {
 import { TextField } from '../../ui/component-library/text-field';
 
 <TextField
-  showClear
+  showClearButton
   clearButtonProps={{
     backgroundColor: COLORS.BACKGROUND_ALTERNATIVE,
     borderRadius: BORDER_RADIUS.XS,
     'data-testid': 'clear-button',
   }}
-  clearButtonIconProps={{ size: SIZES.MD }}
 />;
 ```

--- a/ui/components/component-library/text-field/README.mdx
+++ b/ui/components/component-library/text-field/README.mdx
@@ -18,7 +18,7 @@ The `TextField` accepts all props below as well as all [Box](/docs/ui-components
 
 ### Show Clear Button
 
-Use the `showClearButton` prop to display a clear button when `TextField` has a value. Use the `clearButtonProps` to add an `onClick` handler to clear the value of the input.
+Use the `showClearButton` prop to display a clear button when `TextField` has a value. Use the `clearButtonOnClick` prop to pass an `onClick` event handler to clear the value of the input.
 
 <Canvas>
   <Story id="ui-components-component-library-text-field-text-field-stories-js--show-clear-button" />
@@ -42,28 +42,44 @@ const handleOnClear = () => {
   value={value}
   onChange={handleOnChange}
   showClearButton
-  clearButtonProps={{ onClick: handleOnClear }}
+  clearButtonOnClick={handleOnClear}
 />;
 ```
 
-### Clear Button Props and Clear Button Icon Props
+### Clear Button Props
 
-Use the `clearButtonProps` props to pass props to the clear button.
+Use the `clearButtonProps` to access other props of the clear button.
 
 <Canvas>
-  <Story id="ui-components-component-library-text-field-text-field-stories-js--clear-button-props-clear-button-icon-props" />
+  <Story id="ui-components-component-library-text-field-text-field-stories-js--clear-button-props" />
 </Canvas>
 
 ```jsx
+import React, { useState } from 'react';
 import {
   SIZES,
   COLORS,
   BORDER_RADIUS,
 } from '../../../helpers/constants/design-system';
+
 import { TextField } from '../../ui/component-library/text-field';
 
+const [value, setValue] = useState('show clear');
+
+const handleOnChange = (e) => {
+  setValue(e.target.value);
+};
+
+const handleOnClear = () => {
+  setValue('');
+};
+
 <TextField
+  placeholder="Enter text to show clear"
+  value={value}
+  onChange={handleOnChange}
   showClearButton
+  clearButtonOnClick={handleOnClear}
   clearButtonProps={{
     backgroundColor: COLORS.BACKGROUND_ALTERNATIVE,
     borderRadius: BORDER_RADIUS.XS,

--- a/ui/components/component-library/text-field/README.mdx
+++ b/ui/components/component-library/text-field/README.mdx
@@ -20,6 +20,8 @@ The `TextField` accepts all props below as well as all [Box](/docs/ui-components
 
 Use the `showClearButton` prop to display a clear button when `TextField` has a value. Use the `clearButtonOnClick` prop to pass an `onClick` event handler to clear the value of the input.
 
+The clear button uses [ButtonIcon](/docs/ui-components-component-library-button-icon-button-icon-stories-js--default-story) and accepts all props from that component.
+
 <Canvas>
   <Story id="ui-components-component-library-text-field-text-field-stories-js--show-clear-button" />
 </Canvas>

--- a/ui/components/component-library/text-field/README.mdx
+++ b/ui/components/component-library/text-field/README.mdx
@@ -22,6 +22,8 @@ Use the `showClearButton` prop to display a clear button when `TextField` has a 
 
 The clear button uses [ButtonIcon](/docs/ui-components-component-library-button-icon-button-icon-stories-js--default-story) and accepts all props from that component.
 
+**NOTE: The `showClearButton` only works with a controlled input.**
+
 <Canvas>
   <Story id="ui-components-component-library-text-field-text-field-stories-js--show-clear-button" />
 </Canvas>

--- a/ui/components/component-library/text-field/text-field.js
+++ b/ui/components/component-library/text-field/text-field.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 
@@ -18,69 +18,60 @@ import { TextFieldBase } from '../text-field-base';
 
 export const TextField = ({
   className,
-  showClear,
-  clearButtonIconProps,
+  showClearButton,
+  clearButtonOnClick,
   clearButtonProps,
   rightAccessory,
-  value: valueProp,
-  onChange,
-  onClear,
   inputProps,
+  value,
+  onChange,
   ...props
-}) => {
-  const [value, setValue] = useState(valueProp || '');
-  const handleOnChange = (e) => {
-    setValue(e.target.value);
-    onChange?.(e);
-  };
-  const handleClear = (e) => {
-    setValue('');
-    clearButtonProps?.onClick?.(e);
-    onClear?.(e);
-  };
-  return (
-    <TextFieldBase
-      className={classnames('mm-text-field', className)}
-      value={value}
-      onChange={handleOnChange}
-      rightAccessory={
-        value && showClear ? (
-          <>
-            {/* replace with ButtonIcon */}
-            <Box
-              className="mm-text-field__button-clear"
-              as="button"
-              display={DISPLAY.FLEX}
-              alignItems={ALIGN_ITEMS.CENTER}
-              justifyContent={JUSTIFY_CONTENT.CENTER}
-              backgroundColor={COLORS.TRANSPARENT}
-              padding={0}
-              {...clearButtonProps} // don't override onClick
-              onClick={handleClear}
-            >
-              <Icon
-                name={ICON_NAMES.CLOSE_OUTLINE}
-                size={SIZES.SM}
-                aria-label="Clear" // TODO: i18n
-                {...clearButtonIconProps}
-              />
-            </Box>
-            {rightAccessory}
-          </>
-        ) : (
-          rightAccessory
-        )
-      }
-      inputProps={{
-        marginRight: showClear ? 6 : 0,
-        ...inputProps,
-      }}
-      {...props}
-    />
-  );
-};
+}) => (
+  <TextFieldBase
+    className={classnames('mm-text-field', className)}
+    value={value}
+    onChange={onChange}
+    rightAccessory={
+      value && showClearButton ? (
+        <>
+          {/* TODO: replace with ButtonIcon */}
+          <Box
+            className="mm-text-field__button-clear"
+            as="button"
+            display={DISPLAY.FLEX}
+            alignItems={ALIGN_ITEMS.CENTER}
+            justifyContent={JUSTIFY_CONTENT.CENTER}
+            backgroundColor={COLORS.TRANSPARENT}
+            padding={0}
+            onClick={clearButtonOnClick}
+            {...clearButtonProps}
+            aria-label="Clear" // TODO: i18n
+          >
+            <Icon name={ICON_NAMES.CLOSE_OUTLINE} size={SIZES.SM} />
+          </Box>
+          {rightAccessory}
+        </>
+      ) : (
+        rightAccessory
+      )
+    }
+    inputProps={{
+      marginRight: showClearButton ? 6 : 0,
+      ...inputProps,
+    }}
+    {...props}
+  />
+);
 
 TextField.propTypes = {
+  /**
+   * The value af the TextField
+   */
+  value: TextFieldBase.propTypes.value.isRequired,
+  /**
+   * The onChange handler af the TextField
+   */
+  onChange: TextFieldBase.propTypes.onChange.isRequired,
   /**
    * An additional className to apply to the text-field
    */
@@ -88,19 +79,11 @@ TextField.propTypes = {
   /**
    * Show a clear button to clear the input
    */
-  showClear: PropTypes.bool,
-  /**
-   * The event handler for when the clear button is clicked
-   */
-  onClear: PropTypes.func,
+  showClearButton: PropTypes.bool,
   /**
    * The props to pass to the clear button
    */
   clearButtonProps: PropTypes.shape(Box.PropTypes),
-  /**
-   * The props to pass to the icon inside of the close button
-   */
-  clearButtonIconProps: PropTypes.shape(Icon.PropTypes),
   /**
    * TextField accepts all the props from TextFieldBase and Box
    */

--- a/ui/components/component-library/text-field/text-field.js
+++ b/ui/components/component-library/text-field/text-field.js
@@ -2,17 +2,11 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 
-import {
-  SIZES,
-  DISPLAY,
-  JUSTIFY_CONTENT,
-  ALIGN_ITEMS,
-  COLORS,
-} from '../../../helpers/constants/design-system';
+import { SIZES } from '../../../helpers/constants/design-system';
 
 import Box from '../../ui/box';
 
-import { Icon, ICON_NAMES } from '../icon';
+import { ICON_NAMES } from '../icon';
 import { ButtonIcon } from '../button-icon';
 
 import { TextFieldBase } from '../text-field-base';

--- a/ui/components/component-library/text-field/text-field.js
+++ b/ui/components/component-library/text-field/text-field.js
@@ -13,6 +13,7 @@ import {
 import Box from '../../ui/box';
 
 import { Icon, ICON_NAMES } from '../icon';
+import { ButtonIcon } from '../button-icon';
 
 import { TextFieldBase } from '../text-field-base';
 
@@ -34,21 +35,14 @@ export const TextField = ({
     rightAccessory={
       value && showClearButton ? (
         <>
-          {/* TODO: replace with ButtonIcon */}
-          <Box
+          <ButtonIcon
             className="mm-text-field__button-clear"
-            as="button"
-            display={DISPLAY.FLEX}
-            alignItems={ALIGN_ITEMS.CENTER}
-            justifyContent={JUSTIFY_CONTENT.CENTER}
-            backgroundColor={COLORS.TRANSPARENT}
-            padding={0}
+            ariaLabel="Clear" // TODO: i18n
+            icon={ICON_NAMES.CLOSE_OUTLINE}
+            size={SIZES.SM}
             onClick={clearButtonOnClick}
             {...clearButtonProps}
-            aria-label="Clear" // TODO: i18n
-          >
-            <Icon name={ICON_NAMES.CLOSE_OUTLINE} size={SIZES.SM} />
-          </Box>
+          />
           {rightAccessory}
         </>
       ) : (

--- a/ui/components/component-library/text-field/text-field.js
+++ b/ui/components/component-library/text-field/text-field.js
@@ -81,6 +81,10 @@ TextField.propTypes = {
    */
   showClearButton: PropTypes.bool,
   /**
+   * The onClick handler for the clear button
+   */
+  clearButtonOnClick: PropTypes.func,
+  /**
    * The props to pass to the clear button
    */
   clearButtonProps: PropTypes.shape(Box.PropTypes),

--- a/ui/components/component-library/text-field/text-field.js
+++ b/ui/components/component-library/text-field/text-field.js
@@ -13,7 +13,7 @@ import { TextFieldBase } from '../text-field-base';
 
 export const TextField = ({
   className,
-  showClearButton,
+  showClearButton, // only works with a controlled input
   clearButtonOnClick,
   clearButtonProps,
   rightAccessory,

--- a/ui/components/component-library/text-field/text-field.stories.js
+++ b/ui/components/component-library/text-field/text-field.stories.js
@@ -1,12 +1,11 @@
-import React, { useState } from 'react';
+import React from 'react';
+import { useArgs } from '@storybook/client-api';
 
 import {
   SIZES,
   COLORS,
   BORDER_RADIUS,
 } from '../../../helpers/constants/design-system';
-
-import { Text } from '../text';
 
 import { TEXT_FIELD_SIZES, TEXT_FIELD_TYPES } from './text-field.constants';
 import { TextField } from './text-field';
@@ -41,21 +40,17 @@ export default {
     },
   },
   argTypes: {
-    showClear: {
-      control: 'boolean',
-    },
     value: {
       control: 'text',
     },
     onChange: {
       action: 'onChange',
-      table: { category: 'text field base props' },
     },
-    onClear: {
-      action: 'onClear',
+    showClearButton: {
+      control: 'boolean',
     },
-    clearButtonIconProps: {
-      control: 'object',
+    clearButtonOnClick: {
+      action: 'clearButtonOnClick',
     },
     clearButtonProps: {
       control: 'object',
@@ -172,7 +167,7 @@ export default {
     },
   },
   args: {
-    showClear: false,
+    showClearButton: false,
     placeholder: 'Placeholder...',
     autoFocus: false,
     disabled: false,
@@ -186,62 +181,41 @@ export default {
   },
 };
 
-const Template = (args) => <TextField {...args} />;
-
-export const DefaultStory = Template.bind({});
-DefaultStory.storyName = 'Default';
-
-export const ShowClear = (args) => {
-  const [value, setValue] = useState('show clear');
+const Template = (args) => {
+  const [{ value }, updateArgs] = useArgs();
   const handleOnChange = (e) => {
-    setValue(e.target.value);
+    updateArgs({ value: e.target.value });
+  };
+  const handleOnClear = () => {
+    updateArgs({ value: '' });
   };
   return (
     <TextField
       {...args}
-      placeholder="Enter text to show clear"
       value={value}
       onChange={handleOnChange}
-      showClear
+      clearButtonOnClick={handleOnClear}
     />
   );
 };
 
-export const OnClear = (args) => {
-  const [value, setValue] = useState('onClear example');
-  const [showOnClearMessage, setShowOnClearMessage] = useState(false);
-  const handleOnChange = (e) => {
-    setValue(e.target.value);
-    showOnClearMessage && setShowOnClearMessage(false);
-  };
-  const handleOnClear = () => {
-    setShowOnClearMessage(true);
-  };
-  return (
-    <>
-      <TextField
-        {...args}
-        placeholder="Clear text to show onClear message"
-        value={value}
-        onChange={handleOnChange}
-        onClear={handleOnClear}
-        showClear
-      />
-      {showOnClearMessage && <Text marginTop={4}>onClear called</Text>}
-    </>
-  );
+export const DefaultStory = Template.bind({});
+DefaultStory.storyName = 'Default';
+
+export const ShowClearButton = Template.bind({});
+
+ShowClearButton.args = {
+  placeholder: 'Enter text to show clear',
+  showClearButton: true,
 };
 
-export const ClearButtonPropsClearButtonIconProps = Template.bind({});
-ClearButtonPropsClearButtonIconProps.args = {
+export const ClearButtonProps = Template.bind({});
+ClearButtonProps.args = {
   value: 'clear button props',
   size: SIZES.LG,
-  showClear: true,
+  showClearButton: true,
   clearButtonProps: {
     backgroundColor: COLORS.BACKGROUND_ALTERNATIVE,
     borderRadius: BORDER_RADIUS.XS,
-  },
-  clearButtonIconProps: {
-    size: SIZES.MD,
   },
 };

--- a/ui/components/component-library/text-field/text-field.stories.js
+++ b/ui/components/component-library/text-field/text-field.stories.js
@@ -209,6 +209,13 @@ ShowClearButton.args = {
   showClearButton: true,
 };
 
+export const ClearButtonOnClick = Template.bind({});
+
+ShowClearButton.args = {
+  placeholder: 'Enter text to show clear',
+  showClearButton: true,
+};
+
 export const ClearButtonProps = Template.bind({});
 ClearButtonProps.args = {
   value: 'clear button props',

--- a/ui/components/component-library/text-field/text-field.test.js
+++ b/ui/components/component-library/text-field/text-field.test.js
@@ -1,17 +1,33 @@
 /* eslint-disable jest/require-top-level-describe */
-import React from 'react';
+import React, { useState } from 'react';
 import { fireEvent, render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { TextField } from './text-field';
 
-// setup function as per testing-library docs
-// https://testing-library.com/docs/user-event/intro
+// userEvent setup function as per testing-library docs
+// https://testing-library.com/docs/user-event/intr
 function setup(jsx) {
   return {
     user: userEvent.setup(),
     ...render(jsx),
   };
+}
+
+// Custom userEvent setup function that renders the component in a controlled environment.
+// This is used for the showClearButton and related props as the clearButton will only show in a controlled environment.
+function setupControlled(FormComponent, props) {
+  const ControlledWrapper = () => {
+    const [value, setValue] = useState('');
+    return (
+      <FormComponent
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        {...props}
+      />
+    );
+  };
+  return { user: userEvent.setup(), ...render(<ControlledWrapper />) };
 }
 
 describe('TextField', () => {
@@ -21,9 +37,7 @@ describe('TextField', () => {
   });
   it('should render and be able to input text', async () => {
     const { user, getByRole } = setup(<TextField />);
-
     const textField = getByRole('textbox');
-
     await user.type(textField, 'text value');
     expect(textField).toHaveValue('text value');
   });
@@ -66,68 +80,58 @@ describe('TextField', () => {
     await user.click(getByTestId('text-field'));
     expect(onClick).toHaveBeenCalledTimes(1);
   });
-  it('should render showClearButton button when showClearButton is true and value exists', () => {
-    // As showClearButton is intended to only work with a controlled input we need to pass a value and onChange prop
-    const { getByRole } = render(
-      <TextField value="text" onChange={() => {}} showClearButton />,
-    );
-    expect(getByRole('button', { name: /Clear/u })).toBeDefined();
-    expect(getByRole('textbox')).toBeDefined();
-  });
   it('should render with the rightAccessory', () => {
     const { getByText } = render(
       <TextField rightAccessory={<div>right-accessory</div>} />,
     );
     expect(getByText('right-accessory')).toBeDefined();
   });
-  it('should still render with the rightAccessory when showClearButton is true', () => {
-    const { getByRole, getByTestId, getByText } = render(
-      // As showClearButton is intended to only work with a controlled input we need to pass a value and onChange prop
-      <TextField
-        value="text"
-        onChange={() => {}}
-        clearButtonProps={{ 'data-testid': 'clear-button' }}
-        rightAccessory={<div>right-accessory</div>}
-        showClearButton
-      />,
-    );
-    expect(getByTestId('clear-button')).toBeDefined();
+  it('should render showClearButton button when showClearButton is true and value exists', async () => {
+    // As showClearButton is intended to be used with a controlled input we need to use setupControlled
+    const { user, getByRole } = setupControlled(TextField, {
+      showClearButton: true,
+    });
+    await user.type(getByRole('textbox'), 'test value');
+    expect(getByRole('textbox')).toHaveValue('test value');
+    expect(getByRole('button', { name: /Clear/u })).toBeDefined();
+  });
+  it('should still render with the rightAccessory when showClearButton is true', async () => {
+    // As showClearButton is intended to be used with a controlled input we need to use setupControlled
+    const { user, getByRole, getByText } = setupControlled(TextField, {
+      showClearButton: true,
+      rightAccessory: <div>right-accessory</div>,
+    });
+    await user.type(getByRole('textbox'), 'test value');
+    expect(getByRole('textbox')).toHaveValue('test value');
+    expect(getByRole('button', { name: /Clear/u })).toBeDefined();
     expect(getByText('right-accessory')).toBeDefined();
-    expect(getByRole('textbox')).toBeDefined();
   });
-  it('should fire onClick event when passed to clearButtonProps when clear button is clicked', async () => {
-    // As showClearButton is intended to only work with a controlled input we need to pass a value and onChange prop
+  it('should fire onClick event when passed to clearButtonOnClick when clear button is clicked', async () => {
+    // As showClearButton is intended to be used with a controlled input we need to use setupControlled
     const fn = jest.fn();
-    const { user, getByRole } = setup(
-      <TextField
-        value="text"
-        onChange={() => {}}
-        clearButtonOnClick={fn}
-        showClearButton
-      />,
-    );
+    const { user, getByRole } = setupControlled(TextField, {
+      showClearButton: true,
+      clearButtonOnClick: fn,
+    });
+    await user.type(getByRole('textbox'), 'test value');
     await user.click(getByRole('button', { name: /Clear/u }));
-    expect(fn).toHaveBeenCalledTimes(1); // clear button onClick is fired
+    expect(fn).toHaveBeenCalledTimes(1);
   });
-  it('should fire clearButtonProps.onClick event when passed to clearButtonProps.onClick prop', async () => {
-    // As showClearButton is intended to only work with a controlled input we need to pass a value and onChange prop
+  it('should fire onClick event when passed to clearButtonProps.onClick prop', async () => {
+    // As showClearButton is intended to be used with a controlled input we need to use setupControlled
     const fn = jest.fn();
-    const { user, getByRole } = setup(
-      <TextField
-        value="text"
-        onChange={() => {}}
-        clearButtonProps={{ onClick: fn }}
-        showClearButton
-      />,
-    );
+    const { user, getByRole } = setupControlled(TextField, {
+      showClearButton: true,
+      clearButtonProps: { onClick: fn },
+    });
+    await user.type(getByRole('textbox'), 'test value');
     await user.click(getByRole('button', { name: /Clear/u }));
     expect(fn).toHaveBeenCalledTimes(1);
   });
   it('should be able to accept inputProps', () => {
-    const { getByRole } = render(
+    const { getByTestId } = render(
       <TextField inputProps={{ 'data-testid': 'text-field' }} />,
     );
-    const textField = getByRole('textbox');
-    expect(textField).toBeDefined();
+    expect(getByTestId('text-field')).toBeDefined();
   });
 });

--- a/ui/components/component-library/text-field/text-field.test.js
+++ b/ui/components/component-library/text-field/text-field.test.js
@@ -69,7 +69,7 @@ describe('TextField', () => {
   it('should render showClearButton button when showClearButton is true and value exists', () => {
     // As TextField is a controlled input we need to pass in a value for the clear button to appear
     const { getByRole } = render(<TextField value="text" showClearButton />);
-    expect(getByRole('button', { name: /clear/u })).toBeDefined();
+    expect(getByRole('button', { name: /Clear/u })).toBeDefined();
     expect(getByRole('textbox')).toBeDefined();
   });
   it('should render with the rightAccessory', () => {
@@ -98,7 +98,7 @@ describe('TextField', () => {
     const { user, getByRole } = setup(
       <TextField value="text" clearButtonOnClick={fn} showClearButton />,
     );
-    await user.click(getByRole('button', { name: /clear/u }));
+    await user.click(getByRole('button', { name: /Clear/u }));
     expect(fn).toHaveBeenCalledTimes(1); // clear button onClick is fired
   });
   it('should fire clearButtonProps.onClick event when passed to clearButtonProps.onClick prop', async () => {
@@ -111,7 +111,7 @@ describe('TextField', () => {
         showClearButton
       />,
     );
-    await user.click(getByRole('button', { name: /clear/u }));
+    await user.click(getByRole('button', { name: /Clear/u }));
     expect(fn).toHaveBeenCalledTimes(1);
   });
   it('should be able to accept inputProps', () => {

--- a/ui/components/component-library/text-field/text-field.test.js
+++ b/ui/components/component-library/text-field/text-field.test.js
@@ -67,8 +67,10 @@ describe('TextField', () => {
     expect(onClick).toHaveBeenCalledTimes(1);
   });
   it('should render showClearButton button when showClearButton is true and value exists', () => {
-    // As TextField is a controlled input we need to pass in a value for the clear button to appear
-    const { getByRole } = render(<TextField value="text" showClearButton />);
+    // As showClearButton is intended to only work with a controlled input we need to pass a value and onChange prop
+    const { getByRole } = render(
+      <TextField value="text" onChange={() => {}} showClearButton />,
+    );
     expect(getByRole('button', { name: /Clear/u })).toBeDefined();
     expect(getByRole('textbox')).toBeDefined();
   });
@@ -80,9 +82,10 @@ describe('TextField', () => {
   });
   it('should still render with the rightAccessory when showClearButton is true', () => {
     const { getByRole, getByTestId, getByText } = render(
-      // As TextField is a controlled input we need to pass in a value for the clear button to appear
+      // As showClearButton is intended to only work with a controlled input we need to pass a value and onChange prop
       <TextField
         value="text"
+        onChange={() => {}}
         clearButtonProps={{ 'data-testid': 'clear-button' }}
         rightAccessory={<div>right-accessory</div>}
         showClearButton
@@ -93,20 +96,26 @@ describe('TextField', () => {
     expect(getByRole('textbox')).toBeDefined();
   });
   it('should fire onClick event when passed to clearButtonProps when clear button is clicked', async () => {
-    // As TextField is a controlled input we need to pass in a value for the clear button to appear
+    // As showClearButton is intended to only work with a controlled input we need to pass a value and onChange prop
     const fn = jest.fn();
     const { user, getByRole } = setup(
-      <TextField value="text" clearButtonOnClick={fn} showClearButton />,
+      <TextField
+        value="text"
+        onChange={() => {}}
+        clearButtonOnClick={fn}
+        showClearButton
+      />,
     );
     await user.click(getByRole('button', { name: /Clear/u }));
     expect(fn).toHaveBeenCalledTimes(1); // clear button onClick is fired
   });
   it('should fire clearButtonProps.onClick event when passed to clearButtonProps.onClick prop', async () => {
-    // As TextField is a controlled input we need to pass in a value for the clear button to appear
+    // As showClearButton is intended to only work with a controlled input we need to pass a value and onChange prop
     const fn = jest.fn();
     const { user, getByRole } = setup(
       <TextField
         value="text"
+        onChange={() => {}}
         clearButtonProps={{ onClick: fn }}
         showClearButton
       />,

--- a/ui/components/component-library/text-field/text-field.test.js
+++ b/ui/components/component-library/text-field/text-field.test.js
@@ -1,25 +1,31 @@
 /* eslint-disable jest/require-top-level-describe */
 import React from 'react';
 import { fireEvent, render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 import { TextField } from './text-field';
+
+// setup function as per testing-library docs
+// https://testing-library.com/docs/user-event/intro
+function setup(jsx) {
+  return {
+    user: userEvent.setup(),
+    ...render(jsx),
+  };
+}
 
 describe('TextField', () => {
   it('should render correctly', () => {
     const { getByRole } = render(<TextField />);
     expect(getByRole('textbox')).toBeDefined();
   });
-  it('should render and be able to input text', () => {
-    const { getByTestId } = render(
-      <TextField inputProps={{ 'data-testid': 'text-field' }} />,
-    );
-    const textField = getByTestId('text-field');
+  it('should render and be able to input text', async () => {
+    const { user, getByRole } = setup(<TextField />);
 
-    expect(textField.value).toBe(''); // initial value is empty string
-    fireEvent.change(textField, { target: { value: 'text value' } });
-    expect(textField.value).toBe('text value');
-    fireEvent.change(textField, { target: { value: '' } }); // reset value
-    expect(textField.value).toBe(''); // value is empty string after reset
+    const textField = getByRole('textbox');
+
+    await user.type(textField, 'text value');
+    expect(textField).toHaveValue('text value');
   });
   it('should render and fire onFocus and onBlur events', () => {
     const onFocus = jest.fn();
@@ -38,46 +44,33 @@ describe('TextField', () => {
     fireEvent.blur(textField);
     expect(onBlur).toHaveBeenCalledTimes(1);
   });
-  it('should render and fire onChange event', () => {
+  it('should render and fire onChange event', async () => {
     const onChange = jest.fn();
-    const { getByTestId } = render(
+    const { user, getByRole } = setup(
       <TextField
         inputProps={{ 'data-testid': 'text-field' }}
         onChange={onChange}
       />,
     );
-    const textField = getByTestId('text-field');
+    const textField = getByRole('textbox');
 
-    fireEvent.change(textField, { target: { value: 'text value' } });
-    expect(onChange).toHaveBeenCalledTimes(1);
+    await user.type(textField, '123');
+    expect(textField).toHaveValue('123');
+    expect(onChange).toHaveBeenCalledTimes(3);
   });
-  it('should render and fire onClick event', () => {
+  it('should render and fire onClick event', async () => {
     const onClick = jest.fn();
-    const { getByTestId } = render(
-      <TextField
-        inputProps={{ 'data-testid': 'text-field' }}
-        onClick={onClick}
-      />,
+    const { user, getByTestId } = setup(
+      <TextField data-testid="text-field" onClick={onClick} />,
     );
-    const textField = getByTestId('text-field');
-
-    fireEvent.click(textField);
+    await user.click(getByTestId('text-field'));
     expect(onClick).toHaveBeenCalledTimes(1);
   });
-  it('should render showClear button when showClear is true and value exists', () => {
-    const { getByRole, getByTestId } = render(
-      <TextField
-        clearButtonProps={{ 'data-testid': 'clear-button' }}
-        clearButtonIconProps={{ 'data-testid': 'clear-button-icon' }}
-        showClear
-      />,
-    );
-    const textField = getByRole('textbox');
-    expect(textField.value).toBe(''); // initial value is empty string
-    fireEvent.change(textField, { target: { value: 'text value' } });
-    expect(textField.value).toBe('text value');
-    expect(getByTestId('clear-button')).toBeDefined();
-    expect(getByTestId('clear-button-icon')).toBeDefined();
+  it('should render showClearButton button when showClearButton is true and value exists', () => {
+    // As TextField is a controlled input we need to pass in a value for the clear button to appear
+    const { getByRole } = render(<TextField value="text" showClearButton />);
+    expect(getByRole('button', { name: /clear/u })).toBeDefined();
+    expect(getByRole('textbox')).toBeDefined();
   });
   it('should render with the rightAccessory', () => {
     const { getByText } = render(
@@ -85,71 +78,41 @@ describe('TextField', () => {
     );
     expect(getByText('right-accessory')).toBeDefined();
   });
-  it('should still render with the rightAccessory when showClear is true', () => {
+  it('should still render with the rightAccessory when showClearButton is true', () => {
     const { getByRole, getByTestId, getByText } = render(
+      // As TextField is a controlled input we need to pass in a value for the clear button to appear
       <TextField
+        value="text"
         clearButtonProps={{ 'data-testid': 'clear-button' }}
-        clearButtonIconProps={{ 'data-testid': 'clear-button-icon' }}
         rightAccessory={<div>right-accessory</div>}
-        showClear
+        showClearButton
       />,
     );
-    const textField = getByRole('textbox');
-    expect(textField.value).toBe(''); // initial value is empty string
-    fireEvent.change(textField, { target: { value: 'text value' } });
-    expect(textField.value).toBe('text value');
     expect(getByTestId('clear-button')).toBeDefined();
-    expect(getByTestId('clear-button-icon')).toBeDefined();
     expect(getByText('right-accessory')).toBeDefined();
+    expect(getByRole('textbox')).toBeDefined();
   });
-  it('should clear text when clear button is clicked', () => {
-    const { getByRole, getByTestId } = render(
+  it('should fire onClick event when passed to clearButtonProps when clear button is clicked', async () => {
+    // As TextField is a controlled input we need to pass in a value for the clear button to appear
+    const fn = jest.fn();
+    const { user, getByRole } = setup(
+      <TextField value="text" clearButtonOnClick={fn} showClearButton />,
+    );
+    await user.click(getByRole('button', { name: /clear/u }));
+    expect(fn).toHaveBeenCalledTimes(1); // clear button onClick is fired
+  });
+  it('should fire clearButtonProps.onClick event when passed to clearButtonProps.onClick prop', async () => {
+    // As TextField is a controlled input we need to pass in a value for the clear button to appear
+    const fn = jest.fn();
+    const { user, getByRole } = setup(
       <TextField
-        clearButtonProps={{ 'data-testid': 'clear-button' }}
-        clearButtonIconProps={{ 'data-testid': 'clear-button-icon' }}
-        rightAccessory={<div>right-accessory</div>}
-        showClear
+        value="text"
+        clearButtonProps={{ onClick: fn }}
+        showClearButton
       />,
     );
-    const textField = getByRole('textbox');
-    fireEvent.change(textField, { target: { value: 'text value' } });
-    expect(textField.value).toBe('text value');
-    fireEvent.click(getByTestId('clear-button'));
-    expect(textField.value).toBe('');
-  });
-  it('should fire onClear event when passed to onClear prop', () => {
-    const onClear = jest.fn();
-    const { getByRole, getByTestId } = render(
-      <TextField
-        onClear={onClear}
-        clearButtonProps={{ 'data-testid': 'clear-button' }}
-        clearButtonIconProps={{ 'data-testid': 'clear-button-icon' }}
-        showClear
-      />,
-    );
-    const textField = getByRole('textbox');
-    fireEvent.change(textField, { target: { value: 'text value' } });
-    expect(textField.value).toBe('text value');
-    fireEvent.click(getByTestId('clear-button'));
-    expect(onClear).toHaveBeenCalledTimes(1);
-  });
-  it('should fire clearButtonProps.onClick event when passed to clearButtonProps.onClick prop', () => {
-    const onClear = jest.fn();
-    const onClick = jest.fn();
-    const { getByRole, getByTestId } = render(
-      <TextField
-        onClear={onClear}
-        clearButtonProps={{ 'data-testid': 'clear-button', onClick }}
-        clearButtonIconProps={{ 'data-testid': 'clear-button-icon' }}
-        showClear
-      />,
-    );
-    const textField = getByRole('textbox');
-    fireEvent.change(textField, { target: { value: 'text value' } });
-    expect(textField.value).toBe('text value');
-    fireEvent.click(getByTestId('clear-button'));
-    expect(onClear).toHaveBeenCalledTimes(1);
-    expect(onClick).toHaveBeenCalledTimes(1);
+    await user.click(getByRole('button', { name: /clear/u }));
+    expect(fn).toHaveBeenCalledTimes(1);
   });
   it('should be able to accept inputProps', () => {
     const { getByRole } = render(


### PR DESCRIPTION
## Explanation

**What is the current state of things and why does it need to change?**
The current `TextField` component handles the clear button logic but this was actually breaking the component when `value` was changed outside of the `onChange` function. It also limits the flexibility of the component.

**What is the solution your changes offer and how does it work?**
- Updating the name of the `showClear` prop to `showClearButton` which is more specific
- Reducing the logic used inside of the component in favour of letting the engineer handle it for each usecase
- Updating the stories and docs to reflect these changes
- Updating unit tests to reflect these changes as well as improving the quality of the tests by using [userEvent](https://testing-library.com/docs/user-event/intro/)

## Screenshots/Screencaps

### Before


https://user-images.githubusercontent.com/8112138/200711673-51e703ed-93fd-4177-96ea-370a1c630866.mov



### After


https://user-images.githubusercontent.com/8112138/200711704-21401aeb-55c0-4954-9881-5eb7bb94a6d4.mov



## Manual Testing Steps

- Go to the latest build of storybook in this PR
- Search `TextField` in the search bar (make sure it's under the Component Library section)
- Check the controls and docs

For unit tests
- Checkout this branch
- Run `yarn test:unit:jest ui/components/component-library/text-field/text-field.test.js`

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
