### PR TITLE
Fix `testDev` builds with LavaMoat enabled

### DIFF
--- a/development/build/index.js
+++ b/development/build/index.js
@@ -76,7 +76,9 @@ async function defineAndRunBuildTasks() {
     platform,
   } = await parseArgv();
 
-  const isRootTask = ['dist', 'prod', 'test', 'dev'].includes(entryTask);
+  const isRootTask = ['dist', 'prod', 'test', 'testDev', 'dev'].includes(
+    entryTask,
+  );
 
   if (isRootTask) {
     // scuttle on production/tests environment only

--- a/development/build/index.js
+++ b/development/build/index.js
@@ -14,7 +14,7 @@ const difference = require('lodash/difference');
 const { intersection } = require('lodash');
 const { getVersion } = require('../lib/get-version');
 const { loadBuildTypesConfig } = require('../lib/build-type');
-const { TASKS } = require('./constants');
+const { BUILD_TARGETS, TASKS } = require('./constants');
 const {
   createTask,
   composeSeries,
@@ -28,7 +28,6 @@ const createStaticAssetTasks = require('./static');
 const createEtcTasks = require('./etc');
 const { getBrowserVersionMap, getEnvironment } = require('./utils');
 const { getConfig } = require('./config');
-const { BUILD_TARGETS } = require('./constants');
 
 // Packages required dynamically via browserify configuration in dependencies
 // Required for LavaMoat policy generation
@@ -76,13 +75,11 @@ async function defineAndRunBuildTasks() {
     platform,
   } = await parseArgv();
 
-  const isRootTask = ['dist', 'prod', 'test', 'testDev', 'dev'].includes(
-    entryTask,
-  );
+  const isRootTask = Object.values(BUILD_TARGETS).includes(entryTask);
 
   if (isRootTask) {
     // scuttle on production/tests environment only
-    const shouldScuttle = ['dist', 'prod', 'test'].includes(entryTask);
+    const shouldScuttle = entryTask !== BUILD_TARGETS.DEV;
 
     console.log(
       `Building lavamoat runtime file`,


### PR DESCRIPTION
## Explanation

The build script compiles the LavaMoat runtime during each root task, but it was not recognizing `testDev` as a root task. As a result, all `testDev` builds were broken unless LavaMoat was disabled.

The list of root tasks has been updated to include `testDev`. It should now be complete.

## Manual Testing Steps

* Delete the `dist` directory (if it exists)
* Run `yarn start:test`
* Run any e2e test (e.g.  `yarn test:e2e:single --browser firefox ./test/e2e/tests/account-details.spec.js`) to see that e2e tests run successfully

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
