### PR TITLE
Make `setProviderType` synchronous

### DIFF
--- a/app/scripts/controllers/network/network.js
+++ b/app/scripts/controllers/network/network.js
@@ -295,7 +295,7 @@ export default class NetworkController extends EventEmitter {
     });
   }
 
-  async setProviderType(type) {
+  setProviderType(type) {
     assert.notStrictEqual(
       type,
       NETWORK_TYPES.RPC,


### PR DESCRIPTION
The network controller method `setProviderType` was marked as `async` despite doing nothing async internally. The `async` has been dropped.

This relates to https://github.com/MetaMask/controllers/issues/971

## Manual Testing Steps

This should have zero functional impact.

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
