### PR TITLE
added the new checkbox in skip-srp-backup-popover.js

### DIFF
--- a/ui/pages/onboarding-flow/secure-your-wallet/skip-srp-backup-popover.js
+++ b/ui/pages/onboarding-flow/secure-your-wallet/skip-srp-backup-popover.js
@@ -16,7 +16,6 @@ import {
   TypographyVariant,
 } from '../../../helpers/constants/design-system';
 import { setSeedPhraseBackedUp } from '../../../store/actions';
-import Checkbox from '../../../components/ui/check-box';
 import { ONBOARDING_COMPLETION_ROUTE } from '../../../helpers/constants/routes';
 import {
   MetaMetricsEventCategory,
@@ -27,6 +26,7 @@ import {
   Icon,
   IconName,
   IconSize,
+  Checkbox
 } from '../../../components/component-library';
 
 export default function SkipSRPBackup({ handleClose }) {
@@ -101,9 +101,9 @@ export default function SkipSRPBackup({ handleClose }) {
           <label className="skip-srp-backup-popover__label">
             <Checkbox
               className="skip-srp-backup-popover__checkbox"
-              onClick={() => setChecked(!checked)}
-              checked={checked}
-              dataTestId="skip-srp-backup-popover-checkbox"
+              onChange={() => setChecked(!checked)}
+              isChecked={checked}
+              data-testid="skip-srp-backup-popover-checkbox"
             />
             <Typography
               className="skip-srp-backup-popover__details"


### PR DESCRIPTION
## Explanation

As per the comments on this PR https://github.com/MetaMask/metamask-extension/pull/20198, addressing the issue https://github.com/MetaMask/metamask-extension/issues/20164, I have broken down the changes into smaller PR. In this, PR I have added the checkbox in `ui/pages/onboarding-flow/secure-your-wallet/skip-srp-backup-popover.js`

Part https://github.com/MetaMask/metamask-extension/issues/20163
## Screenshots/Screencaps

<!-- If you're making a change to the UI, make sure to capture a screenshot or a short video showing off your work! -->

### Before

<!-- How did the UI you changed look before your changes? Drag your file(s) below this line: -->

### After

<!-- How does it look now? Drag your file(s) below this line: -->
![image](https://github.com/MetaMask/metamask-extension/assets/38760485/f2f6c76d-dc19-4fba-a321-4454f8ad1a70)

## Manual Testing Steps

<!--
How should reviewers and QA manually test your changes? For instance:

- Go to this screen
- Do this
- Then do this
-->

## Pre-merge author checklist

- [ ] I've clearly explained:
  - [ ] What problem this PR is solving
  - [ ] How this problem was solved
  - [ ] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
