### PR TITLE
fix(17716): increase threshold to include all options for nonce search

### DIFF
--- a/ui/pages/settings/settings-search/settings-search.js
+++ b/ui/pages/settings/settings-search/settings-search.js
@@ -34,7 +34,7 @@ export default function SettingsSearch({
   ///: END:ONLY_INCLUDE_IN
   const settingsSearchFuse = new Fuse(settingsRoutesListArray, {
     shouldSort: true,
-    threshold: 0.2,
+    threshold: 0.3,
     location: 0,
     distance: 100,
     maxPatternLength: 32,


### PR DESCRIPTION
## Explanation

Fix: https://github.com/MetaMask/metamask-extension/issues/17716

[Threshold](https://fusejs.io/api/options.html#threshold) is to tell the algorithm when to give up searching, while "0.0 requires a perfect match (of both letters and location) and 1.0 would match anything". 
The reason behind this bug is we have more than 1 matches for "nonce" and the algorithm stopped when only finding one match.
The fix is straightforward, increasing the threshold and return more results.

<!--
Thanks for the pull request. Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues, Slack conversations, Zendesk issues, user stories, etc. reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

## Screenshots/Screencaps

<!-- If you're making a change to the UI, make sure to capture a screenshot or a short video showing off your work! -->

### Before

<!-- How did the UI you changed look before your changes? Drag your file(s) below this line: -->

### After

<img width="1164" alt="Screenshot 2023-03-06 at 13 58 09" src="https://user-images.githubusercontent.com/12678455/223130662-5a32f0e2-423c-403f-a221-42a3908dc3f3.png">

<!-- How does it look now? Drag your file(s) below this line: -->

## Manual Testing Steps

<!--
How should reviewers and QA manually test your changes? For instance:

- Go to this screen
- Do this
- Then do this
-->

## Pre-merge author checklist

- [ ] I've clearly explained:
  - [ ] What problem this PR is solving
  - [ ] How this problem was solved
  - [ ] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
