### PR TITLE
Make network controller internal fields private

### DIFF
--- a/app/scripts/controllers/network/network-controller.test.ts
+++ b/app/scripts/controllers/network/network-controller.test.ts
@@ -730,7 +730,7 @@ describe('NetworkController', () => {
           await expect(async () => {
             await controller.initializeProvider();
           }).rejects.toThrow(
-            'NetworkController - _configureProvider - unknown type "undefined"',
+            'NetworkController - #configureProvider - unknown type "undefined"',
           );
         },
       );

--- a/app/scripts/controllers/preferences.test.js
+++ b/app/scripts/controllers/preferences.test.js
@@ -2,36 +2,13 @@ import { strict as assert } from 'assert';
 import sinon from 'sinon';
 import { ControllerMessenger } from '@metamask/base-controller';
 import { TokenListController } from '@metamask/assets-controllers';
-import { CHAIN_IDS } from '../../../shared/constants/network';
 import PreferencesController from './preferences';
-import { NetworkController } from './network';
 
 describe('preferences controller', function () {
   let preferencesController;
-  let network;
-  let currentChainId;
-  let provider;
   let tokenListController;
 
   beforeEach(function () {
-    const sandbox = sinon.createSandbox();
-    currentChainId = CHAIN_IDS.MAINNET;
-    const networkControllerProviderConfig = {
-      getAccounts: () => undefined,
-    };
-    const networkControllerMessenger = new ControllerMessenger();
-    network = new NetworkController({
-      infuraProjectId: 'foo',
-      messenger: networkControllerMessenger,
-      state: {
-        provider: {
-          type: 'mainnet',
-          chainId: currentChainId,
-        },
-      },
-    });
-    network.initializeProvider(networkControllerProviderConfig);
-    provider = network.getProviderAndBlockTracker().provider;
     const tokenListMessenger = new ControllerMessenger().getRestricted({
       name: 'TokenListController',
     });
@@ -43,14 +20,8 @@ describe('preferences controller', function () {
       messenger: tokenListMessenger,
     });
 
-    sandbox
-      .stub(network, '_getLatestBlock')
-      .callsFake(() => Promise.resolve({}));
-
     preferencesController = new PreferencesController({
       initLangCode: 'en_US',
-      network,
-      provider,
       tokenListController,
       onInfuraIsBlocked: sinon.spy(),
       onInfuraIsUnblocked: sinon.spy(),


### PR DESCRIPTION
## Explanation

Internal network controller methods and fields are now private fields, using the JavaScript `#` syntax rather than the `private` TypeScript keyword or a leading underscore.

The one reference to a private field was in the preferences controller unit tests. Fortunately it was being used to create a test fixture that was unused. The unnecessary test fixtures have been removed from that test suite.

Fixes https://github.com/MetaMask/metamask-extension/issues/18588

## Manual Testing Steps

No functional changes

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
