### PR TITLE
Fix build types not overriding the manifest

### DIFF
--- a/builds.yml
+++ b/builds.yml
@@ -21,6 +21,8 @@ buildTypes:
       - SEGMENT_PROD_WRITE_KEY
       - INFURA_ENV_KEY_REF: INFURA_PROD_PROJECT_ID
       - SEGMENT_WRITE_KEY_REF: SEGMENT_PROD_WRITE_KEY
+    # Main build uses the default browser manifest
+    manifestOverrides: false
 
   beta:
     features:
@@ -34,7 +36,7 @@ buildTypes:
     # eg. instead of 10.25.0 -> 10.25.0-beta.2
     isPrerelease: true
     # Folder which contains overrides to browser manifests
-    manifestOverrides: ./app/build-types/mmi/manifest/
+    manifestOverrides: ./app/build-types/beta/manifest/
 
   flask:
     # Code surrounded using code fences for that feature
@@ -53,6 +55,7 @@ buildTypes:
       - INFURA_ENV_KEY_REF: INFURA_FLASK_PROJECT_ID
       - SEGMENT_WRITE_KEY_REF: SEGMENT_FLASK_WRITE_KEY
     isPrerelease: true
+    manifestOverrides: ./app/build-types/flask/manifest/
 
   desktop:
     features:
@@ -69,6 +72,7 @@ buildTypes:
       - INFURA_ENV_KEY_REF: INFURA_FLASK_PROJECT_ID
       - SEGMENT_WRITE_KEY_REF: SEGMENT_FLASK_WRITE_KEY
     isPrerelease: true
+    manifestOverrides: ./app/build-types/desktop/manifest/
 
   mmi:
     features:
@@ -83,6 +87,7 @@ buildTypes:
     # For some reason, MMI uses this type of versioning
     # Leaving it on for backwards compatibility
     isPrerelease: true
+    manifestOverrides: ./app/build-types/mmi/manifest/
 
 # Build types are composed of a set of features.
 # Each feature can have code fences that add new code

--- a/development/build/manifest.js
+++ b/development/build/manifest.js
@@ -176,7 +176,7 @@ async function getBuildModifications(buildType, platform) {
   }
 
   const overridesPath = buildConfig.buildTypes[buildType].manifestOverrides;
-  if (overridesPath === undefined) {
+  if (!overridesPath) {
     return {};
   }
 

--- a/development/lib/build-type.js
+++ b/development/lib/build-type.js
@@ -16,6 +16,7 @@ const {
   validate,
   nullable,
   never,
+  literal,
 } = require('superstruct');
 const yaml = require('js-yaml');
 const { uniqWith } = require('lodash');
@@ -65,7 +66,7 @@ const BuildTypeStruct = object({
   features: optional(unique(array(string()))),
   env: optional(EnvArrayStruct),
   isPrerelease: optional(boolean()),
-  manifestOverrides: optional(string()),
+  manifestOverrides: union([string(), literal(false)]),
 });
 
 const CopyAssetStruct = object({ src: string(), dest: string() });


### PR DESCRIPTION
Non-default build types were not overriding the manifest with proper store IDs and descriptions.

To avoid similar problems in the future, disabling manifest overrides requires to be explicit in the `builds.yml` by using `manifestOverrides: false`.

I alternatively considered using superstruct's `refine()` to check if a build is not default and require an override then, but that would create more edge cases in case someone wanted to disable overrides for non-default build.