### PR TITLE
[MMI] Adds mmi build step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -206,10 +206,6 @@ workflows:
           requires:
             - prep-deps
             - prep-build-desktop
-      - test-mozilla-lint-mmi:
-          requires:
-            - prep-deps
-            - prep-build-mmi
       - test-mozilla-lint-flask:
           requires:
             - prep-deps
@@ -236,7 +232,6 @@ workflows:
             - test-mozilla-lint
             - test-mozilla-lint-desktop
             - test-mozilla-lint-flask
-            - test-mozilla-lint-mmi
             - test-e2e-chrome
             - test-e2e-firefox
             - test-e2e-chrome-snaps
@@ -1283,22 +1278,6 @@ jobs:
       - run: *shallow-git-clone
       - attach_workspace:
           at: .
-      - run:
-          name: test:mozilla-lint
-          command: NODE_OPTIONS=--max_old_space_size=3072 yarn mozilla-lint
-
-  test-mozilla-lint-mmi:
-    executor: node-browsers
-    steps:
-      - run: *shallow-git-clone
-      - attach_workspace:
-          at: .
-      - run:
-          name: Move mmi build to dist
-          command: mv ./dist-mmi ./dist
-      - run:
-          name: Move mmi zips to builds
-          command: mv ./builds-mmi ./builds
       - run:
           name: test:mozilla-lint
           command: NODE_OPTIONS=--max_old_space_size=3072 yarn mozilla-lint

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,6 +101,9 @@ workflows:
               build-type: [main, beta, flask, mmi, desktop]
           requires:
             - prep-deps
+      - prep-build-mmi:
+          requires:
+            - prep-deps
       - prep-build:
           requires:
             - prep-deps
@@ -186,6 +189,9 @@ workflows:
               ignore: master
           requires:
             - prep-build-desktop
+      - validate-source-maps-mmi:
+          requires:
+            - prep-build-mmi
       - validate-source-maps-flask:
           requires:
             - prep-build-flask
@@ -200,6 +206,10 @@ workflows:
           requires:
             - prep-deps
             - prep-build-desktop
+      - test-mozilla-lint-mmi:
+          requires:
+            - prep-deps
+            - prep-build-mmi
       - test-mozilla-lint-flask:
           requires:
             - prep-deps
@@ -245,6 +255,7 @@ workflows:
             - prep-build
             - trigger-beta-build
             - prep-build-desktop
+            - prep-build-mmi
             - prep-build-flask
             - prep-build-storybook
             - prep-build-ts-migration-dashboard
@@ -261,6 +272,7 @@ workflows:
             - prep-deps
             - prep-build
             - prep-build-desktop
+            - prep-build-mmi
             - prep-build-flask
             - all-tests-pass
       - job-publish-storybook:
@@ -471,6 +483,49 @@ jobs:
           paths:
             - dist-desktop
             - builds-desktop
+
+  prep-build-mmi:
+    executor: node-browsers-medium-plus
+    steps:
+      - run: *shallow-git-clone
+      - attach_workspace:
+          at: .
+      - when:
+          condition:
+            not:
+              matches:
+                pattern: /^master$/
+                value: << pipeline.git.branch >>
+          steps:
+            - run:
+                name: build:dist
+                command: yarn build --build-type mmi dist
+      - when:
+          condition:
+            matches:
+              pattern: /^master$/
+              value: << pipeline.git.branch >>
+          steps:
+            - run:
+                name: build:prod
+                command: yarn build --build-type mmi prod
+      - run:
+          name: build:debug
+          command: find dist/ -type f -exec md5sum {} \; | sort -k 2
+      - run:
+          name: Move mmi build to 'dist-mmi' to avoid conflict with production build
+          command: mv ./dist ./dist-mmi
+      - run:
+          name: Move mmi zips to 'builds-mmi' to avoid conflict with production build
+          command: mv ./builds ./builds-mmi
+      - persist_to_workspace:
+          root: .
+          paths:
+            - dist-mmi
+            - builds-mmi
+      - store_artifacts:
+          path: builds-mmi
+          destination: builds-mmi
 
   prep-build-flask:
     executor: node-browsers-medium-plus

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -232,6 +232,7 @@ workflows:
             - validate-source-maps-beta
             - validate-source-maps-desktop
             - validate-source-maps-flask
+            - validate-source-maps-mmi
             - test-mozilla-lint
             - test-mozilla-lint-desktop
             - test-mozilla-lint-flask
@@ -1239,6 +1240,22 @@ jobs:
       - run:
           name: Move desktop zips to builds
           command: mv ./builds-desktop ./builds
+      - run:
+          name: Validate source maps
+          command: yarn validate-source-maps
+
+  validate-source-maps-mmi:
+    executor: node-browsers
+    steps:
+      - run: *shallow-git-clone
+      - attach_workspace:
+          at: .
+      - run:
+          name: Move mmi build to dist
+          command: mv ./dist-mmi ./dist
+      - run:
+          name: Move mmi zips to builds
+          command: mv ./builds-mmi ./builds
       - run:
           name: Validate source maps
           command: yarn validate-source-maps

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -236,6 +236,7 @@ workflows:
             - test-mozilla-lint
             - test-mozilla-lint-desktop
             - test-mozilla-lint-flask
+            - test-mozilla-lint-mmi
             - test-e2e-chrome
             - test-e2e-firefox
             - test-e2e-chrome-snaps
@@ -1282,6 +1283,22 @@ jobs:
       - run: *shallow-git-clone
       - attach_workspace:
           at: .
+      - run:
+          name: test:mozilla-lint
+          command: NODE_OPTIONS=--max_old_space_size=3072 yarn mozilla-lint
+
+  test-mozilla-lint-mmi:
+    executor: node-browsers
+    steps:
+      - run: *shallow-git-clone
+      - attach_workspace:
+          at: .
+      - run:
+          name: Move mmi build to dist
+          command: mv ./dist-mmi ./dist
+      - run:
+          name: Move mmi zips to builds
+          command: mv ./builds-mmi ./builds
       - run:
           name: test:mozilla-lint
           command: NODE_OPTIONS=--max_old_space_size=3072 yarn mozilla-lint


### PR DESCRIPTION
This adds the `prep-build-mmi` step, it's necessary and convenient for us to have the artefact generated, it also validates that any change introduced breaks the build.
[CircleCI run](https://app.circleci.com/pipelines/github/MetaMask/metamask-extension/52465/workflows/baf15fce-51f6-408a-bafc-e36e89cd9297/jobs/1534744/artifacts)

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [x] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
