### PR TITLE
Use network provider state, instead of CurrencyRateController state, to select 'nativeCurrency'

### DIFF
--- a/test/data/mock-state.json
+++ b/test/data/mock-state.json
@@ -74,7 +74,8 @@
     "network": "5",
     "provider": {
       "type": "rpc",
-      "chainId": "0x5"
+      "chainId": "0x5",
+      "ticker": "ETH"
     },
     "keyrings": [
       {

--- a/ui/components/app/transaction-activity-log/transaction-activity-log.container.test.js
+++ b/ui/components/app/transaction-activity-log/transaction-activity-log.container.test.js
@@ -18,6 +18,9 @@ describe('TransactionActivityLog container', () => {
           conversionRate: 280.45,
           nativeCurrency: 'ETH',
           frequentRpcListDetail: [],
+          provider: {
+            ticker: 'ETH',
+          },
         },
       };
 
@@ -43,6 +46,7 @@ describe('TransactionActivityLog container', () => {
           ],
           provider: {
             rpcUrl: 'https://customnetwork.com/',
+            ticker: 'ETH',
           },
         },
       };

--- a/ui/ducks/confirm-transaction/confirm-transaction.duck.test.js
+++ b/ui/ducks/confirm-transaction/confirm-transaction.duck.test.js
@@ -290,6 +290,9 @@ describe('Confirm Transaction Duck', () => {
         metamask: {
           conversionRate: 468.58,
           currentCurrency: 'usd',
+          provider: {
+            ticker: 'ETH'
+          },
         },
         confirmTransaction: {
           ethTransactionAmount: '1',

--- a/ui/ducks/confirm-transaction/confirm-transaction.duck.test.js
+++ b/ui/ducks/confirm-transaction/confirm-transaction.duck.test.js
@@ -291,7 +291,7 @@ describe('Confirm Transaction Duck', () => {
           conversionRate: 468.58,
           currentCurrency: 'usd',
           provider: {
-            ticker: 'ETH'
+            ticker: 'ETH',
           },
         },
         confirmTransaction: {

--- a/ui/ducks/metamask/metamask.js
+++ b/ui/ducks/metamask/metamask.js
@@ -10,6 +10,7 @@ import {
   accountsWithSendEtherInfoSelector,
   checkNetworkAndAccountSupports1559,
   getAddressBook,
+  getUseCurrencyRateCheck,
 } from '../../selectors';
 import { updateTransactionGasFees } from '../../store/actions';
 import { setCustomGasLimit, setCustomGasPrice } from '../gas/gas.duck';
@@ -307,7 +308,10 @@ export function getConversionRate(state) {
 }
 
 export function getNativeCurrency(state) {
-  return state.metamask.provider.ticker;
+  const useCurrencyRateCheck = getUseCurrencyRateCheck(state);
+  return useCurrencyRateCheck
+    ? state.metamask.nativeCurrency
+    : state.metamask.provider.ticker;
 }
 
 export function getSendHexDataFeatureFlagState(state) {

--- a/ui/ducks/metamask/metamask.js
+++ b/ui/ducks/metamask/metamask.js
@@ -307,7 +307,7 @@ export function getConversionRate(state) {
 }
 
 export function getNativeCurrency(state) {
-  return state.metamask.nativeCurrency;
+  return state.metamask.provider.ticker;
 }
 
 export function getSendHexDataFeatureFlagState(state) {

--- a/ui/ducks/metamask/metamask.test.js
+++ b/ui/ducks/metamask/metamask.test.js
@@ -318,7 +318,10 @@ describe('MetaMask Reducers', () => {
         expect(
           getNativeCurrency({
             ...mockState,
-            useCurrencyRateCheck: false,
+            metamask: {
+              ...mockState.metamask,
+              useCurrencyRateCheck: false,
+            },
           }),
         ).toStrictEqual('TestETH');
       });

--- a/ui/ducks/metamask/metamask.test.js
+++ b/ui/ducks/metamask/metamask.test.js
@@ -40,11 +40,12 @@ describe('MetaMask Reducers', () => {
         currentBlockGasLimit: '0x4c1878',
         conversionRate: 1200.88200327,
         nativeCurrency: 'ETH',
+        useCurrencyRateCheck: true,
         network: '5',
         provider: {
           type: 'testnet',
           chainId: '0x5',
-          ticker: 'ETH',
+          ticker: 'TestETH',
         },
         accounts: {
           '0xfdea65c8e26263f6d9a1b5de9555d2931a33b825': {
@@ -309,8 +310,17 @@ describe('MetaMask Reducers', () => {
     });
 
     describe('getNativeCurrency()', () => {
-      it('should return the ticker symbol of the selected network', () => {
+      it('should return nativeCurrency when useCurrencyRateCheck is true', () => {
         expect(getNativeCurrency(mockState)).toStrictEqual('ETH');
+      });
+
+      it('should return the ticker symbol of the selected network when useCurrencyRateCheck is false', () => {
+        expect(
+          getNativeCurrency({
+            useCurrencyRateCheck: false,
+            ...mockState,
+          }),
+        ).toStrictEqual('TestETH');
       });
     });
 

--- a/ui/ducks/metamask/metamask.test.js
+++ b/ui/ducks/metamask/metamask.test.js
@@ -44,6 +44,7 @@ describe('MetaMask Reducers', () => {
         provider: {
           type: 'testnet',
           chainId: '0x5',
+          ticker: 'ETH',
         },
         accounts: {
           '0xfdea65c8e26263f6d9a1b5de9555d2931a33b825': {

--- a/ui/ducks/metamask/metamask.test.js
+++ b/ui/ducks/metamask/metamask.test.js
@@ -317,8 +317,8 @@ describe('MetaMask Reducers', () => {
       it('should return the ticker symbol of the selected network when useCurrencyRateCheck is false', () => {
         expect(
           getNativeCurrency({
-            useCurrencyRateCheck: false,
             ...mockState,
+            useCurrencyRateCheck: false,
           }),
         ).toStrictEqual('TestETH');
       });

--- a/ui/pages/send/gas-display/gas-display.js
+++ b/ui/pages/send/gas-display/gas-display.js
@@ -60,9 +60,10 @@ export default function GasDisplay({ gasError }) {
   const useCurrencyRateCheck = useSelector(getUseCurrencyRateCheck);
   const { showFiatInTestnets, useNativeCurrencyAsPrimaryCurrency } =
     useSelector(getPreferences);
-  const { nativeCurrency, provider, unapprovedTxs } = useSelector(
+  const { provider, unapprovedTxs } = useSelector(
     (state) => state.metamask,
   );
+  const nativeCurrency = provider.ticker;
   const { chainId } = provider;
   const networkName = NETWORK_TO_NAME_MAP[chainId];
   const isInsufficientTokenError =

--- a/ui/pages/send/gas-display/gas-display.js
+++ b/ui/pages/send/gas-display/gas-display.js
@@ -60,9 +60,7 @@ export default function GasDisplay({ gasError }) {
   const useCurrencyRateCheck = useSelector(getUseCurrencyRateCheck);
   const { showFiatInTestnets, useNativeCurrencyAsPrimaryCurrency } =
     useSelector(getPreferences);
-  const { provider, unapprovedTxs } = useSelector(
-    (state) => state.metamask,
-  );
+  const { provider, unapprovedTxs } = useSelector((state) => state.metamask);
   const nativeCurrency = provider.ticker;
   const { chainId } = provider;
   const networkName = NETWORK_TO_NAME_MAP[chainId];

--- a/ui/pages/send/send-content/__snapshots__/send-content.component.test.js.snap
+++ b/ui/pages/send/send-content/__snapshots__/send-content.component.test.js.snap
@@ -31,10 +31,8 @@ exports[`SendContent Component render should match snapshot 1`] = `
                 <div
                   class="send-v2__asset-dropdown__asset-icon"
                 >
-                  <img
-                    alt=""
-                    class="identicon"
-                    src="./images/eth_logo.svg"
+                  <div
+                    class="identicon__image-border"
                     style="height: 36px; width: 36px; border-radius: 18px;"
                   />
                 </div>
@@ -43,9 +41,7 @@ exports[`SendContent Component render should match snapshot 1`] = `
                 >
                   <div
                     class="send-v2__asset-dropdown__symbol"
-                  >
-                    ETH
-                  </div>
+                  />
                   <div
                     class="send-v2__asset-dropdown__name"
                   >


### PR DESCRIPTION
Alternative fix for #17429 

I think this works because `state.metamask.nativeCurrency` is always set from the provider config: https://github.com/MetaMask/metamask-extension/blob/develop/app/scripts/metamask-controller.js#L1020-L1028

Further explanation:

The bug from the user perspective is that if the "Show balance and token price checker" is off, then the network logo and "currency symbol" / "network ticker"  will be incorrect after switching networks.

The reason for that is that we don't execute any of the code in the in `CurrencyRateController` `updateExchangeRates` function if that toggle is off. That code updates the `nativeCurrency` property in state, and that property is used throughout the UI to decide which logo and  "currency symbol" / "network ticker" to show.

The `nativeCurrency` property is, however, always set using data from the network provider state. This happens in the metamask controller on two occasions: when the `CurrencyRateController` is initialized, and when the network changes. So, I believe we can safely replace all references to `state.metamask.nativeCurrency` with `state.metamask.provider.ticker`, and it will be functionally equivalent.