### PR TITLE
Add more info to Extensions list

### DIFF
--- a/development/build/index.js
+++ b/development/build/index.js
@@ -147,6 +147,9 @@ async function defineAndRunBuildTasks() {
     browserPlatforms,
     browserVersionMap,
     buildType,
+    applyLavaMoat,
+    shouldIncludeSnow,
+    entryTask,
   });
 
   const styleTasks = createStyleTasks({ livereload });

--- a/development/build/manifest.js
+++ b/development/build/manifest.js
@@ -10,6 +10,7 @@ const { BuildType } = require('../lib/build-type');
 
 const { TASKS } = require('./constants');
 const { createTask, composeSeries } = require('./task');
+const { getEnvironment } = require('./utils');
 
 module.exports = createManifestTasks;
 
@@ -120,6 +121,8 @@ function createManifestTasks({
     const lavamoatStr = applyLavaMoat ? ' lavamoat' : '';
     const snowStr = shouldIncludeSnow ? ' snow' : '';
 
+    const environment = getEnvironment({ buildTarget: entryTask });
+
     // Get the first 8 characters of the git revision id
     const gitRevisionStr = childProcess
       .execSync('git rev-parse HEAD')
@@ -131,7 +134,7 @@ function createManifestTasks({
       buildType,
     )}${mv3Str}${lavamoatStr}${snowStr}`;
 
-    manifest.description = `${entryTask} build from git id: ${gitRevisionStr}`;
+    manifest.description = `${environment} build from git id: ${gitRevisionStr}`;
   }
 
   // helper for merging obj value

--- a/development/build/manifest.js
+++ b/development/build/manifest.js
@@ -6,6 +6,7 @@ const baseManifest = process.env.ENABLE_MV3
   ? require('../../app/manifest/v3/_base.json')
   : require('../../app/manifest/v2/_base.json');
 const { BuildType } = require('../lib/build-type');
+const { hideBin } = require('yargs/helpers');
 
 const { TASKS } = require('./constants');
 const { createTask, composeSeries } = require('./task');
@@ -101,6 +102,10 @@ function createManifestTasks({
           );
           const manifest = await readJson(manifestPath);
           transformFn(manifest);
+
+          manifest.name = 'MetaMask build type `' + process.argv[2] + '`';
+          manifest.description = 'build args: `' + hideBin(process.argv).join(' ') + '`';
+
           await writeJson(manifest, manifestPath);
         }),
       );

--- a/development/build/manifest.js
+++ b/development/build/manifest.js
@@ -5,8 +5,8 @@ const { mergeWith, cloneDeep } = require('lodash');
 const baseManifest = process.env.ENABLE_MV3
   ? require('../../app/manifest/v3/_base.json')
   : require('../../app/manifest/v2/_base.json');
-const { BuildType } = require('../lib/build-type');
 const { hideBin } = require('yargs/helpers');
+const { BuildType } = require('../lib/build-type');
 
 const { TASKS } = require('./constants');
 const { createTask, composeSeries } = require('./task');
@@ -103,8 +103,10 @@ function createManifestTasks({
           const manifest = await readJson(manifestPath);
           transformFn(manifest);
 
-          manifest.name = 'MetaMask build type `' + process.argv[2] + '`';
-          manifest.description = 'build args: `' + hideBin(process.argv).join(' ') + '`';
+          manifest.name = `MetaMask build task \`${process.argv[2]}\``;
+          manifest.description = `build args: \`${hideBin(process.argv).join(
+            ' ',
+          )}\``;
 
           await writeJson(manifest, manifestPath);
         }),

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "start": "yarn build:dev dev --apply-lavamoat=false --snow=false",
     "start:lavamoat": "yarn build:dev dev --apply-lavamoat=true",
     "start:mv3": "ENABLE_MV3=true yarn build:dev dev --apply-lavamoat=false",
+    "start:flask": "yarn start --build-type flask",
     "dist": "yarn build dist",
     "build": "yarn lavamoat:build",
     "build:dev": "node development/build/index.js",


### PR DESCRIPTION
- Adds more info to the Chrome and Firefox extensions list about what your build type is
- Add `yarn start:flask`

(Note if you're curious: truly reading from the command line may no longer be possible https://github.com/npm/cli/issues/4663)

### Image of "Before"
![image](https://user-images.githubusercontent.com/539738/229906593-fd858697-f99e-4c36-8fd1-2532ea6e1117.png)

### Images of "After"
 **Chrome or Chrome-like**
![image](https://user-images.githubusercontent.com/539738/229911175-40803282-c906-46ef-82ee-08fcdd3a86f7.png)

 **Firefox**
![image](https://user-images.githubusercontent.com/539738/229912217-841c2787-2413-4208-8cb7-207c6426fa25.png)

