### PR TITLE
Require `test-deps-depcheck` to pass CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -221,6 +221,7 @@ workflows:
             - prep-build-flask
       - all-tests-pass:
           requires:
+            - test-deps-depcheck
             - validate-lavamoat-allow-scripts
             - validate-lavamoat-policy-build
             - validate-lavamoat-policy-webapp


### PR DESCRIPTION
## Explanation

The CI job `test-deps-depcheck` was optional, allowing PRs to be merged that included dependency errors. It is now a required job, ensuring that no such errors are introduced in the future.

## Manual Testing Steps

N/A

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
