### PR TITLE
Ensure that all networkConfiguration object in networkController state have an id

### DIFF
--- a/app/scripts/migrations/084.test.js
+++ b/app/scripts/migrations/084.test.js
@@ -141,4 +141,114 @@ describe('migration #84', () => {
     };
     expect(newStorage).toStrictEqual(expectedNewStorage);
   });
+
+  it('should not modify state if state.NetworkController is undefined', async () => {
+    const oldStorage = {
+      meta: {
+        version,
+      },
+      data: {
+        testProperty: 'testValue',
+      },
+    };
+
+    const newStorage = await migrate(oldStorage);
+
+    const expectedNewStorage = {
+      meta: {
+        version,
+      },
+      data: {
+        testProperty: 'testValue',
+      },
+    };
+    expect(newStorage).toStrictEqual(expectedNewStorage);
+  });
+
+  it('should not modify state if state.NetworkController is not an object', async () => {
+    const oldStorage = {
+      meta: {
+        version,
+      },
+      data: {
+        NetworkController: false,
+        testProperty: 'testValue',
+      },
+    };
+
+    const newStorage = await migrate(oldStorage);
+
+    const expectedNewStorage = {
+      meta: {
+        version,
+      },
+      data: {
+        NetworkController: false,
+        testProperty: 'testValue',
+      },
+    };
+    expect(newStorage).toStrictEqual(expectedNewStorage);
+  });
+
+  it('should not modify state if state.NetworkController.networkConfigurations is undefined', async () => {
+    const oldStorage = {
+      meta: {
+        version,
+      },
+      data: {
+        NetworkController: {
+          testNetworkControllerProperty: 'testNetworkControllerValue',
+          networkConfigurations: undefined,
+        },
+        testProperty: 'testValue',
+      },
+    };
+
+    const newStorage = await migrate(oldStorage);
+
+    const expectedNewStorage = {
+      meta: {
+        version,
+      },
+      data: {
+        NetworkController: {
+          testNetworkControllerProperty: 'testNetworkControllerValue',
+          networkConfigurations: undefined,
+        },
+        testProperty: 'testValue',
+      },
+    };
+    expect(newStorage).toStrictEqual(expectedNewStorage);
+  });
+
+  it('should not modify state if state.NetworkController.networkConfigurations is an empty object', async () => {
+    const oldStorage = {
+      meta: {
+        version,
+      },
+      data: {
+        NetworkController: {
+          testNetworkControllerProperty: 'testNetworkControllerValue',
+          networkConfigurations: {},
+        },
+        testProperty: 'testValue',
+      },
+    };
+
+    const newStorage = await migrate(oldStorage);
+
+    const expectedNewStorage = {
+      meta: {
+        version,
+      },
+      data: {
+        NetworkController: {
+          testNetworkControllerProperty: 'testNetworkControllerValue',
+          networkConfigurations: {},
+        },
+        testProperty: 'testValue',
+      },
+    };
+    expect(newStorage).toStrictEqual(expectedNewStorage);
+  });
 });

