### PR TITLE
eth_sign toggle Update in advanced settings

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -4458,10 +4458,16 @@
     "message": "Enter “I only sign what I understand” to continue"
   },
   "toggleEthSignModalFormValidation": {
-    "message": "I only sign what I understand"
+    "message": "I only sign what I understand "
   },
   "toggleEthSignModalTitle": {
     "message": "Use at your own risk"
+  },
+  "toggleEthSignOff": {
+    "message": "OFF (Recommended)"
+  },
+  "toggleEthSignOn": {
+    "message": "ON (Not recommended)"
   },
   "toggleTestNetworks": {
     "message": "$1 test networks",

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -4458,7 +4458,7 @@
     "message": "Enter “I only sign what I understand” to continue"
   },
   "toggleEthSignModalFormValidation": {
-    "message": "I only sign what I understand "
+    "message": "I only sign what I understand"
   },
   "toggleEthSignModalTitle": {
     "message": "Use at your own risk"

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -4430,11 +4430,38 @@
     "message": "To: $1",
     "description": "$1 is the address to include in the To label. It is typically shortened first using shortenAddress"
   },
+  "toggleEthSignBannerDescription": {
+    "message": "You’re at risk for phishing attacks. Protect yourself by turning off eth_sign."
+  },
   "toggleEthSignDescriptionField": {
-    "message": "Turn this on to let dapps request your signature using eth_sign requests. eth_sign is an open-ended signing method that lets you sign an arbitrary hash, making it a dangerous phishing risk. Only sign eth_sign requests if you can read what you are signing and trust the origin of the request."
+    "message": "If you enable this setting, you might get signature requests that aren’t readable. By signing a message you don't understand, you could be agreeing to give away your funds and NFTs."
   },
   "toggleEthSignField": {
-    "message": "Toggle eth_sign requests"
+    "message": "Eth_sign requests"
+  },
+  "toggleEthSignModalBannerBoldText": {
+    "message": " you might be getting scammed"
+  },
+  "toggleEthSignModalBannerText": {
+    "message": "If you've been asked to turn this setting on,"
+  },
+  "toggleEthSignModalCheckBox": {
+    "message": "I understand that I can lose all of my funds and NFTs if I enable eth_sign requests. "
+  },
+  "toggleEthSignModalDescription": {
+    "message": "Allowing eth_sign requests can make you vulnerable to phishing attacks. Always review the URL and be careful when signing  messages that contain code."
+  },
+  "toggleEthSignModalFormError": {
+    "message": "The text is incorrect. Try again"
+  },
+  "toggleEthSignModalFormLabel": {
+    "message": "Enter “I only sign what I understand” to continue"
+  },
+  "toggleEthSignModalFormValidation": {
+    "message": "I only sign what I understand"
+  },
+  "toggleEthSignModalTitle": {
+    "message": "Use at your own risk"
   },
   "toggleTestNetworks": {
     "message": "$1 test networks",

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -4452,7 +4452,7 @@
     "message": "Allowing eth_sign requests can make you vulnerable to phishing attacks. Always review the URL and be careful when signing  messages that contain code."
   },
   "toggleEthSignModalFormError": {
-    "message": "The text is incorrect. Try again"
+    "message": "The text is incorrect"
   },
   "toggleEthSignModalFormLabel": {
     "message": "Enter “I only sign what I understand” to continue"

--- a/ui/components/app/modals/eth-sign-modal/__snapshots__/eth-sign-modal.test.js.snap
+++ b/ui/components/app/modals/eth-sign-modal/__snapshots__/eth-sign-modal.test.js.snap
@@ -23,7 +23,7 @@ exports[`Eth Sign Modal should match snapshot 1`] = `
       </button>
     </div>
     <h3
-      class="box mm-text mm-text--heading-md mm-text--text-align-center box--flex-direction-row box--color-text-default"
+      class="box mm-text mm-text--heading-md mm-text--text-align-center box--margin-bottom-6 box--flex-direction-row box--color-text-default"
     >
       Use at your own risk
     </h3>

--- a/ui/components/app/modals/eth-sign-modal/__snapshots__/eth-sign-modal.test.js.snap
+++ b/ui/components/app/modals/eth-sign-modal/__snapshots__/eth-sign-modal.test.js.snap
@@ -1,0 +1,95 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Eth Sign Modal should match snapshot 1`] = `
+<div>
+  <div
+    class="box eth-sign-modal box--padding-4 box--display-flex box--flex-direction-column box--justify-content-flex-start"
+  >
+    <div
+      class="box box--margin-bottom-6 box--display-flex box--flex-direction-row box--justify-content-center"
+    >
+      <span
+        class="box eth-sign-modal__warning-icon mm-icon mm-icon--size-lg box--display-inline-block box--flex-direction-row box--color-error-default"
+        style="mask-image: url('./images/icons/danger.svg');"
+      />
+      <button
+        aria-label="Close"
+        class="box mm-button-icon mm-button-icon--size-sm eth-sign-modal__close box--display-inline-flex box--flex-direction-row box--justify-content-center box--align-items-center box--color-icon-default box--background-color-transparent box--rounded-lg"
+      >
+        <span
+          class="box mm-icon mm-icon--size-sm box--display-inline-block box--flex-direction-row box--color-inherit"
+          style="mask-image: url('./images/icons/close.svg');"
+        />
+      </button>
+    </div>
+    <h3
+      class="box mm-text mm-text--heading-md mm-text--text-align-center box--flex-direction-row box--color-text-default"
+    >
+      Use at your own risk
+    </h3>
+    <p
+      class="box mm-text mm-text--body-md box--flex-direction-row box--color-text-default"
+    >
+      Allowing eth_sign requests can make you vulnerable to phishing attacks. Always review the URL and be careful when signing  messages that contain code.
+      <a
+        class="box mm-text mm-button-base mm-button-link mm-button-link--size-auto mm-text--body-md box--display-inline-flex box--flex-direction-row box--justify-content-center box--align-items-center box--color-primary-default box--background-color-transparent"
+        href="https://support.metamask.io/hc/en-us/articles/14764161421467"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        Learn more
+      </a>
+    </p>
+    <div
+      class="box mm-banner-base mm-banner-alert mm-banner-alert--severity-danger box--margin-top-6 box--margin-bottom-6 box--padding-3 box--padding-left-2 box--display-flex box--gap-2 box--flex-direction-row box--background-color-error-muted box--rounded-sm"
+    >
+      <span
+        class="box mm-icon mm-icon--size-lg box--display-inline-block box--flex-direction-row box--color-error-default"
+        style="mask-image: url('./images/icons/danger.svg');"
+      />
+      <div>
+        If you've been asked to turn this setting on,
+         you might be getting scammed
+      </div>
+    </div>
+    <div
+      class="box box--gap-2 box--flex-direction-row box--align-items-flex-start box--display-flex"
+    >
+      <input
+        class="check-box eth-sign__checkbox far fa-square"
+        data-testid="eth-sign__checkbox"
+        id="eth-sign__checkbox"
+        readonly=""
+        type="checkbox"
+      />
+      <label
+        class="box mm-text mm-label mm-label--html-for mm-text--body-md mm-text--font-weight-bold box--display-inline-flex box--flex-direction-row box--align-items-center box--color-text-default"
+        for="eth-sign__checkbox"
+      >
+        <span
+          class="box mm-text mm-text--body-md box--flex-direction-row box--color-text-default"
+        >
+          I understand that I can lose all of my funds and NFTs if I enable eth_sign requests. 
+        </span>
+      </label>
+    </div>
+    <div
+      class="box box--margin-top-6 box--display-flex box--gap-4 box--flex-direction-row box--justify-content-space-between"
+    >
+      <button
+        class="box mm-text mm-button-base mm-button-base--size-md mm-button-base--block mm-button-primary mm-text--body-md box--padding-right-4 box--padding-left-4 box--display-inline-flex box--flex-direction-row box--justify-content-center box--align-items-center box--color-primary-inverse box--background-color-primary-default box--rounded-pill"
+        type="secondary"
+      >
+        Cancel
+      </button>
+      <button
+        class="box mm-text mm-button-base mm-button-base--size-md mm-button-base--disabled mm-button-base--block mm-button-primary mm-button-primary--disabled mm-text--body-md box--padding-right-4 box--padding-left-4 box--display-inline-flex box--flex-direction-row box--justify-content-center box--align-items-center box--color-primary-inverse box--background-color-primary-default box--rounded-pill"
+        disabled=""
+        type="primary"
+      >
+        Continue
+      </button>
+    </div>
+  </div>
+</div>
+`;

