### PR TITLE
Updating background hover colors with new color design tokens

### DIFF
--- a/ui/components/app/account-menu/index.scss
+++ b/ui/components/app/account-menu/index.scss
@@ -45,11 +45,11 @@
       cursor: pointer;
 
       &:hover {
-        background-color: var(--color-background-alternative);
+        background-color: var(--color-background-default-hover);
       }
 
       &:active {
-        background-color: var(--color-background-alternative);
+        background-color: var(--color-background-default-hover);
       }
     }
 

--- a/ui/components/app/connected-status-indicator/index.scss
+++ b/ui/components/app/connected-status-indicator/index.scss
@@ -9,7 +9,7 @@
 
   &:hover,
   &:active {
-    background-color: var(--color-background-alternative);
+    background-color: var(--color-background-default-hover);
   }
 
   &__inner-circle {

--- a/ui/components/app/dropdowns/dropdown.js
+++ b/ui/components/app/dropdowns/dropdown.js
@@ -36,7 +36,7 @@ export class Dropdown extends Component {
           {`
             li.dropdown-menu-item:hover {
               color:var(--color-text-default);
-              background-color: var(--color-background-alternative);
+              background-color: var(--color-background-default-hover);
               border-radius: 4px;
             }
           `}

--- a/ui/components/app/edit-gas-fee-popover/edit-gas-item/index.scss
+++ b/ui/components/app/edit-gas-fee-popover/edit-gas-item/index.scss
@@ -12,11 +12,15 @@
   width: 100%;
 
   &:hover:not([disabled]) {
-    background-color: var(--color-primary-muted);
+    background-color: var(--color-background-default-hover);
   }
 
   &--selected {
-    background-color: var(--color-background-alternative);
+    background-color: var(--color-primary-muted);
+
+    &:hover:not([disabled]) {
+      background-color: var(--color-primary-muted);
+    }
   }
 
   button.edit-gas-item--disabled[disabled] {

--- a/ui/components/app/flask/snaps-authorship-pill/index.scss
+++ b/ui/components/app/flask/snaps-authorship-pill/index.scss
@@ -18,7 +18,7 @@
   &:hover,
   &:focus {
     .chip {
-      background-color: var(--color-background-alternative);
+      background-color: var(--color-background-default-hover);
     }
   }
 }

--- a/ui/components/app/selected-account/index.scss
+++ b/ui/components/app/selected-account/index.scss
@@ -44,7 +44,7 @@
 
     &:hover,
     &:active {
-      background-color: var(--color-background-alternative);
+      background-color: var(--color-background-default-hover);
     }
   }
 

--- a/ui/components/app/transaction-decoding/components/ui/copy-raw-data/index.scss
+++ b/ui/components/app/transaction-decoding/components/ui/copy-raw-data/index.scss
@@ -12,11 +12,11 @@
     background-color: transparent;
 
     &:hover {
-      background-color: var(--color-background-alternative);
+      background-color: var(--color-background-default-hover);
     }
 
     &:active {
-      background-color: var(--color-background-alternative);
+      background-color: var(--color-background-default-hover);
     }
   }
 

--- a/ui/components/ui/list-item/index.scss
+++ b/ui/components/ui/list-item/index.scss
@@ -21,7 +21,7 @@
 
   &:hover,
   &:focus-within {
-    background-color: var(--color-background-alternative);
+    background-color: var(--color-background-default-hover);
   }
 
   &__icon {

--- a/ui/components/ui/menu/menu.scss
+++ b/ui/components/ui/menu/menu.scss
@@ -37,7 +37,7 @@
 
   &:hover,
   &:active {
-    background: var(--color-background-alternative);
+    background: var(--color-background-default-hover);
   }
 
   &__icon {

--- a/ui/css/itcss/components/send.scss
+++ b/ui/css/itcss/components/send.scss
@@ -688,7 +688,7 @@
         height: 100%;
 
         &:hover {
-          background-color: var(--color-background-default);
+          background-color: var(--color-background-default-hover);
         }
       }
     }

