### PR TITLE
Use form text field component in custom spending cup

### DIFF
--- a/test/e2e/tests/custom-token-add-approve.spec.js
+++ b/test/e2e/tests/custom-token-add-approve.spec.js
@@ -246,9 +246,7 @@ describe('Create token, approve token and approve token without gas', function (
         );
 
         // set custom spending cap
-        let setSpendingCap = await driver.findElement(
-          '[data-testid="custom-spending-cap-input"]',
-        );
+        let setSpendingCap = await driver.findElement('#custom-spending-cap');
         await setSpendingCap.fill('5');
 
         await driver.clickElement({
@@ -303,9 +301,7 @@ describe('Create token, approve token and approve token without gas', function (
           text: 'Edit',
         });
 
-        setSpendingCap = await driver.findElement(
-          '[data-testid="custom-spending-cap-input"]',
-        );
+        setSpendingCap = await driver.findElement('#custom-spending-cap');
         await setSpendingCap.fill('9');
 
         await driver.clickElement({
@@ -391,7 +387,7 @@ describe('Create token, approve token and approve token without gas', function (
 
         // set max spending cap
         await driver.clickElement({
-          css: '.custom-spending-cap__max',
+          tag: 'span',
           text: 'Max',
         });
 

--- a/ui/components/app/custom-spending-cap/custom-spending-cap-tooltip.js
+++ b/ui/components/app/custom-spending-cap/custom-spending-cap-tooltip.js
@@ -34,10 +34,11 @@ export const CustomSpendingCapTooltip = ({
           name={ICON_NAMES.DANGER}
           className="form-field__heading-title__tooltip__warning-icon"
           size={ICON_SIZES.AUTO}
-          style={{ 'vertical-align': 'bottom' }}
         />
       ) : (
-        tooltipIcon !== '' && <Icon name={ICON_NAMES.QUESTION} />
+        tooltipIcon !== '' && (
+          <Icon name={ICON_NAMES.QUESTION} size={ICON_SIZES.AUTO} />
+        )
       )}
     </Tooltip>
   </Box>

--- a/ui/components/app/custom-spending-cap/custom-spending-cap.stories.js
+++ b/ui/components/app/custom-spending-cap/custom-spending-cap.stories.js
@@ -12,7 +12,7 @@ export default {
       control: { type: 'number' },
     },
     dappProposedValue: {
-      control: { type: 'text' },
+      control: { type: 'number' },
     },
     siteOrigin: {
       control: { type: 'text' },
@@ -27,7 +27,7 @@ export default {
   args: {
     tokenName: 'DAI',
     currentTokenBalance: 200.12,
-    dappProposedValue: '7',
+    dappProposedValue: 7,
     siteOrigin: 'Uniswap.org',
     decimals: '4',
   },

--- a/ui/components/ui/review-spending-cap/review-spending-cap.js
+++ b/ui/components/ui/review-spending-cap/review-spending-cap.js
@@ -22,7 +22,6 @@ import {
   TextColor,
   IconColor,
 } from '../../../helpers/constants/design-system';
-import { Numeric } from '../../../../shared/modules/Numeric';
 
 export default function ReviewSpendingCap({
   tokenName,
@@ -31,10 +30,6 @@ export default function ReviewSpendingCap({
   onEdit,
 }) {
   const t = useContext(I18nContext);
-  const valueIsGreaterThanBalance = new Numeric(
-    Number(tokenValue),
-    10,
-  ).greaterThan(Number(currentTokenBalance), 10);
 
   return (
     <Box
@@ -77,7 +72,7 @@ export default function ReviewSpendingCap({
                   color={TextColor.textAlternative}
                   className="review-spending-cap__heading-title__tooltip"
                 >
-                  {valueIsGreaterThanBalance &&
+                  {parseFloat(tokenValue) > currentTokenBalance &&
                     t('warningTooltipText', [
                       <Typography
                         key="tooltip-text"
@@ -92,12 +87,12 @@ export default function ReviewSpendingCap({
                         {t('beCareful')}
                       </Typography>,
                     ])}
-                  {Number(tokenValue) === 0 &&
+                  {parseFloat(tokenValue) === 0 &&
                     t('revokeSpendingCapTooltipText')}
                 </Typography>
               }
             >
-              {valueIsGreaterThanBalance && (
+              {parseFloat(tokenValue) > currentTokenBalance && (
                 <Icon
                   className="review-spending-cap__heading-title__tooltip__warning-icon"
                   name={ICON_NAMES.DANGER}
@@ -106,7 +101,7 @@ export default function ReviewSpendingCap({
                   style={{ 'vertical-align': 'middle' }}
                 />
               )}
-              {Number(tokenValue) === 0 && (
+              {parseFloat(tokenValue) === 0 && (
                 <Icon
                   className="review-spending-cap__heading-title__tooltip__question-icon"
                   name={ICON_NAMES.QUESTION}
@@ -135,7 +130,7 @@ export default function ReviewSpendingCap({
         <Typography
           as={TypographyVariant.H6}
           color={
-            valueIsGreaterThanBalance
+            parseFloat(tokenValue) > currentTokenBalance
               ? TextColor.errorDefault
               : TextColor.textDefault
           }

--- a/ui/components/ui/review-spending-cap/review-spending-cap.stories.js
+++ b/ui/components/ui/review-spending-cap/review-spending-cap.stories.js
@@ -12,7 +12,7 @@ export default {
       control: { type: 'number' },
     },
     tokenValue: {
-      control: { type: 'text' },
+      control: { type: 'number' },
     },
     onEdit: {
       action: 'onEdit',
@@ -21,7 +21,7 @@ export default {
   args: {
     tokenName: 'DAI',
     currentTokenBalance: 200.12,
-    tokenValue: '7',
+    tokenValue: 7,
   },
 };
 

--- a/ui/pages/token-allowance/token-allowance.js
+++ b/ui/pages/token-allowance/token-allowance.js
@@ -54,16 +54,13 @@ import { useGasFeeContext } from '../../contexts/gasFee';
 import { getCustomTxParamsData } from '../confirm-approve/confirm-approve.util';
 import { setCustomTokenAmount } from '../../ducks/app/app';
 import { valuesFor } from '../../helpers/utils/util';
-import { calcTokenAmount } from '../../../shared/lib/transactions-controller-utils';
-import {
-  MAX_TOKEN_ALLOWANCE_AMOUNT,
-  NUM_W_OPT_DECIMAL_COMMA_OR_DOT_REGEX,
-} from '../../../shared/constants/tokens';
 import { ConfirmPageContainerNavigation } from '../../components/app/confirm-page-container';
 import { useSimulationFailureWarning } from '../../hooks/useSimulationFailureWarning';
 import SimulationErrorMessage from '../../components/ui/simulation-error-message';
 import { Icon, ICON_NAMES } from '../../components/component-library';
 import LedgerInstructionField from '../../components/app/ledger-instruction-field/ledger-instruction-field';
+import { calcTokenAmount } from '../../../shared/lib/transactions-controller-utils';
+import { MAX_TOKEN_ALLOWANCE_AMOUNT } from '../../../shared/constants/tokens';
 
 export default function TokenAllowance({
   origin,
@@ -115,15 +112,7 @@ export default function TokenAllowance({
   const useCurrencyRateCheck = useSelector(getUseCurrencyRateCheck);
   const isHardwareWalletConnected = useSelector(isHardwareWallet);
 
-  const replaceCommaToDot = (inputValue) => {
-    return inputValue.replace(/,/gu, '.');
-  };
-
-  let customPermissionAmount = NUM_W_OPT_DECIMAL_COMMA_OR_DOT_REGEX.test(
-    customTokenAmount,
-  )
-    ? replaceCommaToDot(customTokenAmount).toString()
-    : '0';
+  let customPermissionAmount = parseFloat(customTokenAmount);
 
   const maxTokenAmount = calcTokenAmount(MAX_TOKEN_ALLOWANCE_AMOUNT, decimals);
   if (customTokenAmount.length > 1 && Number(customTokenAmount)) {
@@ -395,7 +384,7 @@ export default function TokenAllowance({
             tokenValue={
               isNaN(parseFloat(customTokenAmount))
                 ? dappProposedTokenAmount
-                : replaceCommaToDot(customTokenAmount)
+                : customTokenAmount
             }
             onEdit={() => handleBackClick()}
           />

--- a/ui/pages/token-allowance/token-allowance.test.js
+++ b/ui/pages/token-allowance/token-allowance.test.js
@@ -207,7 +207,7 @@ describe('TokenAllowancePage', () => {
   });
 
   it('should click Use default and set input value to default', () => {
-    const { getByText, getByTestId } = renderWithProvider(
+    const { getByText } = renderWithProvider(
       <TokenAllowance {...props} />,
       store,
     );
@@ -215,17 +215,17 @@ describe('TokenAllowancePage', () => {
     const useDefault = getByText('Use default');
     fireEvent.click(useDefault);
 
-    const input = getByTestId('custom-spending-cap-input');
+    const input = document.getElementsByTagName('input')[0];
     expect(input.value).toBe('1');
   });
 
   it('should call back button when button is clicked and return to previous page', () => {
-    const { getByText, getByTestId } = renderWithProvider(
+    const { getByText } = renderWithProvider(
       <TokenAllowance {...props} />,
       store,
     );
 
-    const textField = getByTestId('custom-spending-cap-input');
+    const textField = document.getElementsByTagName('input')[0];
     fireEvent.change(textField, { target: { value: '1' } });
 
     const nextButton = getByText('Next');
@@ -254,12 +254,12 @@ describe('TokenAllowancePage', () => {
   });
 
   it('should show hardware wallet info text', () => {
-    const { queryByText, getByText, getByTestId } = renderWithProvider(
+    const { queryByText, getByText } = renderWithProvider(
       <TokenAllowance {...props} />,
       store,
     );
 
-    const textField = getByTestId('custom-spending-cap-input');
+    const textField = document.getElementsByTagName('input')[0];
     fireEvent.change(textField, { target: { value: '1' } });
 
     expect(queryByText('Prior to clicking confirm:')).toBeNull();


### PR DESCRIPTION
## Explanation

This PR replaces the FromField component with the FromTextField component.
This PR will move logic from the CustomSpendingCup component to FromTextField. 

The logic that is removed from CustomSpendingCup 

- To prevent entering letters in an input that expects numbers
- Limits the number of decimals that can be entered in the field
- Handling the entering of commas

<!--
Thanks for the pull request. Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues, Slack conversations, Zendesk issues, user stories, etc. reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

* Fixes #17409 

## Screenshots/Screencaps

<!-- If you're making a change to the UI, make sure to capture a screenshot or a short video showing off your work! -->

### Before

<!-- How did the UI you changed look before your changes? Drag your file(s) below this line: -->

### After

<!-- How does it look now? Drag your file(s) below this line: -->

## Manual Testing Steps

<!--
How should reviewers and QA manually test your changes? For instance:

- Go to this screen
- Do this
- Then do this
-->

Go Token allowance flow
CustomSpendingCup component should behave same as before 

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
