### PR TITLE
UX: Icon: Remove unwanted aria label

### DIFF
--- a/ui/components/app/account-menu/account-menu.component.js
+++ b/ui/components/app/account-menu/account-menu.component.js
@@ -374,7 +374,6 @@ export default class AccountMenu extends Component {
             <Icon
               name={ICON_NAMES.ADD}
               color={IconColor.iconAlternative}
-              ariaLabel={t('createAccount')}
             />
           }
           text={t('createAccount')}

--- a/ui/components/app/account-menu/account-menu.component.js
+++ b/ui/components/app/account-menu/account-menu.component.js
@@ -371,10 +371,7 @@ export default class AccountMenu extends Component {
             history.push(NEW_ACCOUNT_ROUTE);
           }}
           icon={
-            <Icon
-              name={ICON_NAMES.ADD}
-              color={IconColor.iconAlternative}
-            />
+            <Icon name={ICON_NAMES.ADD} color={IconColor.iconAlternative} />
           }
           text={t('createAccount')}
         />


### PR DESCRIPTION
## Explanation

George brought to our attention that this attribute isn't needed on `<Icon>`, so removing it to the one place it was being used.


## Pre-merge author checklist

- [ ] I've clearly explained:
  - [ ] What problem this PR is solving
  - [ ] How this problem was solved
  - [ ] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
