### PR TITLE
Fix #19764 - Move Token Options Menu

### DIFF
--- a/ui/components/multichain/app-header/app-header.js
+++ b/ui/components/multichain/app-header/app-header.js
@@ -28,7 +28,6 @@ import {
   ButtonIcon,
   ButtonIconSize,
   IconName,
-  IconSize,
   PickerNetwork,
 } from '../../component-library';
 ///: BEGIN:ONLY_INCLUDE_IN(build-mmi)
@@ -360,7 +359,6 @@ export const AppHeader = ({ location }) => {
                         setAccountOptionsMenuOpen(true);
                       }}
                       size={ButtonIconSize.Sm}
-                      iconProps={{ size: IconSize.Sm }}
                     />
                   </Box>
                 </Box>

--- a/ui/pages/asset/asset.scss
+++ b/ui/pages/asset/asset.scss
@@ -10,7 +10,6 @@
 
 .asset-navigation {
   display: flex;
-  justify-content: space-between;
   align-items: center;
   padding: 16px;
   height: 64px;

--- a/ui/pages/asset/components/asset-navigation.js
+++ b/ui/pages/asset/components/asset-navigation.js
@@ -23,8 +23,4 @@ AssetNavigation.propTypes = {
   optionsButton: PropTypes.element,
 };
 
-AssetNavigation.defaultProps = {
-  optionsButton: undefined,
-};
-
 export default AssetNavigation;

--- a/ui/pages/asset/components/asset-options.js
+++ b/ui/pages/asset/components/asset-options.js
@@ -7,13 +7,16 @@ import { I18nContext } from '../../../contexts/i18n';
 import { Menu, MenuItem } from '../../../components/ui/menu';
 import { getBlockExplorerLinkText } from '../../../selectors';
 import { NETWORKS_ROUTE } from '../../../helpers/constants/routes';
-import { ButtonIcon, IconName } from '../../../components/component-library';
+import {
+  ButtonIcon,
+  ButtonIconSize,
+  IconName,
+} from '../../../components/component-library';
 import { Color } from '../../../helpers/constants/design-system';
 
 const AssetOptions = ({
   onRemove,
   onClickBlockExplorer,
-  onViewAccountDetails,
   onViewTokenDetails,
   tokenSymbol,
   isNativeAsset,
@@ -42,22 +45,13 @@ const AssetOptions = ({
         ariaLabel={t('assetOptions')}
         iconName={IconName.MoreVertical}
         color={Color.textDefault}
+        size={ButtonIconSize.Sm}
       />
       {assetOptionsOpen ? (
         <Menu
           anchorElement={ref.current}
           onHide={() => setAssetOptionsOpen(false)}
         >
-          <MenuItem
-            iconName={IconName.ScanBarcode}
-            data-testid="asset-options__account-details"
-            onClick={() => {
-              setAssetOptionsOpen(false);
-              onViewAccountDetails();
-            }}
-          >
-            {t('accountDetails')}
-          </MenuItem>
           <MenuItem
             iconName={IconName.Export}
             data-testid="asset-options__etherscan"
@@ -111,7 +105,6 @@ const isNotFunc = (p) => {
 AssetOptions.propTypes = {
   isNativeAsset: PropTypes.bool,
   onClickBlockExplorer: PropTypes.func.isRequired,
-  onViewAccountDetails: PropTypes.func.isRequired,
   onRemove: (props) => {
     if (props.isNativeAsset === false && isNotFunc(props.onRemove)) {
       throw new Error(

--- a/ui/pages/asset/components/native-asset.js
+++ b/ui/pages/asset/components/native-asset.js
@@ -1,6 +1,6 @@
 import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
-import { useSelector, useDispatch } from 'react-redux';
+import { useSelector } from 'react-redux';
 import { useHistory } from 'react-router-dom';
 import { getAccountLink } from '@metamask/etherscan-link';
 import TransactionList from '../../../components/app/transaction-list';
@@ -12,7 +12,6 @@ import {
   getSelectedAddress,
   getIsCustomNetwork,
 } from '../../../selectors/selectors';
-import { showModal } from '../../../store/actions';
 import { DEFAULT_ROUTE } from '../../../helpers/constants/routes';
 import { getURLHostName } from '../../../helpers/utils/util';
 import { MetaMetricsContext } from '../../../contexts/metametrics';
@@ -24,7 +23,6 @@ export default function NativeAsset({ nativeCurrency }) {
   const selectedAccountName = useSelector(
     (state) => getSelectedIdentity(state).name,
   );
-  const dispatch = useDispatch();
 
   const chainId = useSelector(getCurrentChainId);
   const rpcPrefs = useSelector(getRpcPrefsForCurrentProvider);
@@ -56,9 +54,6 @@ export default function NativeAsset({ nativeCurrency }) {
               global.platform.openTab({
                 url: accountLink,
               });
-            }}
-            onViewAccountDetails={() => {
-              dispatch(showModal({ name: 'ACCOUNT_DETAILS' }));
             }}
             isCustomNetwork={isCustomNetwork}
           />

--- a/ui/pages/asset/components/token-asset.js
+++ b/ui/pages/asset/components/token-asset.js
@@ -67,9 +67,6 @@ export default function TokenAsset({ token }) {
               });
               global.platform.openTab({ url: tokenTrackerLink });
             }}
-            onViewAccountDetails={() => {
-              dispatch(showModal({ name: 'ACCOUNT_DETAILS' }));
-            }}
             onViewTokenDetails={() => {
               history.push(`${TOKEN_DETAILS}/${token.address}`);
             }}


### PR DESCRIPTION
## Explanation

* Fixes #19764
In this PR, I:

1.  Make the token's three-dot menu smaller
2. Move it next to the breadcrumbs
3. Remove the "Account Details" option from the token detail menu


## Screenshots/Screencaps

<img width="754" alt="SCR-20230626-nkir" src="https://github.com/MetaMask/metamask-extension/assets/46655/4fe414aa-6a88-4d87-809f-ec26367723aa">

## Manual Testing Steps

1.  Click into any token -- see the three-dot menu
2. Click the menu to see it working

## Pre-merge author checklist

- [ ] I've clearly explained:
  - [ ] What problem this PR is solving
  - [ ] How this problem was solved
  - [ ] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
