### PR TITLE
Fix http-cache-semantics dependency vulnerability GHSA-rc47-6667-2j5j

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
     "json-schema": "^0.4.0",
     "simple-get": "^4.0.1",
     "web3-provider-engine/eth-json-rpc-filters": "^5.0.0",
+    "http-cache-semantics": "^4.1.1",
     "typescript@~4.4.0": "patch:typescript@npm:4.4.4#.yarn/patches/typescript-npm-4.4.4-3fedcc07a3.patch",
     "acorn@^7.0.0": "patch:acorn@npm:7.4.1#.yarn/patches/acorn-npm-7.4.1-f450b4646c.patch",
     "acorn@^7.4.1": "patch:acorn@npm:7.4.1#.yarn/patches/acorn-npm-7.4.1-f450b4646c.patch",

--- a/package.json
+++ b/package.json
@@ -99,7 +99,6 @@
     "json-schema": "^0.4.0",
     "simple-get": "^4.0.1",
     "web3-provider-engine/eth-json-rpc-filters": "^5.0.0",
-    "http-cache-semantics": "^4.1.1",
     "typescript@~4.4.0": "patch:typescript@npm:4.4.4#.yarn/patches/typescript-npm-4.4.4-3fedcc07a3.patch",
     "acorn@^7.0.0": "patch:acorn@npm:7.4.1#.yarn/patches/acorn-npm-7.4.1-f450b4646c.patch",
     "acorn@^7.4.1": "patch:acorn@npm:7.4.1#.yarn/patches/acorn-npm-7.4.1-f450b4646c.patch",

--- a/yarn.lock
+++ b/yarn.lock
@@ -19096,7 +19096,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"http-cache-semantics@npm:^4.1.1":
+"http-cache-semantics@npm:^4.0.0, http-cache-semantics@npm:^4.1.0":
   version: 4.1.1
   resolution: "http-cache-semantics@npm:4.1.1"
   checksum: 83ac0bc60b17a3a36f9953e7be55e5c8f41acc61b22583060e8dedc9dd5e3607c823a88d0926f9150e571f90946835c7fe150732801010845c72cd8bbff1a236

--- a/yarn.lock
+++ b/yarn.lock
@@ -19096,10 +19096,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"http-cache-semantics@npm:^4.0.0, http-cache-semantics@npm:^4.1.0":
-  version: 4.1.0
-  resolution: "http-cache-semantics@npm:4.1.0"
-  checksum: 974de94a81c5474be07f269f9fd8383e92ebb5a448208223bfb39e172a9dbc26feff250192ecc23b9593b3f92098e010406b0f24bd4d588d631f80214648ed42
+"http-cache-semantics@npm:^4.1.1":
+  version: 4.1.1
+  resolution: "http-cache-semantics@npm:4.1.1"
+  checksum: 83ac0bc60b17a3a36f9953e7be55e5c8f41acc61b22583060e8dedc9dd5e3607c823a88d0926f9150e571f90946835c7fe150732801010845c72cd8bbff1a236
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fixes https://github.com/advisories/GHSA-rc47-6667-2j5j