### PR TITLE
Stop transpiling libraries using ES2020

### DIFF
--- a/development/build/scripts.js
+++ b/development/build/scripts.js
@@ -889,17 +889,6 @@ function setupBundlerDefaults(
         // Run TypeScript files through Babel
         { extensions },
       ],
-      // Transpile libraries that use ES2020 unsupported by Chrome v78
-      [
-        babelify,
-        {
-          only: [
-            './**/node_modules/@ethereumjs/util',
-            './**/node_modules/superstruct',
-          ],
-          global: true,
-        },
-      ],
       // Inline `fs.readFileSync` files
       brfs,
     ],


### PR DESCRIPTION
## Explanation

Stops transpiling libraries that are using ES2020, since we now support Chrome 80. The transpilation was added as a temporary measure here: #17251
