### PR TITLE
Fix Sign-in With Ethereum (SIWE) metametric, add tests, and clean RPC method middleware event logic

### DIFF
--- a/app/scripts/lib/createRPCMethodTrackingMiddleware.js
+++ b/app/scripts/lib/createRPCMethodTrackingMiddleware.js
@@ -203,7 +203,7 @@ export default function createRPCMethodTrackingMiddleware({
             if (isSIWEMessage) {
               eventProperties.ui_customizations = (
                 eventProperties.ui_customizations || []
-              ).push(METAMETRIC_KEY_OPT.ui_customizations.SIWE);
+              ).concat(METAMETRIC_KEY_OPT.ui_customizations.SIWE);
             }
           }
         } catch (e) {

--- a/app/scripts/lib/createRPCMethodTrackingMiddleware.js
+++ b/app/scripts/lib/createRPCMethodTrackingMiddleware.js
@@ -7,7 +7,6 @@ import {
   EVENT,
   EVENT_NAMES,
   METAMETRIC_KEY_OPT,
-  METAMETRIC_KEY,
 } from '../../../shared/constants/metametrics';
 
 /**

--- a/app/scripts/lib/createRPCMethodTrackingMiddleware.js
+++ b/app/scripts/lib/createRPCMethodTrackingMiddleware.js
@@ -208,7 +208,7 @@ export default function createRPCMethodTrackingMiddleware({
             if (isSIWEMessage) {
               eventProperties.ui_customizations = (
                 eventProperties.ui_customizations || []
-              ).push(METAMETRIC_KEY_OPT[METAMETRIC_KEY.UI_CUSTOMIZATIONS].SIWE);
+              ).push(METAMETRIC_KEY_OPT.ui_customizations.SIWE);
             }
           }
         } catch (e) {

--- a/app/scripts/lib/createRPCMethodTrackingMiddleware.js
+++ b/app/scripts/lib/createRPCMethodTrackingMiddleware.js
@@ -255,7 +255,7 @@ export default function createRPCMethodTrackingMiddleware({
       if (isDisabledRPCMethod) {
         event = eventType.FAILED;
         properties.error = res.error;
-      } else if (res.error?.code === 4001) {
+      } else if (res.error?.code === errorCodes.provider.userRejectedRequest) {
         event = eventType.REJECTED;
       } else {
         event = eventType.APPROVED;

--- a/app/scripts/lib/createRPCMethodTrackingMiddleware.js
+++ b/app/scripts/lib/createRPCMethodTrackingMiddleware.js
@@ -201,22 +201,16 @@ export default function createRPCMethodTrackingMiddleware({
             eventProperties.ui_customizations = [
               METAMETRIC_KEY_OPTIONS.ui_customizations.flaggedAsSafetyUnknown,
             ];
-          } else {
-            eventProperties.ui_customizations = null;
           }
 
           if (method === MESSAGE_TYPE.PERSONAL_SIGN) {
             const { isSIWEMessage } = detectSIWE({ data });
             if (isSIWEMessage) {
-              eventProperties.ui_customizations === null
-                ? (eventProperties.ui_customizations = [
-                    METAMETRIC_KEY_OPTIONS[METAMETRIC_KEY.UI_CUSTOMIZATIONS]
-                      .SIWE,
-                  ])
-                : eventProperties.ui_customizations.push(
-                    METAMETRIC_KEY_OPTIONS[METAMETRIC_KEY.UI_CUSTOMIZATIONS]
-                      .SIWE,
-                  );
+              eventProperties.ui_customizations = (
+                eventProperties.ui_customizations || []
+              ).push(
+                METAMETRIC_KEY_OPTIONS[METAMETRIC_KEY.UI_CUSTOMIZATIONS].SIWE,
+              );
             }
           }
         } catch (e) {

--- a/app/scripts/lib/createRPCMethodTrackingMiddleware.js
+++ b/app/scripts/lib/createRPCMethodTrackingMiddleware.js
@@ -194,9 +194,13 @@ export default function createRPCMethodTrackingMiddleware({
           );
 
           if (securityProviderResponse?.flagAsDangerous === 1) {
-            eventProperties.ui_customizations = ['flagged_as_malicious'];
+            eventProperties.ui_customizations = [
+              METAMETRIC_KEY_OPTIONS.ui_customizations.flaggedAsMalicious,
+            ];
           } else if (securityProviderResponse?.flagAsDangerous === 2) {
-            eventProperties.ui_customizations = ['flagged_as_safety_unknown'];
+            eventProperties.ui_customizations = [
+              METAMETRIC_KEY_OPTIONS.ui_customizations.flaggedAsSafetyUnknown,
+            ];
           } else {
             eventProperties.ui_customizations = null;
           }

--- a/app/scripts/lib/createRPCMethodTrackingMiddleware.js
+++ b/app/scripts/lib/createRPCMethodTrackingMiddleware.js
@@ -6,7 +6,7 @@ import { detectSIWE } from '../../../shared/modules/siwe';
 import {
   EVENT,
   EVENT_NAMES,
-  METAMETRIC_KEY_OPTIONS,
+  METAMETRIC_KEY_OPT,
   METAMETRIC_KEY,
 } from '../../../shared/constants/metametrics';
 
@@ -195,11 +195,11 @@ export default function createRPCMethodTrackingMiddleware({
 
           if (securityProviderResponse?.flagAsDangerous === 1) {
             eventProperties.ui_customizations = [
-              METAMETRIC_KEY_OPTIONS.ui_customizations.flaggedAsMalicious,
+              METAMETRIC_KEY_OPT.ui_customizations.flaggedAsMalicious,
             ];
           } else if (securityProviderResponse?.flagAsDangerous === 2) {
             eventProperties.ui_customizations = [
-              METAMETRIC_KEY_OPTIONS.ui_customizations.flaggedAsSafetyUnknown,
+              METAMETRIC_KEY_OPT.ui_customizations.flaggedAsSafetyUnknown,
             ];
           }
 
@@ -208,9 +208,7 @@ export default function createRPCMethodTrackingMiddleware({
             if (isSIWEMessage) {
               eventProperties.ui_customizations = (
                 eventProperties.ui_customizations || []
-              ).push(
-                METAMETRIC_KEY_OPTIONS[METAMETRIC_KEY.UI_CUSTOMIZATIONS].SIWE,
-              );
+              ).push(METAMETRIC_KEY_OPT[METAMETRIC_KEY.UI_CUSTOMIZATIONS].SIWE);
             }
           }
         } catch (e) {

--- a/app/scripts/lib/createRPCMethodTrackingMiddleware.js
+++ b/app/scripts/lib/createRPCMethodTrackingMiddleware.js
@@ -165,8 +165,6 @@ export default function createRPCMethodTrackingMiddleware({
         ? eventType.REQUESTED
         : EVENT_NAMES.PROVIDER_METHOD_CALLED;
 
-      let msgParams;
-
       if (event === EVENT_NAMES.SIGNATURE_REQUESTED) {
         eventProperties.signature_type = method;
 
@@ -174,15 +172,13 @@ export default function createRPCMethodTrackingMiddleware({
         const from = req?.params?.[1];
         const paramsExamplePassword = req?.params?.[2];
 
-        msgParams = {
-          ...paramsExamplePassword,
-          from,
-          data,
-          origin,
-        };
-
         const msgData = {
-          msgParams,
+          msgParams: {
+            ...paramsExamplePassword,
+            from,
+            data,
+            origin,
+          },
           status: TransactionStatus.unapproved,
           type: req.method,
         };

--- a/app/scripts/lib/createRPCMethodTrackingMiddleware.js
+++ b/app/scripts/lib/createRPCMethodTrackingMiddleware.js
@@ -41,7 +41,7 @@ const RATE_LIMIT_MAP = {
 
 /**
  * For events with user interaction (approve / reject | cancel) this map will
- * return an object with APPROVED, REJECTED and REQUESTED keys that map to the
+ * return an object with APPROVED, REJECTED, REQUESTED, and FAILED keys that map to the
  * appropriate event names.
  */
 const EVENT_NAME_MAP = {

--- a/app/scripts/lib/createRPCMethodTrackingMiddleware.js
+++ b/app/scripts/lib/createRPCMethodTrackingMiddleware.js
@@ -142,7 +142,7 @@ export default function createRPCMethodTrackingMiddleware({
     // keys for the various events in the flow.
     const eventType = EVENT_NAME_MAP[method];
 
-    const properties = {};
+    const eventProperties = {};
 
     // Boolean variable that reduces code duplication and increases legibility
     const shouldTrackEvent =
@@ -167,7 +167,7 @@ export default function createRPCMethodTrackingMiddleware({
       let msgParams;
 
       if (event === EVENT_NAMES.SIGNATURE_REQUESTED) {
-        properties.signature_type = method;
+        eventProperties.signature_type = method;
 
         const data = req?.params?.[0];
         const from = req?.params?.[1];
@@ -193,22 +193,22 @@ export default function createRPCMethodTrackingMiddleware({
           );
 
           if (securityProviderResponse?.flagAsDangerous === 1) {
-            properties.ui_customizations = ['flagged_as_malicious'];
+            eventProperties.ui_customizations = ['flagged_as_malicious'];
           } else if (securityProviderResponse?.flagAsDangerous === 2) {
-            properties.ui_customizations = ['flagged_as_safety_unknown'];
+            eventProperties.ui_customizations = ['flagged_as_safety_unknown'];
           } else {
-            properties.ui_customizations = null;
+            eventProperties.ui_customizations = null;
           }
 
           if (method === MESSAGE_TYPE.PERSONAL_SIGN) {
             const { isSIWEMessage } = detectSIWE({ data });
             if (isSIWEMessage) {
-              properties.ui_customizations === null
-                ? (properties.ui_customizations = [
+              eventProperties.ui_customizations === null
+                ? (eventProperties.ui_customizations = [
                     METAMETRIC_KEY_OPTIONS[METAMETRIC_KEY.UI_CUSTOMIZATIONS]
                       .SIWE,
                   ])
-                : properties.ui_customizations.push(
+                : eventProperties.ui_customizations.push(
                     METAMETRIC_KEY_OPTIONS[METAMETRIC_KEY.UI_CUSTOMIZATIONS]
                       .SIWE,
                   );
@@ -220,7 +220,7 @@ export default function createRPCMethodTrackingMiddleware({
           );
         }
       } else {
-        properties.method = method;
+        eventProperties.method = method;
       }
 
       trackEvent({
@@ -229,7 +229,7 @@ export default function createRPCMethodTrackingMiddleware({
         referrer: {
           url: origin,
         },
-        properties,
+        properties: eventProperties,
       });
 
       rateLimitTimeouts[method] = setTimeout(() => {
@@ -252,7 +252,7 @@ export default function createRPCMethodTrackingMiddleware({
       let event;
       if (isDisabledRPCMethod) {
         event = eventType.FAILED;
-        properties.error = res.error;
+        eventProperties.error = res.error;
       } else if (res.error?.code === errorCodes.provider.userRejectedRequest) {
         event = eventType.REJECTED;
       } else {
@@ -265,7 +265,7 @@ export default function createRPCMethodTrackingMiddleware({
         referrer: {
           url: origin,
         },
-        properties,
+        properties: eventProperties,
       });
 
       return callback();

--- a/app/scripts/lib/createRPCMethodTrackingMiddleware.js
+++ b/app/scripts/lib/createRPCMethodTrackingMiddleware.js
@@ -142,6 +142,8 @@ export default function createRPCMethodTrackingMiddleware({
     // keys for the various events in the flow.
     const eventType = EVENT_NAME_MAP[method];
 
+    const properties = {};
+
     // Boolean variable that reduces code duplication and increases legibility
     const shouldTrackEvent =
       // Don't track if the request came from our own UI or background
@@ -161,8 +163,6 @@ export default function createRPCMethodTrackingMiddleware({
       const event = eventType
         ? eventType.REQUESTED
         : EVENT_NAMES.PROVIDER_METHOD_CALLED;
-
-      const properties = {};
 
       let msgParams;
 
@@ -242,8 +242,6 @@ export default function createRPCMethodTrackingMiddleware({
         return callback();
       }
 
-      const properties = {};
-
       // The rpc error methodNotFound implies that 'eth_sign' is disabled in Advanced Settings
       const isDisabledEthSignAdvancedSetting =
         method === MESSAGE_TYPE.ETH_SIGN &&
@@ -259,65 +257,6 @@ export default function createRPCMethodTrackingMiddleware({
         event = eventType.REJECTED;
       } else {
         event = eventType.APPROVED;
-      }
-
-      let msgParams;
-
-      if (eventType.REQUESTED === EVENT_NAMES.SIGNATURE_REQUESTED) {
-        properties.signature_type = method;
-
-        const data = req?.params?.[0];
-        const from = req?.params?.[1];
-        const paramsExamplePassword = req?.params?.[2];
-
-        msgParams = {
-          ...paramsExamplePassword,
-          from,
-          data,
-          origin,
-        };
-
-        const msgData = {
-          msgParams,
-          status: 'unapproved',
-          type: req.method,
-        };
-
-        try {
-          const securityProviderResponse = await securityProviderRequest(
-            msgData,
-            req.method,
-          );
-
-          if (securityProviderResponse?.flagAsDangerous === 1) {
-            properties.ui_customizations = ['flagged_as_malicious'];
-          } else if (securityProviderResponse?.flagAsDangerous === 2) {
-            properties.ui_customizations = ['flagged_as_safety_unknown'];
-          } else {
-            properties.ui_customizations = null;
-          }
-
-          if (method === MESSAGE_TYPE.PERSONAL_SIGN) {
-            const { isSIWEMessage } = detectSIWE({ data });
-            if (isSIWEMessage) {
-              properties.ui_customizations === null
-                ? (properties.ui_customizations = [
-                    METAMETRIC_KEY_OPTIONS[METAMETRIC_KEY.UI_CUSTOMIZATIONS]
-                      .SIWE,
-                  ])
-                : properties.ui_customizations.push(
-                    METAMETRIC_KEY_OPTIONS[METAMETRIC_KEY.UI_CUSTOMIZATIONS]
-                      .SIWE,
-                  );
-            }
-          }
-        } catch (e) {
-          console.warn(
-            `createRPCMethodTrackingMiddleware: Error calling securityProviderRequest - ${e}`,
-          );
-        }
-      } else {
-        properties.method = method;
       }
 
       trackEvent({

--- a/app/scripts/lib/createRPCMethodTrackingMiddleware.js
+++ b/app/scripts/lib/createRPCMethodTrackingMiddleware.js
@@ -1,5 +1,6 @@
 import { errorCodes } from 'eth-rpc-errors';
 import { MESSAGE_TYPE, ORIGIN_METAMASK } from '../../../shared/constants/app';
+import { TransactionStatus } from '../../../shared/constants/transaction';
 import { SECOND } from '../../../shared/constants/time';
 import { detectSIWE } from '../../../shared/modules/siwe';
 import {
@@ -182,7 +183,7 @@ export default function createRPCMethodTrackingMiddleware({
 
         const msgData = {
           msgParams,
-          status: 'unapproved',
+          status: TransactionStatus.unapproved,
           type: req.method,
         };
 

--- a/app/scripts/lib/createRPCMethodTrackingMiddleware.test.js
+++ b/app/scripts/lib/createRPCMethodTrackingMiddleware.test.js
@@ -356,7 +356,6 @@ describe('createRPCMethodTrackingMiddleware', () => {
 
     describe('when request flagged as safety unknown by security provider', () => {
       beforeEach(() => {
-        metricsState.participateInMetaMetrics = true;
         flagAsDangerous = 2;
       });
 

--- a/app/scripts/lib/createRPCMethodTrackingMiddleware.test.js
+++ b/app/scripts/lib/createRPCMethodTrackingMiddleware.test.js
@@ -258,92 +258,90 @@ describe('createRPCMethodTrackingMiddleware', () => {
         });
       });
     });
-  });
 
-  describe('participateInMetaMetrics is set to true with a request flagged as safe', () => {
-    beforeEach(() => {
-      metricsState.participateInMetaMetrics = true;
-    });
+    describe('when request is flagged as safe by security provider', () => {
+      it(`should immediately track a ${EVENT_NAMES.SIGNATURE_REQUESTED} event`, async () => {
+        const req = {
+          method: MESSAGE_TYPE.ETH_SIGN,
+          origin: 'some.dapp',
+        };
+        const res = {
+          error: null,
+        };
+        const { next } = getNext();
 
-    it(`should immediately track a ${EVENT_NAMES.SIGNATURE_REQUESTED} event which is flagged as safe`, async () => {
-      const req = {
-        method: MESSAGE_TYPE.ETH_SIGN,
-        origin: 'some.dapp',
-      };
+        await handler(req, res, next);
 
-      const res = {
-        error: null,
-      };
-      const { next } = getNext();
-      await handler(req, res, next);
-      expect(trackEvent).toHaveBeenCalledTimes(1);
-      expect(trackEvent.mock.calls[0][0]).toMatchObject({
-        category: 'inpage_provider',
-        event: EVENT_NAMES.SIGNATURE_REQUESTED,
-        properties: {
-          signature_type: MESSAGE_TYPE.ETH_SIGN,
-        },
-        referrer: { url: 'some.dapp' },
+        expect(trackEvent).toHaveBeenCalledTimes(1);
+        expect(trackEvent.mock.calls[0][0]).toMatchObject({
+          category: 'inpage_provider',
+          event: EVENT_NAMES.SIGNATURE_REQUESTED,
+          properties: {
+            signature_type: MESSAGE_TYPE.ETH_SIGN,
+          },
+          referrer: { url: 'some.dapp' },
+        });
       });
     });
-  });
 
-  describe('participateInMetaMetrics is set to true with a request flagged as malicious', () => {
-    beforeEach(() => {
-      metricsState.participateInMetaMetrics = true;
-      flagAsDangerous = 1;
-    });
+    describe('when request is flagged as malicious by security provider', () => {
+      beforeEach(() => {
+        flagAsDangerous = 1;
+      });
 
-    it(`should immediately track a ${EVENT_NAMES.SIGNATURE_REQUESTED} event which is flagged as malicious`, async () => {
-      const req = {
-        method: MESSAGE_TYPE.ETH_SIGN,
-        origin: 'some.dapp',
-      };
+      it(`should immediately track a ${EVENT_NAMES.SIGNATURE_REQUESTED} event which is flagged as malicious`, async () => {
+        const req = {
+          method: MESSAGE_TYPE.ETH_SIGN,
+          origin: 'some.dapp',
+        };
+        const res = {
+          error: null,
+        };
+        const { next } = getNext();
 
-      const res = {
-        error: null,
-      };
-      const { next } = getNext();
-      await handler(req, res, next);
-      expect(trackEvent).toHaveBeenCalledTimes(1);
-      expect(trackEvent.mock.calls[0][0]).toMatchObject({
-        category: 'inpage_provider',
-        event: EVENT_NAMES.SIGNATURE_REQUESTED,
-        properties: {
-          signature_type: MESSAGE_TYPE.ETH_SIGN,
-          ui_customizations: ['flagged_as_malicious'],
-        },
-        referrer: { url: 'some.dapp' },
+        await handler(req, res, next);
+
+        expect(trackEvent).toHaveBeenCalledTimes(1);
+        expect(trackEvent.mock.calls[0][0]).toMatchObject({
+          category: 'inpage_provider',
+          event: EVENT_NAMES.SIGNATURE_REQUESTED,
+          properties: {
+            signature_type: MESSAGE_TYPE.ETH_SIGN,
+            ui_customizations: ['flagged_as_malicious'],
+          },
+          referrer: { url: 'some.dapp' },
+        });
       });
     });
-  });
 
-  describe('participateInMetaMetrics is set to true with a request flagged as safety unknown', () => {
-    beforeEach(() => {
-      metricsState.participateInMetaMetrics = true;
-      flagAsDangerous = 2;
-    });
+    describe('when request flagged as safety unknown by security provider', () => {
+      beforeEach(() => {
+        metricsState.participateInMetaMetrics = true;
+        flagAsDangerous = 2;
+      });
 
-    it(`should immediately track a ${EVENT_NAMES.SIGNATURE_REQUESTED} event which is flagged as safety unknown`, async () => {
-      const req = {
-        method: MESSAGE_TYPE.ETH_SIGN,
-        origin: 'some.dapp',
-      };
+      it(`should immediately track a ${EVENT_NAMES.SIGNATURE_REQUESTED} event which is flagged as safety unknown`, async () => {
+        const req = {
+          method: MESSAGE_TYPE.ETH_SIGN,
+          origin: 'some.dapp',
+        };
+        const res = {
+          error: null,
+        };
+        const { next } = getNext();
 
-      const res = {
-        error: null,
-      };
-      const { next } = getNext();
-      await handler(req, res, next);
-      expect(trackEvent).toHaveBeenCalledTimes(1);
-      expect(trackEvent.mock.calls[0][0]).toMatchObject({
-        category: 'inpage_provider',
-        event: EVENT_NAMES.SIGNATURE_REQUESTED,
-        properties: {
-          signature_type: MESSAGE_TYPE.ETH_SIGN,
-          ui_customizations: ['flagged_as_safety_unknown'],
-        },
-        referrer: { url: 'some.dapp' },
+        await handler(req, res, next);
+
+        expect(trackEvent).toHaveBeenCalledTimes(1);
+        expect(trackEvent.mock.calls[0][0]).toMatchObject({
+          category: 'inpage_provider',
+          event: EVENT_NAMES.SIGNATURE_REQUESTED,
+          properties: {
+            signature_type: MESSAGE_TYPE.ETH_SIGN,
+            ui_customizations: ['flagged_as_safety_unknown'],
+          },
+          referrer: { url: 'some.dapp' },
+        });
       });
     });
   });

--- a/app/scripts/lib/createRPCMethodTrackingMiddleware.test.js
+++ b/app/scripts/lib/createRPCMethodTrackingMiddleware.test.js
@@ -282,7 +282,6 @@ describe('createRPCMethodTrackingMiddleware', () => {
         event: EVENT_NAMES.SIGNATURE_REQUESTED,
         properties: {
           signature_type: MESSAGE_TYPE.ETH_SIGN,
-          ui_customizations: null,
         },
         referrer: { url: 'some.dapp' },
       });

--- a/app/scripts/lib/createRPCMethodTrackingMiddleware.test.js
+++ b/app/scripts/lib/createRPCMethodTrackingMiddleware.test.js
@@ -153,7 +153,7 @@ describe('createRPCMethodTrackingMiddleware', () => {
       };
 
       const res = {
-        error: { code: 4001 },
+        error: { code: errorCodes.provider.userRejectedRequest },
       };
       const { next, executeMiddlewareStack } = getNext();
       await handler(req, res, next);

--- a/shared/constants/metametrics.js
+++ b/shared/constants/metametrics.js
@@ -473,6 +473,8 @@ export const METAMETRIC_KEY = {
  */
 export const METAMETRIC_KEY_OPTIONS = {
   [METAMETRIC_KEY.UI_CUSTOMIZATIONS]: {
+    flaggedAsMalicious: 'flagged_as_malicious',
+    flaggedAsSafetyUnknown: 'flagged_as_safety_unknown',
     SIWE: 'sign_in_with_ethereum',
   },
 };

--- a/shared/constants/metametrics.js
+++ b/shared/constants/metametrics.js
@@ -462,16 +462,16 @@ export const CONTEXT_PROPS = {
 };
 
 /**
- * These types correspond to the keys in the METAMETRIC_KEY_OPTIONS object
+ * These types correspond to the keys in the METAMETRIC_KEY_OPT object
  */
 export const METAMETRIC_KEY = {
   UI_CUSTOMIZATIONS: `ui_customizations`,
 };
 
 /**
- * This object maps a method name to a METAMETRIC_KEY
+ * This object maps a METAMETRIC_KEY to an object of possible options
  */
-export const METAMETRIC_KEY_OPTIONS = {
+export const METAMETRIC_KEY_OPT = {
   [METAMETRIC_KEY.UI_CUSTOMIZATIONS]: {
     flaggedAsMalicious: 'flagged_as_malicious',
     flaggedAsSafetyUnknown: 'flagged_as_safety_unknown',


### PR DESCRIPTION
## Explanation

Fixes: #18474
See: #18007
Progresses #17974

Fix SIWE event and clean createRPCMethodTrackingMiddleware logic

Fix SIWE event that was introduced in https://github.com/MetaMask/metamask-extension/pull/17688:
(while adding a test, I found a bug with the metametric event)
- fix SIWE (sign-in with ethereum) event (returning number of array length instead of string) 
- add SIWE test

Clean: 
- condense tests
- only need to build event properties once
- no need to pass null event property (`ui_customizations`)
- add `ui_customizations` event props to metametrics const
- use `errorCodes` and `TransactionStatus` const

## Screenshots/Screencaps

<!-- If you're making a change to the UI, make sure to capture a screenshot or a short video showing off your work! -->

### Before

<!-- How did the UI you changed look before your changes? Drag your file(s) below this line: -->

### After

<!-- How does it look now? Drag your file(s) below this line: -->

## Manual Testing Steps

1.  send RPC transaction through test Dapp
2. with metametrics turned on, observe metametrics still send
3. observe SIWE 

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [x] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [x] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
