### PR TITLE
UX: Update fa-search icon

### DIFF
--- a/ui/pages/send/send-content/add-recipient/domain-input.component.js
+++ b/ui/pages/send/send-content/add-recipient/domain-input.component.js
@@ -10,6 +10,7 @@ import {
 } from '../../../../../shared/modules/hexstring-utils';
 import {
   ButtonIcon,
+  Icon,
   ICON_NAMES,
 } from '../../../../components/component-library';
 import { IconColor } from '../../../../helpers/constants/design-system';
@@ -102,17 +103,18 @@ export default class DomainInput extends Component {
             'ens-input__wrapper--valid': hasSelectedAddress,
           })}
         >
-          <i
-            className={classnames('ens-input__wrapper__status-icon', 'fa', {
-              'fa-check-circle': hasSelectedAddress,
-              'fa-search': !hasSelectedAddress,
-            })}
-            style={{
-              color: hasSelectedAddress
-                ? 'var(--color-success-default)'
-                : 'var(--color-icon-muted)',
-            }}
-          />
+          {hasSelectedAddress ? (
+            <i
+              className="ens-input__wrapper__status-icon fa fa-check-circle"
+              style={{ color: 'var(--color-success-default)' }}
+            />
+          ) : (
+            <Icon
+              name={ICON_NAMES.SEARCH}
+              color={IconColor.iconMuted}
+              className="ens-input__wrapper__status-icon"
+            />
+          )}
           {hasSelectedAddress ? (
             <>
               <div className="ens-input__wrapper__input ens-input__wrapper__input--selected">


### PR DESCRIPTION
## Explanation

`fa-search` appears only once in our codebase, so I've swapped it out.

## Screenshots/Screencaps

<img width="601" alt="search-icon" src="https://user-images.githubusercontent.com/46655/215887830-c5247abc-b4e7-4f0c-9d86-1777ad50fef1.png">


## Pre-merge author checklist

- [ ] I've clearly explained:
  - [ ] What problem this PR is solving
  - [ ] How this problem was solved
  - [ ] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
