### PR TITLE
Fix flaky test by stop estimating gas when starting a draft transaction in the send flow

### DIFF
--- a/test/e2e/metamask-ui.spec.js
+++ b/test/e2e/metamask-ui.spec.js
@@ -292,6 +292,7 @@ describe('MetaMask', function () {
     it('transitions to the confirm screen', async function () {
       // Continue to next screen
       await driver.delay(largeDelayMs);
+      await driver.waitForElementNotPresent('.loading-overlay');
       await driver.clickElement({ text: 'Next', tag: 'button' });
       await driver.delay(largeDelayMs);
     });
@@ -482,6 +483,7 @@ describe('MetaMask', function () {
 
     it('submits the transaction', async function () {
       await driver.delay(largeDelayMs * 2);
+      await driver.waitForElementNotPresent('.loading-overlay');
       await driver.clickElement({ text: 'Confirm', tag: 'button' });
       await driver.delay(largeDelayMs * 2);
     });

--- a/test/e2e/metamask-ui.spec.js
+++ b/test/e2e/metamask-ui.spec.js
@@ -298,7 +298,7 @@ describe('MetaMask', function () {
     });
 
     it('displays the token transfer data', async function () {
-      await driver.delay(largeDelayMs);
+      await driver.waitForElementNotPresent('.loading-overlay');
       await driver.clickElement({ text: 'Hex', tag: 'button' });
       await driver.delay(regularDelayMs);
 

--- a/test/e2e/metamask-ui.spec.js
+++ b/test/e2e/metamask-ui.spec.js
@@ -291,10 +291,8 @@ describe('MetaMask', function () {
 
     it('transitions to the confirm screen', async function () {
       // Continue to next screen
-      await driver.delay(largeDelayMs);
       await driver.waitForElementNotPresent('.loading-overlay');
       await driver.clickElement({ text: 'Next', tag: 'button' });
-      await driver.delay(largeDelayMs);
     });
 
     it('displays the token transfer data', async function () {
@@ -482,7 +480,6 @@ describe('MetaMask', function () {
     });
 
     it('submits the transaction', async function () {
-      await driver.delay(largeDelayMs * 2);
       await driver.waitForElementNotPresent('.loading-overlay');
       await driver.clickElement({ text: 'Confirm', tag: 'button' });
       await driver.delay(largeDelayMs * 2);

--- a/ui/ducks/send/send.js
+++ b/ui/ducks/send/send.js
@@ -2015,10 +2015,11 @@ export function updateSendAmount(amount) {
  * @param {object} payload - action payload
  * @param {string} payload.type - type of asset to send
  * @param {TokenDetails} [payload.details] - ERC20 details if sending TOKEN asset
+ * @param payload.skipComputeEstimatedGasLimit
  * @returns {ThunkAction<void>}
  */
 export function updateSendAsset(
-  { type, details: providedDetails },
+  { type, details: providedDetails, skipComputeEstimatedGasLimit },
   { initialAssetSet = false } = {},
 ) {
   return async (dispatch, getState) => {
@@ -2149,7 +2150,7 @@ export function updateSendAsset(
 
       await dispatch(actions.updateAsset({ asset, initialAssetSet }));
     }
-    if (initialAssetSet === false) {
+    if (initialAssetSet === false && !skipComputeEstimatedGasLimit) {
       await dispatch(computeEstimatedGasLimit());
     }
   };
@@ -2393,6 +2394,7 @@ export function startNewDraftTransaction(asset) {
       updateSendAsset({
         type: asset.type ?? AssetType.native,
         details: asset.details,
+        skipComputeEstimatedGasLimit: true,
       }),
     );
 


### PR DESCRIPTION
## Explanation

Aims to fix flaky tests like this one https://app.circleci.com/pipelines/github/MetaMask/metamask-extension/50501/workflows/11386fa4-48a1-41c9-b3af-b05ee7bdbe7d/jobs/1457142/tests

That has the error message `Element <button class="button btn--rounded btn-primary page-container__footer-button"> is not clickable at point (674,797) because another element <footer> obscures it`

The problem is that the button on the send screen is briefly enabled, then disabled, and then enabled again. It seems that caused a click to hit the button while it is in a disabled state (and the test was registering that click as happening on the parent of the button element)

The reason for the changing states of the button is that, in the send duck:
- isSendFormInvalid returns true if state.gasEstimateIsLoading is true
- state.gasEstimateIsLoading is initialized to true
- state.gasEstimateIsLoading is set to false , while still on the "Add Recipient" screen, after the - computeEstimatedGasLimit call triggered by updateSendAsset
- then, after going from the "Add Recipient" screen to the send form screen (where the error occurs), the button is briefly enabled
- then, updateRecipient and updateSendAmount are called, both resulting in computeEstimatedGasLimit calls, which - set state.gasEstimateIsLoading to true
- this is when the button is disabled
- once the two computeEstimatedGasLimit  calls resolve, state.gasEstimateIsLoading is set to false again, and then button is now enabled again

The fix is to skip the first call to computeEstimatedGasLimit, since we know the transaction parameters given aren't the final ones and we'll have to re-compute it anyway

There should be no functional changes from a users perspective, although there is a brief period of the button being enabled that could be noticable.

## Manual Testing Steps

1. Start recording your screen
2. Go to the send flow
3. Select/enter a contract addresss
4. On the send screen, the estimated gas limit should be correct
5. Watch the recording at 0.5x speed. Immediately after going from the "Add Recipient" screen to the send form screen, the "Next" button should be disabled and once it is enabled it should stay in that state. There should NOT be a brief moment after going to the send form screen where it is disabled followed by being enabled followed by being disabled again.

## Pre-merge author checklist

- [ ] I've clearly explained:
  - [ ] What problem this PR is solving
  - [ ] How this problem was solved
  - [ ] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
