### PR TITLE
Fix #17948 - Allow editing of NFT sends

### DIFF
--- a/test/e2e/nft/send-nft.spec.js
+++ b/test/e2e/nft/send-nft.spec.js
@@ -47,6 +47,27 @@ describe('Send NFT', function () {
           '0xc427D562164062a23a5cFf596A4a3208e72Acd28',
         );
         await driver.clickElement({ text: 'Next', tag: 'button' });
+
+        // Edit the NFT, ensure same address, and move forward
+        await driver.isElementPresentAndVisible(
+          '[data-testid="confirm-page-back-edit-button"]',
+        );
+        await driver.clickElement(
+          '[data-testid="confirm-page-back-edit-button"]',
+        );
+
+        const recipient = await driver.findElement(
+          '.ens-input__selected-input__title',
+        );
+
+        assert.equal(
+          await recipient.getText(),
+          '0xc427d562164062a23a5cff596a4a3208e72acd28',
+        );
+
+        await driver.clickElement({ text: 'Next', tag: 'button' });
+
+        // Confirm the send
         await driver.clickElement({ text: 'Confirm', tag: 'button' });
 
         // When transaction complete, check the send NFT is displayed in activity tab

--- a/ui/pages/confirm-transaction/confirm-token-transaction-switch.js
+++ b/ui/pages/confirm-transaction/confirm-token-transaction-switch.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { useSelector } from 'react-redux';
-import { Switch, Route } from 'react-router-dom';
+import { useDispatch, useSelector } from 'react-redux';
+import { Switch, Route, useHistory } from 'react-router-dom';
 import {
   CONFIRM_APPROVE_PATH,
   CONFIRM_SAFE_TRANSFER_FROM_PATH,
@@ -9,18 +9,25 @@ import {
   CONFIRM_SET_APPROVAL_FOR_ALL_PATH,
   CONFIRM_TRANSACTION_ROUTE,
   CONFIRM_TRANSFER_FROM_PATH,
+  SEND_ROUTE,
 } from '../../helpers/constants/routes';
 import { transactionFeeSelector } from '../../selectors';
 import ConfirmApprove from '../confirm-approve';
 import ConfirmSendToken from '../confirm-send-token';
 import ConfirmTokenTransactionBase from '../confirm-token-transaction-base';
 import ConfirmTransactionSwitch from '../confirm-transaction-switch';
+import { editExistingTransaction } from '../../ducks/send';
+import { AssetType } from '../../../shared/constants/transaction';
+import { clearConfirmTransaction } from '../../ducks/confirm-transaction/confirm-transaction.duck';
 
 import { useAssetDetails } from '../../hooks/useAssetDetails';
 
 export default function ConfirmTokenTransactionSwitch({ transaction }) {
   const { txParams: { data, to: tokenAddress, from: userAddress } = {} } =
     transaction;
+
+  const dispatch = useDispatch();
+  const history = useHistory();
 
   const {
     assetStandard,
@@ -102,6 +109,14 @@ export default function ConfirmTokenTransactionSwitch({ transaction }) {
             decimals={decimals}
             image={tokenImage}
             tokenAddress={tokenAddress}
+            onEdit={async ({ txData }) => {
+              const { id } = txData;
+              await dispatch(
+                editExistingTransaction(AssetType.NFT, id.toString()),
+              );
+              dispatch(clearConfirmTransaction());
+              history.push(SEND_ROUTE);
+            }}
             toAddress={toAddress}
             tokenAmount={tokenAmount}
             tokenId={tokenId}


### PR DESCRIPTION
## Explanation

* Fixes #17948

The `Edit` link isn't displaying because `confirm-transaction-base.component.js` isn't being provided an `onEdit` prop.  The problem ultimately is happening because `ui/pages/confirm-transaction/confirm-token-transaction-switch.js` renders a `ConfirmTokenTransactionBase` by route `CONFIRM_TRANSFER_FROM_PATH` without the onEdit.

## Screenshots/Screencaps

https://user-images.githubusercontent.com/46655/222549071-8737c676-8a72-420c-86d8-69c3ed567390.mp4

## Manual Testing Steps

1.  Enable the NFT feature with `NFTS_V1 yarn start`
2. Start the NFT send flow
3. On the confirmation screen, click "Edit"
4. See the same NFT still selected
5. Choose a different NFT
6. On the confirmation screen, click "edit"

The proper NFT should display on the edit and confirmation screens.

## Pre-merge author checklist

- [ ] I've clearly explained:
  - [ ] What problem this PR is solving
  - [ ] How this problem was solved
  - [ ] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
