### PR TITLE
scripts/ui.js: add tabs.query promise error handler

### DIFF
--- a/app/scripts/ui.js
+++ b/app/scripts/ui.js
@@ -18,6 +18,7 @@ import {
   PLATFORM_FIREFOX,
 } from '../../shared/constants/app';
 import { isManifestV3 } from '../../shared/modules/mv3.utils';
+import { checkForLastErrorAndLog } from '../../shared/modules/browser-runtime.utils';
 import { SUPPORT_LINK } from '../../shared/lib/ui-utils';
 import { getErrorHtml } from '../../shared/lib/error-utils';
 import ExtensionPlatform from './platforms/extension';
@@ -289,7 +290,12 @@ async function queryCurrentActiveTab(windowType) {
     return {};
   }
 
-  const tabs = await browser.tabs.query({ active: true, currentWindow: true });
+  const tabs = await browser.tabs
+    .query({ active: true, currentWindow: true })
+    .catch((e) => {
+      checkForLastErrorAndLog() || log.error(e);
+    });
+
   const [activeTab] = tabs;
   const { id, title, url } = activeTab;
   const { origin, protocol } = url ? new URL(url) : {};


### PR DESCRIPTION
## Explanation
Fixes https://github.com/MetaMask/metamask-extension/issues/16342

- For promise-based versions of API, we should use error handlers to catch errors.
- For asynchronous API callbacks, we should check for `runtime.lastError`.

ref: https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/runtime/lastError

----
Audit files to adhere to the above statements:
- scripts/contentscript.js
- scripts/ui.js
- scripts/background.js

Audit: 
For promise-based versions of API, we should use error handlers to catch errors
- scripts/contentscript.js
  - no changes
- scripts/ui.js
  - add error handler for browser.tabs.query
- scripts/background.js
  - no changes 

For asynchronous API callbacks, we should check for `runtime.lastError`.
 - no callbacks that need lastError checks were found 


## Manual Testing Steps

Ensure dapp, popup, and home.html are working as expected. 

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [x] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [x] PR is linked to the appropriate GitHub issue
- [x] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
