### PR TITLE
Ensure that protect your funds popover is displayed above tooltip

### DIFF
--- a/ui/pages/home/home.component.js
+++ b/ui/pages/home/home.component.js
@@ -622,6 +622,7 @@ export default class Home extends PureComponent {
                   open={
                     !process.env.IN_TEST &&
                     !shouldShowSeedPhraseReminder &&
+                    !showRecoveryPhraseReminder &&
                     showPortfolioTooltip
                   }
                   interactive


### PR DESCRIPTION


## Explanation

When starting MetaMask with a fresh install _**Portfolio tooltip**_  is above _**Protect your fund popover**_. 

With this PR we will show _**Portfolio** tooltip_ only when _**Protect your fund popover**_  is not on the screen.

<!--
Thanks for the pull request. Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues, Slack conversations, Zendesk issues, user stories, etc. reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->
* Fixes #16387 
## Screenshots/Screencaps

<!-- If you're making a change to the UI, make sure to capture a screenshot or a short video showing off your work! -->

### Before

<!-- How did the UI you changed look before your changes? Drag your file(s) below this line: -->

![image](https://user-images.githubusercontent.com/97883527/210765431-4f109498-e80c-4d46-b214-a9672efd2c12.png)


### After

<!-- How does it look now? Drag your file(s) below this line: -->

<img width="352" alt="image" src="https://user-images.githubusercontent.com/97883527/210766823-13140521-b1a2-4620-a311-8b564730f7a0.png">


## Manual Testing Steps

<!--
How should reviewers and QA manually test your changes? For instance:

- Go to this screen
- Do this
- Then do this
-->

Newly install or update version of MetaMask
When a new Protect your fund popover is available
It should be displayed.

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
