### PR TITLE
Resetting spending cap value to empty when a token allowance request is rejected.

### DIFF
--- a/ui/pages/token-allowance/token-allowance.js
+++ b/ui/pages/token-allowance/token-allowance.js
@@ -44,6 +44,7 @@ import CustomSpendingCap from '../../components/app/custom-spending-cap/custom-s
 import Dialog from '../../components/ui/dialog';
 import { useGasFeeContext } from '../../contexts/gasFee';
 import { getCustomTxParamsData } from '../confirm-approve/confirm-approve.util';
+import { setCustomTokenAmount } from '../../ducks/app/app';
 
 export default function TokenAllowance({
   origin,
@@ -131,6 +132,7 @@ export default function TokenAllowance({
 
   const handleReject = () => {
     dispatch(updateCustomNonce(''));
+    dispatch(setCustomTokenAmount(''));
 
     dispatch(cancelTx(fullTxData)).then(() => {
       dispatch(clearConfirmTransaction());


### PR DESCRIPTION
Fix #16429 
## Explanation
The custom spending cap for the first token allowance request was getting carryover to the next one when the first one is rejected in cases where we had multiple transaction allowance requests.

Solution: We need to rest the customTokenamount to empty when the token allowance request is rejected.
<!--
Thanks for the pull request. Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues, Slack conversations, Zendesk issues, user stories, etc. reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

## Screenshots/Screencaps

<!-- If you're making a change to the UI, make sure to capture a screenshot or a short video showing off your work! -->

### Before

<!-- How did the UI you changed look before your changes? Drag your file(s) below this line: -->

### After

<!-- How does it look now? Drag your file(s) below this line: -->

## Manual Testing Steps

1. Go to https://etherscan.io/token/0x6b175474e89094c44da98b954eedeac495271d0f#writeContract
2. Connect your wallet
3. Under approve, input any address and value
4. Click on write
5. On the MetaMask popup, click on Use default or input a number in the spending cap field
6. Go back to the etherscan site and click on write again to create a new token allowance request
7. See the popup for the first request open up on MetaMask and click on Reject
8. The next token allowance request should have a 0 sending cap set by default.

<!--
How should reviewers and QA manually test your changes? For instance:

- Go to this screen
- Do this
- Then do this
-->

## Pre-merge author checklist

- [ ] I've clearly explained:
  - [ ] What problem this PR is solving
  - [ ] How this problem was solved
  - [ ] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
