### PR TITLE
Fix Playwright install step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -524,7 +524,7 @@ jobs:
           at: .
       - run:
           name: Install Playwright browsers
-          command: yarn dlx playwright install
+          command: yarn exec playwright install
       - run:
           name: Test Storybook
           command: yarn test-storybook:ci


### PR DESCRIPTION
The Playwright install step run in the `test-storybook` job has been updated to ensure that we are running the correct install command. Previously we were using `yarn dlx`, which would use the latest version of `Playwright` rather than the one currently installed. Instead now we are using `yarn exec`, which will invoke the `playwright` binary from the locally installed package. This binary has an `install` command that completes the necessary setup, which is to install custom patched browsers for Playwright to run.

## Manual Testing Steps

This is meant to fix a CI failure, so CI should be sufficient to show that this is working.

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
