### PR TITLE
fix: skip snow usage for MV3 test build

### DIFF
--- a/app/scripts/app-init.js
+++ b/app/scripts/app-init.js
@@ -60,8 +60,10 @@ function importAllScripts() {
   loadFile('./globalthis.js');
   loadFile('./sentry-install.js');
 
-  const isWorker = !self.document
-  if (!isWorker) { // process.env.ENABLE_MV3 ?
+  // eslint-disable-next-line no-undef
+  const isWorker = !self.document;
+  if (!isWorker) {
+    // process.env.ENABLE_MV3 ?
     loadFile('./snow.js');
   }
 

--- a/app/scripts/app-init.js
+++ b/app/scripts/app-init.js
@@ -60,6 +60,13 @@ function importAllScripts() {
   loadFile('./globalthis.js');
   loadFile('./sentry-install.js');
 
+  const isWorker = !self.document
+  if (!isWorker) { // process.env.ENABLE_MV3 ?
+    loadFile('./snow.js');
+  }
+
+  loadFile('./use-snow.js');
+
   // Always apply LavaMoat in e2e test builds, so that we can capture initialization stats
   if (testMode || applyLavaMoat) {
     loadFile('./runtime-lavamoat.js');

--- a/app/scripts/app-init.js
+++ b/app/scripts/app-init.js
@@ -63,7 +63,6 @@ function importAllScripts() {
   // eslint-disable-next-line no-undef
   const isWorker = !self.document;
   if (!isWorker) {
-    // process.env.ENABLE_MV3 ?
     loadFile('./snow.js');
   }
 

--- a/app/scripts/use-snow.js
+++ b/app/scripts/use-snow.js
@@ -8,14 +8,19 @@ Changing this code must be done cautiously to avoid breaking the app!
 // eslint-disable-next-line import/unambiguous
 (function () {
   const log = console.log.bind(console);
+  const isWorker = !self.document; // process.env.ENABLE_MV3 ?
   const msg =
     'Snow detected a new realm creation attempt in MetaMask. Performing scuttling on new realm.';
-  Object.defineProperty(window.top, 'SCUTTLER', {
+  Object.defineProperty(self, 'SCUTTLER', {
     value: (realm, scuttle) => {
-      window.top.SNOW((win) => {
-        log(msg, win);
-        scuttle(win);
-      }, realm);
+      if (isWorker) {
+        scuttle(realm);
+      } else {
+        self.SNOW((win) => {
+          log(msg, win);
+          scuttle(win);
+        }, realm);
+      }
     },
   });
 })();

--- a/app/scripts/use-snow.js
+++ b/app/scripts/use-snow.js
@@ -8,14 +8,17 @@ Changing this code must be done cautiously to avoid breaking the app!
 // eslint-disable-next-line import/unambiguous
 (function () {
   const log = console.log.bind(console);
-  const isWorker = !self.document; // process.env.ENABLE_MV3 ?
+  // eslint-disable-next-line no-undef
+  const isWorker = !self.document;
   const msg =
     'Snow detected a new realm creation attempt in MetaMask. Performing scuttling on new realm.';
+  // eslint-disable-next-line no-undef
   Object.defineProperty(self, 'SCUTTLER', {
     value: (realm, scuttle) => {
       if (isWorker) {
         scuttle(realm);
       } else {
+        // eslint-disable-next-line no-undef
         self.SNOW((win) => {
           log(msg, win);
           scuttle(win);


### PR DESCRIPTION
This [MR](https://github.com/MetaMask/metamask-extension/pull/17969) introduced the problem, integrates Snow usage with LavaMoat to protect the application.

- Snow is a browser JS security solution, and therefore it expects the context it tries to defend to have a DOM.
- In MV3, we no longer have a background context with a DOM, but a service worker that is DOM-less.
- Therefore, `use-snow.js` file fails, because it expects `window `to exist, but in a service worker it doesn't.

The proposed fix is pretty simple, detect runtime execution env is a worker, and if so, skip using Snow.