### PR TITLE
[MMI] Shows Stake & Portfolio buttons and hides the Buy and Bridge buttons

### DIFF
--- a/ui/components/app/wallet-overview/token-overview.js
+++ b/ui/components/app/wallet-overview/token-overview.js
@@ -5,22 +5,37 @@ import { useHistory } from 'react-router-dom';
 
 import CurrencyDisplay from '../../ui/currency-display';
 import { I18nContext } from '../../../contexts/i18n';
-import { isHardwareKeyring } from '../../../helpers/utils/hardware';
 import {
   SEND_ROUTE,
+  ///: BEGIN:ONLY_INCLUDE_IN(build-main,build-beta,build-flask)
   BUILD_QUOTE_ROUTE,
+  ///: END:ONLY_INCLUDE_IN
 } from '../../../helpers/constants/routes';
 import { useTokenTracker } from '../../../hooks/useTokenTracker';
 import { useTokenFiatAmount } from '../../../hooks/useTokenFiatAmount';
 import { startNewDraftTransaction } from '../../../ducks/send';
+///: BEGIN:ONLY_INCLUDE_IN(build-main,build-beta,build-flask)
+import { isHardwareKeyring } from '../../../helpers/utils/hardware';
 import { setSwapsFromToken } from '../../../ducks/swaps/swaps';
+import useRamps from '../../../hooks/experiences/useRamps';
+import { getPortfolioUrl } from '../../../helpers/utils/portfolio';
+///: END:ONLY_INCLUDE_IN
+///: BEGIN:ONLY_INCLUDE_IN(build-mmi)
 import {
-  getCurrentKeyring,
+  getMmiPortfolioEnabled,
+  getMmiPortfolioUrl,
+} from '../../../selectors/institutional/selectors';
+import { MMI_SWAPS_URL } from '../../../../shared/constants/swaps';
+///: END:ONLY_INCLUDE_IN
+import {
   getIsSwapsChain,
-  getIsBuyableChain,
-  getIsBridgeToken,
   getCurrentChainId,
+  ///: BEGIN:ONLY_INCLUDE_IN(build-main,build-beta,build-flask)
+  getIsBridgeToken,
+  getCurrentKeyring,
+  getIsBuyableChain,
   getMetaMetricsId,
+  ///: END:ONLY_INCLUDE_IN
 } from '../../../selectors';
 
 import IconButton from '../../ui/icon-button';
@@ -33,12 +48,10 @@ import {
   MetaMetricsSwapsEventSource,
 } from '../../../../shared/constants/metametrics';
 import { AssetType } from '../../../../shared/constants/transaction';
-import useRamps from '../../../hooks/experiences/useRamps';
 
 import { Icon, IconName } from '../../component-library';
 import { IconColor } from '../../../helpers/constants/design-system';
 
