### PR TITLE
SignatureController: accept approval request first

### DIFF
--- a/.yarn/patches/@metamask-signature-controller-npm-2.0.0-f441f2596e.patch
+++ b/.yarn/patches/@metamask-signature-controller-npm-2.0.0-f441f2596e.patch
@@ -1,0 +1,15 @@
+diff --git a/dist/SignatureController.js b/dist/SignatureController.js
+index 59dc5974218e8d073b65969154f35ada3fd9e8ab..5b16d09dcacf49caa15d11c9db7c34569eb36412 100644
+--- a/dist/SignatureController.js
++++ b/dist/SignatureController.js
+@@ -302,9 +302,9 @@ _SignatureController_keyringController = new WeakMap(), _SignatureController_isE
+         const messageId = msgParams.metamaskId;
+         try {
+             const cleanMessageParams = yield messageManager.approveMessage(msgParams);
++            __classPrivateFieldGet(this, _SignatureController_instances, "m", _SignatureController_acceptApproval).call(this, messageId);
+             const signature = yield getSignature(cleanMessageParams);
+             messageManager.setMessageStatusSigned(messageId, signature);
+-            __classPrivateFieldGet(this, _SignatureController_instances, "m", _SignatureController_acceptApproval).call(this, messageId);
+             return __classPrivateFieldGet(this, _SignatureController_getAllState, "f").call(this);
+         }
+         catch (error) {

--- a/package.json
+++ b/package.json
@@ -196,7 +196,8 @@
     "request@^2.83.0": "patch:request@npm%3A2.88.2#./.yarn/patches/request-npm-2.88.2-f4a57c72c4.patch",
     "request@^2.88.2": "patch:request@npm%3A2.88.2#./.yarn/patches/request-npm-2.88.2-f4a57c72c4.patch",
     "request@^2.85.0": "patch:request@npm%3A2.88.2#./.yarn/patches/request-npm-2.88.2-f4a57c72c4.patch",
-    "@metamask/assets-controllers@^6.0.0": "patch:@metamask/assets-controllers@npm%3A6.0.0#./.yarn/patches/@metamask-assets-controllers-npm-6.0.0-0cb763bd07.patch"
+    "@metamask/assets-controllers@^6.0.0": "patch:@metamask/assets-controllers@npm%3A6.0.0#./.yarn/patches/@metamask-assets-controllers-npm-6.0.0-0cb763bd07.patch",
+    "@metamask/signature-controller@^2.0.0": "patch:@metamask/signature-controller@npm%3A2.0.0#./.yarn/patches/@metamask-signature-controller-npm-2.0.0-f441f2596e.patch"
   },
   "dependencies": {
     "@actions/core": "^1.10.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4568,7 +4568,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/signature-controller@npm:^2.0.0":
+"@metamask/signature-controller@npm:2.0.0":
   version: 2.0.0
   resolution: "@metamask/signature-controller@npm:2.0.0"
   dependencies:
@@ -4580,6 +4580,21 @@ __metadata:
     ethereumjs-util: ^7.0.10
     immer: ^9.0.6
   checksum: aa7a37079cb108bd9dcb23292f82690b6796b3cde5a2b841db7f636fa9f19a5eaaa8eea7461d757dcfd664d1a6a5da3af8ea25a402c6fe575c3204390ff3964f
+  languageName: node
+  linkType: hard
+
+"@metamask/signature-controller@patch:@metamask/signature-controller@npm%3A2.0.0#./.yarn/patches/@metamask-signature-controller-npm-2.0.0-f441f2596e.patch::locator=metamask-crx%40workspace%3A.":
+  version: 2.0.0
+  resolution: "@metamask/signature-controller@patch:@metamask/signature-controller@npm%3A2.0.0#./.yarn/patches/@metamask-signature-controller-npm-2.0.0-f441f2596e.patch::version=2.0.0&hash=6947b7&locator=metamask-crx%40workspace%3A."
+  dependencies:
+    "@metamask/approval-controller": ^2.1.1
+    "@metamask/base-controller": ^2.0.0
+    "@metamask/controller-utils": ^3.4.0
+    "@metamask/message-manager": ^5.0.0
+    eth-rpc-errors: ^4.0.2
+    ethereumjs-util: ^7.0.10
+    immer: ^9.0.6
+  checksum: e7bf00b7470f49a9b466cded53e77fdb9354ec66b13d9bdcf473f6a3cd9a33fe67ab5b4248c8a12c1af34aadf21c09f67c8b5b9b67f6d6f3ead702d06dec5d7a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Explanation

<!--
Thanks for the pull request. Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues, Slack conversations, Zendesk issues, user stories, etc. reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

Creates a SignatureController patch to make sure that approval request is accepted at the same time as the state is changed, instead of waiting until signature concludes. This was the original behaviour before the selectors were changed.

It's done with a patch so that it can be cherry-picked to unblock the release, but this change will be applied to the package directly and then we can remove the patch.

Fixes: https://github.com/MetaMask/metamask-extension/issues/19357

## Manual Testing Steps

<!--
How should reviewers and QA manually test your changes? For instance:

- Go to this screen
- Do this
- Then do this
-->

- build the extension with yarn dist
- open/unlock the extension
- connect your ledger device
- navigate to the test dapp
- connect your account
- click the personal sign button
- click the sign button in the popup

## Pre-merge author checklist

- [X] I've clearly explained:
  - [X] What problem this PR is solving
  - [X] How this problem was solved
  - [X] How reviewers can test my changes
- [] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
