### PR TITLE
security: patch request for CVE-2023-28155

### DIFF
--- a/.iyarc
+++ b/.iyarc
@@ -15,3 +15,7 @@ GHSA-6fc8-4gx4-v693
 # patched version of 3.3.1. We can remove this once the
 # smart-transaction-controller updates its dependency.
 GHSA-8gh8-hqwg-xf34
+
+# request library is subject to SSRF.
+# addressed by temporary patch in .yarn/patches/request-npm-2.88.2-f4a57c72c4.patch
+GHSA-p8p7-x288-28g6

--- a/.yarn/patches/request-npm-2.88.2-f4a57c72c4.patch
+++ b/.yarn/patches/request-npm-2.88.2-f4a57c72c4.patch
@@ -1,0 +1,31 @@
+diff --git a/lib/redirect.js b/lib/redirect.js
+index b9150e77c73d63367845c0aec15b5684d900943f..2864f9f2abc481ecf2b2dd96b1293f5b93393efd 100644
+--- a/lib/redirect.js
++++ b/lib/redirect.js
+@@ -14,6 +14,7 @@ function Redirect (request) {
+   this.redirects = []
+   this.redirectsFollowed = 0
+   this.removeRefererHeader = false
++  this.allowInsecureRedirect = false
+ }
+ 
+ Redirect.prototype.onRequest = function (options) {
+@@ -40,6 +41,9 @@ Redirect.prototype.onRequest = function (options) {
+   if (options.followOriginalHttpMethod !== undefined) {
+     self.followOriginalHttpMethod = options.followOriginalHttpMethod
+   }
++  if (options.allowInsecureRedirect !== undefined) {
++    self.allowInsecureRedirect = options.allowInsecureRedirect
++  }
+ }
+ 
+ Redirect.prototype.redirectTo = function (response) {
+@@ -108,7 +112,7 @@ Redirect.prototype.onResponse = function (response) {
+   request.uri = url.parse(redirectTo)
+ 
+   // handle the case where we change protocol from https to http or vice versa
+-  if (request.uri.protocol !== uriPrev.protocol) {
++  if (request.uri.protocol !== uriPrev.protocol && self.allowInsecureRedirect) {
+     delete request.agent
+   }
+ 

--- a/package.json
+++ b/package.json
@@ -201,7 +201,10 @@
     "async-done@~1.3.2": "patch:async-done@npm%3A1.3.2#./.yarn/patches/async-done-npm-1.3.2-1f0a4a8997.patch",
     "async-done@^1.2.0": "patch:async-done@npm%3A1.3.2#./.yarn/patches/async-done-npm-1.3.2-1f0a4a8997.patch",
     "async-done@^1.2.2": "patch:async-done@npm%3A1.3.2#./.yarn/patches/async-done-npm-1.3.2-1f0a4a8997.patch",
-    "fast-json-patch@^3.1.1": "patch:fast-json-patch@npm%3A3.1.1#./.yarn/patches/fast-json-patch-npm-3.1.1-7e8bb70a45.patch"
+    "fast-json-patch@^3.1.1": "patch:fast-json-patch@npm%3A3.1.1#./.yarn/patches/fast-json-patch-npm-3.1.1-7e8bb70a45.patch",
+    "request@^2.83.0": "patch:request@npm%3A2.88.2#./.yarn/patches/request-npm-2.88.2-f4a57c72c4.patch",
+    "request@^2.88.2": "patch:request@npm%3A2.88.2#./.yarn/patches/request-npm-2.88.2-f4a57c72c4.patch",
+    "request@^2.85.0": "patch:request@npm%3A2.88.2#./.yarn/patches/request-npm-2.88.2-f4a57c72c4.patch"
   },
   "dependencies": {
     "@babel/runtime": "^7.5.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -29800,7 +29800,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"request@npm:^2.83.0, request@npm:^2.85.0, request@npm:^2.88.2":
+"request@npm:2.88.2":
   version: 2.88.2
   resolution: "request@npm:2.88.2"
   dependencies:
@@ -29825,6 +29825,34 @@ __metadata:
     tunnel-agent: ^0.6.0
     uuid: ^3.3.2
   checksum: 4e112c087f6eabe7327869da2417e9d28fcd0910419edd2eb17b6acfc4bfa1dad61954525949c228705805882d8a98a86a0ea12d7f739c01ee92af7062996983
+  languageName: node
+  linkType: hard
+
+"request@patch:request@npm%3A2.88.2#./.yarn/patches/request-npm-2.88.2-f4a57c72c4.patch::locator=metamask-crx%40workspace%3A.":
+  version: 2.88.2
+  resolution: "request@patch:request@npm%3A2.88.2#./.yarn/patches/request-npm-2.88.2-f4a57c72c4.patch::version=2.88.2&hash=2aadd7&locator=metamask-crx%40workspace%3A."
+  dependencies:
+    aws-sign2: ~0.7.0
+    aws4: ^1.8.0
+    caseless: ~0.12.0
+    combined-stream: ~1.0.6
+    extend: ~3.0.2
+    forever-agent: ~0.6.1
+    form-data: ~2.3.2
+    har-validator: ~5.1.3
+    http-signature: ~1.2.0
+    is-typedarray: ~1.0.0
+    isstream: ~0.1.2
+    json-stringify-safe: ~5.0.1
+    mime-types: ~2.1.19
+    oauth-sign: ~0.9.0
+    performance-now: ^2.1.0
+    qs: ~6.5.2
+    safe-buffer: ^5.1.2
+    tough-cookie: ~2.5.0
+    tunnel-agent: ^0.6.0
+    uuid: ^3.3.2
+  checksum: 1a64d706b36b2bdd5803c3a0fd3fee5e76e8c17d01c34f84972460fbfa5914302c300821a1fafce804d236e637f3745f3bdfbbb4219c139e112076790fc279af
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
GHSA-p8p7-x288-28g6

Ported from https://github.com/request/request/pull/3444

This is notably used by `web3-provider-engine` and the reason CI deps audits in `develop` is currently failing: https://app.circleci.com/pipelines/github/MetaMask/metamask-extension/39790/workflows/8a74f244-ffc4-4323-b909-95c5e403885d/jobs/1096152