### PR TITLE
Not use hardware keyring classes when initializing KeyringController in extension MV3 version

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -585,12 +585,15 @@ export default class MetamaskController extends EventEmitter {
       await opts.openPopup();
     });
 
-    const additionalKeyrings = [
-      TrezorKeyring,
-      LedgerBridgeKeyring,
-      LatticeKeyring,
-      QRHardwareKeyring,
-    ];
+    let additionalKeyrings = [];
+    if (!isManifestV3) {
+      additionalKeyrings = [
+        TrezorKeyring,
+        LedgerBridgeKeyring,
+        LatticeKeyring,
+        QRHardwareKeyring,
+      ];
+    }
     this.keyringController = new KeyringController({
       keyringTypes: additionalKeyrings,
       initState: initState.KeyringController,


### PR DESCRIPTION
Partially fixes: https://github.com/MetaMask/metamask-extension/issues/16674
For fix to be completed we need to merge this PR also: https://github.com/MetaMask/KeyringController/pull/169/files#diff-e727e4bdf3657fd1d798edcd6b099d6e092f8573cba266154583a746bba0f346R700

For MV3 we do not pass hardware wallet classes to keyring controller.