### PR TITLE
decrease targets by half a point-ish

### DIFF
--- a/coverage-targets.js
+++ b/coverage-targets.js
@@ -6,10 +6,10 @@
 // subset of files to check against these targets.
 module.exports = {
   global: {
-    lines: 64.39,
-    branches: 53.01,
-    statements: 63.63,
-    functions: 56.67,
+    lines: 64,
+    branches: 52.5,
+    statements: 63.1,
+    functions: 56.1,
   },
   transforms: {
     branches: 100,


### PR DESCRIPTION
## Explanation
in a recent PR we bumped coverage targets to the exact coverage amounts, which results in micro fluctuations to fail builds. This PR drops the targets by half a point - ish, just allowing for wiggle room to avoid breaking builds. 

## Screenshots/Screencaps

<!-- If you're making a change to the UI, make sure to capture a screenshot or a short video showing off your work! -->

### Before

<!-- How did the UI you changed look before your changes? Drag your file(s) below this line: -->

### After

<!-- How does it look now? Drag your file(s) below this line: -->

## Manual Testing Steps

<!--
How should reviewers and QA manually test your changes? For instance:

- Go to this screen
- Do this
- Then do this
-->

## Pre-merge author checklist

- [ ] I've clearly explained:
  - [ ] What problem this PR is solving
  - [ ] How this problem was solved
  - [ ] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
