### PR TITLE
Add MMI builds to metamaskbot comment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1158,6 +1158,9 @@ jobs:
           path: builds-flask
           destination: builds-flask
       - store_artifacts:
+          path: builds-mmi
+          destination: builds-mmi
+      - store_artifacts:
           path: coverage
           destination: coverage
       - store_artifacts:

--- a/development/metamaskbot-build-announce.js
+++ b/development/metamaskbot-build-announce.js
@@ -75,6 +75,12 @@ async function start() {
       return `<a href="${url}">${platform}</a>`;
     })
     .join(', ');
+  const mmiBuildLinks = platforms
+    .map((platform) => {
+      const url = `${BUILD_LINK_BASE}/builds-mmi/metamask-mmi-${platform}-${VERSION}-mmi.0.zip`;
+      return `<a href="${url}">${platform}</a>`;
+    })
+    .join(', ');
 
   // links to bundle browser builds
   const bundles = {};
@@ -140,6 +146,7 @@ async function start() {
     `builds: ${buildLinks}`,
     `builds (beta): ${betaBuildLinks}`,
     `builds (flask): ${flaskBuildLinks}`,
+    `builds (MMI): ${mmiBuildLinks}`,
     `build viz: ${depVizLink}`,
     `mv3: ${moduleInitStatsBackgroundLink}`,
     `mv3: ${moduleInitStatsUILink}`,


### PR DESCRIPTION
## Explanation

The `metamaskbot` comment on each PR now includes links to MMI builds.

This relates to https://github.com/MetaMask/metamask-extension/issues/20782

## Manual Testing Steps

Check that the build linked in the metamaskbot comment can be downloaded

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
