### PR TITLE
[FLASK] Add hardcoded derivation paths

### DIFF
--- a/shared/constants/snaps.ts
+++ b/shared/constants/snaps.ts
@@ -86,6 +86,11 @@ export const SNAPS_DERIVATION_PATHS: SnapsDerivationPath[] = [
     name: 'Bitcoin Testnet Native SegWit',
   },
   {
+    path: ['m', `44'`, `501'`],
+    curve: 'secp256k1',
+    name: 'Solana',
+  },
+  {
     path: ['m', `44'`, `2'`],
     curve: 'secp256k1',
     name: 'Litecoin',

--- a/shared/constants/snaps.ts
+++ b/shared/constants/snaps.ts
@@ -52,13 +52,98 @@ type SnapsDerivationPath = {
 export const SNAPS_DERIVATION_PATHS: SnapsDerivationPath[] = [
   {
     path: ['m', `44'`, `0'`],
+    curve: 'ed25519',
+    name: 'Test BIP-32 Path (ed25519)',
+  },
+  {
+    path: ['m', `44'`, `1'`],
     curve: 'secp256k1',
     name: 'Test BIP-32 Path (secp256k1)',
   },
   {
     path: ['m', `44'`, `0'`],
+    curve: 'secp256k1',
+    name: 'Bitcoin Legacy',
+  },
+  {
+    path: ['m', `49'`, `0'`],
+    curve: 'secp256k1',
+    name: 'Bitcoin Nested SegWit',
+  },
+  {
+    path: ['m', `49'`, `1'`],
+    curve: 'secp256k1',
+    name: 'Bitcoin Testnet Nested SegWit',
+  },
+  {
+    path: ['m', `84'`, `0'`],
+    curve: 'secp256k1',
+    name: 'Bitcoin Native SegWit',
+  },
+  {
+    path: ['m', `84'`, `1'`],
+    curve: 'secp256k1',
+    name: 'Bitcoin Testnet Native SegWit',
+  },
+  {
+    path: ['m', `44'`, `2'`],
+    curve: 'secp256k1',
+    name: 'Litecoin',
+  },
+  {
+    path: ['m', `44'`, `3'`],
+    curve: 'secp256k1',
+    name: 'Dogecoin',
+  },
+  {
+    path: ['m', `44'`, `60'`],
+    curve: 'secp256k1',
+    name: 'Ethereum',
+  },
+  {
+    path: ['m', `44'`, `118'`],
+    curve: 'secp256k1',
+    name: 'Atom',
+  },
+  {
+    path: ['m', `44'`, `145'`],
+    curve: 'secp256k1',
+    name: 'Bitcoin Cash',
+  },
+  {
+    path: ['m', `44'`, `714'`],
+    curve: 'secp256k1',
+    name: 'Binance (BNB)',
+  },
+  {
+    path: ['m', `44'`, `931'`],
+    curve: 'secp256k1',
+    name: 'THORChain (RUNE)',
+  },
+  {
+    path: ['m', `44'`, `330'`],
+    curve: 'secp256k1',
+    name: 'Terra (LUNA)',
+  },
+  {
+    path: ['m', `44'`, `459'`],
+    curve: 'secp256k1',
+    name: 'Kava',
+  },
+  {
+    path: ['m', `44'`, `529'`],
+    curve: 'secp256k1',
+    name: 'Secret Network',
+  },
+  {
+    path: ['m', `44'`, `397'`],
     curve: 'ed25519',
-    name: 'Test BIP-32 Path (ed25519)',
+    name: 'NEAR Protocol',
+  },
+  {
+    path: ['m', `44'`, `1'`, `0'`],
+    curve: 'ed25519',
+    name: 'NEAR Protocol Testnet',
   },
 ];
 ///: END:ONLY_INCLUDE_IN


### PR DESCRIPTION
The derivation paths (and associated chain names) used by the allowlisted protocol snaps that are using the BIP-32 RPC method have been hard-coded into the extension en lieu of a soft-coded method of resolving BIP-32 derivation paths.
