### PR TITLE
permissions-connect: mark requestType as required only on snaps

### DIFF
--- a/ui/pages/permissions-connect/permissions-connect.component.js
+++ b/ui/pages/permissions-connect/permissions-connect.component.js
@@ -38,8 +38,8 @@ export default class PermissionConnect extends Component {
     history: PropTypes.object.isRequired,
     connectPath: PropTypes.string.isRequired,
     confirmPermissionPath: PropTypes.string.isRequired,
-    requestType: PropTypes.string.isRequired,
     ///: BEGIN:ONLY_INCLUDE_IN(snaps)
+    requestType: PropTypes.string.isRequired,
     snapInstallPath: PropTypes.string.isRequired,
     snapUpdatePath: PropTypes.string.isRequired,
     snapResultPath: PropTypes.string.isRequired,


### PR DESCRIPTION
## Explanation
This fixes a regression from #18802 where `requestType` got introduced as a required opt for all build types, resulting in errors being thrown on dapps trying to connect.

This moves the opt inside the guard.

## Screenshots/Screencaps


### Before


### After


## Manual Testing Steps

## Pre-merge author checklist

- [ ] I've clearly explained:
  - [ ] What problem this PR is solving
  - [ ] How this problem was solved
  - [ ] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
