### PR TITLE
UX: Set initial background color to system theme

### DIFF
--- a/ui/css/base-styles.scss
+++ b/ui/css/base-styles.scss
@@ -17,6 +17,30 @@ body {
 
 html {
   min-height: 500px;
+
+  @include screen-sm-max {
+    &:not([data-theme]) {
+      background-color: var(--color-background-default);
+    }
+  }
+
+  /*
+    Until we get the user's preference from React state,
+    assume the user is in dark mode, because the default
+    theme is system preference
+  */
+  @media (prefers-color-scheme: dark) {
+    &:not([data-theme]) {
+      color: var(--brand-colors-white-white000);
+      background-color: var(--brand-colors-grey-grey900);
+    }
+
+    @include screen-sm-max {
+      &:not([data-theme]) {
+        background-color: var(--brand-colors-grey-grey800);
+      }
+    }
+  }
 }
 
 .mouse-user-styles {
@@ -47,10 +71,15 @@ html {
   height: 100%;
   display: flex;
   flex-direction: column;
-  background: var(--color-background-alternative);
+
+  html[data-theme] & {
+    background: var(--color-background-alternative);
+  }
 
   @include screen-sm-max {
-    background-color: var(--color-background-default);
+    html[data-theme] & {
+      background-color: var(--color-background-default);
+    }
   }
 }
 /* stylelint-enable */


### PR DESCRIPTION
## Explanation

Contains the initial CSS loading screen color fixes from https://github.com/MetaMask/metamask-extension/pull/20328

This pull request sets the initial background color of the home screen, popup, and notifications to the system color to avoid an ugly flash upon initial load.

## Screenshots/Screencaps

### Before

https://images.zenhubusercontent.com/42009758/88806063-b72f-4985-8a9a-b7a22c2094dc/screen_recording_2023_07_13_at_7_07_47_pm.mov

### After

https://github.com/MetaMask/metamask-extension/assets/46655/9feeedfa-b0da-41fe-bec1-62002af4b78b


## Manual Testing Steps

1.  Set your system preference (in your OS settings) to dark
2. Open the extension popup -- see dark background immediately
3. (repeat for light mode, but see light background immediately)

## Pre-merge author checklist

- [ ] I've clearly explained:
  - [ ] What problem this PR is solving
  - [ ] How this problem was solved
  - [ ] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
