### PR TITLE
persist user traits for comparison

### DIFF
--- a/app/scripts/controllers/metametrics.js
+++ b/app/scripts/controllers/metametrics.js
@@ -76,6 +76,8 @@ const exceptionsToFilter = {
  * @property {Array} [eventsBeforeMetricsOptIn] - Array of queued events added before
  *  a user opts into metrics.
  * @property {object} [traits] - Traits that are not derived from other state keys.
+ * @property {Record<string any>} [previousUserTraits] - The user traits the last
+ *  time they were computed.
  */
 
 export default class MetaMetricsController {
@@ -685,7 +687,7 @@ export default class MetaMetricsController {
    * @returns {MetaMetricsTraits | null} traits that have changed since last update
    */
   _buildUserTraitsObject(metamaskState) {
-    const { traits } = this.store.getState();
+    const { traits, previousUserTraits } = this.store.getState();
     /** @type {MetaMetricsTraits} */
     const currentTraits = {
       [TRAITS.ADDRESS_BOOK_ENTRIES]: sum(
@@ -722,17 +724,17 @@ export default class MetaMetricsController {
       [TRAITS.TOKEN_DETECTION_ENABLED]: metamaskState.useTokenDetection,
     };
 
-    if (!this.previousTraits) {
-      this.previousTraits = currentTraits;
+    if (!previousUserTraits) {
+      this.store.updateState({ previousUserTraits: currentTraits });
       return currentTraits;
     }
 
-    if (this.previousTraits && !isEqual(this.previousTraits, currentTraits)) {
+    if (previousUserTraits && !isEqual(previousUserTraits, currentTraits)) {
       const updates = pickBy(
         currentTraits,
-        (v, k) => !isEqual(this.previousTraits[k], v),
+        (v, k) => !isEqual(previousUserTraits[k], v),
       );
-      this.previousTraits = currentTraits;
+      this.store.updateState({ previousUserTraits: currentTraits });
       return updates;
     }
 


### PR DESCRIPTION
## Explanation

This pull request does not fundamentally change any values or data related to metrics. This change will result in *less* frequent outbound network requests. The primary issue was that we were storing the previous computed object of traits as an *instance variable*. Some assumptions were made with the initial implementation that are true for normal webapps:

1. Sending traits frequently is preferred because in a traditional web app users must be actively on page to trigger the network request.
2. The background process has a life expiry that makes it inconsequential for using an instance variable.

2 appears to be false because we are seeing a lot of network requests for this mechanism, without any meaningful changes in data sent. 1 is false because we have users who interact with out provider without ever opening MetaMask UI.

2 is further made false by MV3 which will result in many more restarts of the service worker.

This PR just changes the previousTraits instance variable to a persisted object called previousUserTraits. 

## Manual Testing Steps
1. Use MetaMask with metametrics enabled.
2. Open the extension or interact with the provider and see that network requests with the 'identify' type are being made

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
