### PR TITLE
Label PRs based on the labels of the associated issue

### DIFF
--- a/.github/scripts/label-prs.js
+++ b/.github/scripts/label-prs.js
@@ -1,0 +1,142 @@
+async function runLabelPRsAutomation(context, github) {
+  let issueNumber = getIssueNumberFromPullRequestBody(context);
+
+  if (issueNumber === -1) {
+    bailIfIsBranchNameInvalid(process.env.HEAD_REF);
+    bailIfIsNotFeatureBranch();
+    issueNumber = getIssueNumberFromBranchName(process.env.HEAD_REF);
+  }
+
+  await updateLabels(context, github, issueNumber);
+}
+
+function getIssueNumberFromPullRequestBody(context) {
+  console.log("Checking if the PR's body references an issue...");
+
+  let ISSUE_LINK_IN_PR_DESCRIPTION_REGEX =
+    /(close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved)\s#\d+/gi;
+
+  const prBody = context.payload.pull_request.body;
+
+  let matches = prBody.match(ISSUE_LINK_IN_PR_DESCRIPTION_REGEX);
+  if (matches.length === 0) {
+    console.log(
+      'No direct link can be drawn between the PR and an issue from the PR body because no issue number was referenced.',
+    );
+    return -1;
+  }
+
+  if (matches.length > 1) {
+    console.log(
+      'No direct link can be drawn between the PR and an issue from the PR body because more than one issue number was referenced.',
+    );
+    return -1;
+  }
+
+  ISSUE_NUMBER_REGEX = /\d+/;
+  const issueNumber = matches[0].match(ISSUE_NUMBER_REGEX)[0];
+
+  console.log(`Found issue number ${issueNumber} in PR body.`);
+
+  return issueNumber;
+}
+
+function bailIfIsBranchNameInvalid(branchName) {
+  const BRANCH_REGEX =
+    /^(main|develop|(ci|chore|docs|feat|feature|fix|perf|refactor|revert|style)\/\d*(?:[-](?![-])\w*)*|Version-v\d+\.\d+\.\d+)$/;
+  const isValidBranchName = new RegExp(BRANCH_REGEX).test(branchName);
+
+  if (!isValidBranchName) {
+    console.log('This branch name does not follow the convention.');
+    console.log(
+      'Here are some example branch names that are accepted: "fix/123-description", "feat/123-longer-description", "feature/123", "main", "develop", "Version-v10.24.2".',
+    );
+    console.log(
+      'No issue could be linked to this PR, so no labels were copied',
+    );
+
+    process.exit(0);
+  }
+}
+
+function bailIfIsNotFeatureBranch() {
+  if (
+    process.env.HEAD_REF === 'main' ||
+    process.env.HEAD_REF === 'develop' ||
+    process.env.HEAD_REF.startsWith('Version-v')
+  ) {
+    console.log(`${process.env.HEAD_REF} is not a feature branch.`);
+    console.log(
+      'No issue could be linked to this PR, so no labels were copied',
+    );
+    process.exit(0);
+  }
+}
+
+async function updateLabels(context, github, issueNumber) {
+  const owner = context.repo.owner;
+  const repo = context.repo.repo;
+
+  const issue = await github.request(
+    `GET /repos/${owner}/${repo}/issues/${issueNumber}`,
+    { owner, repo, issue_number: issueNumber },
+  );
+
+  const issueLabels = issue.data.labels.map((label) => label.name);
+
+  const prNumber = context.payload.number;
+
+  const pr = await github.request(
+    `GET /repos/${owner}/${repo}/issues/${prNumber}`,
+    {
+      owner,
+      repo,
+      issue_number: issueNumber,
+    },
+  );
+
+  const startingPRLabels = pr.data.labels.map((label) => label.name);
+
+  const dedupedFinalPRLabels = [
+    ...new Set([...startingPRLabels, ...issueLabels]),
+  ];
+
+  const hasIssueAdditionalLabels = !sortedArrayEqual(
+    startingPRLabels,
+    dedupedFinalPRLabels,
+  );
+  if (hasIssueAdditionalLabels) {
+    await github.request(`PATCH /repos/${owner}/${repo}/issues/${prNumber}`, {
+      owner,
+      repo,
+      issue_number: prNumber,
+      labels: dedupedFinalPRLabels,
+    });
+  }
+}
+
+function getIssueNumberFromBranchName(branchName) {
+  console.log('Checking if the branch name references an issue...');
+
+  let issueNumber;
+  if (branchName.split('/').length > 1) {
+    issueNumber = branchName.split('/')[1].split('-')[0];
+  } else {
+    issueNumber = branchName.split('-')[0];
+  }
+
+  console.log(`Found issue number ${issueNumber} in branch name.`);
+
+  return issueNumber;
+}
+
+function sortedArrayEqual(array1, array2) {
+  const lengthsAreEqual = array1.length === array2.length;
+  const everyElementMatchesByIndex = array1.every(
+    (value, index) => value === array2[index],
+  );
+
+  return lengthsAreEqual && everyElementMatchesByIndex;
+}
+
+module.exports = { runLabelPRsAutomation };

