### PR TITLE
Use `nvmrc` in GitHub Actions workflows

### DIFF
--- a/.github/workflows/add-release-label.yml
+++ b/.github/workflows/add-release-label.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '16'
+          node-version-file: '.nvmrc'
 
       - name: Install dependencies
         run: yarn --immutable

--- a/.github/workflows/fitness-functions.yml
+++ b/.github/workflows/fitness-functions.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '16'
+          node-version-file: '.nvmrc'
 
       - name: Install dependencies
         run: yarn


### PR DESCRIPTION
## Explanation

The `nvmrc` file is now referenced in our GitHub Actions workflows, rather than hard-coding the expected Node.js version. This will make future Node.js version changes easier to manage.

## Manual Testing Steps

None; this should have no functional impact. The only affected workflows are the fitness functions check and the release label workflow, which should work the same as before.

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
