### PR TITLE
Eliminated inability to enter the amount of transaction when token decimal exceeds 20.

### DIFF
--- a/app/scripts/controllers/swaps.test.js
+++ b/app/scripts/controllers/swaps.test.js
@@ -138,7 +138,7 @@ const EMPTY_INIT_STATE = {
     swapsQuotePrefetchingRefreshTime: 60000,
     swapsStxBatchStatusRefreshTime: FALLBACK_SMART_TRANSACTIONS_REFRESH_TIME,
     swapsStxGetTransactionsRefreshTime:
-    FALLBACK_SMART_TRANSACTIONS_REFRESH_TIME,
+      FALLBACK_SMART_TRANSACTIONS_REFRESH_TIME,
     swapsStxMaxFeeMultiplier: FALLBACK_SMART_TRANSACTIONS_MAX_FEE_MULTIPLIER,
     swapsUserFeeLevel: '',
     saveFetchedQuotes: false,
@@ -946,9 +946,9 @@ describe('SwapsController', function () {
           tokens: old.tokens,
           swapsQuoteRefreshTime: old.swapsQuoteRefreshTime,
           swapsQuotePrefetchingRefreshTime:
-          old.swapsQuotePrefetchingRefreshTime,
+            old.swapsQuotePrefetchingRefreshTime,
           swapsStxGetTransactionsRefreshTime:
-          old.swapsStxGetTransactionsRefreshTime,
+            old.swapsStxGetTransactionsRefreshTime,
           swapsStxBatchStatusRefreshTime: old.swapsStxBatchStatusRefreshTime,
         });
       });

--- a/app/scripts/controllers/swaps.test.js
+++ b/app/scripts/controllers/swaps.test.js
@@ -138,7 +138,7 @@ const EMPTY_INIT_STATE = {
     swapsQuotePrefetchingRefreshTime: 60000,
     swapsStxBatchStatusRefreshTime: FALLBACK_SMART_TRANSACTIONS_REFRESH_TIME,
     swapsStxGetTransactionsRefreshTime:
-      FALLBACK_SMART_TRANSACTIONS_REFRESH_TIME,
+    FALLBACK_SMART_TRANSACTIONS_REFRESH_TIME,
     swapsStxMaxFeeMultiplier: FALLBACK_SMART_TRANSACTIONS_MAX_FEE_MULTIPLIER,
     swapsUserFeeLevel: '',
     saveFetchedQuotes: false,
@@ -733,14 +733,14 @@ describe('SwapsController', function () {
           gasEstimateWithRefund: '0xb8cae',
           savings: {
             fee: '-0.061067',
-            metaMaskFee: '0.5050505050505050505',
+            metaMaskFee: '0.5050505050505050505050505050505',
             performance: '6',
-            total: '5.4338824949494949495',
-            medianMetaMaskFee: '0.44444444444444444444',
+            total: '5.4338824949494949494949494949495',
+            medianMetaMaskFee: '0.44444444444444444444444444444444',
           },
           ethFee: '0.113536',
           overallValueOfQuote: '49.886464',
-          metaMaskFeeInEth: '0.5050505050505050505',
+          metaMaskFeeInEth: '0.5050505050505050505050505050505',
           ethValueOfTokens: '50',
         });
         assert.strictEqual(
@@ -798,15 +798,15 @@ describe('SwapsController', function () {
           gasEstimateWithRefund: '0xb8cae',
           savings: {
             fee: '-0.061067',
-            metaMaskFee: '0.5050505050505050505',
+            metaMaskFee: '0.5050505050505050505050505050505',
             performance: '6',
-            total: '5.4338824949494949495',
-            medianMetaMaskFee: '0.44444444444444444444',
+            total: '5.4338824949494949494949494949495',
+            medianMetaMaskFee: '0.44444444444444444444444444444444',
           },
           ethFee: '0.113822',
           multiLayerL1TradeFeeTotal: '0x0103c18816d4e8',
           overallValueOfQuote: '49.886178',
-          metaMaskFeeInEth: '0.5050505050505050505',
+          metaMaskFeeInEth: '0.5050505050505050505050505050505',
           ethValueOfTokens: '50',
         });
         assert.strictEqual(
@@ -946,9 +946,9 @@ describe('SwapsController', function () {
           tokens: old.tokens,
           swapsQuoteRefreshTime: old.swapsQuoteRefreshTime,
           swapsQuotePrefetchingRefreshTime:
-            old.swapsQuotePrefetchingRefreshTime,
+          old.swapsQuotePrefetchingRefreshTime,
           swapsStxGetTransactionsRefreshTime:
-            old.swapsStxGetTransactionsRefreshTime,
+          old.swapsStxGetTransactionsRefreshTime,
           swapsStxBatchStatusRefreshTime: old.swapsStxBatchStatusRefreshTime,
         });
       });

--- a/shared/modules/Numeric.test.ts
+++ b/shared/modules/Numeric.test.ts
@@ -225,37 +225,37 @@ describe('Numeric', () => {
       it('should compute correct results for division of big numbers', () => {
         expect(
           new Numeric('175671432', 10).divide('686216', 10).toString(),
-        ).toStrictEqual('256.00019818832554181191');
+        ).toStrictEqual('256.00019818832554181190762092402392');
 
         expect(
           new Numeric('1756714320', 10)
             .divide(new Numeric('686216', 10))
             .toString(),
-        ).toStrictEqual('2560.00198188325541811908');
+        ).toStrictEqual('2560.00198188325541811907620924023922');
 
         expect(
           new Numeric('41756714320', 10)
             .divide(new Numeric('6862160', 10))
             .toString(),
-        ).toStrictEqual('6085.06859647691106007438');
+        ).toStrictEqual('6085.06859647691106007437891276216235');
       });
 
       it('should compute correct results for division of negative big numbers', () => {
         expect(
           new Numeric('175671432', 10).divide('-686216', 10).toString(),
-        ).toStrictEqual('-256.00019818832554181191');
+        ).toStrictEqual('-256.00019818832554181190762092402392');
 
         expect(
           new Numeric('1756714320', 10)
             .divide(new Numeric('-686216', 10))
             .toString(),
-        ).toStrictEqual('-2560.00198188325541811908');
+        ).toStrictEqual('-2560.00198188325541811907620924023922');
 
         expect(
           new Numeric('-41756714320', 10)
             .divide(new Numeric('-6862160', 10))
             .toString(),
-        ).toStrictEqual('6085.06859647691106007438');
+        ).toStrictEqual('6085.06859647691106007437891276216235');
       });
     });
 
