### PR TITLE
Fix a recent code-fencing issue with keyring snaps

### DIFF
--- a/ui/store/actions.ts
+++ b/ui/store/actions.ts
@@ -1126,11 +1126,21 @@ export function enableSnap(
     await forceUpdateMetamaskState(dispatch);
   };
 }
+///: END:ONLY_INCLUDE_IN
 
+// TODO: Clean this up.
+///: BEGIN:ONLY_INCLUDE_IN(snaps)
 export function removeSnap(
   snapId: string,
 ): ThunkAction<void, MetaMaskReduxState, unknown, AnyAction> {
-  return async (dispatch: MetaMaskReduxDispatch, getState) => {
+  return async (
+    dispatch: MetaMaskReduxDispatch,
+    ///: END:ONLY_INCLUDE_IN
+    ///: BEGIN:ONLY_INCLUDE_IN(keyring-snaps)
+    getState,
+    ///: END:ONLY_INCLUDE_IN
+    ///: BEGIN:ONLY_INCLUDE_IN(snaps)
+  ) => {
     dispatch(showLoadingIndication());
     ///: END:ONLY_INCLUDE_IN
     ///: BEGIN:ONLY_INCLUDE_IN(keyring-snaps)
@@ -1140,7 +1150,9 @@ export function removeSnap(
 
     const isAccountsSnap =
       subjects[snapId]?.permissions?.snap_manageAccounts !== undefined;
+    ///: END:ONLY_INCLUDE_IN
 
+    ///: BEGIN:ONLY_INCLUDE_IN(snaps)
     try {
       ///: END:ONLY_INCLUDE_IN
       ///: BEGIN:ONLY_INCLUDE_IN(keyring-snaps)


### PR DESCRIPTION
## Explanation

Fixes a recent code-fencing issue introduced in af2c87d77726413c953b32c56072571131b2cea5.

The problem would only occur when trying to build a stable build of the extension due to the way the fences were set up. This PR corrects these fences, but we should probably consider nested fences to reduce complexity around fencing: https://github.com/MetaMask/metamask-extension/issues/19873
