### PR TITLE
initialize currentLocale in the locale slice upon app start

### DIFF
--- a/ui/index.js
+++ b/ui/index.js
@@ -90,6 +90,7 @@ async function startApp(metamaskState, backgroundConnection, opts) {
     appState: {},
 
     localeMessages: {
+      currentLocale: metamaskState.currentLocale,
       current: currentLocaleMessages,
       en: enLocaleMessages,
     },


### PR DESCRIPTION
## Explanation

in #17499 I changed where we pull currentLocale from to be the locale slice, where we had a selector that pre-existed for selecting current locale from this slice and one in metamask slice. I opted to keep the state (at least where we access it from) in the locale slice but did not initialize this value from the one in the background state. This Pr fixes a bug that is reported in slack by our developers and hasn't been rolled out live yet. 

## Manual Testing Steps
1. On develop run `yarn start` and upon loading the UI you may get an error. If not use stateHooks.getCleanAppState() and explore the locale state and see currentLocale is not set.
2. Repeat here and see that it is set. 

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
