### PR TITLE
Always show connected accounts permissions if they exist

### DIFF
--- a/ui/pages/connected-accounts/connected-accounts.component.js
+++ b/ui/pages/connected-accounts/connected-accounts.component.js
@@ -65,9 +65,9 @@ export default class ConnectedAccounts extends PureComponent {
         onClose={() => history.push(mostRecentOverviewPage)}
         footerClassName="connected-accounts__footer"
         footer={
-          connectedAccounts.length ? (
+          permissions.length > 0 && (
             <ConnectedAccountsPermissions permissions={permissions} />
-          ) : null
+          )
         }
       >
         <ConnectedAccountsList

--- a/ui/pages/connected-accounts/connected-accounts.component.js
+++ b/ui/pages/connected-accounts/connected-accounts.component.js
@@ -65,7 +65,7 @@ export default class ConnectedAccounts extends PureComponent {
         onClose={() => history.push(mostRecentOverviewPage)}
         footerClassName="connected-accounts__footer"
         footer={
-          permissions.length > 0 && (
+          permissions?.length > 0 && (
             <ConnectedAccountsPermissions permissions={permissions} />
           )
         }


### PR DESCRIPTION
## Explanation

This fixes a regression introduced in #20036. Previously, the "connected accounts permissions" component would only be rendered if the site has any connected accounts, not keeping connected snaps in mind. I've fixed this by checking for `permissions.length`, rather than `connectedAccounts.length`. This makes sure that snap permissions show, even if the site does not have any connected accounts.

## Screenshots/Screencaps

### Before

<img width="364" alt="image" src="https://github.com/MetaMask/metamask-extension/assets/7503723/d47f60c4-bf40-494d-8ead-1d847ffe10dd">

### After

<img width="361" alt="image" src="https://github.com/MetaMask/metamask-extension/assets/7503723/4ca0a1cd-6d0f-48c4-bde3-8c8bc2f0ffb2">

## Pre-merge author checklist

- [ ] I've clearly explained:
  - [ ] What problem this PR is solving
  - [ ] How this problem was solved
  - [ ] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone