### PR TITLE
Rename migration 83 to 84 and rename migration 84 to 83

### DIFF
--- a/app/scripts/migrations/083.test.js
+++ b/app/scripts/migrations/083.test.js
@@ -1,103 +1,254 @@
-import { migrate } from './083';
+import { v4 } from 'uuid';
+import { migrate, version } from './083';
 
-describe('migration #83', () => {
-  it('updates the version metadata', async () => {
-    const originalVersionedData = buildOriginalVersionedData({
-      meta: {
-        version: 9999999,
-      },
-    });
+jest.mock('uuid', () => {
+  const actual = jest.requireActual('uuid');
 
-    const newVersionedData = await migrate(originalVersionedData);
-
-    expect(newVersionedData.meta).toStrictEqual({
-      version: 83,
-    });
-  });
-
-  it('does not change the state if the network controller state does not exist', async () => {
-    const originalVersionedData = buildOriginalVersionedData({
-      data: {
-        test: '123',
-      },
-    });
-
-    const newVersionedData = await migrate(originalVersionedData);
-
-    expect(newVersionedData.data).toStrictEqual(originalVersionedData.data);
-  });
-
-  const nonObjects = [undefined, null, 'test', 1, ['test']];
-  for (const invalidState of nonObjects) {
-    it(`does not change the state if the network controller state is ${invalidState}`, async () => {
-      const originalVersionedData = buildOriginalVersionedData({
-        data: {
-          NetworkController: invalidState,
-        },
-      });
-
-      const newVersionedData = await migrate(originalVersionedData);
-
-      expect(newVersionedData.data).toStrictEqual(originalVersionedData.data);
-    });
-  }
-
-  it('does not change the state if the network controller state does not include "network"', async () => {
-    const originalVersionedData = buildOriginalVersionedData({
-      data: {
-        NetworkController: {
-          test: '123',
-        },
-      },
-    });
-
-    const newVersionedData = await migrate(originalVersionedData);
-
-    expect(newVersionedData.data).toStrictEqual(originalVersionedData.data);
-  });
-
-  it('replaces "network" in the network controller state with "networkId": null, "networkStatus": "unknown" if it is "loading"', async () => {
-    const originalVersionedData = buildOriginalVersionedData({
-      data: {
-        NetworkController: {
-          network: 'loading',
-        },
-      },
-    });
-
-    const newVersionedData = await migrate(originalVersionedData);
-
-    expect(newVersionedData.data).toStrictEqual({
-      NetworkController: {
-        networkId: null,
-        networkStatus: 'unknown',
-      },
-    });
-  });
-
-  it('replaces "network" in the network controller state with "networkId": network, "networkStatus": "available" if it is not "loading"', async () => {
-    const originalVersionedData = buildOriginalVersionedData({
-      data: {
-        NetworkController: {
-          network: '12345',
-        },
-      },
-    });
-
-    const newVersionedData = await migrate(originalVersionedData);
-
-    expect(newVersionedData.data).toStrictEqual({
-      NetworkController: {
-        networkId: '12345',
-        networkStatus: 'available',
-      },
-    });
-  });
+  return {
+    ...actual,
+    v4: jest.fn(),
+  };
 });
 
-function buildOriginalVersionedData({ meta = {}, data = {} } = {}) {
-  return {
-    meta: { version: 999999, ...meta },
-    data: { ...data },
-  };
-}
+describe('migration #83', () => {
+  beforeEach(() => {
+    v4.mockImplementationOnce(() => 'network-configuration-id-1')
+      .mockImplementationOnce(() => 'network-configuration-id-2')
+      .mockImplementationOnce(() => 'network-configuration-id-3')
+      .mockImplementationOnce(() => 'network-configuration-id-4');
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+  it('should update the version metadata', async () => {
+    const oldStorage = {
+      meta: {
+        version: 82,
+      },
+      data: {},
+    };
+
+    const newStorage = await migrate(oldStorage);
+    expect(newStorage.meta).toStrictEqual({
+      version,
+    });
+  });
+
+  it('should use the key of the networkConfigurations object to set the id of each network configuration', async () => {
+    const oldStorage = {
+      meta: {
+        version,
+      },
+      data: {
+        NetworkController: {
+          networkConfigurations: {
+            'network-configuration-id-1': {
+              chainId: '0x539',
+              nickname: 'Localhost 8545',
+              rpcPrefs: {},
+              rpcUrl: 'http://localhost:8545',
+              ticker: 'ETH',
+            },
+            'network-configuration-id-2': {
+              chainId: '0xa4b1',
+              nickname: 'Arbitrum One',
+              rpcPrefs: {
+                blockExplorerUrl: 'https://explorer.arbitrum.io',
+              },
+              rpcUrl:
+                'https://arbitrum-mainnet.infura.io/v3/373266a93aab4acda48f89d4fe77c748',
+              ticker: 'ETH',
+            },
+            'network-configuration-id-3': {
+              chainId: '0x4e454152',
+              nickname: 'Aurora Mainnet',
+              rpcPrefs: {
+                blockExplorerUrl: 'https://aurorascan.dev/',
+              },
+              rpcUrl:
+                'https://aurora-mainnet.infura.io/v3/373266a93aab4acda48f89d4fe77c748',
+              ticker: 'Aurora ETH',
+            },
+            'network-configuration-id-4': {
+              chainId: '0x38',
+              nickname:
+                'BNB Smart Chain (previously Binance Smart Chain Mainnet)',
+              rpcPrefs: {
+                blockExplorerUrl: 'https://bscscan.com/',
+              },
+              rpcUrl: 'https://bsc-dataseed.binance.org/',
+              ticker: 'BNB',
+            },
+          },
+        },
+      },
+    };
+
+    const newStorage = await migrate(oldStorage);
+
+    const expectedNewStorage = {
+      meta: {
+        version,
+      },
+      data: {
+        NetworkController: {
+          networkConfigurations: {
+            'network-configuration-id-1': {
+              chainId: '0x539',
+              nickname: 'Localhost 8545',
+              rpcPrefs: {},
+              rpcUrl: 'http://localhost:8545',
+              ticker: 'ETH',
+              id: 'network-configuration-id-1',
+            },
+            'network-configuration-id-2': {
+              chainId: '0xa4b1',
+              nickname: 'Arbitrum One',
+              rpcPrefs: {
+                blockExplorerUrl: 'https://explorer.arbitrum.io',
+              },
+              rpcUrl:
+                'https://arbitrum-mainnet.infura.io/v3/373266a93aab4acda48f89d4fe77c748',
+              ticker: 'ETH',
+              id: 'network-configuration-id-2',
+            },
+            'network-configuration-id-3': {
+              chainId: '0x4e454152',
+              nickname: 'Aurora Mainnet',
+              rpcPrefs: {
+                blockExplorerUrl: 'https://aurorascan.dev/',
+              },
+              rpcUrl:
+                'https://aurora-mainnet.infura.io/v3/373266a93aab4acda48f89d4fe77c748',
+              ticker: 'Aurora ETH',
+              id: 'network-configuration-id-3',
+            },
+            'network-configuration-id-4': {
+              chainId: '0x38',
+              nickname:
+                'BNB Smart Chain (previously Binance Smart Chain Mainnet)',
+              rpcPrefs: {
+                blockExplorerUrl: 'https://bscscan.com/',
+              },
+              rpcUrl: 'https://bsc-dataseed.binance.org/',
+              ticker: 'BNB',
+              id: 'network-configuration-id-4',
+            },
+          },
+        },
+      },
+    };
+    expect(newStorage).toStrictEqual(expectedNewStorage);
+  });
+
+  it('should not modify state if state.NetworkController is undefined', async () => {
+    const oldStorage = {
+      meta: {
+        version,
+      },
+      data: {
+        testProperty: 'testValue',
+      },
+    };
+
+    const newStorage = await migrate(oldStorage);
+
+    const expectedNewStorage = {
+      meta: {
+        version,
+      },
+      data: {
+        testProperty: 'testValue',
+      },
+    };
+    expect(newStorage).toStrictEqual(expectedNewStorage);
+  });
+
+  it('should not modify state if state.NetworkController is not an object', async () => {
+    const oldStorage = {
+      meta: {
+        version,
+      },
+      data: {
+        NetworkController: false,
+        testProperty: 'testValue',
+      },
+    };
+
+    const newStorage = await migrate(oldStorage);
+
+    const expectedNewStorage = {
+      meta: {
+        version,
+      },
+      data: {
+        NetworkController: false,
+        testProperty: 'testValue',
+      },
+    };
+    expect(newStorage).toStrictEqual(expectedNewStorage);
+  });
+
+  it('should not modify state if state.NetworkController.networkConfigurations is undefined', async () => {
+    const oldStorage = {
+      meta: {
+        version,
+      },
+      data: {
+        NetworkController: {
+          testNetworkControllerProperty: 'testNetworkControllerValue',
+          networkConfigurations: undefined,
+        },
+        testProperty: 'testValue',
+      },
+    };
+
+    const newStorage = await migrate(oldStorage);
+
+    const expectedNewStorage = {
+      meta: {
+        version,
+      },
+      data: {
+        NetworkController: {
+          testNetworkControllerProperty: 'testNetworkControllerValue',
+          networkConfigurations: undefined,
+        },
+        testProperty: 'testValue',
+      },
+    };
+    expect(newStorage).toStrictEqual(expectedNewStorage);
+  });
+
+  it('should not modify state if state.NetworkController.networkConfigurations is an empty object', async () => {
+    const oldStorage = {
+      meta: {
+        version,
+      },
+      data: {
+        NetworkController: {
+          testNetworkControllerProperty: 'testNetworkControllerValue',
+          networkConfigurations: {},
+        },
+        testProperty: 'testValue',
+      },
+    };
+
+    const newStorage = await migrate(oldStorage);
+
+    const expectedNewStorage = {
+      meta: {
+        version,
+      },
+      data: {
+        NetworkController: {
+          testNetworkControllerProperty: 'testNetworkControllerValue',
+          networkConfigurations: {},
+        },
+        testProperty: 'testValue',
+      },
+    };
+    expect(newStorage).toStrictEqual(expectedNewStorage);
+  });
+});

--- a/app/scripts/migrations/083.ts
+++ b/app/scripts/migrations/083.ts
@@ -1,10 +1,11 @@
 import { cloneDeep } from 'lodash';
-import { hasProperty, isObject } from '@metamask/utils';
+import { isObject } from '@metamask/utils';
 
 export const version = 83;
 
 /**
- * The `network` property in state was replaced with `networkId` and `networkStatus`.
+ * Ensure that each networkConfigurations object in state.NetworkController.networkConfigurations has an
+ * `id` property which matches the key pointing that object
  *
  * @param originalVersionedData - Versioned MetaMask extension state, exactly what we persist to dist.
  * @param originalVersionedData.meta - State metadata.
@@ -23,25 +24,35 @@ export async function migrate(originalVersionedData: {
 }
 
 function transformState(state: Record<string, unknown>) {
-  if (
-    !hasProperty(state, 'NetworkController') ||
-    !isObject(state.NetworkController) ||
-    !hasProperty(state.NetworkController, 'network')
-  ) {
+  if (!isObject(state.NetworkController)) {
+    return state;
+  }
+  const { NetworkController } = state;
+
+  if (!isObject(NetworkController.networkConfigurations)) {
     return state;
   }
 
-  const NetworkController = { ...state.NetworkController };
+  const { networkConfigurations } = NetworkController;
 
-  if (NetworkController.network === 'loading') {
-    NetworkController.networkId = null;
-    NetworkController.networkStatus = 'unknown';
-  } else {
-    NetworkController.networkId = NetworkController.network;
-    NetworkController.networkStatus = 'available';
+  const newNetworkConfigurations: Record<string, Record<string, unknown>> = {};
+
+  for (const networkConfigurationId of Object.keys(networkConfigurations)) {
+    const networkConfiguration = networkConfigurations[networkConfigurationId];
+    if (!isObject(networkConfiguration)) {
+      return state;
+    }
+    newNetworkConfigurations[networkConfigurationId] = {
+      ...networkConfiguration,
+      id: networkConfigurationId,
+    };
   }
 
-  delete NetworkController.network;
-
-  return { ...state, NetworkController };
+  return {
+    ...state,
+    NetworkController: {
+      ...NetworkController,
+      networkConfigurations: newNetworkConfigurations,
+    },
+  };
 }

--- a/app/scripts/migrations/084.test.js
+++ b/app/scripts/migrations/084.test.js
@@ -1,254 +1,103 @@
-import { v4 } from 'uuid';
-import { migrate, version } from './084';
-
-jest.mock('uuid', () => {
-  const actual = jest.requireActual('uuid');
-
-  return {
-    ...actual,
-    v4: jest.fn(),
-  };
-});
+import { migrate } from './084';
 
 describe('migration #84', () => {
-  beforeEach(() => {
-    v4.mockImplementationOnce(() => 'network-configuration-id-1')
-      .mockImplementationOnce(() => 'network-configuration-id-2')
-      .mockImplementationOnce(() => 'network-configuration-id-3')
-      .mockImplementationOnce(() => 'network-configuration-id-4');
-  });
-
-  afterEach(() => {
-    jest.resetAllMocks();
-  });
-  it('should update the version metadata', async () => {
-    const oldStorage = {
+  it('updates the version metadata', async () => {
+    const originalVersionedData = buildOriginalVersionedData({
       meta: {
-        version: 83,
+        version: 9999999,
       },
-      data: {},
-    };
+    });
 
-    const newStorage = await migrate(oldStorage);
-    expect(newStorage.meta).toStrictEqual({
-      version,
+    const newVersionedData = await migrate(originalVersionedData);
+
+    expect(newVersionedData.meta).toStrictEqual({
+      version: 84,
     });
   });
 
-  it('should use the key of the networkConfigurations object to set the id of each network configuration', async () => {
-    const oldStorage = {
-      meta: {
-        version,
-      },
+  it('does not change the state if the network controller state does not exist', async () => {
+    const originalVersionedData = buildOriginalVersionedData({
       data: {
-        NetworkController: {
-          networkConfigurations: {
-            'network-configuration-id-1': {
-              chainId: '0x539',
-              nickname: 'Localhost 8545',
-              rpcPrefs: {},
-              rpcUrl: 'http://localhost:8545',
-              ticker: 'ETH',
-            },
-            'network-configuration-id-2': {
-              chainId: '0xa4b1',
-              nickname: 'Arbitrum One',
-              rpcPrefs: {
-                blockExplorerUrl: 'https://explorer.arbitrum.io',
-              },
-              rpcUrl:
-                'https://arbitrum-mainnet.infura.io/v3/373266a93aab4acda48f89d4fe77c748',
-              ticker: 'ETH',
-            },
-            'network-configuration-id-3': {
-              chainId: '0x4e454152',
-              nickname: 'Aurora Mainnet',
-              rpcPrefs: {
-                blockExplorerUrl: 'https://aurorascan.dev/',
-              },
-              rpcUrl:
-                'https://aurora-mainnet.infura.io/v3/373266a93aab4acda48f89d4fe77c748',
-              ticker: 'Aurora ETH',
-            },
-            'network-configuration-id-4': {
-              chainId: '0x38',
-              nickname:
-                'BNB Smart Chain (previously Binance Smart Chain Mainnet)',
-              rpcPrefs: {
-                blockExplorerUrl: 'https://bscscan.com/',
-              },
-              rpcUrl: 'https://bsc-dataseed.binance.org/',
-              ticker: 'BNB',
-            },
-          },
-        },
+        test: '123',
       },
-    };
+    });
 
-    const newStorage = await migrate(oldStorage);
+    const newVersionedData = await migrate(originalVersionedData);
 
-    const expectedNewStorage = {
-      meta: {
-        version,
-      },
-      data: {
-        NetworkController: {
-          networkConfigurations: {
-            'network-configuration-id-1': {
-              chainId: '0x539',
-              nickname: 'Localhost 8545',
-              rpcPrefs: {},
-              rpcUrl: 'http://localhost:8545',
-              ticker: 'ETH',
-              id: 'network-configuration-id-1',
-            },
-            'network-configuration-id-2': {
-              chainId: '0xa4b1',
-              nickname: 'Arbitrum One',
-              rpcPrefs: {
-                blockExplorerUrl: 'https://explorer.arbitrum.io',
-              },
-              rpcUrl:
-                'https://arbitrum-mainnet.infura.io/v3/373266a93aab4acda48f89d4fe77c748',
-              ticker: 'ETH',
-              id: 'network-configuration-id-2',
-            },
-            'network-configuration-id-3': {
-              chainId: '0x4e454152',
-              nickname: 'Aurora Mainnet',
-              rpcPrefs: {
-                blockExplorerUrl: 'https://aurorascan.dev/',
-              },
-              rpcUrl:
-                'https://aurora-mainnet.infura.io/v3/373266a93aab4acda48f89d4fe77c748',
-              ticker: 'Aurora ETH',
-              id: 'network-configuration-id-3',
-            },
-            'network-configuration-id-4': {
-              chainId: '0x38',
-              nickname:
-                'BNB Smart Chain (previously Binance Smart Chain Mainnet)',
-              rpcPrefs: {
-                blockExplorerUrl: 'https://bscscan.com/',
-              },
-              rpcUrl: 'https://bsc-dataseed.binance.org/',
-              ticker: 'BNB',
-              id: 'network-configuration-id-4',
-            },
-          },
-        },
-      },
-    };
-    expect(newStorage).toStrictEqual(expectedNewStorage);
+    expect(newVersionedData.data).toStrictEqual(originalVersionedData.data);
   });
 
-  it('should not modify state if state.NetworkController is undefined', async () => {
-    const oldStorage = {
-      meta: {
-        version,
-      },
-      data: {
-        testProperty: 'testValue',
-      },
-    };
+  const nonObjects = [undefined, null, 'test', 1, ['test']];
+  for (const invalidState of nonObjects) {
+    it(`does not change the state if the network controller state is ${invalidState}`, async () => {
+      const originalVersionedData = buildOriginalVersionedData({
+        data: {
+          NetworkController: invalidState,
+        },
+      });
 
-    const newStorage = await migrate(oldStorage);
+      const newVersionedData = await migrate(originalVersionedData);
 
-    const expectedNewStorage = {
-      meta: {
-        version,
-      },
+      expect(newVersionedData.data).toStrictEqual(originalVersionedData.data);
+    });
+  }
+
+  it('does not change the state if the network controller state does not include "network"', async () => {
+    const originalVersionedData = buildOriginalVersionedData({
       data: {
-        testProperty: 'testValue',
+        NetworkController: {
+          test: '123',
+        },
       },
-    };
-    expect(newStorage).toStrictEqual(expectedNewStorage);
+    });
+
+    const newVersionedData = await migrate(originalVersionedData);
+
+    expect(newVersionedData.data).toStrictEqual(originalVersionedData.data);
   });
 
-  it('should not modify state if state.NetworkController is not an object', async () => {
-    const oldStorage = {
-      meta: {
-        version,
-      },
+  it('replaces "network" in the network controller state with "networkId": null, "networkStatus": "unknown" if it is "loading"', async () => {
+    const originalVersionedData = buildOriginalVersionedData({
       data: {
-        NetworkController: false,
-        testProperty: 'testValue',
+        NetworkController: {
+          network: 'loading',
+        },
       },
-    };
+    });
 
-    const newStorage = await migrate(oldStorage);
+    const newVersionedData = await migrate(originalVersionedData);
 
-    const expectedNewStorage = {
-      meta: {
-        version,
+    expect(newVersionedData.data).toStrictEqual({
+      NetworkController: {
+        networkId: null,
+        networkStatus: 'unknown',
       },
-      data: {
-        NetworkController: false,
-        testProperty: 'testValue',
-      },
-    };
-    expect(newStorage).toStrictEqual(expectedNewStorage);
+    });
   });
 
-  it('should not modify state if state.NetworkController.networkConfigurations is undefined', async () => {
-    const oldStorage = {
-      meta: {
-        version,
-      },
+  it('replaces "network" in the network controller state with "networkId": network, "networkStatus": "available" if it is not "loading"', async () => {
+    const originalVersionedData = buildOriginalVersionedData({
       data: {
         NetworkController: {
-          testNetworkControllerProperty: 'testNetworkControllerValue',
-          networkConfigurations: undefined,
+          network: '12345',
         },
-        testProperty: 'testValue',
       },
-    };
+    });
 
-    const newStorage = await migrate(oldStorage);
+    const newVersionedData = await migrate(originalVersionedData);
 
-    const expectedNewStorage = {
-      meta: {
-        version,
+    expect(newVersionedData.data).toStrictEqual({
+      NetworkController: {
+        networkId: '12345',
+        networkStatus: 'available',
       },
-      data: {
-        NetworkController: {
-          testNetworkControllerProperty: 'testNetworkControllerValue',
-          networkConfigurations: undefined,
-        },
-        testProperty: 'testValue',
-      },
-    };
-    expect(newStorage).toStrictEqual(expectedNewStorage);
-  });
-
-  it('should not modify state if state.NetworkController.networkConfigurations is an empty object', async () => {
-    const oldStorage = {
-      meta: {
-        version,
-      },
-      data: {
-        NetworkController: {
-          testNetworkControllerProperty: 'testNetworkControllerValue',
-          networkConfigurations: {},
-        },
-        testProperty: 'testValue',
-      },
-    };
-
-    const newStorage = await migrate(oldStorage);
-
-    const expectedNewStorage = {
-      meta: {
-        version,
-      },
-      data: {
-        NetworkController: {
-          testNetworkControllerProperty: 'testNetworkControllerValue',
-          networkConfigurations: {},
-        },
-        testProperty: 'testValue',
-      },
-    };
-    expect(newStorage).toStrictEqual(expectedNewStorage);
+    });
   });
 });
+
+function buildOriginalVersionedData({ meta = {}, data = {} } = {}) {
+  return {
+    meta: { version: 999999, ...meta },
+    data: { ...data },
+  };
+}


### PR DESCRIPTION
## Explanation

v10.28.3 only included a migration, migration 84. At the time of merging it to master, migration 83 was not yet on master. So the merge to master resolved the merge conflict by renaming and renumbering migration 84 to 83.

Now that we want to sync master with develop, we have to deal with another merge conflict. We need to now rename and renumber migration 83 to 84, and again rename and renumber 84 to 83, on develop. This could be done in the master sync PR, but I am doing it here so that the master sync PR diff follows the usual pattern of only having changes in package.json and the changelog