### PR TITLE
ci: write human readable bundle sizes and specify delta

### DIFF
--- a/development/metamaskbot-build-announce.js
+++ b/development/metamaskbot-build-announce.js
@@ -20,10 +20,18 @@ function getHumanReadableSize(bytes) {
     return '0 Bytes';
   }
 
-  const k = 1024;
-  const sizes = ['Bytes', 'KiB', 'MiB'];
-  const i = Math.floor(Math.log(Math.abs(bytes)) / Math.log(k));
-  return `${parseFloat((bytes / Math.pow(k, i)).toFixed(2))} ${sizes[i]}`;
+  const absBytes = Math.abs(bytes);
+  const kibibyteSize = 1024;
+  const magnitudes = ['Bytes', 'KiB', 'MiB'];
+  let magnitudeIndex = 0;
+  if (absBytes > Math.pow(kibibyteSize, 2)) {
+    magnitudeIndex = 2;
+  } else if (absBytes > kibibyteSize) {
+    magnitudeIndex = 1;
+  }
+  return `${parseFloat(
+    (bytes / Math.pow(kibibyteSize, magnitudeIndex)).toFixed(2),
+  )} ${magnitudes[magnitudeIndex]}`;
 }
 
 function getPercentageChange(from, to) {

--- a/development/metamaskbot-build-announce.js
+++ b/development/metamaskbot-build-announce.js
@@ -15,6 +15,21 @@ function capitalizeFirstLetter(string) {
   return string.charAt(0).toUpperCase() + string.slice(1);
 }
 
+function getHumanReadableSize(bytes) {
+  if (!bytes) {
+    return '0 Bytes';
+  }
+
+  const k = 1024;
+  const sizes = ['Bytes', 'KiB', 'MiB'];
+  const i = Math.floor(Math.log(bytes) / Math.log(k));
+  return `${parseFloat((bytes / Math.pow(k, i)).toFixed(2))} ${sizes[i]}`;
+}
+
+function getPercentageChange(from, to) {
+  return parseFloat(((to - from) / Math.abs(from)) * 100).toFixed(2);
+}
+
 async function start() {
   const { GITHUB_COMMENT_TOKEN, CIRCLE_PULL_REQUEST } = process.env;
   console.log('CIRCLE_PULL_REQUEST', CIRCLE_PULL_REQUEST);
@@ -278,7 +293,11 @@ async function start() {
     }, {});
 
     const sizeDiffRows = Object.keys(diffs).map(
-      (part) => `${part}: ${diffs[part]} bytes`,
+      (part) =>
+        `${part}: ${getHumanReadableSize(diffs[part])} (${getPercentageChange(
+          devSizes[part],
+          prSizes[part],
+        )}%)`,
     );
 
     const sizeDiffHiddenContent = `<ul>${sizeDiffRows

--- a/development/metamaskbot-build-announce.js
+++ b/development/metamaskbot-build-announce.js
@@ -22,7 +22,7 @@ function getHumanReadableSize(bytes) {
 
   const k = 1024;
   const sizes = ['Bytes', 'KiB', 'MiB'];
-  const i = Math.floor(Math.log(bytes) / Math.log(k));
+  const i = Math.floor(Math.log(Math.abs(bytes)) / Math.log(k));
   return `${parseFloat((bytes / Math.pow(k, i)).toFixed(2))} ${sizes[i]}`;
 }
 


### PR DESCRIPTION
## Explanation

<!--
Thanks for the pull request. Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues, Slack conversations, Zendesk issues, user stories, etc. reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

The @metamaskbot writes bundle size diffs in a comment after each build, but they are displayed in bytes, and without giving any information about how significant is the difference (we are not informed of the percentage change).

This PR displays numbers in a human-readable unit and a percentage change of the different bundle parts sizes

## Screenshots/Screencaps

N/A

### Before

<!-- How did the UI you changed look before your changes? Drag your file(s) below this line: -->

### After

<!-- How does it look now? Drag your file(s) below this line: -->

## Manual Testing Steps

<!--
How should reviewers and QA manually test your changes? For instance:

- Go to this screen
- Do this
- Then do this
-->

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
