### PR TITLE
ui: make settings search regex range explicit

### DIFF
--- a/ui/pages/settings/settings-search/settings-search.js
+++ b/ui/pages/settings/settings-search/settings-search.js
@@ -42,7 +42,9 @@ export default function SettingsSearch({
   });
 
   const handleSearch = (_searchQuery) => {
-    const sanitizedSearchQuery = _searchQuery.replace(/[^A-Za-z0-9\s&_]/gu, '');
+    const sanitizedSearchQuery = _searchQuery
+      .replace(/[^A-Za-z0-9\s&_]/gu, '')
+      .trim();
     setSearchQuery(sanitizedSearchQuery);
     if (sanitizedSearchQuery === '') {
       setSearchIconColor('var(--color-icon-muted)');

--- a/ui/pages/settings/settings-search/settings-search.js
+++ b/ui/pages/settings/settings-search/settings-search.js
@@ -42,10 +42,7 @@ export default function SettingsSearch({
   });
 
   const handleSearch = (_searchQuery) => {
-    const sanitizedSearchQuery = _searchQuery.replace(
-      /[^A-z0-9\s&]|[\\]/gu,
-      '',
-    );
+    const sanitizedSearchQuery = _searchQuery.replace(/[^A-Za-z0-9\s&_]/gu, '');
     setSearchQuery(sanitizedSearchQuery);
     if (sanitizedSearchQuery === '') {
       setSearchIconColor('var(--color-icon-muted)');


### PR DESCRIPTION
Addresses CodeQL advisory [#31](https://github.com/MetaMask/metamask-extension/security/code-scanning/31)

* Removes `][^ as valid characters
* Ignores trailing and leading whitespace