### PR TITLE
UX: Remove unwanted spacing from last NFT collection

### DIFF
--- a/ui/components/app/nfts-items/index.scss
+++ b/ui/components/app/nfts-items/index.scss
@@ -2,6 +2,10 @@
   &__collection {
     margin-bottom: 24px;
 
+    &:last-child {
+      margin-bottom: 0;
+    }
+
     &-accordion-title {
       cursor: pointer;
     }


### PR DESCRIPTION
## Explanation

The last NFT collection has an extra 24px padding at the bottom which we don't need.  Let's remove it.

## Pre-merge author checklist

- [ ] I've clearly explained:
  - [ ] What problem this PR is solving
  - [ ] How this problem was solved
  - [ ] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
