### PR TITLE
Fix position of a warning triangle icon on Snap Install Warning

### DIFF
--- a/ui/components/app/snaps/snap-install-warning/snap-install-warning.js
+++ b/ui/components/app/snaps/snap-install-warning/snap-install-warning.js
@@ -12,6 +12,7 @@ import {
   TextAlign,
   JustifyContent,
   FontWeight,
+  Display,
 } from '../../../../helpers/constants/design-system';
 import Popover from '../../../ui/popover';
 import Button from '../../../ui/button';
@@ -86,7 +87,11 @@ export default function SnapInstallWarning({
       footerProps={{ padding: [4, 6] }}
       onClose={onCancel}
     >
-      <Box justifyContent={JustifyContent.center} marginBottom={6}>
+      <Box
+        display={Display.Flex}
+        justifyContent={JustifyContent.center}
+        marginBottom={6}
+      >
         <AvatarIcon
           iconName={IconName.Danger}
           backgroundColor={BackgroundColor.warningMuted}


### PR DESCRIPTION
## Explanation
After some UI components update it is noticed that a warning icon on Snap Install Warning modal is not cetnered anymore. This PR fixes that.

Fixes: https://github.com/MetaMask/metamask-extension/issues/20711

## Screenshots/Screencaps
### Before
![before](https://github.com/MetaMask/metamask-extension/assets/13301024/fb64b907-dca2-4fd0-930b-6c86aac7ddcb)

### After
![Screenshot 2023-09-04 at 12 33 54](https://github.com/MetaMask/metamask-extension/assets/13301024/e28b44ea-87e7-4ef3-9be8-65b90d5f95f0)

## Manual Testing Steps
1. Try to install a snap that triggers install warning modal.
2. Check the icon's position in a modal.

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
