### PR TITLE
Fix #19608 - Make account name validation more strict

### DIFF
--- a/ui/helpers/utils/accounts.js
+++ b/ui/helpers/utils/accounts.js
@@ -7,7 +7,7 @@ export function getAccountNameErrorMessage(
   defaultAccountName,
 ) {
   const isDuplicateAccountName = accounts.some(
-    (item) => item.name === newAccountName,
+    (item) => item.name.toLowerCase() === newAccountName.toLowerCase(),
   );
 
   const isEmptyAccountName = newAccountName === '';
@@ -25,7 +25,7 @@ export function getAccountNameErrorMessage(
   const isReservedAccountName = reservedRegEx.test(newAccountName);
 
   const isValidAccountName =
-    newAccountName === defaultAccountName || // What is written in the text field is the same as the placeholder
+    newAccountName.toLowerCase() === defaultAccountName.toLowerCase() || // What is written in the text field is the same as the placeholder
     (!isDuplicateAccountName && !isReservedAccountName && !isEmptyAccountName);
 
   let errorMessage;

--- a/ui/helpers/utils/accounts.test.js
+++ b/ui/helpers/utils/accounts.test.js
@@ -1,0 +1,47 @@
+import { getAccountNameErrorMessage } from './accounts';
+
+const mockAccounts = [{ name: 'Account 1' }, { name: 'Account 2' }];
+
+const mockLocalization = { t: jest.fn().mockReturnValue('Account') };
+
+describe('Accounts', () => {
+  it('does not allow duplicate names', () => {
+    const { isValidAccountName } = getAccountNameErrorMessage(
+      mockAccounts,
+      mockLocalization,
+      'Account 2',
+      'Account 3',
+    );
+    expect(isValidAccountName).toBe(false);
+  });
+
+  it('does not allow reserved name patterns', () => {
+    const { isValidAccountName } = getAccountNameErrorMessage(
+      mockAccounts,
+      mockLocalization,
+      'Account 7',
+      'Account 3',
+    );
+    expect(isValidAccountName).toBe(false);
+  });
+
+  it('does not allow reserved name patterns in lowercase', () => {
+    const { isValidAccountName } = getAccountNameErrorMessage(
+      mockAccounts,
+      mockLocalization,
+      'account 7',
+      'Account 3',
+    );
+    expect(isValidAccountName).toBe(false);
+  });
+
+  it('allows proposed name in lowercase', () => {
+    const { isValidAccountName } = getAccountNameErrorMessage(
+      mockAccounts,
+      mockLocalization,
+      'account 3',
+      'Account 3',
+    );
+    expect(isValidAccountName).toBe(true);
+  });
+});


### PR DESCRIPTION
## Explanation
 
* Fixes #19608

"account 2" was being flagged as a "reserved" name even though there was no "Account 2", so the root issue is casing.

## Manual Testing Steps

1. Create a fresh wallet with Account 1
2. Add another account called "account 2"  -- should work
3. Add another account called "Account 3" -- should work
4. Try to add another account called "account 3" -- should be flagged as bad

## Pre-merge author checklist

- [ ] I've clearly explained:
  - [ ] What problem this PR is solving
  - [ ] How this problem was solved
  - [ ] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
