### PR TITLE
Fix RPC Url editing issue of existing network

### DIFF
--- a/ui/pages/settings/networks-tab/networks-form/networks-form.js
+++ b/ui/pages/settings/networks-tab/networks-form/networks-form.js
@@ -574,7 +574,7 @@ const NetworksForm = ({
   const deletable = !isCurrentRpcTarget && !viewOnly && !addNewNetwork;
   const stateUnchanged = stateIsUnchanged();
   const chainIdErrorOnFeaturedRpcDuringEdit =
-    selectedNetwork?.rpcUrl && warnings.chainId && chainIdMatchesFeaturedRPC;
+    selectedNetwork?.rpcUrl && errors.chainId && chainIdMatchesFeaturedRPC;
   const isSubmitDisabled =
     hasErrors() ||
     isSubmitting ||


### PR DESCRIPTION
Fixes: https://github.com/MetaMask/metamask-extension/issues/17399
Related: https://github.com/MetaMask/metamask-extension/issues/13249

## Explanation
Previously, changes were introduced so that a duplicate chain error id did not prevent users from adding new networks. Users reporting from https://github.com/MetaMask/metamask-extension/issues/13249 were running in to an issue where the duplicate chain id warning message was preventing RPC url updates to an existing network. As the duplicate message is classed as a "warning" and not an "error", we should be allowed to proceed here. This will still prevent submissions/edits in the case of a malformed/invalid RPC url.

### Before
https://user-images.githubusercontent.com/53189696/214433274-c67f8344-b62a-4e5b-8784-9774e61e2c40.mov

### After

https://user-images.githubusercontent.com/8732757/214996454-c89101f4-2e71-4787-a052-d03edd9be6c4.mov



## Manual Testing Steps
1. Login
2. Click the account menu
3. Click the `Settings` option
4. Click the `Networks` sub menu item
5. Select a custom network
6. Update the RPC URL
7. Ensure that you can save and update the URL
8. Ensure that other values can edited appropriately
9. Ensure that the appropriate form submission errors prevent saving

## Pre-merge author checklist

- [X] I've clearly explained:
  - [X] What problem this PR is solving
  - [X] How this problem was solved
  - [X] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
