### PR TITLE
added deprecation message and comment in ui/check-box

### DIFF
--- a/ui/components/ui/check-box/README.mdx
+++ b/ui/components/ui/check-box/README.mdx
@@ -2,12 +2,12 @@ import { Story, Canvas, ArgsTable } from '@storybook/addon-docs';
 
 import CheckBox from '.';
 
-# Checkbox
+# Check Box(Deprecated)
 
 A small interactive box that can be toggled by the user to indicate an affirmative or negative choice.
 
 <Canvas>
-  <Story id="components-ui-check-box--default-story" />
+  <Story id="components-ui-check-box-deprecated--default-story" />
 </Canvas>
 
 ## Props

--- a/ui/components/ui/check-box/check-box.component.js
+++ b/ui/components/ui/check-box/check-box.component.js
@@ -9,7 +9,14 @@ const CHECKBOX_STATE = {
 };
 
 export const { CHECKED, INDETERMINATE, UNCHECKED } = CHECKBOX_STATE;
-
+/**
+ * @deprecated The `<Checkbox />` component has been deprecated in favor of the new `<Checkbox>` component from the component-library.
+ * Please update your code to use the new `<Checkbox>` component instead, which can be found at ui/components/component-library/checkbox/checkbox.tsx.
+ * You can find documentation for the new Checkbox component in the MetaMask Storybook:
+ * {@link https://metamask.github.io/metamask-storybook/?path=/docs/components-componentlibrary-checkbox--docs}
+ * If you would like to help with the replacement of the old Checkbox component, please submit a pull request against this GitHub issue:
+ * {@link https://github.com/MetaMask/metamask-extension/issues/20163}
+ */
 const CheckBox = ({
   className,
   disabled,

--- a/ui/components/ui/check-box/check-box.component.js
+++ b/ui/components/ui/check-box/check-box.component.js
@@ -9,14 +9,16 @@ const CHECKBOX_STATE = {
 };
 
 export const { CHECKED, INDETERMINATE, UNCHECKED } = CHECKBOX_STATE;
+
 /**
- * @deprecated The `<Checkbox />` component has been deprecated in favor of the new `<Checkbox>` component from the component-library.
+ * @deprecated The `<CheckBox />` component has been deprecated in favor of the new `<Checkbox>` component from the component-library.
  * Please update your code to use the new `<Checkbox>` component instead, which can be found at ui/components/component-library/checkbox/checkbox.tsx.
  * You can find documentation for the new Checkbox component in the MetaMask Storybook:
  * {@link https://metamask.github.io/metamask-storybook/?path=/docs/components-componentlibrary-checkbox--docs}
- * If you would like to help with the replacement of the old Checkbox component, please submit a pull request against this GitHub issue:
+ * If you would like to help with the replacement of the old CheckBox component, please submit a pull request against this GitHub issue:
  * {@link https://github.com/MetaMask/metamask-extension/issues/20163}
  */
+
 const CheckBox = ({
   className,
   disabled,

--- a/ui/components/ui/check-box/check-box.stories.js
+++ b/ui/components/ui/check-box/check-box.stories.js
@@ -15,7 +15,7 @@ const checkboxOptions = {
 };
 
 export default {
-  title: 'Components/UI/Check Box',
+  title: 'Components/UI/Check Box(Deprecated)',
 
   component: CheckBox,
   parameters: {


### PR DESCRIPTION
## Explanation

As per the comments on this PR https://github.com/MetaMask/metamask-extension/pull/20198, addressing the issue https://github.com/MetaMask/metamask-extension/issues/20164, I have broken down the changes into smaller PR. This one addresses the deprecated message that needs to be added to `ui/check-box`

* Fixes #20164

## Screenshots/Screencaps

### After

![Screenshot 2023-07-27 at 4 37 20 PM](https://github.com/MetaMask/metamask-extension/assets/8112138/7e178c6b-d280-4ac9-9082-08b52a3ea25d)

<img width="1393" alt="Screenshot 2023-07-27 at 4 42 25 PM" src="https://github.com/MetaMask/metamask-extension/assets/8112138/6a2b2a6d-d1d5-4b5d-9352-8d51e9b3da77">


## Manual Testing Steps
- Pull this branch
- Search `<CheckBox` 
- See the instance has a strike-through and on hover shows the deprecation message

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
