### PR TITLE
[FLASK] Disable RPC test

### DIFF
--- a/test/e2e/snaps/test-snap-rpc.spec.js
+++ b/test/e2e/snaps/test-snap-rpc.spec.js
@@ -5,6 +5,7 @@ const { TEST_SNAPS_WEBSITE_URL } = require('./enums');
 describe('Test Snap RPC', function () {
   // Disabled for now due to a bug.
   // TODO: Re-enable when fixed.
+  // eslint-disable-next-line mocha/no-skipped-tests
   it.skip('can use the cross-snap RPC endowment and produce a public key', async function () {
     const ganacheOptions = {
       accounts: [

--- a/test/e2e/snaps/test-snap-rpc.spec.js
+++ b/test/e2e/snaps/test-snap-rpc.spec.js
@@ -3,7 +3,9 @@ const FixtureBuilder = require('../fixture-builder');
 const { TEST_SNAPS_WEBSITE_URL } = require('./enums');
 
 describe('Test Snap RPC', function () {
-  it('can use the cross-snap RPC endowment and produce a public key', async function () {
+  // Disabled for now due to a bug.
+  // TODO: Re-enable when fixed.
+  it.skip('can use the cross-snap RPC endowment and produce a public key', async function () {
     const ganacheOptions = {
       accounts: [
         {


### PR DESCRIPTION
## Explanation

Disables the RPC test which is currently failing on E2E due to a bug in the SnapController. Should be enabled when that is fixed.