### PR TITLE
Part of 17670: Replace Typography with Text approve-content-card

### DIFF
--- a/ui/components/app/approve-content-card/approve-content-card.js
+++ b/ui/components/app/approve-content-card/approve-content-card.js
@@ -4,7 +4,7 @@ import classnames from 'classnames';
 import Box from '../../ui/box/box';
 import Button from '../../ui/button';
 import EditGasFeeButton from '../edit-gas-fee-button/edit-gas-fee-button';
-import Typography from '../../ui/typography/typography';
+import { Text } from '../../component-library';
 import {
   AlignItems,
   BLOCK_SIZES,
@@ -14,7 +14,7 @@ import {
   JustifyContent,
   TEXT_ALIGN,
   TextColor,
-  TypographyVariant,
+  TextVariant,
 } from '../../../helpers/constants/design-system';
 import { I18nContext } from '../../../contexts/i18n';
 import GasDetailsItem from '../gas-details-item/gas-details-item';
@@ -73,24 +73,19 @@ export default function ApproveContentCard({
                 marginLeft={4}
                 className="approve-content-card-container__card-header__title"
               >
-                <Typography
-                  variant={TypographyVariant.H6}
-                  fontWeight={FONT_WEIGHT.BOLD}
-                >
-                  {title}
-                </Typography>
+                <Text variant={TextVariant.bodySmBold}>{title}</Text>
               </Box>
             </>
           )}
           {showEdit && (!showAdvanceGasFeeOptions || !supportsEIP1559) && (
             <Box width={BLOCK_SIZES.ONE_SIXTH}>
               <Button type="link" onClick={() => onEditClick()}>
-                <Typography
-                  variant={TypographyVariant.H7}
+                <Text
+                  variant={TextVariant.bodySm}
                   color={TextColor.primaryDefault}
                 >
                   {t('edit')}
-                </Typography>
+                </Text>
               </Button>
             </Box>
           )}
@@ -132,14 +127,14 @@ export default function ApproveContentCard({
                     display={DISPLAY.FLEX}
                     justifyContent={JustifyContent.spaceBetween}
                   >
-                    <Typography
-                      variant={TypographyVariant.H6}
+                    <Text
+                      variant={TextVariant.bodySm}
                       fontWeight={FONT_WEIGHT.NORMAL}
                       color={TextColor.textMuted}
                     >
                       <span>{t('transactionDetailLayer2GasHeading')}</span>
                       {`${ethTransactionTotal} ${nativeCurrency}`}
-                    </Typography>
+                    </Text>
                   </Box>
                   <MultiLayerFeeMessage
                     transaction={fullTxData}
@@ -151,12 +146,12 @@ export default function ApproveContentCard({
               ) : (
                 <>
                   <Box>
-                    <Typography
-                      variant={TypographyVariant.H7}
+                    <Text
+                      variant={TextVariant.bodySm}
                       color={TextColor.textAlternative}
                     >
                       {t('feeAssociatedRequest')}
-                    </Typography>
+                    </Text>
                   </Box>
                   <Box
                     display={DISPLAY.FLEX}
@@ -166,8 +161,8 @@ export default function ApproveContentCard({
                   >
                     {useCurrencyRateCheck && (
                       <Box>
-                        <Typography
-                          variant={TypographyVariant.H4}
+                        <Text
+                          variant={TextVariant.headingSm}
                           fontWeight={FONT_WEIGHT.BOLD}
                           color={TextColor.TEXT_DEFAULT}
                         >
@@ -175,17 +170,17 @@ export default function ApproveContentCard({
                             fiatTransactionTotal,
                             currentCurrency,
                           )}
-                        </Typography>
+                        </Text>
                       </Box>
                     )}
                     <Box>
-                      <Typography
-                        variant={TypographyVariant.H6}
+                      <Text
+                        variant={TextVariant.bodySm}
                         fontWeight={FONT_WEIGHT.NORMAL}
                         color={TextColor.textMuted}
                       >
                         {`${ethTransactionTotal} ${nativeCurrency}`}
-                      </Typography>
+                      </Text>
                     </Box>
                   </Box>
                 </>
@@ -195,35 +190,35 @@ export default function ApproveContentCard({
         {renderDataContent && (
           <Box display={DISPLAY.FLEX} flexDirection={FLEX_DIRECTION.COLUMN}>
             <Box>
-              <Typography
-                variant={TypographyVariant.H7}
+              <Text
+                variant={TextVariant.bodySm}
                 color={TextColor.textAlternative}
               >
                 {isSetApproveForAll
                   ? t('functionSetApprovalForAll')
                   : t('functionApprove')}
-              </Typography>
+              </Text>
             </Box>
             {isSetApproveForAll && isApprovalOrRejection !== undefined ? (
               <Box>
-                <Typography
-                  variant={TypographyVariant.H7}
+                <Text
+                  variant={TextVariant.bodySm}
                   color={TextColor.textAlternative}
                 >
                   {`${t('parameters')}: ${isApprovalOrRejection}`}
-                </Typography>
+                </Text>
               </Box>
             ) : null}
             <Box
               marginRight={4}
               className="approve-content-card-container__data__data-block"
             >
-              <Typography
-                variant={TypographyVariant.H7}
+              <Text
+                variant={TextVariant.bodySm}
                 color={TextColor.textAlternative}
               >
                 {data}
-              </Typography>
+              </Text>
             </Box>
           </Box>
         )}

--- a/ui/components/app/approve-content-card/approve-content-card.js
+++ b/ui/components/app/approve-content-card/approve-content-card.js
@@ -73,7 +73,9 @@ export default function ApproveContentCard({
                 marginLeft={4}
                 className="approve-content-card-container__card-header__title"
               >
-                <Text variant={TextVariant.bodySmBold}>{title}</Text>
+                <Text variant={TextVariant.bodySmBold} as="h6">
+                  {title}
+                </Text>
               </Box>
             </>
           )}
@@ -83,6 +85,7 @@ export default function ApproveContentCard({
                 <Text
                   variant={TextVariant.bodySm}
                   color={TextColor.primaryDefault}
+                  as="h6"
                 >
                   {t('edit')}
                 </Text>
@@ -131,6 +134,7 @@ export default function ApproveContentCard({
                       variant={TextVariant.bodySm}
                       fontWeight={FONT_WEIGHT.NORMAL}
                       color={TextColor.textMuted}
+                      as="h6"
                     >
                       <span>{t('transactionDetailLayer2GasHeading')}</span>
                       {`${ethTransactionTotal} ${nativeCurrency}`}
@@ -149,6 +153,7 @@ export default function ApproveContentCard({
                     <Text
                       variant={TextVariant.bodySm}
                       color={TextColor.textAlternative}
+                      as="h6"
                     >
                       {t('feeAssociatedRequest')}
                     </Text>
@@ -165,6 +170,7 @@ export default function ApproveContentCard({
                           variant={TextVariant.headingSm}
                           fontWeight={FONT_WEIGHT.BOLD}
                           color={TextColor.TEXT_DEFAULT}
+                          as="h6"
                         >
                           {formatCurrency(
                             fiatTransactionTotal,
@@ -178,6 +184,7 @@ export default function ApproveContentCard({
                         variant={TextVariant.bodySm}
                         fontWeight={FONT_WEIGHT.NORMAL}
                         color={TextColor.textMuted}
+                        as="h6"
                       >
                         {`${ethTransactionTotal} ${nativeCurrency}`}
                       </Text>
@@ -193,6 +200,7 @@ export default function ApproveContentCard({
               <Text
                 variant={TextVariant.bodySm}
                 color={TextColor.textAlternative}
+                as="h6"
               >
                 {isSetApproveForAll
                   ? t('functionSetApprovalForAll')
@@ -204,6 +212,7 @@ export default function ApproveContentCard({
                 <Text
                   variant={TextVariant.bodySm}
                   color={TextColor.textAlternative}
+                  as="h6"
                 >
                   {`${t('parameters')}: ${isApprovalOrRejection}`}
                 </Text>
@@ -216,6 +225,7 @@ export default function ApproveContentCard({
               <Text
                 variant={TextVariant.bodySm}
                 color={TextColor.textAlternative}
+                as="h6"
               >
                 {data}
               </Text>

--- a/ui/components/app/approve-content-card/approve-content-card.js
+++ b/ui/components/app/approve-content-card/approve-content-card.js
@@ -170,7 +170,7 @@ export default function ApproveContentCard({
                           variant={TextVariant.headingSm}
                           fontWeight={FONT_WEIGHT.BOLD}
                           color={TextColor.TEXT_DEFAULT}
-                          as="h6"
+                          as="h4"
                         >
                           {formatCurrency(
                             fiatTransactionTotal,


### PR DESCRIPTION
## Explanation

Updating Typography to Text `approve-content-card.js`

Part of: #17670

## Screenshots/Screencaps

### Before

<img width="721" alt="Screenshot 2023-02-14 at 9 46 16 AM" src="https://user-images.githubusercontent.com/8112138/218816751-4b937a98-5361-432c-9302-4a0698b48db2.png">


### After

<img width="1440" alt="Screenshot 2023-02-14 at 9 45 52 AM" src="https://user-images.githubusercontent.com/8112138/218816788-ffce12d0-80fa-424f-8192-9a5018d38dd7.png">


## Manual Testing Steps

- Go to the latest build of storybook on this PR
- Search `ApproveContentCard` in the side panel
- Check `ApproveContentCard` story agains develop storybook https://metamask.github.io/metamask-storybook/?path=/story/components-app-approvecontentcard--default-story

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
