### PR TITLE
Sync NetworkController constructor tests with core

### DIFF
--- a/app/scripts/controllers/network/network-controller.test.ts
+++ b/app/scripts/controllers/network/network-controller.test.ts
@@ -158,57 +158,23 @@ describe('NetworkController', () => {
   describe('constructor', () => {
     const invalidInfuraProjectIds = [undefined, null, {}, 1];
     invalidInfuraProjectIds.forEach((invalidProjectId) => {
-      it(`throws if an invalid Infura ID of "${inspect(
+      it(`throws given an invalid Infura ID of "${inspect(
         invalidProjectId,
-      )}" is provided`, () => {
+      )}"`, () => {
+        const messenger = buildMessenger();
+        const restrictedMessenger = buildNetworkControllerMessenger(messenger);
         expect(
-          // @ts-expect-error We are intentionally passing bad input.
-          () => new NetworkController({ infuraProjectId: invalidProjectId }),
+          () =>
+            new NetworkController({
+              messenger: restrictedMessenger,
+              // @ts-expect-error We are intentionally passing bad input.
+              infuraProjectId: invalidProjectId,
+            }),
         ).toThrow('Invalid Infura project ID');
       });
     });
 
-    it('accepts initial state', async () => {
-      await withController(
-        {
-          state: {
-            providerConfig: {
-              type: 'rpc',
-              rpcUrl: 'http://example-custom-rpc.metamask.io',
-              chainId: '0x9999' as const,
-              nickname: 'Test initial state',
-            },
-            networkDetails: {
-              EIPS: {
-                1559: false,
-              },
-            },
-          },
-        },
-        ({ controller }) => {
-          expect(controller.store.getState()).toMatchInlineSnapshot(`
-            {
-              "networkConfigurations": {},
-              "networkDetails": {
-                "EIPS": {
-                  "1559": false,
-                },
-              },
-              "networkId": null,
-              "networkStatus": "unknown",
-              "providerConfig": {
-                "chainId": "0x9999",
-                "nickname": "Test initial state",
-                "rpcUrl": "http://example-custom-rpc.metamask.io",
-                "type": "rpc",
-              },
-            }
-          `);
-        },
-      );
-    });
-
-    it('sets default state without initial state', async () => {
+    it('initializes the state with some defaults', async () => {
       await withController(({ controller }) => {
         expect(controller.store.getState()).toMatchInlineSnapshot(`
           {
@@ -230,6 +196,46 @@ describe('NetworkController', () => {
           }
         `);
       });
+    });
+
+    it('merges the given state into the default state', async () => {
+      await withController(
+        {
+          state: {
+            providerConfig: {
+              type: 'rpc',
+              rpcUrl: 'http://example-custom-rpc.metamask.io',
+              chainId: '0x9999' as const,
+              nickname: 'Test initial state',
+            },
+            networkDetails: {
+              EIPS: {
+                1559: true,
+              },
+            },
+          },
+        },
+        ({ controller }) => {
+          expect(controller.store.getState()).toMatchInlineSnapshot(`
+            {
+              "networkConfigurations": {},
+              "networkDetails": {
+                "EIPS": {
+                  "1559": true,
+                },
+              },
+              "networkId": null,
+              "networkStatus": "unknown",
+              "providerConfig": {
+                "chainId": "0x9999",
+                "nickname": "Test initial state",
+                "rpcUrl": "http://example-custom-rpc.metamask.io",
+                "type": "rpc",
+              },
+            }
+          `);
+        },
+      );
     });
   });
 


### PR DESCRIPTION


## Explanation

<!--
Thanks for the pull request. Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues, Slack conversations, Zendesk issues, user stories, etc. reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

This makes it easier to compare the NetworkController unit tests between extension and core.

Progresses https://github.com/MetaMask/core/issues/1197.

## Manual Testing Steps

<!--
How should reviewers and QA manually test your changes? For instance:

- Go to this screen
- Do this
- Then do this
-->

There should be no user-facing changes. All tests should pass.

For comparison with core, see: https://github.com/MetaMask/core/blob/bad5f5344ba81e437116802fa8d8a90247e46977/packages/network-controller/tests/NetworkController.test.ts#L164

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
