### PR TITLE
Refactor password validation

### DIFF
--- a/ui/components/app/create-new-vault/create-new-vault.js
+++ b/ui/components/app/create-new-vault/create-new-vault.js
@@ -6,6 +6,7 @@ import Button from '../../ui/button';
 import CheckBox from '../../ui/check-box';
 import Typography from '../../ui/typography';
 import SrpInput from '../srp-input';
+import { PASSWORD_MIN_LENGTH } from '../../../helpers/constants/common';
 
 export default function CreateNewVault({
   disabled = false,
@@ -27,7 +28,7 @@ export default function CreateNewVault({
       let newConfirmPasswordError = '';
       let newPasswordError = '';
 
-      if (newPassword && newPassword.length < 8) {
+      if (newPassword && newPassword.length < PASSWORD_MIN_LENGTH) {
         newPasswordError = t('passwordNotLongEnough');
       }
 

--- a/ui/helpers/constants/common.js
+++ b/ui/helpers/constants/common.js
@@ -23,3 +23,4 @@ _supportRequestLink =
 
 export const SUPPORT_REQUEST_LINK = _supportRequestLink;
 export const CONTRACT_ADDRESS_LINK = _contractAddressLink;
+export const PASSWORD_MIN_LENGTH = 8;

--- a/ui/pages/onboarding-flow/create-password/create-password.js
+++ b/ui/pages/onboarding-flow/create-password/create-password.js
@@ -26,6 +26,7 @@ import {
   TwoStepProgressBar,
   twoStepStages,
 } from '../../../components/app/step-progress-bar';
+import { PASSWORD_MIN_LENGTH } from '../../../helpers/constants/common';
 import ZENDESK_URLS from '../../../helpers/constants/zendesk-url';
 import { getFirstTimeFlowType } from '../../../selectors';
 import { FIRST_TIME_FLOW_TYPES } from '../../../helpers/constants/onboarding';
@@ -55,7 +56,7 @@ export default function CreatePassword({
       return false;
     }
 
-    if (password.length < 8) {
+    if (password.length < PASSWORD_MIN_LENGTH) {
       return false;
     }
 
@@ -101,7 +102,7 @@ export default function CreatePassword({
       </span>,
     ]);
 
-    if (passwordInput.length < 8) {
+    if (passwordInput.length < PASSWORD_MIN_LENGTH) {
       passwordInputError = passwordInput.length
         ? t('passwordNotLongEnough')
         : '';

--- a/ui/pages/onboarding-flow/create-password/create-password.js
+++ b/ui/pages/onboarding-flow/create-password/create-password.js
@@ -63,32 +63,32 @@ export default function CreatePassword({
     return !passwordError && !confirmPasswordError;
   }, [password, confirmPassword, passwordError, confirmPasswordError]);
 
-  const getPasswordStrengthLabel = (isTooShort, score, translation) => {
+  const getPasswordStrengthLabel = (isTooShort, score) => {
     if (isTooShort) {
       return {
         className: 'create-password__weak',
-        text: translation('passwordNotLongEnough'),
+        text: t('passwordNotLongEnough'),
         description: '',
       };
     }
     if (score >= 4) {
       return {
         className: 'create-password__strong',
-        text: translation('strong'),
+        text: t('strong'),
         description: '',
       };
     }
     if (score === 3) {
       return {
         className: 'create-password__average',
-        text: translation('average'),
-        description: translation('passwordStrengthDescription'),
+        text: t('average'),
+        description: t('passwordStrengthDescription'),
       };
     }
     return {
       className: 'create-password__weak',
-      text: translation('weak'),
-      description: translation('passwordStrengthDescription'),
+      text: t('weak'),
+      description: t('passwordStrengthDescription'),
     };
   };
 
@@ -96,11 +96,7 @@ export default function CreatePassword({
     const isTooShort =
       passwordInput.length && passwordInput.length < PASSWORD_MIN_LENGTH;
     const { score } = zxcvbn(passwordInput);
-    const passwordStrengthLabel = getPasswordStrengthLabel(
-      isTooShort,
-      score,
-      t,
-    );
+    const passwordStrengthLabel = getPasswordStrengthLabel(isTooShort, score);
     const passwordStrengthComponent = t('passwordStrength', [
       <span key={score} className={passwordStrengthLabel.className}>
         {passwordStrengthLabel.text}


### PR DESCRIPTION
Targeting #16876 

* introduces constant `PASSWORD_MIN_LENGTH` replacing magic numbers
* uses password strength control for length validation error
* simplifies logic - all local variables are now `const`

Manually tested in Chromium with `ONBOARDING_V2=1`.