### PR TITLE
[e2e]: log exceptions when tests fail

### DIFF
--- a/test/e2e/helpers.js
+++ b/test/e2e/helpers.js
@@ -120,9 +120,7 @@ async function withFixtures(options, testSuite) {
       const cdpConnection = await webDriver.createCDPConnection('page');
       await webDriver.onLogException(cdpConnection, function (exception) {
         const { description } = exception.exceptionDetails.exception;
-        const message = description.substring(0, description.indexOf('\n'));
-        exception.message = exception.message || message;
-        exceptions.push(exception);
+        exceptions.push(description);
       });
     }
 
@@ -157,7 +155,7 @@ async function withFixtures(options, testSuite) {
     }
     if (errors.length === 0 && exceptions.length > 0 && failOnConsoleError) {
       const [exception] = exceptions;
-      throw Error(exception.message);
+      throw Error(exception);
     }
     throw error;
   } finally {

--- a/test/e2e/helpers.js
+++ b/test/e2e/helpers.js
@@ -147,7 +147,11 @@ async function withFixtures(options, testSuite) {
       } catch (verboseReportError) {
         console.error(verboseReportError);
       }
-      if (errors.length === 0 && driver.exceptions.length > 0 && failOnConsoleError) {
+      if (
+        errors.length === 0 &&
+        driver.exceptions.length > 0 &&
+        failOnConsoleError
+      ) {
         const errorMessage = `Errors found in browser console:\n${driver.exceptions.join(
           '\n',
         )}`;

--- a/test/e2e/webdriver/driver.js
+++ b/test/e2e/webdriver/driver.js
@@ -431,7 +431,7 @@ class Driver {
   }
 
   async checkBrowserForExceptions() {
-    const exceptions = this.exceptions;
+    const { exceptions } = this;
     const cdpConnection = await this.driver.createCDPConnection('page');
     await this.driver.onLogException(cdpConnection, function (exception) {
       const { description } = exception.exceptionDetails.exception;

--- a/test/e2e/webdriver/driver.js
+++ b/test/e2e/webdriver/driver.js
@@ -49,6 +49,7 @@ class Driver {
     this.browser = browser;
     this.extensionUrl = extensionUrl;
     this.timeout = timeout;
+    this.exceptions = [];
     // The following values are found in
     // https://github.com/SeleniumHQ/selenium/blob/trunk/javascript/node/selenium-webdriver/lib/input.js#L50-L110
     // These should be replaced with string constants 'Enter' etc for playwright.
@@ -427,6 +428,15 @@ class Driver {
     await fs.writeFile('/tmp/all_logs.json', JSON.stringify(browserLogs));
 
     return browserLogs;
+  }
+
+  async checkBrowserForExceptions() {
+    const exceptions = this.exceptions;
+    const cdpConnection = await this.driver.createCDPConnection('page');
+    await this.driver.onLogException(cdpConnection, function (exception) {
+      const { description } = exception.exceptionDetails.exception;
+      exceptions.push(description);
+    });
   }
 
   async checkBrowserForConsoleErrors() {


### PR DESCRIPTION
## Explanation

<!--
Thanks for the pull request. Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues, Slack conversations, Zendesk issues, user stories, etc. reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

Problem: Many engineers have run into issues where the e2e tests are failing on the pipeline and its not immediately obvious as to why. Usually it occurs when theres a Lavamoat error thrown on the background, preventing the login screen from loading

Solution: This PR surfaces exceptions thrown on the ui/background when a test fails

Notes: The webdriver method used is only available on Chrome, this is consistent with the existing error capturing logic we have

## Screenshots/Screencaps

<!-- If you're making a change to the UI, make sure to capture a screenshot or a short video showing off your work! -->

### Before

<!-- How did the UI you changed look before your changes? Drag your file(s) below this line: -->

```
yarn run v1.22.11
$ SELENIUM_BROWSER=chrome node test/e2e/run-all.js
$ /Users/peteryinusa/Documents/GitHub/metamask-extension-e2e/node_modules/.bin/mocha --no-config --timeout 60000 /Users/peteryinusa/Documents/GitHub/metamask-extension-e2e/test/e2e/tests/account-details.spec.js --exit


  Show account details
Starting ChromeDriver 107.0.5304.62 (1eec40d3a5764881c92085aaee66d25075c159aa-refs/branch-heads/5304@{#942}) on port 63365
Only local connections are allowed.
Please see https://chromedriver.chromium.org/security-considerations for suggestions on keeping ChromeDriver safe.
ChromeDriver was started successfully.
    1) should show the QR code for the account


  0 passing (25s)
  1 failing

  1) Show account details
       should show the QR code for the account:
     TimeoutError: Waiting for element to be located By(css selector, #password)
Wait timed out after 10029ms
      at /Users/peteryinusa/Documents/GitHub/metamask-extension-e2e/node_modules/selenium-webdriver/lib/webdriver.js:906:17
      at processTicksAndRejections (node:internal/process/task_queues:96:5)



info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

### After

<!-- How does it look now? Drag your file(s) below this line: -->

```
yarn run v1.22.11
$ node test/e2e/run-e2e-test.js test/e2e/tests/account-details.spec.js --browser chrome
$ /Users/peteryinusa/Documents/GitHub/metamask-extension-e2e/node_modules/.bin/mocha --no-config --timeout 60000 test/e2e/tests/account-details.spec.js --exit


  Show account details
Starting ChromeDriver 107.0.5304.62 (1eec40d3a5764881c92085aaee66d25075c159aa-refs/branch-heads/5304@{#942}) on port 54610
Only local connections are allowed.
Please see https://chromedriver.chromium.org/security-considerations for suggestions on keeping ChromeDriver safe.
ChromeDriver was started successfully.
    1) should show the QR code for the account


  0 passing (25s)
  1 failing

  1) Show account details
       should show the QR code for the account:
     Error: Errors found in browser console:
Error: LavaMoat - required package not in allowlist: package "@metamask/controllers>eth-keyring-controller" requested "browserify>events" as "events"
  at requireRelative (chrome-extension://eemkccoomdelmfifgfcnkfbjhhfenbpk/runtime-lavamoat.js:11029:15)
  at requireRelativeWithContext (chrome-extension://eemkccoomdelmfifgfcnkfbjhhfenbpk/runtime-lavamoat.js:10978:18)
  at Object.<anonymous> (chrome-extension://eemkccoomdelmfifgfcnkfbjhhfenbpk/common-2.js:1:205594)
  at internalRequire (chrome-extension://eemkccoomdelmfifgfcnkfbjhhfenbpk/runtime-lavamoat.js:10966:27)
  at requireRelative (chrome-extension://eemkccoomdelmfifgfcnkfbjhhfenbpk/runtime-lavamoat.js:11009:27)
  at requireRelativeWithContext (chrome-extension://eemkccoomdelmfifgfcnkfbjhhfenbpk/runtime-lavamoat.js:10978:18)
  at Object.<anonymous> (chrome-extension://eemkccoomdelmfifgfcnkfbjhhfenbpk/common-2.js:1:60750)
  at internalRequire (chrome-extension://eemkccoomdelmfifgfcnkfbjhhfenbpk/runtime-lavamoat.js:10966:27)
  at requireRelative (chrome-extension://eemkccoomdelmfifgfcnkfbjhhfenbpk/runtime-lavamoat.js:11009:27)
  at requireRelativeWithContext (chrome-extension://eemkccoomdelmfifgfcnkfbjhhfenbpk/runtime-lavamoat.js:10978:18)
  at Object.<anonymous> (chrome-extension://eemkccoomdelmfifgfcnkfbjhhfenbpk/common-2.js:1:56697)
  at internalRequire (chrome-extension://eemkccoomdelmfifgfcnkfbjhhfenbpk/runtime-lavamoat.js:10966:27)
  at requireRelative (chrome-extension://eemkccoomdelmfifgfcnkfbjhhfenbpk/runtime-lavamoat.js:11009:27)
  at requireRelativeWithContext (chrome-extension://eemkccoomdelmfifgfcnkfbjhhfenbpk/runtime-lavamoat.js:10978:18)
  at Object.<anonymous> (chrome-extension://eemkccoomdelmfifgfcnkfbjhhfenbpk/ui-7.js:1:70478)
  at internalRequire (chrome-extension://eemkccoomdelmfifgfcnkfbjhhfenbpk/runtime-lavamoat.js:10966:27)
  at requireRelative (chrome-extension://eemkccoomdelmfifgfcnkfbjhhfenbpk/runtime-lavamoat.js:11009:27)
  at requireRelativeWithContext (chrome-extension://eemkccoomdelmfifgfcnkfbjhhfenbpk/runtime-lavamoat.js:10978:18)
  at Object.<anonymous> (chrome-extension://eemkccoomdelmfifgfcnkfbjhhfenbpk/ui-8.js:1:545545)
  at internalRequire (chrome-extension://eemkccoomdelmfifgfcnkfbjhhfenbpk/runtime-lavamoat.js:10966:27)
  at requireRelative (chrome-extension://eemkccoomdelmfifgfcnkfbjhhfenbpk/runtime-lavamoat.js:11009:27)
  at requireRelativeWithContext (chrome-extension://eemkccoomdelmfifgfcnkfbjhhfenbpk/runtime-lavamoat.js:10978:18)
  at Object.<anonymous> (chrome-extension://eemkccoomdelmfifgfcnkfbjhhfenbpk/ui-8.js:1:560923)
  at internalRequire (chrome-extension://eemkccoomdelmfifgfcnkfbjhhfenbpk/runtime-lavamoat.js:10966:27)
  at requireRelative (chrome-extension://eemkccoomdelmfifgfcnkfbjhhfenbpk/runtime-lavamoat.js:11009:27)
  at requireRelativeWithContext (chrome-extension://eemkccoomdelmfifgfcnkfbjhhfenbpk/runtime-lavamoat.js:10978:18)
  at Object.<anonymous> (chrome-extension://eemkccoomdelmfifgfcnkfbjhhfenbpk/ui-9.js:1:18764)
  at internalRequire (chrome-extension://eemkccoomdelmfifgfcnkfbjhhfenbpk/runtime-lavamoat.js:10966:27)
  at requireRelative (chrome-extension://eemkccoomdelmfifgfcnkfbjhhfenbpk/runtime-lavamoat.js:11009:27)
  at requireRelativeWithContext (chrome-extension://eemkccoomdelmfifgfcnkfbjhhfenbpk/runtime-lavamoat.js:10978:18)
  at Object.<anonymous> (chrome-extension://eemkccoomdelmfifgfcnkfbjhhfenbpk/ui-8.js:1:270248)
  at internalRequire (chrome-extension://eemkccoomdelmfifgfcnkfbjhhfenbpk/runtime-lavamoat.js:10966:27)
  at requireRelative (chrome-extension://eemkccoomdelmfifgfcnkfbjhhfenbpk/runtime-lavamoat.js:11009:27)
  at requireRelativeWithContext (chrome-extension://eemkccoomdelmfifgfcnkfbjhhfenbpk/runtime-lavamoat.js:10978:18)
  at Object.<anonymous> (chrome-extension://eemkccoomdelmfifgfcnkfbjhhfenbpk/ui-8.js:1:280767)
  at internalRequire (chrome-extension://eemkccoomdelmfifgfcnkfbjhhfenbpk/runtime-lavamoat.js:10966:27)
  at requireRelative (chrome-extension://eemkccoomdelmfifgfcnkfbjhhfenbpk/runtime-lavamoat.js:11009:27)
  at requireRelativeWithContext (chrome-extension://eemkccoomdelmfifgfcnkfbjhhfenbpk/runtime-lavamoat.js:10978:18)
  at Object.<anonymous> (chrome-extension://eemkccoomdelmfifgfcnkfbjhhfenbpk/ui-8.js:1:263482)
  at internalRequire (chrome-extension://eemkccoomdelmfifgfcnkfbjhhfenbpk/runtime-lavamoat.js:10966:27)
  at requireRelative (chrome-extension://eemkccoomdelmfifgfcnkfbjhhfenbpk/runtime-lavamoat.js:11009:27)
  at requireRelativeWithContext (chrome-extension://eemkccoomdelmfifgfcnkfbjhhfenbpk/runtime-lavamoat.js:10978:18)
  at Object.<anonymous> (chrome-extension://eemkccoomdelmfifgfcnkfbjhhfenbpk/ui-7.js:1:507185)
  at internalRequire (chrome-extension://eemkccoomdelmfifgfcnkfbjhhfenbpk/runtime-lavamoat.js:10966:27)
  at requireRelative (chrome-extension://eemkccoomdelmfifgfcnkfbjhhfenbpk/runtime-lavamoat.js:11009:27)
  at requireRelativeWithContext (chrome-extension://eemkccoomdelmfifgfcnkfbjhhfenbpk/runtime-lavamoat.js:10978:18)
  at Object.<anonymous> (chrome-extension://eemkccoomdelmfifgfcnkfbjhhfenbpk/ui-7.js:1:87850)
  at internalRequire (chrome-extension://eemkccoomdelmfifgfcnkfbjhhfenbpk/runtime-lavamoat.js:10966:27)
  at requireRelative (chrome-extension://eemkccoomdelmfifgfcnkfbjhhfenbpk/runtime-lavamoat.js:11009:27)
  at requireRelativeWithContext (chrome-extension://eemkccoomdelmfifgfcnkfbjhhfenbpk/runtime-lavamoat.js:10978:18)
      at withFixtures (test/e2e/helpers.js:158:15)
      at processTicksAndRejections (node:internal/process/task_queues:96:5)
      at async Context.<anonymous> (test/e2e/tests/account-details.spec.js:16:5)



info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

## Manual Testing Steps

<!--
How should reviewers and QA manually test your changes? For instance:

- Go to this screen
- Do this
- Then do this
-->

- checkout this branch
- throw and error in the background [here](https://github.com/MetaMask/metamask-extension/blob/e2e-log-exceptions/app/scripts/background.js#L173)
```
async function initialize(remotePort) {
  const initState = await loadStateFromPersistence();
  const initLangCode = await getFirstPreferredLangCode();
  throw new Error('Something went wrong');
  setupController(initState, initLangCode, remotePort);
  if (!isManifestV3) {
    await loadPhishingWarningPage();
  }
  log.info('MetaMask initialization complete.');
}
```
- yarn setup
- yarn build test
- yarn test:e2e:single test/e2e/tests/account-details.spec.js --browser chrome
- check the exception is shown (previously the test would just log that it timed out waiting for the password field on the lock screen)

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
