### PR TITLE
[FLASK] Add tooltips to show info about a permission

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -2773,21 +2773,41 @@
     "message": "Access the internet.",
     "description": "The description of the `endowment:network-access` permission."
   },
+  "permission_accessNetworkDescription": {
+    "message": "Allow the snap to access the internet. This can be used to both send and receive data with third-party servers.",
+    "description": "An extended description of the `endowment:network-access` permission."
+  },
   "permission_accessSnap": {
     "message": "Connect to the $1 snap.",
     "description": "The description for the `wallet_snap` permission. $1 is the name of the snap."
+  },
+  "permission_accessSnapDescription": {
+    "message": "Allow the website or snap to interact with $1.",
+    "description": "The description for the `wallet_snap_*` permission. $1 is the name of the Snap."
   },
   "permission_cronjob": {
     "message": "Schedule and execute periodic actions.",
     "description": "The description for the `snap_cronjob` permission"
   },
+  "permission_cronjobDescription": {
+    "message": "Allow the snap to perform actions that run periodically at fixed times, dates, or intervals. This can be used to trigger time-sensitive interactions or notifications.",
+    "description": "An extended description for the `snap_cronjob` permission"
+  },
   "permission_customConfirmation": {
     "message": "Display a confirmation in MetaMask.",
     "description": "The description for the `snap_confirm` permission"
   },
+  "permission_customConfirmationDescription": {
+    "message": "Allow the snap to display MetaMask popups with custom text, and buttons to approve or reject an action.",
+    "description": "An extended description for the `snap_confirm` permission"
+  },
   "permission_dialog": {
     "message": "Display dialog windows in MetaMask.",
     "description": "The description for the `snap_dialog` permission"
+  },
+  "permission_dialogDescription": {
+    "message": "Allow the snap to display MetaMask popups with custom text, input field, and buttons to approve or reject an action.\nCan be used to create e.g. alerts, confirmations, and opt-in flows for a snap.",
+    "description": "An extended description for the `snap_dialog` permission"
   },
   "permission_ethereumAccounts": {
     "message": "See address, account balance, activity and suggest transactions to approve",
@@ -2797,21 +2817,41 @@
     "message": "Access the Ethereum provider.",
     "description": "The description for the `endowment:ethereum-provider` permission"
   },
+  "permission_ethereumProviderDescription": {
+    "message": "Allow the snap to communicate with MetaMask directly, in order for it to read data from the blockchain and suggest messages and transactions.",
+    "description": "An extended description for the `endowment:ethereum-provider` permission"
+  },
   "permission_getEntropy": {
     "message": "Derive arbitrary keys unique to this snap.",
     "description": "The description for the `snap_getEntropy` permission"
+  },
+  "permission_getEntropyDescription": {
+    "message": "Allow the snap to derive arbitrary keys unique to this snap, without exposing them. These keys are separate from your MetaMask account(s) and not related to your private keys or Secret Recovery Phrase. Other snaps cannot access this information.",
+    "description": "An extended description for the `snap_getEntropy` permission"
   },
   "permission_longRunning": {
     "message": "Run indefinitely.",
     "description": "The description for the `endowment:long-running` permission"
   },
+  "permission_longRunningDescription": {
+    "message": "Allow the snap to run indefinitely while, for example, processing large amounts of data.",
+    "description": "An extended description for the `endowment:long-running` permission"
+  },
   "permission_manageBip32Keys": {
     "message": "Control your accounts and assets under $1 ($2).",
     "description": "The description for the `snap_getBip32Entropy` permission. $1 is a derivation path, e.g. 'm/44'/0'/0''. $2 is the elliptic curve name, e.g. 'secp256k1'."
   },
+  "permission_manageBip32KeysDescription": {
+    "message": "Allow the snap to derive BIP-32 key pairs based on your Secret Recovery Phrase without exposing it. This grants full access to all accounts and assets on $1.\nWith the power to manage keys, the snap can support a variety of blockchain protocols beyond Ethereum (EVMs).",
+    "description": "An extended description for the `snap_getBip32Entropy` permission. $1 is a derivation path (name)"
+  },
   "permission_manageBip44Keys": {
     "message": "Control your \"$1\" accounts and assets.",
     "description": "The description for the `snap_getBip44Entropy` permission. $1 is the name of a protocol, e.g. 'Filecoin'."
+  },
+  "permission_manageBip44KeysDescription": {
+    "message": "Allow the snap to derive BIP-44 key pairs based on your Secret Recovery Phrase without exposing it. This grants full access to all accounts and assets on $1.\nWith the power to manage keys, the snap can support a variety of blockchain protocols beyond Ethereum (EVMs).",
+    "description": "An extended description for the `snap_getBip44Entropy` permission. $1 is the name of a protocol, e.g., 'Filecoin'."
   },
   "permission_manageNamedBip32Keys": {
     "message": "Control your $1 accounts and assets.",
@@ -2821,21 +2861,41 @@
     "message": "Store and manage its data on your device.",
     "description": "The description for the `snap_manageState` permission"
   },
+  "permission_manageStateDescription": {
+    "message": "Allow the snap to store, update, and retrieve data securely with encryption. Other snaps cannot access this information.",
+    "description": "An extended description for the `snap_manageState` permission"
+  },
   "permission_notifications": {
     "message": "Show notifications.",
     "description": "The description for the `snap_notify` permission"
+  },
+  "permission_notificationsDescription": {
+    "message": "Allow the snap to display notifications within MetaMask. A short notification text can be triggered by a snap for actionable or time-sensitive information.",
+    "description": "An extended description for the `snap_notify` permission"
   },
   "permission_rpc": {
     "message": "Allow $1 to communicate directly with this snap.",
     "description": "The description for the `endowment:rpc` permission. $1 is 'other snaps' or 'websites'."
   },
+  "permission_rpcDescription": {
+    "message": "Allow $1 to send messages to the snap and receive a response from the snap.",
+    "description": "An extended description for the `endowment:rpc` permission. $1 is 'other snaps' or 'websites'."
+  },
   "permission_transactionInsight": {
     "message": "Fetch and display transaction insights.",
     "description": "The description for the `endowment:transaction-insight` permission"
   },
