### PR TITLE
Update ButtonPrimary and ButtonLink optional props

### DIFF
--- a/ui/components/component-library/button-link/README.mdx
+++ b/ui/components/component-library/button-link/README.mdx
@@ -15,10 +15,6 @@ The `ButtonLink` is an extension of `ButtonBase` to support link styles
 
 <ArgsTable of={ButtonLink} />
 
-The `ButtonLink` accepts all [ButtonBase](/docs/components-componentlibrary-buttonbase--default-story#props) component props
-
-<ArgsTable of={ButtonBase} />
-
 ### Size
 
 Use the `size` prop and the `ButtonLinkSize` enum from `./ui/components/component-library` to change the size of `ButtonLink`. Defaults to `ButtonLinkSize.Auto`

--- a/ui/components/component-library/button-link/button-link.tsx
+++ b/ui/components/component-library/button-link/button-link.tsx
@@ -15,9 +15,9 @@ export const ButtonLink: ButtonLinkComponent = React.forwardRef(
     {
       className,
       color,
-      danger,
-      disabled,
-      loading,
+      danger = false,
+      disabled = false,
+      loading = false,
       size = ButtonLinkSize.Auto,
       ...props
     }: ButtonLinkProps<C>,

--- a/ui/components/component-library/button-link/button-link.types.ts
+++ b/ui/components/component-library/button-link/button-link.types.ts
@@ -16,20 +16,20 @@ export interface ButtonLinkStyleUtilityProps
   /**
    * Boolean to change button type to Danger when true
    */
-  danger: boolean;
+  danger?: boolean;
   /**
    * Boolean to disable button
    */
-  disabled: boolean;
+  disabled?: boolean;
   /**
    * Boolean to show loading spinner in button
    */
-  loading: boolean;
+  loading?: boolean;
   /**
    * Possible size values: 'ButtonLinkSize.Auto'(auto), 'ButtonLinkSize.Sm'(32px), 'ButtonLinkSize.Md'(40px), 'ButtonLinkSize.Lg'(48px), 'ButtonLinkSize.Inherit'(inherits parents font-size)
    * Default value is 'ButtonLinkSize.Auto'.
    */
-  size: ButtonLinkSize;
+  size?: ButtonLinkSize;
 }
 
 export type ButtonLinkProps<C extends React.ElementType> =

--- a/ui/components/component-library/button-primary/button-primary.tsx
+++ b/ui/components/component-library/button-primary/button-primary.tsx
@@ -18,8 +18,8 @@ export const ButtonPrimary: ButtonPrimaryComponent = React.forwardRef(
   <C extends React.ElementType = 'button' | 'a'>(
     {
       className,
-      danger,
-      disabled,
+      danger = false,
+      disabled = false,
       size = ButtonPrimarySize.Md,
       ...props
     }: ButtonPrimaryProps<C>,

--- a/ui/components/component-library/button-primary/button-primary.types.ts
+++ b/ui/components/component-library/button-primary/button-primary.types.ts
@@ -13,21 +13,21 @@ export interface ButtonPrimaryStyleUtilityProps
   /**
    * Boolean to change button type to Danger when true
    */
-  danger: boolean;
+  danger?: boolean;
   /**
    * Boolean to disable button
    */
-  disabled: boolean;
+  disabled?: boolean;
   /**
    * Boolean to show loading spinner in button
    */
-  loading: boolean;
+  loading?: boolean;
   /**
    * Possible size values: 'ButtonPrimarySize.Sm'(32px),
    * 'ButtonPrimarySize.Md'(40px), 'ButtonPrimarySize.Lg'(48px)
    * Default value is 'ButtonPrimarySize.Auto'.
    */
-  size: ButtonPrimarySize;
+  size?: ButtonPrimarySize;
 }
 
 export type ButtonPrimaryProps<C extends React.ElementType> =

--- a/ui/components/component-library/button-secondary/button-secondary.tsx
+++ b/ui/components/component-library/button-secondary/button-secondary.tsx
@@ -14,8 +14,8 @@ export const ButtonSecondary: ButtonSecondaryComponent = React.forwardRef(
   <C extends React.ElementType = 'button' | 'a'>(
     {
       className = '',
-      danger,
-      disabled,
+      danger = false,
+      disabled = false,
       size = ButtonSecondarySize.Md,
       ...props
     }: ButtonSecondaryProps<C>,
@@ -28,8 +28,8 @@ export const ButtonSecondary: ButtonSecondaryComponent = React.forwardRef(
         borderColor={buttonColor}
         color={buttonColor}
         className={classnames(className, 'mm-button-secondary', {
-          'mm-button-secondary--type-danger': Boolean(danger),
-          'mm-button-secondary--disabled': Boolean(disabled),
+          'mm-button-secondary--type-danger': danger,
+          'mm-button-secondary--disabled': disabled,
         })}
         size={size}
         ref={ref}


### PR DESCRIPTION
## Explanation
During the typescript migration of `ButtonPrimary` and `ButtonLink` there were some props that were made required when they should be optional. This PR updates those props to optional 

* Fixes #20447 

## Screenshots/Screencaps

### Before

![Screenshot 2023-08-14 at 9 58 38 AM](https://github.com/MetaMask/metamask-extension/assets/8112138/43dc5032-64b7-4341-9a77-74b14b2c16d6)

### After

![Screenshot 2023-08-14 at 9 59 57 AM](https://github.com/MetaMask/metamask-extension/assets/8112138/f1464afa-a770-4217-a34e-13d987a22655)


## Manual Testing Steps
- Pull this branch
- Open `ui/components/component-library/button-primary/button-primary.stories.tsx`
- Use `ButtonPrimary` with some of the props that are now made optional `danger`, `disabled` etc
- See that there is no type error
- Do the same for `ButtonLink` and `ButtonSecondary`

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
