### PR TITLE
Fix #20184 - Prevent overflow within the activity list

### DIFF
--- a/ui/components/multichain/activity-list-item/__snapshots__/activity-list-item.test.js.snap
+++ b/ui/components/multichain/activity-list-item/__snapshots__/activity-list-item.test.js.snap
@@ -10,8 +10,7 @@ exports[`ActivityListItem should match snapshot with no props 1`] = `
       class="mm-box mm-box--display-flex mm-box--gap-4 mm-box--flex-direction-row mm-box--width-full"
     >
       <div
-        class="mm-box mm-box--display-inline-flex mm-box--width-full"
-        style="overflow: hidden;"
+        class="mm-box activity-list-item__content-container mm-box--display-inline-flex mm-box--width-full"
       >
         <div
           class="mm-box activity-list-item__detail-container mm-box--display-inline-flex mm-box--flex-direction-column mm-box--width-1/3 mm-box--sm:width-7/12"
@@ -53,8 +52,7 @@ exports[`ActivityListItem should match snapshot with props 1`] = `
         />
       </div>
       <div
-        class="mm-box mm-box--display-inline-flex mm-box--width-full"
-        style="overflow: hidden;"
+        class="mm-box activity-list-item__content-container mm-box--display-inline-flex mm-box--width-full"
       >
         <div
           class="mm-box activity-list-item__detail-container mm-box--display-inline-flex mm-box--flex-direction-column mm-box--width-1/3 mm-box--sm:width-7/12"

--- a/ui/components/multichain/activity-list-item/__snapshots__/activity-list-item.test.js.snap
+++ b/ui/components/multichain/activity-list-item/__snapshots__/activity-list-item.test.js.snap
@@ -11,6 +11,7 @@ exports[`ActivityListItem should match snapshot with no props 1`] = `
     >
       <div
         class="mm-box mm-box--display-inline-flex mm-box--width-full"
+        style="overflow: hidden;"
       >
         <div
           class="mm-box activity-list-item__detail-container mm-box--display-inline-flex mm-box--flex-direction-column mm-box--width-1/3 mm-box--sm:width-7/12"
@@ -53,6 +54,7 @@ exports[`ActivityListItem should match snapshot with props 1`] = `
       </div>
       <div
         class="mm-box mm-box--display-inline-flex mm-box--width-full"
+        style="overflow: hidden;"
       >
         <div
           class="mm-box activity-list-item__detail-container mm-box--display-inline-flex mm-box--flex-direction-column mm-box--width-1/3 mm-box--sm:width-7/12"

--- a/ui/components/multichain/activity-list-item/activity-list-item.js
+++ b/ui/components/multichain/activity-list-item/activity-list-item.js
@@ -66,7 +66,11 @@ export const ActivityListItem = ({
         gap={4}
       >
         {icon && <Box display={Display.InlineFlex}>{icon}</Box>}
-        <Box display={Display.InlineFlex} width={BlockSize.Full}>
+        <Box
+          display={Display.InlineFlex}
+          width={BlockSize.Full}
+          style={{ overflow: 'hidden' }}
+        >
           <Box
             display={Display.InlineFlex}
             width={[BlockSize.OneThird, BlockSize.SevenTwelfths]}

--- a/ui/components/multichain/activity-list-item/activity-list-item.js
+++ b/ui/components/multichain/activity-list-item/activity-list-item.js
@@ -69,7 +69,7 @@ export const ActivityListItem = ({
         <Box
           display={Display.InlineFlex}
           width={BlockSize.Full}
-          style={{ overflow: 'hidden' }}
+          className="activity-list-item__content-container"
         >
           <Box
             display={Display.InlineFlex}

--- a/ui/components/multichain/activity-list-item/index.scss
+++ b/ui/components/multichain/activity-list-item/index.scss
@@ -1,6 +1,10 @@
 .activity-list-item {
   cursor: pointer;
 
+  &__content-container {
+    overflow: hidden;
+  }
+
   &__primary-currency {
     max-width: 130px;
 


### PR DESCRIPTION
## Explanation

* Fixes #20184

This PR prevents the activity list from overflowing in small widths with long activity events.

## Screenshots/Screencaps

<img width="398" alt="SCR-20230725-pncq" src="https://github.com/MetaMask/metamask-extension/assets/46655/5908695a-beec-438a-8bfd-369996732c70">


## Manual Testing Steps

Follow steps in issue.

## Pre-merge author checklist

- [ ] I've clearly explained:
  - [ ] What problem this PR is solving
  - [ ] How this problem was solved
  - [ ] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
