### PR TITLE
remove network name from analytics

### DIFF
--- a/app/scripts/lib/rpc-method-middleware/handlers/add-ethereum-chain.js
+++ b/app/scripts/lib/rpc-method-middleware/handlers/add-ethereum-chain.js
@@ -297,7 +297,6 @@ async function addEthereumChainHandler(
       },
       properties: {
         chain_id: _chainId,
-        network_name: _chainName,
         symbol: ticker,
         source: EVENT.SOURCE.TRANSACTION.DAPP,
       },

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -2142,7 +2142,6 @@ export default class MetamaskController extends EventEmitter {
       },
       properties: {
         chain_id: chainId,
-        network_name: chainName,
         symbol: ticker,
         source: EVENT.SOURCE.NETWORK.POPULAR_NETWORK_LIST,
       },

--- a/ui/pages/settings/networks-tab/networks-form/networks-form.js
+++ b/ui/pages/settings/networks-tab/networks-form/networks-form.js
@@ -539,7 +539,6 @@ const NetworksForm = ({
           },
           properties: {
             chain_id: addHexPrefix(Number(chainId).toString(16)),
-            network_name: networkName,
             symbol: ticker,
             source: EVENT.SOURCE.NETWORK.CUSTOM_NETWORK_FORM,
           },


### PR DESCRIPTION
## Explanation
Fixes #16754 

In #16710 @legobeat commented that we should also remove network_name from our analytics. My original argument against doing it in that pull request was that it isn't secret containing. @legobeat reached out in direct message on slack to elaborate on his reasoning, which aligns exactly with @MicahZoltu 's comments in #16754. This pull request simply removes the network_name field from the analytics payload. 

## Manual Testing Steps

1. Run the extension locally with the mock segment server or the development segment writekey
2. Trigger a network added event
3. Examine the payload and see that it does not contain the network_name.

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
