### PR TITLE
add an extra identifier on anonymized duplicate events

### DIFF
--- a/app/scripts/controllers/metametrics.js
+++ b/app/scripts/controllers/metametrics.js
@@ -34,13 +34,16 @@ const defaultCaptureException = (err) => {
 
 // The function is used to build a unique messageId for segment messages
 // It uses actionId and uniqueIdentifier from event if present
-const buildUniqueMessageId = (args) => {
+const buildUniqueMessageId = (args, isDuplicateAnonymizedEvent = false) => {
   let messageId = '';
   if (args.uniqueIdentifier) {
     messageId += `${args.uniqueIdentifier}-`;
   }
   if (args.actionId) {
     messageId += args.actionId;
+  }
+  if (isDuplicateAnonymizedEvent) {
+    messageId += '-0x000';
   }
   if (messageId.length) {
     return messageId;
@@ -530,6 +533,7 @@ export default class MetaMetricsController {
           this._buildEventPayload({
             ...payload,
             properties: combinedProperties,
+            isDuplicateAnonymizedEvent: true,
           }),
           { ...options, excludeMetaMetricsId: true },
         ),
@@ -646,10 +650,14 @@ export default class MetaMetricsController {
       page,
       referrer,
       environmentType = ENVIRONMENT_TYPE_BACKGROUND,
+      isDuplicateAnonymizedEvent,
     } = rawPayload;
     return {
       event,
-      messageId: buildUniqueMessageId(rawPayload),
+      messageId: buildUniqueMessageId(
+        rawPayload,
+        isDuplicateAnonymizedEvent ?? false,
+      ),
       properties: {
         // These values are omitted from properties because they have special meaning
         // in segment. https://segment.com/docs/connections/spec/track/#properties.

--- a/app/scripts/controllers/metametrics.js
+++ b/app/scripts/controllers/metametrics.js
@@ -34,19 +34,19 @@ const defaultCaptureException = (err) => {
 
 // The function is used to build a unique messageId for segment messages
 // It uses actionId and uniqueIdentifier from event if present
-const buildUniqueMessageId = (args, isDuplicateAnonymizedEvent = false) => {
-  let messageId = '';
+const buildUniqueMessageId = (args) => {
+  const messageIdParts = [];
   if (args.uniqueIdentifier) {
-    messageId += `${args.uniqueIdentifier}-`;
+    messageIdParts.push(args.uniqueIdentifier);
   }
   if (args.actionId) {
-    messageId += args.actionId;
+    messageIdParts.push(args.actionId);
   }
-  if (isDuplicateAnonymizedEvent) {
-    messageId += '-0x000';
+  if (messageIdParts.length && args.isDuplicateAnonymizedEvent) {
+    messageIdParts.push('0x000');
   }
-  if (messageId.length) {
-    return messageId;
+  if (messageIdParts.length) {
+    return messageIdParts.join('-');
   }
   return generateRandomId();
 };
@@ -650,14 +650,10 @@ export default class MetaMetricsController {
       page,
       referrer,
       environmentType = ENVIRONMENT_TYPE_BACKGROUND,
-      isDuplicateAnonymizedEvent,
     } = rawPayload;
     return {
       event,
-      messageId: buildUniqueMessageId(
-        rawPayload,
-        isDuplicateAnonymizedEvent ?? false,
-      ),
+      messageId: buildUniqueMessageId(rawPayload),
       properties: {
         // These values are omitted from properties because they have special meaning
         // in segment. https://segment.com/docs/connections/spec/track/#properties.

--- a/app/scripts/controllers/metametrics.test.js
+++ b/app/scripts/controllers/metametrics.test.js
@@ -159,6 +159,9 @@ describe('MetaMetricsController', function () {
     clock = sinon.useFakeTimers(now.getTime());
     sinon.stub(Utils, 'generateRandomId').returns('DUMMY_RANDOM_ID');
   });
+  afterEach(function () {
+    sinon.restore();
+  });
   describe('constructor', function () {
     it('should properly initialize', function () {
       const mock = sinon.mock(segment);
@@ -674,6 +677,197 @@ describe('MetaMetricsController', function () {
         { isOptInPath: true },
       );
       mock.verify();
+    });
+  });
+
+  describe('deterministic messageId', function () {
+    it('should use the actionId as messageId when provided', function () {
+      const metaMetricsController = getMetaMetricsController();
+      const spy = sinon.spy(segment, 'track');
+      metaMetricsController.submitEvent({
+        event: 'Fake Event',
+        category: 'Unit Test',
+        properties: { foo: 'bar' },
+        actionId: '0x001',
+      });
+      assert.ok(spy.calledOnce);
+      assert.ok(
+        spy.calledWith({
+          event: 'Fake Event',
+          userId: TEST_META_METRICS_ID,
+          context: DEFAULT_TEST_CONTEXT,
+          properties: {
+            foo: 'bar',
+            ...DEFAULT_EVENT_PROPERTIES,
+          },
+          messageId: '0x001',
+          timestamp: new Date(),
+        }),
+      );
+    });
+
+    it('should append 0x000 to the actionId of anonymized event when tracking sensitiveProperties', function () {
+      const metaMetricsController = getMetaMetricsController();
+      const spy = sinon.spy(segment, 'track');
+      metaMetricsController.submitEvent({
+        event: 'Fake Event',
+        category: 'Unit Test',
+        sensitiveProperties: { foo: 'bar' },
+        actionId: '0x001',
+      });
+      assert.ok(spy.calledTwice);
+
+      assert.ok(
+        spy.calledWith({
+          event: 'Fake Event',
+          anonymousId: METAMETRICS_ANONYMOUS_ID,
+          context: DEFAULT_TEST_CONTEXT,
+          properties: {
+            foo: 'bar',
+            ...DEFAULT_EVENT_PROPERTIES,
+          },
+          messageId: '0x001-0x000',
+          timestamp: new Date(),
+        }),
+      );
+      assert.ok(
+        spy.calledWith({
+          event: 'Fake Event',
+          userId: TEST_META_METRICS_ID,
+          context: DEFAULT_TEST_CONTEXT,
+          properties: {
+            ...DEFAULT_EVENT_PROPERTIES,
+          },
+          messageId: '0x001',
+          timestamp: new Date(),
+        }),
+      );
+    });
+
+    it('should use the uniqueIdentifier as messageId when provided', function () {
+      const metaMetricsController = getMetaMetricsController();
+      const spy = sinon.spy(segment, 'track');
+      metaMetricsController.submitEvent({
+        event: 'Fake Event',
+        category: 'Unit Test',
+        properties: { foo: 'bar' },
+        uniqueIdentifier: 'transaction-submitted-0000',
+      });
+      assert.ok(spy.calledOnce);
+      assert.ok(
+        spy.calledWith({
+          event: 'Fake Event',
+          userId: TEST_META_METRICS_ID,
+          context: DEFAULT_TEST_CONTEXT,
+          properties: {
+            foo: 'bar',
+            ...DEFAULT_EVENT_PROPERTIES,
+          },
+          messageId: 'transaction-submitted-0000',
+          timestamp: new Date(),
+        }),
+      );
+    });
+
+    it('should append 0x000 to the uniqueIdentifier of anonymized event when tracking sensitiveProperties', function () {
+      const metaMetricsController = getMetaMetricsController();
+      const spy = sinon.spy(segment, 'track');
+      metaMetricsController.submitEvent({
+        event: 'Fake Event',
+        category: 'Unit Test',
+        sensitiveProperties: { foo: 'bar' },
+        uniqueIdentifier: 'transaction-submitted-0000',
+      });
+      assert.ok(spy.calledTwice);
+      assert.ok(
+        spy.calledWith({
+          event: 'Fake Event',
+          anonymousId: METAMETRICS_ANONYMOUS_ID,
+          context: DEFAULT_TEST_CONTEXT,
+          properties: {
+            foo: 'bar',
+            ...DEFAULT_EVENT_PROPERTIES,
+          },
+          messageId: 'transaction-submitted-0000-0x000',
+          timestamp: new Date(),
+        }),
+      );
+      assert.ok(
+        spy.calledWith({
+          event: 'Fake Event',
+          userId: TEST_META_METRICS_ID,
+          context: DEFAULT_TEST_CONTEXT,
+          properties: {
+            ...DEFAULT_EVENT_PROPERTIES,
+          },
+          messageId: 'transaction-submitted-0000',
+          timestamp: new Date(),
+        }),
+      );
+    });
+
+    it('should combine the uniqueIdentifier and actionId as messageId when both provided', function () {
+      const metaMetricsController = getMetaMetricsController();
+      const spy = sinon.spy(segment, 'track');
+      metaMetricsController.submitEvent({
+        event: 'Fake Event',
+        category: 'Unit Test',
+        properties: { foo: 'bar' },
+        actionId: '0x001',
+        uniqueIdentifier: 'transaction-submitted-0000',
+      });
+      assert.ok(spy.calledOnce);
+      assert.ok(
+        spy.calledWith({
+          event: 'Fake Event',
+          userId: TEST_META_METRICS_ID,
+          context: DEFAULT_TEST_CONTEXT,
+          properties: {
+            foo: 'bar',
+            ...DEFAULT_EVENT_PROPERTIES,
+          },
+          messageId: 'transaction-submitted-0000-0x001',
+          timestamp: new Date(),
+        }),
+      );
+    });
+
+    it('should append 0x000 to the combined uniqueIdentifier and actionId of anonymized event when tracking sensitiveProperties', function () {
+      const metaMetricsController = getMetaMetricsController();
+      const spy = sinon.spy(segment, 'track');
+      metaMetricsController.submitEvent({
+        event: 'Fake Event',
+        category: 'Unit Test',
+        sensitiveProperties: { foo: 'bar' },
+        actionId: '0x001',
+        uniqueIdentifier: 'transaction-submitted-0000',
+      });
+      assert.ok(spy.calledTwice);
+      assert.ok(
+        spy.calledWith({
+          event: 'Fake Event',
+          anonymousId: METAMETRICS_ANONYMOUS_ID,
+          context: DEFAULT_TEST_CONTEXT,
+          properties: {
+            foo: 'bar',
+            ...DEFAULT_EVENT_PROPERTIES,
+          },
+          messageId: 'transaction-submitted-0000-0x001-0x000',
+          timestamp: new Date(),
+        }),
+      );
+      assert.ok(
+        spy.calledWith({
+          event: 'Fake Event',
+          userId: TEST_META_METRICS_ID,
+          context: DEFAULT_TEST_CONTEXT,
+          properties: {
+            ...DEFAULT_EVENT_PROPERTIES,
+          },
+          messageId: 'transaction-submitted-0000-0x001',
+          timestamp: new Date(),
+        }),
+      );
     });
   });
 

--- a/app/scripts/controllers/metametrics.test.js
+++ b/app/scripts/controllers/metametrics.test.js
@@ -159,9 +159,7 @@ describe('MetaMetricsController', function () {
     clock = sinon.useFakeTimers(now.getTime());
     sinon.stub(Utils, 'generateRandomId').returns('DUMMY_RANDOM_ID');
   });
-  afterEach(function () {
-    sinon.restore();
-  });
+
   describe('constructor', function () {
     it('should properly initialize', function () {
       const mock = sinon.mock(segment);


### PR DESCRIPTION
## Explanation
in #16267 we shifted to using a deterministic message id for actions that originate from the UI via calls to the background process, and therefore have an 'actionId' associated, or if they use a uniqueIdentifier. As a result only one of our two events were being tracked for any events that used one of these two pathways. This PR adds a new property to the rawPayload object expected by buildEventPayload, called 'isDuplicateAnonymizedEvent' which will append a '0x000' modifier to the messageId without modifying the fragment name at all.

The reason this happened is not because our code somehow prevented the action from firing but rather that segment treats duplicate message ids as the same event and keeps the first, discarding future events with the same id. 

## Manual Testing Steps
1. Add the development segment write key to your .metamaskrc
2. Run `yarn start`
3. Make sure metametrics is enabled.
4. Inspect the background process.
5. Login to segment
6. View the development metamask property and visit the debugger
7. Make a send transaction.
8. Inspect network tab and see both events are fired

*On develop*
1. In debugger see only one event shows up for each "transaction" event such as "Transaction Submitted"

*On this branch*
1. In debugger see both events are tracked.

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
