### PR TITLE
`TextFieldSearch` house keeping 🧹 

### DIFF
--- a/ui/components/component-library/text-field-search/README.mdx
+++ b/ui/components/component-library/text-field-search/README.mdx
@@ -1,10 +1,12 @@
 import { Story, Canvas, ArgsTable } from '@storybook/addon-docs';
 
+import { TextFieldBase, TextField } from '..';
+
 import { TextFieldSearch } from './text-field-search';
 
 # TextFieldSearch
 
-The `TextFieldSearch` allows users to enter text to search. It wraps the `TextField` component that adds a search icon to the left of the input.
+The `TextFieldSearch` allows users to enter text to search
 
 <Canvas>
   <Story id="ui-components-component-library-text-field-search-text-field-search-stories-js--default-story" />
@@ -12,26 +14,34 @@ The `TextFieldSearch` allows users to enter text to search. It wraps the `TextFi
 
 ## Props
 
-The `TextFieldSearch` accepts all props below as well as all [Box](/docs/ui-components-ui-box-box-stories-js--default-story#props), [TextField](/docs/ui-components-component-library-text-field-text-field-stories-js--default-story#props) component props
+The `TextFieldSearch` accepts all props below as well as all [Box](/docs/ui-components-ui-box-box-stories-js--default-story#props) component props
 
 <ArgsTable of={TextFieldSearch} />
 
-### Show Clear Button
+`TextFieldSearch` accepts all [TextField](/docs/ui-components-component-library-text-field-text-field-stories-js--default-story#props)
+component props
 
-Use the `showClearButton` prop to display a clear button when `TextFieldSearch` has a value. Use the `clearButtonOnClick` prop to pass an `onClick` event handler to clear the value of the input.
+<ArgsTable of={TextField} />
 
-Defaults to `true`
+`TextFieldSearch` accepts all [TextFieldBase](/docs/ui-components-component-library-text-field-base-text-field-base-stories-js--default-story#props)
+component props
+
+<ArgsTable of={TextFieldBase} />
+
+### Clear Button On Click
+
+`TextFieldSearch` displays a clear button when text is entered into the input. Use the `clearButtonOnClick` prop to pass an `onClick` event handler to clear the value of the input. To hide the clear button, pass `false` to the `showClearButton` prop.
 
 The clear button uses [ButtonIcon](/docs/ui-components-component-library-button-icon-button-icon-stories-js--default-story) and accepts all props from that component.
 
 **NOTE: The `showClearButton` only works with a controlled input.**
 
 <Canvas>
-  <Story id="ui-components-component-library-text-field-search-text-field-search-stories-js--show-clear-button" />
+  <Story id="ui-components-component-library-text-field-search-text-field-search-stories-js--clear-button-on-click" />
 </Canvas>
 
 ```jsx
-import { TextFieldSearch } from '../../ui/component-library/text-field';
+import { TextFieldSearch } from '../../component-library';
 
 const [value, setValue] = useState('show clear');
 
@@ -67,7 +77,7 @@ import {
   BORDER_RADIUS,
 } from '../../../helpers/constants/design-system';
 
-import { TextFieldSearch } from '../../ui/component-library/text-field';
+import { TextFieldSearch } from '../../component-library';
 
 const [value, setValue] = useState('show clear');
 

--- a/ui/components/component-library/text-field-search/__snapshots__/text-field-search.test.js.snap
+++ b/ui/components/component-library/text-field-search/__snapshots__/text-field-search.test.js.snap
@@ -1,0 +1,21 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`TextFieldSearch should render correctly 1`] = `
+<div>
+  <div
+    class="box mm-text-field-base mm-text-field-base--size-md mm-text-field-base--truncate mm-text-field mm-text-field-search box--padding-left-4 box--display-inline-flex box--flex-direction-row box--align-items-center box--background-color-background-default box--rounded-sm box--border-width-1 box--border-style-solid"
+  >
+    <div
+      class="box mm-icon mm-icon--size-sm box--flex-direction-row box--color-inherit"
+      style="mask-image: url('./images/icons/icon-search-filled.svg');"
+    />
+    <input
+      autocomplete="off"
+      class="box text mm-text-field-base__input text--body-md text--color-text-default box--margin-right-6 box--padding-right-4 box--padding-left-2 box--flex-direction-row box--background-color-transparent"
+      focused="false"
+      type="search"
+      value=""
+    />
+  </div>
+</div>
+`;

