### PR TITLE
remove rpc urls from metrics

### DIFF
--- a/app/scripts/controllers/metametrics.js
+++ b/app/scripts/controllers/metametrics.js
@@ -91,8 +91,6 @@ export default class MetaMetricsController {
    *  networkDidChange event emitted by the networkController
    * @param {Function} options.getCurrentChainId - Gets the current chain id from the
    *  network controller
-   * @param {Function} options.getNetworkIdentifier - Gets the current network
-   *  identifier from the network controller
    * @param {string} options.version - The version of the extension
    * @param {string} options.environment - The environment the extension is running in
    * @param {string} options.extension - webextension-polyfill
@@ -104,7 +102,6 @@ export default class MetaMetricsController {
     preferencesStore,
     onNetworkDidChange,
     getCurrentChainId,
-    getNetworkIdentifier,
     version,
     environment,
     initState,
@@ -120,7 +117,6 @@ export default class MetaMetricsController {
     };
     const prefState = preferencesStore.getState();
     this.chainId = getCurrentChainId();
-    this.network = getNetworkIdentifier();
     this.locale = prefState.currentLocale.replace('_', '-');
     this.version =
       environment === 'production' ? version : `${version}-${environment}`;
@@ -150,7 +146,6 @@ export default class MetaMetricsController {
 
     onNetworkDidChange(() => {
       this.chainId = getCurrentChainId();
-      this.network = getNetworkIdentifier();
     });
     this.segment = segment;
 
@@ -470,7 +465,6 @@ export default class MetaMetricsController {
         properties: {
           params,
           locale: this.locale,
-          network: this.network,
           chain_id: this.chainId,
           environment_type: environmentType,
         },
@@ -668,7 +662,6 @@ export default class MetaMetricsController {
         value,
         currency,
         category,
-        network: properties?.network ?? this.network,
         locale: this.locale,
         chain_id: properties?.chain_id ?? this.chainId,
         environment_type: environmentType,

--- a/app/scripts/controllers/metametrics.test.js
+++ b/app/scripts/controllers/metametrics.test.js
@@ -8,7 +8,11 @@ import {
   TRAITS,
 } from '../../../shared/constants/metametrics';
 import waitUntilCalled from '../../../test/lib/wait-until-called';
-import { CHAIN_IDS, CURRENCY_SYMBOLS } from '../../../shared/constants/network';
+import {
+  CHAIN_IDS,
+  CURRENCY_SYMBOLS,
+  NETWORK_TYPES,
+} from '../../../shared/constants/network';
 import * as Utils from '../lib/util';
 import MetaMetricsController from './metametrics';
 import { NETWORK_EVENTS } from './network';
@@ -16,7 +20,6 @@ import { NETWORK_EVENTS } from './network';
 const segment = createSegmentMock(2, 10000);
 
 const VERSION = '0.0.1-test';
-const NETWORK = 'Mainnet';
 const FAKE_CHAIN_ID = '0x1338';
 const LOCALE = 'en_US';
 const TEST_META_METRICS_ID = '0xabc';
@@ -46,7 +49,6 @@ const DEFAULT_TEST_CONTEXT = {
 const DEFAULT_SHARED_PROPERTIES = {
   chain_id: FAKE_CHAIN_ID,
   locale: LOCALE.replace('_', '-'),
-  network: NETWORK,
   environment_type: 'background',
 };
 
@@ -64,7 +66,7 @@ const DEFAULT_PAGE_PROPERTIES = {
 
 function getMockNetworkController(
   chainId = FAKE_CHAIN_ID,
-  provider = { type: NETWORK },
+  provider = { type: NETWORK_TYPES.MAINNET },
 ) {
   let networkStore = { chainId, provider };
   const on = sinon.stub().withArgs(NETWORK_EVENTS.NETWORK_DID_CHANGE);
@@ -130,8 +132,6 @@ function getMetaMetricsController({
 } = {}) {
   return new MetaMetricsController({
     segment: segmentInstance || segment,
-    getNetworkIdentifier:
-      networkController.getNetworkIdentifier.bind(networkController),
     getCurrentChainId:
       networkController.getCurrentChainId.bind(networkController),
     onNetworkDidChange: networkController.on.bind(
@@ -178,7 +178,6 @@ describe('MetaMetricsController', function () {
         });
       const metaMetricsController = getMetaMetricsController();
       assert.strictEqual(metaMetricsController.version, VERSION);
-      assert.strictEqual(metaMetricsController.network, NETWORK);
       assert.strictEqual(metaMetricsController.chainId, FAKE_CHAIN_ID);
       assert.strictEqual(
         metaMetricsController.state.participateInMetaMetrics,
@@ -203,14 +202,12 @@ describe('MetaMetricsController', function () {
       const metaMetricsController = getMetaMetricsController({
         networkController,
       });
-      assert.strictEqual(metaMetricsController.network, NETWORK);
       networkController.store.updateState({
         provider: {
           type: 'NEW_NETWORK',
         },
         chainId: '0xaab',
       });
-      assert.strictEqual(metaMetricsController.network, 'NEW_NETWORK');
       assert.strictEqual(metaMetricsController.chainId, '0xaab');
     });
 
@@ -219,7 +216,6 @@ describe('MetaMetricsController', function () {
       const metaMetricsController = getMetaMetricsController({
         preferencesStore,
       });
-      assert.strictEqual(metaMetricsController.network, NETWORK);
       preferencesStore.updateState({
         currentLocale: 'en_UK',
       });

--- a/app/scripts/lib/rpc-method-middleware/handlers/add-ethereum-chain.js
+++ b/app/scripts/lib/rpc-method-middleware/handlers/add-ethereum-chain.js
@@ -299,7 +299,6 @@ async function addEthereumChainHandler(
         chain_id: _chainId,
         network_name: _chainName,
         symbol: ticker,
-        block_explorer_url: firstValidBlockExplorerUrl,
         source: EVENT.SOURCE.TRANSACTION.DAPP,
       },
     });

--- a/app/scripts/lib/rpc-method-middleware/handlers/add-ethereum-chain.js
+++ b/app/scripts/lib/rpc-method-middleware/handlers/add-ethereum-chain.js
@@ -289,13 +289,6 @@ async function addEthereumChainHandler(
       }),
     );
 
-    let rpcUrlOrigin;
-    try {
-      rpcUrlOrigin = new URL(firstValidRPCUrl).origin;
-    } catch {
-      // ignore
-    }
-
     sendMetrics({
       event: 'Custom Network Added',
       category: EVENT.CATEGORIES.NETWORK,
@@ -305,17 +298,9 @@ async function addEthereumChainHandler(
       properties: {
         chain_id: _chainId,
         network_name: _chainName,
-        // Including network to override the default network
-        // property included in all events. For RPC type networks
-        // the MetaMetrics controller uses the rpcUrl for the network
-        // property.
-        network: rpcUrlOrigin,
         symbol: ticker,
         block_explorer_url: firstValidBlockExplorerUrl,
         source: EVENT.SOURCE.TRANSACTION.DAPP,
-      },
-      sensitiveProperties: {
-        rpc_url: rpcUrlOrigin,
       },
     });
 

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -2127,7 +2127,6 @@ export default class MetamaskController extends EventEmitter {
         chain_id: chainId,
         network_name: chainName,
         symbol: ticker,
-        block_explorer_url: blockExplorerUrl,
         source: EVENT.SOURCE.NETWORK.POPULAR_NETWORK_LIST,
       },
       actionId,

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -2117,28 +2117,18 @@ export default class MetamaskController extends EventEmitter {
       },
     );
 
-    let rpcUrlOrigin;
-    try {
-      rpcUrlOrigin = new URL(rpcUrl).origin;
-    } catch {
-      // ignore
-    }
     this.metaMetricsController.trackEvent({
       event: 'Custom Network Added',
       category: EVENT.CATEGORIES.NETWORK,
       referrer: {
-        url: rpcUrlOrigin,
+        url: ORIGIN_METAMASK,
       },
       properties: {
         chain_id: chainId,
         network_name: chainName,
-        network: rpcUrlOrigin,
         symbol: ticker,
         block_explorer_url: blockExplorerUrl,
         source: EVENT.SOURCE.NETWORK.POPULAR_NETWORK_LIST,
-      },
-      sensitiveProperties: {
-        rpc_url: rpcUrlOrigin,
       },
       actionId,
     });

--- a/ui/pages/settings/networks-tab/networks-form/networks-form.js
+++ b/ui/pages/settings/networks-tab/networks-form/networks-form.js
@@ -541,7 +541,6 @@ const NetworksForm = ({
             chain_id: addHexPrefix(Number(chainId).toString(16)),
             network_name: networkName,
             symbol: ticker,
-            block_explorer_url: blockExplorerUrl,
             source: EVENT.SOURCE.NETWORK.CUSTOM_NETWORK_FORM,
           },
         });

--- a/ui/pages/settings/networks-tab/networks-form/networks-form.js
+++ b/ui/pages/settings/networks-tab/networks-form/networks-form.js
@@ -42,6 +42,7 @@ import {
   FEATURED_RPCS,
 } from '../../../../../shared/constants/network';
 import { decimalToHex } from '../../../../../shared/lib/transactions-controller-utils';
+import { ORIGIN_METAMASK } from '../../../../../shared/constants/app';
 
 /**
  * Attempts to convert the given chainId to a decimal string, for display
@@ -530,28 +531,18 @@ const NetworksForm = ({
       }
 
       if (addNewNetwork) {
-        let rpcUrlOrigin;
-        try {
-          rpcUrlOrigin = new URL(rpcUrl).origin;
-        } catch {
-          // error
-        }
         trackEvent({
           event: 'Custom Network Added',
           category: EVENT.CATEGORIES.NETWORK,
           referrer: {
-            url: rpcUrlOrigin,
+            url: ORIGIN_METAMASK,
           },
           properties: {
             chain_id: addHexPrefix(Number(chainId).toString(16)),
             network_name: networkName,
-            network: rpcUrlOrigin,
             symbol: ticker,
             block_explorer_url: blockExplorerUrl,
             source: EVENT.SOURCE.NETWORK.CUSTOM_NETWORK_FORM,
-          },
-          sensitiveProperties: {
-            rpc_url: rpcUrlOrigin,
           },
         });
         dispatch(setNewNetworkAdded(networkName));


### PR DESCRIPTION
## Explanation
This pull request aims to remove any place in which we send the current network's rpc url to segment. We have done this since before we used segment, and when we implemented segment it was carried over.

Fixes #15170 

## Screenshots/Screencaps

<!-- If you're making a change to the UI, make sure to capture a screenshot or a short video showing off your work! -->

### Before

![image](https://user-images.githubusercontent.com/4448075/204350133-2881d37e-0ec2-477d-ba6b-b3ee538458ae.png)

### After

![image](https://user-images.githubusercontent.com/4448075/204350496-e198c897-eff1-4451-837b-63f671d4092d.png)

## Manual Testing Steps
1. Add a segment write key to your development config, or setup metametrics for local development
2. start the extension
3. Add extension to chrome
4. inspect the background process
5. Filter the network traffic to "segment"
6. open the extension popup
7. Look for 'batch' requests and examine the payloads
8. see that the rpc url is not listed in the 'network' key on any events (previously it was sent with *every* request)
9. See that the rpc url is not listed in the rpc_url or network key for any 'add network' events sent when adding a network via the addEthereumChain / switchEthereumChain apis OR the custom network form OR populate network lists inside the extension. 

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
