### PR TITLE
Don't call "toPrecisionWithoutTrailingZeros" if a destination value is not a number

### DIFF
--- a/ui/pages/swaps/swaps.util.test.js
+++ b/ui/pages/swaps/swaps.util.test.js
@@ -401,6 +401,12 @@ describe('Swaps Util', () => {
         '39.6493201125',
       );
     });
+
+    it('gets swaps value for display when the value contains three dots', () => {
+      expect(formatSwapsValueForDisplay('33680099000000000000...')).toBe(
+        '33680099000000000000...',
+      );
+    });
   });
 
   describe('getSwapsTokensReceivedFromTxMeta', () => {

--- a/ui/pages/swaps/swaps.util.ts
+++ b/ui/pages/swaps/swaps.util.ts
@@ -545,8 +545,18 @@ export function quotesToRenderableData({
   });
 }
 
-export function formatSwapsValueForDisplay(destinationAmount: string): string {
-  let amountToDisplay = toPrecisionWithoutTrailingZeros(destinationAmount, 12);
+export function formatSwapsValueForDisplay(
+  destinationAmount: string | BigNumber,
+): string {
+  let amountToDisplay;
+  if (
+    typeof destinationAmount === 'string' &&
+    destinationAmount.includes('...')
+  ) {
+    amountToDisplay = destinationAmount;
+  } else {
+    amountToDisplay = toPrecisionWithoutTrailingZeros(destinationAmount, 12);
+  }
   if (amountToDisplay.match(/e[+-]/u)) {
     amountToDisplay = new BigNumber(amountToDisplay).toFixed();
   }


### PR DESCRIPTION
## Explanation
In rare cases when a destination value is too long, we make it shorter and add three zeros (code for it here: https://github.com/MetaMask/metamask-extension/blob/develop/ui/pages/swaps/prepare-swap-page/review-quote.js#L1035)
Then when we called the "toPrecisionWithoutTrailingZeros" function, it was failing, because e.g. this was not recognised as a number: `33680099000000000000...`

With this fix if a destination value is a string and contains three dots, we don't call the "toPrecisionWithoutTrailingZeros" function, so a user can finish the flow.

## Manual Testing Steps
- Open Swaps
- Try to get a quote for ETH -> KUKU
- You can continue with a swap