### PR TITLE
Fix aria label error on the console

### DIFF
--- a/ui/components/app/account-menu/__snapshots__/account-menu.test.js.snap
+++ b/ui/components/app/account-menu/__snapshots__/account-menu.test.js.snap
@@ -296,7 +296,7 @@ exports[`Account Menu Render Content should not render keyring label if keyring 
         class="account-menu__item__icon"
       >
         <span
-          arialabel="Settings"
+          aria-label="Settings"
           class="box mm-icon mm-icon--size-md box--display-inline-block box--flex-direction-row box--color-icon-alternative"
           style="mask-image: url('./images/icons/setting.svg');"
         />

--- a/ui/components/ui/box/box.js
+++ b/ui/components/ui/box/box.js
@@ -301,9 +301,18 @@ const Box = React.forwardRef(function Box(
     return children(boxClassName);
   }
   const Component = as;
-  const ariaLabelProp = {
-    [isCustomComponent(Component) ? ariaLabel : 'aria-label']: ariaLabel,
-  };
+
+  const ariaLabelProp = {};
+  if (isCustomComponent(Component)) {
+    ariaLabelProp.ariaLabel = ariaLabel;
+  } else {
+    ariaLabelProp['aria-label'] = ariaLabel;
+  }
+
+  if (props['aria-label']) {
+    ariaLabelProp['aria-label'] = props['aria-label'];
+  }
+
   return (
     <Component className={boxClassName} ref={ref} {...props} {...ariaLabelProp}>
       {children}
@@ -388,6 +397,7 @@ Box.propTypes = {
    */
   color: MultipleTextColors,
   ariaLabel: PropTypes.string,
+  'aria-label': PropTypes.string,
 };
 
 export default Box;

--- a/ui/components/ui/box/box.js
+++ b/ui/components/ui/box/box.js
@@ -222,6 +222,7 @@ const Box = React.forwardRef(function Box(
     className,
     backgroundColor,
     color,
+    ariaLabel,
     as = 'div',
     ...props
   },
@@ -300,12 +301,26 @@ const Box = React.forwardRef(function Box(
     return children(boxClassName);
   }
   const Component = as;
+  const ariaLabelProp = {
+    [isCustomComponent(Component) ? ariaLabel : 'aria-label']: ariaLabel,
+  };
   return (
-    <Component className={boxClassName} ref={ref} {...props}>
+    <Component className={boxClassName} ref={ref} {...props} {...ariaLabelProp}>
       {children}
     </Component>
   );
 });
+
+function isCustomComponent(element) {
+  if (typeof element.type === 'string') {
+    // Built-in HTML element (div, span, etc.)
+    return false;
+  } else if (typeof element.type === 'function') {
+    // Custom component (class component or functional component)
+    return true;
+  }
+  return false;
+}
 
 Box.propTypes = {
   children: PropTypes.oneOfType([PropTypes.node, PropTypes.func]),
@@ -372,6 +387,7 @@ Box.propTypes = {
    * ./ui/helpers/constants/design-system.js
    */
   color: MultipleTextColors,
+  ariaLabel: PropTypes.string,
 };
 
 export default Box;

--- a/ui/components/ui/box/box.js
+++ b/ui/components/ui/box/box.js
@@ -320,14 +320,10 @@ const Box = React.forwardRef(function Box(
   );
 });
 
+// Both class or functional components have type function.
+// Built-in HTML elements (div, span, etc.) have type string.
 function isCustomComponent(element) {
-  if (typeof element.type === 'function') {
-    // Custom component (class component or functional component)
-    return true;
-  }
-
-  // Built-in HTML elements (div, span, etc.) have type string
-  return false;
+  return typeof element.type === 'function';
 }
 
 Box.propTypes = {

--- a/ui/components/ui/box/box.js
+++ b/ui/components/ui/box/box.js
@@ -321,13 +321,12 @@ const Box = React.forwardRef(function Box(
 });
 
 function isCustomComponent(element) {
-  if (typeof element.type === 'string') {
-    // Built-in HTML element (div, span, etc.)
-    return false;
-  } else if (typeof element.type === 'function') {
+  if (typeof element.type === 'function') {
     // Custom component (class component or functional component)
     return true;
   }
+
+  // Built-in HTML elements (div, span, etc.) have type string
   return false;
 }
 


### PR DESCRIPTION
## Explanation

Fix the aria label bug. The prop should be conditionally named `aria-label` or `ariaLabel` depending on what type of component `<Box>` is rendering. 


## Screenshots/Screencaps

![Untitled](https://user-images.githubusercontent.com/13814744/228625507-a2500c13-3122-4b24-af82-e0c1c7872f61.png)

## Manual Testing Steps

1. Build app `yarn start:mv3`.
2. Go through the onboarding flow.
3. That should trigger the error once.
4. The error should occur again if you add a new wallet.
5. Check out this branch and try again. It should be fixed.

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
