### PR TITLE
Fix issue where clicking around password input calls hide/show function

### DIFF
--- a/ui/components/ui/form-field/form-field.js
+++ b/ui/components/ui/form-field/form-field.js
@@ -49,7 +49,7 @@ export default function FormField({
         'form-field__row--error': error,
       })}
     >
-      <Box as="label" {...wrappingLabelProps}>
+      <Box {...wrappingLabelProps}>
         <div className="form-field__heading">
           <Box
             className="form-field__heading-title"


### PR DESCRIPTION
* Fixes #16804

### Before

### After

https://user-images.githubusercontent.com/34557516/206569490-29786090-de69-4e2e-afbd-18fcb1cc6ce6.mov


## Manual Testing Steps

1. Load MM for the first time
2. Click Create Wallet
3. Accept/Reject Metametrics
4. Insert some input on Password/Confirm password fields
5. Click around the input area - see that the password **is not displayed and hidden as if you were clicking the Display/Hide button**

## Pre-merge author checklist

- [ ] I've clearly explained:
  - [ ] What problem this PR is solving
  - [ ] How this problem was solved
  - [ ] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added


