### PR TITLE
Add a queue for dapps accessing different networks

### DIFF
--- a/app/scripts/controllers/network/network-controller.ts
+++ b/app/scripts/controllers/network/network-controller.ts
@@ -1152,7 +1152,10 @@ export class NetworkController extends EventEmitter {
   getNetworkConfigurationForChainId(chainId: string) {
     console.log(this.store.getState().networkConfigurations);
     for (const networkConfigId in this.store.getState().networkConfigurations) {
-      if (this.store.getState().networkConfigurations[networkConfigId].chainId === chainId) {
+      if (
+        this.store.getState().networkConfigurations[networkConfigId].chainId ===
+        chainId
+      ) {
         return networkConfigId;
       }
     }

--- a/app/scripts/controllers/network/network-controller.ts
+++ b/app/scripts/controllers/network/network-controller.ts
@@ -1148,4 +1148,14 @@ export class NetworkController extends EventEmitter {
       networkConfigurations,
     });
   }
+
+  getNetworkConfigurationForChainId(chainId: string) {
+    console.log(this.store.getState().networkConfigurations);
+    for (const networkConfigId in this.store.getState().networkConfigurations) {
+      if (this.store.getState().networkConfigurations[networkConfigId].chainId === chainId) {
+        return networkConfigId;
+      }
+    }
+    return null;
+  }
 }

--- a/app/scripts/controllers/selected-network-controller.ts
+++ b/app/scripts/controllers/selected-network-controller.ts
@@ -1,0 +1,156 @@
+import EventEmitter from 'events';
+import log from 'loglevel';
+import {
+  EncryptionPublicKeyManager,
+  EncryptionPublicKeyParamsMetamask,
+} from '@metamask/message-manager';
+import { KeyringController } from '@metamask/eth-keyring-controller';
+import {
+  AbstractMessageManager,
+  AbstractMessage,
+  MessageManagerState,
+  AbstractMessageParams,
+  AbstractMessageParamsMetamask,
+  OriginalRequest,
+} from '@metamask/message-manager/dist/AbstractMessageManager';
+import {
+  BaseControllerV2,
+  RestrictedControllerMessenger,
+} from '@metamask/base-controller';
+import { Patch } from 'immer';
+import {
+  AcceptRequest,
+  AddApprovalRequest,
+  RejectRequest,
+} from '@metamask/approval-controller';
+import { MetaMetricsEventCategory } from '../../../shared/constants/metametrics';
+import { KeyringType } from '../../../shared/constants/keyring';
+import { ORIGIN_METAMASK } from '../../../shared/constants/app';
+
+const controllerName = 'SelectedNetworkController';
+const methodNameGetEncryptionPublicKey = 'eth_getEncryptionPublicKey';
+
+const stateMetadata = {
+  domains: { persist: true, anonymous: false },
+  queue: { persist: false, anonymous: false }
+};
+
+const getDefaultState = () => ({
+  domains: {},
+});
+
+type Domain = string;
+type ChainId = string;
+type RequestQueue = Record<Domain, Promise<unknown>[]>;
+
+export type SelectedNetworkControllerState = {
+  domains: Record<Domain, ChainId>;
+};
+
+export type GetSelectedNetworkState = {
+  type: `${typeof controllerName}:getState`;
+  handler: () => SelectedNetworkControllerState;
+};
+
+export type GetSelectedNetworkStateChange = {
+  type: `${typeof controllerName}:stateChange`;
+  payload: [SelectedNetworkControllerState, Patch[]];
+};
+
+export type SelectedNetworkControllerActions = GetSelectedNetworkState;
+
+export type SelectedNetworkControllerEvents =
+  GetSelectedNetworkStateChange;
+
+export type SelectedNetworkControllerMessenger =
+  RestrictedControllerMessenger<
+    typeof controllerName,
+    SelectedNetworkControllerActions,
+    SelectedNetworkControllerEvents,
+    never,
+    never
+  >;
+
+type SwitchNetwork = (chainId: ChainId) => void;
+
+export type SelectedNetworkControllerOptions = {
+  messenger: SelectedNetworkControllerMessenger;
+  switchNetwork: SwitchNetwork;
+};
+
+/**
+ * Controller for requesting encryption public key requests requiring user approval.
+ */
+export default class SelectedNetworkController extends BaseControllerV2<
+  typeof controllerName,
+  SelectedNetworkControllerState,
+  SelectedNetworkControllerMessenger
+> {
+  private switchNetwork: SwitchNetwork;
+  private requestQueue: RequestQueue = {};
+  /**
+   * Construct a EncryptionPublicKey controller.
+   *
+   * @param options - The controller options.
+   * @param options.messenger - The restricted controller messenger for the EncryptionPublicKey controller.
+   * @param options.keyringController - An instance of a keyring controller used to extract the encryption public key.
+   * @param options.getState - Callback to retrieve all user state.
+   * @param options.metricsEvent - A function for emitting a metric event.
+   */
+  constructor({
+    messenger,
+    switchNetwork,
+  }: SelectedNetworkControllerOptions) {
+    super({
+      name: controllerName,
+      metadata: stateMetadata,
+      messenger,
+      state: getDefaultState(),
+    });
+    this.switchNetwork = switchNetwork;
+  }
+
+  /**
+   * Reset the controller state to the initial state.
+   */
+  resetState() {
+    this.update(() => getDefaultState());
+  }
+
+  setChainForDomain(origin: Domain, chainId: ChainId) {
+    this.update((state) => {
+      state.domains[origin] = chainId;
+    });
+  }
+
+  getChainForDomain(origin: Domain) {
+    return this.state.domains[origin];
+  }
+
+  hasQueuedRequests(origin?: Domain) {
+    if (origin) {
+      return this.requestQueue[origin].length > 0;
+    }
+    return Object.keys(this.requestQueue).length > 0;
+  }
+
+  enqueueRequest(origin: Domain, requestNext: Promise<unknown>) {
+    if (this.requestQueue[origin] === undefined) {
+      this.requestQueue[origin] = [];
+    }
+
+    this.requestQueue[origin].push(requestNext);
+
+    return this.requestQueue;
+  }
+
+  async waitForRequestQueue() {
+    console.log('request queue when starting to wait: ', this.requestQueue)
+    const domainQueues = Object.values(
+      this.requestQueue
+    ).map((domainQueue) => Promise.all(domainQueue))
+    await Promise.all(domainQueues);
+    this.requestQueue = {};
+    return true;
+  }
+}

