### PR TITLE
UX: Make 'Done' button a block in Account Details

### DIFF
--- a/ui/components/multichain/account-details/account-details-key.js
+++ b/ui/components/multichain/account-details/account-details-key.js
@@ -55,7 +55,7 @@ export const AccountDetailsKey = ({ accountName, onClose, privateKey }) => {
       <BannerAlert severity={Severity.Danger} marginTop={4}>
         <Text variant={TextVariant.bodySm}>{t('privateKeyWarning')}</Text>
       </BannerAlert>
-      <ButtonPrimary marginTop={6} onClick={onClose}>
+      <ButtonPrimary marginTop={6} onClick={onClose} block>
         {t('done')}
       </ButtonPrimary>
     </>


### PR DESCRIPTION
## Explanation

When exporting a private key, the "Done" button shows as inline, and it's quite small.  Setting it to `block` looks much better.

## Screenshots/Screencaps


Fixed display: 
<img width="509" alt="SCR-20230717-ogbk" src="https://github.com/MetaMask/metamask-extension/assets/46655/fe8db37c-e695-45c7-ad37-b7d23e987183">


## Manual Testing Steps

1.  Click "Account Details" from the Accounts menu
2. Click "Export Account"
3. Put in your password
4. See block-style button

## Pre-merge author checklist

- [ ] I've clearly explained:
  - [ ] What problem this PR is solving
  - [ ] How this problem was solved
  - [ ] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
