### PR TITLE
fix: catch the rejection if you submit an incorrect password to "Show private key"

### DIFF
--- a/ui/components/multichain/account-details/account-details-authenticate.js
+++ b/ui/components/multichain/account-details/account-details-authenticate.js
@@ -7,6 +7,8 @@ import {
   Severity,
   TextVariant,
 } from '../../../helpers/constants/design-system';
+import { useI18nContext } from '../../../hooks/useI18nContext';
+import { exportAccount, hideWarning } from '../../../store/actions';
 import {
   BannerAlert,
   Box,
@@ -14,9 +16,6 @@ import {
   ButtonSecondary,
   FormTextField,
 } from '../../component-library';
-
-import { useI18nContext } from '../../../hooks/useI18nContext';
-import { exportAccount, hideWarning } from '../../../store/actions';
 
 export const AccountDetailsAuthenticate = ({
   address,
@@ -35,10 +34,14 @@ export const AccountDetailsAuthenticate = ({
   const onSubmit = useCallback(() => {
     dispatch(
       exportAccount(password, address, setPrivateKey, setShowHoldToReveal),
-    ).then((res) => {
-      dispatch(hideWarning());
-      return res;
-    });
+    )
+      .then((res) => {
+        dispatch(hideWarning());
+        return res;
+      })
+      .catch(() => {
+        // No need to do anything more with the caught error here, we already logged the error
+      });
   }, [dispatch, password, address, setPrivateKey, setShowHoldToReveal]);
 
   const handleKeyPress = useCallback(
@@ -57,7 +60,7 @@ export const AccountDetailsAuthenticate = ({
         id="account-details-authenticate"
         label={t('enterYourPassword')}
         placeholder={t('password')}
-        error={warning}
+        error={Boolean(warning)}
         helpText={warning}
         onChange={(e) => setPassword(e.target.value)}
         value={password}

--- a/ui/pages/keychains/__snapshots__/reveal-seed.test.js.snap
+++ b/ui/pages/keychains/__snapshots__/reveal-seed.test.js.snap
@@ -89,6 +89,7 @@ exports[`Reveal Seed Page should match snapshot 1`] = `
         class="box mm-text-field mm-text-field--size-lg mm-text-field--focused mm-text-field--truncate box--display-inline-flex box--flex-direction-row box--align-items-center box--width-full box--background-color-background-default box--rounded-sm box--border-width-1 box--border-style-solid"
       >
         <input
+          aria-invalid="false"
           autocomplete="off"
           class="mm-box mm-text mm-input mm-input--disable-state-styles mm-text-field__input mm-text--body-md mm-box--margin-0 mm-box--padding-0 mm-box--padding-right-4 mm-box--padding-left-4 mm-box--color-text-default mm-box--background-color-transparent mm-box--border-style-none"
           data-testid="input-password"

--- a/ui/pages/keychains/reveal-seed.js
+++ b/ui/pages/keychains/reveal-seed.js
@@ -133,7 +133,7 @@ export default function RevealSeedPage() {
           size={TEXT_FIELD_SIZES.LG}
           value={password}
           onChange={(event) => setPassword(event.target.value)}
-          error={error}
+          error={Boolean(error)}
           width={BlockSize.Full}
         />
         {error && (


### PR DESCRIPTION
## Explanation

Fixes #20902

Also fixes these warnings that happen if you enter the wrong password
(fix on line 61 `error={Boolean(warning)}`)

![image](https://github.com/MetaMask/metamask-extension/assets/539738/7566e319-90e6-4a4b-810c-60f4b1488362)

## Manual Testing Steps

1. log in to the extension
2. click the account menu icon
3. click the ellipsis icon to the right of the first account in the account list
4. select the Account Details menu item
5. click the Show Private Key button
6. enter an incorrect password, click Confirm
7. wait a few seconds
8. confirm no uncaught errors in the console