### PR TITLE
UX: Network Menu: Disable testnet toggle when on testnet

### DIFF
--- a/ui/components/multichain/network-list-menu/network-list-menu.js
+++ b/ui/components/multichain/network-list-menu/network-list-menu.js
@@ -17,7 +17,6 @@ import {
   getCurrentChainId,
   getNonTestNetworks,
   getTestNetworks,
-  getCurrentNetwork,
 } from '../../../selectors';
 import ToggleButton from '../../ui/toggle-button';
 import {
@@ -58,15 +57,14 @@ export const NetworkListMenu = ({ onClose }) => {
 
   const nonTestNetworks = useSelector(getNonTestNetworks);
   const testNetworks = useSelector(getTestNetworks);
-
   const showTestNetworks = useSelector(getShowTestNetworks);
   const currentChainId = useSelector(getCurrentChainId);
-
-  const currentNetwork = useSelector(getCurrentNetwork);
 
   const dispatch = useDispatch();
   const history = useHistory();
   const trackEvent = useContext(MetaMetricsContext);
+
+  const currentlyOnTestNetwork = TEST_CHAINS.includes(currentChainId);
 
   const environmentType = getEnvironmentType();
   const isFullScreen = environmentType === ENVIRONMENT_TYPE_FULLSCREEN;
@@ -80,8 +78,8 @@ export const NetworkListMenu = ({ onClose }) => {
       if (!lineaMainnetReleased && network.providerType === 'linea-mainnet') {
         return null;
       }
-      const isCurrentNetwork = currentNetwork.id === network.id;
 
+      const isCurrentNetwork = currentChainId === network.chainId;
       const canDeleteNetwork =
         !isCurrentNetwork && !UNREMOVABLE_CHAIN_IDS.includes(network.chainId);
 
@@ -155,6 +153,7 @@ export const NetworkListMenu = ({ onClose }) => {
             <Text>{t('showTestnetNetworks')}</Text>
             <ToggleButton
               value={showTestNetworks}
+              disabled={currentlyOnTestNetwork}
               onToggle={(value) => {
                 const shouldShowTestNetworks = !value;
                 dispatch(setShowTestNetworks(shouldShowTestNetworks));
@@ -167,7 +166,7 @@ export const NetworkListMenu = ({ onClose }) => {
               }}
             />
           </Box>
-          {showTestNetworks ? (
+          {showTestNetworks || currentlyOnTestNetwork ? (
             <Box className="multichain-network-list-menu">
               {generateMenuItems(testNetworks)}
             </Box>

--- a/ui/components/multichain/network-list-menu/network-list-menu.test.js
+++ b/ui/components/multichain/network-list-menu/network-list-menu.test.js
@@ -4,6 +4,7 @@ import { fireEvent, renderWithProvider } from '../../../../test/jest';
 import configureStore from '../../../store/store';
 import mockState from '../../../../test/data/mock-state.json';
 import {
+  CHAIN_IDS,
   MAINNET_DISPLAY_NAME,
   SEPOLIA_DISPLAY_NAME,
 } from '../../../../shared/constants/network';
@@ -18,10 +19,14 @@ jest.mock('../../../store/actions.ts', () => ({
   toggleNetworkMenu: () => mockToggleNetworkMenu,
 }));
 
-const render = (showTestNetworks = false) => {
+const render = (showTestNetworks = false, currentChainId = '0x1') => {
   const store = configureStore({
     metamask: {
       ...mockState.metamask,
+      providerConfig: {
+        ...mockState.metamask.providerConfig,
+        chainId: currentChainId,
+      },
       preferences: {
         showTestNetworks,
       },
@@ -53,6 +58,11 @@ describe('NetworkListMenu', () => {
     const [testNetworkToggle] = queryAllByRole('checkbox');
     fireEvent.click(testNetworkToggle);
     expect(mockSetShowTestNetworks).toHaveBeenCalled();
+  });
+
+  it('disables toggle when on test network', () => {
+    const { container } = render(false, CHAIN_IDS.GOERLI);
+    expect(container.querySelector('.toggle-button--disabled')).toBeDefined();
   });
 
   it('switches networks when an item is clicked', () => {


### PR DESCRIPTION
## Explanation

At present the "Disable / Enable" Test Networks toggle is _always_ enabled.  If a user is currently on a test network, however, it's best to leave that toggle on so that the user doesn't find themselves in a spot where the current network is hidden via the toggle

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/659

## Screenshots/Screencaps

<img width="624" alt="SCR-20230710-rwjv" src="https://github.com/MetaMask/metamask-extension/assets/46655/e366d198-fad7-4c8e-884c-bfd9e8dbb44d">

## Manual Testing Steps

1.  Open the Network Picker
2. Choose the Goerli network, watch network switch
3. Open the Network Picker again
4. See that the toggle is disabled

## Pre-merge author checklist

- [ ] I've clearly explained:
  - [ ] What problem this PR is solving
  - [ ] How this problem was solved
  - [ ] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
