### PR TITLE
Make `rollbackToPreviousProvider` async

### DIFF
--- a/app/scripts/controllers/network/network-controller.test.ts
+++ b/app/scripts/controllers/network/network-controller.test.ts
@@ -5761,8 +5761,8 @@ describe('NetworkController', () => {
 
               await waitForLookupNetworkToComplete({
                 controller,
-                operation: () => {
-                  controller.rollbackToPreviousProvider();
+                operation: async () => {
+                  await controller.rollbackToPreviousProvider();
                 },
               });
               expect(controller.store.getState().provider).toStrictEqual({
@@ -5827,8 +5827,8 @@ describe('NetworkController', () => {
                   const networkWillChange = await waitForPublishedEvents({
                     messenger: unrestrictedMessenger,
                     eventType: NetworkControllerEventType.NetworkWillChange,
-                    operation: () => {
-                      controller.rollbackToPreviousProvider();
+                    operation: async () => {
+                      await controller.rollbackToPreviousProvider();
                     },
                   });
 
@@ -5891,6 +5891,8 @@ describe('NetworkController', () => {
                     // happens before networkDidChange
                     count: 1,
                     operation: () => {
+                      // Intentionally not awaited because we want to check state
+                      // while this operation is in-progress
                       controller.rollbackToPreviousProvider();
                     },
                   });
@@ -5959,6 +5961,8 @@ describe('NetworkController', () => {
                     // happens before networkDidChange
                     count: 1,
                     operation: () => {
+                      // Intentionally not awaited because we want to check state
+                      // while this operation is in-progress
                       controller.rollbackToPreviousProvider();
                     },
                   });
@@ -6015,8 +6019,8 @@ describe('NetworkController', () => {
 
               await waitForLookupNetworkToComplete({
                 controller,
-                operation: () => {
-                  controller.rollbackToPreviousProvider();
+                operation: async () => {
+                  await controller.rollbackToPreviousProvider();
                 },
               });
 
@@ -6077,8 +6081,8 @@ describe('NetworkController', () => {
                 controller.getProviderAndBlockTracker();
               await waitForLookupNetworkToComplete({
                 controller,
-                operation: () => {
-                  controller.rollbackToPreviousProvider();
+                operation: async () => {
+                  await controller.rollbackToPreviousProvider();
                 },
               });
               const { provider: providerAfter } =
@@ -6138,8 +6142,8 @@ describe('NetworkController', () => {
                   const networkDidChange = await waitForPublishedEvents({
                     messenger: unrestrictedMessenger,
                     eventType: NetworkControllerEventType.NetworkDidChange,
-                    operation: () => {
-                      controller.rollbackToPreviousProvider();
+                    operation: async () => {
+                      await controller.rollbackToPreviousProvider();
                     },
                   });
                   expect(networkDidChange).toBeTruthy();
@@ -6203,7 +6207,7 @@ describe('NetworkController', () => {
               await waitForLookupNetworkToComplete({
                 controller,
                 operation: async () => {
-                  controller.rollbackToPreviousProvider();
+                  await controller.rollbackToPreviousProvider();
                 },
               });
 
@@ -6266,8 +6270,8 @@ describe('NetworkController', () => {
 
               await waitForLookupNetworkToComplete({
                 controller,
-                operation: () => {
-                  controller.rollbackToPreviousProvider();
+                operation: async () => {
+                  await controller.rollbackToPreviousProvider();
                 },
               });
               expect(controller.store.getState().networkStatus).toBe(
@@ -6323,8 +6327,8 @@ describe('NetworkController', () => {
               await waitForLookupNetworkToComplete({
                 controller,
                 numberOfNetworkDetailsChanges: 2,
-                operation: () => {
-                  controller.rollbackToPreviousProvider();
+                operation: async () => {
+                  await controller.rollbackToPreviousProvider();
                 },
               });
               expect(controller.store.getState().networkDetails).toStrictEqual({
@@ -6408,8 +6412,8 @@ describe('NetworkController', () => {
 
             await waitForLookupNetworkToComplete({
               controller,
-              operation: () => {
-                controller.rollbackToPreviousProvider();
+              operation: async () => {
+                await controller.rollbackToPreviousProvider();
               },
             });
             expect(controller.store.getState().provider).toStrictEqual({
@@ -6475,8 +6479,8 @@ describe('NetworkController', () => {
                 const networkWillChange = await waitForPublishedEvents({
                   messenger: unrestrictedMessenger,
                   eventType: NetworkControllerEventType.NetworkWillChange,
-                  operation: () => {
-                    controller.rollbackToPreviousProvider();
+                  operation: async () => {
+                    await controller.rollbackToPreviousProvider();
                   },
                 });
 
@@ -6532,6 +6536,8 @@ describe('NetworkController', () => {
                   // happens before networkDidChange
                   count: 1,
                   operation: () => {
+                    // Intentionally not awaited because we want to check state
+                    // while this operation is in-progress
                     controller.rollbackToPreviousProvider();
                   },
                 });
@@ -6595,6 +6601,8 @@ describe('NetworkController', () => {
                   // happens before networkDidChange
                   count: 1,
                   operation: () => {
+                    // Intentionally not awaited because we want to check state
+                    // while this operation is in-progress
                     controller.rollbackToPreviousProvider();
                   },
                 });
@@ -6646,8 +6654,8 @@ describe('NetworkController', () => {
 
             await waitForLookupNetworkToComplete({
               controller,
-              operation: () => {
-                controller.rollbackToPreviousProvider();
+              operation: async () => {
+                await controller.rollbackToPreviousProvider();
               },
             });
 
@@ -6703,8 +6711,8 @@ describe('NetworkController', () => {
               controller.getProviderAndBlockTracker();
             await waitForLookupNetworkToComplete({
               controller,
-              operation: () => {
-                controller.rollbackToPreviousProvider();
+              operation: async () => {
+                await controller.rollbackToPreviousProvider();
               },
             });
             const { provider: providerAfter } =
@@ -6759,8 +6767,8 @@ describe('NetworkController', () => {
                 const networkDidChange = await waitForPublishedEvents({
                   messenger: unrestrictedMessenger,
                   eventType: NetworkControllerEventType.NetworkDidChange,
-                  operation: () => {
-                    controller.rollbackToPreviousProvider();
+                  operation: async () => {
+                    await controller.rollbackToPreviousProvider();
                   },
                 });
                 expect(networkDidChange).toBeTruthy();
@@ -6814,8 +6822,8 @@ describe('NetworkController', () => {
                 const infuraIsUnblocked = await waitForPublishedEvents({
                   messenger: unrestrictedMessenger,
                   eventType: NetworkControllerEventType.InfuraIsUnblocked,
-                  operation: () => {
-                    controller.rollbackToPreviousProvider();
+                  operation: async () => {
+                    await controller.rollbackToPreviousProvider();
                   },
                 });
 
@@ -6871,8 +6879,8 @@ describe('NetworkController', () => {
 
             await waitForLookupNetworkToComplete({
               controller,
-              operation: () => {
-                controller.rollbackToPreviousProvider();
+              operation: async () => {
+                await controller.rollbackToPreviousProvider();
               },
             });
             expect(controller.store.getState().networkStatus).toBe('unknown');
@@ -6925,8 +6933,8 @@ describe('NetworkController', () => {
 
             await waitForLookupNetworkToComplete({
               controller,
-              operation: () => {
-                controller.rollbackToPreviousProvider();
+              operation: async () => {
+                await controller.rollbackToPreviousProvider();
               },
             });
             expect(controller.store.getState().networkDetails).toStrictEqual({

--- a/app/scripts/controllers/network/network-controller.ts
+++ b/app/scripts/controllers/network/network-controller.ts
@@ -787,10 +787,10 @@ export class NetworkController extends EventEmitter {
    * different than the initial network (if it is, then this is equivalent to
    * calling `resetConnection`).
    */
-  rollbackToPreviousProvider(): void {
+  async rollbackToPreviousProvider() {
     const config = this.#previousProviderConfig;
     this.providerStore.putState(config);
-    this._switchNetwork(config);
+    await this._switchNetwork(config);
   }
 
   /**


### PR DESCRIPTION
## Explanation

The network controller method `rollbackToPreviousProvider` is now async. It will resolve when the network switch has completed.

Relates to https://github.com/MetaMask/metamask-extension/issues/18587

## Manual Testing Steps

There are no functional changes.

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
