### PR TITLE
Skip the first token allowance screen if dapp proposing spending cap is 0

### DIFF
--- a/ui/pages/token-allowance/token-allowance.js
+++ b/ui/pages/token-allowance/token-allowance.js
@@ -76,7 +76,9 @@ export default function TokenAllowance({
 
   const [showContractDetails, setShowContractDetails] = useState(false);
   const [showFullTxDetails, setShowFullTxDetails] = useState(false);
-  const [isFirstPage, setIsFirstPage] = useState(true);
+  const [isFirstPage, setIsFirstPage] = useState(
+    dappProposedTokenAmount !== '0',
+  );
   const [errorText, setErrorText] = useState('');
 
   const currentAccount = useSelector(getCurrentAccountWithSendEtherInfo);
@@ -181,6 +183,8 @@ export default function TokenAllowance({
     setIsFirstPage(true);
   };
 
+  const isEmpty = customTokenAmount === '';
+
   return (
     <Box className="token-allowance-container page-container">
       <Box
@@ -267,7 +271,7 @@ export default function TokenAllowance({
         >
           {isFirstPage && t('setSpendingCap')}
           {!isFirstPage &&
-            (customTokenAmount === 0
+            (customTokenAmount === '0' || isEmpty
               ? t('revokeSpendingCap')
               : t('reviewSpendingCap'))}
         </Typography>
@@ -309,7 +313,11 @@ export default function TokenAllowance({
           <ReviewSpendingCap
             tokenName={tokenSymbol}
             currentTokenBalance={parseFloat(currentTokenBalance)}
-            tokenValue={parseFloat(customTokenAmount)}
+            tokenValue={
+              isNaN(parseFloat(customTokenAmount))
+                ? parseFloat(dappProposedTokenAmount)
+                : parseFloat(customTokenAmount)
+            }
             onEdit={() => handleBackClick()}
           />
         )}


### PR DESCRIPTION

## Explanation
When a dapp proposed value for the spending cap is zero, the user is sent directly to the second screen in the flow and the spending cap is kept as 0 and the title copy reads `Revoke the spending cap for your`.

* Fixes #16428


## Screenshots/Screencaps

### Before


https://user-images.githubusercontent.com/63151811/201906055-1559e130-e060-4a00-9781-f9ba04a25a51.mov


### After


https://user-images.githubusercontent.com/63151811/201905534-2ec590f5-8c7d-4edb-8056-25ede8d361c3.mov


## Manual Testing Steps

1. Go to https://etherscan.io/token/0x6b175474e89094c44da98b954eedeac495271d0f#writeContract
2. Connect your wallet
3. Under approve input any address and 0 as the value
4. Click on write