### PR TITLE
[FLASK] Remove unused snaps code

### DIFF
--- a/.storybook/test-data.js
+++ b/.storybook/test-data.js
@@ -263,12 +263,12 @@ const state = {
         enabled: true,
         id: 'local:http://localhost:8080/',
         initialPermissions: {
-          snap_confirm: {},
+          snap_dialog: {},
         },
         manifest: {
           description: 'An example MetaMask Snap.',
           initialPermissions: {
-            snap_confirm: {},
+            snap_dialog: {},
           },
           manifestVersion: '0.1',
           proposedName: 'MetaMask Example Snap',
@@ -298,7 +298,7 @@ const state = {
         enabled: true,
         id: 'npm:http://localhost:8080/',
         initialPermissions: {
-          snap_confirm: {},
+          snap_dialog: {},
           eth_accounts: {},
           snap_manageState: {},
         },
@@ -306,7 +306,7 @@ const state = {
           description:
             'This swap provides developers everywhere access to an entirely new data storage paradigm, even letting your programs store data autonomously. Learn more.',
           initialPermissions: {
-            snap_confirm: {},
+            snap_dialog: {},
             eth_accounts: {},
             snap_manageState: {},
           },
@@ -1349,9 +1349,9 @@ const state = {
       },
       'local:http://localhost:8080/': {
         permissions: {
-          snap_confirm: {
+          snap_dialog: {
             invoker: 'local:http://localhost:8080/',
-            parentCapability: 'snap_confirm',
+            parentCapability: 'snap_dialog',
             id: 'a7342F4b-beae-4525-a36c-c0635fd03359',
             date: 1620710693178,
             caveats: [],

--- a/app/_locales/de/messages.json
+++ b/app/_locales/de/messages.json
@@ -2697,10 +2697,6 @@
     "message": "Regelmäßige Transaktionen planen und ausführen.",
     "description": "The description for the `snap_cronjob` permission"
   },
-  "permission_customConfirmation": {
-    "message": "Bestätigung in MetaMask anzeigen.",
-    "description": "The description for the `snap_confirm` permission"
-  },
   "permission_dialog": {
     "message": "Dialogfenster in MetaMask anzeigen.",
     "description": "The description for the `snap_dialog` permission"

--- a/app/_locales/el/messages.json
+++ b/app/_locales/el/messages.json
@@ -2697,10 +2697,6 @@
     "message": "Προγραμματισμός και εκτέλεση περιοδικών ενεργειών.",
     "description": "The description for the `snap_cronjob` permission"
   },
-  "permission_customConfirmation": {
-    "message": "Εμφάνιση επιβεβαίωσης στο MetaMask.",
-    "description": "The description for the `snap_confirm` permission"
-  },
   "permission_dialog": {
     "message": "Εμφάνιση παραθύρων διαλόγου στο MetaMask.",
     "description": "The description for the `snap_dialog` permission"

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -2914,14 +2914,6 @@
     "message": "Allow the snap to perform actions that run periodically at fixed times, dates, or intervals. This can be used to trigger time-sensitive interactions or notifications.",
     "description": "An extended description for the `snap_cronjob` permission"
   },
-  "permission_customConfirmation": {
-    "message": "Display a confirmation in MetaMask.",
-    "description": "The description for the `snap_confirm` permission"
-  },
-  "permission_customConfirmationDescription": {
-    "message": "Allow the snap to display MetaMask popups with custom text, and buttons to approve or reject an action.",
-    "description": "An extended description for the `snap_confirm` permission"
-  },
   "permission_dialog": {
     "message": "Display dialog windows in MetaMask.",
     "description": "The description for the `snap_dialog` permission"

--- a/app/_locales/es/messages.json
+++ b/app/_locales/es/messages.json
@@ -2697,10 +2697,6 @@
     "message": "Programar y ejecutar acciones periódicas.",
     "description": "The description for the `snap_cronjob` permission"
   },
-  "permission_customConfirmation": {
-    "message": "Mostrar una confirmación en MetaMask.",
-    "description": "The description for the `snap_confirm` permission"
-  },
   "permission_dialog": {
     "message": "Mostrar ventanas de diálogo en MetaMask.",
     "description": "The description for the `snap_dialog` permission"

--- a/app/_locales/fr/messages.json
+++ b/app/_locales/fr/messages.json
@@ -2697,10 +2697,6 @@
     "message": "Planifiez et exécutez des actions périodiques.",
     "description": "The description for the `snap_cronjob` permission"
   },
-  "permission_customConfirmation": {
-    "message": "Afficher une confirmation dans MetaMask.",
-    "description": "The description for the `snap_confirm` permission"
-  },
   "permission_dialog": {
     "message": "Afficher les boîtes de dialogue dans MetaMask.",
     "description": "The description for the `snap_dialog` permission"

--- a/app/_locales/hi/messages.json
+++ b/app/_locales/hi/messages.json
@@ -2697,10 +2697,6 @@
     "message": "समय-समय पर आने वाले क्रियाओं को शेड्यूल और निष्पादित करें।",
     "description": "The description for the `snap_cronjob` permission"
   },
-  "permission_customConfirmation": {
-    "message": "MetaMask में पुष्टि को दर्शाएं।",
-    "description": "The description for the `snap_confirm` permission"
-  },
   "permission_dialog": {
     "message": "MetaMask में डायलॉग विंडो प्रदर्शित करें।",
     "description": "The description for the `snap_dialog` permission"

--- a/app/_locales/id/messages.json
+++ b/app/_locales/id/messages.json
@@ -2697,10 +2697,6 @@
     "message": "Jadwalkan dan lakukan tindakan berkala.",
     "description": "The description for the `snap_cronjob` permission"
   },
-  "permission_customConfirmation": {
-    "message": "Tampilkan konfirmasi di MetaMask.",
-    "description": "The description for the `snap_confirm` permission"
-  },
   "permission_dialog": {
     "message": "Tampilkan jendela dialog di MetaMask.",
     "description": "The description for the `snap_dialog` permission"

--- a/app/_locales/ja/messages.json
+++ b/app/_locales/ja/messages.json
@@ -2697,10 +2697,6 @@
     "message": "定期的なアクションのスケジュール設定と実行。",
     "description": "The description for the `snap_cronjob` permission"
   },
-  "permission_customConfirmation": {
-    "message": "MetaMask に確認を表示します。",
-    "description": "The description for the `snap_confirm` permission"
-  },
   "permission_dialog": {
     "message": "MetaMask にダイアログウィンドウを表示します。",
     "description": "The description for the `snap_dialog` permission"

--- a/app/_locales/ko/messages.json
+++ b/app/_locales/ko/messages.json
@@ -2697,10 +2697,6 @@
     "message": "정기적 활동 예약 및 실행",
     "description": "The description for the `snap_cronjob` permission"
   },
-  "permission_customConfirmation": {
-    "message": "MetaMask에 확인을 표시합니다.",
-    "description": "The description for the `snap_confirm` permission"
-  },
   "permission_dialog": {
     "message": "MetaMask 대화창 표시",
     "description": "The description for the `snap_dialog` permission"

--- a/app/_locales/pt/messages.json
+++ b/app/_locales/pt/messages.json
@@ -2697,10 +2697,6 @@
     "message": "Agende e execute ações periódicas.",
     "description": "The description for the `snap_cronjob` permission"
   },
-  "permission_customConfirmation": {
-    "message": "Exibir uma confirmação na MetaMask.",
-    "description": "The description for the `snap_confirm` permission"
-  },
   "permission_dialog": {
     "message": "Exibir janelas de diálogo na MetaMask.",
     "description": "The description for the `snap_dialog` permission"

--- a/app/_locales/ru/messages.json
+++ b/app/_locales/ru/messages.json
@@ -2697,10 +2697,6 @@
     "message": "Планируйте и выполняйте периодические действия.",
     "description": "The description for the `snap_cronjob` permission"
   },
-  "permission_customConfirmation": {
-    "message": "Показать подтверждение в MetaMask.",
-    "description": "The description for the `snap_confirm` permission"
-  },
   "permission_dialog": {
     "message": "Отображение диалоговых окон в MetaMask.",
     "description": "The description for the `snap_dialog` permission"

--- a/app/_locales/tl/messages.json
+++ b/app/_locales/tl/messages.json
@@ -2697,10 +2697,6 @@
     "message": "Mag-iskedyul at magsagawa ng mga pana-panahong mga aksyon.",
     "description": "The description for the `snap_cronjob` permission"
   },
-  "permission_customConfirmation": {
-    "message": "Ipakita ang kumpirmasyon sa MetaMask.",
-    "description": "The description for the `snap_confirm` permission"
-  },
   "permission_dialog": {
     "message": "Ipakita ang mga dialog window sa MetaMask.",
     "description": "The description for the `snap_dialog` permission"

--- a/app/_locales/tr/messages.json
+++ b/app/_locales/tr/messages.json
@@ -2697,10 +2697,6 @@
     "message": "Periyodik eylemleri planla ve gerçekleştir.",
     "description": "The description for the `snap_cronjob` permission"
   },
-  "permission_customConfirmation": {
-    "message": "MetaMask'te bir onay görüntüle.",
-    "description": "The description for the `snap_confirm` permission"
-  },
   "permission_dialog": {
     "message": "MetaMask'te iletişim kutusu pencerelerini göster.",
     "description": "The description for the `snap_dialog` permission"

--- a/app/_locales/vi/messages.json
+++ b/app/_locales/vi/messages.json
@@ -2697,10 +2697,6 @@
     "message": "Lên lịch và thực hiện các hành động theo định kỳ.",
     "description": "The description for the `snap_cronjob` permission"
   },
-  "permission_customConfirmation": {
-    "message": "Hiển thị xác nhận trong MetaMask.",
-    "description": "The description for the `snap_confirm` permission"
-  },
   "permission_dialog": {
     "message": "Hiển thị cửa sổ hộp thoại trong MetaMask.",
     "description": "The description for the `snap_dialog` permission"

--- a/app/_locales/zh_CN/messages.json
+++ b/app/_locales/zh_CN/messages.json
@@ -2697,10 +2697,6 @@
     "message": "规划并执行定期操作。",
     "description": "The description for the `snap_cronjob` permission"
   },
-  "permission_customConfirmation": {
-    "message": "在MetaMask中显示确认。",
-    "description": "The description for the `snap_confirm` permission"
-  },
   "permission_dialog": {
     "message": "在 MetaMask 中显示对话框窗口。",
     "description": "The description for the `snap_dialog` permission"

--- a/app/scripts/controllers/permissions/flask/snap-permissions.test.js
+++ b/app/scripts/controllers/permissions/flask/snap-permissions.test.js
@@ -16,7 +16,6 @@ describe('buildSnapRestrictedMethodSpecifications', () => {
       getSnap: () => undefined,
       getSnapRpcHandler: () => undefined,
       getSnapState: () => undefined,
-      showConfirmation: () => undefined,
       updateSnapState: () => undefined,
     };
 

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -1527,12 +1527,6 @@ export default class MetamaskController extends EventEmitter {
           this.controllerMessenger,
           'SnapController:getSnapState',
         ),
-        showConfirmation: (origin, confirmationData) =>
-          this.approvalController.addAndShowApprovalRequest({
-            origin,
-            type: MESSAGE_TYPE.SNAP_DIALOG_CONFIRMATION,
-            requestData: confirmationData,
-          }),
         showDialog: (origin, type, content, placeholder) =>
           this.approvalController.addAndShowApprovalRequest({
             origin,
@@ -3240,32 +3234,6 @@ export default class MetamaskController extends EventEmitter {
     return await this.txController.newUnapprovedTransaction(txParams, req);
   }
 
-  ///: BEGIN:ONLY_INCLUDE_IN(flask)
-  /**
-   * Gets an "app key" corresponding to an Ethereum address. An app key is more
-   * or less an addrdess hashed together with some string, in this case a
-   * subject identifier / origin.
-   *
-   * @todo Figure out a way to derive app keys that doesn't depend on the user's
-   * Ethereum addresses.
-   * @param {string} subject - The identifier of the subject whose app key to
-   * retrieve.
-   * @param {string} [requestedAccount] - The account whose app key to retrieve.
-   * The first account in the keyring will be used by default.
-   */
-  async getAppKeyForSubject(subject, requestedAccount) {
-    let account;
-
-    if (requestedAccount) {
-      account = requestedAccount;
-    } else {
-      [account] = await this.keyringController.getAccounts();
-    }
-
-    return this.keyringController.exportAppKeyForAddress(account, subject);
-  }
-  ///: END:ONLY_INCLUDE_IN
-
   // eth_decrypt methods
 
   /**
@@ -3871,7 +3839,6 @@ export default class MetamaskController extends EventEmitter {
     ///: BEGIN:ONLY_INCLUDE_IN(flask)
     engine.push(
       createSnapMethodMiddleware(subjectType === SubjectType.Snap, {
-        getAppKey: this.getAppKeyForSubject.bind(this, origin),
         getUnlockPromise: this.appStateController.getUnlockPromise.bind(
           this.appStateController,
         ),

--- a/ui/helpers/utils/permission.js
+++ b/ui/helpers/utils/permission.js
@@ -71,12 +71,6 @@ export const PERMISSION_DESCRIPTIONS = deepFreeze({
     weight: 2,
   }),
   ///: BEGIN:ONLY_INCLUDE_IN(flask)
-  [RestrictedMethods.snap_confirm]: ({ t }) => ({
-    label: t('permission_customConfirmation'),
-    description: t('permission_customConfirmationDescription'),
-    leftIcon: ICON_NAMES.SECURITY_TICK,
-    weight: 3,
-  }),
   [RestrictedMethods.snap_dialog]: ({ t }) => ({
     label: t('permission_dialog'),
     description: t('permission_dialogDescription'),

--- a/ui/pages/confirmation/templates/flask/snap-confirmation/snap-confirmation.js
+++ b/ui/pages/confirmation/templates/flask/snap-confirmation/snap-confirmation.js
@@ -1,11 +1,10 @@
-import { TypographyVariant } from '../../../../../helpers/constants/design-system';
 import { mapToTemplate } from '../../../../../components/app/flask/snap-ui-renderer';
 import { DelineatorType } from '../../../../../helpers/constants/flask';
 
 function getValues(pendingApproval, t, actions) {
   const {
     snapName,
-    requestData: { content, title, description, textAreaContent },
+    requestData: { content },
   } = pendingApproval;
 
   return {

--- a/ui/pages/confirmation/templates/flask/snap-confirmation/snap-confirmation.js
+++ b/ui/pages/confirmation/templates/flask/snap-confirmation/snap-confirmation.js
@@ -25,49 +25,7 @@ function getValues(pendingApproval, t, actions) {
             snapName,
           },
           // TODO: Replace with SnapUIRenderer when we don't need to inject the input manually.
-          // TODO: Remove ternary once snap_confirm has been removed.
-          children: content
-            ? mapToTemplate(content)
-            : [
-                {
-                  element: 'Typography',
-                  key: 'title',
-                  children: title,
-                  props: {
-                    variant: TypographyVariant.H3,
-                    fontWeight: 'bold',
-                    boxProps: {
-                      marginBottom: 4,
-                    },
-                  },
-                },
-                ...(description
-                  ? [
-                      {
-                        element: 'Typography',
-                        key: 'subtitle',
-                        children: description,
-                        props: {
-                          variant: TypographyVariant.H6,
-                          boxProps: {
-                            marginBottom: 4,
-                          },
-                        },
-                      },
-                    ]
-                  : []),
-                ...(textAreaContent
-                  ? [
-                      {
-                        element: 'Copyable',
-                        key: 'snap-dialog-content-text',
-                        props: {
-                          text: textAreaContent,
-                        },
-                      },
-                    ]
-                  : []),
-              ],
+          children: mapToTemplate(content),
         },
       },
     ],


### PR DESCRIPTION
## Explanation

- Removes some unused code after `snap_confirm` was removed in an earlier snaps release.
- Removes some unused code for "app keys", which we also removed in an earlier release.