### PR TITLE
bump @metamask/network-controller from v10.3.1 to v11.0.0

### DIFF
--- a/app/scripts/migrations/092.test.ts
+++ b/app/scripts/migrations/092.test.ts
@@ -1,0 +1,111 @@
+import { InfuraNetworkType, NetworkType } from '@metamask/controller-utils';
+import { migrate, version } from './092';
+
+describe('migration #92', () => {
+  it('should update the version metadata', async () => {
+    const oldStorage = {
+      meta: {
+        version: 91,
+      },
+      data: {},
+    };
+
+    const newStorage = await migrate(oldStorage);
+    expect(newStorage.meta).toStrictEqual({
+      version,
+    });
+  });
+
+  it('should return state unaltered if there is no network controller state', async () => {
+    const oldData = {
+      other: 'data',
+    };
+    const oldStorage = {
+      meta: {
+        version: 91,
+      },
+      data: oldData,
+    };
+
+    const newStorage = await migrate(oldStorage);
+    expect(newStorage.data).toStrictEqual(oldData);
+  });
+
+  it('should return state unaltered if there is no network controller providerConfig state', async () => {
+    const oldData = {
+      other: 'data',
+      NetworkController: {
+        networkConfigurations: {
+          id1: {
+            foo: 'bar',
+          },
+        },
+      },
+    };
+    const oldStorage = {
+      meta: {
+        version: 91,
+      },
+      data: oldData,
+    };
+
+    const newStorage = await migrate(oldStorage);
+    expect(newStorage.data).toStrictEqual(oldData);
+  });
+
+  it('should return state unaltered if there is already a ticker in the providerConfig state', async () => {
+    const oldData = {
+      other: 'data',
+      NetworkController: {
+        providerConfig: {
+          ticker: 'ETH',
+          type: InfuraNetworkType.goerli,
+          chainId: '5',
+          nickname: 'Goerli Testnet',
+          id: 'goerli',
+        },
+      },
+    };
+    const oldStorage = {
+      meta: {
+        version: 91,
+      },
+      data: oldData,
+    };
+
+    const newStorage = await migrate(oldStorage);
+    expect(newStorage.data).toStrictEqual(oldData);
+  });
+
+  it('should update the provider config to have a ticker set to "ETH" if none is currently present', async () => {
+    const oldData = {
+      other: 'data',
+      NetworkController: {
+        providerConfig: {
+          type: NetworkType.rpc,
+          chainId: '0x9292',
+          nickname: 'Funky Town Chain',
+        },
+      },
+    };
+    const oldStorage = {
+      meta: {
+        version: 91,
+      },
+      data: oldData,
+    };
+
+    const newStorage = await migrate(oldStorage);
+    expect(newStorage.data).toStrictEqual({
+      other: 'data',
+      NetworkController: {
+        providerConfig: {
+          type: NetworkType.rpc,
+          chainId: '0x9292',
+          nickname: 'Funky Town Chain',
+          ticker: 'ETH',
+        },
+      },
+    });
+  });
+});

