### PR TITLE
[MMI] replace logic from preferences controller with event emitter

### DIFF
--- a/app/scripts/controllers/mmi-controller.js
+++ b/app/scripts/controllers/mmi-controller.js
@@ -14,8 +14,12 @@ import {
   REFRESH_TOKEN_CHANGE_EVENT,
   INTERACTIVE_REPLACEMENT_TOKEN_CHANGE_EVENT,
 } from '@metamask-institutional/sdk';
-import { handleMmiPortfolio, setDashboardCookie } from '@metamask-institutional/portfolio-dashboard';
+import {
+  handleMmiPortfolio,
+  setDashboardCookie,
+} from '@metamask-institutional/portfolio-dashboard';
 import { toChecksumHexAddress } from '../../../shared/modules/hexstring-utils';
+import { CHAIN_IDS } from '../../../shared/constants/network';
 import {
   BUILD_QUOTE_ROUTE,
   CONNECT_HARDWARE_ROUTE,
@@ -71,8 +75,9 @@ export default class MMIController extends EventEmitter {
       });
     }
 
-    this.preferencesController.on('update-mmi-portfolio', () => this.prepareMmiPortfolio());
-
+    this.preferencesController.on('update-mmi-portfolio', () =>
+      this.prepareMmiPortfolio(),
+    );
   } // End of constructor
 
   async persistKeyringsAfterRefreshTokenChange() {
@@ -575,7 +580,8 @@ export default class MMIController extends EventEmitter {
       try {
         const mmiDashboardData = await this.handleMmiDashboardData();
         const cookieSetUrls =
-        this.mmiConfigurationController.store.mmiConfiguration?.portfolio?.cookieSetUrls;
+          this.mmiConfigurationController.store.mmiConfiguration?.portfolio
+            ?.cookieSetUrls;
         setDashboardCookie(mmiDashboardData, cookieSetUrls);
       } catch (error) {
         console.error(error);

--- a/app/scripts/controllers/mmi-controller.js
+++ b/app/scripts/controllers/mmi-controller.js
@@ -24,6 +24,7 @@ import {
   BUILD_QUOTE_ROUTE,
   CONNECT_HARDWARE_ROUTE,
 } from '../../../ui/helpers/constants/routes';
+import { previousValueComparator } from '../lib/util';
 import { getPermissionBackgroundApiMethods } from './permissions';
 
 export default class MMIController extends EventEmitter {
@@ -75,8 +76,15 @@ export default class MMIController extends EventEmitter {
       });
     }
 
-    this.preferencesController.on('update-mmi-portfolio', () =>
-      this.prepareMmiPortfolio(),
+    this.preferencesController.store.subscribe(
+      previousValueComparator(async (prevState, currState) => {
+        const { identities: prevIdentities } = prevState;
+        const { identities: currIdentities } = currState;
+        if (prevIdentities === currIdentities) {
+          return;
+        }
+        await this.prepareMmiPortfolio();
+      }, this.preferencesController.store.getState()),
     );
   } // End of constructor
 

--- a/app/scripts/controllers/mmi-controller.js
+++ b/app/scripts/controllers/mmi-controller.js
@@ -1,6 +1,7 @@
 import EventEmitter from 'events';
 import log from 'loglevel';
 import { captureException } from '@sentry/browser';
+import { isEqual } from 'lodash';
 import {
   PersonalMessageManager,
   TypedMessageManager,
@@ -80,7 +81,7 @@ export default class MMIController extends EventEmitter {
       previousValueComparator(async (prevState, currState) => {
         const { identities: prevIdentities } = prevState;
         const { identities: currIdentities } = currState;
-        if (prevIdentities === currIdentities) {
+        if (isEqual(prevIdentities, currIdentities)) {
           return;
         }
         await this.prepareMmiPortfolio();

--- a/app/scripts/controllers/mmi-controller.js
+++ b/app/scripts/controllers/mmi-controller.js
@@ -546,7 +546,7 @@ export default class MMIController extends EventEmitter {
     });
   }
 
-  async setMmiPortfolioCookie() {
+  async handleMmiDashboardData() {
     await this.appStateController.getUnlockPromise(true);
     const keyringAccounts = await this.keyringController.getAccounts();
     const { identities } = this.preferencesController.store.getState();
@@ -554,14 +554,13 @@ export default class MMIController extends EventEmitter {
     const getAccountDetails = (address) =>
       this.custodyController.getAccountDetails(address);
     const extensionId = this.extension.runtime.id;
-
     const networks = [
       ...this.preferencesController.getRpcMethodPreferences(),
       { chainId: CHAIN_IDS.MAINNET },
       { chainId: CHAIN_IDS.GOERLI },
     ];
 
-    handleMmiPortfolio({
+    return handleMmiPortfolio({
       keyringAccounts,
       identities,
       metaMetricsId,
@@ -574,7 +573,7 @@ export default class MMIController extends EventEmitter {
   async prepareMmiPortfolio() {
     if (!process.env.IN_TEST) {
       try {
-        const mmiDashboardData = await this.setMmiPortfolioCookie();
+        const mmiDashboardData = await this.handleMmiDashboardData();
         const cookieSetUrls =
         this.mmiConfigurationController.store.mmiConfiguration?.portfolio?.cookieSetUrls;
         setDashboardCookie(mmiDashboardData, cookieSetUrls);

--- a/app/scripts/controllers/preferences.js
+++ b/app/scripts/controllers/preferences.js
@@ -1,4 +1,3 @@
-import EventEmitter from 'events';
 import { ObservableStore } from '@metamask/obs-store';
 import { normalize as normalizeAddress } from 'eth-sig-util';
 import { IPFS_DEFAULT_GATEWAY_URL } from '../../../shared/constants/network';
@@ -6,7 +5,7 @@ import { LedgerTransportTypes } from '../../../shared/constants/hardware-wallets
 import { ThemeType } from '../../../shared/constants/preferences';
 import { shouldShowLineaMainnet } from '../../../shared/modules/network.utils';
 
-export default class PreferencesController extends EventEmitter {
+export default class PreferencesController {
   /**
    *
    * @typedef {object} PreferencesController
@@ -23,8 +22,6 @@ export default class PreferencesController extends EventEmitter {
    * @property {string} store.selectedAddress A hex string that matches the currently selected address in the app
    */
   constructor(opts = {}) {
-    super();
-
     const initState = {
       useBlockie: false,
       useNonceField: false,
@@ -253,10 +250,6 @@ export default class PreferencesController extends EventEmitter {
       return ids;
     }, {});
 
-    ///: BEGIN:ONLY_INCLUDE_IN(build-mmi)
-    this.emit('update-mmi-portfolio');
-    ///: END:ONLY_INCLUDE_IN
-
     this.store.updateState({ identities });
   }
 
@@ -281,10 +274,6 @@ export default class PreferencesController extends EventEmitter {
       const [selected] = Object.keys(identities);
       this.setSelectedAddress(selected);
     }
-
-    ///: BEGIN:ONLY_INCLUDE_IN(build-mmi)
-    this.emit('update-mmi-portfolio');
-    ///: END:ONLY_INCLUDE_IN
 
     return address;
   }
@@ -341,10 +330,6 @@ export default class PreferencesController extends EventEmitter {
 
     this.store.updateState({ identities, lostIdentities });
     this.addAddresses(addresses);
-
-    ///: BEGIN:ONLY_INCLUDE_IN(build-mmi)
-    this.emit('update-mmi-portfolio');
-    ///: END:ONLY_INCLUDE_IN
 
     // If the selected account is no longer valid,
     // select an arbitrary other account:

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -382,10 +382,6 @@ export default class MetamaskController extends EventEmitter {
       ),
       tokenListController: this.tokenListController,
       provider: this.provider,
-      ///: BEGIN:ONLY_INCLUDE_IN(build-mmi)
-      handleMmiDashboardData: this.handleMmiDashboardData.bind(this),
-      mmiConfigurationStore: this.mmiConfigurationController.store,
-      ///: END:ONLY_INCLUDE_IN
     });
 
     this.preferencesController.store.subscribe(async ({ currentLocale }) => {

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -71,7 +71,6 @@ import {
 } from '@metamask-institutional/custody-keyring';
 import { InstitutionalFeaturesController } from '@metamask-institutional/institutional-features';
 import { CustodyController } from '@metamask-institutional/custody-controller';
-import { handleMmiPortfolio } from '@metamask-institutional/portfolio-dashboard';
 import { TransactionUpdateController } from '@metamask-institutional/transaction-update';
 ///: END:ONLY_INCLUDE_IN
 import { SignatureController } from '@metamask/signature-controller';
@@ -3914,7 +3913,7 @@ export default class MetamaskController extends EventEmitter {
           ),
         handleMmiCheckIfTokenIsPresent:
           this.mmiController.handleMmiCheckIfTokenIsPresent.bind(this),
-        handleMmiDashboardData: this.handleMmiDashboardData.bind(this),
+        handleMmiDashboardData: this.mmiController.handleMmiDashboardData.bind(this),
         handleMmiOpenSwaps: this.mmiController.handleMmiOpenSwaps.bind(this),
         handleMmiSetAccountAndNetwork:
           this.mmiController.setAccountAndNetwork.bind(this),
@@ -3972,37 +3971,6 @@ export default class MetamaskController extends EventEmitter {
     engine.push(providerAsMiddleware(provider));
     return engine;
   }
-
-  ///: BEGIN:ONLY_INCLUDE_IN(build-mmi)
-  /**
-   * This method is needed in preferences controller
-   * so it needs to be here and not in our controller because
-   * preferences controllers is initiated first
-   */
-  async handleMmiDashboardData() {
-    await this.appStateController.getUnlockPromise(true);
-    const keyringAccounts = await this.keyringController.getAccounts();
-    const { identities } = this.preferencesController.store.getState();
-    const { metaMetricsId } = this.metaMetricsController.store.getState();
-    const getAccountDetails = (address) =>
-      this.custodyController.getAccountDetails(address);
-    const extensionId = this.extension.runtime.id;
-    const networks = [
-      ...this.preferencesController.getRpcMethodPreferences(),
-      { chainId: CHAIN_IDS.MAINNET },
-      { chainId: CHAIN_IDS.GOERLI },
-    ];
-
-    return handleMmiPortfolio({
-      keyringAccounts,
-      identities,
-      metaMetricsId,
-      networks,
-      getAccountDetails,
-      extensionId,
-    });
-  }
-  ///: END:ONLY_INCLUDE_IN
 
   /**
    * TODO:LegacyProvider: Delete

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -3913,7 +3913,8 @@ export default class MetamaskController extends EventEmitter {
           ),
         handleMmiCheckIfTokenIsPresent:
           this.mmiController.handleMmiCheckIfTokenIsPresent.bind(this),
-        handleMmiDashboardData: this.mmiController.handleMmiDashboardData.bind(this),
+        handleMmiDashboardData:
+          this.mmiController.handleMmiDashboardData.bind(this),
         handleMmiOpenSwaps: this.mmiController.handleMmiOpenSwaps.bind(this),
         handleMmiSetAccountAndNetwork:
           this.mmiController.setAccountAndNetwork.bind(this),


### PR DESCRIPTION
This PR updates preferences controller by removing some MMI logic, that is moved now into our mmi-controller.
Meaning instead of having to pass a method plus a controller to the Preferences-Controller, and calling that in there, we are removing that logic and using the EventEmitter to know when some actions happen, by emitting a message `update-mmi-portfolio`, that will be caught in our side in the mmi-controller and act.

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [x] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.
