### PR TITLE
fix: the Snap npm link now leads to a specific version of the npm package

### DIFF
--- a/ui/components/app/snaps/snap-authorship-expanded/snap-authorship-expanded.js
+++ b/ui/components/app/snaps/snap-authorship-expanded/snap-authorship-expanded.js
@@ -1,38 +1,36 @@
-import React from 'react';
-import PropTypes from 'prop-types';
-import classnames from 'classnames';
 import { getSnapPrefix } from '@metamask/snaps-utils';
+import classnames from 'classnames';
+import PropTypes from 'prop-types';
+import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import Box from '../../../ui/box';
 import {
-  BackgroundColor,
-  TextColor,
-  FLEX_DIRECTION,
-  TextVariant,
-  BorderColor,
   AlignItems,
-  DISPLAY,
-  BLOCK_SIZES,
-  JustifyContent,
+  BackgroundColor,
+  BlockSize,
+  BorderColor,
+  BorderRadius,
   BorderStyle,
   Color,
-  BorderRadius,
+  Display,
+  FlexDirection,
   FontWeight,
+  JustifyContent,
+  TextColor,
+  TextVariant,
 } from '../../../../helpers/constants/design-system';
 import {
   formatDate,
   getSnapName,
   removeSnapIdPrefix,
 } from '../../../../helpers/utils/util';
-
-import { ButtonLink, Text } from '../../../component-library';
-import { getTargetSubjectMetadata } from '../../../../selectors';
-import SnapAvatar from '../snap-avatar';
 import { useI18nContext } from '../../../../hooks/useI18nContext';
-import Tooltip from '../../../ui/tooltip/tooltip';
-import ToggleButton from '../../../ui/toggle-button';
-import { disableSnap, enableSnap } from '../../../../store/actions';
 import { useOriginMetadata } from '../../../../hooks/useOriginMetadata';
