### PR TITLE
Discontinue use of deleted getProductionConfig function

### DIFF
--- a/development/build/index.js
+++ b/development/build/index.js
@@ -14,7 +14,7 @@ const difference = require('lodash/difference');
 const { intersection } = require('lodash');
 const { getVersion } = require('../lib/get-version');
 const { loadBuildTypesConfig } = require('../lib/build-type');
-const { TASKS, ENVIRONMENT } = require('./constants');
+const { TASKS } = require('./constants');
 const {
   createTask,
   composeSeries,
@@ -27,7 +27,7 @@ const createStyleTasks = require('./styles');
 const createStaticAssetTasks = require('./static');
 const createEtcTasks = require('./etc');
 const { getBrowserVersionMap, getEnvironment } = require('./utils');
-const { getConfig, getProductionConfig } = require('./config');
+const { getConfig } = require('./config');
 const { BUILD_TARGETS } = require('./constants');
 
 // Packages required dynamically via browserify configuration in dependencies
@@ -360,13 +360,8 @@ testDev: Create an unoptimized, live-reloading build for debugging e2e tests.`,
   const highLevelTasks = Object.values(BUILD_TARGETS);
   if (highLevelTasks.includes(task)) {
     const environment = getEnvironment({ buildTarget: task });
-    if (environment === ENVIRONMENT.PRODUCTION) {
-      // Output ignored, this is only called to ensure config is validated
-      await getProductionConfig(buildType);
-    } else {
-      // Output ignored, this is only called to ensure config is validated
-      await getConfig();
-    }
+    // Output ignored, this is only called to ensure config is validated
+    await getConfig(buildType, environment);
   }
 
   return {


### PR DESCRIPTION
## Explanation

This fixes a bug in our build code that shows up when trying to create a `prod` build. We deleted the `getProductionConfig` function here https://github.com/MetaMask/metamask-extension/pull/18125/files#diff-d7069b9e2275639316041709cf257d4b2580bdc9c80ce701d11b8df8e82a49e3L74-L85

However, we didn't remove one place where we attempt to import and call it in `development/build/index.js`

This leads to a `TypeError: getProductionConfig is not a function` error when attempting to build for production.

The PR fixes the problem by replacing the attempted call to `getProductionConfig` with a call to `getConfig` with the necessary `environment` parameter passed in. That function was updated in the above linked PR, and it now covers the purposes that `getProductionConfig` previous served.

To test this, you could run `yarn build --build-type flask prod` with appropriate environment variables set. Before this PR, you will see the aforementioned type error. After this PR, you will see a different error. (That still needs to be solved, but it will be solved in a future PR.)

## Pre-merge author checklist

- [ ] I've clearly explained:
  - [ ] What problem this PR is solving
  - [ ] How this problem was solved
  - [ ] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
