### PR TITLE
Fix unhandled rejection when rejecting signature requests

### DIFF
--- a/.yarn/patches/@metamask-signature-controller-npm-4.0.1-013e64c9fd.patch
+++ b/.yarn/patches/@metamask-signature-controller-npm-4.0.1-013e64c9fd.patch
@@ -1,0 +1,17 @@
+diff --git a/dist/SignatureController.js b/dist/SignatureController.js
+index b58b27e84aa84393afb366d4585c084d0380d21d..0629bcf517db744ccfa40e4d7d8f2829fa95559e 100644
+--- a/dist/SignatureController.js
++++ b/dist/SignatureController.js
+@@ -237,8 +237,11 @@ _SignatureController_keyringController = new WeakMap(), _SignatureController_isE
+             yield __classPrivateFieldGet(this, _SignatureController_instances, "m", _SignatureController_requestApproval).call(this, messageParamsWithId, approvalType);
+         }
+         catch (error) {
++            signaturePromise.catch(() => {
++                // Expecting reject error but throwing manually rather than waiting
++            });
+             __classPrivateFieldGet(this, _SignatureController_instances, "m", _SignatureController_cancelAbstractMessage).call(this, messageManager, messageId);
+-            throw eth_rpc_errors_1.ethErrors.provider.userRejectedRequest('User rejected the request.');
++            throw eth_rpc_errors_1.ethErrors.provider.userRejectedRequest(`MetaMask ${messageName} Signature: User denied message signature.`);
+         }
+         yield signMessage(messageParamsWithId, version, signingOpts);
+         return signaturePromise;

--- a/package.json
+++ b/package.json
@@ -195,7 +195,8 @@
     "fast-json-patch@^3.1.1": "patch:fast-json-patch@npm%3A3.1.1#./.yarn/patches/fast-json-patch-npm-3.1.1-7e8bb70a45.patch",
     "request@^2.83.0": "patch:request@npm%3A2.88.2#./.yarn/patches/request-npm-2.88.2-f4a57c72c4.patch",
     "request@^2.88.2": "patch:request@npm%3A2.88.2#./.yarn/patches/request-npm-2.88.2-f4a57c72c4.patch",
-    "request@^2.85.0": "patch:request@npm%3A2.88.2#./.yarn/patches/request-npm-2.88.2-f4a57c72c4.patch"
+    "request@^2.85.0": "patch:request@npm%3A2.88.2#./.yarn/patches/request-npm-2.88.2-f4a57c72c4.patch",
+    "@metamask/signature-controller@^4.0.1": "patch:@metamask/signature-controller@npm%3A4.0.1#./.yarn/patches/@metamask-signature-controller-npm-4.0.1-013e64c9fd.patch"
   },
   "dependencies": {
     "@babel/runtime": "^7.18.9",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4705,7 +4705,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/signature-controller@npm:^4.0.1":
+"@metamask/signature-controller@npm:4.0.1":
   version: 4.0.1
   resolution: "@metamask/signature-controller@npm:4.0.1"
   dependencies:
@@ -4721,6 +4721,25 @@ __metadata:
   peerDependencies:
     "@metamask/approval-controller": ^3.3.0
   checksum: 8d510fe3761f2c0ac39bb6b9891497012e3608559480aee11f8f76556573521b01ecde334f1ffd71e8fc674243ae7fa111d0f2aaa36f4466d2e9466998af6618
+  languageName: node
+  linkType: hard
+
+"@metamask/signature-controller@patch:@metamask/signature-controller@npm%3A4.0.1#./.yarn/patches/@metamask-signature-controller-npm-4.0.1-013e64c9fd.patch::locator=metamask-crx%40workspace%3A.":
+  version: 4.0.1
+  resolution: "@metamask/signature-controller@patch:@metamask/signature-controller@npm%3A4.0.1#./.yarn/patches/@metamask-signature-controller-npm-4.0.1-013e64c9fd.patch::version=4.0.1&hash=7f339b&locator=metamask-crx%40workspace%3A."
+  dependencies:
+    "@metamask/approval-controller": ^3.3.0
+    "@metamask/base-controller": ^3.0.0
+    "@metamask/controller-utils": ^4.0.0
+    "@metamask/message-manager": ^7.0.0
+    "@metamask/utils": ^5.0.2
+    eth-rpc-errors: ^4.0.2
+    ethereumjs-util: ^7.0.10
+    immer: ^9.0.6
+    lodash: ^4.17.21
+  peerDependencies:
+    "@metamask/approval-controller": ^3.3.0
+  checksum: d678cf1763cfe9e13c0e5d357fcc44bd4580efc44a6fdca61ba6eed059c47c780fafaf08a075466a4886fbb9c6332544752bf7d25d515a37213c800cfc181665
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Explanation

Patch `@metamask/signature-controller` to fix an unhandled error when rejecting signature requests.

* Fixes #19917 

## Manual Testing Steps

- Go to test dApp.
- Sign any type of message.
- Reject. 

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
