### PR TITLE
GasTiming: Support network change - Fix locale, add loading spinner, fix false error

### DIFF
--- a/ui/pages/send/gas-display/gas-display.js
+++ b/ui/pages/send/gas-display/gas-display.js
@@ -56,7 +56,10 @@ export default function GasDisplay({ gasError }) {
   const t = useContext(I18nContext);
   const dispatch = useDispatch();
   const { estimateUsed } = useGasFeeContext();
+
+  const [isLoading, setLoading] = useState(false);
   const [showDepositPopover, setShowDepositPopover] = useState(false);
+
   const currentProvider = useSelector(getProvider);
   const isMainnet = useSelector(getIsMainnet);
   const isBuyableChain = useSelector(getIsBuyableChain);
@@ -151,8 +154,6 @@ export default function GasDisplay({ gasError }) {
     detailTotal = primaryTotalTextOverrideMaxAmount;
     maxAmount = primaryTotalTextOverrideMaxAmount;
   }
-
-  const [isLoading, setLoading] = useState(false);
 
   useEffect(() => {
     setLoading(!(networkName || currentProvider.nickname));

--- a/ui/pages/send/gas-display/gas-display.js
+++ b/ui/pages/send/gas-display/gas-display.js
@@ -65,9 +65,12 @@ export default function GasDisplay({ gasError }) {
   const { nativeCurrency, unapprovedTxs } = useSelector(
     (state) => state.metamask,
   );
-  const chainId = useSelector(getCurrentChainId);
 
+  const chainId = useSelector(getCurrentChainId);
   const networkName = NETWORK_TO_NAME_MAP[chainId];
+
+  const currencySymbol =
+    draftTransaction.asset.details?.symbol ?? nativeCurrency;
   const isInsufficientTokenError =
     draftTransaction?.amount.error === INSUFFICIENT_TOKENS_ERROR;
   const editingTransaction = unapprovedTxs[draftTransaction.id];
@@ -362,17 +365,12 @@ export default function GasDisplay({ gasError }) {
                     ])}
                   </Typography>
                 ) : (
-                  (draftTransaction.asset.details?.symbol ||
-                    nativeCurrency) && (
+                  currencySymbol && (
                     <Typography variant={TYPOGRAPHY.H7} align="left">
                       {t('insufficientCurrencyBuyOrReceive', [
-                        draftTransaction.asset.details?.symbol ??
-                          nativeCurrency,
+                        currencySymbol,
                         networkName ?? currentProvider.nickname,
-                        `${t('buyAsset', [
-                          draftTransaction.asset.details?.symbol ??
-                            nativeCurrency,
-                        ])}`,
+                        `${t('buyAsset', [currencySymbol])}`,
                         <Button
                           type="inline"
                           className="gas-display__link"

--- a/ui/pages/send/gas-display/gas-display.js
+++ b/ui/pages/send/gas-display/gas-display.js
@@ -24,6 +24,7 @@ import {
   FONT_STYLE,
   FONT_WEIGHT,
 } from '../../../helpers/constants/design-system';
+import { GAS_PRICE_FETCH_FAILURE_ERROR_KEY } from '../../../helpers/constants/error-keys';
 import {
   ERC1155,
   ERC20,
@@ -76,6 +77,10 @@ export default function GasDisplay({ gasError }) {
     draftTransaction.asset.details?.symbol ?? nativeCurrency;
   const isInsufficientTokenError =
     draftTransaction?.amount.error === INSUFFICIENT_TOKENS_ERROR;
+  const showInsufficientTokenError =
+    (gasError && gasError !== GAS_PRICE_FETCH_FAILURE_ERROR_KEY) ||
+    isInsufficientTokenError;
+
   const editingTransaction = unapprovedTxs[draftTransaction.id];
 
   const transactionData = {
@@ -277,7 +282,7 @@ export default function GasDisplay({ gasError }) {
                 />
               }
             />,
-            (gasError || isInsufficientTokenError) && (
+            showInsufficientTokenError && (
               <TransactionDetailItem
                 key="total-item"
                 detailTitle={t('total')}
@@ -324,7 +329,7 @@ export default function GasDisplay({ gasError }) {
           ]}
         />
       </Box>
-      {(gasError || isInsufficientTokenError) && (
+      {showInsufficientTokenError && (
         <Box
           className="gas-display__warning-message"
           data-testid="gas-warning-message"

--- a/ui/pages/send/gas-display/index.scss
+++ b/ui/pages/send/gas-display/index.scss
@@ -15,6 +15,12 @@
     }
   }
 
+  &__spinner {
+    height: 58px;
+    width: 58px;
+    margin: 44px auto;
+  }
+
   &__title {
     &__estimate {
       font-size: 12px;


### PR DESCRIPTION
## Explanation

Fixes #16892

Adding support for network change on the GasDisplay component: 
- Add loading spinner
- Do not show error message if data is loading in-between network change

Additionally: 
- Do not show an Insufficient funds error when the gas error is `gasPriceFetchFailed`

WIP:
1. Insufficient funds error shows on network change despite having enough funds
2. occasional error that breaks the page on network change:
<img width="1055" alt="Screen Shot 2022-12-15 at 04 45 38" src="https://user-images.githubusercontent.com/20778143/207721890-a9da5dae-6d8a-4296-a868-fa7997baad79.png">

3. occasional error that breaks the page on network change:
<img width="956" alt="Screen Shot 2022-12-15 at 03 09 54" src="https://user-images.githubusercontent.com/20778143/207717741-a97e0aba-9233-4d76-b11a-9f5c0d52d82e.png">
4. occasional error that breaks the page on network change: 
<img width="805" alt="Screen Shot 2022-12-15 at 02 38 16" src="https://user-images.githubusercontent.com/20778143/207888594-790c5f9a-4dff-490d-8f24-3373ffeddf3c.png">



<!--
Thanks for the pull request. Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues, Slack conversations, Zendesk issues, user stories, etc. reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

## Screenshots/Screencaps

<!-- If you're making a change to the UI, make sure to capture a screenshot or a short video showing off your work! -->

### Before

<!-- How did the UI you changed look before your changes? Drag your file(s) below this line: -->

### After

### New loading spinner shown during network change
<img width="862" alt="Screen Shot 2022-12-15 at 03 49 40" src="https://user-images.githubusercontent.com/20778143/207718203-28e74d97-b609-4b0d-a406-646a0070145a.png">


<!-- How does it look now? Drag your file(s) below this line: -->

## Manual Testing Steps

<!--
How should reviewers and QA manually test your changes? For instance:

- Go to this screen
- Do this
- Then do this
-->

## Pre-merge author checklist

- [ ] I've clearly explained:
  - [ ] What problem this PR is solving
  - [ ] How this problem was solved
  - [ ] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
