### PR TITLE
UX: Multichain: Network Menu: Set Focus on Selected Network

### DIFF
--- a/ui/components/multichain/network-list-item/network-list-item.js
+++ b/ui/components/multichain/network-list-item/network-list-item.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import classnames from 'classnames';
 import PropTypes from 'prop-types';
 import Box from '../../ui/box/box';
@@ -31,6 +31,14 @@ export const NetworkListItem = ({
   onDeleteClick,
 }) => {
   const t = useI18nContext();
+  const networkRef = useRef();
+
+  useEffect(() => {
+    if (networkRef.current && selected) {
+      networkRef.current.querySelector('.mm-button-link').focus();
+    }
+  }, [networkRef, selected]);
+
   return (
     <Box
       onClick={onClick}
@@ -43,6 +51,7 @@ export const NetworkListItem = ({
       alignItems={AlignItems.center}
       justifyContent={JustifyContent.spaceBetween}
       width={BLOCK_SIZES.FULL}
+      ref={networkRef}
     >
       {selected && (
         <Box
@@ -53,7 +62,14 @@ export const NetworkListItem = ({
       )}
       <AvatarNetwork name={name} src={iconSrc} />
       <Box className="multichain-network-list-item__network-name">
-        <ButtonLink onClick={onClick} color={TextColor.textDefault} ellipsis>
+        <ButtonLink
+          onClick={(e) => {
+            e.stopPropagation();
+            onClick();
+          }}
+          color={TextColor.textDefault}
+          ellipsis
+        >
           {name.length > MAXIMUM_CHARACTERS_WITHOUT_TOOLTIP ? (
             <Tooltip
               title={name}


### PR DESCRIPTION
## Explanation

At present, when the network popover pops up, the keyboard focus stays in the background.  That is bad for accessibility.  With this PR, the keyboard focus is set to the currently selected network in the list.  Not only is the better for keyboard accessibility, but if the user has a long network list and the selected network is in the scroll area, the selected item will immediately be in focus.

## Manual Testing Steps

1.  Add 5+ networks to your MetaMask
2. Click the network picker
3. Click the last network in the list
4. Click the Network picker again
5. See the current selected network scrolled down to, and that you can tab around in the menu

## Pre-merge author checklist

- [ ] I've clearly explained:
  - [ ] What problem this PR is solving
  - [ ] How this problem was solved
  - [ ] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
