### PR TITLE
Updated button label to "Add hardware wallet" in the Accounts Menu list

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -249,6 +249,9 @@
   "addFromAListOfPopularNetworks": {
     "message": "Add from a list of popular networks or add a network manually. Only interact with the entities you trust."
   },
+  "addHardwareWallet": {
+    "message": "Add hardware wallet"
+  },
   "addMemo": {
     "message": "Add memo"
   },
@@ -1754,9 +1757,6 @@
   },
   "hardware": {
     "message": "Hardware"
-  },
-  "hardwareWallet": {
-    "message": "Hardware wallet"
   },
   "hardwareWalletConnected": {
     "message": "Hardware wallet connected"

--- a/test/e2e/tests/import-flow.spec.js
+++ b/test/e2e/tests/import-flow.spec.js
@@ -374,7 +374,7 @@ describe('Import flow', function () {
           // choose Connect hardware wallet from the account menu
           await driver.clickElement('[data-testid="account-menu-icon"]');
           await driver.clickElement({
-            text: 'Hardware wallet',
+            text: 'Add hardware wallet',
             tag: 'button',
           });
           await driver.delay(regularDelayMs);

--- a/ui/components/multichain/account-list-menu/account-list-menu.js
+++ b/ui/components/multichain/account-list-menu/account-list-menu.js
@@ -260,7 +260,7 @@ export const AccountListMenu = ({ onClose }) => {
                     }
                   }}
                 >
-                  {t('hardwareWallet')}
+                  {t('addHardwareWallet')}
                 </ButtonLink>
               </Box>
               {

--- a/ui/components/multichain/account-list-menu/account-list-menu.test.js
+++ b/ui/components/multichain/account-list-menu/account-list-menu.test.js
@@ -62,7 +62,7 @@ describe('AccountListMenu', () => {
     expect(getByPlaceholderText('Search accounts')).toBeInTheDocument();
     expect(getByText('Add account')).toBeInTheDocument();
     expect(getByText('Import account')).toBeInTheDocument();
-    expect(getByText('Hardware wallet')).toBeInTheDocument();
+    expect(getByText('Add hardware wallet')).toBeInTheDocument();
   });
 
   it('shows the account creation UI when Add Account is clicked', () => {
@@ -87,7 +87,7 @@ describe('AccountListMenu', () => {
 
   it('navigates to hardware wallet connection screen when clicked', () => {
     const { getByText } = render();
-    fireEvent.click(getByText('Hardware wallet'));
+    fireEvent.click(getByText('Add hardware wallet'));
     expect(historyPushMock).toHaveBeenCalledWith(CONNECT_HARDWARE_ROUTE);
   });
 


### PR DESCRIPTION
This PR is to Update the label from Hardware wallet to Add hardware wallet

* Fixes #19999 

## Screenshots/Screencaps

### Before

![Screenshot 2023-07-14 at 4 49 08 PM](https://github.com/MetaMask/metamask-extension/assets/39872794/2b52cb06-ff89-474d-a4bc-242d6eba6d7f)

### After

![Screenshot 2023-07-14 at 4 48 27 PM](https://github.com/MetaMask/metamask-extension/assets/39872794/63753273-8e07-4899-b93a-4055adba4b24)

## Manual Testing Steps
- Go to Account List Menu
- Check the button label for hardware button

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
