### PR TITLE
Stabilize e2e test - Creates multiple queued transactions, then confirm

### DIFF
--- a/test/e2e/tests/multiple-transactions.spec.js
+++ b/test/e2e/tests/multiple-transactions.spec.js
@@ -70,6 +70,9 @@ describe('Multiple transactions', function () {
         await driver.switchToWindow(extensionTab);
         await driver.delay(regularDelayMs);
         await driver.clickElement('[data-testid="home__activity-tab"]');
+        await driver.waitForSelector(
+          '.transaction-list__completed-transactions .activity-list-item:nth-of-type(2)',
+        );
 
         const confirmedTxes = await driver.findElements(
           '.transaction-list__completed-transactions .activity-list-item',


### PR DESCRIPTION
## Explanation

Stabilize e2e test - Creates multiple queued transactions, then confirm.
Fixes #20901 

## Pre-merge author checklist

- [X] I've clearly explained:
  - [X] What problem this PR is solving
  - [X] How this problem was solved
