### PR TITLE
[MMI] clean up MMI Portfolio Dashboard URLs

### DIFF
--- a/shared/constants/swaps.ts
+++ b/shared/constants/swaps.ts
@@ -142,8 +142,6 @@ export const WETH_ZKSYNC_ERA_CONTRACT_ADDRESS =
 
 const SWAPS_TESTNET_CHAIN_ID = '0x539';
 
-export const MMI_SWAPS_URL = 'https://metamask-institutional.io/swap';
-
 export const SWAPS_API_V2_BASE_URL = 'https://swap.metaswap.codefi.network';
 export const SWAPS_DEV_API_V2_BASE_URL = 'https://swap.dev-api.cx.metamask.io';
 export const GAS_API_BASE_URL = 'https://gas-api.metaswap.codefi.network';

--- a/ui/components/app/wallet-overview/eth-overview.js
+++ b/ui/components/app/wallet-overview/eth-overview.js
@@ -14,7 +14,6 @@ import {
   getMmiPortfolioEnabled,
   getMmiPortfolioUrl,
 } from '../../../selectors/institutional/selectors';
-import { MMI_SWAPS_URL } from '../../../../shared/constants/swaps';
 ///: END:ONLY_INCLUDE_IN
 import { I18nContext } from '../../../contexts/i18n';
 import {
@@ -112,7 +111,7 @@ const EthOverview = ({ className, showAddress }) => {
           onClick={() => {
             stakingEvent();
             global.platform.openTab({
-              url: 'https://metamask-institutional.io/stake',
+              url: `${mmiPortfolioUrl}/stake`,
             });
           }}
         />
@@ -125,7 +124,9 @@ const EthOverview = ({ className, showAddress }) => {
             label={t('portfolio')}
             onClick={() => {
               portfolioEvent();
-              window.open(mmiPortfolioUrl, '_blank');
+              global.platform.openTab({
+                url: mmiPortfolioUrl,
+              });
             }}
           />
         )}
@@ -262,7 +263,7 @@ const EthOverview = ({ className, showAddress }) => {
             onClick={() => {
               ///: BEGIN:ONLY_INCLUDE_IN(build-mmi)
               global.platform.openTab({
-                url: MMI_SWAPS_URL,
+                url: `${mmiPortfolioUrl}/swap`,
               });
               ///: END:ONLY_INCLUDE_IN
 

--- a/ui/components/app/wallet-overview/eth-overview.test.js
+++ b/ui/components/app/wallet-overview/eth-overview.test.js
@@ -200,7 +200,7 @@ describe('EthOverview', () => {
             portfolio: {
               enabled: true,
               url: 'https://metamask-institutional.io',
-            }
+            },
           },
           keyrings: [
             {

--- a/ui/components/app/wallet-overview/eth-overview.test.js
+++ b/ui/components/app/wallet-overview/eth-overview.test.js
@@ -196,6 +196,12 @@ describe('EthOverview', () => {
       const mockedStoreWithCustodyKeyring = {
         metamask: {
           ...mockStore.metamask,
+          mmiConfiguration: {
+            portfolio: {
+              enabled: true,
+              url: 'https://metamask-institutional.io',
+            }
+          },
           keyrings: [
             {
               type: 'Custody',
@@ -224,9 +230,7 @@ describe('EthOverview', () => {
 
       await waitFor(() =>
         expect(openTabSpy).toHaveBeenCalledWith({
-          url: expect.stringContaining(
-            'https://metamask-institutional.io/swap',
-          ),
+          url: 'https://metamask-institutional.io/swap',
         }),
       );
     });

--- a/ui/components/app/wallet-overview/token-overview.js
+++ b/ui/components/app/wallet-overview/token-overview.js
@@ -25,7 +25,6 @@ import {
   getMmiPortfolioEnabled,
   getMmiPortfolioUrl,
 } from '../../../selectors/institutional/selectors';
-import { MMI_SWAPS_URL } from '../../../../shared/constants/swaps';
 ///: END:ONLY_INCLUDE_IN
 import {
   getIsSwapsChain,
@@ -178,7 +177,7 @@ const TokenOverview = ({ className, token }) => {
                 onClick={() => {
                   stakingEvent();
                   global.platform.openTab({
-                    url: 'https://metamask-institutional.io/stake',
+                    url: `${mmiPortfolioUrl}/stake`,
                   });
                 }}
               />
@@ -195,7 +194,9 @@ const TokenOverview = ({ className, token }) => {
                   data-testid="token-overview-mmi-portfolio"
                   onClick={() => {
                     portfolioEvent();
-                    window.open(mmiPortfolioUrl, '_blank');
+                    global.platform.openTab({
+                      url: mmiPortfolioUrl,
+                    });
                   }}
                 />
               )}
@@ -252,7 +253,7 @@ const TokenOverview = ({ className, token }) => {
               onClick={() => {
                 ///: BEGIN:ONLY_INCLUDE_IN(build-mmi)
                 global.platform.openTab({
-                  url: MMI_SWAPS_URL,
+                  url: `${mmiPortfolioUrl}/swap`,
                 });
                 ///: END:ONLY_INCLUDE_IN
 

--- a/ui/components/multichain/select-action-modal/select-action-modal.js
+++ b/ui/components/multichain/select-action-modal/select-action-modal.js
@@ -49,9 +49,9 @@ import { startNewDraftTransaction } from '../../../ducks/send';
 import { I18nContext } from '../../../contexts/i18n';
 import { AssetType } from '../../../../shared/constants/transaction';
 ///: BEGIN:ONLY_INCLUDE_IN(build-mmi)
-import { MMI_SWAPS_URL } from '../../../../shared/constants/swaps';
-import { MMI_STAKE_WEBSITE } from '../../../helpers/constants/common';
+import { getMmiPortfolioUrl } from '../../../selectors/institutional/selectors';
 ///: END:ONLY_INCLUDE_IN
+
 ///: BEGIN:ONLY_INCLUDE_IN(build-main,build-beta,build-flask)
 import { setSwapsFromToken } from '../../../ducks/swaps/swaps';
 import { isHardwareKeyring } from '../../../helpers/utils/hardware';
@@ -79,6 +79,8 @@ export const SelectActionModal = ({ onClose }) => {
   ///: END:ONLY_INCLUDE_IN
 
   ///: BEGIN:ONLY_INCLUDE_IN(build-mmi)
+  const mmiPortfolioUrl = useSelector(getMmiPortfolioUrl);
+
   const stakingEvent = () => {
     trackEvent({
       category: MetaMetricsEventCategory.Navigation,
@@ -136,7 +138,7 @@ export const SelectActionModal = ({ onClose }) => {
               onClick={() => {
                 stakingEvent();
                 global.platform.openTab({
-                  url: MMI_STAKE_WEBSITE,
+                  url: `${mmiPortfolioUrl}/stake`,
                 });
                 onClose();
               }}
@@ -152,7 +154,7 @@ export const SelectActionModal = ({ onClose }) => {
             onClick={() => {
               ///: BEGIN:ONLY_INCLUDE_IN(build-mmi)
               global.platform.openTab({
-                url: MMI_SWAPS_URL,
+                url: `${mmiPortfolioUrl}/swap`,
               });
               ///: END:ONLY_INCLUDE_IN
 

--- a/ui/helpers/constants/common.ts
+++ b/ui/helpers/constants/common.ts
@@ -7,7 +7,6 @@ const _contractAddressLink =
 ///: BEGIN:ONLY_INCLUDE_IN(build-mmi)
 const _mmiWebSite = 'https://metamask.io/institutions/';
 export const MMI_WEB_SITE = _mmiWebSite;
-export const MMI_STAKE_WEBSITE = 'https://metamask-institutional.io/stake';
 ///: END:ONLY_INCLUDE_IN
 
 // eslint-disable-next-line prefer-destructuring


### PR DESCRIPTION
## **Description**
We are standardising the MMI Portfolio Dashboard urls to make use of the value that comes from our Configuration API and not have them hardcoded.

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained:
  - [x] What problem this PR is solving.
  - [x] How this problem was solved.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
