### PR TITLE
feat: CircleCI is now storing builds-test and builds-test-flask

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -568,14 +568,17 @@ jobs:
           name: Build extension for testing
           command: yarn build:test:flask
       - run:
-          name: Move test build to 'dist-test' to avoid conflict with production build
+          name: Move test build to 'dist-test-flask' to avoid conflict with production build
           command: mv ./dist ./dist-test-flask
       - run:
-          name: Move test zips to 'builds-test' to avoid conflict with production build
+          name: Move test zips to 'builds-test-flask' to avoid conflict with production build
           command: mv ./builds ./builds-test-flask
+      - save_cache:
+          key: builds-test-flask-{{ .Environment.CIRCLE_WORKFLOW_ID }}
+          paths:
+            - builds-test-flask
       - store_artifacts:
           path: builds-test-flask
-          destination: builds-test-flask
       - persist_to_workspace:
           root: .
           paths:
@@ -595,7 +598,7 @@ jobs:
           name: Move test build to 'dist-test' to avoid conflict with production build
           command: mv ./dist ./dist-test-mv3
       - run:
-          name: Move test zips to 'builds-test' to avoid conflict with production build
+          name: Move test zips to 'builds-test-mv3' to avoid conflict with production build
           command: mv ./builds ./builds-test-mv3
       - persist_to_workspace:
           root: .
@@ -620,7 +623,6 @@ jobs:
           command: mv ./builds ./builds-test
       - store_artifacts:
           path: builds-test
-          destination: builds-test
       - persist_to_workspace:
           root: .
           paths:
@@ -1144,6 +1146,9 @@ jobs:
       - checkout
       - attach_workspace:
           at: .
+      - restore_cache:
+          keys:
+            - builds-test-flask-{{ .Environment.CIRCLE_WORKFLOW_ID }}
       - run:
           name: build:source-map-explorer
           command: ./development/source-map-explorer.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -573,6 +573,9 @@ jobs:
       - run:
           name: Move test zips to 'builds-test' to avoid conflict with production build
           command: mv ./builds ./builds-test-flask
+      - store_artifacts:
+          path: builds-test-flask
+          destination: builds-test-flask
       - persist_to_workspace:
           root: .
           paths:
@@ -615,6 +618,9 @@ jobs:
       - run:
           name: Move test zips to 'builds-test' to avoid conflict with production build
           command: mv ./builds ./builds-test
+      - store_artifacts:
+          path: builds-test
+          destination: builds-test
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -574,7 +574,7 @@ jobs:
           name: Move test zips to 'builds-test-flask' to avoid conflict with production build
           command: mv ./builds ./builds-test-flask
       - save_cache:
-          key: builds-test-flask-{{ .Environment.CIRCLE_WORKFLOW_ID }}
+          key: builds-test-flask-{{ .Environment.CIRCLE_SHA1 }}
           paths:
             - builds-test-flask
       - store_artifacts:
@@ -1148,7 +1148,7 @@ jobs:
           at: .
       - restore_cache:
           keys:
-            - builds-test-flask-{{ .Environment.CIRCLE_WORKFLOW_ID }}
+            - builds-test-flask-{{ .Environment.CIRCLE_SHA1 }}
       - run:
           name: build:source-map-explorer
           command: ./development/source-map-explorer.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1163,6 +1163,10 @@ jobs:
           path: builds-mmi
           destination: builds-mmi
       - store_artifacts:
+          path: builds-test
+      - store_artifacts:
+          path: builds-test-flask
+      - store_artifacts:
           path: coverage
           destination: coverage
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -573,12 +573,6 @@ jobs:
       - run:
           name: Move test zips to 'builds-test-flask' to avoid conflict with production build
           command: mv ./builds ./builds-test-flask
-      - save_cache:
-          key: builds-test-flask-{{ .Environment.CIRCLE_SHA1 }}
-          paths:
-            - builds-test-flask
-      - store_artifacts:
-          path: builds-test-flask
       - persist_to_workspace:
           root: .
           paths:
@@ -621,8 +615,6 @@ jobs:
       - run:
           name: Move test zips to 'builds-test' to avoid conflict with production build
           command: mv ./builds ./builds-test
-      - store_artifacts:
-          path: builds-test
       - persist_to_workspace:
           root: .
           paths:
@@ -1146,9 +1138,6 @@ jobs:
       - checkout
       - attach_workspace:
           at: .
