### PR TITLE
Multichain: UX: Snaps: Add Notifications to Global Menu

### DIFF
--- a/ui/components/multichain/global-menu/global-menu.js
+++ b/ui/components/multichain/global-menu/global-menu.js
@@ -134,6 +134,7 @@ export const GlobalMenu = ({ closeMenu, anchorElement }) => {
               history.push(NOTIFICATIONS_ROUTE);
             }}
           >
+            <Text as="span">{t('notifications')}</Text>
             {unreadNotificationsCount > 0 && (
               <Text
                 as="span"
@@ -149,12 +150,11 @@ export const GlobalMenu = ({ closeMenu, anchorElement }) => {
                   borderRadius: '16px',
                   minWidth: '24px',
                 }}
-                marginInlineEnd={2}
+                marginInlineStart={2}
               >
                 {unreadNotificationsCount}
               </Text>
             )}
-            <Text as="span">{t('notifications')}</Text>
           </MenuItem>
         </>
         ///: END:ONLY_INCLUDE_IN(snaps)

--- a/ui/components/multichain/global-menu/global-menu.js
+++ b/ui/components/multichain/global-menu/global-menu.js
@@ -12,7 +12,12 @@ import {
 } from '../../../helpers/constants/routes';
 import { lockMetamask } from '../../../store/actions';
 import { useI18nContext } from '../../../hooks/useI18nContext';
-import { IconName, Text } from '../../component-library';
+import {
+  IconName,
+  ///: BEGIN:ONLY_INCLUDE_IN(snaps)
+  Text,
+  ///: END:ONLY_INCLUDE_IN(snaps)
+} from '../../component-library';
 import { Menu, MenuItem } from '../../ui/menu';
 import { getEnvironmentType } from '../../../../app/scripts/lib/util';
 import { ENVIRONMENT_TYPE_FULLSCREEN } from '../../../../shared/constants/app';
@@ -31,6 +36,7 @@ import {
   getUnreadNotificationsCount,
   ///: END:ONLY_INCLUDE_IN
 } from '../../../selectors';
+///: BEGIN:ONLY_INCLUDE_IN(snaps)
 import {
   AlignItems,
   BackgroundColor,
@@ -40,6 +46,7 @@ import {
   TextColor,
   TextVariant,
 } from '../../../helpers/constants/design-system';
+///: END:ONLY_INCLUDE_IN
 
 export const GlobalMenu = ({ closeMenu, anchorElement }) => {
   const t = useI18nContext();

--- a/ui/components/multichain/global-menu/global-menu.js
+++ b/ui/components/multichain/global-menu/global-menu.js
@@ -6,10 +6,13 @@ import {
   CONNECTED_ROUTE,
   SETTINGS_ROUTE,
   DEFAULT_ROUTE,
+  ///: BEGIN:ONLY_INCLUDE_IN(snaps)
+  NOTIFICATIONS_ROUTE,
+  ///: END:ONLY_INCLUDE_IN(snaps)
 } from '../../../helpers/constants/routes';
 import { lockMetamask } from '../../../store/actions';
 import { useI18nContext } from '../../../hooks/useI18nContext';
-import { IconName } from '../../component-library';
+import { IconName, Text } from '../../component-library';
 import { Menu, MenuItem } from '../../ui/menu';
 import { getEnvironmentType } from '../../../../app/scripts/lib/util';
 import { ENVIRONMENT_TYPE_FULLSCREEN } from '../../../../shared/constants/app';
@@ -22,7 +25,21 @@ import {
   MetaMetricsContextProp,
 } from '../../../../shared/constants/metametrics';
 import { getPortfolioUrl } from '../../../helpers/utils/portfolio';
-import { getMetaMetricsId } from '../../../selectors';
+import {
+  getMetaMetricsId,
+  ///: BEGIN:ONLY_INCLUDE_IN(snaps)
+  getUnreadNotificationsCount,
+  ///: END:ONLY_INCLUDE_IN
+} from '../../../selectors';
+import {
+  AlignItems,
+  BackgroundColor,
+  Display,
+  JustifyContent,
+  TextAlign,
+  TextColor,
+  TextVariant,
+} from '../../../helpers/constants/design-system';
 
 export const GlobalMenu = ({ closeMenu, anchorElement }) => {
   const t = useI18nContext();
@@ -30,6 +47,10 @@ export const GlobalMenu = ({ closeMenu, anchorElement }) => {
   const trackEvent = useContext(MetaMetricsContext);
   const history = useHistory();
   const metaMetricsId = useSelector(getMetaMetricsId);
+
+  ///: BEGIN:ONLY_INCLUDE_IN(snaps)
+  const unreadNotificationsCount = useSelector(getUnreadNotificationsCount);
+  ///: END:ONLY_INCLUDE_IN
 
   return (
     <Menu anchorElement={anchorElement} onHide={closeMenu}>
@@ -96,6 +117,41 @@ export const GlobalMenu = ({ closeMenu, anchorElement }) => {
           {t('expandView')}
         </MenuItem>
       )}
+      {
+        ///: BEGIN:ONLY_INCLUDE_IN(snaps)
+        <>
+          <MenuItem
+            iconName={IconName.Notification}
+            onClick={() => {
+              closeMenu();
+              history.push(NOTIFICATIONS_ROUTE);
+            }}
+          >
+            {unreadNotificationsCount > 0 && (
+              <Text
+                as="span"
+                display={Display.InlineBlock}
+                justifyContent={JustifyContent.center}
+                alignItems={AlignItems.center}
+                backgroundColor={BackgroundColor.primaryDefault}
+                color={TextColor.primaryInverse}
+                padding={[0, 1, 0, 1]}
+                variant={TextVariant.bodyXs}
+                textAlign={TextAlign.Center}
+                style={{
+                  borderRadius: '16px',
+                  minWidth: '24px',
+                }}
+                marginInlineEnd={2}
+              >
+                {unreadNotificationsCount}
+              </Text>
+            )}
+            <Text as="span">{t('notifications')}</Text>
+          </MenuItem>
+        </>
+        ///: END:ONLY_INCLUDE_IN(snaps)
+      }
       <MenuItem
         iconName={IconName.MessageQuestion}
         onClick={() => {


### PR DESCRIPTION
## Explanation

The account menu for Snaps includes a new item for notifications which we need to add to the new Global Menu for Multichain:

<img width="397" alt="SCR-20230518-kigg" src="https://github.com/MetaMask/metamask-extension/assets/46655/8013083b-6c08-4043-9315-415876c0a058">


## Pre-merge author checklist

- [ ] I've clearly explained:
  - [ ] What problem this PR is solving
  - [ ] How this problem was solved
  - [ ] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
