### PR TITLE
Fix infinite rerender on network change while active signature request

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -1490,6 +1490,7 @@ export default class MetamaskController extends EventEmitter {
         this.encryptionPublicKeyController.clearUnapproved();
         this.decryptMessageController.clearUnapproved();
         this.signatureController.clearUnapproved();
+        this.approvalController.clear();
       },
     );
 


### PR DESCRIPTION
## Explanation

<!--
Thanks for the pull request. Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues, Slack conversations, Zendesk issues, user stories, etc. reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

Please see [the bug and reproducible case here.](https://github.com/MetaMask/metamask-extension/issues/20124)

When user changes the network, [we clear controller states](https://github.com/MetaMask/metamask-extension/blob/42d05ef9cd1e971027563244dc3b148e5785b2e3/app/scripts/metamask-controller.js#L1492) (Txs, encrypt/decrypt requests also signatures) but not ApprovalController state and controllers are not clearing approval requests too.
Then the confirmation page gets new properties & rerender because thinks no more signature request but [there is still an approval request](https://github.com/MetaMask/metamask-extension/blob/42d05ef9cd1e971027563244dc3b148e5785b2e3/ui/selectors/approvals.ts#L37). And tries to rerender infinitely.

To fix this we should also clear `ApprovalController` state. 

## Manual Testing Steps

1. Open MM full screen on the side
2. On another browser tab, go to the [test-dapp](https://metamask.github.io/test-dapp/)
3. Try any signature but don't approve
4. Go back to fullscreen MM and change network
5. Active signature notification should close itself without user action


## Pre-merge author checklist

- [X] I've clearly explained:
  - [X] What problem this PR is solving
  - [X] How this problem was solved
  - [X] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
