### PR TITLE
Remove gas fee controller legacy gas API

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -568,12 +568,8 @@ export default class MetamaskController extends EventEmitter {
         ),
       getCurrentAccountEIP1559Compatibility:
         this.getCurrentAccountEIP1559Compatibility.bind(this),
-      legacyAPIEndpoint: `${gasApiBaseUrl}/networks/<chain_id>/gasPrices`,
       EIP1559APIEndpoint: `${gasApiBaseUrl}/networks/<chain_id>/suggestedGasFees`,
-      getCurrentNetworkLegacyGasAPICompatibility: () => {
-        const { chainId } = this.networkController.state.providerConfig;
-        return process.env.IN_TEST || chainId === CHAIN_IDS.MAINNET;
-      },
+      getCurrentNetworkLegacyGasAPICompatibility: () => false,
       getChainId: () => this.networkController.state.providerConfig.chainId,
     });
 


### PR DESCRIPTION
## Explanation

The legacy gas API was only used before the Ethereum Mainnet london hardfork. It has been unused since then.

Note that this gas API remains referenced in some tests because it's still used in swaps. That will be addressed in a separate PR.

Relates to #19735

## Manual Testing Steps

No functional changes

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
