### PR TITLE
Clarify effect of autodetect tokens toggle

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -432,7 +432,7 @@
     "message": "Autodetect tokens"
   },
   "autoDetectTokensDescription": {
-    "message": "We use third-party APIs to detect and display new tokens sent to your wallet. Turn off if you don’t want the app to pull data from those services. $1",
+    "message": "We use third-party APIs to detect and display new tokens sent to your wallet. Turn off if you don’t want the app to automatically pull data from those services. $1",
     "description": "$1 is a link to a support article"
   },
   "autoLockTimeLimit": {

--- a/ui/pages/settings/security-tab/__snapshots__/security-tab.test.js.snap
+++ b/ui/pages/settings/security-tab/__snapshots__/security-tab.test.js.snap
@@ -438,7 +438,7 @@ exports[`Security Tab should match snapshot 1`] = `
           >
             <span>
                
-              We use third-party APIs to detect and display new tokens sent to your wallet. Turn off if you don’t want the app to pull data from those services. 
+              We use third-party APIs to detect and display new tokens sent to your wallet. Turn off if you don’t want the app to automatically pull data from those services. 
               <a
                 href="https://consensys.net/privacy-policy/"
                 rel="noopener noreferrer"


### PR DESCRIPTION
This clarification is needed because we still ping the codefi tokens api when the user manually adds a token or refreshes the list (Note that the codefi tokens api does not track any user data at all, nor does it track/store IPs)