### PR TITLE
Show a slippage notification again before submitting a swap

### DIFF
--- a/app/_locales/de/messages.json
+++ b/app/_locales/de/messages.json
@@ -4431,9 +4431,6 @@
   "swapEditLimit": {
     "message": "Limit bearbeiten"
   },
-  "swapEditTransactionSettings": {
-    "message": "Transaktionseinstellungen anpassen"
-  },
   "swapEnableDescription": {
     "message": "Dies ist erforderlich und gibt MetaMask die Erlaubnis, Ihren $1 zu swappen.",
     "description": "Gives the user info about the required approval transaction for swaps. $1 will be the symbol of a token being approved for swaps."
@@ -4637,20 +4634,8 @@
     "message": "$1%",
     "description": "$1 is the amount of % for slippage"
   },
-  "swapSlippageTooLowDescription": {
-    "message": "Maximale Slippage ist zu niedrig, weswegen Ihre Transaktion fehlschlagen könnte."
-  },
-  "swapSlippageTooLowTitle": {
-    "message": "Slippage erhöhen, um Fehlschlag der Transaktion zu verhindern"
-  },
   "swapSlippageTooltip": {
     "message": "Wenn sich der Kurs zwischen der Aufgabe Ihrer Bestellung und der Bestätigung ändert, nennt man das „Slippage”. Ihr Swap wird automatisch storniert, wenn die Abweichung die von Ihnen eingestellte „Abweichungstoleranz” überschreitet."
-  },
-  "swapSlippageVeryHighDescription": {
-    "message": "Die eingegebene Slippage wird als sehr hoch angesehen und könnte einen schlechten Kurs bewirken"
-  },
-  "swapSlippageVeryHighTitle": {
-    "message": "Sehr hohe Slippage"
   },
   "swapSlippageZeroDescription": {
     "message": "Es gibt weniger Anbieter mit Null-Slippage, was in einem weniger konkurrenzfähigen Angebot resultieren könne."

--- a/app/_locales/el/messages.json
+++ b/app/_locales/el/messages.json
@@ -4431,9 +4431,6 @@
   "swapEditLimit": {
     "message": "Επεξεργασία ορίου"
   },
-  "swapEditTransactionSettings": {
-    "message": "Επεξεργασία ρυθμίσεων συναλλαγών"
-  },
   "swapEnableDescription": {
     "message": "Αυτό απαιτείται και δίνει άδεια στο MetaMask για να ανταλλάξετε το $1 σας.",
     "description": "Gives the user info about the required approval transaction for swaps. $1 will be the symbol of a token being approved for swaps."
@@ -4637,20 +4634,8 @@
     "message": "$1%",
     "description": "$1 is the amount of % for slippage"
   },
-  "swapSlippageTooLowDescription": {
-    "message": "Η μέγιστη απόκλιση είναι πολύ χαμηλή, με αποτέλεσμα την αποτυχία της συναλλαγής σας."
-  },
-  "swapSlippageTooLowTitle": {
-    "message": "Αυξήστε την απόκλιση για να αποφύγετε την αποτυχία της συναλλαγής"
-  },
   "swapSlippageTooltip": {
     "message": "Εάν η τιμή αλλάξει μεταξύ της ώρας που η εντολή αγοράς σας υποβάλλεται και επιβεβαιώνεται, αυτό ονομάζεται «ολίσθηση». Η συναλλαγή θα ακυρωθεί αυτόματα εάν η ολίσθηση υπερβαίνει τη ρύθμιση «ανοχή ολίσθησης»."
-  },
-  "swapSlippageVeryHighDescription": {
-    "message": "Η απόκλιση που καταχωρήθηκε θεωρείται πολύ υψηλή και μπορεί να οδηγήσει σε δυσμενή τιμή"
-  },
-  "swapSlippageVeryHighTitle": {
-    "message": "Πολύ υψηλή απόκλιση"
   },
   "swapSlippageZeroDescription": {
     "message": "Υπάρχουν λίγοι πάροχοι προσφορών με μηδενική απόκλιση, γεγονός που θα οδηγήσει σε λιγότερο ανταγωνιστική προσφορά."

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -850,9 +850,6 @@
   "continue": {
     "message": "Continue"
   },
-  "continueAnyway": {
-    "message": "Continue anyway"
-  },
   "contract": {
     "message": "Contract"
   },
@@ -4500,6 +4497,9 @@
     "message": "Gas fees are paid to crypto miners who process transactions on the $1 network. MetaMask does not profit from gas fees.",
     "description": "$1 is the selected network, e.g. Ethereum or BSC"
   },
+  "swapHighSlippage": {
+    "message": "High slippage"
+  },
   "swapHighSlippageWarning": {
     "message": "Slippage amount is very high."
   },
@@ -4513,6 +4513,9 @@
   },
   "swapLearnMore": {
     "message": "Learn more about Swaps"
+  },
+  "swapLowSlippage": {
+    "message": "Low slippage"
   },
   "swapLowSlippageError": {
     "message": "Transaction may fail, max slippage too low."
@@ -4653,16 +4656,10 @@
     "message": "If the price changes between the time your order is placed and confirmed it’s called “slippage”. Your swap will automatically cancel if slippage exceeds your “slippage tolerance” setting."
   },
   "swapSlippageVeryHighDescription": {
-    "message": "The slippage entered is considered very high and may result in a bad rate"
-  },
-  "swapSlippageVeryHighDescription": {
-    "message": "Slippage this high means you'll get a bad rate. Are you sure you want to continue this swap?"
+    "message": "The slippage entered is considered very high and may result in a bad rate."
   },
   "swapSlippageVeryHighTitle": {
     "message": "Very high slippage"
-  },
-  "swapSlippageVeryHighTitle": {
-    "message": "Your slippage is very high"
   },
   "swapSlippageZeroDescription": {
     "message": "There are fewer zero-slippage quote providers which will result in a less competitive quote."

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -4628,14 +4628,14 @@
     "message": "Show latest quotes"
   },
   "swapSlippageHighDescription": {
-    "message": "The slippage entered ($1%) is considered very high and may result in a bad rate.",
+    "message": "The slippage entered ($1%) is considered very high and may result in a bad rate",
     "description": "$1 is the amount of % for slippage"
   },
   "swapSlippageHighTitle": {
     "message": "High slippage"
   },
   "swapSlippageLowDescription": {
-    "message": "A value this low ($1%) may result in a failed swap.",
+    "message": "A value this low ($1%) may result in a failed swap",
     "description": "$1 is the amount of % for slippage"
   },
   "swapSlippageLowTitle": {

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -4650,18 +4650,18 @@
   "swapSlippageNegativeTitle": {
     "message": "Increase slippage to continue"
   },
+  "swapSlippageOverLimitDescription": {
+    "message": "Slippage tolerance must be 15% or less. Anything higher will result in a bad rate."
+  },
+  "swapSlippageOverLimitTitle": {
+    "message": "Very high slippage"
+  },
   "swapSlippagePercent": {
     "message": "$1%",
     "description": "$1 is the amount of % for slippage"
   },
   "swapSlippageTooltip": {
     "message": "If the price changes between the time your order is placed and confirmed it’s called “slippage”. Your swap will automatically cancel if slippage exceeds your “slippage tolerance” setting."
-  },
-  "swapSlippageVeryHighDescription": {
-    "message": "Slippage tolerance must be 15% or less. Anything higher will result in a bad rate."
-  },
-  "swapSlippageVeryHighTitle": {
-    "message": "Very high slippage"
   },
   "swapSlippageZeroDescription": {
     "message": "There are fewer zero-slippage quote providers which will result in a less competitive quote."

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -4376,6 +4376,9 @@
   "swap": {
     "message": "Swap"
   },
+  "swapAdjustSlippage": {
+    "message": "Adjust slippage"
+  },
   "swapAggregator": {
     "message": "Aggregator"
   },
@@ -4433,9 +4436,6 @@
   },
   "swapEditLimit": {
     "message": "Edit limit"
-  },
-  "swapEditTransactionSettings": {
-    "message": "Edit transaction settings"
   },
   "swapEnableDescription": {
     "message": "This is required and gives MetaMask permission to swap your $1.",
@@ -4627,6 +4627,20 @@
   "swapShowLatestQuotes": {
     "message": "Show latest quotes"
   },
+  "swapSlippageHighDescription": {
+    "message": "The slippage entered ($1%) is considered very high and may result in a bad rate.",
+    "description": "$1 is the amount of % for slippage"
+  },
+  "swapSlippageHighTitle": {
+    "message": "High slippage"
+  },
+  "swapSlippageLowDescription": {
+    "message": "A value this low ($1%) may result in a failed swap.",
+    "description": "$1 is the amount of % for slippage"
+  },
+  "swapSlippageLowTitle": {
+    "message": "Low slippage"
+  },
   "swapSlippageNegative": {
     "message": "Slippage must be greater or equal to zero"
   },
@@ -4636,27 +4650,15 @@
   "swapSlippageNegativeTitle": {
     "message": "Increase slippage to continue"
   },
-  "swapSlippageOverLimitDescription": {
-    "message": "Slippage tolerance must be 15% or less. Anything higher will result in a bad rate."
-  },
-  "swapSlippageOverLimitTitle": {
-    "message": "Reduce slippage to continue"
-  },
   "swapSlippagePercent": {
     "message": "$1%",
     "description": "$1 is the amount of % for slippage"
-  },
-  "swapSlippageTooLowDescription": {
-    "message": "Max slippage is too low which may cause your transaction to fail."
-  },
-  "swapSlippageTooLowTitle": {
-    "message": "Increase slippage to avoid transaction failure"
   },
   "swapSlippageTooltip": {
     "message": "If the price changes between the time your order is placed and confirmed it’s called “slippage”. Your swap will automatically cancel if slippage exceeds your “slippage tolerance” setting."
   },
   "swapSlippageVeryHighDescription": {
-    "message": "The slippage entered is considered very high and may result in a bad rate."
+    "message": "Slippage tolerance must be 15% or less. Anything higher will result in a bad rate."
   },
   "swapSlippageVeryHighTitle": {
     "message": "Very high slippage"

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -850,6 +850,9 @@
   "continue": {
     "message": "Continue"
   },
+  "continueAnyway": {
+    "message": "Continue anyway"
+  },
   "contract": {
     "message": "Contract"
   },
@@ -4652,8 +4655,14 @@
   "swapSlippageVeryHighDescription": {
     "message": "The slippage entered is considered very high and may result in a bad rate"
   },
+  "swapSlippageVeryHighDescription": {
+    "message": "Slippage this high means you'll get a bad rate. Are you sure you want to continue this swap?"
+  },
   "swapSlippageVeryHighTitle": {
     "message": "Very high slippage"
+  },
+  "swapSlippageVeryHighTitle": {
+    "message": "Your slippage is very high"
   },
   "swapSlippageZeroDescription": {
     "message": "There are fewer zero-slippage quote providers which will result in a less competitive quote."

--- a/app/_locales/es/messages.json
+++ b/app/_locales/es/messages.json
@@ -4431,9 +4431,6 @@
   "swapEditLimit": {
     "message": "Editar límite"
   },
-  "swapEditTransactionSettings": {
-    "message": "Editar la configuración de la transacción"
-  },
   "swapEnableDescription": {
     "message": "Esta acción es obligatoria y le da permiso a MetaMask para canjear su $1.",
     "description": "Gives the user info about the required approval transaction for swaps. $1 will be the symbol of a token being approved for swaps."
@@ -4637,20 +4634,8 @@
     "message": "$1%",
     "description": "$1 is the amount of % for slippage"
   },
-  "swapSlippageTooLowDescription": {
-    "message": "El desfase máximo es demasiado bajo, lo que puede hacer que su transacción fracase."
-  },
-  "swapSlippageTooLowTitle": {
-    "message": "Aumente el desfase para evitar fallas en las transacciones"
-  },
   "swapSlippageTooltip": {
     "message": "Si el precio cambia entre el momento en que hace el pedido y cuando se confirma, se denomina \"desfase\". El canje se cancelará automáticamente si el desfase supera lo establecido en la configuración de la \"tolerancia de desfase\"."
-  },
-  "swapSlippageVeryHighDescription": {
-    "message": "El desfase ingresado se considera muy alto y puede resultar en una mala tasa"
-  },
-  "swapSlippageVeryHighTitle": {
-    "message": "Desfase muy alto"
   },
   "swapSlippageZeroDescription": {
     "message": "Hay menos proveedores de cotizaciones de deslizamiento cero, lo que resultará en una cotización menos competitiva."

--- a/app/_locales/fr/messages.json
+++ b/app/_locales/fr/messages.json
@@ -4431,9 +4431,6 @@
   "swapEditLimit": {
     "message": "Modifier la limite"
   },
-  "swapEditTransactionSettings": {
-    "message": "Modifier les paramètres de la transaction"
-  },
   "swapEnableDescription": {
     "message": "Cette information est nécessaire et autorise MetaMask à effectuer le swap de vos $1.",
     "description": "Gives the user info about the required approval transaction for swaps. $1 will be the symbol of a token being approved for swaps."
@@ -4637,20 +4634,8 @@
     "message": "$1 %",
     "description": "$1 is the amount of % for slippage"
   },
-  "swapSlippageTooLowDescription": {
-    "message": "La transaction peut échouer, car le slippage maximal est trop faible."
-  },
-  "swapSlippageTooLowTitle": {
-    "message": "Augmentez le slippage pour éviter l’échec de la transaction"
-  },
   "swapSlippageTooltip": {
     "message": "Si le prix fluctue entre le moment où vous placez un ordre et le moment où il est exécuté, on parle alors d’un « effet de glissement » ou « slippage ». Votre swap sera automatiquement annulé si ce phénomène dépasse le « seuil de glissement toléré » que vous avez fixé."
-  },
-  "swapSlippageVeryHighDescription": {
-    "message": "Le slippage saisi est considéré comme très élevé et peut donner lieu à un taux de change désavantageux"
-  },
-  "swapSlippageVeryHighTitle": {
-    "message": "Slippage très élevé"
   },
   "swapSlippageZeroDescription": {
     "message": "Il y a moins de prestataires de services d’investissement sans slippage, ce qui se traduit par une cotation moins compétitive."

--- a/app/_locales/hi/messages.json
+++ b/app/_locales/hi/messages.json
@@ -4431,9 +4431,6 @@
   "swapEditLimit": {
     "message": "सीमा संपादित करें"
   },
-  "swapEditTransactionSettings": {
-    "message": "लेन-देन सेटिंग्स को संपादित करें"
-  },
   "swapEnableDescription": {
     "message": "यह आवश्यक है और MetaMask को आपके $1 को स्वैप करने की अनुमति देता है।",
     "description": "Gives the user info about the required approval transaction for swaps. $1 will be the symbol of a token being approved for swaps."
@@ -4637,20 +4634,8 @@
     "message": "$1%",
     "description": "$1 is the amount of % for slippage"
   },
-  "swapSlippageTooLowDescription": {
-    "message": "अधिकतम स्लिपेज बहुत कम है जिसके कारण आपका लेन-देन विफल हो सकता है।"
-  },
-  "swapSlippageTooLowTitle": {
-    "message": "लेन-देन की विफलता से बचने के लिए स्लिपेज बढ़ाएं"
-  },
   "swapSlippageTooltip": {
     "message": "यदि आपके ऑर्डर किए जाने और पुष्टि किए जाने के समय के बीच मूल्य में परिवर्तन होता है, तो इसे \"स्लिपेज\" कहा जाता है। यदि स्लिपेज आपकी \"स्लिपेज टॉलरेंस\" सेटिंग से अधिक हो जाता है, तो आपका स्वैप स्वतः रद्द हो जाएगा।"
-  },
-  "swapSlippageVeryHighDescription": {
-    "message": "दर्ज किया गया स्लिपेज बहुत अधिक माना जाता है और इसका परिणाम खराब दर हो सकता है"
-  },
-  "swapSlippageVeryHighTitle": {
-    "message": "बहुत अधिक स्लिपेज"
   },
   "swapSlippageZeroDescription": {
     "message": "शून्य-स्लिपेज उद्धरण प्रदाता कम हैं, जिसके परिणामस्वरूप कम प्रतिस्पर्धी उद्धरण होगा।"

--- a/app/_locales/id/messages.json
+++ b/app/_locales/id/messages.json
@@ -4431,9 +4431,6 @@
   "swapEditLimit": {
     "message": "Edit batas"
   },
-  "swapEditTransactionSettings": {
-    "message": "Edit pengaturan transaksi"
-  },
   "swapEnableDescription": {
     "message": "Ini diwajibkan dan memberikan MetaMask izin untuk menukar $1 Anda.",
     "description": "Gives the user info about the required approval transaction for swaps. $1 will be the symbol of a token being approved for swaps."
@@ -4637,20 +4634,8 @@
     "message": "$1%",
     "description": "$1 is the amount of % for slippage"
   },
-  "swapSlippageTooLowDescription": {
-    "message": "Selip maks terlalu rendah sehingga dapat menyebabkan transaksi gagal."
-  },
-  "swapSlippageTooLowTitle": {
-    "message": "Tingkatkan selip untuk menghindari kegagalan transaksi"
-  },
   "swapSlippageTooltip": {
     "message": "Jika harga berubah antara waktu penempatan dan konfirmasi order Anda, ini disebut “slippage”. Swap Anda akan otomatis dibatalkan jika slippage melebihi pengaturan “slippage tolerance”."
-  },
-  "swapSlippageVeryHighDescription": {
-    "message": "Selip yang dimasukkan dianggap sangat tinggi dan dapat mengakibatkan tarif yang tidak efektif"
-  },
-  "swapSlippageVeryHighTitle": {
-    "message": "Selip sangat tinggi"
   },
   "swapSlippageZeroDescription": {
     "message": "Ada lebih sedikit penyedia kuotasi nol selip sehingga akan menghasilkan kuotasi yang kurang kompetitif."

--- a/app/_locales/ja/messages.json
+++ b/app/_locales/ja/messages.json
@@ -4431,9 +4431,6 @@
   "swapEditLimit": {
     "message": "限度額を編集"
   },
-  "swapEditTransactionSettings": {
-    "message": "トランザクション設定を編集"
-  },
   "swapEnableDescription": {
     "message": "これは必須であり、MetaMaskに$1をスワップする許可を付与します。",
     "description": "Gives the user info about the required approval transaction for swaps. $1 will be the symbol of a token being approved for swaps."
@@ -4637,20 +4634,8 @@
     "message": "$1%",
     "description": "$1 is the amount of % for slippage"
   },
-  "swapSlippageTooLowDescription": {
-    "message": "最大スリッページが低すぎ、トランザクションが失敗する可能性があります。"
-  },
-  "swapSlippageTooLowTitle": {
-    "message": "トランザクションの失敗を防ぐために、スリッページを増やしてください。"
-  },
   "swapSlippageTooltip": {
     "message": "注文から確定までの間に価格が変動することを「スリッページ」といいます。スリッページが「スリッページ許容範囲」の設定を超えた場合、スワップは自動的にキャンセルされます。"
-  },
-  "swapSlippageVeryHighDescription": {
-    "message": "入力されたスリッページが非常に高いため、不利なレートになる可能性があります"
-  },
-  "swapSlippageVeryHighTitle": {
-    "message": "非常に高いスリッページ"
   },
   "swapSlippageZeroDescription": {
     "message": "スリッページがゼロのプロバイダーは少ないため、不利なクォートになる可能性があります。"

--- a/app/_locales/ko/messages.json
+++ b/app/_locales/ko/messages.json
@@ -4431,9 +4431,6 @@
   "swapEditLimit": {
     "message": "한도 편집"
   },
-  "swapEditTransactionSettings": {
-    "message": "거래 설정 편집"
-  },
   "swapEnableDescription": {
     "message": "MetaMask에게 $1 스왑 권한을 부여하는 것으로, 이는 필수입니다.",
     "description": "Gives the user info about the required approval transaction for swaps. $1 will be the symbol of a token being approved for swaps."
@@ -4637,20 +4634,8 @@
     "message": "$1%",
     "description": "$1 is the amount of % for slippage"
   },
-  "swapSlippageTooLowDescription": {
-    "message": "최대 슬리피지가 너무 낮아 거래가 실패할 수 있습니다"
-  },
-  "swapSlippageTooLowTitle": {
-    "message": "거래 실패를 막으려면 슬리피지를 높이세요"
-  },
   "swapSlippageTooltip": {
     "message": "주문 시점과 확인 시점 사이에 가격이 변동되는 현상을 \"슬리패지\"라고 합니다. 슬리패지가 \"최대 슬리패지\" 설정을 초과하면 스왑이 자동으로 취소됩니다."
-  },
-  "swapSlippageVeryHighDescription": {
-    "message": "입력한 슬리피지는 너무 높아 가격이 낮아질 수 있습니다"
-  },
-  "swapSlippageVeryHighTitle": {
-    "message": "너무 높은 슬리피지"
   },
   "swapSlippageZeroDescription": {
     "message": "제로 슬리피지 견적 제공자가 거의 없어 견적의 경쟁력이 약화될 수 있습니다"

--- a/app/_locales/pt/messages.json
+++ b/app/_locales/pt/messages.json
@@ -4431,9 +4431,6 @@
   "swapEditLimit": {
     "message": "Editar limite"
   },
-  "swapEditTransactionSettings": {
-    "message": "Editar configurações de transação"
-  },
   "swapEnableDescription": {
     "message": "Isso é obrigatório e dá à MetaMask permissão para trocar o seu $1.",
     "description": "Gives the user info about the required approval transaction for swaps. $1 will be the symbol of a token being approved for swaps."
@@ -4637,20 +4634,8 @@
     "message": "$1%",
     "description": "$1 is the amount of % for slippage"
   },
-  "swapSlippageTooLowDescription": {
-    "message": "O slippage máximo está muito baixo, o que pode fazer sua transação falhar."
-  },
-  "swapSlippageTooLowTitle": {
-    "message": "Aumente o slippage para evitar falha na transação"
-  },
   "swapSlippageTooltip": {
     "message": "Chamamos de \"slippage\" quando o preço muda entre o momento de realização da ordem e sua confirmação. Seu swap será cancelado automaticamente se o slippage exceder sua configuração de \"tolerância a slippage\"."
-  },
-  "swapSlippageVeryHighDescription": {
-    "message": "O slippage inserido é considerado muito alto e pode resultar em uma taxa ruim"
-  },
-  "swapSlippageVeryHighTitle": {
-    "message": "Slippage muito alto"
   },
   "swapSlippageZeroDescription": {
     "message": "Há menos provedores de cotação com slippage zero, o que resultará em uma cotação menos competitiva."

--- a/app/_locales/ru/messages.json
+++ b/app/_locales/ru/messages.json
@@ -4431,9 +4431,6 @@
   "swapEditLimit": {
     "message": "Изменить лимит"
   },
-  "swapEditTransactionSettings": {
-    "message": "Изменить настройки транзакции"
-  },
   "swapEnableDescription": {
     "message": "Это необходимо и дает MetaMask разрешение на обмен вашего $1.",
     "description": "Gives the user info about the required approval transaction for swaps. $1 will be the symbol of a token being approved for swaps."
@@ -4637,20 +4634,8 @@
     "message": "$1%",
     "description": "$1 is the amount of % for slippage"
   },
-  "swapSlippageTooLowDescription": {
-    "message": "Максимальное проскальзывание слишком мало, что может привести к сбою транзакции."
-  },
-  "swapSlippageTooLowTitle": {
-    "message": "Увеличьте проскальзывание, чтобы избежать неудачной транзакции"
-  },
   "swapSlippageTooltip": {
     "message": "Изменение цены в период между размещением заказа и подтверждением называется «проскальзыванием». Обмен будет автоматически отменен, если фактическое проскальзывание превысит установленный «допуск проскальзывания»."
-  },
-  "swapSlippageVeryHighDescription": {
-    "message": "Введенное проскальзывание считается очень высоким и может привести к неудачной ставке"
-  },
-  "swapSlippageVeryHighTitle": {
-    "message": "Очень высокое проскальзывание"
   },
   "swapSlippageZeroDescription": {
     "message": "Существует меньше поставщиков котировок с нулевым проскальзыванием, что приводит к менее конкурентоспособным котировкам."

--- a/app/_locales/tl/messages.json
+++ b/app/_locales/tl/messages.json
@@ -4431,9 +4431,6 @@
   "swapEditLimit": {
     "message": "I-edit ang limitasyon"
   },
-  "swapEditTransactionSettings": {
-    "message": "I-edit ang mga setting ng transaksyon"
-  },
   "swapEnableDescription": {
     "message": "Kinakailangan ito at nagbibigay ito ng pahintulot sa MetaMask na i-swap ang iyong $1.",
     "description": "Gives the user info about the required approval transaction for swaps. $1 will be the symbol of a token being approved for swaps."
@@ -4637,20 +4634,8 @@
     "message": "$1%",
     "description": "$1 is the amount of % for slippage"
   },
-  "swapSlippageTooLowDescription": {
-    "message": "Masyadong mababa ang max slippage na maaaring maging sanhi para mabigo ang iyong transaksyon."
-  },
-  "swapSlippageTooLowTitle": {
-    "message": "Dagdagan ang slippage para maiwasan ang pagkabigo ng transaksyon"
-  },
   "swapSlippageTooltip": {
     "message": "Kung magbabago ang presyo sa pagitan ng oras na nailagay at nakumpirma ang iyong order, tinatawag itong \"slippage\". Awtomatikong makakansela ang iyong swap kung lalampas ang slippage sa iyong setting ng “pagpapahintulot sa slippage”."
-  },
-  "swapSlippageVeryHighDescription": {
-    "message": "Itinuturing na napakataas ng inilagay na slippage at maaari itong magresulta sa hindi magandang rate"
-  },
-  "swapSlippageVeryHighTitle": {
-    "message": "Napakataas na slippage"
   },
   "swapSlippageZeroDescription": {
     "message": "Kakaunti ang mga tagapagbigay ng zero-slippage quote at maaari itong magresulta sa hindi gaanong mapagkumpitensyang quote."

--- a/app/_locales/tr/messages.json
+++ b/app/_locales/tr/messages.json
@@ -4431,9 +4431,6 @@
   "swapEditLimit": {
     "message": "Limiti düzenle"
   },
-  "swapEditTransactionSettings": {
-    "message": "İşlem ayarlarını düzenleyin"
-  },
   "swapEnableDescription": {
     "message": "Bu gereklidir ve MetaMask'e $1 takası yapma izni verir.",
     "description": "Gives the user info about the required approval transaction for swaps. $1 will be the symbol of a token being approved for swaps."
@@ -4637,20 +4634,8 @@
     "message": "%$1",
     "description": "$1 is the amount of % for slippage"
   },
-  "swapSlippageTooLowDescription": {
-    "message": "Maks. fark çok düşük ve bu durum işleminizin başarısız olmasına neden olabilir."
-  },
-  "swapSlippageTooLowTitle": {
-    "message": "İşlemin başarısız olmasını önlemek için farkı artırın"
-  },
   "swapSlippageTooltip": {
     "message": "Emrinizin verildiği ve onaylandığı zamanlar arasında fiyat farkı oluşursa buna \"fark\" denir. Fark, \"fark toleransı\" ayarınızı aşarsa takas işleminiz otomatik olarak iptal edilir."
-  },
-  "swapSlippageVeryHighDescription": {
-    "message": "Girilen fark çok yüksek kabul ediliyor ve kötü bir oranla sonuçlanabilir"
-  },
-  "swapSlippageVeryHighTitle": {
-    "message": "Fark çok yüksek"
   },
   "swapSlippageZeroDescription": {
     "message": "Daha az rekabetçi bir kota ile sonuçlanacak olan az sayıda sıfır fark kotalı sağlayıcı var."

--- a/app/_locales/vi/messages.json
+++ b/app/_locales/vi/messages.json
@@ -4431,9 +4431,6 @@
   "swapEditLimit": {
     "message": "Chỉnh sửa giới hạn"
   },
-  "swapEditTransactionSettings": {
-    "message": "Chỉnh sửa cài đặt giao dịch"
-  },
   "swapEnableDescription": {
     "message": "Thao tác này là bắt buộc và cấp cho MetaMask quyền hoán đổi $1 của bạn.",
     "description": "Gives the user info about the required approval transaction for swaps. $1 will be the symbol of a token being approved for swaps."
@@ -4637,20 +4634,8 @@
     "message": "$1%",
     "description": "$1 is the amount of % for slippage"
   },
-  "swapSlippageTooLowDescription": {
-    "message": "Mức trượt giá tối đa quá thấp có thể khiến giao dịch của bạn không thành công."
-  },
-  "swapSlippageTooLowTitle": {
-    "message": "Tăng mức trượt giá để tránh giao dịch thất bại"
-  },
   "swapSlippageTooltip": {
     "message": "Khi giá giữa thời điểm đặt lệnh và thời điểm xác nhận lệnh thay đổi, hiện tượng này được gọi là \"trượt giá\". Giao dịch hoán đổi của bạn sẽ tự động hủy nếu mức trượt giá vượt quá \"mức trượt giá cho phép\" đã đặt."
-  },
-  "swapSlippageVeryHighDescription": {
-    "message": "Mức trượt giá đã nhập được xem là quá cao và có thể dẫn đến tỷ giá không sinh lời"
-  },
-  "swapSlippageVeryHighTitle": {
-    "message": "Mức trượt giá quá cao"
   },
   "swapSlippageZeroDescription": {
     "message": "Có ít nhà cung cấp báo giá có mức trượt giá bằng 0 hơn sẽ dẫn đến báo giá kém cạnh tranh hơn."

--- a/app/_locales/zh_CN/messages.json
+++ b/app/_locales/zh_CN/messages.json
@@ -4431,9 +4431,6 @@
   "swapEditLimit": {
     "message": "编辑限制"
   },
-  "swapEditTransactionSettings": {
-    "message": "编辑交易设置"
-  },
   "swapEnableDescription": {
     "message": "这是必须的，并且允许 MetaMask 兑换您的 $1。",
     "description": "Gives the user info about the required approval transaction for swaps. $1 will be the symbol of a token being approved for swaps."
@@ -4637,20 +4634,8 @@
     "message": "$1%",
     "description": "$1 is the amount of % for slippage"
   },
-  "swapSlippageTooLowDescription": {
-    "message": "最大滑点太低，可能导致交易失败。"
-  },
-  "swapSlippageTooLowTitle": {
-    "message": "提高滑点以避免交易失败"
-  },
   "swapSlippageTooltip": {
     "message": "如果价格于下单到订单确认期间发生变化，这被称为“滑点”。如果滑点超过“最大滑点”设置，您的兑换将会自动取消。"
-  },
-  "swapSlippageVeryHighDescription": {
-    "message": "输入的滑点被认为非常高，可能导致不良费率"
-  },
-  "swapSlippageVeryHighTitle": {
-    "message": "非常高的滑点"
   },
   "swapSlippageZeroDescription": {
     "message": "零滑点报价供应商较少，这将导致报价竞争力下降。"

--- a/shared/constants/swaps.ts
+++ b/shared/constants/swaps.ts
@@ -20,6 +20,8 @@ export const SLIPPAGE_VERY_HIGH_ERROR = 'slippage-very-high';
 export const SLIPPAGE_TOO_LOW_ERROR = 'slippage-too-low';
 export const SLIPPAGE_NEGATIVE_ERROR = 'slippage-negative';
 
+export const MAX_ALLOWED_SLIPPAGE = 15;
+
 // An address that the metaswap-api recognizes as the default token for the current network,
 // in place of the token address that ERC-20 tokens have
 const DEFAULT_TOKEN_ADDRESS = '0x0000000000000000000000000000000000000000';

--- a/shared/constants/swaps.ts
+++ b/shared/constants/swaps.ts
@@ -15,9 +15,9 @@ export const QUOTES_NOT_AVAILABLE_ERROR = 'quotes-not-avilable';
 export const CONTRACT_DATA_DISABLED_ERROR = 'contract-data-disabled';
 export const OFFLINE_FOR_MAINTENANCE = 'offline-for-maintenance';
 export const SWAPS_FETCH_ORDER_CONFLICT = 'swaps-fetch-order-conflict';
-export const SLIPPAGE_OVER_LIMIT_ERROR = 'slippage-over-limit';
 export const SLIPPAGE_VERY_HIGH_ERROR = 'slippage-very-high';
-export const SLIPPAGE_TOO_LOW_ERROR = 'slippage-too-low';
+export const SLIPPAGE_HIGH_ERROR = 'slippage-high';
+export const SLIPPAGE_LOW_ERROR = 'slippage-low';
 export const SLIPPAGE_NEGATIVE_ERROR = 'slippage-negative';
 
 export const MAX_ALLOWED_SLIPPAGE = 15;

--- a/test/e2e/swaps/swaps-notifications.spec.js
+++ b/test/e2e/swaps/swaps-notifications.spec.js
@@ -172,12 +172,12 @@ describe('Swaps - notifications', function () {
         await driver.fill('input[data-testid*="slippage"]', '1');
         await checkNotification(driver, {
           title: 'Low slippage',
-          text: 'A value this low (1%) may result in a failed swap.',
+          text: 'A value this low (1%) may result in a failed swap',
         });
         await driver.fill('input[data-testid*="slippage"]', '15');
         await checkNotification(driver, {
           title: 'High slippage',
-          text: 'The slippage entered (15%) is considered very high and may result in a bad rate.',
+          text: 'The slippage entered (15%) is considered very high and may result in a bad rate',
         });
         await driver.fill('input[data-testid*="slippage"]', '20');
         await checkNotification(driver, {

--- a/test/e2e/swaps/swaps-notifications.spec.js
+++ b/test/e2e/swaps/swaps-notifications.spec.js
@@ -171,17 +171,17 @@ describe('Swaps - notifications', function () {
         });
         await driver.fill('input[data-testid*="slippage"]', '1');
         await checkNotification(driver, {
-          title: 'Increase slippage to avoid transaction failure',
-          text: 'Max slippage is too low which may cause your transaction to fail.',
+          title: 'Low slippage',
+          text: 'A value this low (1%) may result in a failed swap.',
         });
         await driver.fill('input[data-testid*="slippage"]', '15');
         await checkNotification(driver, {
-          title: 'Very high slippage',
-          text: 'The slippage entered is considered very high and may result in a bad rate',
+          title: 'High slippage',
+          text: 'The slippage entered (15%) is considered very high and may result in a bad rate.',
         });
         await driver.fill('input[data-testid*="slippage"]', '20');
         await checkNotification(driver, {
-          title: 'Reduce slippage to continue',
+          title: 'Very high slippage',
           text: 'Slippage tolerance must be 15% or less. Anything higher will result in a bad rate.',
         });
         await driver.fill('input[data-testid*="slippage"]', '4');

--- a/ui/pages/swaps/build-quote/build-quote.js
+++ b/ui/pages/swaps/build-quote/build-quote.js
@@ -81,6 +81,7 @@ import {
   SWAPS_CHAINID_DEFAULT_BLOCK_EXPLORER_URL_MAP,
   SWAPS_CHAINID_DEFAULT_TOKEN_MAP,
   TokenBucketPriority,
+  MAX_ALLOWED_SLIPPAGE,
 } from '../../../../shared/constants/swaps';
 
 import {
@@ -109,8 +110,6 @@ const fuseSearchKeys = [
   { name: 'symbol', weight: 0.499 },
   { name: 'address', weight: 0.002 },
 ];
-
-const MAX_ALLOWED_SLIPPAGE = 15;
 
 let timeoutIdForQuotesPrefetching;
 

--- a/ui/pages/swaps/prepare-swap-page/prepare-swap-page.js
+++ b/ui/pages/swaps/prepare-swap-page/prepare-swap-page.js
@@ -90,6 +90,7 @@ import {
   ERROR_FETCHING_QUOTES,
   QUOTES_NOT_AVAILABLE_ERROR,
   QUOTES_EXPIRED_ERROR,
+  MAX_ALLOWED_SLIPPAGE,
 } from '../../../../shared/constants/swaps';
 import {
   resetSwapsPostFetchState,
@@ -136,8 +137,6 @@ import ListWithSearch from '../list-with-search/list-with-search';
 import SmartTransactionsPopover from './smart-transactions-popover';
 import QuotesLoadingAnimation from './quotes-loading-animation';
 import ReviewQuote from './review-quote';
-
-const MAX_ALLOWED_SLIPPAGE = 15;
 
 let timeoutIdForQuotesPrefetching;
 

--- a/ui/pages/swaps/prepare-swap-page/prepare-swap-page.js
+++ b/ui/pages/swaps/prepare-swap-page/prepare-swap-page.js
@@ -1076,7 +1076,10 @@ export default function PrepareSwapPage({
         )}
         {swapsErrorKey && (
           <Box display={DISPLAY.FLEX} marginTop={2}>
-            <SwapsBannerAlert swapsErrorKey={swapsErrorKey} />
+            <SwapsBannerAlert
+              swapsErrorKey={swapsErrorKey}
+              currentSlippage={maxSlippage}
+            />
           </Box>
         )}
         {transactionSettingsOpened &&

--- a/ui/pages/swaps/prepare-swap-page/review-quote.js
+++ b/ui/pages/swaps/prepare-swap-page/review-quote.js
@@ -99,8 +99,8 @@ import {
 import { useTokenTracker } from '../../../hooks/useTokenTracker';
 import {
   QUOTES_EXPIRED_ERROR,
-  SLIPPAGE_VERY_HIGH_ERROR,
-  SLIPPAGE_TOO_LOW_ERROR,
+  SLIPPAGE_HIGH_ERROR,
+  SLIPPAGE_LOW_ERROR,
   MAX_ALLOWED_SLIPPAGE,
 } from '../../../../shared/constants/swaps';
 import { GasRecommendations } from '../../../../shared/constants/gas';
@@ -241,9 +241,9 @@ export default function ReviewQuote({ setReceiveToAmount }) {
   const [slippageErrorKey] = useState(() => {
     const slippage = Number(fetchParams?.slippage);
     if (slippage > 0 && slippage <= 1) {
-      return SLIPPAGE_TOO_LOW_ERROR;
+      return SLIPPAGE_LOW_ERROR;
     } else if (slippage >= 5 && slippage <= MAX_ALLOWED_SLIPPAGE) {
-      return SLIPPAGE_VERY_HIGH_ERROR;
+      return SLIPPAGE_HIGH_ERROR;
     }
     return '';
   });
@@ -1108,6 +1108,7 @@ export default function ReviewQuote({ setReceiveToAmount }) {
           }
           slippageErrorKey={slippageErrorKey}
           onSwapSubmit={onSwapSubmit}
+          currentSlippage={fetchParams?.slippage}
         />
         {
           /* istanbul ignore next */

--- a/ui/pages/swaps/prepare-swap-page/slippage-notification-modal.stories.tsx
+++ b/ui/pages/swaps/prepare-swap-page/slippage-notification-modal.stories.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { StoryFn, Meta } from '@storybook/react';
+import { useArgs } from '@storybook/client-api';
+
+import { BUTTON_VARIANT, Button } from '../../../components/component-library';
+import { SLIPPAGE_HIGH_ERROR } from '../../../../shared/constants/swaps';
+import SlippageNotificationModal from './slippage-notification-modal';
+
+export default {
+  title: 'Pages/Swaps/SlippageNotificationModal',
+  component: SlippageNotificationModal,
+  argTypes: {
+    isShowingModal: {
+      control: 'boolean',
+    },
+  },
+} as Meta<typeof SlippageNotificationModal>;
+
+export const DefaultStory: StoryFn<typeof SlippageNotificationModal> = () => {
+  const [{ isShowingModal }, updateArgs] = useArgs();
+  const toggleModal = () => updateArgs({ isShowingModal: !isShowingModal });
+
+  return (
+    <>
+      <Button variant={BUTTON_VARIANT.PRIMARY} onClick={toggleModal}>
+        Open modal
+      </Button>
+      {isShowingModal && (
+        <SlippageNotificationModal
+          isOpen={isShowingModal}
+          slippageErrorKey={SLIPPAGE_HIGH_ERROR}
+          onSwapSubmit={() => {
+            console.log('onSwapSubmit');
+          }}
+          currentSlippage={10}
+          setSlippageNotificationModalOpened={toggleModal}
+        />
+      )}
+    </>
+  );
+};
+
+DefaultStory.storyName = 'Default';

--- a/ui/pages/swaps/prepare-swap-page/slippage-notification-modal.test.tsx
+++ b/ui/pages/swaps/prepare-swap-page/slippage-notification-modal.test.tsx
@@ -1,64 +1,76 @@
 import React from 'react';
+import configureMockStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
 
-import { renderWithProvider, fireEvent } from '../../../../test/jest';
 import {
-  SLIPPAGE_VERY_HIGH_ERROR,
-  SLIPPAGE_TOO_LOW_ERROR,
+  renderWithProvider,
+  fireEvent,
+  createSwapsMockStore,
+  screen,
+} from '../../../../test/jest';
+import {
+  SLIPPAGE_HIGH_ERROR,
+  SLIPPAGE_LOW_ERROR,
 } from '../../../../shared/constants/swaps';
 import SlippageNotificationModal from './slippage-notification-modal';
+
+const middleware = [thunk];
 
 const createProps = (customProps = {}) => {
   return {
     isOpen: true,
-    slippageErrorKey: SLIPPAGE_VERY_HIGH_ERROR,
+    slippageErrorKey: SLIPPAGE_HIGH_ERROR,
     setSlippageNotificationModalOpened: jest.fn(),
     onSwapSubmit: jest.fn(),
+    currentSlippage: 1,
     ...customProps,
   };
 };
 
 describe('SlippageNotificationModal', () => {
-  it('renders the component with the SLIPPAGE_VERY_HIGH_ERROR, clicks on "Swap anyway"', () => {
-    const props = createProps();
+  it('renders the component with the SLIPPAGE_HIGH_ERROR, clicks on "Swap anyway"', () => {
+    const store = configureMockStore(middleware)(createSwapsMockStore());
+    const props = createProps({ currentSlippage: 10 });
     const { getByText } = renderWithProvider(
       <SlippageNotificationModal {...props} />,
+      store,
     );
-    expect(getByText('High slippage')).toBeInTheDocument();
-    expect(getByText('Very high slippage')).toBeInTheDocument();
+    expect(screen.getByTestId('swaps-banner-title')).toHaveTextContent(
+      'High slippage',
+    );
     expect(
       getByText(
-        'The slippage entered is considered very high and may result in a bad rate.',
+        'The slippage entered (10%) is considered very high and may result in a bad rate.',
       ),
     ).toBeInTheDocument();
-    expect(getByText('Edit transaction settings')).toBeInTheDocument();
+    expect(getByText('Adjust slippage')).toBeInTheDocument();
     const swapAnywayButton = getByText('Swap anyway');
     expect(swapAnywayButton).toBeInTheDocument();
     fireEvent.click(swapAnywayButton);
     expect(props.onSwapSubmit).toHaveBeenCalledWith({
       acknowledgedSlippage: true,
     });
-    expect(props.setSlippageNotificationModalOpened).toHaveBeenCalledWith(
+    expect(props.setSlippageNotificationModalOpened).not.toHaveBeenCalledWith(
       false,
     );
   });
 
-  it('renders the component with the SLIPPAGE_TOO_LOW_ERROR, clicks on "Swap anyway"', () => {
+  it('renders the component with the SLIPPAGE_LOW_ERROR, clicks on "Swap anyway"', () => {
+    const store = configureMockStore(middleware)(createSwapsMockStore());
     const props = createProps({
-      slippageErrorKey: SLIPPAGE_TOO_LOW_ERROR,
+      slippageErrorKey: SLIPPAGE_LOW_ERROR,
     });
     const { getByText } = renderWithProvider(
       <SlippageNotificationModal {...props} />,
+      store,
     );
-    expect(getByText('Low slippage')).toBeInTheDocument();
+    expect(screen.getByTestId('swaps-banner-title')).toHaveTextContent(
+      'Low slippage',
+    );
     expect(
-      getByText('Increase slippage to avoid transaction failure'),
+      getByText('A value this low (1%) may result in a failed swap.'),
     ).toBeInTheDocument();
-    expect(
-      getByText(
-        'Max slippage is too low which may cause your transaction to fail.',
-      ),
-    ).toBeInTheDocument();
-    expect(getByText('Edit transaction settings')).toBeInTheDocument();
+    expect(getByText('Adjust slippage')).toBeInTheDocument();
     expect(getByText('Swap anyway')).toBeInTheDocument();
     const swapAnywayButton = getByText('Swap anyway');
     expect(swapAnywayButton).toBeInTheDocument();
@@ -66,7 +78,7 @@ describe('SlippageNotificationModal', () => {
     expect(props.onSwapSubmit).toHaveBeenCalledWith({
       acknowledgedSlippage: true,
     });
-    expect(props.setSlippageNotificationModalOpened).toHaveBeenCalledWith(
+    expect(props.setSlippageNotificationModalOpened).not.toHaveBeenCalledWith(
       false,
     );
   });

--- a/ui/pages/swaps/prepare-swap-page/slippage-notification-modal.test.tsx
+++ b/ui/pages/swaps/prepare-swap-page/slippage-notification-modal.test.tsx
@@ -1,0 +1,99 @@
+import React from 'react';
+import configureMockStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+
+import {
+  renderWithProvider,
+  fireEvent,
+  createSwapsMockStore,
+} from '../../../../test/jest';
+import {
+  SLIPPAGE_VERY_HIGH_ERROR,
+  SLIPPAGE_TOO_LOW_ERROR,
+} from '../../../../shared/constants/swaps';
+import SlippageNotificationModal from './slippage-notification-modal';
+
+jest.mock('react-redux', () => {
+  const actual = jest.requireActual('react-redux');
+
+  return {
+    ...actual,
+    useDispatch: () => jest.fn(),
+  };
+});
+
+const createProps = (customProps = {}) => {
+  return {
+    isOpen: true,
+    slippageErrorKey: SLIPPAGE_VERY_HIGH_ERROR,
+    setSlippageNotificationModalOpened: jest.fn(),
+    onSwapSubmit: jest.fn(),
+    ...customProps,
+  };
+};
+
+const middleware = [thunk];
+
+describe('SlippageNotificationModal', () => {
+  let store;
+
+  beforeEach(() => {
+    const swapsMockStore = createSwapsMockStore();
+    store = configureMockStore(middleware)(swapsMockStore);
+  });
+
+  it('renders the component with the SLIPPAGE_VERY_HIGH_ERROR, clicks on "Swap anyway"', () => {
+    const props = createProps();
+    const { getByText } = renderWithProvider(
+      <SlippageNotificationModal {...props} />,
+      store,
+    );
+    expect(getByText('High slippage')).toBeInTheDocument();
+    expect(getByText('Very high slippage')).toBeInTheDocument();
+    expect(
+      getByText(
+        'The slippage entered is considered very high and may result in a bad rate.',
+      ),
+    ).toBeInTheDocument();
+    expect(getByText('Edit transaction settings')).toBeInTheDocument();
+    const swapAnywayButton = getByText('Swap anyway');
+    expect(swapAnywayButton).toBeInTheDocument();
+    fireEvent.click(swapAnywayButton);
+    expect(props.onSwapSubmit).toHaveBeenCalledWith({
+      acknowledgedSlippage: true,
+    });
+    expect(props.setSlippageNotificationModalOpened).toHaveBeenCalledWith(
+      false,
+    );
+  });
+
+  it('renders the component with the SLIPPAGE_TOO_LOW_ERROR, clicks on "Swap anyway"', () => {
+    const props = createProps({
+      slippageErrorKey: SLIPPAGE_TOO_LOW_ERROR,
+    });
+    const { getByText } = renderWithProvider(
+      <SlippageNotificationModal {...props} />,
+      store,
+    );
+    expect(getByText('Low slippage')).toBeInTheDocument();
+    expect(
+      getByText('Increase slippage to avoid transaction failure'),
+    ).toBeInTheDocument();
+    expect(
+      getByText(
+        'Max slippage is too low which may cause your transaction to fail.',
+      ),
+    ).toBeInTheDocument();
+    expect(getByText('Edit transaction settings')).toBeInTheDocument();
+    expect(getByText('Swap anyway')).toBeInTheDocument();
+    const swapAnywayButton = getByText('Swap anyway');
+    expect(swapAnywayButton).toBeInTheDocument();
+    fireEvent.click(swapAnywayButton);
+    expect(props.onSwapSubmit).toHaveBeenCalledWith({
+      acknowledgedSlippage: true,
+    });
+    expect(props.setSlippageNotificationModalOpened).toHaveBeenCalledWith(
+      false,
+    );
+  });
+});

--- a/ui/pages/swaps/prepare-swap-page/slippage-notification-modal.test.tsx
+++ b/ui/pages/swaps/prepare-swap-page/slippage-notification-modal.test.tsx
@@ -1,26 +1,11 @@
 import React from 'react';
-import configureMockStore from 'redux-mock-store';
-import thunk from 'redux-thunk';
 
-import {
-  renderWithProvider,
-  fireEvent,
-  createSwapsMockStore,
-} from '../../../../test/jest';
+import { renderWithProvider, fireEvent } from '../../../../test/jest';
 import {
   SLIPPAGE_VERY_HIGH_ERROR,
   SLIPPAGE_TOO_LOW_ERROR,
 } from '../../../../shared/constants/swaps';
 import SlippageNotificationModal from './slippage-notification-modal';
-
-jest.mock('react-redux', () => {
-  const actual = jest.requireActual('react-redux');
-
-  return {
-    ...actual,
-    useDispatch: () => jest.fn(),
-  };
-});
 
 const createProps = (customProps = {}) => {
   return {
@@ -32,21 +17,11 @@ const createProps = (customProps = {}) => {
   };
 };
 
-const middleware = [thunk];
-
 describe('SlippageNotificationModal', () => {
-  let store;
-
-  beforeEach(() => {
-    const swapsMockStore = createSwapsMockStore();
-    store = configureMockStore(middleware)(swapsMockStore);
-  });
-
   it('renders the component with the SLIPPAGE_VERY_HIGH_ERROR, clicks on "Swap anyway"', () => {
     const props = createProps();
     const { getByText } = renderWithProvider(
       <SlippageNotificationModal {...props} />,
-      store,
     );
     expect(getByText('High slippage')).toBeInTheDocument();
     expect(getByText('Very high slippage')).toBeInTheDocument();
@@ -73,7 +48,6 @@ describe('SlippageNotificationModal', () => {
     });
     const { getByText } = renderWithProvider(
       <SlippageNotificationModal {...props} />,
-      store,
     );
     expect(getByText('Low slippage')).toBeInTheDocument();
     expect(

--- a/ui/pages/swaps/prepare-swap-page/slippage-notification-modal.test.tsx
+++ b/ui/pages/swaps/prepare-swap-page/slippage-notification-modal.test.tsx
@@ -40,7 +40,7 @@ describe('SlippageNotificationModal', () => {
     );
     expect(
       getByText(
-        'The slippage entered (10%) is considered very high and may result in a bad rate.',
+        'The slippage entered (10%) is considered very high and may result in a bad rate',
       ),
     ).toBeInTheDocument();
     expect(getByText('Adjust slippage')).toBeInTheDocument();
@@ -68,7 +68,7 @@ describe('SlippageNotificationModal', () => {
       'Low slippage',
     );
     expect(
-      getByText('A value this low (1%) may result in a failed swap.'),
+      getByText('A value this low (1%) may result in a failed swap'),
     ).toBeInTheDocument();
     expect(getByText('Adjust slippage')).toBeInTheDocument();
     expect(getByText('Swap anyway')).toBeInTheDocument();

--- a/ui/pages/swaps/prepare-swap-page/slippage-notification-modal.tsx
+++ b/ui/pages/swaps/prepare-swap-page/slippage-notification-modal.tsx
@@ -1,0 +1,89 @@
+import React, { useContext } from 'react';
+
+import { I18nContext } from '../../../contexts/i18n';
+import {
+  FlexDirection,
+  Display,
+  JustifyContent,
+  AlignItems,
+} from '../../../helpers/constants/design-system';
+import {
+  Modal,
+  ModalContent,
+  ModalHeader,
+  ModalOverlay,
+  Box,
+  ButtonPrimary,
+} from '../../../components/component-library';
+import {
+  SLIPPAGE_VERY_HIGH_ERROR,
+  SLIPPAGE_TOO_LOW_ERROR,
+} from '../../../../shared/constants/swaps';
+import SwapsBannerAlert from '../swaps-banner-alert/swaps-banner-alert';
+
+interface Props {
+  isOpen: boolean;
+  slippageErrorKey: string;
+  setSlippageNotificationModalOpened: (isOpen: boolean) => void;
+  onSwapSubmit: (opts: { acknowledgedSlippage: boolean }) => void;
+}
+
+export default function SlippageNotificationModal({
+  isOpen,
+  slippageErrorKey,
+  setSlippageNotificationModalOpened,
+  onSwapSubmit,
+}: Props) {
+  const t = useContext(I18nContext);
+
+  const getSlippageModalTitle = () => {
+    if (slippageErrorKey === SLIPPAGE_VERY_HIGH_ERROR) {
+      return t('swapHighSlippage');
+    } else if (slippageErrorKey === SLIPPAGE_TOO_LOW_ERROR) {
+      return t('swapLowSlippage');
+    }
+    return '';
+  };
+
+  return (
+    <Modal
+      onClose={() => setSlippageNotificationModalOpened(false)}
+      isOpen={isOpen}
+      isClosedOnOutsideClick
+      isClosedOnEscapeKey
+      className="mm-modal__custom-scrollbar"
+    >
+      <ModalOverlay />
+      <ModalContent>
+        <ModalHeader onClose={() => setSlippageNotificationModalOpened(false)}>
+          {getSlippageModalTitle()}
+        </ModalHeader>
+        <Box
+          display={Display.Flex}
+          flexDirection={FlexDirection.Column}
+          justifyContent={JustifyContent.spaceBetween}
+          alignItems={AlignItems.stretch}
+          className="high-slippage__content"
+          marginTop={7}
+        >
+          <SwapsBannerAlert
+            swapsErrorKey={slippageErrorKey}
+            showTransactionSettingsLink
+          />
+          <Box marginTop={5}>
+            <ButtonPrimary
+              onClick={() => {
+                setSlippageNotificationModalOpened(false);
+                onSwapSubmit({ acknowledgedSlippage: true });
+              }}
+              block
+              data-testid="high-slippage-continue-anyway"
+            >
+              {t('swapAnyway')}
+            </ButtonPrimary>
+          </Box>
+        </Box>
+      </ModalContent>
+    </Modal>
+  );
+}

--- a/ui/pages/swaps/prepare-swap-page/slippage-notification-modal.tsx
+++ b/ui/pages/swaps/prepare-swap-page/slippage-notification-modal.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import React, { useContext, useState } from 'react';
 
 import { I18nContext } from '../../../contexts/i18n';
 import {
@@ -35,6 +35,7 @@ export default function SlippageNotificationModal({
   onSwapSubmit,
 }: Props) {
   const t = useContext(I18nContext);
+  const [submitting, setSubmitting] = useState(false);
 
   const getSlippageModalTitle = () => {
     if (slippageErrorKey === SLIPPAGE_VERY_HIGH_ERROR) {
@@ -44,6 +45,8 @@ export default function SlippageNotificationModal({
     }
     return '';
   };
+
+  const primaryButtonText = submitting ? t('preparingSwap') : t('swapAnyway');
 
   return (
     <Modal
@@ -73,13 +76,14 @@ export default function SlippageNotificationModal({
           <Box marginTop={5}>
             <ButtonPrimary
               onClick={() => {
-                setSlippageNotificationModalOpened(false);
+                setSubmitting(true);
                 onSwapSubmit({ acknowledgedSlippage: true });
               }}
               block
               data-testid="high-slippage-continue-anyway"
+              disabled={submitting}
             >
-              {t('swapAnyway')}
+              {primaryButtonText}
             </ButtonPrimary>
           </Box>
         </Box>

--- a/ui/pages/swaps/prepare-swap-page/slippage-notification-modal.tsx
+++ b/ui/pages/swaps/prepare-swap-page/slippage-notification-modal.tsx
@@ -16,8 +16,8 @@ import {
   ButtonPrimary,
 } from '../../../components/component-library';
 import {
-  SLIPPAGE_VERY_HIGH_ERROR,
-  SLIPPAGE_TOO_LOW_ERROR,
+  SLIPPAGE_HIGH_ERROR,
+  SLIPPAGE_LOW_ERROR,
 } from '../../../../shared/constants/swaps';
 import SwapsBannerAlert from '../swaps-banner-alert/swaps-banner-alert';
 
@@ -26,6 +26,7 @@ interface Props {
   slippageErrorKey: string;
   setSlippageNotificationModalOpened: (isOpen: boolean) => void;
   onSwapSubmit: (opts: { acknowledgedSlippage: boolean }) => void;
+  currentSlippage: number;
 }
 
 export default function SlippageNotificationModal({
@@ -33,14 +34,15 @@ export default function SlippageNotificationModal({
   slippageErrorKey,
   setSlippageNotificationModalOpened,
   onSwapSubmit,
+  currentSlippage,
 }: Props) {
   const t = useContext(I18nContext);
   const [submitting, setSubmitting] = useState(false);
 
   const getSlippageModalTitle = () => {
-    if (slippageErrorKey === SLIPPAGE_VERY_HIGH_ERROR) {
+    if (slippageErrorKey === SLIPPAGE_HIGH_ERROR) {
       return t('swapHighSlippage');
-    } else if (slippageErrorKey === SLIPPAGE_TOO_LOW_ERROR) {
+    } else if (slippageErrorKey === SLIPPAGE_LOW_ERROR) {
       return t('swapLowSlippage');
     }
     return '';
@@ -72,6 +74,7 @@ export default function SlippageNotificationModal({
           <SwapsBannerAlert
             swapsErrorKey={slippageErrorKey}
             showTransactionSettingsLink
+            currentSlippage={currentSlippage}
           />
           <Box marginTop={5}>
             <ButtonPrimary

--- a/ui/pages/swaps/swaps-banner-alert/swaps-banner-alert.js
+++ b/ui/pages/swaps/swaps-banner-alert/swaps-banner-alert.js
@@ -23,9 +23,9 @@ import {
   QUOTES_NOT_AVAILABLE_ERROR,
   CONTRACT_DATA_DISABLED_ERROR,
   OFFLINE_FOR_MAINTENANCE,
-  SLIPPAGE_OVER_LIMIT_ERROR,
   SLIPPAGE_VERY_HIGH_ERROR,
-  SLIPPAGE_TOO_LOW_ERROR,
+  SLIPPAGE_HIGH_ERROR,
+  SLIPPAGE_LOW_ERROR,
   SLIPPAGE_NEGATIVE_ERROR,
 } from '../../../../shared/constants/swaps';
 import { setTransactionSettingsOpened } from '../../../ducks/swaps/swaps';
@@ -33,6 +33,7 @@ import { setTransactionSettingsOpened } from '../../../ducks/swaps/swaps';
 export default function SwapsBannerAlert({
   swapsErrorKey,
   showTransactionSettingsLink,
+  currentSlippage,
 }) {
   const t = useContext(I18nContext);
   const dispatch = useDispatch();
@@ -52,41 +53,41 @@ export default function SwapsBannerAlert({
         dispatch(setTransactionSettingsOpened(true));
       }}
     >
-      {t('swapEditTransactionSettings')}
+      {t('swapAdjustSlippage')}
     </ButtonLink>
   );
 
   switch (swapsErrorKey) {
-    case SLIPPAGE_OVER_LIMIT_ERROR:
-      title = t('swapSlippageOverLimitTitle');
-      description = (
-        <Box>
-          <Text variant={TextVariant.bodyMd} as="h6">
-            {t('swapSlippageOverLimitDescription')}
-          </Text>
-          {transactionSettingsLink}
-        </Box>
-      );
-      break;
     case SLIPPAGE_VERY_HIGH_ERROR:
-      severity = SEVERITIES.WARNING;
       title = t('swapSlippageVeryHighTitle');
       description = (
         <Box>
           <Text variant={TextVariant.bodyMd} as="h6">
             {t('swapSlippageVeryHighDescription')}
           </Text>
+          {transactionSettingsLink}
+        </Box>
+      );
+      break;
+    case SLIPPAGE_HIGH_ERROR:
+      severity = SEVERITIES.WARNING;
+      title = t('swapSlippageHighTitle');
+      description = (
+        <Box>
+          <Text variant={TextVariant.bodyMd} as="h6">
+            {t('swapSlippageHighDescription', [currentSlippage])}
+          </Text>
           {showTransactionSettingsLink && transactionSettingsLink}
         </Box>
       );
       break;
-    case SLIPPAGE_TOO_LOW_ERROR:
+    case SLIPPAGE_LOW_ERROR:
       severity = SEVERITIES.WARNING;
-      title = t('swapSlippageTooLowTitle');
+      title = t('swapSlippageLowTitle');
       description = (
         <Box>
           <Text variant={TextVariant.bodyMd} as="h6">
-            {t('swapSlippageTooLowDescription')}
+            {t('swapSlippageLowDescription', [currentSlippage])}
           </Text>
           {showTransactionSettingsLink && transactionSettingsLink}
         </Box>
@@ -178,4 +179,5 @@ export default function SwapsBannerAlert({
 SwapsBannerAlert.propTypes = {
   swapsErrorKey: PropTypes.string,
   showTransactionSettingsLink: PropTypes.bool,
+  currentSlippage: PropTypes.number,
 };

--- a/ui/pages/swaps/swaps-banner-alert/swaps-banner-alert.js
+++ b/ui/pages/swaps/swaps-banner-alert/swaps-banner-alert.js
@@ -42,19 +42,17 @@ export default function SwapsBannerAlert({
   let description;
 
   const transactionSettingsLink = (
-    <ButtonLink
-      size={ButtonLinkSize.Inherit}
-      textProps={{
-        variant: TextVariant.bodyMd,
-        alignItems: AlignItems.flexStart,
-      }}
-      onClick={(e) => {
-        e.preventDefault();
-        dispatch(setTransactionSettingsOpened(true));
-      }}
-    >
-      {t('swapAdjustSlippage')}
-    </ButtonLink>
+    <Text variant={TextVariant.bodyMd}>
+      <ButtonLink
+        onClick={(e) => {
+          e.preventDefault();
+          dispatch(setTransactionSettingsOpened(true));
+        }}
+        size={ButtonLinkSize.Inherit}
+      >
+        {t('swapAdjustSlippage')}
+      </ButtonLink>
+    </Text>
   );
 
   switch (swapsErrorKey) {

--- a/ui/pages/swaps/swaps-banner-alert/swaps-banner-alert.js
+++ b/ui/pages/swaps/swaps-banner-alert/swaps-banner-alert.js
@@ -57,11 +57,11 @@ export default function SwapsBannerAlert({
 
   switch (swapsErrorKey) {
     case SLIPPAGE_VERY_HIGH_ERROR:
-      title = t('swapSlippageVeryHighTitle');
+      title = t('swapSlippageOverLimitTitle');
       description = (
         <Box>
           <Text variant={TextVariant.bodyMd} as="h6">
-            {t('swapSlippageVeryHighDescription')}
+            {t('swapSlippageOverLimitDescription')}
           </Text>
           {transactionSettingsLink}
         </Box>

--- a/ui/pages/swaps/swaps-banner-alert/swaps-banner-alert.js
+++ b/ui/pages/swaps/swaps-banner-alert/swaps-banner-alert.js
@@ -30,12 +30,32 @@ import {
 } from '../../../../shared/constants/swaps';
 import { setTransactionSettingsOpened } from '../../../ducks/swaps/swaps';
 
-export default function SwapsBannerAlert({ swapsErrorKey }) {
+export default function SwapsBannerAlert({
+  swapsErrorKey,
+  showTransactionSettingsLink,
+}) {
   const t = useContext(I18nContext);
   const dispatch = useDispatch();
   let severity = SEVERITIES.DANGER;
   let title;
   let description;
+
+  const transactionSettingsLink = (
+    <ButtonLink
+      size={ButtonLinkSize.Inherit}
+      textProps={{
+        variant: TextVariant.bodyMd,
+        alignItems: AlignItems.flexStart,
+      }}
+      onClick={(e) => {
+        e.preventDefault();
+        dispatch(setTransactionSettingsOpened(true));
+      }}
+    >
+      {t('swapEditTransactionSettings')}
+    </ButtonLink>
+  );
+
   switch (swapsErrorKey) {
     case SLIPPAGE_OVER_LIMIT_ERROR:
       title = t('swapSlippageOverLimitTitle');
@@ -44,19 +64,7 @@ export default function SwapsBannerAlert({ swapsErrorKey }) {
           <Text variant={TextVariant.bodyMd} as="h6">
             {t('swapSlippageOverLimitDescription')}
           </Text>
-          <ButtonLink
-            size={ButtonLinkSize.Inherit}
-            textProps={{
-              variant: TextVariant.bodyMd,
-              alignItems: AlignItems.flexStart,
-            }}
-            onClick={(e) => {
-              e.preventDefault();
-              dispatch(setTransactionSettingsOpened(true));
-            }}
-          >
-            {t('swapEditTransactionSettings')}
-          </ButtonLink>
+          {transactionSettingsLink}
         </Box>
       );
       break;
@@ -64,18 +72,24 @@ export default function SwapsBannerAlert({ swapsErrorKey }) {
       severity = SEVERITIES.WARNING;
       title = t('swapSlippageVeryHighTitle');
       description = (
-        <Text variant={TextVariant.bodyMd} as="h6">
-          {t('swapSlippageVeryHighDescription')}
-        </Text>
+        <Box>
+          <Text variant={TextVariant.bodyMd} as="h6">
+            {t('swapSlippageVeryHighDescription')}
+          </Text>
+          {showTransactionSettingsLink && transactionSettingsLink}
+        </Box>
       );
       break;
     case SLIPPAGE_TOO_LOW_ERROR:
       severity = SEVERITIES.WARNING;
       title = t('swapSlippageTooLowTitle');
       description = (
-        <Text variant={TextVariant.bodyMd} as="h6">
-          {t('swapSlippageTooLowDescription')}
-        </Text>
+        <Box>
+          <Text variant={TextVariant.bodyMd} as="h6">
+            {t('swapSlippageTooLowDescription')}
+          </Text>
+          {showTransactionSettingsLink && transactionSettingsLink}
+        </Box>
       );
       break;
     case SLIPPAGE_NEGATIVE_ERROR:
@@ -85,19 +99,7 @@ export default function SwapsBannerAlert({ swapsErrorKey }) {
           <Text variant={TextVariant.bodyMd} as="h6">
             {t('swapSlippageNegativeDescription')}
           </Text>
-          <ButtonLink
-            size={ButtonLinkSize.Inherit}
-            textProps={{
-              variant: TextVariant.bodyMd,
-              alignItems: AlignItems.flexStart,
-            }}
-            onClick={(e) => {
-              e.preventDefault();
-              dispatch(setTransactionSettingsOpened(true));
-            }}
-          >
-            {t('swapEditTransactionSettings')}
-          </ButtonLink>
+          {transactionSettingsLink}
         </Box>
       );
       break;
@@ -175,4 +177,5 @@ export default function SwapsBannerAlert({ swapsErrorKey }) {
 
 SwapsBannerAlert.propTypes = {
   swapsErrorKey: PropTypes.string,
+  showTransactionSettingsLink: PropTypes.bool,
 };

--- a/ui/pages/swaps/swaps-banner-alert/swaps-banner-alert.test.js
+++ b/ui/pages/swaps/swaps-banner-alert/swaps-banner-alert.test.js
@@ -55,7 +55,7 @@ describe('SwapsBannerAlert', () => {
     expect(getByText('High slippage')).toBeInTheDocument();
     expect(
       getByText(
-        'The slippage entered (5%) is considered very high and may result in a bad rate.',
+        'The slippage entered (5%) is considered very high and may result in a bad rate',
       ),
     ).toBeInTheDocument();
   });
@@ -74,7 +74,7 @@ describe('SwapsBannerAlert', () => {
     expect(getByText('High slippage')).toBeInTheDocument();
     expect(
       getByText(
-        'The slippage entered (10%) is considered very high and may result in a bad rate.',
+        'The slippage entered (10%) is considered very high and may result in a bad rate',
       ),
     ).toBeInTheDocument();
     expect(getByText('Adjust slippage')).toBeInTheDocument();
@@ -92,7 +92,7 @@ describe('SwapsBannerAlert', () => {
     );
     expect(getByText('Low slippage')).toBeInTheDocument();
     expect(
-      getByText('A value this low (1%) may result in a failed swap.'),
+      getByText('A value this low (1%) may result in a failed swap'),
     ).toBeInTheDocument();
   });
 
@@ -109,7 +109,7 @@ describe('SwapsBannerAlert', () => {
     );
     expect(getByText('Low slippage')).toBeInTheDocument();
     expect(
-      getByText('A value this low (1%) may result in a failed swap.'),
+      getByText('A value this low (1%) may result in a failed swap'),
     ).toBeInTheDocument();
     expect(getByText('Adjust slippage')).toBeInTheDocument();
   });

--- a/ui/pages/swaps/swaps-banner-alert/swaps-banner-alert.test.js
+++ b/ui/pages/swaps/swaps-banner-alert/swaps-banner-alert.test.js
@@ -49,9 +49,28 @@ describe('SwapsBannerAlert', () => {
     expect(getByText('Very high slippage')).toBeInTheDocument();
     expect(
       getByText(
-        'The slippage entered is considered very high and may result in a bad rate',
+        'The slippage entered is considered very high and may result in a bad rate.',
       ),
     ).toBeInTheDocument();
+  });
+
+  it('renders the component with the SLIPPAGE_VERY_HIGH_ERROR with the "Edit transaction settings" link', () => {
+    const mockStore = createSwapsMockStore();
+    const store = configureMockStore(middleware)(mockStore);
+    const { getByText } = renderWithProvider(
+      <SwapsBannerAlert
+        swapsErrorKey={SLIPPAGE_VERY_HIGH_ERROR}
+        showTransactionSettingsLink
+      />,
+      store,
+    );
+    expect(getByText('Very high slippage')).toBeInTheDocument();
+    expect(
+      getByText(
+        'The slippage entered is considered very high and may result in a bad rate.',
+      ),
+    ).toBeInTheDocument();
+    expect(getByText('Edit transaction settings')).toBeInTheDocument();
   });
 
   it('renders the component with the SLIPPAGE_TOO_LOW_ERROR', () => {
@@ -69,6 +88,27 @@ describe('SwapsBannerAlert', () => {
         'Max slippage is too low which may cause your transaction to fail.',
       ),
     ).toBeInTheDocument();
+  });
+
+  it('renders the component with the SLIPPAGE_TOO_LOW_ERROR with the "Edit transaction settings" link', () => {
+    const mockStore = createSwapsMockStore();
+    const store = configureMockStore(middleware)(mockStore);
+    const { getByText } = renderWithProvider(
+      <SwapsBannerAlert
+        swapsErrorKey={SLIPPAGE_TOO_LOW_ERROR}
+        showTransactionSettingsLink
+      />,
+      store,
+    );
+    expect(
+      getByText('Increase slippage to avoid transaction failure'),
+    ).toBeInTheDocument();
+    expect(
+      getByText(
+        'Max slippage is too low which may cause your transaction to fail.',
+      ),
+    ).toBeInTheDocument();
+    expect(getByText('Edit transaction settings')).toBeInTheDocument();
   });
 
   it('renders the component with the SLIPPAGE_NEGATIVE_ERROR', () => {

--- a/ui/pages/swaps/swaps-banner-alert/swaps-banner-alert.test.js
+++ b/ui/pages/swaps/swaps-banner-alert/swaps-banner-alert.test.js
@@ -13,9 +13,9 @@ import {
   QUOTES_NOT_AVAILABLE_ERROR,
   CONTRACT_DATA_DISABLED_ERROR,
   OFFLINE_FOR_MAINTENANCE,
-  SLIPPAGE_OVER_LIMIT_ERROR,
   SLIPPAGE_VERY_HIGH_ERROR,
-  SLIPPAGE_TOO_LOW_ERROR,
+  SLIPPAGE_HIGH_ERROR,
+  SLIPPAGE_LOW_ERROR,
   SLIPPAGE_NEGATIVE_ERROR,
 } from '../../../../shared/constants/swaps';
 import SwapsBannerAlert from './swaps-banner-alert';
@@ -23,92 +23,95 @@ import SwapsBannerAlert from './swaps-banner-alert';
 const middleware = [thunk];
 
 describe('SwapsBannerAlert', () => {
-  it('renders the component with the SLIPPAGE_OVER_LIMIT_ERROR', () => {
-    const mockStore = createSwapsMockStore();
-    const store = configureMockStore(middleware)(mockStore);
-    const { getByText } = renderWithProvider(
-      <SwapsBannerAlert swapsErrorKey={SLIPPAGE_OVER_LIMIT_ERROR} />,
-      store,
-    );
-    expect(getByText('Reduce slippage to continue')).toBeInTheDocument();
-    expect(
-      getByText(
-        'Slippage tolerance must be 15% or less. Anything higher will result in a bad rate.',
-      ),
-    ).toBeInTheDocument();
-    expect(getByText('Edit transaction settings')).toBeInTheDocument();
-  });
-
   it('renders the component with the SLIPPAGE_VERY_HIGH_ERROR', () => {
-    const mockStore = createSwapsMockStore();
-    const store = configureMockStore(middleware)(mockStore);
-    const { getByText } = renderWithProvider(
-      <SwapsBannerAlert swapsErrorKey={SLIPPAGE_VERY_HIGH_ERROR} />,
-      store,
-    );
-    expect(getByText('Very high slippage')).toBeInTheDocument();
-    expect(
-      getByText(
-        'The slippage entered is considered very high and may result in a bad rate.',
-      ),
-    ).toBeInTheDocument();
-  });
-
-  it('renders the component with the SLIPPAGE_VERY_HIGH_ERROR with the "Edit transaction settings" link', () => {
     const mockStore = createSwapsMockStore();
     const store = configureMockStore(middleware)(mockStore);
     const { getByText } = renderWithProvider(
       <SwapsBannerAlert
         swapsErrorKey={SLIPPAGE_VERY_HIGH_ERROR}
-        showTransactionSettingsLink
+        currentSlippage={16}
       />,
       store,
     );
     expect(getByText('Very high slippage')).toBeInTheDocument();
     expect(
       getByText(
-        'The slippage entered is considered very high and may result in a bad rate.',
+        'Slippage tolerance must be 15% or less. Anything higher will result in a bad rate.',
       ),
     ).toBeInTheDocument();
-    expect(getByText('Edit transaction settings')).toBeInTheDocument();
+    expect(getByText('Adjust slippage')).toBeInTheDocument();
   });
 
-  it('renders the component with the SLIPPAGE_TOO_LOW_ERROR', () => {
-    const mockStore = createSwapsMockStore();
-    const store = configureMockStore(middleware)(mockStore);
-    const { getByText } = renderWithProvider(
-      <SwapsBannerAlert swapsErrorKey={SLIPPAGE_TOO_LOW_ERROR} />,
-      store,
-    );
-    expect(
-      getByText('Increase slippage to avoid transaction failure'),
-    ).toBeInTheDocument();
-    expect(
-      getByText(
-        'Max slippage is too low which may cause your transaction to fail.',
-      ),
-    ).toBeInTheDocument();
-  });
-
-  it('renders the component with the SLIPPAGE_TOO_LOW_ERROR with the "Edit transaction settings" link', () => {
+  it('renders the component with the SLIPPAGE_HIGH_ERROR', () => {
     const mockStore = createSwapsMockStore();
     const store = configureMockStore(middleware)(mockStore);
     const { getByText } = renderWithProvider(
       <SwapsBannerAlert
-        swapsErrorKey={SLIPPAGE_TOO_LOW_ERROR}
-        showTransactionSettingsLink
+        swapsErrorKey={SLIPPAGE_HIGH_ERROR}
+        currentSlippage={5}
       />,
       store,
     );
-    expect(
-      getByText('Increase slippage to avoid transaction failure'),
-    ).toBeInTheDocument();
+    expect(getByText('High slippage')).toBeInTheDocument();
     expect(
       getByText(
-        'Max slippage is too low which may cause your transaction to fail.',
+        'The slippage entered (5%) is considered very high and may result in a bad rate.',
       ),
     ).toBeInTheDocument();
-    expect(getByText('Edit transaction settings')).toBeInTheDocument();
+  });
+
+  it('renders the component with the SLIPPAGE_HIGH_ERROR with the "Adjust slippage" link', () => {
+    const mockStore = createSwapsMockStore();
+    const store = configureMockStore(middleware)(mockStore);
+    const { getByText } = renderWithProvider(
+      <SwapsBannerAlert
+        swapsErrorKey={SLIPPAGE_HIGH_ERROR}
+        showTransactionSettingsLink
+        currentSlippage={10}
+      />,
+      store,
+    );
+    expect(getByText('High slippage')).toBeInTheDocument();
+    expect(
+      getByText(
+        'The slippage entered (10%) is considered very high and may result in a bad rate.',
+      ),
+    ).toBeInTheDocument();
+    expect(getByText('Adjust slippage')).toBeInTheDocument();
+  });
+
+  it('renders the component with the SLIPPAGE_LOW_ERROR', () => {
+    const mockStore = createSwapsMockStore();
+    const store = configureMockStore(middleware)(mockStore);
+    const { getByText } = renderWithProvider(
+      <SwapsBannerAlert
+        swapsErrorKey={SLIPPAGE_LOW_ERROR}
+        currentSlippage={1}
+      />,
+      store,
+    );
+    expect(getByText('Low slippage')).toBeInTheDocument();
+    expect(
+      getByText('A value this low (1%) may result in a failed swap.'),
+    ).toBeInTheDocument();
+  });
+
+  it('renders the component with the SLIPPAGE_LOW_ERROR with the "Adjust slippage" link', () => {
+    const mockStore = createSwapsMockStore();
+    const store = configureMockStore(middleware)(mockStore);
+    const { getByText } = renderWithProvider(
+      <SwapsBannerAlert
+        swapsErrorKey={SLIPPAGE_LOW_ERROR}
+        showTransactionSettingsLink
+        currentSlippage={1}
+      />,
+      store,
+    );
+    expect(getByText('Low slippage')).toBeInTheDocument();
+    expect(
+      getByText('A value this low (1%) may result in a failed swap.'),
+    ).toBeInTheDocument();
+    expect(getByText('Adjust slippage')).toBeInTheDocument();
   });
 
   it('renders the component with the SLIPPAGE_NEGATIVE_ERROR', () => {
@@ -122,7 +125,7 @@ describe('SwapsBannerAlert', () => {
     expect(
       getByText('Slippage must be greater or equal to zero'),
     ).toBeInTheDocument();
-    expect(getByText('Edit transaction settings')).toBeInTheDocument();
+    expect(getByText('Adjust slippage')).toBeInTheDocument();
   });
 
   it('renders the component with the QUOTES_NOT_AVAILABLE_ERROR', () => {

--- a/ui/pages/swaps/transaction-settings/transaction-settings.js
+++ b/ui/pages/swaps/transaction-settings/transaction-settings.js
@@ -112,8 +112,8 @@ export default function TransactionSettings({
       notificationTitle = t('swapSlippageHighTitle');
     } else if (Number(customValue) > maxAllowedSlippage) {
       notificationSeverity = SEVERITIES.DANGER;
-      notificationText = t('swapSlippageVeryHighDescription');
-      notificationTitle = t('swapSlippageVeryHighTitle');
+      notificationText = t('swapSlippageOverLimitDescription');
+      notificationTitle = t('swapSlippageOverLimitTitle');
       dispatch(setSwapsErrorKey(SLIPPAGE_VERY_HIGH_ERROR));
     } else if (Number(customValue) === 0) {
       notificationSeverity = SEVERITIES.INFO;

--- a/ui/pages/swaps/transaction-settings/transaction-settings.js
+++ b/ui/pages/swaps/transaction-settings/transaction-settings.js
@@ -21,7 +21,7 @@ import {
 import { getTranslatedStxErrorMessage } from '../swaps.util';
 import {
   Slippage,
-  SLIPPAGE_OVER_LIMIT_ERROR,
+  SLIPPAGE_VERY_HIGH_ERROR,
   SLIPPAGE_NEGATIVE_ERROR,
 } from '../../../../shared/constants/swaps';
 import {
@@ -101,20 +101,20 @@ export default function TransactionSettings({
       // We will not show this warning for 0% slippage, because we will only
       // return non-slippage quotes from off-chain makers.
       notificationSeverity = SEVERITIES.WARNING;
-      notificationText = t('swapSlippageTooLowDescription');
-      notificationTitle = t('swapSlippageTooLowTitle');
+      notificationText = t('swapSlippageLowDescription', [newSlippage]);
+      notificationTitle = t('swapSlippageLowTitle');
     } else if (
       Number(customValue) >= 5 &&
       Number(customValue) <= maxAllowedSlippage
     ) {
       notificationSeverity = SEVERITIES.WARNING;
-      notificationText = t('swapSlippageVeryHighDescription');
-      notificationTitle = t('swapSlippageVeryHighTitle');
+      notificationText = t('swapSlippageHighDescription', [newSlippage]);
+      notificationTitle = t('swapSlippageHighTitle');
     } else if (Number(customValue) > maxAllowedSlippage) {
       notificationSeverity = SEVERITIES.DANGER;
-      notificationText = t('swapSlippageOverLimitDescription');
-      notificationTitle = t('swapSlippageOverLimitTitle');
-      dispatch(setSwapsErrorKey(SLIPPAGE_OVER_LIMIT_ERROR));
+      notificationText = t('swapSlippageVeryHighDescription');
+      notificationTitle = t('swapSlippageVeryHighTitle');
+      dispatch(setSwapsErrorKey(SLIPPAGE_VERY_HIGH_ERROR));
     } else if (Number(customValue) === 0) {
       notificationSeverity = SEVERITIES.INFO;
       notificationText = t('swapSlippageZeroDescription');

--- a/ui/pages/swaps/transaction-settings/transaction-settings.test.js
+++ b/ui/pages/swaps/transaction-settings/transaction-settings.test.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
-// import { useDispatch } from 'react-redux';
 
 import {
   renderWithProvider,


### PR DESCRIPTION
## Explanation
We already show users a warning notification if they choose a slippage that is too low or too high. Now we will also show a slippage modal, which a user has to confirm before submitting a swap.

I've also improved content for our slippage notifications to make them easier to understand.

## Screenshots/Screencaps
Low slippage notification in Transaction Settings
![image](https://github.com/MetaMask/metamask-extension/assets/80175477/55461c1d-cbbd-4de5-8ad1-85d32b77de11)

High slippage notification in Transaction Settings
![image](https://github.com/MetaMask/metamask-extension/assets/80175477/b29c8413-f4be-47dd-a735-f31e2b927642)

Low slippage modal
![image](https://github.com/MetaMask/metamask-extension/assets/80175477/188470ed-309f-49e8-a2c0-a1248d4d4477)

High slippage modal
![image](https://github.com/MetaMask/metamask-extension/assets/80175477/7558cb72-150d-4963-a780-ed29a349eb22)

## Manual Testing Steps
Low slippage modal
- Open Swaps
- Click on Transaction Settings and set custom slippage to e.g. 0.5
- Get a quote
- Click on the Swap button and you will see the low slippage modal

High slippage modal
- Open Swaps
- Click on Transaction Settings and set custom slippage to e.g. 10
- Get a quote
- Click on the Swap button and you will see the high slippage modal