### PR TITLE
Added NFT component to single NFT approval confirmation screen

### DIFF
--- a/ui/components/ui/nft-info/index.scss
+++ b/ui/components/ui/nft-info/index.scss
@@ -2,8 +2,4 @@
   &__content {
     width: 100%;
   }
-
-  &__button {
-    padding: 0;
-  }
 }

--- a/ui/components/ui/nft-info/nft-info.js
+++ b/ui/components/ui/nft-info/nft-info.js
@@ -2,16 +2,14 @@ import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 import { I18nContext } from '../../../contexts/i18n';
 import Box from '../box';
-import Typography from '../typography';
 import {
   BackgroundColor,
   DISPLAY,
-  FONT_WEIGHT,
   TextColor,
-  TypographyVariant,
+  TextVariant,
 } from '../../../helpers/constants/design-system';
-import Identicon from '../identicon';
-import Button from '../button';
+import { Text } from '../../component-library';
+import NftCollectionImage from '../nft-collection-image/nft-collection-image';
 
 export default function NftInfo({ assetName, tokenAddress, tokenId }) {
   const t = useContext(I18nContext);
@@ -24,35 +22,24 @@ export default function NftInfo({ assetName, tokenAddress, tokenId }) {
     >
       <Box display={DISPLAY.FLEX} className="nft-info__content">
         <Box margin={4}>
-          <Identicon address={tokenAddress} diameter={24} />
+          <NftCollectionImage
+            assetName={assetName}
+            tokenAddress={tokenAddress}
+          />
         </Box>
         <Box>
-          <Typography
-            fontWeight={FONT_WEIGHT.BOLD}
-            variant={TypographyVariant.H6}
-            marginTop={4}
-          >
-            {assetName}
-          </Typography>
-          <Typography
-            variant={TypographyVariant.H7}
+          <Text variant={TextVariant.bodyMdBold} marginTop={4} as="h6">
+            {assetName ?? t('unknownCollection')}
+          </Text>
+          <Text
+            variant={TextVariant.bodySm}
             marginBottom={4}
             color={TextColor.textAlternative}
+            as="h6"
           >
             {t('tokenId')} #{tokenId}
-          </Typography>
+          </Text>
         </Box>
-      </Box>
-      <Box marginTop={4} marginRight={4}>
-        <Button className="nft-info__button" type="link">
-          <Typography
-            variant={TypographyVariant.H6}
-            marginTop={0}
-            color={TextColor.primaryDefault}
-          >
-            {t('view')}
-          </Typography>
-        </Button>
       </Box>
     </Box>
   );

--- a/ui/components/ui/nft-info/nft-info.js
+++ b/ui/components/ui/nft-info/nft-info.js
@@ -37,7 +37,7 @@ export default function NftInfo({ assetName, tokenAddress, tokenId }) {
             color={TextColor.textAlternative}
             as="h6"
           >
-            {t('tokenId')} #{tokenId}
+            {`${t('tokenId')} #${tokenId}`}
           </Text>
         </Box>
       </Box>

--- a/ui/components/ui/nft-info/nft-info.test.js
+++ b/ui/components/ui/nft-info/nft-info.test.js
@@ -1,0 +1,44 @@
+import React from 'react';
+import configureMockStore from 'redux-mock-store';
+import mockState from '../../../../test/data/mock-state.json';
+import { renderWithProvider } from '../../../../test/lib/render-helpers';
+import NftInfo from './nft-info';
+
+describe('NftInfo', () => {
+  const store = configureMockStore()(mockState);
+  let props = {};
+
+  beforeEach(() => {
+    props = {
+      assetName: 'Bored Ape Yatch Club',
+      tokenAddress: '0xBC4CA0EdA7647A8aB7C2061c2E118A18a936f13D',
+      tokenId: '123',
+    };
+  });
+
+  it('should render NftInfo component collection name when name of collection are implemented in NFTs smart contracts', () => {
+    const { queryByText } = renderWithProvider(<NftInfo {...props} />, store);
+
+    expect(queryByText('Bored Ape Yatch Club')).toBeInTheDocument();
+  });
+
+  it('should render NftInfo component collection name when name of collection are not implemented in NFTs smart contracts', () => {
+    props.assetName = undefined;
+    const { queryByText } = renderWithProvider(<NftInfo {...props} />, store);
+
+    expect(queryByText('Unnamed collection')).toBeInTheDocument();
+  });
+
+  it('should render NftInfo component token id for specific collection', () => {
+    const { queryByText } = renderWithProvider(<NftInfo {...props} />, store);
+
+    expect(queryByText('Token ID #123')).toBeInTheDocument();
+  });
+
+  it('should render NftInfo component token id for specific collection when token id changes', () => {
+    props.tokenId = '38';
+    const { queryByText } = renderWithProvider(<NftInfo {...props} />, store);
+
+    expect(queryByText('Token ID #38')).toBeInTheDocument();
+  });
+});

--- a/ui/pages/confirm-approve/confirm-approve-content/__snapshots__/confirm-approve-content.component.test.js.snap
+++ b/ui/pages/confirm-approve/confirm-approve-content/__snapshots__/confirm-approve-content.component.test.js.snap
@@ -36,10 +36,13 @@ exports[`ConfirmApproveContent Component should render Confirm approve page corr
         Allow access to and transfer of all your 
         <span
           class="confirm-approve-content__approval-asset-title"
+          title="0x514910771af9ca656af840dff83e8264ecf986ca"
         >
-          ZenAcademy
+          TestDappCollectibles
         </span>
-        
+        <span>
+           (#1)
+        </span>
         ?
          
       </span>
@@ -212,10 +215,13 @@ exports[`ConfirmApproveContent Component should render Confirm approve page corr
         Revoke permission to access and transfer all of your 
         <span
           class="confirm-approve-content__approval-asset-title"
+          title="0x514910771af9ca656af840dff83e8264ecf986ca"
         >
-          ZenAcademy
+          TestDappCollectibles
         </span>
-        
+        <span>
+           (#1)
+        </span>
         ?
          
       </span>
@@ -228,10 +234,13 @@ exports[`ConfirmApproveContent Component should render Confirm approve page corr
         This revokes the permission for a third party to access and transfer all of your 
         <span
           class="confirm-approve-content__approval-asset-title"
+          title="0x514910771af9ca656af840dff83e8264ecf986ca"
         >
-          ZenAcademy
+          TestDappCollectibles
         </span>
-        
+        <span>
+           (#1)
+        </span>
          without further notice.
          
       </span>
@@ -399,10 +408,13 @@ exports[`ConfirmApproveContent Component should render Confirm approve page corr
         Allow access to and transfer all of your NFTs from 
         <span
           class="confirm-approve-content__approval-asset-title"
+          title="0x514910771af9ca656af840dff83e8264ecf986ca"
         >
-          this collection
+          TestDappCollectibles
         </span>
-        
+        <span>
+           (#1)
+        </span>
         ?
          
       </span>
@@ -415,10 +427,13 @@ exports[`ConfirmApproveContent Component should render Confirm approve page corr
         This allows a third party to access and transfer all of your NFTs from 
         <span
           class="confirm-approve-content__approval-asset-title"
+          title="0x514910771af9ca656af840dff83e8264ecf986ca"
         >
-          this collection
+          TestDappCollectibles
         </span>
-        
+        <span>
+           (#1)
+        </span>
          without further notice until you revoke its access.
          
       </span>
@@ -586,10 +601,13 @@ exports[`ConfirmApproveContent Component should render Confirm approve page corr
         Revoke permission to access and transfer all of your NFTs from 
         <span
           class="confirm-approve-content__approval-asset-title"
+          title="0x514910771af9ca656af840dff83e8264ecf986ca"
         >
-          this collection
+          TestDappCollectibles
         </span>
-        
+        <span>
+           (#1)
+        </span>
         ?
          
       </span>
@@ -602,10 +620,13 @@ exports[`ConfirmApproveContent Component should render Confirm approve page corr
         This revokes the permission for a third party to access and transfer all of your NFTs from 
         <span
           class="confirm-approve-content__approval-asset-title"
+          title="0x514910771af9ca656af840dff83e8264ecf986ca"
         >
-          this collection
+          TestDappCollectibles
         </span>
-        
+        <span>
+           (#1)
+        </span>
          without further notice.
          
       </span>

--- a/ui/pages/confirm-approve/confirm-approve-content/confirm-approve-content.component.js
+++ b/ui/pages/confirm-approve/confirm-approve-content/confirm-approve-content.component.js
@@ -32,6 +32,7 @@ import {
   Icon,
   Text,
 } from '../../../components/component-library';
+import NftInfo from '../../../components/ui/nft-info';
 
 export default class ConfirmApproveContent extends Component {
   static contextTypes = {
@@ -544,6 +545,7 @@ export default class ConfirmApproveContent extends Component {
       tokenId,
       tokenAddress,
       assetName,
+      isSetApproveForAll,
       userAcknowledgedGasMissing,
       setUserAcknowledgedGasMissing,
       renderSimulationFailureWarning,
@@ -613,6 +615,17 @@ export default class ConfirmApproveContent extends Component {
             />
           )}
         </Box>
+        {!isSetApproveForAll &&
+        (assetStandard === TokenStandard.ERC721 ||
+          assetStandard === TokenStandard.ERC1155) ? (
+          <Box padding={4} width={BLOCK_SIZES.FULL}>
+            <NftInfo
+              tokenAddress={tokenAddress}
+              assetName={assetName}
+              tokenId={tokenId}
+            />
+          </Box>
+        ) : null}
         <div className="confirm-approve-content__card-wrapper">
           {renderSimulationFailureWarning && (
             <Box

--- a/ui/pages/confirm-approve/confirm-approve-content/confirm-approve-content.component.test.js
+++ b/ui/pages/confirm-approve/confirm-approve-content/confirm-approve-content.component.test.js
@@ -67,6 +67,8 @@ const props = {
   isSetApproveForAll: false,
   isApprovalOrRejection: true,
   tokenAddress: '0x514910771af9ca656af840dff83e8264ecf986ca',
+  assetName: 'TestDappCollectibles',
+  tokenId: '1',
 };
 
 describe('ConfirmApproveContent Component', () => {
@@ -291,6 +293,133 @@ describe('ConfirmApproveContent Component', () => {
     expect(queryByText('2')).toBeInTheDocument();
     fireEvent.click(editButtons[1]);
     expect(props.showCustomizeNonceModal).toHaveBeenCalledTimes(4);
+
+    const showViewTxDetails = getByText('View full transaction details');
+    expect(queryByText('Permission request')).not.toBeInTheDocument();
+    expect(queryByText('Approved asset:')).not.toBeInTheDocument();
+    expect(queryByText('Granted to:')).not.toBeInTheDocument();
+    expect(queryByText('Data')).not.toBeInTheDocument();
+    fireEvent.click(showViewTxDetails);
+    expect(getByText('Hide full transaction details')).toBeInTheDocument();
+    expect(getByText('Permission request')).toBeInTheDocument();
+    expect(getByText('Approved asset:')).toBeInTheDocument();
+    expect(getByText('Granted to:')).toBeInTheDocument();
+    expect(getByText('Contract (0x9bc5baF8...fEF4)')).toBeInTheDocument();
+    expect(getByText('Data')).toBeInTheDocument();
+    expect(getByText('Function: Approve')).toBeInTheDocument();
+    expect(
+      getByText(
+        '0x095ea7b30000000000000000000000009bc5baf874d2da8d216ae9f137804184ee5afef40000000000000000000000000000000000000000000000000000000000011170',
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it('should render Confirm approve page correctly and NftInfo component correctly', () => {
+    const { queryByText, getByText, getAllByText, getByTestId } =
+      renderComponent(props);
+    expect(
+      queryByText('https://metamask.github.io/test-dapp/'),
+    ).toBeInTheDocument();
+    expect(getByTestId('confirm-approve-title').textContent).toStrictEqual(
+      ' Allow access to and transfer of your TestDappCollectibles (#1)? ',
+    );
+    expect(
+      queryByText(
+        'This allows a third party to access and transfer the following NFTs without further notice until you revoke its access.',
+      ),
+    ).toBeInTheDocument();
+    expect(queryByText('Verify contract details')).toBeInTheDocument();
+    const collectionName = getAllByText('TestDappCollectibles');
+    expect(collectionName[1]).toBeInTheDocument();
+    expect(queryByText('Token ID #1')).toBeInTheDocument();
+    expect(
+      queryByText(
+        'We were not able to estimate gas. There might be an error in the contract and this transaction may fail.',
+      ),
+    ).not.toBeInTheDocument();
+    expect(queryByText('I want to proceed anyway')).not.toBeInTheDocument();
+    expect(queryByText('View full transaction details')).toBeInTheDocument();
+
+    const editButtons = getAllByText('Edit');
+
+    expect(queryByText('Transaction fee')).toBeInTheDocument();
+    expect(
+      queryByText('A fee is associated with this request.'),
+    ).toBeInTheDocument();
+    expect(queryByText(`${props.ethTransactionTotal} ETH`)).toBeInTheDocument();
+    expect(queryByText(`$10.00`)).toBeInTheDocument();
+    fireEvent.click(editButtons[0]);
+    expect(props.showCustomizeGasModal).toHaveBeenCalledTimes(5);
+
+    expect(queryByText('Nonce')).toBeInTheDocument();
+    expect(queryByText('2')).toBeInTheDocument();
+    fireEvent.click(editButtons[1]);
+    expect(props.showCustomizeNonceModal).toHaveBeenCalledTimes(5);
+
+    const showViewTxDetails = getByText('View full transaction details');
+    expect(queryByText('Permission request')).not.toBeInTheDocument();
+    expect(queryByText('Approved asset:')).not.toBeInTheDocument();
+    expect(queryByText('Granted to:')).not.toBeInTheDocument();
+    expect(queryByText('Data')).not.toBeInTheDocument();
+    fireEvent.click(showViewTxDetails);
+    expect(getByText('Hide full transaction details')).toBeInTheDocument();
+    expect(getByText('Permission request')).toBeInTheDocument();
+    expect(getByText('Approved asset:')).toBeInTheDocument();
+    expect(getByText('Granted to:')).toBeInTheDocument();
+    expect(getByText('Contract (0x9bc5baF8...fEF4)')).toBeInTheDocument();
+    expect(getByText('Data')).toBeInTheDocument();
+    expect(getByText('Function: Approve')).toBeInTheDocument();
+    expect(
+      getByText(
+        '0x095ea7b30000000000000000000000009bc5baf874d2da8d216ae9f137804184ee5afef40000000000000000000000000000000000000000000000000000000000011170',
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it('should render Confirm approve page correctly and NftInfo component correctly when token id changes', () => {
+    const { queryByText, getByText, getAllByText, getByTestId } =
+      renderComponent({
+        ...props,
+        tokenId: '2',
+      });
+    expect(
+      queryByText('https://metamask.github.io/test-dapp/'),
+    ).toBeInTheDocument();
+    expect(getByTestId('confirm-approve-title').textContent).toStrictEqual(
+      ' Allow access to and transfer of your TestDappCollectibles (#2)? ',
+    );
+    expect(
+      queryByText(
+        'This allows a third party to access and transfer the following NFTs without further notice until you revoke its access.',
+      ),
+    ).toBeInTheDocument();
+    expect(queryByText('Verify contract details')).toBeInTheDocument();
+    const collectionName = getAllByText('TestDappCollectibles');
+    expect(collectionName[1]).toBeInTheDocument();
+    expect(queryByText('Token ID #2')).toBeInTheDocument();
+    expect(
+      queryByText(
+        'We were not able to estimate gas. There might be an error in the contract and this transaction may fail.',
+      ),
+    ).not.toBeInTheDocument();
+    expect(queryByText('I want to proceed anyway')).not.toBeInTheDocument();
+    expect(queryByText('View full transaction details')).toBeInTheDocument();
+
+    const editButtons = getAllByText('Edit');
+
+    expect(queryByText('Transaction fee')).toBeInTheDocument();
+    expect(
+      queryByText('A fee is associated with this request.'),
+    ).toBeInTheDocument();
+    expect(queryByText(`${props.ethTransactionTotal} ETH`)).toBeInTheDocument();
+    expect(queryByText(`$10.00`)).toBeInTheDocument();
+    fireEvent.click(editButtons[0]);
+    expect(props.showCustomizeGasModal).toHaveBeenCalledTimes(6);
+
+    expect(queryByText('Nonce')).toBeInTheDocument();
+    expect(queryByText('2')).toBeInTheDocument();
+    fireEvent.click(editButtons[1]);
+    expect(props.showCustomizeNonceModal).toHaveBeenCalledTimes(6);
 
     const showViewTxDetails = getByText('View full transaction details');
     expect(queryByText('Permission request')).not.toBeInTheDocument();

--- a/ui/pages/confirm-approve/confirm-approve-content/confirm-approve-content.component.test.js
+++ b/ui/pages/confirm-approve/confirm-approve-content/confirm-approve-content.component.test.js
@@ -7,7 +7,34 @@ import ConfirmApproveContent from '.';
 
 const renderComponent = (props) => {
   const store = configureMockStore([])({
-    metamask: { provider: { chainId: '0x0' } },
+    metamask: {
+      provider: { chainId: '0x0' },
+      tokenList: {
+        '0x514910771af9ca656af840dff83e8264ecf986ca': {
+          address: '0x514910771af9ca656af840dff83e8264ecf986ca',
+          symbol: 'LINK',
+          decimals: 18,
+          name: 'ChainLink Token',
+          iconUrl:
+            'https://crypto.com/price/coin-data/icon/LINK/color_icon.png',
+          aggregators: [
+            'Aave',
+            'Bancor',
+            'CMC',
+            'Crypto.com',
+            'CoinGecko',
+            '1inch',
+            'Paraswap',
+            'PMM',
+            'Zapper',
+            'Zerion',
+            '0x',
+          ],
+          occurrences: 12,
+          unlisted: false,
+        },
+      },
+    },
   });
   return renderWithProvider(<ConfirmApproveContent {...props} />, store);
 };
@@ -39,6 +66,7 @@ const props = {
   useCurrencyRateCheck: true,
   isSetApproveForAll: false,
   isApprovalOrRejection: true,
+  tokenAddress: '0x514910771af9ca656af840dff83e8264ecf986ca',
 };
 
 describe('ConfirmApproveContent Component', () => {


### PR DESCRIPTION
## Explanation

Added `NFT component` to `single NFT approval` confirmation screen. 

* Fixes #15753 

## Screenshots/Screencaps

### Before

#### Test-dapp

https://user-images.githubusercontent.com/92527393/225881191-c04bcd91-2c36-4df3-84d6-4188b4e050d9.mov

#### Etherscan

https://user-images.githubusercontent.com/92527393/225881355-2b004246-743a-413b-92dd-015c2cbe52a8.mov

### After

#### Test-dapp

https://user-images.githubusercontent.com/92527393/225873841-c7a1614c-04e9-476a-98dc-489121a6defc.mov

#### Etherscan

https://user-images.githubusercontent.com/92527393/225873951-4a30fdb2-d446-4df4-bb85-ca693837ca1c.mov

## Manual Testing Steps

### Test-dapp

1. Open the test dapp https://metamask.github.io/test-dapp/
2. Under the collectibles section, click on `Deploy`
3. Wait for transaction to be confirmed and click on `Mint` (user can insert grater than 1 in the input field)
4. Wait for transaction to be confirmed and click on `Approve` -- user can see this component

### Etherscan

1. Go to https://etherscan.io/address/0x2a187453064356c898cae034eaed119e1663acb8#writeContract (erc721)
2. Connect your wallet
3. Go to `approve` and input a random `address` and `tokenId`
4. Click on Write
5. See how it is displays this component