### PR TITLE
Fix #17393 - Fix NFT collection header image

### DIFF
--- a/ui/components/app/collectibles-items/collectibles-items.js
+++ b/ui/components/app/collectibles-items/collectibles-items.js
@@ -92,7 +92,7 @@ export default function CollectiblesItems({
       return (
         <img
           alt={collectionName}
-          src={collectionImage}
+          src={getAssetImageURL(collectionImage, ipfsGateway)}
           className="collectibles-items__collection-image"
         />
       );


### PR DESCRIPTION
## Explanation

Piggybacks off of https://github.com/MetaMask/metamask-extension/pull/17302

* Fixes #17393

## Screenshots/Screencaps

<img width="339" alt="Screenshot at Jan 24 14-12-21" src="https://user-images.githubusercontent.com/46655/214398346-314b47dc-3528-4152-8c03-79b0569bd4e2.png">

## Manual Testing Steps

Instructions in issue.

## Pre-merge author checklist

- [ ] I've clearly explained:
  - [ ] What problem this PR is solving
  - [ ] How this problem was solved
  - [ ] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
