### PR TITLE
Fix #19941 - Correctly show network name and selection when chainIds collide

### DIFF
--- a/test/data/mock-state.json
+++ b/test/data/mock-state.json
@@ -115,13 +115,22 @@
       "type": "rpc",
       "chainId": "0x5",
       "ticker": "ETH",
-      "id": "testNetworkConfigurationId"
+      "id": "chain5"
     },
     "networkConfigurations": {
       "testNetworkConfigurationId": {
         "rpcUrl": "https://testrpc.com",
         "chainId": "0x1",
-        "nickname": "Custom Mainnet RPC"
+        "nickname": "Custom Mainnet RPC",
+        "type": "rpc",
+        "id": "testNetworkConfigurationId"
+      },
+      "chain5": {
+        "type": "rpc",
+        "chainId": "0x5",
+        "ticker": "ETH",
+        "nickname": "Chain 5",
+        "id": "chain5"
       }
     },
     "keyrings": [

--- a/test/e2e/fixture-builder.js
+++ b/test/e2e/fixture-builder.js
@@ -515,9 +515,6 @@ class FixtureBuilder {
 
   withNetworkController(data) {
     merge(this.fixture.data.NetworkController, data);
-
-    console.log("network controller is: ", this.fixture.data.NetworkController);
-
     return this;
   }
 

--- a/test/e2e/fixture-builder.js
+++ b/test/e2e/fixture-builder.js
@@ -215,6 +215,7 @@ function defaultFixture() {
           rpcUrl: 'http://localhost:8545',
           ticker: 'ETH',
           type: 'rpc',
+          id: 'networkConfigurationId',
         },
         networkConfigurations: {
           networkConfigurationId: {
@@ -346,6 +347,7 @@ function onboardingFixture() {
           rpcUrl: 'http://localhost:8545',
           chainId: CHAIN_IDS.LOCALHOST,
           nickname: 'Localhost 8545',
+          id: 'networkConfigurationId',
         },
         networkConfigurations: {
           networkConfigurationId: {

--- a/test/e2e/fixture-builder.js
+++ b/test/e2e/fixture-builder.js
@@ -357,6 +357,7 @@ function onboardingFixture() {
             rpcUrl: 'http://localhost:8545',
             ticker: 'ETH',
             networkConfigurationId: 'networkConfigurationId',
+            type: 'rpc',
           },
         },
       },
@@ -514,6 +515,9 @@ class FixtureBuilder {
 
   withNetworkController(data) {
     merge(this.fixture.data.NetworkController, data);
+
+    console.log("network controller is: ", this.fixture.data.NetworkController);
+
     return this;
   }
 

--- a/test/e2e/tests/custom-rpc-history.spec.js
+++ b/test/e2e/tests/custom-rpc-history.spec.js
@@ -197,7 +197,7 @@ describe('Stores custom RPC history', function () {
           .withNetworkController({
             networkConfigurations: {
               networkConfigurationId: {
-                rpcUrl: 'http://127.0.0.1:8545/1',
+                rpcUrl: 'http://127.0.0.1:8545/',
                 chainId: '0x539',
                 ticker: 'ETH',
                 nickname: 'http://127.0.0.1:8545/1',
@@ -249,7 +249,7 @@ describe('Stores custom RPC history', function () {
           .withNetworkController({
             networkConfigurations: {
               networkConfigurationId: {
-                rpcUrl: 'http://127.0.0.1:8545/1',
+                rpcUrl: 'http://127.0.0.1:8545/',
                 chainId: '0x539',
                 ticker: 'ETH',
                 nickname: 'http://127.0.0.1:8545/1',

--- a/test/e2e/tests/custom-rpc-history.spec.js
+++ b/test/e2e/tests/custom-rpc-history.spec.js
@@ -190,18 +190,19 @@ describe('Stores custom RPC history', function () {
     );
   });
 
-  it('finds all recent RPCs in history', async function () {
+  it.only('finds all recent RPCs in history', async function () {
     await withFixtures(
       {
         fixtures: new FixtureBuilder()
           .withNetworkController({
             networkConfigurations: {
               networkConfigurationId: {
-                rpcUrl: 'http://127.0.0.1:8545/',
+                rpcUrl: 'http://127.0.0.1:8545/1',
                 chainId: '0x539',
                 ticker: 'ETH',
                 nickname: 'http://127.0.0.1:8545/1',
                 rpcPrefs: {},
+                type: 'rpc',
               },
               networkConfigurationId2: {
                 rpcUrl: 'http://127.0.0.1:8545/2',
@@ -209,6 +210,7 @@ describe('Stores custom RPC history', function () {
                 ticker: 'ETH',
                 nickname: 'http://127.0.0.1:8545/2',
                 rpcPrefs: {},
+                type: 'rpc',
               },
             },
           })
@@ -249,7 +251,7 @@ describe('Stores custom RPC history', function () {
           .withNetworkController({
             networkConfigurations: {
               networkConfigurationId: {
-                rpcUrl: 'http://127.0.0.1:8545/',
+                rpcUrl: 'http://127.0.0.1:8545/1',
                 chainId: '0x539',
                 ticker: 'ETH',
                 nickname: 'http://127.0.0.1:8545/1',

--- a/test/e2e/tests/custom-rpc-history.spec.js
+++ b/test/e2e/tests/custom-rpc-history.spec.js
@@ -190,13 +190,13 @@ describe('Stores custom RPC history', function () {
     );
   });
 
-  it.only('finds all recent RPCs in history', async function () {
+  it('finds all recent RPCs in history', async function () {
     await withFixtures(
       {
         fixtures: new FixtureBuilder()
           .withNetworkController({
             networkConfigurations: {
-              networkConfigurationId: {
+              networkConfigurationIdOne: {
                 rpcUrl: 'http://127.0.0.1:8545/1',
                 chainId: '0x539',
                 ticker: 'ETH',
@@ -204,7 +204,7 @@ describe('Stores custom RPC history', function () {
                 rpcPrefs: {},
                 type: 'rpc',
               },
-              networkConfigurationId2: {
+              networkConfigurationIdTwo: {
                 rpcUrl: 'http://127.0.0.1:8545/2',
                 chainId: '0x539',
                 ticker: 'ETH',
@@ -250,14 +250,14 @@ describe('Stores custom RPC history', function () {
         fixtures: new FixtureBuilder()
           .withNetworkController({
             networkConfigurations: {
-              networkConfigurationId: {
+              networkConfigurationIdOne: {
                 rpcUrl: 'http://127.0.0.1:8545/1',
                 chainId: '0x539',
                 ticker: 'ETH',
                 nickname: 'http://127.0.0.1:8545/1',
                 rpcPrefs: {},
               },
-              networkConfigurationId2: {
+              networkConfigurationIdTwo: {
                 rpcUrl: 'http://127.0.0.1:8545/2',
                 chainId: '0x539',
                 ticker: 'ETH',

--- a/ui/components/app/nft-details/__snapshots__/nft-details.test.js.snap
+++ b/ui/components/app/nft-details/__snapshots__/nft-details.test.js.snap
@@ -66,7 +66,7 @@ exports[`NFT Details should match minimal props and state snapshot 1`] = `
                 class="box mm-text mm-avatar-base mm-avatar-base--size-sm mm-avatar-network nft-item__network-badge mm-text--body-sm mm-text--text-transform-uppercase box--display-flex box--flex-direction-row box--justify-content-center box--align-items-center box--color-text-default box--background-color-background-alternative box--rounded-full box--border-color-background-default box--border-width-2 box--border-style-solid"
                 data-testid="nft-network-badge"
               >
-                G
+                C
               </div>
             </div>
           </div>

--- a/ui/components/app/nft-details/nft-details.test.js
+++ b/ui/components/app/nft-details/nft-details.test.js
@@ -13,6 +13,12 @@ import {
   removeAndIgnoreNft,
   setRemoveNftMessage,
 } from '../../../store/actions';
+import {
+  CHAIN_IDS,
+  CURRENCY_SYMBOLS,
+  MAINNET_DISPLAY_NAME,
+  NETWORK_TYPES,
+} from '../../../../shared/constants/network';
 import NftDetails from './nft-details';
 
 jest.mock('copy-to-clipboard');
@@ -172,7 +178,10 @@ describe('NFT Details', () => {
         metamask: {
           ...mockState.metamask,
           providerConfig: {
-            chainId: '0x1',
+            chainId: CHAIN_IDS.MAINNET,
+            type: NETWORK_TYPES.MAINNET,
+            ticker: CURRENCY_SYMBOLS.ETH,
+            nickname: MAINNET_DISPLAY_NAME,
           },
         },
       };
@@ -203,12 +212,16 @@ describe('NFT Details', () => {
           ...mockState.metamask,
           providerConfig: {
             chainId: '0x89',
+            type: 'rpc',
+            id: 'custom-mainnet',
           },
           networkConfigurations: {
             testNetworkConfigurationId: {
               rpcUrl: 'https://testrpc.com',
               chainId: '0x89',
               nickname: 'Custom Mainnet RPC',
+              type: 'rpc',
+              id: 'custom-mainnet',
             },
           },
         },
@@ -239,7 +252,8 @@ describe('NFT Details', () => {
         metamask: {
           ...mockState.metamask,
           providerConfig: {
-            chainId: '0xaa36a7',
+            chainId: CHAIN_IDS.SEPOLIA,
+            type: NETWORK_TYPES.SEPOLIA,
           },
         },
       };

--- a/ui/components/multichain/app-header/__snapshots__/app-header.test.js.snap
+++ b/ui/components/multichain/app-header/__snapshots__/app-header.test.js.snap
@@ -214,12 +214,12 @@ exports[`App Header should match snapshot 1`] = `
           <div
             class="box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-network mm-picker-network__avatar-network mm-text--body-xs mm-text--text-transform-uppercase box--display-flex box--flex-direction-row box--justify-content-center box--align-items-center box--color-text-default box--background-color-background-alternative box--rounded-full box--border-color-transparent box--border-style-solid box--border-width-1"
           >
-            G
+            C
           </div>
           <p
             class="box mm-text mm-text--body-sm mm-text--ellipsis box--flex-direction-row box--color-text-default"
           >
-            Goerli
+            Chain 5
           </p>
           <span
             class="box mm-picker-network__arrow-down-icon mm-icon mm-icon--size-xs box--display-inline-block box--flex-direction-row box--color-icon-default"

--- a/ui/components/multichain/network-list-menu/network-list-menu.js
+++ b/ui/components/multichain/network-list-menu/network-list-menu.js
@@ -17,6 +17,7 @@ import {
   getCurrentChainId,
   getNonTestNetworks,
   getTestNetworks,
+  getCurrentNetwork,
 } from '../../../selectors';
 import ToggleButton from '../../ui/toggle-button';
 import {
@@ -60,6 +61,9 @@ export const NetworkListMenu = ({ onClose }) => {
 
   const showTestNetworks = useSelector(getShowTestNetworks);
   const currentChainId = useSelector(getCurrentChainId);
+
+  const currentNetwork = useSelector(getCurrentNetwork);
+
   const dispatch = useDispatch();
   const history = useHistory();
   const trackEvent = useContext(MetaMetricsContext);
@@ -76,7 +80,8 @@ export const NetworkListMenu = ({ onClose }) => {
       if (!lineaMainnetReleased && network.providerType === 'linea-mainnet') {
         return null;
       }
-      const isCurrentNetwork = currentChainId === network.chainId;
+      const isCurrentNetwork = currentNetwork.id === network.id;
+
       const canDeleteNetwork =
         !isCurrentNetwork && !UNREMOVABLE_CHAIN_IDS.includes(network.chainId);
 

--- a/ui/components/multichain/network-list-menu/network-list-menu.test.js
+++ b/ui/components/multichain/network-list-menu/network-list-menu.test.js
@@ -22,6 +22,11 @@ const render = (showTestNetworks = false) => {
   const store = configureStore({
     metamask: {
       ...mockState.metamask,
+      providerConfig: {
+        ...mockState.metamask,
+        // Ensure this chainId matches providerConfig
+        chainId: '0x1',
+      },
       preferences: {
         showTestNetworks,
       },

--- a/ui/components/multichain/network-list-menu/network-list-menu.test.js
+++ b/ui/components/multichain/network-list-menu/network-list-menu.test.js
@@ -22,11 +22,6 @@ const render = (showTestNetworks = false) => {
   const store = configureStore({
     metamask: {
       ...mockState.metamask,
-      providerConfig: {
-        ...mockState.metamask,
-        // Ensure this chainId matches providerConfig
-        chainId: '0x1',
-      },
       preferences: {
         showTestNetworks,
       },

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -1171,12 +1171,11 @@ export function getNetworkConfigurations(state) {
 export function getCurrentNetwork(state) {
   const allNetworks = getAllNetworks(state);
   const providerConfig = getProviderConfig(state);
-  const currentChainId = getCurrentChainId(state);
 
   const filter =
     providerConfig.type === 'rpc'
       ? (network) => network.id === providerConfig.id
-      : (network) => network.chainId === currentChainId;
+      : (network) => network.id === providerConfig.type;
 
   return allNetworks.find(filter);
 }

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -1176,11 +1176,6 @@ export function getCurrentNetwork(state) {
     providerConfig.type === 'rpc'
       ? (network) => network.id === providerConfig.id
       : (network) => network.id === providerConfig.type;
-
-  console.log('providerConfig: ', providerConfig);
-  console.log('allNetworks: ', allNetworks);
-  console.log('allNetworks.find(filter): ', allNetworks.find(filter));
-
   return allNetworks.find(filter);
 }
 

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -1177,6 +1177,10 @@ export function getCurrentNetwork(state) {
       ? (network) => network.id === providerConfig.id
       : (network) => network.id === providerConfig.type;
 
+  console.log('providerConfig: ', providerConfig);
+  console.log('allNetworks: ', allNetworks);
+  console.log('allNetworks.find(filter): ', allNetworks.find(filter));
+
   return allNetworks.find(filter);
 }
 

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -1170,9 +1170,15 @@ export function getNetworkConfigurations(state) {
 
 export function getCurrentNetwork(state) {
   const allNetworks = getAllNetworks(state);
+  const providerConfig = getProviderConfig(state);
   const currentChainId = getCurrentChainId(state);
 
-  return allNetworks.find((network) => network.chainId === currentChainId);
+  const filter =
+    providerConfig.type === 'rpc'
+      ? (network) => network.id === providerConfig.id
+      : (network) => network.chainId === currentChainId;
+
+  return allNetworks.find(filter);
 }
 
 export function getAllEnabledNetworks(state) {
@@ -1193,6 +1199,7 @@ export function getTestNetworks(state) {
       rpcUrl: CHAIN_ID_TO_RPC_URL_MAP[CHAIN_IDS.GOERLI],
       providerType: NETWORK_TYPES.GOERLI,
       ticker: TEST_NETWORK_TICKER_MAP[NETWORK_TYPES.GOERLI],
+      id: NETWORK_TYPES.GOERLI,
     },
     {
       chainId: CHAIN_IDS.SEPOLIA,
@@ -1200,6 +1207,7 @@ export function getTestNetworks(state) {
       rpcUrl: CHAIN_ID_TO_RPC_URL_MAP[CHAIN_IDS.SEPOLIA],
       providerType: NETWORK_TYPES.SEPOLIA,
       ticker: TEST_NETWORK_TICKER_MAP[NETWORK_TYPES.SEPOLIA],
+      id: NETWORK_TYPES.SEPOLIA,
     },
     {
       chainId: CHAIN_IDS.LINEA_GOERLI,
@@ -1210,6 +1218,7 @@ export function getTestNetworks(state) {
       },
       providerType: NETWORK_TYPES.LINEA_GOERLI,
       ticker: TEST_NETWORK_TICKER_MAP[NETWORK_TYPES.LINEA_GOERLI],
+      id: NETWORK_TYPES.LINEA_GOERLI,
     },
     // Localhosts
     ...Object.values(networkConfigurations).filter(
@@ -1232,6 +1241,7 @@ export function getNonTestNetworks(state) {
       },
       providerType: NETWORK_TYPES.MAINNET,
       ticker: CURRENCY_SYMBOLS.ETH,
+      id: NETWORK_TYPES.MAINNET,
     },
     {
       chainId: CHAIN_IDS.LINEA_MAINNET,
@@ -1242,6 +1252,7 @@ export function getNonTestNetworks(state) {
       },
       providerType: NETWORK_TYPES.LINEA_MAINNET,
       ticker: TEST_NETWORK_TICKER_MAP[NETWORK_TYPES.LINEA_MAINNET],
+      id: NETWORK_TYPES.LINEA_MAINNET,
     },
     // Custom networks added by the user
     ...Object.values(networkConfigurations).filter(

--- a/ui/selectors/selectors.test.js
+++ b/ui/selectors/selectors.test.js
@@ -316,6 +316,46 @@ describe('Selectors', () => {
     });
   });
 
+  describe('#getCurrentNetwork', () => {
+    it('returns the correct custom network when there is a chainId collision', () => {
+      const modifiedMockState = {
+        ...mockState,
+        metamask: {
+          ...mockState.metamask,
+          providerConfig: {
+            ...mockState.metamask.networkConfigurations
+              .testNetworkConfigurationId,
+            // 0x1 would collide with Ethereum Mainnet
+            chainId: '0x1',
+            // type of "rpc" signals custom network
+            type: 'rpc',
+          },
+        },
+      };
+
+      const currentNetwork = selectors.getCurrentNetwork(modifiedMockState);
+      expect(currentNetwork.nickname).toBe('Custom Mainnet RPC');
+      expect(currentNetwork.chainId).toBe('0x1');
+    });
+
+    it('returns the correct mainnet network when there is a chainId collision', () => {
+      const modifiedMockState = {
+        ...mockState,
+        metamask: {
+          ...mockState.metamask,
+          providerConfig: {
+            ...mockState.metamask.providerConfig,
+            chainId: '0x1',
+            // Changing type to 'mainnet' represents Ethereum Mainnet
+            type: 'mainnet',
+          },
+        },
+      };
+      const currentNetwork = selectors.getCurrentNetwork(modifiedMockState);
+      expect(currentNetwork.nickname).toBe('Ethereum Mainnet');
+    });
+  });
+
   describe('#getAllEnabledNetworks', () => {
     it('returns only Mainnet and Linea with showTestNetworks off', () => {
       const networks = selectors.getAllEnabledNetworks({


### PR DESCRIPTION
## Explanation

* Fixes #19941

This bug was occurring because we were selecting the first network with a given chain ID.  That means if there's a custom network with a chain ID that matches a pre-installed network (i.e. Mainnet having `0x1` and a localhost `0x1` chain, like the issue cites), we show the wrong network selected in the Network Picker *despite* switching to the correct network.  This is a labeling issue, not a functionality issue.

To fix this issue, I fork the logic for retrieving the current network by checking to see if it's a custom network (by checking for `type=rpc` and searching for the network by configuration ID.  If a pre-installed network, we use the chainId.


## Screenshots/Screencaps


https://github.com/MetaMask/metamask-extension/assets/46655/0a9883a9-ee38-4cfe-a3c3-4f0a6e6b3541



## Manual Testing Steps

1.  Add a bunch of predefined networks like Avalanche, Polygon, etc.
2. Start ganache with `ganache --chain.chainId 1` 
3. Add localhost with a chainID of 1
4. Switch between all of the networks you've added and see that networks switch properly, the network picker shows the correct label, and the correct item in the network list shows as selected.

## Pre-merge author checklist

- [ ] I've clearly explained:
  - [ ] What problem this PR is solving
  - [ ] How this problem was solved
  - [ ] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
