### PR TITLE
identify desktop is paired in the metrics event

### DIFF
--- a/app/scripts/controllers/metametrics.js
+++ b/app/scripts/controllers/metametrics.js
@@ -100,7 +100,6 @@ export default class MetaMetricsController {
    * @param {MetaMetricsControllerState} options.initState - State to initialized with
    * @param options.captureException
    */
-  /* eslint-disable-next-line jsdoc/require-param */
   constructor({
     segment,
     preferencesStore,
@@ -111,9 +110,6 @@ export default class MetaMetricsController {
     initState,
     extension,
     captureException = defaultCaptureException,
-    ///: BEGIN:ONLY_INCLUDE_IN(desktop)
-    getDesktopEnabled,
-    ///: END:ONLY_INCLUDE_IN
   }) {
     this._captureException = (err) => {
       // This is a temporary measure. Currently there are errors flooding sentry due to a problem in how we are tracking anonymousId
@@ -129,9 +125,6 @@ export default class MetaMetricsController {
       environment === 'production' ? version : `${version}-${environment}`;
     this.extension = extension;
     this.environment = environment;
-    ///: BEGIN:ONLY_INCLUDE_IN(desktop)
-    this.getDesktopEnabled = getDesktopEnabled;
-    ///: END:ONLY_INCLUDE_IN
 
     const abandonedFragments = omitBy(initState?.fragments, 'persist');
     const segmentApiCalls = initState?.segmentApiCalls || {};
@@ -477,9 +470,6 @@ export default class MetaMetricsController {
           locale: this.locale,
           chain_id: this.chainId,
           environment_type: environmentType,
-          ///: BEGIN:ONLY_INCLUDE_IN(desktop)
-          desktop_paired: this.getDesktopEnabled(),
-          ///: END:ONLY_INCLUDE_IN
         },
         context: this._buildContext(referrer, page),
       });
@@ -679,9 +669,6 @@ export default class MetaMetricsController {
         locale: this.locale,
         chain_id: properties?.chain_id ?? this.chainId,
         environment_type: environmentType,
-        ///: BEGIN:ONLY_INCLUDE_IN(desktop)
-        desktop_paired: this.getDesktopEnabled(),
-        ///: END:ONLY_INCLUDE_IN
       },
       context: this._buildContext(referrer, page),
     };
@@ -729,6 +716,9 @@ export default class MetaMetricsController {
       [TRAITS.THREE_BOX_ENABLED]: false, // deprecated, hard-coded as false
       [TRAITS.THEME]: metamaskState.theme || 'default',
       [TRAITS.TOKEN_DETECTION_ENABLED]: metamaskState.useTokenDetection,
+      ///: BEGIN:ONLY_INCLUDE_IN(desktop)
+      [TRAITS.DESKTOP_ENABLED]: metamaskState.desktopEnabled || false,
+      ///: END:ONLY_INCLUDE_IN
     };
 
     if (!previousUserTraits) {

--- a/app/scripts/controllers/metametrics.js
+++ b/app/scripts/controllers/metametrics.js
@@ -100,6 +100,7 @@ export default class MetaMetricsController {
    * @param {MetaMetricsControllerState} options.initState - State to initialized with
    * @param options.captureException
    */
+  /* eslint-disable-next-line jsdoc/require-param */
   constructor({
     segment,
     preferencesStore,
@@ -110,6 +111,9 @@ export default class MetaMetricsController {
     initState,
     extension,
     captureException = defaultCaptureException,
+    ///: BEGIN:ONLY_INCLUDE_IN(desktop)
+    getDesktopEnabled,
+    ///: END:ONLY_INCLUDE_IN
   }) {
     this._captureException = (err) => {
       // This is a temporary measure. Currently there are errors flooding sentry due to a problem in how we are tracking anonymousId
@@ -125,6 +129,9 @@ export default class MetaMetricsController {
       environment === 'production' ? version : `${version}-${environment}`;
     this.extension = extension;
     this.environment = environment;
+    ///: BEGIN:ONLY_INCLUDE_IN(desktop)
+    this.getDesktopEnabled = getDesktopEnabled;
+    ///: END:ONLY_INCLUDE_IN
 
     const abandonedFragments = omitBy(initState?.fragments, 'persist');
     const segmentApiCalls = initState?.segmentApiCalls || {};
@@ -470,6 +477,9 @@ export default class MetaMetricsController {
           locale: this.locale,
           chain_id: this.chainId,
           environment_type: environmentType,
+          ///: BEGIN:ONLY_INCLUDE_IN(desktop)
+          desktop_paired: this.getDesktopEnabled(),
+          ///: END:ONLY_INCLUDE_IN
         },
         context: this._buildContext(referrer, page),
       });
@@ -669,6 +679,9 @@ export default class MetaMetricsController {
         locale: this.locale,
         chain_id: properties?.chain_id ?? this.chainId,
         environment_type: environmentType,
+        ///: BEGIN:ONLY_INCLUDE_IN(desktop)
+        desktop_paired: this.getDesktopEnabled(),
+        ///: END:ONLY_INCLUDE_IN
       },
       context: this._buildContext(referrer, page),
     };

--- a/app/scripts/controllers/metametrics.test.js
+++ b/app/scripts/controllers/metametrics.test.js
@@ -50,6 +50,7 @@ const DEFAULT_SHARED_PROPERTIES = {
   chain_id: FAKE_CHAIN_ID,
   locale: LOCALE.replace('_', '-'),
   environment_type: 'background',
+  desktop_paired: false,
 };
 
 const DEFAULT_EVENT_PROPERTIES = {
@@ -102,6 +103,23 @@ function getMockPreferencesStore({ currentLocale = LOCALE } = {}) {
   };
 }
 
+function getMockDesktopController(getDesktopEnabled = false) {
+  let desktopStore = {
+    getDesktopEnabled,
+  };
+  const subscribe = sinon.stub();
+  const updateState = (newState) => {
+    desktopStore = { ...desktopStore, ...newState };
+    subscribe.getCall(0).args[0](desktopStore);
+  };
+  return {
+    getState: sinon.stub().returns(desktopStore),
+    getDesktopEnabled: () => desktopStore.getDesktopEnabled,
+    updateState,
+    subscribe,
+  };
+}
+
 const SAMPLE_PERSISTED_EVENT = {
   id: 'testid',
   persist: true,
@@ -130,6 +148,7 @@ function getMetaMetricsController({
   preferencesStore = getMockPreferencesStore(),
   networkController = getMockNetworkController(),
   segmentInstance,
+  desktopController = getMockDesktopController(),
 } = {}) {
   return new MetaMetricsController({
     segment: segmentInstance || segment,
@@ -151,6 +170,8 @@ function getMetaMetricsController({
       },
       events: {},
     },
+    getDesktopEnabled:
+    desktopController.getDesktopEnabled.bind(desktopController),
   });
 }
 describe('MetaMetricsController', function () {

--- a/app/scripts/controllers/metametrics.test.js
+++ b/app/scripts/controllers/metametrics.test.js
@@ -50,7 +50,6 @@ const DEFAULT_SHARED_PROPERTIES = {
   chain_id: FAKE_CHAIN_ID,
   locale: LOCALE.replace('_', '-'),
   environment_type: 'background',
-  desktop_paired: false,
 };
 
 const DEFAULT_EVENT_PROPERTIES = {
@@ -103,23 +102,6 @@ function getMockPreferencesStore({ currentLocale = LOCALE } = {}) {
   };
 }
 
-function getMockDesktopController(getDesktopEnabled = false) {
-  let desktopStore = {
-    getDesktopEnabled,
-  };
-  const subscribe = sinon.stub();
-  const updateState = (newState) => {
-    desktopStore = { ...desktopStore, ...newState };
-    subscribe.getCall(0).args[0](desktopStore);
-  };
-  return {
-    getState: sinon.stub().returns(desktopStore),
-    getDesktopEnabled: () => desktopStore.getDesktopEnabled,
-    updateState,
-    subscribe,
-  };
-}
-
 const SAMPLE_PERSISTED_EVENT = {
   id: 'testid',
   persist: true,
@@ -148,7 +130,6 @@ function getMetaMetricsController({
   preferencesStore = getMockPreferencesStore(),
   networkController = getMockNetworkController(),
   segmentInstance,
-  desktopController = getMockDesktopController(),
 } = {}) {
   return new MetaMetricsController({
     segment: segmentInstance || segment,
@@ -170,8 +151,6 @@ function getMetaMetricsController({
       },
       events: {},
     },
-    getDesktopEnabled:
-      desktopController.getDesktopEnabled.bind(desktopController),
   });
 }
 describe('MetaMetricsController', function () {
@@ -965,6 +944,7 @@ describe('MetaMetricsController', function () {
         useNftDetection: false,
         theme: 'default',
         useTokenDetection: true,
+        desktopEnabled: false,
       });
 
       assert.deepEqual(traits, {
@@ -982,6 +962,7 @@ describe('MetaMetricsController', function () {
         [TRAITS.THREE_BOX_ENABLED]: false,
         [TRAITS.THEME]: 'default',
         [TRAITS.TOKEN_DETECTION_ENABLED]: true,
+        [TRAITS.DESKTOP_ENABLED]: false,
       });
     });
 
@@ -1003,6 +984,7 @@ describe('MetaMetricsController', function () {
         useNftDetection: false,
         theme: 'default',
         useTokenDetection: true,
+        desktopEnabled: false,
       });
 
       const updatedTraits = metaMetricsController._buildUserTraitsObject({
@@ -1023,6 +1005,7 @@ describe('MetaMetricsController', function () {
         useNftDetection: false,
         theme: 'default',
         useTokenDetection: true,
+        desktopEnabled: false,
       });
 
       assert.deepEqual(updatedTraits, {
@@ -1051,6 +1034,7 @@ describe('MetaMetricsController', function () {
         useNftDetection: true,
         theme: 'default',
         useTokenDetection: true,
+        desktopEnabled: false,
       });
 
       const updatedTraits = metaMetricsController._buildUserTraitsObject({
@@ -1069,6 +1053,7 @@ describe('MetaMetricsController', function () {
         useNftDetection: true,
         theme: 'default',
         useTokenDetection: true,
+        desktopEnabled: false,
       });
 
       assert.equal(updatedTraits, null);

--- a/app/scripts/controllers/metametrics.test.js
+++ b/app/scripts/controllers/metametrics.test.js
@@ -171,7 +171,7 @@ function getMetaMetricsController({
       events: {},
     },
     getDesktopEnabled:
-    desktopController.getDesktopEnabled.bind(desktopController),
+      desktopController.getDesktopEnabled.bind(desktopController),
   });
 }
 describe('MetaMetricsController', function () {

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -434,6 +434,12 @@ export default class MetamaskController extends EventEmitter {
         getNftState: () => this.nftController.state,
       }));
 
+    ///: BEGIN:ONLY_INCLUDE_IN(desktop)
+    this.desktopController = new DesktopController({
+      initState: initState.DesktopController,
+    });
+    ///: END:ONLY_INCLUDE_IN
+
     this.metaMetricsController = new MetaMetricsController({
       segment,
       preferencesStore: this.preferencesController.store,
@@ -453,6 +459,11 @@ export default class MetamaskController extends EventEmitter {
       extension: this.extension,
       initState: initState.MetaMetricsController,
       captureException,
+      ///: BEGIN:ONLY_INCLUDE_IN(desktop)
+      getDesktopEnabled: this.desktopController.getDesktopEnabled.bind(
+        this.desktopController,
+      ),
+      ///: END:ONLY_INCLUDE_IN
     });
 
     this.on('update', (update) => {
@@ -1120,12 +1131,6 @@ export default class MetamaskController extends EventEmitter {
       },
       initState.SmartTransactionsController,
     );
-
-    ///: BEGIN:ONLY_INCLUDE_IN(desktop)
-    this.desktopController = new DesktopController({
-      initState: initState.DesktopController,
-    });
-    ///: END:ONLY_INCLUDE_IN
 
     // ensure accountTracker updates balances after network change
     this.networkController.on(NETWORK_EVENTS.NETWORK_DID_CHANGE, () => {

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -434,12 +434,6 @@ export default class MetamaskController extends EventEmitter {
         getNftState: () => this.nftController.state,
       }));
 
-    ///: BEGIN:ONLY_INCLUDE_IN(desktop)
-    this.desktopController = new DesktopController({
-      initState: initState.DesktopController,
-    });
-    ///: END:ONLY_INCLUDE_IN
-
     this.metaMetricsController = new MetaMetricsController({
       segment,
       preferencesStore: this.preferencesController.store,
@@ -459,11 +453,6 @@ export default class MetamaskController extends EventEmitter {
       extension: this.extension,
       initState: initState.MetaMetricsController,
       captureException,
-      ///: BEGIN:ONLY_INCLUDE_IN(desktop)
-      getDesktopEnabled: this.desktopController.getDesktopEnabled.bind(
-        this.desktopController,
-      ),
-      ///: END:ONLY_INCLUDE_IN
     });
 
     this.on('update', (update) => {
@@ -1131,6 +1120,12 @@ export default class MetamaskController extends EventEmitter {
       },
       initState.SmartTransactionsController,
     );
+
+    ///: BEGIN:ONLY_INCLUDE_IN(desktop)
+    this.desktopController = new DesktopController({
+      initState: initState.DesktopController,
+    });
+    ///: END:ONLY_INCLUDE_IN
 
     // ensure accountTracker updates balances after network change
     this.networkController.on(NETWORK_EVENTS.NETWORK_DID_CHANGE, () => {

--- a/shared/constants/metametrics.js
+++ b/shared/constants/metametrics.js
@@ -186,6 +186,7 @@
  * @property {'token_detection_enabled'} TOKEN_DETECTION_ENABLED - when token detection feature is toggled we
  * identify the token_detection_enabled trait
  * @property {'install_date_ext'} INSTALL_DATE_EXT - when the user installed the extension
+ * @property {'desktop_enabled'} [DESKTOP_ENABLED] - optional / does the user have desktop enabled?
  */
 
 /**
@@ -208,6 +209,7 @@ export const TRAITS = {
   THEME: 'theme',
   THREE_BOX_ENABLED: 'three_box_enabled',
   TOKEN_DETECTION_ENABLED: 'token_detection_enabled',
+  DESKTOP_ENABLED: 'desktop_enabled',
 };
 
 /**
@@ -237,6 +239,7 @@ export const TRAITS = {
  *  enabled? (deprecated)
  * @property {string} [theme] - which theme the user has selected
  * @property {boolean} [token_detection_enabled] - does the user have token detection is enabled?
+ * @property {boolean} [desktop_enabled] - optional / does the user have desktop enabled?
  */
 
 // Mixpanel converts the zero address value to a truly anonymous event, which

--- a/shared/constants/metametrics.js
+++ b/shared/constants/metametrics.js
@@ -399,6 +399,7 @@ export const EVENT = {
     SWAPS: 'Swaps',
     TRANSACTIONS: 'Transactions',
     WALLET: 'Wallet',
+    DESKTOP: 'Desktop',
   },
   EXTERNAL_LINK_TYPES: {
     TRANSACTION_BLOCK_EXPLORER: 'Transaction Block Explorer',

--- a/ui/components/app/desktop-enable-button/desktop-enable-button.component.js
+++ b/ui/components/app/desktop-enable-button/desktop-enable-button.component.js
@@ -19,6 +19,8 @@ import {
   disableDesktop,
 } from '../../../store/actions';
 import { SECOND } from '../../../../shared/constants/time';
+import { MetaMetricsContext } from '../../../contexts/metametrics';
+import { EVENT } from '../../../../shared/constants/metametrics';
 
 const DESKTOP_ERROR_DESKTOP_OUTDATED_ROUTE = `${DESKTOP_ERROR_ROUTE}/${EXTENSION_ERROR_PAGE_TYPES.DESKTOP_OUTDATED}`;
 const DESKTOP_ERROR_EXTENSION_OUTDATED_ROUTE = `${DESKTOP_ERROR_ROUTE}/${EXTENSION_ERROR_PAGE_TYPES.EXTENSION_OUTDATED}`;
@@ -30,6 +32,7 @@ export default function DesktopEnableButton() {
   const t = useContext(I18nContext);
   const dispatch = useDispatch();
   const history = useHistory();
+  const trackEvent = useContext(MetaMetricsContext);
   const showLoader = () => dispatch(showLoadingIndication());
   const hideLoader = () => dispatch(hideLoadingIndication());
   const desktopEnabled = useSelector(getIsDesktopEnabled);
@@ -81,16 +84,23 @@ export default function DesktopEnableButton() {
     history.push(DESKTOP_PAIRING_ROUTE);
   };
 
+  const getButtonText = (isDesktopEnabled) =>
+    isDesktopEnabled ? t('desktopDisableButton') : t('desktopEnableButton');
+
   return (
     <Button
       type="primary"
       large
       onClick={(event) => {
+        trackEvent({
+          category: EVENT.CATEGORIES.DESKTOP,
+          event: `${getButtonText(desktopEnabled)} Button Clicked`,
+        });
         event.preventDefault();
         onClick();
       }}
     >
-      {desktopEnabled ? t('desktopDisableButton') : t('desktopEnableButton')}
+      {getButtonText(desktopEnabled)}
     </Button>
   );
 }

--- a/ui/components/app/desktop-enable-button/desktop-enable-button.component.js
+++ b/ui/components/app/desktop-enable-button/desktop-enable-button.component.js
@@ -43,6 +43,10 @@ export default function DesktopEnableButton() {
     if (desktopEnabled) {
       await disableDesktop();
       setDesktopEnabled(false);
+      trackEvent({
+        category: EVENT.CATEGORIES.DESKTOP,
+        event: `Disable Desktop Button Clicked`,
+      });
       return;
     }
 
@@ -81,6 +85,10 @@ export default function DesktopEnableButton() {
       return;
     }
 
+    trackEvent({
+      category: EVENT.CATEGORIES.DESKTOP,
+      event: `Enable Desktop Button Clicked`,
+    });
     history.push(DESKTOP_PAIRING_ROUTE);
   };
 
@@ -92,10 +100,6 @@ export default function DesktopEnableButton() {
       type="primary"
       large
       onClick={(event) => {
-        trackEvent({
-          category: EVENT.CATEGORIES.DESKTOP,
-          event: `${getButtonText(desktopEnabled)} Button Clicked`,
-        });
         event.preventDefault();
         onClick();
       }}

--- a/ui/components/app/desktop-enable-button/desktop-enable-button.component.js
+++ b/ui/components/app/desktop-enable-button/desktop-enable-button.component.js
@@ -27,6 +27,7 @@ const DESKTOP_ERROR_EXTENSION_OUTDATED_ROUTE = `${DESKTOP_ERROR_ROUTE}/${EXTENSI
 const DESKTOP_ERROR_NOT_FOUND_ROUTE = `${DESKTOP_ERROR_ROUTE}/${EXTENSION_ERROR_PAGE_TYPES.NOT_FOUND}`;
 const DESKTOP_ERROR_PAIRING_KEY_NOT_MATCH_ROUTE = `${DESKTOP_ERROR_ROUTE}/${EXTENSION_ERROR_PAGE_TYPES.PAIRING_KEY_NOT_MATCH}`;
 const SKIP_PAIRING_RESTART_DELAY = 2 * SECOND;
+const DESKTOP_UPDATE_SETTINGS_EVENT = 'Settings Updated';
 
 export default function DesktopEnableButton() {
   const t = useContext(I18nContext);
@@ -45,7 +46,10 @@ export default function DesktopEnableButton() {
       setDesktopEnabled(false);
       trackEvent({
         category: EVENT.CATEGORIES.DESKTOP,
-        event: `Disable Desktop Button Clicked`,
+        event: DESKTOP_UPDATE_SETTINGS_EVENT,
+        properties: {
+          desktop_enabled: false,
+        },
       });
       return;
     }
@@ -87,7 +91,10 @@ export default function DesktopEnableButton() {
 
     trackEvent({
       category: EVENT.CATEGORIES.DESKTOP,
-      event: `Enable Desktop Button Clicked`,
+      event: 'Desktop Button Clicked',
+      properties: {
+        button_action: 'Enable MetaMask Desktop',
+      },
     });
     history.push(DESKTOP_PAIRING_ROUTE);
   };

--- a/ui/pages/desktop-error/desktop-error.component.js
+++ b/ui/pages/desktop-error/desktop-error.component.js
@@ -1,4 +1,5 @@
 import { useParams, useHistory } from 'react-router-dom';
+import { useContext } from 'react';
 import { useI18nContext } from '../../hooks/useI18nContext';
 import {
   downloadDesktopApp,
@@ -6,12 +7,14 @@ import {
   restartExtension,
 } from '../../../shared/lib/error-utils';
 import { DEFAULT_ROUTE } from '../../helpers/constants/routes';
+import { MetaMetricsContext } from '../../contexts/metametrics';
 import { renderDesktopError } from './render-desktop-error';
 
 export default function DesktopError({ forceDisableDesktop }) {
   const t = useI18nContext();
   const { errorType } = useParams();
   const history = useHistory();
+  const trackEvent = useContext(MetaMetricsContext);
 
   return renderDesktopError({
     type: errorType,
@@ -25,5 +28,6 @@ export default function DesktopError({ forceDisableDesktop }) {
     downloadDesktopApp,
     downloadExtension,
     restartExtension,
+    trackEvent,
   });
 }

--- a/ui/pages/desktop-error/render-desktop-error.js
+++ b/ui/pages/desktop-error/render-desktop-error.js
@@ -16,6 +16,7 @@ import Typography from '../../components/ui/typography';
 import Button from '../../components/ui/button';
 import Box from '../../components/ui/box';
 import { openCustomProtocol } from '../../../shared/lib/deep-linking';
+import { EVENT } from '../../../shared/constants/metametrics';
 
 export function renderDesktopError({
   type,
@@ -27,6 +28,7 @@ export function renderDesktopError({
   downloadDesktopApp,
   restartExtension,
   openOrDownloadDesktopApp,
+  trackEvent,
 }) {
   let content;
 
@@ -43,6 +45,12 @@ export function renderDesktopError({
   };
 
   const renderHeader = (text) => {
+    if (typeof trackEvent === 'function') {
+      trackEvent({
+        category: EVENT.CATEGORIES.ERROR,
+        event: `Error: ${text}`,
+      });
+    }
     return (
       <Typography
         variant={TypographyVariant.H4}
@@ -64,7 +72,23 @@ export function renderDesktopError({
   const renderCTA = (id, text, onClick) => {
     return (
       <Box marginTop={6}>
-        <Button type="primary" onClick={onClick ?? noop} id={id}>
+        <Button
+          type="primary"
+          onClick={() => {
+            if (onClick) {
+              onClick();
+              if (typeof trackEvent === 'function') {
+                trackEvent({
+                  category: EVENT.CATEGORIES.DESKTOP,
+                  event: `${text} Button Clicked`,
+                });
+              }
+            } else {
+              noop();
+            }
+          }}
+          id={id}
+        >
           {text}
         </Button>
       </Box>

--- a/ui/pages/desktop-error/render-desktop-error.js
+++ b/ui/pages/desktop-error/render-desktop-error.js
@@ -32,6 +32,17 @@ export function renderDesktopError({
 }) {
   let content;
 
+  const DESKTOP_ERROR_BUTTON_DOWNLOAD_ID = 'desktop-error-button-download-mmd';
+  const DESKTOP_ERROR_BUTTON_OPEN_OR_DOWNLOAD_ID =
+    'desktop-error-button-open-or-download-mmd';
+  const DESKTOP_ERROR_BUTTON_DISABLE_ID = 'desktop-error-button-disable-mmd';
+  const DESKTOP_ERROR_BUTTON_UPDATE_ID = 'desktop-error-button-update-mmd';
+  const DESKTOP_ERROR_BUTTON_NAVIGATE_SETTINGS_ID =
+    'desktop-error-button-navigate-settings';
+  const DESKTOP_ERROR_BUTTON_UPDATE_EXTENSION_ID =
+    'desktop-error-button-update-extension';
+  const DESKTOP_ERROR_BUTTON_RESTART_ID = 'desktop-error-button-restart-mm';
+
   const noop = () => {
     // do nothing
   };
@@ -63,6 +74,37 @@ export function renderDesktopError({
     );
   };
 
+  const getEventNameById = (id) => {
+    let eventName;
+    switch (id) {
+      case DESKTOP_ERROR_BUTTON_DOWNLOAD_ID:
+        eventName = 'Download MetaMask Desktop';
+        break;
+      case DESKTOP_ERROR_BUTTON_OPEN_OR_DOWNLOAD_ID:
+        eventName = 'Open MetaMask Desktop';
+        break;
+      case DESKTOP_ERROR_BUTTON_DISABLE_ID:
+        eventName = 'Disable MetaMask Desktop';
+        break;
+      case DESKTOP_ERROR_BUTTON_UPDATE_ID:
+        eventName = 'Update MetaMask Desktop';
+        break;
+      case DESKTOP_ERROR_BUTTON_NAVIGATE_SETTINGS_ID:
+        eventName = 'Return to Settings Page';
+        break;
+      case DESKTOP_ERROR_BUTTON_UPDATE_EXTENSION_ID:
+        eventName = 'Update MetaMask Extension';
+        break;
+      case DESKTOP_ERROR_BUTTON_RESTART_ID:
+        eventName = 'Restart MetaMask';
+        break;
+      default:
+        eventName = 'Return MetaMask Home';
+        break;
+    }
+    return eventName;
+  };
+
   const renderCTA = (id, text, onClick) => {
     return (
       <Box marginTop={6}>
@@ -74,7 +116,7 @@ export function renderDesktopError({
               if (typeof trackEvent === 'function') {
                 trackEvent({
                   category: EVENT.CATEGORIES.DESKTOP,
-                  event: `${text} Button Clicked`,
+                  event: `${getEventNameById(id)} Button Clicked`,
                 });
               }
             } else {
@@ -103,7 +145,7 @@ export function renderDesktopError({
           {renderDescription(t('desktopNotFoundErrorDescription1'))}
           {renderDescription(t('desktopNotFoundErrorDescription2'))}
           {renderCTA(
-            'desktop-error-button-download-mmd',
+            DESKTOP_ERROR_BUTTON_DOWNLOAD_ID,
             t('desktopNotFoundErrorCTA'),
             downloadDesktopApp,
           )}
@@ -117,12 +159,12 @@ export function renderDesktopError({
           {renderHeader(t('desktopConnectionLostErrorTitle'))}
           {renderDescription(t('desktopConnectionLostErrorDescription'))}
           {renderCTA(
-            'desktop-error-button-open-or-download-mmd',
+            DESKTOP_ERROR_BUTTON_OPEN_OR_DOWNLOAD_ID,
             t('desktopOpenOrDownloadCTA'),
             openOrDownloadDesktopApp,
           )}
           {renderCTA(
-            'desktop-error-button-disable-mmd',
+            DESKTOP_ERROR_BUTTON_DISABLE_ID,
             t('desktopDisableErrorCTA'),
             disableDesktop,
           )}
@@ -136,7 +178,7 @@ export function renderDesktopError({
           {renderHeader(t('desktopOutdatedErrorTitle'))}
           {renderDescription(t('desktopOutdatedErrorDescription'))}
           {renderCTA(
-            'desktop-error-button-update-mmd',
+            DESKTOP_ERROR_BUTTON_UPDATE_ID,
             t('desktopOutdatedErrorCTA'),
             downloadDesktopApp,
           )}
@@ -150,7 +192,7 @@ export function renderDesktopError({
           {renderHeader(t('desktopOutdatedExtensionErrorTitle'))}
           {renderDescription(t('desktopOutdatedExtensionErrorDescription'))}
           {renderCTA(
-            'desktop-error-button-update-extension',
+            DESKTOP_ERROR_BUTTON_UPDATE_EXTENSION_ID,
             t('desktopOutdatedExtensionErrorCTA'),
             downloadExtension,
           )}
@@ -164,12 +206,12 @@ export function renderDesktopError({
           {renderHeader(t('desktopConnectionCriticalErrorTitle'))}
           {renderDescription(t('desktopConnectionCriticalErrorDescription'))}
           {renderCTA(
-            'desktop-error-button-restart-mm',
+            DESKTOP_ERROR_BUTTON_RESTART_ID,
             t('desktopErrorRestartMMCTA'),
             restartExtension,
           )}
           {renderCTA(
-            'desktop-error-button-disable-mmd',
+            DESKTOP_ERROR_BUTTON_DISABLE_ID,
             t('desktopDisableErrorCTA'),
             disableDesktop,
           )}
@@ -185,7 +227,7 @@ export function renderDesktopError({
           {renderHeader(t('desktopRouteNotFoundErrorTitle'))}
           {renderDescription(t('desktopRouteNotFoundErrorDescription'))}
           {renderCTA(
-            'desktop-error-button-navigate-settings',
+            DESKTOP_ERROR_BUTTON_NAVIGATE_SETTINGS_ID,
             t('desktopErrorNavigateSettingsCTA'),
             navigateSettings,
           )}
@@ -209,7 +251,7 @@ export function renderDesktopError({
             {t('desktopPairedWarningDeepLink')}
           </Button>
           {renderCTA(
-            'desktop-error-button-navigate-settings',
+            DESKTOP_ERROR_BUTTON_NAVIGATE_SETTINGS_ID,
             t('desktopErrorNavigateSettingsCTA'),
             navigateSettings,
           )}

--- a/ui/pages/desktop-error/render-desktop-error.js
+++ b/ui/pages/desktop-error/render-desktop-error.js
@@ -32,16 +32,16 @@ export function renderDesktopError({
 }) {
   let content;
 
-  const DESKTOP_ERROR_BUTTON_DOWNLOAD_ID = 'desktop-error-button-download-mmd';
-  const DESKTOP_ERROR_BUTTON_OPEN_OR_DOWNLOAD_ID =
-    'desktop-error-button-open-or-download-mmd';
-  const DESKTOP_ERROR_BUTTON_DISABLE_ID = 'desktop-error-button-disable-mmd';
-  const DESKTOP_ERROR_BUTTON_UPDATE_ID = 'desktop-error-button-update-mmd';
-  const DESKTOP_ERROR_BUTTON_NAVIGATE_SETTINGS_ID =
-    'desktop-error-button-navigate-settings';
-  const DESKTOP_ERROR_BUTTON_UPDATE_EXTENSION_ID =
-    'desktop-error-button-update-extension';
-  const DESKTOP_ERROR_BUTTON_RESTART_ID = 'desktop-error-button-restart-mm';
+  const DESKTOP_BUTTON_ACTIONS = {
+    DOWNLOAD_METAMASK_DESKTOP: 'Download MetaMask Desktop',
+    OPEN_METAMASK_DESKTOP: 'Open MetaMask Desktop',
+    DISABLE_METAMASK_DESKTOP: 'Disable MetaMask Desktop',
+    UPDATE_METAMASK_DESKTOP: 'Update MetaMask Desktop',
+    RETURN_SETTINGS_PAGE: 'Return to Settings Page',
+    UPDATE_METAMASK_EXTENSION: 'Update MetaMask Extension',
+    RESTART_METAMASK: 'Restart MetaMask',
+    RETURN_METAMASK_HOME: 'Return MetaMask Home',
+  };
 
   const noop = () => {
     // do nothing
@@ -74,38 +74,7 @@ export function renderDesktopError({
     );
   };
 
-  const getEventNameById = (id) => {
-    let eventName;
-    switch (id) {
-      case DESKTOP_ERROR_BUTTON_DOWNLOAD_ID:
-        eventName = 'Download MetaMask Desktop';
-        break;
-      case DESKTOP_ERROR_BUTTON_OPEN_OR_DOWNLOAD_ID:
-        eventName = 'Open MetaMask Desktop';
-        break;
-      case DESKTOP_ERROR_BUTTON_DISABLE_ID:
-        eventName = 'Disable MetaMask Desktop';
-        break;
-      case DESKTOP_ERROR_BUTTON_UPDATE_ID:
-        eventName = 'Update MetaMask Desktop';
-        break;
-      case DESKTOP_ERROR_BUTTON_NAVIGATE_SETTINGS_ID:
-        eventName = 'Return to Settings Page';
-        break;
-      case DESKTOP_ERROR_BUTTON_UPDATE_EXTENSION_ID:
-        eventName = 'Update MetaMask Extension';
-        break;
-      case DESKTOP_ERROR_BUTTON_RESTART_ID:
-        eventName = 'Restart MetaMask';
-        break;
-      default:
-        eventName = 'Return MetaMask Home';
-        break;
-    }
-    return eventName;
-  };
-
-  const renderCTA = (id, text, onClick) => {
+  const renderCTA = (id, text, onClick, action) => {
     return (
       <Box marginTop={6}>
         <Button
@@ -116,7 +85,10 @@ export function renderDesktopError({
               if (typeof trackEvent === 'function') {
                 trackEvent({
                   category: EVENT.CATEGORIES.DESKTOP,
-                  event: `${getEventNameById(id)} Button Clicked`,
+                  event: 'Desktop Button Clicked',
+                  properties: {
+                    button_action: action,
+                  },
                 });
               }
             } else {
@@ -145,9 +117,10 @@ export function renderDesktopError({
           {renderDescription(t('desktopNotFoundErrorDescription1'))}
           {renderDescription(t('desktopNotFoundErrorDescription2'))}
           {renderCTA(
-            DESKTOP_ERROR_BUTTON_DOWNLOAD_ID,
+            'desktop-error-button-download-mmd',
             t('desktopNotFoundErrorCTA'),
             downloadDesktopApp,
+            DESKTOP_BUTTON_ACTIONS.DOWNLOAD_METAMASK_DESKTOP,
           )}
         </>
       );
@@ -159,14 +132,15 @@ export function renderDesktopError({
           {renderHeader(t('desktopConnectionLostErrorTitle'))}
           {renderDescription(t('desktopConnectionLostErrorDescription'))}
           {renderCTA(
-            DESKTOP_ERROR_BUTTON_OPEN_OR_DOWNLOAD_ID,
+            'desktop-error-button-open-or-download-mmd',
             t('desktopOpenOrDownloadCTA'),
             openOrDownloadDesktopApp,
           )}
           {renderCTA(
-            DESKTOP_ERROR_BUTTON_DISABLE_ID,
+            'desktop-error-button-disable-mmd',
             t('desktopDisableErrorCTA'),
             disableDesktop,
+            DESKTOP_BUTTON_ACTIONS.DISABLE_METAMASK_DESKTOP,
           )}
         </>
       );
@@ -178,9 +152,10 @@ export function renderDesktopError({
           {renderHeader(t('desktopOutdatedErrorTitle'))}
           {renderDescription(t('desktopOutdatedErrorDescription'))}
           {renderCTA(
-            DESKTOP_ERROR_BUTTON_UPDATE_ID,
+            'desktop-error-button-update-mmd',
             t('desktopOutdatedErrorCTA'),
             downloadDesktopApp,
+            DESKTOP_BUTTON_ACTIONS.UPDATE_METAMASK_DESKTOP,
           )}
         </>
       );
@@ -192,9 +167,10 @@ export function renderDesktopError({
           {renderHeader(t('desktopOutdatedExtensionErrorTitle'))}
           {renderDescription(t('desktopOutdatedExtensionErrorDescription'))}
           {renderCTA(
-            DESKTOP_ERROR_BUTTON_UPDATE_EXTENSION_ID,
+            'desktop-error-button-update-extension',
             t('desktopOutdatedExtensionErrorCTA'),
             downloadExtension,
+            DESKTOP_BUTTON_ACTIONS.UPDATE_METAMASK_EXTENSION,
           )}
         </>
       );
@@ -206,14 +182,16 @@ export function renderDesktopError({
           {renderHeader(t('desktopConnectionCriticalErrorTitle'))}
           {renderDescription(t('desktopConnectionCriticalErrorDescription'))}
           {renderCTA(
-            DESKTOP_ERROR_BUTTON_RESTART_ID,
+            'desktop-error-button-restart-mm',
             t('desktopErrorRestartMMCTA'),
             restartExtension,
+            DESKTOP_BUTTON_ACTIONS.RESTART_METAMASK,
           )}
           {renderCTA(
-            DESKTOP_ERROR_BUTTON_DISABLE_ID,
+            'desktop-error-button-disable-mmd',
             t('desktopDisableErrorCTA'),
             disableDesktop,
+            DESKTOP_BUTTON_ACTIONS.DISABLE_METAMASK_DESKTOP,
           )}
         </>
       );
@@ -227,9 +205,10 @@ export function renderDesktopError({
           {renderHeader(t('desktopRouteNotFoundErrorTitle'))}
           {renderDescription(t('desktopRouteNotFoundErrorDescription'))}
           {renderCTA(
-            DESKTOP_ERROR_BUTTON_NAVIGATE_SETTINGS_ID,
+            'desktop-error-button-navigate-settings',
             t('desktopErrorNavigateSettingsCTA'),
             navigateSettings,
+            DESKTOP_BUTTON_ACTIONS.RETURN_SETTINGS_PAGE,
           )}
         </>
       );
@@ -251,9 +230,10 @@ export function renderDesktopError({
             {t('desktopPairedWarningDeepLink')}
           </Button>
           {renderCTA(
-            DESKTOP_ERROR_BUTTON_NAVIGATE_SETTINGS_ID,
+            'desktop-error-button-navigate-settings',
             t('desktopErrorNavigateSettingsCTA'),
             navigateSettings,
+            DESKTOP_BUTTON_ACTIONS.RETURN_SETTINGS_PAGE,
           )}
         </>
       );
@@ -268,6 +248,7 @@ export function renderDesktopError({
             'desktop-error-button-return-mm-home',
             t('desktopUnexpectedErrorCTA'),
             returnExtensionHome,
+            DESKTOP_BUTTON_ACTIONS.RETURN_METAMASK_HOME,
           )}
         </>
       );

--- a/ui/pages/desktop-error/render-desktop-error.js
+++ b/ui/pages/desktop-error/render-desktop-error.js
@@ -45,12 +45,6 @@ export function renderDesktopError({
   };
 
   const renderHeader = (text) => {
-    if (typeof trackEvent === 'function') {
-      trackEvent({
-        category: EVENT.CATEGORIES.ERROR,
-        event: `Error: ${text}`,
-      });
-    }
     return (
       <Typography
         variant={TypographyVariant.H4}


### PR DESCRIPTION
## Explanation

Adds the metrics code needed to support tracking usage of the [MetaMask Desktop](https://github.com/MetaMask/metamask-desktop) app.

The aim of this PR is to identify if the desktop app is paired with the extension on MetaMetrics to track key operations such as swaps, snaps, transfers, and interaction with dapps. It also includes desktop-related events.

Changes include:
-   `metametrics`: included `desktop_enabled` in traits to identify whenever the user pairs/unpairs the extension and the desktop app.
-  UI changes to emit desktop-related events whenever a button is clicked
    -   Included a new event category `DESKTOP`


## Manual Testing Steps

- Setup Segment following: https://github.com/MetaMask/metamask-extension/blob/develop/development/README.md#segment
- Build the extension for desktop build type - yarn start --build-type desktop
- Navigate to settings->experimental
- Click on enable desktop button
- Once the desktop is paired, perform a transfer (any key operation)
- Check on the segment if identify was triggered with the `desktop_enabled: true`  
Example:
```
analytics.identify({
  userId: '0x',
  traits: {
    desktop_enabled: true,
  }
});
```

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
