### PR TITLE
decrease coverage threshold that requires bump

### DIFF
--- a/test/merge-coverage.js
+++ b/test/merge-coverage.js
@@ -13,6 +13,8 @@ const codecovConfig = yaml.load(fs.readFileSync('codecov.yml', 'utf8'));
 
 const COVERAGE_DIR = './coverage/';
 
+const COVERAGE_THRESHOLD_FOR_BUMP = 1;
+
 /**
  * Load .json file at path and parse it into a javascript object
  *
@@ -113,12 +115,14 @@ function isCoverageInsufficient(target, actual) {
  * @returns {boolean}
  */
 function shouldCoverageBeBumped(target, actual) {
-  const lineCoverageNeedsBumped = actual.lines.pct > target.lines + 5;
-  const branchCoverageNeedsBumped = actual.branches.pct > target.branches + 5;
+  const lineCoverageNeedsBumped =
+    actual.lines.pct > target.lines + COVERAGE_THRESHOLD_FOR_BUMP;
+  const branchCoverageNeedsBumped =
+    actual.branches.pct > target.branches + COVERAGE_THRESHOLD_FOR_BUMP;
   const functionCoverageNeedsBumped =
-    actual.functions.pct > target.functions + 5;
+    actual.functions.pct > target.functions + COVERAGE_THRESHOLD_FOR_BUMP;
   const statementCoverageNeedsBumped =
-    actual.statements.pct > target.statements + 5;
+    actual.statements.pct > target.statements + COVERAGE_THRESHOLD_FOR_BUMP;
   return (
     lineCoverageNeedsBumped ||
     branchCoverageNeedsBumped ||


### PR DESCRIPTION
## Explanation
Previously we had threshold set at 5%, this means that you could increase coverage up to 5% without requiring a bump to our targets. This also means that until the coverage target is updated that anyone could lower it back down to the old target. This is too large of a window to make noticeable gains in coverage. We are experimenting with 1% to see how that does.

## Manual Testing Steps
1. Watch this PR fail and ask me to add coverage until @409H updates #17326 and merges it. 

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
