### PR TITLE
UX Icon: Replace fa-user

### DIFF
--- a/ui/components/component-library/avatar-base/avatar-base.stories.js
+++ b/ui/components/component-library/avatar-base/avatar-base.stories.js
@@ -123,7 +123,7 @@ export const Children = (args) => (
       backgroundColor={BackgroundColor.infoMuted}
       borderColor={BorderColor.infoMuted}
     >
-      <Icon name={ICON_NAMES.USER} color={Color.iconDefault} />
+      <Icon name={ICON_NAMES.USER} color={Color.infoDefault} />
     </AvatarBase>
   </Box>
 );

--- a/ui/components/component-library/avatar-base/avatar-base.stories.js
+++ b/ui/components/component-library/avatar-base/avatar-base.stories.js
@@ -5,10 +5,12 @@ import {
   TextColor,
   BackgroundColor,
   BorderColor,
+  Color,
 } from '../../../helpers/constants/design-system';
 
 import Box from '../../ui/box/box';
 
+import { Icon, ICON_NAMES } from '../icon';
 import README from './README.mdx';
 import { AvatarBase } from './avatar-base';
 import { AVATAR_BASE_SIZES } from './avatar-base.constants';
@@ -121,10 +123,7 @@ export const Children = (args) => (
       backgroundColor={BackgroundColor.infoMuted}
       borderColor={BorderColor.infoMuted}
     >
-      <i
-        className="fa fa-user"
-        style={{ color: 'var(--color-info-default)' }}
-      />
+      <Icon name={ICON_NAMES.USER} color={Color.iconDefault} />
     </AvatarBase>
   </Box>
 );


### PR DESCRIPTION
## Explanation

Replaces instances of `fa-user` with USER icons. 

## Screenshots/Screencaps

### Before
<img width="485" alt="b" src="https://user-images.githubusercontent.com/39872794/219692784-a8effcd9-2851-445e-a553-817a7639beee.png">


### After

<img width="538" alt="hjh" src="https://user-images.githubusercontent.com/39872794/219692769-70d95220-cd8a-4a06-b79f-9b49931ed558.png">

## Pre-merge author checklist

- [ ] I've clearly explained:
  - [ ] What problem this PR is solving
  - [ ] How this problem was solved
  - [ ] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in the browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
