### PR TITLE
replace the deprecated design system constant instances with their enum equivalent for all <Text> components.

### DIFF
--- a/ui/components/app/approve-content-card/approve-content-card.js
+++ b/ui/components/app/approve-content-card/approve-content-card.js
@@ -8,15 +8,15 @@ import Button from '../../ui/button';
 import EditGasFeeButton from '../edit-gas-fee-button/edit-gas-fee-button';
 import { Text } from '../../component-library';
 import {
-  AlignItems,
-  BLOCK_SIZES,
-  DISPLAY,
-  FLEX_DIRECTION,
-  FONT_WEIGHT,
-  JustifyContent,
-  TEXT_ALIGN,
-  TextColor,
-  TextVariant,
+    AlignItems,
+    BLOCK_SIZES,
+    DISPLAY,
+    FLEX_DIRECTION,
+    FontWeight,
+    JustifyContent,
+    TEXT_ALIGN,
+    TextColor,
+    TextVariant,
 } from '../../../helpers/constants/design-system';
 import { PRIMARY, SECONDARY } from '../../../helpers/constants/common';
 import { I18nContext } from '../../../contexts/i18n';
@@ -28,330 +28,331 @@ import TransactionDetailItem from '../transaction-detail-item/transaction-detail
 import UserPreferencedCurrencyDisplay from '../user-preferenced-currency-display';
 
 export default function ApproveContentCard({
-  showHeader = true,
-  symbol,
-  title,
-  showEdit,
-  showAdvanceGasFeeOptions = false,
-  onEditClick,
-  footer,
-  noBorder,
-  supportsEIP1559,
-  renderTransactionDetailsContent,
-  renderDataContent,
-  isMultiLayerFeeNetwork,
-  ethTransactionTotal,
-  nativeCurrency,
-  fullTxData,
-  hexMinimumTransactionFee,
-  hexTransactionTotal,
-  fiatTransactionTotal,
-  currentCurrency,
-  isSetApproveForAll,
-  isApprovalOrRejection,
-  data,
-  userAcknowledgedGasMissing,
-  renderSimulationFailureWarning,
-  useCurrencyRateCheck,
+    showHeader = true,
+    symbol,
+    title,
+    showEdit,
+    showAdvanceGasFeeOptions = false,
+    onEditClick,
+    footer,
+    noBorder,
+    supportsEIP1559,
+    renderTransactionDetailsContent,
+    renderDataContent,
+    isMultiLayerFeeNetwork,
+    ethTransactionTotal,
+    nativeCurrency,
+    fullTxData,
+    hexMinimumTransactionFee,
+    hexTransactionTotal,
+    fiatTransactionTotal,
+    currentCurrency,
+    isSetApproveForAll,
+    isApprovalOrRejection,
+    data,
+    userAcknowledgedGasMissing,
+    renderSimulationFailureWarning,
+    useCurrencyRateCheck,
 }) {
-  const t = useContext(I18nContext);
-  const { useNativeCurrencyAsPrimaryCurrency } = useSelector(getPreferences);
+    const t = useContext(I18nContext);
+    const { useNativeCurrencyAsPrimaryCurrency } = useSelector(getPreferences);
 
-  return (
-    <Box
-      className={classnames({
-        'approve-content-card-container__card': !noBorder,
-        'approve-content-card-container__card--no-border': noBorder,
-      })}
-    >
-      {showHeader && (
-        <Box
-          display={DISPLAY.FLEX}
-          flexDirection={FLEX_DIRECTION.ROW}
-          alignItems={AlignItems.center}
-          justifyContent={JustifyContent.flexEnd}
-          className="approve-content-card-container__card-header"
-        >
-          {supportsEIP1559 && title === t('transactionFee') ? null : (
-            <>
-              <Box className="approve-content-card-container__card-header__symbol">
-                {symbol}
-              </Box>
-              <Box
-                marginLeft={4}
-                className="approve-content-card-container__card-header__title"
-              >
-                <Text variant={TextVariant.bodySmBold} as="h6">
-                  {title}
-                </Text>
-              </Box>
-            </>
-          )}
-          {showEdit && (!showAdvanceGasFeeOptions || !supportsEIP1559) && (
-            <Box width={BLOCK_SIZES.ONE_SIXTH}>
-              <Button type="link" onClick={() => onEditClick()}>
-                <Text
-                  variant={TextVariant.bodySm}
-                  color={TextColor.primaryDefault}
-                  as="h6"
-                >
-                  {t('edit')}
-                </Text>
-              </Button>
-            </Box>
-          )}
-          {showEdit &&
-            showAdvanceGasFeeOptions &&
-            supportsEIP1559 &&
-            !renderSimulationFailureWarning && (
-              <EditGasFeeButton
-                userAcknowledgedGasMissing={userAcknowledgedGasMissing}
-              />
-            )}
-        </Box>
-      )}
-      <Box
-        marginTop={1}
-        marginBottom={3}
-        className="approve-content-card-container__card-content"
-      >
-        {renderTransactionDetailsContent &&
-          (!isMultiLayerFeeNetwork &&
-          supportsEIP1559 &&
-          !renderSimulationFailureWarning ? (
-            <ConfirmGasDisplay
-              userAcknowledgedGasMissing={userAcknowledgedGasMissing}
-            />
-          ) : (
-            <Box
-              display={DISPLAY.FLEX}
-              flexDirection={FLEX_DIRECTION.ROW}
-              justifyContent={JustifyContent.spaceBetween}
-            >
-              {isMultiLayerFeeNetwork ? (
-                <Box
-                  display={DISPLAY.FLEX}
-                  flexDirection={FLEX_DIRECTION.COLUMN}
-                  className="approve-content-card-container__transaction-details-extra-content"
-                >
-                  <TransactionDetailItem
-                    key="total-item"
-                    detailTitle={t('transactionDetailLayer2GasHeading')}
-                    detailTotal={
-                      <UserPreferencedCurrencyDisplay
-                        type={PRIMARY}
-                        value={hexMinimumTransactionFee}
-                        hideLabel={!useNativeCurrencyAsPrimaryCurrency}
-                        numberOfDecimals={18}
-                      />
-                    }
-                    detailText={
-                      <UserPreferencedCurrencyDisplay
-                        type={SECONDARY}
-                        value={hexMinimumTransactionFee}
-                        hideLabel={Boolean(useNativeCurrencyAsPrimaryCurrency)}
-                      />
-                    }
-                    noBold
-                    flexWidthValues
-                  />
-                  <MultiLayerFeeMessage
-                    transaction={fullTxData}
-                    layer2fee={hexTransactionTotal}
-                    nativeCurrency={nativeCurrency}
-                    plainStyle
-                  />
-                </Box>
-              ) : (
-                <>
-                  <Box>
-                    <Text
-                      variant={TextVariant.bodySm}
-                      color={TextColor.textAlternative}
-                      as="h6"
-                    >
-                      {t('feeAssociatedRequest')}
-                    </Text>
-                  </Box>
-                  <Box
-                    display={DISPLAY.FLEX}
-                    flexDirection={FLEX_DIRECTION.COLUMN}
-                    alignItems={AlignItems.flexEnd}
-                    textAlign={TEXT_ALIGN.RIGHT}
-                  >
-                    {useCurrencyRateCheck && (
-                      <Box>
-                        <Text
-                          variant={TextVariant.headingSm}
-                          fontWeight={FONT_WEIGHT.BOLD}
-                          color={TextColor.TEXT_DEFAULT}
-                          as="h4"
+    return ( <
+        Box className = {
+            classnames({
+                'approve-content-card-container__card': !noBorder,
+                'approve-content-card-container__card--no-border': noBorder,
+            })
+        } >
+        {
+            showHeader && ( <
+                Box display = { DISPLAY.FLEX }
+                flexDirection = { FLEX_DIRECTION.ROW }
+                alignItems = { AlignItems.center }
+                justifyContent = { JustifyContent.flexEnd }
+                className = "approve-content-card-container__card-header" >
+                {
+                    supportsEIP1559 && title === t('transactionFee') ? null : ( <
                         >
-                          {formatCurrency(
-                            fiatTransactionTotal,
-                            currentCurrency,
-                          )}
-                        </Text>
-                      </Box>
-                    )}
-                    <Box>
-                      <Text
-                        variant={TextVariant.bodySm}
-                        fontWeight={FONT_WEIGHT.NORMAL}
-                        color={TextColor.textMuted}
-                        as="h6"
-                      >
-                        {`${ethTransactionTotal} ${nativeCurrency}`}
-                      </Text>
-                    </Box>
-                  </Box>
-                </>
-              )}
-            </Box>
-          ))}
-        {renderDataContent && (
-          <Box display={DISPLAY.FLEX} flexDirection={FLEX_DIRECTION.COLUMN}>
-            <Box>
-              <Text
-                variant={TextVariant.bodySm}
-                color={TextColor.textAlternative}
-                as="h6"
-              >
-                {isSetApproveForAll
-                  ? t('functionSetApprovalForAll')
-                  : t('functionApprove')}
-              </Text>
-            </Box>
-            {isSetApproveForAll && isApprovalOrRejection !== undefined ? (
-              <Box>
-                <Text
-                  variant={TextVariant.bodySm}
-                  color={TextColor.textAlternative}
-                  as="h6"
-                >
-                  {`${t('parameters')}: ${isApprovalOrRejection}`}
-                </Text>
-              </Box>
-            ) : null}
-            <Box
-              marginRight={4}
-              className="approve-content-card-container__data__data-block"
-            >
-              <Text
-                variant={TextVariant.bodySm}
-                color={TextColor.textAlternative}
-                as="h6"
-              >
-                {data}
-              </Text>
-            </Box>
-          </Box>
-        )}
-      </Box>
-      {footer}
-    </Box>
-  );
+                        <
+                        Box className = "approve-content-card-container__card-header__symbol" > { symbol } <
+                        /Box> <
+                        Box marginLeft = { 4 }
+                        className = "approve-content-card-container__card-header__title" >
+                        <
+                        Text variant = { TextVariant.bodySmBold }
+                        as = "h6" > { title } <
+                        /Text> <
+                        /Box> <
+                        />
+                    )
+                } {
+                    showEdit && (!showAdvanceGasFeeOptions || !supportsEIP1559) && ( <
+                        Box width = { BLOCK_SIZES.ONE_SIXTH } >
+                        <
+                        Button type = "link"
+                        onClick = {
+                            () => onEditClick() } >
+                        <
+                        Text variant = { TextVariant.bodySm }
+                        color = { TextColor.primaryDefault }
+                        as = "h6" >
+                        { t('edit') } <
+                        /Text> <
+                        /Button> <
+                        /Box>
+                    )
+                } {
+                    showEdit &&
+                        showAdvanceGasFeeOptions &&
+                        supportsEIP1559 &&
+                        !renderSimulationFailureWarning && ( <
+                            EditGasFeeButton userAcknowledgedGasMissing = { userAcknowledgedGasMissing }
+                            />
+                        )
+                } <
+                /Box>
+            )
+        } <
+        Box marginTop = { 1 }
+        marginBottom = { 3 }
+        className = "approve-content-card-container__card-content" >
+        {
+            renderTransactionDetailsContent &&
+            (!isMultiLayerFeeNetwork &&
+                supportsEIP1559 &&
+                !renderSimulationFailureWarning ? ( <
+                    ConfirmGasDisplay userAcknowledgedGasMissing = { userAcknowledgedGasMissing }
+                    />
+                ) : ( <
+                    Box display = { DISPLAY.FLEX }
+                    flexDirection = { FLEX_DIRECTION.ROW }
+                    justifyContent = { JustifyContent.spaceBetween } >
+                    {
+                        isMultiLayerFeeNetwork ? ( <
+                            Box display = { DISPLAY.FLEX }
+                            flexDirection = { FLEX_DIRECTION.COLUMN }
+                            className = "approve-content-card-container__transaction-details-extra-content" >
+                            <
+                            TransactionDetailItem key = "total-item"
+                            detailTitle = { t('transactionDetailLayer2GasHeading') }
+                            detailTotal = { <
+                                UserPreferencedCurrencyDisplay
+                                type = { PRIMARY }
+                                value = { hexMinimumTransactionFee }
+                                hideLabel = {!useNativeCurrencyAsPrimaryCurrency }
+                                numberOfDecimals = { 18 }
+                                />
+                            }
+                            detailText = { <
+                                UserPreferencedCurrencyDisplay
+                                type = { SECONDARY }
+                                value = { hexMinimumTransactionFee }
+                                hideLabel = { Boolean(useNativeCurrencyAsPrimaryCurrency) }
+                                />
+                            }
+                            noBold flexWidthValues /
+                            >
+                            <
+                            MultiLayerFeeMessage transaction = { fullTxData }
+                            layer2fee = { hexTransactionTotal }
+                            nativeCurrency = { nativeCurrency }
+                            plainStyle /
+                            >
+                            <
+                            /Box>
+                        ) : ( <
+                            >
+                            <
+                            Box >
+                            <
+                            Text variant = { TextVariant.bodySm }
+                            color = { TextColor.textAlternative }
+                            as = "h6" >
+                            { t('feeAssociatedRequest') } <
+                            /Text> <
+                            /Box> <
+                            Box display = { DISPLAY.FLEX }
+                            flexDirection = { FLEX_DIRECTION.COLUMN }
+                            alignItems = { AlignItems.flexEnd }
+                            textAlign = { TEXT_ALIGN.RIGHT } >
+                            {
+                                useCurrencyRateCheck && ( <
+                                    Box >
+                                    <
+                                    Text variant = { TextVariant.headingSm }
+                                    fontWeight = { FontWeight.Bold }
+                                    color = { TextColor.textDefault }
+                                    as = "h4" >
+                                    {
+                                        formatCurrency(
+                                            fiatTransactionTotal,
+                                            currentCurrency,
+                                        )
+                                    } <
+                                    /Text> <
+                                    /Box>
+                                )
+                            } <
+                            Box >
+                            <
+                            Text variant = { TextVariant.bodySm }
+                            fontWeight = { FontWeight.Normal }
+                            color = { TextColor.textMuted }
+                            as = "h6" >
+                            { `${ethTransactionTotal} ${nativeCurrency}` } <
+                            /Text> <
+                            /Box> <
+                            /Box> <
+                            />
+                        )
+                    } <
+                    /Box>
+                ))
+        } {
+            renderDataContent && ( <
+                Box display = { DISPLAY.FLEX }
+                flexDirection = { FLEX_DIRECTION.COLUMN } >
+                <
+                Box >
+                <
+                Text variant = { TextVariant.bodySm }
+                color = { TextColor.textAlternative }
+                as = "h6" >
+                {
+                    isSetApproveForAll ?
+                    t('functionSetApprovalForAll') :
+                        t('functionApprove')
+                } <
+                /Text> <
+                /Box> {
+                    isSetApproveForAll && isApprovalOrRejection !== undefined ? ( <
+                        Box >
+                        <
+                        Text variant = { TextVariant.bodySm }
+                        color = { TextColor.textAlternative }
+                        as = "h6" >
+                        { `${t('parameters')}: ${isApprovalOrRejection}` } <
+                        /Text> <
+                        /Box>
+                    ) : null
+                } <
+                Box marginRight = { 4 }
+                className = "approve-content-card-container__data__data-block" >
+                <
+                Text variant = { TextVariant.bodySm }
+                color = { TextColor.textAlternative }
+                as = "h6" >
+                { data } <
+                /Text> <
+                /Box> <
+                /Box>
+            )
+        } <
+        /Box> { footer } <
+        /Box>
+    );
 }
 
 ApproveContentCard.propTypes = {
-  /**
-   * Whether to show header including icon, transaction fee text and edit button
-   */
-  showHeader: PropTypes.bool,
-  /**
-   * Symbol icon
-   */
-  symbol: PropTypes.node,
-  /**
-   * Title to be included in the header
-   */
-  title: PropTypes.string,
-  /**
-   * Whether to show edit button or not
-   */
-  showEdit: PropTypes.bool,
-  /**
-   * Whether to show advanced gas fee options or not
-   */
-  showAdvanceGasFeeOptions: PropTypes.bool,
-  /**
-   * Should open customize gas modal when edit button is clicked
-   */
-  onEditClick: PropTypes.func,
-  /**
-   * Footer to be shown
-   */
-  footer: PropTypes.node,
-  /**
-   * Whether to include border-bottom or not
-   */
-  noBorder: PropTypes.bool,
-  /**
-   * Is enhanced gas fee enabled or not
-   */
-  supportsEIP1559: PropTypes.bool,
-  /**
-   * Whether to render transaction details content or not
-   */
-  renderTransactionDetailsContent: PropTypes.bool,
-  /**
-   * Whether to render data content or not
-   */
-  renderDataContent: PropTypes.bool,
-  /**
-   * Is multi-layer fee network or not
-   */
-  isMultiLayerFeeNetwork: PropTypes.bool,
-  /**
-   * Total sum of the transaction in native currency
-   */
-  ethTransactionTotal: PropTypes.string,
-  /**
-   * Current native currency
-   */
-  nativeCurrency: PropTypes.string,
-  /**
-   * Current transaction
-   */
-  fullTxData: PropTypes.object,
-  /**
-   * Total sum of the transaction converted to hex value
-   */
-  hexTransactionTotal: PropTypes.string,
-  /**
-   * Minimum transaction fee converted to hex value
-   */
-  hexMinimumTransactionFee: PropTypes.string,
-  /**
-   * Total sum of the transaction in fiat currency
-   */
-  fiatTransactionTotal: PropTypes.string,
-  /**
-   * Current fiat currency
-   */
-  currentCurrency: PropTypes.string,
-  /**
-   * Is set approve for all or not
-   */
-  isSetApproveForAll: PropTypes.bool,
-  /**
-   * Whether a current set approval for all transaction will approve or revoke access
-   */
-  isApprovalOrRejection: PropTypes.bool,
-  /**
-   * Current transaction data
-   */
-  data: PropTypes.string,
-  /**
-   * User acknowledge gas is missing or not
-   */
-  userAcknowledgedGasMissing: PropTypes.bool,
-  /**
-   * Render simulation failure warning
-   */
-  renderSimulationFailureWarning: PropTypes.bool,
-  /**
-   * Fiat conversion control
-   */
-  useCurrencyRateCheck: PropTypes.bool,
+    /**
+     * Whether to show header including icon, transaction fee text and edit button
+     */
+    showHeader: PropTypes.bool,
+    /**
+     * Symbol icon
+     */
+    symbol: PropTypes.node,
+    /**
+     * Title to be included in the header
+     */
+    title: PropTypes.string,
+    /**
+     * Whether to show edit button or not
+     */
+    showEdit: PropTypes.bool,
+    /**
+     * Whether to show advanced gas fee options or not
+     */
+    showAdvanceGasFeeOptions: PropTypes.bool,
+    /**
+     * Should open customize gas modal when edit button is clicked
+     */
+    onEditClick: PropTypes.func,
+    /**
+     * Footer to be shown
+     */
+    footer: PropTypes.node,
+    /**
+     * Whether to include border-bottom or not
+     */
+    noBorder: PropTypes.bool,
+    /**
+     * Is enhanced gas fee enabled or not
+     */
+    supportsEIP1559: PropTypes.bool,
+    /**
+     * Whether to render transaction details content or not
+     */
+    renderTransactionDetailsContent: PropTypes.bool,
+    /**
+     * Whether to render data content or not
+     */
+    renderDataContent: PropTypes.bool,
+    /**
+     * Is multi-layer fee network or not
+     */
+    isMultiLayerFeeNetwork: PropTypes.bool,
+    /**
+     * Total sum of the transaction in native currency
+     */
+    ethTransactionTotal: PropTypes.string,
+    /**
+     * Current native currency
+     */
+    nativeCurrency: PropTypes.string,
+    /**
+     * Current transaction
+     */
+    fullTxData: PropTypes.object,
+    /**
+     * Total sum of the transaction converted to hex value
+     */
+    hexTransactionTotal: PropTypes.string,
+    /**
+     * Minimum transaction fee converted to hex value
+     */
+    hexMinimumTransactionFee: PropTypes.string,
+    /**
+     * Total sum of the transaction in fiat currency
+     */
+    fiatTransactionTotal: PropTypes.string,
+    /**
+     * Current fiat currency
+     */
+    currentCurrency: PropTypes.string,
+    /**
+     * Is set approve for all or not
+     */
+    isSetApproveForAll: PropTypes.bool,
+    /**
+     * Whether a current set approval for all transaction will approve or revoke access
+     */
+    isApprovalOrRejection: PropTypes.bool,
+    /**
+     * Current transaction data
+     */
+    data: PropTypes.string,
+    /**
+     * User acknowledge gas is missing or not
+     */
+    userAcknowledgedGasMissing: PropTypes.bool,
+    /**
+     * Render simulation failure warning
+     */
+    renderSimulationFailureWarning: PropTypes.bool,
+    /**
+     * Fiat conversion control
+     */
+    useCurrencyRateCheck: PropTypes.bool,
 };


### PR DESCRIPTION
## Explanation

In ui/app/approve-content-card.js ---> Replace deprecated design system typography consts with enums #18714
<!--
Thanks for the pull request. Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues, Slack conversations, Zendesk issues, user stories, etc. reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

## Screenshots/Screencaps

<!-- If you're making a change to the UI, make sure to capture a screenshot or a short video showing off your work! -->

### Before

<!-- How did the UI you changed look before your changes? Drag your file(s) below this line: -->
I got encountered some issues, so I wasn't able to build the metamask extension locally in my system. But I am sure there wouldn't be any changes in UI with my changes

### After

<!-- How does it look now? Drag your file(s) below this line: -->

## Manual Testing Steps

<!--
How should reviewers and QA manually test your changes? For instance:

- Go to this screen
- Do this
- Then do this
-->

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
