### PR TITLE
Rename BackupController to Backup

### DIFF
--- a/app/scripts/lib/backup.js
+++ b/app/scripts/lib/backup.js
@@ -1,6 +1,6 @@
 import { prependZero } from '../../../shared/modules/string-utils';
 
-export default class BackupController {
+export default class Backup {
   constructor(opts = {}) {
     const {
       preferencesController,

--- a/app/scripts/lib/backup.test.js
+++ b/app/scripts/lib/backup.test.js
@@ -1,6 +1,6 @@
 import { strict as assert } from 'assert';
 import sinon from 'sinon';
-import BackupController from './backup';
+import Backup from './backup';
 
 function getMockPreferencesController() {
   const mcState = {
@@ -151,9 +151,9 @@ const jsonData = JSON.stringify({
   },
 });
 
-describe('BackupController', function () {
-  const getBackupController = () => {
-    return new BackupController({
+describe('Backup', function () {
+  const getBackup = () => {
+    return new Backup({
       preferencesController: getMockPreferencesController(),
       addressBookController: getMockAddressBookController(),
       networkController: getMockNetworkController(),
@@ -163,85 +163,81 @@ describe('BackupController', function () {
 
   describe('constructor', function () {
     it('should setup correctly', async function () {
-      const backupController = getBackupController();
-      const selectedAddress =
-        backupController.preferencesController.getSelectedAddress();
+      const backup = getBackup();
+      const selectedAddress = backup.preferencesController.getSelectedAddress();
       assert.equal(selectedAddress, '0x01');
     });
 
     it('should restore backup', async function () {
-      const backupController = getBackupController();
-      await backupController.restoreUserData(jsonData);
+      const backup = getBackup();
+      await backup.restoreUserData(jsonData);
       // check networks backup
       assert.equal(
-        backupController.networkController.state.networkConfigurations[
+        backup.networkController.state.networkConfigurations[
           'network-configuration-id-1'
         ].chainId,
         '0x539',
       );
       assert.equal(
-        backupController.networkController.state.networkConfigurations[
+        backup.networkController.state.networkConfigurations[
           'network-configuration-id-2'
         ].chainId,
         '0x38',
       );
       assert.equal(
-        backupController.networkController.state.networkConfigurations[
+        backup.networkController.state.networkConfigurations[
           'network-configuration-id-3'
         ].chainId,
         '0x61',
       );
       assert.equal(
-        backupController.networkController.state.networkConfigurations[
+        backup.networkController.state.networkConfigurations[
           'network-configuration-id-4'
         ].chainId,
         '0x89',
       );
       // make sure identities are not lost after restore
       assert.equal(
-        backupController.preferencesController.store.identities[
+        backup.preferencesController.store.identities[
           '0x295e26495CEF6F69dFA69911d9D8e4F3bBadB89B'
         ].lastSelected,
         1655380342907,
       );
       assert.equal(
-        backupController.preferencesController.store.identities[
+        backup.preferencesController.store.identities[
           '0x295e26495CEF6F69dFA69911d9D8e4F3bBadB89B'
         ].name,
         'Account 3',
       );
       assert.equal(
-        backupController.preferencesController.store.lostIdentities[
+        backup.preferencesController.store.lostIdentities[
           '0xfd59bbe569376e3d3e4430297c3c69ea93f77435'
         ].lastSelected,
         1655379648197,
       );
       assert.equal(
-        backupController.preferencesController.store.lostIdentities[
+        backup.preferencesController.store.lostIdentities[
           '0xfd59bbe569376e3d3e4430297c3c69ea93f77435'
         ].name,
         'Ledger 1',
       );
       // make sure selected address is not lost after restore
-      assert.equal(
-        backupController.preferencesController.store.selectedAddress,
-        '0x01',
-      );
+      assert.equal(backup.preferencesController.store.selectedAddress, '0x01');
       // check address book backup
       assert.equal(
-        backupController.addressBookController.store.addressBook['0x61'][
+        backup.addressBookController.store.addressBook['0x61'][
           '0x42EB768f2244C8811C63729A21A3569731535f06'
         ].chainId,
         '0x61',
       );
       assert.equal(
-        backupController.addressBookController.store.addressBook['0x61'][
+        backup.addressBookController.store.addressBook['0x61'][
           '0x42EB768f2244C8811C63729A21A3569731535f06'
         ].address,
         '0x42EB768f2244C8811C63729A21A3569731535f06',
       );
       assert.equal(
-        backupController.addressBookController.store.addressBook['0x61'][
+        backup.addressBookController.store.addressBook['0x61'][
           '0x42EB768f2244C8811C63729A21A3569731535f06'
         ].isEns,
         false,

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -184,7 +184,7 @@ import AppStateController from './controllers/app-state';
 import CachedBalancesController from './controllers/cached-balances';
 import AlertController from './controllers/alert';
 import OnboardingController from './controllers/onboarding';
-import BackupController from './controllers/backup';
+import Backup from './lib/backup';
 import IncomingTransactionsController from './controllers/incoming-transactions';
 import DecryptMessageController from './controllers/decrypt-message';
 import TransactionController from './controllers/transactions';
@@ -1148,7 +1148,7 @@ export default class MetamaskController extends EventEmitter {
     });
     ///: END:ONLY_INCLUDE_IN
 
-    this.backupController = new BackupController({
+    this.backup = new Backup({
       preferencesController: this.preferencesController,
       addressBookController: this.addressBookController,
       networkController: this.networkController,
@@ -1643,7 +1643,6 @@ export default class MetamaskController extends EventEmitter {
       PermissionController: this.permissionController,
       PermissionLogController: this.permissionLogController.store,
       SubjectMetadataController: this.subjectMetadataController,
-      BackupController: this.backupController,
       AnnouncementController: this.announcementController,
       GasFeeController: this.gasFeeController,
       TokenListController: this.tokenListController,
@@ -1690,7 +1689,6 @@ export default class MetamaskController extends EventEmitter {
         PermissionController: this.permissionController,
         PermissionLogController: this.permissionLogController.store,
         SubjectMetadataController: this.subjectMetadataController,
-        BackupController: this.backupController,
         AnnouncementController: this.announcementController,
         GasFeeController: this.gasFeeController,
         TokenListController: this.tokenListController,
@@ -2202,7 +2200,7 @@ export default class MetamaskController extends EventEmitter {
       smartTransactionsController,
       txController,
       assetsContractController,
-      backupController,
+      backup,
       approvalController,
     } = this;
 
@@ -2748,9 +2746,9 @@ export default class MetamaskController extends EventEmitter {
       removePollingTokenFromAppState:
         appStateController.removePollingToken.bind(appStateController),
 
-      // BackupController
-      backupUserData: backupController.backupUserData.bind(backupController),
-      restoreUserData: backupController.restoreUserData.bind(backupController),
+      // Backup
+      backupUserData: backup.backupUserData.bind(backup),
+      restoreUserData: backup.restoreUserData.bind(backup),
 
       // DetectTokenController
       detectNewTokens: detectTokensController.detectNewTokens.bind(


### PR DESCRIPTION
## Explanation

The backup module has been renamed so that it isn't confused with a controller. The "backup controller" has never managed any state or extended the controller base class. It is a module for backing up data, but it's not a controller.

The backup controller's current inclusion in the `store` and `memstore` `ComposableObservableStore`s was getting in the way of some other enhancements to that class (which will come in a later PR).

## Manual Testing Steps

This is a refactor, so it should have no functional changes to test.  The backup functionality affected by this rename can be tested using these steps:
* Navigate to the "Advanced" settings page
* Click "Backup" and save it as a file
* Click "Restore" and choose the backup that you just saved
* Ensure that the wallet behaves as expected and that there are no console errors related to this operation (in either the background console or UI console).

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
