### PR TITLE
NFTs: Remove nft toaster on first autohide

### DIFF
--- a/ui/pages/home/home.component.js
+++ b/ui/pages/home/home.component.js
@@ -278,7 +278,11 @@ export default class Home extends PureComponent {
       setRpcTarget,
     } = this.props;
 
-    const onAutoHide = () => setNewCollectibleAddedMessage('');
+    const onAutoHide = () => {
+      setNewCollectibleAddedMessage('');
+      setRemoveCollectibleMessage('');
+    };
+
     const autoHideDelay = 5 * SECOND;
 
     return (
@@ -363,7 +367,7 @@ export default class Home extends PureComponent {
                 <button
                   className="fas fa-times home__new-nft-notification-close"
                   title={t('close')}
-                  onClick={() => setRemoveCollectibleMessage('')}
+                  onClick={onAutoHide}
                 />
               </Box>
             }


### PR DESCRIPTION
Fixes #17534 

In the current behavior, the autohide removes the toaster notification on the home screen but it still persists in the state and as a result, it appears each time when we go back to the home screen. This PR is to fix this behavior so that the toaster notification should go away on autohide from the home screen. 

### After

https://user-images.githubusercontent.com/39872794/216039636-87f582e5-fa32-4f52-8ceb-f74939aae85b.mov


### Steps to reproduce

1. Open an NFT detail page, click "Remove NFT" to remove it.
2. When redirected to the homepage, wait for the "Collectible was successfully removed" toaster to disappear.
3. Open settings page and close.
4. Check that the remove NFT toaster does not appear again on homepage. 


## Pre-Merge Checklist

- [x] PR template is filled out
- [ ] **IF** this PR fixes a bug, a test that _would have_ caught the bug has been added
- [x] PR is linked to the appropriate GitHub issue
- [x] PR has been added to the appropriate release Milestone

### + If there are functional changes:

- [x] Manual testing complete & passed
- [x] "Extension QA Board" label has been applied


