### PR TITLE
force background exceptions to show

### DIFF
--- a/test/e2e/helpers.js
+++ b/test/e2e/helpers.js
@@ -159,7 +159,7 @@ async function withFixtures(options, testSuite) {
          * proving more helpful context
          */
         await driver.navigate(PAGES.BACKGROUND);
-        const errorMessage = `Errors found in browser console including the backgorund:\n${driver.exceptions.join(
+        const errorMessage = `Errors found in browser console including the background:\n${driver.exceptions.join(
           '\n',
         )}`;
         throw Error(errorMessage);

--- a/test/e2e/helpers.js
+++ b/test/e2e/helpers.js
@@ -9,6 +9,7 @@ const Ganache = require('./ganache');
 const FixtureServer = require('./fixture-server');
 const PhishingWarningPageServer = require('./phishing-warning-page-server');
 const { buildWebDriver } = require('./webdriver');
+const { PAGES } = require('./webdriver/driver');
 const { ensureXServerIsRunning } = require('./x-server');
 const GanacheSeeder = require('./seeder/ganache-seeder');
 
@@ -152,7 +153,13 @@ async function withFixtures(options, testSuite) {
         driver.exceptions.length > 0 &&
         failOnConsoleError
       ) {
-        const errorMessage = `Errors found in browser console:\n${driver.exceptions.join(
+        /**
+         * Navigate to the background
+         * forcing background exceptions to be captured
+         * proving more helpful context
+         */
+        await driver.navigate(PAGES.BACKGROUND);
+        const errorMessage = `Errors found in browser console including the backgorund:\n${driver.exceptions.join(
           '\n',
         )}`;
         throw Error(errorMessage);


### PR DESCRIPTION
## Explanation

<!--
Thanks for the pull request. Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues, Slack conversations, Zendesk issues, user stories, etc. reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

See: #16453

## Screenshots/Screencaps

<!-- If you're making a change to the UI, make sure to capture a screenshot or a short video showing off your work! -->

### Before

<!-- How did the UI you changed look before your changes? Drag your file(s) below this line: -->

```
yarn run v1.22.11
$ node test/e2e/run-e2e-test.js test/e2e/tests/account-details.spec.js --browser chrome
$ /Users/peteryinusa/Documents/GitHub/metamask-extension-gridplus/node_modules/.bin/mocha --no-config --timeout 60000 test/e2e/tests/account-details.spec.js --exit


  Show account details
    1) should show the QR code for the account


  0 passing (25s)
  1 failing

  1) Show account details
       should show the QR code for the account:
     Error: Errors found in browser console:
Error: disconnected
  at new u (chrome-extension://ifoblgjpcpmgcoloepgfgbkehmckopop/ui-0.js:1:3360)
  at l.close (chrome-extension://ifoblgjpcpmgcoloepgfgbkehmckopop/ui-0.js:1:4347)
  at d (chrome-extension://ifoblgjpcpmgcoloepgfgbkehmckopop/common-2.js:110:224851)
  at o.emit (chrome-extension://ifoblgjpcpmgcoloepgfgbkehmckopop/common-2.js:110:227856)
  at D (chrome-extension://ifoblgjpcpmgcoloepgfgbkehmckopop/common-6.js:1:203653)
  at chrome-extension://ifoblgjpcpmgcoloepgfgbkehmckopop/common-6.js:1:224131
  at p.run (chrome-extension://ifoblgjpcpmgcoloepgfgbkehmckopop/common-6.js:1:165446)
  at m (chrome-extension://ifoblgjpcpmgcoloepgfgbkehmckopop/common-6.js:1:164940)
  at s (chrome-extension://ifoblgjpcpmgcoloepgfgbkehmckopop/sentry-install.js:1:11246)
      at withFixtures (test/e2e/helpers.js:160:15)
      at async Context.<anonymous> (test/e2e/tests/account-details.spec.js:16:5)



info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

### After

<!-- How does it look now? Drag your file(s) below this line: -->

```
yarn run v1.22.11
$ node test/e2e/run-e2e-test.js test/e2e/tests/account-details.spec.js --browser chrome
$ /Users/peteryinusa/Documents/GitHub/metamask-extension-gridplus/node_modules/.bin/mocha --no-config --timeout 60000 test/e2e/tests/account-details.spec.js --exit


  Show account details
    1) should show the QR code for the account


  0 passing (26s)
  1 failing

  1) Show account details
       should show the QR code for the account:
     Error: Errors found in browser console including the background:
Error: disconnected
  at new u (chrome-extension://ifoblgjpcpmgcoloepgfgbkehmckopop/ui-0.js:1:3360)
  at l.close (chrome-extension://ifoblgjpcpmgcoloepgfgbkehmckopop/ui-0.js:1:4347)
  at d (chrome-extension://ifoblgjpcpmgcoloepgfgbkehmckopop/common-2.js:110:224851)
  at o.emit (chrome-extension://ifoblgjpcpmgcoloepgfgbkehmckopop/common-2.js:110:227856)
  at D (chrome-extension://ifoblgjpcpmgcoloepgfgbkehmckopop/common-6.js:1:203653)
  at chrome-extension://ifoblgjpcpmgcoloepgfgbkehmckopop/common-6.js:1:224131
  at p.run (chrome-extension://ifoblgjpcpmgcoloepgfgbkehmckopop/common-6.js:1:165446)
  at m (chrome-extension://ifoblgjpcpmgcoloepgfgbkehmckopop/common-6.js:1:164940)
  at s (chrome-extension://ifoblgjpcpmgcoloepgfgbkehmckopop/sentry-install.js:1:11246)
CompileError: WebAssembly.Module(): Refused to compile or instantiate WebAssembly module because neither 'wasm-eval' nor 'unsafe-eval' is an allowed source of script in the following Content Security Policy directive: "script-src 'self'"
  at new Module (chrome-extension://ifoblgjpcpmgcoloepgfgbkehmckopop/runtime-lavamoat.js:10530:24)
  at Object.<anonymous> (chrome-extension://ifoblgjpcpmgcoloepgfgbkehmckopop/background-1.js:1:170265)
  at internalRequire (chrome-extension://ifoblgjpcpmgcoloepgfgbkehmckopop/runtime-lavamoat.js:10966:27)
  at requireRelative (chrome-extension://ifoblgjpcpmgcoloepgfgbkehmckopop/runtime-lavamoat.js:11009:27)
  at requireRelativeWithContext (chrome-extension://ifoblgjpcpmgcoloepgfgbkehmckopop/runtime-lavamoat.js:10978:18)
  at Object.<anonymous> (chrome-extension://ifoblgjpcpmgcoloepgfgbkehmckopop/background-1.js:1:167043)
  at internalRequire (chrome-extension://ifoblgjpcpmgcoloepgfgbkehmckopop/runtime-lavamoat.js:10966:27)
  at requireRelative (chrome-extension://ifoblgjpcpmgcoloepgfgbkehmckopop/runtime-lavamoat.js:11009:27)
  at requireRelativeWithContext (chrome-extension://ifoblgjpcpmgcoloepgfgbkehmckopop/runtime-lavamoat.js:10978:18)
  at Object.<anonymous> (chrome-extension://ifoblgjpcpmgcoloepgfgbkehmckopop/background-1.js:1:182581)
  at internalRequire (chrome-extension://ifoblgjpcpmgcoloepgfgbkehmckopop/runtime-lavamoat.js:10966:27)
  at requireRelative (chrome-extension://ifoblgjpcpmgcoloepgfgbkehmckopop/runtime-lavamoat.js:11009:27)
  at requireRelativeWithContext (chrome-extension://ifoblgjpcpmgcoloepgfgbkehmckopop/runtime-lavamoat.js:10978:18)
  at Object.<anonymous> (chrome-extension://ifoblgjpcpmgcoloepgfgbkehmckopop/background-1.js:1:184810)
  at internalRequire (chrome-extension://ifoblgjpcpmgcoloepgfgbkehmckopop/runtime-lavamoat.js:10966:27)
  at requireRelative (chrome-extension://ifoblgjpcpmgcoloepgfgbkehmckopop/runtime-lavamoat.js:11009:27)
  at requireRelativeWithContext (chrome-extension://ifoblgjpcpmgcoloepgfgbkehmckopop/runtime-lavamoat.js:10978:18)
  at Object.<anonymous> (chrome-extension://ifoblgjpcpmgcoloepgfgbkehmckopop/background-1.js:1:232142)
  at internalRequire (chrome-extension://ifoblgjpcpmgcoloepgfgbkehmckopop/runtime-lavamoat.js:10966:27)
  at requireRelative (chrome-extension://ifoblgjpcpmgcoloepgfgbkehmckopop/runtime-lavamoat.js:11009:27)
  at requireRelativeWithContext (chrome-extension://ifoblgjpcpmgcoloepgfgbkehmckopop/runtime-lavamoat.js:10978:18)
  at Object.<anonymous> (chrome-extension://ifoblgjpcpmgcoloepgfgbkehmckopop/background-1.js:1:213956)
  at internalRequire (chrome-extension://ifoblgjpcpmgcoloepgfgbkehmckopop/runtime-lavamoat.js:10966:27)
  at requireRelative (chrome-extension://ifoblgjpcpmgcoloepgfgbkehmckopop/runtime-lavamoat.js:11009:27)
  at requireRelativeWithContext (chrome-extension://ifoblgjpcpmgcoloepgfgbkehmckopop/runtime-lavamoat.js:10978:18)
  at Object.<anonymous> (chrome-extension://ifoblgjpcpmgcoloepgfgbkehmckopop/background-4.js:13:125256)
  at Object.<anonymous> (chrome-extension://ifoblgjpcpmgcoloepgfgbkehmckopop/background-4.js:13:141202)
  at Object.<anonymous> (chrome-extension://ifoblgjpcpmgcoloepgfgbkehmckopop/background-4.js:13:141215)
  at internalRequire (chrome-extension://ifoblgjpcpmgcoloepgfgbkehmckopop/runtime-lavamoat.js:10966:27)
  at requireRelative (chrome-extension://ifoblgjpcpmgcoloepgfgbkehmckopop/runtime-lavamoat.js:11009:27)
  at requireRelativeWithContext (chrome-extension://ifoblgjpcpmgcoloepgfgbkehmckopop/runtime-lavamoat.js:10978:18)
  at Object.<anonymous> (chrome-extension://ifoblgjpcpmgcoloepgfgbkehmckopop/background-4.js:13:36599)
  at Object.<anonymous> (chrome-extension://ifoblgjpcpmgcoloepgfgbkehmckopop/background-4.js:13:48574)
  at Object.<anonymous> (chrome-extension://ifoblgjpcpmgcoloepgfgbkehmckopop/background-4.js:13:48587)
  at internalRequire (chrome-extension://ifoblgjpcpmgcoloepgfgbkehmckopop/runtime-lavamoat.js:10966:27)
  at requireRelative (chrome-extension://ifoblgjpcpmgcoloepgfgbkehmckopop/runtime-lavamoat.js:11009:27)
  at requireRelativeWithContext (chrome-extension://ifoblgjpcpmgcoloepgfgbkehmckopop/runtime-lavamoat.js:10978:18)
  at Object.<anonymous> (chrome-extension://ifoblgjpcpmgcoloepgfgbkehmckopop/background-4.js:13:107693)
  at Object.<anonymous> (chrome-extension://ifoblgjpcpmgcoloepgfgbkehmckopop/background-4.js:13:111802)
  at Object.<anonymous> (chrome-extension://ifoblgjpcpmgcoloepgfgbkehmckopop/background-4.js:13:111815)
  at internalRequire (chrome-extension://ifoblgjpcpmgcoloepgfgbkehmckopop/runtime-lavamoat.js:10966:27)
  at requireRelative (chrome-extension://ifoblgjpcpmgcoloepgfgbkehmckopop/runtime-lavamoat.js:11009:27)
  at requireRelativeWithContext (chrome-extension://ifoblgjpcpmgcoloepgfgbkehmckopop/runtime-lavamoat.js:10978:18)
  at Object.<anonymous> (chrome-extension://ifoblgjpcpmgcoloepgfgbkehmckopop/background-4.js:13:51059)
  at Object.<anonymous> (chrome-extension://ifoblgjpcpmgcoloepgfgbkehmckopop/background-4.js:13:53147)
  at Object.<anonymous> (chrome-extension://ifoblgjpcpmgcoloepgfgbkehmckopop/background-4.js:13:53160)
  at internalRequire (chrome-extension://ifoblgjpcpmgcoloepgfgbkehmckopop/runtime-lavamoat.js:10966:27)
  at requireRelative (chrome-extension://ifoblgjpcpmgcoloepgfgbkehmckopop/runtime-lavamoat.js:11009:27)
  at requireRelativeWithContext (chrome-extension://ifoblgjpcpmgcoloepgfgbkehmckopop/runtime-lavamoat.js:10978:18)
  at Object.<anonymous> (chrome-extension://ifoblgjpcpmgcoloepgfgbkehmckopop/background-4.js:13:80877)
      at withFixtures (test/e2e/helpers.js:160:15)
      at processTicksAndRejections (node:internal/process/task_queues:96:5)
      at async Context.<anonymous> (test/e2e/tests/account-details.spec.js:16:5)



info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

## Manual Testing Steps

<!--
How should reviewers and QA manually test your changes? For instance:

- Go to this screen
- Do this
- Then do this
-->

See: #16453

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
