### PR TITLE
Fixing prop type errors in components and tests

### DIFF
--- a/ui/components/component-library/avatar-favicon/avatar-favicon.test.js
+++ b/ui/components/component-library/avatar-favicon/avatar-favicon.test.js
@@ -7,11 +7,12 @@ import { AvatarFavicon, AVATAR_FAVICON_SIZES } from '.';
 describe('AvatarFavicon', () => {
   const args = {
     src: './images/eth_logo.svg',
+    name: 'test',
   };
 
   it('should render correctly', () => {
     const { getByTestId, container } = render(
-      <AvatarFavicon data-testid="avatar-favicon" />,
+      <AvatarFavicon name="test" data-testid="avatar-favicon" />,
     );
     expect(getByTestId('avatar-favicon')).toBeDefined();
     expect(container).toMatchSnapshot();
@@ -26,7 +27,7 @@ describe('AvatarFavicon', () => {
 
   it('should render fallback image if no ImageSource is provided', () => {
     const { container } = render(
-      <AvatarFavicon data-testid="avatar-favicon" />,
+      <AvatarFavicon name="test" data-testid="avatar-favicon" />,
     );
     expect(container.getElementsByClassName('mm-icon')).toHaveLength(1);
   });
@@ -34,6 +35,7 @@ describe('AvatarFavicon', () => {
   it('should render fallback image with custom fallbackIconProps if no ImageSource is provided', () => {
     const container = (
       <AvatarFavicon
+        name="test"
         data-testid="avatar-favicon"
         fallbackIconProps={{
           'data-testid': 'fallback-icon',
@@ -96,6 +98,7 @@ describe('AvatarFavicon', () => {
     const { getByTestId } = render(
       <AvatarFavicon
         className="mm-avatar-favicon--test"
+        name="test"
         data-testid="classname"
         {...args}
       />,

--- a/ui/components/component-library/help-text/help-text.test.js
+++ b/ui/components/component-library/help-text/help-text.test.js
@@ -22,7 +22,8 @@ describe('HelpText', () => {
   it('should render with react nodes inside the HelpText', () => {
     const { getByText, getByTestId } = render(
       <HelpText>
-        help text <Icon name={ICON_NAMES.WARNING} data-testid="icon" />
+        help text{' '}
+        <Icon name={ICON_NAMES.WARNING} data-testid="icon" as="span" />
       </HelpText>,
     );
     expect(getByText('help text')).toBeDefined();

--- a/ui/components/component-library/picker-network/picker-network.test.js
+++ b/ui/components/component-library/picker-network/picker-network.test.js
@@ -57,7 +57,11 @@ describe('PickerNetwork', () => {
   // className
   it('should render with custom className', () => {
     const { getByTestId } = render(
-      <PickerNetwork data-testid="picker-network" className="test-class" />,
+      <PickerNetwork
+        data-testid="picker-network"
+        label="test"
+        className="test-class"
+      />,
     );
     expect(getByTestId('picker-network')).toHaveClass('test-class');
   });

--- a/ui/components/component-library/tag-url/tag-url.js
+++ b/ui/components/component-library/tag-url/tag-url.js
@@ -43,7 +43,7 @@ export const TagUrl = ({
       display={DISPLAY.FLEX}
       {...props}
     >
-      <AvatarFavicon src={src} {...avatarFaviconProps} />
+      <AvatarFavicon src={src} name={label} {...avatarFaviconProps} />
       {showLockIcon && (
         <Icon
           className="mm-tag-url__lock-icon"
@@ -58,7 +58,6 @@ export const TagUrl = ({
       <Text variant={TextVariant.bodyMd} ellipsis {...labelProps}>
         {label}
       </Text>
-
       {actionButtonLabel && (
         <ButtonLink
           as="a"


### PR DESCRIPTION
## Explanation
We have a few proptype errors when running jest tests in the component-library folder

To improve the readability as well as spot warnings and errors easier this PR updates any of those tests or components that had prop type errors and makes the terminal all 🍏 📗 🟢 💚 - green

* Fixes #17702 

## Screenshots/Screencaps

### Before

https://user-images.githubusercontent.com/8112138/217962253-98f2340d-ecfa-4210-8325-e4e03d73e2d7.mov

### After

![Screenshot 2023-02-09 at 3 27 18 PM](https://user-images.githubusercontent.com/8112138/217962278-c1873bd5-5f52-4464-9289-199c96282d00.png)

## Manual Testing Steps

- Pull this branch
- Run

```
yarn jest ui/components/component-library
```
- The terminal should be all 🍏 📗 🟢 💚 - green

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
