### PR TITLE
Force update mock state and render nfts item test fix

### DIFF
--- a/ui/components/app/nfts-items/nfts-items.test.js
+++ b/ui/components/app/nfts-items/nfts-items.test.js
@@ -41,7 +41,7 @@ describe('NFTs Item Component', () => {
   const mockStore = configureMockStore([thunk])(mockState);
 
   it('should expand NFT collection showing individual NFTs', async () => {
-    const { queryByTestId, queryAllByTestId, rerender } = renderWithProvider(
+    const { queryByTestId, queryAllByTestId } = renderWithProvider(
       <NftsItems {...props} />,
       mockStore,
     );
@@ -54,16 +54,20 @@ describe('NFTs Item Component', () => {
 
     fireEvent.click(collectionExpanderButton);
 
-    expect(updateNftDropDownState).toHaveBeenCalledWith({
+    const expectedParams = {
       '0x0dcd5d886577d5081b0c52e242ef29e70be3e7bc': {
         '0x5': {
-          '0x0dcd5d886577d5081b0c52e242ef29e70be3e7bc': true,
           '0x495f947276749Ce646f68AC8c248420045cb7b5e': false,
+          '0x0dcd5d886577d5081b0c52e242ef29e70be3e7bc': true,
         },
       },
-    });
+    };
 
-    rerender(<NftsItems {...props} />, mockStore);
+    expect(updateNftDropDownState).toHaveBeenCalledWith(expectedParams);
+
+    // Force rerender component with state/store update
+    mockState.metamask.nftsDropdownState = expectedParams;
+    renderWithProvider(<NftsItems {...props} />, mockStore);
 
     expect(queryAllByTestId('nft-wrapper')).toHaveLength(8);
   });


### PR DESCRIPTION
## Explanation

Currently, we isolate state/store and mock actions for unit testing which leads to issues with `forceUpdateMetamaskState`. This is a workaround to change the state with the expected state passed, update the store, and render the component all within the unit test.


<!--
 Thanks for the pull request. Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues, Slack conversations, Zendesk issues, user stories, etc. reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

## Screenshots/Screencaps

<!-- If you're making a change to the UI, make sure to capture a screenshot or a short video showing off your work! -->

### Before

<!-- How did the UI you changed look before your changes? Drag your file(s) below this line: -->

### After

<!-- How does it look now? Drag your file(s) below this line: -->

## Manual Testing Steps

<!--
How should reviewers and QA manually test your changes? For instance:

- Go to this screen
- Do this
- Then do this
-->

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
