### PR TITLE
fix(action): octokit not supported on MetaMask repos

### DIFF
--- a/.github/workflows/create-bug-report.yml
+++ b/.github/workflows/create-bug-report.yml
@@ -20,12 +20,16 @@ jobs:
       - name: Create bug report issue on planning repo
         if: env.version
         run: |
+          payload=$(cat <<EOF
+          {
+            "title": "v${{ env.version }} Bug Report",
+            "body": "This bug report was automatically created by a GitHub action upon the creation of release branch \`Version-v${{ env.version }}\` (release cut).\n\n**Expected actions for release engineers:**\n\n1. Convert this issue into a Zenhub epic and link all bugs identified during the release regression testing phase to this epic.\n\n2. After completing the first regression run, move this epic to \"Regression Completed\" on the [Extension Release Regression board](https://app.zenhub.com/workspaces/extension-release-regression-6478c62d937eaa15e95c33c5/board?filterLogic=any&labels=release-${{ env.version }},release-task).\n\nNote that once the release is prepared for store submission, meaning the \`Version-v${{ env.version }}\` branch merges into \`master\`, another GitHub action will automatically close this epic.",
+            "labels": ["type-bug", "regression-RC", "release-${{ env.version }}"]
+          }
+          EOF
+          )
           curl -X POST \
             -H "Authorization: token ${{ secrets.BUG_REPORT_TOKEN }}" \
             -H "Accept: application/vnd.github.v3+json" \
             https://api.github.com/repos/MetaMask/MetaMask-planning/issues \
-            -d '{
-            "title": "v${{ env.version }} Bug Report",
-            "body": "This bug report was automatically created by a GitHub action upon the creation of release branch `Version-v${{ env.version }}` (release cut).\n\n**Expected actions for release engineers:**\n\n1. Convert this issue into a Zenhub epic and link all bugs identified during the release regression testing phase to this epic.\n\n2. After completing the first regression run, move this epic to \"Regression Completed\" on the [Extension Release Regression board](https://app.zenhub.com/workspaces/extension-release-regression-6478c62d937eaa15e95c33c5/board?filterLogic=any&labels=release-${{ env.version }},release-task).\n\nNote that once the release is prepared for store submission, meaning the `Version-v${{ env.version }}` branch merges into `master`, another GitHub action will automatically close this epic.",
-            "labels": ["type-bug", "regression-RC", "release-${{ env.version }}"]
-            }'
+            -d "$payload"

--- a/.github/workflows/create-bug-report.yml
+++ b/.github/workflows/create-bug-report.yml
@@ -19,29 +19,13 @@ jobs:
 
       - name: Create bug report issue on planning repo
         if: env.version
-        uses: octokit/request-action@v2.x
-        with:
-          route: POST /repos/MetaMask/MetaMask-planning/issues
-          owner: MetaMask
-          title: v${{ env.version }} Bug Report
-          body: |
-            This bug report was automatically created by a GitHub action upon the creation of release branch `Version-v${{ env.version }}` (release cut).
-
-
-            **Expected actions for release engineers:**
-
-            1. Convert this issue into a Zenhub epic and link all bugs identified during the release regression testing phase to this epic.
-
-            2. After completing the first regression run, move this epic to "Regression Completed" on the [Extension Release Regression board](https://app.zenhub.com/workspaces/extension-release-regression-6478c62d937eaa15e95c33c5/board?filterLogic=any&labels=release-${{ env.version }},release-task).
-
-
-            Note that once the release is prepared for store submission, meaning the `Version-v${{ env.version }}` branch merges into `master`, another GitHub action will automatically close this epic.
-
-          labels: |
-            [
-              "type-bug",
-              "regression-RC",
-              "release-${{ env.version }}"
-            ]
-        env:
-          GITHUB_TOKEN: ${{ secrets.BUG_REPORT_TOKEN }}
+        run: |
+          curl -X POST \
+            -H "Authorization: token ${{ secrets.BUG_REPORT_TOKEN }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            https://api.github.com/repos/MetaMask/MetaMask-planning/issues \
+            -d '{
+            "title": "v${{ env.version }} Bug Report",
+            "body": "This bug report was automatically created by a GitHub action upon the creation of release branch `Version-v${{ env.version }}` (release cut).\n\n**Expected actions for release engineers:**\n\n1. Convert this issue into a Zenhub epic and link all bugs identified during the release regression testing phase to this epic.\n\n2. After completing the first regression run, move this epic to \"Regression Completed\" on the [Extension Release Regression board](https://app.zenhub.com/workspaces/extension-release-regression-6478c62d937eaa15e95c33c5/board?filterLogic=any&labels=release-${{ env.version }},release-task).\n\nNote that once the release is prepared for store submission, meaning the `Version-v${{ env.version }}` branch merges into `master`, another GitHub action will automatically close this epic.",
+            "labels": ["type-bug", "regression-RC", "release-${{ env.version }}"]
+            }'


### PR DESCRIPTION
## Explanation

The github action was constantly failing with the following error: "octokit/request-action@v2.x is not allowed to be used in MetaMask/metamask-extension"

The fix is to use a curl instead of using octokit.

## Screenshots/Screencaps

### Before

### After

## Manual Testing Steps

- See this PR: https://github.com/MetaMask/metamask-extension/pull/20391

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
