### PR TITLE
Prevent user from editing a contract interaction created by a dapp

### DIFF
--- a/test/e2e/tests/dapp-tx-edit.spec.js
+++ b/test/e2e/tests/dapp-tx-edit.spec.js
@@ -1,0 +1,110 @@
+const { strict: assert } = require('assert');
+const { convertToHexValue, withFixtures } = require('../helpers');
+const { SMART_CONTRACTS } = require('../seeder/smart-contracts');
+const FixtureBuilder = require('../fixture-builder');
+
+describe('Editing confirmations of dapp initiated contract interactions', function () {
+  const ganacheOptions = {
+    accounts: [
+      {
+        secretKey:
+          '0x7C9529A67102755B7E6102D6D950AC5D5863C98713805CEC576B945B15B71EAC',
+        balance: convertToHexValue(25000000000000000000),
+      },
+    ],
+  };
+  const smartContract = SMART_CONTRACTS.PIGGYBANK;
+  it('should NOT show an edit button on a contract interaction confirmation iniated by a dapp', async function () {
+    await withFixtures(
+      {
+        dapp: true,
+        fixtures: new FixtureBuilder()
+          .withPermissionControllerConnectedToTestDapp()
+          .build(),
+        ganacheOptions,
+        smartContract,
+        title: this.test.title,
+      },
+      async ({ driver, contractRegistry }) => {
+        const contractAddress = await contractRegistry.getContractAddress(
+          smartContract,
+        );
+        await driver.navigate();
+        await driver.fill('#password', 'correct horse battery staple');
+        await driver.press('#password', driver.Key.ENTER);
+
+        // deploy contract
+        await driver.openNewPage(
+          `http://127.0.0.1:8080/?contract=${contractAddress}`,
+        );
+
+        // wait for deployed contract, calls and confirms a contract method where ETH is sent
+        await driver.findClickableElement('#deployButton');
+        await driver.clickElement('#depositButton');
+        await driver.waitUntilXWindowHandles(3);
+        const windowHandles = await driver.getAllWindowHandles();
+
+        await driver.switchToWindowWithTitle(
+          'MetaMask Notification',
+          windowHandles,
+        );
+        await driver.waitForSelector({
+          css: '.confirm-page-container-summary__action__name',
+          text: 'Deposit',
+        });
+        const editTransactionButton = await driver.isElementPresent({
+          text: 'Edit',
+          tag: 'span',
+        });
+        assert.equal(
+          editTransactionButton,
+          false,
+          `Edit transaction button should not be visible on a contract interaction created by a dapp`,
+        );
+      },
+    );
+  });
+
+  it('should show an edit button on a simple ETH send iniated by a dapp', async function () {
+    await withFixtures(
+      {
+        dapp: true,
+        fixtures: new FixtureBuilder()
+          .withPermissionControllerConnectedToTestDapp()
+          .build(),
+        ganacheOptions,
+        smartContract,
+        title: this.test.title,
+      },
+      async ({ driver }) => {
+        await driver.navigate();
+        await driver.fill('#password', 'correct horse battery staple');
+        await driver.press('#password', driver.Key.ENTER);
+
+        await driver.openNewPage(`http://127.0.0.1:8080/`);
+
+        await driver.clickElement('#sendEIP1559Button');
+        await driver.waitUntilXWindowHandles(3);
+        const windowHandles = await driver.getAllWindowHandles();
+
+        await driver.switchToWindowWithTitle(
+          'MetaMask Notification',
+          windowHandles,
+        );
+        await driver.waitForSelector({
+          css: '.confirm-page-container-summary__action__name',
+          text: 'Sending ETH',
+        });
+        const editTransactionButton = await driver.isElementPresent({
+          text: 'Edit',
+          tag: 'span',
+        });
+        assert.equal(
+          editTransactionButton,
+          true,
+          `Edit transaction button should be visible on a contract interaction created by a dapp`,
+        );
+      },
+    );
+  });
+});

--- a/test/e2e/tests/dapp-tx-edit.spec.js
+++ b/test/e2e/tests/dapp-tx-edit.spec.js
@@ -81,8 +81,7 @@ describe('Editing confirmations of dapp initiated contract interactions', functi
         await driver.press('#password', driver.Key.ENTER);
 
         await driver.openNewPage(`http://127.0.0.1:8080/`);
-
-        await driver.clickElement('#sendEIP1559Button');
+        await driver.clickElement('#sendButton');
         await driver.waitUntilXWindowHandles(3);
         const windowHandles = await driver.getAllWindowHandles();
 

--- a/test/e2e/tests/dapp-tx-edit.spec.js
+++ b/test/e2e/tests/dapp-tx-edit.spec.js
@@ -52,7 +52,7 @@ describe('Editing confirmations of dapp initiated contract interactions', functi
           css: '.confirm-page-container-summary__action__name',
           text: 'Deposit',
         });