--- a/app/scripts/controllers/selected-network-controller.ts
+++ b/app/scripts/controllers/selected-network-controller.ts
@@ -32,7 +32,7 @@ const methodNameGetEncryptionPublicKey = 'eth_getEncryptionPublicKey';
 
 const stateMetadata = {
   domains: { persist: true, anonymous: false },
-  queue: { persist: false, anonymous: false }
+  queue: { persist: false, anonymous: false },
 };
 
 const getDefaultState = () => ({
@@ -59,17 +59,15 @@ export type GetSelectedNetworkStateChange = {
 
 export type SelectedNetworkControllerActions = GetSelectedNetworkState;
 
-export type SelectedNetworkControllerEvents =
-  GetSelectedNetworkStateChange;
+export type SelectedNetworkControllerEvents = GetSelectedNetworkStateChange;
 
-export type SelectedNetworkControllerMessenger =
-  RestrictedControllerMessenger<
-    typeof controllerName,
-    SelectedNetworkControllerActions,
-    SelectedNetworkControllerEvents,
-    never,
-    never
-  >;
+export type SelectedNetworkControllerMessenger = RestrictedControllerMessenger<
+  typeof controllerName,
+  SelectedNetworkControllerActions,
+  SelectedNetworkControllerEvents,
+  never,
+  never
+>;
 
 type SwitchNetwork = (chainId: ChainId) => void;
 
@@ -87,7 +85,9 @@ export default class SelectedNetworkController extends BaseControllerV2<
   SelectedNetworkControllerMessenger
 > {
   private switchNetwork: SwitchNetwork;
+
   private requestQueue: RequestQueue = {};
+
   /**
    * Construct a EncryptionPublicKey controller.
    *
@@ -96,11 +96,9 @@ export default class SelectedNetworkController extends BaseControllerV2<
    * @param options.keyringController - An instance of a keyring controller used to extract the encryption public key.
    * @param options.getState - Callback to retrieve all user state.
    * @param options.metricsEvent - A function for emitting a metric event.
+   * @param options.switchNetwork
    */
-  constructor({
-    messenger,
-    switchNetwork,
-  }: SelectedNetworkControllerOptions) {
+  constructor({ messenger, switchNetwork }: SelectedNetworkControllerOptions) {
     super({
       name: controllerName,
       metadata: stateMetadata,
@@ -145,10 +143,10 @@ export default class SelectedNetworkController extends BaseControllerV2<
   }
 
   async waitForRequestQueue() {
-    console.log('request queue when starting to wait: ', this.requestQueue)
-    const domainQueues = Object.values(
-      this.requestQueue
-    ).map((domainQueue) => Promise.all(domainQueue))
+    console.log('request queue when starting to wait: ', this.requestQueue);
+    const domainQueues = Object.values(this.requestQueue).map((domainQueue) =>
+      Promise.all(domainQueue),
+    );
     await Promise.all(domainQueues);
     this.requestQueue = {};
     return true;

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -3,6 +3,7 @@ import pump from 'pump';
 import { ObservableStore } from '@metamask/obs-store';
 import { storeAsStream } from '@metamask/obs-store/dist/asStream';
 import { JsonRpcEngine } from 'json-rpc-engine';
+import { createAsyncMiddleware } from 'json-rpc-engine';
 import { createEngineStream } from 'json-rpc-middleware-stream';
 import { providerAsMiddleware } from '@metamask/eth-json-rpc-middleware';
 import { debounce } from 'lodash';
@@ -100,6 +101,7 @@ import {
   CHAIN_IDS,
   NETWORK_TYPES,
   NetworkStatus,
+  CHAIN_ID_TO_TYPE_MAP,
 } from '../../shared/constants/network';
 import { HardwareDeviceNames } from '../../shared/constants/hardware-wallets';
 import { KeyringType } from '../../shared/constants/keyring';
@@ -181,6 +183,7 @@ import createMetaRPCHandler from './lib/createMetaRPCHandler';
 import { previousValueComparator } from './lib/util';
 import createMetamaskMiddleware from './lib/createMetamaskMiddleware';
 import EncryptionPublicKeyController from './controllers/encryption-public-key';
+import SelectedNetworkController from './controllers/selected-network-controller';
 
 import {
   CaveatMutatorFactories,
@@ -1361,6 +1364,11 @@ export default class MetamaskController extends EventEmitter {
       initState.SmartTransactionsController,
     );
 
+    this.selectedNetworkController = new SelectedNetworkController({
+      messenger: this.controllerMessenger,
+      switchNetwork: (a) => { }
+    });
+
     // ensure accountTracker updates balances after network change
     networkControllerMessenger.subscribe(
       'NetworkController:networkDidChange',
@@ -1504,6 +1512,7 @@ export default class MetamaskController extends EventEmitter {
       SmartTransactionsController: this.smartTransactionsController,
       NftController: this.nftController,
       PhishingController: this.phishingController,
+      SelectedNetworkController: this.selectedNetworkController,
       ///: BEGIN:ONLY_INCLUDE_IN(snaps)
       SnapController: this.snapController,
       CronjobController: this.cronjobController,
@@ -1547,6 +1556,7 @@ export default class MetamaskController extends EventEmitter {
         TokensController: this.tokensController,
         SmartTransactionsController: this.smartTransactionsController,
         NftController: this.nftController,
+        SelectedNetworkController: this.selectedNetworkController,
         ///: BEGIN:ONLY_INCLUDE_IN(snaps)
         SnapController: this.snapController,
         CronjobController: this.cronjobController,
@@ -3788,6 +3798,72 @@ export default class MetamaskController extends EventEmitter {
     const engine = new JsonRpcEngine();
     const { blockTracker, provider } = this;
 
+    const providerConfig = this.networkController.store.getState().providerConfig;
+
+    if (this.selectedNetworkController.getChainForDomain(origin) === undefined) {
+      console.log('setting default chain id for ', origin, 'to ', providerConfig.chainId);
+      this.selectedNetworkController.setChainForDomain(
+        origin,
+        providerConfig.chainId
+      );
+    }
+
+    console.log('providerConfig.chainId', providerConfig.chainId);
+    console.log('chainForDomain', origin, 'is ', this.selectedNetworkController.getChainForDomain(origin));
+
+
+    // append origin to each request
+    engine.push(createOriginMiddleware({ origin }));
+
+    // add some middleware that will switch chain on each request (as needed)
+    engine.push(createAsyncMiddleware(async (req, res, next) => {
+      if (req.method === 'wallet_switchEthereumChain') {
+        console.log('switch ethereum chain called with', req.params[0].chainId);
+        await next();
+        console.log('setting selected network', req.params[0].chainId);
+        this.selectedNetworkController.setChainForDomain(
+          origin,
+          req.params[0].chainId
+        );
+        return;
+      }
+
+      const chainIdForRequest = this.selectedNetworkController.getChainForDomain(
+        req.origin
+      );
+      console.log('chainIdForRequest', chainIdForRequest);
+
+      // if queue has anything in it && method call depends on chainId
+      const sameChainAsCurrent = chainIdForRequest === this.networkController.store.getState().providerConfig.chainId;
+      if (this.selectedNetworkController.hasQueuedRequests() && !sameChainAsCurrent) {
+        // if the chain id for the request origin is the same as the current chain id, dont wait for queue before calling next
+
+        console.log('waiting for queued requests to complete');
+        await this.selectedNetworkController.waitForRequestQueue();
+        console.log('queued requests complete');
+      }
+      // await all promises in the queue
+      // then continue
+
+      if (chainIdForRequest !== this.networkController.store.getState().providerConfig.chainId) {
+        console.log('SHOULD SWITCH NETWORK');
+        const type = CHAIN_ID_TO_TYPE_MAP[chainIdForRequest];
+        if (type) {
+          this.networkController.setProviderType(type);
+        } else {
+          const networkConfigId = this.networkController.getNetworkConfigurationForChainId(chainIdForRequest);
+          this.networkController.setActiveNetwork(networkConfigId);
+        }
+      }
+
+      // if method call depends on chainId
+      // Add 'next' promise to a queue
+      this.selectedNetworkController.enqueueRequest(
+        chainIdForRequest,
+        next()
+      );
+    }));
+
     // create filter polyfill middleware
     const filterMiddleware = createFilterMiddleware({ provider, blockTracker });
 
@@ -3803,9 +3879,6 @@ export default class MetamaskController extends EventEmitter {
     if (isManifestV3) {
       engine.push(createDupeReqFilterMiddleware());
     }
-
-    // append origin to each request
-    engine.push(createOriginMiddleware({ origin }));
 
     // append tabId to each request if it exists
     if (tabId) {


### PR DESCRIPTION
## Explanation

Currently not working:

- if you call sendTx from dapp 1, then from dapp 2 you call requestPermissions, when you reject the sendTx, it ends up rejecting the requestPermissions too even though u havent seen it yet
- methods that open a confirmation dialog, but where the confirmation does not depend on selected network, should not queue requests from other chains (should just let them through since the confirmation is not chain-specific)

<!--
Thanks for the pull request. Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues, Slack conversations, Zendesk issues, user stories, etc. reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

## Screenshots/Screencaps

<!-- If you're making a change to the UI, make sure to capture a screenshot or a short video showing off your work! -->

### Before

<!-- How did the UI you changed look before your changes? Drag your file(s) below this line: -->

### After

<!-- How does it look now? Drag your file(s) below this line: -->

## Manual Testing Steps

<!--
How should reviewers and QA manually test your changes? For instance:

- Go to this screen
- Do this
- Then do this
-->

## Pre-merge author checklist

- [ ] I've clearly explained:
  - [ ] What problem this PR is solving
  - [ ] How this problem was solved
  - [ ] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
