### PR TITLE
fix: display msg if tokenId already exists

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -2586,6 +2586,9 @@
     "message": "This token is an NFT. Add on the $1",
     "description": "$1 is a clickable link with text defined by the 'importNFTPage' key"
   },
+  "nftAlreadyAdded": {
+    "message": "NFT has already been added."
+  },
   "nftDisclaimer": {
     "message": "Disclaimer: MetaMask pulls the media file from the source url. This url sometimes is changed by the marketplace the NFT was minted on."
   },

--- a/ui/helpers/utils/util.test.js
+++ b/ui/helpers/utils/util.test.js
@@ -929,4 +929,95 @@ describe('util', () => {
       expect(util.getNetworkNameFromProviderType('rpc')).toStrictEqual('');
     });
   });
+
+  describe('checkTokenIdExists()', () => {
+    const data = {
+      '0x2df920B180c58766951395c26ecF1EC2063490Fa': {
+        collectionName: 'Numbers',
+        nfts: [
+          {
+            address: '0x2df920B180c58766951395c26ecF1EC2063490Fa',
+            description: 'Numbers',
+            favorite: false,
+            name: 'Numbers #132',
+            tokenId: '132',
+          },
+        ],
+      },
+      '0x2df920B180c58766951395c26ecF1EC206343334': {
+        collectionName: 'toto',
+        nfts: [
+          {
+            address: '0x2df920B180c58766951395c26ecF1EC206343334',
+            description: 'toto',
+            favorite: false,
+            name: 'toto#3453',
+            tokenId: '3453',
+          },
+        ],
+      },
+      '0xf4910C763eD4e47A585E2D34baA9A4b611aE448C': {
+        collectionName: 'foo',
+        nfts: [
+          {
+            address: '0xf4910C763eD4e47A585E2D34baA9A4b611aE448C',
+            description: 'foo',
+            favorite: false,
+            name: 'toto#111486581076844052489180254627234340268504869259922513413248833349282110111749',
+            tokenId:
+              '111486581076844052489180254627234340268504869259922513413248833349282110111749',
+          },
+        ],
+      },
+    };
+    it('should return true if it exists', () => {
+      expect(
+        util.checkTokenIdExists(
+          '0x2df920B180c58766951395c26ecF1EC206343334',
+          '3453',
+          data,
+        ),
+      ).toBeTruthy();
+    });
+
+    it('should return true if it exists in decimal format', () => {
+      expect(
+        util.checkTokenIdExists(
+          '0x2df920B180c58766951395c26ecF1EC206343334',
+          '0xD7D',
+          data,
+        ),
+      ).toBeTruthy();
+    });
+
+    it('should return true if is exists but input is not decimal nor hex', () => {
+      expect(
+        util.checkTokenIdExists(
+          '0xf4910C763eD4e47A585E2D34baA9A4b611aE448C',
+          '111486581076844052489180254627234340268504869259922513413248833349282110111749',
+          data,
+        ),
+      ).toBeTruthy();
+    });
+
+    it('should return false if it does not exists', () => {
+      expect(
+        util.checkTokenIdExists(
+          '0x2df920B180c58766951395c26ecF1EC206343334',
+          '1122',
+          data,
+        ),
+      ).toBeFalsy();
+    });
+
+    it('should return false if it address does not exists', () => {
+      expect(
+        util.checkTokenIdExists(
+          '0xB0BdaBea57B0BDABeA57b0bdABEA57b0BDabEa57',
+          '1122',
+          data,
+        ),
+      ).toBeFalsy();
+    });
+  });
 });


### PR DESCRIPTION
## Explanation

This PR adds displaying an error msg when the nft has been already imported.
This avoids seeing the same nft twice when the user first imports tokenId(decimal value) then imports it again (hex value).

* Fixes #MMASSETS-27


## Screenshots/Screencaps

### Before
Github issue : https://github.com/MetaMask/metamask-extension/issues/18957

### After

1- Mint and import nft with id 577

![image](https://github.com/MetaMask/metamask-extension/assets/10994169/229a2ffb-7ab0-4bed-82fc-9ff8f0a8c69e)

2- Try importing Nft again with id 577

![image](https://github.com/MetaMask/metamask-extension/assets/10994169/16106948-2bc2-4e1a-837d-d5073417a2a9)

3- Try importing Nft again with hex value: 0x241

![image](https://github.com/MetaMask/metamask-extension/assets/10994169/f957585d-9b0d-47be-9964-39dfe639170a)


## Manual Testing Steps

<!--
How should reviewers and QA manually test your changes? For instance:

- Mint nft exp id 577
- Import the nft with id 577
- Try importing again with id 577
- Try importing again with 0x241
-->

## Pre-merge author checklist

- [ ] I've clearly explained:
  - [x ] What problem this PR is solving
  - [ x] How this problem was solved
  - [x ] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

