### PR TITLE
UX Multichain: Fixed fiat and eth value in Account List Menu

### DIFF
--- a/test/e2e/tests/account-token-list.spec.js
+++ b/test/e2e/tests/account-token-list.spec.js
@@ -1,0 +1,85 @@
+const { strict: assert } = require('assert');
+const {
+  withFixtures,
+  defaultGanacheOptions,
+  unlockWallet,
+} = require('../helpers');
+const FixtureBuilder = require('../fixture-builder');
+const { SMART_CONTRACTS } = require('../seeder/smart-contracts');
+
+describe('Settings', function () {
+  const smartContract = SMART_CONTRACTS.ERC1155;
+  it('Should match the value of token list item and account list item for eth conversion', async function () {
+    await withFixtures(
+      {
+        dapp: true,
+        fixtures: new FixtureBuilder().withNftControllerERC1155().build(),
+        defaultGanacheOptions,
+        smartContract,
+        title: this.test.title,
+      },
+      async ({ driver }) => {
+        await driver.navigate();
+        await unlockWallet(driver);
+
+        await driver.clickElement('[data-testid="home__asset-tab"]');
+
+        const tokenValue = '0 ETH';
+        const tokenListAmount = await driver.findElement(
+          '[data-testid="multichain-token-list-item-value"]',
+        );
+        assert.equal(await tokenListAmount.getText(), tokenValue);
+
+        await driver.clickElement('[data-testid="account-menu-icon"]');
+        const accountTokenValue = await driver.waitForSelector(
+          '.currency-display-component__text',
+        );
+
+        assert.equal(await accountTokenValue.getText(), '0', `ETH`);
+      },
+    );
+  });
+
+  it('Should match the value of token list item and account list item for fiat conversion', async function () {
+    await withFixtures(
+      {
+        dapp: true,
+        fixtures: new FixtureBuilder().withNftControllerERC1155().build(),
+        defaultGanacheOptions,
+        smartContract,
+        title: this.test.title,
+      },
+      async ({ driver }) => {
+        await driver.navigate();
+        await unlockWallet(driver);
+
+        await driver.clickElement(
+          '[data-testid="account-options-menu-button"]',
+        );
+        await driver.clickElement({ text: 'Settings', tag: 'div' });
+        await driver.clickElement({
+          text: 'General',
+          tag: 'div',
+        });
+        await driver.clickElement({ text: 'Fiat', tag: 'label' });
+
+        await driver.clickElement(
+          '.settings-page__header__title-container__close-button',
+        );
+        await driver.clickElement('[data-testid="home__asset-tab"]');
+        const tokenValue = '0 ETH';
+        const tokenListAmount = await driver.findElement(
+          '[data-testid="multichain-token-list-item-value"]',
+        );
+        assert.equal(await tokenListAmount.getText(), tokenValue);
+
+        await driver.clickElement('[data-testid="account-menu-icon"]');
+        const accountTokenValue = await driver.waitForSelector(
+          '.currency-display-component__text',
+        );
+
+        assert.equal(await accountTokenValue.getText(), '0', `ETH`);
+      },
+    );
+  });
+});

--- a/test/e2e/tests/account-token-list.spec.js
+++ b/test/e2e/tests/account-token-list.spec.js
@@ -13,7 +13,7 @@ describe('Settings', function () {
     await withFixtures(
       {
         dapp: true,
-        fixtures: new FixtureBuilder().withNftControllerERC1155().build(),
+        fixtures: new FixtureBuilder().build(),
         defaultGanacheOptions,
         smartContract,
         title: this.test.title,
@@ -44,7 +44,7 @@ describe('Settings', function () {
     await withFixtures(
       {
         dapp: true,
-        fixtures: new FixtureBuilder().withNftControllerERC1155().build(),
+        fixtures: new FixtureBuilder().build(),
         defaultGanacheOptions,
         smartContract,
         title: this.test.title,

--- a/ui/components/multichain/account-list-item/account-list-item.js
+++ b/ui/components/multichain/account-list-item/account-list-item.js
@@ -194,7 +194,7 @@ export const AccountListItem = ({
               <UserPreferencedCurrencyDisplay
                 ethNumberOfDecimals={MAXIMUM_CURRENCY_DECIMALS}
                 value={identity.balance}
-                type={SECONDARY}
+                type={PRIMARY}
               />
             </Text>
           </Box>
@@ -225,7 +225,7 @@ export const AccountListItem = ({
             <UserPreferencedCurrencyDisplay
               ethNumberOfDecimals={MAXIMUM_CURRENCY_DECIMALS}
               value={identity.balance}
-              type={PRIMARY}
+              type={SECONDARY}
             />
           </Text>
         </Box>


### PR DESCRIPTION
This PR is to ensure that When we display the balance and its fiat conversion rate with the primary currency set to the network, we display the top as the primary currency and the bottom as the fiat conversion on the both home screen and activity list menu

* Fixes #20182 

## Screenshots/Screencaps


### Before


https://github.com/MetaMask/metamask-extension/assets/39872794/4a9fec38-b4da-4688-aaa8-ef54343c7096


### After


https://github.com/MetaMask/metamask-extension/assets/39872794/d95465be-91df-4e46-b7f8-03c6abfe59db


## Manual Testing Steps

- Go to this home screen, check eth value is shown on top and fiat below that.
- Check on account list item, it should be in a similar way

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
