### PR TITLE
fix network dropdown bug

### DIFF
--- a/ui/components/app/dropdowns/network-dropdown.js
+++ b/ui/components/app/dropdowns/network-dropdown.js
@@ -199,7 +199,7 @@ class NetworkDropdown extends Component {
           >
             {nickname || rpcUrl}
           </span>
-          {isCurrentRpcTarget && (
+          {isCurrentRpcTarget ? null : (
             <ButtonIcon
               className="delete"
               iconName={ICON_NAMES.CLOSE}


### PR DESCRIPTION
I just found this bug [introduced recently](https://github.com/MetaMask/metamask-extension/pull/17811/files#diff-20a630530452c40a35ae16141be0c8ae488615ab5adb2fd4f8dd9b34656d03c3R202) where the network dropdown shows an `X` to delete the network menu option. It should be available for non preloaded networks that are not currently selected. But at the moment it is only available for the currently selected network (which leads to some bad and unexpected UX):

https://user-images.githubusercontent.com/34557516/224077655-1308804c-8c6e-4d2f-8d07-3b2f318f5d2a.mov


after the fix:
https://user-images.githubusercontent.com/34557516/224077960-e0f68e8d-ca29-462e-bf45-4d485e92fae4.mov


