### PR TITLE
Added title for each nft in send asset dropdown

### DIFF
--- a/ui/pages/send/send-content/send-asset-row/send-asset-row.component.js
+++ b/ui/pages/send/send-content/send-asset-row/send-asset-row.component.js
@@ -46,6 +46,12 @@ export default class SendAssetRow extends Component {
         }),
       }),
     ),
+    collections: PropTypes.arrayOf(
+      PropTypes.shape({
+        address: PropTypes.string.isRequired,
+        name: PropTypes.string,
+      }),
+    ),
   };
 
   static contextTypes = {
@@ -261,7 +267,9 @@ export default class SendAssetRow extends Component {
   renderCollectible(collectible, insideDropdown = false) {
     const { address, name, image, tokenId } = collectible;
     const { t } = this.context;
-
+    const collectibleCollection = this.props.collections.find(
+      (collection) => collection.address === address,
+    );
     return (
       <div
         key={address}
@@ -272,7 +280,9 @@ export default class SendAssetRow extends Component {
           <Identicon address={address} diameter={36} image={image} />
         </div>
         <div className="send-v2__asset-dropdown__asset-data">
-          <div className="send-v2__asset-dropdown__symbol">{name}</div>
+          <div className="send-v2__asset-dropdown__symbol">
+            {collectibleCollection.name || name}
+          </div>
           <div className="send-v2__asset-dropdown__name">
             <span className="send-v2__asset-dropdown__name__label">
               {`${t('tokenId')}:`}

--- a/ui/pages/send/send-content/send-asset-row/send-asset-row.container.js
+++ b/ui/pages/send/send-content/send-asset-row/send-asset-row.container.js
@@ -1,5 +1,6 @@
 import { connect } from 'react-redux';
 import {
+  getCollectibleContracts,
   getCollectibles,
   getNativeCurrency,
 } from '../../../../ducks/metamask/metamask';
@@ -15,6 +16,7 @@ function mapStateToProps(state) {
     tokens: state.metamask.tokens,
     selectedAddress: state.metamask.selectedAddress,
     collectibles: getCollectibles(state),
+    collections: getCollectibleContracts(state),
     sendAsset: getSendAsset(state),
     accounts: getMetaMaskAccounts(state),
     nativeCurrency: getNativeCurrency(state),


### PR DESCRIPTION
Send Asset Dropdown doesn't always provide a title for each NFT. This PR is to add titles for each NFT

Fixes #17158 

### Before

<img width="621" alt="Screenshot 2023-01-19 at 4 25 54 PM" src="https://user-images.githubusercontent.com/39872794/213424547-77cc973a-1d8c-4684-8706-135b09131079.png">

### After

<img width="402" alt="Screenshot 2023-01-19 at 4 24 44 PM" src="https://user-images.githubusercontent.com/39872794/213424300-7ae3aa37-3d85-4032-adc0-cfceeea0fa16.png">

## Pre-merge author checklist

- [X] I've clearly explained:
  - [X] What problem this PR is solving
  - [X] How this problem was solved
  - [X] How reviewers can test my changes

## Pre-merge reviewer checklist

- [X] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [X] PR is linked to the appropriate GitHub issue
- [X] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

