### PR TITLE
Fix #19139 - Allow user to switch network when loading networking fails

### DIFF
--- a/ui/components/app/loading-network-screen/loading-network-screen.component.js
+++ b/ui/components/app/loading-network-screen/loading-network-screen.component.js
@@ -79,6 +79,7 @@ export default class LoadingNetworkScreen extends PureComponent {
       <Popover
         onClose={() => {
           window.clearTimeout(this.cancelCallTimeout);
+          this.setState({ showErrorScreen: false });
         }}
         centerTitle
         title={
@@ -100,6 +101,7 @@ export default class LoadingNetworkScreen extends PureComponent {
           <ButtonSecondary
             onClick={() => {
               window.clearTimeout(this.cancelCallTimeout);
+              this.setState({ showErrorScreen: false });
               showNetworkDropdown();
             }}
             variant={TextVariant.bodySm}


### PR DESCRIPTION
## Explanation

* Fixes #19139

@tmashuang discovered that the network dropdown menu displays `under` the new network loading error popover, thus the "Switch Networks" button only shows a network dropdown that the user can't interact with due to `z-index` issues.  With this PR, upon clicking "Switch networks", the popover closes so the user can choose a different network.

## Screenshots/Screencaps


https://github.com/MetaMask/metamask-extension/assets/46655/8e8a6872-3e86-42a1-8a97-0eff21113620

<!-- How does it look now? Drag your file(s) below this line: -->

## Manual Testing Steps

Original STR from the issue will work.

## Pre-merge author checklist

- [ ] I've clearly explained:
  - [ ] What problem this PR is solving
  - [ ] How this problem was solved
  - [ ] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
