### PR TITLE
Publish MMI builds alongside stable releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1203,6 +1203,9 @@ jobs:
           name: Publish Flask release to Sentry
           command: yarn sentry:publish --build-type flask
       - run:
+          name: Publish MMI release to Sentry
+          command: yarn sentry:publish --build-type mmi
+      - run:
           name: Create GitHub release
           command: |
             .circleci/scripts/release-create-gh-release.sh


### PR DESCRIPTION
## Explanation

MMI builds are now published alongside stable releases, in the same manner as Flask. They will be included in future GitHub release pages, and tracked using separate git tags. Sentry sourcemaps are uploaded for them during the release process as well.

Closes https://github.com/MetaMask/metamask-extension/issues/20782

## Manual Testing Steps

This can be tested by forking the repository, then going through the release process (with this PR included in the release)

I tried this in my fork, and it worked: https://github.com/Gudahtt/metamask-extension/releases/tag/v11.1.1
CircleCI run: https://app.circleci.com/pipelines/github/Gudahtt/metamask-extension/339/workflows/dfd0f53f-67cc-480b-ad98-abf6c9213364/jobs/6118

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
