### PR TITLE
Update network list to use all available screen space

### DIFF
--- a/ui/components/multichain/network-list-menu/index.scss
+++ b/ui/components/multichain/network-list-menu/index.scss
@@ -1,4 +1,10 @@
+.multichain-network-list-menu-content-wrapper {
+  &__dialog {
+    max-height: 100%;
+  }
+}
+
 .multichain-network-list-menu {
-  max-height: 200px;
+  max-height: 100%;
   overflow: auto;
 }

--- a/ui/components/multichain/network-list-menu/network-list-menu.js
+++ b/ui/components/multichain/network-list-menu/network-list-menu.js
@@ -24,6 +24,7 @@ import ToggleButton from '../../ui/toggle-button';
 import {
   BlockSize,
   Display,
+  FlexDirection,
   JustifyContent,
   Size,
   TextColor,
@@ -177,7 +178,12 @@ export const NetworkListMenu = ({ onClose }) => {
       <ModalOverlay />
       <ModalContent
         className="multichain-network-list-menu-content-wrapper"
-        modalDialogProps={{ padding: 0 }}
+        modalDialogProps={{
+          className: 'multichain-network-list-menu-content-wrapper__dialog',
+          display: Display.Flex,
+          flexDirection: FlexDirection.Column,
+          padding: 0,
+        }}
       >
         <ModalHeader
           paddingTop={4}


### PR DESCRIPTION
## Explanation

Currently, the network list inside of the network menu modal is set to a static max height. This limits the amount of networks that can be viewed when there is more screen space available.

This PR updates the `NetworkListMenu` to allow it to dynamically resize and display as many networks as possible within the available space.

* Account menu equivalent: https://github.com/MetaMask/metamask-extension/pull/20745
* See: https://consensys.slack.com/archives/C015BV486HG/p1693499668418789


## Screenshots/Screencaps
Screencasts show the before and after dynamic sizing of the network list

### Before

https://github.com/MetaMask/metamask-extension/assets/8112138/75ff4a3b-d07f-473e-8896-57e6fa97d96a

### After

https://github.com/MetaMask/metamask-extension/assets/8112138/3716bbc0-b182-4430-a2ea-848fd680d82f

## Manual Testing Steps
- Pull this branch/download the build
- Run the extension and open home page
- Open the network menu
- Add many networks
- View the network menu in popup and expanded view
- Resize the browser and see the dynamic sizing of the account list

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
