### PR TITLE
Fix preview builds on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -353,17 +353,15 @@ jobs:
               echo "Not a PR; skipping"
             fi
       - run:
-          name: Setup registry config for using package previews on draft PRs
+          name: Install dependencies
           command: |
             if [[ $IS_DRAFT == 'true' ]]
             then
-              printf '%s\n\n%s' '@metamask:registry=https://npm.pkg.github.com' "//npm.pkg.github.com/:_authToken=${GITHUB_PACKAGE_READ_TOKEN}" > .npmrc
+              # Use GitHub registry on draft PRs, allowing the use of preview builds
+              METAMASK_NPM_REGISTRY=https://npm.pkg.github.com yarn --immutable
             else
-              echo "Not draft; skipping GitHub registry setup"
+              yarn --immutable
             fi
-      - run:
-          name: Install deps
-          command: yarn --immutable
       - save_cache:
           key: dependency-cache-v1-{{ checksum "yarn.lock" }}
           paths:

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -8,6 +8,15 @@ logFilters:
 
 nodeLinker: node-modules
 
+npmRegistries:
+  "https://npm.pkg.github.com":
+    npmAlwaysAuth: true
+    npmAuthToken: "${GITHUB_PACKAGE_READ_TOKEN-}"
+
+npmScopes:
+  metamask:
+    npmRegistryServer: "${METAMASK_NPM_REGISTRY:-https://registry.yarnpkg.com}"
+
 plugins:
   - path: .yarn/plugins/@yarnpkg/plugin-allow-scripts.cjs
     spec: "https://raw.githubusercontent.com/LavaMoat/LavaMoat/main/packages/yarn-plugin-allow-scripts/bundles/@yarnpkg/plugin-allow-scripts.js"


### PR DESCRIPTION
## Explanation

Preview builds were setup to install correctly on CircleCI prior to the Yarn v3 upgrade, but that integration broke with that upgrade. The Yarn and CircleCI configuration has been updated to fix this.

The `.yarnrc.yaml` file has been updated to configure the GitHub registry but leave it disabled by default. It can be enabled dynamically using an environment variable. This lets us switch between registries without updating the file.

The new workflow is documented here: https://github.com/MetaMask/core/pull/1481

Note that preview builds are still not compatible with the GitHub Actions workflows we have. This just lets us complete CircleCI status checks such as e2e tests.

## Manual Testing Steps

This can be tested by adding a preview build to a draft PR that includes this commit, and seeing whether it works. I did that here: https://app.circleci.com/pipelines/github/MetaMask/metamask-extension/51005/workflows/3da3f7df-76d9-43e6-99d4-2fda18a40054/jobs/1477131

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
