### PR TITLE
ButtonBase linting error from IconProps

### DIFF
--- a/ui/components/component-library/button-base/button-base.types.ts
+++ b/ui/components/component-library/button-base/button-base.types.ts
@@ -5,7 +5,8 @@ import type {
 } from '../box';
 import { IconColor } from '../../../helpers/constants/design-system';
 import { TextDirection, TextProps } from '../text';
-import { IconName, IconProps } from '../icon';
+import { IconName } from '../icon';
+import type { IconProps } from '../icon';
 
 export enum ButtonBaseSize {
   Sm = 'sm',
@@ -52,7 +53,7 @@ export interface ButtonBaseStyleUtilityProps extends StyleUtilityProps {
   /**
    * iconProps accepts all the props from Icon
    */
-  startIconProps?: IconProps;
+  startIconProps?: IconProps<'span'>;
   /**
    * Add icon to end (right side) of button text passing icon name
    * The name of the icon to display. Should be one of IconName
@@ -61,11 +62,11 @@ export interface ButtonBaseStyleUtilityProps extends StyleUtilityProps {
   /**
    * iconProps accepts all the props from Icon
    */
-  endIconProps?: IconProps;
+  endIconProps?: IconProps<'span'>;
   /**
    * iconLoadingProps accepts all the props from Icon
    */
-  iconLoadingProps?: IconProps;
+  iconLoadingProps?: IconProps<'span'>;
   /**
    * Boolean to show loading spinner in button
    */


### PR DESCRIPTION
## Explanation

Linting error from `ButtonBase` and `Icon` ts PRs happening at the same time. 

Update to use `IconProps<'span'>`
_Note this is not the best permanent solution since using span limits the `as` argument._ 

<!--
Thanks for the pull request. Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues, Slack conversations, Zendesk issues, user stories, etc. reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

## Screenshots/Screencaps

<!-- If you're making a change to the UI, make sure to capture a screenshot or a short video showing off your work! -->

### Before
<img width="423" alt="Screenshot 2023-07-25 at 3 03 06 PM" src="https://github.com/MetaMask/metamask-extension/assets/26469696/cb745dc1-e802-4634-b7ad-25bdb67a48bf">

<!-- How did the UI you changed look before your changes? Drag your file(s) below this line: -->

### After
<img width="404" alt="Screenshot 2023-07-25 at 3 03 21 PM" src="https://github.com/MetaMask/metamask-extension/assets/26469696/f2078c93-8b57-4491-a46e-7b33b2ef1e8c">

<!-- How does it look now? Drag your file(s) below this line: -->

## Manual Testing Steps

Make sure it pass all tests

<!--
How should reviewers and QA manually test your changes? For instance:

- Go to this screen
- Do this
- Then do this
-->

## Pre-merge author checklist

- [X] I've clearly explained:
  - [X] What problem this PR is solving
  - [X] How this problem was solved
  - [X] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
