### PR TITLE
Restore support for Chromium v78

### DIFF
--- a/app/manifest/v2/chrome.json
+++ b/app/manifest/v2/chrome.json
@@ -1,5 +1,5 @@
 {
-  "content_security_policy": "frame-ancestors 'none'",
+  "content_security_policy": "script-src 'self'; object-src 'self'; frame-ancestors 'none'",
   "externally_connectable": {
     "matches": ["https://metamask.io/*"],
     "ids": ["*"]

--- a/app/manifest/v2/chrome.json
+++ b/app/manifest/v2/chrome.json
@@ -1,5 +1,5 @@
 {
-  "content_security_policy": "script-src 'self'; object-src 'self'; frame-ancestors 'none'",
+  "content_security_policy": "frame-ancestors 'none'; script-src 'self'; object-src 'self'",
   "externally_connectable": {
     "matches": ["https://metamask.io/*"],
     "ids": ["*"]

--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -483,17 +483,16 @@ function setupController(initState, initLangCode) {
 
     let isMetaMaskInternalProcess = false;
     const sourcePlatform = getPlatform();
+    const senderUrl = remotePort.sender?.url
+      ? new URL(remotePort.sender.url)
+      : null;
 
     if (sourcePlatform === PLATFORM_FIREFOX) {
       isMetaMaskInternalProcess = metamaskInternalProcessHash[processName];
     } else {
       isMetaMaskInternalProcess =
-        remotePort.sender.origin === `chrome-extension://${browser.runtime.id}`;
+        senderUrl?.origin === `chrome-extension://${browser.runtime.id}`;
     }
-
-    const senderUrl = remotePort.sender?.url
-      ? new URL(remotePort.sender.url)
-      : null;
 
     if (isMetaMaskInternalProcess) {
       const portStream = new PortStream(remotePort);

--- a/development/build/scripts.js
+++ b/development/build/scripts.js
@@ -828,6 +828,17 @@ function setupBundlerDefaults(
         // Run TypeScript files through Babel
         { extensions },
       ],
+      // Transpile libraries that use ES2020 unsupported by Chrome v78
+      [
+        babelify,
+        {
+          only: [
+            './**/node_modules/@ethereumjs/util',
+            './**/node_modules/superstruct',
+          ],
+          global: true,
+        },
+      ],
       // Inline `fs.readFileSync` files
       brfs,
     ],


### PR DESCRIPTION
Support has been restored for Chromium v78. Previously the extension would crash upon startup.

The main incompatibility was the use of ES2020 operators (the optional chain and nullish coalesce operators) in the libraries  `@ethereumjs/util` and `superstruct`. This was resolved by transpiling those libraries.

After fixing that, the extension no longer crashed but the UI refused to connect. This was because the UI process was not being identified as an internal process, because the code responsible for checking that was relying on the `origin` property of [`MessageSender`](https://developer.chrome.com/docs/extensions/reference/runtime/#type-MessageSender) which wasn't added until Chromium v80. The check has been updated to use the `url` property instead, which existed in older versions of Chrome.

Lastly, the content security policy was updated to include the default content security policy alongside the intended modification. Newer versions of Chrome will merge the configured CSP with the default, but older versions required it to be explicitly specified. This should not result in any functional change.


## Manual Testing Steps

* Download Chromium v78
  * [Windows](https://commondatastorage.googleapis.com/chromium-browser-snapshots/index.html?prefix=Win_x64/693951/), [macOS](https://commondatastorage.googleapis.com/chromium-browser-snapshots/index.html?prefix=Mac/693954/), [Linux](https://commondatastorage.googleapis.com/chromium-browser-snapshots/index.html?prefix=Linux_x64/693954/)
* Install a MetaMask extension build from this branch, and ensure it works as expected (standard regression testing steps).

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
