### PR TITLE
Fix #19393 - Add indicator for Refresh list on tokens screen

### DIFF
--- a/ui/components/multichain/import-token-link/import-token-link.js
+++ b/ui/components/multichain/import-token-link/import-token-link.js
@@ -1,5 +1,5 @@
 import React, { useContext } from 'react';
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { useHistory } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
@@ -26,6 +26,7 @@ export const ImportTokenLink = ({ className, ...props }) => {
   const trackEvent = useContext(MetaMetricsContext);
   const t = useI18nContext();
   const history = useHistory();
+  const dispatch = useDispatch();
 
   const isTokenDetectionSupported = useSelector(getIsTokenDetectionSupported);
   const isTokenDetectionInactiveOnMainnet = useSelector(
@@ -68,7 +69,7 @@ export const ImportTokenLink = ({ className, ...props }) => {
           size={Size.MD}
           startIconName={IconName.Refresh}
           data-testid="refresh-list-button"
-          onClick={() => detectNewTokens()}
+          onClick={() => dispatch(detectNewTokens())}
         >
           {t('refreshList')}
         </ButtonLink>

--- a/ui/components/multichain/import-token-link/import-token-link.test.js
+++ b/ui/components/multichain/import-token-link/import-token-link.test.js
@@ -19,7 +19,7 @@ jest.mock('react-router-dom', () => {
 });
 
 jest.mock('../../../store/actions.ts', () => ({
-  detectNewTokens: jest.fn(),
+  detectNewTokens: jest.fn().mockReturnValue({ type: '' }),
 }));
 
 describe('Import Token Link', () => {

--- a/ui/store/actions.ts
+++ b/ui/store/actions.ts
@@ -2990,6 +2990,22 @@ export function setOpenSeaEnabled(
   };
 }
 
+// DetectTokenController
+export function detectNewTokens(): ThunkAction<
+  void,
+  MetaMaskReduxState,
+  unknown,
+  AnyAction
+> {
+  return async (dispatch: MetaMaskReduxDispatch) => {
+    dispatch(showLoadingIndication());
+    log.debug(`background.detectNewTokens`);
+    await submitRequestToBackground('detectNewTokens');
+    dispatch(hideLoadingIndication());
+    await forceUpdateMetamaskState(dispatch);
+  };
+}
+
 export function detectNfts(): ThunkAction<
   void,
   MetaMaskReduxState,
@@ -4285,11 +4301,6 @@ export function dismissSmartTransactionsErrorMessage(): Action {
   return {
     type: actionConstants.DISMISS_SMART_TRANSACTIONS_ERROR_MESSAGE,
   };
-}
-
-// DetectTokenController
-export async function detectNewTokens() {
-  return submitRequestToBackground('detectNewTokens');
 }
 
 // App state


### PR DESCRIPTION
## Explanation

* Fixes #19393

Clicking "Refresh list" in the token listing provide no feedback to the user that something is happening.  This PR shows our current loading indicator to signal to the user that an action is taking place.

## Manual Testing Steps

1.  Click "Refresh list"
2. See indicator display momentarily
3. See indicator disappear when complete

## Pre-merge author checklist

- [ ] I've clearly explained:
  - [ ] What problem this PR is solving
  - [ ] How this problem was solved
  - [ ] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
