### PR TITLE
signature approved metrics e2e test

### DIFF
--- a/test/e2e/helpers.js
+++ b/test/e2e/helpers.js
@@ -674,6 +674,19 @@ async function terminateServiceWorker(driver) {
   await driver.closeWindowHandle(serviceWorkerTab);
 }
 
+/**
+ * This method assumes the extension is open, the dapp is open and waits for a
+ * third window handle to open (the notification window). Once it does it
+ * switches to the new window.
+ *
+ * @param {WebDriver} driver
+ */
+async function switchToNotificationWindow(driver) {
+  await driver.waitUntilXWindowHandles(3);
+  const windowHandles = await driver.getAllWindowHandles();
+  await driver.switchToWindowWithTitle('MetaMask Notification', windowHandles);
+}
+
 module.exports = {
   DAPP_URL,
   DAPP_ONE_URL,
@@ -720,4 +733,5 @@ module.exports = {
   switchToWindow,
   sleepSeconds,
   terminateServiceWorker,
+  switchToNotificationWindow,
 };

--- a/test/e2e/metrics/signature-approved.spec.js
+++ b/test/e2e/metrics/signature-approved.spec.js
@@ -1,25 +1,12 @@
 const { strict: assert } = require('assert');
 const {
-  convertToHexValue,
+  defaultGanacheOptions,
   withFixtures,
   regularDelayMs,
   openDapp,
   unlockWallet,
 } = require('../helpers');
 const FixtureBuilder = require('../fixture-builder');
-
-/**
- * Shared Ganache options for every test in this suite.
- */
-const ganacheOptions = {
-  accounts: [
-    {
-      secretKey:
-        '0x7C9529A67102755B7E6102D6D950AC5D5863C98713805CEC576B945B15B71EAC',
-      balance: convertToHexValue(25000000000000000000),
-    },
-  ],
-};
 
 /**
  * mocks the segment api multiple times for specific payloads that we expect to
@@ -135,7 +122,7 @@ describe('Signature Approved Event', function () {
             participateInMetaMetrics: true,
           })
           .build(),
-        ganacheOptions,
+        defaultGanacheOptions,
         title: this.test.title,
         testSpecificMock: mockSegment,
       },
@@ -178,7 +165,7 @@ describe('Signature Approved Event', function () {
             participateInMetaMetrics: true,
           })
           .build(),
-        ganacheOptions,
+        defaultGanacheOptions,
         title: this.test.title,
         testSpecificMock: mockSegment,
       },
@@ -221,7 +208,7 @@ describe('Signature Approved Event', function () {
             participateInMetaMetrics: true,
           })
           .build(),
-        ganacheOptions,
+        defaultGanacheOptions,
         title: this.test.title,
         testSpecificMock: mockSegment,
       },
@@ -263,7 +250,7 @@ describe('Signature Approved Event', function () {
             participateInMetaMetrics: true,
           })
           .build(),
-        ganacheOptions,
+        defaultGanacheOptions,
         title: this.test.title,
         testSpecificMock: mockSegment,
       },
@@ -310,7 +297,7 @@ describe('Signature Approved Event', function () {
             participateInMetaMetrics: true,
           })
           .build(),
-        ganacheOptions,
+        defaultGanacheOptions,
         title: this.test.title,
         testSpecificMock: mockSegment,
       },

--- a/test/e2e/metrics/signature-approved.spec.js
+++ b/test/e2e/metrics/signature-approved.spec.js
@@ -1,0 +1,98 @@
+const { strict: assert } = require('assert');
+const {
+  convertToHexValue,
+  withFixtures,
+  regularDelayMs,
+  openDapp,
+} = require('../helpers');
+const FixtureBuilder = require('../fixture-builder');
+
+describe('Signature Approved Event', function () {
+  async function mockSegment(mockServer) {
+    return await mockServer
+      .forPost('https://api.segment.io/v1/batch')
+      .withJsonBodyIncluding({
+        batch: [{ type: 'track', event: 'Signature Approved' }],
+      })
+      .thenCallback(() => {
+        return {
+          statusCode: 200,
+        };
+      });
+  }
+  it('Successfully tracked for signTypedData_v4', async function () {
+    const ganacheOptions = {
+      accounts: [
+        {
+          secretKey:
+            '0x7C9529A67102755B7E6102D6D950AC5D5863C98713805CEC576B945B15B71EAC',
+          balance: convertToHexValue(25000000000000000000),
+        },
+      ],
+    };
+    await withFixtures(
+      {
+        dapp: true,
+        fixtures: new FixtureBuilder()
+          .withPermissionControllerConnectedToTestDapp()
+          .withMetaMetricsController({
+            metaMetricsId: 'fake-metrics-id',
+            participateInMetaMetrics: true,
+          })
+          .build(),
+        ganacheOptions,
+        title: this.test.title,
+        testSpecificMock: mockSegment,
+      },
+      async ({ driver, mockedEndpoint }) => {
+        await driver.navigate();
+        await driver.fill('#password', 'correct horse battery staple');
+        await driver.press('#password', driver.Key.ENTER);
+
+        await openDapp(driver);
+
+        // creates a sign typed data signature request
+        await driver.clickElement('#signTypedDataV4');
+
+        await driver.waitUntilXWindowHandles(3);
+        let windowHandles = await driver.getAllWindowHandles();
+        await driver.switchToWindowWithTitle(
+          'MetaMask Notification',
+          windowHandles,
+        );
+
+        const verifyContractDetailsButton = await driver.findElement(
+          '.signature-request-content__verify-contract-details',
+        );
+
+        verifyContractDetailsButton.click();
+        await driver.clickElement({ text: 'Got it', tag: 'button' });
+
+        // Approve signing typed data
+        await driver.clickElement(
+          '[data-testid="signature-request-scroll-button"]',
+        );
+        await driver.delay(regularDelayMs);
+        await driver.clickElement({ text: 'Sign', tag: 'button' });
+        await driver.waitUntilXWindowHandles(2);
+        windowHandles = await driver.getAllWindowHandles();
+
+        await driver.wait(async () => {
+          const isPending = await mockedEndpoint.isPending();
+          return isPending === false;
+        }, 10000);
+        const mockedRequests = await mockedEndpoint.getSeenRequests();
+        const payloads = mockedRequests
+          .map((req) => req.body.json.batch)
+          .flat();
+        assert.deepStrictEqual(payloads[0].properties, {
+          signature_type: 'eth_signTypedData_v4',
+          category: 'inpage_provider',
+          locale: 'en',
+          chain_id: '0x539',
+          environment_type: 'background',
+        });
+      },
+    );
+  });
+});

--- a/test/e2e/metrics/signature-approved.spec.js
+++ b/test/e2e/metrics/signature-approved.spec.js
@@ -4,9 +4,13 @@ const {
   withFixtures,
   regularDelayMs,
   openDapp,
+  login,
 } = require('../helpers');
 const FixtureBuilder = require('../fixture-builder');
 
+/**
+ * Shared Ganache options for every test in this suite.
+ */
 const ganacheOptions = {
   accounts: [
     {
@@ -17,6 +21,16 @@ const ganacheOptions = {
   ],
 };
 
+/**
+ * mocks the segment api multiple times for specific payloads that we expect to
+ * see when these tests are run. In this case we are looking for
+ * 'Signature Requested' and 'Signature Received'. Do not use the constants
+ * from the metrics constants files, because if these change we want a strong
+ * indicator to our data team that the shape of data will change.
+ *
+ * @param {import('mockttp').Mockttp} mockServer
+ * @returns {Promise<import('mockttp/dist/pluggable-admin').MockttpClientResponse>[]}
+ */
 async function mockSegment(mockServer) {
   return [
     await mockServer
@@ -42,113 +56,295 @@ async function mockSegment(mockServer) {
   ];
 }
 
-async function runSignatureTest(
-  testDappSigningMethodButtonId,
-  expectedMethodNameInPayload,
-  testTitle,
-  shouldVerifyContractDetails = true,
-) {
-  return await withFixtures(
-    {
-      dapp: true,
-      fixtures: new FixtureBuilder()
-        .withPermissionControllerConnectedToTestDapp()
-        .withMetaMetricsController({
-          metaMetricsId: 'fake-metrics-id',
-          participateInMetaMetrics: true,
-        })
-        .build(),
-      ganacheOptions,
-      title: testTitle,
-      testSpecificMock: mockSegment,
-    },
-    async ({ driver, mockedEndpoint: mockedEndpoints }) => {
-      await driver.navigate();
-      await driver.fill('#password', 'correct horse battery staple');
-      await driver.press('#password', driver.Key.ENTER);
+/**
+ * This method assumes the extension is open, the dapp is open and waits for a
+ * third window handle to open (the notification window). Once it does it
+ * switches to the new window.
+ *
+ * @param {WebDriver} driver
+ */
+async function switchToNotificationWindow(driver) {
+  await driver.waitUntilXWindowHandles(3);
+  const windowHandles = await driver.getAllWindowHandles();
+  await driver.switchToWindowWithTitle('MetaMask Notification', windowHandles);
+}
 
-      await openDapp(driver);
-
-      // creates a sign typed data signature request
-      await driver.clickElement(testDappSigningMethodButtonId);
-
-      await driver.waitUntilXWindowHandles(3);
-      let windowHandles = await driver.getAllWindowHandles();
-      await driver.switchToWindowWithTitle(
-        'MetaMask Notification',
-        windowHandles,
-      );
-
-      if (shouldVerifyContractDetails) {
-        const verifyContractDetailsButton = await driver.findElement(
-          '.signature-request-content__verify-contract-details',
-        );
-
-        verifyContractDetailsButton.click();
-        await driver.clickElement({ text: 'Got it', tag: 'button' });
-
-        // Approve signing typed data
-        await driver.clickElement(
-          '[data-testid="signature-request-scroll-button"]',
-        );
-        await driver.delay(regularDelayMs);
-      }
-
-      await driver.clickElement({ text: 'Sign', tag: 'button' });
-      await driver.waitUntilXWindowHandles(2);
-      windowHandles = await driver.getAllWindowHandles();
-
-      await driver.wait(async () => {
-        let isPending = true;
-        for (const mockedEndpoint of mockedEndpoints) {
-          isPending = await mockedEndpoint.isPending();
-        }
-        return isPending === false;
-      }, 10000);
-      const mockedRequests = [];
-      for (const mockedEndpoint of mockedEndpoints) {
-        mockedRequests.push(...(await mockedEndpoint.getSeenRequests()));
-      }
-      const payloads = mockedRequests.map((req) => req.body.json.batch).flat();
-      assert.deepStrictEqual(payloads[0].properties, {
-        signature_type: expectedMethodNameInPayload,
-        category: 'inpage_provider',
-        locale: 'en',
-        chain_id: '0x539',
-        environment_type: 'background',
-      });
-      assert.deepStrictEqual(payloads[1].properties, {
-        signature_type: expectedMethodNameInPayload,
-        category: 'inpage_provider',
-        locale: 'en',
-        chain_id: '0x539',
-        environment_type: 'background',
-      });
-    },
+/**
+ * Some signing methods have extra security that requires the user to click a
+ * button to validate that they have verified the details. This method handles
+ * performing the necessary steps to click that button.
+ *
+ * @param {WebDriver} driver
+ */
+async function validateContractDetails(driver) {
+  const verifyContractDetailsButton = await driver.findElement(
+    '.signature-request-content__verify-contract-details',
   );
+
+  verifyContractDetailsButton.click();
+  await driver.clickElement({ text: 'Got it', tag: 'button' });
+
+  // Approve signing typed data
+  await driver.clickElement('[data-testid="signature-request-scroll-button"]');
+  await driver.delay(regularDelayMs);
+}
+
+/**
+ * This method handles clicking the sign button on signature confrimation
+ * screen.
+ *
+ * @param {WebDriver} driver
+ */
+async function clickSignButtonAndGetEventPayloads(driver) {
+  await driver.clickElement({ text: 'Sign', tag: 'button' });
+  await driver.waitUntilXWindowHandles(2);
+  await driver.getAllWindowHandles();
+}
+
+/**
+ * This method handles getting the mocked requests to the segment server
+ *
+ * @param {WebDriver} driver
+ * @param {import('mockttp').Mockttp} mockedEndpoints
+ * @returns {import('mockttp/dist/pluggable-admin').MockttpClientResponse[]}
+ */
+async function getEventPayloads(driver, mockedEndpoints) {
+  await driver.wait(async () => {
+    let isPending = true;
+    for (const mockedEndpoint of mockedEndpoints) {
+      isPending = await mockedEndpoint.isPending();
+    }
+    return isPending === false;
+  }, 10000);
+  const mockedRequests = [];
+  for (const mockedEndpoint of mockedEndpoints) {
+    mockedRequests.push(...(await mockedEndpoint.getSeenRequests()));
+  }
+  return mockedRequests.map((req) => req.body.json.batch).flat();
 }
 
 describe('Signature Approved Event', function () {
   it('Successfully tracked for signTypedData_v4', async function () {
-    await runSignatureTest(
-      '#signTypedDataV4',
-      'eth_signTypedData_v4',
-      this.test.title,
+    await withFixtures(
+      {
+        dapp: true,
+        fixtures: new FixtureBuilder()
+          .withPermissionControllerConnectedToTestDapp()
+          .withMetaMetricsController({
+            metaMetricsId: 'fake-metrics-id',
+            participateInMetaMetrics: true,
+          })
+          .build(),
+        ganacheOptions,
+        title: this.test.title,
+        testSpecificMock: mockSegment,
+      },
+      async ({ driver, mockedEndpoint: mockedEndpoints }) => {
+        await driver.navigate();
+        await login(driver);
+        await openDapp(driver);
+
+        // creates a sign typed data signature request
+        await driver.clickElement('#signTypedDataV4');
+        await switchToNotificationWindow(driver);
+        await validateContractDetails(driver);
+        await clickSignButtonAndGetEventPayloads(driver);
+        const events = await getEventPayloads(driver, mockedEndpoints);
+        assert.deepStrictEqual(events[0].properties, {
+          signature_type: 'eth_signTypedData_v4',
+          category: 'inpage_provider',
+          locale: 'en',
+          chain_id: '0x539',
+          environment_type: 'background',
+        });
+        assert.deepStrictEqual(events[1].properties, {
+          signature_type: 'eth_signTypedData_v4',
+          category: 'inpage_provider',
+          locale: 'en',
+          chain_id: '0x539',
+          environment_type: 'background',
+        });
+      },
     );
   });
   it('Successfully tracked for signTypedData_v3', async function () {
-    await runSignatureTest(
-      '#signTypedDataV3',
-      'eth_signTypedData_v3',
-      this.test.title,
+    await withFixtures(
+      {
+        dapp: true,
+        fixtures: new FixtureBuilder()
+          .withPermissionControllerConnectedToTestDapp()
+          .withMetaMetricsController({
+            metaMetricsId: 'fake-metrics-id',
+            participateInMetaMetrics: true,
+          })
+          .build(),
+        ganacheOptions,
+        title: this.test.title,
+        testSpecificMock: mockSegment,
+      },
+      async ({ driver, mockedEndpoint: mockedEndpoints }) => {
+        await driver.navigate();
+        await login(driver);
+        await openDapp(driver);
+
+        // creates a sign typed data signature request
+        await driver.clickElement('#signTypedDataV3');
+        await switchToNotificationWindow(driver);
+        await validateContractDetails(driver);
+        await clickSignButtonAndGetEventPayloads(driver);
+        const events = await getEventPayloads(driver, mockedEndpoints);
+        assert.deepStrictEqual(events[0].properties, {
+          signature_type: 'eth_signTypedData_v3',
+          category: 'inpage_provider',
+          locale: 'en',
+          chain_id: '0x539',
+          environment_type: 'background',
+        });
+        assert.deepStrictEqual(events[1].properties, {
+          signature_type: 'eth_signTypedData_v3',
+          category: 'inpage_provider',
+          locale: 'en',
+          chain_id: '0x539',
+          environment_type: 'background',
+        });
+      },
     );
   });
   it('Successfully tracked for signTypedData', async function () {
-    await runSignatureTest(
-      '#signTypedData',
-      'eth_signTypedData',
-      this.test.title,
-      false,
+    await withFixtures(
+      {
+        dapp: true,
+        fixtures: new FixtureBuilder()
+          .withPermissionControllerConnectedToTestDapp()
+          .withMetaMetricsController({
+            metaMetricsId: 'fake-metrics-id',
+            participateInMetaMetrics: true,
+          })
+          .build(),
+        ganacheOptions,
+        title: this.test.title,
+        testSpecificMock: mockSegment,
+      },
+      async ({ driver, mockedEndpoint: mockedEndpoints }) => {
+        await driver.navigate();
+        await login(driver);
+        await openDapp(driver);
+
+        // creates a sign typed data signature request
+        await driver.clickElement('#signTypedData');
+        await switchToNotificationWindow(driver);
+        await clickSignButtonAndGetEventPayloads(driver);
+        const events = await getEventPayloads(driver, mockedEndpoints);
+        assert.deepStrictEqual(events[0].properties, {
+          signature_type: 'eth_signTypedData',
+          category: 'inpage_provider',
+          locale: 'en',
+          chain_id: '0x539',
+          environment_type: 'background',
+        });
+        assert.deepStrictEqual(events[1].properties, {
+          signature_type: 'eth_signTypedData',
+          category: 'inpage_provider',
+          locale: 'en',
+          chain_id: '0x539',
+          environment_type: 'background',
+        });
+      },
+    );
+  });
+  it('Successfully tracked for personalSign', async function () {
+    await withFixtures(
+      {
+        dapp: true,
+        fixtures: new FixtureBuilder()
+          .withPermissionControllerConnectedToTestDapp()
+          .withMetaMetricsController({
+            metaMetricsId: 'fake-metrics-id',
+            participateInMetaMetrics: true,
+          })
+          .build(),
+        ganacheOptions,
+        title: this.test.title,
+        testSpecificMock: mockSegment,
+      },
+      async ({ driver, mockedEndpoint: mockedEndpoints }) => {
+        await driver.navigate();
+        await login(driver);
+        await openDapp(driver);
+
+        // creates a sign typed data signature request
+        await driver.clickElement('#personalSign');
+        await switchToNotificationWindow(driver);
+        const events = await clickSignButtonAndGetEventPayloads(
+          driver,
+          mockedEndpoints,
+        );
+        assert.deepStrictEqual(events[0].properties, {
+          signature_type: 'personal_sign',
+          category: 'inpage_provider',
+          locale: 'en',
+          chain_id: '0x539',
+          environment_type: 'background',
+        });
+        assert.deepStrictEqual(events[1].properties, {
+          signature_type: 'personal_sign',
+          category: 'inpage_provider',
+          locale: 'en',
+          chain_id: '0x539',
+          environment_type: 'background',
+        });
+      },
+    );
+  });
+  it('Successfully tracked for eth_sign', async function () {
+    await withFixtures(
+      {
+        dapp: true,
+        fixtures: new FixtureBuilder()
+          .withPermissionControllerConnectedToTestDapp()
+          .withPreferencesController({
+            disabledRpcMethodPreferences: {
+              eth_sign: true,
+            },
+          })
+          .withMetaMetricsController({
+            metaMetricsId: 'fake-metrics-id',
+            participateInMetaMetrics: true,
+          })
+          .build(),
+        ganacheOptions,
+        title: this.test.title,
+        testSpecificMock: mockSegment,
+      },
+      async ({ driver, mockedEndpoint: mockedEndpoints }) => {
+        await driver.navigate();
+        await login(driver);
+        await openDapp(driver);
+
+        // creates a sign typed data signature request
+        await driver.clickElement('#ethSign');
+        await switchToNotificationWindow(driver);
+        await driver.delay(regularDelayMs);
+        await driver.clickElement('[data-testid="page-container-footer-next"]');
+        await driver.clickElement(
+          '.signature-request-warning__footer__sign-button',
+        );
+        const events = await getEventPayloads(driver, mockedEndpoints);
+        assert.deepStrictEqual(events[0].properties, {
+          signature_type: 'eth_sign',
+          category: 'inpage_provider',
+          locale: 'en',
+          chain_id: '0x539',
+          environment_type: 'background',
+        });
+        assert.deepStrictEqual(events[1].properties, {
+          signature_type: 'eth_sign',
+          category: 'inpage_provider',
+          locale: 'en',
+          chain_id: '0x539',
+          environment_type: 'background',
+        });
+      },
     );
   });
 });

--- a/test/e2e/metrics/signature-approved.spec.js
+++ b/test/e2e/metrics/signature-approved.spec.js
@@ -1,6 +1,7 @@
 const { strict: assert } = require('assert');
 const {
   defaultGanacheOptions,
+  switchToNotificationWindow,
   withFixtures,
   regularDelayMs,
   openDapp,
@@ -41,19 +42,6 @@ async function mockSegment(mockServer) {
         };
       }),
   ];
-}
-
-/**
- * This method assumes the extension is open, the dapp is open and waits for a
- * third window handle to open (the notification window). Once it does it
- * switches to the new window.
- *
- * @param {WebDriver} driver
- */
-async function switchToNotificationWindow(driver) {
-  await driver.waitUntilXWindowHandles(3);
-  const windowHandles = await driver.getAllWindowHandles();
-  await driver.switchToWindowWithTitle('MetaMask Notification', windowHandles);
 }
 
 /**

--- a/test/e2e/metrics/signature-approved.spec.js
+++ b/test/e2e/metrics/signature-approved.spec.js
@@ -4,7 +4,7 @@ const {
   withFixtures,
   regularDelayMs,
   openDapp,
-  login,
+  unlockWallet,
 } = require('../helpers');
 const FixtureBuilder = require('../fixture-builder');
 
@@ -95,7 +95,7 @@ async function validateContractDetails(driver) {
  *
  * @param {WebDriver} driver
  */
-async function clickSignButtonAndGetEventPayloads(driver) {
+async function clickSignOnSignatureConfirmation(driver) {
   await driver.clickElement({ text: 'Sign', tag: 'button' });
   await driver.waitUntilXWindowHandles(2);
   await driver.getAllWindowHandles();
@@ -141,14 +141,14 @@ describe('Signature Approved Event', function () {
       },
       async ({ driver, mockedEndpoint: mockedEndpoints }) => {
         await driver.navigate();
-        await login(driver);
+        await unlockWallet(driver);
         await openDapp(driver);
 
         // creates a sign typed data signature request
         await driver.clickElement('#signTypedDataV4');
         await switchToNotificationWindow(driver);
         await validateContractDetails(driver);
-        await clickSignButtonAndGetEventPayloads(driver);
+        await clickSignOnSignatureConfirmation(driver);
         const events = await getEventPayloads(driver, mockedEndpoints);
         assert.deepStrictEqual(events[0].properties, {
           signature_type: 'eth_signTypedData_v4',
@@ -184,14 +184,14 @@ describe('Signature Approved Event', function () {
       },
       async ({ driver, mockedEndpoint: mockedEndpoints }) => {
         await driver.navigate();
-        await login(driver);
+        await unlockWallet(driver);
         await openDapp(driver);
 
         // creates a sign typed data signature request
         await driver.clickElement('#signTypedDataV3');
         await switchToNotificationWindow(driver);
         await validateContractDetails(driver);
-        await clickSignButtonAndGetEventPayloads(driver);
+        await clickSignOnSignatureConfirmation(driver);
         const events = await getEventPayloads(driver, mockedEndpoints);
         assert.deepStrictEqual(events[0].properties, {
           signature_type: 'eth_signTypedData_v3',
@@ -227,13 +227,13 @@ describe('Signature Approved Event', function () {
       },
       async ({ driver, mockedEndpoint: mockedEndpoints }) => {
         await driver.navigate();
-        await login(driver);
+        await unlockWallet(driver);
         await openDapp(driver);
 
         // creates a sign typed data signature request
         await driver.clickElement('#signTypedData');
         await switchToNotificationWindow(driver);
-        await clickSignButtonAndGetEventPayloads(driver);
+        await clickSignOnSignatureConfirmation(driver);
         const events = await getEventPayloads(driver, mockedEndpoints);
         assert.deepStrictEqual(events[0].properties, {
           signature_type: 'eth_signTypedData',
@@ -269,16 +269,14 @@ describe('Signature Approved Event', function () {
       },
       async ({ driver, mockedEndpoint: mockedEndpoints }) => {
         await driver.navigate();
-        await login(driver);
+        await unlockWallet(driver);
         await openDapp(driver);
 
         // creates a sign typed data signature request
         await driver.clickElement('#personalSign');
         await switchToNotificationWindow(driver);
-        const events = await clickSignButtonAndGetEventPayloads(
-          driver,
-          mockedEndpoints,
-        );
+        await clickSignOnSignatureConfirmation(driver);
+        const events = await getEventPayloads(driver, mockedEndpoints);
         assert.deepStrictEqual(events[0].properties, {
           signature_type: 'personal_sign',
           category: 'inpage_provider',
@@ -318,7 +316,7 @@ describe('Signature Approved Event', function () {
       },
       async ({ driver, mockedEndpoint: mockedEndpoints }) => {
         await driver.navigate();
-        await login(driver);
+        await unlockWallet(driver);
         await openDapp(driver);
 
         // creates a sign typed data signature request

--- a/test/e2e/metrics/signature-approved.spec.js
+++ b/test/e2e/metrics/signature-approved.spec.js
@@ -7,9 +7,29 @@ const {
 } = require('../helpers');
 const FixtureBuilder = require('../fixture-builder');
 
-describe('Signature Approved Event', function () {
-  async function mockSegment(mockServer) {
-    return await mockServer
+const ganacheOptions = {
+  accounts: [
+    {
+      secretKey:
+        '0x7C9529A67102755B7E6102D6D950AC5D5863C98713805CEC576B945B15B71EAC',
+      balance: convertToHexValue(25000000000000000000),
+    },
+  ],
+};
+
+async function mockSegment(mockServer) {
+  return [
+    await mockServer
+      .forPost('https://api.segment.io/v1/batch')
+      .withJsonBodyIncluding({
+        batch: [{ type: 'track', event: 'Signature Requested' }],
+      })
+      .thenCallback(() => {
+        return {
+          statusCode: 200,
+        };
+      }),
+    await mockServer
       .forPost('https://api.segment.io/v1/batch')
       .withJsonBodyIncluding({
         batch: [{ type: 'track', event: 'Signature Approved' }],
@@ -18,49 +38,48 @@ describe('Signature Approved Event', function () {
         return {
           statusCode: 200,
         };
-      });
-  }
-  it('Successfully tracked for signTypedData_v4', async function () {
-    const ganacheOptions = {
-      accounts: [
-        {
-          secretKey:
-            '0x7C9529A67102755B7E6102D6D950AC5D5863C98713805CEC576B945B15B71EAC',
-          balance: convertToHexValue(25000000000000000000),
-        },
-      ],
-    };
-    await withFixtures(
-      {
-        dapp: true,
-        fixtures: new FixtureBuilder()
-          .withPermissionControllerConnectedToTestDapp()
-          .withMetaMetricsController({
-            metaMetricsId: 'fake-metrics-id',
-            participateInMetaMetrics: true,
-          })
-          .build(),
-        ganacheOptions,
-        title: this.test.title,
-        testSpecificMock: mockSegment,
-      },
-      async ({ driver, mockedEndpoint }) => {
-        await driver.navigate();
-        await driver.fill('#password', 'correct horse battery staple');
-        await driver.press('#password', driver.Key.ENTER);
+      }),
+  ];
+}
 
-        await openDapp(driver);
+async function runSignatureTest(
+  testDappSigningMethodButtonId,
+  expectedMethodNameInPayload,
+  testTitle,
+  shouldVerifyContractDetails = true,
+) {
+  return await withFixtures(
+    {
+      dapp: true,
+      fixtures: new FixtureBuilder()
+        .withPermissionControllerConnectedToTestDapp()
+        .withMetaMetricsController({
+          metaMetricsId: 'fake-metrics-id',
+          participateInMetaMetrics: true,
+        })
+        .build(),
+      ganacheOptions,
+      title: testTitle,
+      testSpecificMock: mockSegment,
+    },
+    async ({ driver, mockedEndpoint: mockedEndpoints }) => {
+      await driver.navigate();
+      await driver.fill('#password', 'correct horse battery staple');
+      await driver.press('#password', driver.Key.ENTER);
 
-        // creates a sign typed data signature request
-        await driver.clickElement('#signTypedDataV4');
+      await openDapp(driver);
 
-        await driver.waitUntilXWindowHandles(3);
-        let windowHandles = await driver.getAllWindowHandles();
-        await driver.switchToWindowWithTitle(
-          'MetaMask Notification',
-          windowHandles,
-        );
+      // creates a sign typed data signature request
+      await driver.clickElement(testDappSigningMethodButtonId);
 
+      await driver.waitUntilXWindowHandles(3);
+      let windowHandles = await driver.getAllWindowHandles();
+      await driver.switchToWindowWithTitle(
+        'MetaMask Notification',
+        windowHandles,
+      );
+
+      if (shouldVerifyContractDetails) {
         const verifyContractDetailsButton = await driver.findElement(
           '.signature-request-content__verify-contract-details',
         );
@@ -73,26 +92,63 @@ describe('Signature Approved Event', function () {
           '[data-testid="signature-request-scroll-button"]',
         );
         await driver.delay(regularDelayMs);
-        await driver.clickElement({ text: 'Sign', tag: 'button' });
-        await driver.waitUntilXWindowHandles(2);
-        windowHandles = await driver.getAllWindowHandles();
+      }
 
-        await driver.wait(async () => {
-          const isPending = await mockedEndpoint.isPending();
-          return isPending === false;
-        }, 10000);
-        const mockedRequests = await mockedEndpoint.getSeenRequests();
-        const payloads = mockedRequests
-          .map((req) => req.body.json.batch)
-          .flat();
-        assert.deepStrictEqual(payloads[0].properties, {
-          signature_type: 'eth_signTypedData_v4',
-          category: 'inpage_provider',
-          locale: 'en',
-          chain_id: '0x539',
-          environment_type: 'background',
-        });
-      },
+      await driver.clickElement({ text: 'Sign', tag: 'button' });
+      await driver.waitUntilXWindowHandles(2);
+      windowHandles = await driver.getAllWindowHandles();
+
+      await driver.wait(async () => {
+        let isPending = true;
+        for (const mockedEndpoint of mockedEndpoints) {
+          isPending = await mockedEndpoint.isPending();
+        }
+        return isPending === false;
+      }, 10000);
+      const mockedRequests = [];
+      for (const mockedEndpoint of mockedEndpoints) {
+        mockedRequests.push(...(await mockedEndpoint.getSeenRequests()));
+      }
+      const payloads = mockedRequests.map((req) => req.body.json.batch).flat();
+      assert.deepStrictEqual(payloads[0].properties, {
+        signature_type: expectedMethodNameInPayload,
+        category: 'inpage_provider',
+        locale: 'en',
+        chain_id: '0x539',
+        environment_type: 'background',
+      });
+      assert.deepStrictEqual(payloads[1].properties, {
+        signature_type: expectedMethodNameInPayload,
+        category: 'inpage_provider',
+        locale: 'en',
+        chain_id: '0x539',
+        environment_type: 'background',
+      });
+    },
+  );
+}
+
+describe('Signature Approved Event', function () {
+  it('Successfully tracked for signTypedData_v4', async function () {
+    await runSignatureTest(
+      '#signTypedDataV4',
+      'eth_signTypedData_v4',
+      this.test.title,
+    );
+  });
+  it('Successfully tracked for signTypedData_v3', async function () {
+    await runSignatureTest(
+      '#signTypedDataV3',
+      'eth_signTypedData_v3',
+      this.test.title,
+    );
+  });
+  it('Successfully tracked for signTypedData', async function () {
+    await runSignatureTest(
+      '#signTypedData',
+      'eth_signTypedData',
+      this.test.title,
+      false,
     );
   });
 });

--- a/test/e2e/run-all.js
+++ b/test/e2e/run-all.js
@@ -72,6 +72,7 @@ async function main() {
       ...(await getTestPathsForTestDir(testDir)),
       ...(await getTestPathsForTestDir(path.join(__dirname, 'swaps'))),
       ...(await getTestPathsForTestDir(path.join(__dirname, 'nft'))),
+      ...(await getTestPathsForTestDir(path.join(__dirname, 'metrics'))),
       path.join(__dirname, 'metamask-ui.spec.js'),
     ];
 


### PR DESCRIPTION
## Explanation
Part of #19261 

Implements E2E tests to ensure that signing signature requests results in requested and approved events being fired to segment. This is important so that if anything changes we are alerted before mixpanel reflects a disturbance in our business metrics. These events are only fired for users who opt-in to metametrics so the controller for MetaMetrics is mocked out to have the opt-in flag set to true. 

## Manual Testing Steps
- No functional changes were made in this PR, this should be primarily code review and review of the resulting test runs in CI

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [x] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
