### PR TITLE
Eliminate redundant locator building

### DIFF
--- a/test/e2e/webdriver/driver.js
+++ b/test/e2e/webdriver/driver.js
@@ -161,16 +161,18 @@ class Driver {
     // replacement for the implementation below. It takes an option options
     // bucket that can include the state attribute to wait for elements that
     // match the selector to be removed from the DOM.
-    const selector = this.buildLocator(rawLocator);
     let element;
     if (!['visible', 'detached'].includes(state)) {
       throw new Error(`Provided state selector ${state} is not supported`);
     }
     if (state === 'visible') {
-      element = await this.driver.wait(until.elementLocated(selector), timeout);
+      element = await this.driver.wait(
+        until.elementLocated(this.buildLocator(rawLocator)),
+        timeout,
+      );
     } else if (state === 'detached') {
       element = await this.driver.wait(
-        until.stalenessOf(await this.findElement(selector)),
+        until.stalenessOf(await this.findElement(rawLocator)),
         timeout,
       );
     }
@@ -205,15 +207,13 @@ class Driver {
   }
 
   async findVisibleElement(rawLocator) {
-    const locator = this.buildLocator(rawLocator);
-    const element = await this.findElement(locator);
+    const element = await this.findElement(rawLocator);
     await this.driver.wait(until.elementIsVisible(element), this.timeout);
     return wrapElementWithAPI(element, this);
   }
 
   async findClickableElement(rawLocator) {
-    const locator = this.buildLocator(rawLocator);
-    const element = await this.findElement(locator);
+    const element = await this.findElement(rawLocator);
     await Promise.all([
       this.driver.wait(until.elementIsVisible(element), this.timeout),
       this.driver.wait(until.elementIsEnabled(element), this.timeout),
@@ -231,8 +231,7 @@ class Driver {
   }
 
   async findClickableElements(rawLocator) {
-    const locator = this.buildLocator(rawLocator);
-    const elements = await this.findElements(locator);
+    const elements = await this.findElements(rawLocator);
     await Promise.all(
       elements.reduce((acc, element) => {
         acc.push(
@@ -246,14 +245,12 @@ class Driver {
   }
 
   async clickElement(rawLocator) {
-    const locator = this.buildLocator(rawLocator);
-    const element = await this.findClickableElement(locator);
+    const element = await this.findClickableElement(rawLocator);
     await element.click();
   }
 
   async clickPoint(rawLocator, x, y) {
-    const locator = this.buildLocator(rawLocator);
-    const element = await this.findElement(locator);
+    const element = await this.findElement(rawLocator);
     await this.driver
       .actions()
       .move({ origin: element, x, y })
@@ -281,10 +278,9 @@ class Driver {
   }
 
   async assertElementNotPresent(rawLocator) {
-    const locator = this.buildLocator(rawLocator);
     let dataTab;
     try {
-      dataTab = await this.findElement(locator);
+      dataTab = await this.findElement(rawLocator);
     } catch (err) {
       assert(
         err instanceof webdriverError.NoSuchElementError ||


### PR DESCRIPTION
## Explanation

Our e2e test driver was building the locator object multiple times over in some cases. The `Locator` object is required by certain webdriver methods, but our driver methods all accept a "raw locator".

This change avoids a few redundant calls, and makes it easier to improve the error message for a timeout failure (which will be done in a later PR). It also makes the code match the documentation/parameter names.

## Manual Testing Steps

No functional changes. This affects the e2e tests, but they should behave the same as before.

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
