### PR TITLE
Don't debug calls to switchToFrame in e2e tests

### DIFF
--- a/test/e2e/helpers.js
+++ b/test/e2e/helpers.js
@@ -121,7 +121,10 @@ async function withFixtures(options, testSuite) {
       driverProxy = new Proxy(driver, {
         get(target, prop, receiver) {
           const originalProperty = target[prop];
-          if (typeof originalProperty === 'function') {
+          if (
+            typeof originalProperty === 'function' &&
+            prop !== 'switchToFrame'
+          ) {
             return (...args) => {
               console.log(
                 `[driver] Called '${prop}' with arguments ${JSON.stringify(


### PR DESCRIPTION


## Explanation

<!--
Thanks for the pull request. Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues, Slack conversations, Zendesk issues, user stories, etc. reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

When Chrome e2e tests are run in debug mode and `switchToFrame` is called on the e2e driver, the resulting message printed to standard out is very large, because of some binary data that gets included in the arguments to `switchToFrame`. This ends up preventing all of the output from showing up on a CI run and actually makes it more difficult to debug such a run.

This commit disables logging for `switchToFrame` to resolve this issue.

## Manual Testing Steps

<!--
How should reviewers and QA manually test your changes? For instance:

- Go to this screen
- Do this
- Then do this
-->

Go to the Checks box below, find `test-e2e-chrome`, and open it up. Expand the "test:e2e:chrome" step. You shouldn't see the message "Your output is too large to display in the browser."

(This is an existing build, for reference: https://app.circleci.com/pipelines/github/MetaMask/metamask-extension/49436/workflows/ab611d28-a2a3-42f7-a55a-1d415258808e/jobs/1417920)

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
