### PR TITLE
Fix script to build migrations by having it use the `.ts` template

### DIFF
--- a/development/generate-migration.sh
+++ b/development/generate-migration.sh
@@ -1,7 +1,19 @@
 #! /bin/bash
+
+validate-number(){
+  re='^[0-9]+$'
+  if [[ ! $1 =~ $re ]]; then
+    echo "Error: The value must be a number." >&2
+    exit 1
+  fi
+}
+
 g-migration() {
   [[ -z "$1" ]] && { echo "Migration version is required!" ; exit 1; }
   local vnum=$1
+
+  validate-number "$vnum"
+
   if (($1 < 100)); then
     vnum=0$1
   fi

--- a/development/generate-migration.sh
+++ b/development/generate-migration.sh
@@ -5,8 +5,8 @@ g-migration() {
   if (($1 < 100)); then
     vnum=0$1
   fi
-  touch app/scripts/migrations/"$vnum".js
-  cp app/scripts/migrations/template.js app/scripts/migrations/"$vnum".js
+  touch app/scripts/migrations/"$vnum".ts
+  cp app/scripts/migrations/template.ts app/scripts/migrations/"$vnum".ts
 
   touch app/scripts/migrations/"$vnum".test.js
   cp app/scripts/migrations/template.test.js app/scripts/migrations/"$vnum".test.js


### PR DESCRIPTION
## Explanation
At some point we changed our migration template file to be written in typescript. However, the migration generator was not updated to account for this and still references a `.js` template file. As a result, when trying to create migrations we see that the process fails. This PR upgrades the migration script to use the [new template](https://github.com/MetaMask/metamask-extension/blob/ellul/update-migration-generator-ts/app/scripts/migrations/template.ts) written in typescript.

I also add validation that the version number we provide is numeric and adds a hint if it isn't. This should help others who aren't sure what value should be provided as a parameter, and also ensure no invalid values are given.

### Before

```shell
yarn generate:migration 89
=> cp: app/scripts/migrations/template.js: No such file or directory
```

### After

Migration files are created successfully with the template

## Manual Testing Steps

Run the following command:

```sh
yarn generate:migration 89
```

See that the following files are created and have code pre-populated:

```
app/scripts/migrations/089.test.js 
app/scripts/migrations/089.ts
```

We should also see the validation works

```shell
yarn generate:migration hello
=> Error: The value must be a number.
```


## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved