### PR TITLE
Updates to HeaderBase

### DIFF
--- a/ui/components/component-library/header-base/README.mdx
+++ b/ui/components/component-library/header-base/README.mdx
@@ -21,7 +21,7 @@ The `HeaderBase` accepts all props below as well as all [Box](/docs/components-u
 
 Wrapping content in the `HeaderBase` component will be rendered in the center of the header.
 
-Use the `childrenWrapperProps` prop to customize the wrapper element around the `children` content.
+Use the `childrenWrapperProps` prop to customize the wrapper element around the `children` content. The children wrapper element is a `Text` component by default.
 
 <Canvas>
   <Story id="components-componentlibrary-headerbase--children" />

--- a/ui/components/component-library/header-base/__snapshots__/header-base.test.tsx.snap
+++ b/ui/components/component-library/header-base/__snapshots__/header-base.test.tsx.snap
@@ -7,11 +7,11 @@ exports[`HeaderBase should render HeaderBase element correctly 1`] = `
     data-testid="header-base"
     title="HeaderBase test"
   >
-    <div
-      class="box mm-header-base__children box--flex-direction-row box--width-full"
+    <h4
+      class="box mm-text mm-text--heading-sm mm-text--text-align-center box--flex-direction-row box--width-full box--color-text-default"
     >
       should render HeaderBase element correctly
-    </div>
+    </h4>
   </div>
 </div>
 `;

--- a/ui/components/component-library/header-base/header-base.stories.tsx
+++ b/ui/components/component-library/header-base/header-base.stories.tsx
@@ -8,12 +8,15 @@ import {
   BUTTON_ICON_SIZES,
   BUTTON_SIZES,
   Text,
+  AvatarAccount,
 } from '..';
 import {
+  FLEX_DIRECTION,
   AlignItems,
   BackgroundColor,
   TextVariant,
-  TEXT_ALIGN,
+  JustifyContent,
+  DISPLAY,
 } from '../../../helpers/constants/design-system';
 import { HeaderBase } from './header-base';
 import README from './README.mdx';
@@ -35,11 +38,7 @@ const Template: ComponentStory<typeof HeaderBase> = (args) => (
 export const DefaultStory = Template.bind({});
 
 DefaultStory.args = {
-  children: (
-    <Text variant={TextVariant.headingSm} textAlign={TEXT_ALIGN.CENTER}>
-      Title is sentence case no period
-    </Text>
-  ),
+  children: 'Title is sentence case no period',
   startAccessory: (
     <ButtonIcon
       size={BUTTON_ICON_SIZES.SM}
@@ -60,11 +59,40 @@ DefaultStory.storyName = 'Default';
 
 export const Children = (args) => {
   return (
-    <HeaderBase {...args}>
-      <Text variant={TextVariant.headingSm} textAlign={TEXT_ALIGN.CENTER}>
+    <>
+      <HeaderBase marginBottom={4} {...args}>
         Title is sentence case no period
-      </Text>
-    </HeaderBase>
+      </HeaderBase>
+      <HeaderBase
+        childrenWrapperProps={{
+          variant: TextVariant.bodyLgMedium,
+        }}
+        marginBottom={4}
+        {...args}
+      >
+        Updating variant of Text component to bodyLgMedium using
+        childrenWrapperProps
+      </HeaderBase>
+      <HeaderBase
+        childrenWrapperProps={{
+          as: 'div',
+          display: DISPLAY.FLEX,
+          flexDirection: FLEX_DIRECTION.COLUMN,
+          justifyContent: JustifyContent.center,
+          alignItems: AlignItems.center,
+        }}
+        marginBottom={4}
+        {...args}
+      >
+        <AvatarAccount
+          marginBottom={2}
+          address="0x1234567890123456789012345678901234567890"
+        />
+        <Text variant={TextVariant.headingMd}>
+          Custom header with multiple children
+        </Text>
+      </HeaderBase>
+    </>
   );
 };
 
@@ -81,9 +109,7 @@ export const StartAccessory = (args) => {
       }
       {...args}
     >
-      <Text variant={TextVariant.headingSm} textAlign={TEXT_ALIGN.CENTER}>
-        Title is sentence case no period
-      </Text>
+      Title is sentence case no period
     </HeaderBase>
   );
 };
@@ -101,9 +127,7 @@ export const EndAccessory = (args) => {
       }
       {...args}
     >
-      <Text variant={TextVariant.headingSm} textAlign={TEXT_ALIGN.CENTER}>
-        Title is sentence case no period
-      </Text>
+      Title is sentence case no period
     </HeaderBase>
   );
 };
