### PR TITLE
Ensure the GasDetailsItem component can handle a tx with a maxPriorityFee of 0

### DIFF
--- a/ui/components/app/gas-details-item/gas-details-item.js
+++ b/ui/components/app/gas-details-item/gas-details-item.js
@@ -52,12 +52,12 @@ const GasDetailsItem = ({ userAcknowledgedGasMissing = false }) => {
 
   const maxPriorityFeePerGasToRender = (
     maxPriorityFeePerGas ??
-    hexWEIToDecGWEI(transactionData?.txParams?.maxPriorityFeePerGas ?? '0x0')
+    hexWEIToDecGWEI(transactionData.txParams?.maxPriorityFeePerGas ?? '0x0')
   ).toString();
 
   const maxFeePerGasToRender = (
     maxFeePerGas ??
-    hexWEIToDecGWEI(transactionData?.txParams?.maxFeePerGas ?? '0x0')
+    hexWEIToDecGWEI(transactionData.txParams?.maxFeePerGas ?? '0x0')
   ).toString();
 
   return (

--- a/ui/components/app/gas-details-item/gas-details-item.js
+++ b/ui/components/app/gas-details-item/gas-details-item.js
@@ -51,17 +51,13 @@ const GasDetailsItem = ({ userAcknowledgedGasMissing = false }) => {
   }
 
   const maxPriorityFeePerGasToRender = (
-    maxPriorityFeePerGas === undefined
-      ? hexWEIToDecGWEI(
-          transactionData?.txParams?.maxPriorityFeePerGas ?? '0x0',
-        )
-      : maxPriorityFeePerGas
+    maxPriorityFeePerGas ??
+    hexWEIToDecGWEI(transactionData?.txParams?.maxPriorityFeePerGas ?? '0x0')
   ).toString();
 
   const maxFeePerGasToRender = (
-    maxFeePerGas === undefined
-      ? hexWEIToDecGWEI(transactionData?.txParams?.maxFeePerGas ?? '0x0')
-      : maxFeePerGas
+    maxFeePerGas ??
+    hexWEIToDecGWEI(transactionData?.txParams?.maxFeePerGas ?? '0x0')
   ).toString();
 
   return (

--- a/ui/components/app/gas-details-item/gas-details-item.js
+++ b/ui/components/app/gas-details-item/gas-details-item.js
@@ -50,6 +50,20 @@ const GasDetailsItem = ({ userAcknowledgedGasMissing = false }) => {
     return null;
   }
 
+  const maxPriorityFeePerGasToRender = (
+    maxPriorityFeePerGas === undefined
+      ? hexWEIToDecGWEI(
+          transactionData?.txParams?.maxPriorityFeePerGas ?? '0x0',
+        )
+      : maxPriorityFeePerGas
+  ).toString();
+
+  const maxFeePerGasToRender = (
+    maxFeePerGas === undefined
+      ? hexWEIToDecGWEI(transactionData?.txParams?.maxFeePerGas ?? '0x0')
+      : maxFeePerGas
+  ).toString();
+
   return (
     <TransactionDetailItem
       key="gas-details-item"
@@ -113,14 +127,8 @@ const GasDetailsItem = ({ userAcknowledgedGasMissing = false }) => {
       }
       subTitle={
         <GasTiming
-          maxPriorityFeePerGas={(
-            maxPriorityFeePerGas ||
-            hexWEIToDecGWEI(transactionData.txParams.maxPriorityFeePerGas)
-          ).toString()}
-          maxFeePerGas={(
-            maxFeePerGas ||
-            hexWEIToDecGWEI(transactionData.txParams.maxFeePerGas)
-          ).toString()}
+          maxPriorityFeePerGas={maxPriorityFeePerGasToRender}
+          maxFeePerGas={maxFeePerGasToRender}
         />
       }
     />

--- a/ui/components/app/gas-details-item/gas-details-item.test.js
+++ b/ui/components/app/gas-details-item/gas-details-item.test.js
@@ -110,4 +110,43 @@ describe('GasDetailsItem', () => {
       expect(screen.queryAllByText('ETH').length).toBeGreaterThan(0);
     });
   });
+
+  it('should render gas fee details if maxPriorityFeePerGas is 0', async () => {
+    render({
+      contextProps: {
+        transaction: {
+          txParams: {
+            gas: '0x5208',
+            maxFeePerGas: '0x59682f10',
+            maxPriorityFeePerGas: '0',
+          },
+          simulationFails: false,
+          userFeeLevel: 'low',
+        },
+      },
+    });
+    await waitFor(() => {
+      expect(screen.queryAllByTitle('0.0000315 ETH').length).toBeGreaterThan(0);
+      expect(screen.queryAllByText('ETH').length).toBeGreaterThan(0);
+    });
+  });
+
+  it('should render gas fee details if maxPriorityFeePerGas is undefined', async () => {
+    render({
+      contextProps: {
+        transaction: {
+          txParams: {
+            gas: '0x5208',
+            maxFeePerGas: '0x59682f10',
+          },
+          simulationFails: false,
+          userFeeLevel: 'low',
+        },
+      },
+    });
+    await waitFor(() => {
+      expect(screen.queryAllByTitle('0.0000315 ETH').length).toBeGreaterThan(0);
+      expect(screen.queryAllByText('ETH').length).toBeGreaterThan(0);
+    });
+  });
 });


