### PR TITLE
Stabilize e2e test for IPFS toggle

### DIFF
--- a/test/e2e/tests/ipfs-toggle.spec.js
+++ b/test/e2e/tests/ipfs-toggle.spec.js
@@ -59,7 +59,9 @@ describe('Settings', function () {
         });
 
         // should render image now
-        const nftImage = await driver.findElement('[data-testid="nft-image"]');
+        const nftImage = await driver.findVisibleElement(
+          '[data-testid="nft-image"]',
+        );
         assert.equal(await nftImage.isDisplayed(), true);
       },
     );


### PR DESCRIPTION
## **Description**
Stabilize e2e tests "Shows nft default image when IPFS toggle is off and restore image once we toggle the ipfs modal"
Fixes #20985 

- [X] I've clearly explained:
  - [X] What problem this PR is solving.
  - [X] How this problem was solved.
