### PR TITLE
Updated opensea link for NFT Details

### DIFF
--- a/ui/components/app/nft-details/nft-details.js
+++ b/ui/components/app/nft-details/nft-details.js
@@ -111,12 +111,13 @@ export default function NftDetails({ nft }) {
   const getOpenSeaLink = () => {
     switch (currentNetwork) {
       case CHAIN_IDS.MAINNET:
-        return `https://opensea.io/assets/${address}/${tokenId}`;
+        return `https://opensea.io/assets/ethereum/${address}/${tokenId}`;
       case CHAIN_IDS.POLYGON:
         return `https://opensea.io/assets/matic/${address}/${tokenId}`;
       case CHAIN_IDS.GOERLI:
+        return `https://testnets.opensea.io/assets/goerli/${address}/${tokenId}`;
       case CHAIN_IDS.SEPOLIA:
-        return `https://testnets.opensea.io/assets/${address}/${tokenId}`;
+        return `https://testnets.opensea.io/assets/sepolia/${address}/${tokenId}`;
       default:
         return null;
     }

--- a/ui/components/app/nft-details/nft-details.test.js
+++ b/ui/components/app/nft-details/nft-details.test.js
@@ -51,6 +51,7 @@ describe('NFT Details', () => {
 
   const nfts =
     mockState.metamask.allNfts[mockState.metamask.selectedAddress][toHex(5)];
+  console.log("nidhi", nfts)
 
   const props = {
     nft: nfts[5],
@@ -165,7 +166,7 @@ describe('NFT Details', () => {
 
       await waitFor(() => {
         expect(global.platform.openTab).toHaveBeenCalledWith({
-          url: `https://testnets.opensea.io/assets/${nfts[5].address}/${nfts[5].tokenId}`,
+          url: `https://testnets.opensea.io/assets/goerli/${nfts[5].address}/${nfts[5].tokenId}`,
         });
       });
     });
@@ -200,7 +201,7 @@ describe('NFT Details', () => {
 
       await waitFor(() => {
         expect(global.platform.openTab).toHaveBeenCalledWith({
-          url: `https://opensea.io/assets/${nfts[5].address}/${nfts[5].tokenId}`,
+          url: `https://opensea.io/assets/ethereum/${nfts[5].address}/${nfts[5].tokenId}`,
         });
       });
     });
@@ -272,7 +273,7 @@ describe('NFT Details', () => {
 
       await waitFor(() => {
         expect(global.platform.openTab).toHaveBeenCalledWith({
-          url: `https://testnets.opensea.io/assets/${nfts[5].address}/${nfts[5].tokenId}`,
+          url: `https://testnets.opensea.io/assets/sepolia/${nfts[5].address}/${nfts[5].tokenId}`,
         });
       });
     });

--- a/ui/components/app/nft-details/nft-details.test.js
+++ b/ui/components/app/nft-details/nft-details.test.js
@@ -51,7 +51,6 @@ describe('NFT Details', () => {
 
   const nfts =
     mockState.metamask.allNfts[mockState.metamask.selectedAddress][toHex(5)];
-  console.log("nidhi", nfts)
 
   const props = {
     nft: nfts[5],


### PR DESCRIPTION
Currently, the Opensea link on nft-details navigates the user to a broken Opensea link, this PR updates the Opensea link to route to the correct URL

* Fixes 

## Screenshots/Screencaps


### Before

https://github.com/MetaMask/metamask-extension/assets/39872794/d2b79da5-3bb4-482d-bd21-feaf99296b14



### After


https://github.com/MetaMask/metamask-extension/assets/39872794/a1d84bca-faa0-4959-9480-800de8543f6a


## Manual Testing Steps

- Go to an NFT Detail
- Click on view on opensea
- Check it directs to correct URL

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
