### PR TITLE
Fixed test instability

### DIFF
--- a/test/e2e/swaps/shared.js
+++ b/test/e2e/swaps/shared.js
@@ -83,7 +83,7 @@ const reviewQuote = async (driver, options) => {
     'Error: SwapFrom has wrong symbol',
   );
   const swapToSymbol = await driver.waitForSelector(
-    '.main-quote-summary__destination-row',
+    '.main-quote-summary__destination-row > span',
   );
   assert.equal(
     await swapToSymbol.getText(),


### PR DESCRIPTION
## Explanation

In the reviewQuote function fixed the selector to correctly point to the SwapTo field.  

## Pre-merge author checklist

- [X] I've clearly explained:
  - [X] What problem this PR is solving
  - [X] How this problem was solved
  - [X] How reviewers can test my changes
- [C] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
