### PR TITLE
Remove `nonceDetails` from `TransactionMeta`

### DIFF
--- a/.storybook/initial-states/transactions.js
+++ b/.storybook/initial-states/transactions.js
@@ -75,37 +75,6 @@ export const MOCK_TRANSACTION_BY_TYPE = {
       [
         {
           op: 'add',
-          path: '/nonceDetails',
-          value: {
-            params: {
-              highestLocallyConfirmed: 81,
-              highestSuggested: 81,
-              nextNetworkNonce: 81,
-            },
-            local: {
-              name: 'local',
-              nonce: 83,
-              details: {
-                startPoint: 81,
-                highest: 83,
-              },
-            },
-            network: {
-              name: 'network',
-              nonce: 81,
-              details: {
-                blockNumber: '0xa3e3ac',
-                baseCount: 81,
-              },
-            },
-          },
-          note: 'transactions#approveTransaction',
-          timestamp: 1653527035723,
-        },
-      ],
-      [
-        {
-          op: 'add',
           path: '/r',
           value:
             '0xb66eff07d9061c42e47ccf5f6a52b6626ef4d5b10e50d8aa6b8f20ae645fe347',
@@ -172,29 +141,6 @@ export const MOCK_TRANSACTION_BY_TYPE = {
         },
       ],
     ],
-    nonceDetails: {
-      params: {
-        highestLocallyConfirmed: 81,
-        highestSuggested: 81,
-        nextNetworkNonce: 81,
-      },
-      local: {
-        name: 'local',
-        nonce: 83,
-        details: {
-          startPoint: 81,
-          highest: 83,
-        },
-      },
-      network: {
-        name: 'network',
-        nonce: 81,
-        details: {
-          blockNumber: '0xa3e3ac',
-          baseCount: 81,
-        },
-      },
-    },
     r: '0xb66eff07d9061c42e47ccf5f6a52b6626ef4d5b10e50d8aa6b8f20ae645fe347',
     s: '0x3a2da8d56beff82a2d59e807f7d578f0c3b4b99cd6d3735c72c133d06fe02a9d',
     v: '0x2b',
@@ -405,37 +351,6 @@ export const MOCK_TRANSACTION_BY_TYPE = {
       [
         {
           op: 'add',
-          path: '/nonceDetails',
-          value: {
-            params: {
-              highestLocallyConfirmed: 7,
-              highestSuggested: 7,
-              nextNetworkNonce: 7,
-            },
-            local: {
-              name: 'local',
-              nonce: 10,
-              details: {
-                startPoint: 7,
-                highest: 10,
-              },
-            },
-            network: {
-              name: 'network',
-              nonce: 7,
-              details: {
-                blockNumber: '0xa3d235',
-                baseCount: 7,
-              },
-            },
-          },
-          note: 'transactions#approveTransaction',
-          timestamp: 1653459456415,
-        },
-      ],
-      [
-        {
-          op: 'add',
           path: '/r',
           value:
             '0xde2e3131fb55b1edd182de128453521c86eed588f92058b61b3ce56cdfb33a26',
@@ -497,29 +412,6 @@ export const MOCK_TRANSACTION_BY_TYPE = {
         },
       ],
     ],
-    nonceDetails: {
-      params: {
-        highestLocallyConfirmed: 7,
-        highestSuggested: 7,
-        nextNetworkNonce: 7,
-      },
-      local: {
-        name: 'local',
-        nonce: 10,
-        details: {
-          startPoint: 7,
-          highest: 10,
-        },
-      },
-      network: {
-        name: 'network',
-        nonce: 7,
-        details: {
-          blockNumber: '0xa3d235',
-          baseCount: 7,
-        },
-      },
-    },
     r: '0xde2e3131fb55b1edd182de128453521c86eed588f92058b61b3ce56cdfb33a26',
     s: '0x64ee1eef8d0fa1b35e122658554d16645366e8977253fc1c47d030f28736409b',
     v: '0x00',
@@ -778,33 +670,6 @@ export const MOCK_TRANSACTION_BY_TYPE = {
           note: 'transactions#approveTransaction',
           timestamp: 1653457117294,
         },
-        {
-          op: 'add',
-          path: '/nonceDetails',
-          value: {
-            params: {
-              highestLocallyConfirmed: 5,
-              highestSuggested: 5,
-              nextNetworkNonce: 5,
-            },
-            local: {
-              name: 'local',
-              nonce: 5,
-              details: {
-                startPoint: 5,
-                highest: 5,
-              },
-            },
-            network: {
-              name: 'network',
-              nonce: 5,
-              details: {
-                blockNumber: '0xa3d19b',
-                baseCount: 5,
-              },
-            },
-          },
-        },
       ],
       [
         {
@@ -883,29 +748,6 @@ export const MOCK_TRANSACTION_BY_TYPE = {
       maxPriorityFeePerGas: '0x4a817c800',
     },
     estimatedBaseFee: '14',
-    nonceDetails: {
-      params: {
-        highestLocallyConfirmed: 5,
-        highestSuggested: 5,
-        nextNetworkNonce: 5,
-      },
-      local: {
-        name: 'local',
-        nonce: 5,
-        details: {
-          startPoint: 5,
-          highest: 5,
-        },
-      },
-      network: {
-        name: 'network',
-        nonce: 5,
-        details: {
-          blockNumber: '0xa3d19b',
-          baseCount: 5,
-        },
-      },
-    },
     r: '0xfdd2cb46203b5e7bba99cc56a37da3e5e3f36163a5bd9c51cddfd8d7028f5dd0',
     s: '0x54c35cfa10b3350a3fd3a0e7b4aeb0b603d528c07a8cfdf4a78505d9864edef4',
     v: '0x00',
@@ -949,29 +791,6 @@ export const MOCK_TRANSACTION_BY_TYPE = {
       maxPriorityFeePerGas: '0x3B9ACA00',
     },
     estimatedBaseFee: '3ba182755',
-    nonceDetails: {
-      params: {
-        highestLocallyConfirmed: 87,
-        highestSuggested: 87,
-        nextNetworkNonce: 87,
-      },
-      local: {
-        name: 'local',
-        nonce: 87,
-        details: {
-          startPoint: 87,
-          highest: 87,
-        },
-      },
-      network: {
-        name: 'network',
-        nonce: 87,
-        details: {
-          blockNumber: '0xa28e38',
-          baseCount: 87,
-        },
-      },
-    },
     r: '0xd13310569a8d5876e37788183034bfe4bc3b49c0663c5fd9b2bf13adf9b4791c',
     s: '0x7a83d8840e7edcdf4fdedfd2bc1ce19775e54fd17f29ede5165591a1cf3febea',
     v: '0x00',
@@ -1155,33 +974,6 @@ export const MOCK_TRANSACTION_BY_TYPE = {
           value: '0x5',
           note: 'transactions#approveTransaction',
           timestamp: 1653457091939,
-        },
-        {
-          op: 'add',
-          path: '/nonceDetails',
-          value: {
-            params: {
-              highestLocallyConfirmed: 4,
-              highestSuggested: 4,
-              nextNetworkNonce: 4,
-            },
-            local: {
-              name: 'local',
-              nonce: 4,
-              details: {
-                startPoint: 4,
-                highest: 4,
-              },
-            },
-            network: {
-              name: 'network',
-              nonce: 4,
-              details: {
-                blockNumber: '0xa3d198',
-                baseCount: 4,
-              },
-            },
-          },
         },
       ],
       [
@@ -1370,29 +1162,6 @@ export const MOCK_TRANSACTION_BY_TYPE = {
       maxPriorityFeePerGas: '0x4a817c800',
     },
     estimatedBaseFee: '16',
-    nonceDetails: {
-      params: {
-        highestLocallyConfirmed: 4,
-        highestSuggested: 4,
-        nextNetworkNonce: 4,
-      },
-      local: {
-        name: 'local',
-        nonce: 4,
-        details: {
-          startPoint: 4,
-          highest: 4,
-        },
-      },
-      network: {
-        name: 'network',
-        nonce: 4,
-        details: {
-          blockNumber: '0xa3d198',
-          baseCount: 4,
-        },
-      },
-    },
     r: '0xb0f36e4392f9d302351789aef355a2e95b979bcdd99d19026c533152563d3bce',
     s: '0x08e59de373e65c9c54e6a8052585461e81409d33178464f9b72f4cc36ac75d40',
     v: '0x01',
@@ -1590,33 +1359,6 @@ export const MOCK_TRANSACTION_BY_TYPE = {
           value: '0x6',
           note: 'transactions#approveTransaction',
           timestamp: 1653457330354,
-        },
-        {
-          op: 'add',
-          path: '/nonceDetails',
-          value: {
-            params: {
-              highestLocallyConfirmed: 6,
-              highestSuggested: 6,
-              nextNetworkNonce: 6,
-            },
-            local: {
-              name: 'local',
-              nonce: 6,
-              details: {
-                startPoint: 6,
-                highest: 6,
-              },
-            },
-            network: {
-              name: 'network',
-              nonce: 6,
-              details: {
-                blockNumber: '0xa3d1a8',
-                baseCount: 6,
-              },
-            },
-          },
         },
       ],
       [
@@ -1829,29 +1571,6 @@ export const MOCK_TRANSACTION_BY_TYPE = {
       maxPriorityFeePerGas: '0x59682f00',
     },
     estimatedBaseFee: 'd',
-    nonceDetails: {
-      params: {
-        highestLocallyConfirmed: 6,
-        highestSuggested: 6,
-        nextNetworkNonce: 6,
-      },
-      local: {
-        name: 'local',
-        nonce: 6,
-        details: {
-          startPoint: 6,
-          highest: 6,
-        },
-      },
-      network: {
-        name: 'network',
-        nonce: 6,
-        details: {
-          blockNumber: '0xa3d1a8',
-          baseCount: 6,
-        },
-      },
-    },
     r: '0x58294750acbe46cb0dd15ef615a244be49af61f0d799cce68bbbd3d4e7c75cdc',
     s: '0x3993c38f6e168065d9b20a0b4254697d47db114f57243f56c22f228c7a173f9c',
     v: '0x01',

--- a/.storybook/test-data.js
+++ b/.storybook/test-data.js
@@ -626,34 +626,7 @@ const state = {
               path: '/txParams/nonce',
               timestamp: 1629582711220,
               value: '0x15b',
-            },
-            {
-              op: 'add',
-              path: '/nonceDetails',
-              value: {
-                local: {
-                  details: {
-                    highest: 347,
-                    startPoint: 347,
-                  },
-                  name: 'local',
-                  nonce: 347,
-                },
-                network: {
-                  details: {
-                    baseCount: 347,
-                    blockNumber: '0x9c2682',
-                  },
-                  name: 'network',
-                  nonce: 347,
-                },
-                params: {
-                  highestLocallyConfirmed: 327,
-                  highestSuggested: 347,
-                  nextNetworkNonce: 347,
-                },
-              },
-            },
+            }
           ],
           [
             {
@@ -901,29 +874,6 @@ const state = {
         id: 7900715443136469,
         loadingDefaults: false,
         metamaskNetworkId: '56',
-        nonceDetails: {
-          local: {
-            details: {
-              highest: 347,
-              startPoint: 347,
-            },
-            name: 'local',
-            nonce: 347,
-          },
-          network: {
-            details: {
-              baseCount: 347,
-              blockNumber: '0x9c2682',
-            },
-            name: 'network',
-            nonce: 347,
-          },
-          params: {
-            highestLocallyConfirmed: 327,
-            highestSuggested: 347,
-            nextNetworkNonce: 347,
-          },
-        },
         origin: 'metamask',
         r: '0x90a4dfb0646eef9815454d0ab543b5844acb8772101084565155c93ecce8ed69',
         rawTx:

--- a/app/scripts/controllers/transactions/README.md
+++ b/app/scripts/controllers/transactions/README.md
@@ -59,29 +59,7 @@ txMeta = {
       "value": "0x3b9aca00"
     }]
   ], // I've removed most of history for this
-  "origin": "MetaMask", //debug
-  "nonceDetails": {
-    "params": {
-      "highestLocallyConfirmed": 0,
-      "highestSuggested": 0,
-      "nextNetworkNonce": 0
-    },
-    "local": {
-      "name": "local",
-      "nonce": 0,
-      "details": {
-        "startPoint": 0,
-        "highest": 0
-      }
-    },
-    "network": {
-      "name": "network",
-      "nonce": 0,
-      "details": {
-        "baseCount": 0
-      }
-    }
-  },
+  "origin": "MetaMask",
   "rawTx": "0xf86980843b9aca00827b0c948acce2391c0d510a6c5e5d8f819a678f79b7e67580808602c5b5de66eea05c01a320b96ac730cb210ca56d2cb71fa360e1fc2c21fa5cf333687d18eb323fa02ed05987a6e5fd0f2459fcff80710b76b83b296454ad9a37594a0ccb4643ea90", // used for rebroadcast
   "hash": "0xa45ba834b97c15e6ff4ed09badd04ecd5ce884b455eb60192cdc73bcc583972a",
   "submittedTime": 1524094077902 // time of the attempt to submit the raw tx to the network, used in the ui to show the retry button

--- a/app/scripts/controllers/transactions/index.js
+++ b/app/scripts/controllers/transactions/index.js
@@ -1857,11 +1857,6 @@ export default class TransactionController extends EventEmitter {
         customNonceValue === 0 ? customNonceValue : customNonceValue || nonce;
 
       txMeta.txParams.nonce = addHexPrefix(customOrNonce.toString(16));
-      // add nonce debugging information to txMeta
-      txMeta.nonceDetails = nonceLock.nonceDetails;
-      if (customNonceValue) {
-        txMeta.nonceDetails.customNonceValue = customNonceValue;
-      }
       this.txStateManager.updateTransaction(
         txMeta,
         'transactions#approveTransaction',

--- a/app/scripts/migrations/097.test.ts
+++ b/app/scripts/migrations/097.test.ts
@@ -80,7 +80,32 @@ describe('migration #97', () => {
             },
             otherProp: 'value',
           },
-          tx2: { otherProp: 'value' },
+          tx2: {
+            nonceDetails: {
+              local: {
+                details: {
+                  highest: 347,
+                  startPoint: 347,
+                },
+                name: 'local',
+                nonce: 347,
+              },
+              network: {
+                details: {
+                  baseCount: 347,
+                  blockNumber: '0x9c2682',
+                },
+                name: 'network',
+                nonce: 347,
+              },
+              params: {
+                highestLocallyConfirmed: 327,
+                highestSuggested: 347,
+                nextNetworkNonce: 347,
+              },
+            },
+            otherProp: 'value'
+          },
         },
       },
     };

--- a/app/scripts/migrations/097.test.ts
+++ b/app/scripts/migrations/097.test.ts
@@ -104,7 +104,7 @@ describe('migration #97', () => {
                 nextNetworkNonce: 347,
               },
             },
-            otherProp: 'value'
+            otherProp: 'value',
           },
         },
       },

