### PR TITLE
[E2E] Fixes to try to deflake Snaps E2E tests

### DIFF
--- a/test/e2e/snaps/test-snap-bip-32.spec.js
+++ b/test/e2e/snaps/test-snap-bip-32.spec.js
@@ -36,6 +36,7 @@ describe('Test Snap bip-32', function () {
         await driver.scrollToElement(snapButton1);
         await driver.delay(1000);
         await driver.clickElement('#connectBip32');
+        await driver.delay(1000);
 
         // switch to metamask extension and click connect
         let windowHandles = await driver.waitUntilXWindowHandles(
@@ -78,6 +79,9 @@ describe('Test Snap bip-32', function () {
           text: 'Confirm',
           tag: 'button',
         });
+
+        // delay for npm installation
+        await driver.delay(2000);
 
         // switch back to test-snaps window
         windowHandles = await driver.waitUntilXWindowHandles(1, 1000, 10000);

--- a/test/e2e/snaps/test-snap-bip-44.spec.js
+++ b/test/e2e/snaps/test-snap-bip-44.spec.js
@@ -35,6 +35,7 @@ describe('Test Snap bip-44', function () {
         await driver.scrollToElement(snapButton1);
         await driver.delay(1000);
         await driver.clickElement('#connectBip44Snap');
+        await driver.delay(1000);
 
         // switch to metamask extension and click connect
         let windowHandles = await driver.waitUntilXWindowHandles(
@@ -77,6 +78,9 @@ describe('Test Snap bip-44', function () {
           text: 'Confirm',
           tag: 'button',
         });
+
+        // delay for npm installation
+        await driver.delay(2000);
 
         // click send inputs on test snap page
         windowHandles = await driver.waitUntilXWindowHandles(1, 1000, 10000);

--- a/test/e2e/snaps/test-snap-bip-44.spec.js
+++ b/test/e2e/snaps/test-snap-bip-44.spec.js
@@ -30,6 +30,7 @@ describe('Test Snap bip-44', function () {
 
         // navigate to test snaps page and connect
         await driver.driver.get(TEST_SNAPS_WEBSITE_URL);
+        await driver.delay(1000);
         const snapButton1 = await driver.findElement('#connectBip44Snap');
         await driver.scrollToElement(snapButton1);
         await driver.delay(1000);

--- a/test/e2e/snaps/test-snap-confirm.spec.js
+++ b/test/e2e/snaps/test-snap-confirm.spec.js
@@ -30,10 +30,12 @@ describe('Test Snap Confirm', function () {
 
         // navigate to test snaps page and connect
         await driver.driver.get(TEST_SNAPS_WEBSITE_URL);
+        await driver.delay(1000);
         const snapButton1 = await driver.findElement('#connectConfirmSnap');
         await driver.scrollToElement(snapButton1);
         await driver.delay(1000);
         await driver.clickElement('#connectConfirmSnap');
+        await driver.delay(1000);
 
         // switch to metamask extension and click connect
         let windowHandles = await driver.waitUntilXWindowHandles(
@@ -65,6 +67,9 @@ describe('Test Snap Confirm', function () {
           text: 'Approve & install',
           tag: 'button',
         });
+
+        // delay for npm installation
+        await driver.delay(2000);
 
         // switch back to test snaps page
         windowHandles = await driver.waitUntilXWindowHandles(1, 1000, 10000);

--- a/test/e2e/snaps/test-snap-error.spec.js
+++ b/test/e2e/snaps/test-snap-error.spec.js
@@ -30,10 +30,12 @@ describe('Test Snap Error', function () {
 
         // navigate to test snaps page and connect
         await driver.openNewPage(TEST_SNAPS_WEBSITE_URL);
+        await driver.delay(1000);
         const snapButton = await driver.findElement('#connectErrorSnap');
         await driver.scrollToElement(snapButton);
         await driver.delay(1000);
         await driver.clickElement('#connectErrorSnap');
+        await driver.delay(1000);
 
         // switch to metamask extension and click connect
         let windowHandles = await driver.waitUntilXWindowHandles(
@@ -66,6 +68,9 @@ describe('Test Snap Error', function () {
           text: 'Approve & install',
           tag: 'button',
         });
+
+        // delay for npm installation
+        await driver.delay(2000);
 
         // click send inputs on test snap page
         windowHandles = await driver.waitUntilXWindowHandles(2, 1000, 10000);

--- a/test/e2e/snaps/test-snap-installed.spec.js
+++ b/test/e2e/snaps/test-snap-installed.spec.js
@@ -34,6 +34,7 @@ describe('Test Snap Installed', function () {
         const confirmButton = await driver.findElement('#connectConfirmSnap');
         await driver.scrollToElement(confirmButton);
         await driver.clickElement('#connectConfirmSnap');
+        await driver.delay(1000);
 
         // switch to metamask extension and click connect
         let windowHandles = await driver.waitUntilXWindowHandles(
@@ -65,6 +66,9 @@ describe('Test Snap Installed', function () {
           text: 'Approve & install',
           tag: 'button',
         });
+
+        // delay for npm installation
+        await driver.delay(2000);
 
         // click send inputs on test snap page
         windowHandles = await driver.waitUntilXWindowHandles(2, 1000, 10000);
@@ -101,6 +105,9 @@ describe('Test Snap Installed', function () {
           text: 'Approve & install',
           tag: 'button',
         });
+
+        // delay for npm installation
+        await driver.delay(2000);
 
         windowHandles = await driver.waitUntilXWindowHandles(2, 1000, 10000);
         await driver.switchToWindowWithTitle('Test Snaps', windowHandles);

--- a/test/e2e/snaps/test-snap-management.spec.js
+++ b/test/e2e/snaps/test-snap-management.spec.js
@@ -30,12 +30,14 @@ describe('Test Snap Management', function () {
 
         // open a new tab and navigate to test snaps page and connect
         await driver.openNewPage(TEST_SNAPS_WEBSITE_URL);
+        await driver.delay(1000);
 
         // find and scroll to the correct card and click first
         const snapButton = await driver.findElement('#connectNotification');
         await driver.scrollToElement(snapButton);
-        await driver.delay(500);
+        await driver.delay(1000);
         await driver.clickElement('#connectNotification');
+        await driver.delay(1000);
 
         // switch to metamask extension and click connect
         let windowHandles = await driver.waitUntilXWindowHandles(
@@ -67,6 +69,9 @@ describe('Test Snap Management', function () {
           text: 'Approve & install',
           tag: 'button',
         });
+
+        // delay for npm installation
+        await driver.delay(2000);
 
         // switch to the original MM tab
         const extensionPage = windowHandles[0];

--- a/test/e2e/snaps/test-snap-managestate.spec.js
+++ b/test/e2e/snaps/test-snap-managestate.spec.js
@@ -38,6 +38,7 @@ describe('Test Snap manageState', function () {
         await driver.scrollToElement(snapButton1);
         await driver.delay(1000);
         await driver.clickElement('#connectManageState');
+        await driver.delay(1000);
 
         // switch to metamask extension and click connect
         let windowHandles = await driver.waitUntilXWindowHandles(
@@ -68,6 +69,9 @@ describe('Test Snap manageState', function () {
           text: 'Approve & install',
           tag: 'button',
         });
+
+        // delay for npm installation
+        await driver.delay(2000);
 
         // fill and click send inputs on test snap page
         windowHandles = await driver.waitUntilXWindowHandles(1, 1000, 10000);

--- a/test/e2e/snaps/test-snap-notification.spec.js
+++ b/test/e2e/snaps/test-snap-notification.spec.js
@@ -35,8 +35,9 @@ describe('Test Snap Notification', function () {
         // find and scroll down to snapId5 and connect
         const snapButton = await driver.findElement('#connectNotification');
         await driver.scrollToElement(snapButton);
-        await driver.delay(500);
+        await driver.delay(1000);
         await driver.clickElement('#connectNotification');
+        await driver.delay(1000);
 
         // switch to metamask extension and click connect
         let windowHandles = await driver.waitUntilXWindowHandles(
@@ -68,6 +69,9 @@ describe('Test Snap Notification', function () {
           text: 'Approve & install',
           tag: 'button',
         });
+
+        // delay for npm installation
+        await driver.delay(2000);
 
         // click send inputs on test snap page
         windowHandles = await driver.waitUntilXWindowHandles(2, 1000, 10000);

--- a/test/e2e/snaps/test-snap-txinsights.spec.js
+++ b/test/e2e/snaps/test-snap-txinsights.spec.js
@@ -36,6 +36,7 @@ describe('Test Snap TxInsights', function () {
         await driver.scrollToElement(snapButton1);
         await driver.delay(1000);
         await driver.clickElement('#connectInsightsSnap');
+        await driver.delay(1000);
 
         // switch to metamask extension and click connect
         let windowHandles = await driver.waitUntilXWindowHandles(
@@ -55,6 +56,7 @@ describe('Test Snap TxInsights', function () {
           10000,
         );
 
+        // delay for npm installation
         await driver.delay(2000);
 
         // switch to metamask extension

--- a/test/e2e/snaps/test-snap-update.spec.js
+++ b/test/e2e/snaps/test-snap-update.spec.js
@@ -30,13 +30,13 @@ describe('Test Snap update', function () {
 
         // open a new tab and navigate to test snaps page and connect
         await driver.driver.get(TEST_SNAPS_WEBSITE_URL);
+        await driver.delay(1000);
 
         // find and scroll to the correct card and click first
         const snapButton = await driver.findElement('#connectUpdateNew');
         await driver.scrollToElement(snapButton);
         await driver.delay(1000);
         await driver.clickElement('#connectUpdate');
-
         await driver.delay(2000);
 
         // switch to metamask extension and click connect
@@ -78,6 +78,9 @@ describe('Test Snap update', function () {
           tag: 'button',
         });
 
+        // delay for npm installation
+        await driver.delay(2000);
+
         // navigate to test snap page
         windowHandles = await driver.waitUntilXWindowHandles(1, 1000, 10000);
         await driver.switchToWindowWithTitle('Test Snaps', windowHandles);
@@ -88,6 +91,7 @@ describe('Test Snap update', function () {
         await driver.scrollToElement(snapButton2);
         await driver.delay(1000);
         await driver.clickElement('#connectUpdateNew');
+        await driver.delay(1000);
 
         // switch to metamask extension and click connect
         await driver.waitUntilXWindowHandles(2, 1000, 10000);
@@ -103,6 +107,9 @@ describe('Test Snap update', function () {
           text: 'Approve & update',
           tag: 'button',
         });
+
+        // delay for npm installation
+        await driver.delay(2000);
 
         // navigate to test snap page
         windowHandles = await driver.waitUntilXWindowHandles(1, 1000, 10000);

--- a/test/e2e/snaps/test-snap-update.spec.js
+++ b/test/e2e/snaps/test-snap-update.spec.js
@@ -33,7 +33,7 @@ describe('Test Snap update', function () {
         await driver.delay(1000);
 
         // find and scroll to the correct card and click first
-        const snapButton = await driver.findElement('#connectUpdateNew');
+        const snapButton = await driver.findElement('#connectUpdate');
         await driver.scrollToElement(snapButton);
         await driver.delay(1000);
         await driver.clickElement('#connectUpdate');


### PR DESCRIPTION
Delays were added to combat DOM rendering and NPM installations delays.
This should help with ongoing CI failures.