### PR TITLE
[MMI] fix property name and filter out custodian

### DIFF
--- a/ui/helpers/utils/institutional/find-by-custodian-name.ts
+++ b/ui/helpers/utils/institutional/find-by-custodian-name.ts
@@ -24,9 +24,12 @@ export function findCustodianByDisplayName(
   }
 
   for (const custodian of custodians) {
-    const custodianName = custodian.envName.toLowerCase();
+    const custodianName = custodian.name.toLowerCase();
 
-    if (formatedDisplayName.includes(custodianName)) {
+    if (
+      custodianName.length !== 0 &&
+      formatedDisplayName.includes(custodianName)
+    ) {
       return custodian;
     }
   }

--- a/ui/pages/institutional/custody/custody.js
+++ b/ui/pages/institutional/custody/custody.js
@@ -95,9 +95,11 @@ const CustodyPage = () => {
   const custodianButtons = useMemo(() => {
     const custodianItems = [];
 
-    const sortedCustodians = [...custodians].sort((a, b) =>
-      a.envName.toLowerCase().localeCompare(b.envName.toLowerCase()),
-    );
+    const sortedCustodians = [...custodians]
+      .filter((item) => item.type !== 'Jupiter')
+      .sort((a, b) =>
+        a.envName.toLowerCase().localeCompare(b.envName.toLowerCase()),
+      );
 
     function shouldShowInProduction(custodian) {
       return (

--- a/ui/pages/institutional/custody/custody.test.js
+++ b/ui/pages/institutional/custody/custody.test.js
@@ -43,7 +43,8 @@ describe('CustodyPage', function () {
         custodians: [
           {
             type: 'GK8',
-            envName: 'gk8',
+            envName: 'gk8-prod',
+            name: 'GK8',
             apiUrl: 'https://saturn-custody.dev.metamask-institutional.io',
             iconUrl:
               'https://saturn-custody-ui.dev.metamask-institutional.io/saturn.svg',
@@ -56,7 +57,8 @@ describe('CustodyPage', function () {
           },
           {
             type: 'Saturn B',
-            envName: 'Saturn Custody B',
+            envName: 'saturn-prod',
+            name: 'Saturn Custody B',
             apiUrl: 'https://saturn-custody.dev.metamask-institutional.io',
             iconUrl:
               'https://saturn-custody-ui.dev.metamask-institutional.io/saturn.svg',


### PR DESCRIPTION
We were looking for the wrong property in the `findCustodianByDisplayName` method, and also we can filter out a custodian that we don't need from the list of custodians.

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [x] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
