### PR TITLE
Fix pre-initialization UI error state capture

### DIFF
--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -71,12 +71,6 @@ import DesktopManager from '@metamask/desktop/dist/desktop-manager';
 ///: END:ONLY_INCLUDE_IN
 /* eslint-enable import/order */
 
-// Setup global hook for improved Sentry state snapshots during initialization
-const inTest = process.env.IN_TEST;
-const localStore = inTest ? new ReadOnlyNetworkStore() : new LocalStore();
-global.stateHooks.getMostRecentPersistedState = () =>
-  localStore.mostRecentRetrievedState;
-
 const { sentry } = global;
 const firstTimeState = { ...rawFirstTimeState };
 
@@ -100,6 +94,9 @@ const openMetamaskTabsIDs = {};
 const requestAccountTabIds = {};
 let controller;
 
+// state persistence
+const inTest = process.env.IN_TEST;
+const localStore = inTest ? new ReadOnlyNetworkStore() : new LocalStore();
 let versionedData;
 
 if (inTest || process.env.METAMASK_DEBUG) {

--- a/app/scripts/lib/network-store.js
+++ b/app/scripts/lib/network-store.js
@@ -31,7 +31,6 @@ export default class ReadOnlyNetworkStore {
       const response = await fetchWithTimeout(FIXTURE_SERVER_URL);
       if (response.ok) {
         this._state = await response.json();
-        this.mostRecentRetrievedState = this._state;
       }
     } catch (error) {
       log.debug(`Error loading network state: '${error.message}'`);
@@ -48,6 +47,11 @@ export default class ReadOnlyNetworkStore {
   async get() {
     if (!this._initialized) {
       await this._initializing;
+    }
+    // Delay setting this until after the first read, to match the
+    // behavior of the local store.
+    if (!this.mostRecentRetrievedState) {
+      this.mostRecentRetrievedState = this._state;
     }
     return this._state;
   }

--- a/app/scripts/ui.js
+++ b/app/scripts/ui.js
@@ -33,14 +33,6 @@ import ExtensionPlatform from './platforms/extension';
 import { setupMultiplex } from './lib/stream-utils';
 import { getEnvironmentType, getPlatform } from './lib/util';
 import metaRPCClientFactory from './lib/metaRPCClientFactory';
-import LocalStore from './lib/local-store';
-import ReadOnlyNetworkStore from './lib/network-store';
-
-// Setup global hook for improved Sentry state snapshots during initialization
-const inTest = process.env.IN_TEST;
-const localStore = inTest ? new ReadOnlyNetworkStore() : new LocalStore();
-global.stateHooks.getMostRecentPersistedState = () =>
-  localStore.mostRecentRetrievedState;
 
 const container = document.getElementById('app-content');
 


### PR DESCRIPTION
## Explanation

In the case where an error is thrown in the UI before initialization has finished, we aren't capturing the application state correctly for Sentry errors. We had a test case for this, but the test case was broken due to a mistake in how the `network-store` was setup (it was not matching the behavior of the real `local-tstore` module).

The pre-initialization state capture logic was updated to rely solely upon the `localStore` instance used by Sentry to determine whether the user had opted-in to metrics or not. This simplifies the logic a great deal, removing the need for the `getMostRecentPersistedState` state hook. It also ensures that state is captured corretly pre- initialization in both the background and UI.

## Manual Testing Steps

Update `ui/index.js` to throw an error during initialization (but after the `getMostRecentPersistedState` hook was setup, if testing on `develop`). On `develop`, you'll see that the resulting error doesn't include Sentry state, even though it was meant to. On this PR it will include the state in the error report.

Alternatively you could do what the e2e test does and wait until after initialization, but "emulate" a pre-initialization state by deleting the `getSentryAppState` state hook. Then you can more easily trigger an error by calling `window.stateHooks.throwTestError()`. Again, you should see the same result (on `develop` the state will be missing, but on this PR it will be present).

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
