### PR TITLE
Part of #17670: Replace Typography with Text component

### DIFF
--- a/ui/components/app/confirm-page-container/confirm-page-container-content/confirm-page-container-summary/confirm-page-container-summary.component.js
+++ b/ui/components/app/confirm-page-container/confirm-page-container-content/confirm-page-container-summary/confirm-page-container-summary.component.js
@@ -14,8 +14,8 @@ import { getIpfsGateway } from '../../../../../selectors';
 import Identicon from '../../../../ui/identicon';
 import InfoTooltip from '../../../../ui/info-tooltip';
 import NicknamePopovers from '../../../modals/nickname-popovers';
-import { Text } from '../../component-library'
-import { TextVariant } from '../../../helpers/constants/design-system'
+import { Text } from '../../../../component-library';
+import { TextVariant } from '../../../../../helpers/constants/design-system';
 import { ORIGIN_METAMASK } from '../../../../../../shared/constants/app';
 import SiteOrigin from '../../../../ui/site-origin';
 import { getAssetImageURL } from '../../../../../helpers/utils/util';
@@ -138,7 +138,7 @@ const ConfirmPageContainerSummary = (props) => {
                   ? TextVariant.displayMd
                   : TextVariant.headingMd
               }
-              as={ title && title.length < 10 ? "h1" : "h3"}
+              as={title && title.length < 10 ? 'h1' : 'h3'}
               title={title}
             >
               {titleComponent || title}

--- a/ui/components/app/confirm-page-container/confirm-page-container-content/confirm-page-container-summary/confirm-page-container-summary.component.js
+++ b/ui/components/app/confirm-page-container/confirm-page-container-content/confirm-page-container-summary/confirm-page-container-summary.component.js
@@ -14,8 +14,8 @@ import { getIpfsGateway } from '../../../../../selectors';
 import Identicon from '../../../../ui/identicon';
 import InfoTooltip from '../../../../ui/info-tooltip';
 import NicknamePopovers from '../../../modals/nickname-popovers';
-import Typography from '../../../../ui/typography';
-import { TypographyVariant } from '../../../../../helpers/constants/design-system';
+import { Text } from '../../component-library'
+import { TextVariant } from '../../../helpers/constants/design-system'
 import { ORIGIN_METAMASK } from '../../../../../../shared/constants/app';
 import SiteOrigin from '../../../../ui/site-origin';
 import { getAssetImageURL } from '../../../../../helpers/utils/util';
