### PR TITLE
Refactor: Construct the network controller within each test

### DIFF
--- a/app/scripts/controllers/network/network-controller.test.js
+++ b/app/scripts/controllers/network/network-controller.test.js
@@ -58,22 +58,39 @@ const BLOCK = {
   baseFeePerGas: '0x63c498a46',
 };
 
+const defaultControllerOptions = {
+  infuraProjectId: 'foo',
+};
+
+/**
+ * Builds a controller based on the given options, and calls the given function
+ * with that controller.
+ *
+ * @param args - Either a function, or an options bag + a function. The options
+ * bag is equivalent to the options that NetworkController takes (although
+ * `messenger` is filled in if not given); the function will be called with the
+ * built controller.
+ * @returns Whatever the callback returns.
+ */
+async function withController(...args) {
+  const [{ ...constructorArgs }, fn] = args.length === 2 ? args : [{}, args[0]];
+  const controller = new NetworkController({
+    ...defaultControllerOptions,
+    ...constructorArgs,
+  });
+  try {
+    return await fn({ controller });
+  } finally {
+    await controller.destroy();
+  }
+}
+
 describe('NetworkController', () => {
   describe('controller', () => {
-    let networkController;
-    let setProviderTypeAndWait;
     let latestBlock;
 
     beforeEach(() => {
       latestBlock = BLOCK;
-      networkController = new NetworkController({ infuraProjectId: 'foo' });
-      setProviderTypeAndWait = () =>
-        new Promise((resolve) => {
-          networkController.on(NETWORK_EVENTS.NETWORK_DID_CHANGE, () => {
-            resolve();
-          });
-          networkController.setProviderType('mainnet');
-        });
       nock('http://localhost:8545')
         .persist()
         .post(/.*/u)
@@ -89,112 +106,130 @@ describe('NetworkController', () => {
     });
 
     afterEach(() => {
-      networkController.destroy();
       nock.cleanAll();
     });
 
     describe('#provider', () => {
       it('provider should be updatable without reassignment', async () => {
-        await networkController.initializeProvider();
-        const providerProxy =
-          networkController.getProviderAndBlockTracker().provider;
-        expect(providerProxy.test).toBeUndefined();
-        providerProxy.setTarget({ test: true });
-        expect(providerProxy.test).toStrictEqual(true);
+        await withController(async ({ controller }) => {
+          await controller.initializeProvider();
+          const providerProxy =
+            controller.getProviderAndBlockTracker().provider;
+          expect(providerProxy.test).toBeUndefined();
+
+          providerProxy.setTarget({ test: true });
+
+          expect(providerProxy.test).toStrictEqual(true);
+        });
       });
     });
 
     describe('destroy', () => {
       it('should not throw if called before initialization', async () => {
-        await expect(
-          async () => await networkController.destroy(),
-        ).not.toThrow();
+        const controller = new NetworkController(defaultControllerOptions);
+        await expect(async () => await controller.destroy()).not.toThrow();
       });
 
       it('should stop the block tracker for the current selected network', async () => {
-        await networkController.initializeProvider();
-        const { blockTracker } = networkController.getProviderAndBlockTracker();
-        // The block tracker starts running after a listener is attached
-        blockTracker.addListener('latest', () => {
-          // do nothing
+        await withController(async ({ controller }) => {
+          await controller.initializeProvider();
+          const { blockTracker } = controller.getProviderAndBlockTracker();
+          // The block tracker starts running after a listener is attached
+          blockTracker.addListener('latest', () => {
+            // do nothing
+          });
+          expect(blockTracker.isRunning()).toBe(true);
+
+          controller.destroy();
+
+          expect(blockTracker.isRunning()).toBe(false);
         });
-        expect(blockTracker.isRunning()).toBe(true);
-
-        networkController.destroy();
-
-        expect(blockTracker.isRunning()).toBe(false);
       });
     });
 
     describe('#getNetworkState', () => {
-      it('should return "loading" when new', () => {
-        const networkState = networkController.getNetworkState();
-        expect(networkState).toStrictEqual('loading');
+      it('should return "loading" when uninitialized', async () => {
+        await withController(async ({ controller }) => {
+          const networkState = controller.getNetworkState();
+          expect(networkState).toStrictEqual('loading');
+        });
       });
     });
 
     describe('#setProviderType', () => {
       it('should update provider.type', async () => {
-        await networkController.initializeProvider();
-        networkController.setProviderType('mainnet');
-        const { type } = networkController.getProviderConfig();
-        expect(type).toStrictEqual('mainnet');
+        await withController(async ({ controller }) => {
+          await controller.initializeProvider();
+          controller.setProviderType('mainnet');
+          const { type } = controller.getProviderConfig();
+          expect(type).toStrictEqual('mainnet');
+        });
       });
 
       it('should set the network to loading', async () => {
-        await networkController.initializeProvider();
+        await withController(async ({ controller }) => {
+          await controller.initializeProvider();
 
-        networkController.setProviderType('mainnet');
-        const { promise: networkIdChanged, resolve } = deferredPromise();
-        networkController.networkStore.subscribe(resolve);
+          controller.setProviderType('mainnet');
+          const { promise: networkIdChanged, resolve } = deferredPromise();
+          controller.networkStore.subscribe(resolve);
 
-        expect(networkController.networkStore.getState()).toBe('loading');
-        await networkIdChanged;
-        expect(networkController.networkStore.getState()).toBe('1');
+          expect(controller.networkStore.getState()).toBe('loading');
+          await networkIdChanged;
+          expect(controller.networkStore.getState()).toBe('1');
+        });
       });
     });
 
     describe('#getEIP1559Compatibility', () => {
       it('should return false when baseFeePerGas is not in the block header', async () => {
-        latestBlock = PRE_1559_BLOCK;
-        await networkController.initializeProvider();
-        const supportsEIP1559 =
-          await networkController.getEIP1559Compatibility();
-        expect(supportsEIP1559).toStrictEqual(false);
+        await withController(async ({ controller }) => {
+          latestBlock = PRE_1559_BLOCK;
+          await controller.initializeProvider();
+          const supportsEIP1559 = await controller.getEIP1559Compatibility();
+          expect(supportsEIP1559).toStrictEqual(false);
+        });
       });
 
       it('should return true when baseFeePerGas is in block header', async () => {
-        await networkController.initializeProvider();
-        const supportsEIP1559 =
-          await networkController.getEIP1559Compatibility();
-        expect(supportsEIP1559).toStrictEqual(true);
+        await withController(async ({ controller }) => {
+          await controller.initializeProvider();
+          const supportsEIP1559 = await controller.getEIP1559Compatibility();
+          expect(supportsEIP1559).toStrictEqual(true);
+        });
       });
 
       it('should store EIP1559 support in state to reduce calls to _getLatestBlock', async () => {
-        await networkController.initializeProvider();
-        await networkController.getEIP1559Compatibility();
-        const supportsEIP1559 =
-          await networkController.getEIP1559Compatibility();
-        expect(supportsEIP1559).toStrictEqual(true);
+        await withController(async ({ controller }) => {
+          await controller.initializeProvider();
+          await controller.getEIP1559Compatibility();
+          const supportsEIP1559 = await controller.getEIP1559Compatibility();
+          expect(supportsEIP1559).toStrictEqual(true);
+        });
       });
 
       it('should clear stored EIP1559 support when changing networks', async () => {
-        await networkController.initializeProvider();
-        await networkController.getEIP1559Compatibility();
-        expect(
-          networkController.networkDetails.getState().EIPS[1559],
-        ).toStrictEqual(true);
-        latestBlock = PRE_1559_BLOCK;
-
-        await setProviderTypeAndWait('mainnet');
-
-        expect(
-          networkController.networkDetails.getState().EIPS[1559],
-        ).toBeUndefined();
-        await networkController.getEIP1559Compatibility();
-        expect(
-          networkController.networkDetails.getState().EIPS[1559],
-        ).toStrictEqual(false);
+        await withController(async ({ controller }) => {
+          await controller.initializeProvider();
+          await controller.getEIP1559Compatibility();
+          expect(controller.networkDetails.getState().EIPS[1559]).toStrictEqual(
+            true,
+          );
+          latestBlock = PRE_1559_BLOCK;
+          await new Promise((resolve) => {
+            controller.on(NETWORK_EVENTS.NETWORK_DID_CHANGE, () => {
+              resolve();
+            });
+            controller.setProviderType('mainnet');
+          });
+          expect(
+            controller.networkDetails.getState().EIPS[1559],
+          ).toBeUndefined();
+          await controller.getEIP1559Compatibility();
+          expect(controller.networkDetails.getState().EIPS[1559]).toStrictEqual(
+            false,
+          );
+        });
       });
     });
   });

--- a/app/scripts/controllers/network/network-controller.test.js
+++ b/app/scripts/controllers/network/network-controller.test.js
@@ -125,7 +125,7 @@ describe('NetworkController', () => {
     describe('destroy', () => {
       it('should not throw if called before initialization', async () => {
         const controller = new NetworkController(defaultControllerOptions);
-        await expect(controller.destroy()).not.toThrow();
+        await expect(controller.destroy()).resolves.toBe(undefined);
       });
 
       it('should stop the block tracker for the current selected network', async () => {

--- a/app/scripts/controllers/network/network-controller.test.js
+++ b/app/scripts/controllers/network/network-controller.test.js
@@ -138,7 +138,7 @@ describe('NetworkController', () => {
           });
           expect(blockTracker.isRunning()).toBe(true);
 
-          controller.destroy();
+          await controller.destroy();
 
           expect(blockTracker.isRunning()).toBe(false);
         });

--- a/app/scripts/controllers/network/network-controller.test.js
+++ b/app/scripts/controllers/network/network-controller.test.js
@@ -73,7 +73,7 @@ const defaultControllerOptions = {
  * @returns Whatever the callback returns.
  */
 async function withController(...args) {
-  const [{ ...constructorArgs }, fn] = args.length === 2 ? args : [{}, args[0]];
+  const [constructorArgs, fn] = args.length === 2 ? args : [{}, args[0]];
   const controller = new NetworkController({
     ...defaultControllerOptions,
     ...constructorArgs,

--- a/app/scripts/controllers/network/network-controller.test.js
+++ b/app/scripts/controllers/network/network-controller.test.js
@@ -127,7 +127,7 @@ describe('NetworkController', () => {
     describe('destroy', () => {
       it('should not throw if called before initialization', async () => {
         const controller = new NetworkController(defaultControllerOptions);
-        await expect(async () => await controller.destroy()).not.toThrow();
+        await expect(controller.destroy()).not.toThrow();
       });
 
       it('should stop the block tracker for the current selected network', async () => {

--- a/app/scripts/controllers/network/network-controller.test.js
+++ b/app/scripts/controllers/network/network-controller.test.js
@@ -66,10 +66,8 @@ const defaultControllerOptions = {
  * Builds a controller based on the given options, and calls the given function
  * with that controller.
  *
- * @param args - Either a function, or an options bag + a function. The options
- * bag is equivalent to the options that NetworkController takes (although
- * `messenger` is filled in if not given); the function will be called with the
- * built controller.
+ * @param args - Either a function, or constructor options + a function. The
+ * function will be called with the built controller.
  * @returns Whatever the callback returns.
  */
 async function withController(...args) {


### PR DESCRIPTION
The network controller is now constructed within each network controller unit test, rather than in the `beforeEach`. This allows us to customize the constructor options in each test, which some planned future tests will require.

The controller is constructed with a helper function that also handles calling `destroy` after each test, even if the test failed. This helps to prevent tests from affecting each other.

This relates to https://github.com/MetaMask/metamask-extension/issues/16962

## Pre-merge author checklist

- [ ] I've clearly explained:
  - [ ] What problem this PR is solving
  - [ ] How this problem was solved
  - [ ] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