-import { getPortfolioUrl } from '../../../helpers/utils/portfolio';
 import WalletOverview from './wallet-overview';
 
 const TokenOverview = ({ className, token }) => {
@@ -46,11 +59,13 @@ const TokenOverview = ({ className, token }) => {
   const t = useContext(I18nContext);
   const trackEvent = useContext(MetaMetricsContext);
   const history = useHistory();
+  const { tokensWithBalances } = useTokenTracker([token]);
+  ///: BEGIN:ONLY_INCLUDE_IN(build-main,build-beta,build-flask)
   const keyring = useSelector(getCurrentKeyring);
   const usingHardwareWallet = isHardwareKeyring(keyring.type);
-  const { tokensWithBalances } = useTokenTracker([token]);
-  const balanceToRender = tokensWithBalances[0]?.string;
   const balance = tokensWithBalances[0]?.balance;
+  ///: END:ONLY_INCLUDE_IN
+  const balanceToRender = tokensWithBalances[0]?.string;
   const formattedFiatBalance = useTokenFiatAmount(
     token.address,
     balanceToRender,
@@ -58,11 +73,65 @@ const TokenOverview = ({ className, token }) => {
   );
   const chainId = useSelector(getCurrentChainId);
   const isSwapsChain = useSelector(getIsSwapsChain);
+  ///: BEGIN:ONLY_INCLUDE_IN(build-main,build-beta,build-flask)
   const isBridgeToken = useSelector(getIsBridgeToken(token.address));
   const isBuyableChain = useSelector(getIsBuyableChain);
   const metaMetricsId = useSelector(getMetaMetricsId);
 
   const { openBuyCryptoInPdapp } = useRamps();
+  ///: END:ONLY_INCLUDE_IN
+
+  ///: BEGIN:ONLY_INCLUDE_IN(build-mmi)
+  const mmiPortfolioEnabled = useSelector(getMmiPortfolioEnabled);
+  const mmiPortfolioUrl = useSelector(getMmiPortfolioUrl);
+
+  const portfolioEvent = () => {
+    trackEvent({
+      category: MetaMetricsEventCategory.Navigation,
+      event: MetaMetricsEventName.MMIPortfolioButtonClicked,
+    });
+  };
+
+  const stakingEvent = () => {
+    trackEvent({
+      category: MetaMetricsEventCategory.Navigation,
+      event: MetaMetricsEventName.MMIPortfolioButtonClicked,
+    });
+  };
+
+  const renderInstitutionalButtons = () => {
+    return (
+      <>
+        <IconButton
+          className="eth-overview__button"
+          Icon={<Icon name={IconName.Stake} color={IconColor.primaryInverse} />}
+          label={t('stake')}
+          data-testid="token-overview-mmi-stake"
+          onClick={() => {
+            stakingEvent();
+            global.platform.openTab({
+              url: 'https://metamask-institutional.io/stake',
+            });
+          }}
+        />
+        {mmiPortfolioEnabled && (
+          <IconButton
+            className="eth-overview__button"
+            Icon={
+              <Icon name={IconName.Diagram} color={IconColor.primaryInverse} />
+            }
+            label={t('portfolio')}
+            data-testid="token-overview-mmi-portfolio"
+            onClick={() => {
+              portfolioEvent();
+              window.open(mmiPortfolioUrl, '_blank');
+            }}
+          />
+        )}
+      </>
+    );
+  };
+  ///: END:ONLY_INCLUDE_IN
 
   useEffect(() => {
     if (token.isERC721) {
@@ -99,26 +168,39 @@ const TokenOverview = ({ className, token }) => {
       }
       buttons={
         <>
-          <IconButton
-            className="token-overview__button"
-            Icon={<Icon name={IconName.Add} color={IconColor.primaryInverse} />}
-            label={t('buy')}
-            data-testid="token-overview-buy"
-            onClick={() => {
-              openBuyCryptoInPdapp();
-              trackEvent({
-                event: MetaMetricsEventName.NavBuyButtonClicked,
-                category: MetaMetricsEventCategory.Navigation,
-                properties: {
-                  location: 'Token Overview',
-                  text: 'Buy',
-                  chain_id: chainId,
-                  token_symbol: token.symbol,
-                },
-              });
-            }}
-            disabled={token.isERC721 || !isBuyableChain}
-          />
+          {
+            ///: BEGIN:ONLY_INCLUDE_IN(build-main,build-beta,build-flask)
+            <IconButton
+              className="token-overview__button"
+              Icon={
+                <Icon name={IconName.Add} color={IconColor.primaryInverse} />
+              }
+              label={t('buy')}
+              data-testid="token-overview-buy"
+              onClick={() => {
+                openBuyCryptoInPdapp();
+                trackEvent({
+                  event: MetaMetricsEventName.NavBuyButtonClicked,
+                  category: MetaMetricsEventCategory.Navigation,
+                  properties: {
+                    location: 'Token Overview',
+                    text: 'Buy',
+                    chain_id: chainId,
+                    token_symbol: token.symbol,
+                  },
+                });
+              }}
+              disabled={token.isERC721 || !isBuyableChain}
+            />
+            ///: END:ONLY_INCLUDE_IN
+          }
+
+          {
+            ///: BEGIN:ONLY_INCLUDE_IN(build-mmi)
+            renderInstitutionalButtons()
+            ///: END:ONLY_INCLUDE_IN
+          }
+
           <IconButton
             className="token-overview__button"
             onClick={async () => {
@@ -166,6 +248,13 @@ const TokenOverview = ({ className, token }) => {
                 />
               }
               onClick={() => {
+                ///: BEGIN:ONLY_INCLUDE_IN(build-mmi)
+                global.platform.openTab({
+                  url: MMI_SWAPS_URL,
+                });
+                ///: END:ONLY_INCLUDE_IN
+
+                ///: BEGIN:ONLY_INCLUDE_IN(build-main,build-beta,build-flask)
                 trackEvent({
                   event: MetaMetricsEventName.NavSwapButtonClicked,
                   category: MetaMetricsEventCategory.Swaps,
@@ -190,43 +279,52 @@ const TokenOverview = ({ className, token }) => {
                 } else {
                   history.push(BUILD_QUOTE_ROUTE);
                 }
+                ///: END:ONLY_INCLUDE_IN
               }}
               label={t('swap')}
               tooltipRender={null}
             />
           )}
-          {isBridgeToken && (
-            <IconButton
-              className="token-overview__button"
-              data-testid="token-overview-bridge"
-              Icon={
-                <Icon name={IconName.Bridge} color={IconColor.primaryInverse} />
-              }
-              label={t('bridge')}
-              onClick={() => {
-                const portfolioUrl = getPortfolioUrl(
-                  'bridge',
-                  'ext_bridge_button',
-                  metaMetricsId,
-                );
-                global.platform.openTab({
-                  url: `${portfolioUrl}&token=${token.address}`,
-                });
-                trackEvent({
-                  category: MetaMetricsEventCategory.Navigation,
-                  event: MetaMetricsEventName.BridgeLinkClicked,
-                  properties: {
-                    location: 'Token Overview',
-                    text: 'Bridge',
-                    url: portfolioUrl,
-                    chain_id: chainId,
-                    token_symbol: token.symbol,
-                  },
-                });
-              }}
-              tooltipRender={null}
-            />
-          )}
+
+          {
+            ///: BEGIN:ONLY_INCLUDE_IN(build-main,build-beta,build-flask)
+            isBridgeToken && (
+              <IconButton
+                className="token-overview__button"
+                data-testid="token-overview-bridge"
+                Icon={
+                  <Icon
+                    name={IconName.Bridge}
+                    color={IconColor.primaryInverse}
+                  />
+                }
+                label={t('bridge')}
+                onClick={() => {
+                  const portfolioUrl = getPortfolioUrl(
+                    'bridge',
+                    'ext_bridge_button',
+                    metaMetricsId,
+                  );
+                  global.platform.openTab({
+                    url: `${portfolioUrl}&token=${token.address}`,
+                  });
+                  trackEvent({
+                    category: MetaMetricsEventCategory.Navigation,
+                    event: MetaMetricsEventName.BridgeLinkClicked,
+                    properties: {
+                      location: 'Token Overview',
+                      text: 'Bridge',
+                      url: portfolioUrl,
+                      chain_id: chainId,
+                      token_symbol: token.symbol,
+                    },
+                  });
+                }}
+                tooltipRender={null}
+              />
+            )
+            ///: END:ONLY_INCLUDE_IN
+          }
         </>
       }
       className={className}

--- a/ui/components/app/wallet-overview/token-overview.js
+++ b/ui/components/app/wallet-overview/token-overview.js
@@ -98,39 +98,6 @@ const TokenOverview = ({ className, token }) => {
       event: MetaMetricsEventName.MMIPortfolioButtonClicked,
     });
   };
-
-  const renderInstitutionalButtons = () => {
-    return (
-      <>
-        <IconButton
-          className="eth-overview__button"
-          Icon={<Icon name={IconName.Stake} color={IconColor.primaryInverse} />}
-          label={t('stake')}
-          data-testid="token-overview-mmi-stake"
-          onClick={() => {
-            stakingEvent();
-            global.platform.openTab({
-              url: 'https://metamask-institutional.io/stake',
-            });
-          }}
-        />
-        {mmiPortfolioEnabled && (
-          <IconButton
-            className="eth-overview__button"
-            Icon={
-              <Icon name={IconName.Diagram} color={IconColor.primaryInverse} />
-            }
-            label={t('portfolio')}
-            data-testid="token-overview-mmi-portfolio"
-            onClick={() => {
-              portfolioEvent();
-              window.open(mmiPortfolioUrl, '_blank');
-            }}
-          />
-        )}
-      </>
-    );
-  };
   ///: END:ONLY_INCLUDE_IN
 
   useEffect(() => {
@@ -197,7 +164,42 @@ const TokenOverview = ({ className, token }) => {
 
           {
             ///: BEGIN:ONLY_INCLUDE_IN(build-mmi)
-            renderInstitutionalButtons()
+            <>
+              <IconButton
+                className="eth-overview__button"
+                Icon={
+                  <Icon
+                    name={IconName.Stake}
+                    color={IconColor.primaryInverse}
+                  />
+                }
+                label={t('stake')}
+                data-testid="token-overview-mmi-stake"
+                onClick={() => {
+                  stakingEvent();
+                  global.platform.openTab({
+                    url: 'https://metamask-institutional.io/stake',
+                  });
+                }}
+              />
+              {mmiPortfolioEnabled && (
+                <IconButton
+                  className="eth-overview__button"
+                  Icon={
+                    <Icon
+                      name={IconName.Diagram}
+                      color={IconColor.primaryInverse}
+                    />
+                  }
+                  label={t('portfolio')}
+                  data-testid="token-overview-mmi-portfolio"
+                  onClick={() => {
+                    portfolioEvent();
+                    window.open(mmiPortfolioUrl, '_blank');
+                  }}
+                />
+              )}
+            </>
             ///: END:ONLY_INCLUDE_IN
           }
 

--- a/ui/components/app/wallet-overview/token-overview.test.js
+++ b/ui/components/app/wallet-overview/token-overview.test.js
@@ -52,6 +52,12 @@ describe('TokenOverview', () => {
         },
       ],
       contractExchangeRates: {},
+      mmiConfiguration: {
+        portfolio: {
+          enabled: true,
+        },
+        url: 'https://metamask-institutional.io',
+      },
     },
   };
 
@@ -321,6 +327,18 @@ describe('TokenOverview', () => {
       );
       const bridgeButton = queryByTestId('token-overview-bridge');
       expect(bridgeButton).not.toBeInTheDocument();
+    });
+
+    it('should show the MMI Portfolio and Stake buttons', () => {
+      const { queryByTestId } = renderWithProvider(
+        <TokenOverview token={token} />,
+        store,
+      );
+      const mmiStakeButton = queryByTestId('token-overview-mmi-stake');
+      const mmiPortfolioButton = queryByTestId('token-overview-mmi-portfolio');
+
+      expect(mmiStakeButton).toBeInTheDocument();
+      expect(mmiPortfolioButton).toBeInTheDocument();
     });
   });
 });


### PR DESCRIPTION
## Explanation

In the Token Overview component we were showing the Buy and Bridge buttons, and also missing the MMI Stake and Portfolio ones, so this PR updates that in order to only show the relevant buttons for MMI use case.

#### Screenshot from before:

<img width="355" alt="Screenshot 2023-09-06 at 16 26 00" src="https://github.com/MetaMask/metamask-extension/assets/1125631/259056a4-8a75-4ccb-b7cb-a530decf3b6c">

#### Screenshot after:

<img width="357" alt="Screenshot 2023-09-06 at 16 24 38" src="https://github.com/MetaMask/metamask-extension/assets/1125631/0701c16f-475c-4d51-bfbc-5d9b42e36689">


## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [x] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [x] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.