### PR TITLE
[FLASK] Update Snaps privacy notice

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -1562,10 +1562,6 @@
   "followUsOnTwitter": {
     "message": "Follow us on Twitter"
   },
-  "forMoreDetails": {
-    "message": "for more details.",
-    "description": "Click for more details message in popup modal displayed when installing a snap for the first time."
-  },
   "forbiddenIpfsGateway": {
     "message": "Forbidden IPFS Gateway: Please specify a CID gateway"
   },
@@ -3859,27 +3855,22 @@
     "message": "The snap didn't return any insight"
   },
   "snapsPrivacyWarningFirstMessage": {
-    "message": "Installing a snap retrieves data from third parties. They may collect your personal information.",
-    "description": "First part of a message in popup modal displayed when installing a snap for the first time."
+    "message": "You acknowledge that the snap that you are about to install is a Third Party Service as defined in the ConsenSys $1. Your use of Third Party Services is governed by separate terms and conditions set forth by the Third Party Service provider. You access, rely upon or use the Third Party Service at your own risk. ConsenSys disclaims all responsibility and liability for any losses on account of your use of Third Party Services.",
+    "description": "First part of a message in popup modal displayed when installing a snap for the first time. $1 is terms of use link."
   },
   "snapsPrivacyWarningSecondMessage": {
-    "message": "MetaMask has no access to this information.",
+    "message": "Any information you share with Third Party Services will be collected directly by those Third Party Services in accordance with their privacy policies. Please refer to their privacy policies for more information.",
     "description": "Second part of a message in popup modal displayed when installing a snap for the first time."
+  },
+  "snapsPrivacyWarningThirdMessage": {
+    "message": "ConsenSys has no access to information you share with these third parties.",
+    "description": "Third part of a message in popup modal displayed when installing a snap for the first time."
   },
   "snapsSettingsDescription": {
     "message": "Manage your Snaps"
   },
