### PR TITLE
[FLASK] Update iframe-execution-environment

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -748,7 +748,7 @@ export default class MetamaskController extends EventEmitter {
     ///: BEGIN:ONLY_INCLUDE_IN(flask)
     const snapExecutionServiceArgs = {
       iframeUrl: new URL(
-        'https://metamask.github.io/iframe-execution-environment/0.13.0',
+        'https://metamask.github.io/iframe-execution-environment/0.14.0',
       ),
       messenger: this.controllerMessenger.getRestricted({
         name: 'ExecutionService',


### PR DESCRIPTION
## Explanation

Updates the iframe-execution-environment to `0.14.0`. We forgot to bump this when we updated the snaps packages last time.