### PR TITLE
Fix memory based performance problem caused by use of lodash memoize in box component

### DIFF
--- a/ui/components/component-library/box/box.tsx
+++ b/ui/components/component-library/box/box.tsx
@@ -130,7 +130,7 @@ const generateClassNames = memoize(
     }
     return classNamesObject;
   },
-  (styleDeclaration, value) => [styleDeclaration, value],
+  (styleDeclaration, value) => `${styleDeclaration}${value}`,
 );
 
 export const Box: BoxComponent = React.forwardRef(

--- a/ui/components/ui/box/box.js
+++ b/ui/components/ui/box/box.js
@@ -184,7 +184,7 @@ const generateClassNames = memoize(
     }
     return classesObject;
   },
-  (type, value) => [type, value],
+  (type, value) => `${type}${value}`,
 );
 
 /**


### PR DESCRIPTION
Fixes https://github.com/MetaMask/metamask-extension/issues/19973

## Explanation

We were seeing a serious performance degradation on firefox on v10.34.0 and `develop`. If you build firefox on those branches, opened it, and left the UI running for 10-20 minutes, you will notice that performance is much slower.

My findings were as follows:

 If I click the send button on the home screen and then roughly time how long it takes until I'm actually routed to the send screen.
The first attempt was immediately after reloading the extension. Time from send click to send screen render: ~2 seconds
The second attempt was 3-4 minutes after the first attempt. Time from send click to send screen render: 4-5 seconds
The third attempt was about 10 minutes minutes after the second. Time from send click to send screen render: ~25 seconds :exclamation: :skull:

Using firefox devtools and performance profiler, we could see a flamegraph like this

![Screenshot from 2023-07-12 21-56-25](https://github.com/MetaMask/metamask-extension/assets/7499938/e5ffbb79-590d-4ed3-8592-21a8c4c19ce7)

the Box component was being rendered in a lot of places, and it resulted in a memoized function being called, which eventually results in two assocIndexOf calls, each of which seem to take 500->650ms

The Box component uses lodashes `memoize` method in an attmept to optimize the user of its `generateClassNames` function. However, we discovered that we were using this function incorrectly:

To quote @Gudahtt 

> it uses just the first parameter by default, but can be customized. We're customizing it, see the second parameter to memoize which is this function: (styleDeclaration, value) => [styleDeclaration, value]
> i.e. we're setting the cache key to [styleDeclaration, value]
> So we were using an array as the cache key. An array that gets declared anew each time memoize is called. Effectively memoizing nothing, serving purely as a memory leak.

This PR fixes this by having the resolver function passed to lodash return a string instead of an array. By doing so, the performance problems are eliminated, and clicking the send button at the same intervals as the three attempts described above seems to consistently result in home screen -> send screen in < 2 seconds.

In addition: we recently had to deal with a  significant increase in test flakiness on firefox. We addressed the test failures here https://github.com/MetaMask/metamask-extension/commit/e8bd57fd13735dcf194e779d036ef4a75ff372da, but at the time of that commit we did not get to the root cause of the increase in test flakiness. I took the changes in this PR and applied them to the commit before that flaky test fix: https://github.com/MetaMask/metamask-extension/tree/perf-fix. The firefox passed on the first try on that branch

## Manual Testing Steps

1. Build `develop`
2. Open in firefox
3. Wait 15 minutes
4. Notice slowness when trying to open the send flow or add an account

1. Build this branch
2. Open in firefox
3. Wait 15 minutes
4. No slowness when trying to open the send flow or add an account

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
