### PR TITLE
Ensure that firefox linting of beta builds only happens on beta build…

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1157,14 +1157,9 @@ jobs:
       - attach_workspace:
           at: .
       - run:
-          name: Move beta build to dist
-          command: mv ./dist-beta ./dist
-      - run:
-          name: Move beta zips to builds
-          command: mv ./builds-beta ./builds
-      - run:
-          name: test:mozilla-lint
-          command: NODE_OPTIONS=--max_old_space_size=3072 yarn mozilla-lint
+          name: Lint beta for firefox
+          command: |
+            .circleci/scripts/mozilla-lint-beta.sh
 
   test-mozilla-lint-desktop:
     executor: node-browsers

--- a/.circleci/scripts/mozilla-lint-beta.sh
+++ b/.circleci/scripts/mozilla-lint-beta.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+set -e
+set -u
+set -o pipefail
+
+# => Version-v10.24.1
+version="${CIRCLE_BRANCH/Version-v/}"
+current_commit_msg=$(git show -s --format='%s' HEAD)
+
+if [[ $current_commit_msg =~ Version[[:space:]](v[[:digit:]]+.[[:digit:]]+.[[:digit:]]+[-]beta.[[:digit:]]) ]]
+then
+    # filter the commit message like Version v10.24.1-beta.1
+    printf '%s\n' "Linting beta builds for firefox"
+    # Move beta build to dist
+    mv ./dist-beta ./dist
+    # Move beta zips to builds
+    mv ./builds-beta ./builds
+    # test:mozilla-lint
+    NODE_OPTIONS=--max_old_space_size=3072
+    yarn mozilla-lint
+else
+    printf '%s\n' 'Commit message does not match commit message for beta pattern; skipping linting for firefox'
+    mkdir dist
+    mkdir builds
+    exit 0
+fi
+
+exit 0

--- a/.circleci/scripts/mozilla-lint-beta.sh
+++ b/.circleci/scripts/mozilla-lint-beta.sh
@@ -4,8 +4,6 @@ set -e
 set -u
 set -o pipefail
 
-# => Version-v10.24.1
-version="${CIRCLE_BRANCH/Version-v/}"
 current_commit_msg=$(git show -s --format='%s' HEAD)
 
 if [[ $current_commit_msg =~ Version[[:space:]](v[[:digit:]]+.[[:digit:]]+.[[:digit:]]+[-]beta.[[:digit:]]) ]]
@@ -17,7 +15,7 @@ then
     # Move beta zips to builds
     mv ./builds-beta ./builds
     # test:mozilla-lint
-    NODE_OPTIONS=--max_old_space_size=3072
+    export NODE_OPTIONS='--max_old_space_size=3072'
     yarn mozilla-lint
 else
     printf '%s\n' 'Commit message does not match commit message for beta pattern; skipping linting for firefox'


### PR DESCRIPTION
Fixes the failure we are seeing on release builds here: https://app.circleci.com/pipelines/github/MetaMask/metamask-extension/41331/workflows/b6b2b01e-425f-452b-8dcb-409605c61e98/jobs/1149313

This is happening because  the beta build isn't happening:
Commit message does not match commit message for beta pattern; skipping beta automation build
from https://app.circleci.com/pipelines/github/MetaMask/metamask-extension/41331/workflows/b6b2b01e-425f-452b-8dcb-409605c61e98/jobs/1149172/steps, and the linting of that beta build is running even when the build doesn't exist

This PR ensures that the `yarn mozilla-lint` command is only run under the same conditions under which the beta build is created. In particular, if the commit message matches the beta commit structure we have set for triggering a beta build.