### PR TITLE
Ignore `storybook-build` lint errors

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -15,6 +15,7 @@ module.exports = {
     'development/ts-migration-dashboard/build/**',
     'dist/**/*',
     'node_modules/**/*',
+    'storybook-build/**/*',
     'jest-coverage/**/*',
     'coverage/**/*',
   ],

--- a/.prettierignore
+++ b/.prettierignore
@@ -5,6 +5,7 @@ builds/**
 test-*/**
 coverage/
 jest-coverage/
+storybook-build/
 app/vendor/**
 .nyc_output/**
 .vscode/**


### PR DESCRIPTION
The `storybook-build` directory is the Storybook build output. These are generated files that we do not need to lint.

## Manual Testing Steps

* Run the command `yarn storybook:build`
* Run `yarn lint` and see that there are no lint errors.

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
