### PR TITLE
ci: temporarily disable codecov status checks

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -4,13 +4,14 @@ codecov:
 coverage:
   round: nearest
   status:
-    project:
-      global:
-        target: auto
-        threshold: 0%
-        base: auto
-      transforms:
-        target: 100%
-        threshold: 0%
-        paths:
-          - development/build/transforms/**/*.js
+    project: off
+    patch: off
+      # global:
+      #   target: auto
+      #   threshold: 0%
+      #   base: auto
+      # transforms:
+      #   target: 100%
+      #   threshold: 0%
+      #   paths:
+      #     - development/build/transforms/**/*.js

--- a/test/merge-coverage.js
+++ b/test/merge-coverage.js
@@ -6,10 +6,29 @@ const reports = require('istanbul-reports');
 const glob = require('fast-glob');
 const yargs = require('yargs/yargs');
 const { hideBin } = require('yargs/helpers');
-const yaml = require('js-yaml');
+// Temporarily commented out as we can't rely on the commented yaml file
+// Can be restored when the codecov checks are restored
+// const yaml = require('js-yaml');
 const codecovTargets = require('../coverage-targets');
 
-const codecovConfig = yaml.load(fs.readFileSync('codecov.yml', 'utf8'));
+// Temporarily commented out as we can't rely on the commented yaml file
+// Can be restored when the codecov checks are restored. In the meantime
+// the important parts of the yaml file are copied below in normal js object
+// format.
+// const codecovConfig = yaml.load(fs.readFileSync('codecov.yml', 'utf8'));
+
+const codecovConfig = {
+  coverage: {
+    status: {
+      global: {},
+      project: {
+        transforms: {
+          paths: ['development/build/transforms/**/*.js'],
+        },
+      },
+    },
+  },
+};
 
 const COVERAGE_DIR = './coverage/';
 


### PR DESCRIPTION
## Explanation
Many pull requests have failing checks from codecov that are nonsensical, which makes the signal vs noise ratio less than ideal. There are many possibilities as to why this is happening, but the decision to disable stems from the fact that the codecov reports are **different** then our internal coverage check -- which is using the same coverage files as what is loaded to codecov. For this reason, it makes the most sense to disable. In addition the patch status check has been disabled as the lines that the tool is commenting on do not match at all the lines that are problematic. This, again, has got to be something to do with our merged coverage maps. 

Solution to return this functionality: 
1. Continue the migration away from Mocha until Jest is used globally, this will allow us to remove our merge coverage tool and just use jest's built-in coverage mapping solution. 
2. Return to the use of jest-it-up which was only removed because it was incompatible with merged coverage maps. 
3. Re-enable the *project* check which was simply commented out.
4. In a separate PR attempt to test the *patch* status to see if the comments become more helpful when coverage lines up. 
5. Potentially explore alternative root causes for mismatch in coverages if the codecov reports continue to be off after removing our custom coverage map merging.

## Screenshots/Screencaps

<!-- If you're making a change to the UI, make sure to capture a screenshot or a short video showing off your work! -->

### Before

<!-- How did the UI you changed look before your changes? Drag your file(s) below this line: -->

### After

<!-- How does it look now? Drag your file(s) below this line: -->

## Manual Testing Steps

<!--
How should reviewers and QA manually test your changes? For instance:

- Go to this screen
- Do this
- Then do this
-->

## Pre-merge author checklist

- [ ] I've clearly explained:
  - [ ] What problem this PR is solving
  - [ ] How this problem was solved
  - [ ] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
