### PR TITLE
Add logging for `lookupNetwork`

### DIFF
--- a/app/scripts/controllers/network/network-controller.ts
+++ b/app/scripts/controllers/network/network-controller.ts
@@ -637,10 +637,16 @@ export class NetworkController extends EventEmitter {
           isPlainObject(responseBody) &&
           responseBody.error === INFURA_BLOCKED_KEY
         ) {
+          log.warn('NetworkController - network blocked', error);
           networkStatus = NetworkStatus.Blocked;
         } else if (error.code === errorCodes.rpc.internal) {
+          log.warn(
+            'NetworkController - could not determine network status',
+            error,
+          );
           networkStatus = NetworkStatus.Unknown;
         } else {
+          log.warn('NetworkController - network unavailable', error);
           networkStatus = NetworkStatus.Unavailable;
         }
       } else {


### PR DESCRIPTION
## Explanation

The `lookupNetwork` method of the network controller now includes console warnings for all branches where we fail to connect to a network. This can be very useful when investigating bug reports.

Failing to connect to a network is in a class of errors that is expected, but still noteworthy and potentially related to a bug. Console warnings are a good solution for these situations; they provide hints in the console for anyone investigating, and they show up in Sentry if a real error is thrown in the vicinity of the warning.

## Manual Testing Steps

I noticed these logs were missing when reproducing #19151. A good way to test this would be to reproduce that bug, and see that a helpful console warning is left in the background process.

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
