### PR TITLE
style: update Settings > Experimental > Desktop App - adds section header

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -1159,6 +1159,9 @@
     "message": "Description from $1",
     "description": "$1 represents the name of the snap"
   },
+  "desktopApp": {
+    "message": "Desktop App"
+  },
   "desktopConnectionCriticalErrorDescription": {
     "message": "This error could be intermittent, so try restarting the extension or disable MetaMask Desktop."
   },

--- a/ui/pages/settings/experimental-tab/__snapshots__/experimental-tab.test.js.snap
+++ b/ui/pages/settings/experimental-tab/__snapshots__/experimental-tab.test.js.snap
@@ -197,19 +197,22 @@ exports[`ExperimentalTab with desktop enabled renders ExperimentalTab component 
         </div>
       </div>
     </div>
+    <h4
+      class="mm-box mm-text mm-text--heading-sm mm-box--margin-bottom-2 mm-box--color-text-alternative"
+    >
+      Desktop App
+    </h4>
     <div
-      class="mm-box settings-page__content-row mm-box--display-flex mm-box--flex-direction-row mm-box--justify-content-space-between"
+      class="mm-box mm-box--display-flex mm-box--flex-direction-row mm-box--flex-wrap-wrap mm-box--justify-content-space-between mm-box--align-items-center"
       data-testid="advanced-setting-desktop-pairing"
     >
-      <div
-        class="settings-page__content-item"
+      <p
+        class="mm-box mm-text mm-text--body-md mm-box--margin-top-3 mm-box--padding-right-2 mm-box--color-text-default"
       >
-        <span>
-          Click to run all background processes in the desktop app.
-        </span>
-      </div>
+        Click to run all background processes in the desktop app.
+      </p>
       <div
-        class="settings-page__content-item-col"
+        class="mm-box settings-page__content-item-col mm-box--padding-top-3"
       >
         <button
           class="button btn--rounded btn-primary btn--large"

--- a/ui/pages/settings/experimental-tab/experimental-tab.component.js
+++ b/ui/pages/settings/experimental-tab/experimental-tab.component.js
@@ -13,8 +13,10 @@ import {
   TextVariant,
   FontWeight,
   ///: BEGIN:ONLY_INCLUDE_IN(desktop)
+  AlignItems,
   Display,
   FlexDirection,
+  FlexWrap,
   JustifyContent,
   ///: END:ONLY_INCLUDE_IN
 } from '../../../helpers/constants/design-system';
@@ -245,22 +247,31 @@ export default class ExperimentalTab extends PureComponent {
     const { t } = this.context;
 
     return (
-      <Box
-        ref={this.settingsRefs[6]}
-        className="settings-page__content-row"
-        data-testid="advanced-setting-desktop-pairing"
-        display={Display.Flex}
-        flexDirection={FlexDirection.Row}
-        justifyContent={JustifyContent.spaceBetween}
-      >
-        <div className="settings-page__content-item">
-          <span>{t('desktopEnableButtonDescription')}</span>
-        </div>
-
-        <div className="settings-page__content-item-col">
-          <DesktopEnableButton />
-        </div>
-      </Box>
+      <>
+        <Text
+          variant={TextVariant.headingSm}
+          color={TextColor.textAlternative}
+          marginBottom={2}
+        >
+          {t('desktopApp')}
+        </Text>
+        <Box
+          ref={this.settingsRefs[6]}
+          data-testid="advanced-setting-desktop-pairing"
+          display={Display.Flex}
+          alignItems={AlignItems.center}
+          flexDirection={FlexDirection.Row}
+          flexWrap={FlexWrap.Wrap}
+          justifyContent={JustifyContent.spaceBetween}
+        >
+          <Text marginTop={3} paddingRight={2}>
+            {t('desktopEnableButtonDescription')}
+          </Text>
+          <Box className="settings-page__content-item-col" paddingTop={3}>
+            <DesktopEnableButton />
+          </Box>
+        </Box>
+      </>
     );
   }
   ///: END:ONLY_INCLUDE_IN


### PR DESCRIPTION
## Explanation

Fixes https://github.com/MetaMask/metamask-extension/issues/20675
<!--
Thanks for the pull request. Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues, Slack conversations, Zendesk issues, user stories, etc. reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

## Screenshots/Screencaps

<!-- If you're making a change to the UI, make sure to capture a screenshot or a short video showing off your work! -->
In Settings > Experimental page, the Desktop setting styles need to be updated.

Updates: 
- adds section header to distinguish setting from other settings
- updates description to be responsive
- adds wrap to allow bottom to drop to next line


note: entire section padding being updated here https://github.com/MetaMask/metamask-extension/pull/20674

### Before

<img width="820" alt="Screenshot 2023-08-30 at 4 40 52 PM" src="https://github.com/MetaMask/metamask-extension/assets/20778143/7fdfb6ff-5b0f-41fe-9dd5-1ae3c7e9cb3c">

<img width="380" alt="Screenshot 2023-08-30 at 2 32 05 PM" src="https://github.com/MetaMask/metamask-extension/assets/20778143/015fe587-89cb-436b-a586-a2f89e29f218">

### After 
**(please ignore Security and Privacy styles. These are being updated in another PR)** 

<img width="820" alt="Screenshot 2023-08-30 at 5 41 10 PM" src="https://github.com/MetaMask/metamask-extension/assets/20778143/423c13d2-81e4-4303-b37f-487cf2050300">
<img width="380" alt="Screenshot 2023-08-30 at 5 41 22 PM" src="https://github.com/MetaMask/metamask-extension/assets/20778143/733b9d4c-cdb4-48fd-a97e-d484a4a7c76a">


<!-- How does it look now? Drag your file(s) below this line: -->

## Manual Testing Steps

1. `yarn start:flask`
2. go to Settings > Experimental page

<!--
How should reviewers and QA manually test your changes? For instance:

- Go to this screen
- Do this
- Then do this
-->

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
