### PR TITLE
Ignoring all storybook files from coverage check

### DIFF
--- a/test/merge-coverage.js
+++ b/test/merge-coverage.js
@@ -233,7 +233,7 @@ async function start() {
               // checking test file coverage is redundant.
               '!**/*.test.js',
               '!**/__mocks__/**/*.js',
-              '!**/*.stories.js',
+              '!**/*.stories.*',
             ]),
             coverageMap,
           );


### PR DESCRIPTION
## Explanation
Currently any PRs that include a typescript version of a storybook file e.g. `.stories.tsx` will fail the coverage test 

This PR updates the coverage config file to ignore all `.stories.*` file extensions

## Manual Testing Steps
- Not sure how to test this without making an update to a stories.tsx, stories.js file?

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
