### PR TITLE
fix(18194): Redirect to extension expanded view when click back to sa…

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -3528,7 +3528,11 @@ export default class MetamaskController extends EventEmitter {
     phishingStream.on(
       'data',
       createMetaRPCHandler(
-        { safelistPhishingDomain: this.safelistPhishingDomain.bind(this) },
+        {
+          safelistPhishingDomain: this.safelistPhishingDomain.bind(this),
+          backToSafetyPhishingWarning:
+            this.backToSafetyPhishingWarning.bind(this),
+        },
         phishingStream,
       ),
     );
@@ -4291,6 +4295,11 @@ export default class MetamaskController extends EventEmitter {
    */
   safelistPhishingDomain(hostname) {
     return this.phishingController.bypass(hostname);
+  }
+
+  async backToSafetyPhishingWarning() {
+    const extensionURL = this.platform.getExtensionURL();
+    await this.platform.switchToAnotherURL(undefined, extensionURL);
   }
 
   /**

--- a/app/scripts/platforms/extension.js
+++ b/app/scripts/platforms/extension.js
@@ -77,11 +77,7 @@ export default class ExtensionPlatform {
     return version;
   }
 
-  openExtensionInBrowser(
-    route = null,
-    queryString = null,
-    keepWindowOpen = false,
-  ) {
+  getExtensionURL(route = null, queryString = null) {
     let extensionURL = browser.runtime.getURL('home.html');
 
     if (route) {
@@ -92,7 +88,22 @@ export default class ExtensionPlatform {
       extensionURL += `?${queryString}`;
     }
 
+    return extensionURL;
+  }
+
+  openExtensionInBrowser(
+    route = null,
+    queryString = null,
+    keepWindowOpen = false,
+  ) {
+    const extensionURL = this.getExtensionURL(
+      route,
+      queryString,
+      keepWindowOpen,
+    );
+
     this.openTab({ url: extensionURL });
+
     if (
       getEnvironmentType() !== ENVIRONMENT_TYPE_BACKGROUND &&
       !keepWindowOpen
@@ -151,6 +162,10 @@ export default class ExtensionPlatform {
   async switchToTab(tabId) {
     const tab = await browser.tabs.update(tabId, { highlighted: true });
     return tab;
+  }
+
+  async switchToAnotherURL(tabId, url) {
+    await browser.tabs.update(tabId, { url });
   }
 
   async closeTab(tabId) {

--- a/app/scripts/platforms/extension.test.js
+++ b/app/scripts/platforms/extension.test.js
@@ -1,10 +1,14 @@
 import browser from 'webextension-polyfill';
 import ExtensionPlatform from './extension';
 
+const TEST_URL =
+  'chrome-extension://jjlgkphpeekojaidfeknpknnimdbleaf/home.html';
+
 jest.mock('webextension-polyfill', () => {
   return {
     runtime: {
       getManifest: jest.fn(),
+      getURL: jest.fn(),
     },
   };
 });
@@ -89,6 +93,32 @@ describe('extension platform', () => {
       expect(() => extensionPlatform.getVersion()).toThrow(
         'Version contains invalid prerelease:',
       );
+    });
+  });
+
+  describe('getExtensionURL', () => {
+    let extensionPlatform;
+    beforeEach(() => {
+      browser.runtime.getURL.mockReturnValue(TEST_URL);
+      extensionPlatform = new ExtensionPlatform();
+    });
+
+    it('should return URL itself if no route or queryString is provided', () => {
+      expect(extensionPlatform.getExtensionURL()).toStrictEqual(TEST_URL);
+    });
+
+    it('should return URL with route when provided', () => {
+      const TEST_ROUTE = 'test-route';
+      expect(extensionPlatform.getExtensionURL(TEST_ROUTE)).toStrictEqual(
+        `${TEST_URL}#${TEST_ROUTE}`,
+      );
+    });
+
+    it('should return URL with queryString when provided', () => {
+      const QUERY_STRING = 'name=ferret';
+      expect(
+        extensionPlatform.getExtensionURL(null, QUERY_STRING),
+      ).toStrictEqual(`${TEST_URL}?${QUERY_STRING}`);
     });
   });
 });

--- a/package.json
+++ b/package.json
@@ -375,7 +375,7 @@
     "@metamask/eslint-config-nodejs": "^9.0.0",
     "@metamask/eslint-config-typescript": "^9.0.1",
     "@metamask/forwarder": "^1.1.0",
-    "@metamask/phishing-warning": "^2.0.1",
+    "@metamask/phishing-warning": "^2.1.0",
     "@metamask/test-dapp": "^5.6.0",
     "@sentry/cli": "^1.58.0",
     "@storybook/addon-a11y": "^6.5.13",

--- a/test/e2e/tests/phishing-detection.spec.js
+++ b/test/e2e/tests/phishing-detection.spec.js
@@ -289,4 +289,46 @@ describe('Phishing Detection', function () {
       },
     );
   });
+
+  it('should open a new extension expanded view when clicking back to safety button', async function () {
+    await withFixtures(
+      {
+        fixtures: new FixtureBuilder().build(),
+        ganacheOptions,
+        title: this.test.title,
+        testSpecificMock: mockPhishingDetection,
+        dapp: true,
+        dappPaths: ['mock-page-with-disallowed-iframe'],
+        dappOptions: {
+          numberOfDapps: 2,
+        },
+        failOnConsoleError: false,
+      },
+      async ({ driver }) => {
+        await driver.navigate();
+        await driver.fill('#password', 'correct horse battery staple');
+        await driver.press('#password', driver.Key.ENTER);
+        await driver.openNewPage(
+          `http://localhost:8080?extensionUrl=${driver.extensionUrl}`,
+        );
+
+        const iframe = await driver.findElement('iframe');
+
+        await driver.switchToFrame(iframe);
+        await driver.clickElement({
+          text: 'Open this warning in a new tab',
+        });
+        await driver.switchToWindowWithTitle('MetaMask Phishing Detection');
+        await driver.clickElement({
+          text: 'Back to safety',
+        });
+
+        // Ensure we're redirected to wallet home page
+        const homePage = await driver.findElement('.home__main-view');
+        const homePageDisplayed = await homePage.isDisplayed();
+
+        assert.equal(homePageDisplayed, true);
+      },
+    );
+  });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -4222,9 +4222,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/phishing-warning@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "@metamask/phishing-warning@npm:2.0.1"
+"@metamask/phishing-warning@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "@metamask/phishing-warning@npm:2.1.0"
   dependencies:
     "@metamask/design-tokens": ^1.6.0
     "@metamask/post-message-stream": ^6.0.0
@@ -4235,7 +4235,7 @@ __metadata:
     pump: ^3.0.0
     punycode: ^2.1.1
     ses: ^0.18.1
-  checksum: caa3e596c3a67188e457307b43724c89121d60734353922d369932093f8618f96465ba7613b194dc2c57754399783dcdf1777c900afeff21bd5137f02688b686
+  checksum: d04b3f817deafa077028f2d235ae694fa772a5ee6a02fc73c6f1fed6dbd1a7491370a25b9484157835f9e1a1773e738a1306ce0c854604eba99af86f1624f453
   languageName: node
   linkType: hard
 
@@ -24296,7 +24296,7 @@ __metadata:
     "@metamask/obs-store": ^5.0.0
     "@metamask/permission-controller": ^2.0.0
     "@metamask/phishing-controller": ^2.0.0
-    "@metamask/phishing-warning": ^2.0.1
+    "@metamask/phishing-warning": ^2.1.0
     "@metamask/post-message-stream": ^6.0.0
     "@metamask/providers": ^10.2.1
     "@metamask/rate-limit-controller": ^1.0.0


### PR DESCRIPTION
Fixes #18194

Requires https://github.com/MetaMask/phishing-warning/pull/84

## Explanation

Before we had this buggy situation:

[user visits blocked page] -> [window.location.href = "warning page URL" in contentScript] -> [warning page] -> [user clicks "Back to safety"] -> [ window.close() ] -> not working in Firefox

Now we have:

- [user visits blocked page] -> [ location.href = "warning page URL" ] -> [warning page] -> [user clicks "Back to safety"] -> [rpc message sent to the extension from the phishing warning page] -> extension opens in full screen mode within the tab of the phishing warning screen

To achieve this, we had to add a `switchToAnotherURL` method which is called within a handler for a json rpc message over the `phishingStream` with a `backToSafetyPhishingWarning` method.

## Screenshots/Screencaps

<!-- If you're making a change to the UI, make sure to capture a screenshot or a short video showing off your work! -->

### Before

<!-- How did the UI you changed look before your changes? Drag your file(s) below this line: -->

### After


https://user-images.githubusercontent.com/12678455/228702073-e7676498-b770-41c9-9d24-2f13fd4a2632.mov


<!-- How does it look now? Drag your file(s) below this line: -->

## Manual Testing Steps

<!--
How should reviewers and QA manually test your changes? For instance:

- Go to this screen
- Do this
- Then do this
-->

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
