### PR TITLE
fix(action): add required permissions to remove labels

### DIFF
--- a/.github/workflows/remove-labels-after-pr-closed.yml
+++ b/.github/workflows/remove-labels-after-pr-closed.yml
@@ -9,6 +9,9 @@ on:
 jobs:
   cleanup:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
 
     steps:
     - name: Remove labels


### PR DESCRIPTION
## Explanation

Tiny fix: The Github action didn't have sufficient permissions to remove labels from issues or PRs.

## Screenshots/Screencaps

NA

### Before

We currently have this error when the action is executed:
````
{
  "message": "Resource not accessible by integration",
  "documentation_url": "https://docs.github.com/rest/reference/issues#remove-a-label-from-an-issue"
}
````

### After

No more error.

To reproduce:
1. Add "needs-dev-review" label on PR
2. Merge the PR
3. Label shall be removed a few seconds after PR is merged

## Pre-merge author checklist

- [ x ] I've clearly explained:
  - [ x ] What problem this PR is solving
  - [ x ] How this problem was solved
  - [ x ] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
