### PR TITLE
fix audit failure

### DIFF
--- a/.iyarc
+++ b/.iyarc
@@ -5,3 +5,13 @@ GHSA-257v-vj4p-3w2h
 # it is a false positive. The offending version of 'ws' that is installed is
 # 7.1.1 and is included only via remote-redux-devtools which is a devDependency
 GHSA-6fc8-4gx4-v693
+
+# yarn npm audit reports on a fast-json-patch version < 3.1.1 but due to patch
+# resolution, the only version of fast-json-patch that we use is 3.1.1. We also
+# have 2.2.1 installed but it is a dev only dependency. The "violation" reports
+# smart-transacton-controller as the culprit but if you run
+# `yarn info -A -R dependents fast-json-patch` you can see that only 2.2.1 and
+# 3.3.1 are installed and that smart-transaction-controller resolves to the
+# patched version of 3.3.1. We can remove this once the
+# smart-transaction-controller updates its dependency.
+GHSA-8gh8-hqwg-xf34

--- a/.yarn/patches/fast-json-patch-npm-3.1.1-7e8bb70a45.patch
+++ b/.yarn/patches/fast-json-patch-npm-3.1.1-7e8bb70a45.patch
@@ -1,5 +1,5 @@
 diff --git a/commonjs/helpers.js b/commonjs/helpers.js
-index 0ac28b4d6a715e913da246f1b4b2576c7e5537f4..d048c0a9b498d08fb70337558fa541c1ecc2ed32 100644
+index 5f2350e4c264e61b4b83edf89bbd5d7d9bf2c812..8894686993d61eec7dce91264294f8608db39a31 100644
 --- a/commonjs/helpers.js
 +++ b/commonjs/helpers.js
 @@ -21,7 +21,7 @@ var _hasOwnProperty = Object.prototype.hasOwnProperty;
@@ -10,4 +10,4 @@ index 0ac28b4d6a715e913da246f1b4b2576c7e5537f4..d048c0a9b498d08fb70337558fa541c1
 +Object.defineProperty(exports, "hasOwnProperty", { value: hasOwnProperty });
  function _objectKeys(obj) {
      if (Array.isArray(obj)) {
-         var keys = new Array(obj.length);
+         var keys_1 = new Array(obj.length);

--- a/lavamoat/browserify/beta/policy.json
+++ b/lavamoat/browserify/beta/policy.json
@@ -1171,8 +1171,8 @@
         "@metamask/controller-utils>isomorphic-fetch": true,
         "@metamask/smart-transactions-controller>@metamask/controllers": true,
         "@metamask/smart-transactions-controller>bignumber.js": true,
-        "@metamask/smart-transactions-controller>fast-json-patch": true,
         "ethers>@ethersproject/bytes": true,
+        "fast-json-patch": true,
         "lodash": true
       }
     },
@@ -1395,14 +1395,6 @@
       "globals": {
         "crypto": true,
         "define": true
-      }
-    },
-    "@metamask/smart-transactions-controller>fast-json-patch": {
-      "globals": {
-        "addEventListener": true,
-        "clearTimeout": true,
-        "removeEventListener": true,
-        "setTimeout": true
       }
     },
     "@metamask/snaps-controllers>nanoid": {
@@ -3719,9 +3711,6 @@
         "clearTimeout": true,
         "removeEventListener": true,
         "setTimeout": true
-      },
-      "packages": {
-        "fast-json-patch>fast-deep-equal": true
       }
     },
     "fuse.js": {

--- a/lavamoat/browserify/flask/policy.json
+++ b/lavamoat/browserify/flask/policy.json
@@ -1266,8 +1266,8 @@
         "@metamask/controller-utils>isomorphic-fetch": true,
         "@metamask/smart-transactions-controller>@metamask/controllers": true,
         "@metamask/smart-transactions-controller>bignumber.js": true,
-        "@metamask/smart-transactions-controller>fast-json-patch": true,
         "ethers>@ethersproject/bytes": true,
+        "fast-json-patch": true,
         "lodash": true
       }
     },
