### PR TITLE
fix: filteredTests problem from #20974

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1018,7 +1018,7 @@ jobs:
           command: |
             if .circleci/scripts/test-run-e2e.sh
             then
-              yarn test:e2e:firefox:snaps --retries 2 --debug
+              yarn test:e2e:firefox:snaps --retries 2 --debug --build-type=flask
             fi
           no_output_timeout: 20m
       - run:
@@ -1055,7 +1055,7 @@ jobs:
           command: |
             if .circleci/scripts/test-run-e2e.sh
             then
-              yarn test:e2e:chrome:snaps --retries 2 --debug
+              yarn test:e2e:chrome:snaps --retries 2 --debug --build-type=flask
             fi
           no_output_timeout: 20m
       - run:

--- a/test/e2e/helpers.js
+++ b/test/e2e/helpers.js
@@ -134,7 +134,7 @@ async function withFixtures(options, testSuite) {
               console.log(
                 `[driver] Called '${prop}' with arguments ${JSON.stringify(
                   args,
-                )}`,
+                ).slice(0, 200)}`, // limit the length of the log entry to 200 characters
               );
               return originalProperty.bind(target)(...args);
             };

--- a/test/e2e/run-all.js
+++ b/test/e2e/run-all.js
@@ -126,7 +126,7 @@ async function main() {
     }
   }
 
-  // These tests should only be ran on Flask for now.
+  // These tests should only be run on Flask for now.
   if (buildType !== 'flask') {
     const filteredTests = [
       'settings-add-snap-account-toggle.spec.js',


### PR DESCRIPTION
## **Description**
#20974 introduced a problem where now those filteredTests are not running in **_any_** CI step, this fixes it

This is the [problematic change](https://github.com/MetaMask/metamask-extension/pull/20974/files#diff-0b1cef09574424eab17ed0328f6f2b553a43a02bf4e05eb35266908af28c5913).  I added ` --build-type=flask` to lines in config.yml to fix it.

Also, there's an enormous amount of spam in the logs with lines like this
```
[driver] Called 'scrollToElement' with arguments [{"driver_":{"session_":{},"executor_":{"customCommands_":{},"log_":{"name_":"webdriver.http.Executor","level_":null,"parent_":{"name_":"webdriver.http","level_":null,"parent_":{"name_":"webdriver","level_":null,"parent_":{"name_":"","level_":{"name_":"OFF","value_":null},"parent_":null,"handlers_":null},"handlers_":null},"handlers_":null},"handlers_":null},"w3c":true},"fileDetector_":null,"authenticatorId_":null,"pinnedScripts_":{},"_wsUrl":"ws://127.0.0.1:41845/devtools/page/ED4EC848C3E7A22AFFB6B7BF1D20D367","_wsConnection":{"_events":{"message":
,"_outBuffer":{"type":"Buffer","data":[81,157,118,103,214,2,116,101,170,121,238,32,178,231,246,101,214,26,191,72,243,96,228,99,188,226,175,2,154,155,183,42,0,0,255,255,143,36,240,206,9,56,22,171,115,192,112,208,15,115,17,255,167,70,98,60,189,106,194,188,159,232,96,30,60,40,194,158,61,41,192,189,191,200,131,62,188,74,96,191,126,74,225,189,31,105,218,115,130,151,254,16,177,214,60,175,124,231,206,19,131,164,48,230,125,116,78,203,105,188,210,79,162,2,123,144,63,164,216,134,0,0,255,255,11,37,147,194,26,199,234,197,0,241,237,49,23,253,221,249,27,217,169,207,252,6,13,201,56,253,242,234,47,233,157,67,24,241,101,157,223,241,237,125,111,113,197,85,231,57,77,141,79,1,77,61,199,81,173,157,47,241,197,53,7,49,37,21,135,221,54,155,73,0,0,255,255,0,0,0,227,241,255,255,0,0,0,0,0,0,0,0,0,0,0,0,168,229,241,230,29,127,0,0,176,229,241,230,29,127,0,0,227,241,255,255,0,0,0,0,125,241,255,255,0,0,0,0,0,0,0
```

I put in something to limit the length of a [driver] log entry to 200 characters.

## **Manual testing steps**

1. Look at [test-e2e-chrome-snaps-flask on develop](https://app.circleci.com/pipelines/github/MetaMask/metamask-extension/57356/workflows/b3fc304d-f17c-4267-8e4a-18d07addc96b/jobs/1741952)
   a. Note that, for instance, "Test Snap Lifecycle Hooks" are not being run
   b. Note the huge amount of log spam
2. Look at [test-e2e-chrome-snaps-flask on this PR](https://app.circleci.com/pipelines/github/MetaMask/metamask-extension/57379/workflows/d2e902c9-ef0e-4d26-a048-821ef41e44c5/jobs/1742915)
   a. Note that "Test Snap Lifecycle Hooks" _**are**_ being run (look in parallel run number 2)
   b. Note the lack of log spam

## **Related issues**

_Fixes problem in #20974_

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained:
  - [x] What problem this PR is solving.
  - [x] How this problem was solved.
  - [x] How reviewers can test my changes.
- [x] I’ve indicated what issue this PR is linked to: Fixes #???
- [ ] I’ve included tests if applicable.
- [ ] I’ve documented any added code.
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)).
- [x] I’ve properly set the pull request status:
  - [x] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
