### PR TITLE
[FLASK] Fix update e2e test to catch snaps with caveats 

### DIFF
--- a/test/e2e/snaps/test-snap-update.spec.js
+++ b/test/e2e/snaps/test-snap-update.spec.js
@@ -67,6 +67,15 @@ describe('Test Snap update', function () {
           tag: 'button',
         });
 
+        // wait for permissions popover, click checkboxes and confirm
+        await driver.delay(1000);
+        await driver.clickElement('#key-access-bip32-m-44h-0h-secp256k1-0');
+        await driver.clickElement('#key-access-bip32-m-44h-0h-ed25519-0');
+        await driver.clickElement({
+          text: 'Confirm',
+          tag: 'button',
+        });
+
         // navigate to test snap page
         await driver.waitUntilXWindowHandles(2, 5000, 10000);
         windowHandles = await driver.getAllWindowHandles();
@@ -102,7 +111,7 @@ describe('Test Snap update', function () {
         // look for the correct version text
         const versionResult = await driver.findElement('#updateSnapVersion');
         await driver.delay(1000);
-        assert.equal(await versionResult.getText(), '"2.0.0"');
+        assert.equal(await versionResult.getText(), '"4.0.2"');
       },
     );
   });

--- a/test/e2e/snaps/test-snap-update.spec.js
+++ b/test/e2e/snaps/test-snap-update.spec.js
@@ -29,7 +29,7 @@ describe('Test Snap update', function () {
         await driver.press('#password', driver.Key.ENTER);
 
         // open a new tab and navigate to test snaps page and connect
-        await driver.openNewPage(TEST_SNAPS_WEBSITE_URL);
+        await driver.driver.get(TEST_SNAPS_WEBSITE_URL);
 
         // find and scroll to the correct card and click first
         const snapButton = await driver.findElement('#connectUpdateNew');
@@ -40,7 +40,7 @@ describe('Test Snap update', function () {
         await driver.delay(2000);
 
         // switch to metamask extension and click connect
-        await driver.waitUntilXWindowHandles(3, 5000, 10000);
+        await driver.waitUntilXWindowHandles(2, 5000, 10000);
         let windowHandles = await driver.getAllWindowHandles();
         await driver.switchToWindowWithTitle(
           'MetaMask Notification',
@@ -56,7 +56,7 @@ describe('Test Snap update', function () {
         await driver.delay(2000);
 
         // approve install of snap
-        await driver.waitUntilXWindowHandles(3, 5000, 10000);
+        await driver.waitUntilXWindowHandles(2, 5000, 10000);
         windowHandles = await driver.getAllWindowHandles();
         await driver.switchToWindowWithTitle(
           'MetaMask Notification',
@@ -77,7 +77,7 @@ describe('Test Snap update', function () {
         });
 
         // navigate to test snap page
-        await driver.waitUntilXWindowHandles(2, 5000, 10000);
+        await driver.waitUntilXWindowHandles(1, 5000, 10000);
         windowHandles = await driver.getAllWindowHandles();
         await driver.switchToWindowWithTitle('Test Snaps', windowHandles);
         await driver.delay(1000);
@@ -89,7 +89,7 @@ describe('Test Snap update', function () {
         await driver.clickElement('#connectUpdateNew');
 
         // switch to metamask extension and click connect
-        await driver.waitUntilXWindowHandles(3, 5000, 10000);
+        await driver.waitUntilXWindowHandles(2, 5000, 10000);
         await driver.delay(1000);
 
         // approve update of snap
@@ -104,7 +104,7 @@ describe('Test Snap update', function () {
         });
 
         // navigate to test snap page
-        await driver.waitUntilXWindowHandles(2, 5000, 10000);
+        await driver.waitUntilXWindowHandles(1, 5000, 10000);
         windowHandles = await driver.getAllWindowHandles();
         await driver.switchToWindowWithTitle('Test Snaps', windowHandles);
 


### PR DESCRIPTION
This fix to the update snap E2E test changes the invoked snap from confirm to bip32 - this is to combat missing errors updating snaps with caveats.

NOTE: THIS WILL NOT WORK UNTIL https://github.com/MetaMask/test-snaps/pull/97 IS MERGED, as it relies on a new version of the test-snaps page.

Fixes #16545 