### PR TITLE
[FLASK] Add Snaps JSON-RPC handler permission

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -2633,6 +2633,10 @@
   "osTheme": {
     "message": "System"
   },
+  "otherSnaps": {
+    "message": "other snaps",
+    "description": "Used in the 'permission_rpc' message."
+  },
   "padlock": {
     "message": "Padlock"
   },
@@ -2743,6 +2747,10 @@
   "permission_notifications": {
     "message": "Show notifications.",
     "description": "The description for the `snap_notify` permission"
+  },
+  "permission_rpc": {
+    "message": "Allow $1 to communicate directly with this snap.",
+    "description": "The description for the `endowment:rpc` permission. $1 is 'other snaps' or 'websites'."
   },
   "permission_transactionInsight": {
     "message": "Fetch and display transaction insights.",
@@ -4398,6 +4406,10 @@
   "webhid": {
     "message": "WebHID",
     "description": "Refers to a interface for connecting external devices to the browser. Used for connecting ledger to the browser. Read more here https://developer.mozilla.org/en-US/docs/Web/API/WebHID_API"
+  },
+  "websites": {
+    "message": "websites",
+    "description": "Used in the 'permission_rpc' message."
   },
   "welcome": {
     "message": "Welcome to MetaMask"

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -700,6 +700,7 @@ export default class MetamaskController extends EventEmitter {
         `${this.permissionController.name}:revokePermissionForAllSubjects`,
         `${this.approvalController.name}:addRequest`,
         `${this.permissionController.name}:grantPermissions`,
+        `${this.subjectMetadataController.name}:getSubjectMetadata`,
         'ExecutionService:executeSnap',
         'ExecutionService:getRpcRequestHandler',
         'ExecutionService:terminateSnap',

--- a/shared/constants/permissions.ts
+++ b/shared/constants/permissions.ts
@@ -27,6 +27,7 @@ export const EndowmentPermissions = Object.freeze({
   'endowment:transaction-insight': 'endowment:transaction-insight',
   'endowment:cronjob': 'endowment:cronjob',
   'endowment:ethereum-provider': 'endowment:ethereum-provider',
+  'endowment:rpc': 'endowment:rpc',
 } as const);
 
 // Methods / permissions in external packages that we are temporarily excluding.

--- a/ui/helpers/utils/permission.js
+++ b/ui/helpers/utils/permission.js
@@ -1,6 +1,7 @@
 import deepFreeze from 'deep-freeze-strict';
 ///: BEGIN:ONLY_INCLUDE_IN(flask)
 import React from 'react';
+import { getRpcCaveatOrigins } from '@metamask/snaps-controllers/dist/snaps/endowments/rpc';
 ///: END:ONLY_INCLUDE_IN
 import {
   RestrictedMethods,
@@ -118,9 +119,21 @@ const PERMISSION_DESCRIPTIONS = deepFreeze({
     rightIcon: null,
   },
   [EndowmentPermissions['endowment:rpc']]: {
-    // TODO: Icon and copy.
-    label: (t) => t('permission_rpc'),
-    leftIcon: 'fas fa-code',
+    label: (t, _, permissionValue) => {
+      const { snaps, dapps } = getRpcCaveatOrigins(permissionValue);
+
+      const messages = [];
+      if (snaps) {
+        messages.push(t('permission_rpc', [t('otherSnaps')]));
+      }
+
+      if (dapps) {
+        messages.push(t('permission_rpc', [t('websites')]));
+      }
+
+      return messages;
+    },
+    leftIcon: 'fas fa-plug',
     rightIcon: null,
   },
   ///: END:ONLY_INCLUDE_IN

--- a/ui/helpers/utils/permission.js
+++ b/ui/helpers/utils/permission.js
@@ -117,6 +117,12 @@ const PERMISSION_DESCRIPTIONS = deepFreeze({
     leftIcon: 'fab fa-ethereum',
     rightIcon: null,
   },
+  [EndowmentPermissions['endowment:rpc']]: {
+    // TODO: Icon and copy.
+    label: (t) => t('permission_rpc'),
+    leftIcon: 'fas fa-code',
+    rightIcon: null,
+  },
   ///: END:ONLY_INCLUDE_IN
   [UNKNOWN_PERMISSION]: {
     label: (t, permissionName) =>


### PR DESCRIPTION
This adds support for the `endowment:rpc` permission for Snaps. Pending an icon and copy.

Currently blocked by #16547.