### PR TITLE
Adding Modal component

### DIFF
--- a/lavamoat/browserify/beta/policy.json
+++ b/lavamoat/browserify/beta/policy.json
@@ -3778,6 +3778,64 @@
         "setTimeout": true
       }
     },
+    "react-focus-lock": {
+      "globals": {
+        "addEventListener": true,
+        "console.error": true,
+        "console.warn": true,
+        "document": true,
+        "removeEventListener": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "@babel/runtime": true,
+        "prop-types": true,
+        "react": true,
+        "react-focus-lock>focus-lock": true,
+        "react-focus-lock>react-clientside-effect": true,
+        "react-focus-lock>use-callback-ref": true,
+        "react-focus-lock>use-sidecar": true
+      }
+    },
+    "react-focus-lock>focus-lock": {
+      "globals": {
+        "HTMLIFrameElement": true,
+        "Node.DOCUMENT_FRAGMENT_NODE": true,
+        "Node.DOCUMENT_NODE": true,
+        "Node.DOCUMENT_POSITION_CONTAINED_BY": true,
+        "Node.DOCUMENT_POSITION_CONTAINS": true,
+        "Node.ELEMENT_NODE": true,
+        "console.error": true,
+        "console.warn": true,
+        "document": true,
+        "getComputedStyle": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "wait-on>rxjs>tslib": true
+      }
+    },
+    "react-focus-lock>react-clientside-effect": {
+      "packages": {
+        "react": true,
+        "react-focus-lock>react-clientside-effect>@babel/runtime": true
+      }
+    },
+    "react-focus-lock>use-callback-ref": {
+      "packages": {
+        "react": true
+      }
+    },
+    "react-focus-lock>use-sidecar": {
+      "globals": {
+        "console.error": true
+      },
+      "packages": {
+        "react": true,
+        "react-focus-lock>use-sidecar>detect-node-es": true,
+        "wait-on>rxjs>tslib": true
+      }
+    },
     "react-idle-timer": {
       "globals": {
         "clearTimeout": true,

--- a/lavamoat/browserify/desktop/policy.json
+++ b/lavamoat/browserify/desktop/policy.json
@@ -4188,6 +4188,64 @@
         "setTimeout": true
       }
     },
+    "react-focus-lock": {
+      "globals": {
+        "addEventListener": true,
+        "console.error": true,
+        "console.warn": true,
+        "document": true,
+        "removeEventListener": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "@babel/runtime": true,
+        "prop-types": true,
+        "react": true,
+        "react-focus-lock>focus-lock": true,
+        "react-focus-lock>react-clientside-effect": true,
+        "react-focus-lock>use-callback-ref": true,
+        "react-focus-lock>use-sidecar": true
+      }
+    },
+    "react-focus-lock>focus-lock": {
+      "globals": {
+        "HTMLIFrameElement": true,
+        "Node.DOCUMENT_FRAGMENT_NODE": true,
+        "Node.DOCUMENT_NODE": true,
+        "Node.DOCUMENT_POSITION_CONTAINED_BY": true,
+        "Node.DOCUMENT_POSITION_CONTAINS": true,
+        "Node.ELEMENT_NODE": true,
+        "console.error": true,
+        "console.warn": true,
+        "document": true,
+        "getComputedStyle": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "wait-on>rxjs>tslib": true
+      }
+    },
+    "react-focus-lock>react-clientside-effect": {
+      "packages": {
+        "react": true,
+        "react-focus-lock>react-clientside-effect>@babel/runtime": true
+      }
+    },
+    "react-focus-lock>use-callback-ref": {
+      "packages": {
+        "react": true
+      }
+    },
+    "react-focus-lock>use-sidecar": {
+      "globals": {
+        "console.error": true
+      },
+      "packages": {
+        "react": true,
+        "react-focus-lock>use-sidecar>detect-node-es": true,
+        "wait-on>rxjs>tslib": true
+      }
+    },
     "react-idle-timer": {
       "globals": {
         "clearTimeout": true,

--- a/lavamoat/browserify/flask/policy.json
+++ b/lavamoat/browserify/flask/policy.json
@@ -4188,6 +4188,64 @@
         "setTimeout": true
       }
     },
+    "react-focus-lock": {
+      "globals": {
+        "addEventListener": true,
+        "console.error": true,
+        "console.warn": true,
+        "document": true,
+        "removeEventListener": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "@babel/runtime": true,
+        "prop-types": true,
+        "react": true,
+        "react-focus-lock>focus-lock": true,
+        "react-focus-lock>react-clientside-effect": true,
+        "react-focus-lock>use-callback-ref": true,
+        "react-focus-lock>use-sidecar": true
+      }
+    },
+    "react-focus-lock>focus-lock": {
+      "globals": {
+        "HTMLIFrameElement": true,
+        "Node.DOCUMENT_FRAGMENT_NODE": true,
+        "Node.DOCUMENT_NODE": true,
+        "Node.DOCUMENT_POSITION_CONTAINED_BY": true,
+        "Node.DOCUMENT_POSITION_CONTAINS": true,
+        "Node.ELEMENT_NODE": true,
+        "console.error": true,
+        "console.warn": true,
+        "document": true,
+        "getComputedStyle": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "wait-on>rxjs>tslib": true
+      }
+    },
+    "react-focus-lock>react-clientside-effect": {
+      "packages": {
+        "react": true,
+        "react-focus-lock>react-clientside-effect>@babel/runtime": true
+      }
+    },
+    "react-focus-lock>use-callback-ref": {
+      "packages": {
+        "react": true
+      }
+    },
+    "react-focus-lock>use-sidecar": {
+      "globals": {
+        "console.error": true
+      },
+      "packages": {
+        "react": true,
+        "react-focus-lock>use-sidecar>detect-node-es": true,
+        "wait-on>rxjs>tslib": true
+      }
+    },
     "react-idle-timer": {
       "globals": {
         "clearTimeout": true,

--- a/lavamoat/browserify/main/policy.json
+++ b/lavamoat/browserify/main/policy.json
@@ -3778,6 +3778,64 @@
         "setTimeout": true
       }
     },
