### PR TITLE
Update copy and fix duplicate entries for Token Detection Settings search

### DIFF
--- a/app/_locales/de/messages.json
+++ b/app/_locales/de/messages.json
@@ -1264,14 +1264,8 @@
     "message": "Die von Ihnen eingegebene RPC-URL hat eine andere Chain-ID ($1) zurückgegeben. Bitte aktualisieren Sie die Chain-ID, damit sie mit der RPC-URL des Netzwerks übereinstimmt, das Sie hinzufügen möchten.",
     "description": "$1 is the return value of eth_chainId from an RPC endpoint"
   },
-  "enhancedTokenDetection": {
-    "message": "Erweiterte Token-Erkennung"
-  },
   "enhancedTokenDetectionAlertMessage": {
     "message": "Erweiterte Token-Erkennung ist derzeit über $1 verfügbar. $2"
-  },
-  "enhancedTokenDetectionDescription": {
-    "message": "Die Token-API von ConsenSys aggregiert eine Liste von Token aus verschiedenen Tokenlisten von Drittanbietern. Wenn diese Option aktiviert ist, werden die Token automatisch erkannt und es kann im Ethereum-Mainnet sowie in Binance, Polygon und Avalanche danach gesucht werden. Ist sie deaktiviert, können die automatische Token-Erkennung und -Suche nur im Ethereum-Mainnet verwendet werden."
   },
   "ensIllegalCharacter": {
     "message": "Unzulässiges Zeichen für ENS."

--- a/app/_locales/el/messages.json
+++ b/app/_locales/el/messages.json
@@ -1264,14 +1264,8 @@
     "message": "Το τελικό σημείο επέστρεψε ένα διαφορετικό αναγνωριστικό αλυσίδας: $1",
     "description": "$1 is the return value of eth_chainId from an RPC endpoint"
   },
-  "enhancedTokenDetection": {
-    "message": "Βελτιωμένος εντοπισμός για token"
-  },
   "enhancedTokenDetectionAlertMessage": {
     "message": "Ο βελτιωμένος εντοπισμός για token είναι επί του παρόντος διαθέσιμος στο $1. $2"
-  },
-  "enhancedTokenDetectionDescription": {
-    "message": "Το API token της ConsenSys συγκεντρώνει μια λίστα με token από διάφορες λίστες με token τρίτων. Όταν είναι ενεργοποιημένο, τα token θα εντοπίζονται αυτόματα και θα μπορούν να αναζητηθούν στο κύριο δίκτυο του Ethereum, στο Binance, στο Polygon και στο Avalanche. Όταν είναι απενεργοποιημένο, ο αυτόματος εντοπισμός και η αναζήτηση μπορεί να γίνει μόνο στο κύριο δίκτυο του Ethereum."
   },
   "ensIllegalCharacter": {
     "message": "Μη έγκυρος χαρακτήρας για το ENS."

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -1277,14 +1277,8 @@
     "message": "The RPC URL you have entered returned a different chain ID ($1). Please update the Chain ID to match the RPC URL of the network you are trying to add.",
     "description": "$1 is the return value of eth_chainId from an RPC endpoint"
   },
-  "enhancedTokenDetection": {
-    "message": "Enhanced token detection"
-  },
   "enhancedTokenDetectionAlertMessage": {
     "message": "Enhanced token detection is currently available on $1. $2"
-  },
-  "enhancedTokenDetectionDescription": {
-    "message": "ConsenSys' token API aggregates a list of tokens from various third party token lists. When turned on, tokens will be automatically detected, and searchable, on Ethereum mainnet, Binance, Polygon and Avalanche. When turned off, automatic detection and search can only be done on Ethereum mainnet."
   },
   "ensIllegalCharacter": {
     "message": "Illegal character for ENS."

--- a/app/_locales/es/messages.json
+++ b/app/_locales/es/messages.json
@@ -1264,14 +1264,8 @@
     "message": "El punto de conexión devolvió un id. de cadena diferente: $1",
     "description": "$1 is the return value of eth_chainId from an RPC endpoint"
   },
