### PR TITLE
Make `initializeProvider` and `lookupNetwork` async

### DIFF
--- a/app/scripts/controllers/network/network.js
+++ b/app/scripts/controllers/network/network.js
@@ -203,7 +203,7 @@ export default class NetworkController extends EventEmitter {
 
       this._setNetworkState('loading');
       // keep network details in sync with network state
-      this.clearNetworkDetails();
+      this._clearNetworkDetails();
       return;
     }
 

--- a/app/scripts/controllers/network/network.js
+++ b/app/scripts/controllers/network/network.js
@@ -194,26 +194,25 @@ export default class NetworkController extends EventEmitter {
     }
 
     let networkVersion;
+    let networkVersionError;
     try {
       networkVersion = await this._getNetworkId();
     } catch (error) {
-      if (initialNetwork !== this.getNetworkState()) {
-        return;
-      }
-
-      this._setNetworkState('loading');
-      // keep network details in sync with network state
-      this._clearNetworkDetails();
-      return;
+      networkVersionError = error;
     }
-
     if (initialNetwork !== this.getNetworkState()) {
       return;
     }
 
-    this._setNetworkState(networkVersion);
-    // look up EIP-1559 support
-    await this.getEIP1559Compatibility();
+    if (networkVersionError) {
+      this._setNetworkState('loading');
+      // keep network details in sync with network state
+      this._clearNetworkDetails();
+    } else {
+      this._setNetworkState(networkVersion);
+      // look up EIP-1559 support
+      await this.getEIP1559Compatibility();
+    }
   }
 
   getCurrentChainId() {

--- a/app/scripts/controllers/network/network.js
+++ b/app/scripts/controllers/network/network.js
@@ -183,7 +183,6 @@ export default class NetworkController extends EventEmitter {
     }
 
     // Ping the RPC endpoint so we can confirm that it works
-    const ethQuery = new EthQuery(this._provider);
     const initialNetwork = this.getNetworkState();
     const { type } = this.getProviderConfig();
     const isInfura = INFURA_PROVIDER_TYPES.includes(type);
@@ -196,15 +195,7 @@ export default class NetworkController extends EventEmitter {
 
     let networkVersion;
     try {
-      networkVersion = await new Promise((resolve, reject) => {
-        ethQuery.sendAsync({ method: 'net_version' }, (error, result) => {
-          if (error) {
-            reject(error);
-          } else {
-            resolve(result);
-          }
-        });
-      });
+      networkVersion = await this._getNetworkId();
     } catch (error) {
       if (initialNetwork !== this.getNetworkState()) {
         return;
@@ -298,6 +289,24 @@ export default class NetworkController extends EventEmitter {
   //
   // Private
   //
+
+  /**
+   * Get the network ID for the current selected network
+   *
+   * @returns {string} The network ID for the current network.
+   */
+  async _getNetworkId() {
+    const ethQuery = new EthQuery(this._provider);
+    return await new Promise((resolve, reject) => {
+      ethQuery.sendAsync({ method: 'net_version' }, (error, result) => {
+        if (error) {
+          reject(error);
+        } else {
+          resolve(result);
+        }
+      });
+    });
+  }
 
   /**
    * Method to return the latest block for the current network


### PR DESCRIPTION
These two methods were "synchronous" previously, but initiated an asynchronous operation. They have both been made `async` to bring them more in-line with the mobile controller API, and to make them easier to test.

This relates to https://github.com/MetaMask/controllers/issues/971

## Manual Testing Steps

This should include zero functional changes. These methods are still being invoked without an `await`, to preserve the same behaviour they had previously.

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
