### PR TITLE
Display the address icon for the contract requesting spending cap instead of the dapp/url icon

### DIFF
--- a/ui/components/app/modals/contract-details-modal/contract-details-modal.js
+++ b/ui/components/app/modals/contract-details-modal/contract-details-modal.js
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { getAccountLink } from '@metamask/etherscan-link';
 import { useSelector } from 'react-redux';
-import classnames from 'classnames';
 import Box from '../../../ui/box';
 import Button from '../../../ui/button/button.component';
 import Tooltip from '../../../ui/tooltip/tooltip';
@@ -23,7 +22,6 @@ import {
   AlignItems,
 } from '../../../../helpers/constants/design-system';
 import { useCopyToClipboard } from '../../../../hooks/useCopyToClipboard';
-import UrlIcon from '../../../ui/url-icon/url-icon';
 import { getAddressBookEntry } from '../../../../selectors';
 import { TokenStandard } from '../../../../../shared/constants/transaction';
 import NftCollectionImage from '../../../ui/nft-collection-image/nft-collection-image';
@@ -36,8 +34,6 @@ export default function ContractDetailsModal({
   toAddress,
   chainId,
   rpcPrefs,
-  origin,
-  siteImage,
   tokenId,
   assetName,
   assetStandard,
@@ -207,30 +203,11 @@ export default function ContractDetailsModal({
           borderColor={BorderColor.borderDefault}
           className="contract-details-modal__content__contract"
         >
-          {nft ? (
-            <Identicon
-              className="contract-details-modal__content__contract__identicon"
-              diameter={24}
-              address={toAddress}
-            />
-          ) : (
-            <UrlIcon
-              className={classnames({
-                'contract-details-modal__content__contract__identicon-for-unknown-contact':
-                  addressBookEntry?.data?.name === undefined,
-                'contract-details-modal__content__contract__identicon':
-                  addressBookEntry?.data?.name !== undefined,
-              })}
-              fallbackClassName={classnames({
-                'contract-details-modal__content__contract__identicon-for-unknown-contact':
-                  addressBookEntry?.data?.name === undefined,
-                'contract-details-modal__content__contract__identicon':
-                  addressBookEntry?.data?.name !== undefined,
-              })}
-              name={origin}
-              url={siteImage}
-            />
-          )}
+          <Identicon
+            className="contract-details-modal__content__contract__identicon"
+            diameter={24}
+            address={toAddress}
+          />
           <Box data-testid="recipient">
             <Typography
               fontWeight={FONT_WEIGHT.BOLD}
@@ -341,14 +318,6 @@ ContractDetailsModal.propTypes = {
    * RPC prefs of the current network
    */
   rpcPrefs: PropTypes.object,
-  /**
-   * Dapp URL
-   */
-  origin: PropTypes.string,
-  /**
-   * Dapp image
-   */
-  siteImage: PropTypes.string,
   /**
    * The token id of the NFT
    */

--- a/ui/components/app/modals/contract-details-modal/contract-details-modal.stories.js
+++ b/ui/components/app/modals/contract-details-modal/contract-details-modal.stories.js
@@ -33,16 +33,6 @@ export default {
         type: 'object',
       },
     },
-    origin: {
-      control: {
-        type: 'text',
-      },
-    },
-    siteImage: {
-      control: {
-        type: 'text',
-      },
-    },
   },
   args: {
     tokenName: 'DAI',
@@ -50,8 +40,6 @@ export default {
     toAddress: '0x9bc5baf874d2da8d216ae9f137804184ee5afef4',
     chainId: '0x3',
     rpcPrefs: {},
-    origin: 'https://metamask.github.io',
-    siteImage: 'https://metamask.github.io/test-dapp/metamask-fox.svg',
   },
 };
 

--- a/ui/components/app/modals/contract-details-modal/index.scss
+++ b/ui/components/app/modals/contract-details-modal/index.scss
@@ -11,10 +11,6 @@
         box-shadow: none;
         background: none;
       }
-
-      &__identicon-for-unknown-contact {
-        margin: 16px;
-      }
     }
   }
 }

