### PR TITLE
Make `_setProviderConfig` async

### DIFF
--- a/app/scripts/controllers/network/network-controller.ts
+++ b/app/scripts/controllers/network/network-controller.ts
@@ -866,10 +866,10 @@ export class NetworkController extends EventEmitter {
    *
    * @param providerConfig - The provider configuration.
    */
-  _setProviderConfig(providerConfig: ProviderConfiguration): void {
+  async _setProviderConfig(providerConfig: ProviderConfiguration) {
     this.#previousProviderConfig = this.providerStore.getState();
     this.providerStore.putState(providerConfig);
-    this._switchNetwork(providerConfig);
+    await this._switchNetwork(providerConfig);
   }
 
   /**


### PR DESCRIPTION
## Explanation

The network controller internal method `_setProviderConfig` has been made async, the async `_switchNetwork` operation is now `await`-ed.

Since the `_switchNetwork` call was the last operation, this has zero functional impact.

Relates to https://github.com/MetaMask/metamask-extension/issues/18587

## Manual Testing Steps

No functional changes

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
