### PR TITLE
Update `@metamask/obs-store`

### DIFF
--- a/lavamoat/browserify/beta/policy.json
+++ b/lavamoat/browserify/beta/policy.json
@@ -1327,9 +1327,6 @@
       }
     },
     "@metamask/obs-store": {
-      "globals": {
-        "localStorage": true
-      },
       "packages": {
         "@metamask/obs-store>through2": true,
         "browserify>stream-browserify": true,

--- a/lavamoat/browserify/desktop/policy.json
+++ b/lavamoat/browserify/desktop/policy.json
@@ -857,9 +857,9 @@
         "setTimeout": true
       },
       "packages": {
+        "@metamask/desktop>@metamask/obs-store": true,
         "@metamask/desktop>eciesjs": true,
         "@metamask/desktop>otpauth": true,
-        "@metamask/obs-store": true,
         "browserify>buffer": true,
         "browserify>events": true,
         "browserify>process": true,
@@ -870,6 +870,24 @@
         "obj-multiplex": true,
         "uuid": true,
         "webextension-polyfill": true
+      }
+    },
+    "@metamask/desktop>@metamask/obs-store": {
+      "globals": {
+        "localStorage": true
+      },
+      "packages": {
+        "@metamask/desktop>@metamask/obs-store>through2": true,
+        "browserify>stream-browserify": true,
+        "json-rpc-engine>@metamask/safe-event-emitter": true
+      }
+    },
+    "@metamask/desktop>@metamask/obs-store>through2": {
+      "packages": {
+        "browserify>process": true,
+        "browserify>util": true,
+        "readable-stream": true,
+        "watchify>xtend": true
       }
     },
     "@metamask/desktop>eciesjs": {
@@ -1393,9 +1411,6 @@
       }
     },
     "@metamask/obs-store": {
-      "globals": {
-        "localStorage": true
-      },
       "packages": {
         "@metamask/obs-store>through2": true,
         "browserify>stream-browserify": true,

--- a/lavamoat/browserify/flask/policy.json
+++ b/lavamoat/browserify/flask/policy.json
@@ -857,9 +857,9 @@
         "setTimeout": true
       },
       "packages": {
+        "@metamask/desktop>@metamask/obs-store": true,
         "@metamask/desktop>eciesjs": true,
         "@metamask/desktop>otpauth": true,
-        "@metamask/obs-store": true,
         "browserify>buffer": true,
         "browserify>events": true,
         "browserify>process": true,
@@ -870,6 +870,24 @@
         "obj-multiplex": true,
         "uuid": true,
         "webextension-polyfill": true
+      }
+    },
+    "@metamask/desktop>@metamask/obs-store": {
+      "globals": {
+        "localStorage": true
+      },
+      "packages": {
+        "@metamask/desktop>@metamask/obs-store>through2": true,
+        "browserify>stream-browserify": true,
+        "json-rpc-engine>@metamask/safe-event-emitter": true
+      }
+    },
+    "@metamask/desktop>@metamask/obs-store>through2": {
+      "packages": {
+        "browserify>process": true,
+        "browserify>util": true,
+        "readable-stream": true,
+        "watchify>xtend": true
       }
     },
     "@metamask/desktop>eciesjs": {
@@ -1393,9 +1411,6 @@
       }
     },
     "@metamask/obs-store": {
-      "globals": {
-        "localStorage": true
-      },
       "packages": {
         "@metamask/obs-store>through2": true,
         "browserify>stream-browserify": true,

--- a/lavamoat/browserify/main/policy.json
+++ b/lavamoat/browserify/main/policy.json
@@ -1327,9 +1327,6 @@
       }
     },
     "@metamask/obs-store": {
-      "globals": {
-        "localStorage": true
-      },
       "packages": {
         "@metamask/obs-store>through2": true,
         "browserify>stream-browserify": true,

--- a/package.json
+++ b/package.json
@@ -248,7 +248,7 @@
     "@metamask/message-manager": "^2.0.0",
     "@metamask/metamask-eth-abis": "^3.0.0",
     "@metamask/notification-controller": "^1.0.0",
-    "@metamask/obs-store": "^5.0.0",
+    "@metamask/obs-store": "^8.0.0",
     "@metamask/permission-controller": "^3.1.0",
     "@metamask/phishing-controller": "^2.0.0",
     "@metamask/post-message-stream": "^6.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4150,6 +4150,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@metamask/obs-store@npm:^8.0.0":
+  version: 8.0.0
+  resolution: "@metamask/obs-store@npm:8.0.0"
+  dependencies:
+    "@metamask/safe-event-emitter": ^2.0.0
+    through2: ^2.0.3
+  checksum: 232362e65a3563f0bd3299cec48f5adb37e68d4f066b7de90f2b044480d3b16c2d918c12d672c825e1d9b55344ae818fb8494d91129e4613555097653b9bb887
+  languageName: node
+  linkType: hard
+
 "@metamask/permission-controller@npm:^1.0.1":
   version: 1.0.2
   resolution: "@metamask/permission-controller@npm:1.0.2"
@@ -24289,7 +24299,7 @@ __metadata:
     "@metamask/message-manager": ^2.0.0
     "@metamask/metamask-eth-abis": ^3.0.0
     "@metamask/notification-controller": ^1.0.0
-    "@metamask/obs-store": ^5.0.0
+    "@metamask/obs-store": ^8.0.0
     "@metamask/permission-controller": ^3.1.0
     "@metamask/phishing-controller": ^2.0.0
     "@metamask/phishing-warning": ^2.1.0


### PR DESCRIPTION
`@metamask/obs-store` has been updated from v5 to v7. The breaking changes include updating the minimum supported Node.js version to v12, and removing an unused class `LocalStorageStore`.

This update includes type improvements. The main improvement is that now we can type the observational store using generic parameters. The previous version used `unknown` for the store contents.

## Manual Testing Steps

This should include no functional changes.

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
