### PR TITLE
[FLASK] Allow Snaps to use `eth_accounts` as a revokable permission

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -3567,6 +3567,9 @@
   "revokeSpendingCapTooltipText": {
     "message": "This third party will be unable to spend any more of your current or future tokens."
   },
+  "revokePermission": {
+    "message": "Revoke permission"
+  },
   "riskRating": {
     "message": "Risk rating"
   },

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -366,6 +366,9 @@
   "allowThisSiteTo": {
     "message": "Allow this site to:"
   },
+  "allowThisSnapTo": {
+    "message": "Allow this snap to:"
+  },
   "allowWithdrawAndSpend": {
     "message": "Allow $1 to withdraw and spend up to the following amount:",
     "description": "The url of the site that requested permission to 'withdraw and spend'"
@@ -3683,6 +3686,9 @@
   },
   "selectAccounts": {
     "message": "Select the account(s) to use on this site"
+  },
+  "selectAccountsForSnap": {
+    "message": "Select the account(s) to use with this snap"
   },
   "selectAll": {
     "message": "Select all"

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -3779,10 +3779,6 @@
   "settingsSearchMatchingNotFound": {
     "message": "No matching results found."
   },
-  "shortVersion": {
-    "message": "v$1",
-    "description": "$1 is the version number to show"
-  },
   "show": {
     "message": "Show"
   },

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -3560,15 +3560,15 @@
     "message": "This revokes the permission for a third party to access and transfer all of your NFTs from $1 without further notice.",
     "description": "$1 is a link to contract on the block explorer when we're not able to retrieve a erc721 or erc1155 name"
   },