--- a/.github/scripts/label-prs.ts
+++ b/.github/scripts/label-prs.ts
@@ -1,47 +1,74 @@
-async function runLabelPRsAutomation(context, github) {
-  let issueNumber = getIssueNumberFromPullRequestBody(context);
+import { context } from '@actions/github';
+import { GitHub } from '@actions/github/lib/utils';
 
-  if (issueNumber === -1) {
-    bailIfIsBranchNameInvalid(process.env.HEAD_REF);
-    bailIfIsNotFeatureBranch();
-    issueNumber = getIssueNumberFromBranchName(process.env.HEAD_REF);
+type GithubClient = InstanceType<typeof GitHub>;
+
+main().catch((error: Error): void => {
+  console.error(error);
+  process.exit(1);
+});
+
+async function main(): Promise<void> {
+  const github = new GitHub();
+
+  const logs = JSON.stringify({ github, context });
+  console.log(logs);
+  // github.event.pull_request.head.ref || "";
+  const HEAD_REF = 'test';
+
+  let issueNumber = await getIssueNumberFromPullRequestBody();
+
+  if (issueNumber === "") {
+    bailIfIsBranchNameInvalid(HEAD_REF);
+    bailIfIsNotFeatureBranch(HEAD_REF);
+    issueNumber = getIssueNumberFromBranchName(HEAD_REF);
   }
 
-  await updateLabels(context, github, issueNumber);
+  await updateLabels(github, issueNumber);
 }
 
-function getIssueNumberFromPullRequestBody(context) {
+async function getIssueNumberFromPullRequestBody(): Promise<string> {
   console.log("Checking if the PR's body references an issue...");
 
   let ISSUE_LINK_IN_PR_DESCRIPTION_REGEX =
     /(close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved)\s#\d+/gi;
 
-  const prBody = context.payload.pull_request.body;
+  const prBody = await getPullRequestBody();
 
   let matches = prBody.match(ISSUE_LINK_IN_PR_DESCRIPTION_REGEX);
-  if (matches.length === 0) {
+  if (!matches || matches?.length === 0) {
     console.log(
       'No direct link can be drawn between the PR and an issue from the PR body because no issue number was referenced.',
     );
-    return -1;
+    return "";
   }
 
-  if (matches.length > 1) {
+  if (matches?.length > 1) {
     console.log(
       'No direct link can be drawn between the PR and an issue from the PR body because more than one issue number was referenced.',
     );
-    return -1;
+    return "";
   }
 
-  ISSUE_NUMBER_REGEX = /\d+/;
-  const issueNumber = matches[0].match(ISSUE_NUMBER_REGEX)[0];
+  const ISSUE_NUMBER_REGEX = /\d+/;
+  const issueNumber = matches[0].match(ISSUE_NUMBER_REGEX)?.[0] || '';
 
   console.log(`Found issue number ${issueNumber} in PR body.`);
 
   return issueNumber;
 }
 
-function bailIfIsBranchNameInvalid(branchName) {
+async function getPullRequestBody(): Promise<string> {
+  if (context.eventName !== 'pull_request') {
+    console.log('This action should only run on pull_request events.');
+    process.exit(1);
+  }
+
+  const prBody = context.payload.pull_request?.body || '';
+  return prBody;
+}
+
+function bailIfIsBranchNameInvalid(branchName: string): void {
   const BRANCH_REGEX =
     /^(main|develop|(ci|chore|docs|feat|feature|fix|perf|refactor|revert|style)\/\d*(?:[-](?![-])\w*)*|Version-v\d+\.\d+\.\d+)$/;
   const isValidBranchName = new RegExp(BRANCH_REGEX).test(branchName);
@@ -59,13 +86,13 @@ function bailIfIsBranchNameInvalid(branchName) {
   }
 }
 
-function bailIfIsNotFeatureBranch() {
+function bailIfIsNotFeatureBranch(branchName: string): void {
   if (
-    process.env.HEAD_REF === 'main' ||
-    process.env.HEAD_REF === 'develop' ||
-    process.env.HEAD_REF.startsWith('Version-v')
+    branchName === 'main' ||
+    branchName === 'develop' ||
+    branchName.startsWith('Version-v')
   ) {
-    console.log(`${process.env.HEAD_REF} is not a feature branch.`);
+    console.log(`${branchName} is not a feature branch.`);
     console.log(
       'No issue could be linked to this PR, so no labels were copied',
     );
@@ -73,7 +100,11 @@ function bailIfIsNotFeatureBranch() {
   }
 }
 
-async function updateLabels(context, github, issueNumber) {
+async function updateLabels(github: GithubClient, issueNumber: string): Promise<void> {
+  interface ILabel {
+    name: string;
+  };
+
   const owner = context.repo.owner;
   const repo = context.repo.repo;
 
@@ -82,7 +113,7 @@ async function updateLabels(context, github, issueNumber) {
     { owner, repo, issue_number: issueNumber },
   );
 
-  const issueLabels = issue.data.labels.map((label) => label.name);
+  const issueLabels = issue.data.labels.map((label: ILabel): string => label.name);
 
   const prNumber = context.payload.number;
 
@@ -95,7 +126,7 @@ async function updateLabels(context, github, issueNumber) {
     },
   );
 
-  const startingPRLabels = pr.data.labels.map((label) => label.name);
+  const startingPRLabels = pr.data.labels.map((label: ILabel): string => label.name);
 
   const dedupedFinalPRLabels = [
     ...new Set([...startingPRLabels, ...issueLabels]),
@@ -115,10 +146,10 @@ async function updateLabels(context, github, issueNumber) {
   }
 }
 
-function getIssueNumberFromBranchName(branchName) {
+function getIssueNumberFromBranchName(branchName: string): string {
   console.log('Checking if the branch name references an issue...');
 
-  let issueNumber;
+  let issueNumber: string;
   if (branchName.split('/').length > 1) {
     issueNumber = branchName.split('/')[1].split('-')[0];
   } else {
@@ -130,13 +161,11 @@ function getIssueNumberFromBranchName(branchName) {
   return issueNumber;
 }
 
-function sortedArrayEqual(array1, array2) {
+function sortedArrayEqual(array1: string[], array2: string[]): boolean {
   const lengthsAreEqual = array1.length === array2.length;
   const everyElementMatchesByIndex = array1.every(
-    (value, index) => value === array2[index],
+    (value: string, index: number): boolean => value === array2[index],
   );
 
   return lengthsAreEqual && everyElementMatchesByIndex;
 }
-
-module.exports = { runLabelPRsAutomation };

--- a/.github/scripts/label-prs.ts
+++ b/.github/scripts/label-prs.ts
@@ -162,53 +162,6 @@ async function updateLabels(github: GithubClient, issueNumber: string, octokit: 
   }
 }
 
-
-// async function updateLabels(github: GithubClient, issueNumber: string, octokit: InstanceType<typeof GitHub>): Promise<void> {
-//   interface ILabel {
-//     name: string;
-//   };
-
-//   const owner = context.repo.owner;
-//   const repo = context.repo.repo;
-
-//   const issue = await github.request(
-//     `GET /repos/${owner}/${repo}/issues/${issueNumber}`,
-//     { owner, repo, issue_number: issueNumber },
-//   );
-
-//   const issueLabels = issue.data.labels.map((label: ILabel): string => label.name);
-
-//   const prNumber = context.payload.number;
-
-//   const pr = await github.request(
-//     `GET /repos/${owner}/${repo}/issues/${prNumber}`,
-//     {
-//       owner,
-//       repo,
-//       issue_number: issueNumber,
-//     },
-//   );
-
-//   const startingPRLabels = pr.data.labels.map((label: ILabel): string => label.name);
-
-//   const dedupedFinalPRLabels = [
-//     ...new Set([...startingPRLabels, ...issueLabels]),
-//   ];
-
-//   const hasIssueAdditionalLabels = !sortedArrayEqual(
-//     startingPRLabels,
-//     dedupedFinalPRLabels,
-//   );
-//   if (hasIssueAdditionalLabels) {
-//     await octokit.rest.issues.update({
-//       owner,
-//       repo,
-//       issue_number: prNumber,
-//       labels: dedupedFinalPRLabels,
-//     });
-//   }
-// }
-
 function getIssueNumberFromBranchName(branchName: string): string {
   console.log('Checking if the branch name references an issue...');
 

--- a/.github/scripts/label-prs.ts
+++ b/.github/scripts/label-prs.ts
@@ -13,15 +13,15 @@ async function main(): Promise<void> {
 
   const logs = JSON.stringify({ github, context });
   console.log(logs);
-  // github.event.pull_request.head.ref || "";
-  const HEAD_REF = 'test';
+  const headRef = context.payload.pull_request?.head.ref || '';
+  console.log({ headRef, args: process.argv })
 
   let issueNumber = await getIssueNumberFromPullRequestBody();
 
   if (issueNumber === "") {
-    bailIfIsBranchNameInvalid(HEAD_REF);
-    bailIfIsNotFeatureBranch(HEAD_REF);
-    issueNumber = getIssueNumberFromBranchName(HEAD_REF);
+    bailIfIsBranchNameInvalid(headRef);
+    bailIfIsNotFeatureBranch(headRef);
+    issueNumber = getIssueNumberFromBranchName(headRef);
   }
 
   await updateLabels(github, issueNumber);

--- a/.github/scripts/label-prs.ts
+++ b/.github/scripts/label-prs.ts
@@ -117,49 +117,90 @@ async function updateLabels(github: GithubClient, issueNumber: string, octokit: 
   const owner = context.repo.owner;
   const repo = context.repo.repo;
 
-  const issue = await github.request(
-    `GET /repos/${owner}/${repo}/issues/${issueNumber}`,
-    { owner, repo, issue_number: issueNumber },
-  );
+  const issue = await octokit.rest.issues.get({
+    owner: owner,
+    repo: repo,
+    issue_number: Number(issueNumber),
+  });
 
-  const issueLabels = issue.data.labels.map((label: ILabel): string => label.name);
+  console.log({ labels: issue.data.labels })
 
-  const prNumber = context.payload.number;
+  // const issueLabels = issue.data.labels.map((label: ILabel): string => label.name);
 
-  const pr = await github.request(
-    `GET /repos/${owner}/${repo}/issues/${prNumber}`,
-    {
-      owner,
-      repo,
-      issue_number: issueNumber,
-    },
-  );
+  // const prNumber = context.payload.number;
 
-  const startingPRLabels = pr.data.labels.map((label: ILabel): string => label.name);
+  // const pr = await octokit.rest.issues.get({
+  //   owner: owner,
+  //   repo: repo,
+  //   issue_number: prNumber,
+  // });
 
-  const dedupedFinalPRLabels = [
-    ...new Set([...startingPRLabels, ...issueLabels]),
-  ];
+  // const startingPRLabels = pr.data.labels.map((label: ILabel): string => label.name);
 
-  const hasIssueAdditionalLabels = !sortedArrayEqual(
-    startingPRLabels,
-    dedupedFinalPRLabels,
-  );
-  if (hasIssueAdditionalLabels) {
-    await octokit.rest.issues.update({
-      owner,
-      repo,
-      issue_number: prNumber,
-      labels: dedupedFinalPRLabels,
-    });
-    // await github.request(`PATCH /repos/${owner}/${repo}/issues/${prNumber}`, {
-    //   owner,
-    //   repo,
-    //   issue_number: prNumber,
-    //   labels: dedupedFinalPRLabels,
-    // });
-  }
+  // const dedupedFinalPRLabels = [
+  //   ...new Set([...startingPRLabels, ...issueLabels]),
+  // ];
+
+  // const hasIssueAdditionalLabels = !sortedArrayEqual(
+  //   startingPRLabels,
+  //   dedupedFinalPRLabels,
+  // );
+  // if (hasIssueAdditionalLabels) {
+  //   await octokit.rest.issues.update({
+  //     owner,
+  //     repo,
+  //     issue_number: prNumber,
+  //     labels: dedupedFinalPRLabels,
+  //   });
+  // }
 }
+
+
+// async function updateLabels(github: GithubClient, issueNumber: string, octokit: InstanceType<typeof GitHub>): Promise<void> {
+//   interface ILabel {
+//     name: string;
+//   };
+
+//   const owner = context.repo.owner;
+//   const repo = context.repo.repo;
+
+//   const issue = await github.request(
+//     `GET /repos/${owner}/${repo}/issues/${issueNumber}`,
+//     { owner, repo, issue_number: issueNumber },
+//   );
+
+//   const issueLabels = issue.data.labels.map((label: ILabel): string => label.name);
+
+//   const prNumber = context.payload.number;
+
+//   const pr = await github.request(
+//     `GET /repos/${owner}/${repo}/issues/${prNumber}`,
+//     {
+//       owner,
+//       repo,
+//       issue_number: issueNumber,
+//     },
+//   );
+
+//   const startingPRLabels = pr.data.labels.map((label: ILabel): string => label.name);
+
+//   const dedupedFinalPRLabels = [
+//     ...new Set([...startingPRLabels, ...issueLabels]),
+//   ];
+
+//   const hasIssueAdditionalLabels = !sortedArrayEqual(
+//     startingPRLabels,
+//     dedupedFinalPRLabels,
+//   );
+//   if (hasIssueAdditionalLabels) {
+//     await octokit.rest.issues.update({
+//       owner,
+//       repo,
+//       issue_number: prNumber,
+//       labels: dedupedFinalPRLabels,
+//     });
+//   }
+// }
 
 function getIssueNumberFromBranchName(branchName: string): string {
   console.log('Checking if the branch name references an issue...');

--- a/.github/scripts/label-prs.ts
+++ b/.github/scripts/label-prs.ts
@@ -2,25 +2,20 @@ import * as core from '@actions/core';
 import { context, getOctokit } from '@actions/github';
 import { GitHub } from '@actions/github/lib/utils';
 
-type GithubClient = InstanceType<typeof GitHub>;
-
-const token = process.env.GITHUB_TOKEN;
-
-if (!token) {
-  core.setFailed('GITHUB_TOKEN not found');
-  process.exit(1);
-}
-
-const octokit = getOctokit(token);
-
-
 main().catch((error: Error): void => {
   console.error(error);
   process.exit(1);
 });
 
 async function main(): Promise<void> {
-  const github = new GitHub();
+  const token = process.env.GITHUB_TOKEN;
+
+  if (!token) {
+    core.setFailed('GITHUB_TOKEN not found');
+    process.exit(1);
+  }
+
+  const octokit = getOctokit(token);
 
   const headRef = context.payload.pull_request?.head.ref || '';
 
@@ -31,7 +26,7 @@ async function main(): Promise<void> {
     issueNumber = getIssueNumberFromBranchName(headRef);
   }
 
-  await updateLabels(github, issueNumber, octokit);
+  await updateLabels(octokit, issueNumber);
 }
 
 async function getIssueNumberFromPullRequestBody(): Promise<string> {
@@ -107,18 +102,9 @@ function bailIfIsNotFeatureBranch(branchName: string): void {
   }
 }
 
-async function updateLabels(github: GithubClient, issueNumber: string, octokit: InstanceType<typeof GitHub>): Promise<void> {
+async function updateLabels(octokit: InstanceType<typeof GitHub>, issueNumber: string): Promise<void> {
   interface ILabel {
     name: string;
-    // value: string | {
-    //   id?: number | undefined;
-    //   node_id?: string | undefined;
-    //   url?: string | undefined;
-    //   name?: string | undefined;
-    //   description?: string | null | undefined;
-    //   color?: string | null | undefined;
-    //   default?: boolean | undefined;
-    // }
   };
 
   const owner = context.repo.owner;

--- a/.github/scripts/label-prs.ts
+++ b/.github/scripts/label-prs.ts
@@ -6,8 +6,6 @@ type GithubClient = InstanceType<typeof GitHub>;
 
 const token = process.env.GITHUB_TOKEN;
 
-console.log({ token });
-
 if (!token) {
   core.setFailed('GITHUB_TOKEN not found');
   process.exit(1);
@@ -112,6 +110,15 @@ function bailIfIsNotFeatureBranch(branchName: string): void {
 async function updateLabels(github: GithubClient, issueNumber: string, octokit: InstanceType<typeof GitHub>): Promise<void> {
   interface ILabel {
     name: string;
+    // value: string | {
+    //   id?: number | undefined;
+    //   node_id?: string | undefined;
+    //   url?: string | undefined;
+    //   name?: string | undefined;
+    //   description?: string | null | undefined;
+    //   color?: string | null | undefined;
+    //   default?: boolean | undefined;
+    // }
   };
 
   const owner = context.repo.owner;
@@ -123,36 +130,36 @@ async function updateLabels(github: GithubClient, issueNumber: string, octokit: 
     issue_number: Number(issueNumber),
   });
 
-  console.log({ labels: issue.data.labels })
+  const getNameFromLabel = (label: ILabel): string => label.name
 
-  // const issueLabels = issue.data.labels.map((label: ILabel): string => label.name);
+  const issueLabels = issue.data.labels.map(label => getNameFromLabel(label as ILabel));
 
-  // const prNumber = context.payload.number;
+  const prNumber = context.payload.number;
 
-  // const pr = await octokit.rest.issues.get({
-  //   owner: owner,
-  //   repo: repo,
-  //   issue_number: prNumber,
-  // });
+  const pr = await octokit.rest.issues.get({
+    owner: owner,
+    repo: repo,
+    issue_number: prNumber,
+  });
 
-  // const startingPRLabels = pr.data.labels.map((label: ILabel): string => label.name);
+  const startingPRLabels = pr.data.labels.map(label => getNameFromLabel(label as ILabel));
 
-  // const dedupedFinalPRLabels = [
-  //   ...new Set([...startingPRLabels, ...issueLabels]),
-  // ];
+  const dedupedFinalPRLabels = [
+    ...new Set([...startingPRLabels, ...issueLabels]),
+  ];
 
-  // const hasIssueAdditionalLabels = !sortedArrayEqual(
-  //   startingPRLabels,
-  //   dedupedFinalPRLabels,
-  // );
-  // if (hasIssueAdditionalLabels) {
-  //   await octokit.rest.issues.update({
-  //     owner,
-  //     repo,
-  //     issue_number: prNumber,
-  //     labels: dedupedFinalPRLabels,
-  //   });
-  // }
+  const hasIssueAdditionalLabels = !sortedArrayEqual(
+    startingPRLabels,
+    dedupedFinalPRLabels,
+  );
+  if (hasIssueAdditionalLabels) {
+    await octokit.rest.issues.update({
+      owner,
+      repo,
+      issue_number: prNumber,
+      labels: dedupedFinalPRLabels,
+    });
+  }
 }
 
 

--- a/.github/scripts/label-prs.ts
+++ b/.github/scripts/label-prs.ts
@@ -11,13 +11,9 @@ main().catch((error: Error): void => {
 async function main(): Promise<void> {
   const github = new GitHub();
 
-  const logs = JSON.stringify({ github, context });
-  console.log(logs);
   const headRef = context.payload.pull_request?.head.ref || '';
-  console.log({ headRef, args: process.argv })
 
   let issueNumber = await getIssueNumberFromPullRequestBody();
-
   if (issueNumber === "") {
     bailIfIsBranchNameInvalid(headRef);
     bailIfIsNotFeatureBranch(headRef);

--- a/.github/workflows/label-prs.yml
+++ b/.github/workflows/label-prs.yml
@@ -16,4 +16,4 @@ jobs:
         env:
           HEAD_REF: ${{ github.event.pull_request.head.ref }}
         with:
-          script: npm run stuff -- process.env.HEAD_REF
+          script: npm run label-prs -- process.env.HEAD_REF

--- a/.github/workflows/label-prs.yml
+++ b/.github/workflows/label-prs.yml
@@ -16,7 +16,4 @@ jobs:
         env:
           HEAD_REF: ${{ github.event.pull_request.head.ref }}
         with:
-          script: |
-            const { runLabelPRsAutomation } = require(require('path').resolve('./.github/scripts/label-prs.js'));
-
-            runLabelPRsAutomation(context, github);
+          script: npm run stuff -- process.env.HEAD_REF

--- a/.github/workflows/label-prs.yml
+++ b/.github/workflows/label-prs.yml
@@ -27,7 +27,4 @@ jobs:
       run: yarn
 
     - name: Run PR labelling script
-      env:
-        HEAD_REF: ${{ github.event.pull_request.head.ref }}
-      run: |
-        npm run label-prs -- process.env.HEAD_REF
+      run: npm run label-prs

--- a/.github/workflows/label-prs.yml
+++ b/.github/workflows/label-prs.yml
@@ -10,10 +10,18 @@ jobs:
     permissions:
       issues: write
       pull-requests: write
+
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/github-script@v6
-        env:
-          HEAD_REF: ${{ github.event.pull_request.head.ref }}
-        with:
-          script: npm run label-prs -- process.env.HEAD_REF
+    - name: Checkout code
+      uses: actions/checkout@v3
+
+    - name: Use Node.js
+      uses: actions/setup-node@v3
+      with:
+        node-version: '16'
+
+    - name: Run fitness functions
+      env:
+        HEAD_REF: ${{ github.event.pull_request.head.ref }}
+      run: |
+        npm run label-prs -- process.env.HEAD_REF

--- a/.github/workflows/label-prs.yml
+++ b/.github/workflows/label-prs.yml
@@ -28,3 +28,5 @@ jobs:
 
     - name: Run PR labelling script
       run: npm run label-prs
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/label-prs.yml
+++ b/.github/workflows/label-prs.yml
@@ -1,0 +1,22 @@
+name: Label PR
+
+on:
+  pull_request:
+    types: [assigned, opened, edited, synchronize, reopened]
+
+jobs:
+  label-pr:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/github-script@v6
+        env:
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+        with:
+          script: |
+            const { runLabelPRsAutomation } = require(require('path').resolve('./.github/scripts/label-prs.js'));
+
+            runLabelPRsAutomation(context, github);

--- a/.github/workflows/label-prs.yml
+++ b/.github/workflows/label-prs.yml
@@ -20,7 +20,13 @@ jobs:
       with:
         node-version: '16'
 
-    - name: Run fitness functions
+    - name: Install Yarn
+      run: npm install -g yarn
+
+    - name: Install dependencies
+      run: yarn
+
+    - name: Run PR labelling script
       env:
         HEAD_REF: ${{ github.event.pull_request.head.ref }}
       run: |

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+yarn validate-branch-name

--- a/.validate-branch-namerc.js
+++ b/.validate-branch-namerc.js
@@ -1,0 +1,11 @@
+const BRANCH_REGEX =
+  /^(main|develop|(ci|chore|docs|feat|feature|fix|perf|refactor|revert|style)\/\d*(?:[-](?![-])\w*)*|Version-v\d+\.\d+\.\d+)$/;
+
+const ERROR_MSG =
+  'This branch name does not follow our conventions.' +
+  '\n' +
+  'Rename it with "git branch -m <current-name> <new-name>"' +
+  '\n' +
+  'Here are some example branch names that are accepted: "fix/123-description", "feat/123-longer-description", "feature/123", "main", "develop", "Version-v10.24.2".';
+
+module.exports = { pattern: BRANCH_REGEX, errorMsg: ERROR_MSG };

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "fitness-functions": "ts-node development/fitness-functions/index.ts",
     "generate-beta-commit": "node ./development/generate-beta-commit.js",
     "validate-branch-name": "validate-branch-name",
-    "label-prs": "ts-node .github/scripts/label-prs.ts"
+    "label-prs": "ts-node ./.github/scripts/label-prs.ts"
   },
   "resolutions": {
     "analytics-node/axios": "^0.21.2",

--- a/package.json
+++ b/package.json
@@ -213,6 +213,7 @@
     "request@^2.85.0": "patch:request@npm%3A2.88.2#./.yarn/patches/request-npm-2.88.2-f4a57c72c4.patch"
   },
   "dependencies": {
+    "@actions/core": "^1.10.0",
     "@actions/github": "^5.1.1",
     "@babel/runtime": "^7.5.5",
     "@download/blockies": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -94,7 +94,8 @@
     "githooks:install": "husky install",
     "fitness-functions": "ts-node development/fitness-functions/index.ts",
     "generate-beta-commit": "node ./development/generate-beta-commit.js",
-    "validate-branch-name": "validate-branch-name"
+    "validate-branch-name": "validate-branch-name",
+    "label-prs": "ts-node .github/scripts/label-prs.ts"
   },
   "resolutions": {
     "analytics-node/axios": "^0.21.2",
@@ -212,6 +213,7 @@
     "request@^2.85.0": "patch:request@npm%3A2.88.2#./.yarn/patches/request-npm-2.88.2-f4a57c72c4.patch"
   },
   "dependencies": {
+    "@actions/github": "^5.1.1",
     "@babel/runtime": "^7.5.5",
     "@download/blockies": "^1.0.3",
     "@ensdomains/content-hash": "^2.5.6",

--- a/package.json
+++ b/package.json
@@ -93,7 +93,8 @@
     "test-storybook:ci": "concurrently -k -s first -n \"SB,TEST\" -c \"magenta,blue\" \"yarn storybook:build && npx http-server storybook-build --port 6006 \" \"wait-on tcp:6006 && yarn test-storybook --maxWorkers=2\"",
     "githooks:install": "husky install",
     "fitness-functions": "ts-node development/fitness-functions/index.ts",
-    "generate-beta-commit": "node ./development/generate-beta-commit.js"
+    "generate-beta-commit": "node ./development/generate-beta-commit.js",
+    "validate-branch-name": "validate-branch-name"
   },
   "resolutions": {
     "analytics-node/axios": "^0.21.2",
@@ -317,6 +318,7 @@
     "fuse.js": "^3.2.0",
     "globalthis": "^1.0.1",
     "human-standard-token-abi": "^2.0.0",
+    "husky": "^8.0.3",
     "immer": "^9.0.6",
     "is-retry-allowed": "^2.2.0",
     "jest-junit": "^14.0.1",
@@ -360,6 +362,7 @@
     "unicode-confusables": "^0.1.1",
     "uuid": "^8.3.2",
     "valid-url": "^1.0.9",
+    "validate-branch-name": "^1.3.0",
     "web3-stream-provider": "^4.0.0",
     "zxcvbn": "^4.4.2"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,6 +5,48 @@ __metadata:
   version: 6
   cacheKey: 8
 
+"@actions/github@npm:^5.1.1":
+  version: 5.1.1
+  resolution: "@actions/github@npm:5.1.1"
+  dependencies:
+    "@actions/http-client": ^2.0.1
+    "@octokit/core": ^3.6.0
+    "@octokit/plugin-paginate-rest": ^2.17.0
+    "@octokit/plugin-rest-endpoint-methods": ^5.13.0
+  checksum: 2210bd7f8e1e8b407b7df74a259523dc4c63f4ad3a6bfcc0d7867b6e9c3499bd3e25d7de7a9a1bbd0de3be441a8832d5c0b5c0cff3036cd477378c0ec5502434
+  languageName: node
+  linkType: hard
+
+"@actions/http-client@npm:^2.0.1":
+  version: 2.1.0
+  resolution: "@actions/http-client@npm:2.1.0"
+  dependencies:
+    tunnel: ^0.0.6
+  checksum: 25a72a952cc95fb4b3ab086da73a5754dd0957c206637cace69be2e16f018cc1b3d3c40d3bcf89ffd8a5929d5e8445594b498b50db306a50ad7536023f8e3800
+  languageName: node
+  linkType: hard
+
+"@agoric/babel-standalone@npm:^7.9.5":
+  version: 7.9.5
+  resolution: "@agoric/babel-standalone@npm:7.9.5"
+  checksum: 19c459bc5cb723b1fd0e18a2a39a1f5302554991de05ac28f261bb59314a07b6477768f58c64c8104121a0278596fc29fda2651dcefd2c6678adc811085511eb
+  languageName: node
+  linkType: hard
+
+"@agoric/make-hardener@npm:^0.1.2":
+  version: 0.1.3
+  resolution: "@agoric/make-hardener@npm:0.1.3"
+  checksum: d96ece30734558ad661bfc907b9b101f457df475e1ef83267d8068afe690acb2e12ce4d266124043dc22c61a7f8a3529f4a30d775981d18a6f0e012af5da3262
+  languageName: node
+  linkType: hard
+
+"@agoric/transform-module@npm:^0.4.1":
+  version: 0.4.1
+  resolution: "@agoric/transform-module@npm:0.4.1"
+  checksum: 36bf78c95d1f0f4bb64d3d8d32bb517591334dcc04f8428d493032275e5d070824fe23950345fe941641b2b1938bf175e78dbebd1f350ac157ec4e8787c1b4ec
+  languageName: node
+  linkType: hard
+
 "@ampproject/remapping@npm:^2.1.0":
   version: 2.2.0
   resolution: "@ampproject/remapping@npm:2.2.0"
@@ -4689,6 +4731,116 @@ __metadata:
     puka: ^1.0.1
     read-package-json-fast: ^1.1.3
   checksum: 4c5a381a06e5c1ec62785133c97b24453d8ca6f8b66b1a19b80cfa67c80b623c6ce1e07a41bfd1aa39bc4c635037dcd933390d4f7c332d39cfae625d9f3bcbf1
+  languageName: node
+  linkType: hard
+
+"@octokit/auth-token@npm:^2.4.4":
+  version: 2.5.0
+  resolution: "@octokit/auth-token@npm:2.5.0"
+  dependencies:
+    "@octokit/types": ^6.0.3
+  checksum: 45949296c09abcd6beb4c3f69d45b0c1f265f9581d2a9683cf4d1800c4cf8259c2f58d58e44c16c20bffb85a0282a176c0d51f4af300e428b863f27b910e6297
+  languageName: node
+  linkType: hard
+
+"@octokit/core@npm:^3.6.0":
+  version: 3.6.0
+  resolution: "@octokit/core@npm:3.6.0"
+  dependencies:
+    "@octokit/auth-token": ^2.4.4
+    "@octokit/graphql": ^4.5.8
+    "@octokit/request": ^5.6.3
+    "@octokit/request-error": ^2.0.5
+    "@octokit/types": ^6.0.3
+    before-after-hook: ^2.2.0
+    universal-user-agent: ^6.0.0
+  checksum: f81160129037bd8555d47db60cd5381637b7e3602ad70735a7bdf8f3d250c7b7114a666bb12ef7a8746a326a5d72ed30a1b8f8a5a170007f7285c8e217bef1f0
+  languageName: node
+  linkType: hard
+
+"@octokit/endpoint@npm:^6.0.1":
+  version: 6.0.12
+  resolution: "@octokit/endpoint@npm:6.0.12"
+  dependencies:
+    "@octokit/types": ^6.0.3
+    is-plain-object: ^5.0.0
+    universal-user-agent: ^6.0.0
+  checksum: b48b29940af11c4b9bca41cf56809754bb8385d4e3a6122671799d27f0238ba575b3fde86d2d30a84f4dbbc14430940de821e56ecc6a9a92d47fc2b29a31479d
+  languageName: node
+  linkType: hard
+
+"@octokit/graphql@npm:^4.5.8":
+  version: 4.8.0
+  resolution: "@octokit/graphql@npm:4.8.0"
+  dependencies:
+    "@octokit/request": ^5.6.0
+    "@octokit/types": ^6.0.3
+    universal-user-agent: ^6.0.0
+  checksum: f68afe53f63900d4a16a0a733f2f500df2695b731f8ed32edb728d50edead7f5011437f71d069c2d2f6d656227703d0c832a3c8af58ecf82bd5dcc051f2d2d74
+  languageName: node
+  linkType: hard
+
+"@octokit/openapi-types@npm:^12.11.0":
+  version: 12.11.0
+  resolution: "@octokit/openapi-types@npm:12.11.0"
+  checksum: 8a7d4bd6288cc4085cabe0ca9af2b87c875c303af932cb138aa1b2290eb69d32407759ac23707bb02776466e671244a902e9857896903443a69aff4b6b2b0e3b
+  languageName: node
+  linkType: hard
+
+"@octokit/plugin-paginate-rest@npm:^2.17.0":
+  version: 2.21.3
+  resolution: "@octokit/plugin-paginate-rest@npm:2.21.3"
+  dependencies:
+    "@octokit/types": ^6.40.0
+  peerDependencies:
+    "@octokit/core": ">=2"
+  checksum: acf31de2ba4021bceec7ff49c5b0e25309fc3c009d407f153f928ddf436ab66cd4217344138378d5523f5fb233896e1db58c9c7b3ffd9612a66d760bc5d319ed
+  languageName: node
+  linkType: hard
+
+"@octokit/plugin-rest-endpoint-methods@npm:^5.13.0":
+  version: 5.16.2
+  resolution: "@octokit/plugin-rest-endpoint-methods@npm:5.16.2"
+  dependencies:
+    "@octokit/types": ^6.39.0
+    deprecation: ^2.3.1
+  peerDependencies:
+    "@octokit/core": ">=3"
+  checksum: 30fcc50c335d1093f03573d9fa3a4b7d027fc98b215c43e07e82ee8dabfa0af0cf1b963feb542312ae32d897a2f68dc671577206f30850215517bebedc5a2c73
+  languageName: node
+  linkType: hard
+
+"@octokit/request-error@npm:^2.0.5, @octokit/request-error@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "@octokit/request-error@npm:2.1.0"
+  dependencies:
+    "@octokit/types": ^6.0.3
+    deprecation: ^2.0.0
+    once: ^1.4.0
+  checksum: baec2b5700498be01b4d958f9472cb776b3f3b0ea52924323a07e7a88572e24cac2cdf7eb04a0614031ba346043558b47bea2d346e98f0e8385b4261f138ef18
+  languageName: node
+  linkType: hard
+
+"@octokit/request@npm:^5.6.0, @octokit/request@npm:^5.6.3":
+  version: 5.6.3
+  resolution: "@octokit/request@npm:5.6.3"
+  dependencies:
+    "@octokit/endpoint": ^6.0.1
+    "@octokit/request-error": ^2.1.0
+    "@octokit/types": ^6.16.1
+    is-plain-object: ^5.0.0
+    node-fetch: ^2.6.7
+    universal-user-agent: ^6.0.0
+  checksum: c0b4542eb4baaf880d673c758d3e0b5c4a625a4ae30abf40df5548b35f1ff540edaac74625192b1aff42a79ac661e774da4ab7d5505f1cb4ef81239b1e8510c5
+  languageName: node
+  linkType: hard
+
+"@octokit/types@npm:^6.0.3, @octokit/types@npm:^6.16.1, @octokit/types@npm:^6.39.0, @octokit/types@npm:^6.40.0":
+  version: 6.41.0
+  resolution: "@octokit/types@npm:6.41.0"
+  dependencies:
+    "@octokit/openapi-types": ^12.11.0
+  checksum: fd6f75e0b19b90d1a3d244d2b0c323ed8f2f05e474a281f60a321986683548ef2e0ec2b3a946aa9405d6092e055344455f69f58957c60f58368c8bdda5b7d2ab
   languageName: node
   linkType: hard
 
@@ -10358,6 +10510,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"before-after-hook@npm:^2.2.0":
+  version: 2.2.3
+  resolution: "before-after-hook@npm:2.2.3"
+  checksum: a1a2430976d9bdab4cd89cb50d27fa86b19e2b41812bf1315923b0cba03371ebca99449809226425dd3bcef20e010db61abdaff549278e111d6480034bebae87
+  languageName: node
+  linkType: hard
+
 "better-opn@npm:^2.1.1":
   version: 2.1.1
   resolution: "better-opn@npm:2.1.1"
@@ -13798,6 +13957,13 @@ __metadata:
   bin:
     dependency-tree: bin/cli.js
   checksum: e26dffd0332b80ac6303fa4073dcd8f3df05c1584e26fe8fd15f59572f0427e8618757e9797d8963578648f80eb9d4f4496f25bbbb5984329b4c55e49e51d7be
+  languageName: node
+  linkType: hard
+
+"deprecation@npm:^2.0.0, deprecation@npm:^2.3.1":
+  version: 2.3.1
+  resolution: "deprecation@npm:2.3.1"
+  checksum: f56a05e182c2c195071385455956b0c4106fe14e36245b00c689ceef8e8ab639235176a96977ba7c74afb173317fac2e0ec6ec7a1c6d1e6eaa401c586c714132
   languageName: node
   linkType: hard
 
@@ -24003,6 +24169,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "metamask-crx@workspace:."
   dependencies:
+    "@actions/github": ^5.1.1
     "@babel/code-frame": ^7.12.13
     "@babel/core": ^7.12.1
     "@babel/eslint-parser": ^7.13.14
@@ -33647,6 +33814,13 @@ __metadata:
     unist-util-is: ^4.0.0
     unist-util-visit-parents: ^3.0.0
   checksum: 1fe19d500e212128f96d8c3cfa3312846e586b797748a1fd195fe6479f06bc90a6f6904deb08eefc00dd58e83a1c8a32fb8677252d2273ad7a5e624525b69b8f
+  languageName: node
+  linkType: hard
+
+"universal-user-agent@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "universal-user-agent@npm:6.0.0"
+  checksum: 5092bbc80dd0d583cef0b62c17df0043193b74f425112ea6c1f69bc5eda21eeec7a08d8c4f793a277eb2202ffe9b44bec852fa3faff971234cd209874d1b79ef
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -9913,6 +9913,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"babel-plugin-add-module-exports@npm:^0.2.1":
+  version: 0.2.1
+  resolution: "babel-plugin-add-module-exports@npm:0.2.1"
+  checksum: 0d40e7b970161a10960fbbd0492565ae2f3f4872b4da089f8f5bb874cfac4e38e088e4d96bc33cef22a8963774abe84622feeebbbe049ad95c4ee33c907b277d
+  languageName: node
+  linkType: hard
+
 "babel-plugin-add-react-displayname@npm:^0.0.5":
   version: 0.0.5
   resolution: "babel-plugin-add-react-displayname@npm:0.0.5"
@@ -13247,6 +13254,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"current-git-branch@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "current-git-branch@npm:1.1.0"
+  dependencies:
+    babel-plugin-add-module-exports: ^0.2.1
+    execa: ^0.6.1
+    is-git-repository: ^1.0.0
+  checksum: 57042d5c9fc608a951e81310da1caa3bdf917d0fede06996bfd7eaab5bdee7d29ced3440c3c73e5d90e503e689e2084e1906b1a17723e35684b1579d1bb5a54f
+  languageName: node
+  linkType: hard
+
+"currently-unhandled@npm:^0.4.1":
+  version: 0.4.1
+  resolution: "currently-unhandled@npm:0.4.1"
+  dependencies:
+    array-find-index: ^1.0.1
+  checksum: 1f59fe10b5339b54b1a1eee110022f663f3495cf7cf2f480686e89edc7fa8bfe42dbab4b54f85034bc8b092a76cc7becbc2dad4f9adad332ab5831bec39ad540
+  languageName: node
+  linkType: hard
+
 "cwd@npm:^0.10.0":
   version: 0.10.0
   resolution: "cwd@npm:0.10.0"
@@ -16170,6 +16197,21 @@ __metadata:
   version: 0.3.6
   resolution: "exec-sh@npm:0.3.6"
   checksum: 0be4f06929c8e4834ea4812f29fe59e2dfcc1bc3fc4b4bb71acb38a500c3b394628a05ef7ba432520bc6c5ec4fadab00cc9c513c4ff6a32104965af302e998e0
+  languageName: node
+  linkType: hard
+
+"execa@npm:^0.6.1":
+  version: 0.6.3
+  resolution: "execa@npm:0.6.3"
+  dependencies:
+    cross-spawn: ^5.0.1
+    get-stream: ^3.0.0
+    is-stream: ^1.1.0
+    npm-run-path: ^2.0.0
+    p-finally: ^1.0.0
+    signal-exit: ^3.0.0
+    strip-eof: ^1.0.0
+  checksum: 2c66177731273a7c0a4c031af81b486b67ec1eeeb8f353ebc68e0cfe7f63aca9ebc1e6fe03ba10f130f2bd179c0ac69b35668fe2bfc1ceb68fbf5291d0783457
   languageName: node
   linkType: hard
 
@@ -20033,6 +20075,16 @@ __metadata:
   dependencies:
     has-tostringtag: ^1.0.0
   checksum: d54644e7dbaccef15ceb1e5d91d680eb5068c9ee9f9eb0a9e04173eb5542c9b51b5ab52c5537f5703e48d5fddfd376817c1ca07a84a407b7115b769d4bdde72b
+  languageName: node
+  linkType: hard
+
+"is-git-repository@npm:^1.0.0":
+  version: 1.1.1
+  resolution: "is-git-repository@npm:1.1.1"
+  dependencies:
+    execa: ^0.6.1
+    path-is-absolute: ^1.0.1
+  checksum: 2873d41da9ae5771a9118bdd743f32fa868301c57e8e4d8e255d4e14c04267112294a29f2824531fa554696042d8d87185811cff2de2a06381cff7d61d9ac22d
   languageName: node
   linkType: hard
 
@@ -24280,6 +24332,7 @@ __metadata:
     unicode-confusables: ^0.1.1
     uuid: ^8.3.2
     valid-url: ^1.0.9
+    validate-branch-name: ^1.3.0
     vinyl: ^2.2.1
     vinyl-buffer: ^1.0.1
     vinyl-source-stream: ^2.0.0
@@ -33953,6 +34006,19 @@ __metadata:
   version: 1.0.9
   resolution: "valid-url@npm:1.0.9"
   checksum: 3ecb030559404441c2cf104cbabab8770efb0f36d117db03d1081052ef133015a68806148ce954bb4dd0b5c42c14b709a88783c93d66b0916cb67ba771c98702
+  languageName: node
+  linkType: hard
+
+"validate-branch-name@npm:^1.3.0":
+  version: 1.3.0
+  resolution: "validate-branch-name@npm:1.3.0"
+  dependencies:
+    commander: ^8.3.0
+    cosmiconfig: ^7.0.1
+    current-git-branch: ^1.1.0
+  bin:
+    validate-branch-name: cli.js
+  checksum: be82c1e39bfe0519fa02f01670b5ef928903a19289249559c9148c0fd20df356f373f2490fbfd54d018868a6348cc2ceb82fb67d5f5c48c15ecb48735b9b87fb
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,6 +5,16 @@ __metadata:
   version: 6
   cacheKey: 8
 
+"@actions/core@npm:^1.10.0":
+  version: 1.10.0
+  resolution: "@actions/core@npm:1.10.0"
+  dependencies:
+    "@actions/http-client": ^2.0.1
+    uuid: ^8.3.2
+  checksum: 0a75621e007ab20d887434cdd165f0b9036f14c22252a2faed33543d8b9d04ec95d823e69ca636a25245574e4585d73e1e9e47a845339553c664f9f2c9614669
+  languageName: node
+  linkType: hard
+
 "@actions/github@npm:^5.1.1":
   version: 5.1.1
   resolution: "@actions/github@npm:5.1.1"
@@ -23,27 +33,6 @@ __metadata:
   dependencies:
     tunnel: ^0.0.6
   checksum: 25a72a952cc95fb4b3ab086da73a5754dd0957c206637cace69be2e16f018cc1b3d3c40d3bcf89ffd8a5929d5e8445594b498b50db306a50ad7536023f8e3800
-  languageName: node
-  linkType: hard
-
-"@agoric/babel-standalone@npm:^7.9.5":
-  version: 7.9.5
-  resolution: "@agoric/babel-standalone@npm:7.9.5"
-  checksum: 19c459bc5cb723b1fd0e18a2a39a1f5302554991de05ac28f261bb59314a07b6477768f58c64c8104121a0278596fc29fda2651dcefd2c6678adc811085511eb
-  languageName: node
-  linkType: hard
-
-"@agoric/make-hardener@npm:^0.1.2":
-  version: 0.1.3
-  resolution: "@agoric/make-hardener@npm:0.1.3"
-  checksum: d96ece30734558ad661bfc907b9b101f457df475e1ef83267d8068afe690acb2e12ce4d266124043dc22c61a7f8a3529f4a30d775981d18a6f0e012af5da3262
-  languageName: node
-  linkType: hard
-
-"@agoric/transform-module@npm:^0.4.1":
-  version: 0.4.1
-  resolution: "@agoric/transform-module@npm:0.4.1"
-  checksum: 36bf78c95d1f0f4bb64d3d8d32bb517591334dcc04f8428d493032275e5d070824fe23950345fe941641b2b1938bf175e78dbebd1f350ac157ec4e8787c1b4ec
   languageName: node
   linkType: hard
 
@@ -13424,15 +13413,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"currently-unhandled@npm:^0.4.1":
-  version: 0.4.1
-  resolution: "currently-unhandled@npm:0.4.1"
-  dependencies:
-    array-find-index: ^1.0.1
-  checksum: 1f59fe10b5339b54b1a1eee110022f663f3495cf7cf2f480686e89edc7fa8bfe42dbab4b54f85034bc8b092a76cc7becbc2dad4f9adad332ab5831bec39ad540
-  languageName: node
-  linkType: hard
-
 "cwd@npm:^0.10.0":
   version: 0.10.0
   resolution: "cwd@npm:0.10.0"
@@ -24169,6 +24149,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "metamask-crx@workspace:."
   dependencies:
+    "@actions/core": ^1.10.0
     "@actions/github": ^5.1.1
     "@babel/code-frame": ^7.12.13
     "@babel/core": ^7.12.1


### PR DESCRIPTION
## Explanation

We search on the body of our PR for the issue it closes (as per [our PR template](https://github.com/MetaMask/metamask-extension/blob/develop/.github/PULL_REQUEST_TEMPLATE.md?plain=1#L11)).

A one-to-one link can only be established if the PR body contains one issue number. Otherwise, we use the branch name to establish the connection between the Issue and the Pull Request. For that to work, we nudge developers to do that via the (opt-in) pre-commit hook and enforce it in the CI job.

Syncing the labels is unidirectional and non-destructive. PRs get the labels from the associated issue, but an issue does not ever get new labels automatically. Preexisting PR labels that are not on the issues persist.

No labels are copied if developers do not include an issue number on the PR body and the branch name does not adhere to the convention.

Closes #17602 

 ## How to test

- Remove PR labels
- Clear assignees for the PR
- Assign the PR to me
- The relevant job will trigger and add the issue labels automatically