### PR TITLE
Fix #17932 - Ensure NFT last sold price is formatted correctly

### DIFF
--- a/test/data/mock-state.json
+++ b/test/data/mock-state.json
@@ -465,7 +465,14 @@
             "name": "MUNK #1",
             "description": null,
             "image": "ipfs://QmTSZUNt8AKyDabkyXXXP4oHWDnaVXgNdXoJGEyaYzLbeL",
-            "standard": "ERC721"
+            "standard": "ERC721",
+            "lastSale": {
+              "total_price": "4900000000000000",
+              "event_timestamp": "2023-01-18T21:51:23",
+              "payment_token": {
+                "symbol": "ETH"
+              }
+            }
           },
           {
             "address": "0xDc7382Eb0Bc9C352A4CbA23c909bDA01e0206414",

--- a/ui/components/app/nft-details/__snapshots__/nft-details.test.js.snap
+++ b/ui/components/app/nft-details/__snapshots__/nft-details.test.js.snap
@@ -90,6 +90,42 @@ exports[`NFT Details should match minimal props and state snapshot 1`] = `
         <h6
           class="box box--margin-top-1 box--margin-right-2 box--margin-bottom-4 box--flex-direction-row typography nft-details__link-title typography--h6 typography--weight-bold typography--style-normal typography--color-text-default"
         >
+          Last sold
+        </h6>
+        <div
+          class="box nft-details__contract-wrapper box--display-flex box--flex-direction-row"
+        >
+          <h6
+            class="box box--margin-top-1 box--margin-bottom-4 box--flex-direction-row typography typography--h6 typography--weight-normal typography--style-normal typography--color-text-alternative typography--overflowwrap-break-word"
+          >
+            1/18/2023
+          </h6>
+        </div>
+      </div>
+      <div
+        class="box box--display-flex box--flex-direction-row"
+      >
+        <h6
+          class="box box--margin-top-1 box--margin-right-2 box--margin-bottom-4 box--flex-direction-row typography nft-details__link-title typography--h6 typography--weight-bold typography--style-normal typography--color-text-default"
+        >
+          Last price sold
+        </h6>
+        <div
+          class="box nft-details__contract-wrapper box--display-flex box--flex-direction-row"
+        >
+          <h6
+            class="box box--margin-top-1 box--margin-bottom-4 box--flex-direction-row typography typography--h6 typography--weight-normal typography--style-normal typography--color-text-alternative typography--overflowwrap-break-word"
+          >
+            0.0049 ETH
+          </h6>
+        </div>
+      </div>
+      <div
+        class="box box--display-flex box--flex-direction-row"
+      >
+        <h6
+          class="box box--margin-top-1 box--margin-right-2 box--margin-bottom-4 box--flex-direction-row typography nft-details__link-title typography--h6 typography--weight-bold typography--style-normal typography--color-text-default"
+        >
           Source
         </h6>
         <h6

--- a/ui/components/app/nft-details/nft-details.js
+++ b/ui/components/app/nft-details/nft-details.js
@@ -55,6 +55,7 @@ import {
 import NftDefaultImage from '../nft-default-image';
 import { ButtonIcon, ICON_NAMES } from '../../component-library';
 import Tooltip from '../../ui/tooltip';
+import { decWEIToDecETH } from '../../../../shared/modules/conversion.utils';
 
 export default function NftDetails({ nft }) {
   const {
@@ -86,6 +87,7 @@ export default function NftDetails({ nft }) {
   const nftImageAlt = getNftImageAlt(nft);
   const nftImageURL = getAssetImageURL(imageOriginal ?? image, ipfsGateway);
   const isDataURI = nftImageURL.startsWith('data:');
+
   const formattedTimestamp = formatDate(
     new Date(lastSale?.event_timestamp).getTime(),
     'M/d/y',
@@ -297,7 +299,9 @@ export default function NftDetails({ nft }) {
                     overflowWrap={OVERFLOW_WRAP.BREAK_WORD}
                     boxProps={{ margin: 0, marginBottom: 4 }}
                   >
-                    {lastSale.total_price}
+                    {`${Number(decWEIToDecETH(lastSale.total_price))} ${
+                      lastSale.payment_token.symbol
+                    }`}
                   </Typography>
                 </Box>
               </Box>
@@ -461,6 +465,9 @@ NftDetails.propTypes = {
     lastSale: PropTypes.shape({
       event_timestamp: PropTypes.string,
       total_price: PropTypes.string,
+      payment_token: PropTypes.shape({
+        symbol: PropTypes.string,
+      }),
     }),
   }),
 };

--- a/ui/components/app/nft-details/nft-details.stories.js
+++ b/ui/components/app/nft-details/nft-details.stories.js
@@ -12,6 +12,9 @@ const nft = {
   lastSale: {
     event_timestamp: '2023-01-18T21:51:23',
     total_price: '4900000000000000',
+    payment_token: {
+      symbol: 'ETH',
+    },
   },
 };
 


### PR DESCRIPTION
## Explanation

* Fixes #17932

Before this PR, the "last sold" field was displaying as decimal WEI, which is unhelpful.  This PR converts that number to decimal ETH and provides the symbol.

Verified the correct value via the purchase transaction: https://etherscan.io/tx/0x56dffb71e23e0f477ba8b5f1fedb20f0224307740c01659b29dd9f0b3db7783f

## Screenshots/Screencaps

<img width="737" alt="CorrectPrice" src="https://user-images.githubusercontent.com/46655/222856220-a62021d1-7d1b-4308-b716-8bc1b7f63d9d.png">

## Pre-merge author checklist

- [ ] I've clearly explained:
  - [ ] What problem this PR is solving
  - [ ] How this problem was solved
  - [ ] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
