### PR TITLE
Fix EIP-712 input validation order

### DIFF
--- a/app/scripts/lib/typed-message-manager.js
+++ b/app/scripts/lib/typed-message-manager.js
@@ -197,10 +197,6 @@ export default class TypedMessageManager extends EventEmitter {
           data = JSON.parse(params.data);
         }, '"data" must be a valid JSON string.');
         const validation = jsonschema.validate(data, TYPED_MESSAGE_SCHEMA);
-        assert.ok(
-          data.primaryType in data.types,
-          `Primary type of "${data.primaryType}" has no type definition.`,
-        );
         if (validation.errors.length !== 0) {
           throw ethErrors.rpc.invalidParams({
             message:
@@ -208,6 +204,10 @@ export default class TypedMessageManager extends EventEmitter {
             data: validation.errors.map((v) => v.message.toString()),
           });
         }
+        assert.ok(
+          data.primaryType in data.types,
+          `Primary type of "${data.primaryType}" has no type definition.`,
+        );
         let { chainId } = data.domain;
         if (chainId) {
           const activeChainId = parseInt(this._getCurrentChainId(), 16);


### PR DESCRIPTION
## Explanation

Fixes EIP-712 input validation order, so we validate the input schema before during further validation. This means that we don't throw "Primary type of undefined has no type definition" for undefined inputs.

## Manual Testing Steps
1. Try to sign an ERC-712 message without a `primaryType`
2. You should see the "Signing data must conform to EIP-712 schema." message