### PR TITLE
Remove snapshot update from release process

### DIFF
--- a/test/e2e/tests/errors.spec.js
+++ b/test/e2e/tests/errors.spec.js
@@ -9,9 +9,17 @@ const FixtureBuilder = require('../fixture-builder');
 
 const maskedBackgroundFields = [
   'CurrencyController.conversionDate', // This is a timestamp that changes each run
+  // App metadata is masked so that we don't have to update the snapshot as
+  // part of the release process
+  'AppMetadataController.currentAppVersion',
+  'AppMetadataController.currentMigrationVersion',
 ];
 const maskedUiFields = [
   'metamask.conversionDate', // This is a timestamp that changes each run
+  // App metadata is masked so that we don't have to update the snapshot as
+  // part of the release process
+  'metamask.currentAppVersion',
+  'metamask.currentMigrationVersion',
 ];
 
 const removedBackgroundFields = [

--- a/test/e2e/tests/state-snapshots/errors-after-init-opt-in-background-state.json
+++ b/test/e2e/tests/state-snapshots/errors-after-init-opt-in-background-state.json
@@ -8,10 +8,10 @@
   },
   "AnnouncementController": "object",
   "AppMetadataController": {
-    "currentAppVersion": "10.34.5",
+    "currentAppVersion": "string",
     "previousAppVersion": "",
     "previousMigrationVersion": 0,
-    "currentMigrationVersion": 94
+    "currentMigrationVersion": "number"
   },
   "AppStateController": {
     "connectedStatusPopoverHasBeenShown": true,

--- a/test/e2e/tests/state-snapshots/errors-after-init-opt-in-ui-state.json
+++ b/test/e2e/tests/state-snapshots/errors-after-init-opt-in-ui-state.json
@@ -57,10 +57,10 @@
     "usedNetworks": "object",
     "snapsInstallPrivacyWarningShown": "boolean",
     "serviceWorkerLastActiveTime": "number",
-    "currentAppVersion": "10.34.5",
+    "currentAppVersion": "string",
     "previousAppVersion": "",
     "previousMigrationVersion": 0,
-    "currentMigrationVersion": 94,
+    "currentMigrationVersion": "number",
     "selectedNetworkClientId": "string",
     "networkId": "1337",
     "providerConfig": {


### PR DESCRIPTION
## Explanation

The Sentry e2e state snapshots now mask the application version and migration version, ensuring that the snapshots don't need a extra update in each release candidate branch and post-release sync branch.

The values are masked rather than removed so that the test still shows they are present in error reports, where they can be quite useful for diagnostic purposes.

## Manual Testing Steps

N/A, just an e2e test change

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
