### PR TITLE
Add getProviderConfig action to NetworkController

### DIFF
--- a/app/scripts/controllers/network/network-controller.test.ts
+++ b/app/scripts/controllers/network/network-controller.test.ts
@@ -18,6 +18,7 @@ import {
 import { MetaMetricsNetworkEventSource } from '../../../../shared/constants/metametrics';
 import {
   NetworkController,
+  NetworkControllerAction,
   NetworkControllerEvent,
   NetworkControllerOptions,
   NetworkControllerState,
@@ -2442,6 +2443,31 @@ describe('NetworkController', () => {
           await controller.resetConnection();
         },
       });
+    });
+  });
+
+  describe('NetworkController:getProviderConfig action', () => {
+    it('returns the provider config in state', async () => {
+      await withController(
+        {
+          state: {
+            providerConfig: buildProviderConfig({
+              type: NETWORK_TYPES.MAINNET,
+            }),
+          },
+        },
+        async ({ messenger }) => {
+          const providerConfig = await messenger.call(
+            'NetworkController:getProviderConfig',
+          );
+
+          expect(providerConfig).toStrictEqual(
+            buildProviderConfig({
+              type: NETWORK_TYPES.MAINNET,
+            }),
+          );
+        },
+      );
     });
   });
 
@@ -6082,7 +6108,10 @@ function lookupNetworkTests({
  * @returns The controller messenger.
  */
 function buildMessenger() {
-  return new ControllerMessenger<never, NetworkControllerEvent>();
+  return new ControllerMessenger<
+    NetworkControllerAction,
+    NetworkControllerEvent
+  >();
 }
 
 /**
@@ -6094,6 +6123,7 @@ function buildMessenger() {
 function buildNetworkControllerMessenger(messenger = buildMessenger()) {
   return messenger.getRestricted({
     name: 'NetworkController',
+    allowedActions: ['NetworkController:getProviderConfig'],
     allowedEvents: [
       'NetworkController:networkDidChange',
       'NetworkController:networkWillChange',
@@ -6110,7 +6140,10 @@ type WithControllerCallback<ReturnValue> = ({
   controller,
 }: {
   controller: NetworkController;
-  messenger: ControllerMessenger<never, NetworkControllerEvent>;
+  messenger: ControllerMessenger<
+    NetworkControllerAction,
+    NetworkControllerEvent
+  >;
 }) => Promise<ReturnValue> | ReturnValue;
 
 /**

--- a/app/scripts/controllers/network/network-controller.ts
+++ b/app/scripts/controllers/network/network-controller.ts
@@ -130,12 +130,19 @@ export type NetworkControllerEvent =
   | NetworkControllerInfuraIsBlockedEvent
   | NetworkControllerInfuraIsUnblockedEvent;
 
+export type NetworkControllerGetProviderConfigAction = {
+  type: `NetworkController:getProviderConfig`;
+  handler: () => ProviderConfiguration;
+};
+
+export type NetworkControllerAction = NetworkControllerGetProviderConfigAction;
+
 /**
  * The messenger that the NetworkController uses to publish events.
  */
 export type NetworkControllerMessenger = RestrictedControllerMessenger<
   typeof name,
-  never,
+  NetworkControllerAction,
   NetworkControllerEvent,
   string,
   string
@@ -477,6 +484,9 @@ export class NetworkController extends EventEmitter {
     }
     this.#infuraProjectId = infuraProjectId;
     this.#trackMetaMetricsEvent = trackMetaMetricsEvent;
+    this.#messenger.registerActionHandler(`${name}:getProviderConfig`, () => {
+      return this.store.getState().providerConfig;
+    });
   }
 
   /**


### PR DESCRIPTION


## Explanation

<!--
Thanks for the pull request. Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues, Slack conversations, Zendesk issues, user stories, etc. reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

This controller action exists within the core version of NetworkController. Although there are no plans to make use of this action within the extension, it has accompanying tests. So ultimately, the goal of this commit (like others) is to make it easier to compare differences in the NetworkController tests between this repo and core by adding a test for the `getProviderConfig` action.

Progresses https://github.com/MetaMask/core/issues/1197.

## Manual Testing Steps

<!--
How should reviewers and QA manually test your changes? For instance:

- Go to this screen
- Do this
- Then do this
-->

There should be no functional changes. All tests should pass.

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
