### PR TITLE
test/e2e: increase timeout 60s -> 80s

### DIFF
--- a/test/e2e/run-e2e-test.js
+++ b/test/e2e/run-e2e-test.js
@@ -79,7 +79,7 @@ async function main() {
     process.env.E2E_DEBUG = 'true';
   }
 
-  let testTimeoutInMilliseconds = 60 * 1000;
+  let testTimeoutInMilliseconds = 80 * 1000;
   let exit = '--exit';
 
   if (leaveRunning) {


### PR DESCRIPTION
Attempt to fix https://app.circleci.com/pipelines/github/MetaMask/metamask-extension/31110/workflows/ccd3d414-0162-4b62-a0a4-31a247e8e7ed/jobs/812114?invite=true#step-106-26


A successful run seem to take close to the limit so maybe that's all there is to it.

https://app.circleci.com/pipelines/github/MetaMask/metamask-extension/31094/workflows/46ee61a6-34d1-4d3e-8c3b-49ad07566b7e/jobs/811720?invite=true#step-106-18