### PR TITLE
fix: removed translation key to stop pushing files to Crowdin

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -4,9 +4,10 @@
 
 "preserve_hierarchy": true
 
+# This group identifies the files that should be the source for translations. If a translations key:value is used this
+# indicates that translations from the idneified files will be pushed up to Crowdin.
 files:
   - "source" : "app/_locales/en/messages.json"
-    "translation" : "/app/_locales/%two_letters_code%/%original_file_name%"
     "languages_mapping":
       "two_letters_code":
         "zh-CN": "zh_CN"


### PR DESCRIPTION
## Explanation

This PR removes the pushing of translation files up to Crowdin. It was identified that this was overwriting and conflicting with the Blend translators causing errors in translation.

As a result of this PR, changes for translations should ONLY be make in the en.json file. Corrections to other languages should be submitted through the Crowdin translation platform.

## Screenshots/Screencaps

<!-- If you're making a change to the UI, make sure to capture a screenshot or a short video showing off your work! -->

### Before

The file mapping to this path `"/app/_locales/%two_letters_code%/%original_file_name%"` would be pushed up to Crowdin and conflict with the translators. 

### After

Now only the en.json file is pushed up to be the source of translations. Corrections to other languages should be submitted through the Crowdin translation platform.

## Manual Testing Steps

NA - this change only impacts the translation GH action.

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
