### PR TITLE
Security Alert Blockaid: fix propType and add instance to ConfirmApprove page

### DIFF
--- a/ui/components/app/security-provider-banner-alert/security-provider-banner-alert.js
+++ b/ui/components/app/security-provider-banner-alert/security-provider-banner-alert.js
@@ -83,7 +83,7 @@ SecurityProviderBannerAlert.propTypes = {
     .isRequired,
 
   /** Severity level */
-  severity: PropTypes.oneOfType([Severity.Danger, Severity.Warning]).isRequired,
+  severity: PropTypes.oneOf([Severity.Danger, Severity.Warning]).isRequired,
 
   /** Title to be passed as <BannerAlert> param */
   title: PropTypes.string.isRequired,
@@ -96,7 +96,7 @@ SecurityProviderBannerAlert.propTypes = {
   details: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
 
   /** Name of the security provider */
-  provider: PropTypes.oneOfType(Object.values(SecurityProvider)),
+  provider: PropTypes.oneOf(Object.values(SecurityProvider)),
 };
 
 export default SecurityProviderBannerAlert;

--- a/ui/pages/confirm-approve/confirm-approve-content/confirm-approve-content.component.js
+++ b/ui/pages/confirm-approve/confirm-approve-content/confirm-approve-content.component.js
@@ -22,6 +22,9 @@ import {
 } from '../../../helpers/constants/design-system';
 import { ConfirmPageContainerWarning } from '../../../components/app/confirm-page-container/confirm-page-container-content';
 import LedgerInstructionField from '../../../components/app/ledger-instruction-field';
+///: BEGIN:ONLY_INCLUDE_IN(blockaid)
+import BlockaidBannerAlert from '../../../components/app/security-provider-banner-alert/blockaid-banner-alert/blockaid-banner-alert';
+///: END:ONLY_INCLUDE_IN
 import { isSuspiciousResponse } from '../../../../shared/modules/security-provider.utils';
 
 import { TokenStandard } from '../../../../shared/constants/transaction';
@@ -551,6 +554,13 @@ export default class ConfirmApproveContent extends Component {
           'confirm-approve-content--full': showFullTxDetails,
         })}
       >
+        {
+          ///: BEGIN:ONLY_INCLUDE_IN(blockaid)
+          <BlockaidBannerAlert
+            securityAlertResponse={txData?.securityAlertResponse}
+          />
+          ///: END:ONLY_INCLUDE_IN
+        }
         {isSuspiciousResponse(txData?.securityProviderResponse) && (
           <SecurityProviderBannerMessage
             securityProviderResponse={txData.securityProviderResponse}

--- a/ui/pages/confirm-approve/confirm-approve-content/confirm-approve-content.component.test.js
+++ b/ui/pages/confirm-approve/confirm-approve-content/confirm-approve-content.component.test.js
@@ -3,6 +3,7 @@ import configureMockStore from 'redux-mock-store';
 import { fireEvent } from '@testing-library/react';
 import { renderWithProvider } from '../../../../test/jest/rendering';
 import { TokenStandard } from '../../../../shared/constants/transaction';
+import { BlockaidResultType } from '../../../../shared/constants/security-provider';
 import ConfirmApproveContent from '.';
 
 const renderComponent = (props) => {
@@ -342,5 +343,22 @@ describe('ConfirmApproveContent Component', () => {
     });
 
     expect(getByText(securityProviderResponse.reason)).toBeInTheDocument();
+  });
+
+  it('should render security alert if provided', () => {
+    const mockSecurityAlertResponse = {
+      result_type: BlockaidResultType.Malicious,
+      reason: 'blur_farming',
+    };
+
+    const { getByText } = renderComponent({
+      ...props,
+      txData: {
+        ...props.txData,
+        securityAlertResponse: mockSecurityAlertResponse,
+      },
+    });
+
+    expect(getByText('This is a deceptive request')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Explanation

Fixes https://github.com/MetaMask/MetaMask-planning/issues/1188 by supporting BlockaidBannerAlert in ConfirmApprove page

also, fixes propTypes to fix the following errors shown
<img width="420" alt="Screenshot 2023-08-17 at 1 48 35 AM" src="https://github.com/MetaMask/metamask-extension/assets/20778143/20dfeddd-bdd8-4f6b-9d5f-be4fb24c49ee">


## Screenshots/Screencaps

<!-- If you're making a change to the UI, make sure to capture a screenshot or a short video showing off your work! -->

### Before

<!-- How did the UI you changed look before your changes? Drag your file(s) below this line: -->

### After

<!-- How does it look now? Drag your file(s) below this line: -->

## Manual Testing Steps

<!--
How should reviewers and QA manually test your changes? For instance:

- Go to this screen
- Do this
- Then do this
-->

## Pre-merge author checklist

- [ ] I've clearly explained:
  - [ ] What problem this PR is solving
  - [ ] How this problem was solved
  - [ ] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
