### PR TITLE
[E2E]: Avoid resetting the mock server

### DIFF
--- a/test/e2e/helpers.js
+++ b/test/e2e/helpers.js
@@ -105,7 +105,7 @@ async function withFixtures(options, testSuite) {
         });
       }
     }
-    await setupMocking(mockServer, testSpecificMock);
+    const mockedEndpoint = await setupMocking(mockServer, testSpecificMock);
     await mockServer.start(8000);
     if (
       process.env.SELENIUM_BROWSER === 'chrome' &&
@@ -143,10 +143,10 @@ async function withFixtures(options, testSuite) {
 
     await testSuite({
       driver: driverProxy ?? driver,
-      mockServer,
       contractRegistry,
       ganacheServer,
       secondaryGanacheServer,
+      mockedEndpoint,
     });
   } catch (error) {
     failed = true;

--- a/test/e2e/mock-e2e.js
+++ b/test/e2e/mock-e2e.js
@@ -32,6 +32,11 @@ async function setupMocking(server, testSpecificMock) {
       return {};
     },
   });
+
+  const mockedEndpoint = await testSpecificMock(server);
+
+  // Mocks below this line can be overridden by test-specific mocks
+
   await server
     .forPost(
       'https://arbitrum-mainnet.infura.io/v3/00000000000000000000000000000000',
@@ -369,10 +374,6 @@ async function setupMocking(server, testSpecificMock) {
       };
     });
 
-  testSpecificMock(server);
-
-  // Mocks below this line can be overridden by test-specific mocks
-
   await server.forGet(STALELIST_URL).thenCallback(() => {
     return {
       statusCode: 200,
@@ -399,6 +400,8 @@ async function setupMocking(server, testSpecificMock) {
         },
       };
     });
+
+  return mockedEndpoint;
 }
 
 module.exports = { setupMocking };

--- a/test/e2e/tests/ens.spec.js
+++ b/test/e2e/tests/ens.spec.js
@@ -9,8 +9,6 @@ describe('ENS', function () {
     'https://mainnet.infura.io/v3/00000000000000000000000000000000';
 
   async function mockInfura(mockServer) {
-    await mockServer.reset();
-    await mockServer.forAnyRequest().thenPassThrough();
     await mockServer
       .forPost(infuraUrl)
       .withJsonBodyIncluding({ method: 'eth_blockNumber' })
@@ -103,7 +101,7 @@ describe('ENS', function () {
 
         await driver.clickElement('[data-testid="eth-overview-send"]');
 
-        await driver.fill(
+        await driver.pasteIntoField(
           'input[placeholder="Search, public address (0x), or ENS"]',
           sampleEnsDomain,
         );

--- a/test/e2e/tests/errors.spec.js
+++ b/test/e2e/tests/errors.spec.js
@@ -3,9 +3,7 @@ const { convertToHexValue, withFixtures } = require('../helpers');
 const FixtureBuilder = require('../fixture-builder');
 
 describe('Sentry errors', function () {
-  async function mockSegment(mockServer) {
-    mockServer.reset();
-    await mockServer.forAnyRequest().thenPassThrough();
+  async function mockSentry(mockServer) {
     return await mockServer
       .forPost('https://sentry.io/api/0000000/store/')
       .thenCallback(() => {
@@ -36,9 +34,9 @@ describe('Sentry errors', function () {
         ganacheOptions,
         title: this.test.title,
         failOnConsoleError: false,
+        testSpecificMock: mockSentry,
       },
-      async ({ driver, mockServer }) => {
-        const mockedEndpoint = await mockSegment(mockServer);
+      async ({ driver, mockedEndpoint }) => {
         await driver.navigate();
         await driver.fill('#password', 'correct horse battery staple');
         await driver.press('#password', driver.Key.ENTER);

--- a/test/e2e/tests/network-error.spec.js
+++ b/test/e2e/tests/network-error.spec.js
@@ -8,6 +8,7 @@ describe('Gas API fallback', function () {
       .forGet(
         'https://gas-api.metaswap.codefi.network/networks/1/suggestedGasFees',
       )
+      .always()
       .thenCallback(() => {
         return {
           statusCode: 200,


### PR DESCRIPTION
## Explanation

<!--
Thanks for the pull request. Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues, Slack conversations, Zendesk issues, user stories, etc. reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

This PR removes all the occurrences of [reset](https://httptoolkit.github.io/mockttp/interfaces/Mockttp.html#reset)

When we reset the server, it clears all the global mocking rules, and therefore the rules are unused in the test

Related to https://github.com/metamask/metamask-extension/issues/17843

## Screenshots/Screencaps

<!-- If you're making a change to the UI, make sure to capture a screenshot or a short video showing off your work! -->

### Before

<!-- How did the UI you changed look before your changes? Drag your file(s) below this line: -->

### After

<!-- How does it look now? Drag your file(s) below this line: -->

## Manual Testing Steps

<!--
How should reviewers and QA manually test your changes? For instance:

- Go to this screen
- Do this
- Then do this
-->

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
