### PR TITLE
Fix and test log.info calls run for each migration

### DIFF
--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -88,7 +88,7 @@ const metamaskInternalProcessHash = {
 
 const metamaskBlockedPorts = ['trezor-connect'];
 
-log.setDefaultLevel(process.env.METAMASK_DEBUG ? 'debug' : 'info');
+log.setLevel(process.env.METAMASK_DEBUG ? 'debug' : 'info', false);
 
 const platform = new ExtensionPlatform();
 const notificationManager = new NotificationManager();

--- a/test/e2e/fixture-builder.js
+++ b/test/e2e/fixture-builder.js
@@ -744,6 +744,13 @@ class FixtureBuilder {
     return this;
   }
 
+  withBadPreferencesControllerState() {
+    merge(this.fixture.data, {
+      PreferencesController: 5,
+    });
+    return this;
+  }
+
   withTokensControllerERC20() {
     merge(this.fixture.data.TokensController, {
       tokens: [

--- a/test/e2e/tests/errors.spec.js
+++ b/test/e2e/tests/errors.spec.js
@@ -349,17 +349,20 @@ describe('Sentry errors', function () {
           const mockTextBody = mockedRequest.body.text.split('\n');
           const mockJsonBody = JSON.parse(mockTextBody[2]);
           const breadcrumbs = mockJsonBody?.breadcrumbs ?? [];
-
           const migrationLogBreadcrumbs = breadcrumbs.filter((breadcrumb) => {
-            return breadcrumb.message.match(/Running migration \d+/u);
+            return breadcrumb.message?.match(/Running migration \d+/u);
           });
-          const firstMigrationLog = migrationLogBreadcrumbs[0];
+          const migrationLogMessages = migrationLogBreadcrumbs.map(
+            (breadcrumb) =>
+              breadcrumb.message.match(/(Running migration \d+)/u)[1],
+          );
+          const firstMigrationLog = migrationLogMessages[0];
           const lastMigrationLog =
-            migrationLogBreadcrumbs[migrationLogBreadcrumbs.length - 1];
+            migrationLogMessages[migrationLogMessages.length - 1];
 
-          assert.equal(migrationLogBreadcrumbs.length, 8);
-          assert.equal(firstMigrationLog.message, 'Running migration 75');
-          assert.equal(lastMigrationLog.message, 'Running migration 82');
+          assert.equal(migrationLogMessages.length, 8);
+          assert.equal(firstMigrationLog, 'Running migration 75');
+          assert.equal(lastMigrationLog, 'Running migration 82');
         },
       );
     });

--- a/test/e2e/tests/errors.spec.js
+++ b/test/e2e/tests/errors.spec.js
@@ -124,6 +124,18 @@ describe('Sentry errors', function () {
       });
   }
 
+  async function mockSentryInvariantMigrationError(mockServer) {
+    return await mockServer
+      .forPost('https://sentry.io/api/0000000/envelope/')
+      .withBodyIncluding('typeof state.PreferencesController is number')
+      .thenCallback(() => {
+        return {
+          statusCode: 200,
+          json: {},
+        };
+      });
+  }
+
   async function mockSentryTestError(mockServer) {
     return await mockServer
       .forPost('https://sentry.io/api/0000000/envelope/')
@@ -303,6 +315,51 @@ describe('Sentry errors', function () {
             data: transformBackgroundState(appState.persistedState),
             snapshot: 'errors-before-init-opt-in-background-state',
           });
+        },
+      );
+    });
+
+    it('should capture migration log breadcrumbs when there is an invariant state error in a migration', async function () {
+      await withFixtures(
+        {
+          fixtures: {
+            ...new FixtureBuilder()
+              .withMetaMetricsController({
+                metaMetricsId: 'fake-metrics-id',
+                participateInMetaMetrics: true,
+              })
+              .withBadPreferencesControllerState()
+              .build(),
+          },
+          ganacheOptions,
+          title: this.test.title,
+          failOnConsoleError: false,
+          testSpecificMock: mockSentryInvariantMigrationError,
+        },
+        async ({ driver, mockedEndpoint }) => {
+          await driver.navigate();
+
+          // Wait for Sentry request
+          await driver.wait(async () => {
+            const isPending = await mockedEndpoint.isPending();
+            return isPending === false;
+          }, 3000);
+
+          const [mockedRequest] = await mockedEndpoint.getSeenRequests();
+          const mockTextBody = mockedRequest.body.text.split('\n');
+          const mockJsonBody = JSON.parse(mockTextBody[2]);
+          const breadcrumbs = mockJsonBody?.breadcrumbs ?? [];
+
+          const migrationLogBreadcrumbs = breadcrumbs.filter((breadcrumb) => {
+            return breadcrumb.message.match(/Running migration \d+/u);
+          });
+          const firstMigrationLog = migrationLogBreadcrumbs[0];
+          const lastMigrationLog =
+            migrationLogBreadcrumbs[migrationLogBreadcrumbs.length - 1];
+
+          assert.equal(migrationLogBreadcrumbs.length, 8);
+          assert.equal(firstMigrationLog.message, 'Running migration 75');
+          assert.equal(lastMigrationLog.message, 'Running migration 82');
         },
       );
     });

--- a/ui/index.js
+++ b/ui/index.js
@@ -27,7 +27,7 @@ import Root from './pages';
 import txHelper from './helpers/utils/tx-helper';
 import { _setBackgroundConnection } from './store/action-queue';
 
-log.setLevel(global.METAMASK_DEBUG ? 'debug' : 'warn');
+log.setLevel(global.METAMASK_DEBUG ? 'debug' : 'warn', false);
 
 let reduxStore;
 


### PR DESCRIPTION
In migrator/index.js, log.info is called before an after each migration. These calls are intended to produce breadcrumbs to be captured by sentry in cases where errors happen during or shortly after migrations are run. These calls were not causing any output to the console because the log.setLevel calls in ui/index.js were setting a 'warn value in local storage that was being used by logLevel in the background.

This commit fixes the problem by setting the `persist` param of setLevel to false, so that the background no longer reads the ui's log level.

Tests are added to verify that these logs are captured in sentry breadcrumbs when there is a migration error due to an invariant state.

## Manual Testing Steps

1. Checkout this branch and run `yarn dist`
2. Install and onboard, opting into metametrics while onboarding
3. Run `chrome.storage.local.get(({ data, meta }) => chrome.storage.local.set({ data: { ...data, PreferencesController: 5 }, meta: {...meta, version: 75} }, () => { window.location.reload() }))` in the background dev console
4. You should see logs like "Running migration 75" and "Migration 75 complete" for each of the migrations from 75 to 94.
5. There should be a network request to sentry, with breadcrumbs for the console log entries from 75 to 82.

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
