### PR TITLE
Allow user to scroll network form in onboarding modal

### DIFF
--- a/ui/pages/onboarding-flow/add-network-modal/index.js
+++ b/ui/pages/onboarding-flow/add-network-modal/index.js
@@ -34,6 +34,7 @@ export default function AddNetworkModal() {
       </Box>
       <NetworksForm
         addNewNetwork
+        restrictHeight
         networksToRender={[]}
         cancelCallback={closeCallback}
         submitCallback={closeCallback}

--- a/ui/pages/settings/networks-tab/index.scss
+++ b/ui/pages/settings/networks-tab/index.scss
@@ -234,6 +234,11 @@
     }
   }
 
+  &__restrict-height {
+    max-height: 578px;
+    overflow-y: auto;
+  }
+
   &__add-network-form-footer {
     display: flex;
     flex-flow: row;

--- a/ui/pages/settings/networks-tab/networks-form/networks-form.js
+++ b/ui/pages/settings/networks-tab/networks-form/networks-form.js
@@ -78,6 +78,7 @@ const isValidWhenAppended = (url) => {
 
 const NetworksForm = ({
   addNewNetwork,
+  restrictHeight,
   isCurrentRpcTarget,
   networksToRender,
   selectedNetwork,
@@ -588,6 +589,7 @@ const NetworksForm = ({
       className={classnames({
         'networks-tab__network-form': !addNewNetwork,
         'networks-tab__add-network-form': addNewNetwork,
+        'networks-tab__restrict-height': restrictHeight,
       })}
     >
       {addNewNetwork ? (
@@ -708,6 +710,7 @@ NetworksForm.propTypes = {
   selectedNetwork: PropTypes.object,
   cancelCallback: PropTypes.func,
   submitCallback: PropTypes.func,
+  restrictHeight: PropTypes.bool,
 };
 
 NetworksForm.defaultProps = {


### PR DESCRIPTION
Fixes a bug in v10.24.0 (but not in prod)

If a user is adding a custom network during the onboarding flow, and they get a warning message on the currency or rpc fields, the save button can be pushed out of view. This PR fixes that by adding a scroll in such cases.

Before:

https://user-images.githubusercontent.com/7499938/213450972-04621b9c-5fcb-40db-9f1e-96de35175114.mp4

After:


https://user-images.githubusercontent.com/7499938/213451013-244a5786-3cd4-4944-bdd9-8ab6ed35aff3.mp4

