### PR TITLE
Fix #17825 - Prevent timing conflict with NFT toast messages

### DIFF
--- a/ui/components/app/nft-details/nft-details.js
+++ b/ui/components/app/nft-details/nft-details.js
@@ -36,6 +36,7 @@ import {
   checkAndUpdateSingleNftOwnershipStatus,
   removeAndIgnoreNft,
   setRemoveNftMessage,
+  setNewNftAddedMessage,
 } from '../../../store/actions';
 import { CHAIN_IDS } from '../../../../shared/constants/network';
 import { getEnvironmentType } from '../../../../app/scripts/lib/util';
@@ -92,6 +93,7 @@ export default function NftDetails({ nft }) {
 
   const onRemove = () => {
     dispatch(removeAndIgnoreNft(address, tokenId));
+    dispatch(setNewNftAddedMessage(''));
     dispatch(setRemoveNftMessage('success'));
     history.push(DEFAULT_ROUTE);
   };

--- a/ui/pages/home/home.container.js
+++ b/ui/pages/home/home.container.js
@@ -177,9 +177,11 @@ const mapDispatchToProps = (dispatch) => ({
     dispatch(setNewNetworkAdded(newNetwork));
   },
   setNewNftAddedMessage: (message) => {
+    dispatch(setRemoveNftMessage(''));
     dispatch(setNewNftAddedMessage(message));
   },
   setRemoveNftMessage: (message) => {
+    dispatch(setNewNftAddedMessage(''));
     dispatch(setRemoveNftMessage(message));
   },
   setNewTokensImported: (newTokens) => {


### PR DESCRIPTION
## Explanation

Issue: #17825

The reason this was happening is because the NFT was added and removed so quickly that the "added" toast hadn't expired yet.  This PR clears out messages during addition and removal.

## Manual Testing Steps

1.  Import an NFT
2. Very quickly remove it
3. See the proper toasts at each step

## Pre-merge author checklist

- [ ] I've clearly explained:
  - [ ] What problem this PR is solving
  - [ ] How this problem was solved
  - [ ] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
