### PR TITLE
Improving code formatting in component-library readme

### DIFF
--- a/ui/components/component-library/README.md
+++ b/ui/components/component-library/README.md
@@ -10,22 +10,22 @@ All components are built on top of the `Box` component and accept all `Box` [com
 
 `component-library` components accept all utility props for layout
 
-```
-import { Text } from '../../component-library'
+```jsx
+import { Text } from '../../component-library';
 
-<Text marginBottom={4}>This text has a margin-bottom of 16px</Text>
+<Text marginBottom={4}>This text has a margin-bottom of 16px</Text>;
 ```
 
 #### Polymorphic `as` prop
 
 `component-library` components accept a polymorphic as prop to change the root html element of a component
 
-```
-import { Text } from '../../component-library'
+```jsx
+import { Text } from '../../component-library';
 
 <ul>
-<Text as="li">This renders as list item html element</Text>
-</ul>
+  <Text as="li">This renders as list item html element</Text>
+</ul>;
 ```
 
 ## TypeScript


### PR DESCRIPTION
## Explanation
Small fix to code example formatting in the component-library readme

## Screenshots/Screencaps

### Before

<img width="1440" alt="Screenshot 2023-05-02 at 2 20 19 PM" src="https://user-images.githubusercontent.com/8112138/235585029-3752d4ae-13e8-486a-9db2-2dc3d4a21419.png">

### After

<img width="1440" alt="Screenshot 2023-05-02 at 2 19 30 PM" src="https://user-images.githubusercontent.com/8112138/235585061-db88157f-e9a5-416e-bdc3-84693bc1eaba.png">

## Manual Testing Steps

- Go to the storybook build in this PR
- Check the Introduction readme in the component-library
- See improved code example formatting

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
