### PR TITLE
Fix #19856 - Don't AutoClose Modals when Popover items are clicked

### DIFF
--- a/ui/components/component-library/modal-content/modal-content.tsx
+++ b/ui/components/component-library/modal-content/modal-content.tsx
@@ -44,6 +44,17 @@ export const ModalContent = forwardRef(
     };
 
     const handleClickOutside = (event: MouseEvent) => {
+      // Popover should be launched from within Modal but
+      // the Popover containing element is a sibling to modal,
+      // so this is required to ensure `onClose` isn't triggered
+      // when clicking on a popover item
+      if (
+        isClosedOnOutsideClick &&
+        (event.target as HTMLElement).closest('.mm-popover')
+      ) {
+        return;
+      }
+
       if (
         isClosedOnOutsideClick &&
         modalDialogRef?.current &&


### PR DESCRIPTION
## Explanation

The `handleClickOutside` of `ModalContent` is too aggressive, and will trigger `onClose` if the user clicks a `Popover` item  that was triggered by a Modal action.  Since the `Modal` and `Popover` container elements are siblings, `handleClickOutside` triggers that `onClose`.  This PR makes `ModalContent` check to see if the mousedown target is in a `Popover`, and doesn't close the modal accordingly.

* Fixes #19856 
* Blocks https://github.com/MetaMask/metamask-extension/pull/19553

## Manual Testing Steps

1.  Check out https://github.com/MetaMask/metamask-extension/pull/19809#pullrequestreview-1503755753
2. Apply this PR
3. Open the Accounts menu
4. Click the three-dot menu of any account
5. Click the "Account details" item
6. See the Account Details Popover open, and modal close

## Pre-merge author checklist

- [ ] I've clearly explained:
  - [ ] What problem this PR is solving
  - [ ] How this problem was solved
  - [ ] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
