### PR TITLE
Fixed tag propType issue in unit tests

### DIFF
--- a/ui/components/component-library/tag/tag.js
+++ b/ui/components/component-library/tag/tag.js
@@ -42,7 +42,7 @@ Tag.propTypes = {
   /**
    * The label props of the component. Most Text component props can be used
    */
-  labelProps: Text.propTypes,
+  labelProps: PropTypes.shape(Text.PropTypes),
   /**
    * Additional classNames to be added to the Tag component
    */


### PR DESCRIPTION
Fixed tag prototype issue in unit tests. 

* Fixes #16619 

## Screenshots/Screencaps


### Before

<img width="1068" alt="Screenshot 2022-11-22 at 10 47 43 PM" src="https://user-images.githubusercontent.com/39872794/203379433-034c5bc7-5672-4456-8671-d36aa0a39e57.png">


### After

<img width="1073" alt="Screenshot 2022-11-22 at 10 44 31 PM" src="https://user-images.githubusercontent.com/39872794/203378811-29a62c90-0bd5-4a8f-857c-18a15418c61e.png">


## Manual Testing Steps

`yarn test:unit:jest .ui/components/component-library/tag-url/tag-url.test.js`

## Pre-Merge Checklist

- [x] PR template is filled out
- [x] **IF** this PR fixes a bug, a test that _would have_ caught the bug has been added
- [x] PR is linked to the appropriate GitHub issue
- [x] PR has been added to the appropriate release Milestone

### + If there are functional changes:

- [x] Manual testing complete & passed
- [x] "Extension QA Board" label has been applied