### PR TITLE
Fix #20934 - Show network icon in New Network popover

### DIFF
--- a/ui/components/ui/new-network-info/new-network-info.js
+++ b/ui/components/ui/new-network-info/new-network-info.js
@@ -1,11 +1,10 @@
-import React, { useContext, useEffect, useState, useCallback } from 'react';
+import React, { useCallback, useContext, useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { useHistory } from 'react-router-dom';
+import { TOKEN_API_METASWAP_CODEFI_URL } from '../../../../shared/constants/tokens';
+import fetchWithCache from '../../../../shared/lib/fetch-with-cache';
 import { I18nContext } from '../../../contexts/i18n';
-import Popover from '../popover';
-import Button from '../button';
-import Identicon from '../identicon';
-import Box from '../box';
+import { getProviderConfig } from '../../../ducks/metamask/metamask';
 import {
   AlignItems,
   Color,
@@ -14,18 +13,15 @@ import {
   TextAlign,
   TextVariant,
 } from '../../../helpers/constants/design-system';
-import { TOKEN_API_METASWAP_CODEFI_URL } from '../../../../shared/constants/tokens';
-import fetchWithCache from '../../../../shared/lib/fetch-with-cache';
-import { getCurrentNetwork, getUseTokenDetection } from '../../../selectors';
-import { getProviderConfig } from '../../../ducks/metamask/metamask';
 import { IMPORT_TOKEN_ROUTE } from '../../../helpers/constants/routes';
-import Chip from '../chip/chip';
+import { getCurrentNetwork, getUseTokenDetection } from '../../../selectors';
 import { setFirstTimeUsedNetwork } from '../../../store/actions';
-import { NETWORK_TYPES } from '../../../../shared/constants/network';
-import { Icon, IconName, Text } from '../../component-library';
-import { getNetworkLabelKey } from '../../../helpers/utils/i18n-helper';
+import { PickerNetwork, Text } from '../../component-library';
+import Box from '../box';
+import Button from '../button';
+import Popover from '../popover';
 
-const NewNetworkInfo = () => {
+export default function NewNetworkInfo() {
   const t = useContext(I18nContext);
   const history = useHistory();
   const [tokenDetectionSupported, setTokenDetectionSupported] = useState(false);
@@ -92,32 +88,15 @@ const NewNetworkInfo = () => {
           >
             {t('switchedTo')}
           </Text>
-          <Chip
-            className="new-network-info__token-box"
-            backgroundColor={Color.backgroundAlternative}
-            maxContent={false}
-            label={
-              providerConfig.type === NETWORK_TYPES.RPC
-                ? providerConfig.nickname ?? t('privateNetwork')
-                : t(getNetworkLabelKey(providerConfig.type))
-            }
-            labelProps={{
-              color: Color.textDefault,
-            }}
-            leftIcon={
-              currentNetwork?.rpcPrefs?.imageUrl ? (
-                <Identicon
-                  image={currentNetwork?.rpcPrefs?.imageUrl}
-                  diameter={14}
-                />
-              ) : (
-                <Icon
-                  className="question"
-                  name={IconName.Question}
-                  color={Color.iconDefault}
-                />
-              )
-            }
+          <PickerNetwork
+            label={currentNetwork?.nickname}
+            src={currentNetwork?.rpcPrefs?.imageUrl}
+            marginLeft="auto"
+            marginRight="auto"
+            marginTop={4}
+            marginBottom={4}
+            iconProps={{ display: 'none' }} // do not show the dropdown icon
+            as="div" // do not render as a button
           />
           <Text
             variant={TextVariant.bodySmBold}
@@ -129,7 +108,7 @@ const NewNetworkInfo = () => {
             {t('thingsToKeep')}
           </Text>
           <Box marginRight={4} marginLeft={5} marginTop={6}>
-            {providerConfig.ticker ? (
+            {providerConfig.ticker && (
               <Box
                 display={Display.Flex}
                 alignItems={AlignItems.center}
@@ -160,7 +139,7 @@ const NewNetworkInfo = () => {
                   ])}
                 </Text>
               </Box>
-            ) : null}
+            )}
             <Box
               display={Display.Flex}
               alignItems={AlignItems.center}
@@ -241,6 +220,4 @@ const NewNetworkInfo = () => {
       </Popover>
     )
   );
-};
-
-export default NewNetworkInfo;
+}

--- a/ui/components/ui/new-network-info/new-network-info.js
+++ b/ui/components/ui/new-network-info/new-network-info.js
@@ -16,10 +16,7 @@ import {
 } from '../../../helpers/constants/design-system';
 import { TOKEN_API_METASWAP_CODEFI_URL } from '../../../../shared/constants/tokens';
 import fetchWithCache from '../../../../shared/lib/fetch-with-cache';
-import {
-  getNativeCurrencyImage,
-  getUseTokenDetection,
-} from '../../../selectors';
+import { getCurrentNetwork, getUseTokenDetection } from '../../../selectors';
 import { getProviderConfig } from '../../../ducks/metamask/metamask';
 import { IMPORT_TOKEN_ROUTE } from '../../../helpers/constants/routes';
 import Chip from '../chip/chip';
@@ -35,8 +32,8 @@ const NewNetworkInfo = () => {
   const [showPopup, setShowPopup] = useState(true);
   const [isLoading, setIsLoading] = useState(true);
   const autoDetectToken = useSelector(getUseTokenDetection);
-  const primaryTokenImage = useSelector(getNativeCurrencyImage);
   const providerConfig = useSelector(getProviderConfig);
+  const currentNetwork = useSelector(getCurrentNetwork);
 
   const onCloseClick = () => {
     setShowPopup(false);
@@ -108,8 +105,11 @@ const NewNetworkInfo = () => {
               color: Color.textDefault,
             }}
             leftIcon={
-              primaryTokenImage ? (
-                <Identicon image={primaryTokenImage} diameter={14} />
+              currentNetwork?.rpcPrefs?.imageUrl ? (
+                <Identicon
+                  image={currentNetwork?.rpcPrefs?.imageUrl}
+                  diameter={14}
+                />
               ) : (
                 <Icon
                   className="question"


### PR DESCRIPTION
## **Description**

Fixes #20934

This PR ensures the correct network icon displays when switching to a new network like Optimism and Arbitrum.  While ETH may be the native currency of each of those networks, the chip image should represent the network.

## **Manual testing steps**

1. Open the Networks menu and click "Add network"
2. Add Arbitrum and switch to that network
3. See the Arbitrum logo in the "You've switched" network circle
4. Repeat with Optimism

## **Screenshots/Recordings**

### Before
![image](https://github.com/MetaMask/metamask-extension/assets/539738/911889b2-828f-49dd-99c6-5f92175a0a4c)

### After
![image](https://github.com/MetaMask/metamask-extension/assets/539738/dc1cef55-0019-446a-b8e6-deeb7259f310)


## **Related issues**

Fixes #20934

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained:
  - [x] What problem this PR is solving.
  - [x] How this problem was solved.
  - [x] How reviewers can test my changes.
- [x] I’ve indicated what issue this PR is linked to: Fixes #???
- [ ] I’ve included tests if applicable.
- [ ] I’ve documented any added code.
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)).
- [ ] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
