### PR TITLE
deps/security: vm2@3.9.11->3.9.15

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -34616,14 +34616,14 @@ __metadata:
   linkType: hard
 
 "vm2@npm:^3.9.3":
-  version: 3.9.11
-  resolution: "vm2@npm:3.9.11"
+  version: 3.9.15
+  resolution: "vm2@npm:3.9.15"
   dependencies:
     acorn: ^8.7.0
     acorn-walk: ^8.2.0
   bin:
     vm2: bin/vm2
-  checksum: aab39e6e4b59146d24abacd79f490e854a6e058a8b23d93d2be5aca7720778e2605d2cc028ccc4a5f50d3d91b0c38be9a6247a80d2da1a6de09425cc437770b4
+  checksum: 1df70d5a88173651c0062901aba67e5edfeeb3f699fe6c305f5efb6a5a7391e5724cbf98a6516600b65016c6824dc07cc79947ea4222f8537ae1d9ce0b730ad7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Resolves CVE-2023-29017 / [GHSA-7jxr-cg7f-gpgv](https://github.com/patriksimek/vm2/security/advisories/GHSA-7jxr-cg7f-gpgv)


- [npmdiff:3.9.11...3.9.15](https://npm-diff.app/vm2@3.9.11...vm2@3.9.15)
- [git:3.9.11...3.9.15](https://github.com/patriksimek/vm2/compare/3.9.11...3.9.15)
- [Changelog](https://github.com/patriksimek/vm2/blob/master/CHANGELOG.md)