### PR TITLE
Update SES Version - Vulnerability Fix

### DIFF
--- a/app/scripts/lockdown-run.js
+++ b/app/scripts/lockdown-run.js
@@ -6,6 +6,7 @@ try {
     errorTaming: 'unsafe',
     mathTaming: 'unsafe',
     dateTaming: 'unsafe',
+    domainTaming: 'unsafe',
     overrideTaming: 'severe',
   });
 } catch (error) {

--- a/package.json
+++ b/package.json
@@ -349,7 +349,7 @@
     "redux-thunk": "^2.3.0",
     "remove-trailing-slash": "^0.1.1",
     "reselect": "^3.0.1",
-    "ses": "^0.12.4",
+    "ses": "^0.18.4",
     "single-call-balance-checker-abi": "^1.0.0",
     "unicode-confusables": "^0.1.1",
     "uuid": "^8.3.2",

--- a/test/helpers/protect-intrinsics-helpers.js
+++ b/test/helpers/protect-intrinsics-helpers.js
@@ -13,14 +13,10 @@ module.exports = {
 function getGlobalProperties() {
   const comp = new Compartment().globalThis;
 
-  // These are Agoric inventions, and we don't care about them.
   const ignoreList = new Set([
     'Compartment',
-    'HandledPromise',
-    'StaticModuleRecord',
     ...Object.getOwnPropertySymbols(comp),
   ]);
-
   const namedIntrinsics = Reflect.ownKeys(comp);
 
   return new Set(

--- a/test/unit-global/protect-intrinsics.test.js
+++ b/test/unit-global/protect-intrinsics.test.js
@@ -1,4 +1,4 @@
-import 'ses/lockdown';
+import 'ses/dist/lockdown';
 import '../../app/scripts/lockdown-run';
 import '../../app/scripts/lockdown-more';
 import {

--- a/test/unit-global/protect-intrinsics.test.js
+++ b/test/unit-global/protect-intrinsics.test.js
@@ -1,4 +1,4 @@
-import 'ses/dist/lockdown';
+import 'ses';
 import '../../app/scripts/lockdown-run';
 import '../../app/scripts/lockdown-more';
 import {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,27 +5,6 @@ __metadata:
   version: 6
   cacheKey: 8
 
-"@agoric/babel-standalone@npm:^7.9.5":
-  version: 7.9.5
-  resolution: "@agoric/babel-standalone@npm:7.9.5"
-  checksum: 19c459bc5cb723b1fd0e18a2a39a1f5302554991de05ac28f261bb59314a07b6477768f58c64c8104121a0278596fc29fda2651dcefd2c6678adc811085511eb
-  languageName: node
-  linkType: hard
-
-"@agoric/make-hardener@npm:^0.1.2":
-  version: 0.1.3
-  resolution: "@agoric/make-hardener@npm:0.1.3"
-  checksum: d96ece30734558ad661bfc907b9b101f457df475e1ef83267d8068afe690acb2e12ce4d266124043dc22c61a7f8a3529f4a30d775981d18a6f0e012af5da3262
-  languageName: node
-  linkType: hard
-
-"@agoric/transform-module@npm:^0.4.1":
-  version: 0.4.1
-  resolution: "@agoric/transform-module@npm:0.4.1"
-  checksum: 36bf78c95d1f0f4bb64d3d8d32bb517591334dcc04f8428d493032275e5d070824fe23950345fe941641b2b1938bf175e78dbebd1f350ac157ec4e8787c1b4ec
-  languageName: node
-  linkType: hard
-
 "@ampproject/remapping@npm:^2.1.0":
   version: 2.2.0
   resolution: "@ampproject/remapping@npm:2.2.0"
@@ -24095,7 +24074,7 @@ __metadata:
     selenium-webdriver: ^4.3.1
     semver: ^7.3.5
     serve-handler: ^6.1.2
-    ses: ^0.12.4
+    ses: ^0.18.4
     single-call-balance-checker-abi: ^1.0.0
     sinon: ^9.0.0
     source-map: ^0.7.2
@@ -30424,21 +30403,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ses@npm:^0.12.4":
-  version: 0.12.4
-  resolution: "ses@npm:0.12.4"
-  dependencies:
-    "@agoric/babel-standalone": ^7.9.5
-    "@agoric/make-hardener": ^0.1.2
-    "@agoric/transform-module": ^0.4.1
-  checksum: 51482dfb7c7ee9ac6199cca1a93d990875eebceb32f9369375d4dcff4e3298ac0605e896cf345b07a8685fa52dd3d03b7fb0d8c89c01072f2b657ac5372b51a9
-  languageName: node
-  linkType: hard
-
-"ses@npm:^0.18.1":
-  version: 0.18.1
-  resolution: "ses@npm:0.18.1"
-  checksum: 70ad6918da240833d445434e324f7ec29b1b7efc44ce8c0d75c5521cc1629810397903aec8e9adfe65d1486a19ac715c5254501e25de8925ae58c9f7f582dd76
+"ses@npm:^0.18.1, ses@npm:^0.18.4":
+  version: 0.18.4
+  resolution: "ses@npm:0.18.4"
+  checksum: 9afd6edcf390a693926ef728ebb5a435994bbb0f915009ad524c6588cf62e2f66f6d4b4b2694f093b2af2e92c003947ad55404750d756ba75ce70c8636a7ba02
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Explanation

* Vulnerability has been found recently with `SES<0.16.0` - https://github.com/advisories/GHSA-whpx-q3rq-w8jc
*  Vulnerable versions of the packages are currently loaded in via 
  a) directly via the project's workspace and 
  b) via `@metamask/phishing-warning`
* Package changelog: https://github.com/endojs/endo/blob/master/packages/ses/CHANGELOG.md

## Manual Testing Steps
* `yarn && yarn start`
* Open a URL within the `@metamask/phishing-warning` blocked-list to ensure that the plugin is working as intended
  * Example: https://thekrakenz.com/
* Open the extension in tab form, inspect to see that `lockdown-install.js` is still loaded - i.e., the SES code is still loaded
  * https://gyazo.com/9de8e66a6de39f1a6d9bef02f6b336c7

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
