### PR TITLE
fix(20799): stack 'App installed' event before user opts in when onboarding

### DIFF
--- a/shared/constants/metametrics.ts
+++ b/shared/constants/metametrics.ts
@@ -525,7 +525,6 @@ export enum MetaMetricsEventName {
   NavSendButtonClicked = 'Send Button Clicked',
   NavSwapButtonClicked = 'Swap Button Clicked',
   NftAdded = 'NFT Added',
-  OnboardingWelcome = 'App Installed',
   OnboardingWalletCreationStarted = 'Wallet Setup Selected',
   OnboardingWalletImportStarted = 'Wallet Import Started',
   OnboardingWalletCreationAttempted = 'Wallet Password Created',

--- a/ui/pages/onboarding-flow/welcome/welcome.js
+++ b/ui/pages/onboarding-flow/welcome/welcome.js
@@ -94,16 +94,6 @@ export default function OnboardingWelcome() {
     history.push(ONBOARDING_METAMETRICS);
   };
 
-  trackEvent({
-    category: MetaMetricsEventCategory.Onboarding,
-    event: MetaMetricsEventName.OnboardingWelcome,
-    properties: {
-      message_title: t('welcomeToMetaMask'),
-      app_version: global?.platform?.getVersion(),
-    },
-    addEventBeforeMetricsOptIn: true,
-  });
-
   return (
     <div className="onboarding-welcome" data-testid="onboarding-welcome">
       <Carousel showThumbs={false} showStatus={false} showArrows>


### PR DESCRIPTION
## Explanation
To fix https://github.com/MetaMask/metamask-extension/pull/20101 and https://github.com/MetaMask/metamask-extension/issues/20799, and achieve only start trackEvent method on ui/pages/onboarding-flow/welcome/welcome.js when user opts in metrics track on onboarding.

In fact, this has been achieved by function `addAppInstalledEvent` in `app/scripts/background.js` as
```
    controller.metaMetricsController.addEventBeforeMetricsOptIn({
      category: MetaMetricsEventCategory.App,
      event: MetaMetricsEventName.AppInstalled,
      properties: {},
    });
```
Which means, when we load the UI => `Let's get started`, the event `MetaMetricsEventName.AppInstalled` is stacked, and this metrics event will only be sent to segment after user choose to opt in.

At the same time, we found the piece of code in `welcome.js` is not necessary because it has been handled when app is loaded, you'll find the removal of this part in the changes. 


<!--
Thanks for the pull request. Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues, Slack conversations, Zendesk issues, user stories, etc. reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

## Screenshots/Screencaps

<!-- If you're making a change to the UI, make sure to capture a screenshot or a short video showing off your work! -->

### Before

<!-- How did the UI you changed look before your changes? Drag your file(s) below this line: -->

### After

https://github.com/MetaMask/metamask-extension/assets/12678455/0f54c8a3-0faf-40b0-bc12-b9d6de369b5a


<!-- How does it look now? Drag your file(s) below this line: -->

## Manual Testing Steps
- Install the unpacked zip
- open dev tool from `background.html`
- inspect the network request with keyword `batch`
- onboard with opting in will see the batch request
- onboard with opting out will not see the request until set in the privacy setting

<!--
How should reviewers and QA manually test your changes? For instance:

- Go to this screen
- Do this
- Then do this
-->

## Pre-merge author checklist

- [ ] I've clearly explained:
  - [ ] What problem this PR is solving
  - [ ] How this problem was solved
  - [ ] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
