### PR TITLE
Edit Token Transfer displays mixed info with regular Send Tx (ETH)

### DIFF
--- a/ui/pages/send/send-content/send-asset-row/send-asset-row.component.js
+++ b/ui/pages/send/send-content/send-asset-row/send-asset-row.component.js
@@ -150,6 +150,9 @@ export default class SendAssetRow extends Component {
       if (token) {
         return this.renderToken(token);
       }
+
+      // if token is not found in tokens list, render the details
+      return this.renderToken(details);
     } else if (type === AssetType.NFT) {
       const collectible = collectibles.find(
         ({ address, tokenId }) =>

--- a/ui/pages/send/send-content/send-asset-row/send-asset-row.component.js
+++ b/ui/pages/send/send-content/send-asset-row/send-asset-row.component.js
@@ -150,8 +150,6 @@ export default class SendAssetRow extends Component {
       if (token) {
         return this.renderToken(token);
       }
-
-      // if token is not found in tokens list, render the details
       return this.renderToken(details);
     } else if (type === AssetType.NFT) {
       const collectible = collectibles.find(


### PR DESCRIPTION
## Explanation

When you start a token transfer from a dapp and click edit, if the token is already added to MM, you will see the token name, but if the token is not added to MM, it will default to showing the native currency. 

This PR addresses this issue

Fixes: #15362

## Screenshots/Screencaps

### Before

[<!-- How did the UI you changed look before your changes? Drag your file(s) below this line: -->](https://user-images.githubusercontent.com/54408225/181301057-c8bdd7a5-a210-4156-8e92-d3ad2388c064.mp4)

### After

[<!-- How does it look now? Drag your file(s) below this line: -->](https://user-images.githubusercontent.com/44811/214638103-c41c8bfa-2c1b-4f31-bd9b-597d2edeadb7.mov)

## Manual Testing Steps

1. On develop branch, launch MM
2. Create a token using Open Zeppelin Wizard and Remix (https://docs.openzeppelin.com/contracts/4.x/wizard)
3. Compile and deploy the token
4. Initiate a transfer
5. Click on edit, you should see the Asset Name is showing Native Token
6. Check out this branch
7. Repeat steps 1-4
8. Click on edit, you should see Asset Name is showing the correct token name

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
