### PR TITLE
Fix non-preview draft PR builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -351,26 +351,8 @@ jobs:
             - dependency-cache-v1-
       - gh/install
       - run:
-          name: Set IS_DRAFT environment variable
-          command: |
-            PR_NUMBER="${CIRCLE_PULL_REQUEST##*/}"
-            if [ -n "$PR_NUMBER" ]
-            then
-              echo "IS_DRAFT=$(gh pr view --json isDraft --jq '.isDraft' "$PR_NUMBER")" >> "$BASH_ENV"
-              source "$BASH_ENV"
-            else
-              echo "Not a PR; skipping"
-            fi
-      - run:
           name: Install dependencies
-          command: |
-            if [[ $IS_DRAFT == 'true' ]]
-            then
-              # Use GitHub registry on draft PRs, allowing the use of preview builds
-              METAMASK_NPM_REGISTRY=https://npm.pkg.github.com yarn --immutable
-            else
-              yarn --immutable
-            fi
+          command: .circleci/scripts/install-dependencies.sh
       - save_cache:
           key: dependency-cache-v1-{{ checksum "yarn.lock" }}
           paths:

--- a/.circleci/scripts/install-dependencies.sh
+++ b/.circleci/scripts/install-dependencies.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+set -e
+set -u
+set -o pipefail
+
+PR_NUMBER="${CIRCLE_PULL_REQUEST##*/}"
+if [ -n "$PR_NUMBER" ]
+then
+  IS_DRAFT="$(gh pr view --json isDraft --jq '.isDraft' "$PR_NUMBER")"
+else
+  IS_DRAFT='false'
+fi
+
+# Build query to see whether there are any "preview-like" packages in the manifest
+# A "preview-like" package is a `@metamask`-scoped package with a prerelease version that has no period.
+QUERY='.dependencies + .devDependencies'                            # Get list of all dependencies
+QUERY+=' | with_entries( select(.key | startswith("@metamask") ) )' # filter to @metamask-scoped packages
+QUERY+=' | to_entries[].value'                                      # Get version ranges
+QUERY+=' | select(test("^\\d+\\.\\d+\\.\\d+-[^.]+$"))'              # Get pinned versions where the prerelease part has no "."
+
+# Use `-e` flag so that exit code indicates whether any matches were found
+if jq -e "${QUERY}" < ./package.json
+then
+  echo "Preview builds detected"
+  HAS_PREVIEW_BUILDS='true'
+else
+  echo "No preview builds detected"
+  HAS_PREVIEW_BUILDS='false'
+fi
+
+if [[ $IS_DRAFT == 'true' && $HAS_PREVIEW_BUILDS == 'true' ]]
+then
+  # Use GitHub registry on draft PRs, allowing the use of preview builds
+  echo "Installing with preview builds"
+  METAMASK_NPM_REGISTRY=https://npm.pkg.github.com yarn --immutable
+else
+  echo "Installing without preview builds"
+  yarn --immutable
+fi


### PR DESCRIPTION
## Explanation

Certain draft PRs that add new dependencies have been failing because CI will try to use the GitHub npm registry, which we use for preview builds. This registry does not have non-preview package versions, so the installation will fail if new non-preview dependencies are needed.

CI has been updated to only use the GitHub npm registry when preview builds are detected in the manifest.

## Manual Testing Steps

This can't be properly tested until after merging, unless you want to setup a fork with CircleCI builds. Once merged, we can test these cases:

* See that CircleCI logs the message "Installing without preview builds" on any non-draft PR
* See that CircleCI logs the message "Installing without preview builds" on any draft PR without preview builds
* See that CircleCI logs the message "Installing with preview builds" on any PR with preview builds
* See that the install step always succeeds

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
