### PR TITLE
fix alarms.getAll() console errors

### DIFF
--- a/app/manifest/v2/_base.json
+++ b/app/manifest/v2/_base.json
@@ -60,5 +60,19 @@
   },
   "manifest_version": 2,
   "name": "__MSG_appName__",
+  "permissions": [
+    "storage",
+    "unlimitedStorage",
+    "clipboardWrite",
+    "http://localhost:8545/",
+    "https://*.infura.io/",
+    "https://*.codefi.network/",
+    "https://chainid.network/chains.json",
+    "https://lattice.gridplus.io/*",
+    "activeTab",
+    "webRequest",
+    "*://*.eth/",
+    "notifications"
+  ],
   "short_name": "__MSG_appName__"
 }

--- a/app/manifest/v2/chrome.json
+++ b/app/manifest/v2/chrome.json
@@ -4,19 +4,5 @@
     "matches": ["https://metamask.io/*"],
     "ids": ["*"]
   },
-  "minimum_chrome_version": "80",
-  "permissions": [
-    "storage",
-    "unlimitedStorage",
-    "clipboardWrite",
-    "http://localhost:8545/",
-    "https://*.infura.io/",
-    "https://*.codefi.network/",
-    "https://chainid.network/chains.json",
-    "https://lattice.gridplus.io/*",
-    "activeTab",
-    "webRequest",
-    "*://*.eth/",
-    "notifications"
-  ]
+  "minimum_chrome_version": "80"
 }

--- a/app/manifest/v2/firefox.json
+++ b/app/manifest/v2/firefox.json
@@ -5,19 +5,5 @@
       "strict_min_version": "78.0"
     }
   },
-  "permissions": [
-    "storage",
-    "unlimitedStorage",
-    "clipboardWrite",
-    "http://localhost:8545/",
-    "https://*.infura.io/",
-    "https://*.codefi.network/",
-    "https://chainid.network/chains.json",
-    "https://lattice.gridplus.io/*",
-    "activeTab",
-    "tabs",
-    "webRequest",
-    "*://*.eth/",
-    "notifications"
-  ]
+  "permissions": ["tabs"]
 }

--- a/app/manifest/v2/opera.json
+++ b/app/manifest/v2/opera.json
@@ -1,9 +1,3 @@
 {
-  "permissions": [
-    "storage",
-    "tabs",
-    "clipboardWrite",
-    "clipboardRead",
-    "http://localhost:8545/"
-  ]
+  "permissions": ["tabs", "clipboardRead"]
 }

--- a/app/manifest/v3/_base.json
+++ b/app/manifest/v3/_base.json
@@ -65,5 +65,13 @@
   },
   "manifest_version": 3,
   "name": "__MSG_appName__",
+  "permissions": [
+    "storage",
+    "unlimitedStorage",
+    "clipboardWrite",
+    "activeTab",
+    "webRequest",
+    "notifications"
+  ],
   "short_name": "__MSG_appName__"
 }

--- a/app/manifest/v3/_base.json
+++ b/app/manifest/v3/_base.json
@@ -66,12 +66,14 @@
   "manifest_version": 3,
   "name": "__MSG_appName__",
   "permissions": [
+    "activeTab",
+    "alarms",
+    "clipboardWrite",
+    "notifications",
+    "scripting",
     "storage",
     "unlimitedStorage",
-    "clipboardWrite",
-    "activeTab",
-    "webRequest",
-    "notifications"
+    "webRequest"
   ],
   "short_name": "__MSG_appName__"
 }

--- a/app/manifest/v3/chrome.json
+++ b/app/manifest/v3/chrome.json
@@ -8,6 +8,7 @@
   },
   "minimum_chrome_version": "80",
   "permissions": [
+    "alarms",
     "storage",
     "unlimitedStorage",
     "clipboardWrite",

--- a/app/manifest/v3/chrome.json
+++ b/app/manifest/v3/chrome.json
@@ -6,20 +6,5 @@
     "matches": ["https://metamask.io/*"],
     "ids": ["*"]
   },
-  "minimum_chrome_version": "80",
-  "permissions": [
-    "alarms",
-    "storage",
-    "unlimitedStorage",
-    "clipboardWrite",
-    "http://localhost:8545/",
-    "https://*.infura.io/",
-    "https://*.codefi.network/",
-    "https://chainid.network/chains.json",
-    "https://lattice.gridplus.io/*",
-    "activeTab",
-    "webRequest",
-    "*://*.eth/",
-    "notifications"
-  ]
+  "minimum_chrome_version": "80"
 }

--- a/app/manifest/v3/firefox.json
+++ b/app/manifest/v3/firefox.json
@@ -23,20 +23,5 @@
     "default_popup": "popup.html"
   },
   "manifest_version": 2,
-  "permissions": [
-    "alarms",
-    "storage",
-    "unlimitedStorage",
-    "clipboardWrite",
-    "http://localhost:8545/",
-    "https://*.infura.io/",
-    "https://*.codefi.network/",
-    "https://chainid.network/chains.json",
-    "https://lattice.gridplus.io/*",
-    "tabs",
-    "activeTab",
-    "webRequest",
-    "*://*.eth/",
-    "notifications"
-  ]
+  "permissions": ["tabs"]
 }

--- a/app/manifest/v3/firefox.json
+++ b/app/manifest/v3/firefox.json
@@ -24,6 +24,7 @@
   },
   "manifest_version": 2,
   "permissions": [
+    "alarms",
     "storage",
     "unlimitedStorage",
     "clipboardWrite",

--- a/app/manifest/v3/opera.json
+++ b/app/manifest/v3/opera.json
@@ -1,5 +1,6 @@
 {
   "permissions": [
+    "alarms",
     "storage",
     "tabs",
     "clipboardWrite",

--- a/app/manifest/v3/opera.json
+++ b/app/manifest/v3/opera.json
@@ -1,10 +1,3 @@
 {
-  "permissions": [
-    "alarms",
-    "storage",
-    "tabs",
-    "clipboardWrite",
-    "clipboardRead",
-    "http://localhost:8545/"
-  ]
+  "permissions": ["tabs", "clipboardRead"]
 }


### PR DESCRIPTION
## Explanation

Fixes this error in the console for mv3 builds

```
Uncaught (in promise) TypeError: Cannot read properties of undefined (reading 'getAll')
  at new MetaMetricsController (metametrics.js:179:21)
  at new MetamaskController (metamask-controller.js:396:34)
  at setupController (background.js:399:16)
  at initialize (background.js:251:5)
```