### PR TITLE
Updating jest config to ignore all stories files including js and tsx

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -13,7 +13,7 @@ module.exports = {
     '<rootDir>/development/fitness-functions/**/*.test.(js|ts|tsx)',
   ],
   coverageDirectory: './coverage',
-  coveragePathIgnorePatterns: ['.stories.js', '.snap'],
+  coveragePathIgnorePatterns: ['.stories.*', '.snap'],
   coverageReporters: ['json'],
   reporters: [
     'default',


### PR DESCRIPTION
## Explanation
Currently PRs will still fail coverage tests. Adding more config that I missed in this PR https://github.com/MetaMask/metamask-extension/pull/18225

This PR updates the `jest.config.js` file to ignore all .stories.* file extensions

Also did a search for `stories` to make sure I wasn't missing any other configs that need updating. The only other is the typescript migration.

![Screenshot 2023-03-18 at 9 44 31 AM](https://user-images.githubusercontent.com/8112138/226120879-fb7fa667-ce41-4756-9d7a-34047f0f0df4.png)


## Screenshots/Screencaps

### Before

<img width="1440" alt="Screenshot 2023-03-18 at 9 33 18 AM" src="https://user-images.githubusercontent.com/8112138/226120780-7ecae6b8-8df1-47ed-b602-f322ce4353af.png">


### After

<img width="1439" alt="Screenshot 2023-03-18 at 9 34 42 AM" src="https://user-images.githubusercontent.com/8112138/226120785-fc09f368-1d04-4210-b1fc-07b3efed644b.png">


## Manual Testing Steps

- Pull this branch and run

```
yarn jest ui/components/component-library/ --coverage --coverageReporters='html'
```

- See that `stories.tsx` files aren't included in the coverage reports


## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
