### PR TITLE
updated initial state of new imported nfts to expanded

### DIFF
--- a/ui/pages/add-collectible/add-collectible.js
+++ b/ui/pages/add-collectible/add-collectible.js
@@ -19,10 +19,19 @@ import {
   getTokenStandardAndDetails,
   ignoreTokens,
   setNewCollectibleAddedMessage,
+  updateCollectibleDropDownState,
 } from '../../store/actions';
 import FormField from '../../components/ui/form-field';
-import { getIsMainnet, getUseNftDetection } from '../../selectors';
-import { getCollectiblesDetectionNoticeDismissed } from '../../ducks/metamask/metamask';
+import {
+  getCurrentChainId,
+  getIsMainnet,
+  getSelectedAddress,
+  getUseNftDetection,
+} from '../../selectors';
+import {
+  getCollectiblesDetectionNoticeDismissed,
+  getCollectiblesDropdownState,
+} from '../../ducks/metamask/metamask';
 import CollectiblesDetectionNotice from '../../components/app/collectibles-detection-notice';
 import { MetaMetricsContext } from '../../contexts/metametrics';
 import { AssetType } from '../../../shared/constants/transaction';
@@ -37,12 +46,15 @@ export default function AddCollectible() {
   const collectibleDetectionNoticeDismissed = useSelector(
     getCollectiblesDetectionNoticeDismissed,
   );
+  const collectiblesDropdownState = useSelector(getCollectiblesDropdownState);
+  const selectedAddress = useSelector(getSelectedAddress);
+  const chainId = useSelector(getCurrentChainId);
   const addressEnteredOnImportTokensPage =
     history?.location?.state?.addressEnteredOnImportTokensPage;
   const contractAddressToConvertFromTokenToCollectible =
     history?.location?.state?.tokenAddress;
 
-  const [address, setAddress] = useState(
+  const [collectibleAddress, setCollectibleAddress] = useState(
     addressEnteredOnImportTokensPage ??
       contractAddressToConvertFromTokenToCollectible ??
       '',
@@ -54,7 +66,19 @@ export default function AddCollectible() {
 
   const handleAddCollectible = async () => {
     try {
-      await dispatch(addNftVerifyOwnership(address, tokenId));
+      await dispatch(addNftVerifyOwnership(collectibleAddress, tokenId));
+      const newCollectibleDropdownState = {
+        ...collectiblesDropdownState,
+        [selectedAddress]: {
+          ...collectiblesDropdownState?.[selectedAddress],
+          [chainId]: {
+            ...collectiblesDropdownState?.[selectedAddress]?.[chainId],
+            [collectibleAddress]: true,
+          },
+        },
+      };
+
+      dispatch(updateCollectibleDropDownState(newCollectibleDropdownState));
     } catch (error) {
       const { message } = error;
       dispatch(setNewCollectibleAddedMessage(message));
@@ -72,7 +96,7 @@ export default function AddCollectible() {
     dispatch(setNewCollectibleAddedMessage('success'));
 
     const tokenDetails = await getTokenStandardAndDetails(
-      address,
+      collectibleAddress,
       null,
       tokenId.toString(),
     );
@@ -81,7 +105,7 @@ export default function AddCollectible() {
       event: EVENT_NAMES.TOKEN_ADDED,
       category: 'Wallet',
       sensitiveProperties: {
-        token_contract_address: address,
+        token_contract_address: collectibleAddress,
         token_symbol: tokenDetails?.symbol,
         tokenId: tokenId.toString(),
         asset_type: AssetType.NFT,
@@ -95,11 +119,13 @@ export default function AddCollectible() {
 
   const validateAndSetAddress = (val) => {
     setDisabled(!isValidHexAddress(val) || !tokenId);
-    setAddress(val);
+    setCollectibleAddress(val);
   };
 
   const validateAndSetTokenId = (val) => {
-    setDisabled(!isValidHexAddress(address) || !val || isNaN(Number(val)));
+    setDisabled(
+      !isValidHexAddress(collectibleAddress) || !val || isNaN(Number(val)),
+    );
     setTokenId(val);
   };
 
@@ -154,7 +180,7 @@ export default function AddCollectible() {
               dataTestId="address"
               titleText={t('address')}
               placeholder="0x..."
-              value={address}
+              value={collectibleAddress}
               onChange={(val) => {
                 validateAndSetAddress(val);
                 setCollectibleAddFailed(false);


### PR DESCRIPTION
### Description
Previously, the Newly imported NFT group begins as closed. This PR is to update the NFT tiles to expanded state

Fixes #17160 

### After

<img width="699" alt="Screenshot 2023-01-19 at 3 05 11 PM" src="https://user-images.githubusercontent.com/39872794/213407113-e77038e8-746d-4dfd-badf-51336de7f340.png">

## Pre-merge author checklist

- [X] I've clearly explained:
  - [X] What problem this PR is solving
  - [X] How this problem was solved
  - [X] How reviewers can test my changes

## Pre-merge reviewer checklist

- [X] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [X] PR is linked to the appropriate GitHub issue
- [X] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

