### PR TITLE
[FLASK] Remove permission footer in snap install/update flow

### DIFF
--- a/ui/pages/permissions-connect/flask/snap-install/snap-install.js
+++ b/ui/pages/permissions-connect/flask/snap-install/snap-install.js
@@ -2,7 +2,6 @@ import PropTypes from 'prop-types';
 import React, { useCallback, useState } from 'react';
 import { PageContainerFooter } from '../../../../components/ui/page-container';
 import PermissionsConnectPermissionList from '../../../../components/app/permissions-connect-permission-list';
-import PermissionsConnectFooter from '../../../../components/app/permissions-connect-footer';
 import { useI18nContext } from '../../../../hooks/useI18nContext';
 import SnapInstallWarning from '../../../../components/app/flask/snap-install-warning';
 import Box from '../../../../components/ui/box/box';
@@ -155,9 +154,6 @@ export default function SnapInstall({
         alignItems={AlignItems.center}
         flexDirection={FLEX_DIRECTION.COLUMN}
       >
-        <Box className="snap-install__footer--no-source-code" paddingTop={4}>
-          <PermissionsConnectFooter />
-        </Box>
         <PageContainerFooter
           cancelButtonType="default"
           hideCancel={hasError}

--- a/ui/pages/permissions-connect/flask/snap-result/snap-result.js
+++ b/ui/pages/permissions-connect/flask/snap-result/snap-result.js
@@ -1,8 +1,6 @@
 import PropTypes from 'prop-types';
 import React, { useCallback } from 'react';
 import { PageContainerFooter } from '../../../../components/ui/page-container';
-
-import PermissionsConnectFooter from '../../../../components/app/permissions-connect-footer';
 import { useI18nContext } from '../../../../hooks/useI18nContext';
 
 import Box from '../../../../components/ui/box/box';
@@ -100,9 +98,6 @@ export default function SnapResult({
         alignItems={AlignItems.center}
         flexDirection={FLEX_DIRECTION.COLUMN}
       >
-        <Box className="snap-install__footer--no-source-code" paddingTop={4}>
-          <PermissionsConnectFooter />
-        </Box>
         <PageContainerFooter
           hideCancel
           disabled={isLoading}

--- a/ui/pages/permissions-connect/flask/snap-update/snap-update.js
+++ b/ui/pages/permissions-connect/flask/snap-update/snap-update.js
@@ -1,7 +1,6 @@
 import PropTypes from 'prop-types';
 import React, { useCallback, useState } from 'react';
 import { PageContainerFooter } from '../../../../components/ui/page-container';
-import PermissionsConnectFooter from '../../../../components/app/permissions-connect-footer';
 import { useI18nContext } from '../../../../hooks/useI18nContext';
 import SnapInstallWarning from '../../../../components/app/flask/snap-install-warning';
 import Box from '../../../../components/ui/box/box';
@@ -163,9 +162,6 @@ export default function SnapUpdate({
         alignItems={AlignItems.center}
         flexDirection={FLEX_DIRECTION.COLUMN}
       >
-        <Box className="snap-update__footer--no-source-code" paddingTop={4}>
-          <PermissionsConnectFooter />
-        </Box>
         <PageContainerFooter
           cancelButtonType="default"
           hideCancel={hasError}


### PR DESCRIPTION
## Explanation

Removes the `Only connect with sites you trust` footer in the snap install/update flow because it's not relevant.