+    "react-focus-lock": {
+      "globals": {
+        "addEventListener": true,
+        "console.error": true,
+        "console.warn": true,
+        "document": true,
+        "removeEventListener": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "@babel/runtime": true,
+        "prop-types": true,
+        "react": true,
+        "react-focus-lock>focus-lock": true,
+        "react-focus-lock>react-clientside-effect": true,
+        "react-focus-lock>use-callback-ref": true,
+        "react-focus-lock>use-sidecar": true
+      }
+    },
+    "react-focus-lock>focus-lock": {
+      "globals": {
+        "HTMLIFrameElement": true,
+        "Node.DOCUMENT_FRAGMENT_NODE": true,
+        "Node.DOCUMENT_NODE": true,
+        "Node.DOCUMENT_POSITION_CONTAINED_BY": true,
+        "Node.DOCUMENT_POSITION_CONTAINS": true,
+        "Node.ELEMENT_NODE": true,
+        "console.error": true,
+        "console.warn": true,
+        "document": true,
+        "getComputedStyle": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "wait-on>rxjs>tslib": true
+      }
+    },
+    "react-focus-lock>react-clientside-effect": {
+      "packages": {
+        "react": true,
+        "react-focus-lock>react-clientside-effect>@babel/runtime": true
+      }
+    },
+    "react-focus-lock>use-callback-ref": {
+      "packages": {
+        "react": true
+      }
+    },
+    "react-focus-lock>use-sidecar": {
+      "globals": {
+        "console.error": true
+      },
+      "packages": {
+        "react": true,
+        "react-focus-lock>use-sidecar>detect-node-es": true,
+        "wait-on>rxjs>tslib": true
+      }
+    },
     "react-idle-timer": {
       "globals": {
         "clearTimeout": true,

--- a/package.json
+++ b/package.json
@@ -333,6 +333,7 @@
     "qrcode.react": "^1.0.1",
     "react": "^16.12.0",
     "react-dom": "^16.12.0",
+    "react-focus-lock": "^2.9.4",
     "react-idle-timer": "^4.2.5",
     "react-inspector": "^2.3.0",
     "react-markdown": "^6.0.3",

--- a/ui/components/component-library/component-library-components.scss
+++ b/ui/components/component-library/component-library-components.scss
@@ -31,4 +31,4 @@
 @import 'banner-tip/banner-tip';
 @import 'modal-content/modal-content';
 @import 'modal-overlay/modal-overlay';
-
+@import 'modal/modal';

--- a/ui/components/component-library/index.js
+++ b/ui/components/component-library/index.js
@@ -34,6 +34,7 @@ export { TextField, TEXT_FIELD_TYPES, TEXT_FIELD_SIZES } from './text-field';
 export { TextFieldSearch } from './text-field-search';
 export { ModalContent, ModalContentSize } from './modal-content';
 export { ModalOverlay } from './modal-overlay';
+export { Modal } from './modal';
 
 // Molecules
 export { BannerBase } from './banner-base';

--- a/ui/components/component-library/modal-content/__snapshots__/modal-content.test.tsx.snap
+++ b/ui/components/component-library/modal-content/__snapshots__/modal-content.test.tsx.snap
@@ -2,10 +2,12 @@
 
 exports[`ModalContent should match snapshot 1`] = `
 <div>
-  <div
+  <section
+    aria-modal="true"
     class="box mm-modal-content mm-modal-content--size-sm box--padding-4 box--flex-direction-row box--width-full box--background-color-background-default box--rounded-lg"
+    role="dialog"
   >
     test
-  </div>
+  </section>
 </div>
 `;

--- a/ui/components/component-library/modal-content/modal-content.tsx
+++ b/ui/components/component-library/modal-content/modal-content.tsx
@@ -25,6 +25,9 @@ export const ModalContent = ({
       { [`mm-modal-content--size-${size}`]: !width },
       className,
     )}
+    as="section"
+    role="dialog"
+    aria-modal="true"
     backgroundColor={BackgroundColor.backgroundDefault}
     borderRadius={BorderRadius.LG}
     width={width || BLOCK_SIZES.FULL}

--- a/ui/components/component-library/modal-overlay/__snapshots__/modal-overlay.test.tsx.snap
+++ b/ui/components/component-library/modal-overlay/__snapshots__/modal-overlay.test.tsx.snap
@@ -3,6 +3,7 @@
 exports[`ModalOverlay should match snapshot 1`] = `
 <div>
   <div
+    aria-hidden="true"
     class="box mm-modal-overlay box--flex-direction-row box--width-full box--height-full box--background-color-overlay-default"
   />
 </div>

--- a/ui/components/component-library/modal-overlay/modal-overlay.tsx
+++ b/ui/components/component-library/modal-overlay/modal-overlay.tsx
@@ -21,6 +21,7 @@ export const ModalOverlay: React.FC<ModalOverlayProps> = ({
     width={BLOCK_SIZES.FULL}
     height={BLOCK_SIZES.FULL}
     onClick={onClick}
+    aria-hidden="true"
     {...props}
   />
 );

--- a/ui/components/component-library/modal/README.mdx
+++ b/ui/components/component-library/modal/README.mdx
@@ -1,0 +1,294 @@
+import { Story, Canvas, ArgsTable } from '@storybook/addon-docs';
+
+import { Modal } from './modal';
+
+# Modal
+
+The `Modal` focuses the user's attention exclusively on information via a window that is overlaid on primary content. It uses `ModalOverlay`, `ModalContent` and `ModalHeader` to create a modal dialog.
+
+<Canvas>
+  <Story id="components-componentlibrary-modal--default-story" />
+</Canvas>
+
+## Props
+
+The `Modal` accepts all props below as well as all [Box](/docs/components-ui-box--default-story#props) component props
+
+<ArgsTable of={Modal} />
+
+### Usage
+
+The `Modal` component is a very atomic level component that is meant to be used with `ModalOverlay`, `ModalContent` and `ModalHeader`.
+
+When the modal opens:
+
+- Focus is trapped within the modal and set to the first tabbable element.
+- Content behind a modal dialog is inert, meaning that users cannot interact with it.
+- Use the `isOpen` prop to control whether the modal is open or closed.
+- Use the `onClose` prop to fire a callback when the modal is closed. This is used for the `isClosedOnOutsideClick` prop and the `isClosedOnEscapeKey`.
+- Use the `modalContentRef` prop to pass a ref to `ModalContent` component. This is used to lock focus to `ModalContent` when the `Modal` is open. It is also used for the `isClosedOnOutsideClick` prop. If the ref is not equal to `modalContentRef`, the modal will close.
+
+<Canvas>
+  <Story id="components-componentlibrary-modal--usage" />
+</Canvas>
+
+```jsx
+import React, { useState, useRef } from 'react';
+import { Modal, ModalOverlay, ModalContent, ModalHeader, Text, Button } from '../../component-library';
+
+const modalContentRef = useRef<HTMLDivElement>(null);
+const [open, setOpen] = useState(false);
+
+const handleOnClick = () => {
+  setOpen(true);
+};
+
+const handleOnClose = () => {
+  setOpen(false);
+};
+
+<Button onClick={handleOnClick}>OpenModal</Button>
+<Modal
+  isOpen={open}
+  modalContentRef={modalContentRef}
+  onClose={handleOnClose}
+>
+  <ModalOverlay />
+  <ModalContent ref={modalContentRef}>
+    <ModalHeader onClose={handleOnClose} onBack={handleOnClose}>
+      Modal Header
+    </ModalHeader>
+    <Text>Children</Text>
+  </ModalContent>
+</Modal>
+```
+
+### Children
+
+The `Modal` component is intended to be used with `ModalOverlay`, `ModalContent` and `ModalHeader`. However, if you want to use the `Modal` component as a portal to render a custom component without the other components, you can pass a custom child to the `Modal` component.
+
+<Canvas>
+  <Story id="components-componentlibrary-modal--children" />
+</Canvas>
+
+```jsx
+import React, { useState, useRef } from 'react';
+
+import { BackgroundColor, BorderRadius, TextColor } from '../../../helpers/constants/design-system';
+
+import Box from '../../ui/box'
+
+import { Modal, ModalOverlay, ModalContent, ModalHeader, Text, Button } from '../../component-library';
+
+const modalContentRef = useRef<HTMLDivElement>(null);
+const [open, setOpen] = useState(false);
+
+const handleOnClick = () => {
+  setOpen(true);
+};
+
+const handleOnClose = () => {
+  setOpen(false);
+};
+
+<Button onClick={handleOnClick}>Open modal</Button>
+<Modal
+  modalContentRef={modalContentRef}
+  isOpen={isOpen}
+  onClose={handleOnClose}
+>
+  <Box
+    backgroundColor={BackgroundColor.primaryDefault}
+    padding={8}
+    borderRadius={BorderRadius.LG}
+    ref={modalContentRef}
+  >
+    <Text color={TextColor.primaryInverse}>Custom Modal</Text>{' '}
+    <button onClick={handleOnClose}>Close</button>
+  </Box>
+</Modal>
+```
+
+### Is Closed On Outside Click
+
+Use the `isClosedOnOutsideClick` prop to control whether the modal should close when the user clicks outside of the modal.
+
+Defaults to `true`.
+
+<Canvas>
+  <Story id="components-componentlibrary-modal--is-closed-on-outside-click" />
+</Canvas>
+
+```jsx
+import { Modal } from '../../component-library';
+
+<Modal isClosedOnOutsideClick={false} />;
+```
+
+### Is Closed On Escape Key
+
+Use the `isClosedOnEscapeKey` prop to control whether the modal should close when the user presses the escape key.
+
+Defaults to `true`.
+
+<Canvas>
+  <Story id="components-componentlibrary-modal--is-closed-on-escape-key" />
+</Canvas>
+
+```jsx
+import { Modal } from '../../component-library';
+
+<Modal isClosedOnEscapeKey={false} />;
+```
+
+### Initial Focus Ref
+
+Use the `initialFocusRef` to set the `ref` of the element to receive focus initially. This is useful for input elements that should receive focus when the modal opens.
+
+<Canvas>
+  <Story id="components-componentlibrary-modal--initial-focus-ref" />
+</Canvas>
+
+```jsx
+import React, { useState, useRef } from 'react';
+import { Modal, ModalOverlay, ModalContent, ModalHeader, TextFieldSearch, Button } from '../../component-library';
+
+const modalContentRef = useRef<HTMLDivElement>(null);
+// Ref to set initial focus
+const inputRef = React.useRef<HTMLDivElement>(null);
+
+const [open, setOpen] = useState(false);
+
+const handleOnClick = () => {
+  setOpen(true);
+};
+
+const handleOnClose = () => {
+  setOpen(false);
+};
+
+<Button onClick={handleOnClick}>Open modal</Button>
+<Modal
+  {...args}
+  modalContentRef={modalContentRef}
+  isOpen={isOpen}
+  onClose={handleOnClose}
+  initialFocusRef={inputRef}
+>
+  <ModalOverlay />
+  <ModalContent modalContentRef={modalContentRef}>
+    <ModalHeader
+      onClose={handleOnClose}
+      onBack={handleOnClose}
+      marginBottom={4}
+    >
+      Modal Header
+    </ModalHeader>
+    <TextFieldSearch
+      placeholder="Search"
+      inputProps={{ ref: inputRef }}
+      width={BLOCK_SIZES.FULL}
+    />
+  </ModalContent>
+</Modal>
+```
+
+### Final Focus Ref
+
+Use the `finalFocusRef` to set the `ref` of the element to receive focus when the modal closes.
+
+<Canvas>
+  <Story id="components-componentlibrary-modal--final-focus-ref" />
+</Canvas>
+
+```jsx
+import React, { useState, useRef } from 'react';
+import { Modal, ModalOverlay, ModalContent, ModalHeader, TextFieldSearch, Button } from '../../component-library';
+
+const modalContentRef = useRef<HTMLDivElement>(null);
+// Ref to set focus after modal closes
+const buttonRef = React.useRef<HTMLButtonElement>(null);
+
+const [open, setOpen] = useState(false);
+
+const handleOnClick = () => {
+  setOpen(true);
+};
+
+const handleOnClose = () => {
+  setOpen(false);
+};
+
+<Button onClick={handleOnClick} marginRight={4}>
+  Open modal
+</Button>
+<button ref={buttonRef}>Receives focus after close</button>
+<Modal
+  {...args}
+  modalContentRef={modalContentRef}
+  isOpen={isOpen}
+  onClose={handleOnClose}
+  finalFocusRef={buttonRef}
+>
+  <ModalOverlay />
+  <ModalContent modalContentRef={modalContentRef}>
+    <ModalHeader
+      onClose={handleOnClose}
+      onBack={handleOnClose}
+      marginBottom={4}
+    >
+      Modal Header
+    </ModalHeader>
+    <Text>{args.children}</Text>
+  </ModalContent>
+</Modal>
+```
+
+### Restore Focus
+
+Use the `restoreFocus` prop to restore focus to the element that triggered the `Modal` once it unmounts
+
+Defaults to `false`
+
+<Canvas>
+  <Story id="components-componentlibrary-modal--restore-focus" />
+</Canvas>
+
+```jsx
+import { Modal } from '../../component-library';
+
+<Modal restoreFocus={true} />;
+```
+
+### Auto Focus
+
+If `true`, the first focusable element within the `children` will auto-focused once `Modal` mounts. Depending on the content of `Modal` this is usually the back or close button in the `ModalHeader`.
+
+Defaults to `true`
+
+<Canvas>
+  <Story id="components-componentlibrary-modal--auto-focus" />
+</Canvas>
+
+```jsx
+import { Modal } from '../../component-library';
+
+<Modal autoFocus={false} />;
+```
+
+## Accessibility
+
+### Keyboard and Focus Management
+
+- When the modal opens, focus is trapped within it.
+- When the modal opens, focus is automatically set to the first enabled element, or the element from `initialFocusRef`.
+- When the modal closes, focus returns to the element that was focused before the modal activated, or the element from `finalFocusRef`.
+- Clicking on the overlay closes the Modal.
+- Pressing ESC closes the Modal.
+- Scrolling is blocked on the elements behind the modal.
+- The modal is rendered in a portal attached to the end of document.body to break it out of the source order and make it easy to add aria-hidden to its siblings.
+
+### ARIA
+
+- The `ModalContent` has aria-modal="true" and role="dialog"
+- The `ModalOverlay` has aria-hidden="true"

--- a/ui/components/component-library/modal/README.mdx
+++ b/ui/components/component-library/modal/README.mdx
@@ -4,7 +4,7 @@ import { Modal } from './modal';
 
 # Modal
 
-The `Modal` focuses the user's attention exclusively on information via a window that is overlaid on primary content. It uses `ModalOverlay`, `ModalContent` and `ModalHeader` to create a modal dialog.
+The `Modal` focuses the user's attention exclusively on information via a window that is overlaid on primary content. It should be used with the `ModalOverlay`, `ModalContent` and `ModalHeader` components to create a complete modal.
 
 <Canvas>
   <Story id="components-componentlibrary-modal--default-story" />
@@ -78,7 +78,7 @@ import { BackgroundColor, BorderRadius, TextColor } from '../../../helpers/const
 
 import Box from '../../ui/box'
 
-import { Modal, ModalOverlay, ModalContent, ModalHeader, Text, Button } from '../../component-library';
+import { Modal, Text, Button } from '../../component-library';
 
 const modalContentRef = useRef<HTMLDivElement>(null);
 const [open, setOpen] = useState(false);

--- a/ui/components/component-library/modal/__snapshots__/modal.test.tsx.snap
+++ b/ui/components/component-library/modal/__snapshots__/modal.test.tsx.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Modal should match snapshot 1`] = `<div />`;

--- a/ui/components/component-library/modal/index.ts
+++ b/ui/components/component-library/modal/index.ts
@@ -1,0 +1,4 @@
+export { Modal } from './modal';
+export type { ModalProps } from './modal.types';
+export { ModalFocus } from './modal-focus';
+export type { ModalFocusProps } from './modal-focus.types';

--- a/ui/components/component-library/modal/modal-focus.test.tsx
+++ b/ui/components/component-library/modal/modal-focus.test.tsx
@@ -1,0 +1,71 @@
+/* eslint-disable jest/require-top-level-describe */
+import { render } from '@testing-library/react';
+import React from 'react';
+
+import { ModalFocus } from './modal-focus';
+
+describe('ModalFocus', () => {
+  it('should render with children inside the ModalFocus', () => {
+    const { getByText } = render(
+      <ModalFocus>
+        <div>modal focus</div>
+      </ModalFocus>,
+    );
+    expect(getByText('modal focus')).toBeDefined();
+  });
+
+  it('should render with the initial element focused', () => {
+    const { getByTestId } = render(
+      <ModalFocus>
+        <input data-testid="input" />
+      </ModalFocus>,
+    );
+    expect(getByTestId('input')).toHaveFocus();
+  });
+
+  it('should render with focused with autoFocus is set to false', () => {
+    const { getByTestId } = render(
+      <ModalFocus autoFocus={false}>
+        <input data-testid="input" />
+      </ModalFocus>,
+    );
+    expect(getByTestId('input')).not.toHaveFocus();
+  });
+
+  it('should render with modalContentRef and focus if focusable', () => {
+    const ref: React.RefObject<HTMLInputElement> = React.createRef();
+    const { getByTestId } = render(
+      <ModalFocus autoFocus={false} modalContentRef={ref}>
+        <input data-testid="modal-content-ref" ref={ref} />
+      </ModalFocus>,
+    );
+    expect(getByTestId('modal-content-ref')).toHaveFocus();
+  });
+
+  it('should focus initialFocusRef on render', () => {
+    const ref: React.RefObject<HTMLInputElement> = React.createRef();
+    const { getByTestId } = render(
+      <ModalFocus initialFocusRef={ref}>
+        <input />
+        <input />
+        <input data-testid="input" ref={ref} />
+      </ModalFocus>,
+    );
+    expect(getByTestId('input')).toHaveFocus();
+  });
+
+  it('should focus final focus ref when closed', () => {
+    const finalRef: React.RefObject<HTMLButtonElement> = React.createRef();
+    const { rerender, getByRole } = render(
+      <>
+        <button ref={finalRef}>button</button>
+        <ModalFocus finalFocusRef={finalRef}>
+          <div>modal focus</div>
+        </ModalFocus>
+      </>,
+    );
+    expect(finalRef.current).not.toHaveFocus();
+    rerender(<button ref={finalRef}>button</button>);
+    expect(getByRole('button')).toHaveFocus();
+  });
+});

--- a/ui/components/component-library/modal/modal-focus.tsx
+++ b/ui/components/component-library/modal/modal-focus.tsx
@@ -1,0 +1,47 @@
+import React, { useCallback } from 'react';
+import ReactFocusLock from 'react-focus-lock';
+import type { ModalFocusProps } from './modal-focus.types';
+
+/**
+ * Based on the ModalFocusScope component from chakra-ui
+ * https://github.com/chakra-ui/chakra-ui/blob/main/packages/components/modal/src/modal-focus.tsx
+ */
+
+const FocusTrap: typeof ReactFocusLock =
+  (ReactFocusLock as any).default ?? ReactFocusLock;
+
+export const ModalFocus: React.FC<ModalFocusProps> = ({
+  initialFocusRef,
+  finalFocusRef,
+  modalContentRef,
+  restoreFocus,
+  children,
+  autoFocus,
+}) => {
+  const onActivation = useCallback(() => {
+    if (initialFocusRef?.current) {
+      initialFocusRef.current.focus();
+    } else if (modalContentRef?.current) {
+      modalContentRef.current?.focus();
+    }
+  }, [initialFocusRef, modalContentRef]);
+
+  const onDeactivation = useCallback(() => {
+    finalFocusRef?.current?.focus();
+  }, [finalFocusRef]);
+
+  const returnFocus = restoreFocus && !finalFocusRef;
+
+  return (
+    <FocusTrap
+      autoFocus={autoFocus}
+      onActivation={onActivation}
+      onDeactivation={onDeactivation}
+      returnFocus={returnFocus}
+    >
+      {children}
+    </FocusTrap>
+  );
+};
+
+ModalFocus.displayName = 'ModalFocus';

--- a/ui/components/component-library/modal/modal-focus.types.ts
+++ b/ui/components/component-library/modal/modal-focus.types.ts
@@ -1,0 +1,46 @@
+import React from 'react';
+
+export interface FocusableElement {
+  focus(options?: FocusOptions): void;
+}
+
+export interface ModalFocusProps {
+  /**
+   * The `ref` of the element to receive focus initially
+   */
+  initialFocusRef?: React.RefObject<FocusableElement>;
+  /**
+   * The `ref` of the element to return focus to when `ModalFocus`
+   * unmounts
+   */
+  finalFocusRef?: React.RefObject<FocusableElement>;
+  /**
+   * The `ref` of the wrapper for which the focus-lock wraps
+   * This should generally be the ModalContent element
+   */
+  modalContentRef?: React.RefObject<HTMLElement>;
+  /**
+   * If `true`, focus will be restored to the element that
+   * triggered the `ModalFocus` once it unmounts
+   *
+   * @default false
+   */
+  restoreFocus?: boolean;
+  /**
+   * The modal components to render generally ModalOverlay and ModalContent
+   */
+  children: React.ReactNode;
+  /**
+   * If `true`, the first focusable element within the `children`
+   * will auto-focused once `ModalFocus` mounts
+   *
+   * @default false
+   */
+  autoFocus?: boolean;
+  /**
+   * If `true`, the modal will return focus to the element that triggered it when it closes.
+   *
+   * @default true
+   */
+  returnFocusOnClose?: boolean;
+}

--- a/ui/components/component-library/modal/modal.scss
+++ b/ui/components/component-library/modal/modal.scss
@@ -1,0 +1,6 @@
+.mm-modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  // z-index: 1040; // TODO: Check if this is required for Modal to work properly. It aligns with modal z-index in extension
+}

