### PR TITLE
Use unflattened state for Sentry

### DIFF
--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -886,14 +886,14 @@ browser.runtime.onInstalled.addListener(({ reason }) => {
 
 function setupSentryGetStateGlobal(store) {
   global.stateHooks.getSentryState = function () {
-    const backgroundState = store.getState();
+    const backgroundState = store.memStore.getState();
     const maskedBackgroundState = maskObject(
       backgroundState,
       SENTRY_BACKGROUND_STATE,
     );
     return {
       browser: window.navigator.userAgent,
-      store: { metamask: maskedBackgroundState },
+      store: maskedBackgroundState,
       version: platform.getVersion(),
     };
   };

--- a/app/scripts/lib/setupSentry.js
+++ b/app/scripts/lib/setupSentry.js
@@ -27,52 +27,86 @@ export const ERROR_URL_ALLOWLIST = {
 // sent to Sentry These properties have some potential to be useful for
 // debugging, and they do not contain any identifiable information.
 export const SENTRY_BACKGROUND_STATE = {
-  alertEnabledness: true,
-  completedOnboarding: true,
-  connectedStatusPopoverHasBeenShown: true,
-  conversionDate: true,
-  conversionRate: true,
-  currentAppVersion: true,
-  currentBlockGasLimit: true,
-  currentCurrency: true,
-  currentLocale: true,
-  currentMigrationVersion: true,
-  customNonceValue: true,
-  defaultHomeActiveTabName: true,
-  desktopEnabled: true,
-  featureFlags: true,
-  firstTimeFlowType: true,
-  forgottenPassword: true,
-  incomingTxLastFetchedBlockByChainId: true,
-  ipfsGateway: true,
-  isAccountMenuOpen: true,
-  isInitialized: true,
-  isUnlocked: true,
-  metaMetricsId: true,
-  nativeCurrency: true,
-  networkId: true,
-  networkStatus: true,
-  nextNonce: true,
-  participateInMetaMetrics: true,
-  preferences: true,
-  previousAppVersion: true,
-  previousMigrationVersion: true,
-  providerConfig: {
-    nickname: true,
-    ticker: true,
-    type: true,
+  AccountTracker: {
+    currentBlockGasLimit: true,
   },
-  seedPhraseBackedUp: true,
-  unapprovedDecryptMsgCount: true,
-  unapprovedEncryptionPublicKeyMsgCount: true,
-  unapprovedMsgCount: true,
-  unapprovedPersonalMsgCount: true,
-  unapprovedTypedMessagesCount: true,
-  useBlockie: true,
-  useNonceField: true,
-  usePhishDetect: true,
-  welcomeScreenSeen: true,
+  AlertController: {
+    alertEnabledness: true,
+  },
+  AppMetadataController: {
+    currentAppVersion: true,
+    previousAppVersion: true,
+    previousMigrationVersion: true,
+    currentMigrationVersion: true,
+  },
+  AppStateController: {
+    connectedStatusPopoverHasBeenShown: true,
+    defaultHomeActiveTabName: true,
+  },
+  CurrencyController: {
+    conversionDate: true,
+    conversionRate: true,
+    currentCurrency: true,
+    nativeCurrency: true,
+  },
+  DecryptMessageController: {
+    unapprovedDecryptMsgCount: true,
+  },
+  DesktopController: {
+    desktopEnabled: true,
+  },
+  EncryptionPublicKeyController: {
+    unapprovedEncryptionPublicKeyMsgCount: true,
+  },
+  IncomingTransactionsController: {
+    incomingTxLastFetchedBlockByChainId: true,
+  },
+  KeyringController: {
+    isUnlocked: true,
+  },
+  MetaMetricsController: {
+    metaMetricsId: true,
+    participateInMetaMetrics: true,
+  },
+  NetworkController: {
+    networkId: true,
+    networkStatus: true,
+    providerConfig: {
+      nickname: true,
+      ticker: true,
+      type: true,
+    },
+  },
+  OnboardingController: {
+    completedOnboarding: true,
+    firstTimeFlowType: true,
+    seedPhraseBackedUp: true,
+  },
+  PreferencesController: {
+    currentLocale: true,
+    featureFlags: true,
+    forgottenPassword: true,
+    ipfsGateway: true,
+    preferences: true,
+    useBlockie: true,
+    useNonceField: true,
+    usePhishDetect: true,
+  },
+  SignatureController: {
+    unapprovedMsgCount: true,
+    unapprovedPersonalMsgCount: true,
+    unapprovedTypedMessagesCount: true,
+  },
 };
+
+const flattenedBackgroundStateMask = Object.values(
+  SENTRY_BACKGROUND_STATE,
+).reduce((partialBackgroundState, controllerState) => {
+  return {
+    ...partialBackgroundState,
+    ...controllerState,
+  };
+}, {});
 
 // This describes the subset of Redux state attached to errors sent to Sentry
 // These properties have some potential to be useful for debugging, and they do
@@ -80,7 +114,16 @@ export const SENTRY_BACKGROUND_STATE = {
 export const SENTRY_UI_STATE = {
   gas: true,
   history: true,
-  metamask: SENTRY_BACKGROUND_STATE,
+  metamask: {
+    ...flattenedBackgroundStateMask,
+    // This property comes from the background but isn't in controller state
+    isInitialized: true,
+    // These properties are in the `metamask` slice but not in the background state
+    customNonceValue: true,
+    isAccountMenuOpen: true,
+    nextNonce: true,
+    welcomeScreenSeen: true,
+  },
   unconnectedAccount: true,
 };
 

--- a/test/e2e/tests/state-snapshots/errors-after-init-opt-in-background-state.json
+++ b/test/e2e/tests/state-snapshots/errors-after-init-opt-in-background-state.json
@@ -1,52 +1,32 @@
 {
-  "metamask": {
-    "isInitialized": true,
+  "AccountTracker": { "currentBlockGasLimit": "0x1c9c380" },
+  "AppStateController": {
     "connectedStatusPopoverHasBeenShown": true,
-    "defaultHomeActiveTabName": null,
-    "currentAppVersion": "10.34.4",
-    "previousAppVersion": "",
-    "previousMigrationVersion": 0,
-    "currentMigrationVersion": 94,
+    "defaultHomeActiveTabName": null
+  },
+  "CurrencyController": {
+    "conversionDate": "number",
+    "conversionRate": 1700,
+    "nativeCurrency": "ETH",
+    "currentCurrency": "usd"
+  },
+  "DecryptMessageController": { "unapprovedDecryptMsgCount": 0 },
+  "EncryptionPublicKeyController": {
+    "unapprovedEncryptionPublicKeyMsgCount": 0
+  },
+  "MetaMetricsController": {
+    "participateInMetaMetrics": true,
+    "metaMetricsId": "fake-metrics-id"
+  },
+  "NetworkController": {
     "networkId": "1337",
     "providerConfig": {
       "nickname": "Localhost 8545",
       "ticker": "ETH",
       "type": "rpc"
-    },
-    "isUnlocked": false,
-    "useBlockie": false,
-    "useNonceField": false,
-    "usePhishDetect": true,
-    "featureFlags": { "showIncomingTransactions": true },
-    "currentLocale": "en",
-    "forgottenPassword": false,
-    "preferences": {
-      "hideZeroBalanceTokens": false,
-      "showFiatInTestnets": false,
-      "showTestNetworks": false,
-      "useNativeCurrencyAsPrimaryCurrency": true
-    },
-    "ipfsGateway": "dweb.link",
-    "participateInMetaMetrics": true,
-    "metaMetricsId": "fake-metrics-id",
-    "conversionDate": "number",
-    "conversionRate": 1700,
-    "nativeCurrency": "ETH",
-    "currentCurrency": "usd",
-    "alertEnabledness": { "unconnectedAccount": true, "web3ShimUsage": true },
-    "seedPhraseBackedUp": true,
-    "firstTimeFlowType": "import",
-    "completedOnboarding": true,
-    "incomingTxLastFetchedBlockByChainId": {
-      "0x1": null,
-      "0xe708": null,
-      "0x5": null,
-      "0xaa36a7": null,
-      "0xe704": null
-    },
-    "currentBlockGasLimit": "0x1c9c380",
-    "unapprovedDecryptMsgCount": 0,
-    "unapprovedEncryptionPublicKeyMsgCount": 0,
+    }
+  },
+  "SignatureController": {
     "unapprovedMsgCount": 0,
     "unapprovedPersonalMsgCount": 0,
     "unapprovedTypedMessagesCount": 0


### PR DESCRIPTION
## Explanation

The unflattened background state is now attached to any Sentry errors from the background process. This provides a clearer picture of the state of the wallet, and unblocks further improvements to Sentry state which will come in later PRs.

Relates to #20449

## Manual Testing Steps


The `test/e2e/tests/error.spec.js` background state tests demonstrate how this can be tested. You can look in the network console and use a custom Sentry instance to inspect the errors and associated state.

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
