### PR TITLE
Move `infuraProjectId` to network controller constructor

### DIFF
--- a/app/scripts/controllers/detect-tokens.test.js
+++ b/app/scripts/controllers/detect-tokens.test.js
@@ -33,8 +33,7 @@ describe('DetectTokensController', function () {
 
   beforeEach(async function () {
     keyringMemStore = new ObservableStore({ isUnlocked: false });
-    network = new NetworkController();
-    network.setInfuraProjectId('foo');
+    network = new NetworkController({ infuraProjectId: 'foo' });
     network.initializeProvider(networkControllerProviderConfig);
     provider = network.getProviderAndBlockTracker().provider;
 

--- a/app/scripts/controllers/network/network-controller.test.js
+++ b/app/scripts/controllers/network/network-controller.test.js
@@ -13,11 +13,10 @@ describe('NetworkController', () => {
     };
 
     beforeEach(() => {
-      networkController = new NetworkController();
+      networkController = new NetworkController({ infuraProjectId: 'foo' });
       getLatestBlockStub = sinon
         .stub(networkController, 'getLatestBlock')
         .callsFake(() => Promise.resolve({}));
-      networkController.setInfuraProjectId('foo');
       setProviderTypeAndWait = () =>
         new Promise((resolve) => {
           networkController.on(NETWORK_EVENTS.NETWORK_DID_CHANGE, () => {

--- a/app/scripts/controllers/network/network.js
+++ b/app/scripts/controllers/network/network.js
@@ -71,12 +71,19 @@ export const NETWORK_EVENTS = {
 };
 
 export default class NetworkController extends EventEmitter {
-  constructor(opts = {}) {
+  /**
+   * Construct a NetworkController.
+   *
+   * @param {object} [options] - NetworkController options.
+   * @param {object} [options.state] - Initial controller state.
+   * @param {string} [options.infuraProjectId] - The Infura project ID.
+   */
+  constructor({ state = {}, infuraProjectId } = {}) {
     super();
 
     // create stores
     this.providerStore = new ObservableStore(
-      opts.provider || { ...defaultProviderConfig },
+      state.provider || { ...defaultProviderConfig },
     );
     this.previousProviderStore = new ObservableStore(
       this.providerStore.getState(),
@@ -88,7 +95,7 @@ export default class NetworkController extends EventEmitter {
     // state. Currently this is only used for detecting EIP 1559 support but
     // can be extended to track other network details.
     this.networkDetails = new ObservableStore(
-      opts.networkDetails || {
+      state.networkDetails || {
         ...defaultNetworkDetailsState,
       },
     );
@@ -107,21 +114,12 @@ export default class NetworkController extends EventEmitter {
     this._providerProxy = null;
     this._blockTrackerProxy = null;
 
-    this.on(NETWORK_EVENTS.NETWORK_DID_CHANGE, this.lookupNetwork);
-  }
-
-  /**
-   * Sets the Infura project ID
-   *
-   * @param {string} projectId - The Infura project ID
-   * @throws {Error} If the project ID is not a valid string.
-   */
-  setInfuraProjectId(projectId) {
-    if (!projectId || typeof projectId !== 'string') {
+    if (!infuraProjectId || typeof infuraProjectId !== 'string') {
       throw new Error('Invalid Infura project ID');
     }
+    this._infuraProjectId = infuraProjectId;
 
-    this._infuraProjectId = projectId;
+    this.on(NETWORK_EVENTS.NETWORK_DID_CHANGE, this.lookupNetwork);
   }
 
   initializeProvider(providerParams) {

--- a/app/scripts/controllers/preferences.test.js
+++ b/app/scripts/controllers/preferences.test.js
@@ -20,8 +20,7 @@ describe('preferences controller', function () {
     const networkControllerProviderConfig = {
       getAccounts: () => undefined,
     };
-    network = new NetworkController();
-    network.setInfuraProjectId('foo');
+    network = new NetworkController({ infuraProjectId: 'foo' });
     network.initializeProvider(networkControllerProviderConfig);
     provider = network.getProviderAndBlockTracker().provider;
     const tokenListMessenger = new ControllerMessenger().getRestricted({

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -244,8 +244,10 @@ export default class MetamaskController extends EventEmitter {
       showApprovalRequest: opts.showUserConfirmation,
     });
 
-    this.networkController = new NetworkController(initState.NetworkController);
-    this.networkController.setInfuraProjectId(opts.infuraProjectId);
+    this.networkController = new NetworkController({
+      state: initState.NetworkController,
+      infuraProjectId: opts.infuraProjectId,
+    });
 
     // now we can initialize the RPC provider, which other controllers require
     this.initializeProvider();


### PR DESCRIPTION
The network controller `setInfuraProjectId` method has been deleted. The Infura project ID is only ever set upon construction, so it is now passed in as a constructor parameter instead.

Rather than adding this as a second parameter, the network controller now uses an "options bag" for constructor parameters. The initial state was the first parameter, but it's now passed in as the `state` option instead.

These changes make the API more similar to the mobile network controller API.

This relates to https://github.com/MetaMask/controllers/issues/971

## Manual Testing Steps

This should have zero functional changes.

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
