### PR TITLE
Remove dead addressbook migration code

### DIFF
--- a/app/scripts/controllers/preferences.js
+++ b/app/scripts/controllers/preferences.js
@@ -398,7 +398,7 @@ export default class PreferencesController {
    * @param {string} [nickname] - Nickname of the selected network.
    * @param {object} [rpcPrefs] - Optional RPC preferences, such as the block explorer URL
    */
-  addToFrequentRpcList(
+  upsertToFrequentRpcList(
     rpcUrl,
     chainId,
     ticker = 'ETH',

--- a/app/scripts/controllers/preferences.js
+++ b/app/scripts/controllers/preferences.js
@@ -1,12 +1,7 @@
-import { strict as assert } from 'assert';
 import { ObservableStore } from '@metamask/obs-store';
 import { normalize as normalizeAddress } from 'eth-sig-util';
 import { ethers } from 'ethers';
-import log from 'loglevel';
-import {
-  IPFS_DEFAULT_GATEWAY_URL,
-  BUILT_IN_NETWORKS,
-} from '../../../shared/constants/network';
+import { IPFS_DEFAULT_GATEWAY_URL } from '../../../shared/constants/network';
 import { isPrefixedFormattedHexString } from '../../../shared/modules/network.utils';
 import { LEDGER_TRANSPORT_TYPES } from '../../../shared/constants/hardware-wallets';
 import { THEME_TYPE } from '../../../ui/pages/settings/settings-tab/settings-tab.constant';
@@ -81,7 +76,6 @@ export default class PreferencesController {
     this.store = new ObservableStore(initState);
     this.store.setMaxListeners(12);
     this.openPopup = opts.openPopup;
-    this.migrateAddressBookState = opts.migrateAddressBookState;
     this.tokenListController = opts.tokenListController;
 
     this._subscribeToInfuraAvailability();
@@ -396,84 +390,6 @@ export default class PreferencesController {
   }
 
   /**
-   * updates custom RPC details
-   *
-   * @param {object} newRpcDetails - Options bag.
-   * @param {string} newRpcDetails.rpcUrl - The RPC url to add to frequentRpcList.
-   * @param {string} newRpcDetails.chainId - The chainId of the selected network.
-   * @param {string} [newRpcDetails.ticker] - Optional ticker symbol of the selected network.
-   * @param {string} [newRpcDetails.nickname] - Optional nickname of the selected network.
-   * @param {object} [newRpcDetails.rpcPrefs] - Optional RPC preferences, such as the block explorer URL
-   */
-  async updateRpc(newRpcDetails) {
-    const rpcList = this.getFrequentRpcListDetail();
-    const index = rpcList.findIndex((element) => {
-      return element.rpcUrl === newRpcDetails.rpcUrl;
-    });
-    if (index > -1) {
-      const rpcDetail = rpcList[index];
-      const updatedRpc = { ...rpcDetail, ...newRpcDetails };
-
-
-      // if (rpcDetail.chainId !== updatedRpc.chainId) {
-      //   // When the chainId is changed, associated address book entries should
-      //   // also be migrated. The address book entries are keyed by the `network` state,
-      //   // which for custom networks is the chainId with a fallback to the networkId
-      //   // if the chainId is not set.
-
-      //   let addressBookKey = rpcDetail.chainId;
-      //   if (!addressBookKey) {
-      //     // We need to find the networkId to determine what these addresses were keyed by
-      //     try {
-      //       addressBookKey = await this.ethersProvider.send('net_version');
-      //       assert(typeof addressBookKey === 'string');
-      //     } catch (error) {
-      //       log.debug(error);
-      //       log.warn(
-      //         `Failed to get networkId from ${rpcDetail.rpcUrl}; skipping address book migration`,
-      //       );
-      //     }
-      //   }
-
-      //   // There is an edge case where two separate RPC endpoints are keyed by the same
-      //   // value. In this case, the contact book entries are duplicated so that they remain
-      //   // on both networks, since we don't know which network each contact is intended for.
-
-      //   let duplicate = false;
-      //   const builtInProviderNetworkIds = Object.values(BUILT_IN_NETWORKS).map(
-      //     (ids) => ids.networkId,
-      //   );
-      //   const otherRpcEntries = rpcList.filter(
-      //     (entry) => entry.rpcUrl !== newRpcDetails.rpcUrl,
-      //   );
-      //   if (
-      //     builtInProviderNetworkIds.includes(addressBookKey) ||
-      //     otherRpcEntries.some((entry) => entry.chainId === addressBookKey)
-      //   ) {
-      //     duplicate = true;
-      //   }
-
-      //   this.migrateAddressBookState(
-      //     addressBookKey,
-      //     updatedRpc.chainId,
-      //     duplicate,
-      //   );
-      // }
-      rpcList[index] = updatedRpc;
-      this.store.updateState({ frequentRpcListDetail: rpcList });
-    } else {
-      const {
-        rpcUrl,
-        chainId,
-        ticker,
-        nickname,
-        rpcPrefs = {},
-      } = newRpcDetails;
-      this.addToFrequentRpcList(rpcUrl, chainId, ticker, nickname, rpcPrefs);
-    }
-  }
-
-  /**
    * Adds custom RPC url to state.
    *
    * @param {string} rpcUrl - The RPC url to add to frequentRpcList.
@@ -495,7 +411,8 @@ export default class PreferencesController {
       return element.rpcUrl === rpcUrl;
     });
     if (index !== -1) {
-      rpcList.splice(index, 1);
+      rpcList.splice(index, 1, { rpcUrl, chainId, ticker, nickname, rpcPrefs });
+      return;
     }
 
     if (!isPrefixedFormattedHexString(chainId)) {

--- a/app/scripts/controllers/preferences.js
+++ b/app/scripts/controllers/preferences.js
@@ -413,50 +413,52 @@ export default class PreferencesController {
     if (index > -1) {
       const rpcDetail = rpcList[index];
       const updatedRpc = { ...rpcDetail, ...newRpcDetails };
-      if (rpcDetail.chainId !== updatedRpc.chainId) {
-        // When the chainId is changed, associated address book entries should
-        // also be migrated. The address book entries are keyed by the `network` state,
-        // which for custom networks is the chainId with a fallback to the networkId
-        // if the chainId is not set.
 
-        let addressBookKey = rpcDetail.chainId;
-        if (!addressBookKey) {
-          // We need to find the networkId to determine what these addresses were keyed by
-          try {
-            addressBookKey = await this.ethersProvider.send('net_version');
-            assert(typeof addressBookKey === 'string');
-          } catch (error) {
-            log.debug(error);
-            log.warn(
-              `Failed to get networkId from ${rpcDetail.rpcUrl}; skipping address book migration`,
-            );
-          }
-        }
 
-        // There is an edge case where two separate RPC endpoints are keyed by the same
-        // value. In this case, the contact book entries are duplicated so that they remain
-        // on both networks, since we don't know which network each contact is intended for.
+      // if (rpcDetail.chainId !== updatedRpc.chainId) {
+      //   // When the chainId is changed, associated address book entries should
+      //   // also be migrated. The address book entries are keyed by the `network` state,
+      //   // which for custom networks is the chainId with a fallback to the networkId
+      //   // if the chainId is not set.
 
-        let duplicate = false;
-        const builtInProviderNetworkIds = Object.values(BUILT_IN_NETWORKS).map(
-          (ids) => ids.networkId,
-        );
-        const otherRpcEntries = rpcList.filter(
-          (entry) => entry.rpcUrl !== newRpcDetails.rpcUrl,
-        );
-        if (
-          builtInProviderNetworkIds.includes(addressBookKey) ||
-          otherRpcEntries.some((entry) => entry.chainId === addressBookKey)
-        ) {
-          duplicate = true;
-        }
+      //   let addressBookKey = rpcDetail.chainId;
+      //   if (!addressBookKey) {
+      //     // We need to find the networkId to determine what these addresses were keyed by
+      //     try {
+      //       addressBookKey = await this.ethersProvider.send('net_version');
+      //       assert(typeof addressBookKey === 'string');
+      //     } catch (error) {
+      //       log.debug(error);
+      //       log.warn(
+      //         `Failed to get networkId from ${rpcDetail.rpcUrl}; skipping address book migration`,
+      //       );
+      //     }
+      //   }
 
-        this.migrateAddressBookState(
-          addressBookKey,
-          updatedRpc.chainId,
-          duplicate,
-        );
-      }
+      //   // There is an edge case where two separate RPC endpoints are keyed by the same
+      //   // value. In this case, the contact book entries are duplicated so that they remain
+      //   // on both networks, since we don't know which network each contact is intended for.
+
+      //   let duplicate = false;
+      //   const builtInProviderNetworkIds = Object.values(BUILT_IN_NETWORKS).map(
+      //     (ids) => ids.networkId,
+      //   );
+      //   const otherRpcEntries = rpcList.filter(
+      //     (entry) => entry.rpcUrl !== newRpcDetails.rpcUrl,
+      //   );
+      //   if (
+      //     builtInProviderNetworkIds.includes(addressBookKey) ||
+      //     otherRpcEntries.some((entry) => entry.chainId === addressBookKey)
+      //   ) {
+      //     duplicate = true;
+      //   }
+
+      //   this.migrateAddressBookState(
+      //     addressBookKey,
+      //     updatedRpc.chainId,
+      //     duplicate,
+      //   );
+      // }
       rpcList[index] = updatedRpc;
       this.store.updateState({ frequentRpcListDetail: rpcList });
     } else {

--- a/app/scripts/controllers/preferences.test.js
+++ b/app/scripts/controllers/preferences.test.js
@@ -12,7 +12,6 @@ describe('preferences controller', function () {
   let currentChainId;
   let provider;
   let tokenListController;
-  const migrateAddressBookState = sinon.stub();
 
   beforeEach(function () {
     const sandbox = sinon.createSandbox();
@@ -44,7 +43,6 @@ describe('preferences controller', function () {
 
     preferencesController = new PreferencesController({
       initLangCode: 'en_US',
-      migrateAddressBookState,
       network,
       provider,
       tokenListController,
@@ -177,37 +175,6 @@ describe('preferences controller', function () {
         preferencesController.store.getState().forgottenPassword,
         true,
       );
-    });
-  });
-
-  describe('#updateRpc', function () {
-    it('should update the rpcDetails properly', async function () {
-      preferencesController.store.updateState({
-        frequentRpcListDetail: [{}, { rpcUrl: 'test', chainId: '0x1' }, {}],
-      });
-      await preferencesController.updateRpc({ rpcUrl: 'test', chainId: '0x1' });
-      await preferencesController.updateRpc({
-        rpcUrl: 'test/1',
-        chainId: '0x1',
-      });
-      await preferencesController.updateRpc({
-        rpcUrl: 'test/2',
-        chainId: '0x1',
-      });
-      await preferencesController.updateRpc({
-        rpcUrl: 'test/3',
-        chainId: '0x1',
-      });
-      const list = preferencesController.getFrequentRpcListDetail();
-      assert.deepEqual(list[1], { rpcUrl: 'test', chainId: '0x1' });
-    });
-
-    it('should migrate address book entries if chainId changes', async function () {
-      preferencesController.store.updateState({
-        frequentRpcListDetail: [{}, { rpcUrl: 'test', chainId: '1' }, {}],
-      });
-      await preferencesController.updateRpc({ rpcUrl: 'test', chainId: '0x1' });
-      assert(migrateAddressBookState.calledWith('1', '0x1'));
     });
   });
 

--- a/app/scripts/controllers/preferences.test.js
+++ b/app/scripts/controllers/preferences.test.js
@@ -180,7 +180,7 @@ describe('preferences controller', function () {
 
   describe('adding and removing from frequentRpcListDetail', function () {
     it('should add custom RPC url to state', function () {
-      preferencesController.addToFrequentRpcList('rpc_url', '0x1');
+      preferencesController.upsertToFrequentRpcList('rpc_url', '0x1');
       assert.deepEqual(
         preferencesController.store.getState().frequentRpcListDetail,
         [
@@ -193,7 +193,7 @@ describe('preferences controller', function () {
           },
         ],
       );
-      preferencesController.addToFrequentRpcList('rpc_url', '0x1');
+      preferencesController.upsertToFrequentRpcList('rpc_url', '0x1');
       assert.deepEqual(
         preferencesController.store.getState().frequentRpcListDetail,
         [
@@ -210,12 +210,12 @@ describe('preferences controller', function () {
 
     it('should throw if chainId is invalid', function () {
       assert.throws(() => {
-        preferencesController.addToFrequentRpcList('rpc_url', '1');
+        preferencesController.upsertToFrequentRpcList('rpc_url', '1');
       }, 'should throw on invalid chainId');
     });
 
     it('should remove custom RPC url from state', function () {
-      preferencesController.addToFrequentRpcList('rpc_url', '0x1');
+      preferencesController.upsertToFrequentRpcList('rpc_url', '0x1');
       assert.deepEqual(
         preferencesController.store.getState().frequentRpcListDetail,
         [

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -2128,7 +2128,7 @@ export default class MetamaskController extends EventEmitter {
   async addCustomNetwork(customRpc, actionId) {
     const { chainId, chainName, rpcUrl, ticker, blockExplorerUrl } = customRpc;
 
-    this.preferencesController.addToFrequentRpcList(
+    this.preferencesController.upsertToFrequentRpcList(
       rpcUrl,
       chainId,
       ticker,
@@ -3825,7 +3825,7 @@ export default class MetamaskController extends EventEmitter {
           chainName,
           rpcUrl,
         } = {}) => {
-          await this.preferencesController.addToFrequentRpcList(
+          await this.preferencesController.upsertToFrequentRpcList(
             rpcUrl,
             chainId,
             ticker,
@@ -4270,7 +4270,7 @@ export default class MetamaskController extends EventEmitter {
       nickname,
       rpcPrefs,
     );
-    await this.preferencesController.addToFrequentRpcList(
+    await this.preferencesController.upsertToFrequentRpcList(
       rpcUrl,
       chainId,
       ticker,
@@ -4319,7 +4319,7 @@ export default class MetamaskController extends EventEmitter {
         nickname,
         rpcPrefs,
       );
-      await this.preferencesController.addToFrequentRpcList(
+      await this.preferencesController.upsertToFrequentRpcList(
         rpcUrl,
         chainId,
         ticker,

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -4270,13 +4270,13 @@ export default class MetamaskController extends EventEmitter {
       nickname,
       rpcPrefs,
     );
-    await this.preferencesController.updateRpc({
+    await this.preferencesController.addToFrequentRpcList(
       rpcUrl,
       chainId,
       ticker,
       nickname,
       rpcPrefs,
-    });
+    );
     return rpcUrl;
   }
 

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -285,7 +285,6 @@ export default class MetamaskController extends EventEmitter {
       network: this.networkController,
       tokenListController: this.tokenListController,
       provider: this.provider,
-      migrateAddressBookState: this.migrateAddressBookState.bind(this),
     });
 
     this.tokensController = new TokensController({
@@ -4200,43 +4199,6 @@ export default class MetamaskController extends EventEmitter {
     );
     nonceLock.releaseLock();
     return nonceLock.nextNonce;
-  }
-
-  /**
-   * Migrate address book state from old to new chainId.
-   *
-   * Address book state is keyed by the `networkStore` state from the network controller. This value is set to the
-   * `networkId` for our built-in Infura networks, but it's set to the `chainId` for custom networks.
-   * When this `chainId` value is changed for custom RPC endpoints, we need to migrate any contacts stored under the
-   * old key to the new key.
-   *
-   * The `duplicate` parameter is used to specify that the contacts under the old key should not be removed. This is
-   * useful in the case where two RPC endpoints shared the same set of contacts, and we're not sure which one each
-   * contact belongs under. Duplicating the contacts under both keys is the only way to ensure they are not lost.
-   *
-   * @param {string} oldChainId - The old chainId
-   * @param {string} newChainId - The new chainId
-   * @param {boolean} [duplicate] - Whether to duplicate the addresses on both chainIds (default: false)
-   */
-  async migrateAddressBookState(oldChainId, newChainId, duplicate = false) {
-    const { addressBook } = this.addressBookController.state;
-
-    if (!addressBook[oldChainId]) {
-      return;
-    }
-
-    for (const address of Object.keys(addressBook[oldChainId])) {
-      const entry = addressBook[oldChainId][address];
-      this.addressBookController.set(
-        address,
-        entry.name,
-        newChainId,
-        entry.memo,
-      );
-      if (!duplicate) {
-        this.addressBookController.delete(oldChainId, address);
-      }
-    }
   }
 
   //=============================================================================


### PR DESCRIPTION
## Explanation
This removes a block of code originally introduced to (per Mark's comment [here](https://github.com/MetaMask/core/pull/1011#discussion_r1044838666)) "to accommodate a specific update for metamask-extension, where we went from `chainId` being optional for custom RPC endpoints to it being required, and where we switched from keying this address book state by `chainId` instead of `networkId`". 

As Mark goes on to say: "That was over two years ago. The only wallets that old will be dormant ones. For the tiny subset of users that are starting up a wallet that has been shut down for multiple years, I think we can consider the possibility of losing addresses to be an acceptable risk. Even at the time of the migration this was an edge case."

This PR simply removes all the logic to perform this migration. Additionally it removes the `updateRPC` method (where this code lived) and replaces it's use with a slightly modified `addToFrequentRpcList` method (now called `upsertToFrequentRpcList`). This change reflects the broader context of this PR which is to ease the process of migrating the storage and management of network configurations from the `PreferencesController` to the `NetworkController`, which is tracked here: https://github.com/MetaMask/core/issues/969

## Manual Testing Steps
Add, Update and Remove a custom network and check that these are working as expected.

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes

