### PR TITLE
blockaid settings.

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -2327,6 +2327,9 @@
   "moreComingSoon": {
     "message": "More coming soon..."
   },
+  "moreProviders": {
+    "message": "More providers coming soon"
+  },
   "multipleSnapConnectionWarning": {
     "message": "$1 wants to connect with $2 snaps. Only proceed if you trust this website.",
     "description": "$1 is the dapp and $2 is the number of snaps it wants to connect to."
@@ -3645,6 +3648,12 @@
   "securityAlert": {
     "message": "Security alert from $1 and $2"
   },
+  "securityAlerts": {
+    "message": "Security alerts"
+  },
+  "securityAlertsDescription": {
+    "message": "This feature alerts you to malicious activity by locally reviewing your transactions and signature requests. Your data isn't shared with the third parties providing this service. Always do your own due diligence before approving any requests. There’s no guarantee that this feature will detect all malicious activity."
+  },
   "securityAndPrivacy": {
     "message": "Security & privacy"
   },
@@ -3739,7 +3748,7 @@
     "message": "If you don't see the accounts you expect, try switching the HD path."
   },
   "selectProvider": {
-    "message": "Select providers:"
+    "message": "Select providers"
   },
   "selectType": {
     "message": "Select Type"

--- a/app/scripts/controllers/metametrics.js
+++ b/app/scripts/controllers/metametrics.js
@@ -770,6 +770,8 @@ export default class MetaMetricsController {
         metamaskState.transactionSecurityCheckEnabled ? ['opensea'] : [],
       [MetaMetricsUserTrait.SecurityProviders]:
         metamaskState.securityAlertsEnabled ? ['blockaid'] : [],
+      [MetaMetricsUserTrait.SecurityAlertsEnabled]:
+        metamaskState.securityAlertsEnabled || false,
     };
 
     if (!previousUserTraits) {

--- a/app/scripts/controllers/metametrics.js
+++ b/app/scripts/controllers/metametrics.js
@@ -768,8 +768,8 @@ export default class MetaMetricsController {
       ///: END:ONLY_INCLUDE_IN
       [MetaMetricsUserTrait.SecurityProviders]:
         metamaskState.transactionSecurityCheckEnabled ? ['opensea'] : [],
-      [MetaMetricsUserTrait.SecurityAlertsEnabled]:
-        metamaskState.securityAlertsEnabled || false,
+      [MetaMetricsUserTrait.SecurityProviders]:
+        metamaskState.securityAlertsEnabled ? ['blockaid'] : [],
     };
 
     if (!previousUserTraits) {

--- a/app/scripts/controllers/metametrics.js
+++ b/app/scripts/controllers/metametrics.js
@@ -722,6 +722,18 @@ export default class MetaMetricsController {
         ? Object.keys(metamaskState.custodyAccountDetails)[0]
         : null;
     ///: END:ONLY_INCLUDE_IN
+
+    const securityProviders = [];
+    if (metamaskState.transactionSecurityCheckEnabled) {
+      securityProviders.push('opensea');
+    }
+
+    ///: BEGIN:ONLY_INCLUDE_IN(blockaid)
+    if (metamaskState.securityAlertBlockaidEnabled) {
+      securityProviders.push('blockaid');
+    }
+    ///: END:ONLY_INCLUDE_IN
+
     const { traits, previousUserTraits } = this.store.getState();
     /** @type {MetaMetricsTraits} */
     const currentTraits = {
@@ -766,12 +778,11 @@ export default class MetaMetricsController {
       [MetaMetricsUserTrait.MmiAccountAddress]: mmiAccountAddress,
       [MetaMetricsUserTrait.MmiIsCustodian]: Boolean(mmiAccountAddress),
       ///: END:ONLY_INCLUDE_IN
-      [MetaMetricsUserTrait.SecurityProviders]:
-        metamaskState.transactionSecurityCheckEnabled ? ['opensea'] : [],
-      [MetaMetricsUserTrait.SecurityProviders]:
-        metamaskState.securityAlertsEnabled ? ['blockaid'] : [],
-      [MetaMetricsUserTrait.SecurityAlertsEnabled]:
-        metamaskState.securityAlertsEnabled || false,
+      ///: BEGIN:ONLY_INCLUDE_IN(blockaid)
+      [MetaMetricsUserTrait.SecurityProviders]: securityProviders,
+      [MetaMetricsUserTrait.SecurityAlertBlockaidEnabled]:
+        metamaskState.securityAlertBlockaidEnabled || false,
+      ///: END:ONLY_INCLUDE_IN
     };
 
     if (!previousUserTraits) {

--- a/app/scripts/controllers/metametrics.js
+++ b/app/scripts/controllers/metametrics.js
@@ -768,6 +768,8 @@ export default class MetaMetricsController {
       ///: END:ONLY_INCLUDE_IN
       [MetaMetricsUserTrait.SecurityProviders]:
         metamaskState.transactionSecurityCheckEnabled ? ['opensea'] : [],
+      [MetaMetricsUserTrait.SecurityProviders]:
+        metamaskState.securityAlertsEnabled || false,
     };
 
     if (!previousUserTraits) {

--- a/app/scripts/controllers/metametrics.js
+++ b/app/scripts/controllers/metametrics.js
@@ -768,7 +768,7 @@ export default class MetaMetricsController {
       ///: END:ONLY_INCLUDE_IN
       [MetaMetricsUserTrait.SecurityProviders]:
         metamaskState.transactionSecurityCheckEnabled ? ['opensea'] : [],
-      [MetaMetricsUserTrait.SecurityProviders]:
+      [MetaMetricsUserTrait.SecurityAlertsEnabled]:
         metamaskState.securityAlertsEnabled || false,
     };
 

--- a/app/scripts/controllers/metametrics.test.js
+++ b/app/scripts/controllers/metametrics.test.js
@@ -966,7 +966,9 @@ describe('MetaMetricsController', function () {
         [MetaMetricsUserTrait.Theme]: 'default',
         [MetaMetricsUserTrait.TokenDetectionEnabled]: true,
         [MetaMetricsUserTrait.DesktopEnabled]: false,
-        [MetaMetricsUserTrait.SecurityAlertsEnabled]: false,
+        ///: BEGIN:ONLY_INCLUDE_IN(blockaid)
+        [MetaMetricsUserTrait.SecurityAlertBlockaidEnabled]: false,
+        ///: END:ONLY_INCLUDE_IN
         [MetaMetricsUserTrait.SecurityProviders]: [],
         ///: BEGIN:ONLY_INCLUDE_IN(build-mmi)
         [MetaMetricsUserTrait.MmiExtensionId]: 'testid',

--- a/app/scripts/controllers/metametrics.test.js
+++ b/app/scripts/controllers/metametrics.test.js
@@ -966,6 +966,7 @@ describe('MetaMetricsController', function () {
         [MetaMetricsUserTrait.Theme]: 'default',
         [MetaMetricsUserTrait.TokenDetectionEnabled]: true,
         [MetaMetricsUserTrait.DesktopEnabled]: false,
+        [MetaMetricsUserTrait.SecurityAlertsEnabled]: false,
         [MetaMetricsUserTrait.SecurityProviders]: [],
         ///: BEGIN:ONLY_INCLUDE_IN(build-mmi)
         [MetaMetricsUserTrait.MmiExtensionId]: 'testid',

--- a/app/scripts/controllers/preferences.js
+++ b/app/scripts/controllers/preferences.js
@@ -75,6 +75,7 @@ export default class PreferencesController {
       snapsAddSnapAccountModalDismissed: false,
       ///: END:ONLY_INCLUDE_IN
       isLineaMainnetReleased: false,
+      securityAlertsEnabled: false,
       ...opts.initState,
     };
 
@@ -211,6 +212,17 @@ export default class PreferencesController {
   setTransactionSecurityCheckEnabled(transactionSecurityCheckEnabled) {
     this.store.updateState({
       transactionSecurityCheckEnabled,
+    });
+  }
+
+  /**
+   * Setter for the `securityAlertsEnabled` property
+   *
+   * @param securityAlertsEnabled
+   */
+  setSecurityAlertsEnabled(securityAlertsEnabled) {
+    this.store.updateState({
+      securityAlertsEnabled,
     });
   }
 

--- a/app/scripts/controllers/preferences.js
+++ b/app/scripts/controllers/preferences.js
@@ -75,7 +75,9 @@ export default class PreferencesController {
       snapsAddSnapAccountModalDismissed: false,
       ///: END:ONLY_INCLUDE_IN
       isLineaMainnetReleased: false,
-      securityAlertsEnabled: false,
+      ///: BEGIN:ONLY_INCLUDE_IN(blockaid)
+      securityAlertBlockaidEnabled: false,
+      ///: END:ONLY_INCLUDE_IN
       ...opts.initState,
     };
 
@@ -215,16 +217,18 @@ export default class PreferencesController {
     });
   }
 
+  ///: BEGIN:ONLY_INCLUDE_IN(blockaid)
   /**
-   * Setter for the `securityAlertsEnabled` property
+   * Setter for the `securityAlertBlockaidEnabled` property
    *
-   * @param securityAlertsEnabled
+   * @param securityAlertBlockaidEnabled
    */
-  securityAlertBlockaidEnabled(securityAlertsEnabled) {
+  setSecurityAlertBlockaidEnabled(securityAlertBlockaidEnabled) {
     this.store.updateState({
-      securityAlertsEnabled,
+      securityAlertBlockaidEnabled,
     });
   }
+  ///: END:ONLY_INCLUDE_IN
 
   /**
    * Add new methodData to state, to avoid requesting this information again through Infura

--- a/app/scripts/controllers/preferences.js
+++ b/app/scripts/controllers/preferences.js
@@ -220,7 +220,7 @@ export default class PreferencesController {
    *
    * @param securityAlertsEnabled
    */
-  setSecurityAlertsEnabled(securityAlertsEnabled) {
+  securityAlertBlockaidEnabled(securityAlertsEnabled) {
     this.store.updateState({
       securityAlertsEnabled,
     });

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -2265,6 +2265,10 @@ export default class MetamaskController extends EventEmitter {
         preferencesController.setTransactionSecurityCheckEnabled.bind(
           preferencesController,
         ),
+      setSecurityAlertsEnabled:
+        preferencesController.setSecurityAlertsEnabled.bind(
+          preferencesController,
+        ),
       ///: BEGIN:ONLY_INCLUDE_IN(keyring-snaps)
       setSnapsAddSnapAccountModalDismissed:
         preferencesController.setSnapsAddSnapAccountModalDismissed.bind(
@@ -4636,10 +4640,13 @@ export default class MetamaskController extends EventEmitter {
   };
 
   async securityProviderRequest(requestData, methodName) {
-    const { currentLocale, transactionSecurityCheckEnabled } =
-      this.preferencesController.store.getState();
+    const {
+      currentLocale,
+      transactionSecurityCheckEnabled,
+      securityAlertsEnabled,
+    } = this.preferencesController.store.getState();
 
-    if (transactionSecurityCheckEnabled) {
+    if (transactionSecurityCheckEnabled || securityAlertsEnabled) {
       const chainId = Number(
         hexToDecimal(this.networkController.state.providerConfig.chainId),
       );

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -4643,10 +4643,9 @@ export default class MetamaskController extends EventEmitter {
     const {
       currentLocale,
       transactionSecurityCheckEnabled,
-      securityAlertsEnabled,
     } = this.preferencesController.store.getState();
 
-    if (transactionSecurityCheckEnabled || securityAlertsEnabled) {
+    if (transactionSecurityCheckEnabled) {
       const chainId = Number(
         hexToDecimal(this.networkController.state.providerConfig.chainId),
       );

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -2265,10 +2265,12 @@ export default class MetamaskController extends EventEmitter {
         preferencesController.setTransactionSecurityCheckEnabled.bind(
           preferencesController,
         ),
-      securityAlertBlockaidEnabled:
-        preferencesController.securityAlertBlockaidEnabled.bind(
+      ///: BEGIN:ONLY_INCLUDE_IN(blockaid)
+      setSecurityAlertBlockaidEnabled:
+        preferencesController.setSecurityAlertBlockaidEnabled.bind(
           preferencesController,
         ),
+      ///: END:ONLY_INCLUDE_IN
       ///: BEGIN:ONLY_INCLUDE_IN(keyring-snaps)
       setSnapsAddSnapAccountModalDismissed:
         preferencesController.setSnapsAddSnapAccountModalDismissed.bind(

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -2265,8 +2265,8 @@ export default class MetamaskController extends EventEmitter {
         preferencesController.setTransactionSecurityCheckEnabled.bind(
           preferencesController,
         ),
-      setSecurityAlertsEnabled:
-        preferencesController.setSecurityAlertsEnabled.bind(
+      securityAlertBlockaidEnabled:
+        preferencesController.securityAlertBlockaidEnabled.bind(
           preferencesController,
         ),
       ///: BEGIN:ONLY_INCLUDE_IN(keyring-snaps)

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -4640,10 +4640,8 @@ export default class MetamaskController extends EventEmitter {
   };
 
   async securityProviderRequest(requestData, methodName) {
-    const {
-      currentLocale,
-      transactionSecurityCheckEnabled,
-    } = this.preferencesController.store.getState();
+    const { currentLocale, transactionSecurityCheckEnabled } =
+      this.preferencesController.store.getState();
 
     if (transactionSecurityCheckEnabled) {
       const chainId = Number(

--- a/builds.yml
+++ b/builds.yml
@@ -47,6 +47,7 @@ buildTypes:
       - desktop
       - build-flask
       - keyring-snaps
+      - blockaid
     env:
       - INFURA_FLASK_PROJECT_ID
       - SEGMENT_FLASK_WRITE_KEY

--- a/builds.yml
+++ b/builds.yml
@@ -47,7 +47,6 @@ buildTypes:
       - desktop
       - build-flask
       - keyring-snaps
-      - blockaid
     env:
       - INFURA_FLASK_PROJECT_ID
       - SEGMENT_FLASK_WRITE_KEY

--- a/shared/constants/metametrics.ts
+++ b/shared/constants/metametrics.ts
@@ -455,6 +455,11 @@ export enum MetaMetricsUserTrait {
    */
   MmiIsCustodian = 'mmi_is_custodian',
   ///: END:ONLY_INCLUDE_IN
+  /**
+   * Identified when the security provider feature is enabled.
+   */
+  SecurityAlertsEnabled = 'security_alerts_enabled',
+
 }
 
 /**

--- a/shared/constants/metametrics.ts
+++ b/shared/constants/metametrics.ts
@@ -459,7 +459,6 @@ export enum MetaMetricsUserTrait {
    * Identified when the security provider feature is enabled.
    */
   SecurityAlertsEnabled = 'security_alerts_enabled',
-
 }
 
 /**

--- a/shared/constants/metametrics.ts
+++ b/shared/constants/metametrics.ts
@@ -358,6 +358,10 @@ export type MetaMetricsUserTraits = {
    * Whether the security provider feature has been enabled.
    */
   security_providers?: string[];
+  /**
+   * Whether the security alerts feature has been enabled.
+   */
+  security_alerts_enabled?: boolean;
   ///: BEGIN:ONLY_INCLUDE_IN(build-mmi)
   /**
    * The address of the MMI account in question

--- a/shared/constants/metametrics.ts
+++ b/shared/constants/metametrics.ts
@@ -459,10 +459,12 @@ export enum MetaMetricsUserTrait {
    */
   MmiIsCustodian = 'mmi_is_custodian',
   ///: END:ONLY_INCLUDE_IN
+  ///: BEGIN:ONLY_INCLUDE_IN(blockaid)
   /**
-   * Identified when the security provider feature is enabled.
+   * Identified when the blockaid security provider feature is enabled.
    */
-  SecurityAlertsEnabled = 'security_alerts_enabled',
+  SecurityAlertBlockaidEnabled = 'security_alert_blockaid_enabled',
+  ///: END:ONLY_INCLUDE_IN
 }
 
 /**

--- a/test/e2e/tests/multiple-transactions.spec.js
+++ b/test/e2e/tests/multiple-transactions.spec.js
@@ -4,6 +4,7 @@ const {
   withFixtures,
   openDapp,
   regularDelayMs,
+  veryLargeDelayMs,
 } = require('../helpers');
 const FixtureBuilder = require('../fixture-builder');
 
@@ -74,6 +75,8 @@ describe('Multiple transactions', function () {
         const confirmedTxes = await driver.findElements(
           '.transaction-list__completed-transactions .activity-list-item',
         );
+
+        await driver.delay(veryLargeDelayMs);
 
         assert.equal(confirmedTxes.length, 2);
       },

--- a/ui/helpers/constants/settings.js
+++ b/ui/helpers/constants/settings.js
@@ -346,7 +346,7 @@ export const SETTINGS_CONSTANTS = [
     tabMessage: (t) => t('experimental'),
     sectionMessage: (t) => t('securityAlerts'),
     descriptionMessage: (t) => t('securityAlertsDescription'),
-    route: `${EXPERIMENTAL_ROUTE}#opensea-api`,
+    route: `${EXPERIMENTAL_ROUTE}#security-alerts`,
     icon: 'fa fa-flask',
   },
   {

--- a/ui/helpers/constants/settings.js
+++ b/ui/helpers/constants/settings.js
@@ -343,6 +343,13 @@ export const SETTINGS_CONSTANTS = [
     icon: 'fa fa-flask',
   },
   {
+    tabMessage: (t) => t('experimental'),
+    sectionMessage: (t) => t('securityAlerts'),
+    descriptionMessage: (t) => t('securityAlertsDescription'),
+    route: `${EXPERIMENTAL_ROUTE}#opensea-api`,
+    icon: 'fa fa-flask',
+  },
+  {
     tabMessage: (t) => t('advanced'),
     sectionMessage: (t) => t('backupUserData'),
     descriptionMessage: (t) => t('backupUserDataDescription'),

--- a/ui/helpers/constants/settings.js
+++ b/ui/helpers/constants/settings.js
@@ -342,6 +342,7 @@ export const SETTINGS_CONSTANTS = [
     route: `${EXPERIMENTAL_ROUTE}#autodetect-nfts`,
     icon: 'fa fa-flask',
   },
+  ///: BEGIN:ONLY_INCLUDE_IN(blockaid)
   {
     tabMessage: (t) => t('experimental'),
     sectionMessage: (t) => t('securityAlerts'),
@@ -349,6 +350,7 @@ export const SETTINGS_CONSTANTS = [
     route: `${EXPERIMENTAL_ROUTE}#security-alerts`,
     icon: 'fa fa-flask',
   },
+  ///: END:ONLY_INCLUDE_IN
   {
     tabMessage: (t) => t('advanced'),
     sectionMessage: (t) => t('backupUserData'),

--- a/ui/helpers/utils/settings-search.test.js
+++ b/ui/helpers/utils/settings-search.test.js
@@ -178,7 +178,7 @@ describe('Settings Search Utils', () => {
 
     it('should get good experimental section number', () => {
       expect(getNumberOfSettingsInSection(t, t('experimental'))).toStrictEqual(
-        3,
+        4,
       );
     });
 

--- a/ui/pages/settings/experimental-tab/__snapshots__/experimental-tab.test.js.snap
+++ b/ui/pages/settings/experimental-tab/__snapshots__/experimental-tab.test.js.snap
@@ -5,41 +5,43 @@ exports[`ExperimentalTab with desktop enabled renders ExperimentalTab component 
   <div
     class="settings-page__body"
   >
-    <h4
-      class="box box--margin-top-1 box--margin-bottom-2 box--flex-direction-row typography typography--h4 typography--weight-bold typography--style-normal typography--color-text-alternative"
+    <h3
+      class="box mm-text mm-text--heading-md mm-text--font-weight-bold box--margin-bottom-2 box--flex-direction-row box--color-text-alternative"
     >
       Security
-    </h4>
+    </h3>
     <div
       class="settings-page__content-row settings-page__content-row-experimental settings-page__content-row-security"
     >
       <div
         class="settings-page__content-item"
       >
-        <span>
+        <h4
+          class="box mm-text mm-text--heading-sm mm-text--font-weight-medium box--margin-top-3 box--margin-bottom-1 box--flex-direction-row box--color-text-default"
+        >
           Security alerts
-        </span>
+        </h4>
         <div
           class="settings-page__content-description"
         >
-          <h6
-            class="box box--margin-top-1 box--margin-bottom-1 box--flex-direction-row typography typography--h6 typography--weight-normal typography--style-normal typography--color-text-alternative"
+          <h4
+            class="box mm-text mm-text--heading-sm mm-text--font-weight-normal box--flex-direction-row box--color-text-alternative"
           >
             This feature alerts you to malicious activity by locally reviewing your transactions and signature requests. Your data isn't shared with the third parties providing this service. Always do your own due diligence before approving any requests. There’s no guarantee that this feature will detect all malicious activity.
-          </h6>
-          <h6
-            class="box box--margin-top-3 box--margin-bottom-1 box--flex-direction-row typography typography--h6 typography--weight-bold typography--style-normal typography--color-text-default"
+          </h4>
+          <h4
+            class="box mm-text mm-text--heading-sm mm-text--font-weight-medium box--margin-top-3 box--margin-bottom-1 box--flex-direction-row box--color-text-default"
           >
             Select providers
-          </h6>
+          </h4>
           <div
             class="settings-page__content-item-col settings-page__content-item-col-blockaid"
           >
-            <h5
-              class="box box--margin-top-1 box--flex-direction-row typography typography--h5 typography--weight-medium typography--style-normal typography--color-text-default"
+            <h3
+              class="box mm-text mm-text--heading-md mm-text--font-weight-normal box--flex-direction-row box--color-text-default"
             >
               Blockaid
-            </h5>
+            </h3>
             <label
               class="toggle-button toggle-button--off"
               tabindex="0"
@@ -82,11 +84,11 @@ exports[`ExperimentalTab with desktop enabled renders ExperimentalTab component 
               </div>
             </label>
           </div>
-          <h6
-            class="box box--margin-bottom-1 box--flex-direction-row typography typography--h6 typography--weight-normal typography--style-normal typography--color-text-muted"
+          <h4
+            class="box mm-text mm-text--heading-sm mm-text--font-weight-normal box--flex-direction-row box--color-text-muted"
           >
             More providers coming soon
-          </h6>
+          </h4>
         </div>
       </div>
     </div>

--- a/ui/pages/settings/experimental-tab/__snapshots__/experimental-tab.test.js.snap
+++ b/ui/pages/settings/experimental-tab/__snapshots__/experimental-tab.test.js.snap
@@ -8,6 +8,91 @@ exports[`ExperimentalTab with desktop enabled renders ExperimentalTab component 
     <h4
       class="box box--margin-top-1 box--margin-bottom-2 box--flex-direction-row typography typography--h4 typography--weight-bold typography--style-normal typography--color-text-alternative"
     >
+      Security
+    </h4>
+    <div
+      class="settings-page__content-row settings-page__content-row-experimental settings-page__content-row-security"
+    >
+      <div
+        class="settings-page__content-item"
+      >
+        <span>
+          Security alerts
+        </span>
+        <div
+          class="settings-page__content-description"
+        >
+          <h6
+            class="box box--margin-top-1 box--margin-bottom-1 box--flex-direction-row typography typography--h6 typography--weight-normal typography--style-normal typography--color-text-alternative"
+          >
+            This feature alerts you to malicious activity by locally reviewing your transactions and signature requests. Your data isn't shared with the third parties providing this service. Always do your own due diligence before approving any requests. There’s no guarantee that this feature will detect all malicious activity.
+          </h6>
+          <h6
+            class="box box--margin-top-3 box--margin-bottom-1 box--flex-direction-row typography typography--h6 typography--weight-bold typography--style-normal typography--color-text-default"
+          >
+            Select providers
+          </h6>
+          <div
+            class="settings-page__content-item-col settings-page__content-item-col-blockaid"
+          >
+            <h5
+              class="box box--margin-top-1 box--flex-direction-row typography typography--h5 typography--weight-medium typography--style-normal typography--color-text-default"
+            >
+              Blockaid
+            </h5>
+            <label
+              class="toggle-button toggle-button--off"
+              tabindex="0"
+            >
+              <div
+                style="display: flex; width: 52px; align-items: center; justify-content: flex-start; position: relative; cursor: pointer; background-color: transparent; border: 0px; padding: 0px; user-select: none;"
+              >
+                <div
+                  style="width: 40px; height: 24px; padding: 0px; border-radius: 26px; display: flex; align-items: center; justify-content: center; background-color: rgb(242, 244, 246);"
+                >
+                  <div
+                    style="font-size: 11px; display: flex; align-items: center; justify-content: center; font-family: 'Helvetica Neue', Helvetica, sans-serif; position: relative; color: rgb(250, 250, 250); margin-top: auto; margin-bottom: auto; line-height: 0; opacity: 0; width: 26px; height: 20px; left: 4px;"
+                  />
+                  <div
+                    style="font-size: 11px; display: flex; align-items: center; justify-content: center; font-family: 'Helvetica Neue', Helvetica, sans-serif; position: relative; color: rgba(255, 255, 255, 0.6); bottom: 0px; margin-top: auto; margin-bottom: auto; padding-right: 5px; line-height: 0; width: 26px; height: 20px; opacity: 1;"
+                  />
+                </div>
+                <div
+                  style="position: absolute; height: 100%; top: 0px; left: 0px; display: flex; flex: 1; align-self: stretch; align-items: center; justify-content: flex-start;"
+                >
+                  <div
+                    style="width: 18px; height: 18px; display: flex; align-self: center; box-shadow: none; border-radius: 50%; box-sizing: border-box; position: relative; background-color: rgb(106, 115, 125); left: 3px;"
+                  />
+                </div>
+                <input
+                  style="border: 0px; height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px;"
+                  type="checkbox"
+                  value="false"
+                />
+              </div>
+              <div
+                class="toggle-button__status"
+              >
+                <span
+                  class="toggle-button__label-off"
+                />
+                <span
+                  class="toggle-button__label-on"
+                />
+              </div>
+            </label>
+          </div>
+          <h6
+            class="box box--margin-bottom-1 box--flex-direction-row typography typography--h6 typography--weight-normal typography--style-normal typography--color-text-muted"
+          >
+            More providers coming soon
+          </h6>
+        </div>
+      </div>
+    </div>
+    <h4
+      class="box box--margin-top-1 box--margin-bottom-2 box--flex-direction-row typography typography--h4 typography--weight-bold typography--style-normal typography--color-text-alternative"
+    >
       Privacy
     </h4>
     <div
@@ -30,7 +115,7 @@ exports[`ExperimentalTab with desktop enabled renders ExperimentalTab component 
           <h6
             class="box box--margin-top-3 box--margin-bottom-1 box--flex-direction-row typography typography--h6 typography--weight-normal typography--style-normal typography--color-text-alternative"
           >
-            Select providers:
+            Select providers
           </h6>
           <div
             class="settings-page__content-item-col settings-page__content-item-col-open-sea"

--- a/ui/pages/settings/experimental-tab/experimental-tab.component.js
+++ b/ui/pages/settings/experimental-tab/experimental-tab.component.js
@@ -30,6 +30,8 @@ export default class ExperimentalTab extends PureComponent {
     openSeaEnabled: PropTypes.bool,
     transactionSecurityCheckEnabled: PropTypes.bool,
     setTransactionSecurityCheckEnabled: PropTypes.func,
+    securityAlertsEnabled: PropTypes.bool,
+    setSecurityAlertsEnabled: PropTypes.func,
   };
 
   settingsRefs = Array(
@@ -134,6 +136,82 @@ export default class ExperimentalTab extends PureComponent {
                 offLabel={t('off')}
                 onLabel={t('on')}
               />
+            </div>
+          </div>
+        </div>
+      </>
+    );
+  }
+
+  renderSecurityAlertsToggle() {
+    const { t } = this.context;
+
+    const { securityAlertsEnabled, setSecurityAlertsEnabled } = this.props;
+
+    return (
+      <>
+        <Typography
+          variant={TypographyVariant.H4}
+          color={TextColor.textAlternative}
+          marginBottom={2}
+          fontWeight={FONT_WEIGHT.BOLD}
+        >
+          {t('security')}
+        </Typography>
+        <div
+          ref={this.settingsRefs[2]}
+          className="settings-page__content-row settings-page__content-row-experimental settings-page__content-row-security"
+        >
+          <div className="settings-page__content-item">
+            <span>{t('securityAlerts')}</span>
+            <div className="settings-page__content-description">
+              <Typography
+                variant={TypographyVariant.H6}
+                color={TextColor.textAlternative}
+              >
+                {t('securityAlertsDescription')}
+              </Typography>
+              <Typography
+                marginTop={3}
+                marginBottom={1}
+                variant={TypographyVariant.H6}
+                color={TextColor.textDefault}
+                fontWeight={FONT_WEIGHT.BOLD}
+              >
+                {t('selectProvider')}
+              </Typography>
+              <div className="settings-page__content-item-col settings-page__content-item-col-blockaid">
+                <Typography
+                  variant={TypographyVariant.H5}
+                  color={TextColor.textDefault}
+                  fontWeight={FONT_WEIGHT.MEDIUM}
+                  marginBottom={0}
+                >
+                  {t('blockaid')}
+                </Typography>
+                <ToggleButton
+                  value={securityAlertsEnabled}
+                  onToggle={(value) => {
+                    this.context.trackEvent({
+                      category: MetaMetricsEventCategory.Settings,
+                      event: 'Enabled/Disable Security Alerts',
+                      properties: {
+                        action: 'Enabled/Disable Security Alerts',
+                        security_alerts_enabled: !value,
+                        legacy_event: true,
+                      },
+                    });
+                    setSecurityAlertsEnabled(!value);
+                  }}
+                />
+              </div>
+              <Typography
+                variant={TypographyVariant.H6}
+                color={TextColor.textMuted}
+                marginTop={0}
+              >
+                {t('moreProviders')}
+              </Typography>
             </div>
           </div>
         </div>
@@ -261,6 +339,7 @@ export default class ExperimentalTab extends PureComponent {
   render() {
     return (
       <div className="settings-page__body">
+        {this.renderSecurityAlertsToggle()}
         {this.renderTransactionSecurityCheckToggle()}
         {this.renderOpenSeaEnabledToggle()}
         {

--- a/ui/pages/settings/experimental-tab/experimental-tab.component.js
+++ b/ui/pages/settings/experimental-tab/experimental-tab.component.js
@@ -32,8 +32,8 @@ export default class ExperimentalTab extends PureComponent {
     openSeaEnabled: PropTypes.bool,
     transactionSecurityCheckEnabled: PropTypes.bool,
     setTransactionSecurityCheckEnabled: PropTypes.func,
-    securityAlertsEnabled: PropTypes.bool,
-    securityAlertBlockaidEnabled: PropTypes.func,
+    securityAlertBlockaidEnabled: PropTypes.bool,
+    setSecurityAlertBlockaidEnabled: PropTypes.func,
   };
 
   settingsRefs = Array(
@@ -148,7 +148,8 @@ export default class ExperimentalTab extends PureComponent {
   renderSecurityAlertsToggle() {
     const { t } = this.context;
 
-    const { securityAlertsEnabled, securityAlertBlockaidEnabled } = this.props;
+    const { securityAlertBlockaidEnabled, setSecurityAlertBlockaidEnabled } =
+      this.props;
 
     return (
       <>
@@ -200,7 +201,7 @@ export default class ExperimentalTab extends PureComponent {
                   {t('blockaid')}
                 </Text>
                 <ToggleButton
-                  value={securityAlertsEnabled}
+                  value={securityAlertBlockaidEnabled}
                   onToggle={(value) => {
                     this.context.trackEvent({
                       category: MetaMetricsEventCategory.Settings,
@@ -210,7 +211,7 @@ export default class ExperimentalTab extends PureComponent {
                         security_alerts_enabled: !value,
                       },
                     });
-                    securityAlertBlockaidEnabled(!value);
+                    setSecurityAlertBlockaidEnabled(!value);
                   }}
                 />
               </div>

--- a/ui/pages/settings/experimental-tab/experimental-tab.component.js
+++ b/ui/pages/settings/experimental-tab/experimental-tab.component.js
@@ -10,7 +10,9 @@ import Typography from '../../../components/ui/typography/typography';
 import { Text } from '../../../components/component-library/text/deprecated';
 import {
   FONT_WEIGHT,
+  FontWeight,
   TextColor,
+  TextVariant,
   TypographyVariant,
 } from '../../../helpers/constants/design-system';
 ///: BEGIN:ONLY_INCLUDE_IN(desktop)
@@ -150,45 +152,54 @@ export default class ExperimentalTab extends PureComponent {
 
     return (
       <>
-        <Typography
-          variant={TypographyVariant.H4}
+        <Text
+          variant={TextVariant.headingMd}
           color={TextColor.textAlternative}
           marginBottom={2}
-          fontWeight={FONT_WEIGHT.BOLD}
+          fontWeight={FontWeight.Bold}
         >
           {t('security')}
-        </Typography>
+        </Text>
         <div
           ref={this.settingsRefs[2]}
           className="settings-page__content-row settings-page__content-row-experimental settings-page__content-row-security"
         >
           <div className="settings-page__content-item">
-            <span>{t('securityAlerts')}</span>
+            <Text
+              marginTop={3}
+              marginBottom={1}
+              variant={TextVariant.headingSm}
+              color={TextColor.textDefault}
+              fontWeight={FontWeight.Medium}
+            >
+              {t('securityAlerts')}
+            </Text>
             <div className="settings-page__content-description">
-              <Typography
-                variant={TypographyVariant.H6}
+              <Text
+                variant={TextVariant.headingSm}
                 color={TextColor.textAlternative}
+                fontWeight={FontWeight.Normal}
               >
                 {t('securityAlertsDescription')}
-              </Typography>
-              <Typography
+              </Text>
+              <Text
                 marginTop={3}
                 marginBottom={1}
-                variant={TypographyVariant.H6}
+                variant={TextVariant.headingSm}
                 color={TextColor.textDefault}
-                fontWeight={FONT_WEIGHT.BOLD}
+                fontWeight={FontWeight.Medium}
               >
                 {t('selectProvider')}
-              </Typography>
+              </Text>
               <div className="settings-page__content-item-col settings-page__content-item-col-blockaid">
-                <Typography
-                  variant={TypographyVariant.H5}
+                <Text
+                  variant={TextVariant.headingMd}
                   color={TextColor.textDefault}
-                  fontWeight={FONT_WEIGHT.MEDIUM}
+                  fontWeight={FontWeight.Normal}
                   marginBottom={0}
                 >
                   {t('blockaid')}
-                </Typography>
+                </Text>
                 <ToggleButton
                   value={securityAlertsEnabled}
                   onToggle={(value) => {
@@ -205,13 +216,14 @@ export default class ExperimentalTab extends PureComponent {
                   }}
                 />
               </div>
-              <Typography
-                variant={TypographyVariant.H6}
+              <Text
+                variant={TextVariant.headingSm}
                 color={TextColor.textMuted}
+                fontWeight={FontWeight.Normal}
                 marginTop={0}
               >
                 {t('moreProviders')}
-              </Typography>
+              </Text>
             </div>
           </div>
         </div>
@@ -339,6 +351,7 @@ export default class ExperimentalTab extends PureComponent {
   render() {
     return (
       <div className="settings-page__body">
+        {this.renderSecurityAlertsToggle()}
         {
           ///: BEGIN:ONLY_INCLUDE_IN(blockaid)
           this.renderSecurityAlertsToggle()

--- a/ui/pages/settings/experimental-tab/experimental-tab.component.js
+++ b/ui/pages/settings/experimental-tab/experimental-tab.component.js
@@ -339,7 +339,11 @@ export default class ExperimentalTab extends PureComponent {
   render() {
     return (
       <div className="settings-page__body">
-        {this.renderSecurityAlertsToggle()}
+        {
+          ///: BEGIN:ONLY_INCLUDE_IN(blockaid)
+          this.renderSecurityAlertsToggle()
+          ///: END:ONLY_INCLUDE_IN
+        }
         {this.renderTransactionSecurityCheckToggle()}
         {this.renderOpenSeaEnabledToggle()}
         {

--- a/ui/pages/settings/experimental-tab/experimental-tab.component.js
+++ b/ui/pages/settings/experimental-tab/experimental-tab.component.js
@@ -148,6 +148,7 @@ export default class ExperimentalTab extends PureComponent {
 
     const { securityAlertsEnabled, setSecurityAlertsEnabled } = this.props;
 
+    console.log('securityAlertsEnabled', this.settingsRefs);
     return (
       <>
         <Typography

--- a/ui/pages/settings/experimental-tab/experimental-tab.component.js
+++ b/ui/pages/settings/experimental-tab/experimental-tab.component.js
@@ -148,7 +148,6 @@ export default class ExperimentalTab extends PureComponent {
 
     const { securityAlertsEnabled, setSecurityAlertsEnabled } = this.props;
 
-    console.log('securityAlertsEnabled', this.settingsRefs);
     return (
       <>
         <Typography

--- a/ui/pages/settings/experimental-tab/experimental-tab.component.js
+++ b/ui/pages/settings/experimental-tab/experimental-tab.component.js
@@ -33,7 +33,7 @@ export default class ExperimentalTab extends PureComponent {
     transactionSecurityCheckEnabled: PropTypes.bool,
     setTransactionSecurityCheckEnabled: PropTypes.func,
     securityAlertsEnabled: PropTypes.bool,
-    setSecurityAlertsEnabled: PropTypes.func,
+    securityAlertBlockaidEnabled: PropTypes.func,
   };
 
   settingsRefs = Array(
@@ -148,7 +148,7 @@ export default class ExperimentalTab extends PureComponent {
   renderSecurityAlertsToggle() {
     const { t } = this.context;
 
-    const { securityAlertsEnabled, setSecurityAlertsEnabled } = this.props;
+    const { securityAlertsEnabled, securityAlertBlockaidEnabled } = this.props;
 
     return (
       <>
@@ -196,7 +196,6 @@ export default class ExperimentalTab extends PureComponent {
                   variant={TextVariant.headingMd}
                   color={TextColor.textDefault}
                   fontWeight={FontWeight.Normal}
-                  marginBottom={0}
                 >
                   {t('blockaid')}
                 </Text>
@@ -209,10 +208,9 @@ export default class ExperimentalTab extends PureComponent {
                       properties: {
                         action: 'Enabled/Disable Security Alerts',
                         security_alerts_enabled: !value,
-                        legacy_event: true,
                       },
                     });
-                    setSecurityAlertsEnabled(!value);
+                    securityAlertBlockaidEnabled(!value);
                   }}
                 />
               </div>
@@ -220,7 +218,6 @@ export default class ExperimentalTab extends PureComponent {
                 variant={TextVariant.headingSm}
                 color={TextColor.textMuted}
                 fontWeight={FontWeight.Normal}
-                marginTop={0}
               >
                 {t('moreProviders')}
               </Text>
@@ -351,7 +348,6 @@ export default class ExperimentalTab extends PureComponent {
   render() {
     return (
       <div className="settings-page__body">
-        {this.renderSecurityAlertsToggle()}
         {
           ///: BEGIN:ONLY_INCLUDE_IN(blockaid)
           this.renderSecurityAlertsToggle()

--- a/ui/pages/settings/experimental-tab/experimental-tab.container.js
+++ b/ui/pages/settings/experimental-tab/experimental-tab.container.js
@@ -5,11 +5,13 @@ import {
   setUseNftDetection,
   setOpenSeaEnabled,
   setTransactionSecurityCheckEnabled,
+  setSecurityAlertsEnabled,
 } from '../../../store/actions';
 import {
   getUseNftDetection,
   getOpenSeaEnabled,
   getIsTransactionSecurityCheckEnabled,
+  getIsSecurityAlertsEnabled,
 } from '../../../selectors';
 import ExperimentalTab from './experimental-tab.component';
 
@@ -19,6 +21,7 @@ const mapStateToProps = (state) => {
     openSeaEnabled: getOpenSeaEnabled(state),
     transactionSecurityCheckEnabled:
       getIsTransactionSecurityCheckEnabled(state),
+    securityAlertsEnabled: getIsSecurityAlertsEnabled(state),
   };
 };
 
@@ -28,6 +31,7 @@ const mapDispatchToProps = (dispatch) => {
     setOpenSeaEnabled: (val) => dispatch(setOpenSeaEnabled(val)),
     setTransactionSecurityCheckEnabled: (val) =>
       dispatch(setTransactionSecurityCheckEnabled(val)),
+    setSecurityAlertsEnabled: (val) => dispatch(setSecurityAlertsEnabled(val)),
   };
 };
 

--- a/ui/pages/settings/experimental-tab/experimental-tab.container.js
+++ b/ui/pages/settings/experimental-tab/experimental-tab.container.js
@@ -5,13 +5,17 @@ import {
   setUseNftDetection,
   setOpenSeaEnabled,
   setTransactionSecurityCheckEnabled,
+  ///: BEGIN:ONLY_INCLUDE_IN(blockaid)
   setSecurityAlertBlockaidEnabled,
+  ///: END:ONLY_INCLUDE_IN(blockaid)
 } from '../../../store/actions';
 import {
   getUseNftDetection,
   getOpenSeaEnabled,
   getIsTransactionSecurityCheckEnabled,
+  ///: BEGIN:ONLY_INCLUDE_IN(blockaid)
   getIsSecurityAlertBlockaidEnabled,
+  ///: END:ONLY_INCLUDE_IN(blockaid)
 } from '../../../selectors';
 import ExperimentalTab from './experimental-tab.component';
 
@@ -21,7 +25,9 @@ const mapStateToProps = (state) => {
     openSeaEnabled: getOpenSeaEnabled(state),
     transactionSecurityCheckEnabled:
       getIsTransactionSecurityCheckEnabled(state),
+    ///: BEGIN:ONLY_INCLUDE_IN(blockaid)
     securityAlertBlockaidEnabled: getIsSecurityAlertBlockaidEnabled(state),
+    ///: END:ONLY_INCLUDE_IN(blockaid)
   };
 };
 
@@ -31,8 +37,10 @@ const mapDispatchToProps = (dispatch) => {
     setOpenSeaEnabled: (val) => dispatch(setOpenSeaEnabled(val)),
     setTransactionSecurityCheckEnabled: (val) =>
       dispatch(setTransactionSecurityCheckEnabled(val)),
+    ///: BEGIN:ONLY_INCLUDE_IN(blockaid)
     setSecurityAlertBlockaidEnabled: (val) =>
       dispatch(setSecurityAlertBlockaidEnabled(val)),
+    ///: END:ONLY_INCLUDE_IN(blockaid)
   };
 };
 

--- a/ui/pages/settings/experimental-tab/experimental-tab.container.js
+++ b/ui/pages/settings/experimental-tab/experimental-tab.container.js
@@ -21,9 +21,7 @@ const mapStateToProps = (state) => {
     openSeaEnabled: getOpenSeaEnabled(state),
     transactionSecurityCheckEnabled:
       getIsTransactionSecurityCheckEnabled(state),
-    ///: BEGIN:ONLY_INCLUDE_IN(blockaid)
     securityAlertBlockaidEnabled: getIsSecurityAlertBlockaidEnabled(state),
-    ///: END:ONLY_INCLUDE_IN(blockaid)
   };
 };
 
@@ -33,10 +31,8 @@ const mapDispatchToProps = (dispatch) => {
     setOpenSeaEnabled: (val) => dispatch(setOpenSeaEnabled(val)),
     setTransactionSecurityCheckEnabled: (val) =>
       dispatch(setTransactionSecurityCheckEnabled(val)),
-    ///: BEGIN:ONLY_INCLUDE_IN(blockaid)
     setSecurityAlertBlockaidEnabled: (val) =>
       dispatch(setSecurityAlertBlockaidEnabled(val)),
-    ///: END:ONLY_INCLUDE_IN(blockaid)
   };
 };
 

--- a/ui/pages/settings/experimental-tab/experimental-tab.container.js
+++ b/ui/pages/settings/experimental-tab/experimental-tab.container.js
@@ -31,7 +31,8 @@ const mapDispatchToProps = (dispatch) => {
     setOpenSeaEnabled: (val) => dispatch(setOpenSeaEnabled(val)),
     setTransactionSecurityCheckEnabled: (val) =>
       dispatch(setTransactionSecurityCheckEnabled(val)),
-    securityAlertBlockaidEnabled: (val) => dispatch(securityAlertBlockaidEnabled(val)),
+    securityAlertBlockaidEnabled: (val) =>
+      dispatch(securityAlertBlockaidEnabled(val)),
   };
 };
 

--- a/ui/pages/settings/experimental-tab/experimental-tab.container.js
+++ b/ui/pages/settings/experimental-tab/experimental-tab.container.js
@@ -5,17 +5,13 @@ import {
   setUseNftDetection,
   setOpenSeaEnabled,
   setTransactionSecurityCheckEnabled,
-  ///: BEGIN:ONLY_INCLUDE_IN(blockaid)
   setSecurityAlertBlockaidEnabled,
-  ///: END:ONLY_INCLUDE_IN(blockaid)
 } from '../../../store/actions';
 import {
   getUseNftDetection,
   getOpenSeaEnabled,
   getIsTransactionSecurityCheckEnabled,
-  ///: BEGIN:ONLY_INCLUDE_IN(blockaid)
   getIsSecurityAlertBlockaidEnabled,
-  ///: END:ONLY_INCLUDE_IN(blockaid)
 } from '../../../selectors';
 import ExperimentalTab from './experimental-tab.component';
 
@@ -25,9 +21,7 @@ const mapStateToProps = (state) => {
     openSeaEnabled: getOpenSeaEnabled(state),
     transactionSecurityCheckEnabled:
       getIsTransactionSecurityCheckEnabled(state),
-    ///: BEGIN:ONLY_INCLUDE_IN(blockaid)
     securityAlertBlockaidEnabled: getIsSecurityAlertBlockaidEnabled(state),
-    ///: END:ONLY_INCLUDE_IN(blockaid)
   };
 };
 
@@ -37,10 +31,8 @@ const mapDispatchToProps = (dispatch) => {
     setOpenSeaEnabled: (val) => dispatch(setOpenSeaEnabled(val)),
     setTransactionSecurityCheckEnabled: (val) =>
       dispatch(setTransactionSecurityCheckEnabled(val)),
-    ///: BEGIN:ONLY_INCLUDE_IN(blockaid)
     setSecurityAlertBlockaidEnabled: (val) =>
       dispatch(setSecurityAlertBlockaidEnabled(val)),
-    ///: END:ONLY_INCLUDE_IN(blockaid)
   };
 };
 

--- a/ui/pages/settings/experimental-tab/experimental-tab.container.js
+++ b/ui/pages/settings/experimental-tab/experimental-tab.container.js
@@ -5,7 +5,7 @@ import {
   setUseNftDetection,
   setOpenSeaEnabled,
   setTransactionSecurityCheckEnabled,
-  setSecurityAlertsEnabled,
+  securityAlertBlockaidEnabled,
 } from '../../../store/actions';
 import {
   getUseNftDetection,
@@ -31,7 +31,7 @@ const mapDispatchToProps = (dispatch) => {
     setOpenSeaEnabled: (val) => dispatch(setOpenSeaEnabled(val)),
     setTransactionSecurityCheckEnabled: (val) =>
       dispatch(setTransactionSecurityCheckEnabled(val)),
-    setSecurityAlertsEnabled: (val) => dispatch(setSecurityAlertsEnabled(val)),
+    securityAlertBlockaidEnabled: (val) => dispatch(securityAlertBlockaidEnabled(val)),
   };
 };
 

--- a/ui/pages/settings/experimental-tab/experimental-tab.container.js
+++ b/ui/pages/settings/experimental-tab/experimental-tab.container.js
@@ -5,13 +5,13 @@ import {
   setUseNftDetection,
   setOpenSeaEnabled,
   setTransactionSecurityCheckEnabled,
-  securityAlertBlockaidEnabled,
+  setSecurityAlertBlockaidEnabled,
 } from '../../../store/actions';
 import {
   getUseNftDetection,
   getOpenSeaEnabled,
   getIsTransactionSecurityCheckEnabled,
-  getIsSecurityAlertsEnabled,
+  getIsSecurityAlertBlockaidEnabled,
 } from '../../../selectors';
 import ExperimentalTab from './experimental-tab.component';
 
@@ -21,7 +21,9 @@ const mapStateToProps = (state) => {
     openSeaEnabled: getOpenSeaEnabled(state),
     transactionSecurityCheckEnabled:
       getIsTransactionSecurityCheckEnabled(state),
-    securityAlertsEnabled: getIsSecurityAlertsEnabled(state),
+    ///: BEGIN:ONLY_INCLUDE_IN(blockaid)
+    securityAlertBlockaidEnabled: getIsSecurityAlertBlockaidEnabled(state),
+    ///: END:ONLY_INCLUDE_IN(blockaid)
   };
 };
 
@@ -31,8 +33,10 @@ const mapDispatchToProps = (dispatch) => {
     setOpenSeaEnabled: (val) => dispatch(setOpenSeaEnabled(val)),
     setTransactionSecurityCheckEnabled: (val) =>
       dispatch(setTransactionSecurityCheckEnabled(val)),
-    securityAlertBlockaidEnabled: (val) =>
-      dispatch(securityAlertBlockaidEnabled(val)),
+    ///: BEGIN:ONLY_INCLUDE_IN(blockaid)
+    setSecurityAlertBlockaidEnabled: (val) =>
+      dispatch(setSecurityAlertBlockaidEnabled(val)),
+    ///: END:ONLY_INCLUDE_IN(blockaid)
   };
 };
 

--- a/ui/pages/settings/experimental-tab/experimental-tab.test.js
+++ b/ui/pages/settings/experimental-tab/experimental-tab.test.js
@@ -26,7 +26,7 @@ describe('ExperimentalTab', () => {
     expect(screen.getByText('Security alerts')).toBeDefined();
     expect(screen.getByText('Enable security alerts')).toBeDefined();
     expect(screen.getByText('Blockaid')).toBeDefined();
-    const blockaidToggle =  screen.getAllByRole('checkbox')[0];
+    const blockaidToggle = screen.getAllByRole('checkbox')[0];
     expect(blockaidToggle).not.toBeChecked();
   });
 

--- a/ui/pages/settings/experimental-tab/experimental-tab.test.js
+++ b/ui/pages/settings/experimental-tab/experimental-tab.test.js
@@ -21,6 +21,15 @@ describe('ExperimentalTab', () => {
     }).not.toThrow();
   });
 
+  it('renders Security Alerts settings in ExperimentalTab component', () => {
+    const screen = render({ desktopEnabled: true });
+    expect(screen.getByText('Security alerts')).toBeDefined();
+    expect(screen.getByText('Enable security alerts')).toBeDefined();
+    expect(screen.getByText('Blockaid')).toBeDefined();
+    const blockaidToggle =  screen.getAllByRole('checkbox')[0];
+    expect(blockaidToggle).not.toBeChecked();
+  });
+
   describe('with desktop enabled', () => {
     it('renders ExperimentalTab component without error', () => {
       const { container } = render({ desktopEnabled: true });

--- a/ui/pages/settings/index.scss
+++ b/ui/pages/settings/index.scss
@@ -376,6 +376,12 @@
     }
   }
 
+  &__content-item-col-blockaid {
+    flex-direction: row;
+    justify-content: space-between;
+    margin-bottom: 4px;
+  }
+
   &__content-item-col-open-sea {
     flex-direction: row;
     justify-content: space-between;

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -1433,15 +1433,17 @@ export function getIsTransactionSecurityCheckEnabled(state) {
   return state.metamask.transactionSecurityCheckEnabled;
 }
 
+///: BEGIN:ONLY_INCLUDE_IN(blockaid)
 /**
- * To get the `securityAlertsEnabled` value which determines whether we show security alerts or not
+ * To get the `securityAlertBlockaidEnabled` value which determines whether we show blockaid security alerts or not
  *
  * @param {*} state
  * @returns Boolean
  */
-export function getIsSecurityAlertsEnabled(state) {
-  return state.metamask.securityAlertsEnabled;
+export function getIsSecurityAlertBlockaidEnabled(state) {
+  return state.metamask.securityAlertBlockaidEnabled;
 }
+///: END:ONLY_INCLUDE_IN
 
 export function getIsCustomNetwork(state) {
   const chainId = getCurrentChainId(state);

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -1433,7 +1433,6 @@ export function getIsTransactionSecurityCheckEnabled(state) {
   return state.metamask.transactionSecurityCheckEnabled;
 }
 
-///: BEGIN:ONLY_INCLUDE_IN(blockaid)
 /**
  * To get the `securityAlertBlockaidEnabled` value which determines whether we show blockaid security alerts or not
  *
@@ -1441,9 +1440,11 @@ export function getIsTransactionSecurityCheckEnabled(state) {
  * @returns Boolean
  */
 export function getIsSecurityAlertBlockaidEnabled(state) {
-  return state.metamask.securityAlertBlockaidEnabled || state.metamask.transactionSecurityCheckEnabled;;
+  return (
+    state.metamask.securityAlertBlockaidEnabled ||
+    state.metamask.transactionSecurityCheckEnabled
+  );
 }
-///: END:ONLY_INCLUDE_IN
 
 export function getIsCustomNetwork(state) {
   const chainId = getCurrentChainId(state);

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -1433,6 +1433,16 @@ export function getIsTransactionSecurityCheckEnabled(state) {
   return state.metamask.transactionSecurityCheckEnabled;
 }
 
+/**
+ * To get the `securityAlertsEnabled` value which determines whether we show security alerts or not
+ *
+ * @param {*} state
+ * @returns Boolean
+ */
+export function getIsSecurityAlertsEnabled(state) {
+  return state.metamask.securityAlertsEnabled;
+}
+
 export function getIsCustomNetwork(state) {
   const chainId = getCurrentChainId(state);
 

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -1441,7 +1441,7 @@ export function getIsTransactionSecurityCheckEnabled(state) {
  * @returns Boolean
  */
 export function getIsSecurityAlertBlockaidEnabled(state) {
-  return state.metamask.securityAlertBlockaidEnabled;
+  return state.metamask.securityAlertBlockaidEnabled || state.metamask.transactionSecurityCheckEnabled;;
 }
 ///: END:ONLY_INCLUDE_IN
 

--- a/ui/store/actions.ts
+++ b/ui/store/actions.ts
@@ -4344,19 +4344,21 @@ export function setTransactionSecurityCheckEnabled(
   };
 }
 
-export function securityAlertBlockaidEnabled(
-  securityAlertsEnabled: boolean,
+///: BEGIN:ONLY_INCLUDE_IN(blockaid)
+export function setSecurityAlertBlockaidEnabled(
+  securityAlertBlockaidEnabled: boolean,
 ): ThunkAction<void, MetaMaskReduxState, unknown, AnyAction> {
   return async () => {
     try {
-      await submitRequestToBackground('securityAlertBlockaidEnabled', [
-        securityAlertsEnabled,
+      await submitRequestToBackground('setSecurityAlertBlockaidEnabled', [
+        securityAlertBlockaidEnabled,
       ]);
     } catch (error) {
       logErrorWithMessage(error);
     }
   };
 }
+///: END:ONLY_INCLUDE_IN
 
 export function setFirstTimeUsedNetwork(chainId: string) {
   return submitRequestToBackground('setFirstTimeUsedNetwork', [chainId]);

--- a/ui/store/actions.ts
+++ b/ui/store/actions.ts
@@ -4344,6 +4344,20 @@ export function setTransactionSecurityCheckEnabled(
   };
 }
 
+export function setSecurityAlertsEnabled(
+  securityAlertsEnabled: boolean,
+): ThunkAction<void, MetaMaskReduxState, unknown, AnyAction> {
+  return async () => {
+    try {
+      await submitRequestToBackground('setSecurityAlertsEnabled', [
+        securityAlertsEnabled,
+      ]);
+    } catch (error) {
+      logErrorWithMessage(error);
+    }
+  };
+}
+
 export function setFirstTimeUsedNetwork(chainId: string) {
   return submitRequestToBackground('setFirstTimeUsedNetwork', [chainId]);
 }

--- a/ui/store/actions.ts
+++ b/ui/store/actions.ts
@@ -4344,7 +4344,6 @@ export function setTransactionSecurityCheckEnabled(
   };
 }
 
-///: BEGIN:ONLY_INCLUDE_IN(blockaid)
 export function setSecurityAlertBlockaidEnabled(
   securityAlertBlockaidEnabled: boolean,
 ): ThunkAction<void, MetaMaskReduxState, unknown, AnyAction> {
@@ -4358,7 +4357,6 @@ export function setSecurityAlertBlockaidEnabled(
     }
   };
 }
-///: END:ONLY_INCLUDE_IN
 
 export function setFirstTimeUsedNetwork(chainId: string) {
   return submitRequestToBackground('setFirstTimeUsedNetwork', [chainId]);

--- a/ui/store/actions.ts
+++ b/ui/store/actions.ts
@@ -4344,12 +4344,12 @@ export function setTransactionSecurityCheckEnabled(
   };
 }
 
-export function setSecurityAlertsEnabled(
+export function securityAlertBlockaidEnabled(
   securityAlertsEnabled: boolean,
 ): ThunkAction<void, MetaMaskReduxState, unknown, AnyAction> {
   return async () => {
     try {
-      await submitRequestToBackground('setSecurityAlertsEnabled', [
+      await submitRequestToBackground('securityAlertBlockaidEnabled', [
         securityAlertsEnabled,
       ]);
     } catch (error) {


### PR DESCRIPTION
## Explanation

As we introduce the Blockaid security provider feature we should add a toggle under experimental to allow users to turn the feature on and off.

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/527


## Screenshots/Screencaps

<img width="355" alt="Screenshot 2023-07-08 at 15 43 02" src="https://github.com/MetaMask/metamask-extension/assets/44811/c02fb50f-9c70-4f89-a6af-ab0a7bf35f44">

## Manual Testing Steps

1. Open Settings
2. Tab Experimental
3. You should see the screenshot above
4. Toggle button should be off by default
5. Tap on the toggle button it should stay on
6. Restart MetaMask
7. Toggle should remain on
8. Repeat steps 5-7, this time make sure toggle stays off

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [x] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [x] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
