### PR TITLE
feat(882): Optimize metrics function usage during onboarding flow

### DIFF
--- a/test/e2e/helpers.js
+++ b/test/e2e/helpers.js
@@ -313,10 +313,10 @@ const onboardingBeginCreateNewWallet = async (driver) => {
  * Choose either "I Agree" or "No Thanks" on the MetaMetrics onboarding screen
  *
  * @param {WebDriver} driver
- * @param {boolean} optin - true to opt into metrics, default is false
+ * @param {boolean} option - true to opt into metrics, default is false
  */
-const onboardingChooseMetametricsOption = async (driver, optin = false) => {
-  const optionIdentifier = optin ? 'i-agree' : 'no-thanks';
+const onboardingChooseMetametricsOption = async (driver, option = false) => {
+  const optionIdentifier = option ? 'i-agree' : 'no-thanks';
   // metrics
   await driver.clickElement(`[data-testid="metametrics-${optionIdentifier}"]`);
 };
@@ -744,15 +744,17 @@ async function switchToNotificationWindow(driver) {
  *
  * @param {WebDriver} driver
  * @param {import('mockttp').Mockttp} mockedEndpoints
+ * @param {boolean} hasRequest
  * @returns {import('mockttp/dist/pluggable-admin').MockttpClientResponse[]}
  */
-async function getEventPayloads(driver, mockedEndpoints) {
+async function getEventPayloads(driver, mockedEndpoints, hasRequest = true) {
   await driver.wait(async () => {
     let isPending = true;
     for (const mockedEndpoint of mockedEndpoints) {
       isPending = await mockedEndpoint.isPending();
     }
-    return isPending === false;
+
+    return isPending === !hasRequest;
   }, 10000);
   const mockedRequests = [];
   for (const mockedEndpoint of mockedEndpoints) {

--- a/test/e2e/metrics/permissions-approved.spec.js
+++ b/test/e2e/metrics/permissions-approved.spec.js
@@ -5,6 +5,7 @@ const {
   withFixtures,
   openDapp,
   unlockWallet,
+  getEventPayloads,
 } = require('../helpers');
 const FixtureBuilder = require('../fixture-builder');
 
@@ -41,28 +42,6 @@ async function mockSegment(mockServer) {
         };
       }),
   ];
-}
-
-/**
- * This method handles getting the mocked requests to the segment server
- *
- * @param {WebDriver} driver
- * @param {import('mockttp').Mockttp} mockedEndpoints
- * @returns {import('mockttp/dist/pluggable-admin').MockttpClientResponse[]}
- */
-async function getEventPayloads(driver, mockedEndpoints) {
-  await driver.wait(async () => {
-    let isPending = true;
-    for (const mockedEndpoint of mockedEndpoints) {
-      isPending = await mockedEndpoint.isPending();
-    }
-    return isPending === false;
-  }, 10000);
-  const mockedRequests = [];
-  for (const mockedEndpoint of mockedEndpoints) {
-    mockedRequests.push(...(await mockedEndpoint.getSeenRequests()));
-  }
-  return mockedRequests.map((req) => req.body.json.batch).flat();
 }
 
 describe('Permissions Approved Event', function () {

--- a/ui/pages/onboarding-flow/welcome/welcome.js
+++ b/ui/pages/onboarding-flow/welcome/welcome.js
@@ -101,6 +101,7 @@ export default function OnboardingWelcome() {
       message_title: t('welcomeToMetaMask'),
       app_version: global?.platform?.getVersion(),
     },
+    addEventBeforeMetricsOptIn: true,
   });
 
   return (


### PR DESCRIPTION

## Explanation
Only start `trackEvent` method on `ui/pages/onboarding-flow/welcome/welcome.js` when user opts in metrics track on onboarding.

<!--
Thanks for the pull request. Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues, Slack conversations, Zendesk issues, user stories, etc. reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

## Screenshots/Screencaps

<!-- If you're making a change to the UI, make sure to capture a screenshot or a short video showing off your work! -->

### Before
**_Send metric events_**

https://github.com/MetaMask/metamask-extension/assets/12678455/9df12029-1b2a-44e3-9163-b5eb0885073a




<!-- How did the UI you changed look before your changes? Drag your file(s) below this line: -->

### After
**_Will not send metric events if not opting in_**

https://github.com/MetaMask/metamask-extension/assets/12678455/877176bd-a084-41ae-ac62-c74c851d05aa




<!-- How does it look now? Drag your file(s) below this line: -->

## Manual Testing Steps
- Open network tab when onboarding
- Check if there's any `batch` request to send metrics

<!--
How should reviewers and QA manually test your changes? For instance:

- Go to this screen
- Do this
- Then do this
-->

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
