### PR TITLE
Revert "Shallow git clone (#18491)"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,24 +24,6 @@ rc_branch_only: &rc_branch_only
       only:
         - /^Version-v(\d+)[.](\d+)[.](\d+)/
 
-aliases:
-  # Shallow Git Clone
-  - &shallow-git-clone
-    name: Shallow Git Clone
-    command: |
-      #!/bin/bash
-      set -e
-      set -u
-      set -o pipefail
-
-      # Set up SSH access
-      # This SSH key is the current github.com SSH key as of April 2023, but it will need to be changed whenever github changes their key (probably every few years)
-      GITHUB_SSH_KEY="AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl"
-      mkdir -p ~/.ssh
-      echo github.com ssh-ed25519 $GITHUB_SSH_KEY >> ~/.ssh/known_hosts
-
-      git clone --depth 1 "$CIRCLE_REPOSITORY_URL" --branch "$CIRCLE_BRANCH" .
-
 workflows:
   test_and_release:
     jobs:
@@ -252,7 +234,7 @@ jobs:
   trigger-beta-build:
     executor: node-browsers-medium-plus
     steps:
-      - run: *shallow-git-clone
+      - checkout
       - attach_workspace:
           at: .
       - when:
@@ -281,7 +263,7 @@ jobs:
   create_release_pull_request:
     executor: node-browsers
     steps:
-      - run: *shallow-git-clone
+      - checkout
       - attach_workspace:
           at: .
       - run:
@@ -300,7 +282,7 @@ jobs:
   prep-deps:
     executor: node-browsers
     steps:
-      - run: *shallow-git-clone
+      - checkout
       - restore_cache:
           keys:
             # First try to get the specific cache for the checksum of the yarn.lock file.
@@ -350,7 +332,7 @@ jobs:
   validate-lavamoat-config:
     executor: node-browsers-medium-plus
     steps:
-      - run: *shallow-git-clone
+      - checkout
       - attach_workspace:
           at: .
       - run:
@@ -365,7 +347,7 @@ jobs:
   prep-build:
     executor: node-browsers-medium-plus
     steps:
-      - run: *shallow-git-clone
+      - checkout
       - attach_workspace:
           at: .
       - when:
@@ -399,7 +381,7 @@ jobs:
   prep-build-desktop:
     executor: node-browsers-medium-plus
     steps:
-      - run: *shallow-git-clone
+      - checkout
       - attach_workspace:
           at: .
       - run:
@@ -423,7 +405,7 @@ jobs:
   prep-build-flask:
     executor: node-browsers-medium-plus
     steps:
-      - run: *shallow-git-clone
+      - checkout
       - attach_workspace:
           at: .
       - when:
@@ -463,7 +445,7 @@ jobs:
   prep-build-test-flask:
     executor: node-browsers-medium-plus
     steps:
-      - run: *shallow-git-clone
+      - checkout
       - attach_workspace:
           at: .
       - run:
@@ -484,7 +466,7 @@ jobs:
   prep-build-test-mv3:
     executor: node-browsers-medium-plus
     steps:
-      - run: *shallow-git-clone
+      - checkout
       - attach_workspace:
           at: .
       - run:
@@ -505,7 +487,7 @@ jobs:
   prep-build-test:
     executor: node-browsers-medium-plus
     steps:
-      - run: *shallow-git-clone
+      - checkout
       - attach_workspace:
           at: .
       - run:
@@ -526,7 +508,7 @@ jobs:
   prep-build-storybook:
     executor: node-browsers-medium-plus
     steps:
-      - run: *shallow-git-clone
+      - checkout
       - attach_workspace:
           at: .
       - run:
@@ -540,7 +522,7 @@ jobs:
   prep-build-ts-migration-dashboard:
     executor: node-browsers
     steps:
-      - run: *shallow-git-clone
+      - checkout
       - attach_workspace:
           at: .
       - run:
@@ -554,7 +536,7 @@ jobs:
   test-yarn-dedupe:
     executor: node-browsers
     steps:
