### PR TITLE
Only show a Swaps notification on a supported chain

### DIFF
--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -971,6 +971,7 @@ function getAllowedAnnouncementIds(state) {
   const currentlyUsingLedgerLive =
     getLedgerTransportType(state) === LedgerTransportTypes.live;
   const isFirefox = window.navigator.userAgent.includes('Firefox');
+  const isSwapsChain = getIsSwapsChain(state);
 
   return {
     1: false,
@@ -993,7 +994,7 @@ function getAllowedAnnouncementIds(state) {
     18: true,
     19: true,
     20: currentKeyringIsLedger && isFirefox,
-    21: true,
+    21: isSwapsChain,
   };
 }
 


### PR DESCRIPTION
## Explanation
Only show a Swaps notification in the What's New modal on a supported chain.