--- a/ui/components/app/modals/eth-sign-modal/__snapshots__/eth-sign-modal.test.js.snap
+++ b/ui/components/app/modals/eth-sign-modal/__snapshots__/eth-sign-modal.test.js.snap
@@ -6,7 +6,7 @@ exports[`Eth Sign Modal should match snapshot 1`] = `
     class="box eth-sign-modal box--padding-4 box--display-flex box--flex-direction-column box--justify-content-flex-start"
   >
     <div
-      class="box box--margin-bottom-6 box--display-flex box--flex-direction-row box--justify-content-center"
+      class="box box--margin-bottom-4 box--display-flex box--flex-direction-row box--justify-content-center"
     >
       <span
         class="box eth-sign-modal__warning-icon mm-icon mm-icon--size-lg box--display-inline-block box--flex-direction-row box--color-error-default"
@@ -77,15 +77,13 @@ exports[`Eth Sign Modal should match snapshot 1`] = `
       class="box box--margin-top-6 box--display-flex box--gap-4 box--flex-direction-row box--justify-content-space-between"
     >
       <button
-        class="box mm-text mm-button-base mm-button-base--size-md mm-button-base--block mm-button-primary mm-text--body-md box--padding-right-4 box--padding-left-4 box--display-inline-flex box--flex-direction-row box--justify-content-center box--align-items-center box--color-primary-inverse box--background-color-primary-default box--rounded-pill"
-        type="secondary"
+        class="box mm-text mm-button-base mm-button-base--size-lg mm-button-base--block mm-button-secondary mm-text--body-md box--padding-right-4 box--padding-left-4 box--display-inline-flex box--flex-direction-row box--justify-content-center box--align-items-center box--color-primary-default box--background-color-transparent box--rounded-pill box--border-color-primary-default box--border-style-solid box--border-width-1"
       >
         Cancel
       </button>
       <button
-        class="box mm-text mm-button-base mm-button-base--size-md mm-button-base--disabled mm-button-base--block mm-button-primary mm-button-primary--disabled mm-text--body-md box--padding-right-4 box--padding-left-4 box--display-inline-flex box--flex-direction-row box--justify-content-center box--align-items-center box--color-primary-inverse box--background-color-primary-default box--rounded-pill"
+        class="box mm-text mm-button-base mm-button-base--size-lg mm-button-base--disabled mm-button-base--block mm-button-primary mm-button-primary--disabled mm-text--body-md box--padding-right-4 box--padding-left-4 box--display-inline-flex box--flex-direction-row box--justify-content-center box--align-items-center box--color-primary-inverse box--background-color-primary-default box--rounded-pill"
         disabled=""
-        type="primary"
       >
         Continue
       </button>