-  "enhancedTokenDetection": {
-    "message": "Detección mejorada de tokens"
-  },
   "enhancedTokenDetectionAlertMessage": {
     "message": "Actualmente, la detección mejorada de token se encuentra disponible en $1. $2"
-  },
-  "enhancedTokenDetectionDescription": {
-    "message": "La API de tokens de ConsenSys agrega una lista de tokens de varias listas de tokens de terceros. Cuando está activado, los tokens se detectarán automáticamente y se podrán buscar en la red principal de Ethereum, Binance, Polygon y Avalanche. Cuando está desactivada, la detección y la búsqueda automáticas solo se pueden realizar en la red principal de Ethereum."
   },
   "ensIllegalCharacter": {
     "message": "Caracter ilegal para ENS."

--- a/app/_locales/fr/messages.json
+++ b/app/_locales/fr/messages.json
@@ -1264,14 +1264,8 @@
     "message": "Le point terminal a renvoyé un ID de chaîne différent : $1",
     "description": "$1 is the return value of eth_chainId from an RPC endpoint"
   },
-  "enhancedTokenDetection": {
-    "message": "Détection améliorée des jetons"
-  },
   "enhancedTokenDetectionAlertMessage": {
     "message": "La détection améliorée des jetons est actuellement disponible sur $1. $2"
-  },
-  "enhancedTokenDetectionDescription": {
-    "message": "L’API de jetons de ConsenSys agrège une liste de jetons provenant de diverses listes de jetons tierces. Lorsqu’elle est activée, les jetons sont automatiquement détectés et peuvent être recherchés sur le réseau principal Ethereum, Binance, Polygon et Avalanche. Lorsqu’elle est désactivée, la détection automatique et la recherche ne peuvent être effectuées que sur le réseau principal Ethereum."
   },
   "ensIllegalCharacter": {
     "message": "Caractère invalide pour l’ENS."

--- a/app/_locales/hi/messages.json
+++ b/app/_locales/hi/messages.json
@@ -1264,14 +1264,8 @@
     "message": "समापन बिंदु ने अलग चेन ID लौटाई है: $1",
     "description": "$1 is the return value of eth_chainId from an RPC endpoint"
   },
-  "enhancedTokenDetection": {
-    "message": "उन्नत टोकन डिटेक्शन"
-  },
   "enhancedTokenDetectionAlertMessage": {
     "message": "उन्नत टोकन डिटेक्शन वर्तमान में $1 पर उपलब्ध है। $2"
-  },
-  "enhancedTokenDetectionDescription": {
-    "message": "ConsenSys का टोकन एपीआई विभिन्न तृतीय पक्ष टोकन सूचियों से टोकन की एक सूची एकत्र करता है। चालू होने पर, एथेरियम मेननेट, बिनेंस, पॉलीगॉन और एवलांच पर टोकन का स्वचालित रूप से पता लगाया जाएगा और खोजा जा सकेगा। बंद होने पर, स्वचालित पहचान और खोज केवल एथेरियम मेननेट पर ही की जा सकती है।"
   },
   "ensIllegalCharacter": {
     "message": "ENS के लिए गैर-कानूनी कैरेक्टर।"

--- a/app/_locales/id/messages.json
+++ b/app/_locales/id/messages.json
@@ -1264,14 +1264,8 @@
     "message": "Titik akhir memberikan hasil ID rantai yang berbeda: $1",
     "description": "$1 is the return value of eth_chainId from an RPC endpoint"
   },
-  "enhancedTokenDetection": {
-    "message": "Deteksi token yang ditingkatkan"
-  },
   "enhancedTokenDetectionAlertMessage": {
     "message": "Saat ini deteksi token yang ditingkatkan tersedia di $1. $2"
-  },
-  "enhancedTokenDetectionDescription": {
-    "message": "API token ConsenSys mengumpulkan daftar token dari berbagai daftar token pihak ketiga. Saat diaktifkan, token akan secara otomatis terdeteksi, dan dapat dicari, di mainnet Ethereum, Binance, Polygon, dan Avalanche. Saat dinonaktifkan, deteksi dan pencarian otomatis hanya dapat dilakukan di mainnet Ethereum."
   },
   "ensIllegalCharacter": {
     "message": "Karakter tidak sah untuk ENS."

--- a/app/_locales/ja/messages.json
+++ b/app/_locales/ja/messages.json
@@ -1264,14 +1264,8 @@
     "message": "エンドポイントが別のチェーン ID を返してきました。$1",
     "description": "$1 is the return value of eth_chainId from an RPC endpoint"
   },
-  "enhancedTokenDetection": {
-    "message": "改善されたトークン検出"
-  },
   "enhancedTokenDetectionAlertMessage": {
     "message": "改善されたトークン検出は現在 $1 で利用可能です。$2"
-  },
-  "enhancedTokenDetectionDescription": {
-    "message": "ConsenSys のトークン API は、さまざまなサードパーティトークンリストからトークンを集約し、リスト化します。有効にすると、トークンが自動的に検出され、Ethereum メインネット、Binance、Polygon、Avalanche で検索可能になります。無効にすると、自動検出と検索は Ethereum メインネットでのみ可能になります。"
   },
   "ensIllegalCharacter": {
     "message": "ENSにサポートされていない文字が使用されています。"

--- a/app/_locales/ko/messages.json
+++ b/app/_locales/ko/messages.json
@@ -1264,14 +1264,8 @@
     "message": "엔드포인트에서 다른 체인 ID를 반환했습니다. $1",
     "description": "$1 is the return value of eth_chainId from an RPC endpoint"
   },
-  "enhancedTokenDetection": {
-    "message": "향상된 토큰 감지"
-  },
   "enhancedTokenDetectionAlertMessage": {
     "message": "$1. $2에서 향상된 토큰 감지를 사용할 수 있습니다."
-  },
-  "enhancedTokenDetectionDescription": {
-    "message": "ConsenSys 토큰 API는 다양한 타사 토큰 목록을 활용해 토큰 목록을 집계합니다. 이 기능이 켜져 있으면 이더리움 메인넷, Binance, 폴리곤 및 아발란체에서 토큰이 자동으로 감지되며 검색이 가능합니다. 이 기능을 끄면 이더리움 메인넷에서만 자동 탐지 및 검색이 가능합니다."
   },
   "ensIllegalCharacter": {
     "message": "ENS에 맞지 않는 문자입니다."

--- a/app/_locales/pt/messages.json
+++ b/app/_locales/pt/messages.json
@@ -1264,14 +1264,8 @@
     "message": "O endpoint retornou um ID diferente da chain: $1",
     "description": "$1 is the return value of eth_chainId from an RPC endpoint"
   },
-  "enhancedTokenDetection": {
-    "message": "Detecção aprimorada de tokens"
-  },
   "enhancedTokenDetectionAlertMessage": {
     "message": "A detecção aprimorada de tokens está disponível no momento em $1. $2"
-  },
-  "enhancedTokenDetectionDescription": {
-    "message": "A API de tokens da ConsenSys agrega uma lista de tokens a partir de diversas listas de terceiros. Quando ativada, os tokens serão automaticamente detectados (e pesquisáveis) na mainnet do Ethereum, Binance, Polygon e Avalanche. Quando desativada, a detecção automática e pesquisa só poderão ser feitas na mainnet do Ethereum."
   },
   "ensIllegalCharacter": {
     "message": "Caractere inválido para ENS."

--- a/app/_locales/ru/messages.json
+++ b/app/_locales/ru/messages.json
@@ -1264,14 +1264,8 @@
     "message": "Конечная точка вернула другой идентификатор цепочки: $1",
     "description": "$1 is the return value of eth_chainId from an RPC endpoint"
   },
-  "enhancedTokenDetection": {
-    "message": "Улучшенное обнаружение токена"
-  },
   "enhancedTokenDetectionAlertMessage": {
     "message": "Улучшенное обнаружение токенов в настоящее время доступно на $1. $2"
-  },
-  "enhancedTokenDetectionDescription": {
-    "message": "API токенов ConsenSys объединяет список токенов из различных сторонних списков токенов. При включении токены будут автоматически обнаруживаться и станут доступны для поиска в основной сети Ethereum, Binance, Polygon и Avalanche. При выключении автоматическое обнаружение и поиск могут выполняться только в основной сети Ethereum."
   },
   "ensIllegalCharacter": {
     "message": "Недопустимый символ для ENS."

--- a/app/_locales/tl/messages.json
+++ b/app/_locales/tl/messages.json
@@ -1264,14 +1264,8 @@
     "message": "Nagbalik ang endpoint ng ibang chain ID: $1",
     "description": "$1 is the return value of eth_chainId from an RPC endpoint"
   },
