### PR TITLE
Remove obsolete builds

### DIFF
--- a/development/build/index.js
+++ b/development/build/index.js
@@ -71,7 +71,7 @@ async function defineAndRunBuildTasks() {
     version,
   } = await parseArgv();
 
-  const browserPlatforms = ['firefox', 'chrome', 'brave', 'opera'];
+  const browserPlatforms = ['firefox', 'chrome'];
 
   const browserVersionMap = getBrowserVersionMap(browserPlatforms, version);
 

--- a/development/metamaskbot-build-announce.js
+++ b/development/metamaskbot-build-announce.js
@@ -36,7 +36,7 @@ async function start() {
   // build the github comment content
 
   // links to extension builds
-  const platforms = ['chrome', 'firefox', 'opera'];
+  const platforms = ['chrome', 'firefox'];
   const buildLinks = platforms
     .map((platform) => {
       const url = `${BUILD_LINK_BASE}/builds/metamask-${platform}-${VERSION}.zip`;

--- a/docs/QA_Guide.md
+++ b/docs/QA_Guide.md
@@ -2,6 +2,7 @@
 
 Steps to mark a full pass of QA complete.
 * Browsers: Opera, Chrome, Firefox, Edge.
+  * Use the Chrome build for all Chromium-derived browsers (e.g. Opera and Edge)
 * OS: Ubuntu, Mac OSX, Windows
 * Load older version of MetaMask and attempt to simulate updating the extension.
 * Open Developer Console in background and popup, inspect errors.


### PR DESCRIPTION
The `brave` and `opera` builds are obsolete; in practice we have been using the Chrome build for those browsers, because they are based upon Chromium and are compatible with the Chrome extension API.

## Manual Testing Steps

Make sure the build still works, I suppose?

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
