### PR TITLE
Updating BorderColor enum to prevent proptype error

### DIFF
--- a/ui/components/multichain/account-picker/account-picker.js
+++ b/ui/components/multichain/account-picker/account-picker.js
@@ -13,7 +13,7 @@ import {
   AlignItems,
   BackgroundColor,
   BorderRadius,
-  DISPLAY,
+  Display,
   FontWeight,
   IconColor,
   Size,
@@ -31,7 +31,7 @@ export const AccountPicker = ({ address, name, onClick, disabled }) => {
       borderRadius={BorderRadius.LG}
       ellipsis
       textProps={{
-        display: DISPLAY.FLEX,
+        display: Display.Flex,
         gap: 2,
         alignItems: AlignItems.center,
       }}

--- a/ui/components/multichain/account-picker/account-picker.test.js
+++ b/ui/components/multichain/account-picker/account-picker.test.js
@@ -10,6 +10,7 @@ const DEFAULT_PROPS = {
   name: 'Account 1',
   address: '0x0dcd5d886577d5081b0c52e242ef29e70be3e7bc',
   onClick: () => undefined,
+  disabled: false,
 };
 
 const render = (props = {}, state = {}) => {

--- a/ui/helpers/constants/design-system.ts
+++ b/ui/helpers/constants/design-system.ts
@@ -106,6 +106,7 @@ export enum BorderColor {
   lineaTestnet = 'lineatestnet',
   transparent = 'transparent',
   localhost = 'localhost',
+  backgroundDefault = 'background-default', // exception for border color when element is meant to look "cut out"
 }
 
 export enum TextColor {


### PR DESCRIPTION
## Explanation
Currently there is a propType error on the home page that is caused by an avatar component using a background color for the border color prop. In this case it is valid because the border color is supposed to blend into the background creating a "cut out" effect. This PR adds backgroundDefault to the BorderColor enum to prevent the proptype error

## Screenshots/Screencaps
### Before
<img width="1440" alt="Screenshot 2023-06-12 at 1 05 10 PM" src="https://github.com/MetaMask/metamask-extension/assets/8112138/46927feb-f0c5-49df-974f-25df8d303c11">

![Screenshot 2023-06-12 at 1 04 38 PM](https://github.com/MetaMask/metamask-extension/assets/8112138/8c540d0e-45cb-40a5-8fcc-2f0217a2539d)


### After

![Screenshot 2023-06-12 at 12 58 21 PM](https://github.com/MetaMask/metamask-extension/assets/8112138/87a1876c-64b8-4a8e-9885-82d64201f9c5)
<img width="1440" alt="Screenshot 2023-06-12 at 12 59 45 PM" src="https://github.com/MetaMask/metamask-extension/assets/8112138/d434bf65-88e0-487d-9db2-36b102f8977d">

## Manual Testing Steps

- Pull this branch
- Run extension locally
- Open console on home page see proptype error is gone

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