-      - restore_cache:
-          keys:
-            - builds-test-flask-{{ .Environment.CIRCLE_SHA1 }}
       - run:
           name: build:source-map-explorer
           command: ./development/source-map-explorer.sh

--- a/development/metamaskbot-build-announce.js
+++ b/development/metamaskbot-build-announce.js
@@ -81,6 +81,18 @@ async function start() {
       return `<a href="${url}">${platform}</a>`;
     })
     .join(', ');
+  const testBuildLinks = platforms
+    .map((platform) => {
+      const url = `${BUILD_LINK_BASE}/builds-test/metamask-${platform}-${VERSION}.zip`;
+      return `<a href="${url}">${platform}</a>`;
+    })
+    .join(', ');
+  const testFlaskBuildLinks = platforms
+    .map((platform) => {
+      const url = `${BUILD_LINK_BASE}/builds-test-flask/metamask-flask-${platform}-${VERSION}-flask.0.zip`;
+      return `<a href="${url}">${platform}</a>`;
+    })
+    .join(', ');
 
   // links to bundle browser builds
   const bundles = {};
@@ -147,6 +159,8 @@ async function start() {
     `builds (beta): ${betaBuildLinks}`,
     `builds (flask): ${flaskBuildLinks}`,
     `builds (MMI): ${mmiBuildLinks}`,
+    `builds (test): ${testBuildLinks}`,
+    `builds (test-flask): ${testFlaskBuildLinks}`,
     `build viz: ${depVizLink}`,
     `mv3: ${moduleInitStatsBackgroundLink}`,
     `mv3: ${moduleInitStatsUILink}`,

--- a/development/metamaskbot-build-announce.js
+++ b/development/metamaskbot-build-announce.js
@@ -39,15 +39,19 @@ function getPercentageChange(from, to) {
 }
 
 async function start() {
-  const { GITHUB_COMMENT_TOKEN, CIRCLE_PULL_REQUEST } = process.env;
+  const {
+    GITHUB_COMMENT_TOKEN,
+    CIRCLE_PULL_REQUEST,
+    CIRCLE_SHA1,
+    CIRCLE_BUILD_NUM,
+    CIRCLE_WORKFLOW_JOB_ID,
+    PARENT_COMMIT,
+  } = process.env;
+
   console.log('CIRCLE_PULL_REQUEST', CIRCLE_PULL_REQUEST);
-  const { CIRCLE_SHA1 } = process.env;
   console.log('CIRCLE_SHA1', CIRCLE_SHA1);
-  const { CIRCLE_BUILD_NUM } = process.env;
   console.log('CIRCLE_BUILD_NUM', CIRCLE_BUILD_NUM);
-  const { CIRCLE_WORKFLOW_JOB_ID } = process.env;
   console.log('CIRCLE_WORKFLOW_JOB_ID', CIRCLE_WORKFLOW_JOB_ID);
-  const { PARENT_COMMIT } = process.env;
   console.log('PARENT_COMMIT', PARENT_COMMIT);
 
   if (!CIRCLE_PULL_REQUEST) {


### PR DESCRIPTION
## Explanation

The intent of this PR is very similar to #20783.  We want to save a little time for QA and developers, when they have to write, modify, or debug local E2E tests. The `builds-test` and the `builds-test-flask` can be downloaded from the PR instead of locally generated. It also ensures that your local E2E is running the same code as the CircleCI E2E.

The first version of this PR had to do some acrobatics with `save_cache` because `prep-build-test-flask` was not connected to `jobs-publish-prerelease`.  But now they are connected, so this PR is now more straightforward.

## Screenshots/Screencaps

### Before

![image](https://github.com/MetaMask/metamask-extension/assets/539738/7f6ccba5-8abe-422c-ad02-9b119df2dd66)

### After

![image](https://github.com/MetaMask/metamask-extension/assets/539738/cf52f65f-be60-41ef-a667-a218968fbc07)

## Manual Testing Steps

- For all 4 builds:
  - builds (test): chrome, firefox
  - builds (test-flask): chrome, firefox
1. Download them from the latest metamaskbot links on this PR
2. Open their manifest.json files to confirm that they have
`"description": "testing build from git id: xxxx",`
and `"name": "MetaMask Main lavamoat snow",` or `"name": "MetaMask Flask lavamoat snow",`
3. Try them with `yarn test:e2e:single`, make sure they run E2E tests properly

The QA Engineer Mike Berardi was already testing this as I was developing it.

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [X] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.