### PR TITLE
Deprecate Menu in favor of Popover #20499

### DIFF
--- a/ui/components/ui/menu/menu.js
+++ b/ui/components/ui/menu/menu.js
@@ -4,6 +4,14 @@ import { createPortal } from 'react-dom';
 import { usePopper } from 'react-popper';
 import classnames from 'classnames';
 
+/**
+ * @deprecated The `<Menu />` component has been deprecated in favor of the new `<Popover>` component from the component-library.
+ * Please update your code to use the new `<Popover>` component instead, which can be found at ui/components/component-library/popover/popover.tsx.
+ * You can find documentation for the new `Popover` component in the MetaMask Storybook:
+ * {@link https://metamask.github.io/metamask-storybook/?path=/docs/components-componentlibrary-popover--docs}
+ * If you would like to help with the replacement of the old `Menu` component, please submit a pull request against this GitHub issue:
+ * {@link https://github.com/MetaMask/metamask-extension/issues/20498}
+ */
 const Menu = ({
   anchorElement,
   children,


### PR DESCRIPTION
* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

There's an updation in the `menu.js` file (`ui/components/ui/menu/menu.js`)
- Added the deprecation JSDoc
- Old component has been deprecated (deprecation indicator shows up in VS Code)

Are there any issues, Slack conversations, Zendesk issues, user stories, etc. reviewers should consult to understand this pull request better? For instance:

No issues, Everythings Fine.
-->
