### PR TITLE
Fix error when rejecting multiple messages

### DIFF
--- a/ui/pages/confirm-signature-request/index.js
+++ b/ui/pages/confirm-signature-request/index.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React, { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { withRouter } from 'react-router-dom';
+import { useHistory, withRouter } from 'react-router-dom';
 import log from 'loglevel';
 import { cloneDeep } from 'lodash';
 import * as actions from '../../store/actions';
@@ -69,6 +69,7 @@ const ConfirmTxScreen = ({ match }) => {
   ///: END:ONLY_INCLUDE_IN
 
   const [prevValue, setPrevValues] = useState();
+  const history = useHistory();
 
   useEffect(() => {
     const unconfTxList = txHelper(
@@ -174,6 +175,7 @@ const ConfirmTxScreen = ({ match }) => {
 
   return (
     <SigComponent
+      history={history}
       txData={txData}
       key={txData.id}
       identities={identities}


### PR DESCRIPTION
## Explanation

Provides a missing history property to resolve an error and UI crash when rejecting multiple signature requests.

Fixes: #19879 

## Manual Testing Steps

- Go to test dApp.
- Click `Sign` under `Sign Typed Data V4`.
- Click `Sign` under `Sign Typed Data V4`.
- Click on test dApp to remove focus from notification window.
- Click extension icon.
- Click `Reject 2 requests`.
- Verify UI returns to overview page.

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
