### PR TITLE
Fix #17142 - Ensure toggle arrow is visible in dark mode

### DIFF
--- a/ui/components/app/collectibles-items/index.scss
+++ b/ui/components/app/collectibles-items/index.scss
@@ -27,6 +27,10 @@
       color: var(--color-overlay-inverse);
       text-align: center;
     }
+
+    &__icon-chevron {
+      color: var(--color-icon-default);
+    }
   }
 
   &__item-wrapper {
@@ -51,9 +55,5 @@
       height: 100%;
       cursor: pointer;
     }
-  }
-
-  &__icon-chevron {
-    color: var(--color-icon-default);
   }
 }


### PR DESCRIPTION
* Fixes #17142

The CSS nesting was incorrect, making the arrow color incorrect.

## Screenshots/Screencaps

<img width="696" alt="NFTArrowFixed" src="https://user-images.githubusercontent.com/46655/212388704-82ee5b1f-fa71-4e45-a11d-5d7d2505621f.png">

## Manual Testing Steps

<!--
How should reviewers and QA manually test your changes? For instance:

- Go to this screen
- Do this
- Then do this
-->

## Pre-merge author checklist

- [ ] I've clearly explained:
  - [ ] What problem this PR is solving
  - [ ] How this problem was solved
  - [ ] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
