### PR TITLE
[FLASK] Fix permission confirmations back route

### DIFF
--- a/ui/pages/permissions-connect/permissions-connect.component.js
+++ b/ui/pages/permissions-connect/permissions-connect.component.js
@@ -116,7 +116,7 @@ export default class PermissionConnect extends Component {
     getRequestAccountTabIds();
 
     if (!permissionsRequest) {
-      history.push(DEFAULT_ROUTE);
+      history.replace(DEFAULT_ROUTE);
       return;
     }
 
@@ -130,17 +130,17 @@ export default class PermissionConnect extends Component {
 
       switch (requestType) {
         case 'wallet_installSnap':
-          history.push(snapInstallPath);
+          history.replace(snapInstallPath);
           break;
         case 'wallet_updateSnap':
-          history.push(snapUpdatePath);
+          history.replace(snapUpdatePath);
           break;
         case 'wallet_installSnapResult':
-          history.push(snapResultPath);
+          history.replace(snapResultPath);
           break;
         default:
           ///: END:ONLY_INCLUDE_IN
-          history.push(confirmPermissionPath);
+          history.replace(confirmPermissionPath);
         ///: BEGIN:ONLY_INCLUDE_IN(flask)
       }
       ///: END:ONLY_INCLUDE_IN


### PR DESCRIPTION
## Explanation

This removes the possiblity to go back on the "single-page" confirmations. Before we pushed to history instead of replacing. This means that we were able to go back to the default route of the confirmation flow.

* Fixes #18275


## Screenshots/Screencaps


### Before

![bug](https://user-images.githubusercontent.com/1561200/226891281-a6b60e6a-9e0d-4b5b-8b4e-22f77a848113.gif)

### After


https://user-images.githubusercontent.com/13910212/233085269-36518fe7-811c-4f4d-9e7e-8fdd897e540b.mp4

## Manual Testing Steps

- Try installing a snap
- Right-click on the pop-up
- Click "back"