--- a/app/scripts/migrations/097.test.ts
+++ b/app/scripts/migrations/097.test.ts
@@ -1,0 +1,103 @@
+import { migrate, version } from './097';
+
+const oldVersion = 96;
+describe('migration #97', () => {
+  it('updates the version metadata', async () => {
+    const oldStorage = {
+      meta: { version: oldVersion },
+      data: {},
+    };
+
+    const newStorage = await migrate(oldStorage);
+
+    expect(newStorage.meta).toStrictEqual({ version });
+  });
+
+  it('handles missing TransactionController', async () => {
+    const oldState = {
+      OtherController: {},
+    };
+
+    const transformedState = await migrate({
+      meta: { version: oldVersion },
+      data: oldState,
+    });
+
+    expect(transformedState.data).toEqual(oldState);
+  });
+
+  it('handles empty transactions', async () => {
+    const oldState = {
+      TransactionController: {
+        transactions: {},
+      },
+    };
+
+    const transformedState = await migrate({
+      meta: { version: oldVersion },
+      data: oldState,
+    });
+
+    expect(transformedState.data).toEqual(oldState);
+  });
+
+  it('handles missing state', async () => {
+    const transformedState = await migrate({
+      meta: { version: oldVersion },
+      data: {},
+    });
+
+    expect(transformedState.data).toEqual({});
+  });
+
+  it('removes nonceDetail from transactions', async () => {
+    const oldState = {
+      TransactionController: {
+        transactions: {
+          tx1: {
+            nonceDetails: {
+              local: {
+                details: {
+                  highest: 347,
+                  startPoint: 347,
+                },
+                name: 'local',
+                nonce: 347,
+              },
+              network: {
+                details: {
+                  baseCount: 347,
+                  blockNumber: '0x9c2682',
+                },
+                name: 'network',
+                nonce: 347,
+              },
+              params: {
+                highestLocallyConfirmed: 327,
+                highestSuggested: 347,
+                nextNetworkNonce: 347,
+              },
+            },
+            otherProp: 'value',
+          },
+          tx2: { otherProp: 'value' },
+        },
+      },
+    };
+    const oldStorage = {
+      meta: { version: oldVersion },
+      data: oldState,
+    };
+
+    const newStorage = await migrate(oldStorage);
+
+    expect(newStorage.data).toEqual({
+      TransactionController: {
+        transactions: {
+          tx1: { otherProp: 'value' },
+          tx2: { otherProp: 'value' },
+        },
+      },
+    });
+  });
+});

--- a/app/scripts/migrations/097.ts
+++ b/app/scripts/migrations/097.ts
@@ -1,0 +1,49 @@
+import { cloneDeep, isEmpty } from 'lodash';
+
+type VersionedData = {
+  meta: { version: number };
+  data: Record<string, unknown>;
+};
+
+export const version = 97;
+
+/**
+ * Remove `nonceDetail` from transactions
+ *
+ * @param originalVersionedData
+ */
+export async function migrate(
+  originalVersionedData: VersionedData,
+): Promise<VersionedData> {
+  const versionedData = cloneDeep(originalVersionedData);
+  versionedData.meta.version = version;
+  transformState(versionedData.data);
+  return versionedData;
+}
+
+function transformState(state: Record<string, any>) {
+  const TransactionController = state?.TransactionController || {};
+  const transactions = state?.TransactionController?.transactions || {};
+
+  if (isEmpty(TransactionController) || isEmpty(transactions)) {
+    return;
+  }
+
+  const newTxs = Object.keys(transactions).reduce((txs, txId) => {
+    const transaction = transactions[txId];
+    if (transaction?.nonceDetail) {
+      delete transaction.nonceDetail;
+    }
+    return {
+      ...txs,
+      [txId]: transaction,
+    };
+  }, {});
+
+  state.TransactionController = {
+    ...TransactionController,
+    transactions: {
+      ...newTxs,
+    },
+  };
+}

--- a/app/scripts/migrations/097.ts
+++ b/app/scripts/migrations/097.ts
@@ -22,17 +22,17 @@ export async function migrate(
 }
 
 function transformState(state: Record<string, any>) {
-  const TransactionController = state?.TransactionController || {};
-  const transactions = state?.TransactionController?.transactions || {};
+  const transactionControllerState = state?.TransactionController || {};
+  const transactions = transactionControllerState?.transactions || {};
 
-  if (isEmpty(TransactionController) || isEmpty(transactions)) {
+  if (isEmpty(transactions)) {
     return;
   }
 
   const newTxs = Object.keys(transactions).reduce((txs, txId) => {
     const transaction = transactions[txId];
-    if (transaction?.nonceDetail) {
-      delete transaction.nonceDetail;
+    if (transaction?.nonceDetails) {
+      delete transaction.nonceDetails;
     }
     return {
       ...txs,
@@ -41,9 +41,7 @@ function transformState(state: Record<string, any>) {
   }, {});
 
   state.TransactionController = {
-    ...TransactionController,
-    transactions: {
-      ...newTxs,
-    },
+    ...transactionControllerState,
+    transactions: newTxs,
   };
 }

--- a/app/scripts/migrations/index.js
+++ b/app/scripts/migrations/index.js
@@ -103,6 +103,7 @@ import * as m093 from './093';
 import * as m094 from './094';
 import * as m095 from './095';
 import * as m096 from './096';
+import * as m097 from './097';
 
 const migrations = [
   m002,
@@ -203,5 +204,6 @@ const migrations = [
   m094,
   m095,
   m096,
+  m097,
 ];
 export default migrations;

--- a/shared/constants/transaction.ts
+++ b/shared/constants/transaction.ts
@@ -381,11 +381,6 @@ export interface TransactionMeta {
   /** A boolean representing when the user manually edited the gas limit. */
   userEditedGasLimit: boolean;
   /**
-   * A metadata object containing information used to derive the suggested
-   * nonce, useful for debugging nonce issues.
-   */
-  nonceDetails: Record<string, any>;
-  /**
    * A hex string of the final signed transaction, ready to submit to the
    * network.
    */

--- a/test/data/mock-send-state.json
+++ b/test/data/mock-send-state.json
@@ -408,32 +408,6 @@
               "value": "0xb5",
               "note": "transactions#approveTransaction",
               "timestamp": 1528133131806
-            },
-            {
-              "op": "add",
-              "path": "/nonceDetails",
-              "value": {
-                "params": {
-                  "highestLocallyConfirmed": 0,
-                  "highestSuggested": 181,
-                  "nextNetworkNonce": 181
-                },
-                "local": {
-                  "name": "local",
-                  "nonce": 181,
-                  "details": {
-                    "startPoint": 181,
-                    "highest": 181
-                  }
-                },
-                "network": {
-                  "name": "network",
-                  "nonce": 181,
-                  "details": {
-                    "baseCount": 181
-                  }
-                }
-              }
             }
           ],
           [
@@ -498,28 +472,6 @@
           ]
         ],
         "origin": "MetaMask",
-        "nonceDetails": {
-          "params": {
-            "highestLocallyConfirmed": 0,
-            "highestSuggested": 181,
-            "nextNetworkNonce": 181
-          },
-          "local": {
-            "name": "local",
-            "nonce": 181,
-            "details": {
-              "startPoint": 181,
-              "highest": 181
-            }
-          },
-          "network": {
-            "name": "network",
-            "nonce": 181,
-            "details": {
-              "baseCount": 181
-            }
-          }
-        },
         "rawTx": "0xf86c81b5843b9aca0082cf089492e659448c48fc926ec942d0da1459260d36bb33881bc16d674ec80000802ba03f879cd33a31180da38545d0f809822e00ddf35954d8b0ece83bacf22347ce54a06ad050487978e425ca6a014ed55ea8e9a190069863ed96a0eefa88d729ea1eda",
         "hash": "0x516b77569173a04c76fdb6545cf279ebd0c75f5d25d6e4ce019925205f0e3709",
         "submittedTime": 1528133131951,
@@ -588,32 +540,6 @@
               "value": "0xb6",
               "note": "transactions#approveTransaction",
               "timestamp": 1528133151189
-            },
-            {
-              "op": "add",
-              "path": "/nonceDetails",
-              "value": {
-                "params": {
-                  "highestLocallyConfirmed": 0,
-                  "highestSuggested": 181,
-                  "nextNetworkNonce": 181
-                },
-                "local": {
-                  "name": "local",
-                  "nonce": 182,
-                  "details": {
-                    "startPoint": 181,
-                    "highest": 182
-                  }
-                },
-                "network": {
-                  "name": "network",
-                  "nonce": 181,
-                  "details": {
-                    "baseCount": 181
-                  }
-                }
-              }
             }
           ],
           [
@@ -678,28 +604,6 @@
           ]
         ],
         "origin": "MetaMask",
-        "nonceDetails": {
-          "params": {
-            "highestLocallyConfirmed": 0,
-            "highestSuggested": 181,
-            "nextNetworkNonce": 181
-          },
-          "local": {
-            "name": "local",
-            "nonce": 182,
-            "details": {
-              "startPoint": 181,
-              "highest": 182
-            }
-          },
-          "network": {
-            "name": "network",
-            "nonce": 181,
-            "details": {
-              "baseCount": 181
-            }
-          }
-        },
         "rawTx": "0xf86c81b6843b9aca0082cf089492e659448c48fc926ec942d0da1459260d36bb33881bc16d674ec80000802ba0692deaabf0d79544d41e7c475ad43760679a4f25d0fee908b1da308db1a291a7a0384db85fc6c843ea25986a0760f3c50ab6504fc559fc71fc7f23f60950eb316d",
         "hash": "0x9271b266d05022cfa841362fae43763ebafcee540d84278b0157ef4a68d4e26f",
         "submittedTime": 1528133151347,
@@ -768,32 +672,6 @@
               "value": "0xb7",
               "note": "transactions#approveTransaction",
               "timestamp": 1528133181726
-            },
-            {
-              "op": "add",
-              "path": "/nonceDetails",
-              "value": {
-                "params": {
-                  "highestLocallyConfirmed": 182,
-                  "highestSuggested": 182,
-                  "nextNetworkNonce": 182
-                },
-                "local": {
-                  "name": "local",
-                  "nonce": 183,
-                  "details": {
-                    "startPoint": 182,
-                    "highest": 183
-                  }
-                },
-                "network": {
-                  "name": "network",
-                  "nonce": 182,
-                  "details": {
-                    "baseCount": 182
-                  }
-                }
-              }
             }
           ],
           [
@@ -858,28 +736,6 @@
           ]
         ],
         "origin": "MetaMask",
-        "nonceDetails": {
-          "params": {
-            "highestLocallyConfirmed": 182,
-            "highestSuggested": 182,
-            "nextNetworkNonce": 182
-          },
-          "local": {
-            "name": "local",
-            "nonce": 183,
-            "details": {
-              "startPoint": 182,
-              "highest": 183
-            }
-          },
-          "network": {
-            "name": "network",
-            "nonce": 182,
-            "details": {
-              "baseCount": 182
-            }
-          }
-        },
         "rawTx": "0xf86d81b785012a05f20082cf089492e659448c48fc926ec942d0da1459260d36bb33881bc16d674ec80000802ba086f9846798be6988c39a5cf85f0dbe267e59ca0b96a6a7077e92cba33e10a258a064ffa52ac90c238ce21e6f085283216191b185a1eccd7daae6e2ab66ba26ada0",
         "hash": "0x4e061e977c099735bc9e5203e717f7d9dccb3fcb2f82031a12a3ed326f95d43b",
         "submittedTime": 1528133181885,
