### PR TITLE
[GridPlus] Bumps `gridplus-sdk` to v2.4.0

### DIFF
--- a/lavamoat/browserify/beta/policy.json
+++ b/lavamoat/browserify/beta/policy.json
@@ -612,11 +612,6 @@
         "@ethersproject/bignumber>@ethersproject/logger": true
       }
     },
-    "@metamask/assets-controllers>abort-controller": {
-      "globals": {
-        "AbortController": true
-      }
-    },
     "@metamask/assets-controllers>async-mutex": {
       "globals": {
         "setTimeout": true
@@ -2832,7 +2827,6 @@
     "eth-query": {
       "packages": {
         "eth-query>json-rpc-random-id": true,
-        "nock>debug": true,
         "watchify>xtend": true
       }
     },

--- a/lavamoat/browserify/beta/policy.json
+++ b/lavamoat/browserify/beta/policy.json
@@ -612,6 +612,11 @@
         "@ethersproject/bignumber>@ethersproject/logger": true
       }
     },
+    "@metamask/assets-controllers>abort-controller": {
+      "globals": {
+        "AbortController": true
+      }
+    },
     "@metamask/assets-controllers>async-mutex": {
       "globals": {
         "setTimeout": true
@@ -2690,6 +2695,7 @@
         "bn.js": true,
         "browserify>buffer": true,
         "browserify>process": true,
+        "eth-lattice-keyring>gridplus-sdk>@chainsafe/ssz": true,
         "eth-lattice-keyring>gridplus-sdk>@ethereumjs/common": true,
         "eth-lattice-keyring>gridplus-sdk>@ethereumjs/tx": true,
         "eth-lattice-keyring>gridplus-sdk>bech32": true,
@@ -2699,12 +2705,35 @@
         "eth-lattice-keyring>gridplus-sdk>eth-eip712-util-browser": true,
         "eth-lattice-keyring>gridplus-sdk>js-sha3": true,
         "eth-lattice-keyring>gridplus-sdk>rlp": true,
+        "eth-lattice-keyring>gridplus-sdk>uuid": true,
         "ethereumjs-wallet>aes-js": true,
         "ethereumjs-wallet>bs58check": true,
         "ethers>@ethersproject/sha2>hash.js": true,
         "ethers>@ethersproject/signing-key>elliptic": true,
         "ganache>secp256k1": true,
         "lodash": true
+      }
+    },
+    "eth-lattice-keyring>gridplus-sdk>@chainsafe/ssz": {
+      "packages": {
+        "browserify>buffer": true,
+        "eth-lattice-keyring>gridplus-sdk>@chainsafe/ssz>@chainsafe/as-sha256": true,
+        "eth-lattice-keyring>gridplus-sdk>@chainsafe/ssz>@chainsafe/persistent-merkle-tree": true,
+        "eth-lattice-keyring>gridplus-sdk>@chainsafe/ssz>case": true
+      }
+    },
+    "eth-lattice-keyring>gridplus-sdk>@chainsafe/ssz>@chainsafe/as-sha256": {
+      "globals": {
+        "WebAssembly.Instance": true,
+        "WebAssembly.Module": true
+      }
+    },
+    "eth-lattice-keyring>gridplus-sdk>@chainsafe/ssz>@chainsafe/persistent-merkle-tree": {
+      "globals": {
+        "WeakRef": true
+      },
+      "packages": {
+        "eth-lattice-keyring>gridplus-sdk>@chainsafe/ssz>@chainsafe/as-sha256": true
       }
     },
     "eth-lattice-keyring>gridplus-sdk>@ethereumjs/common": {
@@ -2814,6 +2843,11 @@
         "TextEncoder": true
       }
     },
+    "eth-lattice-keyring>gridplus-sdk>uuid": {
+      "globals": {
+        "crypto": true
+      }
+    },
     "eth-lattice-keyring>rlp": {
       "globals": {
         "TextEncoder": true
@@ -2827,6 +2861,7 @@
     "eth-query": {
       "packages": {
         "eth-query>json-rpc-random-id": true,
+        "nock>debug": true,
         "watchify>xtend": true
       }
     },

--- a/lavamoat/browserify/flask/policy.json
+++ b/lavamoat/browserify/flask/policy.json
@@ -757,6 +757,11 @@
         "@ethersproject/bignumber>@ethersproject/logger": true
       }
     },
+    "@metamask/assets-controllers>abort-controller": {
+      "globals": {
+        "AbortController": true
+      }
+    },
     "@metamask/assets-controllers>async-mutex": {
       "globals": {
         "setTimeout": true
@@ -3218,6 +3223,7 @@
         "bn.js": true,
         "browserify>buffer": true,
         "browserify>process": true,
+        "eth-lattice-keyring>gridplus-sdk>@chainsafe/ssz": true,
         "eth-lattice-keyring>gridplus-sdk>@ethereumjs/common": true,
         "eth-lattice-keyring>gridplus-sdk>@ethereumjs/tx": true,
         "eth-lattice-keyring>gridplus-sdk>bech32": true,
@@ -3227,12 +3233,35 @@
         "eth-lattice-keyring>gridplus-sdk>eth-eip712-util-browser": true,
         "eth-lattice-keyring>gridplus-sdk>js-sha3": true,
         "eth-lattice-keyring>gridplus-sdk>rlp": true,
+        "eth-lattice-keyring>gridplus-sdk>uuid": true,
         "ethereumjs-wallet>aes-js": true,
         "ethereumjs-wallet>bs58check": true,
         "ethers>@ethersproject/sha2>hash.js": true,
         "ethers>@ethersproject/signing-key>elliptic": true,
         "ganache>secp256k1": true,
         "lodash": true
+      }
+    },
+    "eth-lattice-keyring>gridplus-sdk>@chainsafe/ssz": {
+      "packages": {
+        "browserify>buffer": true,
+        "eth-lattice-keyring>gridplus-sdk>@chainsafe/ssz>@chainsafe/as-sha256": true,
+        "eth-lattice-keyring>gridplus-sdk>@chainsafe/ssz>@chainsafe/persistent-merkle-tree": true,
+        "eth-lattice-keyring>gridplus-sdk>@chainsafe/ssz>case": true
+      }
+    },
+    "eth-lattice-keyring>gridplus-sdk>@chainsafe/ssz>@chainsafe/as-sha256": {
+      "globals": {
+        "WebAssembly.Instance": true,
+        "WebAssembly.Module": true
+      }
+    },
+    "eth-lattice-keyring>gridplus-sdk>@chainsafe/ssz>@chainsafe/persistent-merkle-tree": {
+      "globals": {
+        "WeakRef": true
+      },
+      "packages": {
+        "eth-lattice-keyring>gridplus-sdk>@chainsafe/ssz>@chainsafe/as-sha256": true
       }
     },
     "eth-lattice-keyring>gridplus-sdk>@ethereumjs/common": {
@@ -3342,6 +3371,11 @@
         "TextEncoder": true
       }
     },
