### PR TITLE
[FLASK] Create E2E test for snap_dialog

### DIFF
--- a/test/e2e/snaps/enums.js
+++ b/test/e2e/snaps/enums.js
@@ -1,3 +1,3 @@
 module.exports = {
-  TEST_SNAPS_WEBSITE_URL: 'https://metamask.github.io/test-snaps/4.4.1/',
+  TEST_SNAPS_WEBSITE_URL: 'https://metamask.github.io/test-snaps/4.5.0/',
 };

--- a/test/e2e/snaps/test-snap-dialog.spec.js
+++ b/test/e2e/snaps/test-snap-dialog.spec.js
@@ -68,6 +68,9 @@ describe('Test Snap Dialog', function () {
           tag: 'button',
         });
 
+        // delay for npm installation
+        await driver.delay(2000);
+
         // switch to test snaps tab
         windowHandles = await driver.waitUntilXWindowHandles(2, 1000, 10000);
         await driver.switchToWindowWithTitle('Test Snaps', windowHandles);

--- a/test/e2e/snaps/test-snap-dialog.spec.js
+++ b/test/e2e/snaps/test-snap-dialog.spec.js
@@ -30,9 +30,9 @@ describe('Test Snap Dialog', function () {
 
         // navigate to test snaps page and connect to dialog snap
         await driver.openNewPage(TEST_SNAPS_WEBSITE_URL);
-        await driver.delay(1000);
         const dialogButton = await driver.findElement('#connectDialogSnap');
         await driver.scrollToElement(dialogButton);
+        await driver.delay(1000);
         await driver.clickElement('#connectDialogSnap');
 
         // switch to metamask extension and click connect
@@ -70,9 +70,7 @@ describe('Test Snap Dialog', function () {
         windowHandles = await driver.waitUntilXWindowHandles(2, 1000, 10000);
         await driver.switchToWindowWithTitle('Test Snaps', windowHandles);
 
-        // scroll to and click on alert dialog
-        const alertButton = await driver.findElement('#sendAlertButton');
-        await driver.scrollToElement(alertButton);
+        // click on alert dialog
         await driver.clickElement('#sendAlertButton');
         await driver.delay(1000);
 
@@ -103,13 +101,10 @@ describe('Test Snap Dialog', function () {
 
         // check result is null
         result = await driver.findElement('#dialogResult');
-        await driver.scrollToElement(result);
         await driver.delay(1000);
         assert.equal(await result.getText(), 'null');
 
         // click conf button
-        const confButton = await driver.findElement('#sendConfButton');
-        await driver.scrollToElement(confButton);
         await driver.clickElement('#sendConfButton');
         await driver.delay(1000);
 
@@ -134,12 +129,10 @@ describe('Test Snap Dialog', function () {
 
         // check for false result
         result = await driver.findElement('#dialogResult');
-        await driver.scrollToElement(result);
         await driver.delay(1000);
         assert.equal(await result.getText(), 'false');
 
         // click conf button again
-        await driver.scrollToElement(confButton);
         await driver.clickElement('#sendConfButton');
         await driver.delay(1000);
 
@@ -164,13 +157,10 @@ describe('Test Snap Dialog', function () {
 
         // check for true result
         result = await driver.findElement('#dialogResult');
-        await driver.scrollToElement(result);
         await driver.delay(1000);
         assert.equal(await result.getText(), 'true');
 
         // click prompt button
-        const promptButton = await driver.findElement('#sendPromptButton');
-        await driver.scrollToElement(promptButton);
         await driver.clickElement('#sendPromptButton');
         await driver.delay(1000);
 
@@ -198,7 +188,6 @@ describe('Test Snap Dialog', function () {
 
         // check result is equal to '2323'
         result = await driver.findElement('#dialogResult');
-        await driver.scrollToElement(result);
         await driver.delay(1000);
         assert.equal(await result.getText(), '"2323"');
       },

--- a/test/e2e/snaps/test-snap-dialog.spec.js
+++ b/test/e2e/snaps/test-snap-dialog.spec.js
@@ -1,0 +1,207 @@
+const { strict: assert } = require('assert');
+const { withFixtures } = require('../helpers');
+const FixtureBuilder = require('../fixture-builder');
+const { TEST_SNAPS_WEBSITE_URL } = require('./enums');
+
+describe('Test Snap Dialog', function () {
+  it('test all three snap_dialog types', async function () {
+    const ganacheOptions = {
+      accounts: [
+        {
+          secretKey:
+            '0x7C9529A67102755B7E6102D6D950AC5D5863C98713805CEC576B945B15B71EAC',
+          balance: 25000000000000000000,
+        },
+      ],
+    };
+    await withFixtures(
+      {
+        fixtures: new FixtureBuilder().build(),
+        ganacheOptions,
+        failOnConsoleError: false,
+        title: this.test.title,
+      },
+      async ({ driver }) => {
+        await driver.navigate();
+
+        // enter pw into extension
+        await driver.fill('#password', 'correct horse battery staple');
+        await driver.press('#password', driver.Key.ENTER);
+
+        // navigate to test snaps page and connect to dialog snap
+        await driver.openNewPage(TEST_SNAPS_WEBSITE_URL);
+        await driver.delay(1000);
+        const dialogButton = await driver.findElement('#connectDialogSnap');
+        await driver.scrollToElement(dialogButton);
+        await driver.clickElement('#connectDialogSnap');
+
+        // switch to metamask extension and click connect
+        let windowHandles = await driver.waitUntilXWindowHandles(
+          3,
+          1000,
+          10000,
+        );
+        await driver.switchToWindowWithTitle(
+          'MetaMask Notification',
+          windowHandles,
+        );
+        await driver.clickElement(
+          {
+            text: 'Connect',
+            tag: 'button',
+          },
+          10000,
+        );
+
+        await driver.delay(2000);
+
+        // approve install of snap
+        windowHandles = await driver.waitUntilXWindowHandles(3, 1000, 10000);
+        await driver.switchToWindowWithTitle(
+          'MetaMask Notification',
+          windowHandles,
+        );
+        await driver.clickElement({
+          text: 'Approve & install',
+          tag: 'button',
+        });
+
+        // switch to test snaps tab
+        windowHandles = await driver.waitUntilXWindowHandles(2, 1000, 10000);
+        await driver.switchToWindowWithTitle('Test Snaps', windowHandles);
+
+        // scroll to and click on alert dialog
+        const alertButton = await driver.findElement('#sendAlertButton');
+        await driver.scrollToElement(alertButton);
+        await driver.clickElement('#sendAlertButton');
+        await driver.delay(1000);
+
+        // switch to dialog popup
+        windowHandles = await driver.waitUntilXWindowHandles(3, 1000, 10000);
+        windowHandles = await driver.getAllWindowHandles();
+        await driver.switchToWindowWithTitle(
+          'MetaMask Notification',
+          windowHandles,
+        );
+        await driver.delay(1000);
+
+        // check dialog contents
+        let result = await driver.findElement('.snap-ui-renderer__panel');
+        await driver.scrollToElement(result);
+        await driver.delay(1000);
+        assert.equal(await result.getText(), 'Alert Dialog\nText here');
+
+        // click ok button
+        await driver.clickElement({
+          text: 'Ok',
+          tag: 'button',
+        });
+
+        // switch back to test snaps tab
+        windowHandles = await driver.waitUntilXWindowHandles(2, 1000, 10000);
+        await driver.switchToWindowWithTitle('Test Snaps', windowHandles);
+
+        // check result is null
+        result = await driver.findElement('#dialogResult');
+        await driver.scrollToElement(result);
+        await driver.delay(1000);
+        assert.equal(await result.getText(), 'null');
+
+        // click conf button
+        const confButton = await driver.findElement('#sendConfButton');
+        await driver.scrollToElement(confButton);
+        await driver.clickElement('#sendConfButton');
+        await driver.delay(1000);
+
+        // switch to dialog popup
+        windowHandles = await driver.waitUntilXWindowHandles(3, 1000, 10000);
+        windowHandles = await driver.getAllWindowHandles();
+        await driver.switchToWindowWithTitle(
+          'MetaMask Notification',
+          windowHandles,
+        );
+        await driver.delay(1000);
+
+        // click reject
+        await driver.clickElement({
+          text: 'Reject',
+          tag: 'button',
+        });
+
+        // switch back to test snaps tab
+        windowHandles = await driver.waitUntilXWindowHandles(2, 1000, 10000);
+        await driver.switchToWindowWithTitle('Test Snaps', windowHandles);
+
+        // check for false result
+        result = await driver.findElement('#dialogResult');
+        await driver.scrollToElement(result);
+        await driver.delay(1000);
+        assert.equal(await result.getText(), 'false');
+
+        // click conf button again
+        await driver.scrollToElement(confButton);
+        await driver.clickElement('#sendConfButton');
+        await driver.delay(1000);
+
+        // switch to dialog popup
+        windowHandles = await driver.waitUntilXWindowHandles(3, 1000, 10000);
+        windowHandles = await driver.getAllWindowHandles();
+        await driver.switchToWindowWithTitle(
+          'MetaMask Notification',
+          windowHandles,
+        );
+        await driver.delay(1000);
+
+        // click accept
+        await driver.clickElement({
+          text: 'Approve',
+          tag: 'button',
+        });
+
+        // switch back to test snaps tab
+        windowHandles = await driver.waitUntilXWindowHandles(2, 1000, 10000);
+        await driver.switchToWindowWithTitle('Test Snaps', windowHandles);
+
+        // check for true result
+        result = await driver.findElement('#dialogResult');
+        await driver.scrollToElement(result);
+        await driver.delay(1000);
+        assert.equal(await result.getText(), 'true');
+
+        // click prompt button
+        const promptButton = await driver.findElement('#sendPromptButton');
+        await driver.scrollToElement(confButton);
+        await driver.clickElement('#sendPromptButton');
+        await driver.delay(1000);
+
+        // switch to dialog popup
+        windowHandles = await driver.waitUntilXWindowHandles(3, 1000, 10000);
+        windowHandles = await driver.getAllWindowHandles();
+        await driver.switchToWindowWithTitle(
+          'MetaMask Notification',
+          windowHandles,
+        );
+        await driver.delay(1000);
+
+        // fill '2323' in form field
+        await driver.fill('.MuiInput-input', '2323');
+
+        // click submit button
+        await driver.clickElement({
+          text: 'Submit',
+          tag: 'button',
+        });
+
+        // switch back to test snaps tab
+        windowHandles = await driver.waitUntilXWindowHandles(2, 1000, 10000);
+        await driver.switchToWindowWithTitle('Test Snaps', windowHandles);
+
+        // check result is equal to '2323'
+        result = await driver.findElement('#dialogResult');
+        await driver.scrollToElement(result);
+        await driver.delay(1000);
+        assert.equal(await result.getText(), '"2323"');
+      },
+    );
+  });
+});

--- a/test/e2e/snaps/test-snap-dialog.spec.js
+++ b/test/e2e/snaps/test-snap-dialog.spec.js
@@ -30,10 +30,12 @@ describe('Test Snap Dialog', function () {
 
         // navigate to test snaps page and connect to dialog snap
         await driver.openNewPage(TEST_SNAPS_WEBSITE_URL);
+        await driver.delay(1000);
         const dialogButton = await driver.findElement('#connectDialogSnap');
         await driver.scrollToElement(dialogButton);
         await driver.delay(1000);
         await driver.clickElement('#connectDialogSnap');
+        await driver.delay(1000);
 
         // switch to metamask extension and click connect
         let windowHandles = await driver.waitUntilXWindowHandles(

--- a/test/e2e/snaps/test-snap-dialog.spec.js
+++ b/test/e2e/snaps/test-snap-dialog.spec.js
@@ -170,7 +170,7 @@ describe('Test Snap Dialog', function () {
 
         // click prompt button
         const promptButton = await driver.findElement('#sendPromptButton');
-        await driver.scrollToElement(confButton);
+        await driver.scrollToElement(promptButton);
         await driver.clickElement('#sendPromptButton');
         await driver.delay(1000);
 

--- a/test/e2e/snaps/test-snap-dialog.spec.js
+++ b/test/e2e/snaps/test-snap-dialog.spec.js
@@ -81,7 +81,7 @@ describe('Test Snap Dialog', function () {
 
         // switch to dialog popup
         windowHandles = await driver.waitUntilXWindowHandles(3, 1000, 10000);
-        windowHandles = await driver.getAllWindowHandles();
+        // windowHandles = await driver.getAllWindowHandles();
         await driver.switchToWindowWithTitle(
           'MetaMask Notification',
           windowHandles,
@@ -115,7 +115,7 @@ describe('Test Snap Dialog', function () {
 
         // switch to dialog popup
         windowHandles = await driver.waitUntilXWindowHandles(3, 1000, 10000);
-        windowHandles = await driver.getAllWindowHandles();
+        // windowHandles = await driver.getAllWindowHandles();
         await driver.switchToWindowWithTitle(
           'MetaMask Notification',
           windowHandles,
@@ -143,7 +143,7 @@ describe('Test Snap Dialog', function () {
 
         // switch to dialog popup
         windowHandles = await driver.waitUntilXWindowHandles(3, 1000, 10000);
-        windowHandles = await driver.getAllWindowHandles();
+        // windowHandles = await driver.getAllWindowHandles();
         await driver.switchToWindowWithTitle(
           'MetaMask Notification',
           windowHandles,
@@ -171,7 +171,35 @@ describe('Test Snap Dialog', function () {
 
         // switch to dialog popup
         windowHandles = await driver.waitUntilXWindowHandles(3, 1000, 10000);
-        windowHandles = await driver.getAllWindowHandles();
+        // windowHandles = await driver.getAllWindowHandles();
+        await driver.switchToWindowWithTitle(
+          'MetaMask Notification',
+          windowHandles,
+        );
+        await driver.delay(1000);
+
+        // click cancel button
+        await driver.clickElement({
+          text: 'Cancel',
+          tag: 'button',
+        });
+
+        // switch back to test snaps tab
+        windowHandles = await driver.waitUntilXWindowHandles(2, 1000, 10000);
+        await driver.switchToWindowWithTitle('Test Snaps', windowHandles);
+
+        // check result is equal to 'null'
+        result = await driver.findElement('#dialogResult');
+        await driver.delay(1000);
+        assert.equal(await result.getText(), 'null');
+
+        // click prompt button
+        await driver.clickElement('#sendPromptButton');
+        await driver.delay(1000);
+
+        // switch to dialog popup
+        windowHandles = await driver.waitUntilXWindowHandles(3, 1000, 10000);
+        // windowHandles = await driver.getAllWindowHandles();
         await driver.switchToWindowWithTitle(
           'MetaMask Notification',
           windowHandles,

--- a/test/e2e/snaps/test-snap-dialog.spec.js
+++ b/test/e2e/snaps/test-snap-dialog.spec.js
@@ -81,7 +81,6 @@ describe('Test Snap Dialog', function () {
 
         // switch to dialog popup
         windowHandles = await driver.waitUntilXWindowHandles(3, 1000, 10000);
-        // windowHandles = await driver.getAllWindowHandles();
         await driver.switchToWindowWithTitle(
           'MetaMask Notification',
           windowHandles,
@@ -115,7 +114,6 @@ describe('Test Snap Dialog', function () {
 
         // switch to dialog popup
         windowHandles = await driver.waitUntilXWindowHandles(3, 1000, 10000);
-        // windowHandles = await driver.getAllWindowHandles();
         await driver.switchToWindowWithTitle(
           'MetaMask Notification',
           windowHandles,
@@ -143,7 +141,6 @@ describe('Test Snap Dialog', function () {
 
         // switch to dialog popup
         windowHandles = await driver.waitUntilXWindowHandles(3, 1000, 10000);
-        // windowHandles = await driver.getAllWindowHandles();
         await driver.switchToWindowWithTitle(
           'MetaMask Notification',
           windowHandles,
@@ -171,7 +168,6 @@ describe('Test Snap Dialog', function () {
 
         // switch to dialog popup
         windowHandles = await driver.waitUntilXWindowHandles(3, 1000, 10000);
-        // windowHandles = await driver.getAllWindowHandles();
         await driver.switchToWindowWithTitle(
           'MetaMask Notification',
           windowHandles,
@@ -199,7 +195,6 @@ describe('Test Snap Dialog', function () {
 
         // switch to dialog popup
         windowHandles = await driver.waitUntilXWindowHandles(3, 1000, 10000);
-        // windowHandles = await driver.getAllWindowHandles();
         await driver.switchToWindowWithTitle(
           'MetaMask Notification',
           windowHandles,


### PR DESCRIPTION
This creates a new E2E test for snap_dialog.
It tests all three current functions of snap_dialog - alert, confirmation and prompt.

Fixes #17107