### PR TITLE
Reset all Jest mocks in NetworkController tests

### DIFF
--- a/app/scripts/controllers/network/network-controller.test.ts
+++ b/app/scripts/controllers/network/network-controller.test.ts
@@ -153,6 +153,7 @@ describe('NetworkController', () => {
     nock.enableNetConnect('localhost');
     nock.cleanAll();
     resetAllWhenMocks();
+    jest.resetAllMocks();
   });
 
   describe('constructor', () => {


### PR DESCRIPTION

## Explanation

<!--
Thanks for the pull request. Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues, Slack conversations, Zendesk issues, user stories, etc. reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

This makes it possible to test that mock functions are called the
correct amount of times (otherwise Jest will think that a mock function
has been called for as many tests as exist in the NetworkController unit
test suite).

Tangentially related to https://github.com/MetaMask/core/issues/1197.

## Manual Testing Steps

<!--
How should reviewers and QA manually test your changes? For instance:

- Go to this screen
- Do this
- Then do this
-->

There should be no user-facing changes. All tests should pass.

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