--- a/ui/components/component-library/text-field-search/text-field-search.js
+++ b/ui/components/component-library/text-field-search/text-field-search.js
@@ -12,7 +12,6 @@ import { TextField } from '../text-field';
 export const TextFieldSearch = ({
   value,
   onChange,
-  showClearButton = true,
   clearButtonOnClick,
   clearButtonProps,
   className,
@@ -24,7 +23,7 @@ export const TextFieldSearch = ({
     onChange={onChange}
     type={TEXT_FIELD_BASE_TYPES.SEARCH}
     leftAccessory={<Icon name={ICON_NAMES.SEARCH_FILLED} size={SIZES.SM} />}
-    showClearButton={showClearButton}
+    showClearButton
     clearButtonOnClick={clearButtonOnClick}
     clearButtonProps={clearButtonProps}
     {...props}
@@ -41,14 +40,24 @@ TextFieldSearch.propTypes = {
    */
   onChange: TextFieldBase.propTypes.onChange,
   /**
-   * Show a clear button to clear the input
-   * Defaults to true
-   */
-  showClearButton: PropTypes.bool,
-  /**
    * The onClick handler for the clear button
+   * Required unless showClearButton is false
+   *
+   * @param {object} props - The props passed to the component.
+   * @param {string} propName - The prop name in this case 'id'.
+   * @param {string} componentName - The name of the component.
    */
-  clearButtonOnClick: PropTypes.func,
+  clearButtonOnClick: (props, propName, componentName) => {
+    if (
+      props.showClearButton &&
+      (!props[propName] || !props.clearButtonProps?.onClick)
+    ) {
+      return new Error(
+        `${propName} is required unless showClearButton is false. Warning coming from ${componentName} ui/components/component-library/text-field-search/text-field-search.js`,
+      );
+    }
+    return null;
+  },
   /**
    * The props to pass to the clear button
    */

--- a/ui/components/component-library/text-field-search/text-field-search.stories.js
+++ b/ui/components/component-library/text-field-search/text-field-search.stories.js
@@ -46,9 +46,6 @@ export default {
     onChange: {
       action: 'onChange',
     },
-    showClearButton: {
-      control: 'boolean',
-    },
     clearButtonOnClick: {
       action: 'clearButtonOnClick',
     },
@@ -167,8 +164,8 @@ export default {
     },
   },
   args: {
-    showClearButton: true,
     placeholder: 'Search',
+    value: '',
   },
 };
 
@@ -193,18 +190,16 @@ const Template = (args) => {
 export const DefaultStory = Template.bind({});
 DefaultStory.storyName = 'Default';
 
-export const ShowClearButton = Template.bind({});
+export const ClearButtonOnClick = Template.bind({});
 
-ShowClearButton.args = {
-  placeholder: 'Enter text to show clear',
-  showClearButton: true,
+ClearButtonOnClick.args = {
+  value: 'Text to clear',
 };
 
 export const ClearButtonProps = Template.bind({});
 ClearButtonProps.args = {
   value: 'clear button props',
   size: SIZES.LG,
-  showClearButton: true,
   clearButtonProps: {
     backgroundColor: COLORS.BACKGROUND_ALTERNATIVE,
     borderRadius: BORDER_RADIUS.XS,

--- a/ui/components/component-library/text-field-search/text-field-search.test.js
+++ b/ui/components/component-library/text-field-search/text-field-search.test.js
@@ -6,24 +6,38 @@ import { TextFieldSearch } from './text-field-search';
 
 describe('TextFieldSearch', () => {
   it('should render correctly', () => {
-    const { getByRole } = render(<TextFieldSearch />);
+    const { getByRole, container } = render(<TextFieldSearch />);
     expect(getByRole('searchbox')).toBeDefined();
+    expect(container).toMatchSnapshot();
   });
-  it('should render showClearButton button when showClearButton is true and value exists', async () => {
+  it('should render with a custom className', () => {
+    const fn = jest.fn();
+    const { getByTestId } = render(
+      <TextFieldSearch
+        data-testid="test-search"
+        className="test-search"
+        clearButtonOnClick={fn}
+      />,
+    );
+    expect(getByTestId('test-search')).toHaveClass('test-search');
+  });
+  it('should render showClearButton button when value exists', async () => {
+    const fn = jest.fn();
     // As showClearButton is intended to be used with a controlled input we need to use renderControlledInput
     const { user, getByRole } = renderControlledInput(TextFieldSearch, {
-      showClearButton: true,
+      clearButtonOnClick: fn,
     });
     await user.type(getByRole('searchbox'), 'test value');
     expect(getByRole('searchbox')).toHaveValue('test value');
     expect(getByRole('button', { name: /Clear/u })).toBeDefined();
   });
-  it('should still render with the rightAccessory when showClearButton is true', async () => {
+  it('should still render with the rightAccessory if it exists', async () => {
+    const fn = jest.fn();
     // As showClearButton is intended to be used with a controlled input we need to use renderControlledInput
     const { user, getByRole, getByText } = renderControlledInput(
       TextFieldSearch,
       {
-        showClearButton: true,
+        clearButtonOnClick: fn,
         rightAccessory: <div>right-accessory</div>,
       },
     );
@@ -36,7 +50,6 @@ describe('TextFieldSearch', () => {
     // As showClearButton is intended to be used with a controlled input we need to use renderControlledInput
     const fn = jest.fn();
     const { user, getByRole } = renderControlledInput(TextFieldSearch, {
-      showClearButton: true,
       clearButtonOnClick: fn,
     });
     await user.type(getByRole('searchbox'), 'test value');
@@ -47,8 +60,8 @@ describe('TextFieldSearch', () => {
     // As showClearButton is intended to be used with a controlled input we need to use renderControlledInput
     const fn = jest.fn();
     const { user, getByRole } = renderControlledInput(TextFieldSearch, {
-      showClearButton: true,
       clearButtonProps: { onClick: fn },
+      clearButtonOnClick: fn,
     });
     await user.type(getByRole('searchbox'), 'test value');
     await user.click(getByRole('button', { name: /Clear/u }));


### PR DESCRIPTION
## Explanation

Updating `TextFieldSearch` to include the most up to date standards and conventions for the component-library components listed in the issue and description below

* Fixes #16618   

- [x] Has a `className` prop and the PropType descriptions are all the same
- [x] Prop table in MDX docs have the "Accepts all Box component props" description and link
- [x] We are consistent when using the same prop names like `size` and are suggesting the use of the generalized `design-system.js` constants e.g. `SIZES` as the primary option but noting the component consts in the documentation and using them for propType validation and storybook controls only
- [x] Standardize all similar prop names for images `src`
- [x] We have a story for each component prop and we use the prop name verbatim e.g. `size` prop would be `export const Size = (args) => (`
- [x] We have the accompanying documentation for each component prop and we use the prop name verbatim e.g. `size` prop would be `### Size`
- [x] Are multiple props stories allowed? e.g. `Color, Background Color And Border Color` story in `base-avatar` - [ ] yes when it makes sense to
- [x] All Base components follow the suffix convention e.g. `ButtonBase`
- [x] All Base component MDX documentation have the base component notification at the top
- [x] Add `mm-` prefix to all classNames
- [x] className is kebab case version of the component name
- [x] Spread base components props and reduce duplication of props when props aren't being changed and remain the same for both variant and base components
- [x] Add component to root `index.js` file in component-library
- [x] Add locals for any default text I18nContext as default context
- [x] Add any "to dos" with a `// TODO:` comment so we can search for them at a later date e.g. blocking components etc
- [x] Add snapshot testing
- [x] Add pixel values to propType descriptions if we use abstracted prop types that relate to pixel values e.g. `SIZE.MD (32px)`
- [x] Each prop section in the MDX docs should have: a heading, a description, a story and an example code snipped

## Screenshots/Screencaps

### Before

https://user-images.githubusercontent.com/8112138/203667674-26c6299d-4395-4b6b-944d-4198aef3e944.mov

### After

https://user-images.githubusercontent.com/8112138/203667693-8f7da84c-6a86-43f0-b5e8-e852141fd134.mov

## Manual Testing Steps

- Go to latest build of Storybook on this PR
- Search `TextFieldSearch` in the search bar
- Check stories, controls and docs

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.