### PR TITLE
UX Multichain: Replace badge icon with current network image

### DIFF
--- a/ui/components/app/token-cell/__snapshots__/token-cell.test.js.snap
+++ b/ui/components/app/token-cell/__snapshots__/token-cell.test.js.snap
@@ -26,7 +26,7 @@ exports[`Token Cell should match snapshot 1`] = `
             class="box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-network mm-text--body-xs mm-text--text-transform-uppercase box--display-flex box--flex-direction-row box--justify-content-center box--align-items-center box--color-text-default box--background-color-background-alternative box--rounded-full box--border-color-border-muted box--border-style-solid box--border-width-1"
           >
             <img
-              alt="TEST logo"
+              alt="Ethereum Mainnet logo"
               class="mm-avatar-network__network-image"
               src="./images/eth_logo.png"
             />

--- a/ui/components/multichain/token-list-item/__snapshots__/token-list-item.test.js.snap
+++ b/ui/components/multichain/token-list-item/__snapshots__/token-list-item.test.js.snap
@@ -26,7 +26,7 @@ exports[`TokenListItem should render correctly 1`] = `
             class="box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-network mm-text--body-xs mm-text--text-transform-uppercase box--display-flex box--flex-direction-row box--justify-content-center box--align-items-center box--color-text-default box--background-color-background-alternative box--rounded-full box--border-color-border-muted box--border-style-solid box--border-width-1"
           >
             <img
-              alt="undefined logo"
+              alt="Ethereum Mainnet logo"
               class="mm-avatar-network__network-image"
               src="./images/eth_logo.png"
             />

--- a/ui/components/multichain/token-list-item/token-list-item.js
+++ b/ui/components/multichain/token-list-item/token-list-item.js
@@ -21,7 +21,11 @@ import {
   Text,
   Box,
 } from '../../component-library';
-import { getCurrentChainId, getNativeCurrencyImage } from '../../../selectors';
+import {
+  getCurrentChainId,
+  getCurrentNetwork,
+  getNativeCurrencyImage,
+} from '../../../selectors';
 import Tooltip from '../../ui/tooltip';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import { MetaMetricsContext } from '../../../contexts/metametrics';
@@ -29,7 +33,6 @@ import {
   MetaMetricsEventCategory,
   MetaMetricsEventName,
 } from '../../../../shared/constants/metametrics';
-import { LINEA_GOERLI_TOKEN_IMAGE_URL } from '../../../../shared/constants/network';
 
 export const TokenListItem = ({
   className,
@@ -45,11 +48,9 @@ export const TokenListItem = ({
   const dataTheme = document.documentElement.getAttribute('data-theme');
   const trackEvent = useContext(MetaMetricsContext);
   const chainId = useSelector(getCurrentChainId);
-  const badgeWrapperImage =
-    title === 'LineaETH' ? LINEA_GOERLI_TOKEN_IMAGE_URL : primaryTokenImage;
-  const badgeTokenImage =
-    title === 'LineaETH' ? LINEA_GOERLI_TOKEN_IMAGE_URL : tokenImage;
 
+  // Used for badge icon
+  const currentNetwork = useSelector(getCurrentNetwork);
   return (
     <Box
       className={classnames('multichain-token-list-item', className)}
@@ -84,10 +85,10 @@ export const TokenListItem = ({
           badge={
             <AvatarNetwork
               size={Size.XS}
-              name={tokenSymbol}
-              src={badgeWrapperImage}
+              name={currentNetwork?.nickname}
+              src={currentNetwork?.rpcPrefs?.imageUrl}
               borderColor={
-                badgeWrapperImage
+                primaryTokenImage
                   ? BorderColor.borderMuted
                   : BorderColor.borderDefault
               }
@@ -97,12 +98,10 @@ export const TokenListItem = ({
         >
           <AvatarToken
             name={tokenSymbol}
-            src={badgeTokenImage}
+            src={tokenImage}
             showHalo
             borderColor={
-              badgeTokenImage
-                ? BorderColor.transparent
-                : BorderColor.borderDefault
+              tokenImage ? BorderColor.transparent : BorderColor.borderDefault
             }
           />
         </BadgeWrapper>

--- a/ui/components/multichain/token-list-item/token-list-item.stories.js
+++ b/ui/components/multichain/token-list-item/token-list-item.stories.js
@@ -38,7 +38,12 @@ export default {
 
 const customNetworkData = {
   ...testData,
-  metamask: { ...testData.metamask, nativeCurrency: '' },
+  metamask: {
+    ...testData.metamask,
+    providerConfig: {
+      chainId: '0x1',
+    },
+  },
 };
 const customNetworkStore = configureStore(customNetworkData);
 
@@ -47,6 +52,13 @@ const Template = (args) => {
 };
 
 export const DefaultStory = Template.bind({});
+DefaultStory.decorators = [
+  (Story) => (
+    <Provider store={customNetworkStore}>
+      <Story />
+    </Provider>
+  ),
+];
 
 export const ChaosStory = (args) => (
   <div
@@ -55,7 +67,13 @@ export const ChaosStory = (args) => (
     <TokenListItem {...args} />
   </div>
 );
-ChaosStory.storyName = 'ChaosStory';
+ChaosStory.decorators = [
+  (Story) => (
+    <Provider store={customNetworkStore}>
+      <Story />
+    </Provider>
+  ),
+];
 
 ChaosStory.args = {
   title: 'Really long, long name',
@@ -64,14 +82,6 @@ ChaosStory.args = {
 };
 
 export const NoImagesStory = Template.bind({});
-
-NoImagesStory.decorators = [
-  (Story) => (
-    <Provider store={customNetworkStore}>
-      <Story />
-    </Provider>
-  ),
-];
 
 NoImagesStory.args = {
   tokenImage: '',


### PR DESCRIPTION
This PR is to update the avatar badge in the token list to use the current network logo

Fixes #19965 

## Screenshots/Screencaps

### Before

![Screenshot 2023-07-11 at 11 45 51 PM](https://github.com/MetaMask/metamask-extension/assets/39872794/55bfa26e-2b75-4d5c-b906-dc8e39ba5a12)

### After

![Screenshot 2023-07-11 at 11 44 48 PM](https://github.com/MetaMask/metamask-extension/assets/39872794/29da5776-2a85-40f7-b2b3-b41bd7a3707c)

## Manual Testing Steps

- Go to Assets Tab
- Check the badge on tokens is same as the current network image

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
