### PR TITLE
Overriding gas estimate in the send page even if enough ETH is not available

### DIFF
--- a/ui/pages/send/send-content/send-content.component.js
+++ b/ui/pages/send/send-content/send-content.component.js
@@ -7,7 +7,6 @@ import {
   ETH_GAS_PRICE_FETCH_WARNING_KEY,
   GAS_PRICE_FETCH_FAILURE_ERROR_KEY,
   GAS_PRICE_EXCESSIVE_ERROR_KEY,
-  INSUFFICIENT_FUNDS_FOR_GAS_ERROR_KEY,
 } from '../../../helpers/constants/error-keys';
 import { AssetType } from '../../../../shared/constants/transaction';
 import { CONTRACT_ADDRESS_LINK } from '../../../helpers/constants/common';
@@ -30,7 +29,6 @@ export default class SendContent extends Component {
     isEthGasPrice: PropTypes.bool,
     noGasPrice: PropTypes.bool,
     networkOrAccountNotSupports1559: PropTypes.bool,
-    getIsBalanceInsufficient: PropTypes.bool,
     asset: PropTypes.object,
     assetError: PropTypes.string,
     recipient: PropTypes.object,
@@ -46,7 +44,6 @@ export default class SendContent extends Component {
       isEthGasPrice,
       noGasPrice,
       networkOrAccountNotSupports1559,
-      getIsBalanceInsufficient,
       asset,
       assetError,
       recipient,
@@ -58,8 +55,6 @@ export default class SendContent extends Component {
       gasError = GAS_PRICE_EXCESSIVE_ERROR_KEY;
     } else if (noGasPrice) {
       gasError = GAS_PRICE_FETCH_FAILURE_ERROR_KEY;
-    } else if (getIsBalanceInsufficient) {
-      gasError = INSUFFICIENT_FUNDS_FOR_GAS_ERROR_KEY;
     }
     const showHexData =
       this.props.showHexData &&

--- a/ui/pages/send/send-content/send-content.component.test.js
+++ b/ui/pages/send/send-content/send-content.component.test.js
@@ -4,7 +4,6 @@ import configureMockStore from 'redux-mock-store';
 
 import { renderWithProvider } from '../../../../test/lib/render-helpers';
 import mockSendState from '../../../../test/data/mock-send-state.json';
-import { INSUFFICIENT_FUNDS_ERROR } from '../send.constants';
 import SendContent from '.';
 
 jest.mock('../../../store/actions', () => ({
@@ -136,41 +135,6 @@ describe('SendContent Component', () => {
       };
 
       const mockStore = configureMockStore()(noGasPriceState);
-
-      const { queryByTestId } = renderWithProvider(
-        <SendContent {...props} />,
-        mockStore,
-      );
-
-      const gasWarning = queryByTestId('gas-warning-message');
-
-      await waitFor(() => {
-        expect(gasWarning).toBeInTheDocument();
-      });
-    });
-
-    it('should show gas warning for gas error state in draft transaction', async () => {
-      const props = {
-        gasIsExcessive: false,
-        showHexData: false,
-      };
-
-      const gasErrorState = {
-        ...mockSendState,
-        send: {
-          ...mockSendState.send,
-          draftTransactions: {
-            '1-tx': {
-              ...mockSendState.send.draftTransactions['1-tx'],
-              gas: {
-                error: INSUFFICIENT_FUNDS_ERROR,
-              },
-            },
-          },
-        },
-      };
-
-      const mockStore = configureMockStore()(gasErrorState);
 
       const { queryByTestId } = renderWithProvider(
         <SendContent {...props} />,

--- a/ui/pages/send/send-footer/send-footer.component.js
+++ b/ui/pages/send/send-footer/send-footer.component.js
@@ -8,6 +8,7 @@ import {
 } from '../../../helpers/constants/routes';
 import { MetaMetricsEventCategory } from '../../../../shared/constants/metametrics';
 import { SEND_STAGES } from '../../../ducks/send';
+import { INSUFFICIENT_FUNDS_ERROR } from '../send.constants';
 
 export default class SendFooter extends Component {
   static propTypes = {
@@ -92,12 +93,14 @@ export default class SendFooter extends Component {
 
   render() {
     const { t } = this.context;
-    const { sendStage } = this.props;
+    const { sendStage, sendErrors } = this.props;
     return (
       <PageContainerFooter
         onCancel={() => this.onCancel()}
         onSubmit={(e) => this.onSubmit(e)}
-        disabled={this.props.disabled}
+        disabled={
+          this.props.disabled && sendErrors.gasFee !== INSUFFICIENT_FUNDS_ERROR
+        }
         cancelText={sendStage === SEND_STAGES.EDIT ? t('reject') : t('cancel')}
       />
     );


### PR DESCRIPTION
## Explanation

Fixes #17966 
Removing the gas warning and enabling the next button on the send page even when enough ETH is not available for gas.

## Manual Testing Steps
1. Start a send transaction
2. Enter the maximum amount 
3. Make sure the gas warning message is not displayed and `Next` button is active

## Pre-merge author checklist

- [ ] I've clearly explained:
  - [ ] What problem this PR is solving
  - [ ] How this problem was solved
  - [ ] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
