### PR TITLE
Fix #20140 - Ensure only one network displays as selected in the network picker when chain IDs collide

### DIFF
--- a/ui/components/multichain/network-list-menu/network-list-menu.js
+++ b/ui/components/multichain/network-list-menu/network-list-menu.js
@@ -17,6 +17,7 @@ import {
   getCurrentChainId,
   getNonTestNetworks,
   getTestNetworks,
+  getCurrentNetwork,
 } from '../../../selectors';
 import ToggleButton from '../../ui/toggle-button';
 import {
@@ -64,6 +65,7 @@ export const NetworkListMenu = ({ onClose }) => {
   const history = useHistory();
   const trackEvent = useContext(MetaMetricsContext);
 
+  const currentNetwork = useSelector(getCurrentNetwork);
   const currentlyOnTestNetwork = TEST_CHAINS.includes(currentChainId);
 
   const environmentType = getEnvironmentType();
@@ -85,7 +87,8 @@ export const NetworkListMenu = ({ onClose }) => {
         return null;
       }
 
-      const isCurrentNetwork = currentChainId === network.chainId;
+      const isCurrentNetwork = currentNetwork.id === network.id;
+
       const canDeleteNetwork =
         !isCurrentNetwork && !UNREMOVABLE_CHAIN_IDS.includes(network.chainId);
 

--- a/ui/components/multichain/network-list-menu/network-list-menu.test.js
+++ b/ui/components/multichain/network-list-menu/network-list-menu.test.js
@@ -19,19 +19,26 @@ jest.mock('../../../store/actions.ts', () => ({
   toggleNetworkMenu: () => mockToggleNetworkMenu,
 }));
 
-const render = (showTestNetworks = false, currentChainId = '0x1') => {
-  const store = configureStore({
+const render = (
+  showTestNetworks = false,
+  currentChainId = '0x5',
+  providerConfigId = 'chain5',
+) => {
+  const state = {
     metamask: {
       ...mockState.metamask,
       providerConfig: {
         ...mockState.metamask.providerConfig,
         chainId: currentChainId,
+        id: providerConfigId,
       },
       preferences: {
         showTestNetworks,
       },
     },
-  });
+  };
+
+  const store = configureStore(state);
   return renderWithProvider(<NetworkListMenu onClose={jest.fn()} />, store);
 };
 
@@ -61,8 +68,8 @@ describe('NetworkListMenu', () => {
   });
 
   it('disables toggle when on test network', () => {
-    const { container } = render(false, CHAIN_IDS.GOERLI);
-    expect(container.querySelector('.toggle-button--disabled')).toBeDefined();
+    render(false, CHAIN_IDS.GOERLI);
+    expect(document.querySelector('.toggle-button--disabled')).toBeDefined();
   });
 
   it('switches networks when an item is clicked', () => {
@@ -70,5 +77,26 @@ describe('NetworkListMenu', () => {
     fireEvent.click(getByText(MAINNET_DISPLAY_NAME));
     expect(mockToggleNetworkMenu).toHaveBeenCalled();
     expect(mockSetProviderType).toHaveBeenCalled();
+  });
+
+  it('shows the correct selected network when networks share the same chain ID', () => {
+    // Mainnet and Custom Mainnet RPC both use chain ID 0x1
+    render(false, '0x1', 'testNetworkConfigurationId');
+
+    // Contains Mainnet and the two custom networks
+    const networkItems = document.querySelectorAll(
+      '.multichain-network-list-item',
+    );
+    expect(networkItems).toHaveLength(3);
+
+    const selectedNodes = document.querySelectorAll(
+      '.multichain-network-list-item--selected',
+    );
+    expect(selectedNodes).toHaveLength(1);
+
+    const selectedNodeText = selectedNodes[0].querySelector(
+      '.multichain-network-list-item__network-name',
+    ).textContent;
+    expect(selectedNodeText).toStrictEqual('Custom Mainnet RPC');
   });
 });


### PR DESCRIPTION

## Explanation

This issue should have been fixed with https://github.com/MetaMask/metamask-extension/pull/19947 but was errantly reverted in https://github.com/MetaMask/metamask-extension/pull/19951 .

* Fixes [#12345](https://github.com/MetaMask/metamask-extension/issues/20140)

## Screenshots/Screencaps

<img width="578" alt="SCR-20230724-mnkb" src="https://github.com/MetaMask/metamask-extension/assets/46655/befa3d23-1f9c-439b-8138-7424d8f9c3b0">

## Manual Testing Steps

1.  Add the following custom network:

```
Network Name: Ethereum Alt
RPC URL: https://ethereum.publicnode.com
Chain Id: 1
```

2.  Switch between Mainnet and this new custom network using the network picker
3.  Ensure the correct network is selected each time


## Pre-merge author checklist

- [ ] I've clearly explained:
  - [ ] What problem this PR is solving
  - [ ] How this problem was solved
  - [ ] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
