### PR TITLE
Track snap uninstalls

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -2082,15 +2082,6 @@ export default class MetamaskController extends EventEmitter {
     this.controllerMessenger.subscribe(
       `${this.snapController.name}:snapRemoved`,
       (truncatedSnap) => {
-        this.metaMetricsController.trackEvent({
-          event: MetaMetricsEventName.SnapUninstalled,
-          category: MetaMetricsEventCategory.Snaps,
-          properties: {
-            snap_id: truncatedSnap.id,
-            version: truncatedSnap.version,
-          },
-        });
-
         const notificationIds = Object.values(
           this.notificationController.state.notifications,
         ).reduce((idList, notification) => {
@@ -2101,6 +2092,15 @@ export default class MetamaskController extends EventEmitter {
         }, []);
 
         this.dismissNotifications(notificationIds);
+
+        this.metaMetricsController.trackEvent({
+          event: MetaMetricsEventName.SnapUninstalled,
+          category: MetaMetricsEventCategory.Snaps,
+          properties: {
+            snap_id: truncatedSnap.id,
+            version: truncatedSnap.version,
+          },
+        });
       },
     );
 

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -2082,6 +2082,15 @@ export default class MetamaskController extends EventEmitter {
     this.controllerMessenger.subscribe(
       `${this.snapController.name}:snapRemoved`,
       (truncatedSnap) => {
+        this.metaMetricsController.trackEvent({
+          event: MetaMetricsEventName.SnapUninstalled,
+          category: MetaMetricsEventCategory.Snaps,
+          properties: {
+            snap_id: truncatedSnap.id,
+            version: truncatedSnap.version,
+          },
+        });
+
         const notificationIds = Object.values(
           this.notificationController.state.notifications,
         ).reduce((idList, notification) => {

--- a/shared/constants/metametrics.ts
+++ b/shared/constants/metametrics.ts
@@ -627,6 +627,7 @@ export enum MetaMetricsEventName {
   SwapError = 'Swap Error',
   ///: BEGIN:ONLY_INCLUDE_IN(snaps)
   SnapInstalled = 'Snap Installed',
+  SnapUninstalled = 'Snap Uninstalled',
   SnapUpdated = 'Snap Updated',
   SnapExportUsed = 'Snap Export Used',
   ///: END:ONLY_INCLUDE_IN


### PR DESCRIPTION
## Explanation

Fixes https://github.com/MetaMask/MetaMask-planning/issues/1241

Tracks snaps being uninstalled using the **opt-in** MetaMetrics program.

