### PR TITLE
feat(action): remove labels after PR closed

### DIFF
--- a/.github/workflows/remove-labels-after-pr-closed.yml
+++ b/.github/workflows/remove-labels-after-pr-closed.yml
@@ -1,0 +1,40 @@
+name: Remove labels after issue (or PR) closed
+
+on:
+  issues:
+    types: [closed]
+  pull_request:
+    types: [closed]
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Remove labels
+      env:
+        REPO: ${{ github.repository }}
+        ISSUE_NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      run: |
+        LABELS=(
+          "product-backlog"
+          "needs-design"
+          "design-in-progress"
+          "ready-for-dev"
+          "sprint-backlog"
+          "in-progress"
+          "blocked"
+          "needs-dev-review"
+          "needs-qa"
+          "issues-found"
+          "ready-for-release"
+        )
+        for LABEL in "${LABELS[@]}"; do
+          curl \
+          -X DELETE \
+          -H "Authorization: token $GITHUB_TOKEN" \
+          -H "Accept: application/vnd.github.v3+json" \
+          "https://api.github.com/repos/$REPO/issues/$ISSUE_NUMBER/labels/$LABEL"
+        done


### PR DESCRIPTION
## Explanation

An existing [automation](https://github.com/MetaMask/metamask-zaps/tree/main/zaps/github-labels-automation) adds labels on Github issues when they move to a different column on Zenhub.
However these labels are not being removed when the issue is closed.

We need a Github action that removes the following labels from issue once it is closed:
- product-backlog
- needs-design
- design-in-progress
- ready-for-dev
- sprint-backlog
- in-progress
- blocked
- needs-dev-review
- needs-qa
- issues-found
- ready-for-release

## Screenshots/Screencaps

https://recordit.co/PZtLcn6Q5s

### Before

na

### After

na

## Manual Testing Steps

- Add "in-progress" label to an open PR
- Merge the PR
- Label shall be removed

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
