### PR TITLE
Replaced deprecated Dialog component with BannerAlert component from the component-library

### DIFF
--- a/ui/pages/send/send-content/send-content.component.js
+++ b/ui/pages/send/send-content/send-content.component.js
@@ -10,6 +10,8 @@ import {
 } from '../../../helpers/constants/error-keys';
 import { AssetType } from '../../../../shared/constants/transaction';
 import { CONTRACT_ADDRESS_LINK } from '../../../helpers/constants/common';
+import { BannerAlert } from '../../../components/component-library';
+import { Severity } from '../../../helpers/constants/design-system';
 import GasDisplay from '../gas-display';
 import SendAmountRow from './send-amount-row';
 import SendHexDataRow from './send-hex-data-row';
@@ -131,9 +133,9 @@ export default class SendContent extends Component {
   renderError(error) {
     const { t } = this.context;
     return (
-      <Dialog type="error" className="send__error-dialog">
+      <BannerAlert severity={Severity.Danger} className="send__error-dialog">
         {t(error)}
-      </Dialog>
+      </BannerAlert>
     );
   }
 }


### PR DESCRIPTION
## Explanation
@georgewrmarshall 

Here the DialogBox Component (`ui/components/ui/dialog/index.js`) was replaced by BannerAlert component  (`ui/components/component-library/banner-alert/banner-alert.js`) from component-library with passing proper Props.

Please whether it is right to replace the Dialog Box from  other components.

<!--
Thanks for the pull request. Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues, Slack conversations, Zendesk issues, user stories, etc. reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

## Screenshots/Screencaps

![image](https://github.com/MetaMask/metamask-extension/assets/97947439/045c78b5-22c2-41c3-8ccb-32244f8ba5e3)

## Manual Testing Steps

<!--
How should reviewers and QA manually test your changes? For instance:

- Go to this screen
- Do this
- Then do this
-->

## Pre-merge author checklist

- [ ] I've clearly explained:
  - [ ] What problem this PR is solving
  - [ ] How this problem was solved
  - [ ] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
