### PR TITLE
UX: Remove unwanted extra spacing on home screen

### DIFF
--- a/ui/pages/home/home.component.js
+++ b/ui/pages/home/home.component.js
@@ -988,20 +988,21 @@ export default class Home extends PureComponent {
                 ///: END:ONLY_INCLUDE_IN
               }
             </Box>
-            <div className="home__support">
-              {
-                ///: BEGIN:ONLY_INCLUDE_IN(build-beta)
+            {
+              ///: BEGIN:ONLY_INCLUDE_IN(build-beta)
+              <div className="home__support">
                 <BetaHomeFooter />
-                ///: END:ONLY_INCLUDE_IN
-              }
-              {
-                ///: BEGIN:ONLY_INCLUDE_IN(build-flask)
+              </div>
+              ///: END:ONLY_INCLUDE_IN
+            }
+            {
+              ///: BEGIN:ONLY_INCLUDE_IN(build-flask)
+              <div className="home__support">
                 <FlaskHomeFooter />
-                ///: END:ONLY_INCLUDE_IN
-              }
-            </div>
+              </div>
+              ///: END:ONLY_INCLUDE_IN
+            }
           </div>
-
           {this.renderNotifications()}
         </div>
       </div>


### PR DESCRIPTION
## Explanation

The home screen has extra spacing at the bottom, especially noticeable in the popup, which we should remove.  The issue is a `div` that's empty unless it's BETA or FLASK, but has padding.  I thought about using `:empty` but we just shouldn't render empty nodes.

## Screenshots/Screencaps

### Before

<img width="1210" alt="SCR-20230813-srjh" src="https://github.com/MetaMask/metamask-extension/assets/46655/6ffdb0b3-9c28-4025-9446-d534dbade2ba">


### After

<img width="370" alt="SCR-20230813-ssqp" src="https://github.com/MetaMask/metamask-extension/assets/46655/4ea62246-ebfe-402e-8a02-a5b84a3592bf">


## Pre-merge author checklist

- [ ] I've clearly explained:
  - [ ] What problem this PR is solving
  - [ ] How this problem was solved
  - [ ] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
