### PR TITLE
Fix searchable item list height

### DIFF
--- a/ui/pages/swaps/list-with-search/index.scss
+++ b/ui/pages/swaps/list-with-search/index.scss
@@ -1,12 +1,12 @@
 .list-with-search {
   .searchable-item-list {
     &__list-container {
-      height: 320px;
+      max-height: 320px;
       overflow-y: auto;
       padding-right: 8px;
 
       @include screen-sm-min {
-        height: 600px;
+        max-height: 600px;
       }
     }
   }


### PR DESCRIPTION
## Explanation
We want to use the max-height property to make the list flexible in case there is only 1 item (e.g. after filtering).