### PR TITLE
Fix/16620/button href prop

### DIFF
--- a/ui/components/component-library/button-base/button-base.js
+++ b/ui/components/component-library/button-base/button-base.js
@@ -35,6 +35,7 @@ export const ButtonBase = ({
   return (
     <Box
       as={Tag}
+      href={href}
       paddingLeft={size === BUTTON_BASE_SIZES.AUTO ? 0 : 4}
       paddingRight={size === BUTTON_BASE_SIZES.AUTO ? 0 : 4}
       className={classnames(

--- a/ui/components/component-library/button-base/button-base.test.js
+++ b/ui/components/component-library/button-base/button-base.test.js
@@ -24,11 +24,17 @@ describe('ButtonBase', () => {
     expect(anchor).toBe(1);
   });
 
-  it('should render anchor element correctly by href only being passed', () => {
+  it('should render anchor element correctly by href only being passed and href exists', () => {
     const { getByTestId, container } = render(
-      <ButtonBase href="#" data-testid="button-base" />,
+      <ButtonBase href="https://www.test.com/" data-testid="button-base">
+        Button Base
+      </ButtonBase>,
     );
     expect(getByTestId('button-base')).toHaveClass('mm-button');
+    expect(getByTestId('button-base')).toHaveAttribute(
+      'href',
+      'https://www.test.com/',
+    );
     const anchor = container.getElementsByTagName('a').length;
     expect(anchor).toBe(1);
   });


### PR DESCRIPTION
## Explanation

Fixes #16620 
href prop was being used to change the root element but wasn't continued to be passed down. 

## Screenshots/Screencaps

### Before

https://www.loom.com/share/fce9e713cfb5456aa80e6a286e145f8b


### After

https://www.loom.com/share/44957e38da4c42b3a9975fac4342c8ef

## Manual Testing Steps

<!--
How should reviewers and QA manually test your changes? For instance:

- Go to this screen
- Do this
- Then do this
-->

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [x] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [x] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