@@ -953,32 +809,6 @@
               "value": "0xb8",
               "note": "transactions#approveTransaction",
               "timestamp": 1528133227374
-            },
-            {
-              "op": "add",
-              "path": "/nonceDetails",
-              "value": {
-                "params": {
-                  "highestLocallyConfirmed": 184,
-                  "highestSuggested": 184,
-                  "nextNetworkNonce": 184
-                },
-                "local": {
-                  "name": "local",
-                  "nonce": 184,
-                  "details": {
-                    "startPoint": 184,
-                    "highest": 184
-                  }
-                },
-                "network": {
-                  "name": "network",
-                  "nonce": 184,
-                  "details": {
-                    "baseCount": 184
-                  }
-                }
-              }
             }
           ],
           [
@@ -1043,28 +873,6 @@
           ]
         ],
         "origin": "crypko.ai",
-        "nonceDetails": {
-          "params": {
-            "highestLocallyConfirmed": 184,
-            "highestSuggested": 184,
-            "nextNetworkNonce": 184
-          },
-          "local": {
-            "name": "local",
-            "nonce": 184,
-            "details": {
-              "startPoint": 184,
-              "highest": 184
-            }
-          },
-          "network": {
-            "name": "network",
-            "nonce": 184,
-            "details": {
-              "baseCount": 184
-            }
-          }
-        },
         "rawTx": "0xf8b181b8843b9aca008306169e94fe2149773b3513703e79ad23d05a778a185016ee870aa87bee538000b844ea94496b000000000000000000000000000000000000000000000000000000000001e1eb000000000000000000000000000000000000000000000000000000000001de332ca07bb2efbb8529d67606f9f89e7934c594a31d50c7d24a3286c20a2944a3b8c2a9a07b55ebd8aa28728ce0e38dd3b3503b78fccedae80053626d8649c68346c7c49c",
         "hash": "0x466ae7d4b7c270121f0a8d68fbc6c9091ffc4aa976a553a5bfa56a79cf9f63dd",
         "submittedTime": 1528133227538,
@@ -1135,32 +943,6 @@
               "value": "0xb9",
               "note": "transactions#approveTransaction",
               "timestamp": 1528133293706
-            },
-            {
-              "op": "add",
-              "path": "/nonceDetails",
-              "value": {
-                "params": {
-                  "highestLocallyConfirmed": 185,
-                  "highestSuggested": 185,
-                  "nextNetworkNonce": 185
-                },
-                "local": {
-                  "name": "local",
-                  "nonce": 185,
-                  "details": {
-                    "startPoint": 185,
-                    "highest": 185
-                  }
-                },
-                "network": {
-                  "name": "network",
-                  "nonce": 185,
-                  "details": {
-                    "baseCount": 185
-                  }
-                }
-              }
             }
           ],
           [
@@ -1225,28 +1007,6 @@
           ]
         ],
         "origin": "MetaMask",
-        "nonceDetails": {
-          "params": {
-            "highestLocallyConfirmed": 185,
-            "highestSuggested": 185,
-            "nextNetworkNonce": 185
-          },
-          "local": {
-            "name": "local",
-            "nonce": 185,
-            "details": {
-              "startPoint": 185,
-              "highest": 185
-            }
-          },
-          "network": {
-            "name": "network",
-            "nonce": 185,
-            "details": {
-              "baseCount": 185
-            }
-          }
-        },
         "rawTx": "0xf8a981b9843b9aca0082d50894108cf70c7d384c552f42c07c41c0e1e46d77ea0d80b844a9059cbb00000000000000000000000092e659448c48fc926ec942d0da1459260d36bb3300000000000000000000000000000000000000000000000000000000000000022ca04f05310490d3e3a9a159ae25f52cec9afb0a69527d30be832aaae12e64ff056ea075f81a5220bed481e764bab8830c57169c59fe528ca9cf3442f47f7618a9b4a9",
         "hash": "0x3680dc9815cd05b620b6dd0017d949604ca7d92f051d5542fc8a5ecaa876af09",
         "submittedTime": 1528133293859,

--- a/test/data/mock-state.json
+++ b/test/data/mock-state.json
@@ -704,32 +704,6 @@
               "value": "0xb5",
               "note": "transactions#approveTransaction",
               "timestamp": 1528133131806
-            },
-            {
-              "op": "add",
-              "path": "/nonceDetails",
-              "value": {
-                "params": {
-                  "highestLocallyConfirmed": 0,
-                  "highestSuggested": 181,
-                  "nextNetworkNonce": 181
-                },
-                "local": {
-                  "name": "local",
-                  "nonce": 181,
-                  "details": {
-                    "startPoint": 181,
-                    "highest": 181
-                  }
-                },
-                "network": {
-                  "name": "network",
-                  "nonce": 181,
-                  "details": {
-                    "baseCount": 181
-                  }
-                }
-              }
             }
           ],
           [
@@ -794,28 +768,6 @@
           ]
         ],
         "origin": "MetaMask",
-        "nonceDetails": {
-          "params": {
-            "highestLocallyConfirmed": 0,
-            "highestSuggested": 181,
-            "nextNetworkNonce": 181
-          },
-          "local": {
-            "name": "local",
-            "nonce": 181,
-            "details": {
-              "startPoint": 181,
-              "highest": 181
-            }
-          },
-          "network": {
-            "name": "network",
-            "nonce": 181,
-            "details": {
-              "baseCount": 181
-            }
-          }
-        },
         "rawTx": "0xf86c81b5843b9aca0082cf089492e659448c48fc926ec942d0da1459260d36bb33881bc16d674ec80000802ba03f879cd33a31180da38545d0f809822e00ddf35954d8b0ece83bacf22347ce54a06ad050487978e425ca6a014ed55ea8e9a190069863ed96a0eefa88d729ea1eda",
         "hash": "0x516b77569173a04c76fdb6545cf279ebd0c75f5d25d6e4ce019925205f0e3709",
         "submittedTime": 1528133131951,
@@ -884,32 +836,6 @@
               "value": "0xb6",
               "note": "transactions#approveTransaction",
               "timestamp": 1528133151189
-            },
-            {
-              "op": "add",
-              "path": "/nonceDetails",
-              "value": {
-                "params": {
-                  "highestLocallyConfirmed": 0,
-                  "highestSuggested": 181,
-                  "nextNetworkNonce": 181
-                },
-                "local": {
-                  "name": "local",
-                  "nonce": 182,
-                  "details": {
-                    "startPoint": 181,
-                    "highest": 182
-                  }
-                },
-                "network": {
-                  "name": "network",
-                  "nonce": 181,
-                  "details": {
-                    "baseCount": 181
-                  }
-                }
-              }
             }
           ],
           [
@@ -974,28 +900,6 @@
           ]
         ],
         "origin": "MetaMask",
-        "nonceDetails": {
-          "params": {
-            "highestLocallyConfirmed": 0,
-            "highestSuggested": 181,
-            "nextNetworkNonce": 181
-          },
-          "local": {
-            "name": "local",
-            "nonce": 182,
-            "details": {
-              "startPoint": 181,
-              "highest": 182
-            }
-          },
-          "network": {
-            "name": "network",
-            "nonce": 181,
-            "details": {
-              "baseCount": 181
-            }
-          }
-        },
         "rawTx": "0xf86c81b6843b9aca0082cf089492e659448c48fc926ec942d0da1459260d36bb33881bc16d674ec80000802ba0692deaabf0d79544d41e7c475ad43760679a4f25d0fee908b1da308db1a291a7a0384db85fc6c843ea25986a0760f3c50ab6504fc559fc71fc7f23f60950eb316d",
         "hash": "0x9271b266d05022cfa841362fae43763ebafcee540d84278b0157ef4a68d4e26f",
         "submittedTime": 1528133151347,
@@ -1064,32 +968,6 @@
               "value": "0xb7",
               "note": "transactions#approveTransaction",
               "timestamp": 1528133181726
-            },
-            {
-              "op": "add",
-              "path": "/nonceDetails",
-              "value": {
-                "params": {
-                  "highestLocallyConfirmed": 182,
-                  "highestSuggested": 182,
-                  "nextNetworkNonce": 182
-                },
-                "local": {
-                  "name": "local",
-                  "nonce": 183,
-                  "details": {
-                    "startPoint": 182,
-                    "highest": 183
-                  }
-                },
-                "network": {
-                  "name": "network",
-                  "nonce": 182,
-                  "details": {
-                    "baseCount": 182
-                  }
-                }
-              }
             }
           ],
           [
@@ -1154,28 +1032,6 @@
           ]
         ],
         "origin": "MetaMask",
-        "nonceDetails": {
-          "params": {
-            "highestLocallyConfirmed": 182,
-            "highestSuggested": 182,
-            "nextNetworkNonce": 182
-          },
-          "local": {
-            "name": "local",
-            "nonce": 183,
-            "details": {
-              "startPoint": 182,
-              "highest": 183
-            }
-          },
-          "network": {
-            "name": "network",
-            "nonce": 182,
-            "details": {
-              "baseCount": 182
-            }
-          }
-        },
         "rawTx": "0xf86d81b785012a05f20082cf089492e659448c48fc926ec942d0da1459260d36bb33881bc16d674ec80000802ba086f9846798be6988c39a5cf85f0dbe267e59ca0b96a6a7077e92cba33e10a258a064ffa52ac90c238ce21e6f085283216191b185a1eccd7daae6e2ab66ba26ada0",
         "hash": "0x4e061e977c099735bc9e5203e717f7d9dccb3fcb2f82031a12a3ed326f95d43b",
         "submittedTime": 1528133181885,
@@ -1249,32 +1105,6 @@
               "value": "0xb8",
               "note": "transactions#approveTransaction",
               "timestamp": 1528133227374
-            },
-            {
-              "op": "add",
-              "path": "/nonceDetails",
-              "value": {
-                "params": {
-                  "highestLocallyConfirmed": 184,
-                  "highestSuggested": 184,
-                  "nextNetworkNonce": 184
-                },
-                "local": {
-                  "name": "local",
-                  "nonce": 184,
-                  "details": {
-                    "startPoint": 184,
-                    "highest": 184
-                  }
-                },
-                "network": {
-                  "name": "network",
-                  "nonce": 184,
-                  "details": {
-                    "baseCount": 184
-                  }
-                }
-              }
             }
           ],
           [
@@ -1339,28 +1169,6 @@
           ]
         ],
         "origin": "crypko.ai",
-        "nonceDetails": {
-          "params": {
-            "highestLocallyConfirmed": 184,
-            "highestSuggested": 184,
-            "nextNetworkNonce": 184
-          },
-          "local": {
-            "name": "local",
-            "nonce": 184,
-            "details": {
-              "startPoint": 184,
-              "highest": 184
-            }
-          },
-          "network": {
-            "name": "network",
-            "nonce": 184,
-            "details": {
-              "baseCount": 184
-            }
-          }
-        },
         "rawTx": "0xf8b181b8843b9aca008306169e94fe2149773b3513703e79ad23d05a778a185016ee870aa87bee538000b844ea94496b000000000000000000000000000000000000000000000000000000000001e1eb000000000000000000000000000000000000000000000000000000000001de332ca07bb2efbb8529d67606f9f89e7934c594a31d50c7d24a3286c20a2944a3b8c2a9a07b55ebd8aa28728ce0e38dd3b3503b78fccedae80053626d8649c68346c7c49c",
         "hash": "0x466ae7d4b7c270121f0a8d68fbc6c9091ffc4aa976a553a5bfa56a79cf9f63dd",
         "submittedTime": 1528133227538,
@@ -1431,32 +1239,6 @@
               "value": "0xb9",
               "note": "transactions#approveTransaction",
               "timestamp": 1528133293706
-            },
-            {
-              "op": "add",
-              "path": "/nonceDetails",
-              "value": {
-                "params": {
-                  "highestLocallyConfirmed": 185,
-                  "highestSuggested": 185,
-                  "nextNetworkNonce": 185
-                },
-                "local": {
-                  "name": "local",
-                  "nonce": 185,
-                  "details": {
-                    "startPoint": 185,
-                    "highest": 185
-                  }
-                },
-                "network": {
-                  "name": "network",
-                  "nonce": 185,
-                  "details": {
-                    "baseCount": 185
-                  }
-                }
-              }
             }
           ],
           [
@@ -1521,28 +1303,6 @@
           ]
         ],
         "origin": "MetaMask",