+import { getTargetSubjectMetadata } from '../../../../selectors';
+import { disableSnap, enableSnap } from '../../../../store/actions';
+import { Box, ButtonLink, Text } from '../../../component-library';
+import ToggleButton from '../../../ui/toggle-button';
+import Tooltip from '../../../ui/tooltip/tooltip';
+import SnapAvatar from '../snap-avatar';
 import SnapVersion from '../snap-version/snap-version';
 
 const SnapAuthorshipExpanded = ({ snapId, className, snap }) => {
@@ -47,7 +45,7 @@ const SnapAuthorshipExpanded = ({ snapId, className, snap }) => {
   const packageName = snapId && removeSnapIdPrefix(snapId);
   const isNPM = snapPrefix === 'npm:';
   const url = isNPM
-    ? `https://www.npmjs.com/package/${packageName}`
+    ? `https://www.npmjs.com/package/${packageName}/v/${snap?.version}`
     : packageName;
 
   const subjectMetadata = useSelector((state) =>
@@ -76,13 +74,13 @@ const SnapAuthorshipExpanded = ({ snapId, className, snap }) => {
       backgroundColor={BackgroundColor.backgroundDefault}
       borderColor={BorderColor.borderDefault}
       borderWidth={1}
-      width={BLOCK_SIZES.FULL}
+      width={BlockSize.Full}
       borderRadius={BorderRadius.LG}
     >
       <Box
         alignItems={AlignItems.center}
-        display={DISPLAY.FLEX}
-        width={BLOCK_SIZES.FULL}
+        display={Display.Flex}
+        width={BlockSize.Full}
         paddingLeft={4}
         paddingRight={4}
         paddingTop={3}
@@ -94,8 +92,8 @@ const SnapAuthorshipExpanded = ({ snapId, className, snap }) => {
         <Box
           marginLeft={4}
           marginRight={0}
-          display={DISPLAY.FLEX}
-          flexDirection={FLEX_DIRECTION.COLUMN}
+          display={Display.Flex}
+          flexDirection={FlexDirection.Column}
           style={{ overflow: 'hidden' }}
         >
           <Text ellipsis fontWeight={FontWeight.Medium}>
@@ -110,69 +108,67 @@ const SnapAuthorshipExpanded = ({ snapId, className, snap }) => {
           </Text>
         </Box>
       </Box>
-      <Box flexDirection={FLEX_DIRECTION.COLUMN} width={BLOCK_SIZES.FULL}>
-        <Box
-          flexDirection={FLEX_DIRECTION.ROW}
-          justifyContent={JustifyContent.spaceBetween}
-          paddingLeft={4}
-          paddingTop={4}
-          paddingBottom={4}
-          borderColor={BorderColor.borderDefault}
-          width={BLOCK_SIZES.FULL}
-          style={{
-            borderLeft: BorderStyle.none,
-            borderRight: BorderStyle.none,
-          }}
-        >
-          <Text variant={TextVariant.bodyMd} fontWeight={FontWeight.Medium}>
-            {t('enabled')}
-          </Text>
-          <Box style={{ maxWidth: '52px' }}>
-            <Tooltip interactive position="left" html={t('snapsToggle')}>
-              <ToggleButton value={snap?.enabled} onToggle={onToggle} />
-            </Tooltip>
-          </Box>
+      <Box
+        display={Display.Flex}
+        flexDirection={FlexDirection.Row}
+        justifyContent={JustifyContent.spaceBetween}
+        paddingLeft={4}
+        paddingTop={4}
+        paddingBottom={4}
+        borderColor={BorderColor.borderDefault}
+        width={BlockSize.Full}
+        style={{
+          borderLeft: BorderStyle.none,
+          borderRight: BorderStyle.none,
+        }}
+      >
+        <Text variant={TextVariant.bodyMd} fontWeight={FontWeight.Medium}>
+          {t('enabled')}
+        </Text>
+        <Box style={{ maxWidth: '52px' }}>
+          <Tooltip interactive position="left" html={t('snapsToggle')}>
+            <ToggleButton value={snap?.enabled} onToggle={onToggle} />
+          </Tooltip>
         </Box>
-        <Box
-          flexDirection={FLEX_DIRECTION.COLUMN}
-          padding={4}
-          width={BLOCK_SIZES.FULL}
-        >
-          {installOrigin && installInfo && (
-            <Box
-              flexDirection={FLEX_DIRECTION.ROW}
-              justifyContent={JustifyContent.spaceBetween}
-              width={BLOCK_SIZES.FULL}
-            >
-              <Text variant={TextVariant.bodyMd} fontWeight={FontWeight.Medium}>
-                {t('installOrigin')}
-              </Text>
-              <Box
-                flexDirection={FLEX_DIRECTION.COLUMN}
-                alignItems={AlignItems.flexEnd}
-              >
-                <ButtonLink href={installOrigin.origin} target="_blank">
-                  {installOrigin.host}
-                </ButtonLink>
-                <Text color={Color.textMuted}>
-                  {t('installedOn', [
-                    formatDate(installInfo.date, 'dd MMM yyyy'),
-                  ])}
-                </Text>
-              </Box>
-            </Box>
-          )}
+      </Box>
+      <Box padding={4} width={BlockSize.Full}>
+        {installOrigin && installInfo && (
           <Box
-            flexDirection={FLEX_DIRECTION.ROW}
+            display={Display.Flex}
+            flexDirection={FlexDirection.Row}
             justifyContent={JustifyContent.spaceBetween}
-            alignItems={AlignItems.center}
-            marginTop={4}
+            width={BlockSize.Full}
           >
             <Text variant={TextVariant.bodyMd} fontWeight={FontWeight.Medium}>
-              {t('version')}
+              {t('installOrigin')}
             </Text>
-            <SnapVersion version={snap?.version} url={url} />
+            <Box
+              display={Display.Flex}
+              flexDirection={FlexDirection.Column}
+              alignItems={AlignItems.flexEnd}
+            >
+              <ButtonLink href={installOrigin.origin} target="_blank">
+                {installOrigin.host}
+              </ButtonLink>
+              <Text color={Color.textMuted}>
+                {t('installedOn', [
+                  formatDate(installInfo.date, 'dd MMM yyyy'),
+                ])}
+              </Text>
+            </Box>
           </Box>
+        )}
+        <Box
+          display={Display.Flex}
+          flexDirection={FlexDirection.Row}
+          justifyContent={JustifyContent.spaceBetween}
+          alignItems={AlignItems.center}
+          marginTop={4}
+        >
+          <Text variant={TextVariant.bodyMd} fontWeight={FontWeight.Medium}>
+            {t('version')}
+          </Text>
+          <SnapVersion version={snap?.version} url={url} />
         </Box>
       </Box>
     </Box>

--- a/ui/components/app/snaps/snap-authorship-expanded/snap-authorship-expanded.js
+++ b/ui/components/app/snaps/snap-authorship-expanded/snap-authorship-expanded.js
@@ -44,8 +44,10 @@ const SnapAuthorshipExpanded = ({ snapId, className, snap }) => {
   const snapPrefix = snapId && getSnapPrefix(snapId);
   const packageName = snapId && removeSnapIdPrefix(snapId);
   const isNPM = snapPrefix === 'npm:';
+
+  const versionPath = snap?.version ? `/v/${snap?.version}` : '';
   const url = isNPM
-    ? `https://www.npmjs.com/package/${packageName}/v/${snap?.version}`
+    ? `https://www.npmjs.com/package/${packageName}${versionPath}`
     : packageName;
 
   const subjectMetadata = useSelector((state) =>

--- a/ui/components/app/snaps/snap-authorship-header/snap-authorship-header.js
+++ b/ui/components/app/snaps/snap-authorship-header/snap-authorship-header.js
@@ -35,13 +35,14 @@ const SnapAuthorshipHeader = ({
   const snapPrefix = snapId && getSnapPrefix(snapId);
   const packageName = snapId && removeSnapIdPrefix(snapId);
   const isNPM = snapPrefix === 'npm:';
-  const url = isNPM
-    ? `https://www.npmjs.com/package/${packageName}`
-    : packageName;
 
   const subjectMetadata = useSelector((state) =>
     getTargetSubjectMetadata(state, snapId),
   );
+
+  const url = isNPM
+    ? `https://www.npmjs.com/package/${packageName}/v/${subjectMetadata?.version}`
+    : packageName;
 
   const friendlyName = snapId && getSnapName(snapId, subjectMetadata);
 

--- a/ui/components/app/snaps/snap-authorship-header/snap-authorship-header.js
+++ b/ui/components/app/snaps/snap-authorship-header/snap-authorship-header.js
@@ -40,8 +40,11 @@ const SnapAuthorshipHeader = ({
     getTargetSubjectMetadata(state, snapId),
   );
 
+  const versionPath = subjectMetadata?.version
+    ? `/v/${subjectMetadata?.version}`
+    : '';
   const url = isNPM
-    ? `https://www.npmjs.com/package/${packageName}/v/${subjectMetadata?.version}`
+    ? `https://www.npmjs.com/package/${packageName}${versionPath}`
     : packageName;
 
   const friendlyName = snapId && getSnapName(snapId, subjectMetadata);


### PR DESCRIPTION
These two version links used to say a version (0.1.4 in the screenshots), but then link to the newest version on npm.
Now they link to https://www.npmjs.com/package/@metamask/snap-simple-keyring-snap/v/0.1.4

(also updated the deprecated Design System components in `snap-authorship-expanded.js`)

## Screenshots

![image](https://github.com/MetaMask/metamask-extension/assets/539738/dbdd443c-37f8-4882-8bc9-d5d712f04f71)
![image](https://github.com/MetaMask/metamask-extension/assets/539738/c2057813-bcfd-4d81-9269-2649e748abc9)

## Manual Testing Steps

1. Install the old version of a Snap
2. Check the link as you're installing (first screenshot)
3. Check the link after you've installed (second screenshot)

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [x] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.