### PR TITLE
UX: Icons: Remove usage of pencil icon

### DIFF
--- a/ui/components/ui/editable-label/editable-label.js
+++ b/ui/components/ui/editable-label/editable-label.js
@@ -1,7 +1,9 @@
 import classnames from 'classnames';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
+import { Color } from '../../../helpers/constants/design-system';
 import { getAccountNameErrorMessage } from '../../../helpers/utils/accounts';
+import { ButtonIcon, ICON_NAMES } from '../../component-library';
 
 export default class EditableLabel extends Component {
   static propTypes = {
@@ -73,13 +75,13 @@ export default class EditableLabel extends Component {
     return (
       <div className={classnames('editable-label', this.props.className)}>
         <div className="editable-label__value">{this.state.value}</div>
-        <button
-          className="editable-label__icon-button"
+        <ButtonIcon
+          iconName={ICON_NAMES.EDIT}
+          ariaLabel={this.context.t('edit')}
           data-testid="editable-label-button"
           onClick={() => this.setState({ isEditing: true })}
-        >
-          <i className="fas fa-pencil-alt editable-label__icon" />
-        </button>
+          color={Color.iconDefault}
+        />
       </div>
     );
   }

--- a/ui/components/ui/editable-label/index.scss
+++ b/ui/components/ui/editable-label/index.scss
@@ -29,12 +29,6 @@
   &__icon-button {
     margin-left: 10px;
     left: 100%;
-    background: unset;
-  }
-
-  &__icon {
-    cursor: pointer;
-    color: var(--color-icon-default);
   }
 
   &__error {


### PR DESCRIPTION
## Explanation

Removes usage of `fa-pencil-alt` in favor of new icon

## Screenshots/Screencaps

<img width="973" alt="EditIcon" src="https://user-images.githubusercontent.com/46655/217697548-34fd48fb-674f-44bf-a118-697844205913.png">


## Pre-merge author checklist

- [ ] I've clearly explained:
  - [ ] What problem this PR is solving
  - [ ] How this problem was solved
  - [ ] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
