### PR TITLE
Adding deprecation notice to old Button component

### DIFF
--- a/ui/components/ui/button/button.component.js
+++ b/ui/components/ui/button/button.component.js
@@ -22,6 +22,16 @@ const typeHash = {
   raised: CLASSNAME_RAISED,
 };
 
+/**
+ * @deprecated The <Button /> component has been deprecated in favor of the new <Button> component from the component-library.
+ * Please update your code to use the new <Button> component instead, which can be found at ./ui/components/component-library/button/button.js.
+ * You can find documentation for the new Button component in the MetaMask Storybook:
+ * {@link https://metamask.github.io/metamask-storybook/?path=/docs/components-componentlibrary-button--default-story#button}
+ * If you would like to help with the replacement of the old Button component, please submit a pull request against this GitHub issue:
+ * {@link https://github.com/MetaMask/metamask-extension/issues/18896}
+ * @see {@link https://metamask.github.io/metamask-storybook/?path=/docs/components-componentlibrary-button--default-story#button}
+ */
+
 const Button = ({
   type,
   submit = false,

--- a/ui/components/ui/button/button.stories.js
+++ b/ui/components/ui/button/button.stories.js
@@ -1,5 +1,8 @@
 import React from 'react';
 
+import { SEVERITIES } from '../../../helpers/constants/design-system';
+import { BannerAlert } from '../../component-library';
+
 import IconTokenSearch from '../icon/icon-token-search';
 
 import README from './README.mdx';
@@ -7,7 +10,6 @@ import Button from '.';
 
 export default {
   title: 'Components/UI/Button',
-
   component: Button,
   parameters: {
     docs: {
@@ -56,7 +58,19 @@ export default {
 };
 
 export const DefaultStory = (args) => (
-  <Button {...args}>{args.children}</Button>
+  <>
+    <BannerAlert
+      marginBottom={4}
+      severity={SEVERITIES.WARNING}
+      title="Deprecated"
+      description="This version of Button has been deprecated in favour of the component-library version. Contribute to replacing old Button with new Button by submitting a PR against #18896"
+      actionButtonLabel="See details"
+      actionButtonProps={{
+        href: 'https://github.com/MetaMask/metamask-extension/issues/18896',
+      }}
+    />
+    <Button {...args}>{args.children}</Button>
+  </>
 );
 
 DefaultStory.storyName = 'Default';

--- a/ui/components/ui/button/button.stories.js
+++ b/ui/components/ui/button/button.stories.js
@@ -63,7 +63,7 @@ export const DefaultStory = (args) => (
       marginBottom={4}
       severity={SEVERITIES.WARNING}
       title="Deprecated"
-      description="This version of Button has been deprecated in favour of the component-library version. Contribute to replacing old Button with new Button by submitting a PR against #18896"
+      description="This version of Button has been deprecated in favor of the component-library version. Contribute to replacing old Button with new Button by submitting a PR"
       actionButtonLabel="See details"
       actionButtonProps={{
         href: 'https://github.com/MetaMask/metamask-extension/issues/18896',

--- a/ui/components/ui/button/button.stories.js
+++ b/ui/components/ui/button/button.stories.js
@@ -63,7 +63,7 @@ export const DefaultStory = (args) => (
       marginBottom={4}
       severity={SEVERITIES.WARNING}
       title="Deprecated"
-      description="This version of Button has been deprecated in favor of the component-library version. Contribute to replacing old Button with new Button by submitting a PR"
+      description="This version of Button has been deprecated in favor of the component-library version. Contribute to replacing old Button with new Button by submitting a PR to metamask-extension."
       actionButtonLabel="See details"
       actionButtonProps={{
         href: 'https://github.com/MetaMask/metamask-extension/issues/18896',


### PR DESCRIPTION
## Explanation
Currently there are 2 versions of the `Button` component in the extension without any indication of which to use. This PR adds a deprecations notice to the old version of the button so engineers are aware that it has been deprecated in favour of the component-library version

* Fixes #18716 

## Screenshots/Screencaps

<!-- If you're making a change to the UI, make sure to capture a screenshot or a short video showing off your work! -->

### Before

<img width="1434" alt="Screenshot 2023-05-02 at 9 38 10 AM" src="https://user-images.githubusercontent.com/8112138/235553059-fb81fff9-f86e-4030-a996-e691f8f3f448.png">

### After

<img width="1440" alt="Screenshot 2023-05-02 at 11 12 22 AM" src="https://user-images.githubusercontent.com/8112138/235562051-013d7284-ae4c-4e10-8a18-73f4fa80cc89.png">

<img width="661" alt="Screenshot 2023-05-02 at 9 39 34 AM" src="https://user-images.githubusercontent.com/8112138/235553090-36440527-3eea-45aa-9d75-21eb8e603a49.png">

## Manual Testing Steps

- Pull this branch and check any imports of the old Button component. Search: `../ui/button'`
- Hover over the instance to see deprecations message as well as deprecation indicator if VS code has those settings enabled.

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [x] PR is linked to the appropriate GitHub issue
- [x] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
