### PR TITLE
Fix hold to reveal button

### DIFF
--- a/ui/components/app/hold-to-reveal-button/hold-to-reveal-button.js
+++ b/ui/components/app/hold-to-reveal-button/hold-to-reveal-button.js
@@ -170,8 +170,9 @@ export default function HoldToRevealButton({ buttonText, onLongPressed }) {
       onMouseDown={onMouseDown}
       onMouseUp={onMouseUp}
       className="hold-to-reveal-button__button-hold"
+      textProps={{ display: DISPLAY.FLEX, alignItems: AlignItems.center }}
     >
-      <Box className="hold-to-reveal-button__icon-container">
+      <Box className="hold-to-reveal-button__icon-container" marginRight={2}>
         {renderPreCompleteContent()}
         {renderPostCompleteContent()}
       </Box>


### PR DESCRIPTION
## Explanation

Currently the hold to reveal SRP button alignment is broken 

* Fixes #18495 

## Screenshots/Screencaps

### Before

<img width="939" alt="Screenshot 2023-04-06 at 3 30 20 PM" src="https://user-images.githubusercontent.com/8112138/230506120-a16a1e9b-40c2-46c2-9773-9b7657c5e8d8.png">


https://user-images.githubusercontent.com/8112138/230506784-84999494-4461-49e2-a1f5-6073dbd535af.mov



### After

<img width="583" alt="Screenshot 2023-04-06 at 3 36 30 PM" src="https://user-images.githubusercontent.com/8112138/230506248-167d4424-ee3c-4f6c-aef1-e013f9570040.png">


https://user-images.githubusercontent.com/8112138/230506800-a3f26507-9056-4033-93ca-2c310d7afdf5.mov



## Manual Testing Steps

- Go to the storybook build of this PR
- Search `HoldToRevealButton`
- See fixed alignment

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
