### PR TITLE
Ensure chainId comparison in switchEthereumChain handler is case insensitive

### DIFF
--- a/app/scripts/lib/rpc-method-middleware/handlers/switch-ethereum-chain.js
+++ b/app/scripts/lib/rpc-method-middleware/handlers/switch-ethereum-chain.js
@@ -116,7 +116,7 @@ async function switchEthereumChainHandler(
       if (
         Object.values(BUILT_IN_INFURA_NETWORKS)
           .map(({ chainId: id }) => id)
-          .includes(chainId)
+          .includes(_chainId)
       ) {
         await setProviderType(approvedRequestData.type);
       } else {

--- a/app/scripts/lib/rpc-method-middleware/handlers/switch-ethereum-chain.test.js
+++ b/app/scripts/lib/rpc-method-middleware/handlers/switch-ethereum-chain.test.js
@@ -1,0 +1,128 @@
+import {
+  CHAIN_IDS,
+  NETWORK_TYPES,
+} from '../../../../../shared/constants/network';
+import switchEthereumChain from './switch-ethereum-chain';
+
+const NON_INFURA_CHAIN_ID = '0x123456789';
+
+const mockRequestUserApproval = ({ requestData }) => {
+  return Promise.resolve(requestData);
+};
+
+const MOCK_MAINNET_CONFIGURATION = {
+  id: 123,
+  chainId: CHAIN_IDS.MAINNET,
+  type: NETWORK_TYPES.MAINNET,
+};
+const MOCK_LINEA_MAINNET_CONFIGURATION = {
+  id: 123,
+  chainId: CHAIN_IDS.LINEA_MAINNET,
+  type: NETWORK_TYPES.LINEA_MAINNET,
+};
+
+describe('switchEthereumChainHandler', () => {
+  it('should call setProviderType when switching to a built in infura network', async () => {
+    const mockSetProviderType = jest.fn();
+    const mockSetActiveNetwork = jest.fn();
+    const switchEthereumChainHandler = switchEthereumChain.implementation;
+    await switchEthereumChainHandler(
+      {
+        origin: 'example.com',
+        params: [{ chainId: CHAIN_IDS.MAINNET }],
+      },
+      {},
+      jest.fn(),
+      jest.fn(),
+      {
+        getCurrentChainId: () => NON_INFURA_CHAIN_ID,
+        findNetworkConfigurationBy: () => MOCK_MAINNET_CONFIGURATION,
+        setProviderType: mockSetProviderType,
+        setActiveNetwork: mockSetActiveNetwork,
+        requestUserApproval: mockRequestUserApproval,
+      },
+    );
+    expect(mockSetProviderType).toHaveBeenCalledTimes(1);
+    expect(mockSetProviderType).toHaveBeenCalledWith(
+      MOCK_MAINNET_CONFIGURATION.type,
+    );
+  });
+
+  it('should call setProviderType when switching to a built in infura network, when chainId from request is lower case', async () => {
+    const mockSetProviderType = jest.fn();
+    const mockSetActiveNetwork = jest.fn();
+    const switchEthereumChainHandler = switchEthereumChain.implementation;
+    await switchEthereumChainHandler(
+      {
+        origin: 'example.com',
+        params: [{ chainId: CHAIN_IDS.LINEA_MAINNET.toLowerCase() }],
+      },
+      {},
+      jest.fn(),
+      jest.fn(),
+      {
+        getCurrentChainId: () => NON_INFURA_CHAIN_ID,
+        findNetworkConfigurationBy: () => MOCK_LINEA_MAINNET_CONFIGURATION,
+        setProviderType: mockSetProviderType,
+        setActiveNetwork: mockSetActiveNetwork,
+        requestUserApproval: mockRequestUserApproval,
+      },
+    );
+    expect(mockSetProviderType).toHaveBeenCalledTimes(1);
+    expect(mockSetProviderType).toHaveBeenCalledWith(
+      MOCK_LINEA_MAINNET_CONFIGURATION.type,
+    );
+  });
+
+  it('should call setProviderType when switching to a built in infura network, when chainId from request is upper case', async () => {
+    const mockSetProviderType = jest.fn();
+    const mockSetActiveNetwork = jest.fn();
+    const switchEthereumChainHandler = switchEthereumChain.implementation;
+    await switchEthereumChainHandler(
+      {
+        origin: 'example.com',
+        params: [{ chainId: CHAIN_IDS.LINEA_MAINNET.toUpperCase() }],
+      },
+      {},
+      jest.fn(),
+      jest.fn(),
+      {
+        getCurrentChainId: () => NON_INFURA_CHAIN_ID,
+        findNetworkConfigurationBy: () => MOCK_LINEA_MAINNET_CONFIGURATION,
+        setProviderType: mockSetProviderType,
+        setActiveNetwork: mockSetActiveNetwork,
+        requestUserApproval: mockRequestUserApproval,
+      },
+    );
+    expect(mockSetProviderType).toHaveBeenCalledTimes(1);
+    expect(mockSetProviderType).toHaveBeenCalledWith(
+      MOCK_LINEA_MAINNET_CONFIGURATION.type,
+    );
+  });
+
+  it('should call setActiveNetwork when switching to a custom network', async () => {
+    const mockSetProviderType = jest.fn();
+    const mockSetActiveNetwork = jest.fn();
+    const switchEthereumChainHandler = switchEthereumChain.implementation;
+    await switchEthereumChainHandler(
+      {
+        origin: 'example.com',
+        params: [{ chainId: NON_INFURA_CHAIN_ID }],
+      },
+      {},
+      jest.fn(),
+      jest.fn(),
+      {
+        getCurrentChainId: () => CHAIN_IDS.MAINNET,
+        findNetworkConfigurationBy: () => MOCK_MAINNET_CONFIGURATION,
+        setProviderType: mockSetProviderType,
+        setActiveNetwork: mockSetActiveNetwork,
+        requestUserApproval: mockRequestUserApproval,
+      },
+    );
+    expect(mockSetActiveNetwork).toHaveBeenCalledTimes(1);
+    expect(mockSetActiveNetwork).toHaveBeenCalledWith(
+      MOCK_MAINNET_CONFIGURATION.id,
+    );
+  });
+});


### PR DESCRIPTION
Fixes https://github.com/MetaMask/metamask-extension/issues/20084

## Explanation

In `switchEthereumChainHandler` of `app/scripts/lib/rpc-method-middleware/handlers/switch-ethereum-chain.js` we are comparing infura chain ids to the chain ids that are received by the request. In the case of linea, it is possible for those chain ids to have different casing: `0xE708` vs `0xe708`. Our hard coded chain id is in lower case. So dapp attempts to switch the user to linea would fail if the dapp passed an upper case chainId to the `wallet_switchEthereumChain` request

## Manual Testing Steps

1. Select mainnet as your network
2. Go to the test dapp
3. Open the developer console and enter the below code:
```
        await window.ethereum.request({

          method: 'wallet_switchEthereumChain',
          params: [{ chainId: '0xE708'}], 
        });
```
4. Click through the switch chain popup, confirming you want to switch to linea.

On develop the above will fail with an error sent to the dapp upon clicking confirm, and on this branch it will succeed and you will be successfully switched to linea.

## Pre-merge author checklist

- [ ] I've clearly explained:
  - [ ] What problem this PR is solving
  - [ ] How this problem was solved
  - [ ] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
