### PR TITLE
Fixing focus outline of TextField

### DIFF
--- a/ui/components/component-library/form-text-field/__snapshots__/form-text-field.test.js.snap
+++ b/ui/components/component-library/form-text-field/__snapshots__/form-text-field.test.js.snap
@@ -10,7 +10,7 @@ exports[`FormTextField should render correctly 1`] = `
     >
       <input
         autocomplete="off"
-        class="box mm-text mm-input mm-text-field__input mm-text--body-md mm-text--color-text-default box--padding-right-4 box--padding-left-4 box--flex-direction-row box--background-color-transparent box--border-style-none"
+        class="box mm-text mm-input mm-input--disable-state-styles mm-text-field__input mm-text--body-md mm-text--color-text-default box--padding-right-4 box--padding-left-4 box--flex-direction-row box--background-color-transparent box--border-style-none"
         focused="false"
         type="text"
         value=""

--- a/ui/components/component-library/text-field-search/__snapshots__/text-field-search.test.js.snap
+++ b/ui/components/component-library/text-field-search/__snapshots__/text-field-search.test.js.snap
@@ -11,7 +11,7 @@ exports[`TextFieldSearch should render correctly 1`] = `
     />
     <input
       autocomplete="off"
-      class="box mm-text mm-input mm-text-field__input mm-text--body-md mm-text--color-text-default box--margin-right-6 box--padding-right-4 box--padding-left-2 box--flex-direction-row box--background-color-transparent box--border-style-none"
+      class="box mm-text mm-input mm-input--disable-state-styles mm-text-field__input mm-text--body-md mm-text--color-text-default box--margin-right-6 box--padding-right-4 box--padding-left-2 box--flex-direction-row box--background-color-transparent box--border-style-none"
       focused="false"
       type="search"
       value=""

--- a/ui/components/component-library/text-field/__snapshots__/text-field.test.js.snap
+++ b/ui/components/component-library/text-field/__snapshots__/text-field.test.js.snap
@@ -7,7 +7,7 @@ exports[`TextField should render correctly 1`] = `
   >
     <input
       autocomplete="off"
-      class="box mm-text mm-input mm-text-field__input mm-text--body-md mm-text--color-text-default box--padding-right-4 box--padding-left-4 box--flex-direction-row box--background-color-transparent box--border-style-none"
+      class="box mm-text mm-input mm-input--disable-state-styles mm-text-field__input mm-text--body-md mm-text--color-text-default box--padding-right-4 box--padding-left-4 box--flex-direction-row box--background-color-transparent box--border-style-none"
       focused="false"
       type="text"
       value=""

--- a/ui/components/component-library/text-field/text-field.js
+++ b/ui/components/component-library/text-field/text-field.js
@@ -135,6 +135,7 @@ export const TextField = ({
         required={required}
         value={value}
         type={type}
+        disableStateStyles
         {...inputProps} // before className so input className isn't overridden
         className={classnames('mm-text-field__input', inputProps?.className)}
       />

--- a/ui/components/component-library/text-field/text-field.test.js
+++ b/ui/components/component-library/text-field/text-field.test.js
@@ -245,4 +245,14 @@ describe('TextField', () => {
     fireEvent.change(textField, { target: { value: '' } }); // reset value
     expect(textField.value).toBe(''); // value is empty string after reset
   });
+  it('should render the child Input with disableStateStyles to prevent multiple focus outlines', async () => {
+    const { getByTestId, user } = renderWithUserEvent(
+      <TextField inputProps={{ 'data-testid': 'input' }} />,
+    );
+    const InputComponent = getByTestId('input');
+
+    await user.click(InputComponent);
+    expect(getByTestId('input')).toHaveFocus();
+    expect(getByTestId('input')).toHaveClass('mm-input--disable-state-styles');
+  });
 });

--- a/ui/pages/keychains/__snapshots__/reveal-seed.test.js.snap
+++ b/ui/pages/keychains/__snapshots__/reveal-seed.test.js.snap
@@ -98,7 +98,7 @@ exports[`Reveal Seed Page should match snapshot 1`] = `
       >
         <input
           autocomplete="off"
-          class="box mm-text mm-input mm-text-field__input mm-text--body-md mm-text--color-text-default box--padding-right-4 box--padding-left-4 box--flex-direction-row box--background-color-transparent box--border-style-none"
+          class="box mm-text mm-input mm-input--disable-state-styles mm-text-field__input mm-text--body-md mm-text--color-text-default box--padding-right-4 box--padding-left-4 box--flex-direction-row box--background-color-transparent box--border-style-none"
           data-testid="input-password"
           focused="true"
           id="password-box"


### PR DESCRIPTION
## Explanation
Some recent updates to the TextField introduced a bug where the internal input and wrapping border both had focus states when navigating using a keyboard.

This PR fixes the focus outline of the TextField

* Fixes #17850

## Screenshots/Screencaps

### Before


https://user-images.githubusercontent.com/8112138/220693820-ecd6b366-c97d-49a6-8f84-9b92115aeee7.mov

### After

https://user-images.githubusercontent.com/8112138/220693891-9d4cfe5a-0c3a-49bc-a21a-a2de05f4dfb1.mov

## Manual Testing Steps

- Go to the latest storybook build in this PR
- Search `TextField` in the search bar(make sure it's the component-library version)
- Go to the *Start Accessory End* Accessory story
- Use the keyboard to tab through the inputs
- Check that there is only one focus outline per element

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
