### PR TITLE
Fix for error during sending to multisig address

### DIFF
--- a/shared/modules/Numeric.test.ts
+++ b/shared/modules/Numeric.test.ts
@@ -537,5 +537,29 @@ describe('Numeric', () => {
         );
       });
     });
+
+    describe('round', () => {
+      it('should return number rounded', () => {
+        expect(new Numeric(10.4375, 10).round()).toEqual(
+          new Numeric(10.4375, 10),
+        );
+        expect(new Numeric(10.4375, 10).round(0)).toEqual(new Numeric(10, 10));
+        expect(new Numeric(10.4375, 10).round(1)).toEqual(
+          new Numeric(10.4, 10),
+        );
+        expect(new Numeric(10.4375, 10).round(2)).toEqual(
+          new Numeric(10.44, 10),
+        );
+        expect(new Numeric(10.4375, 10).round(3)).toEqual(
+          new Numeric(10.437, 10),
+        );
+        expect(new Numeric(10.4375, 10).round(4)).toEqual(
+          new Numeric(10.4375, 10),
+        );
+        expect(new Numeric(10.4375, 10).round(5)).toEqual(
+          new Numeric(10.4375, 10),
+        );
+      });
+    });
   });
 });

--- a/shared/modules/Numeric.ts
+++ b/shared/modules/Numeric.ts
@@ -434,7 +434,7 @@ export class Numeric {
     numberOfDecimals?: number,
     roundingMode: number = BigNumber.ROUND_HALF_DOWN,
   ) {
-    if (numberOfDecimals) {
+    if (typeof numberOfDecimals === 'number') {
       return new Numeric(
         this.value.round(numberOfDecimals, roundingMode),
         this.base,


### PR DESCRIPTION
## Explanation
If you try to send ETH to a multisig Gnosis Safe wallet address, the transaction fails and you get the below error

`Cannot convert string to buffer. toBuffer only supports 0x-prefixed hex strings and this string was given: 0xa021.8`

This is caused by a bug in how we handle round-ing numbers.


* Fixes #17488 

## Screenshots/Screencaps

### Before
https://user-images.githubusercontent.com/54408225/215474800-9cd49f9b-a000-4807-a908-97e75fdf5f54.mp4

### After

https://user-images.githubusercontent.com/44811/217367947-a09e1a75-b1d7-4c71-b2ee-36b5566c1da4.mov


## Manual Testing Steps

1. On develop branch, follow the steps in the before video above to reproduce the error
2. On this branch, follow the steps in the after video to see the fix.

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
