### PR TITLE
Update `json-rpc-middleware-stream` from v2 to v4

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -4,7 +4,7 @@ import { ObservableStore } from '@metamask/obs-store';
 import { storeAsStream } from '@metamask/obs-store/dist/asStream';
 import { JsonRpcEngine } from 'json-rpc-engine';
 import { debounce } from 'lodash';
-import createEngineStream from 'json-rpc-middleware-stream/engineStream';
+import { createEngineStream } from 'json-rpc-middleware-stream';
 import { providerAsMiddleware } from 'eth-json-rpc-middleware';
 import {
   KeyringController,

--- a/lavamoat/browserify/beta/policy.json
+++ b/lavamoat/browserify/beta/policy.json
@@ -3461,7 +3461,12 @@
       }
     },
     "json-rpc-middleware-stream": {
+      "globals": {
+        "console.warn": true,
+        "setTimeout": true
+      },
       "packages": {
+        "json-rpc-engine>@metamask/safe-event-emitter": true,
         "readable-stream": true
       }
     },

--- a/lavamoat/browserify/flask/policy.json
+++ b/lavamoat/browserify/flask/policy.json
@@ -1423,7 +1423,6 @@
         "@metamask/snaps-controllers>@xstate/fsm": true,
         "@metamask/snaps-controllers>concat-stream": true,
         "@metamask/snaps-controllers>gunzip-maybe": true,
-        "@metamask/snaps-controllers>json-rpc-middleware-stream": true,
         "@metamask/snaps-controllers>nanoid": true,
         "@metamask/snaps-controllers>readable-web-to-node-stream": true,
         "@metamask/snaps-controllers>tar-stream": true,
@@ -1432,6 +1431,7 @@
         "@metamask/utils": true,
         "eth-rpc-errors": true,
         "json-rpc-engine": true,
+        "json-rpc-middleware-stream": true,
         "pump": true
       }
     },
@@ -1529,16 +1529,6 @@
         "browserify>util": true,
         "readable-stream": true,
         "watchify>xtend": true
-      }
-    },
-    "@metamask/snaps-controllers>json-rpc-middleware-stream": {
-      "globals": {
-        "console.warn": true,
-        "setTimeout": true
-      },
-      "packages": {
-        "json-rpc-engine>@metamask/safe-event-emitter": true,
-        "readable-stream": true
       }
     },
     "@metamask/snaps-controllers>nanoid": {
@@ -3785,7 +3775,12 @@
       }
     },
     "json-rpc-middleware-stream": {
+      "globals": {
+        "console.warn": true,
+        "setTimeout": true
+      },
       "packages": {
+        "json-rpc-engine>@metamask/safe-event-emitter": true,
         "readable-stream": true
       }
     },

--- a/lavamoat/browserify/main/policy.json
+++ b/lavamoat/browserify/main/policy.json
@@ -3461,7 +3461,12 @@
       }
     },
     "json-rpc-middleware-stream": {
+      "globals": {
+        "console.warn": true,
+        "setTimeout": true
+      },
       "packages": {
+        "json-rpc-engine>@metamask/safe-event-emitter": true,
         "readable-stream": true
       }
     },

--- a/package.json
+++ b/package.json
@@ -302,7 +302,7 @@
     "is-retry-allowed": "^2.2.0",
     "jest-junit": "^14.0.1",
     "json-rpc-engine": "^6.1.0",
-    "json-rpc-middleware-stream": "^2.1.1",
+    "json-rpc-middleware-stream": "^4.2.1",
     "jsonschema": "^1.2.4",
     "labeled-stream-splicer": "^2.0.2",
     "localforage": "^1.9.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -22156,16 +22156,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"json-rpc-middleware-stream@npm:^2.1.1":
-  version: 2.1.1
-  resolution: "json-rpc-middleware-stream@npm:2.1.1"
-  dependencies:
-    readable-stream: ^2.3.3
-    safe-event-emitter: ^1.0.1
-  checksum: e3c1c25c4b46b25e3c5a577e751ad3cabe3f1a387b5a8f345618563cb0ca24bc26eb25f170cf7ccb1e2c36d759947861cca0debb913b672ddf352b0f8add4ecf
-  languageName: node
-  linkType: hard
-
 "json-rpc-middleware-stream@npm:^4.2.0, json-rpc-middleware-stream@npm:^4.2.1":
   version: 4.2.1
   resolution: "json-rpc-middleware-stream@npm:4.2.1"
@@ -24250,7 +24240,7 @@ __metadata:
     js-yaml: ^4.1.0
     jsdom: ^11.2.0
     json-rpc-engine: ^6.1.0
-    json-rpc-middleware-stream: ^2.1.1
+    json-rpc-middleware-stream: ^4.2.1
     jsonschema: ^1.2.4
     koa: ^2.7.0
     labeled-stream-splicer: ^2.0.2


### PR DESCRIPTION
This package has been updated to reduce the bundle size (we already use the v4 version indirectly). The only breaking change applicable to the usage of this package in the extension is to the package's exports. The one import line has been updated accordingly.

This update comes with types (v3 was the TypeScript migration).

## Manual Testing Steps

No functional changes. The package itself is used to pass messages between the extension and dapps, so hopefully any breakages I may have missed would be detected by our test dapp e2e tests. 

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