+  "permission_transactionInsightDescription": {
+    "message": "Allow the snap to decode transactions and show insights within the MetaMask UI. This can be used for anti-phishing and security solutions.",
+    "description": "An extended description for the `endowment:transaction-insight` permission"
+  },
   "permission_transactionInsightOrigin": {
     "message": "See the origins of websites that suggest transactions",
     "description": "The description for the `transactionOrigin` caveat, to be used with the `endowment:transaction-insight` permission"
+  },
+  "permission_transactionInsightOriginDescription": {
+    "message": "Allow the snap to see the origin (URI) of websites that suggest transactions. This can be used for anti-phishing and security solutions.",
+    "description": "An extended description for the `transactionOrigin` caveat, to be used with the `endowment:transaction-insight` permission"
   },
   "permission_unknown": {
     "message": "Unknown permission: $1",
@@ -2844,6 +2904,10 @@
   "permission_viewBip32PublicKeys": {
     "message": "View your public key for $1 ($2).",
     "description": "The description for the `snap_getBip32PublicKey` permission. $1 is a derivation path, e.g. 'm/44'/0'/0''. $2 is the elliptic curve name, e.g. 'secp256k1'."
+  },
+  "permission_viewBip32PublicKeysDescription": {
+    "message": "Allow the snap to view your public keys (and addresses) for $1. This does not grant any control of accounts or assets.",
+    "description": "An extended description for the `snap_getBip32PublicKey` permission. $1 is a derivation path (name)"
   },
   "permission_viewNamedBip32PublicKeys": {
     "message": "View your public key for $1.",

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -2917,6 +2917,10 @@
     "message": "Support for WebAssembly.",
     "description": "The description of the `endowment:webassembly` permission."
   },
+  "permission_webAssemblyDescription": {
+    "message": "Allow the snap to access low-level execution environments via WebAssembly.",
+    "description": "An extended description of the `endowment:webassembly` permission."
+  },
   "permissions": {
     "message": "Permissions"
   },

--- a/app/images/icons/ethereum.svg
+++ b/app/images/icons/ethereum.svg
@@ -1,3 +1,3 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="none">
-  <g clip-path="url(#a)"><path fill="#24272A" stroke="#24272A" d="M19.5 10a9.5 9.5 0 1 1-19 0 9.5 9.5 0 0 1 19 0Z"/><path fill="#fff" fill-opacity=".602" d="M10.31 2.5v5.544l4.686 2.093L10.31 2.5Z"/><path fill="#fff" d="m10.311 2.5-4.686 7.637 4.686-2.093V2.5Z"/><path fill="#fff" fill-opacity=".602" d="M10.31 13.73v3.767L15 11.01l-4.69 2.72Z"/><path fill="#fff" d="M10.311 17.497v-3.768L5.625 11.01l4.686 6.487Z"/><path fill="#fff" fill-opacity=".2" d="m10.31 12.858 4.686-2.72-4.686-2.093v4.813Z"/><path fill="#fff" fill-opacity=".602" d="m5.625 10.137 4.686 2.721V8.045l-4.686 2.092Z"/></g><defs><clipPath id="a"><path fill="#fff" d="M0 0h20v20H0z"/></clipPath></defs>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 417 417">
+  <path d="m80.5 212.3 64 37.8 64 37.9 127.9-75.7L208.5 0l-128 212.3z"/><path d="m336.5 236.6-128 75.6-128-75.6 128 180.3z"/>
 </svg>

--- a/app/images/icons/ethereum.svg
+++ b/app/images/icons/ethereum.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="none">
+  <g clip-path="url(#a)"><path fill="#24272A" stroke="#24272A" d="M19.5 10a9.5 9.5 0 1 1-19 0 9.5 9.5 0 0 1 19 0Z"/><path fill="#fff" fill-opacity=".602" d="M10.31 2.5v5.544l4.686 2.093L10.31 2.5Z"/><path fill="#fff" d="m10.311 2.5-4.686 7.637 4.686-2.093V2.5Z"/><path fill="#fff" fill-opacity=".602" d="M10.31 13.73v3.767L15 11.01l-4.69 2.72Z"/><path fill="#fff" d="M10.311 17.497v-3.768L5.625 11.01l4.686 6.487Z"/><path fill="#fff" fill-opacity=".2" d="m10.31 12.858 4.686-2.72-4.686-2.093v4.813Z"/><path fill="#fff" fill-opacity=".602" d="m5.625 10.137 4.686 2.721V8.045l-4.686 2.092Z"/></g><defs><clipPath id="a"><path fill="#fff" d="M0 0h20v20H0z"/></clipPath></defs>
+</svg>

--- a/coverage-targets.js
+++ b/coverage-targets.js
@@ -9,7 +9,7 @@ module.exports = {
     lines: 65,
     branches: 53.5,
     statements: 64,
-    functions: 57.5,
+    functions: 57.4,
   },
   transforms: {
     branches: 100,

--- a/ui/components/app/flask/update-snap-permission-list/index.scss
+++ b/ui/components/app/flask/update-snap-permission-list/index.scss
@@ -48,6 +48,7 @@
   .permission {
     &__tooltip-icon {
       margin-left: auto !important;
+      padding-left: 16px;
 
       i {
         color: var(--color-icon-muted);

--- a/ui/components/app/flask/update-snap-permission-list/index.scss
+++ b/ui/components/app/flask/update-snap-permission-list/index.scss
@@ -44,4 +44,18 @@
   .permission-description-subtext {
     @include H7;
   }
+
+  .permission {
+    &__tooltip-icon {
+      margin-left: auto !important;
+
+      i {
+        color: var(--color-icon-muted);
+      }
+
+      &__warning i {
+        color: var(--color-warning-default);
+      }
+    }
+  }
 }

--- a/ui/components/app/flask/update-snap-permission-list/update-snap-permission-list.js
+++ b/ui/components/app/flask/update-snap-permission-list/update-snap-permission-list.js
@@ -1,7 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { isFunction } from 'lodash';
-import { getWeightedPermissions } from '../../../../helpers/utils/permission';
+import {
+  getRightIcon,
+  getWeightedPermissions,
+} from '../../../../helpers/utils/permission';
 import { useI18nContext } from '../../../../hooks/useI18nContext';
 import { formatDate } from '../../../../helpers/utils/util';
 import Typography from '../../../ui/typography/typography';
@@ -15,8 +18,9 @@ export default function UpdateSnapPermissionList({
   const t = useI18nContext();
 
   const Permissions = ({ className, permissions, subText }) => {
-    return getWeightedPermissions(t, permissions).map(
-      ({ label, rightIcon, permissionName, permissionValue }) => (
+    return getWeightedPermissions(t, permissions).map((permission) => {
+      const { label, permissionName, permissionValue } = permission;
+      return (
         <div className={className} key={permissionName}>
           <i className="fas fa-x" />
           <div className="permission-description">
@@ -31,10 +35,10 @@ export default function UpdateSnapPermissionList({
                 : subText}
             </Typography>
           </div>
-          {rightIcon && <i className={rightIcon} />}
+          {getRightIcon(permission)}
         </div>
-      ),
-    );
+      );
+    });
   };
 
   return (

--- a/ui/components/app/permissions-connect-permission-list/index.scss
+++ b/ui/components/app/permissions-connect-permission-list/index.scss
@@ -21,6 +21,18 @@
       font-size: 1rem;
       text-align: center;
     }
+
+    &__tooltip-icon {
+      margin-left: auto !important;
+
+      i {
+        color: var(--color-icon-muted);
+      }
+
+      &__warning i {
+        color: var(--color-warning-default);
+      }
+    }
   }
 
   .permission-label-item {

--- a/ui/components/app/permissions-connect-permission-list/index.scss
+++ b/ui/components/app/permissions-connect-permission-list/index.scss
@@ -6,7 +6,7 @@
 
     width: 100%;
     padding-bottom: 16px;
-    border-bottom: 1px solid var(--color-border-default);
+    border-bottom: 1px solid var(--color-border-muted);
     display: flex;
     flex-direction: row;
     align-items: center;
@@ -22,8 +22,13 @@
       text-align: center;
     }
 
+    .mm-avatar-icon {
+      margin: 16px 16px 16px 0;
+    }
+
     &__tooltip-icon {
       margin-left: auto !important;
+      padding-left: 16px;
 
       i {
         color: var(--color-icon-muted);

--- a/ui/components/app/permissions-connect-permission-list/index.scss
+++ b/ui/components/app/permissions-connect-permission-list/index.scss
@@ -39,3 +39,7 @@
     font-weight: bold;
   }
 }
+
+.tooltip-label-item {
+  font-weight: bold;
+}

--- a/ui/components/app/permissions-connect-permission-list/permissions-connect-permission-list.js
+++ b/ui/components/app/permissions-connect-permission-list/permissions-connect-permission-list.js
@@ -1,28 +1,26 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { getWeightedPermissions } from '../../../helpers/utils/permission';
+import {
+  getRightIcon,
+  getWeightedPermissions,
+} from '../../../helpers/utils/permission';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 
 /**
  * Get one or more permission descriptions for a permission name.
  *
  * @param permission - The permission to render.
- * @param permission.label - The text label.
- * @param permission.leftIcon - The left icon.
- * @param permission.rightIcon - The right icon.
- * @param permission.permissionName - The name of the permission.
- * @param index - The index of the permission in the permissions array.
- * @returns {JSX.Element[]} An array of permission description nodes.
+ * @param index - The index of the permission.
+ * @returns {JSX.Element} A permission description node.
  */
-function getDescriptionNode(
-  { label, leftIcon, rightIcon, permissionName },
-  index,
-) {
+function getDescriptionNode(permission, index) {
+  const { label, leftIcon, permissionName } = permission;
+
   return (
     <div className="permission" key={`${permissionName}-${index}`}>
       {typeof leftIcon === 'string' ? <i className={leftIcon} /> : leftIcon}
       {label}
-      {rightIcon && <i className={rightIcon} />}
+      {getRightIcon(permission)}
     </div>
   );
 }

--- a/ui/helpers/utils/permission.js
+++ b/ui/helpers/utils/permission.js
@@ -81,7 +81,15 @@ const PERMISSION_DESCRIPTIONS = deepFreeze({
             </span>,
             path.join('/'),
           ]),
-          description: t('permission_viewNamedBip32PublicKeysDescription'),
+          description: t('permission_viewBip32PublicKeysDescription', [
+            <span
+              className="tooltip-label-item"
+              key={`description-${path.join('/')}`}
+            >
+              {friendlyName}
+            </span>,
+            path.join('/'),
+          ]),
         };
       }
 
@@ -93,7 +101,15 @@ const PERMISSION_DESCRIPTIONS = deepFreeze({
           </span>,
           curve,
         ]),
-        description: t('permission_viewNamedBip32PublicKeysDescription'),
+        description: t('permission_viewBip32PublicKeysDescription', [
+          <span
+            className="tooltip-label-item"
+            key={`description-${path.join('/')}`}
+          >
+            {path.join('/')}
+          </span>,
+          path.join('/'),
+        ]),
       };
     }),
   [RestrictedMethods.snap_getBip32Entropy]: (t, _, permissionValue) =>
@@ -114,7 +130,15 @@ const PERMISSION_DESCRIPTIONS = deepFreeze({
             </span>,
             path.join('/'),
           ]),
-          description: t('permission_manageNamedBip32KeysDescription'),
+          description: t('permission_manageBip32KeysDescription', [
+            <span
+              className="tooltip-label-item"
+              key={`description-${path.join('/')}`}
+            >
+              {friendlyName}
+            </span>,
+            curve,
+          ]),
         };
       }
 
