### PR TITLE
MenuItem: Fix layout of menu item with subtitle

### DIFF
--- a/test/e2e/tests/dapp-interactions.spec.js
+++ b/test/e2e/tests/dapp-interactions.spec.js
@@ -109,7 +109,7 @@ describe('Dapp interactions', function () {
         await driver.clickElement(
           '[data-testid ="account-options-menu-button"]',
         );
-        await driver.clickElement({ text: 'Connected sites', tag: 'span' });
+        await driver.clickElement({ text: 'Connected sites', tag: 'div' });
         const connectedDapp1 = await driver.isElementPresent({
           text: 'http://127.0.0.1:8080',
           tag: 'bdi',

--- a/test/e2e/tests/token-details.spec.js
+++ b/test/e2e/tests/token-details.spec.js
@@ -36,7 +36,7 @@ describe('Token Details', function () {
         await driver.clickElement({ text: 'Add custom token', tag: 'button' });
         await driver.clickElement({ text: 'Import tokens', tag: 'button' });
         await driver.clickElement('[aria-label="Asset options"]');
-        await driver.clickElement({ text: 'Token details', tag: 'span' });
+        await driver.clickElement({ text: 'Token details', tag: 'div' });
 
         const tokenAddressFound = {
           text: tokenAddress,

--- a/ui/components/ui/menu/menu-item.js
+++ b/ui/components/ui/menu/menu-item.js
@@ -20,8 +20,10 @@ const MenuItem = ({
     {iconName ? (
       <Icon name={iconName} size={ICON_SIZES.SM} marginRight={2} />
     ) : null}
-    <span>{children}</span>
-    {subtitle}
+    <div>
+      <div>{children}</div>
+      {subtitle ? <div>{subtitle}</div> : null}
+    </div>
   </button>
 );
 


### PR DESCRIPTION
## Explanation

Recent changes to the MenuItem structure in https://github.com/MetaMask/metamask-extension/commit/edb2c9ea00e7c320706ef8d981839576297b102a threw off the display on L2s because we display the block explorer address.  This PR fixes the issue.

## Screenshots/Screencaps

<img width="330" alt="MenuItems" src="https://user-images.githubusercontent.com/46655/217355936-fca8e883-ca88-4f27-adb4-1519a41da4b3.png">


## Manual Testing Steps

1.  Add the Polygon network in Settings
2. Open the three-dot menu on the account home screen
3. Ensure the icon and text display as they should

## Pre-merge author checklist

- [ ] I've clearly explained:
  - [ ] What problem this PR is solving
  - [ ] How this problem was solved
  - [ ] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
