### PR TITLE
UX: Remove portfolio from global menu

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -3248,9 +3248,6 @@
   "portfolioDashboard": {
     "message": "Portfolio Dashboard"
   },
-  "portfolioView": {
-    "message": "Portfolio view"
-  },
   "preferredLedgerConnectionType": {
     "message": "Preferred Ledger connection type",
     "description": "A header for a dropdown in Settings > Advanced. Appears above the ledgerConnectionPreferenceDescription message"

--- a/ui/components/multichain/global-menu/global-menu.js
+++ b/ui/components/multichain/global-menu/global-menu.js
@@ -33,9 +33,6 @@ import {
   MetaMetricsEventCategory,
   MetaMetricsContextProp,
 } from '../../../../shared/constants/metametrics';
-///: BEGIN:ONLY_INCLUDE_IN(build-main,build-beta,build-flask)
-import { getPortfolioUrl } from '../../../helpers/utils/portfolio';
-///: END:ONLY_INCLUDE_IN
 ///: BEGIN:ONLY_INCLUDE_IN(build-mmi)
 import {
   getMmiPortfolioEnabled,
@@ -145,40 +142,6 @@ export const GlobalMenu = ({ closeMenu, anchorElement }) => {
         )
         ///: END:ONLY_INCLUDE_IN
       }
-
-      {
-        ///: BEGIN:ONLY_INCLUDE_IN(build-main,build-beta,build-flask)
-        <MenuItem
-          iconName={IconName.Diagram}
-          onClick={() => {
-            const portfolioUrl = getPortfolioUrl('', 'ext', metaMetricsId);
-            global.platform.openTab({
-              url: portfolioUrl,
-            });
-            trackEvent(
-              {
-                category: MetaMetricsEventCategory.Home,
-                event: MetaMetricsEventName.PortfolioLinkClicked,
-                properties: {
-                  url: portfolioUrl,
-                  location: METRICS_LOCATION,
-                },
-              },
-              {
-                contextPropsIntoEventProperties: [
-                  MetaMetricsContextProp.PageTitle,
-                ],
-              },
-            );
-            closeMenu();
-          }}
-          data-testid="global-menu-portfolio"
-        >
-          {t('portfolioView')}
-        </MenuItem>
-        ///: END:ONLY_INCLUDE_IN
-      }
-
       {getEnvironmentType() === ENVIRONMENT_TYPE_FULLSCREEN ? null : (
         <MenuItem
           iconName={IconName.Expand}

--- a/ui/components/multichain/global-menu/global-menu.js
+++ b/ui/components/multichain/global-menu/global-menu.js
@@ -40,7 +40,9 @@ import {
 } from '../../../selectors/institutional/selectors';
 ///: END:ONLY_INCLUDE_IN
 import {
+  ///: BEGIN:ONLY_INCLUDE_IN(build-mmi)
   getMetaMetricsId,
+  ///: END:ONLY_INCLUDE_IN(build-mmi)
   getSelectedAddress,
   ///: BEGIN:ONLY_INCLUDE_IN(snaps)
   getUnreadNotificationsCount,
@@ -66,13 +68,13 @@ export const GlobalMenu = ({ closeMenu, anchorElement }) => {
   const dispatch = useDispatch();
   const trackEvent = useContext(MetaMetricsContext);
   const history = useHistory();
-  const metaMetricsId = useSelector(getMetaMetricsId);
   const address = useSelector(getSelectedAddress);
 
   const hasUnapprovedTransactions = useSelector(
     (state) => Object.keys(state.metamask.unapprovedTxs).length > 0,
   );
   ///: BEGIN:ONLY_INCLUDE_IN(build-mmi)
+  const metaMetricsId = useSelector(getMetaMetricsId);
   const mmiPortfolioUrl = useSelector(getMmiPortfolioUrl);
   const mmiPortfolioEnabled = useSelector(getMmiPortfolioEnabled);
   ///: END:ONLY_INCLUDE_IN

--- a/ui/components/multichain/global-menu/global-menu.test.js
+++ b/ui/components/multichain/global-menu/global-menu.test.js
@@ -33,18 +33,6 @@ describe('AccountListItem', () => {
     });
   });
 
-  it('opens the portfolio site when item is clicked', async () => {
-    global.platform = { openTab: jest.fn() };
-
-    const { getByTestId } = render();
-    fireEvent.click(getByTestId('global-menu-portfolio'));
-    await waitFor(() => {
-      expect(global.platform.openTab).toHaveBeenCalledWith({
-        url: `/?metamaskEntry=ext&metametricsId=`,
-      });
-    });
-  });
-
   it('opens the support site when item is clicked', async () => {
     global.platform = { openTab: jest.fn() };
 


### PR DESCRIPTION
## Explanation

Fixes https://github.com/MetaMask/MetaMask-planning/issues/1069

## Screenshots/Screencaps

<img width="255" alt="SCR-20230726-podq" src="https://github.com/MetaMask/metamask-extension/assets/46655/4e188cbc-31e0-422e-a519-df7647852045">


## Manual Testing Steps

1.  Open the Global Menu
2. No more Portfolio link

## Pre-merge author checklist

- [ ] I've clearly explained:
  - [ ] What problem this PR is solving
  - [ ] How this problem was solved
  - [ ] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
