### PR TITLE
E2e remove redundant code

### DIFF
--- a/test/e2e/metamask-ui.spec.js
+++ b/test/e2e/metamask-ui.spec.js
@@ -458,10 +458,10 @@ describe('MetaMask', function () {
       await driver.delay(veryLargeDelayMs);
       await driver.clickElement({ text: 'Edit', tag: 'button' });
       await driver.delay(veryLargeDelayMs);
-      await driver.clickElement(
-        { text: 'Edit suggested gas fee', tag: 'button' },
-        10000,
-      );
+      await driver.clickElement({
+        text: 'Edit suggested gas fee',
+        tag: 'button',
+      });
       await driver.delay(veryLargeDelayMs);
       const inputs = await driver.findElements('input[type="number"]');
       const gasLimitInput = inputs[0];
@@ -576,10 +576,10 @@ describe('MetaMask', function () {
     it('customizes gas', async function () {
       await driver.clickElement('.confirm-approve-content__small-blue-text');
       await driver.delay(regularDelayMs);
-      await driver.clickElement(
-        { text: 'Edit suggested gas fee', tag: 'button' },
-        10000,
-      );
+      await driver.clickElement({
+        text: 'Edit suggested gas fee',
+        tag: 'button',
+      });
       await driver.delay(regularDelayMs);
 
       const [gasLimitInput, gasPriceInput] = await driver.findElements(

--- a/test/e2e/tests/custom-token-add-approve.spec.js
+++ b/test/e2e/tests/custom-token-add-approve.spec.js
@@ -221,10 +221,10 @@ describe.skip('Create token, approve token and approve token without gas', funct
           await driver.clickElement(
             '.confirm-approve-content__small-blue-text',
           );
-          await driver.clickElement(
-            { text: 'Edit suggested gas fee', tag: 'button' },
-            10000,
-          );
+          await driver.clickElement({
+            text: 'Edit suggested gas fee',
+            tag: 'button',
+          });
           const [gasLimitInput, gasPriceInput] = await driver.findElements(
             'input[type="number"]',
           );

--- a/test/e2e/tests/send-eth.spec.js
+++ b/test/e2e/tests/send-eth.spec.js
@@ -272,10 +272,10 @@ describe('Send ETH from dapp using advanced gas controls', function () {
           css: '.transaction-total-banner',
           text: '0.00021 ETH',
         });
-        await driver.clickElement(
-          { text: 'Edit suggested gas fee', tag: 'button' },
-          10000,
-        );
+        await driver.clickElement({
+          text: 'Edit suggested gas fee',
+          tag: 'button',
+        });
         await driver.waitForSelector({
           css: '.transaction-total-banner',
           text: '0.00021 ETH',

--- a/test/e2e/tests/send-eth.spec.js
+++ b/test/e2e/tests/send-eth.spec.js
@@ -239,23 +239,6 @@ describe('Send ETH from dapp using advanced gas controls', function () {
         await driver.fill('#password', 'correct horse battery staple');
         await driver.press('#password', driver.Key.ENTER);
 
-        // goes to the settings screen
-        await driver.clickElement('.account-menu__icon');
-        await driver.clickElement({ text: 'Settings', tag: 'div' });
-        await driver.clickElement({ text: 'Advanced', tag: 'div' });
-        await driver.clickElement(
-          '[data-testid="advanced-setting-show-testnet-conversion"] .settings-page__content-item-col > label > div',
-        );
-        const advancedGasTitle = await driver.findElement({
-          text: 'Advanced gas controls',
-          tag: 'span',
-        });
-        await driver.scrollToElement(advancedGasTitle);
-        await driver.clickElement(
-          '[data-testid="advanced-setting-advanced-gas-inline"] .settings-page__content-item-col > label > div',
-        );
-        await driver.clickElement('.app-header__logo-container');
-
         // initiates a send from the dapp
         await driver.openNewPage('http://127.0.0.1:8080/');
         await driver.clickElement({ text: 'Send', tag: 'button' });


### PR DESCRIPTION
## Explanation

<!--
Thanks for the pull request. Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues, Slack conversations, Zendesk issues, user stories, etc. reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

- Remove unused code in metamask-ui.spec.js, custom-token-add-approve.spec.js and send-eth.spec
- Remove settings screen steps from send-eth.spec.js as they have no effect on the test

## Screenshots/Screencaps

<!-- If you're making a change to the UI, make sure to capture a screenshot or a short video showing off your work! -->

### Before

<!-- How did the UI you changed look before your changes? Drag your file(s) below this line: -->

n/a

### After

<!-- How does it look now? Drag your file(s) below this line: -->

n/a

## Manual Testing Steps

<!--
How should reviewers and QA manually test your changes? For instance:

- Go to this screen
- Do this
- Then do this
-->

The ci job `ci/circleci: test-e2e-firefox` and `ci/circleci: test-e2e-chrome` should be green

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
