### PR TITLE
Improvements to Swaps quote auto-selection logic, fix an edge case with zero-balance tokens

### DIFF
--- a/test/e2e/swaps/swaps-notifications.spec.js
+++ b/test/e2e/swaps/swaps-notifications.spec.js
@@ -111,7 +111,7 @@ describe('Swaps - notifications', function () {
         });
         await checkNotification(driver, {
           title: 'Insufficient balance',
-          text: 'You need 50 more TESTETH to complete this swap',
+          text: 'You need 43.4467 more TESTETH to complete this swap',
         });
         await reviewQuote(driver, {
           swapFrom: 'TESTETH',

--- a/ui/ducks/swaps/swaps.js
+++ b/ui/ducks/swaps/swaps.js
@@ -124,6 +124,7 @@ const initialState = {
   currentSmartTransactionsError: '',
   swapsSTXLoading: false,
   transactionSettingsOpened: false,
+  latestAddedTokenTo: '',
 };
 
 const slice = createSlice({
@@ -708,7 +709,11 @@ export const fetchQuotesAndSetQuoteState = (
       );
       await dispatch(setLatestAddedTokenTo(toTokenAddress));
     } else {
-      await dispatch(setLatestAddedTokenTo(''));
+      const latestAddedTokenTo = getLatestAddedTokenTo(state);
+      // Only reset the latest added Token To if it's a different token.
+      if (latestAddedTokenTo !== toTokenAddress) {
+        await dispatch(setLatestAddedTokenTo(''));
+      }
     }
 
     if (

--- a/ui/ducks/swaps/swaps.js
+++ b/ui/ducks/swaps/swaps.js
@@ -668,7 +668,12 @@ export const fetchQuotesAndSetQuoteState = (
       iconUrl: fromTokenIconUrl,
       balance: fromTokenBalance,
     } = selectedFromToken;
-    const { address: toTokenAddress, symbol: toTokenSymbol } = selectedToToken;
+    const {
+      address: toTokenAddress,
+      symbol: toTokenSymbol,
+      decimals: toTokenDecimals,
+      iconUrl: toTokenIconUrl,
+    } = selectedToToken;
     // pageRedirectionDisabled is true if quotes prefetching is active (a user is on the Build Quote page).
     // In that case we just want to silently prefetch quotes without redirecting to the quotes loading page.
     if (!pageRedirectionDisabled) {
@@ -678,6 +683,25 @@ export const fetchQuotesAndSetQuoteState = (
     dispatch(setFetchingQuotes(true));
 
     const contractExchangeRates = getTokenExchangeRates(state);
+
+    let destinationTokenAddedForSwap = false;
+    if (
+      toTokenAddress &&
+      toTokenSymbol !== swapsDefaultToken.symbol &&
+      contractExchangeRates[toTokenAddress] === undefined &&
+      !isTokenAlreadyAdded(toTokenAddress, getTokens(state))
+    ) {
+      destinationTokenAddedForSwap = true;
+      await dispatch(
+        addToken(
+          toTokenAddress,
+          toTokenSymbol,
+          toTokenDecimals,
+          toTokenIconUrl,
+          true,
+        ),
+      );
+    }
 
     if (
       fromTokenAddress &&
@@ -747,6 +771,7 @@ export const fetchQuotesAndSetQuoteState = (
             destinationToken: toTokenAddress,
             value: inputValue,
             fromAddress: selectedAccount.address,
+            destinationTokenAddedForSwap,
             balanceError,
             sourceDecimals: fromTokenDecimals,
           },
@@ -841,36 +866,6 @@ export const fetchQuotesAndSetQuoteState = (
 
     dispatch(setFetchingQuotes(false));
   };
-};
-
-const addTokenTo = (dispatch, state) => {
-  const fetchParams = getFetchParams(state);
-  const swapsDefaultToken = getSwapsDefaultToken(state);
-  const contractExchangeRates = getTokenExchangeRates(state);
-  const selectedToToken =
-    getToToken(state) || fetchParams?.metaData?.destinationTokenInfo || {};
-  const {
-    address: toTokenAddress,
-    symbol: toTokenSymbol,
-    decimals: toTokenDecimals,
-    iconUrl: toTokenIconUrl,
-  } = selectedToToken;
-  if (
-    toTokenAddress &&
-    toTokenSymbol !== swapsDefaultToken.symbol &&
-    contractExchangeRates[toTokenAddress] === undefined &&
-    !isTokenAlreadyAdded(toTokenAddress, getTokens(state))
-  ) {
-    dispatch(
-      addToken(
-        toTokenAddress,
-        toTokenSymbol,
-        toTokenDecimals,
-        toTokenIconUrl,
-        true,
-      ),
-    );
-  }
 };
 
 export const signAndSendSwapsSmartTransaction = ({
@@ -972,7 +967,6 @@ export const signAndSendSwapsSmartTransaction = ({
         dispatch(setCurrentSmartTransactionsError(StxErrorTypes.unavailable));
         return;
       }
-      addTokenTo(dispatch, state);
       if (approveTxParams) {
         updatedApproveTxParams.gas = `0x${decimalToHex(
           fees.approvalTxFees?.gasLimit || 0,
@@ -1216,7 +1210,6 @@ export const signAndSendTransactions = (
       history.push(AWAITING_SIGNATURES_ROUTE);
     }
 
-    addTokenTo(dispatch, state);
     if (approveTxParams) {
       if (networkAndAccountSupports1559) {
         approveTxParams.maxFeePerGas = maxFeePerGas;

--- a/ui/ducks/swaps/swaps.js
+++ b/ui/ducks/swaps/swaps.js
@@ -153,6 +153,9 @@ const slice = createSlice({
     setFetchingQuotes: (state, action) => {
       state.fetchingQuotes = action.payload;
     },
+    setLatestAddedTokenTo: (state, action) => {
+      state.latestAddedTokenTo = action.payload;
+    },
     setFromToken: (state, action) => {
       state.fromToken = action.payload;
     },
@@ -247,6 +250,8 @@ export const getTopAssets = (state) => state.swaps.topAssets;
 export const getToToken = (state) => state.swaps.toToken;
 
 export const getFetchingQuotes = (state) => state.swaps.fetchingQuotes;
+
+export const getLatestAddedTokenTo = (state) => state.swaps.latestAddedTokenTo;
 
 export const getQuotesFetchStartTime = (state) =>
   state.swaps.quotesFetchStartTime;
@@ -482,6 +487,7 @@ const {
   setAggregatorMetadata,
   setBalanceError,
   setFetchingQuotes,
+  setLatestAddedTokenTo,
   setFromToken,
   setFromTokenError,
   setFromTokenInputValue,
@@ -505,6 +511,7 @@ export {
   setAggregatorMetadata,
   setBalanceError,
   setFetchingQuotes,
+  setLatestAddedTokenTo,
   setFromToken as setSwapsFromToken,
   setFromTokenError,
   setFromTokenInputValue,
@@ -684,14 +691,12 @@ export const fetchQuotesAndSetQuoteState = (
 
     const contractExchangeRates = getTokenExchangeRates(state);
 
-    let destinationTokenAddedForSwap = false;
     if (
       toTokenAddress &&
       toTokenSymbol !== swapsDefaultToken.symbol &&
       contractExchangeRates[toTokenAddress] === undefined &&
       !isTokenAlreadyAdded(toTokenAddress, getTokens(state))
     ) {
-      destinationTokenAddedForSwap = true;
       await dispatch(
         addToken(
           toTokenAddress,
@@ -701,6 +706,9 @@ export const fetchQuotesAndSetQuoteState = (
           true,
         ),
       );
+      await dispatch(setLatestAddedTokenTo(toTokenAddress));
+    } else {
+      await dispatch(setLatestAddedTokenTo(''));
     }
 
     if (
@@ -771,7 +779,6 @@ export const fetchQuotesAndSetQuoteState = (
             destinationToken: toTokenAddress,
             value: inputValue,
             fromAddress: selectedAccount.address,
-            destinationTokenAddedForSwap,
             balanceError,
             sourceDecimals: fromTokenDecimals,
           },

--- a/ui/pages/swaps/build-quote/build-quote.js
+++ b/ui/pages/swaps/build-quote/build-quote.js
@@ -48,6 +48,7 @@ import {
   getIsFeatureFlagLoaded,
   getCurrentSmartTransactionsError,
   getSmartTransactionFees,
+  getLatestAddedTokenTo,
 } from '../../../ducks/swaps/swaps';
 import {
   getSwapsDefaultToken,
@@ -145,6 +146,7 @@ export default function BuildQuote({
   const tokenList = useSelector(getTokenList, isEqual);
   const quotes = useSelector(getQuotes, isEqual);
   const areQuotesPresent = Object.keys(quotes).length > 0;
+  const latestAddedTokenTo = useSelector(getLatestAddedTokenTo, isEqual);
 
   const tokenConversionRates = useSelector(getTokenExchangeRates, isEqual);
   const conversionRate = useSelector(getConversionRate);
@@ -348,11 +350,10 @@ export default function BuildQuote({
     ? getURLHostName(blockExplorerTokenLink)
     : t('etherscan');
 
-  const { destinationTokenAddedForSwap } = fetchParams || {};
   const { address: toAddress } = toToken || {};
   const onToSelect = useCallback(
     (token) => {
-      if (destinationTokenAddedForSwap && token.address !== toAddress) {
+      if (latestAddedTokenTo && token.address !== toAddress) {
         dispatch(
           ignoreTokens({
             tokensToIgnore: toAddress,
@@ -363,7 +364,7 @@ export default function BuildQuote({
       dispatch(setSwapToToken(token));
       setVerificationClicked(false);
     },
-    [dispatch, destinationTokenAddedForSwap, toAddress],
+    [dispatch, latestAddedTokenTo, toAddress],
   );
 
   const hideDropdownItemIf = useCallback(

--- a/ui/pages/swaps/build-quote/build-quote.js
+++ b/ui/pages/swaps/build-quote/build-quote.js
@@ -84,6 +84,7 @@ import {
 
 import {
   resetSwapsPostFetchState,
+  ignoreTokens,
   setBackgroundSwapRouteState,
   clearSwapsQuotes,
   stopPollingForQuotes,
@@ -347,12 +348,22 @@ export default function BuildQuote({
     ? getURLHostName(blockExplorerTokenLink)
     : t('etherscan');
 
+  const { destinationTokenAddedForSwap } = fetchParams || {};
+  const { address: toAddress } = toToken || {};
   const onToSelect = useCallback(
     (token) => {
+      if (destinationTokenAddedForSwap && token.address !== toAddress) {
+        dispatch(
+          ignoreTokens({
+            tokensToIgnore: toAddress,
+            dontShowLoadingIndicator: true,
+          }),
+        );
+      }
       dispatch(setSwapToToken(token));
       setVerificationClicked(false);
     },
-    [dispatch],
+    [dispatch, destinationTokenAddedForSwap, toAddress],
   );
 
   const hideDropdownItemIf = useCallback(

--- a/ui/pages/swaps/build-quote/build-quote.test.js
+++ b/ui/pages/swaps/build-quote/build-quote.test.js
@@ -29,6 +29,7 @@ const createProps = (customProps = {}) => {
 
 setBackgroundConnection({
   resetPostFetchState: jest.fn(),
+  ignoreTokens: jest.fn(),
   setBackgroundSwapRouteState: jest.fn(),
   clearSwapsQuotes: jest.fn(),
   stopPollingForQuotes: jest.fn(),

--- a/ui/pages/swaps/index.js
+++ b/ui/pages/swaps/index.js
@@ -50,6 +50,7 @@ import {
   navigateBackToBuildQuote,
   getSwapRedesignEnabled,
   setTransactionSettingsOpened,
+  getLatestAddedTokenTo,
 } from '../../ducks/swaps/swaps';
 import {
   checkNetworkAndAccountSupports1559,
@@ -135,6 +136,7 @@ export default function Swap() {
   const routeState = useSelector(getBackgroundSwapRouteState);
   const selectedAccount = useSelector(getSelectedAccount, shallowEqual);
   const quotes = useSelector(getQuotes, isEqual);
+  const latestAddedTokenTo = useSelector(getLatestAddedTokenTo, isEqual);
   const txList = useSelector(currentNetworkTxListSelector, shallowEqual);
   const tradeTxId = useSelector(getTradeTxId);
   const approveTxId = useSelector(getApproveTxId);
@@ -183,8 +185,6 @@ export default function Swap() {
   const { balance: ethBalance, address: selectedAccountAddress } =
     selectedAccount;
 
-  const { destinationTokenAddedForSwap } = fetchParams || {};
-
   const approveTxData =
     approveTxId && txList.find(({ id }) => approveTxId === id);
   const tradeTxData = tradeTxId && txList.find(({ id }) => tradeTxId === id);
@@ -215,13 +215,10 @@ export default function Swap() {
   const clearTemporaryTokenRef = useRef();
   useEffect(() => {
     clearTemporaryTokenRef.current = () => {
-      if (
-        destinationTokenAddedForSwap &&
-        (!isAwaitingSwapRoute || conversionError)
-      ) {
+      if (latestAddedTokenTo && (!isAwaitingSwapRoute || conversionError)) {
         dispatch(
           ignoreTokens({
-            tokensToIgnore: destinationTokenInfo?.address,
+            tokensToIgnore: latestAddedTokenTo,
             dontShowLoadingIndicator: true,
           }),
         );
@@ -230,7 +227,7 @@ export default function Swap() {
   }, [
     conversionError,
     dispatch,
-    destinationTokenAddedForSwap,
+    latestAddedTokenTo,
     destinationTokenInfo,
     fetchParams,
     isAwaitingSwapRoute,

--- a/ui/pages/swaps/prepare-swap-page/prepare-swap-page.js
+++ b/ui/pages/swaps/prepare-swap-page/prepare-swap-page.js
@@ -54,6 +54,7 @@ import {
   getAggregatorMetadata,
   getTransactionSettingsOpened,
   setTransactionSettingsOpened,
+  getLatestAddedTokenTo,
 } from '../../../ducks/swaps/swaps';
 import {
   getSwapsDefaultToken,
@@ -184,6 +185,7 @@ export default function PrepareSwapPage({
   const rpcPrefs = useSelector(getRpcPrefsForCurrentProvider, shallowEqual);
   const tokenList = useSelector(getTokenList, isEqual);
   const quotes = useSelector(getQuotes, isEqual);
+  const latestAddedTokenTo = useSelector(getLatestAddedTokenTo, isEqual);
   const numberOfQuotes = Object.keys(quotes).length;
   const areQuotesPresent = numberOfQuotes > 0;
   const swapsErrorKey = useSelector(getSwapsErrorKey);
@@ -451,11 +453,10 @@ export default function PrepareSwapPage({
     ? getURLHostName(blockExplorerTokenLink)
     : t('etherscan');
 
-  const { destinationTokenAddedForSwap } = fetchParams || {};
   const { address: toAddress } = toToken || {};
   const onToSelect = useCallback(
     (token) => {
-      if (destinationTokenAddedForSwap && token.address !== toAddress) {
+      if (latestAddedTokenTo && token.address !== toAddress) {
         dispatch(
           ignoreTokens({
             tokensToIgnore: toAddress,
@@ -466,7 +467,7 @@ export default function PrepareSwapPage({
       dispatch(setSwapToToken(token));
       setVerificationClicked(false);
     },
-    [dispatch, destinationTokenAddedForSwap, toAddress],
+    [dispatch, latestAddedTokenTo, toAddress],
   );
 
   const tokensWithBalancesFromToken = tokensWithBalances.find((token) =>

--- a/ui/pages/swaps/prepare-swap-page/prepare-swap-page.js
+++ b/ui/pages/swaps/prepare-swap-page/prepare-swap-page.js
@@ -92,6 +92,7 @@ import {
 } from '../../../../shared/constants/swaps';
 import {
   resetSwapsPostFetchState,
+  ignoreTokens,
   clearSwapsQuotes,
   stopPollingForQuotes,
   setSmartTransactionsOptInStatus,
@@ -450,12 +451,22 @@ export default function PrepareSwapPage({
     ? getURLHostName(blockExplorerTokenLink)
     : t('etherscan');
 
+  const { destinationTokenAddedForSwap } = fetchParams || {};
+  const { address: toAddress } = toToken || {};
   const onToSelect = useCallback(
     (token) => {
+      if (destinationTokenAddedForSwap && token.address !== toAddress) {
+        dispatch(
+          ignoreTokens({
+            tokensToIgnore: toAddress,
+            dontShowLoadingIndicator: true,
+          }),
+        );
+      }
       dispatch(setSwapToToken(token));
       setVerificationClicked(false);
     },
-    [dispatch],
+    [dispatch, destinationTokenAddedForSwap, toAddress],
   );
 
   const tokensWithBalancesFromToken = tokensWithBalances.find((token) =>

--- a/ui/pages/swaps/prepare-swap-page/prepare-swap-page.test.js
+++ b/ui/pages/swaps/prepare-swap-page/prepare-swap-page.test.js
@@ -27,6 +27,7 @@ const createProps = (customProps = {}) => {
 
 setBackgroundConnection({
   resetPostFetchState: jest.fn(),
+  ignoreTokens: jest.fn(),
   setBackgroundSwapRouteState: jest.fn(),
   clearSwapsQuotes: jest.fn(),
   stopPollingForQuotes: jest.fn(),

--- a/ui/store/actions.ts
+++ b/ui/store/actions.ts
@@ -3205,6 +3205,7 @@ export function fetchAndSetQuotes(
     destinationToken: string;
     value: string;
     fromAddress: string;
+    destinationTokenAddedForSwap: string;
     balanceError: string;
     sourceDecimals: number;
   },

--- a/ui/store/actions.ts
+++ b/ui/store/actions.ts
@@ -3205,7 +3205,6 @@ export function fetchAndSetQuotes(
     destinationToken: string;
     value: string;
     fromAddress: string;
-    destinationTokenAddedForSwap: string;
     balanceError: string;
     sourceDecimals: number;
   },


### PR DESCRIPTION
## Explanation
- Improvements to Swaps quote auto-selection logic
- Fixing an edge case where zero-balance tokens may be shown in a user's wallet when exiting Swaps

## Manual Testing Steps
**Improvements to Swaps quote auto-selection logic**
- Open Swaps
- Try to select a Token To that you don't yet have in your Tokens list
- Click on "view all quotes" and see a little check mark next to a selected quote

**Fixing an edge case where zero-balance tokens may be shown in a user's wallet when exiting Swaps**
- Open Swaps
- Try to select a Token To that you don't yet have in your Tokens list
- Exit Swaps after about 1 or 2 seconds from when quotes fetching starts
- On the homepage check the Tokens list. The Token To item that you selected shouldn't be there, since you didn't complete a Swap