### PR TITLE
[MMI] Adds the "Institutional" name to the extension card

### DIFF
--- a/development/build/manifest.js
+++ b/development/build/manifest.js
@@ -135,9 +135,12 @@ function createManifestTasks({
       .trim()
       .substring(0, 8);
 
-    manifest.name = `MetaMask ${capitalize(
-      buildType,
-    )}${mv3Str}${lavamoatStr}${snowStr}`;
+    const buildName =
+      buildType === 'mmi'
+        ? `MetaMask Institutional ${mv3Str}${lavamoatStr}${snowStr}`
+        : `MetaMask ${capitalize(buildType)}${mv3Str}${lavamoatStr}${snowStr}`;
+
+    manifest.name = buildName;
 
     manifest.description = `${environment} build from git id: ${gitRevisionStr}`;
   }


### PR DESCRIPTION
## Explanation
This adds the MMI name in the extension card, in the browser extensions page, before it just showed "MetaMask".
<img width="436" alt="Screenshot 2023-06-15 at 17 20 16" src="https://github.com/MetaMask/metamask-extension/assets/1125631/b61d29a1-3a43-4a3b-8e98-79b128c3a424">


## Pre-merge author checklist

- [X] I've clearly explained:
  - [X] What problem this PR is solving
  - [X] How this problem was solved

## Pre-merge reviewer checklist

- [X] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
