### PR TITLE
removeNetworkConfiguration validates given ID

### DIFF
--- a/app/scripts/controllers/network/network-controller.test.ts
+++ b/app/scripts/controllers/network/network-controller.test.ts
@@ -7308,14 +7308,14 @@ describe('NetworkController', () => {
   });
 
   describe('removeNetworkConfigurations', () => {
-    it('should remove a network configuration', async () => {
-      const networkConfigurationId = 'networkConfigurationId';
+    it('removes a network configuration', async () => {
+      const networkConfigurationId = 'testNetworkConfigurationId';
       await withController(
         {
           state: {
             networkConfigurations: {
               [networkConfigurationId]: {
-                id: 'aaaaaa',
+                id: networkConfigurationId,
                 rpcUrl: 'https://test-rpc-url',
                 ticker: 'old_rpc_ticker',
                 nickname: 'old_rpc_chainName',
@@ -7326,22 +7326,41 @@ describe('NetworkController', () => {
           },
         },
         async ({ controller }) => {
-          expect(
-            Object.values(controller.store.getState().networkConfigurations),
-          ).toStrictEqual([
-            {
-              id: 'aaaaaa',
-              rpcUrl: 'https://test-rpc-url',
-              ticker: 'old_rpc_ticker',
-              nickname: 'old_rpc_chainName',
-              rpcPrefs: { blockExplorerUrl: 'testchainscan.io' },
-              chainId: '0x1',
-            },
-          ]);
           controller.removeNetworkConfiguration(networkConfigurationId);
+
           expect(
             controller.store.getState().networkConfigurations,
           ).toStrictEqual({});
+        },
+      );
+    });
+
+    it('throws if the networkConfigurationId it is passed does not correspond to a network configuration in state', async () => {
+      const testNetworkConfigurationId = 'testNetworkConfigurationId';
+      const invalidNetworkConfigurationId = 'invalidNetworkConfigurationId';
+      await withController(
+        {
+          state: {
+            networkConfigurations: {
+              [testNetworkConfigurationId]: {
+                rpcUrl: 'https://rpc-url.com',
+                ticker: 'old_rpc_ticker',
+                nickname: 'old_rpc_nickname',
+                rpcPrefs: { blockExplorerUrl: 'testchainscan.io' },
+                chainId: '0x1',
+                id: testNetworkConfigurationId,
+              },
+            },
+          },
+        },
+        async ({ controller }) => {
+          expect(() =>
+            controller.removeNetworkConfiguration(
+              invalidNetworkConfigurationId,
+            ),
+          ).toThrow(
+            `networkConfigurationId ${invalidNetworkConfigurationId} does not match a configured networkConfiguration`,
+          );
         },
       );
     });

--- a/app/scripts/controllers/network/network-controller.ts
+++ b/app/scripts/controllers/network/network-controller.ts
@@ -1141,9 +1141,12 @@ export class NetworkController extends EventEmitter {
    * @param networkConfigurationId - The unique id for the network configuration
    * to remove.
    */
-  removeNetworkConfiguration(
-    networkConfigurationId: NetworkConfigurationId,
-  ): void {
+  removeNetworkConfiguration(networkConfigurationId: NetworkConfigurationId) {
+    if (!this.store.getState().networkConfigurations[networkConfigurationId]) {
+      throw new Error(
+        `networkConfigurationId ${networkConfigurationId} does not match a configured networkConfiguration`,
+      );
+    }
     const networkConfigurations = {
       ...this.store.getState().networkConfigurations,
     };


### PR DESCRIPTION
## Explanation

<!--
Thanks for the pull request. Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues, Slack conversations, Zendesk issues, user stories, etc. reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

In the `core` version of NetworkController, `removeNetworkConfiguration` throws an error if the given network configuration ID doesn't match an existing network configuration. This commits adds the same check for consistency. It also makes some minor changes to the implementation and tests for `removeNetworkConfiguration` for consistency as well.

For the equivalent implementation in `core`, see: https://github.com/MetaMask/core/blob/c8c9f389589522bc6a5147aad8679cddbd8f3381/packages/network-controller/src/NetworkController.ts#L707 and https://github.com/MetaMask/core/blob/c8c9f389589522bc6a5147aad8679cddbd8f3381/packages/network-controller/tests/NetworkController.test.ts#L4467.

Closes https://github.com/MetaMask/metamask-extension/issues/18649.

## Manual Testing Steps

<!--
How should reviewers and QA manually test your changes? For instance:

- Go to this screen
- Do this
- Then do this
-->

There should be no functional changes, and all automated tests should pass.

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [x] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
