### PR TITLE
feat(custom-spending-cap): sets custom spending cap into dappProposed…

### DIFF
--- a/ui/pages/token-allowance/token-allowance.test.js
+++ b/ui/pages/token-allowance/token-allowance.test.js
@@ -206,6 +206,16 @@ describe('TokenAllowancePage', () => {
     expect(getByText('Function: Approve')).toBeInTheDocument();
   });
 
+  it('should set the default value of the spending cap to the dappProposed', () => {
+    const { getByTestId } = renderWithProvider(
+      <TokenAllowance {...props} />,
+      store,
+    );
+
+    const input = getByTestId('custom-spending-cap-input');
+    expect(input.value).toBe('1');
+  });
+
   it('should click Use default and set input value to default', () => {
     const { getByText, getByTestId } = renderWithProvider(
       <TokenAllowance {...props} />,


### PR DESCRIPTION
…Value when loaded

## Explanation

<!--
Thanks for the pull request. Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues, Slack conversations, Zendesk issues, user stories, etc. reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

What is the current state of things and why does it need to change? Since the last update to the Custom Spending (Approval) screen, users actually need to input the amount they want to allow a contract to spend for them, this seems like an unnecesary step when to submit an approval a dapp needs to submit a value for allowance.

It is understable that most dapps ask for infinite approval out of the gate, which is super detrimental for User Security as any hack could happen and drain most of the funds from the users wallet. A change that we could implement here if that the approval amount that is being required is infinite, show a warning and don't set the field value to infinite. But for specific amount of approvals it just seems like adding an extra step to a flow that might not make a lot of sense.

The solution proposed here just adds the amount that the dapp proposed to the input, this is up for discussion into how we want to handle that, but this should be a first approach at it. There's a case to be made also that if a dapp proposed value is not infinte to automatically move the user to the second step of the approval process to streamline submitting the transaction even smoother.

Another thing is that currently with the custom spending cap screen, the buttons need to be scrolled to be found, but this could be a separate issue of just ui styling

## Screenshots/Screencaps
<img width="336" alt="Screenshot 2023-03-22 at 18 29 23" src="https://user-images.githubusercontent.com/94012134/227043025-7764f6b3-076f-44d3-b025-83e42fc001c4.png">

<!-- If you're making a change to the UI, make sure to capture a screenshot or a short video showing off your work! -->

### Before
<img width="362" alt="Screenshot 2023-03-22 at 18 31 01" src="https://user-images.githubusercontent.com/94012134/227043230-63fd84d4-8acb-4641-a7d1-bf800bad7b5f.png">

<!-- How did the 
UI you changed look before your changes? Drag your file(s) below this line: -->

### After
<img width="336" alt="Screenshot 2023-03-22 at 18 29 23" src="https://user-images.githubusercontent.com/94012134/227043025-7764f6b3-076f-44d3-b025-83e42fc001c4.png">

<!-- How does it look now? Drag your file(s) below this line: -->

## Manual Testing Steps
Go to any approval screen and start the token approval process
<!--
How should reviewers and QA manually test your changes? For instance:

- Go to this screen
- Do this
- Then do this
-->

## Pre-merge author checklist

- [X] I've clearly explained:
  - [X] What problem this PR is solving
  - [X] How this problem was solved
  - [X] How reviewers can test my changes
- [X] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [X] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue -> There is currently no issue filled about this, could create one if its necessary
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
