### PR TITLE
fix: Remove sentry warning on `undefined` `TokenListController`

### DIFF
--- a/app/scripts/migrations/088.test.ts
+++ b/app/scripts/migrations/088.test.ts
@@ -1,4 +1,3 @@
-// @jest-environment node
 import { migrate } from './088';
 
 const sentryCaptureExceptionMock = jest.fn();
@@ -725,11 +724,8 @@ describe('migration #88', () => {
     expect(newStorage.data).toStrictEqual(oldData);
   });
 
-  it('Logs a warning if it has no TokenListController property', async () => {
-    // setup
-    const previousWarnFn = console.warn;
-    const mockWarnFn = jest.fn();
-    console.warn = mockWarnFn;
+  it('logs a warning if it has no TokenListController property', async () => {
+    const mockWarnFn = jest.spyOn(console, 'warn');
 
     const oldData = {
       TokensController: {},
@@ -770,16 +766,10 @@ describe('migration #88', () => {
     expect(mockWarnFn).toHaveBeenCalledWith(
       new Error(`typeof state.TokenListController is undefined`),
     );
-
-    // tear down
-    console.warn = previousWarnFn;
   });
 
-  it('Logs a warning if the TokenListController property is not an object', async () => {
-    // setup
-    const previousWarnFn = console.warn;
-    const mockWarnFn = jest.fn();
-    console.warn = mockWarnFn;
+  it('logs a warning if the TokenListController property is not an object', async () => {
+    const mockWarnFn = jest.spyOn(console, 'warn');
 
     const oldData = {
       TokensController: {},
@@ -821,9 +811,6 @@ describe('migration #88', () => {
     expect(mockWarnFn).toHaveBeenCalledWith(
       new Error(`typeof state.TokenListController is boolean`),
     );
-
-    // tear down
-    console.warn = previousWarnFn;
   });
 
   it('returns the state unaltered if the TokenListController object has no tokensChainsCache property', async () => {

--- a/app/scripts/migrations/088.test.ts
+++ b/app/scripts/migrations/088.test.ts
@@ -1566,25 +1566,6 @@ describe('migration #88', () => {
     expect(newStorage.data).toStrictEqual(oldData);
   });
 
-  it('captures an exception if the TokensController.allDetectedTokens property is not an object', async () => {
-    const oldData = {
-      TokenListController: {},
-      TokensController: {
-        allDetectedTokens: 'foo',
-      },
-    };
-    const oldStorage = {
-      meta: { version: 87 },
-      data: oldData,
-    };
-
-    await migrate(oldStorage);
-    expect(sentryCaptureExceptionMock).toHaveBeenCalledTimes(1);
-    expect(sentryCaptureExceptionMock).toHaveBeenCalledWith(
-      new Error(`typeof state.TokensController.allDetectedTokens is string`),
-    );
-  });
-
   it('rewrites TokensController.allDetectedTokens so that decimal chain IDs are converted to hex strings', async () => {
     const oldStorage = {
       meta: { version: 87 },

--- a/app/scripts/migrations/088.ts
+++ b/app/scripts/migrations/088.ts
@@ -252,12 +252,6 @@ function migrateData(state: Record<string, unknown>): void {
         allDetectedTokens,
         (_, chainId: string) => toHex(chainId),
       );
-    } else if (hasProperty(tokensControllerState, 'allDetectedTokens')) {
-      global.sentry?.captureException?.(
-        new Error(
-          `typeof state.TokensController.allDetectedTokens is ${typeof tokensControllerState.allDetectedTokens}`,
-        ),
-      );
     } else {
       log.warn(
         `typeof state.TokensController.allDetectedTokens is ${typeof tokensControllerState.allDetectedTokens}`,

--- a/app/scripts/migrations/088.ts
+++ b/app/scripts/migrations/088.ts
@@ -164,7 +164,7 @@ function migrateData(state: Record<string, unknown>): void {
       );
     }
   } else {
-    global.sentry?.captureException?.(
+    console.warn(
       new Error(
         `typeof state.TokenListController is ${typeof state.TokenListController}`,
       ),
@@ -251,6 +251,12 @@ function migrateData(state: Record<string, unknown>): void {
       tokensControllerState.allDetectedTokens = mapKeys(
         allDetectedTokens,
         (_, chainId: string) => toHex(chainId),
+      );
+    } else if (hasProperty(tokensControllerState, 'allDetectedTokens')) {
+      global.sentry?.captureException?.(
+        new Error(
+          `typeof state.TokensController.allDetectedTokens is ${typeof tokensControllerState.allDetectedTokens}`,
+        ),
       );
     } else {
       log.warn(


### PR DESCRIPTION
## Explanation

Prior to #20495, it was impossible for TokenListController to be undefined. But that PR added additional validation that skips over that property being initialized to an empty object.

The fix is to convert this `captureException` call to a `log.warn` call.

Fixes Sentry issue reported [here](https://metamask.sentry.io/issues/4410065546/?project=273505).
