### PR TITLE
Update UI elements using keyring to accounts controller

### DIFF
--- a/ui/ducks/metamask/metamask.js
+++ b/ui/ducks/metamask/metamask.js
@@ -436,9 +436,11 @@ export function isAddressLedger(state, accountId) {
  * @returns {boolean} true if the user has a Ledger account and false otherwise
  */
 export function doesUserHaveALedgerAccount(state) {
-  return state.metamask.keyrings.some((kr) => {
-    return kr.type === KeyringType.ledger;
-  });
+  return Object.values(state.metamask.internalAccounts.accounts).some(
+    (account) => {
+      return account.metadata.keyring.type === KeyringType.ledger;
+    },
+  );
 }
 
 export function isLineaMainnetNetworkReleased(state) {

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -156,16 +156,12 @@ export function hasUnsignedQRHardwareTransaction(state) {
     return false;
   }
   const { from } = txParams;
-  const { keyrings } = state.metamask;
-  const qrKeyring = keyrings.find((kr) => kr.type === KeyringType.qr);
-  if (!qrKeyring) {
+  const internalAccount = getFirstInternalAccountByAddress(state, from);
+
+  if (!internalAccount) {
     return false;
   }
-  return Boolean(
-    qrKeyring.accounts.find(
-      (account) => account.toLowerCase() === from.toLowerCase(),
-    ),
-  );
+  return Boolean(internalAccount.metadata.keyring.type === KeyringType.qr);
 }
 
 export function hasUnsignedQRHardwareMessage(state) {
@@ -174,20 +170,17 @@ export function hasUnsignedQRHardwareMessage(state) {
     return false;
   }
   const { from } = msgParams;
-  const { keyrings } = state.metamask;
-  const qrKeyring = keyrings.find((kr) => kr.type === KeyringType.qr);
-  if (!qrKeyring) {
+  const internalAccount = getFirstInternalAccountByAddress(state, from);
+
+  if (!internalAccount) {
     return false;
   }
+
   switch (type) {
     case MESSAGE_TYPE.ETH_SIGN_TYPED_DATA:
     case MESSAGE_TYPE.ETH_SIGN:
     case MESSAGE_TYPE.PERSONAL_SIGN:
-      return Boolean(
-        qrKeyring.accounts.find(
-          (account) => account.toLowerCase() === from.toLowerCase(),
-        ),
-      );
+      return Boolean(internalAccount.metadata.keyring.type === KeyringType.qr);
     default:
       return false;
   }
@@ -387,10 +380,6 @@ export function getInternalAccountsSortedByKeyring(state) {
 export function getNumberOfTokens(state) {
   const { tokens } = state.metamask;
   return tokens ? tokens.length : 0;
-}
-
-export function getMetaMaskKeyrings(state) {
-  return state.metamask.keyrings;
 }
 
 /**


### PR DESCRIPTION
## Explanation

Replaces selectors that uses `metamask.keyring` with internal accounts. The internal account has information of the what the type of keyring that account uses. 

- See https://github.com/MetaMask/accounts-planning/issues/18


## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
