### PR TITLE
UX: Ensure currently selected account displays when Account Menu opens

### DIFF
--- a/ui/components/multichain/account-list-item/account-list-item.js
+++ b/ui/components/multichain/account-list-item/account-list-item.js
@@ -1,4 +1,4 @@
-import React, { useState, useContext } from 'react';
+import React, { useState, useContext, useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 
@@ -87,6 +87,15 @@ export const AccountListItem = ({
     setAccountListItemMenuElement(ref);
   };
 
+  // If this is the selected item in the Account menu,
+  // scroll the item into view
+  const itemRef = useRef(null);
+  useEffect(() => {
+    if (selected) {
+      itemRef.current?.scrollIntoView();
+    }
+  }, [itemRef, selected]);
+
   const keyring = useSelector((state) =>
     findKeyringForAddress(state, identity.address),
   );
@@ -103,6 +112,7 @@ export const AccountListItem = ({
         'multichain-account-list-item--selected': selected,
         'multichain-account-list-item--connected': Boolean(connectedAvatar),
       })}
+      ref={itemRef}
       onClick={() => {
         // Without this check, the account will be selected after
         // the account options menu closes

--- a/ui/components/multichain/account-list-item/account-list-item.js
+++ b/ui/components/multichain/account-list-item/account-list-item.js
@@ -92,7 +92,7 @@ export const AccountListItem = ({
   const itemRef = useRef(null);
   useEffect(() => {
     if (selected) {
-      itemRef.current?.scrollIntoView();
+      itemRef.current?.scrollIntoView?.();
     }
   }, [itemRef, selected]);
 


### PR DESCRIPTION
## Explanation

User feedback brought up a great point that the current account should be in view when the account menu opens.  We presently autofocus the search box for easy account search, but still, the current account should really be in focus as a bonus UX improvement.  Side note: we do currently focus the currently selected network.

## Screenshots/Screencaps

https://github.com/MetaMask/metamask-extension/assets/46655/3a181827-2e3f-4486-bc7c-4bb7e81f4295

## Manual Testing Steps

1.  Create ~10 accounts
2. Select various accounts
3. Ensure that each time the account menu is opened, the currently selected account is in view

## Pre-merge author checklist

- [ ] I've clearly explained:
  - [ ] What problem this PR is solving
  - [ ] How this problem was solved
  - [ ] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
