### PR TITLE
UX: Icons: Fix alignment of settings icons in full screen

### DIFF
--- a/ui/components/app/tab-bar/index.scss
+++ b/ui/components/app/tab-bar/index.scss
@@ -68,10 +68,6 @@
         margin-inline-end: 16px;
         flex: 0 0 18px;
         color: var(--color-icon-alternative);
-
-        @include screen-sm-min {
-          flex: 0 0 14px;
-        }
       }
     }
 


### PR DESCRIPTION
## Explanation
 I noticed the icons for the settings sidebar look weirdly aligned in full screen mode.  This fixes the issue.

## Screenshots/Screencaps

https://user-images.githubusercontent.com/46655/219446772-9f0c3294-efa9-475a-90b9-d212f67bd093.mp4


## Manual Testing Steps

1.  Open MM in full screen
2. View Settings page
3. See all icons and text aligned.

## Pre-merge author checklist

- [ ] I've clearly explained:
  - [ ] What problem this PR is solving
  - [ ] How this problem was solved
  - [ ] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
