### PR TITLE
Remove `loadingDefaults` property from `TransactionController`

### DIFF
--- a/.storybook/initial-states/approval-screens/token-approval.js
+++ b/.storybook/initial-states/approval-screens/token-approval.js
@@ -4,7 +4,7 @@ export const currentNetworkTxListSample = {
   "status": "unapproved",
   "metamaskNetworkId": "1337",
   "chainId": "0x539",
-  "loadingDefaults": false,
+
   "txParams": {
     "from": "0x90f79bf6eb2c4f870365e785982e1f101e93b906",
     "to": "0x057ef64e23666f000b34ae31332854acbd1c8544",
@@ -22,7 +22,7 @@ export const currentNetworkTxListSample = {
       "status": "unapproved",
       "metamaskNetworkId": "1337",
       "chainId": "0x539",
-      "loadingDefaults": true,
+
       "txParams": {
         "from": "0x90f79bf6eb2c4f870365e785982e1f101e93b906",
         "to": "0x057ef64e23666f000b34ae31332854acbd1c8544",
@@ -33,16 +33,7 @@ export const currentNetworkTxListSample = {
       },
       "origin": "https://metamask.github.io",
       "type": "approve"
-    },
-    [
-      {
-        "op": "replace",
-        "path": "/loadingDefaults",
-        "value": false,
-        "note": "Added new unapproved transaction.",
-        "timestamp": 1621395091742
-      }
-    ]
+    }
   ]
 }
 

