### PR TITLE
fix: Pass correct optimism chain id to gas estimation

### DIFF
--- a/ui/components/app/multilayer-fee-message/multi-layer-fee-message.js
+++ b/ui/components/app/multilayer-fee-message/multi-layer-fee-message.js
@@ -44,7 +44,10 @@ export default function MultilayerFeeMessage({
   useEffect(() => {
     const getEstimatedL1Fee = async () => {
       try {
-        const result = await fetchEstimatedL1Fee(transaction);
+        const result = await fetchEstimatedL1Fee(
+          transaction.chainId,
+          transaction.txParams,
+        );
         setLayer1Total(result);
       } catch (e) {
         captureException(e);
@@ -75,7 +78,7 @@ export default function MultilayerFeeMessage({
   return (
     <div className="multi-layer-fee-message">
       <TransactionDetailItem
-        key="total-item"
+        key="total-item-gas-fee"
         detailTitle={t('gasFee')}
         detailTotal={layer1Total}
         detailText={feeTotalInFiat}
@@ -83,7 +86,7 @@ export default function MultilayerFeeMessage({
         flexWidthValues={plainStyle}
       />
       <TransactionDetailItem
-        key="total-item"
+        key="total-item-total"
         detailTitle={t('total')}
         detailTotal={totalInEth}
         detailText={totalInFiat}

--- a/ui/ducks/send/send.js
+++ b/ui/ducks/send/send.js
@@ -505,7 +505,7 @@ export const computeEstimatedGasLimit = createAsyncThunk(
 
     let gasTotalForLayer1;
     if (isMultiLayerFeeNetwork) {
-      gasTotalForLayer1 = await fetchEstimatedL1Fee({
+      gasTotalForLayer1 = await fetchEstimatedL1Fee(chainId, {
         txParams: {
           gasPrice: draftTransaction.gas.gasPrice,
           gas: draftTransaction.gas.gasLimit,

--- a/ui/helpers/utils/optimism/fetchEstimatedL1Fee.js
+++ b/ui/helpers/utils/optimism/fetchEstimatedL1Fee.js
@@ -19,14 +19,20 @@ const OPTIMISM_GAS_PRICE_ORACLE_ABI = [
 const OPTIMISM_GAS_PRICE_ORACLE_ADDRESS =
   '0x420000000000000000000000000000000000000F';
 
-export default async function fetchEstimatedL1Fee(txMeta, ethersProvider) {
+export default async function fetchEstimatedL1Fee(
+  chainId,
+  txMeta,
+  ethersProvider,
+) {
+  const networkId = Number(chainId);
   const provider = global.ethereumProvider
-    ? new Web3Provider(global.ethereumProvider, 10)
+    ? new Web3Provider(global.ethereumProvider, networkId)
     : ethersProvider;
+
   if (process.env.IN_TEST) {
     provider.detectNetwork = async () => ({
       name: 'optimism',
-      chainId: 10,
+      chainId: networkId,
     });
   }
   const contract = new Contract(
@@ -36,7 +42,6 @@ export default async function fetchEstimatedL1Fee(txMeta, ethersProvider) {
   );
   const serializedTransaction =
     buildUnserializedTransaction(txMeta).serialize();
-
   const result = await contract.getL1Fee(serializedTransaction);
   return result?.toHexString();
 }

--- a/ui/helpers/utils/optimism/fetchEstimatedL1Fee.test.js
+++ b/ui/helpers/utils/optimism/fetchEstimatedL1Fee.test.js
@@ -33,7 +33,7 @@ describe('fetchEstimatedL1Fee', () => {
         result: `0x0000000000000000000000000000000000000000000000000000${expectedGasFeeResult}`,
       });
 
-    const gasFee = await fetchEstimatedL1Fee({
+    const gasFee = await fetchEstimatedL1Fee('10', {
       txParams: {
         gasPrice: '0xf4240',
         gas: '0xcf08',
@@ -43,7 +43,6 @@ describe('fetchEstimatedL1Fee', () => {
         data: null,
         type: '0x0',
       },
-      chainId: '10',
     });
     expect(gasFee).toStrictEqual(`0x${expectedGasFeeResult}`);
   });

--- a/ui/pages/swaps/view-quote/view-quote.js
+++ b/ui/pages/swaps/view-quote/view-quote.js
@@ -896,13 +896,12 @@ export default function ViewQuote() {
       try {
         let l1ApprovalFeeTotal = '0x0';
         if (approveTxParams) {
-          l1ApprovalFeeTotal = await fetchEstimatedL1Fee({
+          l1ApprovalFeeTotal = await fetchEstimatedL1Fee(chainId, {
             txParams: {
               ...approveTxParams,
               gasPrice: addHexPrefix(approveTxParams.gasPrice),
               value: '0x0', // For approval txs we need to use "0x0" here.
             },
-            chainId,
           });
           setMultiLayerL1ApprovalFeeTotal(l1ApprovalFeeTotal);
         }


### PR DESCRIPTION
## Explanation
Reported in[ this thread](https://consensys.slack.com/archives/C01KXHPU3C6/p1679407919488439) that gas estimation is 0 when transfer under optimism testing network. The reason behind is chainID `0x1a4` is not passed in the calculation `fetchEstimatedL1Fee` and the value was hardcoded as `10` for optimism network.

<!--
Thanks for the pull request. Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues, Slack conversations, Zendesk issues, user stories, etc. reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

## Screenshots/Screencaps

<!-- If you're making a change to the UI, make sure to capture a screenshot or a short video showing off your work! -->

### Before

<!-- How did the UI you changed look before your changes? Drag your file(s) below this line: -->

### After

https://user-images.githubusercontent.com/12678455/230235151-0d1571c7-c94b-4fa6-9e15-feea7c8e5d30.mov


<!-- How does it look now? Drag your file(s) below this line: -->

## Manual Testing Steps

<!--
How should reviewers and QA manually test your changes? For instance:

- Go to this screen
- Do this
- Then do this
-->

## Pre-merge author checklist

- [ ] I've clearly explained:
  - [ ] What problem this PR is solving
  - [ ] How this problem was solved
  - [ ] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
