### PR TITLE
feature(19493): eliminate e2e flakyness for eth-sign

### DIFF
--- a/test/e2e/helpers.js
+++ b/test/e2e/helpers.js
@@ -546,9 +546,13 @@ async function waitForAccountRendered(driver) {
   );
 }
 
-const logInWithBalanceValidation = async (driver, ganacheServer) => {
+const login = async (driver) => {
   await driver.fill('#password', 'correct horse battery staple');
   await driver.press('#password', driver.Key.ENTER);
+};
+
+const logInWithBalanceValidation = async (driver, ganacheServer) => {
+  await login(driver);
   await assertAccountBalanceForDOM(driver, ganacheServer);
 };
 
@@ -579,6 +583,7 @@ module.exports = {
   defaultGanacheOptions,
   sendTransaction,
   findAnotherAccountFromAccountList,
+  login,
   logInWithBalanceValidation,
   assertAccountBalanceForDOM,
   locateAccountBalanceDOM,

--- a/test/e2e/tests/eth-sign.spec.js
+++ b/test/e2e/tests/eth-sign.spec.js
@@ -1,21 +1,12 @@
 const { strict: assert } = require('assert');
 const {
-  convertToHexValue,
   withFixtures,
   openDapp,
   DAPP_URL,
+  login,
+  defaultGanacheOptions,
 } = require('../helpers');
 const FixtureBuilder = require('../fixture-builder');
-
-const ganacheOptions = {
-  accounts: [
-    {
-      secretKey:
-        '0x7C9529A67102755B7E6102D6D950AC5D5863C98713805CEC576B945B15B71EAC',
-      balance: convertToHexValue(25000000000000000000),
-    },
-  ],
-};
 
 describe('Eth sign', function () {
   it('will detect if eth_sign is disabled', async function () {
@@ -25,13 +16,12 @@ describe('Eth sign', function () {
         fixtures: new FixtureBuilder()
           .withPermissionControllerConnectedToTestDapp()
           .build(),
-        ganacheOptions,
+        ganacheOptions: defaultGanacheOptions,
         title: this.test.title,
       },
       async ({ driver }) => {
         await driver.navigate();
-        await driver.fill('#password', 'correct horse battery staple');
-        await driver.press('#password', driver.Key.ENTER);
+        await login(driver);
 
         await openDapp(driver);
         await driver.clickElement('#ethSign');
@@ -61,13 +51,12 @@ describe('Eth sign', function () {
           })
           .withPermissionControllerConnectedToTestDapp()
           .build(),
-        ganacheOptions,
+        ganacheOptions: defaultGanacheOptions,
         title: this.test.title,
       },
       async ({ driver }) => {
         await driver.navigate();
-        await driver.fill('#password', 'correct horse battery staple');
-        await driver.press('#password', driver.Key.ENTER);
+        await login(driver);
 
         await openDapp(driver);
         await driver.clickElement('#ethSign');
@@ -80,18 +69,20 @@ describe('Eth sign', function () {
           windowHandles,
         );
 
-        const title = await driver.findElement(
-          '.request-signature__content__title',
-        );
-        const origin = await driver.findElement('.request-signature__origin');
-        assert.equal(await title.getText(), 'Signature request');
-        assert.equal(await origin.getText(), DAPP_URL);
+        await driver.findElement({
+          css: '.request-signature__content__title',
+          text: 'Signature request',
+        });
 
-        const personalMessageRow = await driver.findElement(
-          '.request-signature__row-value',
-        );
-        const personalMessage = await personalMessageRow.getText();
-        assert.equal(personalMessage, expectedPersonalMessage);
+        await driver.findElement({
+          css: '.request-signature__origin',
+          text: DAPP_URL,
+        });
+
+        await driver.findElement({
+          css: '.request-signature__row-value',
+          text: expectedPersonalMessage,
+        });
 
         await driver.clickElement('[data-testid="page-container-footer-next"]');
         await driver.clickElement(
@@ -103,8 +94,10 @@ describe('Eth sign', function () {
         await driver.switchToWindowWithTitle('E2E Test Dapp', windowHandles);
 
         // Verify
-        const result = await driver.findElement('#ethSignResult');
-        assert.equal(await result.getText(), expectedEthSignResult);
+        await driver.findElement({
+          css: '#ethSignResult',
+          text: expectedEthSignResult,
+        });
       },
     );
   });


### PR DESCRIPTION
Fixes https://github.com/MetaMask/metamask-extension/issues/19493


## Explanation
There's a racing condition in some e2e tests to find the dom and assert, and we'll try to avoid this pattern.

<!--
Thanks for the pull request. Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues, Slack conversations, Zendesk issues, user stories, etc. reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

## Screenshots/Screencaps

<!-- If you're making a change to the UI, make sure to capture a screenshot or a short video showing off your work! -->

### Before

<!-- How did the UI you changed look before your changes? Drag your file(s) below this line: -->

### After

<!-- How does it look now? Drag your file(s) below this line: -->

## Manual Testing Steps

<!--
How should reviewers and QA manually test your changes? For instance:

- Go to this screen
- Do this
- Then do this
-->

## Pre-merge author checklist

- [ ] I've clearly explained:
  - [ ] What problem this PR is solving
  - [ ] How this problem was solved
  - [ ] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
