### PR TITLE
UX: Replace all "fa-info" instances with Info icon 

### DIFF
--- a/ui/components/app/advanced-gas-inputs/advanced-gas-inputs.component.js
+++ b/ui/components/app/advanced-gas-inputs/advanced-gas-inputs.component.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { debounce } from 'lodash';
 import Tooltip from '../../ui/tooltip';
+import { Icon, ICON_NAMES } from '../../component-library';
 
 export default class AdvancedGasInputs extends Component {
   static contextTypes = {
@@ -140,7 +141,7 @@ export default class AdvancedGasInputs extends Component {
         <div className="advanced-gas-inputs__gas-edit-row__label">
           {label}
           <Tooltip title={tooltipTitle} position="top" arrow>
-            <i className="fa fa-info-circle" />
+            <Icon name={ICON_NAMES.INFO} />
           </Tooltip>
         </div>
         <div className="advanced-gas-inputs__gas-edit-row__input-wrapper">

--- a/ui/components/app/alerts/unconnected-account-alert/unconnected-account-alert.js
+++ b/ui/components/app/alerts/unconnected-account-alert/unconnected-account-alert.js
@@ -22,6 +22,7 @@ import Checkbox from '../../../ui/check-box';
 import Tooltip from '../../../ui/tooltip';
 import ConnectedAccountsList from '../../connected-accounts-list';
 import { useI18nContext } from '../../../../hooks/useI18nContext';
+import { Icon, ICON_NAMES } from '../../../component-library';
 
 const { ERROR, LOADING } = ALERT_STATE;
 
@@ -68,7 +69,7 @@ const UnconnectedAccountAlert = () => {
               title={t('alertDisableTooltip')}
               wrapperClassName="unconnected-account-alert__checkbox-label-tooltip"
             >
-              <i className="fa fa-info-circle" />
+              <Icon name={ICON_NAMES.INFO} />
             </Tooltip>
           </label>
         </div>

--- a/ui/components/app/confirm-page-container/confirm-page-container-content/confirm-page-container-warning/confirm-page-container-warning.component.js
+++ b/ui/components/app/confirm-page-container/confirm-page-container-content/confirm-page-container-warning/confirm-page-container-warning.component.js
@@ -1,10 +1,14 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { Icon, ICON_NAMES } from '../../../../component-library';
 
 const ConfirmPageContainerWarning = (props) => {
   return (
     <div className="confirm-page-container-warning">
-      <i className="fa fa-info-circle confirm-page-container-warning__icon" />
+      <Icon
+        name={ICON_NAMES.INFO}
+        className="confirm-page-container-warning__icon"
+      />
       <div className="confirm-page-container-warning__warning">
         {props.warning}
       </div>

--- a/ui/components/app/home-notification/home-notification.component.js
+++ b/ui/components/app/home-notification/home-notification.component.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import Button from '../../ui/button';
 import Checkbox from '../../ui/check-box';
 import Tooltip from '../../ui/tooltip';
+import { Icon, ICON_NAMES } from '../../component-library';
 
 const HomeNotification = ({
   acceptText,
@@ -39,7 +40,7 @@ const HomeNotification = ({
             title={infoText}
             wrapperClassName="home-notification__tooltip-wrapper"
           >
-            <i className="fa fa-info-circle" />
+            <Icon name={ICON_NAMES.INFO} />
           </Tooltip>
         ) : null}
       </div>

--- a/ui/components/app/nfts-detection-notice/nfts-detection-notice.js
+++ b/ui/components/app/nfts-detection-notice/nfts-detection-notice.js
@@ -14,6 +14,8 @@ import { useI18nContext } from '../../../hooks/useI18nContext';
 import Button from '../../ui/button';
 import { EXPERIMENTAL_ROUTE } from '../../../helpers/constants/routes';
 
+import { Icon, ICON_NAMES } from '../../component-library';
+
 export default function NftsDetectionNotice() {
   const t = useI18nContext();
   const history = useHistory();
@@ -23,12 +25,12 @@ export default function NftsDetectionNotice() {
       <Dialog type="message" className="nfts-detection-notice__message">
         <Box display={DISPLAY.FLEX}>
           <Box paddingTop={1}>
-            <i
+            <Icon
               style={{
                 fontSize: '1rem',
                 color: 'var(--color-primary-default)',
               }}
-              className="fa fa-info-circle"
+              name={ICON_NAMES.INFO}
             />
           </Box>
           <Box paddingLeft={2}>

--- a/ui/components/app/tab-bar/tab-bar.stories.js
+++ b/ui/components/app/tab-bar/tab-bar.stories.js
@@ -54,7 +54,7 @@ export default {
         key: 'experimental',
       },
       {
-        icon: <i className="fa fa-info-circle" />,
+        icon: <Icon name={ICON_NAMES.INFO} />,
         content: 'About',
         key: 'about',
       },

--- a/ui/components/app/transaction-decoding/components/ui/accreditation/accreditation.component.js
+++ b/ui/components/app/transaction-decoding/components/ui/accreditation/accreditation.component.js
@@ -12,6 +12,7 @@ import { TypographyVariant } from '../../../../../../helpers/constants/design-sy
 
 import Button from '../../../../../ui/button';
 import Typography from '../../../../../ui/typography';
+import { Icon, ICON_NAMES } from '../../../../../component-library';
 
 const Accreditation = ({ fetchVia, address }) => {
   const t = useContext(I18nContext);
@@ -55,7 +56,7 @@ const Accreditation = ({ fetchVia, address }) => {
   return (
     <div className="accreditation">
       <div className="accreditation__icon">
-        <i className="fa fa-info-circle" />
+        <Icon name={ICON_NAMES.INFO} />
       </div>
       <div className="accreditation__info">
         <AccreditationLink />

--- a/ui/components/app/transaction-detail-item/transaction-detail-item.stories.js
+++ b/ui/components/app/transaction-detail-item/transaction-detail-item.stories.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import InfoTooltip from '../../ui/info-tooltip/info-tooltip';
-
+import { Icon, ICON_NAMES } from '../../component-library';
 import { TextColor } from '../../../helpers/constants/design-system';
 
 import README from './README.mdx';
@@ -45,7 +45,7 @@ DefaultStory.args = {
     <>
       <strong>Estimated gas fee</strong>
       <InfoTooltip contentText="This is the tooltip text" position="top">
-        <i className="fa fa-info-circle" />
+        <Icon name={ICON_NAMES.INFO} />
       </InfoTooltip>
     </>
   ),

--- a/ui/components/app/transaction-detail/transaction-detail.stories.js
+++ b/ui/components/app/transaction-detail/transaction-detail.stories.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Icon, ICON_NAMES } from '../../component-library';
 import InfoTooltip from '../../ui/info-tooltip/info-tooltip';
 import TransactionDetailItem from '../transaction-detail-item/transaction-detail-item.component';
 import GasTiming from '../gas-timing/gas-timing.component';
@@ -27,7 +28,7 @@ const rows = [
       <>
         Estimated gas fee
         <InfoTooltip contentText="This is the tooltip text" position="top">
-          <i className="fa fa-info-circle" />
+          <Icon name={ICON_NAMES.INFO} />
         </InfoTooltip>
       </>
     }

--- a/ui/components/ui/account-list/account-list.js
+++ b/ui/components/ui/account-list/account-list.js
@@ -8,6 +8,7 @@ import Identicon from '../identicon';
 import UserPreferencedCurrencyDisplay from '../../app/user-preferenced-currency-display';
 import { PRIMARY } from '../../../helpers/constants/common';
 import Tooltip from '../tooltip';
+import { Icon, ICON_NAMES } from '../../component-library';
 
 const AccountList = ({
   selectNewAccountViaModal,
@@ -61,7 +62,7 @@ const AccountList = ({
                 </div>
               }
             >
-              <i className="fa fa-info-circle" />
+              <Icon name={ICON_NAMES.INFO} />
             </Tooltip>
           </div>
         ) : null}
@@ -114,7 +115,7 @@ const AccountList = ({
                       addressLastConnectedMap[address]
                     }`}
                   >
-                    <i className="fa fa-info-circle" />
+                    <Icon name={ICON_NAMES.INFO} />
                   </Tooltip>
                 ) : null}
               </div>

--- a/ui/components/ui/definition-list/definition-list.js
+++ b/ui/components/ui/definition-list/definition-list.js
@@ -10,6 +10,7 @@ import {
   TextColor,
 } from '../../../helpers/constants/design-system';
 import Tooltip from '../tooltip';
+import { Icon, ICON_NAMES } from '../../component-library';
 
 const MARGIN_MAP = {
   [Size.XS]: 0,
@@ -48,7 +49,7 @@ export default function DefinitionList({
                 position="top"
                 containerClassName="definition-list__tooltip-wrapper"
               >
-                <i className="fas fa-info-circle" />
+                <Icon name={ICON_NAMES.INFO} />
               </Tooltip>
             )}
           </Typography>

--- a/ui/components/ui/deprecated-test-networks/deprecated-test-networks.js
+++ b/ui/components/ui/deprecated-test-networks/deprecated-test-networks.js
@@ -13,6 +13,7 @@ import Typography from '../typography/typography';
 import ActionableMessage from '../actionable-message/actionable-message';
 import { getCurrentChainId } from '../../../selectors';
 import { getCompletedOnboarding } from '../../../ducks/metamask/metamask';
+import { Icon, ICON_NAMES } from '../../component-library';
 
 export default function DeprecatedTestNetworks() {
   const currentChainID = useSelector(getCurrentChainId);
@@ -45,7 +46,10 @@ export default function DeprecatedTestNetworks() {
             className="deprecated-test-networks__content"
           >
             <Box marginRight={2} color={Color.warningDefault}>
-              <i className="fa fa-info-circle deprecated-test-networks__content__icon" />
+              <Icon
+                name={ICON_NAMES.INFO}
+                className="deprecated-test-networks__content__icon"
+              />
             </Box>
             <Box justifyContent={JustifyContent.spaceBetween}>
               <Typography

--- a/ui/components/ui/tooltip/tooltip.stories.js
+++ b/ui/components/ui/tooltip/tooltip.stories.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Icon, ICON_NAMES, ICON_SIZES } from '../../component-library';
 import Box from '../box/box';
 import Typography from '../typography/typography';
 import Tooltip from '.';
@@ -60,8 +61,9 @@ export const DefaultStory = (args) => (
   <Box display="flex">
     <Typography>Hover over the info icon to see the tooltip</Typography>
     <Tooltip {...args}>
-      <i
-        className="fa fa-sm fa-info-circle"
+      <Icon
+        name={ICON_NAMES.INFO}
+        size={ICON_SIZES.SM}
         style={{ color: 'var(--color-icon-alternative)' }}
       />
     </Tooltip>
@@ -70,17 +72,20 @@ export const DefaultStory = (args) => (
 
 DefaultStory.storyName = 'Default';
 
-export const HTML = (args) => (
-  <Box display="flex">
-    <Typography>This tooltips content is html</Typography>
-    <Tooltip {...args}>
-      <i
-        className="fa fa-sm fa-info-circle"
-        style={{ color: 'var(--color-icon-alternative)' }}
-      />
-    </Tooltip>
-  </Box>
-);
+export const HTML = (args) => {
+  return (
+    <Box display="flex">
+      <Typography>This tooltips content is html</Typography>
+      <Tooltip {...args}>
+        <Icon
+          name={ICON_NAMES.INFO}
+          size={ICON_SIZES.SM}
+          style={{ color: 'var(--color-icon-alternative)' }}
+        />
+      </Tooltip>
+    </Box>
+  );
+};
 
 HTML.args = {
   interactive: true,

--- a/ui/helpers/constants/settings.js
+++ b/ui/helpers/constants/settings.js
@@ -266,28 +266,28 @@ export const SETTINGS_CONSTANTS = [
     sectionMessage: (t) => t('metamaskVersion'),
     descriptionMessage: (t) => t('builtAroundTheWorld'),
     route: `${ABOUT_US_ROUTE}#version`,
-    icon: 'fa fa-info-circle',
+    iconName: ICON_NAMES.INFO,
   },
   {
     tabMessage: (t) => t('about'),
     sectionMessage: (t) => t('links'),
     descriptionMessage: (t) => t('links'),
     route: `${ABOUT_US_ROUTE}#links`,
-    icon: 'fa fa-info-circle',
+    iconName: ICON_NAMES.INFO,
   },
   {
     tabMessage: (t) => t('about'),
     sectionMessage: (t) => t('privacyMsg'),
     descriptionMessage: (t) => t('privacyMsg'),
     route: `${ABOUT_US_ROUTE}#privacy-policy`,
-    icon: 'fa fa-info-circle',
+    iconName: ICON_NAMES.INFO,
   },
   {
     tabMessage: (t) => t('about'),
     sectionMessage: (t) => t('terms'),
     descriptionMessage: (t) => t('terms'),
     route: `${ABOUT_US_ROUTE}#terms`,
-    icon: 'fa fa-info-circle',
+    iconName: ICON_NAMES.INFO,
   },
 
   {
@@ -295,7 +295,7 @@ export const SETTINGS_CONSTANTS = [
     sectionMessage: (t) => t('attributions'),
     descriptionMessage: (t) => t('attributions'),
     route: `${ABOUT_US_ROUTE}#attributions`,
-    icon: 'fa fa-info-circle',
+    iconName: ICON_NAMES.INFO,
   },
 
   {
@@ -303,7 +303,7 @@ export const SETTINGS_CONSTANTS = [
     sectionMessage: (t) => t('supportCenter'),
     descriptionMessage: (t) => t('supportCenter'),
     route: `${ABOUT_US_ROUTE}#supportcenter`,
-    icon: 'fa fa-info-circle',
+    iconName: ICON_NAMES.INFO,
   },
 
   {
@@ -311,7 +311,7 @@ export const SETTINGS_CONSTANTS = [
     sectionMessage: (t) => t('visitWebSite'),
     descriptionMessage: (t) => t('visitWebSite'),
     route: `${ABOUT_US_ROUTE}#visitwebsite`,
-    icon: 'fa fa-info-circle',
+    iconName: ICON_NAMES.INFO,
   },
 
   {
@@ -319,14 +319,14 @@ export const SETTINGS_CONSTANTS = [
     sectionMessage: (t) => t('contactUs'),
     descriptionMessage: (t) => t('contactUs'),
     route: `${ABOUT_US_ROUTE}#contactus`,
-    icon: 'fa fa-info-circle',
+    iconName: ICON_NAMES.INFO,
   },
   {
     tabMessage: (t) => t('about'),
     sectionMessage: (t) => t('betaTerms'),
     descriptionMessage: (t) => t('betaTerms'),
     route: `${ABOUT_US_ROUTE}#beta-terms`,
-    icon: 'fa fa-info-circle',
+    iconName: ICON_NAMES.INFO,
   },
   {
     tabMessage: (t) => t('experimental'),

--- a/ui/pages/confirm-transaction-base/confirm-transaction-base.component.js
+++ b/ui/pages/confirm-transaction-base/confirm-transaction-base.component.js
@@ -60,6 +60,7 @@ import { ConfirmHexData } from '../../components/app/confirm-hexdata';
 import { ConfirmData } from '../../components/app/confirm-data';
 import { ConfirmTitle } from '../../components/app/confirm-title';
 import { ConfirmSubTitle } from '../../components/app/confirm-subtitle';
+import { Icon, ICON_NAMES } from '../../components/component-library';
 
 const renderHeartBeatIfNotInTest = () =>
   process.env.IN_TEST ? null : <LoadingHeartBeat />;
@@ -456,7 +457,7 @@ export default class ConfirmTransactionBase extends Component {
                   contentText={t('transactionDetailDappGasTooltip')}
                   position="top"
                 >
-                  <i className="fa fa-info-circle" />
+                  <Icon name={ICON_NAMES.INFO} />
                 </InfoTooltip>
               </>
             ) : (
@@ -484,7 +485,7 @@ export default class ConfirmTransactionBase extends Component {
                   }
                   position="top"
                 >
-                  <i className="fa fa-info-circle" />
+                  <Icon name={ICON_NAMES.INFO} />
                 </InfoTooltip>
               </>
             )

--- a/ui/pages/confirmation/templates/add-ethereum-chain.js
+++ b/ui/pages/confirmation/templates/add-ethereum-chain.js
@@ -15,6 +15,7 @@ import { DEFAULT_ROUTE } from '../../../helpers/constants/routes';
 import ZENDESK_URLS from '../../../helpers/constants/zendesk-url';
 import fetchWithCache from '../../../../shared/lib/fetch-with-cache';
 import { jsonRpcRequest } from '../../../../shared/modules/rpc.utils';
+import { ICON_NAMES } from '../../../components/component-library';
 
 const UNRECOGNIZED_CHAIN = {
   id: 'UNRECOGNIZED_CHAIN',
@@ -280,10 +281,9 @@ function getValues(pendingApproval, t, actions, history) {
                 },
                 children: [
                   {
-                    element: 'i',
-                    key: 'info-circle',
+                    element: 'Icon',
                     props: {
-                      className: 'fas fa-info-circle',
+                      name: ICON_NAMES.INFO,
                       style: {
                         marginLeft: '4px',
                         color: 'var(--color-icon-default)',

--- a/ui/pages/settings/alerts-tab/alerts-tab.js
+++ b/ui/pages/settings/alerts-tab/alerts-tab.js
@@ -9,6 +9,7 @@ import { setAlertEnabledness } from '../../../store/actions';
 import { getAlertEnabledness } from '../../../ducks/metamask/metamask';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import { handleSettingsRefs } from '../../../helpers/utils/settings-search';
+import { Icon, ICON_NAMES } from '../../../components/component-library';
 
 const AlertSettingsEntry = ({ alertId, description, title }) => {
   const t = useI18nContext();
@@ -30,7 +31,10 @@ const AlertSettingsEntry = ({ alertId, description, title }) => {
             title={description}
             wrapperClassName="alerts-tab__description"
           >
-            <i className="fa fa-info-circle alerts-tab__description__icon" />
+            <Icon
+              name={ICON_NAMES.INFO}
+              className="alerts-tab__description__icon"
+            />
           </Tooltip>
           <ToggleButton
             offLabel={t('off')}

--- a/ui/pages/settings/settings.component.js
+++ b/ui/pages/settings/settings.component.js
@@ -307,7 +307,7 @@ class SettingsPage extends PureComponent {
       },
       {
         content: t('about'),
-        icon: <i className="fa fa-info-circle" />,
+        icon: <Icon name={ICON_NAMES.INFO} />,
         key: ABOUT_US_ROUTE,
       },
     ];

--- a/ui/pages/swaps/view-quote/view-quote-price-difference.js
+++ b/ui/pages/swaps/view-quote/view-quote-price-difference.js
@@ -12,6 +12,7 @@ import {
   DISPLAY,
 } from '../../../helpers/constants/design-system';
 import { GasRecommendations } from '../../../../shared/constants/gas';
+import { Icon, ICON_NAMES } from '../../../components/component-library';
 
 export default function ViewQuotePriceDifference(props) {
   const {
@@ -74,7 +75,7 @@ export default function ViewQuotePriceDifference(props) {
                   {priceDifferenceTitle}
                 </div>
                 <Tooltip position="bottom" title={t('swapPriceImpactTooltip')}>
-                  <i className="fa fa-info-circle" />
+                  <Icon name={ICON_NAMES.INFO} />
                 </Tooltip>
               </Box>
               {priceDifferenceMessage}


### PR DESCRIPTION
## Explanation

Replaces instances of `<i className="fa-info">` tags with `<Icon name={ICON_NAMES>INFO}  />`  components instead of the current <i className="fa-info"> tags. This PR addresses issue #17475

<!--
Thanks for the pull request. Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues, Slack conversations, Zendesk issues, user stories, etc. reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

## Screenshots/Screencaps

<!-- If you're making a change to the UI, make sure to capture a screenshot or a short video showing off your work! -->

### Before

<!-- How did the UI you changed look before your changes? Drag your file(s) below this line: -->

### After

<!-- How does it look now? Drag your file(s) below this line: -->

## Manual Testing Steps

<!--
How should reviewers and QA manually test your changes? For instance:

- Go to this screen
- Do this
- Then do this
-->

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [ ] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [x] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [x] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
