### PR TITLE
fix(clipboard): Increase DEFAULT copy to clipboard time

### DIFF
--- a/ui/hooks/useCopyToClipboard.js
+++ b/ui/hooks/useCopyToClipboard.js
@@ -1,6 +1,6 @@
 import { useState, useCallback } from 'react';
 import copyToClipboard from 'copy-to-clipboard';
-import { SECOND } from '../../shared/constants/time';
+import { MINUTE } from '../../shared/constants/time';
 import { useTimeout } from './useTimeout';
 
 /**
@@ -9,7 +9,7 @@ import { useTimeout } from './useTimeout';
  * @param {number} [delay=3000] - delay in ms
  * @returns {[boolean, Function]}
  */
-const DEFAULT_DELAY = SECOND * 3;
+const DEFAULT_DELAY = MINUTE;
 
 export function useCopyToClipboard(delay = DEFAULT_DELAY) {
   const [copied, setCopied] = useState(false);


### PR DESCRIPTION
#19948 only fixed a few parts of this problem

The larger problem is that the default timeout on `useCopyToClipboard()` was 3 seconds.

Other confirmed problem areas:

- Copy private key to clipboard
- Contact list
- Token detection import tokens popup
- Activity tab -> select a transaction -> then copy from the destination address

There are also likely to be a few more bugs that nobody has found yet.  So this PR changes the default timeout from 3 seconds to 1 minute.