### PR TITLE
Render correct image in the asset dropdown while sending an NFT

### DIFF
--- a/ui/pages/send/send-content/send-asset-row/send-asset-row.component.js
+++ b/ui/pages/send/send-content/send-asset-row/send-asset-row.component.js
@@ -141,6 +141,7 @@ export default class SendAssetRow extends Component {
       tokens,
       nfts,
     } = this.props;
+    console.log(type, 'type');
 
     if (type === AssetType.token) {
       const token = tokens.find(({ address }) =>
@@ -193,7 +194,7 @@ export default class SendAssetRow extends Component {
       nativeCurrencyImage,
       sendAsset,
     } = this.props;
-
+    console.log(nativeCurrencyImage, sendAsset, 'nativeCurrencyImage');
     const { sendableTokens, sendableNfts } = this.state;
 
     const balanceValue = accounts[selectedAddress]
@@ -211,15 +212,11 @@ export default class SendAssetRow extends Component {
         onClick={() => this.selectToken(AssetType.native)}
       >
         <div className="send-v2__asset-dropdown__asset-icon">
-          {sendAsset?.type === AssetType.NFT && sendAsset?.details?.image ? (
-            <img width={36} src={sendAsset.details.image} />
-          ) : (
-            <Identicon
-              diameter={36}
-              image={nativeCurrencyImage}
-              address={nativeCurrency}
-            />
-          )}
+          <Identicon
+            diameter={36}
+            image={nativeCurrencyImage}
+            address={nativeCurrency}
+          />
         </div>
         <div className="send-v2__asset-dropdown__asset-data">
           <div className="send-v2__asset-dropdown__symbol">

--- a/ui/pages/send/send-content/send-asset-row/send-asset-row.component.js
+++ b/ui/pages/send/send-content/send-asset-row/send-asset-row.component.js
@@ -141,7 +141,6 @@ export default class SendAssetRow extends Component {
       tokens,
       nfts,
     } = this.props;
-    console.log(type, 'type');
 
     if (type === AssetType.token) {
       const token = tokens.find(({ address }) =>
@@ -187,14 +186,8 @@ export default class SendAssetRow extends Component {
 
   renderNativeCurrency(insideDropdown = false) {
     const { t } = this.context;
-    const {
-      accounts,
-      selectedAddress,
-      nativeCurrency,
-      nativeCurrencyImage,
-      sendAsset,
-    } = this.props;
-    console.log(nativeCurrencyImage, sendAsset, 'nativeCurrencyImage');
+    const { accounts, selectedAddress, nativeCurrency, nativeCurrencyImage } =
+      this.props;
     const { sendableTokens, sendableNfts } = this.state;
 
     const balanceValue = accounts[selectedAddress]


### PR DESCRIPTION
In the asset dropdown, the native token image was changed to the selected NFT image while sending an NFT. This PR is to fix this and to ensure the correct image is displayed in the asset dropdown while sending an NFT.

* Fixes #19783 

## Screenshots/Screencaps

### Before

https://github.com/MetaMask/metamask-extension/assets/39872794/7efed2c1-c375-4413-95e0-b10f4bf1bf8f



### After


https://github.com/MetaMask/metamask-extension/assets/39872794/23f41b8f-5826-4476-be52-db8686cead9e


## Manual Testing Steps

- Select an asset and click on send
- In the asset dropdown, select nft
- Check the native token has its own logo and not the nft image in asset dropdown.

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