--- a/.storybook/initial-states/approval-screens/token-approval.js
+++ b/.storybook/initial-states/approval-screens/token-approval.js
@@ -4,7 +4,6 @@ export const currentNetworkTxListSample = {
   "status": "unapproved",
   "metamaskNetworkId": "1337",
   "chainId": "0x539",
-
   "txParams": {
     "from": "0x90f79bf6eb2c4f870365e785982e1f101e93b906",
     "to": "0x057ef64e23666f000b34ae31332854acbd1c8544",
@@ -22,7 +21,6 @@ export const currentNetworkTxListSample = {
       "status": "unapproved",
       "metamaskNetworkId": "1337",
       "chainId": "0x539",
-
       "txParams": {
         "from": "0x90f79bf6eb2c4f870365e785982e1f101e93b906",
         "to": "0x057ef64e23666f000b34ae31332854acbd1c8544",

--- a/.storybook/initial-states/transactions.js
+++ b/.storybook/initial-states/transactions.js
@@ -347,7 +347,6 @@ export const MOCK_TRANSACTION_BY_TYPE = {
     originalGasEstimate: '14609',
     userEditedGasLimit: false,
     chainId: '0x5',
-
     dappSuggestedGasFees: null,
     sendFlowHistory: [],
     txParams: {
@@ -377,7 +376,6 @@ export const MOCK_TRANSACTION_BY_TYPE = {
         originalGasEstimate: '14609',
         userEditedGasLimit: false,
         chainId: '0x5',
-
         dappSuggestedGasFees: null,
         sendFlowHistory: [],
         txParams: {
@@ -587,7 +585,6 @@ export const MOCK_TRANSACTION_BY_TYPE = {
     time: 1589314601567,
     status: 'confirmed',
     metamaskNetworkId: '5',
-
     txParams: {
       from: '0xabca64466f257793eaa52fcfff5066894b76a149',
       to: '0xefg5bc4e8f1f969934d773fa67da095d2e491a97',
@@ -665,7 +662,6 @@ export const MOCK_TRANSACTION_BY_TYPE = {
     originalGasEstimate: '0xb427',
     userEditedGasLimit: false,
     chainId: '0x5',
-
     dappSuggestedGasFees: {
       gasPrice: '0x4a817c800',
       gas: '0xb427',
@@ -693,7 +689,6 @@ export const MOCK_TRANSACTION_BY_TYPE = {
         originalGasEstimate: '0xb427',
         userEditedGasLimit: false,
         chainId: '0x5',
-
         dappSuggestedGasFees: {
           gasPrice: '0x4a817c800',
           gas: '0xb427',
@@ -914,7 +909,6 @@ export const MOCK_TRANSACTION_BY_TYPE = {
     originalGasEstimate: '0x118e0',
     userEditedGasLimit: false,
     chainId: '0x5',
-
     dappSuggestedGasFees: {
       maxPriorityFeePerGas: '0x3B9ACA00',
       maxFeePerGas: '0x7be830aec',
@@ -1038,7 +1032,6 @@ export const MOCK_TRANSACTION_BY_TYPE = {
     originalGasEstimate: '0xea60',
     userEditedGasLimit: false,
     chainId: '0x5',
-
     dappSuggestedGasFees: {
       gasPrice: '0x4a817c800',
       gas: '0xea60',
@@ -1066,7 +1059,6 @@ export const MOCK_TRANSACTION_BY_TYPE = {
         originalGasEstimate: '0xea60',
         userEditedGasLimit: false,
         chainId: '0x5',
-
         dappSuggestedGasFees: {
           gasPrice: '0x4a817c800',
           gas: '0xea60',
@@ -1437,7 +1429,6 @@ export const MOCK_TRANSACTION_BY_TYPE = {
     originalGasEstimate: '0x10896',
     userEditedGasLimit: false,
     chainId: '0x5',
-
     dappSuggestedGasFees: null,
     sendFlowHistory: [
       {
@@ -1487,7 +1478,6 @@ export const MOCK_TRANSACTION_BY_TYPE = {
         originalGasEstimate: '0x10896',
         userEditedGasLimit: false,
         chainId: '0x5',
-
         dappSuggestedGasFees: null,
         sendFlowHistory: [
           {

--- a/.storybook/initial-states/transactions.js
+++ b/.storybook/initial-states/transactions.js
@@ -28,7 +28,6 @@ export const MOCK_TRANSACTION_BY_TYPE = {
     originalGasEstimate: '5208',
     userEditedGasLimit: false,
     chainId: '0x5',
-    loadingDefaults: false,
     dappSuggestedGasFees: null,
     sendFlowHistory: [],
     txParams: {
@@ -54,7 +53,6 @@ export const MOCK_TRANSACTION_BY_TYPE = {
         originalGasEstimate: '5208',
         userEditedGasLimit: false,
         chainId: '0x5',
-        loadingDefaults: false,
         dappSuggestedGasFees: null,
         sendFlowHistory: [],
         txParams: {
@@ -211,7 +209,6 @@ export const MOCK_TRANSACTION_BY_TYPE = {
       maxPriorityFeePerGas: '0x9502F900',
     },
     id: 7694052085150913,
-    loadingDefaults: true,
     metamaskNetworkId: '5',
     origin: 'https://remix.ethereum.org',
     originalGasEstimate: '0x118f4',
@@ -350,7 +347,7 @@ export const MOCK_TRANSACTION_BY_TYPE = {
     originalGasEstimate: '14609',
     userEditedGasLimit: false,
     chainId: '0x5',
-    loadingDefaults: false,
+
     dappSuggestedGasFees: null,
     sendFlowHistory: [],
     txParams: {
@@ -380,7 +377,7 @@ export const MOCK_TRANSACTION_BY_TYPE = {
         originalGasEstimate: '14609',
         userEditedGasLimit: false,
         chainId: '0x5',
-        loadingDefaults: false,
+
         dappSuggestedGasFees: null,
         sendFlowHistory: [],
         txParams: {
@@ -590,7 +587,7 @@ export const MOCK_TRANSACTION_BY_TYPE = {
     time: 1589314601567,
     status: 'confirmed',
     metamaskNetworkId: '5',
-    loadingDefaults: false,
+
     txParams: {
       from: '0xabca64466f257793eaa52fcfff5066894b76a149',
       to: '0xefg5bc4e8f1f969934d773fa67da095d2e491a97',
@@ -668,7 +665,7 @@ export const MOCK_TRANSACTION_BY_TYPE = {
     originalGasEstimate: '0xb427',
     userEditedGasLimit: false,
     chainId: '0x5',
-    loadingDefaults: false,
+
     dappSuggestedGasFees: {
       gasPrice: '0x4a817c800',
       gas: '0xb427',
@@ -696,7 +693,7 @@ export const MOCK_TRANSACTION_BY_TYPE = {
         originalGasEstimate: '0xb427',
         userEditedGasLimit: false,
         chainId: '0x5',
-        loadingDefaults: true,
+
         dappSuggestedGasFees: {
           gasPrice: '0x4a817c800',
           gas: '0xb427',
@@ -730,11 +727,6 @@ export const MOCK_TRANSACTION_BY_TYPE = {
           op: 'add',
           path: '/txParams/maxPriorityFeePerGas',
           value: '0x4a817c800',
-        },
-        {
-          op: 'replace',
-          path: '/loadingDefaults',
-          value: false,
         },
         {
           op: 'add',
@@ -922,7 +914,7 @@ export const MOCK_TRANSACTION_BY_TYPE = {
     originalGasEstimate: '0x118e0',
     userEditedGasLimit: false,
     chainId: '0x5',
-    loadingDefaults: false,
+
     dappSuggestedGasFees: {
       maxPriorityFeePerGas: '0x3B9ACA00',
       maxFeePerGas: '0x7be830aec',
@@ -1046,7 +1038,7 @@ export const MOCK_TRANSACTION_BY_TYPE = {
     originalGasEstimate: '0xea60',
     userEditedGasLimit: false,
     chainId: '0x5',
-    loadingDefaults: false,
+
     dappSuggestedGasFees: {
       gasPrice: '0x4a817c800',
       gas: '0xea60',
@@ -1074,7 +1066,7 @@ export const MOCK_TRANSACTION_BY_TYPE = {
         originalGasEstimate: '0xea60',
         userEditedGasLimit: false,
         chainId: '0x5',
-        loadingDefaults: true,
+
         dappSuggestedGasFees: {
           gasPrice: '0x4a817c800',
           gas: '0xea60',
@@ -1108,11 +1100,6 @@ export const MOCK_TRANSACTION_BY_TYPE = {
           op: 'add',
           path: '/txParams/maxPriorityFeePerGas',
           value: '0x4a817c800',
-        },
-        {
-          op: 'replace',
-          path: '/loadingDefaults',
-          value: false,
         },
         {
           op: 'add',
@@ -1450,7 +1437,7 @@ export const MOCK_TRANSACTION_BY_TYPE = {
     originalGasEstimate: '0x10896',
     userEditedGasLimit: false,
     chainId: '0x5',
-    loadingDefaults: false,
+
     dappSuggestedGasFees: null,
     sendFlowHistory: [
       {
@@ -1500,7 +1487,7 @@ export const MOCK_TRANSACTION_BY_TYPE = {
         originalGasEstimate: '0x10896',
         userEditedGasLimit: false,
         chainId: '0x5',
-        loadingDefaults: true,
+
         dappSuggestedGasFees: null,
         sendFlowHistory: [
           {
@@ -1542,13 +1529,6 @@ export const MOCK_TRANSACTION_BY_TYPE = {
         type: 'transferfrom',
       },
       [
-        {
-          op: 'replace',
-          path: '/loadingDefaults',
-          value: false,
-          note: 'Added new unapproved transaction.',
-          timestamp: 1653457323593,
-        },
         {
           op: 'add',
           path: '/userFeeLevel',

--- a/.storybook/test-data.js
+++ b/.storybook/test-data.js
@@ -574,7 +574,6 @@ const state = {
             chainId: '0x38',
             dappSuggestedGasFees: null,
             id: 2360388496987298,
-
             metamaskNetworkId: '56',
             origin: 'metamask',
             status: 'unapproved',
@@ -879,7 +878,6 @@ const state = {
           ],
         ],
         id: 7900715443136469,
-
         metamaskNetworkId: '56',
         nonceDetails: {
           local: {
@@ -1464,7 +1462,6 @@ const state = {
       status: 'unapproved',
       metamaskNetworkId: '5',
       chainId: '0x5',
-
       txParams: {
         from: '0x64a845a5b02460acf8a3d84503b0d68d028b4bb4',
         to: '0xaD6D458402F60fD3Bd25163575031ACDce07538D',
@@ -1483,7 +1480,6 @@ const state = {
           status: 'unapproved',
           metamaskNetworkId: '5',
           chainId: '0x5',
-
           txParams: {
             from: '0x983211ce699ea5ab57cc528086154b6db1ad8e55',
             to: '0xaD6D458402F60fD3Bd25163575031ACDce07538D',

--- a/.storybook/test-data.js
+++ b/.storybook/test-data.js
@@ -322,7 +322,6 @@ const state = {
         metamaskNetworkId: '5',
         msgParams: '0x64a845a5b02460acf8a3d84503b0d68d028b4bb4',
         chainId: '0x5',
-        loadingDefaults: false,
         txParams: {
           from: '0x64a845a5b02460acf8a3d84503b0d68d028b4bb4',
           to: '0xaD6D458402F60fD3Bd25163575031ACDce07538D',
@@ -341,7 +340,6 @@ const state = {
             status: 'unapproved',
             metamaskNetworkId: '5',
             chainId: '0x5',
-            loadingDefaults: true,
             txParams: {
               from: '0x64a845a5b02460acf8a3d84503b0d68d028b4bb4',
               to: '0xaD6D458402F60fD3Bd25163575031ACDce07538D',
@@ -353,16 +351,7 @@ const state = {
             type: 'standard',
             origin: 'metamask',
             transactionCategory: 'transfer',
-          },
-          [
-            {
-              op: 'replace',
-              path: '/loadingDefaults',
-              value: false,
-              note: 'Added new unapproved transaction.',
-              timestamp: 1620710815497,
-            },
-          ],
+          }
         ],
       },
     },
@@ -585,7 +574,7 @@ const state = {
             chainId: '0x38',
             dappSuggestedGasFees: null,
             id: 2360388496987298,
-            loadingDefaults: true,
+
             metamaskNetworkId: '56',
             origin: 'metamask',
             status: 'unapproved',
@@ -601,15 +590,6 @@ const state = {
             },
             type: 'transfer',
           },
-          [
-            {
-              note: 'Added new unapproved transaction.',
-              op: 'replace',
-              path: '/loadingDefaults',
-              timestamp: 1629582710530,
-              value: false,
-            },
-          ],
           [
             {
               note: 'txStateManager: setting status to approved',
@@ -899,7 +879,7 @@ const state = {
           ],
         ],
         id: 7900715443136469,
-        loadingDefaults: false,
+
         metamaskNetworkId: '56',
         nonceDetails: {
           local: {
@@ -1484,7 +1464,7 @@ const state = {
       status: 'unapproved',
       metamaskNetworkId: '5',
       chainId: '0x5',
-      loadingDefaults: false,
+
       txParams: {
         from: '0x64a845a5b02460acf8a3d84503b0d68d028b4bb4',
         to: '0xaD6D458402F60fD3Bd25163575031ACDce07538D',
@@ -1503,7 +1483,7 @@ const state = {
           status: 'unapproved',
           metamaskNetworkId: '5',
           chainId: '0x5',
-          loadingDefaults: true,
+
           txParams: {
             from: '0x983211ce699ea5ab57cc528086154b6db1ad8e55',
             to: '0xaD6D458402F60fD3Bd25163575031ACDce07538D',
@@ -1516,15 +1496,6 @@ const state = {
           origin: 'https://metamask.github.io',
           transactionCategory: 'approve',
         },
-        [
-          {
-            op: 'replace',
-            path: '/loadingDefaults',
-            value: false,
-            note: 'Added new unapproved transaction.',
-            timestamp: 1620723786844,
-          },
-        ],
       ],
     },
     tokenData: {

--- a/app/scripts/controllers/transactions/README.md
+++ b/app/scripts/controllers/transactions/README.md
@@ -31,7 +31,6 @@ txMeta = {
   "time": 1524094064821, // time of creation
   "status": "confirmed",
   "metamaskNetworkId": "1524091532133", //the network id for the transaction
-   // used to tell the ui when we are done calculating gas defaults
   "txParams": { // the txParams object
     "from": "0x8acce2391c0d510a6c5e5d8f819a678f79b7e675",
     "to": "0x8acce2391c0d510a6c5e5d8f819a678f79b7e675",
@@ -46,7 +45,6 @@ txMeta = {
       "time": 1524094064821,
       "status": "unapproved",
       "metamaskNetworkId": "1524091532133",
-
       "txParams": {
         "from": "0x8acce2391c0d510a6c5e5d8f819a678f79b7e675",
         "to": "0x8acce2391c0d510a6c5e5d8f819a678f79b7e675",

--- a/app/scripts/controllers/transactions/README.md
+++ b/app/scripts/controllers/transactions/README.md
@@ -31,7 +31,7 @@ txMeta = {
   "time": 1524094064821, // time of creation
   "status": "confirmed",
   "metamaskNetworkId": "1524091532133", //the network id for the transaction
-  "loadingDefaults": false, // used to tell the ui when we are done calculating gas defaults
+   // used to tell the ui when we are done calculating gas defaults
   "txParams": { // the txParams object
     "from": "0x8acce2391c0d510a6c5e5d8f819a678f79b7e675",
     "to": "0x8acce2391c0d510a6c5e5d8f819a678f79b7e675",
@@ -46,7 +46,7 @@ txMeta = {
       "time": 1524094064821,
       "status": "unapproved",
       "metamaskNetworkId": "1524091532133",
-      "loadingDefaults": true,
+
       "txParams": {
         "from": "0x8acce2391c0d510a6c5e5d8f819a678f79b7e675",
         "to": "0x8acce2391c0d510a6c5e5d8f819a678f79b7e675",

--- a/app/scripts/controllers/transactions/index.js
+++ b/app/scripts/controllers/transactions/index.js
@@ -566,7 +566,6 @@ export default class TransactionController extends EventEmitter {
         ...newGasParams,
       },
       previousGasParams,
-
       status: TransactionStatus.approved,
       type: TransactionType.cancel,
       actionId,
@@ -625,7 +624,6 @@ export default class TransactionController extends EventEmitter {
         ...newGasParams,
       },
       previousGasParams,
-
       status: TransactionStatus.approved,
       type: TransactionType.retry,
       originalType: originalTxMeta.type,

--- a/app/scripts/controllers/transactions/index.js
+++ b/app/scripts/controllers/transactions/index.js
@@ -566,7 +566,7 @@ export default class TransactionController extends EventEmitter {
         ...newGasParams,
       },
       previousGasParams,
-      loadingDefaults: false,
+
       status: TransactionStatus.approved,
       type: TransactionType.cancel,
       actionId,
@@ -625,7 +625,7 @@ export default class TransactionController extends EventEmitter {
         ...newGasParams,
       },
       previousGasParams,
-      loadingDefaults: false,
+
       status: TransactionStatus.approved,
       type: TransactionType.retry,
       originalType: originalTxMeta.type,
@@ -907,16 +907,12 @@ export default class TransactionController extends EventEmitter {
     } catch (error) {
       log.warn(error);
       updateTxMeta = this.txStateManager.getTransaction(txMeta.id);
-      updateTxMeta.loadingDefaults = false;
       this.txStateManager.updateTransaction(
         txMeta,
         'Failed to calculate gas defaults.',
       );
       throw error;
     }
-
-    updateTxMeta.loadingDefaults = false;
-
     // The history note used here 'Added new unapproved transaction.' is confusing update call only updated the gas defaults.
     // We need to improve `this._addTransaction` to accept history note and change note here.
     this.txStateManager.updateTransaction(
@@ -1966,13 +1962,11 @@ export default class TransactionController extends EventEmitter {
       .getTransactions({
         searchCriteria: {
           status: TransactionStatus.unapproved,
-          loadingDefaults: true,
         },
       })
       .forEach((tx) => {
         this._addTxGasDefaults(tx)
           .then((txMeta) => {
-            txMeta.loadingDefaults = false;
             this.txStateManager.updateTransaction(
               txMeta,
               'transactions: gas estimation for tx on boot',
@@ -1980,7 +1974,6 @@ export default class TransactionController extends EventEmitter {
           })
           .catch((error) => {
             const txMeta = this.txStateManager.getTransaction(tx.id);
-            txMeta.loadingDefaults = false;
             this.txStateManager.updateTransaction(
               txMeta,
               'failed to estimate gas during boot cleanup.',

--- a/app/scripts/controllers/transactions/tx-state-manager.js
+++ b/app/scripts/controllers/transactions/tx-state-manager.js
@@ -137,7 +137,6 @@ export default class TransactionStateManager extends EventEmitter {
       originalGasEstimate: opts.txParams?.gas,
       userEditedGasLimit: false,
       chainId,
-
       dappSuggestedGasFees,
       sendFlowHistory: [],
       ...opts,

--- a/app/scripts/controllers/transactions/tx-state-manager.js
+++ b/app/scripts/controllers/transactions/tx-state-manager.js
@@ -137,7 +137,7 @@ export default class TransactionStateManager extends EventEmitter {
       originalGasEstimate: opts.txParams?.gas,
       userEditedGasLimit: false,
       chainId,
-      loadingDefaults: true,
+
       dappSuggestedGasFees,
       sendFlowHistory: [],
       ...opts,

--- a/app/scripts/migrations/097.test.ts
+++ b/app/scripts/migrations/097.test.ts
@@ -1,0 +1,80 @@
+import { migrate, version } from './097';
+
+const oldVersion = 96;
+describe('migration #97', () => {
+  it('updates the version metadata', async () => {
+    const oldStorage = {
+      meta: { version: oldVersion },
+      data: {},
+    };
+
+    const newStorage = await migrate(oldStorage);
+
+    expect(newStorage.meta).toStrictEqual({ version });
+  });
+
+  it('handles missing TransactionController', async () => {
+    const oldState = {
+      OtherController: {},
+    };
+
+    const transformedState = await migrate({
+      meta: { version: oldVersion },
+      data: oldState,
+    });
+
+    expect(transformedState.data).toEqual(oldState);
+  });
+
+  it('handles empty transactions', async () => {
+    const oldState = {
+      TransactionController: {
+        transactions: {},
+      },
+    };
+
+    const transformedState = await migrate({
+      meta: { version: oldVersion },
+      data: oldState,
+    });
+
+    expect(transformedState.data).toEqual(oldState);
+  });
+
+  it('handles missing state', async () => {
+    const transformedState = await migrate({
+      meta: { version: oldVersion },
+      data: {},
+    });
+
+    expect(transformedState.data).toEqual({});
+  });
+
+  it('removes loadingDefaults property from transactions', async () => {
+    const oldState = {
+      TransactionController: {
+        transactions: {
+          tx1: { loadingDefaults: true, otherProp: 'value' },
+          tx2: { loadingDefaults: true, otherProp: 'value' },
+          tx3: { otherProp: 'value' },
+        },
+      },
+    };
+    const oldStorage = {
+      meta: { version: oldVersion },
+      data: oldState,
+    };
+
+    const newStorage = await migrate(oldStorage);
+
+    expect(newStorage.data).toEqual({
+      TransactionController: {
+        transactions: {
+          tx1: { otherProp: 'value' },
+          tx2: { otherProp: 'value' },
+          tx3: { otherProp: 'value' },
+        },
+      },
+    });
+  });
+});

--- a/app/scripts/migrations/097.ts
+++ b/app/scripts/migrations/097.ts
@@ -1,0 +1,49 @@
+import { cloneDeep, isEmpty } from 'lodash';
+
+type VersionedData = {
+  meta: { version: number };
+  data: Record<string, unknown>;
+};
+
+export const version = 97;
+
+/**
+ * Remove unused `loadingDefaults` property from TransactionMeta
+ *
+ * @param originalVersionedData
+ */
+export async function migrate(
+  originalVersionedData: VersionedData,
+): Promise<VersionedData> {
+  const versionedData = cloneDeep(originalVersionedData);
+  versionedData.meta.version = version;
+  transformState(versionedData.data);
+  return versionedData;
+}
+
+function transformState(state: Record<string, any>) {
+  const TransactionController = state?.TransactionController || {};
+  const transactions = state?.TransactionController?.transactions || {};
+
+  if (isEmpty(TransactionController) || isEmpty(transactions)) {
+    return;
+  }
+
+  const newTxs = Object.keys(transactions).reduce((txs, txId) => {
+    const transaction = transactions[txId];
+    if (transaction?.loadingDefaults) {
+      delete transaction.loadingDefaults;
+    }
+    return {
+      ...txs,
+      [txId]: transaction,
+    };
+  }, {});
+
+  state.TransactionController = {
+    ...TransactionController,
+    transactions: {
+      ...newTxs,
+    },
+  };
+}

--- a/app/scripts/migrations/index.js
+++ b/app/scripts/migrations/index.js
@@ -103,6 +103,7 @@ import * as m093 from './093';
 import * as m094 from './094';
 import * as m095 from './095';
 import * as m096 from './096';
+import * as m097 from './097';
 
 const migrations = [
   m002,
@@ -203,5 +204,6 @@ const migrations = [
   m094,
   m095,
   m096,
+  m097,
 ];
 export default migrations;

--- a/shared/constants/transaction.ts
+++ b/shared/constants/transaction.ts
@@ -364,8 +364,6 @@ export interface TransactionMeta {
   status: TransactionStatus;
   /** The transaction's network ID, used for EIP-155 compliance. */
   metamaskNetworkId: string;
-  /** TODO: Find out what this is and document it */
-  loadingDefaults: boolean;
   /** The transaction params as passed to the network provider. */
   txParams: TxParams;
   txReceipt: TxReceipt;

--- a/test/data/mock-pending-transaction-data.json
+++ b/test/data/mock-pending-transaction-data.json
@@ -7,7 +7,7 @@
     "status": "approved",
     "metamaskNetworkId": "5",
     "chainId": "0x5",
-    "loadingDefaults": false,
+
     "dappSuggestedGasFees": null,
     "txParams": {
       "from": "0x0853dccd30e0582df80b16ec014092160b48e797",
@@ -27,7 +27,7 @@
         "status": "unapproved",
         "metamaskNetworkId": "5",
         "chainId": "0x5",
-        "loadingDefaults": true,
+
         "dappSuggestedGasFees": null,
         "txParams": {
           "from": "0x0853dccd30e0582df80b16ec014092160b48e797",
@@ -42,13 +42,6 @@
         "type": "simpleSend"
       },
       [
-        {
-          "op": "replace",
-          "path": "/loadingDefaults",
-          "value": false,
-          "note": "Added new unapproved transaction.",
-          "timestamp": 1631558469059
-        },
         {
           "op": "add",
           "path": "/userFeeLevel",
@@ -83,7 +76,7 @@
     "status": "approved",
     "metamaskNetworkId": "5",
     "chainId": "0x5",
-    "loadingDefaults": false,
+
     "dappSuggestedGasFees": null,
     "txParams": {
       "from": "0x0853dccd30e0582df80b16ec014092160b48e797",
@@ -103,7 +96,7 @@
         "status": "unapproved",
         "metamaskNetworkId": "5",
         "chainId": "0x5",
-        "loadingDefaults": true,
+
         "dappSuggestedGasFees": null,
         "txParams": {
           "from": "0x0853dccd30e0582df80b16ec014092160b48e797",
@@ -118,13 +111,6 @@
         "type": "simpleSend"
       },
       [
-        {
-          "op": "replace",
-          "path": "/loadingDefaults",
-          "value": false,
-          "note": "Added new unapproved transaction.",
-          "timestamp": 1631558469059
-        },
         {
           "op": "add",
           "path": "/userFeeLevel",
@@ -160,7 +146,7 @@
       "status": "approved",
       "metamaskNetworkId": "5",
       "chainId": "0x5",
-      "loadingDefaults": false,
+
       "dappSuggestedGasFees": null,
       "txParams": {
         "from": "0x0853dccd30e0582df80b16ec014092160b48e797",
@@ -180,7 +166,7 @@
           "status": "unapproved",
           "metamaskNetworkId": "5",
           "chainId": "0x5",
-          "loadingDefaults": true,
+
           "dappSuggestedGasFees": null,
           "txParams": {
             "from": "0x0853dccd30e0582df80b16ec014092160b48e797",
@@ -195,13 +181,6 @@
           "type": "simpleSend"
         },
         [
-          {
-            "op": "replace",
-            "path": "/loadingDefaults",
-            "value": false,
-            "note": "Added new unapproved transaction.",
-            "timestamp": 1631558469059
-          },
           {
             "op": "add",
             "path": "/userFeeLevel",

--- a/test/data/mock-pending-transaction-data.json
+++ b/test/data/mock-pending-transaction-data.json
@@ -7,7 +7,6 @@
     "status": "approved",
     "metamaskNetworkId": "5",
     "chainId": "0x5",
-
     "dappSuggestedGasFees": null,
     "txParams": {
       "from": "0x0853dccd30e0582df80b16ec014092160b48e797",
@@ -27,7 +26,6 @@
         "status": "unapproved",
         "metamaskNetworkId": "5",
         "chainId": "0x5",
-
         "dappSuggestedGasFees": null,
         "txParams": {
           "from": "0x0853dccd30e0582df80b16ec014092160b48e797",
@@ -96,7 +94,6 @@
         "status": "unapproved",
         "metamaskNetworkId": "5",
         "chainId": "0x5",
-
         "dappSuggestedGasFees": null,
         "txParams": {
           "from": "0x0853dccd30e0582df80b16ec014092160b48e797",
@@ -146,7 +143,6 @@
       "status": "approved",
       "metamaskNetworkId": "5",
       "chainId": "0x5",
-
       "dappSuggestedGasFees": null,
       "txParams": {
         "from": "0x0853dccd30e0582df80b16ec014092160b48e797",
@@ -166,7 +162,6 @@
           "status": "unapproved",
           "metamaskNetworkId": "5",
           "chainId": "0x5",
-
           "dappSuggestedGasFees": null,
           "txParams": {
             "from": "0x0853dccd30e0582df80b16ec014092160b48e797",

--- a/test/data/mock-send-state.json
+++ b/test/data/mock-send-state.json
@@ -33,7 +33,6 @@
       "status": "unapproved",
       "metamaskNetworkId": "5",
       "chainId": "0x5",
-
       "txParams": {
         "from": "0x64a845a5b02460acf8a3d84503b0d68d028b4bb4",
         "to": "0xaD6D458402F60fD3Bd25163575031ACDce07538D",
@@ -187,7 +186,6 @@
         "time": 1536268017676,
         "status": "unapproved",
         "metamaskNetworkId": "4",
-
         "txParams": {
           "from": "0x0dcd5d886577d5081b0c52e242ef29e70be3e7bc",
           "to": "0xc42edfcc21ed14dda456aa0756c153f7985d8813",
@@ -201,7 +199,6 @@
             "time": 1536268017676,
             "status": "unapproved",
             "metamaskNetworkId": "4",
-
             "txParams": {
               "from": "0x0dcd5d886577d5081b0c52e242ef29e70be3e7bc",
               "to": "0xc42edfcc21ed14dda456aa0756c153f7985d8813",
@@ -360,7 +357,6 @@
             "time": 1528133130531,
             "status": "unapproved",
             "metamaskNetworkId": "4",
-
             "txParams": {
               "from": "0x3b222de3aaba8ec9771ca9e9af5d8ed757fb7f62",
               "to": "0x92e659448c48fc926ec942d0da1459260d36bb33",
@@ -517,7 +513,6 @@
         "time": 1528133149983,
         "status": "confirmed",
         "metamaskNetworkId": "4",
-
         "txParams": {
           "from": "0x3b222de3aaba8ec9771ca9e9af5d8ed757fb7f62",
           "to": "0x92e659448c48fc926ec942d0da1459260d36bb33",
@@ -532,7 +527,6 @@
             "time": 1528133149983,
             "status": "unapproved",
             "metamaskNetworkId": "4",
-
             "txParams": {
               "from": "0x3b222de3aaba8ec9771ca9e9af5d8ed757fb7f62",
               "to": "0x92e659448c48fc926ec942d0da1459260d36bb33",
@@ -689,7 +683,6 @@
         "time": 1528133180635,
         "status": "confirmed",
         "metamaskNetworkId": "4",
-
         "txParams": {
           "from": "0x3b222de3aaba8ec9771ca9e9af5d8ed757fb7f62",
           "to": "0x92e659448c48fc926ec942d0da1459260d36bb33",
@@ -704,7 +697,6 @@
             "time": 1528133180635,
             "status": "unapproved",
             "metamaskNetworkId": "4",
-
             "txParams": {
               "from": "0x3b222de3aaba8ec9771ca9e9af5d8ed757fb7f62",
               "to": "0x92e659448c48fc926ec942d0da1459260d36bb33",
@@ -861,7 +853,6 @@
         "time": 1528133223918,
         "status": "confirmed",
         "metamaskNetworkId": "4",
-
         "txParams": {
           "from": "0x3b222de3aaba8ec9771ca9e9af5d8ed757fb7f62",
           "to": "0xfe2149773b3513703e79ad23d05a778a185016ee",
@@ -877,7 +868,6 @@
             "time": 1528133223918,
             "status": "unapproved",
             "metamaskNetworkId": "4",
-
             "txParams": {
               "from": "0x3b222de3aaba8ec9771ca9e9af5d8ed757fb7f62",
               "to": "0xfe2149773b3513703e79ad23d05a778a185016ee",
@@ -1041,7 +1031,6 @@
         "time": 1528133291381,
         "status": "confirmed",
         "metamaskNetworkId": "4",
-
         "txParams": {
           "from": "0x3b222de3aaba8ec9771ca9e9af5d8ed757fb7f62",
           "to": "0x108cf70c7d384c552f42c07c41c0e1e46d77ea0d",
@@ -1057,7 +1046,6 @@
             "time": 1528133291381,
             "status": "unapproved",
             "metamaskNetworkId": "4",
-
             "txParams": {
               "from": "0x3b222de3aaba8ec9771ca9e9af5d8ed757fb7f62",
               "to": "0x108cf70c7d384c552f42c07c41c0e1e46d77ea0d",
@@ -1215,7 +1203,6 @@
         "time": 1528133318440,
         "status": "rejected",
         "metamaskNetworkId": "4",
-
         "txParams": {
           "from": "0x3b222de3aaba8ec9771ca9e9af5d8ed757fb7f62",
           "to": "0x3b222de3aaba8ec9771ca9e9af5d8ed757fb7f62",
@@ -1229,7 +1216,6 @@
             "time": 1528133318440,
             "status": "unapproved",
             "metamaskNetworkId": "4",
-
             "txParams": {
               "from": "0x3b222de3aaba8ec9771ca9e9af5d8ed757fb7f62",
               "to": "0x3b222de3aaba8ec9771ca9e9af5d8ed757fb7f62"

--- a/test/data/mock-send-state.json
+++ b/test/data/mock-send-state.json
@@ -33,7 +33,7 @@
       "status": "unapproved",
       "metamaskNetworkId": "5",
       "chainId": "0x5",
-      "loadingDefaults": false,
+
       "txParams": {
         "from": "0x64a845a5b02460acf8a3d84503b0d68d028b4bb4",
         "to": "0xaD6D458402F60fD3Bd25163575031ACDce07538D",
@@ -187,7 +187,7 @@
         "time": 1536268017676,
         "status": "unapproved",
         "metamaskNetworkId": "4",
-        "loadingDefaults": false,
+
         "txParams": {
           "from": "0x0dcd5d886577d5081b0c52e242ef29e70be3e7bc",
           "to": "0xc42edfcc21ed14dda456aa0756c153f7985d8813",
@@ -201,7 +201,7 @@
             "time": 1536268017676,
             "status": "unapproved",
             "metamaskNetworkId": "4",
-            "loadingDefaults": true,
+
             "txParams": {
               "from": "0x0dcd5d886577d5081b0c52e242ef29e70be3e7bc",
               "to": "0xc42edfcc21ed14dda456aa0756c153f7985d8813",
@@ -210,14 +210,6 @@
               "gasPrice": "0x3b9aca00"
             }
           },
-          [
-            {
-              "op": "replace",
-              "path": "/loadingDefaults",
-              "value": false,
-              "timestamp": 1536268017685
-            }
-          ],
           [
             {
               "op": "add",
@@ -353,7 +345,7 @@
         "time": 1528133130531,
         "status": "confirmed",
         "metamaskNetworkId": "4",
-        "loadingDefaults": false,
+
         "txParams": {
           "from": "0x3b222de3aaba8ec9771ca9e9af5d8ed757fb7f62",
           "to": "0x92e659448c48fc926ec942d0da1459260d36bb33",
@@ -368,7 +360,7 @@
             "time": 1528133130531,
             "status": "unapproved",
             "metamaskNetworkId": "4",
-            "loadingDefaults": true,
+
             "txParams": {
               "from": "0x3b222de3aaba8ec9771ca9e9af5d8ed757fb7f62",
               "to": "0x92e659448c48fc926ec942d0da1459260d36bb33",
@@ -377,14 +369,6 @@
               "gasPrice": "0x3b9aca00"
             }
           },
-          [
-            {
-              "op": "replace",
-              "path": "/loadingDefaults",
-              "value": false,
-              "timestamp": 1528133130666
-            }
-          ],
           [
             {
               "op": "add",
@@ -533,7 +517,7 @@
         "time": 1528133149983,
         "status": "confirmed",
         "metamaskNetworkId": "4",
-        "loadingDefaults": false,
+
         "txParams": {
           "from": "0x3b222de3aaba8ec9771ca9e9af5d8ed757fb7f62",
           "to": "0x92e659448c48fc926ec942d0da1459260d36bb33",
@@ -548,7 +532,7 @@
             "time": 1528133149983,
             "status": "unapproved",
             "metamaskNetworkId": "4",
-            "loadingDefaults": true,
+
             "txParams": {
               "from": "0x3b222de3aaba8ec9771ca9e9af5d8ed757fb7f62",
               "to": "0x92e659448c48fc926ec942d0da1459260d36bb33",
@@ -557,14 +541,6 @@
               "gasPrice": "0x3b9aca00"
             }
           },
-          [
-            {
-              "op": "replace",
-              "path": "/loadingDefaults",
-              "value": false,
-              "timestamp": 1528133150011
-            }
-          ],
           [
             {
               "op": "add",
@@ -713,7 +689,7 @@
         "time": 1528133180635,
         "status": "confirmed",
         "metamaskNetworkId": "4",
-        "loadingDefaults": false,
+
         "txParams": {
           "from": "0x3b222de3aaba8ec9771ca9e9af5d8ed757fb7f62",
           "to": "0x92e659448c48fc926ec942d0da1459260d36bb33",
@@ -728,7 +704,7 @@
             "time": 1528133180635,
             "status": "unapproved",
             "metamaskNetworkId": "4",
-            "loadingDefaults": true,
+
             "txParams": {
               "from": "0x3b222de3aaba8ec9771ca9e9af5d8ed757fb7f62",
               "to": "0x92e659448c48fc926ec942d0da1459260d36bb33",
@@ -737,14 +713,6 @@
               "gasPrice": "0x12a05f200"
             }
           },
-          [
-            {
-              "op": "replace",
-              "path": "/loadingDefaults",
-              "value": false,
-              "timestamp": 1528133180720
-            }
-          ],
           [
             {
               "op": "add",
@@ -893,7 +861,7 @@
         "time": 1528133223918,
         "status": "confirmed",
         "metamaskNetworkId": "4",
-        "loadingDefaults": false,
+
         "txParams": {
           "from": "0x3b222de3aaba8ec9771ca9e9af5d8ed757fb7f62",
           "to": "0xfe2149773b3513703e79ad23d05a778a185016ee",
@@ -909,7 +877,7 @@
             "time": 1528133223918,
             "status": "unapproved",
             "metamaskNetworkId": "4",
-            "loadingDefaults": true,
+
             "txParams": {
               "from": "0x3b222de3aaba8ec9771ca9e9af5d8ed757fb7f62",
               "to": "0xfe2149773b3513703e79ad23d05a778a185016ee",
@@ -924,11 +892,6 @@
               "path": "/txParams/gas",
               "value": "0x6169e",
               "timestamp": 1528133225488
-            },
-            {
-              "op": "replace",
-              "path": "/loadingDefaults",
-              "value": false
             }
           ],
           [
@@ -1078,7 +1041,7 @@
         "time": 1528133291381,
         "status": "confirmed",
         "metamaskNetworkId": "4",
-        "loadingDefaults": false,
+
         "txParams": {
           "from": "0x3b222de3aaba8ec9771ca9e9af5d8ed757fb7f62",
           "to": "0x108cf70c7d384c552f42c07c41c0e1e46d77ea0d",
@@ -1094,7 +1057,7 @@
             "time": 1528133291381,
             "status": "unapproved",
             "metamaskNetworkId": "4",
-            "loadingDefaults": true,
+
             "txParams": {
               "from": "0x3b222de3aaba8ec9771ca9e9af5d8ed757fb7f62",
               "to": "0x108cf70c7d384c552f42c07c41c0e1e46d77ea0d",
@@ -1104,14 +1067,6 @@
               "gasPrice": "0x3b9aca00"
             }
           },
-          [
-            {
-              "op": "replace",
-              "path": "/loadingDefaults",
-              "value": false,
-              "timestamp": 1528133291486
-            }
-          ],
           [
             {
               "op": "add",
@@ -1260,7 +1215,7 @@
         "time": 1528133318440,
         "status": "rejected",
         "metamaskNetworkId": "4",
-        "loadingDefaults": false,
+
         "txParams": {
           "from": "0x3b222de3aaba8ec9771ca9e9af5d8ed757fb7f62",
           "to": "0x3b222de3aaba8ec9771ca9e9af5d8ed757fb7f62",
@@ -1274,7 +1229,7 @@
             "time": 1528133318440,
             "status": "unapproved",
             "metamaskNetworkId": "4",
-            "loadingDefaults": true,
+
             "txParams": {
               "from": "0x3b222de3aaba8ec9771ca9e9af5d8ed757fb7f62",
               "to": "0x3b222de3aaba8ec9771ca9e9af5d8ed757fb7f62"
@@ -1296,11 +1251,6 @@
               "op": "add",
               "path": "/txParams/gas",
               "value": "0x5208"
-            },
-            {
-              "op": "replace",
-              "path": "/loadingDefaults",
-              "value": false
             }
           ],
           [

--- a/test/data/mock-state.json
+++ b/test/data/mock-state.json
@@ -235,7 +235,7 @@
         "time": 1536268017676,
         "status": "unapproved",
         "metamaskNetworkId": "4",
-        "loadingDefaults": false,
+
         "txParams": {
           "data": "0xa9059cbb000000000000000000000000b19ac54efa18cc3a14a5b821bfec73d284bf0c5e0000000000000000000000000000000000000000000000003782dace9d900000",
           "from": "0x0dcd5d886577d5081b0c52e242ef29e70be3e7bc",
@@ -250,7 +250,7 @@
             "time": 1536268017676,
             "status": "unapproved",
             "metamaskNetworkId": "4",
-            "loadingDefaults": true,
+
             "txParams": {
               "from": "0x0dcd5d886577d5081b0c52e242ef29e70be3e7bc",
               "to": "0xc42edfcc21ed14dda456aa0756c153f7985d8813",
@@ -259,14 +259,6 @@
               "gasPrice": "0x3b9aca00"
             }
           },
-          [
-            {
-              "op": "replace",
-              "path": "/loadingDefaults",
-              "value": false,
-              "timestamp": 1536268017685
-            }
-          ],
           [
             {
               "op": "add",
@@ -649,7 +641,7 @@
         "time": 1528133130531,
         "status": "confirmed",
         "metamaskNetworkId": "4",
-        "loadingDefaults": false,
+
         "txParams": {
           "from": "0x3b222de3aaba8ec9771ca9e9af5d8ed757fb7f62",
           "to": "0x92e659448c48fc926ec942d0da1459260d36bb33",
@@ -664,7 +656,7 @@
             "time": 1528133130531,
             "status": "unapproved",
             "metamaskNetworkId": "4",
-            "loadingDefaults": true,
+
             "txParams": {
               "from": "0x3b222de3aaba8ec9771ca9e9af5d8ed757fb7f62",
               "to": "0x92e659448c48fc926ec942d0da1459260d36bb33",
@@ -673,14 +665,6 @@
               "gasPrice": "0x3b9aca00"
             }
           },
-          [
-            {
-              "op": "replace",
-              "path": "/loadingDefaults",
-              "value": false,
-              "timestamp": 1528133130666
-            }
-          ],
           [
             {
               "op": "add",
@@ -829,7 +813,7 @@
         "time": 1528133149983,
         "status": "confirmed",
         "metamaskNetworkId": "4",
-        "loadingDefaults": false,
+
         "txParams": {
           "from": "0x3b222de3aaba8ec9771ca9e9af5d8ed757fb7f62",
           "to": "0x92e659448c48fc926ec942d0da1459260d36bb33",
@@ -844,7 +828,7 @@
             "time": 1528133149983,
             "status": "unapproved",
             "metamaskNetworkId": "4",
-            "loadingDefaults": true,
+
             "txParams": {
               "from": "0x3b222de3aaba8ec9771ca9e9af5d8ed757fb7f62",
               "to": "0x92e659448c48fc926ec942d0da1459260d36bb33",
@@ -853,14 +837,6 @@
               "gasPrice": "0x3b9aca00"
             }
           },
-          [
-            {
-              "op": "replace",
-              "path": "/loadingDefaults",
-              "value": false,
-              "timestamp": 1528133150011
-            }
-          ],
           [
             {
               "op": "add",
@@ -1009,7 +985,7 @@
         "time": 1528133180635,
         "status": "confirmed",
         "metamaskNetworkId": "4",
-        "loadingDefaults": false,
+
         "txParams": {
           "from": "0x3b222de3aaba8ec9771ca9e9af5d8ed757fb7f62",
           "to": "0x92e659448c48fc926ec942d0da1459260d36bb33",
@@ -1024,7 +1000,7 @@
             "time": 1528133180635,
             "status": "unapproved",
             "metamaskNetworkId": "4",
-            "loadingDefaults": true,
+
             "txParams": {
               "from": "0x3b222de3aaba8ec9771ca9e9af5d8ed757fb7f62",
               "to": "0x92e659448c48fc926ec942d0da1459260d36bb33",
@@ -1033,14 +1009,6 @@
               "gasPrice": "0x12a05f200"
             }
           },
-          [
-            {
-              "op": "replace",
-              "path": "/loadingDefaults",
-              "value": false,
-              "timestamp": 1528133180720
-            }
-          ],
           [
             {
               "op": "add",
@@ -1189,7 +1157,7 @@
         "time": 1528133223918,
         "status": "confirmed",
         "metamaskNetworkId": "4",
-        "loadingDefaults": false,
+
         "txParams": {
           "from": "0x3b222de3aaba8ec9771ca9e9af5d8ed757fb7f62",
           "to": "0xfe2149773b3513703e79ad23d05a778a185016ee",
@@ -1205,7 +1173,7 @@
             "time": 1528133223918,
             "status": "unapproved",
             "metamaskNetworkId": "4",
-            "loadingDefaults": true,
+
             "txParams": {
               "from": "0x3b222de3aaba8ec9771ca9e9af5d8ed757fb7f62",
               "to": "0xfe2149773b3513703e79ad23d05a778a185016ee",
@@ -1220,11 +1188,6 @@
               "path": "/txParams/gas",
               "value": "0x6169e",
               "timestamp": 1528133225488
-            },
-            {
-              "op": "replace",
-              "path": "/loadingDefaults",
-              "value": false
             }
           ],
           [
@@ -1374,7 +1337,7 @@
         "time": 1528133291381,
         "status": "confirmed",
         "metamaskNetworkId": "4",
-        "loadingDefaults": false,
+
         "txParams": {
           "from": "0x3b222de3aaba8ec9771ca9e9af5d8ed757fb7f62",
           "to": "0x108cf70c7d384c552f42c07c41c0e1e46d77ea0d",
@@ -1390,7 +1353,7 @@
             "time": 1528133291381,
             "status": "unapproved",
             "metamaskNetworkId": "4",
-            "loadingDefaults": true,
+
             "txParams": {
               "from": "0x3b222de3aaba8ec9771ca9e9af5d8ed757fb7f62",
               "to": "0x108cf70c7d384c552f42c07c41c0e1e46d77ea0d",
@@ -1400,14 +1363,6 @@
               "gasPrice": "0x3b9aca00"
             }
           },
-          [
-            {
-              "op": "replace",
-              "path": "/loadingDefaults",
-              "value": false,
-              "timestamp": 1528133291486
-            }
-          ],
           [
             {
               "op": "add",
@@ -1556,7 +1511,7 @@
         "time": 1528133318440,
         "status": "rejected",
         "metamaskNetworkId": "4",
-        "loadingDefaults": false,
+
         "txParams": {
           "from": "0x3b222de3aaba8ec9771ca9e9af5d8ed757fb7f62",
           "to": "0x3b222de3aaba8ec9771ca9e9af5d8ed757fb7f62",
@@ -1570,7 +1525,7 @@
             "time": 1528133318440,
             "status": "unapproved",
             "metamaskNetworkId": "4",
-            "loadingDefaults": true,
+
             "txParams": {
               "from": "0x3b222de3aaba8ec9771ca9e9af5d8ed757fb7f62",
               "to": "0x3b222de3aaba8ec9771ca9e9af5d8ed757fb7f62"
@@ -1592,11 +1547,6 @@
               "op": "add",
               "path": "/txParams/gas",
               "value": "0x5208"
-            },
-            {
-              "op": "replace",
-              "path": "/loadingDefaults",
-              "value": false
             }
           ],
           [

--- a/test/data/mock-state.json
+++ b/test/data/mock-state.json
@@ -235,7 +235,6 @@
         "time": 1536268017676,
         "status": "unapproved",
         "metamaskNetworkId": "4",
-
         "txParams": {
           "data": "0xa9059cbb000000000000000000000000b19ac54efa18cc3a14a5b821bfec73d284bf0c5e0000000000000000000000000000000000000000000000003782dace9d900000",
           "from": "0x0dcd5d886577d5081b0c52e242ef29e70be3e7bc",
@@ -250,7 +249,6 @@
             "time": 1536268017676,
             "status": "unapproved",
             "metamaskNetworkId": "4",
-
             "txParams": {
               "from": "0x0dcd5d886577d5081b0c52e242ef29e70be3e7bc",
               "to": "0xc42edfcc21ed14dda456aa0756c153f7985d8813",
@@ -641,7 +639,6 @@
         "time": 1528133130531,
         "status": "confirmed",
         "metamaskNetworkId": "4",
-
         "txParams": {
           "from": "0x3b222de3aaba8ec9771ca9e9af5d8ed757fb7f62",
           "to": "0x92e659448c48fc926ec942d0da1459260d36bb33",
@@ -656,7 +653,6 @@
             "time": 1528133130531,
             "status": "unapproved",
             "metamaskNetworkId": "4",
-
             "txParams": {
               "from": "0x3b222de3aaba8ec9771ca9e9af5d8ed757fb7f62",
               "to": "0x92e659448c48fc926ec942d0da1459260d36bb33",
@@ -813,7 +809,6 @@
         "time": 1528133149983,
         "status": "confirmed",
         "metamaskNetworkId": "4",
-
         "txParams": {
           "from": "0x3b222de3aaba8ec9771ca9e9af5d8ed757fb7f62",
           "to": "0x92e659448c48fc926ec942d0da1459260d36bb33",
@@ -828,7 +823,6 @@
             "time": 1528133149983,
             "status": "unapproved",
             "metamaskNetworkId": "4",
-
             "txParams": {
               "from": "0x3b222de3aaba8ec9771ca9e9af5d8ed757fb7f62",
               "to": "0x92e659448c48fc926ec942d0da1459260d36bb33",
@@ -985,7 +979,6 @@
         "time": 1528133180635,
         "status": "confirmed",
         "metamaskNetworkId": "4",
-
         "txParams": {
           "from": "0x3b222de3aaba8ec9771ca9e9af5d8ed757fb7f62",
           "to": "0x92e659448c48fc926ec942d0da1459260d36bb33",
@@ -1000,7 +993,6 @@
             "time": 1528133180635,
             "status": "unapproved",
             "metamaskNetworkId": "4",
-
             "txParams": {
               "from": "0x3b222de3aaba8ec9771ca9e9af5d8ed757fb7f62",
               "to": "0x92e659448c48fc926ec942d0da1459260d36bb33",
@@ -1157,7 +1149,6 @@
         "time": 1528133223918,
         "status": "confirmed",
         "metamaskNetworkId": "4",
-
         "txParams": {
           "from": "0x3b222de3aaba8ec9771ca9e9af5d8ed757fb7f62",
           "to": "0xfe2149773b3513703e79ad23d05a778a185016ee",
@@ -1173,7 +1164,6 @@
             "time": 1528133223918,
             "status": "unapproved",
             "metamaskNetworkId": "4",
-
             "txParams": {
               "from": "0x3b222de3aaba8ec9771ca9e9af5d8ed757fb7f62",
               "to": "0xfe2149773b3513703e79ad23d05a778a185016ee",
@@ -1337,7 +1327,6 @@
         "time": 1528133291381,
         "status": "confirmed",
         "metamaskNetworkId": "4",
-
         "txParams": {
           "from": "0x3b222de3aaba8ec9771ca9e9af5d8ed757fb7f62",
           "to": "0x108cf70c7d384c552f42c07c41c0e1e46d77ea0d",
@@ -1353,7 +1342,6 @@
             "time": 1528133291381,
             "status": "unapproved",
             "metamaskNetworkId": "4",
-
             "txParams": {
               "from": "0x3b222de3aaba8ec9771ca9e9af5d8ed757fb7f62",
               "to": "0x108cf70c7d384c552f42c07c41c0e1e46d77ea0d",
@@ -1511,7 +1499,6 @@
         "time": 1528133318440,
         "status": "rejected",
         "metamaskNetworkId": "4",
-
         "txParams": {
           "from": "0x3b222de3aaba8ec9771ca9e9af5d8ed757fb7f62",
           "to": "0x3b222de3aaba8ec9771ca9e9af5d8ed757fb7f62",
@@ -1525,7 +1512,6 @@
             "time": 1528133318440,
             "status": "unapproved",
             "metamaskNetworkId": "4",
-
             "txParams": {
               "from": "0x3b222de3aaba8ec9771ca9e9af5d8ed757fb7f62",
               "to": "0x3b222de3aaba8ec9771ca9e9af5d8ed757fb7f62"

--- a/test/data/transaction-data.json
+++ b/test/data/transaction-data.json
@@ -6,7 +6,7 @@
       "time": 1589314601567,
       "status": "confirmed",
       "metamaskNetworkId": "4",
-      "loadingDefaults": false,
+
       "txParams": {
         "from": "0x9eca64466f257793eaa52fcfff5066894b76a149",
         "to": "0xffe5bc4e8f1f969934d773fa67da095d2e491a97",
@@ -67,7 +67,7 @@
         "time": 1589314601567,
         "status": "confirmed",
         "metamaskNetworkId": "4",
-        "loadingDefaults": false,
+
         "txParams": {
           "from": "0x9eca64466f257793eaa52fcfff5066894b76a149",
           "to": "0xffe5bc4e8f1f969934d773fa67da095d2e491a97",
@@ -128,7 +128,7 @@
       "time": 1589314601567,
       "status": "confirmed",
       "metamaskNetworkId": "4",
-      "loadingDefaults": false,
+
       "txParams": {
         "from": "0x9eca64466f257793eaa52fcfff5066894b76a149",
         "to": "0xffe5bc4e8f1f969934d773fa67da095d2e491a97",
@@ -193,7 +193,7 @@
       "time": 1589314355872,
       "status": "confirmed",
       "metamaskNetworkId": "4",
-      "loadingDefaults": false,
+
       "txParams": {
         "from": "0x9eca64466f257793eaa52fcfff5066894b76a149",
         "to": "0x0ccc8aeeaf5ce790f3b448325981a143fdef8848",
@@ -254,7 +254,7 @@
         "time": 1589314355872,
         "status": "confirmed",
         "metamaskNetworkId": "4",
-        "loadingDefaults": false,
+
         "txParams": {
           "from": "0x9eca64466f257793eaa52fcfff5066894b76a149",
           "to": "0x0ccc8aeeaf5ce790f3b448325981a143fdef8848",
@@ -315,7 +315,7 @@
       "time": 1589314355872,
       "status": "confirmed",
       "metamaskNetworkId": "4",
-      "loadingDefaults": false,
+
       "txParams": {
         "from": "0x9eca64466f257793eaa52fcfff5066894b76a149",
         "to": "0x0ccc8aeeaf5ce790f3b448325981a143fdef8848",
@@ -380,7 +380,7 @@
       "time": 1589314345433,
       "status": "confirmed",
       "metamaskNetworkId": "4",
-      "loadingDefaults": false,
+
       "txParams": {
         "from": "0x9eca64466f257793eaa52fcfff5066894b76a149",
         "to": "0xffe5bc4e8f1f969934d773fa67da095d2e491a97",
@@ -442,7 +442,7 @@
         "time": 1589314345433,
         "status": "confirmed",
         "metamaskNetworkId": "4",
-        "loadingDefaults": false,
+
         "txParams": {
           "from": "0x9eca64466f257793eaa52fcfff5066894b76a149",
           "to": "0xffe5bc4e8f1f969934d773fa67da095d2e491a97",
@@ -504,7 +504,7 @@
       "time": 1589314345433,
       "status": "confirmed",
       "metamaskNetworkId": "4",
-      "loadingDefaults": false,
+
       "txParams": {
         "from": "0x9eca64466f257793eaa52fcfff5066894b76a149",
         "to": "0xffe5bc4e8f1f969934d773fa67da095d2e491a97",
@@ -868,7 +868,7 @@
         "originalGasEstimate": "0x118e0",
         "userEditedGasLimit": false,
         "chainId": "0x5",
-        "loadingDefaults": false,
+
         "dappSuggestedGasFees": {
           "maxPriorityFeePerGas": "0x3B9ACA00",
           "maxFeePerGas": "0x7be830aec"
@@ -984,7 +984,7 @@
       "originalGasEstimate": "0x118e0",
       "userEditedGasLimit": false,
       "chainId": "0x5",
-      "loadingDefaults": false,
+
       "dappSuggestedGasFees": {
         "maxPriorityFeePerGas": "0x3B9ACA00",
         "maxFeePerGas": "0x7be830aec"
@@ -1099,7 +1099,7 @@
       "originalGasEstimate": "0x118e0",
       "userEditedGasLimit": false,
       "chainId": "0x5",
-      "loadingDefaults": false,
+
       "dappSuggestedGasFees": {
         "maxPriorityFeePerGas": "0x3B9ACA00",
         "maxFeePerGas": "0x7be830aec"

--- a/test/data/transaction-data.json
+++ b/test/data/transaction-data.json
@@ -6,7 +6,6 @@
       "time": 1589314601567,
       "status": "confirmed",
       "metamaskNetworkId": "4",
-
       "txParams": {
         "from": "0x9eca64466f257793eaa52fcfff5066894b76a149",
         "to": "0xffe5bc4e8f1f969934d773fa67da095d2e491a97",
@@ -67,7 +66,6 @@
         "time": 1589314601567,
         "status": "confirmed",
         "metamaskNetworkId": "4",
-
         "txParams": {
           "from": "0x9eca64466f257793eaa52fcfff5066894b76a149",
           "to": "0xffe5bc4e8f1f969934d773fa67da095d2e491a97",
@@ -128,7 +126,6 @@
       "time": 1589314601567,
       "status": "confirmed",
       "metamaskNetworkId": "4",
-
       "txParams": {
         "from": "0x9eca64466f257793eaa52fcfff5066894b76a149",
         "to": "0xffe5bc4e8f1f969934d773fa67da095d2e491a97",
@@ -193,7 +190,6 @@
       "time": 1589314355872,
       "status": "confirmed",
       "metamaskNetworkId": "4",
-
       "txParams": {
         "from": "0x9eca64466f257793eaa52fcfff5066894b76a149",
         "to": "0x0ccc8aeeaf5ce790f3b448325981a143fdef8848",
@@ -254,7 +250,6 @@
         "time": 1589314355872,
         "status": "confirmed",
         "metamaskNetworkId": "4",
-
         "txParams": {
           "from": "0x9eca64466f257793eaa52fcfff5066894b76a149",
           "to": "0x0ccc8aeeaf5ce790f3b448325981a143fdef8848",
@@ -315,7 +310,6 @@
       "time": 1589314355872,
       "status": "confirmed",
       "metamaskNetworkId": "4",
-
       "txParams": {
         "from": "0x9eca64466f257793eaa52fcfff5066894b76a149",
         "to": "0x0ccc8aeeaf5ce790f3b448325981a143fdef8848",
@@ -380,7 +374,6 @@
       "time": 1589314345433,
       "status": "confirmed",
       "metamaskNetworkId": "4",
-
       "txParams": {
         "from": "0x9eca64466f257793eaa52fcfff5066894b76a149",
         "to": "0xffe5bc4e8f1f969934d773fa67da095d2e491a97",
@@ -442,7 +435,6 @@
         "time": 1589314345433,
         "status": "confirmed",
         "metamaskNetworkId": "4",
-
         "txParams": {
           "from": "0x9eca64466f257793eaa52fcfff5066894b76a149",
           "to": "0xffe5bc4e8f1f969934d773fa67da095d2e491a97",
@@ -504,7 +496,6 @@
       "time": 1589314345433,
       "status": "confirmed",
       "metamaskNetworkId": "4",
-
       "txParams": {
         "from": "0x9eca64466f257793eaa52fcfff5066894b76a149",
         "to": "0xffe5bc4e8f1f969934d773fa67da095d2e491a97",
@@ -868,7 +859,6 @@
         "originalGasEstimate": "0x118e0",
         "userEditedGasLimit": false,
         "chainId": "0x5",
-
         "dappSuggestedGasFees": {
           "maxPriorityFeePerGas": "0x3B9ACA00",
           "maxFeePerGas": "0x7be830aec"
@@ -984,7 +974,6 @@
       "originalGasEstimate": "0x118e0",
       "userEditedGasLimit": false,
       "chainId": "0x5",
-
       "dappSuggestedGasFees": {
         "maxPriorityFeePerGas": "0x3B9ACA00",
         "maxFeePerGas": "0x7be830aec"
@@ -1099,7 +1088,6 @@
       "originalGasEstimate": "0x118e0",
       "userEditedGasLimit": false,
       "chainId": "0x5",
-
       "dappSuggestedGasFees": {
         "maxPriorityFeePerGas": "0x3B9ACA00",
         "maxFeePerGas": "0x7be830aec"

--- a/test/e2e/fixture-builder.js
+++ b/test/e2e/fixture-builder.js
@@ -769,7 +769,6 @@ class FixtureBuilder {
                 maxPriorityFeePerGas: '0x59682f00',
               },
               id: 7911313280012623,
-
               metamaskNetworkId: '1337',
               origin: 'https://metamask.github.io',
               status: 'unapproved',
@@ -786,7 +785,6 @@ class FixtureBuilder {
             },
           ],
           id: 7911313280012623,
-
           metamaskNetworkId: '1337',
           origin: 'https://metamask.github.io',
           status: 'unapproved',
@@ -817,7 +815,6 @@ class FixtureBuilder {
                 maxPriorityFeePerGas: '0x59682f00',
               },
               id: 7911313280012624,
-
               metamaskNetworkId: '1337',
               origin: 'https://metamask.github.io',
               status: 'unapproved',
@@ -834,7 +831,6 @@ class FixtureBuilder {
             },
           ],
           id: 7911313280012624,
-
           metamaskNetworkId: '1337',
           origin: 'https://metamask.github.io',
           status: 'unapproved',
@@ -865,7 +861,6 @@ class FixtureBuilder {
                 maxPriorityFeePerGas: '0x59682f00',
               },
               id: 7911313280012625,
-
               metamaskNetworkId: '1337',
               origin: 'https://metamask.github.io',
               status: 'unapproved',
@@ -882,7 +877,6 @@ class FixtureBuilder {
             },
           ],
           id: 7911313280012625,
-
           metamaskNetworkId: '1337',
           origin: 'https://metamask.github.io',
           status: 'unapproved',
@@ -913,7 +907,6 @@ class FixtureBuilder {
                 maxPriorityFeePerGas: '0x59682f00',
               },
               id: 7911313280012626,
-
               metamaskNetworkId: '1337',
               origin: 'https://metamask.github.io',
               status: 'unapproved',
@@ -930,7 +923,6 @@ class FixtureBuilder {
             },
           ],
           id: 7911313280012626,
-
           metamaskNetworkId: '1337',
           origin: 'https://metamask.github.io',
           status: 'unapproved',
@@ -958,7 +950,6 @@ class FixtureBuilder {
             {
               chainId: CHAIN_IDS.LOCALHOST,
               id: 4046084157914634,
-
               metamaskNetworkId: '1337',
               origin: 'metamask',
               status: 'unapproved',
@@ -974,13 +965,11 @@ class FixtureBuilder {
             },
           ],
           id: 4046084157914634,
-
           metamaskNetworkId: '1337',
           origin: 'metamask',
           primaryTransaction: {
             chainId: CHAIN_IDS.LOCALHOST,
             id: 4046084157914634,
-
             metamaskNetworkId: '1337',
             origin: 'metamask',
             status: 'unapproved',
@@ -1018,7 +1007,6 @@ class FixtureBuilder {
             {
               chainId: CHAIN_IDS.LOCALHOST,
               id: 4046084157914634,
-
               metamaskNetworkId: '1337',
               origin: 'metamask',
               status: 'unapproved',
@@ -1036,13 +1024,11 @@ class FixtureBuilder {
             },
           ],
           id: 4046084157914634,
-
           metamaskNetworkId: '1337',
           origin: 'metamask',
           primaryTransaction: {
             chainId: CHAIN_IDS.LOCALHOST,
             id: 4046084157914634,
-
             metamaskNetworkId: '1337',
             origin: 'metamask',
             status: 'unapproved',
@@ -1084,7 +1070,6 @@ class FixtureBuilder {
             {
               chainId: CHAIN_IDS.LOCALHOST,
               id: 4046084157914634,
-
               metamaskNetworkId: '1337',
               origin: 'metamask',
               status: 'unapproved',
@@ -1138,13 +1123,11 @@ class FixtureBuilder {
             ],
           ],
           id: 4046084157914634,
-
           metamaskNetworkId: '1337',
           origin: 'metamask',
           primaryTransaction: {
             chainId: CHAIN_IDS.LOCALHOST,
             id: 4046084157914634,
-
             metamaskNetworkId: '1337',
             origin: 'metamask',
             status: 'approved',
@@ -1186,7 +1169,6 @@ class FixtureBuilder {
             {
               chainId: CHAIN_IDS.LOCALHOST,
               id: 5748272735958801,
-
               metamaskNetworkId: '1337',
               origin: 'metamask',
               status: 'unapproved',
@@ -1316,7 +1298,6 @@ class FixtureBuilder {
             ],
           ],
           id: 5748272735958801,
-
           metamaskNetworkId: '5',
           nonceDetails: {
             local: {

--- a/test/e2e/fixture-builder.js
+++ b/test/e2e/fixture-builder.js
@@ -769,7 +769,7 @@ class FixtureBuilder {
                 maxPriorityFeePerGas: '0x59682f00',
               },
               id: 7911313280012623,
-              loadingDefaults: true,
+
               metamaskNetworkId: '1337',
               origin: 'https://metamask.github.io',
               status: 'unapproved',
@@ -784,18 +784,9 @@ class FixtureBuilder {
               },
               type: 'simpleSend',
             },
-            [
-              {
-                note: 'Added new unapproved transaction.',
-                op: 'replace',
-                path: '/loadingDefaults',
-                timestamp: 1631545992244,
-                value: false,
-              },
-            ],
           ],
           id: 7911313280012623,
-          loadingDefaults: false,
+
           metamaskNetworkId: '1337',
           origin: 'https://metamask.github.io',
           status: 'unapproved',
@@ -826,7 +817,7 @@ class FixtureBuilder {
                 maxPriorityFeePerGas: '0x59682f00',
               },
               id: 7911313280012624,
-              loadingDefaults: true,
+
               metamaskNetworkId: '1337',
               origin: 'https://metamask.github.io',
               status: 'unapproved',
@@ -841,18 +832,9 @@ class FixtureBuilder {
               },
               type: 'simpleSend',
             },
-            [
-              {
-                note: 'Added new unapproved transaction.',
-                op: 'replace',
-                path: '/loadingDefaults',
-                timestamp: 1631545994695,
-                value: false,
-              },
-            ],
           ],
           id: 7911313280012624,
-          loadingDefaults: false,
+
           metamaskNetworkId: '1337',
           origin: 'https://metamask.github.io',
           status: 'unapproved',
@@ -883,7 +865,7 @@ class FixtureBuilder {
                 maxPriorityFeePerGas: '0x59682f00',
               },
               id: 7911313280012625,
-              loadingDefaults: true,
+
               metamaskNetworkId: '1337',
               origin: 'https://metamask.github.io',
               status: 'unapproved',
@@ -898,18 +880,9 @@ class FixtureBuilder {
               },
               type: 'simpleSend',
             },
-            [
-              {
-                note: 'Added new unapproved transaction.',
-                op: 'replace',
-                path: '/loadingDefaults',
-                timestamp: 1631545996678,
-                value: false,
-              },
-            ],
           ],
           id: 7911313280012625,
-          loadingDefaults: false,
+
           metamaskNetworkId: '1337',
           origin: 'https://metamask.github.io',
           status: 'unapproved',
@@ -940,7 +913,7 @@ class FixtureBuilder {
                 maxPriorityFeePerGas: '0x59682f00',
               },
               id: 7911313280012626,
-              loadingDefaults: true,
+
               metamaskNetworkId: '1337',
               origin: 'https://metamask.github.io',
               status: 'unapproved',
@@ -955,18 +928,9 @@ class FixtureBuilder {
               },
               type: 'simpleSend',
             },
-            [
-              {
-                note: 'Added new unapproved transaction.',
-                op: 'replace',
-                path: '/loadingDefaults',
-                timestamp: 1631545998677,
-                value: false,
-              },
-            ],
           ],
           id: 7911313280012626,
-          loadingDefaults: false,
+
           metamaskNetworkId: '1337',
           origin: 'https://metamask.github.io',
           status: 'unapproved',
@@ -994,7 +958,7 @@ class FixtureBuilder {
             {
               chainId: CHAIN_IDS.LOCALHOST,
               id: 4046084157914634,
-              loadingDefaults: true,
+
               metamaskNetworkId: '1337',
               origin: 'metamask',
               status: 'unapproved',
@@ -1008,24 +972,15 @@ class FixtureBuilder {
               },
               type: 'simpleSend',
             },
-            [
-              {
-                note: 'Added new unapproved transaction.',
-                op: 'replace',
-                path: '/loadingDefaults',
-                timestamp: 1617228030069,
-                value: false,
-              },
-            ],
           ],
           id: 4046084157914634,
-          loadingDefaults: false,
+
           metamaskNetworkId: '1337',
           origin: 'metamask',
           primaryTransaction: {
             chainId: CHAIN_IDS.LOCALHOST,
             id: 4046084157914634,
-            loadingDefaults: true,
+
             metamaskNetworkId: '1337',
             origin: 'metamask',
             status: 'unapproved',
@@ -1063,7 +1018,7 @@ class FixtureBuilder {
             {
               chainId: CHAIN_IDS.LOCALHOST,
               id: 4046084157914634,
-              loadingDefaults: true,
+
               metamaskNetworkId: '1337',
               origin: 'metamask',
               status: 'unapproved',
@@ -1079,24 +1034,15 @@ class FixtureBuilder {
               },
               type: 'simpleSend',
             },
-            [
-              {
-                note: 'Added new unapproved transaction.',
-                op: 'replace',
-                path: '/loadingDefaults',
-                timestamp: 1617228030069,
-                value: false,
-              },
-            ],
           ],
           id: 4046084157914634,
-          loadingDefaults: false,
+
           metamaskNetworkId: '1337',
           origin: 'metamask',
           primaryTransaction: {
             chainId: CHAIN_IDS.LOCALHOST,
             id: 4046084157914634,
-            loadingDefaults: true,
+
             metamaskNetworkId: '1337',
             origin: 'metamask',
             status: 'unapproved',
@@ -1138,7 +1084,7 @@ class FixtureBuilder {
             {
               chainId: CHAIN_IDS.LOCALHOST,
               id: 4046084157914634,
-              loadingDefaults: true,
+
               metamaskNetworkId: '1337',
               origin: 'metamask',
               status: 'unapproved',
@@ -1154,15 +1100,6 @@ class FixtureBuilder {
               },
               type: 'simpleSend',
             },
-            [
-              {
-                note: 'Added new unapproved transaction.',
-                op: 'replace',
-                path: '/loadingDefaults',
-                timestamp: 1617228030069,
-                value: false,
-              },
-            ],
             [
               {
                 op: 'add',
@@ -1201,13 +1138,13 @@ class FixtureBuilder {
             ],
           ],
           id: 4046084157914634,
-          loadingDefaults: false,
+
           metamaskNetworkId: '1337',
           origin: 'metamask',
           primaryTransaction: {
             chainId: CHAIN_IDS.LOCALHOST,
             id: 4046084157914634,
-            loadingDefaults: true,
+
             metamaskNetworkId: '1337',
             origin: 'metamask',
             status: 'approved',
@@ -1249,7 +1186,7 @@ class FixtureBuilder {
             {
               chainId: CHAIN_IDS.LOCALHOST,
               id: 5748272735958801,
-              loadingDefaults: true,
+
               metamaskNetworkId: '1337',
               origin: 'metamask',
               status: 'unapproved',
@@ -1265,15 +1202,6 @@ class FixtureBuilder {
               },
               type: 'simpleSend',
             },
-            [
-              {
-                note: 'Added new unapproved transaction.',
-                op: 'replace',
-                path: '/loadingDefaults',
-                timestamp: 1671635506520,
-                value: false,
-              },
-            ],
             [
               {
                 note: 'confTx: user approved transaction',
@@ -1388,7 +1316,7 @@ class FixtureBuilder {
             ],
           ],
           id: 5748272735958801,
-          loadingDefaults: false,
+
           metamaskNetworkId: '5',
           nonceDetails: {
             local: {

--- a/test/jest/mock-store.js
+++ b/test/jest/mock-store.js
@@ -163,7 +163,7 @@ export const createSwapsMockStore = () => {
           originalGasEstimate: '0x7548',
           userEditedGasLimit: false,
           chainId: '0x5',
-          loadingDefaults: false,
+
           dappSuggestedGasFees: null,
           sendFlowHistory: null,
           txParams: {

--- a/test/jest/mock-store.js
+++ b/test/jest/mock-store.js
@@ -163,7 +163,6 @@ export const createSwapsMockStore = () => {
           originalGasEstimate: '0x7548',
           userEditedGasLimit: false,
           chainId: '0x5',
-
           dappSuggestedGasFees: null,
           sendFlowHistory: null,
           txParams: {

--- a/test/stub/tx-meta-stub.js
+++ b/test/stub/tx-meta-stub.js
@@ -10,7 +10,6 @@ export const txMetaStub = {
   history: [
     {
       id: 405984854664302,
-
       metamaskNetworkId: '5',
       status: TransactionStatus.unapproved,
       time: 1572395156620,
@@ -154,7 +153,6 @@ export const txMetaStub = {
     ],
   ],
   id: 405984854664302,
-
   metamaskNetworkId: '5',
   nonceDetails: {
     local: {

--- a/test/stub/tx-meta-stub.js
+++ b/test/stub/tx-meta-stub.js
@@ -10,7 +10,7 @@ export const txMetaStub = {
   history: [
     {
       id: 405984854664302,
-      loadingDefaults: true,
+
       metamaskNetworkId: '5',
       status: TransactionStatus.unapproved,
       time: 1572395156620,
@@ -23,14 +23,6 @@ export const txMetaStub = {
         value: '0x0',
       },
     },
-    [
-      {
-        op: 'replace',
-        path: '/loadingDefaults',
-        timestamp: 1572395156645,
-        value: false,
-      },
-    ],
     [
       {
         note: '#newUnapprovedTransaction - adding the origin',
@@ -162,7 +154,7 @@ export const txMetaStub = {
     ],
   ],
   id: 405984854664302,
-  loadingDefaults: false,
+
   metamaskNetworkId: '5',
   nonceDetails: {
     local: {

--- a/ui/components/app/approve-content-card/approve-content-card.stories.js
+++ b/ui/components/app/approve-content-card/approve-content-card.stories.js
@@ -97,7 +97,6 @@ export default {
       originalGasEstimate: '0xea60',
       userEditedGasLimit: false,
       chainId: '0x3',
-
       dappSuggestedGasFees: {
         gasPrice: '0x4a817c800',
         gas: '0xea60',
@@ -123,7 +122,6 @@ export default {
           originalGasEstimate: '0xea60',
           userEditedGasLimit: false,
           chainId: '0x3',
-
           dappSuggestedGasFees: {
             gasPrice: '0x4a817c800',
             gas: '0xea60',

--- a/ui/components/app/approve-content-card/approve-content-card.stories.js
+++ b/ui/components/app/approve-content-card/approve-content-card.stories.js
@@ -97,7 +97,7 @@ export default {
       originalGasEstimate: '0xea60',
       userEditedGasLimit: false,
       chainId: '0x3',
-      loadingDefaults: false,
+
       dappSuggestedGasFees: {
         gasPrice: '0x4a817c800',
         gas: '0xea60',
@@ -123,7 +123,7 @@ export default {
           originalGasEstimate: '0xea60',
           userEditedGasLimit: false,
           chainId: '0x3',
-          loadingDefaults: true,
+
           dappSuggestedGasFees: {
             gasPrice: '0x4a817c800',
             gas: '0xea60',
@@ -156,11 +156,6 @@ export default {
             op: 'add',
             path: '/txParams/maxPriorityFeePerGas',
             value: '0x4a817c800',
-          },
-          {
-            op: 'replace',
-            path: '/loadingDefaults',
-            value: false,
           },
           {
             op: 'add',

--- a/ui/components/app/confirm-page-container/confirm-page-container-container.test.js
+++ b/ui/components/app/confirm-page-container/confirm-page-container-container.test.js
@@ -36,7 +36,7 @@ const props = {
     metamaskNetworkId: '5',
     originalGasEstimate: '0x5208',
     userEditedGasLimit: false,
-    loadingDefaults: false,
+
     dappSuggestedGasFees: null,
     sendFlowHistory: [],
     txParams: {
@@ -70,7 +70,7 @@ const props = {
     originalGasEstimate: '0xea60',
     userEditedGasLimit: false,
     chainId: '0x13881',
-    loadingDefaults: false,
+
     dappSuggestedGasFees: {
       gasPrice: '0x4a817c800',
       gas: '0xea60',
@@ -96,7 +96,7 @@ const props = {
         originalGasEstimate: '0xea60',
         userEditedGasLimit: false,
         chainId: '0x13881',
-        loadingDefaults: true,
+
         dappSuggestedGasFees: {
           gasPrice: '0x4a817c800',
           gas: '0xea60',
@@ -129,11 +129,6 @@ const props = {
           op: 'add',
           path: '/txParams/maxPriorityFeePerGas',
           value: '0x0',
-        },
-        {
-          op: 'replace',
-          path: '/loadingDefaults',
-          value: false,
         },
         {
           op: 'add',

--- a/ui/components/app/confirm-page-container/confirm-page-container-container.test.js
+++ b/ui/components/app/confirm-page-container/confirm-page-container-container.test.js
@@ -36,7 +36,6 @@ const props = {
     metamaskNetworkId: '5',
     originalGasEstimate: '0x5208',
     userEditedGasLimit: false,
-
     dappSuggestedGasFees: null,
     sendFlowHistory: [],
     txParams: {
@@ -70,7 +69,6 @@ const props = {
     originalGasEstimate: '0xea60',
     userEditedGasLimit: false,
     chainId: '0x13881',
-
     dappSuggestedGasFees: {
       gasPrice: '0x4a817c800',
       gas: '0xea60',
@@ -96,7 +94,6 @@ const props = {
         originalGasEstimate: '0xea60',
         userEditedGasLimit: false,
         chainId: '0x13881',
-
         dappSuggestedGasFees: {
           gasPrice: '0x4a817c800',
           gas: '0xea60',

--- a/ui/components/app/transaction-activity-log/transaction-activity-log.util.test.js
+++ b/ui/components/app/transaction-activity-log/transaction-activity-log.util.test.js
@@ -25,7 +25,7 @@ describe('TransactionActivityLog utils', () => {
               status: TransactionStatus.unapproved,
               metamaskNetworkId: '5',
               chainId: '0x5',
-              loadingDefaults: true,
+
               txParams: {
                 from: '0x50a9d56c2b8ba9a5c7f2c08c3d26e0499f23a706',
                 to: '0xc5ae6383e126f901dcb06131d97a88745bfa88d6',
@@ -70,7 +70,7 @@ describe('TransactionActivityLog utils', () => {
             ],
           ],
           id: 6400627574331058,
-          loadingDefaults: false,
+
           metamaskNetworkId: '5',
           chainId: '0x5',
           status: TransactionStatus.dropped,
@@ -95,7 +95,7 @@ describe('TransactionActivityLog utils', () => {
               status: TransactionStatus.unapproved,
               metamaskNetworkId: '5',
               chainId: '0x5',
-              loadingDefaults: false,
+
               txParams: {
                 from: '0x50a9d56c2b8ba9a5c7f2c08c3d26e0499f23a706',
                 to: '0xc5ae6383e126f901dcb06131d97a88745bfa88d6',
@@ -163,7 +163,7 @@ describe('TransactionActivityLog utils', () => {
           ],
           id: 6400627574331060,
           lastGasPrice: '0x4190ab00',
-          loadingDefaults: false,
+
           metamaskNetworkId: '5',
           chainId: '0x5',
           status: TransactionStatus.confirmed,
@@ -251,7 +251,7 @@ describe('TransactionActivityLog utils', () => {
         history: [
           {
             id: 5559712943815343,
-            loadingDefaults: true,
+
             metamaskNetworkId: '5',
             chainId: '0x5',
             status: TransactionStatus.unapproved,
@@ -265,14 +265,6 @@ describe('TransactionActivityLog utils', () => {
               value: '0x2386f26fc10000',
             },
           },
-          [
-            {
-              op: 'replace',
-              path: '/loadingDefaults',
-              timestamp: 1535507561515,
-              value: false,
-            },
-          ],
           [
             {
               note: '#newUnapprovedTransaction - adding the origin',

--- a/ui/components/app/transaction-activity-log/transaction-activity-log.util.test.js
+++ b/ui/components/app/transaction-activity-log/transaction-activity-log.util.test.js
@@ -25,7 +25,6 @@ describe('TransactionActivityLog utils', () => {
               status: TransactionStatus.unapproved,
               metamaskNetworkId: '5',
               chainId: '0x5',
-
               txParams: {
                 from: '0x50a9d56c2b8ba9a5c7f2c08c3d26e0499f23a706',
                 to: '0xc5ae6383e126f901dcb06131d97a88745bfa88d6',
@@ -70,7 +69,6 @@ describe('TransactionActivityLog utils', () => {
             ],
           ],
           id: 6400627574331058,
-
           metamaskNetworkId: '5',
           chainId: '0x5',
           status: TransactionStatus.dropped,
@@ -95,7 +93,6 @@ describe('TransactionActivityLog utils', () => {
               status: TransactionStatus.unapproved,
               metamaskNetworkId: '5',
               chainId: '0x5',
-
               txParams: {
                 from: '0x50a9d56c2b8ba9a5c7f2c08c3d26e0499f23a706',
                 to: '0xc5ae6383e126f901dcb06131d97a88745bfa88d6',
@@ -163,7 +160,6 @@ describe('TransactionActivityLog utils', () => {
           ],
           id: 6400627574331060,
           lastGasPrice: '0x4190ab00',
-
           metamaskNetworkId: '5',
           chainId: '0x5',
           status: TransactionStatus.confirmed,
@@ -251,7 +247,6 @@ describe('TransactionActivityLog utils', () => {
         history: [
           {
             id: 5559712943815343,
-
             metamaskNetworkId: '5',
             chainId: '0x5',
             status: TransactionStatus.unapproved,

--- a/ui/ducks/confirm-transaction/confirm-transaction.duck.test.js
+++ b/ui/ducks/confirm-transaction/confirm-transaction.duck.test.js
@@ -275,7 +275,7 @@ describe('Confirm Transaction Duck', () => {
       const txData = {
         history: [],
         id: 2603411941761054,
-        loadingDefaults: false,
+
         metamaskNetworkId: '5',
         origin: 'faucet.metamask.io',
         status: TransactionStatus.unapproved,
@@ -360,7 +360,7 @@ describe('Confirm Transaction Duck', () => {
             2603411941761054: {
               history: [],
               id: 2603411941761054,
-              loadingDefaults: false,
+
               metamaskNetworkId: '5',
               origin: 'faucet.metamask.io',
               status: TransactionStatus.unapproved,

--- a/ui/ducks/confirm-transaction/confirm-transaction.duck.test.js
+++ b/ui/ducks/confirm-transaction/confirm-transaction.duck.test.js
@@ -275,7 +275,6 @@ describe('Confirm Transaction Duck', () => {
       const txData = {
         history: [],
         id: 2603411941761054,
-
         metamaskNetworkId: '5',
         origin: 'faucet.metamask.io',
         status: TransactionStatus.unapproved,
@@ -360,7 +359,6 @@ describe('Confirm Transaction Duck', () => {
             2603411941761054: {
               history: [],
               id: 2603411941761054,
-
               metamaskNetworkId: '5',
               origin: 'faucet.metamask.io',
               status: TransactionStatus.unapproved,

--- a/ui/pages/confirm-send-ether/confirm-send-ether.stories.js
+++ b/ui/pages/confirm-send-ether/confirm-send-ether.stories.js
@@ -13,7 +13,6 @@ const sendEther = {
   originalGasEstimate: '0x5208',
   userEditedGasLimit: false,
   chainId: '0x5',
-
   dappSuggestedGasFees: {
     maxPriorityFeePerGas: '0x3b9aca00',
     maxFeePerGas: '0x2540be400',

--- a/ui/pages/confirm-send-ether/confirm-send-ether.stories.js
+++ b/ui/pages/confirm-send-ether/confirm-send-ether.stories.js
@@ -13,7 +13,7 @@ const sendEther = {
   originalGasEstimate: '0x5208',
   userEditedGasLimit: false,
   chainId: '0x5',
-  loadingDefaults: false,
+
   dappSuggestedGasFees: {
     maxPriorityFeePerGas: '0x3b9aca00',
     maxFeePerGas: '0x2540be400',

--- a/ui/pages/confirm-send-ether/confirm-send-ether.test.js
+++ b/ui/pages/confirm-send-ether/confirm-send-ether.test.js
@@ -23,7 +23,6 @@ const sendEther = {
   originalGasEstimate: '0x5208',
   userEditedGasLimit: false,
   chainId: '0x5',
-
   dappSuggestedGasFees: {
     maxPriorityFeePerGas: '0x3b9aca00',
     maxFeePerGas: '0x2540be400',

--- a/ui/pages/confirm-send-ether/confirm-send-ether.test.js
+++ b/ui/pages/confirm-send-ether/confirm-send-ether.test.js
@@ -23,7 +23,7 @@ const sendEther = {
   originalGasEstimate: '0x5208',
   userEditedGasLimit: false,
   chainId: '0x5',
-  loadingDefaults: false,
+
   dappSuggestedGasFees: {
     maxPriorityFeePerGas: '0x3b9aca00',
     maxFeePerGas: '0x2540be400',

--- a/ui/pages/confirm-transaction-base/confirm-transaction-base.test.js
+++ b/ui/pages/confirm-transaction-base/confirm-transaction-base.test.js
@@ -139,7 +139,6 @@ const baseStore = {
       originalGasEstimate: '0x5208',
       userEditedGasLimit: false,
       chainId: '0x5',
-
       dappSuggestedGasFees: null,
       sendFlowHistory: [],
       origin: 'metamask',

--- a/ui/pages/confirm-transaction-base/confirm-transaction-base.test.js
+++ b/ui/pages/confirm-transaction-base/confirm-transaction-base.test.js
@@ -139,7 +139,7 @@ const baseStore = {
       originalGasEstimate: '0x5208',
       userEditedGasLimit: false,
       chainId: '0x5',
-      loadingDefaults: false,
+
       dappSuggestedGasFees: null,
       sendFlowHistory: [],
       origin: 'metamask',

--- a/ui/pages/send/send.test.js
+++ b/ui/pages/send/send.test.js
@@ -229,7 +229,7 @@ describe('Send Page', () => {
             status: 'unapproved',
             metamaskNetworkId: '5',
             chainId: '0x5',
-            loadingDefaults: false,
+
             txParams: {
               from: '0x64a845a5b02460acf8a3d84503b0d68d028b4bb4',
               to: '0xaD6D458402F60fD3Bd25163575031ACDce07538D',
@@ -267,7 +267,7 @@ describe('Send Page', () => {
             status: 'unapproved',
             metamaskNetworkId: '5',
             chainId: '0x5',
-            loadingDefaults: false,
+
             txParams: {
               from: '0x64a845a5b02460acf8a3d84503b0d68d028b4bb4',
               to: '0xaD6D458402F60fD3Bd25163575031ACDce07538D',

--- a/ui/pages/send/send.test.js
+++ b/ui/pages/send/send.test.js
@@ -229,7 +229,6 @@ describe('Send Page', () => {
             status: 'unapproved',
             metamaskNetworkId: '5',
             chainId: '0x5',
-
             txParams: {
               from: '0x64a845a5b02460acf8a3d84503b0d68d028b4bb4',
               to: '0xaD6D458402F60fD3Bd25163575031ACDce07538D',
@@ -267,7 +266,6 @@ describe('Send Page', () => {
             status: 'unapproved',
             metamaskNetworkId: '5',
             chainId: '0x5',
-
             txParams: {
               from: '0x64a845a5b02460acf8a3d84503b0d68d028b4bb4',
               to: '0xaD6D458402F60fD3Bd25163575031ACDce07538D',

--- a/ui/pages/token-allowance/token-allowance.stories-to-do.js
+++ b/ui/pages/token-allowance/token-allowance.stories-to-do.js
@@ -102,7 +102,6 @@ export default {
       originalGasEstimate: '0xea60',
       userEditedGasLimit: false,
       chainId: '0x3',
-
       dappSuggestedGasFees: {
         gasPrice: '0x4a817c800',
         gas: '0xea60',
@@ -128,7 +127,6 @@ export default {
           originalGasEstimate: '0xea60',
           userEditedGasLimit: false,
           chainId: '0x3',
-
           dappSuggestedGasFees: {
             gasPrice: '0x4a817c800',
             gas: '0xea60',

--- a/ui/pages/token-allowance/token-allowance.stories-to-do.js
+++ b/ui/pages/token-allowance/token-allowance.stories-to-do.js
@@ -102,7 +102,7 @@ export default {
       originalGasEstimate: '0xea60',
       userEditedGasLimit: false,
       chainId: '0x3',
-      loadingDefaults: false,
+
       dappSuggestedGasFees: {
         gasPrice: '0x4a817c800',
         gas: '0xea60',
@@ -128,7 +128,7 @@ export default {
           originalGasEstimate: '0xea60',
           userEditedGasLimit: false,
           chainId: '0x3',
-          loadingDefaults: true,
+
           dappSuggestedGasFees: {
             gasPrice: '0x4a817c800',
             gas: '0xea60',
@@ -161,11 +161,6 @@ export default {
             op: 'add',
             path: '/txParams/maxPriorityFeePerGas',
             value: '0x4a817c800',
-          },
-          {
-            op: 'replace',
-            path: '/loadingDefaults',
-            value: false,
           },
           {
             op: 'add',

--- a/ui/pages/token-allowance/token-allowance.test.js
+++ b/ui/pages/token-allowance/token-allowance.test.js
@@ -167,7 +167,6 @@ describe('TokenAllowancePage', () => {
       originalGasEstimate: '0xea60',
       userEditedGasLimit: false,
       chainId: '0x3',
-
       dappSuggestedGasFees: {
         gasPrice: '0x4a817c800',
         gas: '0xea60',

--- a/ui/pages/token-allowance/token-allowance.test.js
+++ b/ui/pages/token-allowance/token-allowance.test.js
@@ -167,7 +167,7 @@ describe('TokenAllowancePage', () => {
       originalGasEstimate: '0xea60',
       userEditedGasLimit: false,
       chainId: '0x3',
-      loadingDefaults: false,
+
       dappSuggestedGasFees: {
         gasPrice: '0x4a817c800',
         gas: '0xea60',


### PR DESCRIPTION
## Explanation

This PR aims to remove `loadingDefaults` property from `TransactionMeta` since it's been unused in client. 

Fixing https://github.com/MetaMask/MetaMask-planning/issues/1081

## Manual Testing Steps

No functional change here so expect transactions to be work as usual.

## Pre-merge author checklist

- [X] I've clearly explained:
  - [X] What problem this PR is solving
  - [X] How this problem was solved
  - [X] How reviewers can test my changes
- [X] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
