### PR TITLE
UX: Ensure 'Connect Hardware' route is functioning properly

### DIFF
--- a/ui/helpers/constants/routes.ts
+++ b/ui/helpers/constants/routes.ts
@@ -25,6 +25,7 @@ const RESTORE_VAULT_ROUTE = '/restore-vault';
 const IMPORT_TOKEN_ROUTE = '/import-token';
 const CONFIRM_IMPORT_TOKEN_ROUTE = '/confirm-import-token';
 const CONFIRM_ADD_SUGGESTED_TOKEN_ROUTE = '/confirm-add-suggested-token';
+const NEW_ACCOUNT_ROUTE = '/new-account';
 const CONNECT_HARDWARE_ROUTE = '/new-account/connect';
 ///: BEGIN:ONLY_INCLUDE_IN(build-mmi)
 const CUSTODY_ACCOUNT_ROUTE = '/new-account/custody';
@@ -127,6 +128,7 @@ const PATH_NAME_MAP = {
   [IMPORT_TOKEN_ROUTE]: 'Import Token Page',
   [CONFIRM_IMPORT_TOKEN_ROUTE]: 'Confirm Import Token Page',
   [CONFIRM_ADD_SUGGESTED_TOKEN_ROUTE]: 'Confirm Add Suggested Token Page',
+  [NEW_ACCOUNT_ROUTE]: 'New Account Page',
   [CONNECT_HARDWARE_ROUTE]: 'Connect Hardware Wallet Page',
   ///: BEGIN:ONLY_INCLUDE_IN(build-mmi)
   [INSTITUTIONAL_FEATURES_DONE_ROUTE]: 'Institutional Features Done Page',
@@ -190,6 +192,7 @@ export {
   IMPORT_TOKEN_ROUTE,
   CONFIRM_IMPORT_TOKEN_ROUTE,
   CONFIRM_ADD_SUGGESTED_TOKEN_ROUTE,
+  NEW_ACCOUNT_ROUTE,
   CONNECT_HARDWARE_ROUTE,
   SEND_ROUTE,
   TOKEN_DETAILS,

--- a/ui/pages/pages.scss
+++ b/ui/pages/pages.scss
@@ -11,6 +11,7 @@
 @import 'connected-sites/index';
 @import 'connected-accounts/index';
 @import 'connected-sites/index';
+@import 'create-account/connect-hardware/index';
 @import "institutional/connect-custody/index";
 @import "institutional/custody/index";
 @import "institutional/institutional-entity-done-page/index";

--- a/ui/pages/routes/routes.component.js
+++ b/ui/pages/routes/routes.component.js
@@ -22,6 +22,7 @@ import ImportTokenPage from '../import-token';
 import AddNftPage from '../add-nft';
 import ConfirmImportTokenPage from '../confirm-import-token';
 import ConfirmAddSuggestedTokenPage from '../confirm-add-suggested-token';
+import CreateAccountPage from '../create-account/create-account.component';
 import Loading from '../../components/ui/loading-screen';
 import LoadingNetwork from '../../components/app/loading-network-screen';
 import { Modal } from '../../components/app/modals';
@@ -62,6 +63,7 @@ import {
   CONNECT_ROUTE,
   DEFAULT_ROUTE,
   LOCK_ROUTE,
+  NEW_ACCOUNT_ROUTE,
   RESTORE_VAULT_ROUTE,
   REVEAL_SEED_ROUTE,
   SEND_ROUTE,
@@ -90,7 +92,6 @@ import {
   DESKTOP_PAIRING_ROUTE,
   DESKTOP_ERROR_ROUTE,
   ///: END:ONLY_INCLUDE_IN
-  CONNECT_HARDWARE_ROUTE,
 } from '../../helpers/constants/routes';
 
 ///: BEGIN:ONLY_INCLUDE_IN(desktop)
@@ -110,7 +111,6 @@ import { SEND_STAGES } from '../../ducks/send';
 import DeprecatedTestNetworks from '../../components/ui/deprecated-test-networks/deprecated-test-networks';
 import NewNetworkInfo from '../../components/ui/new-network-info/new-network-info';
 import { ThemeType } from '../../../shared/constants/preferences';
-import CreateAccountPage from '../create-account/create-account.component';
 
 export default class Routes extends Component {
   static propTypes = {
@@ -326,7 +326,7 @@ export default class Routes extends Component {
         {
           ///: END:ONLY_INCLUDE_IN
         }
-        <Authenticated path={CONNECT_HARDWARE_ROUTE} component={CreateAccountPage} />
+        <Authenticated path={NEW_ACCOUNT_ROUTE} component={CreateAccountPage} />
         <Authenticated
           path={`${CONNECT_ROUTE}/:id`}
           component={PermissionsConnect}

--- a/ui/pages/routes/routes.component.js
+++ b/ui/pages/routes/routes.component.js
@@ -90,6 +90,7 @@ import {
   DESKTOP_PAIRING_ROUTE,
   DESKTOP_ERROR_ROUTE,
   ///: END:ONLY_INCLUDE_IN
+  CONNECT_HARDWARE_ROUTE,
 } from '../../helpers/constants/routes';
 
 ///: BEGIN:ONLY_INCLUDE_IN(desktop)
@@ -109,6 +110,7 @@ import { SEND_STAGES } from '../../ducks/send';
 import DeprecatedTestNetworks from '../../components/ui/deprecated-test-networks/deprecated-test-networks';
 import NewNetworkInfo from '../../components/ui/new-network-info/new-network-info';
 import { ThemeType } from '../../../shared/constants/preferences';
+import CreateAccountPage from '../create-account/create-account.component';
 
 export default class Routes extends Component {
   static propTypes = {
@@ -324,6 +326,7 @@ export default class Routes extends Component {
         {
           ///: END:ONLY_INCLUDE_IN
         }
+        <Authenticated path={CONNECT_HARDWARE_ROUTE} component={CreateAccountPage} />
         <Authenticated
           path={`${CONNECT_ROUTE}/:id`}
           component={PermissionsConnect}


### PR DESCRIPTION
## Explanation

Unfortunately with https://github.com/MetaMask/metamask-extension/pull/19346 we removed a stylesheet and route connection which made the Connect Hardware screen impossible to get to.  It also broke styling.  This PR restores the route and fixes the formatting

## Screenshots/Screencaps

<img width="779" alt="SCR-20230615-iovf" src="https://github.com/MetaMask/metamask-extension/assets/46655/c556789f-e982-48d7-89e7-d73eaf0b7958">


## Manual Testing Steps

1.  Open the Accounts picker
2. Click "Hardware wallet"
3. See everything good and working!

## Pre-merge author checklist

- [ ] I've clearly explained:
  - [ ] What problem this PR is solving
  - [ ] How this problem was solved
  - [ ] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
