### PR TITLE
Fix Sentry breadcrumbs collection during initialization

### DIFF
--- a/app/scripts/lib/setupSentry.js
+++ b/app/scripts/lib/setupSentry.js
@@ -127,6 +127,45 @@ export const SENTRY_UI_STATE = {
   unconnectedAccount: true,
 };
 
+/**
+ * Returns whether MetaMetrics is enabled, given the application state.
+ *
+ * @param {{ state: unknown} | { persistedState: unknown }} appState - Application state
+ * @returns `true` if MetaMask's state has been initialized, and MetaMetrics
+ * is enabled, `false` otherwise.
+ */
+function getMetaMetricsEnabledFromAppState(appState) {
+  // during initialization after loading persisted state
+  if (appState.persistedState) {
+    return getMetaMetricsEnabledFromPersistedState(appState.persistedState);
+    // After initialization
+  } else if (appState.state) {
+    // UI
+    if (appState.state.metamask) {
+      return Boolean(appState.state.metamask?.participateInMetaMetrics);
+    }
+    // background
+    return Boolean(
+      appState.state.MetaMetricsController?.participateInMetaMetrics,
+    );
+  }
+  // during initialization, before first persisted state is read
+  return false;
+}
+
+/**
+ * Returns whether MetaMetrics is enabled, given the persisted state.
+ *
+ * @param {unknown} persistedState - Application state
+ * @returns `true` if MetaMask's state has been initialized, and MetaMetrics
+ * is enabled, `false` otherwise.
+ */
+function getMetaMetricsEnabledFromPersistedState(persistedState) {
+  return Boolean(
+    persistedState?.data?.MetaMetricsController?.participateInMetaMetrics,
+  );
+}
+
 export default function setupSentry({ release, getState }) {
   if (!release) {
     throw new Error('Missing release');
@@ -164,22 +203,21 @@ export default function setupSentry({ release, getState }) {
   }
 
   /**
-   * A function that returns whether MetaMetrics is enabled. This should also
-   * return `false` if state has not yet been initialzed.
+   * Returns whether MetaMetrics is enabled. If the application hasn't yet
+   * been initialized, the persisted state will be used (if any).
    *
-   * @returns `true` if MetaMask's state has been initialized, and MetaMetrics
-   * is enabled, `false` otherwise.
+   * @returns `true` if MetaMetrics is enabled, `false` otherwise.
    */
   async function getMetaMetricsEnabled() {
     const appState = getState();
-    if (Object.keys(appState) > 0) {
-      return Boolean(appState?.store?.metamask?.participateInMetaMetrics);
+    if (appState.state || appState.persistedState) {
+      return getMetaMetricsEnabledFromAppState(appState);
     }
+    // If we reach here, it means the error was thrown before initialization
+    // completed, and before we loaded the persisted state for the first time.
     try {
       const persistedState = await globalThis.stateHooks.getPersistedState();
-      return Boolean(
-        persistedState?.data?.MetaMetricsController?.participateInMetaMetrics,
-      );
+      return getMetaMetricsEnabledFromPersistedState(persistedState);
     } catch (error) {
       console.error(error);
       return false;
@@ -321,17 +359,12 @@ function hideUrlIfNotInternal(url) {
  */
 export function beforeBreadcrumb(getState) {
   return (breadcrumb) => {
-    if (getState) {
-      const appState = getState();
-      if (
-        Object.values(appState).length &&
-        (!appState?.store?.metamask?.participateInMetaMetrics ||
-          !appState?.store?.metamask?.completedOnboarding ||
-          breadcrumb?.category === 'ui.input')
-      ) {
-        return null;
-      }
-    } else {
+    if (!getState) {
+      return null;
+    }
+    if (!getMetaMetricsEnabledFromAppState(getState())) {
+      return null;
+    } else if (breadcrumb?.category === 'ui.input') {
       return null;
     }
     const newBreadcrumb = removeUrlsFromBreadCrumb(breadcrumb);

--- a/app/scripts/lib/setupSentry.js
+++ b/app/scripts/lib/setupSentry.js
@@ -362,9 +362,12 @@ export function beforeBreadcrumb(getState) {
     if (!getState) {
       return null;
     }
-    if (!getMetaMetricsEnabledFromAppState(getState())) {
-      return null;
-    } else if (breadcrumb?.category === 'ui.input') {
+    const appState = getState();
+    if (
+      !getMetaMetricsEnabledFromAppState(appState) ||
+      !appState?.store?.metamask?.completedOnboarding ||
+      breadcrumb?.category === 'ui.input'
+    ) {
       return null;
     }
     const newBreadcrumb = removeUrlsFromBreadCrumb(breadcrumb);

--- a/app/scripts/lib/setupSentry.js
+++ b/app/scripts/lib/setupSentry.js
@@ -142,7 +142,7 @@ function getMetaMetricsEnabledFromAppState(appState) {
   } else if (appState.state) {
     // UI
     if (appState.state.metamask) {
-      return Boolean(appState.state.metamask?.participateInMetaMetrics);
+      return Boolean(appState.state.metamask.participateInMetaMetrics);
     }
     // background
     return Boolean(
@@ -183,7 +183,7 @@ function getOnboardingCompleteFromAppState(appState) {
   } else if (appState.state) {
     // UI
     if (appState.state.metamask) {
-      return Boolean(appState.state.metamask?.completedOnboarding);
+      return Boolean(appState.state.metamask.completedOnboarding);
     }
     // background
     return Boolean(appState.state.OnboardingController?.completedOnboarding);

--- a/app/scripts/lib/setupSentry.js
+++ b/app/scripts/lib/setupSentry.js
@@ -169,7 +169,7 @@ function getMetaMetricsEnabledFromPersistedState(persistedState) {
 /**
  * Returns whether onboarding has completed, given the application state.
  *
- * @param {unknown} appState - Application state
+ * @param {Record<string, unknown>} appState - Application state
  * @returns `true` if MetaMask's state has been initialized, and MetaMetrics
  * is enabled, `false` otherwise.
  */

--- a/app/scripts/lib/setupSentry.js
+++ b/app/scripts/lib/setupSentry.js
@@ -177,7 +177,7 @@ function getOnboardingCompleteFromAppState(appState) {
   // during initialization after loading persisted state
   if (appState.persistedState) {
     return Boolean(
-      appState.persistedState.data.OnboardingController?.completedOnboarding,
+      appState.persistedState.data?.OnboardingController?.completedOnboarding,
     );
     // After initialization
   } else if (appState.state) {

--- a/app/scripts/lib/setupSentry.js
+++ b/app/scripts/lib/setupSentry.js
@@ -166,6 +166,32 @@ function getMetaMetricsEnabledFromPersistedState(persistedState) {
   );
 }
 
+/**
+ * Returns whether onboarding has completed, given the application state.
+ *
+ * @param {unknown} appState - Application state
+ * @returns `true` if MetaMask's state has been initialized, and MetaMetrics
+ * is enabled, `false` otherwise.
+ */
+function getOnboardingCompleteFromAppState(appState) {
+  // during initialization after loading persisted state
+  if (appState.persistedState) {
+    return Boolean(
+      appState.persistedState.data.OnboardingController?.completedOnboarding,
+    );
+    // After initialization
+  } else if (appState.state) {
+    // UI
+    if (appState.state.metamask) {
+      return Boolean(appState.state.metamask?.completedOnboarding);
+    }
+    // background
+    return Boolean(appState.state.OnboardingController?.completedOnboarding);
+  }
+  // during initialization, before first persisted state is read
+  return false;
+}
+
 export default function setupSentry({ release, getState }) {
   if (!release) {
     throw new Error('Missing release');
@@ -365,7 +391,7 @@ export function beforeBreadcrumb(getState) {
     const appState = getState();
     if (
       !getMetaMetricsEnabledFromAppState(appState) ||
-      !appState?.store?.metamask?.completedOnboarding ||
+      !getOnboardingCompleteFromAppState(appState) ||
       breadcrumb?.category === 'ui.input'
     ) {
       return null;


### PR DESCRIPTION
## Explanation

The refactor of the Sentry state in #20491 accidentally broke our opt- in detection in the `beforeBreadcrumbs` hook for errors in the background process. It would have broken our error report opt-in detection as well, except that that function was broken in a way that made it work correctly but inefficiently (it was loading the persisted state each time to check, ignoring the application state).

The opt-in detection has been updated to look for both types of application state (during and after initialization). The function was refactored to be used for the `beforeBreadcrumbs` hook as well.

## Manual Testing Steps

This was discovered by @danjm when investigating the e2e test failure in https://github.com/MetaMask/metamask-extension/pull/20517. This can be tested by following a similar approach to the failing e2e test: modify the persisted state in a way that breaks a migration, and ensure the breadcrumbs are collected.

The steps I took are:
* Comment out this line: https://github.com/MetaMask/metamask-extension/blob/88212a7c82ce20f37b5949246d3751a0be605cf4/app/scripts/lib/setupSentry.js#L140
* Create a development build with a valid `SENTRY_DSN_DEV` set in `.metamaskrc`
* Run this code snippet in the background console after installing the extension:
```
chrome.storage.local.get(({ data, meta }) => chrome.storage.local.set({ data: { ...data, MetaMetricsController: { ...data.MetaMetricsController, participateInMetaMetrics: true }, OnboardingController: { ...data.OnboardingController, completedOnboarding: true }, NftController: false }, meta: {...meta, version: 20} }, () => { window.location.reload() }))
```
  * This snippet sets the version back far enough that there are plenty of console logs/breadcrumbs to collect
  * `onboardingComplete` is set to `true` and `participateInMetaMetrics` is set to `true` so that the request goes through and breadcrumbs aren't suppressed
* See that there is a resulting Sentry error report in the network tab, and breadcrumbs are included in the payload
* Try again with `onboardingComplete` set to `false`, and you should see the same error report but without the breadcrumbs
* Try again with `participateInMetaMetrics` set to `false` and there should be no error report
* After initialization, try running `window.stateHooks.throwTestError()` in the UI (checking the network tab to see whether an error is sent, and whether it has breadcrumbs, which should depend on the two properties referenced earlier)
* After initialization, try running `window.stateHooks.throwTestBackgroundError()` in the UI (checking the network tab to see whether an error is sent, and whether it has breadcrumbs, which should depend on the two properties referenced earlier)

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
