### PR TITLE
Fix #17388 - Remove dismiss button from NFT notification

### DIFF
--- a/app/scripts/controllers/app-state.js
+++ b/app/scripts/controllers/app-state.js
@@ -33,7 +33,6 @@ export default class AppStateController extends EventEmitter {
       fullScreenGasPollTokens: [],
       recoveryPhraseReminderHasBeenShown: false,
       recoveryPhraseReminderLastShown: new Date().getTime(),
-      collectiblesDetectionNoticeDismissed: false,
       showTestnetMessageInDropdown: true,
       showPortfolioTooltip: true,
       showBetaHeader: isBeta(),
@@ -301,19 +300,6 @@ export default class AppStateController extends EventEmitter {
    */
   setTrezorModel(trezorModel) {
     this.store.updateState({ trezorModel });
-  }
-
-  /**
-   * A setter for the `collectiblesDetectionNoticeDismissed` property
-   *
-   * @param collectiblesDetectionNoticeDismissed
-   */
-  setCollectiblesDetectionNoticeDismissed(
-    collectiblesDetectionNoticeDismissed,
-  ) {
-    this.store.updateState({
-      collectiblesDetectionNoticeDismissed,
-    });
   }
 
   /**

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -1860,10 +1860,6 @@ export default class MetamaskController extends EventEmitter {
         appStateController.setShowPortfolioTooltip.bind(appStateController),
       setShowBetaHeader:
         appStateController.setShowBetaHeader.bind(appStateController),
-      setCollectiblesDetectionNoticeDismissed:
-        appStateController.setCollectiblesDetectionNoticeDismissed.bind(
-          appStateController,
-        ),
       updateCollectibleDropDownState:
         appStateController.updateCollectibleDropDownState.bind(
           appStateController,

--- a/test/e2e/fixture-builder.js
+++ b/test/e2e/fixture-builder.js
@@ -115,7 +115,6 @@ function defaultFixture() {
       },
       AppStateController: {
         browserEnvironment: {},
-        collectiblesDetectionNoticeDismissed: false,
         collectiblesDropdownState: {},
         connectedStatusPopoverHasBeenShown: true,
         defaultHomeActiveTabName: null,
@@ -282,7 +281,6 @@ function onboardingFixture() {
     data: {
       AppStateController: {
         browserEnvironment: {},
-        collectiblesDetectionNoticeDismissed: false,
         collectiblesDropdownState: {},
         connectedStatusPopoverHasBeenShown: true,
         defaultHomeActiveTabName: null,

--- a/ui/components/app/collectibles-detection-notice/collectibles-detection-notice.js
+++ b/ui/components/app/collectibles-detection-notice/collectibles-detection-notice.js
@@ -13,7 +13,6 @@ import {
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import Button from '../../ui/button';
 import { EXPERIMENTAL_ROUTE } from '../../../helpers/constants/routes';
-import { setCollectiblesDetectionNoticeDismissed } from '../../../store/actions';
 
 export default function CollectiblesDetectionNotice() {
   const t = useI18nContext();
@@ -22,11 +21,6 @@ export default function CollectiblesDetectionNotice() {
   return (
     <Box className="collectibles-detection-notice">
       <Dialog type="message" className="collectibles-detection-notice__message">
-        <button
-          onClick={() => setCollectiblesDetectionNoticeDismissed()}
-          className="fas fa-times collectibles-detection-notice__message__close-button"
-          data-testid="collectibles-detection-notice-close"
-        />
         <Box display={DISPLAY.FLEX}>
           <Box paddingTop={1}>
             <i

--- a/ui/components/app/collectibles-tab/collectibles-tab.js
+++ b/ui/components/app/collectibles-tab/collectibles-tab.js
@@ -17,7 +17,6 @@ import {
   ALIGN_ITEMS,
 } from '../../../helpers/constants/design-system';
 import { useI18nContext } from '../../../hooks/useI18nContext';
-import { getCollectiblesDetectionNoticeDismissed } from '../../../ducks/metamask/metamask';
 import { getIsMainnet, getUseNftDetection } from '../../../selectors';
 import { EXPERIMENTAL_ROUTE } from '../../../helpers/constants/routes';
 import {
@@ -30,9 +29,6 @@ import ZENDESK_URLS from '../../../helpers/constants/zendesk-url';
 export default function CollectiblesTab({ onAddNFT }) {
   const useNftDetection = useSelector(getUseNftDetection);
   const isMainnet = useSelector(getIsMainnet);
-  const collectibleDetectionNoticeDismissed = useSelector(
-    getCollectiblesDetectionNoticeDismissed,
-  );
   const history = useHistory();
   const t = useI18nContext();
   const dispatch = useDispatch();
@@ -65,9 +61,7 @@ export default function CollectiblesTab({ onAddNFT }) {
         />
       ) : (
         <>
-          {isMainnet &&
-          !useNftDetection &&
-          !collectibleDetectionNoticeDismissed ? (
+          {isMainnet && !useNftDetection ? (
             <CollectiblesDetectionNotice />
           ) : null}
           <Box padding={12}>

--- a/ui/components/app/collectibles-tab/collectibles-tab.test.js
+++ b/ui/components/app/collectibles-tab/collectibles-tab.test.js
@@ -149,7 +149,6 @@ const render = ({
   collectibles = [],
   selectedAddress,
   chainId = '0x1',
-  collectiblesDetectionNoticeDismissed = false,
   useNftDetection,
   onAddNFT = jest.fn(),
 }) => {
@@ -167,7 +166,6 @@ const render = ({
       },
       provider: { chainId },
       selectedAddress,
-      collectiblesDetectionNoticeDismissed,
       useNftDetection,
       collectiblesDropdownState,
     },
@@ -177,13 +175,10 @@ const render = ({
 
 describe('Collectible Items', () => {
   const detectCollectiblesStub = jest.fn();
-  const setCollectiblesDetectionNoticeDismissedStub = jest.fn();
   const getStateStub = jest.fn();
   const checkAndUpdateAllCollectiblesOwnershipStatusStub = jest.fn();
   const updateCollectibleDropDownStateStub = jest.fn();
   setBackgroundConnection({
-    setCollectiblesDetectionNoticeDismissed:
-      setCollectiblesDetectionNoticeDismissedStub,
     detectNfts: detectCollectiblesStub,
     getState: getStateStub,
     checkAndUpdateAllNftsOwnershipStatus:
@@ -239,23 +234,8 @@ describe('Collectible Items', () => {
       render({
         selectedAddress: ACCOUNT_1,
         collectibles: COLLECTIBLES,
-        collectiblesDetectionNoticeDismissed: true,
       });
       expect(screen.queryByText('New! NFT detection')).not.toBeInTheDocument();
-    });
-
-    it('should call setCollectibesDetectionNoticeDismissed when users clicks "X"', () => {
-      render({
-        selectedAddress: ACCOUNT_2,
-        collectibles: COLLECTIBLES,
-      });
-      expect(
-        setCollectiblesDetectionNoticeDismissedStub,
-      ).not.toHaveBeenCalled();
-      fireEvent.click(
-        screen.queryByTestId('collectibles-detection-notice-close'),
-      );
-      expect(setCollectiblesDetectionNoticeDismissedStub).toHaveBeenCalled();
     });
   });
 

--- a/ui/ducks/metamask/metamask.js
+++ b/ui/ducks/metamask/metamask.js
@@ -263,10 +263,6 @@ export const getPendingTokens = (state) => state.metamask.pendingTokens;
 
 export const getTokens = (state) => state.metamask.tokens;
 
-export function getCollectiblesDetectionNoticeDismissed(state) {
-  return state.metamask.collectiblesDetectionNoticeDismissed;
-}
-
 export function getCollectiblesDropdownState(state) {
   return state.metamask.collectiblesDropdownState;
 }

--- a/ui/pages/add-collectible/add-collectible.js
+++ b/ui/pages/add-collectible/add-collectible.js
@@ -28,10 +28,7 @@ import {
   getSelectedAddress,
   getUseNftDetection,
 } from '../../selectors';
-import {
-  getCollectiblesDetectionNoticeDismissed,
-  getCollectiblesDropdownState,
-} from '../../ducks/metamask/metamask';
+import { getCollectiblesDropdownState } from '../../ducks/metamask/metamask';
 import CollectiblesDetectionNotice from '../../components/app/collectibles-detection-notice';
 import { MetaMetricsContext } from '../../contexts/metametrics';
 import { AssetType } from '../../../shared/constants/transaction';
@@ -43,9 +40,6 @@ export default function AddCollectible() {
   const dispatch = useDispatch();
   const useNftDetection = useSelector(getUseNftDetection);
   const isMainnet = useSelector(getIsMainnet);
-  const collectibleDetectionNoticeDismissed = useSelector(
-    getCollectiblesDetectionNoticeDismissed,
-  );
   const collectiblesDropdownState = useSelector(getCollectiblesDropdownState);
   const selectedAddress = useSelector(getSelectedAddress);
   const chainId = useSelector(getCurrentChainId);
@@ -145,9 +139,7 @@ export default function AddCollectible() {
       disabled={disabled}
       contentComponent={
         <Box>
-          {isMainnet &&
-          !useNftDetection &&
-          !collectibleDetectionNoticeDismissed ? (
+          {isMainnet && !useNftDetection ? (
             <CollectiblesDetectionNotice />
           ) : null}
           {collectibleAddFailed && (

--- a/ui/store/actions.js
+++ b/ui/store/actions.js
@@ -3805,12 +3805,6 @@ export function hideBetaHeader() {
   return submitRequestToBackground('setShowBetaHeader', [false]);
 }
 
-export function setCollectiblesDetectionNoticeDismissed() {
-  return submitRequestToBackground('setCollectiblesDetectionNoticeDismissed', [
-    true,
-  ]);
-}
-
 export function setTransactionSecurityCheckEnabled(
   transactionSecurityCheckEnabled,
 ) {


### PR DESCRIPTION
* Fixes #17388

## Screenshots/Screencaps

<img width="983" alt="NoClose" src="https://user-images.githubusercontent.com/46655/214380173-0e64f934-197c-4760-a6c1-927cecc9776a.png">

## Manual Testing Steps

1.  Install fresh MetaMask with `NFTS_V1=1 yarn start`
2.  Click NFT tab after setup
3.  See notification to setup NFT detection without close button

## Pre-merge author checklist

- [ ] I've clearly explained:
  - [ ] What problem this PR is solving
  - [ ] How this problem was solved
  - [ ] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