-      - run: *shallow-git-clone
+      - checkout
       - attach_workspace:
           at: .
       - run:
@@ -564,7 +546,7 @@ jobs:
   test-lint:
     executor: node-browsers
     steps:
-      - run: *shallow-git-clone
+      - checkout
       - attach_workspace:
           at: .
       - run:
@@ -577,7 +559,7 @@ jobs:
   test-storybook:
     executor: node-browsers-medium-plus
     steps:
-      - run: *shallow-git-clone
+      - checkout
       - attach_workspace:
           at: .
       - run:
@@ -599,7 +581,7 @@ jobs:
   test-lint-lockfile:
     executor: node-browsers
     steps:
-      - run: *shallow-git-clone
+      - checkout
       - attach_workspace:
           at: .
       - run:
@@ -609,7 +591,7 @@ jobs:
   test-lint-changelog:
     executor: node-browsers
     steps:
-      - run: *shallow-git-clone
+      - checkout
       - attach_workspace:
           at: .
       - when:
@@ -635,7 +617,7 @@ jobs:
   test-deps-audit:
     executor: node-browsers
     steps:
-      - run: *shallow-git-clone
+      - checkout
       - attach_workspace:
           at: .
       - run:
@@ -645,7 +627,7 @@ jobs:
   test-deps-depcheck:
     executor: node-browsers
     steps:
-      - run: *shallow-git-clone
+      - checkout
       - attach_workspace:
           at: .
       - run:
@@ -656,7 +638,7 @@ jobs:
     executor: node-browsers
     parallelism: 8
     steps:
-      - run: *shallow-git-clone
+      - checkout
       - run:
           name: Re-Install Chrome
           command: ./.circleci/scripts/chrome-install.sh
@@ -693,7 +675,7 @@ jobs:
     executor: node-browsers
     parallelism: 8
     steps:
-      - run: *shallow-git-clone
+      - checkout
       - run:
           name: Re-Install Chrome
           command: ./.circleci/scripts/chrome-install.sh
@@ -721,7 +703,7 @@ jobs:
     executor: node-browsers
     parallelism: 4
     steps:
-      - run: *shallow-git-clone
+      - checkout
       - run:
           name: Install Firefox
           command: ./.circleci/scripts/firefox-install.sh
@@ -758,7 +740,7 @@ jobs:
     executor: node-browsers
     parallelism: 4
     steps:
-      - run: *shallow-git-clone
+      - checkout
       - run:
           name: Re-Install Chrome
           command: ./.circleci/scripts/chrome-install.sh
@@ -795,7 +777,7 @@ jobs:
     executor: node-browsers-medium-plus
     parallelism: 8
     steps:
-      - run: *shallow-git-clone
+      - checkout
       - run:
           name: Install Firefox
           command: ./.circleci/scripts/firefox-install.sh
@@ -831,7 +813,7 @@ jobs:
   benchmark:
     executor: node-browsers-medium-plus
     steps:
-      - run: *shallow-git-clone
+      - checkout
       - run:
           name: Re-Install Chrome
           command: ./.circleci/scripts/chrome-install.sh
@@ -857,7 +839,7 @@ jobs:
   user-actions-benchmark:
     executor: node-browsers-medium-plus
     steps:
-      - run: *shallow-git-clone
+      - checkout
       - run:
           name: Re-Install Chrome
           command: ./.circleci/scripts/chrome-install.sh
@@ -883,7 +865,7 @@ jobs:
   stats-module-load-init:
     executor: node-browsers-medium-plus
     steps:
-      - run: *shallow-git-clone
+      - checkout
       - run:
           name: Re-Install Chrome
           command: ./.circleci/scripts/chrome-install.sh
@@ -980,7 +962,7 @@ jobs:
   job-publish-release:
     executor: node-browsers
     steps:
-      - run: *shallow-git-clone
+      - checkout
       - attach_workspace:
           at: .
       - run:
