### PR TITLE
Only recognize "blocked" status for built-in networks

### DIFF
--- a/app/scripts/controllers/network/network-controller.ts
+++ b/app/scripts/controllers/network/network-controller.ts
@@ -623,12 +623,14 @@ export class NetworkController extends EventEmitter {
       supportsEIP1559 = results[1];
       networkStatus = NetworkStatus.Available;
     } catch (error) {
-      if (isErrorWithCode(error) && isErrorWithMessage(error)) {
+      if (isErrorWithCode(error)) {
         let responseBody;
-        try {
-          responseBody = JSON.parse(error.message);
-        } catch {
-          // error.message must not be JSON
+        if (isInfura && isErrorWithMessage(error)) {
+          try {
+            responseBody = JSON.parse(error.message);
+          } catch {
+            // error.message must not be JSON
+          }
         }
 
         if (


### PR DESCRIPTION
## Explanation

The detection of the Infura "blocked" status has been updated to apply only to built-in networks. The message we show to users in this state is meant only for Infura; we don't want to show it for third-party RPC APIs that happen to use the same error response.

This brings the network controller further in alignment with the core network controller.

This isn't tested, but it was found in the course of porting unit tests from core to extension. It will be covered by these tests, which will be added in the next PR.

This relates to [#1197](https://github.com/MetaMask/core/issues/1197)

## Manual Testing Steps

I don't know of a straightforward way to test this, but it should be possible if you have a VPN with an endpoint in a blocked country:
* Add an Infura endpoint as a custom RPC network
* VPN into a blocked country
* See that the network does not function, but the blocked message does not appear.

Maybe not worth the trouble to manually test this though; it seems easily auditable, we have unit test coverage coming in the next PR, and this impacts a rare edge cases with only a marginal impact on the affected users.

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
