### PR TITLE
Fix currency symbol in insufficient balance warning

### DIFF
--- a/ui/pages/send/gas-display/gas-display.js
+++ b/ui/pages/send/gas-display/gas-display.js
@@ -39,6 +39,7 @@ import {
 
 import { INSUFFICIENT_TOKENS_ERROR } from '../send.constants';
 import { getCurrentDraftTransaction } from '../../../ducks/send';
+import { getNativeCurrency } from '../../../ducks/metamask/metamask';
 import { showModal } from '../../../store/actions';
 import {
   addHexes,
@@ -61,7 +62,7 @@ export default function GasDisplay({ gasError }) {
   const { showFiatInTestnets, useNativeCurrencyAsPrimaryCurrency } =
     useSelector(getPreferences);
   const { provider, unapprovedTxs } = useSelector((state) => state.metamask);
-  const nativeCurrency = provider.ticker;
+  const nativeCurrency = useSelector(getNativeCurrency);
   const { chainId } = provider;
   const networkName = NETWORK_TO_NAME_MAP[chainId];
   const isInsufficientTokenError =
@@ -359,12 +360,9 @@ export default function GasDisplay({ gasError }) {
                 ) : (
                   <Typography variant={TypographyVariant.H7} align="left">
                     {t('insufficientCurrencyBuyOrReceive', [
-                      draftTransaction.asset.details?.symbol ?? nativeCurrency,
+                      nativeCurrency,
                       currentNetworkName,
-                      `${t('buyAsset', [
-                        draftTransaction.asset.details?.symbol ??
-                          nativeCurrency,
-                      ])}`,
+                      `${t('buyAsset', [nativeCurrency])}`,
                       <Button
                         type="inline"
                         className="gas-display__link"


### PR DESCRIPTION
Fixes: https://github.com/MetaMask/metamask-extension/issues/17371

## Explanation
Introduced in https://github.com/MetaMask/metamask-extension/pull/17450 - I do not believe it is the case we always want to use `provider.ticker`. However, changing to use `getNativeCurrency` for `nativeCurrency` will do so when appropriately (when `useCurrencyRateCheck` is false)

## Screenshots/Screencaps
<img width="557" alt="Screen Shot 2023-02-19 at 9 15 57 PM" src="https://user-images.githubusercontent.com/8732757/220011818-46e1752d-5abe-4459-ac29-5b8341037a85.png">

## Manual Testing Steps
1. Select an Account with no ETH and with a Token 
2. Click the Token
3. Click Send
4. Add recipient -- confirm warning shows the native network currency in its copy

## Pre-merge author checklist

- [X] I've clearly explained:
  - [X] What problem this PR is solving
  - [X] How this problem was solved
  - [X] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
