### PR TITLE
Fixing linting issue on develop

### DIFF
--- a/ui/components/app/modals/hold-to-reveal-modal/hold-to-reveal-modal.tsx
+++ b/ui/components/app/modals/hold-to-reveal-modal/hold-to-reveal-modal.tsx
@@ -7,8 +7,8 @@ import {
 import ZENDESK_URLS from '../../../../helpers/constants/zendesk-url';
 import { useI18nContext } from '../../../../hooks/useI18nContext';
 import {
-  BUTTON_SIZES,
-  BUTTON_VARIANT,
+  ButtonSize,
+  ButtonVariant,
   Box,
   Button,
   Modal,
@@ -88,11 +88,10 @@ export default function HoldToRevealModal({
             </Text>,
             <Button
               key="hold-to-reveal-5"
-              variant={BUTTON_VARIANT.LINK}
-              size={BUTTON_SIZES.INHERIT}
+              variant={ButtonVariant.Link}
+              size={ButtonSize.Inherit}
               href={ZENDESK_URLS.NON_CUSTODIAL_WALLET}
-              target="_blank"
-              rel="noopener noreferrer"
+              externalLink
             >
               {t('holdToRevealContent5')}
             </Button>,


### PR DESCRIPTION
## Explanation

Fixing linting issue on `develop` caused by bad merge of HoldToRevealModal and the Button component library component TS migration which was causing a type error. This PR updates deprecated constants which will cause a type error if used in a `.tsx` file.

## Screenshots/Screencaps

### Before
https://app.circleci.com/pipelines/github/MetaMask/metamask-extension/55060/workflows/10a3e432-e9b1-4373-8ed2-360bad831d7f/jobs/1640202

<img width="1313" alt="Screenshot 2023-08-28 at 4 15 22 PM" src="https://github.com/MetaMask/metamask-extension/assets/8112138/a144767a-9b1d-4940-92b6-3d80ee916cf7">

### After
I got 14 problems but a type error ain't one

<img width="430" alt="Screenshot 2023-08-28 at 4 15 57 PM" src="https://github.com/MetaMask/metamask-extension/assets/8112138/987d493c-ecb9-4dda-8679-da73ccaf4316">


## Manual Testing Steps

- Pull this branch or depend on CI to pick up linting issue
- Manually run `yarn lint`
- See there are no linting issues

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
