### PR TITLE
updated linea image for token and badge

### DIFF
--- a/ui/components/multichain/token-list-item/token-list-item.js
+++ b/ui/components/multichain/token-list-item/token-list-item.js
@@ -29,6 +29,7 @@ import {
   MetaMetricsEventCategory,
   MetaMetricsEventName,
 } from '../../../../shared/constants/metametrics';
+import { LINEA_GOERLI_TOKEN_IMAGE_URL } from '../../../../shared/constants/network';
 
 export const TokenListItem = ({
   className,
@@ -45,11 +46,9 @@ export const TokenListItem = ({
   const trackEvent = useContext(MetaMetricsContext);
   const chainId = useSelector(getCurrentChainId);
   const badgeWrapperImage =
-    title === 'LineaETH'
-      ? './images/linea-logo-testnet.png'
-      : primaryTokenImage;
+    title === 'LineaETH' ? LINEA_GOERLI_TOKEN_IMAGE_URL : primaryTokenImage;
   const badgeTokenImage =
-    title === 'LineaETH' ? './images/linea-logo-testnet.png' : tokenImage;
+    title === 'LineaETH' ? LINEA_GOERLI_TOKEN_IMAGE_URL : tokenImage;
 
   return (
     <Box

--- a/ui/components/multichain/token-list-item/token-list-item.js
+++ b/ui/components/multichain/token-list-item/token-list-item.js
@@ -44,6 +44,12 @@ export const TokenListItem = ({
   const dataTheme = document.documentElement.getAttribute('data-theme');
   const trackEvent = useContext(MetaMetricsContext);
   const chainId = useSelector(getCurrentChainId);
+  const badgeWrapperImage =
+    title === 'LineaETH'
+      ? './images/linea-logo-testnet.png'
+      : primaryTokenImage;
+  const badgeTokenImage =
+    title === 'LineaETH' ? './images/linea-logo-testnet.png' : tokenImage;
 
   return (
     <Box
@@ -80,9 +86,9 @@ export const TokenListItem = ({
             <AvatarNetwork
               size={Size.XS}
               name={tokenSymbol}
-              src={primaryTokenImage}
+              src={badgeWrapperImage}
               borderColor={
-                primaryTokenImage
+                badgeWrapperImage
                   ? BorderColor.borderMuted
                   : BorderColor.borderDefault
               }
@@ -92,10 +98,12 @@ export const TokenListItem = ({
         >
           <AvatarToken
             name={tokenSymbol}
-            src={tokenImage}
+            src={badgeTokenImage}
             showHalo
             borderColor={
-              tokenImage ? BorderColor.transparent : BorderColor.borderDefault
+              badgeTokenImage
+                ? BorderColor.transparent
+                : BorderColor.borderDefault
             }
           />
         </BadgeWrapper>


### PR DESCRIPTION
This PR is to update the Linea logo for the avatar and badge when on the Linea network. In this solution, we have added a hardcoded string check to ensure that the correct image is displayed for the avatar token and badge.

We introduced the new Linea logo with this [PR](https://github.com/MetaMask/metamask-extension/pull/19326). But the tokenImage is undefined when we tried to access it for the badge on the home screen. The ideal solution will be to have the image be directly included there.

* Fixes #19689 

## Screenshots

### Before
![Screenshot 2023-06-22 at 3 09 39 PM](https://github.com/MetaMask/metamask-extension/assets/39872794/5238750d-03be-4391-a933-98920784ac96)


### After
![Screenshot 2023-06-22 at 3 06 10 PM](https://github.com/MetaMask/metamask-extension/assets/39872794/e964cad8-e3df-4085-8f8a-9e5a6a5f1a29)


## Manual Testing Steps


- Go to Linea network
- Check the linea logo is updated for the avatar badge and avatar token same as what is used in the network picker in header


## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
