### PR TITLE
Log before and after each migration run

### DIFF
--- a/app/scripts/lib/migrator/index.js
+++ b/app/scripts/lib/migrator/index.js
@@ -1,4 +1,5 @@
 import EventEmitter from 'events';
+import log from 'loglevel';
 
 /**
  * @typedef {object} Migration
@@ -36,7 +37,7 @@ export default class Migrator extends EventEmitter {
     // perform each migration
     for (const migration of pendingMigrations) {
       try {
-        console.log(`Running migration ${migration.version}...`)
+        log.info(`Running migration ${migration.version}...`);
 
         // attempt migration and validate
         const migratedData = await migration.migrate(versionedData);
@@ -55,7 +56,7 @@ export default class Migrator extends EventEmitter {
         // eslint-disable-next-line no-param-reassign
         versionedData = migratedData;
 
-        console.log(`Migration ${migration.version} complete`)
+        log.info(`Migration ${migration.version} complete`);
       } catch (err) {
         // rewrite error message to add context without clobbering stack
         const originalErrorMessage = err.message;

--- a/app/scripts/lib/migrator/index.js
+++ b/app/scripts/lib/migrator/index.js
@@ -36,6 +36,8 @@ export default class Migrator extends EventEmitter {
     // perform each migration
     for (const migration of pendingMigrations) {
       try {
+        console.log(`Running migration ${migration.version}...`)
+
         // attempt migration and validate
         const migratedData = await migration.migrate(versionedData);
         if (!migratedData.data) {
@@ -52,6 +54,8 @@ export default class Migrator extends EventEmitter {
         // accept the migration as good
         // eslint-disable-next-line no-param-reassign
         versionedData = migratedData;
+
+        console.log(`Migration ${migration.version} complete`)
       } catch (err) {
         // rewrite error message to add context without clobbering stack
         const originalErrorMessage = err.message;


### PR DESCRIPTION
## Explanation

In order to get better breadcrumbs in our sentry error reports, we are adding logs to tell us when migrations are starting and when they have successfully completed.

## Manual Testing Steps

- [ ] We could verify this by committing some temporary code to throw and error around the end of the migrations (either during the last migration or just after), and connecting to a personal sentry account, and then creating the scenario where the migrations are run and then verifying that the correct logs show up in sentry breadcrumbs

## Pre-merge author checklist

- [ ] I've clearly explained:
  - [ ] What problem this PR is solving
  - [ ] How this problem was solved
  - [ ] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
