### PR TITLE
Update snaps URLs

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -1090,8 +1090,8 @@ export default class MetamaskController extends EventEmitter {
       refetchOnAllowlistMiss: requireAllowlist,
       failOnUnavailableRegistry: requireAllowlist,
       url: {
-        registry: 'https://acl.execution.metamask.io/latest/registry.json',
-        signature: 'https://acl.execution.metamask.io/latest/signature.json',
+        registry: 'https://acl.execution.consensys.io/latest/registry.json',
+        signature: 'https://acl.execution.consensys.io/latest/signature.json',
       },
       publicKey:
         '0x025b65308f0f0fb8bc7f7ff87bfc296e0330eee5d3c1d1ee4a048b2fd6a86fa0a6',

--- a/builds.yml
+++ b/builds.yml
@@ -25,7 +25,7 @@ buildTypes:
       - SEGMENT_WRITE_KEY_REF: SEGMENT_PROD_WRITE_KEY
       - ALLOW_LOCAL_SNAPS: false
       - REQUIRE_SNAPS_ALLOWLIST: true
-      - IFRAME_EXECUTION_ENVIRONMENT_URL: https://execution.metamask.io/1.0.1/index.html
+      - IFRAME_EXECUTION_ENVIRONMENT_URL: https://execution.consensys.io/1.0.1/index.html
     # Main build uses the default browser manifest
     manifestOverrides: false
 
@@ -57,7 +57,7 @@ buildTypes:
       - SEGMENT_FLASK_WRITE_KEY
       - ALLOW_LOCAL_SNAPS: true
       - REQUIRE_SNAPS_ALLOWLIST: false
-      - IFRAME_EXECUTION_ENVIRONMENT_URL: https://execution.metamask.io/0.38.1-flask.1/index.html
+      - IFRAME_EXECUTION_ENVIRONMENT_URL: https://execution.consensys.io/0.38.1-flask.1/index.html
       - SUPPORT_LINK: https://metamask-flask.zendesk.com/hc
       - SUPPORT_REQUEST_LINK: https://metamask-flask.zendesk.com/hc/en-us/requests/new
       - INFURA_ENV_KEY_REF: INFURA_FLASK_PROJECT_ID
@@ -76,7 +76,7 @@ buildTypes:
       - SEGMENT_FLASK_WRITE_KEY
       - ALLOW_LOCAL_SNAPS: true
       - REQUIRE_SNAPS_ALLOWLIST: false
-      - IFRAME_EXECUTION_ENVIRONMENT_URL: https://execution.metamask.io/0.38.1-flask.1/index.html
+      - IFRAME_EXECUTION_ENVIRONMENT_URL: https://execution.consensys.io/0.38.1-flask.1/index.html
       - SUPPORT_LINK: https://metamask-flask.zendesk.com/hc
       - SUPPORT_REQUEST_LINK: https://metamask-flask.zendesk.com/hc/en-us/requests/new
       - INFURA_ENV_KEY_REF: INFURA_FLASK_PROJECT_ID

--- a/shared/modules/provider-injection.js
+++ b/shared/modules/provider-injection.js
@@ -65,6 +65,7 @@ function documentElementCheck() {
  */
 function blockedDomainCheck() {
   const blockedDomains = [
+    'execution.consensys.io',
     'execution.metamask.io',
     'uscourts.gov',
     'dropbox.com',

--- a/test/env.js
+++ b/test/env.js
@@ -1,4 +1,4 @@
 process.env.METAMASK_ENVIRONMENT = 'test';
 process.env.SUPPORT_LINK = 'https://support.metamask.io';
 process.env.IFRAME_EXECUTION_ENVIRONMENT_URL =
-  'https://execution.metamask.io/0.36.1-flask.1/index.html';
+  'https://execution.consensys.io/0.36.1-flask.1/index.html';


### PR DESCRIPTION
## Explanation

Updates URLs for hosted resources used by snaps. 

We will be returning usage to the `*.metamask.io` URL as soon as some DNS problems are resolved.