### PR TITLE
Don't include document in scuttling config for mv3 builds

### DIFF
--- a/development/build/config.js
+++ b/development/build/config.js
@@ -20,6 +20,7 @@ const configurationPropertyNames = [
   'DISABLE_WEB_SOCKET_ENCRYPTION',
   'METAMASK_DEBUG',
   'SKIP_OTP_PAIRING_FLOW',
+  'ENABLE_MV3',
 ];
 
 const productionConfigurationPropertyNames = [

--- a/development/build/scripts.js
+++ b/development/build/scripts.js
@@ -997,7 +997,7 @@ function setupMinification(buildConfiguration) {
 }
 
 function setupScuttlingWrapping(buildConfiguration, applyLavaMoat, envVars) {
-  const scuttlingConfig = envVars.ENABLE_MV3
+  const scuttlingConfig = envVars.ENABLE_MV3 === 'true'
     ? mv3ScuttlingConfig
     : standardScuttlingConfig;
   const { events } = buildConfiguration;

--- a/development/build/scripts.js
+++ b/development/build/scripts.js
@@ -997,9 +997,10 @@ function setupMinification(buildConfiguration) {
 }
 
 function setupScuttlingWrapping(buildConfiguration, applyLavaMoat, envVars) {
-  const scuttlingConfig = envVars.ENABLE_MV3 === 'true'
-    ? mv3ScuttlingConfig
-    : standardScuttlingConfig;
+  const scuttlingConfig =
+    envVars.ENABLE_MV3 === 'true'
+      ? mv3ScuttlingConfig
+      : standardScuttlingConfig;
   const { events } = buildConfiguration;
   events.on('configurePipeline', ({ pipeline }) => {
     pipeline.get('scuttle').push(


### PR DESCRIPTION
Fixes https://github.com/MetaMask/metamask-extension/issues/18348

Scuttling replaces `global` with a proxy, and includes the `document` property on that proxy, but `global.document` is undefined within the mv3 service worker. This leads to a bug in this code:

```
if (!('document' in global)) {
        return;
    }

var triggerDOMHandler = triggerHandlers.bind(null, 'dom');
var globalDOMEventHandler = makeDOMEventHandler(triggerDOMHandler, true);
global.document.addEventListener('click', globalDOMEventHandler, false);
```
from `node_modules/@sentry/utils/esm/instrument.js`

Because `'document' in global` is `true` (when global is proxied as we do via the `wrapAgainstScuttling` function in `metamask-extension/development/build/utils.js`), but `global.document` is `undefined`

To solve this problem, this PR changes the build script so that the `document` property is not included in the config of the proxy.

To test this:

1. Checkout this PRs branch
2. run `yarn && ENABLE_MV3=true yarn build --build-type beta dist`
3. Install the build from `metamask-extension/builds/chrome`
4. Open this metamask installation, you should be able to successfully onboard and use MetaMask
