### PR TITLE
[FLASK] Don't show the title on Install/Update when it's loading

### DIFF
--- a/ui/pages/permissions-connect/snaps/snap-install/snap-install.js
+++ b/ui/pages/permissions-connect/snaps/snap-install/snap-install.js
@@ -91,7 +91,7 @@ export default function SnapInstall({
         flexDirection={FLEX_DIRECTION.COLUMN}
       >
         <SnapAuthorship snapId={targetSubjectMetadata.origin} />
-        {!hasError && (
+        {!isLoading && !hasError && (
           <Text
             variant={TextVariant.headingLg}
             paddingTop={4}

--- a/ui/pages/permissions-connect/snaps/snap-update/snap-update.js
+++ b/ui/pages/permissions-connect/snaps/snap-update/snap-update.js
@@ -97,7 +97,7 @@ export default function SnapUpdate({
         flexDirection={FLEX_DIRECTION.COLUMN}
       >
         <SnapAuthorship snapId={targetSubjectMetadata.origin} />
-        {!hasError && (
+        {!isLoading && !hasError && (
           <Text
             paddingBottom={4}
             paddingTop={4}


### PR DESCRIPTION
## Explanation

This hides the title while the install/update screen is loading data.

## Screenshots/Screencaps



### Before

![image](https://user-images.githubusercontent.com/13910212/236266883-f7d25cc7-0da6-4ee7-a7ca-45c18b691007.png)


### After

![image](https://user-images.githubusercontent.com/13910212/236267128-f2ddd5fd-0781-4167-a3f2-0353c5b370f9.png)

## Manual Testing Steps

- Try installing/updating a snap