### PR TITLE
Recipient name passed to confirm-page-container component should be u…

### DIFF
--- a/test/e2e/tests/send-eth.spec.js
+++ b/test/e2e/tests/send-eth.spec.js
@@ -129,7 +129,7 @@ describe('Send ETH non-contract address with data that matches ERC20 transfer da
 
         await driver.clickElement({ text: 'Next', tag: 'button' });
 
-        await driver.clickElement({ text: 'New contract' });
+        await driver.clickElement({ text: '0xc42...cd28' });
 
         const recipientAddress = await driver.findElements({
           text: '0xc427D562164062a23a5cFf596A4a3208e72Acd28',

--- a/ui/components/app/confirm-page-container/confirm-page-container-container.test.js
+++ b/ui/components/app/confirm-page-container/confirm-page-container-container.test.js
@@ -100,7 +100,7 @@ describe('Confirm Page Container Container Test', () => {
       expect(senderRecipient).toBeInTheDocument();
     });
     it('should render recipient as address', () => {
-      const recipientName = screen.queryByText('New contract');
+      const recipientName = screen.queryByText(shortenAddress(props.toAddress));
       expect(recipientName).toBeInTheDocument();
     });
 
@@ -119,7 +119,7 @@ describe('Confirm Page Container Container Test', () => {
 
   describe('Contact/AddressBook name should appear in recipient header', () => {
     it('should not show add to address dialog if recipient is in contact list and should display contact name', () => {
-      const addressBookName = 'New contract';
+      const addressBookName = 'test save name';
 
       const addressBook = {
         '0x5': {

--- a/ui/components/app/confirm-page-container/confirm-page-container.component.js
+++ b/ui/components/app/confirm-page-container/confirm-page-container.component.js
@@ -66,6 +66,7 @@ export default class ConfirmPageContainer extends Component {
     toMetadataName: PropTypes.string,
     toEns: PropTypes.string,
     toNickname: PropTypes.string,
+    recipientIsOwnedAccount: PropTypes.bool,
     // Content
     contentComponent: PropTypes.node,
     errorKey: PropTypes.string,
@@ -135,6 +136,7 @@ export default class ConfirmPageContainer extends Component {
       toMetadataName,
       toEns,
       toNickname,
+      recipientIsOwnedAccount,
       toAddress,
       disabled,
       errorKey,
@@ -247,6 +249,7 @@ export default class ConfirmPageContainer extends Component {
                   recipientAddress={toAddress}
                   recipientEns={toEns}
                   recipientNickname={toNickname}
+                  recipientIsOwnedAccount={recipientIsOwnedAccount}
                 />
               )}
             </ConfirmPageContainerHeader>

--- a/ui/components/app/confirm-page-container/confirm-page-container.container.js
+++ b/ui/components/app/confirm-page-container/confirm-page-container.container.js
@@ -19,7 +19,7 @@ function mapStateToProps(state, ownProps) {
   const accountBalance = defaultToken.string;
   const identities = getMetaMaskIdentities(state);
   const ownedAccountName = getAccountName(identities, to);
-  const toName = ownedAccountName || contact?.name || ownProps.toName;
+  const toName = ownedAccountName || contact?.name;
   const toMetadataName = getMetadataContractName(state, to);
 
   return {

--- a/ui/components/app/confirm-page-container/confirm-page-container.container.js
+++ b/ui/components/app/confirm-page-container/confirm-page-container.container.js
@@ -7,7 +7,6 @@ import {
   getMetadataContractName,
   getAccountName,
   getMetaMaskIdentities,
-  getAccountsWithLabels,
 } from '../../../selectors';
 import ConfirmPageContainer from './confirm-page-container.component';
 
@@ -19,7 +18,8 @@ function mapStateToProps(state, ownProps) {
   const defaultToken = getSwapsDefaultToken(state);
   const accountBalance = defaultToken.string;
   const identities = getMetaMaskIdentities(state);
-  const toName = getAccountName(identities, to) || ownProps.toName;
+  const ownedAccountName = getAccountName(identities, to);
+  const toName = ownedAccountName || ownProps.toName;
   const toMetadataName = getMetadataContractName(state, to);
 
   return {
@@ -27,9 +27,7 @@ function mapStateToProps(state, ownProps) {
     contact,
     toName,
     toMetadataName,
-    isOwnedAccount: getAccountsWithLabels(state)
-      .map((accountWithLabel) => accountWithLabel.address)
-      .includes(to),
+    recipientIsOwnedAccount: Boolean(ownedAccountName),
     to,
     networkIdentifier,
     accountBalance,

--- a/ui/components/app/confirm-page-container/confirm-page-container.container.js
+++ b/ui/components/app/confirm-page-container/confirm-page-container.container.js
@@ -19,7 +19,7 @@ function mapStateToProps(state, ownProps) {
   const defaultToken = getSwapsDefaultToken(state);
   const accountBalance = defaultToken.string;
   const identities = getMetaMaskIdentities(state);
-  const toName = getAccountName(identities, to);
+  const toName = getAccountName(identities, to) || ownProps.toName;
   const toMetadataName = getMetadataContractName(state, to);
 
   return {

--- a/ui/components/app/confirm-page-container/confirm-page-container.container.js
+++ b/ui/components/app/confirm-page-container/confirm-page-container.container.js
@@ -19,7 +19,7 @@ function mapStateToProps(state, ownProps) {
   const accountBalance = defaultToken.string;
   const identities = getMetaMaskIdentities(state);
   const ownedAccountName = getAccountName(identities, to);
-  const toName = ownedAccountName || ownProps.toName;
+  const toName = ownedAccountName || contact?.name || ownProps.toName;
   const toMetadataName = getMetadataContractName(state, to);
 
   return {

--- a/ui/components/ui/sender-to-recipient/sender-to-recipient.component.js
+++ b/ui/components/ui/sender-to-recipient/sender-to-recipient.component.js
@@ -164,6 +164,7 @@ export function RecipientWithAddress({
                 recipientNickname ||
                 recipientMetadataName ||
                 recipientEns ||
+                shortenAddress(checksummedRecipientAddress) ||
                 t('newContract')}
           </div>
         </Tooltip>

--- a/ui/components/ui/sender-to-recipient/sender-to-recipient.component.js
+++ b/ui/components/ui/sender-to-recipient/sender-to-recipient.component.js
@@ -104,6 +104,7 @@ export function RecipientWithAddress({
   recipientEns,
   recipientName,
   recipientMetadataName,
+  recipientIsOwnedAccount,
 }) {
   const t = useI18nContext();
   const [showNicknamePopovers, setShowNicknamePopovers] = useState(false);
@@ -127,7 +128,7 @@ export function RecipientWithAddress({
       <div
         className="sender-to-recipient__party sender-to-recipient__party--recipient sender-to-recipient__party--recipient-with-address"
         onClick={() => {
-          if (recipientName) {
+          if (recipientIsOwnedAccount) {
             setAddressCopied(true);
             copyToClipboard(checksummedRecipientAddress);
           } else {
@@ -185,6 +186,7 @@ RecipientWithAddress.propTypes = {
   recipientNickname: PropTypes.string,
   addressOnly: PropTypes.bool,
   onRecipientClick: PropTypes.func,
+  recipientIsOwnedAccount: PropTypes.bool,
 };
 
 function Arrow({ variant }) {
@@ -218,6 +220,7 @@ export default function SenderToRecipient({
   recipientAddress,
   variant,
   warnUserOnAccountMismatch,
+  recipientIsOwnedAccount,
 }) {
   const t = useI18nContext();
   const checksummedSenderAddress = toChecksumHexAddress(senderAddress);
@@ -246,6 +249,7 @@ export default function SenderToRecipient({
           recipientEns={recipientEns}
           recipientName={recipientName}
           recipientMetadataName={recipientMetadataName}
+          recipientIsOwnedAccount={recipientIsOwnedAccount}
         />
       ) : (
         <div className="sender-to-recipient__party sender-to-recipient__party--recipient">
@@ -275,4 +279,5 @@ SenderToRecipient.propTypes = {
   onRecipientClick: PropTypes.func,
   onSenderClick: PropTypes.func,
   warnUserOnAccountMismatch: PropTypes.bool,
+  recipientIsOwnedAccount: PropTypes.bool,
 };


### PR DESCRIPTION
…sed if pet name exists for the to address

Fixes https://github.com/MetaMask/metamask-extension/issues/16658

**Explanation**

In a recent PR, in the ConfirmPageContainer, [we stopped defaulting to the addressbook contact name or passed `toName` prop](https://github.com/MetaMask/metamask-extension/pull/15888/files#diff-4e49efdf837e7d7515c99a797b02d7ff25cffd501b31f5d7e7bdadae8d1d910dR21-L23) if no owned account name for the `to` address existed. That causes the send-to-recipient component to default to showing "New Contract" when sending to an address that is not in our address book or account names: https://github.com/MetaMask/metamask-extension/pull/15888/files#diff-214bde98baa3dbda2a9df24d3d2cbb420d51b54bb1404a1b710418213827236fR162-R166.

This PR fixes the issue by firstly adding the shortened address as a fallback in the sender-to-recipient component in all cases. To then also ensure that the address book contact name is shown if it exists, it is added as a fallback in the ConfirmPageContainer container if an owned account name doesn't exist. Appropriate tests are also restored.

Furthermore, this PR passes the sender-to-recipient component a new boolean property which indicates whether the recipient is an account owned by the user. This boolean is used to decide whether to show the user edit/add nickname popover, which should be shown when the recipient is clicked unless that recipient as an account owned by the user. This was also needed to get e2e tests to pass.