### PR TITLE
Require Flask Snaps E2E to pass for CI pass

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -246,6 +246,8 @@ workflows:
             - test-e2e-firefox
             - test-e2e-chrome-snaps
             - test-e2e-firefox-snaps
+            - test-e2e-chrome-snaps-flask
+            - test-e2e-firefox-snaps-flask
             - test-storybook
       - benchmark:
           requires:


### PR DESCRIPTION
## Explanation

Flask Snaps E2E was accidentally not required to pass for `all-tests-pass`. This PR fixes that.