### PR TITLE
Fix NetworkController `destroy` before initialization

### DIFF
--- a/app/scripts/controllers/network/network-controller.js
+++ b/app/scripts/controllers/network/network-controller.js
@@ -132,7 +132,7 @@ export default class NetworkController extends EventEmitter {
    * In-progress requests will not be aborted.
    */
   async destroy() {
-    await this._blockTracker.destroy();
+    await this._blockTracker?.destroy();
   }
 
   async initializeProvider() {

--- a/app/scripts/controllers/network/network-controller.test.js
+++ b/app/scripts/controllers/network/network-controller.test.js
@@ -95,6 +95,12 @@ describe('NetworkController', () => {
     });
 
     describe('destroy', () => {
+      it('should not throw if called before initialization', async () => {
+        await expect(
+          async () => await networkController.destroy(),
+        ).not.toThrow();
+      });
+
       it('should stop the block tracker for the current selected network', async () => {
         nock('http://localhost:8545')
           .persist()


### PR DESCRIPTION
The NetworkController `destroy` method has been updated to ensure that it no longer throws if called before initialization.

This method was added recently in #17032, but we forgot to handle the case where the controller was not initialized.

## Manual Testing Steps

I don't know of a way to test this in the real application. A unit test has been added to cover this case though.

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
