### PR TITLE
Update Snap privacy warning content

### DIFF
--- a/app/_locales/de/messages.json
+++ b/app/_locales/de/messages.json
@@ -4084,18 +4084,6 @@
   "snapsNoInsight": {
     "message": "Der Snap brachte keine Einsicht."
   },
-  "snapsPrivacyWarningFirstMessage": {
-    "message": "Sie sind sich darüber im Klaren, dass es sich bei dem Snap, den Sie im Begriff sind zu installieren, um einen wie in den Consensys $1 definierten Dienst eines Drittanbieters handelt. Ihre Verwendung von Drittanbieterdiensten unterliegt den Nutzungsbedingungen des Drittanbieters. Wenn Sie auf diesen Drittanbieter zugreifen, ihm vertrauen oder ihn verwenden, geschieht das auf Ihr eigenes Risiko. Consensys lehnt jegliche Verantwortung sowie Haftung für etwaige durch die Nutzung von Drittanbieterdiensten entstandene Verluste auf Ihrem Konto ab.",
-    "description": "First part of a message in popup modal displayed when installing a snap for the first time. $1 is terms of use link."
-  },
-  "snapsPrivacyWarningSecondMessage": {
-    "message": "Alle Daten, die Sie mit Drittanbieterdiensten teilen, werden direkt von diesen Drittanbieterdiensten im Einklang mit deren Datenschutzerklärung erfasst. Für weitere Informationen lesen Sie bitte die jeweiligen Datenschutzerklärungen.",
-    "description": "Second part of a message in popup modal displayed when installing a snap for the first time."
-  },
-  "snapsPrivacyWarningThirdMessage": {
-    "message": "Consensys hat keinen Zugriff auf die Daten, die Sie mit diesen Drittanbietern teilen.",
-    "description": "Third part of a message in popup modal displayed when installing a snap for the first time."
-  },
   "snapsSettingsDescription": {
     "message": "Verwalten Sie Ihre Snaps."
   },

--- a/app/_locales/el/messages.json
+++ b/app/_locales/el/messages.json
@@ -4084,18 +4084,6 @@
   "snapsNoInsight": {
     "message": "Το snap δεν επέστρεψε καμία πληροφορία"
   },