--- a/ui/pages/create-account/connect-hardware/index.scss
+++ b/ui/pages/create-account/connect-hardware/index.scss
@@ -206,7 +206,7 @@
   }
 
   &__item:hover {
-    background-color: var(--color-background-alternative);
+    background-color: var(--color-background-default-hover);
   }
 
   &__item__index {

--- a/ui/pages/notifications/index.scss
+++ b/ui/pages/notifications/index.scss
@@ -82,7 +82,7 @@
     cursor: pointer;
 
     &:hover {
-      background-color: var(--color-background-alternative);
+      background-color: var(--color-background-default-hover);
     }
 
     &__unread-dot {

--- a/ui/pages/settings/index.scss
+++ b/ui/pages/settings/index.scss
@@ -84,7 +84,7 @@
 
         > div {
           &:hover {
-            background: var(--color-background-alternative);
+            background: var(--color-background-default-hover);
           }
         }
 

--- a/ui/pages/swaps/dropdown-search-list/index.scss
+++ b/ui/pages/swaps/dropdown-search-list/index.scss
@@ -44,7 +44,7 @@
     height: 60px;
 
     &:hover {
-      background: var(--color-background-alternative);
+      background: var(--color-background-default-hover);
     }
   }
 

--- a/ui/pages/swaps/searchable-item-list/index.scss
+++ b/ui/pages/swaps/searchable-item-list/index.scss
@@ -68,7 +68,7 @@
 
     &:hover,
     &:focus {
-      background: var(--color-background-alternative);
+      background: var(--color-background-default-hover);
     }
 
     &--selected {


### PR DESCRIPTION
## Explanation

* What is the current state of things and why does it need to change?
There is a new version of the design tokens library that includes the correct color tokens for hover if the element uses `--color-background-default`. Currently the only option to use for hover is `--color-background-alternative` this is dangerous because if an element that has a background of `--color-background-default` has a hover background color of `--color-background-alternative` and is on top of a background that is already using `--color-background-alternative` the element will blend perfectly into the background having the illusion of a transparent background. Still following? 😅 Let me demonstrate

Hypothetical component on hover with current color token options.
- body background: `--color-background-alternative`
- component background: `--color-background-default`
- component background hover: `--color-background-alternative`

https://user-images.githubusercontent.com/8112138/202059273-29291e1f-690e-4ad9-86c5-3c13d2d901c3.mov


* What is the solution your changes offer and how does it work?
New hover tokens were created for the background categories and release in design tokens `v.1.10.0` (yup we missed a release) this PR updates the design tokens package and updates all instances of hover using `--color-background-alternative` to `--color-background-default-hover`

The way I did that is to search for `hover` in all `.scss` files. Is there probably some clever regex I could have used? Possibly. Was my brain working well enough at the time of this PR to come up with it. Definitely not.

I've added some more before/after examples as comments in Files changed but haven't added all because it's pretty time consuming and I think there are enough examples to sufficiently understand the visual changes. 🙏 

## Screenshots/Screencaps

### Before

https://user-images.githubusercontent.com/8112138/202059565-a8a017e0-ca26-43b8-a6a8-f4260bc891fa.mov

https://user-images.githubusercontent.com/8112138/202059559-32f28f1b-ea53-42c2-aa9a-b15144a3698b.mov

### After

https://user-images.githubusercontent.com/8112138/202059596-28620c75-1a47-453c-a074-cdff1c536a6f.mov

https://user-images.githubusercontent.com/8112138/202059593-44789275-65c9-46d9-a524-99ec7229ceda.mov

## Manual Testing Steps

- You could check out this branch and do the same search I did for `hover` in all `scss` files and go through one by one
- But that would be ridiculous so you could checkout this branch and go through the menus and check hover states work in light and dark mode and ensure the spelling of the css vars are correct 😁 

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
