### PR TITLE
ci(update-policies): Fail policy update on cache miss

### DIFF
--- a/.github/workflows/update-lavamoat-policies.yml
+++ b/.github/workflows/update-lavamoat-policies.yml
@@ -130,6 +130,7 @@ jobs:
         with:
           path: lavamoat/build-system
           key: cache-build-${{ github.run_id }}-${{ github.run_attempt }}
+          fail-on-cache-miss: true
       # One restore step per build type: [main, beta, flask, mmi, desktop]
       # Ensure this is synchronized with the list above in the "update-lavamoat-webapp-policy" job
       # and with the build type list in `builds.yml`
@@ -138,27 +139,31 @@ jobs:
         with:
           path: lavamoat/browserify/main
           key: cache-main-${{ github.run_id }}-${{ github.run_attempt }}
+          fail-on-cache-miss: true
       - name: Restore beta application policy
         uses: actions/cache/restore@v3
         with:
           path: lavamoat/browserify/beta
           key: cache-beta-${{ github.run_id }}-${{ github.run_attempt }}
+          fail-on-cache-miss: true
       - name: Restore flask application policy
         uses: actions/cache/restore@v3
         with:
           path: lavamoat/browserify/flask
           key: cache-flask-${{ github.run_id }}-${{ github.run_attempt }}
+          fail-on-cache-miss: true
       - name: Restore mmi application policy
         uses: actions/cache/restore@v3
         with:
           path: lavamoat/browserify/mmi
           key: cache-mmi-${{ github.run_id }}-${{ github.run_attempt }}
+          fail-on-cache-miss: true
       - name: Restore desktop application policy
         uses: actions/cache/restore@v3
         with:
           path: lavamoat/browserify/desktop
           key: cache-desktop-${{ github.run_id }}-${{ github.run_attempt }}
-
+          fail-on-cache-miss: true
       - name: Check whether there are policy changes
         id: policy-changes
         run: |


### PR DESCRIPTION
## Explanation

If there is a cache miss during the policy update workflow, the result would be invalid (either a partial update or a misleading "no policy changes" message). To prevent this, the cache step will now fail if it is not able to restore the cache.

See https://github.com/actions/cache#inputs

## Manual Testing Steps

`issue_comment` workflows are only triggered from the main branch, so this can't be tested properly until after merge. I haven't tested this PR in a fork.

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
