### PR TITLE
Fixing issue with gasLimit in transaction being 0

### DIFF
--- a/app/scripts/controllers/transactions/index.js
+++ b/app/scripts/controllers/transactions/index.js
@@ -802,8 +802,8 @@ export default class TransactionController extends EventEmitter {
         this.txStateManager.getTransactionWithActionId(actionId);
       if (existingTxMeta) {
         this.emit('newUnapprovedTx', existingTxMeta);
-        this._requestApproval(existingTxMeta);
         existingTxMeta = await this.addTransactionGasDefaults(existingTxMeta);
+        this._requestApproval(existingTxMeta);
         return existingTxMeta;
       }
     }
@@ -875,9 +875,9 @@ export default class TransactionController extends EventEmitter {
 
     this.addTransaction(txMeta);
     this.emit('newUnapprovedTx', txMeta);
-    this._requestApproval(txMeta);
 
     txMeta = await this.addTransactionGasDefaults(txMeta);
+    this._requestApproval(txMeta);
 
     return txMeta;
   }


### PR DESCRIPTION
Fixes: #18667

Fix issue of gas limit in transaction being `0` when multiple transactions are created.