### PR TITLE
Rename `provider` to `providerConfig`

### DIFF
--- a/.storybook/test-data.js
+++ b/.storybook/test-data.js
@@ -599,7 +599,7 @@ const state = {
     connectedStatusPopoverHasBeenShown: true,
     swapsWelcomeMessageHasBeenShown: true,
     defaultHomeActiveTabName: 'Assets',
-    provider: {
+    providerConfig: {
       type: 'goerli',
       ticker: 'ETH',
       nickname: '',

--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -219,9 +219,9 @@ browser.runtime.onConnectExternal.addListener(async (...args) => {
  * @property {object} featureFlags - An object for optional feature flags.
  * @property {boolean} welcomeScreen - True if welcome screen should be shown.
  * @property {string} currentLocale - A locale string matching the user's preferred display language.
- * @property {object} provider - The current selected network provider.
- * @property {string} provider.rpcUrl - The address for the RPC API, if using an RPC API.
- * @property {string} provider.type - An identifier for the type of network selected, allows MetaMask to use custom provider strategies for known networks.
+ * @property {object} providerConfig - The current selected network provider.
+ * @property {string} providerConfig.rpcUrl - The address for the RPC API, if using an RPC API.
+ * @property {string} providerConfig.type - An identifier for the type of network selected, allows MetaMask to use custom provider strategies for known networks.
  * @property {string} networkId - The stringified number of the current network ID.
  * @property {string} networkStatus - Either "unknown", "available", "unavailable", or "blocked", depending on the status of the currently selected network.
  * @property {object} accounts - An object mapping lower-case hex addresses to objects with "balance" and "address" keys, both storing hex string values.
@@ -462,7 +462,7 @@ export function setupController(
 
   setupEnsIpfsResolver({
     getCurrentChainId: () =>
-      controller.networkController.store.getState().provider.chainId,
+      controller.networkController.store.getState().providerConfig.chainId,
     getIpfsGateway: controller.preferencesController.getIpfsGateway.bind(
       controller.preferencesController,
     ),

--- a/app/scripts/controllers/detect-tokens.js
+++ b/app/scripts/controllers/detect-tokens.js
@@ -209,7 +209,7 @@ export default class DetectTokensController {
   }
 
   getChainIdFromNetworkStore(network) {
-    return network?.store.getState().provider.chainId;
+    return network?.store.getState().providerConfig.chainId;
   }
 
   /* eslint-disable accessor-pairs */

--- a/app/scripts/controllers/detect-tokens.test.js
+++ b/app/scripts/controllers/detect-tokens.test.js
@@ -235,7 +235,7 @@ describe('DetectTokensController', function () {
           const modifiedNetworkState = {
             ...networkState,
             providerConfig: {
-              ...networkState.provider,
+              ...networkState.providerConfig,
             },
           };
           return cb(modifiedNetworkState);
@@ -254,8 +254,10 @@ describe('DetectTokensController', function () {
             const modifiedNetworkState = {
               ...networkState,
               providerConfig: {
-                ...networkState.provider,
-                chainId: convertHexToDecimal(networkState.provider.chainId),
+                ...networkState.providerConfig,
+                chainId: convertHexToDecimal(
+                  networkState.providerConfig.chainId,
+                ),
               },
             };
             return cb(modifiedNetworkState);

--- a/app/scripts/controllers/metametrics.test.js
+++ b/app/scripts/controllers/metametrics.test.js
@@ -65,7 +65,7 @@ const DEFAULT_PAGE_PROPERTIES = {
 
 function getMockNetworkController() {
   let state = {
-    provider: {
+    providerConfig: {
       type: NETWORK_TYPES.GOERLI,
       chainId: FAKE_CHAIN_ID,
     },
@@ -134,7 +134,7 @@ function getMetaMetricsController({
   return new MetaMetricsController({
     segment: segmentInstance || segment,
     getCurrentChainId: () =>
-      networkController.store.getState().provider.chainId,
+      networkController.store.getState().providerConfig.chainId,
     onNetworkDidChange:
       networkController.onNetworkDidChange.bind(networkController),
     preferencesStore,
@@ -203,7 +203,7 @@ describe('MetaMetricsController', function () {
         networkController,
       });
       networkController.store.updateState({
-        provider: {
+        providerConfig: {
           type: 'NEW_NETWORK',
           chainId: '0xaab',
         },

--- a/app/scripts/controllers/network/network-controller.test.ts
+++ b/app/scripts/controllers/network/network-controller.test.ts
@@ -164,7 +164,7 @@ describe('NetworkController', () => {
       await withController(
         {
           state: {
-            provider: {
+            providerConfig: {
               type: 'rpc',
               rpcUrl: 'http://example-custom-rpc.metamask.io',
               chainId: '0x9999' as const,
@@ -188,7 +188,7 @@ describe('NetworkController', () => {
               },
               "networkId": null,
               "networkStatus": "unknown",
-              "provider": {
+              "providerConfig": {
                 "chainId": "0x9999",
                 "nickname": "Test initial state",
                 "rpcUrl": "http://example-custom-rpc.metamask.io",
@@ -212,7 +212,7 @@ describe('NetworkController', () => {
             },
             "networkId": null,
             "networkStatus": "unknown",
-            "provider": {
+            "providerConfig": {
               "chainId": "0x539",
               "nickname": "Localhost 8545",
               "rpcUrl": "http://localhost:8545",
@@ -260,7 +260,7 @@ describe('NetworkController', () => {
         /* @ts-expect-error We're intentionally passing bad input. */
         {
           state: {
-            provider: invalidProviderConfig,
+            providerConfig: invalidProviderConfig,
           },
         },
         async ({ controller }) => {
@@ -279,7 +279,7 @@ describe('NetworkController', () => {
           await withController(
             {
               state: {
-                provider: {
+                providerConfig: {
                   type: networkType,
                   // NOTE: This doesn't need to match the logical chain ID
                   // of the network selected, it just needs to exist
@@ -329,7 +329,7 @@ describe('NetworkController', () => {
           await withController(
             {
               state: {
-                provider: {
+                providerConfig: {
                   type: networkType,
                   // NOTE: This doesn't need to match the logical chain ID
                   // of the network selected, it just needs to exist
@@ -359,7 +359,7 @@ describe('NetworkController', () => {
           await withController(
             {
               state: {
-                provider: {
+                providerConfig: {
                   type: networkType,
                   // NOTE: This doesn't need to match the logical chain ID
                   // of the network selected, it just needs to exist
@@ -399,7 +399,7 @@ describe('NetworkController', () => {
           await withController(
             {
               state: {
-                provider: {
+                providerConfig: {
                   type: networkType,
                   // NOTE: This doesn't need to match the logical chain ID
                   // of the network selected, it just needs to exist
@@ -444,7 +444,7 @@ describe('NetworkController', () => {
         await withController(
           {
             state: {
-              provider: {
+              providerConfig: {
                 type: 'rpc',
                 chainId: '0x1337',
                 rpcUrl: 'https://mock-rpc-url',
@@ -502,7 +502,7 @@ describe('NetworkController', () => {
         await withController(
           {
             state: {
-              provider: {
+              providerConfig: {
                 type: 'rpc',
                 rpcUrl: 'https://mock-rpc-url',
                 chainId: '0xtest',
@@ -540,7 +540,7 @@ describe('NetworkController', () => {
         await withController(
           {
             state: {
-              provider: {
+              providerConfig: {
                 type: 'rpc',
                 rpcUrl: 'https://mock-rpc-url',
                 chainId: '0xtest',
@@ -579,7 +579,7 @@ describe('NetworkController', () => {
         await withController(
           {
             state: {
-              provider: {
+              providerConfig: {
                 type: 'rpc',
                 rpcUrl: 'https://mock-rpc-url',
                 chainId: '0xtest',
@@ -625,7 +625,7 @@ describe('NetworkController', () => {
         await withController(
           {
             state: {
-              provider: {
+              providerConfig: {
                 type: 'rpc',
                 rpcUrl: 'https://mock-rpc-url',
                 chainId: '0xtest',
@@ -705,7 +705,7 @@ describe('NetworkController', () => {
           await withController(
             {
               state: {
-                provider: {
+                providerConfig: {
                   type: 'rpc',
                   rpcUrl: 'https://mock-rpc-url',
                   chainId: '0x1337',
@@ -788,7 +788,7 @@ describe('NetworkController', () => {
         await withController(
           {
             state: {
-              provider: {
+              providerConfig: {
                 type: 'goerli',
                 // NOTE: This doesn't need to match the logical chain ID of
                 // the network selected, it just needs to exist
@@ -1088,7 +1088,7 @@ describe('NetworkController', () => {
           nickname: 'Test initial state',
         };
         const initialState = {
-          provider: providerConfig,
+          providerConfig,
           networkDetails: {
             EIPS: {
               1559: true,
@@ -1160,7 +1160,7 @@ describe('NetworkController', () => {
           /* @ts-expect-error We are intentionally not including a chainId in the provider config. */
           {
             state: {
-              provider: {
+              providerConfig: {
                 type: 'rpc',
                 rpcUrl: 'http://example-custom-rpc.metamask.io',
               },
@@ -1192,7 +1192,7 @@ describe('NetworkController', () => {
           /* @ts-expect-error We are intentionally not including a chainId in the provider config. */
           {
             state: {
-              provider: {
+              providerConfig: {
                 type: 'rpc',
                 rpcUrl: 'http://example-custom-rpc.metamask.io',
               },
@@ -1223,7 +1223,7 @@ describe('NetworkController', () => {
           /* @ts-expect-error We are intentionally not including a chainId in the provider config. */
           {
             state: {
-              provider: {
+              providerConfig: {
                 type: 'rpc',
                 rpcUrl: 'http://example-custom-rpc.metamask.io',
               },
@@ -1257,7 +1257,7 @@ describe('NetworkController', () => {
             await withController(
               {
                 state: {
-                  provider: {
+                  providerConfig: {
                     type: networkType,
                     // NOTE: This doesn't need to match the logical chain ID of
                     // the network selected, it just needs to exist
@@ -1305,7 +1305,7 @@ describe('NetworkController', () => {
             await withController(
               {
                 state: {
-                  provider: {
+                  providerConfig: {
                     type: networkType,
                     // NOTE: This doesn't need to match the logical chain ID of
                     // the network selected, it just needs to exist
@@ -1351,7 +1351,7 @@ describe('NetworkController', () => {
             await withController(
               {
                 state: {
-                  provider: {
+                  providerConfig: {
                     type: networkType,
                     // NOTE: This doesn't need to match the logical chain ID of
                     // the network selected, it just needs to exist
@@ -1401,7 +1401,7 @@ describe('NetworkController', () => {
             await withController(
               {
                 state: {
-                  provider: {
+                  providerConfig: {
                     type: networkType,
                     // NOTE: This doesn't need to match the logical chain ID of
                     // the network selected, it just needs to exist
@@ -1451,7 +1451,7 @@ describe('NetworkController', () => {
             await withController(
               {
                 state: {
-                  provider: {
+                  providerConfig: {
                     type: networkType,
                     // NOTE: This doesn't need to match the logical chain ID
                     // of the network selected, it just needs to exist
@@ -1498,7 +1498,7 @@ describe('NetworkController', () => {
             await withController(
               {
                 state: {
-                  provider: {
+                  providerConfig: {
                     type: networkType,
                     // NOTE: This doesn't need to match the logical chain ID
                     // of the network selected, it just needs to exist
@@ -1543,7 +1543,7 @@ describe('NetworkController', () => {
             await withController(
               {
                 state: {
-                  provider: {
+                  providerConfig: {
                     type: networkType,
                     // NOTE: This doesn't need to match the logical chain ID of
                     // the network selected, it just needs to exist
@@ -1609,7 +1609,7 @@ describe('NetworkController', () => {
             await withController(
               {
                 state: {
-                  provider: {
+                  providerConfig: {
                     type: networkType,
                     // NOTE: This doesn't need to match the logical chain ID of
                     // the network selected, it just needs to exist
@@ -1663,7 +1663,7 @@ describe('NetworkController', () => {
             await withController(
               {
                 state: {
-                  provider: {
+                  providerConfig: {
                     type: networkType,
                     // NOTE: This doesn't need to match the logical chain ID
                     // of the network selected, it just needs to exist
@@ -1706,7 +1706,7 @@ describe('NetworkController', () => {
             await withController(
               {
                 state: {
-                  provider: {
+                  providerConfig: {
                     type: networkType,
                     // NOTE: This doesn't need to match the logical chain ID
                     // of the network selected, it just needs to exist
@@ -1753,7 +1753,7 @@ describe('NetworkController', () => {
             await withController(
               {
                 state: {
-                  provider: {
+                  providerConfig: {
                     type: networkType,
                     // NOTE: This doesn't need to match the logical chain ID of
                     // the network selected, it just needs to exist
@@ -1824,7 +1824,7 @@ describe('NetworkController', () => {
             await withController(
               {
                 state: {
-                  provider: {
+                  providerConfig: {
                     type: networkType,
                     // NOTE: This doesn't need to match the logical chain ID of
                     // the network selected, it just needs to exist
@@ -1895,7 +1895,7 @@ describe('NetworkController', () => {
             await withController(
               {
                 state: {
-                  provider: {
+                  providerConfig: {
                     type: networkType,
                     // NOTE: This doesn't need to match the logical chain ID of
                     // the network selected, it just needs to exist
@@ -1964,7 +1964,7 @@ describe('NetworkController', () => {
             await withController(
               {
                 state: {
-                  provider: {
+                  providerConfig: {
                     type: networkType,
                     // NOTE: This doesn't need to match the logical chain ID of
                     // the network selected, it just needs to exist
@@ -2056,7 +2056,7 @@ describe('NetworkController', () => {
             await withController(
               {
                 state: {
-                  provider: {
+                  providerConfig: {
                     type: networkType,
                     // NOTE: This doesn't need to match the logical chain ID of
                     // the network selected, it just needs to exist
@@ -2103,7 +2103,7 @@ describe('NetworkController', () => {
             await withController(
               {
                 state: {
-                  provider: {
+                  providerConfig: {
                     type: networkType,
                     // NOTE: This doesn't need to match the logical chain ID of
                     // the network selected, it just needs to exist
@@ -2213,7 +2213,7 @@ describe('NetworkController', () => {
             await withController(
               {
                 state: {
-                  provider: {
+                  providerConfig: {
                     type: networkType,
                     // NOTE: This doesn't need to match the logical chain ID of
                     // the network selected, it just needs to exist
@@ -2305,7 +2305,7 @@ describe('NetworkController', () => {
             await withController(
               {
                 state: {
-                  provider: {
+                  providerConfig: {
                     type: networkType,
                     // NOTE: This doesn't need to match the logical chain ID of
                     // the network selected, it just needs to exist
@@ -2407,7 +2407,7 @@ describe('NetworkController', () => {
             await withController(
               {
                 state: {
-                  provider: {
+                  providerConfig: {
                     type: networkType,
                     // NOTE: This doesn't need to match the logical chain ID
                     // of the network selected, it just needs to exist
@@ -2491,7 +2491,7 @@ describe('NetworkController', () => {
           await withController(
             {
               state: {
-                provider: {
+                providerConfig: {
                   type: 'rpc',
                   rpcUrl: 'https://mock-rpc-url',
                   chainId: '0x1337',
@@ -2542,7 +2542,7 @@ describe('NetworkController', () => {
           await withController(
             {
               state: {
-                provider: {
+                providerConfig: {
                   type: 'rpc',
                   rpcUrl: 'https://mock-rpc-url',
                   chainId: '0x1337',
@@ -2595,7 +2595,7 @@ describe('NetworkController', () => {
           await withController(
             {
               state: {
-                provider: {
+                providerConfig: {
                   type: 'rpc',
                   rpcUrl: 'https://mock-rpc-url',
                   chainId: '0x1337',
@@ -2647,7 +2647,7 @@ describe('NetworkController', () => {
           await withController(
             {
               state: {
-                provider: {
+                providerConfig: {
                   type: 'rpc',
                   rpcUrl: 'https://mock-rpc-url',
                   chainId: '0x1337',
@@ -2699,7 +2699,7 @@ describe('NetworkController', () => {
           await withController(
             {
               state: {
-                provider: {
+                providerConfig: {
                   type: 'rpc',
                   rpcUrl: 'https://mock-rpc-url',
                   chainId: '0x1337',
@@ -2751,7 +2751,7 @@ describe('NetworkController', () => {
           await withController(
             {
               state: {
-                provider: {
+                providerConfig: {
                   type: 'rpc',
                   rpcUrl: 'https://mock-rpc-url',
                   chainId: '0x1337',
@@ -2817,7 +2817,7 @@ describe('NetworkController', () => {
           await withController(
             {
               state: {
-                provider: {
+                providerConfig: {
                   type: 'rpc',
                   rpcUrl: 'https://mock-rpc-url',
                   chainId: '0x1337',
@@ -2881,7 +2881,7 @@ describe('NetworkController', () => {
           await withController(
             {
               state: {
-                provider: {
+                providerConfig: {
                   type: 'rpc',
                   rpcUrl: 'https://mock-rpc-url',
                   chainId: '0x1337',
@@ -2945,7 +2945,7 @@ describe('NetworkController', () => {
           await withController(
             {
               state: {
-                provider: {
+                providerConfig: {
                   type: 'rpc',
                   rpcUrl: 'https://mock-rpc-url',
                   chainId: '0x1337',
@@ -3026,7 +3026,7 @@ describe('NetworkController', () => {
           await withController(
             {
               state: {
-                provider: {
+                providerConfig: {
                   type: 'rpc',
                   rpcUrl: 'https://mock-rpc-url',
                   chainId: '0x1337',
@@ -3075,7 +3075,7 @@ describe('NetworkController', () => {
           await withController(
             {
               state: {
-                provider: {
+                providerConfig: {
                   type: 'rpc',
                   rpcUrl: 'https://mock-rpc-url',
                   chainId: '0x1337',
@@ -3125,7 +3125,7 @@ describe('NetworkController', () => {
           await withController(
             {
               state: {
-                provider: {
+                providerConfig: {
                   type: 'rpc',
                   rpcUrl: 'https://mock-rpc-url',
                   chainId: '0x1337',
@@ -3189,7 +3189,7 @@ describe('NetworkController', () => {
           await withController(
             {
               state: {
-                provider: {
+                providerConfig: {
                   type: 'rpc',
                   rpcUrl: 'https://mock-rpc-url',
                   chainId: '0x1337',
@@ -3255,7 +3255,7 @@ describe('NetworkController', () => {
           await withController(
             {
               state: {
-                provider: {
+                providerConfig: {
                   type: 'rpc',
                   rpcUrl: 'https://mock-rpc-url',
                   chainId: '0x1337',
@@ -3330,7 +3330,7 @@ describe('NetworkController', () => {
           await withController(
             {
               state: {
-                provider: {
+                providerConfig: {
                   type: 'rpc',
                   rpcUrl: 'https://mock-rpc-url',
                   chainId: '0x1337',
@@ -3379,7 +3379,7 @@ describe('NetworkController', () => {
           await withController(
             {
               state: {
-                provider: {
+                providerConfig: {
                   type: 'rpc',
                   rpcUrl: 'https://mock-rpc-url',
                   chainId: '0x1337',
@@ -3429,7 +3429,7 @@ describe('NetworkController', () => {
           await withController(
             {
               state: {
-                provider: {
+                providerConfig: {
                   type: 'rpc',
                   rpcUrl: 'https://mock-rpc-url',
                   chainId: '0x1337',
@@ -3521,7 +3521,7 @@ describe('NetworkController', () => {
           await withController(
             {
               state: {
-                provider: {
+                providerConfig: {
                   type: 'rpc',
                   rpcUrl: 'https://mock-rpc-url',
                   chainId: '0x1337',
@@ -3625,7 +3625,7 @@ describe('NetworkController', () => {
           await withController(
             {
               state: {
-                provider: {
+                providerConfig: {
                   type: 'rpc',
                   rpcUrl: 'https://mock-rpc-url',
                   chainId: '0x1337',
@@ -3745,7 +3745,7 @@ describe('NetworkController', () => {
           await withController(
             {
               state: {
-                provider: {
+                providerConfig: {
                   type: 'rpc',
                   rpcUrl: 'https://mock-rpc-url',
                   chainId: '0x1337',
@@ -3836,7 +3836,7 @@ describe('NetworkController', () => {
           await withController(
             {
               state: {
-                provider: {
+                providerConfig: {
                   type: 'rpc',
                   rpcUrl: 'https://mock-rpc-url',
                   chainId: '0x1337',
@@ -3932,7 +3932,7 @@ describe('NetworkController', () => {
           await withController(
             {
               state: {
-                provider: {
+                providerConfig: {
                   type: 'rpc',
                   rpcUrl: 'https://mock-rpc-url',
                   chainId: '0x1337',
@@ -4035,7 +4035,7 @@ describe('NetworkController', () => {
           await withController(
             {
               state: {
-                provider: {
+                providerConfig: {
                   type: 'rpc',
                   rpcUrl: 'https://mock-rpc-url',
                   chainId: '0x1337',
@@ -4155,7 +4155,7 @@ describe('NetworkController', () => {
           await withController(
             {
               state: {
-                provider: {
+                providerConfig: {
                   type: 'rpc',
                   rpcUrl: 'https://mock-rpc-url',
                   chainId: '0x1337',
@@ -4278,7 +4278,7 @@ describe('NetworkController', () => {
       await withController(
         {
           state: {
-            provider: {
+            providerConfig: {
               type: 'rpc',
               rpcUrl: 'https://mock-rpc-url-1',
               chainId: '0x111',
@@ -4315,7 +4315,7 @@ describe('NetworkController', () => {
 
           await controller.setActiveNetwork('testNetworkConfiguration');
 
-          expect(controller.store.getState().provider).toStrictEqual({
+          expect(controller.store.getState().providerConfig).toStrictEqual({
             id: 'testNetworkConfiguration',
             type: 'rpc',
             rpcUrl: 'https://mock-rpc-url-2',
@@ -4334,7 +4334,7 @@ describe('NetworkController', () => {
       await withController(
         {
           state: {
-            provider: {
+            providerConfig: {
               type: 'rpc',
               rpcUrl: 'https://mock-rpc-url-1',
               chainId: '0x111',
@@ -4419,7 +4419,7 @@ describe('NetworkController', () => {
       await withController(
         {
           state: {
-            provider: {
+            providerConfig: {
               type: 'rpc',
               rpcUrl: 'https://mock-rpc-url-1',
               chainId: '0x111',
@@ -4497,7 +4497,7 @@ describe('NetworkController', () => {
       await withController(
         {
           state: {
-            provider: {
+            providerConfig: {
               type: 'rpc',
               rpcUrl: 'https://mock-rpc-url-1',
               chainId: '0x111',
@@ -4643,7 +4643,7 @@ describe('NetworkController', () => {
       await withController(
         {
           state: {
-            provider: {
+            providerConfig: {
               type: 'rpc',
               rpcUrl: 'https://mock-rpc-url-1',
               chainId: '0x111',
@@ -4874,7 +4874,7 @@ describe('NetworkController', () => {
           await withController(
             {
               state: {
-                provider: {
+                providerConfig: {
                   type: 'rpc',
                   rpcUrl: 'https://mock-rpc-url',
                   chainId: '0x1337',
@@ -4893,7 +4893,7 @@ describe('NetworkController', () => {
 
               controller.setProviderType(networkType);
 
-              expect(controller.store.getState().provider).toStrictEqual({
+              expect(controller.store.getState().providerConfig).toStrictEqual({
                 type: networkType,
                 rpcUrl: undefined,
                 chainId,
@@ -4929,7 +4929,7 @@ describe('NetworkController', () => {
           await withController(
             {
               state: {
-                provider: {
+                providerConfig: {
                   type: 'rpc',
                   rpcUrl: 'https://mock-rpc-url',
                   chainId: '0x1337',
@@ -4997,7 +4997,7 @@ describe('NetworkController', () => {
           await withController(
             {
               state: {
-                provider: {
+                providerConfig: {
                   type: 'rpc',
                   rpcUrl: 'https://mock-rpc-url',
                   chainId: '0x1337',
@@ -5127,7 +5127,7 @@ describe('NetworkController', () => {
           await withController(
             {
               state: {
-                provider: {
+                providerConfig: {
                   type: 'rpc',
                   rpcUrl: 'https://mock-rpc-url',
                   chainId: '0x1337',
@@ -5309,7 +5309,7 @@ describe('NetworkController', () => {
           await withController(
             {
               state: {
-                provider: {
+                providerConfig: {
                   type: networkType,
                   // NOTE: This doesn't need to match the logical chain ID of
                   // the network selected, it just needs to exist
@@ -5341,7 +5341,7 @@ describe('NetworkController', () => {
           await withController(
             {
               state: {
-                provider: {
+                providerConfig: {
                   type: networkType,
                   // NOTE: This doesn't need to match the logical chain ID of
                   // the network selected, it just needs to exist
@@ -5387,7 +5387,7 @@ describe('NetworkController', () => {
           await withController(
             {
               state: {
-                provider: {
+                providerConfig: {
                   type: networkType,
                   // NOTE: This doesn't need to match the logical chain ID of
                   // the network selected, it just needs to exist
@@ -5441,7 +5441,7 @@ describe('NetworkController', () => {
           await withController(
             {
               state: {
-                provider: {
+                providerConfig: {
                   type: networkType,
                   // NOTE: This doesn't need to match the logical chain ID of
                   // the network selected, it just needs to exist
@@ -5484,7 +5484,7 @@ describe('NetworkController', () => {
           await withController(
             {
               state: {
-                provider: {
+                providerConfig: {
                   type: networkType,
                   // NOTE: This doesn't need to match the logical chain ID of
                   // the network selected, it just needs to exist
@@ -5513,7 +5513,7 @@ describe('NetworkController', () => {
           await withController(
             {
               state: {
-                provider: {
+                providerConfig: {
                   type: networkType,
                   // NOTE: This doesn't need to match the logical chain ID of
                   // the network selected, it just needs to exist
@@ -5543,7 +5543,7 @@ describe('NetworkController', () => {
           await withController(
             {
               state: {
-                provider: {
+                providerConfig: {
                   type: networkType,
                   // NOTE: This doesn't need to match the logical chain ID of
                   // the network selected, it just needs to exist
@@ -5585,7 +5585,7 @@ describe('NetworkController', () => {
           await withController(
             {
               state: {
-                provider: {
+                providerConfig: {
                   type: networkType,
                   // NOTE: This doesn't need to match the logical chain ID of
                   // the network selected, it just needs to exist
@@ -5624,7 +5624,7 @@ describe('NetworkController', () => {
           await withController(
             {
               state: {
-                provider: {
+                providerConfig: {
                   type: networkType,
                   // NOTE: This doesn't need to match the logical chain ID of
                   // the network selected, it just needs to exist
@@ -5668,7 +5668,7 @@ describe('NetworkController', () => {
         await withController(
           {
             state: {
-              provider: {
+              providerConfig: {
                 type: 'rpc',
                 rpcUrl: 'https://mock-rpc-url',
                 chainId: '0x1337',
@@ -5699,7 +5699,7 @@ describe('NetworkController', () => {
         await withController(
           {
             state: {
-              provider: {
+              providerConfig: {
                 type: 'rpc',
                 rpcUrl: 'https://mock-rpc-url',
                 chainId: '0x1337',
@@ -5742,7 +5742,7 @@ describe('NetworkController', () => {
         await withController(
           {
             state: {
-              provider: {
+              providerConfig: {
                 type: 'rpc',
                 rpcUrl: 'https://mock-rpc-url',
                 chainId: '0x1337',
@@ -5799,7 +5799,7 @@ describe('NetworkController', () => {
         await withController(
           {
             state: {
-              provider: {
+              providerConfig: {
                 type: 'rpc',
                 rpcUrl: 'https://mock-rpc-url',
                 chainId: '0x1337',
@@ -5841,7 +5841,7 @@ describe('NetworkController', () => {
         await withController(
           {
             state: {
-              provider: {
+              providerConfig: {
                 type: 'rpc',
                 rpcUrl: 'https://mock-rpc-url',
                 chainId: '0x1337',
@@ -5869,7 +5869,7 @@ describe('NetworkController', () => {
         await withController(
           {
             state: {
-              provider: {
+              providerConfig: {
                 type: 'rpc',
                 rpcUrl: 'https://mock-rpc-url',
                 chainId: '0x1337',
@@ -5898,7 +5898,7 @@ describe('NetworkController', () => {
         await withController(
           {
             state: {
-              provider: {
+              providerConfig: {
                 type: 'rpc',
                 rpcUrl: 'https://mock-rpc-url',
                 chainId: '0x1337',
@@ -5927,7 +5927,7 @@ describe('NetworkController', () => {
         await withController(
           {
             state: {
-              provider: {
+              providerConfig: {
                 type: 'rpc',
                 rpcUrl: 'https://mock-rpc-url',
                 chainId: '0x1337',
@@ -5963,7 +5963,7 @@ describe('NetworkController', () => {
         await withController(
           {
             state: {
-              provider: {
+              providerConfig: {
                 type: 'rpc',
                 rpcUrl: 'https://mock-rpc-url',
                 chainId: '0x1337',
@@ -6008,7 +6008,7 @@ describe('NetworkController', () => {
           await withController(
             {
               state: {
-                provider: {
+                providerConfig: {
                   type: networkType,
                   // NOTE: This doesn't need to match the logical chain ID
                   // of the network selected, it just needs to exist
@@ -6057,7 +6057,7 @@ describe('NetworkController', () => {
                 })
                 .mockReturnValue(fakeNetworkClients[1]);
               await controller.setActiveNetwork('testNetworkConfiguration');
-              expect(controller.store.getState().provider).toStrictEqual({
+              expect(controller.store.getState().providerConfig).toStrictEqual({
                 type: 'rpc',
                 id: 'testNetworkConfiguration',
                 rpcUrl: 'https://mock-rpc-url-2',
@@ -6076,7 +6076,7 @@ describe('NetworkController', () => {
                 },
               });
 
-              expect(controller.store.getState().provider).toStrictEqual({
+              expect(controller.store.getState().providerConfig).toStrictEqual({
                 type: networkType,
                 chainId: '0x111',
                 rpcUrl: 'https://mock-rpc-url-1',
@@ -6094,7 +6094,7 @@ describe('NetworkController', () => {
           await withController(
             {
               state: {
-                provider: {
+                providerConfig: {
                   type: networkType,
                   // NOTE: This doesn't need to match the logical chain ID of
                   // the network selected, it just needs to exist
@@ -6154,7 +6154,7 @@ describe('NetworkController', () => {
           await withController(
             {
               state: {
-                provider: {
+                providerConfig: {
                   type: networkType,
                   // NOTE: This doesn't need to match the logical chain ID of
                   // the network selected, it just needs to exist
@@ -6241,7 +6241,7 @@ describe('NetworkController', () => {
           await withController(
             {
               state: {
-                provider: {
+                providerConfig: {
                   type: networkType,
                   // NOTE: This doesn't need to match the logical chain ID of
                   // the network selected, it just needs to exist
@@ -6334,7 +6334,7 @@ describe('NetworkController', () => {
           await withController(
             {
               state: {
-                provider: {
+                providerConfig: {
                   type: networkType,
                   // NOTE: This doesn't need to match the logical chain ID of
                   // the network selected, it just needs to exist
@@ -6410,7 +6410,7 @@ describe('NetworkController', () => {
           await withController(
             {
               state: {
-                provider: {
+                providerConfig: {
                   type: networkType,
                   // NOTE: This doesn't need to match the logical chain ID of
                   // the network selected, it just needs to exist
@@ -6468,7 +6468,7 @@ describe('NetworkController', () => {
           await withController(
             {
               state: {
-                provider: {
+                providerConfig: {
                   type: networkType,
                   // NOTE: This doesn't need to match the logical chain ID of
                   // the network selected, it just needs to exist
@@ -6529,7 +6529,7 @@ describe('NetworkController', () => {
           await withController(
             {
               state: {
-                provider: {
+                providerConfig: {
                   type: networkType,
                   // NOTE: This doesn't need to match the logical chain ID of
                   // the network selected, it just needs to exist
@@ -6604,7 +6604,7 @@ describe('NetworkController', () => {
           await withController(
             {
               state: {
-                provider: {
+                providerConfig: {
                   type: networkType,
                   // NOTE: This doesn't need to match the logical chain ID of
                   // the network selected, it just needs to exist
@@ -6680,7 +6680,7 @@ describe('NetworkController', () => {
           await withController(
             {
               state: {
-                provider: {
+                providerConfig: {
                   type: networkType,
                   // NOTE: This doesn't need to match the logical chain ID of
                   // the network selected, it just needs to exist
@@ -6774,7 +6774,7 @@ describe('NetworkController', () => {
         await withController(
           {
             state: {
-              provider: {
+              providerConfig: {
                 type: 'rpc',
                 rpcUrl: 'https://mock-rpc-url',
                 chainId: '0x1337',
@@ -6807,7 +6807,7 @@ describe('NetworkController', () => {
               })
               .mockReturnValue(fakeNetworkClients[1]);
             await controller.setProviderType('goerli');
-            expect(controller.store.getState().provider).toStrictEqual({
+            expect(controller.store.getState().providerConfig).toStrictEqual({
               type: 'goerli',
               rpcUrl: undefined,
               chainId: '0x5',
@@ -6824,7 +6824,7 @@ describe('NetworkController', () => {
                 await controller.rollbackToPreviousProvider();
               },
             });
-            expect(controller.store.getState().provider).toStrictEqual({
+            expect(controller.store.getState().providerConfig).toStrictEqual({
               type: 'rpc',
               rpcUrl: 'https://mock-rpc-url',
               chainId: '0x1337',
@@ -6842,7 +6842,7 @@ describe('NetworkController', () => {
         await withController(
           {
             state: {
-              provider: {
+              providerConfig: {
                 type: 'rpc',
                 rpcUrl: 'https://mock-rpc-url',
                 chainId: '0x1337',
@@ -6893,7 +6893,7 @@ describe('NetworkController', () => {
         await withController(
           {
             state: {
-              provider: {
+              providerConfig: {
                 type: 'rpc',
                 rpcUrl: 'https://mock-rpc-url',
                 chainId: '0x1337',
@@ -6969,7 +6969,7 @@ describe('NetworkController', () => {
         await withController(
           {
             state: {
-              provider: {
+              providerConfig: {
                 type: 'rpc',
                 rpcUrl: 'https://mock-rpc-url',
                 chainId: '0x1337',
@@ -7049,7 +7049,7 @@ describe('NetworkController', () => {
         await withController(
           {
             state: {
-              provider: {
+              providerConfig: {
                 type: 'rpc',
                 rpcUrl: 'https://mock-rpc-url',
                 chainId: '0x1337',
@@ -7116,7 +7116,7 @@ describe('NetworkController', () => {
         await withController(
           {
             state: {
-              provider: {
+              providerConfig: {
                 type: 'rpc',
                 rpcUrl: 'https://mock-rpc-url',
                 chainId: '0x1337',
@@ -7165,7 +7165,7 @@ describe('NetworkController', () => {
         await withController(
           {
             state: {
-              provider: {
+              providerConfig: {
                 type: 'rpc',
                 rpcUrl: 'https://mock-rpc-url',
                 chainId: '0x1337',
@@ -7216,7 +7216,7 @@ describe('NetworkController', () => {
         await withController(
           {
             state: {
-              provider: {
+              providerConfig: {
                 type: 'rpc',
                 rpcUrl: 'https://mock-rpc-url',
                 chainId: '0x1337',
@@ -7267,7 +7267,7 @@ describe('NetworkController', () => {
         await withController(
           {
             state: {
-              provider: {
+              providerConfig: {
                 type: 'rpc',
                 rpcUrl: 'https://mock-rpc-url',
                 chainId: '0x1337',
@@ -7332,7 +7332,7 @@ describe('NetworkController', () => {
         await withController(
           {
             state: {
-              provider: {
+              providerConfig: {
                 type: 'rpc',
                 rpcUrl: 'https://mock-rpc-url',
                 chainId: '0x1337',
@@ -7781,7 +7781,7 @@ describe('NetworkController', () => {
 
     it('should add the given network and not set it to active if the setActive option is not passed (or a falsy value is passed)', async () => {
       uuidV4Mock.mockImplementationOnce(() => 'networkConfigurationId');
-      const originalProvider = {
+      const originalProviderConfig = {
         type: NETWORK_TYPES.RPC,
         rpcUrl: 'https://mock-rpc-url',
         chainId: '0xtest' as const,
@@ -7790,7 +7790,7 @@ describe('NetworkController', () => {
       await withController(
         {
           state: {
-            provider: originalProvider,
+            providerConfig: originalProviderConfig,
             networkConfigurations: {
               testNetworkConfigurationId: {
                 rpcUrl: 'https://mock-rpc-url',
@@ -7813,8 +7813,8 @@ describe('NetworkController', () => {
             source: MetaMetricsNetworkEventSource.Dapp,
           });
 
-          expect(controller.store.getState().provider).toStrictEqual(
-            originalProvider,
+          expect(controller.store.getState().providerConfig).toStrictEqual(
+            originalProviderConfig,
           );
         },
       );
@@ -7825,7 +7825,7 @@ describe('NetworkController', () => {
       await withController(
         {
           state: {
-            provider: {
+            providerConfig: {
               type: 'rpc',
               rpcUrl: 'https://mock-rpc-url',
               chainId: '0xtest',
@@ -7857,7 +7857,7 @@ describe('NetworkController', () => {
             source: MetaMetricsNetworkEventSource.Dapp,
           });
 
-          expect(controller.store.getState().provider).toStrictEqual({
+          expect(controller.store.getState().providerConfig).toStrictEqual({
             ...rpcUrlNetwork,
             nickname: undefined,
             rpcPrefs: undefined,
@@ -7874,7 +7874,7 @@ describe('NetworkController', () => {
       await withController(
         {
           state: {
-            provider: {
+            providerConfig: {
               type: 'rpc',
               rpcUrl: 'https://mock-rpc-url',
               chainId: '0xtest',
@@ -7941,7 +7941,7 @@ describe('NetworkController', () => {
       await withController(
         {
           state: {
-            provider: {
+            providerConfig: {
               type: 'rpc',
               rpcUrl: 'https://mock-rpc-url',
               chainId: '0xtest',

--- a/app/scripts/controllers/network/network-controller.ts
+++ b/app/scripts/controllers/network/network-controller.ts
@@ -266,7 +266,7 @@ type NetworkConfigurations = Record<
  * The state that NetworkController holds after combining its individual stores.
  */
 export type NetworkControllerState = {
-  provider: ProviderConfiguration;
+  providerConfig: ProviderConfiguration;
   networkId: NetworkIdState;
   networkStatus: NetworkStatus;
   networkDetails: NetworkDetails;
@@ -279,7 +279,7 @@ export type NetworkControllerState = {
 export type NetworkControllerOptions = {
   messenger: NetworkControllerMessenger;
   state?: {
-    provider?: ProviderConfiguration;
+    providerConfig?: ProviderConfiguration;
     networkDetails?: NetworkDetails;
     networkConfigurations?: NetworkConfigurations;
   };
@@ -386,7 +386,7 @@ function buildDefaultNetworkConfigurationsState(): NetworkConfigurations {
  */
 function buildDefaultState() {
   return {
-    provider: buildDefaultProviderConfigState(),
+    providerConfig: buildDefaultProviderConfigState(),
     networkId: buildDefaultNetworkIdState(),
     networkStatus: buildDefaultNetworkStatusState(),
     networkDetails: buildDefaultNetworkDetailsState(),
@@ -477,7 +477,7 @@ export class NetworkController extends EventEmitter {
       ...buildDefaultState(),
       ...state,
     });
-    this.#previousProviderConfig = this.store.getState().provider;
+    this.#previousProviderConfig = this.store.getState().providerConfig;
 
     // provider and block tracker
     this.#provider = null;
@@ -508,7 +508,7 @@ export class NetworkController extends EventEmitter {
    * using the provider to gather details about the network.
    */
   async initializeProvider(): Promise<void> {
-    const { type, rpcUrl, chainId } = this.store.getState().provider;
+    const { type, rpcUrl, chainId } = this.store.getState().providerConfig;
     this.#configureProvider({ type, rpcUrl, chainId });
     await this.lookupNetwork();
   }
@@ -575,7 +575,7 @@ export class NetworkController extends EventEmitter {
    * blocking requests, or if the network is not Infura-supported.
    */
   async lookupNetwork(): Promise<void> {
-    const { chainId, type } = this.store.getState().provider;
+    const { chainId, type } = this.store.getState().providerConfig;
     const { provider } = this.getProviderAndBlockTracker();
     let networkChanged = false;
     let networkId: NetworkIdState = null;
@@ -754,7 +754,7 @@ export class NetworkController extends EventEmitter {
    * Re-initializes the provider and block tracker for the current network.
    */
   async resetConnection() {
-    await this.#setProviderConfig(this.store.getState().provider);
+    await this.#setProviderConfig(this.store.getState().providerConfig);
   }
 
   /**
@@ -765,7 +765,7 @@ export class NetworkController extends EventEmitter {
   async rollbackToPreviousProvider() {
     const config = this.#previousProviderConfig;
     this.store.updateState({
-      provider: config,
+      providerConfig: config,
     });
     await this.#switchNetwork(config);
   }
@@ -850,8 +850,8 @@ export class NetworkController extends EventEmitter {
    * @param providerConfig - The provider configuration.
    */
   async #setProviderConfig(providerConfig: ProviderConfiguration) {
-    this.#previousProviderConfig = this.store.getState().provider;
-    this.store.updateState({ provider: providerConfig });
+    this.#previousProviderConfig = this.store.getState().providerConfig;
+    this.store.updateState({ providerConfig });
     await this.#switchNetwork(providerConfig);
   }
 

--- a/app/scripts/lib/setupSentry.js
+++ b/app/scripts/lib/setupSentry.js
@@ -56,7 +56,7 @@ export const SENTRY_STATE = {
     nextNonce: true,
     participateInMetaMetrics: true,
     preferences: true,
-    provider: {
+    providerConfig: {
       nickname: true,
       ticker: true,
       type: true,

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -285,7 +285,7 @@ export default class MetamaskController extends EventEmitter {
 
     this.tokenListController = new TokenListController({
       chainId: hexToDecimal(
-        this.networkController.store.getState().provider.chainId,
+        this.networkController.store.getState().providerConfig.chainId,
       ),
       preventPollingOnNetworkRestart: initState.TokenListController
         ? initState.TokenListController.preventPollingOnNetworkRestart
@@ -295,8 +295,8 @@ export default class MetamaskController extends EventEmitter {
           const modifiedNetworkState = {
             ...networkState,
             providerConfig: {
-              ...networkState.provider,
-              chainId: hexToDecimal(networkState.provider.chainId),
+              ...networkState.providerConfig,
+              chainId: hexToDecimal(networkState.providerConfig.chainId),
             },
           };
           return cb(modifiedNetworkState);
@@ -330,7 +330,7 @@ export default class MetamaskController extends EventEmitter {
           const modifiedNetworkState = {
             ...networkState,
             providerConfig: {
-              ...networkState.provider,
+              ...networkState.providerConfig,
             },
           };
           return cb(modifiedNetworkState);
@@ -367,8 +367,8 @@ export default class MetamaskController extends EventEmitter {
               const modifiedNetworkState = {
                 ...networkState,
                 providerConfig: {
-                  ...networkState.provider,
-                  chainId: hexToDecimal(networkState.provider.chainId),
+                  ...networkState.providerConfig,
+                  chainId: hexToDecimal(networkState.providerConfig.chainId),
                 },
               };
               return cb(modifiedNetworkState);
@@ -392,8 +392,8 @@ export default class MetamaskController extends EventEmitter {
             const modifiedNetworkState = {
               ...networkState,
               providerConfig: {
-                ...networkState.provider,
-                chainId: hexToDecimal(networkState.provider.chainId),
+                ...networkState.providerConfig,
+                chainId: hexToDecimal(networkState.providerConfig.chainId),
               },
             };
             return cb(modifiedNetworkState);
@@ -452,8 +452,8 @@ export default class MetamaskController extends EventEmitter {
           const modifiedNetworkState = {
             ...networkState,
             providerConfig: {
-              ...networkState.provider,
-              chainId: hexToDecimal(networkState.provider.chainId),
+              ...networkState.providerConfig,
+              chainId: hexToDecimal(networkState.providerConfig.chainId),
             },
           };
           return cb(modifiedNetworkState);
@@ -476,11 +476,11 @@ export default class MetamaskController extends EventEmitter {
       ),
       getNetworkIdentifier: () => {
         const { type, rpcUrl } =
-          this.networkController.store.getState().provider;
+          this.networkController.store.getState().providerConfig;
         return type === NETWORK_TYPES.RPC ? rpcUrl : type;
       },
       getCurrentChainId: () =>
-        this.networkController.store.getState().provider.chainId,
+        this.networkController.store.getState().providerConfig.chainId,
       version: this.platform.getVersion(),
       environment: process.env.METAMASK_ENVIRONMENT,
       extension: this.extension,
@@ -522,13 +522,14 @@ export default class MetamaskController extends EventEmitter {
       legacyAPIEndpoint: `${gasApiBaseUrl}/networks/<chain_id>/gasPrices`,
       EIP1559APIEndpoint: `${gasApiBaseUrl}/networks/<chain_id>/suggestedGasFees`,
       getCurrentNetworkLegacyGasAPICompatibility: () => {
-        const { chainId } = this.networkController.store.getState().provider;
+        const { chainId } =
+          this.networkController.store.getState().providerConfig;
         return process.env.IN_TEST || chainId === CHAIN_IDS.MAINNET;
       },
       getChainId: () => {
         return process.env.IN_TEST
           ? CHAIN_IDS.MAINNET
-          : this.networkController.store.getState().provider.chainId;
+          : this.networkController.store.getState().providerConfig.chainId;
       },
     });
 
@@ -558,7 +559,8 @@ export default class MetamaskController extends EventEmitter {
       messenger: currencyRateMessenger,
       state: {
         ...initState.CurrencyController,
-        nativeCurrency: this.networkController.store.getState().provider.ticker,
+        nativeCurrency:
+          this.networkController.store.getState().providerConfig.ticker,
       },
     });
 
@@ -598,8 +600,8 @@ export default class MetamaskController extends EventEmitter {
             const modifiedNetworkState = {
               ...networkState,
               providerConfig: {
-                ...networkState.provider,
-                chainId: hexToDecimal(networkState.provider.chainId),
+                ...networkState.providerConfig,
+                chainId: hexToDecimal(networkState.providerConfig.chainId),
               },
             };
             return cb(modifiedNetworkState);
@@ -632,7 +634,7 @@ export default class MetamaskController extends EventEmitter {
     this.ensController = new EnsController({
       provider: this.provider,
       getCurrentChainId: () =>
-        this.networkController.store.getState().provider.chainId,
+        this.networkController.store.getState().providerConfig.chainId,
       onNetworkDidChange: networkControllerMessenger.subscribe.bind(
         networkControllerMessenger,
         NetworkControllerEventType.NetworkDidChange,
@@ -650,7 +652,7 @@ export default class MetamaskController extends EventEmitter {
         NetworkControllerEventType.NetworkDidChange,
       ),
       getCurrentChainId: () =>
-        this.networkController.store.getState().provider.chainId,
+        this.networkController.store.getState().providerConfig.chainId,
       preferencesController: this.preferencesController,
       onboardingController: this.onboardingController,
       initState: initState.IncomingTransactionsController,
@@ -661,10 +663,10 @@ export default class MetamaskController extends EventEmitter {
       provider: this.provider,
       blockTracker: this.blockTracker,
       getCurrentChainId: () =>
-        this.networkController.store.getState().provider.chainId,
+        this.networkController.store.getState().providerConfig.chainId,
       getNetworkIdentifier: () => {
         const { type, rpcUrl } =
-          this.networkController.store.getState().provider;
+          this.networkController.store.getState().providerConfig;
         return type === NETWORK_TYPES.RPC ? rpcUrl : type;
       },
       preferencesController: this.preferencesController,
@@ -701,7 +703,7 @@ export default class MetamaskController extends EventEmitter {
     this.cachedBalancesController = new CachedBalancesController({
       accountTracker: this.accountTracker,
       getCurrentChainId: () =>
-        this.networkController.store.getState().provider.chainId,
+        this.networkController.store.getState().providerConfig.chainId,
       initState: initState.CachedBalancesController,
     });
 
@@ -987,7 +989,8 @@ export default class MetamaskController extends EventEmitter {
       initState:
         initState.TransactionController || initState.TransactionManager,
       getPermittedAccounts: this.getPermittedAccounts.bind(this),
-      getProviderConfig: () => this.networkController.store.getState().provider,
+      getProviderConfig: () =>
+        this.networkController.store.getState().providerConfig,
       getCurrentNetworkEIP1559Compatibility:
         this.networkController.getEIP1559Compatibility.bind(
           this.networkController,
@@ -1008,7 +1011,7 @@ export default class MetamaskController extends EventEmitter {
         });
       },
       getCurrentChainId: () =>
-        this.networkController.store.getState().provider.chainId,
+        this.networkController.store.getState().providerConfig.chainId,
       preferencesStore: this.preferencesController.store,
       txHistoryLimit: 60,
       signTransaction: this.keyringController.signTransaction.bind(
@@ -1144,7 +1147,8 @@ export default class MetamaskController extends EventEmitter {
     networkControllerMessenger.subscribe(
       NetworkControllerEventType.NetworkDidChange,
       async () => {
-        const { ticker } = this.networkController.store.getState().provider;
+        const { ticker } =
+          this.networkController.store.getState().providerConfig;
         try {
           await this.currencyRateController.setNativeCurrency(ticker);
         } catch (error) {
@@ -1213,10 +1217,11 @@ export default class MetamaskController extends EventEmitter {
       onNetworkStateChange: (listener) =>
         this.networkController.store.subscribe(listener),
       provider: this.provider,
-      getProviderConfig: () => this.networkController.store.getState().provider,
+      getProviderConfig: () =>
+        this.networkController.store.getState().providerConfig,
       getTokenRatesState: () => this.tokenRatesController.state,
       getCurrentChainId: () =>
-        this.networkController.store.getState().provider.chainId,
+        this.networkController.store.getState().providerConfig.chainId,
       getEIP1559GasFeeEstimates:
         this.gasFeeController.fetchGasFeeEstimates.bind(this.gasFeeController),
     });
@@ -1227,7 +1232,7 @@ export default class MetamaskController extends EventEmitter {
             const modifiedNetworkState = {
               ...networkState,
               providerConfig: {
-                ...networkState.provider,
+                ...networkState.providerConfig,
               },
             };
             return cb(modifiedNetworkState);
@@ -1783,7 +1788,7 @@ export default class MetamaskController extends EventEmitter {
     updatePublicConfigStore(this.getState());
 
     function updatePublicConfigStore(memState) {
-      const { chainId } = networkController.store.getState().provider;
+      const { chainId } = networkController.store.getState().providerConfig;
       if (memState.networkStatus === NetworkStatus.Available) {
         publicConfigStore.putState(selectPublicState(chainId, memState));
       }
@@ -1824,7 +1829,7 @@ export default class MetamaskController extends EventEmitter {
   getProviderNetworkState(memState) {
     const { networkId } = memState || this.getState();
     return {
-      chainId: this.networkController.store.getState().provider.chainId,
+      chainId: this.networkController.store.getState().providerConfig.chainId,
       networkVersion: networkId ?? 'loading',
     };
   }
@@ -2796,7 +2801,8 @@ export default class MetamaskController extends EventEmitter {
       this.appStateController.setTrezorModel(model);
     }
 
-    keyring.network = this.networkController.store.getState().provider.type;
+    keyring.network =
+      this.networkController.store.getState().providerConfig.type;
 
     return keyring;
   }
@@ -3668,9 +3674,9 @@ export default class MetamaskController extends EventEmitter {
           ),
 
         getCurrentChainId: () =>
-          this.networkController.store.getState().provider.chainId,
+          this.networkController.store.getState().providerConfig.chainId,
         getCurrentRpcUrl: () =>
-          this.networkController.store.getState().provider.rpcUrl,
+          this.networkController.store.getState().providerConfig.rpcUrl,
         // network configuration-related
         getNetworkConfigurations: () =>
           this.networkController.store.getState().networkConfigurations,
@@ -4262,7 +4268,9 @@ export default class MetamaskController extends EventEmitter {
 
     if (transactionSecurityCheckEnabled) {
       const chainId = Number(
-        hexToDecimal(this.networkController.store.getState().provider.chainId),
+        hexToDecimal(
+          this.networkController.store.getState().providerConfig.chainId,
+        ),
       );
 
       try {

--- a/app/scripts/metamask-controller.test.js
+++ b/app/scripts/metamask-controller.test.js
@@ -116,7 +116,7 @@ const MAINNET_CHAIN_ID = '0x1';
 const firstTimeState = {
   config: {},
   NetworkController: {
-    provider: {
+    providerConfig: {
       type: NETWORK_TYPES.RPC,
       rpcUrl: ALT_MAINNET_RPC_URL,
       chainId: MAINNET_CHAIN_ID,

--- a/app/scripts/migrations/086.test.js
+++ b/app/scripts/migrations/086.test.js
@@ -1,0 +1,88 @@
+import { migrate, version } from './086';
+
+jest.mock('uuid', () => {
+  const actual = jest.requireActual('uuid');
+
+  return {
+    ...actual,
+    v4: jest.fn(),
+  };
+});
+
+describe('migration #86', () => {
+  it('should update the version metadata', async () => {
+    const oldStorage = {
+      meta: {
+        version: 85,
+      },
+      data: {},
+    };
+
+    const newStorage = await migrate(oldStorage);
+    expect(newStorage.meta).toStrictEqual({
+      version,
+    });
+  });
+
+  it('should return state unaltered if there is no network controller state', async () => {
+    const oldData = {
+      other: 'data',
+    };
+    const oldStorage = {
+      meta: {
+        version: 85,
+      },
+      data: oldData,
+    };
+
+    const newStorage = await migrate(oldStorage);
+    expect(newStorage.data).toStrictEqual(oldData);
+  });
+
+  it('should return state unaltered if there is no network controller provider state', async () => {
+    const oldData = {
+      other: 'data',
+      NetworkController: {
+        networkConfigurations: {
+          foo: 'bar',
+        },
+      },
+    };
+    const oldStorage = {
+      meta: {
+        version: 85,
+      },
+      data: oldData,
+    };
+
+    const newStorage = await migrate(oldStorage);
+    expect(newStorage.data).toStrictEqual(oldData);
+  });
+
+  it('should rename the provider config state', async () => {
+    const oldData = {
+      other: 'data',
+      NetworkController: {
+        provider: {
+          some: 'provider',
+        },
+      },
+    };
+    const oldStorage = {
+      meta: {
+        version: 85,
+      },
+      data: oldData,
+    };
+
+    const newStorage = await migrate(oldStorage);
+    expect(newStorage.data).toStrictEqual({
+      other: 'data',
+      NetworkController: {
+        providerConfig: {
+          some: 'provider',
+        },
+      },
+    });
+  });
+});

--- a/app/scripts/migrations/086.ts
+++ b/app/scripts/migrations/086.ts
@@ -1,0 +1,41 @@
+import { hasProperty, isObject } from '@metamask/utils';
+import { cloneDeep } from 'lodash';
+
+export const version = 86;
+
+/**
+ * Rename network controller `provider` state to `providerConfig`.
+ *
+ * @param originalVersionedData - Versioned MetaMask extension state, exactly what we persist to dist.
+ * @param originalVersionedData.meta - State metadata.
+ * @param originalVersionedData.meta.version - The current state version.
+ * @param originalVersionedData.data - The persisted MetaMask state, keyed by controller.
+ * @returns Updated versioned MetaMask extension state.
+ */
+export async function migrate(originalVersionedData: {
+  meta: { version: number };
+  data: Record<string, unknown>;
+}) {
+  const versionedData = cloneDeep(originalVersionedData);
+  versionedData.meta.version = version;
+  versionedData.data = transformState(versionedData.data);
+  return versionedData;
+}
+
+function transformState(state: Record<string, unknown>) {
+  if (
+    hasProperty(state, 'NetworkController') &&
+    isObject(state.NetworkController) &&
+    hasProperty(state.NetworkController, 'provider')
+  ) {
+    const networkControllerState = state.NetworkController;
+    networkControllerState.providerConfig = networkControllerState.provider;
+    delete networkControllerState.provider;
+
+    return {
+      ...state,
+      NetworkController: networkControllerState,
+    };
+  }
+  return state;
+}

--- a/app/scripts/migrations/index.js
+++ b/app/scripts/migrations/index.js
@@ -89,6 +89,7 @@ import * as m082 from './082';
 import * as m083 from './083';
 import * as m084 from './084';
 import * as m085 from './085';
+import * as m086 from './086';
 
 const migrations = [
   m002,
@@ -175,6 +176,7 @@ const migrations = [
   m083,
   m084,
   m085,
+  m086,
 ];
 
 export default migrations;

--- a/development/states/navigate-txs.json
+++ b/development/states/navigate-txs.json
@@ -225,7 +225,7 @@
     "preferences": {
       "useETHAsPrimaryCurrency": true
     },
-    "provider": {
+    "providerConfig": {
       "type": "goerli"
     },
     "network": "4",

--- a/test/data/mock-send-state.json
+++ b/test/data/mock-send-state.json
@@ -115,7 +115,7 @@
       "showIncomingTransactions": true
     },
     "network": "5",
-    "provider": {
+    "providerConfig": {
       "type": "rpc",
       "chainId": "0x5"
     },

--- a/test/data/mock-state.json
+++ b/test/data/mock-state.json
@@ -111,7 +111,7 @@
     },
     "networkId": "5",
     "networkStatus": "available",
-    "provider": {
+    "providerConfig": {
       "type": "rpc",
       "chainId": "0x5",
       "ticker": "ETH",

--- a/test/e2e/fixture-builder.js
+++ b/test/e2e/fixture-builder.js
@@ -197,7 +197,7 @@ function defaultFixture() {
       NetworkController: {
         networkId: '1337',
         networkStatus: 'available',
-        provider: {
+        providerConfig: {
           chainId: CHAIN_IDS.LOCALHOST,
           nickname: 'Localhost 8545',
           rpcPrefs: {},
@@ -329,7 +329,7 @@ function onboardingFixture() {
       NetworkController: {
         networkId: '1337',
         networkStatus: 'available',
-        provider: {
+        providerConfig: {
           ticker: 'ETH',
           type: 'rpc',
           rpcUrl: 'http://localhost:8545',

--- a/test/e2e/tests/ens.spec.js
+++ b/test/e2e/tests/ens.spec.js
@@ -80,7 +80,7 @@ describe('ENS', function () {
       {
         fixtures: new FixtureBuilder()
           .withNetworkController({
-            provider: {
+            providerConfig: {
               chainId: '0x1',
               nickname: '',
               rpcUrl: '',

--- a/test/jest/mock-store.js
+++ b/test/jest/mock-store.js
@@ -137,7 +137,7 @@ export const createSwapsMockStore = () => {
           1559: false,
         },
       },
-      provider: {
+      providerConfig: {
         chainId: CHAIN_IDS.MAINNET,
       },
       cachedBalances: {

--- a/ui/components/app/account-menu/account-menu.test.js
+++ b/ui/components/app/account-menu/account-menu.test.js
@@ -43,7 +43,7 @@ const initialProps = {
 
 const mockStore = {
   metamask: {
-    provider: {
+    providerConfig: {
       type: 'test',
     },
     preferences: {

--- a/ui/components/app/advanced-gas-controls/advanced-gas-controls.test.js
+++ b/ui/components/app/advanced-gas-controls/advanced-gas-controls.test.js
@@ -7,7 +7,7 @@ import AdvancedGasControls from './advanced-gas-controls.component';
 
 const renderComponent = (props) => {
   const store = configureMockStore([])({
-    metamask: { identities: [], provider: {} },
+    metamask: { identities: [], providerConfig: {} },
   });
   return renderWithProvider(<AdvancedGasControls {...props} />, store);
 };

--- a/ui/components/app/advanced-gas-inputs/advanced-gas-inputs.test.js
+++ b/ui/components/app/advanced-gas-inputs/advanced-gas-inputs.test.js
@@ -20,7 +20,7 @@ describe('AdvancedGasInputs', () => {
     minimumGasLimit: 21000,
   };
 
-  const store = configureStore({ metamask: { provider: {} } });
+  const store = configureStore({ metamask: { providerConfig: {} } });
 
   beforeEach(() => {
     clock = sinon.useFakeTimers();

--- a/ui/components/app/alerts/unconnected-account-alert/unconnected-account-alert.test.js
+++ b/ui/components/app/alerts/unconnected-account-alert/unconnected-account-alert.test.js
@@ -64,7 +64,7 @@ describe('Unconnected Account Alert', () => {
       accounts,
       cachedBalances,
       keyrings,
-      provider: {
+      providerConfig: {
         chainId: CHAIN_IDS,
       },
       permissionHistory: {

--- a/ui/components/app/confirm-gas-display/confirm-legacy-gas-display/confirm-legacy-gas-display.test.js
+++ b/ui/components/app/confirm-gas-display/confirm-legacy-gas-display/confirm-legacy-gas-display.test.js
@@ -111,13 +111,13 @@ describe('ConfirmLegacyGasDisplay', () => {
   });
 
   it('should contain L1 L2 fee details for optimism', async () => {
-    mmState.metamask.provider.chainId = CHAIN_IDS.OPTIMISM;
+    mmState.metamask.providerConfig.chainId = CHAIN_IDS.OPTIMISM;
     mmState.confirmTransaction.txData.chainId = CHAIN_IDS.OPTIMISM;
     const state = {
       metamask: {
         ...mmState.metamask,
-        provider: {
-          ...mmState.metamask.provider,
+        providerConfig: {
+          ...mmState.metamask.providerConfig,
           chainId: CHAIN_IDS.OPTIMISM,
         },
       },

--- a/ui/components/app/confirm-page-container/confirm-detail-row/confirm-detail-row.component.test.js
+++ b/ui/components/app/confirm-page-container/confirm-detail-row/confirm-detail-row.component.test.js
@@ -7,7 +7,7 @@ import ConfirmDetailRow from '.';
 describe('Confirm Detail Row Component', () => {
   const mockState = {
     metamask: {
-      provider: {
+      providerConfig: {
         type: 'rpc',
         chainId: '0x5',
       },

--- a/ui/components/app/confirm-page-container/confirm-page-container-content/confirm-page-container-content.component.test.js
+++ b/ui/components/app/confirm-page-container/confirm-page-container-content/confirm-page-container-content.component.test.js
@@ -13,7 +13,7 @@ import ConfirmPageContainerContent from './confirm-page-container-content.compon
 describe('Confirm Page Container Content', () => {
   const mockStore = {
     metamask: {
-      provider: {
+      providerConfig: {
         type: 'test',
         chainId: '0x5',
       },

--- a/ui/components/app/confirm-page-container/confirm-page-container-header/confirm-page-container-header.component.test.js
+++ b/ui/components/app/confirm-page-container/confirm-page-container-header/confirm-page-container-header.component.test.js
@@ -13,7 +13,7 @@ describe('Confirm Detail Row Component', () => {
   const mockState = {
     metamask: {
       networkStatus: 'available',
-      provider: {
+      providerConfig: {
         type: 'rpc',
         chainId: '0x5',
       },

--- a/ui/components/app/confirm-subtitle/confirm-subtitle.test.js
+++ b/ui/components/app/confirm-subtitle/confirm-subtitle.test.js
@@ -46,7 +46,7 @@ describe('ConfirmSubTitle', () => {
     mockState.metamask.preferences.showFiatInTestnets = false;
     mockState.metamask.allNftContracts = {
       [mockState.metamask.selectedAddress]: {
-        [hexToDecimal(mockState.metamask.provider.chainId)]: [
+        [hexToDecimal(mockState.metamask.providerConfig.chainId)]: [
           { address: '0x9' },
         ],
       },

--- a/ui/components/app/contact-list/contact-list.test.js
+++ b/ui/components/app/contact-list/contact-list.test.js
@@ -6,7 +6,7 @@ import ContactList from '.';
 
 describe('Contact List', () => {
   const store = configureMockStore([])({
-    metamask: { provider: { chainId: '0x0' } },
+    metamask: { providerConfig: { chainId: '0x0' } },
   });
 
   describe('given searchForContacts', () => {

--- a/ui/components/app/currency-input/currency-input.test.js
+++ b/ui/components/app/currency-input/currency-input.test.js
@@ -10,7 +10,7 @@ describe('CurrencyInput Component', () => {
       nativeCurrency: 'ETH',
       currentCurrency: 'usd',
       conversionRate: 231.06,
-      provider: {
+      providerConfig: {
         chainId: '0x5',
       },
       preferences: {

--- a/ui/components/app/dropdowns/network-dropdown.js
+++ b/ui/components/app/dropdowns/network-dropdown.js
@@ -56,7 +56,7 @@ const DROP_DOWN_MENU_ITEM_STYLE = {
 
 function mapStateToProps(state) {
   return {
-    provider: getProviderConfig(state),
+    providerConfig: getProviderConfig(state),
     shouldShowTestNetworks: getShowTestNetworks(state),
     networkConfigurations: state.metamask.networkConfigurations,
     networkDropdownOpen: state.appState.networkDropdownOpen,
@@ -98,7 +98,7 @@ class NetworkDropdown extends Component {
   };
 
   static propTypes = {
-    provider: PropTypes.shape({
+    providerConfig: PropTypes.shape({
       nickname: PropTypes.string,
       rpcUrl: PropTypes.string,
       type: PropTypes.string,
@@ -123,7 +123,7 @@ class NetworkDropdown extends Component {
 
   handleClick(newProviderType) {
     const {
-      provider: { type: providerType },
+      providerConfig: { type: providerType },
       setProviderType,
     } = this.props;
     const { trackEvent } = this.context;
@@ -164,12 +164,13 @@ class NetworkDropdown extends Component {
     );
   }
 
-  renderCustomRpcList(networkConfigurations, provider, opts = {}) {
+  renderCustomRpcList(networkConfigurations, providerConfig, opts = {}) {
     return Object.entries(networkConfigurations).map(
       ([networkConfigurationId, networkConfiguration]) => {
         const { rpcUrl, chainId, nickname = '', id } = networkConfiguration;
         const isCurrentRpcTarget =
-          provider.type === NETWORK_TYPES.RPC && rpcUrl === provider.rpcUrl;
+          providerConfig.type === NETWORK_TYPES.RPC &&
+          rpcUrl === providerConfig.rpcUrl;
         return (
           <DropdownMenuItem
             key={`common${rpcUrl}`}
@@ -230,8 +231,8 @@ class NetworkDropdown extends Component {
   }
 
   getNetworkName() {
-    const { provider } = this.props;
-    const providerName = provider.type;
+    const { providerConfig } = this.props;
+    const providerName = providerConfig.type;
     const { t } = this.context;
 
     switch (providerName) {
@@ -246,13 +247,13 @@ class NetworkDropdown extends Component {
       case NETWORK_TYPES.LOCALHOST:
         return t('localhost');
       default:
-        return provider.nickname || t('unknownNetwork');
+        return providerConfig.nickname || t('unknownNetwork');
     }
   }
 
   renderNetworkEntry(network) {
     const {
-      provider: { type: providerType },
+      providerConfig: { type: providerType },
     } = this.props;
     return (
       <DropdownMenuItem
@@ -288,7 +289,7 @@ class NetworkDropdown extends Component {
   }
 
   renderNonInfuraDefaultNetwork(networkConfigurations, network) {
-    const { provider, setActiveNetwork, upsertNetworkConfiguration } =
+    const { providerConfig, setActiveNetwork, upsertNetworkConfiguration } =
       this.props;
 
     const { chainId, ticker, blockExplorerUrl } = BUILT_IN_NETWORKS[network];
@@ -296,7 +297,8 @@ class NetworkDropdown extends Component {
     const rpcUrl = CHAIN_ID_TO_RPC_URL_MAP[chainId];
 
     const isCurrentRpcTarget =
-      provider.type === NETWORK_TYPES.RPC && rpcUrl === provider.rpcUrl;
+      providerConfig.type === NETWORK_TYPES.RPC &&
+      rpcUrl === providerConfig.rpcUrl;
     return (
       <DropdownMenuItem
         key={network}
@@ -345,7 +347,7 @@ class NetworkDropdown extends Component {
           data-testid={`${network}-network-item`}
           style={{
             color:
-              provider.type === network
+              providerConfig.type === network
                 ? 'var(--color-text-default)'
                 : 'var(--color-text-alternative)',
           }}
@@ -447,7 +449,7 @@ class NetworkDropdown extends Component {
 
           {this.renderCustomRpcList(
             rpcListDetailWithoutLocalHostAndLinea,
-            this.props.provider,
+            this.props.providerConfig,
           )}
 
           {shouldShowTestNetworks && (
@@ -464,7 +466,7 @@ class NetworkDropdown extends Component {
               )}
               {this.renderCustomRpcList(
                 rpcListDetailForLocalHost,
-                this.props.provider,
+                this.props.providerConfig,
                 { isLocalHost: true },
               )}
             </>

--- a/ui/components/app/dropdowns/network-dropdown.test.js
+++ b/ui/components/app/dropdowns/network-dropdown.test.js
@@ -23,7 +23,7 @@ describe('Network Dropdown', () => {
       metamask: {
         networkId: '1',
         networkStatus: 'available',
-        provider: {
+        providerConfig: {
           type: 'test',
         },
         showTestnetMessageInDropdown: false,
@@ -58,7 +58,7 @@ describe('Network Dropdown', () => {
       metamask: {
         networkId: '1',
         networkStatus: 'available',
-        provider: {
+        providerConfig: {
           type: 'test',
         },
         showTestnetMessageInDropdown: false,
@@ -137,7 +137,7 @@ describe('Network Dropdown', () => {
       metamask: {
         networkId: '1',
         networkStatus: 'available',
-        provider: {
+        providerConfig: {
           type: 'test',
         },
         showTestnetMessageInDropdown: false,

--- a/ui/components/app/edit-gas-fee-popover/edit-gas-fee-popover.test.js
+++ b/ui/components/app/edit-gas-fee-popover/edit-gas-fee-popover.test.js
@@ -53,7 +53,7 @@ const render = ({ txProps, contextProps } = {}) => {
   const store = configureStore({
     metamask: {
       nativeCurrency: ETH,
-      provider: {},
+      providerConfig: {},
       cachedBalances: {},
       accounts: {
         '0xAddress': {

--- a/ui/components/app/edit-gas-fee-popover/edit-gas-item/edit-gas-item.test.js
+++ b/ui/components/app/edit-gas-fee-popover/edit-gas-item/edit-gas-item.test.js
@@ -59,7 +59,7 @@ const renderComponent = ({
   const store = configureStore({
     metamask: {
       nativeCurrency: ETH,
-      provider: {},
+      providerConfig: {},
       cachedBalances: {},
       accounts: {
         '0xAddress': {

--- a/ui/components/app/edit-gas-fee-popover/edit-gas-tooltip/edit-gas-tooltip.test.js
+++ b/ui/components/app/edit-gas-fee-popover/edit-gas-tooltip/edit-gas-tooltip.test.js
@@ -33,7 +33,7 @@ const HIGH_GAS_OPTION = {
 const renderComponent = (componentProps) => {
   const mockStore = {
     metamask: {
-      provider: {},
+      providerConfig: {},
       cachedBalances: {},
       accounts: {
         '0xAddress': {

--- a/ui/components/app/gas-details-item/gas-details-item-title/gas-details-item-title.test.js
+++ b/ui/components/app/gas-details-item/gas-details-item-title/gas-details-item-title.test.js
@@ -20,7 +20,7 @@ jest.mock('../../../../store/actions', () => ({
 const render = () => {
   const store = configureStore({
     metamask: {
-      provider: { chainId: CHAIN_IDS.MAINNET },
+      providerConfig: { chainId: CHAIN_IDS.MAINNET },
       cachedBalances: {},
       accounts: {
         '0xAddress': {

--- a/ui/components/app/import-token-link/import-token-link.test.js
+++ b/ui/components/app/import-token-link/import-token-link.test.js
@@ -26,7 +26,7 @@ describe('Import Token Link', () => {
   it('should match snapshot for goerli chainId', () => {
     const mockState = {
       metamask: {
-        provider: {
+        providerConfig: {
           chainId: '0x5',
         },
       },
@@ -42,7 +42,7 @@ describe('Import Token Link', () => {
   it('should match snapshot for mainnet chainId', () => {
     const mockState = {
       metamask: {
-        provider: {
+        providerConfig: {
           chainId: '0x1',
         },
       },
@@ -58,7 +58,7 @@ describe('Import Token Link', () => {
   it('should detectNewTokens when clicking refresh', () => {
     const mockState = {
       metamask: {
-        provider: {
+        providerConfig: {
           chainId: '0x5',
         },
       },
@@ -77,7 +77,7 @@ describe('Import Token Link', () => {
   it('should push import token route', () => {
     const mockState = {
       metamask: {
-        provider: {
+        providerConfig: {
           chainId: '0x5',
         },
       },

--- a/ui/components/app/loading-network-screen/loading-network-screen.component.js
+++ b/ui/components/app/loading-network-screen/loading-network-screen.component.js
@@ -17,7 +17,7 @@ export default class LoadingNetworkScreen extends PureComponent {
   static propTypes = {
     loadingMessage: PropTypes.string,
     cancelTime: PropTypes.number,
-    provider: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
+    providerConfig: PropTypes.object,
     providerId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     showNetworkDropdown: PropTypes.func,
     setProviderArgs: PropTypes.array,
@@ -38,8 +38,8 @@ export default class LoadingNetworkScreen extends PureComponent {
     if (loadingMessage) {
       return loadingMessage;
     }
-    const { provider, providerId } = this.props;
-    const providerName = provider.type;
+    const { providerConfig, providerId } = this.props;
+    const providerName = providerConfig.type;
     const { t } = this.context;
 
     switch (providerName) {
@@ -125,9 +125,9 @@ export default class LoadingNetworkScreen extends PureComponent {
   };
 
   componentDidUpdate = (prevProps) => {
-    const { provider } = this.props;
-    const { provider: prevProvider } = prevProps;
-    if (provider.type !== prevProvider.type) {
+    const { providerConfig } = this.props;
+    const { providerConfig: prevProvider } = prevProps;
+    if (providerConfig.type !== prevProvider.type) {
       window.clearTimeout(this.cancelCallTimeout);
       this.setState({ showErrorScreen: false });
       this.cancelCallTimeout = setTimeout(

--- a/ui/components/app/loading-network-screen/loading-network-screen.container.js
+++ b/ui/components/app/loading-network-screen/loading-network-screen.container.js
@@ -9,8 +9,8 @@ const DEPRECATED_TEST_NET_CHAINIDS = ['0x3', '0x2a', '0x4'];
 
 const mapStateToProps = (state) => {
   const { loadingMessage } = state.appState;
-  const provider = getProviderConfig(state);
-  const { rpcUrl, chainId, ticker, nickname, type } = provider;
+  const providerConfig = getProviderConfig(state);
+  const { rpcUrl, chainId, ticker, nickname, type } = providerConfig;
 
   const setProviderArgs =
     type === NETWORK_TYPES.RPC ? [rpcUrl, chainId, ticker, nickname] : [type];
@@ -25,7 +25,7 @@ const mapStateToProps = (state) => {
     isNetworkLoading: isNetworkLoading(state),
     loadingMessage,
     setProviderArgs,
-    provider,
+    providerConfig,
     providerId: getNetworkIdentifier(state),
     showDeprecatedRpcUrlWarning,
   };

--- a/ui/components/app/menu-bar/menu-bar.test.js
+++ b/ui/components/app/menu-bar/menu-bar.test.js
@@ -9,7 +9,7 @@ import MenuBar from './menu-bar';
 const initState = {
   activeTab: {},
   metamask: {
-    provider: {
+    providerConfig: {
       chainId: CHAIN_IDS.GOERLI,
     },
     selectedAddress: '0x0dcd5d886577d5081b0c52e242ef29e70be3e7bc',

--- a/ui/components/app/modals/account-details-modal/account-details-modal.test.js
+++ b/ui/components/app/modals/account-details-modal/account-details-modal.test.js
@@ -86,7 +86,7 @@ describe('Account Details Modal', () => {
             },
           },
         },
-        provider: {
+        providerConfig: {
           chainId: '0x99',
         },
       },

--- a/ui/components/app/modals/cancel-transaction/cancel-transaction-gas-fee/cancel-transaction-gas-fee.component.test.js
+++ b/ui/components/app/modals/cancel-transaction/cancel-transaction-gas-fee/cancel-transaction-gas-fee.component.test.js
@@ -6,7 +6,7 @@ import CancelTransactionGasFee from './cancel-transaction-gas-fee.component';
 describe('CancelTransactionGasFee Component', () => {
   const mockState = {
     metamask: {
-      provider: {
+      providerConfig: {
         chainId: '0x4',
       },
       preferences: {

--- a/ui/components/app/modals/confirm-remove-account/confirm-remove-account.test.js
+++ b/ui/components/app/modals/confirm-remove-account/confirm-remove-account.test.js
@@ -7,7 +7,7 @@ import ConfirmRemoveAccount from '.';
 describe('Confirm Remove Account', () => {
   const state = {
     metamask: {
-      provider: {
+      providerConfig: {
         chainId: '0x99',
       },
     },

--- a/ui/components/app/nft-details/nft-details.test.js
+++ b/ui/components/app/nft-details/nft-details.test.js
@@ -170,7 +170,7 @@ describe('NFT Details', () => {
         ...mockState,
         metamask: {
           ...mockState.metamask,
-          provider: {
+          providerConfig: {
             chainId: '0x1',
           },
         },
@@ -200,7 +200,7 @@ describe('NFT Details', () => {
         ...mockState,
         metamask: {
           ...mockState.metamask,
-          provider: {
+          providerConfig: {
             chainId: '0x89',
           },
         },
@@ -230,7 +230,7 @@ describe('NFT Details', () => {
         ...mockState,
         metamask: {
           ...mockState.metamask,
-          provider: {
+          providerConfig: {
             chainId: '0xaa36a7',
           },
         },
@@ -260,7 +260,7 @@ describe('NFT Details', () => {
         ...mockState,
         metamask: {
           ...mockState.metamask,
-          provider: {
+          providerConfig: {
             chainId: '0x99',
           },
         },

--- a/ui/components/app/nfts-tab/nfts-tab.test.js
+++ b/ui/components/app/nfts-tab/nfts-tab.test.js
@@ -166,7 +166,7 @@ const render = ({
           [chainIdAsDecimal]: nftContracts,
         },
       },
-      provider: { chainId },
+      providerConfig: { chainId },
       selectedAddress,
       useNftDetection,
       nftsDropdownState,

--- a/ui/components/app/signature-request-original/signature-request-original.component.js
+++ b/ui/components/app/signature-request-original/signature-request-original.component.js
@@ -72,7 +72,7 @@ export default class SignatureRequestOriginal extends Component {
     messagesCount: PropTypes.number,
     showRejectTransactionsConfirmationModal: PropTypes.func.isRequired,
     cancelAll: PropTypes.func.isRequired,
-    provider: PropTypes.object,
+    providerConfig: PropTypes.object,
     ///: BEGIN:ONLY_INCLUDE_IN(build-mmi)
     selectedAccount: PropTypes.object,
     ///: END:ONLY_INCLUDE_IN
@@ -83,8 +83,8 @@ export default class SignatureRequestOriginal extends Component {
   };
 
   getNetworkName() {
-    const { provider } = this.props;
-    const providerName = provider.type;
+    const { providerConfig } = this.props;
+    const providerName = providerConfig.type;
     const { t } = this.context;
 
     switch (providerName) {
@@ -99,7 +99,7 @@ export default class SignatureRequestOriginal extends Component {
       case NETWORK_TYPES.LOCALHOST:
         return t('localhost');
       default:
-        return provider.nickname || t('unknownNetwork');
+        return providerConfig.nickname || t('unknownNetwork');
     }
   }
 

--- a/ui/components/app/signature-request-original/signature-request-original.container.js
+++ b/ui/components/app/signature-request-original/signature-request-original.container.js
@@ -31,7 +31,7 @@ function mapStateToProps(state, ownProps) {
   const {
     msgParams: { from },
   } = ownProps.txData;
-  const provider = getProviderConfig(state);
+  const providerConfig = getProviderConfig(state);
 
   const hardwareWalletRequiresConnection =
     doesAddressRequireLedgerHidConnection(state, from);
@@ -56,7 +56,7 @@ function mapStateToProps(state, ownProps) {
     subjectMetadata: getSubjectMetadata(state),
     messagesList,
     messagesCount,
-    provider,
+    providerConfig,
     ///: BEGIN:ONLY_INCLUDE_IN(build-mmi)
     selectedAccount: getSelectedAccount(state),
     ///: END:ONLY_INCLUDE_IN

--- a/ui/components/app/signature-request-original/signature-request-original.stories.js
+++ b/ui/components/app/signature-request-original/signature-request-original.stories.js
@@ -73,7 +73,7 @@ export default {
     },
     mostRecentOverviewPage: '/',
     nativeCurrency: 'ETH',
-    provider: { name: 'Goerli ETH' },
+    providerConfig: { name: 'Goerli ETH' },
     selectedAccount: MOCK_PRIMARY_IDENTITY,
   },
 };

--- a/ui/components/app/signature-request/signature-request-data/signature-request-data.test.js
+++ b/ui/components/app/signature-request/signature-request-data/signature-request-data.test.js
@@ -34,7 +34,7 @@ describe('Signature Request Data', () => {
             unlisted: false,
           },
         },
-        provider: {
+        providerConfig: {
           type: 'test',
           chainId: '0x5',
         },

--- a/ui/components/app/signature-request/signature-request.component.js
+++ b/ui/components/app/signature-request/signature-request.component.js
@@ -85,7 +85,7 @@ export default class SignatureRequest extends PureComponent {
     nativeCurrency: PropTypes.string,
     currentCurrency: PropTypes.string.isRequired,
     conversionRate: PropTypes.number,
-    provider: PropTypes.object,
+    providerConfig: PropTypes.object,
     subjectMetadata: PropTypes.object,
     unapprovedMessagesCount: PropTypes.number,
     clearConfirmTransaction: PropTypes.func.isRequired,
@@ -122,8 +122,8 @@ export default class SignatureRequest extends PureComponent {
   }
 
   getNetworkName() {
-    const { provider } = this.props;
-    const providerName = provider.type;
+    const { providerConfig } = this.props;
+    const providerName = providerConfig.type;
     const { t } = this.context;
 
     switch (providerName) {
@@ -138,7 +138,7 @@ export default class SignatureRequest extends PureComponent {
       case NETWORK_TYPES.LOCALHOST:
         return t('localhost');
       default:
-        return provider.nickname || t('unknownNetwork');
+        return providerConfig.nickname || t('unknownNetwork');
     }
   }
 

--- a/ui/components/app/signature-request/signature-request.component.test.js
+++ b/ui/components/app/signature-request/signature-request.component.test.js
@@ -15,7 +15,7 @@ const baseProps = {
   showRejectTransactionsConfirmationModal: () => undefined,
   sign: () => undefined,
   history: { push: '/' },
-  provider: { type: 'rpc' },
+  providerConfig: { type: 'rpc' },
   nativeCurrency: 'ABC',
   currentCurrency: 'def',
   fromAccount: {

--- a/ui/components/app/signature-request/signature-request.container.js
+++ b/ui/components/app/signature-request/signature-request.container.js
@@ -31,7 +31,7 @@ function mapStateToProps(state, ownProps) {
   const {
     msgParams: { from },
   } = txData;
-  const provider = getProviderConfig(state);
+  const providerConfig = getProviderConfig(state);
 
   const hardwareWalletRequiresConnection =
     doesAddressRequireLedgerHidConnection(state, from);
@@ -43,7 +43,7 @@ function mapStateToProps(state, ownProps) {
   const { useNativeCurrencyAsPrimaryCurrency } = getPreferences(state);
 
   return {
-    provider,
+    providerConfig,
     isLedgerWallet,
     hardwareWalletRequiresConnection,
     chainId,
@@ -96,7 +96,7 @@ function mergeProps(stateProps, dispatchProps, ownProps) {
     nativeCurrency,
     currentCurrency,
     conversionRate,
-    provider,
+    providerConfig,
     subjectMetadata,
     unconfirmedMessagesList,
     unapprovedMessagesCount,
@@ -149,7 +149,7 @@ function mergeProps(stateProps, dispatchProps, ownProps) {
     nativeCurrency,
     currentCurrency,
     conversionRate,
-    provider,
+    providerConfig,
     subjectMetadata,
     unapprovedMessagesCount,
     mostRecentOverviewPage,

--- a/ui/components/app/signature-request/signature-request.container.test.js
+++ b/ui/components/app/signature-request/signature-request.container.test.js
@@ -46,7 +46,7 @@ const mockStoreWithEth = {
         },
       },
     },
-    provider: {
+    providerConfig: {
       type: 'rpc',
     },
     preferences: {
@@ -92,7 +92,7 @@ describe('Signature Request', () => {
     cancel: sinon.stub().resolves(),
     showRejectTransactionsConfirmationModal: sinon.stub().resolves(),
     cancelAll: sinon.stub().resolves(),
-    provider: {
+    providerConfig: {
       type: 'rpc',
     },
     unapprovedMessagesCount: 2,

--- a/ui/components/app/signature-request/signature-request.stories.js
+++ b/ui/components/app/signature-request/signature-request.stories.js
@@ -77,7 +77,7 @@ DefaultStory.args = {
     },
   },
   fromAccount: MOCK_PRIMARY_IDENTITY,
-  provider: { name: 'Goerli ETH' },
+  providerConfig: { name: 'Goerli ETH' },
   selectedAccount: MOCK_PRIMARY_IDENTITY,
 };
 

--- a/ui/components/app/token-cell/token-cell.test.js
+++ b/ui/components/app/token-cell/token-cell.test.js
@@ -15,7 +15,7 @@ describe('Token Cell', () => {
       },
       conversionRate: 7.0,
       preferences: {},
-      provider: {
+      providerConfig: {
         chainId: '0x1',
         ticker: 'ETH',
         type: 'mainnet',

--- a/ui/components/app/transaction-activity-log/transaction-activity-log.container.test.js
+++ b/ui/components/app/transaction-activity-log/transaction-activity-log.container.test.js
@@ -18,7 +18,7 @@ describe('TransactionActivityLog container', () => {
           conversionRate: 280.45,
           nativeCurrency: 'ETH',
           networkConfigurations: {},
-          provider: {
+          providerConfig: {
             ticker: 'ETH',
           },
         },
@@ -41,7 +41,7 @@ describe('TransactionActivityLog container', () => {
               rpcUrl: 'https://customnetwork.com/',
             },
           },
-          provider: {
+          providerConfig: {
             rpcUrl: 'https://customnetwork.com/',
             ticker: 'ETH',
             rpcPrefs: {

--- a/ui/components/app/transaction-alerts/transaction-alerts.stories.js
+++ b/ui/components/app/transaction-alerts/transaction-alerts.stories.js
@@ -19,7 +19,7 @@ const customTransaction = ({
     blockNumber: `${10902987 + i}`,
     id: 4678200543090545 + i,
     metamaskNetworkId: testData?.metamask?.networkId,
-    chainId: testData?.metamask?.provider?.chainId,
+    chainId: testData?.metamask?.providerConfig?.chainId,
     status: 'confirmed',
     time: 1600654021000,
     txParams: {

--- a/ui/components/app/transaction-breakdown/transaction-breakdown.test.js
+++ b/ui/components/app/transaction-breakdown/transaction-breakdown.test.js
@@ -21,7 +21,7 @@ describe('TransactionBreakdown', () => {
     metamask: {
       nativeCurrency: null,
       preferences: {},
-      provider: {
+      providerConfig: {
         chainId: null,
       },
     },

--- a/ui/components/app/user-preferenced-currency-display/user-preferenced-currency-display.test.js
+++ b/ui/components/app/user-preferenced-currency-display/user-preferenced-currency-display.test.js
@@ -7,7 +7,7 @@ describe('UserPreferencedCurrencyDisplay Component', () => {
   describe('rendering', () => {
     const mockState = {
       metamask: {
-        provider: {
+        providerConfig: {
           chainId: '0x99',
         },
         preferences: {

--- a/ui/components/app/wallet-overview/eth-overview.test.js
+++ b/ui/components/app/wallet-overview/eth-overview.test.js
@@ -28,7 +28,7 @@ let openTabSpy;
 describe('EthOverview', () => {
   const mockStore = {
     metamask: {
-      provider: {
+      providerConfig: {
         type: 'test',
         chainId: CHAIN_IDS.MAINNET,
       },
@@ -150,7 +150,10 @@ describe('EthOverview', () => {
         ...mockStore,
         metamask: {
           ...mockStore.metamask,
-          provider: { ...mockStore.metamask.provider, chainId: '0xa86a' },
+          providerConfig: {
+            ...mockStore.metamask.providerConfig,
+            chainId: '0xa86a',
+          },
         },
       };
       const mockedStore = configureMockStore([thunk])(mockedAvalancheStore);
@@ -193,7 +196,10 @@ describe('EthOverview', () => {
         ...mockStore,
         metamask: {
           ...mockStore.metamask,
-          provider: { ...mockStore.metamask.provider, chainId: '0xfa' },
+          providerConfig: {
+            ...mockStore.metamask.providerConfig,
+            chainId: '0xfa',
+          },
         },
       };
       const mockedStore = configureMockStore([thunk])(mockedFantomStore);
@@ -245,7 +251,7 @@ describe('EthOverview', () => {
       const mockedStoreWithUnbuyableChainId = {
         metamask: {
           ...mockStore.metamask,
-          provider: { type: 'test', chainId: CHAIN_IDS.FANTOM },
+          providerConfig: { type: 'test', chainId: CHAIN_IDS.FANTOM },
         },
       };
       const mockedStore = configureMockStore([thunk])(
@@ -265,7 +271,7 @@ describe('EthOverview', () => {
       const mockedStoreWithUnbuyableChainId = {
         metamask: {
           ...mockStore.metamask,
-          provider: { type: 'test', chainId: CHAIN_IDS.POLYGON },
+          providerConfig: { type: 'test', chainId: CHAIN_IDS.POLYGON },
         },
       };
       const mockedStore = configureMockStore([thunk])(
@@ -285,7 +291,7 @@ describe('EthOverview', () => {
       const mockedStoreWithBuyableChainId = {
         metamask: {
           ...mockStore.metamask,
-          provider: { type: 'test', chainId: CHAIN_IDS.POLYGON },
+          providerConfig: { type: 'test', chainId: CHAIN_IDS.POLYGON },
         },
       };
       const mockedStore = configureMockStore([thunk])(

--- a/ui/components/app/wallet-overview/token-overview.test.js
+++ b/ui/components/app/wallet-overview/token-overview.test.js
@@ -28,7 +28,7 @@ let openTabSpy;
 describe('TokenOverview', () => {
   const mockStore = {
     metamask: {
-      provider: {
+      providerConfig: {
         type: 'test',
         chainId: CHAIN_IDS.MAINNET,
       },
@@ -110,7 +110,7 @@ describe('TokenOverview', () => {
       const mockedStoreWithUnbuyableChainId = {
         metamask: {
           ...mockStore.metamask,
-          provider: { type: 'test', chainId: CHAIN_IDS.PALM },
+          providerConfig: { type: 'test', chainId: CHAIN_IDS.PALM },
         },
       };
       const mockedStore = configureMockStore([thunk])(
@@ -143,7 +143,7 @@ describe('TokenOverview', () => {
       const mockedStoreWithUnbuyableChainId = {
         metamask: {
           ...mockStore.metamask,
-          provider: { type: 'test', chainId: CHAIN_IDS.FANTOM },
+          providerConfig: { type: 'test', chainId: CHAIN_IDS.FANTOM },
         },
       };
       const mockedStore = configureMockStore([thunk])(
@@ -163,7 +163,7 @@ describe('TokenOverview', () => {
       const mockedStoreWithBuyableChainId = {
         metamask: {
           ...mockStore.metamask,
-          provider: { type: 'test', chainId: CHAIN_IDS.POLYGON },
+          providerConfig: { type: 'test', chainId: CHAIN_IDS.POLYGON },
         },
       };
       const mockedStore = configureMockStore([thunk])(
@@ -188,7 +188,7 @@ describe('TokenOverview', () => {
       const mockedStoreWithBuyableChainId = {
         metamask: {
           ...mockStore.metamask,
-          provider: { type: 'test', chainId: CHAIN_IDS.POLYGON },
+          providerConfig: { type: 'test', chainId: CHAIN_IDS.POLYGON },
         },
       };
       const mockedStore = configureMockStore([thunk])(
@@ -208,7 +208,7 @@ describe('TokenOverview', () => {
       const mockedStoreWithBuyableChainId = {
         metamask: {
           ...mockStore.metamask,
-          provider: { type: 'test', chainId: CHAIN_IDS.POLYGON },
+          providerConfig: { type: 'test', chainId: CHAIN_IDS.POLYGON },
         },
       };
       const mockedStore = configureMockStore([thunk])(
@@ -286,7 +286,7 @@ describe('TokenOverview', () => {
       const mockedStoreWithBridgeableChainId = {
         metamask: {
           ...mockStore.metamask,
-          provider: { type: 'test', chainId: CHAIN_IDS.POLYGON },
+          providerConfig: { type: 'test', chainId: CHAIN_IDS.POLYGON },
         },
       };
       const mockedStore = configureMockStore([thunk])(
@@ -324,7 +324,7 @@ describe('TokenOverview', () => {
       const mockedStoreWithBridgeableChainId = {
         metamask: {
           ...mockStore.metamask,
-          provider: { type: 'test', chainId: CHAIN_IDS.FANTOM },
+          providerConfig: { type: 'test', chainId: CHAIN_IDS.FANTOM },
         },
       };
       const mockedStore = configureMockStore([thunk])(
@@ -350,7 +350,7 @@ describe('TokenOverview', () => {
       const mockedStoreWithBridgeableChainId = {
         metamask: {
           ...mockStore.metamask,
-          provider: { type: 'test', chainId: CHAIN_IDS.POLYGON },
+          providerConfig: { type: 'test', chainId: CHAIN_IDS.POLYGON },
         },
       };
       const mockedStore = configureMockStore([thunk])(

--- a/ui/components/institutional/compliance-settings/compliance-settings.test.js
+++ b/ui/components/institutional/compliance-settings/compliance-settings.test.js
@@ -14,7 +14,7 @@ jest.mock('../../../store/institutional/institution-background', () => ({
 
 const mockStore = {
   metamask: {
-    provider: {
+    providerConfig: {
       type: 'test',
     },
     institutionalFeatures: {

--- a/ui/components/institutional/custody-confirm-link-modal/custody-confirm-link-modal.stories.js
+++ b/ui/components/institutional/custody-confirm-link-modal/custody-confirm-link-modal.stories.js
@@ -52,7 +52,7 @@ const customData = {
         custodianName: 'saturn-dev',
       },
     },
-    provider: {
+    providerConfig: {
       type: 'test',
     },
     selectedAddress: '0xAddress',

--- a/ui/components/institutional/custody-confirm-link-modal/custody-confirm-link-modal.test.js
+++ b/ui/components/institutional/custody-confirm-link-modal/custody-confirm-link-modal.test.js
@@ -70,7 +70,7 @@ describe('Custody Confirm Link', () => {
           custodianName: mockedCustodianName,
         },
       },
-      provider: {
+      providerConfig: {
         type: 'test',
       },
       selectedAddress: '0xAddress',

--- a/ui/components/institutional/interactive-replacement-token-modal/interactive-replacement-token-modal.stories.js
+++ b/ui/components/institutional/interactive-replacement-token-modal/interactive-replacement-token-modal.stories.js
@@ -42,7 +42,7 @@ const customData = {
         custodianName: 'saturn-dev',
       },
     },
-    provider: {
+    providerConfig: {
       type: 'test',
     },
     selectedAddress: '0xAddress',

--- a/ui/components/institutional/interactive-replacement-token-modal/interactive-replacement-token-modal.test.js
+++ b/ui/components/institutional/interactive-replacement-token-modal/interactive-replacement-token-modal.test.js
@@ -45,7 +45,7 @@ describe('Interactive Replacement Token Modal', function () {
           custodianName: 'saturn-dev',
         },
       },
-      provider: {
+      providerConfig: {
         type: 'test',
       },
       selectedAddress: '0xAddress',

--- a/ui/components/institutional/interactive-replacement-token-notification/interactive-replacement-token-notification.stories.js
+++ b/ui/components/institutional/interactive-replacement-token-notification/interactive-replacement-token-notification.stories.js
@@ -8,7 +8,7 @@ const customData = {
   ...testData,
   metamask: {
     ...testData.metamask,
-    provider: {
+    providerConfig: {
       type: 'test',
     },
     selectedAddress: '0xca8f1F0245530118D0cf14a06b01Daf8f76Cf281',

--- a/ui/components/institutional/interactive-replacement-token-notification/interactive-replacement-token-notification.test.js
+++ b/ui/components/institutional/interactive-replacement-token-notification/interactive-replacement-token-notification.test.js
@@ -49,7 +49,7 @@ describe('Interactive Replacement Token Notification', () => {
 
   const mockStore = {
     metamask: {
-      provider: {
+      providerConfig: {
         type: 'test',
       },
       selectedAddress,

--- a/ui/components/institutional/jwt-url-form/jwt-url-form.test.js
+++ b/ui/components/institutional/jwt-url-form/jwt-url-form.test.js
@@ -8,7 +8,7 @@ import JwtUrlForm from './jwt-url-form';
 describe('JwtUrlForm', function () {
   const mockStore = {
     metamask: {
-      provider: {
+      providerConfig: {
         type: 'test',
       },
     },

--- a/ui/components/multichain/account-picker/account-picker.test.js
+++ b/ui/components/multichain/account-picker/account-picker.test.js
@@ -16,7 +16,7 @@ const render = (props = {}, state = {}) => {
   const store = configureStore({
     metamask: {
       ...mockState.metamask,
-      provider: {
+      providerConfig: {
         chainId: '0x99',
       },
       ...state,

--- a/ui/components/multichain/app-header/app-header.test.js
+++ b/ui/components/multichain/app-header/app-header.test.js
@@ -14,7 +14,7 @@ describe('App Header', () => {
         url: 'https://remix.ethereum.org/',
       },
       metamask: {
-        provider: {
+        providerConfig: {
           chainId: CHAIN_IDS.GOERLI,
         },
         accounts: {

--- a/ui/components/multichain/multichain-import-token-link/multichain-import-token-link.test.js
+++ b/ui/components/multichain/multichain-import-token-link/multichain-import-token-link.test.js
@@ -26,7 +26,7 @@ describe('Import Token Link', () => {
   it('should match snapshot for goerli chainId', () => {
     const mockState = {
       metamask: {
-        provider: {
+        providerConfig: {
           chainId: '0x5',
         },
       },
@@ -45,7 +45,7 @@ describe('Import Token Link', () => {
   it('should match snapshot for mainnet chainId', () => {
     const mockState = {
       metamask: {
-        provider: {
+        providerConfig: {
           chainId: '0x1',
         },
       },
@@ -64,7 +64,7 @@ describe('Import Token Link', () => {
   it('should detectNewTokens when clicking refresh', () => {
     const mockState = {
       metamask: {
-        provider: {
+        providerConfig: {
           chainId: '0x5',
         },
       },
@@ -83,7 +83,7 @@ describe('Import Token Link', () => {
   it('should push import token route', () => {
     const mockState = {
       metamask: {
-        provider: {
+        providerConfig: {
           chainId: '0x5',
         },
       },

--- a/ui/components/multichain/multichain-token-list-item/multichain-token-list-item.test.js
+++ b/ui/components/multichain/multichain-token-list-item/multichain-token-list-item.test.js
@@ -7,7 +7,7 @@ import { MultichainTokenListItem } from './multichain-token-list-item';
 
 const state = {
   metamask: {
-    provider: {
+    providerConfig: {
       ticker: 'ETH',
       nickname: '',
       chainId: '0x1',

--- a/ui/components/ui/identicon/identicon.component.test.js
+++ b/ui/components/ui/identicon/identicon.component.test.js
@@ -6,7 +6,7 @@ import Identicon from '.';
 describe('Identicon', () => {
   const mockState = {
     metamask: {
-      provider: {
+      providerConfig: {
         chainId: '0x99',
       },
       useBlockie: false,

--- a/ui/components/ui/new-network-info/new-network-info.test.js
+++ b/ui/components/ui/new-network-info/new-network-info.test.js
@@ -9,7 +9,7 @@ const fetchWithCache =
 
 const state = {
   metamask: {
-    provider: {
+    providerConfig: {
       ticker: 'ETH',
       nickname: '',
       chainId: '0x1',
@@ -139,7 +139,7 @@ describe('NewNetworkInfo', () => {
       'https://token-api.metaswap.codefi.network/tokens/0x3',
     );
 
-    state.metamask.provider.ticker = null;
+    state.metamask.providerConfig.ticker = null;
 
     const store = configureMockStore()(
       state,

--- a/ui/ducks/confirm-transaction/confirm-transaction.duck.test.js
+++ b/ui/ducks/confirm-transaction/confirm-transaction.duck.test.js
@@ -290,7 +290,7 @@ describe('Confirm Transaction Duck', () => {
         metamask: {
           conversionRate: 468.58,
           currentCurrency: 'usd',
-          provider: {
+          providerConfig: {
             ticker: 'ETH',
           },
         },
@@ -345,7 +345,7 @@ describe('Confirm Transaction Duck', () => {
           currentCurrency: 'usd',
           networkId: '5',
           networkStatus: 'available',
-          provider: {
+          providerConfig: {
             chainId: '0x5',
           },
           unapprovedTxs: {

--- a/ui/ducks/metamask/metamask.js
+++ b/ui/ducks/metamask/metamask.js
@@ -234,10 +234,10 @@ export const getAlertEnabledness = (state) => state.metamask.alertEnabledness;
  * Get the provider configuration for the current selected network.
  *
  * @param {object} state - Redux state object.
- * @returns {import('../../../app/scripts/controllers/network/network-controller').NetworkControllerState['provider']} The provider configuration for the current selected network.
+ * @returns {import('../../../app/scripts/controllers/network/network-controller').NetworkControllerState['providerConfig']} The provider configuration for the current selected network.
  */
 export function getProviderConfig(state) {
-  return state.metamask.provider;
+  return state.metamask.providerConfig;
 }
 
 export const getUnconnectedAccountAlertEnabledness = (state) =>

--- a/ui/ducks/metamask/metamask.test.js
+++ b/ui/ducks/metamask/metamask.test.js
@@ -43,7 +43,7 @@ describe('MetaMask Reducers', () => {
         useCurrencyRateCheck: true,
         networkId: '5',
         networkStatus: 'available',
-        provider: {
+        providerConfig: {
           type: 'testnet',
           chainId: '0x5',
           ticker: 'TestETH',

--- a/ui/ducks/send/send.test.js
+++ b/ui/ducks/send/send.test.js
@@ -1293,7 +1293,7 @@ describe('Send Slice', () => {
                 '0xAddress': '0x0',
               },
             },
-            provider: {
+            providerConfig: {
               chainId: '0x5',
             },
             useTokenDetection: true,
@@ -1425,7 +1425,7 @@ describe('Send Slice', () => {
           metamask: {
             blockGasLimit: '',
             selectedAddress: '',
-            provider: {
+            providerConfig: {
               chainId: '0x1',
             },
           },
@@ -1478,7 +1478,7 @@ describe('Send Slice', () => {
           metamask: {
             blockGasLimit: '',
             selectedAddress: '',
-            provider: {
+            providerConfig: {
               chainId: '0x1',
             },
           },
@@ -1530,7 +1530,7 @@ describe('Send Slice', () => {
           metamask: {
             blockGasLimit: '',
             selectedAddress: '',
-            provider: {
+            providerConfig: {
               chainId: '0x1',
             },
           },
@@ -1575,7 +1575,7 @@ describe('Send Slice', () => {
         metamask: {
           blockGasLimit: '',
           selectedAddress: '',
-          provider: {
+          providerConfig: {
             chainId: CHAIN_IDS.GOERLI,
           },
           cachedBalances: {
@@ -1745,7 +1745,7 @@ describe('Send Slice', () => {
     describe('updateRecipientUserInput', () => {
       const updateRecipientUserInputState = {
         metamask: {
-          provider: {
+          providerConfig: {
             chainId: '',
           },
           tokens: [],
@@ -1882,7 +1882,7 @@ describe('Send Slice', () => {
           metamask: {
             addressBook: {},
             identities: {},
-            provider: {
+            providerConfig: {
               chainId: '0x1',
             },
           },
@@ -1941,7 +1941,7 @@ describe('Send Slice', () => {
                 },
               ],
             },
-            provider: {
+            providerConfig: {
               chainId: '0x1',
             },
           },
@@ -1992,7 +1992,7 @@ describe('Send Slice', () => {
             identities: {},
             blockGasLimit: '',
             selectedAddress: '',
-            provider: {
+            providerConfig: {
               chainId: '0x1',
             },
           },
@@ -2040,7 +2040,7 @@ describe('Send Slice', () => {
           metamask: {
             addressBook: {},
             identities: {},
-            provider: {
+            providerConfig: {
               chainId: '',
             },
             tokens: [],
@@ -2165,7 +2165,7 @@ describe('Send Slice', () => {
             userInputHexData: '',
           },
           metamask: {
-            provider: {
+            providerConfig: {
               chainId: CHAIN_IDS.GOERLI,
             },
           },
@@ -2214,7 +2214,7 @@ describe('Send Slice', () => {
             amountMode: AMOUNT_MODES.MAX,
           },
           metamask: {
-            provider: {
+            providerConfig: {
               chainId: CHAIN_IDS.GOERLI,
             },
           },
@@ -2372,7 +2372,7 @@ describe('Send Slice', () => {
           metamask: {
             gasEstimateType: GasEstimateTypes.none,
             gasFeeEstimates: {},
-            provider: {
+            providerConfig: {
               chainId: CHAIN_IDS.GOERLI,
             },
             tokens: [],
@@ -2507,7 +2507,7 @@ describe('Send Slice', () => {
           metamask: {
             blockGasLimit: '0x3a98',
             selectedAddress: '',
-            provider: {
+            providerConfig: {
               chainId: CHAIN_IDS.GOERLI,
             },
             tokens: [],
@@ -2679,7 +2679,7 @@ describe('Send Slice', () => {
         metamask: {
           blockGasLimit: '0x3a98',
           selectedAddress: '',
-          provider: {
+          providerConfig: {
             chainId: CHAIN_IDS.GOERLI,
           },
           tokens: [
@@ -2910,7 +2910,7 @@ describe('Send Slice', () => {
           expect(
             getGasInputMode({
               metamask: {
-                provider: { chainId: CHAIN_IDS.MAINNET },
+                providerConfig: { chainId: CHAIN_IDS.MAINNET },
                 featureFlags: { advancedInlineGas: false },
               },
               send: initialState,
@@ -2923,7 +2923,7 @@ describe('Send Slice', () => {
           expect(
             getGasInputMode({
               metamask: {
-                provider: { chainId: '0x539' },
+                providerConfig: { chainId: '0x539' },
                 featureFlags: { advancedInlineGas: false },
               },
               send: initialState,
@@ -2936,7 +2936,7 @@ describe('Send Slice', () => {
           expect(
             getGasInputMode({
               metamask: {
-                provider: { chainId: CHAIN_IDS.MAINNET },
+                providerConfig: { chainId: CHAIN_IDS.MAINNET },
                 featureFlags: { advancedInlineGas: true },
               },
               send: initialState,
@@ -2948,7 +2948,7 @@ describe('Send Slice', () => {
           expect(
             getGasInputMode({
               metamask: {
-                provider: { chainId: CHAIN_IDS.MAINNET },
+                providerConfig: { chainId: CHAIN_IDS.MAINNET },
                 featureFlags: { advancedInlineGas: false },
                 gasEstimateType: GasEstimateTypes.ethGasPrice,
               },
@@ -2962,7 +2962,7 @@ describe('Send Slice', () => {
           expect(
             getGasInputMode({
               metamask: {
-                provider: { chainId: CHAIN_IDS.MAINNET },
+                providerConfig: { chainId: CHAIN_IDS.MAINNET },
                 featureFlags: { advancedInlineGas: false },
                 gasEstimateType: GasEstimateTypes.ethGasPrice,
               },
@@ -2976,7 +2976,7 @@ describe('Send Slice', () => {
           expect(
             getGasInputMode({
               metamask: {
-                provider: { chainId: CHAIN_IDS.MAINNET },
+                providerConfig: { chainId: CHAIN_IDS.MAINNET },
                 featureFlags: { advancedInlineGas: true },
               },
               send: {
@@ -3116,7 +3116,7 @@ describe('Send Slice', () => {
               ensResolutionsByAddress: {},
               identities: {},
               addressBook: {},
-              provider: {
+              providerConfig: {
                 chainId: '0x5',
               },
             },
@@ -3131,7 +3131,7 @@ describe('Send Slice', () => {
               ensResolutionsByAddress: {},
               addressBook: {},
               identities: {},
-              provider: {
+              providerConfig: {
                 chainId: '0x5',
               },
             },
@@ -3179,7 +3179,7 @@ describe('Send Slice', () => {
               ensResolutionsByAddress: {},
               identities: {},
               addressBook: {},
-              provider: {
+              providerConfig: {
                 chainId: '0x5',
               },
             },

--- a/ui/ducks/swaps/swaps.test.js
+++ b/ui/ducks/swaps/swaps.test.js
@@ -19,7 +19,7 @@ jest.mock('../../store/actions.ts', () => ({
   }),
 }));
 
-const providerState = {
+const providerConfigState = {
   chainId: '0x1',
   nickname: '',
   rpcPrefs: {},
@@ -64,7 +64,7 @@ describe('Ducks - Swaps', () => {
     const createGetState = () => {
       return () => ({
         metamask: {
-          provider: { ...providerState },
+          providerConfig: { ...providerConfigState },
           from: '0x64a845a5b02460acf8a3d84503b0d68d028b4bb4',
         },
       });
@@ -427,19 +427,19 @@ describe('Ducks - Swaps', () => {
 
     it('returns false if feature flag is enabled, not a HW and is Polygon network', () => {
       const state = createSwapsMockStore();
-      state.metamask.provider.chainId = CHAIN_IDS.POLYGON;
+      state.metamask.providerConfig.chainId = CHAIN_IDS.POLYGON;
       expect(swaps.getSmartTransactionsEnabled(state)).toBe(false);
     });
 
     it('returns false if feature flag is enabled, not a HW and is BSC network', () => {
       const state = createSwapsMockStore();
-      state.metamask.provider.chainId = CHAIN_IDS.BSC;
+      state.metamask.providerConfig.chainId = CHAIN_IDS.BSC;
       expect(swaps.getSmartTransactionsEnabled(state)).toBe(false);
     });
 
     it('returns true if feature flag is enabled, not a HW and is Goerli network', () => {
       const state = createSwapsMockStore();
-      state.metamask.provider.chainId = CHAIN_IDS.GOERLI;
+      state.metamask.providerConfig.chainId = CHAIN_IDS.GOERLI;
       expect(swaps.getSmartTransactionsEnabled(state)).toBe(true);
     });
 

--- a/ui/hooks/useAddressDetails.test.js
+++ b/ui/hooks/useAddressDetails.test.js
@@ -8,7 +8,7 @@ import useAddressDetails from './useAddressDetails';
 const renderUseAddressDetails = (toAddress, stateVariables = {}) => {
   const mockState = {
     metamask: {
-      provider: {
+      providerConfig: {
         type: 'test',
         chainId: '0x5',
       },

--- a/ui/hooks/useAssetDetails.test.js
+++ b/ui/hooks/useAssetDetails.test.js
@@ -14,7 +14,7 @@ const renderUseAssetDetails = ({
 }) => {
   const mockState = {
     metamask: {
-      provider: {
+      providerConfig: {
         type: 'test',
         chainId: '0x5',
       },

--- a/ui/hooks/useTransactionInfo.test.js
+++ b/ui/hooks/useTransactionInfo.test.js
@@ -18,7 +18,7 @@ describe('useTransactionInfo', () => {
     it('should return true if transaction is NFT transfer', () => {
       mockState.metamask.allNftContracts = {
         [mockState.metamask.selectedAddress]: {
-          [hexToDecimal(mockState.metamask.provider.chainId)]: [
+          [hexToDecimal(mockState.metamask.providerConfig.chainId)]: [
             { address: '0x9' },
           ],
         },

--- a/ui/index.js
+++ b/ui/index.js
@@ -161,7 +161,7 @@ async function startApp(metamaskState, backgroundConnection, opts) {
     metamaskState.unapprovedEncryptionPublicKeyMsgs,
     metamaskState.unapprovedTypedMessages,
     metamaskState.networkId,
-    metamaskState.provider.chainId,
+    metamaskState.providerConfig.chainId,
   );
   const numberOfUnapprovedTx = unapprovedTxsAll.length;
   if (numberOfUnapprovedTx > 0) {

--- a/ui/pages/confirm-add-suggested-token/confirm-add-suggested-token.test.js
+++ b/ui/pages/confirm-add-suggested-token/confirm-add-suggested-token.test.js
@@ -44,7 +44,7 @@ const renderComponent = (tokens = []) => {
     metamask: {
       suggestedAssets: [...MOCK_SUGGESTED_ASSETS],
       tokens,
-      provider: { chainId: '0x1' },
+      providerConfig: { chainId: '0x1' },
     },
     history: {
       mostRecentOverviewPage: '/',

--- a/ui/pages/confirm-approve/confirm-approve-content/confirm-approve-content.component.test.js
+++ b/ui/pages/confirm-approve/confirm-approve-content/confirm-approve-content.component.test.js
@@ -7,7 +7,7 @@ import ConfirmApproveContent from '.';
 
 const renderComponent = (props) => {
   const store = configureMockStore([])({
-    metamask: { provider: { chainId: '0x0' } },
+    metamask: { providerConfig: { chainId: '0x0' } },
   });
   return renderWithProvider(<ConfirmApproveContent {...props} />, store);
 };

--- a/ui/pages/confirm-import-token/confirm-import-token.test.js
+++ b/ui/pages/confirm-import-token/confirm-import-token.test.js
@@ -36,7 +36,7 @@ const renderComponent = (mockPendingTokens = MOCK_PENDING_TOKENS) => {
   const store = configureStore({
     metamask: {
       pendingTokens: { ...mockPendingTokens },
-      provider: { chainId: '0x1' },
+      providerConfig: { chainId: '0x1' },
     },
     history: {
       mostRecentOverviewPage: '/',

--- a/ui/pages/confirm-signature-request/index.test.js
+++ b/ui/pages/confirm-signature-request/index.test.js
@@ -31,7 +31,7 @@ const mockState = {
       },
     },
     unapprovedTypedMessagesCount: 1,
-    provider: { chainId: '0x5', type: 'goerli' },
+    providerConfig: { chainId: '0x5', type: 'goerli' },
     keyrings: [],
     networkConfigurations: {},
     subjectMetadata: {},

--- a/ui/pages/confirm-transaction-base/confirm-transaction-base.test.js
+++ b/ui/pages/confirm-transaction-base/confirm-transaction-base.test.js
@@ -72,7 +72,7 @@ const baseStore = {
       useNativeCurrencyAsPrimaryCurrency: false,
     },
     currentCurrency: 'USD',
-    provider: {
+    providerConfig: {
       chainId: CHAIN_IDS.GOERLI,
     },
     nativeCurrency: 'ETH',
@@ -156,7 +156,7 @@ describe('Confirm Transaction Base', () => {
   });
 
   it('should contain L1 L2 fee details for optimism', () => {
-    baseStore.metamask.provider.chainId = CHAIN_IDS.OPTIMISM;
+    baseStore.metamask.providerConfig.chainId = CHAIN_IDS.OPTIMISM;
     baseStore.confirmTransaction.txData.chainId = CHAIN_IDS.OPTIMISM;
     const store = configureMockStore(middleware)(baseStore);
     const { getByText } = renderWithProvider(

--- a/ui/pages/create-account/connect-hardware/index.test.tsx
+++ b/ui/pages/create-account/connect-hardware/index.test.tsx
@@ -48,7 +48,7 @@ const mockProps = {
 
 const mockState = {
   metamask: {
-    provider: {
+    providerConfig: {
       chainId: '0x1',
     },
   },

--- a/ui/pages/import-token/import-token.test.js
+++ b/ui/pages/import-token/import-token.test.js
@@ -35,7 +35,7 @@ describe('Import Token', () => {
     const baseStore = {
       metamask: {
         tokens: [],
-        provider: { chainId: '0x1' },
+        providerConfig: { chainId: '0x1' },
         networkConfigurations: {},
         identities: {},
         selectedAddress: '0x1231231',

--- a/ui/pages/institutional/compliance-feature-page/compliance-feature-page.test.js
+++ b/ui/pages/institutional/compliance-feature-page/compliance-feature-page.test.js
@@ -17,7 +17,7 @@ jest.mock('../../../store/institutional/institution-background', () => ({
 describe('Compliance Feature, connect', function () {
   const mockStore = {
     metamask: {
-      provider: {
+      providerConfig: {
         type: 'test',
       },
       institutionalFeatures: {

--- a/ui/pages/institutional/confirm-add-custodian-token/confirm-add-custodian-token.test.js
+++ b/ui/pages/institutional/confirm-add-custodian-token/confirm-add-custodian-token.test.js
@@ -7,7 +7,7 @@ import ConfirmAddCustodianToken from './confirm-add-custodian-token';
 describe('Confirm Add Custodian Token', () => {
   const mockStore = {
     metamask: {
-      provider: {
+      providerConfig: {
         type: 'test',
       },
       preferences: {
@@ -61,7 +61,7 @@ describe('Confirm Add Custodian Token', () => {
   it('tries to connect to custodian with empty token', async () => {
     const customMockedStore = {
       metamask: {
-        provider: {
+        providerConfig: {
           type: 'test',
         },
         preferences: {

--- a/ui/pages/institutional/confirm-add-institutional-feature/confirm-add-institutional-feature.stories.js
+++ b/ui/pages/institutional/confirm-add-institutional-feature/confirm-add-institutional-feature.stories.js
@@ -7,7 +7,7 @@ import ConfirmAddInstitutionalFeature from '.';
 const customData = {
   ...testData,
   metamask: {
-    provider: {
+    providerConfig: {
       type: 'test',
     },
     institutionalFeatures: {

--- a/ui/pages/institutional/confirm-add-institutional-feature/confirm-add-institutional-feature.test.js
+++ b/ui/pages/institutional/confirm-add-institutional-feature/confirm-add-institutional-feature.test.js
@@ -46,7 +46,7 @@ const render = ({ newState } = {}) => {
   const state = {
     ...mockState,
     metamask: {
-      provider: {
+      providerConfig: {
         type: 'test',
       },
       institutionalFeatures: {

--- a/ui/pages/institutional/connect-custody/account-list.stories.js
+++ b/ui/pages/institutional/connect-custody/account-list.stories.js
@@ -24,7 +24,6 @@ export default {
     selectedAccounts: {},
     onAddAccounts: () => undefined,
     onCancel: () => undefined,
-    provider: 'Test',
     rawList: false,
   },
 };

--- a/ui/pages/institutional/custody/custody.js
+++ b/ui/pages/institutional/custody/custody.js
@@ -41,7 +41,6 @@ import {
   DEFAULT_ROUTE,
 } from '../../../helpers/constants/routes';
 import { getCurrentChainId } from '../../../selectors';
-import { getProviderConfig } from '../../../ducks/metamask/metamask';
 import { getMMIConfiguration } from '../../../selectors/institutional/selectors';
 import CustodyAccountList from '../connect-custody/account-list';
 import JwtUrlForm from '../../../components/institutional/jwt-url-form';
@@ -54,7 +53,6 @@ const CustodyPage = () => {
 
   const mmiActions = mmiActionsFactory();
   const currentChainId = useSelector(getCurrentChainId);
-  const providerConfig = useSelector(getProviderConfig);
   const { custodians } = useSelector(getMMIConfiguration);
 
   const [selectedAccounts, setSelectedAccounts] = useState({});
@@ -494,7 +492,6 @@ const CustodyPage = () => {
 
               setSelectedAccounts(selectedAccounts);
             }}
-            provider={providerConfig}
             selectedAccounts={selectedAccounts}
             onAddAccounts={async () => {
               try {

--- a/ui/pages/institutional/custody/custody.test.js
+++ b/ui/pages/institutional/custody/custody.test.js
@@ -34,7 +34,7 @@ jest.mock('../../../store/institutional/institution-background', () => ({
 describe('CustodyPage', function () {
   const mockStore = {
     metamask: {
-      provider: { chainId: 0x1, type: 'test' },
+      providerConfig: { chainId: 0x1, type: 'test' },
       mmiConfiguration: {
         portfolio: {
           enabled: true,

--- a/ui/pages/institutional/institutional-entity-done-page/institutional-entity-done-page.test.js
+++ b/ui/pages/institutional/institutional-entity-done-page/institutional-entity-done-page.test.js
@@ -19,7 +19,7 @@ const render = () => {
   const store = configureStore({
     ...mockState,
     metamask: {
-      provider: {
+      providerConfig: {
         type: 'test',
       },
     },

--- a/ui/pages/onboarding-flow/creation-successful/creation-successful.test.js
+++ b/ui/pages/onboarding-flow/creation-successful/creation-successful.test.js
@@ -28,7 +28,7 @@ jest.mock('react-router-dom', () => ({
 describe('Creation Successful Onboarding View', () => {
   const mockStore = {
     metamask: {
-      provider: {
+      providerConfig: {
         type: 'test',
       },
     },

--- a/ui/pages/onboarding-flow/pin-extension/pin-extension.test.js
+++ b/ui/pages/onboarding-flow/pin-extension/pin-extension.test.js
@@ -16,7 +16,7 @@ const completeOnboardingStub = jest
 describe('Creation Successful Onboarding View', () => {
   const mockStore = {
     metamask: {
-      provider: {
+      providerConfig: {
         type: 'test',
       },
     },

--- a/ui/pages/onboarding-flow/privacy-settings/privacy-settings.test.js
+++ b/ui/pages/onboarding-flow/privacy-settings/privacy-settings.test.js
@@ -12,7 +12,7 @@ describe('Privacy Settings Onboarding View', () => {
   const mockStore = {
     metamask: {
       networkConfigurations: {},
-      provider: {
+      providerConfig: {
         type: 'test',
       },
     },

--- a/ui/pages/onboarding-flow/secure-your-wallet/secure-your-wallet.test.js
+++ b/ui/pages/onboarding-flow/secure-your-wallet/secure-your-wallet.test.js
@@ -24,7 +24,7 @@ describe('Secure Your Wallet Onboarding View', () => {
 
   const mockStore = {
     metamask: {
-      provider: {
+      providerConfig: {
         type: 'test',
       },
     },

--- a/ui/pages/send/send.test.js
+++ b/ui/pages/send/send.test.js
@@ -93,7 +93,7 @@ const baseStore = {
       useNativeCurrencyAsPrimaryCurrency: false,
     },
     currentCurrency: 'USD',
-    provider: {
+    providerConfig: {
       chainId: CHAIN_IDS.GOERLI,
     },
     nativeCurrency: 'ETH',

--- a/ui/pages/settings/contact-list-tab/add-contact/add-contact.test.js
+++ b/ui/pages/settings/contact-list-tab/add-contact/add-contact.test.js
@@ -10,7 +10,7 @@ describe('AddContact component', () => {
   const middleware = [thunk];
   const state = {
     metamask: {
-      provider: {
+      providerConfig: {
         type: 'mainnet',
         nickname: '',
       },

--- a/ui/pages/settings/contact-list-tab/edit-contact/edit-contact.test.js
+++ b/ui/pages/settings/contact-list-tab/edit-contact/edit-contact.test.js
@@ -10,7 +10,7 @@ describe('AddContact component', () => {
   const middleware = [thunk];
   const state = {
     metamask: {
-      provider: {
+      providerConfig: {
         type: 'mainnet',
         nickname: '',
       },

--- a/ui/pages/settings/networks-tab/networks-list-item/networks-list-item.test.js
+++ b/ui/pages/settings/networks-tab/networks-list-item/networks-list-item.test.js
@@ -6,7 +6,7 @@ import NetworksListItem from '.';
 
 const mockState = {
   metamask: {
-    provider: {
+    providerConfig: {
       chainId: '0x5',
       nickname: '',
       rpcPrefs: {},

--- a/ui/pages/settings/networks-tab/networks-list/networks-list.test.js
+++ b/ui/pages/settings/networks-tab/networks-list/networks-list.test.js
@@ -6,7 +6,7 @@ import NetworksList from '.';
 
 const mockState = {
   metamask: {
-    provider: {
+    providerConfig: {
       chainId: '0x5',
       nickname: '',
       rpcPrefs: {},

--- a/ui/pages/settings/networks-tab/networks-tab-content/networks-tab-content.test.js
+++ b/ui/pages/settings/networks-tab/networks-tab-content/networks-tab-content.test.js
@@ -7,7 +7,7 @@ import NetworksTabContent from '.';
 
 const mockState = {
   metamask: {
-    provider: {
+    providerConfig: {
       chainId: '0x539',
       nickname: '',
       rpcPrefs: {},

--- a/ui/pages/settings/networks-tab/networks-tab-subheader/networks-tab-subheader.test.js
+++ b/ui/pages/settings/networks-tab/networks-tab-subheader/networks-tab-subheader.test.js
@@ -6,7 +6,7 @@ import NetworksTabSubheader from '.';
 
 const mockState = {
   metamask: {
-    provider: {
+    providerConfig: {
       chainId: '0x539',
       nickname: '',
       rpcPrefs: {},

--- a/ui/pages/settings/networks-tab/networks-tab.test.js
+++ b/ui/pages/settings/networks-tab/networks-tab.test.js
@@ -5,7 +5,7 @@ import NetworksTab from '.';
 
 const mockState = {
   metamask: {
-    provider: {
+    providerConfig: {
       chainId: '0x539',
       nickname: '',
       rpcPrefs: {},

--- a/ui/pages/swaps/view-quote/view-quote-price-difference.test.js
+++ b/ui/pages/swaps/view-quote/view-quote-price-difference.test.js
@@ -9,7 +9,7 @@ describe('View Price Quote Difference', () => {
   const mockState = {
     metamask: {
       tokens: [],
-      provider: { type: NETWORK_TYPES.RPC, nickname: '', rpcUrl: '' },
+      providerConfig: { type: NETWORK_TYPES.RPC, nickname: '', rpcUrl: '' },
       preferences: { showFiatInTestnets: true },
       currentCurrency: 'usd',
       conversionRate: 600.0,

--- a/ui/pages/token-allowance/token-allowance.test.js
+++ b/ui/pages/token-allowance/token-allowance.test.js
@@ -39,7 +39,7 @@ const state = {
         name: 'Address Book Account 1',
       },
     ],
-    provider: {
+    providerConfig: {
       type: 'mainnet',
       nickname: '',
     },

--- a/ui/pages/token-details/token-details-page.test.js
+++ b/ui/pages/token-details/token-details-page.test.js
@@ -209,7 +209,7 @@ const state = {
         symbol: 'UMA',
       },
     },
-    provider: {
+    providerConfig: {
       type: 'mainnet',
       nickname: '',
     },

--- a/ui/selectors/confirm-transaction.test.js
+++ b/ui/selectors/confirm-transaction.test.js
@@ -32,7 +32,7 @@ describe('Confirm Transaction Selector', () => {
         unapprovedPersonalMsgCount: 1,
         unapprovedTypedMessagesCount: 1,
         networkId: '5',
-        provider: {
+        providerConfig: {
           chainId: '0x5',
         },
       },

--- a/ui/selectors/institutional/selectors.test.js
+++ b/ui/selectors/institutional/selectors.test.js
@@ -14,7 +14,7 @@ import {
 describe('Institutional selectors', () => {
   const state = {
     metamask: {
-      provider: {
+      providerConfig: {
         type: 'test',
         chainId: '1',
       },

--- a/ui/selectors/nonce-sorted-transactions-selector.test.js
+++ b/ui/selectors/nonce-sorted-transactions-selector.test.js
@@ -74,7 +74,7 @@ const getStateTree = ({
   unapprovedMsgs = [],
 } = {}) => ({
   metamask: {
-    provider: {
+    providerConfig: {
       nickname: 'mainnet',
       chainId: CHAIN_IDS.MAINNET,
     },

--- a/ui/selectors/permissions.test.js
+++ b/ui/selectors/permissions.test.js
@@ -149,7 +149,7 @@ describe('selectors', () => {
         url: 'https://remix.ethereum.org/',
       },
       metamask: {
-        provider: {
+        providerConfig: {
           chainId: CHAIN_IDS.GOERLI,
         },
         accounts: {

--- a/ui/selectors/selectors.test.js
+++ b/ui/selectors/selectors.test.js
@@ -35,16 +35,18 @@ describe('Selectors', () => {
   });
 
   describe('#getRpcPrefsForCurrentProvider', () => {
-    it('returns an empty object if state.metamask.provider is empty', () => {
+    it('returns an empty object if state.metamask.providerConfig is empty', () => {
       expect(
-        selectors.getRpcPrefsForCurrentProvider({ metamask: { provider: {} } }),
+        selectors.getRpcPrefsForCurrentProvider({
+          metamask: { providerConfig: {} },
+        }),
       ).toStrictEqual({});
     });
-    it('returns rpcPrefs from the provider', () => {
+    it('returns rpcPrefs from the providerConfig', () => {
       expect(
         selectors.getRpcPrefsForCurrentProvider({
           metamask: {
-            provider: {
+            providerConfig: {
               rpcPrefs: { blockExplorerUrl: 'https://test-block-explorer' },
             },
           },
@@ -440,17 +442,17 @@ describe('Selectors', () => {
   });
 
   it('#getIsBridgeChain', () => {
-    mockState.metamask.provider.chainId = '0xa';
+    mockState.metamask.providerConfig.chainId = '0xa';
     const isOptimismSupported = selectors.getIsBridgeChain(mockState);
     expect(isOptimismSupported).toBeTruthy();
 
-    mockState.metamask.provider.chainId = '0xfa';
+    mockState.metamask.providerConfig.chainId = '0xfa';
     const isFantomSupported = selectors.getIsBridgeChain(mockState);
     expect(isFantomSupported).toBeFalsy();
   });
 
   it('#getIsBridgeToken', () => {
-    mockState.metamask.provider.chainId = '0xa';
+    mockState.metamask.providerConfig.chainId = '0xa';
     const isOptimismTokenSupported = selectors.getIsBridgeToken(
       '0x94B008aa00579c1307b0ef2c499ad98a8ce58e58',
     )(mockState);
@@ -461,7 +463,7 @@ describe('Selectors', () => {
     )(mockState);
     expect(isOptimismUnknownTokenSupported).toBeFalsy();
 
-    mockState.metamask.provider.chainId = '0xfa';
+    mockState.metamask.providerConfig.chainId = '0xfa';
     const isFantomTokenSupported = selectors.getIsBridgeToken(
       '0x94B008aa00579c1307b0ef2c499ad98a8ce58e58',
     )(mockState);

--- a/ui/selectors/transactions.test.js
+++ b/ui/selectors/transactions.test.js
@@ -29,7 +29,7 @@ describe('Transaction Selectors', () => {
           unapprovedMsgs: {
             1: msg,
           },
-          provider: {
+          providerConfig: {
             chainId: '0x5',
           },
         },
@@ -59,7 +59,7 @@ describe('Transaction Selectors', () => {
           unapprovedPersonalMsgs: {
             1: msg,
           },
-          provider: {
+          providerConfig: {
             chainId: '0x5',
           },
         },
@@ -90,7 +90,7 @@ describe('Transaction Selectors', () => {
           unapprovedTypedMessages: {
             1: msg,
           },
-          provider: {
+          providerConfig: {
             chainId: '0x5',
           },
         },
@@ -107,7 +107,7 @@ describe('Transaction Selectors', () => {
     it('selects the currentNetworkTxList', () => {
       const state = {
         metamask: {
-          provider: {
+          providerConfig: {
             nickname: 'mainnet',
             chainId: CHAIN_IDS.MAINNET,
           },
@@ -171,7 +171,7 @@ describe('Transaction Selectors', () => {
 
       const state = {
         metamask: {
-          provider: {
+          providerConfig: {
             nickname: 'mainnet',
             chainId: CHAIN_IDS.MAINNET,
           },
@@ -255,7 +255,7 @@ describe('Transaction Selectors', () => {
 
     const state = {
       metamask: {
-        provider: {
+        providerConfig: {
           nickname: 'mainnet',
           chainId: CHAIN_IDS.MAINNET,
         },

--- a/ui/store/actions.test.js
+++ b/ui/store/actions.test.js
@@ -16,7 +16,7 @@ const defaultState = {
   metamask: {
     currentLocale: 'test',
     selectedAddress: '0xFirstAddress',
-    provider: { chainId: '0x1' },
+    providerConfig: { chainId: '0x1' },
     accounts: {
       '0xFirstAddress': {
         balance: '0x0',
@@ -231,7 +231,7 @@ describe('Actions', () => {
         cb(null, {
           currentLocale: 'test',
           selectedAddress: '0xAnotherAddress',
-          provider: {
+          providerConfig: {
             chainId: '0x1',
           },
           accounts: {
@@ -2038,7 +2038,7 @@ describe('Actions', () => {
           cb(null, {
             currentLocale: 'test',
             selectedAddress: '0xFirstAddress',
-            provider: {
+            providerConfig: {
               chainId: '0x1',
             },
             accounts: {
@@ -2084,7 +2084,7 @@ describe('Actions', () => {
           cb(null, {
             currentLocale: 'test',
             selectedAddress: '0xFirstAddress',
-            provider: {
+            providerConfig: {
               chainId: '0x1',
             },
             accounts: {

--- a/ui/store/actions.ts
+++ b/ui/store/actions.ts
@@ -1776,7 +1776,7 @@ export function updateMetamaskState(
     const {
       currentLocale: newLocale,
       selectedAddress: newSelectedAddress,
-      provider: newProviderConfig,
+      providerConfig: newProviderConfig,
     } = newState;
 
     if (currentLocale && newLocale && currentLocale !== newLocale) {

--- a/ui/store/institutional/institution-actions.test.js
+++ b/ui/store/institutional/institution-actions.test.js
@@ -15,7 +15,7 @@ const defaultState = {
   metamask: {
     currentLocale: 'test',
     selectedAddress: '0xFirstAddress',
-    provider: { chainId: '0x1' },
+    providerConfig: { chainId: '0x1' },
     accounts: {
       '0xFirstAddress': {
         balance: '0x0',
@@ -199,7 +199,7 @@ describe('#updateCustodyState', () => {
     _setBackgroundConnection(background.getApi());
 
     const newState = {
-      provider: {
+      providerConfig: {
         nickname: 'mainnet',
         chainId: '0x1',
       },
@@ -225,7 +225,7 @@ describe('#updateCustodyState', () => {
     _setBackgroundConnection(background.getApi());
 
     const newState = {
-      provider: {
+      providerConfig: {
         nickname: 'mainnet',
         chainId: '0x1',
       },
@@ -280,7 +280,7 @@ describe('#updateCustodyState', () => {
     _setBackgroundConnection(background.getApi());
 
     const newState = {
-      provider: {
+      providerConfig: {
         nickname: 'mainnet',
         chainId: '0x1',
       },

--- a/ui/store/store.ts
+++ b/ui/store/store.ts
@@ -48,7 +48,7 @@ interface TemporaryBackgroundState {
       name: string;
     }[];
   };
-  provider: {
+  providerConfig: {
     chainId: string;
   };
   currentNetworkTxList: TransactionMeta[];


### PR DESCRIPTION
## Explanation

The network controller `provider` state has been renamed to  `providerConfig`. This better reflects what this state is, and makes this controller more closely aligned with the core network controller.

All references to the provider configuration have been updated to prefer `providerConfig` over `provider`, to make the distinction clear between a provider and provider config.

Closes https://github.com/MetaMask/metamask-extension/issues/18902

## Manual Testing Steps

No functional changes

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
