### PR TITLE
add brad-decker as codeowner of .circle/ folder

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -21,7 +21,7 @@ lavamoat/                            @MetaMask/supply-chain
 # empower our CI steps. ANY addition of orbs to our CircleCI config
 # should be brought to the attention of engineering leadership for
 # discussion
-.circleci/                           @MetaMask/library-admins @kumavis
+.circleci/                           @MetaMask/library-admins @kumavis @brad-decker
 # The CODEOWNERS file constitutes an agreement amongst organization
 # admins and maintainers to restrict approval capabilities to a subset
 # of contributors. Modifications to this file result in a modification of


### PR DESCRIPTION
## Explanation
Currently changes to circleci folder require review from library-admins, which is good because we want to be extra careful about the circleci configuration. However, only one member of that team are currently on the extension team and therefore getting prs merged around these changes are difficult. I have added myself to the list as an additional owner to help with reviews of these prs. 
