### PR TITLE
Fix Snaps E2E test flake

### DIFF
--- a/test/e2e/snaps/test-snap-installed.spec.js
+++ b/test/e2e/snaps/test-snap-installed.spec.js
@@ -33,6 +33,7 @@ describe('Test Snap Installed', function () {
         await driver.delay(1000);
         const confirmButton = await driver.findElement('#connectDialogSnap');
         await driver.scrollToElement(confirmButton);
+        await driver.delay(1000);
         await driver.clickElement('#connectDialogSnap');
         await driver.delay(1000);
 


### PR DESCRIPTION
## Explanation

Adds some delay and follows the existing pattern of waiting after a scroll to hopefully fix a flaky E2E tests.