### PR TITLE
UX: Remove the 'Source' and 'Link' URLs from NFT detail

### DIFF
--- a/app/_locales/de/messages.json
+++ b/app/_locales/de/messages.json
@@ -3255,9 +3255,6 @@
   "somethingWentWrong": {
     "message": "Hoppla! Da hat etwas nicht geklappt."
   },
-  "source": {
-    "message": "Quelle"
-  },
   "speedUp": {
     "message": "Beschleunigen"
   },

--- a/app/_locales/el/messages.json
+++ b/app/_locales/el/messages.json
@@ -3252,9 +3252,6 @@
   "somethingWentWrong": {
     "message": "Ουπς! Κάτι πήγε στραβά."
   },
-  "source": {
-    "message": "Πηγή"
-  },
   "speedUp": {
     "message": "Επιτάχυνση"
   },

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -4094,9 +4094,6 @@
   "somethingWentWrong": {
     "message": "Oops! Something went wrong."
   },
-  "source": {
-    "message": "Source"
-  },
   "speedUp": {
     "message": "Speed up"
   },

--- a/app/_locales/es/messages.json
+++ b/app/_locales/es/messages.json
@@ -3255,9 +3255,6 @@
   "somethingWentWrong": {
     "message": "Lo lamentamos, se produjo un error."
   },
-  "source": {
-    "message": "Fuente"
-  },
   "speedUp": {
     "message": "Acelerar"
   },

--- a/app/_locales/es_419/messages.json
+++ b/app/_locales/es_419/messages.json
@@ -2071,9 +2071,6 @@
   "somethingWentWrong": {
     "message": "Lo lamentamos, se produjo un error."
   },
-  "source": {
-    "message": "Fuente"
-  },
   "speedUp": {
     "message": "Acelerar"
   },

--- a/app/_locales/fr/messages.json
+++ b/app/_locales/fr/messages.json
@@ -3255,9 +3255,6 @@
   "somethingWentWrong": {
     "message": "Oups !  Quelque chose a mal tourné. "
   },
-  "source": {
-    "message": "Source"
-  },
   "speedUp": {
     "message": "Accélérer"
   },

--- a/app/_locales/hi/messages.json
+++ b/app/_locales/hi/messages.json
@@ -3255,9 +3255,6 @@
   "somethingWentWrong": {
     "message": "ओह! कुछ गलत हो गया।"
   },
-  "source": {
-    "message": "स्रोत"
-  },
   "speedUp": {
     "message": "जल्दी करें"
   },

--- a/app/_locales/id/messages.json
+++ b/app/_locales/id/messages.json
@@ -3255,9 +3255,6 @@
   "somethingWentWrong": {
     "message": "Ups! Ada yang salah."
   },
-  "source": {
-    "message": "Sumber"
-  },
   "speedUp": {
     "message": "Percepat"
   },

--- a/app/_locales/ja/messages.json
+++ b/app/_locales/ja/messages.json
@@ -3255,9 +3255,6 @@
   "somethingWentWrong": {
     "message": "申し訳ありません。問題が発生しました。"
   },
-  "source": {
-    "message": "ソース"
-  },
   "speedUp": {
     "message": "スピードアップ"
   },

--- a/app/_locales/ko/messages.json
+++ b/app/_locales/ko/messages.json
@@ -3255,9 +3255,6 @@
   "somethingWentWrong": {
     "message": "죄송합니다! 문제가 생겼습니다."
   },
-  "source": {
-    "message": "소스"
-  },
   "speedUp": {
     "message": "가속화"
   },

--- a/app/_locales/pt/messages.json
+++ b/app/_locales/pt/messages.json
@@ -3255,9 +3255,6 @@
   "somethingWentWrong": {
     "message": "Ops! Algo deu errado."
   },
-  "source": {
-    "message": "Origem"
-  },
   "speedUp": {
     "message": "Acelerar"
   },

--- a/app/_locales/pt_BR/messages.json
+++ b/app/_locales/pt_BR/messages.json
@@ -2071,9 +2071,6 @@
   "somethingWentWrong": {
     "message": "Opa! Ocorreu algum erro."
   },
-  "source": {
-    "message": "Fonte"
-  },
   "speedUp": {
     "message": "Acelerar"
   },

--- a/app/_locales/ru/messages.json
+++ b/app/_locales/ru/messages.json
@@ -3255,9 +3255,6 @@
   "somethingWentWrong": {
     "message": "Ой! Что-то пошло не так."
   },
-  "source": {
-    "message": "Источник"
-  },
   "speedUp": {
     "message": "Ускорить"
   },

