### PR TITLE
prefer locale slice for locale state

### DIFF
--- a/ui/components/app/whats-new-popup/whats-new-popup.js
+++ b/ui/components/app/whats-new-popup/whats-new-popup.js
@@ -3,7 +3,7 @@ import { useHistory } from 'react-router-dom';
 import { useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
-import { getCurrentLocale } from '../../../ducks/metamask/metamask';
+import { getCurrentLocale } from '../../../ducks/locale/locale';
 import { I18nContext } from '../../../contexts/i18n';
 import { useEqualityCheck } from '../../../hooks/useEqualityCheck';
 import Button from '../../ui/button';

--- a/ui/ducks/metamask/metamask.js
+++ b/ui/ducks/metamask/metamask.js
@@ -154,12 +154,6 @@ export default function reduceMetamask(state = {}, action) {
         welcomeScreenSeen: true,
       };
 
-    case actionConstants.SET_CURRENT_LOCALE:
-      return {
-        ...metamaskState,
-        currentLocale: action.value.locale,
-      };
-
     case actionConstants.SET_PENDING_TOKENS:
       return {
         ...metamaskState,
@@ -249,8 +243,6 @@ export function updateGasFees({
 }
 
 // Selectors
-
-export const getCurrentLocale = (state) => state.metamask.currentLocale;
 
 export const getAlertEnabledness = (state) => state.metamask.alertEnabledness;
 

--- a/ui/ducks/metamask/metamask.test.js
+++ b/ui/ducks/metamask/metamask.test.js
@@ -248,18 +248,6 @@ describe('MetaMask Reducers', () => {
     expect(state.welcomeScreenSeen).toStrictEqual(true);
   });
 
-  it('sets current locale', () => {
-    const state = reduceMetamask(
-      {},
-      {
-        type: actionConstants.SET_CURRENT_LOCALE,
-        value: { locale: 'ge' },
-      },
-    );
-
-    expect(state.currentLocale).toStrictEqual('ge');
-  });
-
   it('sets pending tokens', () => {
     const payload = {
       address: '0x617b3f8050a0bd94b6b1da02b4384ee5b4df13f4',

--- a/ui/pages/onboarding-flow/onboarding-app-header/onboarding-app-header.js
+++ b/ui/pages/onboarding-flow/onboarding-app-header/onboarding-app-header.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import MetaFoxLogo from '../../../components/ui/metafox-logo';
 import Dropdown from '../../../components/ui/dropdown';
-import { getCurrentLocale } from '../../../ducks/metamask/metamask';
+import { getCurrentLocale } from '../../../ducks/locale/locale';
 import { updateCurrentLocale } from '../../../store/actions';
 import locales from '../../../../app/_locales/index.json';
 

--- a/ui/pages/onboarding-flow/onboarding-flow.test.js
+++ b/ui/pages/onboarding-flow/onboarding-flow.test.js
@@ -37,6 +37,9 @@ describe('Onboarding Flow', () => {
     metamask: {
       identities: {},
     },
+    localeMessages: {
+      currentLocale: 'en',
+    },
   };
 
   const store = configureMockStore()(mockState);

--- a/ui/pages/onboarding-flow/secure-your-wallet/secure-your-wallet.js
+++ b/ui/pages/onboarding-flow/secure-your-wallet/secure-your-wallet.js
@@ -18,7 +18,7 @@ import {
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import { MetaMetricsContext } from '../../../contexts/metametrics';
 import { ONBOARDING_REVIEW_SRP_ROUTE } from '../../../helpers/constants/routes';
-import { getCurrentLocale } from '../../../ducks/metamask/metamask';
+import { getCurrentLocale } from '../../../ducks/locale/locale';
 import { EVENT_NAMES, EVENT } from '../../../../shared/constants/metametrics';
 import SkipSRPBackup from './skip-srp-backup-popover';
 

--- a/ui/pages/onboarding-flow/secure-your-wallet/secure-your-wallet.test.js
+++ b/ui/pages/onboarding-flow/secure-your-wallet/secure-your-wallet.test.js
@@ -28,6 +28,9 @@ describe('Secure Your Wallet Onboarding View', () => {
         type: 'test',
       },
     },
+    localeMessages: {
+      currentLocale: 'en',
+    },
   };
 
   const store = configureMockStore([thunk])(mockStore);


### PR DESCRIPTION
## Explanation
The action constant "SET_CURRENT_LOCALE" was being handled in two separate places, first the 'metamask' slice and secondly the 'locale' slice. The I18N context consumes locale data from the locale slice and is the most correct place for this data, but we have selectors for both and some files used one versus the other. This eliminates the duplication of the selector and action handler in metamask slice and consolidates on using the one from the locale slice.

## Manual Testing Steps
1. In the flows that were modified, primarily onboarding, ensure that localization works. 

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
