### PR TITLE
Fix production builds for Flask

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -344,9 +344,25 @@ jobs:
       - checkout
       - attach_workspace:
           at: .
-      - run:
-          name: build:dist
-          command: yarn build --build-type flask dist
+      - when:
+          condition:
+            not:
+              matches:
+                pattern: /^master$/
+                value: << pipeline.git.branch >>
+          steps:
+            - run:
+                name: build:dist
+                command: yarn build --build-type flask dist
+      - when:
+          condition:
+              matches:
+                pattern: /^master$/
+                value: << pipeline.git.branch >>
+          steps:
+            - run:
+                name: build:prod
+                command: yarn build --build-type flask prod
       - run:
           name: build:debug
           command: find dist/ -type f -exec md5sum {} \; | sort -k 2


### PR DESCRIPTION
## Explanation

Mirror beta CI configuration to fix building of Flask production builds. Previously we were not building Flask using the production configuration, resulting in non-production builds being released.