### PR TITLE
Close Network added popover on background click

### DIFF
--- a/ui/pages/home/home.component.js
+++ b/ui/pages/home/home.component.js
@@ -637,7 +637,10 @@ export default class Home extends PureComponent {
           />
         ) : null}
         {newNetworkAddedConfigurationId && (
-          <Popover className="home__new-network-added">
+          <Popover
+            className="home__new-network-added"
+            onClose={() => clearNewNetworkAdded()}
+          >
             <i className="fa fa-check-circle fa-2x home__new-network-added__check-circle" />
             <Text
               variant={TextVariant.headingSm}


### PR DESCRIPTION
After adding a network, the switch network popover doesn't close when we click in the background. This PR fixes this issue

## Screencast


### Before

https://github.com/MetaMask/metamask-extension/assets/39872794/a426b627-eebf-4660-8224-ec42e6b42ae7



### After


https://github.com/MetaMask/metamask-extension/assets/39872794/60f05c24-9655-4a65-bfb7-097ab63fb9a6


## Manual Testing Steps


- Add a new network
- Check the popover closes on switch network modal

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
