### PR TITLE
fix: don't render attribute `aria-invalid="false"`

### DIFF
--- a/ui/components/component-library/input/input.tsx
+++ b/ui/components/component-library/input/input.tsx
@@ -47,7 +47,7 @@ export const Input: InputComponent = React.forwardRef(
         },
         className,
       )}
-      {...(error && <>aria-invalid={error}</>)} // This stops it from including the attribute when `aria-invalid="false"`
+      {...(error && { 'aria-invalid': error })}
       as="input"
       autoComplete={autoComplete ? 'on' : 'off'}
       autoFocus={autoFocus}

--- a/ui/components/component-library/input/input.tsx
+++ b/ui/components/component-library/input/input.tsx
@@ -47,7 +47,7 @@ export const Input: InputComponent = React.forwardRef(
         },
         className,
       )}
-      aria-invalid={error}
+      {...(error && <>aria-invalid={error}</>)} // This stops it from including the attribute when `aria-invalid="false"`
       as="input"
       autoComplete={autoComplete ? 'on' : 'off'}
       autoFocus={autoFocus}

--- a/ui/components/component-library/text-field/text-field.js
+++ b/ui/components/component-library/text-field/text-field.js
@@ -113,7 +113,7 @@ export const TextField = ({
     >
       {startAccessory}
       <InputComponent
-        {...(error && <>aria-invalid={error}</>)} // This stops it from including the attribute when `aria-invalid="false"`
+        {...(error && { 'aria-invalid': error })}
         autoComplete={autoComplete}
         autoFocus={autoFocus}
         backgroundColor={BackgroundColor.transparent}

--- a/ui/components/component-library/text-field/text-field.js
+++ b/ui/components/component-library/text-field/text-field.js
@@ -113,7 +113,7 @@ export const TextField = ({
     >
       {startAccessory}
       <InputComponent
-        aria-invalid={error}
+        {...(error && <>aria-invalid={error}</>)} // This stops it from including the attribute when `aria-invalid="false"`
         autoComplete={autoComplete}
         autoFocus={autoFocus}
         backgroundColor={BackgroundColor.transparent}

--- a/ui/pages/keychains/__snapshots__/reveal-seed.test.js.snap
+++ b/ui/pages/keychains/__snapshots__/reveal-seed.test.js.snap
@@ -89,7 +89,6 @@ exports[`Reveal Seed Page should match snapshot 1`] = `
         class="box mm-text-field mm-text-field--size-lg mm-text-field--focused mm-text-field--truncate box--display-inline-flex box--flex-direction-row box--align-items-center box--width-full box--background-color-background-default box--rounded-sm box--border-width-1 box--border-style-solid"
       >
         <input
-          aria-invalid="false"
           autocomplete="off"
           class="mm-box mm-text mm-input mm-input--disable-state-styles mm-text-field__input mm-text--body-md mm-box--margin-0 mm-box--padding-0 mm-box--padding-right-4 mm-box--padding-left-4 mm-box--color-text-default mm-box--background-color-transparent mm-box--border-style-none"
           data-testid="input-password"


### PR DESCRIPTION
## Explanation

The `Input` and `TextField` components both include an `aria-invalid="false"` attribute.

From the [aria-invalid documentation](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-invalid#example):

> Note that since the default value for `aria-invalid` is `false`, it is not strictly necessary to add the attribute to input.

### Before
```
        <input
          aria-invalid="false"
          autocomplete="off"
          ...
        />
```

### After
```
        <input
          autocomplete="off"
          ...
        />
```