### PR TITLE
Update `@metamask/announcement-controller` to v4

### DIFF
--- a/lavamoat/browserify/beta/policy.json
+++ b/lavamoat/browserify/beta/policy.json
@@ -800,12 +800,7 @@
     },
     "@metamask/announcement-controller": {
       "packages": {
-        "@metamask/announcement-controller>@metamask/base-controller": true
-      }
-    },
-    "@metamask/announcement-controller>@metamask/base-controller": {
-      "packages": {
-        "immer": true
+        "@metamask/base-controller": true
       }
     },
     "@metamask/approval-controller": {

--- a/lavamoat/browserify/desktop/policy.json
+++ b/lavamoat/browserify/desktop/policy.json
@@ -800,12 +800,7 @@
     },
     "@metamask/announcement-controller": {
       "packages": {
-        "@metamask/announcement-controller>@metamask/base-controller": true
-      }
-    },
-    "@metamask/announcement-controller>@metamask/base-controller": {
-      "packages": {
-        "immer": true
+        "@metamask/base-controller": true
       }
     },
     "@metamask/approval-controller": {

--- a/lavamoat/browserify/flask/policy.json
+++ b/lavamoat/browserify/flask/policy.json
@@ -800,12 +800,7 @@
     },
     "@metamask/announcement-controller": {
       "packages": {
-        "@metamask/announcement-controller>@metamask/base-controller": true
-      }
-    },
-    "@metamask/announcement-controller>@metamask/base-controller": {
-      "packages": {
-        "immer": true
+        "@metamask/base-controller": true
       }
     },
     "@metamask/approval-controller": {

--- a/lavamoat/browserify/main/policy.json
+++ b/lavamoat/browserify/main/policy.json
@@ -800,12 +800,7 @@
     },
     "@metamask/announcement-controller": {
       "packages": {
-        "@metamask/announcement-controller>@metamask/base-controller": true
-      }
-    },
-    "@metamask/announcement-controller>@metamask/base-controller": {
-      "packages": {
-        "immer": true
+        "@metamask/base-controller": true
       }
     },
     "@metamask/approval-controller": {

--- a/package.json
+++ b/package.json
@@ -224,7 +224,7 @@
     "@metamask-institutional/sdk": "^0.1.17",
     "@metamask-institutional/transaction-update": "^0.1.21",
     "@metamask/address-book-controller": "^2.0.0",
-    "@metamask/announcement-controller": "^3.0.0",
+    "@metamask/announcement-controller": "^4.0.0",
     "@metamask/approval-controller": "^2.1.0",
     "@metamask/assets-controllers": "^7.0.0",
     "@metamask/base-controller": "^3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3877,12 +3877,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/announcement-controller@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "@metamask/announcement-controller@npm:3.0.0"
+"@metamask/announcement-controller@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "@metamask/announcement-controller@npm:4.0.0"
   dependencies:
-    "@metamask/base-controller": ^2.0.0
-  checksum: 14fe28e7db72ca3457618016d33dd66a566c991d4692a62e83ddf89b74f82277e5ed47dbd128aff9079cc3a5045ef79b808c106acc18717a51fb8ef9d05e0d5b
+    "@metamask/base-controller": ^3.0.0
+  checksum: 9652545ddf1da0919c60c97456e695a39d7851c25bde9b73417c179c4c8abce4be32165d4d09b0c97671925b55d8c66a1af9f641595327722bbe92d658886719
   languageName: node
   linkType: hard
 
@@ -23953,7 +23953,7 @@ __metadata:
     "@metamask-institutional/sdk": ^0.1.17
     "@metamask-institutional/transaction-update": ^0.1.21
     "@metamask/address-book-controller": ^2.0.0
-    "@metamask/announcement-controller": ^3.0.0
+    "@metamask/announcement-controller": ^4.0.0
     "@metamask/approval-controller": ^2.1.0
     "@metamask/assets-controllers": ^7.0.0
     "@metamask/auto-changelog": ^2.1.0


### PR DESCRIPTION
## Explanation

The `@metamask/announcement-controller` has been updated to v4, which is the version released in the core monorepo v53 release. The remaining packages released as part of v53 will be updated in later PRs.

The only breaking change is that the minimum Node.js version was updated to v16.

Relates to #19271

## Manual Testing Steps

No functional changes

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
