### PR TITLE
Hide a new feature properly behind a feature toggle

### DIFF
--- a/ui/helpers/constants/settings.js
+++ b/ui/helpers/constants/settings.js
@@ -362,6 +362,5 @@ export const SETTINGS_CONSTANTS = [
     descriptionMessage: (t) => t('transactionSecurityCheckDescription'),
     route: `${EXPERIMENTAL_ROUTE}#transaction-security-check`,
     icon: 'fa fa-flask',
-    featureFlag: process.env.TRANSACTION_SECURITY_PROVIDER,
   },
 ];

--- a/ui/helpers/constants/settings.js
+++ b/ui/helpers/constants/settings.js
@@ -362,5 +362,6 @@ export const SETTINGS_CONSTANTS = [
     descriptionMessage: (t) => t('transactionSecurityCheckDescription'),
     route: `${EXPERIMENTAL_ROUTE}#transaction-security-check`,
     icon: 'fa fa-flask',
+    featureFlag: process.env.TRANSACTION_SECURITY_PROVIDER,
   },
 ];

--- a/ui/helpers/utils/settings-search.js
+++ b/ui/helpers/utils/settings-search.js
@@ -7,8 +7,8 @@ export function getSettingsRoutes() {
   if (settingsRoutes) {
     return settingsRoutes;
   }
-  settingsRoutes = SETTINGS_CONSTANTS.filter((routeObject) =>
-    routeObject.featureFlag ? process.env[routeObject.featureFlag] : true,
+  settingsRoutes = SETTINGS_CONSTANTS.filter(
+    (routeObject) => routeObject.featureFlag !== false,
   );
   return settingsRoutes;
 }


### PR DESCRIPTION
## Explanation

Now, every new feature being shown conditionally using the `feature flag` is hidden properly behind a feature toggle, so as the search functionality.

* Fixes #17396

<!--
Thanks for the pull request. Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues, Slack conversations, Zendesk issues, user stories, etc. reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

## Screenshots/Screencaps

### When feature flag is off

https://user-images.githubusercontent.com/92310504/223373932-66f12759-b359-46d4-951d-e2ac6259723d.mov

### When feature flag is on

https://user-images.githubusercontent.com/92310504/223374010-8a70036c-78ca-4edb-8c82-ebe9fb74d9a1.mov

## Manual Testing Steps

1. Within the `.metamaskrc` set `NFTS_V1` feature flag to `1` or leave it empty in order to check this fix.
2. Go to `Settings` and in the search box type `Autodetect NFTs` or `Enable OpenSea`. If a feature flag is set to `1`, the search result will be shown. If not, it won't.