### PR TITLE
[MMI] Fix wrong custody logo location

### DIFF
--- a/ui/components/multichain/app-header/__snapshots__/app-header.test.js.snap
+++ b/ui/components/multichain/app-header/__snapshots__/app-header.test.js.snap
@@ -7,7 +7,7 @@ exports[`App Header should match snapshot 1`] = `
     data-testid="app-header-logo"
   >
     <button
-      class="box app-header__logo-container app-header__logo-container--clickable box--flex-direction-row box--background-color-transparent"
+      class="mm-box app-header__logo-container app-header__logo-container--clickable mm-box--background-color-transparent"
       data-testid="app-header-logo"
     >
       <svg

--- a/ui/components/multichain/app-header/app-header.scss
+++ b/ui/components/multichain/app-header/app-header.scss
@@ -73,6 +73,7 @@
   flex: 0 0 auto;
 }
 
+///: BEGIN:ONLY_INCLUDE_IN(build-mmi)
 .custody-logo {
   @media screen and (max-width: $break-small) {
     display: none;
@@ -83,6 +84,19 @@
     margin-left: 10px;
   }
 }
+
+.app-header__custody-logo {
+  &--icon {
+    height: 16px;
+    margin-left: 15px;
+    margin-top: 4px;
+
+    @media screen and (min-width: $break-large) {
+      display: none;
+    }
+  }
+}
+///: END:ONLY_INCLUDE_IN
 
 .app-header__metafox-logo {
   &--icon {

--- a/ui/components/ui/metafox-logo/__snapshots__/metafox-logo.component.test.js.snap
+++ b/ui/components/ui/metafox-logo/__snapshots__/metafox-logo.component.test.js.snap
@@ -3,7 +3,7 @@
 exports[`MetaFoxLogo does match snapshot with custodyImgSrc 1`] = `
 <div>
   <button
-    class="box app-header__logo-container box--flex-direction-row box--background-color-transparent"
+    class="mm-box app-header__logo-container mm-box--background-color-transparent"
     data-testid="app-header-logo"
   >
     <div />
@@ -28,7 +28,7 @@ exports[`MetaFoxLogo does match snapshot with custodyImgSrc 1`] = `
 exports[`MetaFoxLogo does not set icon height and width when unsetIconHeight is true 1`] = `
 <div>
   <button
-    class="box app-header__logo-container box--flex-direction-row box--background-color-transparent"
+    class="mm-box app-header__logo-container mm-box--background-color-transparent"
     data-testid="app-header-logo"
   >
     <div />
@@ -44,7 +44,7 @@ exports[`MetaFoxLogo does not set icon height and width when unsetIconHeight is 
 exports[`MetaFoxLogo should match snapshot with img width and height default set to 42 1`] = `
 <div>
   <button
-    class="box app-header__logo-container box--flex-direction-row box--background-color-transparent"
+    class="mm-box app-header__logo-container mm-box--background-color-transparent"
     data-testid="app-header-logo"
   >
     <div />

--- a/ui/components/ui/metafox-logo/metafox-logo.component.js
+++ b/ui/components/ui/metafox-logo/metafox-logo.component.js
@@ -1,7 +1,7 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
-import Box from '../box/box';
+import { Box } from '../../component-library';
 import { BackgroundColor } from '../../../helpers/constants/design-system';
 import MetaFoxHorizontalLogo from './horizontal-logo';
 

--- a/ui/pages/onboarding-flow/onboarding-app-header/__snapshots__/onboarding-app-header.test.js.snap
+++ b/ui/pages/onboarding-flow/onboarding-app-header/__snapshots__/onboarding-app-header.test.js.snap
@@ -9,7 +9,7 @@ exports[`OnboardingAppHeader should match snapshot 1`] = `
       class="onboarding-app-header__contents"
     >
       <button
-        class="box onboarding-app-header__logo-container box--flex-direction-row box--background-color-transparent"
+        class="mm-box onboarding-app-header__logo-container mm-box--background-color-transparent"
         data-testid="app-header-logo"
       >
         <svg


### PR DESCRIPTION
## Explanation

When a Saturn account is connected, the logo will render in the background offset it’s correct place.

## Screenshots/Screencaps

### Before

![Screenshot 2023-07-18 at 09 40 27](https://github.com/MetaMask/metamask-extension/assets/1182864/b5ce25ca-769f-456c-ac1e-3f15deac9c31)

### After

![image](https://github.com/MetaMask/metamask-extension/assets/1182864/20e354fe-4862-4e87-98da-914750e26e3e)

## Pre-merge author checklist

- [X] I've clearly explained:
  - [X] What problem this PR is solving
  - [X] How this problem was solved
  - [X] How reviewers can test my changes
- [X ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [X] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [X] PR is linked to the appropriate GitHub issue
- [X] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone
