### PR TITLE
Update chromedriver version to 109

### DIFF
--- a/.circleci/scripts/chrome-install.sh
+++ b/.circleci/scripts/chrome-install.sh
@@ -5,12 +5,12 @@ set -u
 set -o pipefail
 
 # To get the latest version, see <https://www.ubuntuupdates.org/ppa/google_chrome?dist=stable>
-CHROME_VERSION='107.0.5304.87-1'
+CHROME_VERSION='109.0.5414.74-1'
 CHROME_BINARY="google-chrome-stable_${CHROME_VERSION}_amd64.deb"
 CHROME_BINARY_URL="https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/${CHROME_BINARY}"
 
 # To retrieve this checksum, run the `wget` and `shasum` commands below
-CHROME_BINARY_SHA512SUM='07b443bc1382431da84f6812b7e19f1149aa195fb8b3d28834630cc5964fb9d12124abbf4ec1c98d5c0513cdf16c2a3f16a74518c984aaf57ca418b3cd36a4e2'
+CHROME_BINARY_SHA512SUM='5fa92a552588894eca752575851f4c1a74b02b02233170a03bf642dad58c8544f5af1af919598f8e126efbf6b92b5cbdbdbf58a7df6033ce761587c2bd840629'
 
 wget -O "${CHROME_BINARY}" -t 5 "${CHROME_BINARY_URL}"
 

--- a/package.json
+++ b/package.json
@@ -404,7 +404,7 @@
     "browserify": "^16.5.1",
     "chalk": "^3.0.0",
     "chokidar": "^3.5.3",
-    "chromedriver": "^107.0.0",
+    "chromedriver": "^109.0.0",
     "concurrently": "^7.6.0",
     "copy-webpack-plugin": "^6.0.3",
     "cross-spawn": "^7.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9074,13 +9074,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axios@npm:^0.27.2":
-  version: 0.27.2
-  resolution: "axios@npm:0.27.2"
+"axios@npm:^1.2.1":
+  version: 1.2.2
+  resolution: "axios@npm:1.2.2"
   dependencies:
-    follow-redirects: ^1.14.9
+    follow-redirects: ^1.15.0
     form-data: ^4.0.0
-  checksum: 38cb7540465fe8c4102850c4368053c21683af85c5fdf0ea619f9628abbcb59415d1e22ebc8a6390d2bbc9b58a9806c874f139767389c862ec9b772235f06854
+    proxy-from-env: ^1.1.0
+  checksum: 6e357491b38426c5720f7328ecbafca3c643b03952c052d787570672ce7a9365717c2d64db4ce97cfbee3f830fa405101e360e14d0857ef7f96a9f4d814c4e03
   languageName: node
   linkType: hard
 
@@ -10977,21 +10978,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chromedriver@npm:^107.0.0":
-  version: 107.0.1
-  resolution: "chromedriver@npm:107.0.1"
+"chromedriver@npm:^109.0.0":
+  version: 109.0.0
+  resolution: "chromedriver@npm:109.0.0"
   dependencies:
     "@testim/chrome-version": ^1.1.3
-    axios: ^0.27.2
+    axios: ^1.2.1
     compare-versions: ^5.0.1
-    del: ^6.1.1
     extract-zip: ^2.0.1
     https-proxy-agent: ^5.0.1
     proxy-from-env: ^1.1.0
     tcp-port-used: ^1.0.1
   bin:
     chromedriver: bin/chromedriver
-  checksum: f1cebf41b2e453dcbbda46fb1c00b32de20741f4fcb99d04f77fcb88c76aef55351bc91120373f5041965486abb924f99e42e533e9693f2a0dff2bd58acbea9f
+  checksum: a81347eb8c7dab021f8d94ce6962d1b9eaf5134230dfc589bab01b8db5e97e0120abd0b5df2a6f68c5e0126f9b5c7ae361874c26215d65ba673f6c3b33da8d0b
   languageName: node
   linkType: hard
 
@@ -12802,22 +12802,6 @@ __metadata:
     pify: ^3.0.0
     rimraf: ^2.2.8
   checksum: 88192c10411b55ba644456ac4881c6ed92029b53b882bb6067011af05e8da8d9c87f5ddacf2999cc45a05a9f03af345b83f17f341a88f456417c7daa04458d38
-  languageName: node
-  linkType: hard
-
-"del@npm:^6.1.1":
-  version: 6.1.1
-  resolution: "del@npm:6.1.1"
-  dependencies:
-    globby: ^11.0.1
-    graceful-fs: ^4.2.4
-    is-glob: ^4.0.1
-    is-path-cwd: ^2.2.0
-    is-path-inside: ^3.0.2
-    p-map: ^4.0.0
-    rimraf: ^3.0.2
-    slash: ^3.0.0
-  checksum: 563288b73b8b19a7261c47fd21a330eeab6e2acd7c6208c49790dfd369127120dd7836cdf0c1eca216b77c94782a81507eac6b4734252d3bef2795cb366996b6
   languageName: node
   linkType: hard
 
@@ -16363,7 +16347,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"follow-redirects@npm:^1.14.9":
+"follow-redirects@npm:^1.15.0":
   version: 1.15.2
   resolution: "follow-redirects@npm:1.15.2"
   peerDependenciesMeta:
@@ -19501,13 +19485,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-path-cwd@npm:^2.2.0":
-  version: 2.2.0
-  resolution: "is-path-cwd@npm:2.2.0"
-  checksum: 46a840921bb8cc0dc7b5b423a14220e7db338072a4495743a8230533ce78812dc152548c86f4b828411fe98c5451959f07cf841c6a19f611e46600bd699e8048
-  languageName: node
-  linkType: hard
-
 "is-path-in-cwd@npm:^1.0.0":
   version: 1.0.0
   resolution: "is-path-in-cwd@npm:1.0.0"
@@ -19523,13 +19500,6 @@ __metadata:
   dependencies:
     path-is-inside: ^1.0.1
   checksum: 07e52c81163937ff89b4700b7ad474de3b396846b55ed87530fb0a22cb9103926152939f673bc1a0592448e7e4e9d75eb734be21b4ad411311065c6a509fae54
-  languageName: node
-  linkType: hard
-
-"is-path-inside@npm:^3.0.2":
-  version: 3.0.3
-  resolution: "is-path-inside@npm:3.0.3"
-  checksum: abd50f06186a052b349c15e55b182326f1936c89a78bf6c8f2b707412517c097ce04bc49a0ca221787bc44e1049f51f09a2ffb63d22899051988d3a618ba13e9
   languageName: node
   linkType: hard
 
@@ -22889,7 +22859,7 @@ __metadata:
     browserify: ^16.5.1
     chalk: ^3.0.0
     chokidar: ^3.5.3
-    chromedriver: ^107.0.0
+    chromedriver: ^109.0.0
     classnames: ^2.2.6
     concurrently: ^7.6.0
     copy-to-clipboard: ^3.0.8


### PR DESCRIPTION
## Explanation

Update Chromedriver and Chrome to last stable version for e2e tests.

Info: https://www.ubuntuupdates.org/ppa/google_chrome?dist=stable


### Before

```
"chromedriver": "^107.0.0",
CHROME_VERSION='107.0.5304.87-1'
```

### After

```
"chromedriver": "^109.0.0",
CHROME_VERSION='109.0.5414.74-1'
```

## Manual Testing Steps

Check circle ci tests pass.

## Pre-merge author checklist

- [ ] I've clearly explained:
  - [ ] What problem this PR is solving
  - [ ] How this problem was solved
  - [ ] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
