### PR TITLE
Part of #18714: Replacing deprecated constants in `Popover` folder

### DIFF
--- a/ui/components/component-library/popover/popover.stories.tsx
+++ b/ui/components/component-library/popover/popover.stories.tsx
@@ -1,12 +1,12 @@
 import React, { useState, useEffect } from 'react';
-import { ComponentStory, ComponentMeta } from '@storybook/react';
+import { StoryFn, Meta } from '@storybook/react';
 import Box from '../../ui/box/box';
 import {
   AlignItems,
   BackgroundColor,
   BorderColor,
   Color,
-  DISPLAY,
+  Display,
   JustifyContent,
   TextAlign,
 } from '../../../helpers/constants/design-system';
@@ -41,9 +41,9 @@ export default {
   args: {
     children: 'Popover',
   },
-} as ComponentMeta<typeof Popover>;
+} as Meta<typeof Popover>;
 
-const Template: ComponentStory<typeof Popover> = (args) => {
+const Template: StoryFn<typeof Popover> = (args) => {
   const [referenceElement, setReferenceElement] = useState();
   const [isOpen, setIsOpen] = useState(true);
 
@@ -98,7 +98,7 @@ DefaultStory.args = {
   hasArrow: true,
 };
 
-export const ReferenceElement: ComponentStory<typeof Popover> = (args) => {
+export const ReferenceElement: StoryFn<typeof Popover> = (args) => {
   const [referenceElement, setReferenceElement] = useState();
 
   const setBoxRef = (ref) => {
@@ -125,7 +125,7 @@ export const ReferenceElement: ComponentStory<typeof Popover> = (args) => {
   );
 };
 
-export const Children: ComponentStory<typeof Popover> = (args) => {
+export const Children: StoryFn<typeof Popover> = (args) => {
   const [referenceElement, setReferenceElement] = useState();
 
   const setBoxRef = (ref) => {
@@ -154,7 +154,7 @@ export const Children: ComponentStory<typeof Popover> = (args) => {
   );
 };
 
-export const Position: ComponentStory<typeof Popover> = (args) => {
+export const Position: StoryFn<typeof Popover> = (args) => {
   const [referenceElement, setReferenceElement] = useState();
   const [referenceAutoElement, setReferenceAutoElement] = useState();
 
@@ -176,7 +176,7 @@ export const Position: ComponentStory<typeof Popover> = (args) => {
           minHeight: '400px',
         }}
         borderColor={BorderColor.borderDefault}
-        display={DISPLAY.FLEX}
+        display={Display.Flex}
         justifyContent={JustifyContent.center}
         alignItems={AlignItems.center}
         marginBottom={4}
@@ -185,7 +185,7 @@ export const Position: ComponentStory<typeof Popover> = (args) => {
           ref={setBoxRef}
           backgroundColor={BackgroundColor.primaryMuted}
           style={{ width: 400, height: 200 }}
-          display={DISPLAY.FLEX}
+          display={Display.Flex}
           justifyContent={JustifyContent.center}
           alignItems={AlignItems.center}
           textAlign={TextAlign.Center}
@@ -316,7 +316,7 @@ export const Position: ComponentStory<typeof Popover> = (args) => {
             width: '200vw',
             height: '200vh',
           }}
-          display={DISPLAY.FLEX}
+          display={Display.Flex}
           justifyContent={JustifyContent.center}
           alignItems={AlignItems.center}
         >
@@ -324,7 +324,7 @@ export const Position: ComponentStory<typeof Popover> = (args) => {
             ref={setRefAuto}
             backgroundColor={BackgroundColor.primaryMuted}
             style={{ width: 400, height: 200 }}
-            display={DISPLAY.FLEX}
+            display={Display.Flex}
             justifyContent={JustifyContent.center}
             alignItems={AlignItems.center}
             textAlign={TextAlign.Center}
@@ -346,7 +346,7 @@ export const Position: ComponentStory<typeof Popover> = (args) => {
   );
 };
 
-export const IsPortal: ComponentStory<typeof Popover> = (args) => {
+export const IsPortal: StoryFn<typeof Popover> = (args) => {
   const [referenceElement, setReferenceElement] = useState();
 
   const setBoxRef = (ref) => {
@@ -384,7 +384,7 @@ export const IsPortal: ComponentStory<typeof Popover> = (args) => {
   );
 };
 
-export const HasArrow: ComponentStory<typeof Popover> = (args) => {
+export const HasArrow: StoryFn<typeof Popover> = (args) => {
   const [referenceElement, setReferenceElement] = useState();
 
   const setBoxRef = (ref) => {
@@ -419,7 +419,7 @@ export const HasArrow: ComponentStory<typeof Popover> = (args) => {
   );
 };
 
-export const IsOpen: ComponentStory<typeof Popover> = (args) => {
+export const IsOpen: StoryFn<typeof Popover> = (args) => {
   const [referenceElement, setReferenceElement] = useState();
   const [isOpen, setIsOpen] = useState(true);
 
@@ -438,7 +438,7 @@ export const IsOpen: ComponentStory<typeof Popover> = (args) => {
         backgroundColor={BackgroundColor.primaryMuted}
         style={{ width: 200, height: 200 }}
         onClick={handleClick}
-        display={DISPLAY.FLEX}
+        display={Display.Flex}
         justifyContent={JustifyContent.center}
         alignItems={AlignItems.center}
       >
@@ -468,7 +468,7 @@ export const IsOpen: ComponentStory<typeof Popover> = (args) => {
   );
 };
 
-export const Flip: ComponentStory<typeof Popover> = (args) => {
+export const Flip: StoryFn<typeof Popover> = (args) => {
   const [referenceElement, setReferenceElement] = useState();
 
   const setBoxRef = (ref) => {
@@ -478,7 +478,7 @@ export const Flip: ComponentStory<typeof Popover> = (args) => {
   return (
     <Box
       style={{ height: '200vh' }}
-      display={DISPLAY.FLEX}
+      display={Display.Flex}
       justifyContent={JustifyContent.center}
       alignItems={AlignItems.center}
     >
@@ -486,7 +486,7 @@ export const Flip: ComponentStory<typeof Popover> = (args) => {
         ref={setBoxRef}
         backgroundColor={BackgroundColor.primaryMuted}
         style={{ width: 200, height: 200 }}
-        display={DISPLAY.FLEX}
+        display={Display.Flex}
         justifyContent={JustifyContent.center}
         alignItems={AlignItems.center}
       >
@@ -515,7 +515,7 @@ export const Flip: ComponentStory<typeof Popover> = (args) => {
   );
 };
 
-export const PreventOverflow: ComponentStory<typeof Popover> = (args) => {
+export const PreventOverflow: StoryFn<typeof Popover> = (args) => {
   const [referenceElement, setReferenceElement] = useState();
 
   const setBoxRef = (ref) => {
@@ -525,7 +525,7 @@ export const PreventOverflow: ComponentStory<typeof Popover> = (args) => {
   return (
     <Box
       style={{ height: '200vh', width: '100vw' }}
-      display={DISPLAY.FLEX}
+      display={Display.Flex}
       justifyContent={JustifyContent.center}
       alignItems={AlignItems.center}
     >
@@ -533,7 +533,7 @@ export const PreventOverflow: ComponentStory<typeof Popover> = (args) => {
         ref={setBoxRef}
         backgroundColor={BackgroundColor.primaryMuted}
         style={{ width: 200, height: 200 }}
-        display={DISPLAY.FLEX}
+        display={Display.Flex}
         justifyContent={JustifyContent.center}
         alignItems={AlignItems.center}
         textAlign={TextAlign.Center}
@@ -563,7 +563,7 @@ export const PreventOverflow: ComponentStory<typeof Popover> = (args) => {
   );
 };
 
-export const ReferenceHidden: ComponentStory<typeof Popover> = (args) => {
+export const ReferenceHidden: StoryFn<typeof Popover> = (args) => {
   const [referenceElement, setReferenceElement] = useState();
 
   const setBoxRef = (ref) => {
@@ -573,14 +573,14 @@ export const ReferenceHidden: ComponentStory<typeof Popover> = (args) => {
   return (
     <Box
       style={{ height: '200vh', width: '100vw' }}
-      display={DISPLAY.FLEX}
+      display={Display.Flex}
       justifyContent={JustifyContent.center}
     >
       <Box
         ref={setBoxRef}
         backgroundColor={BackgroundColor.primaryMuted}
         style={{ width: 200, height: 200 }}
-        display={DISPLAY.FLEX}
+        display={Display.Flex}
         justifyContent={JustifyContent.center}
         alignItems={AlignItems.center}
         textAlign={TextAlign.Center}
@@ -610,7 +610,7 @@ export const ReferenceHidden: ComponentStory<typeof Popover> = (args) => {
   );
 };
 
-export const MatchWidth: ComponentStory<typeof Popover> = (args) => {
+export const MatchWidth: StoryFn<typeof Popover> = (args) => {
   const [referenceElement, setReferenceElement] = useState();
 
   const setBoxRef = (ref) => {
@@ -640,7 +640,7 @@ export const MatchWidth: ComponentStory<typeof Popover> = (args) => {
   );
 };
 
-export const Role: ComponentStory<typeof Popover> = (args) => {
+export const Role: StoryFn<typeof Popover> = (args) => {
   const [referenceElement, setReferenceElement] = useState();
 
   const setBoxRef = (ref) => {
@@ -650,14 +650,14 @@ export const Role: ComponentStory<typeof Popover> = (args) => {
   return (
     <Box
       style={{ height: '100vh', width: '100vw' }}
-      display={DISPLAY.FLEX}
+      display={Display.Flex}
       justifyContent={JustifyContent.center}
     >
       <Box
         ref={setBoxRef}
         backgroundColor={BackgroundColor.primaryMuted}
         style={{ width: 200, height: 200 }}
-        display={DISPLAY.FLEX}
+        display={Display.Flex}
         justifyContent={JustifyContent.center}
         alignItems={AlignItems.center}
         textAlign={TextAlign.Center}
@@ -686,7 +686,7 @@ export const Role: ComponentStory<typeof Popover> = (args) => {
   );
 };
 
-export const Offset: ComponentStory<typeof Popover> = (args) => {
+export const Offset: StoryFn<typeof Popover> = (args) => {
   const [referenceElement, setReferenceElement] = useState();
 
   const setBoxRef = (ref) => {
@@ -696,14 +696,14 @@ export const Offset: ComponentStory<typeof Popover> = (args) => {
   return (
     <Box
       style={{ height: '200vh', width: '100vw' }}
-      display={DISPLAY.FLEX}
+      display={Display.Flex}
       justifyContent={JustifyContent.center}
     >
       <Box
         ref={setBoxRef}
         backgroundColor={BackgroundColor.primaryMuted}
         style={{ width: 200, height: 200 }}
-        display={DISPLAY.FLEX}
+        display={Display.Flex}
         justifyContent={JustifyContent.center}
         alignItems={AlignItems.center}
         textAlign={TextAlign.Center}
@@ -731,7 +731,7 @@ export const Offset: ComponentStory<typeof Popover> = (args) => {
   );
 };
 
-export const onPressEscKey: ComponentStory<typeof Popover> = (args) => {
+export const onPressEscKey: StoryFn<typeof Popover> = (args) => {
   const [referenceElement, setReferenceElement] = useState();
   const [isOpen, setIsOpen] = useState(false);
 
@@ -768,7 +768,7 @@ export const onPressEscKey: ComponentStory<typeof Popover> = (args) => {
   );
 };
 
-export const WithPopoverHeader: ComponentStory<typeof Popover> = (args) => {
+export const WithPopoverHeader: StoryFn<typeof Popover> = (args) => {
   const [refTitleElement, setRefTitleElement] = useState();
   const [isOpen, setIsOpen] = useState(true);
 
@@ -809,7 +809,7 @@ export const WithPopoverHeader: ComponentStory<typeof Popover> = (args) => {
   );
 };
 
-export const MouseEventDemo: ComponentStory<typeof Popover> = (args) => {
+export const MouseEventDemo: StoryFn<typeof Popover> = (args) => {
   const [referenceElement, setReferenceElement] = useState();
   const [isOpen, setIsOpen] = useState(false);
 
@@ -846,7 +846,7 @@ export const MouseEventDemo: ComponentStory<typeof Popover> = (args) => {
   );
 };
 
-export const OnFocusBlur: ComponentStory<typeof Popover> = (args) => {
+export const OnFocusBlur: StoryFn<typeof Popover> = (args) => {
   const [referenceElement, setReferenceElement] = useState();
   const [isOpen, setIsOpen] = useState(false);
 

--- a/ui/components/component-library/popover/popover.tsx
+++ b/ui/components/component-library/popover/popover.tsx
@@ -7,7 +7,7 @@ import {
   BackgroundColor,
   BorderColor,
   BorderRadius,
-  DISPLAY,
+  Display,
   JustifyContent,
 } from '../../../helpers/constants/design-system';
 import Box from '../../ui/box/box';
@@ -112,7 +112,7 @@ export const Popover = ({
           borderColor={BorderColor.borderMuted}
           className={classnames('mm-popover__arrow')}
           ref={setArrowElement}
-          display={DISPLAY.FLEX}
+          display={Display.Flex}
           justifyContent={JustifyContent.center}
           alignItems={AlignItems.center}
           style={styles.arrow}


### PR DESCRIPTION
## Explanation

- This PR is a part of #18714 
Replaced deprecated design system and storybook constants in the `Popover` folder
`ui/components/component-library/popover`

<!--
Thanks for the pull request. Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues, Slack conversations, Zendesk issues, user stories, etc. reviewers should consult to understand this pull request better? For instance:

-->

## Screenshots/Screencaps

<!-- If you're making a change to the UI, make sure to capture a screenshot or a short video showing off your work! -->

### Before
<!-- How did the UI you changed look before your changes? Drag your file(s) below this line: -->
https://github.com/MetaMask/metamask-extension/assets/79097544/a678ee61-0ff1-4a8b-846b-8cf685891695


### After

https://github.com/MetaMask/metamask-extension/assets/79097544/7b75df0e-0c99-4d50-9b4f-1ea720b8bbcd



## Manual Testing Steps
jest tests

![image](https://github.com/MetaMask/metamask-extension/assets/79097544/e31b9f12-ee9a-49e5-850c-405766ecf733)

<!--
How should reviewers and QA manually test your changes? For instance:

- Go to this screen
- Do this
- Then do this
-->

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