+  "revokePermission": {
+    "message": "Revoke permission"
+  },
   "revokeSpendingCap": {
     "message": "Revoke spending cap for your $1",
     "description": "$1 is a token symbol"
   },
   "revokeSpendingCapTooltipText": {
     "message": "This third party will be unable to spend any more of your current or future tokens."
-  },
-  "revokePermission": {
-    "message": "Revoke permission"
   },
   "riskRating": {
     "message": "Risk rating"

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -1800,6 +1800,10 @@ export default class MetamaskController extends EventEmitter {
     this.notificationController.markRead(ids);
   }
 
+  revokeDynamicSnapPermissions(permissions) {
+    // TODO
+  }
+
   ///: END:ONLY_INCLUDE_IN
 
   /**

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -1800,10 +1800,6 @@ export default class MetamaskController extends EventEmitter {
     this.notificationController.markRead(ids);
   }
 
-  revokeDynamicSnapPermissions(permissions) {
-    // TODO
-  }
-
   ///: END:ONLY_INCLUDE_IN
 
   /**
@@ -2471,6 +2467,10 @@ export default class MetamaskController extends EventEmitter {
       handleSnapRequest: this.controllerMessenger.call.bind(
         this.controllerMessenger,
         'SnapController:handleRequest',
+      ),
+      revokeDynamicSnapPermissions: this.controllerMessenger.call.bind(
+        this.controllerMessenger,
+        'SnapController:revokeDynamicPermissions',
       ),
       dismissNotifications: this.dismissNotifications.bind(this),
       markNotificationsAsRead: this.markNotificationsAsRead.bind(this),

--- a/shared/constants/snaps/permissions.ts
+++ b/shared/constants/snaps/permissions.ts
@@ -29,3 +29,5 @@ export const ExcludedSnapEndowments = Object.freeze({
     'endowment:long-running is deprecated. For more information please see https://github.com/MetaMask/snaps-monorepo/issues/945.',
   ///: END:ONLY_INCLUDE_IN
 });
+
+export const DynamicSnapPermissions = Object.freeze(['eth_accounts']);

--- a/ui/components/app/permission-cell/permission-cell-options.js
+++ b/ui/components/app/permission-cell/permission-cell-options.js
@@ -13,7 +13,11 @@ import Popover from '../../ui/popover/popover.component';
 import { DynamicSnapPermissions } from '../../../../shared/constants/snaps/permissions';
 import { revokeDynamicSnapPermissions } from '../../../store/actions';
 
-export const PermissionCellOptions = ({ permissionName, description }) => {
+export const PermissionCellOptions = ({
+  snapId,
+  permissionName,
+  description,
+}) => {
   const t = useI18nContext();
   const dispatch = useDispatch();
   const ref = useRef(false);
@@ -42,7 +46,7 @@ export const PermissionCellOptions = ({ permissionName, description }) => {
 
   const handleRevokePermission = () => {
     setShowOptions(false);
-    dispatch(revokeDynamicSnapPermissions([permissionName]));
+    dispatch(revokeDynamicSnapPermissions(snapId, permissionName));
   };
 
   return (
@@ -91,6 +95,7 @@ export const PermissionCellOptions = ({ permissionName, description }) => {
 };
 
 PermissionCellOptions.propTypes = {
+  snapId: PropTypes.string.isRequired,
   permissionName: PropTypes.string.isRequired,
   description: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
 };

--- a/ui/components/app/permission-cell/permission-cell-options.js
+++ b/ui/components/app/permission-cell/permission-cell-options.js
@@ -1,5 +1,6 @@
 import React, { useState, useRef } from 'react';
 import PropTypes from 'prop-types';
+import { useDispatch } from 'react-redux';
 import Box from '../../ui/box';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import { IconName, ButtonIcon, Text } from '../../component-library';
@@ -9,12 +10,17 @@ import {
   TextVariant,
 } from '../../../helpers/constants/design-system';
 import Popover from '../../ui/popover/popover.component';
+import { DynamicSnapPermissions } from '../../../../shared/constants/snaps/permissions';
+import { revokeDynamicSnapPermissions } from '../../../store/actions';
 
 export const PermissionCellOptions = ({ permissionName, description }) => {
   const t = useI18nContext();
+  const dispatch = useDispatch();
   const ref = useRef(false);
   const [showOptions, setShowOptions] = useState(false);
   const [showDetails, setShowDetails] = useState(false);
+
+  const isRevokable = DynamicSnapPermissions.includes(permissionName);
 
   const handleOpen = () => {
     setShowOptions(true);
@@ -36,7 +42,7 @@ export const PermissionCellOptions = ({ permissionName, description }) => {
 
   const handleRevokePermission = () => {
     setShowOptions(false);
-    // TODO
+    dispatch(revokeDynamicSnapPermissions([permissionName]));
   };
 
   return (
@@ -58,17 +64,19 @@ export const PermissionCellOptions = ({ permissionName, description }) => {
               {t('details')}
             </Text>
           </MenuItem>
-          <MenuItem onClick={handleRevokePermission}>
-            <Text
-              variant={TextVariant.bodySm}
-              color={TextColor.errorDefault}
-              style={{
-                whiteSpace: 'nowrap',
-              }}
-            >
-              {t('revokePermission')}
-            </Text>
-          </MenuItem>
+          {isRevokable && (
+            <MenuItem onClick={handleRevokePermission}>
+              <Text
+                variant={TextVariant.bodySm}
+                color={TextColor.errorDefault}
+                style={{
+                  whiteSpace: 'nowrap',
+                }}
+              >
+                {t('revokePermission')}
+              </Text>
+            </MenuItem>
+          )}
         </Menu>
       )}
       {showDetails && (

--- a/ui/components/app/permission-cell/permission-cell-options.js
+++ b/ui/components/app/permission-cell/permission-cell-options.js
@@ -1,0 +1,52 @@
+import React, { useState, useRef } from 'react';
+import Box from '../../ui/box';
+import { useI18nContext } from '../../../hooks/useI18nContext';
+import { IconName, ButtonIcon, Text } from '../../component-library';
+import { Menu, MenuItem } from '../../ui/menu';
+import {
+  TextColor,
+  TextVariant,
+} from '../../../helpers/constants/design-system';
+
+export const PermissionCellOptions = () => {
+  const t = useI18nContext();
+  const ref = useRef(false);
+  const [showOptions, setShowOptions] = useState(false);
+
+  const handleOpen = () => {
+    setShowOptions(true);
+  };
+
+  const handleClose = () => {
+    setShowOptions(false);
+  };
+
+  const handleRevokePermission = () => {
+    // TODO
+  };
+
+  return (
+    <Box ref={ref}>
+      <ButtonIcon
+        iconName={IconName.MoreVertical}
+        ariaLabel={t('options')}
+        onClick={handleOpen}
+      />
+      {showOptions && (
+        <Menu anchorElement={ref.current} onHide={handleClose}>
+          <MenuItem onClick={handleRevokePermission}>
+            <Text
+              variant={TextVariant.bodySm}
+              color={TextColor.errorDefault}
+              style={{
+                whiteSpace: 'nowrap',
+              }}
+            >
+              {t('revokePermission')}
+            </Text>
+          </MenuItem>
+        </Menu>
+      )}
+    </Box>
+  );
+};

--- a/ui/components/app/permission-cell/permission-cell-options.js
+++ b/ui/components/app/permission-cell/permission-cell-options.js
@@ -46,7 +46,7 @@ export const PermissionCellOptions = ({
 
   const handleRevokePermission = () => {
     setShowOptions(false);
-    dispatch(revokeDynamicSnapPermissions(snapId, permissionName));
+    dispatch(revokeDynamicSnapPermissions(snapId, [permissionName]));
   };
 
   return (

--- a/ui/components/app/permission-cell/permission-cell-options.js
+++ b/ui/components/app/permission-cell/permission-cell-options.js
@@ -1,4 +1,5 @@
 import React, { useState, useRef } from 'react';
+import PropTypes from 'prop-types';
 import Box from '../../ui/box';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import { IconName, ButtonIcon, Text } from '../../component-library';
@@ -7,11 +8,13 @@ import {
   TextColor,
   TextVariant,
 } from '../../../helpers/constants/design-system';
+import Popover from '../../ui/popover/popover.component';
 
-export const PermissionCellOptions = () => {
+export const PermissionCellOptions = ({ permissionName, description }) => {
   const t = useI18nContext();
   const ref = useRef(false);
   const [showOptions, setShowOptions] = useState(false);
+  const [showDetails, setShowDetails] = useState(false);
 
   const handleOpen = () => {
     setShowOptions(true);
@@ -21,7 +24,18 @@ export const PermissionCellOptions = () => {
     setShowOptions(false);
   };
 
+  const handleDetailsOpen = () => {
+    setShowOptions(false);
+    setShowDetails(true);
+  };
+
+  const handleDetailsClose = () => {
+    setShowOptions(false);
+    setShowDetails(false);
+  };
+
   const handleRevokePermission = () => {
+    setShowOptions(false);
     // TODO
   };
 
@@ -34,6 +48,16 @@ export const PermissionCellOptions = () => {
       />
       {showOptions && (
         <Menu anchorElement={ref.current} onHide={handleClose}>
+          <MenuItem onClick={handleDetailsOpen}>
+            <Text
+              variant={TextVariant.bodySm}
+              style={{
+                whiteSpace: 'nowrap',
+              }}
+            >
+              {t('details')}
+            </Text>
+          </MenuItem>
           <MenuItem onClick={handleRevokePermission}>
             <Text
               variant={TextVariant.bodySm}
@@ -47,6 +71,18 @@ export const PermissionCellOptions = () => {
           </MenuItem>
         </Menu>
       )}
+      {showDetails && (
+        <Popover title={t('details')} onClose={handleDetailsClose}>
+          <Box marginLeft={4} marginRight={4} marginBottom={4}>
+            <Text>{description}</Text>
+          </Box>
+        </Popover>
+      )}
     </Box>
   );
+};
+
+PermissionCellOptions.propTypes = {
+  permissionName: PropTypes.string.isRequired,
+  description: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
 };

--- a/ui/components/app/permission-cell/permission-cell.js
+++ b/ui/components/app/permission-cell/permission-cell.js
@@ -21,6 +21,7 @@ import {
 import { formatDate } from '../../../helpers/utils/util';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import Tooltip from '../../ui/tooltip';
+import { PermissionCellOptions } from './permission-cell-options';
 
 const PermissionCell = ({
   title,
@@ -29,6 +30,7 @@ const PermissionCell = ({
   avatarIcon,
   dateApproved,
   revoked,
+  showOptions,
 }) => {
   const t = useI18nContext();
 
@@ -107,9 +109,13 @@ const PermissionCell = ({
         </Text>
       </Box>
       <Box>
-        <Tooltip html={<div>{description}</div>} position="bottom">
-          <Icon color={infoIconColor} name={infoIcon} size={IconSize.Sm} />
-        </Tooltip>
+        {showOptions ? (
+          <PermissionCellOptions />
+        ) : (
+          <Tooltip html={<div>{description}</div>} position="bottom">
+            <Icon color={infoIconColor} name={infoIcon} size={IconSize.Sm} />
+          </Tooltip>
+        )}
       </Box>
     </Box>
   );
@@ -125,6 +131,7 @@ PermissionCell.propTypes = {
   avatarIcon: PropTypes.any.isRequired,
   dateApproved: PropTypes.number,
   revoked: PropTypes.bool,
+  showOptions: PropTypes.bool,
 };
 
 export default PermissionCell;

--- a/ui/components/app/permission-cell/permission-cell.js
+++ b/ui/components/app/permission-cell/permission-cell.js
@@ -24,6 +24,7 @@ import Tooltip from '../../ui/tooltip';
 import { PermissionCellOptions } from './permission-cell-options';
 
 const PermissionCell = ({
+  permissionName,
   title,
   description,
   weight,
@@ -110,7 +111,10 @@ const PermissionCell = ({
       </Box>
       <Box>
         {showOptions ? (
-          <PermissionCellOptions />
+          <PermissionCellOptions
+            permissionName={permissionName}
+            description={description}
+          />
         ) : (
           <Tooltip html={<div>{description}</div>} position="bottom">
             <Icon color={infoIconColor} name={infoIcon} size={IconSize.Sm} />
@@ -122,6 +126,7 @@ const PermissionCell = ({
 };
 
 PermissionCell.propTypes = {
+  permissionName: PropTypes.string.isRequired,
   title: PropTypes.oneOfType([
     PropTypes.string.isRequired,
     PropTypes.object.isRequired,

--- a/ui/components/app/permission-cell/permission-cell.js
+++ b/ui/components/app/permission-cell/permission-cell.js
@@ -24,6 +24,7 @@ import Tooltip from '../../ui/tooltip';
 import { PermissionCellOptions } from './permission-cell-options';
 
 const PermissionCell = ({
+  snapId,
   permissionName,
   title,
   description,
@@ -110,8 +111,9 @@ const PermissionCell = ({
         </Text>
       </Box>
       <Box>
-        {showOptions ? (
+        {showOptions && snapId ? (
           <PermissionCellOptions
+            snapId={snapId}
             permissionName={permissionName}
             description={description}
           />
@@ -126,6 +128,7 @@ const PermissionCell = ({
 };
 
 PermissionCell.propTypes = {
+  snapId: PropTypes.string,
   permissionName: PropTypes.string.isRequired,
   title: PropTypes.oneOfType([
     PropTypes.string.isRequired,

--- a/ui/components/app/permission-cell/permission-cell.test.js
+++ b/ui/components/app/permission-cell/permission-cell.test.js
@@ -19,6 +19,7 @@ describe('Permission Cell', () => {
   it('renders approved permission cell', () => {
     renderWithProvider(
       <PermissionCell
+        permissionName={mockPermissionData.permissionName}
         title={mockPermissionData.label}
         description={mockPermissionData.description}
         weight={mockPermissionData.weight}
@@ -36,6 +37,7 @@ describe('Permission Cell', () => {
   it('renders revoked permission cell', () => {
     renderWithProvider(
       <PermissionCell
+        permissionName={mockPermissionData.permissionName}
         title={mockPermissionData.label}
         description={mockPermissionData.description}
         weight={mockPermissionData.weight}
@@ -54,6 +56,7 @@ describe('Permission Cell', () => {
   it('renders requested permission cell', () => {
     renderWithProvider(
       <PermissionCell
+        permissionName={mockPermissionData.permissionName}
         title={mockPermissionData.label}
         description={mockPermissionData.description}
         weight={mockPermissionData.weight}

--- a/ui/components/app/permission-page-container/index.scss
+++ b/ui/components/app/permission-page-container/index.scss
@@ -10,16 +10,24 @@
     justify-content: space-between;
   }
 
-  @include screen-sm-min {
-    width: 426px;
+  &__footers {
+    width: 100%;
     flex: 1;
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-end;
 
-    &__footers {
-      display: flex;
-      flex-direction: column-reverse;
-      flex: 1;
-      padding-bottom: 20px;
-      justify-content: space-between;
+    .page-container__footer {
+      align-items: center;
+      margin-top: 12px;
+
+      @include screen-sm-min {
+        border-top: none;
+      }
+
+      footer {
+        width: 100%;
+      }
     }
   }
 
@@ -38,6 +46,7 @@
     color: var(--color-text-default);
     padding-left: 24px;
     padding-right: 24px;
+    margin-top: 2px;
 
     a,
     a:hover {
@@ -88,19 +97,6 @@
     display: flex;
     flex-direction: column;
     margin-top: 38px;
-  }
-
-  .page-container__footer {
-    align-items: center;
-    margin-top: 12px;
-
-    @include screen-sm-min {
-      border-top: none;
-    }
-
-    footer {
-      width: 100%;
-    }
   }
 
   @include screen-sm-max {

--- a/ui/components/app/permission-page-container/permission-page-container-content/permission-page-container-content.component.js
+++ b/ui/components/app/permission-page-container/permission-page-container-content/permission-page-container-content.component.js
@@ -3,6 +3,7 @@ import React, { PureComponent } from 'react';
 import PermissionsConnectHeader from '../../permissions-connect-header';
 import Tooltip from '../../../ui/tooltip';
 import PermissionsConnectPermissionList from '../../permissions-connect-permission-list';
+import { SubjectType } from '@metamask/permission-controller';
 
 export default class PermissionPageContainerContent extends PureComponent {
   static propTypes = {
@@ -96,11 +97,27 @@ export default class PermissionPageContainerContent extends PureComponent {
     return t('connectTo', [selectedIdentities[0]?.addressLabel]);
   }
 
-  render() {
+  getHeaderText() {
     const { subjectMetadata } = this.props;
     const { t } = this.context;
 
+    ///: BEGIN:ONLY_INCLUDE_IN(snaps)
+    if (subjectMetadata.subjectType === SubjectType.Snap) {
+      return t('allowThisSnapTo');
+    }
+    ///: END:ONLY_INCLUDE_IN
+
+    return subjectMetadata.extensionId
+      ? t('allowExternalExtensionTo', [subjectMetadata.extensionId])
+      : t('allowThisSiteTo');
+  }
+
+  render() {
+    const { subjectMetadata } = this.props;
+
     const title = this.getTitle();
+
+    const headerText = this.getHeaderText();
 
     return (
       <div className="permission-approval-container__content">
@@ -109,12 +126,9 @@ export default class PermissionPageContainerContent extends PureComponent {
             iconUrl={subjectMetadata.iconUrl}
             iconName={subjectMetadata.name}
             headerTitle={title}
-            headerText={
-              subjectMetadata.extensionId
-                ? t('allowExternalExtensionTo', [subjectMetadata.extensionId])
-                : t('allowThisSiteTo')
-            }
+            headerText={headerText}
             siteOrigin={subjectMetadata.origin}
+            subjectType={subjectMetadata.subjectType}
           />
           <section className="permission-approval-container__permissions-container">
             {this.renderRequestedPermissions()}

--- a/ui/components/app/permission-page-container/permission-page-container-content/permission-page-container-content.component.js
+++ b/ui/components/app/permission-page-container/permission-page-container-content/permission-page-container-content.component.js
@@ -1,6 +1,8 @@
 import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
+///: BEGIN:ONLY_INCLUDE_IN(snaps)
 import { SubjectType } from '@metamask/permission-controller';
+///: END:ONLY_INCLUDE_IN
 import PermissionsConnectHeader from '../../permissions-connect-header';
 import Tooltip from '../../../ui/tooltip';
 import PermissionsConnectPermissionList from '../../permissions-connect-permission-list';

--- a/ui/components/app/permission-page-container/permission-page-container-content/permission-page-container-content.component.js
+++ b/ui/components/app/permission-page-container/permission-page-container-content/permission-page-container-content.component.js
@@ -1,9 +1,9 @@
 import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
+import { SubjectType } from '@metamask/permission-controller';
 import PermissionsConnectHeader from '../../permissions-connect-header';
 import Tooltip from '../../../ui/tooltip';
 import PermissionsConnectPermissionList from '../../permissions-connect-permission-list';
-import { SubjectType } from '@metamask/permission-controller';
 
 export default class PermissionPageContainerContent extends PureComponent {
   static propTypes = {

--- a/ui/components/app/permission-page-container/permission-page-container.component.js
+++ b/ui/components/app/permission-page-container/permission-page-container.component.js
@@ -7,6 +7,7 @@ import {
   WALLET_SNAP_PERMISSION_KEY,
 } from '@metamask/rpc-methods';
 ///: END:ONLY_INCLUDE_IN
+import { SubjectType } from '@metamask/permission-controller';
 import { MetaMetricsEventCategory } from '../../../../shared/constants/metametrics';
 import { PageContainerFooter } from '../../ui/page-container';
 import PermissionsConnectFooter from '../permissions-connect-footer';
@@ -210,7 +211,9 @@ export default class PermissionPageContainer extends Component {
           allIdentitiesSelected={allIdentitiesSelected}
         />
         <div className="permission-approval-container__footers">
-          <PermissionsConnectFooter />
+          {targetSubjectMetadata?.subjectType !== SubjectType.Snap && (
+            <PermissionsConnectFooter />
+          )}
           <PageContainerFooter
             cancelButtonType="default"
             onCancel={() => this.onCancel()}

--- a/ui/components/app/permission-page-container/permission-page-container.component.js
+++ b/ui/components/app/permission-page-container/permission-page-container.component.js
@@ -189,7 +189,7 @@ export default class PermissionPageContainer extends Component {
     ///: END:ONLY_INCLUDE_IN
 
     return (
-      <div className="page-container permission-approval-container">
+      <>
         {
           ///: BEGIN:ONLY_INCLUDE_IN(snaps)
           <>
@@ -220,7 +220,7 @@ export default class PermissionPageContainer extends Component {
             buttonSizeLarge={false}
           />
         </div>
-      </div>
+      </>
     );
   }
 }

--- a/ui/components/app/permissions-connect-header/permissions-connect-header.component.js
+++ b/ui/components/app/permissions-connect-header/permissions-connect-header.component.js
@@ -1,6 +1,10 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import classnames from 'classnames';
+///: BEGIN:ONLY_INCLUDE_IN(snaps)
+import { SubjectType } from '@metamask/subject-metadata-controller';
+import SnapAuthorshipHeader from '../snaps/snap-authorship-header/snap-authorship-header';
+///: END:ONLY_INCLUDE_IN
 import SiteOrigin from '../../ui/site-origin';
 import Box from '../../ui/box';
 import {
@@ -19,6 +23,9 @@ export default class PermissionsConnectHeader extends Component {
     headerText: PropTypes.string,
     leftIcon: PropTypes.node,
     rightIcon: PropTypes.node,
+    ///: BEGIN:ONLY_INCLUDE_IN(snaps)
+    subjectType: PropTypes.string,
+    ///: END:ONLY_INCLUDE_IN
   };
 
   static defaultProps = {
@@ -29,7 +36,27 @@ export default class PermissionsConnectHeader extends Component {
   };
 
   renderHeaderIcon() {
-    const { iconUrl, iconName, siteOrigin, leftIcon, rightIcon } = this.props;
+    const {
+      iconUrl,
+      iconName,
+      siteOrigin,
+      leftIcon,
+      rightIcon,
+      ///: BEGIN:ONLY_INCLUDE_IN(snaps)
+      subjectType,
+      ///: END:ONLY_INCLUDE_IN
+    } = this.props;
+
+    ///: BEGIN:ONLY_INCLUDE_IN(snaps)
+
+    if (subjectType === SubjectType.Snap) {
+      return (
+        <div className="permissions-connect-header__icon">
+          <SnapAuthorshipHeader snapId={siteOrigin} />
+        </div>
+      );
+    }
+    ///: END:ONLY_INCLUDE_IN
 
     return (
       <div className="permissions-connect-header__icon">

--- a/ui/components/app/permissions-connect-header/permissions-connect-header.component.js
+++ b/ui/components/app/permissions-connect-header/permissions-connect-header.component.js
@@ -3,7 +3,6 @@ import React, { Component } from 'react';
 import classnames from 'classnames';
 ///: BEGIN:ONLY_INCLUDE_IN(snaps)
 import { SubjectType } from '@metamask/subject-metadata-controller';
-import SnapAuthorshipHeader from '../snaps/snap-authorship-header/snap-authorship-header';
 ///: END:ONLY_INCLUDE_IN
 import SiteOrigin from '../../ui/site-origin';
 import Box from '../../ui/box';
@@ -48,11 +47,7 @@ export default class PermissionsConnectHeader extends Component {
     ///: BEGIN:ONLY_INCLUDE_IN(snaps)
 
     if (subjectType === SubjectType.Snap) {
-      return (
-        <div className="permissions-connect-header__icon">
-          <SnapAuthorshipHeader snapId={siteOrigin} />
-        </div>
-      );
+      return null;
     }
     ///: END:ONLY_INCLUDE_IN
 

--- a/ui/components/app/permissions-connect-header/permissions-connect-header.component.js
+++ b/ui/components/app/permissions-connect-header/permissions-connect-header.component.js
@@ -23,9 +23,7 @@ export default class PermissionsConnectHeader extends Component {
     headerText: PropTypes.string,
     leftIcon: PropTypes.node,
     rightIcon: PropTypes.node,
-    ///: BEGIN:ONLY_INCLUDE_IN(snaps)
     subjectType: PropTypes.string,
-    ///: END:ONLY_INCLUDE_IN
   };
 
   static defaultProps = {

--- a/ui/components/app/snaps/snap-authorship-header/snap-authorship-header.js
+++ b/ui/components/app/snaps/snap-authorship-header/snap-authorship-header.js
@@ -24,7 +24,11 @@ import { getTargetSubjectMetadata } from '../../../../selectors';
 import SnapAvatar from '../snap-avatar';
 import SnapVersion from '../snap-version/snap-version';
 
-const SnapAuthorshipHeader = ({ snapId, className }) => {
+const SnapAuthorshipHeader = ({
+  snapId,
+  className,
+  boxShadow = 'var(--shadow-size-lg) var(--color-shadow-default)',
+}) => {
   // We're using optional chaining with snapId, because with the current implementation
   // of snap update in the snap controller, we do not have reference to snapId when an
   // update request is rejected because the reference comes from the request itself and not subject metadata
@@ -51,7 +55,7 @@ const SnapAuthorshipHeader = ({ snapId, className }) => {
       display={DISPLAY.FLEX}
       padding={4}
       style={{
-        boxShadow: 'var(--shadow-size-lg) var(--color-shadow-default)',
+        boxShadow,
       }}
     >
       <Box>
@@ -91,6 +95,7 @@ SnapAuthorshipHeader.propTypes = {
    * The className of the SnapAuthorship
    */
   className: PropTypes.string,
+  boxShadow: PropTypes.string,
 };
 
 export default SnapAuthorshipHeader;

