### PR TITLE
Add "Do Not Merge" GH Action to block PRs with "DO-NOT-MERGE" label

### DIFF
--- a/.github/workflows/do-not-merge.yml
+++ b/.github/workflows/do-not-merge.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   do-not-merge:
     runs-on: ubuntu-latest
-    if: ${{ contains(github.event.*.labels.*.name, 'DO-NOT-MERGE') }}
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'DO-NOT-MERGE') }}
     steps:
       - name: 'Check for label "DO-NOT-MERGE"'
         run: |

--- a/.github/workflows/do-not-merge.yml
+++ b/.github/workflows/do-not-merge.yml
@@ -1,0 +1,17 @@
+# Fails the pull request if it has the "DO-NOT-MERGE" label
+
+name: Do Not Merge
+
+on:
+  pull_request:
+    types: [opened, reopened, labeled, unlabeled, synchronize]
+
+jobs:
+  do-not-merge:
+    runs-on: ubuntu-latest
+    if: ${{ contains(github.event.*.labels.*.name, 'DO-NOT-MERGE') }}
+    steps:
+      - name: 'Check for label "DO-NOT-MERGE"'
+        run: |
+          echo 'This check fails PRs with the "DO-NOT-MERGE" label'
+          exit 1

--- a/.github/workflows/do-not-merge.yml
+++ b/.github/workflows/do-not-merge.yml
@@ -1,6 +1,6 @@
 # Fails the pull request if it has the "DO-NOT-MERGE" label
 
-name: Do Not Merge
+name: Check "DO-NOT-MERGE" label
 
 on:
   pull_request:
@@ -13,5 +13,5 @@ jobs:
     steps:
       - name: 'Check for label "DO-NOT-MERGE"'
         run: |
-          echo 'This check fails PRs with the "DO-NOT-MERGE" label'
+          echo 'This check fails PRs with the "DO-NOT-MERGE" label to block merging'
           exit 1


### PR DESCRIPTION
## Explanation

backstory: 
I accidentally merged a PR with the "DO-NOT-MERGE" label today https://github.com/MetaMask/metamask-extension/pull/18652 😅

This PR blocks PRs with the "DO-NOT-MERGE" from being merged

Inspo for logic https://www.jessesquires.com/blog/2021/08/24/useful-label-based-github-actions-workflows/#updated-21-march-2022

## Screenshots/Screencaps

<img width="755" alt="Screen Shot 2023-04-21 at 11 18 58 AM" src="https://user-images.githubusercontent.com/20778143/233659736-3191191c-4114-4b28-95d8-2e4d48c1ff24.png">


## Manual Testing Steps

Apply or Remove "DO-NOT-MERGE" label and observe PR checks below

<!--
How should reviewers and QA manually test your changes? For instance:

- Go to this screen
- Do this
- Then do this
-->

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
