### PR TITLE
perf(CI): Shallow git clone that works with PRs from forks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,6 +30,50 @@ rc_branch_only: &rc_branch_only
       only:
         - /^Version-v(\d+)[.](\d+)[.](\d+)/
 
+rc_or_master_branch_only: &rc_or_master_branch_only
+  filters:
+    branches:
+      only:
+        - /^Version-v(\d+)[.](\d+)[.](\d+)|master/
+
+aliases:
+  # Shallow Git Clone
+  - &shallow-git-clone
+    name: Shallow Git Clone
+    command: |
+      #!/bin/bash
+      set -e
+      set -u
+      set -o pipefail
+
+      # This Shallow Git Clone code is adapted from what the standard CircleCI `checkout` command does for the case of an external PR (specifically pull/19693):
+      ### git clone --no-checkout "$CIRCLE_REPOSITORY_URL" .
+      ### git fetch --force origin +refs/pull/18748/head:refs/remotes/origin/pull/18748
+      ### git checkout --force -B "$CIRCLE_BRANCH" "$CIRCLE_SHA1"
+      ### git --no-pager log --no-color -n 1 --format='HEAD is now at %h %s'
+
+      # Set up SSH access
+      # This SSH key is the current github.com SSH key as of June 2023, but it will need to be changed whenever github changes their key (probably every few years)
+      GITHUB_SSH_KEY="AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl"
+      mkdir -p ~/.ssh
+      echo github.com ssh-ed25519 $GITHUB_SSH_KEY >> ~/.ssh/known_hosts
+
+      # Take a different clone path depending on if it's a tag, a PR from an external repo, or the normal case
+      if [ -n "${CIRCLE_TAG-}" ]; then
+        # tag
+        git clone --depth 1 --no-checkout "$CIRCLE_REPOSITORY_URL" .
+        git fetch --depth 1 --force origin "+refs/tags/${CIRCLE_TAG}:refs/tags/${CIRCLE_TAG}"
+        git checkout --force -q "$CIRCLE_TAG" "$CIRCLE_SHA1"
+      elif [[ "$CIRCLE_BRANCH" =~ ^pull\/* ]]; then
+        # pull request
+        git clone --depth 1 --no-checkout "$CIRCLE_REPOSITORY_URL" .
+        git fetch --depth 1 --force origin "${CIRCLE_BRANCH}/head:remotes/origin/${CIRCLE_BRANCH}"
+        git checkout --force -B "$CIRCLE_BRANCH" "$CIRCLE_SHA1"
+      else
+        # normal case
+        git clone --depth 1 "$CIRCLE_REPOSITORY_URL" --branch "$CIRCLE_BRANCH" .
+      fi
+
 workflows:
   test_and_release:
     jobs:
@@ -241,7 +285,7 @@ jobs:
   trigger-beta-build:
     executor: node-browsers-medium-plus
     steps:
-      - checkout
+      - run: *shallow-git-clone
       - attach_workspace:
           at: .
       - when:
@@ -270,7 +314,7 @@ jobs:
   create_release_pull_request:
     executor: node-browsers
     steps:
-      - checkout
+      - run: *shallow-git-clone
       - attach_workspace:
           at: .
       - run:
@@ -289,7 +333,7 @@ jobs:
   prep-deps:
     executor: node-browsers
     steps:
-      - checkout
+      - run: *shallow-git-clone
       - restore_cache:
           keys:
             # First try to get the specific cache for the checksum of the yarn.lock file.
@@ -339,7 +383,7 @@ jobs:
   validate-lavamoat-allow-scripts:
     executor: node-browsers-medium-plus
     steps:
-      - checkout
+      - run: *shallow-git-clone
       - attach_workspace:
           at: .
       - run:
@@ -352,7 +396,7 @@ jobs:
   validate-lavamoat-policy-build:
     executor: node-browsers-medium-plus
     steps:
-      - checkout
+      - run: *shallow-git-clone
       - attach_workspace:
           at: .
       - run:
@@ -368,7 +412,7 @@ jobs:
       build-type:
         type: string
     steps:
-      - checkout
+      - run: *shallow-git-clone
       - attach_workspace:
           at: .
       - run:
@@ -381,7 +425,7 @@ jobs:
   prep-build:
     executor: node-browsers-medium-plus
     steps:
-      - checkout
+      - run: *shallow-git-clone
       - attach_workspace:
           at: .
       - when:
@@ -415,7 +459,7 @@ jobs:
   prep-build-desktop:
     executor: node-browsers-medium-plus
     steps:
-      - checkout
+      - run: *shallow-git-clone
       - attach_workspace:
           at: .
       - run:
@@ -439,7 +483,7 @@ jobs:
   prep-build-flask:
     executor: node-browsers-medium-plus
     steps:
-      - checkout
+      - run: *shallow-git-clone
       - attach_workspace:
           at: .
       - when:
@@ -479,7 +523,7 @@ jobs:
   prep-build-test-flask:
     executor: node-browsers-medium-plus
     steps:
-      - checkout
+      - run: *shallow-git-clone
       - attach_workspace:
           at: .
       - run:
@@ -500,7 +544,7 @@ jobs:
   prep-build-test-mv3:
     executor: node-browsers-medium-plus
     steps:
-      - checkout
+      - run: *shallow-git-clone
       - attach_workspace:
           at: .
       - run:
@@ -521,7 +565,7 @@ jobs:
   prep-build-test:
     executor: node-browsers-medium-plus
     steps:
-      - checkout
+      - run: *shallow-git-clone
       - attach_workspace:
           at: .
       - run:
@@ -542,7 +586,7 @@ jobs:
   prep-build-storybook:
     executor: node-browsers-large
     steps:
-      - checkout
+      - run: *shallow-git-clone
       - attach_workspace:
           at: .
       - run:
@@ -556,7 +600,7 @@ jobs:
   prep-build-ts-migration-dashboard:
     executor: node-browsers
     steps:
-      - checkout
+      - run: *shallow-git-clone
       - attach_workspace:
           at: .
       - run:
@@ -570,7 +614,7 @@ jobs:
   test-yarn-dedupe:
     executor: node-browsers
     steps:
-      - checkout
+      - run: *shallow-git-clone
       - attach_workspace:
           at: .
       - run:
@@ -580,7 +624,7 @@ jobs:
   test-lint:
     executor: node-browsers
     steps:
-      - checkout
+      - run: *shallow-git-clone
       - attach_workspace:
           at: .
       - run:
@@ -593,7 +637,7 @@ jobs:
   test-storybook:
     executor: node-browsers-large
     steps:
-      - checkout
+      - run: *shallow-git-clone
       - attach_workspace:
           at: .
       - run:
@@ -615,7 +659,7 @@ jobs:
   test-lint-lockfile:
     executor: node-browsers
     steps:
-      - checkout
+      - run: *shallow-git-clone
       - attach_workspace:
           at: .
       - run:
@@ -625,7 +669,7 @@ jobs:
   test-lint-changelog:
     executor: node-browsers
     steps:
-      - checkout
+      - run: *shallow-git-clone
       - attach_workspace:
           at: .
       - when:
@@ -651,7 +695,7 @@ jobs:
   test-deps-audit:
     executor: node-browsers
     steps:
-      - checkout
+      - run: *shallow-git-clone
       - attach_workspace:
           at: .
       - run:
@@ -661,7 +705,7 @@ jobs:
   test-deps-depcheck:
     executor: node-browsers
     steps:
-      - checkout
+      - run: *shallow-git-clone
       - attach_workspace:
           at: .
       - run:
@@ -672,7 +716,7 @@ jobs:
     executor: node-browsers
     parallelism: 8
     steps:
-      - checkout
+      - run: *shallow-git-clone
       - run:
           name: Re-Install Chrome
           command: ./.circleci/scripts/chrome-install.sh
@@ -709,7 +753,7 @@ jobs:
     executor: node-browsers
     parallelism: 8
     steps:
-      - checkout
+      - run: *shallow-git-clone
       - run:
           name: Re-Install Chrome
           command: ./.circleci/scripts/chrome-install.sh
@@ -737,7 +781,7 @@ jobs:
     executor: node-browsers
     parallelism: 4
     steps:
-      - checkout
+      - run: *shallow-git-clone
       - run:
           name: Install Firefox
           command: ./.circleci/scripts/firefox-install.sh
@@ -774,7 +818,7 @@ jobs:
     executor: node-browsers
     parallelism: 4
     steps:
-      - checkout
+      - run: *shallow-git-clone
       - run:
           name: Re-Install Chrome
           command: ./.circleci/scripts/chrome-install.sh
@@ -811,7 +855,7 @@ jobs:
     executor: node-browsers-medium-plus
     parallelism: 8
     steps:
-      - checkout
+      - run: *shallow-git-clone
       - run:
           name: Install Firefox
           command: ./.circleci/scripts/firefox-install.sh
@@ -847,7 +891,7 @@ jobs:
   benchmark:
     executor: node-browsers-medium-plus
     steps:
-      - checkout
+      - run: *shallow-git-clone
       - run:
           name: Re-Install Chrome
           command: ./.circleci/scripts/chrome-install.sh
@@ -873,7 +917,7 @@ jobs:
   user-actions-benchmark:
     executor: node-browsers-medium-plus
     steps:
-      - checkout
+      - run: *shallow-git-clone
       - run:
           name: Re-Install Chrome
           command: ./.circleci/scripts/chrome-install.sh
@@ -899,7 +943,7 @@ jobs:
   stats-module-load-init:
     executor: node-browsers-medium-plus
     steps:
-      - checkout
+      - run: *shallow-git-clone
       - run:
           name: Re-Install Chrome
           command: ./.circleci/scripts/chrome-install.sh
@@ -996,7 +1040,7 @@ jobs:
   job-publish-release:
     executor: node-browsers
     steps:
-      - checkout
+      - run: *shallow-git-clone
       - attach_workspace:
           at: .
       - run:
@@ -1016,7 +1060,7 @@ jobs:
       - add_ssh_keys:
           fingerprints:
             - '3d:49:29:f4:b2:e8:ea:af:d1:32:eb:2a:fc:15:85:d8'
-      - checkout
+      - run: *shallow-git-clone
       - attach_workspace:
           at: .
       - run:
@@ -1031,7 +1075,7 @@ jobs:
       - add_ssh_keys:
           fingerprints:
             - '8b:21:e3:20:7c:c9:db:82:74:2d:86:d6:11:a7:2f:49'
-      - checkout
+      - run: *shallow-git-clone
       - attach_workspace:
           at: .
       - run:
@@ -1045,7 +1089,7 @@ jobs:
   test-unit-mocha:
     executor: node-browsers-medium-plus
     steps:
-      - checkout
+      - run: *shallow-git-clone
       - attach_workspace:
           at: .
       - run:
@@ -1060,7 +1104,7 @@ jobs:
   test-unit-jest-development:
     executor: node-browsers
     steps:
-      - checkout
+      - run: *shallow-git-clone
       - attach_workspace:
           at: .
       - run:
@@ -1077,7 +1121,7 @@ jobs:
     executor: node-browsers-medium-plus
     parallelism: 12
     steps:
-      - checkout
+      - run: *shallow-git-clone
       - attach_workspace:
           at: .
       - run:
@@ -1093,7 +1137,7 @@ jobs:
   upload-and-validate-coverage:
     executor: node-browsers
     steps:
-      - checkout
+      - run: *shallow-git-clone
       - attach_workspace:
           at: .
       - codecov/upload
@@ -1108,7 +1152,7 @@ jobs:
   test-unit-global:
     executor: node-browsers
     steps:
-      - checkout
+      - run: *shallow-git-clone
       - attach_workspace:
           at: .
       - run:
@@ -1118,7 +1162,7 @@ jobs:
   validate-source-maps:
     executor: node-browsers
     steps:
-      - checkout
+      - run: *shallow-git-clone
       - attach_workspace:
           at: .
       - run:
@@ -1128,7 +1172,7 @@ jobs:
   validate-source-maps-beta:
     executor: node-browsers
     steps:
-      - checkout
+      - run: *shallow-git-clone
       - attach_workspace:
           at: .
       - run:
@@ -1139,7 +1183,7 @@ jobs:
   validate-source-maps-desktop:
     executor: node-browsers
     steps:
-      - checkout
+      - run: *shallow-git-clone
       - attach_workspace:
           at: .
       - run:
@@ -1155,7 +1199,7 @@ jobs:
   validate-source-maps-flask:
     executor: node-browsers
     steps:
-      - checkout
+      - run: *shallow-git-clone
       - attach_workspace:
           at: .
       - run:
@@ -1171,7 +1215,7 @@ jobs:
   test-mozilla-lint:
     executor: node-browsers
     steps:
-      - checkout
+      - run: *shallow-git-clone
       - attach_workspace:
           at: .
       - run:
@@ -1181,7 +1225,7 @@ jobs:
   test-mozilla-lint-desktop:
     executor: node-browsers
     steps:
-      - checkout
+      - run: *shallow-git-clone
       - attach_workspace:
           at: .
       - run:
@@ -1197,7 +1241,7 @@ jobs:
   test-mozilla-lint-flask:
     executor: node-browsers
     steps:
-      - checkout
+      - run: *shallow-git-clone
       - attach_workspace:
           at: .
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,12 +30,6 @@ rc_branch_only: &rc_branch_only
       only:
         - /^Version-v(\d+)[.](\d+)[.](\d+)/
 
-rc_or_master_branch_only: &rc_or_master_branch_only
-  filters:
-    branches:
-      only:
-        - /^Version-v(\d+)[.](\d+)[.](\d+)|master/
-
 aliases:
   # Shallow Git Clone
   - &shallow-git-clone
@@ -46,7 +40,8 @@ aliases:
       set -u
       set -o pipefail
 
-      # This Shallow Git Clone code is adapted from what the standard CircleCI `checkout` command does for the case of an external PR (specifically pull/19693):
+      # This Shallow Git Clone code is adapted from what the standard CircleCI `checkout` command does for the case of an external PR (link to example below):
+      # https://app.circleci.com/pipelines/github/MetaMask/metamask-extension/49817/workflows/dc195ea6-ac06-4de1-9edf-4c949427b5fb/jobs/1430976/parallel-runs/0/steps/0-101
       ### git clone --no-checkout "$CIRCLE_REPOSITORY_URL" .
       ### git fetch --force origin +refs/pull/18748/head:refs/remotes/origin/pull/18748
       ### git checkout --force -B "$CIRCLE_BRANCH" "$CIRCLE_SHA1"


### PR DESCRIPTION
## Explanation

Reboot of #18783 and #18491

Does a `git clone --depth 1` to speed up every step of the CI by 11 seconds
Now properly works with PRs from forks

I'm not sure how to actually test the `CIRCLE_TAG` code path, because GitHub doesn't let you make a PR from a tag.  It might happen during the release process?