### PR TITLE
Add missing derivation path names

### DIFF
--- a/shared/constants/snaps.ts
+++ b/shared/constants/snaps.ts
@@ -116,9 +116,19 @@ export const SNAPS_DERIVATION_PATHS: SnapsDerivationPath[] = [
     name: 'Bitcoin Cash',
   },
   {
+    path: ['m', `44'`, `637'`],
+    curve: 'ed25519',
+    name: 'Aptos',
+  },
+  {
     path: ['m', `44'`, `714'`],
     curve: 'secp256k1',
     name: 'Binance (BNB)',
+  },
+  {
+    path: ['m', `44'`, `784'`],
+    curve: 'ed25519',
+    name: 'Sui',
   },
   {
     path: ['m', `44'`, `931'`],


### PR DESCRIPTION
## Explanation

A couple derivation paths used by snaps were missing a name. I've added them to the list of named derivation paths in this pull request.

## Pre-merge author checklist

- [ ] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [ ] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone