### PR TITLE
Fixes broken args table in storybook

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
     "pubnub/superagent-proxy": "^3.0.0",
     "json-schema": "^0.4.0",
     "simple-get": "^4.0.1",
+    "ast-types": "^0.14.2",
     "web3-provider-engine/eth-json-rpc-filters": "^5.0.0",
     "typescript@~4.4.0": "patch:typescript@npm:4.4.4#.yarn/patches/typescript-npm-4.4.4-3fedcc07a3.patch",
     "acorn@^7.0.0": "patch:acorn@npm:7.4.1#.yarn/patches/acorn-npm-7.4.1-f450b4646c.patch",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9533,15 +9533,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ast-types@npm:^0.13.2":
-  version: 0.13.4
-  resolution: "ast-types@npm:0.13.4"
-  dependencies:
-    tslib: ^2.0.1
-  checksum: 5a51f7b70588ecced3601845a0e203279ca2f5fdc184416a0a1640c93ec0a267241d6090a328e78eebb8de81f8754754e0a4f1558ba2a3d638f8ccbd0b1f0eff
-  languageName: node
-  linkType: hard
-
 "ast-types@npm:^0.14.2":
   version: 0.14.2
   resolution: "ast-types@npm:0.14.2"


### PR DESCRIPTION
## Explanation

Currently, if a UI component uses optional chaining `?.` in it's component code or stoybook files it will break the args table that shows all of the proptypes that can be rendered from the README.mdx file. This was originally solved in https://github.com/MetaMask/metamask-extension/pull/16103 and was possibly removed when we upgraded to webpack 5 but unfortunately it is still an issue so I've added it back.

This PR adds a resolution for ast-types to `package.json` file.

* Fixes #17723
* Related: #12994, #16103

## Screenshots/Screencaps

### Before

<img width="1440" alt="Screenshot 2023-02-10 at 7 44 45 PM" src="https://user-images.githubusercontent.com/8112138/218237479-66e269e7-9634-42c8-8e93-bc4492705cae.png">
<img width="1440" alt="Screenshot 2023-02-10 at 7 45 15 PM" src="https://user-images.githubusercontent.com/8112138/218237480-c61e03dc-8c7a-43fd-a3c8-661efac94c53.png">


### After

<img width="1440" alt="Screenshot 2023-02-10 at 7 43 58 PM" src="https://user-images.githubusercontent.com/8112138/218237486-f8ddc863-8523-439d-aef6-d8fcee367f12.png">
<img width="1440" alt="Screenshot 2023-02-10 at 7 45 45 PM" src="https://user-images.githubusercontent.com/8112138/218237488-b1419ee3-c3e7-4bb1-a1a2-4e53540befd6.png">


## Manual Testing Steps

- Go to the latest build of storybook in this PR
- Search `UpdateNicknamePopover`
- Click on the Docs tab of the `UpdateNicknamePopover` story see the args table is working
- Do the same for `TextFieldBase`

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
