### PR TITLE
Replacing deprecated Popover with Modal

### DIFF
--- a/ui/components/app/edit-gas-popover/edit-gas-popover.component.js
+++ b/ui/components/app/edit-gas-popover/edit-gas-popover.component.js
@@ -10,8 +10,15 @@ import {
   GasRecommendations,
 } from '../../../../shared/constants/gas';
 
-import Popover from '../../ui/popover';
-import Button from '../../ui/button';
+import {
+  Modal,
+  ModalOverlay,
+  ModalContent,
+  ModalHeader,
+  Button,
+  BUTTON_VARIANT,
+  Box,
+} from '../../component-library';
 import EditGasDisplay from '../edit-gas-display';
 
 import { I18nContext } from '../../../contexts/i18n';
@@ -170,44 +177,49 @@ export default function EditGasPopover({
 
   const footerButtonText = confirmButtonText || t('save');
   return (
-    <Popover
-      title={title}
-      onClose={closePopover}
-      className="edit-gas-popover__wrapper"
-      footer={
-        <Button
-          type="primary"
-          onClick={onSubmit}
-          disabled={hasGasErrors || balanceError || !txParamsHaveBeenCustomized}
-        >
-          {footerButtonText}
-        </Button>
-      }
-    >
-      <div style={{ padding: '0 20px 20px 20px', position: 'relative' }}>
-        {process.env.IN_TEST ? null : <LoadingHeartBeat />}
-        <EditGasDisplay
-          dappSuggestedGasFeeAcknowledged={dappSuggestedGasFeeAcknowledged}
-          setDappSuggestedGasFeeAcknowledged={
-            setDappSuggestedGasFeeAcknowledged
-          }
-          estimatedMinimumNative={estimatedMinimumNative}
-          gasPrice={gasPrice}
-          setGasPrice={setGasPrice}
-          gasLimit={gasLimit}
-          setGasLimit={setGasLimit}
-          properGasLimit={properGasLimit}
-          mode={mode}
-          transaction={updatedTransaction}
-          onManualChange={onManualChange}
-          minimumGasLimit={minimumGasLimitDec}
-          balanceError={balanceError}
-          txParamsHaveBeenCustomized={txParamsHaveBeenCustomized}
-          gasErrors={gasErrors}
-          {...editGasDisplayProps}
-        />
-      </div>
-    </Popover>
+    <Modal isOpen onClose={closePopover} className="edit-gas-popover__wrapper">
+      <ModalOverlay />
+      <ModalContent>
+        <ModalHeader onClose={closePopover} marginBottom={4}>
+          {title}
+        </ModalHeader>
+        <div style={{ padding: '10px 20px 20px 20px', position: 'relative' }}>
+          {process.env.IN_TEST ? null : <LoadingHeartBeat />}
+          <EditGasDisplay
+            dappSuggestedGasFeeAcknowledged={dappSuggestedGasFeeAcknowledged}
+            setDappSuggestedGasFeeAcknowledged={
+              setDappSuggestedGasFeeAcknowledged
+            }
+            estimatedMinimumNative={estimatedMinimumNative}
+            gasPrice={gasPrice}
+            setGasPrice={setGasPrice}
+            gasLimit={gasLimit}
+            setGasLimit={setGasLimit}
+            properGasLimit={properGasLimit}
+            mode={mode}
+            transaction={updatedTransaction}
+            onManualChange={onManualChange}
+            minimumGasLimit={minimumGasLimitDec}
+            balanceError={balanceError}
+            txParamsHaveBeenCustomized={txParamsHaveBeenCustomized}
+            gasErrors={gasErrors}
+            {...editGasDisplayProps}
+          />
+        </div>
+        <Box marginLeft={4} marginRight={4} marginTop={2} marginBottom={2}>
+          <Button
+            block
+            variant={BUTTON_VARIANT.PRIMARY}
+            onClick={onSubmit}
+            disabled={
+              hasGasErrors || balanceError || !txParamsHaveBeenCustomized
+            }
+          >
+            {footerButtonText}
+          </Button>
+        </Box>
+      </ModalContent>
+    </Modal>
   );
 }
 


### PR DESCRIPTION
## Explanation

This pull request addresses the issue of replacing the deprecated Popover component with the new Modal component in the `edit-gas-popover.component.js` file.

### Change Made
- Replaced deprecated `Popover` component with the new `Modal` component.
- Updated deprecated `button` component to the new `button` component.

* Fixes #19555 

## Screenshots/Screencaps
### Before

https://github.com/MetaMask/metamask-extension/assets/81921291/0f175387-86de-4927-83bd-c3587bb5c17a

### After

https://github.com/MetaMask/metamask-extension/assets/81921291/5cf6aa04-1340-46b8-a1e7-8440d89a5b87

## Manual Testing Steps

- Pull this branch
- run storybook
- search `EditGasPopover`

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone
