### PR TITLE
Onboarding V2: Fix 'Securing my Wallet' when coming from backup reminder after account recovery

### DIFF
--- a/ui/pages/onboarding-flow/recovery-phrase/review-recovery-phrase.js
+++ b/ui/pages/onboarding-flow/recovery-phrase/review-recovery-phrase.js
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { useHistory } from 'react-router-dom';
+import { useHistory, useLocation } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import Box from '../../../components/ui/box';
 import Button from '../../../components/ui/button';
@@ -23,9 +23,14 @@ import RecoveryPhraseChips from './recovery-phrase-chips';
 export default function RecoveryPhrase({ secretRecoveryPhrase }) {
   const history = useHistory();
   const t = useI18nContext();
+  const { search } = useLocation();
   const [copied, handleCopy] = useCopyToClipboard();
   const [phraseRevealed, setPhraseRevealed] = useState(false);
   const [hiddenPhrase, setHiddenPhrase] = useState(false);
+  const searchParams = new URLSearchParams(search);
+  const isFromReminderParam = searchParams.get('isFromReminder')
+    ? '/?isFromReminder=true'
+    : '';
 
   return (
     <div className="recovery-phrase" data-testid="recovery-phrase">
@@ -122,7 +127,9 @@ export default function RecoveryPhrase({ secretRecoveryPhrase }) {
               type="primary"
               className="recovery-phrase__footer--button"
               onClick={() => {
-                history.push(ONBOARDING_CONFIRM_SRP_ROUTE);
+                history.push(
+                  `${ONBOARDING_CONFIRM_SRP_ROUTE}${isFromReminderParam}`,
+                );
               }}
             >
               {t('next')}

--- a/ui/pages/onboarding-flow/secure-your-wallet/secure-your-wallet.js
+++ b/ui/pages/onboarding-flow/secure-your-wallet/secure-your-wallet.js
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { useHistory } from 'react-router-dom';
+import { useHistory, useLocation } from 'react-router-dom';
 import { useSelector } from 'react-redux';
 import Box from '../../../components/ui/box';
 import Button from '../../../components/ui/button';
@@ -23,12 +23,17 @@ import SkipSRPBackup from './skip-srp-backup-popover';
 export default function SecureYourWallet() {
   const history = useHistory();
   const t = useI18nContext();
+  const { search } = useLocation();
   const currentLocale = useSelector(getCurrentLocale);
   const [showSkipSRPBackupPopover, setShowSkipSRPBackupPopover] =
     useState(false);
+  const searchParams = new URLSearchParams(search);
+  const isFromReminderParam = searchParams.get('isFromReminder')
+    ? '/?isFromReminder=true'
+    : '';
 
   const handleClickRecommended = () => {
-    history.push(ONBOARDING_REVIEW_SRP_ROUTE);
+    history.push(`${ONBOARDING_REVIEW_SRP_ROUTE}${isFromReminderParam}`);
   };
 
   const handleClickNotRecommended = () => {


### PR DESCRIPTION
Fixes: https://github.com/MetaMask/metamask-extension/issues/17025

## Explanation

This expands on a fix implemented in https://github.com/MetaMask/metamask-extension/pull/16916

The `isFromReminder` parameter needs to persist in a couple of places when coming from the backup reminder in order to complete the backup flow.

## Screenshots/Screencaps

https://user-images.githubusercontent.com/8732757/210885698-732d43a8-4689-4c99-85c1-a244f59ca3bf.mov

## Manual Testing Steps
1. Perform all the Onboarding V2 for Create Account without securing the seed phrase
2. Lock MM
3. Click Forgot Password
4. Add a Seed Phrase and Password
5. Login
6.  Click on the Backup reminder from Home page
7. Click on Secure my Wallet 
8. Ensure you can complete the backup process as expected

## Pre-merge author checklist

- [ ] I've clearly explained:
  - [X] What problem this PR is solving
  - [X] How this problem was solved
  - [X] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
