### PR TITLE
Skip generating LavaMoat policy for MMI

### DIFF
--- a/development/generate-lavamoat-policies.js
+++ b/development/generate-lavamoat-policies.js
@@ -4,6 +4,11 @@ const yargs = require('yargs/yargs');
 const { hideBin } = require('yargs/helpers');
 const { BuildType } = require('./lib/build-type');
 
+const stableBuildTypes = Object.values(BuildType).filter(
+  // Skip generating policy for MMI until that build has stabilized
+  (buildType) => buildType !== BuildType.mmi,
+);
+
 start().catch((error) => {
   console.error('Policy generation failed.', error);
   process.exitCode = 1;
@@ -20,7 +25,7 @@ async function start() {
         .option('build-types', {
           alias: ['t'],
           choices: Object.values(BuildType),
-          default: Object.values(BuildType),
+          default: stableBuildTypes,
           demandOption: true,
           description: 'The build type(s) to generate policy files for.',
         })


### PR DESCRIPTION
The MMI build type is still a work in progress, and should not be expected to build successfully yet, so we haven't committed a LavaMoat policy to the repository for it yet. The policy update script has been updated to skip MMI by default for now; we can include it after that build has reached a point where we are confident it will build successfully.

## Manual Testing Steps

Run `yarn lavamoat:webapp:auto` and see that no policy is generated for MMI, and there are no command-line logs or errors related to MMI.

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
