### PR TITLE
fix: Remove obsolete network controller state properties

### DIFF
--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -360,7 +360,7 @@ async function loadPhishingWarningPage() {
   } catch (error) {
     if (error instanceof PhishingWarningPageTimeoutError) {
       console.warn(
-        'Phishing warning page timeout; page not guaraneteed to work offline.',
+        'Phishing warning page timeout; page not guaranteed to work offline.',
       );
     } else {
       console.error('Failed to initialize phishing warning page', error);

--- a/app/scripts/migrations/092.2.test.ts
+++ b/app/scripts/migrations/092.2.test.ts
@@ -1,5 +1,6 @@
 import { NetworkType, toHex } from '@metamask/controller-utils';
 import { NetworkStatus } from '@metamask/network-controller';
+import { cloneDeep } from 'lodash';
 import { version as currentStateVersion, migrate } from './092.2';
 
 const TEST_NETWORK_CONTROLLER_STATE = {
@@ -37,7 +38,7 @@ describe('migration #96', () => {
       data: {},
     };
 
-    const newStorage = await migrate(originalVersionedState);
+    const newStorage = await migrate(cloneDeep(originalVersionedState));
 
     expect(newStorage.meta).toStrictEqual({ version: currentStateVersion });
   });

--- a/app/scripts/migrations/092.2.test.ts
+++ b/app/scripts/migrations/092.2.test.ts
@@ -52,7 +52,9 @@ describe('migration #96', () => {
       data: originalMetaMaskState,
     };
 
-    const updatedVersionedState = await migrate(originalVersionedState);
+    const updatedVersionedState = await migrate(
+      cloneDeep(originalVersionedState),
+    );
     expect(updatedVersionedState.data).toStrictEqual(originalMetaMaskState);
   });
 
@@ -66,7 +68,9 @@ describe('migration #96', () => {
       data: originalMetaMaskState,
     };
 
-    const updatedVersionedState = await migrate(originalVersionedState);
+    const updatedVersionedState = await migrate(
+      cloneDeep(originalVersionedState),
+    );
     expect(updatedVersionedState.data).toStrictEqual(originalMetaMaskState);
   });
 
