### PR TITLE
Update mv3 minimum version in manifest to chrome v88

### DIFF
--- a/app/manifest/v3/chrome.json
+++ b/app/manifest/v3/chrome.json
@@ -6,5 +6,5 @@
     "matches": ["https://metamask.io/*"],
     "ids": ["*"]
   },
-  "minimum_chrome_version": "80"
+  "minimum_chrome_version": "88"
 }


### PR DESCRIPTION
MV3 only works on chrome versions 88 and later. Without the change in this PR, attempts to upload to the chrome store will fail.