### PR TITLE
[FLASK] Use custom UI for dialogs

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -1265,11 +1265,11 @@ export default class MetamaskController extends EventEmitter {
             type: MESSAGE_TYPE.SNAP_DIALOG_CONFIRMATION,
             requestData: confirmationData,
           }),
-        showDialog: (origin, type, requestData) =>
+        showDialog: (origin, type, content, placeholder) =>
           this.approvalController.addAndShowApprovalRequest({
             origin,
             type: SNAP_DIALOG_TYPES[type],
-            requestData,
+            requestData: { content, placeholder },
           }),
         showNativeNotification: (origin, args) =>
           this.controllerMessenger.call(

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -98,7 +98,7 @@ import {
 } from '../../shared/constants/app';
 import { EVENT, EVENT_NAMES } from '../../shared/constants/metametrics';
 
-import { getTokenIdParam } from '../../ui/helpers/utils/token-util';
+import { getTokenIdParam } from '../../shared/lib/token-util';
 import { isEqualCaseInsensitive } from '../../shared/modules/string-utils';
 import { parseStandardTokenTransactionData } from '../../shared/modules/transaction.utils';
 import { STATIC_MAINNET_TOKEN_LIST } from '../../shared/constants/tokens';

--- a/lavamoat/browserify/flask/policy.json
+++ b/lavamoat/browserify/flask/policy.json
@@ -1755,6 +1755,12 @@
         "pumpify>inherits": true
       }
     },
+    "@metamask/snaps-ui": {
+      "packages": {
+        "@metamask/snaps-ui>superstruct": true,
+        "eth-block-tracker>@metamask/utils": true
+      }
+    },
     "@metamask/snaps-utils": {
       "globals": {
         "TextDecoder": true,

--- a/ui/components/app/flask/snap-ui-renderer/index.js
+++ b/ui/components/app/flask/snap-ui-renderer/index.js
@@ -1,1 +1,1 @@
-export { SnapUIRenderer } from './snap-ui-renderer';
+export { SnapUIRenderer, mapToTemplate } from './snap-ui-renderer';

--- a/ui/components/app/flask/snap-ui-renderer/snap-ui-renderer.js
+++ b/ui/components/app/flask/snap-ui-renderer/snap-ui-renderer.js
@@ -58,7 +58,7 @@ export const UI_MAPPING = {
   }),
 };
 
-const mapToTemplate = (data) => {
+export const mapToTemplate = (data) => {
   const { type } = data;
   const mapped = UI_MAPPING[type](data);
   // TODO: We may want to have deterministic keys at some point

--- a/ui/components/app/flask/snap-ui-renderer/snap-ui-renderer.js
+++ b/ui/components/app/flask/snap-ui-renderer/snap-ui-renderer.js
@@ -58,6 +58,7 @@ export const UI_MAPPING = {
   }),
 };
 
+// TODO: Stop exporting this when we remove the mapToTemplate hack in confirmation templates.
 export const mapToTemplate = (data) => {
   const { type } = data;
   const mapped = UI_MAPPING[type](data);

--- a/ui/helpers/utils/token-util.js
+++ b/ui/helpers/utils/token-util.js
@@ -3,6 +3,7 @@ import {
   conversionUtil,
   multiplyCurrencies,
 } from '../../../shared/modules/conversion.utils';
+import { getTokenIdParam } from '../../../shared/lib/token-util';
 import { getTokenStandardAndDetails } from '../../store/actions';
 import { isEqualCaseInsensitive } from '../../../shared/modules/string-utils';
 import { parseStandardTokenTransactionData } from '../../../shared/modules/transaction.utils';
@@ -123,27 +124,6 @@ export function getTokenAddressParam(tokenData = {}) {
   const value =
     tokenData?.args?._to || tokenData?.args?.to || tokenData?.args?.[0];
   return value?.toString().toLowerCase();
-}
-
-/**
- * Gets the '_value' parameter of the given token transaction data
- * (i.e function call) per the Human Standard Token ABI, if present.
- *
- * @param {object} tokenData - ethers Interface token data.
- * @returns {string | undefined} A decimal string value.
- */
-/**
- * Gets either the '_tokenId' parameter or the 'id' param of the passed token transaction data.,
- * These are the parsed tokenId values returned by `parseStandardTokenTransactionData` as defined
- * in the ERC721 and ERC1155 ABIs from metamask-eth-abis (https://github.com/MetaMask/metamask-eth-abis/tree/main/src/abis)
- *
- * @param {object} tokenData - ethers Interface token data.
- * @returns {string | undefined} A decimal string value.
- */
-export function getTokenIdParam(tokenData = {}) {
-  return (
-    tokenData?.args?._tokenId?.toString() ?? tokenData?.args?.id?.toString()
-  );
 }
 
 /**

--- a/ui/helpers/utils/token-util.js
+++ b/ui/helpers/utils/token-util.js
@@ -3,7 +3,6 @@ import {
   conversionUtil,
   multiplyCurrencies,
 } from '../../../shared/modules/conversion.utils';
-import { getTokenIdParam } from '../../../shared/lib/token-util';
 import { getTokenStandardAndDetails } from '../../store/actions';
 import { isEqualCaseInsensitive } from '../../../shared/modules/string-utils';
 import { parseStandardTokenTransactionData } from '../../../shared/modules/transaction.utils';
@@ -124,6 +123,27 @@ export function getTokenAddressParam(tokenData = {}) {
   const value =
     tokenData?.args?._to || tokenData?.args?.to || tokenData?.args?.[0];
   return value?.toString().toLowerCase();
+}
+
+/**
+ * Gets the '_value' parameter of the given token transaction data
+ * (i.e function call) per the Human Standard Token ABI, if present.
+ *
+ * @param {object} tokenData - ethers Interface token data.
+ * @returns {string | undefined} A decimal string value.
+ */
+/**
+ * Gets either the '_tokenId' parameter or the 'id' param of the passed token transaction data.,
+ * These are the parsed tokenId values returned by `parseStandardTokenTransactionData` as defined
+ * in the ERC721 and ERC1155 ABIs from metamask-eth-abis (https://github.com/MetaMask/metamask-eth-abis/tree/main/src/abis)
+ *
+ * @param {object} tokenData - ethers Interface token data.
+ * @returns {string | undefined} A decimal string value.
+ */
+export function getTokenIdParam(tokenData = {}) {
+  return (
+    tokenData?.args?._tokenId?.toString() ?? tokenData?.args?.id?.toString()
+  );
 }
 
 /**

--- a/ui/pages/confirmation/templates/flask/snap-alert/snap-alert.js
+++ b/ui/pages/confirmation/templates/flask/snap-alert/snap-alert.js
@@ -21,6 +21,7 @@ function getValues(pendingApproval, t, actions) {
           props: {
             snapName,
           },
+          // TODO: Replace with SnapUIRenderer when we don't need to inject the input manually.
           children: mapToTemplate(content),
         },
       },

--- a/ui/pages/confirmation/templates/flask/snap-alert/snap-alert.js
+++ b/ui/pages/confirmation/templates/flask/snap-alert/snap-alert.js
@@ -1,8 +1,10 @@
-import { TYPOGRAPHY } from '../../../../../helpers/constants/design-system';
+import { mapToTemplate } from '../../../../../components/app/flask/snap-ui-renderer';
 
 function getValues(pendingApproval, t, actions) {
-  const { snapName, requestData } = pendingApproval;
-  const { title, description, textAreaContent } = requestData;
+  const {
+    snapName,
+    requestData: { content },
+  } = pendingApproval;
 
   return {
     content: [
@@ -19,46 +21,7 @@ function getValues(pendingApproval, t, actions) {
           props: {
             snapName,
           },
-          children: [
-            {
-              element: 'Typography',
-              key: 'title',
-              children: title,
-              props: {
-                variant: TYPOGRAPHY.H3,
-                fontWeight: 'bold',
-                boxProps: {
-                  marginBottom: 4,
-                },
-              },
-            },
-            ...(description
-              ? [
-                  {
-                    element: 'Typography',
-                    key: 'subtitle',
-                    children: description,
-                    props: {
-                      variant: TYPOGRAPHY.H6,
-                      boxProps: {
-                        marginBottom: 4,
-                      },
-                    },
-                  },
-                ]
-              : []),
-            ...(textAreaContent
-              ? [
-                  {
-                    element: 'Copyable',
-                    key: 'snap-dialog-content-text',
-                    props: {
-                      text: textAreaContent,
-                    },
-                  },
-                ]
-              : []),
-          ],
+          children: mapToTemplate(content),
         },
       },
     ],

--- a/ui/pages/confirmation/templates/flask/snap-confirmation/snap-confirmation.js
+++ b/ui/pages/confirmation/templates/flask/snap-confirmation/snap-confirmation.js
@@ -1,7 +1,10 @@
 import { mapToTemplate } from '../../../../../components/app/flask/snap-ui-renderer';
 
 function getValues(pendingApproval, t, actions) {
-  const { snapName, requestData: content } = pendingApproval;
+  const {
+    snapName,
+    requestData: { content },
+  } = pendingApproval;
 
   return {
     content: [

--- a/ui/pages/confirmation/templates/flask/snap-confirmation/snap-confirmation.js
+++ b/ui/pages/confirmation/templates/flask/snap-confirmation/snap-confirmation.js
@@ -18,6 +18,7 @@ function getValues(pendingApproval, t, actions) {
           props: {
             snapName,
           },
+          // TODO: Replace with SnapUIRenderer when we don't need to inject the input manually.
           children: mapToTemplate(content),
         },
       },

--- a/ui/pages/confirmation/templates/flask/snap-confirmation/snap-confirmation.js
+++ b/ui/pages/confirmation/templates/flask/snap-confirmation/snap-confirmation.js
@@ -24,46 +24,48 @@ function getValues(pendingApproval, t, actions) {
           },
           // TODO: Replace with SnapUIRenderer when we don't need to inject the input manually.
           // TODO: Remove ternary once snap_confirm has been removed.
-          children: content ? mapToTemplate(content) : [
-            {
-              element: 'Typography',
-              key: 'title',
-              children: title,
-              props: {
-                variant: TYPOGRAPHY.H3,
-                fontWeight: 'bold',
-                boxProps: {
-                  marginBottom: 4,
-                },
-              },
-            },
-            ...(description
-              ? [
+          children: content
+            ? mapToTemplate(content)
+            : [
                 {
                   element: 'Typography',
-                  key: 'subtitle',
-                  children: description,
+                  key: 'title',
+                  children: title,
                   props: {
-                    variant: TYPOGRAPHY.H6,
+                    variant: TYPOGRAPHY.H3,
+                    fontWeight: 'bold',
                     boxProps: {
                       marginBottom: 4,
                     },
                   },
                 },
-              ]
-              : []),
-            ...(textAreaContent
-              ? [
-                {
-                  element: 'Copyable',
-                  key: 'snap-dialog-content-text',
-                  props: {
-                    text: textAreaContent,
-                  },
-                },
-              ]
-              : []),
-          ],
+                ...(description
+                  ? [
+                      {
+                        element: 'Typography',
+                        key: 'subtitle',
+                        children: description,
+                        props: {
+                          variant: TYPOGRAPHY.H6,
+                          boxProps: {
+                            marginBottom: 4,
+                          },
+                        },
+                      },
+                    ]
+                  : []),
+                ...(textAreaContent
+                  ? [
+                      {
+                        element: 'Copyable',
+                        key: 'snap-dialog-content-text',
+                        props: {
+                          text: textAreaContent,
+                        },
+                      },
+                    ]
+                  : []),
+              ],
         },
       },
     ],

--- a/ui/pages/confirmation/templates/flask/snap-confirmation/snap-confirmation.js
+++ b/ui/pages/confirmation/templates/flask/snap-confirmation/snap-confirmation.js
@@ -1,8 +1,7 @@
-import { TYPOGRAPHY } from '../../../../../helpers/constants/design-system';
+import { mapToTemplate } from '../../../../../components/app/flask/snap-ui-renderer';
 
 function getValues(pendingApproval, t, actions) {
-  const { snapName, requestData } = pendingApproval;
-  const { title, description, textAreaContent } = requestData;
+  const { snapName, requestData: content } = pendingApproval;
 
   return {
     content: [
@@ -19,46 +18,7 @@ function getValues(pendingApproval, t, actions) {
           props: {
             snapName,
           },
-          children: [
-            {
-              element: 'Typography',
-              key: 'title',
-              children: title,
-              props: {
-                variant: TYPOGRAPHY.H3,
-                fontWeight: 'bold',
-                boxProps: {
-                  marginBottom: 4,
-                },
-              },
-            },
-            ...(description
-              ? [
-                  {
-                    element: 'Typography',
-                    key: 'subtitle',
-                    children: description,
-                    props: {
-                      variant: TYPOGRAPHY.H6,
-                      boxProps: {
-                        marginBottom: 4,
-                      },
-                    },
-                  },
-                ]
-              : []),
-            ...(textAreaContent
-              ? [
-                  {
-                    element: 'Copyable',
-                    key: 'snap-dialog-content-text',
-                    props: {
-                      text: textAreaContent,
-                    },
-                  },
-                ]
-              : []),
-          ],
+          children: mapToTemplate(content),
         },
       },
     ],

--- a/ui/pages/confirmation/templates/flask/snap-confirmation/snap-confirmation.js
+++ b/ui/pages/confirmation/templates/flask/snap-confirmation/snap-confirmation.js
@@ -1,9 +1,10 @@
+import { TYPOGRAPHY } from '../../../../../helpers/constants/design-system';
 import { mapToTemplate } from '../../../../../components/app/flask/snap-ui-renderer';
 
 function getValues(pendingApproval, t, actions) {
   const {
     snapName,
-    requestData: { content },
+    requestData: { content, title, description, textAreaContent },
   } = pendingApproval;
 
   return {
@@ -22,7 +23,47 @@ function getValues(pendingApproval, t, actions) {
             snapName,
           },
           // TODO: Replace with SnapUIRenderer when we don't need to inject the input manually.
-          children: mapToTemplate(content),
+          // TODO: Remove ternary once snap_confirm has been removed.
+          children: content ? mapToTemplate(content) : [
+            {
+              element: 'Typography',
+              key: 'title',
+              children: title,
+              props: {
+                variant: TYPOGRAPHY.H3,
+                fontWeight: 'bold',
+                boxProps: {
+                  marginBottom: 4,
+                },
+              },
+            },
+            ...(description
+              ? [
+                {
+                  element: 'Typography',
+                  key: 'subtitle',
+                  children: description,
+                  props: {
+                    variant: TYPOGRAPHY.H6,
+                    boxProps: {
+                      marginBottom: 4,
+                    },
+                  },
+                },
+              ]
+              : []),
+            ...(textAreaContent
+              ? [
+                {
+                  element: 'Copyable',
+                  key: 'snap-dialog-content-text',
+                  props: {
+                    text: textAreaContent,
+                  },
+                },
+              ]
+              : []),
+          ],
         },
       },
     ],

--- a/ui/pages/confirmation/templates/flask/snap-prompt/snap-prompt.js
+++ b/ui/pages/confirmation/templates/flask/snap-prompt/snap-prompt.js
@@ -1,9 +1,11 @@
-import { TYPOGRAPHY } from '../../../../../helpers/constants/design-system';
+import { mapToTemplate } from '../../../../../components/app/flask/snap-ui-renderer';
 import { MESSAGE_TYPE } from '../../../../../../shared/constants/app';
 
 function getValues(pendingApproval, t, actions, _history, setInputState) {
-  const { snapName, requestData } = pendingApproval;
-  const { title, description, placeholder } = requestData;
+  const {
+    snapName,
+    requestData: { content, placeholder },
+  } = pendingApproval;
 
   return {
     content: [
@@ -21,33 +23,7 @@ function getValues(pendingApproval, t, actions, _history, setInputState) {
             snapName,
           },
           children: [
-            {
-              element: 'Typography',
-              key: 'title',
-              children: title,
-              props: {
-                variant: TYPOGRAPHY.H3,
-                fontWeight: 'bold',
-                boxProps: {
-                  marginBottom: 4,
-                },
-              },
-            },
-            ...(description
-              ? [
-                  {
-                    element: 'Typography',
-                    key: 'subtitle',
-                    children: description,
-                    props: {
-                      variant: TYPOGRAPHY.H6,
-                      boxProps: {
-                        marginBottom: 4,
-                      },
-                    },
-                  },
-                ]
-              : []),
+            mapToTemplate(content),
             {
               element: 'div',
               key: 'snap-prompt-container',

--- a/ui/pages/confirmation/templates/flask/snap-prompt/snap-prompt.js
+++ b/ui/pages/confirmation/templates/flask/snap-prompt/snap-prompt.js
@@ -23,6 +23,7 @@ function getValues(pendingApproval, t, actions, _history, setInputState) {
             snapName,
           },
           children: [
+            // TODO: Replace with SnapUIRenderer when we don't need to inject the input manually.
             mapToTemplate(content),
             {
               element: 'div',


### PR DESCRIPTION
Use custom UI for `snap_dialog`, removing the old dialog format.


Fixes #16522 