### PR TITLE
UX: Show token listing immediately, even when prices loading

### DIFF
--- a/ui/components/app/token-list/token-list.js
+++ b/ui/components/app/token-list/token-list.js
@@ -4,19 +4,11 @@ import { isEqual } from 'lodash';
 
 import { useSelector } from 'react-redux';
 import TokenCell from '../token-cell';
-import { useI18nContext } from '../../../hooks/useI18nContext';
 import { useTokenTracker } from '../../../hooks/useTokenTracker';
 import { getShouldHideZeroBalanceTokens } from '../../../selectors';
 import { getTokens } from '../../../ducks/metamask/metamask';
-import { Box } from '../../component-library';
-import {
-  AlignItems,
-  Display,
-  JustifyContent,
-} from '../../../helpers/constants/design-system';
 
 export default function TokenList({ onTokenClick }) {
-  const t = useI18nContext();
   const shouldHideZeroBalanceTokens = useSelector(
     getShouldHideZeroBalanceTokens,
   );
@@ -24,31 +16,18 @@ export default function TokenList({ onTokenClick }) {
   // from the background so it has a new reference with each background update,
   // even if the tokens haven't changed
   const tokens = useSelector(getTokens, isEqual);
-  const { loading, tokensWithBalances } = useTokenTracker(
+  const { tokensWithBalances } = useTokenTracker(
     tokens,
     true,
     shouldHideZeroBalanceTokens,
   );
-  if (loading) {
-    return (
-      <Box
-        display={Display.Flex}
-        alignItems={AlignItems.center}
-        justifyContent={JustifyContent.center}
-        padding={7}
-        data-testid="token-list-loading-message"
-      >
-        {t('loadingTokens')}
-      </Box>
-    );
-  }
 
   return (
-    <div>
-      {tokensWithBalances.map((tokenData, index) => {
-        return <TokenCell key={index} {...tokenData} onClick={onTokenClick} />;
-      })}
-    </div>
+    <>
+      {tokensWithBalances.map((tokenData, index) => (
+        <TokenCell key={index} {...tokenData} onClick={onTokenClick} />
+      ))}
+    </>
   );
 }
 


### PR DESCRIPTION
## Explanation

Removes the home loading spinner for tokens which only displays until we have pricing.  We shouldn't hold up the token listing for fiat value.  We should display the list, then pop in the fiat value when we have it.

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [ ] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
