### PR TITLE
add progress of scanning QR code

### DIFF
--- a/ui/components/app/modals/qr-scanner/index.scss
+++ b/ui/components/app/modals/qr-scanner/index.scss
@@ -34,6 +34,23 @@
     }
   }
 
+  &__progress {
+    width: 110px;
+    height: 4px;
+    border-radius: 2px;
+    overflow: hidden;
+    background-color: #dadada;
+    margin: 6px auto 0;
+
+    &::before {
+      content: "";
+      display: block;
+      height: 100%;
+      width: var(--progress);
+      background-color: var(--color-primary-default);
+    }
+  }
+
   &__status {
     @include H6;
 

--- a/ui/components/app/modals/qr-scanner/index.scss
+++ b/ui/components/app/modals/qr-scanner/index.scss
@@ -39,7 +39,7 @@
     height: 4px;
     border-radius: 2px;
     overflow: hidden;
-    background-color: #dadada;
+    background-color: var(--color-border-muted);
     margin: 6px auto 0;
 
     &::before {

--- a/ui/components/app/qr-hardware-popover/base-reader.js
+++ b/ui/components/app/qr-hardware-popover/base-reader.js
@@ -26,6 +26,7 @@ const BaseReader = ({
   const [ready, setReady] = useState(READY_STATE.ACCESSING_CAMERA);
   const [error, setError] = useState(null);
   const [urDecoder, setURDecoder] = useState(new URDecoder());
+  const [progress, setProgress] = useState(0);
 
   let permissionChecker = null;
   const mounted = useRef(false);
@@ -34,6 +35,7 @@ const BaseReader = ({
     setReady(READY_STATE.ACCESSING_CAMERA);
     setError(null);
     setURDecoder(new URDecoder());
+    setProgress(0);
   };
 
   const checkEnvironment = async () => {
@@ -86,6 +88,7 @@ const BaseReader = ({
         return;
       }
       urDecoder.receivePart(data);
+      setProgress(urDecoder.estimatedPercentComplete());
       if (urDecoder.isComplete()) {
         const result = urDecoder.resultUR();
         handleSuccess(result).catch(setError);
@@ -197,6 +200,12 @@ const BaseReader = ({
         <div className="qr-scanner__content">
           <EnhancedReader handleScan={handleScan} />
         </div>
+        {progress > 0 && (
+          <div
+            className="qr-scanner__progress"
+            style={{ '--progress': `${Math.floor(progress * 100)}%` }}
+          ></div>
+        )}
         {message && <div className="qr-scanner__status">{message}</div>}
       </>
     );

--- a/ui/components/app/qr-hardware-popover/base-reader.js
+++ b/ui/components/app/qr-hardware-popover/base-reader.js
@@ -168,7 +168,9 @@ const BaseReader = ({
           <img src="images/webcam.svg" width="70" height="70" alt="" />
         </div>
         {title ? <div className="qr-scanner__title">{title}</div> : null}
-        <div className="qr-scanner__error">{msg}</div>
+        <div className="qr-scanner__error" data-testid="qr-scanner__error">
+          {msg}
+        </div>
         <PageContainerFooter
           onCancel={() => {
             setErrorTitle('');
@@ -203,6 +205,7 @@ const BaseReader = ({
         {progress > 0 && (
           <div
             className="qr-scanner__progress"
+            data-testid="qr-reader-progress-bar"
             style={{ '--progress': `${Math.floor(progress * 100)}%` }}
           ></div>
         )}

--- a/ui/components/app/qr-hardware-popover/base-reader.test.js
+++ b/ui/components/app/qr-hardware-popover/base-reader.test.js
@@ -1,0 +1,58 @@
+import React from 'react';
+import { screen } from '@testing-library/react';
+import { renderWithProvider } from '../../../../test/jest';
+import WebcamUtils from '../../../helpers/utils/webcam-utils';
+import BaseReader from './base-reader';
+import EnhancedReader from './enhanced-reader';
+
+jest.mock('./enhanced-reader');
+jest.mock('../../../helpers/utils/webcam-utils');
+
+describe('Base Reader', () => {
+  const mockBaseReaderData = {
+    isReadingWallet: true,
+    handleCancel: jest.fn(),
+    handleSuccess: jest.fn(),
+    setErrorTitle: jest.fn(),
+  };
+
+  it('renders progress bar', () => {
+    EnhancedReader.mockImplementation(({ handleScan }) => {
+      handleScan(
+        'UR:CRYPTO-HDKEY/24-2/LPCSCSAOCSNYCYNLAMSKJPHDGTEHOEADCSFNAOAEAMTAADDYOTADLNCSDWYKCSFNYKAEYKAOCYJKSKTNBKAXAXATTAADDYOEADLRAEWKLAWKAXAEAYCYTEDMFEAYASISGRIHKKJKJYJLJTIHBKJOHSIAIAJLKPJTJYDMJKJYHSJTIEHSJPIEHTSTGSAO',
+      );
+      return null;
+    });
+    WebcamUtils.checkStatus.mockImplementation(() =>
+      Promise.resolve({ permissions: true, environmentReady: true }),
+    );
+    renderWithProvider(<BaseReader {...mockBaseReaderData} />);
+    expect(screen.getByTestId('qr-reader-progress-bar')).toBeInTheDocument();
+  });
+
+  it('not renders progress bar when error', async () => {
+    EnhancedReader.mockImplementation(() => null);
+    WebcamUtils.checkStatus.mockImplementation(() =>
+      Promise.resolve({ permissions: false, environmentReady: false }),
+    );
+    renderWithProvider(<BaseReader {...mockBaseReaderData} />);
+    await screen.findByTestId('qr-scanner__error');
+    expect(screen.queryByTestId('qr-reader-progress-bar')).toBeNull();
+  });
+
+  it('not renders progress bar when ready', async () => {
+    EnhancedReader.mockImplementation(() => null);
+    WebcamUtils.checkStatus.mockImplementation(() =>
+      Promise.resolve({ permissions: true, environmentReady: true }),
+    );
+    renderWithProvider(<BaseReader {...mockBaseReaderData} />);
+    await screen.findByText(
+      'Place the QR code in front of your camera. The screen is blurred, but it will not affect the reading.',
+      undefined,
+      {
+        timeout: 5000,
+      },
+    );
+    expect(screen.queryByTestId('qr-reader-progress-bar')).toBeNull();
+  });
+});


### PR DESCRIPTION
## **Description**
When using with a QR code hardware wallet, if the data is large, it will take a lot of time, but users cannot get any response during the scan. Adding a scanning  progress will give users a better experience.

## **Manual testing steps**
Edited 2/21/2024 after the fact based on [new](https://github.com/MetaMask/metamask-extension/issues/22931#issuecomment-1950972758) information

1. Unlock Keystone
2. Access 3 dots menu
3. Tap `Connect Software Wallet`
4. Tap `MetaMask`
5. Tap 3 dots menu from Connect MetaMask
6. Tap `Change Derivation Path`
7.  Tap `Ledger Live`
8. Tap back arrow to return to Connect MetaMask and note that QR is now animated
9. In MetaMask tap the accounts drop down menu
10. Tap `+ Add account or hardware wallet`
11. Tap `Add hardware wallet`
12. Tap `QR-based`
13. Grant camera permissions as requested
14. Scan animated QR from Keystone into MetaMask
15. Note progress bar is presented

## **Screenshots/Recordings**

### **Before**

<img width="529" alt="image" src="https://github.com/MetaMask/metamask-extension/assets/111484932/6a2a4208-ec10-42ef-9add-b3f95bccc2f0">

### **After**

<img width="566" alt="image" src="https://github.com/MetaMask/metamask-extension/assets/111484932/24faa911-1e4b-4843-bb7b-de942a7de315">

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained:
  - [x] What problem this PR is solving.
  - [x] How this problem was solved.
  - [x] How reviewers can test my changes.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
