### PR TITLE
Fixes clear button size TextFieldSearch

### DIFF
--- a/ui/components/component-library/text-field-search/text-field-search.js
+++ b/ui/components/component-library/text-field-search/text-field-search.js
@@ -4,6 +4,7 @@ import classnames from 'classnames';
 
 import { ButtonIcon, ButtonIconSize, Icon, IconName, IconSize } from '..';
 import { TextField, TEXT_FIELD_TYPES } from '../text-field';
+import { useI18nContext } from '../../../hooks/useI18nContext';
 
 export const TextFieldSearch = ({
   className,
@@ -15,37 +16,40 @@ export const TextFieldSearch = ({
   value,
   onChange,
   ...props
-}) => (
-  <TextField
-    className={classnames('mm-text-field-search', className)}
-    value={value}
-    onChange={onChange}
-    type={TEXT_FIELD_TYPES.SEARCH}
-    endAccessory={
-      value && showClearButton ? (
-        <>
-          <ButtonIcon
-            className="mm-text-field__button-clear"
-            ariaLabel="Clear" // TODO: i18n
-            iconName={IconName.Close}
-            size={ButtonIconSize.Sm}
-            onClick={clearButtonOnClick}
-            {...clearButtonProps}
-          />
-          {endAccessory}
-        </>
-      ) : (
-        endAccessory
-      )
-    }
-    startAccessory={<Icon name={IconName.Search} size={IconSize.Sm} />}
-    inputProps={{
-      marginRight: showClearButton ? 6 : 0,
-      ...inputProps,
-    }}
-    {...props}
-  />
-);
+}) => {
+  const t = useI18nContext();
+  return (
+    <TextField
+      className={classnames('mm-text-field-search', className)}
+      value={value}
+      onChange={onChange}
+      type={TEXT_FIELD_TYPES.SEARCH}
+      endAccessory={
+        value && showClearButton ? (
+          <>
+            <ButtonIcon
+              className="mm-text-field__button-clear"
+              ariaLabel={t('clear')}
+              iconName={IconName.Close}
+              size={ButtonIconSize.Sm}
+              onClick={clearButtonOnClick}
+              {...clearButtonProps}
+            />
+            {endAccessory}
+          </>
+        ) : (
+          endAccessory
+        )
+      }
+      startAccessory={<Icon name={IconName.Search} size={IconSize.Sm} />}
+      inputProps={{
+        marginRight: showClearButton ? 6 : 0,
+        ...inputProps,
+      }}
+      {...props}
+    />
+  );
+};
 
 TextFieldSearch.propTypes = {
   /**

--- a/ui/components/component-library/text-field-search/text-field-search.js
+++ b/ui/components/component-library/text-field-search/text-field-search.js
@@ -28,7 +28,7 @@ export const TextFieldSearch = ({
             className="mm-text-field__button-clear"
             ariaLabel="Clear" // TODO: i18n
             iconName={IconName.Close}
-            size={ButtonIconSize.SM}
+            size={ButtonIconSize.Sm}
             onClick={clearButtonOnClick}
             {...clearButtonProps}
           />

--- a/ui/components/component-library/text-field-search/text-field-search.scss
+++ b/ui/components/component-library/text-field-search/text-field-search.scss
@@ -1,5 +1,9 @@
 .mm-text-field-search {
-  ::-webkit-search-cancel-button {
-    display: none; // hides the default search cancel button
+  // hides the native search icon and clear button
+  ::-webkit-search-decoration,
+  ::-webkit-search-cancel-button,
+  ::-webkit-search-results-button,
+  ::-webkit-search-results-decoration {
+    display: none;
   }
 }

--- a/ui/components/component-library/text-field-search/text-field-search.test.js
+++ b/ui/components/component-library/text-field-search/text-field-search.test.js
@@ -29,7 +29,7 @@ describe('TextFieldSearch', () => {
     });
     await user.type(getByRole('searchbox'), 'test value');
     expect(getByRole('searchbox')).toHaveValue('test value');
-    expect(getByRole('button', { name: /Clear/u })).toBeDefined();
+    expect(getByRole('button', { name: /clear/u })).toBeDefined();
   });
   it('should still render with the endAccessory if it exists', async () => {
     const fn = jest.fn();
@@ -43,7 +43,7 @@ describe('TextFieldSearch', () => {
     );
     await user.type(getByRole('searchbox'), 'test value');
     expect(getByRole('searchbox')).toHaveValue('test value');
-    expect(getByRole('button', { name: /Clear/u })).toBeDefined();
+    expect(getByRole('button', { name: /clear/u })).toBeDefined();
     expect(getByText('end-accessory')).toBeDefined();
   });
   it('should fire onClick event when passed to clearButtonOnClick when clear button is clicked', async () => {
@@ -53,7 +53,7 @@ describe('TextFieldSearch', () => {
       clearButtonOnClick: fn,
     });
     await user.type(getByRole('searchbox'), 'test value');
-    await user.click(getByRole('button', { name: /Clear/u }));
+    await user.click(getByRole('button', { name: /clear/u }));
     expect(fn).toHaveBeenCalledTimes(1);
   });
   it('should fire onClick event when passed to clearButtonProps.onClick prop', async () => {
@@ -64,7 +64,7 @@ describe('TextFieldSearch', () => {
       clearButtonOnClick: fn,
     });
     await user.type(getByRole('searchbox'), 'test value');
-    await user.click(getByRole('button', { name: /Clear/u }));
+    await user.click(getByRole('button', { name: /clear/u }));
     expect(fn).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## Explanation
Currently there is an incorrect prop being passed to the clear button in the `TextFieldSearch` component that is making it HUGE. This probably happened during some TS migration work. This PR fixes that broken prop and maintains appropriate sized buttons in the `TextFieldSearch` universe


* Fixes #19152 
* Fixes https://github.com/MetaMask/design-tokens/issues/466
* Fixes https://github.com/MetaMask/metamask-extension/issues/18864

## Screenshots/Screencaps

<!-- If you're making a change to the UI, make sure to capture a screenshot or a short video showing off your work! -->

### Before

Incorrect sized clear button TOO BIG

<img width="558" alt="Screenshot 2023-05-16 at 7 50 08 AM" src="https://github.com/MetaMask/metamask-extension/assets/8112138/2a573503-f36c-40fd-acd9-bba6d4693d43">

Native browser search icon shows up on mobile browsers

<img width="300" src="https://github.com/MetaMask/metamask-extension/assets/8112138/4fd970fa-e5e8-4057-8dda-b6c855939f74">


### After

Appropriately sized clear button

<img width="639" alt="Screenshot 2023-05-16 at 7 49 19 AM" src="https://github.com/MetaMask/metamask-extension/assets/8112138/299acc2f-f783-44e1-9dfd-31221dffcf6a">

No native search icon or clear button on mobile browsers

<img width="300" src="https://github.com/MetaMask/metamask-extension/assets/8112138/b43f2a10-cfd6-44e1-85e6-ca85038637de">


Also did a search to confirm there where no other incorrect instances of the button icon size being passed

<img width="308" alt="Screenshot 2023-05-16 at 7 58 55 AM" src="https://github.com/MetaMask/metamask-extension/assets/8112138/4e977a67-8c76-45fc-b5dc-971f3632422f">
<img width="324" alt="Screenshot 2023-05-16 at 7 59 10 AM" src="https://github.com/MetaMask/metamask-extension/assets/8112138/a178796c-3e34-470a-935f-a269dfb4e606">


## Manual Testing Steps

- Go to the storybook build on this PR
- Search `TextFieldSearch` in the search bar
- Click into the input and type something to show the clear button
- See that it is more a appropriate size

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
