### PR TITLE
Add snaps entries to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,6 +10,7 @@
 *                                    @MetaMask/extension-devs
 development/                         @MetaMask/extension-devs @kumavis
 lavamoat/                            @MetaMask/supply-chain
+**/snaps/**                          @MetaMask/snaps-devs
 
 # The .circleci/ folder instructs Circle CI on the process by which it
 # should test, build and publish releases of our application. Due to the

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,21 +1,22 @@
 # Lines starting with '#' are comments.
 # Each line is a file pattern followed by one or more owners.
 # Owners bear a responsibility to the organization and the users of this
-# application. Repository administrators have the ability to merge pull 
-# requests that have not yet received the requisite reviews as outlined 
-# in this file. Do not force merge any PR without confidence that it 
-# follows all policies or without full understanding of the impact of 
+# application. Repository administrators have the ability to merge pull
+# requests that have not yet received the requisite reviews as outlined
+# in this file. Do not force merge any PR without confidence that it
+# follows all policies or without full understanding of the impact of
 # those changes on build, release and publishing outcomes.
 
 *                                    @MetaMask/extension-devs
 development/                         @MetaMask/extension-devs @kumavis
 lavamoat/                            @MetaMask/supply-chain
 **/snaps/**                          @MetaMask/snaps-devs
+**/flask/**                          @MetaMask/snaps-devs
 
 # The .circleci/ folder instructs Circle CI on the process by which it
 # should test, build and publish releases of our application. Due to the
 # impact that changes to the files contained within this folder may have
-# on our releases, only those with the knowledge and responsibility to 
+# on our releases, only those with the knowledge and responsibility to
 # publish libraries under the MetaMask name may approve those changes.
 # Note to reviewers: We employ the use of CircleCI "Orbs", which are
 # remotely hosted sections of CircleCI configuration and scripts, to


### PR DESCRIPTION
## Explanation

Adds a snaps entry to CODEOWNERS for all files contained in `snaps` and `flask` subdirectories.