### PR TITLE
Disable the opensea provider and NFT feature What's New notifications

### DIFF
--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -991,8 +991,8 @@ function getAllowedAnnouncementIds(state) {
     15: false,
     16: false,
     17: false,
-    18: true,
-    19: true,
+    18: false,
+    19: false,
     20: currentKeyringIsLedger && isFirefox,
     21: isSwapsChain,
   };


### PR DESCRIPTION
## Explanation

Removes old opensea provider and nft feature What's New notifications

### Before


https://github.com/MetaMask/metamask-extension/assets/7499938/2fa9228b-4552-4c48-adbd-bf3ff4811105



### After


https://github.com/MetaMask/metamask-extension/assets/7499938/ea7c5d1c-0d28-4f73-8f98-b9a0041ebfed



## Manual Testing Steps

Install wallet and go through onboarding flow with the "import" option. After onboarding is complete, only the Swaps notification should be shown

## Pre-merge author checklist

- [ ] I've clearly explained:
  - [ ] What problem this PR is solving
  - [ ] How this problem was solved
  - [ ] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
