### PR TITLE
Fixing broken responsive box background color prop and color fix

### DIFF
--- a/ui/components/ui/box/box.scss
+++ b/ui/components/ui/box/box.scss
@@ -376,7 +376,7 @@ $attributesToApplyExtraProperties: margin;
   @each $breakpoint, $min-width in $screen-sizes-map {
     @each $variant, $color in design-system.$color-map {
       @media screen and (min-width: $min-width) {
-        &--#{$breakpoint}\background-color-#{$variant} {
+        &--#{$breakpoint}\:background-color-#{$variant} {
           background-color: var($color);
         }
       }

--- a/ui/components/ui/box/box.stories.tsx
+++ b/ui/components/ui/box/box.stories.tsx
@@ -606,21 +606,30 @@ export const ResponsiveProps = () => {
       >
         <Box
           padding={[4, 8]}
-          backgroundColor={BackgroundColor.backgroundAlternative}
+          backgroundColor={[
+            BackgroundColor.backgroundAlternative,
+            BackgroundColor.primaryMuted,
+          ]}
           borderColor={BorderColor.borderMuted}
         >
           responsive
         </Box>
         <Box
           padding={[4, 8]}
-          backgroundColor={BackgroundColor.backgroundAlternative}
+          backgroundColor={[
+            BackgroundColor.backgroundAlternative,
+            BackgroundColor.primaryMuted,
+          ]}
           borderColor={BorderColor.borderMuted}
         >
           props
         </Box>
         <Box
           padding={[4, 8]}
-          backgroundColor={BackgroundColor.backgroundAlternative}
+          backgroundColor={[
+            BackgroundColor.backgroundAlternative,
+            BackgroundColor.primaryMuted,
+          ]}
           borderColor={BorderColor.borderMuted}
         >
           example
@@ -633,7 +642,10 @@ export const ResponsiveProps = () => {
             BorderRadius.MD,
             BorderRadius.LG,
           ]}
-          backgroundColor={BackgroundColor.backgroundAlternative}
+          backgroundColor={[
+            BackgroundColor.backgroundAlternative,
+            BackgroundColor.primaryMuted,
+          ]}
           borderColor={BorderColor.borderMuted}
         >
           Responsive Border Radius 1
@@ -646,7 +658,10 @@ export const ResponsiveProps = () => {
             BorderRadius.none,
             BorderRadius.full,
           ]}
-          backgroundColor={BackgroundColor.backgroundAlternative}
+          backgroundColor={[
+            BackgroundColor.backgroundAlternative,
+            BackgroundColor.primaryMuted,
+          ]}
           borderColor={BorderColor.borderMuted}
         >
           Responsive Border Radius 2

--- a/ui/helpers/constants/design-system.ts
+++ b/ui/helpers/constants/design-system.ts
@@ -63,7 +63,7 @@ export enum BackgroundColor {
   primaryAlternative = 'primary-alternative',
   primaryMuted = 'primary-muted',
   errorDefault = 'error-default',
-  errorAlternative = 'error-Alternative',
+  errorAlternative = 'error-alternative',
   errorMuted = 'error-muted',
   warningDefault = 'warning-default',
   warningAlternative = 'warning-alternative',


### PR DESCRIPTION
## Explanation
Background color responsive prop had a syntax error that was preventing it from working. This PR fixes that syntax as well as another incorrect color and adds a story to show the props working

## Screenshots/Screencaps

### After

https://user-images.githubusercontent.com/8112138/235827998-c8fe6779-bd88-4f0e-bcce-b9d2b7233f00.mov

## Manual Testing Steps
- Go to the latest build of storybook in this PR
- Find the `Box` component and check the Responsive Props story to see the background color change working

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
