### PR TITLE
Use Yarn caching in GitHub Actions

### DIFF
--- a/.github/workflows/add-release-label.yml
+++ b/.github/workflows/add-release-label.yml
@@ -21,6 +21,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version-file: '.nvmrc'
+          cache: yarn
 
       - name: Install dependencies
         run: yarn --immutable

--- a/.github/workflows/fitness-functions.yml
+++ b/.github/workflows/fitness-functions.yml
@@ -18,6 +18,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version-file: '.nvmrc'
+          cache: yarn
 
       - name: Install dependencies
         run: yarn --immutable


### PR DESCRIPTION
## Explanation

The only GitHub action to install dependencies will now also cache those dependencies using the standard strategy for Yarn (which is to hash the lockfile).

This matches the module template (see https://github.com/MetaMask/metamask-module-template/pull/145 for details).

This should have no functional impact except that this action will run faster when dependencies are unchanged.

## Manual Testing Steps

None; this should have no functional impact. The only affected workflow is the fitness functions check, which should work the same as before.

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
