### PR TITLE
UX: Snaps: Make Notifications Font Consistent with Other Global Items

### DIFF
--- a/test/e2e/snaps/test-snap-notification.spec.js
+++ b/test/e2e/snaps/test-snap-notification.spec.js
@@ -102,8 +102,8 @@ describe('Test Snap Notification', function () {
 
         // try to click on the notification item (via xpath)
         await driver.clickElement({
-          text: 'Notifications',
-          tag: 'span',
+          text: 'Notifications 1',
+          css: '.menu-item',
         });
         await driver.delay(500);
 

--- a/ui/components/multichain/global-menu/global-menu.js
+++ b/ui/components/multichain/global-menu/global-menu.js
@@ -173,7 +173,7 @@ export const GlobalMenu = ({ closeMenu, anchorElement }) => {
               history.push(NOTIFICATIONS_ROUTE);
             }}
           >
-            <Text as="span">{t('notifications')}</Text>
+            {t('notifications')}
             {unreadNotificationsCount > 0 && (
               <Text
                 as="span"


### PR DESCRIPTION
## Explanation

While exploring Snaps in the extension, I noticed the Global Menu's "Notifications" item had a different font-size than other items.  This PR fixes that issue.

## Screenshots/Screencaps

### Before

<img width="281" alt="SCR-20230801-qylb" src="https://github.com/MetaMask/metamask-extension/assets/46655/8cf25556-49ef-418a-a651-21ad0be9552a">


### After

<img width="264" alt="SCR-20230801-qytn" src="https://github.com/MetaMask/metamask-extension/assets/46655/3a30ed65-dc05-468e-b20a-142b6d3b9c80">

## Pre-merge author checklist

- [ ] I've clearly explained:
  - [ ] What problem this PR is solving
  - [ ] How this problem was solved
  - [ ] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
