### PR TITLE
UX: Multichain: Ensure network picker renders properly for long and short names

### DIFF
--- a/ui/components/multichain/app-header/__snapshots__/app-header.test.js.snap
+++ b/ui/components/multichain/app-header/__snapshots__/app-header.test.js.snap
@@ -8,12 +8,9 @@ exports[`App Header should match snapshot 1`] = `
     <div
       class="box multichain-app-header__lock-contents box--padding-2 box--display-flex box--gap-2 box--flex-direction-row box--justify-content-space-between box--align-items-center box--width-full box--background-color-background-default"
     >
-      <div
-        class="box multichain-app-header__contents__network-container box--display-flex box--flex-direction-row"
-      >
+      <div>
         <button
           class="box mm-picker-network multichain-app-header__contents__network-picker box--padding-right-4 box--padding-left-2 box--display-flex box--gap-2 box--flex-direction-row box--align-items-center box--background-color-background-alternative box--rounded-pill"
-          style="max-width: 100%;"
         >
           <div
             class="box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-network mm-picker-network__avatar-network mm-text--body-xs mm-text--text-transform-uppercase box--display-flex box--flex-direction-row box--justify-content-center box--align-items-center box--color-text-default box--background-color-background-alternative box--rounded-full box--border-color-transparent box--border-style-solid box--border-width-1"

--- a/ui/components/multichain/app-header/__snapshots__/app-header.test.js.snap
+++ b/ui/components/multichain/app-header/__snapshots__/app-header.test.js.snap
@@ -8,24 +8,29 @@ exports[`App Header should match snapshot 1`] = `
     <div
       class="box multichain-app-header__lock-contents box--padding-2 box--display-flex box--gap-2 box--flex-direction-row box--justify-content-space-between box--align-items-center box--width-full box--background-color-background-default"
     >
-      <button
-        class="box mm-picker-network multichain-app-header__contents__network-picker box--padding-right-4 box--padding-left-2 box--display-flex box--gap-2 box--flex-direction-row box--align-items-center box--background-color-background-alternative box--rounded-pill"
+      <div
+        class="box multichain-app-header__contents__network-container box--display-flex box--flex-direction-row"
       >
-        <div
-          class="box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-network mm-picker-network__avatar-network mm-text--body-xs mm-text--text-transform-uppercase box--display-flex box--flex-direction-row box--justify-content-center box--align-items-center box--color-text-default box--background-color-background-alternative box--rounded-full box--border-color-transparent box--border-style-solid box--border-width-1"
+        <button
+          class="box mm-picker-network multichain-app-header__contents__network-picker box--padding-right-4 box--padding-left-2 box--display-flex box--gap-2 box--flex-direction-row box--align-items-center box--background-color-background-alternative box--rounded-pill"
+          style="max-width: 100%;"
         >
-          G
-        </div>
-        <p
-          class="box mm-text mm-text--body-sm mm-text--ellipsis box--flex-direction-row box--color-text-default"
-        >
-          Goerli
-        </p>
-        <span
-          class="box mm-picker-network__arrow-down-icon mm-icon mm-icon--size-xs box--display-inline-block box--flex-direction-row box--color-icon-default"
-          style="mask-image: url('./images/icons/arrow-down.svg');"
-        />
-      </button>
+          <div
+            class="box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-network mm-picker-network__avatar-network mm-text--body-xs mm-text--text-transform-uppercase box--display-flex box--flex-direction-row box--justify-content-center box--align-items-center box--color-text-default box--background-color-background-alternative box--rounded-full box--border-color-transparent box--border-style-solid box--border-width-1"
+          >
+            G
+          </div>
+          <p
+            class="box mm-text mm-text--body-sm mm-text--ellipsis box--flex-direction-row box--color-text-default"
+          >
+            Goerli
+          </p>
+          <span
+            class="box mm-picker-network__arrow-down-icon mm-icon mm-icon--size-xs box--display-inline-block box--flex-direction-row box--color-icon-default"
+            style="mask-image: url('./images/icons/arrow-down.svg');"
+          />
+        </button>
+      </div>
       <div
         class="app-header__logo-container app-header__logo-container--clickable"
         data-testid="app-header-logo"

--- a/ui/components/multichain/app-header/app-header.js
+++ b/ui/components/multichain/app-header/app-header.js
@@ -170,7 +170,6 @@ export const AppHeader = ({ onClick }) => {
                     onClick={networkOpenCallback}
                     display={[DISPLAY.NONE, DISPLAY.FLEX]} // show on desktop hide on popover
                     className="multichain-app-header__contents__network-picker"
-                    style={{ maxWidth: '100%' }}
                   />
                 </div>
               )}

--- a/ui/components/multichain/app-header/app-header.js
+++ b/ui/components/multichain/app-header/app-header.js
@@ -329,7 +329,7 @@ export const AppHeader = ({ onClick }) => {
                     onClick={() => dispatch(toggleNetworkMenu())}
                     className="multichain-app-header__contents__network-picker"
                   />
-                </Box>
+                </div>
               )}
               <MetafoxLogo
                 unsetIconHeight