-        "nonceDetails": {
-          "params": {
-            "highestLocallyConfirmed": 185,
-            "highestSuggested": 185,
-            "nextNetworkNonce": 185
-          },
-          "local": {
-            "name": "local",
-            "nonce": 185,
-            "details": {
-              "startPoint": 185,
-              "highest": 185
-            }
-          },
-          "network": {
-            "name": "network",
-            "nonce": 185,
-            "details": {
-              "baseCount": 185
-            }
-          }
-        },
         "rawTx": "0xf8a981b9843b9aca0082d50894108cf70c7d384c552f42c07c41c0e1e46d77ea0d80b844a9059cbb00000000000000000000000092e659448c48fc926ec942d0da1459260d36bb3300000000000000000000000000000000000000000000000000000000000000022ca04f05310490d3e3a9a159ae25f52cec9afb0a69527d30be832aaae12e64ff056ea075f81a5220bed481e764bab8830c57169c59fe528ca9cf3442f47f7618a9b4a9",
         "hash": "0x3680dc9815cd05b620b6dd0017d949604ca7d92f051d5542fc8a5ecaa876af09",
         "submittedTime": 1528133293859,

--- a/test/data/mock-tx-history.json
+++ b/test/data/mock-tx-history.json
@@ -79,12 +79,6 @@
               "gasPrice": "3b9aca00",
               "gas": "0x7b0d",
               "nonce": 0
-            },
-            "nonceDetails": {
-              "blockNumber": "0x16643c",
-              "baseCount": 0,
-              "baseCountHex": "0x0",
-              "pendingCount": 0
             }
           },
           {
@@ -99,12 +93,6 @@
               "gasPrice": "3b9aca00",
               "gas": "0x7b0d",
               "nonce": 0
-            },
-            "nonceDetails": {
-              "blockNumber": "0x16643c",
-              "baseCount": 0,
-              "baseCountHex": "0x0",
-              "pendingCount": 0
             }
           },
           {
@@ -119,12 +107,6 @@
               "gasPrice": "0x3b9aca00",
               "gas": "0x7b0d",
               "chainId": 5
-            },
-            "nonceDetails": {
-              "blockNumber": "0x16643c",
-              "baseCount": 0,
-              "baseCountHex": "0x0",
-              "pendingCount": 0
             }
           },
           {
@@ -139,12 +121,6 @@
               "gasPrice": "0x3b9aca00",
               "gas": "0x7b0d",
               "chainId": 5
-            },
-            "nonceDetails": {
-              "blockNumber": "0x16643c",
-              "baseCount": 0,
-              "baseCountHex": "0x0",
-              "pendingCount": 0
             }
           },
           {
@@ -159,12 +135,6 @@
               "gasPrice": "0x3b9aca00",
               "gas": "0x7b0d",
               "chainId": 5
-            },
-            "nonceDetails": {
-              "blockNumber": "0x16643c",
-              "baseCount": 0,
-              "baseCountHex": "0x0",
-              "pendingCount": 0
             },
             "rawTx": "0xf86380843b9aca00827b0d943ae39e89dc7e736cce53091057a45bf44b1a566c808029a02e45f61129f0c97634e37a1823b858df7b0dfc867a44949aae7dd9bcea1c1b5aa03b1f002cda0872d40517d5b26caefa3e407ec8fd03bc7dc2d995b84726961264"
           },
@@ -181,12 +151,6 @@
               "gas": "0x7b0d",
               "chainId": 5
             },
-            "nonceDetails": {
-              "blockNumber": "0x16643c",
-              "baseCount": 0,
-              "baseCountHex": "0x0",
-              "pendingCount": 0
-            },
             "rawTx": "0xf86380843b9aca00827b0d943ae39e89dc7e736cce53091057a45bf44b1a566c808029a02e45f61129f0c97634e37a1823b858df7b0dfc867a44949aae7dd9bcea1c1b5aa03b1f002cda0872d40517d5b26caefa3e407ec8fd03bc7dc2d995b84726961264"
           },
           {
@@ -201,12 +165,6 @@
               "gasPrice": "0x3b9aca00",
               "gas": "0x7b0d",
               "chainId": 5
-            },
-            "nonceDetails": {
-              "blockNumber": "0x16643c",
-              "baseCount": 0,
-              "baseCountHex": "0x0",
-              "pendingCount": 0
             },
             "rawTx": "0xf86380843b9aca00827b0d943ae39e89dc7e736cce53091057a45bf44b1a566c808029a02e45f61129f0c97634e37a1823b858df7b0dfc867a44949aae7dd9bcea1c1b5aa03b1f002cda0872d40517d5b26caefa3e407ec8fd03bc7dc2d995b84726961264",
             "hash": "0x38c254639139c94303a3141aee041b15301509e743f08569ffac6aca17518012"
@@ -223,12 +181,6 @@
               "gasPrice": "0x3b9aca00",
               "gas": "0x7b0d",
               "chainId": 5
-            },
-            "nonceDetails": {
-              "blockNumber": "0x16643c",
-              "baseCount": 0,
-              "baseCountHex": "0x0",
-              "pendingCount": 0
             },
             "rawTx": "0xf86380843b9aca00827b0d943ae39e89dc7e736cce53091057a45bf44b1a566c808029a02e45f61129f0c97634e37a1823b858df7b0dfc867a44949aae7dd9bcea1c1b5aa03b1f002cda0872d40517d5b26caefa3e407ec8fd03bc7dc2d995b84726961264",
             "hash": "0x38c254639139c94303a3141aee041b15301509e743f08569ffac6aca17518012"
@@ -246,12 +198,6 @@
               "gas": "0x7b0d",
               "chainId": 5
             },
-            "nonceDetails": {
-              "blockNumber": "0x16643c",
-              "baseCount": 0,
-              "baseCountHex": "0x0",
-              "pendingCount": 0
-            },
             "rawTx": "0xf86380843b9aca00827b0d943ae39e89dc7e736cce53091057a45bf44b1a566c808029a02e45f61129f0c97634e37a1823b858df7b0dfc867a44949aae7dd9bcea1c1b5aa03b1f002cda0872d40517d5b26caefa3e407ec8fd03bc7dc2d995b84726961264",
             "hash": "0x38c254639139c94303a3141aee041b15301509e743f08569ffac6aca17518012"
           },
@@ -267,12 +213,6 @@
               "gasPrice": "0x3b9aca00",
               "gas": "0x7b0d",
               "chainId": 5
-            },
-            "nonceDetails": {
-              "blockNumber": "0x16643c",
-              "baseCount": 0,
-              "baseCountHex": "0x0",
-              "pendingCount": 0
             },
             "rawTx": "0xf86380843b9aca00827b0d943ae39e89dc7e736cce53091057a45bf44b1a566c808029a02e45f61129f0c97634e37a1823b858df7b0dfc867a44949aae7dd9bcea1c1b5aa03b1f002cda0872d40517d5b26caefa3e407ec8fd03bc7dc2d995b84726961264",
             "hash": "0x38c254639139c94303a3141aee041b15301509e743f08569ffac6aca17518012"
@@ -289,12 +229,6 @@
               "gasPrice": "0x3b9aca00",
               "gas": "0x7b0d",
               "chainId": 5
-            },
-            "nonceDetails": {
-              "blockNumber": "0x16643c",
-              "baseCount": 0,
-              "baseCountHex": "0x0",
-              "pendingCount": 0
             },
             "rawTx": "0xf86380843b9aca00827b0d943ae39e89dc7e736cce53091057a45bf44b1a566c808029a02e45f61129f0c97634e37a1823b858df7b0dfc867a44949aae7dd9bcea1c1b5aa03b1f002cda0872d40517d5b26caefa3e407ec8fd03bc7dc2d995b84726961264",
             "hash": "0x38c254639139c94303a3141aee041b15301509e743f08569ffac6aca17518012",
@@ -312,24 +246,12 @@
               "gasPrice": "0x3b9aca00",
               "gas": "0x7b0d",
               "chainId": 5
-            },
-            "nonceDetails": {
-              "blockNumber": "0x16643c",
-              "baseCount": 0,
-              "baseCountHex": "0x0",
-              "pendingCount": 0
             },
             "rawTx": "0xf86380843b9aca00827b0d943ae39e89dc7e736cce53091057a45bf44b1a566c808029a02e45f61129f0c97634e37a1823b858df7b0dfc867a44949aae7dd9bcea1c1b5aa03b1f002cda0872d40517d5b26caefa3e407ec8fd03bc7dc2d995b84726961264",
             "hash": "0x38c254639139c94303a3141aee041b15301509e743f08569ffac6aca17518012",
             "retryCount": 1
           }
         ],
-        "nonceDetails": {
-          "blockNumber": "0x16643c",
-          "baseCount": 0,
-          "baseCountHex": "0x0",
-          "pendingCount": 0
-        },
         "rawTx": "0xf86380843b9aca00827b0d943ae39e89dc7e736cce53091057a45bf44b1a566c808029a02e45f61129f0c97634e37a1823b858df7b0dfc867a44949aae7dd9bcea1c1b5aa03b1f002cda0872d40517d5b26caefa3e407ec8fd03bc7dc2d995b84726961264",
         "hash": "0x38c254639139c94303a3141aee041b15301509e743f08569ffac6aca17518012",
         "retryCount": 1
@@ -454,12 +376,6 @@
               "gasPrice": "28fa6ae00",
               "gas": "0x7b0d",
               "nonce": 1
-            },
-            "nonceDetails": {
-              "blockNumber": "0x168739",
-              "baseCount": 1,
-              "baseCountHex": "0x1",
-              "pendingCount": 0
             }
           },
           {
@@ -474,12 +390,6 @@
               "gasPrice": "28fa6ae00",
               "gas": "0x7b0d",
               "nonce": 1
-            },
-            "nonceDetails": {
-              "blockNumber": "0x168739",
-              "baseCount": 1,
-              "baseCountHex": "0x1",
-              "pendingCount": 0
             }
           },
           {
@@ -495,12 +405,6 @@
               "gas": "0x7b0d",
               "nonce": "0x01",
               "chainId": 5
-            },
-            "nonceDetails": {
-              "blockNumber": "0x168739",
-              "baseCount": 1,
-              "baseCountHex": "0x1",
-              "pendingCount": 0
             }
           },
           {
@@ -516,12 +420,6 @@
               "gas": "0x7b0d",
               "nonce": "0x01",
               "chainId": 5
-            },
-            "nonceDetails": {
-              "blockNumber": "0x168739",
-              "baseCount": 1,
-              "baseCountHex": "0x1",
-              "pendingCount": 0
             }
           },
           {
@@ -537,12 +435,6 @@
               "gas": "0x7b0d",
               "nonce": "0x01",
               "chainId": 5
-            },
-            "nonceDetails": {
-              "blockNumber": "0x168739",
-              "baseCount": 1,
-              "baseCountHex": "0x1",
-              "pendingCount": 0
             },
             "rawTx": "0xf8640185028fa6ae00827b0d943ae39e89dc7e736cce53091057a45bf44b1a566c808029a06261831b3d599a90dc24fac67bc648fd58cab2036e4e8dfbbb5c00c3fd9cf66ba00e2ea6ebc63ba715a94dc94e24120639c4ad60832d3285dd558929a61cc18cc0"
           },
@@ -560,12 +452,6 @@
               "nonce": "0x01",
               "chainId": 5
             },
-            "nonceDetails": {
-              "blockNumber": "0x168739",
-              "baseCount": 1,
-              "baseCountHex": "0x1",
-              "pendingCount": 0
-            },
             "rawTx": "0xf8640185028fa6ae00827b0d943ae39e89dc7e736cce53091057a45bf44b1a566c808029a06261831b3d599a90dc24fac67bc648fd58cab2036e4e8dfbbb5c00c3fd9cf66ba00e2ea6ebc63ba715a94dc94e24120639c4ad60832d3285dd558929a61cc18cc0"
           },
           {
@@ -581,12 +467,6 @@
               "gas": "0x7b0d",
               "nonce": "0x01",
               "chainId": 5
-            },
-            "nonceDetails": {
-              "blockNumber": "0x168739",
-              "baseCount": 1,
-              "baseCountHex": "0x1",
-              "pendingCount": 0
             },
             "rawTx": "0xf8640185028fa6ae00827b0d943ae39e89dc7e736cce53091057a45bf44b1a566c808029a06261831b3d599a90dc24fac67bc648fd58cab2036e4e8dfbbb5c00c3fd9cf66ba00e2ea6ebc63ba715a94dc94e24120639c4ad60832d3285dd558929a61cc18cc0",
             "hash": "0xeb1c57dec9df8410bcc65374c7f684fc8ebfcda6865a149e38bb000fa706a150"
@@ -604,12 +484,6 @@
               "gas": "0x7b0d",
               "nonce": "0x01",
               "chainId": 5
-            },
-            "nonceDetails": {
-              "blockNumber": "0x168739",
-              "baseCount": 1,
-              "baseCountHex": "0x1",
-              "pendingCount": 0
             },
             "rawTx": "0xf8640185028fa6ae00827b0d943ae39e89dc7e736cce53091057a45bf44b1a566c808029a06261831b3d599a90dc24fac67bc648fd58cab2036e4e8dfbbb5c00c3fd9cf66ba00e2ea6ebc63ba715a94dc94e24120639c4ad60832d3285dd558929a61cc18cc0",
             "hash": "0xeb1c57dec9df8410bcc65374c7f684fc8ebfcda6865a149e38bb000fa706a150"
