### PR TITLE
Initialize composable observable store after update

### DIFF
--- a/app/scripts/lib/ComposableObservableStore.js
+++ b/app/scripts/lib/ComposableObservableStore.js
@@ -74,7 +74,7 @@ export default class ComposableObservableStore extends ObservableStore {
         );
       }
 
-      initialState[key] = store.state || store.getState?.();
+      initialState[key] = store.state ?? store.getState?.();
     }
     this.updateState(initialState);
   }

--- a/app/scripts/lib/ComposableObservableStore.js
+++ b/app/scripts/lib/ComposableObservableStore.js
@@ -51,6 +51,7 @@ export default class ComposableObservableStore extends ObservableStore {
   updateStructure(config) {
     this.config = config;
     this.removeAllListeners();
+    const initialState = {};
     for (const key of Object.keys(config)) {
       if (!config[key]) {
         throw new Error(`Undefined '${key}'`);
@@ -72,7 +73,10 @@ export default class ComposableObservableStore extends ObservableStore {
           },
         );
       }
+
+      initialState[key] = store.state || store.getState?.();
     }
+    this.updateState(initialState);
   }
 
   /**

--- a/app/scripts/lib/ComposableObservableStore.test.js
+++ b/app/scripts/lib/ComposableObservableStore.test.js
@@ -120,6 +120,31 @@ describe('ComposableObservableStore', () => {
     });
   });
 
+  it('should initialize state with all three types of stores', () => {
+    const controllerMessenger = new ControllerMessenger();
+    const exampleStore = new ObservableStore();
+    const exampleController = new ExampleController({
+      messenger: controllerMessenger,
+    });
+    const oldExampleController = new OldExampleController();
+    exampleStore.putState('state');
+    exampleController.updateBar('state');
+    oldExampleController.updateBaz('state');
+    const store = new ComposableObservableStore({ controllerMessenger });
+
+    store.updateStructure({
+      Example: exampleController,
+      OldExample: oldExampleController,
+      Store: exampleStore,
+    });
+
+    expect(store.getState()).toStrictEqual({
+      Example: { bar: 'state' },
+      OldExample: { baz: 'state' },
+      Store: 'state',
+    });
+  });
+
   it('should return flattened state', () => {
     const controllerMessenger = new ControllerMessenger();
     const fooStore = new ObservableStore({ foo: 'foo' });

--- a/app/scripts/lib/ComposableObservableStore.test.js
+++ b/app/scripts/lib/ComposableObservableStore.test.js
@@ -145,6 +145,21 @@ describe('ComposableObservableStore', () => {
     });
   });
 
+  it('should initialize falsy state', () => {
+    const controllerMessenger = new ControllerMessenger();
+    const exampleStore = new ObservableStore();
+    exampleStore.putState(false);
+    const store = new ComposableObservableStore({ controllerMessenger });
+
+    store.updateStructure({
+      Example: exampleStore,
+    });
+
+    expect(store.getState()).toStrictEqual({
+      Example: false,
+    });
+  });
+
   it('should return flattened state', () => {
     const controllerMessenger = new ControllerMessenger();
     const fooStore = new ObservableStore({ foo: 'foo' });

--- a/test/e2e/tests/state-snapshots/errors-after-init-opt-in-background-state.json
+++ b/test/e2e/tests/state-snapshots/errors-after-init-opt-in-background-state.json
@@ -1,5 +1,18 @@
 {
   "AccountTracker": { "accounts": "object" },
+  "AddressBookController": "object",
+  "AlertController": {
+    "alertEnabledness": { "unconnectedAccount": true, "web3ShimUsage": true },
+    "unconnectedAccountAlertShownOrigins": "object",
+    "web3ShimUsageOrigins": "object"
+  },
+  "AnnouncementController": "object",
+  "AppMetadataController": {
+    "currentAppVersion": "10.34.4",
+    "previousAppVersion": "",
+    "previousMigrationVersion": 0,
+    "currentMigrationVersion": 94
+  },
   "AppStateController": {
     "connectedStatusPopoverHasBeenShown": true,
     "defaultHomeActiveTabName": null,
@@ -42,6 +55,22 @@
     "unapprovedEncryptionPublicKeyMsgCount": 0
   },
   "EnsController": "object",
+  "GasFeeController": "object",
+  "IncomingTransactionsController": {
+    "incomingTransactions": "object",
+    "incomingTxLastFetchedBlockByChainId": {
+      "0x1": null,
+      "0xe708": null,
+      "0x5": null,
+      "0xaa36a7": null,
+      "0xe704": null
+    }
+  },
+  "KeyringController": {
+    "isUnlocked": false,
+    "keyringTypes": "object",
+    "keyrings": "object"
+  },
   "MetaMetricsController": {
     "participateInMetaMetrics": true,
     "metaMetricsId": "fake-metrics-id",
@@ -66,6 +95,50 @@
     "networksMetadata": "object",
     "networkConfigurations": "object"
   },
+  "NftController": "object",
+  "OnboardingController": {
+    "seedPhraseBackedUp": true,
+    "firstTimeFlowType": "import",
+    "completedOnboarding": true,
+    "onboardingTabs": "object"
+  },
+  "PermissionController": "object",
+  "PermissionLogController": "object",
+  "PreferencesController": {
+    "useBlockie": false,
+    "useNonceField": false,
+    "usePhishDetect": true,
+    "dismissSeedBackUpReminder": "boolean",
+    "disabledRpcMethodPreferences": "object",
+    "useMultiAccountBalanceChecker": "boolean",
+    "useTokenDetection": "boolean",
+    "useNftDetection": "boolean",
+    "use4ByteResolution": "boolean",
+    "useCurrencyRateCheck": "boolean",
+    "openSeaEnabled": "boolean",
+    "advancedGasFee": "object",
+    "featureFlags": { "showIncomingTransactions": true },
+    "knownMethodData": "object",
+    "currentLocale": "en",
+    "identities": "object",
+    "lostIdentities": "object",
+    "forgottenPassword": false,
+    "preferences": {
+      "hideZeroBalanceTokens": false,
+      "showFiatInTestnets": false,
+      "showTestNetworks": false,
+      "useNativeCurrencyAsPrimaryCurrency": true
+    },
+    "ipfsGateway": "dweb.link",
+    "useAddressBarEnsResolution": "boolean",
+    "infuraBlocked": "boolean",
+    "ledgerTransportType": "string",
+    "snapRegistryList": "object",
+    "transactionSecurityCheckEnabled": "boolean",
+    "theme": "string",
+    "isLineaMainnetReleased": "boolean",
+    "selectedAddress": "string"
+  },
   "SignatureController": {
     "unapprovedMsgs": "object",
     "unapprovedPersonalMsgs": "object",
@@ -74,7 +147,10 @@
     "unapprovedPersonalMsgCount": 0,
     "unapprovedTypedMessagesCount": 0
   },
+  "SmartTransactionsController": "object",
+  "SubjectMetadataController": "object",
   "SwapsController": "object",
+  "TokenListController": "object",
   "TokenRatesController": "object",
   "TokensController": "object",
   "TxController": "object"

--- a/test/e2e/tests/state-snapshots/errors-after-init-opt-in-background-state.json
+++ b/test/e2e/tests/state-snapshots/errors-after-init-opt-in-background-state.json
@@ -37,6 +37,7 @@
   },
   "ApprovalController": "object",
   "CachedBalancesController": "object",
+  "CronjobController": "object",
   "CurrencyController": {
     "conversionDate": "number",
     "conversionRate": 1700,
@@ -96,6 +97,7 @@
     "networkConfigurations": "object"
   },
   "NftController": "object",
+  "NotificationController": "object",
   "OnboardingController": {
     "seedPhraseBackedUp": true,
     "firstTimeFlowType": "import",
@@ -148,6 +150,8 @@
     "unapprovedTypedMessagesCount": 0
   },
   "SmartTransactionsController": "object",
+  "SnapController": "object",
+  "SnapsRegistry": "object",
   "SubjectMetadataController": "object",
   "SwapsController": "object",
   "TokenListController": "object",


### PR DESCRIPTION
## Explanation

The composable observable store now updates state immediately when the structure is updated. Previously each store would only be updated after the first state change. This ensures that the composable observable store state is always complete.

## Manual Testing Steps

This PR should ensure that the background state and the UI state contains an entry for every single controller immediately upon construction, without needing to wait for each controller to update. This is most obvious by looking at the background state snapshot captured by the `errors.spec.js` test suite. You can manually test this by looking at the background state in the background console shortly after the extension starts (e.g. using breakpoints or one of the state hooks).

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
