### PR TITLE
`Box` component `0` value fix

### DIFF
--- a/ui/components/app/custom-spending-cap/__snapshots__/custom-spending-cap.test.js.snap
+++ b/ui/components/app/custom-spending-cap/__snapshots__/custom-spending-cap.test.js.snap
@@ -52,10 +52,10 @@ exports[`CustomSpendingCap should match snapshot 1`] = `
                 </div>
               </div>
               <div
-                class="box form-field__heading-detail box--margin-bottom-2 box--flex-direction-row box--text-align-end"
+                class="box form-field__heading-detail box--margin-right-0 box--margin-bottom-2 box--flex-direction-row box--text-align-end"
               >
                 <button
-                  class="box mm-text mm-button-base mm-button-link mm-button-link--size-auto mm-text--body-md box--display-inline-flex box--flex-direction-row box--justify-content-center box--align-items-center box--color-primary-default box--background-color-transparent"
+                  class="box mm-text mm-button-base mm-button-link mm-button-link--size-auto mm-text--body-md box--padding-right-0 box--padding-left-0 box--display-inline-flex box--flex-direction-row box--justify-content-center box--align-items-center box--color-primary-default box--background-color-transparent"
                 >
                   Use default
                 </button>
@@ -76,7 +76,7 @@ exports[`CustomSpendingCap should match snapshot 1`] = `
           class="box custom-spending-cap__max box--margin-left-auto box--padding-right-4 box--padding-bottom-2 box--flex-direction-row box--text-align-end box--width-max"
         >
           <button
-            class="box mm-text mm-button-base mm-button-link mm-button-link--size-auto mm-text--body-md box--display-inline-flex box--flex-direction-row box--justify-content-center box--align-items-center box--color-primary-default box--background-color-transparent"
+            class="box mm-text mm-button-base mm-button-link mm-button-link--size-auto mm-text--body-md box--padding-right-0 box--padding-left-0 box--display-inline-flex box--flex-direction-row box--justify-content-center box--align-items-center box--color-primary-default box--background-color-transparent"
           >
             Max
           </button>

