### PR TITLE
[MMI] adds custody account route to account routes

### DIFF
--- a/ui/pages/create-account/create-account.component.js
+++ b/ui/pages/create-account/create-account.component.js
@@ -6,7 +6,13 @@ import {
   CONNECT_HARDWARE_ROUTE,
   IMPORT_ACCOUNT_ROUTE,
   NEW_ACCOUNT_ROUTE,
+  ///: BEGIN:ONLY_INCLUDE_IN(build-mmi)
+  CUSTODY_ACCOUNT_ROUTE,
+  ///: END:ONLY_INCLUDE_IN
 } from '../../helpers/constants/routes';
+///: BEGIN:ONLY_INCLUDE_IN(build-mmi)
+import CustodyPage from '../institutional/custody';
+///: END:ONLY_INCLUDE_IN
 import ConnectHardwareForm from './connect-hardware';
 import NewAccountImportForm from './import-account';
 import NewAccountCreateForm from './new-account.container';
@@ -30,6 +36,11 @@ export default function CreateAccountPage() {
           path={CONNECT_HARDWARE_ROUTE}
           component={ConnectHardwareForm}
         />
+        {
+          ///: BEGIN:ONLY_INCLUDE_IN(build-mmi)
+          <Route exact path={CUSTODY_ACCOUNT_ROUTE} component={CustodyPage} />
+          ///: END:ONLY_INCLUDE_IN
+        }
       </Switch>
     </Box>
   );


### PR DESCRIPTION
## Explanation

This PR adds the MMI custody account route to the CreateAccountPage router.

## Pre-merge author checklist

- [X] I've clearly explained:
  - [X] What problem this PR is solving
  - [X] How this problem was solved

## Pre-merge reviewer checklist

- [X] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [X] PR is linked to the appropriate GitHub issue