### PR TITLE
Add stale bot to extension

### DIFF
--- a/.github/workflows/stale-issues-pr.yml
+++ b/.github/workflows/stale-issues-pr.yml
@@ -19,7 +19,7 @@ jobs:
           stale-pr-message: 'This PR has been automatically marked as stale because it has not had recent activity in the last 60 days. It will be closed in 7 days. Thank you for your contributions.'
           stale-pr-label: 'stale'
           exempt-pr-labels: 'work-in-progress'
-          close-issue-message: 'This issue was closed because there has been no follow up activity in the last 7 days. If you feel this was closed in error please reopen and provide evidence on the current production app. Thank you for your contributions.'
+          close-issue-message: 'This issue was closed because there has been no follow up activity in the last 7 days. If you feel this was closed in error please reopen and provide evidence on the latest release of the extension. Thank you for your contributions.'
           close-pr-message: 'This PR was closed because there has been no follow up activity in the last 7 days. Thank you for your contributions.'
           days-before-issue-stale: 90
           days-before-pr-stale: 60

--- a/.github/workflows/stale-issues-pr.yml
+++ b/.github/workflows/stale-issues-pr.yml
@@ -1,0 +1,28 @@
+name: 'Close stale issues and PRs'
+on:
+  schedule:
+    - cron: '30 * * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/stale@72afbce2b0dbd1d903bb142cebe2d15dc307ae57
+        with:
+          stale-issue-message: 'This issue has been automatically marked as stale because it has not had recent activity in the last 90 days. It will be closed in 7 days. Thank you for your contributions.'
+          stale-issue-label: 'stale'
+          only-issue-labels: 'type-bug'
+          exempt-issue-labels: 'type-security, type-pinned, feature-request, awaiting-metamask'
+          stale-pr-message: 'This PR has been automatically marked as stale because it has not had recent activity in the last 60 days. It will be closed in 7 days. Thank you for your contributions.'
+          stale-pr-label: 'stale'
+          exempt-pr-labels: 'work-in-progress'
+          close-issue-message: 'This issue was closed because there has been no follow up activity in the last 7 days. If you feel this was closed in error please reopen and provide evidence on the current production app. Thank you for your contributions.'
+          close-pr-message: 'This PR was closed because there has been no follow up activity in the last 7 days. Thank you for your contributions.'
+          days-before-issue-stale: 90
+          days-before-pr-stale: 60
+          days-before-issue-close: 7
+          days-before-pr-close: 7
+          operations-per-run: 200

--- a/.github/workflows/stale-issues-pr.yml
+++ b/.github/workflows/stale-issues-pr.yml
@@ -1,7 +1,7 @@
 name: 'Close stale issues and PRs'
 on:
   schedule:
-    - cron: '30 * * * *'
+    - cron: '0 12 * * *'
 
 jobs:
   stale:
@@ -19,10 +19,10 @@ jobs:
           stale-pr-message: 'This PR has been automatically marked as stale because it has not had recent activity in the last 60 days. It will be closed in 7 days. Thank you for your contributions.'
           stale-pr-label: 'stale'
           exempt-pr-labels: 'work-in-progress'
-          close-issue-message: 'This issue was closed because there has been no follow up activity in the last 7 days. If you feel this was closed in error please reopen and provide evidence on the latest release of the extension. Thank you for your contributions.'
+          close-issue-message: 'This issue was closed because there has been no follow up activity in the last 7 days. If you feel this was closed in error, please reopen and provide evidence on the latest release of the extension. Thank you for your contributions.'
           close-pr-message: 'This PR was closed because there has been no follow up activity in the last 7 days. Thank you for your contributions.'
           days-before-issue-stale: 90
           days-before-pr-stale: 60
-          days-before-issue-close: 7
-          days-before-pr-close: 7
-          operations-per-run: 200
+          days-before-issue-close: 45
+          days-before-pr-close: 14
+          operations-per-run: 1

--- a/.github/workflows/stale-issues-pr.yml
+++ b/.github/workflows/stale-issues-pr.yml
@@ -12,11 +12,11 @@ jobs:
     steps:
       - uses: actions/stale@72afbce2b0dbd1d903bb142cebe2d15dc307ae57
         with:
-          stale-issue-message: 'This issue has been automatically marked as stale because it has not had recent activity in the last 90 days. It will be closed in 7 days. Thank you for your contributions.'
+          stale-issue-message: 'This issue has been automatically marked as stale because it has not had recent activity in the last 90 days. It will be closed in 45 days. Thank you for your contributions.'
           stale-issue-label: 'stale'
           only-issue-labels: 'type-bug'
           exempt-issue-labels: 'type-security, type-pinned, feature-request, awaiting-metamask'
-          stale-pr-message: 'This PR has been automatically marked as stale because it has not had recent activity in the last 60 days. It will be closed in 7 days. Thank you for your contributions.'
+          stale-pr-message: 'This PR has been automatically marked as stale because it has not had recent activity in the last 60 days. It will be closed in 14 days. Thank you for your contributions.'
           stale-pr-label: 'stale'
           exempt-pr-labels: 'work-in-progress'
           close-issue-message: 'This issue was closed because there has been no follow up activity in the last 7 days. If you feel this was closed in error, please reopen and provide evidence on the latest release of the extension. Thank you for your contributions.'


### PR DESCRIPTION
Add automation to close stale GitHub Issues and PRs.


- The PRs will be labeled stale if no activity has been seen for 60 days. They are closed 14 days after being marked as stale to give us plenty of time to review.
- The issues will be labeled stale if no activity has been seen for 90 days. They are closed 45 days after being marked as stale to give us plenty of time to review.

- Issues with labels `type-security` are exempt.

- When an Issue/PR is labeled stale, there is a message explaining why
- When an Issue/PR is closed because it was stale, there is a message explaining that it can be reopened