### PR TITLE
Allow Ganache RPC methods in e2e test

### DIFF
--- a/app/scripts/controllers/permissions/specifications.js
+++ b/app/scripts/controllers/permissions/specifications.js
@@ -209,6 +209,29 @@ function validateCaveatAccounts(accounts, getIdentities) {
   });
 }
 
+// Environment variable injection does not work with destructuring
+// eslint-disable-next-line prefer-destructuring
+const IN_TEST = process.env.IN_TEST;
+
+/**
+ * These are methods supported by Ganache, for use in e2e tests.
+ *
+ * @see {@link https://ganache.dev/}
+ */
+const ganacheMethods = [
+  'evm_addAccount',
+  'evm_increaseTime',
+  'evm_mine',
+  'evm_removeAccount',
+  'evm_revert',
+  'evm_setAccountBalance',
+  'evm_setAccountCode',
+  'evm_setAccountNonce',
+  'evm_setAccountStorageAt',
+  'evm_setTime',
+  'evm_snapshot',
+];
+
 /**
  * All unrestricted methods recognized by the PermissionController.
  * Unrestricted methods are ignored by the permission system, but every
@@ -276,4 +299,5 @@ export const unrestrictedMethods = Object.freeze([
   'wallet_watchAsset',
   'web3_clientVersion',
   'web3_sha3',
+  ...(IN_TEST ? ganacheMethods : []),
 ]);


### PR DESCRIPTION
Ganache RPC methods can now be used in e2e tests. These methods allow greater control over when blocks are mined, letting us eliminate race conditions in our tests related to block time. They also make it easier to adjust blockchain state, such as account nonce and balance.

See here for more information on these methods: https://ganache.dev/#evm_addAccount

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