--- a/ui/components/app/snaps/snap-permissions-list/snap-permissions-list.js
+++ b/ui/components/app/snaps/snap-permissions-list/snap-permissions-list.js
@@ -6,6 +6,7 @@ import PermissionCell from '../../permission-cell';
 import Box from '../../../ui/box';
 
 export default function SnapPermissionsList({
+  snapId,
   permissions,
   targetSubjectMetadata,
   showOptions,
@@ -18,6 +19,7 @@ export default function SnapPermissionsList({
         (permission, index) => {
           return (
             <PermissionCell
+              snapId={snapId}
               permissionName={permission.permissionName}
               title={permission.label}
               description={permission.description}
@@ -35,6 +37,7 @@ export default function SnapPermissionsList({
 }
 
 SnapPermissionsList.propTypes = {
+  snapId: PropTypes.string.isRequired,
   permissions: PropTypes.object.isRequired,
   targetSubjectMetadata: PropTypes.object.isRequired,
   showOptions: PropTypes.bool,

--- a/ui/components/app/snaps/snap-permissions-list/snap-permissions-list.js
+++ b/ui/components/app/snaps/snap-permissions-list/snap-permissions-list.js
@@ -8,6 +8,7 @@ import Box from '../../../ui/box';
 export default function SnapPermissionsList({
   permissions,
   targetSubjectMetadata,
+  showOptions
 }) {
   const t = useI18nContext();
 
@@ -23,6 +24,7 @@ export default function SnapPermissionsList({
               avatarIcon={permission.leftIcon}
               dateApproved={permission?.permissionValue?.date}
               key={`${permission.permissionName}-${index}`}
+              showOptions={showOptions}
             />
           );
         },
@@ -34,4 +36,5 @@ export default function SnapPermissionsList({
 SnapPermissionsList.propTypes = {
   permissions: PropTypes.object.isRequired,
   targetSubjectMetadata: PropTypes.object.isRequired,
+  showOptions: PropTypes.bool,
 };

--- a/ui/components/app/snaps/snap-permissions-list/snap-permissions-list.js
+++ b/ui/components/app/snaps/snap-permissions-list/snap-permissions-list.js
@@ -8,7 +8,7 @@ import Box from '../../../ui/box';
 export default function SnapPermissionsList({
   permissions,
   targetSubjectMetadata,
-  showOptions
+  showOptions,
 }) {
   const t = useI18nContext();
 
@@ -18,6 +18,7 @@ export default function SnapPermissionsList({
         (permission, index) => {
           return (
             <PermissionCell
+              permissionName={permission.permissionName}
               title={permission.label}
               description={permission.description}
               weight={permission.weight}

--- a/ui/components/app/snaps/snap-version/snap-version.js
+++ b/ui/components/app/snaps/snap-version/snap-version.js
@@ -42,7 +42,7 @@ const SnapVersion = ({ version, url }) => {
       >
         {version ? (
           <Text color={Color.textAlternative} variant={TextVariant.bodyMd}>
-            {t('shortVersion', [version])}
+            {version}
           </Text>
         ) : (
           <Preloader size={18} />

--- a/ui/components/app/snaps/snap-version/snap-version.js
+++ b/ui/components/app/snaps/snap-version/snap-version.js
@@ -18,10 +18,8 @@ import {
   Text,
 } from '../../../component-library';
 import Preloader from '../../../ui/icon/preloader/preloader-icon.component';
-import { useI18nContext } from '../../../../hooks/useI18nContext';
 
 const SnapVersion = ({ version, url }) => {
-  const t = useI18nContext();
   return (
     <Button
       variant={BUTTON_VARIANT.LINK}

--- a/ui/components/app/snaps/snap-version/snap-version.test.js
+++ b/ui/components/app/snaps/snap-version/snap-version.test.js
@@ -12,7 +12,7 @@ describe('SnapVersion', () => {
     const { getByText, container } = renderWithLocalization(
       <SnapVersion {...args} />,
     );
-    expect(getByText(`v${args.version}`)).toBeDefined();
+    expect(getByText(args.version)).toBeDefined();
     expect(container.firstChild).toHaveAttribute('href', args.url);
   });
 

--- a/ui/components/app/snaps/update-snap-permission-list/update-snap-permission-list.js
+++ b/ui/components/app/snaps/update-snap-permission-list/update-snap-permission-list.js
@@ -18,6 +18,7 @@ export default function UpdateSnapPermissionList({
       {getWeightedPermissions(t, newPermissions, targetSubjectMetadata).map(
         (permission, index) => (
           <PermissionCell
+            permissionName={permission.permissionName}
             title={permission.label}
             description={permission.description}
             weight={permission.weight}
@@ -30,6 +31,7 @@ export default function UpdateSnapPermissionList({
       {getWeightedPermissions(t, revokedPermissions, targetSubjectMetadata).map(
         (permission, index) => (
           <PermissionCell
+            permissionName={permission.permissionName}
             title={permission.label}
             description={permission.description}
             weight={permission.weight}
@@ -46,6 +48,7 @@ export default function UpdateSnapPermissionList({
         targetSubjectMetadata,
       ).map((permission, index) => (
         <PermissionCell
+          permissionName={permission.permissionName}
           title={permission.label}
           description={permission.description}
           weight={permission.weight}

--- a/ui/pages/permissions-connect/choose-account/choose-account.js
+++ b/ui/pages/permissions-connect/choose-account/choose-account.js
@@ -1,8 +1,6 @@
 import PropTypes from 'prop-types';
 import React, { useState } from 'react';
-///: BEGIN:ONLY_INCLUDE_IN(snaps)
 import { SubjectType } from '@metamask/permission-controller';
-///: END:ONLY_INCLUDE_IN
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import PermissionsConnectHeader from '../../../components/app/permissions-connect-header';
 import PermissionsConnectFooter from '../../../components/app/permissions-connect-footer';
@@ -89,7 +87,9 @@ const ChooseAccount = ({
         />
       </div>
       <div className="permissions-connect-choose-account__footer-container">
-        <PermissionsConnectFooter />
+        {targetSubjectMetadata?.subjectType !== SubjectType.Snap && (
+          <PermissionsConnectFooter />
+        )}
         <PageContainerFooter
           cancelButtonType="default"
           onCancel={() => cancelPermissionsRequest(permissionsRequestId)}

--- a/ui/pages/permissions-connect/choose-account/choose-account.js
+++ b/ui/pages/permissions-connect/choose-account/choose-account.js
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React, { useState } from 'react';
+import { SubjectType } from '@metamask/permission-controller';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import PermissionsConnectHeader from '../../../components/app/permissions-connect-header';
 import PermissionsConnectFooter from '../../../components/app/permissions-connect-footer';
@@ -47,6 +48,21 @@ const ChooseAccount = ({
     return accounts.length === selectedAccounts.size;
   };
 
+  const getHeaderText = () => {
+    if (accounts.length === 0) {
+      return t('connectAccountOrCreate');
+    }
+    ///: BEGIN:ONLY_INCLUDE_IN(snaps)
+    if (targetSubjectMetadata?.subjectType === SubjectType.Snap) {
+      return t('selectAccountsForSnap');
+    }
+    ///: END:ONLY_INCLUDE_IN
+
+    return t('selectAccounts');
+  };
+
+  const headerText = getHeaderText();
+
   return (
     <>
       <div className="permissions-connect-choose-account__content">
@@ -54,11 +70,7 @@ const ChooseAccount = ({
           iconUrl={targetSubjectMetadata?.iconUrl}
           iconName={targetSubjectMetadata?.name}
           headerTitle={t('connectWithMetaMask')}
-          headerText={
-            accounts.length > 0
-              ? t('selectAccounts')
-              : t('connectAccountOrCreate')
-          }
+          headerText={headerText}
           siteOrigin={targetSubjectMetadata?.origin}
           subjectType={targetSubjectMetadata?.subjectType}
         />

--- a/ui/pages/permissions-connect/choose-account/choose-account.js
+++ b/ui/pages/permissions-connect/choose-account/choose-account.js
@@ -1,6 +1,8 @@
 import PropTypes from 'prop-types';
 import React, { useState } from 'react';
+///: BEGIN:ONLY_INCLUDE_IN(snaps)
 import { SubjectType } from '@metamask/permission-controller';
+///: END:ONLY_INCLUDE_IN
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import PermissionsConnectHeader from '../../../components/app/permissions-connect-header';
 import PermissionsConnectFooter from '../../../components/app/permissions-connect-footer';

--- a/ui/pages/permissions-connect/choose-account/choose-account.js
+++ b/ui/pages/permissions-connect/choose-account/choose-account.js
@@ -60,6 +60,7 @@ const ChooseAccount = ({
               : t('connectAccountOrCreate')
           }
           siteOrigin={targetSubjectMetadata?.origin}
+          subjectType={targetSubjectMetadata?.subjectType}
         />
         <AccountList
           accounts={accounts}

--- a/ui/pages/permissions-connect/permissions-connect.component.js
+++ b/ui/pages/permissions-connect/permissions-connect.component.js
@@ -283,11 +283,13 @@ export default class PermissionConnect extends Component {
     return redirecting ? null : (
       <Box
         style={{
+          ///: BEGIN:ONLY_INCLUDE_IN(snaps)
           marginBottom:
             targetSubjectMetadata.subjectType === SubjectType.Snap && '14px',
           boxShadow:
             targetSubjectMetadata.subjectType === SubjectType.Snap &&
             'var(--shadow-size-lg) var(--color-shadow-default)',
+          ///: END:ONLY_INCLUDE_IN
         }}
       >
         <div className="permissions-connect__top-bar">
@@ -310,12 +312,16 @@ export default class PermissionConnect extends Component {
             </div>
           ) : null}
         </div>
-        {targetSubjectMetadata.subjectType === SubjectType.Snap && (
-          <SnapAuthorshipHeader
-            snapId={targetSubjectMetadata.origin}
-            boxShadow="none"
-          />
-        )}
+        {
+          ///: BEGIN:ONLY_INCLUDE_IN(snaps)
+          targetSubjectMetadata.subjectType === SubjectType.Snap && (
+            <SnapAuthorshipHeader
+              snapId={targetSubjectMetadata.origin}
+              boxShadow="none"
+            />
+          )
+          ///: END:ONLY_INCLUDE_IN
+        }
       </Box>
     );
   }

--- a/ui/pages/permissions-connect/permissions-connect.component.js
+++ b/ui/pages/permissions-connect/permissions-connect.component.js
@@ -277,7 +277,12 @@ export default class PermissionConnect extends Component {
   }
 
   renderTopBar() {
-    const { redirecting, targetSubjectMetadata } = this.state;
+    const {
+      redirecting,
+      ///: BEGIN:ONLY_INCLUDE_IN(snaps)
+      targetSubjectMetadata,
+      ///: END:ONLY_INCLUDE_IN
+    } = this.state;
     const { page, isRequestingAccounts, totalPages } = this.props;
     const { t } = this.context;
     return redirecting ? null : (

--- a/ui/pages/permissions-connect/permissions-connect.component.js
+++ b/ui/pages/permissions-connect/permissions-connect.component.js
@@ -3,13 +3,22 @@ import React, { Component } from 'react';
 import { Switch, Route } from 'react-router-dom';
 ///: BEGIN:ONLY_INCLUDE_IN(snaps)
 import { ethErrors, serializeError } from 'eth-rpc-errors';
+import { SubjectType } from '@metamask/subject-metadata-controller';
 ///: END:ONLY_INCLUDE_IN
 import { getEnvironmentType } from '../../../app/scripts/lib/util';
 import { ENVIRONMENT_TYPE_NOTIFICATION } from '../../../shared/constants/app';
 import { MILLISECOND } from '../../../shared/constants/time';
 import { DEFAULT_ROUTE } from '../../helpers/constants/routes';
 import PermissionPageContainer from '../../components/app/permission-page-container';
-import { Icon, IconName, IconSize } from '../../components/component-library';
+import {
+  Box,
+  Icon,
+  IconName,
+  IconSize,
+} from '../../components/component-library';
+///: BEGIN:ONLY_INCLUDE_IN(snaps)
+import SnapAuthorshipHeader from '../../components/app/snaps/snap-authorship-header/snap-authorship-header';
+///: END:ONLY_INCLUDE_IN
 import ChooseAccount from './choose-account';
 import PermissionsRedirect from './redirect';
 ///: BEGIN:ONLY_INCLUDE_IN(snaps)
@@ -268,30 +277,46 @@ export default class PermissionConnect extends Component {
   }
 
   renderTopBar() {
-    const { redirecting } = this.state;
+    const { redirecting, targetSubjectMetadata } = this.state;
     const { page, isRequestingAccounts, totalPages } = this.props;
     const { t } = this.context;
     return redirecting ? null : (
-      <div className="permissions-connect__top-bar">
-        {page === '2' && isRequestingAccounts ? (
-          <div
-            className="permissions-connect__back"
-            onClick={() => this.goBack()}
-          >
-            <Icon
-              name={IconName.ArrowLeft}
-              marginInlineEnd={1}
-              size={IconSize.Xs}
-            />
-            {t('back')}
-          </div>
-        ) : null}
-        {isRequestingAccounts ? (
-          <div className="permissions-connect__page-count">
-            {t('xOfY', [page, totalPages])}
-          </div>
-        ) : null}
-      </div>
+      <Box
+        style={{
+          marginBottom:
+            targetSubjectMetadata.subjectType === SubjectType.Snap && '14px',
+          boxShadow:
+            targetSubjectMetadata.subjectType === SubjectType.Snap &&
+            'var(--shadow-size-lg) var(--color-shadow-default)',
+        }}
+      >
+        <div className="permissions-connect__top-bar">
+          {page === '2' && isRequestingAccounts ? (
+            <div
+              className="permissions-connect__back"
+              onClick={() => this.goBack()}
+            >
+              <Icon
+                name={IconName.ArrowLeft}
+                marginInlineEnd={1}
+                size={IconSize.Xs}
+              />
+              {t('back')}
+            </div>
+          ) : null}
+          {isRequestingAccounts ? (
+            <div className="permissions-connect__page-count">
+              {t('xOfY', [page, totalPages])}
+            </div>
+          ) : null}
+        </div>
+        {targetSubjectMetadata.subjectType === SubjectType.Snap && (
+          <SnapAuthorshipHeader
+            snapId={targetSubjectMetadata.origin}
+            boxShadow="none"
+          />
+        )}
+      </Box>
     );
   }
 

--- a/ui/pages/permissions-connect/snaps/snap-install/snap-install.js
+++ b/ui/pages/permissions-connect/snaps/snap-install/snap-install.js
@@ -179,6 +179,7 @@ export default function SnapInstall({
               ])}
             </Text>
             <SnapPermissionsList
+              snapId={targetSubjectMetadata.origin}
               permissions={requestState.permissions || {}}
               targetSubjectMetadata={targetSubjectMetadata}
             />

--- a/ui/pages/settings/snaps/view-snap/view-snap.js
+++ b/ui/pages/settings/snaps/view-snap/view-snap.js
@@ -149,6 +149,7 @@ function ViewSnap() {
       <Box className="view-snap__permissions" marginTop={12}>
         <Text variant={TextVariant.bodyLgMedium}>{t('permissions')}</Text>
         <SnapPermissionsList
+          snapId={decodedSnapId}
           permissions={permissions ?? {}}
           targetSubjectMetadata={targetSubjectMetadata}
           showOptions

--- a/ui/pages/settings/snaps/view-snap/view-snap.js
+++ b/ui/pages/settings/snaps/view-snap/view-snap.js
@@ -151,6 +151,7 @@ function ViewSnap() {
         <SnapPermissionsList
           permissions={permissions ?? {}}
           targetSubjectMetadata={targetSubjectMetadata}
+          showOptions={true}
         />
       </Box>
       <Box className="view-snap__connected-sites" marginTop={12}>

--- a/ui/pages/settings/snaps/view-snap/view-snap.js
+++ b/ui/pages/settings/snaps/view-snap/view-snap.js
@@ -151,7 +151,7 @@ function ViewSnap() {
         <SnapPermissionsList
           permissions={permissions ?? {}}
           targetSubjectMetadata={targetSubjectMetadata}
-          showOptions={true}
+          showOptions
         />
       </Box>
       <Box className="view-snap__connected-sites" marginTop={12}>

--- a/ui/pages/settings/snaps/view-snap/view-snap.test.js
+++ b/ui/pages/settings/snaps/view-snap/view-snap.test.js
@@ -46,7 +46,7 @@ describe('ViewSnap', () => {
       getByText('An example Snap that signs messages using BLS.'),
     ).toBeDefined();
     // Snap version info
-    expect(getByText('v5.1.2')).toBeDefined();
+    expect(getByText('5.1.2')).toBeDefined();
     // Enable Snap
     expect(getByText('Enabled')).toBeDefined();
     expect(container.getElementsByClassName('toggle-button')?.length).toBe(1);

--- a/ui/store/actions.ts
+++ b/ui/store/actions.ts
@@ -1241,11 +1241,13 @@ export function markNotificationsAsRead(
 }
 
 export function revokeDynamicSnapPermissions(
-  permissions: string[],
+  snapId: string,
+  permissionNames: string[],
 ): ThunkAction<void, MetaMaskReduxState, unknown, AnyAction> {
   return async (dispatch: MetaMaskReduxDispatch) => {
     await submitRequestToBackground('revokeDynamicSnapPermissions', [
-      permissions,
+      snapId,
+      permissionNames,
     ]);
     await forceUpdateMetamaskState(dispatch);
   };

--- a/ui/store/actions.ts
+++ b/ui/store/actions.ts
@@ -1240,6 +1240,17 @@ export function markNotificationsAsRead(
   };
 }
 
+export function revokeDynamicSnapPermissions(
+  permissions: string[],
+): ThunkAction<void, MetaMaskReduxState, unknown, AnyAction> {
+  return async (dispatch: MetaMaskReduxDispatch) => {
+    await submitRequestToBackground('revokeDynamicSnapPermissions', [
+      permissions,
+    ]);
+    await forceUpdateMetamaskState(dispatch);
+  };
+}
+
 ///: END:ONLY_INCLUDE_IN
 ///: BEGIN:ONLY_INCLUDE_IN(desktop)
 


### PR DESCRIPTION
## Explanation

Allows Snaps to access `eth_accounts` as a revokable permission. This means that snaps now can use `eth_accounts` and `eth_requestAccounts` to prompt the user for account selection. This permission can be revoked again in the snaps settings whenever.

This PR is mainly UI changes to make the account connection flow work with these changes and UI additions for permission revoking.

This PR needs the latest, unpublished version of the snaps monorepo to work completely.