### PR TITLE
added sm border radius

### DIFF
--- a/ui/css/design-system/attributes.scss
+++ b/ui/css/design-system/attributes.scss
@@ -50,6 +50,7 @@ $font-style: normal, italic, oblique;
 $font-size: 10px, 12px;
 $border-radius: (
   xs: 2px,
+  sm: 4px,
   md: 4px,
   lg: 8px,
   xl: 12px,

--- a/ui/css/design-system/attributes.scss
+++ b/ui/css/design-system/attributes.scss
@@ -51,7 +51,7 @@ $font-size: 10px, 12px;
 $border-radius: (
   xs: 2px,
   sm: 4px,
-  md: 4px,
+  md: 6px,
   lg: 8px,
   xl: 12px,
   full: 50%,


### PR DESCRIPTION
This PR is to add missing `sm: 4px` in border-radius
* Fixes #16607 

## Screenshots/Screencaps

### Before

<img width="1889" alt="Screenshot 2022-11-21 at 11 05 25 PM" src="https://user-images.githubusercontent.com/39872794/203122734-bd09d83c-a943-40bf-96bd-b61289b1b05f.png">


### After

<img width="1899" alt="Screenshot 2022-11-21 at 11 04 06 PM" src="https://user-images.githubusercontent.com/39872794/203122531-27367dc3-a7a4-40f2-af6c-d95fc9542f26.png">

## Manual Testing Steps

```yarn test:unit:jest .ui/components/ui/box/box.test.js```