### PR TITLE
Document `displayWarning` as deprecated

### DIFF
--- a/ui/store/actions.js
+++ b/ui/store/actions.js
@@ -2358,6 +2358,16 @@ export function hideLoadingIndication() {
   };
 }
 
+/**
+ * An action creator for display a warning to the user in various places in the
+ * UI. It will not be cleared until a new warning replaces it or `hideWarning`
+ * is called.
+ *
+ * @deprecated This way of displaying a warning is confusing for users and
+ * should no longer be used.
+ * @param {string} text - The warning text to show.
+ * @returns The action to display the warning.
+ */
 export function displayWarning(text) {
   return {
     type: actionConstants.DISPLAY_WARNING,


### PR DESCRIPTION
The `displayWarning` action creator will show the error in various different places in the UI. This is confusing for users, we should stop doing this.

Instead we can consider each error case separately. If there is a scenario where it's appropriate to tell a user about an error, we should build that case into the relevant UI and use localized error messages.

## Manual Testing Steps

No functional changes, just inline docs.

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
