### PR TITLE
fix(17855): persist popup when sw is restarted

### DIFF
--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -52,6 +52,7 @@ import getFirstPreferredLangCode from './lib/get-first-preferred-lang-code';
 import getObjStructure from './lib/getObjStructure';
 import setupEnsIpfsResolver from './lib/ens-ipfs/setup';
 import { deferredPromise, getPlatform } from './lib/util';
+
 /* eslint-enable import/first */
 
 const { sentry } = global;
@@ -68,7 +69,6 @@ const metamaskBlockedPorts = ['trezor-connect'];
 log.setDefaultLevel(process.env.METAMASK_DEBUG ? 'debug' : 'info');
 
 const platform = new ExtensionPlatform();
-
 const notificationManager = new NotificationManager();
 global.METAMASK_NOTIFIER = notificationManager;
 
@@ -789,7 +789,12 @@ async function triggerUi() {
   ) {
     uiIsTriggering = true;
     try {
-      await notificationManager.showPopup();
+      const currentPopupId = controller.appStateController.getCurrentPopupId();
+      await notificationManager.showPopup(
+        (newPopupId) =>
+          controller.appStateController.setCurrentPopupId(newPopupId),
+        currentPopupId,
+      );
     } finally {
       uiIsTriggering = false;
     }

--- a/app/scripts/controllers/app-state.js
+++ b/app/scripts/controllers/app-state.js
@@ -43,6 +43,7 @@ export default class AppStateController extends EventEmitter {
       showPortfolioTooltip: true,
       showBetaHeader: isBeta(),
       trezorModel: null,
+      currentPopupId: undefined,
       ...initState,
       qrHardware: {},
       nftsDropdownState: {},
@@ -352,5 +353,23 @@ export default class AppStateController extends EventEmitter {
     usedNetworks[chainId] = true;
 
     this.store.updateState({ usedNetworks });
+  }
+
+  /**
+   * A setter for the currentPopupId which indicates the id of popup window that's currently active
+   *
+   * @param currentPopupId
+   */
+  setCurrentPopupId(currentPopupId) {
+    this.store.updateState({
+      currentPopupId,
+    });
+  }
+
+  /**
+   * A getter to retrieve currentPopupId saved in the appState
+   */
+  getCurrentPopupId() {
+    return this.store.getState().currentPopupId;
   }
 }

--- a/app/scripts/lib/notification-manager.js
+++ b/app/scripts/lib/notification-manager.js
@@ -32,15 +32,19 @@ export default class NotificationManager extends EventEmitter {
    * Either brings an existing MetaMask notification window into focus, or creates a new notification window. New
    * notification windows are given a 'popup' type.
    *
+   * @param {Function} setCurrentPopupId - setter of current popup id from appStateController
+   * @param {number} currentPopupId - id of current opened metamask popup window
    */
-  async showPopup() {
-    const popup = await this._getPopup();
-
+  async showPopup(setCurrentPopupId, currentPopupId) {
+    this._popupId = currentPopupId;
+    this._setCurrentPopupId = setCurrentPopupId;
+    const popup = await this._getPopup(currentPopupId);
     // Bring focus to chrome popup
     if (popup) {
       // bring focus to existing chrome popup
       await this.platform.focusWindow(popup.id);
     } else {
+      // create new notification popup
       let left = 0;
       let top = 0;
       try {
@@ -57,7 +61,6 @@ export default class NotificationManager extends EventEmitter {
         left = Math.max(screenX + (outerWidth - NOTIFICATION_WIDTH), 0);
       }
 
-      // create new notification popup
       const popupWindow = await this.platform.openWindow({
         url: 'notification.html',
         type: 'popup',
@@ -71,13 +74,16 @@ export default class NotificationManager extends EventEmitter {
       if (popupWindow.left !== left && popupWindow.state !== 'fullscreen') {
         await this.platform.updateWindowPosition(popupWindow.id, left, top);
       }
+      // pass new created popup window id to appController setter
+      // and store the id to private variable this._popupId for future access
+      this._setCurrentPopupId(popupWindow.id);
       this._popupId = popupWindow.id;
     }
   }
 
   _onWindowClosed(windowId) {
     if (windowId === this._popupId) {
-      this._popupId = undefined;
+      this._setCurrentPopupId(undefined);
       this.emit(NOTIFICATION_MANAGER_EVENTS.POPUP_CLOSED, {
         automaticallyClosed: this._popupAutomaticallyClosed,
       });

--- a/app/scripts/lib/notification-manager.js
+++ b/app/scripts/lib/notification-manager.js
@@ -84,6 +84,7 @@ export default class NotificationManager extends EventEmitter {
   _onWindowClosed(windowId) {
     if (windowId === this._popupId) {
       this._setCurrentPopupId(undefined);
+      this._popupId = undefined;
       this.emit(NOTIFICATION_MANAGER_EVENTS.POPUP_CLOSED, {
         automaticallyClosed: this._popupAutomaticallyClosed,
       });

--- a/app/scripts/lib/notification-manager.test.ts
+++ b/app/scripts/lib/notification-manager.test.ts
@@ -1,0 +1,71 @@
+import browser from 'webextension-polyfill';
+import NotificationManager from './notification-manager';
+
+function generateMockWindow(overrides?: object) {
+  return {
+    alwaysOnTop: false,
+    focused: true,
+    height: 620,
+    width: 360,
+    id: 1312883868,
+    incognito: false,
+    left: 1326,
+    state: 'normal',
+    tabs: [
+      {
+        active: true,
+        audible: false,
+        autoDiscardable: true,
+        discarded: false,
+        groupId: -1,
+      },
+    ],
+    top: 25,
+    type: 'popup',
+    ...overrides,
+  };
+}
+
+jest.mock('webextension-polyfill', () => {
+  return {
+    windows: {
+      onRemoved: {
+        addListener: jest.fn(),
+      },
+      getAll: jest.fn(),
+      create: jest.fn(),
+      update: jest.fn(),
+    },
+  };
+});
+
+describe('Notification Manager', () => {
+  let notificationManager: NotificationManager,
+    setCurrentPopupIdSpy: (a: number) => void,
+    focusWindowSpy: () => void,
+    currentPopupId: number;
+
+  beforeEach(() => {
+    notificationManager = new NotificationManager();
+  });
+
+  it('should not create a new popup window if there is one', async () => {
+    focusWindowSpy = jest.fn();
+    browser.windows.getAll.mockReturnValue([generateMockWindow()]);
+    browser.windows.update.mockImplementation(focusWindowSpy);
+    currentPopupId = 1312883868;
+    await notificationManager.showPopup(setCurrentPopupIdSpy, currentPopupId);
+    expect(focusWindowSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('should create a new popup window if there is no existing one', async () => {
+    const newPopupWindow = generateMockWindow();
+    setCurrentPopupIdSpy = jest.fn();
+    browser.windows.getAll.mockReturnValue([]);
+    browser.windows.create.mockReturnValue(newPopupWindow);
+    currentPopupId = undefined;
+    await notificationManager.showPopup(setCurrentPopupIdSpy, currentPopupId);
+    expect(setCurrentPopupIdSpy).toHaveBeenCalledTimes(1);
+    expect(setCurrentPopupIdSpy).toHaveBeenCalledWith(newPopupWindow.id);
+  });
+});

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -1906,6 +1906,7 @@ export default class MetamaskController extends EventEmitter {
         appStateController.updateNftDropDownState.bind(appStateController),
       setFirstTimeUsedNetwork:
         appStateController.setFirstTimeUsedNetwork.bind(appStateController),
+
       // EnsController
       tryReverseResolveAddress:
         ensController.reverseResolveAddress.bind(ensController),
@@ -3410,7 +3411,7 @@ export default class MetamaskController extends EventEmitter {
    * @param {object} [req] - The original request, containing the origin.
    * @param version
    */
-  newUnsignedTypedMessage(msgParams, req, version) {
+  async newUnsignedTypedMessage(msgParams, req, version) {
     const promise = this.typedMessageManager.addUnapprovedMessageAsync(
       msgParams,
       req,

--- a/jest.config.js
+++ b/jest.config.js
@@ -41,6 +41,7 @@ module.exports = {
     '<rootDir>/app/scripts/controllers/permissions/**/*.test.js',
     '<rootDir>/app/scripts/flask/**/*.test.js',
     '<rootDir>/app/scripts/lib/**/*.test.js',
+    '<rootDir>/app/scripts/lib/**/*.test.ts',
     '<rootDir>/app/scripts/lib/createRPCMethodTrackingMiddleware.test.js',
     '<rootDir>/app/scripts/migrations/*.test.js',
     '<rootDir>/app/scripts/platforms/*.test.js',


### PR DESCRIPTION
## Explanation

https://github.com/MetaMask/metamask-extension/issues/17386

The cause of problem is straightforward. When we restart sw, we have the screen reloaded, and the local variable `this._popupId` will be erased. It means even though we have a persist window open, inside `NotificationManager`, we will not have the record of that window. Hence `NotificationManager` will open a new window for us.

The fix of this issue is to store the windowId in high level appState, which is persistent until the window is closed. Therefore when `triggerUi` is called by different transactions, we will request the stored `currentPopupId` and inform `NotificationManager` of such id to reuse the previous window. 

PS: e2e will be conducted in a separate ticket in https://github.com/MetaMask/metamask-extension/issues/17386


https://user-images.githubusercontent.com/12678455/220637824-eeff3d32-87c4-49d2-9a06-f889e806c549.mov


<!--
Thanks for the pull request. Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues, Slack conversations, Zendesk issues, user stories, etc. reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

## Screenshots/Screencaps

<!-- If you're making a change to the UI, make sure to capture a screenshot or a short video showing off your work! -->

### Before

<!-- How did the UI you changed look before your changes? Drag your file(s) below this line: -->

### After

<!-- How does it look now? Drag your file(s) below this line: -->

## Manual Testing Steps

<!--
How should reviewers and QA manually test your changes? For instance:

- Go to this screen
- Do this
- Then do this
-->

- run mv3 locally
- connect test-dapp: https://metamask.github.io/test-dapp/
- click "sign" in "Sign Typed Data V4"
- terminate service worker
- before: 2 screens overlay
- after: 1 screen is persisted when sw is restarted and content is reachable

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
