### PR TITLE
Squashed warning when running `yarn test:coverage:jest`

### DIFF
--- a/.storybook/__mocks__/webextension-polyfill.js
+++ b/.storybook/__mocks__/webextension-polyfill.js
@@ -1,8 +1,0 @@
-module.exports = {
-  runtime: {
-    getManifest: () => {
-      return { manifest_version: 2 };
-    }
-  },
-};
-  

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -40,7 +40,7 @@ module.exports = {
       __filename: true,
     };
     config.resolve.alias['webextension-polyfill'] = require.resolve(
-      './__mocks__/webextension-polyfill.js',
+      '../ui/__mocks__/webextension-polyfill.js',
     );
     config.resolve.fallback = {
       child_process: false,


### PR DESCRIPTION
I noticed this warning when running `yarn test:coverage:jest`
```
jest-haste-map: duplicate manual mock found: webextension-polyfill
  The following files share their name; please delete one of them:
    * <rootDir>/.storybook/__mocks__/webextension-polyfill.js
    * <rootDir>/ui/__mocks__/webextension-polyfill.js
```

I was able to squash the warning by deleting `.storybook/__mocks__/webextension-polyfill.js` and changing `.storybook/main.js` from
```
config.resolve.alias['webextension-polyfill'] = require.resolve(
  './__mocks__/webextension-polyfill.js',
);
```
to
```
config.resolve.alias['webextension-polyfill'] = require.resolve(
  '../ui/__mocks__/webextension-polyfill.js',
);
```