### PR TITLE
[FLASK] Update rate limits for `showInAppNotification` and `showNativeNotification`

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -919,8 +919,8 @@ export default class MetamaskController extends EventEmitter {
 
             return null;
           },
-          // 4 calls per 5 minutes
-          rateLimitCount: 4,
+          // 2 calls per 5 minutes
+          rateLimitCount: 2,
           rateLimitTimeout: 300000,
         },
         showInAppNotification: {

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -919,6 +919,9 @@ export default class MetamaskController extends EventEmitter {
 
             return null;
           },
+          // 4 calls per 5 minutes
+          rateLimitCount: 4,
+          rateLimitTimeout: 300000,
         },
         showInAppNotification: {
           method: (origin, message) => {
@@ -930,6 +933,9 @@ export default class MetamaskController extends EventEmitter {
 
             return null;
           },
+          // 5 calls per minute
+          rateLimitCount: 5,
+          rateLimitTimeout: 60000,
         },
       },
     });


### PR DESCRIPTION
## Explanation

This updates the rate limits of `showInAppNotification` and `showNativeNotification` in the `RateLimitController` config.

 - Native notifications are now set to 2 notifications per 5 minutes
 - In app notifications are now set to 5 per minute
 

Fixes https://github.com/MetaMask/snaps/issues/1374

## Manual Testing Steps

 - Try to send more then the allowed amount of notifications with the notification test-snap.