### PR TITLE
Button exploration using more Box props and less CSS

### DIFF
--- a/ui/components/component-library/button-base/README.mdx
+++ b/ui/components/component-library/button-base/README.mdx
@@ -26,7 +26,6 @@ Optional: `BUTTON_BASE_SIZES` from `./button-base` object can be used instead of
 
 Possible sizes include:
 
-- `SIZES.AUTO` inherits the font-size of the parent element.
 - `SIZES.SM` 32px
 - `SIZES.MD` 40px
 - `SIZES.LG` 48px
@@ -39,7 +38,6 @@ Possible sizes include:
 import { SIZES } from '../../../helpers/constants/design-system';
 import { ButtonBase } from '../../ui/components/component-library';
 
-<ButtonBase size={SIZES.AUTO} />
 <ButtonBase size={SIZES.SM} />
 <ButtonBase size={SIZES.MD} />
 <ButtonBase size={SIZES.LG} />
@@ -59,45 +57,6 @@ import { ButtonBase } from '../../ui/components/component-library';
 
 <ButtonBase>Default Button</ButtonBase>
 <ButtonBase block>Block Button</ButtonBase>
-```
-
-### As
-
-Use the `as` box prop to change the element of `ButtonBase`. Defaults to `button`.
-
-When an `href` prop is passed it will change the element to an anchor(`a`) tag.
-
-Button `as` options:
-
-- `button`
-- `a`
-
-<Canvas>
-  <Story id="ui-components-component-library-button-base-button-base-stories-js--as" />
-</Canvas>
-
-```jsx
-import { ButtonBase } from '../../ui/components/component-library';
-
-
-<ButtonBase as="button">Button Element</ButtonBase>
-<ButtonBase as="a" href="#">
-  Anchor Element
-</ButtonBase>
-```
-
-### Href
-
-When an `href` prop is passed it will change the element to an anchor(`a`) tag.
-
-<Canvas>
-  <Story id="ui-components-component-library-button-base-button-base-stories-js--href" />
-</Canvas>
-
-```jsx
-import { ButtonBase } from '../../ui/components/component-library';
-
-<ButtonBase href="/metamask">Anchor Element</ButtonBase>;
 ```
 
 ### Disabled

--- a/ui/components/component-library/button-base/__snapshots__/button-base.test.js.snap
+++ b/ui/components/component-library/button-base/__snapshots__/button-base.test.js.snap
@@ -3,11 +3,11 @@
 exports[`ButtonBase should render button element correctly and match snapshot 1`] = `
 <div>
   <button
-    class="box mm-button-base mm-button-base--size-md box--padding-right-4 box--padding-left-4 box--display-inline-flex box--flex-direction-row box--justify-content-center box--align-items-center box--rounded-pill"
+    class="box mm-button-base mm-button-base--size-md box--padding-right-4 box--padding-left-4 box--display-inline-flex box--flex-direction-row box--justify-content-center box--align-items-center box--color-text-default box--background-color-background-alternative box--rounded-pill box--border-color-border-default box--border-style-solid box--border-width-1"
     data-testid="button-base"
   >
     <span
-      class="box mm-text mm-button-base__content mm-text--body-md mm-text--color-inherit box--gap-2 box--flex-direction-row box--justify-content-center box--align-items-center box--display-flex"
+      class="box mm-text mm-button-base__content mm-text--body-md mm-text--color-inherit box--display-inline-flex box--gap-2 box--flex-direction-row box--justify-content-center box--align-items-center"
     >
       Button base
     </span>

--- a/ui/components/component-library/button-base/button-base.constants.js
+++ b/ui/components/component-library/button-base/button-base.constants.js
@@ -4,5 +4,4 @@ export const BUTTON_BASE_SIZES = {
   SM: SIZES.SM,
   MD: SIZES.MD,
   LG: SIZES.LG,
-  AUTO: SIZES.AUTO,
 };

