### PR TITLE
Disabled button for Import Tokens Modal when no token is selected

### DIFF
--- a/ui/components/app/detected-token/detected-token-selection-popover/detected-token-selection-popover.js
+++ b/ui/components/app/detected-token/detected-token-selection-popover/detected-token-selection-popover.js
@@ -62,6 +62,7 @@ const DetectedTokenSelectionPopover = ({
         className="detected-token-selection-popover__import-button"
         type="primary"
         onClick={onImport}
+        disabled={numOfTokensImporting === '(0)'}
       >
         {t('importWithCount', [numOfTokensImporting])}
       </Button>

--- a/ui/components/app/detected-token/detected-token-selection-popover/detected-token-selection-popover.js
+++ b/ui/components/app/detected-token/detected-token-selection-popover/detected-token-selection-popover.js
@@ -62,7 +62,7 @@ const DetectedTokenSelectionPopover = ({
         className="detected-token-selection-popover__import-button"
         type="primary"
         onClick={onImport}
-        disabled={numOfTokensImporting === '(0)'}
+        disabled={selectedTokens.length === 0}
       >
         {t('importWithCount', [numOfTokensImporting])}
       </Button>


### PR DESCRIPTION
This PR fixes #18392 

Currently, When a new token is detected for a given user, they can click an "Import" link to add them to MetaMask. The modal allows the user to import 0 tokens if none are selected. This PR is to disable the Import Button when no token is selected.

## Screencast/ Screenshot

### Before 

![Screenshot 2023-03-31 at 3 56 12 PM](https://user-images.githubusercontent.com/39872794/229095692-c2aea70a-d1b8-438c-92c8-db4ab49fa53b.jpg)

### After

https://user-images.githubusercontent.com/39872794/229095539-dfa48354-9e93-4031-b28d-62af3761aa5f.mov


## Pre-merge author checklist

- [ ] I've clearly explained:
  - [ ] What problem this PR is solving
  - [ ] How this problem was solved
  - [ ] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
