### PR TITLE
UX: Multichain: Close account menu when item is clicked

### DIFF
--- a/ui/components/multichain/account-list-menu/account-list-menu.js
+++ b/ui/components/multichain/account-list-menu/account-list-menu.js
@@ -103,6 +103,7 @@ export const AccountListMenu = ({ onClose }) => {
                     },
                   });
                   dispatch(setSelectedAccount(account.address));
+                  onClose();
                 }}
                 identity={account}
                 key={account.address}


### PR DESCRIPTION
## Explanation

While testing https://github.com/MetaMask/metamask-extension/pull/18363 , I noticed that clicking the whitespace around account item would close the popover, but clicking the account name button _directly_ would switch accounts but not close the popover.  This PR ensures the popover closes.


## Pre-merge author checklist

- [ ] I've clearly explained:
  - [ ] What problem this PR is solving
  - [ ] How this problem was solved
  - [ ] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
