### PR TITLE
always process e2e test results

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -709,6 +709,7 @@ jobs:
             if [ "$(ls -A test/test-results/e2e)" ]; then
               yarn test:e2e:report
             fi
+          when: always
       - store_artifacts:
           path: test-artifacts
           destination: test-artifacts
@@ -773,6 +774,7 @@ jobs:
             if [ "$(ls -A test/test-results/e2e)" ]; then
               yarn test:e2e:report
             fi
+          when: always
       - store_artifacts:
           path: test-artifacts
           destination: test-artifacts
@@ -809,6 +811,7 @@ jobs:
             if [ "$(ls -A test/test-results/e2e)" ]; then
               yarn test:e2e:report
             fi
+          when: always
       - store_artifacts:
           path: test-artifacts
           destination: test-artifacts
@@ -845,6 +848,7 @@ jobs:
             if [ "$(ls -A test/test-results/e2e)" ]; then
               yarn test:e2e:report
             fi
+          when: always
       - store_artifacts:
           path: test-artifacts
           destination: test-artifacts
@@ -881,6 +885,7 @@ jobs:
             if [ "$(ls -A test/test-results/e2e)" ]; then
               yarn test:e2e:report
             fi
+          when: always
       - store_artifacts:
           path: test-artifacts
           destination: test-artifacts
@@ -917,6 +922,7 @@ jobs:
             if [ "$(ls -A test/test-results/e2e)" ]; then
               yarn test:e2e:report
             fi
+          when: always
       - store_artifacts:
           path: test-artifacts
           destination: test-artifacts


### PR DESCRIPTION
## Explanation

<!--
Thanks for the pull request. Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues, Slack conversations, Zendesk issues, user stories, etc. reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

Fixes #17845

This change ensures that the e2e test report is always processed, so the results can be uploaded to Circle CI on failed e2e test runs. To provide comprehensive insights on failed and flakey tests, not just slow tests.
 
[The when Attribute](https://circleci.com/docs/configuration-reference/#the-when-attribute)

> A value of always means that the step will run regardless of the exit status of previous steps. This is useful if you have a task that you want to run regardless of whether the previous steps are successful or not. For example, you might have a job step that needs to upload logs or code-coverage data somewhere. 

## Screenshots/Screencaps

<!-- If you're making a change to the UI, make sure to capture a screenshot or a short video showing off your work! -->

### Before (Results from a random branch)

<!-- How did the UI you changed look before your changes? Drag your file(s) below this line: -->

The results are not processed on a failed test run
https://app.circleci.com/pipelines/github/MetaMask/metamask-extension/37439/workflows/d46bd77d-867d-490f-bd71-f9df6199f878/jobs/1010658
```
Unable to save test results from /home/circleci/project/test/test-results/e2e.xml
Error error accessing path "/home/circleci/project/test/test-results/e2e.xml": stat /home/circleci/project/test/test-results/e2e.xml: no such file or directory
Found no test results, skipping
```

### After (Results from this branch, prior to rerunning test-e2e-chrome )

<!-- How does it look now? Drag your file(s) below this line: -->

The results are processed on a failed test run
https://app.circleci.com/pipelines/github/MetaMask/metamask-extension/37562/workflows/642c1a38-20bd-408f-8a98-975b651c243a/jobs/1014850/parallel-runs/1
```
Archiving the following test results
  * /home/circleci/project/test/test-results/e2e.xml

Total size uploaded: 941 B
```

## Manual Testing Steps

<!--
How should reviewers and QA manually test your changes? For instance:

- Go to this screen
- Do this
- Then do this
-->

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
