### PR TITLE
button secondary housekeeping

### DIFF
--- a/ui/components/component-library/button-primary/index.js
+++ b/ui/components/component-library/button-primary/index.js
@@ -1,1 +1,2 @@
 export { ButtonPrimary } from './button-primary';
+export { BUTTON_PRIMARY_SIZES } from './button-primary.constants';

--- a/ui/components/component-library/button-secondary/README.mdx
+++ b/ui/components/component-library/button-secondary/README.mdx
@@ -43,7 +43,7 @@ import { ButtonSecondary } from '../ui/component-library/button/button-secondary
 
 ### Danger
 
-Use the `danger` boolean prop to change the `ButtonPrimary` to danger color.
+Use the `danger` boolean prop to change the `ButtonSecondary` to danger color.
 
 <Canvas>
   <Story id="ui-components-component-library-button-secondary-button-secondary-stories-js--danger" />

--- a/ui/components/component-library/button-secondary/__snapshots__/button-secondary.test.js.snap
+++ b/ui/components/component-library/button-secondary/__snapshots__/button-secondary.test.js.snap
@@ -1,0 +1,16 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ButtonSecondary should render button element correctly 1`] = `
+<div>
+  <button
+    class="box mm-button mm-button--size-md mm-button-secondary box--padding-right-4 box--padding-left-4 box--display-inline-flex box--flex-direction-row box--justify-content-center box--align-items-center"
+    data-testid="button-secondary"
+  >
+    <span
+      class="box text mm-button__content text--body-md text--color-inherit box--gap-2 box--flex-direction-row box--justify-content-center box--align-items-center box--display-flex"
+    >
+      Button Secondary
+    </span>
+  </button>
+</div>
+`;

--- a/ui/components/component-library/button-secondary/button-secondary.js
+++ b/ui/components/component-library/button-secondary/button-secondary.js
@@ -32,7 +32,7 @@ ButtonSecondary.propTypes = {
    */
   danger: PropTypes.bool,
   /**
-   * The possible size values for ButtonSecondary: 'SIZES.SM', 'SIZES.MD', 'SIZES.LG',
+   * Possible size values: 'SIZES.SM'(32px), 'SIZES.MD'(40px), 'SIZES.LG'(48px).
    * Default value is 'SIZES.MD'.
    */
   size: PropTypes.oneOf(Object.values(BUTTON_SECONDARY_SIZES)),

--- a/ui/components/component-library/button-secondary/button-secondary.stories.js
+++ b/ui/components/component-library/button-secondary/button-secondary.stories.js
@@ -1,5 +1,9 @@
 import React from 'react';
-import { ALIGN_ITEMS, DISPLAY } from '../../../helpers/constants/design-system';
+import {
+  ALIGN_ITEMS,
+  DISPLAY,
+  SIZES,
+} from '../../../helpers/constants/design-system';
 import Box from '../../ui/box/box';
 import { ICON_NAMES } from '../icon';
 import { ButtonSecondary } from './button-secondary';
@@ -110,13 +114,13 @@ DefaultStory.storyName = 'Default';
 
 export const Size = (args) => (
   <Box display={DISPLAY.FLEX} alignItems={ALIGN_ITEMS.BASELINE} gap={1}>
-    <ButtonSecondary {...args} size={BUTTON_SECONDARY_SIZES.SM}>
+    <ButtonSecondary {...args} size={SIZES.SM}>
       Small Button
     </ButtonSecondary>
-    <ButtonSecondary {...args} size={BUTTON_SECONDARY_SIZES.MD}>
+    <ButtonSecondary {...args} size={SIZES.MD}>
       Medium (Default) Button
     </ButtonSecondary>
-    <ButtonSecondary {...args} size={BUTTON_SECONDARY_SIZES.LG}>
+    <ButtonSecondary {...args} size={SIZES.LG}>
       Large Button
     </ButtonSecondary>
   </Box>

--- a/ui/components/component-library/button-secondary/button-secondary.test.js
+++ b/ui/components/component-library/button-secondary/button-secondary.test.js
@@ -14,6 +14,7 @@ describe('ButtonSecondary', () => {
     expect(getByText('Button Secondary')).toBeDefined();
     expect(container.querySelector('button')).toBeDefined();
     expect(getByTestId('button-secondary')).toHaveClass('mm-button');
+    expect(container).toMatchSnapshot();
   });
 
   it('should render anchor element correctly', () => {

--- a/ui/components/component-library/button-secondary/index.js
+++ b/ui/components/component-library/button-secondary/index.js
@@ -1,1 +1,2 @@
 export { ButtonSecondary } from './button-secondary';
+export { BUTTON_SECONDARY_SIZES } from './button-secondary.constants';


### PR DESCRIPTION
## Explanation

Housekeeping 🧹 to update components consistency. 

Fixes: https://github.com/MetaMask/metamask-extension/issues/16183

## Screenshots/Screencaps

<!-- If you're making a change to the UI, make sure to capture a screenshot or a short video showing off your work! -->

### Before

<img width="1146" alt="Screen Shot 2022-11-14 at 2 25 51 PM" src="https://user-images.githubusercontent.com/26469696/201785405-59309ee7-0f34-42e0-89f1-b5d7f4f987f9.png">

### After
<img width="1126" alt="Screen Shot 2022-11-14 at 2 25 34 PM" src="https://user-images.githubusercontent.com/26469696/201785421-2b3f4fa2-db69-46e6-821c-9215e141e668.png">


## Manual Testing Steps

`yarn test:unit:jest .ui/components/component-library/button-secondary/button-secondary.test.js`

## Pre-merge author checklist

- [x] I've clearly explained:
- [x] What problem this PR is solving
- [x] How this problem was solved
- [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [x] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [x] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.

### Description
Ensure that `ButtonSecondary` adheres to all of the following conventions and standards

- [ ] All Base components follow the suffix convention e.g. `ButtonBase`
- [ ] All Base component MDX documentation have the base component notification at the top
- [x] Has a `className` prop and the PropType descriptions are all the same
- [x] Standardize all similar prop names for images `imgSrc`, `imgAlt`(html element + attribute) (needs audit)
- [x] We are consistent when using the same prop names like `size` and are suggesting the use of the generalized `design-system.js` constants e.g. `SIZES` as the primary option but noting the component consts in the documentation and using them for propType validation and storybook controls only
- [x] Prop table in MDX docs have the "Accepts all Box component props" description and link
- [x] We have a story for each component prop and we use the prop name verbatim e.g. `size` prop would be `export const Size = (args) => (`
- [ ] Are multiple props stories allowed? e.g. `Color, Background Color And Border Color` story in `base-avatar` - [ ] yes when it makes sense to
- [x] We have the accompanying documentation for each component prop and we use the prop name verbatim e.g. `size` prop would be `### Size`
- [x] Add `mm-` prefix to all classNames
- [x] className is kebab case version of the component name
- [x] Spread base components props and reduce duplication of props when props aren't being changed and remain the same for both variant and base components
- [x] Remove `Component.displayName` not needed
- [ ] Add component to root `index.js` file in component-library
- [ ] Add locals for any default text I18nContext as default context 
- [ ] Add any "to dos" with a `// TODO:` comment so we can search for them at a later date e.g. blocking components etc
- [x] Add snapshot testing
- [x] Add pixel values to propType descriptions if we use abstracted prop types that relate to pixel values e.g. `SIZE.MD (32px)`
- [x] Each prop section in the MDX docs should have: a heading, a description, a story and an example code snipped
