### PR TITLE
Revert to old selector for txs and signatures

### DIFF
--- a/ui/pages/home/home.component.js
+++ b/ui/pages/home/home.component.js
@@ -107,7 +107,7 @@ export default class Home extends PureComponent {
     history: PropTypes.object,
     forgottenPassword: PropTypes.bool,
     hasWatchAssetPendingApprovals: PropTypes.bool,
-    hasTransactionPendingApprovals: PropTypes.bool.isRequired,
+    unconfirmedTransactionsCount: PropTypes.number,
     shouldShowSeedPhraseReminder: PropTypes.bool.isRequired,
     isPopup: PropTypes.bool,
     isNotification: PropTypes.bool.isRequired,
@@ -197,7 +197,7 @@ export default class Home extends PureComponent {
       showAwaitingSwapScreen,
       hasWatchAssetPendingApprovals,
       swapsFetchParams,
-      hasTransactionPendingApprovals,
+      unconfirmedTransactionsCount,
     } = this.props;
 
     if (shouldCloseNotificationPopup(props)) {
@@ -205,7 +205,7 @@ export default class Home extends PureComponent {
       closeNotificationPopup();
     } else if (
       firstPermissionsRequestId ||
-      hasTransactionPendingApprovals ||
+      unconfirmedTransactionsCount > 0 ||
       hasWatchAssetPendingApprovals ||
       (!isNotification &&
         (showAwaitingSwapScreen || haveSwapsQuotes || swapsFetchParams))
@@ -269,7 +269,7 @@ export default class Home extends PureComponent {
       history,
       isNotification,
       hasWatchAssetPendingApprovals,
-      hasTransactionPendingApprovals,
+      unconfirmedTransactionsCount,
       haveSwapsQuotes,
       showAwaitingSwapScreen,
       swapsFetchParams,
@@ -288,7 +288,7 @@ export default class Home extends PureComponent {
       history.push(BUILD_QUOTE_ROUTE);
     } else if (firstPermissionsRequestId) {
       history.push(`${CONNECT_ROUTE}/${firstPermissionsRequestId}`);
-    } else if (hasTransactionPendingApprovals) {
+    } else if (unconfirmedTransactionsCount > 0) {
       history.push(CONFIRM_TRANSACTION_ROUTE);
     } else if (hasWatchAssetPendingApprovals) {
       history.push(CONFIRM_ADD_SUGGESTED_TOKEN_ROUTE);

--- a/ui/pages/home/home.container.js
+++ b/ui/pages/home/home.container.js
@@ -36,6 +36,7 @@ import {
   getShouldShowSeedPhraseReminder,
   getRemoveNftMessage,
   hasPendingApprovals,
+  unconfirmedTransactionsCountSelector,
 } from '../../selectors';
 
 import {
@@ -70,7 +71,6 @@ import {
   AlertTypes,
   Web3ShimUsageAlertStates,
 } from '../../../shared/constants/alerts';
-import { hasTransactionPendingApprovals } from '../../selectors/transactions';
 import Home from './home.component';
 
 const mapStateToProps = (state) => {
@@ -130,7 +130,7 @@ const mapStateToProps = (state) => {
     forgottenPassword,
     hasWatchAssetPendingApprovals,
     swapsEnabled,
-    hasTransactionPendingApprovals: hasTransactionPendingApprovals(state),
+    unconfirmedTransactionsCount: unconfirmedTransactionsCountSelector(state),
     shouldShowSeedPhraseReminder: getShouldShowSeedPhraseReminder(state),
     isPopup,
     isNotification,

--- a/ui/selectors/confirm-transaction.js
+++ b/ui/selectors/confirm-transaction.js
@@ -142,6 +142,50 @@ export const unconfirmedMessagesHashSelector = createSelector(
   },
 );
 
+const unapprovedMsgCountSelector = (state) => state.metamask.unapprovedMsgCount;
+const unapprovedPersonalMsgCountSelector = (state) =>
+  state.metamask.unapprovedPersonalMsgCount;
+const unapprovedDecryptMsgCountSelector = (state) =>
+  state.metamask.unapprovedDecryptMsgCount;
+const unapprovedEncryptionPublicKeyMsgCountSelector = (state) =>
+  state.metamask.unapprovedEncryptionPublicKeyMsgCount;
+const unapprovedTypedMessagesCountSelector = (state) =>
+  state.metamask.unapprovedTypedMessagesCount;
+
+export const unconfirmedTransactionsCountSelector = createSelector(
+  unapprovedTxsSelector,
+  unapprovedMsgCountSelector,
+  unapprovedPersonalMsgCountSelector,
+  unapprovedDecryptMsgCountSelector,
+  unapprovedEncryptionPublicKeyMsgCountSelector,
+  unapprovedTypedMessagesCountSelector,
+  deprecatedGetCurrentNetworkId,
+  getCurrentChainId,
+  (
+    unapprovedTxs = {},
+    unapprovedMsgCount = 0,
+    unapprovedPersonalMsgCount = 0,
+    unapprovedDecryptMsgCount = 0,
+    unapprovedEncryptionPublicKeyMsgCount = 0,
+    unapprovedTypedMessagesCount = 0,
+    network,
+    chainId,
+  ) => {
+    const filteredUnapprovedTxIds = Object.keys(unapprovedTxs).filter((txId) =>
+      transactionMatchesNetwork(unapprovedTxs[txId], chainId, network),
+    );
+
+    return (
+      filteredUnapprovedTxIds.length +
+      unapprovedTypedMessagesCount +
+      unapprovedMsgCount +
+      unapprovedPersonalMsgCount +
+      unapprovedDecryptMsgCount +
+      unapprovedEncryptionPublicKeyMsgCount
+    );
+  },
+);
+
 export const currentCurrencySelector = (state) =>
   state.metamask.currentCurrency;
 export const conversionRateSelector = (state) => state.metamask.conversionRate;

--- a/ui/selectors/confirm-transaction.test.js
+++ b/ui/selectors/confirm-transaction.test.js
@@ -1,5 +1,7 @@
+import { CHAIN_IDS } from '../../shared/constants/network';
 import { TransactionType } from '../../shared/constants/transaction';
 import {
+  unconfirmedTransactionsCountSelector,
   sendTokenTokenAmountAndToAddressSelector,
   contractExchangeRateSelector,
   conversionRateSelector,
@@ -15,6 +17,32 @@ const getEthersArrayLikeFromObj = (obj) => {
 };
 
 describe('Confirm Transaction Selector', () => {
+  describe('unconfirmedTransactionsCountSelector', () => {
+    const state = {
+      metamask: {
+        unapprovedTxs: {
+          1: {
+            metamaskNetworkId: '5',
+          },
+          2: {
+            chainId: CHAIN_IDS.MAINNET,
+          },
+        },
+        unapprovedMsgCount: 1,
+        unapprovedPersonalMsgCount: 1,
+        unapprovedTypedMessagesCount: 1,
+        networkId: '5',
+        providerConfig: {
+          chainId: '0x5',
+        },
+      },
+    };
+
+    it('returns number of txs in unapprovedTxs state with the same network plus unapproved signing method counts', () => {
+      expect(unconfirmedTransactionsCountSelector(state)).toStrictEqual(4);
+    });
+  });
+
   describe('sendTokenTokenAmountAndToAddressSelector', () => {
     const state = {
       confirmTransaction: {


### PR DESCRIPTION
## Explanation

<!--
Thanks for the pull request. Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues, Slack conversations, Zendesk issues, user stories, etc. reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

Fixes bug that occurs when using the new selector to sign messages with hardware wallets. It was introduced in this commit: https://github.com/MetaMask/metamask-extension/commit/d37d5bf0eebf5a28fbfe7f672842e5ce3bf9137a

Not a proper fix, but by reverting to the old selector we can identify how to refactor it properly.

Fixes: https://github.com/MetaMask/metamask-extension/issues/19357

<!--
How should reviewers and QA manually test your changes? For instance:

- Go to this screen
- Do this
- Then do this
-->

- build the extension with yarn dist
- open/unlock the extension
- connect your ledger device
- navigate to the test dapp
- connect your account
- click the personal sign button
- click the sign button in the popup

## Pre-merge author checklist

- [X] I've clearly explained:
  - [X] What problem this PR is solving
  - [X] How this problem was solved
  - [X] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
