### PR TITLE
UX: Remove height from loading block, use modern components

### DIFF
--- a/ui/components/app/token-list/token-list.js
+++ b/ui/components/app/token-list/token-list.js
@@ -9,7 +9,11 @@ import { useTokenTracker } from '../../../hooks/useTokenTracker';
 import { getShouldHideZeroBalanceTokens } from '../../../selectors';
 import { getTokens } from '../../../ducks/metamask/metamask';
 import { Box } from '../../component-library';
-import { AlignItems, Display, JustifyContent } from '../../../helpers/constants/design-system';
+import {
+  AlignItems,
+  Display,
+  JustifyContent,
+} from '../../../helpers/constants/design-system';
 
 export default function TokenList({ onTokenClick }) {
   const t = useI18nContext();

--- a/ui/components/app/token-list/token-list.js
+++ b/ui/components/app/token-list/token-list.js
@@ -8,6 +8,8 @@ import { useI18nContext } from '../../../hooks/useI18nContext';
 import { useTokenTracker } from '../../../hooks/useTokenTracker';
 import { getShouldHideZeroBalanceTokens } from '../../../selectors';
 import { getTokens } from '../../../ducks/metamask/metamask';
+import { Box } from '../../component-library';
+import { AlignItems, Display, JustifyContent } from '../../../helpers/constants/design-system';
 
 export default function TokenList({ onTokenClick }) {
   const t = useI18nContext();
@@ -25,17 +27,14 @@ export default function TokenList({ onTokenClick }) {
   );
   if (loading) {
     return (
-      <div
-        style={{
-          display: 'flex',
-          height: '250px',
-          alignItems: 'center',
-          justifyContent: 'center',
-          padding: '30px',
-        }}
+      <Box
+        display={Display.Flex}
+        alignItems={AlignItems.center}
+        justifyContent={JustifyContent.center}
+        padding={7}
       >
         {t('loadingTokens')}
-      </div>
+      </Box>
     );
   }
 


### PR DESCRIPTION
## Explanation

Presently the `loading` box for token is large for no real reason.   This removes that artificial size and updates our components to use modern components.

## Pre-merge author checklist

- [ ] I've clearly explained:
  - [ ] What problem this PR is solving
  - [ ] How this problem was solved
  - [ ] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
