### PR TITLE
remove the ability to navigate back into the onboarding flow after completing onboarding

### DIFF
--- a/ui/pages/home/home.component.js
+++ b/ui/pages/home/home.component.js
@@ -45,6 +45,7 @@ import {
   VIEW_QUOTE_ROUTE,
   CONFIRMATION_V_NEXT_ROUTE,
   ADD_COLLECTIBLE_ROUTE,
+  ONBOARDING_SECURE_YOUR_WALLET_ROUTE,
 } from '../../helpers/constants/routes';
 import ZENDESK_URLS from '../../helpers/constants/zendesk-url';
 import Tooltip from '../../components/ui/tooltip';
@@ -414,12 +415,13 @@ export default class Home extends PureComponent {
             descriptionText={t('backupApprovalNotice')}
             acceptText={t('backupNow')}
             onAccept={() => {
+              const backUpSRPRoute = process.env.ONBOARDING_V2
+                ? ONBOARDING_SECURE_YOUR_WALLET_ROUTE
+                : INITIALIZE_BACKUP_SEED_PHRASE_ROUTE;
               if (isPopup) {
-                global.platform.openExtensionInBrowser(
-                  INITIALIZE_BACKUP_SEED_PHRASE_ROUTE,
-                );
+                global.platform.openExtensionInBrowser(backUpSRPRoute);
               } else {
-                history.push(INITIALIZE_BACKUP_SEED_PHRASE_ROUTE);
+                history.push(backUpSRPRoute);
               }
             }}
             infoText={t('backupApprovalInfo')}

--- a/ui/pages/home/home.component.js
+++ b/ui/pages/home/home.component.js
@@ -410,13 +410,13 @@ export default class Home extends PureComponent {
             key="home-web3ShimUsageNotification"
           />
         ) : null}
