### PR TITLE
Fix locale file issues on chrome store

### DIFF
--- a/app/_locales/hi/messages.json
+++ b/app/_locales/hi/messages.json
@@ -1601,11 +1601,11 @@
     "description": "Is the bolded text in 'holdToRevealContent1'"
   },
   "holdToRevealContent3": {
-    "message": "इसे किसी के साथ साझा न करें। $1$2",
+    "message": "इसे किसी के साथ साझा न करें। $1,$2",
     "description": "$1 is a message from 'holdToRevealContent4' and $2 is a text link with the message from 'holdToRevealContent5'"
   },
   "holdToRevealContent4": {
-    "message": "MetaMask सपोर्ट इसका अनुरोध नहीं करेगा,",
+    "message": "MetaMask सपोर्ट इसका अनुरोध नहीं करेगा",
     "description": "Part of 'holdToRevealContent3'"
   },
   "holdToRevealContent5": {

--- a/app/_locales/ja/messages.json
+++ b/app/_locales/ja/messages.json
@@ -1601,11 +1601,11 @@
     "description": "Is the bolded text in 'holdToRevealContent1'"
   },
   "holdToRevealContent3": {
-    "message": "これは誰にも教えないでください。$1$2",
+    "message": "これは誰にも教えないでください。$1、$2",
     "description": "$1 is a message from 'holdToRevealContent4' and $2 is a text link with the message from 'holdToRevealContent5'"
   },
   "holdToRevealContent4": {
-    "message": "MetaMask サポートがこの情報を尋ねることはなく、",
+    "message": "MetaMask サポートがこの情報を尋ねることはなく",
     "description": "Part of 'holdToRevealContent3'"
   },
   "holdToRevealContent5": {

--- a/app/_locales/tr/messages.json
+++ b/app/_locales/tr/messages.json
@@ -1593,7 +1593,7 @@
     "message": "GKİ'yi göstermek için basılı tut"
   },
   "holdToRevealContent1": {
-    "message": "Gizli Kurtarma İfadeniz: $1$",
+    "message": "Gizli Kurtarma İfadeniz: $1",
     "description": "$1 is a bolded text with the message from 'holdToRevealContent2'"
   },
   "holdToRevealContent2": {


### PR DESCRIPTION
## Explanation

Fixes https://github.com/MetaMask/metamask-extension/issues/18482

We have seen users such as those in the linked ticket being unable to install from the chrome store. In particular `ja` and `tr` language users. The error message in all cases references the `$1$` variable as a problem.

This PR removes the erroneous case of the `$1$` variable from the `tr` locale file, and rearranges the comman placement in the `hi` and `ja` files to remove the other cases.

There is no way for us to test this, we have to see if it limits user reports after we ship it.