### PR TITLE
Fix getFullTxData so that customTxParamsData is not lost

### DIFF
--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -851,7 +851,7 @@ export const getFullTxData = createDeepEqualSelector(
     return getTransaction(state, transactionId);
   },
   (_state, _transactionId, _status, customTxParamsData) => customTxParamsData,
-  (txData, transaction, _status, customTxParamsData) => {
+  (txData, transaction, customTxParamsData) => {
     let fullTxData = { ...txData, ...transaction };
     if (transaction && transaction.simulationFails) {
       txData.simulationFails = transaction.simulationFails;


### PR DESCRIPTION
Fixes https://github.com/MetaMask/metamask-extension/issues/16798#top

This bug was introduced here https://github.com/MetaMask/metamask-extension/commit/4245f24a2e485bd016c8ec9bd14afb17790efdbf#diff-45ae84764c1d49a07813a91adc3351d6ed96bf9ee8fa2ae4c9a116d1e0cba06cR821-R830

**Explanation**

The bug is that the user inputted token allowance is not the token allowance that ends up being submitted on chain. More precisely, if we show the user the token allowance screen and they customize it, the new `txParams.data` is not used.

The cause is the above linked codechange whereby an additional parameter was accidentally added to the result function of the selector creator, thereby rendering `customTxParamsData` undefined. With that parameter removed, `customTxParamsData` will now be defined as it was before, and will reflect the modified data in the case of a user editing a token allowance amount.