### PR TITLE
Remove invalid `tokensChainsCache` state

### DIFF
--- a/app/scripts/migrations/077.js
+++ b/app/scripts/migrations/077.js
@@ -1,4 +1,6 @@
 import { cloneDeep } from 'lodash';
+import log from 'loglevel';
+import { hasProperty, isObject } from '@metamask/utils';
 import transformState077For082 from './077-supplements/077-supplement-for-082';
 import transformState077For084 from './077-supplements/077-supplement-for-084';
 import transformState077For086 from './077-supplements/077-supplement-for-086';
@@ -29,8 +31,23 @@ export default {
 };
 
 function transformState(state) {
-  const TokenListController = state?.TokenListController || {};
-
+  if (!hasProperty(state, 'TokenListController')) {
+    log.warn('Skipping migration, TokenListController state is missing');
+    return state;
+  } else if (!isObject(state.TokenListController)) {
+    global.sentry?.captureException?.(
+      new Error(
+        `typeof state.TokenListController is ${typeof state.TokenListController}`,
+      ),
+    );
+    return state;
+  } else if (!hasProperty(state.TokenListController, 'tokensChainsCache')) {
+    log.warn(
+      'Skipping migration, TokenListController.tokensChainsCache state is missing',
+    );
+    return state;
+  }
+  const { TokenListController } = state;
   const { tokensChainsCache } = TokenListController;
 
   let dataCache;

--- a/app/scripts/migrations/092.1.test.ts
+++ b/app/scripts/migrations/092.1.test.ts
@@ -1,0 +1,139 @@
+import { cloneDeep } from 'lodash';
+import { migrate, version } from './092.1';
+
+const PREVIOUS_VERSION = 92;
+
+const sentryCaptureExceptionMock = jest.fn();
+
+global.sentry = {
+  startSession: jest.fn(),
+  endSession: jest.fn(),
+  toggleSession: jest.fn(),
+  captureException: sentryCaptureExceptionMock,
+};
+
+describe('migration #92.1', () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('should update the version metadata', async () => {
+    const oldStorage = {
+      meta: {
+        version: PREVIOUS_VERSION,
+      },
+      data: {},
+    };
+
+    const newStorage = await migrate(oldStorage);
+    expect(newStorage.meta).toStrictEqual({
+      version,
+    });
+  });
+
+  it('should return state unaltered if there is no TokenListController state', async () => {
+    const oldData = {
+      other: 'data',
+    };
+    const oldStorage = {
+      meta: {
+        version: PREVIOUS_VERSION,
+      },
+      data: oldData,
+    };
+
+    const newStorage = await migrate(cloneDeep(oldStorage));
+    expect(newStorage.data).toStrictEqual(oldData);
+  });
+
+  it('captures an exception if the TokenListController state is invalid', async () => {
+    const oldStorage = {
+      meta: {
+        version: PREVIOUS_VERSION,
+      },
+      data: { TokenListController: 'this is not valid' },
+    };
+
+    await migrate(oldStorage);
+
+    expect(sentryCaptureExceptionMock).toHaveBeenCalledTimes(1);
+    expect(sentryCaptureExceptionMock).toHaveBeenCalledWith(
+      new Error(`typeof state.TokenListController is string`),
+    );
+  });
+
+  it('should return state unaltered if there is no TokenListController tokensChainsCache state', async () => {
+    const oldData = {
+      other: 'data',
+      TokenListController: {
+        tokenList: {},
+      },
+    };
+    const oldStorage = {
+      meta: {
+        version: PREVIOUS_VERSION,
+      },
+      data: oldData,
+    };
+
+    const newStorage = await migrate(cloneDeep(oldStorage));
+    expect(newStorage.data).toStrictEqual(oldData);
+  });
+
+  it('should return state unaltered if the tokensChainsCache state is an unexpected type', async () => {
+    const oldData = {
+      other: 'data',
+      TokenListController: {
+        tokensChainsCache: 'unexpected string',
+      },
+    };
+    const oldStorage = {
+      meta: {
+        version: PREVIOUS_VERSION,
+      },
+      data: oldData,
+    };
+
+    const newStorage = await migrate(cloneDeep(oldStorage));
+    expect(newStorage.data).toStrictEqual(oldData);
+  });
+
+  it('should return state unaltered if the tokensChainsCache state is valid', async () => {
+    const oldData = {
+      other: 'data',
+      TokenListController: {
+        tokensChainsCache: {},
+      },
+    };
+    const oldStorage = {
+      meta: {
+        version: PREVIOUS_VERSION,
+      },
+      data: oldData,
+    };
+
+    const newStorage = await migrate(cloneDeep(oldStorage));
+    expect(newStorage.data).toStrictEqual(oldData);
+  });
+
+  it('should remove undefined tokensChainsCache state', async () => {
+    const oldData = {
+      other: 'data',
+      TokenListController: {
+        tokensChainsCache: undefined,
+      },
+    };
+    const oldStorage = {
+      meta: {
+        version: PREVIOUS_VERSION,
+      },
+      data: oldData,
+    };
+
+    const newStorage = await migrate(cloneDeep(oldStorage));
+    expect(newStorage.data).toStrictEqual({
+      other: 'data',
+      TokenListController: {},
+    });
+  });
+});

