### PR TITLE
[MMI] moves mmi selectors to institutional folder

### DIFF
--- a/ui/selectors/institutional/selectors.js
+++ b/ui/selectors/institutional/selectors.js
@@ -1,4 +1,9 @@
 import { toChecksumAddress } from 'ethereumjs-util';
+import {
+  getSelectedIdentity,
+  getAccountType,
+  getProvider,
+} from '../../selectors';
 
 export function getWaitForConfirmDeepLinkDialog(state) {
   return state.metamask.waitForConfirmDeepLinkDialog;
@@ -43,4 +48,21 @@ export function getCustodianIconForAddress(state, address) {
   }
 
   return custodianIcon;
+}
+
+export function getIsCustodianSupportedChain(state) {
+  const selectedIdentity = getSelectedIdentity(state);
+  const accountType = getAccountType(state);
+  const provider = getProvider(state);
+
+  const supportedChains =
+    accountType === 'custody'
+      ? getCustodyAccountSupportedChains(state, selectedIdentity.address)
+      : null;
+
+  return supportedChains?.supportedChains
+    ? supportedChains.supportedChains.includes(
+        Number(provider.chainId).toString(),
+      )
+    : true;
 }

--- a/ui/selectors/institutional/selectors.js
+++ b/ui/selectors/institutional/selectors.js
@@ -1,0 +1,46 @@
+import { toChecksumAddress } from 'ethereumjs-util';
+
+export function getWaitForConfirmDeepLinkDialog(state) {
+  return state.metamask.waitForConfirmDeepLinkDialog;
+}
+
+export function getTransactionStatusMap(state) {
+  return state.metamask.custodyStatusMaps;
+}
+
+export function getCustodyAccountDetails(state) {
+  return state.metamask.custodyAccountDetails;
+}
+
+export function getCustodyAccountSupportedChains(state, address) {
+  return state.metamask.custodianSupportedChains
+    ? state.metamask.custodianSupportedChains[toChecksumAddress(address)]
+    : [];
+}
+
+export function getMmiPortfolioEnabled(state) {
+  return state.metamask.mmiConfiguration?.portfolio?.enabled;
+}
+
+export function getMmiPortfolioUrl(state) {
+  return state.metamask.mmiConfiguration?.portfolio?.url;
+}
+
+export function getConfiguredCustodians(state) {
+  return state.metamask.mmiConfiguration?.custodians || [];
+}
+
+export function getCustodianIconForAddress(state, address) {
+  let custodianIcon;
+
+  const checksummedAddress = toChecksumAddress(address);
+  if (state.metamask.custodyAccountDetails?.[checksummedAddress]) {
+    const { custodianName } =
+      state.metamask.custodyAccountDetails[checksummedAddress];
+    custodianIcon = state.metamask.mmiConfiguration?.custodians?.find(
+      (custodian) => custodian.name === custodianName,
+    )?.iconUrl;
+  }
+
+  return custodianIcon;
+}

--- a/ui/selectors/institutional/selectors.js
+++ b/ui/selectors/institutional/selectors.js
@@ -1,9 +1,5 @@
 import { toChecksumAddress } from 'ethereumjs-util';
