### PR TITLE
fix(20908): use background state as default privacy value in onboarding flow

### DIFF
--- a/ui/pages/onboarding-flow/privacy-settings/privacy-settings.js
+++ b/ui/pages/onboarding-flow/privacy-settings/privacy-settings.js
@@ -12,13 +12,14 @@ import {
   PRIVACY_POLICY_LINK,
 } from '../../../../shared/lib/ui-utils';
 import {
-  BUTTON_SIZES,
-  BUTTON_VARIANT,
   Box,
-  Button,
   PickerNetwork,
   Text,
   TextField,
+  ButtonPrimary,
+  ButtonPrimarySize,
+  ButtonSecondary,
+  ButtonSecondarySize,
 } from '../../../components/component-library';
 import { MetaMetricsContext } from '../../../contexts/metametrics';
 import {
@@ -48,23 +49,38 @@ export default function PrivacySettings() {
   const t = useI18nContext();
   const dispatch = useDispatch();
   const history = useHistory();
-  const { incomingTransactionsPreferences } = useSelector(
-    (state) => state.metamask,
-  );
 
-  const [usePhishingDetection, setUsePhishingDetection] = useState(true);
-  const [turnOn4ByteResolution, setTurnOn4ByteResolution] = useState(true);
-  const [turnOnTokenDetection, setTurnOnTokenDetection] = useState(true);
-  const [turnOnCurrencyRateCheck, setTurnOnCurrencyRateCheck] = useState(true);
+  const defaultState = useSelector((state) => state.metamask);
+  const {
+    incomingTransactionsPreferences,
+    usePhishDetect,
+    use4ByteResolution,
+    useTokenDetection,
+    useCurrencyRateCheck,
+    useMultiAccountBalanceChecker,
+    ipfsGateway,
+    useAddressBarEnsResolution,
+  } = defaultState;
+
+  const [usePhishingDetection, setUsePhishingDetection] =
+    useState(usePhishDetect);
+  const [turnOn4ByteResolution, setTurnOn4ByteResolution] =
+    useState(use4ByteResolution);
+  const [turnOnTokenDetection, setTurnOnTokenDetection] =
+    useState(useTokenDetection);
+  const [turnOnCurrencyRateCheck, setTurnOnCurrencyRateCheck] =
+    useState(useCurrencyRateCheck);
   const [
     isMultiAccountBalanceCheckerEnabled,
     setMultiAccountBalanceCheckerEnabled,
-  ] = useState(true);
-  const [ipfsURL, setIPFSURL] = useState('');
-  const [addressBarResolution, setAddressBarResolution] = useState(true);
+  ] = useState(useMultiAccountBalanceChecker);
+  const [ipfsURL, setIPFSURL] = useState(ipfsGateway);
   const [ipfsError, setIPFSError] = useState(null);
-  const trackEvent = useContext(MetaMetricsContext);
+  const [addressBarResolution, setAddressBarResolution] = useState(
+    useAddressBarEnsResolution,
+  );
 
+  const trackEvent = useContext(MetaMetricsContext);
   const currentNetwork = useSelector(getCurrentNetwork);
   const allNetworks = useSelector(getAllNetworks);
 
@@ -201,16 +217,15 @@ export default function PrivacySettings() {
                       </>
                     </div>
                   ) : (
-                    <Button
-                      variant={BUTTON_VARIANT.SECONDARY}
-                      size={BUTTON_SIZES.LG}
+                    <ButtonSecondary
+                      size={ButtonSecondarySize.Lg}
                       onClick={(e) => {
                         e.preventDefault();
                         dispatch(showModal({ name: 'ONBOARDING_ADD_NETWORK' }));
                       }}
                     >
                       {t('onboardingAdvancedPrivacyNetworkButton')}
-                    </Button>
+                    </ButtonSecondary>
                   )}
                 </Box>
               </>
@@ -224,6 +239,7 @@ export default function PrivacySettings() {
                 {t('onboardingAdvancedPrivacyIPFSDescription')}
                 <Box paddingTop={2}>
                   <TextField
+                    value={ipfsURL}
                     style={{ width: '100%' }}
                     inputProps={{ 'data-testid': 'ipfs-input' }}
                     onChange={(e) => {
@@ -309,15 +325,14 @@ export default function PrivacySettings() {
               </a>,
             ])}
           />
-          <Button
-            variant={BUTTON_VARIANT.PRIMARY}
-            size={BUTTON_SIZES.LG}
+          <ButtonPrimary
+            size={ButtonPrimarySize.Lg}
             onClick={handleSubmit}
             block
             marginTop={6}
           >
             {t('done')}
-          </Button>
+          </ButtonPrimary>
         </div>
       </div>
     </>

--- a/ui/pages/onboarding-flow/privacy-settings/privacy-settings.test.js
+++ b/ui/pages/onboarding-flow/privacy-settings/privacy-settings.test.js
@@ -23,6 +23,13 @@ describe('Privacy Settings Onboarding View', () => {
         [CHAIN_IDS.SEPOLIA]: false,
         [CHAIN_IDS.LINEA_GOERLI]: true,
       },
+      usePhishDetect: true,
+      use4ByteResolution: true,
+      useTokenDetection: false,
+      useCurrencyRateCheck: true,
+      useMultiAccountBalanceChecker: true,
+      ipfsGateway: 'test.link',
+      useAddressBarEnsResolution: true,
     },
   };
 
@@ -58,7 +65,7 @@ describe('Privacy Settings Onboarding View', () => {
       <PrivacySettings />,
       store,
     );
-    // All settings are initialized toggled to true
+    // All settings are initialized toggled to be same as default
     expect(setUsePhishDetectStub).toHaveBeenCalledTimes(0);
     expect(setUse4ByteResolutionStub).toHaveBeenCalledTimes(0);
     expect(setUseTokenDetectionStub).toHaveBeenCalledTimes(0);
@@ -96,7 +103,7 @@ describe('Privacy Settings Onboarding View', () => {
 
     expect(setUsePhishDetectStub.mock.calls[0][0]).toStrictEqual(false);
     expect(setUse4ByteResolutionStub.mock.calls[0][0]).toStrictEqual(false);
-    expect(setUseTokenDetectionStub.mock.calls[0][0]).toStrictEqual(false);
+    expect(setUseTokenDetectionStub.mock.calls[0][0]).toStrictEqual(true);
     expect(setUseMultiAccountBalanceCheckerStub.mock.calls[0][0]).toStrictEqual(
       false,
     );


### PR DESCRIPTION
Fix: https://github.com/MetaMask/metamask-extension/issues/20908

## **Description**
The default privacy setting value is coming from internal state in the component instead of background state, which will cause inconsistency. 

## **Manual testing steps**

_1.  Create a new account
_2. Go to advanced configuration
_3. Check the default settings value

## **Screenshots/Recordings**

### **Before**


https://github.com/MetaMask/metamask-extension/assets/12678455/362bdc62-7f0d-45c0-98c9-0a6dded74b33



### **After**

https://github.com/MetaMask/metamask-extension/assets/12678455/2cae0bc2-cc87-4be5-9a62-add1d9c55312




## **Related issues**



## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've clearly explained:
  - [ ] What problem this PR is solving.
  - [ ] How this problem was solved.
  - [ ] How reviewers can test my changes.
- [ ] I’ve indicated what issue this PR is linked to: Fixes #???
- [ ] I’ve included tests if applicable.
- [ ] I’ve documented any added code.
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)).
- [ ] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
