### PR TITLE
[E2E] Change to replace confirm snap to dialog snap

### DIFF
--- a/test/e2e/snaps/enums.js
+++ b/test/e2e/snaps/enums.js
@@ -1,3 +1,3 @@
 module.exports = {
-  TEST_SNAPS_WEBSITE_URL: 'https://metamask.github.io/test-snaps/4.4.1/',
+  TEST_SNAPS_WEBSITE_URL: 'https://metamask.github.io/test-snaps/4.5.0/',
 };

--- a/test/e2e/snaps/test-snap-installed.spec.js
+++ b/test/e2e/snaps/test-snap-installed.spec.js
@@ -31,9 +31,9 @@ describe('Test Snap Installed', function () {
         // navigate to test snaps page and connect
         await driver.openNewPage(TEST_SNAPS_WEBSITE_URL);
         await driver.delay(1000);
-        const confirmButton = await driver.findElement('#connectConfirmSnap');
+        const confirmButton = await driver.findElement('#connectDialogSnap');
         await driver.scrollToElement(confirmButton);
-        await driver.clickElement('#connectConfirmSnap');
+        await driver.clickElement('#connectDialogSnap');
         await driver.delay(1000);
 
         // switch to metamask extension and click connect
@@ -117,7 +117,7 @@ describe('Test Snap Installed', function () {
         await driver.delay(1000);
         assert.equal(
           await result.getText(),
-          'npm:@metamask/test-snap-confirm, npm:@metamask/test-snap-error',
+          'npm:@metamask/test-snap-dialog, npm:@metamask/test-snap-error',
         );
       },
     );


### PR DESCRIPTION
With the upcoming deprecation of snap_confirm, this moves the install check e2e to use dialog instead.

See issue in test-snaps https://github.com/MetaMask/test-snaps/issues/108