+    "eth-lattice-keyring>gridplus-sdk>uuid": {
+      "globals": {
+        "crypto": true
+      }
+    },
     "eth-lattice-keyring>rlp": {
       "globals": {
         "TextEncoder": true
@@ -3355,6 +3389,7 @@
     "eth-query": {
       "packages": {
         "eth-query>json-rpc-random-id": true,
+        "nock>debug": true,
         "watchify>xtend": true
       }
     },

--- a/lavamoat/browserify/flask/policy.json
+++ b/lavamoat/browserify/flask/policy.json
@@ -757,11 +757,6 @@
         "@ethersproject/bignumber>@ethersproject/logger": true
       }
     },
-    "@metamask/assets-controllers>abort-controller": {
-      "globals": {
-        "AbortController": true
-      }
-    },
     "@metamask/assets-controllers>async-mutex": {
       "globals": {
         "setTimeout": true
@@ -3360,7 +3355,6 @@
     "eth-query": {
       "packages": {
         "eth-query>json-rpc-random-id": true,
-        "nock>debug": true,
         "watchify>xtend": true
       }
     },

--- a/lavamoat/browserify/main/policy.json
+++ b/lavamoat/browserify/main/policy.json
@@ -612,11 +612,6 @@
         "@ethersproject/bignumber>@ethersproject/logger": true
       }
     },
-    "@metamask/assets-controllers>abort-controller": {
-      "globals": {
-        "AbortController": true
-      }
-    },
     "@metamask/assets-controllers>async-mutex": {
       "globals": {
         "setTimeout": true
@@ -2832,7 +2827,6 @@
     "eth-query": {
       "packages": {
         "eth-query>json-rpc-random-id": true,
-        "nock>debug": true,
         "watchify>xtend": true
       }
     },

--- a/lavamoat/browserify/main/policy.json
+++ b/lavamoat/browserify/main/policy.json
@@ -612,6 +612,11 @@
         "@ethersproject/bignumber>@ethersproject/logger": true
       }
     },
+    "@metamask/assets-controllers>abort-controller": {
+      "globals": {
+        "AbortController": true
+      }
+    },
     "@metamask/assets-controllers>async-mutex": {
       "globals": {
         "setTimeout": true
@@ -2690,6 +2695,7 @@
         "bn.js": true,
         "browserify>buffer": true,
         "browserify>process": true,
+        "eth-lattice-keyring>gridplus-sdk>@chainsafe/ssz": true,
         "eth-lattice-keyring>gridplus-sdk>@ethereumjs/common": true,
         "eth-lattice-keyring>gridplus-sdk>@ethereumjs/tx": true,
         "eth-lattice-keyring>gridplus-sdk>bech32": true,
@@ -2699,12 +2705,35 @@
         "eth-lattice-keyring>gridplus-sdk>eth-eip712-util-browser": true,
         "eth-lattice-keyring>gridplus-sdk>js-sha3": true,
         "eth-lattice-keyring>gridplus-sdk>rlp": true,
+        "eth-lattice-keyring>gridplus-sdk>uuid": true,
         "ethereumjs-wallet>aes-js": true,
         "ethereumjs-wallet>bs58check": true,
         "ethers>@ethersproject/sha2>hash.js": true,
         "ethers>@ethersproject/signing-key>elliptic": true,
         "ganache>secp256k1": true,
         "lodash": true
+      }
+    },
+    "eth-lattice-keyring>gridplus-sdk>@chainsafe/ssz": {
+      "packages": {
+        "browserify>buffer": true,
+        "eth-lattice-keyring>gridplus-sdk>@chainsafe/ssz>@chainsafe/as-sha256": true,
+        "eth-lattice-keyring>gridplus-sdk>@chainsafe/ssz>@chainsafe/persistent-merkle-tree": true,
+        "eth-lattice-keyring>gridplus-sdk>@chainsafe/ssz>case": true
+      }
+    },
+    "eth-lattice-keyring>gridplus-sdk>@chainsafe/ssz>@chainsafe/as-sha256": {
+      "globals": {
+        "WebAssembly.Instance": true,
+        "WebAssembly.Module": true
+      }
+    },
+    "eth-lattice-keyring>gridplus-sdk>@chainsafe/ssz>@chainsafe/persistent-merkle-tree": {
+      "globals": {
+        "WeakRef": true
+      },
+      "packages": {
+        "eth-lattice-keyring>gridplus-sdk>@chainsafe/ssz>@chainsafe/as-sha256": true
       }
     },
     "eth-lattice-keyring>gridplus-sdk>@ethereumjs/common": {
@@ -2814,6 +2843,11 @@
         "TextEncoder": true
       }
     },
