### PR TITLE
[E2E FIX] Fixed enums.js 

### DIFF
--- a/test/e2e/snaps/enums.js
+++ b/test/e2e/snaps/enums.js
@@ -1,3 +1,3 @@
 module.exports = {
-  TEST_SNAPS_WEBSITE_URL: 'https://metamask.github.io/test-snaps/4.4.1/',
+  TEST_SNAPS_WEBSITE_URL: 'https://metamask.github.io/test-snaps/4.5.0/',
 };


### PR DESCRIPTION
The enums.js file that points to the correct version of test-snaps was fixed to point at the correct version.