### PR TITLE
Making add un-approved transaction idempotent

### DIFF
--- a/app/scripts/controllers/transactions/index.js
+++ b/app/scripts/controllers/transactions/index.js
@@ -340,7 +340,7 @@ export default class TransactionController extends EventEmitter {
       opts.origin,
       undefined,
       undefined,
-      opts.id
+      opts.id,
     );
 
     // listen for tx completion (success, fail)

--- a/app/scripts/controllers/transactions/index.js
+++ b/app/scripts/controllers/transactions/index.js
@@ -338,6 +338,9 @@ export default class TransactionController extends EventEmitter {
     const initialTxMeta = await this.addUnapprovedTransaction(
       txParams,
       opts.origin,
+      undefined,
+      undefined,
+      opts.id
     );
 
     // listen for tx completion (success, fail)


### PR DESCRIPTION
Fixes #16965

Using `req.id` as unique id to ensure that duplicate transactions are not generated.