+    "eth-lattice-keyring>gridplus-sdk>uuid": {
+      "globals": {
+        "crypto": true
+      }
+    },
     "eth-lattice-keyring>rlp": {
       "globals": {
         "TextEncoder": true
@@ -2827,6 +2861,7 @@
     "eth-query": {
       "packages": {
         "eth-query>json-rpc-random-id": true,
+        "nock>debug": true,
         "watchify>xtend": true
       }
     },

--- a/lavamoat/build-system/policy.json
+++ b/lavamoat/build-system/policy.json
@@ -1002,12 +1002,12 @@
         "path.join": true
       },
       "globals": {
-        "Buffer": true
+        "Buffer.from": true
       }
     },
     "@lavamoat/lavapack>combine-source-map>inline-source-map": {
       "globals": {
-        "Buffer": true
+        "Buffer.from": true
       },
       "packages": {
         "@lavamoat/lavapack>combine-source-map>inline-source-map>source-map": true
@@ -1040,6 +1040,16 @@
     "@metamask/jazzicon>color>color-convert": {
       "packages": {
         "@metamask/jazzicon>color>color-convert>color-name": true
+      }
+    },
+    "@storybook/addon-essentials>@storybook/addon-docs>remark-slug>unist-util-visit": {
+      "packages": {
+        "@storybook/addon-essentials>@storybook/addon-docs>remark-slug>unist-util-visit>unist-util-visit-parents": true
+      }
+    },
+    "@storybook/addon-essentials>@storybook/addon-docs>remark-slug>unist-util-visit>unist-util-visit-parents": {
+      "packages": {
+        "stylelint>@stylelint/postcss-markdown>unist-util-find-all-after>unist-util-is": true
       }
     },
     "@storybook/api>telejson>is-symbol": {
@@ -2180,13 +2190,6 @@
         "string.prototype.matchall>es-abstract": true
       }
     },
-    "enzyme>object.values": {
-      "packages": {
-        "globalthis>define-properties": true,
-        "string.prototype.matchall>call-bind": true,
-        "string.prototype.matchall>es-abstract": true
-      }
-    },
     "eslint": {
       "builtin": {
         "assert": true,
@@ -2762,7 +2765,6 @@
         "eslint-plugin-react-hooks": true,
         "eslint>ajv": true,
         "eslint>globals": true,
-        "eslint>import-fresh": true,
         "eslint>minimatch": true,
         "eslint>strip-json-comments": true,
         "globby>ignore": true,
@@ -3687,7 +3689,8 @@
         "path.sep": true
       },
       "globals": {
-        "Buffer": true
+        "Buffer.concat": true,
+        "Buffer.from": true
       },
       "packages": {
         "gulp-sourcemaps>@gulp-sourcemaps/identity-map": true,
@@ -6880,6 +6883,12 @@
         "loose-envify>js-tokens": true
       }
     },
+    "madge>detective-scss>gonzales-pe": {
+      "globals": {
+        "console.error": true,
+        "define": true
+      }
+    },
     "madge>ora>is-unicode-supported": {
       "globals": {
         "process.env.CI": true,
@@ -7462,6 +7471,8 @@
         "lodash": true,
         "nock>debug": true,
         "nyc>resolve-from": true,
+        "stylelint>@stylelint/postcss-css-in-js": true,
+        "stylelint>@stylelint/postcss-markdown": true,
         "stylelint>autoprefixer": true,
         "stylelint>balanced-match": true,
         "stylelint>chalk": true,
@@ -7479,19 +7490,170 @@
         "stylelint>micromatch": true,
         "stylelint>normalize-selector": true,
         "stylelint>postcss": true,
+        "stylelint>postcss-html": true,
+        "stylelint>postcss-less": true,
         "stylelint>postcss-media-query-parser": true,
         "stylelint>postcss-reporter": true,
         "stylelint>postcss-resolve-nested-selector": true,
         "stylelint>postcss-safe-parser": true,
+        "stylelint>postcss-sass": true,
+        "stylelint>postcss-scss": true,
         "stylelint>postcss-selector-parser": true,
         "stylelint>postcss-syntax": true,
         "stylelint>postcss-value-parser": true,
         "stylelint>specificity": true,
         "stylelint>style-search": true,
+        "stylelint>sugarss": true,
         "stylelint>svg-tags": true,
         "stylelint>table": true,
         "stylelint>write-file-atomic": true,
         "yargs>string-width": true
+      }
+    },
+    "stylelint>@stylelint/postcss-css-in-js": {
+      "globals": {
+        "__dirname": true
+      },
+      "packages": {
+        "@babel/core": true,
+        "stylelint>postcss": true,
+        "stylelint>postcss-syntax": true
+      }
+    },
+    "stylelint>@stylelint/postcss-markdown": {
+      "packages": {
+        "stylelint>@stylelint/postcss-markdown>remark": true,
+        "stylelint>@stylelint/postcss-markdown>unist-util-find-all-after": true,
+        "stylelint>postcss-html": true,
+        "stylelint>postcss-syntax": true
+      }
+    },
+    "stylelint>@stylelint/postcss-markdown>remark": {
+      "packages": {
+        "stylelint>@stylelint/postcss-markdown>remark>remark-parse": true,
+        "stylelint>@stylelint/postcss-markdown>remark>remark-stringify": true,
+        "stylelint>@stylelint/postcss-markdown>remark>unified": true
+      }
+    },
+    "stylelint>@stylelint/postcss-markdown>remark>remark-parse": {
+      "packages": {
+        "stylelint>@stylelint/postcss-markdown>remark>remark-parse>ccount": true,
+        "stylelint>@stylelint/postcss-markdown>remark>remark-parse>collapse-white-space": true,
+        "stylelint>@stylelint/postcss-markdown>remark>remark-parse>is-alphabetical": true,
+        "stylelint>@stylelint/postcss-markdown>remark>remark-parse>is-decimal": true,
+        "stylelint>@stylelint/postcss-markdown>remark>remark-parse>is-whitespace-character": true,
+        "stylelint>@stylelint/postcss-markdown>remark>remark-parse>is-word-character": true,
+        "stylelint>@stylelint/postcss-markdown>remark>remark-parse>markdown-escapes": true,
+        "stylelint>@stylelint/postcss-markdown>remark>remark-parse>parse-entities": true,
+        "stylelint>@stylelint/postcss-markdown>remark>remark-parse>repeat-string": true,
+        "stylelint>@stylelint/postcss-markdown>remark>remark-parse>state-toggle": true,
+        "stylelint>@stylelint/postcss-markdown>remark>remark-parse>trim": true,
+        "stylelint>@stylelint/postcss-markdown>remark>remark-parse>trim-trailing-lines": true,
+        "stylelint>@stylelint/postcss-markdown>remark>remark-parse>unherit": true,
+        "stylelint>@stylelint/postcss-markdown>remark>remark-parse>unist-util-remove-position": true,
+        "stylelint>@stylelint/postcss-markdown>remark>remark-parse>vfile-location": true,
+        "watchify>xtend": true
+      }
+    },
+    "stylelint>@stylelint/postcss-markdown>remark>remark-parse>parse-entities": {
+      "packages": {
+        "stylelint>@stylelint/postcss-markdown>remark>remark-parse>is-decimal": true,
+        "stylelint>@stylelint/postcss-markdown>remark>remark-parse>parse-entities>character-entities": true,
+        "stylelint>@stylelint/postcss-markdown>remark>remark-parse>parse-entities>character-entities-legacy": true,
+        "stylelint>@stylelint/postcss-markdown>remark>remark-parse>parse-entities>character-reference-invalid": true,
+        "stylelint>@stylelint/postcss-markdown>remark>remark-parse>parse-entities>is-alphanumerical": true,
+        "stylelint>@stylelint/postcss-markdown>remark>remark-parse>parse-entities>is-hexadecimal": true
+      }
+    },
+    "stylelint>@stylelint/postcss-markdown>remark>remark-parse>parse-entities>is-alphanumerical": {
+      "packages": {
+        "stylelint>@stylelint/postcss-markdown>remark>remark-parse>is-alphabetical": true,
+        "stylelint>@stylelint/postcss-markdown>remark>remark-parse>is-decimal": true
+      }
+    },
+    "stylelint>@stylelint/postcss-markdown>remark>remark-parse>unherit": {
+      "packages": {
+        "pumpify>inherits": true,
+        "watchify>xtend": true
+      }
+    },
+    "stylelint>@stylelint/postcss-markdown>remark>remark-parse>unist-util-remove-position": {
+      "packages": {
+        "@storybook/addon-essentials>@storybook/addon-docs>remark-slug>unist-util-visit": true
+      }
+    },
+    "stylelint>@stylelint/postcss-markdown>remark>remark-stringify": {
+      "packages": {
+        "stylelint>@stylelint/postcss-markdown>remark>remark-parse>ccount": true,
+        "stylelint>@stylelint/postcss-markdown>remark>remark-parse>is-decimal": true,
+        "stylelint>@stylelint/postcss-markdown>remark>remark-parse>is-whitespace-character": true,
+        "stylelint>@stylelint/postcss-markdown>remark>remark-parse>markdown-escapes": true,
+        "stylelint>@stylelint/postcss-markdown>remark>remark-parse>parse-entities": true,
+        "stylelint>@stylelint/postcss-markdown>remark>remark-parse>repeat-string": true,
+        "stylelint>@stylelint/postcss-markdown>remark>remark-parse>state-toggle": true,
+        "stylelint>@stylelint/postcss-markdown>remark>remark-parse>unherit": true,
+        "stylelint>@stylelint/postcss-markdown>remark>remark-stringify>is-alphanumeric": true,
+        "stylelint>@stylelint/postcss-markdown>remark>remark-stringify>longest-streak": true,
+        "stylelint>@stylelint/postcss-markdown>remark>remark-stringify>markdown-table": true,
+        "stylelint>@stylelint/postcss-markdown>remark>remark-stringify>mdast-util-compact": true,
+        "stylelint>@stylelint/postcss-markdown>remark>remark-stringify>stringify-entities": true,
+        "watchify>xtend": true
+      }
+    },
+    "stylelint>@stylelint/postcss-markdown>remark>remark-stringify>markdown-table": {
+      "packages": {
+        "stylelint>@stylelint/postcss-markdown>remark>remark-parse>repeat-string": true
+      }
+    },
+    "stylelint>@stylelint/postcss-markdown>remark>remark-stringify>mdast-util-compact": {
+      "packages": {
+        "@storybook/addon-essentials>@storybook/addon-docs>remark-slug>unist-util-visit": true
+      }
+    },
+    "stylelint>@stylelint/postcss-markdown>remark>remark-stringify>stringify-entities": {
+      "packages": {
+        "stylelint>@stylelint/postcss-markdown>remark>remark-parse>is-decimal": true,
+        "stylelint>@stylelint/postcss-markdown>remark>remark-parse>parse-entities>character-entities-legacy": true,
+        "stylelint>@stylelint/postcss-markdown>remark>remark-parse>parse-entities>is-alphanumerical": true,
+        "stylelint>@stylelint/postcss-markdown>remark>remark-parse>parse-entities>is-hexadecimal": true,
+        "stylelint>@stylelint/postcss-markdown>remark>remark-stringify>stringify-entities>character-entities-html4": true
+      }
+    },
+    "stylelint>@stylelint/postcss-markdown>remark>unified": {
+      "packages": {
+        "jsdom>request>extend": true,
+        "stylelint>@stylelint/postcss-markdown>remark>unified>bail": true,
+        "stylelint>@stylelint/postcss-markdown>remark>unified>is-buffer": true,
+        "stylelint>@stylelint/postcss-markdown>remark>unified>is-plain-obj": true,
+        "stylelint>@stylelint/postcss-markdown>remark>unified>trough": true,
+        "stylelint>@stylelint/postcss-markdown>remark>unified>vfile": true
+      }
+    },
+    "stylelint>@stylelint/postcss-markdown>remark>unified>vfile": {
+      "builtin": {
+        "path.basename": true,
+        "path.dirname": true,
+        "path.extname": true,
+        "path.join": true,
+        "path.sep": true
+      },
+      "globals": {
+        "process.cwd": true
+      },
+      "packages": {
+        "stylelint>@stylelint/postcss-markdown>remark>unified>vfile>is-buffer": true,
+        "stylelint>@stylelint/postcss-markdown>remark>unified>vfile>vfile-message": true,
+        "vinyl>replace-ext": true
+      }
+    },
+    "stylelint>@stylelint/postcss-markdown>remark>unified>vfile>vfile-message": {
+      "packages": {
+        "stylelint>@stylelint/postcss-markdown>remark>unified>vfile>unist-util-stringify-position": true
+      }
+    },
+    "stylelint>@stylelint/postcss-markdown>unist-util-find-all-after": {
+      "packages": {
+        "stylelint>@stylelint/postcss-markdown>unist-util-find-all-after>unist-util-is": true
       }
     },
     "stylelint>autoprefixer": {
@@ -7693,12 +7855,88 @@
         "stylelint>postcss>source-map": true
       }
     },
