### PR TITLE
Ensure we can successfully create prod builds with specific types

### DIFF
--- a/development/build/config.js
+++ b/development/build/config.js
@@ -7,15 +7,11 @@ const { loadBuildTypesConfig } = require('../lib/build-type');
 const { Variables } = require('../lib/variables');
 const { ENVIRONMENT } = require('./constants');
 
-const VARIABLES_REQUIRED_IN_PRODUCTION = [
-  'INFURA_BETA_PROJECT_ID',
-  'INFURA_FLASK_PROJECT_ID',
-  'INFURA_PROD_PROJECT_ID',
-  'SEGMENT_BETA_WRITE_KEY',
-  'SEGMENT_FLASK_WRITE_KEY',
-  'SEGMENT_PROD_WRITE_KEY',
-  'SENTRY_DSN',
-];
+const VARIABLES_REQUIRED_IN_PRODUCTION = {
+  main: ['INFURA_PROD_PROJECT_ID', 'SEGMENT_PROD_WRITE_KEY', 'SENTRY_DSN'],
+  beta: ['INFURA_BETA_PROJECT_ID', 'SEGMENT_BETA_WRITE_KEY', 'SENTRY_DSN'],
+  flask: ['INFURA_FLASK_PROJECT_ID', 'SEGMENT_FLASK_WRITE_KEY', 'SENTRY_DSN'],
+};
 
 async function fromIniFile(filepath) {
   let configContents = '';
@@ -137,9 +133,9 @@ async function getConfig(buildType, environment) {
 
   // TODO(ritave): Move build targets and environments to builds.yml
   if (environment === ENVIRONMENT.PRODUCTION) {
-    const undefinedVariables = VARIABLES_REQUIRED_IN_PRODUCTION.filter(
-      (variable) => !variables.isDefined(variable),
-    );
+    const undefinedVariables = VARIABLES_REQUIRED_IN_PRODUCTION[
+      buildType
+    ].filter((variable) => !variables.isDefined(variable));
     if (undefinedVariables.length !== 0) {
       const message = `Some variables required to build production target are not defined.
     - ${undefinedVariables.join('\n  - ')}

--- a/development/build/scripts.js
+++ b/development/build/scripts.js
@@ -125,7 +125,7 @@ function getInfuraProjectId({ buildType, variables, environment, testing }) {
     return variables.get('INFURA_PROJECT_ID');
   }
   /** @type {string|undefined} */
-  const infuraKeyReference = process.env.INFURA_ENV_KEY_REF;
+  const infuraKeyReference = variables.get('INFURA_ENV_KEY_REF');
   assert(
     typeof infuraKeyReference === 'string' && infuraKeyReference.length > 0,
     `Build type "${buildType}" has improperly set INFURA_ENV_KEY_REF in builds.yml. Current value: "${infuraKeyReference}"`,
@@ -154,7 +154,7 @@ function getSegmentWriteKey({ buildType, variables, environment }) {
     return variables.get('SEGMENT_WRITE_KEY');
   }
 
-  const segmentKeyReference = process.env.SEGMENT_WRITE_KEY_REF;
+  const segmentKeyReference = variables.get('SEGMENT_WRITE_KEY_REF');
   assert(
     typeof segmentKeyReference === 'string' && segmentKeyReference.length > 0,
     `Build type "${buildType}" has improperly set SEGMENT_WRITE_KEY_REF in builds.yml. Current value: "${segmentKeyReference}"`,


### PR DESCRIPTION
## Explanation

This PR fixes two bugs that occur when trying to create prod builds with specific types. For example `yarn build --build-type flask prod` currently throws errors (including when it is run with all environment variables appropriately set).

The first is in the `getConfig` function in `development/build/config.js`. For production environments, there is validation that all `VARIABLES_REQUIRED_IN_PRODUCTION` are set. `VARIABLES_REQUIRED_IN_PRODUCTION` includes required variables for all build types (`main`, `flask`, `beta`). However, this validation is per build type. This conflicts with the `build.yml` file which defines environment variables for build type in isolation. So `yarn build --build-type flask prod` will hit the `Some variables required to build production target are not defined.` error because variables specific to the beta and main build types are not set.

The solution to that problem is to only validate the presence of variables needed for the `buildType` passed to `getConfig`

The second problem is in the `getInfuraProjectId` and  `getSegmentWriteKey` functions in `development/build/scripts.js`. These have validation that the `INFURA_ENV_KEY_REF` and `SEGMENT_WRITE_KEY_REF` is defined within environment variables. That validation checks `process.env` for the presence of these properties. But these variables are defined within `builds.yml` and then dynamically added to the instance of the `Variables` class that is created within `getConfig` of  `development/build/config.js` (and not included on `process.env`)

The solution is to use the `get` method of the `variables` class to get the `*_KEY_REF` variables, as is done for `infuraKeyReference` and `segmentKeyReference` within the `getInfuraProjectId` and  `getSegmentWriteKey`. 

(Note: these issues were introduced in https://github.com/MetaMask/metamask-extension/pull/18125)

## Manual Testing Steps

Run `yarn build --build-type flask prod` or `yarn build --build-type beta prod` with appropriate env variables set. A prod build should be successfully built.

## Pre-merge author checklist

- [ ] I've clearly explained:
  - [ ] What problem this PR is solving
  - [ ] How this problem was solved
  - [ ] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
