### PR TITLE
Fix sentry sourcemaps

### DIFF
--- a/app/scripts/lib/setupSentry.js
+++ b/app/scripts/lib/setupSentry.js
@@ -352,6 +352,6 @@ function toMetamaskUrl(origUrl) {
   if (!filePath) {
     return origUrl;
   }
-  const metamaskUrl = `metamask${filePath}`;
+  const metamaskUrl = `/metamask${filePath}`;
   return metamaskUrl;
 }

--- a/development/build/index.js
+++ b/development/build/index.js
@@ -99,6 +99,8 @@ async function defineAndRunBuildTasks() {
       'navigator',
       'harden',
       'console',
+      'WeakSet',
+      'Event',
       'Image', // Used by browser to generate notifications
       // globals chromedriver needs to function
       /cdc_[a-zA-Z0-9]+_[a-zA-Z]+/iu,

--- a/development/sentry-upload-artifacts.sh
+++ b/development/sentry-upload-artifacts.sh
@@ -31,7 +31,7 @@ function upload_sourcemaps {
   local release="${1}"; shift
   local dist_directory="${1}"; shift
 
-  sentry-cli releases files "${release}" upload-sourcemaps "${dist_directory}"/chrome/*.js "${dist_directory}"/sourcemaps/ --rewrite --url-prefix 'metamask'
+  sentry-cli releases files "${release}" upload-sourcemaps "${dist_directory}"/chrome/*.js "${dist_directory}"/sourcemaps/ --rewrite --url-prefix '/metamask'
 }
 
 function main {

--- a/lavamoat/build-system/policy.json
+++ b/lavamoat/build-system/policy.json
@@ -1129,13 +1129,6 @@
         "@metamask/jazzicon>color>color-convert>color-name": true
       }
     },
-    "@sentry/cli>mkdirp": {
-      "builtin": {
-        "fs": true,
-        "path.dirname": true,
-        "path.resolve": true
-      }
-    },
     "@storybook/addon-knobs>qs": {
       "packages": {
         "string.prototype.matchall>side-channel": true
@@ -8158,7 +8151,14 @@
         "path.dirname": true
       },
       "packages": {
-        "@sentry/cli>mkdirp": true
+        "stylelint>file-entry-cache>flat-cache>write>mkdirp": true
+      }
+    },
+    "stylelint>file-entry-cache>flat-cache>write>mkdirp": {
+      "builtin": {
+        "fs": true,
+        "path.dirname": true,
+        "path.resolve": true
       }
     },
     "stylelint>global-modules": {

--- a/package.json
+++ b/package.json
@@ -385,7 +385,7 @@
     "@metamask/forwarder": "^1.1.0",
     "@metamask/phishing-warning": "^2.1.0",
     "@metamask/test-dapp": "^7.0.1",
-    "@sentry/cli": "^1.58.0",
+    "@sentry/cli": "^2.19.4",
     "@storybook/addon-a11y": "^7.0.11",
     "@storybook/addon-actions": "^7.0.11",
     "@storybook/addon-essentials": "^7.0.11",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5674,18 +5674,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sentry/cli@npm:^1.58.0":
-  version: 1.58.0
-  resolution: "@sentry/cli@npm:1.58.0"
+"@sentry/cli@npm:^2.19.4":
+  version: 2.19.4
+  resolution: "@sentry/cli@npm:2.19.4"
   dependencies:
     https-proxy-agent: ^5.0.0
-    mkdirp: ^0.5.5
-    node-fetch: ^2.6.0
+    node-fetch: ^2.6.7
     progress: ^2.0.3
     proxy-from-env: ^1.1.0
+    which: ^2.0.2
   bin:
     sentry-cli: bin/sentry-cli
-  checksum: fc781bbffcf5cd970bb023168421ad89bca4184c2ddfbfddde92f4f5333c8b9075e9e16a8a4b192ecc3b197ac97062715e7b350c306ccc538fc01b955b06c3bb
+  checksum: 1f2442857a5eec2bc6f872a633d88fc2f11ed7f434db36627a034d904390f4cbbb4dccc33c571a8815e423cd36b863c72621298d49a1541b28370c7f7308f0dc
   languageName: node
   linkType: hard
 
@@ -24262,7 +24262,7 @@ __metadata:
     "@reduxjs/toolkit": ^1.6.2
     "@segment/loosely-validate-event": ^2.0.0
     "@sentry/browser": ^7.53.0
-    "@sentry/cli": ^1.58.0
+    "@sentry/cli": ^2.19.4
     "@sentry/integrations": ^7.53.0
     "@sentry/types": ^7.53.0
     "@sentry/utils": ^7.53.0
@@ -25850,7 +25850,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-fetch@npm:^2, node-fetch@npm:^2.6.0, node-fetch@npm:^2.6.1, node-fetch@npm:^2.6.11, node-fetch@npm:^2.6.7, node-fetch@npm:~2.6.1":
+"node-fetch@npm:^2, node-fetch@npm:^2.6.1, node-fetch@npm:^2.6.11, node-fetch@npm:^2.6.7, node-fetch@npm:~2.6.1":
   version: 2.6.11
   resolution: "node-fetch@npm:2.6.11"
   dependencies:


### PR DESCRIPTION
Fixes https://github.com/MetaMask/metamask-extension/issues/19289

## Explanation

We are seeing errors like this in sentry:

![Screenshot from 2023-07-21 11-04-32](https://github.com/MetaMask/metamask-extension/assets/7499938/8b027096-dccc-4127-aee7-9e251ecfc856)

The fix is to add a `/` before the file path in the sentry event report, and before the url-prefix in the sourcemap upload. While this was not necessary at some point in the past, and the change to this being a requirement is seemingly not documented, adding a trailing slash is sufficient for the filepath to be read by sentry as a valid url.

The documentation does describe how the `url-prefix` flag in the cli defaults to `~/` as the url prefix. However, it does not make clear that if setting a custom prefix, it needs to be a valid file path and that neither `~/` or `/` are prefixed to the custom prefix passed to the cli flag. In our case, either `--url-prefix '~/metamask'` or `--url-prefix '/metamask'` would work, but the former violates our `lint:shellcheck` rules so we go with the latter.

It also seems that each error report frame's `filename` property needs to align with the file path that is uploaded by the cli. Alternatively, we could separately set an `abs_path` property on each error report frame, but the solution in this PR is the minimum viable change.

I pieced this solution together by reading different sentry bug reports and by some trial and error using the manual testing process describe below. Some of the sentry bug reports that were helpful to me were:
- https://github.com/robertcepa/toucan-js/issues/54#issuecomment-1055955708
- https://github.com/getsentry/sentry-cli/issues/894#issuecomment-768600143
- https://github.com/getsentry/sentry-webpack-plugin/issues/62#issuecomment-423746322 and https://github.com/getsentry/sentry-webpack-plugin/issues/62#issuecomment-423788005

Note that the scuttling related changes currently in this PR are temporary, as we want to merge them to develop first as part of https://github.com/MetaMask/metamask-extension/pull/20090. They are needed to successfully manually test this PR

Also note that this PR updates the sentry cli version. I am not certain that is required to fix the sourcemaps problem, however it was recommended as a first step in debugging sourcemap problems, and all my testing was done with the updated cli.

### Before

![Screenshot from 2023-07-21 14-57-10](https://github.com/MetaMask/metamask-extension/assets/7499938/11394c5e-746d-41c5-95dc-7586fb7065d7)


### After

![Screenshot from 2023-07-21 14-55-24](https://github.com/MetaMask/metamask-extension/assets/7499938/beb05519-22f7-4344-8fb1-cf0406e02f2d)


## Manual Testing Steps

The below test steps should produce the "Before" error on develop and should show a successfully source mapped stack trace on this branch.

1. Checkout the desired branch (`develop` or this one)
2. Edit some code in the `app/` directory so that you can reliably have an error thrown from the background
3. Follow the instructions for "Debugging in Sentry" found here https://github.com/MetaMask/metamask-extension/tree/develop/development#debugging-in-sentry
4. When onboarding to the metamask install, be sure to agree to `Participate In MetaMetrics`
5. Take the action to have an error thrown
6. Observe the sentry instance you created in step 3

## Pre-merge author checklist

- [ ] I've clearly explained:
  - [ ] What problem this PR is solving
  - [ ] How this problem was solved
  - [ ] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
