### PR TITLE
Add scripting permission

### DIFF
--- a/app/manifest/v3/chrome.json
+++ b/app/manifest/v3/chrome.json
@@ -8,6 +8,7 @@
   },
   "minimum_chrome_version": "80",
   "permissions": [
+    "scripting",
     "storage",
     "unlimitedStorage",
     "clipboardWrite",

--- a/app/manifest/v3/firefox.json
+++ b/app/manifest/v3/firefox.json
@@ -24,6 +24,7 @@
   },
   "manifest_version": 2,
   "permissions": [
+    "scripting",
     "storage",
     "unlimitedStorage",
     "clipboardWrite",

--- a/app/manifest/v3/opera.json
+++ b/app/manifest/v3/opera.json
@@ -1,5 +1,6 @@
 {
   "permissions": [
+    "scripting",
     "storage",
     "tabs",
     "clipboardWrite",


### PR DESCRIPTION
Adds `scripting` permission for mv3 manifest.
Used in https://github.com/MetaMask/metamask-extension/blob/develop/app/scripts/app-init.js#L141
Ref: https://developer.chrome.com/docs/extensions/reference/scripting/

Partially requires the `alarms` permission to be added, https://github.com/MetaMask/metamask-extension/pull/18306.