### PR TITLE
Remove use of `pify` from the static-server script

### DIFF
--- a/development/static-server.js
+++ b/development/static-server.js
@@ -1,14 +1,13 @@
 #!/usr/bin/env node
-const fs = require('fs');
+const fs = require('fs').promises;
 const path = require('path');
 
 const chalk = require('chalk');
-const pify = require('pify');
 
 const createStaticServer = require('./create-static-server');
 const { parsePort } = require('./lib/parse-port');
 
-const fsStat = pify(fs.stat);
+const fsStat = fs.stat;
 const DEFAULT_PORT = 9080;
 
 const onResponse = (request, response) => {


### PR DESCRIPTION
The static server script no longer uses `pify`. `pify` was being used to promisify the `fs.stat` function, but that function has a built-in Promise-supporting API that is now used instead.

## Manual Testing Steps

This is a pretty simple change. I'd expect this script to blow up if this didn't work correctly. This script is used by our e2e tests, so seeing them pass in CI should be sufficient for showing that this works.

You can test it locally using `yarn dapp` though. You should be able to access the test dapp via `localhost:8080`.

## Pre-merge author checklist

- [X] I've clearly explained:
  - [X] What problem this PR is solving
  - [X] How this problem was solved
  - [X] How reviewers can test my changes
- [X] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
