### PR TITLE
NFTs: Hide  detail when no thumbnail available

### DIFF
--- a/ui/components/app/nft-details/__snapshots__/nft-details.test.js.snap
+++ b/ui/components/app/nft-details/__snapshots__/nft-details.test.js.snap
@@ -102,25 +102,6 @@ exports[`Collectible Details should match minimal props and state snapshot 1`] =
         <h6
           class="box box--margin-top-1 box--margin-right-2 box--margin-bottom-4 box--flex-direction-row typography collectible-details__link-title typography--h6 typography--weight-bold typography--style-normal typography--color-text-default"
         >
-          Link
-        </h6>
-        <h6
-          class="box box--margin-top-1 box--margin-bottom-4 box--flex-direction-row typography collectible-details__image-source typography--h6 typography--weight-normal typography--style-normal typography--color-primary-default"
-        >
-          <a
-            href="https://bafybeiclzx7zfjvuiuwobn5ip3ogc236bjqfjzoblumf4pau4ep6dqramu.ipfs.dweb.link"
-            rel="noopener noreferrer"
-            target="_blank"
-            title="https://bafybeiclzx7zfjvuiuwobn5ip3ogc236bjqfjzoblumf4pau4ep6dqramu.ipfs.dweb.link"
-          />
-        </h6>
-      </div>
-      <div
-        class="box box--display-flex box--flex-direction-row"
-      >
-        <h6
-          class="box box--margin-top-1 box--margin-right-2 box--margin-bottom-4 box--flex-direction-row typography collectible-details__link-title typography--h6 typography--weight-bold typography--style-normal typography--color-text-default"
-        >
           Contract address
         </h6>
         <div

--- a/ui/components/app/nft-details/nft-details.js
+++ b/ui/components/app/nft-details/nft-details.js
@@ -344,41 +344,43 @@ export default function CollectibleDetails({ collectible }) {
               )}
             </Typography>
           </Box>
-          <Box display={DISPLAY.FLEX} flexDirection={FLEX_DIRECTION.ROW}>
-            <Typography
-              color={TextColor.textDefault}
-              variant={TypographyVariant.H6}
-              fontWeight={FONT_WEIGHT.BOLD}
-              boxProps={{
-                margin: 0,
-                marginBottom: 4,
-                marginRight: 2,
-              }}
-              className="collectible-details__link-title"
-            >
-              {t('link')}
-            </Typography>
-            <Typography
-              variant={TypographyVariant.H6}
-              boxProps={{
-                margin: 0,
-                marginBottom: 4,
-              }}
-              className="collectible-details__image-source"
-              color={
-                isDataURI ? TextColor.textDefault : TextColor.primaryDefault
-              }
-            >
-              <a
-                target="_blank"
-                rel="noopener noreferrer"
-                href={collectibleImageURL}
-                title={collectibleImageURL}
+          {imageThumbnail ? (
+            <Box display={DISPLAY.FLEX} flexDirection={FLEX_DIRECTION.ROW}>
+              <Typography
+                color={TextColor.textDefault}
+                variant={TypographyVariant.H6}
+                fontWeight={FONT_WEIGHT.BOLD}
+                boxProps={{
+                  margin: 0,
+                  marginBottom: 4,
+                  marginRight: 2,
+                }}
+                className="collectible-details__link-title"
               >
-                {imageThumbnail}
-              </a>
-            </Typography>
-          </Box>
+                {t('link')}
+              </Typography>
+              <Typography
+                variant={TypographyVariant.H6}
+                boxProps={{
+                  margin: 0,
+                  marginBottom: 4,
+                }}
+                className="collectible-details__image-source"
+                color={
+                  isDataURI ? TextColor.textDefault : TextColor.primaryDefault
+                }
+              >
+                <a
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  href={collectibleImageURL}
+                  title={collectibleImageURL}
+                >
+                  {imageThumbnail}
+                </a>
+              </Typography>
+            </Box>
+          ) : null}
           <Box display={DISPLAY.FLEX} flexDirection={FLEX_DIRECTION.ROW}>
             <Typography
               color={TextColor.textDefault}


### PR DESCRIPTION
## Explanation

When importing an NFT on Polygon, the detail screen is missing the `link` information because it's not provided by the API.  If no separate thumbnail link is available, we should hide that row in the NFT detail.

## Screenshots/Screencaps

<img width="764" alt="NoLink" src="https://user-images.githubusercontent.com/46655/217886530-846de238-3672-4b7c-95da-26092e34d4af.png">

## Manual Testing Steps

1.  Add Polygon network to the wallet
2. Import this NFT: https://polygonscan.com/tx/0x02bb91ad32785551c9be1182173fc2df692d1f77062a92bdee060e3bbda3d979
3. Before this PR, a "Link" column would display without required information
4. After this PR, that "Link" column is hidden

## Pre-merge author checklist

- [ ] I've clearly explained:
  - [ ] What problem this PR is solving
  - [ ] How this problem was solved
  - [ ] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
