### PR TITLE
Fix account search by suffix of an address

### DIFF
--- a/ui/components/multichain/account-list-menu/account-list-menu.js
+++ b/ui/components/multichain/account-list-menu/account-list-menu.js
@@ -62,7 +62,7 @@ export const AccountListMenu = ({ onClose }) => {
   let searchResults = accounts;
   if (searchQuery) {
     const fuse = new Fuse(accounts, {
-      threshold: 0.2,
+      threshold: 0.42,
       location: 0,
       distance: 100,
       maxPatternLength: 32,


### PR DESCRIPTION
* What is the current state of things and why does it need to change?
Searching account by suffix of an address doesn't work

* What is the solution your changes offer and how does it work?
By adjusting threshold to 0.42, fuse can search in first 42 characters. See https://www.fusejs.io/api/options.html#threshold

#### Before
location = 0
distance = 100
threshold = 0.2
search within = [location, distance × threshold] = [0, 20]

#### After
location = 0
distance = 100
threshold = 0.42
search within = [location, distance × threshold] = [0, 42]