### PR TITLE
[FLASK] Fix text selection bug in snap ui

### DIFF
--- a/ui/pages/confirmation/templates/flask/snap-alert/snap-alert.js
+++ b/ui/pages/confirmation/templates/flask/snap-alert/snap-alert.js
@@ -6,6 +6,7 @@ function getValues(pendingApproval, t, actions) {
     snapName,
     requestData: { content },
   } = pendingApproval;
+  const elementKeyIndex = { value: 0 };
 
   return {
     content: [
@@ -24,7 +25,7 @@ function getValues(pendingApproval, t, actions) {
             snapName,
           },
           // TODO: Replace with SnapUIRenderer when we don't need to inject the input manually.
-          children: mapToTemplate(content),
+          children: mapToTemplate(content, elementKeyIndex),
         },
       },
     ],

--- a/ui/pages/confirmation/templates/flask/snap-confirmation/snap-confirmation.js
+++ b/ui/pages/confirmation/templates/flask/snap-confirmation/snap-confirmation.js
@@ -6,6 +6,7 @@ function getValues(pendingApproval, t, actions) {
     snapName,
     requestData: { content },
   } = pendingApproval;
+  const elementKeyIndex = { value: 0 };
 
   return {
     content: [
@@ -24,7 +25,7 @@ function getValues(pendingApproval, t, actions) {
             snapName,
           },
           // TODO: Replace with SnapUIRenderer when we don't need to inject the input manually.
-          children: mapToTemplate(content),
+          children: mapToTemplate(content, elementKeyIndex),
         },
       },
     ],

--- a/ui/pages/confirmation/templates/flask/snap-prompt/snap-prompt.js
+++ b/ui/pages/confirmation/templates/flask/snap-prompt/snap-prompt.js
@@ -7,6 +7,7 @@ function getValues(pendingApproval, t, actions, _history, setInputState) {
     snapName,
     requestData: { content, placeholder },
   } = pendingApproval;
+  const elementKeyIndex = { value: 0 };
 
   return {
     content: [
@@ -26,7 +27,7 @@ function getValues(pendingApproval, t, actions, _history, setInputState) {
           },
           children: [
             // TODO: Replace with SnapUIRenderer when we don't need to inject the input manually.
-            mapToTemplate(content),
+            mapToTemplate(content, elementKeyIndex),
             {
               element: 'div',
               key: 'snap-prompt-container',


### PR DESCRIPTION
## Explanation
Fixes: https://github.com/MetaMask/snaps-monorepo/issues/1281

Because of the non-deterministic keys used for Snaps UI elements, `React.memo()` was not working properly and components have been re-rendered multiple times.
Deterministic keys are implemented in this PR and will solve the issue with redundant re-rendering which was taking over the user's text selection.

## Screenshots/Screencaps
### Before
Look at the video provided in: https://github.com/MetaMask/snaps-monorepo/issues/1281
https://user-images.githubusercontent.com/19909/225138286-158951e5-a80a-4ef2-a15e-cebb80a971f5.mov

### After
![Screenshot 2023-04-21 at 13 07 52](https://user-images.githubusercontent.com/13301024/233630713-77654d86-ee38-44e8-a729-b81d2b9c5652.png)
![Screenshot 2023-04-21 at 13 08 18](https://user-images.githubusercontent.com/13301024/233630727-86b4efff-c50f-4727-b2b7-fb26c60045a3.png)
Result: Text selection is possible (copy/paste).

## Manual Testing Steps
1. Create or install some of the existing snaps with multiple UI elements (e.g. Transaction insights, MobyMask, etc).
2. Trigger the transaction confirmation window where Snap UI elements are displayed.
3. Try selecting text inside the Snap UI boxes. Try copy and paste of the text.
4. Text selection should remain and copy/paste should be possible.

## Pre-merge author checklist

- [ ] I've clearly explained:
  - [ ] What problem this PR is solving
  - [ ] How this problem was solved
  - [ ] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