@@ -126,7 +150,15 @@ const PERMISSION_DESCRIPTIONS = deepFreeze({
           </span>,
           curve,
         ]),
-        description: t('permission_manageBip32KeysDescription'),
+        description: t('permission_manageBip32KeysDescription', [
+          <span
+            className="tooltip-label-item"
+            key={`description-${path.join('/')}`}
+          >
+            {path.join('/')}
+          </span>,
+          curve,
+        ]),
       };
     }),
   [RestrictedMethods.snap_getBip44Entropy]: (t, _, permissionValue) =>
@@ -137,7 +169,15 @@ const PERMISSION_DESCRIPTIONS = deepFreeze({
             `${coinType} (Unrecognized protocol)`}
         </span>,
       ]),
-      description: t('permission_manageBip44KeysDescription'),
+      description: t('permission_manageBip44KeysDescription', [
+        <span
+          className="tooltip-label-item"
+          key={`description-coin-type-${coinType}`}
+        >
+          {coinTypeToProtocolName(coinType) ||
+            `${coinType} (Unrecognized protocol)`}
+        </span>,
+      ]),
       leftIcon: 'fas fa-door-open',
       rightIcon: 'fa fa-exclamation-triangle',
       weight: 1,
@@ -179,6 +219,7 @@ const PERMISSION_DESCRIPTIONS = deepFreeze({
       return {
         ...baseDescription,
         label: t('permission_accessSnap', [snapId]),
+        description: t('permission_accessSnapDescription', [snapId]),
       };
     });
   },
