### PR TITLE
UX Multichain: updated margin top for assets tab

### DIFF
--- a/builds.yml
+++ b/builds.yml
@@ -220,4 +220,3 @@ env:
 
   # Uses yaml anchors to DRY - https://juju.is/docs/sdk/yaml-anchors-and-aliases
   - METAMASK_BUILD_TYPE_DEFAULT: *default
-

--- a/builds.yml
+++ b/builds.yml
@@ -220,3 +220,4 @@ env:
 
   # Uses yaml anchors to DRY - https://juju.is/docs/sdk/yaml-anchors-and-aliases
   - METAMASK_BUILD_TYPE_DEFAULT: *default
+  - EDITOR_URL: false

--- a/builds.yml
+++ b/builds.yml
@@ -220,4 +220,4 @@ env:
 
   # Uses yaml anchors to DRY - https://juju.is/docs/sdk/yaml-anchors-and-aliases
   - METAMASK_BUILD_TYPE_DEFAULT: *default
-  - EDITOR_URL: false
+

--- a/ui/pages/home/home.component.js
+++ b/ui/pages/home/home.component.js
@@ -815,13 +815,21 @@ export default class Home extends PureComponent {
                 name={this.context.t('assets')}
                 tabKey="assets"
               >
-                <Box marginTop={2}>
+                {process.env.MULTICHAIN ? (
+                  <Box marginTop={2}>
+                    <AssetList
+                      onClickAsset={(asset) =>
+                        history.push(`${ASSET_ROUTE}/${asset}`)
+                      }
+                    />
+                  </Box>
+                ) : (
                   <AssetList
                     onClickAsset={(asset) =>
                       history.push(`${ASSET_ROUTE}/${asset}`)
                     }
                   />
-                </Box>
+                )}
               </Tab>
               {
                 ///: BEGIN:ONLY_INCLUDE_IN(build-main,build-beta,build-flask)


### PR DESCRIPTION
This PR is to add marginTop only to the assets tab in the multichain UI and to remove it from the current one

## Screenshots/Screencaps


### Before

![Screenshot 2023-05-09 at 7 25 11 PM](https://github.com/MetaMask/metamask-extension/assets/39872794/2988e1a9-5b4f-4452-ba84-95529da1d7ea)


### After

![Screenshot 2023-05-09 at 7 23 48 PM](https://github.com/MetaMask/metamask-extension/assets/39872794/a9261402-6dec-42a6-b3e5-3ed84ac7111a)


## Manual Testing Steps

1. Check the assets tab list component shouldn't have any extra margin.

## Pre-merge author checklist

- [ ] I've clearly explained:
  - [ ] What problem this PR is solving
  - [ ] How this problem was solved
  - [ ] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
