### PR TITLE
Make `resetConnection` async

### DIFF
--- a/app/scripts/controllers/network/network-controller.test.ts
+++ b/app/scripts/controllers/network/network-controller.test.ts
@@ -4992,6 +4992,8 @@ describe('NetworkController', () => {
                 messenger: unrestrictedMessenger,
                 eventType: NetworkControllerEventType.NetworkWillChange,
                 operation: () => {
+                  // Intentionally not awaited because we want to capture an
+                  // event emitted partway throught this operation
                   controller.resetConnection();
                 },
               });
@@ -5032,6 +5034,8 @@ describe('NetworkController', () => {
                 // happens before networkDidChange
                 count: 1,
                 operation: () => {
+                  // Intentionally not awaited because we want to capture a
+                  // state change made partway through the operation
                   controller.resetConnection();
                 },
               });
@@ -5074,6 +5078,8 @@ describe('NetworkController', () => {
                 // happens before networkDidChange
                 count: 1,
                 operation: () => {
+                  // Intentionally not awaited because we want to check state
+                  // partway through the operation
                   controller.resetConnection();
                 },
               });
@@ -5101,7 +5107,7 @@ describe('NetworkController', () => {
             async ({ controller, network }) => {
               network.mockEssentialRpcCalls();
 
-              controller.resetConnection();
+              await controller.resetConnection();
 
               const { provider } = controller.getProviderAndBlockTracker();
               assert(provider, 'Provider is somehow unset');
@@ -5140,7 +5146,7 @@ describe('NetworkController', () => {
 
               const { provider: providerBefore } =
                 controller.getProviderAndBlockTracker();
-              controller.resetConnection();
+              await controller.resetConnection();
               const { provider: providerAfter } =
                 controller.getProviderAndBlockTracker();
 
@@ -5171,8 +5177,8 @@ describe('NetworkController', () => {
               const networkDidChange = await waitForPublishedEvents({
                 messenger: unrestrictedMessenger,
                 eventType: NetworkControllerEventType.NetworkDidChange,
-                operation: () => {
-                  controller.resetConnection();
+                operation: async () => {
+                  await controller.resetConnection();
                 },
               });
 
@@ -5214,7 +5220,7 @@ describe('NetworkController', () => {
                 eventType: NetworkControllerEventType.InfuraIsBlocked,
               });
 
-              controller.resetConnection();
+              await controller.resetConnection();
 
               expect(await promiseForNoInfuraIsUnblockedEvents).toBeTruthy();
               expect(await promiseForInfuraIsBlocked).toBeTruthy();
@@ -5237,13 +5243,7 @@ describe('NetworkController', () => {
             async ({ controller, network }) => {
               network.mockEssentialRpcCalls();
 
-              await waitForStateChanges({
-                controller,
-                propertyPath: ['networkStatus'],
-                operation: () => {
-                  controller.resetConnection();
-                },
-              });
+              await controller.resetConnection();
 
               expect(controller.store.getState().networkStatus).toBe(
                 'available',
@@ -5275,13 +5275,7 @@ describe('NetworkController', () => {
                 },
               });
 
-              await waitForStateChanges({
-                controller,
-                propertyPath: ['networkDetails'],
-                operation: () => {
-                  controller.resetConnection();
-                },
-              });
+              await controller.resetConnection();
 
               expect(controller.store.getState().networkDetails).toStrictEqual({
                 EIPS: {
@@ -5326,6 +5320,8 @@ describe('NetworkController', () => {
               messenger: unrestrictedMessenger,
               eventType: NetworkControllerEventType.NetworkWillChange,
               operation: () => {
+                // Intentionally not awaited because we're capturing an event
+                // emitted partway through the operation
                 controller.resetConnection();
               },
             });
@@ -5376,6 +5372,8 @@ describe('NetworkController', () => {
               // before networkDidChange
               count: 1,
               operation: () => {
+                // Intentionally not awaited because we want to check state
+                // partway through the operation
                 controller.resetConnection();
               },
             });
@@ -5426,6 +5424,8 @@ describe('NetworkController', () => {
               // before networkDidChange
               count: 1,
               operation: () => {
+                // Intentionally not awaited because we want to check state
+                // partway through the operation
                 controller.resetConnection();
               },
             });
@@ -5461,7 +5461,7 @@ describe('NetworkController', () => {
           async ({ controller, network }) => {
             network.mockEssentialRpcCalls();
 
-            controller.resetConnection();
+            await controller.resetConnection();
 
             const { provider } = controller.getProviderAndBlockTracker();
             assert(provider, 'Provider is somehow unset');
@@ -5508,12 +5508,7 @@ describe('NetworkController', () => {
 
             const { provider: providerBefore } =
               controller.getProviderAndBlockTracker();
-            await waitForLookupNetworkToComplete({
-              controller,
-              operation: () => {
-                controller.resetConnection();
-              },
-            });
+            await controller.resetConnection();
             const { provider: providerAfter } =
               controller.getProviderAndBlockTracker();
 
@@ -5552,8 +5547,8 @@ describe('NetworkController', () => {
             const networkDidChange = await waitForPublishedEvents({
               messenger: unrestrictedMessenger,
               eventType: NetworkControllerEventType.NetworkDidChange,
-              operation: () => {
-                controller.resetConnection();
+              operation: async () => {
+                await controller.resetConnection();
               },
             });
 
@@ -5592,8 +5587,8 @@ describe('NetworkController', () => {
             const infuraIsUnblocked = await waitForPublishedEvents({
               messenger: unrestrictedMessenger,
               eventType: NetworkControllerEventType.InfuraIsUnblocked,
-              operation: () => {
-                controller.resetConnection();
+              operation: async () => {
+                await controller.resetConnection();
               },
             });
 
@@ -5630,13 +5625,7 @@ describe('NetworkController', () => {
             });
             expect(controller.store.getState().networkStatus).toBe('unknown');
 
-            await waitForStateChanges({
-              controller,
-              propertyPath: ['networkStatus'],
-              operation: () => {
-                controller.resetConnection();
-              },
-            });
+            await controller.resetConnection();
 
             expect(controller.store.getState().networkStatus).toBe('available');
           },
@@ -5674,13 +5663,7 @@ describe('NetworkController', () => {
               },
             });
 
-            await waitForStateChanges({
-              controller,
-              propertyPath: ['networkDetails'],
-              operation: () => {
-                controller.resetConnection();
-              },
-            });
+            await controller.resetConnection();
 
             expect(controller.store.getState().networkDetails).toStrictEqual({
               EIPS: {

--- a/app/scripts/controllers/network/network-controller.ts
+++ b/app/scripts/controllers/network/network-controller.ts
@@ -753,8 +753,8 @@ export class NetworkController extends EventEmitter {
   /**
    * Re-initializes the provider and block tracker for the current network.
    */
-  resetConnection(): void {
-    this.#setProviderConfig(this.store.getState().provider);
+  async resetConnection() {
+    await this.#setProviderConfig(this.store.getState().provider);
   }
 
   /**


### PR DESCRIPTION
## Explanation

The network controller method `resetConnection` is now async. This has no functional impact.

Relates to https://github.com/MetaMask/metamask-extension/issues/18587

## Manual Testing Steps

No functional changes.

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
