### PR TITLE
fix: minimise public api of tx controller

### DIFF
--- a/app/scripts/controllers/transactions/index.test.js
+++ b/app/scripts/controllers/transactions/index.test.js
@@ -331,7 +331,7 @@ describe('Transaction Controller', function () {
     });
   });
 
-  describe('#addTransaction', function () {
+  describe('_addTransaction', function () {
     const selectedAddress = '0xc684832530fcbddae4b4230a47e991ddcec2831d';
     const recipientAddress = '0xc684832530fcbddae4b4230a47e991ddcec2831d';
 
@@ -750,7 +750,7 @@ describe('Transaction Controller', function () {
         providerResultStub.eth_estimateGas = '0x5209';
 
         signStub = sinon
-          .stub(txController, 'signTransaction')
+          .stub(txController, '_signTransaction')
           .callsFake(() => Promise.resolve());
 
         const pubStub = sinon

--- a/app/scripts/controllers/transactions/index.test.js
+++ b/app/scripts/controllers/transactions/index.test.js
@@ -331,7 +331,7 @@ describe('Transaction Controller', function () {
     });
   });
 
-  describe('_addTransaction', function () {
+  describe('#addTransaction', function () {
     const selectedAddress = '0xc684832530fcbddae4b4230a47e991ddcec2831d';
     const recipientAddress = '0xc684832530fcbddae4b4230a47e991ddcec2831d';
 

--- a/app/scripts/controllers/transactions/index.test.js
+++ b/app/scripts/controllers/transactions/index.test.js
@@ -754,7 +754,7 @@ describe('Transaction Controller', function () {
           .callsFake(() => Promise.resolve());
 
         const pubStub = sinon
-          .stub(txController, 'publishTransaction')
+          .stub(txController, '_publishTransaction')
           .callsFake(() => {
             const txId = getLastTxMeta().id;
             txController.setTxHash(txId, originalValue);
@@ -1212,7 +1212,7 @@ describe('Transaction Controller', function () {
     });
   });
 
-  describe('#addTxGasDefaults', function () {
+  describe('_addTxGasDefaults', function () {
     it('should add the tx defaults if their are none', async function () {
       txController.txStateManager._addTransactionsToState([
         {
@@ -1238,7 +1238,7 @@ describe('Transaction Controller', function () {
       providerResultStub.eth_getBlockByNumber = { gasLimit: '47b784' };
       providerResultStub.eth_estimateGas = '5209';
 
-      const txMetaWithDefaults = await txController.addTxGasDefaults(txMeta);
+      const txMetaWithDefaults = await txController._addTxGasDefaults(txMeta);
       assert.ok(
         txMetaWithDefaults.txParams.gasPrice,
         'should have added the gas price',
@@ -1254,7 +1254,7 @@ describe('Transaction Controller', function () {
       const TEST_MAX_PRIORITY_FEE_PER_GAS = '0x77359400';
 
       const stub1 = sinon
-        .stub(txController, 'getEIP1559Compatibility')
+        .stub(txController, '_getEIP1559Compatibility')
         .returns(true);
 
       const stub2 = sinon
@@ -1287,7 +1287,7 @@ describe('Transaction Controller', function () {
       providerResultStub.eth_getBlockByNumber = { gasLimit: '47b784' };
       providerResultStub.eth_estimateGas = '5209';
 
-      const txMetaWithDefaults = await txController.addTxGasDefaults(txMeta);
+      const txMetaWithDefaults = await txController._addTxGasDefaults(txMeta);
 
       assert.equal(
         txMetaWithDefaults.txParams.maxFeePerGas,
@@ -1307,7 +1307,7 @@ describe('Transaction Controller', function () {
       const TEST_GASPRICE = '0x12a05f200';
 
       const stub1 = sinon
-        .stub(txController, 'getEIP1559Compatibility')
+        .stub(txController, '_getEIP1559Compatibility')
         .returns(true);
 
       const stub2 = sinon
@@ -1337,7 +1337,7 @@ describe('Transaction Controller', function () {
       providerResultStub.eth_getBlockByNumber = { gasLimit: '47b784' };
       providerResultStub.eth_estimateGas = '5209';
 
-      const txMetaWithDefaults = await txController.addTxGasDefaults(txMeta);
+      const txMetaWithDefaults = await txController._addTxGasDefaults(txMeta);
 
       assert.equal(
         txMetaWithDefaults.txParams.maxFeePerGas,
@@ -1357,7 +1357,7 @@ describe('Transaction Controller', function () {
       const TEST_GASPRICE = '0x12a05f200';
 
       const stub1 = sinon
-        .stub(txController, 'getEIP1559Compatibility')
+        .stub(txController, '_getEIP1559Compatibility')
         .returns(true);
 
       const stub2 = sinon
@@ -1389,7 +1389,7 @@ describe('Transaction Controller', function () {
       providerResultStub.eth_getBlockByNumber = { gasLimit: '47b784' };
       providerResultStub.eth_estimateGas = '5209';
 
-      const txMetaWithDefaults = await txController.addTxGasDefaults(txMeta);
+      const txMetaWithDefaults = await txController._addTxGasDefaults(txMeta);
 
       assert.equal(
         txMetaWithDefaults.txParams.maxFeePerGas,
@@ -1411,7 +1411,7 @@ describe('Transaction Controller', function () {
       const TEST_MAX_PRIORITY_FEE_PER_GAS = '0x77359400';
 
       const stub1 = sinon
-        .stub(txController, 'getEIP1559Compatibility')
+        .stub(txController, '_getEIP1559Compatibility')
         .returns(true);
 
       const stub2 = sinon
@@ -1443,7 +1443,7 @@ describe('Transaction Controller', function () {
       providerResultStub.eth_getBlockByNumber = { gasLimit: '47b784' };
       providerResultStub.eth_estimateGas = '5209';
 
-      const txMetaWithDefaults = await txController.addTxGasDefaults(txMeta);
+      const txMetaWithDefaults = await txController._addTxGasDefaults(txMeta);
 
       assert.equal(
         txMetaWithDefaults.txParams.maxFeePerGas,
@@ -1547,27 +1547,27 @@ describe('Transaction Controller', function () {
         },
         noop,
       );
-      const rawTx = await txController.signTransaction('1');
+      const rawTx = await txController._signTransaction('1');
       const ethTx = TransactionFactory.fromSerializedData(toBuffer(rawTx));
       assert.equal(Number(ethTx.common.chainId()), 5);
     });
   });
 
-  describe('#getChainId', function () {
+  describe('_getChainId', function () {
     it('returns the chain ID of the network when it is available', function () {
       networkStatusStore.putState(NetworkStatus.Available);
-      assert.equal(txController.getChainId(), 5);
+      assert.equal(txController._getChainId(), 5);
     });
 
     it('returns 0 when the network is not available', function () {
-      networkStatusStore.putState('asdflsfadf');
-      assert.equal(txController.getChainId(), 0);
+      networkStatusStore.putState('NOT_INTEGER');
+      assert.equal(txController._getChainId(), 0);
     });
 
     it('returns 0 when the chain ID cannot be parsed as a hex string', function () {
       networkStatusStore.putState(NetworkStatus.Available);
-      getCurrentChainId.returns('$fdsjfldf');
-      assert.equal(txController.getChainId(), 0);
+      getCurrentChainId.returns('NOT_INTEGER');
+      assert.equal(txController._getChainId(), 0);
     });
   });
 
@@ -1795,13 +1795,13 @@ describe('Transaction Controller', function () {
           },
         },
       ]);
-      await txController.signTransaction('1');
+      await txController._signTransaction('1');
       assert.equal(fromTxDataSpy.getCall(0).args[0].type, '0x0');
     });
 
     it('sets txParams.type to 0x2 (EIP-1559)', async function () {
       const eip1559CompatibilityStub = sinon
-        .stub(txController, 'getEIP1559Compatibility')
+        .stub(txController, '_getEIP1559Compatibility')
         .returns(true);
       txController.txStateManager._addTransactionsToState([
         {
@@ -1819,13 +1819,13 @@ describe('Transaction Controller', function () {
           },
         },
       ]);
-      await txController.signTransaction('2');
+      await txController._signTransaction('2');
       assert.equal(fromTxDataSpy.getCall(0).args[0].type, '0x2');
       eip1559CompatibilityStub.restore();
     });
   });
 
-  describe('#publishTransaction', function () {
+  describe('_publishTransaction', function () {
     let hash, txMeta, trackTransactionMetricsEventSpy;
 
     beforeEach(function () {
@@ -1856,7 +1856,7 @@ describe('Transaction Controller', function () {
       const rawTx =
         '0x477b2e6553c917af0db0388ae3da62965ff1a184558f61b749d1266b2e6d024c';
       txController.txStateManager.addTransaction(txMeta);
-      await txController.publishTransaction(txMeta.id, rawTx);
+      await txController._publishTransaction(txMeta.id, rawTx);
       const publishedTx = txController.txStateManager.getTransaction(1);
       assert.equal(publishedTx.hash, hash);
       assert.equal(publishedTx.status, TransactionStatus.submitted);
@@ -1869,7 +1869,7 @@ describe('Transaction Controller', function () {
       const rawTx =
         '0xf86204831e848082520894f231d46dd78806e1dd93442cf33c7671f853874880802ca05f973e540f2d3c2f06d3725a626b75247593cb36477187ae07ecfe0a4db3cf57a00259b52ee8c58baaa385fb05c3f96116e58de89bcc165cb3bfdfc708672fed8a';
       txController.txStateManager.addTransaction(txMeta);
-      await txController.publishTransaction(txMeta.id, rawTx);
+      await txController._publishTransaction(txMeta.id, rawTx);
       const publishedTx = txController.txStateManager.getTransaction(1);
       assert.equal(
         publishedTx.hash,
@@ -1882,7 +1882,7 @@ describe('Transaction Controller', function () {
       const rawTx =
         '0x477b2e6553c917af0db0388ae3da62965ff1a184558f61b749d1266b2e6d024c';
       txController.txStateManager.addTransaction(txMeta);
-      await txController.publishTransaction(txMeta.id, rawTx);
+      await txController._publishTransaction(txMeta.id, rawTx);
       assert.equal(trackTransactionMetricsEventSpy.callCount, 1);
       assert.deepEqual(
         trackTransactionMetricsEventSpy.getCall(0).args[0],


### PR DESCRIPTION
## Explanation

<!--
Thanks for the pull request. Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues, Slack conversations, Zendesk issues, user stories, etc. reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

Some methods in the extension TransactionController are public despite no external usages.
In order to minimise public API's this PR aims to add `_` prefix to the functions that has no usage outside of the class.
All the private methods also relocated under public methods to clarification. 

Here is the list of methods converted to private.

- `generateNewGasParams`
- `signExternalTransaction`
- `signTransaction`
- `publishTransaction`
- `confirmTransaction` 
- `getChainId`
- `getEIP1559Compatibility`
- `getCommonConfiguration`
- `addTransactionGasDefaults`
- `addTxGasDefaults`
- `updatePostTxBalance`

## Manual Testing Steps

This PR has no functional changes, transactions should work properly as it is.

<!--
How should reviewers and QA manually test your changes? For instance:

- Go to this screen
- Do this
- Then do this
-->

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
