### PR TITLE
Fix #17385 - Provide autohide callback for ActionMessage

### DIFF
--- a/ui/components/ui/actionable-message/actionable-message.js
+++ b/ui/components/ui/actionable-message/actionable-message.js
@@ -31,6 +31,7 @@ export default function ActionableMessage({
   roundedButtons,
   dataTestId,
   autoHideTime = 0,
+  onAutoHide,
 }) {
   const [shouldDisplay, setShouldDisplay] = useState(true);
   useEffect(
@@ -40,6 +41,7 @@ export default function ActionableMessage({
       }
 
       const timeout = setTimeout(() => {
+        onAutoHide?.();
         setShouldDisplay(false);
       }, autoHideTime);
 
@@ -190,4 +192,8 @@ ActionableMessage.propTypes = {
    * Whether the actionable message should auto-hide itself after a given amount of time
    */
   autoHideTime: PropTypes.number,
+  /**
+   * Callback when autoHide time expires
+   */
+  onAutoHide: PropTypes.func,
 };

--- a/ui/pages/home/home.component.js
+++ b/ui/pages/home/home.component.js
@@ -274,6 +274,9 @@ export default class Home extends PureComponent {
       clearNewCustomNetworkAdded,
       setRpcTarget,
     } = this.props;
+
+    const onAutoHide = () => setNewCollectibleAddedMessage('');
+
     return (
       <MultipleNotifications>
         {
@@ -318,6 +321,7 @@ export default class Home extends PureComponent {
             type="success"
             className="home__new-network-notification"
             autoHideTime={5 * SECOND}
+            onAutoHide={onAutoHide}
             message={
               <Box display={DISPLAY.INLINE_FLEX}>
                 <i className="fa fa-check-circle home__new-nft-notification-icon" />
@@ -330,7 +334,7 @@ export default class Home extends PureComponent {
                 <button
                   className="fas fa-times home__new-nft-notification-close"
                   title={t('close')}
-                  onClick={() => setNewCollectibleAddedMessage('')}
+                  onClick={onAutoHide}
                 />
               </Box>
             }

--- a/ui/pages/home/home.component.js
+++ b/ui/pages/home/home.component.js
@@ -276,6 +276,7 @@ export default class Home extends PureComponent {
     } = this.props;
 
     const onAutoHide = () => setNewCollectibleAddedMessage('');
+    const autoHideDelay = 5 * SECOND;
 
     return (
       <MultipleNotifications>
@@ -320,7 +321,7 @@ export default class Home extends PureComponent {
           <ActionableMessage
             type="success"
             className="home__new-network-notification"
-            autoHideTime={5 * SECOND}
+            autoHideTime={autoHideDelay}
             onAutoHide={onAutoHide}
             message={
               <Box display={DISPLAY.INLINE_FLEX}>
@@ -345,6 +346,8 @@ export default class Home extends PureComponent {
           <ActionableMessage
             type="danger"
             className="home__new-network-notification"
+            autoHideTime={autoHideDelay}
+            onAutoHide={onAutoHide}
             message={
               <Box display={DISPLAY.INLINE_FLEX}>
                 <i className="fa fa-check-circle home__new-nft-notification-icon" />


### PR DESCRIPTION
## Explanation

* Fixes #17385

When the autohide timer goes off, we should record the event so state updates and the ActionableMessage doesn't display again.

## Manual Testing Steps

<!--
How should reviewers and QA manually test your changes? For instance:

- Go to this screen
- Do this
- Then do this
-->

## Pre-merge author checklist

- [ ] I've clearly explained:
  - [ ] What problem this PR is solving
  - [ ] How this problem was solved
  - [ ] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
