### PR TITLE
Enable e2e debug flag in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -655,7 +655,7 @@ jobs:
           command: |
             if .circleci/scripts/test-run-e2e.sh
             then
-              yarn test:e2e:chrome --retries 2
+              yarn test:e2e:chrome --retries 2 --debug
             fi
           no_output_timeout: 20m
       - run:
@@ -692,7 +692,7 @@ jobs:
           command: |
             if .circleci/scripts/test-run-e2e.sh
             then
-              yarn test:e2e:chrome --retries 2 --mv3 || echo "Temporarily suppressing MV3 e2e test failures"
+              yarn test:e2e:chrome --retries 2 --debug --mv3 || echo "Temporarily suppressing MV3 e2e test failures"
             fi
           no_output_timeout: 20m
       - store_artifacts:
@@ -720,7 +720,7 @@ jobs:
           command: |
             if .circleci/scripts/test-run-e2e.sh
             then
-              yarn test:e2e:firefox:snaps --retries 2
+              yarn test:e2e:firefox:snaps --retries 2 --debug
             fi
           no_output_timeout: 20m
       - run:
@@ -757,7 +757,7 @@ jobs:
           command: |
             if .circleci/scripts/test-run-e2e.sh
             then
-              yarn test:e2e:chrome:snaps --retries 2
+              yarn test:e2e:chrome:snaps --retries 2 --debug
             fi
           no_output_timeout: 20m
       - run:
@@ -794,7 +794,7 @@ jobs:
           command: |
             if .circleci/scripts/test-run-e2e.sh
             then
-              yarn test:e2e:firefox --retries 2
+              yarn test:e2e:firefox --retries 2 --debug
             fi
           no_output_timeout: 20m
       - run:


### PR DESCRIPTION
## Explanation

E2E tests will now run in debug mode on CI, printing out each step that the driver takes during a test. This should make debugging intermittent failures much easier.

## Manual Testing Steps

Look at the CI output for the e2e test runs, to see whether debug logs are included

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