--- a/ui/components/component-library/modal/modal.scss
+++ b/ui/components/component-library/modal/modal.scss
@@ -2,5 +2,4 @@
   position: fixed;
   top: 0;
   left: 0;
-  // z-index: 1040; // TODO: Check if this is required for Modal to work properly. It aligns with modal z-index in extension
 }

--- a/ui/components/component-library/modal/modal.stories.tsx
+++ b/ui/components/component-library/modal/modal.stories.tsx
@@ -1,0 +1,346 @@
+import React, { useState } from 'react';
+import { useArgs } from '@storybook/client-api';
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+
+import {
+  BLOCK_SIZES,
+  BackgroundColor,
+  TextColor,
+  BorderRadius,
+  DISPLAY,
+} from '../../../helpers/constants/design-system';
+
+import Box from '../../ui/box';
+
+import {
+  ModalOverlay,
+  ModalContent,
+  ModalHeader,
+  Text,
+  Button,
+  ButtonLink,
+  BUTTON_LINK_SIZES,
+  TextFieldSearch,
+  IconName,
+} from '..';
+
+import { Modal } from './modal';
+
+import README from './README.mdx';
+
+export default {
+  title: 'Components/ComponentLibrary/Modal',
+  component: Modal,
+  parameters: {
+    docs: {
+      page: README,
+    },
+  },
+  argTypes: {
+    isOpen: {
+      control: 'boolean',
+    },
+    onClose: {
+      action: 'onClose',
+    },
+    children: {
+      control: 'node',
+    },
+    className: {
+      control: 'string',
+    },
+    modalContentRef: {
+      control: 'object',
+    },
+    isClosedOnOutsideClick: {
+      control: 'boolean',
+    },
+    isClosedOnEscapeKey: {
+      control: 'boolean',
+    },
+    initialFocusRef: {
+      control: 'object',
+    },
+    finalFocusRef: {
+      control: 'object',
+    },
+    restoreFocus: {
+      control: 'boolean',
+    },
+    autoFocus: {
+      control: 'boolean',
+    },
+    returnFocusOnClose: {
+      control: 'boolean',
+    },
+  },
+  args: {
+    children: (
+      <Text paddingTop={4}>ModalContent children after ModalHeader</Text>
+    ),
+  },
+} as ComponentMeta<typeof Modal>;
+
+const LoremIpsum = (props) => (
+  <Text marginBottom={8} {...props}>
+    Lorem ipsum dolor sit amet, conse{' '}
+    <ButtonLink size={BUTTON_LINK_SIZES.INHERIT}>
+      random focusable button
+    </ButtonLink>{' '}
+    ctetur adipiscing elit. Phasellus posuere nunc enim, quis efficitur dolor
+    tempus viverra. Vivamus pharetra tempor pulvinar. Sed at dui in nisi
+    fermentum volutpat. Proin ut tortor quis eros tincidunt molestie.
+    Suspendisse dictum ex vitae metus consequat, et efficitur dolor luctus.
+    Integer ultricies hendrerit turpis sed faucibus. Nam pellentesque metus a
+    turpis sollicitudin vehicula. Phasellus rutrum luctus pulvinar. Phasellus
+    quis accumsan urna. Praesent justo erat, bibendum ac volutpat ac, placerat
+    in dui. Cras gravida mi et risus feugiat vulputate. Integer vulputate diam
+    eu vehicula euismod. In laoreet quis eros sed tincidunt. Pellentesque purus
+    dui, luctus id sem sit amet, varius congue dui
+  </Text>
+);
+
+const Template: ComponentStory<typeof Modal> = (args) => {
+  const modalContentRef = React.useRef<HTMLDivElement>(null);
+  const [{ isOpen }, updateArgs] = useArgs();
+  const [showLoremIpsum, setShowLoremIpsum] = useState(false);
+  const handleOnClick = () => {
+    updateArgs({ isOpen: true });
+  };
+  const handleOnClose = () => {
+    updateArgs({ isOpen: false });
+  };
+  const handleHideLoremIpsum = () => {
+    setShowLoremIpsum(!showLoremIpsum);
+  };
+
+  return (
+    <Box width={BLOCK_SIZES.FULL} style={{ maxWidth: '700px' }}>
+      <Box display={DISPLAY.FLEX} gap={4}>
+        <Button onClick={handleOnClick}>Open modal</Button>
+        <ButtonLink
+          endIconName={showLoremIpsum ? IconName.Arrow2Up : IconName.Arrow2Down}
+          onClick={handleHideLoremIpsum}
+        >
+          {showLoremIpsum ? 'Hide' : 'Show'} scrollable content
+        </ButtonLink>
+      </Box>
+      <Modal
+        {...args}
+        modalContentRef={modalContentRef}
+        isOpen={isOpen}
+        onClose={handleOnClose}
+      >
+        <ModalOverlay />
+        <ModalContent modalContentRef={modalContentRef}>
+          <ModalHeader onClose={handleOnClose} onBack={handleOnClose}>
+            Modal Header
+          </ModalHeader>
+          {args.children}
+        </ModalContent>
+      </Modal>
+      {showLoremIpsum && (
+        <>
+          <LoremIpsum marginTop={8} />
+          <LoremIpsum />
+          <LoremIpsum />
+          <LoremIpsum />
+          <LoremIpsum />
+          <LoremIpsum />
+        </>
+      )}
+    </Box>
+  );
+};
+export const DefaultStory = Template.bind({});
+DefaultStory.storyName = 'Default';
+
+export const Usage = Template.bind({});
+
+export const Children: ComponentStory<typeof Modal> = (args) => {
+  const modalContentRef = React.useRef<HTMLDivElement>(null);
+  const [{ isOpen }, updateArgs] = useArgs();
+  const handleOnClick = () => {
+    updateArgs({ isOpen: true });
+  };
+  const handleOnClose = () => {
+    updateArgs({ isOpen: false });
+  };
+  return (
+    <>
+      <Text marginBottom={2}>
+        Custom Modal <strong>NOT</strong> using ModalOverlay, ModalContent,
+        ModalHeader as children
+      </Text>
+      <Button onClick={handleOnClick}>Open modal</Button>
+      <Modal
+        {...args}
+        modalContentRef={modalContentRef}
+        isOpen={isOpen}
+        onClose={handleOnClose}
+      >
+        <Box
+          backgroundColor={BackgroundColor.primaryDefault}
+          padding={8}
+          borderRadius={BorderRadius.LG}
+          ref={modalContentRef}
+        >
+          {args.children}
+          <button onClick={handleOnClose}>Close</button>
+        </Box>
+      </Modal>
+    </>
+  );
+};
+Children.args = {
+  children: (
+    <Text color={TextColor.primaryInverse} marginBottom={4}>
+      Custom Modal <strong>NOT</strong> using ModalOverlay, ModalContent,
+      ModalHeader as children
+    </Text>
+  ),
+};
+
+export const IsClosedOnOutsideClick = Template.bind({});
+IsClosedOnOutsideClick.args = {
+  isClosedOnOutsideClick: false,
+  children: (
+    <Text paddingTop={4}>
+      This Modal has set isClosedOnOutsideClick: false. Clicking outside this
+      Modal <strong>WILL NOT</strong> close it
+    </Text>
+  ),
+};
+
+export const IsClosedOnEscapeKey = Template.bind({});
+IsClosedOnEscapeKey.args = {
+  isClosedOnEscapeKey: false,
+  children: (
+    <Text paddingTop={4}>
+      This Modal has set isClosedOnEscapeKey: false. Pressing the ESC key{' '}
+      <strong>WILL NOT</strong> close it
+    </Text>
+  ),
+};
+
+export const InitialFocusRef: ComponentStory<typeof Modal> = (args) => {
+  const modalContentRef = React.useRef<HTMLDivElement>(null);
+  const inputRef = React.useRef<HTMLDivElement>(null);
+  const [{ isOpen }, updateArgs] = useArgs();
+  const handleOnClick = () => {
+    updateArgs({ isOpen: true });
+  };
+  const handleOnClose = () => {
+    updateArgs({ isOpen: false });
+  };
+  return (
+    <>
+      <Button onClick={handleOnClick}>Open modal</Button>
+      <Modal
+        {...args}
+        modalContentRef={modalContentRef}
+        isOpen={isOpen}
+        onClose={handleOnClose}
+        initialFocusRef={inputRef}
+      >
+        <ModalOverlay />
+        <ModalContent modalContentRef={modalContentRef}>
+          <ModalHeader
+            onClose={handleOnClose}
+            onBack={handleOnClose}
+            marginBottom={4}
+          >
+            Modal Header
+          </ModalHeader>
+          <TextFieldSearch
+            placeholder="Search"
+            inputProps={{ ref: inputRef }}
+            width={BLOCK_SIZES.FULL}
+          />
+          {args.children}
+        </ModalContent>
+      </Modal>
+    </>
+  );
+};
+
+InitialFocusRef.args = {
+  children: (
+    <Text paddingTop={4}>
+      This Modal has set initialFocusRef to the TextFieldSearch component. When
+      the Modal opens, the TextFieldSearch component will be focused.
+    </Text>
+  ),
+};
+
+export const FinalFocusRef: ComponentStory<typeof Modal> = (args) => {
+  const modalContentRef = React.useRef<HTMLDivElement>(null);
+  const buttonRef = React.useRef<HTMLButtonElement>(null);
+  const [{ isOpen }, updateArgs] = useArgs();
+  const handleOnClick = () => {
+    updateArgs({ isOpen: true });
+  };
+  const handleOnClose = () => {
+    updateArgs({ isOpen: false });
+  };
+  return (
+    <>
+      <Button onClick={handleOnClick} marginRight={4}>
+        Open modal
+      </Button>
+      <button ref={buttonRef}>Receives focus after close</button>
+      <Modal
+        {...args}
+        modalContentRef={modalContentRef}
+        isOpen={isOpen}
+        onClose={handleOnClose}
+        finalFocusRef={buttonRef}
+      >
+        <ModalOverlay />
+        <ModalContent modalContentRef={modalContentRef}>
+          <ModalHeader
+            onClose={handleOnClose}
+            onBack={handleOnClose}
+            marginBottom={4}
+          >
+            Modal Header
+          </ModalHeader>
+          <Text>{args.children}</Text>
+        </ModalContent>
+      </Modal>
+    </>
+  );
+};
+
+FinalFocusRef.args = {
+  children: (
+    <Text paddingTop={4}>
+      This Modal has set finalFocusRef to the second button element. When the
+      Modal closes, the second button component will be focused. Use keyboard
+      navigation to see it clearly.
+    </Text>
+  ),
+};
+
+export const RestoreFocus = Template.bind({});
+RestoreFocus.args = {
+  restoreFocus: true,
+  children: (
+    <Text paddingTop={4}>
+      This Modal has set restoreFocus: true. When the Modal closes, the Button
+      component will be focused. Use keyboard navigation to see it clearly.
+    </Text>
+  ),
+};
+
+export const AutoFocus = Template.bind({});
+AutoFocus.args = {
+  autoFocus: false,
+  children: (
+    <Text paddingTop={4}>
+      This Modal has set autoFocus: false. When the Modal opens the first
+      element to focus <strong>WILL NOT</strong> be the first focusable element
+      in the Modal.
+    </Text>
+  ),
+};

