### PR TITLE
Set popover zIndex to be higher then tooltip

### DIFF
--- a/ui/pages/home/home.component.js
+++ b/ui/pages/home/home.component.js
@@ -109,6 +109,7 @@ export default class Home extends PureComponent {
     infuraBlocked: PropTypes.bool.isRequired,
     showWhatsNewPopup: PropTypes.bool.isRequired,
     hideWhatsNewPopup: PropTypes.func.isRequired,
+    shouldShowNewNetworkInfo: PropTypes.bool.isRequired,
     showPortfolioTooltip: PropTypes.bool.isRequired,
     hidePortfolioTooltip: PropTypes.func.isRequired,
     portfolioTooltipWasShownInThisSession: PropTypes.bool.isRequired,
@@ -150,6 +151,10 @@ export default class Home extends PureComponent {
     clearNewCustomNetworkAdded: PropTypes.func,
     setRpcTarget: PropTypes.func,
     onboardedInThisUISession: PropTypes.bool,
+    isConnectedSitesShown: PropTypes.bool,
+    isAccountDetailsShown: PropTypes.bool,
+    isAccountMenuOpen: PropTypes.bool,
+    networkDropdownOpen: PropTypes.bool,
   };
 
   state = {
@@ -626,8 +631,13 @@ export default class Home extends PureComponent {
       firstTimeFlowType,
       completedOnboarding,
       shouldShowSeedPhraseReminder,
+      shouldShowNewNetworkInfo,
       onboardedInThisUISession,
       newCustomNetworkAdded,
+      isConnectedSitesShown,
+      isAccountDetailsShown,
+      isAccountMenuOpen,
+      networkDropdownOpen,
     } = this.props;
 
     if (forgottenPassword) {
@@ -644,6 +654,19 @@ export default class Home extends PureComponent {
       !showPortfolioTooltip &&
       !portfolioTooltipWasShownInThisSession &&
       Object.keys(newCustomNetworkAdded).length === 0;
+
+    const shouldShowPortfolioToolTip =
+      !process.env.IN_TEST &&
+      !shouldShowSeedPhraseReminder &&
+      !showRecoveryPhraseReminder &&
+      !shouldShowNewNetworkInfo &&
+      !isConnectedSitesShown &&
+      !isAccountDetailsShown &&
+      !isAccountMenuOpen &&
+      !networkDropdownOpen &&
+      Object.keys(newCustomNetworkAdded).length === 0 &&
+      showPortfolioTooltip;
+
     return (
       <div className="main-container">
         <Route path={CONNECTED_ROUTE} component={ConnectedSites} exact />
@@ -676,12 +699,7 @@ export default class Home extends PureComponent {
               subHeader={
                 <Tooltip
                   position="bottom"
-                  open={
-                    !process.env.IN_TEST &&
-                    !shouldShowSeedPhraseReminder &&
-                    !showRecoveryPhraseReminder &&
-                    showPortfolioTooltip
-                  }
+                  open={shouldShowPortfolioToolTip}
                   interactive
                   theme="home__subheader-link--tooltip"
                   html={

--- a/ui/pages/home/home.container.js
+++ b/ui/pages/home/home.container.js
@@ -26,6 +26,7 @@ import {
   getShowPortfolioTooltip,
   getShouldShowSeedPhraseReminder,
   getRemoveNftMessage,
+  getShouldShowNewNetworkInfo,
 } from '../../selectors';
 
 import {
@@ -65,9 +66,10 @@ import {
   AlertTypes,
   Web3ShimUsageAlertStates,
 } from '../../../shared/constants/alerts';
+import { CONNECTED_ROUTE } from '../../helpers/constants/routes';
 import Home from './home.component';
 
-const mapStateToProps = (state) => {
+const mapStateToProps = (state, ownProps) => {
   const { metamask, appState } = state;
   const {
     suggestedAssets,
@@ -78,8 +80,10 @@ const mapStateToProps = (state) => {
     swapsState,
     firstTimeFlowType,
     completedOnboarding,
+    isAccountMenuOpen,
   } = metamask;
   const { forgottenPassword } = metamask;
+  const { modal, networkDropdownOpen } = appState;
   const totalUnapprovedCount = getTotalUnapprovedCount(state);
   const swapsEnabled = getSwapsFeatureIsLive(state);
   const pendingConfirmations = getUnapprovedTemplatedConfirmations(state);
@@ -112,6 +116,9 @@ const mapStateToProps = (state) => {
   const isSigningQRHardwareTransaction =
     hasUnsignedQRHardwareTransaction(state) ||
     hasUnsignedQRHardwareMessage(state);
+
+  const isConnectedSitesShown = ownProps.location.pathname === CONNECTED_ROUTE;
+  const isAccountDetailsShown = modal.open;
 
   return {
     forgottenPassword,
@@ -156,6 +163,11 @@ const mapStateToProps = (state) => {
     newTokensImported: getNewTokensImported(state),
     newCustomNetworkAdded: appState.newCustomNetworkAdded,
     onboardedInThisUISession: appState.onboardedInThisUISession,
+    shouldShowNewNetworkInfo: getShouldShowNewNetworkInfo(state),
+    isConnectedSitesShown,
+    isAccountDetailsShown,
+    isAccountMenuOpen,
+    networkDropdownOpen,
   };
 };
 

--- a/ui/pages/routes/routes.component.js
+++ b/ui/pages/routes/routes.component.js
@@ -105,15 +105,11 @@ export default class Routes extends Component {
     browserEnvironmentBrowser: PropTypes.string,
     theme: PropTypes.string,
     sendStage: PropTypes.string,
-    isNetworkUsed: PropTypes.bool,
-    allAccountsOnNetworkAreEmpty: PropTypes.bool,
-    isTestNet: PropTypes.bool,
-    currentChainId: PropTypes.string,
     shouldShowSeedPhraseReminder: PropTypes.bool,
     portfolioTooltipIsBeingShown: PropTypes.bool,
     forgottenPassword: PropTypes.bool,
-    isCurrentProviderCustom: PropTypes.bool,
     completedOnboarding: PropTypes.bool,
+    shouldShowNewNetworkInfo: PropTypes.bool,
   };
 
   static contextTypes = {
@@ -364,28 +360,15 @@ export default class Routes extends Component {
       isMouseUser,
       browserEnvironmentOs: os,
       browserEnvironmentBrowser: browser,
-      isNetworkUsed,
-      allAccountsOnNetworkAreEmpty,
-      isTestNet,
-      currentChainId,
       shouldShowSeedPhraseReminder,
+      shouldShowNewNetworkInfo,
       portfolioTooltipIsBeingShown,
-      isCurrentProviderCustom,
       completedOnboarding,
     } = this.props;
     const loadMessage =
       loadingMessage || isNetworkLoading
         ? this.getConnectingLabel(loadingMessage)
         : null;
-
-    const shouldShowNetworkInfo =
-      isUnlocked &&
-      currentChainId &&
-      !isTestNet &&
-      !isNetworkUsed &&
-      !isCurrentProviderCustom &&
-      completedOnboarding &&
-      allAccountsOnNetworkAreEmpty;
 
     const windowType = getEnvironmentType();
 
@@ -411,7 +394,7 @@ export default class Routes extends Component {
         }}
       >
         {shouldShowNetworkDeprecationWarning && <DeprecatedTestNetworks />}
-        {shouldShowNetworkInfo && <NewNetworkInfo />}
+        {shouldShowNewNetworkInfo && <NewNetworkInfo />}
         <QRHardwarePopover />
         <Modal />
         <Alert visible={this.props.alertOpen} msg={alertMessage} />

--- a/ui/pages/routes/routes.container.js
+++ b/ui/pages/routes/routes.container.js
@@ -2,17 +2,13 @@ import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
 import { compose } from 'redux';
 import {
-  getAllAccountsOnNetworkAreEmpty,
-  getIsNetworkUsed,
   getNetworkIdentifier,
   getPreferences,
   isNetworkLoading,
   getTheme,
-  getIsTestnet,
-  getCurrentChainId,
+  getShouldShowNewNetworkInfo,
   getShouldShowSeedPhraseReminder,
   getShowPortfolioTooltip,
-  isCurrentProviderCustom,
 } from '../../selectors';
 import {
   lockMetamask,
@@ -48,15 +44,11 @@ function mapStateToProps(state) {
     providerType: state.metamask.provider?.type,
     theme: getTheme(state),
     sendStage: getSendStage(state),
-    isNetworkUsed: getIsNetworkUsed(state),
-    allAccountsOnNetworkAreEmpty: getAllAccountsOnNetworkAreEmpty(state),
-    isTestNet: getIsTestnet(state),
-    currentChainId: getCurrentChainId(state),
     shouldShowSeedPhraseReminder: getShouldShowSeedPhraseReminder(state),
     portfolioTooltipIsBeingShown: getShowPortfolioTooltip(state),
     forgottenPassword: state.metamask.forgottenPassword,
-    isCurrentProviderCustom: isCurrentProviderCustom(state),
     completedOnboarding,
+    shouldShowNewNetworkInfo: getShouldShowNewNetworkInfo(state),
   };
 }
 

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -1401,6 +1401,22 @@ export function getShouldShowSeedPhraseReminder(state) {
   );
 }
 
+export function getShouldShowNewNetworkInfo(state) {
+  const { isUnlocked, provider, completedOnboarding } = state.metamask;
+  const { chainId } = provider;
+  const isTestNet = TEST_CHAINS.includes(chainId);
+
+  return (
+    isUnlocked &&
+    chainId &&
+    !isTestNet &&
+    !getIsNetworkUsed(state) &&
+    !isCurrentProviderCustom(state) &&
+    completedOnboarding &&
+    getAllAccountsOnNetworkAreEmpty(state)
+  );
+}
+
 export function getCustomTokenAmount(state) {
   return state.appState.customTokenAmount;
 }


### PR DESCRIPTION
## Explanation

<!--
Thanks for the pull request. Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues, Slack conversations, Zendesk issues, user stories, etc. reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->



The portfolio tooltip had a higher z index than the popover component. It caused the tooltip to be over popover. We use the external `react-tippy` package which has zIndex: 9999 and it can't be changed. 

~~This PR will set zIndex of all popovers on the home page to 10000.~~

This PR will show portfolio tooltip only if there is no popover acitve




* Fixes #17398

## Screenshots/Screencaps

<!-- If you're making a change to the UI, make sure to capture a screenshot or a short video showing off your work! -->

### Before

<!-- How did the UI you changed look before your changes? Drag your file(s) below this line: -->

![image](https://user-images.githubusercontent.com/97883527/215043255-79d91575-007d-4692-b297-f1a94108c7e2.png)
![image](https://user-images.githubusercontent.com/97883527/215043283-c80d451d-5ae9-4176-9e21-11c93e0b2563.png)


### After

<!-- How does it look now? Drag your file(s) below this line: -->
<img width="388" alt="image" src="https://user-images.githubusercontent.com/97883527/215043837-76642f2a-d730-48b8-85d0-661b229adcdb.png">

<img width="388" alt="image" src="https://user-images.githubusercontent.com/97883527/215043774-6ff69b2e-1a17-457d-a386-ff9e9cf9235e.png">


## Manual Testing Steps

<!--
How should reviewers and QA manually test your changes? For instance:

- Go to this screen
- Do this
- Then do this
-->
Scenario 1:

Login
Click the ellipsis menu
Select account details
Scenario 2:

Login
Close the extension
Switch networks
Open the popup

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
