### PR TITLE
fix: do not run desktop prep build step on master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,6 +55,9 @@ workflows:
           requires:
             - prep-deps
       - prep-build-desktop:
+          filters:
+            branches:
+              ignore: master
           requires:
             - prep-deps
       - prep-build-flask:
@@ -137,6 +140,9 @@ workflows:
           requires:
             - trigger-beta-build
       - validate-source-maps-desktop:
+          filters:
+            branches:
+              ignore: master
           requires:
             - prep-build-desktop
       - validate-source-maps-flask:
@@ -152,6 +158,9 @@ workflows:
             - prep-deps
             - trigger-beta-build
       - test-mozilla-lint-desktop:
+          filters:
+            branches:
+              ignore: master
           requires:
             - prep-deps
             - prep-build-desktop
@@ -387,25 +396,9 @@ jobs:
       - checkout
       - attach_workspace:
           at: .
-      - when:
-          condition:
-            not:
-              matches:
-                pattern: /^master$/
-                value: << pipeline.git.branch >>
-          steps:
-            - run:
-                name: build:dist
-                command: yarn build --build-type desktop dist
-      - when:
-          condition:
-            matches:
-              pattern: /^master$/
-              value: << pipeline.git.branch >>
-          steps:
-            - run:
-                name: build:prod
-                command: yarn build --build-type desktop prod
+      - run:
+          name: build:dist
+          command: yarn build --build-type desktop dist
       - run:
           name: build:debug
           command: find dist/ -type f -exec md5sum {} \; | sort -k 2


### PR DESCRIPTION
## Explanation

Removes CI desktop build type jobs for master branch. The reason is that desktop build type is not intend to be released on the Extension. It is mainly used for the actual Desktop App build, and introduce new features. Desktop support at the Extension level is available on the Flask build type.

## Manual Testing Steps
Pushed with a `only: test` filter first and let the CI run. [Execution here](https://app.circleci.com/pipelines/github/MetaMask/metamask-extension/39240/workflows/85831b50-772d-4db7-bef4-6772285838e0). You will notice that there are no desktop build type jobs there.

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
