### PR TITLE
Fix #20910 - Turn off ENS resolution if IPFS is turned off

### DIFF
--- a/app/scripts/lib/ens-ipfs/setup.js
+++ b/app/scripts/lib/ens-ipfs/setup.js
@@ -59,14 +59,11 @@ export default function setupEnsIpfsResolver({
     const useAddressBarEnsResolution = getUseAddressBarEnsResolution();
 
     const ensSiteUrl = `https://app.ens.domains/name/${name}`;
-    /*
-    if (!useAddressBarEnsResolution || ipfsGateway === '') {
-      return;
-    }
-    */
 
-    if (useAddressBarEnsResolution) {
-      browser.tabs.update(tabId, { url: `loading.html` });
+    // This is the only case where we can show the loading indicator
+    // https://github.com/MetaMask/metamask-extension/issues/20910#issuecomment-1723962822
+    if (useAddressBarEnsResolution && ipfsGateway) {
+      browser.tabs.update(tabId, { url: 'loading.html' });
     }
 
     let url = ensSiteUrl;
@@ -87,6 +84,7 @@ export default function setupEnsIpfsResolver({
         // If the ENS is via IPFS and that setting is disabled,
         // Do not resolve the ENS
         if (ipfsGateway === '') {
+          url = null;
           return;
         }
         const resolvedUrl = `https://${hash}.${type.slice(
@@ -131,7 +129,11 @@ export default function setupEnsIpfsResolver({
     } catch (err) {
       console.warn(err);
     } finally {
-      if (!useAddressBarEnsResolution && url === ensSiteUrl) {
+      if (
+        url &&
+        (useAddressBarEnsResolution ||
+          (!useAddressBarEnsResolution && url !== ensSiteUrl))
+      ) {
         browser.tabs.update(tabId, { url });
       }
     }

--- a/app/scripts/lib/ens-ipfs/setup.js
+++ b/app/scripts/lib/ens-ipfs/setup.js
@@ -58,13 +58,18 @@ export default function setupEnsIpfsResolver({
     const ipfsGateway = getIpfsGateway();
     const useAddressBarEnsResolution = getUseAddressBarEnsResolution();
 
+    const ensSiteUrl = `https://app.ens.domains/name/${name}`;
+    /*
     if (!useAddressBarEnsResolution || ipfsGateway === '') {
       return;
     }
+    */
 
-    browser.tabs.update(tabId, { url: `loading.html` });
+    if (useAddressBarEnsResolution) {
+      browser.tabs.update(tabId, { url: `loading.html` });
+    }
 
-    let url = `https://app.ens.domains/name/${name}`;
+    let url = ensSiteUrl;
 
     // If we're testing ENS domain resolution support,
     // we assume the ENS domains URL
@@ -79,6 +84,11 @@ export default function setupEnsIpfsResolver({
         name,
       });
       if (type === 'ipfs-ns' || type === 'ipns-ns') {
+        // If the ENS is via IPFS and that setting is disabled,
+        // Do not resolve the ENS
+        if (ipfsGateway === '') {
+          return;
+        }
         const resolvedUrl = `https://${hash}.${type.slice(
           0,
           4,
@@ -121,7 +131,9 @@ export default function setupEnsIpfsResolver({
     } catch (err) {
       console.warn(err);
     } finally {
-      browser.tabs.update(tabId, { url });
+      if (!useAddressBarEnsResolution && url === ensSiteUrl) {
+        browser.tabs.update(tabId, { url });
+      }
     }
   }
 }

--- a/app/scripts/lib/ens-ipfs/setup.js
+++ b/app/scripts/lib/ens-ipfs/setup.js
@@ -60,8 +60,7 @@ export default function setupEnsIpfsResolver({
 
     const ensSiteUrl = `https://app.ens.domains/name/${name}`;
 
-    // This is the only case where we can show the loading indicator
-    // https://github.com/MetaMask/metamask-extension/issues/20910#issuecomment-1723962822
+    // We cannot show this if useAddressBarEnsResolution is off...
     if (useAddressBarEnsResolution && ipfsGateway) {
       browser.tabs.update(tabId, { url: 'loading.html' });
     }
@@ -71,7 +70,9 @@ export default function setupEnsIpfsResolver({
     // If we're testing ENS domain resolution support,
     // we assume the ENS domains URL
     if (process.env.IN_TEST) {
-      browser.tabs.update(tabId, { url });
+      if (useAddressBarEnsResolution || ipfsGateway) {
+        browser.tabs.update(tabId, { url });
+      }
       return;
     }
 
@@ -129,6 +130,8 @@ export default function setupEnsIpfsResolver({
     } catch (err) {
       console.warn(err);
     } finally {
+      // Only forward to destination URL if a URL exists and
+      // useAddressBarEnsResolution is properly
       if (
         url &&
         (useAddressBarEnsResolution ||

--- a/test/e2e/tests/ipfs-ens-resolution.spec.js
+++ b/test/e2e/tests/ipfs-ens-resolution.spec.js
@@ -31,7 +31,7 @@ describe('Settings', function () {
     await driver.quit();
   });
 
-  it('Does not lookup IPFS data for ENS Domain when switched off', async function () {
+  it('Does not fetch ENS data for ENS Domain when ENS and IPFS switched off', async function () {
     let server;
 
     await withFixtures(
@@ -54,7 +54,10 @@ describe('Settings', function () {
         await driver.clickElement({ text: 'Settings', tag: 'div' });
         await driver.clickElement({ text: 'Security & privacy', tag: 'div' });
 
-        // turns off IPFS domain resolution
+        // turns off IPFS setting
+        await driver.clickElement('[data-testid="ipfsToggle"] .toggle-button');
+
+        // turns off ENS domain resolution
         await driver.clickElement(
           '[data-testid="ipfs-gateway-resolution-container"] .toggle-button',
         );

--- a/ui/pages/settings/security-tab/security-tab.component.js
+++ b/ui/pages/settings/security-tab/security-tab.component.js
@@ -408,7 +408,6 @@ export default class SecurityTab extends PureComponent {
                 if (value) {
                   // turning from true to false
                   this.props.setIpfsGateway('');
-                  // this.props.setUseAddressBarEnsResolution(false);
                 } else {
                   // turning from false to true
                   handleIpfsGatewayChange(this.state.ipfsGateway);

--- a/ui/pages/settings/security-tab/security-tab.component.js
+++ b/ui/pages/settings/security-tab/security-tab.component.js
@@ -408,6 +408,7 @@ export default class SecurityTab extends PureComponent {
                 if (value) {
                   // turning from true to false
                   this.props.setIpfsGateway('');
+                  this.props.setUseAddressBarEnsResolution(false);
                 } else {
                   // turning from false to true
                   handleIpfsGatewayChange(this.state.ipfsGateway);

--- a/ui/pages/settings/security-tab/security-tab.component.js
+++ b/ui/pages/settings/security-tab/security-tab.component.js
@@ -408,7 +408,7 @@ export default class SecurityTab extends PureComponent {
                 if (value) {
                   // turning from true to false
                   this.props.setIpfsGateway('');
-                  this.props.setUseAddressBarEnsResolution(false);
+                  // this.props.setUseAddressBarEnsResolution(false);
                 } else {
                   // turning from false to true
                   handleIpfsGatewayChange(this.state.ipfsGateway);


### PR DESCRIPTION
## Explanation

* Fixes #20910

When a user turns off the "IPFS gateway" settings, the "Show ENS domains in address bar" setting should also be disabled. 

## Screenshots/Screencaps

https://github.com/MetaMask/metamask-extension/assets/46655/0dd30049-31fa-4921-8bff-d7a8861ec299


## Manual Testing Steps

1.  Open Settings > Security
2. Turn off the "IPFS gateway" toggle
3. The "Show ENS domains in address bar" should also toggle off

## Pre-merge author checklist

- [ ] I've clearly explained:
  - [ ] What problem this PR is solving
  - [ ] How this problem was solved
  - [ ] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
