### PR TITLE
MMI start script and fixes a bug preventing it to run

### DIFF
--- a/app/scripts/controllers/mmi-controller.js
+++ b/app/scripts/controllers/mmi-controller.js
@@ -544,30 +544,6 @@ export default class MMIController extends EventEmitter {
     });
   }
 
-  async setMmiPortfolioCookie() {
-    await this.appStateController.getUnlockPromise(true);
-    const keyringAccounts = await this.keyringController.getAccounts();
-    const { identities } = this.preferencesController.store.getState();
-    const { metaMetricsId } = this.metaMetricsController.store.getState();
-    const getAccountDetails = (address) =>
-      this.custodyController.getAccountDetails(address);
-    const extensionId = this.extension.runtime.id;
-    const networks = [
-      ...this.preferencesController.getRpcMethodPreferences(),
-      { chainId: CHAIN_IDS.MAINNET },
-      { chainId: CHAIN_IDS.GOERLI },
-    ];
-
-    handleMmiPortfolio({
-      keyringAccounts,
-      identities,
-      metaMetricsId,
-      networks,
-      getAccountDetails,
-      extensionId,
-    });
-  }
-
   async setAccountAndNetwork(origin, address, chainId) {
     await this.appStateController.getUnlockPromise(true);
     const selectedAddress = this.preferencesController.getSelectedAddress();

--- a/app/scripts/controllers/mmi-controller.js
+++ b/app/scripts/controllers/mmi-controller.js
@@ -14,9 +14,7 @@ import {
   REFRESH_TOKEN_CHANGE_EVENT,
   INTERACTIVE_REPLACEMENT_TOKEN_CHANGE_EVENT,
 } from '@metamask-institutional/sdk';
-import { handleMmiPortfolio } from '@metamask-institutional/portfolio-dashboard';
 import { toChecksumHexAddress } from '../../../shared/modules/hexstring-utils';
-import { CHAIN_IDS } from '../../../shared/constants/network';
 import {
   BUILD_QUOTE_ROUTE,
   CONNECT_HARDWARE_ROUTE,

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -70,6 +70,7 @@ import {
 } from '@metamask-institutional/custody-keyring';
 import { InstitutionalFeaturesController } from '@metamask-institutional/institutional-features';
 import { CustodyController } from '@metamask-institutional/custody-controller';
+import { handleMmiPortfolio } from '@metamask-institutional/portfolio-dashboard';
 import { TransactionUpdateController } from '@metamask-institutional/transaction-update';
 ///: END:ONLY_INCLUDE_IN
 import { SignatureController } from '@metamask/signature-controller';

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -348,6 +348,10 @@ export default class MetamaskController extends EventEmitter {
       ),
       tokenListController: this.tokenListController,
       provider: this.provider,
+      ///: BEGIN:ONLY_INCLUDE_IN(build-mmi)
+      handleMmiPortfolio: this.setMmiPortfolioCookie.bind(this),
+      mmiConfigurationStore: this.mmiConfigurationController.store,
+      ///: END:ONLY_INCLUDE_IN
     });
 
     this.tokensController = new TokensController({
@@ -3885,7 +3889,7 @@ export default class MetamaskController extends EventEmitter {
           ),
         handleMmiCheckIfTokenIsPresent:
           this.mmiController.handleMmiCheckIfTokenIsPresent.bind(this),
-        handleMmiPortfolio: this.mmiController.setMmiPortfolioCookie.bind(this),
+        handleMmiPortfolio: this.setMmiPortfolioCookie.bind(this),
         handleMmiOpenSwaps: this.mmiController.handleMmiOpenSwaps.bind(this),
         handleMmiSetAccountAndNetwork:
           this.mmiController.setAccountAndNetwork.bind(this),
@@ -3943,6 +3947,37 @@ export default class MetamaskController extends EventEmitter {
     engine.push(providerAsMiddleware(provider));
     return engine;
   }
+
+  ///: BEGIN:ONLY_INCLUDE_IN(build-mmi)
+  /**
+   * This method is needed in preferences controller
+   * so it needs to be here and not in our controller because
+   * preferences controllers is initiated first
+   */
+  async setMmiPortfolioCookie() {
+    await this.appStateController.getUnlockPromise(true);
+    const keyringAccounts = await this.keyringController.getAccounts();
+    const { identities } = this.preferencesController.store.getState();
+    const { metaMetricsId } = this.metaMetricsController.store.getState();
+    const getAccountDetails = (address) =>
+      this.custodyController.getAccountDetails(address);
+    const extensionId = this.extension.runtime.id;
+    const networks = [
+      ...this.preferencesController.getRpcMethodPreferences(),
+      { chainId: CHAIN_IDS.MAINNET },
+      { chainId: CHAIN_IDS.GOERLI },
+    ];
+
+    return handleMmiPortfolio({
+      keyringAccounts,
+      identities,
+      metaMetricsId,
+      networks,
+      getAccountDetails,
+      extensionId,
+    });
+  }
+  ///: END:ONLY_INCLUDE_IN
 
   /**
    * TODO:LegacyProvider: Delete

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "start": "yarn build:dev dev --apply-lavamoat=false --snow=false",
     "start:mv3": "ENABLE_MV3=true yarn build:dev dev --apply-lavamoat=false",
     "start:flask": "yarn start --build-type flask",
+    "start:mmi": "yarn start --build-type mmi",
     "start:lavamoat": "yarn build:dev dev --apply-lavamoat=true",
     "dist": "yarn build dist",
     "build": "yarn lavamoat:build",

--- a/ui/components/multichain/app-header/app-header.js
+++ b/ui/components/multichain/app-header/app-header.js
@@ -75,8 +75,8 @@ export const AppHeader = ({ location }) => {
 
   ///: BEGIN:ONLY_INCLUDE_IN(build-mmi)
   const selectedAddress = useSelector(getSelectedAddress);
-  const custodianIcon = useSelector((state) =>
-    getCustodianIconForAddress(state, selectedAddress),
+  const custodianIcon = selectedAddress && useSelector((state) =>
+    getCustodianIconForAddress(state, selectedAddress)
   );
   ///: END:ONLY_INCLUDE_IN
 

--- a/ui/components/multichain/app-header/app-header.js
+++ b/ui/components/multichain/app-header/app-header.js
@@ -75,8 +75,8 @@ export const AppHeader = ({ location }) => {
 
   ///: BEGIN:ONLY_INCLUDE_IN(build-mmi)
   const selectedAddress = useSelector(getSelectedAddress);
-  const custodianIcon = selectedAddress && useSelector((state) =>
-    getCustodianIconForAddress(state, selectedAddress)
+  const custodianIcon = useSelector((state) =>
+    getCustodianIconForAddress(state, selectedAddress),
   );
   ///: END:ONLY_INCLUDE_IN
 

--- a/ui/selectors/institutional/selectors.js
+++ b/ui/selectors/institutional/selectors.js
@@ -36,8 +36,11 @@ export function getConfiguredCustodians(state) {
 export function getCustodianIconForAddress(state, address) {
   let custodianIcon;
 
-  const checksummedAddress = toChecksumAddress(address);
-  if (state.metamask.custodyAccountDetails?.[checksummedAddress]) {
+  const checksummedAddress = address && toChecksumAddress(address);
+  if (
+    checksummedAddress &&
+    state.metamask.custodyAccountDetails?.[checksummedAddress]
+  ) {
     const { custodianName } =
       state.metamask.custodyAccountDetails[checksummedAddress];
     custodianIcon = state.metamask.mmiConfiguration?.custodians?.find(


### PR DESCRIPTION
## Explanation

This PR will allow the MMI build to run, allowing us to advance more. It moves one method from mmi-controller into the metamask-controller, because this method is needed in the preferences-controller, so it has to be passed into it when initiated in metamask-controller.
Adds the start command for the mmi build.
Adds a check for the custodianIcon before calling the useSelector.

Note: 
We plan to update/remove this logic soon from the preferences controller, in this task: https://consensyssoftware.atlassian.net/browse/MMI-3316
Where the goal is to replace it with a more generic one, (because eventually it will have to go to Core repo), by using the `EventEmitter` to do a `this.emit('update-mmi-portfolio')` every time an address gets added or removed. And then listen for this in our own MMI controller to do the logic in there.

## Pre-merge author checklist

- [X] I've clearly explained:
  - [X] What problem this PR is solving
  - [X] How this problem was solved

## Pre-merge reviewer checklist

- [X] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [X] PR is linked to the appropriate GitHub issue
