### PR TITLE
Fix hold to reveal button on mobile browsers

### DIFF
--- a/ui/components/app/hold-to-reveal-button/hold-to-reveal-button.js
+++ b/ui/components/app/hold-to-reveal-button/hold-to-reveal-button.js
@@ -2,11 +2,9 @@ import React, { useCallback, useContext, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { I18nContext } from '../../../contexts/i18n';
-import { Button } from '../../component-library';
-import Box from '../../ui/box';
 import {
   AlignItems,
-  DISPLAY,
+  Display,
   JustifyContent,
 } from '../../../helpers/constants/design-system';
 import { MetaMetricsContext } from '../../../contexts/metametrics';
@@ -15,6 +13,7 @@ import {
   MetaMetricsEventKeyType,
   MetaMetricsEventName,
 } from '../../../../shared/constants/metametrics';
+import { Button, Box } from '../../component-library';
 
 const radius = 14;
 const strokeWidth = 2;
@@ -131,7 +130,7 @@ export default function HoldToRevealButton({ buttonText, onLongPressed }) {
           </svg>
         </Box>
         <Box
-          display={DISPLAY.FLEX}
+          display={Display.Flex}
           alignItems={AlignItems.center}
           justifyContent={JustifyContent.center}
           className="hold-to-reveal-button__lock-icon-container"
@@ -197,10 +196,10 @@ export default function HoldToRevealButton({ buttonText, onLongPressed }) {
 
   return (
     <Button
-      onMouseDown={onMouseDown}
-      onMouseUp={onMouseUp}
+      onPointerDown={onMouseDown} // allows for touch and mouse events
+      onPointerUp={onMouseUp} // allows for touch and mouse events
       className="hold-to-reveal-button__button-hold"
-      textProps={{ display: DISPLAY.FLEX, alignItems: AlignItems.center }}
+      textProps={{ display: Display.Flex, alignItems: AlignItems.center }}
     >
       <Box className="hold-to-reveal-button__icon-container" marginRight={2}>
         {renderPreCompleteContent()}

--- a/ui/components/app/hold-to-reveal-button/hold-to-reveal-button.test.js
+++ b/ui/components/app/hold-to-reveal-button/hold-to-reveal-button.test.js
@@ -86,7 +86,7 @@ describe('HoldToRevealButton', () => {
 
     const button = getByText('Hold to reveal SRP');
 
-    fireEvent.mouseDown(button);
+    fireEvent.pointerDown(button);
 
     const circleLocked = getByLabelText('hold to reveal circle locked');
     fireEvent.transitionEnd(circleLocked);

--- a/ui/components/app/modals/export-private-key-modal/export-private-key-modal.component.test.js
+++ b/ui/components/app/modals/export-private-key-modal/export-private-key-modal.component.test.js
@@ -114,7 +114,7 @@ describe('Export Private Key Modal', () => {
     const holdButton = getByText('Hold to reveal Private Key');
     expect(holdButton).toBeInTheDocument();
 
-    fireEvent.mouseDown(holdButton);
+    fireEvent.pointerDown(holdButton);
 
     const circle = getByLabelText('hold to reveal circle locked');
     fireEvent.transitionEnd(circle);

--- a/ui/components/app/modals/hold-to-reveal-modal/hold-to-reveal-modal.test.js
+++ b/ui/components/app/modals/hold-to-reveal-modal/hold-to-reveal-modal.test.js
@@ -67,7 +67,7 @@ describe('Hold to Reveal Modal', () => {
 
     expect(holdButton).toBeDefined();
 
-    fireEvent.mouseUp(holdButton);
+    fireEvent.pointerUp(holdButton);
 
     expect(holdButton).toBeDefined();
   });
@@ -84,7 +84,7 @@ describe('Hold to Reveal Modal', () => {
     const holdButton = getByText('Hold to reveal SRP');
     const circleLocked = queryByLabelText('hold to reveal circle locked');
 
-    fireEvent.mouseDown(holdButton);
+    fireEvent.pointerDown(holdButton);
     fireEvent.transitionEnd(circleLocked);
 
     const circleUnlocked = queryByLabelText('hold to reveal circle unlocked');
@@ -164,7 +164,7 @@ describe('Hold to Reveal Modal', () => {
     const holdButton = getByText('Hold to reveal SRP');
     const circleLocked = queryByLabelText('hold to reveal circle locked');
 
-    fireEvent.mouseDown(holdButton);
+    fireEvent.pointerDown(holdButton);
     fireEvent.transitionEnd(circleLocked);
 
     const circleUnlocked = queryByLabelText('hold to reveal circle unlocked');

--- a/ui/components/app/modals/hold-to-reveal-modal/hold-to-reveal-modal.test.js
+++ b/ui/components/app/modals/hold-to-reveal-modal/hold-to-reveal-modal.test.js
@@ -92,7 +92,7 @@ describe('Hold to Reveal Modal', () => {
 
     await waitFor(() => {
       expect(holdButton.firstChild).toHaveClass(
-        'box hold-to-reveal-button__icon-container box--flex-direction-row',
+        'hold-to-reveal-button__icon-container',
       );
       expect(onLongPressStub).toHaveBeenCalled();
     });
@@ -172,7 +172,7 @@ describe('Hold to Reveal Modal', () => {
 
     await waitFor(() => {
       expect(holdButton.firstChild).toHaveClass(
-        'box hold-to-reveal-button__icon-container box--flex-direction-row',
+        'hold-to-reveal-button__icon-container',
       );
       expect(onLongPressStub).toHaveBeenCalled();
       expect(hideModalStub).not.toHaveBeenCalled();

--- a/ui/pages/keychains/reveal-seed.test.js
+++ b/ui/pages/keychains/reveal-seed.test.js
@@ -216,7 +216,7 @@ describe('Reveal Seed Page', () => {
     const holdButton = getByText('Hold to reveal SRP');
     const circleLocked = queryByLabelText('hold to reveal circle locked');
 
-    fireEvent.mouseDown(holdButton);
+    fireEvent.pointerDown(holdButton);
     fireEvent.transitionEnd(circleLocked);
 
     const circleUnlocked = queryByLabelText('hold to reveal circle unlocked');
@@ -224,7 +224,7 @@ describe('Reveal Seed Page', () => {
 
     await waitFor(() => {
       expect(holdButton.firstChild).toHaveClass(
-        'box hold-to-reveal-button__icon-container box--flex-direction-row',
+        'hold-to-reveal-button__icon-container',
       );
       // tests that the mock srp is now shown.
       expect(getByText('test srp')).toBeInTheDocument();


### PR DESCRIPTION
## Explanation

Currently users who use the extension on their mobile devices are not able to reveal their SRP because the hold to reveal button is not working. This PR changes the `onMouseDown` and `onMouseUp` events to `onPointerDown` and `onPointerUp` which "integrates various inputs from mice, touchscreens, and pens, making separate implementations no longer necessary and authoring for cross-device pointers easier."

https://caniuse.com/pointer

<img width="1411" alt="Screenshot 2023-06-30 at 7 03 51 AM" src="https://github.com/MetaMask/metamask-extension/assets/8112138/94d76a73-b6c6-4f24-94ca-7edbbc6171b1">


## Screenshots/Screencaps

<!-- If you're making a change to the UI, make sure to capture a screenshot or a short video showing off your work! -->

### Before
Checking the story of the `HoldToRevealButton` on an iPhone doesn't work

https://github.com/MetaMask/metamask-extension/assets/8112138/e9387e3d-ee01-4393-9562-adfeb3852f2a

### After

Checking story of the `HoldToRevealButton` on iPhone

https://github.com/MetaMask/metamask-extension/assets/8112138/f23b1734-e870-4a5f-843b-3adf2ae7d5a8

Still working in extension in Chrome browsers

https://github.com/MetaMask/metamask-extension/assets/8112138/68f53cce-4ebc-434f-aad5-cf50b1290aa4

## Manual Testing Steps

- On a mobile device
- Go to the storybook build on this PR
- Search `HoldToRevealButton` 
- Press down to see if circle loader completes and lock icon unlocks

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