--- a/app/scripts/migrations/084.test.js
+++ b/app/scripts/migrations/084.test.js
@@ -1,0 +1,144 @@
+import { v4 } from 'uuid';
+import { migrate, version } from './084';
+
+jest.mock('uuid', () => {
+  const actual = jest.requireActual('uuid');
+
+  return {
+    ...actual,
+    v4: jest.fn(),
+  };
+});
+
+describe('migration #84', () => {
+  beforeEach(() => {
+    v4.mockImplementationOnce(() => 'network-configuration-id-1')
+      .mockImplementationOnce(() => 'network-configuration-id-2')
+      .mockImplementationOnce(() => 'network-configuration-id-3')
+      .mockImplementationOnce(() => 'network-configuration-id-4');
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+  it('should update the version metadata', async () => {
+    const oldStorage = {
+      meta: {
+        version: 83,
+      },
+      data: {},
+    };
+
+    const newStorage = await migrate(oldStorage);
+    expect(newStorage.meta).toStrictEqual({
+      version,
+    });
+  });
+
+  it('should use the key of the networkConfigurations object to set the id of each network configuration', async () => {
+    const oldStorage = {
+      meta: {
+        version,
+      },
+      data: {
+        NetworkController: {
+          networkConfigurations: {
+            'network-configuration-id-1': {
+              chainId: '0x539',
+              nickname: 'Localhost 8545',
+              rpcPrefs: {},
+              rpcUrl: 'http://localhost:8545',
+              ticker: 'ETH',
+            },
+            'network-configuration-id-2': {
+              chainId: '0xa4b1',
+              nickname: 'Arbitrum One',
+              rpcPrefs: {
+                blockExplorerUrl: 'https://explorer.arbitrum.io',
+              },
+              rpcUrl:
+                'https://arbitrum-mainnet.infura.io/v3/373266a93aab4acda48f89d4fe77c748',
+              ticker: 'ETH',
+            },
+            'network-configuration-id-3': {
+              chainId: '0x4e454152',
+              nickname: 'Aurora Mainnet',
+              rpcPrefs: {
+                blockExplorerUrl: 'https://aurorascan.dev/',
+              },
+              rpcUrl:
+                'https://aurora-mainnet.infura.io/v3/373266a93aab4acda48f89d4fe77c748',
+              ticker: 'Aurora ETH',
+            },
+            'network-configuration-id-4': {
+              chainId: '0x38',
+              nickname:
+                'BNB Smart Chain (previously Binance Smart Chain Mainnet)',
+              rpcPrefs: {
+                blockExplorerUrl: 'https://bscscan.com/',
+              },
+              rpcUrl: 'https://bsc-dataseed.binance.org/',
+              ticker: 'BNB',
+            },
+          },
+        },
+      },
+    };
+
+    const newStorage = await migrate(oldStorage);
+
+    const expectedNewStorage = {
+      meta: {
+        version,
+      },
+      data: {
+        NetworkController: {
+          networkConfigurations: {
+            'network-configuration-id-1': {
+              chainId: '0x539',
+              nickname: 'Localhost 8545',
+              rpcPrefs: {},
+              rpcUrl: 'http://localhost:8545',
+              ticker: 'ETH',
+              id: 'network-configuration-id-1',
+            },
+            'network-configuration-id-2': {
+              chainId: '0xa4b1',
+              nickname: 'Arbitrum One',
+              rpcPrefs: {
+                blockExplorerUrl: 'https://explorer.arbitrum.io',
+              },
+              rpcUrl:
+                'https://arbitrum-mainnet.infura.io/v3/373266a93aab4acda48f89d4fe77c748',
+              ticker: 'ETH',
+              id: 'network-configuration-id-2',
+            },
+            'network-configuration-id-3': {
+              chainId: '0x4e454152',
+              nickname: 'Aurora Mainnet',
+              rpcPrefs: {
+                blockExplorerUrl: 'https://aurorascan.dev/',
+              },
+              rpcUrl:
+                'https://aurora-mainnet.infura.io/v3/373266a93aab4acda48f89d4fe77c748',
+              ticker: 'Aurora ETH',
+              id: 'network-configuration-id-3',
+            },
+            'network-configuration-id-4': {
+              chainId: '0x38',
+              nickname:
+                'BNB Smart Chain (previously Binance Smart Chain Mainnet)',
+              rpcPrefs: {
+                blockExplorerUrl: 'https://bscscan.com/',
+              },
+              rpcUrl: 'https://bsc-dataseed.binance.org/',
+              ticker: 'BNB',
+              id: 'network-configuration-id-4',
+            },
+          },
+        },
+      },
+    };
+    expect(newStorage).toStrictEqual(expectedNewStorage);
+  });
+});

--- a/app/scripts/migrations/084.ts
+++ b/app/scripts/migrations/084.ts
@@ -27,21 +27,23 @@ function transformState(state: Record<string, unknown>) {
   if (!isObject(state.NetworkController)) {
     return state;
   }
-  const { NetworkController }: any = state;
+  const { NetworkController } = state;
 
   if (!isObject(NetworkController.networkConfigurations)) {
     return state;
   }
 
-  const {
-    networkConfigurations,
-  }: { networkConfigurations: Record<string, object> } = NetworkController;
+  const { networkConfigurations } = NetworkController;
 
   const newNetworkConfigurations: Record<string, Record<string, unknown>> = {};
 
   for (const networkConfigurationId of Object.keys(networkConfigurations)) {
+    const networkConfiguration = networkConfigurations[networkConfigurationId];
+    if (!isObject(networkConfiguration)) {
+      return state;
+    }
     newNetworkConfigurations[networkConfigurationId] = {
-      ...networkConfigurations[networkConfigurationId],
+      ...networkConfiguration,
       id: networkConfigurationId,
     };
   }

--- a/app/scripts/migrations/084.ts
+++ b/app/scripts/migrations/084.ts
@@ -33,7 +33,7 @@ function transformState(state: Record<string, unknown>) {
     networkConfigurations,
   }: { networkConfigurations: Record<string, object> } = NetworkController;
 
-  const newNetworkConfigurations: Record<string, object> = {};
+  const newNetworkConfigurations: Record<string, Record<string, unknown>> = {};
 
   for (const networkConfigurationId in networkConfigurations) {
     if (

--- a/app/scripts/migrations/084.ts
+++ b/app/scripts/migrations/084.ts
@@ -37,7 +37,6 @@ function transformState(state: Record<string, unknown>) {
     networkConfigurations,
   }: { networkConfigurations: Record<string, object> } = NetworkController;
 
-
   const newNetworkConfigurations: Record<string, Record<string, unknown>> = {};
 
   for (const networkConfigurationId of Object.keys(networkConfigurations)) {

--- a/app/scripts/migrations/084.ts
+++ b/app/scripts/migrations/084.ts
@@ -27,11 +27,16 @@ function transformState(state: Record<string, unknown>) {
   if (!isObject(state.NetworkController)) {
     return state;
   }
-  const { NetworkController } = state;
+  const { NetworkController }: any = state;
+
+  if (!isObject(NetworkController.networkConfigurations)) {
+    return state;
+  }
 
   const {
     networkConfigurations,
   }: { networkConfigurations: Record<string, object> } = NetworkController;
+
 
   const newNetworkConfigurations: Record<string, Record<string, unknown>> = {};
 

--- a/app/scripts/migrations/084.ts
+++ b/app/scripts/migrations/084.ts
@@ -27,7 +27,7 @@ function transformState(state: Record<string, unknown>) {
   if (!isObject(state.NetworkController)) {
     return state;
   }
-  const { NetworkController }: any = state;
+  const { NetworkController } = state;
 
   const {
     networkConfigurations,

--- a/app/scripts/migrations/084.ts
+++ b/app/scripts/migrations/084.ts
@@ -35,18 +35,11 @@ function transformState(state: Record<string, unknown>) {
 
   const newNetworkConfigurations: Record<string, Record<string, unknown>> = {};
 
-  for (const networkConfigurationId in networkConfigurations) {
-    if (
-      Object.prototype.hasOwnProperty.call(
-        networkConfigurations,
-        networkConfigurationId,
-      )
-    ) {
-      newNetworkConfigurations[networkConfigurationId] = {
-        ...networkConfigurations[networkConfigurationId],
-        id: networkConfigurationId,
-      };
-    }
+  for (const networkConfigurationId of Object.keys(networkConfigurations)) {
+    newNetworkConfigurations[networkConfigurationId] = {
+      ...networkConfigurations[networkConfigurationId],
+      id: networkConfigurationId,
+    };
   }
 
   return {

--- a/app/scripts/migrations/084.ts
+++ b/app/scripts/migrations/084.ts
@@ -1,11 +1,10 @@
 import { cloneDeep } from 'lodash';
-import { hasProperty, isObject } from '@metamask/utils';
-import { v4 } from 'uuid';
+import { isObject } from '@metamask/utils';
 
 export const version = 84;
 
 /**
- * Ensure that each networkConfigurations object in state.NetworkController.networkConfigurations has an 
+ * Ensure that each networkConfigurations object in state.NetworkController.networkConfigurations has an
  * `id` property which matches the key pointing that object
  *
  * @param originalVersionedData - Versioned MetaMask extension state, exactly what we persist to dist.
@@ -25,21 +24,28 @@ export async function migrate(originalVersionedData: {
 }
 
 function transformState(state: Record<string, unknown>) {
-  if (
-    !isObject(state.NetworkController)
-  ) {
+  if (!isObject(state.NetworkController)) {
     return state;
   }
-  const NetworkController: any = state.NetworkController;
+  const { NetworkController }: any = state;
 
-  const networkConfigurations: Record<string, object> = NetworkController.networkConfigurations;
+  const {
+    networkConfigurations,
+  }: { networkConfigurations: Record<string, object> } = NetworkController;
 
   const newNetworkConfigurations: Record<string, object> = {};
 
   for (const networkConfigurationId in networkConfigurations) {
-    newNetworkConfigurations[networkConfigurationId] = {
-      ...networkConfigurations[networkConfigurationId],
-      id: networkConfigurationId,
+    if (
+      Object.prototype.hasOwnProperty.call(
+        networkConfigurations,
+        networkConfigurationId,
+      )
+    ) {
+      newNetworkConfigurations[networkConfigurationId] = {
+        ...networkConfigurations[networkConfigurationId],
+        id: networkConfigurationId,
+      };
     }
   }
 

--- a/app/scripts/migrations/084.ts
+++ b/app/scripts/migrations/084.ts
@@ -1,0 +1,53 @@
+import { cloneDeep } from 'lodash';
+import { hasProperty, isObject } from '@metamask/utils';
+import { v4 } from 'uuid';
+
+export const version = 84;
+
+/**
+ * Ensure that each networkConfigurations object in state.NetworkController.networkConfigurations has an 
+ * `id` property which matches the key pointing that object
+ *
+ * @param originalVersionedData - Versioned MetaMask extension state, exactly what we persist to dist.
+ * @param originalVersionedData.meta - State metadata.
+ * @param originalVersionedData.meta.version - The current state version.
+ * @param originalVersionedData.data - The persisted MetaMask state, keyed by controller.
+ * @returns Updated versioned MetaMask extension state.
+ */
+export async function migrate(originalVersionedData: {
+  meta: { version: number };
+  data: Record<string, unknown>;
+}) {
+  const versionedData = cloneDeep(originalVersionedData);
+  versionedData.meta.version = version;
+  versionedData.data = transformState(versionedData.data);
+  return versionedData;
+}
+
+function transformState(state: Record<string, unknown>) {
+  if (
+    !isObject(state.NetworkController)
+  ) {
+    return state;
+  }
+  const NetworkController: any = state.NetworkController;
+
+  const networkConfigurations: Record<string, object> = NetworkController.networkConfigurations;
+
+  const newNetworkConfigurations: Record<string, object> = {};
+
+  for (const networkConfigurationId in networkConfigurations) {
+    newNetworkConfigurations[networkConfigurationId] = {
+      ...networkConfigurations[networkConfigurationId],
+      id: networkConfigurationId,
+    }
+  }
+
+  return {
+    ...state,
+    NetworkController: {
+      ...NetworkController,
+      networkConfigurations: newNetworkConfigurations,
+    },
+  };
+}

--- a/app/scripts/migrations/index.js
+++ b/app/scripts/migrations/index.js
@@ -87,6 +87,7 @@ import m080 from './080';
 import * as m081 from './081';
 import * as m082 from './082';
 import * as m083 from './083';
+import * as m084 from './084';
 
 const migrations = [
   m002,
@@ -171,6 +172,7 @@ const migrations = [
   m081,
   m082,
   m083,
+  m084,
 ];
 
 export default migrations;


### PR DESCRIPTION
Fixes https://github.com/MetaMask/metamask-extension/issues/18509
Fixes https://github.com/MetaMask/metamask-extension/issues/18453

## Explanation

We partially fixed the symptom of 18509 and 18453 with https://github.com/MetaMask/metamask-extension/pull/18483, but that fix was incomplete.

This bug will be experienced by anyone who added a network while on v10.27.0 or earlier, and are now on v10.28.1 or v10.28.2 and trying to confirm a dapp prompted switch to that network. This bug will not affect users who first added the network, via a dapp wallet_addEthereumChain request, while on v10.28.1 . This bug also won't affect users who added the network via the MetaMask UI in v10.28.1

The problem is that migration 82 did not add an `id` property to each network configuration object, but we assume that `id` property exists in the `switch-ethereum-chain.js` handler. If a user adds a network on version v10.27.0 or earlier, and then updates to v10.28.x, migration 82 will create an object within `NetworkController.networkConfigurations` keyed by a random id, but that `id` will not be added to that object itself. Later, when we attempt to switch to the network using that objects `id` property, it fails. It does not fail if the network is added while on v10.28.x, because the `upsertNetworkConfiguration` method, which is called when adding a network on v10.28.x, adds an `id` property to each network.

This PR corrects the problem with a migration that ensures that the each key within `networkConfigurations` is used to set the `id` property of the respective object.

### Before

This video shows what would happen when upgrading from v10.27.0 -> v10.28.2 and then trying to switch to a previously added network:

https://user-images.githubusercontent.com/7499938/230714011-86eef63c-b54d-4b79-b51c-1903e1016a27.mp4



### After

This shows switch network working after an upgrade from v10.27.0 to the branch of this PR:

https://user-images.githubusercontent.com/7499938/230714738-16fa8e2e-be3e-4c71-94b3-01220bb618b8.mp4



## Manual Testing Steps

Do as is done in the above "After" video:

1. Build v10.27.0, from d8591d48c, install and onboard
2. Go to https://syncswap.xyz/, connect and add the suggested network
3. In MetaMask, select Ethereum Mainnet, so that the zkSync network is not selected
4. git checkout this branch, build and then reload the metamask installation that was previously built from v10.27.0
5. login to MetaMask and then go to https://syncswap.xyz/
6. click "Connect Wallet" and confirm the switch network popup
7. open MetaMask, you should now have the zksync network selected

## Pre-merge author checklist

- [ ] I've clearly explained:
  - [ ] What problem this PR is solving
  - [ ] How this problem was solved
  - [ ] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