@@ -628,12 +502,6 @@
               "nonce": "0x01",
               "chainId": 5
             },
-            "nonceDetails": {
-              "blockNumber": "0x168739",
-              "baseCount": 1,
-              "baseCountHex": "0x1",
-              "pendingCount": 0
-            },
             "rawTx": "0xf8640185028fa6ae00827b0d943ae39e89dc7e736cce53091057a45bf44b1a566c808029a06261831b3d599a90dc24fac67bc648fd58cab2036e4e8dfbbb5c00c3fd9cf66ba00e2ea6ebc63ba715a94dc94e24120639c4ad60832d3285dd558929a61cc18cc0",
             "hash": "0xeb1c57dec9df8410bcc65374c7f684fc8ebfcda6865a149e38bb000fa706a150"
           },
@@ -650,12 +518,6 @@
               "gas": "0x7b0d",
               "nonce": "0x01",
               "chainId": 5
-            },
-            "nonceDetails": {
-              "blockNumber": "0x168739",
-              "baseCount": 1,
-              "baseCountHex": "0x1",
-              "pendingCount": 0
             },
             "rawTx": "0xf8640185028fa6ae00827b0d943ae39e89dc7e736cce53091057a45bf44b1a566c808029a06261831b3d599a90dc24fac67bc648fd58cab2036e4e8dfbbb5c00c3fd9cf66ba00e2ea6ebc63ba715a94dc94e24120639c4ad60832d3285dd558929a61cc18cc0",
             "hash": "0xeb1c57dec9df8410bcc65374c7f684fc8ebfcda6865a149e38bb000fa706a150"
@@ -673,12 +535,6 @@
               "gas": "0x7b0d",
               "nonce": "0x01",
               "chainId": 5
-            },
-            "nonceDetails": {
-              "blockNumber": "0x168739",
-              "baseCount": 1,
-              "baseCountHex": "0x1",
-              "pendingCount": 0
             },
             "rawTx": "0xf8640185028fa6ae00827b0d943ae39e89dc7e736cce53091057a45bf44b1a566c808029a06261831b3d599a90dc24fac67bc648fd58cab2036e4e8dfbbb5c00c3fd9cf66ba00e2ea6ebc63ba715a94dc94e24120639c4ad60832d3285dd558929a61cc18cc0",
             "hash": "0xeb1c57dec9df8410bcc65374c7f684fc8ebfcda6865a149e38bb000fa706a150",
@@ -697,24 +553,12 @@
               "gas": "0x7b0d",
               "nonce": "0x01",
               "chainId": 5
-            },
-            "nonceDetails": {
-              "blockNumber": "0x168739",
-              "baseCount": 1,
-              "baseCountHex": "0x1",
-              "pendingCount": 0
             },
             "rawTx": "0xf8640185028fa6ae00827b0d943ae39e89dc7e736cce53091057a45bf44b1a566c808029a06261831b3d599a90dc24fac67bc648fd58cab2036e4e8dfbbb5c00c3fd9cf66ba00e2ea6ebc63ba715a94dc94e24120639c4ad60832d3285dd558929a61cc18cc0",
             "hash": "0xeb1c57dec9df8410bcc65374c7f684fc8ebfcda6865a149e38bb000fa706a150",
             "retryCount": 1
           }
         ],
-        "nonceDetails": {
-          "blockNumber": "0x168739",
-          "baseCount": 1,
-          "baseCountHex": "0x1",
-          "pendingCount": 0
-        },
         "rawTx": "0xf8640185028fa6ae00827b0d943ae39e89dc7e736cce53091057a45bf44b1a566c808029a06261831b3d599a90dc24fac67bc648fd58cab2036e4e8dfbbb5c00c3fd9cf66ba00e2ea6ebc63ba715a94dc94e24120639c4ad60832d3285dd558929a61cc18cc0",
         "hash": "0xeb1c57dec9df8410bcc65374c7f684fc8ebfcda6865a149e38bb000fa706a150",
         "retryCount": 1
@@ -798,12 +642,6 @@
               "gasPrice": "4a817c800",
               "gas": "0x7b0d",
               "nonce": 2
-            },
-            "nonceDetails": {
-              "blockNumber": "0x16b066",
-              "baseCount": 2,
-              "baseCountHex": "0x2",
-              "pendingCount": 0
             }
           },
           {
@@ -818,12 +656,6 @@
               "gasPrice": "4a817c800",
               "gas": "0x7b0d",
               "nonce": 2
-            },
-            "nonceDetails": {
-              "blockNumber": "0x16b066",
-              "baseCount": 2,
-              "baseCountHex": "0x2",
-              "pendingCount": 0
             }
           },
           {
@@ -839,12 +671,6 @@
               "gas": "0x7b0d",
               "nonce": "0x02",
               "chainId": 5
-            },
-            "nonceDetails": {
-              "blockNumber": "0x16b066",
-              "baseCount": 2,
-              "baseCountHex": "0x2",
-              "pendingCount": 0
             }
           },
           {
@@ -860,12 +686,6 @@
               "gas": "0x7b0d",
               "nonce": "0x02",
               "chainId": 5
-            },
-            "nonceDetails": {
-              "blockNumber": "0x16b066",
-              "baseCount": 2,
-              "baseCountHex": "0x2",
-              "pendingCount": 0
             }
           },
           {
@@ -881,12 +701,6 @@
               "gas": "0x7b0d",
               "nonce": "0x02",
               "chainId": 5
-            },
-            "nonceDetails": {
-              "blockNumber": "0x16b066",
-              "baseCount": 2,
-              "baseCountHex": "0x2",
-              "pendingCount": 0
             },
             "rawTx": "0xf864028504a817c800827b0d943ae39e89dc7e736cce53091057a45bf44b1a566c80802aa057380f9007a48d4bce31792859b1a25cb2b45ba615e7951d8e8a925360a0b301a042393e72d1a96a2605c0da95705c5f3f7c744f0affcac01e0a64721037f04adc"
           },
@@ -904,12 +718,6 @@
               "nonce": "0x02",
               "chainId": 5
             },
-            "nonceDetails": {
-              "blockNumber": "0x16b066",
-              "baseCount": 2,
-              "baseCountHex": "0x2",
-              "pendingCount": 0
-            },
             "rawTx": "0xf864028504a817c800827b0d943ae39e89dc7e736cce53091057a45bf44b1a566c80802aa057380f9007a48d4bce31792859b1a25cb2b45ba615e7951d8e8a925360a0b301a042393e72d1a96a2605c0da95705c5f3f7c744f0affcac01e0a64721037f04adc"
           },
           {
@@ -925,12 +733,6 @@
               "gas": "0x7b0d",
               "nonce": "0x02",
               "chainId": 5
-            },
-            "nonceDetails": {
-              "blockNumber": "0x16b066",
-              "baseCount": 2,
-              "baseCountHex": "0x2",
-              "pendingCount": 0
             },
             "rawTx": "0xf864028504a817c800827b0d943ae39e89dc7e736cce53091057a45bf44b1a566c80802aa057380f9007a48d4bce31792859b1a25cb2b45ba615e7951d8e8a925360a0b301a042393e72d1a96a2605c0da95705c5f3f7c744f0affcac01e0a64721037f04adc",
             "hash": "0xc28ceb1e2c4e5c61b805b181e3cc99dd7bade58935233fab76c63cedfd494270"
@@ -948,12 +750,6 @@
               "gas": "0x7b0d",
               "nonce": "0x02",
               "chainId": 5
-            },
-            "nonceDetails": {
-              "blockNumber": "0x16b066",
-              "baseCount": 2,
-              "baseCountHex": "0x2",
-              "pendingCount": 0
             },
             "rawTx": "0xf864028504a817c800827b0d943ae39e89dc7e736cce53091057a45bf44b1a566c80802aa057380f9007a48d4bce31792859b1a25cb2b45ba615e7951d8e8a925360a0b301a042393e72d1a96a2605c0da95705c5f3f7c744f0affcac01e0a64721037f04adc",
             "hash": "0xc28ceb1e2c4e5c61b805b181e3cc99dd7bade58935233fab76c63cedfd494270"
@@ -972,12 +768,6 @@
               "nonce": "0x02",
               "chainId": 5
             },
-            "nonceDetails": {
-              "blockNumber": "0x16b066",
-              "baseCount": 2,
-              "baseCountHex": "0x2",
-              "pendingCount": 0
-            },
             "rawTx": "0xf864028504a817c800827b0d943ae39e89dc7e736cce53091057a45bf44b1a566c80802aa057380f9007a48d4bce31792859b1a25cb2b45ba615e7951d8e8a925360a0b301a042393e72d1a96a2605c0da95705c5f3f7c744f0affcac01e0a64721037f04adc",
             "hash": "0xc28ceb1e2c4e5c61b805b181e3cc99dd7bade58935233fab76c63cedfd494270"
           },
@@ -994,12 +784,6 @@
               "gas": "0x7b0d",
               "nonce": "0x02",
               "chainId": 5
-            },
-            "nonceDetails": {
-              "blockNumber": "0x16b066",
-              "baseCount": 2,
-              "baseCountHex": "0x2",
-              "pendingCount": 0
             },
             "rawTx": "0xf864028504a817c800827b0d943ae39e89dc7e736cce53091057a45bf44b1a566c80802aa057380f9007a48d4bce31792859b1a25cb2b45ba615e7951d8e8a925360a0b301a042393e72d1a96a2605c0da95705c5f3f7c744f0affcac01e0a64721037f04adc",
             "hash": "0xc28ceb1e2c4e5c61b805b181e3cc99dd7bade58935233fab76c63cedfd494270"
@@ -1017,12 +801,6 @@
               "gas": "0x7b0d",
               "nonce": "0x02",
               "chainId": 5
-            },
-            "nonceDetails": {
-              "blockNumber": "0x16b066",
-              "baseCount": 2,
-              "baseCountHex": "0x2",
-              "pendingCount": 0
             },
             "rawTx": "0xf864028504a817c800827b0d943ae39e89dc7e736cce53091057a45bf44b1a566c80802aa057380f9007a48d4bce31792859b1a25cb2b45ba615e7951d8e8a925360a0b301a042393e72d1a96a2605c0da95705c5f3f7c744f0affcac01e0a64721037f04adc",
             "hash": "0xc28ceb1e2c4e5c61b805b181e3cc99dd7bade58935233fab76c63cedfd494270",
@@ -1041,24 +819,12 @@
               "gas": "0x7b0d",
               "nonce": "0x02",
               "chainId": 5
-            },
-            "nonceDetails": {
-              "blockNumber": "0x16b066",
-              "baseCount": 2,
-              "baseCountHex": "0x2",
-              "pendingCount": 0
             },
             "rawTx": "0xf864028504a817c800827b0d943ae39e89dc7e736cce53091057a45bf44b1a566c80802aa057380f9007a48d4bce31792859b1a25cb2b45ba615e7951d8e8a925360a0b301a042393e72d1a96a2605c0da95705c5f3f7c744f0affcac01e0a64721037f04adc",
             "hash": "0xc28ceb1e2c4e5c61b805b181e3cc99dd7bade58935233fab76c63cedfd494270",
             "retryCount": 1
           }
         ],
-        "nonceDetails": {
-          "blockNumber": "0x16b066",
-          "baseCount": 2,
-          "baseCountHex": "0x2",
-          "pendingCount": 0
-        },
         "rawTx": "0xf864028504a817c800827b0d943ae39e89dc7e736cce53091057a45bf44b1a566c80802aa057380f9007a48d4bce31792859b1a25cb2b45ba615e7951d8e8a925360a0b301a042393e72d1a96a2605c0da95705c5f3f7c744f0affcac01e0a64721037f04adc",
         "hash": "0xc28ceb1e2c4e5c61b805b181e3cc99dd7bade58935233fab76c63cedfd494270",
         "retryCount": 1
@@ -1142,12 +908,6 @@
               "gasPrice": "0x3b9aca00",
               "gas": "0x7b0d",
               "nonce": 3
