### PR TITLE
Fix `updateCaveat` not being exposed in the background API

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -2733,6 +2733,7 @@ export default class MetamaskController extends EventEmitter {
       ),
       dismissNotifications: this.dismissNotifications.bind(this),
       markNotificationsAsRead: this.markNotificationsAsRead.bind(this),
+      updateCaveat: this.updateCaveat.bind(this),
       ///: END:ONLY_INCLUDE_IN
       ///: BEGIN:ONLY_INCLUDE_IN(keyring-snaps)
       updateSnapRegistry: this.preferencesController.updateSnapRegistry.bind(


### PR DESCRIPTION
## **Description**
Follow up to #20983

Fixes an issue where `updateCaveat` was not being exposed in the background API. This caused problems when trying to disconnect a single dapp from a snap. I had misdiagnosed the bug in the first PR and thought that it was fixed, but @NidhiKJha  reported that it was still broken.

## **Manual testing steps**

1. Connect to 2 snaps from a single dapp
2. Go to one of the snap's settings
4. Disconnect from the dapp
5. Go to the other snap's settings and check that you are not disconnected
