### PR TITLE
[e2e] ENS test improvement - with network controller fixture

### DIFF
--- a/test/e2e/tests/ens.spec.js
+++ b/test/e2e/tests/ens.spec.js
@@ -52,7 +52,16 @@ describe('ENS', function () {
   it('domain resolves to a correct address', async function () {
     await withFixtures(
       {
-        fixtures: new FixtureBuilder().build(),
+        fixtures: new FixtureBuilder()
+        .withNetworkController({
+          provider: {
+            chainId: '0x1',
+            nickname: '',
+            rpcUrl: '',
+            type: 'mainnet',
+          },
+        })
+        .build(),
         ganacheOptions,
         title: this.test.title,
         testSpecificMock: mockInfura,
@@ -63,9 +72,7 @@ describe('ENS', function () {
         await driver.press('#password', driver.Key.ENTER);
 
         await driver.waitForElementNotPresent('.loading-overlay');
-        await driver.clickElement('.network-display');
-        await driver.clickElement({ text: 'Ethereum Mainnet', tag: 'span' });
-
+        
         await driver.clickElement('[data-testid="eth-overview-send"]');
 
         await driver.fill(

--- a/test/e2e/tests/ens.spec.js
+++ b/test/e2e/tests/ens.spec.js
@@ -53,15 +53,15 @@ describe('ENS', function () {
     await withFixtures(
       {
         fixtures: new FixtureBuilder()
-        .withNetworkController({
-          provider: {
-            chainId: '0x1',
-            nickname: '',
-            rpcUrl: '',
-            type: 'mainnet',
-          },
-        })
-        .build(),
+          .withNetworkController({
+            provider: {
+              chainId: '0x1',
+              nickname: '',
+              rpcUrl: '',
+              type: 'mainnet',
+            },
+          })
+          .build(),
         ganacheOptions,
         title: this.test.title,
         testSpecificMock: mockInfura,
@@ -72,7 +72,7 @@ describe('ENS', function () {
         await driver.press('#password', driver.Key.ENTER);
 
         await driver.waitForElementNotPresent('.loading-overlay');
-        
+
         await driver.clickElement('[data-testid="eth-overview-send"]');
 
         await driver.fill(


### PR DESCRIPTION
## Explanation
Adding Network Controller fixture to ENS test, to skip the initial steps of changing network.

## Screenshots/Screencaps
/

### Before

/

### After

/

## Manual Testing Steps
On your local run
- `yarn build:test`
- `yarn test:e2e:single test/e2e/tests/ens.spec.js --browser=firefox`

## Pre-merge author checklist

- [X] I've clearly explained:
  - [X] What problem this PR is solving
  - [X] How this problem was solved
  - [X] How reviewers can test my changes
- [X] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