-            },
-            "nonceDetails": {
-              "blockNumber": "0x16b067",
-              "baseCount": 2,
-              "baseCountHex": "0x2",
-              "pendingCount": 1
             }
           },
           {
@@ -1162,12 +922,6 @@
               "gasPrice": "0x3b9aca00",
               "gas": "0x7b0d",
               "nonce": 3
-            },
-            "nonceDetails": {
-              "blockNumber": "0x16b067",
-              "baseCount": 2,
-              "baseCountHex": "0x2",
-              "pendingCount": 1
             }
           },
           {
@@ -1183,12 +937,6 @@
               "gas": "0x7b0d",
               "nonce": "0x03",
               "chainId": 5
-            },
-            "nonceDetails": {
-              "blockNumber": "0x16b067",
-              "baseCount": 2,
-              "baseCountHex": "0x2",
-              "pendingCount": 1
             }
           },
           {
@@ -1204,12 +952,6 @@
               "gas": "0x7b0d",
               "nonce": "0x03",
               "chainId": 5
-            },
-            "nonceDetails": {
-              "blockNumber": "0x16b067",
-              "baseCount": 2,
-              "baseCountHex": "0x2",
-              "pendingCount": 1
             }
           },
           {
@@ -1225,12 +967,6 @@
               "gas": "0x7b0d",
               "nonce": "0x03",
               "chainId": 5
-            },
-            "nonceDetails": {
-              "blockNumber": "0x16b067",
-              "baseCount": 2,
-              "baseCountHex": "0x2",
-              "pendingCount": 1
             },
             "rawTx": "0xf86303843b9aca00827b0d943ae39e89dc7e736cce53091057a45bf44b1a566c80802aa0e442afe9386066936f556d852a296d22b8392652aa2ddb26969d83d661759ee1a06dc55b164f666a37107e86d575d2701602fc100f0ef4875736d45995150d4897"
           },
@@ -1248,12 +984,6 @@
               "nonce": "0x03",
               "chainId": 5
             },
-            "nonceDetails": {
-              "blockNumber": "0x16b067",
-              "baseCount": 2,
-              "baseCountHex": "0x2",
-              "pendingCount": 1
-            },
             "rawTx": "0xf86303843b9aca00827b0d943ae39e89dc7e736cce53091057a45bf44b1a566c80802aa0e442afe9386066936f556d852a296d22b8392652aa2ddb26969d83d661759ee1a06dc55b164f666a37107e86d575d2701602fc100f0ef4875736d45995150d4897"
           },
           {
@@ -1269,12 +999,6 @@
               "gas": "0x7b0d",
               "nonce": "0x03",
               "chainId": 5
-            },
-            "nonceDetails": {
-              "blockNumber": "0x16b067",
-              "baseCount": 2,
-              "baseCountHex": "0x2",
-              "pendingCount": 1
             },
             "rawTx": "0xf86303843b9aca00827b0d943ae39e89dc7e736cce53091057a45bf44b1a566c80802aa0e442afe9386066936f556d852a296d22b8392652aa2ddb26969d83d661759ee1a06dc55b164f666a37107e86d575d2701602fc100f0ef4875736d45995150d4897",
             "hash": "0xfcc66b8002c64a5aaa076adea7f7e48d194de10e40eb64924c8de344805c8cb7"
@@ -1292,12 +1016,6 @@
               "gas": "0x7b0d",
               "nonce": "0x03",
               "chainId": 5
-            },
-            "nonceDetails": {
-              "blockNumber": "0x16b067",
-              "baseCount": 2,
-              "baseCountHex": "0x2",
-              "pendingCount": 1
             },
             "rawTx": "0xf86303843b9aca00827b0d943ae39e89dc7e736cce53091057a45bf44b1a566c80802aa0e442afe9386066936f556d852a296d22b8392652aa2ddb26969d83d661759ee1a06dc55b164f666a37107e86d575d2701602fc100f0ef4875736d45995150d4897",
             "hash": "0xfcc66b8002c64a5aaa076adea7f7e48d194de10e40eb64924c8de344805c8cb7"
@@ -1316,12 +1034,6 @@
               "nonce": "0x03",
               "chainId": 5
             },
-            "nonceDetails": {
-              "blockNumber": "0x16b067",
-              "baseCount": 2,
-              "baseCountHex": "0x2",
-              "pendingCount": 1
-            },
             "rawTx": "0xf86303843b9aca00827b0d943ae39e89dc7e736cce53091057a45bf44b1a566c80802aa0e442afe9386066936f556d852a296d22b8392652aa2ddb26969d83d661759ee1a06dc55b164f666a37107e86d575d2701602fc100f0ef4875736d45995150d4897",
             "hash": "0xfcc66b8002c64a5aaa076adea7f7e48d194de10e40eb64924c8de344805c8cb7"
           },
@@ -1338,12 +1050,6 @@
               "gas": "0x7b0d",
               "nonce": "0x03",
               "chainId": 5
-            },
-            "nonceDetails": {
-              "blockNumber": "0x16b067",
-              "baseCount": 2,
-              "baseCountHex": "0x2",
-              "pendingCount": 1
             },
             "rawTx": "0xf86303843b9aca00827b0d943ae39e89dc7e736cce53091057a45bf44b1a566c80802aa0e442afe9386066936f556d852a296d22b8392652aa2ddb26969d83d661759ee1a06dc55b164f666a37107e86d575d2701602fc100f0ef4875736d45995150d4897",
             "hash": "0xfcc66b8002c64a5aaa076adea7f7e48d194de10e40eb64924c8de344805c8cb7"
@@ -1361,12 +1067,6 @@
               "gas": "0x7b0d",
               "nonce": "0x03",
               "chainId": 5
-            },
-            "nonceDetails": {
-              "blockNumber": "0x16b067",
-              "baseCount": 2,
-              "baseCountHex": "0x2",
-              "pendingCount": 1
             },
             "rawTx": "0xf86303843b9aca00827b0d943ae39e89dc7e736cce53091057a45bf44b1a566c80802aa0e442afe9386066936f556d852a296d22b8392652aa2ddb26969d83d661759ee1a06dc55b164f666a37107e86d575d2701602fc100f0ef4875736d45995150d4897",
             "hash": "0xfcc66b8002c64a5aaa076adea7f7e48d194de10e40eb64924c8de344805c8cb7",
@@ -1385,24 +1085,12 @@
               "gas": "0x7b0d",
               "nonce": "0x03",
               "chainId": 5
-            },
-            "nonceDetails": {
-              "blockNumber": "0x16b067",
-              "baseCount": 2,
-              "baseCountHex": "0x2",
-              "pendingCount": 1
             },
             "rawTx": "0xf86303843b9aca00827b0d943ae39e89dc7e736cce53091057a45bf44b1a566c80802aa0e442afe9386066936f556d852a296d22b8392652aa2ddb26969d83d661759ee1a06dc55b164f666a37107e86d575d2701602fc100f0ef4875736d45995150d4897",
             "hash": "0xfcc66b8002c64a5aaa076adea7f7e48d194de10e40eb64924c8de344805c8cb7",
             "retryCount": 2
           }
         ],
-        "nonceDetails": {
-          "blockNumber": "0x16b067",
-          "baseCount": 2,
-          "baseCountHex": "0x2",
-          "pendingCount": 1
-        },
         "rawTx": "0xf86303843b9aca00827b0d943ae39e89dc7e736cce53091057a45bf44b1a566c80802aa0e442afe9386066936f556d852a296d22b8392652aa2ddb26969d83d661759ee1a06dc55b164f666a37107e86d575d2701602fc100f0ef4875736d45995150d4897",
         "hash": "0xfcc66b8002c64a5aaa076adea7f7e48d194de10e40eb64924c8de344805c8cb7",
         "retryCount": 2
@@ -1486,12 +1174,6 @@
               "gasPrice": "4a817c800",
               "gas": "0x7b0d",
               "nonce": 4
-            },
-            "nonceDetails": {
-              "blockNumber": "0x16b067",
-              "baseCount": 2,
-              "baseCountHex": "0x2",
-              "pendingCount": 2
             }
           },
           {
@@ -1506,12 +1188,6 @@
               "gasPrice": "4a817c800",
               "gas": "0x7b0d",
               "nonce": 4
-            },
-            "nonceDetails": {
-              "blockNumber": "0x16b067",
-              "baseCount": 2,
-              "baseCountHex": "0x2",
-              "pendingCount": 2
             }
           },
           {
@@ -1527,12 +1203,6 @@
               "gas": "0x7b0d",
               "nonce": "0x04",
               "chainId": 5
-            },
-            "nonceDetails": {
-              "blockNumber": "0x16b067",
-              "baseCount": 2,
-              "baseCountHex": "0x2",
-              "pendingCount": 2
             }
           },
           {
@@ -1548,12 +1218,6 @@
               "gas": "0x7b0d",
               "nonce": "0x04",
               "chainId": 5
-            },
-            "nonceDetails": {
-              "blockNumber": "0x16b067",
-              "baseCount": 2,
-              "baseCountHex": "0x2",
-              "pendingCount": 2
             }
           },
           {
@@ -1569,12 +1233,6 @@
               "gas": "0x7b0d",
               "nonce": "0x04",
               "chainId": 5
-            },
-            "nonceDetails": {
-              "blockNumber": "0x16b067",
-              "baseCount": 2,
-              "baseCountHex": "0x2",
-              "pendingCount": 2
             },
             "rawTx": "0xf864048504a817c800827b0d943ae39e89dc7e736cce53091057a45bf44b1a566c808029a04be1c01535745fa7ec7aeb6e0b64d009981713808ca443b181fad802ce941352a03887e90375d9225b8dfd0d42324eed8eb4982fd14ea7b4069290237b29d1dcd3"
           },
@@ -1592,12 +1250,6 @@
               "nonce": "0x04",
               "chainId": 5
             },
-            "nonceDetails": {
-              "blockNumber": "0x16b067",
-              "baseCount": 2,
-              "baseCountHex": "0x2",
-              "pendingCount": 2
-            },
             "rawTx": "0xf864048504a817c800827b0d943ae39e89dc7e736cce53091057a45bf44b1a566c808029a04be1c01535745fa7ec7aeb6e0b64d009981713808ca443b181fad802ce941352a03887e90375d9225b8dfd0d42324eed8eb4982fd14ea7b4069290237b29d1dcd3"
           },
           {
@@ -1613,12 +1265,6 @@
               "gas": "0x7b0d",
               "nonce": "0x04",
               "chainId": 5
-            },
-            "nonceDetails": {
-              "blockNumber": "0x16b067",
-              "baseCount": 2,
-              "baseCountHex": "0x2",
-              "pendingCount": 2
             },
             "rawTx": "0xf864048504a817c800827b0d943ae39e89dc7e736cce53091057a45bf44b1a566c808029a04be1c01535745fa7ec7aeb6e0b64d009981713808ca443b181fad802ce941352a03887e90375d9225b8dfd0d42324eed8eb4982fd14ea7b4069290237b29d1dcd3",
             "hash": "0x9258ed7e451402612f572cbef52b63cd63cc2c59f443a207b7b4f8d317958635"
@@ -1636,12 +1282,6 @@
               "gas": "0x7b0d",
               "nonce": "0x04",
               "chainId": 5
-            },
-            "nonceDetails": {
-              "blockNumber": "0x16b067",
-              "baseCount": 2,
-              "baseCountHex": "0x2",
-              "pendingCount": 2
             },
             "rawTx": "0xf864048504a817c800827b0d943ae39e89dc7e736cce53091057a45bf44b1a566c808029a04be1c01535745fa7ec7aeb6e0b64d009981713808ca443b181fad802ce941352a03887e90375d9225b8dfd0d42324eed8eb4982fd14ea7b4069290237b29d1dcd3",
             "hash": "0x9258ed7e451402612f572cbef52b63cd63cc2c59f443a207b7b4f8d317958635"
@@ -1660,12 +1300,6 @@
               "nonce": "0x04",
               "chainId": 5
             },
-            "nonceDetails": {
-              "blockNumber": "0x16b067",
-              "baseCount": 2,
-              "baseCountHex": "0x2",
-              "pendingCount": 2
-            },
             "rawTx": "0xf864048504a817c800827b0d943ae39e89dc7e736cce53091057a45bf44b1a566c808029a04be1c01535745fa7ec7aeb6e0b64d009981713808ca443b181fad802ce941352a03887e90375d9225b8dfd0d42324eed8eb4982fd14ea7b4069290237b29d1dcd3",
             "hash": "0x9258ed7e451402612f572cbef52b63cd63cc2c59f443a207b7b4f8d317958635"
           },
@@ -1682,12 +1316,6 @@
               "gas": "0x7b0d",
               "nonce": "0x04",
               "chainId": 5
-            },
-            "nonceDetails": {
-              "blockNumber": "0x16b067",
-              "baseCount": 2,
-              "baseCountHex": "0x2",
-              "pendingCount": 2
             },
             "rawTx": "0xf864048504a817c800827b0d943ae39e89dc7e736cce53091057a45bf44b1a566c808029a04be1c01535745fa7ec7aeb6e0b64d009981713808ca443b181fad802ce941352a03887e90375d9225b8dfd0d42324eed8eb4982fd14ea7b4069290237b29d1dcd3",
             "hash": "0x9258ed7e451402612f572cbef52b63cd63cc2c59f443a207b7b4f8d317958635"
@@ -1705,12 +1333,6 @@
               "gas": "0x7b0d",
               "nonce": "0x04",
               "chainId": 5
-            },
-            "nonceDetails": {
-              "blockNumber": "0x16b067",
-              "baseCount": 2,
-              "baseCountHex": "0x2",
-              "pendingCount": 2
             },
             "rawTx": "0xf864048504a817c800827b0d943ae39e89dc7e736cce53091057a45bf44b1a566c808029a04be1c01535745fa7ec7aeb6e0b64d009981713808ca443b181fad802ce941352a03887e90375d9225b8dfd0d42324eed8eb4982fd14ea7b4069290237b29d1dcd3",
             "hash": "0x9258ed7e451402612f572cbef52b63cd63cc2c59f443a207b7b4f8d317958635",
@@ -1729,24 +1351,12 @@
               "gas": "0x7b0d",
               "nonce": "0x04",
               "chainId": 5
-            },
-            "nonceDetails": {
-              "blockNumber": "0x16b067",
-              "baseCount": 2,
-              "baseCountHex": "0x2",
-              "pendingCount": 2
             },
             "rawTx": "0xf864048504a817c800827b0d943ae39e89dc7e736cce53091057a45bf44b1a566c808029a04be1c01535745fa7ec7aeb6e0b64d009981713808ca443b181fad802ce941352a03887e90375d9225b8dfd0d42324eed8eb4982fd14ea7b4069290237b29d1dcd3",
             "hash": "0x9258ed7e451402612f572cbef52b63cd63cc2c59f443a207b7b4f8d317958635",
             "retryCount": 4
           }
         ],
-        "nonceDetails": {
-          "blockNumber": "0x16b067",
-          "baseCount": 2,
-          "baseCountHex": "0x2",
-          "pendingCount": 2
-        },
         "rawTx": "0xf864048504a817c800827b0d943ae39e89dc7e736cce53091057a45bf44b1a566c808029a04be1c01535745fa7ec7aeb6e0b64d009981713808ca443b181fad802ce941352a03887e90375d9225b8dfd0d42324eed8eb4982fd14ea7b4069290237b29d1dcd3",
         "hash": "0x9258ed7e451402612f572cbef52b63cd63cc2c59f443a207b7b4f8d317958635",
         "retryCount": 4
@@ -1830,12 +1440,6 @@
               "gasPrice": "4a817c800",
               "gas": "0x7b0d",
               "nonce": 5
-            },
-            "nonceDetails": {
-              "blockNumber": "0x16b068",
-              "baseCount": 3,
-              "baseCountHex": "0x3",
-              "pendingCount": 2
             }
           },
           {
@@ -1850,12 +1454,6 @@
               "gasPrice": "4a817c800",
               "gas": "0x7b0d",
               "nonce": 5
-            },
-            "nonceDetails": {
-              "blockNumber": "0x16b068",
-              "baseCount": 3,
-              "baseCountHex": "0x3",
-              "pendingCount": 2
             }
           },
           {
@@ -1871,12 +1469,6 @@
               "gas": "0x7b0d",
               "nonce": "0x05",
               "chainId": 5
-            },
-            "nonceDetails": {
-              "blockNumber": "0x16b068",
-              "baseCount": 3,
-              "baseCountHex": "0x3",
-              "pendingCount": 2
             }
           },
           {
@@ -1892,12 +1484,6 @@
               "gas": "0x7b0d",
               "nonce": "0x05",
               "chainId": 5
-            },
-            "nonceDetails": {
-              "blockNumber": "0x16b068",
-              "baseCount": 3,
-              "baseCountHex": "0x3",
-              "pendingCount": 2
             }
           },
           {
@@ -1913,12 +1499,6 @@
               "gas": "0x7b0d",
               "nonce": "0x05",
               "chainId": 5
-            },
-            "nonceDetails": {
-              "blockNumber": "0x16b068",
-              "baseCount": 3,
-              "baseCountHex": "0x3",
-              "pendingCount": 2
             },
             "rawTx": "0xf864058504a817c800827b0d943ae39e89dc7e736cce53091057a45bf44b1a566c808029a0dac4756e84c008714b3b8b43807157ed63737450780bc57590e930c8a360750ca00b43ac8ec5235f57ccca7e68ce8fbf77f43d6ffa5fbff296cba66cef47889cf5"
           },
@@ -1936,12 +1516,6 @@
               "nonce": "0x05",
               "chainId": 5
             },
-            "nonceDetails": {
-              "blockNumber": "0x16b068",
-              "baseCount": 3,
-              "baseCountHex": "0x3",
-              "pendingCount": 2
-            },
             "rawTx": "0xf864058504a817c800827b0d943ae39e89dc7e736cce53091057a45bf44b1a566c808029a0dac4756e84c008714b3b8b43807157ed63737450780bc57590e930c8a360750ca00b43ac8ec5235f57ccca7e68ce8fbf77f43d6ffa5fbff296cba66cef47889cf5"
           },
           {
@@ -1957,12 +1531,6 @@
               "gas": "0x7b0d",
               "nonce": "0x05",
               "chainId": 5
-            },
-            "nonceDetails": {
-              "blockNumber": "0x16b068",
-              "baseCount": 3,
-              "baseCountHex": "0x3",
-              "pendingCount": 2
             },
             "rawTx": "0xf864058504a817c800827b0d943ae39e89dc7e736cce53091057a45bf44b1a566c808029a0dac4756e84c008714b3b8b43807157ed63737450780bc57590e930c8a360750ca00b43ac8ec5235f57ccca7e68ce8fbf77f43d6ffa5fbff296cba66cef47889cf5",
             "hash": "0x67cdff49c1f8ed506c759fc8fd7ffe93d59fcb3bfd926b964cad47e2e504dc9e"
@@ -1980,12 +1548,6 @@
               "gas": "0x7b0d",
               "nonce": "0x05",
               "chainId": 5
-            },
-            "nonceDetails": {
-              "blockNumber": "0x16b068",
-              "baseCount": 3,
-              "baseCountHex": "0x3",
-              "pendingCount": 2
             },
             "rawTx": "0xf864058504a817c800827b0d943ae39e89dc7e736cce53091057a45bf44b1a566c808029a0dac4756e84c008714b3b8b43807157ed63737450780bc57590e930c8a360750ca00b43ac8ec5235f57ccca7e68ce8fbf77f43d6ffa5fbff296cba66cef47889cf5",
             "hash": "0x67cdff49c1f8ed506c759fc8fd7ffe93d59fcb3bfd926b964cad47e2e504dc9e"
@@ -2004,12 +1566,6 @@
               "nonce": "0x05",
               "chainId": 5
             },
-            "nonceDetails": {
-              "blockNumber": "0x16b068",
-              "baseCount": 3,
-              "baseCountHex": "0x3",
-              "pendingCount": 2
-            },
             "rawTx": "0xf864058504a817c800827b0d943ae39e89dc7e736cce53091057a45bf44b1a566c808029a0dac4756e84c008714b3b8b43807157ed63737450780bc57590e930c8a360750ca00b43ac8ec5235f57ccca7e68ce8fbf77f43d6ffa5fbff296cba66cef47889cf5",
             "hash": "0x67cdff49c1f8ed506c759fc8fd7ffe93d59fcb3bfd926b964cad47e2e504dc9e"
           },
@@ -2026,12 +1582,6 @@
               "gas": "0x7b0d",
               "nonce": "0x05",
               "chainId": 5
-            },
-            "nonceDetails": {
-              "blockNumber": "0x16b068",
-              "baseCount": 3,
-              "baseCountHex": "0x3",
-              "pendingCount": 2
             },
             "rawTx": "0xf864058504a817c800827b0d943ae39e89dc7e736cce53091057a45bf44b1a566c808029a0dac4756e84c008714b3b8b43807157ed63737450780bc57590e930c8a360750ca00b43ac8ec5235f57ccca7e68ce8fbf77f43d6ffa5fbff296cba66cef47889cf5",
             "hash": "0x67cdff49c1f8ed506c759fc8fd7ffe93d59fcb3bfd926b964cad47e2e504dc9e"
@@ -2049,12 +1599,6 @@
               "gas": "0x7b0d",
               "nonce": "0x05",
               "chainId": 5
-            },
-            "nonceDetails": {
-              "blockNumber": "0x16b068",
-              "baseCount": 3,
-              "baseCountHex": "0x3",
-              "pendingCount": 2
             },
             "rawTx": "0xf864058504a817c800827b0d943ae39e89dc7e736cce53091057a45bf44b1a566c808029a0dac4756e84c008714b3b8b43807157ed63737450780bc57590e930c8a360750ca00b43ac8ec5235f57ccca7e68ce8fbf77f43d6ffa5fbff296cba66cef47889cf5",
             "hash": "0x67cdff49c1f8ed506c759fc8fd7ffe93d59fcb3bfd926b964cad47e2e504dc9e",
@@ -2073,24 +1617,12 @@
               "gas": "0x7b0d",
               "nonce": "0x05",
               "chainId": 5
-            },
-            "nonceDetails": {
-              "blockNumber": "0x16b068",
-              "baseCount": 3,
-              "baseCountHex": "0x3",
-              "pendingCount": 2
             },
             "rawTx": "0xf864058504a817c800827b0d943ae39e89dc7e736cce53091057a45bf44b1a566c808029a0dac4756e84c008714b3b8b43807157ed63737450780bc57590e930c8a360750ca00b43ac8ec5235f57ccca7e68ce8fbf77f43d6ffa5fbff296cba66cef47889cf5",
             "hash": "0x67cdff49c1f8ed506c759fc8fd7ffe93d59fcb3bfd926b964cad47e2e504dc9e",
             "retryCount": 3
           }
         ],
-        "nonceDetails": {
-          "blockNumber": "0x16b068",
-          "baseCount": 3,
-          "baseCountHex": "0x3",
-          "pendingCount": 2
-        },
         "rawTx": "0xf864058504a817c800827b0d943ae39e89dc7e736cce53091057a45bf44b1a566c808029a0dac4756e84c008714b3b8b43807157ed63737450780bc57590e930c8a360750ca00b43ac8ec5235f57ccca7e68ce8fbf77f43d6ffa5fbff296cba66cef47889cf5",
         "hash": "0x67cdff49c1f8ed506c759fc8fd7ffe93d59fcb3bfd926b964cad47e2e504dc9e",
         "retryCount": 3

--- a/test/data/transaction-data.json
+++ b/test/data/transaction-data.json
@@ -17,29 +17,6 @@
       },
       "origin": "metamask",
       "type": "simpleSend",
-      "nonceDetails": {
-        "params": {
-          "highestLocallyConfirmed": 12,
-          "highestSuggested": 12,
-          "nextNetworkNonce": 12
-        },
-        "local": {
-          "name": "local",
-          "nonce": 12,
-          "details": {
-            "startPoint": 12,
-            "highest": 12
-          }
-        },
-        "network": {
-          "name": "network",
-          "nonce": 12,
-          "details": {
-            "blockNumber": "0x62d5dc",
-            "baseCount": 12
-          }
-        }
-      },
       "r": "0xe0b79a8e33b15460ea79b05a5fb16bc067a796592eeb4edc5007c88615c12595",
       "s": "0x1c834a25f1df07af5122996a40e99e554a40dc971a25041bc6e31638846c4f58",
       "v": "0x2c",
@@ -78,29 +55,6 @@
         },
         "origin": "metamask",
         "type": "sentEther",
-        "nonceDetails": {
-          "params": {
-            "highestLocallyConfirmed": 12,
-            "highestSuggested": 12,
-            "nextNetworkNonce": 12
-          },
-          "local": {
-            "name": "local",
-            "nonce": 12,
-            "details": {
-              "startPoint": 12,
-              "highest": 12
-            }
-          },
-          "network": {
-            "name": "network",
-            "nonce": 12,
-            "details": {
-              "blockNumber": "0x62d5dc",
-              "baseCount": 12
-            }
-          }
-        },
         "r": "0xe0b79a8e33b15460ea79b05a5fb16bc067a796592eeb4edc5007c88615c12595",
         "s": "0x1c834a25f1df07af5122996a40e99e554a40dc971a25041bc6e31638846c4f58",
         "v": "0x2c",
@@ -139,29 +93,6 @@
       },
       "origin": "metamask",
       "type": "simpleSend",
-      "nonceDetails": {
-        "params": {
-          "highestLocallyConfirmed": 12,
-          "highestSuggested": 12,
-          "nextNetworkNonce": 12
-        },
-        "local": {
-          "name": "local",
-          "nonce": 12,
-          "details": {
-            "startPoint": 12,
-            "highest": 12
-          }
-        },
-        "network": {
-          "name": "network",
-          "nonce": 12,
-          "details": {
-            "blockNumber": "0x62d5dc",
-            "baseCount": 12
-          }
-        }
-      },
       "r": "0xe0b79a8e33b15460ea79b05a5fb16bc067a796592eeb4edc5007c88615c12595",
       "s": "0x1c834a25f1df07af5122996a40e99e554a40dc971a25041bc6e31638846c4f58",
       "v": "0x2c",
@@ -204,29 +135,6 @@
       },
       "origin": "metamask",
       "type": "simpleSend",
