### PR TITLE
[e2e] Add e2e test for deleting custom network

### DIFF
--- a/test/e2e/tests/add-custom-network.spec.js
+++ b/test/e2e/tests/add-custom-network.spec.js
@@ -147,4 +147,59 @@ describe('Custom network', function () {
       },
     );
   });
+  it('add a custom network and then delete that same network', async function () {
+    await withFixtures(
+      {
+        fixtures: new FixtureBuilder().build(),
+        ganacheOptions,
+        title: this.test.title,
+      },
+      async ({ driver }) => {
+        await driver.navigate();
+        await driver.fill('#password', 'correct horse battery staple');
+        await driver.press('#password', driver.Key.ENTER);
+
+        await driver.clickElement('[data-testid="network-display"]');
+        await driver.clickElement('.network__add-network-button');
+
+        let networks = await driver.findElements({ tag: 'button', text: 'Add' });
+        let addNetwork = networks[0];
+        addNetwork.click();
+
+        await driver.clickElement({ tag: 'button', text: 'Approve' });
+
+        await driver.clickElement({
+            tag: 'h6',
+            text: 'Dismiss',
+  
+          });
+
+          // goes to the settings screen
+        await driver.clickElement('.account-menu__icon');
+        await driver.clickElement({ text: 'Settings', tag: 'div' });
+
+        await driver.clickElement({ text: 'Networks', tag: 'div' });
+
+        const arbitrumNetwork = await driver.clickElement({
+          text: `Arbitrum One`,
+          tag: 'div',
+        });
+        
+
+        await driver.clickElement({
+          tag: 'button',
+          text: 'Delete',
+
+        });
+
+
+        assert.equal(arbitrumNetwork, undefined);
+        
+        //await driver.clickElement('.button btn--rounded btn-danger-primary modal-container__footer-button');
+        console.log('which network', arbitrumNetwork);
+
+        
+      },
+    );
+  });
 });

--- a/test/e2e/tests/add-custom-network.spec.js
+++ b/test/e2e/tests/add-custom-network.spec.js
@@ -147,7 +147,7 @@ describe('Custom network', function () {
       },
     );
   });
