### PR TITLE
`TextFieldBase` house keeping 🧹 

### DIFF
--- a/ui/components/component-library/icon/icon.stories.js
+++ b/ui/components/component-library/icon/icon.stories.js
@@ -179,7 +179,7 @@ export const DefaultStory = (args) => {
                   backgroundColor={COLORS.BACKGROUND_ALTERNATIVE}
                   rightAccessory={
                     <ButtonIcon
-                      icon={ICON_NAMES.COPY_FILLED}
+                      iconName={ICON_NAMES.COPY_FILLED}
                       size={SIZES.SM}
                       color={COLORS.ICON_ALTERNATIVE}
                       ariaLabel="Copy to clipboard"

--- a/ui/components/component-library/text-field-base/README.mdx
+++ b/ui/components/component-library/text-field-base/README.mdx
@@ -35,8 +35,8 @@ Defaults to `md`
 </Canvas>
 
 ```jsx
-import { TextFieldBase } from '../../ui/components/component-library';
 import { SIZES } from '../../../helpers/constants/design-system';
+import { TextFieldBase } from '../../component-library';
 
 <TextFieldBase size={SIZES.SM} />
 <TextFieldBase size={SIZES.MD} />
@@ -60,7 +60,7 @@ Defaults to `text`.
 </Canvas>
 
 ```jsx
-import { TextFieldBase } from '../../ui/components/component-library';
+import { TextFieldBase } from '../../component-library';
 
 <TextFieldBase type="text" /> // (Default)
 <TextFieldBase type="number" />
@@ -76,7 +76,7 @@ Use the `truncate` prop to truncate the text of the the `TextFieldBase`. Default
 </Canvas>
 
 ```jsx
-import { TextFieldBase } from '../../ui/components/component-library';
+import { TextFieldBase } from '../../component-library';
 
 <TextFieldBase truncate />; // truncate is set to `true` by default
 <TextFieldBase truncate={false} />;
@@ -92,9 +92,7 @@ Use the `leftAccessory` and `rightAccessory` props to add components such as ico
 
 ```jsx
 import { COLORS, SIZES, DISPLAY } from '../../../helpers/constants/design-system';
-import { Icon, ICON_NAMES } from '../../ui/components/component-library';
-
-import { TextFieldBase } from '../../ui/components/component-library';
+import { ButtonIcon, Icon, ICON_NAMES, TextFieldBase } from '../../component-library';
 
 <TextFieldBase
   placeholder="Search"
@@ -109,18 +107,11 @@ import { TextFieldBase } from '../../ui/components/component-library';
 <TextFieldBase
   placeholder="Public address (0x), or ENS"
   rightAccessory={
-    // TODO: replace with ButtonIcon
-    <Box
-      as="button"
-      display={DISPLAY.FLEX}
-      style={{ padding: 0 }}
-      backgroundColor={COLORS.TRANSPARENT}
-    >
-      <Icon
-        color={COLORS.PRIMARY_DEFAULT}
-        name={ICON_NAMES.SCAN_BARCODE_FILLED}
-      />
-    </Box>
+    <ButtonIcon
+      name={ICON_NAMES.SCAN_BARCODE_FILLED}
+      ariaLabel="Scan QR code"
+      iconProps={{ color: COLORS.PRIMARY_DEFAULT }}
+    />
   }
 />
 
@@ -156,7 +147,7 @@ Use the `inputRef` prop to access the ref of the `<input />` html element of `Te
 </Canvas>
 
 ```jsx
-import { TextFieldBase } from '../../ui/components/component-library';
+import { Button, TextFieldBase } from '../../component-library';
 
 const inputRef = useRef(null);
 const [value, setValue] = useState('');
@@ -172,20 +163,9 @@ const handleOnChange = (e) => {
   value={value}
   onChange={handleOnChange}
 />
-// TODO: replace with Button component
-<Box
-  as="button"
-  backgroundColor={COLORS.BACKGROUND_ALTERNATIVE}
-  color={COLORS.TEXT_DEFAULT}
-  borderColor={COLORS.BORDER_DEFAULT}
-  borderRadius={SIZES.XL}
-  marginLeft={1}
-  paddingLeft={2}
-  paddingRight={2}
-  onClick={handleOnClick}
->
+<Button marginLeft={1} onClick={handleOnClick}>
   Edit
-</Box>
+</Button>
 ```
 
 ### Input Component
@@ -227,7 +207,7 @@ To function fully the custom component should accept the following props:
 </Canvas>
 
 ```jsx
-import { TextFieldBase, Icon, ICON_NAMES } from '../../ui/component-library';
+import { TextFieldBase, Icon, ICON_NAMES } from '../../component-library';
 
 // should map the props to the custom input component
 const CustomInputComponent = () => <div>{/* Custom input component */}</div>;
@@ -252,7 +232,7 @@ Use the `autoComplete` prop to set the autocomplete html attribute. It allows th
 </Canvas>
 
 ```jsx
-import { TextFieldBase } from '../../ui/components/component-library';
+import { TextFieldBase } from '../../component-library';
 
 <TextFieldBase type="password" autoComplete />;
 ```
@@ -266,7 +246,7 @@ Use the `autoFocus` prop to focus the `TextFieldBase` during the first mount
 </Canvas>
 
 ```jsx
-import { TextFieldBase } from '../../ui/components/component-library';
+import { TextFieldBase } from '../../component-library';
 
 <TextFieldBase autoFocus />;
 ```
@@ -280,7 +260,7 @@ Use the `defaultValue` prop to set the default value of the `TextFieldBase`
 </Canvas>
 
 ```jsx
-import { TextFieldBase } from '../../ui/components/component-library';
+import { TextFieldBase } from '../../component-library';
 
 <TextFieldBase defaultValue="default value" />;
 ```
@@ -294,7 +274,7 @@ Use the `disabled` prop to set the disabled state of the `TextFieldBase`
 </Canvas>
 
 ```jsx
-import { TextFieldBase } from '../../ui/components/component-library';
+import { TextFieldBase } from '../../component-library';
 
 <TextFieldBase disabled />;
 ```
@@ -308,7 +288,7 @@ Use the `error` prop to set the error state of the `TextFieldBase`
 </Canvas>
 
 ```jsx
-import { TextFieldBase } from '../../ui/components/component-library';
+import { TextFieldBase } from '../../component-library';
 
 <TextFieldBase error />;
 ```
@@ -322,7 +302,7 @@ Use the `maxLength` prop to set the maximum allowed input characters for the `Te
 </Canvas>
 
 ```jsx
-import { TextFieldBase } from '../../ui/components/component-library';
+import { TextFieldBase } from '../../component-library';
 
 <TextFieldBase maxLength={10} />;
 ```
@@ -336,7 +316,7 @@ Use the `readOnly` prop to set the `TextFieldBase` to read only. When `readOnly`
 </Canvas>
 
 ```jsx
-import { TextFieldBase } from '../../ui/components/component-library';
+import { TextFieldBase } from '../../component-library';
 
 <TextFieldBase readOnly />;
 ```
@@ -350,7 +330,7 @@ Use the `required` prop to set the `TextFieldBase` to required. Currently there 
 </Canvas>
 
 ```jsx
-import { TextFieldBase } from '../../ui/components/component-library';
+import { TextFieldBase } from '../../component-library';
 
 // Currently no visual difference
 <TextFieldBase required />;

--- a/ui/components/component-library/text-field-base/README.mdx
+++ b/ui/components/component-library/text-field-base/README.mdx
@@ -108,7 +108,7 @@ import { ButtonIcon, Icon, ICON_NAMES, TextFieldBase } from '../../component-lib
   placeholder="Public address (0x), or ENS"
   rightAccessory={
     <ButtonIcon
-      name={ICON_NAMES.SCAN_BARCODE_FILLED}
+      iconName={ICON_NAMES.SCAN_BARCODE_FILLED}
       ariaLabel="Scan QR code"
       iconProps={{ color: COLORS.PRIMARY_DEFAULT }}
     />

--- a/ui/components/component-library/text-field-base/__snapshots__/text-field-base.test.js.snap
+++ b/ui/components/component-library/text-field-base/__snapshots__/text-field-base.test.js.snap
@@ -7,7 +7,7 @@ exports[`TextFieldBase should render correctly 1`] = `
   >
     <input
       autocomplete="off"
-      class="box text mm-text-field-base__input text--body-md text--color-text-default box--padding-right-4 box--padding-left-4 box--flex-direction-row box--background-color-transparent"
+      class="box mm-text mm-text-field-base__input mm-text--body-md mm-text--color-text-default box--padding-right-4 box--padding-left-4 box--flex-direction-row box--background-color-transparent"
       focused="false"
       type="text"
       value=""

--- a/ui/components/component-library/text-field-base/__snapshots__/text-field-base.test.js.snap
+++ b/ui/components/component-library/text-field-base/__snapshots__/text-field-base.test.js.snap
@@ -1,0 +1,17 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`TextFieldBase should render correctly 1`] = `
+<div>
+  <div
+    class="box mm-text-field-base mm-text-field-base--size-md mm-text-field-base--truncate box--display-inline-flex box--flex-direction-row box--align-items-center box--background-color-background-default box--rounded-sm box--border-width-1 box--border-style-solid"
+  >
+    <input
+      autocomplete="off"
+      class="box text mm-text-field-base__input text--body-md text--color-text-default box--padding-right-4 box--padding-left-4 box--flex-direction-row box--background-color-transparent"
+      focused="false"
+      type="text"
+      value=""
+    />
+  </div>
+</div>
+`;

--- a/ui/components/component-library/text-field-base/text-field-base.js
+++ b/ui/components/component-library/text-field-base/text-field-base.js
@@ -67,7 +67,7 @@ export const TextFieldBase = ({
       setFocused(true);
     }
 
-    if (onClick) {
+    if (onClick && !disabled) {
       onClick(event);
     }
   };
@@ -97,7 +97,7 @@ export const TextFieldBase = ({
         'mm-text-field-base',
         `mm-text-field-base--size-${size}`,
         {
-          'mm-text-field-base--focused': focused && !disabled && !readOnly,
+          'mm-text-field-base--focused': focused && !disabled,
           'mm-text-field-base--error': error,
           'mm-text-field-base--disabled': disabled,
           'mm-text-field-base--truncate': truncate,

--- a/ui/components/component-library/text-field-base/text-field-base.stories.js
+++ b/ui/components/component-library/text-field-base/text-field-base.stories.js
@@ -1,5 +1,6 @@
 import React, { useState, useRef } from 'react';
 import { useArgs } from '@storybook/client-api';
+import PropTypes from 'prop-types';
 
 import {
   SIZES,
@@ -241,7 +242,6 @@ export const LeftAccessoryRightAccessory = (args) => {
         value={value.search}
         name="search"
         onChange={handleOnChange}
-        showClear
         leftAccessory={
           <Icon
             color={COLORS.ICON_ALTERNATIVE}
@@ -352,46 +352,52 @@ export const InputRef = (args) => {
   );
 };
 
-const CustomInputComponent = ({
-  as,
-  autoComplete,
-  autoFocus,
-  defaultValue,
-  disabled,
-  focused,
-  id,
-  maxLength,
-  name,
-  onBlur,
-  onChange,
-  onFocus,
-  padding,
-  paddingLeft,
-  paddingRight,
-  placeholder,
-  readOnly,
-  ref,
-  required,
-  value,
-  variant,
-  type,
-  className,
-  'aria-invalid': ariaInvalid,
-  ...props
-}) => {
-  return (
+const CustomInputComponent = React.forwardRef(
+  (
+    {
+      as,
+      autoComplete,
+      autoFocus,
+      defaultValue,
+      disabled,
+      focused,
+      id,
+      inputProps,
+      inputRef,
+      maxLength,
+      name,
+      onBlur,
+      onChange,
+      onFocus,
+      padding,
+      paddingLeft,
+      paddingRight,
+      placeholder,
+      readOnly,
+      required,
+      value,
+      variant,
+      type,
+      className,
+      'aria-invalid': ariaInvalid,
+      ...props
+    },
+    ref,
+  ) => (
     <Box
       display={DISPLAY.FLEX}
       flexDirection={FLEX_DIRECTION.COLUMN}
+      ref={ref}
       {...{ padding, paddingLeft, paddingRight, ...props }}
     >
       <Box display={DISPLAY.INLINE_FLEX}>
         <Text
           style={{ padding: 0 }}
           aria-invalid={ariaInvalid}
+          ref={inputRef}
           {...{
-            as,
             className,
+            as,
             autoComplete,
             autoFocus,
             defaultValue,
@@ -405,11 +411,11 @@ const CustomInputComponent = ({
             onFocus,
             placeholder,
             readOnly,
-            ref,
             required,
             value,
             variant,
             type,
+            ...inputProps,
           }}
         />
         <Text variant={TEXT.BODY_XS} color={COLORS.TEXT_ALTERNATIVE}>
@@ -418,10 +424,41 @@ const CustomInputComponent = ({
       </Box>
       <Text variant={TEXT.BODY_XS}>No conversion rate available</Text>
     </Box>
-  );
-};
+  ),
+);
 
-CustomInputComponent.propTypes = { ...TextFieldBase.propTypes };
+CustomInputComponent.propTypes = {
+  /**
+   * The custom input component should accepts all props that the
+   * InputComponent accepts in ./text-field-base.js
+   */
+  autoFocus: PropTypes.bool,
+  className: PropTypes.string,
+  defaultValue: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  disabled: PropTypes.bool,
+  id: PropTypes.string,
+  inputProps: PropTypes.object,
+  inputRef: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
+  maxLength: PropTypes.number,
+  name: PropTypes.string,
+  onBlur: PropTypes.func,
+  onChange: PropTypes.func,
+  onFocus: PropTypes.func,
+  placeholder: PropTypes.string,
+  readOnly: PropTypes.bool,
+  required: PropTypes.bool,
+  type: PropTypes.oneOf(Object.values(TEXT_FIELD_BASE_TYPES)),
+  /**
+   * Because we manipulate the type in TextFieldBase so the html element
+   * receives the correct attribute we need to change the autoComplete
+   * propType to a string
+   */
+  autoComplete: PropTypes.string,
+  /**
+   * The custom input component should also accept all the props from Box
+   */
+  ...Box.propTypes,
+};
 
 export const InputComponent = (args) => (
   <TextFieldBase
@@ -435,6 +472,8 @@ export const InputComponent = (args) => (
     }
   />
 );
+
+InputComponent.args = { autoComplete: true };
 
 export const AutoComplete = Template.bind({});
 AutoComplete.args = {

--- a/ui/components/component-library/text-field-base/text-field-base.stories.js
+++ b/ui/components/component-library/text-field-base/text-field-base.stories.js
@@ -1,4 +1,5 @@
 import React, { useState, useRef } from 'react';
+import { useArgs } from '@storybook/client-api';
 
 import {
   SIZES,
@@ -10,16 +11,22 @@ import {
 } from '../../../helpers/constants/design-system';
 import Box from '../../ui/box/box';
 
-import { Icon, ICON_NAMES } from '../icon';
-import { AvatarToken } from '../avatar-token';
-import { AvatarAccount } from '../avatar-account';
-import { Text } from '../text';
+import {
+  AvatarAccount,
+  AvatarToken,
+  Button,
+  ButtonIcon,
+  ICON_NAMES,
+  Icon,
+  Text,
+} from '..';
 
 import {
   TEXT_FIELD_BASE_SIZES,
   TEXT_FIELD_BASE_TYPES,
 } from './text-field-base.constants';
 import { TextFieldBase } from './text-field-base';
+
 import README from './README.mdx';
 
 const marginSizeControlOptions = [
@@ -144,7 +151,23 @@ export default {
   },
 };
 
-const Template = (args) => <TextFieldBase {...args} />;
+const Template = (args) => {
+  const [{ value }, updateArgs] = useArgs();
+  const handleOnChange = (e) => {
+    updateArgs({ value: e.target.value });
+  };
+  const handleOnClear = () => {
+    updateArgs({ value: '' });
+  };
+  return (
+    <TextFieldBase
+      {...args}
+      value={value}
+      onChange={handleOnChange}
+      clearButtonOnClick={handleOnClear}
+    />
+  );
+};
 
 export const DefaultStory = Template.bind({});
 DefaultStory.storyName = 'Default';
@@ -243,17 +266,11 @@ export const LeftAccessoryRightAccessory = (args) => {
         name="address"
         onChange={handleOnChange}
         rightAccessory={
-          <Box
-            as="button"
-            display={DISPLAY.FLEX}
-            style={{ padding: 0 }}
-            backgroundColor={COLORS.TRANSPARENT}
-          >
-            <Icon
-              color={COLORS.PRIMARY_DEFAULT}
-              name={ICON_NAMES.SCAN_BARCODE_FILLED}
-            />
-          </Box>
+          <ButtonIcon
+            name={ICON_NAMES.SCAN_BARCODE_FILLED}
+            ariaLabel="Scan QR code"
+            iconProps={{ color: COLORS.PRIMARY_DEFAULT }}
+          />
         }
       />
       <TextFieldBase
@@ -274,11 +291,11 @@ export const LeftAccessoryRightAccessory = (args) => {
             alignItems={ALIGN_ITEMS.CENTER}
           >
             <AvatarToken
-              tokenName="ast"
-              tokenImageUrl="./AST.png"
+              tokenName="eth"
+              tokenImageUrl="./images/eth_logo.svg"
               size={SIZES.SM}
             />
-            <Text>AST</Text>
+            <Text>ETH</Text>
             <Icon
               name={ICON_NAMES.ARROW_DOWN}
               color={COLORS.ICON_DEFAULT}
@@ -287,8 +304,12 @@ export const LeftAccessoryRightAccessory = (args) => {
           </Box>
         }
         rightAccessory={
-          <Text variant={TEXT.BODY_SM} color={COLORS.TEXT_ALTERNATIVE}>
-            = ${handleTokenPrice(value.amount, 0.11)}
+          <Text
+            variant={TEXT.BODY_SM}
+            color={COLORS.TEXT_ALTERNATIVE}
+            style={{ whiteSpace: 'nowrap' }}
+          >
+            = ${handleTokenPrice(value.amount, 1173.58)}
           </Text>
         }
       />
@@ -327,27 +348,17 @@ export const InputRef = (args) => {
     setValue(e.target.value);
   };
   return (
-    <>
+    <Box display={DISPLAY.FLEX}>
       <TextFieldBase
         {...args}
         inputRef={inputRef}
         value={value}
         onChange={handleOnChange}
       />
-      <Box
-        as="button"
-        backgroundColor={COLORS.BACKGROUND_ALTERNATIVE}
-        color={COLORS.TEXT_DEFAULT}
-        borderColor={COLORS.BORDER_DEFAULT}
-        borderRadius={SIZES.XL}
-        marginLeft={1}
-        paddingLeft={2}
-        paddingRight={2}
-        onClick={handleOnClick}
-      >
+      <Button marginLeft={1} onClick={handleOnClick}>
         Edit
-      </Box>
-    </>
+      </Button>
+    </Box>
   );
 };
 

--- a/ui/components/component-library/text-field-base/text-field-base.stories.js
+++ b/ui/components/component-library/text-field-base/text-field-base.stories.js
@@ -257,7 +257,7 @@ export const LeftAccessoryRightAccessory = (args) => {
         onChange={handleOnChange}
         rightAccessory={
           <ButtonIcon
-            name={ICON_NAMES.SCAN_BARCODE_FILLED}
+            iconName={ICON_NAMES.SCAN_BARCODE_FILLED}
             ariaLabel="Scan QR code"
             iconProps={{ color: COLORS.PRIMARY_DEFAULT }}
           />
@@ -459,6 +459,8 @@ CustomInputComponent.propTypes = {
    */
   ...Box.propTypes,
 };
+
+CustomInputComponent.displayName = 'CustomInputComponent';
 
 export const InputComponent = (args) => (
   <TextFieldBase

--- a/ui/components/component-library/text-field-base/text-field-base.stories.js
+++ b/ui/components/component-library/text-field-base/text-field-base.stories.js
@@ -156,17 +156,7 @@ const Template = (args) => {
   const handleOnChange = (e) => {
     updateArgs({ value: e.target.value });
   };
-  const handleOnClear = () => {
-    updateArgs({ value: '' });
-  };
-  return (
-    <TextFieldBase
-      {...args}
-      value={value}
-      onChange={handleOnChange}
-      clearButtonOnClick={handleOnClear}
-    />
-  );
+  return <TextFieldBase {...args} value={value} onChange={handleOnChange} />;
 };
 
 export const DefaultStory = Template.bind({});

--- a/ui/components/component-library/text-field/text-field.js
+++ b/ui/components/component-library/text-field/text-field.js
@@ -30,7 +30,7 @@ export const TextField = ({
           <ButtonIcon
             className="mm-text-field__button-clear"
             ariaLabel="Clear" // TODO: i18n
-            icon={ICON_NAMES.CLOSE_OUTLINE}
+            iconName={ICON_NAMES.CLOSE_OUTLINE}
             size={SIZES.SM}
             onClick={clearButtonOnClick}
             {...clearButtonProps}


### PR DESCRIPTION
## Explanation

Updating `TextFieldBase` to include the most up to date standards and conventions for the component-library components listed in the issue and description below

* Fixes #16184 

- [x] Has a `className` prop and the PropType descriptions are all the same
- [x] Prop table in MDX docs have the "Accepts all Box component props" description and link
- [x] We are consistent when using the same prop names like `size` and are suggesting the use of the generalized `design-system.js` constants e.g. `SIZES` as the primary option but noting the component consts in the documentation and using them for propType validation and storybook controls only
- [x] Standardize all similar prop names for images `src`
- [x] We have a story for each component prop and we use the prop name verbatim e.g. `size` prop would be `export const Size = (args) => (`
- [x] We have the accompanying documentation for each component prop and we use the prop name verbatim e.g. `size` prop would be `### Size`
- [x] Are multiple props stories allowed? e.g. `Color, Background Color And Border Color` story in `base-avatar` - [ ] yes when it makes sense to
- [x] All Base components follow the suffix convention e.g. `ButtonBase`
- [x] All Base component MDX documentation have the base component notification at the top
- [x] Add `mm-` prefix to all classNames
- [x] className is kebab case version of the component name
- [x] Spread base components props and reduce duplication of props when props aren't being changed and remain the same for both variant and base components
- [x] Add component to root `index.js` file in component-library
- [x] Add locals for any default text I18nContext as default context 
- [x] Add any "to dos" with a `// TODO:` comment so we can search for them at a later date e.g. blocking components etc
- [x] Add snapshot testing
- [x] Add pixel values to propType descriptions if we use abstracted prop types that relate to pixel values e.g. `SIZE.MD (32px)`
- [x] Each prop section in the MDX docs should have: a heading, a description, a story and an example code snipped

## Screenshots/Screencaps

### Before

https://user-images.githubusercontent.com/8112138/203655191-f7412a60-7655-4e79-9352-272b125bd312.mov

### After

https://user-images.githubusercontent.com/8112138/203655303-3b8a2cc0-f0e2-4360-af6f-8b3724eae370.mov


## Manual Testing Steps

- Go to latest build of Storybook on this PR
- Search `TextFieldBase` in the search bar
- Check stories, controls and docs

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.