### PR TITLE
Fix missing transaction notifications

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -826,10 +826,12 @@ export default class MetamaskController extends EventEmitter {
 
           const originMetadata = subjectMetadataState.subjectMetadata[origin];
 
-          this.platform._showNotification(
-            originMetadata?.name ?? origin,
-            message,
-          );
+          this.platform
+            ._showNotification(originMetadata?.name ?? origin, message)
+            .catch((error) => {
+              log.error('Failed to create notification', error);
+            });
+
           return null;
         },
         showInAppNotification: (origin, message) => {

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -969,7 +969,12 @@ export default class MetamaskController extends EventEmitter {
           );
           rpcPrefs = matchingNetworkConfig?.rpcPrefs ?? {};
         }
-        this.platform.showTransactionNotification(txMeta, rpcPrefs);
+
+        try {
+          await this.platform.showTransactionNotification(txMeta, rpcPrefs);
+        } catch (error) {
+          log.error('Failed to create transaction notification', error);
+        }
 
         const { txReceipt } = txMeta;
 

--- a/app/scripts/platforms/extension.js
+++ b/app/scripts/platforms/extension.js
@@ -2,7 +2,6 @@ import browser from 'webextension-polyfill';
 
 import { getBlockExplorerLink } from '@metamask/etherscan-link';
 import { startCase, toLower } from 'lodash';
-import log from 'loglevel';
 import { getEnvironmentType } from '../lib/util';
 import { ENVIRONMENT_TYPE_BACKGROUND } from '../../../shared/constants/app';
 import { TransactionStatus } from '../../../shared/constants/transaction';
@@ -191,21 +190,12 @@ export default class ExtensionPlatform {
   async _showNotification(title, message, url) {
     const iconUrl = await browser.runtime.getURL('../../images/icon-64.png');
 
-    try {
-      await browser.notifications.create(url, {
-        type: 'basic',
-        title,
-        iconUrl,
-        message,
-      });
-    } catch (error) {
-      log.debug('Failed to create notification', {
-        title,
-        message,
-        url,
-        error,
-      });
-    }
+    await browser.notifications.create(url, {
+      type: 'basic',
+      title,
+      iconUrl,
+      message,
+    });
   }
 
   _subscribeToNotificationClicked() {

--- a/app/scripts/platforms/extension.js
+++ b/app/scripts/platforms/extension.js
@@ -113,19 +113,19 @@ export default class ExtensionPlatform {
     }
   }
 
-  showTransactionNotification(txMeta, rpcPrefs) {
+  async showTransactionNotification(txMeta, rpcPrefs) {
     const { status, txReceipt: { status: receiptStatus } = {} } = txMeta;
 
     if (status === TransactionStatus.confirmed) {
       // There was an on-chain failure
       receiptStatus === '0x0'
-        ? this._showFailedTransaction(
+        ? await this._showFailedTransaction(
             txMeta,
             'Transaction encountered an error.',
           )
-        : this._showConfirmedTransaction(txMeta, rpcPrefs);
+        : await this._showConfirmedTransaction(txMeta, rpcPrefs);
     } else if (status === TransactionStatus.failed) {
-      this._showFailedTransaction(txMeta);
+      await this._showFailedTransaction(txMeta);
     }
   }
 
@@ -157,7 +157,7 @@ export default class ExtensionPlatform {
     await browser.tabs.remove(tabId);
   }
 
-  _showConfirmedTransaction(txMeta, rpcPrefs) {
+  async _showConfirmedTransaction(txMeta, rpcPrefs) {
     this._subscribeToNotificationClicked();
 
     const url = getBlockExplorerLink(txMeta, rpcPrefs);
@@ -170,10 +170,10 @@ export default class ExtensionPlatform {
     const message = `Transaction ${nonce} confirmed! ${
       url.length ? `View on ${view}` : ''
     }`;
-    this._showNotification(title, message, url);
+    await this._showNotification(title, message, url);
   }
 
-  _showFailedTransaction(txMeta, errorMessage) {
+  async _showFailedTransaction(txMeta, errorMessage) {
     const nonce = parseInt(txMeta.txParams.nonce, 16);
     const title = 'Failed transaction';
     let message = `Transaction ${nonce} failed! ${
@@ -184,7 +184,7 @@ export default class ExtensionPlatform {
       message = `Transaction failed! ${errorMessage || txMeta.err.message}`;
     }
     ///: END:ONLY_INCLUDE_IN
-    this._showNotification(title, message);
+    await this._showNotification(title, message);
   }
 
   async _showNotification(title, message, url) {

--- a/app/scripts/platforms/extension.js
+++ b/app/scripts/platforms/extension.js
@@ -2,6 +2,7 @@ import browser from 'webextension-polyfill';
 
 import { getBlockExplorerLink } from '@metamask/etherscan-link';
 import { startCase, toLower } from 'lodash';
+import log from 'loglevel';
 import { getEnvironmentType } from '../lib/util';
 import { ENVIRONMENT_TYPE_BACKGROUND } from '../../../shared/constants/app';
 import { TransactionStatus } from '../../../shared/constants/transaction';
@@ -189,12 +190,22 @@ export default class ExtensionPlatform {
 
   async _showNotification(title, message, url) {
     const iconUrl = await browser.runtime.getURL('../../images/icon-64.png');
-    browser.notifications.create(url, {
-      type: 'basic',
-      title,
-      iconUrl,
-      message,
-    });
+
+    try {
+      await browser.notifications.create(url, {
+        type: 'basic',
+        title,
+        iconUrl,
+        message,
+      });
+    } catch (error) {
+      log.debug('Failed to create notification', {
+        title,
+        message,
+        url,
+        error,
+      });
+    }
   }
 
   _subscribeToNotificationClicked() {

--- a/development/build/index.js
+++ b/development/build/index.js
@@ -102,6 +102,7 @@ async function defineAndRunBuildTasks() {
       'navigator',
       'harden',
       'console',
+      'Image', // Used by browser to generate notifications
       // globals chrome driver needs to function (test env)
       /cdc_[a-zA-Z0-9]+_[a-zA-Z]+/iu,
       'performance',


### PR DESCRIPTION
## Explanation

Resolves issue causing transaction notifications to fail due to LavaMoat scuttling.

Also updates the notification code to not fail silently in future.

* Fixes #18235

## Manual Testing Steps

Perform transaction and verify resulting notification.

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
