### PR TITLE
updated to new checbox in unconnected-account-alert

### DIFF
--- a/ui/components/app/alerts/unconnected-account-alert/unconnected-account-alert.js
+++ b/ui/components/app/alerts/unconnected-account-alert/unconnected-account-alert.js
@@ -18,11 +18,10 @@ import {
 import { isExtensionUrl, getURLHost } from '../../../../helpers/utils/util';
 import Popover from '../../../ui/popover';
 import Button from '../../../ui/button';
-import Checkbox from '../../../ui/check-box';
 import Tooltip from '../../../ui/tooltip';
 import ConnectedAccountsList from '../../connected-accounts-list';
 import { useI18nContext } from '../../../../hooks/useI18nContext';
-import { Icon, IconName } from '../../../component-library';
+import { Icon, IconName, Checkbox } from '../../../component-library';
 
 const { ERROR, LOADING } = ALERT_STATE;
 
@@ -55,9 +54,9 @@ const UnconnectedAccountAlert = () => {
         <div className="unconnected-account-alert__checkbox-wrapper">
           <Checkbox
             id="unconnectedAccount_dontShowThisAgain"
-            checked={dontShowThisAgain}
+            isChecked={dontShowThisAgain}
             className="unconnected-account-alert__checkbox"
-            onClick={() => setDontShowThisAgain((checked) => !checked)}
+            onChange={() => setDontShowThisAgain((checked) => !checked)}
           />
           <label
             className="unconnected-account-alert__checkbox-label"


### PR DESCRIPTION
## Explanation

<!--
Thanks for the pull request. Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues, Slack conversations, Zendesk issues, user stories, etc. reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->
As per the comments on this PR https://github.com/MetaMask/metamask-extension/pull/20198, addressing the issue https://github.com/MetaMask/metamask-extension/issues/20164, I have broken down the changes into smaller PR. This one addresses replacing the checkbox in `ui/components/app/alerts/unconnected-account-alert/unconnected-account-alert.js`
## Screenshots/Screencaps

<!-- If you're making a change to the UI, make sure to capture a screenshot or a short video showing off your work! -->

### Before

<!-- How did the UI you changed look before your changes? Drag your file(s) below this line: -->

### After

<!-- How does it look now? Drag your file(s) below this line: -->

## Manual Testing Steps

<!--
How should reviewers and QA manually test your changes? For instance:

- Go to this screen
- Do this
- Then do this
-->

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
