### PR TITLE
Part of #18714: Replacing deprecated constants in `approve-content-card` folder

### DIFF
--- a/ui/components/app/approve-content-card/approve-content-card.js
+++ b/ui/components/app/approve-content-card/approve-content-card.js
@@ -9,9 +9,9 @@ import EditGasFeeButton from '../edit-gas-fee-button/edit-gas-fee-button';
 import { Text } from '../../component-library';
 import {
   AlignItems,
-  BLOCK_SIZES,
-  DISPLAY,
-  FLEX_DIRECTION,
+  BlockSize,
+  Display,
+  FlexDirection,
   FontWeight,
   JustifyContent,
   TextAlign,
@@ -66,8 +66,8 @@ export default function ApproveContentCard({
     >
       {showHeader && (
         <Box
-          display={DISPLAY.FLEX}
-          flexDirection={FLEX_DIRECTION.ROW}
+          display={Display.Flex}
+          flexDirection={FlexDirection.Row}
           alignItems={AlignItems.center}
           justifyContent={JustifyContent.flexEnd}
           className="approve-content-card-container__card-header"
@@ -88,7 +88,7 @@ export default function ApproveContentCard({
             </>
           )}
           {showEdit && (!showAdvanceGasFeeOptions || !supportsEIP1559) && (
-            <Box width={BLOCK_SIZES.ONE_SIXTH}>
+            <Box width={BlockSize.OneSixth}>
               <Button type="link" onClick={() => onEditClick()}>
                 <Text
                   variant={TextVariant.bodySm}
@@ -124,14 +124,14 @@ export default function ApproveContentCard({
             />
           ) : (
             <Box
-              display={DISPLAY.FLEX}
-              flexDirection={FLEX_DIRECTION.ROW}
+              display={Display.Flex}
+              flexDirection={FlexDirection.Row}
               justifyContent={JustifyContent.spaceBetween}
             >
               {isMultiLayerFeeNetwork ? (
                 <Box
-                  display={DISPLAY.FLEX}
-                  flexDirection={FLEX_DIRECTION.COLUMN}
+                  display={Display.Flex}
+                  flexDirection={FlexDirection.Column}
                   className="approve-content-card-container__transaction-details-extra-content"
                 >
                   <TransactionDetailItem
@@ -174,8 +174,8 @@ export default function ApproveContentCard({
                     </Text>
                   </Box>
                   <Box
-                    display={DISPLAY.FLEX}
-                    flexDirection={FLEX_DIRECTION.COLUMN}
+                    display={Display.Flex}
+                    flexDirection={FlexDirection.Column}
                     alignItems={AlignItems.flexEnd}
                     textAlign={TextAlign.Right}
                   >
@@ -210,7 +210,7 @@ export default function ApproveContentCard({
             </Box>
           ))}
         {renderDataContent && (
-          <Box display={DISPLAY.FLEX} flexDirection={FLEX_DIRECTION.COLUMN}>
+          <Box display={Display.Flex} flexDirection={FlexDirection.Column}>
             <Box>
               <Text
                 variant={TextVariant.bodySm}


### PR DESCRIPTION
## Explanation

- This PR is a part of #18714 

Replaced deprecated design system and storybook constants in the approve-content-card folder
ui/components/app/approve-content-card

<!--
Thanks for the pull request. Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues, Slack conversations, Zendesk issues, user stories, etc. reviewers should consult to understand this pull request better? For instance:

-->

## Screenshots/Screencaps

<!-- If you're making a change to the UI, make sure to capture a screenshot or a short video showing off your work! -->

### Before
![image](https://github.com/MetaMask/metamask-extension/assets/129620973/bc27a78b-8287-40ce-ad4a-12cb20c51481)


<!-- How did the UI you changed look before your changes? Drag your file(s) below this line: -->

### After
![image](https://github.com/MetaMask/metamask-extension/assets/129620973/ca83f038-8ac5-42db-a35d-49ff577ac57e)


<!-- How does it look now? Drag your file(s) below this line: -->

## Manual Testing Steps

<!--
How should reviewers and QA manually test your changes? For instance:

- Go to this screen
- Do this
- Then do this
-->

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
