### PR TITLE
Fix #18199 : Add fallbacks for confirmation title on NFT transfers

### DIFF
--- a/ui/components/app/confirm-subtitle/confirm-subtitle.test.js
+++ b/ui/components/app/confirm-subtitle/confirm-subtitle.test.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { hexToDecimal } from '../../../../shared/modules/conversion.utils';
 
 import mockState from '../../../../test/data/mock-state.json';
 import { renderWithProvider } from '../../../../test/lib/render-helpers';
@@ -45,7 +46,9 @@ describe('ConfirmSubTitle', () => {
     mockState.metamask.preferences.showFiatInTestnets = false;
     mockState.metamask.allNftContracts = {
       [mockState.metamask.selectedAddress]: {
-        [mockState.metamask.provider.chainId]: [{ address: '0x9' }],
+        [hexToDecimal(mockState.metamask.provider.chainId)]: [
+          { address: '0x9' },
+        ],
       },
     };
     store = configureStore(mockState);

--- a/ui/hooks/useTransactionInfo.js
+++ b/ui/hooks/useTransactionInfo.js
@@ -1,4 +1,5 @@
 import { useSelector } from 'react-redux';
+import { hexToDecimal } from '../../shared/modules/conversion.utils';
 
 import { isEqualCaseInsensitive } from '../../shared/modules/string-utils';
 
@@ -10,9 +11,11 @@ export const useTransactionInfo = (txData = {}) => {
   } = useSelector((state) => state.metamask);
 
   const isNftTransfer = Boolean(
-    allNftContracts?.[selectedAddress]?.[chainId]?.find((contract) => {
-      return isEqualCaseInsensitive(contract.address, txData.txParams.to);
-    }),
+    allNftContracts?.[selectedAddress]?.[hexToDecimal(chainId)]?.find(
+      (contract) => {
+        return isEqualCaseInsensitive(contract.address, txData.txParams.to);
+      },
+    ),
   );
 
   return { isNftTransfer };

--- a/ui/hooks/useTransactionInfo.test.js
+++ b/ui/hooks/useTransactionInfo.test.js
@@ -1,4 +1,5 @@
 import { renderHookWithProvider } from '../../test/lib/render-helpers';
+import { hexToDecimal } from '../../shared/modules/conversion.utils';
 import mockState from '../../test/data/mock-state.json';
 import { useTransactionInfo } from './useTransactionInfo';
 
@@ -17,7 +18,9 @@ describe('useTransactionInfo', () => {
     it('should return true if transaction is NFT transfer', () => {
       mockState.metamask.allNftContracts = {
         [mockState.metamask.selectedAddress]: {
-          [mockState.metamask.provider.chainId]: [{ address: '0x9' }],
+          [hexToDecimal(mockState.metamask.provider.chainId)]: [
+            { address: '0x9' },
+          ],
         },
       };
 

--- a/ui/pages/confirm-token-transaction-base/confirm-token-transaction-base.js
+++ b/ui/pages/confirm-token-transaction-base/confirm-token-transaction-base.js
@@ -71,7 +71,7 @@ export default function ConfirmTokenTransactionBase({
         collection.address.toLowerCase() === tokenAddress.toLowerCase(),
     );
     const titleTokenDescription =
-      tokenSymbol || nftCollection?.name || t('unkownCollection');
+      tokenSymbol || nftCollection?.name || t('unknownCollection');
 
     if (renderType === 'text') {
       return titleTokenDescription;


### PR DESCRIPTION
## Explanation
Fixes: #18199 

The bug was filed originally because antivirus software was blocking the URL of arweave.  This PR provides a fallback name and total subtitle based on the collection name.

## Screenshot

### With arweave address blocked
<img width="438" alt="ConfirmDisplay" src="https://user-images.githubusercontent.com/46655/226769264-24c94c06-9307-42e5-a522-cad6f49a5975.png">

### With requests answered normally
<img width="483" alt="NormalNFTSend" src="https://user-images.githubusercontent.com/46655/226769397-65d1a89a-c547-495b-893e-c9425ebd9747.png">
