### PR TITLE
[MMI] Updates custody-keyring package

### DIFF
--- a/package.json
+++ b/package.json
@@ -225,7 +225,7 @@
     "@lavamoat/snow": "^1.5.0",
     "@material-ui/core": "^4.11.0",
     "@metamask-institutional/custody-controller": "^0.2.12",
-    "@metamask-institutional/custody-keyring": "^1.0.1",
+    "@metamask-institutional/custody-keyring": "^1.0.2",
     "@metamask-institutional/extension": "^0.3.5",
     "@metamask-institutional/institutional-features": "^1.2.4",
     "@metamask-institutional/portfolio-dashboard": "^1.4.0",

--- a/ui/pages/institutional/custody/custody.js
+++ b/ui/pages/institutional/custody/custody.js
@@ -124,7 +124,7 @@ const CustodyPage = () => {
         'name' in custodian &&
         connectRequest &&
         Object.keys(connectRequest).length &&
-        custodian.name !== selectedCustodianName
+        custodian.envName !== selectedCustodianName
       );
     }
 
@@ -171,9 +171,9 @@ const CustodyPage = () => {
                   custodians,
                 );
                 const jwtListValue = await dispatch(
-                  mmiActions.getCustodianJWTList(custodian.name),
+                  mmiActions.getCustodianJWTList(custodian.envName),
                 );
-                setSelectedCustodianName(custodian.name);
+                setSelectedCustodianName(custodian.envName);
                 setSelectedCustodianDisplayName(custodian.displayName);
                 setSelectedCustodianImage(custodian.iconUrl);
                 setApiUrl(custodian.apiUrl);
@@ -195,7 +195,7 @@ const CustodyPage = () => {
                   category: MetaMetricsEventCategory.MMI,
                   event: MetaMetricsEventName.CustodianSelected,
                   properties: {
-                    custodian: custodian.name,
+                    custodian: custodian.envName,
                   },
                 });
               } catch (error) {
@@ -598,7 +598,7 @@ const CustodyPage = () => {
             onAddAccounts={async () => {
               try {
                 const selectedCustodian = custodians.find(
-                  (custodian) => custodian.name === selectedCustodianName,
+                  (custodian) => custodian.envName === selectedCustodianName,
                 );
 
                 await dispatch(
@@ -622,9 +622,9 @@ const CustodyPage = () => {
                 history.push({
                   pathname: CUSTODY_ACCOUNT_DONE_ROUTE,
                   state: {
-                    imgSrc: selectedCustodian.iconUrl,
+                    imgSrc: selectedCustodian && selectedCustodian.iconUrl,
                     title: t('custodianAccountAddedTitle', [
-                      selectedCustodian.displayName,
+                      selectedCustodian && selectedCustodian.displayName || 'Custodian',
                     ]),
                     description: t('custodianAccountAddedDesc'),
                   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3657,6 +3657,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@metamask-institutional/custody-keyring@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "@metamask-institutional/custody-keyring@npm:1.0.2"
+  dependencies:
+    "@ethereumjs/tx": "npm:^4.1.1"
+    "@ethereumjs/util": "npm:^8.0.5"
+    "@metamask-institutional/configuration-client": "npm:^2.0.0"
+    "@metamask-institutional/sdk": "npm:^0.1.18"
+    "@metamask-institutional/types": "npm:^1.0.3"
+    "@metamask/obs-store": "npm:^8.0.0"
+    crypto: "npm:^1.0.1"
+    lodash.clonedeep: "npm:^4.5.0"
+  checksum: eff487de17a9d7ea889a953f9874ee0a55b568928c97bf93a90c33af52acfc8958d708d8fb4e4cd909ec0e57757409ac86476b6ab89b72b72b4f6559eab3b06b
+  languageName: node
+  linkType: hard
+
 "@metamask-institutional/extension@npm:^0.3.5":
   version: 0.3.5
   resolution: "@metamask-institutional/extension@npm:0.3.5"
@@ -24106,7 +24122,7 @@ __metadata:
     "@lavamoat/snow": "npm:^1.5.0"
     "@material-ui/core": "npm:^4.11.0"
     "@metamask-institutional/custody-controller": "npm:^0.2.12"
-    "@metamask-institutional/custody-keyring": "npm:^1.0.1"
+    "@metamask-institutional/custody-keyring": "npm:^1.0.2"
     "@metamask-institutional/extension": "npm:^0.3.5"
     "@metamask-institutional/institutional-features": "npm:^1.2.4"
     "@metamask-institutional/portfolio-dashboard": "npm:^1.4.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3641,23 +3641,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask-institutional/custody-keyring@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "@metamask-institutional/custody-keyring@npm:1.0.1"
-  dependencies:
-    "@ethereumjs/tx": "npm:^4.1.1"
-    "@ethereumjs/util": "npm:^8.0.5"
-    "@metamask-institutional/configuration-client": "npm:^2.0.0"
-    "@metamask-institutional/sdk": "npm:^0.1.18"
-    "@metamask-institutional/types": "npm:^1.0.3"
-    "@metamask/obs-store": "npm:^8.0.0"
-    crypto: "npm:^1.0.1"
-    lodash.clonedeep: "npm:^4.5.0"
-  checksum: c9c763bd8416bd4434f4ae00d687f3bd33c6f4c6b7c299f0887e772e077b82291f59ecb6eebcac18cce56775887dfa8bc0a1be121d38ba35b5d5650bbb85ddf9
-  languageName: node
-  linkType: hard
-
-"@metamask-institutional/custody-keyring@npm:^1.0.2":
+"@metamask-institutional/custody-keyring@npm:^1.0.1, @metamask-institutional/custody-keyring@npm:^1.0.2":
   version: 1.0.2
   resolution: "@metamask-institutional/custody-keyring@npm:1.0.2"
   dependencies:


### PR DESCRIPTION
## **Description**
We had a small bug lately in our MMI Custody Keyring that was preventing us from connecting custodian accounts.
Also updated the custodian name property to use the environment name from ou Configuration API V2, instead of the default name.

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained:
  - [x] What problem this PR is solving.
  - [x] How this problem was solved.
  - [x] How reviewers can test my changes.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
