### PR TITLE
Update the announcement controller to v2

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -547,10 +547,14 @@ export default class MetamaskController extends EventEmitter {
       this.phishingController.setStalelistRefreshInterval(30 * SECOND);
     }
 
-    this.announcementController = new AnnouncementController(
-      { allAnnouncements: UI_NOTIFICATIONS },
-      initState.AnnouncementController,
-    );
+    const announcementMessenger = this.controllerMessenger.getRestricted({
+      name: 'AnnouncementController',
+    });
+    this.announcementController = new AnnouncementController({
+      messenger: announcementMessenger,
+      allAnnouncements: UI_NOTIFICATIONS,
+      state: initState.AnnouncementController,
+    });
 
     // token exchange rate tracker
     this.tokenRatesController = new TokenRatesController(

--- a/lavamoat/browserify/beta/policy.json
+++ b/lavamoat/browserify/beta/policy.json
@@ -686,18 +686,10 @@
     },
     "@metamask/announcement-controller": {
       "packages": {
-        "@metamask/announcement-controller>@metamask/base-controller": true
-      }
-    },
-    "@metamask/announcement-controller>@metamask/base-controller": {
-      "packages": {
-        "immer": true
+        "@metamask/base-controller": true
       }
     },
     "@metamask/approval-controller": {
-      "globals": {
-        "console.log": true
-      },
       "packages": {
         "@metamask/approval-controller>nanoid": true,
         "@metamask/base-controller": true,

--- a/lavamoat/browserify/desktop/policy.json
+++ b/lavamoat/browserify/desktop/policy.json
@@ -686,18 +686,10 @@
     },
     "@metamask/announcement-controller": {
       "packages": {
-        "@metamask/announcement-controller>@metamask/base-controller": true
-      }
-    },
-    "@metamask/announcement-controller>@metamask/base-controller": {
-      "packages": {
-        "immer": true
+        "@metamask/base-controller": true
       }
     },
     "@metamask/approval-controller": {
-      "globals": {
-        "console.log": true
-      },
       "packages": {
         "@metamask/approval-controller>nanoid": true,
         "@metamask/base-controller": true,

--- a/lavamoat/browserify/flask/policy.json
+++ b/lavamoat/browserify/flask/policy.json
@@ -686,18 +686,10 @@
     },
     "@metamask/announcement-controller": {
       "packages": {
-        "@metamask/announcement-controller>@metamask/base-controller": true
-      }
-    },
-    "@metamask/announcement-controller>@metamask/base-controller": {
-      "packages": {
-        "immer": true
+        "@metamask/base-controller": true
       }
     },
     "@metamask/approval-controller": {
-      "globals": {
-        "console.log": true
-      },
       "packages": {
         "@metamask/approval-controller>nanoid": true,
         "@metamask/base-controller": true,

--- a/lavamoat/browserify/main/policy.json
+++ b/lavamoat/browserify/main/policy.json
@@ -686,18 +686,10 @@
     },
     "@metamask/announcement-controller": {
       "packages": {
-        "@metamask/announcement-controller>@metamask/base-controller": true
-      }
-    },
-    "@metamask/announcement-controller>@metamask/base-controller": {
-      "packages": {
-        "immer": true
+        "@metamask/base-controller": true
       }
     },
     "@metamask/approval-controller": {
-      "globals": {
-        "console.log": true
-      },
       "packages": {
         "@metamask/approval-controller>nanoid": true,
         "@metamask/base-controller": true,

--- a/package.json
+++ b/package.json
@@ -226,7 +226,7 @@
     "@lavamoat/snow": "^1.5.0",
     "@material-ui/core": "^4.11.0",
     "@metamask/address-book-controller": "^1.0.0",
-    "@metamask/announcement-controller": "^1.0.0",
+    "@metamask/announcement-controller": "^2.0.1",
     "@metamask/approval-controller": "^1.0.0",
     "@metamask/assets-controllers": "^4.0.1",
     "@metamask/base-controller": "^1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3586,12 +3586,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/announcement-controller@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "@metamask/announcement-controller@npm:1.0.0"
+"@metamask/announcement-controller@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "@metamask/announcement-controller@npm:2.0.1"
   dependencies:
-    "@metamask/base-controller": ~1.0.0
-  checksum: 013c370484bf38d724e1ac5988043bc9b14391908f1ffe02b2b68e15c4ee65ce84d3622f510c830112bb742c69adea213547aeb858d079d626a081bbc2bb664f
+    "@metamask/base-controller": ^1.1.2
+  checksum: 170db513315dc81f131fc38a560a6d8959c4af9111a26c4f263847ab41cf2520a6dc4c77cfe40d8566ca4e87c3fe85a67def9e5499e9ccd02678792f4a8b9e56
   languageName: node
   linkType: hard
 
@@ -24277,7 +24277,7 @@ __metadata:
     "@lavamoat/snow": ^1.5.0
     "@material-ui/core": ^4.11.0
     "@metamask/address-book-controller": ^1.0.0
-    "@metamask/announcement-controller": ^1.0.0
+    "@metamask/announcement-controller": ^2.0.1
     "@metamask/approval-controller": ^1.0.0
     "@metamask/assets-controllers": ^4.0.1
     "@metamask/auto-changelog": ^2.1.0


### PR DESCRIPTION
The announcement controller has been updated to v2.0.1. The breaking change in v2 was the migration to the BaseControllerV2 API. This affected the constructor, as well as some methods/properties that we do not use.

## Manual Testing Steps

This should have no functional changesl.

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
