### PR TITLE
Use tokenList to get token details, when available, in getTokenStanda…

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -2215,15 +2215,15 @@ export default class MetamaskController extends EventEmitter {
       !isEqualCaseInsensitive(tokenDetails.standard, TokenStandard.ERC721) &&
       !tokenDetails.erc721;
 
-    const otherThanStandardDetailsAreERC20Like =
+    const otherDetailsAreERC20Like =
       tokenDetails.decimals !== undefined && tokenDetails.symbol;
 
-    const weCanAttemptToFetchERC20TokenBalance =
+    const tokenCanBeTreatedAsAnERC20 =
       tokenDetailsStandardIsERC20 ||
-      (noEvidenceThatTokenIsAnNFT && otherThanStandardDetailsAreERC20Like);
+      (noEvidenceThatTokenIsAnNFT && otherDetailsAreERC20Like);
 
     let details;
-    if (weCanAttemptToFetchERC20TokenBalance) {
+    if (tokenCanBeTreatedAsAnERC20) {
       try {
         const balance = await fetchTokenBalance(
           address,

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -2208,7 +2208,7 @@ export default class MetamaskController extends EventEmitter {
       ...tokenListDetails,
       ...userDefinedTokenDetails,
     };
-    const tokenDetailsStandardIsisERC20 =
+    const tokenDetailsStandardIsERC20 =
       isEqualCaseInsensitive(tokenDetails.standard, TokenStandard.ERC20) ||
       tokenDetails.erc20 === true;
     const noEvidenceThatTokenIsAnNFT =

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -64,7 +64,6 @@ import {
 ///: END:ONLY_INCLUDE_IN
 
 import browser from 'webextension-polyfill';
-import EthContract from 'ethjs-contract';
 import {
   AssetType,
   TransactionStatus,
@@ -2192,7 +2191,6 @@ export default class MetamaskController extends EventEmitter {
   }
 
   async getTokenStandardAndDetails(address, userAddress, tokenId) {
-    const contract = new EthContract(this.ethQuery);
     const { tokenList } = this.tokenListController.state;
     const tokenListEntry = tokenList[address.toLowerCase()];
     let details;
@@ -2200,7 +2198,7 @@ export default class MetamaskController extends EventEmitter {
       const standard = tokenListEntry.standard?.toUpperCase() ?? 'NONE';
       let balance;
       if (standard === 'ERC20') {
-        balance = await fetchTokenBalance(address, userAddress, contract);
+        balance = await fetchTokenBalance(address, userAddress, this.provider);
       }
 
       details = {

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -265,8 +265,6 @@ export default class MetamaskController extends EventEmitter {
     this.blockTracker =
       this.networkController.getProviderAndBlockTracker().blockTracker;
 
-    this.ethQuery = new EthQuery(this.provider);
-
     const tokenListMessenger = this.controllerMessenger.getRestricted({
       name: 'TokenListController',
     });
@@ -2394,10 +2392,11 @@ export default class MetamaskController extends EventEmitter {
         seedPhraseAsBuffer,
       );
 
+      const ethQuery = new EthQuery(this.provider);
       accounts = await keyringController.getAccounts();
       lastBalance = await this.getBalance(
         accounts[accounts.length - 1],
-        this.ethQuery,
+        ethQuery,
       );
 
       const [primaryKeyring] = keyringController.getKeyringsByType(
@@ -2413,7 +2412,7 @@ export default class MetamaskController extends EventEmitter {
         accounts = await keyringController.getAccounts();
         lastBalance = await this.getBalance(
           accounts[accounts.length - 1],
-          this.ethQuery,
+          ethQuery,
         );
       }
 

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -2241,7 +2241,7 @@ export default class MetamaskController extends EventEmitter {
       } catch (e) {
         // If the `fetchTokenBalance` call failed, `details` remains undefined, and we
         // fall back to the below `assetsContractController.getTokenStandardAndDetails` call
-        log.warning('Failed to get token balance');
+        log.warning(`Failed to get token balance. Error: ${e}`);
       }
     }
 

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -2218,12 +2218,12 @@ export default class MetamaskController extends EventEmitter {
     const otherThanStandardDetailsAreERC20Like =
       tokenDetails.decimals !== undefined && tokenDetails.symbol;
 
-    const tokenCanBeTreatedAsAnERC20 =
+    const weCanAttemptToFetchERC20TokenBalance =
       tokenDetailsStandardIsisERC20 ||
       (noEvidenceThatTokenIsAnNFT && otherThanStandardDetailsAreERC20Like);
 
     let details;
-    if (tokenCanBeTreatedAsAnERC20) {
+    if (weCanAttemptToFetchERC20TokenBalance) {
       try {
         const balance = await fetchTokenBalance(
           address,
@@ -2239,10 +2239,15 @@ export default class MetamaskController extends EventEmitter {
           symbol: tokenDetails.symbol,
         };
       } catch (e) {
+        // If the `fetchTokenBalance` call failed, `details` remains undefined, and we
+        // fall back to the below `assetsContractController.getTokenStandardAndDetails` call
         log.warning('Failed to get token balance');
       }
     }
 
+    // `details`` will be undefined if `weCanAttemptToFetchERC20TokenBalance`` is false,
+    // or if it is true but the `fetchTokenBalance`` call failed. In either case, we should
+    // attempt to retrieve details from `assetsContractController.getTokenStandardAndDetails` 
     if (details === undefined) {
       details = await this.assetsContractController.getTokenStandardAndDetails(
         address,

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -2245,7 +2245,7 @@ export default class MetamaskController extends EventEmitter {
       }
     }
 
-    // `details`` will be undefined if `weCanAttemptToFetchERC20TokenBalance`` is false,
+    // `details`` will be undefined if `tokenCanBeTreatedAsAnERC20`` is false,
     // or if it is true but the `fetchTokenBalance`` call failed. In either case, we should
     // attempt to retrieve details from `assetsContractController.getTokenStandardAndDetails`
     if (details === undefined) {

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -2212,9 +2212,11 @@ export default class MetamaskController extends EventEmitter {
       isEqualCaseInsensitive(tokenDetails.standard, TokenStandard.ERC20) ||
       tokenDetails.erc20 === true;
     const noEvidenceThatTokenIsAnNFT =
+      !tokenId &&
       !isEqualCaseInsensitive(tokenDetails.standard, TokenStandard.ERC1155) &&
       !isEqualCaseInsensitive(tokenDetails.standard, TokenStandard.ERC721) &&
-      !tokenDetails.erc721;
+      !tokenDetails.erc721
+      
     const otherThanStandardDetailsAreERC20Like =
       tokenDetails.decimals !== undefined && tokenDetails.symbol;
 

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -2213,13 +2213,13 @@ export default class MetamaskController extends EventEmitter {
       !tokenId &&
       !isEqualCaseInsensitive(tokenDetails.standard, TokenStandard.ERC1155) &&
       !isEqualCaseInsensitive(tokenDetails.standard, TokenStandard.ERC721) &&
-      !tokenDetails.erc721
-      
+      !tokenDetails.erc721;
+
     const otherThanStandardDetailsAreERC20Like =
       tokenDetails.decimals !== undefined && tokenDetails.symbol;
 
     const weCanAttemptToFetchERC20TokenBalance =
-      tokenDetailsStandardIsisERC20 ||
+      tokenDetailsStandardIsERC20 ||
       (noEvidenceThatTokenIsAnNFT && otherThanStandardDetailsAreERC20Like);
 
     let details;
@@ -2247,7 +2247,7 @@ export default class MetamaskController extends EventEmitter {
 
     // `details`` will be undefined if `weCanAttemptToFetchERC20TokenBalance`` is false,
     // or if it is true but the `fetchTokenBalance`` call failed. In either case, we should
-    // attempt to retrieve details from `assetsContractController.getTokenStandardAndDetails` 
+    // attempt to retrieve details from `assetsContractController.getTokenStandardAndDetails`
     if (details === undefined) {
       details = await this.assetsContractController.getTokenStandardAndDetails(
         address,

--- a/coverage-targets.js
+++ b/coverage-targets.js
@@ -7,9 +7,9 @@
 module.exports = {
   global: {
     lines: 64.5,
-    branches: 53,
-    statements: 63,
-    functions: 56.5,
+    branches: 53.15,
+    statements: 63.57,
+    functions: 56.58,
   },
   transforms: {
     branches: 100,

--- a/shared/lib/token-util.ts
+++ b/shared/lib/token-util.ts
@@ -1,4 +1,4 @@
-import { abiERC20 } from '@metamask/metamask-eth-abis'
+import { abiERC20 } from '@metamask/metamask-eth-abis';
 import { Contract } from '@ethersproject/contracts';
 import { Web3Provider } from '@ethersproject/providers';
 

--- a/shared/lib/token-util.ts
+++ b/shared/lib/token-util.ts
@@ -1,0 +1,34 @@
+import abi from 'human-standard-token-abi';
+
+/**
+ * Gets the '_value' parameter of the given token transaction data
+ * (i.e function call) per the Human Standard Token ABI, if present.
+ *
+ * @param {object} tokenData - ethers Interface token data.
+ * @returns {string | undefined} A decimal string value.
+ */
+/**
+ * Gets either the '_tokenId' parameter or the 'id' param of the passed token transaction data.,
+ * These are the parsed tokenId values returned by `parseStandardTokenTransactionData` as defined
+ * in the ERC721 and ERC1155 ABIs from metamask-eth-abis (https://github.com/MetaMask/metamask-eth-abis/tree/main/src/abis)
+ *
+ * @param {object} tokenData - ethers Interface token data.
+ * @returns {string | undefined} A decimal string value.
+ */
+export function getTokenIdParam(tokenData: any = {}): string | undefined  {
+  return (
+    tokenData?.args?._tokenId?.toString() ?? tokenData?.args?.id?.toString()
+  );
+}
+
+export async function fetchTokenBalance(
+  address: string,
+  userAddress: string,
+  contract: (abi: string) => any,
+): Promise<any> {
+  const tokenContract = contract(abi).at(address);
+  const tokenBalancePromise = tokenContract
+    ? tokenContract.balanceOf(userAddress)
+    : Promise.resolve();
+  return await tokenBalancePromise;
+}

--- a/shared/lib/token-util.ts
+++ b/shared/lib/token-util.ts
@@ -12,10 +12,10 @@ import abi from 'human-standard-token-abi';
  * These are the parsed tokenId values returned by `parseStandardTokenTransactionData` as defined
  * in the ERC721 and ERC1155 ABIs from metamask-eth-abis (https://github.com/MetaMask/metamask-eth-abis/tree/main/src/abis)
  *
- * @param {object} tokenData - ethers Interface token data.
- * @returns {string | undefined} A decimal string value.
+ * @param tokenData - ethers Interface token data.
+ * @returns A decimal string value.
  */
-export function getTokenIdParam(tokenData: any = {}): string | undefined  {
+export function getTokenIdParam(tokenData: any = {}): string | undefined {
   return (
     tokenData?.args?._tokenId?.toString() ?? tokenData?.args?.id?.toString()
   );

--- a/shared/lib/token-util.ts
+++ b/shared/lib/token-util.ts
@@ -1,4 +1,4 @@
-import abi from 'human-standard-token-abi';
+import { abiERC20 } from '@metamask/metamask-eth-abis'
 import { Contract } from '@ethersproject/contracts';
 import { Web3Provider } from '@ethersproject/providers';
 
@@ -29,7 +29,7 @@ export async function fetchTokenBalance(
   provider,
 ): Promise<any> {
   const ethersProvider = new Web3Provider(provider);
-  const tokenContract = new Contract(address, abi, ethersProvider);
+  const tokenContract = new Contract(address, abiERC20, ethersProvider);
   const tokenBalancePromise = tokenContract
     ? tokenContract.balanceOf(userAddress)
     : Promise.resolve();

--- a/shared/lib/token-util.ts
+++ b/shared/lib/token-util.ts
@@ -26,7 +26,7 @@ export function getTokenIdParam(tokenData: any = {}): string | undefined {
 export async function fetchTokenBalance(
   address: string,
   userAddress: string,
-  provider,
+  provider: any,
 ): Promise<any> {
   const ethersProvider = new Web3Provider(provider);
   const tokenContract = new Contract(address, abiERC20, ethersProvider);

--- a/shared/lib/token-util.ts
+++ b/shared/lib/token-util.ts
@@ -1,4 +1,6 @@
 import abi from 'human-standard-token-abi';
+import { Contract } from '@ethersproject/contracts';
+import { Web3Provider } from '@ethersproject/providers';
 
 /**
  * Gets the '_value' parameter of the given token transaction data
@@ -24,9 +26,10 @@ export function getTokenIdParam(tokenData: any = {}): string | undefined {
 export async function fetchTokenBalance(
   address: string,
   userAddress: string,
-  contract: (abi: string) => any,
+  provider,
 ): Promise<any> {
-  const tokenContract = contract(abi).at(address);
+  const ethersProvider = new Web3Provider(provider);
+  const tokenContract = new Contract(address, abi, ethersProvider);
   const tokenBalancePromise = tokenContract
     ? tokenContract.balanceOf(userAddress)
     : Promise.resolve();

--- a/ui/components/app/confirm-page-container/confirm-page-container.component.js
+++ b/ui/components/app/confirm-page-container/confirm-page-container.component.js
@@ -24,7 +24,7 @@ import Typography from '../../ui/typography';
 import { TypographyVariant } from '../../../helpers/constants/design-system';
 
 import NetworkAccountBalanceHeader from '../network-account-balance-header/network-account-balance-header';
-import { fetchTokenBalance } from '../../../pages/swaps/swaps.util';
+import { fetchTokenBalance } from '../../../../shared/lib/token-util.ts';
 import SetApproveForAllWarning from '../set-approval-for-all-warning';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 ///: BEGIN:ONLY_INCLUDE_IN(flask)
@@ -132,7 +132,11 @@ const ConfirmPageContainer = (props) => {
     NETWORK_TO_NAME_MAP[currentTransaction.chainId] || networkIdentifier;
 
   const fetchCollectionBalance = useCallback(async () => {
-    const tokenBalance = await fetchTokenBalance(tokenAddress, fromAddress);
+    const tokenBalance = await fetchTokenBalance(
+      tokenAddress,
+      fromAddress,
+      global.eth.contract,
+    );
     setCollectionBalance(tokenBalance?.balance?.words?.[0] || 0);
   }, [fromAddress, tokenAddress]);
 

--- a/ui/components/app/confirm-page-container/confirm-page-container.component.js
+++ b/ui/components/app/confirm-page-container/confirm-page-container.component.js
@@ -135,7 +135,7 @@ const ConfirmPageContainer = (props) => {
     const tokenBalance = await fetchTokenBalance(
       tokenAddress,
       fromAddress,
-      global.eth.contract,
+      global.ethereumProvider,
     );
     setCollectionBalance(tokenBalance?.balance?.words?.[0] || 0);
   }, [fromAddress, tokenAddress]);

--- a/ui/pages/swaps/build-quote/build-quote.js
+++ b/ui/pages/swaps/build-quote/build-quote.js
@@ -98,14 +98,11 @@ import {
   setSmartTransactionsOptInStatus,
   clearSmartTransactionFees,
 } from '../../../store/actions';
-import {
-  countDecimals,
-  fetchTokenPrice,
-  fetchTokenBalance,
-} from '../swaps.util';
+import { countDecimals, fetchTokenPrice } from '../swaps.util';
 import SwapsFooter from '../swaps-footer';
 import { isEqualCaseInsensitive } from '../../../../shared/modules/string-utils';
 import { calcTokenAmount } from '../../../../shared/lib/transactions-controller-utils';
+import { fetchTokenBalance } from '../../../../shared/lib/token-util.ts';
 import { shouldEnableDirectWrapping } from '../../../../shared/lib/swaps-utils';
 import {
   getValueFromWeiHex,
@@ -313,24 +310,26 @@ export default function BuildQuote({
         isEqualCaseInsensitive(usersToken.address, token.address),
       )
     ) {
-      fetchTokenBalance(token.address, selectedAccountAddress).then(
-        (fetchedBalance) => {
-          if (fetchedBalance?.balance) {
-            const balanceAsDecString = fetchedBalance.balance.toString(10);
-            const userTokenBalance = calcTokenAmount(
-              balanceAsDecString,
-              token.decimals,
-            );
-            dispatch(
-              setSwapsFromToken({
-                ...token,
-                string: userTokenBalance.toString(10),
-                balance: balanceAsDecString,
-              }),
-            );
-          }
-        },
-      );
+      fetchTokenBalance(
+        token.address,
+        selectedAccountAddress,
+        global.eth.contract,
+      ).then((fetchedBalance) => {
+        if (fetchedBalance?.balance) {
+          const balanceAsDecString = fetchedBalance.balance.toString(10);
+          const userTokenBalance = calcTokenAmount(
+            balanceAsDecString,
+            token.decimals,
+          );
+          dispatch(
+            setSwapsFromToken({
+              ...token,
+              string: userTokenBalance.toString(10),
+              balance: balanceAsDecString,
+            }),
+          );
+        }
+      });
     }
     dispatch(setSwapsFromToken(token));
     onInputChange(

--- a/ui/pages/swaps/build-quote/build-quote.js
+++ b/ui/pages/swaps/build-quote/build-quote.js
@@ -313,7 +313,7 @@ export default function BuildQuote({
       fetchTokenBalance(
         token.address,
         selectedAccountAddress,
-        global.eth.contract,
+        global.ethereumProvider,
       ).then((fetchedBalance) => {
         if (fetchedBalance?.balance) {
           const balanceAsDecString = fetchedBalance.balance.toString(10);

--- a/ui/pages/swaps/build-quote/build-quote.test.js
+++ b/ui/pages/swaps/build-quote/build-quote.test.js
@@ -8,6 +8,7 @@ import {
   setBackgroundConnection,
   fireEvent,
 } from '../../../../test/jest';
+import { createTestProviderTools } from '../../../../test/stub/provider';
 import {
   setSwapsFromToken,
   setSwapToToken,
@@ -61,19 +62,24 @@ jest.mock('../swaps.util', () => {
   };
 });
 
+const providerResultStub = {
+  eth_getCode: '0x123',
+  eth_call:
+    '0x00000000000000000000000000000000000000000000000029a2241af62c0000',
+};
+const { provider } = createTestProviderTools({
+  scaffold: providerResultStub,
+  networkId: '5',
+  chainId: '5',
+});
+
 describe('BuildQuote', () => {
   beforeAll(() => {
     jest.clearAllMocks();
   });
 
   beforeEach(() => {
-    global.eth = {
-      contract: jest.fn(() => ({
-        at: jest.fn(() => ({
-          balanceOf: jest.fn(() => undefined),
-        })),
-      })),
-    };
+    global.ethereumProvider = provider;
   });
 
   afterEach(() => {

--- a/ui/pages/swaps/build-quote/build-quote.test.js
+++ b/ui/pages/swaps/build-quote/build-quote.test.js
@@ -62,7 +62,21 @@ jest.mock('../swaps.util', () => {
 });
 
 describe('BuildQuote', () => {
+  beforeAll(() => {
+    jest.clearAllMocks();
+  });
+
   beforeEach(() => {
+    global.eth = {
+      contract: jest.fn(() => ({
+        at: jest.fn(() => ({
+          balanceOf: jest.fn(() => undefined),
+        })),
+      })),
+    };
+  });
+
+  afterEach(() => {
     jest.clearAllMocks();
   });
 

--- a/ui/pages/swaps/swaps.util.ts
+++ b/ui/pages/swaps/swaps.util.ts
@@ -215,17 +215,6 @@ export async function fetchTokenPrice(address: string): Promise<any> {
   return prices?.[address]?.eth;
 }
 
-export async function fetchTokenBalance(
-  address: string,
-  userAddress: string,
-): Promise<any> {
-  const tokenContract = (global as any).eth.contract(abi).at(address);
-  const tokenBalancePromise = tokenContract
-    ? tokenContract.balanceOf(userAddress)
-    : Promise.resolve();
-  return await tokenBalancePromise;
-}
-
 export async function fetchSwapsGasPrices(chainId: any): Promise<
   | any
   | {

--- a/ui/pages/swaps/swaps.util.ts
+++ b/ui/pages/swaps/swaps.util.ts
@@ -1,5 +1,4 @@
 import { BigNumber } from 'bignumber.js';
-import abi from 'human-standard-token-abi';
 import { Json } from '@metamask/controller-utils';
 import { IndividualTxFees } from '@metamask/smart-transactions-controller/dist/types';
 import {


### PR DESCRIPTION
…rdAndDetails

Previously, every call to getTokenStandardAndDetails would fetch data via the provider. This would result in at least 3 network requests whenever that method is called for an ERC20 token, contributing to unneccesary loading and lagging in multiple places. This commit takes advantage of stored data we already have available to avoid the unnecessary loading.

Fixes https://github.com/MetaMask/metamask-extension/issues/17577