### PR TITLE
Sync default value of networkDetails w/ core

### DIFF
--- a/app/scripts/controllers/network/network-controller.test.ts
+++ b/app/scripts/controllers/network/network-controller.test.ts
@@ -173,9 +173,7 @@ describe('NetworkController', () => {
           {
             "networkConfigurations": {},
             "networkDetails": {
-              "EIPS": {
-                "1559": undefined,
-              },
+              "EIPS": {},
             },
             "networkId": null,
             "networkStatus": "unknown",
@@ -2804,9 +2802,7 @@ describe('NetworkController', () => {
                       expect(
                         controller.store.getState().networkDetails,
                       ).toStrictEqual({
-                        EIPS: {
-                          1559: undefined,
-                        },
+                        EIPS: {},
                       });
                     },
                   });
@@ -3519,9 +3515,7 @@ describe('NetworkController', () => {
                     expect(
                       controller.store.getState().networkDetails,
                     ).toStrictEqual({
-                      EIPS: {
-                        1559: undefined,
-                      },
+                      EIPS: {},
                     });
                   },
                 });
@@ -4788,9 +4782,7 @@ function refreshNetworkTests({
         });
 
         expect(controller.store.getState().networkDetails).toStrictEqual({
-          EIPS: {
-            1559: undefined,
-          },
+          EIPS: {},
         });
       },
     );

--- a/app/scripts/controllers/network/network-controller.ts
+++ b/app/scripts/controllers/network/network-controller.ts
@@ -357,9 +357,7 @@ function buildDefaultNetworkStatusState(): NetworkStatus {
  */
 function buildDefaultNetworkDetailsState(): NetworkDetails {
   return {
-    EIPS: {
-      1559: undefined,
-    },
+    EIPS: {},
   };
 }
 


### PR DESCRIPTION


## Explanation

<!--
Thanks for the pull request. Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues, Slack conversations, Zendesk issues, user stories, etc. reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

In the core version of NetworkController, the `networkDetails` property is initialized to `{ EIPS: {} }`. It is also reset to this representation when `refreshNetwork` is called.

In this version of NetworkController, however, the default representation of `networkDetails` is `{ EIPS: { 1559: undefined } }`. From a consumer's perspective this doesn't make a difference — it's practically the same. It does make a slight difference in tests, however.

With that in mind, this commit changes the default representation to `{ EIPS: {} }`. This makes it easier to visually compare differences in the NetworkController unit tests between core and this repo.

Tangentially related to https://github.com/MetaMask/core/issues/1197.

## Manual Testing Steps

<!--
How should reviewers and QA manually test your changes? For instance:

- Go to this screen
- Do this
- Then do this
-->

Although this is a change to NetworkController, it should not have any user-facing impact. All functionality should be the same.

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
