### PR TITLE
Change migration 78 version to 79, 79 to 80 and 80 to 78 (so that the…

### DIFF
--- a/app/scripts/migrations/078.test.js
+++ b/app/scripts/migrations/078.test.js
@@ -1,173 +1,108 @@
-import migration78 from './078';
+import { migrate, version } from './078';
 
 describe('migration #78', () => {
-  it('should update the version metadata', async () => {
+  it('updates the version metadata', async () => {
     const oldStorage = {
       meta: {
         version: 77,
       },
+      data: {},
     };
 
-    const newStorage = await migration78.migrate(oldStorage);
+    const newStorage = await migrate(oldStorage);
+
     expect(newStorage.meta).toStrictEqual({
-      version: 78,
+      version,
     });
   });
 
-  it('should remove the "collectiblesDetectionNoticeDismissed"', async () => {
+  it('does not change the state if the phishing controller state does not exist', async () => {
+    const oldStorage = {
+      meta: {
+        version: 77,
+      },
+      data: { test: '123' },
+    };
+
+    const newStorage = await migrate(oldStorage);
+
+    expect(newStorage.data).toStrictEqual(oldStorage.data);
+  });
+
+  const nonObjects = [undefined, null, 'test', 1, ['test']];
+
+  for (const invalidState of nonObjects) {
+    it(`does not change the state if the phishing controller state is ${invalidState}`, async () => {
+      const oldStorage = {
+        meta: {
+          version: 77,
+        },
+        data: { PhishingController: invalidState },
+      };
+
+      const newStorage = await migrate(oldStorage);
+
+      expect(newStorage.data).toStrictEqual(oldStorage.data);
+    });
+  }
+
+  it('does not change the state if the phishing controller state does not include "phishing" or "lastFetched" properties', async () => {
+    const oldStorage = {
+      meta: {
+        version: 77,
+      },
+      data: { PhishingController: { test: '123' } },
+    };
+
+    const newStorage = await migrate(oldStorage);
+
+    expect(newStorage.data).toStrictEqual(oldStorage.data);
+  });
+
+  it('deletes the "phishing" property', async () => {
+    const oldStorage = {
+      meta: {
+        version: 77,
+      },
+      data: { PhishingController: { test: '123', phishing: [] } },
+    };
+
+    const newStorage = await migrate(oldStorage);
+
+    expect(newStorage.data).toStrictEqual({
+      PhishingController: { test: '123' },
+    });
+  });
+
+  it('deletes the "lastFetched" property', async () => {
+    const oldStorage = {
+      meta: {
+        version: 77,
+      },
+      data: { PhishingController: { test: '123', lastFetched: 100 } },
+    };
+
+    const newStorage = await migrate(oldStorage);
+
+    expect(newStorage.data).toStrictEqual({
+      PhishingController: { test: '123' },
+    });
+  });
+
+  it('deletes the "phishing" and "lastFetched" properties', async () => {
     const oldStorage = {
       meta: {
         version: 77,
       },
       data: {
-        AppStateController: {
-          collectiblesDetectionNoticeDismissed: false,
-          bar: 'baz',
-        },
+        PhishingController: { test: '123', lastFetched: 100, phishing: [] },
       },
     };
 
-    const newStorage = await migration78.migrate(oldStorage);
-    expect(newStorage).toStrictEqual({
-      meta: {
-        version: 78,
-      },
-      data: {
-        AppStateController: {
-          bar: 'baz',
-        },
-      },
-    });
-  });
+    const newStorage = await migrate(oldStorage);
 
-  it('should remove the "collectiblesDropdownState"', async () => {
-    const oldStorage = {
-      meta: {
-        version: 77,
-      },
-      data: {
-        metamask: {
-          isInitialized: true,
-          isUnlocked: true,
-          isAccountMenuOpen: false,
-          identities: {
-            '0x00000': {
-              address: '0x00000',
-              lastSelected: 1675966229118,
-              name: 'Account 1',
-            },
-            '0x00001': {
-              address: '0x00001',
-              name: 'Account 2',
-            },
-          },
-          collectiblesDropdownState: {},
-          qrHardware: {},
-        },
-      },
-    };
-
-    const newStorage = await migration78.migrate(oldStorage);
-    expect(newStorage).toStrictEqual({
-      meta: {
-        version: 78,
-      },
-      data: {
-        metamask: {
-          isInitialized: true,
-          isUnlocked: true,
-          isAccountMenuOpen: false,
-          identities: {
-            '0x00000': {
-              address: '0x00000',
-              lastSelected: 1675966229118,
-              name: 'Account 1',
-            },
-            '0x00001': {
-              address: '0x00001',
-              name: 'Account 2',
-            },
-          },
-          qrHardware: {},
-        },
-      },
-    });
-  });
-
-  it('should make no changes if "collectiblesDetectionNoticeDismissed" never existed', async () => {
-    const oldStorage = {
-      meta: {
-        version: 77,
-      },
-      data: {
-        AppStateController: {
-          bar: 'baz',
-        },
-      },
-    };
-
-    const newStorage = await migration78.migrate(oldStorage);
-    expect(newStorage).toStrictEqual({
-      meta: {
-        version: 78,
-      },
-      data: {
-        AppStateController: {
-          bar: 'baz',
-        },
-      },
-    });
-  });
-  it('should make no changes if "collectiblesDropdownState" never existed', async () => {
-    const oldStorage = {
-      meta: {
-        version: 77,
-      },
-      data: {
-        metamask: {
-          isInitialized: true,
-          isUnlocked: true,
-          isAccountMenuOpen: false,
-          identities: {
-            '0x00000': {
-              address: '0x00000',
-              lastSelected: 1675966229118,
-              name: 'Account 1',
-            },
-            '0x00001': {
-              address: '0x00001',
-              name: 'Account 2',
-            },
-          },
-          qrHardware: {},
-        },
-      },
-    };
-
-    const newStorage = await migration78.migrate(oldStorage);
-    expect(newStorage).toStrictEqual({
-      meta: {
-        version: 78,
-      },
-      data: {
-        metamask: {
-          isInitialized: true,
-          isUnlocked: true,
-          isAccountMenuOpen: false,
-          identities: {
-            '0x00000': {
-              address: '0x00000',
-              lastSelected: 1675966229118,
-              name: 'Account 1',
-            },
-            '0x00001': {
-              address: '0x00001',
-              name: 'Account 2',
-            },
-          },
-          qrHardware: {},
-        },
-      },
+    expect(newStorage.data).toStrictEqual({
+      PhishingController: { test: '123' },
     });
   });
 });

--- a/app/scripts/migrations/078.ts
+++ b/app/scripts/migrations/078.ts
@@ -1,7 +1,7 @@
 import { cloneDeep } from 'lodash';
 import { hasProperty, isObject } from '@metamask/utils';
 
-export const version = 80;
+export const version = 78;
 
 /**
  * The`@metamask/phishing-controller` state was updated in v2.0.0.

--- a/app/scripts/migrations/079.js
+++ b/app/scripts/migrations/079.js
@@ -3,8 +3,7 @@ import { cloneDeep } from 'lodash';
 const version = 79;
 
 /**
- * The portfolio tooltip has been moved to a button on the home screen so
- * this property is no longer needed in state
+ * Remove collectiblesDropdownState and collectiblesDetectionNoticeDismissed:.
  */
 export default {
   version,
@@ -19,9 +18,14 @@ export default {
 };
 
 function transformState(state) {
-  if (state?.metamask?.showPortfolioTooltip !== undefined) {
-    delete state.metamask.showPortfolioTooltip;
+  if (
+    state?.AppStateController?.collectiblesDetectionNoticeDismissed !==
+    undefined
+  ) {
+    delete state.AppStateController.collectiblesDetectionNoticeDismissed;
   }
-
+  if (state?.metamask?.collectiblesDropdownState !== undefined) {
+    delete state.metamask.collectiblesDropdownState;
+  }
   return state;
 }

--- a/app/scripts/migrations/079.test.js
+++ b/app/scripts/migrations/079.test.js
@@ -14,7 +14,33 @@ describe('migration #79', () => {
     });
   });
 
-  it('should remove the "showPortfolioToolip" property', async () => {
+  it('should remove the "collectiblesDetectionNoticeDismissed"', async () => {
+    const oldStorage = {
+      meta: {
+        version: 78,
+      },
+      data: {
+        AppStateController: {
+          collectiblesDetectionNoticeDismissed: false,
+          bar: 'baz',
+        },
+      },
+    };
+
+    const newStorage = await migration79.migrate(oldStorage);
+    expect(newStorage).toStrictEqual({
+      meta: {
+        version: 79,
+      },
+      data: {
+        AppStateController: {
+          bar: 'baz',
+        },
+      },
+    });
+  });
+
+  it('should remove the "collectiblesDropdownState"', async () => {
     const oldStorage = {
       meta: {
         version: 78,
@@ -35,19 +61,7 @@ describe('migration #79', () => {
               name: 'Account 2',
             },
           },
-          unapprovedTxs: {},
-          frequentRpcList: [],
-          addressBook: {},
-          popupGasPollTokens: [],
-          notificationGasPollTokens: [],
-          fullScreenGasPollTokens: [],
-          recoveryPhraseReminderHasBeenShown: false,
-          recoveryPhraseReminderLastShown: 1675966206345,
-          outdatedBrowserWarningLastShown: 1675966206345,
-          showTestnetMessageInDropdown: true,
-          showPortfolioTooltip: false,
-          showBetaHeader: false,
-          trezorModel: null,
+          collectiblesDropdownState: {},
           qrHardware: {},
         },
       },
@@ -74,25 +88,37 @@ describe('migration #79', () => {
               name: 'Account 2',
             },
           },
-          unapprovedTxs: {},
-          frequentRpcList: [],
-          addressBook: {},
-          popupGasPollTokens: [],
-          notificationGasPollTokens: [],
-          fullScreenGasPollTokens: [],
-          recoveryPhraseReminderHasBeenShown: false,
-          recoveryPhraseReminderLastShown: 1675966206345,
-          outdatedBrowserWarningLastShown: 1675966206345,
-          showTestnetMessageInDropdown: true,
-          showBetaHeader: false,
-          trezorModel: null,
           qrHardware: {},
         },
       },
     });
   });
 
-  it('should make no changes if "showPortfolioToolip" never existed', async () => {
+  it('should make no changes if "collectiblesDetectionNoticeDismissed" never existed', async () => {
+    const oldStorage = {
+      meta: {
+        version: 78,
+      },
+      data: {
+        AppStateController: {
+          bar: 'baz',
+        },
+      },
+    };
+
+    const newStorage = await migration79.migrate(oldStorage);
+    expect(newStorage).toStrictEqual({
+      meta: {
+        version: 79,
+      },
+      data: {
+        AppStateController: {
+          bar: 'baz',
+        },
+      },
+    });
+  });
+  it('should make no changes if "collectiblesDropdownState" never existed', async () => {
     const oldStorage = {
       meta: {
         version: 78,
@@ -113,18 +139,6 @@ describe('migration #79', () => {
               name: 'Account 2',
             },
           },
-          unapprovedTxs: {},
-          frequentRpcList: [],
-          addressBook: {},
-          popupGasPollTokens: [],
-          notificationGasPollTokens: [],
-          fullScreenGasPollTokens: [],
-          recoveryPhraseReminderHasBeenShown: false,
-          recoveryPhraseReminderLastShown: 1675966206345,
-          outdatedBrowserWarningLastShown: 1675966206345,
-          showTestnetMessageInDropdown: true,
-          showBetaHeader: false,
-          trezorModel: null,
           qrHardware: {},
         },
       },
@@ -151,18 +165,6 @@ describe('migration #79', () => {
               name: 'Account 2',
             },
           },
-          unapprovedTxs: {},
-          frequentRpcList: [],
-          addressBook: {},
-          popupGasPollTokens: [],
-          notificationGasPollTokens: [],
-          fullScreenGasPollTokens: [],
-          recoveryPhraseReminderHasBeenShown: false,
-          recoveryPhraseReminderLastShown: 1675966206345,
-          outdatedBrowserWarningLastShown: 1675966206345,
-          showTestnetMessageInDropdown: true,
-          showBetaHeader: false,
-          trezorModel: null,
           qrHardware: {},
         },
       },

--- a/app/scripts/migrations/080.js
+++ b/app/scripts/migrations/080.js
@@ -1,9 +1,10 @@
 import { cloneDeep } from 'lodash';
 
-const version = 78;
+const version = 80;
 
 /**
- * Remove collectiblesDropdownState and collectiblesDetectionNoticeDismissed:.
+ * The portfolio tooltip has been moved to a button on the home screen so
+ * this property is no longer needed in state
  */
 export default {
   version,
@@ -18,14 +19,9 @@ export default {
 };
 
 function transformState(state) {
-  if (
-    state?.AppStateController?.collectiblesDetectionNoticeDismissed !==
-    undefined
-  ) {
-    delete state.AppStateController.collectiblesDetectionNoticeDismissed;
+  if (state?.metamask?.showPortfolioTooltip !== undefined) {
+    delete state.metamask.showPortfolioTooltip;
   }
-  if (state?.metamask?.collectiblesDropdownState !== undefined) {
-    delete state.metamask.collectiblesDropdownState;
-  }
+
   return state;
 }

--- a/app/scripts/migrations/080.test.js
+++ b/app/scripts/migrations/080.test.js
@@ -1,108 +1,171 @@
-import { migrate, version } from './080';
+import migration80 from './080';
 
 describe('migration #80', () => {
-  it('updates the version metadata', async () => {
+  it('should update the version metadata', async () => {
     const oldStorage = {
       meta: {
-        version: 79,
+        version: 80,
       },
-      data: {},
     };
 
-    const newStorage = await migrate(oldStorage);
-
+    const newStorage = await migration80.migrate(oldStorage);
     expect(newStorage.meta).toStrictEqual({
-      version,
+      version: 80,
     });
   });
 
-  it('does not change the state if the phishing controller state does not exist', async () => {
+  it('should remove the "showPortfolioToolip" property', async () => {
     const oldStorage = {
       meta: {
-        version: 79,
-      },
-      data: { test: '123' },
-    };
-
-    const newStorage = await migrate(oldStorage);
-
-    expect(newStorage.data).toStrictEqual(oldStorage.data);
-  });
-
-  const nonObjects = [undefined, null, 'test', 1, ['test']];
-
-  for (const invalidState of nonObjects) {
-    it(`does not change the state if the phishing controller state is ${invalidState}`, async () => {
-      const oldStorage = {
-        meta: {
-          version: 79,
-        },
-        data: { PhishingController: invalidState },
-      };
-
-      const newStorage = await migrate(oldStorage);
-
-      expect(newStorage.data).toStrictEqual(oldStorage.data);
-    });
-  }
-
-  it('does not change the state if the phishing controller state does not include "phishing" or "lastFetched" properties', async () => {
-    const oldStorage = {
-      meta: {
-        version: 79,
-      },
-      data: { PhishingController: { test: '123' } },
-    };
-
-    const newStorage = await migrate(oldStorage);
-
-    expect(newStorage.data).toStrictEqual(oldStorage.data);
-  });
-
-  it('deletes the "phishing" property', async () => {
-    const oldStorage = {
-      meta: {
-        version: 79,
-      },
-      data: { PhishingController: { test: '123', phishing: [] } },
-    };
-
-    const newStorage = await migrate(oldStorage);
-
-    expect(newStorage.data).toStrictEqual({
-      PhishingController: { test: '123' },
-    });
-  });
-
-  it('deletes the "lastFetched" property', async () => {
-    const oldStorage = {
-      meta: {
-        version: 79,
-      },
-      data: { PhishingController: { test: '123', lastFetched: 100 } },
-    };
-
-    const newStorage = await migrate(oldStorage);
-
-    expect(newStorage.data).toStrictEqual({
-      PhishingController: { test: '123' },
-    });
-  });
-
-  it('deletes the "phishing" and "lastFetched" properties', async () => {
-    const oldStorage = {
-      meta: {
-        version: 79,
+        version: 80,
       },
       data: {
-        PhishingController: { test: '123', lastFetched: 100, phishing: [] },
+        metamask: {
+          isInitialized: true,
+          isUnlocked: true,
+          isAccountMenuOpen: false,
+          identities: {
+            '0x00000': {
+              address: '0x00000',
+              lastSelected: 1675966229118,
+              name: 'Account 1',
+            },
+            '0x00001': {
+              address: '0x00001',
+              name: 'Account 2',
+            },
+          },
+          unapprovedTxs: {},
+          frequentRpcList: [],
+          addressBook: {},
+          popupGasPollTokens: [],
+          notificationGasPollTokens: [],
+          fullScreenGasPollTokens: [],
+          recoveryPhraseReminderHasBeenShown: false,
+          recoveryPhraseReminderLastShown: 1675966206345,
+          outdatedBrowserWarningLastShown: 1675966206345,
+          showTestnetMessageInDropdown: true,
+          showPortfolioTooltip: false,
+          showBetaHeader: false,
+          trezorModel: null,
+          qrHardware: {},
+        },
       },
     };
 
-    const newStorage = await migrate(oldStorage);
+    const newStorage = await migration80.migrate(oldStorage);
+    expect(newStorage).toStrictEqual({
+      meta: {
+        version: 80,
+      },
+      data: {
+        metamask: {
+          isInitialized: true,
+          isUnlocked: true,
+          isAccountMenuOpen: false,
+          identities: {
+            '0x00000': {
+              address: '0x00000',
+              lastSelected: 1675966229118,
+              name: 'Account 1',
+            },
+            '0x00001': {
+              address: '0x00001',
+              name: 'Account 2',
+            },
+          },
+          unapprovedTxs: {},
+          frequentRpcList: [],
+          addressBook: {},
+          popupGasPollTokens: [],
+          notificationGasPollTokens: [],
+          fullScreenGasPollTokens: [],
+          recoveryPhraseReminderHasBeenShown: false,
+          recoveryPhraseReminderLastShown: 1675966206345,
+          outdatedBrowserWarningLastShown: 1675966206345,
+          showTestnetMessageInDropdown: true,
+          showBetaHeader: false,
+          trezorModel: null,
+          qrHardware: {},
+        },
+      },
+    });
+  });
 
-    expect(newStorage.data).toStrictEqual({
-      PhishingController: { test: '123' },
+  it('should make no changes if "showPortfolioToolip" never existed', async () => {
+    const oldStorage = {
+      meta: {
+        version: 80,
+      },
+      data: {
+        metamask: {
+          isInitialized: true,
+          isUnlocked: true,
+          isAccountMenuOpen: false,
+          identities: {
+            '0x00000': {
+              address: '0x00000',
+              lastSelected: 1675966229118,
+              name: 'Account 1',
+            },
+            '0x00001': {
+              address: '0x00001',
+              name: 'Account 2',
+            },
+          },
+          unapprovedTxs: {},
+          frequentRpcList: [],
+          addressBook: {},
+          popupGasPollTokens: [],
+          notificationGasPollTokens: [],
+          fullScreenGasPollTokens: [],
+          recoveryPhraseReminderHasBeenShown: false,
+          recoveryPhraseReminderLastShown: 1675966206345,
+          outdatedBrowserWarningLastShown: 1675966206345,
+          showTestnetMessageInDropdown: true,
+          showBetaHeader: false,
+          trezorModel: null,
+          qrHardware: {},
+        },
+      },
+    };
+
+    const newStorage = await migration80.migrate(oldStorage);
+    expect(newStorage).toStrictEqual({
+      meta: {
+        version: 80,
+      },
+      data: {
+        metamask: {
+          isInitialized: true,
+          isUnlocked: true,
+          isAccountMenuOpen: false,
+          identities: {
+            '0x00000': {
+              address: '0x00000',
+              lastSelected: 1675966229118,
+              name: 'Account 1',
+            },
+            '0x00001': {
+              address: '0x00001',
+              name: 'Account 2',
+            },
+          },
+          unapprovedTxs: {},
+          frequentRpcList: [],
+          addressBook: {},
+          popupGasPollTokens: [],
+          notificationGasPollTokens: [],
+          fullScreenGasPollTokens: [],
+          recoveryPhraseReminderHasBeenShown: false,
+          recoveryPhraseReminderLastShown: 1675966206345,
+          outdatedBrowserWarningLastShown: 1675966206345,
+          showTestnetMessageInDropdown: true,
+          showBetaHeader: false,
+          trezorModel: null,
+          qrHardware: {},
+        },
+      },
     });
   });
 });

--- a/app/scripts/migrations/index.js
+++ b/app/scripts/migrations/index.js
@@ -81,9 +81,9 @@ import m074 from './074';
 import m075 from './075';
 import m076 from './076';
 import m077 from './077';
-import m078 from './078';
+import * as m078 from './078';
 import m079 from './079';
-import * as m080 from './080';
+import m080 from './080';
 
 const migrations = [
   m002,


### PR DESCRIPTION
… new 78 can be picked into an RC)

We have this challenge:

> [v10.26](https://github.com/MetaMask/metamask-extension/pull/17698) is currently in progress and we are hoping to get it merged and release soon.
We would like to ship the [Phishing Controller](https://github.com/MetaMask/metamask-extension/pull/17835) update as part of v10.26, the Phishing Controller update contains migration 80, whilst v10.26 is currently on migration 77.
How should I approach resolving conflicts, considering I do not want to include either of the following;
- Collectible Controller gets updated to NFT Controller ([migration 78](https://github.com/MetaMask/metamask-extension/pull/17741))
- showPortfolioTooltip gets deleted ([migration 79](https://github.com/MetaMask/metamask-extension/pull/17722)), the portfolio tooltip is being updated again in v10.27

And the solution is:
> because all of these are only on develop  and not master, we might just be able to make a PR to develop that changes the phishing controller migration to 78 and bumps the other two by 1

Note to reviewers: the only changes I made in code were to file names and version numbers within the migration files. Any other code changes in the diff are a result of simultaneously changing files names of each file to one of the other existing filed
