### PR TITLE
Migration 89: ensure providerConfig in state has an id property

### DIFF
--- a/app/scripts/migrations/089.test.ts
+++ b/app/scripts/migrations/089.test.ts
@@ -1,0 +1,224 @@
+import { migrate, version } from './089';
+
+jest.mock('uuid', () => {
+  const actual = jest.requireActual('uuid');
+
+  return {
+    ...actual,
+    v4: jest.fn(),
+  };
+});
+
+describe('migration #89', () => {
+  it('should update the version metadata', async () => {
+    const oldStorage = {
+      meta: {
+        version: 88,
+      },
+      data: {},
+    };
+
+    const newStorage = await migrate(oldStorage);
+    expect(newStorage.meta).toStrictEqual({
+      version,
+    });
+  });
+
+  it('should return state unaltered if there is no network controller state', async () => {
+    const oldData = {
+      other: 'data',
+    };
+    const oldStorage = {
+      meta: {
+        version: 88,
+      },
+      data: oldData,
+    };
+
+    const newStorage = await migrate(oldStorage);
+    expect(newStorage.data).toStrictEqual(oldData);
+  });
+
+  it('should return state unaltered if there is no network controller providerConfig state', async () => {
+    const oldData = {
+      other: 'data',
+      NetworkController: {
+        networkConfigurations: {
+          id1: {
+            foo: 'bar',
+          },
+        },
+      },
+    };
+    const oldStorage = {
+      meta: {
+        version: 88,
+      },
+      data: oldData,
+    };
+
+    const newStorage = await migrate(oldStorage);
+    expect(newStorage.data).toStrictEqual(oldData);
+  });
+
+  it('should return state unaltered if the providerConfig already has an id', async () => {
+    const oldData = {
+      other: 'data',
+      NetworkController: {
+        networkConfigurations: {
+          id1: {
+            foo: 'bar',
+          },
+        },
+        providerConfig: {
+          id: 'test',
+        },
+      },
+    };
+    const oldStorage = {
+      meta: {
+        version: 88,
+      },
+      data: oldData,
+    };
+
+    const newStorage = await migrate(oldStorage);
+    expect(newStorage.data).toStrictEqual(oldData);
+  });
+
+  it('should return state unaltered if there is no network config with the same rpcUrl and the providerConfig', async () => {
+    const oldData = {
+      other: 'data',
+      NetworkController: {
+        networkConfigurations: {
+          id1: {
+            foo: 'bar',
+            rpcUrl: 'http://foo.bar',
+          },
+        },
+        providerConfig: {
+          rpcUrl: 'http://baz.buzz',
+        },
+      },
+    };
+    const oldStorage = {
+      meta: {
+        version: 88,
+      },
+      data: oldData,
+    };
+
+    const newStorage = await migrate(oldStorage);
+    expect(newStorage.data).toStrictEqual(oldData);
+  });
+
+  it('should update the provider config to have the id of a network config with the same rpcUrl', async () => {
+    const oldData = {
+      other: 'data',
+      NetworkController: {
+        networkConfigurations: {
+          id1: {
+            foo: 'bar',
+            rpcUrl: 'http://foo.bar',
+            id: 'test',
+          },
+        },
+        providerConfig: {
+          rpcUrl: 'http://foo.bar',
+        },
+      },
+    };
+    const oldStorage = {
+      meta: {
+        version: 88,
+      },
+      data: oldData,
+    };
+
+    const newStorage = await migrate(oldStorage);
+    expect(newStorage.data).toStrictEqual({
+      other: 'data',
+      NetworkController: {
+        networkConfigurations: {
+          id1: {
+            foo: 'bar',
+            rpcUrl: 'http://foo.bar',
+            id: 'test',
+          },
+        },
+        providerConfig: {
+          rpcUrl: 'http://foo.bar',
+          id: 'test',
+        },
+      },
+    });
+  });
+
+  it('should update the provider config to have the id of a network config with the same rpcUrl, even if there are other networks with the same chainId', async () => {
+    const oldData = {
+      other: 'data',
+      NetworkController: {
+        networkConfigurations: {
+          id1: {
+            foo: 'bar',
+            rpcUrl: 'http://fizz.buzz',
+            id: 'FAILEDtest',
+            chainId: 1,
+          },
+          id2: {
+            foo: 'bar',
+            rpcUrl: 'http://foo.bar',
+            id: 'PASSEDtest',
+          },
+          id3: {
+            foo: 'bar',
+            rpcUrl: 'http://baz.buzz',
+            id: 'FAILEDtest',
+            chainId: 1,
+          },
+        },
+        providerConfig: {
+          rpcUrl: 'http://foo.bar',
+          chainId: 1,
+        },
+      },
+    };
+    const oldStorage = {
+      meta: {
+        version: 88,
+      },
+      data: oldData,
+    };
+
+    const newStorage = await migrate(oldStorage);
+    expect(newStorage.data).toStrictEqual({
+      other: 'data',
+      NetworkController: {
+        networkConfigurations: {
+          id1: {
+            foo: 'bar',
+            rpcUrl: 'http://fizz.buzz',
+            id: 'FAILEDtest',
+            chainId: 1,
+          },
+          id2: {
+            foo: 'bar',
+            rpcUrl: 'http://foo.bar',
+            id: 'PASSEDtest',
+          },
+          id3: {
+            foo: 'bar',
+            rpcUrl: 'http://baz.buzz',
+            id: 'FAILEDtest',
+            chainId: 1,
+          },
+        },
+        providerConfig: {
+          rpcUrl: 'http://foo.bar',
+          id: 'PASSEDtest',
+          chainId: 1,
+        },
+      },
+    });
+  });
+});

--- a/app/scripts/migrations/089.ts
+++ b/app/scripts/migrations/089.ts
@@ -37,6 +37,10 @@ function transformState(state: Record<string, unknown>) {
       return state;
     }
 
+    if (providerConfig.id) {
+      return state;
+    }
+
     for (const networkConfigurationId of Object.keys(networkConfigurations)) {
       const networkConfiguration =
         networkConfigurations[networkConfigurationId];
@@ -48,7 +52,7 @@ function transformState(state: Record<string, unknown>) {
       }
     }
 
-    if (providerConfig.id || !newProviderConfigId) {
+    if (!newProviderConfigId) {
       return state;
     }
 

--- a/app/scripts/migrations/089.ts
+++ b/app/scripts/migrations/089.ts
@@ -31,8 +31,6 @@ function transformState(state: Record<string, unknown>) {
   ) {
     const { networkConfigurations, providerConfig } = state.NetworkController;
 
-    let newProviderConfigId;
-
     if (!isObject(networkConfigurations)) {
       return state;
     }
@@ -40,6 +38,8 @@ function transformState(state: Record<string, unknown>) {
     if (providerConfig.id) {
       return state;
     }
+
+    let newProviderConfigId;
 
     for (const networkConfigurationId of Object.keys(networkConfigurations)) {
       const networkConfiguration =
@@ -49,6 +49,7 @@ function transformState(state: Record<string, unknown>) {
       }
       if (networkConfiguration.rpcUrl === providerConfig.rpcUrl) {
         newProviderConfigId = networkConfiguration.id;
+        break;
       }
     }
 

--- a/app/scripts/migrations/089.ts
+++ b/app/scripts/migrations/089.ts
@@ -1,0 +1,66 @@
+import { hasProperty, isObject } from '@metamask/utils';
+import { cloneDeep } from 'lodash';
+
+export const version = 89;
+
+/**
+ * Add an `id` to the `providerConfig` object.
+ *
+ * @param originalVersionedData - Versioned MetaMask extension state, exactly what we persist to dist.
+ * @param originalVersionedData.meta - State metadata.
+ * @param originalVersionedData.meta.version - The current state version.
+ * @param originalVersionedData.data - The persisted MetaMask state, keyed by controller.
+ * @returns Updated versioned MetaMask extension state.
+ */
+export async function migrate(originalVersionedData: {
+  meta: { version: number };
+  data: Record<string, unknown>;
+}) {
+  const versionedData = cloneDeep(originalVersionedData);
+  versionedData.meta.version = version;
+  versionedData.data = transformState(versionedData.data);
+  return versionedData;
+}
+
+function transformState(state: Record<string, unknown>) {
+  if (
+    hasProperty(state, 'NetworkController') &&
+    isObject(state.NetworkController) &&
+    hasProperty(state.NetworkController, 'providerConfig') &&
+    isObject(state.NetworkController.providerConfig)
+  ) {
+    const { networkConfigurations, providerConfig } = state.NetworkController;
+
+    let newProviderConfigId;
+
+    if (!isObject(networkConfigurations)) {
+      return state;
+    }
+
+    for (const networkConfigurationId of Object.keys(networkConfigurations)) {
+      const networkConfiguration =
+        networkConfigurations[networkConfigurationId];
+      if (!isObject(networkConfiguration)) {
+        return state;
+      }
+      if (networkConfiguration.rpcUrl === providerConfig.rpcUrl) {
+        newProviderConfigId = networkConfiguration.id;
+      }
+    }
+
+    if (providerConfig.id || !newProviderConfigId) {
+      return state;
+    }
+
+    state.NetworkController.providerConfig = {
+      ...providerConfig,
+      id: newProviderConfigId,
+    };
+
+    return {
+      ...state,
+      NetworkController: state.NetworkController,
+    };
+  }
+  return state;
+}

--- a/app/scripts/migrations/index.js
+++ b/app/scripts/migrations/index.js
@@ -92,6 +92,7 @@ import * as m085 from './085';
 import * as m086 from './086';
 import * as m087 from './087';
 import * as m088 from './088';
+import * as m089 from './089';
 
 const migrations = [
   m002,
@@ -181,6 +182,7 @@ const migrations = [
   m086,
   m087,
   m088,
+  m089,
 ];
 
 export default migrations;


### PR DESCRIPTION
Fixes https://github.com/MetaMask/metamask-extension/issues/20138

## Explanation

Bug report as summarized by CS: "we have 5 reports of “Cannot read properties of undefined (reading ‘id’)” since yesterday that appear when users are clicking on the network menu"

<img src="https://github.com/MetaMask/metamask-extension/assets/7499938/96dbaaf8-e3be-4fde-ba8a-ed0b58ad9d96" width=200 />
<img src="https://github.com/MetaMask/metamask-extension/assets/7499938/ad98064d-7e9d-40e0-b34c-76dec522a135" width=300 />


The bug can be reproduced in this way:

1. Install a MetaMask version lower than v10.28.0
2. Add a custom network
3. Update the install to v10.34.0
4. Try to open the network selection modal

this was caused by combination of two things:

1. When we started giving network configurations unique IDs, we didn't migrate the provider object that was in use at the time to all have an id . There are two migrations where we maybe should have done that: https://github.com/MetaMask/metamask-extension/blob/develop/app/scripts/migrations/082.ts and https://github.com/MetaMask/metamask-extension/blob/develop/app/scripts/migrations/083.ts
2. 
3. Then we recently made a change that assumes all providerConfig objects in state will have an id [https://github.com/MetaMask/metamask-extension/commit/719d8a499b0cb557ec217a2c8fffd8b78315ef6c#diff-45ae84764c1d49a07813[…]a116d1e0cba06cR1173-R1179](https://github.com/MetaMask/metamask-extension/commit/719d8a499b0cb557ec217a2c8fffd8b78315ef6c#diff-45ae84764c1d49a07813a91adc3351d6ed96bf9ee8fa2ae4c9a116d1e0cba06cR1173-R1179)

So anyone who selected a network prior to the version that included migration 82 (I think that might have been v10.25.0), and then later upgraded to v10.34.0 without having switched networks in between, will hit this error when trying to open the network selector (and might hit other errors elsewhere) because getCurrentNetwork can return undefined for these users (edited)

## Manual Testing Steps

1. Install a MetaMask version v10.27.0
2. Add a custom network
3. Update the install to v10.34.0
4. The network modal should open successfully

## Pre-merge author checklist

- [ ] I've clearly explained:
  - [ ] What problem this PR is solving
  - [ ] How this problem was solved
  - [ ] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