-import {
-  getSelectedIdentity,
-  getAccountType,
-  getProvider,
-} from '../../selectors';
+import { getSelectedIdentity, getAccountType, getProvider } from '../selectors';
 
 export function getWaitForConfirmDeepLinkDialog(state) {
   return state.metamask.waitForConfirmDeepLinkDialog;

--- a/ui/selectors/institutional/selectors.test.js
+++ b/ui/selectors/institutional/selectors.test.js
@@ -69,21 +69,21 @@ describe('Institutional selectors', () => {
   describe('getWaitForConfirmDeepLinkDialog', () => {
     it('extracts a state property', () => {
       const result = getWaitForConfirmDeepLinkDialog(state);
-      expect(result).toEqual(state.metamask.waitForConfirmDeepLinkDialog);
+      expect(result).toStrictEqual(state.metamask.waitForConfirmDeepLinkDialog);
     });
   });
 
   describe('getCustodyAccountDetails', () => {
     it('extracts a state property', () => {
       const result = getCustodyAccountDetails(state);
-      expect(result).toEqual(state.metamask.custodyAccountDetails);
+      expect(result).toStrictEqual(state.metamask.custodyAccountDetails);
     });
   });
 
   describe('getTransactionStatusMap', () => {
     it('extracts a state property', () => {
       const result = getTransactionStatusMap(state);
-      expect(result).toEqual(state.metamask.custodyStatusMaps);
+      expect(result).toStrictEqual(state.metamask.custodyStatusMaps);
     });
   });
 
@@ -93,7 +93,7 @@ describe('Institutional selectors', () => {
         state,
         '0x5ab19e7091dd208f352f8e727b6dcc6f8abb6275',
       );
-      expect(result).toEqual(
+      expect(result).toStrictEqual(
         state.metamask.custodianSupportedChains[
           toChecksumAddress('0x5ab19e7091dd208f352f8e727b6dcc6f8abb6275')
         ],
@@ -104,21 +104,25 @@ describe('Institutional selectors', () => {
   describe('getMmiPortfolioEnabled', () => {
     it('extracts a state property', () => {
       const result = getMmiPortfolioEnabled(state);
-      expect(result).toEqual(state.metamask.mmiConfiguration.portfolio.enabled);
+      expect(result).toStrictEqual(
+        state.metamask.mmiConfiguration.portfolio.enabled,
+      );
     });
   });
 
   describe('getMmiPortfolioUrl', () => {
     it('extracts a state property', () => {
       const result = getMmiPortfolioUrl(state);
-      expect(result).toEqual(state.metamask.mmiConfiguration.portfolio.url);
+      expect(result).toStrictEqual(
+        state.metamask.mmiConfiguration.portfolio.url,
+      );
     });
   });
 
   describe('getConfiguredCustodians', () => {
     it('extracts a state property', () => {
       const result = getConfiguredCustodians(state);
-      expect(result).toEqual(state.metamask.mmiConfiguration.custodians);
+      expect(result).toStrictEqual(state.metamask.mmiConfiguration.custodians);
     });
   });
 
@@ -129,7 +133,7 @@ describe('Institutional selectors', () => {
         '0x5ab19e7091dd208f352f8e727b6dcc6f8abb6275',
       );
 
-      expect(result).toEqual(
+      expect(result).toStrictEqual(
         state.metamask.mmiConfiguration.custodians[0].iconUrl,
       );
     });
@@ -141,7 +145,7 @@ describe('Institutional selectors', () => {
         state,
         '0x5ab19e7091dd208f352f8e727b6dcc6f8abb6275',
       );
-      expect(result).toEqual(true);
+      expect(result).toStrictEqual(true);
     });
   });
 });

--- a/ui/selectors/institutional/selectors.test.js
+++ b/ui/selectors/institutional/selectors.test.js
@@ -1,0 +1,147 @@
+import { toChecksumAddress } from 'ethereumjs-util';
+import {
+  getConfiguredCustodians,
+  getCustodianIconForAddress,
+  getCustodyAccountDetails,
+  getCustodyAccountSupportedChains,
+  getMmiPortfolioEnabled,
+  getMmiPortfolioUrl,
+  getTransactionStatusMap,
+  getWaitForConfirmDeepLinkDialog,
+  getIsCustodianSupportedChain,
+} from './selectors';
+
+describe('Institutional selectors', () => {
+  const state = {
+    metamask: {
+      provider: {
+        type: 'test',
+        chainId: '1',
+      },
+      identities: {
+        '0x5Ab19e7091dD208F352F8E727B6DCC6F8aBB6275': {
+          name: 'Custody Account A',
+          address: '0x5Ab19e7091dD208F352F8E727B6DCC6F8aBB6275',
+        },
+      },
+      selectedAddress: '0x5Ab19e7091dD208F352F8E727B6DCC6F8aBB6275',
+      waitForConfirmDeepLinkDialog: '123',
+      keyrings: [
+        {
+          type: 'Custody',
+          accounts: ['0x5Ab19e7091dD208F352F8E727B6DCC6F8aBB6275'],
+        },
+      ],
+      custodyStatusMaps: '123',
+      custodyAccountDetails: {
+        '0x5Ab19e7091dD208F352F8E727B6DCC6F8aBB6275': {
+          custodianName: 'saturn',
+        },
+      },
+      custodianSupportedChains: {
+        '0x5Ab19e7091dD208F352F8E727B6DCC6F8aBB6275': {
+          supportedChains: ['1', '2'],
+          custodianName: 'saturn',
+        },
+      },
+      mmiConfiguration: {
+        portfolio: {
+          enabled: true,
+          url: 'https://dashboard.metamask-institutional.io',
+        },
+        custodians: [
+          {
+            type: 'saturn',
+            name: 'saturn',
+            apiUrl: 'https://saturn-custody.dev.metamask-institutional.io',
+            iconUrl: 'images/saturn.svg',
+            displayName: 'Saturn Custody',
+            production: true,
+            refreshTokenUrl: null,
+            isNoteToTraderSupported: false,
+            version: 1,
+          },
+        ],
+      },
+    },
+  };
+
+  describe('getWaitForConfirmDeepLinkDialog', () => {
+    it('extracts a state property', () => {
+      const result = getWaitForConfirmDeepLinkDialog(state);
+      expect(result).toEqual(state.metamask.waitForConfirmDeepLinkDialog);
+    });
+  });
+
+  describe('getCustodyAccountDetails', () => {
+    it('extracts a state property', () => {
+      const result = getCustodyAccountDetails(state);
+      expect(result).toEqual(state.metamask.custodyAccountDetails);
+    });
+  });
+
+  describe('getTransactionStatusMap', () => {
+    it('extracts a state property', () => {
+      const result = getTransactionStatusMap(state);
+      expect(result).toEqual(state.metamask.custodyStatusMaps);
+    });
+  });
+
+  describe('getCustodianSupportedChains', () => {
+    it('extracts a state property', () => {
+      const result = getCustodyAccountSupportedChains(
+        state,
+        '0x5ab19e7091dd208f352f8e727b6dcc6f8abb6275',
+      );
+      expect(result).toEqual(
+        state.metamask.custodianSupportedChains[
+          toChecksumAddress('0x5ab19e7091dd208f352f8e727b6dcc6f8abb6275')
+        ],
+      );
+    });
+  });
+
+  describe('getMmiPortfolioEnabled', () => {
+    it('extracts a state property', () => {
+      const result = getMmiPortfolioEnabled(state);
+      expect(result).toEqual(state.metamask.mmiConfiguration.portfolio.enabled);
+    });
+  });
+
+  describe('getMmiPortfolioUrl', () => {
+    it('extracts a state property', () => {
+      const result = getMmiPortfolioUrl(state);
+      expect(result).toEqual(state.metamask.mmiConfiguration.portfolio.url);
+    });
+  });
+
+  describe('getConfiguredCustodians', () => {
+    it('extracts a state property', () => {
+      const result = getConfiguredCustodians(state);
+      expect(result).toEqual(state.metamask.mmiConfiguration.custodians);
+    });
+  });
+
+  describe('getCustodianIconForAddress', () => {
+    it('extracts a state property', () => {
+      const result = getCustodianIconForAddress(
+        state,
+        '0x5ab19e7091dd208f352f8e727b6dcc6f8abb6275',
+      );
+
+      expect(result).toEqual(
+        state.metamask.mmiConfiguration.custodians[0].iconUrl,
+      );
+    });
+  });
+
+  describe('getIsCustodianSupportedChain', () => {
+    it('extracts a state property', () => {
+      const result = getIsCustodianSupportedChain(
+        state,
+        '0x5ab19e7091dd208f352f8e727b6dcc6f8abb6275',
+      );
+      expect(result).toEqual(true);
+    });
+  });
+});

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -227,6 +227,12 @@ export function getAccountType(state) {
   const currentKeyring = getCurrentKeyring(state);
   const type = currentKeyring && currentKeyring.type;
 
+  ///: BEGIN:ONLY_INCLUDE_IN(mmi)
+  if (type.startsWith('Custody')) {
+    return 'custody';
+  }
+  ///: END:ONLY_INCLUDE_IN
+
   switch (type) {
     case KeyringType.trezor:
     case KeyringType.ledger:


### PR DESCRIPTION
## Explanation

This PR adds a few MMI selectors under the `institutional/` folder to be used later.

## Pre-merge author checklist

- [X] I've clearly explained:
  - [X] What problem this PR is solving
  - [X] How this problem was solved

## Pre-merge reviewer checklist

- [X] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [X] PR is linked to the appropriate GitHub issue