-        const editTransactionButton = await driver.isElementPresent(
+        const editTransactionButton = await driver.isElementPresentAndVisible(
           '[data-testid="confirm-page-back-edit-button"]',
         );
         assert.equal(
@@ -94,7 +94,7 @@ describe('Editing confirmations of dapp initiated contract interactions', functi
           css: '.confirm-page-container-summary__action__name',
           text: 'Sending ETH',
         });
-        const editTransactionButton = await driver.isElementPresent(
+        const editTransactionButton = await driver.isElementPresentAndVisible(
           '[data-testid="confirm-page-back-edit-button"]',
         );
         assert.equal(

--- a/test/e2e/tests/dapp-tx-edit.spec.js
+++ b/test/e2e/tests/dapp-tx-edit.spec.js
@@ -52,10 +52,9 @@ describe('Editing confirmations of dapp initiated contract interactions', functi
           css: '.confirm-page-container-summary__action__name',
           text: 'Deposit',
         });
-        const editTransactionButton = await driver.isElementPresent({
-          text: 'Edit',
-          tag: 'span',
-        });
+        const editTransactionButton = await driver.isElementPresent(
+          '[data-testid="confirm-page-back-edit-button"]',
+        );
         assert.equal(
           editTransactionButton,
           false,
@@ -95,10 +94,9 @@ describe('Editing confirmations of dapp initiated contract interactions', functi
           css: '.confirm-page-container-summary__action__name',
           text: 'Sending ETH',
         });
-        const editTransactionButton = await driver.isElementPresent({
-          text: 'Edit',
-          tag: 'span',
-        });
+        const editTransactionButton = await driver.isElementPresent(
+          '[data-testid="confirm-page-back-edit-button"]',
+        );
         assert.equal(
           editTransactionButton,
           true,

--- a/test/e2e/webdriver/driver.js
+++ b/test/e2e/webdriver/driver.js
@@ -272,6 +272,15 @@ class Driver {
     }
   }
 
+  async isElementPresentAndVisible(rawLocator) {
+    try {
+      await this.findVisibleElement(rawLocator);
+      return true;
+    } catch (err) {
+      return false;
+    }
+  }
+
   /**
    * Paste a string into a field.
    *

--- a/ui/components/app/confirm-page-container/confirm-page-container-header/__snapshots__/confirm-page-container-header.component.test.js.snap
+++ b/ui/components/app/confirm-page-container/confirm-page-container-header/__snapshots__/confirm-page-container-header.component.test.js.snap
@@ -26,6 +26,7 @@ exports[`Confirm Detail Row Component should match snapshot 1`] = `
         </svg>
         <span
           class="confirm-page-container-header__back-button"
+          data-testid="confirm-page-back-edit-button"
         >
           Edit
         </span>

--- a/ui/components/app/confirm-page-container/confirm-page-container-header/confirm-page-container-header.component.js
+++ b/ui/components/app/confirm-page-container/confirm-page-container-header/confirm-page-container-header.component.js
@@ -56,6 +56,7 @@ export default function ConfirmPageContainerHeader({
           >
             <IconCaretLeft />
             <span
+              data-testid="confirm-page-back-edit-button"
               className="confirm-page-container-header__back-button"
               onClick={() => onEdit()}
             >

--- a/ui/pages/confirm-transaction-base/confirm-transaction-base.component.js
+++ b/ui/pages/confirm-transaction-base/confirm-transaction-base.component.js
@@ -1157,14 +1157,12 @@ export default class ConfirmTransactionBase extends Component {
       requestsWaitingText,
     } = this.getNavigateTxData();
 
-    let functionType;
-    let isContractInteractionFromDapp = false;
-    if (
+    const isContractInteractionFromDapp =
       txData.type === TRANSACTION_TYPES.CONTRACT_INTERACTION &&
-      txData.origin !== 'metamask'
-    ) {
+      txData.origin !== 'metamask';
+    let functionType;
+    if (isContractInteractionFromDapp) {
       functionType = getMethodName(name);
-      isContractInteractionFromDapp = true;
     }
 
     if (!functionType) {

--- a/ui/pages/confirm-transaction-base/confirm-transaction-base.component.js
+++ b/ui/pages/confirm-transaction-base/confirm-transaction-base.component.js
@@ -1158,11 +1158,13 @@ export default class ConfirmTransactionBase extends Component {
     } = this.getNavigateTxData();
 
     let functionType;
+    let isContractInteractionFromDapp = false;
     if (
       txData.type === TRANSACTION_TYPES.CONTRACT_INTERACTION &&
       txData.origin !== 'metamask'
     ) {
       functionType = getMethodName(name);
+      isContractInteractionFromDapp = true;
     }
 
     if (!functionType) {
@@ -1183,7 +1185,7 @@ export default class ConfirmTransactionBase extends Component {
           toAddress={toAddress}
           toEns={toEns}
           toNickname={toNickname}
-          showEdit={Boolean(onEdit)}
+          showEdit={!isContractInteractionFromDapp && Boolean(onEdit)}
           action={functionType}
           title={title}
           image={image}


### PR DESCRIPTION
Fixes problem introduced in https://github.com/MetaMask/metamask-extension/pull/15812

As of that PR, it became possible for users to edit contract interact transactions. That is okay if the transaction originates from MetaMask, but not if the transaction originates from a dapp. Editing the recipient or the asset type can have unexpected consequences in that case, include allowing the user to transfer tokens to a smart contract address.

This PR prevents the user from editing contract interactions from a dapp. This was the way things were prior to v10.21.0

An e2e test is added to prevent such a regression in the future