### PR TITLE
removed mmi fencing from copy icon in header

### DIFF
--- a/ui/components/app/selected-account/__snapshots__/selected-account-component.test.js.snap
+++ b/ui/components/app/selected-account/__snapshots__/selected-account-component.test.js.snap
@@ -33,14 +33,6 @@ exports[`SelectedAccount Component should match snapshot 1`] = `
               class="selected-account__copy"
             >
               <span
-                class="box mm-icon mm-icon--size-md box--display-inline-block box--flex-direction-row box--color-icon-alternative"
-                style="mask-image: url('./images/icons/undefined.svg');"
-              />
-            </div>
-            <div
-              class="selected-account__copy"
-            >
-              <span
                 class="box mm-icon mm-icon--size-sm box--display-inline-block box--flex-direction-row box--color-icon-alternative"
                 style="mask-image: url('./images/icons/copy.svg');"
               />

--- a/ui/components/app/selected-account/selected-account.component.js
+++ b/ui/components/app/selected-account/selected-account.component.js
@@ -120,22 +120,13 @@ class SelectedAccount extends Component {
                 <div className="selected-account__copy">
                   <Icon
                     name={
-                      this.state.copied ? IconName.COPY_SUCCESS : IconName.COPY
+                      this.state.copied ? IconName.CopySuccess : IconName.Copy
                     }
-                    size={IconSize.SM}
+                    size={IconSize.Sm}
                     color={IconColor.iconAlternative}
                   />
                 </div>
               )}
-              <div className="selected-account__copy">
-                <Icon
-                  name={
-                    this.state.copied ? IconName.CopySuccess : IconName.Copy
-                  }
-                  size={IconSize.Sm}
-                  color={IconColor.iconAlternative}
-                />
-              </div>
             </div>
           </button>
         </Tooltip>


### PR DESCRIPTION
With the MMI fencing, the copy icon in the header was adding extra spacing as the copy icon was duplicated. This PR is to fix the icon in header

## Screenshots/Screencaps


### Before
![Screenshot 2023-05-10 at 2 39 32 PM](https://github.com/MetaMask/metamask-extension/assets/39872794/34d03d50-473b-4343-97b8-08e468d9e36c)


### After
![Screenshot 2023-05-10 at 2 39 46 PM](https://github.com/MetaMask/metamask-extension/assets/39872794/a717e7b6-5b45-4814-9e29-0e2e56723b1c)


## Manual Testing Steps

1. Look at the copy icon in the header. 
2. Check there is no extra spacing

## Pre-merge author checklist

- [ ] I've clearly explained:
  - [ ] What problem this PR is solving
  - [ ] How this problem was solved
  - [ ] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