--- a/ui/components/app/signature-request/signature-request.component.js
+++ b/ui/components/app/signature-request/signature-request.component.js
@@ -60,10 +60,6 @@ export default class SignatureRequest extends PureComponent {
      * RPC prefs of the current network
      */
     rpcPrefs: PropTypes.object,
-    /**
-     * Dapp image
-     */
-    siteImage: PropTypes.string,
     conversionRate: PropTypes.number,
     nativeCurrency: PropTypes.string,
     provider: PropTypes.object,
@@ -155,7 +151,6 @@ export default class SignatureRequest extends PureComponent {
       hardwareWalletRequiresConnection,
       chainId,
       rpcPrefs,
-      siteImage,
       txData,
       subjectMetadata,
       conversionRate,
@@ -298,8 +293,6 @@ export default class SignatureRequest extends PureComponent {
             toAddress={verifyingContract}
             chainId={chainId}
             rpcPrefs={rpcPrefs}
-            origin={origin}
-            siteImage={siteImage}
             onClose={() => this.setState({ showContractDetails: false })}
             isContractRequestingSignature
           />

--- a/ui/components/app/signature-request/signature-request.container.js
+++ b/ui/components/app/signature-request/signature-request.container.js
@@ -32,12 +32,8 @@ function mapStateToProps(state, ownProps) {
   const isLedgerWallet = isAddressLedger(state, from);
   const chainId = getCurrentChainId(state);
   const rpcPrefs = getRpcPrefsForCurrentProvider(state);
-  const subjectMetadata = getSubjectMetadata(state);
   const unconfirmedMessagesList = unconfirmedMessagesHashSelector(state);
   const unapprovedMessagesCount = getTotalUnapprovedMessagesCount(state);
-
-  const { iconUrl: siteImage = '' } =
-    subjectMetadata[txData.msgParams.origin] || {};
 
   return {
     provider,
@@ -45,7 +41,6 @@ function mapStateToProps(state, ownProps) {
     hardwareWalletRequiresConnection,
     chainId,
     rpcPrefs,
-    siteImage,
     unconfirmedMessagesList,
     unapprovedMessagesCount,
     mostRecentOverviewPage: getMostRecentOverviewPage(state),
@@ -85,7 +80,6 @@ function mergeProps(stateProps, dispatchProps, ownProps) {
     hardwareWalletRequiresConnection,
     chainId,
     rpcPrefs,
-    siteImage,
     conversionRate,
     nativeCurrency,
     provider,
@@ -138,7 +132,6 @@ function mergeProps(stateProps, dispatchProps, ownProps) {
     hardwareWalletRequiresConnection,
     chainId,
     rpcPrefs,
-    siteImage,
     conversionRate,
     nativeCurrency,
     provider,

--- a/ui/pages/token-allowance/token-allowance.js
+++ b/ui/pages/token-allowance/token-allowance.js
@@ -518,8 +518,6 @@ export default function TokenAllowance({
           toAddress={toAddress}
           chainId={fullTxData.chainId}
           rpcPrefs={rpcPrefs}
-          origin={origin}
-          siteImage={siteImage}
         />
       )}
     </Box>


### PR DESCRIPTION

## Explanation

With this fix, on the verify contract details modal, we display the address icon for the contract requesting spending cap instead of the dapp/url icon. Also we display the address icon for the contract requesting signature instead of the dapp/url icon.

* Fixes #17357 

## Screenshots/Screencaps

### Before

#### dapp/url icon for the contract requesting spending cap

<img width="366" alt="214112436-ea793838-8493-4e3d-8cc5-6bbb513a2cb5" src="https://user-images.githubusercontent.com/92527393/220643769-baf948b1-93cf-458c-a18b-499997c6e4ba.png">

#### dapp/url for the contract requesting signature

![Screenshot 2023-02-22 at 15 00 41](https://user-images.githubusercontent.com/92527393/220643953-7a1b4e4e-88e5-44d2-9339-0d33eed5a83e.png)

### After

#### the address icon for the contract requesting spending cap and for the contract requesting signature

https://user-images.githubusercontent.com/92527393/220644377-f04e89e1-15de-4562-b1b8-0bed8d7df470.mov

## Manual Testing Steps

### Etherscan

1. Go to https://etherscan.io/address/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2#writeContract
2. Connect your wallet
3. Go to `approve`
4. Input an address and an amount
5. Click write
6. On the MetaMask popup, click on verify contract details and notice how the contract requesting spending cap displays the address icon

### Test dapp

1. Go to https://metamask.github.io/test-dapp
2. Connect your wallet
3. Go to `Sign Typed Data V3` or `Sign Typed Data V4` section and click `Sign`
4. On the MetaMask popup, click on verify contract details and notice how the contract requesting signature displays the address icon
