### PR TITLE
Reduce logging in production builds

### DIFF
--- a/app/scripts/lib/createLoggerMiddleware.js
+++ b/app/scripts/lib/createLoggerMiddleware.js
@@ -1,7 +1,8 @@
 import log from 'loglevel';
 
 /**
- * Returns a middleware that logs RPC activity
+ * Returns a middleware that logs RPC activity. Logging is detailed in
+ * development builds, but more limited in production builds.
  *
  * @param {{ origin: string }} opts - The middleware options
  * @returns {Function}
@@ -14,12 +15,20 @@ export default function createLoggerMiddleware(opts) {
   ) {
     next((/** @type {Function} */ cb) => {
       if (res.error) {
-        log.error('Error in RPC response:\n', res);
+        log.debug('Error in RPC response:\n', res);
       }
       if (req.isMetamaskInternal) {
         return;
       }
-      log.info(`RPC (${opts.origin}):`, req, '->', res);
+      if (process.env.METAMASK_DEBUG) {
+        log.info(`RPC (${opts.origin}):`, req, '->', res);
+      } else {
+        log.info(
+          `RPC (${opts.origin}): ${req.method} -> ${
+            res.error ? 'error' : 'success'
+          }`,
+        );
+      }
       cb();
     });
   };

--- a/app/scripts/lib/rpc-method-middleware/createMethodMiddleware.js
+++ b/app/scripts/lib/rpc-method-middleware/createMethodMiddleware.js
@@ -65,7 +65,9 @@ export function createMethodMiddleware(hooks) {
           selectHooks(hooks, hookNames),
         );
       } catch (error) {
-        console.error(error);
+        if (process.env.METAMASK_DEBUG) {
+          console.error(error);
+        }
         return end(error);
       }
     }
@@ -101,7 +103,9 @@ export function createSnapMethodMiddleware(isSnap, hooks) {
           selectHooks(hooks, hookNames),
         );
       } catch (error) {
-        console.error(error);
+        if (process.env.METAMASK_DEBUG) {
+          console.error(error);
+        }
         return end(error);
       }
     }


### PR DESCRIPTION
## Explanation

Our logger middleware can be quite noisy in production, logging all RPC requests. It has been updated to have more condensed logs in production builds, but preserving the existing logging for development builds.

A few error logs in the method handling middleware have been suppressed in production as well. They were redundant anyway.

This fixes https://github.com/MetaMask/MetaMask-planning/issues/1281

## Manual Testing Steps

* Use the test dapp. See that the logs are the same as before on a development build (`yarn start` or `yarn start:test`). But on non-development builds they have less detail (and there is no longer a separate log entry for errors).

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
