### PR TITLE
Fix mocha syntax fitness function

### DIFF
--- a/.github/workflows/fitness-functions.yml
+++ b/.github/workflows/fitness-functions.yml
@@ -25,4 +25,4 @@ jobs:
           git fetch origin $HEAD_REF
           git fetch origin $BASE_REF
           git diff origin/$BASE_REF origin/$HEAD_REF -- . ':(exclude)development/fitness-functions/*' > diff
-          # npm run fitness-functions -- "ci" "./diff"
+          npm run fitness-functions -- "ci" "./diff"

--- a/coverage-targets.js
+++ b/coverage-targets.js
@@ -6,10 +6,10 @@
 // subset of files to check against these targets.
 module.exports = {
   global: {
-    lines: 62.25,
-    branches: 50.5,
-    statements: 61.5,
-    functions: 55,
+    lines: 63,
+    branches: 51,
+    statements: 62.5,
+    functions: 55.5,
   },
   transforms: {
     branches: 100,

--- a/development/fitness-functions/check-mocha-syntax.js
+++ b/development/fitness-functions/check-mocha-syntax.js
@@ -1,4 +1,5 @@
 const {
+  EXCLUDE_E2E_TESTS_REGEX,
   filterDiffAdditions,
   filterDiffByFilePath,
   hasNumberOfCodeBlocksIncreased,
@@ -15,10 +16,9 @@ function checkMochaSyntax(diff) {
     'sinon.',
   ];
 
-  console.log(`Checking ${ruleHeading}...`);
+  console.log(`\nChecking ${ruleHeading}...`);
 
-  const jsFilesExcludingE2ETests = '^(?!.*/test/e2e/).*.(js|ts|jsx)$';
-  const diffByFilePath = filterDiffByFilePath(diff, jsFilesExcludingE2ETests);
+  const diffByFilePath = filterDiffByFilePath(diff, EXCLUDE_E2E_TESTS_REGEX);
   const diffAdditions = filterDiffAdditions(diffByFilePath);
   const hashmap = hasNumberOfCodeBlocksIncreased(diffAdditions, codeBlocks);
 
@@ -30,7 +30,7 @@ function checkMochaSyntax(diff) {
 
   if (Object.values(hashmap).includes(true)) {
     console.error(
-      `...changes have not been committed.\nFor more info, see: https://github.com/MetaMask/metamask-extension/blob/develop/docs/testing.md#${ruleHeading}`,
+      `...changes have not been accepted by the fitness function.\nFor more info, see: https://github.com/MetaMask/metamask-extension/blob/develop/docs/testing.md#${ruleHeading}`,
     );
     process.exit(1);
   } else {

--- a/development/fitness-functions/shared.js
+++ b/development/fitness-functions/shared.js
@@ -1,3 +1,5 @@
+const EXCLUDE_E2E_TESTS_REGEX = '^(?!test/e2e/).*.(js|ts|jsx)$';
+
 function filterDiffByFilePath(diff, regex) {
   // split by `diff --git` and remove the first element which is empty
   const diffBlocks = diff.split(`diff --git`).slice(1);
@@ -64,6 +66,7 @@ function hasNumberOfCodeBlocksIncreased(diffFragment, codeBlocks) {
 }
 
 module.exports = {
+  EXCLUDE_E2E_TESTS_REGEX,
   filterDiffByFilePath,
   filterDiffAdditions,
   hasNumberOfCodeBlocksIncreased,

--- a/development/fitness-functions/shared.test.js
+++ b/development/fitness-functions/shared.test.js
@@ -1,4 +1,5 @@
 const {
+  EXCLUDE_E2E_TESTS_REGEX,
   filterDiffAdditions,
   hasNumberOfCodeBlocksIncreased,
   filterDiffByFilePath,
@@ -154,5 +155,53 @@ describe('filterDiffByFilePath()', () => {
       @@ -34,33 +39,4 @@
       -yang"
     `);
+  });
+});
+
+describe(`EXCLUDE_E2E_TESTS_REGEX "${EXCLUDE_E2E_TESTS_REGEX}"`, () => {
+  const PATHS_IT_SHOULD_MATCH = [
+    'file.js',
+    'path/file.js',
+    'much/longer/path/file.js',
+    'file.ts',
+    'path/file.ts',
+    'much/longer/path/file.ts',
+    'file.jsx',
+    'path/file.jsx',
+    'much/longer/path/file.jsx',
+  ];
+
+  const PATHS_IT_SHOULD_NOT_MATCH = [
+    'test/e2e/file',
+    'test/e2e/file.extension',
+    'test/e2e/path/file.extension',
+    'test/e2e/much/longer/path/file.extension',
+    'test/e2e/file.js',
+    'test/e2e/path/file.ts',
+    'test/e2e/much/longer/path/file.jsx',
+    'file',
+    'file.extension',
+    'path/file.extension',
+    'much/longer/path/file.extension',
+  ];
+
+  describe('included paths', () => {
+    PATHS_IT_SHOULD_MATCH.forEach((path) => {
+      it(`should match "${path}"`, () => {
+        const result = new RegExp(EXCLUDE_E2E_TESTS_REGEX, 'u').test(path);
+
+        expect(result).toStrictEqual(true);
+      });
+    });
+  });
+
+  describe('excluded paths', () => {
+    PATHS_IT_SHOULD_NOT_MATCH.forEach((path) => {
+      it(`should not match "${path}"`, () => {
+        const result = new RegExp(EXCLUDE_E2E_TESTS_REGEX, 'u').test(path);
+
+        expect(result).toStrictEqual(false);
+      });
+    });
   });
 });


### PR DESCRIPTION
## Explanation

Fixes the regex for excluding e2e tests on [this rule](https://github.com/MetaMask/metamask-extension/blob/develop/docs/testing.md#favor-jest-instead-of-mocha). The rule only applies to unit and component tests. E2E tests should be able to continue using assert.