### PR TITLE
Fix #19742 - Limit Cases for "Refresh List" to be used

### DIFF
--- a/ui/components/app/asset-list/asset-list.js
+++ b/ui/components/app/asset-list/asset-list.js
@@ -11,6 +11,7 @@ import {
   getDetectedTokensInCurrentNetwork,
   getIstokenDetectionInactiveOnNonMainnetSupportedNetwork,
   getTokenList,
+  getCurrentChainId,
 } from '../../../selectors';
 import { getNativeCurrency } from '../../../ducks/metamask/metamask';
 import { useCurrencyDisplay } from '../../../hooks/useCurrencyDisplay';
@@ -26,6 +27,7 @@ import {
   TokenListItem,
   ImportTokenLink,
 } from '../../multichain';
+import { isTokenDetectionEnabledForNetwork } from '../../../../shared/modules/network.utils';
 
 const AssetList = ({ onClickAsset }) => {
   const [showDetectedTokens, setShowDetectedTokens] = useState(false);
@@ -35,7 +37,10 @@ const AssetList = ({ onClickAsset }) => {
   const showFiat = useSelector(getShouldShowFiat);
   const trackEvent = useContext(MetaMetricsContext);
   const balance = useSelector(getSelectedAccountCachedBalance);
+  const chainId = useSelector(getCurrentChainId);
   const balanceIsLoading = !balance;
+
+  const showImportLink = isTokenDetectionEnabledForNetwork(chainId);
 
   const {
     currency: primaryCurrency,
@@ -102,9 +107,11 @@ const AssetList = ({ onClickAsset }) => {
           margin={4}
         />
       ) : null}
-      <Box marginTop={detectedTokens.length > 0 ? 0 : 4}>
-        <ImportTokenLink margin={4} />
-      </Box>
+      {showImportLink ? (
+        <Box marginTop={detectedTokens.length > 0 ? 0 : 4}>
+          <ImportTokenLink margin={4} />
+        </Box>
+      ) : null}
       {showDetectedTokens && (
         <DetectedToken setShowDetectedTokens={setShowDetectedTokens} />
       )}

--- a/ui/components/app/asset-list/asset-list.js
+++ b/ui/components/app/asset-list/asset-list.js
@@ -11,7 +11,6 @@ import {
   getDetectedTokensInCurrentNetwork,
   getIstokenDetectionInactiveOnNonMainnetSupportedNetwork,
   getTokenList,
-  getCurrentChainId,
 } from '../../../selectors';
 import { getNativeCurrency } from '../../../ducks/metamask/metamask';
 import { useCurrencyDisplay } from '../../../hooks/useCurrencyDisplay';
@@ -27,7 +26,6 @@ import {
   TokenListItem,
   ImportTokenLink,
 } from '../../multichain';
-import { isTokenDetectionEnabledForNetwork } from '../../../../shared/modules/network.utils';
 
 const AssetList = ({ onClickAsset }) => {
   const [showDetectedTokens, setShowDetectedTokens] = useState(false);
@@ -37,10 +35,7 @@ const AssetList = ({ onClickAsset }) => {
   const showFiat = useSelector(getShouldShowFiat);
   const trackEvent = useContext(MetaMetricsContext);
   const balance = useSelector(getSelectedAccountCachedBalance);
-  const chainId = useSelector(getCurrentChainId);
   const balanceIsLoading = !balance;
-
-  const showImportLink = isTokenDetectionEnabledForNetwork(chainId);
 
   const {
     currency: primaryCurrency,
@@ -107,11 +102,9 @@ const AssetList = ({ onClickAsset }) => {
           margin={4}
         />
       ) : null}
-      {showImportLink ? (
-        <Box marginTop={detectedTokens.length > 0 ? 0 : 4}>
-          <ImportTokenLink margin={4} />
-        </Box>
-      ) : null}
+      <Box marginTop={detectedTokens.length > 0 ? 0 : 4}>
+        <ImportTokenLink margin={4} />
+      </Box>
       {showDetectedTokens && (
         <DetectedToken setShowDetectedTokens={setShowDetectedTokens} />
       )}

--- a/ui/components/app/asset-list/asset-list.test.js
+++ b/ui/components/app/asset-list/asset-list.test.js
@@ -5,18 +5,24 @@ import configureStore from '../../../store/store';
 import mockState from '../../../../test/data/mock-state.json';
 import AssetList from './asset-list';
 
-const render = () => {
+const render = (chainId) => {
   const store = configureStore({
     metamask: {
       ...mockState.metamask,
+      providerConfig: { chainId },
     },
   });
-  return renderWithProvider(<AssetList />, store);
+  return renderWithProvider(<AssetList onClickAsset={jest.fn()} />, store);
 };
 
 describe('AssetList', () => {
   it('renders AssetList component and shows Refresh List text', () => {
-    render();
+    render('0x1');
     expect(screen.getByText('Refresh list')).toBeInTheDocument();
+  });
+
+  it('renders AssetList component and hides Refresh List on unsupported network', () => {
+    const { queryByText } = render('0x99');
+    expect(queryByText('Refresh list')).not.toBeInTheDocument();
   });
 });

--- a/ui/components/multichain/import-token-link/import-token-link.js
+++ b/ui/components/multichain/import-token-link/import-token-link.js
@@ -21,7 +21,9 @@ import {
 import {
   getIsTokenDetectionSupported,
   getIsTokenDetectionInactiveOnMainnet,
+  getCurrentChainId,
 } from '../../../selectors';
+import { isTokenDetectionEnabledForNetwork } from '../../../../shared/modules/network.utils';
 
 export const ImportTokenLink = ({ className, ...props }) => {
   const trackEvent = useContext(MetaMetricsContext);
@@ -32,6 +34,9 @@ export const ImportTokenLink = ({ className, ...props }) => {
   const isTokenDetectionInactiveOnMainnet = useSelector(
     getIsTokenDetectionInactiveOnMainnet,
   );
+
+  const chainId = useSelector(getCurrentChainId);
+  const showRefreshLink = isTokenDetectionEnabledForNetwork(chainId);
 
   const isTokenDetectionAvailable =
     isTokenDetectionSupported ||
@@ -64,20 +69,22 @@ export const ImportTokenLink = ({ className, ...props }) => {
               t('importTokensCamelCase').slice(1)}
         </ButtonLink>
       </Box>
-      <Box
-        display={Display.Flex}
-        alignItems={AlignItems.center}
-        paddingBottom={4}
-        paddingTop={4}
-      >
-        <ButtonLink
-          startIconName={IconName.Refresh}
-          data-testid="refresh-list-button"
-          onClick={() => detectNewTokens()}
+      {showRefreshLink ? (
+        <Box
+          display={Display.Flex}
+          alignItems={AlignItems.center}
+          paddingBottom={4}
+          paddingTop={4}
         >
-          {t('refreshList')}
-        </ButtonLink>
-      </Box>
+          <ButtonLink
+            startIconName={IconName.Refresh}
+            data-testid="refresh-list-button"
+            onClick={() => detectNewTokens()}
+          >
+            {t('refreshList')}
+          </ButtonLink>
+        </Box>
+      ) : null}
     </Box>
   );
 };


### PR DESCRIPTION
## Explanation

* Fixes #19742

Presently we have a "refresh list" link on the home screen which triggers detecting new tokens in the user's wallet.  At the moment this link is showing regardless of network, which won't work on unsupported networks.  This PR checks the network before displaying the link.  

## Screenshots/Screencaps


https://github.com/MetaMask/metamask-extension/assets/46655/a2681783-5f23-42e5-be7f-a96364965e17


## Manual Testing Steps

1.  See "Refresh list" on the home screen with Ethereum Mainnet
2. See "Refresh list" on the home screen with Polygon
3. DO NOT  see "Refresh list" on the home screen with any test network, or Arbitrum

## Pre-merge author checklist

- [ ] I've clearly explained:
  - [ ] What problem this PR is solving
  - [ ] How this problem was solved
  - [ ] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
