### PR TITLE
Token Approve page - use DAPP suggested value if it is less than user's token balance

### DIFF
--- a/ui/components/app/custom-spending-cap/custom-spending-cap.js
+++ b/ui/components/app/custom-spending-cap/custom-spending-cap.js
@@ -43,11 +43,17 @@ export default function CustomSpendingCap({
   const t = useContext(I18nContext);
   const dispatch = useDispatch();
 
-  const value = useSelector(getCustomTokenAmount);
+  const customTokenAmount = useSelector(getCustomTokenAmount);
+  const [value, setValue] = useState(() => {
+    if (Number(dappProposedValue) <= Number(currentTokenBalance)) {
+      return dappProposedValue;
+    }
+    return customTokenAmount;
+  });
 
   const [error, setError] = useState('');
   const [showUseDefaultButton, setShowUseDefaultButton] = useState(
-    value !== String(dappProposedValue) && true,
+    value !== String(dappProposedValue),
   );
   const inputLogicEmptyStateText = t('inputLogicEmptyState');
 
@@ -127,6 +133,7 @@ export default function CustomSpendingCap({
       }
     }
 
+    setValue(valueInput);
     dispatch(setCustomTokenAmount(String(valueInput)));
   };
 


### PR DESCRIPTION
On Approve token pafe use DAPP suggested token amount if it is less than user's balance.