### PR TITLE
Part of #18714: Replace deprecated design system typography consts with enums in:custody-labels.js

### DIFF
--- a/ui/components/institutional/custody-labels/custody-labels.js
+++ b/ui/components/institutional/custody-labels/custody-labels.js
@@ -2,10 +2,10 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Text, Label } from '../../component-library';
 import {
-  TEXT_TRANSFORM,
+  TextTransform,
   BackgroundColor,
   TextColor,
-  FONT_WEIGHT,
+  FontWeight,
   BorderRadius,
   TypographyVariant,
 } from '../../../helpers/constants/design-system';
@@ -25,7 +25,7 @@ const CustodyLabels = (props) => {
       {filteredLabels.map((item) => (
         <Text
           key={item.key}
-          textTransform={TEXT_TRANSFORM.UPPERCASE}
+          textTransform={TextTransform.Uppercase}
           className="custody-label"
           style={background ? { background } : {}}
           marginTop={1}
@@ -37,7 +37,7 @@ const CustodyLabels = (props) => {
           paddingRight={2}
           backgroundColor={BackgroundColor.backgroundAlternative}
           color={TextColor.textMuted}
-          fontWeight={FONT_WEIGHT.NORMAL}
+          fontWeight={FontWeight.Normal}
           borderRadius={BorderRadius.SM}
           variant={TypographyVariant.H9}
         >


### PR DESCRIPTION
## Explanation
This PR is a part of #18714
Replaced deprecated design system typography consts with enums in ```custody-labels.js```

- ui/components/institutional/custody-labels.js 

<!--
Thanks for the pull request. Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues, Slack conversations, Zendesk issues, user stories, etc. reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

## Screenshots/Screencaps

<!-- If you're making a change to the UI, make sure to capture a screenshot or a short video showing off your work! -->

### Before

<!-- How did the UI you changed look before your changes? Drag your file(s) below this line: -->
![image](https://user-images.githubusercontent.com/79097544/236634348-3eedf079-b05a-443d-9e21-6bec6c395af4.png)

### After

<!-- How does it look now? Drag your file(s) below this line: -->
![image](https://user-images.githubusercontent.com/79097544/236634385-f92e77b1-bc4b-4e76-84a5-ae83e96ea6c3.png)

## Manual Testing Steps

<!--
How should reviewers and QA manually test your changes? For instance:

- Go to this screen
- Do this
- Then do this
-->

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
