### PR TITLE
Update account list to use all available screen space

### DIFF
--- a/ui/components/component-library/modal-content/__snapshots__/modal-content.test.tsx.snap
+++ b/ui/components/component-library/modal-content/__snapshots__/modal-content.test.tsx.snap
@@ -2,12 +2,12 @@
 
 exports[`ModalContent should match snapshot 1`] = `
 <div
-  class="mm-box mm-modal-content mm-box--padding-4 mm-box--display-flex mm-box--justify-content-center mm-box--align-items-flex-start mm-box--width-screen mm-box--height-screen"
+  class="mm-box mm-modal-content mm-box--padding-top-4 mm-box--sm:padding-top-8 mm-box--md:padding-top-12 mm-box--padding-right-4 mm-box--padding-bottom-4 mm-box--sm:padding-bottom-8 mm-box--md:padding-bottom-12 mm-box--padding-left-4 mm-box--display-flex mm-box--justify-content-center mm-box--align-items-flex-start mm-box--width-screen mm-box--height-screen"
   data-testid="test"
 >
   <section
     aria-modal="true"
-    class="mm-box mm-modal-content__dialog mm-modal-content__dialog--size-sm mm-box--sm:margin-top-8 mm-box--md:margin-top-12 mm-box--sm:margin-bottom-8 mm-box--md:margin-bottom-12 mm-box--padding-4 mm-box--width-full mm-box--background-color-background-default mm-box--rounded-lg"
+    class="mm-box mm-modal-content__dialog mm-modal-content__dialog--size-sm mm-box--padding-4 mm-box--width-full mm-box--background-color-background-default mm-box--rounded-lg"
     role="dialog"
   >
     test

--- a/ui/components/component-library/modal-content/modal-content.scss
+++ b/ui/components/component-library/modal-content/modal-content.scss
@@ -6,6 +6,22 @@
   overflow: auto;
   overscroll-behavior-y: none;
 
+  // Scroll bar styles
+  // Firefox
+  scrollbar-width: thin;
+  scrollbar-color: var(--color-icon-muted) transparent;
+
+  // Webkit: Chrome, Brave
+  ::-webkit-scrollbar {
+    width: 8px;
+  }
+
+  ::-webkit-scrollbar-thumb {
+    -webkit-border-radius: 8px;
+    border-radius: 8px;
+    background: var(--color-icon-muted);
+  }
+
   &__dialog {
     --modal-content-size: var(--size, 360px);
 

--- a/ui/components/component-library/modal-content/modal-content.test.tsx
+++ b/ui/components/component-library/modal-content/modal-content.test.tsx
@@ -55,11 +55,14 @@ describe('ModalContent', () => {
       'mm-modal-content__dialog--size-sm',
     );
   });
-  it('should render with additional props being passed to modalDialogProps', () => {
+  it('should render with additional props being passed to modalDialogProps and not override default class name', () => {
     const { getByTestId } = render(
       <Modal isOpen onClose={onClose}>
         <ModalContent
-          modalDialogProps={{ 'data-testid': 'test' }}
+          modalDialogProps={{
+            'data-testid': 'test',
+            className: 'custom-dialog-class',
+          }}
           data-testid="modal-content"
         >
           test
@@ -67,6 +70,9 @@ describe('ModalContent', () => {
       </Modal>,
     );
     expect(getByTestId('test')).toBeDefined();
+    expect(getByTestId('test')).toHaveClass(
+      'mm-modal-content__dialog custom-dialog-class',
+    );
   });
   it('should close when escape key is pressed', () => {
     const { getByRole } = render(

--- a/ui/components/component-library/modal-content/modal-content.tsx
+++ b/ui/components/component-library/modal-content/modal-content.tsx
@@ -86,25 +86,27 @@ export const ModalContent = forwardRef(
           height={BlockSize.Screen}
           justifyContent={JustifyContent.center}
           alignItems={AlignItems.flexStart}
-          padding={4}
+          paddingRight={4}
+          paddingLeft={4}
+          paddingTop={[4, 8, 12]}
+          paddingBottom={[4, 8, 12]}
           {...props}
         >
           <Box
-            className={classnames(
-              'mm-modal-content__dialog',
-              `mm-modal-content__dialog--size-${size}`,
-            )}
             as="section"
             role="dialog"
             aria-modal="true"
             backgroundColor={BackgroundColor.backgroundDefault}
             borderRadius={BorderRadius.LG}
             width={BlockSize.Full}
-            marginTop={[null, 8, 12]}
-            marginBottom={[null, 8, 12]}
             padding={4}
             ref={modalDialogRef}
             {...modalDialogProps}
+            className={classnames(
+              'mm-modal-content__dialog',
+              `mm-modal-content__dialog--size-${size}`,
+              modalDialogProps?.className,
+            )}
           >
             {children}
           </Box>

--- a/ui/components/multichain/account-list-menu/account-list-menu.js
+++ b/ui/components/multichain/account-list-menu/account-list-menu.js
@@ -19,6 +19,8 @@ import {
   BlockSize,
   Size,
   TextColor,
+  Display,
+  FlexDirection,
 } from '../../../helpers/constants/design-system';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import { MetaMetricsContext } from '../../../contexts/metametrics';
@@ -85,24 +87,22 @@ export const AccountListMenu = ({ onClose }) => {
       <ModalOverlay />
       <ModalContent
         className="multichain-account-menu-popover"
-        modalDialogProps={{ padding: 0, marginBottom: 0 }}
+        modalDialogProps={{
+          className: 'multichain-account-menu-popover__dialog',
+          padding: 0,
+          display: Display.Flex,
+          flexDirection: FlexDirection.Column,
+        }}
       >
         <ModalHeader
-          paddingTop={4}
-          paddingRight={4}
-          paddingBottom={6}
+          padding={4}
           onClose={onClose}
           onBack={actionMode === '' ? null : () => setActionMode('')}
         >
           {title}
         </ModalHeader>
         {actionMode === 'add' ? (
-          <Box
-            paddingLeft={4}
-            paddingRight={4}
-            paddingBottom={4}
-            paddingTop={0}
-          >
+          <Box paddingLeft={4} paddingRight={4} paddingBottom={4}>
             <CreateAccount
               onActionComplete={(confirmed) => {
                 if (confirmed) {
@@ -133,7 +133,7 @@ export const AccountListMenu = ({ onClose }) => {
           </Box>
         ) : null}
         {actionMode === '' ? (
-          <Box>
+          <>
             {/* Search box */}
             {accounts.length > 1 ? (
               <Box
@@ -315,7 +315,7 @@ export const AccountListMenu = ({ onClose }) => {
                 ///: END:ONLY_INCLUDE_IN
               }
             </Box>
-          </Box>
+          </>
         ) : null}
       </ModalContent>
     </Modal>

--- a/ui/components/multichain/account-list-menu/index.scss
+++ b/ui/components/multichain/account-list-menu/index.scss
@@ -1,10 +1,13 @@
 .multichain-account-menu-popover {
+  &__dialog {
+    max-height: 100%;
+  }
+
   .popover-content {
     border-radius: 0;
   }
 
   &__list {
-    max-height: 200px;
     overflow: auto;
   }
 }


### PR DESCRIPTION
## Explanation

Currently, the account list inside of the account modal is set to a static max height. This limits the amount of accounts that can be viewed when there is more screen space available.

This PR updates the `ModalContent` component-library component to allow for the dynamic resizing of content that scrolls **inside** of the modal dialog. It also adjusts the `AccountListMenu` component's max-height to allow it to dynamically resize and display as many accounts as possible within the available space. It also updates the scrollbar styling in webkit and firefox browsers so it matches our light and dark themes appropriately. 

* See: https://consensys.slack.com/archives/C015BV486HG/p1693499668418789


## Screenshots/Screencaps
Screencasts show the before and after dynamic sizing of the account list and scroll bar styling updates.

### Before

https://github.com/MetaMask/metamask-extension/assets/8112138/a49bcb14-857b-4007-80cd-d076a9f9bffe

### After

https://github.com/MetaMask/metamask-extension/assets/8112138/901ce4fd-b98d-4c1e-8f96-c856f9089c1d

Screenshots below show before/after of the scroll bar styles in chrome and firefox

## Scrollbar Chrome
### Before
<img width="430" alt="Screenshot 2023-09-05 at 1 14 26 PM" src="https://github.com/MetaMask/metamask-extension/assets/8112138/0b2a970a-b4e7-4e0e-9c04-9ac143087e78">

### After
<img width="371" alt="Screenshot 2023-09-05 at 1 23 50 PM" src="https://github.com/MetaMask/metamask-extension/assets/8112138/4343dfd7-e19b-4402-b4ec-04e2f2bdcadc">


## Scrollbar Firefox
### Before
<img width="378" alt="Screenshot 2023-09-05 at 1 16 35 PM" src="https://github.com/MetaMask/metamask-extension/assets/8112138/9f9d10ed-52a2-4e61-95ab-1662794273f1">

### After
<img width="375" alt="Screenshot 2023-09-05 at 1 19 30 PM" src="https://github.com/MetaMask/metamask-extension/assets/8112138/f03a7534-3420-4ea6-86cb-909a0167edf9">


## Manual Testing Steps
- Pull this branch/download the build
- Run the extension and open home page
- Open the account menu
- Add many accounts
- View the account menu in popup and expanded view
- Resize the browser and see the dynamic sizing of the account list

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
