### PR TITLE
Adjust 'Confirm' button color on setApprovalForAll revocations

### DIFF
--- a/ui/components/app/confirm-page-container/confirm-page-container.component.js
+++ b/ui/components/app/confirm-page-container/confirm-page-container.component.js
@@ -277,7 +277,11 @@ const ConfirmPageContainer = (props) => {
                 : onSubmit
             }
             submitText={t('confirm')}
-            submitButtonType={isSetApproveForAll ? 'danger-primary' : 'primary'}
+            submitButtonType={
+              isSetApproveForAll && isApprovalOrRejection
+                ? 'danger-primary'
+                : 'primary'
+            }
             disabled={disabled}
           >
             {unapprovedTxCount > 1 && (


### PR DESCRIPTION
Fixes: https://github.com/MetaMask/metamask-extension/issues/17466

### Before
![Screenshot 2023-01-27 at 12 55 23](https://user-images.githubusercontent.com/34968356/215130175-fe292347-858d-4688-ab52-2dbc884961db.png)

### After
<img width="373" alt="Screen Shot 2023-01-31 at 3 33 51 AM" src="https://user-images.githubusercontent.com/8732757/215746145-b89ef463-c511-4193-831e-0ab5c2cf1306.png">
<img width="359" alt="Screen Shot 2023-01-31 at 3 34 11 AM" src="https://user-images.githubusercontent.com/8732757/215746151-378df38b-bd8a-4b81-ad84-5132eefbfe0b.png">

## Manual Testing Steps
1. Go to https://etherscan.io/address/0xbc4ca0eda7647a8ab7c2061c2e118a18a936f13d#writeContract
2. Connect your wallet
3. Go to setApprovalForAll
4. Input any address and `false` for the approved(bool) parameter
5. Click write
6. Ensure the confirm button shows up as blue

## Pre-merge author checklist

- [X] I've clearly explained:
  - [X] What problem this PR is solving
  - [X] How this problem was solved
  - [X] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
