### PR TITLE
New SecurityProviderBannerAlert component

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -3574,6 +3574,9 @@
     "message": "Security advice by $1",
     "description": "The security provider that is providing data"
   },
+  "seeDetails": {
+    "message": "See details"
+  },
   "seedPhraseConfirm": {
     "message": "Confirm Secret Recovery Phrase"
   },
@@ -3627,9 +3630,6 @@
   },
   "seedPhraseWriteDownHeader": {
     "message": "Write down your Secret Recovery Phrase"
-  },
-  "seeDetails": {
-    "message": "See details"
   },
   "select": {
     "message": "Select"

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -3570,6 +3570,10 @@
   "securityAndPrivacy": {
     "message": "Security & privacy"
   },
+  "securityProviderAdviceBy": {
+    "message": "Security advice by $1",
+    "description": "The security provider that is providing data"
+  },
   "seedPhraseConfirm": {
     "message": "Confirm Secret Recovery Phrase"
   },
@@ -3623,6 +3627,9 @@
   },
   "seedPhraseWriteDownHeader": {
     "message": "Write down your Secret Recovery Phrase"
+  },
+  "seeDetails": {
+    "message": "See details"
   },
   "select": {
     "message": "Select"

--- a/shared/constants/security-provider.ts
+++ b/shared/constants/security-provider.ts
@@ -17,7 +17,7 @@ export const SECURITY_PROVIDER_CONFIG: SecurityProviderConfig = {
     tKeyName: 'blockaid',
     url: 'https://blockaid.io/',
   },
-};
+} as const;
 
 /**
  * @typedef {object} SecurityProviderMessageSeverity

--- a/shared/constants/security-provider.ts
+++ b/shared/constants/security-provider.ts
@@ -1,3 +1,21 @@
+export enum SecurityProvider {
+  Blockaid = 'blockaid',
+}
+
+/**
+ * @typedef {object} SecurityProviderConfig
+ * @property {string} tKeyName - translation key for security provider name
+ * @property {string} url - URL to securty provider website
+ */
+
+/** @type {Record<string, SecurityProviderConfig>} */
+export const SECURITY_PROVIDER_CONFIG = {
+  [SecurityProvider.Blockaid]: {
+    tKeyName: 'blockaid',
+    url: 'https://blockaid.io/',
+  },
+};
+
 /**
  * @typedef {object} SecurityProviderMessageSeverity
  * @property {0} NOT_MALICIOUS - Indicates message is not malicious

--- a/shared/constants/security-provider.ts
+++ b/shared/constants/security-provider.ts
@@ -2,14 +2,17 @@ export enum SecurityProvider {
   Blockaid = 'blockaid',
 }
 
-/**
- * @typedef {object} SecurityProviderConfig
- * @property {string} tKeyName - translation key for security provider name
- * @property {string} url - URL to securty provider website
- */
+type SecurityProviderConfig = Record<
+  SecurityProvider,
+  {
+    /** translation key for security provider name */
+    tKeyName: string;
+    /** URL to securty provider website */
+    url: string;
+  }
+>;
 
-/** @type {Record<string, SecurityProviderConfig>} */
-export const SECURITY_PROVIDER_CONFIG = {
+export const SECURITY_PROVIDER_CONFIG: SecurityProviderConfig = {
   [SecurityProvider.Blockaid]: {
     tKeyName: 'blockaid',
     url: 'https://blockaid.io/',

--- a/shared/constants/security-provider.ts
+++ b/shared/constants/security-provider.ts
@@ -17,7 +17,7 @@ export const SECURITY_PROVIDER_CONFIG: Readonly<SecurityProviderConfig> = {
     tKeyName: 'blockaid',
     url: 'https://blockaid.io/',
   },
-} as const;
+};
 
 /**
  * @typedef {object} SecurityProviderMessageSeverity

--- a/shared/constants/security-provider.ts
+++ b/shared/constants/security-provider.ts
@@ -6,13 +6,13 @@ type SecurityProviderConfig = Record<
   SecurityProvider,
   {
     /** translation key for security provider name */
-    tKeyName: string;
+    readonly tKeyName: string;
     /** URL to securty provider website */
-    url: string;
+    readonly url: string;
   }
 >;
 
