### PR TITLE
Fix swaps controller: update provider after networkIdStore state update

### DIFF
--- a/app/scripts/controllers/swaps.js
+++ b/app/scripts/controllers/swaps.js
@@ -113,7 +113,7 @@ export default class SwapsController {
     fetchTradesInfo = defaultFetchTradesInfo,
     getCurrentChainId,
     getEIP1559GasFeeEstimates,
-    onNetworkDidChange,
+    onNetworkStateChange,
   }) {
     this.store = new ObservableStore({
       swapsState: { ...initialState.swapsState },
@@ -137,7 +137,7 @@ export default class SwapsController {
 
     this.ethersProvider = new Web3Provider(provider);
     this._currentNetworkId = networkController.store.getState().networkId;
-    onNetworkDidChange(() => {
+    onNetworkStateChange(() => {
       const { networkId, networkStatus } = networkController.store.getState();
       if (
         networkStatus === NetworkStatus.Available &&

--- a/app/scripts/controllers/swaps.test.js
+++ b/app/scripts/controllers/swaps.test.js
@@ -160,7 +160,7 @@ describe('SwapsController', function () {
     return new SwapsController({
       getBufferedGasLimit: MOCK_GET_BUFFERED_GAS_LIMIT,
       networkController: getMockNetworkController(),
-      onNetworkDidChange: sinon.stub(),
+      onNetworkStateChange: sinon.stub(),
       provider: _provider,
       getProviderConfig: MOCK_GET_PROVIDER_CONFIG,
       getTokenRatesState: MOCK_TOKEN_RATES_STORE,
@@ -208,11 +208,11 @@ describe('SwapsController', function () {
 
     it('should replace ethers instance when network changes', function () {
       const networkController = getMockNetworkController();
-      const onNetworkDidChange = sinon.stub();
+      const onNetworkStateChange = sinon.stub();
       const swapsController = new SwapsController({
         getBufferedGasLimit: MOCK_GET_BUFFERED_GAS_LIMIT,
         networkController,
-        onNetworkDidChange,
+        onNetworkStateChange,
         provider,
         getProviderConfig: MOCK_GET_PROVIDER_CONFIG,
         getTokenRatesState: MOCK_TOKEN_RATES_STORE,
@@ -220,7 +220,7 @@ describe('SwapsController', function () {
         getCurrentChainId: getCurrentChainIdStub,
       });
       const currentEthersInstance = swapsController.ethersProvider;
-      const changeNetwork = onNetworkDidChange.getCall(0).args[0];
+      const changeNetwork = onNetworkStateChange.getCall(0).args[0];
 
       networkController.store.getState.returns({
         networkId: NETWORK_IDS.MAINNET,
@@ -238,11 +238,11 @@ describe('SwapsController', function () {
 
     it('should not replace ethers instance when network changes to loading', function () {
       const networkController = getMockNetworkController();
-      const onNetworkDidChange = sinon.stub();
+      const onNetworkStateChange = sinon.stub();
       const swapsController = new SwapsController({
         getBufferedGasLimit: MOCK_GET_BUFFERED_GAS_LIMIT,
         networkController,
-        onNetworkDidChange,
+        onNetworkStateChange,
         provider,
         getProviderConfig: MOCK_GET_PROVIDER_CONFIG,
         getTokenRatesState: MOCK_TOKEN_RATES_STORE,
@@ -250,7 +250,7 @@ describe('SwapsController', function () {
         getCurrentChainId: getCurrentChainIdStub,
       });
       const currentEthersInstance = swapsController.ethersProvider;
-      const changeNetwork = onNetworkDidChange.getCall(0).args[0];
+      const changeNetwork = onNetworkStateChange.getCall(0).args[0];
 
       networkController.store.getState.returns({
         networkId: null,
@@ -268,11 +268,11 @@ describe('SwapsController', function () {
 
     it('should not replace ethers instance when network changes to the same network', function () {
       const networkController = getMockNetworkController();
-      const onNetworkDidChange = sinon.stub();
+      const onNetworkStateChange = sinon.stub();
       const swapsController = new SwapsController({
         getBufferedGasLimit: MOCK_GET_BUFFERED_GAS_LIMIT,
         networkController,
-        onNetworkDidChange,
+        onNetworkStateChange,
         provider,
         getProviderConfig: MOCK_GET_PROVIDER_CONFIG,
         getTokenRatesState: MOCK_TOKEN_RATES_STORE,
@@ -280,7 +280,7 @@ describe('SwapsController', function () {
         getCurrentChainId: getCurrentChainIdStub,
       });
       const currentEthersInstance = swapsController.ethersProvider;
-      const changeNetwork = onNetworkDidChange.getCall(0).args[0];
+      const changeNetwork = onNetworkStateChange.getCall(0).args[0];
 
       networkController.store.getState.returns({
         networkId: NETWORK_IDS.GOERLI,

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -1195,10 +1195,8 @@ export default class MetamaskController extends EventEmitter {
         this.txController.txGasUtil,
       ),
       networkController: this.networkController,
-      onNetworkDidChange: networkControllerMessenger.subscribe.bind(
-        networkControllerMessenger,
-        NetworkControllerEventType.NetworkDidChange,
-      ),
+      onNetworkStateChange: (listener) =>
+        this.networkController.networkIdStore.subscribe(listener),
       provider: this.provider,
       getProviderConfig: () => this.networkController.store.getState().provider,
       getTokenRatesState: () => this.tokenRatesController.state,

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -1196,7 +1196,7 @@ export default class MetamaskController extends EventEmitter {
       ),
       networkController: this.networkController,
       onNetworkStateChange: (listener) =>
-        this.networkController.networkIdStore.subscribe(listener),
+        this.networkController.store.subscribe(listener),
       provider: this.provider,
       getProviderConfig: () => this.networkController.store.getState().provider,
       getTokenRatesState: () => this.tokenRatesController.state,


### PR DESCRIPTION
Fixes https://github.com/MetaMask/metamask-extension/issues/18669

## Explanation

The linked bug is reproducible by the following steps:

1. Switch network to ethereum mainnet
2. reload the extension
3. switch to optimism
4. click swaps on the overview page
5. enter an eth amount
6. change the to currency to usdc
7. click review swap
8. see "Failed to fetch"

the bug is not reproducible if step 1 is "Switch network to optimism" and then step 3 is skipped

The problem is an assumption in the swaps controller, in this code:
```
    onNetworkDidChange(() => {
      const { networkId, networkStatus } = networkController.store.getState();
      if (
        networkStatus === NetworkStatus.Available &&
        networkId !== this._currentNetworkId
```
It is assumed that `networkId` and `networkStatus` will be updated when a `NetworkControllerEventType.NetworkDidChange` event is emitted. However, they are not updated until later. In the network controller, there is this code:
```
  _switchNetwork(opts) {
    this.messenger.publish(NetworkControllerEventTypes.NetworkWillChange);
    this._resetNetworkId();
    this._resetNetworkStatus();
    this._resetNetworkDetails();
    this._configureProvider(opts);
    this.messenger.publish(NetworkControllerEventTypes.NetworkDidChange);
    this.lookupNetwork();
  }
```
The necessary state updates are made within the `this.lookupNetwork();` call, which happens after `this.messenger.publish(NetworkControllerEventTypes.NetworkDidChange)`

And so the swaps controller does not update its provider correctly on a network state change.

The fix is for the swaps controller to subscribe to networkIdStore changes, so that we only attempt to update the provider after the necessary state changes are complete.

## Manual Testing Steps

1. Switch network to ethereum mainnet
2. reload the extension
3. switch to optimism
4. click swaps on the overview page
5. enter an eth amount
6. change the to currency to usdc
7. click review swap
8. swap quotes should be successfully retrieved, and you should now be on the swaps quote page

## Pre-merge author checklist

- [ ] I've clearly explained:
  - [ ] What problem this PR is solving
  - [ ] How this problem was solved
  - [ ] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [x] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