+    "stylelint>postcss-html": {
+      "globals": {
+        "__dirname": true
+      },
+      "packages": {
+        "stylelint>postcss-html>htmlparser2": true,
+        "stylelint>postcss-syntax": true
+      }
+    },
+    "stylelint>postcss-html>htmlparser2": {
+      "builtin": {
+        "buffer.Buffer": true,
+        "events.EventEmitter": true,
+        "string_decoder.StringDecoder": true
+      },
+      "packages": {
+        "pumpify>inherits": true,
+        "stylelint>postcss-html>htmlparser2>domelementtype": true,
+        "stylelint>postcss-html>htmlparser2>domhandler": true,
+        "stylelint>postcss-html>htmlparser2>domutils": true,
+        "stylelint>postcss-html>htmlparser2>entities": true,
+        "stylelint>postcss-html>htmlparser2>readable-stream": true
+      }
+    },
+    "stylelint>postcss-html>htmlparser2>domhandler": {
+      "packages": {
+        "stylelint>postcss-html>htmlparser2>domelementtype": true
+      }
+    },
+    "stylelint>postcss-html>htmlparser2>domutils": {
+      "packages": {
+        "stylelint>postcss-html>htmlparser2>domelementtype": true,
+        "stylelint>postcss-html>htmlparser2>domutils>dom-serializer": true
+      }
+    },
+    "stylelint>postcss-html>htmlparser2>domutils>dom-serializer": {
+      "packages": {
+        "stylelint>postcss-html>htmlparser2>domelementtype": true,
+        "stylelint>postcss-html>htmlparser2>entities": true
+      }
+    },
+    "stylelint>postcss-html>htmlparser2>readable-stream": {
+      "builtin": {
+        "buffer.Buffer": true,
+        "events.EventEmitter": true,
+        "stream": true,
+        "util": true
+      },
+      "globals": {
+        "process.env.READABLE_STREAM": true,
+        "process.nextTick": true,
+        "process.stderr": true,
+        "process.stdout": true
+      },
+      "packages": {
+        "@storybook/api>util-deprecate": true,
+        "browserify>string_decoder": true,
+        "pumpify>inherits": true
+      }
+    },
+    "stylelint>postcss-less": {
+      "packages": {
+        "stylelint>postcss": true
+      }
+    },
     "stylelint>postcss-reporter": {
       "packages": {
         "lodash": true
       }
     },
     "stylelint>postcss-safe-parser": {
+      "packages": {
+        "stylelint>postcss": true
+      }
+    },
+    "stylelint>postcss-sass": {
+      "packages": {
+        "madge>detective-scss>gonzales-pe": true,
+        "stylelint>postcss": true
+      }
+    },
+    "stylelint>postcss-scss": {
       "packages": {
         "stylelint>postcss": true
       }
@@ -7732,6 +7970,11 @@
     "stylelint>specificity": {
       "globals": {
         "define": true
+      }
+    },
+    "stylelint>sugarss": {
+      "packages": {
+        "stylelint>postcss": true
       }
     },
     "stylelint>table": {

--- a/lavamoat/build-system/policy.json
+++ b/lavamoat/build-system/policy.json
@@ -1002,12 +1002,12 @@
         "path.join": true
       },
       "globals": {
-        "Buffer.from": true
+        "Buffer": true
       }
     },
     "@lavamoat/lavapack>combine-source-map>inline-source-map": {
       "globals": {
-        "Buffer.from": true
+        "Buffer": true
       },
       "packages": {
         "@lavamoat/lavapack>combine-source-map>inline-source-map>source-map": true
@@ -1040,16 +1040,6 @@
     "@metamask/jazzicon>color>color-convert": {
       "packages": {
         "@metamask/jazzicon>color>color-convert>color-name": true
-      }
-    },
-    "@storybook/addon-essentials>@storybook/addon-docs>remark-slug>unist-util-visit": {
-      "packages": {
-        "@storybook/addon-essentials>@storybook/addon-docs>remark-slug>unist-util-visit>unist-util-visit-parents": true
-      }
-    },
-    "@storybook/addon-essentials>@storybook/addon-docs>remark-slug>unist-util-visit>unist-util-visit-parents": {
-      "packages": {
-        "stylelint>@stylelint/postcss-markdown>unist-util-find-all-after>unist-util-is": true
       }
     },
     "@storybook/api>telejson>is-symbol": {
@@ -2190,6 +2180,13 @@
         "string.prototype.matchall>es-abstract": true
       }
     },
+    "enzyme>object.values": {
+      "packages": {
+        "globalthis>define-properties": true,
+        "string.prototype.matchall>call-bind": true,
+        "string.prototype.matchall>es-abstract": true
+      }
+    },
     "eslint": {
       "builtin": {
         "assert": true,
@@ -2765,6 +2762,7 @@
         "eslint-plugin-react-hooks": true,
         "eslint>ajv": true,
         "eslint>globals": true,
+        "eslint>import-fresh": true,
         "eslint>minimatch": true,
         "eslint>strip-json-comments": true,
         "globby>ignore": true,
@@ -3689,8 +3687,7 @@
         "path.sep": true
       },
       "globals": {
-        "Buffer.concat": true,
-        "Buffer.from": true
+        "Buffer": true
       },
       "packages": {
         "gulp-sourcemaps>@gulp-sourcemaps/identity-map": true,
@@ -6883,12 +6880,6 @@
         "loose-envify>js-tokens": true
       }
     },
-    "madge>detective-scss>gonzales-pe": {
-      "globals": {
-        "console.error": true,
-        "define": true
-      }
-    },
     "madge>ora>is-unicode-supported": {
       "globals": {
         "process.env.CI": true,
@@ -7471,8 +7462,6 @@
         "lodash": true,
         "nock>debug": true,
         "nyc>resolve-from": true,
-        "stylelint>@stylelint/postcss-css-in-js": true,
-        "stylelint>@stylelint/postcss-markdown": true,
         "stylelint>autoprefixer": true,
         "stylelint>balanced-match": true,
         "stylelint>chalk": true,
@@ -7490,170 +7479,19 @@
         "stylelint>micromatch": true,
         "stylelint>normalize-selector": true,
         "stylelint>postcss": true,
-        "stylelint>postcss-html": true,
-        "stylelint>postcss-less": true,
         "stylelint>postcss-media-query-parser": true,
         "stylelint>postcss-reporter": true,
         "stylelint>postcss-resolve-nested-selector": true,
         "stylelint>postcss-safe-parser": true,
-        "stylelint>postcss-sass": true,
-        "stylelint>postcss-scss": true,
         "stylelint>postcss-selector-parser": true,
         "stylelint>postcss-syntax": true,
         "stylelint>postcss-value-parser": true,
         "stylelint>specificity": true,
         "stylelint>style-search": true,
-        "stylelint>sugarss": true,
         "stylelint>svg-tags": true,
         "stylelint>table": true,
         "stylelint>write-file-atomic": true,
         "yargs>string-width": true
-      }
-    },
-    "stylelint>@stylelint/postcss-css-in-js": {
-      "globals": {
-        "__dirname": true
-      },
-      "packages": {
-        "@babel/core": true,
-        "stylelint>postcss": true,
-        "stylelint>postcss-syntax": true
-      }
-    },
-    "stylelint>@stylelint/postcss-markdown": {
-      "packages": {
-        "stylelint>@stylelint/postcss-markdown>remark": true,
-        "stylelint>@stylelint/postcss-markdown>unist-util-find-all-after": true,
-        "stylelint>postcss-html": true,
-        "stylelint>postcss-syntax": true
-      }
-    },
-    "stylelint>@stylelint/postcss-markdown>remark": {
-      "packages": {
-        "stylelint>@stylelint/postcss-markdown>remark>remark-parse": true,
-        "stylelint>@stylelint/postcss-markdown>remark>remark-stringify": true,
-        "stylelint>@stylelint/postcss-markdown>remark>unified": true
-      }
-    },
-    "stylelint>@stylelint/postcss-markdown>remark>remark-parse": {
-      "packages": {
-        "stylelint>@stylelint/postcss-markdown>remark>remark-parse>ccount": true,
-        "stylelint>@stylelint/postcss-markdown>remark>remark-parse>collapse-white-space": true,
-        "stylelint>@stylelint/postcss-markdown>remark>remark-parse>is-alphabetical": true,
-        "stylelint>@stylelint/postcss-markdown>remark>remark-parse>is-decimal": true,
-        "stylelint>@stylelint/postcss-markdown>remark>remark-parse>is-whitespace-character": true,
-        "stylelint>@stylelint/postcss-markdown>remark>remark-parse>is-word-character": true,
-        "stylelint>@stylelint/postcss-markdown>remark>remark-parse>markdown-escapes": true,
-        "stylelint>@stylelint/postcss-markdown>remark>remark-parse>parse-entities": true,
-        "stylelint>@stylelint/postcss-markdown>remark>remark-parse>repeat-string": true,
-        "stylelint>@stylelint/postcss-markdown>remark>remark-parse>state-toggle": true,
-        "stylelint>@stylelint/postcss-markdown>remark>remark-parse>trim": true,
-        "stylelint>@stylelint/postcss-markdown>remark>remark-parse>trim-trailing-lines": true,
-        "stylelint>@stylelint/postcss-markdown>remark>remark-parse>unherit": true,
-        "stylelint>@stylelint/postcss-markdown>remark>remark-parse>unist-util-remove-position": true,
-        "stylelint>@stylelint/postcss-markdown>remark>remark-parse>vfile-location": true,
-        "watchify>xtend": true
-      }
-    },
-    "stylelint>@stylelint/postcss-markdown>remark>remark-parse>parse-entities": {
-      "packages": {
-        "stylelint>@stylelint/postcss-markdown>remark>remark-parse>is-decimal": true,
-        "stylelint>@stylelint/postcss-markdown>remark>remark-parse>parse-entities>character-entities": true,
-        "stylelint>@stylelint/postcss-markdown>remark>remark-parse>parse-entities>character-entities-legacy": true,
-        "stylelint>@stylelint/postcss-markdown>remark>remark-parse>parse-entities>character-reference-invalid": true,
-        "stylelint>@stylelint/postcss-markdown>remark>remark-parse>parse-entities>is-alphanumerical": true,
-        "stylelint>@stylelint/postcss-markdown>remark>remark-parse>parse-entities>is-hexadecimal": true
-      }
-    },
-    "stylelint>@stylelint/postcss-markdown>remark>remark-parse>parse-entities>is-alphanumerical": {
-      "packages": {
-        "stylelint>@stylelint/postcss-markdown>remark>remark-parse>is-alphabetical": true,
-        "stylelint>@stylelint/postcss-markdown>remark>remark-parse>is-decimal": true
-      }
-    },
-    "stylelint>@stylelint/postcss-markdown>remark>remark-parse>unherit": {
-      "packages": {
-        "pumpify>inherits": true,
-        "watchify>xtend": true
-      }
-    },
-    "stylelint>@stylelint/postcss-markdown>remark>remark-parse>unist-util-remove-position": {
-      "packages": {
-        "@storybook/addon-essentials>@storybook/addon-docs>remark-slug>unist-util-visit": true
-      }
-    },
-    "stylelint>@stylelint/postcss-markdown>remark>remark-stringify": {
-      "packages": {
-        "stylelint>@stylelint/postcss-markdown>remark>remark-parse>ccount": true,
-        "stylelint>@stylelint/postcss-markdown>remark>remark-parse>is-decimal": true,
-        "stylelint>@stylelint/postcss-markdown>remark>remark-parse>is-whitespace-character": true,
-        "stylelint>@stylelint/postcss-markdown>remark>remark-parse>markdown-escapes": true,
-        "stylelint>@stylelint/postcss-markdown>remark>remark-parse>parse-entities": true,
-        "stylelint>@stylelint/postcss-markdown>remark>remark-parse>repeat-string": true,
-        "stylelint>@stylelint/postcss-markdown>remark>remark-parse>state-toggle": true,
-        "stylelint>@stylelint/postcss-markdown>remark>remark-parse>unherit": true,
-        "stylelint>@stylelint/postcss-markdown>remark>remark-stringify>is-alphanumeric": true,
-        "stylelint>@stylelint/postcss-markdown>remark>remark-stringify>longest-streak": true,
-        "stylelint>@stylelint/postcss-markdown>remark>remark-stringify>markdown-table": true,
-        "stylelint>@stylelint/postcss-markdown>remark>remark-stringify>mdast-util-compact": true,
-        "stylelint>@stylelint/postcss-markdown>remark>remark-stringify>stringify-entities": true,
-        "watchify>xtend": true
-      }
-    },
-    "stylelint>@stylelint/postcss-markdown>remark>remark-stringify>markdown-table": {
-      "packages": {
-        "stylelint>@stylelint/postcss-markdown>remark>remark-parse>repeat-string": true
-      }
-    },
-    "stylelint>@stylelint/postcss-markdown>remark>remark-stringify>mdast-util-compact": {
-      "packages": {
-        "@storybook/addon-essentials>@storybook/addon-docs>remark-slug>unist-util-visit": true
-      }
-    },
-    "stylelint>@stylelint/postcss-markdown>remark>remark-stringify>stringify-entities": {
-      "packages": {
-        "stylelint>@stylelint/postcss-markdown>remark>remark-parse>is-decimal": true,
-        "stylelint>@stylelint/postcss-markdown>remark>remark-parse>parse-entities>character-entities-legacy": true,
-        "stylelint>@stylelint/postcss-markdown>remark>remark-parse>parse-entities>is-alphanumerical": true,
-        "stylelint>@stylelint/postcss-markdown>remark>remark-parse>parse-entities>is-hexadecimal": true,
-        "stylelint>@stylelint/postcss-markdown>remark>remark-stringify>stringify-entities>character-entities-html4": true
-      }
-    },
-    "stylelint>@stylelint/postcss-markdown>remark>unified": {
-      "packages": {
-        "jsdom>request>extend": true,
-        "stylelint>@stylelint/postcss-markdown>remark>unified>bail": true,
-        "stylelint>@stylelint/postcss-markdown>remark>unified>is-buffer": true,
-        "stylelint>@stylelint/postcss-markdown>remark>unified>is-plain-obj": true,
-        "stylelint>@stylelint/postcss-markdown>remark>unified>trough": true,
-        "stylelint>@stylelint/postcss-markdown>remark>unified>vfile": true
-      }
-    },
-    "stylelint>@stylelint/postcss-markdown>remark>unified>vfile": {
-      "builtin": {
-        "path.basename": true,
-        "path.dirname": true,
-        "path.extname": true,
-        "path.join": true,
-        "path.sep": true
-      },
-      "globals": {
-        "process.cwd": true
-      },
-      "packages": {
-        "stylelint>@stylelint/postcss-markdown>remark>unified>vfile>is-buffer": true,
-        "stylelint>@stylelint/postcss-markdown>remark>unified>vfile>vfile-message": true,
-        "vinyl>replace-ext": true
-      }
-    },
-    "stylelint>@stylelint/postcss-markdown>remark>unified>vfile>vfile-message": {
-      "packages": {
-        "stylelint>@stylelint/postcss-markdown>remark>unified>vfile>unist-util-stringify-position": true
-      }
-    },
-    "stylelint>@stylelint/postcss-markdown>unist-util-find-all-after": {
-      "packages": {
-        "stylelint>@stylelint/postcss-markdown>unist-util-find-all-after>unist-util-is": true
       }
     },
     "stylelint>autoprefixer": {
@@ -7855,88 +7693,12 @@
         "stylelint>postcss>source-map": true
       }
     },
