### PR TITLE
UX: Multichain: Improve accessibility of accounts menu

### DIFF
--- a/ui/components/multichain/account-list-item/__snapshots__/account-list-item.test.js.snap
+++ b/ui/components/multichain/account-list-item/__snapshots__/account-list-item.test.js.snap
@@ -60,11 +60,11 @@ exports[`AccountListItem renders AccountListItem component and shows account nam
           <div
             class="box mm-text mm-text--body-md mm-text--ellipsis box--flex-direction-row box--color-text-default"
           >
-            <a
-              href="#"
+            <button
+              class="box mm-text mm-button-base multichain-account-list-item__account-name mm-button-link mm-button-link--size-auto mm-text--body-md box--display-inline-flex box--flex-direction-row box--justify-content-center box--align-items-center box--color-primary-default box--background-color-transparent"
             >
               Test Account
-            </a>
+            </button>
           </div>
           <div
             class="box box--display-flex box--flex-direction-row box--align-items-center"

--- a/ui/components/multichain/account-list-item/__snapshots__/account-list-item.test.js.snap
+++ b/ui/components/multichain/account-list-item/__snapshots__/account-list-item.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`AccountListItem renders AccountListItem component and shows account name, address, and balance 1`] = `
 <div>
-  <button
+  <div
     class="box multichain-account-list-item box--padding-4 box--display-flex box--gap-2 box--flex-direction-row box--background-color-transparent"
   >
     <div
@@ -60,7 +60,11 @@ exports[`AccountListItem renders AccountListItem component and shows account nam
           <div
             class="box mm-text mm-text--body-md mm-text--ellipsis box--flex-direction-row box--color-text-default"
           >
-            Test Account
+            <a
+              href="#"
+            >
+              Test Account
+            </a>
           </div>
           <div
             class="box box--display-flex box--flex-direction-row box--align-items-center"
@@ -123,18 +127,17 @@ exports[`AccountListItem renders AccountListItem component and shows account nam
       </div>
     </div>
     <div>
-      <div
+      <button
         aria-label="Test Account Options"
         class="box mm-button-icon mm-button-icon--size-sm box--display-inline-flex box--flex-direction-row box--justify-content-center box--align-items-center box--color-icon-default box--background-color-transparent box--rounded-lg"
         data-testid="account-list-item-menu-button"
-        tabindex="0"
       >
         <span
           class="box mm-icon mm-icon--size-sm box--display-inline-block box--flex-direction-row box--color-inherit"
           style="mask-image: url('./images/icons/more-vertical.svg');"
         />
-      </div>
+      </button>
     </div>
-  </button>
+  </div>
 </div>
 `;

--- a/ui/components/multichain/account-list-item/__snapshots__/account-list-item.test.js.snap
+++ b/ui/components/multichain/account-list-item/__snapshots__/account-list-item.test.js.snap
@@ -61,9 +61,13 @@ exports[`AccountListItem renders AccountListItem component and shows account nam
             class="box mm-text mm-text--body-md mm-text--ellipsis box--flex-direction-row box--color-text-default"
           >
             <button
-              class="box mm-text mm-button-base multichain-account-list-item__account-name mm-button-link mm-button-link--size-auto mm-text--body-md box--display-inline-flex box--flex-direction-row box--justify-content-center box--align-items-center box--color-primary-default box--background-color-transparent"
+              class="box mm-text mm-button-base mm-button-base--ellipsis multichain-account-list-item__account-name mm-button-link mm-button-link--size-auto mm-text--body-md mm-text--ellipsis box--display-inline-flex box--flex-direction-row box--justify-content-center box--align-items-center box--color-text-default box--background-color-transparent"
             >
-              Test Account
+              <span
+                class="box mm-text mm-text--inherit mm-text--ellipsis box--flex-direction-row box--color-text-default"
+              >
+                Test Account
+              </span>
             </button>
           </div>
           <div

--- a/ui/components/multichain/account-list-item/account-list-item.js
+++ b/ui/components/multichain/account-list-item/account-list-item.js
@@ -87,9 +87,7 @@ export const AccountListItem = ({
       className={classnames('multichain-account-list-item', {
         'multichain-account-list-item--selected': selected,
       })}
-      as="button"
-      onClick={(e) => {
-        e.preventDefault();
+      onClick={() => {
         // Without this check, the account will be selected after
         // the account options menu closes
         if (!accountOptionsMenuOpen) {
@@ -127,10 +125,14 @@ export const AccountListItem = ({
                   position="bottom"
                   wrapperClassName="multichain-account-list-item__tooltip"
                 >
-                  {identity.name}
+                  <a href="#" onClick={onClick}>
+                    {identity.name}
+                  </a>
                 </Tooltip>
               ) : (
-                identity.name
+                <a href="#" onClick={onClick}>
+                  {identity.name}
+                </a>
               )}
             </Text>
             <Box
@@ -194,13 +196,6 @@ export const AccountListItem = ({
           onClick={(e) => {
             e.stopPropagation();
             setAccountOptionsMenuOpen(true);
-          }}
-          as="div"
-          tabIndex={0}
-          onKeyPress={(e) => {
-            if (e.key === 'Enter') {
-              setAccountOptionsMenuOpen(true);
-            }
           }}
           data-testid="account-list-item-menu-button"
         />

--- a/ui/components/multichain/account-list-item/account-list-item.js
+++ b/ui/components/multichain/account-list-item/account-list-item.js
@@ -120,27 +120,24 @@ export const AccountListItem = ({
             gap={2}
           >
             <Text ellipsis as="div">
-              {identity.name.length > MAXIMUM_CHARACTERS_WITHOUT_TOOLTIP ? (
-                <Tooltip
-                  title={identity.name}
-                  position="bottom"
-                  wrapperClassName="multichain-account-list-item__tooltip"
-                >
-                  <ButtonLink
-                    onClick={onClick}
-                    className="multichain-account-list-item__account-name"
+              <ButtonLink
+                onClick={onClick}
+                className="multichain-account-list-item__account-name"
+                color={Color.textDefault}
+                ellipsis
+              >
+                {identity.name.length > MAXIMUM_CHARACTERS_WITHOUT_TOOLTIP ? (
+                  <Tooltip
+                    title={identity.name}
+                    position="bottom"
+                    wrapperClassName="multichain-account-list-item__tooltip"
                   >
                     {identity.name}
-                  </ButtonLink>
-                </Tooltip>
-              ) : (
-                <ButtonLink
-                  onClick={onClick}
-                  className="multichain-account-list-item__account-name"
-                >
-                  {identity.name}
-                </ButtonLink>
-              )}
+                  </Tooltip>
+                ) : (
+                  identity.name
+                )}
+              </ButtonLink>
             </Text>
             <Box
               display={DISPLAY.FLEX}

--- a/ui/components/multichain/account-list-item/account-list-item.js
+++ b/ui/components/multichain/account-list-item/account-list-item.js
@@ -17,6 +17,7 @@ import {
   ICON_SIZES,
   AvatarFavicon,
   Tag,
+  ButtonLink,
 } from '../../component-library';
 import {
   Color,
@@ -125,14 +126,20 @@ export const AccountListItem = ({
                   position="bottom"
                   wrapperClassName="multichain-account-list-item__tooltip"
                 >
-                  <a href="#" onClick={onClick}>
+                  <ButtonLink
+                    onClick={onClick}
+                    className="multichain-account-list-item__account-name"
+                  >
                     {identity.name}
-                  </a>
+                  </ButtonLink>
                 </Tooltip>
               ) : (
-                <a href="#" onClick={onClick}>
+                <ButtonLink
+                  onClick={onClick}
+                  className="multichain-account-list-item__account-name"
+                >
                   {identity.name}
-                </a>
+                </ButtonLink>
               )}
             </Text>
             <Box

--- a/ui/components/multichain/account-list-item/index.scss
+++ b/ui/components/multichain/account-list-item/index.scss
@@ -11,8 +11,6 @@
   }
 
   &__account-name {
-    color: inherit;
-
     &:hover,
     &:focus {
       opacity: 1;

--- a/ui/components/multichain/account-list-item/index.scss
+++ b/ui/components/multichain/account-list-item/index.scss
@@ -1,12 +1,18 @@
 .multichain-account-list-item {
   position: relative;
   width: 100%;
+  cursor: pointer;
 
   &:not(.account-list-item--selected) {
     &:hover,
     &:focus-within {
       background: var(--color-background-default-hover);
     }
+  }
+
+  a:hover,
+  a:focus {
+    color: inherit;
   }
 
   &__selected-indicator {

--- a/ui/components/multichain/account-list-item/index.scss
+++ b/ui/components/multichain/account-list-item/index.scss
@@ -10,9 +10,13 @@
     }
   }
 
-  a:hover,
-  a:focus {
+  &__account-name {
     color: inherit;
+
+    &:hover,
+    &:focus {
+      opacity: 1;
+    }
   }
 
   &__selected-indicator {


### PR DESCRIPTION
## Explanation

The original implementation of the `AccountListItem` was kinda hacky; it was an `<a>` that contains a `[button as span]` and was kinda weird.  After speaking with @georgewrmarshall and looking at what GitHub does, I think this solution is much nicer.

## Screenshots/Screencaps

The account menu items look exactly the same; instead, when tabbing, you'll stop on just the account name instead of the whole block.

## Pre-merge author checklist

- [ ] I've clearly explained:
  - [ ] What problem this PR is solving
  - [ ] How this problem was solved
  - [ ] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
