### PR TITLE
Combine network stores into a single store

### DIFF
--- a/.storybook/test-data.js
+++ b/.storybook/test-data.js
@@ -601,13 +601,6 @@ const state = {
       rpcUrl: '',
       chainId: '0x5',
     },
-    previousProviderStore: {
-      type: 'goerli',
-      ticker: 'ETH',
-      nickname: '',
-      rpcUrl: '',
-      chainId: '0x5',
-    },
     network: '5',
     accounts: {
       '0x64a845a5b02460acf8a3d84503b0d68d028b4bb4': {

--- a/app/scripts/controllers/network/network-controller.test.js
+++ b/app/scripts/controllers/network/network-controller.test.js
@@ -105,16 +105,16 @@ describe('NetworkController', () => {
         );
         await networkController.getEIP1559Compatibility();
         expect(
-          networkController.networkDetails.getState().EIPS[1559],
+          networkController.store.getState().networkDetails.EIPS[1559],
         ).toStrictEqual(true);
         getLatestBlockStub.callsFake(() => Promise.resolve({}));
         await setProviderTypeAndWait('mainnet');
         expect(
-          networkController.networkDetails.getState().EIPS[1559],
+          networkController.store.getState().networkDetails.EIPS[1559],
         ).toBeUndefined();
         await networkController.getEIP1559Compatibility();
         expect(
-          networkController.networkDetails.getState().EIPS[1559],
+          networkController.store.getState().networkDetails.EIPS[1559],
         ).toStrictEqual(false);
         expect(getLatestBlockStub.calledTwice).toStrictEqual(true);
       });

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -479,7 +479,7 @@ export default class MetamaskController extends EventEmitter {
       messenger: currencyRateMessenger,
       state: {
         ...initState.CurrencyController,
-        nativeCurrency: this.networkController.providerStore.getState().ticker,
+        nativeCurrency: this.networkController.store.getState().provider.ticker,
       },
     });
 
@@ -838,9 +838,11 @@ export default class MetamaskController extends EventEmitter {
         ),
       getCurrentAccountEIP1559Compatibility:
         this.getCurrentAccountEIP1559Compatibility.bind(this),
-      getNetworkState: () => this.networkController.networkStore.getState(),
-      onNetworkStateChange: (listener) =>
-        this.networkController.networkStore.subscribe(listener),
+      getNetworkState: () => this.networkController.store.getState().network,
+      onNetworkStateChange: this.networkController.on.bind(
+        this.networkController,
+        NETWORK_EVENTS.NETWORK_DID_CHANGE,
+      ),
       getCurrentChainId: this.networkController.getCurrentChainId.bind(
         this.networkController,
       ),
@@ -4225,7 +4227,7 @@ export default class MetamaskController extends EventEmitter {
   /**
    * Migrate address book state from old to new chainId.
    *
-   * Address book state is keyed by the `networkStore` state from the network controller. This value is set to the
+   * Address book state is keyed by the `network` state from the network controller. This value is set to the
    * `networkId` for our built-in Infura networks, but it's set to the `chainId` for custom networks.
    * When this `chainId` value is changed for custom RPC endpoints, we need to migrate any contacts stored under the
    * old key to the new key.


### PR DESCRIPTION
Three of the ObservableStores in the NetworkController have been combined into a single store. This is more similar to how our other controllers work, and will help with the effort to merge this network controller with the mobile network controller.

One internal ObservableStore, the `previousProviderStore`, was converted to a private instance variable. It was only used internally.

This relates to https://github.com/MetaMask/controllers/issues/971

## Manual Testing Steps

This has no functional changes.

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
