### PR TITLE
Use `addNewAccount` from core `KeyringController`

### DIFF
--- a/app/scripts/metamask-controller.actions.test.js
+++ b/app/scripts/metamask-controller.actions.test.js
@@ -145,27 +145,21 @@ describe('MetaMaskController', function () {
         metamaskController.addNewAccount(1),
         metamaskController.addNewAccount(1),
       ]);
-      assert.deepEqual(
-        Object.keys(addNewAccountResult1.identities),
-        Object.keys(addNewAccountResult2.identities),
-      );
+      assert.equal(addNewAccountResult1, addNewAccountResult2);
     });
 
     it('two successive calls with same accountCount give same result', async function () {
       await metamaskController.createNewVaultAndKeychain('test@123');
       const addNewAccountResult1 = await metamaskController.addNewAccount(1);
       const addNewAccountResult2 = await metamaskController.addNewAccount(1);
-      assert.deepEqual(
-        Object.keys(addNewAccountResult1.identities),
-        Object.keys(addNewAccountResult2.identities),
-      );
+      assert.equal(addNewAccountResult1, addNewAccountResult2);
     });
 
     it('two successive calls with different accountCount give different results', async function () {
       await metamaskController.createNewVaultAndKeychain('test@123');
       const addNewAccountResult1 = await metamaskController.addNewAccount(1);
       const addNewAccountResult2 = await metamaskController.addNewAccount(2);
-      assert.notDeepEqual(addNewAccountResult1, addNewAccountResult2);
+      assert.notEqual(addNewAccountResult1, addNewAccountResult2);
     });
   });
 

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -2943,12 +2943,10 @@ export default class MetamaskController extends EventEmitter {
 
       // seek out the first zero balance
       while (lastBalance !== '0x0') {
-        await this.coreKeyringController.addNewAccount(accounts.length);
+        const { addedAccountAddress } =
+          await this.coreKeyringController.addNewAccount(accounts.length);
         accounts = await this.coreKeyringController.getAccounts();
-        lastBalance = await this.getBalance(
-          accounts[accounts.length - 1],
-          ethQuery,
-        );
+        lastBalance = await this.getBalance(addedAccountAddress, ethQuery);
       }
 
       // remove extra zero balance account potentially created from seeking ahead

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -3404,38 +3404,12 @@ export default class MetamaskController extends EventEmitter {
       await new Promise((resolve) => setTimeout(resolve, 5_000));
     }
 
-    const [primaryKeyring] = this.coreKeyringController.getKeyringsByType(
-      KeyringType.hdKeyTree,
-    );
-    if (!primaryKeyring) {
-      throw new Error('MetamaskController - No HD Key Tree found');
-    }
-    const { keyringController } = this;
-    const { identities: oldIdentities } =
-      this.preferencesController.store.getState();
+    const { addedAccountAddress } =
+      await this.coreKeyringController.addNewAccount(accountCount);
 
-    if (Object.keys(oldIdentities).length === accountCount) {
-      const oldAccounts = await keyringController.getAccounts();
-      const keyState = await keyringController.addNewAccount(primaryKeyring);
-      const newAccounts = await keyringController.getAccounts();
+    this.preferencesController.setSelectedAddress(addedAccountAddress);
 
-      await this.verifySeedPhrase();
-
-      this.preferencesController.setAddresses(newAccounts);
-      newAccounts.forEach((address) => {
-        if (!oldAccounts.includes(address)) {
-          this.preferencesController.setSelectedAddress(address);
-        }
-      });
-
-      const { identities } = this.preferencesController.store.getState();
-      return { ...keyState, identities };
-    }
-
-    return {
-      ...keyringController.memStore.getState(),
-      identities: oldIdentities,
-    };
+    return addedAccountAddress;
   }
 
   /**

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -3392,7 +3392,7 @@ export default class MetamaskController extends EventEmitter {
    * Adds a new account to the default (first) HD seed phrase Keyring.
    *
    * @param accountCount
-   * @returns {} keyState
+   * @returns {Promise<string>} The address of the newly-created account.
    */
   async addNewAccount(accountCount) {
     const isActionMetricsQueueE2ETest =
@@ -3402,10 +3402,15 @@ export default class MetamaskController extends EventEmitter {
       await new Promise((resolve) => setTimeout(resolve, 5_000));
     }
 
+    const { identities: oldIdentities } =
+      this.preferencesController.store.getState();
+
     const { addedAccountAddress } =
       await this.coreKeyringController.addNewAccount(accountCount);
 
-    this.preferencesController.setSelectedAddress(addedAccountAddress);
+    if (Object.keys(oldIdentities).length === accountCount) {
+      this.preferencesController.setSelectedAddress(addedAccountAddress);
+    }
 
     return addedAccountAddress;
   }

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -3402,13 +3402,12 @@ export default class MetamaskController extends EventEmitter {
       await new Promise((resolve) => setTimeout(resolve, 5_000));
     }
 