--- a/ui/components/component-library/modal/modal.test.tsx
+++ b/ui/components/component-library/modal/modal.test.tsx
@@ -1,0 +1,139 @@
+/* eslint-disable jest/require-top-level-describe */
+import { render, fireEvent } from '@testing-library/react';
+import React from 'react';
+
+import { Modal } from './modal';
+
+describe('Modal', () => {
+  const onClose = jest.fn();
+
+  beforeEach(() => {
+    onClose.mockClear();
+  });
+
+  it('should render the Modal without crashing', () => {
+    const { getByText, getByTestId } = render(
+      <Modal onClose={onClose} isOpen data-testid="modal">
+        <div>modal dialog</div>
+      </Modal>,
+    );
+    expect(getByText('modal dialog')).toBeDefined();
+    expect(getByTestId('modal')).toHaveClass('mm-modal');
+  });
+
+  it('should match snapshot', () => {
+    const { container } = render(
+      <Modal onClose={onClose} isOpen>
+        <div>modal dialog</div>
+      </Modal>,
+    );
+    expect(container).toMatchSnapshot();
+  });
+
+  it('should render with and additional className', () => {
+    const { getByTestId } = render(
+      <Modal
+        onClose={onClose}
+        isOpen
+        className="test-class"
+        data-testid="modal"
+      >
+        <div>modal dialog</div>
+      </Modal>,
+    );
+    expect(getByTestId('modal')).toHaveClass('mm-modal test-class');
+  });
+
+  it('should close when escape key is pressed', () => {
+    const { getByRole } = render(
+      <Modal isOpen={true} onClose={onClose}>
+        <div role="dialog">modal dialog</div>
+      </Modal>,
+    );
+    fireEvent.keyDown(getByRole('dialog'), { key: 'Escape' });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('should not close when isClosedOnEscapeKey is false and escape key is pressed', () => {
+    const { getByRole } = render(
+      <Modal isOpen={true} onClose={onClose} isClosedOnEscapeKey={false}>
+        <div role="dialog">modal dialog</div>
+      </Modal>,
+    );
+    fireEvent.keyDown(getByRole('dialog'), { key: 'Escape' });
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('should close when clicked outside', () => {
+    const ref: React.RefObject<HTMLDivElement> = React.createRef();
+    const { getByTestId } = render(
+      <Modal isOpen={true} onClose={onClose} modalContentRef={ref}>
+        <div data-testid="modal-dialog" ref={ref}>
+          modal dialog
+        </div>
+      </Modal>,
+    );
+    // don't close when clicked inside
+    fireEvent.mouseDown(getByTestId('modal-dialog'));
+    expect(onClose).not.toHaveBeenCalled();
+    // close when clicked outside
+    fireEvent.mouseDown(document.body);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('should not close when isClosedOnOutsideClick is false and clicked outside', () => {
+    const ref: React.RefObject<HTMLDivElement> = React.createRef();
+    const { getByTestId } = render(
+      <Modal
+        isOpen={true}
+        onClose={onClose}
+        modalContentRef={ref}
+        isClosedOnOutsideClick={false}
+      >
+        <div data-testid="modal-dialog" ref={ref}>
+          modal dialog
+        </div>
+      </Modal>,
+    );
+    // don't close when clicked inside
+    fireEvent.mouseDown(getByTestId('modal-dialog'));
+    expect(onClose).not.toHaveBeenCalled();
+    // don't close when clicked outside
+    fireEvent.mouseDown(document.body);
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('should focus initial focus ref when autoFocus is false', () => {
+    const initialRef: React.RefObject<HTMLInputElement> = React.createRef();
+    const { getByTestId } = render(
+      <Modal isOpen={true} onClose={onClose} initialFocusRef={initialRef}>
+        <div>
+          <button>modal dialog</button>
+          <input data-testid="input" ref={initialRef} />
+        </div>
+      </Modal>,
+    );
+    expect(getByTestId('input')).toHaveFocus();
+  });
+
+  it('should focus final focus ref when modal is closed', () => {
+    const finalRef: React.RefObject<HTMLButtonElement> = React.createRef();
+    const { rerender } = render(
+      <>
+        <button ref={finalRef}>button</button>
+        <Modal isOpen={true} onClose={onClose} finalFocusRef={finalRef}>
+          <div data-testid="modal-dialog">modal dialog</div>
+        </Modal>
+      </>,
+    );
+    rerender(
+      <>
+        <button ref={finalRef}>button</button>
+        <Modal isOpen={false} onClose={onClose} finalFocusRef={finalRef}>
+          <div data-testid="modal-dialog">modal dialog</div>
+        </Modal>
+      </>,
+    );
+    expect(finalRef.current).toHaveFocus();
+  });
+});

--- a/ui/components/component-library/modal/modal.tsx
+++ b/ui/components/component-library/modal/modal.tsx
@@ -1,0 +1,84 @@
+import React, { useEffect } from 'react';
+import ReactDOM from 'react-dom';
+import classnames from 'classnames';
+
+import {
+  AlignItems,
+  BLOCK_SIZES,
+  DISPLAY,
+  JustifyContent,
+} from '../../../helpers/constants/design-system';
+
+import Box from '../../ui/box/box';
+import { ModalFocus } from './modal-focus';
+
+import { ModalProps } from './modal.types';
+
+export const Modal: React.FC<ModalProps> = ({
+  className = '',
+  isOpen,
+  onClose,
+  children,
+  modalContentRef,
+  isClosedOnOutsideClick = true,
+  isClosedOnEscapeKey = true,
+  autoFocus = true,
+  initialFocusRef,
+  finalFocusRef,
+  restoreFocus,
+  ...props
+}) => {
+  const handleEscKey = (event: KeyboardEvent) => {
+    if (isClosedOnEscapeKey && event.key === 'Escape') {
+      onClose();
+    }
+  };
+
+  const handleClickOutside = (event: MouseEvent) => {
+    if (
+      isClosedOnOutsideClick &&
+      modalContentRef?.current &&
+      !modalContentRef.current.contains(event.target as Node)
+    ) {
+      onClose();
+    }
+  };
+
+  useEffect(() => {
+    document.addEventListener('keydown', handleEscKey);
+    document.addEventListener('mousedown', handleClickOutside);
+
+    return () => {
+      document.removeEventListener('keydown', handleEscKey);
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, []);
+
+  return isOpen
+    ? ReactDOM.createPortal(
+        <Box
+          className={classnames('mm-modal', className)}
+          display={DISPLAY.FLEX}
+          justifyContent={JustifyContent.center}
+          alignItems={AlignItems.center}
+          width={BLOCK_SIZES.FULL}
+          height={BLOCK_SIZES.FULL}
+          padding={4}
+          {...props}
+        >
+          <ModalFocus
+            autoFocus={autoFocus}
+            initialFocusRef={initialFocusRef}
+            finalFocusRef={finalFocusRef}
+            restoreFocus={restoreFocus}
+            modalContentRef={modalContentRef}
+          >
+            {children}
+          </ModalFocus>
+        </Box>,
+        document.body,
+      )
+    : null;
+};
+
+export default Modal;

--- a/ui/components/component-library/modal/modal.types.ts
+++ b/ui/components/component-library/modal/modal.types.ts
@@ -1,0 +1,40 @@
+import type { BoxProps } from '../../ui/box/box.d';
+import type { ModalFocusProps } from './modal-focus.types';
+
+export interface ModalProps extends ModalFocusProps, BoxProps {
+  /**
+   * If the modal is open or not
+   */
+  isOpen: boolean;
+  /**
+   * Fires when the modal is closed
+   */
+  onClose: () => void;
+  /**
+   * The elements to be rendered inside the modal
+   * Usually ModalOverlay and ModalContent
+   */
+  children: React.ReactNode;
+  /**
+   * The class name to be applied to the modal
+   */
+  className?: string;
+  /**
+   * The modalContentRef allows for the modal to be closed when the user clicks outside of the modal
+   * You should apply this ref to ModalContent or the equivalent element
+   */
+  modalContentRef?: React.RefObject<HTMLDivElement>;
+  /**
+   * isClosedOnOutsideClick enables the ability to close the modal when the user clicks outside of the modal
+   *
+   * @default true
+   */
+  isClosedOnOutsideClick?: boolean;
+  /**
+   * closeOnEscape enables the ability to close the modal when the user presses the escape key
+   * If this is disabled there should be a close button in the modal or allow keyboard only users to close the modal with a button that is accessible via the tab key
+   *
+   * @default true
+   */
+  isClosedOnEscapeKey?: boolean;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1596,6 +1596,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/runtime@npm:^7.12.13":
+  version: 7.21.0
+  resolution: "@babel/runtime@npm:7.21.0"
+  dependencies:
+    regenerator-runtime: ^0.13.11
+  checksum: 7b33e25bfa9e0e1b9e8828bb61b2d32bdd46b41b07ba7cb43319ad08efc6fda8eb89445193e67d6541814627df0ca59122c0ea795e412b99c5183a0540d338ab
+  languageName: node
+  linkType: hard
+
 "@babel/runtime@patch:@babel/runtime@npm%3A7.18.9#./.yarn/patches/@babel-runtime-npm-7.18.9-28ca6b5f61.patch::locator=metamask-crx%40workspace%3A.":
   version: 7.18.9
   resolution: "@babel/runtime@patch:@babel/runtime@npm%3A7.18.9#./.yarn/patches/@babel-runtime-npm-7.18.9-28ca6b5f61.patch::version=7.18.9&hash=918bda&locator=metamask-crx%40workspace%3A."
@@ -13783,6 +13792,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"detect-node-es@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "detect-node-es@npm:1.1.0"
+  checksum: e46307d7264644975b71c104b9f028ed1d3d34b83a15b8a22373640ce5ea630e5640b1078b8ea15f202b54641da71e4aa7597093bd4b91f113db520a26a37449
+  languageName: node
+  linkType: hard
+
 "detect-node@npm:^2.0.4":
   version: 2.0.4
   resolution: "detect-node@npm:2.0.4"
@@ -17075,6 +17091,15 @@ __metadata:
     inherits: ^2.0.1
     readable-stream: ^2.0.4
   checksum: d7423c666c9bbef0b7e511d126e8e7a4cef4c7271a7294b8abf27cdc6687c780f72384dafa5c11d3d0665923be5cf4ff880bf74ec1846d8c125008a0cfe5a692
+  languageName: node
+  linkType: hard
+
+"focus-lock@npm:^0.11.6":
+  version: 0.11.6
+  resolution: "focus-lock@npm:0.11.6"
+  dependencies:
+    tslib: ^2.0.3
+  checksum: 6a407c4c45f05f8258f92565541fc5f8043f576643a7603eb999e1a790173e08712056766ed034ccd31c6d6deed259dea558002712fa5ef2432fc6930b9c7a05
   languageName: node
   linkType: hard
 
@@ -24178,6 +24203,7 @@ __metadata:
     react: ^16.12.0
     react-devtools: ^4.11.0
     react-dom: ^16.12.0
+    react-focus-lock: ^2.9.4
     react-idle-timer: ^4.2.5
     react-inspector: ^2.3.0
     react-markdown: ^6.0.3
@@ -28232,6 +28258,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-clientside-effect@npm:^1.2.6":
+  version: 1.2.6
+  resolution: "react-clientside-effect@npm:1.2.6"
+  dependencies:
+    "@babel/runtime": ^7.12.13
+  peerDependencies:
+    react: ^15.3.0 || ^16.0.0 || ^17.0.0 || ^18.0.0
+  checksum: 7db6110027a51458b1a46109d2b63dd822825f483c71afef7c0c0a671f3b1aa155049dbd8651c9d536ffac83601f8823b7c3f8916b4f4ee5c3cb7647a85cce4e
+  languageName: node
+  linkType: hard
+
 "react-colorful@npm:^5.1.2":
   version: 5.3.0
   resolution: "react-colorful@npm:5.3.0"
@@ -28347,6 +28384,26 @@ __metadata:
   version: 3.2.0
   resolution: "react-fast-compare@npm:3.2.0"
   checksum: 8ef272c825ae329f61633ce4ce7f15aa5b84e5214d88bc0823880236e03e985a13195befa2c7a4eda7db3b017dc7985729152d88445823f652403cf36c2b86aa
+  languageName: node
+  linkType: hard
+
+"react-focus-lock@npm:^2.9.4":
+  version: 2.9.4
+  resolution: "react-focus-lock@npm:2.9.4"
+  dependencies:
+    "@babel/runtime": ^7.0.0
+    focus-lock: ^0.11.6
+    prop-types: ^15.6.2
+    react-clientside-effect: ^1.2.6
+    use-callback-ref: ^1.3.0
+    use-sidecar: ^1.1.2
+  peerDependencies:
+    "@types/react": ^16.8.0 || ^17.0.0 || ^18.0.0
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: f4c696bdbde5008560388622b994c00502d1faeeabff32b02964770c8c020208872f5f6b914b249a8bf3e97cc12e58bb0d227cd33460093654156b7b7f4c8d76
   languageName: node
   linkType: hard
 
@@ -28992,7 +29049,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"regenerator-runtime@npm:^0.13.9":
+"regenerator-runtime@npm:^0.13.11, regenerator-runtime@npm:^0.13.9":
   version: 0.13.11
   resolution: "regenerator-runtime@npm:0.13.11"
   checksum: 27481628d22a1c4e3ff551096a683b424242a216fee44685467307f14d58020af1e19660bf2e26064de946bad7eff28950eae9f8209d55723e2d9351e632bbb4
@@ -33734,6 +33791,37 @@ __metadata:
     punycode: 1.3.2
     querystring: 0.2.0
   checksum: 50d100d3dd2d98b9fe3ada48cadb0b08aa6be6d3ac64112b867b56b19be4bfcba03c2a9a0d7922bfd7ac17d4834e88537749fe182430dfd9b68e520175900d90
+  languageName: node
+  linkType: hard
+
+"use-callback-ref@npm:^1.3.0":
+  version: 1.3.0
+  resolution: "use-callback-ref@npm:1.3.0"
+  dependencies:
+    tslib: ^2.0.0
+  peerDependencies:
+    "@types/react": ^16.8.0 || ^17.0.0 || ^18.0.0
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 7913df383a5a6fcb399212eedefaac2e0c6f843555202d4e3010bac3848afe38ecaa3d0d6500ad1d936fbeffd637e6c517e68edb024af5e6beca7f27f3ce7b21
+  languageName: node
+  linkType: hard
+
+"use-sidecar@npm:^1.1.2":
+  version: 1.1.2
+  resolution: "use-sidecar@npm:1.1.2"
+  dependencies:
+    detect-node-es: ^1.1.0
+    tslib: ^2.0.0
+  peerDependencies:
+    "@types/react": ^16.9.0 || ^17.0.0 || ^18.0.0
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 925d1922f9853e516eaad526b6fed1be38008073067274f0ecc3f56b17bb8ab63480140dd7c271f94150027c996cea4efe83d3e3525e8f3eda22055f6a39220b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Explanation

Adding `Modal` component based on [insight report](https://www.figma.com/file/hxYqloYgmVcgsoiVqmGZ8K/Modal-Audit?node-id=493%3A233&t=O9QcNdhRvMCxlQIR-1). This PR adds the final components to complete the new `Modal` component as well as stories, documentation and tests. It also introduces a `ModalFocus` component that uses the [react-focus-lock](https://github.com/theKashey/react-focus-lock) library to improve the accessibility of our Modal component for keyboard only users.

* Fixes #15432 
- [Insight report](https://www.figma.com/file/hxYqloYgmVcgsoiVqmGZ8K/Modal-Audit?node-id=493%3A233&t=O9QcNdhRvMCxlQIR-1)
- [x] Merge https://github.com/MetaMask/metamask-extension/pull/18311
- [x] Merge https://github.com/MetaMask/metamask-extension/pull/18161
- [x] Merge https://github.com/MetaMask/metamask-extension/pull/18175
- [x] Add tests

## Screenshots/Screencaps

### After

https://user-images.githubusercontent.com/8112138/234746491-46d9f3c5-3c29-4ae5-beba-73c521d422f3.mov

Text coverage for `Modal` and `ModalFocus`

<img width="1433" alt="Screenshot 2023-04-27 at 11 56 09 AM" src="https://user-images.githubusercontent.com/8112138/234747139-72bd6f8c-18e7-4069-9663-9b0150c4bad2.png">

## Manual Testing Steps

- Go to the latest storybook build on this PR
- Search `Modal` in the search bar
- View `stories`, `controls` and `docs`

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
