### PR TITLE
Fixing FormTextField test

### DIFF
--- a/ui/components/component-library/text-field/text-field.test.js
+++ b/ui/components/component-library/text-field/text-field.test.js
@@ -1,5 +1,6 @@
 /* eslint-disable jest/require-top-level-describe */
 import React from 'react';
+import PropTypes from 'prop-types';
 import { fireEvent, render } from '@testing-library/react';
 import { renderWithUserEvent } from '../../../../test/lib/render-helpers';
 
@@ -227,9 +228,19 @@ describe('TextField', () => {
     expect(getByTestId('text-field-required')).toHaveAttribute('required', '');
   });
   it('should render with a custom input and still work', async () => {
-    const CustomInputComponent = React.forwardRef((props, ref) => (
-      <Box ref={ref} as="input" {...props} />
-    ));
+    const CustomInputComponent = React.forwardRef(
+      ({ disableStateStyles, ...props }, ref) => (
+        <Box
+          ref={ref}
+          as="input"
+          {...props}
+          placeholder={`Removing ${disableStateStyles} from ...props spread to prevent error in test`}
+        />
+      ),
+    );
+    CustomInputComponent.propTypes = {
+      disableStateStyles: PropTypes.bool,
+    };
     CustomInputComponent.displayName = 'CustomInputComponent'; // fixes eslint error
     const { getByTestId, user } = renderWithUserEvent(
       <TextField


### PR DESCRIPTION
## Explanation
A test was creating an error in the console in FormTextField

## Screenshots/Screencaps

### Before 

<img width="772" alt="Screenshot 2023-02-28 at 4 46 00 PM" src="https://user-images.githubusercontent.com/8112138/222016223-82f2422b-33ec-4103-add2-df9bc9871e43.png">

![Screenshot 2023-02-28 at 4 45 13 PM](https://user-images.githubusercontent.com/8112138/222016065-15a729f4-3f62-4151-9b58-2b4e875aefeb.png)

![Screenshot 2023-02-28 at 4 44 33 PM](https://user-images.githubusercontent.com/8112138/222015985-637a7d53-f266-481e-8a96-f027a634df79.png)

### After

<img width="1052" alt="Screenshot 2023-02-28 at 4 42 01 PM" src="https://user-images.githubusercontent.com/8112138/222015835-c01b07af-c43d-45a2-8cdc-dc8332d1de17.png">

Tests are fixed

![Screenshot 2023-02-28 at 4 48 30 PM](https://user-images.githubusercontent.com/8112138/222016471-8f35d22e-2b35-471f-a2c2-02872437604f.png)


## Manual Testing Steps

- Go to the storybook build on this branch
- Search `FormTextField` in the search bar
- Check HelpText story works with `error` or use the controls to turn error on while there is some HelpText

For tests check the CI unit test build or pull this branch and run 
```
yarn jest ui/components/component-library
```
And check the console is all greeeen 🍏 📗 🟢 

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
