### PR TITLE
Deprecating Typography component

### DIFF
--- a/ui/components/ui/typography/README.mdx
+++ b/ui/components/ui/typography/README.mdx
@@ -1,6 +1,19 @@
 import { Story, Canvas, ArgsTable } from '@storybook/addon-docs';
 import ActionableMessage from '../actionable-message';
 import Typography from '.';
+import { SEVERITIES } from '../../../helpers/constants/design-system';
+
+import { BannerAlert } from '../../component-library/banner-alert';
+
+<BannerAlert
+  severity={SEVERITIES.WARNING}
+  title="Deprecated"
+  description="<Typography/> has been deprecated in favour of the <Text /> component"
+  actionButtonLabel="See details"
+  actionButtonProps={{
+    href: 'https://github.com/MetaMask/metamask-extension/issues/17670',
+  }}
+/>
 
 # Typography
 

--- a/ui/components/ui/typography/typography.js
+++ b/ui/components/ui/typography/typography.js
@@ -53,6 +53,14 @@ export const ValidTags = [
   'label',
 ];
 
+/**
+ * @deprecated `<Typography />` has been deprecated in favour of the `<Text />` component in ./ui/components/component-library/text/text.js
+ *
+ * See storybook documentation for Text here https://metamask.github.io/metamask-storybook/?path=/docs/components-componentlibrary-text--default-story#text
+ *
+ * Help to replace `Typography` with `Text` by submitting PRs against https://github.com/MetaMask/metamask-extension/issues/17670
+ */
+
 export default function Typography({
   variant = TypographyVariant.paragraph,
   color = Color.textDefault,

--- a/ui/components/ui/typography/typography.scss
+++ b/ui/components/ui/typography/typography.scss
@@ -1,3 +1,11 @@
+/**
+ * @deprecated `<Typography />` has been deprecated in favour of the `<Text />` component in ./ui/components/component-library/text/text.js
+ *
+ * See storybook documentation for Text here https://metamask.github.io/metamask-storybook/?path=/docs/components-componentlibrary-text--default-story#text
+ *
+ * Help to replace `Typography` with `Text` by submitting PRs against https://github.com/MetaMask/metamask-extension/issues/17670
+ */
+
 @use "design-system";
 @use "sass:map";
 

--- a/ui/components/ui/typography/typography.stories.js
+++ b/ui/components/ui/typography/typography.stories.js
@@ -14,12 +14,12 @@ import {
 } from '../../../helpers/constants/design-system';
 import Box from '../box';
 
+import { BannerAlert } from '../../component-library/banner-alert';
+
 import { ValidColors, ValidTags } from './typography';
 
 import README from './README.mdx';
 import Typography from '.';
-
-import { BannerAlert } from '../../component-library/banner-alert';
 
 const sizeKnobOptions = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
 const marginSizeKnobOptions = [...sizeKnobOptions, 'auto'];

--- a/ui/components/ui/typography/typography.stories.js
+++ b/ui/components/ui/typography/typography.stories.js
@@ -10,6 +10,7 @@ import {
   Color as ColorEnum,
   TextColor,
   BorderColor,
+  SEVERITIES,
 } from '../../../helpers/constants/design-system';
 import Box from '../box';
 
@@ -17,6 +18,8 @@ import { ValidColors, ValidTags } from './typography';
 
 import README from './README.mdx';
 import Typography from '.';
+
+import { BannerAlert } from '../../component-library/banner-alert';
 
 const sizeKnobOptions = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
 const marginSizeKnobOptions = [...sizeKnobOptions, 'auto'];
@@ -104,12 +107,23 @@ function renderBackgroundColor(color) {
 }
 
 export const DefaultStory = (args) => (
-  <Typography
-    boxProps={{ backgroundColor: renderBackgroundColor(args.color) }}
-    {...args}
-  >
-    {args.children}
-  </Typography>
+  <>
+    <BannerAlert
+      severity={SEVERITIES.WARNING}
+      title="Deprecated"
+      description="<Typography/> has been deprecated in favour of the <Text /> component"
+      actionButtonLabel="See details"
+      actionButtonProps={{
+        href: 'https://github.com/MetaMask/metamask-extension/issues/17670',
+      }}
+    />
+    <Typography
+      boxProps={{ backgroundColor: renderBackgroundColor(args.color) }}
+      {...args}
+    >
+      {args.children}
+    </Typography>
+  </>
 );
 
 DefaultStory.storyName = 'Default';
@@ -120,6 +134,15 @@ DefaultStory.args = {
 
 export const Variant = (args) => (
   <>
+    <BannerAlert
+      severity={SEVERITIES.WARNING}
+      title="Deprecated"
+      description="<Typography/> has been deprecated in favour of the <Text /> component"
+      actionButtonLabel="See details"
+      actionButtonProps={{
+        href: 'https://github.com/MetaMask/metamask-extension/issues/17670',
+      }}
+    />
     {Object.values(TypographyVariant).map((variant) => (
       <Typography
         boxProps={{ backgroundColor: renderBackgroundColor(args.color) }}
@@ -138,6 +161,15 @@ export const Color = (args) => {
   const LAST_VALID_COLORS_ARRAY_INDEX = 16;
   return (
     <>
+      <BannerAlert
+        severity={SEVERITIES.WARNING}
+        title="Deprecated"
+        description="<Typography/> has been deprecated in favour of the <Text /> component"
+        actionButtonLabel="See details"
+        actionButtonProps={{
+          href: 'https://github.com/MetaMask/metamask-extension/issues/17670',
+        }}
+      />
       {Object.values(ValidColors).map((color, index) => {
         if (index === LAST_VALID_COLORS_ARRAY_INDEX) {
           return (
@@ -191,6 +223,15 @@ export const Color = (args) => {
 
 export const FontWeight = (args) => (
   <>
+    <BannerAlert
+      severity={SEVERITIES.WARNING}
+      title="Deprecated"
+      description="<Typography/> has been deprecated in favour of the <Text /> component"
+      actionButtonLabel="See details"
+      actionButtonProps={{
+        href: 'https://github.com/MetaMask/metamask-extension/issues/17670',
+      }}
+    />
     {Object.values(FONT_WEIGHT).map((weight) => (
       <Typography
         boxProps={{ backgroundColor: renderBackgroundColor(args.color) }}
@@ -206,6 +247,15 @@ export const FontWeight = (args) => (
 
 export const FontStyle = (args) => (
   <>
+    <BannerAlert
+      severity={SEVERITIES.WARNING}
+      title="Deprecated"
+      description="<Typography/> has been deprecated in favour of the <Text /> component"
+      actionButtonLabel="See details"
+      actionButtonProps={{
+        href: 'https://github.com/MetaMask/metamask-extension/issues/17670',
+      }}
+    />
     {Object.values(FONT_STYLE).map((style) => (
       <Typography
         boxProps={{ backgroundColor: renderBackgroundColor(args.color) }}
@@ -221,6 +271,15 @@ export const FontStyle = (args) => (
 
 export const Align = (args) => (
   <>
+    <BannerAlert
+      severity={SEVERITIES.WARNING}
+      title="Deprecated"
+      description="<Typography/> has been deprecated in favour of the <Text /> component"
+      actionButtonLabel="See details"
+      actionButtonProps={{
+        href: 'https://github.com/MetaMask/metamask-extension/issues/17670',
+      }}
+    />
     {Object.values(TEXT_ALIGN).map((align) => (
       <Typography
         boxProps={{ backgroundColor: renderBackgroundColor(args.color) }}
@@ -235,24 +294,44 @@ export const Align = (args) => (
 );
 
 export const OverflowWrap = (args) => (
-  <div
-    style={{
-      width: 250,
-      border: '1px solid var(--color-error-default)',
-      display: 'block',
-    }}
-  >
-    <Typography {...args} overflowWrap={OVERFLOW_WRAP.NORMAL}>
-      {OVERFLOW_WRAP.NORMAL}: 0x39013f961c378f02c2b82a6e1d31e9812786fd9d
-    </Typography>
-    <Typography {...args} overflowWrap={OVERFLOW_WRAP.BREAK_WORD}>
-      {OVERFLOW_WRAP.BREAK_WORD}: 0x39013f961c378f02c2b82a6e1d31e9812786fd9d
-    </Typography>
-  </div>
+  <>
+    <BannerAlert
+      severity={SEVERITIES.WARNING}
+      title="Deprecated"
+      description="<Typography/> has been deprecated in favour of the <Text /> component"
+      actionButtonLabel="See details"
+      actionButtonProps={{
+        href: 'https://github.com/MetaMask/metamask-extension/issues/17670',
+      }}
+    />
+    <div
+      style={{
+        width: 250,
+        border: '1px solid var(--color-error-default)',
+        display: 'block',
+      }}
+    >
+      <Typography {...args} overflowWrap={OVERFLOW_WRAP.NORMAL}>
+        {OVERFLOW_WRAP.NORMAL}: 0x39013f961c378f02c2b82a6e1d31e9812786fd9d
+      </Typography>
+      <Typography {...args} overflowWrap={OVERFLOW_WRAP.BREAK_WORD}>
+        {OVERFLOW_WRAP.BREAK_WORD}: 0x39013f961c378f02c2b82a6e1d31e9812786fd9d
+      </Typography>
+    </div>
+  </>
 );
 
 export const As = (args) => (
   <>
+    <BannerAlert
+      severity={SEVERITIES.WARNING}
+      title="Deprecated"
+      description="<Typography/> has been deprecated in favour of the <Text /> component"
+      actionButtonLabel="See details"
+      actionButtonProps={{
+        href: 'https://github.com/MetaMask/metamask-extension/issues/17670',
+      }}
+    />
     <Typography boxProps={{ display: DISPLAY.BLOCK }} marginBottom={4}>
       You can change the root element of the Typography component using the as
       prop. Inspect the below elements to see the underlying HTML elements
@@ -276,9 +355,20 @@ export const As = (args) => (
 );
 
 export const Margin = (args) => (
-  <Typography {...args}>
-    This Typography component has a margin of {args.margin * 4}px
-  </Typography>
+  <>
+    <BannerAlert
+      severity={SEVERITIES.WARNING}
+      title="Deprecated"
+      description="<Typography/> has been deprecated in favour of the <Text /> component"
+      actionButtonLabel="See details"
+      actionButtonProps={{
+        href: 'https://github.com/MetaMask/metamask-extension/issues/17670',
+      }}
+    />
+    <Typography {...args}>
+      This Typography component has a margin of {args.margin * 4}px
+    </Typography>
+  </>
 );
 
 Margin.args = {
@@ -286,7 +376,18 @@ Margin.args = {
 };
 
 export const BoxProps = (args) => (
-  <Typography {...args}>This uses the boxProps prop</Typography>
+  <>
+    <BannerAlert
+      severity={SEVERITIES.WARNING}
+      title="Deprecated"
+      description="<Typography/> has been deprecated in favour of the <Text /> component"
+      actionButtonLabel="See details"
+      actionButtonProps={{
+        href: 'https://github.com/MetaMask/metamask-extension/issues/17670',
+      }}
+    />
+    <Typography {...args}>This uses the boxProps prop</Typography>
+  </>
 );
 
 BoxProps.args = {


### PR DESCRIPTION
## Explanation
Currently there are 2 components engineers can use for typography: `Typography` and `Text`.

This could cause confusion and create more duplication. 

This PR adds deprecation JSDoc to the Typography `.js` and `.sccs` files. It also adds a banner to storybook. With a link to the "good first issue" https://github.com/MetaMask/metamask-extension/issues/17670

## Screenshots/Screencaps

<!-- If you're making a change to the UI, make sure to capture a screenshot or a short video showing off your work! -->

### Before

https://user-images.githubusercontent.com/8112138/217685342-7340ec4f-a013-4f80-ab1a-ab5b154bf3fe.mov

### After


https://user-images.githubusercontent.com/8112138/217685416-0928ed90-aaf9-442e-b2f0-5b045b3c613a.mov

![Screenshot 2023-02-08 at 4 08 06 PM](https://user-images.githubusercontent.com/8112138/217685762-daf3803f-454a-47ad-95b7-147e71121af9.png)

## Manual Testing Steps

- Go to the latest build of storybook in this PR 
- Search Typography see deprecated messages in stories and MDX documentation
- In code for this branch in VScode find a `<Typography>` component and hover over it to see deprecation message

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] ~Sufficient automated test coverage has been added~ N/A

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
