### PR TITLE
fix warning on revoke approval for all nfts

### DIFF
--- a/test/e2e/tests/collectibles.spec.js
+++ b/test/e2e/tests/collectibles.spec.js
@@ -260,7 +260,6 @@ describe('Collectibles', function () {
 
         // Confirm disabling set approval for all
         await driver.clickElement({ text: 'Confirm', tag: 'button' });
-        await driver.clickElement({ text: 'Approve', tag: 'button' });
 
         await driver.waitUntilXWindowHandles(2);
         await driver.switchToWindow(extension);

--- a/ui/components/app/confirm-page-container/confirm-page-container.component.js
+++ b/ui/components/app/confirm-page-container/confirm-page-container.component.js
@@ -115,6 +115,7 @@ export default class ConfirmPageContainer extends Component {
     supportsEIP1559V2: PropTypes.bool,
     nativeCurrency: PropTypes.string,
     isBuyableChain: PropTypes.bool,
+    isApprovalOrRejection: PropTypes.bool,
   };
 
   async componentDidMount() {
@@ -193,6 +194,7 @@ export default class ConfirmPageContainer extends Component {
       ///: END:ONLY_INCLUDE_IN
       accountBalance,
       assetStandard,
+      isApprovalOrRejection,
     } = this.props;
 
     const showAddToAddressDialog =
@@ -386,7 +388,11 @@ export default class ConfirmPageContainer extends Component {
             <PageContainerFooter
               onCancel={onCancel}
               cancelText={t('reject')}
-              onSubmit={isSetApproveForAll ? onSetApprovalForAll : onSubmit}
+              onSubmit={
+                isSetApproveForAll && isApprovalOrRejection
+                  ? onSetApprovalForAll
+                  : onSubmit
+              }
               submitText={t('confirm')}
               submitButtonType={
                 isSetApproveForAll ? 'danger-primary' : 'primary'


### PR DESCRIPTION
Fixes #16846
## Explanation
I have removed the warning modal for revoking access to all NFTs. The "Confirm" action button performs the revoking call without any modal warning now.

For reference, initially I have  tried keeping the warning modal with appropriate warning message on revoking access to all NFTs. But it was later suggested in https://github.com/MetaMask/metamask-extension/pull/16898#issuecomment-1346441605 to not have modal warning on revokation. 

## Manual Testing Steps
Manual testing was performed using the test-dapp.
The following actions were tested for collectibles.
- Deploy
- Mint
- Approve
- Set Approval for All
- Revoke
