### PR TITLE
Stop failing pull request creation due to branch validation in .githu/scripts/label-prs.ts

### DIFF
--- a/.github/scripts/label-prs.ts
+++ b/.github/scripts/label-prs.ts
@@ -21,12 +21,15 @@ async function main(): Promise<void> {
 
   let issueNumber = await getIssueNumberFromPullRequestBody();
   if (issueNumber === "") {
-    bailIfIsBranchNameInvalid(headRef);
-    bailIfIsNotFeatureBranch(headRef);
+    // Disabling the below two validations until we agree on conventions
+    // bailIfIsBranchNameInvalid(headRef);
+    // bailIfIsNotFeatureBranch(headRef);
     issueNumber = getIssueNumberFromBranchName(headRef);
   }
 
-  await updateLabels(octokit, issueNumber);
+  if (issueNumber) {
+    await updateLabels(octokit, issueNumber);
+  }
 }
 
 async function getIssueNumberFromPullRequestBody(): Promise<string> {


### PR DESCRIPTION
The changes in #17603 included code that validated branch names according to conventions introduced by that PR. PR creation fails if branch names are invalid. Included in that is code the prevents PRs from being created if there are no associated issues.

While we may want to enforce branch name validation in the future, we should wait until we have an agreed set of conventions. Also, we probably don't want to require that all PRs have an associated issue, so we might want to reconsider that aspect of validation as well.

For now, this PR comments out the code that would cause PR creation to fail if branch names are "invalid".