### PR TITLE
UX Multichain: UI fixes for settings page

### DIFF
--- a/ui/pages/settings/index.scss
+++ b/ui/pages/settings/index.scss
@@ -134,6 +134,7 @@
         }
       }
     }
+
     .app-header__logo-container {
       display: flex;
     }

--- a/ui/pages/settings/index.scss
+++ b/ui/pages/settings/index.scss
@@ -23,8 +23,6 @@
   }
 
   &__header {
-    padding: 20px 16px 20px 16px;
-
     &__title-container {
       display: grid;
       align-items: center;
@@ -33,7 +31,7 @@
       @include screen-sm-max {
         grid-template-rows: 1fr 1fr;
         grid-template-columns: 0.5fr 2fr 0.5fr;
-        gap: 20px;
+        gap: 16px;
         grid-template-areas:
           'back title close'
           'search search search';
@@ -44,6 +42,7 @@
 
         &__title {
           grid-area: title;
+          text-align: center;
         }
 
         &__close-button {
@@ -135,6 +134,13 @@
         }
       }
     }
+    .app-header__logo-container {
+      display: flex;
+    }
+
+    .app-header__metafox-logo--icon {
+      height: 24px;
+    }
   }
 
   &__subheader,
@@ -210,7 +216,6 @@
   }
 
   &__content {
-    margin-top: 8px;
     display: flex;
     flex-flow: row nowrap;
     height: 100%;

--- a/ui/pages/settings/settings.component.js
+++ b/ui/pages/settings/settings.component.js
@@ -23,24 +23,29 @@ import {
   EXPERIMENTAL_ROUTE,
   ADD_NETWORK_ROUTE,
   ADD_POPULAR_CUSTOM_NETWORK,
+  DEFAULT_ROUTE,
 } from '../../helpers/constants/routes';
 
 import { getSettingsRoutes } from '../../helpers/utils/settings-search';
 import AddNetwork from '../../components/app/add-network/add-network';
 import {
   ButtonIcon,
+  ButtonIconSize,
   Icon,
   IconName,
   Text,
+  Box,
 } from '../../components/component-library';
 import {
   AlignItems,
   Color,
-  DISPLAY,
-  FLEX_DIRECTION,
+  Display,
+  FlexDirection,
   TextVariant,
 } from '../../helpers/constants/design-system';
-import Box from '../../components/ui/box';
+import MetafoxLogo from '../../components/ui/metafox-logo';
+import { getEnvironmentType } from '../../../app/scripts/lib/util';
+import { ENVIRONMENT_TYPE_POPUP } from '../../../shared/constants/app';
 import SettingsTab from './settings-tab';
 import AlertsTab from './alerts-tab';
 import NetworksTab from './networks-tab';
@@ -121,6 +126,7 @@ class SettingsPage extends PureComponent {
 
     const { searchResults, isSearchList, searchText } = this.state;
     const { t } = this.context;
+    const isPopup = getEnvironmentType() === ENVIRONMENT_TYPE_POPUP;
 
     return (
       <div
@@ -128,22 +134,38 @@ class SettingsPage extends PureComponent {
           'settings-page--selected': currentPath !== SETTINGS_ROUTE,
         })}
       >
-        <div className="settings-page__header">
+        <Box
+          className="settings-page__header"
+          padding={4}
+          paddingBottom={[2, 4]}
+        >
           <div className="settings-page__header__title-container">
-            {currentPath !== SETTINGS_ROUTE && (
-              <ButtonIcon
-                ariaLabel={t('back')}
-                iconName={IconName.ArrowLeft}
-                className="settings-page__header__title-container__back-button"
-                color={Color.iconDefault}
-                onClick={() => history.push(backRoute)}
-                display={[DISPLAY.FLEX, DISPLAY.NONE]}
-              />
+            {isPopup && (
+              <>
+                {currentPath === SETTINGS_ROUTE ? (
+                  <MetafoxLogo
+                    className="settings-page__header__title-container__metamask-logo"
+                    unsetIconHeight
+                    onClick={async () => history.push(DEFAULT_ROUTE)}
+                    display={[Display.Flex, Display.None]}
+                  />
+                ) : (
+                  <ButtonIcon
+                    ariaLabel={t('back')}
+                    iconName={IconName.ArrowLeft}
+                    className="settings-page__header__title-container__back-button"
+                    color={Color.iconDefault}
+                    onClick={() => history.push(backRoute)}
+                    display={[Display.Flex, Display.None]}
+                    size={ButtonIconSize.Sm}
+                  />
+                )}
+              </>
             )}
             {this.renderTitle()}
             <Box
               className="settings-page__header__title-container__search"
-              display={[DISPLAY.BLOCK]}
+              display={[Display.BLOCK]}
             >
               <SettingsSearch
                 onSearch={({ searchQuery = '', results = [] }) => {
@@ -173,10 +195,11 @@ class SettingsPage extends PureComponent {
                   history.push(mostRecentOverviewPage);
                 }
               }}
+              size={ButtonIconSize.Sm}
               marginLeft="auto"
             />
           </div>
-        </div>
+        </Box>
 
         <div className="settings-page__content">
           <div className="settings-page__content__tabs">
@@ -244,8 +267,8 @@ class SettingsPage extends PureComponent {
         <Box
           className="settings-page__subheader"
           padding={4}
-          display={DISPLAY.FLEX}
-          flexDirection={FLEX_DIRECTION.ROW}
+          display={Display.Flex}
+          flexDirection={FlexDirection.Row}
           alignItems={AlignItems.center}
         >
           <Text


### PR DESCRIPTION
This PR is to fix the UI bugs for settings Page:
- Since we swapped the position of add contacts. The title in settings page is now center aligned
- Fixed the paddings
- Added Fox icon in popup to keep in sync with mobile

* Fixes [MetaMask-planning/issues/705](https://github.com/MetaMask/MetaMask-planning/issues/705)

## Screenshots/Screencaps


### Before
![Screenshot 2023-06-13 at 1 27 11 PM](https://github.com/MetaMask/metamask-extension/assets/39872794/b8673cfb-fa68-487b-8fe0-77c5ba8f7965)


### After

![Screenshot 2023-06-13 at 1 25 36 PM](https://github.com/MetaMask/metamask-extension/assets/39872794/7c2164d6-5cfb-4628-aed5-88f1f92ea847)

## Manual Testing Steps

- Go to the settings screen
- Check there is metamask logo in mobile view

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
