### PR TITLE
UX: Multichain: Don't filter out custom Mainnet RPCs

### DIFF
--- a/test/data/mock-state.json
+++ b/test/data/mock-state.json
@@ -120,7 +120,8 @@
     "networkConfigurations": {
       "testNetworkConfigurationId": {
         "rpcUrl": "https://testrpc.com",
-        "chainId": "0x1"
+        "chainId": "0x1",
+        "nickname": "Custom Mainnet RPC"
       }
     },
     "keyrings": [

--- a/ui/components/multichain/network-list-menu/network-list-menu.js
+++ b/ui/components/multichain/network-list-menu/network-list-menu.js
@@ -76,7 +76,7 @@ export const NetworkListMenu = ({ onClose }) => {
     >
       <>
         <Box className="multichain-network-list-menu" ref={networkListRef}>
-          {networks.map((network) => {
+          {networks.map((network, index) => {
             const isCurrentNetwork = currentChainId === network.chainId;
             const canDeleteNetwork =
               !isCurrentNetwork &&
@@ -86,7 +86,7 @@ export const NetworkListMenu = ({ onClose }) => {
               <NetworkListItem
                 name={network.nickname}
                 iconSrc={network?.rpcPrefs?.imageUrl}
-                key={network.id || network.chainId}
+                key={`${network.id || network.chainId}-${index}`}
                 selected={isCurrentNetwork}
                 onClick={async () => {
                   dispatch(toggleNetworkMenu());

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -1188,7 +1188,6 @@ export function getAllNetworks(state) {
       ({ chainId }) =>
         ![
           CHAIN_IDS.LOCALHOST,
-          CHAIN_IDS.MAINNET,
           // Linea gets added as a custom network configuration so
           // we must ignore it here to display in test networks
           CHAIN_IDS.LINEA_TESTNET,


### PR DESCRIPTION
## Explanation

@Gudahtt mentioned that we need to remove the extra Mainnet filter so that users can have their own RPC.  I've updated the `getAllNetworks` selector to remove the extra filtering, as well as updated test data to prevent weird errors and warnings.  Also updated the item key in the case that Mainnet chain ID is duplicated.

## Pre-merge author checklist

- [ ] I've clearly explained:
  - [ ] What problem this PR is solving
  - [ ] How this problem was solved
  - [ ] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
