### PR TITLE
Make `_switchNetwork` async

### DIFF
--- a/app/scripts/controllers/network/network-controller.ts
+++ b/app/scripts/controllers/network/network-controller.ts
@@ -904,14 +904,14 @@ export class NetworkController extends EventEmitter {
    * @param providerConfig - The provider configuration object that specifies
    * the new network.
    */
-  _switchNetwork(providerConfig: ProviderConfiguration): void {
+  async _switchNetwork(providerConfig: ProviderConfiguration) {
     this.messenger.publish(NetworkControllerEventType.NetworkWillChange);
     this._resetNetworkId();
     this._resetNetworkStatus();
     this._resetNetworkDetails();
     this._configureProvider(providerConfig);
     this.messenger.publish(NetworkControllerEventType.NetworkDidChange);
-    this.lookupNetwork();
+    await this.lookupNetwork();
   }
 
   /**


### PR DESCRIPTION
## Explanation

The network controller internal method `_switchNetwork` has been made async, and the `lookupNetwork` call is now awaited. Because this method is only used internally, and because the `await`-ed async operation was the last operation in this function, this change has no functional impact whatsoever.

Relates to https://github.com/MetaMask/metamask-extension/issues/18587

## Manual Testing Steps

No functional changes.

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
