### PR TITLE
Fix #19059 - Show network picker when locked

### DIFF
--- a/ui/components/multichain/app-header/app-header.js
+++ b/ui/components/multichain/app-header/app-header.js
@@ -350,16 +350,14 @@ export const AppHeader = ({ location }) => {
               padding={2}
               gap={2}
             >
-              {popupStatus ? null : (
-                <div>
-                  <PickerNetwork
-                    label={currentNetwork?.nickname}
-                    src={currentNetwork?.rpcPrefs?.imageUrl}
-                    onClick={() => dispatch(toggleNetworkMenu())}
-                    className="multichain-app-header__contents__network-picker"
-                  />
-                </div>
-              )}
+              <div>
+                <PickerNetwork
+                  label={currentNetwork?.nickname}
+                  src={currentNetwork?.rpcPrefs?.imageUrl}
+                  onClick={() => dispatch(toggleNetworkMenu())}
+                  className="multichain-app-header__contents__network-picker"
+                />
+              </div>
               <MetafoxLogo
                 unsetIconHeight
                 onClick={async () => {


### PR DESCRIPTION
## Explanation

* Fixes #19059

Displays the Network Picker when the user isn't logged in.



## Pre-merge author checklist

- [ ] I've clearly explained:
  - [ ] What problem this PR is solving
  - [ ] How this problem was solved
  - [ ] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
