### PR TITLE
Fixed transaction details activity log currency symbol display error

### DIFF
--- a/ui/components/app/transaction-activity-log/transaction-activity-log.component.js
+++ b/ui/components/app/transaction-activity-log/transaction-activity-log.component.js
@@ -3,10 +3,7 @@ import PropTypes from 'prop-types';
 import classnames from 'classnames';
 
 import { getBlockExplorerLink } from '@metamask/etherscan-link';
-import {
-  getEthConversionFromWeiHex,
-  getValueFromWeiHex,
-} from '../../../helpers/utils/conversions.util';
+import { getValueFromWeiHex } from '../../../helpers/utils/conversions.util';
 import { formatDate, getURLHostName } from '../../../helpers/utils/util';
 import { EVENT } from '../../../../shared/constants/metametrics';
 import TransactionActivityLogIcon from './transaction-activity-log-icon';
@@ -90,21 +87,13 @@ export default class TransactionActivityLog extends PureComponent {
   renderActivity(activity, index) {
     const { conversionRate, nativeCurrency } = this.props;
     const { eventKey, value, timestamp } = activity;
-    const ethValue =
-      index === 0
-        ? `${getValueFromWeiHex({
-            value,
-            fromCurrency: 'ETH',
-            toCurrency: 'ETH',
-            conversionRate,
-            numberOfDecimals: 6,
-          })} ${nativeCurrency}`
-        : getEthConversionFromWeiHex({
-            value,
-            fromCurrency: 'ETH',
-            conversionRate,
-            numberOfDecimals: 3,
-          });
+    const ethValue = `${getValueFromWeiHex({
+      value,
+      fromCurrency: 'ETH',
+      toCurrency: 'ETH',
+      conversionRate,
+      numberOfDecimals: 6,
+    })} ${nativeCurrency}`;
     const formattedTimestamp = formatDate(timestamp, "T 'on' M/d/y");
     const activityText = this.context.t(eventKey, [
       ethValue,


### PR DESCRIPTION
## Explanation
When submitting a transaction, in transaction details activity log currency symbol is wrong for gas fee.

* Fixes #16793
<!--
Thanks for the pull request. Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues, Slack conversations, Zendesk issues, user stories, etc. reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

## Screenshots/Screencaps

<!-- If you're making a change to the UI, make sure to capture a screenshot or a short video showing off your work! -->

### Before
<img width="308" alt="Before" src="https://user-images.githubusercontent.com/92310504/207561128-dffee600-7927-40e9-b996-7387ac9e6d8f.png">

<!-- How did the UI you changed look before your changes? Drag your file(s) below this line: -->

### After
<img width="305" alt="After" src="https://user-images.githubusercontent.com/92310504/207561146-97a5099d-5b9b-49fc-9c89-28797058a067.png">

<!-- How does it look now? Drag your file(s) below this line: -->

## Manual Testing Steps

1. Create a `simple send` transaction
2. Edit `gas fee`
3. Wait for the transaction to finish
4. On `Activity` tab, from the home screen, click on the previously created transaction and expand the `Acitvity log` on bottom