### PR TITLE
Fix: Unable to edit token allowance / custom spending cap

### DIFF
--- a/ui/components/app/custom-spending-cap/custom-spending-cap.js
+++ b/ui/components/app/custom-spending-cap/custom-spending-cap.js
@@ -141,6 +141,7 @@ export default function CustomSpendingCap({
         setError(spendingCapError);
       }
     }
+
     setCustomSpendingCap(String(valueInput));
     dispatch(setCustomTokenAmount(String(valueInput)));
 

--- a/ui/pages/token-allowance/__snapshots__/token-allowance.test.js.snap
+++ b/ui/pages/token-allowance/__snapshots__/token-allowance.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`TokenAllowancePage should match snapshot 1`] = `
+exports[`TokenAllowancePage when mounted should match snapshot 1`] = `
 <div>
   <div
     class="box token-allowance-container page-container box--flex-direction-row"
@@ -376,6 +376,11 @@ exports[`TokenAllowancePage should match snapshot 1`] = `
               </div>
             </div>
           </div>
+          <button
+            class="mm-box mm-text mm-button-base mm-button-link mm-button-link--size-auto mm-text--body-md-medium mm-box--margin-left-auto mm-box--padding-0 mm-box--padding-right-0 mm-box--padding-left-0 mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-primary-default mm-box--background-color-transparent"
+          >
+            Use site suggestion
+          </button>
         </div>
         <div
           class="box mm-text-field mm-text-field--size-md mm-text-field--focused mm-text-field--truncate box--padding-right-4 box--display-inline-flex box--flex-direction-row box--align-items-center box--width-full box--background-color-background-default box--rounded-sm box--border-width-1 box--border-style-solid"
@@ -388,7 +393,7 @@ exports[`TokenAllowancePage should match snapshot 1`] = `
             id="custom-spending-cap"
             placeholder="Enter a number"
             type="text"
-            value="7"
+            value="1"
           />
           <button
             class="mm-box mm-text mm-button-base mm-button-link mm-button-link--size-auto mm-text--body-md-medium mm-box--padding-0 mm-box--padding-right-0 mm-box--padding-left-0 mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-primary-default mm-box--background-color-transparent"
