### PR TITLE
Updating Label according to insight report

### DIFF
--- a/ui/components/component-library/form-text-field/README.mdx
+++ b/ui/components/component-library/form-text-field/README.mdx
@@ -290,7 +290,7 @@ import {
       * or require adding some form of customization
       * import the Label component separately
       */}
-    <Label htmlFor="custom-spending-cap" required>
+    <Label htmlFor="custom-spending-cap">
       Custom spending cap
     </Label>
     <Icon
@@ -326,7 +326,7 @@ import {
     * import the HelpText component separately and handle the error
     * logic yourself
     */}
-  <HelpText htmlFor="chainId" required marginRight={2}>
+  <HelpText htmlFor="chainId" marginRight={2}>
     Only enter a number that you're comfortable with the contract accessing
     now or in the future. You can always increase the token limit later.
   </HelpText>

--- a/ui/components/component-library/form-text-field/form-text-field.js
+++ b/ui/components/component-library/form-text-field/form-text-field.js
@@ -59,7 +59,6 @@ export const FormTextField = ({
     {label && (
       <Label
         htmlFor={id}
-        required={required}
         {...labelProps}
         className={classnames(
           'mm-form-text-field__label',

--- a/ui/components/component-library/form-text-field/form-text-field.stories.js
+++ b/ui/components/component-library/form-text-field/form-text-field.stories.js
@@ -405,9 +405,7 @@ export const CustomLabelOrHelpText = () => (
         {/* If you need a custom label
         or require adding some form of customization
         import the Label component separately */}
-        <Label htmlFor="custom-spending-cap" required>
-          Custom spending cap
-        </Label>
+        <Label htmlFor="custom-spending-cap">Custom spending cap</Label>
         <Icon
           name={ICON_NAMES.INFO}
           size={Size.SM}

--- a/ui/components/component-library/form-text-field/form-text-field.test.js
+++ b/ui/components/component-library/form-text-field/form-text-field.test.js
@@ -234,17 +234,6 @@ describe('FormTextField', () => {
     expect(getByRole('textbox')).toHaveValue('test value');
     expect(getByRole('textbox')).toHaveAttribute('readonly', '');
   });
-  // required
-  it('should render with required asterisk after Label', () => {
-    const { getByTestId } = render(
-      <FormTextField
-        required
-        label="test label"
-        labelProps={{ 'data-testid': 'label-test-id' }}
-      />,
-    );
-    expect(getByTestId('label-test-id')).toHaveTextContent('test label*');
-  });
   // size = SIZES.MD
   it('should render with different size classes', () => {
     const { getByTestId } = render(

--- a/ui/components/component-library/label/README.mdx
+++ b/ui/components/component-library/label/README.mdx
@@ -6,7 +6,7 @@ import { Label } from './label';
 
 # Label
 
-The `Label` is a component used to label form inputs
+`Label` is used to describe the purpose of a form field
 
 <Canvas>
   <Story id="components-componentlibrary-label--default-story" />
@@ -68,22 +68,7 @@ import { Label, TextField } from '../../component-library';
 <TextField id="add-network" placeholder="Enter network name" />
 ```
 
-### Required
+### Internal Resources
 
-Use the `required` prop to add a required red asterisk next to the `children` of the `Label`. Note the required asterisk will always render after the `children`.
-
-<Canvas>
-  <Story id="components-componentlibrary-label--required" />
-</Canvas>
-
-```jsx
-import { Label } from '../../component-library';
-
-<Label required>Label</Label>;
-```
-
-```jsx
-import { Label } from '../../component-library';
-
-<Label disabled>Label</Label>;
-```
+- [Figma component](https://www.figma.com/file/HKpPKij9V3TpsyMV1TpV7C/branch/7uyrueQIFQBLqo9uzkxclr/DS-Components?node-id=13879%3A38076&t=dBHjnJTMSVE8N2UP-1)
+- [Insight report](https://www.figma.com/file/aGW8sk6X6Jf9ac0MRMD4kX/TextField-Audit?node-id=282%3A22&t=ZgCGFwGOBmOwQR5c-1)

--- a/ui/components/component-library/label/label.js
+++ b/ui/components/component-library/label/label.js
@@ -3,14 +3,13 @@ import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { Text } from '../text';
 import {
-  Color,
   FONT_WEIGHT,
   TextVariant,
   DISPLAY,
   AlignItems,
 } from '../../../helpers/constants/design-system';
 
-export const Label = ({ htmlFor, required, className, children, ...props }) => (
+export const Label = ({ htmlFor, className, children, ...props }) => (
   <Text
     className={classnames(
       'mm-label',
@@ -26,16 +25,6 @@ export const Label = ({ htmlFor, required, className, children, ...props }) => (
     {...props}
   >
     {children}
-    {required && (
-      <Text
-        as="span"
-        className="mm-label__required-asterisk"
-        aria-hidden="true"
-        color={Color.errorDefault}
-      >
-        *
-      </Text>
-    )}
   </Text>
 );
 
@@ -48,10 +37,6 @@ Label.propTypes = {
    * The id of the input associated with the label
    */
   htmlFor: PropTypes.string,
-  /**
-   * If true the label will display as required
-   */
-  required: PropTypes.bool,
   /**
    * Additional classNames to be added to the label component
    */

--- a/ui/components/component-library/label/label.stories.js
+++ b/ui/components/component-library/label/label.stories.js
@@ -28,9 +28,6 @@ export default {
     htmlFor: {
       control: 'text',
     },
-    required: {
-      control: 'boolean',
-    },
     children: {
       control: 'text',
     },
@@ -95,9 +92,4 @@ export const HtmlFor = (args) => {
 HtmlFor.args = {
   children: 'Network name',
   htmlFor: 'add-network',
-};
-
-export const Required = Template.bind({});
-Required.args = {
-  required: true,
 };

--- a/ui/components/component-library/label/label.test.js
+++ b/ui/components/component-library/label/label.test.js
@@ -57,9 +57,4 @@ describe('label', () => {
     fireEvent.click(label);
     expect(input).toHaveFocus();
   });
-  it('should render with required asterisk', () => {
-    const { getByText } = render(<Label required>label</Label>);
-    expect(getByText('label')).toBeDefined();
-    expect(getByText('*')).toBeDefined();
-  });
 });


### PR DESCRIPTION
## Explanation

`Label` was out of date with insight report. This PR makes those updates:
- updates description
- removes `required` prop
- I've checked codebase for use of `Label` and `FormTextField` to ensure required is not being used anywhere
- Added Figma component and Insight report links

[Insight report ](https://www.figma.com/file/aGW8sk6X6Jf9ac0MRMD4kX/TextField-Audit?node-id=282%3A22&t=ZgCGFwGOBmOwQR5c-1)

## Screenshots/Screencaps

### Before


https://user-images.githubusercontent.com/8112138/225105896-519bc57b-6a23-4c70-9075-b8c0074c11d0.mov



### After


https://user-images.githubusercontent.com/8112138/225105954-2d85425d-61aa-4079-a403-e51022801210.mov

![Screenshot 2023-03-14 at 11 30 36 AM](https://user-images.githubusercontent.com/8112138/225106014-01b2c114-dd52-446e-bb9b-5570a3ad7e33.png)
![Screenshot 2023-03-14 at 11 31 46 AM](https://user-images.githubusercontent.com/8112138/225106017-f5cb5777-b055-4c1a-b260-72f73da0f588.png)


## Manual Testing Steps

- Go to the latest build of storybook on this PR
- Search `Label` in left panel 
- Go to `Label` story and check stories, controls and docs

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
