### PR TITLE
[FLASK] Fix overflow on snaps connect screen

### DIFF
--- a/ui/pages/permissions-connect/snaps/snaps-connect/index.scss
+++ b/ui/pages/permissions-connect/snaps/snaps-connect/index.scss
@@ -1,6 +1,10 @@
 .snaps-connect {
   overflow-y: hidden;
 
+  &__header {
+    width: 100%;
+  }
+
   .page-container__footer {
     border-top: 0;
     margin-top: auto;

--- a/ui/pages/permissions-connect/snaps/snaps-connect/snaps-connect.js
+++ b/ui/pages/permissions-connect/snaps/snaps-connect/snaps-connect.js
@@ -18,6 +18,7 @@ import {
   Display,
   FontWeight,
   BlockSize,
+  OverflowWrap,
 } from '../../../../helpers/constants/design-system';
 import { PageContainerFooter } from '../../../../components/ui/page-container';
 import SnapConnectCell from '../../../../components/app/snaps/snap-connect-cell/snap-connect-cell';
@@ -164,6 +165,7 @@ export default function SnapsConnect({
             variant={TextVariant.bodyMd}
             textAlign={TextAlign.Center}
             padding={[0, 4]}
+            overflowWrap={OverflowWrap.Anywhere}
           >
             {t('snapConnectionWarning', [
               <Text


### PR DESCRIPTION
## Explanation

Fixes an overflow issue on the snaps connect screen.

Fixes https://github.com/MetaMask/snaps/issues/1591

## Screenshots/Screencaps

<!-- If you're making a change to the UI, make sure to capture a screenshot or a short video showing off your work! -->

### Before

![image](https://github.com/MetaMask/metamask-extension/assets/1561200/11f36d4e-c8b3-4f69-9dd7-71dc2139f72b)

### After

![image](https://github.com/MetaMask/metamask-extension/assets/1561200/42a5bc4e-abb3-48d5-81ca-5096b5f9e0b6)

## Manual Testing Steps
1. Connect on https://o4aqbpyv5tlbspik7mwtv2pufwm6yd4ogqzztq3jklhwtjxxv5oq.arweave.net/dwEAvxXs1hk9CvstOun0LZnsD440M5nDaVLPaab3r10/
2. See that the connect screen looks fine
