### PR TITLE
make network-controller methods overwrite rather than merge provider state

### DIFF
--- a/app/scripts/controllers/network/network-controller.js
+++ b/app/scripts/controllers/network/network-controller.js
@@ -294,7 +294,7 @@ export default class NetworkController extends EventEmitter {
 
   rollbackToPreviousProvider() {
     const config = this.previousProviderStore.getState();
-    this.providerStore.updateState(config);
+    this.providerStore.putState(config);
     this._switchNetwork(config);
   }
 
@@ -352,7 +352,7 @@ export default class NetworkController extends EventEmitter {
    * @param {boolean} isSupported - True if the EIP is supported
    */
   _setNetworkEIPSupport(EIPNumber, isSupported) {
-    this.networkDetails.updateState({
+    this.networkDetails.putState({
       EIPS: {
         [EIPNumber]: isSupported,
       },
@@ -372,8 +372,8 @@ export default class NetworkController extends EventEmitter {
    * @param config
    */
   _setProviderConfig(config) {
-    this.previousProviderStore.updateState(this.providerStore.getState());
-    this.providerStore.updateState(config);
+    this.previousProviderStore.putState(this.providerStore.getState());
+    this.providerStore.putState(config);
     this._switchNetwork(config);
   }
 

--- a/app/scripts/controllers/network/network-controller.js
+++ b/app/scripts/controllers/network/network-controller.js
@@ -572,7 +572,7 @@ export default class NetworkController extends EventEmitter {
     )?.id;
 
     const newNetworkConfigurationId = oldNetworkConfigurationId || random();
-    this.networkConfigurationsStore.updateState({
+    this.networkConfigurationsStore.putState({
       ...networkConfigurations,
       [newNetworkConfigurationId]: {
         ...newNetworkConfiguration,

--- a/app/scripts/controllers/network/network-controller.test.js
+++ b/app/scripts/controllers/network/network-controller.test.js
@@ -3218,7 +3218,6 @@ describe('NetworkController', () => {
                   blockExplorerUrl:
                     BUILT_IN_NETWORKS[networkType].blockExplorerUrl,
                 },
-                id: 'testNetworkConfigurationId2',
               });
             },
           );
@@ -4213,7 +4212,7 @@ describe('NetworkController', () => {
       networkVersion,
     } of INFURA_NETWORKS) {
       describe(`if the previous provider configuration had a type of "${networkType}"`, () => {
-        it('merges the previous configuration into the current provider configuration', async () => {
+        it('overwrites the the current provider configuration with the previous provider configuration', async () => {
           await withController(
             {
               state: {
@@ -4295,7 +4294,6 @@ describe('NetworkController', () => {
                 chainId: BUILT_IN_NETWORKS[networkType].chainId,
                 ticker: BUILT_IN_NETWORKS[networkType].ticker,
                 nickname: '',
-                id: 'testNetworkConfigurationId1',
                 rpcPrefs: {
                   blockExplorerUrl:
                     BUILT_IN_NETWORKS[networkType].blockExplorerUrl,
@@ -4871,7 +4869,7 @@ describe('NetworkController', () => {
     }
 
     describe(`if the previous provider configuration had a type of "rpc"`, () => {
-      it('merges the previous configuration into the current provider configuration', async () => {
+      it('overwrites the the current provider configuration with the previous provider configuration', async () => {
         await withController(
           {
             state: {
@@ -4940,7 +4938,6 @@ describe('NetworkController', () => {
               rpcPrefs: {
                 blockExplorerUrl: 'https://goerli.etherscan.io',
               },
-              id: 'testNetworkConfigurationId2',
             });
 
             await waitForLookupNetworkToComplete({
@@ -4953,8 +4950,8 @@ describe('NetworkController', () => {
               type: 'rpc',
               rpcUrl: 'https://mock-rpc-url-2',
               chainId: '0x1337',
-              ticker: 'TEST2',
               nickname: 'test-chain-2',
+              ticker: 'TEST2',
               rpcPrefs: {
                 blockExplorerUrl: 'test-block-explorer-2.com',
               },


### PR DESCRIPTION
This changes several places in the `NetworkController` where we  call  `updateState` - which merges partial state - on an `ObservableStore` instance, to `putState` -  which wholly overwrites state in that store. This pattern of immutable state mutation is safer and avoids confusing state scenarios where, for instance, a `rollbackToPreviousProvider` call results in a provider state with some of the state of the provider we failed to connect alongside the the details of the provider we rolled back to.