### PR TITLE
Replaces mmi for institutional in builds.yml

### DIFF
--- a/builds.yml
+++ b/builds.yml
@@ -130,7 +130,7 @@ features:
     assets:
       - src: ./app/build-types/mmi/images/
         dest: images
-      - ./{app,shared,ui}/**/mmi/**
+      - ./{app,shared,ui}/**/institutional/**
   build-flask:
     assets:
       - src: ./app/build-types/flask/images/


### PR DESCRIPTION
## Explanation

We've been using the folder name `institutional/` instead of the `mmi` since the beginning, because it's a better name, easier to understand.