### PR TITLE
Adding previously allowed Text types to ButtonBase

### DIFF
--- a/ui/components/component-library/button-base/button-base.types.ts
+++ b/ui/components/component-library/button-base/button-base.types.ts
@@ -1,10 +1,7 @@
 import { ReactNode } from 'react';
-import type {
-  StyleUtilityProps,
-  PolymorphicComponentPropWithRef,
-} from '../box';
+import type { PolymorphicComponentPropWithRef } from '../box';
 import { IconColor } from '../../../helpers/constants/design-system';
-import { TextDirection, TextProps } from '../text';
+import { TextDirection, TextProps, TextStyleUtilityProps } from '../text';
 import { IconName } from '../icon';
 import type { IconProps } from '../icon';
 
@@ -15,7 +12,9 @@ export enum ButtonBaseSize {
 }
 
 export type ValidButtonTagType = 'button' | 'a';
-export interface ButtonBaseStyleUtilityProps extends StyleUtilityProps {
+
+export interface ButtonBaseStyleUtilityProps
+  extends Omit<TextStyleUtilityProps, 'as' | 'children' | 'ellipsis'> {
   /**
    * The polymorphic `as` prop allows you to change the root HTML element of the Button component between `button` and `a` tag
    *

--- a/ui/components/component-library/button-link/button-link.tsx
+++ b/ui/components/component-library/button-link/button-link.tsx
@@ -13,7 +13,7 @@ import { ButtonLinkSize, ButtonLinkComponent } from './button-link.types';
 export const ButtonLink: ButtonLinkComponent = React.forwardRef(
   <C extends React.ElementType = 'button' | 'a'>(
     {
-      className,
+      className = '',
       color,
       danger = false,
       disabled = false,

--- a/ui/components/component-library/button-primary/button-primary.tsx
+++ b/ui/components/component-library/button-primary/button-primary.tsx
@@ -17,7 +17,7 @@ import {
 export const ButtonPrimary: ButtonPrimaryComponent = React.forwardRef(
   <C extends React.ElementType = 'button' | 'a'>(
     {
-      className,
+      className = '',
       danger = false,
       disabled = false,
       size = ButtonPrimarySize.Md,

--- a/ui/components/component-library/button/button.types.ts
+++ b/ui/components/component-library/button/button.types.ts
@@ -23,15 +23,15 @@ type ButtonPropsByVariant = {
   [ButtonVariant.Primary]: {
     variant?: ButtonVariant.Primary;
     size?: ValidButtonSize; // Allows for only ButtonSize.Sm, ButtonSize.Md, ButtonSize.Lg
-  } & Omit<ButtonPrimaryStyleUtilityProps, 'size'>;
+  } & Omit<ButtonPrimaryStyleUtilityProps, 'size' | 'variant'>;
   [ButtonVariant.Secondary]: {
     variant?: ButtonVariant.Secondary;
     size?: ValidButtonSize; // Allows for only ButtonSize.Sm, ButtonSize.Md, ButtonSize.Lg
-  } & Omit<ButtonSecondaryStyleUtilityProps, 'size'>;
+  } & Omit<ButtonSecondaryStyleUtilityProps, 'size' | 'variant'>;
   [ButtonVariant.Link]: {
     variant?: ButtonVariant.Link;
     size?: ButtonSize;
-  } & Omit<ButtonLinkStyleUtilityProps, 'size'>;
+  } & Omit<ButtonLinkStyleUtilityProps, 'size' | 'variant'>;
 };
 
 type ButtonPropsMap = {


### PR DESCRIPTION
## Explanation
Currently, if you were to add a `Text` props such as `overflowWrap`, `fontWeight` etc to a button component from the component-library in a `.tsx` file you would receive a type error. This should not be the case because the `Text` component is what's used as a base for the buttons and there are instances where they should be used. This PR adds the correct types so `ButtonBase` and all button variants `ButtonPrimary`, `ButtonSecondary`, `ButtonLink` and `Button` so they accept `Text` props

* Fixes #20644

## Screenshots/Screencaps

### Before
<img width="584" alt="Screenshot 2023-08-29 at 10 40 59 AM" src="https://github.com/MetaMask/metamask-extension/assets/8112138/c9269636-6028-484e-bf23-eb81928df8ea">
<img width="595" alt="Screenshot 2023-08-29 at 10 41 39 AM" src="https://github.com/MetaMask/metamask-extension/assets/8112138/4dd77613-618c-4d95-b8f4-217d3ea523b3">
<img width="647" alt="Screenshot 2023-08-29 at 10 42 18 AM" src="https://github.com/MetaMask/metamask-extension/assets/8112138/bfdd5eb5-8cb7-4656-88c8-39c7626915cd">
<img width="657" alt="Screenshot 2023-08-29 at 10 42 54 AM" src="https://github.com/MetaMask/metamask-extension/assets/8112138/6251885c-e681-499b-aedf-e843445737a2">



### After

<img width="463" alt="Screenshot 2023-08-29 at 10 43 59 AM" src="https://github.com/MetaMask/metamask-extension/assets/8112138/d4e99a3e-fa7b-4ffb-b58c-4e0ff138a01a">
<img width="544" alt="Screenshot 2023-08-29 at 10 44 11 AM" src="https://github.com/MetaMask/metamask-extension/assets/8112138/654ca96a-7ca8-4e23-aa15-6dfd6b5f62fb">
<img width="540" alt="Screenshot 2023-08-29 at 10 44 27 AM" src="https://github.com/MetaMask/metamask-extension/assets/8112138/8f7970ca-72bd-4858-914e-a68830ecdba0">
<img width="505" alt="Screenshot 2023-08-29 at 10 44 56 AM" src="https://github.com/MetaMask/metamask-extension/assets/8112138/af8c3707-03c8-4f98-a7f9-aede0908ff9c">


## Manual Testing Steps

- Pull this branch
- Go to any of the button component storybook files
- `ui/components/component-library/button/button.stories.tsx`
- `ui/components/component-library/button-link/button-link.stories.tsx`
- `ui/components/component-library/button-primary/button-primary.stories.tsx`
- `ui/components/component-library/button-secondary/button-secondary.stories.tsx`
- Add an `overflowWrap` prop to one of the stories and use the `OverflowWrap` enum from `../../../helpers/constants/design-system`
- See that there is no type error

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