-  "enhancedTokenDetection": {
-    "message": "Pinahusay na pagtukoy ng token"
-  },
   "enhancedTokenDetectionAlertMessage": {
     "message": "Ang pinahusay na pagtuklas ng token ay kasalukuyang magagamit sa $1. $2"
-  },
-  "enhancedTokenDetectionDescription": {
-    "message": "Pinagsasama-sama ng ConsenSys' token API ang isang listahan ng mga token mula sa iba't ibang listahan ng token ng third-party. Kapag naka-on, ang mga token ay kusang matutukoy at mahahanap sa Ethereum mainnet, Binance, Polygon, at Avalanche. Kapag naka-off, ang kusang pagtuklas at paghahanap ay maaari lamang gawin sa Ethereum mainnet."
   },
   "ensIllegalCharacter": {
     "message": "Mga ilegal na character para sa ENS."

--- a/app/_locales/tr/messages.json
+++ b/app/_locales/tr/messages.json
@@ -1264,14 +1264,8 @@
     "message": "Bitiş noktası farklı bir zincir kimliğine ulaştı: $1",
     "description": "$1 is the return value of eth_chainId from an RPC endpoint"
   },
-  "enhancedTokenDetection": {
-    "message": "Gelişmiş token algılama"
-  },
   "enhancedTokenDetectionAlertMessage": {
     "message": "Gelişmiş token algılama şu anda $1 üzerinden kullanılabilir. $2"
-  },
-  "enhancedTokenDetectionDescription": {
-    "message": "ConsenSys token API, çeşitli üçüncü taraf token listelerinden token listesi toplar. Açıldığında, tokenler Ethereum ana ağı, Binance, Polygon ve Avalanche üzerinde otomatik olarak algılanır ve aratılabilir. Kapatıldığında otomatik algılama ve arama sadece Ethereum ana ağı üzerinde yapılabilir."
   },
   "ensIllegalCharacter": {
     "message": "ENS için uygun olmayan karakter."

--- a/app/_locales/vi/messages.json
+++ b/app/_locales/vi/messages.json
@@ -1264,14 +1264,8 @@
     "message": "Điểm cuối đã trả về một mã chuỗi khác: $1",
     "description": "$1 is the return value of eth_chainId from an RPC endpoint"
   },
-  "enhancedTokenDetection": {
-    "message": "Phát hiện token nâng cao"
-  },
   "enhancedTokenDetectionAlertMessage": {
     "message": "Tính năng phát hiện token nâng cao hiện có sẵn trên $1. $2"
-  },
-  "enhancedTokenDetectionDescription": {
-    "message": "API token của ConsenSys sẽ tổng hợp danh sách token từ các danh sách token khác nhau của bên thứ ba. Khi bật, các token sẽ tự động được phát hiện và có thể tìm kiếm được trên mạng chính thức của Ethereum, Binance, Polygon và Avalanche. Khi tắt, tính năng tìm kiếm và tự động phát hiện chỉ có thể được thực hiện trên mạng chính thức của Ethereum."
   },
   "ensIllegalCharacter": {
     "message": "Ký tự không hợp lệ đối với ENS."

--- a/app/_locales/zh_CN/messages.json
+++ b/app/_locales/zh_CN/messages.json
@@ -1264,14 +1264,8 @@
     "message": "RPC 端点使用链不同的链 ID: $1",
     "description": "$1 is the return value of eth_chainId from an RPC endpoint"
   },
