### PR TITLE
Disabling network and account changes after the send flow is initiated

### DIFF
--- a/coverage-targets.js
+++ b/coverage-targets.js
@@ -9,7 +9,7 @@ module.exports = {
     lines: 66.58,
     branches: 54.79,
     statements: 65.74,
-    functions: 58.54,
+    functions: 58.4,
   },
   transforms: {
     branches: 100,

--- a/coverage-targets.js
+++ b/coverage-targets.js
@@ -6,10 +6,10 @@
 // subset of files to check against these targets.
 module.exports = {
   global: {
-    lines: 66.58,
-    branches: 54.79,
-    statements: 65.74,
-    functions: 58.4,
+    lines: 67.8,
+    branches: 55.84,
+    statements: 67.13,
+    functions: 59.66,
   },
   transforms: {
     branches: 100,

--- a/coverage-targets.js
+++ b/coverage-targets.js
@@ -6,10 +6,10 @@
 // subset of files to check against these targets.
 module.exports = {
   global: {
-    lines: 66,
-    branches: 54.4,
-    statements: 65,
-    functions: 58.5,
+    lines: 66.58,
+    branches: 54.79,
+    statements: 65.74,
+    functions: 58.54,
   },
   transforms: {
     branches: 100,

--- a/test/data/mock-send-state.json
+++ b/test/data/mock-send-state.json
@@ -2,6 +2,13 @@
   "DNS": {
     "resolution": ""
   },
+  "activeTab": {
+    "id": 113,
+    "title": "E2E Test Dapp",
+    "origin": "https://metamask.github.io",
+    "protocol": "https:",
+    "url": "https://metamask.github.io/test-dapp/"
+  },
   "appState": {
     "networkDropdownOpen": false,
     "gasIsLoading": false,
@@ -16,7 +23,8 @@
         "name": null
       }
     },
-    "warning": null
+    "warning": null,
+    "alertOpen": false
   },
   "confirmTransaction": {
     "txData": {
@@ -41,6 +49,10 @@
   },
   "history": {
     "mostRecentOverviewPage": "/mostRecentOverviewPage"
+  },
+  "invalidCustomNetwork": {
+    "state": "CLOSED",
+    "networkName": ""
   },
   "metamask": {
     "ipfsGateway": "",
@@ -88,6 +100,14 @@
     "ensResolutionsByAddress": {},
     "isAccountMenuOpen": false,
     "isUnlocked": true,
+    "completedOnboarding": true,
+    "usedNetworks": {
+      "0x1": true,
+      "0x5": true,
+      "0x539": true
+    },
+    "showTestnetMessageInDropdown": true,
+    "networkConfigurations": {},
     "alertEnabledness": {
       "unconnectedAccount": true
     },
@@ -1358,5 +1378,8 @@
       "balance": "0x4563918244f40000"
     },
     "stage": "DRAFT"
+  },
+  "unconnectedAccount": {
+    "state": "CLOSED"
   }
 }

--- a/ui/components/app/app-header/app-header.component.js
+++ b/ui/components/app/app-header/app-header.component.js
@@ -89,6 +89,7 @@ export default class AppHeader extends PureComponent {
           className={classnames('account-menu__icon', {
             'account-menu__icon--disabled': disabled,
           })}
+          disabled={disabled}
           onClick={() => {
             if (!disabled) {
               !isAccountMenuOpen &&

--- a/ui/components/app/app-header/app-header.component.js
+++ b/ui/components/app/app-header/app-header.component.js
@@ -89,7 +89,7 @@ export default class AppHeader extends PureComponent {
           className={classnames('account-menu__icon', {
             'account-menu__icon--disabled': disabled,
           })}
-          disabled={disabled}
+          disabled={disabled !== false}
           onClick={() => {
             if (!disabled) {
               !isAccountMenuOpen &&

--- a/ui/components/app/app-header/app-header.component.js
+++ b/ui/components/app/app-header/app-header.component.js
@@ -89,7 +89,7 @@ export default class AppHeader extends PureComponent {
           className={classnames('account-menu__icon', {
             'account-menu__icon--disabled': disabled,
           })}
-          disabled={disabled !== false}
+          disabled={Boolean(disabled)}
           onClick={() => {
             if (!disabled) {
               !isAccountMenuOpen &&

--- a/ui/pages/routes/routes.component.js
+++ b/ui/pages/routes/routes.component.js
@@ -322,7 +322,11 @@ export default class Routes extends Component {
   }
 
   onEditTransactionPage() {
-    return this.props.sendStage === SEND_STAGES.EDIT;
+    return (
+      this.props.sendStage === SEND_STAGES.EDIT ||
+      this.props.sendStage === SEND_STAGES.DRAFT ||
+      this.props.sendStage === SEND_STAGES.ADD_RECIPIENT
+    );
   }
 
   onSwapsPage() {

--- a/ui/pages/routes/routes.component.test.js
+++ b/ui/pages/routes/routes.component.test.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import configureMockStore from 'redux-mock-store';
 import { fireEvent } from '@testing-library/react';
-import thunk from 'redux-thunk';
 
 import { SEND_STAGES } from '../../ducks/send';
 import { renderWithProvider } from '../../../test/jest';

--- a/ui/pages/routes/routes.component.test.js
+++ b/ui/pages/routes/routes.component.test.js
@@ -55,7 +55,7 @@ describe('Routes Component', () => {
     mockHideNetworkDropdown.mockClear();
   });
   describe('render during send flow', () => {
-    it('should render while adding recipient for send flow', () => {
+    it('should render with network and account change disabled while adding recipient for send flow', () => {
       const store = configureMockStore()({
         ...mockSendState,
         send: {
@@ -71,7 +71,7 @@ describe('Routes Component', () => {
       fireEvent.click(networkDisplay);
       expect(mockShowNetworkDropdown).not.toHaveBeenCalled();
     });
-    it('should render draft send page', () => {
+    it('should render with network and account change disabled while user is in send page', () => {
       const store = configureMockStore()({
         ...mockSendState,
       });
@@ -83,7 +83,7 @@ describe('Routes Component', () => {
       fireEvent.click(networkDisplay);
       expect(mockShowNetworkDropdown).not.toHaveBeenCalled();
     });
-    it('should render while editing a send transaction', () => {
+    it('should render with network and account change disabled while editing a send transaction', () => {
       const store = configureMockStore()({
         ...mockSendState,
         send: {
@@ -100,7 +100,7 @@ describe('Routes Component', () => {
       expect(mockShowNetworkDropdown).not.toHaveBeenCalled();
     });
     it('should render when send transaction is not active', () => {
-      const store = configureMockStore([thunk])({
+      const store = configureMockStore()({
         ...mockSendState,
         metamask: {
           ...mockSendState.metamask,

--- a/ui/pages/routes/routes.component.test.js
+++ b/ui/pages/routes/routes.component.test.js
@@ -1,0 +1,54 @@
+import React from 'react';
+import configureMockStore from 'redux-mock-store';
+// import { fireEvent } from '@testing-library/react';
+
+// import { SEND_STAGES } from '../../ducks/send';
+// import { getInitialSendStateWithExistingTxState } from '../../../test/jest/mocks';
+import { renderWithProvider } from '../../../test/jest';
+import mockSendState from '../../../test/data/mock-send-state.json';
+import Routes from '.';
+
+jest.mock('webextension-polyfill', () => ({
+  runtime: {
+    onMessage: {
+      addListener: jest.fn(),
+      removeListener: jest.fn(),
+    },
+    getManifest: () => ({ manifest_version: 2 }),
+  },
+}));
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useHistory: () => ({
+    push: jest.fn(),
+  }),
+}));
+
+jest.mock('react-redux', () => {
+  const actual = jest.requireActual('react-redux');
+
+  return {
+    ...actual,
+    useDispatch: jest.fn(),
+  };
+});
+
+describe('Routes Component', () => {
+  describe('render', () => {
+    it('should render draft send page', () => {
+      const store = configureMockStore()({
+        ...mockSendState,
+        // send: getInitialSendStateWithExistingTxState(),
+      });
+      const { container, findByTestId } = renderWithProvider(
+        <Routes />,
+        store,
+        ['/send'],
+      );
+
+      expect(container).toMatchSnapshot();
+      expect(findByTestId('account-menu-icon')).toBeDisabled();
+    });
+  });
+});

--- a/ui/pages/routes/routes.component.test.js
+++ b/ui/pages/routes/routes.component.test.js
@@ -1,12 +1,15 @@
 import React from 'react';
 import configureMockStore from 'redux-mock-store';
-// import { fireEvent } from '@testing-library/react';
+import { fireEvent } from '@testing-library/react';
+import thunk from 'redux-thunk';
 
-// import { SEND_STAGES } from '../../ducks/send';
-// import { getInitialSendStateWithExistingTxState } from '../../../test/jest/mocks';
+import { SEND_STAGES } from '../../ducks/send';
 import { renderWithProvider } from '../../../test/jest';
 import mockSendState from '../../../test/data/mock-send-state.json';
 import Routes from '.';
+
+const mockShowNetworkDropdown = jest.fn();
+const mockHideNetworkDropdown = jest.fn();
 
 jest.mock('webextension-polyfill', () => ({
   runtime: {
@@ -19,14 +22,13 @@ jest.mock('webextension-polyfill', () => ({
 }));
 
 jest.mock('../../store/actions', () => ({
-  disconnectGasFeeEstimatePoller: jest.fn(),
   getGasFeeTimeEstimate: jest.fn().mockImplementation(() => Promise.resolve()),
   getGasFeeEstimatesAndStartPolling: jest
     .fn()
     .mockImplementation(() => Promise.resolve()),
   addPollingTokenToAppState: jest.fn(),
-  removePollingTokenFromAppState: jest.fn(),
-  createTransactionEventFragment: jest.fn(),
+  showNetworkDropdown: () => mockShowNetworkDropdown,
+  hideNetworkDropdown: () => mockHideNetworkDropdown,
 }));
 
 jest.mock('react-router-dom', () => ({
@@ -48,7 +50,27 @@ jest.mock('../../ducks/domains', () => ({
 }));
 
 describe('Routes Component', () => {
-  describe('render', () => {
+  afterEach(() => {
+    mockShowNetworkDropdown.mockClear();
+    mockHideNetworkDropdown.mockClear();
+  });
+  describe('render during send flow', () => {
+    it('should render while adding recipient for send flow', () => {
+      const store = configureMockStore()({
+        ...mockSendState,
+        send: {
+          ...mockSendState.send,
+          stage: SEND_STAGES.ADD_RECIPIENT,
+        },
+      });
+      const { getByTestId } = renderWithProvider(<Routes />, store, ['/send']);
+
+      expect(getByTestId('account-menu-icon')).toBeDisabled();
+
+      const networkDisplay = getByTestId('network-display');
+      fireEvent.click(networkDisplay);
+      expect(mockShowNetworkDropdown).not.toHaveBeenCalled();
+    });
     it('should render draft send page', () => {
       const store = configureMockStore()({
         ...mockSendState,
@@ -56,6 +78,46 @@ describe('Routes Component', () => {
       const { getByTestId } = renderWithProvider(<Routes />, store, ['/send']);
 
       expect(getByTestId('account-menu-icon')).toBeDisabled();
+
+      const networkDisplay = getByTestId('network-display');
+      fireEvent.click(networkDisplay);
+      expect(mockShowNetworkDropdown).not.toHaveBeenCalled();
+    });
+    it('should render while editing a send transaction', () => {
+      const store = configureMockStore()({
+        ...mockSendState,
+        send: {
+          ...mockSendState.send,
+          stage: SEND_STAGES.EDIT,
+        },
+      });
+      const { getByTestId } = renderWithProvider(<Routes />, store, ['/send']);
+
+      expect(getByTestId('account-menu-icon')).toBeDisabled();
+
+      const networkDisplay = getByTestId('network-display');
+      fireEvent.click(networkDisplay);
+      expect(mockShowNetworkDropdown).not.toHaveBeenCalled();
+    });
+    it('should render when send transaction is not active', () => {
+      const store = configureMockStore([thunk])({
+        ...mockSendState,
+        metamask: {
+          ...mockSendState.metamask,
+          swapsState: {
+            ...mockSendState.metamask.swapsState,
+            swapsFeatureIsLive: true,
+          },
+          pendingApprovals: {},
+          announcements: {},
+        },
+        send: {
+          ...mockSendState.send,
+          stage: SEND_STAGES.INACTIVE,
+        },
+      });
+      const { getByTestId } = renderWithProvider(<Routes />, store);
+      expect(getByTestId('account-menu-icon')).not.toBeDisabled();
     });
   });
 });

--- a/ui/pages/routes/routes.component.test.js
+++ b/ui/pages/routes/routes.component.test.js
@@ -18,6 +18,17 @@ jest.mock('webextension-polyfill', () => ({
   },
 }));
 
+jest.mock('../../store/actions', () => ({
+  disconnectGasFeeEstimatePoller: jest.fn(),
+  getGasFeeTimeEstimate: jest.fn().mockImplementation(() => Promise.resolve()),
+  getGasFeeEstimatesAndStartPolling: jest
+    .fn()
+    .mockImplementation(() => Promise.resolve()),
+  addPollingTokenToAppState: jest.fn(),
+  removePollingTokenFromAppState: jest.fn(),
+  createTransactionEventFragment: jest.fn(),
+}));
+
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
   useHistory: () => ({
@@ -25,30 +36,26 @@ jest.mock('react-router-dom', () => ({
   }),
 }));
 
-jest.mock('react-redux', () => {
-  const actual = jest.requireActual('react-redux');
+jest.mock('../../ducks/send', () => ({
+  ...jest.requireActual('../../ducks/send'),
+  resetSendState: () => ({ type: 'XXX' }),
+  getGasPrice: jest.fn(),
+}));
 
-  return {
-    ...actual,
-    useDispatch: jest.fn(),
-  };
-});
+jest.mock('../../ducks/domains', () => ({
+  ...jest.requireActual('../../ducks/domains'),
+  initializeDomainSlice: () => ({ type: 'XXX' }),
+}));
 
 describe('Routes Component', () => {
   describe('render', () => {
     it('should render draft send page', () => {
       const store = configureMockStore()({
         ...mockSendState,
-        // send: getInitialSendStateWithExistingTxState(),
       });
-      const { container, findByTestId } = renderWithProvider(
-        <Routes />,
-        store,
-        ['/send'],
-      );
+      const { getByTestId } = renderWithProvider(<Routes />, store, ['/send']);
 
-      expect(container).toMatchSnapshot();
-      expect(findByTestId('account-menu-icon')).toBeDisabled();
+      expect(getByTestId('account-menu-icon')).toBeDisabled();
     });
   });
 });


### PR DESCRIPTION
## Explanation
Fixes #18045 
The initial issue was that if the user changes the network while performing a send transaction using ens, the ens gets resolved to the new network's wrong address.

The solution is to disable the ability to change the network and account once the user start a sends transactions. 
https://github.com/MetaMask/metamask-extension/issues/18045#issuecomment-1460467835

<!--
Thanks for the pull request. Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues, Slack conversations, Zendesk issues, user stories, etc. reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

## Screenshots/Screencaps

<!-- If you're making a change to the UI, make sure to capture a screenshot or a short video showing off your work! -->

### Before

<!-- How did the UI you changed look before your changes? Drag your file(s) below this line: -->

### After

<!-- How does it look now? Drag your file(s) below this line: -->

## Manual Testing Steps
1. Start a send transaction.
2. Click on the network display bar to change the network in the `add recipient page`; this should be disabled.
3. Click on the network display bar to change the network in the `draft send page`, this should also be disabled.
<!--
How should reviewers and QA manually test your changes? For instance:

- Go to this screen
- Do this
- Then do this
-->

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
