### PR TITLE
Allow transactions with gas price or priority fee 0

### DIFF
--- a/ui/components/app/advanced-gas-fee-popover/advanced-gas-fee-inputs/priority-fee-input/priority-fee-input.js
+++ b/ui/components/app/advanced-gas-fee-popover/advanced-gas-fee-inputs/priority-fee-input/priority-fee-input.js
@@ -25,7 +25,6 @@ const validatePriorityFee = (value, gasFeeEstimates) => {
     return 'editGasMaxPriorityFeeBelowMinimumV2';
   }
   if (
-    Number(value) !== 0 &&
     gasFeeEstimates?.low &&
     bnLessThan(value, gasFeeEstimates.low.suggestedMaxPriorityFeePerGas)
   ) {

--- a/ui/components/app/advanced-gas-fee-popover/advanced-gas-fee-inputs/priority-fee-input/priority-fee-input.js
+++ b/ui/components/app/advanced-gas-fee-popover/advanced-gas-fee-inputs/priority-fee-input/priority-fee-input.js
@@ -25,7 +25,7 @@ const validatePriorityFee = (value, gasFeeEstimates) => {
     return 'editGasMaxPriorityFeeBelowMinimumV2';
   }
   if (
-    value !== 0 &&
+    Number(value) !== 0 &&
     gasFeeEstimates?.low &&
     bnLessThan(value, gasFeeEstimates.low.suggestedMaxPriorityFeePerGas)
   ) {

--- a/ui/components/app/advanced-gas-fee-popover/advanced-gas-fee-inputs/priority-fee-input/priority-fee-input.js
+++ b/ui/components/app/advanced-gas-fee-popover/advanced-gas-fee-inputs/priority-fee-input/priority-fee-input.js
@@ -21,10 +21,11 @@ import { useAdvancedGasFeePopoverContext } from '../../context';
 import AdvancedGasFeeInputSubtext from '../../advanced-gas-fee-input-subtext';
 
 const validatePriorityFee = (value, gasFeeEstimates) => {
-  if (value <= 0) {
+  if (value < 0) {
     return 'editGasMaxPriorityFeeBelowMinimumV2';
   }
   if (
+    value !== 0 &&
     gasFeeEstimates?.low &&
     bnLessThan(value, gasFeeEstimates.low.suggestedMaxPriorityFeePerGas)
   ) {

--- a/ui/components/app/advanced-gas-fee-popover/advanced-gas-fee-inputs/priority-fee-input/priority-fee-input.test.js
+++ b/ui/components/app/advanced-gas-fee-popover/advanced-gas-fee-inputs/priority-fee-input/priority-fee-input.test.js
@@ -111,7 +111,7 @@ describe('PriorityfeeInput', () => {
     expect(screen.queryByText('2 - 125 GWEI')).toBeInTheDocument();
   });
 
-  it('should show error if value entered is 0', () => {
+  it('should not show error if value entered is 0', () => {
     render({
       txParams: {
         maxPriorityFeePerGas: '0x174876E800',
@@ -125,6 +125,6 @@ describe('PriorityfeeInput', () => {
     });
     expect(
       screen.queryByText('Priority fee must be greater than 0.'),
-    ).toBeInTheDocument();
+    ).not.toBeInTheDocument();
   });
 });

--- a/ui/components/app/advanced-gas-fee-popover/advanced-gas-fee-inputs/priority-fee-input/priority-fee-input.test.js
+++ b/ui/components/app/advanced-gas-fee-popover/advanced-gas-fee-inputs/priority-fee-input/priority-fee-input.test.js
@@ -127,4 +127,15 @@ describe('PriorityfeeInput', () => {
       screen.queryByText('Priority fee must be greater than 0.'),
     ).not.toBeInTheDocument();
   });
+
+  it('should not show the error if priority fee is 0', () => {
+    render({
+      txParams: {
+        maxPriorityFeePerGas: '0x0',
+      },
+    });
+    expect(
+      screen.queryByText('Priority fee must be greater than 0.'),
+    ).not.toBeInTheDocument();
+  });
 });

--- a/ui/components/app/advanced-gas-fee-popover/advanced-gas-fee-popover.test.js
+++ b/ui/components/app/advanced-gas-fee-popover/advanced-gas-fee-popover.test.js
@@ -63,12 +63,12 @@ describe('AdvancedGasFeePopover', () => {
     expect(screen.queryByRole('button', { name: 'Save' })).not.toBeDisabled();
   });
 
-  it('should disable save button if priority fee 0 is entered', () => {
+  it('should enable save button if priority fee 0 is entered', () => {
     render();
     fireEvent.change(document.getElementsByTagName('input')[1], {
       target: { value: 0 },
     });
-    expect(screen.queryByRole('button', { name: 'Save' })).toBeDisabled();
+    expect(screen.queryByRole('button', { name: 'Save' })).toBeEnabled();
   });
 
   it('should disable save button if priority fee entered is greater than base fee', () => {

--- a/ui/hooks/gasFeeInput/useGasFeeErrors.js
+++ b/ui/hooks/gasFeeInput/useGasFeeErrors.js
@@ -11,11 +11,7 @@ import {
 } from '../../selectors';
 import { addHexes } from '../../helpers/utils/conversions.util';
 import { isLegacyTransaction } from '../../helpers/utils/transactions.util';
-import {
-  bnGreaterThan,
-  bnLessThan,
-  bnLessThanEqualTo,
-} from '../../helpers/utils/util';
+import { bnGreaterThan, bnLessThan } from '../../helpers/utils/util';
 import { GAS_FORM_ERRORS } from '../../helpers/constants/gas';
 
 const HIGH_FEE_WARNING_MULTIPLIER = 1.5;
@@ -36,7 +32,7 @@ const validateMaxPriorityFee = (maxPriorityFeePerGas, supportsEIP1559) => {
   if (!supportsEIP1559) {
     return undefined;
   }
-  if (bnLessThanEqualTo(maxPriorityFeePerGas, 0)) {
+  if (bnLessThan(maxPriorityFeePerGas, 0)) {
     return GAS_FORM_ERRORS.MAX_PRIORITY_FEE_BELOW_MINIMUM;
   }
   return undefined;
@@ -68,7 +64,7 @@ const validateGasPrice = (
   }
   if (
     (!supportsEIP1559 || transaction?.txParams?.gasPrice) &&
-    bnLessThanEqualTo(gasPrice, 0)
+    bnLessThan(gasPrice, 0)
   ) {
     return GAS_FORM_ERRORS.GAS_PRICE_TOO_LOW;
   }
@@ -86,6 +82,7 @@ const getMaxPriorityFeeWarning = (
     return undefined;
   }
   if (
+    maxPriorityFeePerGas !== 0 &&
     bnLessThan(
       maxPriorityFeePerGas,
       gasFeeEstimates?.low?.suggestedMaxPriorityFeePerGas,

--- a/ui/hooks/gasFeeInput/useGasFeeErrors.js
+++ b/ui/hooks/gasFeeInput/useGasFeeErrors.js
@@ -82,7 +82,7 @@ const getMaxPriorityFeeWarning = (
     return undefined;
   }
   if (
-    maxPriorityFeePerGas !== 0 &&
+    Number(maxPriorityFeePerGas) !== 0 &&
     bnLessThan(
       maxPriorityFeePerGas,
       gasFeeEstimates?.low?.suggestedMaxPriorityFeePerGas,

--- a/ui/hooks/gasFeeInput/useGasFeeErrors.js
+++ b/ui/hooks/gasFeeInput/useGasFeeErrors.js
@@ -82,7 +82,6 @@ const getMaxPriorityFeeWarning = (
     return undefined;
   }
   if (
-    Number(maxPriorityFeePerGas) !== 0 &&
     bnLessThan(
       maxPriorityFeePerGas,
       gasFeeEstimates?.low?.suggestedMaxPriorityFeePerGas,

--- a/ui/hooks/gasFeeInput/useGasFeeErrors.test.js
+++ b/ui/hooks/gasFeeInput/useGasFeeErrors.test.js
@@ -124,12 +124,14 @@ describe('useGasFeeErrors', () => {
         );
         expect(result.current.hasGasErrors).toBe(true);
       });
-      it('returns MAX_FEE_IMBALANCE error if maxPriorityFeePerGas is 0', () => {
+      it('does not return MAX_FEE_IMBALANCE error if maxPriorityFeePerGas is 0', () => {
         const { result } = renderUseGasFeeErrorsHook({
           maxFeePerGas: '1',
           maxPriorityFeePerGas: '0',
         });
-        expect(result.current.gasErrors.maxFee).toBeDefined();
+        expect(result.current.gasErrors.maxFee).not.toBe(
+          GAS_FORM_ERRORS.MAX_FEE_IMBALANCE,
+        );
       });
     });
     describe('Legacy estimates', () => {

--- a/ui/hooks/gasFeeInput/useGasFeeErrors.test.js
+++ b/ui/hooks/gasFeeInput/useGasFeeErrors.test.js
@@ -80,14 +80,14 @@ describe('useGasFeeErrors', () => {
         expect(result.current.gasErrors.maxPriorityFee).toBeUndefined();
         expect(result.current.hasGasErrors).toBe(false);
       });
-      it('return maxPriorityFeeError if maxPriorityFee is 0', () => {
+      it('does not return maxPriorityFeeError if maxPriorityFee is 0', () => {
         const { result } = renderUseGasFeeErrorsHook({
           maxPriorityFeePerGas: '0',
         });
-        expect(result.current.gasErrors.maxPriorityFee).toBe(
+        expect(result.current.gasErrors.maxPriorityFee).not.toBe(
           GAS_FORM_ERRORS.MAX_PRIORITY_FEE_BELOW_MINIMUM,
         );
-        expect(result.current.hasGasErrors).toBe(true);
+        expect(result.current.hasGasErrors).toBe(false);
       });
     });
     describe('Legacy estimates', () => {
@@ -124,12 +124,12 @@ describe('useGasFeeErrors', () => {
         );
         expect(result.current.hasGasErrors).toBe(true);
       });
-      it('does not return MAX_FEE_IMBALANCE error if maxPriorityFeePerGas is 0', () => {
+      it('returns MAX_FEE_IMBALANCE error if maxPriorityFeePerGas is 0', () => {
         const { result } = renderUseGasFeeErrorsHook({
           maxFeePerGas: '1',
           maxPriorityFeePerGas: '0',
         });
-        expect(result.current.gasErrors.maxFee).toBeUndefined();
+        expect(result.current.gasErrors.maxFee).toBeDefined();
       });
     });
     describe('Legacy estimates', () => {
@@ -163,15 +163,15 @@ describe('useGasFeeErrors', () => {
       beforeEach(() => {
         configureLegacy();
       });
-      it('returns gasPriceError if gasPrice is 0', () => {
+      it('does not return gasPriceError if gasPrice is 0', () => {
         const { result } = renderUseGasFeeErrorsHook({
           gasPrice: '0',
           ...LEGACY_GAS_ESTIMATE_RETURN_VALUE,
         });
-        expect(result.current.gasErrors.gasPrice).toBe(
+        expect(result.current.gasErrors.gasPrice).not.toBe(
           GAS_FORM_ERRORS.GAS_PRICE_TOO_LOW,
         );
-        expect(result.current.hasGasErrors).toBe(true);
+        expect(result.current.hasGasErrors).toBe(false);
       });
       it('does not return gasPriceError if gasPrice is > 0', () => {
         const { result } = renderUseGasFeeErrorsHook(


### PR DESCRIPTION
## Explanation
This allows users submitting the transaction with `gas price 0` or `priority fee 0`.

* Fixes #16442 
<!--
Thanks for the pull request. Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues, Slack conversations, Zendesk issues, user stories, etc. reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

## Screenshots/Screencaps

<!-- If you're making a change to the UI, make sure to capture a screenshot or a short video showing off your work! -->

### Before

https://user-images.githubusercontent.com/92310504/203506740-5861317b-a07f-4bb8-be2c-7dfe598f047b.mov


<!-- How did the UI you changed look before your changes? Drag your file(s) below this line: -->

### After


https://user-images.githubusercontent.com/92310504/203796360-ded61910-d715-4fc7-bca3-7f571dec6dbf.mov




<!-- How does it look now? Drag your file(s) below this line: -->

## Manual Testing Steps
`1st case:`
1. Send
2. Choose or enter an address
3. Enter or not some amount
4. Next
5. Edit (the lower one - within the transaction)
6. Advanced options
7. Set `Max priority fee` to 0

`2nd case`:
1. Settings
2. Experimental
3. Enable enhanced gas fee UI
4. Send
5. Choose or enter an address
6. Enter or not some amount
7. Next
8. Edit gas fee (`Low`, `Market`, `Aggressive`, `Advanced`)
9. Advanced
10. Set `Priority fee` to 0

`3rd case`:
1. Go to test dapp
2. Send legacy transaction
3. Edit (the lower one - within the transaction)
4. Edit suggested gas fee
5. Set `Gas price` to 0

<!--
How should reviewers and QA manually test your changes? For instance:

- Go to this screen
- Do this
- Then do this
-->