### PR TITLE
Type sentry startup methods and provide a way to start or stop sentry reporting during runtime. 

### DIFF
--- a/app/scripts/controllers/metametrics.js
+++ b/app/scripts/controllers/metametrics.js
@@ -143,6 +143,8 @@ export default class MetaMetricsController {
       },
     });
 
+    global.sentry.toggleSentry(initState.participateInMetaMetrics ?? false);
+
     preferencesStore.subscribe(({ currentLocale }) => {
       this.locale = currentLocale.replace('_', '-');
     });
@@ -429,6 +431,7 @@ export default class MetaMetricsController {
     } else if (participateInMetaMetrics === false) {
       metaMetricsId = null;
     }
+    global.sentry.toggleSentry(participateInMetaMetrics);
     this.store.updateState({ participateInMetaMetrics, metaMetricsId });
     if (participateInMetaMetrics) {
       this.trackEventsAfterMetricsOptIn();

--- a/app/scripts/sentry-install.js
+++ b/app/scripts/sentry-install.js
@@ -1,10 +1,7 @@
-import setupSentry from './lib/setupSentry';
+import { initializeSentry } from '../../shared/modules/sentry.utils';
 
 // The root compartment will populate this with hooks
 global.stateHooks = {};
 
 // setup sentry error reporting
-global.sentry = setupSentry({
-  release: process.env.METAMASK_VERSION,
-  getState: () => global.stateHooks?.getSentryState?.() || {},
-});
+global.sentry = initializeSentry();

--- a/shared/modules/sentry.utils.ts
+++ b/shared/modules/sentry.utils.ts
@@ -1,0 +1,464 @@
+import * as Sentry from '@sentry/browser';
+import { Dedupe } from '@sentry/browser';
+import { ExtraErrorData } from '@sentry/integrations';
+import { Breadcrumb, Event as EventType } from '@sentry/types';
+import { SentryDebugInfo } from '../../types/global';
+import extractEthjsErrorMessage from '../../app/scripts/lib/extractEthjsErrorMessage';
+import { FilterEvents } from '../../app/scripts/lib/sentry-filter-events';
+
+export const ERROR_URL_ALLOWLIST = {
+  CRYPTOCOMPARE: 'cryptocompare.com',
+  COINGECKO: 'coingecko.com',
+  ETHERSCAN: 'etherscan.io',
+  CODEFI: 'codefi.network',
+  SEGMENT: 'segment.io',
+};
+
+/* eslint-disable prefer-destructuring */
+// Destructuring breaks the inlining of the environment variables
+const METAMASK_DEBUG = process.env.METAMASK_DEBUG;
+const METAMASK_ENVIRONMENT = process.env.METAMASK_ENVIRONMENT;
+const SENTRY_DSN_DEV =
+  process.env.SENTRY_DSN_DEV ||
+  'https://f59f3dd640d2429d9d0e2445a87ea8e1@sentry.io/273496';
+const METAMASK_BUILD_TYPE = process.env.METAMASK_BUILD_TYPE;
+const IN_TEST = process.env.IN_TEST;
+const METAMASK_VERSION = process.env.METAMASK_VERSION;
+/* eslint-enable prefer-destructuring */
+
+const SENTRY_ENVIRONMENT_STRING =
+  METAMASK_BUILD_TYPE === 'main'
+    ? METAMASK_ENVIRONMENT
+    : `${METAMASK_ENVIRONMENT}-${METAMASK_BUILD_TYPE}`;
+
+export interface SentryDebugState {
+  gas: {
+    customData: {
+      price: string | null;
+      limit: string | null;
+    };
+  };
+  history: {
+    mostRecentOverviewPage: string;
+  };
+  metamask: {
+    alertEnabledness: {
+      unconnectedAccount: boolean;
+      web3ShimUsage: boolean;
+    };
+    completedOnboarding: boolean;
+    connectedStatusPopoverHasBeenShown: boolean;
+    conversionDate: number;
+    conversionRate: number;
+    currentBlockGasLimit: string;
+    currentCurrency: string;
+    currentLocale: string;
+    // Note to self, this below key exists in the metamask duck but isn't in
+    // the background state. its set in metamask state and passed around as an
+    // ephemeral value which is probably better suited for a different slice.
+    customNonceValue: string;
+    defaultHomeActiveTabName: string | null;
+    desktopEnabled: boolean;
+    featureFlags: Record<string, boolean>;
+    firstTimeFlowType: string;
+    forgottenPassword: boolean;
+    incomingTxLastFetchedBlockByChainId: Record<string, number>;
+    ipfsGateway: string;
+    isAccountMenuOpen: boolean;
+    isInitialized: boolean;
+    isUnlocked: boolean;
+    metaMetricsId: string;
+    nativeCurrency: string;
+    networkId: string;
+    networkStatus: string;
+    nextNonce: number;
+    participateInMetaMetrics: boolean;
+    preferences: {
+      autoLockTimeLimit?: number;
+      showFiatInTestnets: boolean;
+      showTestNetworks: boolean;
+      useNativeCurrencyAsPrimaryCurrency: boolean;
+      hideZeroBalanceTokens: boolean;
+    };
+    providerConfig: {
+      nickname: string;
+      ticker: string;
+      type: string;
+    };
+    seedPhraseBackedUp: boolean;
+    unapprovedDecryptMsgCount: number;
+    unapprovedEncryptionPublicKeyMsgCount: number;
+    unapprovedMsgCount: number;
+    unapprovedPersonalMsgCount: number;
+    unapprovedTypedMessagesCount: number;
+    useBlockie: boolean;
+    useNonceField: boolean;
+    usePhishDetect: boolean;
+    welcomeScreenSeen: boolean;
+  };
+  unconnectedAccount: {
+    state: string;
+  };
+}
+
+// This describes the subset of Redux state attached to errors sent to Sentry
+// These properties have some potential to be useful for debugging, and they do
+// not contain any identifiable information.
+export const SENTRY_STATE = {
+  gas: true,
+  history: true,
+  metamask: {
+    alertEnabledness: true,
+    completedOnboarding: true,
+    connectedStatusPopoverHasBeenShown: true,
+    conversionDate: true,
+    conversionRate: true,
+    currentBlockGasLimit: true,
+    currentCurrency: true,
+    currentLocale: true,
+    customNonceValue: true,
+    defaultHomeActiveTabName: true,
+    desktopEnabled: true,
+    featureFlags: true,
+    firstTimeFlowType: true,
+    forgottenPassword: true,
+    incomingTxLastFetchedBlockByChainId: true,
+    ipfsGateway: true,
+    isAccountMenuOpen: true,
+    isInitialized: true,
+    isUnlocked: true,
+    metaMetricsId: true,
+    nativeCurrency: true,
+    networkId: true,
+    networkStatus: true,
+    nextNonce: true,
+    participateInMetaMetrics: true,
+    preferences: true,
+    providerConfig: {
+      nickname: true,
+      ticker: true,
+      type: true,
+    },
+    seedPhraseBackedUp: true,
+    unapprovedDecryptMsgCount: true,
+    unapprovedEncryptionPublicKeyMsgCount: true,
+    unapprovedMsgCount: true,
+    unapprovedPersonalMsgCount: true,
+    unapprovedTypedMessagesCount: true,
+    useBlockie: true,
+    useNonceField: true,
+    usePhishDetect: true,
+    welcomeScreenSeen: true,
+  },
+  unconnectedAccount: true,
+};
+
+function getSentryTarget() {
+  if (METAMASK_ENVIRONMENT === 'production') {
+    if (!process.env.SENTRY_DSN) {
+      throw new Error(
+        `Missing SENTRY_DSN environment variable in production environment`,
+      );
+    }
+    console.log(
+      `Setting up Sentry Remote Error Reporting for '${SENTRY_ENVIRONMENT_STRING}': SENTRY_DSN`,
+    );
+    return process.env.SENTRY_DSN;
+  }
+  console.log(
+    `Setting up Sentry Remote Error Reporting for '${SENTRY_ENVIRONMENT_STRING}': SENTRY_DSN_DEV`,
+  );
+  return SENTRY_DSN_DEV;
+}
+
+function getSentryOptions({ enabled }: { enabled?: boolean } = {}) {
+  const sentryTarget = getSentryTarget();
+
+  const getSentryDebugInfo = () => global.stateHooks?.getSentryState?.() ?? {};
+
+  /**
+   * A function that returns whether MetaMetrics is enabled. This should also
+   * return `false` if state has not yet been initialzed.
+   *
+   * @returns `true` if MetaMask's state has been initialized, and MetaMetrics
+   * is enabled, `false` otherwise.
+   */
+  function getMetaMetricsEnabled() {
+    const sentryDebugInfo = getSentryDebugInfo();
+    return sentryDebugInfo?.store?.metamask?.participateInMetaMetrics ?? false;
+  }
+
+  return {
+    dsn: sentryTarget,
+    debug: true,
+    enabled: typeof enabled === 'undefined' ? true : enabled,
+    environment: SENTRY_ENVIRONMENT_STRING,
+    integrations: [
+      new FilterEvents({ getMetaMetricsEnabled }),
+      new Dedupe(),
+      new ExtraErrorData(),
+    ],
+    release: process.env.METAMASK_VERSION,
+    beforeSend: (report: EventType) =>
+      rewriteReport(report, getSentryDebugInfo),
+    beforeBreadcrumb: beforeBreadcrumb(getSentryDebugInfo),
+  };
+}
+
+export function toggleSentry(participateInMetaMetrics = false) {
+  console.log('begin toggle');
+  const hub = global.sentry?.getCurrentHub?.();
+  if (!hub) {
+    console.log('hub not active');
+    return;
+  }
+  const isEnabled = hub.getClient?.()?.getOptions?.().enabled ?? false;
+  console.log('isSentryEnabled', isEnabled);
+  if (participateInMetaMetrics === true && isEnabled === false) {
+    console.log('init with enabled true');
+    global.sentry.init(getSentryOptions({ enabled: true }));
+  } else if (participateInMetaMetrics === false && isEnabled === true) {
+    console.log('init with enabled false');
+    global.sentry.init({ enabled: false });
+  }
+}
+
+export function initializeSentry():
+  | (typeof Sentry & {
+      toggleSentry: (participateInMetaMetrics: boolean) => void;
+    })
+  | undefined {
+  console.log('begin init');
+  if (!METAMASK_VERSION) {
+    throw new Error('Missing release');
+  } else if (METAMASK_DEBUG && !IN_TEST) {
+    /**
+     * Workaround until the following issue is resolved
+     * https://github.com/MetaMask/metamask-extension/issues/15691
+     * The IN_TEST condition allows the e2e tests to run with both
+     * yarn start:test and yarn build:test
+     */
+    return undefined;
+  }
+
+  Sentry.init(getSentryOptions());
+  return {
+    ...Sentry,
+    toggleSentry,
+  };
+}
+
+/**
+ * Receives a string and returns that string if it is a
+ * regex match for a url with a `chrome-extension` or `moz-extension`
+ * protocol, and an empty string otherwise.
+ *
+ * @param url - The URL to check.
+ * @returns An empty string if the URL was internal, or the unmodified URL otherwise.
+ */
+function hideUrlIfNotInternal(url: string) {
+  const re = /^(chrome-extension|moz-extension):\/\//u;
+  if (!url.match(re)) {
+    return '';
+  }
+  return url;
+}
+
+/**
+ * Returns a method that handles the Sentry breadcrumb using a specific method to get the extension state
+ *
+ * @param getState - A method that returns the state of the extension
+ * @returns A method that modifies a Sentry breadcrumb object
+ */
+export function beforeBreadcrumb(getState: () => SentryDebugInfo) {
+  return (breadcrumb: Breadcrumb) => {
+    if (getState) {
+      const appState = getState();
+      if (
+        Object.values(appState).length &&
+        (!appState?.store?.metamask?.participateInMetaMetrics ||
+          !appState?.store?.metamask?.completedOnboarding ||
+          breadcrumb?.category === 'ui.input')
+      ) {
+        return null;
+      }
+    } else {
+      return null;
+    }
+    const newBreadcrumb = removeUrlsFromBreadCrumb(breadcrumb);
+    return newBreadcrumb;
+  };
+}
+
+/**
+ * Receives a Sentry breadcrumb object and potentially removes urls
+ * from its `data` property, it particular those possibly found at
+ * data.from, data.to and data.url
+ *
+ * @param breadcrumb - A Sentry breadcrumb object: https://develop.sentry.dev/sdk/event-payloads/breadcrumbs/
+ * @returns A modified Sentry breadcrumb object.
+ */
+export function removeUrlsFromBreadCrumb(breadcrumb: Breadcrumb) {
+  if (breadcrumb?.data?.url) {
+    breadcrumb.data.url = hideUrlIfNotInternal(breadcrumb.data.url);
+  }
+  if (breadcrumb?.data?.to) {
+    breadcrumb.data.to = hideUrlIfNotInternal(breadcrumb.data.to);
+  }
+  if (breadcrumb?.data?.from) {
+    breadcrumb.data.from = hideUrlIfNotInternal(breadcrumb.data.from);
+  }
+  return breadcrumb;
+}
+
+/**
+ * Receives a Sentry event object and modifies it before the
+ * error is sent to Sentry. Modifications include both sanitization
+ * of data via helper methods and addition of state data from the
+ * return value of the second parameter passed to the function.
+ *
+ * @param report - A Sentry event object: https://develop.sentry.dev/sdk/event-payloads/
+ * @param getState - A function that should return an object representing some amount
+ * of app state that we wish to submit with our error reports
+ * @returns A modified Sentry event object.
+ */
+export function rewriteReport(
+  report: EventType,
+  getState: () => SentryDebugInfo,
+) {
+  try {
+    // simplify certain complex error messages (e.g. Ethjs)
+    simplifyErrorMessages(report);
+    // remove urls from error message
+    sanitizeUrlsFromErrorMessages(report);
+    // Remove evm addresses from error message.
+    // Note that this is redundent with data scrubbing we do within our sentry dashboard,
+    // but putting the code here as well gives public visibility to how we are handling
+    // privacy with respect to sentry.
+    sanitizeAddressesFromErrorMessages(report);
+    // modify report urls
+    rewriteReportUrls(report);
+    // append app state
+    if (getState) {
+      const appState = getState();
+      if (!report.extra) {
+        report.extra = {};
+      }
+      report.extra.appState = appState;
+    }
+  } catch (err) {
+    console.warn(err);
+  }
+  return report;
+}
+
+/**
+ * Receives a Sentry event object and modifies it so that urls are removed from any of its
+ * error messages.
+ *
+ * @param report - the report to modify
+ */
+function sanitizeUrlsFromErrorMessages(report: EventType) {
+  rewriteErrorMessages(report, (errorMessage) => {
+    let newErrorMessage = errorMessage;
+    const re = /(([-.+a-zA-Z]+:\/\/)|(www\.))\S+[@:.]\S+/gu;
+    const urlsInMessage = newErrorMessage.match(re) || [];
+    urlsInMessage.forEach((url) => {
+      try {
+        const urlObj = new URL(url);
+        const { hostname } = urlObj;
+        if (
+          !Object.values(ERROR_URL_ALLOWLIST).some(
+            (allowedHostname) =>
+              hostname === allowedHostname ||
+              hostname.endsWith(`.${allowedHostname}`),
+          )
+        ) {
+          newErrorMessage = newErrorMessage.replace(url, '**');
+        }
+      } catch (e) {
+        newErrorMessage = newErrorMessage.replace(url, '**');
+      }
+    });
+    return newErrorMessage;
+  });
+}
+
+/**
+ * Receives a Sentry event object and modifies it so that ethereum addresses are removed from
+ * any of its error messages.
+ *
+ * @param report - the report to modify
+ */
+function sanitizeAddressesFromErrorMessages(report: EventType) {
+  rewriteErrorMessages(report, (errorMessage) => {
+    const newErrorMessage = errorMessage.replace(/0x[A-Fa-f0-9]{40}/u, '0x**');
+    return newErrorMessage;
+  });
+}
+
+function simplifyErrorMessages(report: EventType) {
+  rewriteErrorMessages(report, (errorMessage: string) => {
+    // simplify ethjs error messages
+    let simplifiedErrorMessage = extractEthjsErrorMessage(errorMessage);
+    // simplify 'Transaction Failed: known transaction'
+    if (
+      simplifiedErrorMessage.indexOf(
+        'Transaction Failed: known transaction',
+      ) === 0
+    ) {
+      // cut the hash from the error message
+      simplifiedErrorMessage = 'Transaction Failed: known transaction';
+    }
+    return simplifiedErrorMessage;
+  });
+}
+
+function rewriteErrorMessages(
+  report: EventType,
+  rewriteFn: (errorMessage: string) => string,
+) {
+  // rewrite top level message
+  if (typeof report.message === 'string') {
+    report.message = rewriteFn(report.message);
+  }
+  // rewrite each exception message
+  if (report.exception?.values) {
+    report.exception.values.forEach((item) => {
+      if (typeof item.value === 'string') {
+        item.value = rewriteFn(item.value);
+      }
+    });
+  }
+}
+
+function rewriteReportUrls(report: EventType) {
+  if (report.request?.url) {
+    // update request url
+    report.request.url = toMetamaskUrl(report.request.url);
+  }
+
+  // update exception stack trace
+  if (report.exception?.values) {
+    report.exception.values.forEach((item) => {
+      if (item.stacktrace) {
+        item.stacktrace?.frames?.forEach((frame) => {
+          frame.filename = toMetamaskUrl(frame.filename);
+        });
+      }
+    });
+  }
+}
+
+export function toMetamaskUrl(origUrl?: string) {
+  if (!globalThis.location?.origin) {
+    return origUrl;
+  }
+
+  const filePath = origUrl?.split(globalThis.location.origin)[1];
+  if (!filePath) {
+    return origUrl;
+  }
+  const metamaskUrl = `metamask${filePath}`;
+  return metamaskUrl;
+}

--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -2,14 +2,33 @@
 // declared using var and not const or let, which is why this rule is disabled
 /* eslint-disable no-var */
 
+import * as Sentry from '@sentry/browser';
+import { SentryDebugState } from '../shared/modules/sentry.utils';
+
 declare class Platform {
   openTab: (opts: { url: string }) => void;
 
   closeCurrentWindow: () => void;
 }
 
+export declare class SentryDebugInfo {
+  browser?: string;
+
+  store?: SentryDebugState;
+
+  version?: string;
+}
+
+declare class StateHooks {
+  getSentryState?: () => SentryDebugInfo;
+}
+
 export declare global {
   var platform: Platform;
+  var stateHooks: StateHooks;
+  var sentry: typeof Sentry & {
+    toggleSentry: (participateInMetaMetrics: boolean) => void;
+  };
 
   namespace jest {
     interface Matchers<R> {

--- a/ui/index.js
+++ b/ui/index.js
@@ -99,6 +99,8 @@ async function startApp(metamaskState, backgroundConnection, opts) {
     metamaskState.featureFlags = {};
   }
 
+  global.sentry.toggleSentry(metamaskState.participateInMetaMetrics);
+
   const { currentLocaleMessages, enLocaleMessages } = await setupLocale(
     metamaskState.currentLocale,
   );

--- a/ui/store/actions.ts
+++ b/ui/store/actions.ts
@@ -1558,6 +1558,15 @@ export function updateMetamaskState(
         });
       }
     });
