### PR TITLE
Bump json-middleware-rpc-stream to 4.2.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -323,7 +323,7 @@
     "is-retry-allowed": "^2.2.0",
     "jest-junit": "^14.0.1",
     "json-rpc-engine": "^6.1.0",
-    "json-rpc-middleware-stream": "^4.2.1",
+    "json-rpc-middleware-stream": "^4.2.2",
     "labeled-stream-splicer": "^2.0.2",
     "localforage": "^1.9.0",
     "lodash": "^4.17.21",

--- a/yarn.lock
+++ b/yarn.lock
@@ -22376,6 +22376,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"json-rpc-middleware-stream@npm:^4.2.2":
+  version: 4.2.2
+  resolution: "json-rpc-middleware-stream@npm:4.2.2"
+  dependencies:
+    "@metamask/safe-event-emitter": "npm:^3.0.0"
+    readable-stream: "npm:^2.3.3"
+  checksum: 0f7882b5898001c00a442104790a487c1276faf40b64fb6257aceffcb30f0f0ccabb67553a43d6313e30a940fc256ddd8f7c0176e3bdeea172a7bfe11e9aa56e
+  languageName: node
+  linkType: hard
+
 "json-rpc-random-id@npm:^1.0.0, json-rpc-random-id@npm:^1.0.1":
   version: 1.0.1
   resolution: "json-rpc-random-id@npm:1.0.1"
@@ -24453,7 +24463,7 @@ __metadata:
     js-yaml: "npm:^4.1.0"
     jsdom: "npm:^16.7.0"
     json-rpc-engine: "npm:^6.1.0"
-    json-rpc-middleware-stream: "npm:^4.2.1"
+    json-rpc-middleware-stream: "npm:^4.2.2"
     junit-report-merger: "npm:^4.0.0"
     koa: "npm:^2.7.0"
     labeled-stream-splicer: "npm:^2.0.2"


### PR DESCRIPTION
## Explanation

This version bump includes the fix that was made in this PR https://github.com/MetaMask/json-rpc-middleware-stream/pull/47

This may fix the problem described here https://github.com/Uniswap/interface/issues/6613, but it seems possible that the problem described there was already fixed by https://github.com/MetaMask/metamask-extension/pull/19727. We need to verify this.

## Manual Testing Steps

- [ ] If possible, add manual testing steps once determine a consistently reproducible bug that was not already fixed on develop / in prod

## Pre-merge author checklist

- [ ] I've clearly explained:
  - [ ] What problem this PR is solving
  - [ ] How this problem was solved
  - [ ] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
