### PR TITLE
Fix Sentry source maps

### DIFF
--- a/development/sentry-upload-artifacts.sh
+++ b/development/sentry-upload-artifacts.sh
@@ -31,7 +31,7 @@ function upload_sourcemaps {
   local release="${1}"; shift
   local dist_directory="${1}"; shift
 
-  sentry-cli releases files "${release}" upload-sourcemaps "${dist_directory}"/chrome/*.js "${dist_directory}"/sourcemaps/ --rewrite --url-prefix 'metamask'
+  sentry-cli releases files "${release}" upload-sourcemaps "${dist_directory}"/chrome/*.js "${dist_directory}"/sourcemaps/ --rewrite --url-prefix '/metamask'
 }
 
 function main {


### PR DESCRIPTION
## Explanation

Sentry source maps were broken a few weeks back, and then fixed in the PR #20122. The fix was to add a leading slash to our file paths in the source maps.

This fix was accidentally undone recently in #19552, which is an otherwise unrelated change. I suspect this was committed accidentally due to local testing of #20122 around the same time.

This PR restores the file path change made in #20122

## Manual Testing Steps

Use the testing steps described here: https://github.com/MetaMask/metamask-extension/pull/20122

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
