### PR TITLE
[FLASK] Add extend-runtime endowment

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -3268,6 +3268,14 @@
     "message": "Allow the snap to communicate with MetaMask directly, in order for it to read data from the blockchain and suggest messages and transactions.",
     "description": "An extended description for the `endowment:ethereum-provider` permission"
   },
+  "permission_extendRuntime": {
+    "message": "Extend runtime.",
+    "description": "Label for the `endowment:extend-runtime` permission"
+  },
+  "permission_extendRuntimeDescription": {
+    "message": "Let this snap run for an extended duration. This can be used for demanding computation.",
+    "description": "An extended description for the `endowment:extend-runtime` permission"
+  },
   "permission_getEntropy": {
     "message": "Derive arbitrary keys unique to this snap.",
     "description": "The description for the `snap_getEntropy` permission"

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -1015,6 +1015,7 @@ export default class MetamaskController extends EventEmitter {
         'ExecutionService:unhandledError',
         'ExecutionService:outboundRequest',
         'ExecutionService:outboundResponse',
+        'ExecutionService:timerPauseRequest',
         'SnapController:snapInstalled',
         'SnapController:snapUpdated',
       ],

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -1015,7 +1015,7 @@ export default class MetamaskController extends EventEmitter {
         'ExecutionService:unhandledError',
         'ExecutionService:outboundRequest',
         'ExecutionService:outboundResponse',
-        'ExecutionService:timerPauseRequest',
+        'ExecutionService:executionTimerRequest',
         'SnapController:snapInstalled',
         'SnapController:snapUpdated',
       ],

--- a/shared/constants/permissions.test.js
+++ b/shared/constants/permissions.test.js
@@ -14,6 +14,7 @@ describe('EndowmentPermissions', () => {
     expect(Object.keys(EndowmentPermissions).sort()).toStrictEqual(
       [
         'endowment:long-running',
+        'endowment:extend-runtime',
         'endowment:lifecycle-hooks',
         ...Object.keys(endowmentPermissionBuilders).filter(
           (targetName) =>

--- a/shared/constants/snaps/permissions.ts
+++ b/shared/constants/snaps/permissions.ts
@@ -8,6 +8,7 @@ export const EndowmentPermissions = Object.freeze({
   ///: BEGIN:ONLY_INCLUDE_IN(build-flask)
   'endowment:long-running': 'endowment:long-running',
   'endowment:lifecycle-hooks': 'endowment:lifecycle-hooks',
+  'endowment:extend-runtime': 'endowment:extend-runtime',
   ///: END:ONLY_INCLUDE_IN
 } as const);
 

--- a/ui/helpers/utils/permission.js
+++ b/ui/helpers/utils/permission.js
@@ -320,6 +320,12 @@ export const PERMISSION_DESCRIPTIONS = deepFreeze({
     leftIcon: IconName.Link,
     weight: 3,
   }),
+  [EndowmentPermissions['endowment:extend-runtime']]: ({ t }) => ({
+    label: t('permission_extendRuntime'),
+    description: t('permission_extendRuntimeDescription'),
+    leftIcon: IconName.Timer,
+    weight: 3,
+  }),
   [EndowmentPermissions['endowment:transaction-insight']]: ({
     t,
     permissionValue,


### PR DESCRIPTION
## Explanation
This PR will add support for Snaps Platform endowment that provides extended runtime possibilities by controlling the execution timer.
In this PR added are:
- Endowment specification (label, description, icon) and its registration to permissions.
- New allowed event to the Snaps Controller Messenger configuration (`ExecutionService:timerPauseRequest`).

Related ticket following the work in Snaps repository: https://github.com/MetaMask/snaps/issues/1604

## Screenshots/Screencaps

### Before
Nothing from before is affected by this PR.

### After
TODO: Permission screenshot

## Manual Testing Steps

<!--
How should reviewers and QA manually test your changes? For instance:

- Go to this screen
- Do this
- Then do this
-->

## Pre-merge author checklist

- [ ] I've clearly explained:
  - [ ] What problem this PR is solving
  - [ ] How this problem was solved
  - [ ] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
