### PR TITLE
Fix intermittent build error

### DIFF
--- a/.yarn/patches/lavamoat-core-npm-14.2.0-c453f4f755.patch
+++ b/.yarn/patches/lavamoat-core-npm-14.2.0-c453f4f755.patch
@@ -1,0 +1,18 @@
+diff --git a/src/loadPolicy.js b/src/loadPolicy.js
+index ef71923f9282d6a5e9f74e6ec6fa0516f28f508b..0118fda7e1b0fa461ec01ceff8d7112d072f3dfb 100644
+--- a/src/loadPolicy.js
++++ b/src/loadPolicy.js
+@@ -33,10 +33,9 @@ async function loadPolicyAndApplyOverrides({ debugMode, policyPath, policyOverri
+     }
+     const policyOverride = await readPolicyFile({ debugMode, policyPath: policyOverridePath })
+     lavamoatPolicy = mergePolicy(policy, policyOverride)
+-    // TODO: Only write if merge results in changes.
+-    // Would have to make a deep equal check on whole policy, which is a waste of time.
+-    // mergePolicy() should be able to do it in one pass.
+-    fs.writeFileSync(policyPath, jsonStringify(lavamoatPolicy, { space: 2 }))
++    // Skip policy write step to prevent intermittent build failures
++    // The extension validates the policy in a separate step, we don't need it
++    // to be written to disk here.
+   }
+   return lavamoatPolicy
+ }

--- a/lavamoat/build-system/policy.json
+++ b/lavamoat/build-system/policy.json
@@ -6283,7 +6283,6 @@
         "events": true,
         "fs.existsSync": true,
         "fs.readFileSync": true,
-        "fs.writeFileSync": true,
         "path.extname": true,
         "path.join": true
       },

--- a/package.json
+++ b/package.json
@@ -196,7 +196,8 @@
     "request@^2.83.0": "patch:request@npm%3A2.88.2#./.yarn/patches/request-npm-2.88.2-f4a57c72c4.patch",
     "request@^2.88.2": "patch:request@npm%3A2.88.2#./.yarn/patches/request-npm-2.88.2-f4a57c72c4.patch",
     "request@^2.85.0": "patch:request@npm%3A2.88.2#./.yarn/patches/request-npm-2.88.2-f4a57c72c4.patch",
-    "@metamask/signature-controller@^4.0.1": "patch:@metamask/signature-controller@npm%3A4.0.1#./.yarn/patches/@metamask-signature-controller-npm-4.0.1-013e64c9fd.patch"
+    "@metamask/signature-controller@^4.0.1": "patch:@metamask/signature-controller@npm%3A4.0.1#./.yarn/patches/@metamask-signature-controller-npm-4.0.1-013e64c9fd.patch",
+    "lavamoat-core@^14.2.0": "patch:lavamoat-core@npm%3A14.2.0#./.yarn/patches/lavamoat-core-npm-14.2.0-c453f4f755.patch"
   },
   "dependencies": {
     "@babel/runtime": "^7.18.9",

--- a/yarn.lock
+++ b/yarn.lock
@@ -23184,6 +23184,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lavamoat-core@npm:14.2.0":
+  version: 14.2.0
+  resolution: "lavamoat-core@npm:14.2.0"
+  dependencies:
+    json-stable-stringify: ^1.0.2
+    lavamoat-tofu: ^6.0.2
+    merge-deep: ^3.0.3
+  checksum: 2f254c85a466561393a9ad0b8bcd8ff93b7b195d2f820f89be452348559f3fa689260887dcf4af3d605bc7ddb8fef2637ca7d5bfe1b7f565050aca172b9733d6
+  languageName: node
+  linkType: hard
+
 "lavamoat-core@npm:^10.0.1":
   version: 10.1.2
   resolution: "lavamoat-core@npm:10.1.2"
@@ -23197,14 +23208,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lavamoat-core@npm:^14.2.0":
+"lavamoat-core@patch:lavamoat-core@npm%3A14.2.0#./.yarn/patches/lavamoat-core-npm-14.2.0-c453f4f755.patch::locator=metamask-crx%40workspace%3A.":
   version: 14.2.0
-  resolution: "lavamoat-core@npm:14.2.0"
+  resolution: "lavamoat-core@patch:lavamoat-core@npm%3A14.2.0#./.yarn/patches/lavamoat-core-npm-14.2.0-c453f4f755.patch::version=14.2.0&hash=70a573&locator=metamask-crx%40workspace%3A."
   dependencies:
     json-stable-stringify: ^1.0.2
     lavamoat-tofu: ^6.0.2
     merge-deep: ^3.0.3
-  checksum: 2f254c85a466561393a9ad0b8bcd8ff93b7b195d2f820f89be452348559f3fa689260887dcf4af3d605bc7ddb8fef2637ca7d5bfe1b7f565050aca172b9733d6
+  checksum: 964ecb811357e2c77ed9e41c02f69d1925a7b20b917fd44f800186a274c70a25fa056d62056509014233a0b2b4dab78b271458947560dbe64d44c963e0ccdf65
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Explanation

Occasionally our builds have been failing with the error "Unexpected end of JSON input", with a stack pointing at `lavamoat-core`. The file in question was reading the policy, reading overrides, merging them, then writing the policy back to disk.

The intermittent errors can be explained if the policy file was read in one process while it was being written in another. The extension build script builds bundles in multiple processes in parallel, so it does follow that this would happen some of the time. This could result in a partial policy file being read by the build script, resulting in a JSON parsing error.

This has been fixed by removing the policy write step using a patch. We don't need this step. We update the policy using a different function altogether, and we have a CI job to ensure we never forget to update it.

## Manual Testing Steps

All build commands using LavaMoat (e.g. `yarn build:test` and `yarn dist`) should fail less often. The only functional difference should be that running the build will not update the policy after overrides have been changed. However, the policy update commands that we usually use (`yarn lavamoat:auto` and related scripts) will still update the policy correctly even after overrides have been changed.

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
