### PR TITLE
Improve stability of e2e test snap approval step

### DIFF
--- a/test/e2e/helpers.js
+++ b/test/e2e/helpers.js
@@ -328,6 +328,36 @@ const completeImportSRPOnboardingFlowWordByWord = async (
   });
 };
 
+/**
+ * Retry steps if the browser window closes.
+ *
+ * This can be useful for testing steps where the extension popup might rapidly close then open up
+ * again. For example, when approving snap installation, or using a dapp that performs two separate
+ * sequential actions. In these cases, there is no reliable way to know when the first popup has
+ * closed and the second one has opened.
+ *
+ * Instead we can capture this error and retry any related steps.
+ *
+ * Typically this callback should start with switching to the expected window. You may also want to
+ * update the window handles first, if the test using this function maintains a list of open window
+ * handles.
+ *
+ * The action must also include one or more interactions with the window. The error about the
+ * window already being closed usually doesn't occur until the first action in that window.
+ *
+ * @param {Function} stepsToRetry - The steps to retry upon close.
+ */
+async function retryOnClosed(stepsToRetry) {
+  try {
+    await stepsToRetry();
+  } catch (error) {
+    if (error.name === 'NoSuchWindowError') {
+      await stepsToRetry();
+    }
+    throw error;
+  }
+}
+
 module.exports = {
   getWindowHandles,
   convertToHexValue,
@@ -339,4 +369,5 @@ module.exports = {
   completeImportSRPOnboardingFlow,
   completeImportSRPOnboardingFlowWordByWord,
   createDownloadFolder,
+  retryOnClosed,
 };

--- a/test/e2e/snaps/test-snap-bip-32.spec.js
+++ b/test/e2e/snaps/test-snap-bip-32.spec.js
@@ -1,5 +1,5 @@
 const { strict: assert } = require('assert');
-const { withFixtures } = require('../helpers');
+const { retryOnClosed, withFixtures } = require('../helpers');
 const FixtureBuilder = require('../fixture-builder');
 const { TEST_SNAPS_WEBSITE_URL } = require('./enums');
 
@@ -55,19 +55,17 @@ describe('Test Snap bip-32', function () {
           10000,
         );
 
-        await driver.delay(2000);
-
-        // switch to metamask extension
-        windowHandles = await driver.waitUntilXWindowHandles(2, 1000, 10000);
-
         // approve install of snap
-        await driver.switchToWindowWithTitle(
-          'MetaMask Notification',
-          windowHandles,
-        );
-        await driver.clickElement({
-          text: 'Approve & install',
-          tag: 'button',
+        await retryOnClosed(async () => {
+          windowHandles = await driver.waitUntilXWindowHandles(2);
+          await driver.switchToWindowWithTitle(
+            'MetaMask Notification',
+            windowHandles,
+          );
+          await driver.clickElement({
+            text: 'Approve & install',
+            tag: 'button',
+          });
         });
 
         // wait for permissions popover, click checkboxes and confirm

--- a/test/e2e/snaps/test-snap-bip-44.spec.js
+++ b/test/e2e/snaps/test-snap-bip-44.spec.js
@@ -1,5 +1,5 @@
 const { strict: assert } = require('assert');
-const { withFixtures } = require('../helpers');
+const { retryOnClosed, withFixtures } = require('../helpers');
 const FixtureBuilder = require('../fixture-builder');
 const { TEST_SNAPS_WEBSITE_URL } = require('./enums');
 
@@ -53,19 +53,17 @@ describe('Test Snap bip-44', function () {
           10000,
         );
 
-        await driver.delay(2000);
-
-        // switch to metamask extension
-        windowHandles = await driver.waitUntilXWindowHandles(2, 1000, 10000);
-
         // approve install of snap
-        await driver.switchToWindowWithTitle(
-          'MetaMask Notification',
-          windowHandles,
-        );
-        await driver.clickElement({
-          text: 'Approve & install',
-          tag: 'button',
+        await retryOnClosed(async () => {
+          windowHandles = await driver.waitUntilXWindowHandles(2);
+          await driver.switchToWindowWithTitle(
+            'MetaMask Notification',
+            windowHandles,
+          );
+          await driver.clickElement({
+            text: 'Approve & install',
+            tag: 'button',
+          });
         });
 
         // deal with permissions popover

--- a/test/e2e/snaps/test-snap-confirm.spec.js
+++ b/test/e2e/snaps/test-snap-confirm.spec.js
@@ -1,5 +1,5 @@
 const { strict: assert } = require('assert');
-const { withFixtures } = require('../helpers');
+const { retryOnClosed, withFixtures } = require('../helpers');
 const FixtureBuilder = require('../fixture-builder');
 const { TEST_SNAPS_WEBSITE_URL } = require('./enums');
 
@@ -53,17 +53,17 @@ describe('Test Snap Confirm', function () {
           10000,
         );
 
-        await driver.delay(2000);
-
         // approve install of snap
-        windowHandles = await driver.waitUntilXWindowHandles(2, 1000, 10000);
-        await driver.switchToWindowWithTitle(
-          'MetaMask Notification',
-          windowHandles,
-        );
-        await driver.clickElement({
-          text: 'Approve & install',
-          tag: 'button',
+        await retryOnClosed(async () => {
+          windowHandles = await driver.waitUntilXWindowHandles(2);
+          await driver.switchToWindowWithTitle(
+            'MetaMask Notification',
+            windowHandles,
+          );
+          await driver.clickElement({
+            text: 'Approve & install',
+            tag: 'button',
+          });
         });
 
         // switch back to test snaps page

--- a/test/e2e/snaps/test-snap-error.spec.js
+++ b/test/e2e/snaps/test-snap-error.spec.js
@@ -1,5 +1,5 @@
 const { strict: assert } = require('assert');
-const { withFixtures } = require('../helpers');
+const { retryOnClosed, withFixtures } = require('../helpers');
 const FixtureBuilder = require('../fixture-builder');
 const { TEST_SNAPS_WEBSITE_URL } = require('./enums');
 
@@ -54,17 +54,17 @@ describe('Test Snap Error', function () {
           10000,
         );
 
-        await driver.delay(2000);
-
         // approve install of snap
-        windowHandles = await driver.waitUntilXWindowHandles(3, 1000, 10000);
-        await driver.switchToWindowWithTitle(
-          'MetaMask Notification',
-          windowHandles,
-        );
-        await driver.clickElement({
-          text: 'Approve & install',
-          tag: 'button',
+        await retryOnClosed(async () => {
+          windowHandles = await driver.waitUntilXWindowHandles(3);
+          await driver.switchToWindowWithTitle(
+            'MetaMask Notification',
+            windowHandles,
+          );
+          await driver.clickElement({
+            text: 'Approve & install',
+            tag: 'button',
+          });
         });
 
         // click send inputs on test snap page

--- a/test/e2e/snaps/test-snap-installed.spec.js
+++ b/test/e2e/snaps/test-snap-installed.spec.js
@@ -1,5 +1,5 @@
 const { strict: assert } = require('assert');
-const { withFixtures } = require('../helpers');
+const { retryOnClosed, withFixtures } = require('../helpers');
 const FixtureBuilder = require('../fixture-builder');
 const { TEST_SNAPS_WEBSITE_URL } = require('./enums');
 
@@ -53,17 +53,17 @@ describe('Test Snap Installed', function () {
           10000,
         );
 
-        await driver.delay(2000);
-
         // approve install of snap
-        windowHandles = await driver.waitUntilXWindowHandles(3, 1000, 10000);
-        await driver.switchToWindowWithTitle(
-          'MetaMask Notification',
-          windowHandles,
-        );
-        await driver.clickElement({
-          text: 'Approve & install',
-          tag: 'button',
+        await retryOnClosed(async () => {
+          windowHandles = await driver.waitUntilXWindowHandles(3);
+          await driver.switchToWindowWithTitle(
+            'MetaMask Notification',
+            windowHandles,
+          );
+          await driver.clickElement({
+            text: 'Approve & install',
+            tag: 'button',
+          });
         });
 
         // click send inputs on test snap page
@@ -89,17 +89,17 @@ describe('Test Snap Installed', function () {
           10000,
         );
 
-        await driver.delay(2000);
-
         // approve install of snap
-        windowHandles = await driver.getAllWindowHandles();
-        await driver.switchToWindowWithTitle(
-          'MetaMask Notification',
-          windowHandles,
-        );
-        await driver.clickElement({
-          text: 'Approve & install',
-          tag: 'button',
+        await retryOnClosed(async () => {
+          windowHandles = await driver.waitUntilXWindowHandles(3);
+          await driver.switchToWindowWithTitle(
+            'MetaMask Notification',
+            windowHandles,
+          );
+          await driver.clickElement({
+            text: 'Approve & install',
+            tag: 'button',
+          });
         });
 
         windowHandles = await driver.waitUntilXWindowHandles(2, 1000, 10000);

--- a/test/e2e/snaps/test-snap-management.spec.js
+++ b/test/e2e/snaps/test-snap-management.spec.js
@@ -1,5 +1,5 @@
 const { strict: assert } = require('assert');
-const { withFixtures } = require('../helpers');
+const { retryOnClosed, withFixtures } = require('../helpers');
 const FixtureBuilder = require('../fixture-builder');
 const { TEST_SNAPS_WEBSITE_URL } = require('./enums');
 
@@ -55,17 +55,17 @@ describe('Test Snap Management', function () {
           10000,
         );
 
-        await driver.delay(1000);
-
         // approve install of snap
-        windowHandles = await driver.getAllWindowHandles();
-        await driver.switchToWindowWithTitle(
-          'MetaMask Notification',
-          windowHandles,
-        );
-        await driver.clickElement({
-          text: 'Approve & install',
-          tag: 'button',
+        await retryOnClosed(async () => {
+          windowHandles = await driver.waitUntilXWindowHandles(3);
+          await driver.switchToWindowWithTitle(
+            'MetaMask Notification',
+            windowHandles,
+          );
+          await driver.clickElement({
+            text: 'Approve & install',
+            tag: 'button',
+          });
         });
 
         // switch to the original MM tab

--- a/test/e2e/snaps/test-snap-managestate.spec.js
+++ b/test/e2e/snaps/test-snap-managestate.spec.js
@@ -1,5 +1,5 @@
 const { strict: assert } = require('assert');
-const { withFixtures } = require('../helpers');
+const { retryOnClosed, withFixtures } = require('../helpers');
 const FixtureBuilder = require('../fixture-builder');
 const { TEST_SNAPS_WEBSITE_URL } = require('./enums');
 
@@ -56,17 +56,18 @@ describe('Test Snap manageState', function () {
           },
           10000,
         );
-        await driver.delay(2000);
 
         // approve install of snap
-        windowHandles = await driver.waitUntilXWindowHandles(2, 1000, 10000);
-        await driver.switchToWindowWithTitle(
-          'MetaMask Notification',
-          windowHandles,
-        );
-        await driver.clickElement({
-          text: 'Approve & install',
-          tag: 'button',
+        await retryOnClosed(async () => {
+          windowHandles = await driver.waitUntilXWindowHandles(2);
+          await driver.switchToWindowWithTitle(
+            'MetaMask Notification',
+            windowHandles,
+          );
+          await driver.clickElement({
+            text: 'Approve & install',
+            tag: 'button',
+          });
         });
 
         // fill and click send inputs on test snap page

--- a/test/e2e/snaps/test-snap-notification.spec.js
+++ b/test/e2e/snaps/test-snap-notification.spec.js
@@ -1,5 +1,5 @@
 const { strict: assert } = require('assert');
-const { withFixtures } = require('../helpers');
+const { retryOnClosed, withFixtures } = require('../helpers');
 const FixtureBuilder = require('../fixture-builder');
 const { TEST_SNAPS_WEBSITE_URL } = require('./enums');
 
@@ -56,17 +56,18 @@ describe('Test Snap Notification', function () {
           },
           10000,
         );
-        await driver.delay(2000);
 
         // approve install of snap
-        windowHandles = await driver.waitUntilXWindowHandles(3, 1000, 10000);
-        await driver.switchToWindowWithTitle(
-          'MetaMask Notification',
-          windowHandles,
-        );
-        await driver.clickElement({
-          text: 'Approve & install',
-          tag: 'button',
+        await retryOnClosed(async () => {
+          windowHandles = await driver.waitUntilXWindowHandles(3);
+          await driver.switchToWindowWithTitle(
+            'MetaMask Notification',
+            windowHandles,
+          );
+          await driver.clickElement({
+            text: 'Approve & install',
+            tag: 'button',
+          });
         });
 
         // click send inputs on test snap page

--- a/test/e2e/snaps/test-snap-txinsights.spec.js
+++ b/test/e2e/snaps/test-snap-txinsights.spec.js
@@ -1,5 +1,5 @@
 const { strict: assert } = require('assert');
-const { withFixtures } = require('../helpers');
+const { retryOnClosed, withFixtures } = require('../helpers');
 const FixtureBuilder = require('../fixture-builder');
 const { TEST_SNAPS_WEBSITE_URL } = require('./enums');
 
@@ -55,19 +55,17 @@ describe('Test Snap TxInsights', function () {
           10000,
         );
 
-        await driver.delay(2000);
-
-        // switch to metamask extension
-        windowHandles = await driver.waitUntilXWindowHandles(2, 1000, 10000);
-
         // approve install of snap
-        await driver.switchToWindowWithTitle(
-          'MetaMask Notification',
-          windowHandles,
-        );
-        await driver.clickElement({
-          text: 'Approve & install',
-          tag: 'button',
+        await retryOnClosed(async () => {
+          windowHandles = await driver.waitUntilXWindowHandles(2);
+          await driver.switchToWindowWithTitle(
+            'MetaMask Notification',
+            windowHandles,
+          );
+          await driver.clickElement({
+            text: 'Approve & install',
+            tag: 'button',
+          });
         });
 
         await driver.delay(1000);

--- a/test/e2e/snaps/test-snap-update.spec.js
+++ b/test/e2e/snaps/test-snap-update.spec.js
@@ -1,5 +1,5 @@
 const { strict: assert } = require('assert');
-const { withFixtures } = require('../helpers');
+const { retryOnClosed, withFixtures } = require('../helpers');
 const FixtureBuilder = require('../fixture-builder');
 const { TEST_SNAPS_WEBSITE_URL } = require('./enums');
 
@@ -56,17 +56,18 @@ describe('Test Snap update', function () {
           },
           10000,
         );
-        await driver.delay(2000);
 
         // approve install of snap
-        windowHandles = await driver.waitUntilXWindowHandles(2, 1000, 10000);
-        await driver.switchToWindowWithTitle(
-          'MetaMask Notification',
-          windowHandles,
-        );
-        await driver.clickElement({
-          text: 'Approve & install',
-          tag: 'button',
+        await retryOnClosed(async () => {
+          windowHandles = await driver.waitUntilXWindowHandles(2);
+          await driver.switchToWindowWithTitle(
+            'MetaMask Notification',
+            windowHandles,
+          );
+          await driver.clickElement({
+            text: 'Approve & install',
+            tag: 'button',
+          });
         });
 
         // wait for permissions popover, click checkboxes and confirm


### PR DESCRIPTION
The snap approval step of the snaps e2e tests is prone to failure because of how the popup behaves. The popup rapidly closes after the connect step, then re-appears for the snap approval. There is no reliable way to know when the first popup has closed and the second one has opened.

Instead of trying to guess when the second popup would be open by introducing a delay, we can now use the new utility function `retryOnClosed` to retry the step of switching to a window and making the first interaction with it. All snap tests that include an approval step have been updated to use this utility.

## Explanation

## Manual Testing Steps

If you run snaps e2e tests long enough locally, you should see a failure. I was seeing it about once every 10-20 runs.

If you run the tests on this branch using the `--debug` flag from https://github.com/MetaMask/metamask-extension/pull/16937 , you should instead see a _third_ switch window command being used where usually there is only two. This might be hard to reproduce though, again only happening every 10-20 runs for me locally (system-dependent, so it may be easier or harder to reproduce on your machine).

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
