### PR TITLE
Privacy - Show default selected network after a custom network has been added during onboarding

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -2659,33 +2659,8 @@
   "onboardingMetametricsTitle": {
     "message": "Help us improve MetaMask"
   },
-  "onboardingMetametricsAnonymousText": {
-    "message": "MetaMask only collects relevant data like your country, but not your specific location. Your clicks and page views are anonymous."
-  },
-  "onboardingMetametricsAnonymousTitle": {
-    "message": "Anonymous"
-  },
-  "onboardingMetametricsFooter": {
-    "message": "This data is aggregated and is therefore anonymous for the purposes of General Data Protection Regulation (EU) 2016/679. For more information in relation to our privacy practices, please see our $1."
-  },
-  "onboardingMetametricsIntro2": {
-    "message": "When we gather metrics, it's always:"
-  },
   "onboardingMetametricsModalTitle": {
     "message": "Add custom network"
-  },
-  "onboardingMetametricsOptionalText": {
-    "message": "You’re in control of whether to share your data. You can always change your preferences and delete your extension usage data via settings at any time."
-  },
-  "onboardingMetametricsOptionalTitle": {
-    "message": "Optional"
-  },
-  "onboardingMetametricsPrivateText": {
-    "message": "Your keys, transactions, full IP address, and any personal information are private. MetaMask doesn’t collect this information, but to enable certain features we use third-party service providers who might. For example, RPC providers collect your IP address when you send a transaction. $1 is the default RPC for MetaMask. You can change this to another provider in settings.",
-    "description": "$1 represents `infura`"
-  },
-  "onboardingMetametricsPrivateTitle": {
-    "message": "Private"
   },
   "onboardingPinExtensionBillboardAccess": {
     "message": "Full access"

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -2583,6 +2583,15 @@
   "on": {
     "message": "On"
   },
+  "onboardingAdvancedPrivacyNetworkButton": {
+    "message": "Add custom network"
+  },
+  "onboardingAdvancedPrivacyNetworkDescription": {
+    "message": "We use Infura as our remote procedure call (RPC) provider to offer the most reliable and private access to Ethereum data we can. You can choose your own RPC, but remember that any RPC will receive your IP address and Ethereum wallet to make transactions. Read our $1 to learn more about how Infura handles data."
+  },
+  "onboardingAdvancedPrivacyNetworkTitle": {
+    "message": "Choose your network"
+  },
   "onboardingCreateWallet": {
     "message": "Create a new wallet"
   },
@@ -2637,6 +2646,34 @@
   },
   "onboardingMetametricsTitle": {
     "message": "Help us improve MetaMask"
+  },
+  "onboardingMetametricsAnonymousText": {
+    "message": "MetaMask only collects relevant data like your country, but not your specific location. Your clicks and page views are anonymous."
+  },
+  "onboardingMetametricsAnonymousTitle": {
+    "message": "Anonymous"
+  },
+  "onboardingMetametricsFooter": {
+    "message": "This data is aggregated and is therefore anonymous for the purposes of General Data Protection Regulation (EU) 2016/679. For more information in relation to our privacy practices, please see our $1."
+  },
+  "onboardingMetametricsIntro2": {
+    "message": "When we gather metrics, it's always:"
+  },
+  "onboardingMetametricsModalTitle": {
+    "message": "Add custom network"
+  },
+  "onboardingMetametricsOptionalText": {
+    "message": "You’re in control of whether to share your data. You can always change your preferences and delete your extension usage data via settings at any time."
+  },
+  "onboardingMetametricsOptionalTitle": {
+    "message": "Optional"
+  },
+  "onboardingMetametricsPrivateText": {
+    "message": "Your keys, transactions, full IP address, and any personal information are private. MetaMask doesn’t collect this information, but to enable certain features we use third-party service providers who might. For example, RPC providers collect your IP address when you send a transaction. $1 is the default RPC for MetaMask. You can change this to another provider in settings.",
+    "description": "$1 represents `infura`"
+  },
+  "onboardingMetametricsPrivateTitle": {
+    "message": "Private"
   },
   "onboardingPinExtensionBillboardAccess": {
     "message": "Full access"

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -2638,6 +2638,9 @@
   "onboardingMetametricsInfuraTermsPolicyLink": {
     "message": "here"
   },
+  "onboardingMetametricsModalTitle": {
+    "message": "Add custom network"
+  },
   "onboardingMetametricsNeverCollect": {
     "message": "$1 collect information we don’t need to provide the service (such as keys, addresses, transaction hashes, or balances)",
     "description": "$1 represents `onboardingMetametricsNeverEmphasis`"
@@ -2658,9 +2661,6 @@
   },
   "onboardingMetametricsTitle": {
     "message": "Help us improve MetaMask"
-  },
-  "onboardingMetametricsModalTitle": {
-    "message": "Add custom network"
   },
   "onboardingPinExtensionBillboardAccess": {
     "message": "Full access"

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -2583,6 +2583,18 @@
   "on": {
     "message": "On"
   },
+  "onboardingAdvancedPrivacyIPFSDescription": {
+    "message": "The IPFS gateway makes it possible to access and view data hosted by third parties. You can add a custom IPFS gateway or continue using the default."
+  },
+  "onboardingAdvancedPrivacyIPFSInvalid": {
+    "message": "Please enter a valid URL"
+  },
+  "onboardingAdvancedPrivacyIPFSTitle": {
+    "message": "Add custom IPFS Gateway"
+  },
+  "onboardingAdvancedPrivacyIPFSValid": {
+    "message": "IPFS gateway URL is valid"
+  },
   "onboardingAdvancedPrivacyNetworkButton": {
     "message": "Add custom network"
   },

--- a/ui/components/app/dropdowns/network-dropdown.js
+++ b/ui/components/app/dropdowns/network-dropdown.js
@@ -101,6 +101,9 @@ class NetworkDropdown extends Component {
     showTestnetMessageInDropdown: PropTypes.bool.isRequired,
     hideTestNetMessage: PropTypes.func.isRequired,
     history: PropTypes.object,
+    dropdownStyles: PropTypes.object,
+    hideElementsForOnboarding: PropTypes.bool,
+    onAddClick: PropTypes.func,
   };
 
   handleClick(newProviderType) {
@@ -122,16 +125,21 @@ class NetworkDropdown extends Component {
   }
 
   renderAddCustomButton() {
+    const { onAddClick } = this.props;
     return (
       <div className="network__add-network-button">
         <Button
           type="secondary"
           onClick={() => {
-            getEnvironmentType() === ENVIRONMENT_TYPE_POPUP
-              ? global.platform.openExtensionInBrowser(
-                  ADD_POPULAR_CUSTOM_NETWORK,
-                )
-              : this.props.history.push(ADD_POPULAR_CUSTOM_NETWORK);
+            if (onAddClick) {
+              onAddClick();
+            } else {
+              getEnvironmentType() === ENVIRONMENT_TYPE_POPUP
+                ? global.platform.openExtensionInBrowser(
+                    ADD_POPULAR_CUSTOM_NETWORK,
+                  )
+                : this.props.history.push(ADD_POPULAR_CUSTOM_NETWORK);
+            }
             this.props.hideNetworkDropdown();
           }}
         >
@@ -263,6 +271,7 @@ class NetworkDropdown extends Component {
   render() {
     const {
       history,
+      hideElementsForOnboarding,
       hideNetworkDropdown,
       shouldShowTestNetworks,
       showTestnetMessageInDropdown,
@@ -294,20 +303,26 @@ class NetworkDropdown extends Component {
         }}
         containerClassName="network-droppo"
         zIndex={55}
-        style={{
-          position: 'absolute',
-          top: '58px',
-          width: '309px',
-          zIndex: '55px',
-        }}
+        style={
+          this.props.dropdownStyles || {
+            position: 'absolute',
+            top: '58px',
+            width: '309px',
+            zIndex: '55',
+          }
+        }
         innerStyle={{
           padding: '16px 0',
         }}
       >
         <div className="network-dropdown-header">
-          <div className="network-dropdown-title">{t('networks')}</div>
-          <div className="network-dropdown-divider" />
-          {showTestnetMessageInDropdown ? (
+          {hideElementsForOnboarding ? null : (
+            <div className="network-dropdown-title">{t('networks')}</div>
+          )}
+          {hideElementsForOnboarding ? null : (
+            <div className="network-dropdown-divider" />
+          )}
+          {showTestnetMessageInDropdown && !hideElementsForOnboarding ? (
             <div className="network-dropdown-content">
               {t('toggleTestNetworks', [
                 <a

--- a/ui/components/app/modals/modal.js
+++ b/ui/components/app/modals/modal.js
@@ -8,6 +8,7 @@ import { getEnvironmentType } from '../../../../app/scripts/lib/util';
 import { ENVIRONMENT_TYPE_POPUP } from '../../../../shared/constants/app';
 
 // Modal Components
+import AddNetworkModal from '../../../pages/onboarding-flow/add-network-modal';
 import AccountDetailsModal from './account-details-modal';
 import ExportPrivateKeyModal from './export-private-key-modal';
 import HideTokenConfirmationModal from './hide-token-confirmation-modal';
@@ -76,6 +77,10 @@ const accountModalStyle = {
 };
 
 const MODALS = {
+  ONBOARDING_ADD_NETWORK: {
+    contents: <AddNetworkModal />,
+    ...accountModalStyle,
+  },
   NEW_ACCOUNT: {
     contents: <NewAccountModal />,
     mobileModalStyle: {

--- a/ui/helpers/utils/ipfs.js
+++ b/ui/helpers/utils/ipfs.js
@@ -1,5 +1,3 @@
 export function addUrlProtocolPrefix(urlString) {
-  return urlString.match(/^https?:\/\//u)
-    ? urlString
-    : `https://${urlString}`;
+  return urlString.match(/^https?:\/\//u) ? urlString : `https://${urlString}`;
 }

--- a/ui/helpers/utils/ipfs.js
+++ b/ui/helpers/utils/ipfs.js
@@ -1,6 +1,5 @@
 export function addUrlProtocolPrefix(urlString) {
-  if (!urlString.match(/(^http:\/\/)|(^https:\/\/)/u)) {
-    return `https://${urlString}`;
-  }
-  return urlString;
+  return urlString.match(/^https?:\/\//u)
+    ? urlString
+    : `https://${urlString}`;
 }

--- a/ui/helpers/utils/ipfs.js
+++ b/ui/helpers/utils/ipfs.js
@@ -1,0 +1,6 @@
+export function addUrlProtocolPrefix(urlString) {
+  if (!urlString.match(/(^http:\/\/)|(^https:\/\/)/u)) {
+    return `https://${urlString}`;
+  }
+  return urlString;
+}

--- a/ui/pages/onboarding-flow/add-network-modal/index.js
+++ b/ui/pages/onboarding-flow/add-network-modal/index.js
@@ -1,0 +1,43 @@
+import React from 'react';
+import { useDispatch } from 'react-redux';
+import { useI18nContext } from '../../../hooks/useI18nContext';
+
+import { hideModal } from '../../../store/actions';
+
+import Typography from '../../../components/ui/typography/typography';
+import Box from '../../../components/ui/box/box';
+import {
+  TEXT_ALIGN,
+  TYPOGRAPHY,
+  FONT_WEIGHT,
+} from '../../../helpers/constants/design-system';
+
+import NetworksForm from '../../settings/networks-tab/networks-form/networks-form';
+
+export default function AddNetworkModal() {
+  const dispatch = useDispatch();
+  const t = useI18nContext();
+
+  const closeCallback = () =>
+    dispatch(hideModal({ name: 'ONBOARDING_ADD_NETWORK' }));
+
+  return (
+    <>
+      <Box paddingTop={4}>
+        <Typography
+          variant={TYPOGRAPHY.H4}
+          align={TEXT_ALIGN.CENTER}
+          fontWeight={FONT_WEIGHT.BOLD}
+        >
+          {t('onboardingMetametricsModalTitle')}
+        </Typography>
+      </Box>
+      <NetworksForm
+        addNewNetwork
+        networksToRender={[]}
+        cancelCallback={closeCallback}
+        submitCallback={closeCallback}
+      />
+    </>
+  );
+}

--- a/ui/pages/onboarding-flow/metametrics/metametrics.js
+++ b/ui/pages/onboarding-flow/metametrics/metametrics.js
@@ -20,7 +20,6 @@ import {
 import { EVENT, EVENT_NAMES } from '../../../../shared/constants/metametrics';
 
 import { MetaMetricsContext } from '../../../contexts/metametrics';
-import { Icon } from '../../../components/component-library';
 
 export default function OnboardingMetametrics() {
   const t = useI18nContext();
@@ -209,93 +208,6 @@ export default function OnboardingMetametrics() {
           </a>,
         ])}
       </Typography>
-      <Typography align={TEXT_ALIGN.CENTER} marginBottom={8}>
-        {t('onboardingMetametricsIntro2')}
-      </Typography>
-
-      <div className="onboarding-metametrics__grouping">
-        <Icon
-          name="eye-slash-filled"
-          color={COLORS.PRIMARY_DEFAULT}
-          marginRight={3}
-        />
-        <div className="onboarding-metametrics__grouping-text">
-          <Typography
-            variant={TYPOGRAPHY.H4}
-            fontWeight={FONT_WEIGHT.BOLD}
-            marginTop={0}
-          >
-            {t('onboardingMetametricsAnonymousTitle')}
-          </Typography>
-          <Typography color={COLORS.TEXT_ALTERNATIVE} marginBottom={8}>
-            {t('onboardingMetametricsAnonymousText')}
-          </Typography>
-        </div>
-      </div>
-
-      <div className="onboarding-metametrics__grouping">
-        <Icon
-          name="security-key-filled"
-          color={COLORS.PRIMARY_DEFAULT}
-          marginRight={3}
-        />
-        <div className="onboarding-metametrics__grouping-text">
-          <Typography
-            variant={TYPOGRAPHY.H4}
-            fontWeight={FONT_WEIGHT.BOLD}
-            marginTop={0}
-          >
-            {t('onboardingMetametricsPrivateTitle')}
-          </Typography>
-          <Typography color={COLORS.TEXT_ALTERNATIVE} marginBottom={8}>
-            {t('onboardingMetametricsPrivateText', [
-              <a
-                href="https://consensys.net/privacy-policy/"
-                target="_blank"
-                rel="noopener noreferrer"
-                key="infura-link"
-              >
-                {t('infura')}
-              </a>,
-            ])}
-          </Typography>
-        </div>
-      </div>
-
-      <div className="onboarding-metametrics__grouping">
-        <Icon
-          name="setting-filled"
-          color={COLORS.PRIMARY_DEFAULT}
-          marginRight={3}
-        />
-        <div className="onboarding-metametrics__grouping-text">
-          <Typography
-            variant={TYPOGRAPHY.H4}
-            fontWeight={FONT_WEIGHT.BOLD}
-            marginTop={0}
-          >
-            {t('onboardingMetametricsOptionalTitle')}
-          </Typography>
-          <Typography marginBottom={8} color={COLORS.TEXT_ALTERNATIVE}>
-            {t('onboardingMetametricsOptionalText')}
-          </Typography>
-        </div>
-      </div>
-
-      <div className="onboarding-metametrics__grouping">
-        <Typography color={COLORS.TEXT_ALTERNATIVE} align={TEXT_ALIGN.CENTER}>
-          {t('onboardingMetametricsFooter', [
-            <a
-              href="https://consensys.net/privacy-policy/"
-              key="link"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              {t('gdprMessagePrivacyPolicy')}
-            </a>,
-          ])}
-        </Typography>
-      </div>
 
       <div className="onboarding-metametrics__buttons">
         <Button

--- a/ui/pages/onboarding-flow/metametrics/metametrics.js
+++ b/ui/pages/onboarding-flow/metametrics/metametrics.js
@@ -20,6 +20,7 @@ import {
 import { EVENT, EVENT_NAMES } from '../../../../shared/constants/metametrics';
 
 import { MetaMetricsContext } from '../../../contexts/metametrics';
+import { Icon } from '../../../components/component-library';
 
 export default function OnboardingMetametrics() {
   const t = useI18nContext();
@@ -208,6 +209,93 @@ export default function OnboardingMetametrics() {
           </a>,
         ])}
       </Typography>
+      <Typography align={TEXT_ALIGN.CENTER} marginBottom={8}>
+        {t('onboardingMetametricsIntro2')}
+      </Typography>
+
+      <div className="onboarding-metametrics__grouping">
+        <Icon
+          name="eye-slash-filled"
+          color={COLORS.PRIMARY_DEFAULT}
+          marginRight={3}
+        />
+        <div className="onboarding-metametrics__grouping-text">
+          <Typography
+            variant={TYPOGRAPHY.H4}
+            fontWeight={FONT_WEIGHT.BOLD}
+            marginTop={0}
+          >
+            {t('onboardingMetametricsAnonymousTitle')}
+          </Typography>
+          <Typography color={COLORS.TEXT_ALTERNATIVE} marginBottom={8}>
+            {t('onboardingMetametricsAnonymousText')}
+          </Typography>
+        </div>
+      </div>
+
+      <div className="onboarding-metametrics__grouping">
+        <Icon
+          name="security-key-filled"
+          color={COLORS.PRIMARY_DEFAULT}
+          marginRight={3}
+        />
+        <div className="onboarding-metametrics__grouping-text">
+          <Typography
+            variant={TYPOGRAPHY.H4}
+            fontWeight={FONT_WEIGHT.BOLD}
+            marginTop={0}
+          >
+            {t('onboardingMetametricsPrivateTitle')}
+          </Typography>
+          <Typography color={COLORS.TEXT_ALTERNATIVE} marginBottom={8}>
+            {t('onboardingMetametricsPrivateText', [
+              <a
+                href="https://consensys.net/privacy-policy/"
+                target="_blank"
+                rel="noopener noreferrer"
+                key="infura-link"
+              >
+                {t('infura')}
+              </a>,
+            ])}
+          </Typography>
+        </div>
+      </div>
+
+      <div className="onboarding-metametrics__grouping">
+        <Icon
+          name="setting-filled"
+          color={COLORS.PRIMARY_DEFAULT}
+          marginRight={3}
+        />
+        <div className="onboarding-metametrics__grouping-text">
+          <Typography
+            variant={TYPOGRAPHY.H4}
+            fontWeight={FONT_WEIGHT.BOLD}
+            marginTop={0}
+          >
+            {t('onboardingMetametricsOptionalTitle')}
+          </Typography>
+          <Typography marginBottom={8} color={COLORS.TEXT_ALTERNATIVE}>
+            {t('onboardingMetametricsOptionalText')}
+          </Typography>
+        </div>
+      </div>
+
+      <div className="onboarding-metametrics__grouping">
+        <Typography color={COLORS.TEXT_ALTERNATIVE} align={TEXT_ALIGN.CENTER}>
+          {t('onboardingMetametricsFooter', [
+            <a
+              href="https://consensys.net/privacy-policy/"
+              key="link"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              {t('gdprMessagePrivacyPolicy')}
+            </a>,
+          ])}
+        </Typography>
+      </div>
 
       <div className="onboarding-metametrics__buttons">
         <Button

--- a/ui/pages/onboarding-flow/privacy-settings/index.scss
+++ b/ui/pages/onboarding-flow/privacy-settings/index.scss
@@ -56,6 +56,15 @@
     }
   }
 
+  &__network {
+    position: relative;
+
+    .dropdown-menu-item {
+      font-size: 14px !important;
+      padding: 8px !important;
+    }
+  }
+
   & button {
     max-width: 50%;
     padding: 15px;

--- a/ui/pages/onboarding-flow/privacy-settings/privacy-settings.js
+++ b/ui/pages/onboarding-flow/privacy-settings/privacy-settings.js
@@ -8,8 +8,6 @@ import Button from '../../../components/ui/button';
 import Typography from '../../../components/ui/typography';
 import {
   COLORS,
-} from '../../../../shared/constants/network';
-import {
   FONT_WEIGHT,
   TYPOGRAPHY,
 } from '../../../helpers/constants/design-system';
@@ -27,8 +25,6 @@ import {
 } from '../../../store/actions';
 import { ONBOARDING_PIN_EXTENSION_ROUTE } from '../../../helpers/constants/routes';
 import { Icon, TextField } from '../../../components/component-library';
-import { ONBOARDING_PIN_EXTENSION_ROUTE } from '../../../helpers/constants/routes';
-import { Icon } from '../../../components/component-library';
 import NetworkDropdown from '../../../components/app/dropdowns/network-dropdown';
 import NetworkDisplay from '../../../components/app/network-display/network-display';
 import { Setting } from './setting';

--- a/ui/pages/onboarding-flow/privacy-settings/privacy-settings.js
+++ b/ui/pages/onboarding-flow/privacy-settings/privacy-settings.js
@@ -6,10 +6,12 @@ import Box from '../../../components/ui/box/box';
 import Button from '../../../components/ui/button';
 import Typography from '../../../components/ui/typography';
 import {
+  COLORS,
   FONT_WEIGHT,
   TYPOGRAPHY,
 } from '../../../helpers/constants/design-system';
 import { useI18nContext } from '../../../hooks/useI18nContext';
+import { addUrlProtocolPrefix } from '../../../helpers/utils/ipfs';
 import {
   setCompletedOnboarding,
   setFeatureFlag,
@@ -17,9 +19,10 @@ import {
   setUsePhishDetect,
   setUseTokenDetection,
   showModal,
+  setIpfsGateway,
 } from '../../../store/actions';
 import { ONBOARDING_PIN_EXTENSION_ROUTE } from '../../../helpers/constants/routes';
-import { Icon } from '../../../components/component-library';
+import { Icon, TextField } from '../../../components/component-library';
 import { Setting } from './setting';
 
 export default function PrivacySettings() {
@@ -34,6 +37,8 @@ export default function PrivacySettings() {
     isMultiAccountBalanceCheckerEnabled,
     setMultiAccountBalanceCheckerEnabled,
   ] = useState(true);
+  const [ipfsURL, setIPFSURL] = useState('');
+  const [ipfsError, setIPFSError] = useState(null);
 
   const handleSubmit = () => {
     dispatch(
@@ -45,7 +50,26 @@ export default function PrivacySettings() {
       setUseMultiAccountBalanceChecker(isMultiAccountBalanceCheckerEnabled),
     );
     dispatch(setCompletedOnboarding());
+
+    if (ipfsURL && !ipfsError) {
+      const { host } = new URL(addUrlProtocolPrefix(ipfsURL));
+      dispatch(setIpfsGateway(host));
+    }
+
     history.push(ONBOARDING_PIN_EXTENSION_ROUTE);
+  };
+
+  const handleIPFSChange = (url) => {
+    setIPFSURL(url);
+    try {
+      const { host } = new URL(addUrlProtocolPrefix(url));
+      if (!host || host === 'gateway.ipfs.io') {
+        throw new Error();
+      }
+      setIPFSError(null);
+    } catch (error) {
+      setIPFSError(t('onboardingAdvancedPrivacyIPFSInvalid'));
+    }
   };
 
   return (
@@ -149,6 +173,35 @@ export default function PrivacySettings() {
                   >
                     {t('onboardingAdvancedPrivacyNetworkButton')}
                   </Button>
+                </Box>
+              </>
+            }
+          />
+          <Setting
+            title={t('onboardingAdvancedPrivacyIPFSTitle')}
+            showToggle={false}
+            description={
+              <>
+                {t('onboardingAdvancedPrivacyIPFSDescription')}
+                <Box paddingTop={2}>
+                  <TextField
+                    style={{ width: '100%' }}
+                    onChange={(e) => {
+                      handleIPFSChange(e.target.value);
+                    }}
+                  />
+                  {ipfsURL ? (
+                    <Typography
+                      variant={TYPOGRAPHY.H7}
+                      color={
+                        ipfsError
+                          ? COLORS.ERROR_DEFAULT
+                          : COLORS.SUCCESS_DEFAULT
+                      }
+                    >
+                      {ipfsError || t('onboardingAdvancedPrivacyIPFSValid')}
+                    </Typography>
+                  ) : null}
                 </Box>
               </>
             }

--- a/ui/pages/onboarding-flow/privacy-settings/privacy-settings.js
+++ b/ui/pages/onboarding-flow/privacy-settings/privacy-settings.js
@@ -8,10 +8,15 @@ import Button from '../../../components/ui/button';
 import Typography from '../../../components/ui/typography';
 import {
   COLORS,
+  CHAIN_IDS,
+  MAINNET_DISPLAY_NAME,
+  MAINNET_RPC_URL,
+  CURRENCY_SYMBOLS,
+} from '../../../../shared/constants/network';
+import {
   FONT_WEIGHT,
   TYPOGRAPHY,
 } from '../../../helpers/constants/design-system';
-import { MAINNET_DISPLAY_NAME } from '../../../../shared/constants/network';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import { addUrlProtocolPrefix } from '../../../helpers/utils/ipfs';
 import {
@@ -22,9 +27,12 @@ import {
   setUseTokenDetection,
   showModal,
   setIpfsGateway,
+  setRpcTarget,
 } from '../../../store/actions';
 import { ONBOARDING_PIN_EXTENSION_ROUTE } from '../../../helpers/constants/routes';
-import { Icon, TextField, Tag } from '../../../components/component-library';
+import { Icon, TextField } from '../../../components/component-library';
+import { ONBOARDING_PIN_EXTENSION_ROUTE } from '../../../helpers/constants/routes';
+import { Icon } from '../../../components/component-library';
 import { Setting } from './setting';
 
 export default function PrivacySettings() {
@@ -42,9 +50,7 @@ export default function PrivacySettings() {
   const [ipfsURL, setIPFSURL] = useState('');
   const [ipfsError, setIPFSError] = useState(null);
 
-  const currentNetworkNickname = useSelector(
-    (state) => state.metamask.provider.nickname,
-  );
+  const networks = useSelector((state) => state.metamask.frequentRpcListDetail);
 
   const handleSubmit = () => {
     dispatch(
@@ -168,23 +174,57 @@ export default function PrivacySettings() {
                 ])}
 
                 <Box paddingTop={2}>
-                  {currentNetworkNickname &&
-                  currentNetworkNickname !== MAINNET_DISPLAY_NAME ? (
-                    <Tag label={currentNetworkNickname} />
-                  ) : (
-                    <Button
-                      type="secondary"
-                      rounded
-                      large
-                      onClick={(e) => {
-                        e.preventDefault();
-                        dispatch(showModal({ name: 'ONBOARDING_ADD_NETWORK' }));
-                      }}
-                      icon={<Icon name="add-outline" marginRight={2} />}
-                    >
-                      {t('onboardingAdvancedPrivacyNetworkButton')}
-                    </Button>
-                  )}
+                  <select
+                    onChange={({ target }) => {
+                      const { value } = target;
+                      if (value === CHAIN_IDS.MAINNET) {
+                        dispatch(
+                          setRpcTarget(
+                            MAINNET_RPC_URL,
+                            CHAIN_IDS.MAINNET,
+                            CURRENCY_SYMBOLS.ETH,
+                            MAINNET_DISPLAY_NAME,
+                          ),
+                        );
+                        return;
+                      }
+
+                      const chosenNetwork = networks.find(
+                        ({ chainId }) => chainId === value,
+                      );
+                      if (chosenNetwork) {
+                        dispatch(
+                          setRpcTarget(
+                            chosenNetwork.rpcUrl,
+                            chosenNetwork.chainId,
+                            chosenNetwork.ticker,
+                            chosenNetwork.nickname,
+                          ),
+                        );
+                      }
+                    }}
+                  >
+                    <option value={CHAIN_IDS.MAINNET}>
+                      {MAINNET_DISPLAY_NAME}
+                    </option>
+                    {networks.map(({ chainId, nickname }) => (
+                      <option key={chainId} value={chainId}>
+                        {nickname}
+                      </option>
+                    ))}
+                  </select>
+                  <Button
+                    type="secondary"
+                    rounded
+                    large
+                    onClick={(e) => {
+                      e.preventDefault();
+                      dispatch(showModal({ name: 'ONBOARDING_ADD_NETWORK' }));
+                    }}
+                    icon={<Icon name="add-outline" marginRight={2} />}
+                  >
+                    {t('onboardingAdvancedPrivacyNetworkButton')}
+                  </Button>
                 </Box>
               </>
             }

--- a/ui/pages/onboarding-flow/privacy-settings/privacy-settings.js
+++ b/ui/pages/onboarding-flow/privacy-settings/privacy-settings.js
@@ -44,7 +44,9 @@ export default function PrivacySettings() {
   const [ipfsURL, setIPFSURL] = useState('');
   const [ipfsError, setIPFSError] = useState(null);
 
-  const networks = useSelector((state) => state.metamask.frequentRpcListDetail);
+  const networks = useSelector(
+    (state) => state.metamask.frequentRpcListDetail || [],
+  );
 
   const handleSubmit = () => {
     dispatch(

--- a/ui/pages/onboarding-flow/privacy-settings/privacy-settings.js
+++ b/ui/pages/onboarding-flow/privacy-settings/privacy-settings.js
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
+
 import { useHistory } from 'react-router-dom';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 
 import Box from '../../../components/ui/box/box';
 import Button from '../../../components/ui/button';
@@ -10,6 +11,7 @@ import {
   FONT_WEIGHT,
   TYPOGRAPHY,
 } from '../../../helpers/constants/design-system';
+import { MAINNET_DISPLAY_NAME } from '../../../../shared/constants/network';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import { addUrlProtocolPrefix } from '../../../helpers/utils/ipfs';
 import {
@@ -22,7 +24,7 @@ import {
   setIpfsGateway,
 } from '../../../store/actions';
 import { ONBOARDING_PIN_EXTENSION_ROUTE } from '../../../helpers/constants/routes';
-import { Icon, TextField } from '../../../components/component-library';
+import { Icon, TextField, Tag } from '../../../components/component-library';
 import { Setting } from './setting';
 
 export default function PrivacySettings() {
@@ -39,6 +41,10 @@ export default function PrivacySettings() {
   ] = useState(true);
   const [ipfsURL, setIPFSURL] = useState('');
   const [ipfsError, setIPFSError] = useState(null);
+
+  const currentNetworkNickname = useSelector(
+    (state) => state.metamask.provider.nickname,
+  );
 
   const handleSubmit = () => {
     dispatch(
@@ -160,19 +166,25 @@ export default function PrivacySettings() {
                     {t('privacyMsg')}
                   </a>,
                 ])}
+
                 <Box paddingTop={2}>
-                  <Button
-                    type="secondary"
-                    rounded
-                    large
-                    onClick={(e) => {
-                      e.preventDefault();
-                      dispatch(showModal({ name: 'ONBOARDING_ADD_NETWORK' }));
-                    }}
-                    icon={<Icon name="add-outline" marginRight={2} />}
-                  >
-                    {t('onboardingAdvancedPrivacyNetworkButton')}
-                  </Button>
+                  {currentNetworkNickname &&
+                  currentNetworkNickname !== MAINNET_DISPLAY_NAME ? (
+                    <Tag label={currentNetworkNickname} />
+                  ) : (
+                    <Button
+                      type="secondary"
+                      rounded
+                      large
+                      onClick={(e) => {
+                        e.preventDefault();
+                        dispatch(showModal({ name: 'ONBOARDING_ADD_NETWORK' }));
+                      }}
+                      icon={<Icon name="add-outline" marginRight={2} />}
+                    >
+                      {t('onboardingAdvancedPrivacyNetworkButton')}
+                    </Button>
+                  )}
                 </Box>
               </>
             }

--- a/ui/pages/onboarding-flow/privacy-settings/privacy-settings.js
+++ b/ui/pages/onboarding-flow/privacy-settings/privacy-settings.js
@@ -8,10 +8,6 @@ import Button from '../../../components/ui/button';
 import Typography from '../../../components/ui/typography';
 import {
   COLORS,
-  CHAIN_IDS,
-  MAINNET_DISPLAY_NAME,
-  MAINNET_RPC_URL,
-  CURRENCY_SYMBOLS,
 } from '../../../../shared/constants/network';
 import {
   FONT_WEIGHT,
@@ -27,12 +23,14 @@ import {
   setUseTokenDetection,
   showModal,
   setIpfsGateway,
-  setRpcTarget,
+  showNetworkDropdown,
 } from '../../../store/actions';
 import { ONBOARDING_PIN_EXTENSION_ROUTE } from '../../../helpers/constants/routes';
 import { Icon, TextField } from '../../../components/component-library';
 import { ONBOARDING_PIN_EXTENSION_ROUTE } from '../../../helpers/constants/routes';
 import { Icon } from '../../../components/component-library';
+import NetworkDropdown from '../../../components/app/dropdowns/network-dropdown';
+import NetworkDisplay from '../../../components/app/network-display/network-display';
 import { Setting } from './setting';
 
 export default function PrivacySettings() {
@@ -174,57 +172,44 @@ export default function PrivacySettings() {
                 ])}
 
                 <Box paddingTop={2}>
-                  <select
-                    onChange={({ target }) => {
-                      const { value } = target;
-                      if (value === CHAIN_IDS.MAINNET) {
-                        dispatch(
-                          setRpcTarget(
-                            MAINNET_RPC_URL,
-                            CHAIN_IDS.MAINNET,
-                            CURRENCY_SYMBOLS.ETH,
-                            MAINNET_DISPLAY_NAME,
-                          ),
-                        );
-                        return;
-                      }
-
-                      const chosenNetwork = networks.find(
-                        ({ chainId }) => chainId === value,
-                      );
-                      if (chosenNetwork) {
-                        dispatch(
-                          setRpcTarget(
-                            chosenNetwork.rpcUrl,
-                            chosenNetwork.chainId,
-                            chosenNetwork.ticker,
-                            chosenNetwork.nickname,
-                          ),
-                        );
-                      }
-                    }}
-                  >
-                    <option value={CHAIN_IDS.MAINNET}>
-                      {MAINNET_DISPLAY_NAME}
-                    </option>
-                    {networks.map(({ chainId, nickname }) => (
-                      <option key={chainId} value={chainId}>
-                        {nickname}
-                      </option>
-                    ))}
-                  </select>
-                  <Button
-                    type="secondary"
-                    rounded
-                    large
-                    onClick={(e) => {
-                      e.preventDefault();
-                      dispatch(showModal({ name: 'ONBOARDING_ADD_NETWORK' }));
-                    }}
-                    icon={<Icon name="add-outline" marginRight={2} />}
-                  >
-                    {t('onboardingAdvancedPrivacyNetworkButton')}
-                  </Button>
+                  {networks.length > 1 ? (
+                    <div className="privacy-settings__network">
+                      <>
+                        <NetworkDisplay
+                          onClick={() => dispatch(showNetworkDropdown())}
+                        />
+                        <NetworkDropdown
+                          hideElementsForOnboarding
+                          dropdownStyles={{
+                            position: 'absolute',
+                            top: '40px',
+                            left: '0',
+                            width: '309px',
+                            zIndex: '55',
+                          }}
+                          onAddClick={() => {
+                            dispatch(
+                              showModal({ name: 'ONBOARDING_ADD_NETWORK' }),
+                            );
+                          }}
+                        />
+                      </>
+                    </div>
+                  ) : null}
+                  {networks.length === 1 ? (
+                    <Button
+                      type="secondary"
+                      rounded
+                      large
+                      onClick={(e) => {
+                        e.preventDefault();
+                        dispatch(showModal({ name: 'ONBOARDING_ADD_NETWORK' }));
+                      }}
+                      icon={<Icon name="add-outline" marginRight={2} />}
+                    >
+                      {t('onboardingAdvancedPrivacyNetworkButton')}
+                    </Button>
+                  ) : null}
                 </Box>
               </>
             }

--- a/ui/pages/onboarding-flow/privacy-settings/privacy-settings.js
+++ b/ui/pages/onboarding-flow/privacy-settings/privacy-settings.js
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { useHistory } from 'react-router-dom';
 import { useDispatch } from 'react-redux';
 
+import Box from '../../../components/ui/box/box';
 import Button from '../../../components/ui/button';
 import Typography from '../../../components/ui/typography';
 import {
@@ -15,8 +16,10 @@ import {
   setUseMultiAccountBalanceChecker,
   setUsePhishDetect,
   setUseTokenDetection,
+  showModal,
 } from '../../../store/actions';
 import { ONBOARDING_PIN_EXTENSION_ROUTE } from '../../../helpers/constants/routes';
+import { Icon } from '../../../components/component-library';
 import { Setting } from './setting';
 
 export default function PrivacySettings() {
@@ -117,6 +120,38 @@ export default function PrivacySettings() {
             setValue={setMultiAccountBalanceCheckerEnabled}
             title={t('useMultiAccountBalanceChecker')}
             description={t('useMultiAccountBalanceCheckerDescription')}
+          />
+          <Setting
+            title={t('onboardingAdvancedPrivacyNetworkTitle')}
+            showToggle={false}
+            description={
+              <>
+                {t('onboardingAdvancedPrivacyNetworkDescription', [
+                  <a
+                    href="https://consensys.net/privacy-policy/"
+                    key="link"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    {t('privacyMsg')}
+                  </a>,
+                ])}
+                <Box paddingTop={2}>
+                  <Button
+                    type="secondary"
+                    rounded
+                    large
+                    onClick={(e) => {
+                      e.preventDefault();
+                      dispatch(showModal({ name: 'ONBOARDING_ADD_NETWORK' }));
+                    }}
+                    icon={<Icon name="add-outline" marginRight={2} />}
+                  >
+                    {t('onboardingAdvancedPrivacyNetworkButton')}
+                  </Button>
+                </Box>
+              </>
+            }
           />
         </div>
         <Button type="primary" rounded onClick={handleSubmit}>

--- a/ui/pages/onboarding-flow/privacy-settings/privacy-settings.test.js
+++ b/ui/pages/onboarding-flow/privacy-settings/privacy-settings.test.js
@@ -11,6 +11,7 @@ import PrivacySettings from './privacy-settings';
 describe('Privacy Settings Onboarding View', () => {
   const mockStore = {
     metamask: {
+      frequentRpcListDetail: [],
       provider: {
         type: 'test',
       },

--- a/ui/pages/onboarding-flow/privacy-settings/setting.js
+++ b/ui/pages/onboarding-flow/privacy-settings/setting.js
@@ -9,7 +9,13 @@ import {
   FONT_WEIGHT,
 } from '../../../helpers/constants/design-system';
 
-export const Setting = ({ value, setValue, title, description }) => {
+export const Setting = ({
+  value,
+  setValue,
+  title,
+  description,
+  showToggle = true,
+}) => {
   return (
     <Box justifyContent={JUSTIFY_CONTENT.CENTER} margin={3}>
       <div className="privacy-settings__setting">
@@ -18,9 +24,11 @@ export const Setting = ({ value, setValue, title, description }) => {
         </Typography>
         <Typography variant={TYPOGRAPHY.H6}>{description}</Typography>
       </div>
-      <div className="privacy-settings__setting__toggle">
-        <ToggleButton value={value} onToggle={(val) => setValue(!val)} />
-      </div>
+      {showToggle ? (
+        <div className="privacy-settings__setting__toggle">
+          <ToggleButton value={value} onToggle={(val) => setValue(!val)} />
+        </div>
+      ) : null}
     </Box>
   );
 };
@@ -30,4 +38,5 @@ Setting.propTypes = {
   setValue: PropTypes.func,
   title: PropTypes.string,
   description: PropTypes.oneOfType([PropTypes.object, PropTypes.string]),
+  showToggle: PropTypes.bool,
 };

--- a/ui/pages/routes/routes.component.js
+++ b/ui/pages/routes/routes.component.js
@@ -439,7 +439,7 @@ export default class Routes extends Component {
         {process.env.ONBOARDING_V2 && this.showOnboardingHeader() && (
           <OnboardingAppHeader />
         )}
-        <NetworkDropdown />
+        {completedOnboarding ? <NetworkDropdown /> : null}
         <AccountMenu />
         <div className="main-container-wrapper">
           {isLoading ? <Loading loadingMessage={loadMessage} /> : null}

--- a/ui/pages/routes/routes.component.js
+++ b/ui/pages/routes/routes.component.js
@@ -115,6 +115,7 @@ export default class Routes extends Component {
     portfolioTooltipIsBeingShown: PropTypes.bool,
     forgottenPassword: PropTypes.bool,
     isCurrentProviderCustom: PropTypes.bool,
+    completedOnboarding: PropTypes.bool,
   };
 
   static contextTypes = {
@@ -379,6 +380,7 @@ export default class Routes extends Component {
       shouldShowSeedPhraseReminder,
       portfolioTooltipIsBeingShown,
       isCurrentProviderCustom,
+      completedOnboarding,
     } = this.props;
     const loadMessage =
       loadingMessage || isNetworkLoading
@@ -391,6 +393,7 @@ export default class Routes extends Component {
       !isTestNet &&
       !isNetworkUsed &&
       !isCurrentProviderCustom &&
+      completedOnboarding &&
       allAccountsOnNetworkAreEmpty;
 
     const windowType = getEnvironmentType();

--- a/ui/pages/routes/routes.container.js
+++ b/ui/pages/routes/routes.container.js
@@ -29,6 +29,7 @@ function mapStateToProps(state) {
   const { appState } = state;
   const { alertOpen, alertMessage, isLoading, loadingMessage } = appState;
   const { autoLockTimeLimit = 0 } = getPreferences(state);
+  const { completedOnboarding } = state.metamask;
 
   return {
     alertOpen,
@@ -55,6 +56,7 @@ function mapStateToProps(state) {
     portfolioTooltipIsBeingShown: getShowPortfolioTooltip(state),
     forgottenPassword: state.metamask.forgottenPassword,
     isCurrentProviderCustom: isCurrentProviderCustom(state),
+    completedOnboarding,
   };
 }
 

--- a/ui/pages/settings/advanced-tab/advanced-tab.component.js
+++ b/ui/pages/settings/advanced-tab/advanced-tab.component.js
@@ -14,6 +14,7 @@ import {
   getNumberOfSettingsInSection,
   handleSettingsRefs,
 } from '../../../helpers/utils/settings-search';
+import { addUrlProtocolPrefix } from '../../../helpers/utils/ipfs';
 
 import {
   LEDGER_TRANSPORT_TYPES,
@@ -841,11 +842,4 @@ export default class AdvancedTab extends PureComponent {
       </div>
     );
   }
-}
-
-function addUrlProtocolPrefix(urlString) {
-  if (!urlString.match(/(^http:\/\/)|(^https:\/\/)/u)) {
-    return `https://${urlString}`;
-  }
-  return urlString;
 }

--- a/ui/pages/settings/networks-tab/networks-form/networks-form.js
+++ b/ui/pages/settings/networks-tab/networks-form/networks-form.js
@@ -5,7 +5,6 @@ import React, {
   useRef,
   useState,
 } from 'react';
-import { useHistory } from 'react-router-dom';
 import { useDispatch } from 'react-redux';
 import PropTypes from 'prop-types';
 import validUrl from 'valid-url';
@@ -29,10 +28,6 @@ import {
   showModal,
   setNewNetworkAdded,
 } from '../../../../store/actions';
-import {
-  DEFAULT_ROUTE,
-  NETWORKS_ROUTE,
-} from '../../../../helpers/constants/routes';
 import fetchWithCache from '../../../../../shared/lib/fetch-with-cache';
 import { usePrevious } from '../../../../hooks/usePrevious';
 import { MetaMetricsContext } from '../../../../contexts/metametrics';
@@ -86,10 +81,11 @@ const NetworksForm = ({
   isCurrentRpcTarget,
   networksToRender,
   selectedNetwork,
+  cancelCallback,
+  submitCallback,
 }) => {
   const t = useI18nContext();
   const trackEvent = useContext(MetaMetricsContext);
-  const history = useHistory();
   const dispatch = useDispatch();
   const { label, labelKey, viewOnly, rpcPrefs } = selectedNetwork;
   const selectedNetworkName = label || (labelKey && t(labelKey));
@@ -544,7 +540,8 @@ const NetworksForm = ({
           },
         });
         dispatch(setNewNetworkAdded(networkName));
-        history.push(DEFAULT_ROUTE);
+
+        submitCallback?.();
       }
     } catch (error) {
       setIsSubmitting(false);
@@ -555,7 +552,7 @@ const NetworksForm = ({
   const onCancel = () => {
     if (addNewNetwork) {
       dispatch(setSelectedSettingsRpcUrl(''));
-      history.push(NETWORKS_ROUTE);
+      cancelCallback?.();
     } else {
       resetForm();
     }
@@ -709,6 +706,8 @@ NetworksForm.propTypes = {
   isCurrentRpcTarget: PropTypes.bool,
   networksToRender: PropTypes.array.isRequired,
   selectedNetwork: PropTypes.object,
+  cancelCallback: PropTypes.func,
+  submitCallback: PropTypes.func,
 };
 
 NetworksForm.defaultProps = {

--- a/ui/pages/settings/networks-tab/networks-tab-content/networks-tab-content.js
+++ b/ui/pages/settings/networks-tab/networks-tab-content/networks-tab-content.js
@@ -1,9 +1,15 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { useSelector } from 'react-redux';
+import { useHistory } from 'react-router-dom';
 import NetworksForm from '../networks-form';
 import NetworksList from '../networks-list';
 import { getProvider } from '../../../../selectors';
+
+import {
+  DEFAULT_ROUTE,
+  NETWORKS_ROUTE,
+} from '../../../../helpers/constants/routes';
 
 const NetworksTabContent = ({
   networkDefaultedToProvider,
@@ -13,6 +19,7 @@ const NetworksTabContent = ({
   shouldRenderNetworkForm,
 }) => {
   const provider = useSelector(getProvider);
+  const history = useHistory();
 
   return (
     <>
@@ -27,6 +34,8 @@ const NetworksTabContent = ({
           isCurrentRpcTarget={provider.rpcUrl === selectedNetwork.rpcUrl}
           networksToRender={networksToRender}
           selectedNetwork={selectedNetwork}
+          submitCallback={() => history.push(DEFAULT_ROUTE)}
+          cancelCallback={() => history.push(NETWORKS_ROUTE)}
         />
       ) : null}
     </>

--- a/ui/pages/settings/networks-tab/networks-tab.js
+++ b/ui/pages/settings/networks-tab/networks-tab.js
@@ -7,6 +7,8 @@ import { useI18nContext } from '../../../hooks/useI18nContext';
 import {
   ADD_POPULAR_CUSTOM_NETWORK,
   NETWORKS_FORM_ROUTE,
+  DEFAULT_ROUTE,
+  NETWORKS_ROUTE,
 } from '../../../helpers/constants/routes';
 import { setSelectedSettingsRpcUrl } from '../../../store/actions';
 import Button from '../../../components/ui/button';
@@ -106,6 +108,8 @@ const NetworksTab = ({ addNewNetwork }) => {
           <NetworksForm
             networksToRender={networksToRender}
             addNewNetwork={addNewNetwork}
+            submitCallback={() => history.push(DEFAULT_ROUTE)}
+            cancelCallback={() => history.push(NETWORKS_ROUTE)}
           />
         ) : (
           <>


### PR DESCRIPTION
## Explanation

The design for after a custom network has been added during onboarding shows the following:

<img width="648" alt="Hug" src="https://user-images.githubusercontent.com/46655/205400620-341e9375-ce82-4aff-8d7a-3903579e2fd8.png">

I've used a `Tag` component to show said network after a custom network has been added:

<img width="541" alt="Network" src="https://user-images.githubusercontent.com/46655/205400696-794403aa-83f6-4405-a26e-7f4a02cd9eec.png">

Will seek more clarification on what that control is meant to do in the design, but in the mean time, this Tag at least provides feedback as to what's happened.



## Screenshots/Screencaps

<!-- If you're making a change to the UI, make sure to capture a screenshot or a short video showing off your work! -->

### Before

<!-- How did the UI you changed look before your changes? Drag your file(s) below this line: -->

### After

<!-- How does it look now? Drag your file(s) below this line: -->

## Manual Testing Steps

<!--
How should reviewers and QA manually test your changes? For instance:

- Go to this screen
- Do this
- Then do this
-->

## Pre-merge author checklist

- [ ] I've clearly explained:
  - [ ] What problem this PR is solving
  - [ ] How this problem was solved
  - [ ] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
