### PR TITLE
fix keeping the wallet unlocked after service worker restarted more than once

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -2598,7 +2598,9 @@ export default class MetamaskController extends EventEmitter {
       if (loginToken && loginSalt) {
         const { vault } = this.keyringController.store.getState();
 
-        if (vault.salt !== loginSalt) {
+        const jsonVault = JSON.parse(vault);
+
+        if (jsonVault.salt !== loginSalt) {
           console.warn(
             'submitEncryptionKey: Stored salt and vault salt do not match',
           );


### PR DESCRIPTION
## Explanation

We want to keep the wallet unlocked when a service worker restarts.

In `submitEncryptionKey` on the `metamask-controller.js`, the vault is a string, not an object. So to correctly compare the salt, we need to parse that string into JSON.

Note that this PR does not fix the first time the service worker is restarted after a fresh wallet is loaded and the onboarding flow is complete. This will be fixed in a separate PR. However, in any number of subsequent restarts, the unlock state is now persisted.

For context, this was [previously addressed](https://github.com/MetaMask/metamask-extension/pull/15558), but the wallet was still locked after a long enough waiting period after the service worker restarted. [Another PR](https://github.com/MetaMask/metamask-extension/pull/16559) merged immediately after made the wallet lock more immediate.

## Manual Testing Steps

1. Build the wallet from develop

`git checkout develop && git pull && yarn && yarn:start:mv3`

2. Load the wallet in the browser and complete the onboarding flow

3. Terminate the service worker using `chrome://inspect/#service-workers`. 

4. The wallet should lock after a couple of seconds.

5. Input the password and unlock the wallet

6. Terminate the service worker again (repeat step 3)

7. The wallet should lock after a couple of seconds.

9. Build the wallet from this branch

`git checkout fix/keep-user-login && git pull && yarn && yarn:start:mv3`

10. Load the wallet in the browser and complete the onboarding flow

11. Terminate the service worker using `chrome://inspect/#service-workers`. 

12. The wallet should lock after a couple of seconds.

13. Input the password and unlock the wallet

14. Terminate the service worker again (repeat step 11)

15. The wallet should remain unlocked.


## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
