### PR TITLE
deprecating Dialog in favour of BannerAlert

### DIFF
--- a/ui/components/ui/dialog/dialog.stories.js
+++ b/ui/components/ui/dialog/dialog.stories.js
@@ -1,4 +1,6 @@
 import React from 'react';
+import { BannerAlert } from '../../component-library';
+import { Severity } from '../../../helpers/constants/design-system';
 import README from './README.mdx';
 import Dialog from '.';
 
@@ -19,9 +21,22 @@ export default {
   },
 };
 
-export const DefaultDialog = (args) => {
-  return <Dialog {...args} />;
-};
+export const DefaultDialog = (args) => (
+  <>
+    <BannerAlert
+      severity={Severity.Warning}
+      title="Deprecated"
+      description="The <Dialog> component has been deprecated in favor of the new <BannerAlert> component from the component-library.
+      If you would like to help with the replacement of the old Dialog component, please submit a pull request to metamask-extension"
+      actionButtonLabel="See details"
+      actionButtonProps={{
+        href: 'https://github.com/MetaMask/metamask-extension/issues/20463',
+      }}
+      marginBottom={4}
+    />
+    <Dialog {...args} />
+  </>
+);
 
 DefaultDialog.storyName = 'Default';
 DefaultDialog.args = {

--- a/ui/components/ui/dialog/index.js
+++ b/ui/components/ui/dialog/index.js
@@ -2,6 +2,15 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 
+/**
+ * @deprecated The `<Dialog />` component has been deprecated in favor of the new `<BannerAlert>` component from the component-library.
+ * Please update your code to use the new `<BannerAlert>` component instead, which can be found at ui/components/component-library/banner-alert/banner-alert.js.
+ * You can find documentation for the new `BannerAlert` component in the MetaMask Storybook:
+ * {@link https://metamask.github.io/metamask-storybook/?path=/docs/components-componentlibrary-banneralert--docs}
+ * If you would like to help with the replacement of the old `Dialog` component, please submit a pull request against this GitHub issue:
+ * {@link https://github.com/MetaMask/metamask-extension/issues/20463}
+ */
+
 export default function Dialog(props) {
   const { children, type, className, onClick } = props;
   return (


### PR DESCRIPTION
## Explanation
- fixes #20464 

## Screenshots/Screencaps

### After
![image](https://github.com/MetaMask/metamask-extension/assets/79097544/207fb52a-5071-47fd-92fe-373b40c77134)
![image](https://github.com/MetaMask/metamask-extension/assets/79097544/a06149ad-1b75-44a2-8485-a5ad51a280b7)


## Manual Testing Steps
- check deprecation message on `Dialog` story and component on this branch

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
