### PR TITLE
Creating story for `icon-border`

### DIFF
--- a/ui/components/ui/icon-border/icon-border.js
+++ b/ui/components/ui/icon-border/icon-border.js
@@ -2,6 +2,14 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 
+/**
+ * @deprecated The `<IconBorder />` component has been deprecated in favor of the `<AvatarBase />` component from the component-library.
+ * Please update your code to use the new `<AvatarBase>` component instead, which can be found at ./ui/components/component-library/avatar-base/avatar-base.js.
+ * You can find documentation for the new AvatarBase component in the MetaMask Storybook:
+ * {@link https://metamask.github.io/metamask-storybook/?path=/docs/components-componentlibrary-avatarbase--docs}
+ * If you would like to help with the replacement of the old IconBorder component, please submit a pull request
+ */
+
 export default function IconBorder({ children, size, className }) {
   const borderStyle = { height: `${size}px`, width: `${size}px` };
   return (

--- a/ui/components/ui/icon-border/icon-border.stories.js
+++ b/ui/components/ui/icon-border/icon-border.stories.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import IconBorder from './icon-border';
+
+export default {
+  title: 'Components/UI/IconBorder',
+
+  component: IconBorder,
+  argTypes: {
+    className: {
+      control: 'text',
+    },
+    children: {
+      control: 'text',
+    },
+    size: {
+      control: 'number',
+    },
+  },
+  args: {
+    className: '',
+    children: 'D',
+    size: 5,
+  },
+};
+
+export const DefaultStory = (args) => <IconBorder {...args} />;
+
+DefaultStory.storyName = 'Default';

--- a/ui/components/ui/icon-border/icon-border.stories.js
+++ b/ui/components/ui/icon-border/icon-border.stories.js
@@ -1,9 +1,11 @@
 import React from 'react';
+import { Severity } from '../../../helpers/constants/design-system';
+import { BannerAlert } from '../../component-library';
+
 import IconBorder from './icon-border';
 
 export default {
   title: 'Components/UI/IconBorder',
-
   component: IconBorder,
   argTypes: {
     className: {
@@ -19,10 +21,20 @@ export default {
   args: {
     className: '',
     children: 'D',
-    size: 5,
+    size: 32,
   },
 };
 
-export const DefaultStory = (args) => <IconBorder {...args} />;
+export const DefaultStory = (args) => (
+  <>
+    <BannerAlert
+      severity={Severity.Warning}
+      title="Deprecated"
+      description="<IconBorder/> has been deprecated in favour of the <AvatarBase /> component"
+      marginBottom={4}
+    />
+    <IconBorder {...args} />
+  </>
+);
 
 DefaultStory.storyName = 'Default';


### PR DESCRIPTION
## Explanation

- Created story for `icon-border` component 

- `ui/components/ui/icon-border`

<!--
Thanks for the pull request. Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues, Slack conversations, Zendesk issues, user stories, etc. reviewers should consult to understand this pull request better? For instance:

-->

## Screenshots/Screencaps

<!-- If you're making a change to the UI, make sure to capture a screenshot or a short video showing off your work! -->

### Before

<!-- How did the UI you changed look before your changes? Drag your file(s) below this line: -->
![image](https://github.com/MetaMask/metamask-extension/assets/79097544/28e0e1a0-162b-49d8-a21b-5d8cbabf5011)

### After

<!-- How does it look now? Drag your file(s) below this line: -->
![image](https://github.com/MetaMask/metamask-extension/assets/79097544/6949c87b-34d3-474e-bd37-38c43a720323)

https://github.com/MetaMask/metamask-extension/assets/79097544/96ca0b61-d22b-4d6c-99f8-2e92af3bddc2

## Manual Testing Steps

<!--
How should reviewers and QA manually test your changes? For instance:

- Go to this screen
- Do this
- Then do this
-->

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
