### PR TITLE
Skip injection on snaps iframe

### DIFF
--- a/shared/modules/provider-injection.js
+++ b/shared/modules/provider-injection.js
@@ -65,17 +65,17 @@ function documentElementCheck() {
  */
 function blockedDomainCheck() {
   const blockedDomains = [
-    'execution.metamask.io',
-    'uscourts.gov',
-    'dropbox.com',
-    'webbyawards.com',
-    'cdn.shopify.com/s/javascripts/tricorder/xtld-read-only-frame.html',
-    'adyen.com',
-    'gravityforms.com',
-    'harbourair.com',
-    'ani.gamer.com.tw',
-    'blueskybooking.com',
-    'sharefile.com',
+    'execution\.metamask\.io',
+    'uscourts\.gov',
+    'dropbox\.com',
+    'webbyawards\.com',
+    'cdn\.shopify\.com/s/javascripts/tricorder/xtld-read-only-frame.html',
+    'adyen\.com',
+    'gravityforms\.com',
+    'harbourair\.com',
+    'ani\.gamer\.com\.tw',
+    'blueskybooking\.com',
+    'sharefile\.com',
   ];
   const currentUrl = window.location.href;
   let currentRegex;

--- a/shared/modules/provider-injection.js
+++ b/shared/modules/provider-injection.js
@@ -65,17 +65,17 @@ function documentElementCheck() {
  */
 function blockedDomainCheck() {
   const blockedDomains = [
-    'execution\.metamask\.io',
-    'uscourts\.gov',
-    'dropbox\.com',
-    'webbyawards\.com',
-    'cdn\.shopify\.com/s/javascripts/tricorder/xtld-read-only-frame.html',
-    'adyen\.com',
-    'gravityforms\.com',
-    'harbourair\.com',
-    'ani\.gamer\.com\.tw',
-    'blueskybooking\.com',
-    'sharefile\.com',
+    'execution.metamask.io',
+    'uscourts.gov',
+    'dropbox.com',
+    'webbyawards.com',
+    'cdn.shopify.com/s/javascripts/tricorder/xtld-read-only-frame.html',
+    'adyen.com',
+    'gravityforms.com',
+    'harbourair.com',
+    'ani.gamer.com.tw',
+    'blueskybooking.com',
+    'sharefile.com',
   ];
   const currentUrl = window.location.href;
   let currentRegex;

--- a/shared/modules/provider-injection.js
+++ b/shared/modules/provider-injection.js
@@ -65,6 +65,7 @@ function documentElementCheck() {
  */
 function blockedDomainCheck() {
   const blockedDomains = [
+    'execution.metamask.io',
     'uscourts.gov',
     'dropbox.com',
     'webbyawards.com',


### PR DESCRIPTION
When developing snaps, you sometimes get lavamoat errors b/c MM tries to inject the provider in the snaps iframe, which is locked down with LavaMoat.

So this change will stop trying to do that so we no longer throw these errors that instruct snaps devs to bother the team:
![image](https://github.com/MetaMask/metamask-extension/assets/542863/e6dd9650-6be7-4a45-847b-e3d0f3b0bdd7)
