### PR TITLE
Use 'Unnamed Collection' instead of first nft name, for name of 1155 …

### DIFF
--- a/ui/hooks/useNftsCollections.js
+++ b/ui/hooks/useNftsCollections.js
@@ -4,8 +4,10 @@ import { isEqual } from 'lodash';
 import { getNfts, getNftContracts } from '../ducks/metamask/metamask';
 import { getCurrentChainId, getSelectedAddress } from '../selectors';
 import { usePrevious } from './usePrevious';
+import { useI18nContext } from './useI18nContext';
 
 export function useNftsCollections() {
+  const t = useI18nContext();
   const [collections, setCollections] = useState({});
   const [previouslyOwnedCollection, setPreviouslyOwnedCollection] = useState({
     collectionName: 'Previously Owned',
@@ -41,7 +43,7 @@ export function useNftsCollections() {
             ({ address }) => address === nft.address,
           );
           newCollections[nft.address] = {
-            collectionName: collectionContract?.name || nft.name,
+            collectionName: collectionContract?.name || t('unknownCollection'),
             collectionImage: collectionContract?.logo || nft.image,
             nfts: [nft],
           };
@@ -68,6 +70,7 @@ export function useNftsCollections() {
     prevChainId,
     selectedAddress,
     prevSelectedAddress,
+    t,
   ]);
 
   return { nftsLoading, collections, previouslyOwnedCollection };


### PR DESCRIPTION
…nft collection if it is not otherwise found

Fixes #18362

## Explanation

@seaona noticed a discrepancy between display of ERC 1155 collection names on mobile and extension. This PR corrects that discrepancy by defaulting to "Unnamed Collection" instead of the name of the first NFT in the collection.

## Screenshots/Screencaps

### Before

![Screenshot from 2023-03-30 17-24-32](https://user-images.githubusercontent.com/7499938/228951188-0fc750fc-1831-4363-9b75-11d9c018c3e3.png)

### After

![Screenshot from 2023-03-30 17-24-32](https://user-images.githubusercontent.com/7499938/228951212-b12246a7-520b-4478-8294-20c4cd41af02.png)

## Pre-merge author checklist

- [ ] I've clearly explained:
  - [ ] What problem this PR is solving
  - [ ] How this problem was solved
  - [ ] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
