### PR TITLE
Use immutable install in fitness function workflow

### DIFF
--- a/.github/workflows/fitness-functions.yml
+++ b/.github/workflows/fitness-functions.yml
@@ -20,7 +20,7 @@ jobs:
           node-version: '16'
 
       - name: Install dependencies
-        run: yarn
+        run: yarn --immutable
 
       - name: Run fitness functions
         env:


### PR DESCRIPTION
## Explanation

The fitness function workflow now uses an immutable install, ensuring that the dependencies installed are known and tracked in the lockfile. This makes it easier to audit exactly which dependencies were used for each run.

## Manual Testing Steps

No functional changes

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
