### PR TITLE
Update codeowners to reflect importance of review

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,31 @@
 # Lines starting with '#' are comments.
 # Each line is a file pattern followed by one or more owners.
+# Owners bear a responsibility to the organization and the users of this
+# application. You may be a CODEOWNER AND a repository admin, granting
+# you the ability to merge pull requests that have not yet received the
+# requisite reviews as outlined in this file. Do not force merge any PR
+# without confidence that it follows all policies or without full 
+# understanding of the impact of those changes on build, release and 
+# publishing outcomes.
 
 *                                    @MetaMask/extension-devs
-.circleci/                           @MetaMask/extension-devs @kumavis
 development/                         @MetaMask/extension-devs @kumavis
 lavamoat/                            @MetaMask/supply-chain
+
+# The .circleci/ folder instructs Circle CI on the process by which it
+# should test, build and publish releases of our application. Due to the
+# impact that changes to the files contained within this folder may have
+# on our releases, only those with the knowledge and responsibility to 
+# publish libraries under the MetaMask name may approve those changes.
+# Note to reviewers: We employ the use of CircleCI "Orbs", which are
+# remotely hosted sections of CircleCI configuration and scripts, to
+# empower our CI steps. ANY addition of orbs to our CircleCI config
+# should be brought to the attention of engineering leadership for
+# discussion
+.circleci/                           @MetaMask/library-admins @kumavis
+# The CODEOWNERS file constitutes an agreement amongst organization
+# admins and maintainers to restrict approval capabilities to a subset
+# of contributors. Modifications to this file result in a modification of
+# that agreement and can only be approved by those with the knowledge
+# and responsibility to publish libraries under the MetaMask name.
+.github/CODEOWNERS                   @MetaMask/library-admins @kumavis

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,12 +1,11 @@
 # Lines starting with '#' are comments.
 # Each line is a file pattern followed by one or more owners.
 # Owners bear a responsibility to the organization and the users of this
-# application. You may be a CODEOWNER AND a repository admin, granting
-# you the ability to merge pull requests that have not yet received the
-# requisite reviews as outlined in this file. Do not force merge any PR
-# without confidence that it follows all policies or without full 
-# understanding of the impact of those changes on build, release and 
-# publishing outcomes.
+# application. Repository administrators have the ability to merge pull 
+# requests that have not yet received the requisite reviews as outlined 
+# in this file. Do not force merge any PR without confidence that it 
+# follows all policies or without full understanding of the impact of 
+# those changes on build, release and publishing outcomes.
 
 *                                    @MetaMask/extension-devs
 development/                         @MetaMask/extension-devs @kumavis


### PR DESCRIPTION
## Explanation
We will be adding the capability for CircleCI to use third party orbs. Orbs are remotely hosted sections of CircleCI config, and scripts, that act in concert to perform tasks within the parent configuration file. Once we enable this feature, we must keep a close accounting of how our circleci config changes to ensure that no unauthorized instances of orbs are added to our config. To help protect us I have modified the CODEOWNERS to further restrict reviews on PRs that touch either CODEOWNERS or .circleci/ folder. 

In addition to the functional changes for reviewers, comments have been added to highlight the above and stress the importance of thorough reviews to the changes in those files. 

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added
