### PR TITLE
`HelpText` house keeping 🧹 

### DIFF
--- a/ui/components/component-library/help-text/README.mdx
+++ b/ui/components/component-library/help-text/README.mdx
@@ -1,5 +1,7 @@
 import { Story, Canvas, ArgsTable } from '@storybook/addon-docs';
 
+import { Text } from '..';
+
 import { HelpText } from './help-text';
 
 # HelpText
@@ -12,13 +14,17 @@ The `HelpText` is intended to be used as the help or error text under a form ele
 
 ## Props
 
-The `HelpText` accepts all props below as well as all [Text](/docs/ui-components-component-library-text-text-stories-js--default-story#props) and [Box](/docs/ui-components-ui-box-box-stories-js--default-story#props) component props.
+The `HelpText` accepts all props below as well as all [Box](/docs/ui-components-ui-box-box-stories-js--default-story#props) component props
 
 <ArgsTable of={HelpText} />
 
+`HelpText` accepts all [Text](/docs/ui-components-component-library-text-text-stories-js--default-story#props) component props
+
+<ArgsTable of={Text} />
+
 ### Children
 
-The `children` of the `HelpText` can be plain text or react nodes.
+The `children` of the `HelpText` can be plain text or react nodes
 
 <Canvas>
   <Story id="ui-components-component-library-help-text-help-text-stories-js--children" />
@@ -26,8 +32,7 @@ The `children` of the `HelpText` can be plain text or react nodes.
 
 ```jsx
 import { SIZES, COLORS } from '../../../helpers/constants/design-system';
-import { Icon, ICON_NAMES } from '../../ui/components/component-library';
-import { HelpText } from '../../ui/components/component-library';
+import { HelpText, Icon, ICON_NAMES } from '../../component-library';
 
 <HelpText>Plain text</HelpText>
 <HelpText>
@@ -43,14 +48,14 @@ import { HelpText } from '../../ui/components/component-library';
 
 ### Error
 
-Use the `error` prop to show the `HelpText` in error state.
+Use the `error` prop to show the `HelpText` in error state
 
 <Canvas>
   <Story id="ui-components-component-library-help-text-help-text-stories-js--error-story" />
 </Canvas>
 
 ```jsx
-import { HelpText } from '../../ui/components/component-library';
+import { HelpText } from '../../component-library';
 
 <HelpText error>This HelpText in error state</HelpText>;
 ```
@@ -65,7 +70,7 @@ It may be useful to change the color of the `HelpText`. Use the `color` prop and
 
 ```jsx
 import { COLORS } from '../../../helpers/constants/design-system';
-import { HelpText } from '../../ui/components/component-library';
+import { HelpText } from '../../component-library';
 
 <Box display={DISPLAY.FLEX} flexDirection={FLEX_DIRECTION.COLUMN} gap={2}>
   <HelpText color={COLORS.TEXT_DEFAULT}>

--- a/ui/components/component-library/help-text/__snapshots__/help-text.test.js.snap
+++ b/ui/components/component-library/help-text/__snapshots__/help-text.test.js.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`HelpText should render with text inside the HelpText 1`] = `
+<div>
+  <span
+    class="box text mm-help-text text--body-xs text--color-text-default box--flex-direction-row"
+  >
+    help text
+  </span>
+</div>
+`;

--- a/ui/components/component-library/help-text/help-text.js
+++ b/ui/components/component-library/help-text/help-text.js
@@ -18,8 +18,8 @@ export const HelpText = ({
   ...props
 }) => (
   <Text
-    as="span"
     className={classnames('mm-help-text', className)}
+    as="span"
     variant={TEXT.BODY_XS}
     color={error ? COLORS.ERROR_DEFAULT : color}
     {...props}

--- a/ui/components/component-library/help-text/help-text.stories.js
+++ b/ui/components/component-library/help-text/help-text.stories.js
@@ -8,7 +8,8 @@ import {
 } from '../../../helpers/constants/design-system';
 
 import Box from '../../ui/box';
-import { Icon, ICON_NAMES } from '../icon';
+
+import { Icon, ICON_NAMES } from '..';
 
 import { HelpText } from './help-text';
 

--- a/ui/components/component-library/help-text/help-text.test.js
+++ b/ui/components/component-library/help-text/help-text.test.js
@@ -8,8 +8,16 @@ import { HelpText } from './help-text';
 
 describe('HelpText', () => {
   it('should render with text inside the HelpText', () => {
-    const { getByText } = render(<HelpText>help text</HelpText>);
+    const { getByText, container } = render(<HelpText>help text</HelpText>);
     expect(getByText('help text')).toBeDefined();
+    expect(getByText('help text')).toHaveClass('mm-help-text');
+    expect(container).toMatchSnapshot();
+  });
+  it('should render with and additional className', () => {
+    const { getByText } = render(
+      <HelpText className="test-class">help text</HelpText>,
+    );
+    expect(getByText('help text')).toHaveClass('mm-help-text test-class');
   });
   it('should render with react nodes inside the HelpText', () => {
     const { getByText, getByTestId } = render(
@@ -20,19 +28,8 @@ describe('HelpText', () => {
     expect(getByText('help text')).toBeDefined();
     expect(getByTestId('icon')).toBeDefined();
   });
-  it('should render with and additional className', () => {
-    const { getByText } = render(
-      <HelpText className="test-class">help text</HelpText>,
-    );
-    expect(getByText('help text')).toBeDefined();
-    expect(getByText('help text')).toHaveClass('test-class');
-  });
   it('should render with error state', () => {
-    const { getByText } = render(
-      <>
-        <HelpText error>error</HelpText>
-      </>,
-    );
+    const { getByText } = render(<HelpText error>error</HelpText>);
     expect(getByText('error')).toHaveClass('text--color-error-default');
   });
   it('should render with different colors', () => {


### PR DESCRIPTION
## Explanation

Updating `HelpText` to include the most up to date standards and conventions for the component-library components listed in the issue and description below

* Fixes #16638   

- [x] Has a `className` prop and the PropType descriptions are all the same
- [x] Prop table in MDX docs have the "Accepts all Box component props" description and link
- [x] We are consistent when using the same prop names like `size` and are suggesting the use of the generalized `design-system.js` constants e.g. `SIZES` as the primary option but noting the component consts in the documentation and using them for propType validation and storybook controls only
- [x] Standardize all similar prop names for images `src`
- [x] We have a story for each component prop and we use the prop name verbatim e.g. `size` prop would be `export const Size = (args) => (`
- [x] We have the accompanying documentation for each component prop and we use the prop name verbatim e.g. `size` prop would be `### Size`
- [x] Are multiple props stories allowed? e.g. `Color, Background Color And Border Color` story in `base-avatar` - [ ] yes when it makes sense to
- [x] All Base components follow the suffix convention e.g. `ButtonBase`
- [x] All Base component MDX documentation have the base component notification at the top
- [x] Add `mm-` prefix to all classNames
- [x] className is kebab case version of the component name
- [x] Spread base components props and reduce duplication of props when props aren't being changed and remain the same for both variant and base components
- [x] Add component to root `index.js` file in component-library
- [x] Add locals for any default text I18nContext as default context
- [x] Add any "to dos" with a `// TODO:` comment so we can search for them at a later date e.g. blocking components etc
- [x] Add snapshot testing
- [x] Add pixel values to propType descriptions if we use abstracted prop types that relate to pixel values e.g. `SIZE.MD (32px)`
- [x] Each prop section in the MDX docs should have: a heading, a description, a story and an example code snipped

## Screenshots/Screencaps

### Before

https://user-images.githubusercontent.com/8112138/203863442-19680d49-4e94-4518-b438-cc33d4e48ee4.mov

### After

https://user-images.githubusercontent.com/8112138/203863474-fbcff451-c68b-444a-b3b7-1b1a3f160cbb.mov

## Manual Testing Steps

- Go to latest build of Storybook on this PR
- Search `HelpText` in the search bar
- Check stories, controls and docs

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.