### PR TITLE
Add `--retry-until-failure` flag to e2e test script

### DIFF
--- a/development/lib/retry.js
+++ b/development/lib/retry.js
@@ -11,13 +11,19 @@
  * @param {string} args.rejectionMessage - The message for the rejected promise
  * this function will return in the event of failure. (Default: "Retry limit
  * reached")
+ * @param {string} args.retryUntilFailure - Retries until the function fails.
  * @param {Function} functionToRetry - The function that is run and tested for
  * failure.
  * @returns {Promise<null | Error>} a promise that either resolves to null if
  * the function is successful or is rejected with rejectionMessage otherwise.
  */
 async function retry(
-  { retries, delay = 0, rejectionMessage = 'Retry limit reached' },
+  {
+    retries,
+    delay = 0,
+    rejectionMessage = 'Retry limit reached',
+    retryUntilFailure = false,
+  },
   functionToRetry,
 ) {
   let attempts = 0;
@@ -28,9 +34,14 @@ async function retry(
 
     try {
       await functionToRetry();
-      return;
+      if (!retryUntilFailure) {
+        return;
+      }
     } catch (error) {
       console.error(error);
+      if (retryUntilFailure) {
+        return;
+      }
     } finally {
       attempts += 1;
     }

--- a/test/e2e/run-e2e-test.js
+++ b/test/e2e/run-e2e-test.js
@@ -31,6 +31,11 @@ async function main() {
               'Set how many times the test should be retried upon failure.',
             type: 'number',
           })
+          .option('retry-until-failure', {
+            default: false,
+            description: 'Retries until the test fails',
+            type: 'boolean',
+          })
           .option('leave-running', {
             default: false,
             description:
@@ -46,7 +51,14 @@ async function main() {
     .strict()
     .help('help');
 
-  const { browser, debug, e2eTestPath, retries, leaveRunning } = argv;
+  const {
+    browser,
+    debug,
+    e2eTestPath,
+    retries,
+    retryUntilFailure,
+    leaveRunning,
+  } = argv;
 
   if (!browser) {
     exitWithError(
@@ -97,7 +109,7 @@ async function main() {
   const dir = 'test/test-results/e2e';
   fs.mkdir(dir, { recursive: true });
 
-  await retry({ retries }, async () => {
+  await retry({ retries, retryUntilFailure }, async () => {
     await runInShell(
       'yarn',
       [


### PR DESCRIPTION
## Explanation

The e2e test script now accepts a `--retry-until-failure` flag that can be useful for locally reproducing intermittent failures.

Normally the `retries` option will only retry upon failure. But if you want the test to fail to inspect the failure state, you want it to keep running until the first failure then stop. This flag accomplishes that, reversing the retry conditions.

## Manual Testing Steps

Try running it to see that it works. e.g.
```
yarn test:e2e:single --debug --browser firefox --leave-running --retries 5 --retry-until-failure test/e2e/tests/add-custom-network.spec.js
```


## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
