### PR TITLE
use @blockaid/ppom_release vs @blockaid/ppom

### DIFF
--- a/app/scripts/lib/ppom/ppom-middleware.ts
+++ b/app/scripts/lib/ppom/ppom-middleware.ts
@@ -1,4 +1,4 @@
-import { PPOM } from '@blockaid/ppom';
+import { PPOM } from '@blockaid/ppom_release';
 import { PPOMController } from '@metamask/ppom-validator';
 
 import {

--- a/development/build/static.js
+++ b/development/build/static.js
@@ -204,7 +204,7 @@ function getCopyTargets(
 
   if (activeFeatures.includes('blockaid')) {
     allCopyTargets.push({
-      src: getPathInsideNodeModules('@blockaid/ppom', '/'),
+      src: getPathInsideNodeModules('@blockaid/ppom_release', '/'),
       pattern: '*.wasm',
       dest: '',
     });

--- a/package.json
+++ b/package.json
@@ -206,7 +206,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.18.9",
-    "@blockaid/ppom": "^1.1.1",
+    "@blockaid/ppom_release": "^1.2.6",
     "@download/blockies": "^1.0.3",
     "@ensdomains/content-hash": "^2.5.6",
     "@ethereumjs/common": "^3.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1612,10 +1612,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@blockaid/ppom@npm:^1.1.1":
-  version: 1.1.1
-  resolution: "@blockaid/ppom@npm:1.1.1"
-  checksum: d12ae3ee9e91ce8719381f828834b9dc438671482608fc39a82c854e203be327b5d7feaaac378b7eb8132e0596e202a699f889bbf863ae26f45fa4d44512b4b3
+"@blockaid/ppom_release@npm:^1.2.6":
+  version: 1.2.6
+  resolution: "@blockaid/ppom_release@npm:1.2.6"
+  checksum: 090d5f3f7422b9b1d66619fd0412ac865457fa2f30426380f4adaad11a2d93d5f1c4a0f67e2a1d20af50edf6e1b09cbd6cb5d7972dcaab5cbbbc4c52cfa0507a
   languageName: node
   linkType: hard
 
@@ -24169,7 +24169,7 @@ __metadata:
     "@babel/preset-typescript": "npm:^7.16.7"
     "@babel/register": "npm:^7.5.5"
     "@babel/runtime": "npm:^7.18.9"
-    "@blockaid/ppom": "npm:^1.1.1"
+    "@blockaid/ppom_release": "npm:^1.2.6"
     "@download/blockies": "npm:^1.0.3"
     "@ensdomains/content-hash": "npm:^2.5.6"
     "@ethereumjs/common": "npm:^3.1.1"


### PR DESCRIPTION
## Explanation
@blockaid/ppom was made private, and a new package @blockaid/ppom_release was published. We have been advised to use the new version.

## Manual Testing Steps
1. There presumably shouldn't be functional changes. The one place we used the PPOM object from the package was as a type, and in the buildsystem. But I am unaware of how it all works together. Regardless its behind a feature flag so any issues with this can be resolved by the team working with Blockaid after the pipeline is restored.
2. 
## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