@@ -377,7 +377,7 @@ describe('Numeric', () => {
       it('should multiply the value by the inverse of conversionRate supplied when second parameter is true', () => {
         expect(
           new Numeric(10, 10).applyConversionRate(468.5, true).toString(),
-        ).toStrictEqual('0.0213447171824973319');
+        ).toStrictEqual('0.0213447171824973319103521878335');
       });
 
       it('should multiply the value by the inverse of the BigNumber conversionRate supplied when second parameter is true', () => {
@@ -385,7 +385,7 @@ describe('Numeric', () => {
           new Numeric(10, 10)
             .applyConversionRate(new BigNumber(468.5, 10), true)
             .toString(),
-        ).toStrictEqual('0.0213447171824973319');
+        ).toStrictEqual('0.0213447171824973319103521878335');
       });
     });
   });

--- a/shared/modules/Numeric.ts
+++ b/shared/modules/Numeric.ts
@@ -9,6 +9,24 @@ export type NumericValue = string | number | BN | BigNumber;
 export type NumericBase = 10 | 16;
 
 /**
+ * By default, bignumber.js library allows using 20 decimal places.
+ * Due to the fact that some tokens have more decimal places, it's required
+ * to increase the number of decimal places up to 32. This help us to avoid incorrect
+ * calculations in methods like applyConversionRate when invert parameter in true.
+ *
+ * For example:
+ *
+ *  new Numeric(some_value)
+ *    .applyConversionRate(27, true)
+ *
+ * This operation gives us 0, because bignumber.js doesn't allow for enough decimal places to
+ * store the calculated value in the applyConversionRate function (due to the division math operation).
+ */
+BigNumber.config({
+  DECIMAL_PLACES: 32,
+});
+
+/**
  * All variations of isHexString from our own utilities and etherumjs-utils
  * return false for a '-' prefixed hex string. This utility method strips the
  * possible '-' from the string before testing its validity so that negative

--- a/shared/modules/Numeric.ts
+++ b/shared/modules/Numeric.ts
@@ -16,9 +16,8 @@ export type NumericBase = 10 | 16;
  *
  * For example:
  *
- *  new Numeric(some_value)
- *    .applyConversionRate(27, true)
- *
+ * new Numeric(some_value).applyConversionRate(27, true)
+ *    
  * This operation gives us 0, because bignumber.js doesn't allow for enough decimal places to
  * store the calculated value in the applyConversionRate function (due to the division math operation).
  */

--- a/shared/modules/Numeric.ts
+++ b/shared/modules/Numeric.ts
@@ -17,7 +17,7 @@ export type NumericBase = 10 | 16;
  * For example:
  *
  * new Numeric(some_value).applyConversionRate(27, true)
- *    
+ *
  * This operation gives us 0, because bignumber.js doesn't allow for enough decimal places to
  * store the calculated value in the applyConversionRate function (due to the division math operation).
  */


### PR DESCRIPTION
## Explanation

When the user enters the amount of transaction, and the number of token decimal places is greater than 20, the entered value always equals 0 


This is not UI behaviour. There are no limits or constraints for the input field.

This issue relates to BigNumber precision. By default, `DECIMAL_PLACES` value is set to 20 in [bignumber.js library configuration](https://mikemcl.github.io/bignumber.js/#decimal-places).
After an amount is entered in the input field, it is passed to [the function that saves it into redux storage](https://github.com/MetaMask/metamask-extension/blob/b5ece42ca1aec91215651b5debc3e853e8f535b5/ui/ducks/send/send.js#L1968) . The function converts the entered value (https://github.com/MetaMask/metamask-extension/blob/b5ece42ca1aec91215651b5debc3e853e8f535b5/ui/ducks/send/send.js#L1980-L1986), which causes incorrect calculation.

https://github.com/MetaMask/metamask-extension/blob/6b72316eb68485ff4548275668646ea667c586ac/shared/modules/Numeric.ts#L421-L444

In our case, `applyConversionRate` function converts the value to 0.
When a token has, for example, 27 decimal places, the ‘rate’ parameter of this function will be 1e27.

https://github.com/MetaMask/metamask-extension/blob/6b72316eb68485ff4548275668646ea667c586ac/shared/modules/Numeric.ts#L428

`conversionRate` value equals 1e-27 (0.000000000000000000000000001) on line 428. But, by default, there is not enough bignumber.js precision to store this value correctly, so it converts to 0.
Any value smaller than 1e20 will become 0. 
And that’s why any transaction will be 0 in the submission form. 

This issue can be fixed by increasing the number of BigNumber decimal places.

`BigNumber.config({ DECIMAL_PLACES: 32 })`


## Screenshots/Screencaps

### Before

https://github.com/MetaMask/metamask-extension/assets/84840096/23588580-9ceb-457d-b3bd-5e1ded9a8794

### After

https://github.com/MetaMask/metamask-extension/assets/84840096/fc583374-b167-44f9-a4ee-45703f12645f

## Manual Testing Steps

- Open menu “Select a network”
- On main workspace click “Import Token” button
- Enter “0x406F892f98b6789FE6699735DD9a287b7d393001” value as token contract address (Instead of this token you can use another one, but it should have more than 20 decimals). Then the required information about token symbol and token decimal will automatically load

![img_1](https://github.com/MetaMask/metamask-extension/assets/84840096/dd22b0d6-29f9-42a1-bcbe-3c39d182ef93)

- Approve importing of the token
- Click “Send” button on your wallet dashboard
- Enter a wallet address as a destination
- Try entering any amount in “Send token” form


## Version 
10.34.1

## Browser
Chrome, Firefox, Safari

## Operating system
Windows, Linux, MacOS

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
