### PR TITLE
Part of #18714 : Replaced deprecated design system typography consts with enums

### DIFF
--- a/ui/components/app/approve-content-card/approve-content-card.js
+++ b/ui/components/app/approve-content-card/approve-content-card.js
@@ -183,8 +183,7 @@ export default function ApproveContentCard({
                       <Box>
                         <Text
                           variant={TextVariant.headingSm}
-                          fontWeight={FontWeight.Bold}
-                          color={TextColor.TEXT_DEFAULT}
+                          color={TextColor.textDefault}
                           as="h4"
                         >
                           {formatCurrency(

--- a/ui/components/app/approve-content-card/approve-content-card.js
+++ b/ui/components/app/approve-content-card/approve-content-card.js
@@ -12,7 +12,6 @@ import {
   BLOCK_SIZES,
   DISPLAY,
   FLEX_DIRECTION,
-  FontWeight,
   JustifyContent,
   TextAlign,
   TextColor,
@@ -196,7 +195,6 @@ export default function ApproveContentCard({
                     <Box>
                       <Text
                         variant={TextVariant.bodySm}
-                        fontWeight={FontWeight.Normal}
                         color={TextColor.textMuted}
                         as="h6"
                       >


### PR DESCRIPTION
## Explanation
Replaced deprecated design system typography consts with enums as per the requirement from the issue #18714 

<!--
Thanks for the pull request. Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues, Slack conversations, Zendesk issues, user stories, etc. reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

## Screenshots/Screencaps

<!-- If you're making a change to the UI, make sure to capture a screenshot or a short video showing off your work! -->

### Before

`ui/components/app/approve-content-card/approve-content-card.js
`

![Opera Snapshot_2023-04-22_144533_localhost](https://user-images.githubusercontent.com/68021378/233776473-d83a599e-eb40-4e3d-a6c5-95e3d615dbba.png)

`ui/components/app/confirm-hexdata/confirm-hexdata.js`


![Opera Snapshot_2023-04-22_145721_localhost](https://user-images.githubusercontent.com/68021378/233776513-03efa529-73c2-4e2a-acd8-88ff0936171f.png)


<!-- How did the UI you changed look before your changes? Drag your file(s) below this line: -->

### After

`ui/components/app/approve-content-card/approve-content-card.js`

![approvecardAfter](https://user-images.githubusercontent.com/68021378/233776599-f2e3f834-4ecc-4384-9855-c3eb7e8d2a81.png)


`ui/components/app/confirm-hexdata/confirm-hexdata.js`

![HexDataAfter](https://user-images.githubusercontent.com/68021378/233776639-628a0f5a-355a-457f-bac1-78a4e1dcd861.png)






<!-- How does it look now? Drag your file(s) below this line: -->

## Manual Testing Steps

- Open Storybook in your local environment 
- Search `ApproveContentCard` and `ConfirmHexData`
- Check the Results against the this Develop link : [https://metamask.github.io/metamask-storybook/?path=/story/components-app-addnetwork--default-story](url)
<!--
How should reviewers and QA manually test your changes? For instance:

- Go to this screen
- Do this
- Then do this
-->

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
