### PR TITLE
Updated swap and send header for popup view

### DIFF
--- a/ui/components/multichain/app-header/app-header.js
+++ b/ui/components/multichain/app-header/app-header.js
@@ -151,7 +151,7 @@ export const AppHeader = ({ location }) => {
 
   // This is required to ensure send and confirmation screens
   // look as desired
-  const headerBottomMargin = disableNetworkPicker ? 4 : 0;
+  const headerBottomMargin = !popupStatus && disableNetworkPicker ? 4 : 0;
 
   return (
     <>


### PR DESCRIPTION
This PR is to remove extra margin from app header in popup view for swap and send screen

## Screenshots/Screencaps

### Before

![Screenshot 2023-06-28 at 8 14 56 PM](https://github.com/MetaMask/metamask-extension/assets/39872794/d21c7c31-f071-49f1-9b8d-822f962cc518)

### After
![Screenshot 2023-06-28 at 8 14 10 PM](https://github.com/MetaMask/metamask-extension/assets/39872794/f5c28809-bb3b-4a58-9f12-99fe7e902443)


## Manual Testing Steps

- Go to send or swap screen
- Check there is an extra padding between header and content only in full screen view
- no extra padding should be between header and content


## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
