### PR TITLE
[FLASK] Fix race condition with transaction insights

### DIFF
--- a/ui/hooks/flask/useTransactionInsightSnap.js
+++ b/ui/hooks/flask/useTransactionInsightSnap.js
@@ -28,6 +28,7 @@ export function useTransactionInsightSnap({
   const [error, setError] = useState(undefined);
 
   useEffect(() => {
+    let cancelled = false;
     async function fetchInsight() {
       try {
         setError(undefined);
@@ -43,16 +44,23 @@ export function useTransactionInsightSnap({
             params: { transaction, chainId, transactionOrigin },
           },
         });
-        setData(d);
+        if (!cancelled) {
+          setData(d);
+        }
       } catch (err) {
-        setError(err);
+        if (!cancelled) {
+          setError(err);
+        }
       } finally {
-        setLoading(false);
+        if (!cancelled) {
+          setLoading(false);
+        }
       }
     }
     if (transaction) {
       fetchInsight();
     }
+    return () => (cancelled = true);
   }, [snapId, transaction, chainId, transactionOrigin]);
 
   return { data, error, loading };

--- a/ui/hooks/flask/useTransactionInsightSnap.js
+++ b/ui/hooks/flask/useTransactionInsightSnap.js
@@ -34,7 +34,7 @@ export function useTransactionInsightSnap({
         setError(undefined);
         setLoading(true);
 
-        const d = await handleSnapRequest({
+        const newData = await handleSnapRequest({
           snapId,
           origin: '',
           handler: 'onTransaction',
@@ -45,7 +45,7 @@ export function useTransactionInsightSnap({
           },
         });
         if (!cancelled) {
-          setData(d);
+          setData(newData);
         }
       } catch (err) {
         if (!cancelled) {


### PR DESCRIPTION
## Explanation

Fixes a race condition that would occur when a user had more than one transaction insight snap installed. If the transaction insight tab is loading data from the selected snap while a new one is selected a race condition will occur in determining which of the results to show.