### PR TITLE
UX Multichain: Added Tooltip for AvatarNetwork in Header

### DIFF
--- a/ui/components/multichain/app-header/app-header.js
+++ b/ui/components/multichain/app-header/app-header.js
@@ -57,6 +57,7 @@ import ConnectedStatusIndicator from '../../app/connected-status-indicator';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import { getCompletedOnboarding } from '../../../ducks/metamask/metamask';
 import { getSendStage, SEND_STAGES } from '../../../ducks/send';
+import Tooltip from '../../ui/tooltip';
 
 export const AppHeader = ({ location }) => {
   const trackEvent = useContext(MetaMetricsContext);
@@ -175,20 +176,25 @@ export const AppHeader = ({ location }) => {
               paddingRight={4}
               gap={2}
             >
-              <AvatarNetwork
-                className="multichain-app-header__contents--avatar-network"
-                ref={menuRef}
-                as="button"
-                aria-label={t('networkMenu')}
-                padding={0}
-                name={currentNetwork?.nickname}
-                src={currentNetwork?.rpcPrefs?.imageUrl}
-                size={Size.SM}
-                onClick={networkOpenCallback}
-                display={[DISPLAY.FLEX, DISPLAY.NONE]} // show on popover hide on desktop
-                disabled={disableNetworkPicker}
-              />
-              {popupStatus ? null : (
+              {popupStatus ? (
+                <Box className="multichain-app-header__contents__container">
+                  <Tooltip title={currentNetwork?.nickname} position="right">
+                    <AvatarNetwork
+                      className="multichain-app-header__contents--avatar-network"
+                      ref={menuRef}
+                      as="button"
+                      aria-label={t('networkMenu')}
+                      padding={0}
+                      name={currentNetwork?.nickname}
+                      src={currentNetwork?.rpcPrefs?.imageUrl}
+                      size={Size.SM}
+                      onClick={networkOpenCallback}
+                      display={[DISPLAY.FLEX, DISPLAY.NONE]} // show on popover hide on desktop
+                      disabled={disableNetworkPicker}
+                    />
+                  </Tooltip>
+                </Box>
+              ) : (
                 <div>
                   <PickerNetwork
                     margin={2}

--- a/ui/components/multichain/app-header/app-header.scss
+++ b/ui/components/multichain/app-header/app-header.scss
@@ -36,6 +36,10 @@
     &--avatar-network {
       padding: 0; // TODO: Remove once https://github.com/MetaMask/metamask-extension/pull/17006 is merged
     }
+
+    &__container {
+      width: fit-content;
+    }
   }
 
   &__lock-contents {


### PR DESCRIPTION
Fixes #19049 

Adds Tooltip on hover for avatar network
## Screenshots/Screencaps

### Before

https://github.com/MetaMask/metamask-extension/assets/39872794/9589f64e-d311-43e9-af72-8b5a7098fac1



### After


https://github.com/MetaMask/metamask-extension/assets/39872794/bc7c0c3f-e25a-4193-b066-fd38026ec569



## Manual Testing Steps

- Go to the avatar network in popup view
- Hover on the avatar network and see it has network name in the tooltip


## Pre-merge author checklist

- [ ] I've clearly explained:
  - [ ] What problem this PR is solving
  - [ ] How this problem was solved
  - [ ] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
