### PR TITLE
Remove unnecessary log from accept approval

### DIFF
--- a/app/scripts/controllers/app-state.js
+++ b/app/scripts/controllers/app-state.js
@@ -452,7 +452,6 @@ export default class AppStateController extends EventEmitter {
 
   _acceptApproval() {
     if (!this._approvalRequestId) {
-      log.error('Attempted to accept missing unlock approval request');
       return;
     }
     try {
@@ -461,7 +460,7 @@ export default class AppStateController extends EventEmitter {
         this._approvalRequestId,
       );
     } catch (error) {
-      log.error('Failed to accept transaction approval request', error);
+      log.error('Failed to accept approval request', error);
     }
 
     this._approvalRequestId = null;

--- a/app/scripts/controllers/app-state.js
+++ b/app/scripts/controllers/app-state.js
@@ -460,7 +460,7 @@ export default class AppStateController extends EventEmitter {
         this._approvalRequestId,
       );
     } catch (error) {
-      log.error('Failed to accept approval request', error);
+      log.error('Failed to unlock approval request', error);
     }
 
     this._approvalRequestId = null;

--- a/app/scripts/controllers/app-state.test.js
+++ b/app/scripts/controllers/app-state.test.js
@@ -1,9 +1,6 @@
 import { ObservableStore } from '@metamask/obs-store';
-import log from 'loglevel';
 import { ORIGIN_METAMASK } from '../../../shared/constants/app';
 import AppStateController from './app-state';
-
-jest.mock('loglevel');
 
 let appStateController, mockStore;
 
@@ -145,52 +142,6 @@ describe('AppStateController', () => {
       expect(appStateController.messagingSystem.call).toHaveBeenCalledWith(
         'ApprovalController:acceptRequest',
         expect.any(String),
-      );
-    });
-
-    it('logs if rejecting approval request throws', async () => {
-      appStateController._approvalRequestId = 'mock-approval-request-id';
-      appStateController = new AppStateController({
-        addUnlockListener: jest.fn(),
-        isUnlocked: jest.fn(() => true),
-        onInactiveTimeout: jest.fn(),
-        showUnlockRequest: jest.fn(),
-        preferencesStore: {
-          subscribe: jest.fn(),
-          getState: jest.fn(() => ({
-            preferences: {
-              autoLockTimeLimit: 0,
-            },
-          })),
-        },
-        qrHardwareStore: {
-          subscribe: jest.fn(),
-        },
-        messenger: {
-          call: jest.fn(() => {
-            throw new Error('mock error');
-          }),
-        },
-      });
-
-      appStateController.handleUnlock();
-
-      expect(log.error).toHaveBeenCalledTimes(1);
-      expect(log.error).toHaveBeenCalledWith(
-        'Attempted to accept missing unlock approval request',
-      );
-    });
-
-    it('returns without call messenger if no approval request in pending', async () => {
-      const emitSpy = jest.spyOn(appStateController, 'emit');
-
-      appStateController.handleUnlock();
-
-      expect(emitSpy).toHaveBeenCalledTimes(0);
-      expect(appStateController.messagingSystem.call).toHaveBeenCalledTimes(0);
-      expect(log.error).toHaveBeenCalledTimes(1);
-      expect(log.error).toHaveBeenCalledWith(
-        'Attempted to accept missing unlock approval request',
       );
     });
   });


### PR DESCRIPTION
## Explanation
To give more context the changes in the PR were part of the initiative to standardise how the popup is triggered in the extension and to favour the approval controller as the single route to confirmation rather than passing callbacks around.

Once an unlock is triggered and there is no approval request it was logging:
```
Attempted to accept missing unlock approval request
_acceptApproval	@	app-state.js:422
```

That log is harmless, however, is best to remove it as it does not add much to debug.

<!--
Thanks for the pull request. Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues, Slack conversations, Zendesk issues, user stories, etc. reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->
Fixes https://github.com/MetaMask/MetaMask-planning/issues/904

## Manual Testing Steps
Restart your extension so you have sure it's locked
Go to [dapp test page](https://metamask.github.io/test-dapp/)
Try to connect
A popup will be displayed to unlock MM and connect
result: Operation should work as usual, open confirmation to user input the password, connecting to the dapp test and enabling to perform any action there.

<!--
How should reviewers and QA manually test your changes? For instance:

- Go to this screen
- Do this
- Then do this
-->

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
