### PR TITLE
Replaced all fa-icon-circle with INFO icon

### DIFF
--- a/ui/components/app/advanced-gas-inputs/advanced-gas-inputs.component.js
+++ b/ui/components/app/advanced-gas-inputs/advanced-gas-inputs.component.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { debounce } from 'lodash';
 import Tooltip from '../../ui/tooltip';
+import { Icon, ICON_NAMES } from '../../component-library';
 
 export default class AdvancedGasInputs extends Component {
   static contextTypes = {
@@ -138,7 +139,7 @@ export default class AdvancedGasInputs extends Component {
         <div className="advanced-gas-inputs__gas-edit-row__label">
           {label}
           <Tooltip title={tooltipTitle} position="top" arrow>
-            <i className="fa fa-info-circle" />
+            <Icon name={ICON_NAMES.INFO} />
           </Tooltip>
         </div>
         <div className="advanced-gas-inputs__gas-edit-row__input-wrapper">

--- a/ui/components/app/advanced-gas-inputs/advanced-gas-inputs.component.js
+++ b/ui/components/app/advanced-gas-inputs/advanced-gas-inputs.component.js
@@ -4,7 +4,7 @@ import classnames from 'classnames';
 import { debounce } from 'lodash';
 import Tooltip from '../../ui/tooltip';
 import { Icon, ICON_NAMES } from '../../component-library';
-import { IconColor } from 'ui/helpers/constants/design-system';
+import { IconColor } from '../../../helpers/constants/design-system';
 
 export default class AdvancedGasInputs extends Component {
   static contextTypes = {

--- a/ui/components/app/advanced-gas-inputs/advanced-gas-inputs.component.js
+++ b/ui/components/app/advanced-gas-inputs/advanced-gas-inputs.component.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { debounce } from 'lodash';
 import Tooltip from '../../ui/tooltip';
-import { Icon, ICON_NAMES } from '../../component-library';
+import { Icon, IconName } from '../../component-library';
 import { IconColor } from '../../../helpers/constants/design-system';
 
 export default class AdvancedGasInputs extends Component {
@@ -141,7 +141,7 @@ export default class AdvancedGasInputs extends Component {
           {label}
           <Tooltip title={tooltipTitle} position="top" arrow>
             <Icon
-              name={ICON_NAMES.INFO}
+              name={IconName.Info}
               color={IconColor.iconAlternative}
               className="info-circle"
             />

--- a/ui/components/app/advanced-gas-inputs/advanced-gas-inputs.component.js
+++ b/ui/components/app/advanced-gas-inputs/advanced-gas-inputs.component.js
@@ -4,6 +4,7 @@ import classnames from 'classnames';
 import { debounce } from 'lodash';
 import Tooltip from '../../ui/tooltip';
 import { Icon, ICON_NAMES } from '../../component-library';
+import { IconColor } from 'ui/helpers/constants/design-system';
 
 export default class AdvancedGasInputs extends Component {
   static contextTypes = {
@@ -139,7 +140,11 @@ export default class AdvancedGasInputs extends Component {
         <div className="advanced-gas-inputs__gas-edit-row__label">
           {label}
           <Tooltip title={tooltipTitle} position="top" arrow>
-            <Icon name={ICON_NAMES.INFO} />
+            <Icon
+              name={ICON_NAMES.INFO}
+              color={IconColor.iconAlternative}
+              className="info-circle"
+            />
           </Tooltip>
         </div>
         <div className="advanced-gas-inputs__gas-edit-row__input-wrapper">

--- a/ui/components/app/advanced-gas-inputs/index.scss
+++ b/ui/components/app/advanced-gas-inputs/index.scss
@@ -22,12 +22,11 @@
         @include H8;
       }
 
-      .fa-info-circle {
-        color: var(--color-icon-alternative);
+      .info-circle {
         cursor: pointer;
       }
 
-      .fa-info-circle:hover {
+      .info-circle:hover {
         color: var(--color-icon-muted);
       }
     }

--- a/ui/components/app/alerts/unconnected-account-alert/unconnected-account-alert.js
+++ b/ui/components/app/alerts/unconnected-account-alert/unconnected-account-alert.js
@@ -69,7 +69,7 @@ const UnconnectedAccountAlert = () => {
               title={t('alertDisableTooltip')}
               wrapperClassName="unconnected-account-alert__checkbox-label-tooltip"
             >
-              <Icon name={ICON_NAMES.INFO} className="fa-info-circle" />
+              <Icon name={ICON_NAMES.INFO} />
             </Tooltip>
           </label>
         </div>

--- a/ui/components/app/alerts/unconnected-account-alert/unconnected-account-alert.js
+++ b/ui/components/app/alerts/unconnected-account-alert/unconnected-account-alert.js
@@ -22,7 +22,7 @@ import Checkbox from '../../../ui/check-box';
 import Tooltip from '../../../ui/tooltip';
 import ConnectedAccountsList from '../../connected-accounts-list';
 import { useI18nContext } from '../../../../hooks/useI18nContext';
-import { Icon, ICON_NAMES } from '../../../component-library';
+import { Icon, IconName } from '../../../component-library';
 
 const { ERROR, LOADING } = ALERT_STATE;
 
@@ -69,7 +69,7 @@ const UnconnectedAccountAlert = () => {
               title={t('alertDisableTooltip')}
               wrapperClassName="unconnected-account-alert__checkbox-label-tooltip"
             >
-              <Icon name={ICON_NAMES.INFO} />
+              <Icon name={IconName.Info} />
             </Tooltip>
           </label>
         </div>

--- a/ui/components/app/alerts/unconnected-account-alert/unconnected-account-alert.js
+++ b/ui/components/app/alerts/unconnected-account-alert/unconnected-account-alert.js
@@ -22,6 +22,7 @@ import Checkbox from '../../../ui/check-box';
 import Tooltip from '../../../ui/tooltip';
 import ConnectedAccountsList from '../../connected-accounts-list';
 import { useI18nContext } from '../../../../hooks/useI18nContext';
+import { Icon, ICON_NAMES } from '../../../component-library';
 
 const { ERROR, LOADING } = ALERT_STATE;
 
@@ -68,7 +69,7 @@ const UnconnectedAccountAlert = () => {
               title={t('alertDisableTooltip')}
               wrapperClassName="unconnected-account-alert__checkbox-label-tooltip"
             >
-              <i className="fa fa-info-circle" />
+              <Icon name={ICON_NAMES.INFO} className="fa-info-circle" />
             </Tooltip>
           </label>
         </div>

--- a/ui/components/app/confirm-gas-display/confirm-legacy-gas-display/confirm-legacy-gas-display.js
+++ b/ui/components/app/confirm-gas-display/confirm-legacy-gas-display/confirm-legacy-gas-display.js
@@ -26,6 +26,7 @@ import {
 import { useDraftTransactionGasValues } from '../../../../hooks/useDraftTransactionGasValues';
 import { getNativeCurrency } from '../../../../ducks/metamask/metamask';
 import MultilayerFeeMessage from '../../multilayer-fee-message/multi-layer-fee-message';
+import { Icon, IconName } from '../../../component-library';
 
 const renderHeartBeatIfNotInTest = () =>
   process.env.IN_TEST ? null : <LoadingHeartBeat />;
@@ -95,7 +96,7 @@ const ConfirmLegacyGasDisplay = () => {
               contentText={t('transactionDetailDappGasTooltip')}
               position="top"
             >
-              <i className="fa fa-info-circle" />
+              <Icon name={IconName.Info} />
             </InfoTooltip>
           </>
         ) : (
@@ -123,7 +124,7 @@ const ConfirmLegacyGasDisplay = () => {
               }
               position="top"
             >
-              <i className="fa fa-info-circle" />
+              <Icon name={IconName.Info} />
             </InfoTooltip>
           </>
         )

--- a/ui/components/app/confirm-page-container/confirm-page-container-content/confirm-page-container-warning/confirm-page-container-warning.component.js
+++ b/ui/components/app/confirm-page-container/confirm-page-container-content/confirm-page-container-warning/confirm-page-container-warning.component.js
@@ -1,10 +1,14 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { Icon, ICON_NAMES } from '../../../../component-library';
 
 const ConfirmPageContainerWarning = (props) => {
   return (
     <div className="confirm-page-container-warning">
-      <i className="fa fa-info-circle confirm-page-container-warning__icon" />
+      <Icon
+        name={ICON_NAMES.INFO}
+        className="confirm-page-container-warning__icon"
+      />
       <div className="confirm-page-container-warning__warning">
         {props.warning}
       </div>

--- a/ui/components/app/confirm-page-container/confirm-page-container-content/confirm-page-container-warning/confirm-page-container-warning.component.js
+++ b/ui/components/app/confirm-page-container/confirm-page-container-content/confirm-page-container-warning/confirm-page-container-warning.component.js
@@ -1,12 +1,14 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Icon, ICON_NAMES } from '../../../../component-library';
+import { IconColor } from '../../../../../helpers/constants/design-system';
 
 const ConfirmPageContainerWarning = (props) => {
   return (
     <div className="confirm-page-container-warning">
       <Icon
         name={ICON_NAMES.INFO}
+        color={IconColor.warningDefault}
         className="confirm-page-container-warning__icon"
       />
       <div className="confirm-page-container-warning__warning">

--- a/ui/components/app/confirm-page-container/confirm-page-container-content/confirm-page-container-warning/confirm-page-container-warning.component.js
+++ b/ui/components/app/confirm-page-container/confirm-page-container-content/confirm-page-container-warning/confirm-page-container-warning.component.js
@@ -1,13 +1,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Icon, ICON_NAMES } from '../../../../component-library';
+import { Icon, IconName } from '../../../../component-library';
 import { IconColor } from '../../../../../helpers/constants/design-system';
 
 const ConfirmPageContainerWarning = (props) => {
   return (
     <div className="confirm-page-container-warning">
       <Icon
-        name={ICON_NAMES.INFO}
+        name={IconName.Info}
         color={IconColor.warningDefault}
         className="confirm-page-container-warning__icon"
       />

--- a/ui/components/app/home-notification/home-notification.component.js
+++ b/ui/components/app/home-notification/home-notification.component.js
@@ -5,6 +5,7 @@ import Button from '../../ui/button';
 import Checkbox from '../../ui/check-box';
 import Tooltip from '../../ui/tooltip';
 import { Icon, ICON_NAMES } from '../../component-library';
+import { IconColor } from 'ui/helpers/constants/design-system';
 
 const HomeNotification = ({
   acceptText,
@@ -40,7 +41,7 @@ const HomeNotification = ({
             title={infoText}
             wrapperClassName="home-notification__tooltip-wrapper"
           >
-            <Icon name={ICON_NAMES.INFO} />
+            <Icon name={ICON_NAMES.INFO} color={IconColor.iconDefault} />
           </Tooltip>
         ) : null}
       </div>

--- a/ui/components/app/home-notification/home-notification.component.js
+++ b/ui/components/app/home-notification/home-notification.component.js
@@ -40,7 +40,7 @@ const HomeNotification = ({
             title={infoText}
             wrapperClassName="home-notification__tooltip-wrapper"
           >
-            <Icon name={ICON_NAMES.INFO} className="info-circle" />
+            <Icon name={ICON_NAMES.INFO} />
           </Tooltip>
         ) : null}
       </div>

--- a/ui/components/app/home-notification/home-notification.component.js
+++ b/ui/components/app/home-notification/home-notification.component.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import Button from '../../ui/button';
 import Checkbox from '../../ui/check-box';
 import Tooltip from '../../ui/tooltip';
+import { Icon, ICON_NAMES } from '../../component-library';
 
 const HomeNotification = ({
   acceptText,
@@ -39,7 +40,7 @@ const HomeNotification = ({
             title={infoText}
             wrapperClassName="home-notification__tooltip-wrapper"
           >
-            <i className="fa fa-info-circle" />
+            <Icon name={ICON_NAMES.INFO} className="info-circle" />
           </Tooltip>
         ) : null}
       </div>

--- a/ui/components/app/home-notification/home-notification.component.js
+++ b/ui/components/app/home-notification/home-notification.component.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import Button from '../../ui/button';
 import Checkbox from '../../ui/check-box';
 import Tooltip from '../../ui/tooltip';
-import { Icon, ICON_NAMES } from '../../component-library';
+import { Icon, IconName } from '../../component-library';
 import { IconColor } from '../../../helpers/constants/design-system';
 
 const HomeNotification = ({
@@ -41,7 +41,7 @@ const HomeNotification = ({
             title={infoText}
             wrapperClassName="home-notification__tooltip-wrapper"
           >
-            <Icon name={ICON_NAMES.INFO} color={IconColor.iconDefault} />
+            <Icon name={IconName.Info} color={IconColor.iconDefault} />
           </Tooltip>
         ) : null}
       </div>

--- a/ui/components/app/home-notification/home-notification.component.js
+++ b/ui/components/app/home-notification/home-notification.component.js
@@ -5,7 +5,7 @@ import Button from '../../ui/button';
 import Checkbox from '../../ui/check-box';
 import Tooltip from '../../ui/tooltip';
 import { Icon, ICON_NAMES } from '../../component-library';
-import { IconColor } from 'ui/helpers/constants/design-system';
+import { IconColor } from '../../../helpers/constants/design-system';
 
 const HomeNotification = ({
   acceptText,

--- a/ui/components/app/home-notification/index.scss
+++ b/ui/components/app/home-notification/index.scss
@@ -36,10 +36,6 @@
     cursor: pointer;
   }
 
-  .fa-info-circle {
-    color: var(--color-icon-default);
-  }
-
   &__checkbox-wrapper {
     display: flex;
     flex-direction: row;

--- a/ui/components/app/nfts-detection-notice/nfts-detection-notice.js
+++ b/ui/components/app/nfts-detection-notice/nfts-detection-notice.js
@@ -14,7 +14,7 @@ import {
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import Button from '../../ui/button';
 import { EXPERIMENTAL_ROUTE } from '../../../helpers/constants/routes';
-import { Icon, ICON_NAMES } from '../../component-library';
+import { Icon, IconName } from '../../component-library';
 
 export default function NftsDetectionNotice() {
   const t = useI18nContext();
@@ -26,7 +26,7 @@ export default function NftsDetectionNotice() {
         <Box display={DISPLAY.FLEX}>
           <Box paddingTop={1}>
             <Icon
-              name={ICON_NAMES.INFO}
+              name={IconName.Info}
               className="info-circle"
               color={IconColor.primaryDefault}
             />

--- a/ui/components/app/nfts-detection-notice/nfts-detection-notice.js
+++ b/ui/components/app/nfts-detection-notice/nfts-detection-notice.js
@@ -9,10 +9,12 @@ import {
   FONT_WEIGHT,
   DISPLAY,
   TextColor,
+  IconColor,
 } from '../../../helpers/constants/design-system';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import Button from '../../ui/button';
 import { EXPERIMENTAL_ROUTE } from '../../../helpers/constants/routes';
+import { Icon, ICON_NAMES } from '../../component-library';
 
 export default function NftsDetectionNotice() {
   const t = useI18nContext();
@@ -23,12 +25,10 @@ export default function NftsDetectionNotice() {
       <Dialog type="message" className="nfts-detection-notice__message">
         <Box display={DISPLAY.FLEX}>
           <Box paddingTop={1}>
-            <i
-              style={{
-                fontSize: '1rem',
-                color: 'var(--color-primary-default)',
-              }}
-              className="fa fa-info-circle"
+            <Icon
+              name={ICON_NAMES.INFO}
+              className="info-circle"
+              color={IconColor.primaryDefault}
             />
           </Box>
           <Box paddingLeft={2}>

--- a/ui/components/app/tab-bar/tab-bar.stories.js
+++ b/ui/components/app/tab-bar/tab-bar.stories.js
@@ -54,7 +54,7 @@ export default {
         key: 'experimental',
       },
       {
-        icon: <i className="fa fa-info-circle" />,
+        icon: <Icon name={ICON_NAMES.INFO} />,
         content: 'About',
         key: 'about',
       },

--- a/ui/components/app/tab-bar/tab-bar.stories.js
+++ b/ui/components/app/tab-bar/tab-bar.stories.js
@@ -54,7 +54,7 @@ export default {
         key: 'experimental',
       },
       {
-        icon: <Icon name={ICON_NAMES.INFO} />,
+        icon: <Icon name={IconName.Info} />,
         content: 'About',
         key: 'about',
       },

--- a/ui/components/app/transaction-decoding/components/ui/accreditation/accrediation.component.stories.js
+++ b/ui/components/app/transaction-decoding/components/ui/accreditation/accrediation.component.stories.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import Accreditation from './accreditation.component';
+
+export default {
+  title: 'Components/App/Accrediation', // title should follow the folder structure location of the component. Don't use spaces.
+
+  argTypes: {
+    fetchVia: {
+      control: 'string',
+    },
+    address: { control: 'string' },
+  },
+  args: {
+    address: '0x6b175474e89094c44da98b954eedeac495271d0f',
+  },
+};
+
+export const DefaultStory = (args) => <Accreditation {...args} />;
+
+DefaultStory.storyName = 'Default';

--- a/ui/components/app/transaction-decoding/components/ui/accreditation/accreditation.component.js
+++ b/ui/components/app/transaction-decoding/components/ui/accreditation/accreditation.component.js
@@ -12,6 +12,7 @@ import { TypographyVariant } from '../../../../../../helpers/constants/design-sy
 
 import Button from '../../../../../ui/button';
 import Typography from '../../../../../ui/typography';
+import { Icon, ICON_NAMES } from '../../../../../component-library';
 
 const Accreditation = ({ fetchVia, address }) => {
   const t = useContext(I18nContext);
@@ -55,7 +56,7 @@ const Accreditation = ({ fetchVia, address }) => {
   return (
     <div className="accreditation">
       <div className="accreditation__icon">
-        <i className="fa fa-info-circle" />
+        <Icon name={ICON_NAMES.INFO} className="info-circle" />
       </div>
       <div className="accreditation__info">
         <AccreditationLink />

--- a/ui/components/app/transaction-decoding/components/ui/accreditation/accreditation.component.js
+++ b/ui/components/app/transaction-decoding/components/ui/accreditation/accreditation.component.js
@@ -12,7 +12,7 @@ import { TypographyVariant } from '../../../../../../helpers/constants/design-sy
 
 import Button from '../../../../../ui/button';
 import Typography from '../../../../../ui/typography';
-import { Icon, ICON_NAMES } from '../../../../../component-library';
+import { Icon, IconName } from '../../../../../component-library';
 
 const Accreditation = ({ fetchVia, address }) => {
   const t = useContext(I18nContext);
@@ -56,7 +56,7 @@ const Accreditation = ({ fetchVia, address }) => {
   return (
     <div className="accreditation">
       <div className="accreditation__icon">
-        <Icon name={ICON_NAMES.INFO} />
+        <Icon name={IconName.Info} />
       </div>
       <div className="accreditation__info">
         <AccreditationLink />

--- a/ui/components/app/transaction-decoding/components/ui/accreditation/accreditation.component.js
+++ b/ui/components/app/transaction-decoding/components/ui/accreditation/accreditation.component.js
@@ -56,7 +56,7 @@ const Accreditation = ({ fetchVia, address }) => {
   return (
     <div className="accreditation">
       <div className="accreditation__icon">
-        <Icon name={ICON_NAMES.INFO} className="info-circle" />
+        <Icon name={ICON_NAMES.INFO} />
       </div>
       <div className="accreditation__info">
         <AccreditationLink />

--- a/ui/components/app/transaction-detail-item/transaction-detail-item.stories.js
+++ b/ui/components/app/transaction-detail-item/transaction-detail-item.stories.js
@@ -46,7 +46,7 @@ DefaultStory.args = {
     <>
       <strong>Estimated gas fee</strong>
       <InfoTooltip contentText="This is the tooltip text" position="top">
-        <Icon name={ICON_NAMES.INFO} className="info-circle" />
+        <Icon name={ICON_NAMES.INFO} />
       </InfoTooltip>
     </>
   ),

--- a/ui/components/app/transaction-detail-item/transaction-detail-item.stories.js
+++ b/ui/components/app/transaction-detail-item/transaction-detail-item.stories.js
@@ -3,7 +3,7 @@ import InfoTooltip from '../../ui/info-tooltip/info-tooltip';
 
 import { TextColor } from '../../../helpers/constants/design-system';
 
-import { Icon, ICON_NAMES } from '../../component-library';
+import { Icon, IconName } from '../../component-library';
 import README from './README.mdx';
 import TransactionDetailItem from '.';
 
@@ -46,7 +46,7 @@ DefaultStory.args = {
     <>
       <strong>Estimated gas fee</strong>
       <InfoTooltip contentText="This is the tooltip text" position="top">
-        <Icon name={ICON_NAMES.INFO} />
+        <Icon name={IconName.Info} />
       </InfoTooltip>
     </>
   ),

--- a/ui/components/app/transaction-detail-item/transaction-detail-item.stories.js
+++ b/ui/components/app/transaction-detail-item/transaction-detail-item.stories.js
@@ -3,6 +3,7 @@ import InfoTooltip from '../../ui/info-tooltip/info-tooltip';
 
 import { TextColor } from '../../../helpers/constants/design-system';
 
+import { Icon, ICON_NAMES } from '../../component-library';
 import README from './README.mdx';
 import TransactionDetailItem from '.';
 
@@ -45,7 +46,7 @@ DefaultStory.args = {
     <>
       <strong>Estimated gas fee</strong>
       <InfoTooltip contentText="This is the tooltip text" position="top">
-        <i className="fa fa-info-circle" />
+        <Icon name={ICON_NAMES.INFO} className="info-circle" />
       </InfoTooltip>
     </>
   ),

--- a/ui/components/app/transaction-detail/transaction-detail.stories.js
+++ b/ui/components/app/transaction-detail/transaction-detail.stories.js
@@ -28,7 +28,7 @@ const rows = [
       <>
         Estimated gas fee
         <InfoTooltip contentText="This is the tooltip text" position="top">
-          <Icon name={ICON_NAMES.INFO} className="info-circle" />
+          <Icon name={ICON_NAMES.INFO} />
         </InfoTooltip>
       </>
     }

--- a/ui/components/app/transaction-detail/transaction-detail.stories.js
+++ b/ui/components/app/transaction-detail/transaction-detail.stories.js
@@ -2,7 +2,7 @@ import React from 'react';
 import InfoTooltip from '../../ui/info-tooltip/info-tooltip';
 import TransactionDetailItem from '../transaction-detail-item/transaction-detail-item.component';
 import GasTiming from '../gas-timing/gas-timing.component';
-import { Icon, ICON_NAMES } from '../../component-library';
+import { Icon, IconName } from '../../component-library';
 import README from './README.mdx';
 import TransactionDetail from '.';
 
@@ -28,7 +28,7 @@ const rows = [
       <>
         Estimated gas fee
         <InfoTooltip contentText="This is the tooltip text" position="top">
-          <Icon name={ICON_NAMES.INFO} />
+          <Icon name={IconName.Info} />
         </InfoTooltip>
       </>
     }

--- a/ui/components/app/transaction-detail/transaction-detail.stories.js
+++ b/ui/components/app/transaction-detail/transaction-detail.stories.js
@@ -4,6 +4,7 @@ import TransactionDetailItem from '../transaction-detail-item/transaction-detail
 import GasTiming from '../gas-timing/gas-timing.component';
 import README from './README.mdx';
 import TransactionDetail from '.';
+import { Icon, ICON_NAMES } from 'ui/components/component-library';
 
 export default {
   title: 'Components/App/TransactionDetail',
@@ -27,7 +28,7 @@ const rows = [
       <>
         Estimated gas fee
         <InfoTooltip contentText="This is the tooltip text" position="top">
-          <i className="fa fa-info-circle" />
+          <Icon name={ICON_NAMES.INFO} className="info-circle" />
         </InfoTooltip>
       </>
     }

--- a/ui/components/app/transaction-detail/transaction-detail.stories.js
+++ b/ui/components/app/transaction-detail/transaction-detail.stories.js
@@ -2,9 +2,9 @@ import React from 'react';
 import InfoTooltip from '../../ui/info-tooltip/info-tooltip';
 import TransactionDetailItem from '../transaction-detail-item/transaction-detail-item.component';
 import GasTiming from '../gas-timing/gas-timing.component';
+import { Icon, ICON_NAMES } from '../../component-library';
 import README from './README.mdx';
 import TransactionDetail from '.';
-import { Icon, ICON_NAMES } from 'ui/components/component-library';
 
 export default {
   title: 'Components/App/TransactionDetail',

--- a/ui/components/ui/account-list/account-list.js
+++ b/ui/components/ui/account-list/account-list.js
@@ -8,6 +8,7 @@ import Identicon from '../identicon';
 import UserPreferencedCurrencyDisplay from '../../app/user-preferenced-currency-display';
 import { PRIMARY } from '../../../helpers/constants/common';
 import Tooltip from '../tooltip';
+import { Icon, ICON_NAMES } from '../../component-library';
 
 const AccountList = ({
   selectNewAccountViaModal,
@@ -61,7 +62,7 @@ const AccountList = ({
                 </div>
               }
             >
-              <i className="fa fa-info-circle" />
+              <Icon name={ICON_NAMES.INFO} />
             </Tooltip>
           </div>
         ) : null}
@@ -114,7 +115,7 @@ const AccountList = ({
                       addressLastConnectedMap[address]
                     }`}
                   >
-                    <i className="fa fa-info-circle" />
+                    <Icon name={ICON_NAMES.INFO} />
                   </Tooltip>
                 ) : null}
               </div>

--- a/ui/components/ui/account-list/account-list.js
+++ b/ui/components/ui/account-list/account-list.js
@@ -9,6 +9,7 @@ import UserPreferencedCurrencyDisplay from '../../app/user-preferenced-currency-
 import { PRIMARY } from '../../../helpers/constants/common';
 import Tooltip from '../tooltip';
 import { Icon, ICON_NAMES } from '../../component-library';
+import { IconColor } from 'ui/helpers/constants/design-system';
 
 const AccountList = ({
   selectNewAccountViaModal,
@@ -62,7 +63,11 @@ const AccountList = ({
                 </div>
               }
             >
-              <Icon name={ICON_NAMES.INFO} />
+              <Icon
+                name={ICON_NAMES.INFO}
+                color={IconColor.iconMuted}
+                className="info-circle"
+              />
             </Tooltip>
           </div>
         ) : null}
@@ -115,7 +120,11 @@ const AccountList = ({
                       addressLastConnectedMap[address]
                     }`}
                   >
-                    <Icon name={ICON_NAMES.INFO} />
+                    <Icon
+                      name={ICON_NAMES.INFO}
+                      color={IconColor.iconMuted}
+                      className="info-circle"
+                    />
                   </Tooltip>
                 ) : null}
               </div>

--- a/ui/components/ui/account-list/account-list.js
+++ b/ui/components/ui/account-list/account-list.js
@@ -9,7 +9,7 @@ import UserPreferencedCurrencyDisplay from '../../app/user-preferenced-currency-
 import { PRIMARY } from '../../../helpers/constants/common';
 import Tooltip from '../tooltip';
 import { Icon, ICON_NAMES } from '../../component-library';
-import { IconColor } from 'ui/helpers/constants/design-system';
+import { IconColor } from '../../../helpers/constants/design-system';
 
 const AccountList = ({
   selectNewAccountViaModal,

--- a/ui/components/ui/account-list/account-list.js
+++ b/ui/components/ui/account-list/account-list.js
@@ -8,7 +8,7 @@ import Identicon from '../identicon';
 import UserPreferencedCurrencyDisplay from '../../app/user-preferenced-currency-display';
 import { PRIMARY } from '../../../helpers/constants/common';
 import Tooltip from '../tooltip';
-import { Icon, ICON_NAMES } from '../../component-library';
+import { Icon, IconName } from '../../component-library';
 import { IconColor } from '../../../helpers/constants/design-system';
 
 const AccountList = ({
@@ -64,7 +64,7 @@ const AccountList = ({
               }
             >
               <Icon
-                name={ICON_NAMES.INFO}
+                name={IconName.Info}
                 color={IconColor.iconMuted}
                 className="info-circle"
               />
@@ -121,7 +121,7 @@ const AccountList = ({
                     }`}
                   >
                     <Icon
-                      name={ICON_NAMES.INFO}
+                      name={IconName.Info}
                       color={IconColor.iconMuted}
                       className="info-circle"
                     />

--- a/ui/components/ui/account-list/account-list.js
+++ b/ui/components/ui/account-list/account-list.js
@@ -67,6 +67,7 @@ const AccountList = ({
                 name={IconName.Info}
                 color={IconColor.iconMuted}
                 className="info-circle"
+                marginInlineStart={2}
               />
             </Tooltip>
           </div>
@@ -124,6 +125,7 @@ const AccountList = ({
                       name={IconName.Info}
                       color={IconColor.iconMuted}
                       className="info-circle"
+                      marginInlineStart={2}
                     />
                   </Tooltip>
                 ) : null}

--- a/ui/components/ui/account-list/index.scss
+++ b/ui/components/ui/account-list/index.scss
@@ -114,9 +114,7 @@
   }
 
   .info-circle {
-    color: var(--color-icon-muted);
     cursor: pointer;
-    margin-inline-start: 8px;
   }
 
   .info-circle:hover {

--- a/ui/components/ui/account-list/index.scss
+++ b/ui/components/ui/account-list/index.scss
@@ -113,14 +113,13 @@
     }
   }
 
-  .fa-info-circle {
+  .info-circle {
     color: var(--color-icon-muted);
     cursor: pointer;
     margin-inline-start: 8px;
-    font-size: 0.9rem;
   }
 
-  .fa-info-circle:hover {
+  .info-circle:hover {
     color: var(--color-icon-default);
   }
 

--- a/ui/components/ui/definition-list/definition-list.js
+++ b/ui/components/ui/definition-list/definition-list.js
@@ -11,7 +11,7 @@ import {
   IconColor,
 } from '../../../helpers/constants/design-system';
 import Tooltip from '../tooltip';
-import { Icon, ICON_NAMES, ICON_SIZES } from '../../component-library';
+import { Icon, IconName, IconSize } from '../../component-library';
 
 const MARGIN_MAP = {
   [Size.XS]: 0,
@@ -51,8 +51,8 @@ export default function DefinitionList({
                 containerClassName="definition-list__tooltip-wrapper"
               >
                 <Icon
-                  name={ICON_NAMES.INFO}
-                  size={ICON_SIZES.SM}
+                  name={IconName.Info}
+                  size={IconSize.Sm}
                   marginLeft={1}
                   color={IconColor.iconDefault}
                 />

--- a/ui/components/ui/definition-list/definition-list.js
+++ b/ui/components/ui/definition-list/definition-list.js
@@ -10,6 +10,7 @@ import {
   TextColor,
 } from '../../../helpers/constants/design-system';
 import Tooltip from '../tooltip';
+import { Icon, ICON_NAMES } from '../../component-library';
 
 const MARGIN_MAP = {
   [Size.XS]: 0,
@@ -48,7 +49,7 @@ export default function DefinitionList({
                 position="top"
                 containerClassName="definition-list__tooltip-wrapper"
               >
-                <i className="fas fa-info-circle" />
+                <Icon name={ICON_NAMES.INFO} />
               </Tooltip>
             )}
           </Typography>

--- a/ui/components/ui/definition-list/definition-list.js
+++ b/ui/components/ui/definition-list/definition-list.js
@@ -8,9 +8,10 @@ import {
   FONT_WEIGHT,
   OVERFLOW_WRAP,
   TextColor,
+  IconColor,
 } from '../../../helpers/constants/design-system';
 import Tooltip from '../tooltip';
-import { Icon, ICON_NAMES } from '../../component-library';
+import { Icon, ICON_NAMES, ICON_SIZES } from '../../component-library';
 
 const MARGIN_MAP = {
   [Size.XS]: 0,
@@ -49,7 +50,12 @@ export default function DefinitionList({
                 position="top"
                 containerClassName="definition-list__tooltip-wrapper"
               >
-                <Icon name={ICON_NAMES.INFO} />
+                <Icon
+                  name={ICON_NAMES.INFO}
+                  size={ICON_SIZES.SM}
+                  marginLeft={1}
+                  color={IconColor.iconDefault}
+                />
               </Tooltip>
             )}
           </Typography>

--- a/ui/components/ui/definition-list/definition-list.scss
+++ b/ui/components/ui/definition-list/definition-list.scss
@@ -5,12 +5,6 @@
     display: flex;
     align-items: center;
 
-    & i {
-      color: var(--color-icon-default);
-      margin-left: 6px;
-      font-size: $font-size-h8;
-    }
-
     & #{$self}__tooltip-wrapper {
       display: flex !important;
       align-items: center;

--- a/ui/components/ui/deprecated-test-networks/deprecated-test-networks.js
+++ b/ui/components/ui/deprecated-test-networks/deprecated-test-networks.js
@@ -12,7 +12,7 @@ import Box from '../box/box';
 import ActionableMessage from '../actionable-message/actionable-message';
 import { getCurrentChainId } from '../../../selectors';
 import { getCompletedOnboarding } from '../../../ducks/metamask/metamask';
-import { Text, Icon, ICON_NAMES } from '../../component-library';
+import { Text, Icon, IconName } from '../../component-library';
 
 export default function DeprecatedTestNetworks() {
   const currentChainID = useSelector(getCurrentChainId);
@@ -46,7 +46,7 @@ export default function DeprecatedTestNetworks() {
           >
             <Box marginRight={2} color={Color.warningDefault}>
               <Icon
-                name={ICON_NAMES.INFO}
+                name={IconName.Info}
                 className="deprecated-test-networks__content__icon"
               />
             </Box>

--- a/ui/components/ui/deprecated-test-networks/deprecated-test-networks.js
+++ b/ui/components/ui/deprecated-test-networks/deprecated-test-networks.js
@@ -12,7 +12,7 @@ import Box from '../box/box';
 import ActionableMessage from '../actionable-message/actionable-message';
 import { getCurrentChainId } from '../../../selectors';
 import { getCompletedOnboarding } from '../../../ducks/metamask/metamask';
-import { Text } from '../../component-library';
+import { Text, Icon, ICON_NAMES } from '../../component-library';
 
 export default function DeprecatedTestNetworks() {
   const currentChainID = useSelector(getCurrentChainId);
@@ -45,7 +45,10 @@ export default function DeprecatedTestNetworks() {
             className="deprecated-test-networks__content"
           >
             <Box marginRight={2} color={Color.warningDefault}>
-              <i className="fa fa-info-circle deprecated-test-networks__content__icon" />
+              <Icon
+                name={ICON_NAMES.INFO}
+                className="deprecated-test-networks__content__icon"
+              />
             </Box>
             <Box justifyContent={JustifyContent.spaceBetween}>
               <Text

--- a/ui/components/ui/deprecated-test-networks/deprecated-test-networks.js
+++ b/ui/components/ui/deprecated-test-networks/deprecated-test-networks.js
@@ -12,7 +12,7 @@ import Box from '../box/box';
 import ActionableMessage from '../actionable-message/actionable-message';
 import { getCurrentChainId } from '../../../selectors';
 import { getCompletedOnboarding } from '../../../ducks/metamask/metamask';
-import { Text, Icon, IconName } from '../../component-library';
+import { Text, Icon, IconName, IconSize } from '../../component-library';
 
 export default function DeprecatedTestNetworks() {
   const currentChainID = useSelector(getCurrentChainId);
@@ -45,10 +45,7 @@ export default function DeprecatedTestNetworks() {
             className="deprecated-test-networks__content"
           >
             <Box marginRight={2} color={Color.warningDefault}>
-              <Icon
-                name={IconName.Info}
-                className="deprecated-test-networks__content__icon"
-              />
+              <Icon name={IconName.Info} size={IconSize.Sm} />
             </Box>
             <Box justifyContent={JustifyContent.spaceBetween}>
               <Text

--- a/ui/components/ui/deprecated-test-networks/index.scss
+++ b/ui/components/ui/deprecated-test-networks/index.scss
@@ -5,9 +5,6 @@
   z-index: 1050;
 
   &__content {
-    &__icon {
-      font-size: 16px;
-    }
 
     &__inline-link {
       @include H7;

--- a/ui/components/ui/deprecated-test-networks/index.scss
+++ b/ui/components/ui/deprecated-test-networks/index.scss
@@ -5,7 +5,6 @@
   z-index: 1050;
 
   &__content {
-
     &__inline-link {
       @include H7;
 

--- a/ui/components/ui/tooltip/tooltip.stories.js
+++ b/ui/components/ui/tooltip/tooltip.stories.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import Box from '../box/box';
-import { Icon, ICON_NAMES, Text } from '../../component-library';
-import { ICON_COLORS } from '../../../helpers/constants/design-system';
+import { Text } from '../../component-library';
 import Tooltip from '.';
 
 export default {
@@ -61,7 +60,10 @@ export const DefaultStory = (args) => (
   <Box display="flex">
     <Text>Hover over the info icon to see the tooltip</Text>
     <Tooltip {...args}>
-      <Icon name={ICON_NAMES.INFO} color={ICON_COLORS.ICON_ALTERNATIVE} />
+      <i
+        className="fa fa-sm fa-info-circle"
+        style={{ color: 'var(--color-icon-alternative)' }}
+      />
     </Tooltip>
   </Box>
 );
@@ -72,7 +74,10 @@ export const HTML = (args) => (
   <Box display="flex">
     <Text>This tooltips content is html</Text>
     <Tooltip {...args}>
-      <Icon name={ICON_NAMES.INFO} color={ICON_COLORS.ICON_ALTERNATIVE} />
+      <i
+        className="fa fa-sm fa-info-circle"
+        style={{ color: 'var(--color-icon-alternative)' }}
+      />
     </Tooltip>
   </Box>
 );

--- a/ui/components/ui/tooltip/tooltip.stories.js
+++ b/ui/components/ui/tooltip/tooltip.stories.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import Box from '../box/box';
-import { Text } from '../../component-library';
+import { Icon, IconName, Text } from '../../component-library';
+import { IconColor } from '../../../helpers/constants/design-system';
 import Tooltip from '.';
 
 export default {
@@ -60,10 +61,7 @@ export const DefaultStory = (args) => (
   <Box display="flex">
     <Text>Hover over the info icon to see the tooltip</Text>
     <Tooltip {...args}>
-      <i
-        className="fa fa-sm fa-info-circle"
-        style={{ color: 'var(--color-icon-alternative)' }}
-      />
+      <Icon name={IconName.Info} color={IconColor.iconAlternative} />
     </Tooltip>
   </Box>
 );
@@ -74,10 +72,7 @@ export const HTML = (args) => (
   <Box display="flex">
     <Text>This tooltips content is html</Text>
     <Tooltip {...args}>
-      <i
-        className="fa fa-sm fa-info-circle"
-        style={{ color: 'var(--color-icon-alternative)' }}
-      />
+      <Icon name={IconName.Info} color={IconColor.iconAlternative} />
     </Tooltip>
   </Box>
 );

--- a/ui/components/ui/tooltip/tooltip.stories.js
+++ b/ui/components/ui/tooltip/tooltip.stories.js
@@ -1,9 +1,8 @@
 import React from 'react';
 import Box from '../box/box';
-import { Text } from '../../component-library';
-import Tooltip from '.';
+import { Icon, ICON_NAMES, Text } from '../../component-library';
 import { ICON_COLORS } from '../../../helpers/constants/design-system';
-import { Icon, ICON_NAMES } from '../../component-library';
+import Tooltip from '.';
 
 export default {
   title: 'Components/UI/Tooltip',
@@ -62,11 +61,7 @@ export const DefaultStory = (args) => (
   <Box display="flex">
     <Text>Hover over the info icon to see the tooltip</Text>
     <Tooltip {...args}>
-      <Icon
-        name={ICON_NAMES.INFO}
-        className="deprecated-test-networks__content__icon"
-        color={ICON_COLORS.ICON_ALTERNATIVE}
-      />
+      <Icon name={ICON_NAMES.INFO} color={ICON_COLORS.ICON_ALTERNATIVE} />
     </Tooltip>
   </Box>
 );
@@ -77,11 +72,7 @@ export const HTML = (args) => (
   <Box display="flex">
     <Text>This tooltips content is html</Text>
     <Tooltip {...args}>
-      <Icon
-        name={ICON_NAMES.INFO}
-        className="deprecated-test-networks__content__icon"
-        color={ICON_COLORS.ICON_ALTERNATIVE}
-      />
+      <Icon name={ICON_NAMES.INFO} color={ICON_COLORS.ICON_ALTERNATIVE} />
     </Tooltip>
   </Box>
 );

--- a/ui/components/ui/tooltip/tooltip.stories.js
+++ b/ui/components/ui/tooltip/tooltip.stories.js
@@ -2,6 +2,8 @@ import React from 'react';
 import Box from '../box/box';
 import { Text } from '../../component-library';
 import Tooltip from '.';
+import { ICON_COLORS } from '../../../helpers/constants/design-system';
+import { Icon, ICON_NAMES } from '../../component-library';
 
 export default {
   title: 'Components/UI/Tooltip',
@@ -60,9 +62,10 @@ export const DefaultStory = (args) => (
   <Box display="flex">
     <Text>Hover over the info icon to see the tooltip</Text>
     <Tooltip {...args}>
-      <i
-        className="fa fa-sm fa-info-circle"
-        style={{ color: 'var(--color-icon-alternative)' }}
+      <Icon
+        name={ICON_NAMES.INFO}
+        className="deprecated-test-networks__content__icon"
+        color={ICON_COLORS.ICON_ALTERNATIVE}
       />
     </Tooltip>
   </Box>
@@ -74,9 +77,10 @@ export const HTML = (args) => (
   <Box display="flex">
     <Text>This tooltips content is html</Text>
     <Tooltip {...args}>
-      <i
-        className="fa fa-sm fa-info-circle"
-        style={{ color: 'var(--color-icon-alternative)' }}
+      <Icon
+        name={ICON_NAMES.INFO}
+        className="deprecated-test-networks__content__icon"
+        color={ICON_COLORS.ICON_ALTERNATIVE}
       />
     </Tooltip>
   </Box>

--- a/ui/helpers/constants/settings.js
+++ b/ui/helpers/constants/settings.js
@@ -1,3 +1,4 @@
+import { IconName } from '../../components/component-library';
 import { ICON_NAMES } from '../../components/component-library/icon/deprecated';
 import {
   ALERTS_ROUTE,
@@ -259,28 +260,28 @@ export const SETTINGS_CONSTANTS = [
     sectionMessage: (t) => t('metamaskVersion'),
     descriptionMessage: (t) => t('builtAroundTheWorld'),
     route: `${ABOUT_US_ROUTE}#version`,
-    icon: 'fa fa-info-circle',
+    iconName: IconName.Info,
   },
   {
     tabMessage: (t) => t('about'),
     sectionMessage: (t) => t('links'),
     descriptionMessage: (t) => t('links'),
     route: `${ABOUT_US_ROUTE}#links`,
-    icon: 'fa fa-info-circle',
+    iconName: IconName.Info,
   },
   {
     tabMessage: (t) => t('about'),
     sectionMessage: (t) => t('privacyMsg'),
     descriptionMessage: (t) => t('privacyMsg'),
     route: `${ABOUT_US_ROUTE}#privacy-policy`,
-    icon: 'fa fa-info-circle',
+    iconName: IconName.Info,
   },
   {
     tabMessage: (t) => t('about'),
     sectionMessage: (t) => t('terms'),
     descriptionMessage: (t) => t('terms'),
     route: `${ABOUT_US_ROUTE}#terms`,
-    icon: 'fa fa-info-circle',
+    iconName: IconName.Info,
   },
 
   {
@@ -288,7 +289,7 @@ export const SETTINGS_CONSTANTS = [
     sectionMessage: (t) => t('attributions'),
     descriptionMessage: (t) => t('attributions'),
     route: `${ABOUT_US_ROUTE}#attributions`,
-    icon: 'fa fa-info-circle',
+    iconName: IconName.Info,
   },
 
   {
@@ -296,7 +297,7 @@ export const SETTINGS_CONSTANTS = [
     sectionMessage: (t) => t('supportCenter'),
     descriptionMessage: (t) => t('supportCenter'),
     route: `${ABOUT_US_ROUTE}#supportcenter`,
-    icon: 'fa fa-info-circle',
+    iconName: IconName.Info,
   },
 
   {
@@ -304,7 +305,7 @@ export const SETTINGS_CONSTANTS = [
     sectionMessage: (t) => t('visitWebSite'),
     descriptionMessage: (t) => t('visitWebSite'),
     route: `${ABOUT_US_ROUTE}#visitwebsite`,
-    icon: 'fa fa-info-circle',
+    iconName: IconName.Info,
   },
 
   {
@@ -312,14 +313,14 @@ export const SETTINGS_CONSTANTS = [
     sectionMessage: (t) => t('contactUs'),
     descriptionMessage: (t) => t('contactUs'),
     route: `${ABOUT_US_ROUTE}#contactus`,
-    icon: 'fa fa-info-circle',
+    iconName: IconName.Info,
   },
   {
     tabMessage: (t) => t('about'),
     sectionMessage: (t) => t('betaTerms'),
     descriptionMessage: (t) => t('betaTerms'),
     route: `${ABOUT_US_ROUTE}#beta-terms`,
-    icon: 'fa fa-info-circle',
+    iconName: IconName.Info,
   },
   {
     tabMessage: (t) => t('experimental'),

--- a/ui/helpers/constants/settings.js
+++ b/ui/helpers/constants/settings.js
@@ -259,28 +259,28 @@ export const SETTINGS_CONSTANTS = [
     sectionMessage: (t) => t('metamaskVersion'),
     descriptionMessage: (t) => t('builtAroundTheWorld'),
     route: `${ABOUT_US_ROUTE}#version`,
-    icon: 'fa fa-info-circle',
+    iconName: ICON_NAMES.INFO,
   },
   {
     tabMessage: (t) => t('about'),
     sectionMessage: (t) => t('links'),
     descriptionMessage: (t) => t('links'),
     route: `${ABOUT_US_ROUTE}#links`,
-    icon: 'fa fa-info-circle',
+    iconName: ICON_NAMES.INFO,
   },
   {
     tabMessage: (t) => t('about'),
     sectionMessage: (t) => t('privacyMsg'),
     descriptionMessage: (t) => t('privacyMsg'),
     route: `${ABOUT_US_ROUTE}#privacy-policy`,
-    icon: 'fa fa-info-circle',
+    iconName: ICON_NAMES.INFO,
   },
   {
     tabMessage: (t) => t('about'),
     sectionMessage: (t) => t('terms'),
     descriptionMessage: (t) => t('terms'),
     route: `${ABOUT_US_ROUTE}#terms`,
-    icon: 'fa fa-info-circle',
+    iconName: ICON_NAMES.INFO,
   },
 
   {
@@ -288,7 +288,7 @@ export const SETTINGS_CONSTANTS = [
     sectionMessage: (t) => t('attributions'),
     descriptionMessage: (t) => t('attributions'),
     route: `${ABOUT_US_ROUTE}#attributions`,
-    icon: 'fa fa-info-circle',
+    iconName: ICON_NAMES.INFO,
   },
 
   {
@@ -296,7 +296,7 @@ export const SETTINGS_CONSTANTS = [
     sectionMessage: (t) => t('supportCenter'),
     descriptionMessage: (t) => t('supportCenter'),
     route: `${ABOUT_US_ROUTE}#supportcenter`,
-    icon: 'fa fa-info-circle',
+    iconName: ICON_NAMES.INFO,
   },
 
   {
@@ -304,7 +304,7 @@ export const SETTINGS_CONSTANTS = [
     sectionMessage: (t) => t('visitWebSite'),
     descriptionMessage: (t) => t('visitWebSite'),
     route: `${ABOUT_US_ROUTE}#visitwebsite`,
-    icon: 'fa fa-info-circle',
+    iconName: ICON_NAMES.INFO,
   },
 
   {
@@ -312,14 +312,14 @@ export const SETTINGS_CONSTANTS = [
     sectionMessage: (t) => t('contactUs'),
     descriptionMessage: (t) => t('contactUs'),
     route: `${ABOUT_US_ROUTE}#contactus`,
-    icon: 'fa fa-info-circle',
+    iconName: ICON_NAMES.INFO,
   },
   {
     tabMessage: (t) => t('about'),
     sectionMessage: (t) => t('betaTerms'),
     descriptionMessage: (t) => t('betaTerms'),
     route: `${ABOUT_US_ROUTE}#beta-terms`,
-    icon: 'fa fa-info-circle',
+    iconName: ICON_NAMES.INFO,
   },
   {
     tabMessage: (t) => t('experimental'),

--- a/ui/helpers/constants/settings.js
+++ b/ui/helpers/constants/settings.js
@@ -259,28 +259,28 @@ export const SETTINGS_CONSTANTS = [
     sectionMessage: (t) => t('metamaskVersion'),
     descriptionMessage: (t) => t('builtAroundTheWorld'),
     route: `${ABOUT_US_ROUTE}#version`,
-    iconName: ICON_NAMES.INFO,
+    icon: 'fa fa-info-circle',
   },
   {
     tabMessage: (t) => t('about'),
     sectionMessage: (t) => t('links'),
     descriptionMessage: (t) => t('links'),
     route: `${ABOUT_US_ROUTE}#links`,
-    iconName: ICON_NAMES.INFO,
+    icon: 'fa fa-info-circle',
   },
   {
     tabMessage: (t) => t('about'),
     sectionMessage: (t) => t('privacyMsg'),
     descriptionMessage: (t) => t('privacyMsg'),
     route: `${ABOUT_US_ROUTE}#privacy-policy`,
-    iconName: ICON_NAMES.INFO,
+    icon: 'fa fa-info-circle',
   },
   {
     tabMessage: (t) => t('about'),
     sectionMessage: (t) => t('terms'),
     descriptionMessage: (t) => t('terms'),
     route: `${ABOUT_US_ROUTE}#terms`,
-    iconName: ICON_NAMES.INFO,
+    icon: 'fa fa-info-circle',
   },
 
   {
@@ -288,7 +288,7 @@ export const SETTINGS_CONSTANTS = [
     sectionMessage: (t) => t('attributions'),
     descriptionMessage: (t) => t('attributions'),
     route: `${ABOUT_US_ROUTE}#attributions`,
-    iconName: ICON_NAMES.INFO,
+    icon: 'fa fa-info-circle',
   },
 
   {
@@ -296,7 +296,7 @@ export const SETTINGS_CONSTANTS = [
     sectionMessage: (t) => t('supportCenter'),
     descriptionMessage: (t) => t('supportCenter'),
     route: `${ABOUT_US_ROUTE}#supportcenter`,
-    iconName: ICON_NAMES.INFO,
+    icon: 'fa fa-info-circle',
   },
 
   {
@@ -304,7 +304,7 @@ export const SETTINGS_CONSTANTS = [
     sectionMessage: (t) => t('visitWebSite'),
     descriptionMessage: (t) => t('visitWebSite'),
     route: `${ABOUT_US_ROUTE}#visitwebsite`,
-    iconName: ICON_NAMES.INFO,
+    icon: 'fa fa-info-circle',
   },
 
   {
@@ -312,14 +312,14 @@ export const SETTINGS_CONSTANTS = [
     sectionMessage: (t) => t('contactUs'),
     descriptionMessage: (t) => t('contactUs'),
     route: `${ABOUT_US_ROUTE}#contactus`,
-    iconName: ICON_NAMES.INFO,
+    icon: 'fa fa-info-circle',
   },
   {
     tabMessage: (t) => t('about'),
     sectionMessage: (t) => t('betaTerms'),
     descriptionMessage: (t) => t('betaTerms'),
     route: `${ABOUT_US_ROUTE}#beta-terms`,
-    iconName: ICON_NAMES.INFO,
+    icon: 'fa fa-info-circle',
   },
   {
     tabMessage: (t) => t('experimental'),

--- a/ui/pages/send/send-content/send-gas-row/__snapshots__/send-gas-row.test.js.snap
+++ b/ui/pages/send/send-content/send-gas-row/__snapshots__/send-gas-row.test.js.snap
@@ -30,8 +30,9 @@ exports[`SendGasRow Component render should match snapshot 1`] = `
                 style="display: inline;"
                 tabindex="0"
               >
-                <i
-                  class="fa fa-info-circle"
+                <div
+                  class="box mm-icon mm-icon--size-md box--flex-direction-row box--color-inherit"
+                  style="mask-image: url('./images/icons/info.svg');"
                 />
               </div>
             </div>
@@ -82,8 +83,9 @@ exports[`SendGasRow Component render should match snapshot 1`] = `
                 style="display: inline;"
                 tabindex="0"
               >
-                <i
-                  class="fa fa-info-circle"
+                <div
+                  class="box mm-icon mm-icon--size-md box--flex-direction-row box--color-inherit"
+                  style="mask-image: url('./images/icons/info.svg');"
                 />
               </div>
             </div>

--- a/ui/pages/send/send-content/send-gas-row/__snapshots__/send-gas-row.test.js.snap
+++ b/ui/pages/send/send-content/send-gas-row/__snapshots__/send-gas-row.test.js.snap
@@ -30,8 +30,8 @@ exports[`SendGasRow Component render should match snapshot 1`] = `
                 style="display: inline;"
                 tabindex="0"
               >
-                <div
-                  class="box info-circle mm-icon mm-icon--size-md box--flex-direction-row box--color-icon-alternative"
+                <span
+                  class="box info-circle mm-icon mm-icon--size-md box--display-inline-block box--flex-direction-row box--color-icon-alternative"
                   style="mask-image: url('./images/icons/info.svg');"
                 />
               </div>
@@ -83,8 +83,8 @@ exports[`SendGasRow Component render should match snapshot 1`] = `
                 style="display: inline;"
                 tabindex="0"
               >
-                <div
-                  class="box info-circle mm-icon mm-icon--size-md box--flex-direction-row box--color-icon-alternative"
+                <span
+                  class="box info-circle mm-icon mm-icon--size-md box--display-inline-block box--flex-direction-row box--color-icon-alternative"
                   style="mask-image: url('./images/icons/info.svg');"
                 />
               </div>

--- a/ui/pages/send/send-content/send-gas-row/__snapshots__/send-gas-row.test.js.snap
+++ b/ui/pages/send/send-content/send-gas-row/__snapshots__/send-gas-row.test.js.snap
@@ -31,7 +31,7 @@ exports[`SendGasRow Component render should match snapshot 1`] = `
                 tabindex="0"
               >
                 <div
-                  class="box mm-icon mm-icon--size-md box--flex-direction-row box--color-inherit"
+                  class="box info-circle mm-icon mm-icon--size-md box--flex-direction-row box--color-icon-alternative"
                   style="mask-image: url('./images/icons/info.svg');"
                 />
               </div>
@@ -84,7 +84,7 @@ exports[`SendGasRow Component render should match snapshot 1`] = `
                 tabindex="0"
               >
                 <div
-                  class="box mm-icon mm-icon--size-md box--flex-direction-row box--color-inherit"
+                  class="box info-circle mm-icon mm-icon--size-md box--flex-direction-row box--color-icon-alternative"
                   style="mask-image: url('./images/icons/info.svg');"
                 />
               </div>

--- a/ui/pages/settings/alerts-tab/alerts-tab.js
+++ b/ui/pages/settings/alerts-tab/alerts-tab.js
@@ -9,7 +9,7 @@ import { setAlertEnabledness } from '../../../store/actions';
 import { getAlertEnabledness } from '../../../ducks/metamask/metamask';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import { handleSettingsRefs } from '../../../helpers/utils/settings-search';
-import { Icon, ICON_NAMES } from '../../../components/component-library';
+import { Icon, IconName } from '../../../components/component-library';
 
 const AlertSettingsEntry = ({ alertId, description, title }) => {
   const t = useI18nContext();
@@ -32,7 +32,7 @@ const AlertSettingsEntry = ({ alertId, description, title }) => {
             wrapperClassName="alerts-tab__description"
           >
             <Icon
-              name={ICON_NAMES.INFO}
+              name={IconName.Info}
               className="alerts-tab__description__icon"
             />
           </Tooltip>

--- a/ui/pages/settings/alerts-tab/alerts-tab.js
+++ b/ui/pages/settings/alerts-tab/alerts-tab.js
@@ -33,7 +33,7 @@ const AlertSettingsEntry = ({ alertId, description, title }) => {
           >
             <Icon
               name={ICON_NAMES.INFO}
-              className="info-circle alerts-tab__description__icon"
+              className="alerts-tab__description__icon"
             />
           </Tooltip>
           <ToggleButton

--- a/ui/pages/settings/alerts-tab/alerts-tab.js
+++ b/ui/pages/settings/alerts-tab/alerts-tab.js
@@ -9,6 +9,7 @@ import { setAlertEnabledness } from '../../../store/actions';
 import { getAlertEnabledness } from '../../../ducks/metamask/metamask';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import { handleSettingsRefs } from '../../../helpers/utils/settings-search';
+import { Icon, ICON_NAMES } from '../../../components/component-library';
 
 const AlertSettingsEntry = ({ alertId, description, title }) => {
   const t = useI18nContext();
@@ -30,7 +31,10 @@ const AlertSettingsEntry = ({ alertId, description, title }) => {
             title={description}
             wrapperClassName="alerts-tab__description"
           >
-            <i className="fa fa-info-circle alerts-tab__description__icon" />
+            <Icon
+              name={ICON_NAMES.INFO}
+              className="info-circle alerts-tab__description__icon"
+            />
           </Tooltip>
           <ToggleButton
             offLabel={t('off')}

--- a/ui/pages/settings/alerts-tab/alerts-tab.stories.js
+++ b/ui/pages/settings/alerts-tab/alerts-tab.stories.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import AlertsTab from './alerts-tab';
+
+export default {
+  title: 'Components/UI/Pages/AlertsTab ',
+
+  component: AlertsTab,
+};
+
+export const DefaultAlertsTab = () => {
+  return <AlertsTab />;
+};
+
+DefaultAlertsTab.storyName = 'Default';

--- a/ui/pages/settings/settings.component.js
+++ b/ui/pages/settings/settings.component.js
@@ -303,7 +303,7 @@ class SettingsPage extends PureComponent {
       },
       {
         content: t('about'),
-        icon: <i className="fa fa-info-circle" />,
+        icon: <Icon name={IconName.Info} />,
         key: ABOUT_US_ROUTE,
       },
     ];

--- a/ui/pages/settings/settings.component.js
+++ b/ui/pages/settings/settings.component.js
@@ -43,7 +43,6 @@ import ViewSnap from './snaps/view-snap';
 ///: END:ONLY_INCLUDE_IN
 import SettingsSearch from './settings-search';
 import SettingsSearchList from './settings-search-list';
-import { Icon, ICON_NAMES } from '../../components/component-library';
 
 class SettingsPage extends PureComponent {
   static propTypes = {

--- a/ui/pages/settings/settings.component.js
+++ b/ui/pages/settings/settings.component.js
@@ -43,6 +43,7 @@ import ViewSnap from './snaps/view-snap';
 ///: END:ONLY_INCLUDE_IN
 import SettingsSearch from './settings-search';
 import SettingsSearchList from './settings-search-list';
+import { Icon, ICON_NAMES } from '../../components/component-library';
 
 class SettingsPage extends PureComponent {
   static propTypes = {

--- a/ui/pages/swaps/view-quote/__snapshots__/view-quote-price-difference.test.js.snap
+++ b/ui/pages/swaps/view-quote/__snapshots__/view-quote-price-difference.test.js.snap
@@ -35,8 +35,8 @@ exports[`View Price Quote Difference displays a fiat error when calculationError
                   style="display: inline;"
                   tabindex="0"
                 >
-                  <div
-                    class="box mm-icon mm-icon--size-md box--flex-direction-row box--color-inherit"
+                  <span
+                    class="box mm-icon mm-icon--size-md box--display-inline-block box--flex-direction-row box--color-inherit"
                     style="mask-image: url('./images/icons/info.svg');"
                   />
                 </div>
@@ -93,8 +93,8 @@ exports[`View Price Quote Difference displays an error when in high bucket 1`] =
                   style="display: inline;"
                   tabindex="0"
                 >
-                  <div
-                    class="box mm-icon mm-icon--size-md box--flex-direction-row box--color-inherit"
+                  <span
+                    class="box mm-icon mm-icon--size-md box--display-inline-block box--flex-direction-row box--color-inherit"
                     style="mask-image: url('./images/icons/info.svg');"
                   />
                 </div>
@@ -151,8 +151,8 @@ exports[`View Price Quote Difference displays an error when in medium bucket 1`]
                   style="display: inline;"
                   tabindex="0"
                 >
-                  <div
-                    class="box mm-icon mm-icon--size-md box--flex-direction-row box--color-inherit"
+                  <span
+                    class="box mm-icon mm-icon--size-md box--display-inline-block box--flex-direction-row box--color-inherit"
                     style="mask-image: url('./images/icons/info.svg');"
                   />
                 </div>
@@ -209,8 +209,8 @@ exports[`View Price Quote Difference should match snapshot 1`] = `
                   style="display: inline;"
                   tabindex="0"
                 >
-                  <div
-                    class="box mm-icon mm-icon--size-md box--flex-direction-row box--color-inherit"
+                  <span
+                    class="box mm-icon mm-icon--size-md box--display-inline-block box--flex-direction-row box--color-inherit"
                     style="mask-image: url('./images/icons/info.svg');"
                   />
                 </div>

--- a/ui/pages/swaps/view-quote/__snapshots__/view-quote-price-difference.test.js.snap
+++ b/ui/pages/swaps/view-quote/__snapshots__/view-quote-price-difference.test.js.snap
@@ -35,8 +35,9 @@ exports[`View Price Quote Difference displays a fiat error when calculationError
                   style="display: inline;"
                   tabindex="0"
                 >
-                  <i
-                    class="fa fa-info-circle"
+                  <div
+                    class="box mm-icon mm-icon--size-md box--flex-direction-row box--color-inherit"
+                    style="mask-image: url('./images/icons/info.svg');"
                   />
                 </div>
               </div>
@@ -92,8 +93,9 @@ exports[`View Price Quote Difference displays an error when in high bucket 1`] =
                   style="display: inline;"
                   tabindex="0"
                 >
-                  <i
-                    class="fa fa-info-circle"
+                  <div
+                    class="box mm-icon mm-icon--size-md box--flex-direction-row box--color-inherit"
+                    style="mask-image: url('./images/icons/info.svg');"
                   />
                 </div>
               </div>
@@ -149,8 +151,9 @@ exports[`View Price Quote Difference displays an error when in medium bucket 1`]
                   style="display: inline;"
                   tabindex="0"
                 >
-                  <i
-                    class="fa fa-info-circle"
+                  <div
+                    class="box mm-icon mm-icon--size-md box--flex-direction-row box--color-inherit"
+                    style="mask-image: url('./images/icons/info.svg');"
                   />
                 </div>
               </div>
@@ -206,8 +209,9 @@ exports[`View Price Quote Difference should match snapshot 1`] = `
                   style="display: inline;"
                   tabindex="0"
                 >
-                  <i
-                    class="fa fa-info-circle"
+                  <div
+                    class="box mm-icon mm-icon--size-md box--flex-direction-row box--color-inherit"
+                    style="mask-image: url('./images/icons/info.svg');"
                   />
                 </div>
               </div>

--- a/ui/pages/swaps/view-quote/view-quote-price-difference.js
+++ b/ui/pages/swaps/view-quote/view-quote-price-difference.js
@@ -12,6 +12,7 @@ import {
   DISPLAY,
 } from '../../../helpers/constants/design-system';
 import { GasRecommendations } from '../../../../shared/constants/gas';
+import { Icon, ICON_NAMES } from '../../../components/component-library';
 
 export default function ViewQuotePriceDifference(props) {
   const {
@@ -74,7 +75,7 @@ export default function ViewQuotePriceDifference(props) {
                   {priceDifferenceTitle}
                 </div>
                 <Tooltip position="bottom" title={t('swapPriceImpactTooltip')}>
-                  <i className="fa fa-info-circle" />
+                  <Icon name={ICON_NAMES.INFO} className="fa-info-circle" />
                 </Tooltip>
               </Box>
               {priceDifferenceMessage}

--- a/ui/pages/swaps/view-quote/view-quote-price-difference.js
+++ b/ui/pages/swaps/view-quote/view-quote-price-difference.js
@@ -75,7 +75,7 @@ export default function ViewQuotePriceDifference(props) {
                   {priceDifferenceTitle}
                 </div>
                 <Tooltip position="bottom" title={t('swapPriceImpactTooltip')}>
-                  <Icon name={ICON_NAMES.INFO} className="fa-info-circle" />
+                  <Icon name={ICON_NAMES.INFO} />
                 </Tooltip>
               </Box>
               {priceDifferenceMessage}

--- a/ui/pages/swaps/view-quote/view-quote-price-difference.js
+++ b/ui/pages/swaps/view-quote/view-quote-price-difference.js
@@ -12,7 +12,7 @@ import {
   DISPLAY,
 } from '../../../helpers/constants/design-system';
 import { GasRecommendations } from '../../../../shared/constants/gas';
-import { Icon, ICON_NAMES } from '../../../components/component-library';
+import { Icon, IconName } from '../../../components/component-library';
 
 export default function ViewQuotePriceDifference(props) {
   const {
@@ -75,7 +75,7 @@ export default function ViewQuotePriceDifference(props) {
                   {priceDifferenceTitle}
                 </div>
                 <Tooltip position="bottom" title={t('swapPriceImpactTooltip')}>
-                  <Icon name={ICON_NAMES.INFO} />
+                  <Icon name={IconName.Info} />
                 </Tooltip>
               </Box>
               {priceDifferenceMessage}


### PR DESCRIPTION
## Explanation

Replaces instances of `fa-icon-circle` with INFO icons. 

## Screenshots/Screencaps

<img width="905" alt="Screenshot 2023-02-01 at 6 57 30 PM" src="https://user-images.githubusercontent.com/39872794/216055966-d040d321-f314-4a31-8aa4-128fe258ea52.png">


## Pre-merge author checklist

- [ ] I've clearly explained:
  - [ ] What problem this PR is solving
  - [ ] How this problem was solved
  - [ ] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in the browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
