### PR TITLE
Add github action to trigger metamask-desktop CI

### DIFF
--- a/.github/workflows/trigger-metamask-desktop-ci.yml
+++ b/.github/workflows/trigger-metamask-desktop-ci.yml
@@ -24,10 +24,10 @@ jobs:
           EXTENSION_BRANCH: ${{ github.head_ref || github.event.base_ref }}
           DESKTOP_BRANCH: app-stable
         run: |
-          echo Extension branch - $EXTENSION_BRANCH
-          echo Desktop branch - $DESKTOP_BRANCH
+          echo "Extension branch - $EXTENSION_BRANCH"
+          echo "Desktop branch - $DESKTOP_BRANCH"
           curl --request POST \
-          --url $DESKTOP_CI_URL \
+          --url "$DESKTOP_CI_URL" \
           --header "Circle-Token: $CI_TOKEN" \
           --header "content-type: application/json" \
           --data '{"branch":"main","parameters":{"extension-release":true,"extension-release-branch":"'"$EXTENSION_BRANCH"'","app-stable-branch":"'"$DESKTOP_BRANCH"'"}}'

--- a/.github/workflows/trigger-metamask-desktop-ci.yml
+++ b/.github/workflows/trigger-metamask-desktop-ci.yml
@@ -1,0 +1,33 @@
+name: Trigger MetaMask Desktop CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+
+jobs:
+  trigger-desktop-ci:
+    runs-on: ubuntu-latest
+    environment: desktop
+    if: ${{ (!github.event.pull_request.draft && startsWith(github.head_ref, 'Version-v')) || (!github.event.pull_request) }}
+    steps:
+      - name: Trigger MetaMask Desktop CI
+        env:
+          CI_TOKEN: ${{ secrets.DESKTOP_CI_TOKEN }}
+          DESKTOP_CI_URL: ${{ secrets.DESKTOP_CI_URL }}
+          EXTENSION_BRANCH: ${{ github.head_ref || github.event.base_ref }}
+          DESKTOP_BRANCH: app-stable
+        run: |
+          echo Extension branch - $EXTENSION_BRANCH
+          echo Desktop branch - $DESKTOP_BRANCH
+          curl --request POST \
+          --url $DESKTOP_CI_URL \
+          --header "Circle-Token: $CI_TOKEN" \
+          --header "content-type: application/json" \
+          --data '{"branch":"main","parameters":{"extension-release":true,"extension-release-branch":"'"$EXTENSION_BRANCH"'","app-stable-branch":"'"$DESKTOP_BRANCH"'"}}'


### PR DESCRIPTION
## Explanation

We want to be able to trigger MetaMask Desktop CI whenever we are releasing the Extension, i.e:
* whenever there is a push to `master`. Desktop CI will run with Extension master branch (base ref on the push event)
* whenever a PR is open against `master`. Draft PRs are not considered and the head branch needs to start with `Version-v*`. In this case the Desktop CI will run with Extension PR Head branch (i.e. `Version-v*`).

This will allow the team maintaining the Desktop App to easily identify whenever a breaking change (to the extension-desktop app pairing) is being released and address the issue within the Desktop App in a timely manner.

## Manual Testing Steps
Can be tested locally using [act](https://github.com/nektos/act).
Example of Desktop CI being triggered [here](https://app.circleci.com/pipelines/github/MetaMask/metamask-desktop/2359/workflows/6fa233ec-dd3b-4fea-bd30-2322151a2075).

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
