### PR TITLE
[FLASK] Fix usages of `getSnapName`

### DIFF
--- a/ui/helpers/utils/permission.js
+++ b/ui/helpers/utils/permission.js
@@ -91,7 +91,7 @@ export const PERMISSION_DESCRIPTIONS = deepFreeze({
             fontWeight={FontWeight.Medium}
             as="span"
           >
-            {getSnapName(targetSubjectMetadata?.origin)}
+            {getSnapName(targetSubjectMetadata?.origin, targetSubjectMetadata)}
           </Text>,
           <Text as="span" key="2" fontWeight={FontWeight.Medium}>
             {getSnapDerivationPathName(path, curve) ??
@@ -160,7 +160,7 @@ export const PERMISSION_DESCRIPTIONS = deepFreeze({
             fontWeight={FontWeight.Medium}
             as="span"
           >
-            {getSnapName(targetSubjectMetadata?.origin)}
+            {getSnapName(targetSubjectMetadata?.origin, targetSubjectMetadata)}
           </Text>,
           <Text as="span" key="2" fontWeight={FontWeight.Medium}>
             {getSnapDerivationPathName(path, curve) ??
@@ -241,7 +241,7 @@ export const PERMISSION_DESCRIPTIONS = deepFreeze({
           fontWeight={FontWeight.Medium}
           as="span"
         >
-          {getSnapName(targetSubjectMetadata?.origin)}
+          {getSnapName(targetSubjectMetadata?.origin, targetSubjectMetadata)}
         </Text>,
         <Text as="span" key="2" fontWeight={FontWeight.Medium}>
           {coinTypeToProtocolName(coinType) ||
@@ -261,7 +261,11 @@ export const PERMISSION_DESCRIPTIONS = deepFreeze({
     leftIcon: IconName.AddSquare,
     weight: 3,
   }),
-  [RestrictedMethods.wallet_snap]: ({ t, permissionValue }) => {
+  [RestrictedMethods.wallet_snap]: ({
+    t,
+    permissionValue,
+    targetSubjectMetadata,
+  }) => {
     const snaps = permissionValue.caveats[0].value;
     const baseDescription = {
       leftIcon: getLeftIcon(IconName.Flash),
@@ -269,7 +273,7 @@ export const PERMISSION_DESCRIPTIONS = deepFreeze({
     };
 
     return Object.keys(snaps).map((snapId) => {
-      const friendlyName = getSnapName(snapId);
+      const friendlyName = getSnapName(snapId, targetSubjectMetadata);
       if (friendlyName) {
         return {
           ...baseDescription,

--- a/ui/pages/permissions-connect/snaps/snap-install/snap-install.js
+++ b/ui/pages/permissions-connect/snaps/snap-install/snap-install.js
@@ -66,7 +66,10 @@ export default function SnapInstall({
 
   const shouldShowWarning = warnings.length > 0;
 
-  const snapName = getSnapName(targetSubjectMetadata.origin);
+  const snapName = getSnapName(
+    targetSubjectMetadata.origin,
+    targetSubjectMetadata,
+  );
 
   const handleSubmit = () => {
     if (!hasError && shouldShowWarning) {

--- a/ui/pages/permissions-connect/snaps/snap-result/snap-result.js
+++ b/ui/pages/permissions-connect/snaps/snap-result/snap-result.js
@@ -44,7 +44,10 @@ export default function SnapResult({
 
   const hasError = !requestState.loading && requestState.error;
   const isLoading = requestState.loading;
-  const snapName = getSnapName(targetSubjectMetadata.origin);
+  const snapName = getSnapName(
+    targetSubjectMetadata.origin,
+    targetSubjectMetadata,
+  );
 
   function getSuccessScreen(requestType, snapNameToRender) {
     let successScreenTitle;

--- a/ui/pages/permissions-connect/snaps/snap-update/snap-update.js
+++ b/ui/pages/permissions-connect/snaps/snap-update/snap-update.js
@@ -73,7 +73,10 @@ export default function SnapUpdate({
 
   const shouldShowWarning = warnings.length > 0;
 
-  const snapName = getSnapName(targetSubjectMetadata.origin);
+  const snapName = getSnapName(
+    targetSubjectMetadata.origin,
+    targetSubjectMetadata,
+  );
 
   const handleSubmit = () => {
     if (!hasError && shouldShowWarning) {


### PR DESCRIPTION
## Explanation

Fixes a handful of instances where we weren't passing `subjectMetadata` to `getSnapName`.