### PR TITLE
Fix unknown processing time not showing in warning color

### DIFF
--- a/ui/components/app/gas-timing/gas-timing.component.js
+++ b/ui/components/app/gas-timing/gas-timing.component.js
@@ -151,6 +151,7 @@ export default function GasTiming({
         customEstimatedTime?.upperTimeBound === 'unknown'
       ) {
         text = t('editGasTooLow');
+        attitude = 'negative';
       } else {
         text = t('gasTimingNegative', [
           toHumanReadableTime(Number(customEstimatedTime?.upperTimeBound), t),
@@ -162,6 +163,9 @@ export default function GasTiming({
       ]);
     }
   }
+
+  console.log('attitude', attitude);
+  console.log('estimateUsed', estimateUsed);
 
   return (
     <Typography

--- a/ui/components/app/gas-timing/gas-timing.component.js
+++ b/ui/components/app/gas-timing/gas-timing.component.js
@@ -164,9 +164,6 @@ export default function GasTiming({
     }
   }
 
-  console.log('attitude', attitude);
-  console.log('estimateUsed', estimateUsed);
-
   return (
     <Typography
       variant={TypographyVariant.H7}

--- a/ui/hooks/gasFeeInput/useGasFeeInputs.js
+++ b/ui/hooks/gasFeeInput/useGasFeeInputs.js
@@ -92,13 +92,14 @@ import { useTransactionFunctions } from './useTransactionFunctions';
  *  './useGasFeeEstimates'
  * ).GasEstimates} gas fee input state and the GasFeeEstimates object
  */
+
+const GAS_LIMIT_TOO_HIGH_IN_ETH = '1';
 export function useGasFeeInputs(
   defaultEstimateToUse = GasRecommendations.medium,
   _transaction,
   minimumGasLimit = '0x5208',
   editGasMode = EditGasModes.modifyInPlace,
 ) {
-  const GAS_LIMIT_TOO_HIGH_IN_ETH = '1';
 
   const initialRetryTxMeta = {
     txParams: _transaction?.txParams,

--- a/ui/hooks/gasFeeInput/useGasFeeInputs.js
+++ b/ui/hooks/gasFeeInput/useGasFeeInputs.js
@@ -100,7 +100,6 @@ export function useGasFeeInputs(
   minimumGasLimit = '0x5208',
   editGasMode = EditGasModes.modifyInPlace,
 ) {
-
   const initialRetryTxMeta = {
     txParams: _transaction?.txParams,
     id: _transaction?.id,

--- a/ui/pages/confirm-send-ether/__snapshots__/confirm-send-ether.test.js.snap
+++ b/ui/pages/confirm-send-ether/__snapshots__/confirm-send-ether.test.js.snap
@@ -492,7 +492,7 @@ exports[`ConfirmSendEther should render correct information for for confirm send
               >
                 <div>
                   <h6
-                    class="box box--margin-top-1 box--margin-bottom-1 box--flex-direction-row typography gas-timing gas-timing--positive typography--h7 typography--weight-normal typography--style-normal typography--color-text-default"
+                    class="box box--margin-top-1 box--margin-bottom-1 box--flex-direction-row typography gas-timing gas-timing--negative typography--h7 typography--weight-normal typography--style-normal typography--color-text-default"
                   >
                     Unknown processing time
                   </h6>

--- a/ui/pages/send/send-content/__snapshots__/send-content.component.test.js.snap
+++ b/ui/pages/send/send-content/__snapshots__/send-content.component.test.js.snap
@@ -265,7 +265,7 @@ exports[`SendContent Component render should match snapshot 1`] = `
               >
                 <div>
                   <h6
-                    class="box box--margin-top-1 box--margin-bottom-1 box--flex-direction-row typography gas-timing gas-timing--positive typography--h7 typography--weight-normal typography--style-normal typography--color-text-default"
+                    class="box box--margin-top-1 box--margin-bottom-1 box--flex-direction-row typography gas-timing gas-timing--negative typography--h7 typography--weight-normal typography--style-normal typography--color-text-default"
                   >
                     Unknown processing time
                   </h6>


### PR DESCRIPTION
## Explanation
Problem: whenever we are sending a transaction with an Unknown processing time we see the text displayed green instead of in the Warning color.

Fixes: #19305 

## Screenshots/Screencaps

### Before

![](https://user-images.githubusercontent.com/54408225/241233731-933744ab-ad90-4c60-9e19-a6894c2d7b87.png)

### After

<img width="414" alt="Screenshot 2023-06-08 at 22 15 36" src="https://github.com/MetaMask/metamask-extension/assets/44811/d4ba32c2-25a1-412f-bdb2-809baf27cf20">

## Manual Testing Steps

1. Start a transaction
2. Click to edit the gas fees
3. Click on advanced
4. Set Priority Fee to 0
5. Click Save
6. Unknown processing time should be shown in warning colour.

## Pre-merge author checklist

- [ ] I've clearly explained:
  - [ ] What problem this PR is solving
  - [ ] How this problem was solved
  - [ ] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
