### PR TITLE
Add e2e debugging logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,21 +68,26 @@ Our e2e test suite can be run on either Firefox or Chrome.
  * Firefox e2e tests can be run with `yarn test:e2e:firefox`.
  * Chrome e2e tests can be run with `yarn test:e2e:chrome`. The `chromedriver` package major version must match the major version of your local Chrome installation. If they don't match, update whichever is behind before running Chrome e2e tests.
 
+These test scripts all support additional options, which might be helpful for debugging. Run the script with the flag `--help` to see all options.
+
 #### Running a single e2e test
 
 Single e2e tests can be run with `yarn test:e2e:single test/e2e/tests/TEST_NAME.spec.js` along with the options below.
 
 ```console
---browser             Set the browser used; either 'chrome' or 'firefox'.
-
---leave-running       Leaves the browser running after a test fails, along with anything else
-                      that the test used (ganache, the test dapp, etc.).
-
---retries             Set how many times the test should be retried upon failure. Default is 0.
+  --browser        Set the browser used; either 'chrome' or 'firefox'.
+                                         [string] [choices: "chrome", "firefox"]
+  --debug          Run tests in debug mode, logging each driver interaction
+                                                      [boolean] [default: false]
+  --retries        Set how many times the test should be retried upon failure.
+                                                           [number] [default: 0]
+  --leave-running  Leaves the browser running after a test fails, along with
+                   anything else that the test used (ganache, the test dapp,
+                   etc.)                              [boolean] [default: false]
 ```
 
-An example for running `account-details` testcase with chrome and leaving the browser open would be:
-`yarn test:e2e:single test/e2e/tests/account-details.spec.js --browser=chrome --leave-running`
+For example, to run the `account-details` tests using Chrome, with debug logging and with the browser set to remain open upon failure, you would use:
+`yarn test:e2e:single test/e2e/tests/account-details.spec.js --browser=chrome --debug --leave-running`
 
 ### Changing dependencies
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "dist": "yarn build dist",
     "build": "yarn lavamoat:build",
     "build:dev": "node development/build/index.js",
-    "start:test": "SEGMENT_HOST='https://api.segment.io' SEGMENT_WRITE_KEY='FAKE' SENTRY_DSN_DEV=https://fake@sentry.io/0000000 PORTFOLIO_URL=http://127.0.0.1:8080 yarn build testDev",
+    "start:test": "SEGMENT_HOST='https://api.segment.io' SEGMENT_WRITE_KEY='FAKE' SENTRY_DSN_DEV=https://fake@sentry.io/0000000 PORTFOLIO_URL=http://127.0.0.1:8080 yarn build:dev testDev",
     "benchmark:chrome": "SELENIUM_BROWSER=chrome node test/e2e/benchmark.js",
     "mv3:stats:chrome": "SELENIUM_BROWSER=chrome ENABLE_MV3=true node test/e2e/mv3-perf-stats/index.js",
     "user-actions-benchmark:chrome": "SELENIUM_BROWSER=chrome node test/e2e/user-actions-benchmark.js",

--- a/test/e2e/helpers.js
+++ b/test/e2e/helpers.js
@@ -120,8 +120,28 @@ async function withFixtures(options, testSuite) {
       await driver.checkBrowserForExceptions();
     }
 
+    let driverProxy;
+    if (process.env.E2E_DEBUG === 'true') {
+      driverProxy = new Proxy(driver, {
+        get(target, prop, receiver) {
+          const originalProperty = target[prop];
+          if (typeof originalProperty === 'function') {
+            return (...args) => {
+              console.log(
+                `[driver] Called '${prop}' with arguments '${JSON.stringify(
+                  args,
+                )}'`,
+              );
+              return originalProperty.bind(target)(...args);
+            };
+          }
+          return Reflect.get(target, prop, receiver);
+        },
+      });
+    }
+
     await testSuite({
-      driver,
+      driver: driverProxy ?? driver,
       mockServer,
       contractRegistry,
     });

