### PR TITLE
Replace deprecated install command

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -363,8 +363,7 @@ jobs:
             fi
       - run:
           name: Install deps
-          command: |
-            .circleci/scripts/deps-install.sh
+          command: yarn --immutable
       - save_cache:
           key: dependency-cache-v1-{{ checksum "yarn.lock" }}
           paths:

--- a/.circleci/scripts/deps-install.sh
+++ b/.circleci/scripts/deps-install.sh
@@ -1,9 +1,0 @@
-#!/usr/bin/env bash
-
-# Print commands and their arguments as they are executed.
-set -x
-# Exit immediately if a command exits with a non-zero status.
-set -e
-
-yarn install --frozen-lockfile
-


### PR DESCRIPTION
## Explanation

The `--frozen-lockfile` flag is not supported by Yarn v3. It has been replaced by the Yarn v3 equivalent, which is `--immutable`.

Additionally, the `deps-install` script was deleted and this command was inlined in the CircleCI configuration. I don't think we need to maintain a separate script just for one command.

## Manual Testing Steps

Check that the `prep-deps` CircleCI job completes without a warning regarding `--frozen-lockfile`

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
