### PR TITLE
Fix #19437 - Prevent Connected Sites global menu item from being clicked during confirmation

### DIFF
--- a/ui/components/multichain/global-menu/global-menu.js
+++ b/ui/components/multichain/global-menu/global-menu.js
@@ -77,6 +77,7 @@ export const GlobalMenu = ({ closeMenu, anchorElement }) => {
     <Menu anchorElement={anchorElement} onHide={closeMenu}>
       <MenuItem
         iconName={IconName.Connect}
+        disabled={hasUnapprovedTransactions}
         onClick={() => {
           history.push(CONNECTED_ROUTE);
           trackEvent({

--- a/ui/components/multichain/global-menu/global-menu.js
+++ b/ui/components/multichain/global-menu/global-menu.js
@@ -89,6 +89,7 @@ export const GlobalMenu = ({ closeMenu, anchorElement }) => {
           });
           closeMenu();
         }}
+        data-testid="global-menu-connected-sites"
       >
         {t('connectedSites')}
       </MenuItem>

--- a/ui/components/multichain/global-menu/global-menu.test.js
+++ b/ui/components/multichain/global-menu/global-menu.test.js
@@ -67,6 +67,20 @@ describe('AccountListItem', () => {
     });
   });
 
+  it('disables the connected sites item when there is an active transaction', async () => {
+    const { getByTestId } = render();
+    await waitFor(() => {
+      expect(getByTestId('global-menu-connected-sites')).toBeDisabled();
+    });
+  });
+
+  it('enables the connected sites item when there is no active transaction', async () => {
+    const { getByTestId } = render({ unapprovedTxs: {} });
+    await waitFor(() => {
+      expect(getByTestId('global-menu-connected-sites')).toBeEnabled();
+    });
+  });
+
   it('expands metamask to tab when item is clicked', async () => {
     global.platform = { openExtensionInBrowser: jest.fn() };
 


### PR DESCRIPTION


## Explanation

Much like the "Settings" item which we recently disabled during confirmations, the Connected Sites item triggers a `history.push` navigation event which we need to prevent while the user is at the confirmation screen.

* Fixes #19437

## Manual Testing Steps

1.  Start a "Send", get to the confirmation screen
2. Click global menu
3. See that "Connected sites" is disabled.

## Pre-merge author checklist

- [ ] I've clearly explained:
  - [ ] What problem this PR is solving
  - [ ] How this problem was solved
  - [ ] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
