### PR TITLE
Part of #18714 Replace deprecated design system typography consts with enums in:  'srp-input'

### DIFF
--- a/ui/components/app/srp-input/srp-input.js
+++ b/ui/components/app/srp-input/srp-input.js
@@ -6,13 +6,13 @@ import TextField from '../../ui/text-field';
 import { clearClipboard } from '../../../helpers/utils/util';
 import ActionableMessage from '../../ui/actionable-message';
 import Dropdown from '../../ui/dropdown';
-import Typography from '../../ui/typography';
 import ShowHideToggle from '../../ui/show-hide-toggle';
 import {
-  FONT_WEIGHT,
-  TEXT_ALIGN,
-  TypographyVariant,
+  FontWeight,
+  TextAlign,
+  TextVariant,
 } from '../../../helpers/constants/design-system';
+import { Text } from '../../component-library';
 import { parseSecretRecoveryPhrase } from './parse-secret-recovery-phrase';
 
 const defaultNumberOfWords = 12;
@@ -129,13 +129,14 @@ export default function SrpInput({ onChange, srpText }) {
   return (
     <div className="import-srp__container">
       <label className="import-srp__srp-label">
-        <Typography
-          align={TEXT_ALIGN.LEFT}
-          variant={TypographyVariant.H4}
-          fontWeight={FONT_WEIGHT.BOLD}
+        <Text
+          align={TextAlign.Left}
+          variant={TextVariant.headingSm}
+          as="h4"
+          fontWeight={FontWeight.Bold}
         >
           {srpText}
-        </Typography>
+        </Text>
       </label>
       <ActionableMessage
         className="import-srp__paste-tip"
@@ -170,7 +171,7 @@ export default function SrpInput({ onChange, srpText }) {
           return (
             <div key={index} className="import-srp__srp-word">
               <label htmlFor={id} className="import-srp__srp-word-label">
-                <Typography>{`${index + 1}.`}</Typography>
+                <Text>{`${index + 1}.`}</Text>
               </label>
               <TextField
                 id={id}

--- a/ui/components/app/srp-input/srp-input.js
+++ b/ui/components/app/srp-input/srp-input.js
@@ -133,7 +133,6 @@ export default function SrpInput({ onChange, srpText }) {
           align={TextAlign.Left}
           variant={TextVariant.headingSm}
           as="h4"
-          fontWeight={FontWeight.Bold}
         >
           {srpText}
         </Text>

--- a/ui/components/app/srp-input/srp-input.js
+++ b/ui/components/app/srp-input/srp-input.js
@@ -8,7 +8,6 @@ import ActionableMessage from '../../ui/actionable-message';
 import Dropdown from '../../ui/dropdown';
 import ShowHideToggle from '../../ui/show-hide-toggle';
 import {
-  FontWeight,
   TextAlign,
   TextVariant,
 } from '../../../helpers/constants/design-system';
@@ -129,11 +128,7 @@ export default function SrpInput({ onChange, srpText }) {
   return (
     <div className="import-srp__container">
       <label className="import-srp__srp-label">
-        <Text
-          align={TextAlign.Left}
-          variant={TextVariant.headingSm}
-          as="h4"
-        >
+        <Text align={TextAlign.Left} variant={TextVariant.headingSm} as="h4">
           {srpText}
         </Text>
       </label>


### PR DESCRIPTION
## Explanation
This PR is a part of the issue #18714 Replace deprecated design system typography consts with enums in: 
**ui\components\app\srp-input\srp-input.js**

Part of #18714 

## Screenshots/Screencaps

<!-- If you're making a change to the UI, make sure to capture a screenshot or a short video showing off your work! -->

### Before
![Screenshot (93)](https://user-images.githubusercontent.com/125105825/236672678-39022043-fe0e-455d-890a-b659af809e07.png)


<!-- How did the UI you changed look before your changes? Drag your file(s) below this line: -->

### After
![Screenshot (95)](https://user-images.githubusercontent.com/125105825/236672729-74c00873-a976-4f59-aa6c-962f54f81062.png)


<!-- How does it look now? Drag your file(s) below this line: -->

## Manual Testing Steps

<!--
How should reviewers and QA manually test your changes? For instance:

- Go to this screen
- Do this
- Then do this
-->

## Pre-merge author checklist

- [ ] I've clearly explained:
  - [ ] What problem this PR is solving
  - [ ] How this problem was solved
  - [ ] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
