### PR TITLE
MV3: support Service Worker restart for phishing warning pages

### DIFF
--- a/app/scripts/contentscript.js
+++ b/app/scripts/contentscript.js
@@ -138,11 +138,7 @@ function setupPhishingPageStreams() {
   });
 
   if (isManifestV3) {
-    phishingPageStream.on('data', ({ data: { method } }) => {
-      if (!IGNORE_INIT_METHODS_FOR_KEEP_ALIVE.includes(method)) {
-        runWorkerKeepAliveInterval();
-      }
-    });
+    runWorkerKeepAliveInterval();
   }
 
   // create and connect channel muxers

--- a/app/scripts/contentscript.js
+++ b/app/scripts/contentscript.js
@@ -6,10 +6,7 @@ import PortStream from 'extension-port-stream';
 import { obj as createThoughStream } from 'through2';
 
 import { EXTENSION_MESSAGES, MESSAGE_TYPE } from '../../shared/constants/app';
-import {
-  checkForLastError,
-  checkForLastErrorAndWarn,
-} from '../../shared/modules/browser-runtime.utils';
+import { checkForLastError } from '../../shared/modules/browser-runtime.utils';
 import { isManifestV3 } from '../../shared/modules/mv3.utils';
 import shouldInjectProvider from '../../shared/modules/provider-injection';
 
@@ -220,13 +217,25 @@ const destroyPhishingExtStreams = () => {
  * so that streams may be re-established later the phishing extension port is reconnected.
  */
 const onDisconnectDestroyPhishingStreams = () => {
-  checkForLastErrorAndWarn();
+  const err = checkForLastError();
 
   phishingExtPort.onDisconnect.removeListener(
     onDisconnectDestroyPhishingStreams,
   );
 
   destroyPhishingExtStreams();
+
+  /**
+   * If an error is found, reset the streams. When running two or more dapps, resetting the service
+   * worker may cause the error, "Error: Could not establish connection. Receiving end does not
+   * exist.", due to a race-condition. The disconnect event may be called by runtime.connect which
+   * may cause issues. We suspect that this is a chromium bug as this event should only be called
+   * once the port and connections are ready. Delay time is arbitrary.
+   */
+  if (err) {
+    console.warn(`${err} Resetting the phishing streams.`);
+    setTimeout(setupPhishingExtStreams, 1000);
+  }
 };
 
 /**


### PR DESCRIPTION
## Explanation

- Fix bug and add support to enable service worker to reload while using phishing streams (Fixes #16448)
- Only keep service worker alive on load (Fixes #15987) 


**Note:** There is an issue with the phishing warning detection which is out of scope of this PR: https://github.com/MetaMask/metamask-extension/issues/16551

> [@seaona](https://github.com/seaona) observed refreshing the extension from chrome://extensions and then opening a URL detected as a phishing page will not show the phishing warning page.
>
> Looking into this, it appears that the blocklist may not finish loading when the user first lands on a detected phishing page.



## Screenshots/Screencaps

<!-- If you're making a change to the UI, make sure to capture a screenshot or a short video showing off your work! -->

### Before

<img width="1048" alt="Screen Shot 2022-11-14 at 23 46 40" src="https://user-images.githubusercontent.com/20778143/201721447-f329b534-bd27-4841-84c2-8404ba523ebe.png">

### After

<img width="1053" alt="Screen Shot 2022-11-14 at 23 55 05" src="https://user-images.githubusercontent.com/20778143/201721490-e4aaf9b7-f985-4d88-8eda-d049dce8cc55.png">

## Manual Testing Steps

<!--
How should reviewers and QA manually test your changes? For instance:

- Go to this screen
- Do this
- Then do this
-->

Steps to reproduce
- Load MM
- Open a malicious page: https://ethereum-mask.com/ -- see that you are redirected to MM Phishing Detection
- Restart the service worker
- Click on "continuing at your own risk." to be redirected to the malicious site
- Open the malicious page: https://ethereum-mask.com/ again and notice that you will go directly to the malicious site. This means that the service restart is working because after clicking "continuing at your own risk.",  the site is saved to the allowlist/safelist of the wallet. 
- To repro, use a different wallet without the malicious page in the allowlist/safelist

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [x] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [x] PR is linked to the appropriate GitHub issue
- [x] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.