### PR TITLE
update icons with AvatarNetwork for add-network

### DIFF
--- a/ui/components/app/add-network/add-network.js
+++ b/ui/components/app/add-network/add-network.js
@@ -14,11 +14,10 @@ import {
   BackgroundColor,
   TextColor,
   IconColor,
+  Size,
 } from '../../../helpers/constants/design-system';
 import Button from '../../ui/button';
 import Tooltip from '../../ui/tooltip';
-import IconWithFallback from '../../ui/icon-with-fallback';
-import IconBorder from '../../ui/icon-border';
 import {
   getNetworkConfigurations,
   getUnapprovedConfirmations,
@@ -36,7 +35,13 @@ import { FEATURED_RPCS } from '../../../../shared/constants/network';
 import { ADD_NETWORK_ROUTE } from '../../../helpers/constants/routes';
 import { getEnvironmentType } from '../../../../app/scripts/lib/util';
 import ZENDESK_URLS from '../../../helpers/constants/zendesk-url';
-import { Text, Icon, IconName, IconSize } from '../../component-library';
+import {
+  Text,
+  Icon,
+  IconName,
+  IconSize,
+  AvatarNetwork,
+} from '../../component-library';
 import { MetaMetricsNetworkEventSource } from '../../../../shared/constants/metametrics';
 
 const AddNetwork = () => {
@@ -193,15 +198,11 @@ const AddNetwork = () => {
                 className="add-network__list-of-networks"
               >
                 <Box display={Display.Flex} alignItems={AlignItems.center}>
-                  <Box>
-                    <IconBorder size={24}>
-                      <IconWithFallback
-                        icon={item.rpcPrefs?.imageUrl}
-                        name={item.nickname}
-                        size={24}
-                      />
-                    </IconBorder>
-                  </Box>
+                  <AvatarNetwork
+                    size={Size.SM}
+                    src={item.rpcPrefs?.imageUrl}
+                    name={item.nickname}
+                  />
                   <Box marginLeft={2}>
                     <Text
                       variant={TextVariant.bodySmBold}


### PR DESCRIPTION
This PR fixes the network icons that are not vertically centered for add-network and replace the old icon component with AvatarNetwork.

* Fixes #19483 

## Screenshots/Screencaps

### Before

![Screenshot 2023-06-08 at 4 05 54 PM](https://github.com/MetaMask/metamask-extension/assets/39872794/5f8959c7-bbd1-435c-8129-8a34a0967334)

### After
![Screenshot 2023-06-08 at 4 06 08 PM](https://github.com/MetaMask/metamask-extension/assets/39872794/c75782f3-8665-48b0-b249-8f32a9415dc2)


## Manual Testing Steps

- Go to the home screen
- Click on the network dropdown
- Click on add network
- The icons on the add network should be vertically centered

## Pre-merge author checklist

- [ ] I've clearly explained:
  - [ ] What problem this PR is solving
  - [ ] How this problem was solved
  - [ ] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
