### PR TITLE
Move all validate-source-maps-beta steps in config.yml into the respective .sh file

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1098,12 +1098,6 @@ jobs:
       - attach_workspace:
           at: .
       - run:
-          name: Move beta build to dist
-          command: mv ./dist-beta ./dist
-      - run:
-          name: Move beta zips to builds
-          command: mv ./builds-beta ./builds
-      - run:
           name: Validate source maps
           command: |
             .circleci/scripts/validate-source-maps-beta.sh

--- a/.circleci/scripts/validate-source-maps-beta.sh
+++ b/.circleci/scripts/validate-source-maps-beta.sh
@@ -10,6 +10,8 @@ current_commit_msg=$(git show -s --format='%s' HEAD)
 if [[ $current_commit_msg =~ Version[[:space:]](v[[:digit:]]+.[[:digit:]]+.[[:digit:]]+[-]beta.[[:digit:]]) ]]
 then
     # filter the commit message like Version v10.24.1-beta.1
+	mv ./dist-beta ./dist
+	mv ./builds-beta ./builds
     printf '%s\n' "Validate source maps with beta version $current_commit_msg"
     yarn validate-source-maps
 else


### PR DESCRIPTION
Fixes this build error on master https://app.circleci.com/pipelines/github/MetaMask/metamask-extension/41484/workflows/66ba0f82-827c-4728-8b11-d6b82841d8d8/jobs/1154670

We are attempting to run the `validate-source-maps-beta` job on master, but the beta build does not exist there. We have a `validate-source-maps-beta.sh` file which runs on the appropriate commits, but a couple of steps within the `validate-source-maps-beta` are outside of that script. This PR moves them into the script, avoiding errors thrown by attempting to `mv` the non-existing `dist-beta` folder