### PR TITLE
Bump `fast-xml-parser` to fix audit issue

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -16726,13 +16726,13 @@ __metadata:
   linkType: hard
 
 "fast-xml-parser@npm:^4.1.3":
-  version: 4.2.2
-  resolution: "fast-xml-parser@npm:4.2.2"
+  version: 4.2.4
+  resolution: "fast-xml-parser@npm:4.2.4"
   dependencies:
     strnum: ^1.0.5
   bin:
     fxparser: src/cli/cli.js
-  checksum: f0e687927ddc11b2ba9e434d8bf77ef759b6692639dd2dd731e2f30201319e7c70dec08a103dd67a1af7a27f176246502d9d0f5325b5b5b99ab49665fa876857
+  checksum: d3b4d0c0152c09f98def792769fca6bb3fa1d597f9745d9564451c239089bd86bdf573c9263b4944860028cb7edb81752d64399c1aff8b87c9225ecef96905f7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Explanation

Bumps `fast-xml-parser` to `4.2.4` to fix a `yarn audit` failure. 

https://github.com/advisories/GHSA-6w63-h3fj-q4vw