### PR TITLE
lint - always include extensions for non-js imports

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -96,6 +96,14 @@ module.exports = {
       parserOptions: {
         sourceType: 'module',
       },
+      rules: {
+        "import/extensions": [
+          "error",
+          "ignorePackages", {
+            "js": "never",
+          }
+       ]
+      },
       settings: {
         'import/resolver': {
           // When determining the location of an `import`, use Node's resolution
@@ -105,7 +113,9 @@ module.exports = {
           // packages like `prop-types` (where we would otherwise get "No
           // default export found in imported module 'prop-types'" from
           // TypeScript because imports work differently there).
-          node: {},
+          node: {
+            extensions: [".js", ".jsx", ".ts", ".tsx"],
+          },
           typescript: {
             // Always try to resolve types under `<root>/@types` directory even
             // it doesn't contain any source code, like `@types/unist`


### PR DESCRIPTION
We currently prefer to omit file extensions from imports. idk why we do this!

but in confuses some tools, like Endo bundler, especially when we expect the extension to be autofilled with something like `.ts`. As a start, this rule requires us to list the extension whenever it does not resolve to `.js`

:warning:  [This rule currently does not have an autofixer](https://github.com/import-js/eslint-plugin-import/pull/2593).
For that reason, and because there are about ~230 issues, I'm leaving this in draft.