### PR TITLE
Fix the display of the block explorer whats new notification, and add…

### DIFF
--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -977,7 +977,7 @@ export const getUnreadNotificationsCount = createSelector(
  * @param {object} state
  * @returns {object}
  */
-function getAllowedAnnouncementIds(state) {
+export function getAllowedAnnouncementIds(state) {
   const currentKeyring = getCurrentKeyring(state);
   const currentKeyringIsLedger = currentKeyring?.type === KeyringType.ledger;
   const supportsWebHid = window.navigator.hid !== undefined;
@@ -1008,6 +1008,7 @@ function getAllowedAnnouncementIds(state) {
     19: false,
     20: currentKeyringIsLedger && isFirefox,
     21: isSwapsChain,
+    22: true,
     ///: BEGIN:ONLY_INCLUDE_IN(blockaid)
     23: true,
     ///: END:ONLY_INCLUDE_IN

--- a/ui/selectors/selectors.test.js
+++ b/ui/selectors/selectors.test.js
@@ -6,6 +6,7 @@ import {
   LOCALHOST_DISPLAY_NAME,
   NETWORK_TYPES,
 } from '../../shared/constants/network';
+import { UI_NOTIFICATIONS } from '../../shared/notifications';
 import * as selectors from './selectors';
 
 jest.mock('../../shared/modules/network.utils', () => {
@@ -737,5 +738,21 @@ describe('Selectors', () => {
 
     mockState.metamask.snapsInstallPrivacyWarningShown = null;
     expect(selectors.getSnapsInstallPrivacyWarningShown(mockState)).toBe(false);
+  });
+
+  describe('#getAllowedAnnouncementIds', () => {
+    it('includes properties for all notifications exported from shared/nofitications/index.js', () => {
+      const allowedAnnouncements =
+        selectors.getAllowedAnnouncementIds(mockState);
+
+      const uiNotificationIds = Object.keys(UI_NOTIFICATIONS);
+
+      const uiNotificationIdsNotInAllowedAnnouncements =
+        uiNotificationIds.filter(
+          (id) => allowedAnnouncements[id] === undefined,
+        );
+
+      expect(uiNotificationIdsNotInAllowedAnnouncements).toStrictEqual([]);
+    });
   });
 });


### PR DESCRIPTION
… a test to validate getAllowedAnnouncementIds

Rebase after https://github.com/MetaMask/metamask-extension/pull/20371 is merged