### PR DESCRIPTION
Fixes https://github.com/MetaMask/metamask-extension/issues/19091

## Explanation

The `GasDetailsItem` component had this code prior to this PR:

```
            maxPriorityFeePerGas ||
            hexWEIToDecGWEI(transactionData.txParams.maxPriorityFeePerGas)
```

This causes an error when `maxPriorityFeePerGas` is `0` and `transactionData.txParams` is `undefined`. `transactionData.txParams` will only be defined if we are in the send flow, and so `getCurrentDraftTransaction` returns a transaction. So the error would occur if we are on the confirm screen and `maxPriorityFeePerGas` is `0`

This situation can happen in two ways:
1. A dapp creates a transaction and explicitly sets the `maxPriorityFeePerGas` to 0
2. A dapp creates a transaction and doesn't set a `maxPriorityFeePerGas`, and this occurs on a network where [our transaction controller defaults the `maxPriorityFeePerGas` to 0](https://github.com/MetaMask/metamask-extension/blob/develop/app/scripts/controllers/transactions/index.js#L1041)

Defaulting the `maxPriorityFeePerGas` to zero will only happen on certain networks, arbitrum being the currently known example. (fyi, this bug was first reported by 5 different users on arbitrum)

The `maxPriorityFeePerGas` being zero would cause  `maxPriorityFeePerGas || hexWEIToDecGWEI(transactionData.txParams.maxPriorityFeePerGas)` to resolve to `hexWEIToDecGWEI(transactionData.txParams.maxPriorityFeePerGas)` because in `GasDetailsItem` if `maxPriorityFeePerGas` is 0, it will be a `Number` and not a string. This is ultimately because of the logic and handling of types in `useMaxPriorityFeePerGasInput`

This PR fixes the present bug by properly handling the possible types within the `GasDetailsItem` component. A unit test is also added that would have failed prior to this PR.

Meanwhile, the handling of types in `useMaxPriorityFeePerGasInput`, in particular when dealing with `0` or equivalent values, should be revisited and very likely cleaned up in some way. However, I leave that work to the future: https://github.com/MetaMask/metamask-extension/issues/19103


## Screenshots/Screencaps

### Before

https://github.com/MetaMask/metamask-extension/assets/7499938/1c2fa068-e28e-4f0d-87c8-4cbc410fbdcb

### After

https://github.com/MetaMask/metamask-extension/assets/7499938/51c6b961-016c-48d2-92e1-2ce9718b7d76

## Manual Testing Steps

1. Switch to the Arbitrum network
2. Go to https://metamask.github.io/test-dapp/
3. Scroll down to the form at the bottom
4. Enter an ERC20 token contract address in the `to` field, e.g. `0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9` (which is USDT on the arbitrum chain)
5. Select a type 2 transaction
6. enter a value for "Max Fee" but not for "Max Priority Fee"
7. In the "Data" field, enter the data necessary for an ERC20 token `approve` call. e.g. `0x095ea7b3000000000000000000000000000000000022d473030f116ddee9f6b43ac78ba3ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff`
8. When the confirmation popup loads, enter an approval amount and click "Next".
9. The second step of the token approval flow should render without error.

You should also be able to repeat the same steps as above, but on another network and in step 6, explictly set "Max Priority Fee" to `0`

Both of the above scenarios should fail on `develop` or `master` (with an error at step 9), but succeed on this branch

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
