### PR TITLE
Disable MetaMask on Battle.net

### DIFF
--- a/shared/modules/provider-injection.js
+++ b/shared/modules/provider-injection.js
@@ -77,6 +77,7 @@ function blockedDomainCheck() {
     'ani.gamer.com.tw',
     'blueskybooking.com',
     'sharefile.com',
+    'battle.net',
   ];
   const currentUrl = window.location.href;
   let currentRegex;


### PR DESCRIPTION
## **Description**

Adds battle.net to `blockedDomainCheck()` to disable MetaMask on that site and fix a 2FA login bug.

Here's the actual problem:
- The page headers on Battle.net list the following 4 icons
```
<link rel="icon" type="image/png" sizes="192x192" href="/login/static/images/toolkit/themes/bnet-next/meta/android-icon-192x192.png">
<link rel="icon" type="image/png" sizes="16x16" href="/login/static/images/toolkit/themes/bnet-next/meta/favicon-16x16.png">
<link rel="icon" type="image/png" sizes="32x32" href="/login/static/images/toolkit/themes/bnet-next/meta/favicon-32x32.png">
<link rel="icon" type="image/png" sizes="96x96" href="/login/static/images/toolkit/themes/bnet-next/meta/favicon-96x96.png">
```
- That first one, if you try to actually visit it, is a 404 error: https://us.account.battle.net/login/static/images/toolkit/themes/bnet-next/meta/android-icon-192x192.png
- Our @metamask/providers tries to load that icon
- Battle.net has some sort of code that if you're in the middle of 2FA and you get a 404 error, go back to the login page
- You can independently verify this if you disable MetaMask, then on the 2FA page run either of
      `fetch('https://us.account.battle.net/login/static/images/…it/themes/bnet-next/meta/android-icon-192x192.png')`
      `fetch('https://us.account.battle.net/login/static/404')`  _(not at all an image, but a deliberate 404)_
      you will get the same result of being forced back to the login page

## **Related issues**

Fixes: #14463

## **Manual testing steps**

1. Have MetaMask Extension activated
2. Visit https://battle.net
3. Login with an account that uses Mobile 2FA
4. You **SHOULD NOT** be redirected back to the username and password prompt

## **Screenshots/Recordings**
## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained what problem this PR is solving and how it is solved.
- [x] I've linked related issues
- [x] I've included manual testing steps
- [ ] I've included screenshots/recordings if applicable
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [x] I’ve properly set the pull request status:
  - [x] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
