### PR TITLE
Fix #682 - Show connected app favicon in bottom bar

### DIFF
--- a/ui/components/multichain/app-footer/app-footer.js
+++ b/ui/components/multichain/app-footer/app-footer.js
@@ -24,6 +24,7 @@ import {
   AlignItems,
   BackgroundColor,
   BlockSize,
+  BorderColor,
   BorderRadius,
   Display,
   FlexDirection,
@@ -141,29 +142,30 @@ export const AppFooter = () => {
         tabIndex={0}
       >
         {connectedSite ? (
-          <BadgeWrapper
-            display={Display.Flex}
-            className="app-footer__connected-badge"
-            badge={
-              <AvatarNetwork
-                backgroundColor={testNetworkBackgroundColor}
-                size={AvatarNetworkSize.Xs}
-                name={currentChain.nickname}
-                src={currentChain.rpcPrefs?.imageUrl}
-                borderWidth={2}
-                borderColor={BackgroundColor.backgroundDefault}
+          <Box alignItems={AlignItems.center}>
+            <BadgeWrapper
+              display={Display.Flex}
+              className="app-footer__connected-badge"
+              badge={
+                <AvatarNetwork
+                  backgroundColor={testNetworkBackgroundColor}
+                  size={AvatarNetworkSize.Xs}
+                  name={currentChain.nickname}
+                  src={currentChain.rpcPrefs?.imageUrl}
+                  borderWidth={2}
+                  borderColor={BorderColor.borderDefault}
+                />
+              }
+            >
+              <AvatarFavicon
+                size={Size.SM}
+                src={connectedAvatar}
+                name={connectedAvatarName}
               />
-            }
-          >
-            <AvatarFavicon
-              size={Size.SM}
-              src={connectedAvatar}
-              name={connectedAvatarName}
-            />
-          </BadgeWrapper>
+            </BadgeWrapper>
+          </Box>
         ) : (
           <Icon
-            data-testid="app-footer-connections-button"
             color={
               activeConnections
                 ? IconColor.primaryDefault

--- a/ui/components/multichain/app-footer/app-footer.js
+++ b/ui/components/multichain/app-footer/app-footer.js
@@ -1,11 +1,16 @@
 import React from 'react';
 import { useLocation } from 'react-router-dom';
 import { useDispatch } from 'react-redux';
+import { useSelector } from 'react-redux';
 import {
   CONNECTED_ROUTE,
   DEFAULT_ROUTE,
 } from '../../../helpers/constants/routes';
 import {
+  AvatarFavicon,
+  AvatarNetwork,
+  AvatarNetworkSize,
+  BadgeWrapper,
   Box,
   ButtonIcon,
   ButtonIconSize,
@@ -24,9 +29,17 @@ import {
   FlexDirection,
   IconColor,
   JustifyContent,
+  Size,
   TextColor,
   TextVariant,
 } from '../../../helpers/constants/design-system';
+import {
+  getConnectedSubjectsForAllAddresses,
+  getCurrentNetwork,
+  getOriginOfCurrentTab,
+  getSelectedAddress,
+  getTestNetworkBackgroundColor,
+} from '../../../selectors';
 import { showSelectActionModal } from './app-footer-actions';
 
 export const AppFooter = () => {
@@ -38,6 +51,20 @@ export const AppFooter = () => {
   const connectedRoute = `#${CONNECTED_ROUTE}`;
   const activeWallet = location.pathname === DEFAULT_ROUTE;
   const activeConnections = location.pathname === CONNECTED_ROUTE;
+
+  const selectedAddress = useSelector(getSelectedAddress);
+
+  const currentTabOrigin = useSelector(getOriginOfCurrentTab);
+  const connectedSites = useSelector(getConnectedSubjectsForAllAddresses);
+  const connectedSite = connectedSites[selectedAddress]?.find(
+    ({ origin }) => origin === currentTabOrigin,
+  );
+  const connectedAvatar = connectedSite?.iconUrl;
+  const connectedAvatarName = connectedSite?.name;
+
+  const testNetworkBackgroundColor = useSelector(getTestNetworkBackgroundColor);
+
+  const currentChain = useSelector(getCurrentNetwork);
 
   return (
     <Box
@@ -113,16 +140,39 @@ export const AppFooter = () => {
         alignItems={AlignItems.center}
         tabIndex={0}
       >
-        <Icon
-          data-testid="app-footer-connections-button"
-          color={
-            activeConnections
-              ? IconColor.primaryDefault
-              : IconColor.iconAlternative
-          }
-          name={IconName.Global}
-          size={IconSize.Lg}
-        />
+        {connectedSite ? (
+          <BadgeWrapper
+            display={Display.Flex}
+            className="app-footer__connected-badge"
+            badge={
+              <AvatarNetwork
+                backgroundColor={testNetworkBackgroundColor}
+                size={AvatarNetworkSize.Xs}
+                name={currentChain.nickname}
+                src={currentChain.rpcPrefs?.imageUrl}
+                borderWidth={2}
+                borderColor={BackgroundColor.backgroundDefault}
+              />
+            }
+          >
+            <AvatarFavicon
+              size={Size.SM}
+              src={connectedAvatar}
+              name={connectedAvatarName}
+            />
+          </BadgeWrapper>
+        ) : (
+          <Icon
+            data-testid="app-footer-connections-button"
+            color={
+              activeConnections
+                ? IconColor.primaryDefault
+                : IconColor.iconAlternative
+            }
+            name={IconName.Global}
+            size={IconSize.Lg}
+          />
+        )}
         <Text
           color={
             activeConnections

--- a/ui/components/multichain/app-footer/app-footer.js
+++ b/ui/components/multichain/app-footer/app-footer.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import { useLocation } from 'react-router-dom';
-import { useDispatch } from 'react-redux';
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import {
   CONNECTED_ROUTE,
   DEFAULT_ROUTE,

--- a/ui/components/multichain/app-footer/app-footer.scss
+++ b/ui/components/multichain/app-footer/app-footer.scss
@@ -5,4 +5,8 @@
   &__button {
     cursor: pointer;
   }
+
+  &__connected-badge {
+    align-self: center;
+  }
 }

--- a/ui/components/multichain/app-footer/app-footer.scss
+++ b/ui/components/multichain/app-footer/app-footer.scss
@@ -5,8 +5,4 @@
   &__button {
     cursor: pointer;
   }
-
-  &__connected-badge {
-    align-self: center;
-  }
 }

--- a/ui/components/multichain/app-footer/app-footer.stories.js
+++ b/ui/components/multichain/app-footer/app-footer.stories.js
@@ -1,9 +1,50 @@
 import React from 'react';
+import { Provider } from 'react-redux';
+import testData from '../../../../.storybook/test-data';
+import configureStore from '../../../store/store';
 import { AppFooter } from '.';
+
+const customNetworkData = {
+  ...testData,
+  activeTab: {
+    id: 1111,
+    title: 'Uniswap',
+    origin: 'https://app.uniswap.org',
+    protocol: 'https:',
+    url: 'https://app.uniswap.org/',
+  },
+  metamask: {
+    ...testData.metamask,
+    providerConfig: {
+      chainId: '0x1',
+    },
+    selectedAddress: '0x64a845a5b02460acf8a3d84503b0d68d028b4bb4',
+    subjectMetadata: {
+      ...testData.metamask.subjectMetadata,
+      'https://app.uniswap.org': {
+        extensionId: null,
+        iconUrl: 'https://app.uniswap.org/favicon.png',
+        name: 'Uniswap',
+        origin: 'https://app.uniswap.org',
+        subjectType: 'website',
+      },
+    },
+  },
+};
+const customNetworkStore = configureStore(customNetworkData);
 
 export default {
   title: 'Components/Multichain/AppFooter',
 };
 export const DefaultStory = () => <AppFooter />;
-
 DefaultStory.storyName = 'Default';
+
+export const ConnectedStory = () => <AppFooter />;
+ConnectedStory.storyName = 'Connected';
+ConnectedStory.decorators = [
+  (Story) => (
+    <Provider store={customNetworkStore}>
+      <Story />
+    </Provider>
+  ),
+];


### PR DESCRIPTION
## Explanation

* Fixes https://github.com/MetaMask/MetaMask-planning/issues/682

When the selected tab's origin is connected, show the app's favicon in the footer's "connected button"


## Screenshots/Screencaps

<img width="560" alt="SCR-20230828-pxcx" src="https://github.com/MetaMask/metamask-extension/assets/46655/158ab56b-ab9b-48ee-ac8c-da53665f06ed">



## Manual Testing Steps

View "App Footer > Connected" story in Storybook

## Pre-merge author checklist

- [ ] I've clearly explained:
  - [ ] What problem this PR is solving
  - [ ] How this problem was solved
  - [ ] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
