### PR TITLE
scuttle weakset and event

### DIFF
--- a/development/build/index.js
+++ b/development/build/index.js
@@ -100,6 +100,7 @@ async function defineAndRunBuildTasks() {
       'harden',
       'console',
       'WeakSet',
+      'Event',
       'Image', // Used by browser to generate notifications
       // globals chromedriver needs to function
       /cdc_[a-zA-Z0-9]+_[a-zA-Z]+/iu,

--- a/development/build/index.js
+++ b/development/build/index.js
@@ -99,6 +99,7 @@ async function defineAndRunBuildTasks() {
       'navigator',
       'harden',
       'console',
+      'WeakSet',
       'Image', // Used by browser to generate notifications
       // globals chromedriver needs to function
       /cdc_[a-zA-Z0-9]+_[a-zA-Z]+/iu,


### PR DESCRIPTION
We are seeing these errors in our sentry breadcrumbs:

> {ERROR: **non-serializable** (Error: LavaMoat - property "WeakSet" of globalThis is inaccessible under scuttling mode. To learn more visit https://github.com/LavaMoat/LavaMoat/pull/360.)}

