### PR TITLE
Fix ICON_NAMES error for snaps settings

### DIFF
--- a/ui/pages/settings/settings.component.js
+++ b/ui/pages/settings/settings.component.js
@@ -276,7 +276,7 @@ class SettingsPage extends PureComponent {
       {
         content: t('snaps'),
         icon: (
-          <Icon name={ICON_NAMES.SNAPS} title={t('snapsSettingsDescription')} />
+          <Icon name={IconName.Snaps} title={t('snapsSettingsDescription')} />
         ),
         key: SNAPS_LIST_ROUTE,
       },


### PR DESCRIPTION
## Explanation

This appears to be broken on `develop` branch right now.  `ICON_NAMES` became `IconName`

## Pre-merge author checklist

- [ ] I've clearly explained:
  - [ ] What problem this PR is solving
  - [ ] How this problem was solved
  - [ ] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
