### PR TITLE
bump json-rpc-middleware-stream to 4.2.2

### DIFF
--- a/lavamoat/browserify/beta/policy.json
+++ b/lavamoat/browserify/beta/policy.json
@@ -3976,8 +3976,16 @@
         "setTimeout": true
       },
       "packages": {
-        "@metamask/safe-event-emitter": true,
+        "json-rpc-middleware-stream>@metamask/safe-event-emitter": true,
         "readable-stream": true
+      }
+    },
+    "json-rpc-middleware-stream>@metamask/safe-event-emitter": {
+      "globals": {
+        "setTimeout": true
+      },
+      "packages": {
+        "browserify>events": true
       }
     },
     "koa>is-generator-function>has-tostringtag": {

--- a/lavamoat/browserify/desktop/policy.json
+++ b/lavamoat/browserify/desktop/policy.json
@@ -4527,8 +4527,16 @@
         "setTimeout": true
       },
       "packages": {
-        "@metamask/safe-event-emitter": true,
+        "json-rpc-middleware-stream>@metamask/safe-event-emitter": true,
         "readable-stream": true
+      }
+    },
+    "json-rpc-middleware-stream>@metamask/safe-event-emitter": {
+      "globals": {
+        "setTimeout": true
+      },
+      "packages": {
+        "browserify>events": true
       }
     },
     "koa>is-generator-function>has-tostringtag": {

--- a/lavamoat/browserify/flask/policy.json
+++ b/lavamoat/browserify/flask/policy.json
@@ -4527,8 +4527,16 @@
         "setTimeout": true
       },
       "packages": {
-        "@metamask/safe-event-emitter": true,
+        "json-rpc-middleware-stream>@metamask/safe-event-emitter": true,
         "readable-stream": true
+      }
+    },
+    "json-rpc-middleware-stream>@metamask/safe-event-emitter": {
+      "globals": {
+        "setTimeout": true
+      },
+      "packages": {
+        "browserify>events": true
       }
     },
     "koa>is-generator-function>has-tostringtag": {

--- a/lavamoat/browserify/main/policy.json
+++ b/lavamoat/browserify/main/policy.json
@@ -3976,8 +3976,16 @@
         "setTimeout": true
       },
       "packages": {
-        "@metamask/safe-event-emitter": true,
+        "json-rpc-middleware-stream>@metamask/safe-event-emitter": true,
         "readable-stream": true
+      }
+    },
+    "json-rpc-middleware-stream>@metamask/safe-event-emitter": {
+      "globals": {
+        "setTimeout": true
+      },
+      "packages": {
+        "browserify>events": true
       }
     },
     "koa>is-generator-function>has-tostringtag": {

--- a/lavamoat/browserify/mmi/policy.json
+++ b/lavamoat/browserify/mmi/policy.json
@@ -4204,8 +4204,16 @@
         "setTimeout": true
       },
       "packages": {
-        "@metamask/safe-event-emitter": true,
+        "json-rpc-middleware-stream>@metamask/safe-event-emitter": true,
         "readable-stream": true
+      }
+    },
+    "json-rpc-middleware-stream>@metamask/safe-event-emitter": {
+      "globals": {
+        "setTimeout": true
+      },
+      "packages": {
+        "browserify>events": true
       }
     },
     "koa>is-generator-function>has-tostringtag": {

--- a/package.json
+++ b/package.json
@@ -323,7 +323,7 @@
     "is-retry-allowed": "^2.2.0",
     "jest-junit": "^14.0.1",
     "json-rpc-engine": "^6.1.0",
-    "json-rpc-middleware-stream": "^4.2.1",
+    "json-rpc-middleware-stream": "^4.2.2",
     "labeled-stream-splicer": "^2.0.2",
     "localforage": "^1.9.0",
     "lodash": "^4.17.21",

--- a/yarn.lock
+++ b/yarn.lock
@@ -22366,13 +22366,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"json-rpc-middleware-stream@npm:^4.2.0, json-rpc-middleware-stream@npm:^4.2.1":
-  version: 4.2.1
-  resolution: "json-rpc-middleware-stream@npm:4.2.1"
+"json-rpc-middleware-stream@npm:^4.2.0, json-rpc-middleware-stream@npm:^4.2.1, json-rpc-middleware-stream@npm:^4.2.2":
+  version: 4.2.2
+  resolution: "json-rpc-middleware-stream@npm:4.2.2"
   dependencies:
-    "@metamask/safe-event-emitter": "npm:^2.0.0"
+    "@metamask/safe-event-emitter": "npm:^3.0.0"
     readable-stream: "npm:^2.3.3"
-  checksum: 7cf1b521cb2dd24fc06a38f80960aa0bd53e020b955feb92119a64831986be474ba695bfa4851ed0bf9e7828a07b49f70fdc38a58bc2c62502abe874d4acff6c
+  checksum: 0f7882b5898001c00a442104790a487c1276faf40b64fb6257aceffcb30f0f0ccabb67553a43d6313e30a940fc256ddd8f7c0176e3bdeea172a7bfe11e9aa56e
   languageName: node
   linkType: hard
 
@@ -24453,7 +24453,7 @@ __metadata:
     js-yaml: "npm:^4.1.0"
     jsdom: "npm:^16.7.0"
     json-rpc-engine: "npm:^6.1.0"
-    json-rpc-middleware-stream: "npm:^4.2.1"
+    json-rpc-middleware-stream: "npm:^4.2.2"
     junit-report-merger: "npm:^4.0.0"
     koa: "npm:^2.7.0"
     labeled-stream-splicer: "npm:^2.0.2"


### PR DESCRIPTION
## Explanation
Bumps the version of json-rpc-middleware-stream to fix a race condition that sometimes occurs when connecting to MetaMask on multiple Dapps including the Uniswap interface.

More context in the json-rpc-middleware-stream fix PR [here](https://github.com/MetaMask/json-rpc-middleware-stream/pull/47)
<!--
Thanks for the pull request. Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues, Slack conversations, Zendesk issues, user stories, etc. reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

## Screenshots/Screencaps

<!-- If you're making a change to the UI, make sure to capture a screenshot or a short video showing off your work! -->
N/A

<!-- How does it look now? Drag your file(s) below this line: -->

## Manual Testing Steps

<!--
How should reviewers and QA manually test your changes? For instance:

- Go to this screen
- Do this
- Then do this
-->

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
