### PR TITLE
fix: tweak fitness function rule for mocha tests

### DIFF
--- a/development/fitness-functions/common/shared.ts
+++ b/development/fitness-functions/common/shared.ts
@@ -32,6 +32,14 @@ function filterDiffByFilePath(diff: string, regex: string): string {
   return filteredDiff;
 }
 
+// This function returns all lines that are additions to files that are being
+// modified but that previously already existed. Example:
+// diff --git a/test.js b/test.js
+// index 0000000000..872e0d8293
+// --- /dev/null
+// +++ b/test.js
+// @@ -0,0 +1 @@
+// +new line change to a previously existing file
 function filterDiffLineAdditions(diff: string): string {
   const diffLines = diff.split('\n');
 
@@ -44,6 +52,15 @@ function filterDiffLineAdditions(diff: string): string {
   return diffAdditionLines.join('/n');
 }
 
+// This function returns all lines that are additions to new files that are being
+// created. Example:
+// diff --git a/test.js b/test.js
+// new file mode 100644
+// index 0000000000..872e0d8293
+// --- /dev/null
+// +++ b/test.js
+// @@ -0,0 +1 @@
+// +new line change as the new file is created
 function filterDiffFileCreations(diff: string): string {
   // split by `diff --git` and remove the first element which is empty
   const diffBlocks = diff.split(`diff --git`).slice(1);
@@ -91,7 +108,7 @@ function hasNumberOfCodeBlocksIncreased(
 
 export {
   filterDiffByFilePath,
-  filterDiffLineAdditions,
   filterDiffFileCreations,
+  filterDiffLineAdditions,
   hasNumberOfCodeBlocksIncreased,
 };

--- a/development/fitness-functions/rules/sinon-assert-syntax.test.ts
+++ b/development/fitness-functions/rules/sinon-assert-syntax.test.ts
@@ -1,4 +1,7 @@
-import { generateModifyFilesDiff } from '../common/test-data';
+import {
+  generateCreateFileDiff,
+  generateModifyFilesDiff,
+} from '../common/test-data';
 import { preventSinonAssertSyntax } from './sinon-assert-syntax';
 
 describe('preventSinonAssertSyntax()', (): void => {
@@ -10,7 +13,7 @@ describe('preventSinonAssertSyntax()', (): void => {
     expect(hasRulePassed).toBe(true);
   });
 
-  it('should not pass when receiving a diff with one of the blocked expressions', (): void => {
+  it('should pass when receiving a diff with an existing file with one of the blocked expressions', (): void => {
     const infringingExpression = 'assert.equal';
     const testDiff = [
       generateModifyFilesDiff('new-file.ts', 'foo', 'bar'),
@@ -19,6 +22,22 @@ describe('preventSinonAssertSyntax()', (): void => {
         'test.js',
         `yada yada ${infringingExpression} yada yada`,
         undefined,
+      ),
+    ].join('');
+
+    const hasRulePassed = preventSinonAssertSyntax(testDiff);
+
+    expect(hasRulePassed).toBe(true);
+  });
+
+  it('should not pass when receiving a diff with a new file with one of the blocked expressions', (): void => {
+    const infringingExpression = 'assert.equal';
+    const testDiff = [
+      generateModifyFilesDiff('new-file.ts', 'foo', 'bar'),
+      generateCreateFileDiff('old-file.js', 'pong'),
+      generateCreateFileDiff(
+        'test.js',
+        `yada yada ${infringingExpression} yada yada`,
       ),
     ].join('');
 

--- a/development/fitness-functions/rules/sinon-assert-syntax.ts
+++ b/development/fitness-functions/rules/sinon-assert-syntax.ts
@@ -1,7 +1,7 @@
 import { EXCLUDE_E2E_TESTS_REGEX } from '../common/constants';
 import {
-  filterDiffLineAdditions,
   filterDiffByFilePath,
+  filterDiffFileCreations,
   hasNumberOfCodeBlocksIncreased,
 } from '../common/shared';
 
@@ -16,7 +16,7 @@ const codeBlocks = [
 
 function preventSinonAssertSyntax(diff: string): boolean {
   const diffByFilePath = filterDiffByFilePath(diff, EXCLUDE_E2E_TESTS_REGEX);
-  const diffAdditions = filterDiffLineAdditions(diffByFilePath);
+  const diffAdditions = filterDiffFileCreations(diffByFilePath);
   const hashmap = hasNumberOfCodeBlocksIncreased(diffAdditions, codeBlocks);
 
   const haveOccurencesOfAtLeastOneCodeBlockIncreased =


### PR DESCRIPTION
## Explanation

The fitness function framework promotes an evolutionary view of the code quality and architecture of the extension.

Two important helper functions for fitness function rules are `filterDiffLineAdditions` and `filterDiffFileCreations`. The first filters the git diff for line additions in existing files. The second method filters line changes for new files only. And since we are encouraging a progressive adoption of the framework, `filterDiffFileCreations` is the function we will want to rely on for most rules.

One of the fitness function rules implemented so far encourages developers to update their tests from the mocha harness to jest. With the existing documentation, it's not always clear to developers how to address these changes -- this will be addressed in a subsequent PR. But in the meantime, this PR changes that rule to be enforced on new files only. This pattern is already used in the other fitness function rule that forbids JavaScript file additions in the `shared` folder but allows changes to existing JavaScript files in the entire repository.

* Fixes #18945