### PR TITLE
Await `initializeProvider` in network controller tests

### DIFF
--- a/app/scripts/controllers/network/network-controller.test.js
+++ b/app/scripts/controllers/network/network-controller.test.js
@@ -80,8 +80,8 @@ describe('NetworkController', () => {
     });
 
     describe('#provider', () => {
-      it('provider should be updatable without reassignment', () => {
-        networkController.initializeProvider();
+      it('provider should be updatable without reassignment', async () => {
+        await networkController.initializeProvider();
         const providerProxy =
           networkController.getProviderAndBlockTracker().provider;
         expect(providerProxy.test).toBeUndefined();
@@ -126,15 +126,15 @@ describe('NetworkController', () => {
     });
 
     describe('#setProviderType', () => {
-      it('should update provider.type', () => {
-        networkController.initializeProvider();
+      it('should update provider.type', async () => {
+        await networkController.initializeProvider();
         networkController.setProviderType('mainnet');
         const { type } = networkController.getProviderConfig();
         expect(type).toStrictEqual('mainnet');
       });
 
-      it('should set the network to loading', () => {
-        networkController.initializeProvider();
+      it('should set the network to loading', async () => {
+        await networkController.initializeProvider();
 
         const spy = sinon.spy(networkController, '_setNetworkState');
         networkController.setProviderType('mainnet');
@@ -146,14 +146,14 @@ describe('NetworkController', () => {
 
     describe('#getEIP1559Compatibility', () => {
       it('should return false when baseFeePerGas is not in the block header', async () => {
-        networkController.initializeProvider();
+        await networkController.initializeProvider();
         const supportsEIP1559 =
           await networkController.getEIP1559Compatibility();
         expect(supportsEIP1559).toStrictEqual(false);
       });
 
       it('should return true when baseFeePerGas is in block header', async () => {
-        networkController.initializeProvider();
+        await networkController.initializeProvider();
         getLatestBlockStub.callsFake(() =>
           Promise.resolve({ baseFeePerGas: '0xa ' }),
         );
@@ -163,7 +163,7 @@ describe('NetworkController', () => {
       });
 
       it('should store EIP1559 support in state to reduce calls to _getLatestBlock', async () => {
-        networkController.initializeProvider();
+        await networkController.initializeProvider();
         getLatestBlockStub.callsFake(() =>
           Promise.resolve({ baseFeePerGas: '0xa ' }),
         );
@@ -175,7 +175,7 @@ describe('NetworkController', () => {
       });
 
       it('should clear stored EIP1559 support when changing networks', async () => {
-        networkController.initializeProvider();
+        await networkController.initializeProvider();
         getLatestBlockStub.callsFake(() =>
           Promise.resolve({ baseFeePerGas: '0xa ' }),
         );


### PR DESCRIPTION
The network controller unit tests have been updated to wait until the network controller is fully initialized before proceeding. This ensures that the initialization doesn't have any side-effects that affect later tests.

This relates to https://github.com/MetaMask/metamask-extension/issues/16962

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
