### PR TITLE
removed portfolio link from wallet view

### DIFF
--- a/test/e2e/tests/portfolio-site.spec.js
+++ b/test/e2e/tests/portfolio-site.spec.js
@@ -34,7 +34,7 @@ describe('Portfolio site', function () {
         // Verify site
         assert.equal(
           await driver.getCurrentUrl(),
-          'http://127.0.0.1:8080/?metamaskEntry=ext&metametricsId=null',
+          'http://127.0.0.1:8080/?metamaskEntry=ext_portfolio_button&metametricsId=null',
         );
       },
     );

--- a/test/e2e/tests/portfolio-site.spec.js
+++ b/test/e2e/tests/portfolio-site.spec.js
@@ -26,7 +26,7 @@ describe('Portfolio site', function () {
         await driver.press('#password', driver.Key.ENTER);
 
         // Click Portfolio site
-        await driver.clickElement('[data-testid="home__portfolio-site"]');
+        await driver.clickElement('[data-testid="eth-overview-portfolio"]');
         await driver.waitUntilXWindowHandles(2);
         const windowHandles = await driver.getAllWindowHandles();
         await driver.switchToWindowWithTitle('E2E Test Dapp', windowHandles);

--- a/ui/components/app/wallet-overview/eth-overview.js
+++ b/ui/components/app/wallet-overview/eth-overview.js
@@ -157,7 +157,7 @@ const EthOverview = ({ className }) => {
                 <span className="eth-overview__cached-star">*</span>
               ) : null}
               {
-                ///: BEGIN:ONLY_INCLUDE_IN(build-main,build-beta,build-flask)
+                ///: BEGIN:ONLY_INCLUDE_IN(build-beta,build-flask)
                 <ButtonIcon
                   className="eth-overview__portfolio-button"
                   data-testid="home__portfolio-site"

--- a/ui/components/app/wallet-overview/eth-overview.js
+++ b/ui/components/app/wallet-overview/eth-overview.js
@@ -36,7 +36,6 @@ import IconButton from '../../ui/icon-button';
 import { isHardwareKeyring } from '../../../helpers/utils/hardware';
 import { MetaMetricsContext } from '../../../contexts/metametrics';
 import {
-  MetaMetricsContextProp,
   MetaMetricsEventCategory,
   MetaMetricsEventName,
   MetaMetricsSwapsEventSource,
@@ -44,12 +43,7 @@ import {
 import Spinner from '../../ui/spinner';
 import { startNewDraftTransaction } from '../../../ducks/send';
 import { AssetType } from '../../../../shared/constants/transaction';
-import {
-  ButtonIcon,
-  ButtonIconSize,
-  Icon,
-  IconName,
-} from '../../component-library';
+import { Icon, IconName } from '../../component-library';
 import { IconColor } from '../../../helpers/constants/design-system';
 import useRamps from '../../../hooks/experiences/useRamps';
 import { getPortfolioUrl } from '../../../helpers/utils/portfolio';
@@ -156,42 +150,6 @@ const EthOverview = ({ className }) => {
               {balanceIsCached ? (
                 <span className="eth-overview__cached-star">*</span>
               ) : null}
-              {
-                ///: BEGIN:ONLY_INCLUDE_IN(build-beta,build-flask)
-                <ButtonIcon
-                  className="eth-overview__portfolio-button"
-                  data-testid="home__portfolio-site"
-                  color={IconColor.primaryDefault}
-                  iconName={IconName.Diagram}
-                  ariaLabel={t('portfolio')}
-                  size={ButtonIconSize.Lg}
-                  onClick={() => {
-                    const portfolioUrl = getPortfolioUrl(
-                      '',
-                      'ext',
-                      metaMetricsId,
-                    );
-                    global.platform.openTab({
-                      url: portfolioUrl,
-                    });
-                    trackEvent(
-                      {
-                        category: MetaMetricsEventCategory.Home,
-                        event: MetaMetricsEventName.PortfolioLinkClicked,
-                        properties: {
-                          url: portfolioUrl,
-                        },
-                      },
-                      {
-                        contextPropsIntoEventProperties: [
-                          MetaMetricsContextProp.PageTitle,
-                        ],
-                      },
-                    );
-                  }}
-                />
-                ///: END:ONLY_INCLUDE_IN
-              }
             </div>
             {showFiat && balance && (
               <UserPreferencedCurrencyDisplay

--- a/ui/components/app/wallet-overview/eth-overview.test.js
+++ b/ui/components/app/wallet-overview/eth-overview.test.js
@@ -71,7 +71,7 @@ describe('EthOverview', () => {
   const store = configureMockStore([thunk])(mockStore);
   const ETH_OVERVIEW_BUY = 'eth-overview-buy';
   const ETH_OVERVIEW_BRIDGE = 'eth-overview-bridge';
-  const ETH_OVERVIEW_PORTFOLIO = 'home__portfolio-site';
+  const ETH_OVERVIEW_PORTFOLIO = 'eth-overview-portfolio';
   const ETH_OVERVIEW_PRIMARY_CURRENCY = 'eth-overview__primary-currency';
   const ETH_OVERVIEW_SECONDARY_CURRENCY = 'eth-overview__secondary-currency';
 


### PR DESCRIPTION
This PR is to remove the portfolio link from Eth Overview

* Fixes [#839](https://github.com/MetaMask/MetaMask-planning/issues/839)

## Screenshots/Screencaps

### Before
![Screenshot 2023-06-22 at 2 29 00 PM](https://github.com/MetaMask/metamask-extension/assets/39872794/871e54d4-b03f-4fc0-9fc3-2b6d9ab8a463)


### After
![Screenshot 2023-06-22 at 2 28 08 PM](https://github.com/MetaMask/metamask-extension/assets/39872794/32304ba2-f1c7-4262-bb3a-eaee7b658d43)


## Manual Testing Steps

- Go to the home screen
- In eth overview, no portfolio link should be there

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
