### PR TITLE
Add improved downloading logic when exporting state logs

### DIFF
--- a/test/e2e/tests/backup-restore.spec.js
+++ b/test/e2e/tests/backup-restore.spec.js
@@ -56,6 +56,10 @@ describe('Backup and Restore', function () {
     ],
   };
   it('should backup the account settings', async function () {
+    if (process.env.SELENIUM_BROWSER === 'chrome') {
+      // Chrome shows OS level download prompt which can't be dismissed by Selenium
+      this.skip();
+    }
     await withFixtures(
       {
         fixtures: new FixtureBuilder().build(),
@@ -97,6 +101,10 @@ describe('Backup and Restore', function () {
   });
 
   it('should restore the account settings', async function () {
+    if (process.env.SELENIUM_BROWSER === 'chrome') {
+      // Chrome shows OS level download prompt which can't be dismissed by Selenium
+      this.skip();
+    }
     await withFixtures(
       {
         fixtures: new FixtureBuilder().build(),

--- a/test/e2e/tests/state-logs.spec.js
+++ b/test/e2e/tests/state-logs.spec.js
@@ -30,7 +30,12 @@ describe('State logs', function () {
       },
     ],
   };
+
   it('should download state logs for the account', async function () {
+    if (process.env.SELENIUM_BROWSER === 'chrome') {
+      // Chrome shows OS level download prompt which can't be dismissed by Selenium
+      this.skip();
+    }
     await withFixtures(
       {
         fixtures: new FixtureBuilder().build(),

--- a/ui/helpers/utils/export-utils.js
+++ b/ui/helpers/utils/export-utils.js
@@ -1,11 +1,93 @@
-import { getRandomFileName } from './util';
+/**
+ * @enum { string }
+ */
+export const ExportableContentType = {
+  JSON: 'application/json',
+  TXT: 'text/plain',
+};
 
-export function exportAsFile(filename, data, type = 'text/csv') {
+/**
+ * @enum { string }
+ */
+const ExtensionForContentType = {
+  [ExportableContentType.JSON]: '.json',
+  [ExportableContentType.TXT]: '.txt',
+};
+
+/**
+ * Export data as a file.
+ *
+ * @param {string} filename - The name of the file to export.
+ * @param {string} data - The data to export.
+ * @param {ExportableContentType} contentType - The content type of the file to export.
+ */
+export async function exportAsFile(filename, data, contentType) {
+  if (!ExtensionForContentType[contentType]) {
+    throw new Error(`Unsupported file type: ${contentType}`);
+  }
+
+  if (supportsShowSaveFilePicker()) {
+    // Preferred method for downloads
+    await saveFileUsingFilePicker(filename, data, contentType);
+  } else {
+    saveFileUsingDataUri(filename, data, contentType);
+  }
+}
+/**
+ * Notes if the browser supports the File System Access API.
+ *
+ * @returns {boolean}
+ */
+function supportsShowSaveFilePicker() {
+  return (
+    typeof window !== 'undefined' &&
+    typeof window.showSaveFilePicker !== 'undefined'
+  );
+}
+
+/**
+ * Saves a file using the File System Access API.
+ *
+ * @param {string} filename - The name of the file to export.
+ * @param {string} data - The data to export.
+ * @param {ExportableContentType} contentType - The content type of the file to export.
+ * @returns {Promise<void>}
+ */
+async function saveFileUsingFilePicker(filename, data, contentType) {
+  // eslint-disable-next-line no-undef
+  const blob = new Blob([data], { contentType });
+  const fileExtension = ExtensionForContentType[contentType];
+
+  const handle = await window.showSaveFilePicker({
+    suggestedName: filename,
+    types: [
+      {
+        description: filename,
+        accept: {
+          [contentType]: [fileExtension],
+        },
+      },
+    ],
+  });
+
+  const writable = await handle.createWritable();
+  await writable.write(blob);
+  await writable.close();
+}
+
+/**
+ * Saves a file using a data URI.
+ * This is a fallback for browsers that do not support the File System Access API.
+ * This method is less preferred because it requires the entire file to be encoded in a data URI.
+ *
+ * @param {string} filename - The name of the file to export.
+ * @param {string} data - The data to export.
+ * @param {ExportableContentType} contentType - The content type of the file to export.
+ */
+function saveFileUsingDataUri(filename, data, contentType) {
   const b64 = Buffer.from(data, 'utf8').toString('base64');
-  // eslint-disable-next-line no-param-reassign
-  filename = filename || getRandomFileName();
-  const elem = window.document.createElement('a');
-  elem.href = `data:${type};Base64,${b64}`;
+  const elem = document.createElement('a');
+  elem.href = `data:${contentType};Base64,${b64}`;
   elem.download = filename;
   document.body.appendChild(elem);
   elem.click();

--- a/ui/helpers/utils/export-utils.js
+++ b/ui/helpers/utils/export-utils.js
@@ -41,7 +41,8 @@ export async function exportAsFile(filename, data, contentType) {
 function supportsShowSaveFilePicker() {
   return (
     typeof window !== 'undefined' &&
-    typeof window.showSaveFilePicker !== 'undefined'
+    typeof window.showSaveFilePicker !== 'undefined' &&
+    typeof window.Blob !== 'undefined'
   );
 }
 

--- a/ui/helpers/utils/export-utils.js
+++ b/ui/helpers/utils/export-utils.js
@@ -54,8 +54,7 @@ function supportsShowSaveFilePicker() {
  * @returns {Promise<void>}
  */
 async function saveFileUsingFilePicker(filename, data, contentType) {
-  // eslint-disable-next-line no-undef
-  const blob = new Blob([data], { contentType });
+  const blob = new window.Blob([data], { contentType });
   const fileExtension = ExtensionForContentType[contentType];
 
   const handle = await window.showSaveFilePicker({

--- a/ui/helpers/utils/export-utils.test.js
+++ b/ui/helpers/utils/export-utils.test.js
@@ -1,0 +1,67 @@
+import { exportAsFile, ExportableContentType } from './export-utils';
+
+describe('exportAsFile', () => {
+  let windowSpy;
+
+  beforeEach(() => {
+    windowSpy = jest.spyOn(window, 'window', 'get');
+  });
+
+  afterEach(() => {
+    windowSpy.mockRestore();
+  });
+
+  describe('when showSaveFilePicker is supported', () => {
+    it('uses .json file extension when content type is JSON', async () => {
+      const showSaveFilePicker = mockShowSaveFilePicker();
+      const filename = 'test';
+      const data = '{file: "content"}';
+
+      windowSpy.mockImplementation(() => ({
+        showSaveFilePicker,
+      }));
+
+      await exportAsFile(filename, data, ExportableContentType.JSON);
+
+      expect(showSaveFilePicker).toHaveBeenCalledWith({
+        suggestedName: filename,
+        types: [
+          {
+            description: filename,
+            accept: { 'application/json': ['.json'] },
+          },
+        ],
+      });
+    });
+
+    it('uses .txt file extension when content type is TXT', async () => {
+      const showSaveFilePicker = mockShowSaveFilePicker();
+      const filename = 'test.txt';
+      const data = 'file content';
+
+      windowSpy.mockImplementation(() => ({
+        showSaveFilePicker,
+      }));
+
+      await exportAsFile(filename, data, ExportableContentType.TXT);
+
+      expect(showSaveFilePicker).toHaveBeenCalledWith({
+        suggestedName: filename,
+        types: [
+          {
+            description: filename,
+            accept: { 'text/plain': ['.txt'] },
+          },
+        ],
+      });
+    });
+  });
+});
+
+function mockShowSaveFilePicker() {
+  return jest.fn().mockResolvedValueOnce({
+    createWritable: jest
+      .fn()
+      .mockResolvedValueOnce({ write: jest.fn(), close: jest.fn() }),
+  });
+}

--- a/ui/helpers/utils/export-utils.test.js
+++ b/ui/helpers/utils/export-utils.test.js
@@ -14,7 +14,7 @@ describe('exportAsFile', () => {
   describe('when showSaveFilePicker is supported', () => {
     it('uses .json file extension when content type is JSON', async () => {
       const showSaveFilePicker = mockShowSaveFilePicker();
-      const filename = 'test';
+      const filename = 'test.json';
       const data = '{file: "content"}';
 
       windowSpy.mockImplementation(() => ({

--- a/ui/helpers/utils/export-utils.test.js
+++ b/ui/helpers/utils/export-utils.test.js
@@ -16,9 +16,9 @@ describe('exportAsFile', () => {
       const showSaveFilePicker = mockShowSaveFilePicker();
       const filename = 'test.json';
       const data = '{file: "content"}';
-
       windowSpy.mockImplementation(() => ({
         showSaveFilePicker,
+        Blob: global.Blob,
       }));
 
       await exportAsFile(filename, data, ExportableContentType.JSON);
@@ -41,6 +41,7 @@ describe('exportAsFile', () => {
 
       windowSpy.mockImplementation(() => ({
         showSaveFilePicker,
+        Blob: global.Blob,
       }));
 
       await exportAsFile(filename, data, ExportableContentType.TXT);

--- a/ui/pages/settings/advanced-tab/advanced-tab.component.js
+++ b/ui/pages/settings/advanced-tab/advanced-tab.component.js
@@ -23,7 +23,10 @@ import {
   MetaMetricsEventName,
 } from '../../../../shared/constants/metametrics';
 import { DEFAULT_AUTO_LOCK_TIME_LIMIT } from '../../../../shared/constants/preferences';
-import { exportAsFile } from '../../../helpers/utils/export-utils';
+import {
+  exportAsFile,
+  ExportableContentType,
+} from '../../../helpers/utils/export-utils';
 import ActionableMessage from '../../../components/ui/actionable-message';
 import ZENDESK_URLS from '../../../helpers/constants/zendesk-url';
 import { BannerAlert } from '../../../components/component-library';
@@ -150,7 +153,7 @@ export default class AdvancedTab extends PureComponent {
 
   backupUserData = async () => {
     const { fileName, data } = await this.props.backupUserData();
-    exportAsFile(fileName, data);
+    exportAsFile(fileName, data, ExportableContentType.JSON);
 
     this.context.trackEvent({
       event: 'User Data Exported',
@@ -185,7 +188,11 @@ export default class AdvancedTab extends PureComponent {
                   if (err) {
                     displayWarning(t('stateLogError'));
                   } else {
-                    exportAsFile(`${t('stateLogFileName')}.json`, result);
+                    exportAsFile(
+                      `${t('stateLogFileName')}.json`,
+                      result,
+                      ExportableContentType.JSON,
+                    );
                   }
                 });
               }}


### PR DESCRIPTION
## Explanation

The current mechanism we use to export state logs requires base64 encoding the entire file contents and adding them to a large data URI. This new approach uses the improved file picker API which has been supported by chromium based browsers since oct 2020. 

Non chromium browsers will default back to the existing behaviour.

## Manual Testing Steps

**In chrome**
* Open the MetaMask Extension
* Navigate to settings --> Advance --> Download state logs
* See that you are presented with a window to select your download location and the option to customize its name

**In firefox**
* Open the MetaMask Extension
* Navigate to settings --> Advance --> Download state logs
* See that the file downloads automatically and does not allow for customization


## Pre-merge author checklist

- [X] I've clearly explained:
  - [X] What problem this PR is solving
  - [X] How this problem was solved
  - [X] How reviewers can test my changes
- [X] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