-  "snapsPrivacyWarningFirstMessage": {
-    "message": "Αναγνωρίζετε ότι το snap που πρόκειται να εγκαταστήσετε είναι μια Υπηρεσία Τρίτων όπως ορίζεται στο Consensys $1. Η χρήση των Υπηρεσιών Τρίτων διέπεται από ξεχωριστούς όρους και προϋποθέσεις που καθορίζονται από τον πάροχο των Υπηρεσιών Τρίτων. Η πρόσβαση, η στήριξη ή η χρήση της Υπηρεσίας Τρίτων γίνεται με δική σας ευθύνη. Η Consensys αποποιείται κάθε ευθύνη και υποχρέωση για οποιεσδήποτε απώλειες λόγω της χρήσης από εσάς των Υπηρεσιών Τρίτων.",
-    "description": "First part of a message in popup modal displayed when installing a snap for the first time. $1 is terms of use link."
-  },
-  "snapsPrivacyWarningSecondMessage": {
-    "message": "Οποιεσδήποτε πληροφορίες μοιράζεστε με τις Υπηρεσίες Τρίτων θα συλλέγονται απευθείας από τις εν λόγω Υπηρεσίες Τρίτων σύμφωνα με τις πολιτικές απορρήτου τους. Ανατρέξτε στις πολιτικές απορρήτου τους για περισσότερες πληροφορίες.",
-    "description": "Second part of a message in popup modal displayed when installing a snap for the first time."
-  },
-  "snapsPrivacyWarningThirdMessage": {
-    "message": "Η Consensys δεν έχει πρόσβαση στις πληροφορίες που μοιράζεστε με αυτά τα τρίτα μέρη.",
-    "description": "Third part of a message in popup modal displayed when installing a snap for the first time."
-  },
   "snapsSettingsDescription": {
     "message": "Διαχειριστείτε τα Snaps σας"
   },

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -4100,7 +4100,7 @@
     "message": "The snap didn't return any insight"
   },
   "snapsPrivacyWarningFirstMessage": {
-    "message": "You acknowledge that the snap that you are about to install is a Third Party Service as defined in the Consensys $1. Your use of Third Party Services is governed by separate terms and conditions set forth by the Third Party Service provider. You access, rely upon or use the Third Party Service at your own risk. Consensys disclaims all responsibility and liability for any losses on account of your use of Third Party Services.",
+    "message": "You acknowledge that any Snap that you install is a Third Party Service, unless otherwise identified, as defined in the Consensys $1. Your use of Third Party Services is governed by separate terms and conditions set forth by the Third Party Service provider. Consensys does not recommend the use of any Snap by any particular person for any particular reason. You access, rely upon or use the Third Party Service at your own risk. Consensys disclaims all responsibility and liability for any losses on account of your use of Third Party Services.",
     "description": "First part of a message in popup modal displayed when installing a snap for the first time. $1 is terms of use link."
   },
   "snapsPrivacyWarningSecondMessage": {
@@ -4108,7 +4108,7 @@
     "description": "Second part of a message in popup modal displayed when installing a snap for the first time."
   },
   "snapsPrivacyWarningThirdMessage": {
-    "message": "Consensys has no access to information you share with these third parties.",
+    "message": "Consensys has no access to information you share with Third Party Services.",
     "description": "Third part of a message in popup modal displayed when installing a snap for the first time."
   },
   "snapsSettingsDescription": {

--- a/app/_locales/es/messages.json
+++ b/app/_locales/es/messages.json
@@ -4084,18 +4084,6 @@
   "snapsNoInsight": {
     "message": "El snap no devolvió ninguna información"
   },
-  "snapsPrivacyWarningFirstMessage": {
-    "message": "Usted reconoce que el snap que está a punto de instalar es un Servicio de terceros según se define en Consensys $1. Su uso de los Servicios de terceros se rige por términos y condiciones separados establecidos por el proveedor de Servicios de terceros. Usted accede, confía o utiliza el Servicio de terceros bajo su propio riesgo. Consensys se exime de toda responsabilidad por cualquier pérdida a causa de su uso de los Servicios de terceros.",
-    "description": "First part of a message in popup modal displayed when installing a snap for the first time. $1 is terms of use link."
-  },
-  "snapsPrivacyWarningSecondMessage": {
-    "message": "Cualquier información que comparta con Servicios de terceros será recopilada directamente por dichos Servicios de terceros de acuerdo con sus políticas de privacidad. Consulte sus políticas de privacidad para obtener más información.",
-    "description": "Second part of a message in popup modal displayed when installing a snap for the first time."
-  },
-  "snapsPrivacyWarningThirdMessage": {
-    "message": "Consensys no tiene acceso a la información que comparta con estos terceros.",
-    "description": "Third part of a message in popup modal displayed when installing a snap for the first time."
-  },
   "snapsSettingsDescription": {
     "message": "Administre sus snaps"
   },

--- a/app/_locales/fr/messages.json
+++ b/app/_locales/fr/messages.json
@@ -4084,18 +4084,6 @@
   "snapsNoInsight": {
     "message": "Le snap n’a renvoyé aucun aperçu"
   },
-  "snapsPrivacyWarningFirstMessage": {
-    "message": "Vous reconnaissez que le snap que vous êtes sur le point d’installer est un « Service tiers » tel que défini dans les $1 de Consensys. L’utilisation des services tiers est régie par des conditions distinctes définies par le fournisseur du service tiers. Si vous décidez d’utiliser ce service tiers, vous le faites à vos propres risques. Consensys décline toute responsabilité pour toute perte liée à l’utilisation des services tiers.",
-    "description": "First part of a message in popup modal displayed when installing a snap for the first time. $1 is terms of use link."
-  },
-  "snapsPrivacyWarningSecondMessage": {
-    "message": "Toute information que vous partagez avec des services tiers sera collectée directement par ces services tiers conformément à leur politique de confidentialité. Pour plus d’informations, veuillez consulter leur politique de confidentialité.",
-    "description": "Second part of a message in popup modal displayed when installing a snap for the first time."
-  },
-  "snapsPrivacyWarningThirdMessage": {
-    "message": "Consensys n’a pas accès aux informations que vous partagez avec ces tiers.",
-    "description": "Third part of a message in popup modal displayed when installing a snap for the first time."
-  },
   "snapsSettingsDescription": {
     "message": "Gérez vos Snaps"
   },

--- a/app/_locales/hi/messages.json
+++ b/app/_locales/hi/messages.json
@@ -4084,18 +4084,6 @@
   "snapsNoInsight": {
     "message": "Snap ने कोई इनसाइट नहीं लौटाई"
   },
-  "snapsPrivacyWarningFirstMessage": {
-    "message": "आप स्वीकार करते हैं कि आप जिस Snap को इंस्टॉल करने जा रहे हैं वह एक थर्ड पार्टी सेवा है जैसा कि Consensys $1 में परिभाषित किया गया है। थर्ड पार्टी सेवाओं का आपका इस्तेमाल थर्ड पार्टी सेवा प्रोवाइडर द्वारा निर्धारित अलग नियमों और शर्तों द्वारा नियंत्रित होता है। आप अपने जोखिम पर थर्ड पार्टी सेवा का एक्सेस करते हैं, उस पर भरोसा करते हैं या उसका इस्तेमाल करते हैं। थर्ड पार्टी सेवाओं के आपके इस्तेमाल के कारण किसी भी नुकसान के लिए Consensys सभी जिम्मेदारियों और उत्तरदायित्वों को अस्वीकार करता है।",
-    "description": "First part of a message in popup modal displayed when installing a snap for the first time. $1 is terms of use link."
-  },
-  "snapsPrivacyWarningSecondMessage": {
-    "message": "थर्ड पार्टी सेवाओं के साथ आप जो भी सूचना शेयर करते हैं, उसे उन थर्ड पार्टी सेवाओं द्वारा उनकी अपनी गोपनीयता नीतियों के अनुसार सीधे एकत्र की जाएगी। अधिक जानकारी के लिए कृपया उनकी गोपनीयता नीतियां देखें।",
-    "description": "Second part of a message in popup modal displayed when installing a snap for the first time."
-  },
-  "snapsPrivacyWarningThirdMessage": {
-    "message": "Consensys के पास उस सूचना का एक्सेस नहीं है जो आप इन थर्ड पार्टियों से शेयर करते हैं।",
-    "description": "Third part of a message in popup modal displayed when installing a snap for the first time."
-  },
   "snapsSettingsDescription": {
     "message": "अपने Snaps प्रबंधित करें"
   },

--- a/app/_locales/id/messages.json
+++ b/app/_locales/id/messages.json
@@ -4084,18 +4084,6 @@
   "snapsNoInsight": {
     "message": "Snap tidak mengembalikan wawasan apa pun"
   },
-  "snapsPrivacyWarningFirstMessage": {
-    "message": "Anda menyatakan bahwa snap yang akan diinstal adalah Layanan Pihak Ketiga sebagaimana dijelaskan dalam $1 Consensys. Penggunaan Layanan Pihak Ketiga diatur oleh syarat dan ketentuan terpisah yang ditetapkan oleh penyedia Layanan Pihak Ketiga. Anda mengakses, mengandalkan, atau menggunakan Layanan Pihak Ketiga dengan risiko Anda sendiri. Consensys menafikan semua tanggung jawab dan kewajiban atas kerugian yang timbul karena penggunaan Layanan Pihak Ketiga.",
-    "description": "First part of a message in popup modal displayed when installing a snap for the first time. $1 is terms of use link."
-  },
-  "snapsPrivacyWarningSecondMessage": {
-    "message": "Setiap informasi yang Anda bagikan kepada Layanan Pihak Ketiga akan dikumpulkan langsung oleh Layanan Pihak Ketiga tersebut sesuai dengan kebijakan privasinya. Baca kebijakan privasinya untuk informasi lebih lanjut.",
-    "description": "Second part of a message in popup modal displayed when installing a snap for the first time."
-  },
-  "snapsPrivacyWarningThirdMessage": {
-    "message": "Consensys tidak memiliki akses ke informasi yang Anda bagikan kepada pihak ketiga ini.",
-    "description": "Third part of a message in popup modal displayed when installing a snap for the first time."
-  },
   "snapsSettingsDescription": {
     "message": "Kelola Snap Anda"
   },

--- a/app/_locales/ja/messages.json
+++ b/app/_locales/ja/messages.json
@@ -4084,18 +4084,6 @@
   "snapsNoInsight": {
     "message": "snapがインサイトを返しませんでした"
   },
-  "snapsPrivacyWarningFirstMessage": {
-    "message": "ユーザーは、インストールしようとしているsnapが、Consensys$1で定義されているサードパーティサービスであることを認めたものとみなされます。サードパーティサービスの使用には、当該サードパーティサービスのプロバイダーにより定められた、別の諸条件が適用されます。サードパーティサービスへのアクセス、依存、使用は、ユーザーの自己責任で行うものとします。Consensysは、サードパーティサービスの使用によりアカウントで発生する損失について、一切責任および賠償責任を負いません。",
-    "description": "First part of a message in popup modal displayed when installing a snap for the first time. $1 is terms of use link."
-  },
-  "snapsPrivacyWarningSecondMessage": {
-    "message": "サードパーティサービスと共有する情報は、当該サードパーティサービスにより、それぞれのプライバシーポリシーに従い直接収集されます。詳細は、各サードパーティサービスのプライバシーポリシーをご覧ください。",
-    "description": "Second part of a message in popup modal displayed when installing a snap for the first time."
-  },
-  "snapsPrivacyWarningThirdMessage": {
-    "message": "Consensysは、ユーザーがこれらのサードパーティと共有した情報に一切アクセスできません。",
-    "description": "Third part of a message in popup modal displayed when installing a snap for the first time."
-  },
   "snapsSettingsDescription": {
     "message": "Snapsの管理"
   },

--- a/app/_locales/ko/messages.json
+++ b/app/_locales/ko/messages.json
@@ -4063,18 +4063,6 @@
   "snapsNoInsight": {
     "message": "스냅이 인사이트를 가져오지 못했습니다"
   },
-  "snapsPrivacyWarningFirstMessage": {
-    "message": "귀하는 현재 설치하려고 하는 스냅이 Consensys $1에 정의된 바와 같은 타사 서비스임에 해당한다는 사실을 인정합니다. 타사 서비스 이용은 해당 타사 서비스 공급업체의 이용약관에 따라 별도로 관리됩니다. 타사 서비스에 대한 액세스나 의존 또는 사용에 대한 책임은 전적으로 귀하에게 부과됩니다. Consensys는 타사 서비스 이용으로 인해 귀하의 계정에 발생하는 그 어떤 손실에 대해 모든 책임과 법적 의무를 지지 않습니다.",
-    "description": "First part of a message in popup modal displayed when installing a snap for the first time. $1 is terms of use link."
-  },
-  "snapsPrivacyWarningSecondMessage": {
-    "message": "타사와 공유하는 모든 정보는 해당 타사의 개인정보 처리방침에 따라 직접 수집됩니다. 더 자세한 내용은 해당 회사의 개인정보 처리방침을 참고하시기 바랍니다.",
-    "description": "Second part of a message in popup modal displayed when installing a snap for the first time."
-  },
-  "snapsPrivacyWarningThirdMessage": {
-    "message": "Consensys는 귀하가 타사와 공유한 정보에 대한 접근 권한이 없습니다.",
-    "description": "Third part of a message in popup modal displayed when installing a snap for the first time."
-  },
   "snapsSettingsDescription": {
     "message": "스냅 관리"
   },

--- a/app/_locales/pt/messages.json
+++ b/app/_locales/pt/messages.json
@@ -4084,18 +4084,6 @@
   "snapsNoInsight": {
     "message": "O snap não retornou nenhum insight"
   },
-  "snapsPrivacyWarningFirstMessage": {
-    "message": "Você reconhece que o snap que está prestes a instalar é um Serviço de Terceiros, conforme definido nos $1 da Consensys. O uso de Serviços de Terceiros é regido por termos e condições separados, definidos pelo prestador de Serviços de Terceiros. Você acessa, confia ou usa o Serviço de Terceiros por sua conta e risco. A Consensys se isenta de todas as responsabilidades por perdas relacionadas ao seu uso de Serviços de Terceiros.",
-    "description": "First part of a message in popup modal displayed when installing a snap for the first time. $1 is terms of use link."
-  },
-  "snapsPrivacyWarningSecondMessage": {
-    "message": "Informações compartilhadas com Serviços de Terceiros serão coletadas diretamente por eles, de acordo com políticas de privacidade próprias. Por favor, consulte-as para obter mais informações.",
-    "description": "Second part of a message in popup modal displayed when installing a snap for the first time."
-  },
-  "snapsPrivacyWarningThirdMessage": {
-    "message": "A Consensys não tem acesso às informações que você compartilha com terceiros.",
-    "description": "Third part of a message in popup modal displayed when installing a snap for the first time."
-  },
   "snapsSettingsDescription": {
     "message": "Gerencie seus snaps"
   },

--- a/app/_locales/ru/messages.json
+++ b/app/_locales/ru/messages.json
@@ -4084,18 +4084,6 @@
   "snapsNoInsight": {
     "message": "Этот snap не выдал никакой аналитики"
   },
-  "snapsPrivacyWarningFirstMessage": {
-    "message": "Вы признаете, что snap, который вы собираетесь установить, является Сторонней службой, как она определена в $1 Consensys. Использование вами Сторонних служб регулируется отдельными положениями и условиями, установленными сторонним поставщиком услуг. Вы получаете доступ к Сторонней службе, полагаетесь на нее или используете его на свой страх и риск. Consensys отказывается от любой ответственности и ответственности за любые убытки, связанные с использованием вами сторонних услуг.",
-    "description": "First part of a message in popup modal displayed when installing a snap for the first time. $1 is terms of use link."
-  },
-  "snapsPrivacyWarningSecondMessage": {
-    "message": "Любая информация, которую вы передаете Сторонним службам, будет собираться непосредственно этими Сторонними службами в соответствии с их политикой конфиденциальности. Пожалуйста, обратитесь к их политике конфиденциальности для получения дополнительной информации.",
-    "description": "Second part of a message in popup modal displayed when installing a snap for the first time."
-  },
-  "snapsPrivacyWarningThirdMessage": {
-    "message": "У Consensys нет доступа к информации, которой вы делитесь с этими третьими сторонами.",
-    "description": "Third part of a message in popup modal displayed when installing a snap for the first time."
-  },
   "snapsSettingsDescription": {
     "message": "Управление вашим Snaps"
   },

--- a/app/_locales/tl/messages.json
+++ b/app/_locales/tl/messages.json
@@ -4084,18 +4084,6 @@
   "snapsNoInsight": {
     "message": "Ang snap ay hindi nagbalik ng anumang insight"
   },
-  "snapsPrivacyWarningFirstMessage": {
-    "message": "Kinikilala mo na ang snap na ii-install mo ay isang Serbisyo ng Third Party gaya ng tinukoy sa $1 ng Consensys. Ang iyong paggamit ng mga Serbisyo ng Third Party ay pinapamahalaan ng hiwalay na mga tuntunin at kundisyon na itinakda ng tagapagbigay ng Serbisyo ng Third Party. Ina-access, pinagbabatayan, o ginagamit mo ang Serbisyo ng Third Party sa sarili mong panganib. Itinatanggi ng Consensys ang lahat ng responsibilidad at pananagutan para sa anumang pagkalugi sa account dahil sa iyong paggamit ng mga Serbisyo ng Third Party.",
-    "description": "First part of a message in popup modal displayed when installing a snap for the first time. $1 is terms of use link."
-  },
-  "snapsPrivacyWarningSecondMessage": {
-    "message": "Ang anumang impormasyong ibinabahagi mo sa mga Serbisyo ng Third Party ay direktang kokolektahin ng mga Serbisyo ng Third Party na iyon alinsunod sa kanilang mga patakaran sa pagkapribado. Pakitingnan ang kanilang mga patakaran sa pagkapribado para sa higit pang impormasyon.",
-    "description": "Second part of a message in popup modal displayed when installing a snap for the first time."
-  },
-  "snapsPrivacyWarningThirdMessage": {
-    "message": "Walang access ang Consensys sa impormasyong ibinabahagi mo sa mga third party na ito.",
-    "description": "Third part of a message in popup modal displayed when installing a snap for the first time."
-  },
   "snapsSettingsDescription": {
     "message": "Pamahalaan ang iyong mga Snap"
   },

--- a/app/_locales/tr/messages.json
+++ b/app/_locales/tr/messages.json
@@ -4084,18 +4084,6 @@
   "snapsNoInsight": {
     "message": "Snap herhangi bir ayrıntıya ulaşamadı"
   },
-  "snapsPrivacyWarningFirstMessage": {
-    "message": "Yüklemek üzere olduğunuz snapin Consensys $1 içinde tanımlanan bir Üçüncü Taraf Hizmet olduğunu kabul edersiniz. Üçüncü Taraf Hizmetlerini kullanımınız Üçüncü Taraf Hizmet sağlayıcısı tarafından belirtilen ayrı şart ve koşullar tarafından yönetilir. Üçüncü Taraf Hizmetine erişiminizin, güvenmenizin veya kullanımınızın riski size aittir. Consensys, Üçüncü Taraf Hizmetlerini kullanımınızdan kaynaklanan zararlar konusunda tüm sorumluluk ve yükümlülüğü reddeder.",
-    "description": "First part of a message in popup modal displayed when installing a snap for the first time. $1 is terms of use link."
-  },
-  "snapsPrivacyWarningSecondMessage": {
-    "message": "Üçüncü Taraf Hizmetleri ile paylaştığınız tüm bilgiler söz konusu Üçüncü Taraf Hizmetlerinin gizlilik politikalarına göre doğrudan üçüncü taraflar tarafından toplanacaktır. Daha fazla bilgi için lütfen üçüncü tarafların gizlilik politikalarına bakın.",
-    "description": "Second part of a message in popup modal displayed when installing a snap for the first time."
-  },
-  "snapsPrivacyWarningThirdMessage": {
-    "message": "Consensys'un bu üçüncü taraflarla paylaştığınız bilgilere hiçbir erişimi bulunmamaktadır.",
-    "description": "Third part of a message in popup modal displayed when installing a snap for the first time."
-  },
   "snapsSettingsDescription": {
     "message": "Snaplerini yönet"
   },

--- a/app/_locales/vi/messages.json
+++ b/app/_locales/vi/messages.json
@@ -4084,18 +4084,6 @@
   "snapsNoInsight": {
     "message": "Snap không trả về bất kỳ thông tin chi tiết nào"
   },
-  "snapsPrivacyWarningFirstMessage": {
-    "message": "Bạn thừa nhận rằng Snap mà bạn sắp cài đặt là Dịch vụ bên thứ ba như được định nghĩa trong $1 của Consensys. Việc bạn sử dụng Dịch vụ bên thứ ba sẽ phải tuân theo các điều khoản và điều kiện riêng do nhà cung cấp Dịch vụ bên thứ ba quy định. Bạn tự chịu rủi ro khi truy cập, tin tưởng hoặc sử dụng Dịch vụ bên thứ ba. Consensys từ chối mọi trách nhiệm và trách nhiệm pháp lý đối với bất kỳ tổn thất nào khi bạn sử dụng Dịch vụ bên thứ ba.",
-    "description": "First part of a message in popup modal displayed when installing a snap for the first time. $1 is terms of use link."
-  },
-  "snapsPrivacyWarningSecondMessage": {
-    "message": "Mọi thông tin mà bạn chia sẻ với Dịch vụ bên thứ ba sẽ được Dịch vụ bên thứ ba đó thu thập trực tiếp theo chính sách quyền riêng tư của họ. Vui lòng tham khảo chính sách quyền riêng tư của họ để biết thêm thông tin.",
-    "description": "Second part of a message in popup modal displayed when installing a snap for the first time."
-  },
-  "snapsPrivacyWarningThirdMessage": {
-    "message": "Consensys không có quyền truy cập vào thông tin mà bạn chia sẻ với các bên thứ ba này.",
-    "description": "Third part of a message in popup modal displayed when installing a snap for the first time."
-  },
   "snapsSettingsDescription": {
     "message": "Quản lý Snap"
   },

--- a/app/_locales/zh_CN/messages.json
+++ b/app/_locales/zh_CN/messages.json
@@ -4084,18 +4084,6 @@
   "snapsNoInsight": {
     "message": "Snap 没有返回任何洞察"
   },
-  "snapsPrivacyWarningFirstMessage": {
-    "message": "您确认您即将安装的 snap 是 Consensys $1中定义的第三方服务。您对第三方服务的使用，受第三方服务提供商规定的单独条款和条件约束。您访问、依赖或使用第三方服务的风险，由您自己承担。对于您因使用第三方服务而造成的任何损失，Consensys 概不承担任何责任。",
-    "description": "First part of a message in popup modal displayed when installing a snap for the first time. $1 is terms of use link."
-  },
-  "snapsPrivacyWarningSecondMessage": {
-    "message": "您与第三方服务分享的任何信息，将由这些第三方服务根据其隐私政策直接收集。请参阅其隐私政策以了解更多信息。",
-    "description": "Second part of a message in popup modal displayed when installing a snap for the first time."
-  },
-  "snapsPrivacyWarningThirdMessage": {
-    "message": "Consensys 无法访问您与这些第三方分享的信息。",
-    "description": "Third part of a message in popup modal displayed when installing a snap for the first time."
-  },
   "snapsSettingsDescription": {
     "message": "管理您的 Snaps"
   },

--- a/shared/constants/terms.js
+++ b/shared/constants/terms.js
@@ -1,2 +1,2 @@
-export const TERMS_OF_USE_LINK = 'https://consensys.net/terms-of-use/';
+export const TERMS_OF_USE_LINK = 'https://consensys.io/terms-of-use/';
 export const TERMS_OF_USE_LAST_UPDATED = '2023-03-25';

--- a/ui/components/app/snaps/snap-privacy-warning/snap-privacy-warning.test.js
+++ b/ui/components/app/snaps/snap-privacy-warning/snap-privacy-warning.test.js
@@ -21,7 +21,7 @@ describe('Snap Privacy Warning Popover', () => {
     ).toBeInTheDocument();
     expect(
       screen.getByText(
-        'Consensys has no access to information you share with these third parties.',
+        'Consensys has no access to information you share with Third Party Services.',
       ),
     ).toBeInTheDocument();
     expect(


### PR DESCRIPTION
## Explanation
This PR updates Snap Privacy Warning message displayed in the modal that appears on the first Snap installation.
This PR also updates the URL for Terms of Use from domain `consensys.net` to domain `consensys.io`.

Changes done is this PR are requested internally over private communication channel, no ticket is following the change.

Notes:
* Three rows UI structure is retained for the new content.
* Translations to other languages should be done after this PR is merged. Update is done only for English version.
* Translations are removed as agreed and requested within the team. They're considered to be inaccurate after the change and should be translated again.

## Screenshots/Screencaps
### Before
![Screenshot 2023-09-05 at 18 39 10](https://github.com/MetaMask/metamask-extension/assets/13301024/cff13132-34db-441f-8a3b-6cf65a3379f7)
![Screenshot 2023-09-05 at 18 39 28](https://github.com/MetaMask/metamask-extension/assets/13301024/5e9e340c-adef-4f5a-a11f-dc26e7fe3afb)

### After
![Screenshot 2023-09-05 at 18 43 24](https://github.com/MetaMask/metamask-extension/assets/13301024/c194ce31-0176-4908-a819-c37d57d53709)
![Screenshot 2023-09-05 at 18 44 11](https://github.com/MetaMask/metamask-extension/assets/13301024/c9f4c313-6a91-43d6-8805-4155cdc986a6)


## Manual Testing Steps
1. Do a fresh install of the MetaMask extension.
2. Setup a wallet.
3. Try to install a Snap.
4. Privacy modal will appear - confirm the contents of it.

## Pre-merge author checklist

- [ ] I've clearly explained:
  - [ ] What problem this PR is solving
  - [ ] How this problem was solved
  - [ ] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
