### PR TITLE
Remove call to `_updateMemStoreKeyrings`

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -1931,7 +1931,7 @@ export default class MetamaskController extends EventEmitter {
         getSnapKeyring: this.getSnapKeyring.bind(this),
         saveSnapKeyring: async () => {
           await this.keyringController.persistAllKeyrings();
-          await this.keyringController._updateMemStoreKeyrings();
+          await this.keyringController.updateMemStoreKeyrings();
           await this.keyringController.fullUpdate();
         },
         ///: END:ONLY_INCLUDE_IN

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -1931,8 +1931,6 @@ export default class MetamaskController extends EventEmitter {
         getSnapKeyring: this.getSnapKeyring.bind(this),
         saveSnapKeyring: async () => {
           await this.keyringController.persistAllKeyrings();
-          await this.keyringController.updateMemStoreKeyrings();
-          await this.keyringController.fullUpdate();
         },
         ///: END:ONLY_INCLUDE_IN
         ///: BEGIN:ONLY_INCLUDE_IN(snaps)


### PR DESCRIPTION
This PR fixes a regression that was introduced with the migration to the new `KeyringController`, which renamed the `_updateMemStoreKeyrings` method to `updateMemStoreKeyrings` (removed the `_` prefix.)

Instead of updating the method name, we simply remove the call to `updateMemStoreKeyrings` since it's allready called internaly by `persistAllKeyrings`.

The changes in this PR are limited to the `keyring-snaps` feature flag.

- Fixes: https://github.com/MetaMask/accounts-planning/issues/30