@@ -131,17 +131,18 @@ const ConfirmPageContainerSummary = (props) => {
         <div className="confirm-page-container-summary__title">
           {renderImage()}
           {!hideTitle ? (
-            <Typography
+            <Text
               className="confirm-page-container-summary__title-text"
               variant={
                 title && title.length < 10
-                  ? TypographyVariant.H1
-                  : TypographyVariant.H3
+                  ? TextVariant.displayMd
+                  : TextVariant.headingMd
               }
+              as={ title && title.length < 10 ? "h1" : "h3"}
               title={title}
             >
               {titleComponent || title}
-            </Typography>
+            </Text>
           ) : null}
         </div>
         {hideSubtitle ? null : (

--- a/ui/components/app/confirm-page-container/confirm-page-container-content/confirm-page-container-summary/confirm-page-container-summary.stories.js
+++ b/ui/components/app/confirm-page-container/confirm-page-container-content/confirm-page-container-summary/confirm-page-container-summary.stories.js
@@ -2,7 +2,8 @@ import React from 'react';
 import ConfirmPageContainerSummary from '.';
 
 export default {
-  title: 'Components/UI/ConfirmPageContainerSummary', // title should follow the folder structure location of the component. Don't use spaces.
+  title:
+    'Components/App/ConfirmPageContainer/ConfirmPageContainerContent/ConfirmPageContainerSummary',
   argTypes: {
     action: {
       control: 'text',

--- a/ui/components/app/confirm-page-container/confirm-page-container-content/confirm-page-container-summary/confirm-page-container-summary.stories.js
+++ b/ui/components/app/confirm-page-container/confirm-page-container-content/confirm-page-container-summary/confirm-page-container-summary.stories.js
@@ -1,0 +1,64 @@
+import React from 'react';
+import ConfirmPageContainerSummary from '.';
+
+export default {
+  title: 'Components/UI/ConfirmPageContainerSummary', // title should follow the folder structure location of the component. Don't use spaces.
+  argTypes: {
+    action: {
+      control: 'text',
+    },
+    title: {
+      control: 'text',
+    },
+    image: {
+      control: 'text',
+    },
+    titleComponent: {
+      control: 'text',
+    },
+    subtitleComponent: {
+      control: 'text',
+    },
+    hideSubtitle: {
+      control: 'boolean',
+    },
+    className: {
+      control: 'text',
+    },
+    tokenAddress: {
+      control: 'text',
+    },
+    toAddress: {
+      control: 'text',
+    },
+    nonce: {
+      control: 'text',
+    },
+    origin: {
+      control: 'text',
+    },
+    hideTitle: {
+      control: 'boolean',
+    },
+    transactionType: {
+      control: 'text',
+    },
+  },
+  args: {
+    action: 'action',
+    title: 'title',
+    titleComponent: 'titleComponent',
+    subtitleComponent: 'subtitleComponent',
+    className: 'className',
+    tokenAddress: '0x2170ed0880ac9a755fd29b2688956bd959f933f8',
+    toAddress: '0x2170ed0880ac9a755fd29b2688956bd959f933f8',
+    nonce: 'nonce',
+    origin: 'origin',
+    hideTitle: 'hideTitle',
+    transactionType: 'transactionType',
+  },
+};
+
+export const DefaultStory = (args) => <ConfirmPageContainerSummary {...args} />;
+
+DefaultStory.storyName = 'Default';

--- a/ui/components/app/confirm-page-container/flask/snap-insight.js
+++ b/ui/components/app/confirm-page-container/flask/snap-insight.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import Preloader from '../../../ui/icon/preloader/preloader-icon.component';
-import { Text } from '../../component-library'
+import { Text } from '../../../component-library';
 import {
   AlignItems,
   FLEX_DIRECTION,

--- a/ui/components/app/confirm-page-container/flask/snap-insight.js
+++ b/ui/components/app/confirm-page-container/flask/snap-insight.js
@@ -2,14 +2,14 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import Preloader from '../../../ui/icon/preloader/preloader-icon.component';
-import Typography from '../../../ui/typography/typography';
+import { Text } from '../../component-library'
 import {
   AlignItems,
   FLEX_DIRECTION,
   JustifyContent,
   TEXT_ALIGN,
   TextColor,
-  TypographyVariant,
+  TextVariant,
 } from '../../../../helpers/constants/design-system';
 import { useI18nContext } from '../../../../hooks/useI18nContext';
 import { useTransactionInsightSnap } from '../../../../hooks/flask/useTransactionInsightSnap';
@@ -54,12 +54,13 @@ export const SnapInsight = ({ transaction, origin, chainId, selectedSnap }) => {
           {data && Object.keys(data).length > 0 ? (
             <SnapUIRenderer snapId={selectedSnap.id} data={data} />
           ) : (
-            <Typography
+            <Text
               color={TextColor.textAlternative}
-              variant={TypographyVariant.H6}
+              variant={TextVariant.bodySm}
+              as="h6"
             >
               {t('snapsNoInsight')}
-            </Typography>
+            </Text>
           )}
         </Box>
       )}
@@ -87,13 +88,14 @@ export const SnapInsight = ({ transaction, origin, chainId, selectedSnap }) => {
       {loading && (
         <>
           <Preloader size={40} />
-          <Typography
+          <Text
             marginTop={3}
             color={TextColor.textAlternative}
-            variant={TypographyVariant.H6}
+            variant={TextVariant.bodySm}
+            as="h6"
           >
             {t('snapsInsightLoading')}
-          </Typography>
+          </Text>
         </>
       )}
     </Box>

--- a/ui/components/app/confirmation-warning-modal/confirmation-warning-modal.js
+++ b/ui/components/app/confirmation-warning-modal/confirmation-warning-modal.js
@@ -5,7 +5,6 @@ import { useI18nContext } from '../../../hooks/useI18nContext';
 import Popover from '../../ui/popover';
 import Box from '../../ui/box';
 import Button from '../../ui/button';
-import { Text } from '../../component-library';
 import {
   DISPLAY,
   FLEX_DIRECTION,
@@ -15,7 +14,7 @@ import {
   AlignItems,
   IconColor,
 } from '../../../helpers/constants/design-system';
-import { Icon, ICON_NAMES, ICON_SIZES } from '../../component-library';
+import { Text, Icon, ICON_NAMES, ICON_SIZES } from '../../component-library';
 
 const ConfirmationWarningModal = ({ onSubmit, onCancel }) => {
   const t = useI18nContext();

--- a/ui/components/app/confirmation-warning-modal/confirmation-warning-modal.js
+++ b/ui/components/app/confirmation-warning-modal/confirmation-warning-modal.js
@@ -5,13 +5,13 @@ import { useI18nContext } from '../../../hooks/useI18nContext';
 import Popover from '../../ui/popover';
 import Box from '../../ui/box';
 import Button from '../../ui/button';
-import Typography from '../../ui/typography';
+import { Text } from '../../component-library';
 import {
   DISPLAY,
   FLEX_DIRECTION,
   FONT_WEIGHT,
   JustifyContent,
-  TypographyVariant,
+  TextVariant,
   AlignItems,
   IconColor,
 } from '../../../helpers/constants/design-system';
@@ -61,39 +61,40 @@ const ConfirmationWarningModal = ({ onSubmit, onCancel }) => {
           className="confirmation-warning-modal__content__header__warning-icon"
           size={ICON_SIZES.XL}
         />
-        <Typography
-          variant={TypographyVariant.H4}
+        <Text
+          variant={TextVariant.headingSm}
+          as="h4"
           fontWeight={FONT_WEIGHT.BOLD}
         >
           {t('addEthereumChainWarningModalTitle')}
-        </Typography>
+        </Text>
       </Box>
       <Box marginLeft={6} marginRight={6} marginTop={0} marginBottom={3}>
-        <Typography marginTop={4} variant={TypographyVariant.H6}>
+        <Text marginTop={4} variant={TextVariant.bodySm} as="h6">
           {t('addEthereumChainWarningModalHeader', [
             <strong key="part-2">
               {t('addEthereumChainWarningModalHeaderPartTwo')}
             </strong>,
           ])}
-        </Typography>
-        <Typography marginTop={4} variant={TypographyVariant.H6}>
+        </Text>
+        <Text marginTop={4} variant={TextVariant.bodySm} as="h6">
           {t('addEthereumChainWarningModalListHeader')}
-        </Typography>
+        </Text>
         <ul>
           <li>
-            <Typography marginTop={2} variant={TypographyVariant.H6}>
+            <Text marginTop={2} variant={TextVariant.bodySm} as="h6">
               {t('addEthereumChainWarningModalListPointOne')}
-            </Typography>
+            </Text>
           </li>
           <li>
-            <Typography marginTop={2} variant={TypographyVariant.H6}>
+            <Text marginTop={2} variant={TextVariant.bodySm} as="h6">
               {t('addEthereumChainWarningModalListPointTwo')}
-            </Typography>
+            </Text>
           </li>
           <li>
-            <Typography marginTop={2} variant={TypographyVariant.H6}>
+            <Text marginTop={2} variant={TextVariant.bodySm} as="h6">
               {t('addEthereumChainWarningModalListPointThree')}
-            </Typography>
+            </Text>
           </li>
         </ul>
       </Box>

--- a/ui/components/app/create-new-vault/create-new-vault.js
+++ b/ui/components/app/create-new-vault/create-new-vault.js
@@ -4,7 +4,7 @@ import { useI18nContext } from '../../../hooks/useI18nContext';
 import TextField from '../../ui/text-field';
 import Button from '../../ui/button';
 import CheckBox from '../../ui/check-box';
-import { Text } from '../../component-library'
+import { Text } from '../../component-library';
 import SrpInput from '../srp-input';
 import { PASSWORD_MIN_LENGTH } from '../../../helpers/constants/common';
 

--- a/ui/components/app/create-new-vault/create-new-vault.js
+++ b/ui/components/app/create-new-vault/create-new-vault.js
@@ -4,7 +4,7 @@ import { useI18nContext } from '../../../hooks/useI18nContext';
 import TextField from '../../ui/text-field';
 import Button from '../../ui/button';
 import CheckBox from '../../ui/check-box';
-import Typography from '../../ui/typography';
+import { Text } from '../../component-library'
 import SrpInput from '../srp-input';
 import { PASSWORD_MIN_LENGTH } from '../../../helpers/constants/common';
 
@@ -135,7 +135,7 @@ export default function CreateNewVault({
             className="create-new-vault__terms-label"
             htmlFor="create-new-vault__terms-checkbox"
           >
-            <Typography as="span">{termsOfUse}</Typography>
+            <Text as="span">{termsOfUse}</Text>
           </label>
         </div>
       ) : null}

--- a/ui/pages/confirm-transaction-base/__snapshots__/confirm-transaction-base.test.js.snap
+++ b/ui/pages/confirm-transaction-base/__snapshots__/confirm-transaction-base.test.js.snap
@@ -254,7 +254,7 @@ exports[`Confirm Transaction Base should match snapshot 1`] = `
           class="confirm-page-container-summary__title"
         >
           <h3
-            class="box box--margin-top-1 box--margin-bottom-1 box--flex-direction-row typography confirm-page-container-summary__title-text typography--h3 typography--weight-normal typography--style-normal typography--color-text-default"
+            class="box mm-text confirm-page-container-summary__title-text mm-text--heading-md mm-text--color-text-default box--flex-direction-row"
           >
             <div
               class="currency-display-component"


### PR DESCRIPTION
## Explanation

This pull request has the changes which are required in issue #17670. It changes all the Typography components with Text components.

Files updated through this PR : 
1. [metamask-extension\ui\components\app\confirm-page-container\confirm-page-container-content\confirm-page-container-summary\confirm-page-container-summary.component.js](https://github.com/MetaMask/metamask-extension/blob/develop/ui/components/app/confirm-page-container/confirm-page-container-content/confirm-page-container-summary/confirm-page-container-summary.component.js)
2. [metamask-extension\ui\components\app\confirm-page-container\flask\snap-insight.js](https://github.com/MetaMask/metamask-extension/blob/develop/ui/components/app/confirm-page-container/flask/snap-insight.js)
3. [metamask-extension\ui\components\app\confirmation-warning-modal\confirmation-warning-modal.js](https://github.com/MetaMask/metamask-extension/blob/develop/ui/components/app/confirmation-warning-modal/confirmation-warning-modal.js)
4. [metamask-extension\ui\components\app\create-new-vault\create-new-vault.js](https://github.com/MetaMask/metamask-extension/blob/develop/ui/components/app/create-new-vault/create-new-vault.js)
5. [metamask-extension\ui\components\app\custom-spending-cap\custom-spending-cap-tooltip.js](https://github.com/MetaMask/metamask-extension/blob/develop/ui/components/app/custom-spending-cap/custom-spending-cap-tooltip.js)


## Screenshots/Screencaps

<!-- If you're making a change to the UI, make sure to capture a screenshot or a short video showing off your work! -->

### Before
``
<img width="941" alt="confirm-summary-comp-before" src="https://user-images.githubusercontent.com/63995872/222404928-ddd49535-dc4c-4e39-aa3e-ea255c2ad039.png">

`confirmation-warning-modol.js`
<img width="935" alt="confirmation-warning-modal-before" src="https://user-images.githubusercontent.com/63995872/222416479-bc512c66-121e-4d0f-ab42-6ae463ec654b.png">

`create-new-vault.js`
<img width="930" alt="create-new-vault before" src="https://user-images.githubusercontent.com/63995872/222419547-11aaacef-b49d-4e74-89d6-e1eaa9f60e7c.png">

`cusotm-spending-tooltip-cap.js`
<img width="942" alt="custom-spending-tooltip-cap-before" src="https://user-images.githubusercontent.com/63995872/223742386-a8908320-0a18-4f51-8e61-ece288a0cdba.png">


### After

<img width="941" alt="confirm-summary-comp-after" src="https://user-images.githubusercontent.com/63995872/222405055-95ba9726-e3d0-417f-b41c-e1ce8e8e1680.png">

`confirmation-warning-modol.js`
<img width="940" alt="confirmation-warning-modal-after" src="https://user-images.githubusercontent.com/63995872/222416541-2c84a2cd-fd59-4345-9cc0-c2dfd0fe64c8.png">

`create-new-vault.js`
<img width="930" alt="create-new-vault-after" src="https://user-images.githubusercontent.com/63995872/222419651-903ede78-0042-467c-9eca-5368c0f5b7cd.png">

`cusotm-spending-tooltip-cap.js`
<img width="935" alt="custom-spending-tooltip-cap-after" src="https://user-images.githubusercontent.com/63995872/223742606-d044b309-1a24-46a7-9dca-987d68730930.png">

## Pre-merge author checklist

- [x] I've clearly explained:
  - [ ] What problem this PR is solving
  - [ ] How this problem was solved
  - [ ] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
