### PR TITLE
Consistent message for third party requests across screens

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -842,10 +842,10 @@
     "message": "NFT contract"
   },
   "contractRequestingAccess": {
-    "message": "Contract requesting access"
+    "message": "Third party requesting access"
   },
   "contractRequestingSignature": {
-    "message": "Contract requesting signature"
+    "message": "Third party requesting signature"
   },
   "contractRequestingSpendingCap": {
     "message": "Third party requesting spending cap"


### PR DESCRIPTION
Fixes: #18806

Change `Contract requesting ...` to `Third party requesting ...` across all screens.