### PR TITLE
fix issue with network state shape expected in NftDetectionController

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -395,9 +395,17 @@ export default class MetamaskController extends EventEmitter {
           this.preferencesController.store.subscribe.bind(
             this.preferencesController.store,
           ),
-        onNetworkStateChange: this.networkController.store.subscribe.bind(
-          this.networkController.store,
-        ),
+        onNetworkStateChange: (cb) =>
+          this.networkController.store.subscribe((networkState) => {
+            const modifiedNetworkState = {
+              ...networkState,
+              providerConfig: {
+                ...networkState.provider,
+                chainId: hexToDecimal(networkState.provider.chainId),
+              },
+            };
+            return cb(modifiedNetworkState);
+          }),
         getOpenSeaApiKey: () => this.nftController.openSeaApiKey,
         getBalancesInSingleCall:
           this.assetsContractController.getBalancesInSingleCall.bind(


### PR DESCRIPTION
## Explanation

In https://github.com/MetaMask/metamask-extension/pull/16772 we updated the AssetController and as part of that updated the shape we send to various controllers pulled from the Core repo for network change events. Mainly our network controller has state under the provider key, whereas in the Network Controller in core repo the key is providerConfig. In that PR we correctly fixed *most* cases of the network shape, but we missed one behind the NFT feature flag. 

This was causing a benign error in the background for me that was giving me frustrations because I was trying to work with the errors.test.js e2e test and instead of getting the error I wanted i was getting the one from this failure. It may or may not have impacted most people who had NFT flag enabled. 

## Manual Testing Steps

1.  enable NFT_V1 flag on develop
2. `yarn start`
3. load the background console and see an error about accessing type of undefined.
4. pull this branch and repeat and see its gone.

Massive props to @mcmire and @Gudahtt for holding my hand while I realized the reason no one else had the issue is because I left a flag enabled :P 

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
