### PR TITLE
fix issue where non-standard NFT watchAsset requests result in notification with home screen view

### DIFF
--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -1,7 +1,7 @@
 ///: BEGIN:ONLY_INCLUDE_IN(snaps)
 import { SubjectType } from '@metamask/subject-metadata-controller';
 ///: END:ONLY_INCLUDE_IN
-import { ApprovalType, ERC1155, ERC721 } from '@metamask/controller-utils';
+import { ApprovalType } from '@metamask/controller-utils';
 import {
   createSelector,
   createSelectorCreator,
@@ -574,7 +574,7 @@ export function getSuggestedNfts(state) {
     getUnapprovedConfirmations(state)?.filter(({ requestData, type }) => {
       return (
         type === ApprovalType.WatchAsset &&
-        [ERC721, ERC1155].includes(requestData?.asset?.standard)
+        requestData?.asset?.tokenId !== undefined
       );
     }) || []
   );


### PR DESCRIPTION
Partially fixes https://github.com/MetaMask/MetaMask-planning/issues/852

Note this bug (where metadata can't be fetched when OpenSea API is off) exists only for ERC721 contracts that don't implement [the metadata interface](https://eips.ethereum.org/EIPS/eip-721). The UX of describing to the user why were unable to fetch the metadata and how they should proceed if they want to get it added correctly is complicated and will require longer UX discussion. We should have this discussion. We've run into similar non-standard contract issues before and have not yet come up with a coherent solution.

### Before

https://github.com/MetaMask/metamask-extension/assets/34557516/70d854b6-bde7-4ada-b2ee-007e232ef4a3

### After

https://github.com/MetaMask/metamask-extension/assets/34557516/55230a00-ee13-4f59-95fd-39d1a9165a82

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [ ] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