-    const { identities: oldIdentities } =
-      this.preferencesController.store.getState();
+    const oldAccounts = await this.coreKeyringController.getAccounts();
 
     const { addedAccountAddress } =
       await this.coreKeyringController.addNewAccount(accountCount);
 
-    if (Object.keys(oldIdentities).length === accountCount) {
+    if (!oldAccounts.includes(addedAccountAddress)) {
       this.preferencesController.setSelectedAddress(addedAccountAddress);
     }
 

--- a/app/scripts/metamask-controller.test.js
+++ b/app/scripts/metamask-controller.test.js
@@ -737,7 +737,7 @@ describe('MetaMaskController', function () {
           metamaskController.keyringController,
           'addNewAccount',
         );
-        addNewAccountStub.returns({});
+        addNewAccountStub.returns('0x123');
 
         getAccountsStub = sinon.stub(
           metamaskController.keyringController,
@@ -818,7 +818,7 @@ describe('MetaMaskController', function () {
           await addNewAccount;
           assert.fail('should throw');
         } catch (e) {
-          assert.equal(e.message, 'MetamaskController - No HD Key Tree found');
+          assert.equal(e.message, 'No HD keyring found');
         }
       });
     });

--- a/ui/store/actions.test.js
+++ b/ui/store/actions.test.js
@@ -398,7 +398,7 @@ describe('Actions', () => {
 
       const addNewAccount = background.addNewAccount.callsFake((_, cb) =>
         cb(null, {
-          identities: {},
+          addedAccountAddress: '0x123',
         }),
       );
 

--- a/ui/store/actions.ts
+++ b/ui/store/actions.ts
@@ -432,12 +432,11 @@ export function addNewAccount(): ThunkAction<
     const oldIdentities = getState().metamask.identities;
     dispatch(showLoadingIndication());
 
-    let newIdentities;
+    let addedAccountAddress;
     try {
-      const { identities } = await submitRequestToBackground('addNewAccount', [
+      addedAccountAddress = await submitRequestToBackground('addNewAccount', [
         Object.keys(oldIdentities).length,
       ]);
-      newIdentities = identities;
     } catch (error) {
       dispatch(displayWarning(error));
       throw error;
@@ -445,11 +444,8 @@ export function addNewAccount(): ThunkAction<
       dispatch(hideLoadingIndication());
     }
 
-    const newAccountAddress = Object.keys(newIdentities).find(
-      (address) => !oldIdentities[address],
-    );
     await forceUpdateMetamaskState(dispatch);
-    return newAccountAddress;
+    return addedAccountAddress;
   };
 }
 


### PR DESCRIPTION
## Explanation

<!--
Thanks for the pull request. Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues, Slack conversations, Zendesk issues, user stories, etc. reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

This PR uses `addNewAccount` from core `KeyringController` instead of calling `EthKeyringController` directly. As `addNewAccount` from `KeyringController` does not automatically select the added account, it is now selected by the client after the account creation.

* Fixes #18761
* Fixes #18759

## Manual Testing Steps

<!--
How should reviewers and QA manually test your changes? For instance:

- Go to this screen
- Do this
- Then do this
-->

- Adding a new HD account should work as before.
- When adding a new account, the created account should be selected as before. 

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
