### PR TITLE
UX: Icons: Fix Chevrons in Settings Tabs

### DIFF
--- a/ui/pages/settings/index.scss
+++ b/ui/pages/settings/index.scss
@@ -252,6 +252,12 @@
         @include screen-sm-min {
           max-height: 50px;
         }
+
+        &__caret {
+          @include screen-sm-min {
+            display: none;
+          }
+        }
       }
     }
 


### PR DESCRIPTION
## Explanation

I spotted the right-pointing chevrons displaying in the Settings tab while in full screen.  They should only be shown in popup view.

## Screenshots/Screencaps

### Before
<img width="385" alt="FullScreenSettings" src="https://user-images.githubusercontent.com/46655/222580562-8aba62c4-c0a1-449a-9110-c80d8578ff9d.png">

### After

<img width="1078" alt="SettingsChevron" src="https://user-images.githubusercontent.com/46655/222580611-cad96736-19db-436c-9d5b-d39c3a292eed.png">


## Pre-merge author checklist

- [ ] I've clearly explained:
  - [ ] What problem this PR is solving
  - [ ] How this problem was solved
  - [ ] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
