### PR TITLE
Remove fenced code in TypeScript files

### DIFF
--- a/development/build/transforms/remove-fenced-code.js
+++ b/development/build/transforms/remove-fenced-code.js
@@ -104,14 +104,14 @@ function createRemoveFencedCodeTransform(
   // string.
 
   /**
-   * Returns a transform stream that removes fenced code from JavaScript files. For non-JavaScript
+   * Returns a transform stream that removes fenced code from JavaScript/TypeScript files. For non-JavaScript
    * files, a pass-through stream is returned.
    *
    * @param filePath - The file path to transform.
    * @returns {Transform} The transform stream.
    */
   return function removeFencedCodeTransform(filePath) {
-    if (!['.js', '.cjs', '.mjs'].includes(path.extname(filePath))) {
+    if (!['.js', '.cjs', '.mjs', '.ts'].includes(path.extname(filePath))) {
       return new PassThrough();
     }
 


### PR DESCRIPTION
## Explanation

Currently, you can find traces of Snaps code in the main extension due to the few files we have converted to TypeScript not being fenced correctly, i.e. https://github.com/MetaMask/metamask-extension/blob/develop/shared/constants/permissions.ts

This PR will make sure we correctly remove fenced code in TypeScript files.

## Manual Testing Steps

You can manually test this by searching for `snap_` prefixed RPC methods in the MetaMask main bundle. With this PR those should be gone.

