### PR TITLE
Declared <TextField/> as deprecated

### DIFF
--- a/ui/components/ui/text-field/text-field.component.js
+++ b/ui/components/ui/text-field/text-field.component.js
@@ -3,6 +3,15 @@ import PropTypes from 'prop-types';
 import { withStyles } from '@material-ui/core/styles';
 import MaterialTextField from '@material-ui/core/TextField';
 
+/**
+ * @deprecated The `<TextField />` component has been deprecated in favor of the new `<TextField>` component from the component-library.
+ * Please update your code to use the new `<TextField>` component instead, which can be found at ui/components/component-library/text-field/text-field.js.
+ * You can find documentation for the new `TextField` component in the MetaMask Storybook:
+ * {@link https://metamask.github.io/metamask-storybook/?path=/docs/components-componentlibrary-textfield--docs}
+ * If you would like to help with the replacement of the old `TextField` component, please submit a pull request against this GitHub issue:
+ * {@link https://github.com/MetaMask/metamask-extension/issues/20483}
+ */
+
 const inputLabelBase = {
   transform: 'none',
   transition: 'none',

--- a/ui/components/ui/text-field/text-field.stories.js
+++ b/ui/components/ui/text-field/text-field.stories.js
@@ -1,6 +1,25 @@
 import React from 'react';
+import PropTypes from 'prop-types';
+import { BannerAlert } from '../../component-library';
+import { Severity } from '../../../helpers/constants/design-system';
 import README from './README.mdx';
 import TextField from '.';
+
+const Deprecated = ({ children }) => (
+  <>
+    <BannerAlert
+      severity={Severity.Warning}
+      title="Deprecated"
+      description="<Menu/> has been deprecated in favor of <Popover/>"
+      marginBottom={4}
+    />
+    {children}
+  </>
+);
+
+Deprecated.propTypes = {
+  children: PropTypes.node,
+};
 
 export default {
   title: 'Components/UI/TextField',
@@ -27,46 +46,74 @@ export default {
   },
 };
 
-export const DefaultStory = (args) => <TextField {...args} />;
+export const DefaultStory = (args) => (
+  <Deprecated>
+    <TextField {...args} />
+  </Deprecated>
+);
 DefaultStory.storyName = 'Default';
 DefaultStory.args = {
   label: 'Text',
   type: 'text',
 };
 
-export const Password = (args) => <TextField {...args} />;
+export const Password = (args) => (
+  <Deprecated>
+    <TextField {...args} />
+  </Deprecated>
+);
 Password.args = {
   label: 'Password',
   type: 'password',
 };
-export const TextError = (args) => <TextField {...args} />;
+export const TextError = (args) => (
+  <Deprecated>
+    <TextField {...args} />
+  </Deprecated>
+);
 TextError.args = {
   type: 'text',
   label: 'Name',
   error: 'Invalid Value',
 };
-export const MascaraText = (args) => <TextField {...args} />;
+export const MascaraText = (args) => (
+  <Deprecated>
+    <TextField {...args} />
+  </Deprecated>
+);
 MascaraText.args = {
   label: 'Text',
   type: 'text',
   largeLabel: true,
 };
 
-export const MaterialText = (args) => <TextField {...args} />;
+export const MaterialText = (args) => (
+  <Deprecated>
+    <TextField {...args} />
+  </Deprecated>
+);
 MaterialText.args = {
   label: 'Text',
   type: 'text',
   theme: 'material',
 };
 
-export const MaterialPassword = (args) => <TextField {...args} />;
+export const MaterialPassword = (args) => (
+  <Deprecated>
+    <TextField {...args} />
+  </Deprecated>
+);
 MaterialPassword.args = {
   label: 'Password',
   type: 'password',
   theme: 'material',
 };
 
-export const MaterialError = (args) => <TextField {...args} />;
+export const MaterialError = (args) => (
+  <Deprecated>
+    <TextField {...args} />
+  </Deprecated>
+);
 MaterialError.args = {
   type: 'text',
   label: 'Name',

--- a/ui/components/ui/text-field/text-field.stories.js
+++ b/ui/components/ui/text-field/text-field.stories.js
@@ -10,7 +10,7 @@ const Deprecated = ({ children }) => (
     <BannerAlert
       severity={Severity.Warning}
       title="Deprecated"
-      description="<Menu/> has been deprecated in favor of <Popover/>"
+      description="<TextField/> has been deprecated in favor of <TextField/>"
       marginBottom={4}
     />
     {children}


### PR DESCRIPTION
## Explanation
Added JsDoc to the deprecated component `<TextField/>`
Added deprecation notice to `text-filed.stories.js`
Fixes https://github.com/MetaMask/metamask-extension/issues/20484


<img width="1280" alt="Screenshot 2023-08-29 at 11 35 06 AM" src="https://github.com/MetaMask/metamask-extension/assets/99127578/b686e9ab-bc2d-45c7-b468-8433901f1cbb">
 -
<img width="1280" alt="Screenshot 2023-08-29 at 11 36 16 AM" src="https://github.com/MetaMask/metamask-extension/assets/99127578/afeb01f8-7549-4234-9ae4-643cc6e1436e">
<img width="1280" alt="Screenshot 2023-08-29 at 11 42 53 AM" src="https://github.com/MetaMask/metamask-extension/assets/99127578/ad90962d-850f-4f5c-a051-01d1b0f336ed">



<!--
Thanks for the pull request. Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues, Slack conversations, Zendesk issues, user stories, etc. reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

## Screenshots/Screencaps

<!-- If you're making a change to the UI, make sure to capture a screenshot or a short video showing off your work! -->

### Before

<!-- How did the UI you changed look before your changes? Drag your file(s) below this line: -->

### After

<!-- How does it look now? Drag your file(s) below this line: -->

## Manual Testing Steps

<!--
How should reviewers and QA manually test your changes? For instance:

- Go to this screen
- Do this
- Then do this
-->

## Pre-merge author checklist

- [X] I've clearly explained:
  - [X] What problem this PR is solving
  - [X] How this problem was solved
  - [X] How reviewers can test my changes
- [X] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
