### PR TITLE
Fix insufficient currency buy or receive error message

### DIFF
--- a/ui/pages/send/gas-display/gas-display.js
+++ b/ui/pages/send/gas-display/gas-display.js
@@ -66,7 +66,7 @@ export default function GasDisplay({ gasError }) {
   const isInsufficientTokenError =
     draftTransaction?.amount.error === INSUFFICIENT_TOKENS_ERROR;
   const editingTransaction = unapprovedTxs[draftTransaction.id];
-  const currentNetworkName = networkName ? networkName : currentProvider.nickname;
+  const currentNetworkName = networkName || currentProvider.nickname;
 
   const transactionData = {
     txParams: {

--- a/ui/pages/send/gas-display/gas-display.js
+++ b/ui/pages/send/gas-display/gas-display.js
@@ -66,6 +66,7 @@ export default function GasDisplay({ gasError }) {
   const isInsufficientTokenError =
     draftTransaction?.amount.error === INSUFFICIENT_TOKENS_ERROR;
   const editingTransaction = unapprovedTxs[draftTransaction.id];
+  const currentNetworkName = networkName ? networkName : currentProvider.nickname;
 
   const transactionData = {
     txParams: {
@@ -304,7 +305,7 @@ export default function GasDisplay({ gasError }) {
           ]}
         />
       </Box>
-      {(gasError || isInsufficientTokenError) && (
+      {(gasError || isInsufficientTokenError) && currentNetworkName && (
         <Box
           className="gas-display__warning-message"
           data-testid="gas-warning-message"
@@ -322,7 +323,7 @@ export default function GasDisplay({ gasError }) {
                   <Typography variant={TYPOGRAPHY.H7} align="left">
                     {t('insufficientCurrencyBuyOrReceive', [
                       nativeCurrency,
-                      networkName ?? currentProvider.nickname,
+                      currentNetworkName,
                       <Button
                         type="inline"
                         className="confirm-page-container-content__link"
@@ -349,7 +350,7 @@ export default function GasDisplay({ gasError }) {
                   <Typography variant={TYPOGRAPHY.H7} align="left">
                     {t('insufficientCurrencyBuyOrReceive', [
                       draftTransaction.asset.details?.symbol ?? nativeCurrency,
-                      networkName ?? currentProvider.nickname,
+                      currentNetworkName,
                       `${t('buyAsset', [
                         draftTransaction.asset.details?.symbol ??
                           nativeCurrency,


### PR DESCRIPTION
## Explanation
Error: Insufficient number of substitutions for key "insufficientCurrencyBuyOrReceive" with locale "en". This error appears on send screen while changing network. The issue was that network name was **undefined** while switching between networks and that was causing this error message, so the additional condition for warning message was added. Warning message will appear when all needed data for it is fetched (networkName, symbol...).

* Fixes #16892 

## Screenshots/Screencaps

### Before

https://user-images.githubusercontent.com/92531782/208085038-1b04ecd6-5b03-4f17-a45c-69efe52d56d3.mov



### After

https://user-images.githubusercontent.com/92531782/208085173-bb6dc16a-733e-4776-880c-67dd85e1383b.mov



## Manual Testing Steps

1. Login extension
2. Switch to localhost
3. Click the Send button on the overview page
4. Enter an amount thats more than the native currency held on Locahost and Ethereum Mainnet
5. Switch to Ethereum Mainnet


