### PR TITLE
Fix transaction decoding data types `string` and `bool`

### DIFF
--- a/ui/components/app/transaction-decoding/transaction-decoding.component.js
+++ b/ui/components/app/transaction-decoding/transaction-decoding.component.js
@@ -129,6 +129,9 @@ export default function TransactionDecoding({ to = '', inputData: data = '' }) {
               </span>
             );
 
+          case 'bool':
+            return <span className="sol-item">{String(value.asBoolean)}</span>;
+
           case 'bytes':
             return (
               <span className="sol-item solidity-bytes">{value.asHex}</span>

--- a/ui/components/app/transaction-decoding/transaction-decoding.component.js
+++ b/ui/components/app/transaction-decoding/transaction-decoding.component.js
@@ -134,6 +134,11 @@ export default function TransactionDecoding({ to = '', inputData: data = '' }) {
               <span className="sol-item solidity-bytes">{value.asHex}</span>
             );
 
+          case 'string':
+            return (
+              <span className="sol-item solidity-string">{value.asString}</span>
+            );
+
           case 'array':
             return (
               <details>


### PR DESCRIPTION
## Explanation

Fixes #17294
Fixes #16950
Fixes #16951
Fixes #16952

A bug has caused `string` and `bool` transaction data types to display their value as `undefined`. This PR fixes this bug by explicitly handling the `string` and `bool` types. This also fixes the issue where `string` values were truncated, and `string` and `bool` values were showing in an object format.

----

<!--
Thanks for the pull request. Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues, Slack conversations, Zendesk issues, user stories, etc. reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

**Additional dev note:** no test file is currently written for the `transaction-decoding` component , so I think it's better to hold off on writing tests since we also plan to refactor related code soon. 


## Screenshots/Screencaps

<!-- If you're making a change to the UI, make sure to capture a screenshot or a short video showing off your work! -->

### Before

see related issue tickets

### After

<img width="515" alt="Screen Shot 2023-01-20 at 1 12 28 AM" src="https://user-images.githubusercontent.com/20778143/213527729-1d1d095a-ea6a-4298-b68c-3aa8ad6211a7.png">

<img width="502" alt="Screen Shot 2023-01-20 at 12 06 29 AM" src="https://user-images.githubusercontent.com/20778143/213527682-64bfc630-18f2-4ac3-9367-4407a983e86e.png">


## Manual Testing Steps

1. Set Goerli network
2. Go to the contract https://goerli.etherscan.io/address/0xcf21e74221443eda1d3313b7b46b4650761aeeda#writeContract
3. Click on Write Contract
4. Click Connect for connecting MM
5. Click checkString function
6. Fill the value with a string. I.e. "hello"
7. Click Write
8. Click on the DATA tab from MetaMask prompt -- see string value as undefined

to test `boolean` values, follow types 5-8 except use `checkBool` and enter the boolean value e.g.  "[true]" or "[false]"

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added . 
## Pre-merge reviewer checklist

- [x] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [x] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
