### PR TITLE
Fix audit failure - cookiejar to 2.1.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "ganache-core/lodash": "^4.17.21",
     "netmask": "^2.0.1",
     "pubnub/superagent-proxy": "^3.0.0",
+    "superagent/cookiejar": "^2.1.4",
     "json-schema": "^0.4.0",
     "simple-get": "^4.0.1",
     "web3-provider-engine/eth-json-rpc-filters": "^5.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12504,10 +12504,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cookiejar@npm:^2.1.0":
-  version: 2.1.3
-  resolution: "cookiejar@npm:2.1.3"
-  checksum: 88259983ebc52ceb23cdacfa48762b6a518a57872eff1c7ed01d214fff5cf492e2660d7d5c04700a28f1787a76811df39e8639f8e17670b3cf94ecd86e161f07
+"cookiejar@npm:^2.1.4":
+  version: 2.1.4
+  resolution: "cookiejar@npm:2.1.4"
+  checksum: c4442111963077dc0e5672359956d6556a195d31cbb35b528356ce5f184922b99ac48245ac05ed86cf993f7df157c56da10ab3efdadfed79778a0d9b1b092d5b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Explanation
Fixes: https://github.com/advisories/GHSA-h452-7996-h45h

We have one package that relies upon cookiejar which is superagent, so I add a resolution to bump us up to the patch version that fixes the vulnerability. 

## Manual Testing Steps
1. tests pass

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
