### PR TITLE
`Label` house keeping 🧹

### DIFF
--- a/ui/components/component-library/label/README.mdx
+++ b/ui/components/component-library/label/README.mdx
@@ -1,10 +1,12 @@
 import { Story, Canvas, ArgsTable } from '@storybook/addon-docs';
 
+import { Text } from '..';
+
 import { Label } from './label';
 
 # Label
 
-The `Label` is a component used to label form inputs.
+The `Label` is a component used to label form inputs
 
 <Canvas>
   <Story id="ui-components-component-library-label-label-stories-js--default-story" />
@@ -12,13 +14,17 @@ The `Label` is a component used to label form inputs.
 
 ## Props
 
-The `Label` accepts all props below as well as all [Text](/docs/ui-components-component-library-text-text-stories-js--default-story#props) and [Box](/docs/ui-components-ui-box-box-stories-js--default-story#props) component props.
+The `Label` accepts all props below as well as all [Box](/docs/ui-components-ui-box-box-stories-js--default-story#props) component props
 
 <ArgsTable of={Label} />
 
+`Label` accepts all [Text](/docs/ui-components-component-library-text-text-stories-js--default-story#props) component props
+
+<ArgsTable of={Text} />
+
 ### Children
 
-The `children` of the label can be text or a react node.
+The `children` of the label can be text or a react node
 
 <Canvas>
   <Story id="ui-components-component-library-label-label-stories-js--children" />
@@ -26,9 +32,7 @@ The `children` of the label can be text or a react node.
 
 ```jsx
 import { DISPLAY, ALIGN_ITEMS, FLEX_DIRECTION, SIZES, COLORS } from '../../../helpers/constants/design-system';
-import { Icon, ICON_NAMES } from '../../ui/components/component-library';
-import { Label } from '../../ui/components/component-library';
-import { TextFieldBase } from '../../ui/components/component-library';
+import { Label, TextField, Icon, ICON_NAMES } from '../../component-library';
 
 <Label>Plain text</Label>
 <Label display={DISPLAY.FLEX} alignItems={ALIGN_ITEMS.FLEX_START}>
@@ -45,25 +49,23 @@ import { TextFieldBase } from '../../ui/components/component-library';
   alignItems={ALIGN_ITEMS.FLEX_START}
 >
   Label that wraps an input
-  {/* TODO: replace with TextField component */}
-  <TextFieldBase placeholder="Click label to focus" />
+  <TextField placeholder="Click label to focus" />
 </Label>
 ```
 
 ### Html For
 
-Use the `htmlFor` prop to allow the `Label` to focus on an input with the same id when clicked. The cursor will also change to a `pointer` when the `htmlFor` has a value
+Use the `htmlFor` prop to allow the `Label` to focus on an input with the same id when clicked. The cursor will also change to a `pointer` when the `htmlFor` has a value.
 
 <Canvas>
   <Story id="ui-components-component-library-label-label-stories-js--html-for" />
 </Canvas>
 
 ```jsx
-import { TextFieldBase } from '../../ui/components/component-library';
-import { Label } from '../../ui/components/component-library';
+import { Label, TextFieldBase } from '../../component-library';
 
 <Label htmlFor="add-network">Add network</Label>
-<TextFieldBase  id="add-network" placeholder="Enter network name" />
+<TextField id="add-network" placeholder="Enter network name" />
 ```
 
 ### Required
@@ -75,7 +77,7 @@ Use the `required` prop to add a required red asterisk next to the `children` of
 </Canvas>
 
 ```jsx
-import { Label } from '../../ui/components/component-library';
+import { Label } from '../../component-library';
 
 <Label required>Label</Label>;
 ```
@@ -89,7 +91,7 @@ Use the `disabled` prop to set the `Label` in disabled state
 </Canvas>
 
 ```jsx
-import { Label } from '../../ui/components/component-library';
+import { Label } from '../../component-library';
 
 <Label disabled>Label</Label>;
 ```

--- a/ui/components/component-library/label/__snapshots__/label.test.js.snap
+++ b/ui/components/component-library/label/__snapshots__/label.test.js.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`label should render text inside the label 1`] = `
+<div>
+  <label
+    class="box text mm-label text--body-md text--font-weight-bold text--color-text-default box--display-inline-flex box--flex-direction-row box--align-items-center"
+  >
+    label
+  </label>
+</div>
+`;

--- a/ui/components/component-library/label/label.js
+++ b/ui/components/component-library/label/label.js
@@ -20,15 +20,15 @@ export const Label = ({
   ...props
 }) => (
   <Text
-    as="label"
-    disabled={disabled}
-    htmlFor={htmlFor}
     className={classnames(
       'mm-label',
       { 'mm-label--disabled': disabled },
       { 'mm-label--html-for': htmlFor && !disabled },
       className,
     )}
+    as="label"
+    disabled={disabled}
+    htmlFor={htmlFor}
     variant={TEXT.BODY_MD}
     fontWeight={FONT_WEIGHT.BOLD}
     display={DISPLAY.INLINE_FLEX}

--- a/ui/components/component-library/label/label.stories.js
+++ b/ui/components/component-library/label/label.stories.js
@@ -8,8 +8,8 @@ import {
 } from '../../../helpers/constants/design-system';
 
 import Box from '../../ui/box';
-import { Icon, ICON_NAMES } from '../icon';
-import { TextFieldBase } from '../text-field-base';
+
+import { Icon, ICON_NAMES, TextField } from '..';
 
 import { Label } from './label';
 
@@ -73,8 +73,7 @@ export const Children = (args) => (
       alignItems={ALIGN_ITEMS.FLEX_START}
     >
       Label that wraps an input
-      {/* TODO: replace with TextField component */}
-      <TextFieldBase placeholder="Click label to focus" />
+      <TextField placeholder="Click label to focus" />
     </Label>
   </Box>
 );
@@ -87,7 +86,7 @@ export const HtmlFor = (args) => {
   return (
     <Box display={DISPLAY.INLINE_FLEX} flexDirection={FLEX_DIRECTION.COLUMN}>
       <Label {...args} />
-      <TextFieldBase
+      <TextField
         id="add-network"
         value={value}
         onChange={handleOnChange}

--- a/ui/components/component-library/label/label.test.js
+++ b/ui/components/component-library/label/label.test.js
@@ -8,8 +8,14 @@ import { Label } from './label';
 
 describe('label', () => {
   it('should render text inside the label', () => {
-    const { getByText } = render(<Label>label</Label>);
+    const { getByText, container } = render(<Label>label</Label>);
+    expect(getByText('label')).toHaveClass('mm-label');
     expect(getByText('label')).toBeDefined();
+    expect(container).toMatchSnapshot();
+  });
+  it('should render with additional className', () => {
+    const { getByText } = render(<Label className="test-class">label</Label>);
+    expect(getByText('label')).toHaveClass('mm-label test-class');
   });
   it('should render text and react nodes as children', () => {
     const { getByText, getByTestId } = render(
@@ -59,9 +65,5 @@ describe('label', () => {
   it('should render with disabled state and have disabled class', () => {
     const { getByText } = render(<Label disabled>label</Label>);
     expect(getByText('label')).toHaveClass('mm-label--disabled');
-  });
-  it('should render with additional className', () => {
-    const { getByText } = render(<Label className="test-class">label</Label>);
-    expect(getByText('label')).toHaveClass('test-class');
   });
 });


### PR DESCRIPTION
## Explanation

Updating `Label` to include the most up to date standards and conventions for the component-library components listed in the issue and description below

* Fixes #16639    

- [x] Has a `className` prop and the PropType descriptions are all the same
- [x] Prop table in MDX docs have the "Accepts all Box component props" description and link
- [x] We are consistent when using the same prop names like `size` and are suggesting the use of the generalized `design-system.js` constants e.g. `SIZES` as the primary option but noting the component consts in the documentation and using them for propType validation and storybook controls only
- [x] Standardize all similar prop names for images `src`
- [x] We have a story for each component prop and we use the prop name verbatim e.g. `size` prop would be `export const Size = (args) => (`
- [x] We have the accompanying documentation for each component prop and we use the prop name verbatim e.g. `size` prop would be `### Size`
- [x] Are multiple props stories allowed? e.g. `Color, Background Color And Border Color` story in `base-avatar` - [ ] yes when it makes sense to
- [x] All Base components follow the suffix convention e.g. `ButtonBase`
- [x] All Base component MDX documentation have the base component notification at the top
- [x] Add `mm-` prefix to all classNames
- [x] className is kebab case version of the component name
- [x] Spread base components props and reduce duplication of props when props aren't being changed and remain the same for both variant and base components
- [x] Add component to root `index.js` file in component-library
- [x] Add locals for any default text I18nContext as default context
- [x] Add any "to dos" with a `// TODO:` comment so we can search for them at a later date e.g. blocking components etc
- [x] Add snapshot testing
- [x] Add pixel values to propType descriptions if we use abstracted prop types that relate to pixel values e.g. `SIZE.MD (32px)`
- [x] Each prop section in the MDX docs should have: a heading, a description, a story and an example code snipped

## Screenshots/Screencaps

### Before

https://user-images.githubusercontent.com/8112138/203856322-74752950-9600-4e74-be27-0ed7b4aff36e.mov

### After

https://user-images.githubusercontent.com/8112138/203856358-a039c342-fcc3-43cf-adbd-f3fa81c3a37b.mov

## Manual Testing Steps

- Go to latest build of Storybook on this PR
- Search `Label` in the search bar
- Check stories, controls and docs

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.