### PR TITLE
Updating ppom validator

### DIFF
--- a/package.json
+++ b/package.json
@@ -261,7 +261,7 @@
     "@metamask/permission-controller": "^4.0.0",
     "@metamask/phishing-controller": "^6.0.0",
     "@metamask/post-message-stream": "^6.2.0",
-    "@metamask/ppom-validator": "^0.4.0",
+    "@metamask/ppom-validator": "^0.5.0",
     "@metamask/providers": "^11.1.0",
     "@metamask/rate-limit-controller": "^3.0.0",
     "@metamask/rpc-methods": "^1.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4537,16 +4537,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/ppom-validator@npm:^0.4.0":
-  version: 0.4.0
-  resolution: "@metamask/ppom-validator@npm:0.4.0"
+"@metamask/ppom-validator@npm:^0.5.0":
+  version: 0.5.0
+  resolution: "@metamask/ppom-validator@npm:0.5.0"
   dependencies:
     "@metamask/base-controller": "npm:^3.0.0"
     "@metamask/controller-utils": "npm:^4.0.0"
     await-semaphore: "npm:^0.1.3"
     elliptic: "npm:^6.5.4"
     json-rpc-random-id: "npm:^1.0.1"
-  checksum: f5999d6bd201ab4e290fb890e17c8f30830db2471eb530b939b6f371cab5b3be8675ce47535e341251cba90022a41ffce25b17d84f35d572738f6edbae5070e0
+  checksum: 17c35eb0c240cc92cf4ea1982899760adf07da7e4a6a4698e87b38b18bbbd9533334c6a1b1201e11fd07b5f55f82f78c5bc40daac36020a5c5f5108653259e34
   languageName: node
   linkType: hard
 
@@ -24232,7 +24232,7 @@ __metadata:
     "@metamask/phishing-controller": "npm:^6.0.0"
     "@metamask/phishing-warning": "npm:^2.1.0"
     "@metamask/post-message-stream": "npm:^6.2.0"
-    "@metamask/ppom-validator": "npm:^0.4.0"
+    "@metamask/ppom-validator": "npm:^0.5.0"
     "@metamask/providers": "npm:^11.1.0"
     "@metamask/rate-limit-controller": "npm:^3.0.0"
     "@metamask/rpc-methods": "npm:^1.0.2"


### PR DESCRIPTION
Updating ppom validator to latest version.

This includes fix for checkin that transaction is on ethereum mainnet.