### PR TITLE
Cleanup: clearTimeout on useEffect for gas estimation and prevent state update on unmounted ConfirmTransactionBase

### DIFF
--- a/ui/hooks/useShouldAnimateGasEstimations.js
+++ b/ui/hooks/useShouldAnimateGasEstimations.js
@@ -44,13 +44,18 @@ export function useShouldAnimateGasEstimations() {
   }, [dispatch, isGasLoadingAnimationActive, showLoadingAnimation]);
 
   useEffect(() => {
-    if (
-      isGasLoadingAnimationActive === true &&
-      showLoadingAnimation === false
-    ) {
-      setTimeout(() => {
+    let timer;
+
+    if (isGasLoadingAnimationActive && !showLoadingAnimation) {
+      timer = setTimeout(() => {
         dispatch(toggleGasLoadingAnimation(false));
       }, 2000);
     }
+
+    return () => {
+      if (timer) {
+        clearTimeout(timer);
+      }
+    };
   }, [dispatch, isGasLoadingAnimationActive, showLoadingAnimation]);
 }

--- a/ui/pages/confirm-transaction-base/confirm-transaction-base.component.js
+++ b/ui/pages/confirm-transaction-base/confirm-transaction-base.component.js
@@ -866,6 +866,10 @@ export default class ConfirmTransactionBase extends Component {
         sendTransaction(txData)
           .then(() => {
             clearConfirmTransaction();
+            if (!this._isMounted) {
+              return;
+            }
+
             this.setState(
               {
                 submitting: false,
@@ -877,6 +881,10 @@ export default class ConfirmTransactionBase extends Component {
             );
           })
           .catch((error) => {
+            if (!this._isMounted) {
+              return;
+            }
+
             this.setState({
               submitting: false,
               submitError: error.message,


### PR DESCRIPTION
## Explanation

- Clears timeout in gas estimation useEffect hook to prevent memory leak
- Fix ConfirmTransactionBase error message: "Can't perform a React state updated on an unmounted component" 

## Screenshots/Screencaps

<!-- If you're making a change to the UI, make sure to capture a screenshot or a short video showing off your work! -->

### Before

<img width="1680" alt="Screen Shot 2023-02-17 at 2 48 22 PM" src="https://user-images.githubusercontent.com/20778143/219652764-daf4449d-9ea3-4a9f-b7a7-c4bcb15e15ee.png">

warnings still exist after this PR, it should be less frequent.
<img width="1680" alt="Screen Shot 2023-02-17 at 4 31 28 PM" src="https://user-images.githubusercontent.com/20778143/219652801-37d224c5-e6d3-430a-a330-0d8ab1c6a673.png">



### After

<!-- How does it look now? Drag your file(s) below this line: -->

## Manual Testing Steps
- Create transactions
- Interact with transactions by rejecting or confirming
- Observe console

<!--
How should reviewers and QA manually test your changes? For instance:

- Go to this screen
- Do this
- Then do this
-->

## Pre-merge author checklist

- [ ] I've clearly explained:
  - [ ] What problem this PR is solving
  - [ ] How this problem was solved
  - [ ] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
