### PR TITLE
UX: Multichain: Use correct blockie or jazzicon in the account menu

### DIFF
--- a/ui/components/multichain/account-list-item/account-list-item.js
+++ b/ui/components/multichain/account-list-item/account-list-item.js
@@ -18,6 +18,7 @@ import {
   ButtonIcon,
   IconName,
   IconSize,
+  AvatarAccountVariant,
 } from '../../component-library';
 import {
   Color,
@@ -70,6 +71,8 @@ export const AccountListItem = ({
   const t = useI18nContext();
   const [accountOptionsMenuOpen, setAccountOptionsMenuOpen] = useState(false);
   const ref = useRef(false);
+  const useBlockie = useSelector((state) => state.metamask.useBlockie);
+
   const keyring = useSelector((state) =>
     findKeyringForAddress(state, identity.address),
   );
@@ -107,6 +110,11 @@ export const AccountListItem = ({
         borderColor={BorderColor.transparent}
         size={Size.SM}
         address={identity.address}
+        variant={
+          useBlockie
+            ? AvatarAccountVariant.Blockies
+            : AvatarAccountVariant.Jazzicon
+        }
       ></AvatarAccount>
       <Box
         display={DISPLAY.FLEX}


### PR DESCRIPTION
## Explanation

@vthomas13 correctly pointed out that the account list isn't adhering to the use of Blockies or Jazzicons.  Great catch!  This ensures that the correct image is displayed based on blockie or jazzicon preference.

## Screenshots/Screencaps

<img width="365" alt="SCR-20230424-jfnm" src="https://user-images.githubusercontent.com/46655/234036663-88dd556e-a346-4b55-914b-75d405dced6a.png">

## Manual Testing Steps

1.  See the account menu using blockies
2. Go to settings, switch to Jazzicons 
3. See the account menu use jazzicons

## Pre-merge author checklist

- [ ] I've clearly explained:
  - [ ] What problem this PR is solving
  - [ ] How this problem was solved
  - [ ] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
