### PR TITLE
Use first non-symbol character as snap fallback icon

### DIFF
--- a/ui/components/app/snaps/snap-avatar/snap-avatar.js
+++ b/ui/components/app/snaps/snap-avatar/snap-avatar.js
@@ -37,12 +37,8 @@ const SnapAvatar = ({
 
   const iconUrl = subjectMetadata?.iconUrl;
 
-  const firstCharacterIndex = friendlyName?.[0] === '@' ? 1 : 0;
-
-  const fallbackIcon =
-    friendlyName && friendlyName[firstCharacterIndex]
-      ? friendlyName[firstCharacterIndex]
-      : '?';
+  // We choose the first non-symbol char as the fallback icon.
+  const fallbackIcon = friendlyName?.match(/[a-z0-9]/iu)?.[0] ?? '?';
 
   return (
     <BadgeWrapper

--- a/ui/components/app/snaps/snap-avatar/snap-avatar.js
+++ b/ui/components/app/snaps/snap-avatar/snap-avatar.js
@@ -37,7 +37,12 @@ const SnapAvatar = ({
 
   const iconUrl = subjectMetadata?.iconUrl;
 
-  const fallbackIcon = friendlyName && friendlyName[0] ? friendlyName[0] : '?';
+  const firstCharacterIndex = friendlyName?.[0] === '@' ? 1 : 0;
+
+  const fallbackIcon =
+    friendlyName && friendlyName[firstCharacterIndex]
+      ? friendlyName[firstCharacterIndex]
+      : '?';
 
   return (
     <BadgeWrapper


### PR DESCRIPTION
## Explanation
We now use the first non-symbol character as the snap fallback icon. This prevents an issue where often the fallback icon would be `@`.

Fixes https://github.com/MetaMask/MetaMask-planning/issues/1293