--- a/test/e2e/helpers.js
+++ b/test/e2e/helpers.js
@@ -128,9 +128,9 @@ async function withFixtures(options, testSuite) {
           if (typeof originalProperty === 'function') {
             return (...args) => {
               console.log(
-                `[driver] Called '${prop}' with arguments '${JSON.stringify(
+                `[driver] Called '${prop}' with arguments ${JSON.stringify(
                   args,
-                )}'`,
+                )}`,
               );
               return originalProperty.bind(target)(...args);
             };

--- a/test/e2e/run-all.js
+++ b/test/e2e/run-all.js
@@ -36,6 +36,12 @@ async function main() {
             type: 'string',
             choices: ['chrome', 'firefox'],
           })
+          .option('debug', {
+            default: process.env.E2E_DEBUG === 'true',
+            description:
+              'Run tests in debug mode, logging each driver interaction',
+            type: 'boolean',
+          })
           .option('snaps', {
             description: `run snaps e2e tests`,
             type: 'boolean',
@@ -53,7 +59,7 @@ async function main() {
     .strict()
     .help('help');
 
-  const { browser, retries, snaps, mv3 } = argv;
+  const { browser, debug, retries, snaps, mv3 } = argv;
 
   let testPaths;
 
@@ -83,6 +89,9 @@ async function main() {
   }
   if (retries) {
     args.push('--retries', retries);
+  }
+  if (debug) {
+    args.push('--debug');
   }
 
   // For running E2Es in parallel in CI

--- a/test/e2e/run-e2e-test.js
+++ b/test/e2e/run-e2e-test.js
@@ -18,6 +18,12 @@ async function main() {
             type: 'string',
             choices: ['chrome', 'firefox'],
           })
+          .option('debug', {
+            default: process.env.E2E_DEBUG === 'true',
+            description:
+              'Run tests in debug mode, logging each driver interaction',
+            type: 'boolean',
+          })
           .option('retries', {
             default: 0,
             description:
@@ -39,7 +45,7 @@ async function main() {
     .strict()
     .help('help');
 
-  const { browser, e2eTestPath, retries, leaveRunning } = argv;
+  const { browser, debug, e2eTestPath, retries, leaveRunning } = argv;
 
   if (!browser) {
     exitWithError(
@@ -67,6 +73,10 @@ async function main() {
       return;
     }
     throw error;
+  }
+
+  if (debug) {
+    process.env.E2E_DEBUG = 'true';
   }
 
   let testTimeoutInMilliseconds = 60 * 1000;


### PR DESCRIPTION
A `debug` flag has been added to our e2e test runner scripts, enabling e2e debug logs. When this flag is enabled, all driver interactions will be logged to the console. This is extremely useful when debugging e2e tests, because it lets you known how far the test had progressed before failing.

This flag should work with all existing e2e test scripts, including both `test:e2e:single` and all of the test commands that run entire test suites.

The README has been updated to reference this flag in the section regarding how to run a single e2e test. To ensure this wasn't totally missed for the other scripts, I added a line suggesting that users use `--help` to see all supported options.

## Explanation

## Manual Testing Steps

* Create a test build (`yarn start:test`, then interrupt the process when the "primary" bundle has finished)
* Run a test or a test suite with the `--debug` flag (e.g. `yarn test:e2e:single --browser firefox --debug ./test/e2e/swaps/swaps-notifications.spec.js`)
* See that driver logs are printed to the console

Here is an example of the logs you should see for the first swaps notification test, from the example command listed above:
```
Swaps - notifications
[driver] Called 'navigate' with arguments []
[driver] Called 'fill' with arguments ["#password","correct horse battery staple"]
[driver] Called 'press' with arguments ["#password",""]
[driver] Called 'clickElement' with arguments [".wallet-overview__buttons .icon-button:nth-child(3)"]
[driver] Called 'fill' with arguments ["input[placeholder*=\"0\"]",2]
[driver] Called 'delay' with arguments [1600]
[driver] Called 'clickElement' with arguments ["[class=\"dropdown-search-list__closed-primary-label dropdown-search-list__select-default\"]"]
[driver] Called 'wait' with arguments [null]
[driver] Called 'findElements' with arguments [".searchable-item-list__item"]
[driver] Called 'clickElement' with arguments [".searchable-item-list__labels"]'
[driver] Called 'clickElement' with arguments [".dropdown-input-pair__to"]
[driver] Called 'clickElement' with arguments ["input[data-testid=\"search-list-items\"]"]
[driver] Called 'fill' with arguments ["input[data-testid=\"search-list-items\"]","INUINU"]
[driver] Called 'wait' with arguments [null]
[driver] Called 'findElements' with arguments [".searchable-item-list__primary-label"]
[driver] Called 'findElements' with arguments [".searchable-item-list__primary-label"]
[driver] Called 'findElements' with arguments [".searchable-item-list__primary-label"]
[driver] Called 'clickElement' with arguments [".searchable-item-list__primary-label"]
[driver] Called 'findElement' with arguments ["[data-testid=\"page-container-footer-next\"]"]
[driver] Called 'findClickableElement' with arguments [".actionable-message__action-warning"]
[driver] Called 'waitForSelector' with arguments [{"css":"[class*=\"box--align-items-center\"]","text":"Estimated gas fee"}]
[driver] Called 'findElement' with arguments ["[data-testid=\"page-container-footer-next\"]"]
[driver] Called 'clickElement' with arguments [{"text":"I understand","tag":"button"}]
    ✓ tests notifications for verified token on 1 source and price difference (22482ms)
```

## Pre-merge author checklist

- [ ] I've clearly explained:
  - [ ] What problem this PR is solving
  - [ ] How this problem was solved
  - [ ] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
