### PR TITLE
Add migration to ensure that TokenListController.tokensChainsCache is not undefined

### DIFF
--- a/app/scripts/migrations/078.js
+++ b/app/scripts/migrations/078.js
@@ -1,0 +1,31 @@
+import { cloneDeep } from 'lodash';
+
+const version = 78;
+
+/**
+ * Fixes an issue with 077.js: tokensChainsCache should default to `{}` not `undefined`
+ */
+export default {
+  version,
+  async migrate(originalVersionedData) {
+    const versionedData = cloneDeep(originalVersionedData);
+    versionedData.meta.version = version;
+    const state = versionedData.data;
+    const newState = transformState(state);
+    versionedData.data = newState;
+    return versionedData;
+  },
+};
+
+function transformState(state) {
+  const TokenListController = state?.TokenListController || {};
+
+  TokenListController.tokensChainsCache = TokenListController.tokensChainsCache || {};
+
+  return {
+    ...state,
+    TokenListController: {
+      ...TokenListController,
+    },
+  };
+}

--- a/app/scripts/migrations/078.test.js
+++ b/app/scripts/migrations/078.test.js
@@ -1,0 +1,199 @@
+import migration78 from './078';
+
+describe('migration #78', () => {
+  it('should update the version metadata', async () => {
+    const oldStorage = {
+      meta: {
+        version: 77,
+      },
+    };
+
+    const newStorage = await migration78.migrate(oldStorage);
+    expect(newStorage.meta).toStrictEqual({
+      version: 78,
+    });
+  });
+
+  it('should set tokensChainsCache to an empty object if the property is not set', async () => {
+    const oldStorage = {
+      meta: {
+        version: 77,
+      },
+      data: {
+        TokenListController: {
+          tokenList: {
+            '0x514910781af9ca656af840dff83e8264ecf986ca': {
+              address: '0x514910781af9ca656af840dff83e8264ecf986ca',
+              symbol: 'LINK',
+              decimals: 18,
+            },
+          },
+        },
+      },
+    };
+    const newStorage = await migration78.migrate(oldStorage);
+    expect(newStorage).toStrictEqual({
+      meta: {
+        version: 78,
+      },
+      data: {
+        TokenListController: {
+          tokenList: {
+            '0x514910781af9ca656af840dff83e8264ecf986ca': {
+              address: '0x514910781af9ca656af840dff83e8264ecf986ca',
+              symbol: 'LINK',
+              decimals: 18,
+            },
+          },
+          tokensChainsCache: {},
+        },
+      },
+    });
+  });
+
+  it('should set tokensChainsCache to an empty object if the property is set to undefined', async () => {
+    const oldStorage = {
+      meta: {
+        version: 77,
+      },
+      data: {
+        TokenListController: {
+          tokenList: {
+            '0x514910781af9ca656af840dff83e8264ecf986ca': {
+              address: '0x514910781af9ca656af840dff83e8264ecf986ca',
+              symbol: 'LINK',
+              decimals: 18,
+            },
+          },
+          tokensChainsCache: undefined,
+        },
+      },
+    };
+    const newStorage = await migration78.migrate(oldStorage);
+    expect(newStorage).toStrictEqual({
+      meta: {
+        version: 78,
+      },
+      data: {
+        TokenListController: {
+          tokenList: {
+            '0x514910781af9ca656af840dff83e8264ecf986ca': {
+              address: '0x514910781af9ca656af840dff83e8264ecf986ca',
+              symbol: 'LINK',
+              decimals: 18,
+            },
+          },
+          tokensChainsCache: {},
+        },
+      },
+    });
+  });
+
+  it('should leave tokensChainsCache unchanged if it is an empty object', async () => {
+    const oldStorage = {
+      meta: {
+        version: 77,
+      },
+      data: {
+        TokenListController: {
+          tokenList: {
+            '0x514910781af9ca656af840dff83e8264ecf986ca': {
+              address: '0x514910781af9ca656af840dff83e8264ecf986ca',
+              symbol: 'LINK',
+              decimals: 18,
+            },
+          },
+          tokensChainsCache: {},
+        },
+      },
+    };
+    const newStorage = await migration78.migrate(oldStorage);
+    expect(newStorage).toStrictEqual({
+      meta: {
+        version: 78,
+      },
+      data: {
+        TokenListController: {
+          tokenList: {
+            '0x514910781af9ca656af840dff83e8264ecf986ca': {
+              address: '0x514910781af9ca656af840dff83e8264ecf986ca',
+              symbol: 'LINK',
+              decimals: 18,
+            },
+          },
+          tokensChainsCache: {},
+        },
+      },
+    });
+  });
+
+  it('should leave tokensChainsCache unchanged if it is an object with data', async () => {
+    const oldStorage = {
+      meta: {
+        version: 77,
+      },
+      data: {
+        TokenListController: {
+          tokenList: {
+            '0x514910781af9ca656af840dff83e8264ecf986ca': {
+              address: '0x514910781af9ca656af840dff83e8264ecf986ca',
+              symbol: 'LINK',
+              decimals: 18,
+            },
+          },
+          tokensChainsCache: {
+            1: {
+              timestamp: 1234,
+              data: {
+                '0x514910771af9ca656af840dff83e8264ecf986ca': {
+                  address: '0x514910771af9ca656af840dff83e8264ecf986ca',
+                  symbol: 'LINK',
+                  decimals: 18,
+                },
+                '0xc00e94cb662c3520282e6f5717214004a7f26888': {
+                  address: '0xc00e94cb662c3520282e6f5717214004a7f26888',
+                  symbol: 'COMP',
+                  decimals: 18,
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+    const newStorage = await migration78.migrate(oldStorage);
+    expect(newStorage).toStrictEqual({
+      meta: {
+        version: 78,
+      },
+      data: {
+        TokenListController: {
+          tokenList: {
+            '0x514910781af9ca656af840dff83e8264ecf986ca': {
+              address: '0x514910781af9ca656af840dff83e8264ecf986ca',
+              symbol: 'LINK',
+              decimals: 18,
+            },
+          },
+          tokensChainsCache: {
+            1: {
+              timestamp: 1234,
+              data: {
+                '0x514910771af9ca656af840dff83e8264ecf986ca': {
+                  address: '0x514910771af9ca656af840dff83e8264ecf986ca',
+                  symbol: 'LINK',
+                  decimals: 18,
+                },
+                '0xc00e94cb662c3520282e6f5717214004a7f26888': {
+                  address: '0xc00e94cb662c3520282e6f5717214004a7f26888',
+                  symbol: 'COMP',
+                  decimals: 18,
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+  });
+});

--- a/app/scripts/migrations/index.js
+++ b/app/scripts/migrations/index.js
@@ -81,6 +81,7 @@ import m074 from './074';
 import m075 from './075';
 import m076 from './076';
 import m077 from './077';
+import m078 from './078';
 
 const migrations = [
   m002,
@@ -159,6 +160,7 @@ const migrations = [
   m075,
   m076,
   m077,
+  m078,
 ];
 
 export default migrations;


### PR DESCRIPTION
Fixes #17387

Explanation copied from slack:

Dan Miller
  [19 hours ago](https://consensys.slack.com/archives/GTQAGKY5V/p1674641935176309?thread_ts=1674587160.103669&cid=GTQAGKY5V)
tokenListController does this: https://github.com/MetaMask/core/blob/main/packages/assets-controllers/src/TokenListController.ts#L134-L139

[TokenListController.ts](https://github.com/MetaMask/core/blob/main/packages/assets-controllers/src/TokenListController.ts)
    super({
      name,
      metadata,
      messenger,
      state: { ...defaultState, ...state },
Show more
<https://github.com/[MetaMask/core](https://github.com/MetaMask/core)|MetaMask/core>MetaMask/core | Added by [GitHub](https://consensys.slack.com/services/B01UACT8SA1)





Dan Miller
  [19 hours ago](https://consensys.slack.com/archives/GTQAGKY5V/p1674641954816599?thread_ts=1674587160.103669&cid=GTQAGKY5V)
that is in the constructor


Dan Miller
  [19 hours ago](https://consensys.slack.com/archives/GTQAGKY5V/p1674642039701509?thread_ts=1674587160.103669&cid=GTQAGKY5V)
and the migration here https://github.com/MetaMask/metamask-extension/commit/8f18e04b97 does this:
const TokenListController = state?.TokenListController || {};

  const { tokensChainsCache } = TokenListController;

  let dataCache;
  let dataObject;
  // eslint-disable-next-line
  for (const chainId in tokensChainsCache) {
...
}
TokenListController.tokensChainsCache = tokensChainsCache;


Dan Miller
  [19 hours ago](https://consensys.slack.com/archives/GTQAGKY5V/p1674642084403459?thread_ts=1674587160.103669&cid=GTQAGKY5V)
so if there was no tokensChainsCache property before this migration was run, it would be explicitly set to undefined


Dan Miller
  [19 hours ago](https://consensys.slack.com/archives/GTQAGKY5V/p1674642145570029?thread_ts=1674587160.103669&cid=GTQAGKY5V)
which would result in it being initialized to undefined, because (for example) ->
Screenshot from 2023-01-25 06-51-39.png
 
Screenshot from 2023-01-25 06-51-39.png




Dan Miller
  [19 hours ago](https://consensys.slack.com/archives/GTQAGKY5V/p1674642369039999?thread_ts=1674587160.103669&cid=GTQAGKY5V)
although, it looks like that property was always part of the tokenlistcontroller, so how could it not be set in state? [https://github.com/MetaMask/core/commit/84b410f05709dd3e5a0798b4263c3d4cbaebf880#diff-c2ec75b01a3b2e2e1284df7c48a[…]a26ea7f1455167cc8390d91ca865b854](https://github.com/MetaMask/core/commit/84b410f05709dd3e5a0798b4263c3d4cbaebf880#diff-c2ec75b01a3b2e2e1284df7c48ad4c80a26ea7f1455167cc8390d91ca865b854)


Dan Miller
  [19 hours ago](https://consensys.slack.com/archives/GTQAGKY5V/p1674643279482649?thread_ts=1674587160.103669&cid=GTQAGKY5V)
oh, if the user was starting MetaMask for the first time since before the tokenlistcontroller was added, then const TokenListController = state?.TokenListController || {}; would result in {} and then const { tokensChainsCache } = TokenListController; would resullt in a tokenChainsCache that is undefined