### PR TITLE
Support hex and number `net_version` responses

### DIFF
--- a/app/scripts/controllers/network/network-controller.test.ts
+++ b/app/scripts/controllers/network/network-controller.test.ts
@@ -5,6 +5,7 @@ import { v4 } from 'uuid';
 import nock from 'nock';
 import { ControllerMessenger } from '@metamask/base-controller';
 import { SafeEventEmitterProvider } from '@metamask/eth-json-rpc-provider';
+import { toHex } from '@metamask/controller-utils';
 import { when, resetAllWhenMocks } from 'jest-when';
 import { ethErrors } from 'eth-rpc-errors';
 import { NETWORK_TYPES } from '../../../../shared/constants/network';
@@ -6320,55 +6321,62 @@ function lookupNetworkTests({
   operation: (controller: NetworkController) => Promise<void>;
 }) {
   describe('if the network ID and network details requests resolve successfully', () => {
-    describe('if the current network is different from the network in state', () => {
-      it('updates the network in state to match', async () => {
-        await withController(
-          {
-            state: initialState,
-          },
-          async ({ controller }) => {
-            await setFakeProvider(controller, {
-              stubs: [
-                {
-                  request: { method: 'net_version' },
-                  response: { result: '12345' },
-                },
-              ],
-              stubLookupNetworkWhileSetting: true,
-            });
+    const validNetworkIds = [12345, '12345', toHex(12345)];
+    for (const networkId of validNetworkIds) {
+      describe(`with a network id of '${networkId}'`, () => {
+        describe('if the current network is different from the network in state', () => {
+          it('updates the network in state to match', async () => {
+            await withController(
+              {
+                state: initialState,
+              },
+              async ({ controller }) => {
+                await setFakeProvider(controller, {
+                  stubs: [
+                    {
+                      request: { method: 'net_version' },
+                      response: { result: networkId },
+                    },
+                  ],
+                  stubLookupNetworkWhileSetting: true,
+                });
 
-            await operation(controller);
+                await operation(controller);
 
-            expect(controller.store.getState().networkId).toBe('12345');
-          },
-        );
+                expect(controller.store.getState().networkId).toBe('12345');
+              },
+            );
+          });
+        });
+
+        describe('if the version of the current network is the same as that in state', () => {
+          it('does not change network ID in state', async () => {
+            await withController(
+              {
+                state: initialState,
+              },
+              async ({ controller }) => {
+                await setFakeProvider(controller, {
+                  stubs: [
+                    {
+                      request: { method: 'net_version' },
+                      response: { result: networkId },
+                    },
+                  ],
+                  stubLookupNetworkWhileSetting: true,
+                });
+
+                await operation(controller);
+
+                await expect(controller.store.getState().networkId).toBe(
+                  '12345',
+                );
+              },
+            );
+          });
+        });
       });
-    });
-
-    describe('if the version of the current network is the same as that in state', () => {
-      it('does not change network ID in state', async () => {
-        await withController(
-          {
-            state: initialState,
-          },
-          async ({ controller }) => {
-            await setFakeProvider(controller, {
-              stubs: [
-                {
-                  request: { method: 'net_version' },
-                  response: { result: '12345' },
-                },
-              ],
-              stubLookupNetworkWhileSetting: true,
-            });
-
-            await operation(controller);
-
-            await expect(controller.store.getState().networkId).toBe('12345');
-          },
-        );
-      });
-    });
+    }
 
     describe('if the network details of the current network are different from the network details in state', () => {
       it('updates the network in state to match', async () => {

--- a/app/scripts/controllers/network/network-controller.ts
+++ b/app/scripts/controllers/network/network-controller.ts
@@ -10,10 +10,11 @@ import {
 import EthQuery from 'eth-query';
 import { RestrictedControllerMessenger } from '@metamask/base-controller';
 import { v4 as uuid } from 'uuid';
-import { Hex, isPlainObject } from '@metamask/utils';
+import { Hex, isPlainObject, isStrictHexString } from '@metamask/utils';
 import { errorCodes } from 'eth-rpc-errors';
 import { SafeEventEmitterProvider } from '@metamask/eth-json-rpc-provider';
 import { PollingBlockTracker } from 'eth-block-tracker';
+import { hexToDecimal } from '../../../../shared/modules/conversion.utils';
 import {
   INFURA_PROVIDER_TYPES,
   INFURA_BLOCKED_KEY,
@@ -301,15 +302,22 @@ function isErrorWithCode(error: unknown): error is { code: string | number } {
 }
 
 /**
- * Asserts that the given value is a network ID, i.e., that it is a decimal
- * number represented as a string.
+ * Convert the given value into a valid network ID. The ID is accepted
+ * as either a number, a decimal string, or a 0x-prefixed hex string.
  *
- * @param value - The value to check.
+ * @param value - The network ID to convert, in an unknown format.
+ * @returns A valid network ID (as a decimal string)
+ * @throws If the given value cannot be safely parsed.
  */
-function assertNetworkId(value: any): asserts value is NetworkId {
-  if (!/^\d+$/u.test(value) || Number.isNaN(Number(value))) {
-    throw new Error('value is not a number');
+function convertNetworkId(value: unknown): NetworkId {
+  if (typeof value === 'number' && !Number.isNaN(value)) {
+    return `${value}`;
+  } else if (isStrictHexString(value)) {
+    return hexToDecimal(value) as NetworkId;
+  } else if (typeof value === 'string' && /^\d+$/u.test(value)) {
+    return value as NetworkId;
   }
+  throw new Error(`Cannot parse as a valid network ID: '${value}'`);
 }
 
 /**
@@ -618,8 +626,7 @@ export class NetworkController extends EventEmitter {
         this.#determineEIP1559Compatibility(provider),
       ]);
       const possibleNetworkId = results[0];
-      assertNetworkId(possibleNetworkId);
-      networkId = possibleNetworkId;
+      networkId = convertNetworkId(possibleNetworkId);
       supportsEIP1559 = results[1];
       networkStatus = NetworkStatus.Available;
     } catch (error) {


### PR DESCRIPTION
## Explanation

Hex and number responses from the `net_version` request are now accepted. While most chains return decimal strings for this request, some chains were returning hex responses instead and failing our validation for this request (which was added in v10.30.0). This resolves that problem.

Support for number responses was added because it likely worked in older versions as well, so support is maintained to avoid similar problems.

Fixes #19151

## Manual Testing Steps

- Add The SKALE custom network using the information shown here: https://mainnet.skalenodes.com/#/chains/elated-tan-skat
- Switch to this network, and see that it is able to successfully connect
  - Previously it would say "Loading" for some time, followed by an "Oops, something failed" message and a "Try again" button.

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
