### PR TITLE
UX: Ensure multichain native token name is always shown

### DIFF
--- a/ui/components/app/asset-list/asset-list.js
+++ b/ui/components/app/asset-list/asset-list.js
@@ -10,7 +10,6 @@ import {
   getNativeCurrencyImage,
   getDetectedTokensInCurrentNetwork,
   getIstokenDetectionInactiveOnNonMainnetSupportedNetwork,
-  getTokenList,
 } from '../../../selectors';
 import { getNativeCurrency } from '../../../ducks/metamask/metamask';
 import { useCurrencyDisplay } from '../../../hooks/useCurrencyDisplay';

--- a/ui/components/app/asset-list/asset-list.js
+++ b/ui/components/app/asset-list/asset-list.js
@@ -62,19 +62,15 @@ const AssetList = ({ onClickAsset }) => {
 
   const primaryTokenImage = useSelector(getNativeCurrencyImage);
   const detectedTokens = useSelector(getDetectedTokensInCurrentNetwork) || [];
-  const istokenDetectionInactiveOnNonMainnetSupportedNetwork = useSelector(
+  const isTokenDetectionInactiveOnNonMainnetSupportedNetwork = useSelector(
     getIstokenDetectionInactiveOnNonMainnetSupportedNetwork,
   );
-  const tokenList = useSelector(getTokenList);
-  const tokenData = Object.values(tokenList).find(
-    (token) => token.symbol === primaryCurrencyProperties.suffix,
-  );
-  const title = tokenData?.name || primaryCurrencyProperties.suffix;
+
   return (
     <>
       <TokenListItem
         onClick={() => onClickAsset(nativeCurrency)}
-        title={title}
+        title={nativeCurrency}
         primary={
           primaryCurrencyProperties.value ?? secondaryCurrencyProperties.value
         }
@@ -96,7 +92,7 @@ const AssetList = ({ onClickAsset }) => {
         }}
       />
       {detectedTokens.length > 0 &&
-      !istokenDetectionInactiveOnNonMainnetSupportedNetwork ? (
+      !isTokenDetectionInactiveOnNonMainnetSupportedNetwork ? (
         <DetectedTokensBanner
           actionButtonOnClick={() => setShowDetectedTokens(true)}
           margin={4}


### PR DESCRIPTION
## Explanation

This PR ensures that the native token name is displayed regardless of the Settings -> Primary currency value.  Previously it was showing "USD" for Ethereum, which is confusing.

* Fixes https://github.com/MetaMask/MetaMask-planning/issues/788

## Screenshots/Screencaps

<!-- If you're making a change to the UI, make sure to capture a screenshot or a short video showing off your work! -->

### Before

![247115557-6cff3806-9310-406f-9a67-afd53b17f486](https://github.com/MetaMask/metamask-extension/assets/46655/33e8e6d9-e21a-4bef-ba4b-e0fb49031028)

### After

<img width="724" alt="SCR-20230621-iwjw" src="https://github.com/MetaMask/metamask-extension/assets/46655/417317ca-aa6f-4685-aeb1-9ca251f6100c">

## Manual Testing Steps

* Flip the settings for Primary currency between Fiat and ETH, see Ethereum shown as the native token in the token list
* Switch to Polygon
* Flip the settings for Primary currency between Fiat and MATIC, see MATIC shown as the native token in the token list

## Pre-merge author checklist

- [ ] I've clearly explained:
  - [ ] What problem this PR is solving
  - [ ] How this problem was solved
  - [ ] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