@@ -112,14 +136,14 @@ export const UseCaseDemos = (args) => (
   <>
     <Text>children only assigned</Text>
     <Box backgroundColor={BackgroundColor.warningAlternative}>
-      <HeaderBase marginBottom={4} {...args}>
-        <Text
-          variant={TextVariant.headingSm}
-          textAlign={TEXT_ALIGN.CENTER}
-          backgroundColor={BackgroundColor.primaryAlternative}
-        >
-          Title is sentence case no period
-        </Text>
+      <HeaderBase
+        marginBottom={4}
+        childrenWrapperProps={{
+          backgroundColor: BackgroundColor.primaryAlternative,
+        }}
+        {...args}
+      >
+        Title is sentence case no period
       </HeaderBase>
     </Box>
     <Text>children and endAccessory assigned </Text>
@@ -134,15 +158,12 @@ export const UseCaseDemos = (args) => (
             ariaLabel="close"
           />
         }
+        childrenWrapperProps={{
+          backgroundColor: BackgroundColor.primaryAlternative,
+        }}
         {...args}
       >
-        <Text
-          variant={TextVariant.headingSm}
-          textAlign={TEXT_ALIGN.CENTER}
-          backgroundColor={BackgroundColor.primaryAlternative}
-        >
-          Title is sentence case no period
-        </Text>
+        Title is sentence case no period
       </HeaderBase>
     </Box>
     <Text>children and startAccessory assigned </Text>
@@ -157,15 +178,12 @@ export const UseCaseDemos = (args) => (
             ariaLabel="back"
           />
         }
+        childrenWrapperProps={{
+          backgroundColor: BackgroundColor.primaryAlternative,
+        }}
         {...args}
       >
-        <Text
-          variant={TextVariant.headingSm}
-          textAlign={TEXT_ALIGN.CENTER}
-          backgroundColor={BackgroundColor.primaryAlternative}
-        >
-          Title is sentence case no period
-        </Text>
+        Title is sentence case no period
       </HeaderBase>
     </Box>
     <Text>children, startAccessory, and endAccessory assigned </Text>
@@ -188,15 +206,12 @@ export const UseCaseDemos = (args) => (
             ariaLabel="close"
           />
         }
+        childrenWrapperProps={{
+          backgroundColor: BackgroundColor.primaryAlternative,
+        }}
         {...args}
       >
-        <Text
-          variant={TextVariant.headingSm}
-          textAlign={TEXT_ALIGN.CENTER}
-          backgroundColor={BackgroundColor.primaryAlternative}
-        >
-          Title is sentence case no period
-        </Text>
+        Title is sentence case no period
       </HeaderBase>
     </Box>
     <Text>children, startAccessory, and endAccessory assigned </Text>
@@ -220,15 +235,12 @@ export const UseCaseDemos = (args) => (
             ariaLabel="close"
           />
         }
+        childrenWrapperProps={{
+          backgroundColor: BackgroundColor.primaryAlternative,
+        }}
         {...args}
       >
-        <Text
-          variant={TextVariant.headingSm}
-          textAlign={TEXT_ALIGN.CENTER}
-          backgroundColor={BackgroundColor.primaryAlternative}
-        >
-          Title is sentence case no period
-        </Text>
+        Title is sentence case no period
       </HeaderBase>
     </Box>
     <Text>
@@ -255,15 +267,12 @@ export const UseCaseDemos = (args) => (
             Download
           </Button>
         }
+        childrenWrapperProps={{
+          backgroundColor: BackgroundColor.primaryAlternative,
+        }}
         {...args}
       >
-        <Text
-          variant={TextVariant.headingSm}
-          textAlign={TEXT_ALIGN.CENTER}
-          backgroundColor={BackgroundColor.primaryAlternative}
-        >
-          Title is sentence case no period
-        </Text>
+        Title is sentence case no period
       </HeaderBase>
     </Box>
     <Text>startAccessory and endAccessory assigned </Text>
@@ -287,7 +296,7 @@ export const UseCaseDemos = (args) => (
           />
         }
         {...args}
-      ></HeaderBase>
+      />
     </Box>
   </>
 );

--- a/ui/components/component-library/header-base/header-base.test.tsx
+++ b/ui/components/component-library/header-base/header-base.test.tsx
@@ -55,7 +55,19 @@ describe('HeaderBase', () => {
         }
       />,
     );
-
     expect(getByTestId('end-accessory')).toBeDefined();
+  });
+
+  it('should render HeaderBase with childrenWrapperProps', () => {
+    const { getByTestId } = render(
+      <HeaderBase
+        childrenWrapperProps={{
+          'data-testid': 'children-wrapper',
+        }}
+      >
+        HeaderBase children test
+      </HeaderBase>,
+    );
+    expect(getByTestId('children-wrapper')).toBeDefined();
   });
 });

