### PR TITLE
Add .vscode settings to the repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,6 @@ package
 
 # IDEs
 .idea
-.vscode
 .sublime-project
 
 *.bak

--- a/.prettierignore
+++ b/.prettierignore
@@ -8,7 +8,6 @@ jest-coverage/
 storybook-build/
 app/vendor/**
 .nyc_output/**
-.vscode/**
 test/e2e/send-eth-with-private-key-test/**
 *.scss
 development/chromereload.js

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+  "recommendations": [
+    "rvest.vs-code-prettier-eslint"
+  ]
+}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,5 +1,3 @@
 {
-  "recommendations": [
-    "rvest.vs-code-prettier-eslint"
-  ]
+  "recommendations": ["rvest.vs-code-prettier-eslint"]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+  "editor.defaultFormatter": "rvest.vs-code-prettier-eslint",
+  "editor.tabSize": 2,
+  "files.trimTrailingWhitespace": true,
+  "javascript.preferences.importModuleSpecifier": "relative"
+}

--- a/development/build/scripts.js
+++ b/development/build/scripts.js
@@ -894,6 +894,16 @@ function setupBundlerDefaults(
     fullPaths: isDevBuild(buildTarget) || isTestBuild(buildTarget),
     // For sourcemaps
     debug: true,
+    /**
+     * @see {@link https://github.com/browserify/browserify#browserifyfiles--opts}
+     * `opts.paths` is an array of directories that browserify searches when looking for modules which
+     * are not referenced using relative path. Can be absolute or relative to `basedir`. Equivalent of
+     * setting `NODE_PATH` environmental variable when calling `browserify` command.
+     *
+     * In the case of MetaMask, this allows imports like `a/b/c` instead of `../../../../a/b/c`
+     * This is important because VSCode autocomplete import will always suggest the path relative to the root package.json
+     */
+    paths: ['.'],
   });
 
   // Ensure react-devtools is only included in dev builds

--- a/development/build/scripts.js
+++ b/development/build/scripts.js
@@ -894,16 +894,6 @@ function setupBundlerDefaults(
     fullPaths: isDevBuild(buildTarget) || isTestBuild(buildTarget),
     // For sourcemaps
     debug: true,
-    /**
-     * @see {@link https://github.com/browserify/browserify#browserifyfiles--opts}
-     * `opts.paths` is an array of directories that browserify searches when looking for modules which
-     * are not referenced using relative path. Can be absolute or relative to `basedir`. Equivalent of
-     * setting `NODE_PATH` environmental variable when calling `browserify` command.
-     *
-     * In the case of MetaMask, this allows imports like `a/b/c` instead of `../../../../a/b/c`
-     * This is important because VSCode autocomplete import will always suggest the path relative to the root package.json
-     */
-    paths: ['.'],
   });
 
   // Ensure react-devtools is only included in dev builds


### PR DESCRIPTION
Currently in metamask-extension, we often have to write our imports like `import { x } from '../../../../a/b/c'`

This PR allows us to write `import { x } from 'a/b/c'` instead.  This is important because VSCode autocomplete import will always suggest this shorter form, with the path relative to the root package.json.

Documentation on this browserify option can be found at https://github.com/browserify/browserify#browserifyfiles--opts

> `opts.paths` is an array of directories that browserify searches when looking for modules which are not referenced using relative path. Can be absolute or relative to `basedir`. Equivalent of setting `NODE_PATH` environmental variable when calling `browserify` command.