### PR TITLE
Fix #19060 - Ensure there's multiple accounts before focusing search

### DIFF
--- a/ui/components/multichain/account-list-menu/account-list-menu.js
+++ b/ui/components/multichain/account-list-menu/account-list-menu.js
@@ -66,7 +66,7 @@ export const AccountListMenu = ({ onClose }) => {
   // Focus on the search box when the popover is opened
   useEffect(() => {
     if (inputRef.current) {
-      inputRef.current.rootNode.querySelector('input[type=search]').focus();
+      inputRef.current.rootNode.querySelector('input[type=search]')?.focus();
     }
   }, [inputRef]);
 


### PR DESCRIPTION
## Explanation

* Fixes #19060

Since we removed the search box when there's only one account, we cannot try to focus on it upon launching the modal

## Manual Testing Steps

1.  Create a new MetaMask with 1 account
2. Click account Menu -- it works
3. Create a new account
4. Open the account menu
5. The search box is focused

## Pre-merge author checklist

- [ ] I've clearly explained:
  - [ ] What problem this PR is solving
  - [ ] How this problem was solved
  - [ ] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
