### PR TITLE
Issue 18714 Replace deprecated constants with enums

### DIFF
--- a/ui/pages/swaps/slippage-buttons/slippage-buttons.js
+++ b/ui/pages/swaps/slippage-buttons/slippage-buttons.js
@@ -11,7 +11,7 @@ import {
   TextVariant,
   FontWeight,
   AlignItems,
-  DISPLAY,
+  Display,
 } from '../../../helpers/constants/design-system';
 import { getTranslatedStxErrorMessage } from '../swaps.util';
 import { Slippage } from '../../../../shared/constants/swaps';
@@ -201,9 +201,9 @@ export default function SlippageButtons({
               </div>
             )}
             {smartTransactionsEnabled && (
-              <Box marginTop={2} display={DISPLAY.FLEX}>
+              <Box marginTop={2} display={Display.Flex}>
                 <Box
-                  display={DISPLAY.FLEX}
+                  display={Display.Flex}
                   alignItems={AlignItems.center}
                   paddingRight={3}
                 >


### PR DESCRIPTION
## Explanation

This PR replaces the use of deprecated Display constant with enum in slippage-buttons.js file.
Fixes #18714 

## Screenshots/Screencaps

### Before

![Screenshot 2023-06-11 140106](https://github.com/MetaMask/metamask-extension/assets/20976813/a2ea1d31-2b52-48a7-99b3-13b2328fb585)

### After

![Screenshot 2023-06-11 140123](https://github.com/MetaMask/metamask-extension/assets/20976813/6d874d41-9a8d-445c-8a38-54cda0183f9a)

## Manual Testing Steps

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [ ] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [x] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [x] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
