### PR TITLE
fix(lint): Change endOfLine rules to better support linting on Windows

### DIFF
--- a/.eslintrc.base.js
+++ b/.eslintrc.base.js
@@ -72,5 +72,8 @@ module.exports = {
     // upgrading eslint and dependencies. This rule should be evaluated and
     // if agreeable turned on upstream in @metamask/eslint-config
     'import/no-named-as-default-member': 'off',
+
+    // This is necessary to run eslint on Windows and not get a thousand CRLF errors
+    'prettier/prettier': ['error', { endOfLine: 'auto' }],
   },
 };

--- a/.prettierrc.yml
+++ b/.prettierrc.yml
@@ -1,2 +1,5 @@
+# All of these are defaults except singleQuote and endOfLine, but we specify them
+# for explicitness
+endOfLine: auto
 singleQuote: true
 trailingComma: all

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "lint:lockfile:dedupe:fix": "yarn dedupe",
     "lint:lockfile": "lockfile-lint --path yarn.lock --allowed-hosts npm yarn github.com codeload.github.com --empty-hostname true --allowed-schemes \"https:\" \"git+https:\" \"npm:\" \"patch:\" \"workspace:\"",
     "lint:shellcheck": "./development/shellcheck.sh",
-    "lint:styles": "stylelint -- */**/*.scss",
+    "lint:styles": "stylelint '*/**/*.scss'",
     "lint:styles:fix": "yarn lint:styles --fix",
     "lint:tsc": "tsc --project tsconfig.json --noEmit",
     "validate-source-maps": "node ./development/sourcemap-validator.js",


### PR DESCRIPTION
Before this PR, if you run eslint on Windows, you will get thousands of CRLF errors like this:
```
    1:52   error  Delete `␍`  prettier/prettier
    2:52   error  Delete `␍`  prettier/prettier
    3:74   error  Delete `␍`  prettier/prettier
```
You can fix them with `yarn lint:fix`, but they will probably come back again, depending on your git and text editor settings.

Meanwhile, git commits everything as LF, so it shouldn't affect Mac/Linux.

**Notes:**
- Made similar changes to eslint-config, but metamask-extension is currently on an old version of eslint-config, so putting it in this repo as well
MetaMask/eslint-config#311
- This line in package.json was invalid syntax: `"lint:styles": "stylelint -- */**/*.scss",`
and on Windows, produced the error `The command line is too long.`
Changed to the valid `"lint:styles": "stylelint '*/**/*.scss'",`