### PR TITLE
[FLASK] Fix regression in transaction confirmation tabs

### DIFF
--- a/test/e2e/snaps/test-snap-txinsights.spec.js
+++ b/test/e2e/snaps/test-snap-txinsights.spec.js
@@ -102,6 +102,11 @@ describe('Test Snap TxInsights', function () {
           'MetaMask Notification',
           windowHandles,
         );
+        await driver.delay(1000);
+        await driver.clickElement({
+          text: 'Insights Example Snap',
+          tag: 'button',
+        });
 
         // check that txinsightstest tab contains the right info
         await driver.delay(1000);

--- a/ui/components/app/confirm-page-container/confirm-page-container-content/confirm-page-container-content.component.js
+++ b/ui/components/app/confirm-page-container/confirm-page-container-content/confirm-page-container-content.component.js
@@ -120,7 +120,7 @@ export default class ConfirmPageContainerContent extends Component {
     } = this.props;
 
     return (
-      <Tabs>
+      <Tabs defaultActiveTabKey="details">
         <Tab
           className="confirm-page-container-content__tab"
           name={t('details')}


### PR DESCRIPTION
## Explanation

This fixes a regression in the transaction confirmation tabs component, causing the last tab to always be selected when a transaction insights snap is installed.

The function to set the initial tab index uses:

```ts
Math.max(_findChildByKey(defaultActiveTabKey), 0)
```

The `_findChildByKey` looks like this:

```ts
const _findChildByKey = (tabKey) => {
  return _getValidChildren().findIndex((c) => c?.props.tabKey === tabKey);
};
```

Previously, no `defaultActiveTabKey` was set (so it was `undefined`). Since the transaction insights page does not have a `tabKey` (meaning it's also `undefined`), the transaction insights tab was used, since `props.tabKey` and `tabKey` are equal (both undefined).

To fix it, I simply set the `defaultActiveTabKey` to `details`.

### Before

Previously, upon opening the transaction confirmation page, it looks like this:

<img width="472" alt="image" src="https://github.com/MetaMask/metamask-extension/assets/7503723/e0ac98fa-7a55-4817-8f38-149a89cf7516">

Note that the transaction insights page is selected by default.

### After

After this change, it looks like this:

<img width="472" alt="image" src="https://github.com/MetaMask/metamask-extension/assets/7503723/eb7aed46-c6f8-46c0-a381-9c61f3e0a574">

## Manual Testing Steps

- Build the extension with Flask enabled.
- Go to [test-snaps](https://metamask.github.io/snaps/test-snaps/0.38.0-flask.1/).
- Install the transaction insights snap.
- Send a transaction, and check that the first tab is selected, not the transaction insights tab.

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone