### PR TITLE
Added support for eth_createAccessList and sendTransaction support fo…

### DIFF
--- a/app/scripts/controllers/permissions/specifications.js
+++ b/app/scripts/controllers/permissions/specifications.js
@@ -221,6 +221,7 @@ export const unrestrictedMethods = Object.freeze([
   'eth_coinbase',
   'eth_decrypt',
   'eth_estimateGas',
+  'eth_createAccessList',
   'eth_feeHistory',
   'eth_gasPrice',
   'eth_getBalance',

--- a/app/scripts/controllers/transactions/lib/util.js
+++ b/app/scripts/controllers/transactions/lib/util.js
@@ -9,6 +9,7 @@ import {
 import { isEIP1559Transaction } from '../../../../../shared/modules/transaction.utils';
 import { isValidHexAddress } from '../../../../../shared/modules/hexstring-utils';
 
+const identity = (x) => x;
 const normalizers = {
   from: addHexPrefix,
   to: (to, lowerCase) =>
@@ -21,8 +22,9 @@ const normalizers = {
   maxFeePerGas: addHexPrefix,
   maxPriorityFeePerGas: addHexPrefix,
   type: addHexPrefix,
-  estimateSuggested: (estimate) => estimate,
-  estimateUsed: (estimate) => estimate,
+  estimateSuggested: identity,
+  estimateUsed: identity,
+  accessList: identity,
 };
 
 export function normalizeAndValidateTxParams(txParams, lowerCase = true) {
@@ -224,10 +226,25 @@ export function validateTxParams(txParams, eip1559Compatibility = true) {
         validateInputData(value);
         ensureFieldIsString(txParams, 'data');
         break;
+      case 'accessList':
+        validateAccessList(value);
+        break;
       default:
         ensureFieldIsString(txParams, key);
     }
   });
+}
+
+/**
+ *
+ * @param {*} value
+ */
+export function validateAccessList(value) {
+  if (value instanceof Array === false) {
+    throw ethErrors.rpc.invalidParams(
+      `Invalid transaction params: accessList must be an array of access entries`,
+    );
+  }
 }
 
 /**

--- a/app/scripts/controllers/transactions/tx-gas-utils.js
+++ b/app/scripts/controllers/transactions/tx-gas-utils.js
@@ -76,8 +76,27 @@ export default class TxGasUtil {
     delete txParams.maxFeePerGas;
     delete txParams.maxPriorityFeePerGas;
 
-    // estimate tx gas requirements
-    return await this.query.estimateGas(txParams);
+    // dont use ethjs-query here because it will blow up about accessList
+    if (txParams.accessList) {
+      return await new Promise((resolve, reject) => {
+        this.query.rpc.currentProvider.sendAsync(
+          {
+            id: '1',
+            jsonrpc: '2.0',
+            method: 'eth_estimateGas',
+            params: [txParams, 'latest'],
+          },
+          (err, { result, error }) => {
+            if (error || err) {
+              reject(error);
+            } else {
+              resolve(result);
+            }
+          },
+        );
+      });
+    }
+    return this.query.estimateGas(txParams);
   }
 
   /**

--- a/app/scripts/controllers/transactions/tx-state-manager.js
+++ b/app/scripts/controllers/transactions/tx-state-manager.js
@@ -242,6 +242,7 @@ export default class TransactionStateManager extends EventEmitter {
     if (txMeta.txParams) {
       txMeta.txParams = normalizeAndValidateTxParams(txMeta.txParams, false);
     }
+    console.log('add transaction, post normalization', txMeta.txParams);
 
     this.once(`${txMeta.id}:signed`, () => {
       this.removeAllListeners(`${txMeta.id}:rejected`);


### PR DESCRIPTION
…r it

## Explanation

Problem:
At the moment, we don't support accessList in transactions. This is a feature added by  [eip-2930](https://eips.ethereum.org/EIPS/eip-2930), and in certain cases leads to gas used savings. 

Solution:
At the very least, we should allow proxying eth_createAccessList calls to the connected network, and pass the transaction field `accessList` to be passed in for signing. We also allow `accessList` to be passed into estimate gas.

Future considerations:
We can determine, for most cases, if providing an access list will amount to gas savings. There are however some cases where we wont know until after the transaction is added to a block, since the transaction and associated access list might be dependant on the state of a particular block, and become suboptimal in the next. We could explore ways of detecting these situations, but it would be pretty elaborate and so automatically creating accessLists was left out of the scope of this PR. 

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/870



## Screenshots/Screencaps

<!-- If you're making a change to the UI, make sure to capture a screenshot or a short video showing off your work! -->

### Before

<!-- How did the UI you changed look before your changes? Drag your file(s) below this line: -->

### After

<!-- How does it look now? Drag your file(s) below this line: -->

## Manual Testing Steps

<!--
How should reviewers and QA manually test your changes? For instance:

- Go to this screen
- Do this
- Then do this
-->

## Pre-merge author checklist

- [ ] I've clearly explained:
  - [ ] What problem this PR is solving
  - [ ] How this problem was solved
  - [ ] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
