### PR TITLE
Only show enabled insight snaps on the confirmation screen

### DIFF
--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -936,8 +936,17 @@ export const getSnap = createDeepEqualSelector(
   },
 );
 
+export const getEnabledSnaps = createDeepEqualSelector(getSnaps, (snaps) => {
+  return Object.values(snaps).reduce((acc, cur) => {
+    if (cur.enabled) {
+      acc[cur.id] = cur;
+    }
+    return acc;
+  }, {});
+});
+
 export const getInsightSnaps = createDeepEqualSelector(
-  getSnaps,
+  getEnabledSnaps,
   getPermissionSubjects,
   (snaps, subjects) => {
     return Object.values(snaps).filter(


### PR DESCRIPTION
## Explanation

Adds a `getEnabledSnaps` selector and uses that for selecting which insight snaps to use, this prevents an issue where disabled snaps would still show up in the insight dropdown.

Fixes https://github.com/MetaMask/metamask-extension/issues/20730
