### PR TITLE
Ensure prod beta build is created when merging to master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -283,9 +283,26 @@ jobs:
       - checkout
       - attach_workspace:
           at: .
-      - run:
-          name: build:dist
-          command: yarn build --build-type beta dist
+      - when:
+          condition:
+            not:
+              matches:
+                pattern: /^master$/
+                value: << pipeline.git.branch >>
+          steps:
+            - run:
+                name: build:dist
+                command: yarn build --build-type beta dist
+      - when:
+          condition:
+            not:
+              matches:
+                pattern: /^master$/
+                value: << pipeline.git.branch >>
+          steps:
+            - run:
+                name: build:dist
+                command: yarn build --build-type beta prod
       - run:
           name: build:debug
           command: find dist/ -type f -exec md5sum {} \; | sort -k 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -300,7 +300,7 @@ jobs:
                 value: << pipeline.git.branch >>
           steps:
             - run:
-                name: build:dist
+                name: build:prod
                 command: yarn build --build-type beta prod
       - run:
           name: build:debug

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -295,7 +295,6 @@ jobs:
                 command: yarn build --build-type beta dist
       - when:
           condition:
-            not:
               matches:
                 pattern: /^master$/
                 value: << pipeline.git.branch >>


### PR DESCRIPTION
Currently, the builds generated by the `prep-build-beta` step of CI only produce development builds. This PR ensures that prod builds are created by that step when merging to master