### PR TITLE
Add alt text for NFT images

### DIFF
--- a/ui/components/app/collectible-details/collectible-details.js
+++ b/ui/components/app/collectible-details/collectible-details.js
@@ -82,6 +82,7 @@ export default function CollectibleDetails({ collectible }) {
     imageOriginal ?? image,
     ipfsGateway,
   );
+  const collectibleImageAlt = description ?? `${name} Token ID: ${tokenId}`;
   const isDataURI = collectibleImageURL.startsWith('data:');
 
   const onRemove = () => {
@@ -178,7 +179,7 @@ export default function CollectibleDetails({ collectible }) {
               <img
                 className="collectible-details__image"
                 src={collectibleImageURL}
-                alt={description}
+                alt={collectibleImageAlt}
               />
             ) : (
               <CollectibleDefaultImage name={name} tokenId={tokenId} />

--- a/ui/components/app/collectible-details/collectible-details.js
+++ b/ui/components/app/collectible-details/collectible-details.js
@@ -20,6 +20,7 @@ import {
 } from '../../../helpers/constants/design-system';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import { getAssetImageURL, shortenAddress } from '../../../helpers/utils/util';
+import { getCollectibleImageAlt } from '../../../helpers/utils/collectibles';
 import {
   getCurrentChainId,
   getIpfsGateway,
@@ -82,7 +83,7 @@ export default function CollectibleDetails({ collectible }) {
     imageOriginal ?? image,
     ipfsGateway,
   );
-  const collectibleImageAlt = description ?? `${name} Token ID: ${tokenId}`;
+  const collectibleImageAlt = getCollectibleImageAlt(collectible);
   const isDataURI = collectibleImageURL.startsWith('data:');
 
   const onRemove = () => {

--- a/ui/components/app/collectible-details/collectible-details.js
+++ b/ui/components/app/collectible-details/collectible-details.js
@@ -178,6 +178,7 @@ export default function CollectibleDetails({ collectible }) {
               <img
                 className="collectible-details__image"
                 src={collectibleImageURL}
+                alt={description}
               />
             ) : (
               <CollectibleDefaultImage name={name} tokenId={tokenId} />

--- a/ui/components/app/collectibles-items/collectibles-items.js
+++ b/ui/components/app/collectibles-items/collectibles-items.js
@@ -182,6 +182,8 @@ export default function CollectiblesItems({
                 description,
               } = collectible;
               const collectibleImage = getAssetImageURL(image, ipfsGateway);
+              const collectibleImageAlt =
+                description ?? `${name} Token ID: ${tokenId}`;
               const handleImageClick = () =>
                 history.push(`${ASSET_ROUTE}/${address}/${tokenId}`);
 
@@ -207,7 +209,7 @@ export default function CollectiblesItems({
                         <img
                           className="collectibles-items__item-image"
                           src={collectibleImage}
-                          alt={description}
+                          alt={collectibleImageAlt}
                         />
                       </button>
                     ) : (

--- a/ui/components/app/collectibles-items/collectibles-items.js
+++ b/ui/components/app/collectibles-items/collectibles-items.js
@@ -25,6 +25,7 @@ import {
 } from '../../../selectors';
 import { ASSET_ROUTE } from '../../../helpers/constants/routes';
 import { getAssetImageURL } from '../../../helpers/utils/util';
+import { getCollectibleImageAlt } from '../../../helpers/utils/collectibles';
 import { updateCollectibleDropDownState } from '../../../store/actions';
 import { usePrevious } from '../../../hooks/usePrevious';
 import { getCollectiblesDropdownState } from '../../../ducks/metamask/metamask';
@@ -173,17 +174,10 @@ export default function CollectiblesItems({
         {isExpanded ? (
           <Box display={DISPLAY.FLEX} flexWrap={FLEX_WRAP.WRAP} gap={4}>
             {collectibles.map((collectible, i) => {
-              const {
-                image,
-                address,
-                tokenId,
-                backgroundColor,
-                name,
-                description,
-              } = collectible;
+              const { image, address, tokenId, backgroundColor, name } =
+                collectible;
               const collectibleImage = getAssetImageURL(image, ipfsGateway);
-              const collectibleImageAlt =
-                description ?? `${name} Token ID: ${tokenId}`;
+              const collectibleImageAlt = getCollectibleImageAlt(collectible);
               const handleImageClick = () =>
                 history.push(`${ASSET_ROUTE}/${address}/${tokenId}`);
 

--- a/ui/components/app/collectibles-items/collectibles-items.js
+++ b/ui/components/app/collectibles-items/collectibles-items.js
@@ -90,6 +90,7 @@ export default function CollectiblesItems({
     if (collectionImage) {
       return (
         <img
+          alt={collectionName}
           src={collectionImage}
           className="collectibles-items__collection-image"
         />
@@ -172,8 +173,14 @@ export default function CollectiblesItems({
         {isExpanded ? (
           <Box display={DISPLAY.FLEX} flexWrap={FLEX_WRAP.WRAP} gap={4}>
             {collectibles.map((collectible, i) => {
-              const { image, address, tokenId, backgroundColor, name } =
-                collectible;
+              const {
+                image,
+                address,
+                tokenId,
+                backgroundColor,
+                name,
+                description,
+              } = collectible;
               const collectibleImage = getAssetImageURL(image, ipfsGateway);
               const handleImageClick = () =>
                 history.push(`${ASSET_ROUTE}/${address}/${tokenId}`);
@@ -200,6 +207,7 @@ export default function CollectiblesItems({
                         <img
                           className="collectibles-items__item-image"
                           src={collectibleImage}
+                          alt={description}
                         />
                       </button>
                     ) : (

--- a/ui/helpers/utils/collectibles.js
+++ b/ui/helpers/utils/collectibles.js
@@ -1,0 +1,3 @@
+export const getCollectibleImageAlt = ({ name, tokenId, description }) => {
+  return description ?? `${name} ${tokenId}`;
+};

--- a/ui/helpers/utils/collectibles.test.js
+++ b/ui/helpers/utils/collectibles.test.js
@@ -1,0 +1,31 @@
+import { getCollectibleImageAlt } from './collectibles';
+
+describe('Collectibles Utils', () => {
+  describe('getCollectibleImageAlt', () => {
+    it('returns the description attribute when it is available', () => {
+      expect(
+        getCollectibleImageAlt({
+          name: 'Cool NFT',
+          tokenId: '555',
+          description: 'This is a really cool NFT',
+        }),
+      ).toBe('This is a really cool NFT');
+    });
+
+    it('returns the formatted name and tokenId attributes when a description is not present', () => {
+      expect(
+        getCollectibleImageAlt({
+          name: 'Cool NFT',
+          tokenId: '555',
+          description: null,
+        }),
+      ).toBe('Cool NFT 555');
+      expect(
+        getCollectibleImageAlt({
+          name: 'Cool NFT',
+          tokenId: '555',
+        }),
+      ).toBe('Cool NFT 555');
+    });
+  });
+});


### PR DESCRIPTION
Fixes: https://github.com/MetaMask/metamask-extension/issues/17280

## Explanation
Uses the `description` property of the collectible for the image alt text on the NFT's tab and NFT details page.

## Manual Testing Steps
1. Create an NFT build
2. Import some NFTs with images
3. Ensure that the alt text for the NFT image on the detail and list pages show with the respective NFT description (when available)

## Pre-merge author checklist

- [X] I've clearly explained:
  - [X] What problem this PR is solving
  - [X] How this problem was solved
  - [X] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
