### PR TITLE
Improve logging at build-time

### DIFF
--- a/development/build/scripts.js
+++ b/development/build/scripts.js
@@ -1074,6 +1074,11 @@ async function createBundle(buildConfiguration, { reloadOnChange }) {
         logError(error);
         process.exit(1);
       });
+      pipeline.on('error', (error) => {
+        console.error('Pipeline failed! See details below.');
+        logError(error);
+        process.exit(1);
+      })
     }
     // trigger build pipeline instrumentations
     events.emit('configurePipeline', { pipeline, bundleStream });

--- a/development/build/scripts.js
+++ b/development/build/scripts.js
@@ -1078,7 +1078,7 @@ async function createBundle(buildConfiguration, { reloadOnChange }) {
         console.error('Pipeline failed! See details below.');
         logError(error);
         process.exit(1);
-      })
+      });
     }
     // trigger build pipeline instrumentations
     events.emit('configurePipeline', { pipeline, bundleStream });

--- a/development/build/task.js
+++ b/development/build/task.js
@@ -80,12 +80,9 @@ function runInChildProcess(
     );
 
     // forward logs to main process
-    // skip the first stdout event (announcing the process command)
-    childProcess.stdout.once('data', () => {
-      childProcess.stdout.on('data', (data) =>
-        process.stdout.write(`${taskName}: ${data}`),
-      );
-    });
+    childProcess.stdout.on('data', (data) =>
+      process.stdout.write(`${taskName}: ${data}`),
+    );
 
     childProcess.stderr.on('data', (data) =>
       process.stderr.write(`${taskName}: ${data}`),


### PR DESCRIPTION
## Explanation

Improves logging at build-time. We were previously not logging errors that occurred in the `pipeline` stream. We also were skipping some `stdout` output unnecessarily.
