### PR TITLE
test/e2e/fix: Add Chromedriver v113 scuttle exceptions

### DIFF
--- a/development/build/index.js
+++ b/development/build/index.js
@@ -127,6 +127,8 @@ async function defineAndRunBuildTasks() {
         'Promise',
         'JSON',
         'Date',
+        'Proxy',
+        'ret_nodes',
         // globals sentry needs to function
         '__SENTRY__',
         'appState',

--- a/test/e2e/benchmark.js
+++ b/test/e2e/benchmark.js
@@ -79,11 +79,11 @@ async function profilePageLoad(pages, numSamples, retries) {
     if (runResults.some((result) => result.navigation.lenth > 1)) {
       throw new Error(`Multiple navigations not supported`);
     } else if (
-      runResults.some((result) => result.navigation[0].type !== 'navigate')
+      runResults.some((result) => result.navigation[0] && result.navigation[0].type !== 'navigate')
     ) {
       throw new Error(
         `Navigation type ${
-          runResults.find((result) => result.navigation[0].type !== 'navigate')
+          runResults.find((result) => result.navigation[0] && result.navigation[0].type !== 'navigate')
             .navigation[0].type
         } not supported`,
       );


### PR DESCRIPTION
Targeting: #19180 

- build/fix: add `Proxy`,`ret_nodes` to `scuttleGlobalThisExceptions`
  - Attempt fixing `chromedriver`@`v113` compatibility (https://github.com/MetaMask/metamask-extension/pull/19180, https://app.circleci.com/pipelines/github/MetaMask/metamask-extension/46203/workflows/d7bdba7d-b0d0-454b-986b-a82fe68e3083/jobs/1317884)