### PR TITLE
Call onbootcleanup at the end of the tx controller constructor

### DIFF
--- a/app/scripts/controllers/transactions/index.js
+++ b/app/scripts/controllers/transactions/index.js
@@ -161,7 +161,6 @@ export default class TransactionController extends EventEmitter {
       getNetwork: this.getNetwork.bind(this),
       getCurrentChainId: opts.getCurrentChainId,
     });
-    this._onBootCleanUp();
 
     this.store = this.txStateManager.store;
     this.nonceTracker = new NonceTracker({
@@ -208,6 +207,7 @@ export default class TransactionController extends EventEmitter {
 
     // request state update to finalize initialization
     this._updatePendingTxsAfterFirstBlock();
+    this._onBootCleanUp();
   }
 
   /**
@@ -1359,6 +1359,7 @@ export default class TransactionController extends EventEmitter {
         txMeta,
         'transactions#approveTransaction',
       );
+      // throw new Error();
       // sign transaction
       const rawTx = await this.signTransaction(txId);
       await this.publishTransaction(txId, rawTx, actionId);

--- a/app/scripts/controllers/transactions/index.js
+++ b/app/scripts/controllers/transactions/index.js
@@ -1359,7 +1359,6 @@ export default class TransactionController extends EventEmitter {
         txMeta,
         'transactions#approveTransaction',
       );
-      // throw new Error();
       // sign transaction
       const rawTx = await this.signTransaction(txId);
       await this.publishTransaction(txId, rawTx, actionId);

--- a/test/e2e/fixture-builder.js
+++ b/test/e2e/fixture-builder.js
@@ -981,6 +981,117 @@ class FixtureBuilder {
     });
   }
 
+  withTransactionControllerApprovedTransaction() {
+    return this.withTransactionController({
+      transactions: {
+        4046084157914634: {
+          chainId: '0x539',
+          history: [
+            {
+              chainId: '0x539',
+              id: 4046084157914634,
+              loadingDefaults: true,
+              metamaskNetworkId: '1337',
+              origin: 'metamask',
+              status: 'unapproved',
+              time: 1617228030067,
+              txParams: {
+                from: '0x5cfe73b6021e818b776b421b1c4db2474086a7e1',
+                gas: '0x61a8',
+                maxFeePerGas: '0x59682f0c',
+                maxPriorityFeePerGas: '0x59682f00',
+                to: '0x2f318C334780961FB129D2a6c30D0763d9a5C970',
+                type: '0x2',
+                value: '0xde0b6b3a7640000',
+              },
+              type: 'simpleSend',
+            },
+            [
+              {
+                note: 'Added new unapproved transaction.',
+                op: 'replace',
+                path: '/loadingDefaults',
+                timestamp: 1617228030069,
+                value: false,
+              },
+            ],
+            [
+              {
+                op: 'add',
+                path: '/txParams/nonce',
+                value: '0x0',
+                note: 'transactions#approveTransaction',
+                timestamp: 1617228031069,
+              },
+              {
+                op: 'add',
+                path: '/nonceDetails',
+                value: {
+                  params: {
+                    highestLocallyConfirmed: 0,
+                    highestSuggested: 0,
+                    nextNetworkNonce: 0,
+                  },
+                  local: {
+                    name: 'local',
+                    nonce: 0,
+                    details: {
+                      startPoint: 0,
+                      highest: 0,
+                    },
+                  },
+                  network: {
+                    name: 'network',
+                    nonce: 0,
+                    details: {
+                      blockNumber: '0x0',
+                      baseCount: 0,
+                    },
+                  },
+                },
+              },
+            ],
+          ],
+          id: 4046084157914634,
+          loadingDefaults: false,
+          metamaskNetworkId: '1337',
+          origin: 'metamask',
+          primaryTransaction: {
+            chainId: '0x539',
+            id: 4046084157914634,
+            loadingDefaults: true,
+            metamaskNetworkId: '1337',
+            origin: 'metamask',
+            status: 'approved',
+            time: 1617228030067,
+            txParams: {
+              from: '0x5cfe73b6021e818b776b421b1c4db2474086a7e1',
+              gas: '0x61a8',
+              maxFeePerGas: '0x59682f0c',
+              maxPriorityFeePerGas: '0x59682f00',
+              to: '0x2f318C334780961FB129D2a6c30D0763d9a5C970',
+              type: '0x2',
+              value: '0xde0b6b3a7640000',
+            },
+            type: 'sentEther',
+          },
+          status: 'approved',
+          time: 1617228030067,
+          txParams: {
+            from: '0x5cfe73b6021e818b776b421b1c4db2474086a7e1',
+            gas: '0x61a8',
+            maxFeePerGas: '0x59682f0c',
+            maxPriorityFeePerGas: '0x59682f00',
+            to: '0x2f318C334780961FB129D2a6c30D0763d9a5C970',
+            type: '0x2',
+            value: '0xde0b6b3a7640000',
+          },
+          type: 'simpleSend',
+        },
+      },
+    });
+  }
+
   build() {
     this.fixture.meta = {
       version: 74,

--- a/test/e2e/tests/stuck-approved-transaction.spec.js
+++ b/test/e2e/tests/stuck-approved-transaction.spec.js
@@ -1,0 +1,47 @@
+const { strict: assert } = require('assert');
+const { convertToHexValue, withFixtures } = require('../helpers');
+const FixtureBuilder = require('../fixture-builder');
+
+describe('Editing Confirm Transaction', function () {
+  it('approves a transaction stuck in approved state on boot', async function () {
+    const ganacheOptions = {
+      hardfork: 'london',
+      accounts: [
+        {
+          secretKey:
+            '0x7C9529A67102755B7E6102D6D950AC5D5863C98713805CEC576B945B15B71EAC',
+          balance: convertToHexValue(25000000000000000000),
+        },
+      ],
+    };
+    await withFixtures(
+      {
+        fixtures: new FixtureBuilder()
+          .withTransactionControllerApprovedTransaction()
+          .build(),
+        ganacheOptions,
+        title: this.test.title,
+      },
+      async ({ driver }) => {
+        await driver.navigate();
+
+        await driver.fill('#password', 'correct horse battery staple');
+        await driver.press('#password', driver.Key.ENTER);
+
+        await driver.clickElement('[data-testid="home__activity-tab"]');
+        await driver.wait(async () => {
+          const confirmedTxes = await driver.findElements(
+            '.transaction-list__completed-transactions .transaction-list-item',
+          );
+          return confirmedTxes.length === 1;
+        }, 10000);
+
+        const txValues = await driver.findElements(
+          '.transaction-list-item__primary-currency',
+        );
+        assert.equal(txValues.length, 1);
+        assert.ok(/-1\s*ETH/u.test(await txValues[0].getText()));
+      },
+    );
+  });
+});


### PR DESCRIPTION
Fixes https://github.com/MetaMask/metamask-extension/issues/16447
Fixes https://github.com/MetaMask/metamask-extension/issues/16433

This PR fixes issues related to the `onBootCleanup` call in the constructor of the transaction controller. That call relies on instantiation of other class properties. To ensure that everything it requires is instantiated when it is called, we move it to the bottom of the constructor.

An e2e test is added to verify that onbootcleanup successfully approves a transaction stuck in approve state. This would have caught the bug this PR is fixing, as well as the bug that was fixed in v10.21.2