### PR TITLE
housekeeping for picker-network

### DIFF
--- a/ui/components/component-library/picker-network/README.mdx
+++ b/ui/components/component-library/picker-network/README.mdx
@@ -25,7 +25,7 @@ Use the `label` prop for the text content of the `PickerNetwork` component
 </Canvas>
 
 ```jsx
-import { PickerNetwork } from '../../ui/component-library/picker-network';
+import { PickerNetwork } from '../../ui/component-library';
   <PickerNetwork label="Arbitrum One" />
   <PickerNetwork label="Polygon Mainnet" />
   <PickerNetwork label="Optimism" />
@@ -40,7 +40,7 @@ Use the `src` prop with an image url to render the `AvatarNetwork`.
 </Canvas>
 
 ```jsx
-import { PickerNetwork } from '../../ui/component-library/picker-network';
+import { PickerNetwork } from '../../ui/component-library';
   <PickerNetwork src="./images/arbitrum.svg" />
   <PickerNetwork src="./images/matic-token.png" />
   <PickerNetwork src="./images/optimism.svg" />

--- a/ui/components/component-library/picker-network/README.mdx
+++ b/ui/components/component-library/picker-network/README.mdx
@@ -26,14 +26,14 @@ Use the `label` prop for the text content of the `PickerNetwork` component
 
 ```jsx
 import { PickerNetwork } from '../../ui/component-library';
-  <PickerNetwork label="Arbitrum One" />
-  <PickerNetwork label="Polygon Mainnet" />
-  <PickerNetwork label="Optimism" />
+<PickerNetwork label="Arbitrum One" />
+<PickerNetwork label="Polygon Mainnet" />
+<PickerNetwork label="Optimism" />
 ```
 
 ### Src
 
-Use the `src` prop with an image url to render the `AvatarNetwork`.
+Use the `src` prop with an image url to render the `AvatarNetwork`. Use the `avatarNetworkProps` to pass additional props to the `AvatarNetwork` component.
 
 <Canvas>
   <Story id="ui-components-component-library-picker-network-picker-network-stories-js--src" />
@@ -41,7 +41,7 @@ Use the `src` prop with an image url to render the `AvatarNetwork`.
 
 ```jsx
 import { PickerNetwork } from '../../ui/component-library';
-  <PickerNetwork src="./images/arbitrum.svg" />
-  <PickerNetwork src="./images/matic-token.png" />
-  <PickerNetwork src="./images/optimism.svg" />
+<PickerNetwork src="./images/arbitrum.svg" />
+<PickerNetwork src="./images/matic-token.png" />
+<PickerNetwork src="./images/optimism.svg" />
 ```

--- a/ui/components/component-library/picker-network/README.mdx
+++ b/ui/components/component-library/picker-network/README.mdx
@@ -16,21 +16,6 @@ The `PickerNetwork` accepts all props below as well as all [Box](/docs/ui-compon
 
 <ArgsTable of={PickerNetwork} />
 
-### Src
-
-Use the `src` prop with an image url to render the `AvatarNetwork`.
-
-<Canvas>
-  <Story id="ui-components-component-library-picker-network-picker-network-stories-js--src" />
-</Canvas>
-
-```jsx
-import { PickerNetwork } from '../../ui/component-library/picker-network';
-  <PickerNetwork src="./images/arbitrum.svg" />
-  <PickerNetwork src="./images/matic-token.png" />
-  <PickerNetwork src="./images/optimism.svg" />
-```
-
 ### Label
 
 Use the `label` prop for the text content of the `PickerNetwork` component
@@ -44,4 +29,19 @@ import { PickerNetwork } from '../../ui/component-library/picker-network';
   <PickerNetwork label="Arbitrum One" />
   <PickerNetwork label="Polygon Mainnet" />
   <PickerNetwork label="Optimism" />
+```
+
+### Src
+
+Use the `src` prop with an image url to render the `AvatarNetwork`.
+
+<Canvas>
+  <Story id="ui-components-component-library-picker-network-picker-network-stories-js--src" />
+</Canvas>
+
+```jsx
+import { PickerNetwork } from '../../ui/component-library/picker-network';
+  <PickerNetwork src="./images/arbitrum.svg" />
+  <PickerNetwork src="./images/matic-token.png" />
+  <PickerNetwork src="./images/optimism.svg" />
 ```

--- a/ui/components/component-library/picker-network/picker-network.test.js
+++ b/ui/components/component-library/picker-network/picker-network.test.js
@@ -54,4 +54,11 @@ describe('PickerNetwork', () => {
       'down-arrow-picker-icon',
     );
   });
+  // className
+  it('should render with custom className', () => {
+    const { getByTestId } = render(
+      <PickerNetwork data-testid="picker-network" className="test-class" />,
+    );
+    expect(getByTestId('picker-network')).toHaveClass('test-class');
+  });
 });


### PR DESCRIPTION
* Fixes #16640 

This PR is to ensure that `PickerNetwork` adheres to all of the following conventions and standards

- [x] Has a `className` prop and the PropType descriptions are all the same
- [x] Prop table in MDX docs have the "Accepts all Box component props" description and link
- [x] We are consistent when using the same prop names like `size` and are suggesting the use of the generalized `design-system.js` constants e.g. `SIZES` as the primary option but noting the component consts in the documentation and using them for propType validation and storybook controls only
- [x] Standardize all similar prop names for images `imgSrc`, `imgAlt`(html element + attribute) (needs audit)
- [x] We have a story for each component prop and we use the prop name verbatim e.g. `size` prop would be `export const Size = (args) => (`
- [x] We have the accompanying documentation for each component prop and we use the prop name verbatim e.g. `size` prop would be `### Size`
- [ ] Are multiple props stories allowed? e.g. `Color, Background Color And Border Color` story in `base-avatar` - [ ] yes when it makes sense to
- [ ] All Base components follow the suffix convention e.g. `ButtonBase`
- [x] All Base component MDX documentation have the base component notification at the top
- [x] Add `mm-` prefix to all classNames
- [x] className is kebab case version of the component name
- x ] Spread base components props and reduce duplication of props when props aren't being changed and remain the same for both variant and base components
- [x] Add component to root `index.js` file in component-library
- [ ] Add locals for any default text I18nContext as default context 
- [ ] Add any "to dos" with a `// TODO:` comment so we can search for them at a later date e.g. blocking components etc
- [x] Add snapshot testing
- [ ] Add pixel values to propType descriptions if we use abstracted prop types that relate to pixel values e.g. `SIZE.MD (32px)`
- [x] Each prop section in the MDX docs should have: a heading, a description, a story and an example code snipped