### PR TITLE
[MMI] Added code fences to updateExtensionUninstallUrl

### DIFF
--- a/app/scripts/controllers/metametrics.js
+++ b/app/scripts/controllers/metametrics.js
@@ -435,7 +435,10 @@ export default class MetaMetricsController {
       this.clearEventsAfterMetricsOptIn();
     }
 
+    ///: BEGIN:ONLY_INCLUDE_IN(build-main,build-beta,build-flask)
     this.updateExtensionUninstallUrl(participateInMetaMetrics, metaMetricsId);
+    ///: END:ONLY_INCLUDE_IN
+
     return metaMetricsId;
   }
 


### PR DESCRIPTION
## Explanation

When the user removes the extension from the browser, MM opens this page automatically.
We don’t have it in our current extension, so for now, at least, it doesn’t make sense to show it either.

![image](https://github.com/MetaMask/metamask-extension/assets/1182864/bc978c58-b8ee-43c8-819a-045298f8c394)

**AC:**

When the user removes the extension, this page doesn’t open anymore.

**Ticket:**
https://consensyssoftware.atlassian.net/browse/MMI-3341

## Pre-merge author checklist

- [X] I've clearly explained:
  - [X] What problem this PR is solving
  - [X] How this problem was solved

## Pre-merge reviewer checklist

- [X] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [X] PR is linked to the appropriate GitHub issue
