### PR TITLE
Nock some endpoints to improve test perf

### DIFF
--- a/app/scripts/metamask-controller.actions.test.js
+++ b/app/scripts/metamask-controller.actions.test.js
@@ -4,6 +4,7 @@ import proxyquire from 'proxyquire';
 
 import { ApprovalRequestNotFoundError } from '@metamask/approval-controller';
 import { PermissionsRequestNotFoundError } from '@metamask/permission-controller';
+import nock from 'nock';
 import { ORIGIN_METAMASK } from '../../shared/constants/app';
 
 const Ganache = require('../../test/e2e/ganache');
@@ -59,6 +60,21 @@ describe('MetaMaskController', function () {
   });
 
   beforeEach(function () {
+    nock('https://static.metafi.codefi.network')
+      .persist()
+      .get('/api/v1/lists/eth_phishing_detect_config.json')
+      .reply(
+        200,
+        JSON.stringify({
+          version: 2,
+          tolerance: 2,
+          fuzzylist: [],
+          whitelist: [],
+          blacklist: ['127.0.0.1'],
+        }),
+      )
+      .get('/api/v1/lists/phishfort_hotlist.json')
+      .reply(200, JSON.stringify(['127.0.0.1']));
     metamaskController = new MetaMaskController({
       showUserConfirmation: noop,
       encryptor: {
@@ -82,6 +98,7 @@ describe('MetaMaskController', function () {
 
   afterEach(function () {
     sandbox.restore();
+    nock.cleanAll();
   });
 
   after(async function () {

--- a/app/scripts/metamask-controller.test.js
+++ b/app/scripts/metamask-controller.test.js
@@ -117,6 +117,21 @@ describe('MetaMaskController', function () {
       .persist()
       .get(/.*/u)
       .reply(200, '{"JPY":12415.9}');
+    nock('https://static.metafi.codefi.network')
+      .persist()
+      .get('/api/v1/lists/eth_phishing_detect_config.json')
+      .reply(
+        200,
+        JSON.stringify({
+          version: 2,
+          tolerance: 2,
+          fuzzylist: [],
+          whitelist: [],
+          blacklist: ['127.0.0.1'],
+        }),
+      )
+      .get('/api/v1/lists/phishfort_hotlist.json')
+      .reply(200, JSON.stringify(['127.0.0.1']));
 
     sandbox.replace(browser, 'runtime', {
       sendMessage: sandbox.stub().rejects(),


### PR DESCRIPTION
## Explanation
```
FetchError: request to https://static.metafi.codefi.network/api/v1/lists/eth_phishing_detect_config.json failed, reason: Nock: Disallowed net connect for "static.metafi.codefi.network:443/api/v1/lists/eth_phishing_detect_config.json"
    at ErroringClientRequest.<anonymous> (/home/sceleus/Documents/Dev/ConsenSys/metamask-extension/node_modules/node-fetch/lib/index.js:1491:11)
    at ErroringClientRequest.emit (node:events:527:28)
    at ErroringClientRequest.emit (node:domain:475:12)
    at ErroringClientRequest.<anonymous> (/home/sceleus/Documents/Dev/ConsenSys/metamask-extension/node_modules/nock/lib/intercept.js:241:12)
    at processTicksAndRejections (node:internal/process/task_queues:78:11) {
  type: 'system',
  errno: 'ENETUNREACH',
  code: 'ENETUNREACH'
}
FetchError: request to https://static.metafi.codefi.network/api/v1/lists/phishfort_hotlist.json failed, reason: Nock: Disallowed net connect for "static.metafi.codefi.network:443/api/v1/lists/phishfort_hotlist.json"
    at ErroringClientRequest.<anonymous> (/home/sceleus/Documents/Dev/ConsenSys/metamask-extension/node_modules/node-fetch/lib/index.js:1491:11)
    at ErroringClientRequest.emit (node:events:527:28)
    at ErroringClientRequest.emit (node:domain:475:12)
    at ErroringClientRequest.<anonymous> (/home/sceleus/Documents/Dev/ConsenSys/metamask-extension/node_modules/nock/lib/intercept.js:241:12)
    at processTicksAndRejections (node:internal/process/task_queues:78:11) {
  type: 'system',
  errno: 'ENETUNREACH',
  code: 'ENETUNREACH'
}
```
gets spammed over and over again when running unit tests and it appears to be delaying execution steps *between* tests. If you run mocha with the `-s 0` flag it displays test times, and none of the tests are egregious, yet we wait for a long time between test runs due to timeouts from missing endpoint nocks. This nocks the end points for the metamask-controller and metamask-controller.actions tests. there are still *some* failing for the swaps controller @dan437 

## Manual Testing Steps
1. run `yarn test:unit:mocha` on develop
2. see console spam, possible test time outs (exits with code 1)
3. switch to this branch.
4. run `yarn test:unit:mocha`
5. See less spam, not timing out.

In addition i tried this on my split-unit-tests branch because the new `test-unit-mocha` step fails always, but after this change it does not.

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added
