### PR TITLE
Use versioned URL for `manageAccounts` test

### DIFF
--- a/test/e2e/snaps/enums.js
+++ b/test/e2e/snaps/enums.js
@@ -2,5 +2,5 @@ module.exports = {
   TEST_SNAPS_WEBSITE_URL:
     'https://metamask.github.io/snaps/test-snaps/0.38.0-flask.1/',
   TEST_SNAPS_SIMPLE_KEYRING_WEBSITE_URL:
-    'https://metamask.github.io/snap-simple-keyring/latest/',
+    'https://metamask.github.io/snap-simple-keyring/0.1.4/',
 };


### PR DESCRIPTION
## Explanation

Use versioned URL for `manageAccounts` test such that changes in another repo doesn't impact E2E testing in the extension.