### PR TITLE
Fix an issue with disconnecting a single dapp from a snap

### DIFF
--- a/ui/pages/settings/snaps/view-snap/view-snap.js
+++ b/ui/pages/settings/snaps/view-snap/view-snap.js
@@ -87,7 +87,7 @@ function ViewSnap() {
         .caveats[0].value;
     const newCaveatValue = { ...caveatValue };
     delete newCaveatValue[snapId];
-    if (Object.keys(newCaveatValue) > 0) {
+    if (Object.keys(newCaveatValue).length > 0) {
       dispatch(
         updateCaveat(
           connectedOrigin,


### PR DESCRIPTION
## **Description**
Fixes an issue with disconnecting a single dapp from a snap. Because of a typo, trying to disconnect from a dapp would disconnect from all connected dapps.

Thanks for the report @NidhiKJha !

## **Manual testing steps**

1. Connect to a snap from 2 dapps
2. Go to the snaps settings
3. Disconnect from one of the dapps
4. Notice that you are now correctly disconnected from one of the dapps