@@ -406,7 +411,7 @@ exports[`TokenAllowancePage should match snapshot 1`] = `
             <span
               class="mm-box mm-text mm-text--body-sm-bold mm-box--color-text-default"
             >
-              7
+              1
                
               TST
             </span>

--- a/ui/pages/token-allowance/token-allowance.js
+++ b/ui/pages/token-allowance/token-allowance.js
@@ -25,6 +25,7 @@ import ReviewSpendingCap from '../../components/ui/review-spending-cap/review-sp
 import { PageContainerFooter } from '../../components/ui/page-container';
 import ContractDetailsModal from '../../components/app/modals/contract-details-modal/contract-details-modal';
 import {
+  getCustomTokenAmount,
   getNetworkIdentifier,
   transactionFeeSelector,
   getKnownMethodData,
@@ -109,9 +110,9 @@ export default function TokenAllowance({
   const { hostname } = new URL(origin);
   const thisOriginIsAllowedToSkipFirstPage = ALLOWED_HOSTS.includes(hostname);
 
-  const [customSpendingCap, setCustomSpendingCap] = useState(
-    dappProposedTokenAmount,
-  );
+  const customTokenAmount = useSelector(getCustomTokenAmount);
+  const [customSpendingCap, setCustomSpendingCap] = useState(customTokenAmount);
+
   const [showContractDetails, setShowContractDetails] = useState(false);
   const [inputChangeInProgress, setInputChangeInProgress] = useState(false);
   const [showFullTxDetails, setShowFullTxDetails] = useState(false);
@@ -135,6 +136,20 @@ export default function TokenAllowance({
   const useCurrencyRateCheck = useSelector(getUseCurrencyRateCheck);
   const nextNonce = useSelector(getNextSuggestedNonce);
   const customNonceValue = useSelector(getCustomNonceValue);
+
+  const initializeCustomSpendingCap = () => {
+    if (
+      (!customSpendingCap || customSpendingCap === '') &&
+      dappProposedTokenAmount
+    ) {
+      setCustomSpendingCap(dappProposedTokenAmount);
+    }
+  };
+
+  useEffect(() => {
+    initializeCustomSpendingCap();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const replaceCommaToDot = (inputValue) => {
     return inputValue.replace(/,/gu, '.');

--- a/ui/pages/token-allowance/token-allowance.js
+++ b/ui/pages/token-allowance/token-allowance.js
@@ -137,6 +137,10 @@ export default function TokenAllowance({
   const nextNonce = useSelector(getNextSuggestedNonce);
   const customNonceValue = useSelector(getCustomNonceValue);
 
+  /**
+   * We set the customSpendingCap to the dappProposedTokenAmount, if provided, rather than setting customTokenAmount
+   * because customTokenAmount is reserved for custom user input. This is only set once when the component is mounted.
+   */
   const initializeCustomSpendingCap = () => {
     if (
       (!customSpendingCap || customSpendingCap === '') &&

--- a/ui/pages/token-allowance/token-allowance.test.js
+++ b/ui/pages/token-allowance/token-allowance.test.js
@@ -375,7 +375,7 @@ describe('TokenAllowancePage', () => {
     expect(getByText('Function: Approve')).toBeInTheDocument();
   });
 
-  it('should click Use site suggestion and set input value to default', () => {
+  it('should click "Use site suggestion" and set input value to dappProposedTokenAmount', () => {
     mockedState.appState.customTokenAmount = '';
 
     const { getByText, getByTestId } = renderWithProvider(

--- a/ui/pages/token-allowance/token-allowance.test.js
+++ b/ui/pages/token-allowance/token-allowance.test.js
@@ -225,12 +225,11 @@ describe('TokenAllowancePage', () => {
       const input = getByTestId('custom-spending-cap-input');
       expect(input.value).toBe('7');
 
-      // FIXME: This test is flaky
-      // waitFor(() => {
-      //   expect(
-      //     container.querySelector('.mm-help-text .mm-text').innerText,
-      //   ).toContain('7 TST');
-      // });
+      waitFor(() => {
+        expect(
+          container.querySelector('.mm-help-text .mm-text')?.innerText,
+        ).toContain('7 TST');
+      });
     });
   });
 

--- a/ui/pages/token-allowance/token-allowance.test.js
+++ b/ui/pages/token-allowance/token-allowance.test.js
@@ -375,8 +375,7 @@ describe('TokenAllowancePage', () => {
     expect(getByText('Function: Approve')).toBeInTheDocument();
   });
 
-  /** FIXME: Running this test by itself will pass, but running it with the rest of the tests will fail. */
-  it.skip('should click Use site suggestion and set input value to default', () => {
+  it('should click Use site suggestion and set input value to default', () => {
     mockedState.appState.customTokenAmount = '';
 
     const { getByText, getByTestId } = renderWithProvider(

--- a/ui/pages/token-allowance/token-allowance.test.js
+++ b/ui/pages/token-allowance/token-allowance.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import configureMockStore from 'redux-mock-store';
-import { act, fireEvent, waitFor } from '@testing-library/react';
+import { act, fireEvent } from '@testing-library/react';
 import thunk from 'redux-thunk';
 import { NetworkType } from '@metamask/controller-utils';
 import { NetworkStatus } from '@metamask/network-controller';
@@ -214,7 +214,7 @@ describe('TokenAllowancePage', () => {
     it('should load the page with dappProposedAmount prefilled and "Use site suggestion" should not be displayed', () => {
       mockedState.appState.customTokenAmount = '';
 
-      const { container, queryByText, getByTestId } = renderWithProvider(
+      const { queryByText, getByTestId } = renderWithProvider(
         <TokenAllowance {...props} />,
         configureMockStore([thunk])(mockedState),
       );
@@ -224,12 +224,6 @@ describe('TokenAllowancePage', () => {
 
       const input = getByTestId('custom-spending-cap-input');
       expect(input.value).toBe('7');
-
-      waitFor(() => {
-        expect(
-          container.querySelector('.mm-help-text .mm-text')?.innerText,
-        ).toContain('7 TST');
-      });
     });
   });
 

--- a/ui/pages/token-allowance/token-allowance.test.js
+++ b/ui/pages/token-allowance/token-allowance.test.js
@@ -225,11 +225,12 @@ describe('TokenAllowancePage', () => {
       const input = getByTestId('custom-spending-cap-input');
       expect(input.value).toBe('7');
 
-      waitFor(() => {
-        expect(
-          container.querySelector('.mm-help-text .mm-text').innerText,
-        ).toContain('7 TST');
-      });
+      // FIXME: This test is flaky
+      // waitFor(() => {
+      //   expect(
+      //     container.querySelector('.mm-help-text .mm-text').innerText,
+      //   ).toContain('7 TST');
+      // });
     });
   });
 
@@ -381,7 +382,7 @@ describe('TokenAllowancePage', () => {
     expect(getByText('Function: Approve')).toBeInTheDocument();
   });
 
-  /** @fixme Running this test by itself will pass, but running it with the rest of the tests will fail. */
+  /** FIXME: Running this test by itself will pass, but running it with the rest of the tests will fail. */
   it.skip('should click Use site suggestion and set input value to default', () => {
     mockedState.appState.customTokenAmount = '';
 


### PR DESCRIPTION
## Explanation

Fixes https://github.com/MetaMask/metamask-extension/issues/20649

This fix involves decoupling customSpendingCap from the dappProposedTokenAmount. customSpendingCap can now accept changes. customSpendingCap will be set as dappProposedTokenAmount on load if it is empty. 


## Screenshots/Screencaps

<!-- If you're making a change to the UI, make sure to capture a screenshot or a short video showing off your work! -->

### Before

<!-- How did the UI you changed look before your changes? Drag your file(s) below this line: -->

### After

<!-- How does it look now? Drag your file(s) below this line: -->

## Manual Testing Steps

<!--
How should reviewers and QA manually test your changes? For instance:

- Go to this screen
- Do this
- Then do this
-->

## Pre-merge author checklist

- [ ] I've clearly explained:
  - [ ] What problem this PR is solving
  - [ ] How this problem was solved
  - [ ] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
