### PR TITLE
Fix the ganache:start command by making the 'yarn bin' usage yarn3 compatible

### DIFF
--- a/development/run-ganache.sh
+++ b/development/run-ganache.sh
@@ -4,7 +4,7 @@ set -e
 set -u
 set -o pipefail
 
-ganache_cli="$(yarn bin)/ganache"
+ganache_cli="$(yarn bin ganache)"
 seed_phrase="${GANACHE_SEED_PHRASE:-phrase upgrade clock rough situate wedding elder clever doctor stamp excess tent}"
 
 _term () {


### PR DESCRIPTION
## Explanation

As of the yarn3 upgrade, `yarn ganache:start` has been broken. This is because it attempts to execute `$(yarn bin)/ganache`, which fails due to changes to `yarn bin` in yarn 3.

prior to the yarn3 [commit](https://github.com/MetaMask/metamask-extension/commit/6d1170f06c71aee9839ae17d61a8c129a717b72b), `yarn bin`  gives this output `/home/danjm/metamask/metamask-extension/node_modules/.bin` and `$(yarn bin)` gives  `bash: /home/danjm/metamask/metamask-extension/node_modules/.bin: Is a directory` (on my linux system)
after the yarn3 commit, `yarn bin` outputs a list of binaries, and `$(yarn bin)` gives `➤: command not found`

[yarn v1 docs](https://classic.yarnpkg.com/lang/en/docs/cli/bin/#toc-yarn-bin) say that "yarn bin will print the folder where yarn will install executable files for your package"
[yarn v2+ docs](https://yarnpkg.com/cli/bin#usage) say that yarn bin will "List all the available binaries"

yarn v2+ docs also say that to "Print the path to a specific binary" run `yarn bin binary_name`. This PR updates `run-ganache.sh` to use yarn bin in that way