### PR TITLE
[MMI] Don't group transactions by nonce if they are custodial Tx

### DIFF
--- a/ui/selectors/transactions.js
+++ b/ui/selectors/transactions.js
@@ -251,7 +251,16 @@ export const nonceSortedTransactionsSelector = createSelector(
         txReceipt,
       } = transaction;
 
-      if (typeof nonce === 'undefined' || type === TransactionType.incoming) {
+      let undefinedNonceOrIncomingTransaction =
+        typeof nonce === 'undefined' || type === TransactionType.incoming;
+
+      ///: BEGIN:ONLY_INCLUDE_IN(build-mmi)
+      // Don't group transactions by nonce if they are custodial TXes
+      undefinedNonceOrIncomingTransaction =
+        undefinedNonceOrIncomingTransaction || transaction.custodyId;
+      ///: END:ONLY_INCLUDE_IN
+
+      if (undefinedNonceOrIncomingTransaction) {
         const transactionGroup = {
           transactions: [transaction],
           initialTransaction: transaction,

--- a/ui/selectors/transactions.js
+++ b/ui/selectors/transactions.js
@@ -251,16 +251,19 @@ export const nonceSortedTransactionsSelector = createSelector(
         txReceipt,
       } = transaction;
 
-      let undefinedNonceOrIncomingTransaction =
+      // Don't group transactions by nonce if:
+      // 1. Tx nonce is undefined
+      // 2. Tx is incoming (deposit)
+      // 3. Tx is custodial (mmi specific)
+      let shouldNotBeGrouped =
         typeof nonce === 'undefined' || type === TransactionType.incoming;
 
       ///: BEGIN:ONLY_INCLUDE_IN(build-mmi)
-      // Don't group transactions by nonce if they are custodial TXes
-      undefinedNonceOrIncomingTransaction =
-        undefinedNonceOrIncomingTransaction || transaction.custodyId;
+      shouldNotBeGrouped =
+        shouldNotBeGrouped || Boolean(transaction.custodyId);
       ///: END:ONLY_INCLUDE_IN
 
-      if (undefinedNonceOrIncomingTransaction) {
+      if (shouldNotBeGrouped) {
         const transactionGroup = {
           transactions: [transaction],
           initialTransaction: transaction,

--- a/ui/selectors/transactions.js
+++ b/ui/selectors/transactions.js
@@ -259,8 +259,7 @@ export const nonceSortedTransactionsSelector = createSelector(
         typeof nonce === 'undefined' || type === TransactionType.incoming;
 
       ///: BEGIN:ONLY_INCLUDE_IN(build-mmi)
-      shouldNotBeGrouped =
-        shouldNotBeGrouped || Boolean(transaction.custodyId);
+      shouldNotBeGrouped = shouldNotBeGrouped || Boolean(transaction.custodyId);
       ///: END:ONLY_INCLUDE_IN
 
       if (shouldNotBeGrouped) {


### PR DESCRIPTION
## Explanation

This PR adds a small code fence (where it checks if the `transaction` has a `custodyId`), so that we don't have custodial transactions grouped by nonce in MMI.

## Pre-merge author checklist

- [X] I've clearly explained:
  - [X] What problem this PR is solving
  - [X] How this problem was solved

## Pre-merge reviewer checklist

- [X] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [X] PR is linked to the appropriate GitHub issue