### PR TITLE
When gas fees suggested by dapp is too high, show warning color and icon

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -1025,7 +1025,7 @@
     "description": "$1 is url for the dapp that has suggested gas settings"
   },
   "dappSuggestedHigh": {
-    "message": "Site suggested high gas estimate"
+    "message": "Site suggested"
   },
   "dappSuggestedHighShortLabel": {
     "message": "Site (high)"

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -1024,6 +1024,12 @@
     "message": "$1 has suggested this price.",
     "description": "$1 is url for the dapp that has suggested gas settings"
   },
+  "dappSuggestedHigh": {
+    "message": "Site suggested high gas estimate"
+  },
+  "dappSuggestedHighShortLabel": {
+    "message": "Site (high)"
+  },
   "dappSuggestedShortLabel": {
     "message": "Site"
   },

--- a/shared/constants/gas.ts
+++ b/shared/constants/gas.ts
@@ -55,6 +55,7 @@ export enum PriorityLevels {
   high = 'high',
   custom = 'custom',
   dAppSuggested = 'dappSuggested',
+  dappSuggestedHigh = 'dappSuggestedHigh',
 }
 
 /**

--- a/shared/constants/gas.ts
+++ b/shared/constants/gas.ts
@@ -3,6 +3,7 @@ import { addHexPrefix } from 'ethereumjs-util';
 const ONE_HUNDRED_THOUSAND = 100000;
 const MIN_GAS_LIMIT_DEC = '21000';
 
+export const TOO_HIGH_GAS_LIMIT = '1'; // 1 ETH
 export const MIN_GAS_LIMIT_HEX = parseInt(MIN_GAS_LIMIT_DEC, 10).toString(16);
 
 export const GAS_LIMITS = {

--- a/shared/constants/gas.ts
+++ b/shared/constants/gas.ts
@@ -3,7 +3,6 @@ import { addHexPrefix } from 'ethereumjs-util';
 const ONE_HUNDRED_THOUSAND = 100000;
 const MIN_GAS_LIMIT_DEC = '21000';
 
-export const TOO_HIGH_GAS_LIMIT = '1'; // 1 ETH
 export const MIN_GAS_LIMIT_HEX = parseInt(MIN_GAS_LIMIT_DEC, 10).toString(16);
 
 export const GAS_LIMITS = {

--- a/ui/components/app/edit-gas-fee-popover/edit-gas-item/edit-gas-item.js
+++ b/ui/components/app/edit-gas-fee-popover/edit-gas-item/edit-gas-item.js
@@ -25,6 +25,8 @@ const getTitleAndIcon = (priorityLevel, editGasMode) => {
   let title = priorityLevel;
   if (priorityLevel === PriorityLevels.dAppSuggested) {
     title = 'dappSuggestedShortLabel';
+  } else if (priorityLevel === PriorityLevels.dappSuggestedHigh) {
+    title = 'dappSuggestedHighShortLabel';
   } else if (priorityLevel === PriorityLevels.tenPercentIncreased) {
     icon = null;
     title = 'tenPercentIncreased';

--- a/ui/components/app/gas-details-item/gas-details-item.js
+++ b/ui/components/app/gas-details-item/gas-details-item.js
@@ -94,13 +94,16 @@ const GasDetailsItem = ({ userAcknowledgedGasMissing = false }) => {
             key="editGasSubTextFeeLabel"
             display="inline-flex"
             className={classNames('gas-details-item__gasfee-label', {
-              'gas-details-item__gas-fee-warning': estimateUsed === 'high',
+              'gas-details-item__gas-fee-warning':
+                estimateUsed === 'high' || estimateUsed === 'dappSuggestedHigh',
             })}
           >
             <LoadingHeartBeat estimateUsed={estimateUsed} />
             <Box marginRight={1}>
               <strong>
-                {estimateUsed === 'high' && '⚠ '}
+                {(estimateUsed === 'high' ||
+                  estimateUsed === 'dappSuggestedHigh') &&
+                  '⚠ '}
                 {t('editGasSubTextFeeLabel')}
               </strong>
             </Box>

--- a/ui/components/app/gas-details-item/gas-details-item.js
+++ b/ui/components/app/gas-details-item/gas-details-item.js
@@ -21,6 +21,7 @@ import TransactionDetailItem from '../transaction-detail-item/transaction-detail
 import UserPreferencedCurrencyDisplay from '../user-preferenced-currency-display';
 import { hexWEIToDecGWEI } from '../../../../shared/modules/conversion.utils';
 import { useDraftTransactionWithTxParams } from '../../../hooks/useDraftTransactionWithTxParams';
+import { PriorityLevels } from '../../../../shared/constants/gas';
 import GasDetailsItemTitle from './gas-details-item-title';
 
 const GasDetailsItem = ({ userAcknowledgedGasMissing = false }) => {
@@ -95,14 +96,15 @@ const GasDetailsItem = ({ userAcknowledgedGasMissing = false }) => {
             display="inline-flex"
             className={classNames('gas-details-item__gasfee-label', {
               'gas-details-item__gas-fee-warning':
-                estimateUsed === 'high' || estimateUsed === 'dappSuggestedHigh',
+                estimateUsed === PriorityLevels.high ||
+                estimateUsed === PriorityLevels.dappSuggestedHigh,
             })}
           >
             <LoadingHeartBeat estimateUsed={estimateUsed} />
             <Box marginRight={1}>
               <strong>
-                {(estimateUsed === 'high' ||
-                  estimateUsed === 'dappSuggestedHigh') &&
+                {(estimateUsed === PriorityLevels.high ||
+                  estimateUsed === PriorityLevels.dappSuggestedHigh) &&
                   '⚠ '}
                 {t('editGasSubTextFeeLabel')}
               </strong>

--- a/ui/components/app/gas-details-item/gas-details-item.test.js
+++ b/ui/components/app/gas-details-item/gas-details-item.test.js
@@ -80,11 +80,14 @@ describe('GasDetailsItem', () => {
       contextProps: {
         gasFeeEstimates: {
           high: {
-            suggestedMaxPriorityFeePerGas: '2',
+            suggestedMaxPriorityFeePerGas: '1',
           },
         },
         transaction: {
-          txParams: {},
+          txParams: {
+            gas: '0x52081',
+            maxFeePerGas: '0x38D7EA4C68000',
+          },
           userFeeLevel: 'medium',
           dappSuggestedGasFees: {
             maxPriorityFeePerGas: '0x38D7EA4C68000',

--- a/ui/components/app/gas-details-item/gas-details-item.test.js
+++ b/ui/components/app/gas-details-item/gas-details-item.test.js
@@ -33,6 +33,7 @@ const render = ({ contextProps } = {}) => {
         useNativeCurrencyAsPrimaryCurrency: true,
       },
       gasFeeEstimates: mockEstimates[GasEstimateTypes.feeMarket],
+      ...contextProps,
     },
   });
 
@@ -68,6 +69,29 @@ describe('GasDetailsItem', () => {
   it('should show warning icon if estimates are high', async () => {
     render({
       contextProps: { transaction: { txParams: {}, userFeeLevel: 'high' } },
+    });
+    await waitFor(() => {
+      expect(screen.queryByText('⚠ Max fee:')).toBeInTheDocument();
+    });
+  });
+
+  it('should show warning icon if dapp estimates are high', async () => {
+    render({
+      contextProps: {
+        gasFeeEstimates: {
+          high: {
+            suggestedMaxPriorityFeePerGas: '2',
+          },
+        },
+        transaction: {
+          txParams: {},
+          userFeeLevel: 'medium',
+          dappSuggestedGasFees: {
+            maxPriorityFeePerGas: '0x38D7EA4C68000',
+            maxFeePerGas: '0x38D7EA4C68000',
+          },
+        },
+      },
     });
     await waitFor(() => {
       expect(screen.queryByText('⚠ Max fee:')).toBeInTheDocument();

--- a/ui/helpers/constants/gas.js
+++ b/ui/helpers/constants/gas.js
@@ -37,6 +37,7 @@ export const PRIORITY_LEVEL_ICON_MAP = {
   medium: '🦊',
   high: '🦍',
   dappSuggested: '🌐',
+  dappSuggestedHigh: '🌐',
   swapSuggested: '🔄',
   custom: '⚙️',
 };

--- a/ui/hooks/gasFeeInput/useGasFeeInputs.js
+++ b/ui/hooks/gasFeeInput/useGasFeeInputs.js
@@ -168,6 +168,30 @@ export function useGasFeeInputs(
         setEstimateUsed(transaction?.userFeeLevel);
         setInternalEstimateToUse(transaction?.userFeeLevel);
       }
+
+      if (
+        transaction &&
+        transaction.dappSuggestedGasFees !== undefined &&
+        transaction.dappSuggestedGasFees !== null &&
+        Object.keys(transaction.dappSuggestedGasFees).length > 0 &&
+        transaction.dappSuggestedGasFees.maxPriorityFeePerGas !== undefined
+      ) {
+        const dappMaxFeePerGas = Number(
+          hexToDecimal(transaction.dappSuggestedGasFees.maxPriorityFeePerGas),
+        );
+
+        let highGasFees = 2;
+        if (gasFeeEstimates.high !== undefined) {
+          highGasFees = Number(
+            gasFeeEstimates.high.suggestedMaxPriorityFeePerGas,
+          );
+        }
+
+        if (dappMaxFeePerGas > highGasFees) {
+          setEstimateUsed(PriorityLevels.dappSuggestedHigh);
+        }
+      }
+
       setGasLimit(Number(hexToDecimal(transaction?.txParams?.gas ?? '0x0')));
     }
   }, [

--- a/ui/hooks/gasFeeInput/useGasFeeInputs.js
+++ b/ui/hooks/gasFeeInput/useGasFeeInputs.js
@@ -18,12 +18,7 @@ import { isLegacyTransaction } from '../../helpers/utils/transactions.util';
 import { useGasFeeEstimates } from '../useGasFeeEstimates';
 
 import { editGasModeIsSpeedUpOrCancel } from '../../helpers/utils/gas';
-import {
-  decEthToConvertedCurrency,
-  hexToDecimal,
-  hexWEIToDecETH,
-  hexWEIToDecGWEI,
-} from '../../../shared/modules/conversion.utils';
+import { hexToDecimal } from '../../../shared/modules/conversion.utils';
 import { useGasFeeErrors } from './useGasFeeErrors';
 import { useGasPriceInput } from './useGasPriceInput';
 import { useMaxFeePerGasInput } from './useMaxFeePerGasInput';
@@ -164,7 +159,9 @@ export function useGasFeeInputs(
 
   const properGasLimit = Number(hexToDecimal(transaction?.originalGasEstimate));
 
-  const fee = useSelector((state) => transactionFeeSelector(state, transaction));
+  const fee = useSelector((state) =>
+    transactionFeeSelector(state, transaction),
+  );
 
   /**
    * In EIP-1559 V2 designs change to gas estimate is always updated to transaction
@@ -178,10 +175,7 @@ export function useGasFeeInputs(
         setInternalEstimateToUse(transaction?.userFeeLevel);
       }
 
-      console.log('fee: ', fee);
-      console.log('transaction: ', transaction);
-
-      if(fee.ethTransactionTotal > TOO_HIGH_GAS_LIMIT) {
+      if (fee.ethTransactionTotal > TOO_HIGH_GAS_LIMIT) {
         setEstimateUsed(PriorityLevels.dappSuggestedHigh);
       }
 

--- a/ui/hooks/gasFeeInput/useGasFeeInputs.js
+++ b/ui/hooks/gasFeeInput/useGasFeeInputs.js
@@ -6,7 +6,6 @@ import {
   GasRecommendations,
   EditGasModes,
   PriorityLevels,
-  TOO_HIGH_GAS_LIMIT,
 } from '../../../shared/constants/gas';
 import { GAS_FORM_ERRORS } from '../../helpers/constants/gas';
 import {
@@ -99,6 +98,9 @@ export function useGasFeeInputs(
   minimumGasLimit = '0x5208',
   editGasMode = EditGasModes.modifyInPlace,
 ) {
+
+  const GAS_LIMIT_TOO_HIGH_IN_ETH = '1';
+
   const initialRetryTxMeta = {
     txParams: _transaction?.txParams,
     id: _transaction?.id,
@@ -176,14 +178,12 @@ export function useGasFeeInputs(
         .times(new Numeric(transaction?.txParams?.maxFeePerGas ?? '0x0', 16))
         .toPrefixedHexString();
 
-      console.log('maximumGas: ', maximumGas);
       const fee = new Numeric(maximumGas, 16, EtherDenomination.WEI)
         .toDenomination(EtherDenomination.ETH)
         .toBase(10)
         .toString();
 
-      console.log('fee: ', fee);
-      if (Number(fee) > Number(TOO_HIGH_GAS_LIMIT)) {
+      if (Number(fee) > Number(GAS_LIMIT_TOO_HIGH_IN_ETH)) {
         setEstimateUsed(PriorityLevels.dappSuggestedHigh);
       }
 

--- a/ui/hooks/gasFeeInput/useGasFeeInputs.js
+++ b/ui/hooks/gasFeeInput/useGasFeeInputs.js
@@ -169,7 +169,6 @@ export function useGasFeeInputs(
   useEffect(() => {
     if (supportsEIP1559) {
       if (transaction?.userFeeLevel) {
-        setEstimateUsed(transaction?.userFeeLevel);
         setInternalEstimateToUse(transaction?.userFeeLevel);
       }
 
@@ -184,6 +183,8 @@ export function useGasFeeInputs(
 
       if (Number(fee) > Number(GAS_LIMIT_TOO_HIGH_IN_ETH)) {
         setEstimateUsed(PriorityLevels.dappSuggestedHigh);
+      } else if (transaction?.userFeeLevel) {
+        setEstimateUsed(transaction?.userFeeLevel);
       }
 
       setGasLimit(Number(hexToDecimal(transaction?.txParams?.gas ?? '0x0')));

--- a/ui/hooks/gasFeeInput/useGasFeeInputs.js
+++ b/ui/hooks/gasFeeInput/useGasFeeInputs.js
@@ -98,7 +98,6 @@ export function useGasFeeInputs(
   minimumGasLimit = '0x5208',
   editGasMode = EditGasModes.modifyInPlace,
 ) {
-
   const GAS_LIMIT_TOO_HIGH_IN_ETH = '1';
 
   const initialRetryTxMeta = {

--- a/ui/pages/confirm-send-ether/__snapshots__/confirm-send-ether.test.js.snap
+++ b/ui/pages/confirm-send-ether/__snapshots__/confirm-send-ether.test.js.snap
@@ -349,37 +349,13 @@ exports[`ConfirmSendEther should render correct information for for confirm send
                 <span
                   class="edit-gas-fee-button__label"
                 >
-                  Site suggested
+                  Site suggested high gas estimate
                 </span>
                 <span
                   class="box mm-icon mm-icon--size-xs box--display-inline-block box--flex-direction-row box--color-primary-default"
                   style="mask-image: url('./images/icons/arrow-right.svg');"
                 />
               </button>
-              <div
-                class="info-tooltip"
-              >
-                <div>
-                  <div
-                    aria-describedby="tippy-tooltip-2"
-                    class="info-tooltip__tooltip-container"
-                    data-original-title="null"
-                    data-tooltipped=""
-                    style="display: inline;"
-                    tabindex="0"
-                  >
-                    <svg
-                      viewBox="0 0 10 10"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M5 0C2.2 0 0 2.2 0 5s2.2 5 5 5 5-2.2 5-5-2.2-5-5-5zm0 2c.4 0 .7.3.7.7s-.3.7-.7.7-.7-.2-.7-.6.3-.8.7-.8zm.7 6H4.3V4.3h1.5V8z"
-                        fill="var(--color-icon-alternative)"
-                      />
-                    </svg>
-                  </div>
-                </div>
-              </div>
             </div>
           </div>
           <div
@@ -501,12 +477,13 @@ exports[`ConfirmSendEther should render correct information for for confirm send
                   class="box box--margin-top-1 box--margin-bottom-1 box--flex-direction-row typography transaction-detail-item__row-subText typography--h7 typography--weight-normal typography--style-normal typography--align-end typography--color-text-alternative"
                 >
                   <div
-                    class="box gas-details-item__gasfee-label box--display-inline-flex box--flex-direction-row"
+                    class="box gas-details-item__gasfee-label gas-details-item__gas-fee-warning box--display-inline-flex box--flex-direction-row"
                   >
                     <div
                       class="box box--margin-right-1 box--flex-direction-row"
                     >
                       <strong>
+                        ⚠ 
                         Max fee:
                       </strong>
                     </div>

--- a/ui/pages/confirm-send-ether/__snapshots__/confirm-send-ether.test.js.snap
+++ b/ui/pages/confirm-send-ether/__snapshots__/confirm-send-ether.test.js.snap
@@ -349,13 +349,37 @@ exports[`ConfirmSendEther should render correct information for for confirm send
                 <span
                   class="edit-gas-fee-button__label"
                 >
-                  Site suggested high gas estimate
+                  Site suggested
                 </span>
                 <span
                   class="box mm-icon mm-icon--size-xs box--display-inline-block box--flex-direction-row box--color-primary-default"
                   style="mask-image: url('./images/icons/arrow-right.svg');"
                 />
               </button>
+              <div
+                class="info-tooltip"
+              >
+                <div>
+                  <div
+                    aria-describedby="tippy-tooltip-2"
+                    class="info-tooltip__tooltip-container"
+                    data-original-title="null"
+                    data-tooltipped=""
+                    style="display: inline;"
+                    tabindex="0"
+                  >
+                    <svg
+                      viewBox="0 0 10 10"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M5 0C2.2 0 0 2.2 0 5s2.2 5 5 5 5-2.2 5-5-2.2-5-5-5zm0 2c.4 0 .7.3.7.7s-.3.7-.7.7-.7-.2-.7-.6.3-.8.7-.8zm.7 6H4.3V4.3h1.5V8z"
+                        fill="var(--color-icon-alternative)"
+                      />
+                    </svg>
+                  </div>
+                </div>
+              </div>
             </div>
           </div>
           <div
@@ -477,13 +501,12 @@ exports[`ConfirmSendEther should render correct information for for confirm send
                   class="box box--margin-top-1 box--margin-bottom-1 box--flex-direction-row typography transaction-detail-item__row-subText typography--h7 typography--weight-normal typography--style-normal typography--align-end typography--color-text-alternative"
                 >
                   <div
-                    class="box gas-details-item__gasfee-label gas-details-item__gas-fee-warning box--display-inline-flex box--flex-direction-row"
+                    class="box gas-details-item__gasfee-label box--display-inline-flex box--flex-direction-row"
                   >
                     <div
                       class="box box--margin-right-1 box--flex-direction-row"
                     >
                       <strong>
-                        ⚠ 
                         Max fee:
                       </strong>
                     </div>


### PR DESCRIPTION
## Explanation

When a Dapp triggers a transaction/contract interaction, it sets the proposed fees maxFeePerGas maxPriorityFeePerGas and gasLimit. MetaMask takes the values from the Dapp as they are and displayes Site suggested meaning that it's the Dapp who suggested the fees. Despite of that, if the Dapp sets a high value, user can loose all its money and there is no warning on MM side.

This PR shows a warning icon and colour when dapp suggested fee is higher than aggressive suggested fees.

Fixes: #17313 

test

## Screenshots/Screencaps

### Before

![](https://user-images.githubusercontent.com/54408225/237359531-9052f11c-1e66-4e68-a04b-aa8b5d24fd64.png)


### After

<img width="417" alt="Screenshot 2023-05-10 at 14 43 12" src="https://github.com/MetaMask/metamask-extension/assets/44811/8bc2172a-0ec3-478e-a935-14f591c4b969">


## Manual Testing Steps

1. Clone test dapp https://github.com/MetaMask/test-dapp
2. Set some high fee values on lines 637 and 638
maxFeePerGas: '0x38D7EA4C68000',
maxPriorityFeePerGas: '0x38D7EA4C68000',
3. Start test dapp: npm start
4. Go to localhost:9011
5. Connect MM
6. Click Send EIP1559
7. See suggested fees with warning colour and icon

## Pre-merge author checklist

- [ ] I've clearly explained:
  - [ ] What problem this PR is solving
  - [ ] How this problem was solved
  - [ ] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
