### PR TITLE
ci(update-policies): Fix update lavamoat policies workflow

### DIFF
--- a/.github/workflows/update-lavamoat-policies.yml
+++ b/.github/workflows/update-lavamoat-policies.yml
@@ -27,7 +27,13 @@ jobs:
     # Early exit if this is a fork, since later steps are skipped for forks
     if: ${{ needs.is-fork-pull-request.outputs.IS_FORK == 'false' }}
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Checkout pull request
+        run: gh pr checkout "${PR_NUMBER}"
+        env:
+          GITHUB_TOKEN: ${{ secrets.LAVAMOAT_UPDATE_TOKEN }}
+          PR_NUMBER: ${{ github.event.issue.number }}
       - name: Use Node.js
         uses: actions/setup-node@v3
         with:
@@ -44,6 +50,11 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
+      - name: Checkout pull request
+        run: gh pr checkout "${PR_NUMBER}"
+        env:
+          GITHUB_TOKEN: ${{ secrets.LAVAMOAT_UPDATE_TOKEN }}
+          PR_NUMBER: ${{ github.event.issue.number }}
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
@@ -72,6 +83,11 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
+      - name: Checkout pull request
+        run: gh pr checkout "${PR_NUMBER}"
+        env:
+          GITHUB_TOKEN: ${{ secrets.LAVAMOAT_UPDATE_TOKEN }}
+          PR_NUMBER: ${{ github.event.issue.number }}
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
@@ -99,7 +115,8 @@ jobs:
     # Ensure forks don't get access to the LavaMoat update token
     if: ${{ needs.is-fork-pull-request.outputs.IS_FORK == 'false' }}
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout repository
+        uses: actions/checkout@v3
         with:
           # Use PAT to ensure that the commit later can trigger status check workflows
           token: ${{ secrets.LAVAMOAT_UPDATE_TOKEN }}


### PR DESCRIPTION
## Explanation

The update LavaMoat policies workflow was installing dependencies from the `develop` branch rather than the PR. This resulted in invalid policy updates. It has been updated to use the PR branch in each step instead.

## Manual Testing Steps

`issue_comment` workflows are only triggered from the main branch, so this can't be tested properly until after merge. I have checked that it works in a fork though:  https://github.com/Gudahtt/metamask-extension/actions/runs/5384978254

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
