### PR TITLE
fix: "Allow quick Add Account name based on default name" (20168)

### DIFF
--- a/ui/components/multichain/create-account/create-account.js
+++ b/ui/components/multichain/create-account/create-account.js
@@ -44,7 +44,7 @@ export const CreateAccount = ({ onActionComplete }) => {
   const { isValidAccountName, errorMessage } = getAccountNameErrorMessage(
     accounts,
     { t },
-    trimmedAccountName ?? defaultAccountName,
+    trimmedAccountName || defaultAccountName,
     defaultAccountName,
   );
 


### PR DESCRIPTION
I made a mistake in a suggestion on PR #20168, and Mark Stacey noticed it.  This PR fixes it.