### PR TITLE
Move THEME_TYPE to new preferences.ts file

### DIFF
--- a/app/scripts/controllers/preferences.js
+++ b/app/scripts/controllers/preferences.js
@@ -3,7 +3,7 @@ import { normalize as normalizeAddress } from 'eth-sig-util';
 import { IPFS_DEFAULT_GATEWAY_URL } from '../../../shared/constants/network';
 import { isPrefixedFormattedHexString } from '../../../shared/modules/network.utils';
 import { LedgerTransportTypes } from '../../../shared/constants/hardware-wallets';
-import { THEME_TYPE } from '../../../ui/pages/settings/settings-tab/settings-tab.constant';
+import { ThemeType } from '../../../shared/constants/preferences';
 import { NETWORK_EVENTS } from './network';
 
 export default class PreferencesController {
@@ -66,7 +66,7 @@ export default class PreferencesController {
         ? LedgerTransportTypes.webhid
         : LedgerTransportTypes.u2f,
       transactionSecurityCheckEnabled: false,
-      theme: THEME_TYPE.OS,
+      theme: ThemeType.os,
       ...opts.initState,
     };
 

--- a/shared/constants/preferences.ts
+++ b/shared/constants/preferences.ts
@@ -1,0 +1,5 @@
+export enum ThemeType {
+  light = 'light',
+  dark = 'dark',
+  os = 'os',
+}

--- a/ui/pages/routes/routes.component.js
+++ b/ui/pages/routes/routes.component.js
@@ -77,9 +77,9 @@ import ConfirmationPage from '../confirmation';
 import OnboardingFlow from '../onboarding-flow/onboarding-flow';
 import QRHardwarePopover from '../../components/app/qr-hardware-popover';
 import { SEND_STAGES } from '../../ducks/send';
-import { THEME_TYPE } from '../settings/settings-tab/settings-tab.constant';
 import DeprecatedTestNetworks from '../../components/ui/deprecated-test-networks/deprecated-test-networks';
 import NewNetworkInfo from '../../components/ui/new-network-info/new-network-info';
+import { ThemeType } from '../../../shared/constants/preferences';
 
 export default class Routes extends Component {
   static propTypes = {
@@ -125,8 +125,8 @@ export default class Routes extends Component {
 
   handleOsTheme() {
     const osTheme = window?.matchMedia('(prefers-color-scheme: dark)')?.matches
-      ? THEME_TYPE.DARK
-      : THEME_TYPE.LIGHT;
+      ? ThemeType.dark
+      : ThemeType.light;
 
     document.documentElement.setAttribute('data-theme', osTheme);
   }
@@ -135,7 +135,7 @@ export default class Routes extends Component {
     const { theme } = this.props;
 
     if (theme !== prevProps.theme) {
-      if (theme === THEME_TYPE.OS) {
+      if (theme === ThemeType.OS) {
         this.handleOsTheme();
       } else {
         document.documentElement.setAttribute('data-theme', theme);
@@ -160,7 +160,7 @@ export default class Routes extends Component {
         pageChanged(locationObj.pathname);
       }
     });
-    if (theme === THEME_TYPE.OS) {
+    if (theme === ThemeType.os) {
       this.handleOsTheme();
     } else {
       document.documentElement.setAttribute('data-theme', theme);

--- a/ui/pages/settings/settings-tab/settings-tab.component.js
+++ b/ui/pages/settings/settings-tab/settings-tab.component.js
@@ -15,7 +15,7 @@ import {
   getNumberOfSettingsInSection,
   handleSettingsRefs,
 } from '../../../helpers/utils/settings-search';
-import { THEME_TYPE } from './settings-tab.constant';
+import { ThemeType } from '../../../../shared/constants/preferences';
 
 const sortedCurrencies = availableCurrencies.sort((a, b) => {
   return a.name.toLocaleLowerCase().localeCompare(b.name.toLocaleLowerCase());
@@ -336,15 +336,15 @@ export default class SettingsTab extends PureComponent {
     const themesOptions = [
       {
         name: t('lightTheme'),
-        value: THEME_TYPE.LIGHT,
+        value: ThemeType.light,
       },
       {
         name: t('darkTheme'),
-        value: THEME_TYPE.DARK,
+        value: ThemeType.dark,
       },
       {
         name: t('osTheme'),
-        value: THEME_TYPE.OS,
+        value: ThemeType.os,
       },
     ];
 

--- a/ui/pages/settings/settings-tab/settings-tab.constant.js
+++ b/ui/pages/settings/settings-tab/settings-tab.constant.js
@@ -1,5 +1,0 @@
-export const THEME_TYPE = {
-  LIGHT: 'light',
-  DARK: 'dark',
-  OS: 'os',
-};


### PR DESCRIPTION
## Explanation
Lifts the THEME_TYPE enum from the setings page to the shared folder (the background folder was importing from the ui folder which is something we should avoid) and renamed to ThemeType in TypeScript.

## Manual Testing Steps
1. Ensure that the settings page still allows proper selection of themes.

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [x] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