-  "enhancedTokenDetection": {
-    "message": "增强型代币检测"
-  },
   "enhancedTokenDetectionAlertMessage": {
     "message": "$1. $2目前提供增强型代币检测"
-  },
-  "enhancedTokenDetectionDescription": {
-    "message": "ConsenSys的代币API汇集了来自各种第三方代币列表的一系列代币。启用后，代币即可在以太坊主网、Binance、Polygon和Avalanche上被自动检测，并可搜索。关闭后，自动检测和搜索仅可在以太坊主网上进行。"
   },
   "ensIllegalCharacter": {
     "message": "ENS 的非法字符。"

--- a/ui/helpers/constants/settings.js
+++ b/ui/helpers/constants/settings.js
@@ -178,13 +178,6 @@ export const SETTINGS_CONSTANTS = [
   },
   {
     tabMessage: (t) => t('securityAndPrivacy'),
-    sectionMessage: (t) => t('enhancedTokenDetection'),
-    descriptionMessage: (t) => t('enhancedTokenDetectionDescription'),
-    route: `${SECURITY_ROUTE}#token-description`,
-    icon: 'fas fa-sliders-h',
-  },
-  {
-    tabMessage: (t) => t('securityAndPrivacy'),
     sectionMessage: (t) => t('chooseYourNetwork'),
     descriptionMessage: (t) => t('chooseYourNetworkDescription'),
     route: `${SECURITY_ROUTE}#-chose-your-network`,
@@ -334,13 +327,6 @@ export const SETTINGS_CONSTANTS = [
     descriptionMessage: (t) => t('betaTerms'),
     route: `${ABOUT_US_ROUTE}#beta-terms`,
     icon: 'fa fa-info-circle',
-  },
-  {
-    tabMessage: (t) => t('advanced'),
-    sectionMessage: (t) => t('enhancedTokenDetection'),
-    descriptionMessage: (t) => t('enhancedTokenDetectionDescription'),
-    route: `${ADVANCED_ROUTE}#token-description`,
-    icon: 'fas fa-sliders-h',
   },
   {
     tabMessage: (t) => t('experimental'),

--- a/ui/helpers/utils/settings-search.test.js
+++ b/ui/helpers/utils/settings-search.test.js
@@ -103,10 +103,10 @@ const t = (key) => {
       return 'Localhost 8545';
     case 'experimental':
       return 'Experimental';
-    case 'enhancedTokenDetection':
-      return 'Enhanced token detection';
-    case 'enhancedTokenDetectionDescription':
-      return "ConsenSys' token API aggregates a list of tokens from various third party token lists. When turned on, tokens will be automatically detected, and searchable, on Ethereum mainnet, Binance, Polygon and Avalanche. When turned off, automatic detection and search can only be done on Ethereum mainnet.";
+    case 'autoDetectTokens':
+      return 'Autodetect tokens';
+    case 'autoDetectTokensDescription':
+      return 'We use third-party APIs to detect and display new tokens sent to your wallet. Turn off if you don’t want the app to pull data from those services.';
     case 'enableOpenSeaAPI':
       return 'Enable OpenSea API';
     case 'enableOpenSeaAPIDescription':
@@ -159,7 +159,7 @@ describe('Settings Search Utils', () => {
     });
 
     it('should get good advanced section number', () => {
-      expect(getNumberOfSettingsInSection(t, t('advanced'))).toStrictEqual(14);
+      expect(getNumberOfSettingsInSection(t, t('advanced'))).toStrictEqual(13);
     });
 
     it('should get good contact section number', () => {
@@ -169,7 +169,7 @@ describe('Settings Search Utils', () => {
     it('should get good security & privacy section number', () => {
       expect(
         getNumberOfSettingsInSection(t, t('securityAndPrivacy')),
-      ).toStrictEqual(10);
+      ).toStrictEqual(9);
     });
 
     it('should get good alerts section number', () => {


### PR DESCRIPTION
Fixes: https://github.com/MetaMask/metamask-extension/issues/17265

## Explanation
This issue was being caused by an old, incorrect entry under the advanced settings tab for the token detection feature, as well as a duplicate entry for the auto detect tokens feature. This issue is resolved by removing both of those entries, allowing the correct one to work.

### Before
https://user-images.githubusercontent.com/54408225/212970625-0a442d0e-074b-48c2-b201-10d864c58ad3.mp4

### After
https://user-images.githubusercontent.com/8732757/213087513-ef03fbec-4ed6-42f6-8cca-26288b42b030.mov

## Manual Testing Steps
1. Go to settings
2. Type "Token" in to the settings search and ensure that only the correct Autodetect Tokens entry is shown, and is marked under "Security & Privacy"

## Pre-merge author checklist

- [X] I've clearly explained:
  - [X] What problem this PR is solving
  - [X] How this problem was solved
  - [X] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
