### PR TITLE
Removing TEXT_VARIANTS in favour of TextVariant

### DIFF
--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -2,4 +2,4 @@
 
 A design system is a series of components that can be reused in different combinations. Design systems allow you to manage design at scale.
 
-Design System [Figma File](https://www.figma.com/file/aWgwMrzdAuv9VuPdtst64uuw/Style-Guide?node-id=211%3A0)
+Design System [Figma File](https://www.figma.com/file/HKpPKij9V3TpsyMV1TpV7C/DS-Components?node-id=401%3A2122&t=oqaI3NKZ059Vo67h-1)

--- a/ui/components/component-library/index.js
+++ b/ui/components/component-library/index.js
@@ -26,7 +26,7 @@ export { Label } from './label';
 export { PickerNetwork } from './picker-network';
 export { Tag } from './tag';
 export { TagUrl } from './tag-url';
-export { Text, TEXT_VARIANTS, TEXT_DIRECTIONS } from './text';
+export { Text, TEXT_DIRECTIONS } from './text';
 export { TextField, TEXT_FIELD_TYPES, TEXT_FIELD_SIZES } from './text-field';
 export {
   TextFieldBase,

--- a/ui/components/component-library/text/README.mdx
+++ b/ui/components/component-library/text/README.mdx
@@ -20,9 +20,7 @@ The `Text` accepts all props below as well as all [Box](/docs/components-ui-box-
 
 ### Variant
 
-Use the `variant` prop and the `TEXT` object from `./ui/helpers/constants/design-system.js` to change the font size of the component.
-
-Optional: `TEXT_VARIANTS` from ./text object can also be used.
+Use the `variant` prop and the `TextVariant` enum from `./ui/helpers/constants/design-system.js` to change the font size of the component.
 
 <Canvas>
   <Story id="components-componentlibrary-text--variant" />
@@ -47,10 +45,10 @@ import { TextVariant } from '../../../helpers/constants/design-system';
 
 ### Color
 
-Use the `color` prop and the `COLORS` object from `./ui/helpers/constants/design-system.js` to change the color of the `Text` component.
+Use the `color` prop and the `TextColor` object from `./ui/helpers/constants/design-system.js` to change the color of the `Text` component.
 
 <Canvas>
-  <Story id="components-componentlibrary-text--color" />
+  <Story id="components-componentlibrary-text--color-story" />
 </Canvas>
 
 ```jsx

--- a/ui/components/component-library/text/index.js
+++ b/ui/components/component-library/text/index.js
@@ -1,2 +1,2 @@
 export { Text } from './text';
-export { TEXT_VARIANTS, TEXT_DIRECTIONS } from './text.constants';
+export { TEXT_DIRECTIONS } from './text.constants';

--- a/ui/components/component-library/text/text.constants.js
+++ b/ui/components/component-library/text/text.constants.js
@@ -1,19 +1,3 @@
-import { TextVariant } from '../../../helpers/constants/design-system';
-
-export const TEXT_VARIANTS = {
-  DISPLAY_MD: TextVariant.displayMd,
-  HEADING_LG: TextVariant.headingLg,
-  HEADING_MD: TextVariant.headingMd,
-  HEADING_SM: TextVariant.headingSm,
-  BODY_LG_MEDIUM: TextVariant.bodyLgMedium,
-  BODY_MD: TextVariant.bodyMd,
-  BODY_MD_BOLD: TextVariant.bodyMdBold,
-  BODY_SM: TextVariant.bodySm,
-  BODY_SM_BOLD: TextVariant.bodySmBold,
-  BODY_XS: TextVariant.bodyXs,
-  INHERIT: TextVariant.inherit,
-};
-
 export const TEXT_DIRECTIONS = {
   LEFT_TO_RIGHT: 'ltr',
   RIGHT_TO_LEFT: 'rtl',

--- a/ui/components/component-library/text/text.js
+++ b/ui/components/component-library/text/text.js
@@ -11,7 +11,7 @@ import {
   OVERFLOW_WRAP,
   TextColor,
 } from '../../../helpers/constants/design-system';
-import { TEXT_VARIANTS, TEXT_DIRECTIONS } from './text.constants';
+import { TEXT_DIRECTIONS } from './text.constants';
 
 export const ValidTags = [
   'dd',
@@ -115,7 +115,7 @@ Text.propTypes = {
    * `BODY_XS` large screen: 12px / small screen: 10px,
    * `INHERIT`
    */
-  variant: PropTypes.oneOf(Object.values(TEXT_VARIANTS)),
+  variant: PropTypes.oneOf(Object.values(TextVariant)),
   /**
    * The color of the Text component Should use the COLOR object from
    * ./ui/helpers/constants/design-system.js


### PR DESCRIPTION
**IMPORTANT This PR updates jest coverage targets in `coverage-targets.js`**

## Explanation

During the typescript update https://github.com/MetaMask/metamask-extension/pull/17518 some of our documentation became out of date. This PR updates that documentation and removes the `TEXT_VARIANTS` object so engineers are only using the `TextVariants` from `design-system.ts` we could eventually move it to the component-library folder if it makes sense.

This will also help any contributors that are contributing to replacing Typography with the Text component efforts https://github.com/MetaMask/metamask-extension/issues/17670

## Screenshots/Screencaps

### Before

https://user-images.githubusercontent.com/8112138/217690130-279a0f24-64e8-46ab-a281-749fd0317fdf.mov

### After

https://user-images.githubusercontent.com/8112138/217690195-b949efc9-c2d9-499f-90ba-6b9c753de6fd.mov

## Manual Testing Steps

- Go to the latest build of storybook in this PR
- Search Text in the search bar
- See updated documentation in the Docs tab

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
