### PR TITLE
UX: Multichain: Add maximum width for network picker in full screen mode

### DIFF
--- a/ui/components/multichain/app-header/app-header.js
+++ b/ui/components/multichain/app-header/app-header.js
@@ -164,6 +164,7 @@ export const AppHeader = ({ onClick }) => {
                 src={currentNetwork?.rpcPrefs?.imageUrl}
                 onClick={networkOpenCallback}
                 display={[DISPLAY.NONE, DISPLAY.FLEX]} // show on desktop hide on popover
+                className="multichain-app-header__contents__network-picker"
               />
               {showProductTour &&
               popupStatus &&


### PR DESCRIPTION
## Explanation

With https://github.com/MetaMask/metamask-extension/commit/27b2993cae5f2209c6681dcf47a4a586bff7d3bd we implemented a max width for the network picker in the dropdown, but we should definitely still implement one in full screen mode as well.

## Screenshots/Screencaps

<img width="916" alt="SCR-20230428-mbuo" src="https://user-images.githubusercontent.com/46655/235225880-53ff7c9d-a97a-411c-bd6e-1345352ac54f.png">


## Pre-merge author checklist

- [ ] I've clearly explained:
  - [ ] What problem this PR is solving
  - [ ] How this problem was solved
  - [ ] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
