### PR TITLE
Remove `keyringMemStore` from `DetectTokensController`

### DIFF
--- a/app/scripts/controllers/detect-tokens.js
+++ b/app/scripts/controllers/detect-tokens.js
@@ -40,7 +40,6 @@ export default class DetectTokensController {
     interval = DEFAULT_INTERVAL,
     preferences,
     network,
-    keyringMemStore,
     tokenList,
     tokensController,
     assetsContractController = null,
@@ -52,7 +51,6 @@ export default class DetectTokensController {
     this.preferences = preferences;
     this.interval = interval;
     this.network = network;
-    this.keyringMemStore = keyringMemStore;
     this.tokenList = tokenList;
     this.useTokenDetection =
       this.preferences?.store.getState().useTokenDetection;
@@ -90,6 +88,13 @@ export default class DetectTokensController {
         this.chainId = chainId;
         this.restartTokenDetection({ chainId: this.chainId });
       }
+    });
+    messenger.subscribe('KeyringController:unlock', () => {
+      this.isUnlocked = true;
+      this.restartTokenDetection();
+    });
+    messenger.subscribe('KeyringController:lock', () => {
+      this.isUnlocked = false;
     });
   }
 
@@ -234,26 +239,6 @@ export default class DetectTokensController {
     this._handle = setInterval(() => {
       this.detectNewTokens();
     }, interval);
-  }
-
-  /**
-   * In setter when isUnlocked is updated to true, detectNewTokens and restart polling
-   *
-   * @type {object}
-   */
-  set keyringMemStore(keyringMemStore) {
-    if (!keyringMemStore) {
-      return;
-    }
-    this._keyringMemStore = keyringMemStore;
-    this._keyringMemStore.subscribe(({ isUnlocked }) => {
-      if (this.isUnlocked !== isUnlocked) {
-        this.isUnlocked = isUnlocked;
-        if (isUnlocked) {
-          this.restartTokenDetection();
-        }
-      }
-    });
   }
 
   /**

--- a/app/scripts/controllers/detect-tokens.js
+++ b/app/scripts/controllers/detect-tokens.js
@@ -28,7 +28,6 @@ export default class DetectTokensController {
    * @param config.interval
    * @param config.preferences
    * @param config.network
-   * @param config.keyringMemStore
    * @param config.tokenList
    * @param config.tokensController
    * @param config.assetsContractController
@@ -89,13 +88,8 @@ export default class DetectTokensController {
         this.restartTokenDetection({ chainId: this.chainId });
       }
     });
-    messenger.subscribe('KeyringController:unlock', () => {
-      this.isUnlocked = true;
-      this.restartTokenDetection();
-    });
-    messenger.subscribe('KeyringController:lock', () => {
-      this.isUnlocked = false;
-    });
+
+    this.#registerKeyringHandlers();
   }
 
   /**
@@ -260,4 +254,22 @@ export default class DetectTokensController {
     return this.isOpen && this.isUnlocked;
   }
   /* eslint-enable accessor-pairs */
+
+  /**
+   * Constructor helper to register listeners on the keyring
+   * locked state changes
+   */
+  #registerKeyringHandlers() {
+    const { isUnlocked } = this.messenger.call('KeyringController:getState');
+    this.isUnlocked = isUnlocked;
+
+    this.messenger.subscribe('KeyringController:unlock', () => {
+      this.isUnlocked = true;
+      this.restartTokenDetection();
+    });
+
+    this.messenger.subscribe('KeyringController:lock', () => {
+      this.isUnlocked = false;
+    });
+  }
 }

--- a/app/scripts/controllers/detect-tokens.test.js
+++ b/app/scripts/controllers/detect-tokens.test.js
@@ -485,6 +485,25 @@ describe('DetectTokensController', function () {
     messenger.publish('KeyringController:unlock');
 
     sandbox.assert.called(stub);
+    assert.equal(controller.isUnlocked, true);
+  });
+
+  it('should not be active after lock event is emitted', async function () {
+    sandbox.useFakeTimers();
+    const controller = new DetectTokensController({
+      messenger: getRestrictedMessenger(),
+      preferences,
+      network,
+      tokenList: tokenListController,
+      tokensController,
+      assetsContractController,
+    });
+    controller.isOpen = true;
+
+    messenger.publish('KeyringController:lock');
+
+    assert.equal(controller.isUnlocked, false);
+    assert.equal(controller.isActive, false);
   });
 
   it('should not trigger detect new tokens when not unlocked', async function () {

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -1142,7 +1142,11 @@ export default class MetamaskController extends EventEmitter {
     const detectTokensControllerMessenger =
       this.controllerMessenger.getRestricted({
         name: 'DetectTokensController',
-        allowedEvents: ['NetworkController:stateChange'],
+        allowedEvents: [
+          'NetworkController:stateChange',
+          'KeyringController:lock',
+          'KeyringController:unlock',
+        ],
       });
     this.detectTokensController = new DetectTokensController({
       messenger: detectTokensControllerMessenger,
@@ -1150,7 +1154,6 @@ export default class MetamaskController extends EventEmitter {
       tokensController: this.tokensController,
       assetsContractController: this.assetsContractController,
       network: this.networkController,
-      keyringMemStore: this.keyringController.memStore,
       tokenList: this.tokenListController,
       trackMetaMetricsEvent: this.metaMetricsController.trackEvent.bind(
         this.metaMetricsController,

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -1142,6 +1142,7 @@ export default class MetamaskController extends EventEmitter {
     const detectTokensControllerMessenger =
       this.controllerMessenger.getRestricted({
         name: 'DetectTokensController',
+        allowedActions: ['KeyringController:getState'],
         allowedEvents: [
           'NetworkController:stateChange',
           'KeyringController:lock',


### PR DESCRIPTION
## Explanation

<!--
Thanks for the pull request. Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues, Slack conversations, Zendesk issues, user stories, etc. reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->
This PR removes the `keyringMemStore` constructor parameter, as we can now subscribe to `KeyringController` events through the messenger. Instead of listening on all Keyring state changes, we can listen to `:lock` and `:unlock` events.

* Fixes #20723 

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