--- a/ui/components/component-library/header-base/header-base.tsx
+++ b/ui/components/component-library/header-base/header-base.tsx
@@ -3,9 +3,12 @@ import classnames from 'classnames';
 import {
   BLOCK_SIZES,
   DISPLAY,
+  TextVariant,
+  TEXT_ALIGN,
   JustifyContent,
 } from '../../../helpers/constants/design-system';
 import Box from '../../ui/box';
+import { Text } from '..';
 
 import { HeaderBaseProps } from './header-base.types';
 
@@ -70,7 +73,6 @@ export const HeaderBase: React.FC<HeaderBaseProps> = ({
     >
       {startAccessory && (
         <Box
-          className="mm-header-base__start-accessory"
           ref={startAccessoryRef}
           style={
             children
@@ -85,20 +87,20 @@ export const HeaderBase: React.FC<HeaderBaseProps> = ({
         </Box>
       )}
       {children && (
-        <Box
-          className="mm-header-base__children"
+        <Text
+          variant={TextVariant.headingSm}
+          textAlign={TEXT_ALIGN.CENTER}
           width={BLOCK_SIZES.FULL}
-          style={getTitleStyles}
           {...childrenWrapperProps}
+          style={{ ...getTitleStyles }}
         >
           {children}
-        </Box>
+        </Text>
       )}
       {endAccessory && (
         <Box
           display={DISPLAY.FLEX}
           justifyContent={JustifyContent.flexEnd}
-          className="mm-header-base__end-accessory"
           ref={endAccessoryRef}
           style={
             children

--- a/ui/components/component-library/header-base/header-base.types.ts
+++ b/ui/components/component-library/header-base/header-base.types.ts
@@ -1,5 +1,6 @@
 import React from 'react';
 import type { BoxProps } from '../../ui/box/box.d';
+import type { TextProps } from '../text/text.types';
 
 export interface HeaderBaseProps extends BoxProps {
   /**
@@ -7,9 +8,9 @@ export interface HeaderBaseProps extends BoxProps {
    */
   children?: React.ReactNode;
   /**
-   * Use the `childrenWrapperProps` prop to define the props to the children wrapper
+   * Use the `childrenWrapperProps` prop to define the props to the children wrapper accepts all Text props
    */
-  childrenWrapperProps?: BoxProps;
+  childrenWrapperProps?: TextProps;
   /**
    * The start(default left) content area of HeaderBase
    */

--- a/ui/components/component-library/text/text.types.ts
+++ b/ui/components/component-library/text/text.types.ts
@@ -43,6 +43,8 @@ export enum ValidTag {
   Input = 'input',
 }
 
+type TextAlign = typeof TEXT_ALIGN[keyof typeof TEXT_ALIGN];
+
 export interface TextProps extends BoxProps {
   /**
    * The text content of the Text component
@@ -88,7 +90,7 @@ export interface TextProps extends BoxProps {
    * The text-align of the Text component. Should use the TEXT_ALIGN object from
    * ./ui/helpers/constants/design-system.js
    */
-  textAlign?: keyof typeof TEXT_ALIGN;
+  textAlign?: TextAlign;
   /**
    * Change the dir (direction) global attribute of text to support the direction a language is written
    * Possible values: `LEFT_TO_RIGHT` (default), `RIGHT_TO_LEFT`, `AUTO` (user agent decides)


### PR DESCRIPTION
## Explanation

Currently `HeaderBase` uses the Box component to wrap the `Text` component. We are reasonably sure that the middle component will always contain text. This PR replaces the middle component in `HeaderBase` with a `Text` component which adds the default styles for Text and reduces the nesting.

Unblocks
- https://github.com/MetaMask/metamask-extension/pull/18311
- PopoverHeader

## Screenshots/Screencaps
No visual changes to component but reduces HTML nesting.

### Before

Getting a type error when using the `Text` component and `textAlign`
![Screenshot 2023-04-05 at 11 30 06 AM](https://user-images.githubusercontent.com/8112138/230172972-9feeb7b2-61d0-48f8-88bc-883ba758de60.png)

Only one update to the `Children` story to show how one customizes the text and children while not nesting divs in header tags

https://user-images.githubusercontent.com/8112138/230170804-0bce433b-034e-4050-b4a7-f2a2c45a8b02.mov

### After

Ability to use `textAlign` and `TEXT_ALIGN` const without type error

![Screenshot 2023-04-05 at 11 30 59 AM](https://user-images.githubusercontent.com/8112138/230173182-81cef4ad-895a-4b85-bd69-b298a7938635.png)


No visual changes to story apart from one update to the `Children` story to show how one customizes the text and children while not nesting divs in header tags

https://user-images.githubusercontent.com/8112138/230170902-6017de3f-d61a-4978-879c-88fdb46553fb.mov

## Manual Testing Steps
- Go to the storybook build of this PR
- Search `HeaderBase` 
- Go to the `HeaderBase` story and check the HTML tab to see reduced nesting
- Check stories and docs work as normal

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
