### PR TITLE
deprecating NetworkDisplay in favour of PickerNetwork

### DIFF
--- a/ui/components/app/network-display/network-display.js
+++ b/ui/components/app/network-display/network-display.js
@@ -22,6 +22,15 @@ import { Icon, IconName, IconSize } from '../../component-library';
 import { getProviderConfig } from '../../../ducks/metamask/metamask';
 import { getNetworkLabelKey } from '../../../helpers/utils/i18n-helper';
 
+/**
+ * @deprecated The `<NetworkDisplay />` component has been deprecated in favor of the new `<PickerNetwork>` component from the component-library.
+ * Please update your code to use the new `<PickerNetwork>` component instead, which can be found at ui/components/component-library/picker-network/picker-network.tsx.
+ * You can find documentation for the new `PickerNetwork` component in the MetaMask Storybook:
+ * {@link https://metamask.github.io/metamask-storybook/?path=/docs/components-componentlibrary-pickernetwork--docs}
+ * If you would like to help with the replacement of the old `NetworkDisplay` component, please submit a pull request against this GitHub issue:
+ * {@link https://github.com/MetaMask/metamask-extension/issues/20485}
+ */
+
 export default function NetworkDisplay({
   indicatorSize,
   disabled,

--- a/ui/components/app/network-display/network-display.stories.js
+++ b/ui/components/app/network-display/network-display.stories.js
@@ -4,8 +4,9 @@ import {
   BUILT_IN_NETWORKS,
   NETWORK_TYPES,
 } from '../../../../shared/constants/network';
-import { Size } from '../../../helpers/constants/design-system';
+import { Severity, Size } from '../../../helpers/constants/design-system';
 
+import { BannerAlert } from '../../component-library/banner-alert';
 import NetworkDisplay from '.';
 
 export default {
@@ -38,13 +39,26 @@ export default {
 };
 
 export const DefaultStory = (args) => (
-  <NetworkDisplay
-    {...args}
-    targetNetwork={{
-      type: args.targetNetwork,
-      nickname: args.targetNetwork,
-    }}
-  />
+  <>
+    <BannerAlert
+      severity={Severity.Warning}
+      title="Deprecated"
+      description="The <NetworkDisplay> component has been deprecated in favor of the new <PickerNetwork> component from the component-library.
+        Please update your code to use the new <PickerNetwork> component instead, which can be found at ui/components/component-library/picker-network/picker-network.tsx."
+      actionButtonLabel="See details"
+      actionButtonProps={{
+        href: 'https://github.com/MetaMask/metamask-extension/issues/20485',
+      }}
+      marginBottom={4}
+    />
+    <NetworkDisplay
+      {...args}
+      targetNetwork={{
+        type: args.targetNetwork,
+        nickname: args.targetNetwork,
+      }}
+    />
+  </>
 );
 
 DefaultStory.storyName = 'Default';


### PR DESCRIPTION
## Explanation

- fixes #20486

## Screenshots/Screencaps
### After

![image](https://github.com/MetaMask/metamask-extension/assets/79097544/d49a1c16-99df-43df-9357-7b4a11e3c933)
![image](https://github.com/MetaMask/metamask-extension/assets/79097544/4854b849-f59d-4e50-afa9-d5710116393c)

## Manual Testing Steps
- check deprecation message on `NetworkDisplay` story and component on this branch

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