+    if (
+      isEqual(
+        newState.participateInMetaMetrics,
+        currentState.participateInMetaMetrics,
+      ) === false &&
+      newState.participateInMetaMetrics !== null
+    ) {
+      global.sentry.toggleSentry(newState.participateInMetaMetrics);
+    }
     // Also emit an event for the selected account changing, either due to a
     // property update or if the entire account changes.
     if (isEqual(oldSelectedAccount, newSelectedAccount) === false) {


### PR DESCRIPTION
## Explanation
Supersedes #20114 with more typing and a better approach. 

I was hoping to avoid the issue of LavaMoat doing what it does best of not allowing access to things injected into global objects by putting a toggleSentry method *on the object* and just re-initializing it but it seems that something is *replaced* when you call .init instead of settings being updated. This is to store my approach for analysis and figure out the next step. 


https://github.com/MetaMask/metamask-extension/assets/4448075/5b960d80-4e0b-4f68-820c-a21a96e9ab22



<!--
Thanks for the pull request. Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues, Slack conversations, Zendesk issues, user stories, etc. reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

## Screenshots/Screencaps

<!-- If you're making a change to the UI, make sure to capture a screenshot or a short video showing off your work! -->

### Before

<!-- How did the UI you changed look before your changes? Drag your file(s) below this line: -->

### After

<!-- How does it look now? Drag your file(s) below this line: -->

## Manual Testing Steps

<!--
How should reviewers and QA manually test your changes? For instance:

- Go to this screen
- Do this
- Then do this
-->

## Pre-merge author checklist

- [ ] I've clearly explained:
  - [ ] What problem this PR is solving
  - [ ] How this problem was solved
  - [ ] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
