### PR TITLE
Update qs via yarn.lock to 6.5.3

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -20474,9 +20474,9 @@ qs@^6.10.0, qs@^6.4.0, qs@^6.5.1:
     side-channel "^1.0.4"
 
 qs@~6.5.2:
-  version "6.5.2"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
-  integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
+  version "6.5.3"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.3.tgz#3aeeffc91967ef6e35c0e488ef46fb296ab76aad"
+  integrity sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==
 
 query-ast@^1.0.3:
   version "1.0.4"


### PR DESCRIPTION
Fixes the test-deps-audit failure seen here https://app.circleci.com/pipelines/github/MetaMask/metamask-extension/31979/workflows/f096458b-c2a5-4516-932d-2882d5054de5/jobs/837357