### PR TITLE
Part of #18714: Replace deprecated constants with enums in: `AvatarBase` and `Text`

### DIFF
--- a/ui/components/component-library/avatar-base/avatar-base.stories.tsx
+++ b/ui/components/component-library/avatar-base/avatar-base.stories.tsx
@@ -1,8 +1,8 @@
-import { ComponentMeta } from '@storybook/react';
+import { Meta } from '@storybook/react';
 import React from 'react';
 import {
   AlignItems,
-  DISPLAY,
+  Display,
   TextColor,
   BackgroundColor,
   BorderColor,
@@ -60,7 +60,7 @@ export default {
       control: 'select',
     },
     display: {
-      options: Object.values(DISPLAY),
+      options: Object.values(Display),
       control: 'select',
       table: { category: 'box props' },
     },
@@ -92,14 +92,14 @@ export default {
     borderColor: BorderColor.borderDefault,
     children: 'B',
   },
-} as ComponentMeta<typeof AvatarBase>;
+} as Meta<typeof AvatarBase>;
 
 export const DefaultStory = (args: AvatarBaseProps) => <AvatarBase {...args} />;
 
 DefaultStory.storyName = 'Default';
 
 export const Size = (args: AvatarBaseProps) => (
-  <Box display={DISPLAY.FLEX} alignItems={AlignItems.baseline} gap={1}>
+  <Box display={Display.Flex} alignItems={AlignItems.baseline} gap={1}>
     <AvatarBase {...args} size={AvatarBaseSize.Xs} />
     <AvatarBase {...args} size={AvatarBaseSize.Sm} />
     <AvatarBase {...args} size={AvatarBaseSize.Md} />
@@ -109,7 +109,7 @@ export const Size = (args: AvatarBaseProps) => (
 );
 
 export const Children = (args: AvatarBaseProps) => (
-  <Box display={DISPLAY.FLEX} gap={1}>
+  <Box display={Display.Flex} gap={1}>
     <AvatarBase {...args}>
       <img src="./images/eth_logo.png" />
     </AvatarBase>
@@ -131,7 +131,7 @@ export const Children = (args: AvatarBaseProps) => (
 );
 
 export const ColorBackgroundColorAndBorderColor = (args: AvatarBaseProps) => (
-  <Box display={DISPLAY.FLEX} gap={1}>
+  <Box display={Display.Flex} gap={1}>
     <AvatarBase {...args}>B</AvatarBase>
     <AvatarBase
       {...args}

--- a/ui/components/component-library/avatar-base/avatar-base.tsx
+++ b/ui/components/component-library/avatar-base/avatar-base.tsx
@@ -5,7 +5,7 @@ import {
   BackgroundColor,
   BorderColor,
   TextColor,
-  DISPLAY,
+  Display,
   JustifyContent,
   AlignItems,
   BorderRadius,
@@ -48,7 +48,7 @@ export const AvatarBase = forwardRef(
         )}
         ref={ref}
         as={ValidTag.Div}
-        display={DISPLAY.FLEX}
+        display={Display.Flex}
         justifyContent={JustifyContent.center}
         alignItems={AlignItems.center}
         borderRadius={BorderRadius.full}

--- a/ui/components/component-library/text/text.stories.tsx
+++ b/ui/components/component-library/text/text.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import { ComponentStory, ComponentMeta } from '@storybook/react';
+import { StoryFn, Meta } from '@storybook/react';
 import {
-  DISPLAY,
+  Display,
   BackgroundColor,
   BorderColor,
   FontWeight,
@@ -10,8 +10,8 @@ import {
   TextAlign,
   OverflowWrap,
   TextTransform,
-  FRACTIONS,
-  FLEX_DIRECTION,
+  BlockSize,
+  FlexDirection,
   TextVariant,
   Color,
 } from '../../../helpers/constants/design-system';
@@ -30,7 +30,7 @@ export default {
       page: README,
     },
   },
-} as ComponentMeta<typeof Text>;
+} as Meta<typeof Text>;
 
 function renderBackgroundColor(color) {
   let bgColor;
@@ -70,7 +70,7 @@ function renderBackgroundColor(color) {
   return bgColor;
 }
 
-const Template: ComponentStory<typeof Text> = (args) => (
+const Template: StoryFn<typeof Text> = (args) => (
   <Text {...args}>{args.children}</Text>
 );
 
@@ -92,7 +92,7 @@ export const Variant = (args) => (
   </>
 );
 
-export const ColorStory: ComponentStory<typeof Text> = (args) => {
+export const ColorStory: StoryFn<typeof Text> = (args) => {
   // Index of last valid color in TextColor array
   return (
     <>
@@ -113,7 +113,7 @@ export const ColorStory: ComponentStory<typeof Text> = (args) => {
 };
 ColorStory.storyName = 'Color';
 
-export const FontWeightStory: ComponentStory<typeof Text> = (args) => (
+export const FontWeightStory: StoryFn<typeof Text> = (args) => (
   <>
     {Object.values(FontWeight).map((weight) => (
       <Text {...args} fontWeight={weight} key={weight}>
@@ -125,7 +125,7 @@ export const FontWeightStory: ComponentStory<typeof Text> = (args) => (
 
 FontWeightStory.storyName = 'Font Weight';
 
-export const FontStyleStory: ComponentStory<typeof Text> = (args) => (
+export const FontStyleStory: StoryFn<typeof Text> = (args) => (
   <>
     {Object.values(FontStyle).map((style) => (
       <Text {...args} fontStyle={style} key={style}>
@@ -137,7 +137,7 @@ export const FontStyleStory: ComponentStory<typeof Text> = (args) => (
 
 FontStyleStory.storyName = 'Font Style';
 
-export const TextTransformStory: ComponentStory<typeof Text> = (args) => (
+export const TextTransformStory: StoryFn<typeof Text> = (args) => (
   <>
     {Object.values(TextTransform).map((transform) => (
       <Text {...args} textTransform={transform} key={transform}>
@@ -149,7 +149,7 @@ export const TextTransformStory: ComponentStory<typeof Text> = (args) => (
 
 TextTransformStory.storyName = 'Text Transform';
 
-export const TextAlignStory: ComponentStory<typeof Text> = (args) => (
+export const TextAlignStory: StoryFn<typeof Text> = (args) => (
   <>
     {Object.values(TextAlign).map((align) => (
       <Text {...args} textAlign={align} key={align}>
@@ -161,10 +161,10 @@ export const TextAlignStory: ComponentStory<typeof Text> = (args) => (
 
 TextAlignStory.storyName = 'Text Align';
 
-export const OverflowWrapStory: ComponentStory<typeof Text> = (args) => (
+export const OverflowWrapStory: StoryFn<typeof Text> = (args) => (
   <Box
     borderColor={BorderColor.warningDefault}
-    display={DISPLAY.BLOCK}
+    display={Display.Block}
     style={{ width: 200 }}
   >
     <Text {...args} overflowWrap={OverflowWrap.Normal}>
@@ -178,11 +178,11 @@ export const OverflowWrapStory: ComponentStory<typeof Text> = (args) => (
 
 OverflowWrapStory.storyName = 'Overflow Wrap';
 
-export const Ellipsis: ComponentStory<typeof Text> = (args) => (
+export const Ellipsis: StoryFn<typeof Text> = (args) => (
   <Box
     borderColor={BorderColor.primaryDefault}
-    display={DISPLAY.BLOCK}
-    width={FRACTIONS.ONE_THIRD}
+    display={Display.Block}
+    width={BlockSize.OneThird}
   >
     <Text {...args} ellipsis>
       Ellipsis: 0x39013f961c378f02c2b82a6e1d31e9812786fd9d
@@ -193,7 +193,7 @@ export const Ellipsis: ComponentStory<typeof Text> = (args) => (
   </Box>
 );
 
-export const As: ComponentStory<typeof Text> = (args) => (
+export const As: StoryFn<typeof Text> = (args) => (
   <>
     {Object.keys(ValidTag).map((tag) => {
       if (ValidTag[tag] === ValidTag.Input) {
@@ -217,11 +217,11 @@ export const As: ComponentStory<typeof Text> = (args) => (
   </>
 );
 
-export const TextDirectionStory: ComponentStory<typeof Text> = (args) => (
+export const TextDirectionStory: StoryFn<typeof Text> = (args) => (
   <Box
     style={{ maxWidth: 300 }}
-    display={DISPLAY.FLEX}
-    flexDirection={FLEX_DIRECTION.COLUMN}
+    display={Display.Flex}
+    flexDirection={FlexDirection.Column}
     gap={4}
   >
     <Text {...args} textDirection={TextDirection.LeftToRight}>
@@ -237,7 +237,7 @@ export const TextDirectionStory: ComponentStory<typeof Text> = (args) => (
   </Box>
 );
 
-export const Strong: ComponentStory<typeof Text> = (args) => (
+export const Strong: StoryFn<typeof Text> = (args) => (
   <>
     <Text {...args} as="strong">
       This is an as="strong" demo.


### PR DESCRIPTION
 ## Explanation

- This PR is a part of   #18714 

All the deprecated constants were replaced with their equivalent enums.
Deprecated storybook tags were also replaced.

The changes were made in the `component-library` folder:
`ui/components/component-library/avatar-base`
`ui/components/component-library/text`

<!--
Thanks for the pull request. Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues, Slack conversations, Zendesk issues, user stories, etc. reviewers should consult to understand this pull request better? For instance:


-->

## Screenshots/Screencaps

<!-- If you're making a change to the UI, make sure to capture a screenshot or a short video showing off your work! -->
## `AvatarBase`
### Before

<!-- How did the UI you changed look before your changes? Drag your file(s) below this line: -->
![image](https://github.com/MetaMask/metamask-extension/assets/79097544/ecce072e-cb9d-4d68-bb2b-917239759f8c)
![image](https://github.com/MetaMask/metamask-extension/assets/79097544/05315d47-43bf-479a-92fe-aa0a5135ebf5)
![image](https://github.com/MetaMask/metamask-extension/assets/79097544/f1958113-c2ea-4a64-ae0a-abedfa111c90)
![image](https://github.com/MetaMask/metamask-extension/assets/79097544/1e2b5742-a2f0-47b7-a5c8-6a59c62ae142)

### After
![image](https://github.com/MetaMask/metamask-extension/assets/79097544/7941aa38-54b9-41de-a494-81bfa24209b7)
![image](https://github.com/MetaMask/metamask-extension/assets/79097544/612725ed-2caf-46bf-bcc1-e753ccb6cf51)
![image](https://github.com/MetaMask/metamask-extension/assets/79097544/7ad311cb-5a1e-4c7b-affa-9f7a43f513a3)
![image](https://github.com/MetaMask/metamask-extension/assets/79097544/08e01bdf-3126-4777-aee0-75e30a71f80d)


## `Text`
### Before

<!-- How did the UI you changed look before your changes? Drag your file(s) below this line: -->
![image](https://github.com/MetaMask/metamask-extension/assets/79097544/b03174cc-f479-4c43-afb6-1441bf2311ab)
![image](https://github.com/MetaMask/metamask-extension/assets/79097544/11564db8-e268-4e32-9b3e-95f5ad9c8295)
![image](https://github.com/MetaMask/metamask-extension/assets/79097544/0b0fecbd-7c2e-4352-82e6-20e1f5f79195)
![image](https://github.com/MetaMask/metamask-extension/assets/79097544/6dedb904-449f-46e3-9802-1bd8c57b59a3)
![image](https://github.com/MetaMask/metamask-extension/assets/79097544/3e928d57-d2ba-48fc-8353-4d6e24791a3b)
![image](https://github.com/MetaMask/metamask-extension/assets/79097544/ea98cc42-4ab1-4e1a-a226-07653cedd244)
![image](https://github.com/MetaMask/metamask-extension/assets/79097544/e269b449-d627-45ea-962f-23dfa64003d6)
![image](https://github.com/MetaMask/metamask-extension/assets/79097544/685d9f67-711a-472c-bd27-3e730d0eaa57)
![image](https://github.com/MetaMask/metamask-extension/assets/79097544/7b463fda-2a38-4dd6-9448-4f5c13b18bec)
![image](https://github.com/MetaMask/metamask-extension/assets/79097544/290e050f-1d05-4e66-bdf8-af398c096133)
![image](https://github.com/MetaMask/metamask-extension/assets/79097544/7ce2b879-a367-456e-a3c9-f8a6ae6dbca3)
![image](https://github.com/MetaMask/metamask-extension/assets/79097544/705349c9-41a0-42ce-9a62-b9edc0589023)

### After

<!-- How does it look now? Drag your file(s) below this line: -->
![image](https://github.com/MetaMask/metamask-extension/assets/79097544/641900e1-3309-43f6-bd95-80021fa3b7c6)
![image](https://github.com/MetaMask/metamask-extension/assets/79097544/e9baa0e4-6f17-483a-bd09-5e201362aee6)
![image](https://github.com/MetaMask/metamask-extension/assets/79097544/50ac3121-b11c-49ad-8f99-054bc7bd5f50)
![image](https://github.com/MetaMask/metamask-extension/assets/79097544/2224a534-6764-435a-a292-839182e19a38)
![image](https://github.com/MetaMask/metamask-extension/assets/79097544/fb36a45d-703e-4967-b897-937aec28013a)
![image](https://github.com/MetaMask/metamask-extension/assets/79097544/8a4a4cd2-0626-44c6-b49b-915f84be34eb)
![image](https://github.com/MetaMask/metamask-extension/assets/79097544/46f418ff-2680-4105-b4d1-00aec35fda71)
![image](https://github.com/MetaMask/metamask-extension/assets/79097544/d4b003b2-0cae-4b5a-82ae-0b2f29671e2d)
![image](https://github.com/MetaMask/metamask-extension/assets/79097544/f5c61e4a-5676-4044-aa29-394cb9cbde50)
![image](https://github.com/MetaMask/metamask-extension/assets/79097544/817ae30d-6f70-45e7-8b0b-dcc796fa3a83)
![image](https://github.com/MetaMask/metamask-extension/assets/79097544/5e4afc1e-300c-42d7-9595-862ebc857636)
![image](https://github.com/MetaMask/metamask-extension/assets/79097544/66b3bcfe-33c8-489d-9f83-d046fe8c3190)

## Manual Testing Steps
`jest` tests passed locally
![image](https://github.com/MetaMask/metamask-extension/assets/79097544/98c5e134-b077-42ac-a141-a3e1a7f3e02b)

![image](https://github.com/MetaMask/metamask-extension/assets/79097544/05f202f4-1c94-4e70-b278-31d85d2f1894)

<!--
How should reviewers and QA manually test your changes? For instance:

- Go to this screen
- Do this
- Then do this
-->

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
