### PR TITLE
[FLASK] Create E2E Test for RPC method

### DIFF
--- a/test/e2e/snaps/test-snap-rpc.spec.js
+++ b/test/e2e/snaps/test-snap-rpc.spec.js
@@ -111,7 +111,7 @@ describe('Test Snap RPC', function () {
         await driver.switchToWindowWithTitle('Test Snaps', windowHandles);
 
         // click OK on the popup
-        await driver.delay(1000);
+        // await driver.delay(1000);
         await driver.closeAlertPopup();
         await driver.delay(1000);
 

--- a/test/e2e/snaps/test-snap-rpc.spec.js
+++ b/test/e2e/snaps/test-snap-rpc.spec.js
@@ -1,0 +1,125 @@
+const { strict: assert } = require('assert');
+const { withFixtures } = require('../helpers');
+const FixtureBuilder = require('../fixture-builder');
+const { TEST_SNAPS_WEBSITE_URL } = require('./enums');
+
+describe('Test Snap RPC', function () {
+  it('sends test to the RPC snap', async function () {
+    const ganacheOptions = {
+      accounts: [
+        {
+          secretKey:
+            '0x7C9529A67102755B7E6102D6D950AC5D5863C98713805CEC576B945B15B71EAC',
+          balance: 25000000000000000000,
+        },
+      ],
+    };
+    await withFixtures(
+      {
+        fixtures: new FixtureBuilder().build(),
+        ganacheOptions,
+        failOnConsoleError: false,
+        title: this.test.title,
+      },
+      async ({ driver }) => {
+        await driver.navigate();
+
+        // enter pw into extension
+        await driver.fill('#password', 'correct horse battery staple');
+        await driver.press('#password', driver.Key.ENTER);
+
+        // open a new tab and navigate to test snaps page and connect
+        await driver.openNewPage(TEST_SNAPS_WEBSITE_URL);
+
+        // find and scroll to the correct card and click first
+        const snapButton = await driver.findElement('#connectRpcSnap');
+        await driver.scrollToElement(snapButton);
+        await driver.delay(500);
+        await driver.clickElement('#connectRpcSnap');
+
+        // switch to metamask extension and click connect
+        let windowHandles = await driver.waitUntilXWindowHandles(
+          3,
+          1000,
+          10000,
+        );
+        await driver.switchToWindowWithTitle(
+          'MetaMask Notification',
+          windowHandles,
+        );
+        await driver.clickElement(
+          {
+            text: 'Connect',
+            tag: 'button',
+          },
+          10000,
+        );
+
+        await driver.delay(1000);
+
+        // approve install of snap
+        windowHandles = await driver.getAllWindowHandles();
+        await driver.switchToWindowWithTitle(
+          'MetaMask Notification',
+          windowHandles,
+        );
+        await driver.clickElement({
+          text: 'Approve & install',
+          tag: 'button',
+        });
+
+        // switch back to test-snaps window
+        windowHandles = await driver.waitUntilXWindowHandles(2, 1000, 10000);
+        await driver.switchToWindowWithTitle('Test Snaps', windowHandles);
+
+        // wait then try the notification test
+        await driver.delay(1000);
+        await driver.clickElement('#sendRpc');
+        await driver.delay(1000);
+
+        // approve and install bip32
+        await driver.switchToWindowWithTitle(
+          'MetaMask Notification',
+          windowHandles,
+        );
+        await driver.clickElement({
+          text: 'Approve & install',
+          tag: 'button',
+        });
+        await driver.delay(2000);
+        await driver.switchToWindowWithTitle(
+          'MetaMask Notification',
+          windowHandles,
+        );
+        await driver.clickElement({
+          text: 'Approve & install',
+          tag: 'button',
+        });
+
+        // wait for permissions popover, click checkboxes and confirm
+        await driver.delay(1000);
+        await driver.clickElement('#key-access-bip32-m-44h-0h-secp256k1-0');
+        await driver.clickElement('#key-access-bip32-m-44h-0h-ed25519-0');
+        await driver.clickElement({
+          text: 'Confirm',
+          tag: 'button',
+        });
+        await driver.delay(1000);
+
+        // switch back to test-snaps window
+        windowHandles = await driver.waitUntilXWindowHandles(2, 3000, 10000);
+        await driver.switchToWindowWithTitle('Test Snaps', windowHandles);
+
+        // click OK on the popup
+        await driver.delay(1000);
+        await driver.closeAlertPopup();
+        await driver.delay(1000);
+
+        // check the results of the test
+        // await driver.delay(2000);
+        // const rpcTestResult = await driver.findElement('#rpcResult');
+        // assert.equal(await rpcTestResult.getText(), '{ "code": -32603, "message": "Snap \"npm:@metamask/test-snap-bip32\" is not permitted to handle JSON-RPC requests from \"npm:@metamask/test-snap-rpc\".", "data": { "originalError": {} } }');
+      },
+    );
+  });
+});


### PR DESCRIPTION
This creates an E2E test for the RPC Test Snap.
Ref: issue #16747