### PR TITLE
Fix #20930 - Prevent Firefox start failure by awaiting startUISync event

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -3212,7 +3212,7 @@ export default class MetamaskController extends EventEmitter {
   }
 
   _startUISync() {
-    // Message startUISync is used in MV3 to start syncing state with UI
+    // Message startUISync is used to start syncing state with UI
     // Sending this message after login is completed helps to ensure that incomplete state without
     // account details are not flushed to UI.
     this.emit('startUISync');

--- a/app/scripts/ui.js
+++ b/app/scripts/ui.js
@@ -257,7 +257,13 @@ async function start() {
     extensionPort.onMessage.addListener(messageListener);
     extensionPort.onDisconnect.addListener(resetExtensionStreamAndListeners);
   } else {
-    initializeUiWithTab(activeTab);
+    const messageListener = async (message) => {
+      if (message?.data?.method === 'startUISync') {
+        initializeUiWithTab(activeTab);
+        extensionPort.onMessage.removeListener(messageListener);
+      }
+    };
+    extensionPort.onMessage.addListener(messageListener);
   }
 
   function initializeUiWithTab(tab) {


### PR DESCRIPTION
## **Description**
[This PR](https://github.com/MetaMask/metamask-extension/pull/20843) further highlighted the problem that sometimes the UI loads before the background (most notably in Firefox).  This leaves MetaMask in a state where the user sees the MetaMask fox logo and spinner but nothing actually happens.  I've seen this quite a bit specifically in E2E tests.

## **Manual testing steps**

_1. Complete usual wallet creation and subsequent login and logout, refreshing the page, etc.  Everything should work as normal.

2.  Checkout https://github.com/MetaMask/metamask-extension/pull/20843
3. Run `yarn build test`
4. Run `yarn test:e2e:single test/e2e/metamask-ui.spec.js --browser firefox --leave-running --debug`
5. All tests should pass and MetaMask should properly function

## **Related issues**

_Fixes #20930

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've clearly explained:
  - [ ] What problem this PR is solving.
  - [ ] How this problem was solved.
  - [ ] How reviewers can test my changes.
- [ ] I’ve indicated what issue this PR is linked to: Fixes #???
- [ ] I’ve included tests if applicable.
- [ ] I’ve documented any added code.
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)).
- [ ] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
