### PR TITLE
Move subject type enum to `@metamask/subject-metadata-controller`

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -46,7 +46,10 @@ import {
   PermissionController,
   PermissionsRequestNotFoundError,
 } from '@metamask/permission-controller';
-import { SubjectMetadataController } from '@metamask/subject-metadata-controller';
+import {
+  SubjectMetadataController,
+  SubjectType,
+} from '@metamask/subject-metadata-controller';
 ///: BEGIN:ONLY_INCLUDE_IN(flask)
 import { RateLimitController } from '@metamask/rate-limit-controller';
 import { NotificationController } from '@metamask/notification-controller';
@@ -97,7 +100,6 @@ import {
   SNAP_DIALOG_TYPES,
   ///: END:ONLY_INCLUDE_IN
   POLLING_TOKEN_ENVIRONMENT_TYPES,
-  SUBJECT_TYPES,
 } from '../../shared/constants/app';
 import { EVENT, EVENT_NAMES } from '../../shared/constants/metametrics';
 
@@ -1494,7 +1496,7 @@ export default class MetamaskController extends EventEmitter {
           version,
         } = snap;
         this.subjectMetadataController.addSubjectMetadata({
-          subjectType: SUBJECT_TYPES.SNAP,
+          subjectType: SubjectType.Snap,
           name: proposedName,
           origin: snap.id,
           version,
@@ -3541,9 +3543,9 @@ export default class MetamaskController extends EventEmitter {
     if (subjectType) {
       _subjectType = subjectType;
     } else if (sender.id && sender.id !== this.extension.runtime.id) {
-      _subjectType = SUBJECT_TYPES.EXTENSION;
+      _subjectType = SubjectType.Extension;
     } else {
-      _subjectType = SUBJECT_TYPES.WEBSITE;
+      _subjectType = SubjectType.Website;
     }
 
     if (sender.url) {
@@ -3595,7 +3597,7 @@ export default class MetamaskController extends EventEmitter {
     this.setupProviderConnection(
       mux.createStream('provider'),
       sender,
-      SUBJECT_TYPES.INTERNAL,
+      SubjectType.Internal,
     );
   }
 
@@ -3711,15 +3713,15 @@ export default class MetamaskController extends EventEmitter {
    *
    * @param {*} outStream - The stream to provide over.
    * @param {MessageSender | SnapSender} sender - The sender of the messages on this stream
-   * @param {string} subjectType - The type of the sender, i.e. subject.
+   * @param {SubjectType} subjectType - The type of the sender, i.e. subject.
    */
   setupProviderConnection(outStream, sender, subjectType) {
     let origin;
-    if (subjectType === SUBJECT_TYPES.INTERNAL) {
+    if (subjectType === SubjectType.Internal) {
       origin = ORIGIN_METAMASK;
     }
     ///: BEGIN:ONLY_INCLUDE_IN(flask)
-    else if (subjectType === SUBJECT_TYPES.SNAP) {
+    else if (subjectType === SubjectType.Snap) {
       origin = sender.snapId;
     }
     ///: END:ONLY_INCLUDE_IN
@@ -3731,7 +3733,7 @@ export default class MetamaskController extends EventEmitter {
       this.subjectMetadataController.addSubjectMetadata({
         origin,
         extensionId: sender.id,
-        subjectType: SUBJECT_TYPES.EXTENSION,
+        subjectType: SubjectType.Extension,
       });
     }
 
@@ -3777,7 +3779,7 @@ export default class MetamaskController extends EventEmitter {
     this.setupUntrustedCommunication({
       connectionStream,
       sender: { snapId },
-      subjectType: SUBJECT_TYPES.SNAP,
+      subjectType: SubjectType.Snap,
     });
   }
   ///: END:ONLY_INCLUDE_IN
@@ -3834,7 +3836,7 @@ export default class MetamaskController extends EventEmitter {
     );
 
     // onboarding
-    if (subjectType === SUBJECT_TYPES.WEBSITE) {
+    if (subjectType === SubjectType.Website) {
       engine.push(
         createOnboardingMiddleware({
           location: sender.url,
@@ -3942,7 +3944,7 @@ export default class MetamaskController extends EventEmitter {
 
     ///: BEGIN:ONLY_INCLUDE_IN(flask)
     engine.push(
-      createSnapMethodMiddleware(subjectType === SUBJECT_TYPES.SNAP, {
+      createSnapMethodMiddleware(subjectType === SubjectType.Snap, {
         getAppKey: this.getAppKeyForSubject.bind(this, origin),
         getUnlockPromise: this.appStateController.getUnlockPromise.bind(
           this.appStateController,
@@ -3975,7 +3977,7 @@ export default class MetamaskController extends EventEmitter {
     );
     ///: END:ONLY_INCLUDE_IN
 
-    if (subjectType !== SUBJECT_TYPES.INTERNAL) {
+    if (subjectType !== SubjectType.Internal) {
       // permissions
       engine.push(
         this.permissionController.createPermissionMiddleware({

--- a/app/scripts/migrations/069.js
+++ b/app/scripts/migrations/069.js
@@ -1,5 +1,5 @@
+import { SubjectType } from '@metamask/controllers';
 import { cloneDeep } from 'lodash';
-import { SUBJECT_TYPES } from '../../../shared/constants/app';
 
 const version = 69;
 
@@ -32,8 +32,8 @@ function transformState(state) {
         !Array.isArray(metadata)
       ) {
         metadata.subjectType = metadata.extensionId
-          ? SUBJECT_TYPES.EXTENSION
-          : SUBJECT_TYPES.WEBSITE;
+          ? SubjectType.Extension
+          : SubjectType.Website;
       }
     });
   }

--- a/app/scripts/migrations/069.js
+++ b/app/scripts/migrations/069.js
@@ -1,4 +1,4 @@
-import { SubjectType } from '@metamask/controllers';
+import { SubjectType } from '@metamask/subject-metadata-controller';
 import { cloneDeep } from 'lodash';
 
 const version = 69;

--- a/app/scripts/migrations/069.test.js
+++ b/app/scripts/migrations/069.test.js
@@ -1,4 +1,4 @@
-import { SubjectType } from '@metamask/controllers';
+import { SubjectType } from '@metamask/subject-metadata-controller';
 import migration69 from './069';
 
 describe('migration #69', () => {

--- a/app/scripts/migrations/069.test.js
+++ b/app/scripts/migrations/069.test.js
@@ -1,4 +1,4 @@
-import { SUBJECT_TYPES } from '../../../shared/constants/app';
+import { SubjectType } from '@metamask/controllers';
 import migration69 from './069';
 
 describe('migration #69', () => {
@@ -61,14 +61,14 @@ describe('migration #69', () => {
               name: 'DEX Aggregator - 1inch.exchange',
               origin: 'https://1inch.exchange',
               extensionId: null,
-              subjectType: SUBJECT_TYPES.WEBSITE,
+              subjectType: SubjectType.Website,
             },
             'https://ascii-tree-generator.com': {
               iconUrl: 'https://ascii-tree-generator.com/favicon.ico',
               name: 'ASCII Tree Generator',
               origin: 'https://ascii-tree-generator.com',
               extensionId: 'ascii-tree-generator-extension',
-              subjectType: SUBJECT_TYPES.EXTENSION,
+              subjectType: SubjectType.Extension,
             },
             'https://null.com': null,
             'https://foo.com': 'bad data',

--- a/shared/constants/app.ts
+++ b/shared/constants/app.ts
@@ -78,20 +78,6 @@ export const EXTENSION_MESSAGES = {
   READY: 'METAMASK_EXTENSION_READY',
 } as const;
 
-/**
- * The different kinds of subjects that MetaMask may interact with, including
- * third parties and itself (e.g. when the background communicated with the UI).
- */
-export const SUBJECT_TYPES = {
-  EXTENSION: 'extension',
-  INTERNAL: 'internal',
-  UNKNOWN: 'unknown',
-  WEBSITE: 'website',
-  ///: BEGIN:ONLY_INCLUDE_IN(flask)
-  SNAP: 'snap',
-  ///: END:ONLY_INCLUDE_IN
-} as const;
-
 export const POLLING_TOKEN_ENVIRONMENT_TYPES = {
   [ENVIRONMENT_TYPE_POPUP]: 'popupGasPollTokens',
   [ENVIRONMENT_TYPE_NOTIFICATION]: 'notificationGasPollTokens',

--- a/ui/hooks/useOriginMetadata.js
+++ b/ui/hooks/useOriginMetadata.js
@@ -1,4 +1,4 @@
-import { SubjectType } from '@metamask/controllers';
+import { SubjectType } from '@metamask/subject-metadata-controller';
 import { useSelector } from 'react-redux';
 import { getTargetSubjectMetadata } from '../selectors';
 

--- a/ui/hooks/useOriginMetadata.js
+++ b/ui/hooks/useOriginMetadata.js
@@ -1,6 +1,6 @@
+import { SubjectType } from '@metamask/controllers';
 import { useSelector } from 'react-redux';
 import { getTargetSubjectMetadata } from '../selectors';
-import { SUBJECT_TYPES } from '../../shared/constants/app';
 
 /**
  * @typedef {object} OriginMetadata
@@ -34,7 +34,7 @@ export function useOriginMetadata(origin) {
       host: url.host,
       hostname: url.hostname,
       origin,
-      subjectType: SUBJECT_TYPES.UNKNOWN,
+      subjectType: SubjectType.Unknown,
     };
   } catch (_) {
     // do nothing

--- a/ui/pages/permissions-connect/permissions-connect.container.js
+++ b/ui/pages/permissions-connect/permissions-connect.container.js
@@ -1,3 +1,4 @@
+import { SubjectType } from '@metamask/controllers';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import {
@@ -32,7 +33,6 @@ import {
   CONNECT_SNAP_UPDATE_ROUTE,
   ///: END:ONLY_INCLUDE_IN
 } from '../../helpers/constants/routes';
-import { SUBJECT_TYPES } from '../../../shared/constants/app';
 import PermissionApproval from './permissions-connect.component';
 
 const mapStateToProps = (state, ownProps) => {
@@ -68,11 +68,11 @@ const mapStateToProps = (state, ownProps) => {
     origin,
     iconUrl: null,
     extensionId: null,
-    subjectType: SUBJECT_TYPES.UNKNOWN,
+    subjectType: SubjectType.Unknown,
   };
 
   ///: BEGIN:ONLY_INCLUDE_IN(flask)
-  const isSnap = targetSubjectMetadata.subjectType === SUBJECT_TYPES.SNAP;
+  const isSnap = targetSubjectMetadata.subjectType === SubjectType.Snap;
   ///: END:ONLY_INCLUDE_IN
 
   const accountsWithLabels = getAccountsWithLabels(state);

--- a/ui/pages/permissions-connect/permissions-connect.container.js
+++ b/ui/pages/permissions-connect/permissions-connect.container.js
@@ -1,4 +1,4 @@
-import { SubjectType } from '@metamask/controllers';
+import { SubjectType } from '@metamask/subject-metadata-controller';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import {

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -1,3 +1,6 @@
+///: BEGIN:ONLY_INCLUDE_IN(flask)
+import { SubjectType } from '@metamask/controllers';
+///: END:ONLY_INCLUDE_IN
 import {
   createSelector,
   createSelectorCreator,
@@ -28,13 +31,7 @@ import {
   LedgerTransportTypes,
   HardwareTransportStates,
 } from '../../shared/constants/hardware-wallets';
-
-import {
-  MESSAGE_TYPE,
-  ///: BEGIN:ONLY_INCLUDE_IN(flask)
-  SUBJECT_TYPES,
-  ///: END:ONLY_INCLUDE_IN
-} from '../../shared/constants/app';
+import { MESSAGE_TYPE } from '../../shared/constants/app';
 
 import { TRUNCATED_NAME_CHAR_LIMIT } from '../../shared/constants/labels';
 
@@ -632,7 +629,7 @@ export function getTargetSubjectMetadata(state, origin) {
   const metadata = getSubjectMetadata(state)[origin];
 
   ///: BEGIN:ONLY_INCLUDE_IN(flask)
-  if (metadata?.subjectType === SUBJECT_TYPES.SNAP) {
+  if (metadata?.subjectType === SubjectType.Snap) {
     const { svgIcon, ...remainingMetadata } = metadata;
     return {
       ...remainingMetadata,

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -1,5 +1,5 @@
 ///: BEGIN:ONLY_INCLUDE_IN(flask)
-import { SubjectType } from '@metamask/controllers';
+import { SubjectType } from '@metamask/subject-metadata-controller';
 ///: END:ONLY_INCLUDE_IN
 import {
   createSelector,


### PR DESCRIPTION
For reusability, I've moved the `SUBJECT_TYPES` "enum" to the `@metamask/controllers` package, as we need this in Snaps.