-    "stylelint>postcss-html": {
-      "globals": {
-        "__dirname": true
-      },
-      "packages": {
-        "stylelint>postcss-html>htmlparser2": true,
-        "stylelint>postcss-syntax": true
-      }
-    },
-    "stylelint>postcss-html>htmlparser2": {
-      "builtin": {
-        "buffer.Buffer": true,
-        "events.EventEmitter": true,
-        "string_decoder.StringDecoder": true
-      },
-      "packages": {
-        "pumpify>inherits": true,
-        "stylelint>postcss-html>htmlparser2>domelementtype": true,
-        "stylelint>postcss-html>htmlparser2>domhandler": true,
-        "stylelint>postcss-html>htmlparser2>domutils": true,
-        "stylelint>postcss-html>htmlparser2>entities": true,
-        "stylelint>postcss-html>htmlparser2>readable-stream": true
-      }
-    },
-    "stylelint>postcss-html>htmlparser2>domhandler": {
-      "packages": {
-        "stylelint>postcss-html>htmlparser2>domelementtype": true
-      }
-    },
-    "stylelint>postcss-html>htmlparser2>domutils": {
-      "packages": {
-        "stylelint>postcss-html>htmlparser2>domelementtype": true,
-        "stylelint>postcss-html>htmlparser2>domutils>dom-serializer": true
-      }
-    },
-    "stylelint>postcss-html>htmlparser2>domutils>dom-serializer": {
-      "packages": {
-        "stylelint>postcss-html>htmlparser2>domelementtype": true,
-        "stylelint>postcss-html>htmlparser2>entities": true
-      }
-    },
-    "stylelint>postcss-html>htmlparser2>readable-stream": {
-      "builtin": {
-        "buffer.Buffer": true,
-        "events.EventEmitter": true,
-        "stream": true,
-        "util": true
-      },
-      "globals": {
-        "process.env.READABLE_STREAM": true,
-        "process.nextTick": true,
-        "process.stderr": true,
-        "process.stdout": true
-      },
-      "packages": {
-        "@storybook/api>util-deprecate": true,
-        "browserify>string_decoder": true,
-        "pumpify>inherits": true
-      }
-    },
-    "stylelint>postcss-less": {
-      "packages": {
-        "stylelint>postcss": true
-      }
-    },
     "stylelint>postcss-reporter": {
       "packages": {
         "lodash": true
       }
     },
     "stylelint>postcss-safe-parser": {
-      "packages": {
-        "stylelint>postcss": true
-      }
-    },
-    "stylelint>postcss-sass": {
-      "packages": {
-        "madge>detective-scss>gonzales-pe": true,
-        "stylelint>postcss": true
-      }
-    },
-    "stylelint>postcss-scss": {
       "packages": {
         "stylelint>postcss": true
       }
@@ -7970,11 +7732,6 @@
     "stylelint>specificity": {
       "globals": {
         "define": true
-      }
-    },
-    "stylelint>sugarss": {
-      "packages": {
-        "stylelint>postcss": true
       }
     },
     "stylelint>table": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1193,6 +1193,27 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
+"@chainsafe/as-sha256@^0.3.1":
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/@chainsafe/as-sha256/-/as-sha256-0.3.1.tgz#3639df0e1435cab03f4d9870cc3ac079e57a6fc9"
+  integrity sha512-hldFFYuf49ed7DAakWVXSJODuq3pzJEguD8tQ7h+sGkM18vja+OFoJI9krnGmgzyuZC2ETX0NOIcCTy31v2Mtg==
+
+"@chainsafe/persistent-merkle-tree@^0.4.2":
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/@chainsafe/persistent-merkle-tree/-/persistent-merkle-tree-0.4.2.tgz#4c9ee80cc57cd3be7208d98c40014ad38f36f7ff"
+  integrity sha512-lLO3ihKPngXLTus/L7WHKaw9PnNJWizlOF1H9NNzHP6Xvh82vzg9F2bzkXhYIFshMZ2gTCEz8tq6STe7r5NDfQ==
+  dependencies:
+    "@chainsafe/as-sha256" "^0.3.1"
+
+"@chainsafe/ssz@^0.9.2":
+  version "0.9.2"
+  resolved "https://registry.yarnpkg.com/@chainsafe/ssz/-/ssz-0.9.2.tgz#6f2552db312217b911e34bcdef9057f8a3a108f2"
+  integrity sha512-r3bKiGMF7EZlsgXTyyzQbS+GJTj6MvTlY3Ms1byFZLL1H9Maht8muE2LkF3pS1zU9KY4tiJeQd+KABdhyfB9Ag==
+  dependencies:
+    "@chainsafe/as-sha256" "^0.3.1"
+    "@chainsafe/persistent-merkle-tree" "^0.4.2"
+    case "^1.6.3"
+
 "@choojs/findup@^0.2.1":
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/@choojs/findup/-/findup-0.2.1.tgz#ac13c59ae7be6e1da64de0779a0a7f03d75615a3"
@@ -1450,7 +1471,7 @@
     "@ethersproject/properties" "^5.6.0"
     "@ethersproject/strings" "^5.6.0"
 
-"@ethersproject/abi@^5.6.0", "@ethersproject/abi@^5.7.0":
+"@ethersproject/abi@^5.5.0", "@ethersproject/abi@^5.6.0", "@ethersproject/abi@^5.7.0":
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/abi/-/abi-5.7.0.tgz#b3f3e045bbbeed1af3947335c247ad625a44e449"
   integrity sha512-351ktp42TiRcYB3H1OP8yajPeAQstMW/yCFokj/AthP9bLHzQFPlOrxOcwYEDkUAICmOHljvN4K39OMTMUa9RA==
@@ -8335,6 +8356,11 @@ case-sensitive-paths-webpack-plugin@^2.3.0:
   resolved "https://registry.yarnpkg.com/case-sensitive-paths-webpack-plugin/-/case-sensitive-paths-webpack-plugin-2.4.0.tgz#db64066c6422eed2e08cc14b986ca43796dbc6d4"
   integrity sha512-roIFONhcxog0JSSWbvVAh3OocukmSgpqOH6YpMkCvav/ySIV3JKg4Dc8vYtQjYi/UxpNE36r/9v+VqTQqgkYmw==
 
+case@^1.6.3:
+  version "1.6.3"
+  resolved "https://registry.yarnpkg.com/case/-/case-1.6.3.tgz#0a4386e3e9825351ca2e6216c60467ff5f1ea1c9"
+  integrity sha512-mzDSXIPaFwVDvZAHqZ9VlbyF4yyXRuX6IvB06WvPYkqJVO24kX1PPhv9bfpKNFZyxYFmmgo03HUiD8iklmJYRQ==
+
 caseless@~0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
@@ -13620,12 +13646,14 @@ graphviz@0.0.9:
     temp "~0.4.0"
 
 gridplus-sdk@^2.2.9:
-  version "2.2.9"
-  resolved "https://registry.yarnpkg.com/gridplus-sdk/-/gridplus-sdk-2.2.9.tgz#bd98257fee13d82e19ee267dfa21cd12f81eea21"
-  integrity sha512-U39YxeLisEJmw9KCtKCQB6C8UTVRKTonhDxwcDpN8T23VZuxk2SOzdmvq/HS01l5N+p1QEKKzQF6OCFQ7nVcYA==
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/gridplus-sdk/-/gridplus-sdk-2.4.0.tgz#820e049154c8ddc9923a28340bb000f79b866ff9"
+  integrity sha512-9yYE5gUuYWl03X3gmU0ETkT3XS69MYOex2t1OOpwYBSWUWWycWa51RJz8i3nTWAB0JbQLC/Ix5uKfuHJ2xxokg==
   dependencies:
+    "@chainsafe/ssz" "^0.9.2"
     "@ethereumjs/common" "2.4.0"
     "@ethereumjs/tx" "3.3.0"
+    "@ethersproject/abi" "^5.5.0"
     aes-js "^3.1.1"
     bech32 "^2.0.0"
     bignumber.js "^9.0.1"
@@ -13640,6 +13668,7 @@ gridplus-sdk@^2.2.9:
     js-sha3 "^0.8.0"
     rlp "^3.0.0"
     secp256k1 "4.0.2"
+    uuid "^9.0.0"
 
 growl@1.10.5:
   version "1.10.5"
@@ -24753,6 +24782,11 @@ uuid@^8.3.2:
   version "8.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
+
+uuid@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.0.tgz#592f550650024a38ceb0c562f2f6aa435761efb5"
+  integrity sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==
 
 v8-compile-cache-lib@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
The only change relevant to MetaMask users is a [fix to an ABI decoding util](https://github.com/GridPlus/gridplus-sdk/pull/483/commits/23b42df0eb89d6aa04352676212a020e270b105c) that addresses an edge case that led to failed ABI decoding for certain data types.

Full changes: https://github.com/GridPlus/gridplus-sdk/compare/v2.2.9...v2.4.0