### PR TITLE
Updating network list item hover

### DIFF
--- a/test/e2e/tests/add-custom-network.spec.js
+++ b/test/e2e/tests/add-custom-network.spec.js
@@ -363,7 +363,7 @@ describe('Custom network', function () {
 
         const arbitrumNetwork = await driver.findElements({
           text: 'Arbitrum One',
-          tag: 'span',
+          tag: 'button',
         });
         assert.ok(arbitrumNetwork.length, 1);
       },

--- a/test/e2e/tests/chain-interactions.spec.js
+++ b/test/e2e/tests/chain-interactions.spec.js
@@ -63,7 +63,7 @@ describe('Chain Interactions', function () {
         await driver.clickElement('[data-testid="network-display"]');
         const ganacheChain = await driver.findElements({
           text: `Localhost ${port}`,
-          tag: 'span',
+          tag: 'button',
         });
         assert.ok(ganacheChain.length, 1);
       },

--- a/test/e2e/tests/custom-rpc-history.spec.js
+++ b/test/e2e/tests/custom-rpc-history.spec.js
@@ -185,7 +185,7 @@ describe('Stores custom RPC history', function () {
         await driver.waitForElementNotPresent('.loading-overlay');
         await driver.clickElement('[data-testid="network-display"]');
 
-        await driver.clickElement({ text: 'Ethereum Mainnet', tag: 'span' });
+        await driver.clickElement({ text: 'Ethereum Mainnet', tag: 'button' });
       },
     );
   });
@@ -237,7 +237,7 @@ describe('Stores custom RPC history', function () {
         });
 
         // click Mainnet to dismiss network dropdown
-        await driver.clickElement({ text: 'Ethereum Mainnet', tag: 'span' });
+        await driver.clickElement({ text: 'Ethereum Mainnet', tag: 'button' });
 
         assert.equal(customRpcs.length, 2);
       },

--- a/test/e2e/tests/import-flow.spec.js
+++ b/test/e2e/tests/import-flow.spec.js
@@ -79,7 +79,7 @@ describe('Import flow', function () {
         await driver.delay(largeDelayMs);
         await driver.clickElement('[data-testid="network-display"]');
         await driver.clickElement('.toggle-button');
-        await driver.clickElement({ text: 'Localhost', tag: 'span' });
+        await driver.clickElement({ text: 'Localhost', tag: 'button' });
 
         // choose Create account from the account menu
         await driver.clickElement('[data-testid="account-menu-icon"]');

--- a/test/e2e/tests/provider-api.spec.js
+++ b/test/e2e/tests/provider-api.spec.js
@@ -47,7 +47,7 @@ describe('MetaMask', function () {
         await driver.switchToWindow(windowHandles[0]);
 
         await driver.clickElement('[data-testid="network-display"]');
-        await driver.clickElement({ text: 'Ethereum Mainnet', tag: 'span' });
+        await driver.clickElement({ text: 'Ethereum Mainnet', tag: 'button' });
 
         await driver.switchToWindowWithTitle('E2E Test Dapp', windowHandles);
         const switchedNetworkDiv = await driver.waitForSelector({

--- a/ui/components/multichain/network-list-item/__snapshots__/network-list-item.test.js.snap
+++ b/ui/components/multichain/network-list-item/__snapshots__/network-list-item.test.js.snap
@@ -18,13 +18,9 @@ exports[`NetworkListItem renders properly 1`] = `
       class="mm-box multichain-network-list-item__network-name"
     >
       <button
-        class="mm-box mm-text mm-button-base mm-button-base--ellipsis mm-button-link mm-button-link--size-auto mm-text--body-md-medium mm-text--ellipsis mm-box--padding-right-0 mm-box--padding-left-0 mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-transparent"
+        class="mm-box mm-text mm-text--body-md mm-text--ellipsis mm-box--color-text-default mm-box--background-color-transparent"
       >
-        <span
-          class="mm-box mm-text mm-text--inherit mm-text--ellipsis mm-box--color-text-default"
-        >
-          Polygon
-        </span>
+        Polygon
       </button>
     </div>
     <button

--- a/ui/components/multichain/network-list-item/network-list-item.js
+++ b/ui/components/multichain/network-list-item/network-list-item.js
@@ -16,7 +16,7 @@ import {
 import {
   AvatarNetwork,
   ButtonIcon,
-  ButtonLink,
+  Text,
   IconName,
   Box,
 } from '../../component-library';
@@ -55,7 +55,7 @@ export const NetworkListItem = ({
 
   useEffect(() => {
     if (networkRef.current && selected) {
-      networkRef.current.querySelector('.mm-button-link').focus();
+      networkRef.current.focus();
     }
   }, [networkRef, selected]);
 
@@ -72,7 +72,6 @@ export const NetworkListItem = ({
       alignItems={AlignItems.center}
       justifyContent={JustifyContent.spaceBetween}
       width={BlockSize.Full}
-      ref={networkRef}
     >
       {selected && (
         <Box
@@ -87,12 +86,15 @@ export const NetworkListItem = ({
         src={iconSrc}
       />
       <Box className="multichain-network-list-item__network-name">
-        <ButtonLink
+        <Text
+          ref={networkRef}
+          as="button"
           onClick={(e) => {
             e.stopPropagation();
             onClick();
           }}
           color={TextColor.textDefault}
+          backgroundColor={BackgroundColor.transparent}
           ellipsis
         >
           {name.length > MAXIMUM_CHARACTERS_WITHOUT_TOOLTIP ? (
@@ -106,7 +108,7 @@ export const NetworkListItem = ({
           ) : (
             name
           )}
-        </ButtonLink>
+        </Text>
       </Box>
       {onDeleteClick ? (
         <ButtonIcon


### PR DESCRIPTION
## Explanation
Currently the hover statefor the network menu list item shows an underline on hover. This was because we made and update to the hover state of `ButtonLink`. This PR updates the component to use the `Text` component and changes the underlying HTML using the `as` prop. 

## Screenshots/Screencaps

### Before


https://github.com/MetaMask/metamask-extension/assets/8112138/1f3b219a-d2bd-401f-b05a-a02101e73e8e


https://github.com/MetaMask/metamask-extension/assets/8112138/7111a914-4db4-42e6-a815-9bec1253a07c



### After


https://github.com/MetaMask/metamask-extension/assets/8112138/22570037-75dc-4746-a901-b2d37e7898c1


https://github.com/MetaMask/metamask-extension/assets/8112138/458e1665-22e9-44f4-8020-857b55b51986



## Manual Testing Steps
- Go to the latest build of storybook on this PR
- Search for `NetworkListMenu` in the search panel
- Move the cursor to hover over the text of the network menu items
- See no underline on hover

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
