### PR TITLE
fix infura rpc detection

### DIFF
--- a/ui/components/app/loading-network-screen/loading-network-screen.container.js
+++ b/ui/components/app/loading-network-screen/loading-network-screen.container.js
@@ -19,7 +19,8 @@ const mapStateToProps = (state) => {
   const providerChainId = provider?.chainId;
   const isDeprecatedNetwork =
     DEPRECATED_TEST_NET_CHAINIDS.includes(providerChainId);
-  const isInfuraRpcUrl = provider?.rpcUrl?.match('infura');
+  const isInfuraRpcUrl =
+    provider?.rpcUrl && new URL(provider.rpcUrl).host.endsWith('.infura.io');
   const showDeprecatedRpcUrlWarning = isDeprecatedNetwork && isInfuraRpcUrl;
 
   return {


### PR DESCRIPTION
Fixes the following error when trying to connect to Rinkeby:

```
backend.js:12979 Warning: Failed prop type: Invalid prop `showDeprecatedRpcUrlWarning` of type `array` supplied to `LoadingNetworkScreen`, expected `boolean`.
    in LoadingNetworkScreen (created by ConnectFunction)
    in ConnectFunction (created by Routes)
    in div (created by Routes)
    in div (created by Routes)
    in Routes (created by ConnectFunction)
    in ConnectFunction (created by Context.Consumer)
    in withRouter(Connect(Routes)) (created by Index)
    in LegacyI18nProvider (created by Index)
    in I18nProvider (created by Index)
    in LegacyMetaMetricsProvider (created by Index)
    in MetaMetricsProvider (created by Index)
    in Router (created by HashRouter)
    in HashRouter (created by Index)
    in Provider (created by Index)
    in Index
```

Also actually check the domain rather than substring inclusion on the URL.