### PR TITLE
Terms of use e2e

### DIFF
--- a/test/e2e/fixture-builder.js
+++ b/test/e2e/fixture-builder.js
@@ -140,7 +140,8 @@ function defaultFixture() {
         browserEnvironment: {},
         nftsDropdownState: {},
         connectedStatusPopoverHasBeenShown: true,
-        termsOfUseLastAgreed: 86400000000000,
+        termsOfUseLastAgreed:
+          '__FIXTURE_SUBSTITUTION__currentDateInMilliseconds',
         defaultHomeActiveTabName: null,
         fullScreenGasPollTokens: [],
         notificationGasPollTokens: [],

--- a/test/e2e/tests/terms-of-use.spec.js
+++ b/test/e2e/tests/terms-of-use.spec.js
@@ -1,0 +1,45 @@
+const { strict: assert } = require('assert');
+const { convertToHexValue, withFixtures } = require('../helpers');
+const FixtureBuilder = require('../fixture-builder');
+
+describe('Terms of use', function () {
+  const ganacheOptions = {
+    accounts: [
+      {
+        secretKey:
+          '0x7C9529A67102755B7E6102D6D950AC5D5863C98713805CEC576B945B15B71EAC',
+        balance: convertToHexValue(25000000000000000000),
+      },
+    ],
+  };
+  it('accepts the updated terms of use', async function () {
+    const firstOfJan = 1672574400;
+    await withFixtures(
+      {
+        fixtures: new FixtureBuilder()
+          .withAppStateController({
+            termsOfUseLastAgreed: firstOfJan,
+          })
+          .build(),
+        ganacheOptions,
+        title: this.test.title,
+      },
+      async ({ driver }) => {
+        await driver.navigate();
+        await driver.fill('#password', 'correct horse battery staple');
+        await driver.press('#password', driver.Key.ENTER);
+
+        // accept updated terms of use
+        const acceptTerms = '[data-testid="terms-of-use-accept-button"]';
+        await driver.clickElement('[data-testid="popover-scroll-button"]');
+        await driver.clickElement('[data-testid="terms-of-use-checkbox"]');
+        await driver.clickElement(acceptTerms);
+
+        // check modal is no longer shown
+        await driver.waitForElementNotPresent(acceptTerms);
+        const termsExists = await driver.isElementPresent(acceptTerms);
+        assert.equal(termsExists, false, 'terms of use should not be shown');
+      },
+    );
+  });
+});


### PR DESCRIPTION
## Explanation

<!--
Thanks for the pull request. Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues, Slack conversations, Zendesk issues, user stories, etc. reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

This PR adds test coverage for the updated terms of use modal implemented in https://github.com/MetaMask/metamask-extension/pull/18221

## Screenshots/Screencaps

<!-- If you're making a change to the UI, make sure to capture a screenshot or a short video showing off your work! -->

### Before

<!-- How did the UI you changed look before your changes? Drag your file(s) below this line: -->

### After

<!-- How does it look now? Drag your file(s) below this line: -->

## Manual Testing Steps

<!--
How should reviewers and QA manually test your changes? For instance:

- Go to this screen
- Do this
- Then do this
-->

Check all the tests are green on this PR, or run the tests locally using the following command;
```
yarn
yarn buid:test
yarn test:e2e:single test/e2e/tests/terms-of-use.spec.js  --browser chrome
yarn test:e2e:single test/e2e/tests/terms-of-use.spec.js  --browser firefox
```


## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