-  it('add a custom network and then delete that same network', async function () {
+  it('Add a custom network and then delete that same network', async function () {
     await withFixtures(
       {
         fixtures: new FixtureBuilder().build(),
@@ -162,44 +162,41 @@ describe('Custom network', function () {
         await driver.clickElement('[data-testid="network-display"]');
         await driver.clickElement('.network__add-network-button');
 
-        const networks = await driver.findElements({ tag: 'button', text: 'Add' });
+        const networks = await driver.findElements({ 
+          tag: 'button', 
+          text: 'Add',
+        });
+
         const addNetwork = networks[0];
         addNetwork.click();
 
         await driver.clickElement({ tag: 'button', text: 'Approve' });
 
-        await driver.clickElement({
-            tag: 'h6',
-            text: 'Dismiss',
-  
-          });
+        await driver.clickElement({ tag: 'h6', text: 'Dismiss' });
 
-          // goes to the settings screen
+        // goes to the settings screen
         await driver.clickElement('.account-menu__icon');
         await driver.clickElement({ text: 'Settings', tag: 'div' });
-
         await driver.clickElement({ text: 'Networks', tag: 'div' });
 
-        const arbitrumNetwork = await driver.clickElement({
-          text: `Arbitrum One`,
+        const arbitrumNetwork = await driver.clickElement({ 
+          text: `Arbitrum One`, 
           tag: 'div',
         });
 
-        const addedNetworks = await driver.findElements('.networks-tab__networks-list-name');
+        await driver.clickElement({
+          tag: 'button',
+          text: 'Delete',
+        });
 
         await driver.clickElement({
           tag: 'button',
           text: 'Delete',
-
-        });
-        await driver.clickElement({
-          tag: 'button',
-          text: 'Delete',
-
         });
 
-        assert.ok(addedNetworks.length-1);
-        
+        // it checks if custom network is delete 
+        const existNetwork = await driver.isElementPresent(arbitrumNetwork);
+        assert.equal(existNetwork, false, 'Network is not deleted');
       },
     );
   });

--- a/test/e2e/tests/add-custom-network.spec.js
+++ b/test/e2e/tests/add-custom-network.spec.js
@@ -162,8 +162,8 @@ describe('Custom network', function () {
         await driver.clickElement('[data-testid="network-display"]');
         await driver.clickElement('.network__add-network-button');
 
-        let networks = await driver.findElements({ tag: 'button', text: 'Add' });
-        let addNetwork = networks[0];
+        const networks = await driver.findElements({ tag: 'button', text: 'Add' });
+        const addNetwork = networks[0];
         addNetwork.click();
 
         await driver.clickElement({ tag: 'button', text: 'Approve' });

--- a/test/e2e/tests/add-custom-network.spec.js
+++ b/test/e2e/tests/add-custom-network.spec.js
@@ -192,11 +192,12 @@ describe('Custom network', function () {
 
         });
 
+        const addedNetworks = await driver.clickElement('.networks-tab__networks-list-name')
 
-        assert.equal(arbitrumNetwork, undefined);
+        assert.equal(addedNetworks.length,addedNetworks.length -1);
         
         //await driver.clickElement('.button btn--rounded btn-danger-primary modal-container__footer-button');
-        console.log('which network', arbitrumNetwork);
+        console.log('which network', addedNetworks);
 
         
       },

--- a/test/e2e/tests/add-custom-network.spec.js
+++ b/test/e2e/tests/add-custom-network.spec.js
@@ -188,6 +188,8 @@ describe('Custom network', function () {
           tag: 'button',
           text: 'Delete',
         });
+        
+        await driver.findElement('.modal-container__footer');
 
         await driver.clickElement({
           tag: 'button',

--- a/test/e2e/tests/add-custom-network.spec.js
+++ b/test/e2e/tests/add-custom-network.spec.js
@@ -162,8 +162,8 @@ describe('Custom network', function () {
         await driver.clickElement('[data-testid="network-display"]');
         await driver.clickElement('.network__add-network-button');
 
-        const networks = await driver.findElements({ 
-          tag: 'button', 
+        const networks = await driver.findElements({
+          tag: 'button',
           text: 'Add',
         });
 
@@ -179,8 +179,8 @@ describe('Custom network', function () {
         await driver.clickElement({ text: 'Settings', tag: 'div' });
         await driver.clickElement({ text: 'Networks', tag: 'div' });
 
-        const arbitrumNetwork = await driver.clickElement({ 
-          text: `Arbitrum One`, 
+        const arbitrumNetwork = await driver.clickElement({
+          text: `Arbitrum One`,
           tag: 'div',
         });
 
@@ -188,7 +188,7 @@ describe('Custom network', function () {
           tag: 'button',
           text: 'Delete',
         });
-        
+
         await driver.findElement('.modal-container__footer');
 
         await driver.clickElement({
@@ -196,7 +196,7 @@ describe('Custom network', function () {
           text: 'Delete',
         });
 
-        // it checks if custom network is delete 
+        // it checks if custom network is delete
         const existNetwork = await driver.isElementPresent(arbitrumNetwork);
         assert.equal(existNetwork, false, 'Network is not deleted');
       },

--- a/test/e2e/tests/add-custom-network.spec.js
+++ b/test/e2e/tests/add-custom-network.spec.js
@@ -184,21 +184,21 @@ describe('Custom network', function () {
           text: `Arbitrum One`,
           tag: 'div',
         });
-        
+
+        const addedNetworks = await driver.findElements('.networks-tab__networks-list-name');
 
         await driver.clickElement({
           tag: 'button',
           text: 'Delete',
 
         });
+        await driver.clickElement({
+          tag: 'button',
+          text: 'Delete',
 
-        const addedNetworks = await driver.clickElement('.networks-tab__networks-list-name')
+        });
 
-        assert.equal(addedNetworks.length,addedNetworks.length -1);
-        
-        //await driver.clickElement('.button btn--rounded btn-danger-primary modal-container__footer-button');
-        console.log('which network', addedNetworks);
-
+        assert.ok(addedNetworks.length-1);
         
       },
     );

--- a/test/e2e/tests/add-custom-network.spec.js
+++ b/test/e2e/tests/add-custom-network.spec.js
@@ -190,7 +190,7 @@ describe('Custom network', function () {
         });
 
         await driver.findElement('.modal-container__footer');
-
+        // should be deleted from the modal shown again to complete  deletion custom network
         await driver.clickElement({
           tag: 'button',
           text: 'Delete',


### PR DESCRIPTION
## Explanation

Added new custom network and deleted the same one.

* Fixes #17023 




## Manual Testing Steps

Run testcase locally or check ci pipeline and ensure that it continues to work normally:
`yarn test:e2e:single test/e2e/tests/add-custom-network.spec.js`

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