-      "nonceDetails": {
-        "params": {
-          "highestLocallyConfirmed": 0,
-          "highestSuggested": 10,
-          "nextNetworkNonce": 10
-        },
-        "local": {
-          "name": "local",
-          "nonce": 11,
-          "details": {
-            "startPoint": 10,
-            "highest": 11
-          }
-        },
-        "network": {
-          "name": "network",
-          "nonce": 10,
-          "details": {
-            "blockNumber": "0x62d5cc",
-            "baseCount": 10
-          }
-        }
-      },
       "r": "0xe6828baea0a93a52779ffa5ea55e927781fb7d4be58107a29c75d314d433d055",
       "s": "0x10613f984c57b8928d8ed9fce16ddda5746767e5f68f4c8fc29542e86a61f458",
       "v": "0x2b",
@@ -265,29 +173,6 @@
         },
         "origin": "metamask",
         "type": "sentEther",
-        "nonceDetails": {
-          "params": {
-            "highestLocallyConfirmed": 0,
-            "highestSuggested": 10,
-            "nextNetworkNonce": 10
-          },
-          "local": {
-            "name": "local",
-            "nonce": 11,
-            "details": {
-              "startPoint": 10,
-              "highest": 11
-            }
-          },
-          "network": {
-            "name": "network",
-            "nonce": 10,
-            "details": {
-              "blockNumber": "0x62d5cc",
-              "baseCount": 10
-            }
-          }
-        },
         "r": "0xe6828baea0a93a52779ffa5ea55e927781fb7d4be58107a29c75d314d433d055",
         "s": "0x10613f984c57b8928d8ed9fce16ddda5746767e5f68f4c8fc29542e86a61f458",
         "v": "0x2b",
@@ -326,29 +211,6 @@
       },
       "origin": "metamask",
       "type": "simpleSend",
-      "nonceDetails": {
-        "params": {
-          "highestLocallyConfirmed": 0,
-          "highestSuggested": 10,
-          "nextNetworkNonce": 10
-        },
-        "local": {
-          "name": "local",
-          "nonce": 11,
-          "details": {
-            "startPoint": 10,
-            "highest": 11
-          }
-        },
-        "network": {
-          "name": "network",
-          "nonce": 10,
-          "details": {
-            "blockNumber": "0x62d5cc",
-            "baseCount": 10
-          }
-        }
-      },
       "r": "0xe6828baea0a93a52779ffa5ea55e927781fb7d4be58107a29c75d314d433d055",
       "s": "0x10613f984c57b8928d8ed9fce16ddda5746767e5f68f4c8fc29542e86a61f458",
       "v": "0x2b",
@@ -391,29 +253,6 @@
       },
       "origin": "metamask",
       "type": "simpleSend",
-      "nonceDetails": {
-        "params": {
-          "highestLocallyConfirmed": 0,
-          "highestSuggested": 10,
-          "nextNetworkNonce": 10
-        },
-        "local": {
-          "name": "local",
-          "nonce": 10,
-          "details": {
-            "startPoint": 10,
-            "highest": 10
-          }
-        },
-        "network": {
-          "name": "network",
-          "nonce": 10,
-          "details": {
-            "blockNumber": "0x62d5cb",
-            "baseCount": 10
-          }
-        }
-      },
       "r": "0x94b120a1df80be3dfad057b7ccac866b6b7583b63d61e5b021811c8b7ffc9a3b",
       "s": "0x1778de08e29a4c8dfc3aa3e2c2338e98494ebd2c380c901d0dfba95126dde65f",
       "v": "0x2c",
@@ -453,29 +292,6 @@
         },
         "origin": "metamask",
         "type": "sentEther",
-        "nonceDetails": {
-          "params": {
-            "highestLocallyConfirmed": 0,
-            "highestSuggested": 10,
-            "nextNetworkNonce": 10
-          },
-          "local": {
-            "name": "local",
-            "nonce": 10,
-            "details": {
-              "startPoint": 10,
-              "highest": 10
-            }
-          },
-          "network": {
-            "name": "network",
-            "nonce": 10,
-            "details": {
-              "blockNumber": "0x62d5cb",
-              "baseCount": 10
-            }
-          }
-        },
         "r": "0x94b120a1df80be3dfad057b7ccac866b6b7583b63d61e5b021811c8b7ffc9a3b",
         "s": "0x1778de08e29a4c8dfc3aa3e2c2338e98494ebd2c380c901d0dfba95126dde65f",
         "v": "0x2c",
@@ -515,29 +331,6 @@
       },
       "origin": "metamask",
       "type": "simpleSend",
-      "nonceDetails": {
-        "params": {
-          "highestLocallyConfirmed": 0,
-          "highestSuggested": 10,
-          "nextNetworkNonce": 10
-        },
-        "local": {
-          "name": "local",
-          "nonce": 10,
-          "details": {
-            "startPoint": 10,
-            "highest": 10
-          }
-        },
-        "network": {
-          "name": "network",
-          "nonce": 10,
-          "details": {
-            "blockNumber": "0x62d5cb",
-            "baseCount": 10
-          }
-        }
-      },
       "r": "0x94b120a1df80be3dfad057b7ccac866b6b7583b63d61e5b021811c8b7ffc9a3b",
       "s": "0x1778de08e29a4c8dfc3aa3e2c2338e98494ebd2c380c901d0dfba95126dde65f",
       "v": "0x2c",
@@ -894,29 +687,6 @@
           "maxPriorityFeePerGas": "0x3B9ACA00"
         },
         "estimatedBaseFee": "3ba182755",
-        "nonceDetails": {
-          "params": {
-            "highestLocallyConfirmed": 87,
-            "highestSuggested": 87,
-            "nextNetworkNonce": 87
-          },
-          "local": {
-            "name": "local",
-            "nonce": 87,
-            "details": {
-              "startPoint": 87,
-              "highest": 87
-            }
-          },
-          "network": {
-            "name": "network",
-            "nonce": 87,
-            "details": {
-              "blockNumber": "0xa28e38",
-              "baseCount": 87
-            }
-          }
-        },
         "r": "0xd13310569a8d5876e37788183034bfe4bc3b49c0663c5fd9b2bf13adf9b4791c",
         "s": "0x7a83d8840e7edcdf4fdedfd2bc1ce19775e54fd17f29ede5165591a1cf3febea",
         "v": "0x00",
@@ -1010,29 +780,6 @@
         "maxPriorityFeePerGas": "0x3B9ACA00"
       },
       "estimatedBaseFee": "3ba182755",
-      "nonceDetails": {
-        "params": {
-          "highestLocallyConfirmed": 87,
-          "highestSuggested": 87,
-          "nextNetworkNonce": 87
-        },
-        "local": {
-          "name": "local",
-          "nonce": 87,
-          "details": {
-            "startPoint": 87,
-            "highest": 87
-          }
-        },
-        "network": {
-          "name": "network",
-          "nonce": 87,
-          "details": {
-            "blockNumber": "0xa28e38",
-            "baseCount": 87
-          }
-        }
-      },
       "r": "0xd13310569a8d5876e37788183034bfe4bc3b49c0663c5fd9b2bf13adf9b4791c",
       "s": "0x7a83d8840e7edcdf4fdedfd2bc1ce19775e54fd17f29ede5165591a1cf3febea",
       "v": "0x00",
@@ -1125,29 +872,6 @@
         "maxPriorityFeePerGas": "0x3B9ACA00"
       },
       "estimatedBaseFee": "3ba182755",
-      "nonceDetails": {
-        "params": {
-          "highestLocallyConfirmed": 87,
-          "highestSuggested": 87,
-          "nextNetworkNonce": 87
-        },
-        "local": {
-          "name": "local",
-          "nonce": 87,
-          "details": {
-            "startPoint": 87,
-            "highest": 87
-          }
-        },
-        "network": {
-          "name": "network",
-          "nonce": 87,
-          "details": {
-            "blockNumber": "0xa28e38",
-            "baseCount": 87
-          }
-        }
-      },
       "r": "0xd13310569a8d5876e37788183034bfe4bc3b49c0663c5fd9b2bf13adf9b4791c",
       "s": "0x7a83d8840e7edcdf4fdedfd2bc1ce19775e54fd17f29ede5165591a1cf3febea",
       "v": "0x00",

--- a/test/e2e/fixture-builder.js
+++ b/test/e2e/fixture-builder.js
@@ -1171,33 +1171,6 @@ class FixtureBuilder {
                 note: 'transactions#approveTransaction',
                 timestamp: 1617228031069,
               },
-              {
-                op: 'add',
-                path: '/nonceDetails',
-                value: {
-                  params: {
-                    highestLocallyConfirmed: 0,
-                    highestSuggested: 0,
-                    nextNetworkNonce: 0,
-                  },
-                  local: {
-                    name: 'local',
-                    nonce: 0,
-                    details: {
-                      startPoint: 0,
-                      highest: 0,
-                    },
-                  },
-                  network: {
-                    name: 'network',
-                    nonce: 0,
-                    details: {
-                      blockNumber: '0x0',
-                      baseCount: 0,
-                    },
-                  },
-                },
-              },
             ],
           ],
           id: 4046084157914634,
@@ -1300,33 +1273,6 @@ class FixtureBuilder {
                 timestamp: 1671635510592,
                 value: '0x2',
               },
-              {
-                op: 'add',
-                path: '/nonceDetails',
-                value: {
-                  local: {
-                    details: {
-                      highest: 2,
-                      startPoint: 2,
-                    },
-                    name: 'local',
-                    nonce: 2,
-                  },
-                  network: {
-                    details: {
-                      baseCount: 2,
-                      blockNumber: '0x7cbf93',
-                    },
-                    name: 'network',
-                    nonce: 2,
-                  },
-                  params: {
-                    highestLocallyConfirmed: 0,
-                    highestSuggested: 2,
-                    nextNetworkNonce: 2,
-                  },
-                },
-              },
             ],
             [
               {
@@ -1390,29 +1336,6 @@ class FixtureBuilder {
           id: 5748272735958801,
           loadingDefaults: false,
           metamaskNetworkId: '5',
-          nonceDetails: {
-            local: {
-              details: {
-                highest: 2,
-                startPoint: 2,
-              },
-              name: 'local',
-              nonce: 2,
-            },
-            network: {
-              details: {
-                baseCount: 2,
-                blockNumber: '0x7cbf93',
-              },
-              name: 'network',
-              nonce: 2,
-            },
-            params: {
-              highestLocallyConfirmed: 0,
-              highestSuggested: 2,
-              nextNetworkNonce: 2,
-            },
-          },
           origin: 'metamask',
           status: 'confirmed',
           submittedTime: 1671635510753,

--- a/test/stub/tx-meta-stub.js
+++ b/test/stub/tx-meta-stub.js
@@ -58,33 +58,6 @@ export const txMetaStub = {
         timestamp: 1572395158261,
         value: '0x5',
       },
-      {
-        op: 'add',
-        path: '/nonceDetails',
-        value: {
-          local: {
-            details: {
-              highest: 4,
-              startPoint: 4,
-            },
-            name: 'local',
-            nonce: 4,
-          },
-          network: {
-            details: {
-              baseCount: 4,
-              blockNumber: '0x51a401',
-            },
-            name: 'network',
-            nonce: 4,
-          },
-          params: {
-            highestLocallyConfirmed: 0,
-            highestSuggested: 4,
-            nextNetworkNonce: 4,
-          },
-        },
-      },
     ],
     [
       {
@@ -164,29 +137,6 @@ export const txMetaStub = {
   id: 405984854664302,
   loadingDefaults: false,
   metamaskNetworkId: '5',
-  nonceDetails: {
-    local: {
-      details: {
-        highest: 4,
-        startPoint: 4,
-      },
-      name: 'local',
-      nonce: 4,
-    },
-    network: {
-      details: {
-        baseCount: 4,
-        blockNumber: '0x51a401',
-      },
-      name: 'network',
-      nonce: 4,
-    },
-    params: {
-      highestLocallyConfirmed: 0,
-      highestSuggested: 4,
-      nextNetworkNonce: 4,
-    },
-  },
   origin: 'MetaMask',
   r: '0x5f973e540f2d3c2f06d3725a626b75247593cb36477187ae07ecfe0a4db3cf57',
   rawTx:

--- a/ui/components/app/transaction-activity-log/transaction-activity-log.util.test.js
+++ b/ui/components/app/transaction-activity-log/transaction-activity-log.util.test.js
@@ -309,15 +309,6 @@ describe('TransactionActivityLog utils', () => {
               timestamp: 1535507564439,
               value: '0xa4',
             },
-            {
-              op: 'add',
-              path: '/nonceDetails',
-              value: {
-                local: {},
-                network: {},
-                params: {},
-              },
-            },
           ],
           [
             {


### PR DESCRIPTION
## Explanation

This PR aims to remove `nonceDetails` property from `TransactionMeta` since it's not used in clients and purely debugging purpose. 

Fixing https://github.com/MetaMask/MetaMask-planning/issues/1094

## Manual Testing Steps

No functional change here so expect transactions to be work as usual.

## Pre-merge author checklist

- [X] I've clearly explained:
  - [X] What problem this PR is solving
  - [X] How this problem was solved
  - [X] How reviewers can test my changes
- [X] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
