### PR TITLE
Validating or restricting the number of digits on token allowance flow

### DIFF
--- a/shared/constants/tokens.js
+++ b/shared/constants/tokens.js
@@ -45,3 +45,4 @@ export const MAX_TOKEN_ALLOWANCE_AMOUNT = new BigNumber(2)
   .minus(1)
   .toString(10);
 export const TOKEN_ALLOWANCE_VALUE_REGEX = /^[0-9]{1,}([,.][0-9]{1,})?$/u;
+export const DECIMAL_REGEX = /\.(\d*)/u;

--- a/ui/components/app/custom-spending-cap/custom-spending-cap.js
+++ b/ui/components/app/custom-spending-cap/custom-spending-cap.js
@@ -30,6 +30,7 @@ import {
 import {
   MAX_TOKEN_ALLOWANCE_AMOUNT,
   TOKEN_ALLOWANCE_VALUE_REGEX,
+  DECIMAL_REGEX,
 } from '../../../../shared/constants/tokens';
 import { CustomSpendingCapTooltip } from './custom-spending-cap-tooltip';
 
@@ -54,13 +55,6 @@ export default function CustomSpendingCap({
 
   const replaceCommaToDot = (inputValue) => {
     return inputValue.replace(/,/gu, '.');
-  };
-
-  const countDecimals = (inputValue) => {
-    if (replaceCommaToDot(inputValue).toString().split('.')[1] !== undefined) {
-      return replaceCommaToDot(inputValue).toString().split('.')[1].length;
-    }
-    return 0;
   };
 
   const decConversionGreaterThan = (tokenValue, tokenBalance) => {
@@ -113,8 +107,8 @@ export default function CustomSpendingCap({
     let spendingCapError = '';
     const inputTextLogic = getInputTextLogic(valueInput);
     const inputTextLogicDescription = inputTextLogic.description;
-
-    if (countDecimals(valueInput) > decimals) {
+    const match = DECIMAL_REGEX.exec(replaceCommaToDot(valueInput));
+    if (match?.[1]?.length > decimals) {
       return;
     }
 

--- a/ui/components/app/custom-spending-cap/custom-spending-cap.js
+++ b/ui/components/app/custom-spending-cap/custom-spending-cap.js
@@ -1,6 +1,7 @@
 import React, { useState, useContext, useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
+import classnames from 'classnames';
 import BigNumber from 'bignumber.js';
 import { I18nContext } from '../../../contexts/i18n';
 import Box from '../../ui/box';
@@ -55,6 +56,13 @@ export default function CustomSpendingCap({
     return inputValue.replace(/,/gu, '.');
   };
 
+  const countDecimals = (inputValue) => {
+    if (replaceCommaToDot(inputValue).toString().split('.')[1] !== undefined) {
+      return replaceCommaToDot(inputValue).toString().split('.')[1].length;
+    }
+    return 0;
+  };
+
   const decConversionGreaterThan = (tokenValue, tokenBalance) => {
     return conversionGreaterThan(
       { value: Number(replaceCommaToDot(tokenValue)), fromNumericBase: 'dec' },
@@ -105,6 +113,10 @@ export default function CustomSpendingCap({
     let spendingCapError = '';
     const inputTextLogic = getInputTextLogic(valueInput);
     const inputTextLogicDescription = inputTextLogic.description;
+
+    if (countDecimals(valueInput) > decimals) {
+      return;
+    }
 
     if (valueInput && !TOKEN_ALLOWANCE_VALUE_REGEX.test(valueInput)) {
       spendingCapError = t('spendingCapError');
@@ -230,7 +242,9 @@ export default function CustomSpendingCap({
               paddingRight={4}
               paddingBottom={2}
               textAlign={TEXT_ALIGN.END}
-              className="custom-spending-cap__max"
+              className={classnames('custom-spending-cap__max', {
+                'custom-spending-cap__max--with-error-message': error,
+              })}
             >
               <ButtonLink
                 size={SIZES.AUTO}
@@ -242,16 +256,21 @@ export default function CustomSpendingCap({
                 {t('max')}
               </ButtonLink>
             </Box>
-            <Typography
-              className="custom-spending-cap__description"
-              color={COLORS.TEXT_DEFAULT}
-              variant={TYPOGRAPHY.H7}
-              boxProps={{ paddingTop: 2, paddingBottom: 2 }}
+            <Box
+              className={classnames('custom-spending-cap__description', {
+                'custom-spending-cap__description--with-error-message': error,
+              })}
             >
-              {replaceCommaToDot(value)
-                ? customSpendingCapText
-                : inputLogicEmptyStateText}
-            </Typography>
+              <Typography
+                color={COLORS.TEXT_DEFAULT}
+                variant={TYPOGRAPHY.H7}
+                boxProps={{ paddingTop: 2, paddingBottom: 2 }}
+              >
+                {replaceCommaToDot(value)
+                  ? customSpendingCapText
+                  : inputLogicEmptyStateText}
+              </Typography>
+            </Box>
           </label>
         </Box>
       </Box>

--- a/ui/components/app/custom-spending-cap/index.scss
+++ b/ui/components/app/custom-spending-cap/index.scss
@@ -6,6 +6,10 @@
   &__max {
     position: relative;
     margin-top: -30px;
+
+    &--with-error-message {
+      margin-top: -66px;
+    }
   }
 
   &__input {
@@ -14,6 +18,10 @@
 
   &__description {
     word-break: break-word;
+
+    &--with-error-message {
+      margin-top: 30px;
+    }
   }
 
   #custom-spending-cap-input-value {

--- a/ui/components/ui/numeric-input/numeric-input.component.js
+++ b/ui/components/ui/numeric-input/numeric-input.component.js
@@ -3,8 +3,7 @@ import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import Typography from '../typography/typography';
 import { COLORS, TYPOGRAPHY } from '../../../helpers/constants/design-system';
-
-const DECIMAL_REGEX = /\.(\d*)/u;
+import { DECIMAL_REGEX } from '../../../../shared/constants/tokens';
 
 export default function NumericInput({
   detailText = '',


### PR DESCRIPTION
## Explanation

The problem here is that the test case that resulted in the error entered more decimal numbers than the token allows, which causes the problem with a decimal point within the hex value/data. The proper fix here is to prevent the user from enter more numbers in the decimal place than the token has decimals. This PR are validating or restricting the number of digits after the decimal point that the user can enter and fixing styles for Max button and description when error message is shown.

* Fixes #17175 

## Screenshots/Screencaps

### Before

https://user-images.githubusercontent.com/92527393/212714310-180a738c-2f9b-4fa7-9d54-0c167663344f.mov

### After

https://user-images.githubusercontent.com/92527393/212712143-bd577398-dfaa-4bf1-9fa2-240cfedf0c41.mov

## Manual Testing Steps

### Test-Dapp

1. Login the extension
2. Click the account menu
3. Click `Experimental -> Improved token allowance experience` to turn the setting `ON`
4. Navigate to the `test dapp` https://metamask.github.io/test-dapp
5. Deploy an ERC20 from the `Send Tokens` section, click `Create Token`
6. Once deployed, click `Approve Tokens`
7. Try to enter the amount `0.123456789987654321` (you will see that you can enter only 0.1234 and other decimals are not entered because this token has 4 decimals)
8. Click `Next`
9. Click `Approve`

### Etherscan

1. Unlock MetaMask
2. Click the account menu
3. Click `Experimental -> Improved token allowance experience` to turn the setting `ON`
4. Go to https://etherscan.io/token/0x6b175474e89094c44da98b954eedeac495271d0f#writeContract
5. Connect your wallet
6. Under `approve` input any address and a number
7. Click on write
8. Try to enter the amount `0.123456789987654321567345` (you will see that you can enter only 0.123456789987654321 and other decimals are not entered because this token has 18 decimals)
