### PR TITLE
Fix 'Back' navigation from Restore Vault page when accessed from popup

### DIFF
--- a/ui/pages/keychains/restore-vault.js
+++ b/ui/pages/keychains/restore-vault.js
@@ -61,7 +61,7 @@ class RestoreVaultPage extends Component {
               onClick={(e) => {
                 e.preventDefault();
                 this.props.leaveImportSeedScreenState();
-                this.props.history.goBack();
+                this.props.history.push(DEFAULT_ROUTE);
               }}
               href="#"
             >


### PR DESCRIPTION
Fixes: https://github.com/MetaMask/metamask-extension/issues/17094

## Explanation
`history.goBack()` was being used for backwards navigation from Restore Vault. In the case the page was accessed from the "Forgot Password" prompt in the popup window, there was nothing to "go back" to. We can just push `DEFAULT_ROUTE` here safely as a catch-all.

## Screenshots/Screencaps
https://user-images.githubusercontent.com/8732757/211091174-b9acd56a-ed29-486f-82be-a4f86fedacaa.mov

## Manual Testing Steps
1. Open the extension by clicking the extension icon in browser
2. Click the "forgot password" link
3. Try to click the "Back" button from the opened Reset Wallet screen
4. Ensure you are navigated back to the Unlock screen

<!--
How should reviewers and QA manually test your changes? For instance:

- Go to this screen
- Do this
- Then do this
-->

## Pre-merge author checklist

- [X] I've clearly explained:
  - [X] What problem this PR is solving
  - [X] How this problem was solved
  - [X] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
