### PR TITLE
[FLASK] Bump RateLimitController to v3

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -894,29 +894,33 @@ export default class MetamaskController extends EventEmitter {
         name: 'RateLimitController',
       }),
       implementations: {
-        showNativeNotification: (origin, message) => {
-          const subjectMetadataState = this.controllerMessenger.call(
-            'SubjectMetadataController:getState',
-          );
+        showNativeNotification: {
+          method: (origin, message) => {
+            const subjectMetadataState = this.controllerMessenger.call(
+              'SubjectMetadataController:getState',
+            );
 
-          const originMetadata = subjectMetadataState.subjectMetadata[origin];
+            const originMetadata = subjectMetadataState.subjectMetadata[origin];
 
-          this.platform
-            ._showNotification(originMetadata?.name ?? origin, message)
-            .catch((error) => {
-              log.error('Failed to create notification', error);
-            });
+            this.platform
+              ._showNotification(originMetadata?.name ?? origin, message)
+              .catch((error) => {
+                log.error('Failed to create notification', error);
+              });
 
-          return null;
+            return null;
+          },
         },
-        showInAppNotification: (origin, message) => {
-          this.controllerMessenger.call(
-            'NotificationController:show',
-            origin,
-            message,
-          );
+        showInAppNotification: {
+          method: (origin, message) => {
+            this.controllerMessenger.call(
+              'NotificationController:show',
+              origin,
+              message,
+            );
 
-          return null;
+            return null;
+          },
         },
       },
     });

--- a/lavamoat/browserify/desktop/policy.json
+++ b/lavamoat/browserify/desktop/policy.json
@@ -1849,13 +1849,8 @@
         "setTimeout": true
       },
       "packages": {
-        "@metamask/rate-limit-controller>@metamask/base-controller": true,
+        "@metamask/base-controller": true,
         "eth-rpc-errors": true
-      }
-    },
-    "@metamask/rate-limit-controller>@metamask/base-controller": {
-      "packages": {
-        "immer": true
       }
     },
     "@metamask/rpc-methods-flask": {

--- a/lavamoat/browserify/flask/policy.json
+++ b/lavamoat/browserify/flask/policy.json
@@ -1849,13 +1849,8 @@
         "setTimeout": true
       },
       "packages": {
-        "@metamask/rate-limit-controller>@metamask/base-controller": true,
+        "@metamask/base-controller": true,
         "eth-rpc-errors": true
-      }
-    },
-    "@metamask/rate-limit-controller>@metamask/base-controller": {
-      "packages": {
-        "immer": true
       }
     },
     "@metamask/rpc-methods-flask": {

--- a/package.json
+++ b/package.json
@@ -255,7 +255,7 @@
     "@metamask/phishing-controller": "^3.0.0",
     "@metamask/post-message-stream": "^6.0.0",
     "@metamask/providers": "^10.2.1",
-    "@metamask/rate-limit-controller": "^2.0.0",
+    "@metamask/rate-limit-controller": "^3.0.0",
     "@metamask/rpc-methods": "^0.32.2",
     "@metamask/rpc-methods-flask": "npm:@metamask/rpc-methods@0.34.0-flask.1",
     "@metamask/safe-event-emitter": "^2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4555,14 +4555,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/rate-limit-controller@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "@metamask/rate-limit-controller@npm:2.0.0"
+"@metamask/rate-limit-controller@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@metamask/rate-limit-controller@npm:3.0.0"
   dependencies:
-    "@metamask/base-controller": ^2.0.0
-    eth-rpc-errors: ^4.0.0
+    "@metamask/base-controller": ^3.0.0
+    eth-rpc-errors: ^4.0.2
     immer: ^9.0.6
-  checksum: da0b3cb6607201b07ee54f81a4ce8ce3ce047acde33c5f483aa0c8c907bcbe32e70944d95cf4f0df5d4b664388be832320d6973cf61cd00e22f81d16ff0ddfd2
+  checksum: 9bf1a99056303a1a23e3ea1984f2db2635f5a09edc307e114e6246db1addac878f8d8e89be862d2f1ad06248c0d4e4613d648caf191dc42fbdc0d310e6f8896f
   languageName: node
   linkType: hard
 
@@ -24066,7 +24066,7 @@ __metadata:
     "@metamask/phishing-warning": ^2.1.0
     "@metamask/post-message-stream": ^6.0.0
     "@metamask/providers": ^10.2.1
-    "@metamask/rate-limit-controller": ^2.0.0
+    "@metamask/rate-limit-controller": ^3.0.0
     "@metamask/rpc-methods": ^0.32.2
     "@metamask/rpc-methods-flask": "npm:@metamask/rpc-methods@0.34.0-flask.1"
     "@metamask/safe-event-emitter": ^2.0.0


### PR DESCRIPTION
## Explanation

Bumps `metamask/rate-limit-controller` to `3.0.0` and handles breaking changes.