### PR TITLE
Capture exception with sentry when invariant conditions are met in migrations

### DIFF
--- a/app/scripts/migrations/082.test.js
+++ b/app/scripts/migrations/082.test.js
@@ -715,7 +715,7 @@ describe('migration #82', () => {
     expect(newStorage.data).toStrictEqual(oldStorage.data);
   });
 
-  it('should capture an exception if PreferencesController is undefined', async () => {
+  it('should capture an exception if PreferencesController is not an object', async () => {
     const oldStorage = {
       meta: {
         version: 81,
@@ -746,12 +746,13 @@ describe('migration #82', () => {
             type: 'mainnet',
           },
         },
+        PreferencesController: false,
       },
     };
     await migrate(oldStorage);
     expect(sentryCaptureExceptionMock).toHaveBeenCalledTimes(1);
     expect(sentryCaptureExceptionMock).toHaveBeenCalledWith(
-      new Error(`typeof state.PreferencesController is undefined`),
+      new Error(`typeof state.PreferencesController is boolean`),
     );
   });
 

--- a/app/scripts/migrations/082.test.js
+++ b/app/scripts/migrations/082.test.js
@@ -4,8 +4,8 @@ import { migrate, version } from './082';
 const sentryCaptureExceptionMock = jest.fn();
 
 global.sentry = {
-  captureException: sentryCaptureExceptionMock;
-}
+  captureException: sentryCaptureExceptionMock,
+};
 
 jest.mock('uuid', () => {
   const actual = jest.requireActual('uuid');

--- a/app/scripts/migrations/082.test.js
+++ b/app/scripts/migrations/082.test.js
@@ -3,8 +3,9 @@ import { migrate, version } from './082';
 
 const sentryCaptureExceptionMock = jest.fn();
 
-global.sentry = global.sentry || {};
-global.sentry.captureException = sentryCaptureExceptionMock;
+global.sentry = {
+  captureException: sentryCaptureExceptionMock;
+}
 
 jest.mock('uuid', () => {
   const actual = jest.requireActual('uuid');

--- a/app/scripts/migrations/082.test.js
+++ b/app/scripts/migrations/082.test.js
@@ -539,7 +539,6 @@ describe('migration #82', () => {
       new Error(
         `state.PreferencesController.frequentRpcListDetail contains an element of type string`,
       ),
-      { extra: {} },
     );
   });
 
@@ -675,7 +674,6 @@ describe('migration #82', () => {
       new Error(
         `typeof state.PreferencesController.frequentRpcListDetail is undefined`,
       ),
-      { extra: {} },
     );
   });
 
@@ -753,7 +751,6 @@ describe('migration #82', () => {
     expect(sentryCaptureExceptionMock).toHaveBeenCalledTimes(1);
     expect(sentryCaptureExceptionMock).toHaveBeenCalledWith(
       new Error(`typeof state.PreferencesController is undefined`),
-      { extra: {} },
     );
   });
 
@@ -770,7 +767,6 @@ describe('migration #82', () => {
     expect(sentryCaptureExceptionMock).toHaveBeenCalledTimes(1);
     expect(sentryCaptureExceptionMock).toHaveBeenCalledWith(
       new Error(`typeof state.NetworkController is undefined`),
-      { extra: {} },
     );
   });
 });

--- a/app/scripts/migrations/082.test.js
+++ b/app/scripts/migrations/082.test.js
@@ -1,6 +1,11 @@
 import { v4 } from 'uuid';
 import { migrate, version } from './082';
 
+const sentryCaptureExceptionMock = jest.fn();
+
+global.sentry = global.sentry || {};
+global.sentry.captureException = sentryCaptureExceptionMock;
+
 jest.mock('uuid', () => {
   const actual = jest.requireActual('uuid');
 
@@ -472,10 +477,73 @@ describe('migration #82', () => {
       },
     };
     const newStorage = await migrate(oldStorage);
+    expect(sentryCaptureExceptionMock).toHaveBeenCalled();
     expect(newStorage.data).toStrictEqual(oldStorage.data);
   });
 
-  it('should not change anything if there is no frequentRpcListDetail property on PreferencesController', async () => {
+  it('should capture an exception if any PreferencesController.frequentRpcListDetail entries are not objects', async () => {
+    const oldStorage = {
+      meta: {
+        version: 81,
+      },
+      data: {
+        PreferencesController: {
+          transactionSecurityCheckEnabled: false,
+          useBlockie: false,
+          useCurrencyRateCheck: true,
+          useMultiAccountBalanceChecker: true,
+          useNftDetection: false,
+          useNonceField: false,
+          frequentRpcListDetail: [
+            {
+              chainId: '0x539',
+              nickname: 'Localhost 8545',
+              rpcPrefs: {},
+              rpcUrl: 'http://localhost:8545',
+              ticker: 'ETH',
+            },
+            'invalid entry type',
+            1,
+          ],
+        },
+        NetworkController: {
+          network: '1',
+          networkDetails: {
+            EIPS: {
+              1559: true,
+            },
+          },
+          previousProviderStore: {
+            chainId: '0x89',
+            nickname: 'Polygon Mainnet',
+            rpcPrefs: {},
+            rpcUrl:
+              'https://polygon-mainnet.infura.io/v3/373266a93aab4acda48f89d4fe77c748',
+            ticker: 'MATIC',
+            type: 'rpc',
+          },
+          provider: {
+            chainId: '0x1',
+            nickname: '',
+            rpcPrefs: {},
+            rpcUrl: '',
+            ticker: 'ETH',
+            type: 'mainnet',
+          },
+        },
+      },
+    };
+    await migrate(oldStorage);
+    expect(sentryCaptureExceptionMock).toHaveBeenCalledTimes(1);
+    expect(sentryCaptureExceptionMock).toHaveBeenCalledWith(
+      new Error(
+        `state.PreferencesController.frequentRpcListDetail contains an element of type string`,
+      ),
+      { extra: {} },
+    );
+  });
+
+  it('should not change anything, and not capture an exception, if there is no frequentRpcListDetail property on PreferencesController but there is a networkConfigurations object', async () => {
     const oldStorage = {
       meta: {
         version: 81,
@@ -556,7 +624,59 @@ describe('migration #82', () => {
       },
     };
     const newStorage = await migrate(oldStorage);
+    expect(sentryCaptureExceptionMock).not.toHaveBeenCalled();
     expect(newStorage.data).toStrictEqual(oldStorage.data);
+  });
+
+  it('should capture an exception if there is no frequentRpcListDetail property on PreferencesController and no networkConfiguration object', async () => {
+    const oldStorage = {
+      meta: {
+        version: 81,
+      },
+      data: {
+        PreferencesController: {
+          transactionSecurityCheckEnabled: false,
+          useBlockie: false,
+          useCurrencyRateCheck: true,
+          useMultiAccountBalanceChecker: true,
+          useNftDetection: false,
+          useNonceField: false,
+        },
+        NetworkController: {
+          network: '1',
+          networkDetails: {
+            EIPS: {
+              1559: true,
+            },
+          },
+          previousProviderStore: {
+            chainId: '0x89',
+            nickname: 'Polygon Mainnet',
+            rpcPrefs: {},
+            rpcUrl:
+              'https://polygon-mainnet.infura.io/v3/373266a93aab4acda48f89d4fe77c748',
+            ticker: 'MATIC',
+            type: 'rpc',
+          },
+          provider: {
+            chainId: '0x1',
+            nickname: '',
+            rpcPrefs: {},
+            rpcUrl: '',
+            ticker: 'ETH',
+            type: 'mainnet',
+          },
+        },
+      },
+    };
+    await migrate(oldStorage);
+    expect(sentryCaptureExceptionMock).toHaveBeenCalledTimes(1);
+    expect(sentryCaptureExceptionMock).toHaveBeenCalledWith(
+      new Error(
+        `typeof state.PreferencesController.frequentRpcListDetail is undefined`,
+      ),
+      { extra: {} },
+    );
   });
 
   it('should change nothing if PreferencesController is undefined', async () => {
@@ -594,5 +714,63 @@ describe('migration #82', () => {
     };
     const newStorage = await migrate(oldStorage);
     expect(newStorage.data).toStrictEqual(oldStorage.data);
+  });
+
+  it('should capture an exception if PreferencesController is undefined', async () => {
+    const oldStorage = {
+      meta: {
+        version: 81,
+      },
+      data: {
+        NetworkController: {
+          network: '1',
+          networkDetails: {
+            EIPS: {
+              1559: true,
+            },
+          },
+          previousProviderStore: {
+            chainId: '0x89',
+            nickname: 'Polygon Mainnet',
+            rpcPrefs: {},
+            rpcUrl:
+              'https://polygon-mainnet.infura.io/v3/373266a93aab4acda48f89d4fe77c748',
+            ticker: 'MATIC',
+            type: 'rpc',
+          },
+          provider: {
+            chainId: '0x1',
+            nickname: '',
+            rpcPrefs: {},
+            rpcUrl: '',
+            ticker: 'ETH',
+            type: 'mainnet',
+          },
+        },
+      },
+    };
+    await migrate(oldStorage);
+    expect(sentryCaptureExceptionMock).toHaveBeenCalledTimes(1);
+    expect(sentryCaptureExceptionMock).toHaveBeenCalledWith(
+      new Error(`typeof state.PreferencesController is undefined`),
+      { extra: {} },
+    );
+  });
+
+  it('should capture an exception if NetworkController is undefined', async () => {
+    const oldStorage = {
+      meta: {
+        version: 81,
+      },
+      data: {
+        PreferencesController: {},
+      },
+    };
+    await migrate(oldStorage);
+    expect(sentryCaptureExceptionMock).toHaveBeenCalledTimes(1);
+    expect(sentryCaptureExceptionMock).toHaveBeenCalledWith(
+      new Error(`typeof state.NetworkController is undefined`),
+      { extra: {} },
+    );
   });
 });

--- a/app/scripts/migrations/082.ts
+++ b/app/scripts/migrations/082.ts
@@ -1,6 +1,7 @@
 import { cloneDeep } from 'lodash';
 import { hasProperty, isObject } from '@metamask/utils';
 import { v4 } from 'uuid';
+import log from 'loglevel';
 
 export const version = 82;
 
@@ -26,6 +27,7 @@ export async function migrate(originalVersionedData: {
 
 function transformState(state: Record<string, unknown>) {
   if (!hasProperty(state, 'PreferencesController')) {
+    log.warn(`state.PreferencesController is undefined`);
     return state;
   }
   if (!isObject(state.PreferencesController)) {

--- a/app/scripts/migrations/082.ts
+++ b/app/scripts/migrations/082.ts
@@ -25,10 +25,10 @@ export async function migrate(originalVersionedData: {
 }
 
 function transformState(state: Record<string, unknown>) {
-  if (
-    !hasProperty(state, 'PreferencesController') ||
-    !isObject(state.PreferencesController)
-  ) {
+  if (!hasProperty(state, 'PreferencesController')) {
+    return state;
+  }
+  if (!isObject(state.PreferencesController)) {
     global.sentry?.captureException?.(
       new Error(
         `typeof state.PreferencesController is ${typeof state.PreferencesController}`,

--- a/app/scripts/migrations/082.ts
+++ b/app/scripts/migrations/082.ts
@@ -33,10 +33,6 @@ function transformState(state: Record<string, unknown>) {
       new Error(
         `typeof state.PreferencesController is ${typeof state.PreferencesController}`,
       ),
-      {
-        // "extra" key is required by Sentry
-        extra: {},
-      },
     );
     return state;
   }
@@ -48,10 +44,6 @@ function transformState(state: Record<string, unknown>) {
       new Error(
         `typeof state.NetworkController is ${typeof state.NetworkController}`,
       ),
-      {
-        // "extra" key is required by Sentry
-        extra: {},
-      },
     );
     return state;
   }
@@ -68,10 +60,6 @@ function transformState(state: Record<string, unknown>) {
           `typeof state.PreferencesController.frequentRpcListDetail is ${typeof state
             .PreferencesController.frequentRpcListDetail}`,
         ),
-        {
-          // "extra" key is required by Sentry
-          extra: {},
-        },
       );
     }
     return state;
@@ -85,10 +73,6 @@ function transformState(state: Record<string, unknown>) {
       new Error(
         `state.PreferencesController.frequentRpcListDetail contains an element of type ${typeof erroneousElement}`,
       ),
-      {
-        // "extra" key is required by Sentry
-        extra: {},
-      },
     );
     return state;
   }

--- a/app/scripts/migrations/082.ts
+++ b/app/scripts/migrations/082.ts
@@ -27,12 +27,69 @@ export async function migrate(originalVersionedData: {
 function transformState(state: Record<string, unknown>) {
   if (
     !hasProperty(state, 'PreferencesController') ||
-    !isObject(state.PreferencesController) ||
-    !isObject(state.NetworkController) ||
-    !hasProperty(state.PreferencesController, 'frequentRpcListDetail') ||
-    !Array.isArray(state.PreferencesController.frequentRpcListDetail) ||
-    !state.PreferencesController.frequentRpcListDetail.every(isObject)
+    !isObject(state.PreferencesController)
   ) {
+    global.sentry?.captureException?.(
+      new Error(
+        `typeof state.PreferencesController is ${typeof state.PreferencesController}`,
+      ),
+      {
+        // "extra" key is required by Sentry
+        extra: {},
+      },
+    );
+    return state;
+  }
+  if (
+    !hasProperty(state, 'NetworkController') ||
+    !isObject(state.NetworkController)
+  ) {
+    global.sentry?.captureException?.(
+      new Error(
+        `typeof state.NetworkController is ${typeof state.NetworkController}`,
+      ),
+      {
+        // "extra" key is required by Sentry
+        extra: {},
+      },
+    );
+    return state;
+  }
+  if (
+    !hasProperty(state.PreferencesController, 'frequentRpcListDetail') ||
+    !Array.isArray(state.PreferencesController.frequentRpcListDetail)
+  ) {
+    const inPost077SupplementFor082State =
+      state.NetworkController.networkConfigurations &&
+      state.PreferencesController.frequentRpcListDetail === undefined;
+    if (!inPost077SupplementFor082State) {
+      global.sentry?.captureException?.(
+        new Error(
+          `typeof state.PreferencesController.frequentRpcListDetail is ${typeof state
+            .PreferencesController.frequentRpcListDetail}`,
+        ),
+        {
+          // "extra" key is required by Sentry
+          extra: {},
+        },
+      );
+    }
+    return state;
+  }
+  if (!state.PreferencesController.frequentRpcListDetail.every(isObject)) {
+    const erroneousElement =
+      state.PreferencesController.frequentRpcListDetail.find(
+        (element) => !isObject(element),
+      );
+    global.sentry?.captureException?.(
+      new Error(
+        `state.PreferencesController.frequentRpcListDetail contains an element of type ${typeof erroneousElement}`,
+      ),
+      {
+        // "extra" key is required by Sentry
+        extra: {},
+      },
+    );
     return state;
   }
   const { PreferencesController, NetworkController } = state;

--- a/app/scripts/migrations/083.test.js
+++ b/app/scripts/migrations/083.test.js
@@ -1,6 +1,11 @@
 import { v4 } from 'uuid';
 import { migrate, version } from './083';
 
+const sentryCaptureExceptionMock = jest.fn();
+
+global.sentry = {};
+global.sentry.captureException = sentryCaptureExceptionMock;
+
 jest.mock('uuid', () => {
   const actual = jest.requireActual('uuid');
 
@@ -165,6 +170,24 @@ describe('migration #83', () => {
     expect(newStorage).toStrictEqual(expectedNewStorage);
   });
 
+  it('should capture an exception if state.NetworkController is undefined', async () => {
+    const oldStorage = {
+      meta: {
+        version,
+      },
+      data: {
+        testProperty: 'testValue',
+      },
+    };
+
+    await migrate(oldStorage);
+
+    expect(sentryCaptureExceptionMock).toHaveBeenCalledTimes(1);
+    expect(sentryCaptureExceptionMock).toHaveBeenCalledWith(
+      new Error(`typeof state.NetworkController is undefined`),
+    );
+  });
+
   it('should not modify state if state.NetworkController is not an object', async () => {
     const oldStorage = {
       meta: {
@@ -188,6 +211,25 @@ describe('migration #83', () => {
       },
     };
     expect(newStorage).toStrictEqual(expectedNewStorage);
+  });
+
+  it('should capture an exception if state.NetworkController is not an object', async () => {
+    const oldStorage = {
+      meta: {
+        version,
+      },
+      data: {
+        NetworkController: false,
+        testProperty: 'testValue',
+      },
+    };
+
+    await migrate(oldStorage);
+
+    expect(sentryCaptureExceptionMock).toHaveBeenCalledTimes(1);
+    expect(sentryCaptureExceptionMock).toHaveBeenCalledWith(
+      new Error(`typeof state.NetworkController is boolean`),
+    );
   });
 
   it('should not modify state if state.NetworkController.networkConfigurations is undefined', async () => {
@@ -219,6 +261,28 @@ describe('migration #83', () => {
       },
     };
     expect(newStorage).toStrictEqual(expectedNewStorage);
+  });
+
+  it('should capture an exception if state.NetworkController.networkConfigurations is undefined', async () => {
+    const oldStorage = {
+      meta: {
+        version,
+      },
+      data: {
+        NetworkController: {
+          testNetworkControllerProperty: 'testNetworkControllerValue',
+          networkConfigurations: undefined,
+        },
+        testProperty: 'testValue',
+      },
+    };
+
+    await migrate(oldStorage);
+
+    expect(sentryCaptureExceptionMock).toHaveBeenCalledTimes(1);
+    expect(sentryCaptureExceptionMock).toHaveBeenCalledWith(
+      new Error(`typeof NetworkController.networkConfigurations is undefined`),
+    );
   });
 
   it('should not modify state if state.NetworkController.networkConfigurations is an empty object', async () => {

--- a/app/scripts/migrations/083.test.js
+++ b/app/scripts/migrations/083.test.js
@@ -3,8 +3,9 @@ import { migrate, version } from './083';
 
 const sentryCaptureExceptionMock = jest.fn();
 
-global.sentry = {};
-global.sentry.captureException = sentryCaptureExceptionMock;
+global.sentry = {
+  captureException: sentryCaptureExceptionMock,
+};
 
 jest.mock('uuid', () => {
   const actual = jest.requireActual('uuid');

--- a/app/scripts/migrations/083.ts
+++ b/app/scripts/migrations/083.ts
@@ -25,11 +25,21 @@ export async function migrate(originalVersionedData: {
 
 function transformState(state: Record<string, unknown>) {
   if (!isObject(state.NetworkController)) {
+    global.sentry?.captureException?.(
+      new Error(
+        `typeof state.NetworkController is ${typeof state.NetworkController}`,
+      ),
+    );
     return state;
   }
   const { NetworkController } = state;
 
   if (!isObject(NetworkController.networkConfigurations)) {
+    global.sentry?.captureException?.(
+      new Error(
+        `typeof NetworkController.networkConfigurations is ${typeof NetworkController.networkConfigurations}`,
+      ),
+    );
     return state;
   }
 

--- a/app/scripts/migrations/084.test.js
+++ b/app/scripts/migrations/084.test.js
@@ -2,8 +2,9 @@ import { migrate } from './084';
 
 const sentryCaptureExceptionMock = jest.fn();
 
-global.sentry = {};
-global.sentry.captureException = sentryCaptureExceptionMock;
+global.sentry = {
+  captureException: sentryCaptureExceptionMock,
+};
 
 describe('migration #84', () => {
   afterEach(() => {

--- a/app/scripts/migrations/084.test.js
+++ b/app/scripts/migrations/084.test.js
@@ -1,6 +1,15 @@
 import { migrate } from './084';
 
+const sentryCaptureExceptionMock = jest.fn();
+
+global.sentry = {};
+global.sentry.captureException = sentryCaptureExceptionMock;
+
 describe('migration #84', () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
   it('updates the version metadata', async () => {
     const originalVersionedData = buildOriginalVersionedData({
       meta: {
@@ -27,6 +36,21 @@ describe('migration #84', () => {
     expect(newVersionedData.data).toStrictEqual(originalVersionedData.data);
   });
 
+  it('captures an exception if the network controller state does not exist', async () => {
+    const originalVersionedData = buildOriginalVersionedData({
+      data: {
+        test: '123',
+      },
+    });
+
+    await migrate(originalVersionedData);
+
+    expect(sentryCaptureExceptionMock).toHaveBeenCalledTimes(1);
+    expect(sentryCaptureExceptionMock).toHaveBeenCalledWith(
+      new Error(`typeof state.NetworkController is undefined`),
+    );
+  });
+
   const nonObjects = [undefined, null, 'test', 1, ['test']];
   for (const invalidState of nonObjects) {
     it(`does not change the state if the network controller state is ${invalidState}`, async () => {
@@ -39,6 +63,21 @@ describe('migration #84', () => {
       const newVersionedData = await migrate(originalVersionedData);
 
       expect(newVersionedData.data).toStrictEqual(originalVersionedData.data);
+    });
+
+    it(`captures an exception if the network controller state is ${invalidState}`, async () => {
+      const originalVersionedData = buildOriginalVersionedData({
+        data: {
+          NetworkController: invalidState,
+        },
+      });
+
+      await migrate(originalVersionedData);
+
+      expect(sentryCaptureExceptionMock).toHaveBeenCalledTimes(1);
+      expect(sentryCaptureExceptionMock).toHaveBeenCalledWith(
+        new Error(`typeof state.NetworkController is ${typeof invalidState}`),
+      );
     });
   }
 
@@ -54,6 +93,38 @@ describe('migration #84', () => {
     const newVersionedData = await migrate(originalVersionedData);
 
     expect(newVersionedData.data).toStrictEqual(originalVersionedData.data);
+  });
+
+  it('captures an exception if the network controller state does not include "network" and does not include "networkId"', async () => {
+    const originalVersionedData = buildOriginalVersionedData({
+      data: {
+        NetworkController: {
+          test: '123',
+        },
+      },
+    });
+
+    await migrate(originalVersionedData);
+
+    expect(sentryCaptureExceptionMock).toHaveBeenCalledTimes(1);
+    expect(sentryCaptureExceptionMock).toHaveBeenCalledWith(
+      new Error(`typeof state.NetworkController.network is undefined`),
+    );
+  });
+
+  it('does not capture an exception if the network controller state does not include "network" but does include "networkId"', async () => {
+    const originalVersionedData = buildOriginalVersionedData({
+      data: {
+        NetworkController: {
+          test: '123',
+          networkId: 'foobar',
+        },
+      },
+    });
+
+    await migrate(originalVersionedData);
+
+    expect(sentryCaptureExceptionMock).toHaveBeenCalledTimes(0);
   });
 
   it('replaces "network" in the network controller state with "networkId": null, "networkStatus": "unknown" if it is "loading"', async () => {

--- a/app/scripts/migrations/084.ts
+++ b/app/scripts/migrations/084.ts
@@ -25,9 +25,26 @@ export async function migrate(originalVersionedData: {
 function transformState(state: Record<string, unknown>) {
   if (
     !hasProperty(state, 'NetworkController') ||
-    !isObject(state.NetworkController) ||
-    !hasProperty(state.NetworkController, 'network')
+    !isObject(state.NetworkController)
   ) {
+    global.sentry?.captureException?.(
+      new Error(
+        `typeof state.NetworkController is ${typeof state.NetworkController}`,
+      ),
+    );
+    return state;
+  }
+  if (!hasProperty(state.NetworkController, 'network')) {
+    const inPost077SupplementFor084state =
+      state.NetworkController.networkId !== undefined;
+    if (!inPost077SupplementFor084state) {
+      global.sentry?.captureException?.(
+        new Error(
+          `typeof state.NetworkController.network is ${typeof state
+            .NetworkController.network}`,
+        ),
+      );
+    }
     return state;
   }
 

--- a/app/scripts/migrations/084.ts
+++ b/app/scripts/migrations/084.ts
@@ -35,9 +35,9 @@ function transformState(state: Record<string, unknown>) {
     return state;
   }
   if (!hasProperty(state.NetworkController, 'network')) {
-    const inPost077SupplementFor084state =
-      state.NetworkController.networkId !== undefined;
-    if (!inPost077SupplementFor084state) {
+    const thePost077SupplementFor084HasNotModifiedState =
+      state.NetworkController.networkId === undefined;
+    if (thePost077SupplementFor084HasNotModifiedState) {
       global.sentry?.captureException?.(
         new Error(
           `typeof state.NetworkController.network is ${typeof state

--- a/app/scripts/migrations/085.test.js
+++ b/app/scripts/migrations/085.test.js
@@ -2,8 +2,9 @@ import { migrate, version } from './085';
 
 const sentryCaptureExceptionMock = jest.fn();
 
-global.sentry = {};
-global.sentry.captureException = sentryCaptureExceptionMock;
+global.sentry = {
+  captureException: sentryCaptureExceptionMock,
+};
 
 jest.mock('uuid', () => {
   const actual = jest.requireActual('uuid');

--- a/app/scripts/migrations/085.ts
+++ b/app/scripts/migrations/085.ts
@@ -24,6 +24,11 @@ export async function migrate(originalVersionedData: {
 
 function transformState(state: Record<string, unknown>) {
   if (!isObject(state.NetworkController)) {
+    global.sentry?.captureException?.(
+      new Error(
+        `typeof state.NetworkController is ${typeof state.NetworkController}`,
+      ),
+    );
     return state;
   }
 

--- a/app/scripts/migrations/086.test.js
+++ b/app/scripts/migrations/086.test.js
@@ -2,8 +2,9 @@ import { migrate, version } from './086';
 
 const sentryCaptureExceptionMock = jest.fn();
 
-global.sentry = {};
-global.sentry.captureException = sentryCaptureExceptionMock;
+global.sentry = {
+  captureException: sentryCaptureExceptionMock,
+};
 
 jest.mock('uuid', () => {
   const actual = jest.requireActual('uuid');

--- a/app/scripts/migrations/086.test.js
+++ b/app/scripts/migrations/086.test.js
@@ -1,5 +1,10 @@
 import { migrate, version } from './086';
 
+const sentryCaptureExceptionMock = jest.fn();
+
+global.sentry = {};
+global.sentry.captureException = sentryCaptureExceptionMock;
+
 jest.mock('uuid', () => {
   const actual = jest.requireActual('uuid');
 
@@ -10,6 +15,10 @@ jest.mock('uuid', () => {
 });
 
 describe('migration #86', () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
   it('should update the version metadata', async () => {
     const oldStorage = {
       meta: {
@@ -39,6 +48,25 @@ describe('migration #86', () => {
     expect(newStorage.data).toStrictEqual(oldData);
   });
 
+  it('should capture an exception if there is no network controller state', async () => {
+    const oldData = {
+      other: 'data',
+    };
+    const oldStorage = {
+      meta: {
+        version: 85,
+      },
+      data: oldData,
+    };
+
+    await migrate(oldStorage);
+
+    expect(sentryCaptureExceptionMock).toHaveBeenCalledTimes(1);
+    expect(sentryCaptureExceptionMock).toHaveBeenCalledWith(
+      new Error(`typeof state.NetworkController is undefined`),
+    );
+  });
+
   it('should return state unaltered if there is no network controller provider state', async () => {
     const oldData = {
       other: 'data',
@@ -57,6 +85,52 @@ describe('migration #86', () => {
 
     const newStorage = await migrate(oldStorage);
     expect(newStorage.data).toStrictEqual(oldData);
+  });
+
+  it('should capture an exception if there is no network controller provider state and no providerConfig state', async () => {
+    const oldData = {
+      other: 'data',
+      NetworkController: {
+        networkConfigurations: {
+          foo: 'bar',
+        },
+      },
+    };
+    const oldStorage = {
+      meta: {
+        version: 85,
+      },
+      data: oldData,
+    };
+
+    await migrate(oldStorage);
+
+    expect(sentryCaptureExceptionMock).toHaveBeenCalledTimes(1);
+    expect(sentryCaptureExceptionMock).toHaveBeenCalledWith(
+      new Error(`typeof state.NetworkController.provider is undefined`),
+    );
+  });
+
+  it('should not capture an exception if there is no network controller provider state but there is a providerConfig state', async () => {
+    const oldData = {
+      other: 'data',
+      NetworkController: {
+        networkConfigurations: {
+          foo: 'bar',
+        },
+        providerConfig: {},
+      },
+    };
+    const oldStorage = {
+      meta: {
+        version: 85,
+      },
+      data: oldData,
+    };
+
+    await migrate(oldStorage);
+
+    expect(sentryCaptureExceptionMock).toHaveBeenCalledTimes(0);
   });
 
   it('should rename the provider config state', async () => {

--- a/app/scripts/migrations/086.ts
+++ b/app/scripts/migrations/086.ts
@@ -44,9 +44,9 @@ function transformState(state: Record<string, unknown>) {
       ),
     );
   } else if (!hasProperty(state.NetworkController, 'provider')) {
-    const inPost077SupplementFor086state =
-      state.NetworkController.providerConfig !== undefined;
-    if (!inPost077SupplementFor086state) {
+    const thePost077SupplementFor086HasNotModifiedState =
+      state.NetworkController.providerConfig === undefined;
+    if (thePost077SupplementFor086HasNotModifiedState) {
       global.sentry?.captureException?.(
         new Error(
           `typeof state.NetworkController.provider is ${typeof state

--- a/app/scripts/migrations/086.ts
+++ b/app/scripts/migrations/086.ts
@@ -37,5 +37,24 @@ function transformState(state: Record<string, unknown>) {
       NetworkController: networkControllerState,
     };
   }
+  if (!isObject(state.NetworkController)) {
+    global.sentry?.captureException?.(
+      new Error(
+        `typeof state.NetworkController is ${typeof state.NetworkController}`,
+      ),
+    );
+  } else if (!hasProperty(state.NetworkController, 'provider')) {
+    const inPost077SupplementFor086state =
+      state.NetworkController.providerConfig !== undefined;
+    if (!inPost077SupplementFor086state) {
+      global.sentry?.captureException?.(
+        new Error(
+          `typeof state.NetworkController.provider is ${typeof state
+            .NetworkController.provider}`,
+        ),
+      );
+    }
+  }
+
   return state;
 }

--- a/app/scripts/migrations/087.ts
+++ b/app/scripts/migrations/087.ts
@@ -24,6 +24,11 @@ export async function migrate(originalVersionedData: {
 
 function transformState(state: Record<string, unknown>) {
   if (!isObject(state.TokensController)) {
+    global.sentry?.captureException?.(
+      new Error(
+        `typeof state.TokensController is ${typeof state.TokensController}`,
+      ),
+    );
     return state;
   }
 

--- a/app/scripts/migrations/088.test.ts
+++ b/app/scripts/migrations/088.test.ts
@@ -1,6 +1,16 @@
 import { migrate } from './088';
 
+const sentryCaptureExceptionMock = jest.fn();
+
+global.sentry = {
+  captureException: sentryCaptureExceptionMock,
+};
+
 describe('migration #88', () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
   it('updates the version metadata', async () => {
     const oldStorage = {
       meta: { version: 87 },
@@ -24,6 +34,24 @@ describe('migration #88', () => {
     const newStorage = await migrate(oldStorage);
 
     expect(newStorage.data).toStrictEqual(oldData);
+  });
+
+  it('captures an exception if the NftController property is not an object', async () => {
+    const oldData = {
+      TokenListController: {},
+      TokensController: {},
+      NftController: false,
+    };
+    const oldStorage = {
+      meta: { version: 87 },
+      data: oldData,
+    };
+
+    await migrate(oldStorage);
+    expect(sentryCaptureExceptionMock).toHaveBeenCalledTimes(1);
+    expect(sentryCaptureExceptionMock).toHaveBeenCalledWith(
+      new Error(`typeof state.NftController is boolean`),
+    );
   });
 
   it('returns the state unaltered if the NftController object has no allNftContracts property', async () => {
@@ -56,6 +84,26 @@ describe('migration #88', () => {
     const newStorage = await migrate(oldStorage);
 
     expect(newStorage.data).toStrictEqual(oldData);
+  });
+
+  it('captures an exception if it NftController.allNftContracts is not an object', async () => {
+    const oldData = {
+      TokenListController: {},
+      TokensController: {},
+      NftController: {
+        allNftContracts: 'foo',
+      },
+    };
+    const oldStorage = {
+      meta: { version: 87 },
+      data: oldData,
+    };
+
+    await migrate(oldStorage);
+    expect(sentryCaptureExceptionMock).toHaveBeenCalledTimes(1);
+    expect(sentryCaptureExceptionMock).toHaveBeenCalledWith(
+      new Error(`typeof state.NftController.allNftContracts is string`),
+    );
   });
 
   it('returns the state unaltered if any value of the NftController.allNftContracts object is not an object itself', async () => {
@@ -322,6 +370,26 @@ describe('migration #88', () => {
     const newStorage = await migrate(oldStorage);
 
     expect(newStorage.data).toStrictEqual(oldData);
+  });
+
+  it('captures an exception if it NftController.allNfts is not an object', async () => {
+    const oldData = {
+      TokenListController: {},
+      TokensController: {},
+      NftController: {
+        allNfts: 'foo',
+      },
+    };
+    const oldStorage = {
+      meta: { version: 87 },
+      data: oldData,
+    };
+
+    await migrate(oldStorage);
+    expect(sentryCaptureExceptionMock).toHaveBeenCalledTimes(1);
+    expect(sentryCaptureExceptionMock).toHaveBeenCalledWith(
+      new Error(`typeof state.NftController.allNfts is string`),
+    );
   });
 
   it('returns the state unaltered if any value of the NftController.allNfts object is not an object itself', async () => {
@@ -656,6 +724,91 @@ describe('migration #88', () => {
     expect(newStorage.data).toStrictEqual(oldData);
   });
 
+  it('captures an exception if it has no TokenListController property', async () => {
+    const oldData = {
+      TokensController: {},
+      NftController: {
+        allNfts: {
+          '0x111': {
+            '0x10': [
+              {
+                name: 'NFT 1',
+                description: 'Description for NFT 1',
+                image: 'nft1.jpg',
+                standard: 'ERC721',
+                tokenId: '1',
+                address: '0xaaa',
+              },
+            ],
+          },
+        },
+        allNftContracts: {
+          '0x111': {
+            '0x10': [
+              {
+                name: 'Contract 1',
+                address: '0xaaa',
+              },
+            ],
+          },
+        },
+      },
+    };
+    const oldStorage = {
+      meta: { version: 87 },
+      data: oldData,
+    };
+
+    await migrate(oldStorage);
+    expect(sentryCaptureExceptionMock).toHaveBeenCalledTimes(1);
+    expect(sentryCaptureExceptionMock).toHaveBeenCalledWith(
+      new Error(`typeof state.TokenListController is undefined`),
+    );
+  });
+
+  it('captures an exception if the TokenListController property is not an object', async () => {
+    const oldData = {
+      TokensController: {},
+      NftController: {
+        allNfts: {
+          '0x111': {
+            '0x10': [
+              {
+                name: 'NFT 1',
+                description: 'Description for NFT 1',
+                image: 'nft1.jpg',
+                standard: 'ERC721',
+                tokenId: '1',
+                address: '0xaaa',
+              },
+            ],
+          },
+        },
+        allNftContracts: {
+          '0x111': {
+            '0x10': [
+              {
+                name: 'Contract 1',
+                address: '0xaaa',
+              },
+            ],
+          },
+        },
+      },
+      TokenListController: false,
+    };
+    const oldStorage = {
+      meta: { version: 87 },
+      data: oldData,
+    };
+
+    await migrate(oldStorage);
+    expect(sentryCaptureExceptionMock).toHaveBeenCalledTimes(1);
+    expect(sentryCaptureExceptionMock).toHaveBeenCalledWith(
+      new Error(`typeof state.TokenListController is boolean`),
+    );
+  });
+
   it('returns the state unaltered if the TokenListController object has no tokensChainsCache property', async () => {
     const oldData = {
       TokenListController: {
@@ -686,6 +839,25 @@ describe('migration #88', () => {
     const newStorage = await migrate(oldStorage);
 
     expect(newStorage.data).toStrictEqual(oldData);
+  });
+
+  it('captures an exception if the TokenListController.tokensChainsCache property is not an object', async () => {
+    const oldData = {
+      TokenListController: {
+        tokensChainsCache: 'foo',
+      },
+      TokensController: {},
+    };
+    const oldStorage = {
+      meta: { version: 87 },
+      data: oldData,
+    };
+
+    await migrate(oldStorage);
+    expect(sentryCaptureExceptionMock).toHaveBeenCalledTimes(1);
+    expect(sentryCaptureExceptionMock).toHaveBeenCalledWith(
+      new Error(`typeof state.TokenListController.tokensChainsCache is string`),
+    );
   });
 
   it('rewrites TokenListController.tokensChainsCache so that decimal chain IDs are converted to hex strings', async () => {
@@ -919,6 +1091,39 @@ describe('migration #88', () => {
     expect(newStorage.data).toStrictEqual(oldData);
   });
 
+  it('captures an exception if it has no TokensController property', async () => {
+    const oldData = {
+      TokenListController: {},
+    };
+    const oldStorage = {
+      meta: { version: 87 },
+      data: oldData,
+    };
+
+    await migrate(oldStorage);
+    expect(sentryCaptureExceptionMock).toHaveBeenCalledTimes(1);
+    expect(sentryCaptureExceptionMock).toHaveBeenCalledWith(
+      new Error(`typeof state.TokensController is undefined`),
+    );
+  });
+
+  it('captures an exception if the TokensController property is not an object', async () => {
+    const oldData = {
+      TokenListController: {},
+      TokensController: false,
+    };
+    const oldStorage = {
+      meta: { version: 87 },
+      data: oldData,
+    };
+
+    await migrate(oldStorage);
+    expect(sentryCaptureExceptionMock).toHaveBeenCalledTimes(1);
+    expect(sentryCaptureExceptionMock).toHaveBeenCalledWith(
+      new Error(`typeof state.TokensController is boolean`),
+    );
+  });
+
   it('returns the state unaltered if the TokensController object has no allTokens property', async () => {
     const oldData = {
       TokensController: {
@@ -949,6 +1154,25 @@ describe('migration #88', () => {
     const newStorage = await migrate(oldStorage);
 
     expect(newStorage.data).toStrictEqual(oldData);
+  });
+
+  it('captures an exception if the TokensController.allTokens property is not an object', async () => {
+    const oldData = {
+      TokenListController: {},
+      TokensController: {
+        allTokens: 'foo',
+      },
+    };
+    const oldStorage = {
+      meta: { version: 87 },
+      data: oldData,
+    };
+
+    await migrate(oldStorage);
+    expect(sentryCaptureExceptionMock).toHaveBeenCalledTimes(1);
+    expect(sentryCaptureExceptionMock).toHaveBeenCalledWith(
+      new Error(`typeof state.TokensController.allTokens is string`),
+    );
   });
 
   it('rewrites TokensController.allTokens so that decimal chain IDs are converted to hex strings', async () => {
@@ -1163,6 +1387,25 @@ describe('migration #88', () => {
     expect(newStorage.data).toStrictEqual(oldData);
   });
 
+  it('captures an exception if the TokensController.allIgnoredTokens property is not an object', async () => {
+    const oldData = {
+      TokenListController: {},
+      TokensController: {
+        allIgnoredTokens: 'foo',
+      },
+    };
+    const oldStorage = {
+      meta: { version: 87 },
+      data: oldData,
+    };
+
+    await migrate(oldStorage);
+    expect(sentryCaptureExceptionMock).toHaveBeenCalledTimes(1);
+    expect(sentryCaptureExceptionMock).toHaveBeenCalledWith(
+      new Error(`typeof state.TokensController.allIgnoredTokens is string`),
+    );
+  });
+
   it('rewrites TokensController.allIgnoredTokens so that decimal chain IDs are converted to hex strings', async () => {
     const oldStorage = {
       meta: { version: 87 },
@@ -1321,6 +1564,25 @@ describe('migration #88', () => {
     const newStorage = await migrate(oldStorage);
 
     expect(newStorage.data).toStrictEqual(oldData);
+  });
+
+  it('captures an exception if the TokensController.allDetectedTokens property is not an object', async () => {
+    const oldData = {
+      TokenListController: {},
+      TokensController: {
+        allDetectedTokens: 'foo',
+      },
+    };
+    const oldStorage = {
+      meta: { version: 87 },
+      data: oldData,
+    };
+
+    await migrate(oldStorage);
+    expect(sentryCaptureExceptionMock).toHaveBeenCalledTimes(1);
+    expect(sentryCaptureExceptionMock).toHaveBeenCalledWith(
+      new Error(`typeof state.TokensController.allDetectedTokens is string`),
+    );
   });
 
   it('rewrites TokensController.allDetectedTokens so that decimal chain IDs are converted to hex strings', async () => {

--- a/app/scripts/migrations/088.ts
+++ b/app/scripts/migrations/088.ts
@@ -1,6 +1,7 @@
 import { hasProperty, Hex, isObject, isStrictHexString } from '@metamask/utils';
 import { BN } from 'ethereumjs-util';
 import { cloneDeep, mapKeys } from 'lodash';
+import log from 'loglevel';
 
 type VersionedData = {
   meta: { version: number };
@@ -70,6 +71,16 @@ function migrateData(state: Record<string, unknown>): void {
           }
         });
       }
+    } else if (hasProperty(nftControllerState, 'allNftContracts')) {
+      global.sentry?.captureException?.(
+        new Error(
+          `typeof state.NftController.allNftContracts is ${typeof nftControllerState.allNftContracts}`,
+        ),
+      );
+    } else {
+      log.warn(
+        `typeof state.NftController.allNftContracts is ${typeof nftControllerState.allNftContracts}`,
+      );
     }
 
     // Migrate NftController.allNfts
@@ -96,9 +107,25 @@ function migrateData(state: Record<string, unknown>): void {
           }
         });
       }
+    } else if (hasProperty(nftControllerState, 'allNfts')) {
+      global.sentry?.captureException?.(
+        new Error(
+          `typeof state.NftController.allNfts is ${typeof nftControllerState.allNfts}`,
+        ),
+      );
+    } else {
+      log.warn(
+        `typeof state.NftController.allNfts is ${typeof nftControllerState.allNfts}`,
+      );
     }
 
     state.NftController = nftControllerState;
+  } else if (hasProperty(state, 'NftController')) {
+    global.sentry?.captureException?.(
+      new Error(`typeof state.NftController is ${typeof state.NftController}`),
+    );
+  } else {
+    log.warn(`typeof state.NftController is undefined`);
   }
 
   if (
@@ -124,7 +151,24 @@ function migrateData(state: Record<string, unknown>): void {
         tokenListControllerState.tokensChainsCache,
         (_, chainId: string) => toHex(chainId),
       );
+    } else if (hasProperty(tokenListControllerState, 'tokensChainsCache')) {
+      global.sentry?.captureException?.(
+        new Error(
+          `typeof state.TokenListController.tokensChainsCache is ${typeof state
+            .TokenListController.tokensChainsCache}`,
+        ),
+      );
+    } else {
+      log.warn(
+        `typeof state.TokenListController.tokensChainsCache is undefined`,
+      );
     }
+  } else {
+    global.sentry?.captureException?.(
+      new Error(
+        `typeof state.TokenListController is ${typeof state.TokenListController}`,
+      ),
+    );
   }
 
   if (
@@ -150,6 +194,16 @@ function migrateData(state: Record<string, unknown>): void {
         allTokens,
         (_, chainId: string) => toHex(chainId),
       );
+    } else if (hasProperty(tokensControllerState, 'allTokens')) {
+      global.sentry?.captureException?.(
+        new Error(
+          `typeof state.TokensController.allTokens is ${typeof tokensControllerState.allTokens}`,
+        ),
+      );
+    } else {
+      log.warn(
+        `typeof state.TokensController.allTokens is ${typeof tokensControllerState.allTokens}`,
+      );
     }
 
     // Migrate TokensController.allIgnoredTokens
@@ -168,6 +222,16 @@ function migrateData(state: Record<string, unknown>): void {
       tokensControllerState.allIgnoredTokens = mapKeys(
         allIgnoredTokens,
         (_, chainId: string) => toHex(chainId),
+      );
+    } else if (hasProperty(tokensControllerState, 'allIgnoredTokens')) {
+      global.sentry?.captureException?.(
+        new Error(
+          `typeof state.TokensController.allIgnoredTokens is ${typeof tokensControllerState.allIgnoredTokens}`,
+        ),
+      );
+    } else {
+      log.warn(
+        `typeof state.TokensController.allIgnoredTokens is ${typeof tokensControllerState.allIgnoredTokens}`,
       );
     }
 
@@ -188,9 +252,25 @@ function migrateData(state: Record<string, unknown>): void {
         allDetectedTokens,
         (_, chainId: string) => toHex(chainId),
       );
+    } else if (hasProperty(tokensControllerState, 'allDetectedTokens')) {
+      global.sentry?.captureException?.(
+        new Error(
+          `typeof state.TokensController.allDetectedTokens is ${typeof tokensControllerState.allDetectedTokens}`,
+        ),
+      );
+    } else {
+      log.warn(
+        `typeof state.TokensController.allDetectedTokens is ${typeof tokensControllerState.allDetectedTokens}`,
+      );
     }
 
     state.TokensController = tokensControllerState;
+  } else {
+    global.sentry?.captureException?.(
+      new Error(
+        `typeof state.TokensController is ${typeof state.TokensController}`,
+      ),
+    );
   }
 }
 

--- a/app/scripts/migrations/089.ts
+++ b/app/scripts/migrations/089.ts
@@ -66,6 +66,19 @@ function transformState(state: Record<string, unknown>) {
       ...state,
       NetworkController: state.NetworkController,
     };
+  } else if (!isObject(state.NetworkController)) {
+    global.sentry?.captureException?.(
+      new Error(
+        `typeof state.NetworkController is ${typeof state.NetworkController}`,
+      ),
+    );
+  } else if (!isObject(state.NetworkController.providerConfig)) {
+    global.sentry?.captureException?.(
+      new Error(
+        `typeof state.NetworkController.providerConfig is ${typeof state
+          .NetworkController.providerConfig}`,
+      ),
+    );
   }
   return state;
 }

--- a/app/scripts/migrations/090.ts
+++ b/app/scripts/migrations/090.ts
@@ -1,5 +1,6 @@
 import { cloneDeep } from 'lodash';
 import { hasProperty, isObject } from '@metamask/utils';
+import log from 'loglevel';
 
 export const version = 90;
 
@@ -23,11 +24,24 @@ export async function migrate(originalVersionedData: {
 }
 
 function transformState(state: Record<string, unknown>) {
-  if (
-    !hasProperty(state, 'PhishingController') ||
-    !isObject(state.PhishingController) ||
-    !hasProperty(state.PhishingController, 'listState')
-  ) {
+  if (!hasProperty(state, 'PhishingController')) {
+    log.warn(
+      `typeof state.PhishingController is undefined`,
+    );
+    return state;
+  }
+  if (!isObject(state.PhishingController)) {
+    global.sentry?.captureException?.(
+      new Error(
+        `typeof state.PhishingController is ${typeof state.PhishingController}`,
+      ),
+    );
+    return state;
+  }
+  if (!hasProperty(state.PhishingController, 'listState')) {
+    log.warn(
+      `typeof state.PhishingController.listState is ${typeof state.PhishingController}`,
+    );
     return state;
   }
 

--- a/app/scripts/migrations/090.ts
+++ b/app/scripts/migrations/090.ts
@@ -25,9 +25,7 @@ export async function migrate(originalVersionedData: {
 
 function transformState(state: Record<string, unknown>) {
   if (!hasProperty(state, 'PhishingController')) {
-    log.warn(
-      `typeof state.PhishingController is undefined`,
-    );
+    log.warn(`typeof state.PhishingController is undefined`);
     return state;
   }
   if (!isObject(state.PhishingController)) {

--- a/app/scripts/migrations/091.test.ts
+++ b/app/scripts/migrations/091.test.ts
@@ -1,6 +1,15 @@
 import { cloneDeep } from 'lodash';
 import { migrate, version } from './091';
 
+const sentryCaptureExceptionMock = jest.fn();
+
+global.sentry = {
+  startSession: jest.fn(),
+  endSession: jest.fn(),
+  toggleSession: jest.fn(),
+  captureException: sentryCaptureExceptionMock,
+};
+
 jest.mock('uuid', () => {
   const actual = jest.requireActual('uuid');
 
@@ -11,6 +20,10 @@ jest.mock('uuid', () => {
 });
 
 describe('migration #91', () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
   it('should update the version metadata', async () => {
     const oldStorage = {
       meta: {
@@ -40,6 +53,25 @@ describe('migration #91', () => {
     expect(newStorage.data).toStrictEqual(oldData);
   });
 
+  it('should capture an exception if there is no network controller state', async () => {
+    const oldData = {
+      other: 'data',
+    };
+    const oldStorage = {
+      meta: {
+        version: 90,
+      },
+      data: oldData,
+    };
+
+    await migrate(oldStorage);
+
+    expect(sentryCaptureExceptionMock).toHaveBeenCalledTimes(1);
+    expect(sentryCaptureExceptionMock).toHaveBeenCalledWith(
+      new Error(`typeof state.NetworkController is undefined`),
+    );
+  });
+
   it('should return state unaltered if there is no network controller networkConfigurations state', async () => {
     const oldData = {
       other: 'data',
@@ -58,6 +90,32 @@ describe('migration #91', () => {
 
     const newStorage = await migrate(cloneDeep(oldStorage));
     expect(newStorage.data).toStrictEqual(oldData);
+  });
+
+  it('should capture an exception if there is no network controller networkConfigurations state', async () => {
+    const oldData = {
+      other: 'data',
+      NetworkController: {
+        providerConfig: {
+          foo: 'bar',
+        },
+      },
+    };
+    const oldStorage = {
+      meta: {
+        version: 90,
+      },
+      data: oldData,
+    };
+
+    await migrate(oldStorage);
+
+    expect(sentryCaptureExceptionMock).toHaveBeenCalledTimes(1);
+    expect(sentryCaptureExceptionMock).toHaveBeenCalledWith(
+      new Error(
+        `typeof state.NetworkController.networkConfigurations is undefined`,
+      ),
+    );
   });
 
   it('should return state unaltered if the networkConfigurations all have a chainId', async () => {

--- a/app/scripts/migrations/091.ts
+++ b/app/scripts/migrations/091.ts
@@ -50,6 +50,19 @@ function transformState(state: Record<string, unknown>) {
       ...state,
       NetworkController: state.NetworkController,
     };
+  } else if (!isObject(state.NetworkController)) {
+    global.sentry?.captureException?.(
+      new Error(
+        `typeof state.NetworkController is ${typeof state.NetworkController}`,
+      ),
+    );
+  } else if (!isObject(state.NetworkController.networkConfigurations)) {
+    global.sentry?.captureException?.(
+      new Error(
+        `typeof state.NetworkController.networkConfigurations is ${typeof state
+          .NetworkController.networkConfigurations}`,
+      ),
+    );
   }
   return state;
 }

--- a/app/scripts/migrations/092.ts
+++ b/app/scripts/migrations/092.ts
@@ -1,5 +1,6 @@
 import { cloneDeep } from 'lodash';
 import { hasProperty, isObject } from '@metamask/utils';
+import log from 'loglevel';
 
 export const version = 92;
 
@@ -30,6 +31,14 @@ function transformState(state: Record<string, unknown>) {
   ) {
     delete state.PhishingController.stalelistLastFetched;
     delete state.PhishingController.hotlistLastFetched;
+  } else if (hasProperty(state, 'PhishingController')) {
+    global.sentry?.captureException?.(
+      new Error(
+        `typeof state.PhishingController is ${typeof state.PhishingController}`,
+      ),
+    );
+  } else {
+    log.warn(`typeof state.PhishingController is undefined`);
   }
   return state;
 }

--- a/app/scripts/migrations/093.test.ts
+++ b/app/scripts/migrations/093.test.ts
@@ -3,7 +3,20 @@ import { migrate, version } from './093';
 
 const PREVIOUS_VERSION = version - 1;
 
+const sentryCaptureExceptionMock = jest.fn();
+
+global.sentry = {
+  startSession: jest.fn(),
+  endSession: jest.fn(),
+  toggleSession: jest.fn(),
+  captureException: sentryCaptureExceptionMock,
+};
+
 describe('migration #93', () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
   it('should update the version metadata', async () => {
     const oldStorage = {
       meta: {
@@ -33,6 +46,25 @@ describe('migration #93', () => {
     expect(newStorage.data).toStrictEqual(oldData);
   });
 
+  it('should capture an exception if there is no network controller state', async () => {
+    const oldData = {
+      other: 'data',
+    };
+    const oldStorage = {
+      meta: {
+        version: PREVIOUS_VERSION,
+      },
+      data: oldData,
+    };
+
+    await migrate(oldStorage);
+
+    expect(sentryCaptureExceptionMock).toHaveBeenCalledTimes(1);
+    expect(sentryCaptureExceptionMock).toHaveBeenCalledWith(
+      new Error(`typeof state.NetworkController is undefined`),
+    );
+  });
+
   it('should return state unaltered if there is no network controller providerConfig state', async () => {
     const oldData = {
       other: 'data',
@@ -53,6 +85,32 @@ describe('migration #93', () => {
 
     const newStorage = await migrate(oldStorage);
     expect(newStorage.data).toStrictEqual(oldData);
+  });
+
+  it('should capture an exception if there is no network controller providerConfig state', async () => {
+    const oldData = {
+      other: 'data',
+      NetworkController: {
+        networkConfigurations: {
+          id1: {
+            foo: 'bar',
+          },
+        },
+      },
+    };
+    const oldStorage = {
+      meta: {
+        version: PREVIOUS_VERSION,
+      },
+      data: oldData,
+    };
+
+    await migrate(oldStorage);
+
+    expect(sentryCaptureExceptionMock).toHaveBeenCalledTimes(1);
+    expect(sentryCaptureExceptionMock).toHaveBeenCalledWith(
+      new Error(`typeof state.NetworkController.providerConfig is undefined`),
+    );
   });
 
   it('should return state unaltered if there is already a ticker in the providerConfig state', async () => {

--- a/app/scripts/migrations/093.ts
+++ b/app/scripts/migrations/093.ts
@@ -44,6 +44,22 @@ function transformState(state: Record<string, unknown>) {
       ...state,
       NetworkController: state.NetworkController,
     };
+  } else if (!isObject(state.NetworkController)) {
+    global.sentry?.captureException?.(
+      new Error(
+        `typeof state.NetworkController is ${typeof state.NetworkController}`,
+      ),
+    );
+  } else if (
+    isObject(state.NetworkController) &&
+    !isObject(state.NetworkController.providerConfig)
+  ) {
+    global.sentry?.captureException?.(
+      new Error(
+        `typeof state.NetworkController.providerConfig is ${typeof state
+          .NetworkController.providerConfig}`,
+      ),
+    );
   }
   return state;
 }

--- a/app/scripts/migrations/094.ts
+++ b/app/scripts/migrations/094.ts
@@ -84,6 +84,35 @@ function transformState(state: Record<string, unknown>) {
         selectedNetworkClientId,
       },
     };
+  } else if (!isObject(state.NetworkController)) {
+    global.sentry?.captureException?.(
+      new Error(
+        `typeof state.NetworkController is ${typeof state.NetworkController}`,
+      ),
+    );
+  } else if (
+    isObject(state.NetworkController) &&
+    !isObject(state.NetworkController.providerConfig)
+  ) {
+    global.sentry?.captureException?.(
+      new Error(
+        `typeof state.NetworkController.providerConfig is ${typeof state
+          .NetworkController.providerConfig}`,
+      ),
+    );
+  } else if (
+    isObject(state.NetworkController) &&
+    isObject(state.NetworkController.providerConfig)
+  ) {
+    global.sentry?.captureException?.(
+      new Error(
+        `typeof state.NetworkController.providerConfig.id is ${typeof state
+          .NetworkController.providerConfig
+          .id} and state.NetworkController.providerConfig.type is ${
+          state.NetworkController.providerConfig.type
+        }`,
+      ),
+    );
   }
   return state;
 }

--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -21,7 +21,7 @@ declare class SentryObject extends Sentry {
   // Calls either startSession or endSession based on optin status
   toggleSession: () => void;
 
-  captureException: (error: Error, extra: Record<string, unknown>) => void;
+  captureException: (error: Error, extra?: Record<string, unknown>) => void;
 }
 
 export declare global {

--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -20,6 +20,8 @@ declare class SentryObject extends Sentry {
 
   // Calls either startSession or endSession based on optin status
   toggleSession: () => void;
+
+  captureException: (error: Error, extra: Record<string, unknown>) => void;
 }
 
 export declare global {

--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -9,7 +9,7 @@ declare class Platform {
   closeCurrentWindow: () => void;
 }
 
-declare class SentryObject extends Sentry {
+type SentryObject = Sentry & {
   // Verifies that the user has opted into metrics and then updates the sentry
   // instance to track sessions and begins the session.
   startSession: () => void;
@@ -20,9 +20,7 @@ declare class SentryObject extends Sentry {
 
   // Calls either startSession or endSession based on optin status
   toggleSession: () => void;
-
-  captureException: (error: Error, extra?: Record<string, unknown>) => void;
-}
+};
 
 export declare global {
   var platform: Platform;


### PR DESCRIPTION
## Explanation

There are states that we expect to never see in migrations. Although we do handle such cases and return state unchanged when they occur. This PR will add sentry `captureExceptions` calls when these states are detected, to better inform debugging of bugs/errors where the presence of those states may play a factor.

## Manual Testing Steps

1. Build this branch, onboard
2. Run the following script in the background console
```
chrome.storage.local.get(({ data, meta }) => chrome.storage.local.set({ data: { ...data, PreferencesController: false }, meta: {...meta, version: 81} }, () => { window.location.reload() }))
```
3. You should see a network request to sentry with  `typeof state.PreferencesController is boolean` in the payload

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
