### PR TITLE
UX: Allow quick Add Account name based on default name

### DIFF
--- a/ui/components/multichain/create-account/create-account.js
+++ b/ui/components/multichain/create-account/create-account.js
@@ -39,11 +39,12 @@ export const CreateAccount = ({ onActionComplete }) => {
   const defaultAccountName = t('newAccountNumberName', [newAccountNumber]);
 
   const [newAccountName, setNewAccountName] = useState('');
+  const trimmedAccountName = newAccountName.trim();
 
   const { isValidAccountName, errorMessage } = getAccountNameErrorMessage(
     accounts,
     { t },
-    newAccountName === '' ? defaultAccountName : newAccountName,
+    trimmedAccountName ?? defaultAccountName,
     defaultAccountName,
   );
 
@@ -58,7 +59,7 @@ export const CreateAccount = ({ onActionComplete }) => {
     event.preventDefault();
 
     try {
-      await onCreateAccount(newAccountName || defaultAccountName);
+      await onCreateAccount(trimmedAccountName || defaultAccountName);
       onActionComplete(true);
       trackEvent({
         category: MetaMetricsEventCategory.Accounts,

--- a/ui/components/multichain/create-account/create-account.js
+++ b/ui/components/multichain/create-account/create-account.js
@@ -43,7 +43,7 @@ export const CreateAccount = ({ onActionComplete }) => {
   const { isValidAccountName, errorMessage } = getAccountNameErrorMessage(
     accounts,
     { t },
-    newAccountName,
+    newAccountName === '' ? defaultAccountName : newAccountName,
     defaultAccountName,
   );
 

--- a/ui/components/ui/editable-label/editable-label.js
+++ b/ui/components/ui/editable-label/editable-label.js
@@ -38,7 +38,7 @@ export default class EditableLabel extends Component {
       return;
     }
 
-    await this.props.onSubmit(this.state.value);
+    await this.props.onSubmit(this.state.value.trim());
     this.setState({ isEditing: false });
   }
 


### PR DESCRIPTION
## Explanation

Formerly it was possible to quickly create a new account with the next default account name but this was recently changed.  If the new account input is empty, the placeholder value should be used as the account name.

## Screenshots/Screencaps

https://github.com/MetaMask/metamask-extension/assets/46655/3e7a138b-5f83-4cac-a124-8f1e1675b3e9

## Manual Testing Steps

1.  Open the account menu
2. Click "Add account"
3. Don't change the value of the Account input (keep it empty)
4. Click create
5. See the account created with the placeholder name

## Pre-merge author checklist

- [ ] I've clearly explained:
  - [ ] What problem this PR is solving
  - [ ] How this problem was solved
  - [ ] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
