### PR TITLE
Make username mandatory in the edit contact screen

### DIFF
--- a/ui/pages/settings/contact-list-tab/edit-contact/edit-contact.component.js
+++ b/ui/pages/settings/contact-list-tab/edit-contact/edit-contact.component.js
@@ -170,9 +170,10 @@ export default class EditContact extends PureComponent {
           }}
           submitText={this.context.t('save')}
           disabled={
-            this.state.newName === name &&
-            this.state.newAddress === address &&
-            this.state.newMemo === memo
+            (this.state.newName === name &&
+              this.state.newAddress === address &&
+              this.state.newMemo === memo) ||
+            !this.state.newName.trim()
           }
         />
       </div>

--- a/ui/pages/settings/contact-list-tab/edit-contact/edit-contact.test.js
+++ b/ui/pages/settings/contact-list-tab/edit-contact/edit-contact.test.js
@@ -1,0 +1,61 @@
+import React from 'react';
+import { fireEvent } from '@testing-library/react';
+import configureMockStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+import { renderWithProvider } from '../../../../../test/lib/render-helpers';
+import '@testing-library/jest-dom/extend-expect';
+import EditContact from './edit-contact.component';
+
+describe('AddContact component', () => {
+  const middleware = [thunk];
+  const state = {
+    metamask: {
+      provider: {
+        type: 'mainnet',
+        nickname: '',
+      },
+    },
+  };
+  const props = {
+    addToAddressBook: jest.fn(),
+    removeFromAddressBook: jest.fn(),
+    history: { push: jest.fn() },
+    name: '',
+    address: '0x0000000000000000001',
+    chainId: '',
+    memo: '',
+    viewRoute: '',
+    listRoute: '',
+  };
+
+  it('should render the component with correct properties', () => {
+    const store = configureMockStore(middleware)(state);
+
+    const { getByText } = renderWithProvider(<EditContact {...props} />, store);
+
+    expect(getByText('Username')).toBeInTheDocument();
+    expect(getByText('Ethereum public address')).toBeInTheDocument();
+  });
+
+  it('should validate the address correctly', () => {
+    const store = configureMockStore(middleware)(state);
+    const { getByText } = renderWithProvider(<EditContact {...props} />, store);
+
+    const input = document.getElementById('address');
+    fireEvent.change(input, { target: { value: 'invalid address' } });
+    setTimeout(() => {
+      expect(getByText('Invalid address')).toBeInTheDocument();
+    }, 100);
+  });
+
+  it('should get disabled submit button when username field is empty', () => {
+    const store = configureMockStore(middleware)(state);
+    const { getByText } = renderWithProvider(<EditContact {...props} />, store);
+
+    const input = document.getElementById('nickname');
+    fireEvent.change(input, { target: { value: '' } });
+
+    const saveButton = getByText('Save');
+    expect(saveButton).toBeDisabled();
+  });
+});


### PR DESCRIPTION
## Explanation

The username is not mandatory when editing recent contacts.
This PR will make username mandatory in edit recent contacts screen.

<!--
Thanks for the pull request. Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues, Slack conversations, Zendesk issues, user stories, etc. reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->
* Fixes #17375 

## Screenshots/Screencaps

<!-- If you're making a change to the UI, make sure to capture a screenshot or a short video showing off your work! -->

### Before

<!-- How did the UI you changed look before your changes? Drag your file(s) below this line: -->

https://user-images.githubusercontent.com/53189696/214325574-2d993361-d9ff-4999-80d5-90f88546760e.mov

### After

<!-- How does it look now? Drag your file(s) below this line: -->

https://user-images.githubusercontent.com/97883527/214794050-867a9896-f57d-4c1b-8405-9c05475f0d6b.mov


## Manual Testing Steps

<!--
How should reviewers and QA manually test your changes? For instance:

- Go to this screen
- Do this
- Then do this
-->

- Login
- Click the Send button on the overview page
- Enter an address that you do not have in your address book
- Click Next, accepting the send defaults
- Click Confirm, to confirm the transaction
- Click on the account icon to open the menu
- Click Settings, followed by Contacts
- Select the contact you just sent to, in the Recents section
- Edit the contact(memo), leaving the username empty
- Notice that save is disabled when username is empty.

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [ ] How this problem was solved
  - [ ] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
