### PR TITLE
GasDisplay: fix z-index for Confirm Approve warning

### DIFF
--- a/ui/pages/send/gas-display/index.scss
+++ b/ui/pages/send/gas-display/index.scss
@@ -47,7 +47,8 @@
         padding: 0 32px 16px 16px;
         position: fixed;
         bottom: 80px;
-        z-index: 1;
+        // Set z-index above ".send-v2__hex-data__input". This should be a temp fix. TODO: Refactor z-indexes
+        z-index: 1026;
       }
     }
   }

--- a/ui/pages/send/gas-display/index.scss
+++ b/ui/pages/send/gas-display/index.scss
@@ -47,7 +47,9 @@
         padding: 0 32px 16px 16px;
         position: fixed;
         bottom: 80px;
-        // Set z-index above ".send-v2__hex-data__input". This should be a temp fix. TODO: Refactor z-indexes
+        // We set z-index above ".send-v2__hex-data__input" by 1 index. ".send-v2__hex-data__input"
+        // was set to `z-index: 1025;` 4 years ago from the time of this comment. This should be a temp fix.
+        // TODO: Refactor z-indexes
         z-index: 1026;
       }
     }


### PR DESCRIPTION
## Explanation

Fix Confirm Approval warning z-index. Quick fix for now since updating the related z-indexes would be a larger refactor. This PR sets the z-index for the warning dialog 1 value higher than the ".send-v2__hex-data__input" z-index of 1025 which was set 4 years ago. 

## Screenshots/Screencaps

<!-- If you're making a change to the UI, make sure to capture a screenshot or a short video showing off your work! -->

### Before

<img width="408" alt="Screen Shot 2023-01-27 at 11 28 48 PM" src="https://user-images.githubusercontent.com/20778143/215148615-3cf7c224-dae1-43fa-9b58-3a2cab0c4012.png">


### After
<img width="406" alt="Screen Shot 2023-01-28 at 12 03 05 AM" src="https://user-images.githubusercontent.com/20778143/215148771-0b0a3829-be1e-4d00-a98d-7a1eb0c684bb.png">

<!-- How does it look now? Drag your file(s) below this line: -->

## Manual Testing Steps

<!--
How should reviewers and QA manually test your changes? For instance:

- Go to this screen
- Do this
- Then do this
-->

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [x] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
