### PR TITLE
Rep actionablemessage with banneralert in import token

### DIFF
--- a/ui/components/app/srp-input/srp-input.js
+++ b/ui/components/app/srp-input/srp-input.js
@@ -4,14 +4,13 @@ import PropTypes from 'prop-types';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import TextField from '../../ui/text-field';
 import { clearClipboard } from '../../../helpers/utils/util';
-import ActionableMessage from '../../ui/actionable-message';
+import { BannerAlert, Text } from '../../component-library';
 import Dropdown from '../../ui/dropdown';
 import ShowHideToggle from '../../ui/show-hide-toggle';
 import {
   TextAlign,
   TextVariant,
 } from '../../../helpers/constants/design-system';
-import { Text } from '../../component-library';
 import { parseSecretRecoveryPhrase } from './parse-secret-recovery-phrase';
 
 const defaultNumberOfWords = 12;
@@ -132,11 +131,10 @@ export default function SrpInput({ onChange, srpText }) {
           {srpText}
         </Text>
       </label>
-      <ActionableMessage
+      <BannerAlert
         className="import-srp__paste-tip"
-        iconFillColor="var(--color-info-default)"
-        message={t('srpPasteTip')}
-        useIcon
+        severity="info"
+        description={t('srpPasteTip')}
       />
       <Dropdown
         className="import-srp__number-of-words-dropdown"
@@ -200,25 +198,19 @@ export default function SrpInput({ onChange, srpText }) {
         })}
       </div>
       {srpError ? (
-        <ActionableMessage
+        <BannerAlert
           className="import-srp__srp-error"
-          iconFillColor="var(--color-error-default)"
-          message={srpError}
-          type="danger"
-          useIcon
+          severity="danger"
+          description={srpError}
         />
       ) : null}
       {pasteFailed ? (
-        <ActionableMessage
+        <BannerAlert
           className="import-srp__srp-too-many-words-error"
-          iconFillColor="var(--color-error-default)"
-          message={t('srpPasteFailedTooManyWords')}
-          primaryAction={{
-            label: t('dismiss'),
-            onClick: () => setPasteFailed(false),
-          }}
-          type="danger"
-          useIcon
+          severity="danger"
+          actionButtonLabel={t('dismiss')}
+          actionButtonOnClick={() => setPasteFailed(false)}
+          description={t('srpPasteFailedTooManyWords')}
         />
       ) : null}
     </div>

--- a/ui/pages/swaps/import-token/import-token.js
+++ b/ui/pages/swaps/import-token/import-token.js
@@ -6,7 +6,7 @@ import Popover from '../../../components/ui/popover';
 import Button from '../../../components/ui/button';
 import Box from '../../../components/ui/box';
 import { Text } from '../../../components/component-library/text/deprecated';
-import { BannerAlert } from '../../../components/component-library';
+import ActionableMessage from '../../../components/ui/actionable-message/actionable-message';
 import {
   TextVariant,
   FONT_WEIGHT,
@@ -55,7 +55,7 @@ export default function ImportToken({
         display={DISPLAY.FLEX}
         className="import-token"
       >
-        <BannerAlert severity="danger" description={t('importTokenWarning')} />
+        <ActionableMessage type="danger" message={t('importTokenWarning')} />
         <UrlIcon
           url={tokenForImport.iconUrl}
           className="import-token__token-icon"

--- a/ui/pages/swaps/import-token/import-token.js
+++ b/ui/pages/swaps/import-token/import-token.js
@@ -5,8 +5,7 @@ import UrlIcon from '../../../components/ui/url-icon';
 import Popover from '../../../components/ui/popover';
 import Button from '../../../components/ui/button';
 import Box from '../../../components/ui/box';
-import { Text } from '../../../components/component-library/text/deprecated';
-import ActionableMessage from '../../../components/ui/actionable-message/actionable-message';
+import { Text, BannerAlert } from '../../../components/component-library';
 import {
   TextVariant,
   FONT_WEIGHT,
@@ -55,7 +54,7 @@ export default function ImportToken({
         display={DISPLAY.FLEX}
         className="import-token"
       >
-        <ActionableMessage type="danger" message={t('importTokenWarning')} />
+        <BannerAlert severity="danger" description={t('importTokenWarning')} />
         <UrlIcon
           url={tokenForImport.iconUrl}
           className="import-token__token-icon"

--- a/ui/pages/swaps/import-token/import-token.js
+++ b/ui/pages/swaps/import-token/import-token.js
@@ -6,7 +6,7 @@ import Popover from '../../../components/ui/popover';
 import Button from '../../../components/ui/button';
 import Box from '../../../components/ui/box';
 import { Text } from '../../../components/component-library/text/deprecated';
-import ActionableMessage from '../../../components/ui/actionable-message/actionable-message';
+import { BannerAlert } from '../../../components/component-library';
 import {
   TextVariant,
   FONT_WEIGHT,
@@ -55,7 +55,7 @@ export default function ImportToken({
         display={DISPLAY.FLEX}
         className="import-token"
       >
-        <ActionableMessage type="danger" message={t('importTokenWarning')} />
+        <BannerAlert severity="danger" description={t('importTokenWarning')} />
         <UrlIcon
           url={tokenForImport.iconUrl}
           className="import-token__token-icon"


### PR DESCRIPTION
## Explanation
- Part of #19528 
<!--
Thanks for the pull request. Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues, Slack conversations, Zendesk issues, user stories, etc. reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

## Screenshots/Screencaps

<!-- If you're making a change to the UI, make sure to capture a screenshot or a short video showing off your work! -->

### Before

<!-- How did the UI you changed look before your changes? Drag your file(s) below this line: -->
![before](https://github.com/MetaMask/metamask-extension/assets/46365255/9c51f417-0519-42da-9bcb-3505d9033a6a)

### After

<!-- How does it look now? Drag your file(s) below this line: -->
![after](https://github.com/MetaMask/metamask-extension/assets/46365255/58928b01-7a23-482f-8fcc-408280e8bc96)

## Manual Testing Steps

<!--
How should reviewers and QA manually test your changes? For instance:

- Go to this screen
- Do this
- Then do this
-->
create new storybook build from this PR
## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
