### PR TITLE
Set network status to "unknown" when ID is invalid

### DIFF
--- a/app/scripts/controllers/network/network-controller.ts
+++ b/app/scripts/controllers/network/network-controller.ts
@@ -307,10 +307,9 @@ function isErrorWithCode(error: unknown): error is { code: string | number } {
  * @param value - The value to check.
  */
 function assertNetworkId(value: any): asserts value is NetworkId {
-  assert(
-    /^\d+$/u.test(value) && !Number.isNaN(Number(value)),
-    'value is not a number',
-  );
+  if (!/^\d+$/u.test(value) || Number.isNaN(Number(value))) {
+    throw new Error('value is not a number');
+  }
 }
 
 /**


### PR DESCRIPTION
## Explanation

We now set the network status to "unknown" rather than "unavailable" when the network ID is invalid. This better reflects what we know when this happens, and it makes the network controller better aligned with the core network controller.

This was accomplished by using a regular error for the network ID assertion rather than using `assert` directly. `assert` would throw an error with a `code` property, which resutled in us treating it like an RPC error.

This isn't tested, but it was found in the course of porting unit tests from core to extension. It will be covered by these tests, which will be added in the next PR.

This change should have no functional impact because we treat these two network statuses as equivalent. The distinction between unknown and unavailable is useful only for debugging.

This relates to [#1197](https://github.com/MetaMask/core/issues/1197)

## Manual Testing Steps

No functional impact

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
