### PR TITLE
Fix #17138 - Allow ActionMessage to be autohidden after a given number of milliseconds

### DIFF
--- a/ui/components/ui/actionable-message/actionable-message.js
+++ b/ui/components/ui/actionable-message/actionable-message.js
@@ -33,17 +33,22 @@ export default function ActionableMessage({
   autoHideTime = 0,
 }) {
   const [shouldDisplay, setShouldDisplay] = useState(true);
-  useEffect(() => {
-    if (autoHideTime === 0) {
-      return;
-    }
+  useEffect(
+    function () {
+      if (autoHideTime === 0) {
+        return undefined;
+      }
 
-    const timeout = setTimeout(() => {
-      setShouldDisplay(false);
-    }, autoHideTime);
+      const timeout = setTimeout(() => {
+        setShouldDisplay(false);
+      }, autoHideTime);
 
-    return () => clearTimeout(timeout);
-  }, [autoHideTime]);
+      return function () {
+        clearTimeout(timeout);
+      };
+    },
+    [autoHideTime],
+  );
 
   const actionableMessageClassName = classnames(
     'actionable-message',

--- a/ui/components/ui/actionable-message/actionable-message.js
+++ b/ui/components/ui/actionable-message/actionable-message.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import InfoTooltip from '../info-tooltip';
@@ -30,7 +30,21 @@ export default function ActionableMessage({
   iconFillColor = '',
   roundedButtons,
   dataTestId,
+  autoHideTime = 0,
 }) {
+  const [shouldDisplay, setShouldDisplay] = useState(true);
+  useEffect(() => {
+    if (autoHideTime === 0) {
+      return;
+    }
+
+    const timeout = setTimeout(() => {
+      setShouldDisplay(false);
+    }, autoHideTime);
+
+    return () => clearTimeout(timeout);
+  }, [autoHideTime]);
+
   const actionableMessageClassName = classnames(
     'actionable-message',
     typeHash[type],
@@ -41,6 +55,10 @@ export default function ActionableMessage({
 
   const onlyOneAction =
     (primaryAction && !secondaryAction) || (secondaryAction && !primaryAction);
+
+  if (!shouldDisplay) {
+    return null;
+  }
 
   return (
     <div className={actionableMessageClassName} data-testid={dataTestId}>
@@ -163,4 +181,8 @@ ActionableMessage.propTypes = {
    */
   roundedButtons: PropTypes.bool,
   dataTestId: PropTypes.string,
+  /**
+   * Whether the actionable message should auto-hide itself after a given amount of time
+   */
+  autoHideTime: PropTypes.number,
 };

--- a/ui/pages/home/home.component.js
+++ b/ui/pages/home/home.component.js
@@ -30,6 +30,7 @@ import {
   DISPLAY,
   COLORS,
 } from '../../helpers/constants/design-system';
+import { SECOND } from '../../../shared/constants/time';
 
 import {
   ASSET_ROUTE,
@@ -312,7 +313,7 @@ export default class Home extends PureComponent {
           <ActionableMessage
             type="success"
             className="home__new-network-notification"
-            autoHideTime={5000}
+            autoHideTime={5 * SECOND}
             message={
               <Box display={DISPLAY.INLINE_FLEX}>
                 <i className="fa fa-check-circle home__new-nft-notification-icon" />

--- a/ui/pages/home/home.component.js
+++ b/ui/pages/home/home.component.js
@@ -312,6 +312,7 @@ export default class Home extends PureComponent {
           <ActionableMessage
             type="success"
             className="home__new-network-notification"
+            autoHideTime={5000}
             message={
               <Box display={DISPLAY.INLINE_FLEX}>
                 <i className="fa fa-check-circle home__new-nft-notification-icon" />


### PR DESCRIPTION
The `ActionMessage` instance that displays on the home screen after a NFT has been added is annoying.  We should hide it after a given amount of time.  Instead of only allowing that functionality for this use case, adding that capability to ActionMessage will allow it to be used everywhere.

* Fixes #17138

## Manual Testing Steps

1. Add a new NFT
2. See that the Actionable message hides after 5 seconds

## Pre-merge author checklist

- [ ] I've clearly explained:
  - [ ] What problem this PR is solving
  - [ ] How this problem was solved
  - [ ] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
