### PR TITLE
fix chainId validation on network form

### DIFF
--- a/ui/pages/settings/networks-tab/networks-form/networks-form.test.js
+++ b/ui/pages/settings/networks-tab/networks-form/networks-form.test.js
@@ -78,7 +78,13 @@ describe('NetworkForm Component', () => {
       encodedQueryParams: true,
     })
       .post('/')
-      .reply(200, { jsonrpc: '2.0', id: '1643927040523', result: '0x38' });
+      .reply(200, { jsonrpc: '2.0', result: '0x38' });
+
+    nock('https://rpc.flashbots.net:443', {
+      encodedQueryParams: true,
+    })
+      .post('/')
+      .reply(200, { jsonrpc: '2.0', result: '0x1' });
   });
 
   afterEach(() => {
@@ -190,9 +196,20 @@ describe('NetworkForm Component', () => {
     renderComponent(propNewNetwork);
     const chainIdField = screen.getByRole('textbox', { name: 'Chain ID' });
     const rpcUrlField = screen.getByRole('textbox', { name: 'New RPC URL' });
+    const currencySymbolField = screen.getByRole('textbox', {
+      name: 'Currency symbol',
+    });
 
     fireEvent.change(chainIdField, {
       target: { value: '1' },
+    });
+
+    fireEvent.change(currencySymbolField, {
+      target: { value: 'test' },
+    });
+
+    fireEvent.change(rpcUrlField, {
+      target: { value: 'https://rpc.flashbots.net' },
     });
 
     expect(
@@ -201,6 +218,8 @@ describe('NetworkForm Component', () => {
       ),
     ).toBeInTheDocument();
 
+    expect(screen.getByText('Save')).not.toBeDisabled();
+
     fireEvent.change(rpcUrlField, {
       target: { value: 'https://bsc-dataseed.binance.org/' },
     });
@@ -208,6 +227,8 @@ describe('NetworkForm Component', () => {
     const expectedWarning =
       'The RPC URL you have entered returned a different chain ID (56). Please update the Chain ID to match the RPC URL of the network you are trying to add.';
     expect(await screen.findByText(expectedWarning)).toBeInTheDocument();
+
+    expect(screen.getByText('Save')).toBeDisabled();
 
     fireEvent.change(chainIdField, {
       target: { value: 'a' },


### PR DESCRIPTION
## Explanation
An issue was introduced [a few months back](https://github.com/MetaMask/metamask-extension/pull/14644) on the add network form where entering `chainId` that did not match the `chainId` returned by the `rpcUrl` didn't block form submission. This issue was introduced while attempting to allow users to add alternative networks (via the form) that had a chainId that matched an existing network (for example [a flashbots RPC provider for mainnet](https://medium.com/alchemistcoin/how-to-add-flashbots-protect-rpc-to-your-metamask-3f1412a16787)). We want to warn but not block users when they attempt to add networks with a chainId for which they already have a network added, but we still want to fully block them from adding networks where `chainId` and `rpcUrls` do not match eachother.

### Before

https://user-images.githubusercontent.com/34557516/201164095-2780562e-710d-476e-a65f-ad2497f0d054.mov


### After

https://user-images.githubusercontent.com/34557516/201163567-56562d3f-6500-44b6-8d70-2be92571037d.mov


## Manual Testing Steps
1. Navigate to Add Network Form
2. Add a Currency Ticker and Name
3. Add a valid RPC Url
4. Input a chainId that does not match this RPC
5. You should see that you are not able to submit the form

Also
1. Navigate to Add Network Form
2. Add a Currency Ticker and Name
3. Add a valid alternative RPC Url for a network you already have added
4. Input the chainId that **does** match this RPC
5. You should see a warning that `This Chain ID is currently used by the ____ network`
6. You should still be able to submit the form

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [ ] How this problem was solved
  - [x] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [x] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
