### PR TITLE
[FLASK] Fix missing icon for webassembly endowment

### DIFF
--- a/ui/helpers/utils/permission.js
+++ b/ui/helpers/utils/permission.js
@@ -312,7 +312,7 @@ export const PERMISSION_DESCRIPTIONS = deepFreeze({
   [EndowmentPermissions['endowment:webassembly']]: ({ t }) => ({
     label: t('permission_webAssembly'),
     description: t('permission_webAssemblyDescription'),
-    leftIcon: 'fas fa-microchip',
+    leftIcon: ICON_NAMES.DOCUMENT_CODE,
     rightIcon: null,
     weight: 2,
   }),


### PR DESCRIPTION
## Explanation
This PR is hotfix for missing icon used for WebAssembly endowment.
WebAssembly was the only permission using FA icons with `'fas fa-microchip'` and is replaced with `ICON_NAMES.DOCUMENT_CODE` in this PR.

## Screenshots/Screencaps

### Before
![Screenshot 2023-04-24 at 16 46 42](https://user-images.githubusercontent.com/13301024/234032390-147768fd-3e00-4d3d-9ade-1feea84d0c72.png)
![image](https://user-images.githubusercontent.com/13301024/234032401-0d406438-bbe5-4a9d-98b1-ca211daf513e.png)


### After
![Screenshot 2023-04-24 at 16 36 03](https://user-images.githubusercontent.com/13301024/234030984-42f03938-964b-4dc8-9945-2f2d38a22af5.png)

## Manual Testing Steps
1. Create or install a snap with `"endowment:webassembly": {},` permission.
2. Try to install snap with WebAssembly permission.
3. Icon for WebAssembly permission should be visible as on the image on this PR under `After` screenshot.

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
