### PR TITLE
fix issue with fragment messageIds

### DIFF
--- a/app/scripts/controllers/metametrics.js
+++ b/app/scripts/controllers/metametrics.js
@@ -356,7 +356,14 @@ export default class MetaMetricsController {
       currency: fragment.currency,
       environmentType: fragment.environmentType,
       actionId: fragment.actionId,
-      uniqueIdentifier: fragment.uniqueIdentifier,
+      // We append success or failure to the unique-identifier so that the
+      // messageId can still be idempotent, but so that it differs from the
+      // initial event fired. The initial event was preventing new events from
+      // making it to mixpanel because they were using the same unique ID as
+      // the events processed in other parts of the fragment lifecycle.
+      uniqueIdentifier: fragment.uniqueIdentifier
+        ? `${fragment.uniqueIdentifier}-${abandoned ? 'failure' : 'success'}`
+        : undefined,
     });
     const { fragments } = this.store.getState();
     delete fragments[id];

--- a/app/scripts/controllers/metametrics.test.js
+++ b/app/scripts/controllers/metametrics.test.js
@@ -119,6 +119,7 @@ const SAMPLE_NON_PERSISTED_EVENT = {
   category: 'Unit Test',
   successEvent: 'sample non-persisted event success',
   failureEvent: 'sample non-persisted event failure',
+  uniqueIdentifier: 'sample-non-persisted-event',
   properties: {
     test: true,
   },
@@ -175,7 +176,7 @@ describe('MetaMetricsController', function () {
             ...DEFAULT_EVENT_PROPERTIES,
             test: true,
           },
-          messageId: Utils.generateRandomId(),
+          messageId: 'sample-non-persisted-event-failure',
           timestamp: new Date(),
         });
       const metaMetricsController = getMetaMetricsController();


### PR DESCRIPTION
## Explanation
@worldlyjohn recently pointed out that the recent fix for message ids for transaction events was only partially successful. The reason for this is because when we provide a unique identifier for a fragment, which we do for our transacation fragments, that unique identifier is used in all events tracked from that fragment. We have two fragments for transaction events:

1. Initial: Transaction Added -> Success: Transaction Approved -> failure: Transaction Rejected
2. initial: Transaction Submitted -> Success: Transaction Finalized (no failure event) 

The initial events were both fixed with the last change, but the problem is the fragment's unique identifier is static for each of those chains... and so segment would view the success or failure events as duplications.

This PR simply adds a -success or -failure modifier to the uniqueIdentifier we pass to trackEvent internally so that it can modify the messageId. A test was updated to capture this change, but I noticed a few things when adding tests:

1. The tests are *brittle* and the frequent creation of a spy for the trackEvent method seems to not be being reset / restored between tests.
2. There are no tests at all for creating event fragments, just one for finalizing a fragment already in state and one for finalizing as a result of rebooting the controller for a non persisted fragment. 

We should fix these, but not here. 

## Manual Testing Steps
1. On develop run `yarn start`
2. Make sure you have a segment write key set in .metamaskrc and you are opted into metrics
3. Inspect background process' network tab
4. Initialize a send and get to confirmation screen.
5. View 'batch' entries in network tab and look at payload, see the messageId is something like 'transaction-added-{transactionId}{actionId}-0x000' (there should be two, one with 0x000 and one without)
6. Hit confirm and inspect batch entries, see that the messageId for the 'transaction approved' event is still 'transaction-added-{transactionId}-{actionId}-0x000'

repeat steps on this branch, but the last messageId would be 'transaction-added-success-{transactionId}-{actionId}-0x000' instead.

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
