### PR TITLE
Part of #17670: Replace Typography with Text component

### DIFF
--- a/ui/components/app/create-new-vault/create-new-vault.js
+++ b/ui/components/app/create-new-vault/create-new-vault.js
@@ -4,7 +4,8 @@ import { useI18nContext } from '../../../hooks/useI18nContext';
 import TextField from '../../ui/text-field';
 import Button from '../../ui/button';
 import CheckBox from '../../ui/check-box';
-import Typography from '../../ui/typography';
+import { Text } from '../../component-library';
+import { TextVariant } from '../../../helpers/constants/design-system';
 import SrpInput from '../srp-input';
 import { PASSWORD_MIN_LENGTH } from '../../../helpers/constants/common';
 
@@ -135,7 +136,9 @@ export default function CreateNewVault({
             className="create-new-vault__terms-label"
             htmlFor="create-new-vault__terms-checkbox"
           >
-            <Typography as="span">{termsOfUse}</Typography>
+            <Text variant={TextVariant.inherit} as="span">
+              {termsOfUse}
+            </Text>
           </label>
         </div>
       ) : null}


### PR DESCRIPTION
## Explanation

New fork of: https://github.com/MetaMask/metamask-extension/pull/18128 due to some issues. Sorry.

## Screenshots/Screencaps

### Before

<img width="404" alt="Screenshot 2023-03-13 at 3 34 50 PM" src="https://user-images.githubusercontent.com/5207617/224848893-ea043374-1c47-4832-ade1-0d8ada9f8270.png">


### After

<img width="419" alt="Screenshot 2023-03-13 at 3 34 55 PM" src="https://user-images.githubusercontent.com/5207617/224848914-ec7c88c4-e6c1-4e91-bef6-14ca82aaed4c.png">