--- a/ui/components/multichain/app-header/app-header.js
+++ b/ui/components/multichain/app-header/app-header.js
@@ -161,13 +161,19 @@ export const AppHeader = ({ onClick }) => {
                 onClick={networkOpenCallback}
                 display={[DISPLAY.FLEX, DISPLAY.NONE]} // show on popover hide on desktop
               />
-              <PickerNetwork
-                label={currentNetwork?.nickname}
-                src={currentNetwork?.rpcPrefs?.imageUrl}
-                onClick={networkOpenCallback}
-                display={[DISPLAY.NONE, DISPLAY.FLEX]} // show on desktop hide on popover
-                className="multichain-app-header__contents__network-picker"
-              />
+              {popupStatus ? null : (
+                <div>
+                  <PickerNetwork
+                    margin={2}
+                    label={currentNetwork?.nickname}
+                    src={currentNetwork?.rpcPrefs?.imageUrl}
+                    onClick={networkOpenCallback}
+                    display={[DISPLAY.NONE, DISPLAY.FLEX]} // show on desktop hide on popover
+                    className="multichain-app-header__contents__network-picker"
+                    style={{ maxWidth: '100%' }}
+                  />
+                </div>
+              )}
               {showProductTour &&
               popupStatus &&
               multichainProductTourStep === 1 ? (
@@ -316,12 +322,20 @@ export const AppHeader = ({ onClick }) => {
               padding={2}
               gap={2}
             >
-              <PickerNetwork
-                label={currentNetwork?.nickname}
-                src={currentNetwork?.rpcPrefs?.imageUrl}
-                onClick={() => dispatch(toggleNetworkMenu())}
-                className="multichain-app-header__contents__network-picker"
-              />
+              {popupStatus ? null : (
+                <Box
+                  display={DISPLAY.FLEX}
+                  className="multichain-app-header__contents__network-container"
+                >
+                  <PickerNetwork
+                    label={currentNetwork?.nickname}
+                    src={currentNetwork?.rpcPrefs?.imageUrl}
+                    onClick={() => dispatch(toggleNetworkMenu())}
+                    className="multichain-app-header__contents__network-picker"
+                    style={{ maxWidth: '100%' }}
+                  />
+                </Box>
+              )}
               <MetafoxLogo
                 unsetIconHeight
                 onClick={async () => {

--- a/ui/components/multichain/app-header/app-header.js
+++ b/ui/components/multichain/app-header/app-header.js
@@ -322,10 +322,7 @@ export const AppHeader = ({ onClick }) => {
               gap={2}
             >
               {popupStatus ? null : (
-                <Box
-                  display={DISPLAY.FLEX}
-                  className="multichain-app-header__contents__network-container"
-                >
+                <div>
                   <PickerNetwork
                     label={currentNetwork?.nickname}
                     src={currentNetwork?.rpcPrefs?.imageUrl}

--- a/ui/components/multichain/app-header/app-header.js
+++ b/ui/components/multichain/app-header/app-header.js
@@ -328,7 +328,6 @@ export const AppHeader = ({ onClick }) => {
                     src={currentNetwork?.rpcPrefs?.imageUrl}
                     onClick={() => dispatch(toggleNetworkMenu())}
                     className="multichain-app-header__contents__network-picker"
-                    style={{ maxWidth: '100%' }}
                   />
                 </Box>
               )}

--- a/ui/components/multichain/app-header/app-header.scss
+++ b/ui/components/multichain/app-header/app-header.scss
@@ -30,7 +30,7 @@
     }
 
     &__network-picker {
-      max-width: 100%;
+      max-width: 250px;
     }
 
     &--avatar-network {

--- a/ui/components/multichain/app-header/app-header.scss
+++ b/ui/components/multichain/app-header/app-header.scss
@@ -29,10 +29,6 @@
       width: $width-screen-lg-min;
     }
 
-    &__network-container {
-      max-width: 250px;
-    }
-
     &__network-picker {
       max-width: 100%;
     }

--- a/ui/components/multichain/app-header/app-header.scss
+++ b/ui/components/multichain/app-header/app-header.scss
@@ -29,8 +29,12 @@
       width: $width-screen-lg-min;
     }
 
+    &__network-container {
+      max-width: 250px;
+    }
+
     &__network-picker {
-      max-width: 200px;
+      max-width: 100%;
     }
 
     &--avatar-network {


### PR DESCRIPTION
## Explanation

My previous PR to enforce a maximum network name with ellipsis worked well for long network names but not for short.  This was the side effect with short network names:

<img width="245" alt="SCR-20230502-mduz" src="https://user-images.githubusercontent.com/46655/235812897-e483ac27-7cf9-49e4-b06a-f76c2e25a718.png">

Note that `max-width` with `flex` makes the width stretch even when the network name is short.  This PR ensures the PickerNetwork only takes up the space required and ellipsizes once it hits max width.

## Screenshots/Screencaps

<img width="631" alt="SCR-20230502-rbqx" src="https://user-images.githubusercontent.com/46655/235813400-d2a00673-0854-47da-b66a-d9f518bc4506.png">
<img width="672" alt="SCR-20230502-rboo" src="https://user-images.githubusercontent.com/46655/235813401-5f486827-0f00-484e-a637-f1cca2f1191d.png">

## Manual Testing Steps

1.  Add a variety of networks with different lengths
2. View in full screen
3. View in popup

## Pre-merge author checklist

- [ ] I've clearly explained:
  - [ ] What problem this PR is solving
  - [ ] How this problem was solved
  - [ ] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
