### PR TITLE
UX: Fix token image not displaying in asset listing

### DIFF
--- a/ui/components/app/token-cell/token-cell.js
+++ b/ui/components/app/token-cell/token-cell.js
@@ -11,6 +11,7 @@ export default function TokenCell({
   address,
   decimals,
   balanceError,
+  image,
   symbol,
   string,
   onClick,
@@ -45,6 +46,7 @@ export default function TokenCell({
       tokenAddress={address}
       tokenSymbol={symbol}
       tokenDecimals={decimals}
+      tokenImage={image}
       warning={warning}
       primary={`${string || 0}`}
       secondary={formattedFiat}
@@ -61,6 +63,7 @@ TokenCell.propTypes = {
   string: PropTypes.string,
   onClick: PropTypes.func.isRequired,
   isERC721: PropTypes.bool,
+  image: PropTypes.string,
 };
 
 TokenCell.defaultProps = {

--- a/ui/components/ui/identicon/identicon.component.js
+++ b/ui/components/ui/identicon/identicon.component.js
@@ -59,6 +59,10 @@ export default class Identicon extends Component {
     ipfsGateway: PropTypes.string,
   };
 
+  state = {
+    imageLoadingError: false,
+  };
+
   static defaultProps = {
     addBorder: false,
     address: undefined,
@@ -93,6 +97,10 @@ export default class Identicon extends Component {
         src={image}
         style={getStyles(diameter)}
         alt={alt}
+        onError={() => {
+          this.setState({ imageLoadingError: true });
+          this.forceUpdate();
+        }}
       />
     );
   }
@@ -124,6 +132,11 @@ export default class Identicon extends Component {
     );
   }
 
+  renderBlockieOrJazzIcon() {
+    const { useBlockie } = this.props;
+    return useBlockie ? this.renderBlockie() : this.renderJazzicon();
+  }
+
   shouldComponentUpdate(nextProps) {
     // We only want to re-render if props are different.
     return !isEqual(nextProps, this.props);
@@ -132,7 +145,12 @@ export default class Identicon extends Component {
   render() {
     const { address, image, useBlockie, addBorder, diameter, tokenList } =
       this.props;
+    const { imageLoadingError } = this.state;
     const size = diameter + 8;
+
+    if (imageLoadingError) {
+      return this.renderBlockieOrJazzIcon();
+    }
 
     if (image) {
       return this.renderImage();
@@ -148,7 +166,7 @@ export default class Identicon extends Component {
           className={classnames({ 'identicon__address-wrapper': addBorder })}
           style={addBorder ? getStyles(size) : null}
         >
-          {useBlockie ? this.renderBlockie() : this.renderJazzicon()}
+          {this.renderBlockieOrJazzIcon()}
         </div>
       );
     }

--- a/ui/components/ui/identicon/identicon.component.js
+++ b/ui/components/ui/identicon/identicon.component.js
@@ -143,8 +143,7 @@ export default class Identicon extends Component {
   }
 
   render() {
-    const { address, image, useBlockie, addBorder, diameter, tokenList } =
-      this.props;
+    const { address, image, addBorder, diameter, tokenList } = this.props;
     const { imageLoadingError } = this.state;
     const size = diameter + 8;
 

--- a/ui/components/ui/identicon/identicon.component.js
+++ b/ui/components/ui/identicon/identicon.component.js
@@ -99,7 +99,6 @@ export default class Identicon extends Component {
         alt={alt}
         onError={() => {
           this.setState({ imageLoadingError: true });
-          this.forceUpdate();
         }}
       />
     );
@@ -137,9 +136,9 @@ export default class Identicon extends Component {
     return useBlockie ? this.renderBlockie() : this.renderJazzicon();
   }
 
-  shouldComponentUpdate(nextProps) {
+  shouldComponentUpdate(nextProps, nextState) {
     // We only want to re-render if props are different.
-    return !isEqual(nextProps, this.props);
+    return !isEqual(nextProps, this.props) || !isEqual(nextState, this.state);
   }
 
   render() {


### PR DESCRIPTION
## Explanation

Tokens that we *do* have icons for sometimes don't display that icon in the token listing -- instead, a JazzIcon or Blockie displays.  When clicking into the token's detail screen, the correct image *does* display.  We weren't taking advantage of the image being passed in, which I've fixed.

One side effect of fixing the original problem is that a token for which we don't have an icon for shows a 404 icon, which is a problem.  I've fixed this by showing a JazzIcon or Blockie if the image errors.

## Screenshots/Screencaps

<img width="930" alt="GoodIcon" src="https://user-images.githubusercontent.com/46655/216402718-732523e4-55f3-4cd6-96e0-5799fa20cddd.png">

## Manual Testing Steps

1.  Add Binance Smart Chain if you don't already have it
2. Import token `0xe4fae3faa8300810c835970b9187c268f55d998f`
3. Previously, a Blockie/JazzIcon would display -- now you'll see the correct icon
4. Switch to MainNet
5. Import the same token address -- this would have shown a 404 image
6. Now see that the Blockie/JazzIcon displays


## Pre-merge author checklist

- [ ] I've clearly explained:
  - [ ] What problem this PR is solving
  - [ ] How this problem was solved
  - [ ] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
