### PR TITLE
Fix #19950 - Use removable property to determine if network should be removable in Network Menu List

### DIFF
--- a/ui/components/multichain/network-list-menu/network-list-menu.js
+++ b/ui/components/multichain/network-list-menu/network-list-menu.js
@@ -11,7 +11,7 @@ import {
   setProviderType,
   toggleNetworkMenu,
 } from '../../../store/actions';
-import { CHAIN_IDS, TEST_CHAINS } from '../../../../shared/constants/network';
+import { TEST_CHAINS } from '../../../../shared/constants/network';
 import {
   getShowTestNetworks,
   getCurrentChainId,
@@ -46,12 +46,6 @@ import {
   getCompletedOnboarding,
   isLineaMainnetNetworkReleased,
 } from '../../../ducks/metamask/metamask';
-
-const UNREMOVABLE_CHAIN_IDS = [
-  CHAIN_IDS.MAINNET,
-  CHAIN_IDS.LINEA_MAINNET,
-  ...TEST_CHAINS,
-];
 
 export const NetworkListMenu = ({ onClose }) => {
   const t = useI18nContext();
@@ -88,9 +82,7 @@ export const NetworkListMenu = ({ onClose }) => {
       }
 
       const isCurrentNetwork = currentNetwork.id === network.id;
-
-      const canDeleteNetwork =
-        !isCurrentNetwork && !UNREMOVABLE_CHAIN_IDS.includes(network.chainId);
+      const canDeleteNetwork = !isCurrentNetwork && network.removable;
 
       return (
         <NetworkListItem

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -1211,6 +1211,7 @@ export function getTestNetworks(state) {
       providerType: NETWORK_TYPES.GOERLI,
       ticker: TEST_NETWORK_TICKER_MAP[NETWORK_TYPES.GOERLI],
       id: NETWORK_TYPES.GOERLI,
+      removable: false,
     },
     {
       chainId: CHAIN_IDS.SEPOLIA,
@@ -1219,6 +1220,7 @@ export function getTestNetworks(state) {
       providerType: NETWORK_TYPES.SEPOLIA,
       ticker: TEST_NETWORK_TICKER_MAP[NETWORK_TYPES.SEPOLIA],
       id: NETWORK_TYPES.SEPOLIA,
+      removable: false,
     },
     {
       chainId: CHAIN_IDS.LINEA_GOERLI,
@@ -1230,11 +1232,12 @@ export function getTestNetworks(state) {
       providerType: NETWORK_TYPES.LINEA_GOERLI,
       ticker: TEST_NETWORK_TICKER_MAP[NETWORK_TYPES.LINEA_GOERLI],
       id: NETWORK_TYPES.LINEA_GOERLI,
+      removable: false,
     },
     // Localhosts
-    ...Object.values(networkConfigurations).filter(
-      ({ chainId }) => chainId === CHAIN_IDS.LOCALHOST,
-    ),
+    ...Object.values(networkConfigurations)
+      .filter(({ chainId }) => chainId === CHAIN_IDS.LOCALHOST)
+      .map((network) => ({ ...network, removable: true })),
   ];
 }
 
@@ -1253,6 +1256,7 @@ export function getNonTestNetworks(state) {
       providerType: NETWORK_TYPES.MAINNET,
       ticker: CURRENCY_SYMBOLS.ETH,
       id: NETWORK_TYPES.MAINNET,
+      removable: false,
     },
     {
       chainId: CHAIN_IDS.LINEA_MAINNET,
@@ -1264,11 +1268,12 @@ export function getNonTestNetworks(state) {
       providerType: NETWORK_TYPES.LINEA_MAINNET,
       ticker: TEST_NETWORK_TICKER_MAP[NETWORK_TYPES.LINEA_MAINNET],
       id: NETWORK_TYPES.LINEA_MAINNET,
+      removable: false,
     },
     // Custom networks added by the user
-    ...Object.values(networkConfigurations).filter(
-      ({ chainId }) => ![CHAIN_IDS.LOCALHOST].includes(chainId),
-    ),
+    ...Object.values(networkConfigurations)
+      .filter(({ chainId }) => ![CHAIN_IDS.LOCALHOST].includes(chainId))
+      .map((network) => ({ ...network, removable: true })),
   ];
 }
 

--- a/ui/selectors/selectors.test.js
+++ b/ui/selectors/selectors.test.js
@@ -4,6 +4,7 @@ import { KeyringType } from '../../shared/constants/keyring';
 import {
   CHAIN_IDS,
   LOCALHOST_DISPLAY_NAME,
+  NETWORK_TYPES,
 } from '../../shared/constants/network';
 import * as selectors from './selectors';
 
@@ -313,6 +314,33 @@ describe('Selectors', () => {
       });
       const lastItem = networks.pop();
       expect(lastItem.nickname.toLowerCase()).toContain('localhost');
+    });
+
+    it('properly assigns a network as removable', () => {
+      const networks = selectors.getAllNetworks({
+        metamask: {
+          preferences: {
+            showTestNetworks: true,
+          },
+          networkConfigurations: {
+            'some-config-name': {
+              chainId: CHAIN_IDS.LOCALHOST,
+              nickname: LOCALHOST_DISPLAY_NAME,
+              id: 'some-config-name',
+            },
+          },
+        },
+      });
+
+      const mainnet = networks.find(
+        (network) => network.id === NETWORK_TYPES.MAINNET,
+      );
+      expect(mainnet.removable).toBe(false);
+
+      const customNetwork = networks.find(
+        (network) => network.id === 'some-config-name',
+      );
+      expect(customNetwork.removable).toBe(true);
     });
   });
 


### PR DESCRIPTION
## Explanation
Basing whether a network should be removable or not by chainId is insufficient, as a user could have a custom Ethereum RPC  with a chainId like `0x1`.  This PR adds a 'removable' property to network objects so that we aren't determining removability in the NetworkMenu -- instead we're doing it in the selector.

* Fixes #19950

## ToDo
- [ ] Add an end to end test

## Screenshots/Screencaps

<img width="417" alt="SCR-20230726-pdlf" src="https://github.com/MetaMask/metamask-extension/assets/46655/2b681f27-38be-4d26-ba3e-8ef353472e13">

## Manual Testing Steps

1.  Add a bunch of custom networks to your MetaMask install
2. Hover over Ethereum Mainnet, Goerli, Linea ... don't see delete icon
3. Hover over the custom networks you've added ... see the delete icon

## Pre-merge author checklist

- [ ] I've clearly explained:
  - [ ] What problem this PR is solving
  - [ ] How this problem was solved
  - [ ] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
