### PR TITLE
Fix 16842 - Update NFT error message so that it's caught properly and displayed

### DIFF
--- a/ui/store/actions.js
+++ b/ui/store/actions.js
@@ -1826,8 +1826,8 @@ export function addNftVerifyOwnership(
       ]);
     } catch (error) {
       if (
-        error.message.includes('This collectible is not owned by the user') ||
-        error.message.includes('Unable to verify ownership.')
+        error.message.includes('This NFT is not owned by the user') ||
+        error.message.includes('Unable to verify ownership')
       ) {
         throw error;
       } else {


### PR DESCRIPTION
## Explanation

* Fixes #16842

An error message in the NFTController was changed from "collectible" to "NFT" and thus the error message wasn't properly caught and displayed on the front-end.

## Screenshots/Screencaps

The error is now identified properly and the ActionableMessage now displays without forwarding the user to the home screen

<img width="564" alt="Screenshot at Jan 12 12-58-15" src="https://user-images.githubusercontent.com/46655/212157249-f1b82227-3539-43be-9603-2a4ae42c4fe6.png">


## Manual Testing Steps

1.  `NFTS_V1=1 yarn start`
2. Click the "NFTs" tab
3.  Click "Import" 
4.  Attempt to import an NFT you don't own
5.  See correct error message

## Pre-merge author checklist

- [ ] I've clearly explained:
  - [ ] What problem this PR is solving
  - [ ] How this problem was solved
  - [ ] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
