### PR TITLE
Pass correct params to fetchEstimatedL1Fee in the swaps controller

### DIFF
--- a/app/scripts/controllers/swaps.js
+++ b/app/scripts/controllers/swaps.js
@@ -304,6 +304,7 @@ export default class SwapsController {
         Object.values(newQuotes).map(async (quote) => {
           if (quote.trade) {
             const multiLayerL1TradeFeeTotal = await fetchEstimatedL1Fee(
+              chainId,
               {
                 txParams: quote.trade,
                 chainId,

--- a/app/scripts/controllers/swaps.test.js
+++ b/app/scripts/controllers/swaps.test.js
@@ -156,12 +156,12 @@ const getEIP1559GasFeeEstimatesStub = sandbox.stub(() => {
 describe('SwapsController', function () {
   let provider;
 
-  const getSwapsController = () => {
+  const getSwapsController = (_provider = provider) => {
     return new SwapsController({
       getBufferedGasLimit: MOCK_GET_BUFFERED_GAS_LIMIT,
       networkController: getMockNetworkController(),
       onNetworkDidChange: sinon.stub(),
-      provider,
+      provider: _provider,
       getProviderConfig: MOCK_GET_PROVIDER_CONFIG,
       getTokenRatesState: MOCK_TOKEN_RATES_STORE,
       fetchTradesInfo: fetchTradesInfoStub,
@@ -717,6 +717,72 @@ describe('SwapsController', function () {
         assert.strictEqual(
           fetchTradesInfoStub.calledOnceWithExactly(MOCK_FETCH_PARAMS, {
             ...MOCK_FETCH_METADATA,
+          }),
+          true,
+        );
+      });
+
+      it('calls returns the correct quotes on the optimism chain', async function () {
+        fetchTradesInfoStub.resetHistory();
+        const OPTIMISM_MOCK_FETCH_METADATA = {
+          ...MOCK_FETCH_METADATA,
+          chainId: CHAIN_IDS.OPTIMISM,
+        };
+        const optimismProviderResultStub = {
+          // 1 gwei
+          eth_gasPrice: '0x0de0b6b3a7640000',
+          // by default, all accounts are external accounts (not contracts)
+          eth_getCode: '0x',
+          eth_call:
+            '0x000000000000000000000000000000000000000000000000000103c18816d4e8',
+        };
+        const optimismProvider = createTestProviderTools({
+          scaffold: optimismProviderResultStub,
+          networkId: 10,
+          chainId: 10,
+        }).provider;
+
+        swapsController = getSwapsController(optimismProvider);
+
+        fetchTradesInfoStub.resolves(getMockQuotes());
+
+        // Make it so approval is not required
+        sandbox
+          .stub(swapsController, '_getERC20Allowance')
+          .resolves(BigNumber.from(1));
+
+        const [newQuotes] = await swapsController.fetchAndSetQuotes(
+          MOCK_FETCH_PARAMS,
+          OPTIMISM_MOCK_FETCH_METADATA,
+        );
+
+        assert.deepStrictEqual(newQuotes[TEST_AGG_ID_BEST], {
+          ...getMockQuotes()[TEST_AGG_ID_BEST],
+          sourceTokenInfo: undefined,
+          destinationTokenInfo: {
+            symbol: 'FOO',
+            decimals: 18,
+          },
+          isBestQuote: true,
+          // TODO: find a way to calculate these values dynamically
+          gasEstimate: 2000000,
+          gasEstimateWithRefund: '0xb8cae',
+          savings: {
+            fee: '-0.061067',
+            metaMaskFee: '0.5050505050505050505',
+            performance: '6',
+            total: '5.4338824949494949495',
+            medianMetaMaskFee: '0.44444444444444444444',
+          },
+          ethFee: '0.113822',
+          multiLayerL1TradeFeeTotal: '0x0103c18816d4e8',
+          overallValueOfQuote: '49.886178',
+          metaMaskFeeInEth: '0.5050505050505050505',
+          ethValueOfTokens: '50',
+        });
+        assert.strictEqual(
+          fetchTradesInfoStub.calledOnceWithExactly(MOCK_FETCH_PARAMS, {
+            ...OPTIMISM_MOCK_FETCH_METADATA,
           }),
           true,
         );


### PR DESCRIPTION
Fixes https://github.com/MetaMask/metamask-extension/issues/18580

# Explanation

https://github.com/MetaMask/metamask-extension/commit/f92e463a0f2 changed the expected parameters of the `fetchEstimatedL1Fee` function. We updated the use of that function in the UI directory, but missed the use of that function in the swaps controller. This PR updates that function to correctly pass the chainId, and also adds a unit test that would have caught this bug