--- a/app/_locales/tl/messages.json
+++ b/app/_locales/tl/messages.json
@@ -3255,9 +3255,6 @@
   "somethingWentWrong": {
     "message": "Oops! Nagkaproblema."
   },
-  "source": {
-    "message": "Pinagmulan"
-  },
   "speedUp": {
     "message": "Pabilisin"
   },

--- a/app/_locales/tr/messages.json
+++ b/app/_locales/tr/messages.json
@@ -3255,9 +3255,6 @@
   "somethingWentWrong": {
     "message": "Eyvah! Bir şeyler ters gitti."
   },
-  "source": {
-    "message": "Kaynak"
-  },
   "speedUp": {
     "message": "Hızlandır"
   },

--- a/app/_locales/vi/messages.json
+++ b/app/_locales/vi/messages.json
@@ -3255,9 +3255,6 @@
   "somethingWentWrong": {
     "message": "Rất tiếc! Đã xảy ra sự cố."
   },
-  "source": {
-    "message": "Nguồn"
-  },
   "speedUp": {
     "message": "Tăng tốc"
   },

--- a/app/_locales/zh_CN/messages.json
+++ b/app/_locales/zh_CN/messages.json
@@ -3255,9 +3255,6 @@
   "somethingWentWrong": {
     "message": "哎呀！出了点问题。"
   },
-  "source": {
-    "message": "来源"
-  },
   "speedUp": {
     "message": "加速"
   },

--- a/test/e2e/nft/view-erc1155-details.spec.js
+++ b/test/e2e/nft/view-erc1155-details.spec.js
@@ -16,8 +16,6 @@ describe('View ERC1155 NFT details', function () {
   };
 
   it('user should be able to view ERC1155 NFT details', async function () {
-    const expectedImageSource =
-      'https://bafkreifvhjdf6ve4jfv6qytqtux5nd4nwnelioeiqx5x2ez5yrgrzk7ypi.ipfs.dweb.link';
     await withFixtures(
       {
         dapp: true,
@@ -56,11 +54,6 @@ describe('View ERC1155 NFT details', function () {
 
         const nftImage = await driver.findElement('.nft-item__container');
         assert.equal(await nftImage.isDisplayed(), true);
-
-        const nftImageSource = await driver.findElement(
-          '.nft-details__image-source',
-        );
-        assert.equal(await nftImageSource.getText(), expectedImageSource);
 
         const nftContract = await driver.findElement(
           '.nft-details__contract-wrapper',

--- a/test/e2e/nft/view-nft-details.spec.js
+++ b/test/e2e/nft/view-nft-details.spec.js
@@ -16,8 +16,6 @@ describe('View NFT details', function () {
   };
 
   it('user should be able to view ERC721 NFT details', async function () {
-    const expectedImageSource =
-      'data:image/svg+xml;base64,PHN2ZyBoZWlnaHQ9IjM1MCIgd2lkdGg9IjM1MCIgdmlld0JveD0iMCAwIDEwMCAxMDAiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGRlZnM+PHBhdGggaWQ9Ik15UGF0aCIgZmlsbD0ibm9uZSIgc3Ryb2tlPSJyZWQiIGQ9Ik0xMCw5MCBROTAsOTAgOTAsNDUgUTkwLDEwIDUwLDEwIFExMCwxMCAxMCw0MCBRMTAsNzAgNDUsNzAgUTcwLDcwIDc1LDUwIiAvPjwvZGVmcz48dGV4dD48dGV4dFBhdGggaHJlZj0iI015UGF0aCI+UXVpY2sgYnJvd24gZm94IGp1bXBzIG92ZXIgdGhlIGxhenkgZG9nLjwvdGV4dFBhdGg+PC90ZXh0Pjwvc3ZnPg==';
     await withFixtures(
       {
         dapp: true,
@@ -55,11 +53,6 @@ describe('View NFT details', function () {
 
         const nftImage = await driver.findElement('.nft-item__container');
         assert.equal(await nftImage.isDisplayed(), true);
-
-        const nftImageSource = await driver.findElement(
-          '.nft-details__image-source',
-        );
-        assert.equal(await nftImageSource.getText(), expectedImageSource);
 
         const nftContract = await driver.findElement(
           '.nft-details__contract-wrapper',

--- a/ui/components/app/nft-details/__snapshots__/nft-details.test.js.snap
+++ b/ui/components/app/nft-details/__snapshots__/nft-details.test.js.snap
@@ -147,27 +147,6 @@ exports[`NFT Details should match minimal props and state snapshot 1`] = `
         <h6
           class="mm-box mm-text nft-details__link-title mm-text--body-sm-bold mm-box--margin-right-2 mm-box--margin-bottom-4 mm-box--color-text-default"
         >
-          Source
-        </h6>
-        <h6
-          class="mm-box mm-text nft-details__image-source mm-text--body-sm mm-box--margin-bottom-4 mm-box--color-primary-default"
-        >
-          <a
-            href="https://bafybeiclzx7zfjvuiuwobn5ip3ogc236bjqfjzoblumf4pau4ep6dqramu.ipfs.dweb.link"
-            rel="noopener noreferrer"
-            target="_blank"
-            title="https://bafybeiclzx7zfjvuiuwobn5ip3ogc236bjqfjzoblumf4pau4ep6dqramu.ipfs.dweb.link"
-          >
-            https://bafybeiclzx7zfjvuiuwobn5ip3ogc236bjqfjzoblumf4pau4ep6dqramu.ipfs.dweb.link
-          </a>
-        </h6>
-      </div>
-      <div
-        class="box box--display-flex box--flex-direction-row"
-      >
-        <h6
-          class="mm-box mm-text nft-details__link-title mm-text--body-sm-bold mm-box--margin-right-2 mm-box--margin-bottom-4 mm-box--color-text-default"
-        >
           Contract address
         </h6>
         <div

--- a/ui/components/app/nft-details/nft-details.js
+++ b/ui/components/app/nft-details/nft-details.js
@@ -67,7 +67,6 @@ export default function NftDetails({ nft }) {
     standard,
     isCurrentlyOwned,
     lastSale,
-    imageThumbnail,
   } = nft;
   const t = useI18nContext();
   const history = useHistory();
@@ -87,7 +86,6 @@ export default function NftDetails({ nft }) {
   );
   const nftImageAlt = getNftImageAlt(nft);
   const nftImageURL = getAssetImageURL(imageOriginal ?? image, ipfsGateway);
-  const isDataURI = nftImageURL.startsWith('data:');
 
   const formattedTimestamp = formatDate(
     new Date(lastSale?.event_timestamp).getTime(),
@@ -308,72 +306,6 @@ export default function NftDetails({ nft }) {
                 </Box>
               </Box>
             </>
-          ) : null}
-          <Box display={Display.Flex} flexDirection={FlexDirection.Row}>
-            <Text
-              color={TextColor.textDefault}
-              variant={TextVariant.bodySmBold}
-              as="h6"
-              marginBottom={4}
-              marginRight={2}
-              className="nft-details__link-title"
-            >
-              {t('source')}
-            </Text>
-            <Text
-              variant={TextVariant.bodySm}
-              as="h6"
-              marginBottom={4}
-              className="nft-details__image-source"
-              color={
-                isDataURI ? TextColor.textDefault : TextColor.primaryDefault
-              }
-            >
-              {isDataURI ? (
-                <>{nftImageURL}</>
-              ) : (
-                <a
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  href={nftImageURL}
-                  title={nftImageURL}
-                >
-                  {nftImageURL}
-                </a>
-              )}
-            </Text>
-          </Box>
-          {imageThumbnail ? (
-            <Box display={Display.Flex} flexDirection={FlexDirection.Row}>
-              <Text
-                color={TextColor.textDefault}
-                variant={TextVariant.bodySmBold}
-                as="h6"
-                marginBottom={4}
-                marginRight={2}
-                className="nft-details__link-title"
-              >
-                {t('link')}
-              </Text>
-              <Text
-                variant={TextVariant.bodySm}
-                as="h6"
-                marginBottom={4}
-                className="nft-details__image-source"
-                color={
-                  isDataURI ? TextColor.textDefault : TextColor.primaryDefault
-                }
-              >
-                <a
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  href={nftImageURL}
-                  title={nftImageURL}
-                >
-                  {imageThumbnail}
-                </a>
-              </Text>
-            </Box>
           ) : null}
           <Box display={Display.Flex} flexDirection={FlexDirection.Row}>
             <Text


### PR DESCRIPTION
## Explanation

Removes the `Source` and `Link` fields from NFT details.

## Screenshots/Screencaps

### After

<img width="751" alt="SCR-20230727-pwyi" src="https://github.com/MetaMask/metamask-extension/assets/46655/90ca3418-98fe-41ca-a29b-f59689f0ad1b">


## Manual Testing Steps

1.  Click into any NFT to get to the detail screen
2. See no "Link" or "Source" information

## Pre-merge author checklist

- [ ] I've clearly explained:
  - [ ] What problem this PR is solving
  - [ ] How this problem was solved
  - [ ] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
