### PR TITLE
Fix 'Global Menu Explorer / Account Details' What's New

### DIFF
--- a/shared/notifications/index.js
+++ b/shared/notifications/index.js
@@ -119,7 +119,6 @@ export const UI_NOTIFICATIONS = {
     date: null,
     image: {
       src: 'images/global-menu-block-explorer.svg',
-      width: '100%',
     },
   },
   ///: BEGIN:ONLY_INCLUDE_IN(blockaid)

--- a/ui/components/app/whats-new-popup/whats-new-popup.js
+++ b/ui/components/app/whats-new-popup/whats-new-popup.js
@@ -100,6 +100,9 @@ function getActionFunctionById(id, history) {
       updateViewedNotifications({ 21: true });
       history.push(PREPARE_SWAP_ROUTE);
     },
+    22: () => {
+      updateViewedNotifications({ 22: true });
+    },
     ///: BEGIN:ONLY_INCLUDE_IN(blockaid)
     23: () => {
       updateViewedNotifications({ 23: true });
@@ -383,6 +386,7 @@ export default function WhatsNewPopup({
     18: renderFirstNotification,
     19: renderFirstNotification,
     21: renderFirstNotification,
+    22: renderFirstNotification,
     ///: BEGIN:ONLY_INCLUDE_IN(blockaid)
     23: renderFirstNotification,
     ///: END:ONLY_INCLUDE_IN

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -1008,6 +1008,7 @@ function getAllowedAnnouncementIds(state) {
     19: false,
     20: currentKeyringIsLedger && isFirefox,
     21: isSwapsChain,
+    22: true,
     ///: BEGIN:ONLY_INCLUDE_IN(blockaid)
     23: true,
     ///: END:ONLY_INCLUDE_IN


### PR DESCRIPTION
## Explanation

One of my commits for the What's New item from my Global Menu PR was somehow lost in the ether, possibly by a bad rebase.  This PR ensures the What's New item displays.

As an additional follow up, I'm going to document a checklist for what's new items.  There are loads of files involved.

## Screenshots/Screencaps

<img width="582" alt="SCR-20230802-mtie" src="https://github.com/MetaMask/metamask-extension/assets/46655/449c9300-10a9-4003-b6af-7ac70ddb5ab9">


## Manual Testing Steps

1.  Open extension
2. See the What's new item

## Pre-merge author checklist

- [ ] I've clearly explained:
  - [ ] What problem this PR is solving
  - [ ] How this problem was solved
  - [ ] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
