### PR TITLE
Fix broken `approveTokenDescriptionWithoutSymbol` translation key

### DIFF
--- a/app/_locales/fr/messages.json
+++ b/app/_locales/fr/messages.json
@@ -416,7 +416,7 @@
     "message": "Tant que vous n’aurez pas révoqué cette autorisation, l’autre partie pourra accéder à votre portefeuille et transférer sans préavis les NFT suivants."
   },
   "approveTokenDescriptionWithoutSymbol": {
-    "message": "Tant que vous n’aurez pas révoqué cette autorisation, l’autre partie pourra accéder à votre portefeuille et transférer sans préavis les NFT via $1$.",
+    "message": "Tant que vous n’aurez pas révoqué cette autorisation, l’autre partie pourra accéder à votre portefeuille et transférer sans préavis les NFT via $1.",
     "description": "$1 is a link to contract on the block explorer when we're not able to retrieve a erc721 or erc1155 name"
   },
   "approveTokenTitle": {


### PR DESCRIPTION
## Explanation

The broken translation message in `approveTokenDescriptionWithoutSymbol` was reintroduced by https://github.com/MetaMask/metamask-extension/issues/20563 after https://github.com/MetaMask/metamask-extension/pull/20606 fixes it.

This fixes it another time.