### PR TITLE
fix issue where final onboarding pages are not show

### DIFF
--- a/ui/pages/onboarding-flow/creation-successful/creation-successful.js
+++ b/ui/pages/onboarding-flow/creation-successful/creation-successful.js
@@ -21,9 +21,6 @@ export default function CreationSuccessful() {
   const history = useHistory();
   const t = useI18nContext();
 
-  const onComplete = async () => {
-    history.push(ONBOARDING_PIN_EXTENSION_ROUTE);
-  };
   return (
     <div className="creation-successful" data-testid="creation-successful">
       <Box textAlign={TEXT_ALIGN.CENTER}>
@@ -96,7 +93,7 @@ export default function CreationSuccessful() {
           type="primary"
           large
           rounded
-          onClick={onComplete}
+          onClick={() => history.push(ONBOARDING_PIN_EXTENSION_ROUTE)}
         >
           {t('gotIt')}
         </Button>

--- a/ui/pages/onboarding-flow/creation-successful/creation-successful.js
+++ b/ui/pages/onboarding-flow/creation-successful/creation-successful.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import { useHistory } from 'react-router-dom';
-import { useDispatch } from 'react-redux';
 
 import Box from '../../../components/ui/box';
 import Typography from '../../../components/ui/typography';
@@ -16,16 +15,13 @@ import {
   ONBOARDING_PIN_EXTENSION_ROUTE,
   ONBOARDING_PRIVACY_SETTINGS_ROUTE,
 } from '../../../helpers/constants/routes';
-import { setCompletedOnboarding } from '../../../store/actions';
 import { isBeta } from '../../../helpers/utils/build-types';
 
 export default function CreationSuccessful() {
   const history = useHistory();
   const t = useI18nContext();
-  const dispatch = useDispatch();
 
   const onComplete = async () => {
-    await dispatch(setCompletedOnboarding());
     history.push(ONBOARDING_PIN_EXTENSION_ROUTE);
   };
   return (

--- a/ui/pages/onboarding-flow/pin-extension/pin-extension.js
+++ b/ui/pages/onboarding-flow/pin-extension/pin-extension.js
@@ -20,6 +20,15 @@ export default function OnboardingPinExtension() {
   const history = useHistory();
   const dispatch = useDispatch();
 
+  const handleClick = async () => {
+    if (selectedIndex === 0) {
+      setSelectedIndex(1);
+    } else {
+      await dispatch(setCompletedOnboarding());
+      history.push(DEFAULT_ROUTE);
+    }
+  };
+
   return (
     <div
       className="onboarding-pin-extension"
@@ -67,14 +76,7 @@ export default function OnboardingPinExtension() {
             selectedIndex === 0 ? 'pin-extension-next' : 'pin-extension-done'
           }
           type="primary"
-          onClick={async () => {
-            if (selectedIndex === 0) {
-              setSelectedIndex(1);
-            } else {
-              await dispatch(setCompletedOnboarding());
-              history.push(DEFAULT_ROUTE);
-            }
-          }}
+          onClick={handleClick}
         >
           {selectedIndex === 0 ? t('next') : t('done')}
         </Button>

--- a/ui/pages/onboarding-flow/pin-extension/pin-extension.js
+++ b/ui/pages/onboarding-flow/pin-extension/pin-extension.js
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { useHistory } from 'react-router-dom';
-
+import { useDispatch } from 'react-redux';
 import { Carousel } from 'react-responsive-carousel';
 import Typography from '../../../components/ui/typography/typography';
 import { useI18nContext } from '../../../hooks/useI18nContext';
@@ -11,12 +11,14 @@ import {
   TEXT_ALIGN,
 } from '../../../helpers/constants/design-system';
 import { DEFAULT_ROUTE } from '../../../helpers/constants/routes';
+import { setCompletedOnboarding } from '../../../store/actions';
 import OnboardingPinBillboard from './pin-billboard';
 
 export default function OnboardingPinExtension() {
   const t = useI18nContext();
   const [selectedIndex, setSelectedIndex] = useState(0);
   const history = useHistory();
+  const dispatch = useDispatch();
 
   return (
     <div
@@ -65,10 +67,11 @@ export default function OnboardingPinExtension() {
             selectedIndex === 0 ? 'pin-extension-next' : 'pin-extension-done'
           }
           type="primary"
-          onClick={() => {
+          onClick={async () => {
             if (selectedIndex === 0) {
               setSelectedIndex(1);
             } else {
+              await dispatch(setCompletedOnboarding());
               history.push(DEFAULT_ROUTE);
             }
           }}

--- a/ui/pages/onboarding-flow/pin-extension/pin-extension.test.js
+++ b/ui/pages/onboarding-flow/pin-extension/pin-extension.test.js
@@ -3,12 +3,11 @@ import { fireEvent } from '@testing-library/react';
 import reactRouterDom from 'react-router-dom';
 import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
-import { ONBOARDING_PRIVACY_SETTINGS_ROUTE } from '../../../helpers/constants/routes';
 import {
   renderWithProvider,
   setBackgroundConnection,
 } from '../../../../test/jest';
-import CreationSuccessful from './creation-successful';
+import PinExtension from './pin-extension';
 
 const completeOnboardingStub = jest
   .fn()
@@ -33,10 +32,12 @@ describe('Creation Successful Onboarding View', () => {
       .mockReturnValue({ push: pushMock });
   });
 
-  it('should redirect to privacy-settings view when "Advanced configuration" button is clicked', () => {
-    const { getByText } = renderWithProvider(<CreationSuccessful />, store);
-    const privacySettingsButton = getByText('Advanced configuration');
-    fireEvent.click(privacySettingsButton);
-    expect(pushMock).toHaveBeenCalledWith(ONBOARDING_PRIVACY_SETTINGS_ROUTE);
+  it('should call completeOnboarding in the background when Done" button is clicked', () => {
+    const { getByText } = renderWithProvider(<PinExtension />, store);
+    const nextButton = getByText('Next');
+    fireEvent.click(nextButton);
+    const gotItButton = getByText('Done');
+    fireEvent.click(gotItButton);
+    expect(completeOnboardingStub).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
This [recently merged PR](https://github.com/MetaMask/metamask-extension/pull/16916), created an issue where the final page of the onboarding flow is no longer shown.

This PR fixes it by not marking onboarding as complete until after this page is viewed.

### Before
https://user-images.githubusercontent.com/34557516/207430225-1607d98e-4bf0-4d38-8fd6-16bfa9fbb2f6.mov

### After

Final onboarding pages are back:
https://user-images.githubusercontent.com/34557516/207429664-401c2c50-48c7-40a1-8a83-47a5cc4f6174.mov

## Manual Testing Steps

- go through the onboarding flow and check that you see final page showing where the extension can be found

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

