### PR TITLE
[FLASK] Update snap install warning

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -3682,7 +3682,7 @@
     "description": "$1 is the dApp origin requesting the snap and $2 is the snap name"
   },
   "snapInstallWarningCheck": {
-    "message": "Ensure that the permission below align with your intended actions. Only proceed with authors you trust."
+    "message": "Ensure that the permission below aligns with your intended actions. Only proceed with authors you trust."
   },
   "snapInstallWarningCheckPlural": {
     "message": "Ensure that the permissions below align with your intended actions. Only proceed with authors you trust."

--- a/ui/helpers/utils/permission.js
+++ b/ui/helpers/utils/permission.js
@@ -367,7 +367,7 @@ export const PERMISSION_DESCRIPTIONS = deepFreeze({
     label: t('permission_ethereumProvider'),
     description: t('permission_ethereumProviderDescription'),
     leftIcon: ICON_NAMES.ETHEREUM,
-    weight: 1,
+    weight: 2,
     id: 'ethereum-provider-access',
     message: t('ethereumProviderAccess', [targetSubjectMetadata?.origin]),
   }),


### PR DESCRIPTION
Weight for the `endowment:ethereum-provider` endowment was changed to `2`. The snaps team has agreed that the level of access the endowment provides doesn't warrant a weight of `1`. The copy for the warning was also updated to fix a grammar mistake.