--- a/app/scripts/migrations/092.1.ts
+++ b/app/scripts/migrations/092.1.ts
@@ -1,0 +1,53 @@
+import { cloneDeep } from 'lodash';
+import { hasProperty, isObject } from '@metamask/utils';
+import log from 'loglevel';
+
+export const version = 92.1;
+
+/**
+ * Check whether the `TokenListController.tokensChainsCache` state is
+ * `undefined`, and delete it if so.
+ *
+ * This property was accidentally set to `undefined` by an earlier revision of
+ * migration #77 in some cases.
+ *
+ * @param originalVersionedData - Versioned MetaMask extension state, exactly what we persist to dist.
+ * @param originalVersionedData.meta - State metadata.
+ * @param originalVersionedData.meta.version - The current state version.
+ * @param originalVersionedData.data - The persisted MetaMask state, keyed by controller.
+ * @returns Updated versioned MetaMask extension state.
+ */
+export async function migrate(originalVersionedData: {
+  meta: { version: number };
+  data: Record<string, unknown>;
+}) {
+  const versionedData = cloneDeep(originalVersionedData);
+  versionedData.meta.version = version;
+  versionedData.data = transformState(versionedData.data);
+  return versionedData;
+}
+
+function transformState(state: Record<string, unknown>) {
+  if (!hasProperty(state, 'TokenListController')) {
+    log.warn('Skipping migration, TokenListController state is missing');
+    return state;
+  } else if (!isObject(state.TokenListController)) {
+    global.sentry?.captureException?.(
+      new Error(
+        `typeof state.TokenListController is ${typeof state.TokenListController}`,
+      ),
+    );
+    return state;
+  } else if (!hasProperty(state.TokenListController, 'tokensChainsCache')) {
+    log.warn(
+      'Skipping migration, TokenListController.tokensChainsCache state is missing',
+    );
+    return state;
+  }
+
+  if (state.TokenListController.tokensChainsCache === undefined) {
+    delete state.TokenListController.tokensChainsCache;
+  }
+
+  return state;
+}

--- a/app/scripts/migrations/093.test.ts
+++ b/app/scripts/migrations/093.test.ts
@@ -1,7 +1,7 @@
 import { InfuraNetworkType, NetworkType } from '@metamask/controller-utils';
 import { migrate, version } from './093';
 
-const PREVIOUS_VERSION = version - 1;
+const PREVIOUS_VERSION = 92.1;
 
 const sentryCaptureExceptionMock = jest.fn();
 

--- a/app/scripts/migrations/index.js
+++ b/app/scripts/migrations/index.js
@@ -96,6 +96,7 @@ import * as m089 from './089';
 import * as m090 from './090';
 import * as m091 from './091';
 import * as m092 from './092';
+import * as m092point1 from './092.1';
 import * as m093 from './093';
 import * as m094 from './094';
 
@@ -191,6 +192,7 @@ const migrations = [
   m090,
   m091,
   m092,
+  m092point1,
   m093,
   m094,
 ];

--- a/test/e2e/tests/errors.spec.js
+++ b/test/e2e/tests/errors.spec.js
@@ -20,7 +20,6 @@ const removedBackgroundFields = [
   // These properties are set to undefined, causing inconsistencies between Chrome and Firefox
   'AppStateController.currentPopupId',
   'AppStateController.timeoutMinutes',
-  'TokenListController.tokensChainsCache',
 ];
 
 const removedUiFields = [
@@ -29,7 +28,6 @@ const removedUiFields = [
   // These properties are set to undefined, causing inconsistencies between Chrome and Firefox
   'metamask.currentPopupId',
   'metamask.timeoutMinutes',
-  'metamask.tokensChainsCache',
 ];
 
 /**

--- a/test/e2e/tests/state-snapshots/errors-after-init-opt-in-ui-state.json
+++ b/test/e2e/tests/state-snapshots/errors-after-init-opt-in-ui-state.json
@@ -130,6 +130,7 @@
     "estimatedGasFeeTimeBounds": "object",
     "gasEstimateType": "string",
     "tokenList": "object",
+    "tokensChainsCache": "object",
     "preventPollingOnNetworkRestart": "boolean",
     "tokens": "object",
     "ignoredTokens": "object",


### PR DESCRIPTION
## Explanation

Migration #77 would set the `TokenListController.tokensChainsCache` state to `undefined` if it wasn't already set to anything when that migration was run. This is probably harmless except that it results in Sentry errors during migrations, and it results in that property having a value (at least temporarily) that doesn't match its type.

Migration #77 has been updated to prevent this property from being set to `undefined` going forward. A new migration has been added to delete this value for any users already affected by this problem. The new migration was named "92.1" so that it could run after 92 but before 93, to make backporting this to v10.34.x easier (v10.34.x is currently on migration 92). "92.1" is still a valid number so this should work just as well as a whole number.

## Manual Testing Steps

The current fixture builder default state is affected by this problem. It is missing `TokenListController` state, so you would see the `tokensChainsCache` property set to `undefined` on initialization if you test on `develop`. The `errors.spec.js` test had to exclude this property from the snapshot tests for this reason. That should no longer happen on this PR.

To test that the new migration works, you'll need to use Firefox because Chrome will discard any `undefined` values in our persisted state automatically (they're removed because they're not valid JSON). On Firefox, try using a `develop` build and stopping the extension just after the state initializes. Then update to this PR, and you should see it removed by the new migration.

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