@@ -83,7 +87,9 @@ describe('migration #96', () => {
       data: originalMetaMaskState,
     };
 
-    const updatedVersionedState = await migrate(originalVersionedState);
+    const updatedVersionedState = await migrate(
+      cloneDeep(originalVersionedState),
+    );
     expect(updatedVersionedState.data).not.toStrictEqual(originalMetaMaskState);
     expect(updatedVersionedState.data).toStrictEqual({
       anotherController: 'another-controller-state',

--- a/app/scripts/migrations/092.2.test.ts
+++ b/app/scripts/migrations/092.2.test.ts
@@ -1,0 +1,99 @@
+import { NetworkType } from '@metamask/controller-utils';
+import { NetworkStatus } from '@metamask/network-controller';
+import { migrate, version as currentStateVersion } from './092.2';
+
+const TEST_NETWORK_CONTROLLER_STATE = {
+  selectedNetworkClientId: 'test-network-client-id',
+  networkId: 'sdf',
+  providerConfig: {
+    type: NetworkType.rpc,
+    chainId: '0x9393',
+    nickname: 'Funky Town Chain',
+    ticker: 'ETH',
+    id: 'test-network-client-id',
+  },
+  networkConfigurations: {
+    'network-configuration-id-1': {
+      chainId: '0x539',
+      nickname: 'Localhost 8545',
+      rpcPrefs: {},
+      rpcUrl: 'http://localhost:8545',
+      ticker: 'ETH',
+    },
+  },
+  networksMetadata: {
+    'test-network-client-id': {
+      status: NetworkStatus.Available,
+      EIPS: {},
+    },
+  },
+};
+
+const anyPreviousStateVersion = Math.floor(
+  Math.random() * (currentStateVersion - 1) + 1,
+);
+
+describe('migration #96', () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('should update the state version number in the appropriate metadata field', async () => {
+    const originalVersionedState = {
+      meta: { version: anyPreviousStateVersion },
+      data: {},
+    };
+
+    const newStorage = await migrate(originalVersionedState);
+
+    expect(newStorage.meta).toStrictEqual({ version: currentStateVersion });
+  });
+
+  it('should return state unaltered if there is no network controller state', async () => {
+    const originalMetaMaskState = {
+      anotherController: 'another-controller-state',
+    };
+    const originalVersionedState = {
+      meta: { version: anyPreviousStateVersion },
+      data: originalMetaMaskState,
+    };
+
+    const updatedVersionedState = await migrate(originalVersionedState);
+    expect(updatedVersionedState.data).toStrictEqual(originalMetaMaskState);
+  });
+
+  it('should return unaltered state if there are no obsolete network controller state properties', async () => {
+    const originalMetaMaskState = {
+      anotherController: 'another-controller-state',
+      NetworkController: TEST_NETWORK_CONTROLLER_STATE,
+    };
+    const originalVersionedState = {
+      meta: { version: anyPreviousStateVersion },
+      data: originalMetaMaskState,
+    };
+
+    const updatedVersionedState = await migrate(originalVersionedState);
+    expect(updatedVersionedState.data).toStrictEqual(originalMetaMaskState);
+  });
+
+  it('should return updated state without obsolete network controller state properties', async () => {
+    const originalMetaMaskState = {
+      anotherController: 'another-controller-state',
+      NetworkController: {
+        ...TEST_NETWORK_CONTROLLER_STATE,
+        someSortOfRogueObsoleteStateProperty: 'exists',
+      },
+    };
+    const originalVersionedState = {
+      meta: { version: anyPreviousStateVersion },
+      data: originalMetaMaskState,
+    };
+
+    const updatedVersionedState = await migrate(originalVersionedState);
+    expect(updatedVersionedState.data).not.toStrictEqual(originalMetaMaskState);
+    expect(updatedVersionedState.data).toStrictEqual({
+      anotherController: 'another-controller-state',
+      NetworkController: TEST_NETWORK_CONTROLLER_STATE,
+    });
+  });
+});

--- a/app/scripts/migrations/092.2.test.ts
+++ b/app/scripts/migrations/092.2.test.ts
@@ -1,37 +1,30 @@
-import { NetworkType } from '@metamask/controller-utils';
+import { NetworkType, toHex } from '@metamask/controller-utils';
 import { NetworkStatus } from '@metamask/network-controller';
-import { migrate, version as currentStateVersion } from './092.2';
+import { version as currentStateVersion, migrate } from './092.2';
 
 const TEST_NETWORK_CONTROLLER_STATE = {
-  selectedNetworkClientId: 'test-network-client-id',
-  networkId: 'sdf',
+  networkId: 'network-id',
+  networkStatus: NetworkStatus.Available,
   providerConfig: {
     type: NetworkType.rpc,
-    chainId: '0x9393',
+    chainId: toHex(42),
     nickname: 'Funky Town Chain',
     ticker: 'ETH',
     id: 'test-network-client-id',
   },
+  networkDetails: { EIPS: {} },
   networkConfigurations: {
     'network-configuration-id-1': {
-      chainId: '0x539',
+      chainId: toHex(42),
       nickname: 'Localhost 8545',
       rpcPrefs: {},
       rpcUrl: 'http://localhost:8545',
       ticker: 'ETH',
     },
   },
-  networksMetadata: {
-    'test-network-client-id': {
-      status: NetworkStatus.Available,
-      EIPS: {},
-    },
-  },
 };
 
-const anyPreviousStateVersion = Math.floor(
-  Math.random() * (currentStateVersion - 1) + 1,
-);
+const anyPreviousStateVersion = 91;
 
 describe('migration #96', () => {
   afterEach(() => {

--- a/app/scripts/migrations/092.2.ts
+++ b/app/scripts/migrations/092.2.ts
@@ -72,6 +72,4 @@ function filterOutObsoleteNetworkControllerStateProperties(
     ...state,
     NetworkController: updatedNetworkController,
   };
-
-  return state;
 }

--- a/app/scripts/migrations/092.2.ts
+++ b/app/scripts/migrations/092.2.ts
@@ -1,0 +1,66 @@
+import { cloneDeep } from 'lodash';
+
+type MetaMaskState = Record<string, unknown>;
+type VersionedState = {
+  meta: { version: number };
+  data: MetaMaskState;
+};
+
+export const version = 92.2;
+
+/**
+ * This migration removes obsolete NetworkController state properties.
+ *
+ * @param originalVersionedState - Versioned MetaMask extension state, exactly what we persist to dist.
+ * @param originalVersionedState.meta - State metadata.
+ * @param originalVersionedState.meta.version - The current state version.
+ * @param originalVersionedState.data - The persisted MetaMask state, keyed by controller.
+ * @returns Updated versioned of MetaMask extension state.
+ */
+export async function migrate(
+  originalVersionedState: VersionedState,
+): Promise<VersionedState> {
+  const updatedVersionedState = cloneDeep(originalVersionedState);
+
+  updatedVersionedState.meta.version = version;
+  updatedVersionedState.data = transformState(updatedVersionedState.data);
+
+  return updatedVersionedState;
+}
+
+function transformState(originalState: MetaMaskState): MetaMaskState {
+  const updatedState =
+    filterOutObsoleteNetworkControllerStateProperties(originalState);
+
+  return updatedState;
+}
+
+function filterOutObsoleteNetworkControllerStateProperties(
+  state: MetaMaskState,
+): MetaMaskState {
+  // https://github.com/MetaMask/core/blob/%40metamask/network-controller%4010.3.1/packages/network-controller/src/NetworkController.ts#L336-L342
+  const CURRENT_NETWORK_CONTROLLER_STATE_PROPS = [
+    'networkId',
+    'networkStatus',
+    'providerConfig',
+    'networkDetails',
+    'networkConfigurations',
+  ];
+
+  const networkControllerState: Record<string, any> =
+    state.NetworkController || {};
+  const networkControllerStateProps = Object.keys(networkControllerState);
+
+  // delete network state properties that are not currently in use
+  for (let p = 0; p < networkControllerStateProps.length; p++) {
+    if (
+      !CURRENT_NETWORK_CONTROLLER_STATE_PROPS.includes(
+        networkControllerStateProps[p],
+      )
+    ) {
+      delete networkControllerState[networkControllerStateProps[p]];
+    }
+  }
+
+  return state;
+}

--- a/app/scripts/migrations/index.js
+++ b/app/scripts/migrations/index.js
@@ -97,6 +97,7 @@ import * as m090 from './090';
 import * as m091 from './091';
 import * as m092 from './092';
 import * as m092point1 from './092.1';
+import * as m092point2 from './092.2';
 import * as m092point3 from './092.3';
 import * as m093 from './093';
 import * as m094 from './094';
@@ -196,6 +197,7 @@ const migrations = [
   m091,
   m092,
   m092point1,
+  m092point2,
   m092point3,
   m093,
   m094,


### PR DESCRIPTION
## Explanation

There have been user reports and Sentry monitoring errors regarding invalid network controller states.

Implements a new migration that removes any top-level properties on the network controller state object that are not expected, as per the latest `NetworkState` type [on the core repository](https://github.com/MetaMask/core/blob/5a3e28fc2e00cb4ce3db2c6b4bed298c495f28de/packages/network-controller/src/NetworkController.ts#L336-L342):

Currently, this migration makes no changes to obsolete properties at deeper levels of the state object of that controller.

Fixes: #20574