-        {shouldShowSeedPhraseReminder ? (
+        {showRecoveryPhraseReminder ? (
           <HomeNotification
             descriptionText={t('backupApprovalNotice')}
             acceptText={t('backupNow')}
             onAccept={() => {
               const backUpSRPRoute = process.env.ONBOARDING_V2
-                ? ONBOARDING_SECURE_YOUR_WALLET_ROUTE
+                ? `${ONBOARDING_SECURE_YOUR_WALLET_ROUTE}/?isFromReminder=true`
                 : INITIALIZE_BACKUP_SEED_PHRASE_ROUTE;
               if (isPopup) {
                 global.platform.openExtensionInBrowser(backUpSRPRoute);

--- a/ui/pages/home/home.component.js
+++ b/ui/pages/home/home.component.js
@@ -410,7 +410,7 @@ export default class Home extends PureComponent {
             key="home-web3ShimUsageNotification"
           />
         ) : null}
-        {showRecoveryPhraseReminder ? (
+        {shouldShowSeedPhraseReminder ? (
           <HomeNotification
             descriptionText={t('backupApprovalNotice')}
             acceptText={t('backupNow')}

--- a/ui/pages/onboarding-flow/onboarding-flow.js
+++ b/ui/pages/onboarding-flow/onboarding-flow.js
@@ -27,6 +27,7 @@ import {
   createNewVaultAndGetSeedPhrase,
   unlockAndGetSeedPhrase,
   createNewVaultAndRestore,
+  verifySeedPhrase,
 } from '../../store/actions';
 import { getFirstTimeFlowTypeRoute } from '../../selectors';
 import Button from '../../components/ui/button';
@@ -61,6 +62,18 @@ export default function OnboardingFlow() {
       history.push(DEFAULT_ROUTE);
     }
   }, [history, completedOnboarding, seedPhraseBackedUp]);
+
+  useEffect(() => {
+    const verifyAndSetSeedPhrase = async () => {
+      if (completedOnboarding && !secretRecoveryPhrase) {
+        const verifiedSeedPhrase = await verifySeedPhrase();
+        if (verifiedSeedPhrase) {
+          setSecretRecoveryPhrase(verifiedSeedPhrase);
+        }
+      }
+    };
+    verifyAndSetSeedPhrase();
+  }, [completedOnboarding, secretRecoveryPhrase]);
 
   const handleCreateNewAccount = async (password) => {
     const newSecretRecoveryPhrase = await dispatch(

--- a/ui/pages/onboarding-flow/onboarding-flow.js
+++ b/ui/pages/onboarding-flow/onboarding-flow.js
@@ -1,5 +1,10 @@
 import React, { useEffect, useState } from 'react';
-import { Switch, Route, useHistory, useLocation } from 'react-router-dom';
+import {
+  Switch,
+  Route,
+  useHistory,
+  useLocation,
+} from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
 import Unlock from '../unlock-page';
 import {
@@ -50,15 +55,15 @@ import MetaMetricsComponent from './metametrics/metametrics';
 export default function OnboardingFlow() {
   const [secretRecoveryPhrase, setSecretRecoveryPhrase] = useState('');
   const dispatch = useDispatch();
-  const currentLocation = useLocation();
+  const { pathName, search } = useLocation();
   const history = useHistory();
   const t = useI18nContext();
   const completedOnboarding = useSelector(getCompletedOnboarding);
   const seedPhraseBackedUp = useSelector(getSeedPhraseBackedUp);
   const nextRoute = useSelector(getFirstTimeFlowTypeRoute);
-
+  const isFromReminder = new URLSearchParams(search).get('isFromReminder');
   useEffect(() => {
-    if (completedOnboarding && seedPhraseBackedUp) {
+    if (completedOnboarding && !isFromReminder) {
       history.push(DEFAULT_ROUTE);
     }
   }, [history, completedOnboarding, seedPhraseBackedUp]);
@@ -74,6 +79,7 @@ export default function OnboardingFlow() {
     };
     verifyAndSetSeedPhrase();
   }, [completedOnboarding, secretRecoveryPhrase]);
+
 
   const handleCreateNewAccount = async (password) => {
     const newSecretRecoveryPhrase = await dispatch(
@@ -110,7 +116,6 @@ export default function OnboardingFlow() {
             )}
           />
           <Route
-            exact
             path={ONBOARDING_SECURE_YOUR_WALLET_ROUTE}
             component={SecureYourWallet}
           />
@@ -183,7 +188,7 @@ export default function OnboardingFlow() {
           <Route exact path="*" component={OnboardingFlowSwitch} />
         </Switch>
       </div>
-      {currentLocation?.pathname === ONBOARDING_COMPLETION_ROUTE && (
+      {pathName === ONBOARDING_COMPLETION_ROUTE && (
         <Button
           className="onboarding-flow__twitter-button"
           type="link"

--- a/ui/pages/onboarding-flow/onboarding-flow.js
+++ b/ui/pages/onboarding-flow/onboarding-flow.js
@@ -19,10 +19,7 @@ import {
   ONBOARDING_PIN_EXTENSION_ROUTE,
   ONBOARDING_METAMETRICS,
 } from '../../helpers/constants/routes';
-import {
-  getCompletedOnboarding,
-  getSeedPhraseBackedUp,
-} from '../../ducks/metamask/metamask';
+import { getCompletedOnboarding } from '../../ducks/metamask/metamask';
 import {
   createNewVaultAndGetSeedPhrase,
   unlockAndGetSeedPhrase,
@@ -54,14 +51,13 @@ export default function OnboardingFlow() {
   const history = useHistory();
   const t = useI18nContext();
   const completedOnboarding = useSelector(getCompletedOnboarding);
-  const seedPhraseBackedUp = useSelector(getSeedPhraseBackedUp);
   const nextRoute = useSelector(getFirstTimeFlowTypeRoute);
   const isFromReminder = new URLSearchParams(search).get('isFromReminder');
   useEffect(() => {
     if (completedOnboarding && !isFromReminder) {
       history.push(DEFAULT_ROUTE);
     }
-  }, [history, completedOnboarding, seedPhraseBackedUp]);
+  }, [history, completedOnboarding, isFromReminder]);
 
   useEffect(() => {
     const verifyAndSetSeedPhrase = async () => {

--- a/ui/pages/onboarding-flow/onboarding-flow.js
+++ b/ui/pages/onboarding-flow/onboarding-flow.js
@@ -1,10 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import {
-  Switch,
-  Route,
-  useHistory,
-  useLocation,
-} from 'react-router-dom';
+import { Switch, Route, useHistory, useLocation } from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
 import Unlock from '../unlock-page';
 import {
@@ -79,7 +74,6 @@ export default function OnboardingFlow() {
     };
     verifyAndSetSeedPhrase();
   }, [completedOnboarding, secretRecoveryPhrase]);
-
 
   const handleCreateNewAccount = async (password) => {
     const newSecretRecoveryPhrase = await dispatch(

--- a/ui/pages/onboarding-flow/onboarding-flow.test.js
+++ b/ui/pages/onboarding-flow/onboarding-flow.test.js
@@ -29,7 +29,7 @@ jest.mock('../../store/actions', () => ({
   createNewVaultAndGetSeedPhrase: jest.fn().mockResolvedValue(null),
   unlockAndGetSeedPhrase: jest.fn().mockResolvedValue(null),
   createNewVaultAndRestore: jest.fn(),
-  verifySeedPhrase: jest.fn()
+  verifySeedPhrase: jest.fn(),
 }));
 
 describe('Onboarding Flow', () => {

--- a/ui/pages/onboarding-flow/onboarding-flow.test.js
+++ b/ui/pages/onboarding-flow/onboarding-flow.test.js
@@ -29,6 +29,7 @@ jest.mock('../../store/actions', () => ({
   createNewVaultAndGetSeedPhrase: jest.fn().mockResolvedValue(null),
   unlockAndGetSeedPhrase: jest.fn().mockResolvedValue(null),
   createNewVaultAndRestore: jest.fn(),
+  verifySeedPhrase: jest.fn()
 }));
 
 describe('Onboarding Flow', () => {


### PR DESCRIPTION
* Fixes #16890

Fixes issue where the secret recovery phrase state is not available when navigating back after completing onboarding. We now prevent users from navigating back into the onboarding flow at all after its completion. The one exception is when you click the `Backup Now` button on the `Backup your Secret Recovery Phrase to keep your wallet and funds secure.` reminder if you opted to not reveal and back up the security phrase in the initial onboarding flow.

### Before

https://user-images.githubusercontent.com/34557516/207152480-55462427-f183-40c4-8b51-c9eafb780a84.mp4

and backup reminder button takes us to V1 secure seedphrase flow instead of V2 even when feature flag is on:
https://user-images.githubusercontent.com/34557516/207154103-5e38e796-c18c-4ece-bf9d-a7b4c56f7ff6.mov


### After

See you cannot navigate back after completing onboarding but you are able to navigate back to secure your wallet if you did not do so initially (the reminder here is hardcoded to show up immediately for demonstration purposes).
https://user-images.githubusercontent.com/34557516/207164461-1e6ea62d-6e5e-4538-8b9e-3f794188bc62.mov


## Manual Testing Steps

1. Load MM with Onboarding V2
2. Go through Create Wallet flow until Home page
3. Attempt to click back, see that you cannot navigate back

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes

