### PR TITLE
Remove unused methods in the transaction controller

### DIFF
--- a/app/scripts/controllers/transactions/index.js
+++ b/app/scripts/controllers/transactions/index.js
@@ -558,27 +558,6 @@ export default class TransactionController extends EventEmitter {
   }
 
   /**
-   * updates a transaction's user settings only if the transaction state is unapproved
-   *
-   * @param {string} txId
-   * @param {object} userSettings - holds the metadata
-   * @param {string} userSettings.userEditedGasLimit
-   * @param {string} userSettings.userFeeLevel
-   * @returns {TransactionMeta} the txMeta of the updated transaction
-   */
-  updateTransactionUserSettings(txId, { userEditedGasLimit, userFeeLevel }) {
-    this._throwErrorIfNotUnapprovedTx(txId, 'updateTransactionUserSettings');
-
-    let userSettings = { userEditedGasLimit, userFeeLevel };
-    // only update what is defined
-    userSettings = pickBy(userSettings);
-
-    const note = `Update User Settings for ${txId}`;
-    this._updateTransaction(txId, userSettings, note);
-    return this._getTransaction(txId);
-  }
-
-  /**
    * append new sendFlowHistory to the transaction with id if the transaction
    * state is unapproved. Returns the updated transaction.
    *

--- a/app/scripts/controllers/transactions/index.js
+++ b/app/scripts/controllers/transactions/index.js
@@ -558,33 +558,6 @@ export default class TransactionController extends EventEmitter {
   }
 
   /**
-   * updates the estimate base fees of the transaction with id if the transaction state is unapproved
-   *
-   * @param {string} txId - transaction id
-   * @param {object} txEstimateBaseFees - holds the estimate base fees parameters
-   * @param {string} txEstimateBaseFees.estimatedBaseFee
-   * @param {string} txEstimateBaseFees.decEstimatedBaseFee
-   * @returns {TransactionMeta} the txMeta of the updated transaction
-   */
-  updateTransactionEstimatedBaseFee(
-    txId,
-    { estimatedBaseFee, decEstimatedBaseFee },
-  ) {
-    this._throwErrorIfNotUnapprovedTx(
-      txId,
-      'updateTransactionEstimatedBaseFee',
-    );
-
-    let txEstimateBaseFees = { estimatedBaseFee, decEstimatedBaseFee };
-    // only update what is defined
-    txEstimateBaseFees = pickBy(txEstimateBaseFees);
-
-    const note = `Update Transaction Estimated Base Fees for ${txId}`;
-    this._updateTransaction(txId, txEstimateBaseFees, note);
-    return this._getTransaction(txId);
-  }
-
-  /**
    * updates a transaction's user settings only if the transaction state is unapproved
    *
    * @param {string} txId

--- a/app/scripts/controllers/transactions/index.test.js
+++ b/app/scripts/controllers/transactions/index.test.js
@@ -3021,17 +3021,6 @@ describe('Transaction Controller', function () {
       assert.equal(result.estimateUsed, '0x0055');
     });
 
-    it('updates transaction user settings', function () {
-      txController.updateTransactionUserSettings('1', {
-        userEditedGasLimit: '0x0088',
-        userFeeLevel: 'high',
-      });
-
-      const result = txStateManager.getTransaction('1');
-      assert.equal(result.userEditedGasLimit, '0x0088');
-      assert.equal(result.userFeeLevel, 'high');
-    });
-
     it('should not update and should throw error if status is not type "unapproved"', function () {
       txStateManager.addTransaction({
         id: '4',

--- a/app/scripts/controllers/transactions/index.test.js
+++ b/app/scripts/controllers/transactions/index.test.js
@@ -3021,16 +3021,6 @@ describe('Transaction Controller', function () {
       assert.equal(result.estimateUsed, '0x0055');
     });
 
-    it('updates estimated base fee', function () {
-      txController.updateTransactionEstimatedBaseFee('1', {
-        estimatedBaseFee: '0x0066',
-        decEstimatedBaseFee: '66',
-      });
-      const result = txStateManager.getTransaction('1');
-      assert.equal(result.estimatedBaseFee, '0x0066');
-      assert.equal(result.decEstimatedBaseFee, '66');
-    });
-
     it('updates transaction user settings', function () {
       txController.updateTransactionUserSettings('1', {
         userEditedGasLimit: '0x0088',


### PR DESCRIPTION
## Explanation
In line with the ongoing initiative to align the transaction controller between the extension and the core repository, this pull request addresses code maintainability by removing two unused methods.

Removed Methods:

- `updateTransactionUserSettings`
- `updateTransactionEstimatedBaseFee`

These methods are no longer being used, and their removal will help streamline the codebase and ensure better maintainability going forward. The changes have been carefully tested to avoid any impact on existing functionalities.

<!--
Thanks for the pull request. Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues, Slack conversations, Zendesk issues, user stories, etc. reviewers should consult to understand this pull request better? For instance:


* See: #67890
-->
* Fixes https://github.com/MetaMask/MetaMask-planning/issues/957

<!-- How does it look now? Drag your file(s) below this line: -->

## Manual Testing Steps
- Go to [Test dApp](https://metamask.github.io/test-dapp/)
- Perform all existing transaction support

<!--
How should reviewers and QA manually test your changes? For instance:

- Go to this screen
- Do this
- Then do this
-->

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
