### PR TITLE
Do not display experimental settings tab when there are no settings to show

### DIFF
--- a/ui/pages/settings/settings.component.js
+++ b/ui/pages/settings/settings.component.js
@@ -78,6 +78,9 @@ class SettingsPage extends PureComponent {
     searchText: '',
   };
 
+  shouldRenderExperimentalTab =
+    process.env.TRANSACTION_SECURITY_PROVIDER || process.env.NFTS_V1;
+
   componentDidMount() {
     this.handleConversionDate();
   }
@@ -260,63 +263,65 @@ class SettingsPage extends PureComponent {
   renderTabs() {
     const { history, currentPath } = this.props;
     const { t } = this.context;
+    const tabs = [
+      {
+        content: t('general'),
+        icon: <i className="fa fa-cog" />,
+        key: GENERAL_ROUTE,
+      },
+      {
+        content: t('advanced'),
+        icon: <i className="fas fa-sliders-h" />,
+        key: ADVANCED_ROUTE,
+      },
+      {
+        content: t('contacts'),
+        icon: <Icon name={ICON_NAMES.BOOK} />,
+        key: CONTACT_LIST_ROUTE,
+      },
+      ///: BEGIN:ONLY_INCLUDE_IN(flask)
+      {
+        content: t('snaps'),
+        icon: (
+          <i className="fa fa-flask" title={t('snapsSettingsDescription')} />
+        ),
+        key: SNAPS_LIST_ROUTE,
+      },
+      ///: END:ONLY_INCLUDE_IN
+      {
+        content: t('securityAndPrivacy'),
+        icon: <i className="fa fa-lock" />,
+        key: SECURITY_ROUTE,
+      },
+      {
+        content: t('alerts'),
+        icon: <Icon name={ICON_NAMES.NOTIFICATION} />,
+        key: ALERTS_ROUTE,
+      },
+      {
+        content: t('networks'),
+        icon: <i className="fa fa-plug" />,
+        key: NETWORKS_ROUTE,
+      },
+    ];
+
+    if (this.shouldRenderExperimentalTab) {
+      tabs.push({
+        content: t('experimental'),
+        icon: <i className="fa fa-flask" />,
+        key: EXPERIMENTAL_ROUTE,
+      });
+    }
+
+    tabs.push({
+      content: t('about'),
+      icon: <i className="fa fa-info-circle" />,
+      key: ABOUT_US_ROUTE,
+    });
 
     return (
       <TabBar
-        tabs={[
-          {
-            content: t('general'),
-            icon: <i className="fa fa-cog" />,
-            key: GENERAL_ROUTE,
-          },
-          {
-            content: t('advanced'),
-            icon: <i className="fas fa-sliders-h" />,
-            key: ADVANCED_ROUTE,
-          },
-          {
-            content: t('contacts'),
-            icon: <Icon name={ICON_NAMES.BOOK} />,
-            key: CONTACT_LIST_ROUTE,
-          },
-          ///: BEGIN:ONLY_INCLUDE_IN(flask)
-          {
-            content: t('snaps'),
-            icon: (
-              <i
-                className="fa fa-flask"
-                title={t('snapsSettingsDescription')}
-              />
-            ),
-            key: SNAPS_LIST_ROUTE,
-          },
-          ///: END:ONLY_INCLUDE_IN
-          {
-            content: t('securityAndPrivacy'),
-            icon: <i className="fa fa-lock" />,
-            key: SECURITY_ROUTE,
-          },
-          {
-            content: t('alerts'),
-            icon: <Icon name={ICON_NAMES.NOTIFICATION} />,
-            key: ALERTS_ROUTE,
-          },
-          {
-            content: t('networks'),
-            icon: <i className="fa fa-plug" />,
-            key: NETWORKS_ROUTE,
-          },
-          {
-            content: t('experimental'),
-            icon: <i className="fa fa-flask" />,
-            key: EXPERIMENTAL_ROUTE,
-          },
-          {
-            content: t('about'),
-            icon: <i className="fa fa-info-circle" />,
-            key: ABOUT_US_ROUTE,
-          },
-        ]}
+        tabs={tabs}
         isActive={(key) => {
           if (key === GENERAL_ROUTE && currentPath === SETTINGS_ROUTE) {
             return true;
@@ -360,7 +365,9 @@ class SettingsPage extends PureComponent {
           render={() => <AddNetwork />}
         />
         <Route exact path={SECURITY_ROUTE} component={SecurityTab} />
-        <Route exact path={EXPERIMENTAL_ROUTE} component={ExperimentalTab} />
+        {this.shouldRenderExperimentalTab ? (
+          <Route exact path={EXPERIMENTAL_ROUTE} component={ExperimentalTab} />
+        ) : null}
         <Route exact path={CONTACT_LIST_ROUTE} component={ContactListTab} />
         <Route exact path={CONTACT_ADD_ROUTE} component={ContactListTab} />
         <Route


### PR DESCRIPTION
Fixes: https://github.com/MetaMask/metamask-extension/issues/17714

## Screenshots/Screencaps
<img width="501" alt="Screen Shot 2023-02-15 at 2 19 16 AM" src="https://user-images.githubusercontent.com/8732757/218989648-35369242-4823-47e5-a4ea-1419fa43bd4b.png">

<img width="509" alt="Screen Shot 2023-02-15 at 2 22 05 AM" src="https://user-images.githubusercontent.com/8732757/218989655-45e31658-0116-4609-b6aa-53a50d6157c4.png">


## Manual Testing Steps
1. Disable both the `NFTS_V1` and the `TRANSACTION_SECURITY_PROVIDER` feature flags
2. Ensure the experimental tab is not visible or accessible
3. Repeat steps 1 by switching 1 or both of them on and ensuring its accessibility

## Pre-merge author checklist

- [ ] I've clearly explained:
  - [ ] What problem this PR is solving
  - [ ] How this problem was solved
  - [ ] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
