### PR TITLE
[FLASK] Allow Snaps UI to use Markdown for text formatting

### DIFF
--- a/lavamoat/browserify/flask/policy.json
+++ b/lavamoat/browserify/flask/policy.json
@@ -5413,6 +5413,120 @@
         "proxyquire>fill-keys>is-object": true
       }
     },
+    "react-markdown": {
+      "globals": {
+        "console.warn": true
+      },
+      "packages": {
+        "prop-types": true,
+        "react": true,
+        "react-markdown>comma-separated-tokens": true,
+        "react-markdown>property-information": true,
+        "react-markdown>react-is": true,
+        "react-markdown>remark-parse": true,
+        "react-markdown>remark-rehype": true,
+        "react-markdown>space-separated-tokens": true,
+        "react-markdown>style-to-object": true,
+        "react-markdown>unified": true,
+        "react-markdown>unist-util-visit": true,
+        "react-markdown>vfile": true
+      }
+    },
+    "react-markdown>property-information": {
+      "packages": {
+        "watchify>xtend": true
+      }
+    },
+    "react-markdown>react-is": {
+      "globals": {
+        "console": true
+      }
+    },
+    "react-markdown>remark-parse": {
+      "packages": {
+        "react-markdown>remark-parse>mdast-util-from-markdown": true
+      }
+    },
+    "react-markdown>remark-parse>mdast-util-from-markdown": {
+      "packages": {
+        "react-markdown>remark-parse>mdast-util-from-markdown>mdast-util-to-string": true,
+        "react-markdown>remark-parse>mdast-util-from-markdown>micromark": true,
+        "react-markdown>remark-parse>mdast-util-from-markdown>parse-entities": true,
+        "react-markdown>vfile>unist-util-stringify-position": true
+      }
+    },
+    "react-markdown>remark-parse>mdast-util-from-markdown>micromark": {
+      "packages": {
+        "react-markdown>remark-parse>mdast-util-from-markdown>parse-entities": true
+      }
+    },
+    "react-markdown>remark-parse>mdast-util-from-markdown>parse-entities": {
+      "globals": {
+        "document.createElement": true
+      }
+    },
+    "react-markdown>remark-rehype": {
+      "packages": {
+        "react-markdown>remark-rehype>mdast-util-to-hast": true
+      }
+    },
+    "react-markdown>remark-rehype>mdast-util-to-hast": {
+      "globals": {
+        "console.warn": true
+      },
+      "packages": {
+        "react-markdown>remark-rehype>mdast-util-to-hast>mdast-util-definitions": true,
+        "react-markdown>remark-rehype>mdast-util-to-hast>mdurl": true,
+        "react-markdown>remark-rehype>mdast-util-to-hast>unist-builder": true,
+        "react-markdown>remark-rehype>mdast-util-to-hast>unist-util-generated": true,
+        "react-markdown>remark-rehype>mdast-util-to-hast>unist-util-position": true,
+        "react-markdown>unist-util-visit": true
+      }
+    },
+    "react-markdown>remark-rehype>mdast-util-to-hast>mdast-util-definitions": {
+      "packages": {
+        "react-markdown>unist-util-visit": true
+      }
+    },
+    "react-markdown>style-to-object": {
+      "packages": {
+        "react-markdown>style-to-object>inline-style-parser": true
+      }
+    },
+    "react-markdown>unified": {
+      "packages": {
+        "jsdom>request>extend": true,
+        "react-markdown>unified>bail": true,
+        "react-markdown>unified>is-buffer": true,
+        "react-markdown>unified>is-plain-obj": true,
+        "react-markdown>unified>trough": true,
+        "react-markdown>vfile": true
+      }
+    },
+    "react-markdown>unist-util-visit": {
+      "packages": {
+        "react-markdown>unist-util-visit>unist-util-visit-parents": true
+      }
+    },
+    "react-markdown>unist-util-visit>unist-util-visit-parents": {
+      "packages": {
+        "react-markdown>unist-util-visit>unist-util-is": true
+      }
+    },
+    "react-markdown>vfile": {
+      "packages": {
+        "browserify>path-browserify": true,
+        "browserify>process": true,
+        "react-markdown>vfile>is-buffer": true,
+        "react-markdown>vfile>vfile-message": true,
+        "vinyl>replace-ext": true
+      }
+    },
+    "react-markdown>vfile>vfile-message": {
+      "packages": {
+        "react-markdown>vfile>unist-util-stringify-position": true
+      }
+    },
     "react-popper": {
       "globals": {
         "document": true
@@ -5775,6 +5889,11 @@
     "vinyl>clone": {
       "packages": {
         "browserify>buffer": true
+      }
+    },
+    "vinyl>replace-ext": {
+      "packages": {
+        "browserify>path-browserify": true
       }
     },
     "web3": {

--- a/lavamoat/build-system/policy.json
+++ b/lavamoat/build-system/policy.json
@@ -1033,16 +1033,6 @@
         "@metamask/jazzicon>color>color-convert>color-name": true
       }
     },
-    "@storybook/addon-essentials>@storybook/addon-docs>remark-slug>unist-util-visit": {
-      "packages": {
-        "@storybook/addon-essentials>@storybook/addon-docs>remark-slug>unist-util-visit>unist-util-visit-parents": true
-      }
-    },
-    "@storybook/addon-essentials>@storybook/addon-docs>remark-slug>unist-util-visit>unist-util-visit-parents": {
-      "packages": {
-        "stylelint>@stylelint/postcss-markdown>unist-util-find-all-after>unist-util-is": true
-      }
-    },
     "@storybook/api>telejson>is-symbol": {
       "packages": {
         "string.prototype.matchall>has-symbols": true
@@ -6363,6 +6353,64 @@
         "define": true
       }
     },
+    "react-markdown>remark-parse>mdast-util-from-markdown>parse-entities": {
+      "packages": {
+        "react-markdown>remark-parse>mdast-util-from-markdown>parse-entities>character-entities": true,
+        "react-markdown>remark-parse>mdast-util-from-markdown>parse-entities>character-entities-legacy": true,
+        "react-markdown>remark-parse>mdast-util-from-markdown>parse-entities>character-reference-invalid": true,
+        "react-markdown>remark-parse>mdast-util-from-markdown>parse-entities>is-alphanumerical": true,
+        "react-markdown>remark-parse>mdast-util-from-markdown>parse-entities>is-hexadecimal": true,
+        "stylelint>@stylelint/postcss-markdown>remark>remark-parse>is-decimal": true
+      }
+    },
+    "react-markdown>remark-parse>mdast-util-from-markdown>parse-entities>is-alphanumerical": {
+      "packages": {
+        "stylelint>@stylelint/postcss-markdown>remark>remark-parse>is-alphabetical": true,
+        "stylelint>@stylelint/postcss-markdown>remark>remark-parse>is-decimal": true
+      }
+    },
+    "react-markdown>unified": {
+      "packages": {
+        "jsdom>request>extend": true,
+        "react-markdown>unified>bail": true,
+        "react-markdown>unified>is-buffer": true,
+        "react-markdown>unified>is-plain-obj": true,
+        "react-markdown>unified>trough": true,
+        "react-markdown>vfile": true
+      }
+    },
+    "react-markdown>unist-util-visit": {
+      "packages": {
+        "react-markdown>unist-util-visit>unist-util-visit-parents": true
+      }
+    },
+    "react-markdown>unist-util-visit>unist-util-visit-parents": {
+      "packages": {
+        "react-markdown>unist-util-visit>unist-util-is": true
+      }
+    },
+    "react-markdown>vfile": {
+      "builtin": {
+        "path.basename": true,
+        "path.dirname": true,
+        "path.extname": true,
+        "path.join": true,
+        "path.sep": true
+      },
+      "globals": {
+        "process.cwd": true
+      },
+      "packages": {
+        "react-markdown>vfile>is-buffer": true,
+        "react-markdown>vfile>vfile-message": true,
+        "vinyl>replace-ext": true
+      }
+    },
+    "react-markdown>vfile>vfile-message": {
+      "packages": {
+        "react-markdown>vfile>unist-util-stringify-position": true
+      }
+    },
     "readable-stream": {
       "builtin": {
         "events.EventEmitter": true,
@@ -6695,13 +6743,14 @@
     },
     "stylelint>@stylelint/postcss-markdown>remark": {
       "packages": {
+        "react-markdown>unified": true,
         "stylelint>@stylelint/postcss-markdown>remark>remark-parse": true,
-        "stylelint>@stylelint/postcss-markdown>remark>remark-stringify": true,
-        "stylelint>@stylelint/postcss-markdown>remark>unified": true
+        "stylelint>@stylelint/postcss-markdown>remark>remark-stringify": true
       }
     },
     "stylelint>@stylelint/postcss-markdown>remark>remark-parse": {
       "packages": {
+        "react-markdown>remark-parse>mdast-util-from-markdown>parse-entities": true,
         "stylelint>@stylelint/postcss-markdown>remark>remark-parse>ccount": true,
         "stylelint>@stylelint/postcss-markdown>remark>remark-parse>collapse-white-space": true,
         "stylelint>@stylelint/postcss-markdown>remark>remark-parse>is-alphabetical": true,
@@ -6709,7 +6758,6 @@
         "stylelint>@stylelint/postcss-markdown>remark>remark-parse>is-whitespace-character": true,
         "stylelint>@stylelint/postcss-markdown>remark>remark-parse>is-word-character": true,
         "stylelint>@stylelint/postcss-markdown>remark>remark-parse>markdown-escapes": true,
-        "stylelint>@stylelint/postcss-markdown>remark>remark-parse>parse-entities": true,
         "stylelint>@stylelint/postcss-markdown>remark>remark-parse>repeat-string": true,
         "stylelint>@stylelint/postcss-markdown>remark>remark-parse>state-toggle": true,
         "stylelint>@stylelint/postcss-markdown>remark>remark-parse>trim": true,
@@ -6720,22 +6768,6 @@
         "watchify>xtend": true
       }
     },
-    "stylelint>@stylelint/postcss-markdown>remark>remark-parse>parse-entities": {
-      "packages": {
-        "stylelint>@stylelint/postcss-markdown>remark>remark-parse>is-decimal": true,
-        "stylelint>@stylelint/postcss-markdown>remark>remark-parse>parse-entities>character-entities": true,
-        "stylelint>@stylelint/postcss-markdown>remark>remark-parse>parse-entities>character-entities-legacy": true,
-        "stylelint>@stylelint/postcss-markdown>remark>remark-parse>parse-entities>character-reference-invalid": true,
-        "stylelint>@stylelint/postcss-markdown>remark>remark-parse>parse-entities>is-alphanumerical": true,
-        "stylelint>@stylelint/postcss-markdown>remark>remark-parse>parse-entities>is-hexadecimal": true
-      }
-    },
-    "stylelint>@stylelint/postcss-markdown>remark>remark-parse>parse-entities>is-alphanumerical": {
-      "packages": {
-        "stylelint>@stylelint/postcss-markdown>remark>remark-parse>is-alphabetical": true,
-        "stylelint>@stylelint/postcss-markdown>remark>remark-parse>is-decimal": true
-      }
-    },
     "stylelint>@stylelint/postcss-markdown>remark>remark-parse>unherit": {
       "packages": {
         "pumpify>inherits": true,
@@ -6744,16 +6776,16 @@
     },
     "stylelint>@stylelint/postcss-markdown>remark>remark-parse>unist-util-remove-position": {
       "packages": {
-        "@storybook/addon-essentials>@storybook/addon-docs>remark-slug>unist-util-visit": true
+        "react-markdown>unist-util-visit": true
       }
     },
     "stylelint>@stylelint/postcss-markdown>remark>remark-stringify": {
       "packages": {
+        "react-markdown>remark-parse>mdast-util-from-markdown>parse-entities": true,
         "stylelint>@stylelint/postcss-markdown>remark>remark-parse>ccount": true,
         "stylelint>@stylelint/postcss-markdown>remark>remark-parse>is-decimal": true,
         "stylelint>@stylelint/postcss-markdown>remark>remark-parse>is-whitespace-character": true,
         "stylelint>@stylelint/postcss-markdown>remark>remark-parse>markdown-escapes": true,
-        "stylelint>@stylelint/postcss-markdown>remark>remark-parse>parse-entities": true,
         "stylelint>@stylelint/postcss-markdown>remark>remark-parse>repeat-string": true,
         "stylelint>@stylelint/postcss-markdown>remark>remark-parse>state-toggle": true,
         "stylelint>@stylelint/postcss-markdown>remark>remark-parse>unherit": true,
@@ -6772,53 +6804,21 @@
     },
     "stylelint>@stylelint/postcss-markdown>remark>remark-stringify>mdast-util-compact": {
       "packages": {
-        "@storybook/addon-essentials>@storybook/addon-docs>remark-slug>unist-util-visit": true
+        "react-markdown>unist-util-visit": true
       }
     },
     "stylelint>@stylelint/postcss-markdown>remark>remark-stringify>stringify-entities": {
       "packages": {
+        "react-markdown>remark-parse>mdast-util-from-markdown>parse-entities>character-entities-legacy": true,
+        "react-markdown>remark-parse>mdast-util-from-markdown>parse-entities>is-alphanumerical": true,
+        "react-markdown>remark-parse>mdast-util-from-markdown>parse-entities>is-hexadecimal": true,
         "stylelint>@stylelint/postcss-markdown>remark>remark-parse>is-decimal": true,
-        "stylelint>@stylelint/postcss-markdown>remark>remark-parse>parse-entities>character-entities-legacy": true,
-        "stylelint>@stylelint/postcss-markdown>remark>remark-parse>parse-entities>is-alphanumerical": true,
-        "stylelint>@stylelint/postcss-markdown>remark>remark-parse>parse-entities>is-hexadecimal": true,
         "stylelint>@stylelint/postcss-markdown>remark>remark-stringify>stringify-entities>character-entities-html4": true
-      }
-    },
-    "stylelint>@stylelint/postcss-markdown>remark>unified": {
-      "packages": {
-        "jsdom>request>extend": true,
-        "stylelint>@stylelint/postcss-markdown>remark>unified>bail": true,
-        "stylelint>@stylelint/postcss-markdown>remark>unified>is-buffer": true,
-        "stylelint>@stylelint/postcss-markdown>remark>unified>is-plain-obj": true,
-        "stylelint>@stylelint/postcss-markdown>remark>unified>trough": true,
-        "stylelint>@stylelint/postcss-markdown>remark>unified>vfile": true
-      }
-    },
-    "stylelint>@stylelint/postcss-markdown>remark>unified>vfile": {
-      "builtin": {
-        "path.basename": true,
-        "path.dirname": true,
-        "path.extname": true,
-        "path.join": true,
-        "path.sep": true
-      },
-      "globals": {
-        "process.cwd": true
-      },
-      "packages": {
-        "stylelint>@stylelint/postcss-markdown>remark>unified>vfile>is-buffer": true,
-        "stylelint>@stylelint/postcss-markdown>remark>unified>vfile>vfile-message": true,
-        "vinyl>replace-ext": true
-      }
-    },
-    "stylelint>@stylelint/postcss-markdown>remark>unified>vfile>vfile-message": {
-      "packages": {
-        "stylelint>@stylelint/postcss-markdown>remark>unified>vfile>unist-util-stringify-position": true
       }
     },
     "stylelint>@stylelint/postcss-markdown>unist-util-find-all-after": {
       "packages": {
-        "stylelint>@stylelint/postcss-markdown>unist-util-find-all-after>unist-util-is": true
+        "react-markdown>unist-util-visit>unist-util-is": true
       }
     },
     "stylelint>autoprefixer": {

--- a/package.json
+++ b/package.json
@@ -141,6 +141,7 @@
     "regenerator-runtime@^0.13.4": "patch:regenerator-runtime@npm%3A0.13.7#./.yarn/patches/regenerator-runtime-npm-0.13.7-41bcbe64ea.patch",
     "regenerator-runtime@^0.13.7": "patch:regenerator-runtime@npm%3A0.13.7#./.yarn/patches/regenerator-runtime-npm-0.13.7-41bcbe64ea.patch",
     "regenerator-runtime@^0.11.0": "patch:regenerator-runtime@npm%3A0.13.7#./.yarn/patches/regenerator-runtime-npm-0.13.7-41bcbe64ea.patch",
+    "trim": "^0.0.3",
     "@babel/runtime@^7.5.5": "patch:@babel/runtime@npm%3A7.18.9#./.yarn/patches/@babel-runtime-npm-7.18.9-28ca6b5f61.patch",
     "@babel/runtime@^7.7.6": "patch:@babel/runtime@npm%3A7.18.9#./.yarn/patches/@babel-runtime-npm-7.18.9-28ca6b5f61.patch",
     "@babel/runtime@^7.9.2": "patch:@babel/runtime@npm%3A7.18.9#./.yarn/patches/@babel-runtime-npm-7.18.9-28ca6b5f61.patch",

--- a/package.json
+++ b/package.json
@@ -305,6 +305,7 @@
     "react-dom": "^16.12.0",
     "react-idle-timer": "^4.2.5",
     "react-inspector": "^2.3.0",
+    "react-markdown": "^6.0.3",
     "react-popper": "^2.2.3",
     "react-redux": "^7.2.0",
     "react-responsive-carousel": "^3.2.21",

--- a/ui/components/app/app-components.scss
+++ b/ui/components/app/app-components.scss
@@ -39,6 +39,7 @@
 @import 'flask/snap-install-warning/index';
 @import 'flask/snap-remove-warning/index';
 @import 'flask/snap-ui-renderer/index';
+@import 'flask/snap-ui-markdown/index';
 @import 'flask/snap-delineator/index';
 @import 'flask/snap-settings-card/index';
 @import 'flask/update-snap-permission-list/index';

--- a/ui/components/app/flask/snap-ui-markdown/index.js
+++ b/ui/components/app/flask/snap-ui-markdown/index.js
@@ -1,0 +1,1 @@
+export { SnapUIMarkdown } from './snap-ui-markdown';

--- a/ui/components/app/flask/snap-ui-markdown/index.scss
+++ b/ui/components/app/flask/snap-ui-markdown/index.scss
@@ -1,8 +1,7 @@
 .snap-ui-markdown {
-    &__text {
-      em {
-        font-style: revert;
-      }
+  &__text {
+    em {
+      font-style: revert;
     }
   }
-  
+}

--- a/ui/components/app/flask/snap-ui-markdown/index.scss
+++ b/ui/components/app/flask/snap-ui-markdown/index.scss
@@ -1,0 +1,8 @@
+.snap-ui-markdown {
+    &__text {
+      em {
+        font-style: revert;
+      }
+    }
+  }
+  

--- a/ui/components/app/flask/snap-ui-markdown/snap-ui-markdown.js
+++ b/ui/components/app/flask/snap-ui-markdown/snap-ui-markdown.js
@@ -1,10 +1,10 @@
-import React, { Fragment } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import ReactMarkdown from 'react-markdown';
 import { TYPOGRAPHY } from '../../../../helpers/constants/design-system';
 import Typography from '../../../ui/typography/typography';
 
-const Paragraph = (props) => <Typography {...props} variant={TYPOGRAPHY.H6} />
+const Paragraph = (props) => <Typography {...props} variant={TYPOGRAPHY.H6} />;
 
 export const SnapUIMarkdown = ({ children }) => {
   return (

--- a/ui/components/app/flask/snap-ui-markdown/snap-ui-markdown.js
+++ b/ui/components/app/flask/snap-ui-markdown/snap-ui-markdown.js
@@ -1,0 +1,23 @@
+import React, { Fragment } from 'react';
+import PropTypes from 'prop-types';
+import ReactMarkdown from 'react-markdown';
+import { TYPOGRAPHY } from '../../../../helpers/constants/design-system';
+import Typography from '../../../ui/typography/typography';
+
+export const SnapUIMarkdown = ({ children }) => {
+  return (
+    <Typography variant={TYPOGRAPHY.H6}>
+      <ReactMarkdown
+        className="snap-ui-markdown__text"
+        allowedElements={['p', 'strong', 'em']}
+        components={{ p: Fragment }}
+      >
+        {children}
+      </ReactMarkdown>
+    </Typography>
+  );
+};
+
+SnapUIMarkdown.propTypes = {
+  children: PropTypes.string,
+};

--- a/ui/components/app/flask/snap-ui-markdown/snap-ui-markdown.js
+++ b/ui/components/app/flask/snap-ui-markdown/snap-ui-markdown.js
@@ -4,17 +4,17 @@ import ReactMarkdown from 'react-markdown';
 import { TYPOGRAPHY } from '../../../../helpers/constants/design-system';
 import Typography from '../../../ui/typography/typography';
 
+const Paragraph = (props) => <Typography {...props} variant={TYPOGRAPHY.H6} />
+
 export const SnapUIMarkdown = ({ children }) => {
   return (
-    <Typography variant={TYPOGRAPHY.H6}>
-      <ReactMarkdown
-        className="snap-ui-markdown__text"
-        allowedElements={['p', 'strong', 'em']}
-        components={{ p: Fragment }}
-      >
-        {children}
-      </ReactMarkdown>
-    </Typography>
+    <ReactMarkdown
+      className="snap-ui-markdown__text"
+      allowedElements={['p', 'strong', 'em']}
+      components={{ p: Paragraph }}
+    >
+      {children}
+    </ReactMarkdown>
   );
 };
 

--- a/ui/components/app/flask/snap-ui-renderer/snap-ui-renderer.js
+++ b/ui/components/app/flask/snap-ui-renderer/snap-ui-renderer.js
@@ -35,11 +35,8 @@ export const UI_MAPPING = {
     },
   }),
   text: (props) => ({
-    element: 'Typography',
+    element: 'SnapUIMarkdown',
     children: props.value,
-    props: {
-      variant: TYPOGRAPHY.H6,
-    },
   }),
   spinner: () => ({
     element: 'Spinner',

--- a/ui/components/app/metamask-template-renderer/safe-component-list.js
+++ b/ui/components/app/metamask-template-renderer/safe-component-list.js
@@ -16,6 +16,7 @@ import Tooltip from '../../ui/tooltip/tooltip';
 import { SnapDelineator } from '../flask/snap-delineator';
 import { Copyable } from '../flask/copyable';
 import Spinner from '../../ui/spinner';
+import { SnapUIMarkdown } from '../flask/snap-ui-markdown';
 ///: END:ONLY_INCLUDE_IN
 
 export const safeComponentList = {
@@ -44,5 +45,6 @@ export const safeComponentList = {
   Copyable,
   Spinner,
   hr: 'hr',
+  SnapUIMarkdown,
   ///: END:ONLY_INCLUDE_IN
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -32440,7 +32440,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"trim@npm:0.0.3":
+"trim@npm:^0.0.3":
   version: 0.0.3
   resolution: "trim@npm:0.0.3"
   checksum: 9a059ba56d5e22c9e571798a7c63640cb25478c495d8a9d001f6352927207c6bd224018751a0c5145fbedc943ee2ebab1d7cc2e8ccba3121a51a7d3428dd879c

--- a/yarn.lock
+++ b/yarn.lock
@@ -23057,6 +23057,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"mdast-util-from-markdown@npm:^0.8.0":
+  version: 0.8.5
+  resolution: "mdast-util-from-markdown@npm:0.8.5"
+  dependencies:
+    "@types/mdast": ^3.0.0
+    mdast-util-to-string: ^2.0.0
+    micromark: ~2.11.0
+    parse-entities: ^2.0.0
+    unist-util-stringify-position: ^2.0.0
+  checksum: 5a9d0d753a42db763761e874c22365d0c7c9934a5a18b5ff76a0643610108a208a041ffdb2f3d3dd1863d3d915225a4020a0aade282af0facfd0df110601eee6
+  languageName: node
+  linkType: hard
+
 "mdast-util-to-hast@npm:10.0.1":
   version: 10.0.1
   resolution: "mdast-util-to-hast@npm:10.0.1"
@@ -23073,10 +23086,33 @@ __metadata:
   languageName: node
   linkType: hard
 
+"mdast-util-to-hast@npm:^10.2.0":
+  version: 10.2.0
+  resolution: "mdast-util-to-hast@npm:10.2.0"
+  dependencies:
+    "@types/mdast": ^3.0.0
+    "@types/unist": ^2.0.0
+    mdast-util-definitions: ^4.0.0
+    mdurl: ^1.0.0
+    unist-builder: ^2.0.0
+    unist-util-generated: ^1.0.0
+    unist-util-position: ^3.0.0
+    unist-util-visit: ^2.0.0
+  checksum: 72df2dd9bfa2d07b4750a333444f82e0f3752dae75b6e300cf0a716407a185eb75095a54ecad90cbd6f6d133b20dea8844ff76c1ea78612550de170b43d4fa85
+  languageName: node
+  linkType: hard
+
 "mdast-util-to-string@npm:^1.0.0":
   version: 1.1.0
   resolution: "mdast-util-to-string@npm:1.1.0"
   checksum: eec1eb283f3341376c8398b67ce512a11ab3e3191e3dbd5644d32a26784eac8d5f6d0b0fb81193af00d75a2c545cde765c8b03e966bd890076efb5d357fb4fe2
+  languageName: node
+  linkType: hard
+
+"mdast-util-to-string@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "mdast-util-to-string@npm:2.0.0"
+  checksum: 0b2113ada10e002fbccb014170506dabe2f2ddacaacbe4bc1045c33f986652c5a162732a2c057c5335cdb58419e2ad23e368e5be226855d4d4e280b81c4e9ec2
   languageName: node
   linkType: hard
 
@@ -23562,6 +23598,7 @@ __metadata:
     react-dom: ^16.12.0
     react-idle-timer: ^4.2.5
     react-inspector: ^2.3.0
+    react-markdown: ^6.0.3
     react-popper: ^2.2.3
     react-redux: ^7.2.0
     react-responsive-carousel: ^3.2.21
@@ -23631,6 +23668,16 @@ __metadata:
   version: 0.1.1
   resolution: "microevent.ts@npm:0.1.1"
   checksum: 7874fcdb3f0dfa4e996d3ea63b3b9882874ae7d22be28d51ae20da24c712e9e28e5011d988095c27dd2b32e37c0ad7425342a71b89adb8e808ec7194fadf4a7a
+  languageName: node
+  linkType: hard
+
+"micromark@npm:~2.11.0":
+  version: 2.11.4
+  resolution: "micromark@npm:2.11.4"
+  dependencies:
+    debug: ^4.0.0
+    parse-entities: ^2.0.0
+  checksum: f8a5477d394908a5d770227aea71657a76423d420227c67ea0699e659a5f62eb39d504c1f7d69ec525a6af5aaeb6a7bffcdba95614968c03d41d3851edecb0d6
   languageName: node
   linkType: hard
 
@@ -27921,7 +27968,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-is@npm:17.0.2, react-is@npm:^17.0.1":
+"react-is@npm:17.0.2, react-is@npm:^17.0.0, react-is@npm:^17.0.1":
   version: 17.0.2
   resolution: "react-is@npm:17.0.2"
   checksum: 9d6d111d8990dc98bc5402c1266a808b0459b5d54830bbea24c12d908b536df7883f268a7868cfaedde3dd9d4e0d574db456f84d2e6df9c4526f99bb4b5344d8
@@ -27946,6 +27993,30 @@ __metadata:
   version: 3.0.4
   resolution: "react-lifecycles-compat@npm:3.0.4"
   checksum: a904b0fc0a8eeb15a148c9feb7bc17cec7ef96e71188280061fc340043fd6d8ee3ff233381f0e8f95c1cf926210b2c4a31f38182c8f35ac55057e453d6df204f
+  languageName: node
+  linkType: hard
+
+"react-markdown@npm:^6.0.3":
+  version: 6.0.3
+  resolution: "react-markdown@npm:6.0.3"
+  dependencies:
+    "@types/hast": ^2.0.0
+    "@types/unist": ^2.0.3
+    comma-separated-tokens: ^1.0.0
+    prop-types: ^15.7.2
+    property-information: ^5.3.0
+    react-is: ^17.0.0
+    remark-parse: ^9.0.0
+    remark-rehype: ^8.0.0
+    space-separated-tokens: ^1.1.0
+    style-to-object: ^0.3.0
+    unified: ^9.0.0
+    unist-util-visit: ^2.0.0
+    vfile: ^4.0.0
+  peerDependencies:
+    "@types/react": ">=16"
+    react: ">=16"
+  checksum: 5176e6a314a397b4747570213ae6c092f76c5c3dc67c748731243a0d4108e002134a9061cea87df1bea00db46cc7d238e092bae1609de74983c844e8386c0554
   languageName: node
   linkType: hard
 
@@ -28705,6 +28776,24 @@ __metadata:
     vfile-location: ^3.0.0
     xtend: ^4.0.1
   checksum: 2dfea250e7606ddfc9e223b9f41e0b115c5c701be4bd35181beaadd46ee59816bc00aadc6085a420f8df00b991ada73b590ea7fd34ace14557de4a0a41805be5
+  languageName: node
+  linkType: hard
+
+"remark-parse@npm:^9.0.0":
+  version: 9.0.0
+  resolution: "remark-parse@npm:9.0.0"
+  dependencies:
+    mdast-util-from-markdown: ^0.8.0
+  checksum: 50104880549639b7dd7ae6f1e23c214915fe9c054f02f3328abdaee3f6de6d7282bf4357c3c5b106958fe75e644a3c248c2197755df34f9955e8e028fc74868f
+  languageName: node
+  linkType: hard
+
+"remark-rehype@npm:^8.0.0":
+  version: 8.1.0
+  resolution: "remark-rehype@npm:8.1.0"
+  dependencies:
+    mdast-util-to-hast: ^10.2.0
+  checksum: e1152464cfa83c14b570b1cb85eb9b3667795b5bed2f6b16d1c6e96c369816b07945a3c04eb0e1fd57a19cc1837969527d0056d5b6d179f1290688db2a7e2c5f
   languageName: node
   linkType: hard
 
@@ -30540,6 +30629,13 @@ __metadata:
   version: 1.1.4
   resolution: "space-separated-tokens@npm:1.1.4"
   checksum: 4048c44ac1bded6927f4a31bf4bc958d6b878adf3ed3af9b08e7873b789016fe946ee69ca049d8030a3829ec2fe0481b55a93b066f29ab8f529864bcc85e043b
+  languageName: node
+  linkType: hard
+
+"space-separated-tokens@npm:^1.1.0":
+  version: 1.1.5
+  resolution: "space-separated-tokens@npm:1.1.5"
+  checksum: 8ef68f1cfa8ccad316b7f8d0df0919d0f1f6d32101e8faeee34ea3a923ce8509c1ad562f57388585ee4951e92d27afa211ed0a077d3d5995b5ba9180331be708
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -30625,14 +30625,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"space-separated-tokens@npm:^1.0.0":
-  version: 1.1.4
-  resolution: "space-separated-tokens@npm:1.1.4"
-  checksum: 4048c44ac1bded6927f4a31bf4bc958d6b878adf3ed3af9b08e7873b789016fe946ee69ca049d8030a3829ec2fe0481b55a93b066f29ab8f529864bcc85e043b
-  languageName: node
-  linkType: hard
-
-"space-separated-tokens@npm:^1.1.0":
+"space-separated-tokens@npm:^1.0.0, space-separated-tokens@npm:^1.1.0":
   version: 1.1.5
   resolution: "space-separated-tokens@npm:1.1.5"
   checksum: 8ef68f1cfa8ccad316b7f8d0df0919d0f1f6d32101e8faeee34ea3a923ce8509c1ad562f57388585ee4951e92d27afa211ed0a077d3d5995b5ba9180331be708
@@ -32447,10 +32440,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"trim@npm:0.0.1":
-  version: 0.0.1
-  resolution: "trim@npm:0.0.1"
-  checksum: 2b4646dff99a222e8e1526edd4e3a43bbd925af0b8e837c340455d250157e7deefaa4da49bb891ab841e5c27b1afc5e9e32d4b57afb875d2dfcabf4e319b8f7f
+"trim@npm:0.0.3":
+  version: 0.0.3
+  resolution: "trim@npm:0.0.3"
+  checksum: 9a059ba56d5e22c9e571798a7c63640cb25478c495d8a9d001f6352927207c6bd224018751a0c5145fbedc943ee2ebab1d7cc2e8ccba3121a51a7d3428dd879c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Explanation

Allow Snaps custom UI to use Markdown for text formatting. For now, this only allows for usage of bold and italic text formatting in the Markdown feature set.

## Screenshots/Screencaps

![image](https://user-images.githubusercontent.com/1561200/207049676-bc1821f5-8684-433b-ab90-8022dfe6bd14.png)
