### PR TITLE
feature: Add legacy derivation path to Trezor

### DIFF
--- a/ui/pages/create-account/connect-hardware/index.js
+++ b/ui/pages/create-account/connect-hardware/index.js
@@ -60,6 +60,7 @@ export const LATTICE_HD_PATHS = [
 const TREZOR_TESTNET_PATH = `m/44'/1'/0'/0`;
 export const TREZOR_HD_PATHS = [
   { name: `BIP44 Standard (e.g. MetaMask, Trezor)`, value: BIP44_PATH },
+  { name: `Legacy (Ledger / MEW / MyCrypto)`, value: MEW_PATH },
   { name: `Trezor Testnets`, value: TREZOR_TESTNET_PATH },
 ];
 


### PR DESCRIPTION
## Explanation

Ledger users are migrating to Trezor, directly inputting their recovery phrases into the HWW. OG Ethereum users are unable to access their assets on Trezor to due the 'legacy' [derivation path](https://github.com/MetaMask/metamask-extension/blob/f03f2d3f79ce0c54bbce033cd83cdf9c4f26b363/ui/pages/create-account/connect-hardware/index.js#L37) not available when configuring Trezor.

The Ledger integration offers the same legacy derivation path: https://github.com/MetaMask/metamask-extension/blob/f03f2d3f79ce0c54bbce033cd83cdf9c4f26b363/ui/pages/create-account/connect-hardware/index.js#LL41C1-L41C1

https://www.reddit.com/r/TREZOR/comments/13wy3xz/comment/jmlwqyw/?context=3

## Manual Testing Steps

- Connect Trezor or [Trezor emulator](https://github.com/trezor/trezor-user-env/)
- Choose legacy derivation path
- See account address from legacy derivation path

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

