### PR TITLE
fix(878): fix toggle align styles for eth-sign in settings

### DIFF
--- a/ui/pages/settings/advanced-tab/__snapshots__/advanced-tab.component.test.js.snap
+++ b/ui/pages/settings/advanced-tab/__snapshots__/advanced-tab.component.test.js.snap
@@ -586,7 +586,7 @@ exports[`AdvancedTab Component should match snapshot 1`] = `
       </div>
     </div>
     <div
-      class="mm-box settings-page__content-row mm-box--display-flex mm-box--flex-direction-row mm-box--justify-content-space-between"
+      class="mm-box settings-page__content-row mm-box--display-flex mm-box--flex-direction-column"
       data-testid="advanced-setting-toggle-ethsign"
     >
       <div

--- a/ui/pages/settings/advanced-tab/advanced-tab.component.js
+++ b/ui/pages/settings/advanced-tab/advanced-tab.component.js
@@ -10,7 +10,7 @@ import {
   Display,
   FlexDirection,
   JustifyContent,
-  SEVERITIES,
+  Severity,
   TextVariant,
 } from '../../../helpers/constants/design-system';
 import { getPlatform } from '../../../../app/scripts/lib/util';
@@ -600,8 +600,7 @@ export default class AdvancedTab extends PureComponent {
         className="settings-page__content-row"
         data-testid="advanced-setting-toggle-ethsign"
         display={Display.Flex}
-        flexDirection={FlexDirection.Row}
-        justifyContent={JustifyContent.spaceBetween}
+        flexDirection={FlexDirection.Column}
       >
         <div className="settings-page__content-item">
           <span>{t('toggleEthSignField')}</span>
@@ -609,11 +608,11 @@ export default class AdvancedTab extends PureComponent {
             {t('toggleEthSignDescriptionField')}
           </div>
         </div>
-
         {disabledRpcMethodPreferences?.eth_sign ? (
           <BannerAlert
-            severity={SEVERITIES.DANGER}
-            marginBottom={5}
+            severity={Severity.Danger}
+            marginTop={3}
+            marginBottom={4}
             descriptionProps={{ variant: TextVariant.bodyMd }}
           >
             {t('toggleEthSignBannerDescription')}


### PR DESCRIPTION
## Explanation
Introduced in [this MR](https://github.com/MetaMask/metamask-extension/pull/20363), there is a style alignment issue for eth-sign for settings. 

<!--
Thanks for the pull request. Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues, Slack conversations, Zendesk issues, user stories, etc. reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

## Screenshots/Screencaps

<!-- If you're making a change to the UI, make sure to capture a screenshot or a short video showing off your work! -->

### Before
<img width="1005" alt="Screenshot 2023-08-24 at 11 36 25" src="https://github.com/MetaMask/metamask-extension/assets/12678455/4b1786e8-13eb-4eee-82ae-80f9386abbad">
<img width="996" alt="Screenshot 2023-08-24 at 11 36 55" src="https://github.com/MetaMask/metamask-extension/assets/12678455/fd0ef064-7f83-45ff-a728-8505c56b434b">

### After

<img width="1000" alt="Screenshot 2023-08-24 at 11 45 32" src="https://github.com/MetaMask/metamask-extension/assets/12678455/c74b11a6-8e5d-4af8-89be-fcf38174bae0">

<img width="989" alt="Screenshot 2023-08-24 at 11 44 13" src="https://github.com/MetaMask/metamask-extension/assets/12678455/cba18a4e-0602-425a-ab0e-e03e703b027d">


## Manual Testing Steps

<!--
How should reviewers and QA manually test your changes? For instance:

- Go to this screen
- Do this
- Then do this
-->

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
