### PR TITLE
Fix MMI policy generation

### DIFF
--- a/builds.yml
+++ b/builds.yml
@@ -89,7 +89,7 @@ buildTypes:
       - SEGMENT_WRITE_KEY_REF: SEGMENT_MMI_WRITE_KEY
       - SUPPORT_LINK: https://mmi-support.zendesk.com/hc/en-us
       - SUPPORT_REQUEST_LINK: https://mmi-support.zendesk.com/hc/en-us/requests/new
-      - MMI_CONFIGURATION_SERVICE_URL
+      - MMI_CONFIGURATION_SERVICE_URL: ''
     # For some reason, MMI uses this type of versioning
     # Leaving it on for backwards compatibility
     isPrerelease: true


### PR DESCRIPTION
## Explanation

The command `yarn lavamoat:auto` will fail unless the environment variable `CONFIGURATION_SERVICE_URL` is set locally. Most contributors will have no reason to set this to anything.

This has been fixed by assigning this variable a default value of an empty string, as the error suggests doing.

## Manual Testing Steps

* Run `yarn lavamoat:webapp:auto --build-types=mmi` without the `CONFIGURATION_SERVICE_URL` environment variable set
* See that it passes
  * On `develop` right now, it will fail with the error `TypeError: Tried to access a declared, but not defined environmental variable "MMI_CONFIGURATION_SERVICE_URL"`

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
