### PR TITLE
Update transaction status to not be considered anonymous

### DIFF
--- a/app/scripts/controllers/transactions/index.js
+++ b/app/scripts/controllers/transactions/index.js
@@ -2483,10 +2483,12 @@ export default class TransactionController extends EventEmitter {
       uiCustomizations = null;
     }
 
+    // The transaction status property is not considered sensitive and is now included in the non-anonymous event
     let properties = {
       chain_id: chainId,
       referrer,
       source,
+      status,
       network,
       eip_1559_version: eip1559Version,
       gas_edit_type: 'none',
@@ -2508,7 +2510,6 @@ export default class TransactionController extends EventEmitter {
     }
 
     let sensitiveProperties = {
-      status,
       transaction_envelope_type: isEIP1559Transaction(txMeta)
         ? TRANSACTION_ENVELOPE_TYPE_NAMES.FEE_MARKET
         : TRANSACTION_ENVELOPE_TYPE_NAMES.LEGACY,

--- a/app/scripts/controllers/transactions/index.js
+++ b/app/scripts/controllers/transactions/index.js
@@ -2483,7 +2483,7 @@ export default class TransactionController extends EventEmitter {
       uiCustomizations = null;
     }
 
-    // The transaction status property is not considered sensitive and is now included in the non-anonymous event
+    /** The transaction status property is not considered sensitive and is now included in the non-anonymous event */
     let properties = {
       chain_id: chainId,
       referrer,

--- a/app/scripts/controllers/transactions/index.test.js
+++ b/app/scripts/controllers/transactions/index.test.js
@@ -2423,6 +2423,7 @@ describe('Transaction Controller', function () {
             device_model: 'N/A',
             transaction_speed_up: false,
             ui_customizations: null,
+            status: 'unapproved',
           },
           sensitiveProperties: {
             default_gas: '0.000031501',
@@ -2433,7 +2434,6 @@ describe('Transaction Controller', function () {
             transaction_replaced: undefined,
             first_seen: 1624408066355,
             transaction_envelope_type: TRANSACTION_ENVELOPE_TYPE_NAMES.LEGACY,
-            status: 'unapproved',
           },
         };
 
@@ -2510,6 +2510,7 @@ describe('Transaction Controller', function () {
             device_model: 'N/A',
             transaction_speed_up: false,
             ui_customizations: null,
+            status: 'unapproved',
           },
           sensitiveProperties: {
             default_gas: '0.000031501',
@@ -2520,7 +2521,6 @@ describe('Transaction Controller', function () {
             transaction_replaced: undefined,
             first_seen: 1624408066355,
             transaction_envelope_type: TRANSACTION_ENVELOPE_TYPE_NAMES.LEGACY,
-            status: 'unapproved',
           },
         };
 
@@ -2609,6 +2609,7 @@ describe('Transaction Controller', function () {
             device_model: 'N/A',
             transaction_speed_up: false,
             ui_customizations: null,
+            status: 'unapproved',
           },
           sensitiveProperties: {
             default_gas: '0.000031501',
@@ -2619,7 +2620,6 @@ describe('Transaction Controller', function () {
             transaction_replaced: undefined,
             first_seen: 1624408066355,
             transaction_envelope_type: TRANSACTION_ENVELOPE_TYPE_NAMES.LEGACY,
-            status: 'unapproved',
           },
         };
 
@@ -2698,6 +2698,7 @@ describe('Transaction Controller', function () {
             device_model: 'N/A',
             transaction_speed_up: false,
             ui_customizations: null,
+            status: 'unapproved',
           },
           sensitiveProperties: {
             default_gas: '0.000031501',
@@ -2708,7 +2709,6 @@ describe('Transaction Controller', function () {
             transaction_replaced: undefined,
             first_seen: 1624408066355,
             transaction_envelope_type: TRANSACTION_ENVELOPE_TYPE_NAMES.LEGACY,
-            status: 'unapproved',
           },
         };
 
@@ -2789,6 +2789,7 @@ describe('Transaction Controller', function () {
           device_model: 'N/A',
           transaction_speed_up: false,
           ui_customizations: null,
+          status: 'unapproved',
         },
         sensitiveProperties: {
           gas_price: '2',
@@ -2797,7 +2798,6 @@ describe('Transaction Controller', function () {
           transaction_replaced: undefined,
           first_seen: 1624408066355,
           transaction_envelope_type: TRANSACTION_ENVELOPE_TYPE_NAMES.LEGACY,
-          status: 'unapproved',
         },
       };
       await txController._trackTransactionMetricsEvent(
@@ -2861,6 +2861,7 @@ describe('Transaction Controller', function () {
           device_model: 'N/A',
           transaction_speed_up: false,
           ui_customizations: null,
+          status: 'unapproved',
         },
         sensitiveProperties: {
           baz: 3.0,
@@ -2871,7 +2872,6 @@ describe('Transaction Controller', function () {
           transaction_replaced: undefined,
           first_seen: 1624408066355,
           transaction_envelope_type: TRANSACTION_ENVELOPE_TYPE_NAMES.LEGACY,
-          status: 'unapproved',
         },
       };
 
@@ -2935,6 +2935,7 @@ describe('Transaction Controller', function () {
           device_model: 'N/A',
           transaction_speed_up: false,
           ui_customizations: ['flagged_as_malicious'],
+          status: 'unapproved',
         },
         sensitiveProperties: {
           baz: 3.0,
@@ -2945,7 +2946,6 @@ describe('Transaction Controller', function () {
           transaction_replaced: undefined,
           first_seen: 1624408066355,
           transaction_envelope_type: TRANSACTION_ENVELOPE_TYPE_NAMES.LEGACY,
-          status: 'unapproved',
         },
       };
 
@@ -3009,6 +3009,7 @@ describe('Transaction Controller', function () {
           device_model: 'N/A',
           transaction_speed_up: false,
           ui_customizations: ['flagged_as_safety_unknown'],
+          status: 'unapproved',
         },
         sensitiveProperties: {
           baz: 3.0,
@@ -3019,7 +3020,6 @@ describe('Transaction Controller', function () {
           transaction_replaced: undefined,
           first_seen: 1624408066355,
           transaction_envelope_type: TRANSACTION_ENVELOPE_TYPE_NAMES.LEGACY,
-          status: 'unapproved',
         },
       };
 
@@ -3091,6 +3091,7 @@ describe('Transaction Controller', function () {
           device_model: 'N/A',
           transaction_speed_up: false,
           ui_customizations: null,
+          status: 'unapproved',
         },
         sensitiveProperties: {
           baz: 3.0,
@@ -3102,7 +3103,6 @@ describe('Transaction Controller', function () {
           transaction_replaced: undefined,
           first_seen: 1624408066355,
           transaction_envelope_type: TRANSACTION_ENVELOPE_TYPE_NAMES.FEE_MARKET,
-          status: 'unapproved',
           estimate_suggested: GasRecommendations.medium,
           estimate_used: GasRecommendations.high,
           default_estimate: 'medium',

--- a/test/e2e/metrics/transaction-finalized.spec.js
+++ b/test/e2e/metrics/transaction-finalized.spec.js
@@ -263,6 +263,7 @@ describe('Transaction Finalized Event', function () {
             category: 'Transactions',
             locale: 'en',
             environment_type: 'background',
+            status: 'submitted',
           },
           'Transaction Submitted event without sensitive properties does not match the expected payload',
         );
@@ -317,6 +318,7 @@ describe('Transaction Finalized Event', function () {
             category: 'Transactions',
             locale: 'en',
             environment_type: 'background',
+            status: 'confirmed',
           },
           'Transaction Finalized event without sensitive properties does not match the expected payload',
         );

--- a/test/e2e/metrics/transaction-finalized.spec.js
+++ b/test/e2e/metrics/transaction-finalized.spec.js
@@ -217,7 +217,6 @@ describe('Transaction Finalized Event', function () {
         assert.deepStrictEqual(
           transactionSubmittedNoMMId.properties,
           {
-            status: 'submitted',
             transaction_envelope_type: 'legacy',
             gas_limit: '0x5208',
             gas_price: '2',
@@ -263,6 +262,7 @@ describe('Transaction Finalized Event', function () {
             category: 'Transactions',
             locale: 'en',
             environment_type: 'background',
+            status: 'submitted',
           },
           'Transaction Submitted event without sensitive properties does not match the expected payload',
         );
@@ -270,7 +270,6 @@ describe('Transaction Finalized Event', function () {
         assert.deepStrictEqual(
           transactionFinalizedNoMMId.properties,
           {
-            status: 'confirmed',
             transaction_envelope_type: 'legacy',
             gas_limit: '0x5208',
             gas_price: '2',
@@ -317,6 +316,7 @@ describe('Transaction Finalized Event', function () {
             category: 'Transactions',
             locale: 'en',
             environment_type: 'background',
+            status: 'confirmed',
           },
           'Transaction Finalized event without sensitive properties does not match the expected payload',
         );

--- a/test/e2e/metrics/transaction-finalized.spec.js
+++ b/test/e2e/metrics/transaction-finalized.spec.js
@@ -217,6 +217,7 @@ describe('Transaction Finalized Event', function () {
         assert.deepStrictEqual(
           transactionSubmittedNoMMId.properties,
           {
+            status: 'submitted',
             transaction_envelope_type: 'legacy',
             gas_limit: '0x5208',
             gas_price: '2',
@@ -262,7 +263,6 @@ describe('Transaction Finalized Event', function () {
             category: 'Transactions',
             locale: 'en',
             environment_type: 'background',
-            status: 'submitted',
           },
           'Transaction Submitted event without sensitive properties does not match the expected payload',
         );
@@ -270,6 +270,7 @@ describe('Transaction Finalized Event', function () {
         assert.deepStrictEqual(
           transactionFinalizedNoMMId.properties,
           {
+            status: 'confirmed',
             transaction_envelope_type: 'legacy',
             gas_limit: '0x5208',
             gas_price: '2',
@@ -316,7 +317,6 @@ describe('Transaction Finalized Event', function () {
             category: 'Transactions',
             locale: 'en',
             environment_type: 'background',
-            status: 'confirmed',
           },
           'Transaction Finalized event without sensitive properties does not match the expected payload',
         );


### PR DESCRIPTION
## Explanation
- To include transaction status to the non-anonymous transaction finalised events. See [details](https://consensys.slack.com/archives/C03FWKDGGAG/p1684364620306539?thread_ts=1684359414.334289&cid=C03FWKDGGAG).
- Fixes [#836](https://github.com/MetaMask/MetaMask-planning/issues/836)

<!--
Thanks for the pull request. Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues, Slack conversations, Zendesk issues, user stories, etc. reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

## Screenshots/Screencaps

<!-- If you're making a change to the UI, make sure to capture a screenshot or a short video showing off your work! -->

### Before

<!-- How did the UI you changed look before your changes? Drag your file(s) below this line: -->

### After

<!-- How does it look now? Drag your file(s) below this line: -->

## Manual Testing Steps

<!--
How should reviewers and QA manually test your changes? For instance:

- Go to this screen
- Do this
- Then do this
-->

## Pre-merge author checklist

- [ ] I've clearly explained:
  - [ ] What problem this PR is solving
  - [ ] How this problem was solved
  - [ ] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
