### PR TITLE
chain_id value in the Custom Network Added event

### DIFF
--- a/ui/pages/settings/networks-tab/networks-form/networks-form.js
+++ b/ui/pages/settings/networks-tab/networks-form/networks-form.js
@@ -527,7 +527,7 @@ const NetworksForm = ({
             url: rpcUrlOrigin,
           },
           properties: {
-            chain_id: addHexPrefix(chainId.toString(16)),
+            chain_id: addHexPrefix(Number(chainId).toString(16)),
             network_name: networkName,
             network: rpcUrlOrigin,
             symbol: ticker,


### PR DESCRIPTION
## Explanation

chain_id values passed in the Custom Network Added event are the converted hex values even if users have inputted a decimal value as the chain id.

Example:
If the user inputs 137 as the chain id for Polygon, the chain_id in Custom Network Added event will be 0x89.

## More Information
* Fixes #16403


## Screenshots/Screencaps

### Before

https://user-images.githubusercontent.com/63151811/200844518-d2d0f9e2-c0e7-4027-a62a-7855949ef7fd.mov


### After

https://user-images.githubusercontent.com/63151811/200844529-479d9a7a-fe4e-484d-9c5c-03a5cbaa68cc.mov