### PR TITLE
Make certain network controller methods private

### DIFF
--- a/app/scripts/controllers/detect-tokens.test.js
+++ b/app/scripts/controllers/detect-tokens.test.js
@@ -76,7 +76,7 @@ describe('DetectTokensController', function () {
     });
 
     sandbox
-      .stub(network, 'getLatestBlock')
+      .stub(network, '_getLatestBlock')
       .callsFake(() => Promise.resolve({}));
     sandbox
       .stub(tokensController, '_instantiateNewEthersProvider')

--- a/app/scripts/controllers/network/network-controller.test.js
+++ b/app/scripts/controllers/network/network-controller.test.js
@@ -15,7 +15,7 @@ describe('NetworkController', () => {
     beforeEach(() => {
       networkController = new NetworkController();
       getLatestBlockStub = sinon
-        .stub(networkController, 'getLatestBlock')
+        .stub(networkController, '_getLatestBlock')
         .callsFake(() => Promise.resolve({}));
       networkController.setInfuraProjectId('foo');
       setProviderTypeAndWait = () =>
@@ -49,14 +49,6 @@ describe('NetworkController', () => {
       });
     });
 
-    describe('#setNetworkState', () => {
-      it('should update the network', () => {
-        networkController.setNetworkState('1');
-        const networkState = networkController.getNetworkState();
-        expect(networkState).toStrictEqual('1');
-      });
-    });
-
     describe('#setProviderType', () => {
       it('should update provider.type', () => {
         networkController.initializeProvider(networkControllerProviderConfig);
@@ -68,7 +60,7 @@ describe('NetworkController', () => {
       it('should set the network to loading', () => {
         networkController.initializeProvider(networkControllerProviderConfig);
 
-        const spy = sinon.spy(networkController, 'setNetworkState');
+        const spy = sinon.spy(networkController, '_setNetworkState');
         networkController.setProviderType('mainnet');
 
         expect(spy.callCount).toStrictEqual(1);
@@ -94,7 +86,7 @@ describe('NetworkController', () => {
         expect(supportsEIP1559).toStrictEqual(true);
       });
 
-      it('should store EIP1559 support in state to reduce calls to getLatestBlock', async () => {
+      it('should store EIP1559 support in state to reduce calls to _getLatestBlock', async () => {
         networkController.initializeProvider(networkControllerProviderConfig);
         getLatestBlockStub.callsFake(() =>
           Promise.resolve({ baseFeePerGas: '0xa ' }),

--- a/app/scripts/controllers/network/network.js
+++ b/app/scripts/controllers/network/network.js
@@ -139,27 +139,6 @@ export default class NetworkController extends EventEmitter {
   }
 
   /**
-   * Method to return the latest block for the current network
-   *
-   * @returns {object} Block header
-   */
-  getLatestBlock() {
-    return new Promise((resolve, reject) => {
-      const { provider } = this.getProviderAndBlockTracker();
-      const ethQuery = new EthQuery(provider);
-      ethQuery.sendAsync(
-        { method: 'eth_getBlockByNumber', params: ['latest', false] },
-        (err, block) => {
-          if (err) {
-            return reject(err);
-          }
-          return resolve(block);
-        },
-      );
-    });
-  }
-
-  /**
    * Method to check if the block header contains fields that indicate EIP 1559
    * support (baseFeePerGas).
    *
@@ -170,10 +149,10 @@ export default class NetworkController extends EventEmitter {
     if (EIPS[1559] !== undefined) {
       return EIPS[1559];
     }
-    const latestBlock = await this.getLatestBlock();
+    const latestBlock = await this._getLatestBlock();
     const supportsEIP1559 =
       latestBlock && latestBlock.baseFeePerGas !== undefined;
-    this.setNetworkEIPSupport(1559, supportsEIP1559);
+    this._setNetworkEIPSupport(1559, supportsEIP1559);
     return supportsEIP1559;
   }
 
@@ -186,31 +165,6 @@ export default class NetworkController extends EventEmitter {
 
   getNetworkState() {
     return this.networkStore.getState();
-  }
-
-  setNetworkState(network) {
-    this.networkStore.putState(network);
-  }
-
-  /**
-   * Set EIP support indication in the networkDetails store
-   *
-   * @param {number} EIPNumber - The number of the EIP to mark support for
-   * @param {boolean} isSupported - True if the EIP is supported
-   */
-  setNetworkEIPSupport(EIPNumber, isSupported) {
-    this.networkDetails.updateState({
-      EIPS: {
-        [EIPNumber]: isSupported,
-      },
-    });
-  }
-
-  /**
-   * Reset EIP support to default (no support)
-   */
-  clearNetworkDetails() {
-    this.networkDetails.putState({ ...defaultNetworkDetailsState });
   }
 
   isNetworkLoading() {
@@ -231,9 +185,9 @@ export default class NetworkController extends EventEmitter {
       log.warn(
         'NetworkController - lookupNetwork aborted due to missing chainId',
       );
-      this.setNetworkState('loading');
+      this._setNetworkState('loading');
       // keep network details in sync with network state
-      this.clearNetworkDetails();
+      this._clearNetworkDetails();
       return;
     }
 
@@ -253,13 +207,13 @@ export default class NetworkController extends EventEmitter {
       const currentNetwork = this.getNetworkState();
       if (initialNetwork === currentNetwork) {
         if (err) {
-          this.setNetworkState('loading');
+          this._setNetworkState('loading');
           // keep network details in sync with network state
-          this.clearNetworkDetails();
+          this._clearNetworkDetails();
           return;
         }
 
-        this.setNetworkState(networkVersion);
+        this._setNetworkState(networkVersion);
         // look up EIP-1559 support
         this.getEIP1559Compatibility();
       }
@@ -285,7 +239,7 @@ export default class NetworkController extends EventEmitter {
       isSafeChainId(parseInt(chainId, 16)),
       `Invalid chain ID "${chainId}": numerical value greater than max safe value.`,
     );
-    this.setProviderConfig({
+    this._setProviderConfig({
       type: NETWORK_TYPES.RPC,
       rpcUrl,
       chainId,
@@ -306,7 +260,7 @@ export default class NetworkController extends EventEmitter {
       `Unknown Infura provider type "${type}".`,
     );
     const { chainId, ticker } = BUILT_IN_NETWORKS[type];
-    this.setProviderConfig({
+    this._setProviderConfig({
       type,
       rpcUrl: '',
       chainId,
@@ -316,18 +270,7 @@ export default class NetworkController extends EventEmitter {
   }
 
   resetConnection() {
-    this.setProviderConfig(this.getProviderConfig());
-  }
-
-  /**
-   * Sets the provider config and switches the network.
-   *
-   * @param config
-   */
-  setProviderConfig(config) {
-    this.previousProviderStore.updateState(this.getProviderConfig());
-    this.providerStore.updateState(config);
-    this._switchNetwork(config);
+    this._setProviderConfig(this.getProviderConfig());
   }
 
   rollbackToPreviousProvider() {
@@ -350,6 +293,63 @@ export default class NetworkController extends EventEmitter {
   //
   // Private
   //
+
+  /**
+   * Method to return the latest block for the current network
+   *
+   * @returns {object} Block header
+   */
+  _getLatestBlock() {
+    return new Promise((resolve, reject) => {
+      const { provider } = this.getProviderAndBlockTracker();
+      const ethQuery = new EthQuery(provider);
+      ethQuery.sendAsync(
+        { method: 'eth_getBlockByNumber', params: ['latest', false] },
+        (err, block) => {
+          if (err) {
+            return reject(err);
+          }
+          return resolve(block);
+        },
+      );
+    });
+  }
+
+  _setNetworkState(network) {
+    this.networkStore.putState(network);
+  }
+
+  /**
+   * Set EIP support indication in the networkDetails store
+   *
+   * @param {number} EIPNumber - The number of the EIP to mark support for
+   * @param {boolean} isSupported - True if the EIP is supported
+   */
+  _setNetworkEIPSupport(EIPNumber, isSupported) {
+    this.networkDetails.updateState({
+      EIPS: {
+        [EIPNumber]: isSupported,
+      },
+    });
+  }
+
+  /**
+   * Reset EIP support to default (no support)
+   */
+  _clearNetworkDetails() {
+    this.networkDetails.putState({ ...defaultNetworkDetailsState });
+  }
+
+  /**
+   * Sets the provider config and switches the network.
+   *
+   * @param config
+   */
+  _setProviderConfig(config) {
+    this.previousProviderStore.updateState(this.getProviderConfig());
+    this.providerStore.updateState(config);
+    this._switchNetwork(config);
+  }
 
   async _checkInfuraAvailability(network) {
     const rpcUrl = `https://${network}.infura.io/v3/${this._infuraProjectId}`;
@@ -394,9 +394,9 @@ export default class NetworkController extends EventEmitter {
     // Indicate to subscribers that network is about to change
     this.emit(NETWORK_EVENTS.NETWORK_WILL_CHANGE);
     // Set loading state
-    this.setNetworkState('loading');
+    this._setNetworkState('loading');
     // Reset network details
-    this.clearNetworkDetails();
+    this._clearNetworkDetails();
     // Configure the provider appropriately
     this._configureProvider(opts);
     // Notify subscribers that network has changed

--- a/app/scripts/controllers/preferences.test.js
+++ b/app/scripts/controllers/preferences.test.js
@@ -36,7 +36,7 @@ describe('preferences controller', function () {
     });
 
     sandbox
-      .stub(network, 'getLatestBlock')
+      .stub(network, '_getLatestBlock')
       .callsFake(() => Promise.resolve({}));
     sandbox.stub(network, 'getCurrentChainId').callsFake(() => currentChainId);
     sandbox


### PR DESCRIPTION
Five network controller methods have been renamed to start with an underscore:
* `getLatestBlock`
* `setNetworkState`
* `setNetworkEIPSupport`
* `clearNetworkDetails`
* `setProviderConfig`

All of these methods were used solely within the network controller. The leading underscore now documents these methods as being private.

A few tests required updates as well because they were stubbing out one of these methods.

This relates to https://github.com/MetaMask/controllers/issues/971

## Manual Testing Steps

This should include zero functional changes.

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
