### PR TITLE
Update NetworkController `setProviderType` to clear `rpcUrl`/`nickname`

### DIFF
--- a/app/scripts/controllers/network/network-controller.test.ts
+++ b/app/scripts/controllers/network/network-controller.test.ts
@@ -5006,10 +5006,10 @@ describe('NetworkController', () => {
 
               expect(controller.store.getState().provider).toStrictEqual({
                 type: networkType,
-                rpcUrl: '',
+                rpcUrl: undefined,
                 chainId,
                 ticker,
-                nickname: '',
+                nickname: undefined,
                 rpcPrefs: { blockExplorerUrl },
               });
             },
@@ -6975,10 +6975,10 @@ describe('NetworkController', () => {
             await controller.setProviderType('goerli');
             expect(controller.store.getState().provider).toStrictEqual({
               type: 'goerli',
-              rpcUrl: '',
+              rpcUrl: undefined,
               chainId: '0x5',
               ticker: 'GoerliETH',
-              nickname: '',
+              nickname: undefined,
               rpcPrefs: {
                 blockExplorerUrl: 'https://goerli.etherscan.io',
               },

--- a/app/scripts/controllers/network/network-controller.ts
+++ b/app/scripts/controllers/network/network-controller.ts
@@ -742,10 +742,10 @@ export class NetworkController extends EventEmitter {
     const network = BUILT_IN_INFURA_NETWORKS[type];
     await this.#setProviderConfig({
       type,
-      rpcUrl: '',
+      rpcUrl: undefined,
       chainId: network.chainId,
       ticker: 'ticker' in network ? network.ticker : 'ETH',
-      nickname: '',
+      nickname: undefined,
       rpcPrefs: { blockExplorerUrl: network.blockExplorerUrl },
     });
   }


### PR DESCRIPTION


## Explanation

<!--
Thanks for the pull request. Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues, Slack conversations, Zendesk issues, user stories, etc. reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

In the core version of NetworkController, `setProviderType` sets `rpcTarget` (its name for `rpcUrl`) and `nickname` to `undefined`. While it would be better to completely remove these properties, it would be better to follow suit so that we can make the tests between the two versions of the controllers more alike.

See corresponding code in `core`: https://github.com/MetaMask/core/blob/684470616b55c0ab2556bdc09bdf6970f6ba0be2/packages/network-controller/src/NetworkController.ts#L493

Fixes https://github.com/MetaMask/metamask-extension/issues/18673.

## Manual Testing Steps

<!--
How should reviewers and QA manually test your changes? For instance:

- Go to this screen
- Do this
- Then do this
-->

There should be no functional changes, but anything that is using `rpcUrl` or `nickname` when the provider type is an Infura provider type as opposed to "rpc", or anything that is treating `""` as an unset RPC URL (e.g. `if (rpcUrl !== '')` or `rpcUrl || somethingElse` as opposed to `if (rpcUrl)` or `rpcUrl ?? somethingElse`), may be affected. I've done my best to confirm that this is not the case in this codebase.

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
