### PR TITLE
Network request in background should not start until onboarding is completed

### DIFF
--- a/app/scripts/controllers/incoming-transactions.js
+++ b/app/scripts/controllers/incoming-transactions.js
@@ -167,8 +167,7 @@ export default class IncomingTransactionsController {
    * @param {number} [newBlockNumberDec] - block number to begin fetching from
    */
   async _update(address, newBlockNumberDec) {
-    const completedOnboarding =
-      this.onboardingController.store.getState().completedOnboarding;
+    const { completedOnboarding } = this.onboardingController.store.getState();
     const chainId = this.getCurrentChainId();
     if (
       !etherscanSupportedNetworks.includes(chainId) ||

--- a/app/scripts/controllers/incoming-transactions.js
+++ b/app/scripts/controllers/incoming-transactions.js
@@ -125,7 +125,9 @@ export default class IncomingTransactionsController {
 
     this.onboardingController.store.subscribe(
       previousValueComparator(async (prevState, currState) => {
-        if (!prevState.completedOnboarding && currState.completedOnboarding) {
+        const { completedOnboarding: prevCompletedOnboarding } = prevState;
+        const { completedOnboarding: currCompletedOnboarding } = currState;
+        if (!prevCompletedOnboarding && currCompletedOnboarding) {
           const address = this.preferencesController.getSelectedAddress();
           await this._update(address);
         }

--- a/app/scripts/controllers/incoming-transactions.js
+++ b/app/scripts/controllers/incoming-transactions.js
@@ -2,7 +2,7 @@ import { ObservableStore } from '@metamask/obs-store';
 import log from 'loglevel';
 import BN from 'bn.js';
 import createId from '../../../shared/modules/random-id';
-import { bnToHex } from '../lib/util';
+import { bnToHex, previousValueComparator } from '../lib/util';
 import getFetchWithTimeout from '../../../shared/modules/fetch-with-timeout';
 
 import {
@@ -61,10 +61,12 @@ export default class IncomingTransactionsController {
       onNetworkDidChange,
       getCurrentChainId,
       preferencesController,
+      onboardingController,
     } = opts;
     this.blockTracker = blockTracker;
     this.getCurrentChainId = getCurrentChainId;
     this.preferencesController = preferencesController;
+    this.onboardingController = onboardingController;
 
     this._onLatestBlock = async (newBlockNumberHex) => {
       const selectedAddress = this.preferencesController.getSelectedAddress();
@@ -121,6 +123,15 @@ export default class IncomingTransactionsController {
       }, this.preferencesController.store.getState()),
     );
 
+    this.onboardingController.store.subscribe(
+      previousValueComparator(async (prevState, currState) => {
+        if (!prevState.completedOnboarding && currState.completedOnboarding) {
+          const address = this.preferencesController.getSelectedAddress();
+          await this._update(address);
+        }
+      }, this.onboardingController.store.getState()),
+    );
+
     onNetworkDidChange(async () => {
       const address = this.preferencesController.getSelectedAddress();
       await this._update(address);
@@ -154,8 +165,14 @@ export default class IncomingTransactionsController {
    * @param {number} [newBlockNumberDec] - block number to begin fetching from
    */
   async _update(address, newBlockNumberDec) {
+    const completedOnboarding =
+      this.onboardingController.store.getState().completedOnboarding;
     const chainId = this.getCurrentChainId();
-    if (!etherscanSupportedNetworks.includes(chainId) || !address) {
+    if (
+      !etherscanSupportedNetworks.includes(chainId) ||
+      !address ||
+      !completedOnboarding
+    ) {
       return;
     }
     try {
@@ -292,32 +309,4 @@ export default class IncomingTransactionsController {
       type: TRANSACTION_TYPES.INCOMING,
     };
   }
-}
-
-/**
- * Returns a function with arity 1 that caches the argument that the function
- * is called with and invokes the comparator with both the cached, previous,
- * value and the current value. If specified, the initialValue will be passed
- * in as the previous value on the first invocation of the returned method.
- *
- * @template A - The type of the compared value.
- * @param {(prevValue: A, nextValue: A) => void} comparator - A method to compare
- * the previous and next values.
- * @param {A} [initialValue] - The initial value to supply to prevValue
- * on first call of the method.
- */
-function previousValueComparator(comparator, initialValue) {
-  let first = true;
-  let cache;
-  return (value) => {
-    try {
-      if (first) {
-        first = false;
-        return comparator(initialValue ?? value, value);
-      }
-      return comparator(cache, value);
-    } finally {
-      cache = value;
-    }
-  };
 }

--- a/app/scripts/controllers/incoming-transactions.test.js
+++ b/app/scripts/controllers/incoming-transactions.test.js
@@ -83,8 +83,8 @@ function getMockOnboardingController() {
       getState: sinon.stub().returns({
         completedOnboarding: true,
       }),
+      subscribe: sinon.spy(),
     },
-    subscribe: sinon.spy(),
   };
 }
 

--- a/app/scripts/controllers/incoming-transactions.test.js
+++ b/app/scripts/controllers/incoming-transactions.test.js
@@ -80,7 +80,9 @@ function getMockPreferencesController({
 function getMockOnboardingController() {
   return {
     store: {
-      completedOnboarding: true,
+      getState: sinon.stub().returns({
+        completedOnboarding: true,
+      }),
     },
   };
 }

--- a/app/scripts/controllers/incoming-transactions.test.js
+++ b/app/scripts/controllers/incoming-transactions.test.js
@@ -77,6 +77,14 @@ function getMockPreferencesController({
   };
 }
 
+function getMockOnboardingController() {
+  return {
+    store: {
+      completedOnboarding: true,
+    },
+  };
+}
+
 function getMockBlockTracker() {
   return {
     addListener: sinon.stub().callsArgWithAsync(1, '0xa'),
@@ -169,6 +177,7 @@ describe('IncomingTransactionsController', function () {
           blockTracker: getMockBlockTracker(),
           ...mockedNetworkMethods,
           preferencesController: getMockPreferencesController(),
+          onboardingController: getMockOnboardingController(),
           initState: {},
         },
       );
@@ -199,6 +208,7 @@ describe('IncomingTransactionsController', function () {
           blockTracker: getMockBlockTracker(),
           ...getMockNetworkControllerMethods(),
           preferencesController: getMockPreferencesController(),
+          onboardingController: getMockOnboardingController(),
           initState: getNonEmptyInitState(),
         },
       );
@@ -217,6 +227,7 @@ describe('IncomingTransactionsController', function () {
           blockTracker: getMockBlockTracker(),
           ...getMockNetworkControllerMethods(),
           preferencesController: getMockPreferencesController(),
+          onboardingController: getMockOnboardingController(),
           initState: {},
         },
       );
@@ -239,6 +250,7 @@ describe('IncomingTransactionsController', function () {
           blockTracker: getMockBlockTracker(),
           ...getMockNetworkControllerMethods(CHAIN_IDS.GOERLI),
           preferencesController: getMockPreferencesController(),
+          onboardingController: getMockOnboardingController(),
           initState: getNonEmptyInitState(),
         },
       );
@@ -344,6 +356,7 @@ describe('IncomingTransactionsController', function () {
           blockTracker: getMockBlockTracker(),
           ...getMockNetworkControllerMethods(),
           preferencesController: getMockPreferencesController(),
+          onboardingController: getMockOnboardingController(),
           initState: getNonEmptyInitState(),
         },
       );
@@ -394,6 +407,7 @@ describe('IncomingTransactionsController', function () {
           preferencesController: getMockPreferencesController({
             showIncomingTransactions: false,
           }),
+          onboardingController: getMockOnboardingController(),
           initState: getNonEmptyInitState(),
         },
       );
@@ -441,6 +455,7 @@ describe('IncomingTransactionsController', function () {
           blockTracker: getMockBlockTracker(),
           ...getMockNetworkControllerMethods(CHAIN_IDS.GOERLI),
           preferencesController: getMockPreferencesController(),
+          onboardingController: getMockOnboardingController(),
           initState: getNonEmptyInitState(),
         },
       );
@@ -486,6 +501,7 @@ describe('IncomingTransactionsController', function () {
           blockTracker: getMockBlockTracker(),
           ...getMockNetworkControllerMethods(CHAIN_IDS.GOERLI),
           preferencesController: getMockPreferencesController(),
+          onboardingController: getMockOnboardingController(),
           initState: getNonEmptyInitState(),
         },
       );
@@ -533,6 +549,7 @@ describe('IncomingTransactionsController', function () {
           blockTracker: getMockBlockTracker(),
           ...getMockNetworkControllerMethods(CHAIN_IDS.GOERLI),
           preferencesController: getMockPreferencesController(),
+          onboardingController: getMockOnboardingController(),
           initState: getNonEmptyInitState(),
         },
       );
@@ -624,6 +641,7 @@ describe('IncomingTransactionsController', function () {
           blockTracker: { ...getMockBlockTracker() },
           ...getMockNetworkControllerMethods(),
           preferencesController: getMockPreferencesController(),
+          onboardingController: getMockOnboardingController(),
           initState: getNonEmptyInitState(),
         },
       );
@@ -685,6 +703,7 @@ describe('IncomingTransactionsController', function () {
           blockTracker: getMockBlockTracker(),
           ...mockedNetworkMethods,
           preferencesController: getMockPreferencesController(),
+          onboardingController: getMockOnboardingController(),
           initState: getNonEmptyInitState(),
         },
       );
@@ -768,6 +787,7 @@ describe('IncomingTransactionsController', function () {
           blockTracker: getMockBlockTracker(),
           ...mockedNetworkMethods,
           preferencesController: getMockPreferencesController(),
+          onboardingController: getMockOnboardingController(),
           initState: getNonEmptyInitState(),
         },
       );
@@ -822,6 +842,7 @@ describe('IncomingTransactionsController', function () {
             blockTracker: getMockBlockTracker(),
             ...getMockNetworkControllerMethods(CHAIN_IDS.GOERLI),
             preferencesController: getMockPreferencesController(),
+            onboardingController: getMockOnboardingController(),
             initState: getEmptyInitState(),
             getCurrentChainId: () => CHAIN_IDS.GOERLI,
           });
@@ -858,6 +879,7 @@ describe('IncomingTransactionsController', function () {
             blockTracker: getMockBlockTracker(),
             ...getMockNetworkControllerMethods(CHAIN_IDS.GOERLI),
             preferencesController: getMockPreferencesController(),
+            onboardingController: getMockOnboardingController(),
             initState: getEmptyInitState(),
             getCurrentChainId: () => CHAIN_IDS.GOERLI,
           });
@@ -911,6 +933,7 @@ describe('IncomingTransactionsController', function () {
             blockTracker: getMockBlockTracker(),
             ...getMockNetworkControllerMethods(CHAIN_IDS.GOERLI),
             preferencesController: getMockPreferencesController(),
+            onboardingController: getMockOnboardingController(),
             initState: getNonEmptyInitState(),
             getCurrentChainId: () => CHAIN_IDS.GOERLI,
           });
@@ -951,6 +974,7 @@ describe('IncomingTransactionsController', function () {
           blockTracker: getMockBlockTracker(),
           ...getMockNetworkControllerMethods(CHAIN_IDS.GOERLI),
           preferencesController: getMockPreferencesController(),
+          onboardingController: getMockOnboardingController(),
           initState: getNonEmptyInitState(),
           getCurrentChainId: () => CHAIN_IDS.GOERLI,
         },
@@ -1026,6 +1050,7 @@ describe('IncomingTransactionsController', function () {
           blockTracker: getMockBlockTracker(),
           ...getMockNetworkControllerMethods(CHAIN_IDS.GOERLI),
           preferencesController: getMockPreferencesController(),
+          onboardingController: getMockOnboardingController(),
           initState: getNonEmptyInitState(),
         },
       );
@@ -1049,6 +1074,7 @@ describe('IncomingTransactionsController', function () {
           blockTracker: getMockBlockTracker(),
           ...getMockNetworkControllerMethods(CHAIN_IDS.MAINNET),
           preferencesController: getMockPreferencesController(),
+          onboardingController: getMockOnboardingController(),
           initState: getNonEmptyInitState(),
         },
       );
@@ -1072,6 +1098,7 @@ describe('IncomingTransactionsController', function () {
           blockTracker: getMockBlockTracker(),
           ...getMockNetworkControllerMethods(CHAIN_IDS.GOERLI),
           preferencesController: getMockPreferencesController(),
+          onboardingController: getMockOnboardingController(),
           initState: getNonEmptyInitState(),
         },
       );
@@ -1095,6 +1122,7 @@ describe('IncomingTransactionsController', function () {
           blockTracker: getMockBlockTracker(),
           ...getMockNetworkControllerMethods(CHAIN_IDS.GOERLI),
           preferencesController: getMockPreferencesController(),
+          onboardingController: getMockOnboardingController(),
           initState: getNonEmptyInitState(),
         },
       );
@@ -1128,6 +1156,7 @@ describe('IncomingTransactionsController', function () {
           blockTracker: getMockBlockTracker(),
           ...getMockNetworkControllerMethods(CHAIN_IDS.GOERLI),
           preferencesController: getMockPreferencesController(),
+          onboardingController: getMockOnboardingController(),
           initState: getNonEmptyInitState(),
         },
       );
@@ -1156,6 +1185,7 @@ describe('IncomingTransactionsController', function () {
           blockTracker: getMockBlockTracker(),
           ...getMockNetworkControllerMethods(CHAIN_IDS.GOERLI),
           preferencesController: getMockPreferencesController(),
+          onboardingController: getMockOnboardingController(),
           initState: getNonEmptyInitState(),
         },
       );
@@ -1179,6 +1209,7 @@ describe('IncomingTransactionsController', function () {
           blockTracker: getMockBlockTracker(),
           ...getMockNetworkControllerMethods(CHAIN_IDS.GOERLI),
           preferencesController: getMockPreferencesController(),
+          onboardingController: getMockOnboardingController(),
           initState: getNonEmptyInitState(),
         },
       );
@@ -1225,6 +1256,7 @@ describe('IncomingTransactionsController', function () {
           blockTracker: getMockBlockTracker(),
           ...getMockNetworkControllerMethods(CHAIN_IDS.GOERLI),
           preferencesController: getMockPreferencesController(),
+          onboardingController: getMockOnboardingController(),
           initState: getNonEmptyInitState(),
         },
       );
@@ -1271,6 +1303,7 @@ describe('IncomingTransactionsController', function () {
           blockTracker: getMockBlockTracker(),
           ...getMockNetworkControllerMethods(CHAIN_IDS.GOERLI),
           preferencesController: getMockPreferencesController(),
+          onboardingController: getMockOnboardingController(),
           initState: getNonEmptyInitState(),
         },
       );

--- a/app/scripts/controllers/incoming-transactions.test.js
+++ b/app/scripts/controllers/incoming-transactions.test.js
@@ -84,6 +84,7 @@ function getMockOnboardingController() {
         completedOnboarding: true,
       }),
     },
+    subscribe: sinon.spy(),
   };
 }
 

--- a/app/scripts/lib/account-tracker.js
+++ b/app/scripts/lib/account-tracker.js
@@ -86,7 +86,9 @@ export default class AccountTracker {
 
     this.onboardingController.store.subscribe(
       previousValueComparator(async (prevState, currState) => {
-        if (!prevState.completedOnboarding && currState.completedOnboarding) {
+        const { completedOnboarding: prevCompletedOnboarding } = prevState;
+        const { completedOnboarding: currCompletedOnboarding } = currState;
+        if (!prevCompletedOnboarding && currCompletedOnboarding) {
           this._updateAccounts();
         }
       }, this.onboardingController.store.getState()),

--- a/app/scripts/lib/account-tracker.js
+++ b/app/scripts/lib/account-tracker.js
@@ -30,6 +30,7 @@ import {
   SINGLE_CALL_BALANCES_ADDRESS_FANTOM,
   SINGLE_CALL_BALANCES_ADDRESS_ARBITRUM,
 } from '../constants/contracts';
+import { previousValueComparator } from './util';
 
 /**
  * This module is responsible for tracking any number of accounts and caching their current balances & transaction
@@ -79,8 +80,17 @@ export default class AccountTracker {
     this.getCurrentChainId = opts.getCurrentChainId;
     this.getNetworkIdentifier = opts.getNetworkIdentifier;
     this.preferencesController = opts.preferencesController;
+    this.onboardingController = opts.onboardingController;
 
     this.ethersProvider = new ethers.providers.Web3Provider(this._provider);
+
+    this.onboardingController.store.subscribe(
+      previousValueComparator(async (prevState, currState) => {
+        if (!prevState.completedOnboarding && currState.completedOnboarding) {
+          this._updateAccounts();
+        }
+      }, this.onboardingController.store.getState()),
+    );
   }
 
   start() {
@@ -206,6 +216,11 @@ export default class AccountTracker {
    * @returns {Promise} after all account balances updated
    */
   async _updateAccounts() {
+    const completedOnboarding =
+      this.onboardingController.store.getState().completedOnboarding;
+    if (!completedOnboarding) {
+      return;
+    }
     const { useMultiAccountBalanceChecker } =
       this.preferencesController.store.getState();
 

--- a/app/scripts/lib/account-tracker.js
+++ b/app/scripts/lib/account-tracker.js
@@ -218,8 +218,7 @@ export default class AccountTracker {
    * @returns {Promise} after all account balances updated
    */
   async _updateAccounts() {
-    const completedOnboarding =
-      this.onboardingController.store.getState().completedOnboarding;
+    const { completedOnboarding } = this.onboardingController.store.getState();
     if (!completedOnboarding) {
       return;
     }

--- a/app/scripts/lib/util.js
+++ b/app/scripts/lib/util.js
@@ -218,3 +218,31 @@ export function deferredPromise() {
   });
   return { promise, resolve, reject };
 }
+
+/**
+ * Returns a function with arity 1 that caches the argument that the function
+ * is called with and invokes the comparator with both the cached, previous,
+ * value and the current value. If specified, the initialValue will be passed
+ * in as the previous value on the first invocation of the returned method.
+ *
+ * @template A - The type of the compared value.
+ * @param {(prevValue: A, nextValue: A) => void} comparator - A method to compare
+ * the previous and next values.
+ * @param {A} [initialValue] - The initial value to supply to prevValue
+ * on first call of the method.
+ */
+export function previousValueComparator(comparator, initialValue) {
+  let first = true;
+  let cache;
+  return (value) => {
+    try {
+      if (first) {
+        first = false;
+        return comparator(initialValue ?? value, value);
+      }
+      return comparator(cache, value);
+    } finally {
+      cache = value;
+    }
+  };
+}

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -562,8 +562,8 @@ export default class MetamaskController extends EventEmitter {
 
     // start and stop polling for balances based on activeControllerConnections
     this.on('controllerConnectionChanged', (activeControllerConnections) => {
-      const completedOnboarding =
-        this.onboardingController.store.getState().completedOnboarding;
+      const { completedOnboarding } =
+        this.onboardingController.store.getState();
       if (activeControllerConnections > 0 && completedOnboarding) {
         this.triggerNetworkrequests();
       } else {

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -573,7 +573,9 @@ export default class MetamaskController extends EventEmitter {
 
     this.onboardingController.store.subscribe(
       previousValueComparator(async (prevState, currState) => {
-        if (!prevState.completedOnboarding && currState.completedOnboarding) {
+        const { completedOnboarding: prevCompletedOnboarding } = prevState;
+        const { completedOnboarding: currCompletedOnboarding } = currState;
+        if (!prevCompletedOnboarding && currCompletedOnboarding) {
           this.triggerNetworkrequests();
         }
       }, this.onboardingController.store.getState()),

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -146,6 +146,7 @@ import seedPhraseVerifier from './lib/seed-phrase-verifier';
 import MetaMetricsController from './controllers/metametrics';
 import { segment } from './lib/segment';
 import createMetaRPCHandler from './lib/createMetaRPCHandler';
+import { previousValueComparator } from './lib/util';
 
 import {
   CaveatMutatorFactories,
@@ -527,6 +528,10 @@ export default class MetamaskController extends EventEmitter {
       ),
     });
 
+    this.onboardingController = new OnboardingController({
+      initState: initState.OnboardingController,
+    });
+
     this.incomingTransactionsController = new IncomingTransactionsController({
       blockTracker: this.blockTracker,
       onNetworkDidChange: this.networkController.on.bind(
@@ -537,6 +542,7 @@ export default class MetamaskController extends EventEmitter {
         this.networkController,
       ),
       preferencesController: this.preferencesController,
+      onboardingController: this.onboardingController,
       initState: initState.IncomingTransactionsController,
     });
 
@@ -551,26 +557,27 @@ export default class MetamaskController extends EventEmitter {
         this.networkController,
       ),
       preferencesController: this.preferencesController,
+      onboardingController: this.onboardingController,
     });
 
     // start and stop polling for balances based on activeControllerConnections
     this.on('controllerConnectionChanged', (activeControllerConnections) => {
-      if (activeControllerConnections > 0) {
-        this.accountTracker.start();
-        this.incomingTransactionsController.start();
-        this.currencyRateController.start();
-        if (this.preferencesController.store.getState().useTokenDetection) {
-          this.tokenListController.start();
-        }
+      const completedOnboarding =
+        this.onboardingController.store.getState().completedOnboarding;
+      if (activeControllerConnections > 0 && completedOnboarding) {
+        this.triggerNetworkrequests();
       } else {
-        this.accountTracker.stop();
-        this.incomingTransactionsController.stop();
-        this.currencyRateController.stop();
-        if (this.preferencesController.store.getState().useTokenDetection) {
-          this.tokenListController.stop();
-        }
+        this.stopNetworkRequests();
       }
     });
+
+    this.onboardingController.store.subscribe(
+      previousValueComparator(async (prevState, currState) => {
+        if (!prevState.completedOnboarding && currState.completedOnboarding) {
+          this.triggerNetworkrequests();
+        }
+      }, this.onboardingController.store.getState()),
+    );
 
     this.cachedBalancesController = new CachedBalancesController({
       accountTracker: this.accountTracker,
@@ -578,10 +585,6 @@ export default class MetamaskController extends EventEmitter {
         this.networkController,
       ),
       initState: initState.CachedBalancesController,
-    });
-
-    this.onboardingController = new OnboardingController({
-      initState: initState.OnboardingController,
     });
 
     this.tokensController.hub.on('pendingSuggestedAsset', async () => {
@@ -1189,6 +1192,24 @@ export default class MetamaskController extends EventEmitter {
     this.extension.runtime.onMessageExternal.addListener(onMessageReceived);
     // Fire a ping message to check if other extensions are running
     checkForMultipleVersionsRunning();
+  }
+
+  triggerNetworkrequests() {
+    this.accountTracker.start();
+    this.incomingTransactionsController.start();
+    this.currencyRateController.start();
+    if (this.preferencesController.store.getState().useTokenDetection) {
+      this.tokenListController.start();
+    }
+  }
+
+  stopNetworkRequests() {
+    this.accountTracker.stop();
+    this.incomingTransactionsController.stop();
+    this.currencyRateController.stop();
+    if (this.preferencesController.store.getState().useTokenDetection) {
+      this.tokenListController.stop();
+    }
   }
 
   resetStates(resetMethods) {


### PR DESCRIPTION
Fixes: #16705

Network requests (except segment) should only be started after onboarding is completed.