### PR TITLE
Removing Box props description from TS component docs

### DIFF
--- a/ui/components/component-library/avatar-account/README.mdx
+++ b/ui/components/component-library/avatar-account/README.mdx
@@ -13,8 +13,6 @@ The `AvatarAccount` is a type of avatar reserved for representing accounts.
 
 ## Props
 
-The `AvatarAccount` accepts all props below as well as all [Box](/docs/components-componentlibrary-box--docs#props) component props
-
 <ArgsTable of={AvatarAccount} />
 
 ### Size

--- a/ui/components/component-library/avatar-base/README.mdx
+++ b/ui/components/component-library/avatar-base/README.mdx
@@ -14,8 +14,6 @@ The `AvatarBase` is a wrapper component responsible for enforcing dimensions and
 
 ## Props
 
-The `AvatarBase` accepts all props below as well as all [Box](/docs/components-componentlibrary-box--docs#props) component props.
-
 <ArgsTable of={AvatarBase} />
 
 ### Size

--- a/ui/components/component-library/avatar-icon/README.mdx
+++ b/ui/components/component-library/avatar-icon/README.mdx
@@ -13,8 +13,6 @@ The `AvatarIcon` is an avatar component that renders only an icon inside and is 
 
 ## Props
 
-The `AvatarIcon` accepts all props below as well as all [Box](/docs/components-componentlibrary-box--docs#props) component props
-
 <ArgsTable of={AvatarIcon} />
 
 `AvatarIcon` accepts all [AvatarBase](/docs/components-componentlibrary-avatarbase--default-story))

--- a/ui/components/component-library/avatar-network/README.mdx
+++ b/ui/components/component-library/avatar-network/README.mdx
@@ -12,8 +12,6 @@ The `AvatarNetwork` is a component responsible for display of the image of a giv
 
 ## Props
 
-The `AvatarNetwork` accepts all props below as well as all [Box](/docs/components-componentlibrary-box--docs#props) component props
-
 <ArgsTable of={AvatarNetwork} />
 
 ### Size

--- a/ui/components/component-library/avatar-token/README.mdx
+++ b/ui/components/component-library/avatar-token/README.mdx
@@ -12,8 +12,6 @@ The `AvatarToken` is a component responsible for display of the image of a given
 
 ## Props
 
-The `AvatarToken` accepts all props below as well as all [Box](/docs/components-componentlibrary-box--docs#props) component props
-
 <ArgsTable of={AvatarToken} />
 
 ### Size

--- a/ui/components/component-library/badge-wrapper/README.mdx
+++ b/ui/components/component-library/badge-wrapper/README.mdx
@@ -12,8 +12,6 @@ The `BadgeWrapper` positions a badge on top of another component
 
 ## Props
 
-The `BadgeWrapper` accepts all props below as well as all [Box](/docs/components-ui-box--default-story#props) component props.
-
 <ArgsTable of={BadgeWrapper} />
 
 ### Children

--- a/ui/components/component-library/box/box.types.ts
+++ b/ui/components/component-library/box/box.types.ts
@@ -225,187 +225,187 @@ export type PolymorphicComponentPropWithRef<
  */
 export interface StyleUtilityProps {
   /**
-   * The flex direction of the Box component.
+   * The flex direction of the component.
    * Use the FlexDirection enum from '../../../helpers/constants/design-system';
    * Accepts responsive props in the form of an array.
    */
   flexDirection?: FlexDirection | FlexDirectionArray;
   /**
-   * The flex wrap of the Box component.
+   * The flex wrap of the component.
    * Use the FlexWrap enum from '../../../helpers/constants/design-system';
    * Accepts responsive props in the form of an array.
    */
   flexWrap?: FlexWrap | FlexWrapArray;
   /**
-   * The gap between the Box component's children.
+   * The gap between the component's children.
    * Use 1-12 for a gap of 4px-48px.
    * Accepts responsive props in the form of an array.
    */
   gap?: SizeNumber | SizeNumberArray | undefined;
   /**
-   * The margin of the Box component.
+   * The margin of the component.
    * Use 1-12 for 4px-48px or 'auto'.
    * Accepts responsive props in the form of an array.
    */
   margin?: SizeNumberAndAuto | SizeNumberAndAutoArray;
   /**
-   * The margin-top of the Box component.
+   * The margin-top of the component.
    * Use 1-12 for 4px-48px or 'auto'.
    * Accepts responsive props in the form of an array.
    */
   marginTop?: SizeNumberAndAuto | SizeNumberAndAutoArray;
   /**
-   * The margin-bottom of the Box component.
+   * The margin-bottom of the component.
    * Use 1-12 for 4px-48px or 'auto'.
    * Accepts responsive props in the form of an array.
    */
   marginBottom?: SizeNumberAndAuto | SizeNumberAndAutoArray;
   /**
-   * The margin-right of the Box component.
+   * The margin-right of the component.
    * Use 1-12 for 4px-48px or 'auto'.
    * Accepts responsive props in the form of an array.
    */
   marginRight?: SizeNumberAndAuto | SizeNumberAndAutoArray;
   /**
-   * The margin-left of the Box component.
+   * The margin-left of the component.
    * Use 1-12 for 4px-48px or 'auto'.
    * Accepts responsive props in the form of an array.
    */
   marginLeft?: SizeNumberAndAuto | SizeNumberAndAutoArray;
   /**
-   * The margin-inline of the Box component.
+   * The margin-inline of the component.
    * Use 1-12 for 4px-48px or 'auto'.
    * Accepts responsive props in the form of an array.
    */
   marginInline?: SizeNumberAndAuto | SizeNumberAndAutoArray;
   /**
-   * The margin-inline-start of the Box component.
+   * The margin-inline-start of the component.
    * Use 1-12 for 4px-48px or 'auto'.
    * Accepts responsive props in the form of an array.
    */
   marginInlineStart?: SizeNumberAndAuto | SizeNumberAndAutoArray;
   /**
-   * The margin-inline-end of the Box component.
+   * The margin-inline-end of the component.
    * Use 1-12 for 4px-48px or 'auto'.
    * Accepts responsive props in the form of an array.
    */
   marginInlineEnd?: SizeNumberAndAuto | SizeNumberAndAutoArray;
   /**
-   * The padding of the Box component.
+   * The padding of the component.
    * Use 1-12 for 4px-48px.
    * Accepts responsive props in the form of an array.
    */
   padding?: SizeNumber | SizeNumberArray;
   /**
-   * The padding-top of the Box component.
+   * The padding-top of the component.
    * Use 1-12 for 4px-48px.
    * Accepts responsive props in the form of an array.
    */
   paddingTop?: SizeNumber | SizeNumberArray;
   /**
-   * The padding-bottom of the Box component.
+   * The padding-bottom of the component.
    * Use 1-12 for 4px-48px.
    * Accepts responsive props in the form of an array.
    */
   paddingBottom?: SizeNumber | SizeNumberArray;
   /**
-   * The padding-right of the Box component.
+   * The padding-right of the component.
    * Use 1-12 for 4px-48px.
    * Accepts responsive props in the form of an array.
    */
   paddingRight?: SizeNumber | SizeNumberArray;
   /**
-   * The padding-left of the Box component.
+   * The padding-left of the component.
    * Use 1-12 for 4px-48px.
    * Accepts responsive props in the form of an array.
    */
   paddingLeft?: SizeNumber | SizeNumberArray;
   /**
-   * The padding-inline of the Box component.
+   * The padding-inline of the component.
    * Use 1-12 for 4px-48px.
    * Accepts responsive props in the form of an array.
    */
   paddingInline?: SizeNumber | SizeNumberArray;
   /**
-   * The padding-inline-start of the Box component.
+   * The padding-inline-start of the component.
    * Use 1-12 for 4px-48px.
    * Accepts responsive props in the form of an array.
    */
   paddingInlineStart?: SizeNumber | SizeNumberArray;
   /**
-   * The padding-inline-end of the Box component.
+   * The padding-inline-end of the component.
    * Use 1-12 for 4px-48px.
    * Accepts responsive props in the form of an array.
    */
   paddingInlineEnd?: SizeNumber | SizeNumberArray;
   /**
-   * The border-color of the Box component.
+   * The border-color of the component.
    * Use BorderColor enum from '../../../helpers/constants/design-system';
    * Accepts responsive props in the form of an array.
    */
   borderColor?: BorderColor | BorderColorArray;
   /**
-   * The border-width of the Box component.
+   * The border-width of the component.
    * Use 1-12 for 1px-12px.
    * Accepts responsive props in the form of an array.
    */
   borderWidth?: SizeNumber | SizeNumberArray;
   /**
-   * The border-radius of the Box component.
+   * The border-radius of the component.
    * Use BorderRadius enum from '../../../helpers/constants/design-system';
    * Accepts responsive props in the form of an array.
    */
   borderRadius?: BorderRadius | BorderRadiusArray;
   /**
-   * The border-style of the Box component.
+   * The border-style of the component.
    * Use BorderStyle enum from '../../../helpers/constants/design-system';
    * Accepts responsive props in the form of an array.
    */
   borderStyle?: BorderStyle | BorderStyleArray;
   /**
-   * The align-items of the Box component.
+   * The align-items of the component.
    * Use AlignItems enum from '../../../helpers/constants/design-system';
    * Accepts responsive props in the form of an array.
    */
   alignItems?: AlignItems | AlignItemsArray;
   /**
-   * The justify-content of the Box component.
+   * The justify-content of the component.
    * Use JustifyContent enum from '../../../helpers/constants/design-system';
    * Accepts responsive props in the form of an array.
    */
   justifyContent?: JustifyContent | JustifyContentArray;
   /**
-   * The text-align of the Box component.
+   * The text-align of the component.
    * Use TextAlign enum from '../../../helpers/constants/design-system';
    * Accepts responsive props in the form of an array.
    */
   textAlign?: TextAlign | TextAlignArray;
   /**
-   * The display of the Box component.
+   * The display of the component.
    * Use Display enum from '../../../helpers/constants/design-system';
    * Accepts responsive props in the form of an array.
    */
   display?: Display | DisplayArray;
   /**
-   * The width of the Box component.
+   * The width of the component.
    * Use BlockSize enum from '../../../helpers/constants/design-system';
    * Accepts responsive props in the form of an array.
    */
   width?: BlockSize | BlockSizeArray;
   /**
-   * The height of the Box component.
+   * The height of the component.
    * Use BlockSize enum from '../../../helpers/constants/design-system';
    * Accepts responsive props in the form of an array.
    */
   height?: BlockSize | BlockSizeArray;
   /**
-   * The background-color of the Box component.
+   * The background-color of the component.
    * Use BackgroundColor enum from '../../../helpers/constants/design-system';
    * Accepts responsive props in the form of an array.
    */
   backgroundColor?: BackgroundColor | BackgroundColorArray;
   /**
-   * The text-color of the Box component.
+   * The text-color of the component.
    * Use TextColor enum from '../../../helpers/constants/design-system';
    * Accepts responsive props in the form of an array.
    */

--- a/ui/components/component-library/button-base/README.mdx
+++ b/ui/components/component-library/button-base/README.mdx
@@ -13,8 +13,6 @@ The `ButtonBase` is the base component for buttons.
 
 ## Props
 
-The `ButtonBase` accepts all props below as well as all [Box](/docs/components-ui-box--default-story#props) component props
-
 <ArgsTable of={ButtonBase} />
 
 ### Size

--- a/ui/components/component-library/button-icon/README.mdx
+++ b/ui/components/component-library/button-icon/README.mdx
@@ -11,8 +11,6 @@ The `ButtonIcon` is used for icons associated with a user action.
 
 ## Props
 
-The `ButtonIcon` accepts all props below as well as all [Box](/docs/components-componentlibrary-box--docs#props) component props
-
 <ArgsTable of={ButtonIcon} />
 
 ### Icon Name<span style={{ color: 'red' }}>\*</span>

--- a/ui/components/component-library/checkbox/README.mdx
+++ b/ui/components/component-library/checkbox/README.mdx
@@ -12,8 +12,6 @@ Checkbox is a graphical element that allows users to select one or more options 
 
 ## Props
 
-The `Checkbox` accepts all props below as well as all [Box](/docs/components-componentlibrary-box--docs#props) component props
-
 <ArgsTable of={Checkbox} />
 
 ### Label

--- a/ui/components/component-library/header-base/README.mdx
+++ b/ui/components/component-library/header-base/README.mdx
@@ -13,8 +13,6 @@ The `HeaderBase` component is a reusable UI component for displaying a header wi
 
 ## Props
 
-The `HeaderBase` accepts all props below as well as all [Box](/docs/components-ui-box--default-story#props) component props
-
 <ArgsTable of={HeaderBase} />
 
 ### Children

--- a/ui/components/component-library/help-text/README.mdx
+++ b/ui/components/component-library/help-text/README.mdx
@@ -14,8 +14,6 @@ The `HelpText` is used as feedback text under a form field including error, succ
 
 ## Props
 
-The `HelpText` accepts all props below as well as all [Box](/docs/components-ui-box--default-story#props) component props
-
 <ArgsTable of={HelpText} />
 
 `HelpText` accepts all [Text](/docs/components-componentlibrary-text--default-story#props) component props

--- a/ui/components/component-library/icon/README.mdx
+++ b/ui/components/component-library/icon/README.mdx
@@ -12,8 +12,6 @@ The `Icon` component in conjunction with `IconName` can be used for all icons in
 
 ## Props
 
-The `Icon` accepts all props below as well as all [Box](/docs/components-ui-box--default-story#props) component props
-
 <ArgsTable of={Icon} />
 
 ### Name

--- a/ui/components/component-library/input/README.mdx
+++ b/ui/components/component-library/input/README.mdx
@@ -12,8 +12,6 @@ import { Input } from './input';
 
 ## Props
 
-The `Input` accepts all props below as well as all [Box](/docs/components-componentlibrary-box--docs#props) component props
-
 <ArgsTable of={Input} />
 
 ### Type

--- a/ui/components/component-library/label/README.mdx
+++ b/ui/components/component-library/label/README.mdx
@@ -14,8 +14,6 @@ import { Label } from './label';
 
 ## Props
 
-The `Label` accepts all props below as well as all [Box](/docs/components-ui-box--default-story#props) component props
-
 <ArgsTable of={Label} />
 
 `Label` accepts all [Text](/docs/components-componentlibrary-text--default-story#props) component props

--- a/ui/components/component-library/modal-content/README.mdx
+++ b/ui/components/component-library/modal-content/README.mdx
@@ -12,8 +12,6 @@ import { ModalContent } from './modal-content';
 
 ## Props
 
-The `ModalContent` accepts all props below as well as all [Box](/docs/components-ui-box--default-story#props) component props
-
 <ArgsTable of={ModalContent} />
 
 ### Children

--- a/ui/components/component-library/modal-overlay/README.mdx
+++ b/ui/components/component-library/modal-overlay/README.mdx
@@ -12,8 +12,6 @@ import { ModalOverlay } from './modal-overlay';
 
 ## Props
 
-The `ModalOverlay` accepts all props below as well as all [Box](/docs/components-componentlibrary-box--docs#props) component props
-
 <ArgsTable of={ModalOverlay} />
 
 ### On Click

--- a/ui/components/component-library/modal/README.mdx
+++ b/ui/components/component-library/modal/README.mdx
@@ -12,8 +12,6 @@ The `Modal` focuses the user's attention exclusively on information via a window
 
 ## Props
 
-The `Modal` accepts all props below as well as all [Box](/docs/components-ui-box--default-story#props) component props
-
 <ArgsTable of={Modal} />
 
 ### Usage

--- a/ui/components/component-library/tag/README.mdx
+++ b/ui/components/component-library/tag/README.mdx
@@ -12,8 +12,6 @@ The `Tag` is a component used to display text within a container.
 
 ## Props
 
-The `Tag` accepts all props below as well as all [Box](/docs/components-ui-box--default-story#props) component props.
-
 <ArgsTable of={Tag} />
 
 ### Label

--- a/ui/components/component-library/text/README.mdx
+++ b/ui/components/component-library/text/README.mdx
@@ -14,8 +14,6 @@ Good typography improves readability, legibility and hierarchy of information.
 
 ## Props
 
-The `Text` accepts all props below as well as all [Box](/docs/components-componentlibrary-box--docs#props) component props
-
 <ArgsTable of={Text} />
 
 ### Variant


### PR DESCRIPTION
## Explanation

Currently, we include a line in our documentation above the prop table to explain that all of our components accept `Box` component props. Now that all props including the style utility props like `margin` and `padding` show up in the props table this line is kind of redundant. This PR removes the line describing that the component accepts all `Box` props from all TS component documentation and updates the `StyleUtilityProps` descriptions, removing `Box` so they are generic and can be applied to all components.

* Fixes #20004 

## Screenshots/Screencaps

### Before

Here you can see that the `Box` style utility props are already in the prop table so there is no value in repeating this. 


https://github.com/MetaMask/metamask-extension/assets/8112138/530e905e-e7dd-4013-bc17-342b9c171665



### After

After showing the removal of the `Box` props sentence and the update to make the style utility prop descriptions more generic so it can be applied to all components


https://github.com/MetaMask/metamask-extension/assets/8112138/0f803b0b-a201-4853-8eb9-8c4ceb180b03



## Manual Testing Steps

- Go to the storybook build on this PR 
- Find the second set of alphabetical ordering this is how storybook orders TS components for some reason.
- Check that the `Box` prop sentence has been removed on all TS component docs 

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
