### PR TITLE
Fix e2e test for NFT interactions

### DIFF
--- a/test/e2e/nft/erc721-interaction.spec.js
+++ b/test/e2e/nft/erc721-interaction.spec.js
@@ -62,9 +62,7 @@ describe('ERC721 NFTs testdapp interaction', function () {
         );
 
         // Verify transaction
-        const completedTx = await driver.findElement('.list-item__title');
-        const completedTxText = await completedTx.getText();
-        assert.equal(completedTxText, 'Send Token');
+        await driver.findElement({ text: 'Send TDC' });
       },
     );
   });


### PR DESCRIPTION
The test `should transfer a single ERC721 NFT from one account to another` has been failing intermittently. It seems to be failing due to a race condition; the first render shows "Send Token" but later renders show "Send TDC". The test only passes if it runs fast enough to read the first render of the list item component.

The test has been updated to look for the text "Send TDC", which is what the component shows from the second render onward.

## Manual Testing Steps

No functional changes; the e2e tests should just pass more consistently.

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
