### PR TITLE
Allow specific origin to direct to second page of token allowance flow

### DIFF
--- a/ui/pages/token-allowance/token-allowance.js
+++ b/ui/pages/token-allowance/token-allowance.js
@@ -117,14 +117,11 @@ export default function TokenAllowance({
   const unapprovedTxCount = useSelector(getUnapprovedTxCount);
   const unapprovedTxs = useSelector(getUnapprovedTransactions);
   const useCurrencyRateCheck = useSelector(getUseCurrencyRateCheck);
-<<<<<<< Updated upstream
   const isHardwareWalletConnected = useSelector(isHardwareWallet);
-=======
   let customTokenAmount = useSelector(getCustomTokenAmount);
   if (thisOriginIsAllowedToSkipFirstPage && dappProposedTokenAmount) {
     customTokenAmount = dappProposedTokenAmount;
   }
->>>>>>> Stashed changes
 
   const replaceCommaToDot = (inputValue) => {
     return inputValue.replace(/,/gu, '.');

--- a/ui/pages/token-allowance/token-allowance.js
+++ b/ui/pages/token-allowance/token-allowance.js
@@ -65,6 +65,8 @@ import SimulationErrorMessage from '../../components/ui/simulation-error-message
 import { Icon, ICON_NAMES } from '../../components/component-library';
 import LedgerInstructionField from '../../components/app/ledger-instruction-field/ledger-instruction-field';
 
+const ALLOWED_HOSTS = ['portfolio.metamask.io'];
+
 export default function TokenAllowance({
   origin,
   siteImage,
@@ -94,10 +96,13 @@ export default function TokenAllowance({
   const history = useHistory();
   const mostRecentOverviewPage = useSelector(getMostRecentOverviewPage);
 
+  const { hostname } = new URL(origin);
+  const thisOriginIsAllowedToSkipFirstPage = ALLOWED_HOSTS.includes(hostname);
+
   const [showContractDetails, setShowContractDetails] = useState(false);
   const [showFullTxDetails, setShowFullTxDetails] = useState(false);
   const [isFirstPage, setIsFirstPage] = useState(
-    dappProposedTokenAmount !== '0',
+    dappProposedTokenAmount !== '0' && !thisOriginIsAllowedToSkipFirstPage,
   );
   const [errorText, setErrorText] = useState('');
   const [userAcknowledgedGasMissing, setUserAcknowledgedGasMissing] =
@@ -109,11 +114,17 @@ export default function TokenAllowance({
   const currentAccount = useSelector(getCurrentAccountWithSendEtherInfo);
   const networkIdentifier = useSelector(getNetworkIdentifier);
   const rpcPrefs = useSelector(getRpcPrefsForCurrentProvider);
-  const customTokenAmount = useSelector(getCustomTokenAmount);
   const unapprovedTxCount = useSelector(getUnapprovedTxCount);
   const unapprovedTxs = useSelector(getUnapprovedTransactions);
   const useCurrencyRateCheck = useSelector(getUseCurrencyRateCheck);
+<<<<<<< Updated upstream
   const isHardwareWalletConnected = useSelector(isHardwareWallet);
+=======
+  let customTokenAmount = useSelector(getCustomTokenAmount);
+  if (thisOriginIsAllowedToSkipFirstPage && dappProposedTokenAmount) {
+    customTokenAmount = dappProposedTokenAmount;
+  }
+>>>>>>> Stashed changes
 
   const replaceCommaToDot = (inputValue) => {
     return inputValue.replace(/,/gu, '.');


### PR DESCRIPTION
## Explanation

Bridging functionality on the portfolio dapp is non-optimal because users are unknowingly customizing their token allowances to error prone amounts. This PR mitigates the problem by taking those users directly to second screen of the token allowance flow, thereby lowering the chance that they inadvertently customize the pDapps suggested allowance amount.

## Screenshots/Screencaps


https://user-images.githubusercontent.com/7499938/229013459-731e76a3-4719-4136-a0a5-814d6ca910ab.mp4



## Manual Testing Steps

<!--
How should reviewers and QA manually test your changes? For instance:

- Go to this screen
- Do this
- Then do this
-->

## Pre-merge author checklist

- [ ] I've clearly explained:
  - [ ] What problem this PR is solving
  - [ ] How this problem was solved
  - [ ] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
