### PR TITLE
[FLASK] Resolve `snap_dialog` approval on close

### DIFF
--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -723,8 +723,10 @@ function setupController(initState, initLangCode) {
           REJECT_NOTFICIATION_CLOSE,
         ),
       );
+
+    // Finally, resolve snap dialog approvals on Flask and reject all the others managed by the ApprovalController.
+
     ///: BEGIN:ONLY_INCLUDE_IN(flask)
-    // Finally, resolve snap dialog approvals and reject all the others managed by the ApprovalController
     Object.values(controller.approvalController.state.pendingApprovals).forEach(
       ({ id, type }) => {
         if (type.startsWith(RestrictedMethods.snap_dialog)) {

--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -29,7 +29,9 @@ import {
 import { checkForLastErrorAndLog } from '../../shared/modules/browser-runtime.utils';
 import { isManifestV3 } from '../../shared/modules/mv3.utils';
 import { maskObject } from '../../shared/modules/object.utils';
+///: BEGIN:ONLY_INCLUDE_IN(flask)
 import { RestrictedMethods } from '../../shared/constants/permissions';
+///: END:ONLY_INCLUDE_IN
 import migrations from './migrations';
 import Migrator from './lib/migrator';
 import ExtensionPlatform from './platforms/extension';
@@ -721,6 +723,7 @@ function setupController(initState, initLangCode) {
           REJECT_NOTFICIATION_CLOSE,
         ),
       );
+    ///: BEGIN:ONLY_INCLUDE_IN(flask)
     // Finally, resolve snap dialog approvals and reject all the others managed by the ApprovalController
     Object.values(controller.approvalController.state.pendingApprovals).forEach(
       ({ id, type }) => {
@@ -734,6 +737,13 @@ function setupController(initState, initLangCode) {
         }
       },
     );
+    ///: END:ONLY_INCLUDE_IN
+
+    ///: BEGIN:ONLY_INCLUDE_IN(main,beta)
+    controller.approvalController.clear(
+      ethErrors.provider.userRejectedRequest(),
+    );
+    ///: END:ONLY_INCLUDE_IN
 
     updateBadge();
   }

--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -721,9 +721,6 @@ function setupController(initState, initLangCode) {
           REJECT_NOTFICIATION_CLOSE,
         ),
       );
-
-    console.log(controller.approvalController.state.pendingApprovals);
-
     // Finally, resolve snap dialog approvals and reject all the others managed by the ApprovalController
     Object.values(controller.approvalController.state.pendingApprovals).forEach(
       ({ id, type }) => {

--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -17,7 +17,9 @@ import {
   ENVIRONMENT_TYPE_FULLSCREEN,
   EXTENSION_MESSAGES,
   PLATFORM_FIREFOX,
+  ///: BEGIN:ONLY_INCLUDE_IN(flask)
   MESSAGE_TYPE,
+  ///: END:ONLY_INCLUDE_IN
 } from '../../shared/constants/app';
 import { SECOND } from '../../shared/constants/time';
 import {
@@ -30,9 +32,6 @@ import {
 import { checkForLastErrorAndLog } from '../../shared/modules/browser-runtime.utils';
 import { isManifestV3 } from '../../shared/modules/mv3.utils';
 import { maskObject } from '../../shared/modules/object.utils';
-///: BEGIN:ONLY_INCLUDE_IN(flask)
-import { RestrictedMethods } from '../../shared/constants/permissions';
-///: END:ONLY_INCLUDE_IN
 import migrations from './migrations';
 import Migrator from './lib/migrator';
 import ExtensionPlatform from './platforms/extension';

--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -738,7 +738,7 @@ function setupController(initState, initLangCode) {
             break;
           ///: END:ONLY_INCLUDE_IN
           default:
-            controller.appStateController.reject(
+            controller.approvalController.reject(
               id,
               ethErrors.provider.userRejectedRequest(),
             );


### PR DESCRIPTION
## Explanation

Resolve approvals of type `snap_dialog_*` with the value `null` instead of rejecting them on close.

* Fixes #16761 

## Manual Testing Steps


- Trigger a `snap_dialog` confirmation (you can use https://github.com/GuillaumeRx/snap-dialog-test).
- Close the confirmation using the window's close button.
- Observe that no error was thrown.