### PR TITLE
Add additional validation for persisted state metadata

### DIFF
--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -13,6 +13,7 @@ import debounce from 'debounce-stream';
 import log from 'loglevel';
 import browser from 'webextension-polyfill';
 import { storeAsStream } from '@metamask/obs-store';
+import { isObject } from '@metamask/utils';
 ///: BEGIN:ONLY_INCLUDE_IN(snaps)
 import { ApprovalType } from '@metamask/controller-utils';
 ///: END:ONLY_INCLUDE_IN
@@ -411,6 +412,19 @@ export async function loadStateFromPersistence() {
   versionedData = await migrator.migrateData(versionedData);
   if (!versionedData) {
     throw new Error('MetaMask - migrator returned undefined');
+  } else if (!isObject(versionedData.meta)) {
+    throw new Error(
+      `MetaMask - migrator metadata has invalid type '${typeof versionedData.meta}'`,
+    );
+  } else if (typeof versionedData.meta.version !== 'number') {
+    throw new Error(
+      `MetaMask - migrator metadata version has invalid type '${typeof versionedData
+        .meta.version}'`,
+    );
+  } else if (!isObject(versionedData.data)) {
+    throw new Error(
+      `MetaMask - migrator data has invalid type '${typeof versionedData.data}'`,
+    );
   }
   // this initializes the meta/version data as a class variable to be used for future writes
   localStore.setMetadata(versionedData.meta);


### PR DESCRIPTION
## Explanation

Additional validation has been added for persisted state metadata. Beforehand we just checked that the state itself wasn't falsy. Now we ensure that the metadata is an object with a valid version as well.

Relates to #20449

## Manual Testing Steps

1. checkout this branch
2. add 'chrome' to the `scuttleGlobalThisExceptions` array in `development/build/index,js`
3. `yarn dist`, install and onboard. be sure to opt in to metametrics while onboarding
4. Run `chrome.storage.local.get(({ data, meta }) => chrome.storage.local.set({ data: { ...data }, meta: false }, () => { window.location.reload() }))` in the background dev console. 
5. You will see a network request to sentry with the following in the payload: `MetaMask - migrator metadata has invalid type 'boolean'`

Similar steps should be able to be taken, with modifications to step 4 can be taken to test the other two error cases.

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added
  - I wasn't sure how to test this. Unit tests didn't seem feasible without a great deal of refactoring.

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
