### PR TITLE
Show proper amount of gas token needed to buy if insufficient

### DIFF
--- a/ui/pages/swaps/prepare-swap-page/review-quote.js
+++ b/ui/pages/swaps/prepare-swap-page/review-quote.js
@@ -13,6 +13,7 @@ import { isEqual } from 'lodash';
 import classnames from 'classnames';
 import { captureException } from '@sentry/browser';
 import PropTypes from 'prop-types';
+import { ZERO_ADDRESS } from '@truffle/codec/dist/lib/evm/utils';
 
 import { I18nContext } from '../../../contexts/i18n';
 import SelectQuotePopover from '../select-quote-popover';
@@ -787,11 +788,16 @@ export default function ReviewQuote({ setReceiveToAmount }) {
 
   const needsMoreGas = Boolean(ethBalanceNeededStx || ethBalanceNeeded);
 
+  // If source token is gas token, then use ethBalanceStx or ethBalanceNeeded, o/w use tokenBalanceNeeded
+  const isSourceNativeToken = fetchParams.sourceToken === ZERO_ADDRESS;
+
   const actionableBalanceErrorMessage = tokenBalanceUnavailable
     ? t('swapTokenBalanceUnavailable', [sourceTokenSymbol])
     : t('swapApproveNeedMoreTokens', [
         <span key="swapApproveNeedMoreTokens-1">
-          {tokenBalanceNeeded || ethBalanceNeededStx || ethBalanceNeeded}
+          {isSourceNativeToken
+            ? ethBalanceNeededStx || ethBalanceNeeded
+            : tokenBalanceNeeded || ethBalanceNeededStx || ethBalanceNeeded}
         </span>,
         tokenBalanceNeeded && !(sourceTokenSymbol === defaultSwapsToken.symbol)
           ? sourceTokenSymbol


### PR DESCRIPTION
## Explanation

<!--
Thanks for the pull request. Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues, Slack conversations, Zendesk issues, user stories, etc. reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

This PR fixes MMS-536. This fixes the following bug:

1. User has 0.1 ETH, and enters in 1 ETH as the From Token
2. The user is informed that they need 1 more ETH to complete the swap, rather than 0.9 (+gas fee)

It was fixed by checking if the From Token is the gas token, and displaying the correct amount of gas token required to complete the swap.

## Screenshots/Screencaps

<!-- If you're making a change to the UI, make sure to capture a screenshot or a short video showing off your work! -->

### Before

<!-- How did the UI you changed look before your changes? Drag your file(s) below this line: -->


![Screenshot 2023-08-02 at 3 12 28 PM](https://github.com/MetaMask/metamask-extension/assets/139582705/4a316a48-7bd2-4b8a-ad95-f87da2cd42f9)

### After

<!-- How does it look now? Drag your file(s) below this line: -->
![Screenshot 2023-08-02 at 3 15 23 PM](https://github.com/MetaMask/metamask-extension/assets/139582705/c1a20d0c-7a50-487c-a196-58f7adb62c49)

## Manual Testing Steps

<!--
How should reviewers and QA manually test your changes? For instance:

- Go to this screen
- Do this
- Then do this
-->

1. Select ETH <> DAI (or other To Token) pair
2. Enter in an amount > your wallet balance for From Token
4. Observe the amount required to complete the swap

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
