### PR TITLE
Correctly categorize dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -201,8 +201,6 @@
     "@metamask/signature-controller@^3.0.0": "patch:@metamask/signature-controller@npm%3A3.0.0#./.yarn/patches/@metamask-signature-controller-npm-3.0.0-8771b6885e.patch"
   },
   "dependencies": {
-    "@actions/core": "^1.10.0",
-    "@actions/github": "^5.1.1",
     "@babel/runtime": "^7.18.9",
     "@download/blockies": "^1.0.3",
     "@ensdomains/content-hash": "^2.5.6",
@@ -318,7 +316,6 @@
     "fuse.js": "^3.2.0",
     "globalthis": "^1.0.1",
     "human-standard-token-abi": "^2.0.0",
-    "husky": "^8.0.3",
     "immer": "^9.0.6",
     "is-retry-allowed": "^2.2.0",
     "jest-junit": "^14.0.1",
@@ -367,6 +364,8 @@
     "zxcvbn": "^4.4.2"
   },
   "devDependencies": {
+    "@actions/core": "^1.10.0",
+    "@actions/github": "^5.1.1",
     "@babel/code-frame": "^7.12.13",
     "@babel/core": "^7.21.5",
     "@babel/eslint-parser": "^7.13.14",


### PR DESCRIPTION
## Explanation

The two GitHub action dependencies were mistakenly listed as production dependencies. They've been moved to `devDependencies` instead.

The `husky` development dependency was mistakenly listed as a production dependency as well. It has been removed from that set, now listed as just a `devDependency`.

## Manual Testing Steps

No functional changes to test

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
