### PR TITLE
Return state when calling EncryptionPublicKeyController.cancelEncryptionPublicKey

### DIFF
--- a/app/scripts/controllers/encryption-public-key.test.ts
+++ b/app/scripts/controllers/encryption-public-key.test.ts
@@ -352,6 +352,15 @@ describe('EncryptionPublicKeyController', () => {
         'Cancel',
       );
     });
+
+    it('returns current state', async () => {
+      getStateMock.mockReturnValueOnce(stateMock);
+      expect(
+        await encryptionPublicKeyController.cancelEncryptionPublicKey(
+          messageIdMock,
+        ),
+      ).toEqual(stateMock);
+    });
   });
 
   describe('message manager events', () => {

--- a/app/scripts/controllers/encryption-public-key.ts
+++ b/app/scripts/controllers/encryption-public-key.ts
@@ -275,7 +275,7 @@ export default class EncryptionPublicKeyController extends BaseControllerV2<
    * @param msgId - The id of the message to cancel.
    */
   cancelEncryptionPublicKey(msgId: string) {
-    this._cancelAbstractMessage(this._encryptionPublicKeyManager, msgId);
+    return this._cancelAbstractMessage(this._encryptionPublicKeyManager, msgId);
   }
 
   /**


### PR DESCRIPTION
## Explanation

Returns the state when calling `EncryptionPublicKeyController.cancelEncryptionPublicKey`, which was the original behaviour before the recent changes from https://github.com/MetaMask/metamask-extension/pull/18319.

* Fixes https://github.com/MetaMask/metamask-extension/issues/18826

## Manual Testing Steps

- Log in to the extension
- connect to the test dapp
- click get encryption key
- switch to the extension
- open the request from the activity list
- cancel the confirmation

## Pre-merge author checklist

- [X] I've clearly explained:
  - [X] What problem this PR is solving
  - [X] How this problem was solved
  - [X] How reviewers can test my changes
- [X] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
