### PR TITLE
Fix #17848 - Ensure NFT collections toggle appropriately

### DIFF
--- a/ui/components/app/nfts-items/nfts-items.js
+++ b/ui/components/app/nfts-items/nfts-items.js
@@ -106,17 +106,19 @@ export default function NftsItems({
   };
 
   const updateNftDropDownStateKey = (key, isExpanded) => {
-    const currentAccountNftDropdownState =
-      nftsDropdownState[selectedAddress][chainId];
-
     const newCurrentAccountState = {
-      ...currentAccountNftDropdownState,
+      ...nftsDropdownState[selectedAddress][chainId],
       [key]: !isExpanded,
     };
 
-    nftsDropdownState[selectedAddress][chainId] = newCurrentAccountState;
+    const newState = {
+      ...nftsDropdownState,
+      [selectedAddress]: {
+        [chainId]: newCurrentAccountState,
+      },
+    };
 
-    dispatch(updateNftDropDownState(nftsDropdownState));
+    dispatch(updateNftDropDownState(newState));
   };
 
   const renderCollection = ({ nfts, collectionName, collectionImage, key }) => {


### PR DESCRIPTION
## Explanation

* Fixes #17848

This weird effect of the collections toggling themselves was due to mutating the current state, as evidenced by this error:

```
Uncaught Error: Invariant failed: A state mutation was detected between dispatches, in the path 'metamask.nftsDropdownState.0x0836f5ed6b62baf60706fe3adc0ff0fd1df833da.0x1'.  This may cause incorrect behavior. (https://redux.js.org/style-guide/style-guide#do-not-mutate-state)
```

This PR prevents the mutation and thus fixes the issue.

## Manual Testing Steps

1.  Start the extension with NFTS turned on: `NFTS_V1 yarn start`
2. Toggle a collection chevron to hide the collection
3. Wait 10 seconds, see the collection is still closed

## Pre-merge author checklist

- [ ] I've clearly explained:
  - [ ] What problem this PR is solving
  - [ ] How this problem was solved
  - [ ] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
