### PR TITLE
Jest: Add browser.runtime (webextension-polyfill) utils tests

### DIFF
--- a/shared/modules/browser-runtime.utils.test.js
+++ b/shared/modules/browser-runtime.utils.test.js
@@ -51,18 +51,4 @@ describe('Browser Runtime Utils', () => {
       log.error.restore();
     });
   });
-
-  describe('checkForLastErrorAndWarn', () => {
-    it('should log and return error if error was found', () => {
-      sinon.stub(browser.runtime, 'lastError').value({ ...mockLastError });
-      sinon.stub(console, 'warn');
-
-      const result = BrowserRuntimeUtil.checkForLastErrorAndWarn();
-
-      expect(console.warn.calledWith(result)).toBeTruthy();
-      expect(result).toStrictEqual(mockLastError);
-
-      console.warn.restore();
-    });
-  });
 });

--- a/shared/modules/browser-runtime.utils.test.js
+++ b/shared/modules/browser-runtime.utils.test.js
@@ -1,0 +1,68 @@
+import sinon from 'sinon';
+import browser from 'webextension-polyfill';
+import log from 'loglevel';
+import * as BrowserRuntimeUtil from './browser-runtime.utils';
+
+const mockLastError = { message: 'error', stack: [] };
+
+describe('Browser Runtime Utils', () => {
+  beforeAll(() => {
+    sinon.replace(browser, 'runtime', {
+      lastError: undefined,
+    });
+  });
+
+  describe('checkForLastError', () => {
+    it('should return undefined if no lastError found', () => {
+      expect(BrowserRuntimeUtil.checkForLastError()).toBeUndefined();
+    });
+
+    it('should return the lastError (Error object) if lastError is found', () => {
+      sinon.stub(browser.runtime, 'lastError').value(mockLastError);
+
+      expect(BrowserRuntimeUtil.checkForLastError()).toStrictEqual(
+        mockLastError,
+      );
+    });
+
+    it('should return an Error object if the lastError is found with no stack', () => {
+      sinon
+        .stub(browser.runtime, 'lastError')
+        .value({ message: mockLastError.message });
+
+      const result = BrowserRuntimeUtil.checkForLastError();
+
+      expect(result).toStrictEqual(expect.any(Error));
+      expect(result).toHaveProperty('stack');
+      expect(result.message).toBe(mockLastError.message);
+    });
+  });
+
+  describe('checkForLastErrorAndLog', () => {
+    it('should log and return error if error was found', () => {
+      sinon.stub(browser.runtime, 'lastError').value({ ...mockLastError });
+      sinon.stub(log, 'error');
+
+      const result = BrowserRuntimeUtil.checkForLastErrorAndLog();
+
+      expect(log.error.calledWith(result)).toBeTruthy();
+      expect(result).toStrictEqual(mockLastError);
+
+      log.error.restore();
+    });
+  });
+
+  describe('checkForLastErrorAndWarn', () => {
+    it('should log and return error if error was found', () => {
+      sinon.stub(browser.runtime, 'lastError').value({ ...mockLastError });
+      sinon.stub(console, 'warn');
+
+      const result = BrowserRuntimeUtil.checkForLastErrorAndWarn();
+
+      expect(console.warn.calledWith(result)).toBeTruthy();
+      expect(result).toStrictEqual(mockLastError);
+
+      console.warn.restore();
+    });
+  });
+});


### PR DESCRIPTION
## Explanation

Created a new utils file to support `browser.runtime` API from 'webextension-polyfill' npm module here: https://github.com/MetaMask/metamask-extension/pull/16075. This PR adds tests for the new utils. 

## Screenshots/Screencaps

<img width="729" alt="Screen Shot 2022-11-14 at 21 04 19" src="https://user-images.githubusercontent.com/20778143/201680177-600d8774-4c23-4e9b-a163-475b784139fd.png">
minus `checkForLastErrorAndWarn` since we will no longer be needing this. we are removing the uses of `checkForLastErrorAndWarn` here: https://github.com/MetaMask/metamask-extension/pull/16488

## Manual Testing Steps

Run: 
```
yarn run test:unit:jest -u shared/modules/browser-runtime.utils.test.js
```

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [x] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [x] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
