### PR TITLE
[e2e] [MV3] Mitigate completely flaky test Deletes custom RPC

### DIFF
--- a/test/e2e/tests/custom-rpc-history.spec.js
+++ b/test/e2e/tests/custom-rpc-history.spec.js
@@ -293,18 +293,13 @@ describe('Stores custom RPC history', function () {
         await driver.clickElement('.btn-danger');
 
         // wait for confirm delete modal to be visible
-        const confirmDeleteModal = await driver.findVisibleElement(
-          'span .modal',
-        );
+        await driver.findVisibleElement('span .modal');
 
         await driver.clickElement(
           '.button.btn-danger-primary.modal-container__footer-button',
         );
 
-        if (await driver.isElementPresent('span .modal')) {
-          // wait for confirm delete modal to be removed from DOM.
-          await confirmDeleteModal.waitForElementState('hidden');
-        }
+        await driver.waitForElementNotPresent('span .modal');
 
         const newNetworkListItems = await driver.findElements(
           '.networks-tab__networks-list-name',


### PR DESCRIPTION
## Explanation
The `Deletes a custom RPC` e2e test case is still occasionally flaky, specially in slow environments like MV3, where we can see it fail more often. With this PR we mitigate completely the flaky-ness behaviour by making use of the new function introduced in a [previous PR ](https://github.com/MetaMask/metamask-extension/commit/ff25d44d984362179f597ce839a2a97f37ded0d7) for waiting until an element disappears.

## Screenshots/Screencaps

<!-- If you're making a change to the UI, make sure to capture a screenshot or a short video showing off your work! -->

### Before

![image](https://user-images.githubusercontent.com/54408225/203570893-85680bca-2772-4204-b7e4-1bf11acf33bb.png)


### After

![image](https://user-images.githubusercontent.com/54408225/203570963-ef93a0ef-4b12-493d-bb66-17329f20dd6c.png)


## Manual Testing Steps
On [circle ci](https://circleci.com/gh/MetaMask/metamask-extension/819019), check that in the Artifacts section there is no error related to the Deletes custom RPC.

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
