### PR TITLE
Removing none from Size enum

### DIFF
--- a/ui/helpers/constants/design-system.ts
+++ b/ui/helpers/constants/design-system.ts
@@ -206,7 +206,6 @@ export enum Size {
   XL = 'xl',
   inherit = 'inherit', // Used for Text, Icon, and Button components to inherit the parent elements font-size
   auto = 'auto',
-  none = 'none',
 }
 
 export enum BorderStyle {


### PR DESCRIPTION
## Explanation
Currently the design system Size enum included `none`. None is not a size and is not used. It was previously used for border size but that has now been updated on BorderStyle. This PR updates the Size enum by remove the none option. I have searched the code base for instances of `Size.none` with no results so it is safe to remove

* Fixes #15453 

## Screenshots/Screencaps

![Screenshot 2023-07-21 at 11 41 25 AM](https://github.com/MetaMask/metamask-extension/assets/8112138/294be6e1-53aa-4d08-a144-d892f7a90dd4)

## Manual Testing Steps

- Pull this branch
- Search `Size.none`
- See no results found

## Pre-merge author checklist

- [ ] I've clearly explained:
  - [ ] What problem this PR is solving
  - [ ] How this problem was solved
  - [ ] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