-  "snapsThirdPartyNoticeReadMorePartOne": {
-    "message": "Any information you share with third-party-developed snaps will be collected directly by those snaps in accordance with their privacy policies. ",
-    "description": "First part of a tooltip content in popup modal displayed when installing a snap for the first time."
-  },
-  "snapsThirdPartyNoticeReadMorePartThree": {
-    "message": "MetaMask has no access to information you share with these third parties.",
-    "description": "Third part of a tooltip content in popup modal displayed when installing a snap for the first time."
-  },
-  "snapsThirdPartyNoticeReadMorePartTwo": {
-    "message": "During the installation of a snap, npmjs (npmjs.com) and AWS (aws.amazon.com) may collect your IP address. Please refer to their privacy policies for more information.",
-    "description": "Second part of a tooltip content in popup modal displayed when installing a snap for the first time."
+  "snapsTermsOfUse": {
+    "message": "Terms of Use"
   },
   "snapsToggle": {
     "message": "A snap will only run if it is enabled"
@@ -4499,7 +4490,7 @@
     "message": "Things to keep in mind:"
   },
   "thirdPartySoftware": {
-    "message": "Third party software",
+    "message": "Third-party software notice",
     "description": "Title of a popup modal displayed when installing a snap for the first time."
   },
   "thisCollection": {

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -3855,7 +3855,7 @@
     "message": "The snap didn't return any insight"
   },
   "snapsPrivacyWarningFirstMessage": {
-    "message": "You acknowledge that the snap that you are about to install is a Third Party Service as defined in the ConsenSys $1. Your use of Third Party Services is governed by separate terms and conditions set forth by the Third Party Service provider. You access, rely upon or use the Third Party Service at your own risk. ConsenSys disclaims all responsibility and liability for any losses on account of your use of Third Party Services.",
+    "message": "You acknowledge that the snap that you are about to install is a Third Party Service as defined in the Consensys $1. Your use of Third Party Services is governed by separate terms and conditions set forth by the Third Party Service provider. You access, rely upon or use the Third Party Service at your own risk. Consensys disclaims all responsibility and liability for any losses on account of your use of Third Party Services.",
     "description": "First part of a message in popup modal displayed when installing a snap for the first time. $1 is terms of use link."
   },
   "snapsPrivacyWarningSecondMessage": {
@@ -3863,7 +3863,7 @@
     "description": "Second part of a message in popup modal displayed when installing a snap for the first time."
   },
   "snapsPrivacyWarningThirdMessage": {
-    "message": "ConsenSys has no access to information you share with these third parties.",
+    "message": "Consensys has no access to information you share with these third parties.",
     "description": "Third part of a message in popup modal displayed when installing a snap for the first time."
   },
   "snapsSettingsDescription": {

--- a/shared/constants/terms.js
+++ b/shared/constants/terms.js
@@ -1,1 +1,2 @@
+export const TERMS_OF_USE_LINK = 'https://consensys.net/terms-of-use/';
 export const TERMS_OF_USE_LAST_UPDATED = '2023-03-25';

--- a/ui/components/app/app-components.scss
+++ b/ui/components/app/app-components.scss
@@ -64,6 +64,7 @@
 @import 'signature-request-original/index';
 @import 'signature-request-original/signature-request-original-warning/index';
 @import 'srp-input/srp-input';
+@import 'snaps/snap-privacy-warning/index';
 @import 'tab-bar/index';
 @import 'token-cell/token-cell';
 @import 'token-list-display/token-list-display';

--- a/ui/components/app/snaps/snap-privacy-warning/index.scss
+++ b/ui/components/app/snaps/snap-privacy-warning/index.scss
@@ -1,0 +1,15 @@
+.snap-privacy-warning {
+  &__content {
+    max-height: 325px;
+    overflow-y: auto;
+
+    &__scroll-button {
+      position: absolute;
+      margin-left: auto;
+      margin-right: auto;
+      right: 0;
+      left: 0;
+      bottom: 110px;
+    }
+  }
+}

--- a/ui/components/app/snaps/snap-privacy-warning/snap-privacy-warning.js
+++ b/ui/components/app/snaps/snap-privacy-warning/snap-privacy-warning.js
@@ -103,7 +103,7 @@ export default function SnapPrivacyWarning({ onAccepted, onCanceled }) {
               data-testid="snap-privacy-warning-scroll"
               iconName={IconName.Arrow2Down}
               backgroundColor={BackgroundColor.infoDefault}
-              color={IconColor.iconDefault}
+              color={IconColor.primaryInverse}
               onClick={scrollToBottom}
               style={{ cursor: 'pointer' }}
             />

--- a/ui/components/app/snaps/snap-privacy-warning/snap-privacy-warning.js
+++ b/ui/components/app/snaps/snap-privacy-warning/snap-privacy-warning.js
@@ -24,87 +24,124 @@ import {
   JustifyContent,
   TextVariant,
 } from '../../../../helpers/constants/design-system';
+import { useScrollRequired } from '../../../../hooks/useScrollRequired';
 
 export default function SnapPrivacyWarning({ onAccepted, onCanceled }) {
   const t = useI18nContext();
+  const { isScrollable, isScrolledToBottom, scrollToBottom, ref, onScroll } =
+    useScrollRequired();
 
   return (
     <Popover className="snap-privacy-warning">
-      <Box padding={4}>
+      <Box>
         <Box
-          className="snap-privacy-warning__info-icon"
-          display={DISPLAY.FLEX}
-          justifyContent={JustifyContent.center}
-          alignItems={AlignItems.center}
+          className="snap-privacy-warning__header"
+          paddingLeft={4}
+          paddingRight={4}
         >
-          <AvatarIcon
-            iconName={IconName.Info}
-            color={IconColor.infoDefault}
-            backgroundColor={BackgroundColor.primaryMuted}
-            size={IconSize.Md}
-          />
+          <Box
+            marginTop={4}
+            className="snap-privacy-warning__header__info-icon"
+            display={DISPLAY.FLEX}
+            justifyContent={JustifyContent.center}
+            alignItems={AlignItems.center}
+          >
+            <AvatarIcon
+              iconName={IconName.Info}
+              color={IconColor.infoDefault}
+              backgroundColor={BackgroundColor.primaryMuted}
+              size={IconSize.Md}
+            />
+          </Box>
+          <Box
+            className="snap-privacy-warning__header__title"
+            marginTop={4}
+            marginBottom={4}
+            display={DISPLAY.FLEX}
+            justifyContent={JustifyContent.center}
+            alignItems={AlignItems.center}
+          >
+            <Text variant={TextVariant.headingMd} fontWeight={FontWeight.Bold}>
+              {t('thirdPartySoftware')}
+            </Text>
+          </Box>
         </Box>
         <Box
-          className="snap-privacy-warning__title"
-          marginTop={4}
-          marginBottom={6}
-          display={DISPLAY.FLEX}
-          justifyContent={JustifyContent.center}
-          alignItems={AlignItems.center}
+          paddingLeft={4}
+          paddingRight={4}
+          className="snap-privacy-warning__content"
+          ref={ref}
+          onScroll={onScroll}
         >
-          <Text variant={TextVariant.headingMd} fontWeight={FontWeight.Bold}>
-            {t('thirdPartySoftware')}
-          </Text>
-        </Box>
-        <Box className="snap-privacy-warning__message">
-          <Text variant={TextVariant.bodyMd}>
-            {t('snapsPrivacyWarningFirstMessage', [
-              <ButtonLink
-                key="privacyNoticeTermsOfUseLink"
-                size={BUTTON_LINK_SIZES.INHERIT}
-                href="https://consensys.net/"
-                target="_blank"
-              >
-                &nbsp;{t('snapsTermsOfUse')}&nbsp;
-              </ButtonLink>,
-            ])}
-          </Text>
-          <Text variant={TextVariant.bodyMd} paddingTop={6}>
-            {t('snapsPrivacyWarningSecondMessage')}
-          </Text>
-          <Text
-            variant={TextVariant.bodyMd}
-            fontWeight={FontWeight.Bold}
-            paddingTop={6}
-          >
-            {t('snapsPrivacyWarningThirdMessage')}
-          </Text>
+          <Box className="snap-privacy-warning__message">
+            <Text variant={TextVariant.bodyMd}>
+              {t('snapsPrivacyWarningFirstMessage', [
+                <ButtonLink
+                  key="privacyNoticeTermsOfUseLink"
+                  size={BUTTON_LINK_SIZES.INHERIT}
+                  href="https://consensys.net/"
+                  target="_blank"
+                >
+                  &nbsp;{t('snapsTermsOfUse')}&nbsp;
+                </ButtonLink>,
+              ])}
+            </Text>
+            <Text variant={TextVariant.bodyMd} paddingTop={6}>
+              {t('snapsPrivacyWarningSecondMessage')}
+            </Text>
+            <Text
+              variant={TextVariant.bodyMd}
+              fontWeight={FontWeight.Bold}
+              paddingTop={6}
+            >
+              {t('snapsPrivacyWarningThirdMessage')}
+            </Text>
+          </Box>
+          {isScrollable && !isScrolledToBottom ? (
+            <AvatarIcon
+              className="snap-privacy-warning__content__scroll-button"
+              data-testid="snap-privacy-warning-scroll"
+              iconName={IconName.Arrow2Down}
+              backgroundColor={BackgroundColor.infoDefault}
+              color={IconColor.iconDefault}
+              onClick={scrollToBottom}
+              style={{ cursor: 'pointer' }}
+            />
+          ) : null}
         </Box>
         <Box
-          className="snap-privacy-warning__ok-button"
-          marginTop={6}
-          display={DISPLAY.FLEX}
+          paddingLeft={4}
+          paddingRight={4}
+          paddingBottom={4}
+          className="snap-privacy-warning__footer"
         >
-          <Button
-            variant={BUTTON_VARIANT.SECONDARY}
-            size={BUTTON_PRIMARY_SIZES.LG}
-            width={BLOCK_SIZES.FULL}
-            className="snap-privacy-warning__cancel-button"
-            onClick={onCanceled}
-            marginRight={2}
+          <Box
+            className="snap-privacy-warning__footer"
+            marginTop={6}
+            display={DISPLAY.FLEX}
           >
-            {t('cancel')}
-          </Button>
-          <Button
-            variant={BUTTON_VARIANT.PRIMARY}
-            size={BUTTON_PRIMARY_SIZES.LG}
-            width={BLOCK_SIZES.FULL}
-            className="snap-privacy-warning__ok-button"
-            onClick={onAccepted}
-            marginLeft={2}
-          >
-            {t('accept')}
-          </Button>
+            <Button
+              variant={BUTTON_VARIANT.SECONDARY}
+              size={BUTTON_PRIMARY_SIZES.LG}
+              width={BLOCK_SIZES.FULL}
+              className="snap-privacy-warning__cancel-button"
+              onClick={onCanceled}
+              marginRight={2}
+            >
+              {t('cancel')}
+            </Button>
+            <Button
+              variant={BUTTON_VARIANT.PRIMARY}
+              size={BUTTON_PRIMARY_SIZES.LG}
+              width={BLOCK_SIZES.FULL}
+              className="snap-privacy-warning__ok-button"
+              onClick={onAccepted}
+              marginLeft={2}
+              disabled={!isScrolledToBottom}
+            >
+              {t('accept')}
+            </Button>
+          </Box>
         </Box>
       </Box>
     </Popover>

--- a/ui/components/app/snaps/snap-privacy-warning/snap-privacy-warning.js
+++ b/ui/components/app/snaps/snap-privacy-warning/snap-privacy-warning.js
@@ -25,6 +25,7 @@ import {
   TextVariant,
 } from '../../../../helpers/constants/design-system';
 import { useScrollRequired } from '../../../../hooks/useScrollRequired';
+import { TERMS_OF_USE_LINK } from '../../../../../shared/constants/terms';
 
 export default function SnapPrivacyWarning({ onAccepted, onCanceled }) {
   const t = useI18nContext();
@@ -79,7 +80,7 @@ export default function SnapPrivacyWarning({ onAccepted, onCanceled }) {
                 <ButtonLink
                   key="privacyNoticeTermsOfUseLink"
                   size={BUTTON_LINK_SIZES.INHERIT}
-                  href="https://consensys.net/terms-of-use/"
+                  href={TERMS_OF_USE_LINK}
                   target="_blank"
                 >
                   &nbsp;{t('snapsTermsOfUse')}&nbsp;

--- a/ui/components/app/snaps/snap-privacy-warning/snap-privacy-warning.js
+++ b/ui/components/app/snaps/snap-privacy-warning/snap-privacy-warning.js
@@ -79,7 +79,7 @@ export default function SnapPrivacyWarning({ onAccepted, onCanceled }) {
                 <ButtonLink
                   key="privacyNoticeTermsOfUseLink"
                   size={BUTTON_LINK_SIZES.INHERIT}
-                  href="https://consensys.net/"
+                  href="https://consensys.net/terms-of-use/"
                   target="_blank"
                 >
                   &nbsp;{t('snapsTermsOfUse')}&nbsp;

--- a/ui/components/app/snaps/snap-privacy-warning/snap-privacy-warning.js
+++ b/ui/components/app/snaps/snap-privacy-warning/snap-privacy-warning.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import { useI18nContext } from '../../../../hooks/useI18nContext';
 import Box from '../../../ui/box/box';
@@ -19,6 +19,7 @@ import {
   BackgroundColor,
   BLOCK_SIZES,
   DISPLAY,
+  FontWeight,
   IconColor,
   JustifyContent,
   TextVariant,
@@ -26,11 +27,6 @@ import {
 
 export default function SnapPrivacyWarning({ onAccepted, onCanceled }) {
   const t = useI18nContext();
-  const [isDescriptionOpen, setIsDescriptionOpen] = useState(false);
-
-  const handleReadMoreClick = () => {
-    setIsDescriptionOpen(true);
-  };
 
   return (
     <Popover className="snap-privacy-warning">
@@ -56,46 +52,33 @@ export default function SnapPrivacyWarning({ onAccepted, onCanceled }) {
           justifyContent={JustifyContent.center}
           alignItems={AlignItems.center}
         >
-          <Text variant={TextVariant.headingMd}>{t('thirdPartySoftware')}</Text>
+          <Text variant={TextVariant.headingMd} fontWeight={FontWeight.Bold}>
+            {t('thirdPartySoftware')}
+          </Text>
         </Box>
         <Box className="snap-privacy-warning__message">
           <Text variant={TextVariant.bodyMd}>
-            {t('snapsPrivacyWarningFirstMessage')}
-          </Text>
-          {!isDescriptionOpen && (
-            <>
-              <Text variant={TextVariant.bodyMd} paddingTop={6}>
-                {t('snapsPrivacyWarningSecondMessage')}
-              </Text>
-              <Text
-                variant={TextVariant.bodyMd}
-                className="snap-privacy-warning__more-details"
+            {t('snapsPrivacyWarningFirstMessage', [
+              <ButtonLink
+                key="privacyNoticeTermsOfUseLink"
+                size={BUTTON_LINK_SIZES.INHERIT}
+                href="https://consensys.net/"
+                target="_blank"
               >
-                {t('click')}
-                <ButtonLink
-                  size={BUTTON_LINK_SIZES.INHERIT}
-                  onClick={handleReadMoreClick}
-                  data-testid="snapsPrivacyPopup_readMoreButton"
-                >
-                  &nbsp;{t('here')}&nbsp;
-                </ButtonLink>
-                {t('forMoreDetails')}
-              </Text>
-            </>
-          )}
-          {isDescriptionOpen && (
-            <>
-              <Text variant={TextVariant.bodyMd} paddingTop={6}>
-                {t('snapsThirdPartyNoticeReadMorePartOne')}
-              </Text>
-              <Text variant={TextVariant.bodyMd} paddingTop={6}>
-                {t('snapsThirdPartyNoticeReadMorePartTwo')}
-              </Text>
-              <Text variant={TextVariant.bodyMd} paddingTop={6}>
-                {t('snapsThirdPartyNoticeReadMorePartThree')}
-              </Text>
-            </>
-          )}
+                &nbsp;{t('snapsTermsOfUse')}&nbsp;
+              </ButtonLink>,
+            ])}
+          </Text>
+          <Text variant={TextVariant.bodyMd} paddingTop={6}>
+            {t('snapsPrivacyWarningSecondMessage')}
+          </Text>
+          <Text
+            variant={TextVariant.bodyMd}
+            fontWeight={FontWeight.Bold}
+            paddingTop={6}
+          >
+            {t('snapsPrivacyWarningThirdMessage')}
+          </Text>
         </Box>
         <Box
           className="snap-privacy-warning__ok-button"

--- a/ui/components/app/snaps/snap-privacy-warning/snap-privacy-warning.test.js
+++ b/ui/components/app/snaps/snap-privacy-warning/snap-privacy-warning.test.js
@@ -6,35 +6,22 @@ import SnapPrivacyWarning from './snap-privacy-warning';
 describe('Snap Privacy Warning Popover', () => {
   it('renders snaps privacy warning popover and works with accept flow', () => {
     const mockOnAcceptCallback = jest.fn();
-    const { getByTestId } = renderWithProvider(
+    renderWithProvider(
       <SnapPrivacyWarning
         onAccepted={mockOnAcceptCallback}
         onCanceled={jest.fn()}
       />,
     );
 
-    expect(screen.getByText('Third party software')).toBeInTheDocument();
+    expect(screen.getByText('Third-party software notice')).toBeInTheDocument();
     expect(
       screen.getByText(
-        'Installing a snap retrieves data from third parties. They may collect your personal information.',
-      ),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByText('MetaMask has no access to this information.'),
-    ).toBeInTheDocument();
-    const clickHereToReadMoreButton = getByTestId(
-      'snapsPrivacyPopup_readMoreButton',
-    );
-    expect(clickHereToReadMoreButton).toBeDefined();
-    clickHereToReadMoreButton.click();
-    expect(
-      screen.getByText(
-        'Any information you share with third-party-developed snaps will be collected directly by those snaps in accordance with their privacy policies.',
+        'Any information you share with Third Party Services will be collected directly by those Third Party Services in accordance with their privacy policies. Please refer to their privacy policies for more information.',
       ),
     ).toBeInTheDocument();
     expect(
       screen.getByText(
-        'During the installation of a snap, npmjs (npmjs.com) and AWS (aws.amazon.com) may collect your IP address. Please refer to their privacy policies for more information.',
+        'ConsenSys has no access to information you share with these third parties.',
       ),
     ).toBeInTheDocument();
     expect(
@@ -60,7 +47,7 @@ describe('Snap Privacy Warning Popover', () => {
       />,
     );
 
-    expect(screen.getByText('Third party software')).toBeInTheDocument();
+    expect(screen.getByText('Third-party software notice')).toBeInTheDocument();
     expect(
       screen.getByRole('button', {
         name: /Cancel/iu,

--- a/ui/components/app/snaps/snap-privacy-warning/snap-privacy-warning.test.js
+++ b/ui/components/app/snaps/snap-privacy-warning/snap-privacy-warning.test.js
@@ -21,7 +21,7 @@ describe('Snap Privacy Warning Popover', () => {
     ).toBeInTheDocument();
     expect(
       screen.getByText(
-        'ConsenSys has no access to information you share with these third parties.',
+        'Consensys has no access to information you share with these third parties.',
       ),
     ).toBeInTheDocument();
     expect(

--- a/ui/pages/permissions-connect/snaps/snap-install/snap-install.js
+++ b/ui/pages/permissions-connect/snaps/snap-install/snap-install.js
@@ -14,6 +14,7 @@ import {
   TextVariant,
   TEXT_ALIGN,
   FontWeight,
+  IconColor,
 } from '../../../../helpers/constants/design-system';
 import { getSnapInstallWarnings } from '../util';
 import PulseLoader from '../../../../components/ui/pulse-loader/pulse-loader';
@@ -146,7 +147,7 @@ export default function SnapInstall({
                 data-testid="snap-install-scroll"
                 iconName={IconName.Arrow2Down}
                 backgroundColor={BackgroundColor.infoDefault}
-                color={BackgroundColor.backgroundDefault}
+                color={IconColor.primaryInverse}
                 onClick={scrollToBottom}
                 style={{ cursor: 'pointer' }}
               />

--- a/ui/pages/permissions-connect/snaps/snap-update/snap-update.js
+++ b/ui/pages/permissions-connect/snaps/snap-update/snap-update.js
@@ -14,6 +14,7 @@ import {
   JustifyContent,
   TextVariant,
   TEXT_ALIGN,
+  IconColor,
 } from '../../../../helpers/constants/design-system';
 
 import UpdateSnapPermissionList from '../../../../components/app/snaps/update-snap-permission-list';
@@ -173,7 +174,7 @@ export default function SnapUpdate({
                 data-testid="snap-update-scroll"
                 iconName={IconName.Arrow2Down}
                 backgroundColor={BackgroundColor.infoDefault}
-                color={BackgroundColor.backgroundDefault}
+                color={IconColor.primaryInverse}
                 onClick={scrollToBottom}
                 style={{ cursor: 'pointer' }}
               />


### PR DESCRIPTION
## Explanation
This PR will update Snaps privacy notice content and UX as requested. This notice is the one displayed on first snap installation or until user accepts the terms of use displayed in the popup.

Fixes https://github.com/MetaMask/metamask-extension/issues/19500

Figma designs: https://www.figma.com/file/Wlwk0cTx6PQkNhiX7vN13e/Snaps-Platform-v1?type=design&node-id=198-20452&t=3qMge4mvjrh6nAIS-0

Note: Scroll icon color is updated on the install screen as well to match the requirement and look the same.

## Screenshots/Screencaps

### After
![Screenshot 2023-06-08 at 12 48 16](https://github.com/MetaMask/metamask-extension/assets/13301024/a540f488-a288-4680-bac3-1b5ce34d3776)
![Screenshot 2023-06-08 at 12 48 30](https://github.com/MetaMask/metamask-extension/assets/13301024/d818912d-a765-4438-b264-8fca72b354d4)
<img width="357" alt="Screenshot 2023-06-08 at 12 49 31" src="https://github.com/MetaMask/metamask-extension/assets/13301024/599ad6a4-0557-4ea0-892b-462ef82c416a">

### Before
![Screenshot 2023-06-08 at 14 07 52](https://github.com/MetaMask/metamask-extension/assets/13301024/6f3b89d4-5694-4b67-849e-c5fd75e1f03f)
![Screenshot 2023-06-08 at 14 08 06](https://github.com/MetaMask/metamask-extension/assets/13301024/9c5f3938-5ac4-4c8d-a60b-2d0b7dbd73ed)

## Manual Testing Steps

<!--
How should reviewers and QA manually test your changes? For instance:

- Go to this screen
- Do this
- Then do this
-->

## Pre-merge author checklist

- [ ] I've clearly explained:
  - [ ] What problem this PR is solving
  - [ ] How this problem was solved
  - [ ] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
