### PR TITLE
[FLASK] Add WebAssembly endowment

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -2822,6 +2822,10 @@
     "message": "View your public key for $1.",
     "description": "The description for the `snap_getBip32PublicKey` permission. $1 is a name for the derivation path, e.g., 'Ethereum accounts'."
   },
+  "permission_webAssembly": {
+    "message": "Support for WebAssembly.",
+    "description": "The description of the `endowment:webassembly` permission."
+  },
   "permissions": {
     "message": "Permissions"
   },

--- a/shared/constants/permissions.ts
+++ b/shared/constants/permissions.ts
@@ -24,7 +24,6 @@ export const RestrictedMethods = Object.freeze({
  */
 export const EndowmentPermissions = Object.freeze({
   'endowment:network-access': 'endowment:network-access',
-  'endowment:webassembly': 'endowment:webassembly',
   'endowment:transaction-insight': 'endowment:transaction-insight',
   'endowment:cronjob': 'endowment:cronjob',
   'endowment:ethereum-provider': 'endowment:ethereum-provider',

--- a/shared/constants/permissions.ts
+++ b/shared/constants/permissions.ts
@@ -24,6 +24,7 @@ export const RestrictedMethods = Object.freeze({
  */
 export const EndowmentPermissions = Object.freeze({
   'endowment:network-access': 'endowment:network-access',
+  'endowment:webassembly': 'endowment:webassembly',
   'endowment:transaction-insight': 'endowment:transaction-insight',
   'endowment:cronjob': 'endowment:cronjob',
   'endowment:ethereum-provider': 'endowment:ethereum-provider',

--- a/ui/helpers/utils/permission.js
+++ b/ui/helpers/utils/permission.js
@@ -171,6 +171,12 @@ const PERMISSION_DESCRIPTIONS = deepFreeze({
     rightIcon: null,
     weight: 2,
   }),
+  [EndowmentPermissions['endowment:webassembly']]: (t) => ({
+    label: t('permission_webAssembly'),
+    leftIcon: 'fas fa-microchip',
+    rightIcon: null,
+    weight: 2,
+  }),
   [EndowmentPermissions['endowment:long-running']]: (t) => ({
     label: t('permission_longRunning'),
     leftIcon: 'fas fa-infinity',


### PR DESCRIPTION
Fixes: https://github.com/MetaMask/snaps-monorepo/issues/1150

Add WebAssembly Snaps endowment permission available only in Flask.
Snaps Monorepo related PR: https://github.com/MetaMask/snaps-monorepo/pull/1185

Note: This is part of endowments hardening epic: https://app.zenhub.com/workspaces/snaps-615b3a7c08d2b20015eb6c4e/issues/gh/metamask/snaps-monorepo/585

WebAssembly was previously part of the default-endowments. Because of some security concerns it is determined that this endowment should be protected by permission which this PR is introducing.

Changes visible in the UI when permission is used:
![Screenshot 2023-02-10 at 16 22 52](https://user-images.githubusercontent.com/13301024/218129102-15e8350e-d877-44c7-9512-294c22d872e1.png)

