### PR TITLE
Add `codefi.network` host permission

### DIFF
--- a/app/manifest/v2/_base.json
+++ b/app/manifest/v2/_base.json
@@ -66,6 +66,7 @@
     "clipboardWrite",
     "http://localhost:8545/",
     "https://*.infura.io/",
+    "https://*.codefi.network/",
     "https://chainid.network/chains.json",
     "https://lattice.gridplus.io/*",
     "activeTab",


### PR DESCRIPTION
This host permission bypasses cross-origin restrictions for our internal APIs ([see here for details on host permissions and CORs](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#host_permissions)). This acts as a safeguard, ensuring that if CORs is misconfigured on these endpoints, everything will still work.

Possibly related to #16989

## Manual Testing Steps

We were seeing occasional network failures on Firefox when loading the phishing configuration. We were unable to find reliably steps to reproduce this, but usually I could see it fail by disabling the cache in devtools and refreshing over and over. This should no longer be reproducible after this change.

Otherwise this should have no functional impact. I would recommend manually verifying that the phishing config is still getting updated (either by checking the network tab or trying to visit a site that should be blocked).

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
