### PR TITLE
UX: Multichain: Remove hover background on Account Picker

### DIFF
--- a/ui/components/multichain/account-picker/__snapshots__/account-picker.test.js.snap
+++ b/ui/components/multichain/account-picker/__snapshots__/account-picker.test.js.snap
@@ -3,11 +3,11 @@
 exports[`AccountPicker renders properly 1`] = `
 <div>
   <button
-    class="mm-box mm-text mm-button-base mm-button-base--size-md mm-button-base--ellipsis multichain-account-picker mm-button-primary mm-text--body-md-medium mm-text--ellipsis mm-box--padding-0 mm-box--padding-right-4 mm-box--padding-left-4 mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-primary-inverse mm-box--background-color-transparent mm-box--rounded-lg"
+    class="mm-box mm-text mm-button-base mm-button-base--size-md mm-button-base--ellipsis multichain-account-picker mm-text--body-md-medium mm-text--ellipsis mm-box--padding-0 mm-box--padding-right-4 mm-box--padding-left-4 mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-transparent mm-box--rounded-lg"
     data-testid="account-menu-icon"
   >
     <span
-      class="mm-box mm-text mm-text--inherit mm-text--ellipsis mm-box--display-flex mm-box--gap-2 mm-box--align-items-center mm-box--color-primary-inverse"
+      class="mm-box mm-text mm-text--inherit mm-text--ellipsis mm-box--display-flex mm-box--gap-2 mm-box--align-items-center mm-box--color-text-default"
     >
       <div
         class="mm-box multichain-account-picker-container mm-box--display-flex mm-box--flex-direction-column"

--- a/ui/components/multichain/account-picker/account-picker.js
+++ b/ui/components/multichain/account-picker/account-picker.js
@@ -4,12 +4,12 @@ import { useSelector } from 'react-redux';
 import { toChecksumHexAddress } from '@metamask/controller-utils';
 import {
   Box,
-  Button,
   AvatarAccount,
   AvatarAccountVariant,
   Icon,
   IconName,
   Text,
+  ButtonBase,
 } from '../../component-library';
 import {
   AlignItems,
@@ -38,7 +38,7 @@ export const AccountPicker = ({
   const shortenedAddress = shortenAddress(toChecksumHexAddress(address));
 
   return (
-    <Button
+    <ButtonBase
       className="multichain-account-picker"
       data-testid="account-menu-icon"
       onClick={onClick}
@@ -87,7 +87,7 @@ export const AccountPicker = ({
           </Text>
         ) : null}
       </Box>
-    </Button>
+    </ButtonBase>
   );
 };
 

--- a/ui/components/multichain/app-header/__snapshots__/app-header.test.js.snap
+++ b/ui/components/multichain/app-header/__snapshots__/app-header.test.js.snap
@@ -228,11 +228,11 @@ exports[`App Header should match snapshot 1`] = `
         </button>
       </div>
       <button
-        class="mm-box mm-text mm-button-base mm-button-base--size-md mm-button-base--ellipsis multichain-account-picker mm-button-primary mm-text--body-md-medium mm-text--ellipsis mm-box--padding-0 mm-box--padding-right-4 mm-box--padding-left-4 mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-primary-inverse mm-box--background-color-transparent mm-box--rounded-lg"
+        class="mm-box mm-text mm-button-base mm-button-base--size-md mm-button-base--ellipsis multichain-account-picker mm-text--body-md-medium mm-text--ellipsis mm-box--padding-0 mm-box--padding-right-4 mm-box--padding-left-4 mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-transparent mm-box--rounded-lg"
         data-testid="account-menu-icon"
       >
         <span
-          class="mm-box mm-text mm-text--inherit mm-text--ellipsis mm-box--display-flex mm-box--gap-2 mm-box--align-items-center mm-box--color-primary-inverse"
+          class="mm-box mm-text mm-text--inherit mm-text--ellipsis mm-box--display-flex mm-box--gap-2 mm-box--align-items-center mm-box--color-text-default"
         >
           <div
             class="mm-box multichain-account-picker-container mm-box--display-flex mm-box--flex-direction-column"


### PR DESCRIPTION
## Explanation

During @NidhiKJha's demo yesterday, I noticed an unwanted highlight effect when hovering over the Account Picker.  Updating the component to use `ButtonBase` fixes the problem.

## Manual Testing Steps

- Hover over the account picker
- Only see a background effect, not an outline effect

## Pre-merge author checklist

- [ ] I've clearly explained:
  - [ ] What problem this PR is solving
  - [ ] How this problem was solved
  - [ ] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