@@ -1000,7 +982,7 @@ jobs:
       - add_ssh_keys:
           fingerprints:
             - '3d:49:29:f4:b2:e8:ea:af:d1:32:eb:2a:fc:15:85:d8'
-      - run: *shallow-git-clone
+      - checkout
       - attach_workspace:
           at: .
       - run:
@@ -1015,7 +997,7 @@ jobs:
       - add_ssh_keys:
           fingerprints:
             - '8b:21:e3:20:7c:c9:db:82:74:2d:86:d6:11:a7:2f:49'
-      - run: *shallow-git-clone
+      - checkout
       - attach_workspace:
           at: .
       - run:
@@ -1029,7 +1011,7 @@ jobs:
   test-unit-mocha:
     executor: node-browsers-medium-plus
     steps:
-      - run: *shallow-git-clone
+      - checkout
       - attach_workspace:
           at: .
       - run:
@@ -1044,7 +1026,7 @@ jobs:
   test-unit-jest-development:
     executor: node-browsers
     steps:
-      - run: *shallow-git-clone
+      - checkout
       - attach_workspace:
           at: .
       - run:
@@ -1061,7 +1043,7 @@ jobs:
     executor: node-browsers-medium-plus
     parallelism: 12
     steps:
-      - run: *shallow-git-clone
+      - checkout
       - attach_workspace:
           at: .
       - run:
@@ -1077,7 +1059,7 @@ jobs:
   upload-and-validate-coverage:
     executor: node-browsers
     steps:
-      - run: *shallow-git-clone
+      - checkout
       - attach_workspace:
           at: .
       - codecov/upload
@@ -1092,7 +1074,7 @@ jobs:
   test-unit-global:
     executor: node-browsers
     steps:
-      - run: *shallow-git-clone
+      - checkout
       - attach_workspace:
           at: .
       - run:
@@ -1102,7 +1084,7 @@ jobs:
   validate-source-maps:
     executor: node-browsers
     steps:
-      - run: *shallow-git-clone
+      - checkout
       - attach_workspace:
           at: .
       - run:
@@ -1112,7 +1094,7 @@ jobs:
   validate-source-maps-beta:
     executor: node-browsers
     steps:
-      - run: *shallow-git-clone
+      - checkout
       - attach_workspace:
           at: .
       - run:
@@ -1123,7 +1105,7 @@ jobs:
   validate-source-maps-desktop:
     executor: node-browsers
     steps:
-      - run: *shallow-git-clone
+      - checkout
       - attach_workspace:
           at: .
       - run:
@@ -1139,7 +1121,7 @@ jobs:
   validate-source-maps-flask:
     executor: node-browsers
     steps:
-      - run: *shallow-git-clone
+      - checkout
       - attach_workspace:
           at: .
       - run:
@@ -1155,7 +1137,7 @@ jobs:
   test-mozilla-lint:
     executor: node-browsers
     steps:
-      - run: *shallow-git-clone
+      - checkout
       - attach_workspace:
           at: .
       - run:
@@ -1165,7 +1147,7 @@ jobs:
   test-mozilla-lint-beta:
     executor: node-browsers
     steps:
-      - run: *shallow-git-clone
+      - checkout
       - attach_workspace:
           at: .
       - run:
@@ -1176,7 +1158,7 @@ jobs:
   test-mozilla-lint-desktop:
     executor: node-browsers
     steps:
-      - run: *shallow-git-clone
+      - checkout
       - attach_workspace:
           at: .
       - run:
@@ -1192,7 +1174,7 @@ jobs:
   test-mozilla-lint-flask:
     executor: node-browsers
     steps:
-      - run: *shallow-git-clone
+      - checkout
       - attach_workspace:
           at: .
       - run:


### PR DESCRIPTION
This reverts commit b704a3d60f407eac99a7dc3f8a65529eff812203.

## Explanation
in #18491 there was discussion that this does not work for all forks. In #18783 @HowardBraham is experimenting with fixes for this issue. For now, this will get fork builds working 
