### PR TITLE
Use KeyringController messenger events

### DIFF
--- a/app/scripts/metamask-controller.actions.test.js
+++ b/app/scripts/metamask-controller.actions.test.js
@@ -220,6 +220,14 @@ describe('MetaMaskController', function () {
     });
   });
 
+  describe('#setLocked', function () {
+    it('should lock the wallet', async function () {
+      const { isUnlocked, keyrings } = await metamaskController.setLocked();
+      assert(!isUnlocked);
+      assert.deepEqual(keyrings, []);
+    });
+  });
+
   describe('#addToken', function () {
     const address = '0x514910771af9ca656af840dff83e8264ecf986ca';
     const symbol = 'LINK';

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -872,13 +872,13 @@ export default class MetamaskController extends EventEmitter {
       ),
     });
 
-    keyringControllerMessenger.subscribe('KeyringController:unlock', () =>
+    this.controllerMessenger.subscribe('KeyringController:unlock', () =>
       this._onUnlock(),
     );
-    keyringControllerMessenger.subscribe('KeyringController:lock', () =>
+    this.controllerMessenger.subscribe('KeyringController:lock', () =>
       this._onLock(),
     );
-    keyringControllerMessenger.subscribe(
+    this.controllerMessenger.subscribe(
       'KeyringController:stateChange',
       (state) => {
         this._onKeyringControllerUpdate(state);

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -4676,6 +4676,13 @@ export default class MetamaskController extends EventEmitter {
    * Locks MetaMask
    */
   setLocked() {
+    const [trezorKeyring] = this.coreKeyringController.getKeyringsByType(
+      KeyringType.trezor,
+    );
+    if (trezorKeyring) {
+      trezorKeyring.dispose();
+    }
+
     if (isManifestV3) {
       this.clearLoginArtifacts();
     }

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -872,15 +872,21 @@ export default class MetamaskController extends EventEmitter {
       ),
     });
 
-    this.keyringController =
-      this.coreKeyringController.getEthKeyringController();
-
-    this.keyringController.memStore.subscribe((state) =>
-      this._onKeyringControllerUpdate(state),
+    keyringControllerMessenger.subscribe('KeyringController:unlock', () =>
+      this._onUnlock(),
+    );
+    keyringControllerMessenger.subscribe('KeyringController:lock', () =>
+      this._onLock(),
+    );
+    keyringControllerMessenger.subscribe(
+      'KeyringController:stateChange',
+      (state) => {
+        this._onKeyringControllerUpdate(state);
+      },
     );
 
-    this.keyringController.on('unlock', () => this._onUnlock());
-    this.keyringController.on('lock', () => this._onLock());
+    this.keyringController =
+      this.coreKeyringController.getEthKeyringController();
 
     const getIdentities = () =>
       this.preferencesController.store.getState().identities;
@@ -3028,10 +3034,9 @@ export default class MetamaskController extends EventEmitter {
    * is up to date with known accounts once the vault is decrypted.
    *
    * @param {string} password - The user's password
-   * @returns {Promise<object>} The keyringController update.
    */
   async submitPassword(password) {
-    await this.keyringController.submitPassword(password);
+    await this.coreKeyringController.submitPassword(password);
 
     ///: BEGIN:ONLY_INCLUDE_IN(build-mmi)
     this.mmiController.onSubmitPassword();
@@ -3051,8 +3056,6 @@ export default class MetamaskController extends EventEmitter {
       this.preferencesController.getLedgerTransportPreference();
 
     this.setLedgerTransportPreference(transportPreference);
-
-    return this.keyringController.fullUpdate();
   }
 
   async _loginUser() {
@@ -3091,7 +3094,7 @@ export default class MetamaskController extends EventEmitter {
       const { loginToken, loginSalt } =
         await this.extension.storage.session.get(['loginToken', 'loginSalt']);
       if (loginToken && loginSalt) {
-        const { vault } = this.keyringController.store.getState();
+        const { vault } = this.coreKeyringController.state;
 
         const jsonVault = JSON.parse(vault);
 
@@ -3103,7 +3106,10 @@ export default class MetamaskController extends EventEmitter {
           return;
         }
 
-        await this.keyringController.submitEncryptionKey(loginToken, loginSalt);
+        await this.coreKeyringController.submitEncryptionKey(
+          loginToken,
+          loginSalt,
+        );
       }
     } catch (e) {
       // If somehow this login token doesn't work properly,
@@ -4670,23 +4676,11 @@ export default class MetamaskController extends EventEmitter {
    * Locks MetaMask
    */
   setLocked() {
-    const [trezorKeyring] = this.coreKeyringController.getKeyringsByType(
-      KeyringType.trezor,
-    );
-    if (trezorKeyring) {
-      trezorKeyring.dispose();
-    }
-
-    const [ledgerKeyring] = this.coreKeyringController.getKeyringsByType(
-      KeyringType.ledger,
-    );
-    ledgerKeyring?.destroy?.();
-
     if (isManifestV3) {
       this.clearLoginArtifacts();
     }
 
-    return this.keyringController.setLocked();
+    return this.coreKeyringController.setLocked();
   }
 
   removePermissionsFor = (subjects) => {

--- a/app/scripts/metamask-controller.test.js
+++ b/app/scripts/metamask-controller.test.js
@@ -390,6 +390,8 @@ describe('MetaMaskController', function () {
 
     describe('setLocked', function () {
       it('should lock KeyringController', async function () {
+        sandbox.spy(metamaskController.coreKeyringController, 'setLocked');
+
         await metamaskController.setLocked();
 
         assert(metamaskController.coreKeyringController.setLocked.called);

--- a/app/scripts/metamask-controller.test.js
+++ b/app/scripts/metamask-controller.test.js
@@ -370,7 +370,7 @@ describe('MetaMaskController', function () {
           metamaskController.preferencesController.store.getState().identities,
         );
         const addresses =
-          await metamaskController.keyringController.getAccounts();
+          await metamaskController.coreKeyringController.getAccounts();
 
         identities.forEach((identity) => {
           assert.ok(
@@ -385,6 +385,18 @@ describe('MetaMaskController', function () {
             `identities should include all Addresses: ${address}`,
           );
         });
+      });
+    });
+
+    describe('setLocked', function () {
+      it('should lock KeyringController', async function () {
+        await metamaskController.setLocked();
+
+        assert(metamaskController.coreKeyringController.setLocked.called);
+        assert.equal(
+          metamaskController.coreKeyringController.state.isUnlocked,
+          false,
+        );
       });
     });
 


### PR DESCRIPTION
## Explanation

<!--
Thanks for the pull request. Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues, Slack conversations, Zendesk issues, user stories, etc. reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->
With this PR, `MetamaskController` starts using the KeyringController messenger to listen to `lock`, `unlock`, and `updateState` events, instead of subscribing to `EthKeyringController` directly. 

## Manual Testing Steps

<!--
How should reviewers and QA manually test your changes? For instance:

- Go to this screen
- Do this
- Then do this
-->

Lock and unlock functionalities (also MV3 with `submitEncryptionKey`) should work as before.

## Pre-merge author checklist

- [ ] I've clearly explained:
  - [ ] What problem this PR is solving
  - [ ] How this problem was solved
  - [ ] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
