### PR TITLE
UX: Multichain: Only show the account picker with a selected identity

### DIFF
--- a/ui/components/multichain/app-header/app-header.js
+++ b/ui/components/multichain/app-header/app-header.js
@@ -219,22 +219,24 @@ export const AppHeader = ({ location }) => {
                 />
               ) : null}
 
-              <AccountPicker
-                address={identity.address}
-                name={identity.name}
-                onClick={() => {
-                  dispatch(toggleAccountMenu());
+              {identity ? (
+                <AccountPicker
+                  address={identity.address}
+                  name={identity.name}
+                  onClick={() => {
+                    dispatch(toggleAccountMenu());
 
-                  trackEvent({
-                    event: MetaMetricsEventName.NavAccountMenuOpened,
-                    category: MetaMetricsEventCategory.Navigation,
-                    properties: {
-                      location: 'Home',
-                    },
-                  });
-                }}
-                disabled={disablePickers}
-              />
+                    trackEvent({
+                      event: MetaMetricsEventName.NavAccountMenuOpened,
+                      category: MetaMetricsEventCategory.Navigation,
+                      properties: {
+                        location: 'Home',
+                      },
+                    });
+                  }}
+                  disabled={disablePickers}
+                />
+              ) : null}
               <Box
                 display={DISPLAY.FLEX}
                 alignItems={AlignItems.center}


### PR DESCRIPTION
## Explanation

While removing the feature flag for https://github.com/MetaMask/metamask-extension/pull/18903, I realized that an identity isn't immediately selected, thus triggering an error immediately after using the "Forgot password" functionality.

## Manual Testing Steps

1.  Create a MetaMask wallet, saving the SRP
2.  Log out of extension
3. Use "forgot password" link on unlock screen, enter SRP
4. (Don't see an error)
5. See the first Account picked

## Pre-merge author checklist

- [ ] I've clearly explained:
  - [ ] What problem this PR is solving
  - [ ] How this problem was solved
  - [ ] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
