### PR TITLE
Adding deprecation notice to javascript version of Icon

### DIFF
--- a/ui/components/component-library/icon/deprecated/icon.js
+++ b/ui/components/component-library/icon/deprecated/icon.js
@@ -19,6 +19,7 @@ import { ICON_SIZES, ICON_NAMES } from './icon.constants';
  *
  * `import { Icon, IconSize, IconName } from '../../component-library'`;
  */
+
 export const Icon = ({
   name,
   size = Size.MD,

--- a/ui/components/component-library/icon/deprecated/icon.js
+++ b/ui/components/component-library/icon/deprecated/icon.js
@@ -12,6 +12,13 @@ import {
 
 import { ICON_SIZES, ICON_NAMES } from './icon.constants';
 
+/**
+ * @deprecated This is the javascript version of `Icon` which has been deprecated in favour of the TypeScript version of the same name.
+ *
+ * To use the TS version update the imports and enums as follows:
+ *
+ * `import { Icon, IconSize, IconName } from '../../component-library'`;
+ */
 export const Icon = ({
   name,
   size = Size.MD,


### PR DESCRIPTION
## Explanation

Adding a deprecation notice to the JS version of the `Icon` component

## Screenshots/Screencaps

### Before

<img width="620" alt="Screenshot 2023-04-20 at 6 05 20 PM" src="https://user-images.githubusercontent.com/8112138/233309000-740626c3-576f-48b8-8a0e-db5d9e5250ee.png">

### After

<img width="645" alt="Screenshot 2023-04-20 at 6 04 18 PM" src="https://user-images.githubusercontent.com/8112138/233308793-312757fa-50f8-4d36-a64c-cc0b0f9b1d68.png">

<img width="621" alt="Screenshot 2023-04-20 at 6 08 55 PM" src="https://user-images.githubusercontent.com/8112138/233309933-42642267-21e1-4509-8216-09851d8cee1b.png">


## Manual Testing Steps

- Checkout this branch 
- Search for `component-library/icon/deprecated`
- Find an import that used the `Icon` component 
- See that it's striked out

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
