### PR TITLE
UX: Ensure block explorer link is for desired account

### DIFF
--- a/ui/components/multichain/account-list-item-menu/account-list-item-menu.js
+++ b/ui/components/multichain/account-list-item-menu/account-list-item-menu.js
@@ -138,6 +138,7 @@ export const AccountListItemMenu = ({
             metricsLocation={METRICS_LOCATION}
             closeMenu={closeMenu}
             textProps={{ variant: TextVariant.bodySm }}
+            address={identity.address}
           />
           {isRemovable ? (
             <MenuItem

--- a/ui/components/multichain/global-menu/global-menu.js
+++ b/ui/components/multichain/global-menu/global-menu.js
@@ -99,6 +99,7 @@ export const GlobalMenu = ({ closeMenu, anchorElement }) => {
       <ViewExplorerMenuItem
         metricsLocation={METRICS_LOCATION}
         closeMenu={closeMenu}
+        address={address}
       />
       <MenuItem
         iconName={IconName.Connect}

--- a/ui/components/multichain/menu-items/view-explorer-menu-item.js
+++ b/ui/components/multichain/menu-items/view-explorer-menu-item.js
@@ -18,7 +18,6 @@ import {
   getBlockExplorerLinkText,
   getCurrentChainId,
   getRpcPrefsForCurrentProvider,
-  getSelectedAddress,
 } from '../../../selectors';
 import { getURLHostName } from '../../../helpers/utils/util';
 import { NETWORKS_ROUTE } from '../../../helpers/constants/routes';
@@ -27,15 +26,15 @@ export const ViewExplorerMenuItem = ({
   metricsLocation,
   closeMenu,
   textProps,
+  address,
 }) => {
   const t = useI18nContext();
   const trackEvent = useContext(MetaMetricsContext);
   const history = useHistory();
 
-  const currentAddress = useSelector(getSelectedAddress);
   const chainId = useSelector(getCurrentChainId);
   const rpcPrefs = useSelector(getRpcPrefsForCurrentProvider);
-  const addressLink = getAccountLink(currentAddress, chainId, rpcPrefs);
+  const addressLink = getAccountLink(address, chainId, rpcPrefs);
 
   const { blockExplorerUrl } = rpcPrefs;
   const blockExplorerUrlSubTitle = getURLHostName(blockExplorerUrl);
@@ -94,4 +93,5 @@ ViewExplorerMenuItem.propTypes = {
   metricsLocation: PropTypes.string.isRequired,
   closeMenu: PropTypes.func,
   textProps: PropTypes.object,
+  address: PropTypes.string.isRequired,
 };

--- a/ui/components/multichain/menu-items/view-explorer-menu-item.test.js
+++ b/ui/components/multichain/menu-items/view-explorer-menu-item.test.js
@@ -10,6 +10,7 @@ const render = () => {
     <ViewExplorerMenuItem
       metricsLocation="Global Menu"
       closeMenu={jest.fn()}
+      address="0x0dcd5d886577d5081b0c52e242ef29e70be3e7bc"
     />,
     store,
   );


### PR DESCRIPTION
## Explanation

A regression in https://github.com/MetaMask/metamask-extension/pull/20013 caused the "View on Explorer" link to always open the link for the *current* address, which would break the VoE menu item in the Account Menu.

## Screenshots/Screencaps

<img width="534" alt="SCR-20230724-igkx" src="https://github.com/MetaMask/metamask-extension/assets/46655/3fce511a-8cd5-417d-a4bf-0329a6bdf356">

## Manual Testing Steps

1.  Open accounts menu
2. Click the three-dot menu of the selected account
3. Click "View on Explorer", ensure the correct address shows on Etherscan
4. Open accounts menu again
5. Click the three-dot menu of an account that is *not* selected
6. Click "View on Explorer", ensure the correct address shows on Etherscan

## Pre-merge author checklist

- [ ] I've clearly explained:
  - [ ] What problem this PR is solving
  - [ ] How this problem was solved
  - [ ] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
