### PR TITLE
PermissionsConnectHeader: unlock SiteOrigin title

### DIFF
--- a/ui/components/app/permissions-connect-header/permissions-connect-header.component.js
+++ b/ui/components/app/permissions-connect-header/permissions-connect-header.component.js
@@ -64,6 +64,7 @@ export default class PermissionsConnectHeader extends Component {
         <SiteOrigin
           chip
           siteOrigin={siteOrigin}
+          title={siteOrigin}
           iconSrc={iconUrl}
           name={iconName}
           leftIcon={leftIcon}

--- a/ui/components/app/signature-request-original/__snapshots__/signature-request-original.test.js.snap
+++ b/ui/components/app/signature-request-original/__snapshots__/signature-request-original.test.js.snap
@@ -182,6 +182,7 @@ exports[`SignatureRequestOriginal should match snapshot 1`] = `
       >
         <div
           class="site-origin"
+          title="https://happydapp.website/governance?futarchy=true"
         >
           <div
             class="chip chip--with-left-icon chip--border-color-border-muted chip--background-color-undefined"

--- a/ui/components/app/signature-request-original/signature-request-original.component.js
+++ b/ui/components/app/signature-request-original/signature-request-original.component.js
@@ -154,6 +154,7 @@ export default class SignatureRequestOriginal extends Component {
         ) : null}
         <div className="request-signature__origin">
           <SiteOrigin
+            title={txData.msgParams.origin}
             siteOrigin={txData.msgParams.origin}
             iconSrc={targetSubjectMetadata?.iconUrl}
             iconName={

--- a/ui/components/app/signature-request-siwe/__snapshots__/signature-request-siwe.test.js.snap
+++ b/ui/components/app/signature-request-siwe/__snapshots__/signature-request-siwe.test.js.snap
@@ -16,6 +16,7 @@ exports[`SignatureRequestSIWE (Sign in with Ethereum) should match snapshot 1`] 
         >
           <div
             class="site-origin"
+            title="https://example-dapp.website"
           >
             <div
               class="chip chip--with-left-icon chip--border-color-border-muted chip--background-color-undefined"


### PR DESCRIPTION
## Explanation

In case the origin is not fully displayed, use html title to display the site origin.

- Unlock SiteOrigin title for PermissionHeaderConnect
  - note: Sign-in With Ethereum for some reason uses PermissionHeaderConnect. We may want to look into this
- Unlock SiteOrigin title for SignatureRequestOriginal 

<!--
Thanks for the pull request. Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues, Slack conversations, Zendesk issues, user stories, etc. reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

## Screenshots/Screencaps

<!-- If you're making a change to the UI, make sure to capture a screenshot or a short video showing off your work! -->

### Before

<img width="390" alt="Screen Shot 2023-03-17 at 10 31 59 AM" src="https://user-images.githubusercontent.com/20778143/226752921-5db686a3-3ccc-410f-826f-a2cd807ae811.png">

<!-- How did the UI you changed look before your changes? Drag your file(s) below this line: -->

### After

<img width="385" alt="Screen Shot 2023-03-21 at 3 13 37 PM" src="https://user-images.githubusercontent.com/20778143/226753735-506529b0-78a3-48b7-bc5e-70e9530581de.png">

<!-- How does it look now? Drag your file(s) below this line: -->

## Manual Testing Steps

1. Create Sign-in With Ethereum, or another Signature Request transaction
2. Hover over SiteOrigin
3. Observe html title tooltip is displayed

<!--
How should reviewers and QA manually test your changes? For instance:

- Go to this screen
- Do this
- Then do this
-->

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
