### PR TITLE
Reset price ack if price diff in % changed, insufficient gas event, log a page load event once

### DIFF
--- a/shared/constants/metametrics.ts
+++ b/shared/constants/metametrics.ts
@@ -624,6 +624,7 @@ export enum MetaMetricsEventName {
   SwapCompleted = 'Swap Completed',
   TransactionFinalized = 'Transaction Finalized',
   ExitedSwaps = 'Exited Swaps',
+  UiWarnings = 'UI Warnings',
 }
 
 export enum MetaMetricsEventAccountType {

--- a/shared/constants/metametrics.ts
+++ b/shared/constants/metametrics.ts
@@ -624,7 +624,7 @@ export enum MetaMetricsEventName {
   SwapCompleted = 'Swap Completed',
   TransactionFinalized = 'Transaction Finalized',
   ExitedSwaps = 'Exited Swaps',
-  UiWarnings = 'UI Warnings',
+  SwapError = 'Swap Error',
 }
 
 export enum MetaMetricsEventAccountType {
@@ -680,6 +680,10 @@ export enum MetaMetricsEventLinkType {
 export enum MetaMetricsEventKeyType {
   Pkey = 'private_key',
   Srp = 'srp',
+}
+
+export enum MetaMetricsEventErrorType {
+  InsufficientGas = 'insufficient_gas',
 }
 
 export enum MetaMetricsNetworkEventSource {

--- a/ui/pages/swaps/prepare-swap-page/prepare-swap-page.js
+++ b/ui/pages/swaps/prepare-swap-page/prepare-swap-page.js
@@ -54,6 +54,7 @@ import {
   getAggregatorMetadata,
   getTransactionSettingsOpened,
   setTransactionSettingsOpened,
+  getSmartTransactionsError,
 } from '../../../ducks/swaps/swaps';
 import {
   getSwapsDefaultToken,
@@ -99,6 +100,7 @@ import {
   setSwapsErrorKey,
   setBackgroundSwapRouteState,
 } from '../../../store/actions';
+import { SET_SMART_TRANSACTIONS_ERROR } from '../../../store/actionConstants';
 import {
   countDecimals,
   fetchTokenPrice,
@@ -630,6 +632,10 @@ export default function PrepareSwapPage({
       if (!isReviewSwapButtonDisabled) {
         if (isSmartTransaction) {
           clearSmartTransactionFees(); // Clean up STX fees eery time there is a form change.
+          dispatch({
+            type: SET_SMART_TRANSACTIONS_ERROR,
+            payload: null,
+          });
         }
         // Only do quotes prefetching if the Review swap button is enabled.
         prefetchQuotesWithoutRedirecting();

--- a/ui/pages/swaps/prepare-swap-page/prepare-swap-page.js
+++ b/ui/pages/swaps/prepare-swap-page/prepare-swap-page.js
@@ -54,7 +54,6 @@ import {
   getAggregatorMetadata,
   getTransactionSettingsOpened,
   setTransactionSettingsOpened,
-  getSmartTransactionsError,
 } from '../../../ducks/swaps/swaps';
 import {
   getSwapsDefaultToken,
@@ -558,7 +557,7 @@ export default function PrepareSwapPage({
     dispatch(resetSwapsPostFetchState());
     dispatch(setReviewSwapClickedTimestamp());
     trackPrepareSwapPageLoadedEvent();
-  }, [dispatch, trackPrepareSwapPageLoadedEvent]);
+  }, [dispatch]);
 
   const BlockExplorerLink = () => {
     return (

--- a/ui/pages/swaps/prepare-swap-page/review-quote.js
+++ b/ui/pages/swaps/prepare-swap-page/review-quote.js
@@ -509,36 +509,6 @@ export default function ReviewQuote({ setReceiveToAmount }) {
     );
   }
 
-  useEffect(() => {
-    if (quotesLastFetched === prevQuotesLastFetched) {
-      return;
-    }
-    let balanceNeeded;
-    if (isSmartTransaction && ethBalanceNeededStx) {
-      balanceNeeded = ethBalanceNeededStx;
-    } else if (!isSmartTransaction && ethBalanceNeeded) {
-      balanceNeeded = ethBalanceNeeded;
-    } else {
-      return; // A user has enough balance for a gas fee, so we don't need to track it.
-    }
-    trackEvent({
-      event: MetaMetricsEventName.UiWarnings,
-      category: MetaMetricsEventCategory.Swaps,
-      sensitiveProperties: {
-        stx_enabled: smartTransactionsEnabled,
-        current_stx_enabled: currentSmartTransactionsEnabled,
-        stx_user_opt_in: smartTransactionsOptInStatus,
-        balance_needed: balanceNeeded,
-      },
-    });
-  }, [
-    quotesLastFetched,
-    prevQuotesLastFetched,
-    ethBalanceNeededStx,
-    isSmartTransaction,
-    trackEvent,
-  ]);
-
   const destinationToken = useSelector(getDestinationTokenInfo, isEqual);
   useEffect(() => {
     if (isSmartTransaction) {
@@ -729,6 +699,34 @@ export default function ReviewQuote({ setReceiveToAmount }) {
     sourceTokenSymbol,
     sourceTokenValue,
     trackBestQuoteReviewedEvent,
+  ]);
+
+  useEffect(() => {
+    if (quotesLastFetched === prevQuotesLastFetched) {
+      return;
+    }
+    let balanceNeeded;
+    if (isSmartTransaction && ethBalanceNeededStx) {
+      balanceNeeded = ethBalanceNeededStx;
+    } else if (!isSmartTransaction && ethBalanceNeeded) {
+      balanceNeeded = ethBalanceNeeded;
+    } else {
+      return; // A user has enough balance for a gas fee, so we don't need to track it.
+    }
+    trackEvent({
+      event: MetaMetricsEventName.UiWarnings,
+      category: MetaMetricsEventCategory.Swaps,
+      sensitiveProperties: {
+        ...eventObjectBase,
+        balance_needed: balanceNeeded,
+      },
+    });
+  }, [
+    quotesLastFetched,
+    prevQuotesLastFetched,
+    ethBalanceNeededStx,
+    isSmartTransaction,
+    trackEvent,
   ]);
 
   const metaMaskFee = usedQuote.fee;

--- a/ui/pages/swaps/prepare-swap-page/review-quote.js
+++ b/ui/pages/swaps/prepare-swap-page/review-quote.js
@@ -876,6 +876,17 @@ export default function ReviewQuote({ setReceiveToAmount }) {
   );
 
   useEffect(() => {
+    if (
+      shouldShowPriceDifferenceWarning &&
+      acknowledgedPriceDifference &&
+      quotesLastFetched !== prevQuotesLastFetched
+    ) {
+      // Reset price difference acknowledgement if price diff % changed.
+      setAcknowledgedPriceDifference(false);
+    }
+  }, [priceDifferencePercentage]);
+
+  useEffect(() => {
     if (isSmartTransaction && !insufficientTokens) {
       const unsignedTx = {
         from: unsignedTransaction.from,

--- a/ui/pages/swaps/prepare-swap-page/review-quote.js
+++ b/ui/pages/swaps/prepare-swap-page/review-quote.js
@@ -523,8 +523,13 @@ export default function ReviewQuote({ setReceiveToAmount }) {
     } else if (balanceError && !insufficientTokens && !insufficientEth) {
       dispatch(setBalanceError(false));
     }
-    // eslint-disable-next-line
-  }, [insufficientTokens, insufficientEth, dispatch, isSmartTransaction]);
+  }, [
+    insufficientTokens,
+    insufficientEth,
+    dispatch,
+    isSmartTransaction,
+    balanceError,
+  ]);
 
   useEffect(() => {
     const currentTime = Date.now();
@@ -733,6 +738,9 @@ export default function ReviewQuote({ setReceiveToAmount }) {
     ethBalanceNeededStx,
     isSmartTransaction,
     trackEvent,
+    prevEthBalanceNeededStx,
+    ethBalanceNeeded,
+    eventObjectBase,
   ]);
 
   const metaMaskFee = usedQuote.fee;
@@ -831,6 +839,7 @@ export default function ReviewQuote({ setReceiveToAmount }) {
       10,
     );
   }
+  const prevPriceDifferencePercentage = usePrevious(priceDifferencePercentage);
 
   const shouldShowPriceDifferenceWarning =
     !tokenBalanceUnavailable &&
@@ -883,12 +892,20 @@ export default function ReviewQuote({ setReceiveToAmount }) {
     if (
       shouldShowPriceDifferenceWarning &&
       acknowledgedPriceDifference &&
-      quotesLastFetched !== prevQuotesLastFetched
+      quotesLastFetched !== prevQuotesLastFetched &&
+      priceDifferencePercentage !== prevPriceDifferencePercentage
     ) {
       // Reset price difference acknowledgement if price diff % changed.
       setAcknowledgedPriceDifference(false);
     }
-  }, [priceDifferencePercentage]);
+  }, [
+    acknowledgedPriceDifference,
+    prevQuotesLastFetched,
+    quotesLastFetched,
+    shouldShowPriceDifferenceWarning,
+    priceDifferencePercentage,
+    prevPriceDifferencePercentage,
+  ]);
 
   useEffect(() => {
     if (isSmartTransaction && !insufficientTokens) {


### PR DESCRIPTION
## Explanation
This PR has the following things:
- Reset price acknowledgement if price diff in % changed
- Insufficient gas event (it will help us to understand how often users don't have enough for gas on different networks and if they continue with swapping afterwards)
- Log a page load event only once

### Testing
**Reset price ack if price diff in % changed**
- Select tokens for a swap that will trigger the price acknowledgement notification
- Confirm it
- When the price diff in % changes, you have to confirm it again

**Insufficient gas event**
- Select token from (ETH) and token to in Swaps
- If you have for example a 0.1 ETH balance, choose 0.099 ETH in the amount field
- You will see a blue notification about insufficient gas
- In the background dev tools in the Network tab you can see a new "Swap Error" event

**Log a page load event only once**
- Go to Swaps and see the "Prepare Swap Page Loaded" event in the background dev tools in the Network tab
- Click on the gear icon for Transaction Settings and opt-in / opt-out from Smart Swap, click on the Update button
- Verify that there is not another "Prepare Swap Page Loaded" event after clicking on the Update button