--- a/ui/components/component-library/button-base/button-base.js
+++ b/ui/components/component-library/button-base/button-base.js
@@ -10,7 +10,7 @@ import {
   ALIGN_ITEMS,
   DISPLAY,
   JUSTIFY_CONTENT,
-  TEXT_COLORS,
+  COLORS,
   TEXT,
   SIZES,
   FLEX_DIRECTION,
@@ -19,80 +19,70 @@ import {
 import { BUTTON_BASE_SIZES } from './button-base.constants';
 
 export const ButtonBase = ({
-  as = 'button',
   block,
   children,
   className,
-  href,
   size = BUTTON_BASE_SIZES.MD,
   iconName,
   iconPositionRight,
   loading,
   disabled,
   iconProps,
+  buttonTextProps,
   ...props
-}) => {
-  const Tag = href ? 'a' : as;
-  return (
-    <Box
-      as={Tag}
-      href={href}
-      paddingLeft={size === BUTTON_BASE_SIZES.AUTO ? 0 : 4}
-      paddingRight={size === BUTTON_BASE_SIZES.AUTO ? 0 : 4}
-      borderRadius={BORDER_RADIUS.PILL}
-      className={classnames(
-        'mm-button-base',
-        `mm-button-base--size-${size}`,
-        {
-          'mm-button-base--loading': loading,
-          'mm-button-base--disabled': disabled,
-          'mm-button-base--block': block,
-        },
-        className,
-      )}
-      disabled={disabled}
+}) => (
+  <Box
+    as="button"
+    paddingLeft={4}
+    paddingRight={4}
+    borderRadius={BORDER_RADIUS.PILL}
+    className={classnames(
+      'mm-button-base',
+      `mm-button-base--size-${size}`,
+      {
+        'mm-button-base--loading': loading,
+        'mm-button-base--disabled': disabled,
+        'mm-button-base--block': block,
+      },
+      className,
+    )}
+    disabled={disabled}
+    display={DISPLAY.INLINE_FLEX}
+    justifyContent={JUSTIFY_CONTENT.CENTER}
+    alignItems={ALIGN_ITEMS.CENTER}
+    color={COLORS.TEXT_DEFAULT}
+    backgroundColor={COLORS.BACKGROUND_ALTERNATIVE}
+    borderColor={COLORS.BORDER_DEFAULT}
+    {...props}
+  >
+    <Text
+      as="span"
+      className="mm-button-base__content"
       display={DISPLAY.INLINE_FLEX}
-      justifyContent={JUSTIFY_CONTENT.CENTER}
       alignItems={ALIGN_ITEMS.CENTER}
-      {...props}
+      justifyContent={JUSTIFY_CONTENT.CENTER}
+      flexDirection={
+        iconPositionRight ? FLEX_DIRECTION.ROW_REVERSE : FLEX_DIRECTION.ROW
+      }
+      gap={2}
+      variant={TEXT.BODY_MD}
+      color={COLORS.INHERIT}
+      {...buttonTextProps}
     >
-      <Text
-        as="span"
-        className="mm-button-base__content"
-        alignItems={ALIGN_ITEMS.CENTER}
-        justifyContent={JUSTIFY_CONTENT.CENTER}
-        flexDirection={
-          iconPositionRight ? FLEX_DIRECTION.ROW_REVERSE : FLEX_DIRECTION.ROW
-        }
-        gap={2}
-        variant={size === BUTTON_BASE_SIZES.AUTO ? TEXT.INHERIT : TEXT.BODY_MD}
-        color={TEXT_COLORS.INHERIT}
-      >
-        {iconName && (
-          <Icon
-            name={iconName}
-            size={size === BUTTON_BASE_SIZES.AUTO ? SIZES.AUTO : SIZES.SM}
-            {...iconProps}
-          />
-        )}
-        {children}
-      </Text>
-      {loading && (
-        <Icon
-          className="mm-button-base__icon-loading"
-          name={ICON_NAMES.LOADING_FILLED}
-          size={size === BUTTON_BASE_SIZES.AUTO ? SIZES.AUTO : SIZES.MD}
-        />
-      )}
-    </Box>
-  );
-};
+      {iconName && <Icon name={iconName} size={SIZES.SM} {...iconProps} />}
+      {children}
+    </Text>
+    {loading && (
+      <Icon
+        className="mm-button-base__icon-loading"
+        name={ICON_NAMES.LOADING_FILLED}
+        size={SIZES.MD}
+      />
+    )}
+  </Box>
+);
 
 ButtonBase.propTypes = {
-  /**
-   * The polymorphic `as` prop allows you to change the root HTML element of the Button component between `button` and `a` tag
-   */
-  as: PropTypes.string,
   /**
    * Boolean prop to quickly activate box prop display block
    */
@@ -102,6 +92,10 @@ ButtonBase.propTypes = {
    */
   children: PropTypes.node,
   /**
+   * Additional props to pass to the Text component that wraps the button children
+   */
+  buttonTextProps: PropTypes.shape(Text.PropTypes),
+  /**
    * An additional className to apply to the ButtonBase.
    */
   className: PropTypes.string,
@@ -109,10 +103,6 @@ ButtonBase.propTypes = {
    * Boolean to disable button
    */
   disabled: PropTypes.bool,
-  /**
-   * When an `href` prop is passed, ButtonBase will automatically change the root element to be an `a` (anchor) tag
-   */
-  href: PropTypes.string,
   /**
    * Add icon to left side of button text passing icon name
    * The name of the icon to display. Should be one of ICON_NAMES
@@ -133,7 +123,7 @@ ButtonBase.propTypes = {
   loading: PropTypes.bool,
   /**
    * The size of the ButtonBase.
-   * Possible values could be 'SIZES.AUTO', 'SIZES.SM'(32px), 'SIZES.MD'(40px), 'SIZES.LG'(48px),
+   * Possible values could be 'SIZES.SM'(32px), 'SIZES.MD'(40px), 'SIZES.LG'(48px),
    */
   size: PropTypes.oneOf(Object.values(BUTTON_BASE_SIZES)),
   /**

--- a/ui/components/component-library/button-base/button-base.scss
+++ b/ui/components/component-library/button-base/button-base.scss
@@ -1,17 +1,9 @@
 .mm-button-base {
   position: relative;
   height: 40px;
-  padding: 0;
   cursor: pointer;
-  color: var(--color-text-default);
-  background-color: var(--brand-colors-grey-grey100);
   vertical-align: middle;
   user-select: none;
-
-  &:active,
-  &:hover {
-    color: var(--color-text-default);
-  }
 
   &--block {
     display: block;
@@ -21,7 +13,6 @@
   &__content {
     height: 100%;
   }
-
 
   &--size-sm {
     height: 32px;
@@ -33,18 +24,6 @@
 
   &--size-lg {
     height: 48px;
-  }
-
-  &--size-auto {
-    height: auto;
-    background-color: transparent;
-    border-radius: 0;
-    vertical-align: top;
-    font-family: inherit;
-    font-weight: inherit;
-    font-size: inherit;
-    line-height: inherit;
-    letter-spacing: inherit;
   }
 
   &--loading {

--- a/ui/components/component-library/button-base/button-base.stories.js
+++ b/ui/components/component-library/button-base/button-base.stories.js
@@ -2,13 +2,10 @@ import React from 'react';
 import {
   ALIGN_ITEMS,
   DISPLAY,
-  FLEX_DIRECTION,
   SIZES,
-  TEXT,
 } from '../../../helpers/constants/design-system';
 import Box from '../../ui/box/box';
 import { ICON_NAMES } from '../icon';
-import { Text } from '../text';
 import { BUTTON_BASE_SIZES } from './button-base.constants';
 import { ButtonBase } from './button-base';
 import README from './README.mdx';
@@ -116,12 +113,6 @@ export const Size = (args) => (
         Button LG
       </ButtonBase>
     </Box>
-    <Text variant={TEXT.BODY_SM}>
-      <ButtonBase {...args} size={SIZES.AUTO}>
-        Button Auto
-      </ButtonBase>{' '}
-      inherits the font-size of the parent element.
-    </Text>
   </>
 );
 
@@ -135,21 +126,6 @@ export const Block = (args) => (
     </ButtonBase>
   </>
 );
-
-export const As = (args) => (
-  <Box display={DISPLAY.FLEX} flexDirection={FLEX_DIRECTION.ROW} gap={2}>
-    <ButtonBase {...args}>Button Element</ButtonBase>
-    <ButtonBase as="a" href="#" {...args}>
-      Anchor Element
-    </ButtonBase>
-  </Box>
-);
-
-export const Href = (args) => <ButtonBase {...args}>Anchor Element</ButtonBase>;
-
-Href.args = {
-  href: '/metamask',
-};
 
 export const Disabled = (args) => (
   <ButtonBase {...args}>Disabled Button</ButtonBase>

--- a/ui/components/component-library/button-base/button-base.test.js
+++ b/ui/components/component-library/button-base/button-base.test.js
@@ -15,30 +15,6 @@ describe('ButtonBase', () => {
     expect(container).toMatchSnapshot();
   });
 
-  it('should render anchor element correctly', () => {
-    const { getByTestId, container } = render(
-      <ButtonBase as="a" data-testid="button-base" />,
-    );
-    expect(getByTestId('button-base')).toHaveClass('mm-button-base');
-    const anchor = container.getElementsByTagName('a').length;
-    expect(anchor).toBe(1);
-  });
-
-  it('should render anchor element correctly by href only being passed and href exists', () => {
-    const { getByTestId, container } = render(
-      <ButtonBase href="https://www.test.com/" data-testid="button-base">
-        Button Base
-      </ButtonBase>,
-    );
-    expect(getByTestId('button-base')).toHaveClass('mm-button-base');
-    expect(getByTestId('button-base')).toHaveAttribute(
-      'href',
-      'https://www.test.com/',
-    );
-    const anchor = container.getElementsByTagName('a').length;
-    expect(anchor).toBe(1);
-  });
-
   it('should render button as block', () => {
     const { getByTestId } = render(<ButtonBase block data-testid="block" />);
     expect(getByTestId('block')).toHaveClass(`mm-button-base--block`);
@@ -47,10 +23,6 @@ describe('ButtonBase', () => {
   it('should render with different size classes', () => {
     const { getByTestId } = render(
       <>
-        <ButtonBase
-          size={BUTTON_BASE_SIZES.AUTO}
-          data-testid={BUTTON_BASE_SIZES.AUTO}
-        />
         <ButtonBase
           size={BUTTON_BASE_SIZES.SM}
           data-testid={BUTTON_BASE_SIZES.SM}
@@ -64,9 +36,6 @@ describe('ButtonBase', () => {
           data-testid={BUTTON_BASE_SIZES.LG}
         />
       </>,
-    );
-    expect(getByTestId(BUTTON_BASE_SIZES.AUTO)).toHaveClass(
-      `mm-button-base--size-${BUTTON_BASE_SIZES.AUTO}`,
     );
     expect(getByTestId(BUTTON_BASE_SIZES.SM)).toHaveClass(
       `mm-button-base--size-${BUTTON_BASE_SIZES.SM}`,

--- a/ui/components/component-library/button-link/README.mdx
+++ b/ui/components/component-library/button-link/README.mdx
@@ -35,7 +35,7 @@ Possible sizes include:
 
 ```jsx
 import { SIZES } from '../../../helpers/constants/design-system';
-import { ButtonLink } from '../../ui/components/component-library';
+import { ButtonLink } from '../../component-library';
 
 <ButtonLink size={SIZES.AUTO} />
 <ButtonLink size={SIZES.SM} />
@@ -52,22 +52,47 @@ Use the `danger` boolean prop to change the `ButtonLink` to danger color.
 </Canvas>
 
 ```jsx
-import { ButtonLink } from '../../ui/components/component-library';
+import { ButtonLink } from '../../component-library';
 
 <ButtonLink>Normal</ButtonLink>
 <ButtonLink danger>Danger</ButtonLink>
 ```
 
-### Href
+### As
 
-When an `href` is passed the tag element will switch to an `anchor`(`a`) tag.
+Use the `as` box prop to change the element of `ButtonLink`. Defaults to `button`.
+
+When an `href` prop is passed it will change the element to an anchor(`a`) tag.
+
+Button `as` options:
+
+- `button`
+- `a`
 
 <Canvas>
-  <Story id="ui-components-component-library-button-link-button-link-stories-js--href" />
+  <Story id="ui-components-component-library-button-base-button-base-stories-js--as" />
 </Canvas>
 
 ```jsx
-import { ButtonLink } from '../../ui/components/component-library';
+import { ButtonLink } from '../../component-library';
 
-<ButtonLink href="/">Href Example</ButtonLink>;
+
+<ButtonLink as="button">Button Element</ButtonLink>
+<ButtonLink as="a" href="#">
+  Anchor Element
+</ButtonLink>
+```
+
+### Href
+
+When an `href` prop is passed it will change the element to an anchor(`a`) tag.
+
+<Canvas>
+  <Story id="ui-components-component-library-button-base-button-base-stories-js--href" />
+</Canvas>
+
+```jsx
+import { ButtonLink } from '../../component-library';
+
+<ButtonLink href="/metamask">Anchor Element</ButtonLink>;
 ```

--- a/ui/components/component-library/button-link/__snapshots__/button-link.test.js.snap
+++ b/ui/components/component-library/button-link/__snapshots__/button-link.test.js.snap
@@ -3,11 +3,11 @@
 exports[`ButtonLink should render button element correctly 1`] = `
 <div>
   <button
-    class="box mm-button-base mm-button-base--size-md mm-button-link box--padding-right-4 box--padding-left-4 box--display-inline-flex box--flex-direction-row box--justify-content-center box--align-items-center box--background-color-transparent box--rounded-pill"
+    class="box mm-button-base mm-button-base--size-md mm-button-link box--padding-right-4 box--padding-left-4 box--display-inline-flex box--flex-direction-row box--justify-content-center box--align-items-center box--color-primary-default box--background-color-transparent box--rounded-pill box--border-style-none box--border-color-border-default box--border-width-1"
     data-testid="button-link"
   >
     <span
-      class="box mm-text mm-button-base__content mm-text--body-md mm-text--color-inherit box--gap-2 box--flex-direction-row box--justify-content-center box--align-items-center box--display-flex"
+      class="box mm-text mm-button-base__content mm-text--body-md mm-text--color-inherit box--display-inline-flex box--gap-2 box--flex-direction-row box--justify-content-center box--align-items-center"
     >
       Button Link
     </span>

--- a/ui/components/component-library/button-link/button-link.js
+++ b/ui/components/component-library/button-link/button-link.js
@@ -3,30 +3,56 @@ import PropTypes from 'prop-types';
 import classnames from 'classnames';
 
 import { ButtonBase } from '../button-base';
-import { COLORS } from '../../../helpers/constants/design-system';
+import {
+  BORDER_STYLE,
+  COLORS,
+  SIZES,
+  TEXT,
+} from '../../../helpers/constants/design-system';
 import { BUTTON_LINK_SIZES } from './button-link.constants';
 
 export const ButtonLink = ({
   className,
   danger,
   disabled,
-  size = BUTTON_LINK_SIZES.MD,
+  size = SIZES.MD,
+  as = 'button',
+  href,
   ...props
 }) => {
+  const Tag = href ? 'a' : as;
   return (
     <ButtonBase
       className={classnames(className, 'mm-button-link', {
         'mm-button-link--type-danger': danger,
         'mm-button-link--disabled': disabled,
+        'mm-button-link--size-auto': size === SIZES.AUTO,
       })}
-      size={size}
+      as={Tag}
+      href={href}
+      size={size === SIZES.AUTO ? null : size}
+      paddingLeft={size === SIZES.AUTO ? 0 : 4} // TODO will work once 0 value Box is fixed
+      paddingRight={size === SIZES.AUTO ? 0 : 4} // TODO will work once 0 value Box is fixed
+      color={danger ? COLORS.ERROR_DEFAULT : COLORS.PRIMARY_DEFAULT}
+      borderStyle={BORDER_STYLE.NONE}
       backgroundColor={COLORS.TRANSPARENT}
+      buttonTextProps={{
+        variant: size === SIZES.AUTO ? TEXT.INHERIT : TEXT.BODY_MD,
+      }}
       {...{ disabled, ...props }}
     />
   );
 };
 
 ButtonLink.propTypes = {
+  /**
+   * The polymorphic `as` prop allows you to change the root HTML element of the Button component between `button` and `a` tag
+   */
+  as: PropTypes.string,
+  /**
+   * When an `href` prop is passed, ButtonLink will automatically change the root element to be an `a` (anchor) tag
+   */
+  href: PropTypes.string,
   /**
    * An additional className to apply to the ButtonLink.
    */
@@ -40,12 +66,13 @@ ButtonLink.propTypes = {
    */
   disabled: PropTypes.bool,
   /**
-   * Possible size values: 'SIZES.AUTO', 'SIZES.SM'(32px), 'SIZES.MD'(40px), 'SIZES.LG'(48px).
-   * Default value is 'SIZES.MD'.
-   */
-  size: PropTypes.oneOf(Object.values(BUTTON_LINK_SIZES)),
-  /**
    * ButtonLink accepts all the props from ButtonBase
    */
   ...ButtonBase.propTypes,
+  /**
+   * Possible size values: 'SIZES.AUTO', 'SIZES.SM'(32px), 'SIZES.MD'(40px), 'SIZES.LG'(48px).
+   * Extends ButtonBase sizes with 'SIZES.AUTO' value
+   * Default value is 'SIZES.MD'.
+   */
+  size: PropTypes.oneOf(Object.values(BUTTON_LINK_SIZES)),
 };

--- a/ui/components/component-library/button-link/button-link.scss
+++ b/ui/components/component-library/button-link/button-link.scss
@@ -1,42 +1,40 @@
 .mm-button-link {
-  color: var(--color-primary-default);
-
-  &:hover {
+  &:hover:not(&--disabled) {
     color: var(--color-primary-default);
     opacity: 0.5;
   }
 
-  &:active {
-    color: var(--color-primary-default);
+  &:active:not(&--disabled) {
+    color: var(--color-primary-alternative);
     opacity: 0.5;
-  }
-
-  &--disabled {
-    &:hover {
-      color: var(--color-primary-default);
-      opacity: 0.3;
-    }
-
-    &:active {
-      opacity: 0.3;
-    }
   }
 
   &--type-danger {
+    &:hover:not(.mm-button-link--disabled) {
+      color: var(--color-error-default);
+      opacity: 0.5;
+    }
+
+    &:active:not(.mm-button-link--disabled) {
+      color: var(--color-error-alternative);
+      opacity: 0.5;
+    }
+  }
+
+  // Needed for danger in disabled <a> tags
+  &--type-danger#{&}--disabled:hover,
+  &--type-danger#{&}--disabled:active {
     color: var(--color-error-default);
+  }
 
-    &:hover {
-      color: var(--color-error-default);
-      opacity: 0.5;
-    }
-
-    &:active {
-      color: var(--color-error-default);
-      opacity: 0.5;
-    }
-
-    &--disabled:hover {
-      color: var(--color-error-default);
-    }
+  &--size-auto {
+    padding: 0 !important; // TODO: remove once https://github.com/MetaMask/metamask-extension/pull/17006 is merged
+    height: auto;
+    vertical-align: top;
+    font-family: inherit;
+    font-weight: inherit;
+    font-size: inherit;
+    line-height: inherit;
+    letter-spacing: inherit;
   }
 }

--- a/ui/components/component-library/button-link/button-link.stories.js
+++ b/ui/components/component-library/button-link/button-link.stories.js
@@ -4,6 +4,7 @@ import {
   DISPLAY,
   SIZES,
   TEXT,
+  FLEX_DIRECTION,
 } from '../../../helpers/constants/design-system';
 import Box from '../../ui/box/box';
 import { ICON_NAMES } from '../icon';
@@ -130,7 +131,7 @@ export const Size = (args) => (
         Large Button
       </ButtonLink>
     </Box>
-    <Text variant={TEXT.BODY_MD}>
+    <Text variant={TEXT.BODY_SM}>
       <ButtonLink {...args} size={SIZES.AUTO}>
         Button Auto
       </ButtonLink>{' '}
@@ -149,7 +150,16 @@ export const Danger = (args) => (
   </Box>
 );
 
-export const Href = (args) => <ButtonLink {...args}>Href Example</ButtonLink>;
+export const As = (args) => (
+  <Box display={DISPLAY.FLEX} flexDirection={FLEX_DIRECTION.ROW} gap={2}>
+    <ButtonLink {...args}>Button Element</ButtonLink>
+    <ButtonLink as="a" href="#" {...args}>
+      Anchor Element
+    </ButtonLink>
+  </Box>
+);
+
+export const Href = (args) => <ButtonLink {...args}>Anchor Element</ButtonLink>;
 
 Href.args = {
   href: '/metamask',

--- a/ui/components/component-library/button-link/button-link.test.js
+++ b/ui/components/component-library/button-link/button-link.test.js
@@ -15,15 +15,6 @@ describe('ButtonLink', () => {
     expect(container).toMatchSnapshot();
   });
 
-  it('should render anchor element correctly', () => {
-    const { getByTestId, container } = render(
-      <ButtonLink as="a" data-testid="button-link" />,
-    );
-    expect(getByTestId('button-link')).toHaveClass('mm-button-base');
-    const anchor = container.getElementsByTagName('a').length;
-    expect(anchor).toBe(1);
-  });
-
   it('should render button as block', () => {
     const { getByTestId } = render(<ButtonLink block data-testid="block" />);
     expect(getByTestId('block')).toHaveClass(`mm-button-base--block`);
@@ -56,7 +47,7 @@ describe('ButtonLink', () => {
       `mm-button-base--size-${SIZES.LG}`,
     );
     expect(getByTestId(SIZES.AUTO)).toHaveClass(
-      `mm-button-base--size-${SIZES.AUTO}`,
+      `mm-button-link--size-${SIZES.AUTO}`,
     );
   });
 
@@ -80,6 +71,7 @@ describe('ButtonLink', () => {
     expect(getByTestId('loading')).toHaveClass(`mm-button-base--loading`);
     expect(getByTestId('disabled')).toHaveClass(`mm-button-base--disabled`);
   });
+
   it('should render with icon', () => {
     const { container } = render(
       <ButtonLink data-testid="icon" iconName="add-square-filled" />,
@@ -87,5 +79,19 @@ describe('ButtonLink', () => {
 
     const icons = container.getElementsByClassName('mm-icon').length;
     expect(icons).toBe(1);
+  });
+
+  it('should render anchor element correctly', () => {
+    const { getByRole } = render(
+      <ButtonLink as="a" href="https://www.test.com" />,
+    );
+    expect(getByRole('link')).toHaveAttribute('href', 'https://www.test.com');
+  });
+
+  it('should render anchor element correctly by href only being passed and href exists', () => {
+    const { getByRole } = render(
+      <ButtonLink href="https://www.test.com">Button Base</ButtonLink>,
+    );
+    expect(getByRole('link')).toHaveAttribute('href', 'https://www.test.com');
   });
 });

--- a/ui/components/component-library/button-primary/README.mdx
+++ b/ui/components/component-library/button-primary/README.mdx
@@ -34,7 +34,7 @@ Possible sizes include:
 
 ```jsx
 import { SIZES } from '../../../helpers/constants/design-system';
-import { ButtonPrimary } from '../../ui/components/component-library';
+import { ButtonPrimary } from '../../component-library';
 
 <ButtonPrimary size={SIZES.SM} />
 <ButtonPrimary size={SIZES.MD} />
@@ -50,7 +50,7 @@ Use the `danger` boolean prop to change the `ButtonPrimary` to danger color.
 </Canvas>
 
 ```jsx
-import { ButtonPrimary } from '../../ui/components/component-library';
+import { ButtonPrimary } from '../../component-library';
 
 <ButtonPrimary>Normal</ButtonPrimary>
 <ButtonPrimary danger>Danger</ButtonPrimary>

--- a/ui/components/component-library/button-primary/__snapshots__/button-primary.test.js.snap
+++ b/ui/components/component-library/button-primary/__snapshots__/button-primary.test.js.snap
@@ -3,11 +3,11 @@
 exports[`ButtonPrimary should render button element correctly 1`] = `
 <div>
   <button
-    class="box mm-button-base mm-button-base--size-md mm-button-primary box--padding-right-4 box--padding-left-4 box--display-inline-flex box--flex-direction-row box--justify-content-center box--align-items-center box--rounded-pill"
+    class="box mm-button-base mm-button-base--size-md mm-button-primary box--padding-right-4 box--padding-left-4 box--display-inline-flex box--flex-direction-row box--justify-content-center box--align-items-center box--color-primary-inverse box--background-color-primary-default box--rounded-pill box--border-color-primary-default box--border-style-solid box--border-width-1"
     data-testid="button-primary"
   >
     <span
-      class="box mm-text mm-button-base__content mm-text--body-md mm-text--color-inherit box--gap-2 box--flex-direction-row box--justify-content-center box--align-items-center box--display-flex"
+      class="box mm-text mm-button-base__content mm-text--body-md mm-text--color-inherit box--display-inline-flex box--gap-2 box--flex-direction-row box--justify-content-center box--align-items-center"
     >
       Button Primary
     </span>

--- a/ui/components/component-library/button-primary/button-primary.js
+++ b/ui/components/component-library/button-primary/button-primary.js
@@ -2,6 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 
+import { COLORS, SIZES } from '../../../helpers/constants/design-system';
+
 import { ButtonBase } from '../button-base';
 import { BUTTON_PRIMARY_SIZES } from './button-primary.constants';
 
@@ -9,7 +11,7 @@ export const ButtonPrimary = ({
   className,
   danger,
   disabled,
-  size = BUTTON_PRIMARY_SIZES.MD,
+  size = SIZES.MD,
   ...props
 }) => {
   return (
@@ -19,6 +21,9 @@ export const ButtonPrimary = ({
         'mm-button-primary--disabled': disabled,
       })}
       size={size}
+      backgroundColor={danger ? COLORS.ERROR_DEFAULT : COLORS.PRIMARY_DEFAULT}
+      borderColor={danger ? COLORS.ERROR_DEFAULT : COLORS.PRIMARY_DEFAULT}
+      color={danger ? COLORS.ERROR_INVERSE : COLORS.PRIMARY_INVERSE}
       {...{ disabled, ...props }}
     />
   );

--- a/ui/components/component-library/button-primary/button-primary.scss
+++ b/ui/components/component-library/button-primary/button-primary.scss
@@ -1,45 +1,24 @@
 .mm-button-primary {
-  color: var(--color-primary-inverse);
-  background-color: var(--color-primary-default);
-
-  &:hover {
+  &:hover:not(&--disabled) {
     color: var(--color-primary-inverse);
     box-shadow: var(--component-button-primary-shadow);
   }
 
-  &:active {
+  &:active:not(&--disabled) {
     color: var(--color-primary-inverse);
     background-color: var(--color-primary-alternative);
   }
 
   // Danger type
   &--type-danger {
-    color: var(--color-error-inverse);
-    background-color: var(--color-error-default);
-
-    &:hover {
+    &:hover:not(.mm-button-primary--disabled) {
       color: var(--color-error-inverse);
       box-shadow: var(--component-button-danger-shadow);
     }
 
-    &:active {
+    &:active:not(.mm-button-primary--disabled) {
       color: var(--color-error-inverse);
       background-color: var(--color-error-alternative);
     }
-  }
-
-  // Disabled
-  &--disabled {
-    &:hover {
-      box-shadow: none;
-    }
-
-    &:active {
-      background-color: var(--color-primary-default);
-    }
-  }
-  // Disabled danger
-  &--type-danger#{&}--disabled:active {
-    background-color: var(--color-error-default);
   }
 }

--- a/ui/components/component-library/button-secondary/README.mdx
+++ b/ui/components/component-library/button-secondary/README.mdx
@@ -34,7 +34,7 @@ Possible sizes include:
 
 ```jsx
 import { SIZES } from '../../../helpers/constants/design-system';
-import { ButtonSecondary } from '../../ui/components/component-library';
+import { ButtonSecondary } from '../../component-library';
 
 <ButtonSecondary size={SIZES.SM} />
 <ButtonSecondary size={SIZES.MD} />
@@ -50,7 +50,7 @@ Use the `danger` boolean prop to change the `ButtonSecondary` to danger color.
 </Canvas>
 
 ```jsx
-import { ButtonSecondary } from '../../ui/components/component-library';
+import { ButtonSecondary } from '../../component-library';
 
 <ButtonSecondary>Normal</ButtonSecondary>
 <ButtonSecondary danger>Danger</ButtonSecondary>

--- a/ui/components/component-library/button-secondary/__snapshots__/button-secondary.test.js.snap
+++ b/ui/components/component-library/button-secondary/__snapshots__/button-secondary.test.js.snap
@@ -3,11 +3,11 @@
 exports[`ButtonSecondary should render button element correctly 1`] = `
 <div>
   <button
-    class="box mm-button-base mm-button-base--size-md mm-button-secondary box--padding-right-4 box--padding-left-4 box--display-inline-flex box--flex-direction-row box--justify-content-center box--align-items-center box--rounded-pill"
+    class="box mm-button-base mm-button-base--size-md mm-button-secondary box--padding-right-4 box--padding-left-4 box--display-inline-flex box--flex-direction-row box--justify-content-center box--align-items-center box--color-primary-default box--background-color-transparent box--rounded-pill box--border-color-primary-default box--border-style-solid box--border-width-1"
     data-testid="button-secondary"
   >
     <span
-      class="box mm-text mm-button-base__content mm-text--body-md mm-text--color-inherit box--gap-2 box--flex-direction-row box--justify-content-center box--align-items-center box--display-flex"
+      class="box mm-text mm-button-base__content mm-text--body-md mm-text--color-inherit box--display-inline-flex box--gap-2 box--flex-direction-row box--justify-content-center box--align-items-center"
     >
       Button Secondary
     </span>

--- a/ui/components/component-library/button-secondary/button-secondary.js
+++ b/ui/components/component-library/button-secondary/button-secondary.js
@@ -2,6 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 
+import { COLORS, SIZES } from '../../../helpers/constants/design-system';
+
 import { ButtonBase } from '../button-base';
 import { BUTTON_SECONDARY_SIZES } from './button-secondary.constants';
 
@@ -9,7 +11,7 @@ export const ButtonSecondary = ({
   className,
   danger,
   disabled,
-  size = BUTTON_SECONDARY_SIZES.MD,
+  size = SIZES.MD,
   ...props
 }) => {
   return (
@@ -18,6 +20,9 @@ export const ButtonSecondary = ({
         'mm-button-secondary--type-danger': danger,
         'mm-button-secondary--disabled': disabled,
       })}
+      color={danger ? COLORS.ERROR_DEFAULT : COLORS.PRIMARY_DEFAULT}
+      backgroundColor={COLORS.TRANSPARENT}
+      borderColor={danger ? COLORS.ERROR_DEFAULT : COLORS.PRIMARY_DEFAULT}
       size={size}
       {...{ disabled, ...props }}
     />

--- a/ui/components/component-library/button-secondary/button-secondary.scss
+++ b/ui/components/component-library/button-secondary/button-secondary.scss
@@ -1,15 +1,11 @@
 .mm-button-secondary {
-  color: var(--color-primary-default);
-  border: 1px solid var(--color-primary-default);
-  background-color: transparent;
-
-  &:hover {
+  &:hover:not(&--disabled) {
     color: var(--color-primary-inverse);
     background-color: var(--color-primary-default);
     box-shadow: var(--component-button-primary-shadow);
   }
 
-  &:active {
+  &:active:not(&--disabled) {
     color: var(--color-primary-inverse);
     background-color: var(--color-primary-alternative);
     border-color: var(--color-primary-alternative);
@@ -17,38 +13,16 @@
 
   // Danger type
   &--type-danger {
-    color: var(--color-error-default);
-    border: 1px solid var(--color-error-default);
-    background-color: transparent;
-
-    &:hover {
+    &:hover:not(.mm-button-secondary--disabled) {
       color: var(--color-error-inverse);
       background-color: var(--color-error-default);
       box-shadow: var(--component-button-danger-shadow);
     }
 
-    &:active {
+    &:active:not(.mm-button-secondary--disabled) {
       color: var(--color-error-inverse);
       background-color: var(--color-error-alternative);
       border-color: var(--color-error-alternative);
     }
-  }
-
-  // Disabled
-  &--disabled {
-    &:hover {
-      color: var(--color-primary-default);
-      box-shadow: none;
-      background-color: transparent;
-    }
-
-    &:active {
-      background-color: transparent;
-    }
-  }
-
-  // Disabled danger
-  &--type-danger#{&}--disabled:hover {
-    color: var(--color-error-default);
   }
 }

--- a/ui/components/component-library/button/__snapshots__/button.test.js.snap
+++ b/ui/components/component-library/button/__snapshots__/button.test.js.snap
@@ -3,11 +3,11 @@
 exports[`Button should render button element correctly 1`] = `
 <div>
   <button
-    class="box mm-button-base mm-button-base--size-md mm-button-primary box--padding-right-4 box--padding-left-4 box--display-inline-flex box--flex-direction-row box--justify-content-center box--align-items-center box--rounded-pill"
+    class="box mm-button-base mm-button-base--size-md mm-button-primary box--padding-right-4 box--padding-left-4 box--display-inline-flex box--flex-direction-row box--justify-content-center box--align-items-center box--color-primary-inverse box--background-color-primary-default box--rounded-pill box--border-color-primary-default box--border-style-solid box--border-width-1"
     data-testid="button"
   >
     <span
-      class="box mm-text mm-button-base__content mm-text--body-md mm-text--color-inherit box--gap-2 box--flex-direction-row box--justify-content-center box--align-items-center box--display-flex"
+      class="box mm-text mm-button-base__content mm-text--body-md mm-text--color-inherit box--display-inline-flex box--gap-2 box--flex-direction-row box--justify-content-center box--align-items-center"
     >
       Button
     </span>
@@ -18,31 +18,31 @@ exports[`Button should render button element correctly 1`] = `
 exports[`Button should render with different button types 1`] = `
 <div>
   <button
-    class="box mm-button-base mm-button-base--size-md mm-button-primary box--padding-right-4 box--padding-left-4 box--display-inline-flex box--flex-direction-row box--justify-content-center box--align-items-center box--rounded-pill"
+    class="box mm-button-base mm-button-base--size-md mm-button-primary box--padding-right-4 box--padding-left-4 box--display-inline-flex box--flex-direction-row box--justify-content-center box--align-items-center box--color-primary-inverse box--background-color-primary-default box--rounded-pill box--border-color-primary-default box--border-style-solid box--border-width-1"
     data-testid="primary"
   >
     <span
-      class="box mm-text mm-button-base__content mm-text--body-md mm-text--color-inherit box--gap-2 box--flex-direction-row box--justify-content-center box--align-items-center box--display-flex"
+      class="box mm-text mm-button-base__content mm-text--body-md mm-text--color-inherit box--display-inline-flex box--gap-2 box--flex-direction-row box--justify-content-center box--align-items-center"
     >
       Button
     </span>
   </button>
   <button
-    class="box mm-button-base mm-button-base--size-md mm-button-secondary box--padding-right-4 box--padding-left-4 box--display-inline-flex box--flex-direction-row box--justify-content-center box--align-items-center box--rounded-pill"
+    class="box mm-button-base mm-button-base--size-md mm-button-secondary box--padding-right-4 box--padding-left-4 box--display-inline-flex box--flex-direction-row box--justify-content-center box--align-items-center box--color-primary-default box--background-color-transparent box--rounded-pill box--border-color-primary-default box--border-style-solid box--border-width-1"
     data-testid="secondary"
   >
     <span
-      class="box mm-text mm-button-base__content mm-text--body-md mm-text--color-inherit box--gap-2 box--flex-direction-row box--justify-content-center box--align-items-center box--display-flex"
+      class="box mm-text mm-button-base__content mm-text--body-md mm-text--color-inherit box--display-inline-flex box--gap-2 box--flex-direction-row box--justify-content-center box--align-items-center"
     >
       Button
     </span>
   </button>
   <button
-    class="box mm-button-base mm-button-base--size-md mm-button-link box--padding-right-4 box--padding-left-4 box--display-inline-flex box--flex-direction-row box--justify-content-center box--align-items-center box--background-color-transparent box--rounded-pill"
+    class="box mm-button-base mm-button-base--size-md mm-button-link box--padding-right-4 box--padding-left-4 box--display-inline-flex box--flex-direction-row box--justify-content-center box--align-items-center box--color-primary-default box--background-color-transparent box--rounded-pill box--border-style-none box--border-color-border-default box--border-width-1"
     data-testid="link"
   >
     <span
-      class="box mm-text mm-button-base__content mm-text--body-md mm-text--color-inherit box--gap-2 box--flex-direction-row box--justify-content-center box--align-items-center box--display-flex"
+      class="box mm-text mm-button-base__content mm-text--body-md mm-text--color-inherit box--display-inline-flex box--gap-2 box--flex-direction-row box--justify-content-center box--align-items-center"
     >
       Button
     </span>

--- a/ui/components/component-library/button/button.js
+++ b/ui/components/component-library/button/button.js
@@ -1,6 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { merge } from 'lodash';
 
+import { ButtonBase } from '../button-base';
 import { ButtonPrimary } from '../button-primary';
 import { ButtonSecondary } from '../button-secondary';
 import { ButtonLink } from '../button-link';
@@ -20,6 +22,13 @@ export const Button = ({ type, ...props }) => {
   }
 };
 
+const buttonPropTypes = merge(
+  ButtonBase.propTypes,
+  ButtonSecondary.propTypes,
+  ButtonPrimary.propTypes,
+  ButtonLink.propTypes,
+);
+
 Button.propTypes = {
   /**
    * Select the type of Button.
@@ -28,7 +37,7 @@ Button.propTypes = {
    */
   type: PropTypes.oneOf(Object.values(BUTTON_TYPES)),
   /**
-   * Button accepts all the props from ButtonPrimary (same props as ButtonSecondary & ButtonLink)
+   * Button accepts all button base and variant props ButtonBase, ButtonPrimary, ButtonSecondary, ButtonLink
    */
-  ...ButtonPrimary.propTypes,
+  ...buttonPropTypes,
 };

--- a/ui/components/component-library/button/button.stories.js
+++ b/ui/components/component-library/button/button.stories.js
@@ -129,33 +129,36 @@ export const Type = (args) => (
   </Box>
 );
 
-export const Size = (args) => (
-  <>
-    <Box
-      display={DISPLAY.FLEX}
-      alignItems={ALIGN_ITEMS.BASELINE}
-      gap={1}
-      marginBottom={3}
-    >
-      <Button {...args} size={SIZES.SM}>
-        Small Button
-      </Button>
-      <Button {...args} size={SIZES.MD}>
-        Medium (Default) Button
-      </Button>
-      <Button {...args} size={SIZES.LG}>
-        Large Button
-      </Button>
-    </Box>
-    <Text variant={TEXT.BODY_SM}>
-      <Button {...args} type={BUTTON_TYPES.LINK} size={SIZES.AUTO}>
-        Button Auto
-      </Button>{' '}
-      inherits the font-size of the parent element. Auto size only used for
-      ButtonLink.
-    </Text>
-  </>
-);
+export const Size = (args) => {
+  const { size, ...rest } = args;
+  return (
+    <>
+      <Box
+        display={DISPLAY.FLEX}
+        alignItems={ALIGN_ITEMS.BASELINE}
+        gap={1}
+        marginBottom={3}
+      >
+        <Button {...rest} size={size === SIZES.AUTO ? SIZES.SM : size}>
+          Small Button
+        </Button>
+        <Button {...rest} size={size === SIZES.AUTO ? SIZES.MD : size}>
+          Medium (Default) Button
+        </Button>
+        <Button {...rest} size={size === SIZES.AUTO ? SIZES.LG : size}>
+          Large Button
+        </Button>
+      </Box>
+      <Text variant={TEXT.BODY_SM}>
+        <Button {...rest} type={BUTTON_TYPES.LINK} size={SIZES.AUTO}>
+          Button Auto
+        </Button>{' '}
+        inherits the font-size of the parent element. Auto size only used for
+        ButtonLink.
+      </Text>
+    </>
+  );
+};
 
 export const Danger = (args) => (
   <Box display={DISPLAY.FLEX} gap={1}>

--- a/ui/components/component-library/button/button.test.js
+++ b/ui/components/component-library/button/button.test.js
@@ -16,25 +16,21 @@ describe('Button', () => {
   });
 
   it('should render anchor element correctly', () => {
-    const { getByTestId, container } = render(
-      <Button as="a" data-testid="button">
+    const { getByRole } = render(
+      <Button as="a" href="https://www.test.com">
         Button
       </Button>,
     );
-    expect(getByTestId('button')).toHaveClass('mm-button-base');
-    const anchor = container.getElementsByTagName('a').length;
-    expect(anchor).toBe(1);
+    expect(getByRole('link')).toHaveAttribute('href', 'https://www.test.com');
   });
 
-  it('should render anchor element correctly by href only being passed', () => {
-    const { getByTestId, container } = render(
-      <Button href="/metamask" data-testid="button">
-        Visit Site
+  it('should render anchor element correctly by href only being passed and href exists if type link', () => {
+    const { getByRole } = render(
+      <Button type="link" href="https://www.test.com">
+        Button
       </Button>,
     );
-    expect(getByTestId('button')).toHaveClass('mm-button-base');
-    const anchor = container.getElementsByTagName('a').length;
-    expect(anchor).toBe(1);
+    expect(getByRole('link')).toHaveAttribute('href', 'https://www.test.com');
   });
 
   it('should render button as block', () => {
@@ -93,7 +89,7 @@ describe('Button', () => {
       </>,
     );
     expect(getByTestId(BUTTON_SIZES.AUTO)).toHaveClass(
-      `mm-button-base--size-${BUTTON_SIZES.AUTO}`,
+      `mm-button-link--size-${BUTTON_SIZES.AUTO}`,
     );
     expect(getByTestId(BUTTON_SIZES.SM)).toHaveClass(
       `mm-button-base--size-${BUTTON_SIZES.SM}`,


### PR DESCRIPTION
## Explanation

Exploration to use more Box props for Buttons and isolating all props related to ButtonLink inside of ButtonLink.

These updates shouldn't effect anything visually but rather save some lines of CSS and establish a process for using as many Box props as possible and extending base components to use extra logic that isn't present in all variants.

- Add `buttonTextProps` to wrapping `Text` component in `ButtonBase`
- Use `Box` props for `backgroundColor` and `color` and remove components CSS
- Moves SIZE.AUTO logic to ButtonLink only
