### PR TITLE
fix cached detected token results

### DIFF
--- a/.storybook/test-data.js
+++ b/.storybook/test-data.js
@@ -459,6 +459,53 @@ const state = {
         decimals: 18,
       },
     ],
+    allDetectedTokens: {
+      '0x5' : {
+        '0x9d0ba4ddac06032527b140912ec808ab9451b788': [
+          {
+            address: '0x514910771AF9Ca656af840dff83E8264EcF986CA',
+            decimals: 18,
+            symbol: 'LINK',
+            image: 'https://crypto.com/price/coin-data/icon/LINK/color_icon.png',
+            aggregators: ['coinGecko', 'oneInch', 'paraswap', 'zapper', 'zerion'],
+          },
+          {
+            address: '0xc00e94Cb662C3520282E6f5717214004A7f26888',
+            decimals: 18,
+            symbol: 'COMP',
+            image: 'https://crypto.com/price/coin-data/icon/COMP/color_icon.png',
+            aggregators: [
+              'bancor',
+              'cmc',
+              'cryptocom',
+              'coinGecko',
+              'oneInch',
+              'paraswap',
+              'pmm',
+              'zapper',
+              'zerion',
+              'zeroEx',
+            ],
+          },
+          {
+            address: '0xfffffffFf15AbF397dA76f1dcc1A1604F45126DB',
+            decimals: 18,
+            symbol: 'FSW',
+            image:
+              'https://assets.coingecko.com/coins/images/12256/thumb/falconswap.png?1598534184',
+            aggregators: [
+              'aave',
+              'cmc',
+              'coinGecko',
+              'oneInch',
+              'paraswap',
+              'zapper',
+              'zerion',
+            ],
+          },
+        ]
+      }
+    },
     detectedTokens: [
       {
         address: '0x514910771AF9Ca656af840dff83E8264EcF986CA',

--- a/app/scripts/controllers/detect-tokens.js
+++ b/app/scripts/controllers/detect-tokens.js
@@ -89,7 +89,8 @@ export default class DetectTokensController {
    */
   async detectNewTokens({ selectedAddress, chainId }) {
     const addressAgainstWhichToDetect = selectedAddress ?? this.selectedAddress;
-    const chainIdAgainstWhichToDetect = chainId ?? this.chainId;
+    const chainIdAgainstWhichToDetect =
+      chainId ?? this.getChainIdFromNetworkStore(this._network);
     if (!this.isActive) {
       return;
     }

--- a/app/scripts/controllers/detect-tokens.js
+++ b/app/scripts/controllers/detect-tokens.js
@@ -191,7 +191,7 @@ export default class DetectTokensController {
    * @param options0.selectedAddress
    * @param options0.chainId
    */
-  restartTokenDetection({ selectedAddress, chainId }) {
+  restartTokenDetection({ selectedAddress, chainId } = {}) {
     const addressAgainstWhichToDetect = selectedAddress ?? this.selectedAddress;
     const chainIdAgainstWhichToDetect = chainId ?? this.chainId;
     if (

--- a/app/scripts/controllers/detect-tokens.js
+++ b/app/scripts/controllers/detect-tokens.js
@@ -66,7 +66,7 @@ export default class DetectTokensController {
       ) {
         this.selectedAddress = selectedAddress;
         this.useTokenDetection = useTokenDetection;
-        this.restartTokenDetection();
+        this.restartTokenDetection({ selectedAddress });
       }
     });
     tokensController?.subscribe(

--- a/app/scripts/controllers/detect-tokens.js
+++ b/app/scripts/controllers/detect-tokens.js
@@ -83,9 +83,9 @@ export default class DetectTokensController {
   /**
    * For each token in the tokenlist provided by the TokenListController, check selectedAddress balance.
    *
-   * @param options0
-   * @param options0.selectedAddress
-   * @param options0.chainId
+   * @param options
+   * @param options.selectedAddress - the selectedAddress against which to detect for token balances
+   * @param options.chainId - the chainId against which to detect for token balances
    */
   async detectNewTokens({ selectedAddress, chainId }) {
     const addressAgainstWhichToDetect = selectedAddress ?? this.selectedAddress;
@@ -187,9 +187,9 @@ export default class DetectTokensController {
    * Restart token detection polling period and call detectNewTokens
    * in case of address change or user session initialization.
    *
-   * @param options0
-   * @param options0.selectedAddress
-   * @param options0.chainId
+   * @param options
+   * @param options.selectedAddress - the selectedAddress against which to detect for token balances
+   * @param options.chainId - the chainId against which to detect for token balances
    */
   restartTokenDetection({ selectedAddress, chainId } = {}) {
     const addressAgainstWhichToDetect = selectedAddress ?? this.selectedAddress;

--- a/app/scripts/controllers/detect-tokens.js
+++ b/app/scripts/controllers/detect-tokens.js
@@ -195,13 +195,7 @@ export default class DetectTokensController {
   restartTokenDetection({ selectedAddress, chainId } = {}) {
     const addressAgainstWhichToDetect = selectedAddress ?? this.selectedAddress;
     const chainIdAgainstWhichToDetect = chainId ?? this.chainId;
-    if (
-      !(
-        this.isActive ||
-        !addressAgainstWhichToDetect ||
-        chainIdAgainstWhichToDetect !== CHAIN_IDS.MAINNET
-      )
-    ) {
+    if (!(this.isActive && addressAgainstWhichToDetect)) {
       return;
     }
     this.detectNewTokens({

--- a/app/scripts/controllers/detect-tokens.js
+++ b/app/scripts/controllers/detect-tokens.js
@@ -172,7 +172,10 @@ export default class DetectTokensController {
               asset_type: ASSET_TYPES.TOKEN,
             },
           });
-          await this.tokensController.addDetectedTokens(tokensWithBalance);
+          await this.tokensController.addDetectedTokens(tokensWithBalance, {
+            selectedAddress: this.selectedAddress,
+            chainId: this.chainId,
+          });
         }
       }
     }

--- a/app/scripts/controllers/detect-tokens.js
+++ b/app/scripts/controllers/detect-tokens.js
@@ -87,7 +87,7 @@ export default class DetectTokensController {
    * @param options.selectedAddress - the selectedAddress against which to detect for token balances
    * @param options.chainId - the chainId against which to detect for token balances
    */
-  async detectNewTokens({ selectedAddress, chainId }) {
+  async detectNewTokens({ selectedAddress, chainId } = {}) {
     const addressAgainstWhichToDetect = selectedAddress ?? this.selectedAddress;
     const chainIdAgainstWhichToDetect =
       chainId ?? this.getChainIdFromNetworkStore(this._network);

--- a/lavamoat/browserify/beta/policy.json
+++ b/lavamoat/browserify/beta/policy.json
@@ -502,14 +502,9 @@
     },
     "@metamask/approval-controller": {
       "packages": {
-        "@metamask/approval-controller>@metamask/base-controller": true,
         "@metamask/approval-controller>nanoid": true,
+        "@metamask/base-controller": true,
         "eth-rpc-errors": true
-      }
-    },
-    "@metamask/approval-controller>@metamask/base-controller": {
-      "packages": {
-        "immer": true
       }
     },
     "@metamask/approval-controller>nanoid": {
@@ -1146,18 +1141,13 @@
     },
     "@metamask/permission-controller": {
       "packages": {
+        "@metamask/base-controller": true,
         "@metamask/controller-utils": true,
-        "@metamask/permission-controller>@metamask/base-controller": true,
         "@metamask/permission-controller>nanoid": true,
         "deep-freeze-strict": true,
         "eth-rpc-errors": true,
         "immer": true,
         "json-rpc-engine": true
-      }
-    },
-    "@metamask/permission-controller>@metamask/base-controller": {
-      "packages": {
-        "immer": true
       }
     },
     "@metamask/permission-controller>nanoid": {
@@ -1448,12 +1438,7 @@
     },
     "@metamask/subject-metadata-controller": {
       "packages": {
-        "@metamask/subject-metadata-controller>@metamask/base-controller": true
-      }
-    },
-    "@metamask/subject-metadata-controller>@metamask/base-controller": {
-      "packages": {
-        "immer": true
+        "@metamask/base-controller": true
       }
     },
     "@ngraveio/bc-ur": {

--- a/lavamoat/browserify/beta/policy.json
+++ b/lavamoat/browserify/beta/policy.json
@@ -502,9 +502,14 @@
     },
     "@metamask/approval-controller": {
       "packages": {
+        "@metamask/approval-controller>@metamask/base-controller": true,
         "@metamask/approval-controller>nanoid": true,
-        "@metamask/base-controller": true,
         "eth-rpc-errors": true
+      }
+    },
+    "@metamask/approval-controller>@metamask/base-controller": {
+      "packages": {
+        "immer": true
       }
     },
     "@metamask/approval-controller>nanoid": {
@@ -526,10 +531,10 @@
         "@eth-optimism/contracts>@ethersproject/contracts": true,
         "@metamask/assets-controllers>@ethersproject/abi": true,
         "@metamask/assets-controllers>@ethersproject/providers": true,
-        "@metamask/assets-controllers>@metamask/base-controller": true,
         "@metamask/assets-controllers>abort-controller": true,
         "@metamask/assets-controllers>async-mutex": true,
         "@metamask/assets-controllers>multiformats": true,
+        "@metamask/base-controller": true,
         "@metamask/contract-metadata": true,
         "@metamask/controller-utils": true,
         "@metamask/metamask-eth-abis": true,
@@ -601,11 +606,6 @@
       "packages": {
         "@ethersproject/bignumber>@ethersproject/bytes": true,
         "@ethersproject/bignumber>@ethersproject/logger": true
-      }
-    },
-    "@metamask/assets-controllers>@metamask/base-controller": {
-      "packages": {
-        "immer": true
       }
     },
     "@metamask/assets-controllers>abort-controller": {
@@ -1146,13 +1146,18 @@
     },
     "@metamask/permission-controller": {
       "packages": {
-        "@metamask/base-controller": true,
         "@metamask/controller-utils": true,
+        "@metamask/permission-controller>@metamask/base-controller": true,
         "@metamask/permission-controller>nanoid": true,
         "deep-freeze-strict": true,
         "eth-rpc-errors": true,
         "immer": true,
         "json-rpc-engine": true
+      }
+    },
+    "@metamask/permission-controller>@metamask/base-controller": {
+      "packages": {
+        "immer": true
       }
     },
     "@metamask/permission-controller>nanoid": {
@@ -1443,7 +1448,12 @@
     },
     "@metamask/subject-metadata-controller": {
       "packages": {
-        "@metamask/base-controller": true
+        "@metamask/subject-metadata-controller>@metamask/base-controller": true
+      }
+    },
+    "@metamask/subject-metadata-controller>@metamask/base-controller": {
+      "packages": {
+        "immer": true
       }
     },
     "@ngraveio/bc-ur": {

--- a/lavamoat/browserify/flask/policy.json
+++ b/lavamoat/browserify/flask/policy.json
@@ -502,14 +502,9 @@
     },
     "@metamask/approval-controller": {
       "packages": {
-        "@metamask/approval-controller>@metamask/base-controller": true,
         "@metamask/approval-controller>nanoid": true,
+        "@metamask/base-controller": true,
         "eth-rpc-errors": true
-      }
-    },
-    "@metamask/approval-controller>@metamask/base-controller": {
-      "packages": {
-        "immer": true
       }
     },
     "@metamask/approval-controller>nanoid": {
@@ -1158,18 +1153,13 @@
     },
     "@metamask/permission-controller": {
       "packages": {
+        "@metamask/base-controller": true,
         "@metamask/controller-utils": true,
-        "@metamask/permission-controller>@metamask/base-controller": true,
         "@metamask/permission-controller>nanoid": true,
         "deep-freeze-strict": true,
         "eth-rpc-errors": true,
         "immer": true,
         "json-rpc-engine": true
-      }
-    },
-    "@metamask/permission-controller>@metamask/base-controller": {
-      "packages": {
-        "immer": true
       }
     },
     "@metamask/permission-controller>nanoid": {
@@ -1817,12 +1807,7 @@
     },
     "@metamask/subject-metadata-controller": {
       "packages": {
-        "@metamask/subject-metadata-controller>@metamask/base-controller": true
-      }
-    },
-    "@metamask/subject-metadata-controller>@metamask/base-controller": {
-      "packages": {
-        "immer": true
+        "@metamask/base-controller": true
       }
     },
     "@ngraveio/bc-ur": {

--- a/lavamoat/browserify/flask/policy.json
+++ b/lavamoat/browserify/flask/policy.json
@@ -502,9 +502,14 @@
     },
     "@metamask/approval-controller": {
       "packages": {
+        "@metamask/approval-controller>@metamask/base-controller": true,
         "@metamask/approval-controller>nanoid": true,
-        "@metamask/base-controller": true,
         "eth-rpc-errors": true
+      }
+    },
+    "@metamask/approval-controller>@metamask/base-controller": {
+      "packages": {
+        "immer": true
       }
     },
     "@metamask/approval-controller>nanoid": {
@@ -526,10 +531,10 @@
         "@eth-optimism/contracts>@ethersproject/contracts": true,
         "@metamask/assets-controllers>@ethersproject/abi": true,
         "@metamask/assets-controllers>@ethersproject/providers": true,
-        "@metamask/assets-controllers>@metamask/base-controller": true,
         "@metamask/assets-controllers>abort-controller": true,
         "@metamask/assets-controllers>async-mutex": true,
         "@metamask/assets-controllers>multiformats": true,
+        "@metamask/base-controller": true,
         "@metamask/contract-metadata": true,
         "@metamask/controller-utils": true,
         "@metamask/metamask-eth-abis": true,
@@ -601,11 +606,6 @@
       "packages": {
         "@ethersproject/bignumber>@ethersproject/bytes": true,
         "@ethersproject/bignumber>@ethersproject/logger": true
-      }
-    },
-    "@metamask/assets-controllers>@metamask/base-controller": {
-      "packages": {
-        "immer": true
       }
     },
     "@metamask/assets-controllers>abort-controller": {
@@ -1158,13 +1158,18 @@
     },
     "@metamask/permission-controller": {
       "packages": {
-        "@metamask/base-controller": true,
         "@metamask/controller-utils": true,
+        "@metamask/permission-controller>@metamask/base-controller": true,
         "@metamask/permission-controller>nanoid": true,
         "deep-freeze-strict": true,
         "eth-rpc-errors": true,
         "immer": true,
         "json-rpc-engine": true
+      }
+    },
+    "@metamask/permission-controller>@metamask/base-controller": {
+      "packages": {
+        "immer": true
       }
     },
     "@metamask/permission-controller>nanoid": {
@@ -1812,7 +1817,12 @@
     },
     "@metamask/subject-metadata-controller": {
       "packages": {
-        "@metamask/base-controller": true
+        "@metamask/subject-metadata-controller>@metamask/base-controller": true
+      }
+    },
+    "@metamask/subject-metadata-controller>@metamask/base-controller": {
+      "packages": {
+        "immer": true
       }
     },
     "@ngraveio/bc-ur": {

--- a/lavamoat/browserify/main/policy.json
+++ b/lavamoat/browserify/main/policy.json
@@ -502,14 +502,9 @@
     },
     "@metamask/approval-controller": {
       "packages": {
-        "@metamask/approval-controller>@metamask/base-controller": true,
         "@metamask/approval-controller>nanoid": true,
+        "@metamask/base-controller": true,
         "eth-rpc-errors": true
-      }
-    },
-    "@metamask/approval-controller>@metamask/base-controller": {
-      "packages": {
-        "immer": true
       }
     },
     "@metamask/approval-controller>nanoid": {
@@ -1146,18 +1141,13 @@
     },
     "@metamask/permission-controller": {
       "packages": {
+        "@metamask/base-controller": true,
         "@metamask/controller-utils": true,
-        "@metamask/permission-controller>@metamask/base-controller": true,
         "@metamask/permission-controller>nanoid": true,
         "deep-freeze-strict": true,
         "eth-rpc-errors": true,
         "immer": true,
         "json-rpc-engine": true
-      }
-    },
-    "@metamask/permission-controller>@metamask/base-controller": {
-      "packages": {
-        "immer": true
       }
     },
     "@metamask/permission-controller>nanoid": {
@@ -1448,12 +1438,7 @@
     },
     "@metamask/subject-metadata-controller": {
       "packages": {
-        "@metamask/subject-metadata-controller>@metamask/base-controller": true
-      }
-    },
-    "@metamask/subject-metadata-controller>@metamask/base-controller": {
-      "packages": {
-        "immer": true
+        "@metamask/base-controller": true
       }
     },
     "@ngraveio/bc-ur": {

--- a/lavamoat/browserify/main/policy.json
+++ b/lavamoat/browserify/main/policy.json
@@ -502,9 +502,14 @@
     },
     "@metamask/approval-controller": {
       "packages": {
+        "@metamask/approval-controller>@metamask/base-controller": true,
         "@metamask/approval-controller>nanoid": true,
-        "@metamask/base-controller": true,
         "eth-rpc-errors": true
+      }
+    },
+    "@metamask/approval-controller>@metamask/base-controller": {
+      "packages": {
+        "immer": true
       }
     },
     "@metamask/approval-controller>nanoid": {
@@ -526,10 +531,10 @@
         "@eth-optimism/contracts>@ethersproject/contracts": true,
         "@metamask/assets-controllers>@ethersproject/abi": true,
         "@metamask/assets-controllers>@ethersproject/providers": true,
-        "@metamask/assets-controllers>@metamask/base-controller": true,
         "@metamask/assets-controllers>abort-controller": true,
         "@metamask/assets-controllers>async-mutex": true,
         "@metamask/assets-controllers>multiformats": true,
+        "@metamask/base-controller": true,
         "@metamask/contract-metadata": true,
         "@metamask/controller-utils": true,
         "@metamask/metamask-eth-abis": true,
@@ -601,11 +606,6 @@
       "packages": {
         "@ethersproject/bignumber>@ethersproject/bytes": true,
         "@ethersproject/bignumber>@ethersproject/logger": true
-      }
-    },
-    "@metamask/assets-controllers>@metamask/base-controller": {
-      "packages": {
-        "immer": true
       }
     },
     "@metamask/assets-controllers>abort-controller": {
@@ -1146,13 +1146,18 @@
     },
     "@metamask/permission-controller": {
       "packages": {
-        "@metamask/base-controller": true,
         "@metamask/controller-utils": true,
+        "@metamask/permission-controller>@metamask/base-controller": true,
         "@metamask/permission-controller>nanoid": true,
         "deep-freeze-strict": true,
         "eth-rpc-errors": true,
         "immer": true,
         "json-rpc-engine": true
+      }
+    },
+    "@metamask/permission-controller>@metamask/base-controller": {
+      "packages": {
+        "immer": true
       }
     },
     "@metamask/permission-controller>nanoid": {
@@ -1443,7 +1448,12 @@
     },
     "@metamask/subject-metadata-controller": {
       "packages": {
-        "@metamask/base-controller": true
+        "@metamask/subject-metadata-controller>@metamask/base-controller": true
+      }
+    },
+    "@metamask/subject-metadata-controller>@metamask/base-controller": {
+      "packages": {
+        "immer": true
       }
     },
     "@ngraveio/bc-ur": {

--- a/lavamoat/build-system/policy.json
+++ b/lavamoat/build-system/policy.json
@@ -957,6 +957,70 @@
         "gulp>gulp-cli>isobject": true
       }
     },
+    "@lavamoat/allow-scripts>@npmcli/run-script>node-gyp>npmlog": {
+      "builtin": {
+        "events.EventEmitter": true,
+        "util": true
+      },
+      "globals": {
+        "process.nextTick": true,
+        "process.stderr": true
+      },
+      "packages": {
+        "@lavamoat/allow-scripts>@npmcli/run-script>node-gyp>npmlog>are-we-there-yet": true,
+        "@lavamoat/allow-scripts>@npmcli/run-script>node-gyp>npmlog>gauge": true,
+        "@storybook/react>@storybook/node-logger>npmlog>console-control-strings": true,
+        "nyc>yargs>set-blocking": true
+      }
+    },
+    "@lavamoat/allow-scripts>@npmcli/run-script>node-gyp>npmlog>are-we-there-yet": {
+      "builtin": {
+        "events.EventEmitter": true,
+        "util.inherits": true
+      },
+      "packages": {
+        "koa>delegates": true,
+        "readable-stream": true
+      }
+    },
+    "@lavamoat/allow-scripts>@npmcli/run-script>node-gyp>npmlog>gauge": {
+      "builtin": {
+        "util.format": true
+      },
+      "globals": {
+        "clearInterval": true,
+        "process": true,
+        "setImmediate": true,
+        "setInterval": true
+      },
+      "packages": {
+        "@lavamoat/allow-scripts>@npmcli/run-script>node-gyp>npmlog>gauge>aproba": true,
+        "@lavamoat/allow-scripts>@npmcli/run-script>node-gyp>npmlog>gauge>string-width": true,
+        "@lavamoat/allow-scripts>@npmcli/run-script>node-gyp>npmlog>gauge>strip-ansi": true,
+        "@storybook/react>@storybook/node-logger>npmlog>console-control-strings": true,
+        "@storybook/react>@storybook/node-logger>npmlog>gauge>has-unicode": true,
+        "@storybook/react>@storybook/node-logger>npmlog>gauge>wide-align": true,
+        "nyc>signal-exit": true,
+        "react>object-assign": true
+      }
+    },
+    "@lavamoat/allow-scripts>@npmcli/run-script>node-gyp>npmlog>gauge>string-width": {
+      "packages": {
+        "@lavamoat/allow-scripts>@npmcli/run-script>node-gyp>npmlog>gauge>string-width>is-fullwidth-code-point": true,
+        "@lavamoat/allow-scripts>@npmcli/run-script>node-gyp>npmlog>gauge>strip-ansi": true,
+        "gulp>gulp-cli>yargs>string-width>code-point-at": true
+      }
+    },
+    "@lavamoat/allow-scripts>@npmcli/run-script>node-gyp>npmlog>gauge>string-width>is-fullwidth-code-point": {
+      "packages": {
+        "gulp>gulp-cli>yargs>string-width>is-fullwidth-code-point>number-is-nan": true
+      }
+    },
+    "@lavamoat/allow-scripts>@npmcli/run-script>node-gyp>npmlog>gauge>strip-ansi": {
+      "packages": {
+        "@lavamoat/allow-scripts>@npmcli/run-script>node-gyp>npmlog>gauge>strip-ansi>ansi-regex": true
+      }
+    },
     "@lavamoat/lavapack": {
       "builtin": {
         "assert": true,
@@ -1056,6 +1120,31 @@
     "@storybook/components>qs": {
       "packages": {
         "string.prototype.matchall>side-channel": true
+      }
+    },
+    "@storybook/core>@storybook/core-server>x-default-browser>default-browser-id>untildify>os-homedir": {
+      "builtin": {
+        "os.homedir": true
+      },
+      "globals": {
+        "process.env": true,
+        "process.getuid": true,
+        "process.platform": true
+      }
+    },
+    "@storybook/react>@storybook/node-logger>npmlog>gauge>has-unicode": {
+      "builtin": {
+        "os.type": true
+      },
+      "globals": {
+        "process.env.LANG": true,
+        "process.env.LC_ALL": true,
+        "process.env.LC_CTYPE": true
+      }
+    },
+    "@storybook/react>@storybook/node-logger>npmlog>gauge>wide-align": {
+      "packages": {
+        "yargs>string-width": true
       }
     },
     "@storybook/react>acorn-walk": {
@@ -1809,6 +1898,7 @@
       },
       "packages": {
         "chokidar>braces": true,
+        "chokidar>fsevents": true,
         "chokidar>glob-parent": true,
         "chokidar>is-binary-path": true,
         "chokidar>normalize-path": true,
@@ -1834,6 +1924,13 @@
       "packages": {
         "chokidar>braces>fill-range>to-regex-range>is-number": true
       }
+    },
+    "chokidar>fsevents": {
+      "globals": {
+        "console.assert": true,
+        "process.platform": true
+      },
+      "native": true
     },
     "chokidar>glob-parent": {
       "builtin": {
@@ -4186,6 +4283,7 @@
         "gulp-watch>chokidar>anymatch": true,
         "gulp-watch>chokidar>async-each": true,
         "gulp-watch>chokidar>braces": true,
+        "gulp-watch>chokidar>fsevents": true,
         "gulp-watch>chokidar>is-binary-path": true,
         "gulp-watch>chokidar>readdirp": true,
         "gulp-watch>chokidar>upath": true,
@@ -4556,6 +4654,142 @@
     "gulp-watch>chokidar>braces>to-regex>safe-regex": {
       "packages": {
         "enzyme>rst-selector-parser>nearley>randexp>ret": true
+      }
+    },
+    "gulp-watch>chokidar>fsevents": {
+      "builtin": {
+        "events.EventEmitter": true,
+        "fs.stat": true,
+        "path.join": true,
+        "util.inherits": true
+      },
+      "globals": {
+        "__dirname": true,
+        "console.assert": true,
+        "process.nextTick": true,
+        "process.platform": true,
+        "setImmediate": true
+      },
+      "packages": {
+        "gulp-watch>chokidar>fsevents>node-pre-gyp": true
+      }
+    },
+    "gulp-watch>chokidar>fsevents>node-pre-gyp": {
+      "builtin": {
+        "events.EventEmitter": true,
+        "fs.existsSync": true,
+        "fs.readFileSync": true,
+        "fs.renameSync": true,
+        "path.dirname": true,
+        "path.existsSync": true,
+        "path.join": true,
+        "path.resolve": true,
+        "url.parse": true,
+        "url.resolve": true,
+        "util.inherits": true
+      },
+      "globals": {
+        "__dirname": true,
+        "console.log": true,
+        "process.arch": true,
+        "process.cwd": true,
+        "process.env": true,
+        "process.platform": true,
+        "process.version.substr": true,
+        "process.versions": true
+      },
+      "packages": {
+        "@lavamoat/allow-scripts>@npmcli/run-script>node-gyp>npmlog": true,
+        "gulp-watch>chokidar>fsevents>node-pre-gyp>detect-libc": true,
+        "gulp-watch>chokidar>fsevents>node-pre-gyp>nopt": true,
+        "gulp-watch>chokidar>fsevents>node-pre-gyp>rimraf": true,
+        "gulp-watch>chokidar>fsevents>node-pre-gyp>semver": true
+      }
+    },
+    "gulp-watch>chokidar>fsevents>node-pre-gyp>detect-libc": {
+      "builtin": {
+        "child_process.spawnSync": true,
+        "fs.readdirSync": true,
+        "os.platform": true
+      },
+      "globals": {
+        "process.env": true
+      }
+    },
+    "gulp-watch>chokidar>fsevents>node-pre-gyp>nopt": {
+      "builtin": {
+        "path": true,
+        "stream.Stream": true,
+        "url": true
+      },
+      "globals": {
+        "console": true,
+        "process.argv": true,
+        "process.env.DEBUG_NOPT": true,
+        "process.env.NOPT_DEBUG": true,
+        "process.platform": true
+      },
+      "packages": {
+        "@lavamoat/allow-scripts>@npmcli/run-script>node-gyp>nopt>abbrev": true,
+        "gulp-watch>chokidar>fsevents>node-pre-gyp>nopt>osenv": true
+      }
+    },
+    "gulp-watch>chokidar>fsevents>node-pre-gyp>nopt>osenv": {
+      "builtin": {
+        "child_process.exec": true,
+        "path": true
+      },
+      "globals": {
+        "process.env.COMPUTERNAME": true,
+        "process.env.ComSpec": true,
+        "process.env.EDITOR": true,
+        "process.env.HOSTNAME": true,
+        "process.env.PATH": true,
+        "process.env.PROMPT": true,
+        "process.env.PS1": true,
+        "process.env.Path": true,
+        "process.env.SHELL": true,
+        "process.env.USER": true,
+        "process.env.USERDOMAIN": true,
+        "process.env.USERNAME": true,
+        "process.env.VISUAL": true,
+        "process.env.path": true,
+        "process.nextTick": true,
+        "process.platform": true
+      },
+      "packages": {
+        "@storybook/core>@storybook/core-server>x-default-browser>default-browser-id>untildify>os-homedir": true,
+        "gulp-watch>chokidar>fsevents>node-pre-gyp>nopt>osenv>os-tmpdir": true
+      }
+    },
+    "gulp-watch>chokidar>fsevents>node-pre-gyp>nopt>osenv>os-tmpdir": {
+      "globals": {
+        "process.env.SystemRoot": true,
+        "process.env.TEMP": true,
+        "process.env.TMP": true,
+        "process.env.TMPDIR": true,
+        "process.env.windir": true,
+        "process.platform": true
+      }
+    },
+    "gulp-watch>chokidar>fsevents>node-pre-gyp>rimraf": {
+      "builtin": {
+        "assert": true,
+        "fs": true,
+        "path.join": true
+      },
+      "globals": {
+        "process.platform": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "nyc>glob": true
+      }
+    },
+    "gulp-watch>chokidar>fsevents>node-pre-gyp>semver": {
+      "globals": {
+        "console": true,
+        "process": true
       }
     },
     "gulp-watch>chokidar>is-binary-path": {
@@ -5134,6 +5368,7 @@
         "gulp-watch>path-is-absolute": true,
         "gulp>glob-watcher>anymatch": true,
         "gulp>glob-watcher>chokidar>braces": true,
+        "gulp>glob-watcher>chokidar>fsevents": true,
         "gulp>glob-watcher>chokidar>glob-parent": true,
         "gulp>glob-watcher>chokidar>is-binary-path": true,
         "gulp>glob-watcher>chokidar>readdirp": true,
@@ -5190,6 +5425,24 @@
       "packages": {
         "gulp>glob-watcher>chokidar>braces>fill-range>is-number": true,
         "stylelint>@stylelint/postcss-markdown>remark>remark-parse>repeat-string": true
+      }
+    },
+    "gulp>glob-watcher>chokidar>fsevents": {
+      "builtin": {
+        "events.EventEmitter": true,
+        "fs.stat": true,
+        "path.join": true,
+        "util.inherits": true
+      },
+      "globals": {
+        "__dirname": true,
+        "console.assert": true,
+        "process.nextTick": true,
+        "process.platform": true,
+        "setImmediate": true
+      },
+      "packages": {
+        "gulp-watch>chokidar>fsevents>node-pre-gyp": true
       }
     },
     "gulp>glob-watcher>chokidar>glob-parent": {
@@ -6263,6 +6516,12 @@
         "define": true,
         "isWindows": "write",
         "process": true
+      }
+    },
+    "nyc>yargs>set-blocking": {
+      "globals": {
+        "process.stderr": true,
+        "process.stdout": true
       }
     },
     "prettier": {

--- a/package.json
+++ b/package.json
@@ -202,7 +202,7 @@
     "@metamask/address-book-controller": "^1.0.0",
     "@metamask/announcement-controller": "^1.0.0",
     "@metamask/approval-controller": "^1.0.0",
-    "@metamask/assets-controllers": "^1.0.0",
+    "@metamask/assets-controllers": "^1.0.1",
     "@metamask/base-controller": "^1.0.0",
     "@metamask/contract-metadata": "^1.31.0",
     "@metamask/controller-utils": "^1.0.0",

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -1218,7 +1218,9 @@ export function getIsDynamicTokenListAvailable(state) {
  * @returns list of token objects
  */
 export function getDetectedTokensInCurrentNetwork(state) {
-  return state.metamask.detectedTokens;
+  const currentChainId = getCurrentChainId(state);
+  const selectedAddress = getSelectedAddress(state);
+  return state.metamask.allDetectedTokens?.[currentChainId]?.[selectedAddress];
 }
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -3723,15 +3723,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/assets-controllers@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "@metamask/assets-controllers@npm:1.0.0"
+"@metamask/assets-controllers@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "@metamask/assets-controllers@npm:1.0.1"
   dependencies:
     "@ethersproject/abi": ^5.7.0
     "@ethersproject/bignumber": ^5.7.0
     "@ethersproject/contracts": ^5.7.0
     "@ethersproject/providers": ^5.7.0
-    "@metamask/base-controller": ~1.0.0
+    "@metamask/base-controller": ~1.1.0
     "@metamask/contract-metadata": ^1.35.0
     "@metamask/controller-utils": ~1.0.0
     "@metamask/metamask-eth-abis": 3.0.0
@@ -3748,7 +3748,7 @@ __metadata:
     multiformats: ^9.5.2
     single-call-balance-checker-abi: ^1.0.0
     uuid: ^8.3.2
-  checksum: ac9bc8730abf1403ce3344e7c49f43b5ad1ec1fe472d291bf727f1bcab3a59c5d6ed81a946b26dfc22b29db17e5f2bf72b247a438395ed2499877c844a8a32f5
+  checksum: 678f32126aa84de769065581661218a247166ef2e4918290a8e082dd9c7b175d84c5a4d4f431c884dc83201b183f324c2b5047bc69a2ea7825d710470cae5f87
   languageName: node
   linkType: hard
 
@@ -3783,6 +3783,16 @@ __metadata:
     "@metamask/controller-utils": ~1.0.0
     immer: ^9.0.6
   checksum: 40affd024add235548c886bd8ad3348682231af8d4a2f7e6fbc5dea5ffa077ed48535f21ac17017c640c50b5d17b5211c30cbb23b7025f360801e72ccbd61a5d
+  languageName: node
+  linkType: hard
+
+"@metamask/base-controller@npm:~1.1.0":
+  version: 1.1.1
+  resolution: "@metamask/base-controller@npm:1.1.1"
+  dependencies:
+    "@metamask/controller-utils": ^1.0.0
+    immer: ^9.0.6
+  checksum: 676408129710a247e95a0705344aef09f2ed55b05ba516fc2788302e1cc2472b5e85f24866e7111ee667bd9e1311eb8f75da8409131ad9dc9901d6e31131db2a
   languageName: node
   linkType: hard
 
@@ -23332,7 +23342,7 @@ __metadata:
     "@metamask/address-book-controller": ^1.0.0
     "@metamask/announcement-controller": ^1.0.0
     "@metamask/approval-controller": ^1.0.0
-    "@metamask/assets-controllers": ^1.0.0
+    "@metamask/assets-controllers": ^1.0.1
     "@metamask/auto-changelog": ^2.1.0
     "@metamask/base-controller": ^1.0.0
     "@metamask/contract-metadata": ^1.31.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -3796,6 +3796,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@metamask/base-controller@npm:~1.0.0":
+  version: 1.0.0
+  resolution: "@metamask/base-controller@npm:1.0.0"
+  dependencies:
+    "@metamask/controller-utils": ~1.0.0
+    immer: ^9.0.6
+  checksum: 40affd024add235548c886bd8ad3348682231af8d4a2f7e6fbc5dea5ffa077ed48535f21ac17017c640c50b5d17b5211c30cbb23b7025f360801e72ccbd61a5d
+  languageName: node
+  linkType: hard
+
 "@metamask/bip39@npm:^4.0.0":
   version: 4.0.0
   resolution: "@metamask/bip39@npm:4.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3766,27 +3766,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/base-controller@npm:^1.0.0, @metamask/base-controller@npm:^1.1.1":
-  version: 1.1.1
-  resolution: "@metamask/base-controller@npm:1.1.1"
-  dependencies:
-    "@metamask/controller-utils": ^1.0.0
-    immer: ^9.0.6
-  checksum: 676408129710a247e95a0705344aef09f2ed55b05ba516fc2788302e1cc2472b5e85f24866e7111ee667bd9e1311eb8f75da8409131ad9dc9901d6e31131db2a
-  languageName: node
-  linkType: hard
-
-"@metamask/base-controller@npm:~1.0.0":
-  version: 1.0.0
-  resolution: "@metamask/base-controller@npm:1.0.0"
-  dependencies:
-    "@metamask/controller-utils": ~1.0.0
-    immer: ^9.0.6
-  checksum: 40affd024add235548c886bd8ad3348682231af8d4a2f7e6fbc5dea5ffa077ed48535f21ac17017c640c50b5d17b5211c30cbb23b7025f360801e72ccbd61a5d
-  languageName: node
-  linkType: hard
-
-"@metamask/base-controller@npm:~1.1.0":
+"@metamask/base-controller@npm:^1.0.0, @metamask/base-controller@npm:^1.1.1, @metamask/base-controller@npm:~1.1.0":
   version: 1.1.1
   resolution: "@metamask/base-controller@npm:1.1.1"
   dependencies:


### PR DESCRIPTION
~Blocked by https://github.com/MetaMask/controllers/pull/956 (and subsequent release of `@metamask/controllers`)~

Context (from https://github.com/MetaMask/controllers/pull/956):

_Currently there exists an issue (exposed by https://github.com/MetaMask/metamask-extension/issues/16349) where if a user changes accounts (account x to account y) or (changes from network a to network b) right as a detectTokens() call is occuring, the results of the getBalancesInSingleCall() call (withindetectTokens()) made against address x or network acan get incorrectly misattributed to accountyornetwork b. This can happen because currently detectTokens() simply calls this.addDetectedTokens() on the TokensController with the detected tokensToAdd assuming that when this call occurs in the TokensController the selectedAddress or chainId [used to store these detected assets](https://github.com/MetaMask/controllers/blob/9b82201b4c99059a7ab35942febdba840adce5ee/packages/assets-controllers/src/TokensController.ts#L709) will be the same as the one used to detect them. With sufficiently unfortunate timing this expectation can be broken, and so this PR introduces a pattern ([already used in the analogous flow between the NftDetectionController and the NftController](https://github.com/MetaMask/controllers/blob/main/packages/assets-controllers/src/NftDetectionController.ts#L397), whereby the address and network data are passed along with the detectedToken data to ensure they are stored correctly._

This PR leverages the changes made in https://github.com/MetaMask/controllers/pull/956, and additionally fixes a race condition that occurs where even if the detection data is stored correctly, the `detectedTokens` value does not get updated to reflect the correct chainId/network combo if/when the network/account is changed while the service worker is being restarted.

* Fixes https://github.com/MetaMask/metamask-extension/issues/16349


### Before

https://user-images.githubusercontent.com/34557516/206777046-4fbabb91-bcba-4bb9-9ffe-d380a0665238.mov

### After

https://user-images.githubusercontent.com/34557516/206775291-19339d64-232c-4271-99ad-7839165f3b76.mov


## Manual Testing Steps

1. Unlock MM
2. Get some tokens on the first account, so they are detected
3. Create a fresh new account
4. Change back to the account from step 2
5. Terminate service worker
6. Change back to the account from step 3 -- see that no detected tokens are cached

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes

