### PR TITLE
Fix spacing on connected sites in the snap details page

### DIFF
--- a/ui/components/app/connected-sites-list/connected-sites-list.component.js
+++ b/ui/components/app/connected-sites-list/connected-sites-list.component.js
@@ -4,7 +4,7 @@ import Button from '../../ui/button';
 import { AvatarFavicon } from '../../component-library';
 import { stripHttpsSchemeWithoutPort } from '../../../helpers/utils/util';
 import SiteOrigin from '../../ui/site-origin';
-import { BorderColor, Size } from '../../../helpers/constants/design-system';
+import { Size } from '../../../helpers/constants/design-system';
 
 export default class ConnectedSitesList extends Component {
   static contextTypes = {
@@ -35,7 +35,6 @@ export default class ConnectedSitesList extends Component {
           >
             <div className="connected-sites-list__subject-info">
               <AvatarFavicon
-                borderColor={BorderColor.borderMuted}
                 className="connected-sites-list__subject-icon"
                 name={subject.name}
                 size={Size.MD}

--- a/ui/pages/settings/snaps/view-snap/index.scss
+++ b/ui/pages/settings/snaps/view-snap/index.scss
@@ -37,7 +37,7 @@
   .connected-sites-list {
     &__content-row {
       border-top: none;
-      padding: 0;
+      padding: 0 0 8px 0;
 
       & &-link-button {
         padding: 0;

--- a/ui/pages/settings/snaps/view-snap/view-snap.js
+++ b/ui/pages/settings/snaps/view-snap/view-snap.js
@@ -156,7 +156,7 @@ function ViewSnap() {
         />
       </Box>
       <Box className="view-snap__connected-sites" marginTop={12}>
-        <Text variant={TextVariant.bodyLgMedium} marginBottom={4}>
+        <Text variant={TextVariant.bodyLgMedium} marginBottom={2}>
           {t('connectedSites')}
         </Text>
         <ConnectedSitesList


### PR DESCRIPTION
## Explanation

Fixes spacing on connected sites in the snap details page, also removes an unexpected border color at the request of @eriknson.

Fixes https://github.com/MetaMask/metamask-extension/issues/20731

## Screenshots/Screencaps

<!-- If you're making a change to the UI, make sure to capture a screenshot or a short video showing off your work! -->

### Before

![image](https://github.com/MetaMask/metamask-extension/assets/1561200/4b38c432-0a15-4166-b785-71faa283c779)

### After

![image](https://github.com/MetaMask/metamask-extension/assets/1561200/10398bd2-a8d1-4d0c-94eb-5d8e2f1f9748)
