### PR TITLE
style: Fix Settings pages padding

### DIFF
--- a/ui/pages/settings/index.scss
+++ b/ui/pages/settings/index.scss
@@ -259,10 +259,6 @@
 
   &__body {
     padding: 24px;
-
-    @include screen-sm-min {
-      padding: 12px;
-    }
   }
 
   &__content-row {


### PR DESCRIPTION
## Explanation

Fixes https://github.com/MetaMask/metamask-extension/issues/20673
<!--
Thanks for the pull request. Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues, Slack conversations, Zendesk issues, user stories, etc. reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

This fix adds padding to the settings page body as `.settings-page__body` has not been aligned with the settings page header.

## Screenshots/Screencaps

<!-- If you're making a change to the UI, make sure to capture a screenshot or a short video showing off your work! -->

### Before
<img width="1147" alt="Screenshot 2023-08-30 at 2 57 43 PM" src="https://github.com/MetaMask/metamask-extension/assets/20778143/1b35c541-6838-466d-b446-52d4cc2dea3c">
<img width="1142" alt="Screenshot 2023-08-30 at 2 57 49 PM" src="https://github.com/MetaMask/metamask-extension/assets/20778143/8b155eaa-5e59-4bab-b465-1024284f509d">
<img width="1123" alt="Screenshot 2023-08-30 at 3 00 16 PM" src="https://github.com/MetaMask/metamask-extension/assets/20778143/f7164724-21a6-45c7-9b97-8db67264f369">
<img width="1115" alt="Screenshot 2023-08-30 at 3 00 27 PM" src="https://github.com/MetaMask/metamask-extension/assets/20778143/5e167459-512b-41d6-9a9c-c4a598206e42">
<img width="1142" alt="Screenshot 2023-08-30 at 3 00 33 PM" src="https://github.com/MetaMask/metamask-extension/assets/20778143/4e38f329-dd0c-437a-9690-7f2c58c93ba1">

<!-- How did the UI you changed look before your changes? Drag your file(s) below this line: -->

### After
<img width="1152" alt="Screenshot 2023-08-30 at 3 12 37 PM" src="https://github.com/MetaMask/metamask-extension/assets/20778143/b52a8254-1256-4259-8486-9a38a5a554da">
<img width="1136" alt="Screenshot 2023-08-30 at 3 12 42 PM" src="https://github.com/MetaMask/metamask-extension/assets/20778143/b4c0989d-337b-4716-89f7-0254c12f3dbd">
<img width="1139" alt="Screenshot 2023-08-30 at 3 13 01 PM" src="https://github.com/MetaMask/metamask-extension/assets/20778143/9dc2f619-eff2-43c5-8f8e-f78588b0170a">
<img width="1123" alt="Screenshot 2023-08-30 at 3 13 09 PM" src="https://github.com/MetaMask/metamask-extension/assets/20778143/9824eb88-9fc8-4ab8-bb95-6ce401ee8966">
<img width="1132" alt="Screenshot 2023-08-30 at 3 16 11 PM" src="https://github.com/MetaMask/metamask-extension/assets/20778143/32366f25-c165-43fd-b5ce-13dd4903cdb4">

### Smaller views remain the same 
<img width="527" alt="Screenshot 2023-08-30 at 3 19 00 PM" src="https://github.com/MetaMask/metamask-extension/assets/20778143/4cf2ad38-060a-4057-abdb-659c25780be8">

<!-- How does it look now? Drag your file(s) below this line: -->

## Manual Testing Steps

<!--
How should reviewers and QA manually test your changes? For instance:

- Go to this screen
- Do this
- Then do this
-->

## Pre-merge author checklist

- [ ] I've clearly explained:
  - [ ] What problem this PR is solving
  - [ ] How this problem was solved
  - [ ] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
