### PR TITLE
Force an update of the phishing warning configuration

### DIFF
--- a/app/scripts/migrations/092.test.ts
+++ b/app/scripts/migrations/092.test.ts
@@ -1,11 +1,13 @@
-import { InfuraNetworkType, NetworkType } from '@metamask/controller-utils';
+import { cloneDeep } from 'lodash';
 import { migrate, version } from './092';
+
+const PREVIOUS_VERSION = version - 1;
 
 describe('migration #92', () => {
   it('should update the version metadata', async () => {
     const oldStorage = {
       meta: {
-        version: 91,
+        version: PREVIOUS_VERSION,
       },
       data: {},
     };
@@ -16,81 +18,51 @@ describe('migration #92', () => {
     });
   });
 
-  it('should return state unaltered if there is no network controller state', async () => {
+  it('should return state unaltered if there is no phishing controller state', async () => {
     const oldData = {
       other: 'data',
     };
     const oldStorage = {
       meta: {
-        version: 91,
+        version: PREVIOUS_VERSION,
       },
       data: oldData,
     };
 
-    const newStorage = await migrate(oldStorage);
+    const newStorage = await migrate(cloneDeep(oldStorage));
     expect(newStorage.data).toStrictEqual(oldData);
   });
 
-  it('should return state unaltered if there is no network controller providerConfig state', async () => {
+  it('should return state unaltered if there is no phishing controller last fetched state', async () => {
     const oldData = {
       other: 'data',
-      NetworkController: {
-        networkConfigurations: {
-          id1: {
-            foo: 'bar',
-          },
-        },
+      PhishingController: {
+        whitelist: [],
       },
     };
     const oldStorage = {
       meta: {
-        version: 91,
+        version: PREVIOUS_VERSION,
       },
       data: oldData,
     };
 
-    const newStorage = await migrate(oldStorage);
+    const newStorage = await migrate(cloneDeep(oldStorage));
     expect(newStorage.data).toStrictEqual(oldData);
   });
 
-  it('should return state unaltered if there is already a ticker in the providerConfig state', async () => {
+  it('should remove both last fetched properties from phishing controller state', async () => {
     const oldData = {
       other: 'data',
-      NetworkController: {
-        providerConfig: {
-          ticker: 'GoerliETH',
-          type: InfuraNetworkType.goerli,
-          chainId: '5',
-          nickname: 'Goerli Testnet',
-          id: 'goerli',
-        },
+      PhishingController: {
+        whitelist: [],
+        hotlistLastFetched: 0,
+        stalelistLastFetched: 0,
       },
     };
     const oldStorage = {
       meta: {
-        version: 91,
-      },
-      data: oldData,
-    };
-
-    const newStorage = await migrate(oldStorage);
-    expect(newStorage.data).toStrictEqual(oldData);
-  });
-
-  it('should update the provider config to have a ticker set to "ETH" if none is currently present', async () => {
-    const oldData = {
-      other: 'data',
-      NetworkController: {
-        providerConfig: {
-          type: NetworkType.rpc,
-          chainId: '0x9292',
-          nickname: 'Funky Town Chain',
-        },
-      },
-    };
-    const oldStorage = {
-      meta: {
-        version: 91,
+        version: PREVIOUS_VERSION,
       },
       data: oldData,
     };
@@ -98,13 +70,8 @@ describe('migration #92', () => {
     const newStorage = await migrate(oldStorage);
     expect(newStorage.data).toStrictEqual({
       other: 'data',
-      NetworkController: {
-        providerConfig: {
-          type: NetworkType.rpc,
-          chainId: '0x9292',
-          nickname: 'Funky Town Chain',
-          ticker: 'ETH',
-        },
+      PhishingController: {
+        whitelist: [],
       },
     });
   });

--- a/app/scripts/migrations/093.test.ts
+++ b/app/scripts/migrations/093.test.ts
@@ -1,0 +1,113 @@
+import { InfuraNetworkType, NetworkType } from '@metamask/controller-utils';
+import { migrate, version } from './093';
+
+const PREVIOUS_VERSION = version - 1;
+
+describe('migration #93', () => {
+  it('should update the version metadata', async () => {
+    const oldStorage = {
+      meta: {
+        version: PREVIOUS_VERSION,
+      },
+      data: {},
+    };
+
+    const newStorage = await migrate(oldStorage);
+    expect(newStorage.meta).toStrictEqual({
+      version,
+    });
+  });
+
+  it('should return state unaltered if there is no network controller state', async () => {
+    const oldData = {
+      other: 'data',
+    };
+    const oldStorage = {
+      meta: {
+        version: PREVIOUS_VERSION,
+      },
+      data: oldData,
+    };
+
+    const newStorage = await migrate(oldStorage);
+    expect(newStorage.data).toStrictEqual(oldData);
+  });
+
+  it('should return state unaltered if there is no network controller providerConfig state', async () => {
+    const oldData = {
+      other: 'data',
+      NetworkController: {
+        networkConfigurations: {
+          id1: {
+            foo: 'bar',
+          },
+        },
+      },
+    };
+    const oldStorage = {
+      meta: {
+        version: PREVIOUS_VERSION,
+      },
+      data: oldData,
+    };
+
+    const newStorage = await migrate(oldStorage);
+    expect(newStorage.data).toStrictEqual(oldData);
+  });
+
+  it('should return state unaltered if there is already a ticker in the providerConfig state', async () => {
+    const oldData = {
+      other: 'data',
+      NetworkController: {
+        providerConfig: {
+          ticker: 'GoerliETH',
+          type: InfuraNetworkType.goerli,
+          chainId: '5',
+          nickname: 'Goerli Testnet',
+          id: 'goerli',
+        },
+      },
+    };
+    const oldStorage = {
+      meta: {
+        version: PREVIOUS_VERSION,
+      },
+      data: oldData,
+    };
+
+    const newStorage = await migrate(oldStorage);
+    expect(newStorage.data).toStrictEqual(oldData);
+  });
+
+  it('should update the provider config to have a ticker set to "ETH" if none is currently present', async () => {
+    const oldData = {
+      other: 'data',
+      NetworkController: {
+        providerConfig: {
+          type: NetworkType.rpc,
+          chainId: '0x9292',
+          nickname: 'Funky Town Chain',
+        },
+      },
+    };
+    const oldStorage = {
+      meta: {
+        version: PREVIOUS_VERSION,
+      },
+      data: oldData,
+    };
+
+    const newStorage = await migrate(oldStorage);
+    expect(newStorage.data).toStrictEqual({
+      other: 'data',
+      NetworkController: {
+        providerConfig: {
+          type: NetworkType.rpc,
+          chainId: '0x9292',
+          nickname: 'Funky Town Chain',
+          ticker: 'ETH',
+        },
+      },
+    });
+  });
+});

--- a/app/scripts/migrations/index.js
+++ b/app/scripts/migrations/index.js
@@ -96,6 +96,7 @@ import * as m089 from './089';
 import * as m090 from './090';
 import * as m091 from './091';
 import * as m092 from './092';
+import * as m093 from './093';
 
 const migrations = [
   m002,
@@ -189,5 +190,6 @@ const migrations = [
   m090,
   m091,
   m092,
+  m093,
 ];
 export default migrations;


### PR DESCRIPTION
## Explanation

The "last fetched" state for the `PhishingController` has been deleted to force an immediate full update of the phishing configuration state. We're doing this because the state was cleared in v10.34.2 because the format of that state had changed.

This has been implemented in migration 92. The previous migration 92 has been renamed to 93 because it won't be included until a future release. We need the migrations to remain sequential, and this will save us from having to resolve a complex conflict when releasing this.

## Manual Testing Steps

* Install v10.34.1, onboard
* Navigate to this test website to ensure that it's blocked: https://test.metamask-phishing.io/
* update the directory you are loading the extension from to a v10.34.2 build
* See that the site is still blocked

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
