### PR TITLE
feat: skip spending cap prompt for permit2

### DIFF
--- a/ui/pages/token-allowance/token-allowance.js
+++ b/ui/pages/token-allowance/token-allowance.js
@@ -64,8 +64,13 @@ import LedgerInstructionField from '../../components/app/ledger-instruction-fiel
 import { SECURITY_PROVIDER_MESSAGE_SEVERITIES } from '../../components/app/security-provider-banner-message/security-provider-banner-message.constants';
 import SecurityProviderBannerMessage from '../../components/app/security-provider-banner-message/security-provider-banner-message';
 import { Text, Icon, IconName } from '../../components/component-library';
+import { parseStandardTokenTransactionData } from '../../../shared/modules/transaction.utils';
+import { getTokenAddressParam } from '../../helpers/utils/token-util';
 
 const ALLOWED_HOSTS = ['portfolio.metamask.io'];
+const ALLOWED_CONTRACTS = [
+  '0x000000000022d473030f116ddee9f6b43ac78ba3', // PERMIT2
+];
 
 export default function TokenAllowance({
   origin,
@@ -99,7 +104,10 @@ export default function TokenAllowance({
   const mostRecentOverviewPage = useSelector(getMostRecentOverviewPage);
 
   const { hostname } = new URL(origin);
-  const thisOriginIsAllowedToSkipFirstPage = ALLOWED_HOSTS.includes(hostname);
+  const approvalParams = parseStandardTokenTransactionData(data);
+  const spender = getTokenAddressParam(approvalParams);
+  const thisOriginIsAllowedToSkipFirstPage =
+    ALLOWED_HOSTS.includes(hostname) || ALLOWED_CONTRACTS.includes(spender);
 
   const [showContractDetails, setShowContractDetails] = useState(false);
   const [inputChangeInProgress, setInputChangeInProgress] = useState(false);


### PR DESCRIPTION
## Explanation

Feature raised here: https://community.metamask.io/t/skip-spending-cap-prompt-for-permit2-approvals/26007

Change: Skip to 2nd page of approval page when spender is [Permit2](https://github.com/Uniswap/permit2)

Description:
MetaMask has a security focused feature that encourages users to set limited spending caps for their tokens when prompted for approvals. The motivation for this is clear - specifically, this reduces the potential of long living allowances (unlimited approvals) that could be later be exploited.

However, there are certain scenarios where encouraging limited spending caps is highly disruptive while not providing significant security. One clear instance of this is users making approvals to Permit 2. Permit2 is a contract that allows any ERC20 token to leverage gasless, time limited way for users to allow token transfers out of their wallets (approvals).

By pushing the user to make limited spending cap approvals to Permit2, we reduce it’s effectiveness because having spent the spending cap, the user must again submit an on chain approval to continue using Permit2 gassless approvals. A user which fully spends and acquires a token frequently will be required to approve permit2 multiple times.

Purpose:

Given that Permit2 is already a highly tested and trusted contract in the eco system, for which users also have a high level expectation for user experience:

We propose to allow approvals to the canonical Permit2 contracts to skip the spending cap input page. This would be functionally similar to approvals originating from MetaMask’s portfolio application which are also afforded this benefit.
## Screenshots/Screencaps

<!-- If you're making a change to the UI, make sure to capture a screenshot or a short video showing off your work! -->

### Before

![image](https://github.com/MetaMask/metamask-extension/assets/11529637/a913435b-0eb9-4ea4-920e-6faba802c88f)

### After
For Permit2:

![image](https://github.com/MetaMask/metamask-extension/assets/11529637/01726cf0-aeff-4edb-84aa-caac0a6d44f6)

## Manual Testing Steps

1. Go to Uniswap and approve an erc20 token 
2. Notice spending cap input has been skipped

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