--- a/ui/components/app/modals/eth-sign-modal/eth-sign-modal.js
+++ b/ui/components/app/modals/eth-sign-modal/eth-sign-modal.js
@@ -6,7 +6,7 @@ import {
   BannerAlert,
   Button,
   ButtonIcon,
-  BUTTON_TYPES,
+  BUTTON_VARIANT,
   FormTextField,
   Icon,
   IconName,
@@ -33,22 +33,13 @@ const EthSignModal = ({ hideModal }) => {
   const [isEthSignChecked, setIsEthSignChecked] = useState(false);
   const [showTextField, setShowTextField] = useState(false);
   const [inputKeyword, setInputKeyword] = useState('');
-  const [showEnable, setShowEnable] = useState(false);
-  const [showError, setShowError] = useState(false);
+
   const t = useI18nContext();
   const handleCancel = () => {
     hideModal();
   };
-  const handleKeyPress = (event) => {
-    if (inputKeyword !== '' && event.key === 'Enter') {
-      event.preventDefault();
-      if (inputKeyword === 'I only sign what I understand') {
-        setShowEnable(true);
-      } else {
-        setShowError(true);
-      }
-    }
-  };
+
+  const isValid = inputKeyword === 'I only sign what I understand';
   return (
     <Box
       className="eth-sign-modal"
@@ -94,13 +85,15 @@ const EthSignModal = ({ hideModal }) => {
         <FormTextField
           id="enter-eth-sign-text"
           label="Enter “I only sign what I understand” to continue"
-          error={showError}
-          helpText={showError ? `The text is incorrect. Try again.` : null}
+          error={inputKeyword.length > 0 && !isValid}
+          helpText={
+            inputKeyword.length > 0 &&
+            !isValid &&
+            `The text is incorrect. Try again.`
+          }
           onChange={(event) => setInputKeyword(event.target.value)}
           value={inputKeyword}
-          inputProps={{
-            onKeyPress: handleKeyPress,
-          }}
+          onPaste={(event) => event.preventDefault()}
         />
       ) : (
         <Box
@@ -133,7 +126,7 @@ const EthSignModal = ({ hideModal }) => {
         marginTop={6}
       >
         <Button
-          type={BUTTON_TYPES.SECONDARY}
+          type={BUTTON_VARIANT.SECONDARY}
           width={BLOCK_SIZES.FULL}
           onClick={handleCancel}
         >
@@ -141,17 +134,19 @@ const EthSignModal = ({ hideModal }) => {
         </Button>
         {showTextField ? (
           <Button
-            type={BUTTON_TYPES.PRIMARY}
+            type={BUTTON_VARIANT.PRIMARY}
             danger
             width={BLOCK_SIZES.FULL}
-            disabled={!showEnable}
-            onClick={() => setShowTextField(true)}
+            disabled={!isValid}
+            onClick={() => {
+              hideModal();
+            }}
           >
             Enable
           </Button>
         ) : (
           <Button
-            type={BUTTON_TYPES.PRIMARY}
+            type={BUTTON_VARIANT.PRIMARY}
             width={BLOCK_SIZES.FULL}
             disabled={!isEthSignChecked}
             onClick={() => setShowTextField(true)}

--- a/ui/components/app/modals/eth-sign-modal/eth-sign-modal.js
+++ b/ui/components/app/modals/eth-sign-modal/eth-sign-modal.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useContext, useState } from 'react';
 import PropTypes from 'prop-types';
 import { useSelector, useDispatch } from 'react-redux';
 import withModalProps from '../../../../helpers/higher-order-components/with-modal-props';
@@ -31,6 +31,11 @@ import { useI18nContext } from '../../../../hooks/useI18nContext';
 import CheckBox from '../../../ui/check-box';
 import { setDisabledRpcMethodPreference } from '../../../../store/actions';
 import { getDisabledRpcMethodPreferences } from '../../../../selectors';
+import {
+  MetaMetricsEventCategory,
+  MetaMetricsEventName,
+} from '../../../../../shared/constants/metametrics';
+import { MetaMetricsContext } from '../../../../contexts/metametrics';
 
 const EthSignModal = ({ hideModal }) => {
   const [isEthSignChecked, setIsEthSignChecked] = useState(false);
@@ -42,6 +47,7 @@ const EthSignModal = ({ hideModal }) => {
 
   const t = useI18nContext();
   const dispatch = useDispatch();
+  const trackEvent = useContext(MetaMetricsContext);
   const handleCancel = () => {
     hideModal();
   };
@@ -163,7 +169,17 @@ const EthSignModal = ({ hideModal }) => {
             type={BUTTON_VARIANT.PRIMARY}
             block
             disabled={!isEthSignChecked}
-            onClick={() => setShowTextField(true)}
+            onClick={() => {
+              setShowTextField(true);
+              trackEvent({
+                category: MetaMetricsEventCategory.Settings,
+                event: MetaMetricsEventName.OnboardingWalletAdvancedSettings,
+                properties: {
+                  location: 'Settings',
+                  enable_eth_sign: true,
+                },
+              });
+            }}
           >
             {t('continue')}
           </Button>

--- a/ui/components/app/modals/eth-sign-modal/eth-sign-modal.js
+++ b/ui/components/app/modals/eth-sign-modal/eth-sign-modal.js
@@ -1,0 +1,122 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import withModalProps from '../../../../helpers/higher-order-components/with-modal-props';
+import Box from '../../../ui/box';
+import {
+  BannerAlert,
+  Button,
+  ButtonIcon,
+  BUTTON_TYPES,
+  Icon,
+  IconName,
+  IconSize,
+  Label,
+  Text,
+} from '../../../component-library';
+import {
+  AlignItems,
+  BLOCK_SIZES,
+  DISPLAY,
+  FLEX_DIRECTION,
+  IconColor,
+  JustifyContent,
+  SEVERITIES,
+  Size,
+  TextAlign,
+  TextVariant,
+} from '../../../../helpers/constants/design-system';
+import { useI18nContext } from '../../../../hooks/useI18nContext';
+import CheckBox from '../../../ui/check-box';
+
+const EthSignModal = ({ hideModal }) => {
+    const [isEthSignChecked, setIsEthSignChecked] = useState(false);
+  const t = useI18nContext();
+  const handleCancel = () => {
+    hideModal();
+  };
+  return (
+    <Box
+      className="eth-sign-modal"
+      display={DISPLAY.FLEX}
+      flexDirection={FLEX_DIRECTION.COLUMN}
+      justifyContent={JustifyContent.flexStart}
+      padding={6}
+    >
+      <Box
+        display={DISPLAY.FLEX}
+        flexDirection={FLEX_DIRECTION.ROW}
+        marginBottom={6}
+        justifyContent={JustifyContent.center}
+      >
+        <Icon
+          className="eth-sign-modal__warning-icon"
+          name={IconName.Danger}
+          color={IconColor.errorDefault}
+          size={IconSize.Lg}
+        />
+        <ButtonIcon
+          className="eth-sign-modal__close"
+          iconName={IconName.Close}
+          size={Size.SM}
+          onClick={handleCancel}
+          ariaLabel={t('close')}
+        />
+      </Box>
+
+      <Text variant={TextVariant.headingMd} textAlign={TextAlign.Center}>
+        Use at your own risk
+      </Text>
+      <Text variant={TextVariant.bodyMd}>
+        Allowing eth_sign requests can make you vulnerable to phishing attacks.
+        Always review the URL and be careful when signing messages that contain
+        code. Learn more.
+      </Text>
+      <BannerAlert severity={SEVERITIES.DANGER}>
+        If you have been asked to turn this setting on, you might be getting
+        scammed.
+      </BannerAlert>
+      <Box
+        flexDirection={FLEX_DIRECTION.ROW}
+        alignItems={AlignItems.flexStart}
+        marginLeft={3}
+        marginRight={3}
+        gap={2}
+      >
+        <CheckBox
+          id="eth-sign__checkbox"
+          className="eth-sign__checkbox"
+          dataTestId="eth-sign__checkbox"
+          checked={isEthSignChecked}
+          onClick={() => {
+            setIsEthSignChecked(!isEthSignChecked);
+          }}
+        />
+        <Label htmlFor="eth-sign__checkbox">
+          <Text variant={TextVariant.bodyMd} as="span">
+            I understand that I can lose all of my funds and NFTs if I enable
+            eth_sign requests.
+          </Text>
+        </Label>
+      </Box>
+      <Box
+        display={DISPLAY.FLEX}
+        flexDirection={FLEX_DIRECTION.ROW}
+        justifyContent={JustifyContent.spaceBetween}
+        gap={4}
+      >
+        <Button type={BUTTON_TYPES.SECONDARY} width={BLOCK_SIZES.FULL}>
+          {t('cancel')}
+        </Button>
+        <Button type={BUTTON_TYPES.PRIMARY} width={BLOCK_SIZES.FULL}>
+          {t('continue')}
+        </Button>
+      </Box>
+    </Box>
+  );
+};
+
+EthSignModal.propTypes = {
+  // The function to close the Modal
+  hideModal: PropTypes.func,
+};
+export default withModalProps(EthSignModal);

--- a/ui/components/app/modals/eth-sign-modal/eth-sign-modal.js
+++ b/ui/components/app/modals/eth-sign-modal/eth-sign-modal.js
@@ -7,6 +7,7 @@ import {
   Button,
   ButtonIcon,
   BUTTON_TYPES,
+  FormTextField,
   Icon,
   IconName,
   IconSize,
@@ -29,10 +30,24 @@ import { useI18nContext } from '../../../../hooks/useI18nContext';
 import CheckBox from '../../../ui/check-box';
 
 const EthSignModal = ({ hideModal }) => {
-    const [isEthSignChecked, setIsEthSignChecked] = useState(false);
+  const [isEthSignChecked, setIsEthSignChecked] = useState(false);
+  const [showTextField, setShowTextField] = useState(false);
+  const [inputKeyword, setInputKeyword] = useState('');
+  const [showEnable, setShowEnable] = useState(false);
+  const [showError, setShowError] = useState(false);
   const t = useI18nContext();
   const handleCancel = () => {
     hideModal();
+  };
+  const handleKeyPress = (event) => {
+    if (inputKeyword !== '' && event.key === 'Enter') {
+      event.preventDefault();
+      if (inputKeyword === 'I only sign what I understand') {
+        setShowEnable(true);
+      } else {
+        setShowError(true);
+      }
+    }
   };
   return (
     <Box
@@ -40,7 +55,7 @@ const EthSignModal = ({ hideModal }) => {
       display={DISPLAY.FLEX}
       flexDirection={FLEX_DIRECTION.COLUMN}
       justifyContent={JustifyContent.flexStart}
-      padding={6}
+      padding={4}
     >
       <Box
         display={DISPLAY.FLEX}
@@ -71,45 +86,79 @@ const EthSignModal = ({ hideModal }) => {
         Always review the URL and be careful when signing messages that contain
         code. Learn more.
       </Text>
-      <BannerAlert severity={SEVERITIES.DANGER}>
+      <BannerAlert severity={SEVERITIES.DANGER} marginTop={6} marginBottom={6}>
         If you have been asked to turn this setting on, you might be getting
         scammed.
       </BannerAlert>
-      <Box
-        flexDirection={FLEX_DIRECTION.ROW}
-        alignItems={AlignItems.flexStart}
-        marginLeft={3}
-        marginRight={3}
-        gap={2}
-      >
-        <CheckBox
-          id="eth-sign__checkbox"
-          className="eth-sign__checkbox"
-          dataTestId="eth-sign__checkbox"
-          checked={isEthSignChecked}
-          onClick={() => {
-            setIsEthSignChecked(!isEthSignChecked);
+      {showTextField ? (
+        <FormTextField
+          id="enter-eth-sign-text"
+          label="Enter “I only sign what I understand” to continue"
+          error={showError}
+          helpText={showError ? `The text is incorrect. Try again.` : null}
+          onChange={(event) => setInputKeyword(event.target.value)}
+          value={inputKeyword}
+          inputProps={{
+            onKeyPress: handleKeyPress,
           }}
         />
-        <Label htmlFor="eth-sign__checkbox">
-          <Text variant={TextVariant.bodyMd} as="span">
-            I understand that I can lose all of my funds and NFTs if I enable
-            eth_sign requests.
-          </Text>
-        </Label>
-      </Box>
+      ) : (
+        <Box
+          flexDirection={FLEX_DIRECTION.ROW}
+          alignItems={AlignItems.flexStart}
+          gap={2}
+        >
+          <CheckBox
+            id="eth-sign__checkbox"
+            className="eth-sign__checkbox"
+            dataTestId="eth-sign__checkbox"
+            checked={isEthSignChecked}
+            onClick={() => {
+              setIsEthSignChecked(!isEthSignChecked);
+            }}
+          />
+          <Label htmlFor="eth-sign__checkbox">
+            <Text variant={TextVariant.bodyMd} as="span">
+              I understand that I can lose all of my funds and NFTs if I enable
+              eth_sign requests.
+            </Text>
+          </Label>
+        </Box>
+      )}
       <Box
         display={DISPLAY.FLEX}
         flexDirection={FLEX_DIRECTION.ROW}
         justifyContent={JustifyContent.spaceBetween}
         gap={4}
+        marginTop={6}
       >
-        <Button type={BUTTON_TYPES.SECONDARY} width={BLOCK_SIZES.FULL}>
+        <Button
+          type={BUTTON_TYPES.SECONDARY}
+          width={BLOCK_SIZES.FULL}
+          onClick={handleCancel}
+        >
           {t('cancel')}
         </Button>
-        <Button type={BUTTON_TYPES.PRIMARY} width={BLOCK_SIZES.FULL}>
-          {t('continue')}
-        </Button>
+        {showTextField ? (
+          <Button
+            type={BUTTON_TYPES.PRIMARY}
+            danger
+            width={BLOCK_SIZES.FULL}
+            disabled={!showEnable}
+            onClick={() => setShowTextField(true)}
+          >
+            Enable
+          </Button>
+        ) : (
+          <Button
+            type={BUTTON_TYPES.PRIMARY}
+            width={BLOCK_SIZES.FULL}
+            disabled={!isEthSignChecked}
+            onClick={() => setShowTextField(true)}
+          >
+            {t('continue')}
+          </Button>
+        )}
       </Box>
     </Box>
   );

--- a/ui/components/app/modals/eth-sign-modal/eth-sign-modal.js
+++ b/ui/components/app/modals/eth-sign-modal/eth-sign-modal.js
@@ -48,15 +48,12 @@ const EthSignModal = ({ hideModal }) => {
   const t = useI18nContext();
   const dispatch = useDispatch();
   const trackEvent = useContext(MetaMetricsContext);
-  const handleCancel = () => {
-    hideModal();
-  };
 
   const handleSubmit = () => {
     dispatch(
       setDisabledRpcMethodPreference(
         'eth_sign',
-        !disabledRpcMethodPreferences?.eth_sign,
+        !disabledRpcMethodPreferences.eth_sign,
       ),
     );
     hideModal();
@@ -87,12 +84,16 @@ const EthSignModal = ({ hideModal }) => {
           className="eth-sign-modal__close"
           iconName={IconName.Close}
           size={Size.SM}
-          onClick={handleCancel}
+          onClick={() => hideModal()}
           ariaLabel={t('close')}
         />
       </Box>
 
-      <Text variant={TextVariant.headingMd} textAlign={TextAlign.Center}>
+      <Text
+        variant={TextVariant.headingMd}
+        textAlign={TextAlign.Center}
+        marginBottom={6}
+      >
         {t('toggleEthSignModalTitle')}
       </Text>
       <Text variant={TextVariant.bodyMd}>
@@ -151,7 +152,7 @@ const EthSignModal = ({ hideModal }) => {
         gap={4}
         marginTop={6}
       >
-        <ButtonSecondary onClick={handleCancel} size={Size.LG} block>
+        <ButtonSecondary onClick={() => hideModal()} size={Size.LG} block>
           {t('cancel')}
         </ButtonSecondary>
         {showTextField ? (

--- a/ui/components/app/modals/eth-sign-modal/eth-sign-modal.js
+++ b/ui/components/app/modals/eth-sign-modal/eth-sign-modal.js
@@ -1,11 +1,13 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
+import { useSelector, useDispatch } from 'react-redux';
 import withModalProps from '../../../../helpers/higher-order-components/with-modal-props';
 import Box from '../../../ui/box';
 import {
   BannerAlert,
   Button,
   ButtonIcon,
+  ButtonLink,
   BUTTON_VARIANT,
   FormTextField,
   Icon,
@@ -27,14 +29,30 @@ import {
 } from '../../../../helpers/constants/design-system';
 import { useI18nContext } from '../../../../hooks/useI18nContext';
 import CheckBox from '../../../ui/check-box';
+import { setDisabledRpcMethodPreference } from '../../../../store/actions';
+import { getDisabledRpcMethodPreferences } from '../../../../selectors';
 
 const EthSignModal = ({ hideModal }) => {
   const [isEthSignChecked, setIsEthSignChecked] = useState(false);
   const [showTextField, setShowTextField] = useState(false);
   const [inputKeyword, setInputKeyword] = useState('');
+  const disabledRpcMethodPreferences = useSelector(
+    getDisabledRpcMethodPreferences,
+  );
 
   const t = useI18nContext();
+  const dispatch = useDispatch();
   const handleCancel = () => {
+    hideModal();
+  };
+
+  const handleSubmit = () => {
+    dispatch(
+      setDisabledRpcMethodPreference(
+        'eth_sign',
+        !disabledRpcMethodPreferences?.eth_sign,
+      ),
+    );
     hideModal();
   };
 
@@ -74,7 +92,13 @@ const EthSignModal = ({ hideModal }) => {
       <Text variant={TextVariant.bodyMd}>
         Allowing eth_sign requests can make you vulnerable to phishing attacks.
         Always review the URL and be careful when signing messages that contain
-        code. Learn more.
+        code.{' '}
+        <ButtonLink
+          href="https://support.metamask.io/hc/en-us/articles/14764161421467"
+          externalLink
+        >
+          {t('learnMoreUpperCase')}
+        </ButtonLink>
       </Text>
       <BannerAlert severity={SEVERITIES.DANGER} marginTop={6} marginBottom={6}>
         If you have been asked to turn this setting on, you might be getting
@@ -133,11 +157,9 @@ const EthSignModal = ({ hideModal }) => {
             danger
             block
             disabled={!isValid}
-            onClick={() => {
-              hideModal();
-            }}
+            onClick={handleSubmit}
           >
-            Enable
+            {t('enableSnap')}
           </Button>
         ) : (
           <Button

--- a/ui/components/app/modals/eth-sign-modal/eth-sign-modal.js
+++ b/ui/components/app/modals/eth-sign-modal/eth-sign-modal.js
@@ -5,10 +5,10 @@ import withModalProps from '../../../../helpers/higher-order-components/with-mod
 import Box from '../../../ui/box';
 import {
   BannerAlert,
-  Button,
   ButtonIcon,
   ButtonLink,
-  BUTTON_VARIANT,
+  ButtonPrimary,
+  ButtonSecondary,
   FormTextField,
   Icon,
   IconName,
@@ -74,7 +74,7 @@ const EthSignModal = ({ hideModal }) => {
       <Box
         display={DISPLAY.FLEX}
         flexDirection={FLEX_DIRECTION.ROW}
-        marginBottom={6}
+        marginBottom={4}
         justifyContent={JustifyContent.center}
       >
         <Icon
@@ -151,24 +151,24 @@ const EthSignModal = ({ hideModal }) => {
         gap={4}
         marginTop={6}
       >
-        <Button type={BUTTON_VARIANT.SECONDARY} block onClick={handleCancel}>
+        <ButtonSecondary onClick={handleCancel} size={Size.LG} block>
           {t('cancel')}
-        </Button>
+        </ButtonSecondary>
         {showTextField ? (
-          <Button
-            type={BUTTON_VARIANT.PRIMARY}
+          <ButtonPrimary
             danger
             block
             disabled={!isValid}
             onClick={handleSubmit}
+            size={Size.LG}
           >
             {t('enableSnap')}
-          </Button>
+          </ButtonPrimary>
         ) : (
-          <Button
-            type={BUTTON_VARIANT.PRIMARY}
+          <ButtonPrimary
             block
             disabled={!isEthSignChecked}
+            size={Size.LG}
             onClick={() => {
               setShowTextField(true);
               trackEvent({
@@ -182,7 +182,7 @@ const EthSignModal = ({ hideModal }) => {
             }}
           >
             {t('continue')}
-          </Button>
+          </ButtonPrimary>
         )}
       </Box>
     </Box>

--- a/ui/components/app/modals/eth-sign-modal/eth-sign-modal.js
+++ b/ui/components/app/modals/eth-sign-modal/eth-sign-modal.js
@@ -16,7 +16,6 @@ import {
 } from '../../../component-library';
 import {
   AlignItems,
-  BLOCK_SIZES,
   DISPLAY,
   FLEX_DIRECTION,
   IconColor,
@@ -125,18 +124,14 @@ const EthSignModal = ({ hideModal }) => {
         gap={4}
         marginTop={6}
       >
-        <Button
-          type={BUTTON_VARIANT.SECONDARY}
-          width={BLOCK_SIZES.FULL}
-          onClick={handleCancel}
-        >
+        <Button type={BUTTON_VARIANT.SECONDARY} block onClick={handleCancel}>
           {t('cancel')}
         </Button>
         {showTextField ? (
           <Button
             type={BUTTON_VARIANT.PRIMARY}
             danger
-            width={BLOCK_SIZES.FULL}
+            block
             disabled={!isValid}
             onClick={() => {
               hideModal();
@@ -147,7 +142,7 @@ const EthSignModal = ({ hideModal }) => {
         ) : (
           <Button
             type={BUTTON_VARIANT.PRIMARY}
-            width={BLOCK_SIZES.FULL}
+            block
             disabled={!isEthSignChecked}
             onClick={() => setShowTextField(true)}
           >

--- a/ui/components/app/modals/eth-sign-modal/eth-sign-modal.js
+++ b/ui/components/app/modals/eth-sign-modal/eth-sign-modal.js
@@ -56,7 +56,7 @@ const EthSignModal = ({ hideModal }) => {
     hideModal();
   };
 
-  const isValid = inputKeyword === 'I only sign what I understand';
+  const isValid = inputKeyword === t('toggleEthSignModalFormValidation');
   return (
     <Box
       className="eth-sign-modal"
@@ -87,12 +87,10 @@ const EthSignModal = ({ hideModal }) => {
       </Box>
 
       <Text variant={TextVariant.headingMd} textAlign={TextAlign.Center}>
-        Use at your own risk
+        {t('toggleEthSignModalTitle')}
       </Text>
       <Text variant={TextVariant.bodyMd}>
-        Allowing eth_sign requests can make you vulnerable to phishing attacks.
-        Always review the URL and be careful when signing messages that contain
-        code.{' '}
+        {t('toggleEthSignModalDescription')}
         <ButtonLink
           href="https://support.metamask.io/hc/en-us/articles/14764161421467"
           externalLink
@@ -101,18 +99,18 @@ const EthSignModal = ({ hideModal }) => {
         </ButtonLink>
       </Text>
       <BannerAlert severity={SEVERITIES.DANGER} marginTop={6} marginBottom={6}>
-        If you have been asked to turn this setting on, you might be getting
-        scammed.
+        {t('toggleEthSignModalBannerText')}
+        {t('toggleEthSignModalBannerBoldText')}
       </BannerAlert>
       {showTextField ? (
         <FormTextField
           id="enter-eth-sign-text"
-          label="Enter “I only sign what I understand” to continue"
+          label={t('toggleEthSignModalFormLabel')}
           error={inputKeyword.length > 0 && !isValid}
           helpText={
             inputKeyword.length > 0 &&
             !isValid &&
-            `The text is incorrect. Try again.`
+            t('toggleEthSignModalFormError')
           }
           onChange={(event) => setInputKeyword(event.target.value)}
           value={inputKeyword}
@@ -135,8 +133,7 @@ const EthSignModal = ({ hideModal }) => {
           />
           <Label htmlFor="eth-sign__checkbox">
             <Text variant={TextVariant.bodyMd} as="span">
-              I understand that I can lose all of my funds and NFTs if I enable
-              eth_sign requests.
+              {t('toggleEthSignModalCheckBox')}
             </Text>
           </Label>
         </Box>

--- a/ui/components/app/modals/eth-sign-modal/eth-sign-modal.stories.js
+++ b/ui/components/app/modals/eth-sign-modal/eth-sign-modal.stories.js
@@ -1,0 +1,9 @@
+import React from 'react';
+import EthSignModal from './eth-sign-modal';
+
+export default {
+  title: 'Components/App/Modals/EthSignModal',
+  component: EthSignModal,
+};
+
+export const DefaultStory = (args) => <EthSignModal {...args} />;

--- a/ui/components/app/modals/eth-sign-modal/eth-sign-modal.test.js
+++ b/ui/components/app/modals/eth-sign-modal/eth-sign-modal.test.js
@@ -1,0 +1,44 @@
+import React from 'react';
+import configureMockStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+import { renderWithProvider } from '../../../../../test/lib/render-helpers';
+import EthSignModal from './eth-sign-modal';
+
+const mockHideModal = jest.fn();
+const mockGetDisabledRpcMethodPreferences = jest.fn();
+
+jest.mock('../../../../store/actions.ts', () => ({
+  ...jest.requireActual('../../../../store/actions.ts'),
+  hideModal: () => mockHideModal,
+  getDisabledRpcMethodPreferences: () => mockGetDisabledRpcMethodPreferences,
+}));
+
+describe('Eth Sign Modal', () => {
+  const mockState = {
+    appState: {
+      modal: {
+        modalState: {
+          props: {},
+        },
+      },
+    },
+    metamask: {
+      provider: {
+        type: 'rpc',
+        chainId: '0x5',
+      },
+      disabledRpcMethodPreferences: { eth_sign: true },
+    },
+  };
+
+  const mockStore = configureMockStore([thunk])(mockState);
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should match snapshot', () => {
+    const { container } = renderWithProvider(<EthSignModal />, mockStore);
+    expect(container).toMatchSnapshot();
+  });
+});

--- a/ui/components/app/modals/eth-sign-modal/index.js
+++ b/ui/components/app/modals/eth-sign-modal/index.js
@@ -1,0 +1,1 @@
+export { default } from './eth-sign-modal';

--- a/ui/components/app/modals/eth-sign-modal/index.scss
+++ b/ui/components/app/modals/eth-sign-modal/index.scss
@@ -5,15 +5,4 @@
     position: absolute;
     right: 16px;
   }
-
-  &__footer-button {
-  @extend %row-nowrap;
-
-  padding: 1rem;
-
-  button + button {
-    margin-left: 1rem;
-  }
-}
-
 }

--- a/ui/components/app/modals/eth-sign-modal/index.scss
+++ b/ui/components/app/modals/eth-sign-modal/index.scss
@@ -1,0 +1,19 @@
+.eth-sign-modal {
+  position: relative;
+
+  &__close {
+    position: absolute;
+    right: 16px;
+  }
+
+  &__footer-button {
+  @extend %row-nowrap;
+
+  padding: 1rem;
+
+  button + button {
+    margin-left: 1rem;
+  }
+}
+
+}

--- a/ui/components/app/modals/index.scss
+++ b/ui/components/app/modals/index.scss
@@ -12,6 +12,7 @@
 @import 'convert-token-to-nft-modal/index';
 @import 'contract-details-modal/index';
 @import 'hold-to-reveal-modal/index';
+@import 'eth-sign-modal/index';
 
 .modal {
   z-index: 1050;

--- a/ui/components/app/modals/modal.js
+++ b/ui/components/app/modals/modal.js
@@ -27,6 +27,8 @@ import NewAccountModal from './new-account-modal';
 import CustomizeNonceModal from './customize-nonce';
 import ConvertTokenToNftModal from './convert-token-to-nft-modal/convert-token-to-nft-modal';
 
+import EthSignModal from './eth-sign-modal/eth-sign-modal';
+
 const modalContainerBaseStyle = {
   transform: 'translate3d(-50%, 0, 0px)',
   border: '1px solid var(--color-border-default)',
@@ -160,6 +162,18 @@ const MODALS = {
     },
   },
 
+  ETH_SIGN: {
+    contents: <EthSignModal />,
+    mobileModalStyle: {
+      ...modalContainerMobileStyle,
+    },
+    laptopModalStyle: {
+      ...modalContainerLaptopStyle,
+    },
+    contentStyle: {
+      borderRadius: '8px',
+    },
+  },
   CONFIRM_REMOVE_ACCOUNT: {
     contents: <ConfirmRemoveAccount />,
     mobileModalStyle: {

--- a/ui/pages/settings/advanced-tab/advanced-tab.component.js
+++ b/ui/pages/settings/advanced-tab/advanced-tab.component.js
@@ -583,8 +583,8 @@ export default class AdvancedTab extends PureComponent {
                   ? setDisabledRpcMethodPreference('eth_sign', !value)
                   : showEthSignModal();
               }}
-              offLabel={t('off')}
-              onLabel={t('on')}
+              offLabel={t('toggleEthSignOff')}
+              onLabel={t('toggleEthSignOn')}
             />
           </div>
         </div>

--- a/ui/pages/settings/advanced-tab/advanced-tab.component.js
+++ b/ui/pages/settings/advanced-tab/advanced-tab.component.js
@@ -545,13 +545,23 @@ export default class AdvancedTab extends PureComponent {
   }
 
   renderToggleEthSignControl() {
-    const { t } = this.context;
+    const { t, trackEvent } = this.context;
     const {
       disabledRpcMethodPreferences,
       showEthSignModal,
       setDisabledRpcMethodPreference,
     } = this.props;
-
+    const toggleOff = (value) => {
+      setDisabledRpcMethodPreference('eth_sign', !value);
+      trackEvent({
+        category: MetaMetricsEventCategory.Settings,
+        event: MetaMetricsEventName.OnboardingWalletAdvancedSettings,
+        properties: {
+          location: 'Settings',
+          enable_eth_sign: false,
+        },
+      });
+    };
     return (
       <div
         ref={this.settingsRefs[10]}
@@ -579,9 +589,7 @@ export default class AdvancedTab extends PureComponent {
             <ToggleButton
               value={disabledRpcMethodPreferences?.eth_sign || false}
               onToggle={(value) => {
-                value
-                  ? setDisabledRpcMethodPreference('eth_sign', !value)
-                  : showEthSignModal();
+                value ? toggleOff(value) : showEthSignModal();
               }}
               offLabel={t('toggleEthSignOff')}
               onLabel={t('toggleEthSignOn')}

--- a/ui/pages/settings/advanced-tab/advanced-tab.component.js
+++ b/ui/pages/settings/advanced-tab/advanced-tab.component.js
@@ -546,8 +546,11 @@ export default class AdvancedTab extends PureComponent {
 
   renderToggleEthSignControl() {
     const { t } = this.context;
-    const { disabledRpcMethodPreferences } = this.props;
-    const { showEthSignModal, setDisabledRpcMethodPreference } = this.props;
+    const {
+      disabledRpcMethodPreferences,
+      showEthSignModal,
+      setDisabledRpcMethodPreference,
+    } = this.props;
 
     return (
       <div

--- a/ui/pages/settings/advanced-tab/advanced-tab.component.js
+++ b/ui/pages/settings/advanced-tab/advanced-tab.component.js
@@ -587,6 +587,7 @@ export default class AdvancedTab extends PureComponent {
         <div className="settings-page__content-item">
           <div className="settings-page__content-item-col">
             <ToggleButton
+              className="eth-sign-toggle"
               value={disabledRpcMethodPreferences?.eth_sign || false}
               onToggle={(value) => {
                 value ? toggleOff(value) : showEthSignModal();

--- a/ui/pages/settings/advanced-tab/advanced-tab.component.js
+++ b/ui/pages/settings/advanced-tab/advanced-tab.component.js
@@ -26,7 +26,10 @@ import { exportAsFile } from '../../../helpers/utils/export-utils';
 import ActionableMessage from '../../../components/ui/actionable-message';
 import ZENDESK_URLS from '../../../helpers/constants/zendesk-url';
 import { BannerAlert } from '../../../components/component-library';
-import { SEVERITIES } from '../../../helpers/constants/design-system';
+import {
+  SEVERITIES,
+  TextVariant,
+} from '../../../helpers/constants/design-system';
 
 const CORRUPT_JSON_FILE = 'CORRUPT_JSON_FILE';
 
@@ -560,9 +563,12 @@ export default class AdvancedTab extends PureComponent {
         </div>
 
         {disabledRpcMethodPreferences?.eth_sign === true ? (
-          <BannerAlert severity={SEVERITIES.DANGER} marginBottom={5}>
-            You’re at risk for phishing attacks. Protect yourself by turning off
-            eth_sign.
+          <BannerAlert
+            severity={SEVERITIES.DANGER}
+            marginBottom={5}
+            descriptionProps={{ variant: TextVariant.bodyMd }}
+          >
+            {t('toggleEthSignBannerDescription')}
           </BannerAlert>
         ) : null}
         <div className="settings-page__content-item">

--- a/ui/pages/settings/advanced-tab/advanced-tab.component.js
+++ b/ui/pages/settings/advanced-tab/advanced-tab.component.js
@@ -25,6 +25,8 @@ import {
 import { exportAsFile } from '../../../helpers/utils/export-utils';
 import ActionableMessage from '../../../components/ui/actionable-message';
 import ZENDESK_URLS from '../../../helpers/constants/zendesk-url';
+import { BannerAlert } from '../../../components/component-library';
+import { SEVERITIES } from '../../../helpers/constants/design-system';
 
 const CORRUPT_JSON_FILE = 'CORRUPT_JSON_FILE';
 
@@ -541,9 +543,9 @@ export default class AdvancedTab extends PureComponent {
 
   renderToggleEthSignControl() {
     const { t } = this.context;
-    const { disabledRpcMethodPreferences, setDisabledRpcMethodPreference } =
-      this.props;
-    const { showEthSignModal } = this.props;
+    const { disabledRpcMethodPreferences } = this.props;
+    const { showEthSignModal, setDisabledRpcMethodPreference } = this.props;
+
     return (
       <div
         ref={this.settingsRefs[10]}
@@ -556,11 +558,22 @@ export default class AdvancedTab extends PureComponent {
             {t('toggleEthSignDescriptionField')}
           </div>
         </div>
+
+        {disabledRpcMethodPreferences?.eth_sign === true ? (
+          <BannerAlert severity={SEVERITIES.DANGER} marginBottom={5}>
+            You’re at risk for phishing attacks. Protect yourself by turning off
+            eth_sign.
+          </BannerAlert>
+        ) : null}
         <div className="settings-page__content-item">
           <div className="settings-page__content-item-col">
             <ToggleButton
               value={disabledRpcMethodPreferences?.eth_sign || false}
-              onToggle={() => showEthSignModal()}
+              onToggle={(value) => {
+                value
+                  ? setDisabledRpcMethodPreference('eth_sign', !value)
+                  : showEthSignModal();
+              }}
               offLabel={t('off')}
               onLabel={t('on')}
             />

--- a/ui/pages/settings/advanced-tab/advanced-tab.component.js
+++ b/ui/pages/settings/advanced-tab/advanced-tab.component.js
@@ -40,6 +40,7 @@ export default class AdvancedTab extends PureComponent {
     setHexDataFeatureFlag: PropTypes.func,
     displayWarning: PropTypes.func,
     showResetAccountConfirmationModal: PropTypes.func,
+    showEthSignModal: PropTypes.func,
     warning: PropTypes.string,
     sendHexData: PropTypes.bool,
     showFiatInTestnets: PropTypes.bool,
@@ -542,7 +543,7 @@ export default class AdvancedTab extends PureComponent {
     const { t } = this.context;
     const { disabledRpcMethodPreferences, setDisabledRpcMethodPreference } =
       this.props;
-
+    const { showEthSignModal } = this.props;
     return (
       <div
         ref={this.settingsRefs[10]}
@@ -559,9 +560,7 @@ export default class AdvancedTab extends PureComponent {
           <div className="settings-page__content-item-col">
             <ToggleButton
               value={disabledRpcMethodPreferences?.eth_sign || false}
-              onToggle={(value) =>
-                setDisabledRpcMethodPreference('eth_sign', !value)
-              }
+              onToggle={() => showEthSignModal()}
               offLabel={t('off')}
               onLabel={t('on')}
             />

--- a/ui/pages/settings/advanced-tab/advanced-tab.container.js
+++ b/ui/pages/settings/advanced-tab/advanced-tab.container.js
@@ -68,6 +68,7 @@ export const mapDispatchToProps = (dispatch) => {
     displayWarning: (warning) => dispatch(displayWarning(warning)),
     showResetAccountConfirmationModal: () =>
       dispatch(showModal({ name: 'CONFIRM_RESET_ACCOUNT' })),
+    showEthSignModal: () => dispatch(showModal({ name: 'ETH_SIGN' })),
     setUseNonceField: (value) => dispatch(setUseNonceField(value)),
     setShowFiatConversionOnTestnetsPreference: (value) => {
       return dispatch(setShowFiatConversionOnTestnetsPreference(value));

--- a/ui/pages/settings/advanced-tab/advanced-tab.stories.js
+++ b/ui/pages/settings/advanced-tab/advanced-tab.stories.js
@@ -27,6 +27,9 @@ export default {
     showResetAccountConfirmationModal: {
       action: 'showResetAccountConfirmationModal',
     },
+    showEthSignModal: {
+      action: 'showEthSignModal',
+    },
   },
 };
 

--- a/ui/pages/settings/index.scss
+++ b/ui/pages/settings/index.scss
@@ -379,6 +379,9 @@
       max-width: 100%;
       width: 100%;
     }
+    .eth-sign-toggle .toggle-button__status { // for eth_sign we need to override the uppercase property of toggle button text
+      text-transform: capitalize;
+    }
   }
 
   &__content-item-col-open-sea {

--- a/ui/pages/settings/index.scss
+++ b/ui/pages/settings/index.scss
@@ -379,6 +379,7 @@
       max-width: 100%;
       width: 100%;
     }
+
     .eth-sign-toggle .toggle-button__status { // for eth_sign we need to override the uppercase property of toggle button text
       text-transform: capitalize;
     }

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -597,6 +597,10 @@ export function getShowTestNetworks(state) {
   return Boolean(showTestNetworks);
 }
 
+export function getDisabledRpcMethodPreferences(state) {
+  return state.metamask.disabledRpcMethodPreferences;
+}
+
 export function getShouldShowFiat(state) {
   const isMainNet = getIsMainnet(state);
   const isCustomNetwork = getIsCustomNetwork(state);


### PR DESCRIPTION
Currently,  eth_sign has been disabled by default, but users can enable the confirmation method in Settings > Advanced. Enabling eth_sign puts the user at risk of [phishing scams](https://medium.com/chainlight/si-vis-pacem-para-bellum-exploring-metamask-phishing-4605425d80a7) that can result in loss of funds. This PR is to add extra friction to enable eth_sign by adding Modal and text input. This PR also includes the analytics update for eth_sign

1. When user completes the flow to enable eth_sign toggle, we should fire the Settings Updated event with a enable_eth_sign boolean property with true as the value.

2. When user completes the flow to disable eth_sign toggle, we should fire the Settings Updated event with a enable_eth_sign boolean property with false as the value.

Fixes #18586 

## Screenshots/Screencaps

### Before

https://user-images.githubusercontent.com/39872794/234841744-2096c3fb-ffaa-424a-ba5f-d424fae584e0.mov


### After


https://user-images.githubusercontent.com/39872794/235162191-2ff933b7-503d-433e-b36d-1e076d405401.mov




## Manual Testing Steps

-  Go to the Settings > Advanced screen
- Toggle on the eth_sign toggle button
- Complete the steps in the modal
- At any step if you cancel the flow or click outside of the modal, it won't toggle on the modal unless you click the enable button in the last step of modal
- To turn off the eth_sign just click the toggle button

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
