### PR TITLE
Fix/check pr labels

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -20,5 +20,6 @@ When you're done with your project / bugfix / feature and ready to submit a PR, 
 - [ ] **Keep it simple**: Try not to include multiple features in a single PR, and don't make extraneous changes outside the scope of your contribution. All those touched files make things harder to review ;)
 - [ ] **PR against `develop`**: Submit your PR against the `develop` branch. This is where we merge new features so they get some time to receive extra testing before being pushed to `master` for production. If your PR is a hot-fix that needs to be published urgently, you may submit a PR against the `master` branch, but this PR will receive tighter scrutiny before merging.
 - [ ] **Get reviewed by a core contributor**: Make sure you get a `:thumbsup`, `:+1`, or `LGTM` from a user with a `Member` badge before merging.
+- [ ] **Ensure the PR is correctly labeled.**: More detail about labels definitions can be found [here](https://github.com/MetaMask/metamask-extension/blob/develop/.github/LABELING_GUIDELINES.md).
 
 And that's it! Thanks for helping out.

--- a/.github/LABELING_GUIDELINES.md
+++ b/.github/LABELING_GUIDELINES.md
@@ -1,0 +1,24 @@
+# PR Labeling Guidelines
+To maintain a consistent and efficient development workflow, we have set specific label guidelines for all pull requests (PRs). Please ensure you adhere to the following instructions:
+
+### Mandatory Labels:
+- **Internal Developers**: Every PR raised by an internal developer must include a label prefixed with `team-` (e.g., `team-extension-ux`, `team-extension-platform`, etc.). This indicates the respective internal team responsible for the PR.
+
+- **External Contributors**: PRs from contributors outside the organization must have the `external-contributor` label.
+
+It's essential to ensure that PRs have the appropriate labels before they are considered for merging.
+
+### Prohibited Labels:
+Any PR that includes one of the following labels can not be merged:
+
+- **needs-qa**: The PR requires a full manual QA prior to being added to a release.
+- **QA'd but questions**: The PR has been checked by QA, but there are pending questions or clarifications needed on minor issues that were found.
+- **issues-found**: The PR has been checked by QA or other reviewers, and appeared to include issues that need to be addressed.
+- **need-ux-ds-review**: The PR requires a review from the User Experience or Design System teams.
+- **blocked**: There are unresolved dependencies or other issues blocking the progress of this PR.
+- **stale**: The PR has not had recent activity in the last 90 days. It will be closed in 7 days.
+- **DO-NOT-MERGE**: The PR should not be merged under any circumstances.
+
+To maintain code quality and project integrity, it's crucial to respect these label guidelines. Please ensure you review and update labels appropriately throughout the PR lifecycle.
+
+Thank you for your cooperation!

--- a/.github/scripts/check-pr-has-required-labels.ts
+++ b/.github/scripts/check-pr-has-required-labels.ts
@@ -53,7 +53,7 @@ async function main(): Promise<void> {
   if (!hasTeamLabel) {
     errorMessage += 'No team labels found on the PR. ';
   }
-  errorMessage += 'Please add the required label(s) before merging the PR.';
+  errorMessage += `Please make sure the PR is appropriately labeled before merging it.\n\nSee labeling guidelines for more detail: https://github.com/MetaMask/metamask-extension/blob/develop/.github/LABELING_GUIDELINES.md`;
   throw new Error(errorMessage);
 
 }

--- a/.github/workflows/check-pr-labels.yml
+++ b/.github/workflows/check-pr-labels.yml
@@ -2,7 +2,7 @@ name: "Check PR has required labels"
 on:
   pull_request:
     branches:
-      - main
+      - develop
     types:
       - opened
       - reopened


### PR DESCRIPTION
## Explanation

Here's a tiny fix to this [PR](https://github.com/MetaMask/metamask-extension/pull/19984) because the target branch was wrong: `main` instead of `develop`.
I also included some additional documentation.

## Screenshots/Screencaps

NA

### Before

NA

### After

NA

## Manual Testing Steps

NA

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
