### PR TITLE
[MMI] hides the CancelSpeedupPopover

### DIFF
--- a/ui/components/app/transaction-list-item/transaction-list-item.component.js
+++ b/ui/components/app/transaction-list-item/transaction-list-item.component.js
@@ -58,7 +58,9 @@ import { formatDateWithYearContext } from '../../../helpers/utils/util';
 import Button from '../../ui/button';
 import AdvancedGasFeePopover from '../advanced-gas-fee-popover';
 import CancelButton from '../cancel-button';
+///: BEGIN:ONLY_INCLUDE_IN(build-main,build-beta,build-flask)
 import CancelSpeedupPopover from '../cancel-speedup-popover';
+///: END:ONLY_INCLUDE_IN
 import EditGasFeePopover from '../edit-gas-fee-popover';
 import EditGasPopover from '../edit-gas-popover';
 import { MetaMetricsContext } from '../../../contexts/metametrics';
@@ -435,7 +437,11 @@ const TransactionListItem = (props) => {
         <TransactionListItemInner {...props} setEditGasMode={setEditGasMode} />
         {supportsEIP1559 && (
           <>
-            <CancelSpeedupPopover />
+            {
+              ///: BEGIN:ONLY_INCLUDE_IN(build-main,build-beta,build-flask)
+              <CancelSpeedupPopover />
+              ///: END:ONLY_INCLUDE_IN
+            }
             <EditGasFeePopover />
             <AdvancedGasFeePopover />
           </>


### PR DESCRIPTION
We don't want to allow the user to speed up a transaction, as it will cause problems at the custodian end since it can still be in progress waiting for approval.

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [x] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
