### PR TITLE
updated colors for typography component

### DIFF
--- a/ui/components/ui/typography/typography.js
+++ b/ui/components/ui/typography/typography.js
@@ -28,6 +28,10 @@ export const ValidColors = [
   COLORS.WARNING_INVERSE,
   COLORS.INFO_DEFAULT,
   COLORS.INFO_INVERSE,
+  COLORS.GOERLI,
+  COLORS.SEPOLIA,
+  COLORS.GOERLI_INVERSE,
+  COLORS.SEPOLIA_INVERSE,
 ];
 
 export const ValidTags = [
@@ -125,7 +129,7 @@ Typography.propTypes = {
    * The color of the Typography component Should use the COLOR object from
    * ./ui/helpers/constants/design-system.js
    */
-  color: PropTypes.oneOf(Object.values(COLORS)),
+  color: PropTypes.oneOf(ValidColors),
   /**
    * The font-weight of the Typography component. Should use the FONT_WEIGHT object from
    * ./ui/helpers/constants/design-system.js

--- a/ui/components/ui/typography/typography.js
+++ b/ui/components/ui/typography/typography.js
@@ -125,7 +125,7 @@ Typography.propTypes = {
    * The color of the Typography component Should use the COLOR object from
    * ./ui/helpers/constants/design-system.js
    */
-  color: PropTypes.oneOf(ValidColors),
+  color: PropTypes.oneOf(Object.values(COLORS)),
   /**
    * The font-weight of the Typography component. Should use the FONT_WEIGHT object from
    * ./ui/helpers/constants/design-system.js


### PR DESCRIPTION
This PR is to fix the propType error in the `Box` component related to the recent goerli and sepolia update in colors.

* Fixes #17005 

## Before 

<img width="1506" alt="Screenshot 2022-12-20 at 6 39 30 PM" src="https://user-images.githubusercontent.com/39872794/208674855-8b87e4ab-b311-407b-9f9a-2a8d8761a36f.png">

## After

<img width="1503" alt="Screenshot 2022-12-20 at 6 38 59 PM" src="https://user-images.githubusercontent.com/39872794/208674780-17a54ef7-b7d1-49d1-bce0-0fba38ef7bd9.png">
