### PR TITLE
Updating Label component

### DIFF
--- a/ui/components/component-library/form-text-field/form-text-field.js
+++ b/ui/components/component-library/form-text-field/form-text-field.js
@@ -62,8 +62,11 @@ export const FormTextField = ({
       <Label
         htmlFor={id}
         required={required}
-        disabled={disabled}
         {...labelProps}
+        className={classnames(
+          'mm-form-text-field__label',
+          labelProps?.className,
+        )}
       >
         {label}
       </Label>
@@ -105,13 +108,13 @@ export const FormTextField = ({
     />
     {helpText && (
       <HelpText
+        error={error}
+        marginTop={1}
+        {...helpTextProps}
         className={classnames(
           'mm-form-text-field__help-text',
           helpTextProps?.className,
         )}
-        error={error}
-        marginTop={1}
-        {...helpTextProps}
       >
         {helpText}
       </HelpText>

--- a/ui/components/component-library/form-text-field/form-text-field.scss
+++ b/ui/components/component-library/form-text-field/form-text-field.scss
@@ -1,9 +1,11 @@
 .mm-form-text-field {
-  --help-text-opacity-disabled: 0.5;
+  --text-opacity-disabled: 0.5;
 
   &--disabled {
+    .mm-form-text-field__label,
     .mm-form-text-field__help-text {
-      opacity: var(--help-text-opacity-disabled);
+      opacity: var(--text-opacity-disabled);
+      cursor: default;
     }
   }
 }

--- a/ui/components/component-library/form-text-field/form-text-field.test.js
+++ b/ui/components/component-library/form-text-field/form-text-field.test.js
@@ -96,11 +96,14 @@ describe('FormTextField', () => {
     const { getByText, getByTestId } = render(
       <FormTextField
         helpText="test help text"
-        helpTextProps={{ 'data-testid': 'help-text-test' }}
+        helpTextProps={{ 'data-testid': 'help-text-test', className: 'test' }}
       />,
     );
     expect(getByText('test help text')).toBeDefined();
     expect(getByTestId('help-text-test')).toBeDefined();
+    expect(getByTestId('help-text-test')).toHaveClass(
+      'mm-form-text-field__help-text test',
+    );
   });
   // id
   it('should render the FormTextField with an id and pass it to input and Label as htmlFor. When clicking on Label the input should have focus', async () => {
@@ -141,12 +144,15 @@ describe('FormTextField', () => {
     const { getByTestId, getByLabelText } = render(
       <FormTextField
         label="test label"
-        labelProps={{ 'data-testid': 'label-test-id' }}
+        labelProps={{ 'data-testid': 'label-test-id', className: 'test' }}
         id="test-id"
       />,
     );
     expect(getByLabelText('test label')).toBeDefined();
     expect(getByTestId('label-test-id')).toBeDefined();
+    expect(getByTestId('label-test-id')).toHaveClass(
+      'mm-form-text-field__label test',
+    );
   });
   // leftAccessory, // rightAccessory
   it('should render with right and left accessories', () => {

--- a/ui/components/component-library/label/README.mdx
+++ b/ui/components/component-library/label/README.mdx
@@ -82,14 +82,6 @@ import { Label } from '../../component-library';
 <Label required>Label</Label>;
 ```
 
-### Disabled
-
-Use the `disabled` prop to set the `Label` in disabled state
-
-<Canvas>
-  <Story id="components-componentlibrary-label--disabled" />
-</Canvas>
-
 ```jsx
 import { Label } from '../../component-library';
 

--- a/ui/components/component-library/label/label.js
+++ b/ui/components/component-library/label/label.js
@@ -10,23 +10,14 @@ import {
   AlignItems,
 } from '../../../helpers/constants/design-system';
 
-export const Label = ({
-  htmlFor,
-  required,
-  disabled,
-  className,
-  children,
-  ...props
-}) => (
+export const Label = ({ htmlFor, required, className, children, ...props }) => (
   <Text
     className={classnames(
       'mm-label',
-      { 'mm-label--disabled': disabled },
-      { 'mm-label--html-for': htmlFor && !disabled },
+      { 'mm-label--html-for': htmlFor },
       className,
     )}
     as="label"
-    disabled={disabled}
     htmlFor={htmlFor}
     variant={TextVariant.bodyMd}
     fontWeight={FONT_WEIGHT.BOLD}
@@ -61,10 +52,6 @@ Label.propTypes = {
    * If true the label will display as required
    */
   required: PropTypes.bool,
-  /**
-   * Whether the label is disabled or not
-   */
-  disabled: PropTypes.bool,
   /**
    * Additional classNames to be added to the label component
    */

--- a/ui/components/component-library/label/label.scss
+++ b/ui/components/component-library/label/label.scss
@@ -1,11 +1,5 @@
 .mm-label {
-  --label-opacity-disabled: 0.5; // TODO: replace with design token
-
   &--html-for {
     cursor: pointer;
-  }
-
-  &--disabled {
-    opacity: var(--label-opacity-disabled);
   }
 }

--- a/ui/components/component-library/label/label.stories.js
+++ b/ui/components/component-library/label/label.stories.js
@@ -31,9 +31,6 @@ export default {
     required: {
       control: 'boolean',
     },
-    disabled: {
-      control: 'boolean',
-    },
     children: {
       control: 'text',
     },
@@ -103,9 +100,4 @@ HtmlFor.args = {
 export const Required = Template.bind({});
 Required.args = {
   required: true,
-};
-
-export const Disabled = Template.bind({});
-Disabled.args = {
-  disabled: true,
 };

--- a/ui/components/component-library/label/label.test.js
+++ b/ui/components/component-library/label/label.test.js
@@ -62,8 +62,4 @@ describe('label', () => {
     expect(getByText('label')).toBeDefined();
     expect(getByText('*')).toBeDefined();
   });
-  it('should render with disabled state and have disabled class', () => {
-    const { getByText } = render(<Label disabled>label</Label>);
-    expect(getByText('label')).toHaveClass('mm-label--disabled');
-  });
 });


### PR DESCRIPTION
## Explanation
Updating the `Label` component based on audit and insight report.
- Removed `disabled` on `Label` component
- Removed `disabled` story and docs
- Updated `FormTextField` with new method of disabled styles
- Add more tests to check that classNames still work for `HelpText` and `Label` inside `FormTextField`


- https://www.figma.com/file/aGW8sk6X6Jf9ac0MRMD4kX/TextField-Audit?node-id=282%3A22&t=uXWtYPu6jWtwEwXT-1
* Fixes #17730

<img width="702" alt="Screenshot 2023-02-10 at 5 29 46 PM" src="https://user-images.githubusercontent.com/8112138/218231461-63c14687-89a7-4806-81a3-f17b09f8969f.png">

## Screenshots/Screencaps

<!-- If you're making a change to the UI, make sure to capture a screenshot or a short video showing off your work! -->

### Before

https://user-images.githubusercontent.com/8112138/218231611-4fc4a434-ca45-4542-8e98-dbe534fdf98c.mov

### After

https://user-images.githubusercontent.com/8112138/218231655-585e5b82-1b1e-4627-b37e-e2d79bb0dc3d.mov

## Manual Testing Steps

- Go to the latest build of storybook in this PR
- Search Label component 
- See Disabled story and docs have been removed
- Go to FormTextField story
- Turn on the disabled control
- See that there is still disabled styles for the Label

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
