### PR TITLE
Fix crash on e2e test failure

### DIFF
--- a/test/e2e/webdriver/driver.js
+++ b/test/e2e/webdriver/driver.js
@@ -416,7 +416,7 @@ class Driver {
     await fs.writeFile(`${filepathBase}-dom.html`, htmlSource);
     const uiState = await this.driver.executeScript(
       () =>
-        window.stateHooks.getCleanAppState &&
+        window.stateHooks?.getCleanAppState &&
         window.stateHooks.getCleanAppState(),
     );
     await fs.writeFile(


### PR DESCRIPTION
If an e2e test fails on a website, the driver will crash on this line because it can't find a reference to `stateHooks`. That variable is only set in our UI, not on other sites.

## Manual Testing Steps

Not sure this needs manual testing. An example of the crash is here though: https://app.circleci.com/pipelines/github/MetaMask/metamask-extension/30900/workflows/90e1609a-a961-438b-b328-651eb2e0e00c/jobs/806238

## Pre-merge author checklist

- [ ] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [ ] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