@@ -1490,14 +1490,6 @@
       "globals": {
         "crypto": true,
         "define": true
-      }
-    },
-    "@metamask/smart-transactions-controller>fast-json-patch": {
-      "globals": {
-        "addEventListener": true,
-        "clearTimeout": true,
-        "removeEventListener": true,
-        "setTimeout": true
       }
     },
     "@metamask/snaps-controllers": {
@@ -4044,9 +4036,6 @@
         "clearTimeout": true,
         "removeEventListener": true,
         "setTimeout": true
-      },
-      "packages": {
-        "fast-json-patch>fast-deep-equal": true
       }
     },
     "fuse.js": {

--- a/lavamoat/browserify/main/policy.json
+++ b/lavamoat/browserify/main/policy.json
@@ -1171,8 +1171,8 @@
         "@metamask/controller-utils>isomorphic-fetch": true,
         "@metamask/smart-transactions-controller>@metamask/controllers": true,
         "@metamask/smart-transactions-controller>bignumber.js": true,
-        "@metamask/smart-transactions-controller>fast-json-patch": true,
         "ethers>@ethersproject/bytes": true,
+        "fast-json-patch": true,
         "lodash": true
       }
     },
@@ -1395,14 +1395,6 @@
       "globals": {
         "crypto": true,
         "define": true
-      }
-    },
-    "@metamask/smart-transactions-controller>fast-json-patch": {
-      "globals": {
-        "addEventListener": true,
-        "clearTimeout": true,
-        "removeEventListener": true,
-        "setTimeout": true
       }
     },
     "@metamask/snaps-controllers>nanoid": {
@@ -3719,9 +3711,6 @@
         "clearTimeout": true,
         "removeEventListener": true,
         "setTimeout": true
-      },
-      "packages": {
-        "fast-json-patch>fast-deep-equal": true
       }
     },
     "fuse.js": {

--- a/package.json
+++ b/package.json
@@ -167,7 +167,7 @@
     "@fortawesome/fontawesome-free@^5.13.0": "patch:@fortawesome/fontawesome-free@npm%3A5.13.0#./.yarn/patches/@fortawesome-fontawesome-free-npm-5.13.0-f20fc0388d.patch",
     "@keystonehq/bc-ur-registry@^0.5.0-alpha.5": "patch:@keystonehq/bc-ur-registry@npm%3A0.5.0-alpha.5#./.yarn/patches/@keystonehq-bc-ur-registry-npm-0.5.0-alpha.5-b95c7992a6.patch",
     "@lavamoat/lavapack@^3.1.0": "patch:@lavamoat/lavapack@npm%3A3.1.0#./.yarn/patches/@lavamoat-lavapack-npm-3.1.0-34c65d233b.patch",
-    "fast-json-patch@^3.1.0": "patch:fast-json-patch@npm%3A3.1.0#./.yarn/patches/fast-json-patch-npm-3.1.0-f4bd467b5f.patch",
+    "fast-json-patch@^3.1.0": "patch:fast-json-patch@npm%3A3.1.1#./.yarn/patches/fast-json-patch-npm-3.1.1-7e8bb70a45.patch",
     "@reduxjs/toolkit@^1.6.2": "patch:@reduxjs/toolkit@npm%3A1.6.2#./.yarn/patches/@reduxjs-toolkit-npm-1.6.2-67af09515f.patch",
     "parse5@^7.0.0": "patch:parse5@npm%3A7.0.0#./.yarn/patches/parse5-npm-7.0.0-3158a72394.patch",
     "@types/madge@^5.0.0": "patch:@types/madge@npm%3A5.0.0#./.yarn/patches/@types-madge-npm-5.0.0-654566c2d2.patch",
@@ -185,7 +185,8 @@
     "luxon@^3.0.1": "patch:luxon@npm%3A3.1.0#./.yarn/patches/luxon-npm-3.1.0-16e2508500.patch",
     "improved-yarn-audit@^3.0.0": "patch:improved-yarn-audit@npm%3A3.0.0#./.yarn/patches/improved-yarn-audit-npm-3.0.0-3e37ee431a.patch",
     "lockfile-lint-api@^5.4.6": "patch:lockfile-lint-api@npm%3A5.4.6#./.yarn/patches/lockfile-lint-api-npm-5.4.6-dc86b73900.patch",
-    "symbol-observable": "^2.0.3"
+    "symbol-observable": "^2.0.3",
+    "fast-json-patch@^3.1.1": "patch:fast-json-patch@npm%3A3.1.1#./.yarn/patches/fast-json-patch-npm-3.1.1-7e8bb70a45.patch"
   },
   "dependencies": {
     "@babel/runtime": "^7.5.5",
@@ -275,7 +276,7 @@
     "ethjs-contract": "^0.2.3",
     "ethjs-query": "^0.3.4",
     "extension-port-stream": "^2.0.0",
-    "fast-json-patch": "^2.2.1",
+    "fast-json-patch": "^3.1.1",
     "fuse.js": "^3.2.0",
     "globalthis": "^1.0.1",
     "human-standard-token-abi": "^2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15902,10 +15902,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-json-patch@npm:3.1.0":
-  version: 3.1.0
-  resolution: "fast-json-patch@npm:3.1.0"
-  checksum: bad25a6121650d5e138fba787f8e8c6c738779a9a84a978513261110632b1450d96b92a7fedd17188ae847cd5a2b0560725b400a0214aefd3c6506e1be36c66e
+"fast-json-patch@npm:3.1.1":
+  version: 3.1.1
+  resolution: "fast-json-patch@npm:3.1.1"
+  checksum: c4525b61b2471df60d4b025b4118b036d99778a93431aa44d1084218182841d82ce93056f0f3bbd731a24e6a8e69820128adf1873eb2199a26c62ef58d137833
   languageName: node
   linkType: hard
 
@@ -15918,10 +15918,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-json-patch@patch:fast-json-patch@npm%3A3.1.0#./.yarn/patches/fast-json-patch-npm-3.1.0-f4bd467b5f.patch::locator=metamask-crx%40workspace%3A.":
-  version: 3.1.0
-  resolution: "fast-json-patch@patch:fast-json-patch@npm%3A3.1.0#./.yarn/patches/fast-json-patch-npm-3.1.0-f4bd467b5f.patch::version=3.1.0&hash=a705a6&locator=metamask-crx%40workspace%3A."
-  checksum: 4452b428571e0a7650889711952509f08f5301f4f8b0b7fe7d38b92ed830bd2bf76d11a6b1b72b77724a6c4b27dfe66dbca53f91d695b08cec37cf2394945a56
+"fast-json-patch@patch:fast-json-patch@npm%3A3.1.1#./.yarn/patches/fast-json-patch-npm-3.1.1-7e8bb70a45.patch::locator=metamask-crx%40workspace%3A.":
+  version: 3.1.1
+  resolution: "fast-json-patch@patch:fast-json-patch@npm%3A3.1.1#./.yarn/patches/fast-json-patch-npm-3.1.1-7e8bb70a45.patch::version=3.1.1&hash=aa95c0&locator=metamask-crx%40workspace%3A."
+  checksum: 8ad8658818cde8447863e233a1ae333d70e125ad8493794e5a5bb162ba744875ca78031f94348bd31efda06403b9fdcb724e06e495cee6c6a13452823c194d6e
   languageName: node
   linkType: hard
 
@@ -23012,7 +23012,7 @@ __metadata:
     extension-port-stream: ^2.0.0
     fancy-log: ^1.3.3
     fast-glob: ^3.2.2
-    fast-json-patch: ^2.2.1
+    fast-json-patch: ^3.1.1
     fs-extra: ^8.1.0
     fuse.js: ^3.2.0
     ganache: ^v7.0.4


### PR DESCRIPTION
## Explanation
Fixes current audit failure on develop. fast-json-patch is the culprit. I updated our version to use 3.1.1 and patched that version. This removes the need for our 3.1.0 patch. Note that a override was also required because technically smart-transaction-controller has 3.1.0 shipped with it but we use 3.1.1 as our base for the patch and specify that anything requesting 3.1.0 should use 3.1.1. If you use `yarn info -A -R --dependents fast-json-patch` you should only see 3.1.1 and 2.2.1 in the output. Note that the 2.2.1 version is only a development dependency and does not trip the audit failure.

## Manual Testing Steps
1. pull this branch
2. run `yarn`
3. run `yarn info -A -R --dependents fast-json-patch`
4. verify only 3.1.1 and 2.2.1 are included and that both are patched.
5. run `.circleci/scripts/yarn-audit.sh`
6. see no failure.

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
