### PR TITLE
Add back error when password is too short

### DIFF
--- a/ui/pages/onboarding-flow/create-password/create-password.js
+++ b/ui/pages/onboarding-flow/create-password/create-password.js
@@ -85,13 +85,14 @@ export default function CreatePassword({
 
   const handlePasswordChange = (passwordInput) => {
     let confirmError = '';
+    let passwordInputError = '';
     const passwordEvaluation = zxcvbn(passwordInput);
     const passwordStrengthLabel = getPasswordStrengthLabel(
       passwordEvaluation.score,
       t,
     );
-    const passwordStrengthDescription = passwordStrengthLabel.description;
-    const passwordStrengthInput = t('passwordStrength', [
+    let passwordStrengthDescription = passwordStrengthLabel.description;
+    let passwordStrengthInput = t('passwordStrength', [
       <span
         key={passwordEvaluation.score}
         className={passwordStrengthLabel.className}
@@ -100,11 +101,20 @@ export default function CreatePassword({
       </span>,
     ]);
 
+    if (passwordInput.length < 8) {
+      passwordInputError = passwordInput.length
+        ? t('passwordNotLongEnough')
+        : '';
+      passwordStrengthInput = null;
+      passwordStrengthDescription = '';
+    }
+
     if (confirmPassword && passwordInput !== confirmPassword) {
       confirmError = t('passwordsDontMatch');
     }
 
     setPassword(passwordInput);
+    setPasswordError(passwordInputError);
     setPasswordStrength(passwordStrengthInput);
     setPasswordStrengthText(passwordStrengthDescription);
     setConfirmPasswordError(confirmError);
@@ -175,6 +185,7 @@ export default function CreatePassword({
           <FormField
             dataTestId="create-password-new"
             autoFocus
+            error={passwordError}
             passwordStrength={passwordStrength}
             passwordStrengthText={passwordStrengthText}
             onChange={handlePasswordChange}


### PR DESCRIPTION
In Onboarding V2 we do not show an error indicating why the user cannot proceed if they have entered a password shorter than 8 characters - we do show this error in Onboarding V1:
![205687681-5f0a65fc-7ef3-4596-bc0b-028547d88413](https://user-images.githubusercontent.com/34557516/206565235-78941896-d91f-42d4-bbdb-20455c1a2ddb.png)

* Fixes #16802

### Before

https://user-images.githubusercontent.com/34557516/206565268-705eee14-283d-4f75-aa2e-dabee309209d.mp4

### After

https://user-images.githubusercontent.com/34557516/206566750-d8c65a51-5c5a-4e03-8793-a360672ed0e6.mov


## Manual Testing Steps

1. Load MM for the first time
2. Go through the onboarding process for Create a New Wallet
3. Enter a password shorter than 8 characters
4. You should see an error - "Password is not long enough" - indicating why you cannot proceed.

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