--- a/app/scripts/migrations/092.test.ts
+++ b/app/scripts/migrations/092.test.ts
@@ -58,7 +58,7 @@ describe('migration #92', () => {
       other: 'data',
       NetworkController: {
         providerConfig: {
-          ticker: 'ETH',
+          ticker: 'GoerliETH',
           type: InfuraNetworkType.goerli,
           chainId: '5',
           nickname: 'Goerli Testnet',

--- a/app/scripts/migrations/092.ts
+++ b/app/scripts/migrations/092.ts
@@ -36,8 +36,8 @@ function transformState(state: Record<string, unknown>) {
     }
 
     state.NetworkController.providerConfig = {
-      ...providerConfig,
       ticker: 'ETH',
+      ...providerConfig,
     };
 
     return {

--- a/app/scripts/migrations/092.ts
+++ b/app/scripts/migrations/092.ts
@@ -1,0 +1,49 @@
+import { cloneDeep } from 'lodash';
+import { hasProperty, isObject } from '@metamask/utils';
+
+export const version = 92;
+
+/**
+ * Add ticker to the providerConfig object if missing
+ *
+ * @param originalVersionedData - Versioned MetaMask extension state, exactly what we persist to dist.
+ * @param originalVersionedData.meta - State metadata.
+ * @param originalVersionedData.meta.version - The current state version.
+ * @param originalVersionedData.data - The persisted MetaMask state, keyed by controller.
+ * @returns Updated versioned MetaMask extension state.
+ */
+export async function migrate(originalVersionedData: {
+  meta: { version: number };
+  data: Record<string, unknown>;
+}) {
+  const versionedData = cloneDeep(originalVersionedData);
+  versionedData.meta.version = version;
+  versionedData.data = transformState(versionedData.data);
+  return versionedData;
+}
+
+function transformState(state: Record<string, unknown>) {
+  if (
+    hasProperty(state, 'NetworkController') &&
+    isObject(state.NetworkController) &&
+    hasProperty(state.NetworkController, 'providerConfig') &&
+    isObject(state.NetworkController.providerConfig)
+  ) {
+    const { providerConfig } = state.NetworkController;
+
+    if (providerConfig.ticker) {
+      return state;
+    }
+
+    state.NetworkController.providerConfig = {
+      ...providerConfig,
+      ticker: 'ETH',
+    };
+
+    return {
+      ...state,
+      NetworkController: state.NetworkController,
+    };
+  }
+  return state;
+}

--- a/app/scripts/migrations/index.js
+++ b/app/scripts/migrations/index.js
@@ -95,6 +95,7 @@ import * as m088 from './088';
 import * as m089 from './089';
 import * as m090 from './090';
 import * as m091 from './091';
+import * as m092 from './092';
 
 const migrations = [
   m002,
@@ -187,6 +188,6 @@ const migrations = [
   m089,
   m090,
   m091,
+  m092,
 ];
-
 export default migrations;

--- a/lavamoat/browserify/beta/policy.json
+++ b/lavamoat/browserify/beta/policy.json
@@ -1667,8 +1667,8 @@
         "@metamask/network-controller>@metamask/eth-json-rpc-infura": true,
         "@metamask/network-controller>@metamask/eth-json-rpc-provider": true,
         "@metamask/network-controller>@metamask/swappable-obj-proxy": true,
+        "@metamask/network-controller>@metamask/utils": true,
         "@metamask/network-controller>eth-block-tracker": true,
-        "@metamask/utils": true,
         "browserify>assert": true,
         "eth-query": true,
         "eth-rpc-errors": true,
@@ -1704,6 +1704,19 @@
       "packages": {
         "@metamask/safe-event-emitter": true,
         "json-rpc-engine": true
+      }
+    },
+    "@metamask/network-controller>@metamask/utils": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true
+      },
+      "packages": {
+        "@metamask/key-tree>@noble/hashes": true,
+        "browserify>buffer": true,
+        "nock>debug": true,
+        "semver": true,
+        "superstruct": true
       }
     },
     "@metamask/network-controller>eth-block-tracker": {

--- a/lavamoat/browserify/desktop/policy.json
+++ b/lavamoat/browserify/desktop/policy.json
@@ -1818,8 +1818,8 @@
         "@metamask/network-controller>@metamask/eth-json-rpc-infura": true,
         "@metamask/network-controller>@metamask/eth-json-rpc-provider": true,
         "@metamask/network-controller>@metamask/swappable-obj-proxy": true,
+        "@metamask/network-controller>@metamask/utils": true,
         "@metamask/network-controller>eth-block-tracker": true,
-        "@metamask/utils": true,
         "browserify>assert": true,
         "eth-query": true,
         "eth-rpc-errors": true,
@@ -1855,6 +1855,19 @@
       "packages": {
         "@metamask/safe-event-emitter": true,
         "json-rpc-engine": true
+      }
+    },
+    "@metamask/network-controller>@metamask/utils": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true
+      },
+      "packages": {
+        "@metamask/key-tree>@noble/hashes": true,
+        "browserify>buffer": true,
+        "nock>debug": true,
+        "semver": true,
+        "superstruct": true
       }
     },
     "@metamask/network-controller>eth-block-tracker": {

--- a/lavamoat/browserify/flask/policy.json
+++ b/lavamoat/browserify/flask/policy.json
@@ -1818,8 +1818,8 @@
         "@metamask/network-controller>@metamask/eth-json-rpc-infura": true,
         "@metamask/network-controller>@metamask/eth-json-rpc-provider": true,
         "@metamask/network-controller>@metamask/swappable-obj-proxy": true,
+        "@metamask/network-controller>@metamask/utils": true,
         "@metamask/network-controller>eth-block-tracker": true,
-        "@metamask/utils": true,
         "browserify>assert": true,
         "eth-query": true,
         "eth-rpc-errors": true,
@@ -1855,6 +1855,19 @@
       "packages": {
         "@metamask/safe-event-emitter": true,
         "json-rpc-engine": true
+      }
+    },
+    "@metamask/network-controller>@metamask/utils": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true
+      },
+      "packages": {
+        "@metamask/key-tree>@noble/hashes": true,
+        "browserify>buffer": true,
+        "nock>debug": true,
+        "semver": true,
+        "superstruct": true
       }
     },
     "@metamask/network-controller>eth-block-tracker": {

--- a/lavamoat/browserify/main/policy.json
+++ b/lavamoat/browserify/main/policy.json
@@ -1667,8 +1667,8 @@
         "@metamask/network-controller>@metamask/eth-json-rpc-infura": true,
         "@metamask/network-controller>@metamask/eth-json-rpc-provider": true,
         "@metamask/network-controller>@metamask/swappable-obj-proxy": true,
+        "@metamask/network-controller>@metamask/utils": true,
         "@metamask/network-controller>eth-block-tracker": true,
-        "@metamask/utils": true,
         "browserify>assert": true,
         "eth-query": true,
         "eth-rpc-errors": true,
@@ -1704,6 +1704,19 @@
       "packages": {
         "@metamask/safe-event-emitter": true,
         "json-rpc-engine": true
+      }
+    },
+    "@metamask/network-controller>@metamask/utils": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true
+      },
+      "packages": {
+        "@metamask/key-tree>@noble/hashes": true,
+        "browserify>buffer": true,
+        "nock>debug": true,
+        "semver": true,
+        "superstruct": true
       }
     },
     "@metamask/network-controller>eth-block-tracker": {

--- a/lavamoat/browserify/mmi/policy.json
+++ b/lavamoat/browserify/mmi/policy.json
@@ -1895,8 +1895,8 @@
         "@metamask/network-controller>@metamask/eth-json-rpc-infura": true,
         "@metamask/network-controller>@metamask/eth-json-rpc-provider": true,
         "@metamask/network-controller>@metamask/swappable-obj-proxy": true,
+        "@metamask/network-controller>@metamask/utils": true,
         "@metamask/network-controller>eth-block-tracker": true,
-        "@metamask/utils": true,
         "browserify>assert": true,
         "eth-query": true,
         "eth-rpc-errors": true,
@@ -1932,6 +1932,19 @@
       "packages": {
         "@metamask/safe-event-emitter": true,
         "json-rpc-engine": true
+      }
+    },
+    "@metamask/network-controller>@metamask/utils": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true
+      },
+      "packages": {
+        "@metamask/key-tree>@noble/hashes": true,
+        "browserify>buffer": true,
+        "nock>debug": true,
+        "semver": true,
+        "superstruct": true
       }
     },
     "@metamask/network-controller>eth-block-tracker": {

--- a/package.json
+++ b/package.json
@@ -252,7 +252,7 @@
     "@metamask/logo": "^3.1.1",
     "@metamask/message-manager": "^7.0.2",
     "@metamask/metamask-eth-abis": "^3.0.0",
-    "@metamask/network-controller": "^10.3.1",
+    "@metamask/network-controller": "^11.0.0",
     "@metamask/notification-controller": "^3.0.0",
     "@metamask/obs-store": "^8.1.0",
     "@metamask/permission-controller": "^4.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4037,7 +4037,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/eth-json-rpc-infura@npm:^8.1.0":
+"@metamask/eth-json-rpc-infura@npm:^8.1.0, @metamask/eth-json-rpc-infura@npm:^8.1.1":
   version: 8.1.1
   resolution: "@metamask/eth-json-rpc-infura@npm:8.1.1"
   dependencies:
@@ -4377,7 +4377,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/network-controller@npm:^10.2.0, @metamask/network-controller@npm:^10.3.0, @metamask/network-controller@npm:^10.3.1":
+"@metamask/network-controller@npm:^10.2.0, @metamask/network-controller@npm:^10.3.0":
   version: 10.3.1
   resolution: "@metamask/network-controller@npm:10.3.1"
   dependencies:
@@ -4397,6 +4397,28 @@ __metadata:
     json-rpc-engine: "npm:^6.1.0"
     uuid: "npm:^8.3.2"
   checksum: 48b30bee12f90ca5e818dd99d3e164b4330368498e6388cc1044141be2f70eea28b2a85310bacb176d1c12027e2d8c996effa3902238aff75e6c20e31351740d
+  languageName: node
+  linkType: hard
+
+"@metamask/network-controller@npm:^11.0.0":
+  version: 11.0.0
+  resolution: "@metamask/network-controller@npm:11.0.0"
+  dependencies:
+    "@metamask/base-controller": "npm:^3.2.0"
+    "@metamask/controller-utils": "npm:^4.3.0"
+    "@metamask/eth-json-rpc-infura": "npm:^8.1.1"
+    "@metamask/eth-json-rpc-middleware": "npm:^11.0.0"
+    "@metamask/eth-json-rpc-provider": "npm:^1.0.0"
+    "@metamask/swappable-obj-proxy": "npm:^2.1.0"
+    "@metamask/utils": "npm:^6.2.0"
+    async-mutex: "npm:^0.2.6"
+    eth-block-tracker: "npm:^7.0.1"
+    eth-query: "npm:^2.1.2"
+    eth-rpc-errors: "npm:^4.0.2"
+    immer: "npm:^9.0.6"
+    json-rpc-engine: "npm:^6.1.0"
+    uuid: "npm:^8.3.2"
+  checksum: de89ed99001eedce04309285276837080f038859a1a9fee231f89fdb851a037766396f36dc75b2d2feff6941171bb6bde6970d60c11f2885f44e33534e644dc1
   languageName: node
   linkType: hard
 
@@ -24237,7 +24259,7 @@ __metadata:
     "@metamask/logo": "npm:^3.1.1"
     "@metamask/message-manager": "npm:^7.0.2"
     "@metamask/metamask-eth-abis": "npm:^3.0.0"
-    "@metamask/network-controller": "npm:^10.3.1"
+    "@metamask/network-controller": "npm:^11.0.0"
     "@metamask/notification-controller": "npm:^3.0.0"
     "@metamask/obs-store": "npm:^8.1.0"
     "@metamask/permission-controller": "npm:^4.0.0"


### PR DESCRIPTION
Bumps `@metamask/network-controller` from v10.3.1 to v11.0.0 and adds migration to add ticker to current `providerConfig` state if its missing: [relevant v11.0.0 changelog entry](https://github.com/MetaMask/core/blob/main/packages/network-controller/CHANGELOG.md#changed-1)