### PR TITLE
[FLASK] Align update error state with Figma

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -3352,9 +3352,6 @@
   "reportLastRunTooltip": {
     "message": "The date and time of when the last AML/CFT report was run"
   },
-  "requestFailed": {
-    "message": "Request failed"
-  },
   "requestFlaggedAsMaliciousFallbackCopyReason": {
     "message": "The security provider has not shared additional details"
   },

--- a/ui/pages/permissions-connect/snaps/snap-update/snap-update.js
+++ b/ui/pages/permissions-connect/snaps/snap-update/snap-update.js
@@ -124,7 +124,16 @@ export default function SnapUpdate({
           </Box>
         )}
         {hasError && (
-          <InstallError error={requestState.error} title={t('requestFailed')} />
+          <InstallError
+            iconName={IconName.Warning}
+            error={requestState.error}
+            title={t('snapUpdateErrorTitle')}
+            description={t('snapUpdateErrorDescription', [
+              <Text as={ValidTag.Span} key="1" fontWeight={FontWeight.Medium}>
+                {snapName}
+              </Text>,
+            ])}
+          />
         )}
         {!hasError && !isLoading && (
           <>


### PR DESCRIPTION
## Explanation

Aligns the error state that occurs when failing to update a snap with Figma. This can be triggered by attempting to update a snap to a lower version than the one installed. This is triggered differently from the `snap-result` case, but should look the same.