### PR TITLE
Reduce e2e test flakiness

### DIFF
--- a/test/e2e/tests/chain-interactions.spec.js
+++ b/test/e2e/tests/chain-interactions.spec.js
@@ -55,10 +55,10 @@ describe('Chain Interactions', function () {
         await driver.switchToWindow(extension);
 
         // verify networks
-        const networkDisplay = await driver.findElement(
-          '[data-testid="network-display"] p',
-        );
-        assert.equal(await networkDisplay.getText(), 'Localhost 8545');
+        await driver.findElement({
+          css: '[data-testid="network-display"]',
+          text: 'Localhost 8545',
+        });
 
         await driver.clickElement('[data-testid="network-display"]');
         const ganacheChain = await driver.findElements({
@@ -103,10 +103,10 @@ describe('Chain Interactions', function () {
         await driver.switchToWindow(extension);
 
         // verify current network
-        const networkDisplay = await driver.findElement(
-          '[data-testid="network-display"] p',
-        );
-        assert.equal(await networkDisplay.getText(), `Localhost ${port}`);
+        await driver.findElement({
+          css: '[data-testid="network-display"]',
+          text: `Localhost ${port}`,
+        });
       },
     );
   });

--- a/test/e2e/tests/onboarding.spec.js
+++ b/test/e2e/tests/onboarding.spec.js
@@ -301,10 +301,10 @@ describe('MetaMask onboarding', function () {
         assert.equal(networkNotification, true);
 
         // Check localhost 8546 is selected and its balance value is correct
-        const networkDisplay = await driver.findElement(
-          '[data-testid="network-display"] p',
-        );
-        assert.equal(await networkDisplay.getText(), networkName);
+        await driver.findElement({
+          css: '[data-testid="network-display"]',
+          text: networkName,
+        });
 
         await assertAccountBalanceForDOM(driver, secondaryGanacheServer);
       },


### PR DESCRIPTION
## Explanation

Three e2e tests have been updated to fix a possible race condition causing intermittent e2e test failures.

In each of the updated tests, the test checks the current network. The check is performed as a two-step process: locate the current network element, then check the text to ensure it's correct.

This fails when the test driver finds the element before it re-renders. If the test runs too quickly, it compares the text before the switch is shown on screen, and the test fails.

Instead the tests use the element locator to describe what they want. This tells the test driver to keep looking until the conditions are met, ensuring the test doesn't fail unless the network switch takes longer than the default timeout (which should not happen).

This is a good example of why we should avoid using assertions on elements in e2e tests. Express your assertions as locators instead to make the test more resilient in the case where the test runs before the next render.

## Manual Testing Steps

Check that the affected e2e test suites pass

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