--- a/ui/components/app/ledger-instruction-field/__snapshots__/ledger-instruction-field.test.js.snap
+++ b/ui/components/app/ledger-instruction-field/__snapshots__/ledger-instruction-field.test.js.snap
@@ -37,7 +37,7 @@ exports[`LedgerInstructionField Component rendering should render properly with 
             >
               <span>
                 <button
-                  class="box mm-text mm-button-base mm-button-link mm-button-link--size-auto mm-text--body-md mm-text--text-align-left box--display-inline-flex box--flex-direction-row box--justify-content-center box--align-items-center box--color-primary-default box--background-color-transparent"
+                  class="box mm-text mm-button-base mm-button-link mm-button-link--size-auto mm-text--body-md mm-text--text-align-left box--padding-right-0 box--padding-left-0 box--display-inline-flex box--flex-direction-row box--justify-content-center box--align-items-center box--color-primary-default box--background-color-transparent"
                 >
                   Go to full screen to connect your Ledger.
                 </button>

--- a/ui/components/app/modals/eth-sign-modal/__snapshots__/eth-sign-modal.test.js.snap
+++ b/ui/components/app/modals/eth-sign-modal/__snapshots__/eth-sign-modal.test.js.snap
@@ -32,7 +32,7 @@ exports[`Eth Sign Modal should match snapshot 1`] = `
     >
       Allowing eth_sign requests can make you vulnerable to phishing attacks. Always review the URL and be careful when signing  messages that contain code.
       <a
-        class="box mm-text mm-button-base mm-button-link mm-button-link--size-auto mm-text--body-md box--display-inline-flex box--flex-direction-row box--justify-content-center box--align-items-center box--color-primary-default box--background-color-transparent"
+        class="box mm-text mm-button-base mm-button-link mm-button-link--size-auto mm-text--body-md box--padding-right-0 box--padding-left-0 box--display-inline-flex box--flex-direction-row box--justify-content-center box--align-items-center box--color-primary-default box--background-color-transparent"
         href="https://support.metamask.io/hc/en-us/articles/14764161421467"
         rel="noopener noreferrer"
         target="_blank"

--- a/ui/components/app/modals/export-private-key-modal/__snapshots__/export-private-key-modal.test.js.snap
+++ b/ui/components/app/modals/export-private-key-modal/__snapshots__/export-private-key-modal.test.js.snap
@@ -69,10 +69,10 @@ exports[`Export PrivateKey Modal should match snapshot 1`] = `
         0x0DCD5D886577d5081B0c52e242Ef29E70Be3E7bc
       </div>
       <div
-        class="box export-private-key-modal__divider box--margin-5 box--md:margin-3 box--flex-direction-row box--width-full"
+        class="box export-private-key-modal__divider box--margin-5 box--sm:margin-0 box--md:margin-3 box--lg:margin-0 box--flex-direction-row box--width-full"
       />
       <p
-        class="box mm-text mm-text--body-lg-medium mm-text--font-weight-normal box--margin-4 box--md:margin-4 box--flex-direction-row box--color-text-default"
+        class="box mm-text mm-text--body-lg-medium mm-text--font-weight-normal box--margin-4 box--sm:margin-0 box--md:margin-4 box--lg:margin-0 box--flex-direction-row box--color-text-default"
       >
         Show Private Keys
       </p>
@@ -85,12 +85,12 @@ exports[`Export PrivateKey Modal should match snapshot 1`] = `
           Type your MetaMask password
         </label>
         <div
-          class="box mm-text-field mm-text-field--size-md mm-text-field--truncate export-private-key-modal__password-input box--display-inline-flex box--flex-direction-row box--align-items-center box--width-full box--background-color-background-default box--rounded-sm box--border-width-1 box--border-style-solid"
+          class="box mm-text-field mm-text-field--size-md mm-text-field--truncate export-private-key-modal__password-input box--padding-right-0 box--padding-left-0 box--display-inline-flex box--flex-direction-row box--align-items-center box--width-full box--background-color-background-default box--rounded-sm box--border-width-1 box--border-style-solid"
           data-testid="password-input"
         >
           <input
             autocomplete="off"
-            class="box mm-text mm-input mm-input--disable-state-styles mm-text-field__input mm-text--body-md box--padding-right-4 box--padding-left-4 box--flex-direction-row box--color-text-default box--background-color-transparent box--border-style-none"
+            class="box mm-text mm-input mm-input--disable-state-styles mm-text-field__input mm-text--body-md box--margin-0 box--padding-0 box--padding-right-4 box--padding-left-4 box--flex-direction-row box--color-text-default box--background-color-transparent box--border-style-none"
             focused="false"
             placeholder="Enter password"
             type="password"
@@ -102,7 +102,7 @@ exports[`Export PrivateKey Modal should match snapshot 1`] = `
         class="box mm-text mm-text--body-sm box--flex-direction-row box--color-error-default"
       />
       <div
-        class="box mm-banner-base mm-banner-alert mm-banner-alert--severity-danger box--margin-top-4 box--margin-right-5 box--margin-left-5 box--padding-1 box--sm:padding-3 box--lg:padding-3 box--padding-left-2 box--display-flex box--gap-2 box--flex-direction-row box--background-color-error-muted box--rounded-sm"
+        class="box mm-banner-base mm-banner-alert mm-banner-alert--severity-danger box--margin-top-4 box--margin-right-5 box--margin-left-5 box--padding-1 box--sm:padding-3 box--md:padding-0 box--lg:padding-3 box--padding-left-2 box--display-flex box--gap-2 box--flex-direction-row box--background-color-error-muted box--rounded-sm"
       >
         <span
           class="box mm-icon mm-icon--size-lg box--display-inline-block box--flex-direction-row box--color-error-default"
@@ -117,7 +117,7 @@ exports[`Export PrivateKey Modal should match snapshot 1`] = `
         </div>
       </div>
       <div
-        class="box box--margin-top-3 box--padding-5 box--md:padding-5 box--display-flex box--flex-direction-row box--justify-content-space-between box--width-full"
+        class="box box--margin-top-3 box--padding-5 box--sm:padding-0 box--md:padding-5 box--lg:padding-0 box--display-flex box--flex-direction-row box--justify-content-space-between box--width-full"
       >
         <button
           class="box mm-text mm-button-base mm-button-base--size-lg mm-button-primary mm-text--body-md box--margin-right-4 box--padding-right-4 box--padding-left-4 box--display-inline-flex box--flex-direction-row box--justify-content-center box--align-items-center box--width-1/2 box--color-primary-inverse box--background-color-primary-default box--rounded-pill"

--- a/ui/components/app/nft-details/__snapshots__/nft-details.test.js.snap
+++ b/ui/components/app/nft-details/__snapshots__/nft-details.test.js.snap
@@ -43,7 +43,7 @@ exports[`NFT Details should match minimal props and state snapshot 1`] = `
       class="nft-details__top-section"
     >
       <div
-        class="box nft-details__card box--flex-direction-row box--justify-content-center box--background-color-background-default box--rounded-md box--border-style-solid box--border-color-border-muted box--border-width-1 box--display-flex"
+        class="box nft-details__card box--padding-0 box--flex-direction-row box--justify-content-center box--background-color-background-default box--rounded-md box--border-style-solid box--border-color-border-muted box--border-width-1 box--display-flex"
       >
         <img
           alt="MUNK #1 1"

--- a/ui/components/app/signature-request-original/__snapshots__/signature-request-original.test.js.snap
+++ b/ui/components/app/signature-request-original/__snapshots__/signature-request-original.test.js.snap
@@ -145,12 +145,12 @@ exports[`SignatureRequestOriginal should match snapshot 1`] = `
             class="box box--display-flex box--flex-direction-column box--align-items-flex-start"
           >
             <h6
-              class="box mm-text mm-text--body-sm box--flex-direction-row box--color-text-alternative"
+              class="box mm-text mm-text--body-sm box--margin-bottom-0 box--flex-direction-row box--color-text-alternative"
             >
               Unknown private network
             </h6>
             <h6
-              class="box mm-text mm-text--body-sm mm-text--font-weight-bold box--flex-direction-row box--color-text-default"
+              class="box mm-text mm-text--body-sm mm-text--font-weight-bold box--margin-top-0 box--flex-direction-row box--color-text-default"
             >
               Test Account
             </h6>
@@ -160,13 +160,13 @@ exports[`SignatureRequestOriginal should match snapshot 1`] = `
           class="box box--display-flex box--flex-direction-column box--align-items-flex-end"
         >
           <h6
-            class="box mm-text mm-text--body-sm box--flex-direction-row box--color-text-alternative"
+            class="box mm-text mm-text--body-sm box--margin-bottom-0 box--flex-direction-row box--color-text-alternative"
           >
             Balance
           </h6>
           <h6
             align="end"
-            class="box mm-text mm-text--body-sm mm-text--font-weight-bold box--flex-direction-row box--color-text-default"
+            class="box mm-text mm-text--body-sm mm-text--font-weight-bold box--margin-top-0 box--flex-direction-row box--color-text-default"
           >
             966.987986
              

--- a/ui/components/app/signature-request/__snapshots__/signature-request.component.test.js.snap
+++ b/ui/components/app/signature-request/__snapshots__/signature-request.component.test.js.snap
@@ -142,12 +142,12 @@ exports[`Signature Request Component render should match snapshot when we are us
             class="box box--display-flex box--flex-direction-column box--align-items-flex-start"
           >
             <h6
-              class="box mm-text mm-text--body-sm box--flex-direction-row box--color-text-alternative"
+              class="box mm-text mm-text--body-sm box--margin-bottom-0 box--flex-direction-row box--color-text-alternative"
             >
               Unknown private network
             </h6>
             <h6
-              class="box mm-text mm-text--body-sm mm-text--font-weight-bold box--flex-direction-row box--color-text-default"
+              class="box mm-text mm-text--body-sm mm-text--font-weight-bold box--margin-top-0 box--flex-direction-row box--color-text-default"
             >
               Antonio
             </h6>
@@ -157,13 +157,13 @@ exports[`Signature Request Component render should match snapshot when we are us
           class="box box--display-flex box--flex-direction-column box--align-items-flex-end"
         >
           <h6
-            class="box mm-text mm-text--body-sm box--flex-direction-row box--color-text-alternative"
+            class="box mm-text mm-text--body-sm box--margin-bottom-0 box--flex-direction-row box--color-text-alternative"
           >
             Balance
           </h6>
           <h6
             align="end"
-            class="box mm-text mm-text--body-sm mm-text--font-weight-bold box--flex-direction-row box--color-text-default"
+            class="box mm-text mm-text--body-sm mm-text--font-weight-bold box--margin-top-0 box--flex-direction-row box--color-text-default"
           >
             966.987986
              
@@ -918,12 +918,12 @@ exports[`Signature Request Component render should match snapshot when we want t
             class="box box--display-flex box--flex-direction-column box--align-items-flex-start"
           >
             <h6
-              class="box mm-text mm-text--body-sm box--flex-direction-row box--color-text-alternative"
+              class="box mm-text mm-text--body-sm box--margin-bottom-0 box--flex-direction-row box--color-text-alternative"
             >
               Unknown private network
             </h6>
             <h6
-              class="box mm-text mm-text--body-sm mm-text--font-weight-bold box--flex-direction-row box--color-text-default"
+              class="box mm-text mm-text--body-sm mm-text--font-weight-bold box--margin-top-0 box--flex-direction-row box--color-text-default"
             >
               Antonio
             </h6>
@@ -933,13 +933,13 @@ exports[`Signature Request Component render should match snapshot when we want t
           class="box box--display-flex box--flex-direction-column box--align-items-flex-end"
         >
           <h6
-            class="box mm-text mm-text--body-sm box--flex-direction-row box--color-text-alternative"
+            class="box mm-text mm-text--body-sm box--margin-bottom-0 box--flex-direction-row box--color-text-alternative"
           >
             Balance
           </h6>
           <h6
             align="end"
-            class="box mm-text mm-text--body-sm mm-text--font-weight-bold box--flex-direction-row box--color-text-default"
+            class="box mm-text mm-text--body-sm mm-text--font-weight-bold box--margin-top-0 box--flex-direction-row box--color-text-default"
           >
             1515270.174798
              

--- a/ui/components/component-library/button-link/__snapshots__/button-link.test.js.snap
+++ b/ui/components/component-library/button-link/__snapshots__/button-link.test.js.snap
@@ -3,7 +3,7 @@
 exports[`ButtonLink should render button element correctly 1`] = `
 <div>
   <button
-    class="box mm-text mm-button-base mm-button-link mm-button-link--size-auto mm-text--body-md box--display-inline-flex box--flex-direction-row box--justify-content-center box--align-items-center box--color-primary-default box--background-color-transparent"
+    class="box mm-text mm-button-base mm-button-link mm-button-link--size-auto mm-text--body-md box--padding-right-0 box--padding-left-0 box--display-inline-flex box--flex-direction-row box--justify-content-center box--align-items-center box--color-primary-default box--background-color-transparent"
     data-testid="button-link"
   >
     Button Link

--- a/ui/components/component-library/button/__snapshots__/button.test.js.snap
+++ b/ui/components/component-library/button/__snapshots__/button.test.js.snap
@@ -26,7 +26,7 @@ exports[`Button should render with different button types 1`] = `
     Button
   </button>
   <button
-    class="box mm-text mm-button-base mm-button-link mm-button-link--size-auto mm-text--body-md box--display-inline-flex box--flex-direction-row box--justify-content-center box--align-items-center box--color-primary-default box--background-color-transparent"
+    class="box mm-text mm-button-base mm-button-link mm-button-link--size-auto mm-text--body-md box--padding-right-0 box--padding-left-0 box--display-inline-flex box--flex-direction-row box--justify-content-center box--align-items-center box--color-primary-default box--background-color-transparent"
     data-testid="link"
   >
     Button

--- a/ui/components/component-library/form-text-field/__snapshots__/form-text-field.test.js.snap
+++ b/ui/components/component-library/form-text-field/__snapshots__/form-text-field.test.js.snap
@@ -6,11 +6,11 @@ exports[`FormTextField should render correctly 1`] = `
     class="box mm-form-text-field box--display-flex box--flex-direction-column"
   >
     <div
-      class="box mm-text-field mm-text-field--size-md mm-text-field--truncate mm-form-text-field__text-field box--display-inline-flex box--flex-direction-row box--align-items-center box--background-color-background-default box--rounded-sm box--border-width-1 box--border-style-solid"
+      class="box mm-text-field mm-text-field--size-md mm-text-field--truncate mm-form-text-field__text-field box--padding-right-0 box--padding-left-0 box--display-inline-flex box--flex-direction-row box--align-items-center box--background-color-background-default box--rounded-sm box--border-width-1 box--border-style-solid"
     >
       <input
         autocomplete="off"
-        class="box mm-text mm-input mm-input--disable-state-styles mm-text-field__input mm-text--body-md box--padding-right-4 box--padding-left-4 box--flex-direction-row box--color-text-default box--background-color-transparent box--border-style-none"
+        class="box mm-text mm-input mm-input--disable-state-styles mm-text-field__input mm-text--body-md box--margin-0 box--padding-0 box--padding-right-4 box--padding-left-4 box--flex-direction-row box--color-text-default box--background-color-transparent box--border-style-none"
         focused="false"
         type="text"
         value=""

--- a/ui/components/component-library/input/__snapshots__/input.test.js.snap
+++ b/ui/components/component-library/input/__snapshots__/input.test.js.snap
@@ -4,7 +4,7 @@ exports[`Input should render correctly 1`] = `
 <div>
   <input
     autocomplete="off"
-    class="box mm-text mm-input mm-text--body-md box--flex-direction-row box--color-text-default box--background-color-transparent box--border-style-none"
+    class="box mm-text mm-input mm-text--body-md box--margin-0 box--padding-0 box--flex-direction-row box--color-text-default box--background-color-transparent box--border-style-none"
     type="text"
     value=""
   />

--- a/ui/components/component-library/text-field-search/__snapshots__/text-field-search.test.js.snap
+++ b/ui/components/component-library/text-field-search/__snapshots__/text-field-search.test.js.snap
@@ -3,7 +3,7 @@
 exports[`TextFieldSearch should render correctly 1`] = `
 <div>
   <div
-    class="box mm-text-field mm-text-field--size-md mm-text-field--truncate mm-text-field-search box--padding-left-4 box--display-inline-flex box--flex-direction-row box--align-items-center box--background-color-background-default box--rounded-sm box--border-width-1 box--border-style-solid"
+    class="box mm-text-field mm-text-field--size-md mm-text-field--truncate mm-text-field-search box--padding-right-0 box--padding-left-4 box--display-inline-flex box--flex-direction-row box--align-items-center box--background-color-background-default box--rounded-sm box--border-width-1 box--border-style-solid"
   >
     <span
       class="box mm-icon mm-icon--size-sm box--display-inline-block box--flex-direction-row box--color-inherit"
@@ -11,7 +11,7 @@ exports[`TextFieldSearch should render correctly 1`] = `
     />
     <input
       autocomplete="off"
-      class="box mm-text mm-input mm-input--disable-state-styles mm-text-field__input mm-text--body-md box--margin-right-6 box--padding-right-4 box--padding-left-2 box--flex-direction-row box--color-text-default box--background-color-transparent box--border-style-none"
+      class="box mm-text mm-input mm-input--disable-state-styles mm-text-field__input mm-text--body-md box--margin-0 box--margin-right-6 box--padding-0 box--padding-right-4 box--padding-left-2 box--flex-direction-row box--color-text-default box--background-color-transparent box--border-style-none"
       focused="false"
       type="search"
       value=""

--- a/ui/components/component-library/text-field/__snapshots__/text-field.test.js.snap
+++ b/ui/components/component-library/text-field/__snapshots__/text-field.test.js.snap
@@ -3,11 +3,11 @@
 exports[`TextField should render correctly 1`] = `
 <div>
   <div
-    class="box mm-text-field mm-text-field--size-md mm-text-field--truncate box--display-inline-flex box--flex-direction-row box--align-items-center box--background-color-background-default box--rounded-sm box--border-width-1 box--border-style-solid"
+    class="box mm-text-field mm-text-field--size-md mm-text-field--truncate box--padding-right-0 box--padding-left-0 box--display-inline-flex box--flex-direction-row box--align-items-center box--background-color-background-default box--rounded-sm box--border-width-1 box--border-style-solid"
   >
     <input
       autocomplete="off"
-      class="box mm-text mm-input mm-input--disable-state-styles mm-text-field__input mm-text--body-md box--padding-right-4 box--padding-left-4 box--flex-direction-row box--color-text-default box--background-color-transparent box--border-style-none"
+      class="box mm-text mm-input mm-input--disable-state-styles mm-text-field__input mm-text--body-md box--margin-0 box--padding-0 box--padding-right-4 box--padding-left-4 box--flex-direction-row box--color-text-default box--background-color-transparent box--border-style-none"
       focused="false"
       type="text"
       value=""

--- a/ui/components/institutional/compliance-settings/__snapshots__/compliance-settings.test.js.snap
+++ b/ui/components/institutional/compliance-settings/__snapshots__/compliance-settings.test.js.snap
@@ -20,7 +20,7 @@ exports[`Compliance Settings shows disconnect when Compliance is activated 1`] =
         Disconnect
       </button>
       <button
-        class="box mm-text mm-button-base mm-button-base--size-lg mm-button-link mm-text--body-md box--display-inline-flex box--flex-direction-row box--justify-content-center box--align-items-center box--color-primary-default box--background-color-transparent"
+        class="box mm-text mm-button-base mm-button-base--size-lg mm-button-link mm-text--body-md box--padding-right-0 box--padding-left-0 box--display-inline-flex box--flex-direction-row box--justify-content-center box--align-items-center box--color-primary-default box--background-color-transparent"
         data-testid="start-compliance"
       >
         Open Codefi Compliance
@@ -33,7 +33,7 @@ exports[`Compliance Settings shows disconnect when Compliance is activated 1`] =
 exports[`Compliance Settings shows start btn when Compliance its not activated 1`] = `
 <div>
   <div
-    class="box box--sm:padding-6 box--flex-direction-row box--color-text-alternative"
+    class="box box--padding-0 box--sm:padding-6 box--flex-direction-row box--color-text-alternative"
     data-testid="institutional-content"
   >
     <div
@@ -80,7 +80,7 @@ exports[`Compliance Settings shows start btn when Compliance its not activated 1
         class="box institutional-feature__footer box--padding-4 box--sm:padding-6 box--flex-direction-row box--border-style-solid box--border-color-border-muted box--border-width-1"
       >
         <button
-          class="box mm-text mm-button-base mm-button-base--size-lg mm-button-link mm-text--body-md box--display-inline-flex box--flex-direction-row box--justify-content-center box--align-items-center box--color-primary-default box--background-color-transparent"
+          class="box mm-text mm-button-base mm-button-base--size-lg mm-button-link mm-text--body-md box--padding-right-0 box--padding-left-0 box--display-inline-flex box--flex-direction-row box--justify-content-center box--align-items-center box--color-primary-default box--background-color-transparent"
           data-testid="start-compliance"
         >
           Open Codefi Compliance

--- a/ui/components/institutional/confirm-remove-jwt-modal/__snapshots__/confirm-remove-jwt-modal.test.js.snap
+++ b/ui/components/institutional/confirm-remove-jwt-modal/__snapshots__/confirm-remove-jwt-modal.test.js.snap
@@ -78,7 +78,7 @@ exports[`Confirm Remove JWT should render correctly 1`] = `
                     class="box mm-text custody-account-list__item mm-text--body-md box--display-flex box--flex-direction-row box--color-text-default"
                   >
                     <a
-                      class="box mm-text mm-button-base mm-button-link mm-button-link--size-auto mm-text--body-md box--display-inline-flex box--flex-direction-row box--justify-content-center box--align-items-center box--color-primary-default box--background-color-transparent"
+                      class="box mm-text mm-button-base mm-button-link mm-button-link--size-auto mm-text--body-md box--padding-right-0 box--padding-left-0 box--display-inline-flex box--flex-direction-row box--justify-content-center box--align-items-center box--color-primary-default box--background-color-transparent"
                       href="https://etherscan.io/address/0xaD6D458402F60fD3Bd25163575031ACDce07538D"
                       rel="noopener noreferrer"
                       target="_blank"

--- a/ui/components/multichain/account-list-item/__snapshots__/account-list-item.test.js.snap
+++ b/ui/components/multichain/account-list-item/__snapshots__/account-list-item.test.js.snap
@@ -61,7 +61,7 @@ exports[`AccountListItem renders AccountListItem component and shows account nam
             class="box mm-text multichain-account-list-item__account-name mm-text--body-md mm-text--ellipsis box--margin-inline-end-2 box--flex-direction-row box--color-text-default"
           >
             <button
-              class="box mm-text mm-button-base mm-button-base--ellipsis multichain-account-list-item__account-name__button mm-button-link mm-button-link--size-auto mm-text--body-md mm-text--ellipsis box--display-inline-flex box--flex-direction-row box--justify-content-center box--align-items-center box--color-text-default box--background-color-transparent"
+              class="box mm-text mm-button-base mm-button-base--ellipsis multichain-account-list-item__account-name__button mm-button-link mm-button-link--size-auto mm-text--body-md mm-text--ellipsis box--padding-right-0 box--padding-left-0 box--display-inline-flex box--flex-direction-row box--justify-content-center box--align-items-center box--color-text-default box--background-color-transparent"
             >
               <span
                 class="box mm-text mm-text--inherit mm-text--ellipsis box--flex-direction-row box--color-text-default"

--- a/ui/components/multichain/detected-token-banner/__snapshots__/detected-token-banner.test.js.snap
+++ b/ui/components/multichain/detected-token-banner/__snapshots__/detected-token-banner.test.js.snap
@@ -17,7 +17,7 @@ exports[`DetectedTokensBanner should render correctly 1`] = `
         3 new tokens found in this account
       </p>
       <button
-        class="box mm-text mm-button-base mm-button-link mm-button-link--size-auto mm-text--body-md box--display-inline-flex box--flex-direction-row box--justify-content-center box--align-items-center box--color-primary-default box--background-color-transparent"
+        class="box mm-text mm-button-base mm-button-link mm-button-link--size-auto mm-text--body-md box--padding-right-0 box--padding-left-0 box--display-inline-flex box--flex-direction-row box--justify-content-center box--align-items-center box--color-primary-default box--background-color-transparent"
       >
         Import tokens
       </button>

--- a/ui/components/multichain/multichain-import-token-link/__snapshots__/multichain-import-token-link.test.js.snap
+++ b/ui/components/multichain/multichain-import-token-link/__snapshots__/multichain-import-token-link.test.js.snap
@@ -9,7 +9,7 @@ exports[`Import Token Link should match snapshot for goerli chainId 1`] = `
       class="box box--display-flex box--flex-direction-row box--align-items-center"
     >
       <button
-        class="box mm-text mm-button-base mm-button-base--size-md mm-button-link mm-text--body-md box--display-inline-flex box--flex-direction-row box--justify-content-center box--align-items-center box--color-primary-default box--background-color-transparent"
+        class="box mm-text mm-button-base mm-button-base--size-md mm-button-link mm-text--body-md box--padding-right-0 box--padding-left-0 box--display-inline-flex box--flex-direction-row box--justify-content-center box--align-items-center box--color-primary-default box--background-color-transparent"
         data-testid="import-token-button"
       >
         <span
@@ -23,7 +23,7 @@ exports[`Import Token Link should match snapshot for goerli chainId 1`] = `
       class="box box--padding-top-4 box--padding-bottom-4 box--display-flex box--flex-direction-row box--align-items-center"
     >
       <button
-        class="box mm-text mm-button-base mm-button-link mm-button-link--size-auto mm-text--body-md box--display-inline-flex box--flex-direction-row box--justify-content-center box--align-items-center box--color-primary-default box--background-color-transparent"
+        class="box mm-text mm-button-base mm-button-link mm-button-link--size-auto mm-text--body-md box--padding-right-0 box--padding-left-0 box--display-inline-flex box--flex-direction-row box--justify-content-center box--align-items-center box--color-primary-default box--background-color-transparent"
         data-testid="refresh-list-button"
       >
         <span
@@ -46,7 +46,7 @@ exports[`Import Token Link should match snapshot for mainnet chainId 1`] = `
       class="box box--display-flex box--flex-direction-row box--align-items-center"
     >
       <button
-        class="box mm-text mm-button-base mm-button-base--size-md mm-button-link mm-text--body-md box--display-inline-flex box--flex-direction-row box--justify-content-center box--align-items-center box--color-primary-default box--background-color-transparent"
+        class="box mm-text mm-button-base mm-button-base--size-md mm-button-link mm-text--body-md box--padding-right-0 box--padding-left-0 box--display-inline-flex box--flex-direction-row box--justify-content-center box--align-items-center box--color-primary-default box--background-color-transparent"
         data-testid="import-token-button"
       >
         <span
@@ -60,7 +60,7 @@ exports[`Import Token Link should match snapshot for mainnet chainId 1`] = `
       class="box box--padding-top-4 box--padding-bottom-4 box--display-flex box--flex-direction-row box--align-items-center"
     >
       <button
-        class="box mm-text mm-button-base mm-button-link mm-button-link--size-auto mm-text--body-md box--display-inline-flex box--flex-direction-row box--justify-content-center box--align-items-center box--color-primary-default box--background-color-transparent"
+        class="box mm-text mm-button-base mm-button-link mm-button-link--size-auto mm-text--body-md box--padding-right-0 box--padding-left-0 box--display-inline-flex box--flex-direction-row box--justify-content-center box--align-items-center box--color-primary-default box--background-color-transparent"
         data-testid="refresh-list-button"
       >
         <span

--- a/ui/components/multichain/network-list-item/__snapshots__/network-list-item.test.js.snap
+++ b/ui/components/multichain/network-list-item/__snapshots__/network-list-item.test.js.snap
@@ -18,7 +18,7 @@ exports[`NetworkListItem renders properly 1`] = `
       class="box multichain-network-list-item__network-name box--flex-direction-row"
     >
       <button
-        class="box mm-text mm-button-base mm-button-base--ellipsis mm-button-link mm-button-link--size-auto mm-text--body-md mm-text--ellipsis box--display-inline-flex box--flex-direction-row box--justify-content-center box--align-items-center box--color-text-default box--background-color-transparent"
+        class="box mm-text mm-button-base mm-button-base--ellipsis mm-button-link mm-button-link--size-auto mm-text--body-md mm-text--ellipsis box--padding-right-0 box--padding-left-0 box--display-inline-flex box--flex-direction-row box--justify-content-center box--align-items-center box--color-text-default box--background-color-transparent"
       >
         <span
           class="box mm-text mm-text--inherit mm-text--ellipsis box--flex-direction-row box--color-text-default"

--- a/ui/components/ui/box/box.js
+++ b/ui/components/ui/box/box.js
@@ -119,8 +119,8 @@ function isValidString(type, value) {
 
 const generateClassNames = memoize(
   (type, value, validatorFn) => {
-    // if value does not exist return null
-    if (!value) {
+    // if value does not exist return null, accepts 0 as a valid value
+    if (!value && typeof value !== 'number') {
       return null;
     }
     const classesObject = {};
@@ -134,7 +134,13 @@ const generateClassNames = memoize(
         ? value
         : undefined;
     // single digit equals single value or single array item
-    const singleValue = singleValueProp || singleArrayItemProp;
+    let singleValue;
+    if (singleValueProp || singleValueProp === 0) {
+      singleValue = singleValueProp;
+    }
+    if (singleArrayItemProp || singleArrayItemProp === 0) {
+      singleValue = singleArrayItemProp;
+    }
     // 0 is an acceptable value but is falsy in js
     if (singleValue || singleValue === 0) {
       // add base style without any breakpoint prefixes to classObject
@@ -148,35 +154,35 @@ const generateClassNames = memoize(
         case 4:
           // add base/sm/md/lg
           classesObject[`${BASE_CLASS_NAME}--${type}-${value[0]}`] =
-            value[0] && validatorFn(type, value[0]);
+            validatorFn(type, value[0]);
           classesObject[
             `${BASE_CLASS_NAME}--${BREAKPOINTS[1]}:${type}-${value[1]}`
-          ] = value[1] && validatorFn(type, value[1]);
+          ] = validatorFn(type, value[1]);
           classesObject[
             `${BASE_CLASS_NAME}--${BREAKPOINTS[2]}:${type}-${value[2]}`
-          ] = value[2] && validatorFn(type, value[2]);
+          ] = validatorFn(type, value[2]);
           classesObject[
             `${BASE_CLASS_NAME}--${BREAKPOINTS[3]}:${type}-${value[3]}`
-          ] = value[3] && validatorFn(type, value[3]);
+          ] = validatorFn(type, value[3]);
           break;
         case 3:
           // add base/sm/md
           classesObject[`${BASE_CLASS_NAME}--${type}-${value[0]}`] =
-            value[0] && validatorFn(type, value[0]);
+            validatorFn(type, value[0]);
           classesObject[
             `${BASE_CLASS_NAME}--${BREAKPOINTS[1]}:${type}-${value[1]}`
-          ] = value[1] && validatorFn(type, value[1]);
+          ] = validatorFn(type, value[1]);
           classesObject[
             `${BASE_CLASS_NAME}--${BREAKPOINTS[2]}:${type}-${value[2]}`
-          ] = value[2] && validatorFn(type, value[2]);
+          ] = validatorFn(type, value[2]);
           break;
         case 2:
           // add base/sm
           classesObject[`${BASE_CLASS_NAME}--${type}-${value[0]}`] =
-            value[0] && validatorFn(type, value[0]);
+            validatorFn(type, value[0]);
           classesObject[
             `${BASE_CLASS_NAME}--${BREAKPOINTS[1]}:${type}-${value[1]}`
-          ] = value[1] && validatorFn(type, value[1]);
+          ] = validatorFn(type, value[1]);
           break;
         default:
           console.log(`Invalid array prop length: ${value.length}`);
@@ -232,56 +238,38 @@ const Box = React.forwardRef(function Box(
     BASE_CLASS_NAME,
     className,
     // Margin
-    margin && generateClassNames('margin', margin, isValidSize),
-    marginTop && generateClassNames('margin-top', marginTop, isValidSize),
-    marginRight && generateClassNames('margin-right', marginRight, isValidSize),
-    marginBottom &&
-      generateClassNames('margin-bottom', marginBottom, isValidSize),
-    marginLeft && generateClassNames('margin-left', marginLeft, isValidSize),
-    marginInline &&
-      generateClassNames('margin-inline', marginInline, isValidSize),
-    marginInlineStart &&
-      generateClassNames('margin-inline-start', marginInlineStart, isValidSize),
-    marginInlineEnd &&
-      generateClassNames('margin-inline-end', marginInlineEnd, isValidSize),
+    generateClassNames('margin', margin, isValidSize),
+    generateClassNames('margin-top', marginTop, isValidSize),
+    generateClassNames('margin-right', marginRight, isValidSize),
+    generateClassNames('margin-bottom', marginBottom, isValidSize),
+    generateClassNames('margin-left', marginLeft, isValidSize),
+    generateClassNames('margin-inline', marginInline, isValidSize),
+    generateClassNames('margin-inline-start', marginInlineStart, isValidSize),
+    generateClassNames('margin-inline-end', marginInlineEnd, isValidSize),
     // Padding
-    padding && generateClassNames('padding', padding, isValidSize),
-    paddingTop && generateClassNames('padding-top', paddingTop, isValidSize),
-    paddingRight &&
-      generateClassNames('padding-right', paddingRight, isValidSize),
-    paddingBottom &&
-      generateClassNames('padding-bottom', paddingBottom, isValidSize),
-    paddingLeft && generateClassNames('padding-left', paddingLeft, isValidSize),
-    paddingInline &&
-      generateClassNames('padding-inline', paddingInline, isValidSize),
-    paddingInlineStart &&
-      generateClassNames(
-        'padding-inline-start',
-        paddingInlineStart,
-        isValidSize,
-      ),
-    paddingInlineEnd &&
-      generateClassNames('padding-inline-end', paddingInlineEnd, isValidSize),
-    display && generateClassNames('display', display, isValidString),
-    gap && generateClassNames('gap', gap, isValidSize),
-    flexDirection &&
-      generateClassNames('flex-direction', flexDirection, isValidString),
-    flexWrap && generateClassNames('flex-wrap', flexWrap, isValidString),
-    justifyContent &&
-      generateClassNames('justify-content', justifyContent, isValidString),
-    alignItems && generateClassNames('align-items', alignItems, isValidString),
-    textAlign && generateClassNames('text-align', textAlign, isValidString),
-    width && generateClassNames('width', width, isValidString),
-    height && generateClassNames('height', height, isValidString),
-    color && generateClassNames('color', color, isValidString),
-    backgroundColor &&
-      generateClassNames('background-color', backgroundColor, isValidString),
-    borderRadius && generateClassNames('rounded', borderRadius, isValidString),
-    borderStyle &&
-      generateClassNames('border-style', borderStyle, isValidString),
-    borderColor &&
-      generateClassNames('border-color', borderColor, isValidString),
-    borderWidth && generateClassNames('border-width', borderWidth, isValidSize),
+    generateClassNames('padding', padding, isValidSize),
+    generateClassNames('padding-top', paddingTop, isValidSize),
+    generateClassNames('padding-right', paddingRight, isValidSize),
+    generateClassNames('padding-bottom', paddingBottom, isValidSize),
+    generateClassNames('padding-left', paddingLeft, isValidSize),
+    generateClassNames('padding-inline', paddingInline, isValidSize),
+    generateClassNames('padding-inline-start', paddingInlineStart, isValidSize),
+    generateClassNames('padding-inline-end', paddingInlineEnd, isValidSize),
+    generateClassNames('display', display, isValidString),
+    generateClassNames('gap', gap, isValidSize),
+    generateClassNames('flex-direction', flexDirection, isValidString),
+    generateClassNames('flex-wrap', flexWrap, isValidString),
+    generateClassNames('justify-content', justifyContent, isValidString),
+    generateClassNames('align-items', alignItems, isValidString),
+    generateClassNames('text-align', textAlign, isValidString),
+    generateClassNames('width', width, isValidString),
+    generateClassNames('height', height, isValidString),
+    generateClassNames('color', color, isValidString),
+    generateClassNames('background-color', backgroundColor, isValidString),
+    generateClassNames('rounded', borderRadius, isValidString),
+    generateClassNames('border-style', borderStyle, isValidString),
+    generateClassNames('border-color', borderColor, isValidString),
+    generateClassNames('border-width', borderWidth, isValidSize),
     {
       // Auto applied classes
       // ---Borders---

--- a/ui/components/ui/box/box.stories.tsx
+++ b/ui/components/ui/box/box.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ComponentStory, ComponentMeta } from '@storybook/react';
+import { StoryFn, Meta } from '@storybook/react';
 
 import {
   BlockSize,
@@ -215,11 +215,9 @@ export default {
       table: { category: 'as (root html element)' },
     },
   },
-} as ComponentMeta<typeof Box>;
+} as Meta<typeof Box>;
 
-export const DefaultStory: ComponentStory<typeof Box> = (args) => (
-  <Box {...args} />
-);
+export const DefaultStory: StoryFn<typeof Box> = (args) => <Box {...args} />;
 
 DefaultStory.args = {
   children: 'Box component',
@@ -234,7 +232,7 @@ DefaultStory.args = {
 
 DefaultStory.storyName = 'Default';
 
-export const Margin: ComponentStory<typeof Box> = (args) => {
+export const Margin: StoryFn<typeof Box> = (args) => {
   return (
     <Box borderColor={BorderColor.borderMuted}>
       <Box
@@ -259,7 +257,7 @@ export const Margin: ComponentStory<typeof Box> = (args) => {
   );
 };
 
-export const Padding: ComponentStory<typeof Box> = (args) => {
+export const Padding: StoryFn<typeof Box> = (args) => {
   return (
     <Box borderColor={BorderColor.borderMuted}>
       <Box
@@ -282,7 +280,7 @@ export const Padding: ComponentStory<typeof Box> = (args) => {
   );
 };
 
-export const ColorStory: ComponentStory<typeof Box> = (args) => {
+export const ColorStory: StoryFn<typeof Box> = (args) => {
   return (
     <>
       <Box {...args} padding={3} color={TextColor.textDefault}>
@@ -667,11 +665,56 @@ export const ResponsiveProps = () => {
           Responsive Border Radius 2
         </Box>
       </Box>
+      <Text marginBottom={4} marginTop={4}>
+        Boxes below are only visible on certain screen sizes
+      </Text>
+      <Box
+        padding={4}
+        display={[Display.Block, Display.None]}
+        backgroundColor={BackgroundColor.infoMuted}
+      >
+        This box is only visible on screens 0px - 575px
+      </Box>
+      <Box
+        padding={4}
+        display={[Display.Block, null, Display.None]}
+        backgroundColor={BackgroundColor.warningMuted}
+      >
+        This box is only visible on screens 0px - 767px
+      </Box>
+      <Box
+        padding={4}
+        display={[Display.Block, null, null, Display.None]}
+        backgroundColor={BackgroundColor.errorMuted}
+      >
+        This box is only visible on screens 0px - 1279px
+      </Box>
+      <Box
+        padding={4}
+        display={[Display.None, null, null, Display.Block]}
+        backgroundColor={BackgroundColor.successMuted}
+      >
+        This box is only visible on screens 1280px and above
+      </Box>
+      <Box
+        padding={4}
+        display={[Display.None, null, Display.Block]}
+        backgroundColor={BackgroundColor.backgroundAlternative}
+      >
+        This box is only visible on screens 768px and above
+      </Box>
+      <Box
+        padding={4}
+        display={[Display.None, Display.Block]}
+        borderColor={BorderColor.borderDefault}
+      >
+        This box is only visible on screens 576px and above
+      </Box>
     </>
   );
 };
 
-export const As: ComponentStory<typeof Box> = (args) => {
+export const As: StoryFn<typeof Box> = (args) => {
   return (
     <>
       <Text marginBottom={4}>
@@ -687,7 +730,7 @@ export const As: ComponentStory<typeof Box> = (args) => {
   );
 };
 
-export const Width: ComponentStory<typeof Box> = () => {
+export const Width: StoryFn<typeof Box> = () => {
   const getColumns = (): JSX.Element[] => {
     const content: JSX.Element[] = [];
     for (let i = 0; i < 12; i++) {
@@ -932,13 +975,4 @@ export const Width: ComponentStory<typeof Box> = () => {
       </Box>
     </>
   );
-};
-
-Width.args = {
-  width: [
-    BlockSize.Half,
-    BlockSize.OneFifth,
-    BlockSize.ThreeFourths,
-    BlockSize.OneFourth,
-  ],
 };

--- a/ui/components/ui/box/box.test.tsx
+++ b/ui/components/ui/box/box.test.tsx
@@ -28,97 +28,543 @@ describe('Box', () => {
     expect(getByText('Box content')).toBeDefined();
   });
   describe('margin', () => {
-    it('should render the Box with the margin class', () => {
-      const { getByText } = render(<Box margin={1}>Box content</Box>);
+    it('should render the Box with the margin classes', () => {
+      const { getByText } = render(
+        <>
+          <Box margin={0}>Box margin 0</Box>
+          <Box margin={1}>Box margin 1</Box>
+          <Box margin={2}>Box margin 2</Box>
+          <Box margin={3}>Box margin 3</Box>
+          <Box margin={4}>Box margin 4</Box>
+          <Box margin={5}>Box margin 5</Box>
+          <Box margin={6}>Box margin 6</Box>
+          <Box margin={7}>Box margin 7</Box>
+          <Box margin={8}>Box margin 8</Box>
+          <Box margin={9}>Box margin 9</Box>
+          <Box margin={10}>Box margin 10</Box>
+          <Box margin={11}>Box margin 11</Box>
+          <Box margin={12}>Box margin 12</Box>
+          <Box margin="auto">Box margin auto</Box>
+        </>,
+      );
 
-      expect(getByText('Box content')).toHaveClass('box--margin-1');
-    });
-    it('should render the Box with the margin auto class', () => {
-      const { getByText } = render(<Box margin="auto">Box content</Box>);
-
-      expect(getByText('Box content')).toHaveClass('box--margin-auto');
+      expect(getByText('Box margin 0')).toHaveClass('box--margin-0');
+      expect(getByText('Box margin 1')).toHaveClass('box--margin-1');
+      expect(getByText('Box margin 2')).toHaveClass('box--margin-2');
+      expect(getByText('Box margin 3')).toHaveClass('box--margin-3');
+      expect(getByText('Box margin 4')).toHaveClass('box--margin-4');
+      expect(getByText('Box margin 5')).toHaveClass('box--margin-5');
+      expect(getByText('Box margin 6')).toHaveClass('box--margin-6');
+      expect(getByText('Box margin 7')).toHaveClass('box--margin-7');
+      expect(getByText('Box margin 8')).toHaveClass('box--margin-8');
+      expect(getByText('Box margin 9')).toHaveClass('box--margin-9');
+      expect(getByText('Box margin 10')).toHaveClass('box--margin-10');
+      expect(getByText('Box margin 11')).toHaveClass('box--margin-11');
+      expect(getByText('Box margin 12')).toHaveClass('box--margin-12');
+      expect(getByText('Box margin auto')).toHaveClass('box--margin-auto');
     });
     it('should render the Box with the responsive margin classes', () => {
       const { getByText } = render(
-        <Box margin={[1, 'auto', 3, 4]}>Box content</Box>,
+        <>
+          <Box margin={[0, 0, 0, 0]}>Box margin 0</Box>
+          <Box margin={[1, 1, 1, 1]}>Box margin 1</Box>
+          <Box margin={[2, 2, 2, 2]}>Box margin 2</Box>
+          <Box margin={[3, 3, 3, 3]}>Box margin 3</Box>
+          <Box margin={[4, 4, 4, 4]}>Box margin 4</Box>
+          <Box margin={[5, 5, 5, 5]}>Box margin 5</Box>
+          <Box margin={[6, 6, 6, 6]}>Box margin 6</Box>
+          <Box margin={[7, 7, 7, 7]}>Box margin 7</Box>
+          <Box margin={[8, 8, 8, 8]}>Box margin 8</Box>
+          <Box margin={[9, 9, 9, 9]}>Box margin 9</Box>
+          <Box margin={[10, 10, 10, 10]}>Box margin 10</Box>
+          <Box margin={[11, 11, 11, 11]}>Box margin 11</Box>
+          <Box margin={[12, 12, 12, 12]}>Box margin 12</Box>
+          <Box margin={['auto', 'auto', 'auto', 'auto']}>Box margin auto</Box>
+        </>,
+      );
+      expect(getByText('Box margin 0')).toHaveClass(
+        'box--margin-0 box--sm:margin-0 box--md:margin-0 box--lg:margin-0',
+      );
+      expect(getByText('Box margin 1')).toHaveClass(
+        'box--margin-1 box--sm:margin-1 box--md:margin-1 box--lg:margin-1',
+      );
+      expect(getByText('Box margin 2')).toHaveClass(
+        'box--margin-2 box--sm:margin-2 box--md:margin-2 box--lg:margin-2',
+      );
+      expect(getByText('Box margin 3')).toHaveClass(
+        'box--margin-3 box--sm:margin-3 box--md:margin-3 box--lg:margin-3',
+      );
+      expect(getByText('Box margin 4')).toHaveClass(
+        'box--margin-4 box--sm:margin-4 box--md:margin-4 box--lg:margin-4',
+      );
+      expect(getByText('Box margin 5')).toHaveClass(
+        'box--margin-5 box--sm:margin-5 box--md:margin-5 box--lg:margin-5',
+      );
+      expect(getByText('Box margin 6')).toHaveClass(
+        'box--margin-6 box--sm:margin-6 box--md:margin-6 box--lg:margin-6',
+      );
+      expect(getByText('Box margin 7')).toHaveClass(
+        'box--margin-7 box--sm:margin-7 box--md:margin-7 box--lg:margin-7',
+      );
+      expect(getByText('Box margin 8')).toHaveClass(
+        'box--margin-8 box--sm:margin-8 box--md:margin-8 box--lg:margin-8',
+      );
+      expect(getByText('Box margin 9')).toHaveClass(
+        'box--margin-9 box--sm:margin-9 box--md:margin-9 box--lg:margin-9',
+      );
+      expect(getByText('Box margin 10')).toHaveClass(
+        'box--margin-10 box--sm:margin-10 box--md:margin-10 box--lg:margin-10',
+      );
+      expect(getByText('Box margin 11')).toHaveClass(
+        'box--margin-11 box--sm:margin-11 box--md:margin-11 box--lg:margin-11',
+      );
+      expect(getByText('Box margin 12')).toHaveClass(
+        'box--margin-12 box--sm:margin-12 box--md:margin-12 box--lg:margin-12',
       );
 
-      expect(getByText('Box content')).toHaveClass('box--margin-1');
-      expect(getByText('Box content')).toHaveClass('box--sm:margin-auto');
-      expect(getByText('Box content')).toHaveClass('box--md:margin-3');
-      expect(getByText('Box content')).toHaveClass('box--lg:margin-4');
+      expect(getByText('Box margin auto')).toHaveClass(
+        'box--margin-auto box--sm:margin-auto box--md:margin-auto box--lg:margin-auto',
+      );
     });
-    it('should render the Box with the marginTop class', () => {
-      const { getByText } = render(<Box marginTop={1}>Box content</Box>);
+    it('should render the Box with the marginTop classes', () => {
+      const { getByText } = render(
+        <>
+          <Box marginTop={0}>Box marginTop 0</Box>
+          <Box marginTop={1}>Box marginTop 1</Box>
+          <Box marginTop={2}>Box marginTop 2</Box>
+          <Box marginTop={3}>Box marginTop 3</Box>
+          <Box marginTop={4}>Box marginTop 4</Box>
+          <Box marginTop={5}>Box marginTop 5</Box>
+          <Box marginTop={6}>Box marginTop 6</Box>
+          <Box marginTop={7}>Box marginTop 7</Box>
+          <Box marginTop={8}>Box marginTop 8</Box>
+          <Box marginTop={9}>Box marginTop 9</Box>
+          <Box marginTop={10}>Box marginTop 10</Box>
+          <Box marginTop={11}>Box marginTop 11</Box>
+          <Box marginTop={12}>Box marginTop 12</Box>
+          <Box marginTop="auto">Box marginTop auto</Box>
+        </>,
+      );
 
-      expect(getByText('Box content')).toHaveClass('box--margin-top-1');
-    });
-    it('should render the Box with the marginTop auto class', () => {
-      const { getByText } = render(<Box marginTop="auto">Box content</Box>);
-
-      expect(getByText('Box content')).toHaveClass('box--margin-top-auto');
+      expect(getByText('Box marginTop 0')).toHaveClass('box--margin-top-0');
+      expect(getByText('Box marginTop 1')).toHaveClass('box--margin-top-1');
+      expect(getByText('Box marginTop 2')).toHaveClass('box--margin-top-2');
+      expect(getByText('Box marginTop 3')).toHaveClass('box--margin-top-3');
+      expect(getByText('Box marginTop 4')).toHaveClass('box--margin-top-4');
+      expect(getByText('Box marginTop 5')).toHaveClass('box--margin-top-5');
+      expect(getByText('Box marginTop 6')).toHaveClass('box--margin-top-6');
+      expect(getByText('Box marginTop 7')).toHaveClass('box--margin-top-7');
+      expect(getByText('Box marginTop 8')).toHaveClass('box--margin-top-8');
+      expect(getByText('Box marginTop 9')).toHaveClass('box--margin-top-9');
+      expect(getByText('Box marginTop 10')).toHaveClass('box--margin-top-10');
+      expect(getByText('Box marginTop 11')).toHaveClass('box--margin-top-11');
+      expect(getByText('Box marginTop 12')).toHaveClass('box--margin-top-12');
+      expect(getByText('Box marginTop auto')).toHaveClass(
+        'box--margin-top-auto',
+      );
     });
     it('should render the Box with the responsive marginTop classes', () => {
       const { getByText } = render(
-        <Box marginTop={[1, 'auto', 3, 4]}>Box content</Box>,
+        <>
+          <Box marginTop={[0, 0, 0, 0]}>Box marginTop 0</Box>
+          <Box marginTop={[1, 1, 1, 1]}>Box marginTop 1</Box>
+          <Box marginTop={[2, 2, 2, 2]}>Box marginTop 2</Box>
+          <Box marginTop={[3, 3, 3, 3]}>Box marginTop 3</Box>
+          <Box marginTop={[4, 4, 4, 4]}>Box marginTop 4</Box>
+          <Box marginTop={[5, 5, 5, 5]}>Box marginTop 5</Box>
+          <Box marginTop={[6, 6, 6, 6]}>Box marginTop 6</Box>
+          <Box marginTop={[7, 7, 7, 7]}>Box marginTop 7</Box>
+          <Box marginTop={[8, 8, 8, 8]}>Box marginTop 8</Box>
+          <Box marginTop={[9, 9, 9, 9]}>Box marginTop 9</Box>
+          <Box marginTop={[10, 10, 10, 10]}>Box marginTop 10</Box>
+          <Box marginTop={[11, 11, 11, 11]}>Box marginTop 11</Box>
+          <Box marginTop={[12, 12, 12, 12]}>Box marginTop 12</Box>
+          <Box marginTop={['auto', 'auto', 'auto', 'auto']}>
+            Box marginTop auto
+          </Box>
+        </>,
+      );
+      expect(getByText('Box marginTop 0')).toHaveClass(
+        'box--margin-top-0 box--sm:margin-top-0 box--md:margin-top-0 box--lg:margin-top-0',
+      );
+      expect(getByText('Box marginTop 1')).toHaveClass(
+        'box--margin-top-1 box--sm:margin-top-1 box--md:margin-top-1 box--lg:margin-top-1',
+      );
+      expect(getByText('Box marginTop 2')).toHaveClass(
+        'box--margin-top-2 box--sm:margin-top-2 box--md:margin-top-2 box--lg:margin-top-2',
+      );
+      expect(getByText('Box marginTop 3')).toHaveClass(
+        'box--margin-top-3 box--sm:margin-top-3 box--md:margin-top-3 box--lg:margin-top-3',
+      );
+      expect(getByText('Box marginTop 4')).toHaveClass(
+        'box--margin-top-4 box--sm:margin-top-4 box--md:margin-top-4 box--lg:margin-top-4',
+      );
+      expect(getByText('Box marginTop 5')).toHaveClass(
+        'box--margin-top-5 box--sm:margin-top-5 box--md:margin-top-5 box--lg:margin-top-5',
+      );
+      expect(getByText('Box marginTop 6')).toHaveClass(
+        'box--margin-top-6 box--sm:margin-top-6 box--md:margin-top-6 box--lg:margin-top-6',
+      );
+      expect(getByText('Box marginTop 7')).toHaveClass(
+        'box--margin-top-7 box--sm:margin-top-7 box--md:margin-top-7 box--lg:margin-top-7',
+      );
+      expect(getByText('Box marginTop 8')).toHaveClass(
+        'box--margin-top-8 box--sm:margin-top-8 box--md:margin-top-8 box--lg:margin-top-8',
+      );
+      expect(getByText('Box marginTop 9')).toHaveClass(
+        'box--margin-top-9 box--sm:margin-top-9 box--md:margin-top-9 box--lg:margin-top-9',
+      );
+      expect(getByText('Box marginTop 10')).toHaveClass(
+        'box--margin-top-10 box--sm:margin-top-10 box--md:margin-top-10 box--lg:margin-top-10',
+      );
+      expect(getByText('Box marginTop 11')).toHaveClass(
+        'box--margin-top-11 box--sm:margin-top-11 box--md:margin-top-11 box--lg:margin-top-11',
+      );
+      expect(getByText('Box marginTop 12')).toHaveClass(
+        'box--margin-top-12 box--sm:margin-top-12 box--md:margin-top-12 box--lg:margin-top-12',
       );
 
-      expect(getByText('Box content')).toHaveClass('box--margin-top-1');
-      expect(getByText('Box content')).toHaveClass('box--sm:margin-top-auto');
-      expect(getByText('Box content')).toHaveClass('box--md:margin-top-3');
-      expect(getByText('Box content')).toHaveClass('box--lg:margin-top-4');
+      expect(getByText('Box marginTop auto')).toHaveClass(
+        'box--margin-top-auto box--sm:margin-top-auto box--md:margin-top-auto box--lg:margin-top-auto',
+      );
     });
-    it('should render the Box with the marginRight class', () => {
-      const { getByText } = render(<Box marginRight={1}>Box content</Box>);
+    it('should render the Box with the marginRight classes', () => {
+      const { getByText } = render(
+        <>
+          <Box marginRight={0}>Box marginRight 0</Box>
+          <Box marginRight={1}>Box marginRight 1</Box>
+          <Box marginRight={2}>Box marginRight 2</Box>
+          <Box marginRight={3}>Box marginRight 3</Box>
+          <Box marginRight={4}>Box marginRight 4</Box>
+          <Box marginRight={5}>Box marginRight 5</Box>
+          <Box marginRight={6}>Box marginRight 6</Box>
+          <Box marginRight={7}>Box marginRight 7</Box>
+          <Box marginRight={8}>Box marginRight 8</Box>
+          <Box marginRight={9}>Box marginRight 9</Box>
+          <Box marginRight={10}>Box marginRight 10</Box>
+          <Box marginRight={11}>Box marginRight 11</Box>
+          <Box marginRight={12}>Box marginRight 12</Box>
+          <Box marginRight="auto">Box marginRight auto</Box>
+        </>,
+      );
 
-      expect(getByText('Box content')).toHaveClass('box--margin-right-1');
-    });
-    it('should render the Box with the marginRight auto class', () => {
-      const { getByText } = render(<Box marginRight="auto">Box content</Box>);
-
-      expect(getByText('Box content')).toHaveClass('box--margin-right-auto');
+      expect(getByText('Box marginRight 0')).toHaveClass('box--margin-right-0');
+      expect(getByText('Box marginRight 1')).toHaveClass('box--margin-right-1');
+      expect(getByText('Box marginRight 2')).toHaveClass('box--margin-right-2');
+      expect(getByText('Box marginRight 3')).toHaveClass('box--margin-right-3');
+      expect(getByText('Box marginRight 4')).toHaveClass('box--margin-right-4');
+      expect(getByText('Box marginRight 5')).toHaveClass('box--margin-right-5');
+      expect(getByText('Box marginRight 6')).toHaveClass('box--margin-right-6');
+      expect(getByText('Box marginRight 7')).toHaveClass('box--margin-right-7');
+      expect(getByText('Box marginRight 8')).toHaveClass('box--margin-right-8');
+      expect(getByText('Box marginRight 9')).toHaveClass('box--margin-right-9');
+      expect(getByText('Box marginRight 10')).toHaveClass(
+        'box--margin-right-10',
+      );
+      expect(getByText('Box marginRight 11')).toHaveClass(
+        'box--margin-right-11',
+      );
+      expect(getByText('Box marginRight 12')).toHaveClass(
+        'box--margin-right-12',
+      );
+      expect(getByText('Box marginRight auto')).toHaveClass(
+        'box--margin-right-auto',
+      );
     });
     it('should render the Box with the responsive marginRight classes', () => {
       const { getByText } = render(
-        <Box marginRight={[1, 'auto', 3, 4]}>Box content</Box>,
+        <>
+          <Box marginRight={[0, 0, 0, 0]}>Box marginRight 0</Box>
+          <Box marginRight={[1, 1, 1, 1]}>Box marginRight 1</Box>
+          <Box marginRight={[2, 2, 2, 2]}>Box marginRight 2</Box>
+          <Box marginRight={[3, 3, 3, 3]}>Box marginRight 3</Box>
+          <Box marginRight={[4, 4, 4, 4]}>Box marginRight 4</Box>
+          <Box marginRight={[5, 5, 5, 5]}>Box marginRight 5</Box>
+          <Box marginRight={[6, 6, 6, 6]}>Box marginRight 6</Box>
+          <Box marginRight={[7, 7, 7, 7]}>Box marginRight 7</Box>
+          <Box marginRight={[8, 8, 8, 8]}>Box marginRight 8</Box>
+          <Box marginRight={[9, 9, 9, 9]}>Box marginRight 9</Box>
+          <Box marginRight={[10, 10, 10, 10]}>Box marginRight 10</Box>
+          <Box marginRight={[11, 11, 11, 11]}>Box marginRight 11</Box>
+          <Box marginRight={[12, 12, 12, 12]}>Box marginRight 12</Box>
+          <Box marginRight={['auto', 'auto', 'auto', 'auto']}>
+            Box marginRight auto
+          </Box>
+        </>,
+      );
+      expect(getByText('Box marginRight 0')).toHaveClass(
+        'box--margin-right-0 box--sm:margin-right-0 box--md:margin-right-0 box--lg:margin-right-0',
+      );
+      expect(getByText('Box marginRight 1')).toHaveClass(
+        'box--margin-right-1 box--sm:margin-right-1 box--md:margin-right-1 box--lg:margin-right-1',
+      );
+      expect(getByText('Box marginRight 2')).toHaveClass(
+        'box--margin-right-2 box--sm:margin-right-2 box--md:margin-right-2 box--lg:margin-right-2',
+      );
+      expect(getByText('Box marginRight 3')).toHaveClass(
+        'box--margin-right-3 box--sm:margin-right-3 box--md:margin-right-3 box--lg:margin-right-3',
+      );
+      expect(getByText('Box marginRight 4')).toHaveClass(
+        'box--margin-right-4 box--sm:margin-right-4 box--md:margin-right-4 box--lg:margin-right-4',
+      );
+      expect(getByText('Box marginRight 5')).toHaveClass(
+        'box--margin-right-5 box--sm:margin-right-5 box--md:margin-right-5 box--lg:margin-right-5',
+      );
+      expect(getByText('Box marginRight 6')).toHaveClass(
+        'box--margin-right-6 box--sm:margin-right-6 box--md:margin-right-6 box--lg:margin-right-6',
+      );
+      expect(getByText('Box marginRight 7')).toHaveClass(
+        'box--margin-right-7 box--sm:margin-right-7 box--md:margin-right-7 box--lg:margin-right-7',
+      );
+      expect(getByText('Box marginRight 8')).toHaveClass(
+        'box--margin-right-8 box--sm:margin-right-8 box--md:margin-right-8 box--lg:margin-right-8',
+      );
+      expect(getByText('Box marginRight 9')).toHaveClass(
+        'box--margin-right-9 box--sm:margin-right-9 box--md:margin-right-9 box--lg:margin-right-9',
+      );
+      expect(getByText('Box marginRight 10')).toHaveClass(
+        'box--margin-right-10 box--sm:margin-right-10 box--md:margin-right-10 box--lg:margin-right-10',
+      );
+      expect(getByText('Box marginRight 11')).toHaveClass(
+        'box--margin-right-11 box--sm:margin-right-11 box--md:margin-right-11 box--lg:margin-right-11',
+      );
+      expect(getByText('Box marginRight 12')).toHaveClass(
+        'box--margin-right-12 box--sm:margin-right-12 box--md:margin-right-12 box--lg:margin-right-12',
       );
 
-      expect(getByText('Box content')).toHaveClass('box--margin-right-1');
-      expect(getByText('Box content')).toHaveClass('box--sm:margin-right-auto');
-      expect(getByText('Box content')).toHaveClass('box--md:margin-right-3');
-      expect(getByText('Box content')).toHaveClass('box--lg:margin-right-4');
+      expect(getByText('Box marginRight auto')).toHaveClass(
+        'box--margin-right-auto box--sm:margin-right-auto box--md:margin-right-auto box--lg:margin-right-auto',
+      );
     });
-    it('should render the Box with the marginBottom class', () => {
-      const { getByText } = render(<Box marginBottom={1}>Box content</Box>);
+    it('should render the Box with the marginBottom classes', () => {
+      const { getByText } = render(
+        <>
+          <Box marginBottom={0}>Box marginBottom 0</Box>
+          <Box marginBottom={1}>Box marginBottom 1</Box>
+          <Box marginBottom={2}>Box marginBottom 2</Box>
+          <Box marginBottom={3}>Box marginBottom 3</Box>
+          <Box marginBottom={4}>Box marginBottom 4</Box>
+          <Box marginBottom={5}>Box marginBottom 5</Box>
+          <Box marginBottom={6}>Box marginBottom 6</Box>
+          <Box marginBottom={7}>Box marginBottom 7</Box>
+          <Box marginBottom={8}>Box marginBottom 8</Box>
+          <Box marginBottom={9}>Box marginBottom 9</Box>
+          <Box marginBottom={10}>Box marginBottom 10</Box>
+          <Box marginBottom={11}>Box marginBottom 11</Box>
+          <Box marginBottom={12}>Box marginBottom 12</Box>
+          <Box marginBottom="auto">Box marginBottom auto</Box>
+        </>,
+      );
 
-      expect(getByText('Box content')).toHaveClass('box--margin-bottom-1');
+      expect(getByText('Box marginBottom 0')).toHaveClass(
+        'box--margin-bottom-0',
+      );
+      expect(getByText('Box marginBottom 1')).toHaveClass(
+        'box--margin-bottom-1',
+      );
+      expect(getByText('Box marginBottom 2')).toHaveClass(
+        'box--margin-bottom-2',
+      );
+      expect(getByText('Box marginBottom 3')).toHaveClass(
+        'box--margin-bottom-3',
+      );
+      expect(getByText('Box marginBottom 4')).toHaveClass(
+        'box--margin-bottom-4',
+      );
+      expect(getByText('Box marginBottom 5')).toHaveClass(
+        'box--margin-bottom-5',
+      );
+      expect(getByText('Box marginBottom 6')).toHaveClass(
+        'box--margin-bottom-6',
+      );
+      expect(getByText('Box marginBottom 7')).toHaveClass(
+        'box--margin-bottom-7',
+      );
+      expect(getByText('Box marginBottom 8')).toHaveClass(
+        'box--margin-bottom-8',
+      );
+      expect(getByText('Box marginBottom 9')).toHaveClass(
+        'box--margin-bottom-9',
+      );
+      expect(getByText('Box marginBottom 10')).toHaveClass(
+        'box--margin-bottom-10',
+      );
+      expect(getByText('Box marginBottom 11')).toHaveClass(
+        'box--margin-bottom-11',
+      );
+      expect(getByText('Box marginBottom 12')).toHaveClass(
+        'box--margin-bottom-12',
+      );
+      expect(getByText('Box marginBottom auto')).toHaveClass(
+        'box--margin-bottom-auto',
+      );
     });
     it('should render the Box with the responsive marginBottom classes', () => {
       const { getByText } = render(
-        <Box marginBottom={[1, 'auto', 3, 4]}>Box content</Box>,
+        <>
+          <Box marginBottom={[0, 0, 0, 0]}>Box marginBottom 0</Box>
+          <Box marginBottom={[1, 1, 1, 1]}>Box marginBottom 1</Box>
+          <Box marginBottom={[2, 2, 2, 2]}>Box marginBottom 2</Box>
+          <Box marginBottom={[3, 3, 3, 3]}>Box marginBottom 3</Box>
+          <Box marginBottom={[4, 4, 4, 4]}>Box marginBottom 4</Box>
+          <Box marginBottom={[5, 5, 5, 5]}>Box marginBottom 5</Box>
+          <Box marginBottom={[6, 6, 6, 6]}>Box marginBottom 6</Box>
+          <Box marginBottom={[7, 7, 7, 7]}>Box marginBottom 7</Box>
+          <Box marginBottom={[8, 8, 8, 8]}>Box marginBottom 8</Box>
+          <Box marginBottom={[9, 9, 9, 9]}>Box marginBottom 9</Box>
+          <Box marginBottom={[10, 10, 10, 10]}>Box marginBottom 10</Box>
+          <Box marginBottom={[11, 11, 11, 11]}>Box marginBottom 11</Box>
+          <Box marginBottom={[12, 12, 12, 12]}>Box marginBottom 12</Box>
+          <Box marginBottom={['auto', 'auto', 'auto', 'auto']}>
+            Box marginBottom auto
+          </Box>
+        </>,
+      );
+      expect(getByText('Box marginBottom 0')).toHaveClass(
+        'box--margin-bottom-0 box--sm:margin-bottom-0 box--md:margin-bottom-0 box--lg:margin-bottom-0',
+      );
+      expect(getByText('Box marginBottom 1')).toHaveClass(
+        'box--margin-bottom-1 box--sm:margin-bottom-1 box--md:margin-bottom-1 box--lg:margin-bottom-1',
+      );
+      expect(getByText('Box marginBottom 2')).toHaveClass(
+        'box--margin-bottom-2 box--sm:margin-bottom-2 box--md:margin-bottom-2 box--lg:margin-bottom-2',
+      );
+      expect(getByText('Box marginBottom 3')).toHaveClass(
+        'box--margin-bottom-3 box--sm:margin-bottom-3 box--md:margin-bottom-3 box--lg:margin-bottom-3',
+      );
+      expect(getByText('Box marginBottom 4')).toHaveClass(
+        'box--margin-bottom-4 box--sm:margin-bottom-4 box--md:margin-bottom-4 box--lg:margin-bottom-4',
+      );
+      expect(getByText('Box marginBottom 5')).toHaveClass(
+        'box--margin-bottom-5 box--sm:margin-bottom-5 box--md:margin-bottom-5 box--lg:margin-bottom-5',
+      );
+      expect(getByText('Box marginBottom 6')).toHaveClass(
+        'box--margin-bottom-6 box--sm:margin-bottom-6 box--md:margin-bottom-6 box--lg:margin-bottom-6',
+      );
+      expect(getByText('Box marginBottom 7')).toHaveClass(
+        'box--margin-bottom-7 box--sm:margin-bottom-7 box--md:margin-bottom-7 box--lg:margin-bottom-7',
+      );
+      expect(getByText('Box marginBottom 8')).toHaveClass(
+        'box--margin-bottom-8 box--sm:margin-bottom-8 box--md:margin-bottom-8 box--lg:margin-bottom-8',
+      );
+      expect(getByText('Box marginBottom 9')).toHaveClass(
+        'box--margin-bottom-9 box--sm:margin-bottom-9 box--md:margin-bottom-9 box--lg:margin-bottom-9',
+      );
+      expect(getByText('Box marginBottom 10')).toHaveClass(
+        'box--margin-bottom-10 box--sm:margin-bottom-10 box--md:margin-bottom-10 box--lg:margin-bottom-10',
+      );
+      expect(getByText('Box marginBottom 11')).toHaveClass(
+        'box--margin-bottom-11 box--sm:margin-bottom-11 box--md:margin-bottom-11 box--lg:margin-bottom-11',
+      );
+      expect(getByText('Box marginBottom 12')).toHaveClass(
+        'box--margin-bottom-12 box--sm:margin-bottom-12 box--md:margin-bottom-12 box--lg:margin-bottom-12',
       );
 
-      expect(getByText('Box content')).toHaveClass('box--margin-bottom-1');
-      expect(getByText('Box content')).toHaveClass(
-        'box--sm:margin-bottom-auto',
+      expect(getByText('Box marginBottom auto')).toHaveClass(
+        'box--margin-bottom-auto box--sm:margin-bottom-auto box--md:margin-bottom-auto box--lg:margin-bottom-auto',
       );
-      expect(getByText('Box content')).toHaveClass('box--md:margin-bottom-3');
-      expect(getByText('Box content')).toHaveClass('box--lg:margin-bottom-4');
     });
-    it('should render the Box with the marginLeft class', () => {
-      const { getByText } = render(<Box marginLeft={1}>Box content</Box>);
+    it('should render the Box with the marginLeft classes', () => {
+      const { getByText } = render(
+        <>
+          <Box marginLeft={0}>Box marginLeft 0</Box>
+          <Box marginLeft={1}>Box marginLeft 1</Box>
+          <Box marginLeft={2}>Box marginLeft 2</Box>
+          <Box marginLeft={3}>Box marginLeft 3</Box>
+          <Box marginLeft={4}>Box marginLeft 4</Box>
+          <Box marginLeft={5}>Box marginLeft 5</Box>
+          <Box marginLeft={6}>Box marginLeft 6</Box>
+          <Box marginLeft={7}>Box marginLeft 7</Box>
+          <Box marginLeft={8}>Box marginLeft 8</Box>
+          <Box marginLeft={9}>Box marginLeft 9</Box>
+          <Box marginLeft={10}>Box marginLeft 10</Box>
+          <Box marginLeft={11}>Box marginLeft 11</Box>
+          <Box marginLeft={12}>Box marginLeft 12</Box>
+          <Box marginLeft="auto">Box marginLeft auto</Box>
+        </>,
+      );
 
-      expect(getByText('Box content')).toHaveClass('box--margin-left-1');
+      expect(getByText('Box marginLeft 0')).toHaveClass('box--margin-left-0');
+      expect(getByText('Box marginLeft 1')).toHaveClass('box--margin-left-1');
+      expect(getByText('Box marginLeft 2')).toHaveClass('box--margin-left-2');
+      expect(getByText('Box marginLeft 3')).toHaveClass('box--margin-left-3');
+      expect(getByText('Box marginLeft 4')).toHaveClass('box--margin-left-4');
+      expect(getByText('Box marginLeft 5')).toHaveClass('box--margin-left-5');
+      expect(getByText('Box marginLeft 6')).toHaveClass('box--margin-left-6');
+      expect(getByText('Box marginLeft 7')).toHaveClass('box--margin-left-7');
+      expect(getByText('Box marginLeft 8')).toHaveClass('box--margin-left-8');
+      expect(getByText('Box marginLeft 9')).toHaveClass('box--margin-left-9');
+      expect(getByText('Box marginLeft 10')).toHaveClass('box--margin-left-10');
+      expect(getByText('Box marginLeft 11')).toHaveClass('box--margin-left-11');
+      expect(getByText('Box marginLeft 12')).toHaveClass('box--margin-left-12');
+      expect(getByText('Box marginLeft auto')).toHaveClass(
+        'box--margin-left-auto',
+      );
     });
     it('should render the Box with the responsive marginLeft classes', () => {
       const { getByText } = render(
-        <Box marginLeft={[1, 'auto', 3, 4]}>Box content</Box>,
+        <>
+          <Box marginLeft={[0, 0, 0, 0]}>Box marginLeft 0</Box>
+          <Box marginLeft={[1, 1, 1, 1]}>Box marginLeft 1</Box>
+          <Box marginLeft={[2, 2, 2, 2]}>Box marginLeft 2</Box>
+          <Box marginLeft={[3, 3, 3, 3]}>Box marginLeft 3</Box>
+          <Box marginLeft={[4, 4, 4, 4]}>Box marginLeft 4</Box>
+          <Box marginLeft={[5, 5, 5, 5]}>Box marginLeft 5</Box>
+          <Box marginLeft={[6, 6, 6, 6]}>Box marginLeft 6</Box>
+          <Box marginLeft={[7, 7, 7, 7]}>Box marginLeft 7</Box>
+          <Box marginLeft={[8, 8, 8, 8]}>Box marginLeft 8</Box>
+          <Box marginLeft={[9, 9, 9, 9]}>Box marginLeft 9</Box>
+          <Box marginLeft={[10, 10, 10, 10]}>Box marginLeft 10</Box>
+          <Box marginLeft={[11, 11, 11, 11]}>Box marginLeft 11</Box>
+          <Box marginLeft={[12, 12, 12, 12]}>Box marginLeft 12</Box>
+          <Box marginLeft={['auto', 'auto', 'auto', 'auto']}>
+            Box marginLeft auto
+          </Box>
+        </>,
+      );
+      expect(getByText('Box marginLeft 0')).toHaveClass(
+        'box--margin-left-0 box--sm:margin-left-0 box--md:margin-left-0 box--lg:margin-left-0',
+      );
+      expect(getByText('Box marginLeft 1')).toHaveClass(
+        'box--margin-left-1 box--sm:margin-left-1 box--md:margin-left-1 box--lg:margin-left-1',
+      );
+      expect(getByText('Box marginLeft 2')).toHaveClass(
+        'box--margin-left-2 box--sm:margin-left-2 box--md:margin-left-2 box--lg:margin-left-2',
+      );
+      expect(getByText('Box marginLeft 3')).toHaveClass(
+        'box--margin-left-3 box--sm:margin-left-3 box--md:margin-left-3 box--lg:margin-left-3',
+      );
+      expect(getByText('Box marginLeft 4')).toHaveClass(
+        'box--margin-left-4 box--sm:margin-left-4 box--md:margin-left-4 box--lg:margin-left-4',
+      );
+      expect(getByText('Box marginLeft 5')).toHaveClass(
+        'box--margin-left-5 box--sm:margin-left-5 box--md:margin-left-5 box--lg:margin-left-5',
+      );
+      expect(getByText('Box marginLeft 6')).toHaveClass(
+        'box--margin-left-6 box--sm:margin-left-6 box--md:margin-left-6 box--lg:margin-left-6',
+      );
+      expect(getByText('Box marginLeft 7')).toHaveClass(
+        'box--margin-left-7 box--sm:margin-left-7 box--md:margin-left-7 box--lg:margin-left-7',
+      );
+      expect(getByText('Box marginLeft 8')).toHaveClass(
+        'box--margin-left-8 box--sm:margin-left-8 box--md:margin-left-8 box--lg:margin-left-8',
+      );
+      expect(getByText('Box marginLeft 9')).toHaveClass(
+        'box--margin-left-9 box--sm:margin-left-9 box--md:margin-left-9 box--lg:margin-left-9',
+      );
+      expect(getByText('Box marginLeft 10')).toHaveClass(
+        'box--margin-left-10 box--sm:margin-left-10 box--md:margin-left-10 box--lg:margin-left-10',
+      );
+      expect(getByText('Box marginLeft 11')).toHaveClass(
+        'box--margin-left-11 box--sm:margin-left-11 box--md:margin-left-11 box--lg:margin-left-11',
+      );
+      expect(getByText('Box marginLeft 12')).toHaveClass(
+        'box--margin-left-12 box--sm:margin-left-12 box--md:margin-left-12 box--lg:margin-left-12',
       );
 
-      expect(getByText('Box content')).toHaveClass('box--margin-left-1');
-      expect(getByText('Box content')).toHaveClass('box--sm:margin-left-auto');
-      expect(getByText('Box content')).toHaveClass('box--md:margin-left-3');
-      expect(getByText('Box content')).toHaveClass('box--lg:margin-left-4');
+      expect(getByText('Box marginLeft auto')).toHaveClass(
+        'box--margin-left-auto box--sm:margin-left-auto box--md:margin-left-auto box--lg:margin-left-auto',
+      );
     });
     it('should render the Box with the marginInline class', () => {
       const { getByText } = render(<Box marginInline={1}>Box content</Box>);
@@ -209,89 +655,519 @@ describe('Box', () => {
       );
     });
   });
-
   describe('padding', () => {
-    it('should render the Box with the padding class with singular value prop or one item array prop', () => {
+    it('should render the Box with the padding classes', () => {
       const { getByText } = render(
         <>
-          <Box padding={1}>Box content</Box>
-          <Box padding={[1]}>Box content one item array</Box>
+          <Box padding={0}>Box padding 0</Box>
+          <Box padding={1}>Box padding 1</Box>
+          <Box padding={2}>Box padding 2</Box>
+          <Box padding={3}>Box padding 3</Box>
+          <Box padding={4}>Box padding 4</Box>
+          <Box padding={5}>Box padding 5</Box>
+          <Box padding={6}>Box padding 6</Box>
+          <Box padding={7}>Box padding 7</Box>
+          <Box padding={8}>Box padding 8</Box>
+          <Box padding={9}>Box padding 9</Box>
+          <Box padding={10}>Box padding 10</Box>
+          <Box padding={11}>Box padding 11</Box>
+          <Box padding={12}>Box padding 12</Box>
         </>,
       );
-      expect(getByText('Box content')).toHaveClass('box--padding-1');
-      expect(getByText('Box content one item array')).toHaveClass(
-        'box--padding-1',
-      );
+
+      expect(getByText('Box padding 0')).toHaveClass('box--padding-0');
+      expect(getByText('Box padding 1')).toHaveClass('box--padding-1');
+      expect(getByText('Box padding 2')).toHaveClass('box--padding-2');
+      expect(getByText('Box padding 3')).toHaveClass('box--padding-3');
+      expect(getByText('Box padding 4')).toHaveClass('box--padding-4');
+      expect(getByText('Box padding 5')).toHaveClass('box--padding-5');
+      expect(getByText('Box padding 6')).toHaveClass('box--padding-6');
+      expect(getByText('Box padding 7')).toHaveClass('box--padding-7');
+      expect(getByText('Box padding 8')).toHaveClass('box--padding-8');
+      expect(getByText('Box padding 9')).toHaveClass('box--padding-9');
+      expect(getByText('Box padding 10')).toHaveClass('box--padding-10');
+      expect(getByText('Box padding 11')).toHaveClass('box--padding-11');
+      expect(getByText('Box padding 12')).toHaveClass('box--padding-12');
     });
     it('should render the Box with the responsive padding classes', () => {
       const { getByText } = render(
-        <Box padding={[1, 2, 3, 4]}>Box content</Box>,
+        <>
+          <Box padding={[0, 0, 0, 0]}>Box padding 0</Box>
+          <Box padding={[1, 1, 1, 1]}>Box padding 1</Box>
+          <Box padding={[2, 2, 2, 2]}>Box padding 2</Box>
+          <Box padding={[3, 3, 3, 3]}>Box padding 3</Box>
+          <Box padding={[4, 4, 4, 4]}>Box padding 4</Box>
+          <Box padding={[5, 5, 5, 5]}>Box padding 5</Box>
+          <Box padding={[6, 6, 6, 6]}>Box padding 6</Box>
+          <Box padding={[7, 7, 7, 7]}>Box padding 7</Box>
+          <Box padding={[8, 8, 8, 8]}>Box padding 8</Box>
+          <Box padding={[9, 9, 9, 9]}>Box padding 9</Box>
+          <Box padding={[10, 10, 10, 10]}>Box padding 10</Box>
+          <Box padding={[11, 11, 11, 11]}>Box padding 11</Box>
+          <Box padding={[12, 12, 12, 12]}>Box padding 12</Box>
+        </>,
+      );
+      expect(getByText('Box padding 0')).toHaveClass(
+        'box--padding-0 box--sm:padding-0 box--md:padding-0 box--lg:padding-0',
+      );
+      expect(getByText('Box padding 1')).toHaveClass(
+        'box--padding-1 box--sm:padding-1 box--md:padding-1 box--lg:padding-1',
+      );
+      expect(getByText('Box padding 2')).toHaveClass(
+        'box--padding-2 box--sm:padding-2 box--md:padding-2 box--lg:padding-2',
+      );
+      expect(getByText('Box padding 3')).toHaveClass(
+        'box--padding-3 box--sm:padding-3 box--md:padding-3 box--lg:padding-3',
+      );
+      expect(getByText('Box padding 4')).toHaveClass(
+        'box--padding-4 box--sm:padding-4 box--md:padding-4 box--lg:padding-4',
+      );
+      expect(getByText('Box padding 5')).toHaveClass(
+        'box--padding-5 box--sm:padding-5 box--md:padding-5 box--lg:padding-5',
+      );
+      expect(getByText('Box padding 6')).toHaveClass(
+        'box--padding-6 box--sm:padding-6 box--md:padding-6 box--lg:padding-6',
+      );
+      expect(getByText('Box padding 7')).toHaveClass(
+        'box--padding-7 box--sm:padding-7 box--md:padding-7 box--lg:padding-7',
+      );
+      expect(getByText('Box padding 8')).toHaveClass(
+        'box--padding-8 box--sm:padding-8 box--md:padding-8 box--lg:padding-8',
+      );
+      expect(getByText('Box padding 9')).toHaveClass(
+        'box--padding-9 box--sm:padding-9 box--md:padding-9 box--lg:padding-9',
+      );
+      expect(getByText('Box padding 10')).toHaveClass(
+        'box--padding-10 box--sm:padding-10 box--md:padding-10 box--lg:padding-10',
+      );
+      expect(getByText('Box padding 11')).toHaveClass(
+        'box--padding-11 box--sm:padding-11 box--md:padding-11 box--lg:padding-11',
+      );
+      expect(getByText('Box padding 12')).toHaveClass(
+        'box--padding-12 box--sm:padding-12 box--md:padding-12 box--lg:padding-12',
+      );
+    });
+    it('should render the Box with the paddingTop classes', () => {
+      const { getByText } = render(
+        <>
+          <Box paddingTop={0}>Box paddingTop 0</Box>
+          <Box paddingTop={1}>Box paddingTop 1</Box>
+          <Box paddingTop={2}>Box paddingTop 2</Box>
+          <Box paddingTop={3}>Box paddingTop 3</Box>
+          <Box paddingTop={4}>Box paddingTop 4</Box>
+          <Box paddingTop={5}>Box paddingTop 5</Box>
+          <Box paddingTop={6}>Box paddingTop 6</Box>
+          <Box paddingTop={7}>Box paddingTop 7</Box>
+          <Box paddingTop={8}>Box paddingTop 8</Box>
+          <Box paddingTop={9}>Box paddingTop 9</Box>
+          <Box paddingTop={10}>Box paddingTop 10</Box>
+          <Box paddingTop={11}>Box paddingTop 11</Box>
+          <Box paddingTop={12}>Box paddingTop 12</Box>
+        </>,
       );
 
-      expect(getByText('Box content')).toHaveClass('box--padding-1');
-      expect(getByText('Box content')).toHaveClass('box--sm:padding-2');
-      expect(getByText('Box content')).toHaveClass('box--md:padding-3');
-      expect(getByText('Box content')).toHaveClass('box--lg:padding-4');
-    });
-    it('should render the Box with the paddingTop class', () => {
-      const { getByText } = render(<Box paddingTop={1}>Box content</Box>);
-
-      expect(getByText('Box content')).toHaveClass('box--padding-top-1');
+      expect(getByText('Box paddingTop 0')).toHaveClass('box--padding-top-0');
+      expect(getByText('Box paddingTop 1')).toHaveClass('box--padding-top-1');
+      expect(getByText('Box paddingTop 2')).toHaveClass('box--padding-top-2');
+      expect(getByText('Box paddingTop 3')).toHaveClass('box--padding-top-3');
+      expect(getByText('Box paddingTop 4')).toHaveClass('box--padding-top-4');
+      expect(getByText('Box paddingTop 5')).toHaveClass('box--padding-top-5');
+      expect(getByText('Box paddingTop 6')).toHaveClass('box--padding-top-6');
+      expect(getByText('Box paddingTop 7')).toHaveClass('box--padding-top-7');
+      expect(getByText('Box paddingTop 8')).toHaveClass('box--padding-top-8');
+      expect(getByText('Box paddingTop 9')).toHaveClass('box--padding-top-9');
+      expect(getByText('Box paddingTop 10')).toHaveClass('box--padding-top-10');
+      expect(getByText('Box paddingTop 11')).toHaveClass('box--padding-top-11');
+      expect(getByText('Box paddingTop 12')).toHaveClass('box--padding-top-12');
     });
     it('should render the Box with the responsive paddingTop classes', () => {
       const { getByText } = render(
-        <Box paddingTop={[1, 2, 3, 4]}>Box content</Box>,
+        <>
+          <Box paddingTop={[0, 0, 0, 0]}>Box paddingTop 0</Box>
+          <Box paddingTop={[1, 1, 1, 1]}>Box paddingTop 1</Box>
+          <Box paddingTop={[2, 2, 2, 2]}>Box paddingTop 2</Box>
+          <Box paddingTop={[3, 3, 3, 3]}>Box paddingTop 3</Box>
+          <Box paddingTop={[4, 4, 4, 4]}>Box paddingTop 4</Box>
+          <Box paddingTop={[5, 5, 5, 5]}>Box paddingTop 5</Box>
+          <Box paddingTop={[6, 6, 6, 6]}>Box paddingTop 6</Box>
+          <Box paddingTop={[7, 7, 7, 7]}>Box paddingTop 7</Box>
+          <Box paddingTop={[8, 8, 8, 8]}>Box paddingTop 8</Box>
+          <Box paddingTop={[9, 9, 9, 9]}>Box paddingTop 9</Box>
+          <Box paddingTop={[10, 10, 10, 10]}>Box paddingTop 10</Box>
+          <Box paddingTop={[11, 11, 11, 11]}>Box paddingTop 11</Box>
+          <Box paddingTop={[12, 12, 12, 12]}>Box paddingTop 12</Box>
+        </>,
+      );
+      expect(getByText('Box paddingTop 0')).toHaveClass(
+        'box--padding-top-0 box--sm:padding-top-0 box--md:padding-top-0 box--lg:padding-top-0',
+      );
+      expect(getByText('Box paddingTop 1')).toHaveClass(
+        'box--padding-top-1 box--sm:padding-top-1 box--md:padding-top-1 box--lg:padding-top-1',
+      );
+      expect(getByText('Box paddingTop 2')).toHaveClass(
+        'box--padding-top-2 box--sm:padding-top-2 box--md:padding-top-2 box--lg:padding-top-2',
+      );
+      expect(getByText('Box paddingTop 3')).toHaveClass(
+        'box--padding-top-3 box--sm:padding-top-3 box--md:padding-top-3 box--lg:padding-top-3',
+      );
+      expect(getByText('Box paddingTop 4')).toHaveClass(
+        'box--padding-top-4 box--sm:padding-top-4 box--md:padding-top-4 box--lg:padding-top-4',
+      );
+      expect(getByText('Box paddingTop 5')).toHaveClass(
+        'box--padding-top-5 box--sm:padding-top-5 box--md:padding-top-5 box--lg:padding-top-5',
+      );
+      expect(getByText('Box paddingTop 6')).toHaveClass(
+        'box--padding-top-6 box--sm:padding-top-6 box--md:padding-top-6 box--lg:padding-top-6',
+      );
+      expect(getByText('Box paddingTop 7')).toHaveClass(
+        'box--padding-top-7 box--sm:padding-top-7 box--md:padding-top-7 box--lg:padding-top-7',
+      );
+      expect(getByText('Box paddingTop 8')).toHaveClass(
+        'box--padding-top-8 box--sm:padding-top-8 box--md:padding-top-8 box--lg:padding-top-8',
+      );
+      expect(getByText('Box paddingTop 9')).toHaveClass(
+        'box--padding-top-9 box--sm:padding-top-9 box--md:padding-top-9 box--lg:padding-top-9',
+      );
+      expect(getByText('Box paddingTop 10')).toHaveClass(
+        'box--padding-top-10 box--sm:padding-top-10 box--md:padding-top-10 box--lg:padding-top-10',
+      );
+      expect(getByText('Box paddingTop 11')).toHaveClass(
+        'box--padding-top-11 box--sm:padding-top-11 box--md:padding-top-11 box--lg:padding-top-11',
+      );
+      expect(getByText('Box paddingTop 12')).toHaveClass(
+        'box--padding-top-12 box--sm:padding-top-12 box--md:padding-top-12 box--lg:padding-top-12',
+      );
+    });
+    it('should render the Box with the paddingRight classes', () => {
+      const { getByText } = render(
+        <>
+          <Box paddingRight={0}>Box paddingRight 0</Box>
+          <Box paddingRight={1}>Box paddingRight 1</Box>
+          <Box paddingRight={2}>Box paddingRight 2</Box>
+          <Box paddingRight={3}>Box paddingRight 3</Box>
+          <Box paddingRight={4}>Box paddingRight 4</Box>
+          <Box paddingRight={5}>Box paddingRight 5</Box>
+          <Box paddingRight={6}>Box paddingRight 6</Box>
+          <Box paddingRight={7}>Box paddingRight 7</Box>
+          <Box paddingRight={8}>Box paddingRight 8</Box>
+          <Box paddingRight={9}>Box paddingRight 9</Box>
+          <Box paddingRight={10}>Box paddingRight 10</Box>
+          <Box paddingRight={11}>Box paddingRight 11</Box>
+          <Box paddingRight={12}>Box paddingRight 12</Box>
+        </>,
       );
 
-      expect(getByText('Box content')).toHaveClass('box--padding-top-1');
-      expect(getByText('Box content')).toHaveClass('box--sm:padding-top-2');
-      expect(getByText('Box content')).toHaveClass('box--md:padding-top-3');
-      expect(getByText('Box content')).toHaveClass('box--lg:padding-top-4');
-    });
-    it('should render the Box with the paddingRight class', () => {
-      const { getByText } = render(<Box paddingRight={1}>Box content</Box>);
-
-      expect(getByText('Box content')).toHaveClass('box--padding-right-1');
+      expect(getByText('Box paddingRight 0')).toHaveClass(
+        'box--padding-right-0',
+      );
+      expect(getByText('Box paddingRight 1')).toHaveClass(
+        'box--padding-right-1',
+      );
+      expect(getByText('Box paddingRight 2')).toHaveClass(
+        'box--padding-right-2',
+      );
+      expect(getByText('Box paddingRight 3')).toHaveClass(
+        'box--padding-right-3',
+      );
+      expect(getByText('Box paddingRight 4')).toHaveClass(
+        'box--padding-right-4',
+      );
+      expect(getByText('Box paddingRight 5')).toHaveClass(
+        'box--padding-right-5',
+      );
+      expect(getByText('Box paddingRight 6')).toHaveClass(
+        'box--padding-right-6',
+      );
+      expect(getByText('Box paddingRight 7')).toHaveClass(
+        'box--padding-right-7',
+      );
+      expect(getByText('Box paddingRight 8')).toHaveClass(
+        'box--padding-right-8',
+      );
+      expect(getByText('Box paddingRight 9')).toHaveClass(
+        'box--padding-right-9',
+      );
+      expect(getByText('Box paddingRight 10')).toHaveClass(
+        'box--padding-right-10',
+      );
+      expect(getByText('Box paddingRight 11')).toHaveClass(
+        'box--padding-right-11',
+      );
+      expect(getByText('Box paddingRight 12')).toHaveClass(
+        'box--padding-right-12',
+      );
     });
     it('should render the Box with the responsive paddingRight classes', () => {
       const { getByText } = render(
-        <Box paddingRight={[1, 2, 3, 4]}>Box content</Box>,
+        <>
+          <Box paddingRight={[0, 0, 0, 0]}>Box paddingRight 0</Box>
+          <Box paddingRight={[1, 1, 1, 1]}>Box paddingRight 1</Box>
+          <Box paddingRight={[2, 2, 2, 2]}>Box paddingRight 2</Box>
+          <Box paddingRight={[3, 3, 3, 3]}>Box paddingRight 3</Box>
+          <Box paddingRight={[4, 4, 4, 4]}>Box paddingRight 4</Box>
+          <Box paddingRight={[5, 5, 5, 5]}>Box paddingRight 5</Box>
+          <Box paddingRight={[6, 6, 6, 6]}>Box paddingRight 6</Box>
+          <Box paddingRight={[7, 7, 7, 7]}>Box paddingRight 7</Box>
+          <Box paddingRight={[8, 8, 8, 8]}>Box paddingRight 8</Box>
+          <Box paddingRight={[9, 9, 9, 9]}>Box paddingRight 9</Box>
+          <Box paddingRight={[10, 10, 10, 10]}>Box paddingRight 10</Box>
+          <Box paddingRight={[11, 11, 11, 11]}>Box paddingRight 11</Box>
+          <Box paddingRight={[12, 12, 12, 12]}>Box paddingRight 12</Box>
+        </>,
+      );
+      expect(getByText('Box paddingRight 0')).toHaveClass(
+        'box--padding-right-0 box--sm:padding-right-0 box--md:padding-right-0 box--lg:padding-right-0',
+      );
+      expect(getByText('Box paddingRight 1')).toHaveClass(
+        'box--padding-right-1 box--sm:padding-right-1 box--md:padding-right-1 box--lg:padding-right-1',
+      );
+      expect(getByText('Box paddingRight 2')).toHaveClass(
+        'box--padding-right-2 box--sm:padding-right-2 box--md:padding-right-2 box--lg:padding-right-2',
+      );
+      expect(getByText('Box paddingRight 3')).toHaveClass(
+        'box--padding-right-3 box--sm:padding-right-3 box--md:padding-right-3 box--lg:padding-right-3',
+      );
+      expect(getByText('Box paddingRight 4')).toHaveClass(
+        'box--padding-right-4 box--sm:padding-right-4 box--md:padding-right-4 box--lg:padding-right-4',
+      );
+      expect(getByText('Box paddingRight 5')).toHaveClass(
+        'box--padding-right-5 box--sm:padding-right-5 box--md:padding-right-5 box--lg:padding-right-5',
+      );
+      expect(getByText('Box paddingRight 6')).toHaveClass(
+        'box--padding-right-6 box--sm:padding-right-6 box--md:padding-right-6 box--lg:padding-right-6',
+      );
+      expect(getByText('Box paddingRight 7')).toHaveClass(
+        'box--padding-right-7 box--sm:padding-right-7 box--md:padding-right-7 box--lg:padding-right-7',
+      );
+      expect(getByText('Box paddingRight 8')).toHaveClass(
+        'box--padding-right-8 box--sm:padding-right-8 box--md:padding-right-8 box--lg:padding-right-8',
+      );
+      expect(getByText('Box paddingRight 9')).toHaveClass(
+        'box--padding-right-9 box--sm:padding-right-9 box--md:padding-right-9 box--lg:padding-right-9',
+      );
+      expect(getByText('Box paddingRight 10')).toHaveClass(
+        'box--padding-right-10 box--sm:padding-right-10 box--md:padding-right-10 box--lg:padding-right-10',
+      );
+      expect(getByText('Box paddingRight 11')).toHaveClass(
+        'box--padding-right-11 box--sm:padding-right-11 box--md:padding-right-11 box--lg:padding-right-11',
+      );
+      expect(getByText('Box paddingRight 12')).toHaveClass(
+        'box--padding-right-12 box--sm:padding-right-12 box--md:padding-right-12 box--lg:padding-right-12',
+      );
+    });
+    it('should render the Box with the paddingBottom classes', () => {
+      const { getByText } = render(
+        <>
+          <Box paddingBottom={0}>Box paddingBottom 0</Box>
+          <Box paddingBottom={1}>Box paddingBottom 1</Box>
+          <Box paddingBottom={2}>Box paddingBottom 2</Box>
+          <Box paddingBottom={3}>Box paddingBottom 3</Box>
+          <Box paddingBottom={4}>Box paddingBottom 4</Box>
+          <Box paddingBottom={5}>Box paddingBottom 5</Box>
+          <Box paddingBottom={6}>Box paddingBottom 6</Box>
+          <Box paddingBottom={7}>Box paddingBottom 7</Box>
+          <Box paddingBottom={8}>Box paddingBottom 8</Box>
+          <Box paddingBottom={9}>Box paddingBottom 9</Box>
+          <Box paddingBottom={10}>Box paddingBottom 10</Box>
+          <Box paddingBottom={11}>Box paddingBottom 11</Box>
+          <Box paddingBottom={12}>Box paddingBottom 12</Box>
+        </>,
       );
 
-      expect(getByText('Box content')).toHaveClass('box--padding-right-1');
-      expect(getByText('Box content')).toHaveClass('box--sm:padding-right-2');
-      expect(getByText('Box content')).toHaveClass('box--md:padding-right-3');
-      expect(getByText('Box content')).toHaveClass('box--lg:padding-right-4');
-    });
-    it('should render the Box with the paddingBottom class', () => {
-      const { getByText } = render(<Box paddingBottom={1}>Box content</Box>);
-
-      expect(getByText('Box content')).toHaveClass('box--padding-bottom-1');
+      expect(getByText('Box paddingBottom 0')).toHaveClass(
+        'box--padding-bottom-0',
+      );
+      expect(getByText('Box paddingBottom 1')).toHaveClass(
+        'box--padding-bottom-1',
+      );
+      expect(getByText('Box paddingBottom 2')).toHaveClass(
+        'box--padding-bottom-2',
+      );
+      expect(getByText('Box paddingBottom 3')).toHaveClass(
+        'box--padding-bottom-3',
+      );
+      expect(getByText('Box paddingBottom 4')).toHaveClass(
+        'box--padding-bottom-4',
+      );
+      expect(getByText('Box paddingBottom 5')).toHaveClass(
+        'box--padding-bottom-5',
+      );
+      expect(getByText('Box paddingBottom 6')).toHaveClass(
+        'box--padding-bottom-6',
+      );
+      expect(getByText('Box paddingBottom 7')).toHaveClass(
+        'box--padding-bottom-7',
+      );
+      expect(getByText('Box paddingBottom 8')).toHaveClass(
+        'box--padding-bottom-8',
+      );
+      expect(getByText('Box paddingBottom 9')).toHaveClass(
+        'box--padding-bottom-9',
+      );
+      expect(getByText('Box paddingBottom 10')).toHaveClass(
+        'box--padding-bottom-10',
+      );
+      expect(getByText('Box paddingBottom 11')).toHaveClass(
+        'box--padding-bottom-11',
+      );
+      expect(getByText('Box paddingBottom 12')).toHaveClass(
+        'box--padding-bottom-12',
+      );
     });
     it('should render the Box with the responsive paddingBottom classes', () => {
       const { getByText } = render(
-        <Box paddingBottom={[1, 2, 3, 4]}>Box content</Box>,
+        <>
+          <Box paddingBottom={[0, 0, 0, 0]}>Box paddingBottom 0</Box>
+          <Box paddingBottom={[1, 1, 1, 1]}>Box paddingBottom 1</Box>
+          <Box paddingBottom={[2, 2, 2, 2]}>Box paddingBottom 2</Box>
+          <Box paddingBottom={[3, 3, 3, 3]}>Box paddingBottom 3</Box>
+          <Box paddingBottom={[4, 4, 4, 4]}>Box paddingBottom 4</Box>
+          <Box paddingBottom={[5, 5, 5, 5]}>Box paddingBottom 5</Box>
+          <Box paddingBottom={[6, 6, 6, 6]}>Box paddingBottom 6</Box>
+          <Box paddingBottom={[7, 7, 7, 7]}>Box paddingBottom 7</Box>
+          <Box paddingBottom={[8, 8, 8, 8]}>Box paddingBottom 8</Box>
+          <Box paddingBottom={[9, 9, 9, 9]}>Box paddingBottom 9</Box>
+          <Box paddingBottom={[10, 10, 10, 10]}>Box paddingBottom 10</Box>
+          <Box paddingBottom={[11, 11, 11, 11]}>Box paddingBottom 11</Box>
+          <Box paddingBottom={[12, 12, 12, 12]}>Box paddingBottom 12</Box>
+        </>,
+      );
+      expect(getByText('Box paddingBottom 0')).toHaveClass(
+        'box--padding-bottom-0 box--sm:padding-bottom-0 box--md:padding-bottom-0 box--lg:padding-bottom-0',
+      );
+      expect(getByText('Box paddingBottom 1')).toHaveClass(
+        'box--padding-bottom-1 box--sm:padding-bottom-1 box--md:padding-bottom-1 box--lg:padding-bottom-1',
+      );
+      expect(getByText('Box paddingBottom 2')).toHaveClass(
+        'box--padding-bottom-2 box--sm:padding-bottom-2 box--md:padding-bottom-2 box--lg:padding-bottom-2',
+      );
+      expect(getByText('Box paddingBottom 3')).toHaveClass(
+        'box--padding-bottom-3 box--sm:padding-bottom-3 box--md:padding-bottom-3 box--lg:padding-bottom-3',
+      );
+      expect(getByText('Box paddingBottom 4')).toHaveClass(
+        'box--padding-bottom-4 box--sm:padding-bottom-4 box--md:padding-bottom-4 box--lg:padding-bottom-4',
+      );
+      expect(getByText('Box paddingBottom 5')).toHaveClass(
+        'box--padding-bottom-5 box--sm:padding-bottom-5 box--md:padding-bottom-5 box--lg:padding-bottom-5',
+      );
+      expect(getByText('Box paddingBottom 6')).toHaveClass(
+        'box--padding-bottom-6 box--sm:padding-bottom-6 box--md:padding-bottom-6 box--lg:padding-bottom-6',
+      );
+      expect(getByText('Box paddingBottom 7')).toHaveClass(
+        'box--padding-bottom-7 box--sm:padding-bottom-7 box--md:padding-bottom-7 box--lg:padding-bottom-7',
+      );
+      expect(getByText('Box paddingBottom 8')).toHaveClass(
+        'box--padding-bottom-8 box--sm:padding-bottom-8 box--md:padding-bottom-8 box--lg:padding-bottom-8',
+      );
+      expect(getByText('Box paddingBottom 9')).toHaveClass(
+        'box--padding-bottom-9 box--sm:padding-bottom-9 box--md:padding-bottom-9 box--lg:padding-bottom-9',
+      );
+      expect(getByText('Box paddingBottom 10')).toHaveClass(
+        'box--padding-bottom-10 box--sm:padding-bottom-10 box--md:padding-bottom-10 box--lg:padding-bottom-10',
+      );
+      expect(getByText('Box paddingBottom 11')).toHaveClass(
+        'box--padding-bottom-11 box--sm:padding-bottom-11 box--md:padding-bottom-11 box--lg:padding-bottom-11',
+      );
+      expect(getByText('Box paddingBottom 12')).toHaveClass(
+        'box--padding-bottom-12 box--sm:padding-bottom-12 box--md:padding-bottom-12 box--lg:padding-bottom-12',
+      );
+    });
+    it('should render the Box with the paddingLeft classes', () => {
+      const { getByText } = render(
+        <>
+          <Box paddingLeft={0}>Box paddingLeft 0</Box>
+          <Box paddingLeft={1}>Box paddingLeft 1</Box>
+          <Box paddingLeft={2}>Box paddingLeft 2</Box>
+          <Box paddingLeft={3}>Box paddingLeft 3</Box>
+          <Box paddingLeft={4}>Box paddingLeft 4</Box>
+          <Box paddingLeft={5}>Box paddingLeft 5</Box>
+          <Box paddingLeft={6}>Box paddingLeft 6</Box>
+          <Box paddingLeft={7}>Box paddingLeft 7</Box>
+          <Box paddingLeft={8}>Box paddingLeft 8</Box>
+          <Box paddingLeft={9}>Box paddingLeft 9</Box>
+          <Box paddingLeft={10}>Box paddingLeft 10</Box>
+          <Box paddingLeft={11}>Box paddingLeft 11</Box>
+          <Box paddingLeft={12}>Box paddingLeft 12</Box>
+        </>,
       );
 
-      expect(getByText('Box content')).toHaveClass('box--padding-bottom-1');
-      expect(getByText('Box content')).toHaveClass('box--sm:padding-bottom-2');
-      expect(getByText('Box content')).toHaveClass('box--md:padding-bottom-3');
-      expect(getByText('Box content')).toHaveClass('box--lg:padding-bottom-4');
-    });
-    it('should render the Box with the paddingLeft class', () => {
-      const { getByText } = render(<Box paddingLeft={1}>Box content</Box>);
-
-      expect(getByText('Box content')).toHaveClass('box--padding-left-1');
+      expect(getByText('Box paddingLeft 0')).toHaveClass('box--padding-left-0');
+      expect(getByText('Box paddingLeft 1')).toHaveClass('box--padding-left-1');
+      expect(getByText('Box paddingLeft 2')).toHaveClass('box--padding-left-2');
+      expect(getByText('Box paddingLeft 3')).toHaveClass('box--padding-left-3');
+      expect(getByText('Box paddingLeft 4')).toHaveClass('box--padding-left-4');
+      expect(getByText('Box paddingLeft 5')).toHaveClass('box--padding-left-5');
+      expect(getByText('Box paddingLeft 6')).toHaveClass('box--padding-left-6');
+      expect(getByText('Box paddingLeft 7')).toHaveClass('box--padding-left-7');
+      expect(getByText('Box paddingLeft 8')).toHaveClass('box--padding-left-8');
+      expect(getByText('Box paddingLeft 9')).toHaveClass('box--padding-left-9');
+      expect(getByText('Box paddingLeft 10')).toHaveClass(
+        'box--padding-left-10',
+      );
+      expect(getByText('Box paddingLeft 11')).toHaveClass(
+        'box--padding-left-11',
+      );
+      expect(getByText('Box paddingLeft 12')).toHaveClass(
+        'box--padding-left-12',
+      );
     });
     it('should render the Box with the responsive paddingLeft classes', () => {
       const { getByText } = render(
-        <Box paddingLeft={[1, 2, 3, 4]}>Box content</Box>,
+        <>
+          <Box paddingLeft={[0, 0, 0, 0]}>Box paddingLeft 0</Box>
+          <Box paddingLeft={[1, 1, 1, 1]}>Box paddingLeft 1</Box>
+          <Box paddingLeft={[2, 2, 2, 2]}>Box paddingLeft 2</Box>
+          <Box paddingLeft={[3, 3, 3, 3]}>Box paddingLeft 3</Box>
+          <Box paddingLeft={[4, 4, 4, 4]}>Box paddingLeft 4</Box>
+          <Box paddingLeft={[5, 5, 5, 5]}>Box paddingLeft 5</Box>
+          <Box paddingLeft={[6, 6, 6, 6]}>Box paddingLeft 6</Box>
+          <Box paddingLeft={[7, 7, 7, 7]}>Box paddingLeft 7</Box>
+          <Box paddingLeft={[8, 8, 8, 8]}>Box paddingLeft 8</Box>
+          <Box paddingLeft={[9, 9, 9, 9]}>Box paddingLeft 9</Box>
+          <Box paddingLeft={[10, 10, 10, 10]}>Box paddingLeft 10</Box>
+          <Box paddingLeft={[11, 11, 11, 11]}>Box paddingLeft 11</Box>
+          <Box paddingLeft={[12, 12, 12, 12]}>Box paddingLeft 12</Box>
+        </>,
       );
-
-      expect(getByText('Box content')).toHaveClass('box--padding-left-1');
-      expect(getByText('Box content')).toHaveClass('box--sm:padding-left-2');
-      expect(getByText('Box content')).toHaveClass('box--md:padding-left-3');
-      expect(getByText('Box content')).toHaveClass('box--lg:padding-left-4');
+      expect(getByText('Box paddingLeft 0')).toHaveClass(
+        'box--padding-left-0 box--sm:padding-left-0 box--md:padding-left-0 box--lg:padding-left-0',
+      );
+      expect(getByText('Box paddingLeft 1')).toHaveClass(
+        'box--padding-left-1 box--sm:padding-left-1 box--md:padding-left-1 box--lg:padding-left-1',
+      );
+      expect(getByText('Box paddingLeft 2')).toHaveClass(
+        'box--padding-left-2 box--sm:padding-left-2 box--md:padding-left-2 box--lg:padding-left-2',
+      );
+      expect(getByText('Box paddingLeft 3')).toHaveClass(
+        'box--padding-left-3 box--sm:padding-left-3 box--md:padding-left-3 box--lg:padding-left-3',
+      );
+      expect(getByText('Box paddingLeft 4')).toHaveClass(
+        'box--padding-left-4 box--sm:padding-left-4 box--md:padding-left-4 box--lg:padding-left-4',
+      );
+      expect(getByText('Box paddingLeft 5')).toHaveClass(
+        'box--padding-left-5 box--sm:padding-left-5 box--md:padding-left-5 box--lg:padding-left-5',
+      );
+      expect(getByText('Box paddingLeft 6')).toHaveClass(
+        'box--padding-left-6 box--sm:padding-left-6 box--md:padding-left-6 box--lg:padding-left-6',
+      );
+      expect(getByText('Box paddingLeft 7')).toHaveClass(
+        'box--padding-left-7 box--sm:padding-left-7 box--md:padding-left-7 box--lg:padding-left-7',
+      );
+      expect(getByText('Box paddingLeft 8')).toHaveClass(
+        'box--padding-left-8 box--sm:padding-left-8 box--md:padding-left-8 box--lg:padding-left-8',
+      );
+      expect(getByText('Box paddingLeft 9')).toHaveClass(
+        'box--padding-left-9 box--sm:padding-left-9 box--md:padding-left-9 box--lg:padding-left-9',
+      );
+      expect(getByText('Box paddingLeft 10')).toHaveClass(
+        'box--padding-left-10 box--sm:padding-left-10 box--md:padding-left-10 box--lg:padding-left-10',
+      );
+      expect(getByText('Box paddingLeft 11')).toHaveClass(
+        'box--padding-left-11 box--sm:padding-left-11 box--md:padding-left-11 box--lg:padding-left-11',
+      );
+      expect(getByText('Box paddingLeft 12')).toHaveClass(
+        'box--padding-left-12 box--sm:padding-left-12 box--md:padding-left-12 box--lg:padding-left-12',
+      );
     });
     it('should render the Box with the responsive paddingInline classes', () => {
       const { getByText } = render(
@@ -599,17 +1475,59 @@ describe('Box', () => {
       );
     });
     it('should render the Box with the gap class', () => {
-      const { getByText } = render(<Box gap={1}>Box content</Box>);
+      const { getByText } = render(
+        <>
+          <Box gap={0}>Box gap 0</Box>
+          <Box gap={1}>Box gap 1</Box>
+          <Box gap={2}>Box gap 2</Box>
+          <Box gap={3}>Box gap 3</Box>
+          <Box gap={4}>Box gap 4</Box>
+          <Box gap={5}>Box gap 5</Box>
+          <Box gap={6}>Box gap 6</Box>
+          <Box gap={7}>Box gap 7</Box>
+          <Box gap={8}>Box gap 8</Box>
+          <Box gap={9}>Box gap 9</Box>
+          <Box gap={10}>Box gap 10</Box>
+          <Box gap={11}>Box gap 11</Box>
+          <Box gap={12}>Box gap 12</Box>
+        </>,
+      );
 
-      expect(getByText('Box content')).toHaveClass('box--gap-1');
+      expect(getByText('Box gap 1')).toHaveClass('box--gap-1');
+      expect(getByText('Box gap 2')).toHaveClass('box--gap-2');
+      expect(getByText('Box gap 3')).toHaveClass('box--gap-3');
+      expect(getByText('Box gap 4')).toHaveClass('box--gap-4');
+      expect(getByText('Box gap 5')).toHaveClass('box--gap-5');
+      expect(getByText('Box gap 6')).toHaveClass('box--gap-6');
+      expect(getByText('Box gap 7')).toHaveClass('box--gap-7');
+      expect(getByText('Box gap 8')).toHaveClass('box--gap-8');
+      expect(getByText('Box gap 9')).toHaveClass('box--gap-9');
+      expect(getByText('Box gap 10')).toHaveClass('box--gap-10');
+      expect(getByText('Box gap 11')).toHaveClass('box--gap-11');
+      expect(getByText('Box gap 12')).toHaveClass('box--gap-12');
     });
     it('should render the Box with the responsive gap classes', () => {
-      const { getByText } = render(<Box gap={[1, 2, 3, 4]}>Box content</Box>);
+      const { getByText } = render(
+        <>
+          <Box gap={[0, 1, 2, 3]}>Box gap 0123</Box>
+          <Box gap={[4, 5, 6, 7]}>Box gap 4567</Box>
+          <Box gap={[8, 9, 10, 11]}>Box gap 891011</Box>
+          <Box gap={[12, 12, 12, 12]}>Box gap 12</Box>
+        </>,
+      );
 
-      expect(getByText('Box content')).toHaveClass('box--gap-1');
-      expect(getByText('Box content')).toHaveClass('box--sm:gap-2');
-      expect(getByText('Box content')).toHaveClass('box--md:gap-3');
-      expect(getByText('Box content')).toHaveClass('box--lg:gap-4');
+      expect(getByText('Box gap 0123')).toHaveClass(
+        'box--gap-0 box--sm:gap-1 box--md:gap-2 box--lg:gap-3',
+      );
+      expect(getByText('Box gap 4567')).toHaveClass(
+        'box--gap-4 box--sm:gap-5 box--md:gap-6 box--lg:gap-7',
+      );
+      expect(getByText('Box gap 891011')).toHaveClass(
+        'box--gap-8 box--sm:gap-9 box--md:gap-10 box--lg:gap-11',
+      );
+      expect(getByText('Box gap 12')).toHaveClass(
+        'box--gap-12 box--sm:gap-12 box--md:gap-12 box--lg:gap-12',
+      );
     });
     it('should render the Box with the flexDirection classes', () => {
       const { getByText } = render(
@@ -1034,7 +1952,6 @@ describe('Box', () => {
       );
     });
   });
-
   describe('color', () => {
     it('should render the Box with the color class', () => {
       const { getByText } = render(
@@ -1067,7 +1984,6 @@ describe('Box', () => {
       );
     });
   });
-
   describe('width, height', () => {
     it('should render the Box with the width class', () => {
       const { getByText } = render(

--- a/ui/pages/confirm-signature-request/__snapshots__/index.test.js.snap
+++ b/ui/pages/confirm-signature-request/__snapshots__/index.test.js.snap
@@ -142,12 +142,12 @@ exports[`Signature Request Component render should match snapshot 1`] = `
             class="box box--display-flex box--flex-direction-column box--align-items-flex-start"
           >
             <h6
-              class="box mm-text mm-text--body-sm box--flex-direction-row box--color-text-alternative"
+              class="box mm-text mm-text--body-sm box--margin-bottom-0 box--flex-direction-row box--color-text-alternative"
             >
               Goerli test network
             </h6>
             <h6
-              class="box mm-text mm-text--body-sm mm-text--font-weight-bold box--flex-direction-row box--color-text-default"
+              class="box mm-text mm-text--body-sm mm-text--font-weight-bold box--margin-top-0 box--flex-direction-row box--color-text-default"
             >
               Account 1
             </h6>
@@ -157,13 +157,13 @@ exports[`Signature Request Component render should match snapshot 1`] = `
           class="box box--display-flex box--flex-direction-column box--align-items-flex-end"
         >
           <h6
-            class="box mm-text mm-text--body-sm box--flex-direction-row box--color-text-alternative"
+            class="box mm-text mm-text--body-sm box--margin-bottom-0 box--flex-direction-row box--color-text-alternative"
           >
             Balance
           </h6>
           <h6
             align="end"
-            class="box mm-text mm-text--body-sm mm-text--font-weight-bold box--flex-direction-row box--color-text-default"
+            class="box mm-text mm-text--body-sm mm-text--font-weight-bold box--margin-top-0 box--flex-direction-row box--color-text-default"
           >
             9.107408
              

--- a/ui/pages/confirmation/templates/__snapshots__/add-ethereum-chain.test.js.snap
+++ b/ui/pages/confirmation/templates/__snapshots__/add-ethereum-chain.test.js.snap
@@ -37,17 +37,17 @@ exports[`add-ethereum-chain confirmation should match snapshot 1`] = `
         </div>
       </div>
       <h3
-        class="box box--md:margin-4 box--margin-top-1 box--margin-bottom-1 box--flex-direction-row typography typography--h3 typography--weight-bold typography--style-normal typography--align-center typography--color-text-default"
+        class="box box--margin-0 box--sm:margin-0 box--md:margin-4 box--margin-top-1 box--margin-bottom-1 box--flex-direction-row typography typography--h3 typography--weight-bold typography--style-normal typography--align-center typography--color-text-default"
       >
         Allow this site to add a network?
       </h3>
       <h6
-        class="box box--md:margin-4 box--margin-top-1 box--margin-bottom-1 box--flex-direction-row typography typography--h7 typography--weight-normal typography--style-normal typography--align-center typography--color-text-default"
+        class="box box--margin-0 box--sm:margin-0 box--md:margin-4 box--margin-top-1 box--margin-bottom-1 box--flex-direction-row typography typography--h7 typography--weight-normal typography--style-normal typography--align-center typography--color-text-default"
       >
         This will allow this network to be used within MetaMask.
       </h6>
       <h6
-        class="box box--margin-top-1 box--margin-bottom-1 box--display-flex box--flex-direction-column box--align-items-center typography typography--h7 typography--weight-normal typography--style-normal typography--color-text-default"
+        class="box box--margin-0 box--margin-top-1 box--margin-bottom-1 box--display-flex box--flex-direction-column box--align-items-center typography typography--h7 typography--weight-normal typography--style-normal typography--color-text-default"
       >
         <b>
           MetaMask does not verify custom networks. 
@@ -72,7 +72,7 @@ exports[`add-ethereum-chain confirmation should match snapshot 1`] = `
           class="definition-list"
         >
           <dt
-            class="box box--margin-bottom-1 box--flex-direction-row typography definition-list__term typography--h6 typography--weight-bold typography--style-normal typography--color-text-default"
+            class="box box--margin-top-0 box--margin-bottom-1 box--flex-direction-row typography definition-list__term typography--h6 typography--weight-bold typography--style-normal typography--color-text-default"
           >
             Network name
             <div>
@@ -92,12 +92,12 @@ exports[`add-ethereum-chain confirmation should match snapshot 1`] = `
             </div>
           </dt>
           <dd
-            class="box box--margin-bottom-2 box--flex-direction-row typography definition-list__definition typography--h6 typography--weight-normal typography--style-normal typography--color-text-alternative typography--overflowwrap-break-word"
+            class="box box--margin-top-0 box--margin-bottom-2 box--flex-direction-row typography definition-list__definition typography--h6 typography--weight-normal typography--style-normal typography--color-text-alternative typography--overflowwrap-break-word"
           >
             Test chain
           </dd>
           <dt
-            class="box box--margin-bottom-1 box--flex-direction-row typography definition-list__term typography--h6 typography--weight-bold typography--style-normal typography--color-text-default"
+            class="box box--margin-top-0 box--margin-bottom-1 box--flex-direction-row typography definition-list__term typography--h6 typography--weight-bold typography--style-normal typography--color-text-default"
           >
             Network URL
             <div>
@@ -117,12 +117,12 @@ exports[`add-ethereum-chain confirmation should match snapshot 1`] = `
             </div>
           </dt>
           <dd
-            class="box box--margin-bottom-2 box--flex-direction-row typography definition-list__definition typography--h6 typography--weight-normal typography--style-normal typography--color-text-alternative typography--overflowwrap-break-word"
+            class="box box--margin-top-0 box--margin-bottom-2 box--flex-direction-row typography definition-list__definition typography--h6 typography--weight-normal typography--style-normal typography--color-text-alternative typography--overflowwrap-break-word"
           >
             https://rpcurl.test.chain
           </dd>
           <dt
-            class="box box--margin-bottom-1 box--flex-direction-row typography definition-list__term typography--h6 typography--weight-bold typography--style-normal typography--color-text-default"
+            class="box box--margin-top-0 box--margin-bottom-1 box--flex-direction-row typography definition-list__term typography--h6 typography--weight-bold typography--style-normal typography--color-text-default"
           >
             Chain ID
             <div>
@@ -142,12 +142,12 @@ exports[`add-ethereum-chain confirmation should match snapshot 1`] = `
             </div>
           </dt>
           <dd
-            class="box box--margin-bottom-2 box--flex-direction-row typography definition-list__definition typography--h6 typography--weight-normal typography--style-normal typography--color-text-alternative typography--overflowwrap-break-word"
+            class="box box--margin-top-0 box--margin-bottom-2 box--flex-direction-row typography definition-list__definition typography--h6 typography--weight-normal typography--style-normal typography--color-text-alternative typography--overflowwrap-break-word"
           >
             39321
           </dd>
           <dt
-            class="box box--margin-bottom-1 box--flex-direction-row typography definition-list__term typography--h6 typography--weight-bold typography--style-normal typography--color-text-default"
+            class="box box--margin-top-0 box--margin-bottom-1 box--flex-direction-row typography definition-list__term typography--h6 typography--weight-bold typography--style-normal typography--color-text-default"
           >
             Currency symbol
             <div>
@@ -167,7 +167,7 @@ exports[`add-ethereum-chain confirmation should match snapshot 1`] = `
             </div>
           </dt>
           <dd
-            class="box box--margin-bottom-2 box--flex-direction-row typography definition-list__definition typography--h6 typography--weight-normal typography--style-normal typography--color-text-alternative typography--overflowwrap-break-word"
+            class="box box--margin-top-0 box--margin-bottom-2 box--flex-direction-row typography definition-list__definition typography--h6 typography--weight-normal typography--style-normal typography--color-text-alternative typography--overflowwrap-break-word"
           >
             TST
           </dd>
@@ -244,17 +244,17 @@ exports[`add-ethereum-chain confirmation should match snapshot 2`] = `
         </div>
       </div>
       <h3
-        class="box box--md:margin-4 box--margin-top-1 box--margin-bottom-1 box--flex-direction-row typography typography--h3 typography--weight-bold typography--style-normal typography--align-center typography--color-text-default"
+        class="box box--margin-0 box--sm:margin-0 box--md:margin-4 box--margin-top-1 box--margin-bottom-1 box--flex-direction-row typography typography--h3 typography--weight-bold typography--style-normal typography--align-center typography--color-text-default"
       >
         Allow this site to add a network?
       </h3>
       <h6
-        class="box box--md:margin-4 box--margin-top-1 box--margin-bottom-1 box--flex-direction-row typography typography--h7 typography--weight-normal typography--style-normal typography--align-center typography--color-text-default"
+        class="box box--margin-0 box--sm:margin-0 box--md:margin-4 box--margin-top-1 box--margin-bottom-1 box--flex-direction-row typography typography--h7 typography--weight-normal typography--style-normal typography--align-center typography--color-text-default"
       >
         This will allow this network to be used within MetaMask.
       </h6>
       <h6
-        class="box box--margin-top-1 box--margin-bottom-1 box--display-flex box--flex-direction-column box--align-items-center typography typography--h7 typography--weight-normal typography--style-normal typography--color-text-default"
+        class="box box--margin-0 box--margin-top-1 box--margin-bottom-1 box--display-flex box--flex-direction-column box--align-items-center typography typography--h7 typography--weight-normal typography--style-normal typography--color-text-default"
       >
         <b>
           MetaMask does not verify custom networks. 
@@ -279,7 +279,7 @@ exports[`add-ethereum-chain confirmation should match snapshot 2`] = `
           class="definition-list"
         >
           <dt
-            class="box box--margin-bottom-1 box--flex-direction-row typography definition-list__term typography--h6 typography--weight-bold typography--style-normal typography--color-text-default"
+            class="box box--margin-top-0 box--margin-bottom-1 box--flex-direction-row typography definition-list__term typography--h6 typography--weight-bold typography--style-normal typography--color-text-default"
           >
             Network name
             <div>
@@ -299,12 +299,12 @@ exports[`add-ethereum-chain confirmation should match snapshot 2`] = `
             </div>
           </dt>
           <dd
-            class="box box--margin-bottom-2 box--flex-direction-row typography definition-list__definition typography--h6 typography--weight-normal typography--style-normal typography--color-text-alternative typography--overflowwrap-break-word"
+            class="box box--margin-top-0 box--margin-bottom-2 box--flex-direction-row typography definition-list__definition typography--h6 typography--weight-normal typography--style-normal typography--color-text-alternative typography--overflowwrap-break-word"
           >
             Test chain
           </dd>
           <dt
-            class="box box--margin-bottom-1 box--flex-direction-row typography definition-list__term typography--h6 typography--weight-bold typography--style-normal typography--color-text-default"
+            class="box box--margin-top-0 box--margin-bottom-1 box--flex-direction-row typography definition-list__term typography--h6 typography--weight-bold typography--style-normal typography--color-text-default"
           >
             Network URL
             <div>
@@ -324,12 +324,12 @@ exports[`add-ethereum-chain confirmation should match snapshot 2`] = `
             </div>
           </dt>
           <dd
-            class="box box--margin-bottom-2 box--flex-direction-row typography definition-list__definition typography--h6 typography--weight-normal typography--style-normal typography--color-text-alternative typography--overflowwrap-break-word"
+            class="box box--margin-top-0 box--margin-bottom-2 box--flex-direction-row typography definition-list__definition typography--h6 typography--weight-normal typography--style-normal typography--color-text-alternative typography--overflowwrap-break-word"
           >
             https://rpcurl.test.chain
           </dd>
           <dt
-            class="box box--margin-bottom-1 box--flex-direction-row typography definition-list__term typography--h6 typography--weight-bold typography--style-normal typography--color-text-default"
+            class="box box--margin-top-0 box--margin-bottom-1 box--flex-direction-row typography definition-list__term typography--h6 typography--weight-bold typography--style-normal typography--color-text-default"
           >
             Chain ID
             <div>
@@ -349,12 +349,12 @@ exports[`add-ethereum-chain confirmation should match snapshot 2`] = `
             </div>
           </dt>
           <dd
-            class="box box--margin-bottom-2 box--flex-direction-row typography definition-list__definition typography--h6 typography--weight-normal typography--style-normal typography--color-text-alternative typography--overflowwrap-break-word"
+            class="box box--margin-top-0 box--margin-bottom-2 box--flex-direction-row typography definition-list__definition typography--h6 typography--weight-normal typography--style-normal typography--color-text-alternative typography--overflowwrap-break-word"
           >
             39321
           </dd>
           <dt
-            class="box box--margin-bottom-1 box--flex-direction-row typography definition-list__term typography--h6 typography--weight-bold typography--style-normal typography--color-text-default"
+            class="box box--margin-top-0 box--margin-bottom-1 box--flex-direction-row typography definition-list__term typography--h6 typography--weight-bold typography--style-normal typography--color-text-default"
           >
             Currency symbol
             <div>
@@ -374,7 +374,7 @@ exports[`add-ethereum-chain confirmation should match snapshot 2`] = `
             </div>
           </dt>
           <dd
-            class="box box--margin-bottom-2 box--flex-direction-row typography definition-list__definition typography--h6 typography--weight-normal typography--style-normal typography--color-text-alternative typography--overflowwrap-break-word"
+            class="box box--margin-top-0 box--margin-bottom-2 box--flex-direction-row typography definition-list__definition typography--h6 typography--weight-normal typography--style-normal typography--color-text-alternative typography--overflowwrap-break-word"
           >
             TST
           </dd>

--- a/ui/pages/confirmation/templates/__snapshots__/switch-ethereum-chain.test.js.snap
+++ b/ui/pages/confirmation/templates/__snapshots__/switch-ethereum-chain.test.js.snap
@@ -37,12 +37,12 @@ exports[`switch-ethereum-chain confirmation should match snapshot 1`] = `
         </div>
       </div>
       <h3
-        class="box box--md:margin-2 box--margin-top-1 box--margin-bottom-1 box--sm:padding-4 box--lg:padding-4 box--flex-direction-row typography typography--h3 typography--weight-normal typography--style-normal typography--align-center typography--color-text-default"
+        class="box box--margin-0 box--sm:margin-0 box--md:margin-2 box--margin-top-1 box--margin-bottom-1 box--padding-0 box--sm:padding-4 box--md:padding-0 box--lg:padding-4 box--flex-direction-row typography typography--h3 typography--weight-normal typography--style-normal typography--align-center typography--color-text-default"
       >
         Allow this site to switch the network?
       </h3>
       <h6
-        class="box box--margin-top-1 box--margin-bottom-1 box--sm:padding-4 box--lg:padding-4 box--flex-direction-row typography typography--h7 typography--weight-normal typography--style-normal typography--align-center typography--color-text-alternative"
+        class="box box--margin-top-1 box--margin-bottom-1 box--padding-0 box--sm:padding-4 box--md:padding-0 box--lg:padding-4 box--flex-direction-row typography typography--h7 typography--weight-normal typography--style-normal typography--align-center typography--color-text-alternative"
       >
         This will switch the selected network within MetaMask to a previously added network:
       </h6>
@@ -162,12 +162,12 @@ exports[`switch-ethereum-chain confirmation should show alert if there are pendi
         </div>
       </div>
       <h3
-        class="box box--md:margin-2 box--margin-top-1 box--margin-bottom-1 box--sm:padding-4 box--lg:padding-4 box--flex-direction-row typography typography--h3 typography--weight-normal typography--style-normal typography--align-center typography--color-text-default"
+        class="box box--margin-0 box--sm:margin-0 box--md:margin-2 box--margin-top-1 box--margin-bottom-1 box--padding-0 box--sm:padding-4 box--md:padding-0 box--lg:padding-4 box--flex-direction-row typography typography--h3 typography--weight-normal typography--style-normal typography--align-center typography--color-text-default"
       >
         Allow this site to switch the network?
       </h3>
       <h6
-        class="box box--margin-top-1 box--margin-bottom-1 box--sm:padding-4 box--lg:padding-4 box--flex-direction-row typography typography--h7 typography--weight-normal typography--style-normal typography--align-center typography--color-text-alternative"
+        class="box box--margin-top-1 box--margin-bottom-1 box--padding-0 box--sm:padding-4 box--md:padding-0 box--lg:padding-4 box--flex-direction-row typography typography--h7 typography--weight-normal typography--style-normal typography--align-center typography--color-text-alternative"
       >
         This will switch the selected network within MetaMask to a previously added network:
       </h6>

--- a/ui/pages/create-account/import-account/__snapshots__/json.test.tsx.snap
+++ b/ui/pages/create-account/import-account/__snapshots__/json.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`Json should match snapshot 1`] = `
   >
     Used by a variety of different clients
     <a
-      class="box mm-text mm-button-base mm-button-link mm-button-link--size-inherit mm-text--body-md box--display-inline-flex box--flex-direction-row box--justify-content-center box--align-items-center box--color-primary-default box--background-color-transparent"
+      class="box mm-text mm-button-base mm-button-link mm-button-link--size-inherit mm-text--body-md box--padding-right-0 box--padding-left-0 box--display-inline-flex box--flex-direction-row box--justify-content-center box--align-items-center box--color-primary-default box--background-color-transparent"
       href="https://metamask.zendesk.com/hc/en-us/articles/360015289932"
       rel="noopener noreferrer"
       target="_blank"
@@ -25,12 +25,12 @@ exports[`Json should match snapshot 1`] = `
     class="box mm-form-text-field box--margin-bottom-4 box--display-flex box--flex-direction-column"
   >
     <div
-      class="box mm-text-field mm-text-field--size-md mm-text-field--focused mm-text-field--error mm-text-field--truncate mm-form-text-field__text-field box--display-inline-flex box--flex-direction-row box--align-items-center box--background-color-background-default box--rounded-sm box--border-width-1 box--border-style-solid"
+      class="box mm-text-field mm-text-field--size-md mm-text-field--focused mm-text-field--error mm-text-field--truncate mm-form-text-field__text-field box--padding-right-0 box--padding-left-0 box--display-inline-flex box--flex-direction-row box--align-items-center box--background-color-background-default box--rounded-sm box--border-width-1 box--border-style-solid"
     >
       <input
         aria-invalid="true"
         autocomplete="off"
-        class="box mm-text mm-input mm-input--disable-state-styles mm-text-field__input mm-text--body-md box--padding-right-4 box--padding-left-4 box--flex-direction-row box--color-text-default box--background-color-transparent box--border-style-none"
+        class="box mm-text mm-input mm-input--disable-state-styles mm-text-field__input mm-text--body-md box--margin-0 box--padding-0 box--padding-right-4 box--padding-left-4 box--flex-direction-row box--color-text-default box--background-color-transparent box--border-style-none"
         focused="true"
         id="json-password-box"
         placeholder="Enter optional password"

--- a/ui/pages/institutional/confirm-add-institutional-feature/__snapshots__/confirm-add-institutional-feature.test.js.snap
+++ b/ui/pages/institutional/confirm-add-institutional-feature/__snapshots__/confirm-add-institutional-feature.test.js.snap
@@ -24,7 +24,7 @@ exports[`Confirm Add Institutional Feature opens confirm institutional sucessful
       class="box page-container__content box--flex-direction-row"
     >
       <p
-        class="box mm-text mm-text--body-sm box--margin-top-3 box--margin-right-8 box--margin-left-8 box--flex-direction-row box--color-text-default"
+        class="box mm-text mm-text--body-sm box--margin-top-3 box--margin-right-8 box--margin-bottom-0 box--margin-left-8 box--flex-direction-row box--color-text-default"
       >
         Project Name
       </p>

--- a/ui/pages/institutional/connect-custody/__snapshots__/account-list.test.js.snap
+++ b/ui/pages/institutional/connect-custody/__snapshots__/account-list.test.js.snap
@@ -44,7 +44,7 @@ exports[`CustodyAccountList renders accounts 1`] = `
               class="box mm-text custody-account-list__item mm-text--body-md box--display-flex box--flex-direction-row box--color-text-default"
             >
               <a
-                class="box mm-text mm-button-base mm-button-link mm-button-link--size-auto mm-text--body-md box--display-inline-flex box--flex-direction-row box--justify-content-center box--align-items-center box--color-primary-default box--background-color-transparent"
+                class="box mm-text mm-button-base mm-button-link mm-button-link--size-auto mm-text--body-md box--padding-right-0 box--padding-left-0 box--display-inline-flex box--flex-direction-row box--justify-content-center box--align-items-center box--color-primary-default box--background-color-transparent"
                 href="https://etherscan.io/address/0x1234567890123456789012345678901234567890"
                 rel="noopener noreferrer"
                 target="_blank"
@@ -120,7 +120,7 @@ exports[`CustodyAccountList renders accounts 1`] = `
               class="box mm-text custody-account-list__item mm-text--body-md box--display-flex box--flex-direction-row box--color-text-default"
             >
               <a
-                class="box mm-text mm-button-base mm-button-link mm-button-link--size-auto mm-text--body-md box--display-inline-flex box--flex-direction-row box--justify-content-center box--align-items-center box--color-primary-default box--background-color-transparent"
+                class="box mm-text mm-button-base mm-button-link mm-button-link--size-auto mm-text--body-md box--padding-right-0 box--padding-left-0 box--display-inline-flex box--flex-direction-row box--justify-content-center box--align-items-center box--color-primary-default box--background-color-transparent"
                 href="https://etherscan.io/address/0x0987654321098765432109876543210987654321"
                 rel="noopener noreferrer"
                 target="_blank"

--- a/ui/pages/institutional/custody/__snapshots__/custody.test.js.snap
+++ b/ui/pages/institutional/custody/__snapshots__/custody.test.js.snap
@@ -8,7 +8,7 @@ exports[`CustodyPage renders CustodyPage 1`] = `
     
     
     <div
-      class="box box--sm:padding-7 box--md:padding-2 box--display-flex box--flex-direction-column"
+      class="box box--padding-0 box--sm:padding-7 box--md:padding-2 box--display-flex box--flex-direction-column"
     >
       <button
         aria-label="Back"
@@ -76,7 +76,7 @@ exports[`CustodyPage renders CustodyPage 2`] = `
     
     
     <div
-      class="box box--sm:padding-7 box--md:padding-2 box--display-flex box--flex-direction-column"
+      class="box box--padding-0 box--sm:padding-7 box--md:padding-2 box--display-flex box--flex-direction-column"
     >
       <button
         aria-label="Back"
@@ -151,7 +151,7 @@ exports[`CustodyPage renders CustodyPage 2`] = `
         </div>
       </div>
       <div
-        class="box box--padding-4 box--display-flex box--flex-direction-row box--justify-content-center"
+        class="box box--padding-4 box--sm:padding-0 box--display-flex box--flex-direction-row box--justify-content-center"
       >
         <button
           class="box mm-text mm-button-base mm-button-base--size-md mm-button-primary mm-text--body-md box--margin-right-4 box--padding-right-4 box--padding-left-4 box--display-inline-flex box--flex-direction-row box--justify-content-center box--align-items-center box--color-primary-inverse box--background-color-primary-default box--rounded-pill"

--- a/ui/pages/keychains/__snapshots__/reveal-seed.test.js.snap
+++ b/ui/pages/keychains/__snapshots__/reveal-seed.test.js.snap
@@ -17,7 +17,7 @@ exports[`Reveal Seed Page should match snapshot 1`] = `
          
         The 
         <a
-          class="box mm-text mm-button-base mm-button-link mm-button-link--size-inherit mm-text--body-md box--display-inline-flex box--flex-direction-row box--justify-content-center box--align-items-center box--color-primary-default box--background-color-transparent"
+          class="box mm-text mm-button-base mm-button-link mm-button-link--size-inherit mm-text--body-md box--padding-right-0 box--padding-left-0 box--display-inline-flex box--flex-direction-row box--justify-content-center box--align-items-center box--color-primary-default box--background-color-transparent"
           href="https://metamask.zendesk.com/hc/en-us/articles/360060826432-What-is-a-Secret-Recovery-Phrase-and-how-to-keep-your-crypto-wallet-secure"
           rel="noopener noreferrer"
           target="_blank"
@@ -42,7 +42,7 @@ exports[`Reveal Seed Page should match snapshot 1`] = `
          
         MetaMask is a 
         <a
-          class="box mm-text mm-button-base mm-button-link mm-button-link--size-inherit mm-text--body-md box--display-inline-flex box--flex-direction-row box--justify-content-center box--align-items-center box--color-primary-default box--background-color-transparent"
+          class="box mm-text mm-button-base mm-button-link mm-button-link--size-inherit mm-text--body-md box--padding-right-0 box--padding-left-0 box--display-inline-flex box--flex-direction-row box--justify-content-center box--align-items-center box--color-primary-default box--background-color-transparent"
           href="https://metamask.zendesk.com/hc/en-us/articles/360059952212-MetaMask-is-a-non-custodial-wallet"
           rel="noopener noreferrer"
           target="_blank"
@@ -86,11 +86,11 @@ exports[`Reveal Seed Page should match snapshot 1`] = `
         Enter password to continue
       </label>
       <div
-        class="box mm-text-field mm-text-field--size-lg mm-text-field--focused mm-text-field--truncate box--display-inline-flex box--flex-direction-row box--align-items-center box--width-full box--background-color-background-default box--rounded-sm box--border-width-1 box--border-style-solid"
+        class="box mm-text-field mm-text-field--size-lg mm-text-field--focused mm-text-field--truncate box--padding-right-0 box--padding-left-0 box--display-inline-flex box--flex-direction-row box--align-items-center box--width-full box--background-color-background-default box--rounded-sm box--border-width-1 box--border-style-solid"
       >
         <input
           autocomplete="off"
-          class="box mm-text mm-input mm-input--disable-state-styles mm-text-field__input mm-text--body-md box--padding-right-4 box--padding-left-4 box--flex-direction-row box--color-text-default box--background-color-transparent box--border-style-none"
+          class="box mm-text mm-input mm-input--disable-state-styles mm-text-field__input mm-text--body-md box--margin-0 box--padding-0 box--padding-right-4 box--padding-left-4 box--flex-direction-row box--color-text-default box--background-color-transparent box--border-style-none"
           data-testid="input-password"
           focused="true"
           id="password-box"

--- a/ui/pages/onboarding-flow/metametrics/__snapshots__/metametrics.test.js.snap
+++ b/ui/pages/onboarding-flow/metametrics/__snapshots__/metametrics.test.js.snap
@@ -48,7 +48,7 @@ exports[`Onboarding Metametrics Component should match snapshot 1`] = `
              
             
             <span
-              class="box box--margin-bottom-1 box--flex-direction-row typography typography--span typography--weight-bold typography--style-normal typography--color-text-default"
+              class="box box--margin-top-0 box--margin-bottom-1 box--flex-direction-row typography typography--span typography--weight-bold typography--style-normal typography--color-text-default"
             >
               Never
             </span>

--- a/ui/pages/settings/experimental-tab/__snapshots__/experimental-tab.test.js.snap
+++ b/ui/pages/settings/experimental-tab/__snapshots__/experimental-tab.test.js.snap
@@ -36,7 +36,7 @@ exports[`ExperimentalTab with desktop enabled renders ExperimentalTab component 
             class="settings-page__content-item-col settings-page__content-item-col-open-sea"
           >
             <h5
-              class="box box--margin-top-1 box--flex-direction-row typography typography--h5 typography--weight-medium typography--style-normal typography--color-text-default"
+              class="box box--margin-top-1 box--margin-bottom-0 box--flex-direction-row typography typography--h5 typography--weight-medium typography--style-normal typography--color-text-default"
             >
               OpenSea + Blockaid (Beta)
             </h5>
@@ -83,7 +83,7 @@ exports[`ExperimentalTab with desktop enabled renders ExperimentalTab component 
             </label>
           </div>
           <h6
-            class="box box--margin-bottom-1 box--flex-direction-row typography typography--h6 typography--weight-normal typography--style-normal typography--color-text-alternative"
+            class="box box--margin-top-0 box--margin-bottom-1 box--flex-direction-row typography typography--h6 typography--weight-normal typography--style-normal typography--color-text-alternative"
           >
             <span>
                


### PR DESCRIPTION
## Explanation

**What is the current state of things and why does it need to change?**
Currently `0` value option does not work on the `Box` component margin or padding props. The CSS styles exists but the classNames are not being generated. This was introduced during the responsive props update https://github.com/MetaMask/metamask-extension/pull/15106 and completely my fault 🤦 

**What is the solution your changes offer and how does it work?**
- The `Box` component logic has been updated to resolve the `0` value issue and now generates the correct class names
- Tests have been update to have a more comprehensive coverage for margin, padding and gap.
- Responsive story has been updated to show more responsive prop examples.
- Snapshots updated with missing margin/padding 0 class names

This update removes the `&&` operator during the `generateClassNames` call for each prop and instead does a value check inside of `generateClassNames`. This means `generateClassNames` is called regardless of it's prop value. I've run some basic performance tests and couldn't see a huge change but open to suggestions on this. `0.4ms` vs `0.466ms` after the update run in an incognito window using the react dev tools profiler have documented results below.

* Fixes #16976 

## Screenshots/Screencaps

### Before


https://user-images.githubusercontent.com/8112138/208551691-7e030506-39cc-4ec8-b06a-aa3fb0436311.mov

https://user-images.githubusercontent.com/8112138/208551721-2031caaf-e6ff-4029-a164-fe42b1134b7e.mov

#### Profiler testing performance
- Render 1: `0.4ms`
- Render 2: `0.3ms`
- Render 3: `0.5ms`

Average of `0.4ms`

<img width="721" alt="Screenshot 2022-12-19 at 4 25 03 PM" src="https://user-images.githubusercontent.com/8112138/208553598-4673fadd-f2d5-4df9-9e0e-24b78fac015b.png">
<img width="1439" alt="Screenshot 2022-12-19 at 4 25 40 PM" src="https://user-images.githubusercontent.com/8112138/208553600-ab3e9378-e90d-4c07-a86e-24fb2bb0d660.png">
<img width="1440" alt="Screenshot 2022-12-19 at 4 26 16 PM" src="https://user-images.githubusercontent.com/8112138/208553603-14452fd3-89a5-4328-8383-20c7b74b3afb.png">


### After


https://user-images.githubusercontent.com/8112138/208551746-5643e43a-f459-4f1e-bdf4-dcdd93380e40.mov

https://user-images.githubusercontent.com/8112138/208551766-f24ec980-4f3a-4ed5-ae61-5017cc714c72.mov

#### Profiler testing performance
- Render 1: `0.5ms`
- Render 2: `0.7ms`
- Render 3: `0.2ms`

Average of `0.466ms`

<img width="1440" alt="Screenshot 2022-12-19 at 4 22 39 PM" src="https://user-images.githubusercontent.com/8112138/208553617-46134ec3-242e-47cc-b30a-0a7b729aecc0.png">
<img width="1438" alt="Screenshot 2022-12-19 at 4 23 22 PM" src="https://user-images.githubusercontent.com/8112138/208553621-a7875af4-5935-4047-ade9-68b9d683114c.png">
<img width="1440" alt="Screenshot 2022-12-19 at 4 24 06 PM" src="https://user-images.githubusercontent.com/8112138/208553625-fc92c8a5-f93d-4845-ac4d-be9ef5f184c8.png">


## Manual Testing Steps

- Go to the latest storybook build of this PR
- Search `Box` in the search panel
- Update any of the bounding box controls (margin, marginTop, padding, paddingTop, etc) to use `0` value
- In developer tools check that the className and CSS have been added correctly

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.