### PR TITLE
Fix diff generation for fitness functions

### DIFF
--- a/.github/workflows/fitness-functions.yml
+++ b/.github/workflows/fitness-functions.yml
@@ -17,12 +17,13 @@ jobs:
         with:
           node-version: '16'
 
+      - name: Install dependencies
+        run: yarn
+
       - name: Run fitness functions
         env:
-          HEAD_REF: ${{ github.event.pull_request.head.ref }}
           BASE_REF: ${{ github.event.pull_request.base.ref }}
         run: |
-          # git fetch origin $HEAD_REF
-          # git fetch origin $BASE_REF
-          # git diff origin/$BASE_REF origin/$HEAD_REF -- . > diff
-          # npm run fitness-functions -- "ci" "./diff"
+          git fetch origin $BASE_REF
+          git diff origin/$BASE_REF HEAD -- . > diff
+          npm run fitness-functions -- "ci" "./diff"


### PR DESCRIPTION
## Explanation

To fix the underlying issue reported on https://github.com/MetaMask/metamask-extension/pull/17754, we implemented a different mechanism to generate the diff for fitness functions that supports PRs opened by external contributors using repository forks.

We don't need to fetch HEAD from the origin, instead directly using the one available in the CI.