### PR TITLE
UX Multichain: fixed padding for edit screen

### DIFF
--- a/ui/components/multichain/app-header/__snapshots__/app-header.test.js.snap
+++ b/ui/components/multichain/app-header/__snapshots__/app-header.test.js.snap
@@ -200,7 +200,7 @@ exports[`App Header should match snapshot 1`] = `
     </button>
   </div>
   <div
-    class="box multichain-app-header box--display-flex box--flex-direction-row box--align-items-center box--width-full box--background-color-background-alternative"
+    class="box multichain-app-header box--margin-bottom-4 box--display-flex box--flex-direction-row box--align-items-center box--width-full box--background-color-background-alternative"
   >
     <div
       class="box multichain-app-header__contents multichain-app-header-shadow box--padding-2 box--padding-right-4 box--padding-left-4 box--gap-2 box--flex-direction-row box--align-items-center box--width-full box--background-color-background-default box--display-flex"

--- a/ui/components/multichain/app-header/app-header.js
+++ b/ui/components/multichain/app-header/app-header.js
@@ -175,6 +175,7 @@ export const AppHeader = ({ location }) => {
         className={classnames('multichain-app-header', {
           'multichain-app-header-shadow': !isUnlocked || popupStatus,
         })}
+        marginBottom={disableAccountPicker && 4}
         alignItems={AlignItems.center}
         width={BlockSize.Full}
         backgroundColor={

--- a/ui/components/multichain/app-header/app-header.js
+++ b/ui/components/multichain/app-header/app-header.js
@@ -149,6 +149,10 @@ export const AppHeader = ({ location }) => {
     });
   }, [chainId, dispatch, trackEvent]);
 
+  // This is required to ensure send and confirmation screens
+  // look as desired
+  const headerBottomMargin = disableNetworkPicker ? 4 : 0;
+
   return (
     <>
       {isUnlocked && !popupStatus ? (
@@ -175,7 +179,7 @@ export const AppHeader = ({ location }) => {
         className={classnames('multichain-app-header', {
           'multichain-app-header-shadow': !isUnlocked || popupStatus,
         })}
-        marginBottom={disableAccountPicker && 4}
+        marginBottom={headerBottomMargin}
         alignItems={AlignItems.center}
         width={BlockSize.Full}
         backgroundColor={

--- a/ui/pages/routes/routes.component.js
+++ b/ui/pages/routes/routes.component.js
@@ -562,10 +562,7 @@ export default class Routes extends Component {
         {accountDetailsAddress ? (
           <AccountDetails address={accountDetailsAddress} />
         ) : null}
-        <Box
-          className="main-container-wrapper"
-          paddingTop={isUnlocked && [0, 4]}
-        >
+        <Box className="main-container-wrapper">
           {isLoading ? <Loading loadingMessage={loadMessage} /> : null}
           {!isLoading && isNetworkLoading ? <LoadingNetwork /> : null}
           {this.renderRoutes()}

--- a/ui/pages/swaps/index.scss
+++ b/ui/pages/swaps/index.scss
@@ -57,8 +57,7 @@
       background: var(--color-background-default);
       box-shadow: var(--shadow-size-xs) var(--color-shadow-default);
       border: 1px solid var(--color-border-muted);
-      border-top: 0;
-      border-radius: 0 0 8px 8px;
+      border-radius: 8px;
       height: 620px;
     }
   }


### PR DESCRIPTION
This PR is to remove the extra margin between header and content from all the screens and just adding it to the send edit and swap screen.

* Fixes MetaMask/MetaMask-planning#850 

## Screenshots/Screencaps


https://github.com/MetaMask/metamask-extension/assets/39872794/34ab9214-3514-448e-95ac-6226a4402eef



## Manual Testing Steps

- Go to send and swap screen
- Check the content and header has gap of 16px

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
