### PR TITLE
disable ff

### DIFF
--- a/.github/workflows/fitness-functions.yml
+++ b/.github/workflows/fitness-functions.yml
@@ -22,7 +22,7 @@ jobs:
           HEAD_REF: ${{ github.event.pull_request.head.ref }}
           BASE_REF: ${{ github.event.pull_request.base.ref }}
         run: |
-          git fetch origin $HEAD_REF
-          git fetch origin $BASE_REF
-          git diff origin/$BASE_REF origin/$HEAD_REF -- . ':(exclude)development/fitness-functions/*' > diff
-          npm run fitness-functions -- "ci" "./diff"
+          # git fetch origin $HEAD_REF
+          # git fetch origin $BASE_REF
+          # git diff origin/$BASE_REF origin/$HEAD_REF -- . ':(exclude)development/fitness-functions/*' > diff
+          # npm run fitness-functions -- "ci" "./diff"


### PR DESCRIPTION
## Explanation

Disabling the fitness functions for the time being because the diffs are not generated correctly on PRs opened from forks.

The head branch is not found in the origin of the extension because it's on the fork origin [see example job failure](https://github.com/MetaMask/metamask-extension/actions/runs/4159407587/jobs/7195431356) from [this PR](
https://github.com/MetaMask/metamask-extension/pull/17677).