### PR TITLE
Use NETWORK_EVENTS.NETWORK_DID_CHANGE to trigger network change callb…

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -302,7 +302,8 @@ export default class MetamaskController extends EventEmitter {
         onPreferencesStateChange: (listener) =>
           this.preferencesController.store.subscribe(listener),
         onNetworkStateChange: (cb) =>
-          this.networkController.store.subscribe((networkState) => {
+          this.networkController.on(NETWORK_EVENTS.NETWORK_DID_CHANGE, () => {
+            const networkState = this.networkController.store.getState();
             const modifiedNetworkState = {
               ...networkState,
               provider: {


### PR DESCRIPTION
…ack in  assetsContractController

Fixes https://github.com/MetaMask/metamask-extension/issues/16687

### Here is an explanation of the cause of the above bug:

The AssetsContractController has the following code:
```
        onNetworkStateChange((networkState) => {
            if (this.config.chainId !== networkState.provider.chainId) {
                // const provider1 = new providers_1.Web3Provider(newProvider);
                // console.log('provider1', provider1)
                this.configure({
                    chainId: networkState.provider.chainId,
                });
            }
        });
```

The `this.configure` call will run the following code (defined in the BaseController which the AssetsContractController inherits from):
```
for (const key in this.internalConfig) {
    if (typeof this.internalConfig[key] !== 'undefined') {
        this[key] = this.internalConfig[key];
    }
}
```
This code will effectively set the `this.provider` property of the AssetsContractController to be equal to whatever `this.internalConfig.provider` was before the `this.configure` call.

This caused a problem when paired with the `onNetworkStateChange` method that is passed to the AssetsContractController constructor from the MetaMask Controller. Before this PR, that method was using `this.networkController.store.subscribe` to trigger the callback defined in the AssetContractController. This would run after any state change in the network controller. Here is the code that runs when a user switches a network:
```
  _switchNetwork(opts) {
    // Indicate to subscribers that network is about to change
    this.emit(NETWORK_EVENTS.NETWORK_WILL_CHANGE);
    // Set loading state
    this.setNetworkState('loading');
    // Reset network details
    this.clearNetworkDetails();
    // Configure the provider appropriately
    this._configureProvider(opts);
    // Notify subscribers that network has changed
    this.emit(NETWORK_EVENTS.NETWORK_DID_CHANGE, opts.type);
  }
```
There, you can see that state changes happen before the provider is configured. And herein lies the problem.

1. The user would switch a network,
2. then a state change would happen,
3. the `onNetworkStateChange` callback in the AssetsContractController would run _before the network controller and configured the provider_
4. so then the AssetsContractController `this.provider` would be set to the previous `this.internalConfig.provider`, which would have been configured for the network that the user is switching away from
5. so the AssetsContractController `this.provider` is now configured for the wrong network

This would cause the `getTokenStandardAndDetails` call on the AssetsContractController to fail, thereby causing the behaviour shown in the bug report linked above: that we show an approval screen for the wrong type of token after switching networks and switching back again.

This failure of `getTokenStandardAndDetails` would happen on the `contract.decimals()` call in `ERC20Standard.js`, where `contract` is constructed by ethers. This failure was not happening prior to the recent controllers version update, because the contract object constructed by Web3.js would still successfully return the correct result, regardless of the network configuration of the provider, but ethers.js throws an error in this case. The most recent version update for this controller changed it to use ethers.js instead of web3.js

### The solution

The fix is straightforward: use the `NETWORK_EVENTS.NETWORK_DID_CHANGE` to trigger the `onNetworkStateChange` callback, instead of the state update. This works because that event is only emitted after the network controller configures a provider after a network is switched. So the provider that is set during the BaseController's `configure` call is the updated provider and not the previous provider.

This also just makes the this network change method consistent with other controllers like the GasController, ENSController and IncomingTransactionsController, which also use `NETWORK_EVENTS.NETWORK_DID_CHANGE` to trigger their `onNetworkDidChange` callbacks.

### Manual testing steps

1. Switch the network to mainnet
2. Go to https://etherscan.io/token/0x6b175474e89094c44da98b954eedeac495271d0f#writeContract
3. Connect your wallet
4. Click "Approve"
5. Enter any address and any amount
6. Click "Write". You should now see a MetaMask confirmation window asking about accessing/spending your DAI
7. Reject the confirmation
8. Open metamask and switch network to something other than mainnet
9. Switch back to mainnet
10. Repeat steps 2-6. You should see the same confirmation window at step 6
          