### PR TITLE
[MMI] Adds missing return for MMI

### DIFF
--- a/app/scripts/controllers/transactions/index.js
+++ b/app/scripts/controllers/transactions/index.js
@@ -1305,6 +1305,8 @@ export default class TransactionController extends EventEmitter {
         txMeta.custodyId,
         fromAddress,
       );
+
+      return null;
     }
     ///: END:ONLY_INCLUDE_IN
 
@@ -1313,12 +1315,6 @@ export default class TransactionController extends EventEmitter {
     txMeta.r = addHexPrefix(signedEthTx.r.toString(16));
     txMeta.s = addHexPrefix(signedEthTx.s.toString(16));
     txMeta.v = addHexPrefix(signedEthTx.v.toString(16));
-
-    ///: BEGIN:ONLY_INCLUDE_IN(build-mmi)
-    if (txMeta.custodyStatus) {
-      return null;
-    }
-    ///: END:ONLY_INCLUDE_IN
 
     this.txStateManager.updateTransaction(
       txMeta,

--- a/app/scripts/controllers/transactions/index.js
+++ b/app/scripts/controllers/transactions/index.js
@@ -1314,6 +1314,12 @@ export default class TransactionController extends EventEmitter {
     txMeta.s = addHexPrefix(signedEthTx.s.toString(16));
     txMeta.v = addHexPrefix(signedEthTx.v.toString(16));
 
+    ///: BEGIN:ONLY_INCLUDE_IN(build-mmi)
+    if (txMeta.custodyStatus) {
+      return null;
+    }
+    ///: END:ONLY_INCLUDE_IN
+
     this.txStateManager.updateTransaction(
       txMeta,
       'transactions#signTransaction: add r, s, v values',


### PR DESCRIPTION
When a transaction has a custodyStatus it means it comes from a custodian account and therefore we don’t want MM to update it and mark it as signed automatically, because this has to be done on the custodian side and can happen at any time.

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [x] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
