### PR TITLE
Add missing appName in the zh_TW language file

### DIFF
--- a/app/_locales/zh_TW/messages.json
+++ b/app/_locales/zh_TW/messages.json
@@ -115,6 +115,18 @@
   "amount": {
     "message": "數量"
   },
+  "appName": {
+    "message": "MetaMask",
+    "description": "The name of the application"
+  },
+  "appNameBeta": {
+    "message": "MetaMask Beta",
+    "description": "The name of the application (Beta)"
+  },
+  "appNameFlask": {
+    "message": "MetaMask Flask",
+    "description": "The name of the application (Flask)"
+  },
   "appDescription": {
     "message": "以太坊瀏覽器擴充插件",
     "description": "The description of the application"

--- a/app/_locales/zh_TW/messages.json
+++ b/app/_locales/zh_TW/messages.json
@@ -115,6 +115,10 @@
   "amount": {
     "message": "數量"
   },
+  "appDescription": {
+    "message": "以太坊瀏覽器擴充插件",
+    "description": "The description of the application"
+  },
   "appName": {
     "message": "MetaMask",
     "description": "The name of the application"
@@ -126,10 +130,6 @@
   "appNameFlask": {
     "message": "MetaMask Flask",
     "description": "The name of the application (Flask)"
-  },
-  "appDescription": {
-    "message": "以太坊瀏覽器擴充插件",
-    "description": "The description of the application"
   },
   "approve": {
     "message": "批准花費上限"


### PR DESCRIPTION
The "appName" translation key and message is required for all translation files because it is used by the extension store.

This was removed from the `zh_TW` file in https://github.com/MetaMask/metamask-extension/pull/11212

Although the reason for its removal was not documented in that PR, it is presumably because their is no translation, and so as the locale message in `zh_TW` will match the one in the `en` file, it is fine to remove it in `zh_TW` so that the fallback to `en` is used.

As a follow-up task, we should add code to our verify-locales script that fails builds if these keys and translations are not included