### PR TITLE
Cleanup PR: Renaming getNetworkName and moving that to utils file

### DIFF
--- a/ui/components/app/dropdowns/network-dropdown.js
+++ b/ui/components/app/dropdowns/network-dropdown.js
@@ -230,27 +230,6 @@ class NetworkDropdown extends Component {
     );
   }
 
-  getNetworkName() {
-    const { providerConfig } = this.props;
-    const providerName = providerConfig.type;
-    const { t } = this.context;
-
-    switch (providerName) {
-      case NETWORK_TYPES.MAINNET:
-        return t('mainnet');
-      case NETWORK_TYPES.GOERLI:
-        return t('goerli');
-      case NETWORK_TYPES.SEPOLIA:
-        return t('sepolia');
-      case NETWORK_TYPES.LINEA_TESTNET:
-        return t('lineatestnet');
-      case NETWORK_TYPES.LOCALHOST:
-        return t('localhost');
-      default:
-        return providerConfig.nickname || t('unknownNetwork');
-    }
-  }
-
   renderNetworkEntry(network) {
     const {
       providerConfig: { type: providerType },

--- a/ui/components/app/signature-request-original/signature-request-original.component.js
+++ b/ui/components/app/signature-request-original/signature-request-original.component.js
@@ -5,6 +5,7 @@ import { ObjectInspector } from 'react-inspector';
 import LedgerInstructionField from '../ledger-instruction-field';
 import { MESSAGE_TYPE } from '../../../../shared/constants/app';
 import {
+  getNetworkNameFromProviderType,
   getURLHostName,
   sanitizeString,
   ///: BEGIN:ONLY_INCLUDE_IN(build-mmi)
@@ -30,7 +31,6 @@ import {
   BackgroundColor,
   ///: END:ONLY_INCLUDE_IN
 } from '../../../helpers/constants/design-system';
-import { NETWORK_TYPES } from '../../../../shared/constants/network';
 import { Numeric } from '../../../../shared/modules/Numeric';
 import { EtherDenomination } from '../../../../shared/constants/common';
 import ConfirmPageContainerNavigation from '../confirm-page-container/confirm-page-container-navigation';
@@ -80,27 +80,6 @@ export default class SignatureRequestOriginal extends Component {
   state = {
     showSignatureRequestWarning: false,
   };
-
-  getNetworkName() {
-    const { providerConfig } = this.props;
-    const providerName = providerConfig.type;
-    const { t } = this.context;
-
-    switch (providerName) {
-      case NETWORK_TYPES.MAINNET:
-        return t('mainnet');
-      case NETWORK_TYPES.GOERLI:
-        return t('goerli');
-      case NETWORK_TYPES.SEPOLIA:
-        return t('sepolia');
-      case NETWORK_TYPES.LINEA_TESTNET:
-        return t('lineatestnet');
-      case NETWORK_TYPES.LOCALHOST:
-        return t('localhost');
-      default:
-        return providerConfig.nickname || t('unknownNetwork');
-    }
-  }
 
   msgHexToText = (hex) => {
     try {
@@ -348,6 +327,7 @@ export default class SignatureRequestOriginal extends Component {
 
   render = () => {
     const {
+      providerConfig,
       messagesCount,
       nativeCurrency,
       currentCurrency,
@@ -358,7 +338,7 @@ export default class SignatureRequestOriginal extends Component {
     const { t } = this.context;
 
     const rejectNText = t('rejectRequestsN', [messagesCount]);
-    const currentNetwork = this.getNetworkName();
+    const currentNetwork = getNetworkNameFromProviderType(providerConfig, t);
 
     const balanceInBaseAsset = conversionRate
       ? formatCurrency(

--- a/ui/components/app/signature-request-original/signature-request-original.component.js
+++ b/ui/components/app/signature-request-original/signature-request-original.component.js
@@ -338,7 +338,11 @@ export default class SignatureRequestOriginal extends Component {
     const { t } = this.context;
 
     const rejectNText = t('rejectRequestsN', [messagesCount]);
-    const currentNetwork = getNetworkNameFromProviderType(providerConfig, t);
+    const networkName = getNetworkNameFromProviderType(providerConfig.type);
+    const currentNetwork =
+      networkName === ''
+        ? providerConfig.nickname || t('unknownNetwork')
+        : t(networkName);
 
     const balanceInBaseAsset = conversionRate
       ? formatCurrency(

--- a/ui/components/app/signature-request/signature-request.component.js
+++ b/ui/components/app/signature-request/signature-request.component.js
@@ -176,7 +176,11 @@ export default class SignatureRequest extends PureComponent {
       primaryType,
     } = this.memoizedParseMessage(data);
     const rejectNText = t('rejectRequestsN', [unapprovedMessagesCount]);
-    const currentNetwork = getNetworkNameFromProviderType(providerConfig, t);
+    const networkName = getNetworkNameFromProviderType(providerConfig.type);
+    const currentNetwork =
+      networkName === ''
+        ? providerConfig.nickname || t('unknownNetwork')
+        : t(networkName);
 
     const balanceInBaseAsset = conversionRate
       ? formatCurrency(

--- a/ui/components/app/signature-request/signature-request.component.js
+++ b/ui/components/app/signature-request/signature-request.component.js
@@ -5,6 +5,7 @@ import LedgerInstructionField from '../ledger-instruction-field';
 import {
   sanitizeMessage,
   getURLHostName,
+  getNetworkNameFromProviderType,
   ///: BEGIN:ONLY_INCLUDE_IN(build-mmi)
   shortenAddress,
   ///: END:ONLY_INCLUDE_IN
@@ -28,7 +29,6 @@ import {
   ///: END:ONLY_INCLUDE_IN
 } from '../../../helpers/constants/design-system';
 import NetworkAccountBalanceHeader from '../network-account-balance-header';
-import { NETWORK_TYPES } from '../../../../shared/constants/network';
 import { Numeric } from '../../../../shared/modules/Numeric';
 import { EtherDenomination } from '../../../../shared/constants/common';
 import ConfirmPageContainerNavigation from '../confirm-page-container/confirm-page-container-navigation';
@@ -121,27 +121,6 @@ export default class SignatureRequest extends PureComponent {
     )}`;
   }
 
-  getNetworkName() {
-    const { providerConfig } = this.props;
-    const providerName = providerConfig.type;
-    const { t } = this.context;
-
-    switch (providerName) {
-      case NETWORK_TYPES.MAINNET:
-        return t('mainnet');
-      case NETWORK_TYPES.GOERLI:
-        return t('goerli');
-      case NETWORK_TYPES.SEPOLIA:
-        return t('sepolia');
-      case NETWORK_TYPES.LINEA_TESTNET:
-        return t('lineatestnet');
-      case NETWORK_TYPES.LOCALHOST:
-        return t('localhost');
-      default:
-        return providerConfig.nickname || t('unknownNetwork');
-    }
-  }
-
   memoizedParseMessage = memoize((data) => {
     const { message, domain = {}, primaryType, types } = JSON.parse(data);
     const sanitizedMessage = sanitizeMessage(message, primaryType, types);
@@ -170,6 +149,7 @@ export default class SignatureRequest extends PureComponent {
 
   render() {
     const {
+      providerConfig,
       txData: {
         msgParams: { data, origin, version },
         type,
@@ -196,7 +176,7 @@ export default class SignatureRequest extends PureComponent {
       primaryType,
     } = this.memoizedParseMessage(data);
     const rejectNText = t('rejectRequestsN', [unapprovedMessagesCount]);
-    const currentNetwork = this.getNetworkName();
+    const currentNetwork = getNetworkNameFromProviderType(providerConfig, t);
 
     const balanceInBaseAsset = conversionRate
       ? formatCurrency(

--- a/ui/helpers/utils/util.js
+++ b/ui/helpers/utils/util.js
@@ -10,7 +10,7 @@ import bowser from 'bowser';
 ///: BEGIN:ONLY_INCLUDE_IN(snaps)
 import { getSnapPrefix } from '@metamask/snaps-utils';
 ///: END:ONLY_INCLUDE_IN
-import { CHAIN_IDS } from '../../../shared/constants/network';
+import { CHAIN_IDS, NETWORK_TYPES } from '../../../shared/constants/network';
 import {
   toChecksumHexAddress,
   stripHexPrefix,
@@ -583,4 +583,31 @@ export const sanitizeString = (value) => {
   }
   const regex = /\u202E/giu;
   return value.replace(regex, '\\u202E');
+};
+
+/**
+ * This method checks current provider type and returns its string representation
+ *
+ * @param {*} provider
+ * @param {*} t
+ * @returns
+ */
+
+export const getNetworkNameFromProviderType = (providerConfig, t) => {
+  const providerName = providerConfig.type;
+
+  switch (providerName) {
+    case NETWORK_TYPES.MAINNET:
+      return t('mainnet');
+    case NETWORK_TYPES.GOERLI:
+      return t('goerli');
+    case NETWORK_TYPES.SEPOLIA:
+      return t('sepolia');
+    case NETWORK_TYPES.LINEA_TESTNET:
+      return t('lineatestnet');
+    case NETWORK_TYPES.LOCALHOST:
+      return t('localhost');
+    default:
+      return providerConfig.nickname || t('unknownNetwork');
+  }
 };

--- a/ui/helpers/utils/util.js
+++ b/ui/helpers/utils/util.js
@@ -593,21 +593,9 @@ export const sanitizeString = (value) => {
  * @returns
  */
 
-export const getNetworkNameFromProviderType = (providerConfig, t) => {
-  const providerName = providerConfig.type;
-
-  switch (providerName) {
-    case NETWORK_TYPES.MAINNET:
-      return t('mainnet');
-    case NETWORK_TYPES.GOERLI:
-      return t('goerli');
-    case NETWORK_TYPES.SEPOLIA:
-      return t('sepolia');
-    case NETWORK_TYPES.LINEA_TESTNET:
-      return t('lineatestnet');
-    case NETWORK_TYPES.LOCALHOST:
-      return t('localhost');
-    default:
-      return providerConfig.nickname || t('unknownNetwork');
+export const getNetworkNameFromProviderType = (providerName) => {
+  if (providerName === NETWORK_TYPES.RPC) {
+    return '';
   }
+  return providerName;
 };

--- a/ui/helpers/utils/util.test.js
+++ b/ui/helpers/utils/util.test.js
@@ -918,4 +918,15 @@ describe('util', () => {
       expect(util.isDefaultMetaMaskChain(CHAIN_IDS.CELO)).toBeFalsy();
     });
   });
+
+  describe('getNetworkNameFromProviderType()', () => {
+    it('should return providerConfig.type if the type is not rpc', () => {
+      expect(util.getNetworkNameFromProviderType('mainnet')).toStrictEqual(
+        'mainnet',
+      );
+    });
+    it('should return empty string if teh providerConfig.type is rpc', () => {
+      expect(util.getNetworkNameFromProviderType('rpc')).toStrictEqual('');
+    });
+  });
 });


### PR DESCRIPTION
## Explanation
This is a cleaning-up PR to :

- Rename the method to `getNetworkNameFromProviderType` and move it to `ui/helpers/utils/util.js` file.
- Remove the redundant  `getNetworkName` function definition from from `NetworkDropdown` , `Signature-request. component` and `Signature-Request-Original.component`
- Import the new function to use in `Signature-request. component` and `Signature-Request-Original.component`

<!--
Thanks for the pull request. Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues, Slack conversations, Zendesk issues, user stories, etc. reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

## Screenshots/Screencaps

<!-- If you're making a change to the UI, make sure to capture a screenshot or a short video showing off your work! -->

### Before

<!-- How did the UI you changed look before your changes? Drag your file(s) below this line: -->

### After

<!-- How does it look now? Drag your file(s) below this line: -->

## Manual Testing Steps
1. Start a Sign Typed Data V3 or Sign Typed Data V4 request from Test Dapp.
2. Make sure the `NetworkAccountBalanceHeader` is showing the correct network name.
<!--
How should reviewers and QA manually test your changes? For instance:

- Go to this screen
- Do this
- Then do this
-->

## Pre-merge author checklist

- [ ] I've clearly explained:
  - [ ] What problem this PR is solving
  - [ ] How this problem was solved
  - [ ] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
