### PR TITLE
[MMI] Added code fences to hide emojis just for MMI build

### DIFF
--- a/ui/components/app/edit-gas-fee-button/edit-gas-fee-button.js
+++ b/ui/components/app/edit-gas-fee-button/edit-gas-fee-button.js
@@ -66,11 +66,15 @@ export default function EditGasFeeButton({ userAcknowledgedGasMissing }) {
   return (
     <div className="edit-gas-fee-button">
       <button onClick={openEditGasFeeModal} data-testid="edit-gas-fee-button">
-        {icon && (
-          <span className="edit-gas-fee-button__icon">
-            {PRIORITY_LEVEL_ICON_MAP[icon]}
-          </span>
-        )}
+        {
+          ///: BEGIN:ONLY_INCLUDE_IN(build-main,build-beta,build-flask)
+          icon && (
+            <span className="edit-gas-fee-button__icon">
+              {PRIORITY_LEVEL_ICON_MAP[icon]}
+            </span>
+          )
+          ///: END:ONLY_INCLUDE_IN
+        }
         <span className="edit-gas-fee-button__label">{t(title)}</span>
         <Icon
           name={IconName.ArrowRight}

--- a/ui/components/app/edit-gas-fee-button/edit-gas-fee-button.js
+++ b/ui/components/app/edit-gas-fee-button/edit-gas-fee-button.js
@@ -7,7 +7,9 @@ import {
   TextColor,
   TextVariant,
 } from '../../../helpers/constants/design-system';
+///: BEGIN:ONLY_INCLUDE_IN(build-main,build-beta,build-flask)
 import { PRIORITY_LEVEL_ICON_MAP } from '../../../helpers/constants/gas';
+///: END:ONLY_INCLUDE_IN
 import { useGasFeeContext } from '../../../contexts/gasFee';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import { useTransactionEventFragment } from '../../../hooks/useTransactionEventFragment';

--- a/ui/components/app/edit-gas-fee-button/edit-gas-fee-button.js
+++ b/ui/components/app/edit-gas-fee-button/edit-gas-fee-button.js
@@ -37,17 +37,22 @@ export default function EditGasFeeButton({ userAcknowledgedGasMissing }) {
   if (!supportsEIP1559 || !estimateUsed || !editEnabled) {
     return null;
   }
-
+  ///: BEGIN:ONLY_INCLUDE_IN(build-main,build-beta,build-flask)
   let icon = estimateUsed;
+  ///: END:ONLY_INCLUDE_IN
   let title = estimateUsed;
   if (
     estimateUsed === PriorityLevels.high &&
     editGasMode === EditGasModes.swaps
   ) {
+    ///: BEGIN:ONLY_INCLUDE_IN(build-main,build-beta,build-flask)
     icon = 'swapSuggested';
+    ///: END:ONLY_INCLUDE_IN
     title = 'swapSuggested';
   } else if (estimateUsed === PriorityLevels.tenPercentIncreased) {
+    ///: BEGIN:ONLY_INCLUDE_IN(build-main,build-beta,build-flask)
     icon = undefined;
+    ///: END:ONLY_INCLUDE_IN
     title = 'tenPercentIncreased';
   }
 

--- a/ui/components/app/edit-gas-fee-popover/edit-gas-item/edit-gas-item.js
+++ b/ui/components/app/edit-gas-fee-popover/edit-gas-item/edit-gas-item.js
@@ -6,7 +6,9 @@ import {
   EditGasModes,
   PriorityLevels,
 } from '../../../../../shared/constants/gas';
+///: BEGIN:ONLY_INCLUDE_IN(build-main,build-beta,build-flask)
 import { PRIORITY_LEVEL_ICON_MAP } from '../../../../helpers/constants/gas';
+///: END:ONLY_INCLUDE_IN
 import { PRIMARY } from '../../../../helpers/constants/common';
 import { toHumanReadableTime } from '../../../../helpers/utils/util';
 import { useGasFeeContext } from '../../../../contexts/gasFee';

--- a/ui/components/app/edit-gas-fee-popover/edit-gas-item/edit-gas-item.js
+++ b/ui/components/app/edit-gas-fee-popover/edit-gas-item/edit-gas-item.js
@@ -23,23 +23,34 @@ import EditGasToolTip from '../edit-gas-tooltip/edit-gas-tooltip';
 import { useGasItemFeeDetails } from './useGasItemFeeDetails';
 
 const getTitleAndIcon = (priorityLevel, editGasMode) => {
+  ///: BEGIN:ONLY_INCLUDE_IN(build-main,build-beta,build-flask)
   let icon = priorityLevel;
+  ///: END:ONLY_INCLUDE_IN
   let title = priorityLevel;
   if (priorityLevel === PriorityLevels.dAppSuggested) {
     title = 'dappSuggestedShortLabel';
   } else if (priorityLevel === PriorityLevels.dappSuggestedHigh) {
     title = 'dappSuggestedHighShortLabel';
   } else if (priorityLevel === PriorityLevels.tenPercentIncreased) {
+    ///: BEGIN:ONLY_INCLUDE_IN(build-main,build-beta,build-flask)
     icon = null;
+    ///: END:ONLY_INCLUDE_IN
     title = 'tenPercentIncreased';
   } else if (
     priorityLevel === PriorityLevels.high &&
     editGasMode === EditGasModes.swaps
   ) {
+    ///: BEGIN:ONLY_INCLUDE_IN(build-main,build-beta,build-flask)
     icon = 'swapSuggested';
+    ///: END:ONLY_INCLUDE_IN
     title = 'swapSuggested';
   }
-  return { title, icon };
+  return {
+    title,
+    ///: BEGIN:ONLY_INCLUDE_IN(build-main,build-beta,build-flask)
+    icon,
+    ///: END:ONLY_INCLUDE_IN
+  };
 };
 
 const EditGasItem = ({ priorityLevel }) => {
@@ -102,7 +113,12 @@ const EditGasItem = ({ priorityLevel }) => {
     }
   };
 
-  const { title, icon } = getTitleAndIcon(priorityLevel, editGasMode);
+  const {
+    title,
+    ///: BEGIN:ONLY_INCLUDE_IN(build-main,build-beta,build-flask)
+    icon,
+    ///: END:ONLY_INCLUDE_IN
+  } = getTitleAndIcon(priorityLevel, editGasMode);
 
   return (
     <button

--- a/ui/components/app/edit-gas-fee-popover/edit-gas-item/edit-gas-item.js
+++ b/ui/components/app/edit-gas-fee-popover/edit-gas-item/edit-gas-item.js
@@ -115,13 +115,17 @@ const EditGasItem = ({ priorityLevel }) => {
       data-testid={`edit-gas-fee-item-${priorityLevel}`}
     >
       <span className="edit-gas-item__name">
-        {icon && (
-          <span
-            className={`edit-gas-item__icon edit-gas-item__icon-${priorityLevel}`}
-          >
-            {PRIORITY_LEVEL_ICON_MAP[icon]}
-          </span>
-        )}
+        {
+          ///: BEGIN:ONLY_INCLUDE_IN(build-main,build-beta,build-flask)
+          icon && (
+            <span
+              className={`edit-gas-item__icon edit-gas-item__icon-${priorityLevel}`}
+            >
+              {PRIORITY_LEVEL_ICON_MAP[icon]}
+            </span>
+          )
+          ///: END:ONLY_INCLUDE_IN
+        }
         {t(title)}
       </span>
       <span


### PR DESCRIPTION
## Explanation

Added code fences to hide emojis just for MMI build

## Screenshots/Screencaps

### Before

<img width="349" alt="eb5ccaf0-072f-4a07-bc42-94ea12a9b43b" src="https://github.com/MetaMask/metamask-extension/assets/1182864/d51d114c-6d83-4f33-b84c-7cd3eeec6739">


![bc66e78a-748b-46cd-8235-799e31bd255a](https://github.com/MetaMask/metamask-extension/assets/1182864/24d395d1-1eb9-4b39-a156-f5b2cb720512)

### After

![Screenshot 2023-09-06 at 13 53 48](https://github.com/MetaMask/metamask-extension/assets/1182864/f7355eed-3a24-420e-88bd-6029e90d6906)


![Screenshot 2023-09-06 at 13 53 59](https://github.com/MetaMask/metamask-extension/assets/1182864/b7445829-d5e1-4153-9d85-b11e8b4adf62)

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [x] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [x] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.