### PR TITLE
Fix duplicate button issue on Ledger connectivity screen

### DIFF
--- a/ui/pages/create-account/connect-hardware/select-hardware.js
+++ b/ui/pages/create-account/connect-hardware/select-hardware.js
@@ -181,6 +181,7 @@ export default class SelectHardware extends Component {
     const steps = [];
     if (this.props.ledgerTransportType === LEDGER_TRANSPORT_TYPES.LIVE) {
       steps.push({
+        renderButtons: false,
         title: this.context.t('step1LedgerWallet'),
         message: this.context.t('step1LedgerWalletMsg', [
           <a
@@ -197,6 +198,7 @@ export default class SelectHardware extends Component {
     }
 
     steps.push({
+      renderButtons: true,
       asset: 'plug-in-wallet',
       dimensions: { width: '225px', height: '75px' },
       title: this.context.t('step2LedgerWallet'),
@@ -218,32 +220,36 @@ export default class SelectHardware extends Component {
         {steps.map((step, index) => (
           <div className="hw-connect" key={index}>
             <h3 className="hw-connect__title">{step.title}</h3>
-            <Button
-              className="hw-connect__external-btn-first"
-              type="secondary"
-              onClick={() => {
-                this.context.trackEvent({
-                  category: EVENT.CATEGORIES.NAVIGATION,
-                  event: 'Clicked Ledger Buy Now',
-                });
-                window.open(AFFILIATE_LINKS.LEDGER, '_blank');
-              }}
-            >
-              {this.context.t('buyNow')}
-            </Button>
-            <Button
-              className="hw-connect__external-btn"
-              type="secondary"
-              onClick={() => {
-                this.context.trackEvent({
-                  category: EVENT.CATEGORIES.NAVIGATION,
-                  event: 'Clicked Ledger Tutorial',
-                });
-                window.open(AFFILIATE_TUTORIAL_LINKS.LEDGER, '_blank');
-              }}
-            >
-              {this.context.t('tutorial')}
-            </Button>
+            {step.renderButtons ? (
+              <>
+                <Button
+                  className="hw-connect__external-btn-first"
+                  type="secondary"
+                  onClick={() => {
+                    this.context.trackEvent({
+                      category: EVENT.CATEGORIES.NAVIGATION,
+                      event: 'Clicked Ledger Buy Now',
+                    });
+                    window.open(AFFILIATE_LINKS.LEDGER, '_blank');
+                  }}
+                >
+                  {this.context.t('buyNow')}
+                </Button>
+                <Button
+                  className="hw-connect__external-btn"
+                  type="secondary"
+                  onClick={() => {
+                    this.context.trackEvent({
+                      category: EVENT.CATEGORIES.NAVIGATION,
+                      event: 'Clicked Ledger Tutorial',
+                    });
+                    window.open(AFFILIATE_TUTORIAL_LINKS.LEDGER, '_blank');
+                  }}
+                >
+                  {this.context.t('tutorial')}
+                </Button>
+              </>
+            ) : null}
             <p className="hw-connect__msg">{step.message}</p>
             {step.asset && (
               <img
@@ -549,7 +555,7 @@ export default class SelectHardware extends Component {
         {steps.map((step, index) => (
           <div className="hw-connect" key={index}>
             {step.title && <h3 className="hw-connect__title">{step.title}</h3>}
-            <p className="hw-connect__msg">{step.message}</p>
+            <div className="hw-connect__msg">{step.message}</div>
             {step.asset && (
               <img
                 className="hw-connect__step-asset"


### PR DESCRIPTION
Fixes: https://github.com/MetaMask/metamask-extension/issues/17031

## Explanation
Also fixes a warning thrown on the connect screen(`<p>` nesting issue):

<img width="432" alt="Screen Shot 2023-01-10 at 11 45 15 PM" src="https://user-images.githubusercontent.com/8732757/211738216-462774ba-3ada-44f3-9b5e-3c095c75fde3.png">

### Before
https://user-images.githubusercontent.com/54408225/209006758-a7050f80-315a-43d5-9839-00d2511fb824.mp4

### After
https://user-images.githubusercontent.com/8732757/211738395-b8c3aebd-7e55-447a-a998-876f5e9fdfc2.mov

## Manual Testing Steps
1. Go to Advanced Settings
2. Select Ledger Live on Ledger Connectivity type
3. Close Settings
4. Click Import Hardware Wallet
5. Click Ledger 
6. Ensure duplicate button issue is not present

## Pre-merge author checklist

- [X] I've clearly explained:
  - [X] What problem this PR is solving
  - [X] How this problem was solved
  - [X] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
