### PR TITLE
Check for blocked snaps on extension startup

### DIFF
--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -801,6 +801,11 @@ export function setupController(
     });
   }
   ///: END:ONLY_INCLUDE_IN
+
+  ///: BEGIN:ONLY_INCLUDE_IN(snaps)
+  // Updates the snaps registry and check for newly blocked snaps to block.
+  controller.controllerMessenger.call('SnapController:updateBlockedSnaps');
+  ///: END:ONLY_INCLUDE_IN
 }
 
 //

--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -803,8 +803,10 @@ export function setupController(
   ///: END:ONLY_INCLUDE_IN
 
   ///: BEGIN:ONLY_INCLUDE_IN(snaps)
-  // Updates the snaps registry and check for newly blocked snaps to block.
-  controller.controllerMessenger.call('SnapController:updateBlockedSnaps');
+  // Updates the snaps registry and check for newly blocked snaps to block if the user has at least one snap installed.
+  if (Object.keys(controller.snapController.state.snaps).length > 0) {
+    controller.snapController.updateBlockedSnaps();
+  }
   ///: END:ONLY_INCLUDE_IN
 }
 

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -986,6 +986,7 @@ export default class MetamaskController extends EventEmitter {
         'ExecutionService:handleRpcRequest',
         'SnapsRegistry:get',
         'SnapsRegistry:getMetadata',
+        'SnapsRegistry:update',
       ],
     });
 


### PR DESCRIPTION
## Explanation

This calls `SnapController:updateBlockedSnaps` when the extensions starts (when the browser is opened)

## Manual Testing Steps

- Disable the extension in the extension page of your browser
- Re-enable it
- Quickly open the background inspector to the network tab
- See that the registry has been updated