### PR TITLE
Add flag to update E2E snapshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,15 +88,17 @@ These test scripts all support additional options, which might be helpful for de
 Single e2e tests can be run with `yarn test:e2e:single test/e2e/tests/TEST_NAME.spec.js` along with the options below.
 
 ```console
-  --browser        Set the browser used; either 'chrome' or 'firefox'.
-                                         [string] [choices: "chrome", "firefox"]
-  --debug          Run tests in debug mode, logging each driver interaction
-                                                      [boolean] [default: false]
-  --retries        Set how many times the test should be retried upon failure.
-                                                           [number] [default: 0]
-  --leave-running  Leaves the browser running after a test fails, along with
-                   anything else that the test used (ganache, the test dapp,
-                   etc.)                              [boolean] [default: false]
+  --browser           Set the browser used; either 'chrome' or 'firefox'.
+                                            [string] [choices: "chrome", "firefox"]
+  --debug             Run tests in debug mode, logging each driver interaction
+                                                         [boolean] [default: false]
+  --retries           Set how many times the test should be retried upon failure.
+                                                              [number] [default: 0]
+  --leave-running     Leaves the browser running after a test fails, along with
+                      anything else that the test used (ganache, the test dapp,
+                      etc.)                              [boolean] [default: false]
+  --update-snapshot   Update E2E test snapshots
+                                             [alias: -u] [boolean] [default: false]
 ```
 
 For example, to run the `account-details` tests using Chrome, with debug logging and with the browser set to remain open upon failure, you would use:

--- a/test/e2e/run-all.js
+++ b/test/e2e/run-all.js
@@ -74,12 +74,27 @@ async function main() {
             description:
               'Set how many times the test should be retried upon failure.',
             type: 'number',
+          })
+          .option('update-snapshot', {
+            alias: 'u',
+            default: false,
+            description: 'Update E2E snapshots',
+            type: 'boolean',
           }),
     )
     .strict()
     .help('help');
 
-  const { browser, debug, retries, snaps, mv3, rpc, buildType } = argv;
+  const {
+    browser,
+    debug,
+    retries,
+    snaps,
+    mv3,
+    rpc,
+    buildType,
+    updateSnapshot,
+  } = argv;
 
   let testPaths;
 
@@ -129,6 +144,9 @@ async function main() {
   }
   if (debug) {
     args.push('--debug');
+  }
+  if (updateSnapshot) {
+    args.push('--update-snapshot');
   }
 
   // For running E2Es in parallel in CI

--- a/test/e2e/run-e2e-test.js
+++ b/test/e2e/run-e2e-test.js
@@ -42,6 +42,12 @@ async function main() {
               'Leaves the browser running after a test fails, along with anything else that the test used (ganache, the test dapp, etc.)',
             type: 'boolean',
           })
+          .option('update-snapshot', {
+            alias: 'u',
+            default: false,
+            description: 'Update E2E snapshots',
+            type: 'boolean',
+          })
           .positional('e2e-test-path', {
             describe: 'The path for the E2E test to run.',
             type: 'string',
@@ -58,6 +64,7 @@ async function main() {
     retries,
     retryUntilFailure,
     leaveRunning,
+    updateSnapshot,
   } = argv;
 
   if (!browser) {
@@ -101,6 +108,10 @@ async function main() {
     process.env.E2E_LEAVE_RUNNING = 'true';
     testTimeoutInMilliseconds = 0;
     exit = '--no-exit';
+  }
+
+  if (updateSnapshot) {
+    process.env.UPDATE_SNAPSHOTS = 'true';
   }
 
   const configFile = path.join(__dirname, '.mocharc.js');


### PR DESCRIPTION
## Explanation

The E2E test scripts now have a flag for updating E2E test snapshots. The flag has been documented as well. This makes it easier to update snapshots and raises visbility of this feature.

## Manual Testing Steps

Change snapshots, then try updating them using any of the e2e test commands. e.g.
- `yarn test:e2e:chrome -u`
- `yarn test:e2e:chrome --update-snapshot`
- `yarn test:e2e:single --browser firefox -u ./test/e2e/tests/errors.spec.js`
- `yarn test:e2e:single --browser chrome --update-snapshot ./test/e2e/tests/errors.spec.js`

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
