### PR TITLE
Revert "feature: Add legacy derivation path to Trezor"

### DIFF
--- a/ui/pages/create-account/connect-hardware/index.js
+++ b/ui/pages/create-account/connect-hardware/index.js
@@ -60,7 +60,6 @@ export const LATTICE_HD_PATHS = [
 const TREZOR_TESTNET_PATH = `m/44'/1'/0'/0`;
 export const TREZOR_HD_PATHS = [
   { name: `BIP44 Standard (e.g. MetaMask, Trezor)`, value: BIP44_PATH },
-  { name: `Legacy (Ledger / MEW / MyCrypto)`, value: MEW_PATH },
   { name: `Trezor Testnets`, value: TREZOR_TESTNET_PATH },
 ];
 


### PR DESCRIPTION
Reverts MetaMask/metamask-extension#19443

Was asked to do this by @plasmacorral who is in the process of testing the commit. Communication about this happened in slack and was not reflected on the PR which led to it being merged. 