### PR TITLE
onramp/fix: Set Optimism nativeCurrency symbol to OP

### DIFF
--- a/shared/constants/network.ts
+++ b/shared/constants/network.ts
@@ -924,7 +924,7 @@ export const BUYABLE_CHAINS_MAP: {
     network: 'celo',
   },
   [CHAIN_IDS.OPTIMISM]: {
-    nativeCurrency: CURRENCY_SYMBOLS.ETH,
+    nativeCurrency: CURRENCY_SYMBOLS.OPTIMISM,
     network: 'optimism',
   },
   [CHAIN_IDS.ARBITRUM]: {


### PR DESCRIPTION
## Explanation

The native asset on Optimism network is `OP`, not `ETH`.

## Screenshots/Screencaps


### Before

TODO

### After

TODO


## Manual Testing Steps

<!--
How should reviewers and QA manually test your changes? For instance:

- Go to this screen
- Do this
- Then do this
-->

## Pre-merge author checklist

- [ ] I've clearly explained:
  - [x] What problem this PR is solving
  - [ ] How this problem was solved
  - [ ] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
