### PR TITLE
UX: Accessibility: Focus on Popover title upon display

### DIFF
--- a/ui/components/ui/popover/popover.component.js
+++ b/ui/components/ui/popover/popover.component.js
@@ -1,4 +1,4 @@
-import React, { PureComponent } from 'react';
+import React, { PureComponent, useEffect, useRef } from 'react';
 import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
@@ -69,7 +69,13 @@ const Popover = ({
   footerProps = defaultFooterProps,
 }) => {
   const t = useI18nContext();
+  const headingRef = useRef();
   const showHeader = title || onBack || subtitle || onClose;
+
+  useEffect(() => {
+    headingRef?.current?.focus();
+  });
+
   const Header = () => (
     <Box
       {...{ ...defaultHeaderProps, ...headerProps }}
@@ -99,6 +105,8 @@ const Popover = ({
           variant={TextVariant.headingSm}
           as="h2"
           width={BLOCK_SIZES.FULL}
+          ref={headingRef}
+          tabIndex="0"
         >
           {title}
         </Text>

--- a/ui/components/ui/popover/popover.component.js
+++ b/ui/components/ui/popover/popover.component.js
@@ -1,4 +1,4 @@
-import React, { PureComponent, useEffect, useRef } from 'react';
+import React, { PureComponent, useEffect, useRef, useState } from 'react';
 import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
@@ -70,11 +70,22 @@ const Popover = ({
 }) => {
   const t = useI18nContext();
   const headingRef = useRef();
+  const [launchingElement, setLaunchingElement] = useState(null);
   const showHeader = title || onBack || subtitle || onClose;
 
+  const close = () => {
+    onClose?.();
+    try {
+      launchingElement?.focus();
+    } catch (e) {
+      console.log('Popover close error: ', e);
+    }
+  };
+
   useEffect(() => {
-    headingRef?.current?.focus();
-  });
+    setLaunchingElement(document.activeElement);
+    headingRef.current?.focus();
+  }, [setLaunchingElement]);
 
   const Header = () => (
     <Box
@@ -115,7 +126,7 @@ const Popover = ({
             iconName={ICON_NAMES.CLOSE}
             ariaLabel={t('close')}
             data-testid="popover-close"
-            onClick={onClose}
+            onClick={close}
             size={Size.SM}
           />
         ) : null}
@@ -127,9 +138,9 @@ const Popover = ({
   return (
     <div className="popover-container">
       {CustomBackground ? (
-        <CustomBackground onClose={onClose} />
+        <CustomBackground onClose={close} />
       ) : (
-        <div className="popover-bg" onClick={onClose} />
+        <div className="popover-bg" onClick={close} />
       )}
       <section
         className={classnames('popover-wrap', className)}


### PR DESCRIPTION
## Explanation

At present: the Popover launch doesn't move the tab position, so a user tabbing happens underneath the Popover.  With this PR, every time a Popover launches, the focus goes to the Popover title, allowing an sight-impaired user to know where they are and allow them to tab around the Popover.

## Screenshots/Screencaps

<!-- If you're making a change to the UI, make sure to capture a screenshot or a short video showing off your work! -->

### Before

<!-- How did the UI you changed look before your changes? Drag your file(s) below this line: -->

### After

<!-- How does it look now? Drag your file(s) below this line: -->

## Manual Testing Steps

<!--
How should reviewers and QA manually test your changes? For instance:

- Go to this screen
- Do this
- Then do this
-->

## Pre-merge author checklist

- [ ] I've clearly explained:
  - [ ] What problem this PR is solving
  - [ ] How this problem was solved
  - [ ] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
