### PR TITLE
Update CODEOWNERS: remove requirement for supply-chain team to approv…

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,6 +11,7 @@
 **/snaps/**                          @MetaMask/snaps-devs
 **/flask/**                          @MetaMask/snaps-devs
 development/                         @MetaMask/extension-devs @kumavis
+lavamoat/                            @MetaMask/extension-devs @MetaMask/supply-chain @MetaMask/snaps-devs
 
 # The .circleci/ folder instructs Circle CI on the process by which it
 # should test, build and publish releases of our application. Due to the

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,7 +11,6 @@
 **/snaps/**                          @MetaMask/snaps-devs
 **/flask/**                          @MetaMask/snaps-devs
 development/                         @MetaMask/extension-devs @kumavis
-lavamoat/                            @MetaMask/supply-chain
 
 # The .circleci/ folder instructs Circle CI on the process by which it
 # should test, build and publish releases of our application. Due to the


### PR DESCRIPTION
…e lavamoat policy changes

## Explanation

Now that the supply-chain team on github has write access to the metamask-extension repo, all PRs that change lavamoat policy files require approval from one of you four (or leotm). This access was given as a result of this thread, https://consensys.slack.com/archives/GTQAGKY5V/p1683200894794789, but I think the requirement to approve all such PRs was not intended.

That requirement is occuring because of this line in the CODEOWNERS file https://github.com/MetaMask/metamask-extension/blob/develop/.github/CODEOWNERS#L12

Prior to the supply-chain team being granted write access, that line in the CODEOWNERS file was ignored, but now it is coming into effect. We might want to change the CODEOWNERS file going forward, but for now we will temporarily remove this to unblock the PR and release pipelines.