### PR TITLE
UX Multichain: Added background color of test network to activity screen

### DIFF
--- a/ui/components/app/transaction-list-item/transaction-list-item.component.js
+++ b/ui/components/app/transaction-list-item/transaction-list-item.component.js
@@ -51,6 +51,7 @@ import {
 import {
   checkNetworkAndAccountSupports1559,
   getCurrentNetwork,
+  getTestNetworkBackgroundColor,
 } from '../../../selectors';
 import { isLegacyTransaction } from '../../../helpers/utils/transactions.util';
 import { formatDateWithYearContext } from '../../../helpers/utils/util';
@@ -77,6 +78,7 @@ function TransactionListItemInner({
   const [showRetryEditGasPopover, setShowRetryEditGasPopover] = useState(false);
   const { supportsEIP1559 } = useGasFeeContext();
   const { openModal } = useTransactionModalContext();
+  const testNetworkBackgroundColor = useSelector(getTestNetworkBackgroundColor);
 
   const {
     initialTransaction: { id },
@@ -276,6 +278,7 @@ function TransactionListItemInner({
                   src={currentChain?.rpcPrefs?.imageUrl}
                   borderWidth={1}
                   borderColor={BackgroundColor.backgroundDefault}
+                  backgroundColor={testNetworkBackgroundColor}
                 />
               }
             >


### PR DESCRIPTION
We have already added testnet colors to the Asset and NFTs tab via this [PR](https://github.com/MetaMask/metamask-extension/pull/20032/). This PR is to add it to the activity screen badge

* Fixes #20001 

## Screenshots

### Before

![Screenshot 2023-07-18 at 1 13 25 PM](https://github.com/MetaMask/metamask-extension/assets/39872794/13feecbc-6b30-44d9-acf7-57a9a66d3f95)


### After
![Screenshot 2023-07-18 at 1 15 35 PM](https://github.com/MetaMask/metamask-extension/assets/39872794/b1de2411-e9ca-4c89-9a15-657080760b89)

## Manual Testing Steps
- Switch to testnet
- Go to activity screen
- Check the background color of testnet matches the badge color in Activity screen


## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
