### PR TITLE
Modal sub component small updates

### DIFF
--- a/ui/components/component-library/modal-header/__snapshots__/modal-header.test.tsx.snap
+++ b/ui/components/component-library/modal-header/__snapshots__/modal-header.test.tsx.snap
@@ -9,11 +9,11 @@ exports[`ModalHeader should render ModalHeader correctly 1`] = `
     <div
       class="box box--flex-direction-row box--width-full"
     >
-      <h4
+      <header
         class="box mm-text mm-text--heading-sm mm-text--text-align-center box--flex-direction-row box--color-text-default"
       >
         Modal header
-      </h4>
+      </header>
     </div>
   </div>
 </div>

--- a/ui/components/component-library/modal-header/modal-header.tsx
+++ b/ui/components/component-library/modal-header/modal-header.tsx
@@ -1,6 +1,13 @@
 import React from 'react';
 import classnames from 'classnames';
-import { HeaderBase, Text, ButtonIcon, ButtonIconSize, IconName } from '..';
+import {
+  HeaderBase,
+  Text,
+  ButtonIcon,
+  ButtonIconSize,
+  IconName,
+  ValidTag,
+} from '..';
 import {
   TextVariant,
   TextAlign,
@@ -50,7 +57,11 @@ export const ModalHeader: React.FC<ModalHeaderProps> = ({
       {...props}
     >
       {typeof children === 'string' ? (
-        <Text variant={TextVariant.headingSm} textAlign={TextAlign.Center}>
+        <Text
+          as={ValidTag.Header}
+          variant={TextVariant.headingSm}
+          textAlign={TextAlign.Center}
+        >
           {children}
         </Text>
       ) : (

--- a/ui/components/component-library/modal-overlay/__snapshots__/modal-overlay.test.tsx.snap
+++ b/ui/components/component-library/modal-overlay/__snapshots__/modal-overlay.test.tsx.snap
@@ -3,6 +3,7 @@
 exports[`ModalOverlay should match snapshot 1`] = `
 <div>
   <div
+    aria-hidden="true"
     class="box mm-modal-overlay box--flex-direction-row box--width-full box--height-full box--background-color-overlay-default"
   />
 </div>

--- a/ui/components/component-library/modal-overlay/modal-overlay.scss
+++ b/ui/components/component-library/modal-overlay/modal-overlay.scss
@@ -1,7 +1,8 @@
 .mm-modal-overlay {
-  position: absolute;
+  position: fixed;
   top: 0;
   left: 0;
   right: 0;
   bottom: 0;
+  z-index: $modal-z-index;
 }

--- a/ui/components/component-library/modal-overlay/modal-overlay.tsx
+++ b/ui/components/component-library/modal-overlay/modal-overlay.tsx
@@ -21,6 +21,7 @@ export const ModalOverlay: React.FC<ModalOverlayProps> = ({
     width={BLOCK_SIZES.FULL}
     height={BLOCK_SIZES.FULL}
     onClick={onClick}
+    aria-hidden="true"
     {...props}
   />
 );

--- a/ui/components/component-library/text/text.types.ts
+++ b/ui/components/component-library/text/text.types.ts
@@ -41,6 +41,7 @@ export enum ValidTag {
   Ul = 'ul',
   Label = 'label',
   Input = 'input',
+  Header = 'header',
 }
 
 export interface TextProps extends BoxProps {

--- a/ui/components/ui/popover/index.scss
+++ b/ui/components/ui/popover/index.scss
@@ -51,7 +51,7 @@
     display: flex;
     justify-content: center;
     align-items: center;
-    z-index: 1050;
+    z-index: $modal-z-index;
   }
 
   &-footer {

--- a/ui/css/design-system/z-index.scss
+++ b/ui/css/design-system/z-index.scss
@@ -10,3 +10,4 @@ $main-container-z-index: 18;
 $send-card-z-index: 20;
 $sidebar-z-index: 26;
 $sidebar-overlay-z-index: 25;
+$modal-z-index: 1050;


### PR DESCRIPTION
## Explanation
Some style, accessibility and semantic html updates to new modal sub components and current Popover. Breaking them out into a separate PR for easier review 

- Dependency of https://github.com/MetaMask/metamask-extension/pull/19020
- Part of #15432

## Screenshots/Screencaps

Added screenshots in comments next to relevant code

## Manual Testing Steps

- Go to the latest build of storybook on this PR
- Check styles, aria-labels and semantic mark up of Popover, ModalOverlay and ModalHeader

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
