### PR TITLE
fix: use approvals selector fn in permission selectors

### DIFF
--- a/ui/selectors/permissions.js
+++ b/ui/selectors/permissions.js
@@ -1,7 +1,9 @@
+import { ApprovalType } from '@metamask/controller-utils';
 ///: BEGIN:ONLY_INCLUDE_IN(snaps)
 import { WALLET_SNAP_PERMISSION_KEY } from '@metamask/rpc-methods';
 ///: END:ONLY_INCLUDE_IN
 import { CaveatTypes } from '../../shared/constants/permissions';
+import { getApprovalRequestsByType } from './approvals';
 import {
   getMetaMaskAccountsOrdered,
   getOriginOfCurrentTab,
@@ -341,9 +343,10 @@ export function getFirstSnapInstallOrUpdateRequest(state) {
 ///: END:ONLY_INCLUDE_IN
 
 export function getPermissionsRequests(state) {
-  return Object.values(state.metamask.pendingApprovals)
-    .filter(({ type }) => type === 'wallet_requestPermissions')
-    .map(({ requestData }) => requestData);
+  return getApprovalRequestsByType(
+    state,
+    ApprovalType.WalletRequestPermissions,
+  ).map(({ requestData }) => requestData);
 }
 
 export function getFirstPermissionRequest(state) {


### PR DESCRIPTION
## Explanation

This is PR is a part of centralising approvals selector by using same selector function in all selectors.

## Manual Testing Steps

No functional changes 

## Pre-merge author checklist

- [X] I've clearly explained:
  - [X] What problem this PR is solving
  - [X] How this problem was solved
  - [ ] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
