### PR TITLE
Enable token detection for the Aurora network

### DIFF
--- a/.yarn/patches/@metamask-assets-controllers-npm-6.0.0-0cb763bd07.patch
+++ b/.yarn/patches/@metamask-assets-controllers-npm-6.0.0-0cb763bd07.patch
@@ -1,0 +1,38 @@
+diff --git a/dist/AssetsContractController.js b/dist/AssetsContractController.js
+index 332c87d7cc5687dec4d80ec3c51dcc4bda632c32..1d88cd313efb00c9c9b57f6824ed74bbca6349e3 100644
+--- a/dist/AssetsContractController.js
++++ b/dist/AssetsContractController.js
+@@ -33,6 +33,7 @@ exports.SINGLE_CALL_BALANCES_ADDRESS_BY_CHAINID = {
+     [assetsUtil_1.SupportedTokenDetectionNetworks.bsc]: '0x2352c63A83f9Fd126af8676146721Fa00924d7e4',
+     [assetsUtil_1.SupportedTokenDetectionNetworks.polygon]: '0x2352c63A83f9Fd126af8676146721Fa00924d7e4',
+     [assetsUtil_1.SupportedTokenDetectionNetworks.avax]: '0xD023D153a0DFa485130ECFdE2FAA7e612EF94818',
++    [assetsUtil_1.SupportedTokenDetectionNetworks.aurora]: '0x1286415D333855237f89Df27D388127181448538',
+ };
+ exports.MISSING_PROVIDER_ERROR = 'AssetsContractController failed to set the provider correctly. A provider must be set for this method to be available';
+ /**
+diff --git a/dist/assetsUtil.d.ts b/dist/assetsUtil.d.ts
+index 1b69903a3f8e19f5a451c94791ea16fb18e94d93..d45fe80652fea24d19b2b30dd9af7e6219939153 100644
+--- a/dist/assetsUtil.d.ts
++++ b/dist/assetsUtil.d.ts
+@@ -45,7 +45,8 @@ export declare enum SupportedTokenDetectionNetworks {
+     mainnet = "1",
+     bsc = "56",
+     polygon = "137",
+-    avax = "43114"
++    avax = "43114",
++    aurora = "1313161554"
+ }
+ /**
+  * Check if token detection is enabled for certain networks.
+diff --git a/dist/assetsUtil.js b/dist/assetsUtil.js
+index 4b54e82504cdfae1d937860b0b89b14860385b8e..232228688454d32df818065119dff104f5b0c16c 100644
+--- a/dist/assetsUtil.js
++++ b/dist/assetsUtil.js
+@@ -120,6 +120,7 @@ var SupportedTokenDetectionNetworks;
+     SupportedTokenDetectionNetworks["bsc"] = "56";
+     SupportedTokenDetectionNetworks["polygon"] = "137";
+     SupportedTokenDetectionNetworks["avax"] = "43114";
++    SupportedTokenDetectionNetworks["aurora"] = "1313161554";
+ })(SupportedTokenDetectionNetworks = exports.SupportedTokenDetectionNetworks || (exports.SupportedTokenDetectionNetworks = {}));
+ /**
+  * Check if token detection is enabled for certain networks.

--- a/package.json
+++ b/package.json
@@ -221,7 +221,8 @@
     "@babel/core@>=7.9.0": "patch:@babel/core@npm%3A7.21.5#./.yarn/patches/@babel-core-npm-7.21.5-c72c337956.patch",
     "@babel/core@^7.1.0": "patch:@babel/core@npm%3A7.21.5#./.yarn/patches/@babel-core-npm-7.21.5-c72c337956.patch",
     "@babel/core@^7.12.3": "patch:@babel/core@npm%3A7.21.5#./.yarn/patches/@babel-core-npm-7.21.5-c72c337956.patch",
-    "@babel/core@7.12.9": "patch:@babel/core@npm%3A7.21.5#./.yarn/patches/@babel-core-npm-7.21.5-c72c337956.patch"
+    "@babel/core@7.12.9": "patch:@babel/core@npm%3A7.21.5#./.yarn/patches/@babel-core-npm-7.21.5-c72c337956.patch",
+    "@metamask/assets-controllers@^6.0.0": "patch:@metamask/assets-controllers@npm%3A6.0.0#./.yarn/patches/@metamask-assets-controllers-npm-6.0.0-0cb763bd07.patch"
   },
   "dependencies": {
     "@actions/core": "^1.10.0",

--- a/shared/constants/network.ts
+++ b/shared/constants/network.ts
@@ -203,7 +203,7 @@ export const LOCALHOST_RPC_URL = 'http://localhost:8545';
  */
 export const CURRENCY_SYMBOLS = {
   ARBITRUM: 'ETH',
-  AURORA: 'Aurora ETH',
+  AURORA: 'AURORA ETH',
   AVALANCHE: 'AVAX',
   BNB: 'BNB',
   BUSD: 'BUSD',
@@ -575,7 +575,7 @@ export const FEATURED_RPCS: RPCDefinition[] = [
     chainId: CHAIN_IDS.AURORA,
     nickname: AURORA_DISPLAY_NAME,
     rpcUrl: `https://aurora-mainnet.infura.io/v3/${infuraProjectId}`,
-    ticker: CURRENCY_SYMBOLS.AURORA,
+    ticker: CURRENCY_SYMBOLS.ETH,
     rpcPrefs: {
       blockExplorerUrl: 'https://aurorascan.dev/',
       imageUrl: AURORA_TOKEN_IMAGE_URL,

--- a/shared/constants/network.ts
+++ b/shared/constants/network.ts
@@ -3,14 +3,14 @@ import { capitalize, pick } from 'lodash';
  * A type representing any valid value for 'type' for setProviderType and other
  * methods that add or manipulate networks in MetaMask state.
  */
-export type NetworkType = typeof NETWORK_TYPES[keyof typeof NETWORK_TYPES];
+export type NetworkType = (typeof NETWORK_TYPES)[keyof typeof NETWORK_TYPES];
 
 /**
  * A union type of all possible hard-coded chain ids. This type is not
  * exhaustive and cannot be used for typing chainId in areas where the user or
  * dapp may specify any chainId.
  */
-export type ChainId = typeof CHAIN_IDS[keyof typeof CHAIN_IDS];
+export type ChainId = (typeof CHAIN_IDS)[keyof typeof CHAIN_IDS];
 
 /**
  * A type that is a union type of all possible hardcoded currency symbols.
@@ -18,13 +18,13 @@ export type ChainId = typeof CHAIN_IDS[keyof typeof CHAIN_IDS];
  * or dapp may supply their own symbol.
  */
 export type CurrencySymbol =
-  typeof CURRENCY_SYMBOLS[keyof typeof CURRENCY_SYMBOLS];
+  (typeof CURRENCY_SYMBOLS)[keyof typeof CURRENCY_SYMBOLS];
 /**
  * Test networks have special symbols that combine the network name and 'ETH'
  * so that they are distinct from mainnet and other networks that use 'ETH'.
  */
 export type TestNetworkCurrencySymbol =
-  typeof TEST_NETWORK_TICKER_MAP[keyof typeof TEST_NETWORK_TICKER_MAP];
+  (typeof TEST_NETWORK_TICKER_MAP)[keyof typeof TEST_NETWORK_TICKER_MAP];
 
 /**
  * An object containing preferences for an RPC definition

--- a/shared/constants/network.ts
+++ b/shared/constants/network.ts
@@ -3,14 +3,14 @@ import { capitalize, pick } from 'lodash';
  * A type representing any valid value for 'type' for setProviderType and other
  * methods that add or manipulate networks in MetaMask state.
  */
-export type NetworkType = (typeof NETWORK_TYPES)[keyof typeof NETWORK_TYPES];
+export type NetworkType = typeof NETWORK_TYPES[keyof typeof NETWORK_TYPES];
 
 /**
  * A union type of all possible hard-coded chain ids. This type is not
  * exhaustive and cannot be used for typing chainId in areas where the user or
  * dapp may specify any chainId.
  */
-export type ChainId = (typeof CHAIN_IDS)[keyof typeof CHAIN_IDS];
+export type ChainId = typeof CHAIN_IDS[keyof typeof CHAIN_IDS];
 
 /**
  * A type that is a union type of all possible hardcoded currency symbols.
@@ -18,13 +18,13 @@ export type ChainId = (typeof CHAIN_IDS)[keyof typeof CHAIN_IDS];
  * or dapp may supply their own symbol.
  */
 export type CurrencySymbol =
-  (typeof CURRENCY_SYMBOLS)[keyof typeof CURRENCY_SYMBOLS];
+  typeof CURRENCY_SYMBOLS[keyof typeof CURRENCY_SYMBOLS];
 /**
  * Test networks have special symbols that combine the network name and 'ETH'
  * so that they are distinct from mainnet and other networks that use 'ETH'.
  */
 export type TestNetworkCurrencySymbol =
-  (typeof TEST_NETWORK_TICKER_MAP)[keyof typeof TEST_NETWORK_TICKER_MAP];
+  typeof TEST_NETWORK_TICKER_MAP[keyof typeof TEST_NETWORK_TICKER_MAP];
 
 /**
  * An object containing preferences for an RPC definition
@@ -203,7 +203,7 @@ export const LOCALHOST_RPC_URL = 'http://localhost:8545';
  */
 export const CURRENCY_SYMBOLS = {
   ARBITRUM: 'ETH',
-  AURORA: 'AURORA ETH',
+  AURORA_ETH: 'AURORA ETH',
   AVALANCHE: 'AVAX',
   BNB: 'BNB',
   BUSD: 'BUSD',
@@ -381,6 +381,7 @@ export const NATIVE_CURRENCY_TOKEN_IMAGE_MAP = {
   [CURRENCY_SYMBOLS.AVALANCHE]: AVAX_TOKEN_IMAGE_URL,
   [CURRENCY_SYMBOLS.OPTIMISM]: OPTIMISM_TOKEN_IMAGE_URL,
   [CURRENCY_SYMBOLS.CELO]: CELO_TOKEN_IMAGE_URL,
+  [CURRENCY_SYMBOLS.AURORA_ETH]: ETH_TOKEN_IMAGE_URL,
 } as const;
 
 export const INFURA_BLOCKED_KEY = 'countryBlocked';

--- a/shared/constants/network.ts
+++ b/shared/constants/network.ts
@@ -576,7 +576,7 @@ export const FEATURED_RPCS: RPCDefinition[] = [
     chainId: CHAIN_IDS.AURORA,
     nickname: AURORA_DISPLAY_NAME,
     rpcUrl: `https://aurora-mainnet.infura.io/v3/${infuraProjectId}`,
-    ticker: CURRENCY_SYMBOLS.ETH,
+    ticker: CURRENCY_SYMBOLS.AURORA_ETH,
     rpcPrefs: {
       blockExplorerUrl: 'https://aurorascan.dev/',
       imageUrl: AURORA_TOKEN_IMAGE_URL,

--- a/shared/constants/swaps.ts
+++ b/shared/constants/swaps.ts
@@ -130,8 +130,7 @@ export const WETH_ARBITRUM_CONTRACT_ADDRESS =
 const SWAPS_TESTNET_CHAIN_ID = '0x539';
 
 export const SWAPS_API_V2_BASE_URL = 'https://swap.metaswap.codefi.network';
-export const SWAPS_DEV_API_V2_BASE_URL =
-  'https://swap.metaswap-dev.codefi.network';
+export const SWAPS_DEV_API_V2_BASE_URL = 'https://swap.dev-api.cx.metamask.io';
 export const GAS_API_BASE_URL = 'https://gas-api.metaswap.codefi.network';
 export const GAS_DEV_API_BASE_URL =
   'https://gas-api.metaswap-dev.codefi.network';

--- a/shared/modules/network.utils.test.ts
+++ b/shared/modules/network.utils.test.ts
@@ -73,6 +73,10 @@ describe('network utils', () => {
       expect(isTokenDetectionEnabledForNetwork('0xa86a')).toBe(true);
     });
 
+    it('returns true given the chain ID for Aurora', () => {
+      expect(isTokenDetectionEnabledForNetwork('0x4e454152')).toBe(true);
+    });
+
     it('returns false given a string that is not the chain ID for Mainnet, BSC, Polygon, or Avalanche', () => {
       expect(isTokenDetectionEnabledForNetwork('some other chain ID')).toBe(
         false,

--- a/shared/modules/network.utils.ts
+++ b/shared/modules/network.utils.ts
@@ -39,6 +39,7 @@ export function isTokenDetectionEnabledForNetwork(chainId: string | undefined) {
     case CHAIN_IDS.BSC:
     case CHAIN_IDS.POLYGON:
     case CHAIN_IDS.AVALANCHE:
+    case CHAIN_IDS.AURORA:
       return true;
     default:
       return false;

--- a/ui/hooks/useTokensToSearch.js
+++ b/ui/hooks/useTokensToSearch.js
@@ -68,6 +68,7 @@ export function getRenderableTokenData(
     (symbol === CURRENCY_SYMBOLS.AVALANCHE &&
       chainId === CHAIN_IDS.AVALANCHE) ||
     (symbol === CURRENCY_SYMBOLS.ETH && chainId === CHAIN_IDS.OPTIMISM) ||
+    (symbol === CURRENCY_SYMBOLS.ETH && chainId === CHAIN_IDS.AURORA) ||
     (symbol === CURRENCY_SYMBOLS.ETH && chainId === CHAIN_IDS.ARBITRUM)
       ? iconUrl
       : formatIconUrlWithProxy({

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -21,6 +21,7 @@ import {
   BSC_DISPLAY_NAME,
   POLYGON_DISPLAY_NAME,
   AVALANCHE_DISPLAY_NAME,
+  AURORA_DISPLAY_NAME,
   CHAIN_ID_TO_RPC_URL_MAP,
   CHAIN_IDS,
   NETWORK_TYPES,
@@ -1274,6 +1275,8 @@ export const getTokenDetectionSupportNetworkByChainId = (state) => {
       return POLYGON_DISPLAY_NAME;
     case CHAIN_IDS.AVALANCHE:
       return AVALANCHE_DISPLAY_NAME;
+    case CHAIN_IDS.AURORA:
+      return AURORA_DISPLAY_NAME;
     default:
       return '';
   }

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -1279,8 +1279,8 @@ export const getTokenDetectionSupportNetworkByChainId = (state) => {
   }
 };
 /**
- * To check if teh chainId supports token detection ,
- * currently it returns true for Ethereum Mainnet, Polygon, BSC and Avalanche
+ * To check if the chainId supports token detection,
+ * currently it returns true for Ethereum Mainnet, Polygon, BSC, Avalanche and Aurora
  *
  * @param {*} state
  * @returns Boolean
@@ -1292,6 +1292,7 @@ export function getIsDynamicTokenListAvailable(state) {
     CHAIN_IDS.BSC,
     CHAIN_IDS.POLYGON,
     CHAIN_IDS.AVALANCHE,
+    CHAIN_IDS.AURORA,
   ].includes(chainId);
 }
 
@@ -1334,7 +1335,7 @@ export function getIsTokenDetectionInactiveOnMainnet(state) {
 
 /**
  * To check for the chainId that supports token detection ,
- * currently it returns true for Ethereum Mainnet, Polygon, BSC and Avalanche
+ * currently it returns true for Ethereum Mainnet, Polygon, BSC, Avalanche and Aurora
  *
  * @param {*} state
  * @returns Boolean

--- a/yarn.lock
+++ b/yarn.lock
@@ -3668,7 +3668,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/assets-controllers@npm:^6.0.0":
+"@metamask/assets-controllers@npm:6.0.0":
   version: 6.0.0
   resolution: "@metamask/assets-controllers@npm:6.0.0"
   dependencies:
@@ -3699,6 +3699,40 @@ __metadata:
     "@metamask/approval-controller": ^2.1.0
     "@metamask/network-controller": ^7.0.0
   checksum: 79c56421567b48b24deab2410645ae60022954ad590e6d91c3770fbeaf24ea3e92608935ae15696349a51bfc5d4337b22cc21f48b0d09bbf4e2f1a0c4aa96904
+  languageName: node
+  linkType: hard
+
+"@metamask/assets-controllers@patch:@metamask/assets-controllers@npm%3A6.0.0#./.yarn/patches/@metamask-assets-controllers-npm-6.0.0-0cb763bd07.patch::locator=metamask-crx%40workspace%3A.":
+  version: 6.0.0
+  resolution: "@metamask/assets-controllers@patch:@metamask/assets-controllers@npm%3A6.0.0#./.yarn/patches/@metamask-assets-controllers-npm-6.0.0-0cb763bd07.patch::version=6.0.0&hash=b3036f&locator=metamask-crx%40workspace%3A."
+  dependencies:
+    "@ethersproject/bignumber": ^5.7.0
+    "@ethersproject/contracts": ^5.7.0
+    "@ethersproject/providers": ^5.7.0
+    "@metamask/abi-utils": ^1.1.0
+    "@metamask/approval-controller": ^2.1.0
+    "@metamask/base-controller": ^2.0.0
+    "@metamask/contract-metadata": ^2.3.1
+    "@metamask/controller-utils": ^3.2.0
+    "@metamask/metamask-eth-abis": 3.0.0
+    "@metamask/network-controller": ^7.0.0
+    "@metamask/preferences-controller": ^3.0.0
+    "@metamask/utils": ^5.0.1
+    "@types/uuid": ^8.3.0
+    abort-controller: ^3.0.0
+    async-mutex: ^0.2.6
+    babel-runtime: ^6.26.0
+    eth-query: ^2.1.2
+    eth-rpc-errors: ^4.0.2
+    ethereumjs-util: ^7.0.10
+    immer: ^9.0.6
+    multiformats: ^9.5.2
+    single-call-balance-checker-abi: ^1.0.0
+    uuid: ^8.3.2
+  peerDependencies:
+    "@metamask/approval-controller": ^2.1.0
+    "@metamask/network-controller": ^7.0.0
+  checksum: 7fcb7d4b62bca0205d8e4d833d40c5b9f5cc6e80a27a3b1f3f3108e7e643121eb2a6f208672fd537e9b372280163fc9029f7f9c1d99ba252d359654a6493affa
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Explanation
This PR: 
- Enables token detection for the Aurora network
- Fixes default currency for Aurora
- Updates a URL for dev Swaps API

- [x] This PR has a dependency on this PR in the `MetaMask/core` repo: https://github.com/MetaMask/core/pull/1327
- [x] It's also waiting for backend changes to be in prod to display token icons on the Aurora network

## Testing steps
- Have tokens with non-zero balance on the Aurora network and not displayed in the extension yet
- Click on `Refresh list` in the extension: 
![image](https://user-images.githubusercontent.com/80175477/236210519-d7eefd9a-fb17-4d96-b729-a888fa6035b5.png)
- New tokens are detected