### PR TITLE
Privacy - Allow users to set a custom RPC from the onboarding process

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -2592,12 +2592,9 @@
   "onboardingMetametricsPrivateEmphasizedText": {
     "message": "We will never sell your data. Ever!"
   },
-  "onboardingMetametricsPrivateSettingsText": {
-    "message": "settings"
-  },
   "onboardingMetametricsPrivateText": {
-    "message": "Your keys, transactions, full IP address, and any personal information are private. MetaMask doesn’t collect this information, but to enable certain features we use third-party service providers who might. For example, RPC providers collect your IP address when you send a transaction. $1 is the default RPC for MetaMask. You can change this to another provider in $2.",
-    "description": "$1 represents `infura`, $2 represents `onboardingMetametricsPrivateSettingsText`"
+    "message": "Your keys, transactions, full IP address, and any personal information are private. MetaMask doesn’t collect this information, but to enable certain features we use third-party service providers who might. For example, RPC providers collect your IP address when you send a transaction. $1 is the default RPC for MetaMask. You can change this to another provider in settings.",
+    "description": "$1 represents `infura`"
   },
   "onboardingMetametricsPrivateTitle": {
     "message": "Private"

--- a/ui/pages/onboarding-flow/metametrics/metametrics.js
+++ b/ui/pages/onboarding-flow/metametrics/metametrics.js
@@ -17,7 +17,6 @@ import {
   getParticipateInMetaMetrics,
 } from '../../../selectors';
 
-import { SECURITY_ROUTE } from '../../../helpers/constants/routes';
 import { EVENT, EVENT_NAMES } from '../../../../shared/constants/metametrics';
 
 import { MetaMetricsContext } from '../../../contexts/metametrics';
@@ -178,14 +177,6 @@ export default function OnboardingMetametrics() {
                 key="infura-link"
               >
                 {t('infura')}
-              </a>,
-              <a
-                href={`#${SECURITY_ROUTE}`}
-                target="_blank"
-                rel="noopener noreferrer"
-                key="settings-link"
-              >
-                {t('onboardingMetametricsPrivateSettingsText')}
               </a>,
             ])}
           </Typography>


### PR DESCRIPTION
## Explanation

* Fixes [#12345](https://github.com/MetaMask/metamask-extension/issues/16696)

## Screenshots/Screencaps


https://user-images.githubusercontent.com/46655/205152670-64b6ad68-d5ab-472e-84b6-d69b36a37eba.mp4



## Pre-merge author checklist

- [ ] I've clearly explained:
  - [ ] What problem this PR is solving
  - [ ] How this problem was solved
  - [ ] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
