### PR TITLE
Update `useScrollRequired` logic

### DIFF
--- a/ui/hooks/useScrollRequired.js
+++ b/ui/hooks/useScrollRequired.js
@@ -30,11 +30,7 @@ export const useScrollRequired = (dependencies = []) => {
 
     setIsScrollable(isScrollable);
 
-    if (!isScrollable) {
-      setIsScrolledToBottom(true);
-    }
-
-    if (isScrolledToBottom) {
+    if (!isScrollable || isScrolledToBottom) {
       setIsScrolledToBottom(true);
     }
   };

--- a/ui/hooks/useScrollRequired.js
+++ b/ui/hooks/useScrollRequired.js
@@ -16,19 +16,35 @@ export const useScrollRequired = (dependencies = []) => {
   const [isScrolledToBottomState, setIsScrolledToBottom] = useState(false);
 
   const update = () => {
+    if (!ref.current) {
+      return;
+    }
+
     const isScrollable =
       ref.current && ref.current.scrollHeight > ref.current.clientHeight;
-    const isScrolledToBottom = isScrollable
-      ? Math.round(ref.current.scrollTop) + ref.current.offsetHeight >=
-        ref.current.scrollHeight
-      : true;
+
+    const isScrolledToBottom =
+      isScrollable &&
+      Math.round(ref.current.scrollTop) + ref.current.offsetHeight + 16 >=
+        ref.current.scrollHeight;
+
     setIsScrollable(isScrollable);
-    setIsScrolledToBottom(isScrolledToBottom);
+
+    if (!isScrollable) {
+      console.log(ref.current);
+      setIsScrolledToBottom(true);
+    }
+
+    if (isScrolledToBottom) {
+      setIsScrolledToBottom(true);
+    }
   };
 
   useEffect(update, [ref, ...dependencies]);
 
   const scrollToBottom = () => {
+    setIsScrolledToBottom(true);
+
     if (ref.current) {
       ref.current.scrollTo(0, ref.current.scrollHeight);
     }

--- a/ui/hooks/useScrollRequired.js
+++ b/ui/hooks/useScrollRequired.js
@@ -25,6 +25,8 @@ export const useScrollRequired = (dependencies = []) => {
 
     const isScrolledToBottom =
       isScrollable &&
+      // Add 16px to the actual scroll position to trigger setIsScrolledToBottom sooner.
+      // This avoids the problem where a user has scrolled down to the bottom and it's not detected.
       Math.round(ref.current.scrollTop) + ref.current.offsetHeight + 16 >=
         ref.current.scrollHeight;
 

--- a/ui/hooks/useScrollRequired.js
+++ b/ui/hooks/useScrollRequired.js
@@ -31,7 +31,6 @@ export const useScrollRequired = (dependencies = []) => {
     setIsScrollable(isScrollable);
 
     if (!isScrollable) {
-      console.log(ref.current);
       setIsScrolledToBottom(true);
     }
 

--- a/ui/pages/permissions-connect/snaps/snap-install/snap-install.js
+++ b/ui/pages/permissions-connect/snaps/snap-install/snap-install.js
@@ -120,7 +120,7 @@ export default function SnapInstall({
         <SnapAuthorshipHeader snapId={targetSubjectMetadata.origin} />
       )}
       <Box
-        ref={ref}
+        ref={!isLoading && !hasError ? ref : undefined}
         onScroll={onScroll}
         className="snap-install__content"
         style={{


### PR DESCRIPTION
## Explanation

This changes the logic so a user only needs to scroll to the bottom once to continue

to prevent other potential scroll bugs, a click on the scroll-down button will also allow the user to continue (even if something is not working with the scroll)

It also adds a 16px buffer on the scroll to prevent bugs with it.

* Fixes #20882

## Manual Testing Steps

- Go to the install snap screen with a long list of permissions
- Look at the scrolling behaviour