### PR TITLE
UX: Show loading notification in extension badge

### DIFF
--- a/app/home.html
+++ b/app/home.html
@@ -12,10 +12,10 @@
   </head>
   <body>
     <div id="app-content">
-      <img class="loading-logo" src="./images/logo/metamask-fox.svg" alt="" />
-      <img class="loading-spinner" src="./images/spinner.gif" alt="" />
+
     </div>
     <div id="popover-content"></div>
+    <script src="./signal-app-loading.js" type="text/javascript" charset="utf-8"></script>
     <script src="./snow.js" type="text/javascript" charset="utf-8"></script>
     <script src="./use-snow.js" type="text/javascript" charset="utf-8"></script>
     <script src="./globalthis.js" type="text/javascript" charset="utf-8"></script>

--- a/app/notification.html
+++ b/app/notification.html
@@ -32,10 +32,9 @@
   </head>
   <body class="notification">
     <div id="app-content">
-      <img id="loading__logo" src="./images/logo/metamask-fox.svg" alt="" />
-      <img id="loading__spinner" src="./images/spinner.gif" alt="" />
     </div>
     <div id="popover-content"></div>
+    <script src="./signal-app-loading.js" type="text/javascript" charset="utf-8"></script>
     <script src="./snow.js" type="text/javascript" charset="utf-8"></script>
     <script src="./use-snow.js" type="text/javascript" charset="utf-8"></script>
     <script src="./globalthis.js" type="text/javascript" charset="utf-8"></script>

--- a/app/popup.html
+++ b/app/popup.html
@@ -9,10 +9,11 @@
   </head>
   <body style="width:357px; height:600px;">
     <div id="app-content">
-      <img class="loading-logo" src="./images/logo/metamask-fox.svg" alt="" />
-      <img class="loading-spinner" src="./images/spinner.gif" alt="" />
+
     </div>
     <div id="popover-content"></div>
+
+    <script src="./signal-app-loading.js" type="text/javascript" charset="utf-8"></script>
     <script src="./snow.js" type="text/javascript" charset="utf-8"></script>
     <script src="./use-snow.js" type="text/javascript" charset="utf-8"></script>
     <script src="./globalthis.js" type="text/javascript" charset="utf-8"></script>

--- a/app/scripts/signal-app-loading.js
+++ b/app/scripts/signal-app-loading.js
@@ -1,0 +1,5 @@
+if(chrome?.browserAction) {
+  chrome.browserAction.setBadgeText({ text: '°' });
+} else if(browser?.browserAction) {
+  browser.browserAction.setBadgeText({ text: '°' });
+}

--- a/app/scripts/signal-app-loading.js
+++ b/app/scripts/signal-app-loading.js
@@ -1,5 +1,7 @@
-if(chrome?.browserAction) {
-  chrome.browserAction.setBadgeText({ text: '°' });
-} else if(browser?.browserAction) {
-  browser.browserAction.setBadgeText({ text: '°' });
-}
+// eslint-disable-next-line import/unambiguous
+'use strict';
+
+(({ browserAction }) => {
+  browserAction.setBadgeText({ text: '+' });
+  browserAction.setBadgeBackgroundColor({ color: '#5DD879' });
+})(window.chrome ?? window.browser);

--- a/app/scripts/ui.js
+++ b/app/scripts/ui.js
@@ -294,6 +294,14 @@ async function start() {
         ) {
           global.platform.openExtensionInBrowser();
         }
+
+        if (isManifestV3) {
+          browser.action.setBadgeText({ text: '' });
+          browser.action.setBadgeBackgroundColor({ color: '' });
+        } else {
+          browser.browserAction.setBadgeText({ text: '' });
+          browser.browserAction.setBadgeBackgroundColor({ color: '' });
+        }
       },
     );
   }

--- a/development/build/static.js
+++ b/development/build/static.js
@@ -159,6 +159,10 @@ function getCopyTargets(
       dest: `globalthis.js`,
     },
     {
+      src: `./app/scripts/signal-app-loading.js`,
+      dest: `signal-app-loading.js`,
+    },
+    {
       src: shouldIncludeSnow
         ? `./node_modules/@lavamoat/snow/snow.prod.js`
         : EMPTY_JS_FILE,


### PR DESCRIPTION
## Explanation

This could be an alternative or addition to https://github.com/MetaMask/metamask-extension/pull/20328

Instead of the loading fox animation in an empty page, I've added a special badge to the extension's fox logo while the app loads.  This is an experiment, just looking for thoughts

## Screenshots/Screencaps

(Updated with `+` and green color)


https://github.com/MetaMask/metamask-extension/assets/46655/16f64c2d-8775-4f18-a1e2-5a21f5d32974



## Manual Testing Steps

1.  Click the popup -- see it show a circular character to signify loading
2. Watch the badge go away when loading is done and the popup displays
3. Go to the expanded/home screen
4. See the circular character while loading, gone when page loads

## Pre-merge author checklist

- [ ] I've clearly explained:
  - [ ] What problem this PR is solving
  - [ ] How this problem was solved
  - [ ] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