@@ -264,7 +305,7 @@ const PERMISSION_DESCRIPTIONS = deepFreeze({
       results.push({
         ...baseDescription,
         label: t('permission_rpc', [t('otherSnaps')]),
-        description: t('permission_rpcDescription'),
+        description: t('permission_rpcDescription', [t('otherSnaps')]),
       });
     }
 
@@ -272,7 +313,7 @@ const PERMISSION_DESCRIPTIONS = deepFreeze({
       results.push({
         ...baseDescription,
         label: t('permission_rpc', [t('websites')]),
-        description: t('permission_rpcDescription'),
+        description: t('permission_rpcDescription', [t('websites')]),
       });
     }
 
@@ -370,7 +411,8 @@ export function getRightIcon({ rightIcon, description, weight }) {
           'permission__tooltip-icon',
           weight === 1 && 'permission__tooltip-icon__warning',
         )}
-        html={description}
+        html={<div>{description}</div>}
+        position="bottom"
       >
         <i className={rightIcon} />
       </Tooltip>

--- a/ui/helpers/utils/permission.js
+++ b/ui/helpers/utils/permission.js
@@ -6,12 +6,16 @@ import { getRpcCaveatOrigins } from '@metamask/snaps-controllers/dist/snaps/endo
 import { SnapCaveatType } from '@metamask/snaps-utils';
 import { isNonEmptyArray } from '@metamask/controller-utils';
 ///: END:ONLY_INCLUDE_IN
+import classnames from 'classnames';
 import {
   RestrictedMethods,
   ///: BEGIN:ONLY_INCLUDE_IN(flask)
   EndowmentPermissions,
   ///: END:ONLY_INCLUDE_IN
 } from '../../../shared/constants/permissions';
+///: BEGIN:ONLY_INCLUDE_IN(flask)
+import Tooltip from '../../components/ui/tooltip';
+///: END:ONLY_INCLUDE_IN
 import { Icon, ICON_NAMES } from '../../components/component-library';
 import { Color } from '../constants/design-system';
 ///: BEGIN:ONLY_INCLUDE_IN(flask)
@@ -36,20 +40,23 @@ const PERMISSION_DESCRIPTIONS = deepFreeze({
   ///: BEGIN:ONLY_INCLUDE_IN(flask)
   [RestrictedMethods.snap_confirm]: (t) => ({
     label: t('permission_customConfirmation'),
+    description: 'TODO.',
     leftIcon: 'fas fa-user-check',
-    rightIcon: null,
+    rightIcon: 'fas fa-info-circle',
     weight: 3,
   }),
   [RestrictedMethods.snap_dialog]: (t) => ({
     label: t('permission_dialog'),
+    description: 'TODO.',
     leftIcon: 'fas fa-user-check',
-    rightIcon: null,
+    rightIcon: 'fas fa-info-circle',
     weight: 3,
   }),
   [RestrictedMethods.snap_notify]: (t) => ({
     leftIcon: <Icon name={ICON_NAMES.NOTIFICATION} />,
+    description: 'TODO.',
     label: t('permission_notifications'),
-    rightIcon: null,
+    rightIcon: 'fas fa-info-circle',
     weight: 3,
   }),
   [RestrictedMethods.snap_getBip32PublicKey]: (t, _, permissionValue) =>
@@ -62,7 +69,7 @@ const PERMISSION_DESCRIPTIONS = deepFreeze({
             color={Color.iconAlternative}
           />
         ),
-        rightIcon: null,
+        rightIcon: 'fa fa-exclamation-triangle',
         weight: 1,
       };
 
@@ -92,8 +99,9 @@ const PERMISSION_DESCRIPTIONS = deepFreeze({
   [RestrictedMethods.snap_getBip32Entropy]: (t, _, permissionValue) =>
     permissionValue.caveats[0].value.map(({ path, curve }) => {
       const baseDescription = {
+        description: 'TODO.',
         leftIcon: 'fas fa-door-open',
-        rightIcon: null,
+        rightIcon: 'fa fa-exclamation-triangle',
         weight: 1,
       };
 
@@ -128,27 +136,31 @@ const PERMISSION_DESCRIPTIONS = deepFreeze({
             `${coinType} (Unrecognized protocol)`}
         </span>,
       ]),
+      description: 'TODO.',
       leftIcon: 'fas fa-door-open',
-      rightIcon: null,
+      rightIcon: 'fa fa-exclamation-triangle',
       weight: 1,
     })),
   [RestrictedMethods.snap_getEntropy]: (t) => ({
     label: t('permission_getEntropy'),
+    description: 'TODO.',
     leftIcon: 'fas fa-key',
-    rightIcon: null,
+    rightIcon: 'fas fa-info-circle',
     weight: 3,
   }),
   [RestrictedMethods.snap_manageState]: (t) => ({
     label: t('permission_manageState'),
+    description: 'TODO.',
     leftIcon: 'fas fa-download',
-    rightIcon: null,
+    rightIcon: 'fas fa-info-circle',
     weight: 3,
   }),
   [RestrictedMethods.wallet_snap]: (t, _, permissionValue) => {
     const snaps = permissionValue.caveats[0].value;
     const baseDescription = {
+      description: 'TODO.',
       leftIcon: 'fas fa-bolt',
-      rightIcon: null,
+      rightIcon: 'fas fa-info-circle',
     };
     return Object.keys(snaps).map((snapId) => {
       const friendlyName = getSnapName(snapId);
@@ -170,8 +182,9 @@ const PERMISSION_DESCRIPTIONS = deepFreeze({
   },
   [EndowmentPermissions['endowment:network-access']]: (t) => ({
     label: t('permission_accessNetwork'),
+    description: 'TODO.',
     leftIcon: 'fas fa-wifi',
-    rightIcon: null,
+    rightIcon: 'fas fa-info-circle',
     weight: 2,
   }),
   [EndowmentPermissions['endowment:webassembly']]: (t) => ({
@@ -182,8 +195,9 @@ const PERMISSION_DESCRIPTIONS = deepFreeze({
   }),
   [EndowmentPermissions['endowment:long-running']]: (t) => ({
     label: t('permission_longRunning'),
+    description: 'TODO.',
     leftIcon: 'fas fa-infinity',
-    rightIcon: null,
+    rightIcon: 'fas fa-info-circle',
     weight: 3,
   }),
   [EndowmentPermissions['endowment:transaction-insight']]: (
@@ -192,8 +206,9 @@ const PERMISSION_DESCRIPTIONS = deepFreeze({
     permissionValue,
   ) => {
     const baseDescription = {
+      description: 'TODO.',
       leftIcon: 'fas fa-info',
-      rightIcon: null,
+      rightIcon: 'fas fa-info-circle',
     };
 
     const result = [
@@ -219,14 +234,16 @@ const PERMISSION_DESCRIPTIONS = deepFreeze({
   },
   [EndowmentPermissions['endowment:cronjob']]: (t) => ({
     label: t('permission_cronjob'),
+    description: 'TODO.',
     leftIcon: 'fas fa-clock',
-    rightIcon: null,
+    rightIcon: 'fas fa-info-circle',
     weight: 2,
   }),
   [EndowmentPermissions['endowment:ethereum-provider']]: (t) => ({
     label: t('permission_ethereumProvider'),
+    description: 'TODO.',
     leftIcon: 'fab fa-ethereum',
-    rightIcon: null,
+    rightIcon: 'fas fa-info-circle',
     weight: 1,
   }),
   [EndowmentPermissions['endowment:rpc']]: (t, _, permissionValue) => {
@@ -243,8 +260,9 @@ const PERMISSION_DESCRIPTIONS = deepFreeze({
 
     return labels.map((label) => ({
       label,
+      description: 'TODO.',
       leftIcon: 'fas fa-plug',
-      rightIcon: null,
+      rightIcon: 'fas fa-info-circle',
       weight: 2,
     }));
   },
@@ -260,6 +278,8 @@ const PERMISSION_DESCRIPTIONS = deepFreeze({
 /**
  * @typedef {object} PermissionLabelObject
  * @property {string} label - The text label.
+ * @property {string} [description] - An optional description, shown when the
+ * `rightIcon` is hovered.
  * @property {string} leftIcon - The left icon.
  * @property {string} rightIcon - The right icon.
  * @property {number} weight - The weight of the permission.
@@ -314,4 +334,40 @@ export function getWeightedPermissions(t, permissions) {
       [],
     )
     .sort((left, right) => left.weight - right.weight);
+}
+
+/**
+ * Get the right icon for a permission. If a description is provided, the icon
+ * will be wrapped in a tooltip. Otherwise, the icon will be rendered as-is. If
+ * there's no right icon, this function will return null.
+ *
+ * If the weight is 1, the icon will be rendered with a warning color.
+ *
+ * @param {PermissionLabelObject} permission - The permission object.
+ * @param {string} permission.rightIcon - The right icon.
+ * @param {string} permission.description - The description.
+ * @param {number} permission.weight - The weight.
+ * @returns {JSX.Element | null} The right icon, or null if there's no
+ * right icon.
+ */
+export function getRightIcon({ rightIcon, description, weight }) {
+  if (rightIcon && description) {
+    return (
+      <Tooltip
+        wrapperClassName={classnames(
+          'permission__tooltip-icon',
+          weight === 1 && 'permission__tooltip-icon__warning',
+        )}
+        html={description}
+      >
+        <i className={rightIcon} />
+      </Tooltip>
+    );
+  }
+
+  if (rightIcon) {
+    return <i className={classnames(rightIcon, 'permission__tooltip-icon')} />;
+  }
+
+  return null;
 }

--- a/ui/helpers/utils/permission.js
+++ b/ui/helpers/utils/permission.js
@@ -66,7 +66,7 @@ function getLeftIcon(iconName) {
 const PERMISSION_DESCRIPTIONS = deepFreeze({
   [RestrictedMethods.eth_accounts]: (t) => ({
     label: t('permission_ethereumAccounts'),
-    leftIcon: getLeftIcon(ICON_NAMES.ETHEREUM),
+    leftIcon: getLeftIcon(ICON_NAMES.EYE),
     rightIcon: null,
     weight: 2,
   }),

--- a/ui/helpers/utils/permission.js
+++ b/ui/helpers/utils/permission.js
@@ -195,7 +195,7 @@ const PERMISSION_DESCRIPTIONS = deepFreeze({
       label: t('permission_manageBip44Keys', [
         <span className="permission-label-item" key={`coin-type-${coinType}`}>
           {coinTypeToProtocolName(coinType) ||
-            `${coinType} (Unrecognized protocol)`}
+            t('unrecognizedProtocol', [coinType])}
         </span>,
       ]),
       description: t('permission_manageBip44KeysDescription', [
@@ -204,7 +204,7 @@ const PERMISSION_DESCRIPTIONS = deepFreeze({
           key={`description-coin-type-${coinType}`}
         >
           {coinTypeToProtocolName(coinType) ||
-            `${coinType} (Unrecognized protocol)`}
+            t('unrecognizedProtocol', [coinType])}
         </span>,
       ]),
       leftIcon: getLeftIcon(ICON_NAMES.KEY),

--- a/ui/helpers/utils/permission.js
+++ b/ui/helpers/utils/permission.js
@@ -38,22 +38,22 @@ const PERMISSION_DESCRIPTIONS = deepFreeze({
   ///: BEGIN:ONLY_INCLUDE_IN(flask)
   [RestrictedMethods.snap_confirm]: (t) => ({
     label: t('permission_customConfirmation'),
-    description: 'TODO.',
+    description: t('permission_customConfirmationDescription'),
     leftIcon: 'fas fa-user-check',
     rightIcon: 'fas fa-info-circle',
     weight: 3,
   }),
   [RestrictedMethods.snap_dialog]: (t) => ({
     label: t('permission_dialog'),
-    description: 'TODO.',
+    description: t('permission_dialogDescription'),
     leftIcon: 'fas fa-user-check',
     rightIcon: 'fas fa-info-circle',
     weight: 3,
   }),
   [RestrictedMethods.snap_notify]: (t) => ({
-    leftIcon: <Icon name={ICON_NAMES.NOTIFICATION} />,
-    description: 'TODO.',
     label: t('permission_notifications'),
+    description: t('permission_notificationsDescription'),
+    leftIcon: <Icon name={ICON_NAMES.NOTIFICATION} />,
     rightIcon: 'fas fa-info-circle',
     weight: 3,
   }),
@@ -81,6 +81,7 @@ const PERMISSION_DESCRIPTIONS = deepFreeze({
             </span>,
             path.join('/'),
           ]),
+          description: t('permission_viewNamedBip32PublicKeysDescription'),
         };
       }
 
@@ -92,12 +93,12 @@ const PERMISSION_DESCRIPTIONS = deepFreeze({
           </span>,
           curve,
         ]),
+        description: t('permission_viewNamedBip32PublicKeysDescription'),
       };
     }),
   [RestrictedMethods.snap_getBip32Entropy]: (t, _, permissionValue) =>
     permissionValue.caveats[0].value.map(({ path, curve }) => {
       const baseDescription = {
-        description: 'TODO.',
         leftIcon: 'fas fa-door-open',
         rightIcon: 'fa fa-exclamation-triangle',
         weight: 1,
@@ -113,6 +114,7 @@ const PERMISSION_DESCRIPTIONS = deepFreeze({
             </span>,
             path.join('/'),
           ]),
+          description: t('permission_manageNamedBip32KeysDescription'),
         };
       }
 
@@ -124,6 +126,7 @@ const PERMISSION_DESCRIPTIONS = deepFreeze({
           </span>,
           curve,
         ]),
+        description: t('permission_manageBip32KeysDescription'),
       };
     }),
   [RestrictedMethods.snap_getBip44Entropy]: (t, _, permissionValue) =>
@@ -134,21 +137,21 @@ const PERMISSION_DESCRIPTIONS = deepFreeze({
             `${coinType} (Unrecognized protocol)`}
         </span>,
       ]),
-      description: 'TODO.',
+      description: t('permission_manageBip44KeysDescription'),
       leftIcon: 'fas fa-door-open',
       rightIcon: 'fa fa-exclamation-triangle',
       weight: 1,
     })),
   [RestrictedMethods.snap_getEntropy]: (t) => ({
     label: t('permission_getEntropy'),
-    description: 'TODO.',
+    description: t('permission_getEntropyDescription'),
     leftIcon: 'fas fa-key',
     rightIcon: 'fas fa-info-circle',
     weight: 3,
   }),
   [RestrictedMethods.snap_manageState]: (t) => ({
     label: t('permission_manageState'),
-    description: 'TODO.',
+    description: t('permission_manageStateDescription'),
     leftIcon: 'fas fa-download',
     rightIcon: 'fas fa-info-circle',
     weight: 3,
@@ -156,10 +159,10 @@ const PERMISSION_DESCRIPTIONS = deepFreeze({
   [RestrictedMethods.wallet_snap]: (t, _, permissionValue) => {
     const snaps = permissionValue.caveats[0].value;
     const baseDescription = {
-      description: 'TODO.',
       leftIcon: 'fas fa-bolt',
       rightIcon: 'fas fa-info-circle',
     };
+
     return Object.keys(snaps).map((snapId) => {
       const friendlyName = getSnapName(snapId);
       if (friendlyName) {
@@ -172,6 +175,7 @@ const PERMISSION_DESCRIPTIONS = deepFreeze({
           ]),
         };
       }
+
       return {
         ...baseDescription,
         label: t('permission_accessSnap', [snapId]),
@@ -180,7 +184,7 @@ const PERMISSION_DESCRIPTIONS = deepFreeze({
   },
   [EndowmentPermissions['endowment:network-access']]: (t) => ({
     label: t('permission_accessNetwork'),
-    description: 'TODO.',
+    description: t('permission_accessNetworkDescription'),
     leftIcon: 'fas fa-wifi',
     rightIcon: 'fas fa-info-circle',
     weight: 2,
@@ -193,7 +197,7 @@ const PERMISSION_DESCRIPTIONS = deepFreeze({
   }),
   [EndowmentPermissions['endowment:long-running']]: (t) => ({
     label: t('permission_longRunning'),
-    description: 'TODO.',
+    description: t('permission_longRunningDescription'),
     leftIcon: 'fas fa-infinity',
     rightIcon: 'fas fa-info-circle',
     weight: 3,
@@ -204,15 +208,16 @@ const PERMISSION_DESCRIPTIONS = deepFreeze({
     permissionValue,
   ) => {
     const baseDescription = {
-      description: 'TODO.',
       leftIcon: 'fas fa-info',
       rightIcon: 'fas fa-info-circle',
+      weight: 3,
     };
 
     const result = [
       {
         ...baseDescription,
         label: t('permission_transactionInsight'),
+        description: t('permission_transactionInsightDescription'),
       },
     ];
 
@@ -224,6 +229,7 @@ const PERMISSION_DESCRIPTIONS = deepFreeze({
       result.push({
         ...baseDescription,
         label: t('permission_transactionInsightOrigin'),
+        description: t('permission_transactionInsightOriginDescription'),
         leftIcon: 'fas fa-compass',
       });
     }
@@ -232,37 +238,45 @@ const PERMISSION_DESCRIPTIONS = deepFreeze({
   },
   [EndowmentPermissions['endowment:cronjob']]: (t) => ({
     label: t('permission_cronjob'),
-    description: 'TODO.',
+    description: t('permission_cronjobDescription'),
     leftIcon: 'fas fa-clock',
     rightIcon: 'fas fa-info-circle',
     weight: 2,
   }),
   [EndowmentPermissions['endowment:ethereum-provider']]: (t) => ({
     label: t('permission_ethereumProvider'),
-    description: 'TODO.',
+    description: t('permission_ethereumProviderDescription'),
     leftIcon: 'fab fa-ethereum',
     rightIcon: 'fas fa-info-circle',
     weight: 1,
   }),
   [EndowmentPermissions['endowment:rpc']]: (t, _, permissionValue) => {
-    const { snaps, dapps } = getRpcCaveatOrigins(permissionValue);
-
-    const labels = [];
-    if (snaps) {
-      labels.push(t('permission_rpc', [t('otherSnaps')]));
-    }
-
-    if (dapps) {
-      labels.push(t('permission_rpc', [t('websites')]));
-    }
-
-    return labels.map((label) => ({
-      label,
-      description: 'TODO.',
+    const baseDescription = {
       leftIcon: 'fas fa-plug',
       rightIcon: 'fas fa-info-circle',
       weight: 2,
-    }));
+    };
+
+    const { snaps, dapps } = getRpcCaveatOrigins(permissionValue);
+
+    const results = [];
+    if (snaps) {
+      results.push({
+        ...baseDescription,
+        label: t('permission_rpc', [t('otherSnaps')]),
+        description: t('permission_rpcDescription'),
+      });
+    }
+
+    if (dapps) {
+      results.push({
+        ...baseDescription,
+        label: t('permission_rpc', [t('websites')]),
+        description: t('permission_rpcDescription'),
+      });
+    }
+
+    return results;
   },
   ///: END:ONLY_INCLUDE_IN
   [UNKNOWN_PERMISSION]: (t, permissionName) => ({

--- a/ui/helpers/utils/permission.js
+++ b/ui/helpers/utils/permission.js
@@ -14,9 +14,14 @@ import {
   ///: END:ONLY_INCLUDE_IN
 } from '../../../shared/constants/permissions';
 import Tooltip from '../../components/ui/tooltip';
-import { Icon, ICON_NAMES } from '../../components/component-library';
-import { Color } from '../constants/design-system';
+import {
+  Icon,
+  ICON_NAMES,
+  AvatarIcon,
+  ICON_SIZES,
+} from '../../components/component-library';
 ///: BEGIN:ONLY_INCLUDE_IN(flask)
+import { IconColor } from '../constants/design-system';
 import {
   coinTypeToProtocolName,
   getSnapDerivationPathName,
@@ -26,12 +31,38 @@ import {
 
 const UNKNOWN_PERMISSION = Symbol('unknown');
 
+const RIGHT_WARNING_ICON = (
+  <Icon
+    name={ICON_NAMES.DANGER}
+    size={ICON_SIZES.SM}
+    color={IconColor.warningDefault}
+  />
+);
+
+const RIGHT_INFO_ICON = (
+  <Icon
+    name={ICON_NAMES.INFO}
+    size={ICON_SIZES.SM}
+    color={IconColor.iconMuted}
+  />
+);
+
+function getLeftIcon(iconName) {
+  return (
+    <AvatarIcon
+      iconName={iconName}
+      size={ICON_SIZES.SM}
+      iconProps={{
+        size: ICON_SIZES.XS,
+      }}
+    />
+  );
+}
+
 const PERMISSION_DESCRIPTIONS = deepFreeze({
   [RestrictedMethods.eth_accounts]: (t) => ({
     label: t('permission_ethereumAccounts'),
-    leftIcon: (
-      <Icon name={ICON_NAMES.EYE} margin={4} color={Color.iconAlternative} />
-    ),
+    leftIcon: getLeftIcon(ICON_NAMES.ETHEREUM),
     rightIcon: null,
     weight: 2,
   }),
@@ -39,35 +70,29 @@ const PERMISSION_DESCRIPTIONS = deepFreeze({
   [RestrictedMethods.snap_confirm]: (t) => ({
     label: t('permission_customConfirmation'),
     description: t('permission_customConfirmationDescription'),
-    leftIcon: 'fas fa-user-check',
-    rightIcon: 'fas fa-info-circle',
+    leftIcon: getLeftIcon(ICON_NAMES.SECURITY_TICK),
+    rightIcon: RIGHT_INFO_ICON,
     weight: 3,
   }),
   [RestrictedMethods.snap_dialog]: (t) => ({
     label: t('permission_dialog'),
     description: t('permission_dialogDescription'),
-    leftIcon: 'fas fa-user-check',
-    rightIcon: 'fas fa-info-circle',
+    leftIcon: getLeftIcon(ICON_NAMES.MESSAGES),
+    rightIcon: RIGHT_INFO_ICON,
     weight: 3,
   }),
   [RestrictedMethods.snap_notify]: (t) => ({
     label: t('permission_notifications'),
     description: t('permission_notificationsDescription'),
-    leftIcon: <Icon name={ICON_NAMES.NOTIFICATION} />,
-    rightIcon: 'fas fa-info-circle',
+    leftIcon: getLeftIcon(ICON_NAMES.NOTIFICATION),
+    rightIcon: RIGHT_INFO_ICON,
     weight: 3,
   }),
   [RestrictedMethods.snap_getBip32PublicKey]: (t, _, permissionValue) =>
     permissionValue.caveats[0].value.map(({ path, curve }) => {
       const baseDescription = {
-        leftIcon: (
-          <Icon
-            name={ICON_NAMES.EYE}
-            margin={4}
-            color={Color.iconAlternative}
-          />
-        ),
-        rightIcon: 'fa fa-exclamation-triangle',
+        leftIcon: getLeftIcon(ICON_NAMES.SECURITY_SEARCH),
+        rightIcon: RIGHT_WARNING_ICON,
         weight: 1,
       };
 
@@ -115,8 +140,8 @@ const PERMISSION_DESCRIPTIONS = deepFreeze({
   [RestrictedMethods.snap_getBip32Entropy]: (t, _, permissionValue) =>
     permissionValue.caveats[0].value.map(({ path, curve }) => {
       const baseDescription = {
-        leftIcon: 'fas fa-door-open',
-        rightIcon: 'fa fa-exclamation-triangle',
+        leftIcon: getLeftIcon(ICON_NAMES.KEY),
+        rightIcon: RIGHT_WARNING_ICON,
         weight: 1,
       };
 
@@ -178,29 +203,29 @@ const PERMISSION_DESCRIPTIONS = deepFreeze({
             `${coinType} (Unrecognized protocol)`}
         </span>,
       ]),
-      leftIcon: 'fas fa-door-open',
-      rightIcon: 'fa fa-exclamation-triangle',
+      leftIcon: getLeftIcon(ICON_NAMES.KEY),
+      rightIcon: RIGHT_WARNING_ICON,
       weight: 1,
     })),
   [RestrictedMethods.snap_getEntropy]: (t) => ({
     label: t('permission_getEntropy'),
     description: t('permission_getEntropyDescription'),
-    leftIcon: 'fas fa-key',
-    rightIcon: 'fas fa-info-circle',
+    leftIcon: getLeftIcon(ICON_NAMES.SECURITY_KEY),
+    rightIcon: RIGHT_INFO_ICON,
     weight: 3,
   }),
   [RestrictedMethods.snap_manageState]: (t) => ({
     label: t('permission_manageState'),
     description: t('permission_manageStateDescription'),
-    leftIcon: 'fas fa-download',
-    rightIcon: 'fas fa-info-circle',
+    leftIcon: getLeftIcon(ICON_NAMES.ADD_SQUARE),
+    rightIcon: RIGHT_INFO_ICON,
     weight: 3,
   }),
   [RestrictedMethods.wallet_snap]: (t, _, permissionValue) => {
     const snaps = permissionValue.caveats[0].value;
     const baseDescription = {
-      leftIcon: 'fas fa-bolt',
-      rightIcon: 'fas fa-info-circle',
+      leftIcon: getLeftIcon(ICON_NAMES.FLASH),
+      rightIcon: RIGHT_INFO_ICON,
     };
 
     return Object.keys(snaps).map((snapId) => {
@@ -226,8 +251,8 @@ const PERMISSION_DESCRIPTIONS = deepFreeze({
   [EndowmentPermissions['endowment:network-access']]: (t) => ({
     label: t('permission_accessNetwork'),
     description: t('permission_accessNetworkDescription'),
-    leftIcon: 'fas fa-wifi',
-    rightIcon: 'fas fa-info-circle',
+    leftIcon: getLeftIcon(ICON_NAMES.GLOBAL),
+    rightIcon: RIGHT_INFO_ICON,
     weight: 2,
   }),
   [EndowmentPermissions['endowment:webassembly']]: (t) => ({
@@ -239,8 +264,8 @@ const PERMISSION_DESCRIPTIONS = deepFreeze({
   [EndowmentPermissions['endowment:long-running']]: (t) => ({
     label: t('permission_longRunning'),
     description: t('permission_longRunningDescription'),
-    leftIcon: 'fas fa-infinity',
-    rightIcon: 'fas fa-info-circle',
+    leftIcon: getLeftIcon(ICON_NAMES.LINK),
+    rightIcon: RIGHT_INFO_ICON,
     weight: 3,
   }),
   [EndowmentPermissions['endowment:transaction-insight']]: (
@@ -249,8 +274,8 @@ const PERMISSION_DESCRIPTIONS = deepFreeze({
     permissionValue,
   ) => {
     const baseDescription = {
-      leftIcon: 'fas fa-info',
-      rightIcon: 'fas fa-info-circle',
+      leftIcon: getLeftIcon(ICON_NAMES.SPEEDOMETER),
+      rightIcon: RIGHT_INFO_ICON,
       weight: 3,
     };
 
@@ -271,7 +296,7 @@ const PERMISSION_DESCRIPTIONS = deepFreeze({
         ...baseDescription,
         label: t('permission_transactionInsightOrigin'),
         description: t('permission_transactionInsightOriginDescription'),
-        leftIcon: 'fas fa-compass',
+        leftIcon: getLeftIcon(ICON_NAMES.EXPLORE),
       });
     }
 
@@ -280,21 +305,21 @@ const PERMISSION_DESCRIPTIONS = deepFreeze({
   [EndowmentPermissions['endowment:cronjob']]: (t) => ({
     label: t('permission_cronjob'),
     description: t('permission_cronjobDescription'),
-    leftIcon: 'fas fa-clock',
-    rightIcon: 'fas fa-info-circle',
+    leftIcon: getLeftIcon(ICON_NAMES.CLOCK),
+    rightIcon: RIGHT_INFO_ICON,
     weight: 2,
   }),
   [EndowmentPermissions['endowment:ethereum-provider']]: (t) => ({
     label: t('permission_ethereumProvider'),
     description: t('permission_ethereumProviderDescription'),
-    leftIcon: 'fab fa-ethereum',
-    rightIcon: 'fas fa-info-circle',
+    leftIcon: getLeftIcon(ICON_NAMES.ETHEREUM),
+    rightIcon: RIGHT_INFO_ICON,
     weight: 1,
   }),
   [EndowmentPermissions['endowment:rpc']]: (t, _, permissionValue) => {
     const baseDescription = {
-      leftIcon: 'fas fa-plug',
-      rightIcon: 'fas fa-info-circle',
+      leftIcon: getLeftIcon(ICON_NAMES.HIERARCHY),
+      rightIcon: RIGHT_INFO_ICON,
       weight: 2,
     };
 
@@ -322,7 +347,7 @@ const PERMISSION_DESCRIPTIONS = deepFreeze({
   ///: END:ONLY_INCLUDE_IN
   [UNKNOWN_PERMISSION]: (t, permissionName) => ({
     label: t('permission_unknown', [permissionName ?? 'undefined']),
-    leftIcon: 'fas fa-times-circle',
+    leftIcon: getLeftIcon(ICON_NAMES.QUESTION),
     rightIcon: null,
     weight: 4,
   }),
@@ -397,7 +422,7 @@ export function getWeightedPermissions(t, permissions) {
  * If the weight is 1, the icon will be rendered with a warning color.
  *
  * @param {PermissionLabelObject} permission - The permission object.
- * @param {string} permission.rightIcon - The right icon.
+ * @param {JSX.Element | string} permission.rightIcon - The right icon.
  * @param {string} permission.description - The description.
  * @param {number} permission.weight - The weight.
  * @returns {JSX.Element | null} The right icon, or null if there's no
@@ -414,13 +439,23 @@ export function getRightIcon({ rightIcon, description, weight }) {
         html={<div>{description}</div>}
         position="bottom"
       >
-        <i className={rightIcon} />
+        {typeof rightIcon === 'string' ? (
+          <i className={rightIcon} />
+        ) : (
+          rightIcon
+        )}
       </Tooltip>
     );
   }
 
   if (rightIcon) {
-    return <i className={classnames(rightIcon, 'permission__tooltip-icon')} />;
+    if (typeof rightIcon === 'string') {
+      return (
+        <i className={classnames(rightIcon, 'permission__tooltip-icon')} />
+      );
+    }
+
+    return rightIcon;
   }
 
   return null;

--- a/ui/helpers/utils/permission.js
+++ b/ui/helpers/utils/permission.js
@@ -262,6 +262,7 @@ const PERMISSION_DESCRIPTIONS = deepFreeze({
   }),
   [EndowmentPermissions['endowment:webassembly']]: (t) => ({
     label: t('permission_webAssembly'),
+    description: t('permission_webAssemblyDescription'),
     leftIcon: 'fas fa-microchip',
     rightIcon: null,
     weight: 2,

--- a/ui/helpers/utils/permission.js
+++ b/ui/helpers/utils/permission.js
@@ -13,9 +13,7 @@ import {
   EndowmentPermissions,
   ///: END:ONLY_INCLUDE_IN
 } from '../../../shared/constants/permissions';
-///: BEGIN:ONLY_INCLUDE_IN(flask)
 import Tooltip from '../../components/ui/tooltip';
-///: END:ONLY_INCLUDE_IN
 import { Icon, ICON_NAMES } from '../../components/component-library';
 import { Color } from '../constants/design-system';
 ///: BEGIN:ONLY_INCLUDE_IN(flask)

--- a/ui/helpers/utils/permission.js
+++ b/ui/helpers/utils/permission.js
@@ -238,6 +238,7 @@ const PERMISSION_DESCRIPTIONS = deepFreeze({
               {friendlyName}
             </span>,
           ]),
+          description: t('permission_accessSnapDescription', [friendlyName]),
         };
       }
 

--- a/ui/helpers/utils/permission.js
+++ b/ui/helpers/utils/permission.js
@@ -15,9 +15,11 @@ import {
 } from '../../../shared/constants/permissions';
 import Tooltip from '../../components/ui/tooltip';
 import {
-  Icon,
-  ICON_NAMES,
   AvatarIcon,
+  ///: BEGIN:ONLY_INCLUDE_IN(flask)
+  Icon,
+  ///: END:ONLY_INCLUDE_IN
+  ICON_NAMES,
   ICON_SIZES,
 } from '../../components/component-library';
 ///: BEGIN:ONLY_INCLUDE_IN(flask)
@@ -31,6 +33,7 @@ import {
 
 const UNKNOWN_PERMISSION = Symbol('unknown');
 
+///: BEGIN:ONLY_INCLUDE_IN(flask)
 const RIGHT_WARNING_ICON = (
   <Icon
     name={ICON_NAMES.DANGER}
@@ -46,6 +49,7 @@ const RIGHT_INFO_ICON = (
     color={IconColor.iconMuted}
   />
 );
+///: END:ONLY_INCLUDE_IN
 
 function getLeftIcon(iconName) {
   return (


### PR DESCRIPTION
## Explanation

This adds support for showing tooltips on permissions, and adds a tooltip to all the Snaps-related permissions.

Closes #17624.

### Before

<!-- How did the UI you changed look before your changes? Drag your file(s) below this line: -->

<img width="300" alt="image" src="https://user-images.githubusercontent.com/7503723/217795094-1b0fa5f9-09b7-40be-9a51-a5c4e860b9d3.png">

### After

<img width="300" alt="image" src="https://user-images.githubusercontent.com/7503723/220143125-1b6e9cd6-2688-4afe-8b05-3819ee72f870.png"> <img width="300" alt="image" src="https://user-images.githubusercontent.com/7503723/220143132-16f92257-bb98-48fc-9340-8318e85b569d.png">

## Manual Testing Steps

1. Go to `test-snaps`.
2. Click to connect to a snap.
3. Ensure that the right icon shows up, and shows a tooltip when hovering.

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone