### PR TITLE
[e2e] test-dapp update to `v6.0.0`

### DIFF
--- a/package.json
+++ b/package.json
@@ -378,7 +378,7 @@
     "@metamask/eslint-config-typescript": "^9.0.1",
     "@metamask/forwarder": "^1.1.0",
     "@metamask/phishing-warning": "^2.1.0",
-    "@metamask/test-dapp": "^5.6.0",
+    "@metamask/test-dapp": "^6.0.0",
     "@sentry/cli": "^1.58.0",
     "@storybook/addon-a11y": "^6.5.13",
     "@storybook/addon-actions": "^6.5.13",

--- a/test/e2e/seeder/smart-contracts.js
+++ b/test/e2e/seeder/smart-contracts.js
@@ -14,7 +14,7 @@ const {
 } = require('@metamask/test-dapp/dist/constants.json');
 
 const hstFactory = {
-  initialAmount: 100,
+  initialAmount: 10,
   tokenName: 'TST',
   decimalUnits: 4,
   tokenSymbol: 'TST',

--- a/test/e2e/tests/send-eth.spec.js
+++ b/test/e2e/tests/send-eth.spec.js
@@ -336,11 +336,11 @@ describe('Send ETH from dapp using advanced gas controls', function () {
         await driver.clickElement({ text: 'Save', tag: 'button' });
         await driver.waitForSelector({
           css: '.transaction-detail-item:nth-of-type(1) h6:nth-of-type(2)',
-          text: '0.02367237 ETH',
+          text: '0.04503836 ETH',
         });
         await driver.waitForSelector({
           css: '.transaction-detail-item:nth-of-type(2) h6:nth-of-type(2)',
-          text: '0.02367237 ETH',
+          text: '0.04503836 ETH',
         });
 
         await driver.clickElement({ text: 'Confirm', tag: 'button' });

--- a/test/e2e/tests/send-hex-address.spec.js
+++ b/test/e2e/tests/send-hex-address.spec.js
@@ -155,7 +155,7 @@ describe('Send ERC20 to a 40 character hexadecimal address', function () {
         });
         await driver.waitForSelector({
           css: '.transaction-detail-item',
-          text: '0.00008346 ETH',
+          text: '0.00008455 ETH',
         });
         await driver.clickElement({ text: 'Next', tag: 'button' });
 
@@ -220,7 +220,7 @@ describe('Send ERC20 to a 40 character hexadecimal address', function () {
         });
         await driver.waitForSelector({
           css: '.transaction-detail-item',
-          text: '0.00008346 ETH',
+          text: '0.00008455 ETH',
         });
         await driver.clickElement({ text: 'Next', tag: 'button' });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4435,10 +4435,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/test-dapp@npm:^5.6.0":
-  version: 5.6.0
-  resolution: "@metamask/test-dapp@npm:5.6.0"
-  checksum: 352399ee03a9bee7a2a1045a102d4993a3b4b17a4c2c87b77265924dc6b04659b743f79a08f91bfbeeea3b7cbb9d1a88dc251ec32366877312e9eaa01ce0c82f
+"@metamask/test-dapp@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "@metamask/test-dapp@npm:6.0.0"
+  checksum: eee793c8816d1205667002bd0ef60d248f3a35027937d66a51fd6a87e6eb7be70efd63052412d4dbabdd4329a5e729ab8293655dbdd8d3329bd732b1b1be45d1
   languageName: node
   linkType: hard
 
@@ -23866,7 +23866,7 @@ __metadata:
     "@metamask/snaps-utils": ^0.32.2
     "@metamask/subject-metadata-controller": ^2.0.0
     "@metamask/swappable-obj-proxy": ^2.1.0
-    "@metamask/test-dapp": ^5.6.0
+    "@metamask/test-dapp": ^6.0.0
     "@metamask/utils": ^5.0.0
     "@ngraveio/bc-ur": ^1.1.6
     "@popperjs/core": ^2.4.0


### PR DESCRIPTION
## Explanation
After the new `test-dapp` version has been released, here we update the package to use the last version `6.0.0`.
This will allow us to work on the tests involving working with different ERC20 token decimals, not just the default `4`.

In order to update the package, we also have to:
- update the `initalTokenAmount` from the contract seeder, as it was set as `100` but the previous contract had some issue with decimals, making the initial token amount being always `10`. Since all tests rely on a token amount of `10` (see example [here](https://github.com/MetaMask/metamask-extension/blob/develop/test/e2e/tests/custom-token-add-approve.spec.js#L78)), we update this value so it matches the correct expectations.
- update the gas estimates for interacting with the new ERC20 token contract

- Fixes https://github.com/MetaMask/metamask-extension/issues/18143

## Screenshots/Screencaps


### Before
`@metamask/test-dapp": "^5.6.0",`


### After
`@metamask/test-dapp": "^6.0.0",`

## Manual Testing Steps
- Check circle ci tests - they should all pass
- Manually run the tests in your local environment `yarn test:e2e:chrome` `yarn test:e2e:firefox`

## Pre-merge author checklist

- [X] I've clearly explained:
  - [X] What problem this PR is solving
  - [X] How this problem was solved
  - [X] How reviewers can test my changes
- [X] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [x] PR is linked to the appropriate GitHub issue
- [x] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
