### PR TITLE
[FLASK] Limit notification count display to 99+

### DIFF
--- a/ui/components/multichain/global-menu/global-menu.js
+++ b/ui/components/multichain/global-menu/global-menu.js
@@ -153,7 +153,9 @@ export const GlobalMenu = ({ closeMenu, anchorElement }) => {
                 }}
                 marginInlineStart={2}
               >
-                {unreadNotificationsCount}
+                {unreadNotificationsCount > 99
+                  ? '99+'
+                  : unreadNotificationsCount}
               </Text>
             )}
           </MenuItem>


### PR DESCRIPTION
## Explanation

Limits the notification count display to `99+` when the notification count is higher than 99.

Fixes https://github.com/MetaMask/metamask-extension/issues/19288
