### PR TITLE
TransactionUtils: update determineTransactionType method / contractInteraction support

### DIFF
--- a/shared/modules/transaction.utils.js
+++ b/shared/modules/transaction.utils.js
@@ -176,6 +176,8 @@ export async function determineTransactionType(txParams, query) {
     contractCode = resultCode;
 
     if (isContractAddress) {
+      const hasValue = txParams.value && txParams.value !== '0x0';
+
       const tokenMethodName = [
         TransactionType.tokenMethodApprove,
         TransactionType.tokenMethodSetApprovalForAll,
@@ -184,13 +186,8 @@ export async function determineTransactionType(txParams, query) {
         TransactionType.tokenMethodSafeTransferFrom,
       ].find((methodName) => isEqualCaseInsensitive(methodName, name));
 
-      const isSendWithApprove =
-        txParams.value &&
-        txParams.value !== '0x0' &&
-        tokenMethodName === TransactionType.tokenMethodApprove;
-
       result =
-        data && tokenMethodName && !isSendWithApprove
+        data && tokenMethodName && !hasValue
           ? tokenMethodName
           : TransactionType.contractInteraction;
     } else {

--- a/shared/modules/transaction.utils.test.js
+++ b/shared/modules/transaction.utils.test.js
@@ -135,7 +135,7 @@ describe('Transaction.utils', function () {
       });
     });
 
-    it('should return a token transfer type when the recipient is a contract and data is for the respective method call', async function () {
+    it('should return a token transfer type when the recipient is a contract, there is no value passed, and data is for the respective method call', async function () {
       const _providerResultStub = {
         // 1 gwei
         eth_gasPrice: '0x0de0b6b3a7640000',
@@ -158,6 +158,48 @@ describe('Transaction.utils', function () {
         getCodeResponse: '0xab',
       });
     });
+
+    it(
+      'should NOT return a token transfer type and instead return contract interaction' +
+        ' when the recipient is a contract, the data matches the respective method call, but there is a value passed',
+      async function () {
+        const _providerResultStub = {
+          // 1 gwei
+          eth_gasPrice: '0x0de0b6b3a7640000',
+          // by default, all accounts are external accounts (not contracts)
+          eth_getCode: '0xab',
+        };
+        const _provider = createTestProviderTools({
+          scaffold: _providerResultStub,
+        }).provider;
+
+        const resultWithEmptyValue = await determineTransactionType(
+          {
+            value: '0x0',
+            to: '0x9e673399f795D01116e9A8B2dD2F156705131ee9',
+            data: '0xa9059cbb0000000000000000000000002f318C334780961FB129D2a6c30D0763d9a5C970000000000000000000000000000000000000000000000000000000000000000a',
+          },
+          new EthQuery(_provider),
+        );
+        expect(resultWithEmptyValue).toMatchObject({
+          type: TransactionType.tokenMethodTransfer,
+          getCodeResponse: '0xab',
+        });
+
+        const resultWithValue = await determineTransactionType(
+          {
+            value: '0x12345',
+            to: '0x9e673399f795D01116e9A8B2dD2F156705131ee9',
+            data: '0xa9059cbb0000000000000000000000002f318C334780961FB129D2a6c30D0763d9a5C970000000000000000000000000000000000000000000000000000000000000000a',
+          },
+          new EthQuery(_provider),
+        );
+        expect(resultWithValue).toMatchObject({
+          type: TransactionType.contractInteraction,
+          getCodeResponse: '0xab',
+        });
+      },
+    );
 
     it('should NOT return a token transfer type when the recipient is not a contract but the data matches the respective method call', async function () {
       const _providerResultStub = {
@@ -182,7 +224,6 @@ describe('Transaction.utils', function () {
         getCodeResponse: '0x',
       });
     });
-
     it('should return a token approve type when when the recipient is a contract and data is for the respective method call', async function () {
       const _providerResultStub = {
         // 1 gwei

--- a/shared/modules/transaction.utils.test.js
+++ b/shared/modules/transaction.utils.test.js
@@ -224,6 +224,7 @@ describe('Transaction.utils', function () {
         getCodeResponse: '0x',
       });
     });
+
     it('should return a token approve type when when the recipient is a contract and data is for the respective method call', async function () {
       const _providerResultStub = {
         // 1 gwei


### PR DESCRIPTION
## Explanation
Disable custom contract transaction screen when value is present. These cases will show the contract Interaction fallback page.

Fixes Extension portion of https://github.com/MetaMask/MetaMask-planning/issues/380
Mobile fix is on the way

<!--
Thanks for the pull request. Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues, Slack conversations, Zendesk issues, user stories, etc. reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890

-->

## Screenshots/Screencaps

<!-- If you're making a change to the UI, make sure to capture a screenshot or a short video showing off your work! -->

### Before

(see Issue ticket https://github.com/MetaMask/MetaMask-planning/issues/380) 
<!-- How did the UI you changed look before your changes? Drag your file(s) below this line: -->

### After

ERC20 transfer without value shows token:
<img width="560" alt="Screen Shot 2023-04-19 at 5 02 54 PM" src="https://user-images.githubusercontent.com/20778143/233187783-17bc848c-adea-4747-ba39-d28e7b7f0e1c.png">

ERC20 transfer with value shows ETH:
<img width="527" alt="Screen Shot 2023-04-19 at 4 59 05 PM" src="https://user-images.githubusercontent.com/20778143/233187843-df030477-1911-44b7-9fb3-aca9a3d12792.png">

approve:
<img width="536" alt="Screen Shot 2023-04-19 at 2 31 24 PM" src="https://user-images.githubusercontent.com/20778143/233154414-a9cc5347-5eee-4768-9d3f-1c1cf67abdb6.png">

setApprovalForAll:
<img width="572" alt="Screen Shot 2023-04-19 at 1 58 43 PM" src="https://user-images.githubusercontent.com/20778143/233153895-5022e5e4-6143-4731-8316-f23f5f11eca9.png">

transferFrom:
<img width="539" alt="Screen Shot 2023-04-19 at 2 03 31 PM" src="https://user-images.githubusercontent.com/20778143/233153897-f3368338-34af-45c6-8d19-dba6d2ca2f72.png">

ERC721 transfer without a value:
<img width="637" alt="Screen Shot 2023-04-19 at 5 17 21 PM" src="https://user-images.githubusercontent.com/20778143/233190894-eba3ba4f-17e2-4c2f-9b6e-360a5c9ca360.png">

ERC721 transfer with a value:
<img width="557" alt="Screen Shot 2023-04-19 at 5 18 20 PM" src="https://user-images.githubusercontent.com/20778143/233190915-693b192f-b9c8-4ecb-acf2-73f5086b40a5.png">



<!-- How does it look now? Drag your file(s) below this line: -->

## Manual Testing Steps

(see instructions in Issue ticket https://github.com/MetaMask/MetaMask-planning/issues/380) 


<!--
How should reviewers and QA manually test your changes? For instance:

- Go to this screen
- Do this
- Then do this
-->

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [x] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [x] PR is linked to the appropriate GitHub issue
- [x] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
