### PR TITLE
Remove unecessary code from the network controller tests

### DIFF
--- a/app/scripts/controllers/network/network-controller.test.js
+++ b/app/scripts/controllers/network/network-controller.test.js
@@ -58,10 +58,6 @@ describe('NetworkController', () => {
     let networkController;
     let getLatestBlockStub;
     let setProviderTypeAndWait;
-    const noop = () => undefined;
-    const networkControllerProviderConfig = {
-      getAccounts: noop,
-    };
 
     beforeEach(() => {
       networkController = new NetworkController({ infuraProjectId: 'foo' });
@@ -85,7 +81,7 @@ describe('NetworkController', () => {
 
     describe('#provider', () => {
       it('provider should be updatable without reassignment', () => {
-        networkController.initializeProvider(networkControllerProviderConfig);
+        networkController.initializeProvider();
         const providerProxy =
           networkController.getProviderAndBlockTracker().provider;
         expect(providerProxy.test).toBeUndefined();
@@ -102,9 +98,7 @@ describe('NetworkController', () => {
           .reply(200, () =>
             JSON.stringify(constructSuccessfulRpcResponse(BLOCK)),
           );
-        await networkController.initializeProvider(
-          networkControllerProviderConfig,
-        );
+        await networkController.initializeProvider();
         const { blockTracker } = networkController.getProviderAndBlockTracker();
         // The block tracker starts running after a listener is attached
         blockTracker.addListener('latest', () => {
@@ -127,14 +121,14 @@ describe('NetworkController', () => {
 
     describe('#setProviderType', () => {
       it('should update provider.type', () => {
-        networkController.initializeProvider(networkControllerProviderConfig);
+        networkController.initializeProvider();
         networkController.setProviderType('mainnet');
         const { type } = networkController.getProviderConfig();
         expect(type).toStrictEqual('mainnet');
       });
 
       it('should set the network to loading', () => {
-        networkController.initializeProvider(networkControllerProviderConfig);
+        networkController.initializeProvider();
 
         const spy = sinon.spy(networkController, '_setNetworkState');
         networkController.setProviderType('mainnet');
@@ -146,14 +140,14 @@ describe('NetworkController', () => {
 
     describe('#getEIP1559Compatibility', () => {
       it('should return false when baseFeePerGas is not in the block header', async () => {
-        networkController.initializeProvider(networkControllerProviderConfig);
+        networkController.initializeProvider();
         const supportsEIP1559 =
           await networkController.getEIP1559Compatibility();
         expect(supportsEIP1559).toStrictEqual(false);
       });
 
       it('should return true when baseFeePerGas is in block header', async () => {
-        networkController.initializeProvider(networkControllerProviderConfig);
+        networkController.initializeProvider();
         getLatestBlockStub.callsFake(() =>
           Promise.resolve({ baseFeePerGas: '0xa ' }),
         );
@@ -163,7 +157,7 @@ describe('NetworkController', () => {
       });
 
       it('should store EIP1559 support in state to reduce calls to _getLatestBlock', async () => {
-        networkController.initializeProvider(networkControllerProviderConfig);
+        networkController.initializeProvider();
         getLatestBlockStub.callsFake(() =>
           Promise.resolve({ baseFeePerGas: '0xa ' }),
         );
@@ -175,8 +169,7 @@ describe('NetworkController', () => {
       });
 
       it('should clear stored EIP1559 support when changing networks', async () => {
-        networkController.initializeProvider(networkControllerProviderConfig);
-        networkController.consoleThis = true;
+        networkController.initializeProvider();
         getLatestBlockStub.callsFake(() =>
           Promise.resolve({ baseFeePerGas: '0xa ' }),
         );


### PR DESCRIPTION
The `initializeProvider` parameters were removed recently in #16863, but they were still being set in tests. They have now been removed.

An unused property was also being set in the tests, which has now also been removed.

## Manual Testing Steps

N/A

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
