### PR TITLE
Document callback-style background calls as deprecated

### DIFF
--- a/ui/store/action-queue/index.js
+++ b/ui/store/action-queue/index.js
@@ -99,12 +99,13 @@ export function submitRequestToBackground(
 }
 
 /**
- * Callback-style call to background method
+ * [Deprecated] Callback-style call to background method
  * In MV2: invokes promisifiedBackground method directly.
  * In MV3: action is added to retry queue, along with resolve handler to be executed on completion,
  *  the queue is then immediately processed if background connection is available.
  *  On completion (successful or error) the action is removed from the retry queue.
  *
+ * @deprecated Use async `submitRequestToBackground` function instead.
  * @param {string} method - name of the background method
  * @param {Array} [args] - arguments to that method, if any
  * @param callback - Node style (error, result) callback for finishing the operation


### PR DESCRIPTION
We've been migrating from callback-based to async background calls for a number of years now. The async calls are easier to read, and less likely to be misused (especially when it comes to error handling).

The `callBackgroundMethod` method, used to make a callback-based background call, has been marked as deprecated. Hopefully this will discourage further use.

## Manual Testing Steps

N/A

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
