### PR TITLE
Fix #19548 - Increase address copy to clipboard time

### DIFF
--- a/ui/components/multichain/address-copy-button/address-copy-button.js
+++ b/ui/components/multichain/address-copy-button/address-copy-button.js
@@ -14,15 +14,17 @@ import { useCopyToClipboard } from '../../../hooks/useCopyToClipboard';
 import { shortenAddress } from '../../../helpers/utils/util';
 import Tooltip from '../../ui/tooltip/tooltip';
 import { useI18nContext } from '../../../hooks/useI18nContext';
+import { SECOND } from '../../../../shared/constants/time';
 
 export const AddressCopyButton = ({
   address,
   shorten = false,
   wrap = false,
   onClick,
+  delay = SECOND * 60,
 }) => {
   const displayAddress = shorten ? shortenAddress(address) : address;
-  const [copied, handleCopy] = useCopyToClipboard();
+  const [copied, handleCopy] = useCopyToClipboard(delay);
   const t = useI18nContext();
 
   return (
@@ -69,4 +71,8 @@ AddressCopyButton.propTypes = {
    * Fires when the button is clicked
    */
   onClick: PropTypes.func,
+  /**
+   * Amount of time before the clipboard should be cleared
+   */
+  delay: PropTypes.number,
 };

--- a/ui/components/multichain/address-copy-button/address-copy-button.js
+++ b/ui/components/multichain/address-copy-button/address-copy-button.js
@@ -21,10 +21,9 @@ export const AddressCopyButton = ({
   shorten = false,
   wrap = false,
   onClick,
-  delay = MINUTE,
 }) => {
   const displayAddress = shorten ? shortenAddress(address) : address;
-  const [copied, handleCopy] = useCopyToClipboard(delay);
+  const [copied, handleCopy] = useCopyToClipboard(MINUTE);
   const t = useI18nContext();
 
   return (
@@ -71,8 +70,4 @@ AddressCopyButton.propTypes = {
    * Fires when the button is clicked
    */
   onClick: PropTypes.func,
-  /**
-   * Amount of time before the clipboard should be cleared
-   */
-  delay: PropTypes.number,
 };

--- a/ui/components/multichain/address-copy-button/address-copy-button.js
+++ b/ui/components/multichain/address-copy-button/address-copy-button.js
@@ -14,14 +14,14 @@ import { useCopyToClipboard } from '../../../hooks/useCopyToClipboard';
 import { shortenAddress } from '../../../helpers/utils/util';
 import Tooltip from '../../ui/tooltip/tooltip';
 import { useI18nContext } from '../../../hooks/useI18nContext';
-import { SECOND } from '../../../../shared/constants/time';
+import { MINUTE } from '../../../../shared/constants/time';
 
 export const AddressCopyButton = ({
   address,
   shorten = false,
   wrap = false,
   onClick,
-  delay = SECOND * 60,
+  delay = MINUTE,
 }) => {
   const displayAddress = shorten ? shortenAddress(address) : address;
   const [copied, handleCopy] = useCopyToClipboard(delay);


### PR DESCRIPTION
## Explanation

* Fixes #19548

Increases the time before clipboard gets cleared after copying a wallet address.

## Manual Testing Steps

1.  From the home screen, click the address button
2. Command-V several times to a new document until the clipboard eventually gets cleared

## Pre-merge author checklist

- [ ] I've clearly explained:
  - [ ] What problem this PR is solving
  - [ ] How this problem was solved
  - [ ] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
