### PR TITLE
Accept hexadecimal response from `net_version`

### DIFF
--- a/app/scripts/controllers/network/network-controller.ts
+++ b/app/scripts/controllers/network/network-controller.ts
@@ -302,12 +302,12 @@ function isErrorWithCode(error: unknown): error is { code: string | number } {
 
 /**
  * Asserts that the given value is a network ID, i.e., that it is a decimal
- * number represented as a string.
+ * or hexadecimal number represented as a string.
  *
  * @param value - The value to check.
  */
 function assertNetworkId(value: any): asserts value is NetworkId {
-  if (!/^\d+$/u.test(value) || Number.isNaN(Number(value))) {
+  if (!/^0x[\da-fA-F]+|\d+$/u.test(value) || Number.isNaN(Number(value))) {
     throw new Error('value is not a number');
   }
 }


### PR DESCRIPTION
## Explanation

Networks which return a hexadecimal response from `net_version` used to work, but now don't - #19151

This PR relaxes the validation, so we accept hexadecimal chain IDs.

Fixes #19151

<!--
Thanks for the pull request. Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues, Slack conversations, Zendesk issues, user stories, etc. reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

## Manual Testing Steps

**I have not yet tested anything, I will do that as soon as possible. I'm raising this early in case it helps.**

## Pre-merge author checklist

- [ ] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [ ] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
