### PR TITLE
updated keyringType in Multichain Account Menu and storybook

### DIFF
--- a/.storybook/test-data.js
+++ b/.storybook/test-data.js
@@ -1182,11 +1182,9 @@ const state = {
         ],
       },
       {
-        type: HardwareKeyringTypes.ledger,
-        accounts: [
-          '0x9d0ba4ddac06032527b140912ec808ab9451b788'
-        ],
-      }
+        type: KeyringType.ledger,
+        accounts: ['0x9d0ba4ddac06032527b140912ec808ab9451b788'],
+      },
     ],
     networkConfigurations: {
       'test-networkConfigurationId-1': {

--- a/ui/components/multichain/account-list-item/account-list-item.js
+++ b/ui/components/multichain/account-list-item/account-list-item.js
@@ -30,10 +30,8 @@ import {
   Size,
   BorderColor,
 } from '../../../helpers/constants/design-system';
-import {
-  HardwareKeyringTypes,
-  HardwareKeyringNames,
-} from '../../../../shared/constants/hardware-wallets';
+import { HardwareKeyringNames } from '../../../../shared/constants/hardware-wallets';
+import { KeyringType } from '../../../../shared/constants/keyring';
 import UserPreferencedCurrencyDisplay from '../../app/user-preferenced-currency-display/user-preferenced-currency-display.component';
 import { SECONDARY, PRIMARY } from '../../../helpers/constants/common';
 import { findKeyringForAddress } from '../../../ducks/metamask/metamask';
@@ -45,15 +43,15 @@ const MAXIMUM_CHARACTERS_WITHOUT_TOOLTIP = 17;
 function getLabel(keyring = {}, t) {
   const { type } = keyring;
   switch (type) {
-    case HardwareKeyringTypes.qr:
+    case KeyringType.qr:
       return HardwareKeyringNames.qr;
-    case HardwareKeyringTypes.imported:
+    case KeyringType.imported:
       return t('imported');
-    case HardwareKeyringTypes.trezor:
+    case KeyringType.trezor:
       return HardwareKeyringNames.trezor;
-    case HardwareKeyringTypes.ledger:
+    case KeyringType.ledger:
       return HardwareKeyringNames.ledger;
-    case HardwareKeyringTypes.lattice:
+    case KeyringType.lattice:
       return HardwareKeyringNames.lattice;
     default:
       return null;
@@ -212,7 +210,7 @@ export const AccountListItem = ({
             blockExplorerUrlSubTitle={blockExplorerUrlSubTitle}
             identity={identity}
             onClose={() => setAccountOptionsMenuOpen(false)}
-            isRemovable={keyring?.type !== HardwareKeyringTypes.hdKeyTree}
+            isRemovable={keyring?.type !== KeyringType.hdKeyTree}
             closeMenu={closeMenu}
           />
         ) : null}


### PR DESCRIPTION
Since, the storybook json was not updated to use the updated Keyring types, the current storybook build is broken in develop. This PR is to update the storybook test data and AccountListItem to use the updated [Keyring types](https://github.com/MetaMask/metamask-extension/pull/17490) and fix the current lint errors.

## Manual Testing Steps

<!--
How should reviewers and QA manually test your changes? For instance:

- Go to this screen
- Do this
- Then do this
-->

## Pre-merge author checklist

- [ ] I've clearly explained:
  - [ ] What problem this PR is solving
  - [ ] How this problem was solved
  - [ ] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.

