### PR TITLE
[MMI] Removed institutional portfolio dashboard

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -673,9 +673,6 @@
   "coingecko": {
     "message": "CoinGecko"
   },
-  "compliance": {
-    "message": "Compliance"
-  },
   "complianceActivatedDesc": {
     "message": "You can now use compliance in MetaMask Institutional. Receiving AML/CFT analysis within the confirmation screen on all the addresses you interact with."
   },

--- a/ui/components/multichain/global-menu/global-menu.js
+++ b/ui/components/multichain/global-menu/global-menu.js
@@ -114,44 +114,22 @@ export const GlobalMenu = ({ closeMenu, anchorElement }) => {
 
       {
         ///: BEGIN:ONLY_INCLUDE_IN(build-mmi)
-        <>
-          {mmiPortfolioEnabled && (
-            <MenuItem
-              iconName={IconName.Diagram}
-              onClick={() => {
-                trackEvent({
-                  category: MetaMetricsEventCategory.Navigation,
-                  event: MetaMetricsEventName.UserClickedPortfolioButton,
-                });
-                window.open(mmiPortfolioUrl, '_blank');
-                closeMenu();
-              }}
-              data-testid="global-menu-mmi-portfolio"
-            >
-              {t('portfolioDashboard')}
-            </MenuItem>
-          )}
-
+        mmiPortfolioEnabled && (
           <MenuItem
-            iconName={IconName.Compliance}
+            iconName={IconName.Diagram}
             onClick={() => {
               trackEvent({
                 category: MetaMetricsEventCategory.Navigation,
-                event: MetaMetricsEventName.UserClickedCompliance,
+                event: MetaMetricsEventName.UserClickedPortfolioButton,
               });
-              if (getEnvironmentType() === ENVIRONMENT_TYPE_POPUP) {
-                global.platform.openExtensionInBrowser(
-                  COMPLIANCE_FEATURE_ROUTE,
-                );
-              } else {
-                history.push(COMPLIANCE_FEATURE_ROUTE);
-              }
+              window.open(mmiPortfolioUrl, '_blank');
+              closeMenu();
             }}
-            data-testid="global-menu-mmi-compliance"
+            data-testid="global-menu-mmi-portfolio"
           >
-            {t('compliance')}
+            {t('portfolioDashboard')}
           </MenuItem>
-        </>
+        )
         ///: END:ONLY_INCLUDE_IN
       }
 

--- a/ui/components/multichain/global-menu/global-menu.js
+++ b/ui/components/multichain/global-menu/global-menu.js
@@ -9,9 +9,6 @@ import {
   ///: BEGIN:ONLY_INCLUDE_IN(snaps)
   NOTIFICATIONS_ROUTE,
   ///: END:ONLY_INCLUDE_IN(snaps)
-  ///: BEGIN:ONLY_INCLUDE_IN(build-mmi)
-  COMPLIANCE_FEATURE_ROUTE,
-  ///: END:ONLY_INCLUDE_IN
 } from '../../../helpers/constants/routes';
 import { lockMetamask } from '../../../store/actions';
 import { useI18nContext } from '../../../hooks/useI18nContext';
@@ -23,12 +20,7 @@ import {
 } from '../../component-library';
 import { Menu, MenuItem } from '../../ui/menu';
 import { getEnvironmentType } from '../../../../app/scripts/lib/util';
-import {
-  ENVIRONMENT_TYPE_FULLSCREEN,
-  ///: BEGIN:ONLY_INCLUDE_IN(build-mmi)
-  ENVIRONMENT_TYPE_POPUP,
-  ///: END:ONLY_INCLUDE_IN
-} from '../../../../shared/constants/app';
+import { ENVIRONMENT_TYPE_FULLSCREEN } from '../../../../shared/constants/app';
 import { SUPPORT_LINK } from '../../../../shared/lib/ui-utils';
 ///: BEGIN:ONLY_INCLUDE_IN(build-beta,build-flask)
 import { SUPPORT_REQUEST_LINK } from '../../../helpers/constants/common';


### PR DESCRIPTION
## Explanation

We don’t want our users to navigate to the compliance page, so that we can remove the Compliance link from the dropdown menu in the home view.

![image](https://github.com/MetaMask/metamask-extension/assets/1182864/1b6fa6eb-2628-401e-99e6-36ff63257c93)

**AC:**

The compliance page link doesn’t exist anymore in the dropdown menu. 

A PR with these changes has been created for the MM team to review

**Ticket:**
https://consensyssoftware.atlassian.net/browse/MMI-3322

## Pre-merge author checklist

- [X] I've clearly explained:
  - [X] What problem this PR is solving
  - [X] How this problem was solved

## Pre-merge reviewer checklist

- [X] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [X] PR is linked to the appropriate GitHub issue