-export const SECURITY_PROVIDER_CONFIG: SecurityProviderConfig = {
+export const SECURITY_PROVIDER_CONFIG: Readonly<SecurityProviderConfig> = {
   [SecurityProvider.Blockaid]: {
     tKeyName: 'blockaid',
     url: 'https://blockaid.io/',

--- a/ui/components/app/security-provider-banner-alert/__snapshots__/security-provider-banner-alert.test.js.snap
+++ b/ui/components/app/security-provider-banner-alert/__snapshots__/security-provider-banner-alert.test.js.snap
@@ -16,11 +16,11 @@ exports[`Security Provider Banner Alert should match snapshot 1`] = `
       >
         Malicious third party detected
       </h5>
-      <h6
-        class="box mm-text mm-text--body-sm box--margin-top-2 box--flex-direction-row box--color-text-default"
+      <p
+        class="box mm-text mm-text--body-md box--flex-direction-row box--color-text-default"
       >
         This is a description to warn the user of malicious or suspicious transactions.
-      </h6>
+      </p>
       <div
         class="disclosure"
       >
@@ -28,9 +28,13 @@ exports[`Security Provider Banner Alert should match snapshot 1`] = `
           <summary
             class="disclosure__summary is-arrow"
           >
-            [seeDetails]
+            <p
+              class="box mm-text mm-text--body-md box--flex-direction-row box--color-primary-default"
+            >
+              [seeDetails]
+            </p>
             <span
-              class="box disclosure__summary--icon mm-icon mm-icon--size-sm box--margin-inline-start-2 box--display-inline-block box--flex-direction-row box--color-inherit"
+              class="box disclosure__summary--icon mm-icon mm-icon--size-sm box--margin-inline-start-2 box--display-inline-block box--flex-direction-row box--color-primary-default"
               style="mask-image: url('./images/icons/arrow-up.svg');"
             />
           </summary>
@@ -54,7 +58,7 @@ exports[`Security Provider Banner Alert should match snapshot 1`] = `
           />
         </details>
       </div>
-      <h6
+      <p
         class="box mm-text mm-text--body-sm box--margin-top-2 box--flex-direction-row box--align-items-center box--color-text-alternative box--display-flex"
       >
         <span
@@ -62,7 +66,7 @@ exports[`Security Provider Banner Alert should match snapshot 1`] = `
           style="mask-image: url('./images/icons/security-tick.svg');"
         />
         [securityProviderAdviceBy]
-      </h6>
+      </p>
     </div>
   </div>
 </div>

--- a/ui/components/app/security-provider-banner-alert/__snapshots__/security-provider-banner-alert.test.js.snap
+++ b/ui/components/app/security-provider-banner-alert/__snapshots__/security-provider-banner-alert.test.js.snap
@@ -14,7 +14,7 @@ exports[`Security Provider Banner Alert should match snapshot 1`] = `
         class="box mm-text mm-banner-base__title mm-text--body-lg-medium box--flex-direction-row box--color-text-default"
         data-testid="mm-banner-base-title"
       >
-        Title is sentence case no period
+        Malicious third party detected
       </h5>
       <h6
         class="box mm-text mm-text--body-sm box--margin-top-2 box--flex-direction-row box--color-text-default"

--- a/ui/components/app/security-provider-banner-alert/__snapshots__/security-provider-banner-alert.test.js.snap
+++ b/ui/components/app/security-provider-banner-alert/__snapshots__/security-provider-banner-alert.test.js.snap
@@ -17,7 +17,7 @@ exports[`Security Provider Banner Alert should match snapshot 1`] = `
         Malicious third party detected
       </h5>
       <p
-        class="box mm-text mm-text--body-md box--flex-direction-row box--color-text-default"
+        class="mm-box mm-text mm-text--body-md mm-box--margin-top-2 mm-box--color-text-default"
       >
         This is a description to warn the user of malicious or suspicious transactions.
       </p>
@@ -29,7 +29,7 @@ exports[`Security Provider Banner Alert should match snapshot 1`] = `
             class="disclosure__summary is-arrow"
           >
             <p
-              class="box mm-text mm-text--body-md box--flex-direction-row box--color-primary-default"
+              class="mm-box mm-text mm-text--body-md mm-box--color-primary-default"
             >
               [seeDetails]
             </p>
@@ -59,7 +59,7 @@ exports[`Security Provider Banner Alert should match snapshot 1`] = `
         </details>
       </div>
       <p
-        class="box mm-text mm-text--body-sm box--margin-top-2 box--flex-direction-row box--align-items-center box--color-text-alternative box--display-flex"
+        class="mm-box mm-text mm-text--body-sm mm-box--margin-top-2 mm-box--align-items-center mm-box--color-text-alternative"
       >
         <span
           class="box disclosure__summary--icon mm-icon mm-icon--size-sm box--margin-inline-end-1 box--display-inline-block box--flex-direction-row box--color-primary-default"

--- a/ui/components/app/security-provider-banner-alert/__snapshots__/security-provider-banner-alert.test.js.snap
+++ b/ui/components/app/security-provider-banner-alert/__snapshots__/security-provider-banner-alert.test.js.snap
@@ -1,0 +1,69 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Security Provider Banner Alert should match snapshot 1`] = `
+<div>
+  <div
+    class="box mm-banner-base mm-banner-alert mm-banner-alert--severity-danger box--margin-top-4 box--margin-right-4 box--margin-left-4 box--padding-3 box--padding-left-2 box--display-flex box--gap-2 box--flex-direction-row box--background-color-error-muted box--rounded-sm"
+  >
+    <span
+      class="box mm-icon mm-icon--size-lg box--display-inline-block box--flex-direction-row box--color-error-default"
+      style="mask-image: url('./images/icons/danger.svg');"
+    />
+    <div>
+      <h5
+        class="box mm-text mm-banner-base__title mm-text--body-lg-medium box--flex-direction-row box--color-text-default"
+        data-testid="mm-banner-base-title"
+      >
+        Title is sentence case no period
+      </h5>
+      <h6
+        class="box mm-text mm-text--body-sm box--margin-top-2 box--flex-direction-row box--color-text-default"
+      >
+        This is a description to warn the user of malicious or suspicious transactions.
+      </h6>
+      <div
+        class="disclosure"
+      >
+        <details>
+          <summary
+            class="disclosure__summary is-arrow"
+          >
+            [seeDetails]
+            <span
+              class="box disclosure__summary--icon mm-icon mm-icon--size-sm box--margin-inline-start-2 box--display-inline-block box--flex-direction-row box--color-inherit"
+              style="mask-image: url('./images/icons/arrow-up.svg');"
+            />
+          </summary>
+          <div
+            class="disclosure__content normal"
+          >
+            <ul>
+              <li>
+                List item
+              </li>
+              <li>
+                List item
+              </li>
+              <li>
+                List item
+              </li>
+            </ul>
+          </div>
+          <div
+            class="disclosure__footer"
+          />
+        </details>
+      </div>
+      <h6
+        class="box mm-text mm-text--body-sm box--margin-top-2 box--flex-direction-row box--align-items-center box--color-text-alternative box--display-flex"
+      >
+        <span
+          class="box disclosure__summary--icon mm-icon mm-icon--size-sm box--margin-inline-end-1 box--display-inline-block box--flex-direction-row box--color-primary-default"
+          style="mask-image: url('./images/icons/security-tick.svg');"
+        />
+        [securityProviderAdviceBy]
+      </h6>
+    </div>
+  </div>
+</div>
+`;

--- a/ui/components/app/security-provider-banner-alert/__snapshots__/security-provider-banner-alert.test.js.snap
+++ b/ui/components/app/security-provider-banner-alert/__snapshots__/security-provider-banner-alert.test.js.snap
@@ -11,7 +11,7 @@ exports[`Security Provider Banner Alert should match snapshot 1`] = `
     />
     <div>
       <h5
-        class="box mm-text mm-banner-base__title mm-text--body-lg-medium box--flex-direction-row box--color-text-default"
+        class="mm-box mm-text mm-banner-base__title mm-text--body-lg-medium mm-box--color-text-default"
         data-testid="mm-banner-base-title"
       >
         Malicious third party detected

--- a/ui/components/app/security-provider-banner-alert/index.js
+++ b/ui/components/app/security-provider-banner-alert/index.js
@@ -1,0 +1,1 @@
+export { default } from './security-provider-banner-alert';

--- a/ui/components/app/security-provider-banner-alert/security-provider-banner-alert.js
+++ b/ui/components/app/security-provider-banner-alert/security-provider-banner-alert.js
@@ -11,6 +11,7 @@ import {
 import {
   AlignItems,
   Color,
+  IconColor,
   Severity,
   Size,
   TextVariant,
@@ -57,7 +58,7 @@ function SecurityProviderBannerAlert({
       >
         <Icon
           className="disclosure__summary--icon"
-          color={Color.primaryDefault}
+          color={IconColor.primaryDefault}
           name={IconName.SecurityTick}
           size={IconSize.Sm}
           marginInlineEnd={1}

--- a/ui/components/app/security-provider-banner-alert/security-provider-banner-alert.js
+++ b/ui/components/app/security-provider-banner-alert/security-provider-banner-alert.js
@@ -45,7 +45,7 @@ function SecurityProviderBannerAlert({
       marginLeft={4}
     >
       {details && (
-        <Disclosure title={t('seeDetails')} type={DisclosureVariant.Arrow}>
+        <Disclosure title={t('seeDetails')} variant={DisclosureVariant.Arrow}>
           {details}
         </Disclosure>
       )}

--- a/ui/components/app/security-provider-banner-alert/security-provider-banner-alert.js
+++ b/ui/components/app/security-provider-banner-alert/security-provider-banner-alert.js
@@ -38,12 +38,13 @@ function SecurityProviderBannerAlert({
   return (
     <BannerAlert
       title={title}
-      description={description}
       severity={severity}
       marginTop={4}
       marginRight={4}
       marginLeft={4}
     >
+      <Text marginTop={2}>{description}</Text>
+
       {details && (
         <Disclosure title={t('seeDetails')} variant={DisclosureVariant.Arrow}>
           {details}

--- a/ui/components/app/security-provider-banner-alert/security-provider-banner-alert.js
+++ b/ui/components/app/security-provider-banner-alert/security-provider-banner-alert.js
@@ -1,0 +1,94 @@
+import React, { useContext } from 'react';
+import PropTypes from 'prop-types';
+import {
+  BannerAlert,
+  ButtonLink,
+  Icon,
+  IconName,
+  IconSize,
+  Text,
+} from '../../component-library';
+import {
+  AlignItems,
+  Color,
+  Severity,
+  Size,
+  TextVariant,
+} from '../../../helpers/constants/design-system';
+import { I18nContext } from '../../../../.storybook/i18n';
+
+import Disclosure from '../../ui/disclosure';
+import { DISCLOSURE_TYPES } from '../../ui/disclosure/disclosure.constants';
+import {
+  SecurityProvider,
+  SECURITY_PROVIDER_CONFIG,
+} from '../../../../shared/constants/security-provider';
+
+function SecurityProviderBannerAlert({
+  description,
+  details,
+  provider,
+  severity,
+  title,
+}) {
+  const t = useContext(I18nContext);
+
+  return (
+    <BannerAlert
+      title={title}
+      severity={severity}
+      marginTop={4}
+      marginRight={4}
+      marginLeft={4}
+    >
+      <Text variant={TextVariant.bodySm} as="h6" marginTop={2}>
+        {description}
+      </Text>
+
+      {details && (
+        <Disclosure title={t('seeDetails')} type={DISCLOSURE_TYPES.ARROW}>
+          {details}
+        </Disclosure>
+      )}
+
+      <Text
+        as="h6"
+        marginTop={2}
+        alignItems={AlignItems.center}
+        color={Color.textAlternative}
+        variant={TextVariant.bodySm}
+      >
+        <Icon
+          className="disclosure__summary--icon"
+          color={Color.primaryDefault}
+          name={IconName.SecurityTick}
+          size={IconSize.Sm}
+          marginInlineEnd={1}
+        />
+        {t('securityProviderAdviceBy', [
+          <ButtonLink
+            key="security-provider-button-link"
+            size={Size.inherit}
+            href={SECURITY_PROVIDER_CONFIG[provider].url}
+            externalLink
+          >
+            {t(SECURITY_PROVIDER_CONFIG[provider].tKeyName)}
+          </ButtonLink>,
+        ])}
+      </Text>
+    </BannerAlert>
+  );
+}
+
+SecurityProviderBannerAlert.propTypes = {
+  description: PropTypes.oneOf([PropTypes.string, PropTypes.element])
+    .isRequired,
+  provider: PropTypes.oneOf(Object.values(SecurityProvider)).isRequired,
+  severity: PropTypes.oneOf([Severity.Danger, Severity.Warning]).isRequired,
+  title: PropTypes.string.isRequired,
+
+  //  Optional
+  details: PropTypes.oneOf([PropTypes.string, PropTypes.element]),
+};
+
+export default SecurityProviderBannerAlert;

--- a/ui/components/app/security-provider-banner-alert/security-provider-banner-alert.js
+++ b/ui/components/app/security-provider-banner-alert/security-provider-banner-alert.js
@@ -8,6 +8,9 @@ import {
   IconSize,
   Text,
 } from '../../component-library';
+import Disclosure from '../../ui/disclosure';
+import { DisclosureVariant } from '../../ui/disclosure/disclosure.constants';
+
 import { I18nContext } from '../../../contexts/i18n';
 import {
   AlignItems,
@@ -18,8 +21,6 @@ import {
   TextVariant,
 } from '../../../helpers/constants/design-system';
 
-import Disclosure from '../../ui/disclosure';
-import { DisclosureVariant } from '../../ui/disclosure/disclosure.constants';
 import {
   SecurityProvider,
   SECURITY_PROVIDER_CONFIG,

--- a/ui/components/app/security-provider-banner-alert/security-provider-banner-alert.js
+++ b/ui/components/app/security-provider-banner-alert/security-provider-banner-alert.js
@@ -8,6 +8,7 @@ import {
   IconSize,
   Text,
 } from '../../component-library';
+import { I18nContext } from '../../../contexts/i18n';
 import {
   AlignItems,
   Color,
@@ -16,7 +17,6 @@ import {
   Size,
   TextVariant,
 } from '../../../helpers/constants/design-system';
-import { I18nContext } from '../../../../.storybook/i18n';
 
 import Disclosure from '../../ui/disclosure';
 import { DisclosureVariant } from '../../ui/disclosure/disclosure.constants';

--- a/ui/components/app/security-provider-banner-alert/security-provider-banner-alert.js
+++ b/ui/components/app/security-provider-banner-alert/security-provider-banner-alert.js
@@ -67,7 +67,7 @@ function SecurityProviderBannerAlert({
         />
         {t('securityProviderAdviceBy', [
           <ButtonLink
-            key="security-provider-button-link"
+            key={`security-provider-button-link-${provider}`}
             size={Size.inherit}
             href={SECURITY_PROVIDER_CONFIG[provider].url}
             externalLink

--- a/ui/components/app/security-provider-banner-alert/security-provider-banner-alert.js
+++ b/ui/components/app/security-provider-banner-alert/security-provider-banner-alert.js
@@ -81,14 +81,14 @@ function SecurityProviderBannerAlert({
 }
 
 SecurityProviderBannerAlert.propTypes = {
-  description: PropTypes.oneOf([PropTypes.string, PropTypes.element])
+  description: PropTypes.oneOfType([PropTypes.string, PropTypes.element])
     .isRequired,
-  provider: PropTypes.oneOf(Object.values(SecurityProvider)).isRequired,
-  severity: PropTypes.oneOf([Severity.Danger, Severity.Warning]).isRequired,
+  provider: PropTypes.oneOfType(Object.values(SecurityProvider)).isRequired,
+  severity: PropTypes.oneOfType([Severity.Danger, Severity.Warning]).isRequired,
   title: PropTypes.string.isRequired,
 
   //  Optional
-  details: PropTypes.oneOf([PropTypes.string, PropTypes.element]),
+  details: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
 };
 
 export default SecurityProviderBannerAlert;

--- a/ui/components/app/security-provider-banner-alert/security-provider-banner-alert.js
+++ b/ui/components/app/security-provider-banner-alert/security-provider-banner-alert.js
@@ -36,15 +36,12 @@ function SecurityProviderBannerAlert({
   return (
     <BannerAlert
       title={title}
+      description={description}
       severity={severity}
       marginTop={4}
       marginRight={4}
       marginLeft={4}
     >
-      <Text variant={TextVariant.bodySm} as="h6" marginTop={2}>
-        {description}
-      </Text>
-
       {details && (
         <Disclosure title={t('seeDetails')} type={DisclosureVariant.Arrow}>
           {details}

--- a/ui/components/app/security-provider-banner-alert/security-provider-banner-alert.js
+++ b/ui/components/app/security-provider-banner-alert/security-provider-banner-alert.js
@@ -18,7 +18,7 @@ import {
 import { I18nContext } from '../../../../.storybook/i18n';
 
 import Disclosure from '../../ui/disclosure';
-import { DISCLOSURE_TYPES } from '../../ui/disclosure/disclosure.constants';
+import { DisclosureVariant } from '../../ui/disclosure/disclosure.constants';
 import {
   SecurityProvider,
   SECURITY_PROVIDER_CONFIG,
@@ -46,7 +46,7 @@ function SecurityProviderBannerAlert({
       </Text>
 
       {details && (
-        <Disclosure title={t('seeDetails')} type={DISCLOSURE_TYPES.ARROW}>
+        <Disclosure title={t('seeDetails')} type={DisclosureVariant.Arrow}>
           {details}
         </Disclosure>
       )}

--- a/ui/components/app/security-provider-banner-alert/security-provider-banner-alert.js
+++ b/ui/components/app/security-provider-banner-alert/security-provider-banner-alert.js
@@ -51,7 +51,6 @@ function SecurityProviderBannerAlert({
       )}
 
       <Text
-        as="h6"
         marginTop={2}
         alignItems={AlignItems.center}
         color={Color.textAlternative}

--- a/ui/components/app/security-provider-banner-alert/security-provider-banner-alert.js
+++ b/ui/components/app/security-provider-banner-alert/security-provider-banner-alert.js
@@ -81,13 +81,24 @@ function SecurityProviderBannerAlert({
 }
 
 SecurityProviderBannerAlert.propTypes = {
+  /** Description content that may be plain text or contain hyperlinks */
   description: PropTypes.oneOfType([PropTypes.string, PropTypes.element])
     .isRequired,
+
+  /** Name of the security provider */
   provider: PropTypes.oneOfType(Object.values(SecurityProvider)).isRequired,
+
+  /** Severity level */
   severity: PropTypes.oneOfType([Severity.Danger, Severity.Warning]).isRequired,
+
+  /** Title to be passed as <BannerAlert> param */
   title: PropTypes.string.isRequired,
 
-  //  Optional
+  /**
+   * Optional
+   */
+
+  /** Additional details to be displayed under the description */
   details: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
 };
 

--- a/ui/components/app/security-provider-banner-alert/security-provider-banner-alert.stories.js
+++ b/ui/components/app/security-provider-banner-alert/security-provider-banner-alert.stories.js
@@ -1,8 +1,5 @@
 import React from 'react';
-import {
-  Severity,
-  TextVariant,
-} from '../../../helpers/constants/design-system';
+import { Severity } from '../../../helpers/constants/design-system';
 import { ButtonLink, BUTTON_LINK_SIZES, Text } from '../../component-library';
 import { SecurityProvider } from '../../../../shared/constants/security-provider';
 import SecurityProviderBannerAlert from './security-provider-banner-alert';
@@ -20,7 +17,7 @@ const MockDescriptionWithLinks = () => (
 );
 
 const MockDetailsList = () => (
-  <Text as="ul" variant={TextVariant.bodySm}>
+  <Text as="ul">
     <li>• List item</li>
     <li>• List item</li>
     <li>• List item</li>

--- a/ui/components/app/security-provider-banner-alert/security-provider-banner-alert.stories.js
+++ b/ui/components/app/security-provider-banner-alert/security-provider-banner-alert.stories.js
@@ -20,14 +20,12 @@ const MockDescriptionWithLinks = () => (
 );
 
 const MockDetailsList = () => (
-  <ul>
-    <Text variant={TextVariant.bodySm}>
-      <li>• List item</li>
-      <li>• List item</li>
-      <li>• List item</li>
-      <li>• List item</li>
-    </Text>
-  </ul>
+  <Text as="ul" variant={TextVariant.bodySm}>
+    <li>• List item</li>
+    <li>• List item</li>
+    <li>• List item</li>
+    <li>• List item</li>
+  </Text>
 );
 
 export default {

--- a/ui/components/app/security-provider-banner-alert/security-provider-banner-alert.stories.js
+++ b/ui/components/app/security-provider-banner-alert/security-provider-banner-alert.stories.js
@@ -1,6 +1,9 @@
 import React from 'react';
-import { Severity } from '../../../helpers/constants/design-system';
-import { ButtonLink, BUTTON_LINK_SIZES } from '../../component-library';
+import {
+  Severity,
+  TextVariant,
+} from '../../../helpers/constants/design-system';
+import { ButtonLink, BUTTON_LINK_SIZES, Text } from '../../component-library';
 import { SecurityProvider } from '../../../../shared/constants/security-provider';
 import SecurityProviderBannerAlert from './security-provider-banner-alert';
 
@@ -9,19 +12,21 @@ const mockPlainText =
   'amet laoreet vitae, semper in est. Nulla vel tristique felis. Donec non tellus eget neque cursus malesuada.';
 
 const MockDescriptionWithLinks = () => (
-  <span>
+  <>
     Description shouldn’t repeat title. 1-3 lines. Can contain a{' '}
     <ButtonLink size={BUTTON_LINK_SIZES.INHERIT}>hyperlink</ButtonLink>. It can
     also contain a toggle to enable progressive disclosure.
-  </span>
+  </>
 );
 
 const MockDetailsList = () => (
   <ul>
-    <li>• List item</li>
-    <li>• List item</li>
-    <li>• List item</li>
-    <li>• List item</li>
+    <Text variant={TextVariant.bodySm}>
+      <li>• List item</li>
+      <li>• List item</li>
+      <li>• List item</li>
+      <li>• List item</li>
+    </Text>
   </ul>
 );
 

--- a/ui/components/app/security-provider-banner-alert/security-provider-banner-alert.stories.js
+++ b/ui/components/app/security-provider-banner-alert/security-provider-banner-alert.stories.js
@@ -74,9 +74,13 @@ export default {
 };
 
 export const DefaultStory = (args) => (
-  <SecurityProviderBannerAlert severity={Severity.Danger} {...args} />
+  <SecurityProviderBannerAlert severity={Severity.Warning} {...args} />
 );
 DefaultStory.storyName = 'Default';
+
+export const Danger = (args) => (
+  <SecurityProviderBannerAlert severity={Severity.Danger} {...args} />
+);
 
 export const Warning = (args) => (
   <SecurityProviderBannerAlert severity={Severity.Warning} {...args} />

--- a/ui/components/app/security-provider-banner-alert/security-provider-banner-alert.stories.js
+++ b/ui/components/app/security-provider-banner-alert/security-provider-banner-alert.stories.js
@@ -1,0 +1,84 @@
+import React from 'react';
+import { Severity } from '../../../helpers/constants/design-system';
+import { ButtonLink, BUTTON_LINK_SIZES } from '../../component-library';
+import { SecurityProvider } from '../../../../shared/constants/security-provider';
+import SecurityProviderBannerAlert from './security-provider-banner-alert';
+
+const mockPlainText =
+  'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sapien tellus, elementum sit ' +
+  'amet laoreet vitae, semper in est. Nulla vel tristique felis. Donec non tellus eget neque cursus malesuada.';
+
+const MockDescriptionWithLinks = () => (
+  <span>
+    Description shouldn’t repeat title. 1-3 lines. Can contain a{' '}
+    <ButtonLink size={BUTTON_LINK_SIZES.INHERIT}>hyperlink</ButtonLink>. It can
+    also contain a toggle to enable progressive disclosure.
+  </span>
+);
+
+const MockDetailsList = () => (
+  <ul>
+    <li>• List item</li>
+    <li>• List item</li>
+    <li>• List item</li>
+    <li>• List item</li>
+  </ul>
+);
+
+export default {
+  title: 'Components/App/SecurityProviderBannerAlert',
+
+  argTypes: {
+    description: {
+      control: {
+        type: 'select',
+      },
+      options: ['plainText', 'withLinks'],
+      mapping: {
+        plainText: mockPlainText,
+        withLinks: <MockDescriptionWithLinks />,
+      },
+    },
+    details: {
+      control: {
+        type: 'select',
+      },
+      options: ['none', 'plainText', 'withList'],
+      mapping: {
+        none: null,
+        plainText: mockPlainText,
+        withList: <MockDetailsList />,
+      },
+    },
+    provider: {
+      control: {
+        type: 'select',
+      },
+      options: [Object.values(SecurityProvider)],
+    },
+    severity: {
+      control: {
+        type: 'select',
+      },
+      options: [Severity.Danger, Severity.Warning],
+    },
+    title: {
+      control: 'text',
+    },
+  },
+  args: {
+    title: 'Title is sentence case no period',
+    description: <MockDescriptionWithLinks />,
+    details: <MockDetailsList />,
+    provider: SecurityProvider.Blockaid,
+  },
+};
+
+export const DefaultStory = (args) => (
+  <SecurityProviderBannerAlert severity={Severity.Danger} {...args} />
+);
+DefaultStory.storyName = 'Default';
+
+export const Warning = (args) => (
+  <SecurityProviderBannerAlert severity={Severity.Warning} {...args} />
+);

--- a/ui/components/app/security-provider-banner-alert/security-provider-banner-alert.stories.js
+++ b/ui/components/app/security-provider-banner-alert/security-provider-banner-alert.stories.js
@@ -32,7 +32,6 @@ const MockDetailsList = () => (
 
 export default {
   title: 'Components/App/SecurityProviderBannerAlert',
-
   argTypes: {
     description: {
       control: {

--- a/ui/components/app/security-provider-banner-alert/security-provider-banner-alert.test.js
+++ b/ui/components/app/security-provider-banner-alert/security-provider-banner-alert.test.js
@@ -41,9 +41,6 @@ describe('Security Provider Banner Alert', () => {
       />,
     );
 
-    const btn = container.querySelector('.mm-button-link');
-    console.log(btn);
-
     expect(getByText(mockTitle)).toBeInTheDocument();
     expect(getByText(mockDescription)).toBeInTheDocument();
     expect(container.querySelector('.disclosure')).toBeInTheDocument();

--- a/ui/components/app/security-provider-banner-alert/security-provider-banner-alert.test.js
+++ b/ui/components/app/security-provider-banner-alert/security-provider-banner-alert.test.js
@@ -1,0 +1,64 @@
+import React from 'react';
+import { Severity } from '../../../helpers/constants/design-system';
+import { renderWithProvider } from '../../../../test/lib/render-helpers';
+import { SecurityProvider } from '../../../../shared/constants/security-provider';
+import SecurityProviderBannerAlert from '.';
+
+const mockTitle = 'Malicious third party detected';
+const mockDescription =
+  'This is a description to warn the user of malicious or suspicious transactions.';
+const mockDetails = (
+  <ul>
+    <li>List item</li>
+    <li>List item</li>
+    <li>List item</li>
+  </ul>
+);
+
+describe('Security Provider Banner Alert', () => {
+  it('should match snapshot', () => {
+    const { container } = renderWithProvider(
+      <SecurityProviderBannerAlert
+        description={mockDescription}
+        details={mockDetails}
+        provider={SecurityProvider.Blockaid}
+        severity={Severity.Danger}
+        title={mockTitle}
+      />,
+    );
+
+    expect(container).toMatchSnapshot();
+  });
+
+  it('should render', () => {
+    const { container, getByText } = renderWithProvider(
+      <SecurityProviderBannerAlert
+        description={mockDescription}
+        details={mockDetails}
+        provider={SecurityProvider.Blockaid}
+        severity={Severity.Danger}
+        title={mockTitle}
+      />,
+    );
+
+    const btn = container.querySelector('.mm-button-link');
+    console.log(btn);
+
+    expect(getByText(mockTitle)).toBeInTheDocument();
+    expect(getByText(mockDescription)).toBeInTheDocument();
+    expect(container.querySelector('.disclosure')).toBeInTheDocument();
+  });
+
+  it('should not render disclosure component if no details were provided', () => {
+    const { container } = renderWithProvider(
+      <SecurityProviderBannerAlert
+        description={mockDescription}
+        provider={SecurityProvider.Blockaid}
+        severity={Severity.Danger}
+        title={mockTitle}
+      />,
+    );
+
+    expect(container.querySelector('.disclosure')).not.toBeInTheDocument();
+  });
+});

--- a/ui/components/ui/disclosure/disclosure.js
+++ b/ui/components/ui/disclosure/disclosure.js
@@ -51,30 +51,6 @@ const Disclosure = ({ children, title, size, variant }) => {
   const disclosureFooterEl = useRef(null);
   const [open, setOpen] = useState(false);
 
-  const renderArrowSummary = () => (
-    <summary className="disclosure__summary is-arrow">
-      {title}
-      <Icon
-        className="disclosure__summary--icon"
-        name={IconName.ArrowUp}
-        size={IconSize.Sm}
-        marginInlineStart={2}
-      />
-    </summary>
-  );
-
-  const renderPlusSummary = () => (
-    <summary className="disclosure__summary">
-      <Icon
-        className="disclosure__summary--icon"
-        name={IconName.Add}
-        size={IconSize.Sm}
-        marginInlineEnd={2}
-      />
-      {title}
-    </summary>
-  );
-
   const scrollToBottom = () => {
     disclosureFooterEl &&
       disclosureFooterEl.current &&

--- a/ui/components/ui/disclosure/disclosure.js
+++ b/ui/components/ui/disclosure/disclosure.js
@@ -51,6 +51,30 @@ const Disclosure = ({ children, title, size, variant }) => {
   const disclosureFooterEl = useRef(null);
   const [open, setOpen] = useState(false);
 
+  const renderArrowSummary = () => (
+    <summary className="disclosure__summary is-arrow">
+      {title}
+      <Icon
+        className="disclosure__summary--icon"
+        name={IconName.ArrowUp}
+        size={IconSize.Sm}
+        marginInlineStart={2}
+      />
+    </summary>
+  );
+
+  const renderPlusSummary = () => (
+    <summary className="disclosure__summary">
+      <Icon
+        className="disclosure__summary--icon"
+        name={IconName.Add}
+        size={IconSize.Sm}
+        marginInlineEnd={2}
+      />
+      {title}
+    </summary>
+  );
+
   const scrollToBottom = () => {
     disclosureFooterEl &&
       disclosureFooterEl.current &&


### PR DESCRIPTION
## Explanation

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/558
Blocked By: https://github.com/MetaMask/metamask-extension/issues/19768
Blocks: https://github.com/MetaMask/metamask-extension/issues/19257

We will be replacing the OpenSea security provider warning message. The current SecurityProviderBannerMessage component that displays this has specific logic for OpenSea. This PR creates a new UI component that allows for scalability and general use cases. UI differences from the OpenSea provider warning message include the option to include details, an updated footer copy, and a SecurityTick icon.

## Screenshots/Screencaps

### New Component 

![Screen Shot 2023-06-29 at 4 44 33 PM](https://github.com/MetaMask/metamask-extension/assets/20778143/66b01333-0dde-4710-98d0-9a3b559c14e3)

## Manual Testing Steps

1. run storybook - `yarn storybook`
2. view new component - http://localhost:6006/?path=/docs/components-app-securityproviderbanneralert--docs

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [x] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [x] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
