### PR TITLE
Fix dropdown for multiple transaction insight snaps

### DIFF
--- a/ui/components/ui/tabs/snaps/dropdown-tab/dropdown-tab.js
+++ b/ui/components/ui/tabs/snaps/dropdown-tab/dropdown-tab.js
@@ -103,12 +103,7 @@ export const DropdownTab = ({
         >
           {selectedOptionName}
         </Text>
-        <Box
-          marginLeft={2}
-          paddingLeft={1}
-          paddingRight={1}
-          onClick={openDropdown}
-        >
+        <Box paddingLeft={1} paddingRight={1} onClick={openDropdown}>
           <Icon name={IconName.ArrowDown} size={IconSize.Sm} />
         </Box>
       </Box>

--- a/ui/components/ui/tabs/snaps/dropdown-tab/dropdown-tab.js
+++ b/ui/components/ui/tabs/snaps/dropdown-tab/dropdown-tab.js
@@ -98,12 +98,14 @@ export const DropdownTab = ({
         >
           {selectedOptionName}
         </Text>
-        <Icon
+        <Box
           marginLeft={2}
-          name={IconName.ArrowDown}
-          size={IconSize.Sm}
+          paddingLeft={1}
+          paddingRight={1}
           onClick={openDropdown}
-        />
+        >
+          <Icon name={IconName.ArrowDown} size={IconSize.Sm} />
+        </Box>
       </Box>
       {isOpen && (
         <Box

--- a/ui/components/ui/tabs/snaps/dropdown-tab/dropdown-tab.js
+++ b/ui/components/ui/tabs/snaps/dropdown-tab/dropdown-tab.js
@@ -4,14 +4,14 @@ import classnames from 'classnames';
 import Box from '../../../box';
 import {
   AlignItems,
-  BLOCK_SIZES,
+  BlockSize,
   BackgroundColor,
   BorderColor,
   BorderRadius,
   BorderStyle,
-  DISPLAY,
-  FLEX_DIRECTION,
-  FLEX_WRAP,
+  Display,
+  FlexDirection,
+  FlexWrap,
   TextVariant,
 } from '../../../../../helpers/constants/design-system';
 import { Icon, IconName, IconSize, Text } from '../../../../component-library';
@@ -43,6 +43,10 @@ export const DropdownTab = ({
   const openDropdown = (event) => {
     event.preventDefault();
     setIsOpen(true);
+  };
+
+  const onTabClick = (event) => {
+    event.preventDefault();
     onClick(tabIndex);
   };
 
@@ -75,11 +79,11 @@ export const DropdownTab = ({
         [activeClassName]: activeClassName && isActive,
       })}
       data-testid={dataTestId}
-      onClick={openDropdown}
+      onClick={onTabClick}
       dataTestId={dataTestId}
-      flexDirection={FLEX_DIRECTION.ROW}
-      flexWrap={FLEX_WRAP.NO_WRAP}
-      height={BLOCK_SIZES.FULL}
+      flexDirection={FlexDirection.Row}
+      flexWrap={FlexWrap.NoWrap}
+      height={BlockSize.Full}
       style={{ cursor: 'pointer', overflow: 'hidden' }}
       title={selectedOptionName}
     >
@@ -94,7 +98,12 @@ export const DropdownTab = ({
         >
           {selectedOptionName}
         </Text>
-        <Icon marginLeft={2} name={IconName.ArrowDown} size={IconSize.Sm} />
+        <Icon
+          marginLeft={2}
+          name={IconName.ArrowDown}
+          size={IconSize.Sm}
+          onClick={openDropdown}
+        />
       </Box>
       {isOpen && (
         <Box
@@ -104,9 +113,9 @@ export const DropdownTab = ({
           borderRadius={BorderRadius.SM}
           paddingLeft={2}
           paddingRight={2}
-          display={DISPLAY.FLEX}
-          flexDirection={FLEX_DIRECTION.COLUMN}
-          flexWrap={FLEX_WRAP.NO_WRAP}
+          display={Display.Flex}
+          flexDirection={FlexDirection.Column}
+          flexWrap={FlexWrap.NoWrap}
           style={{ position: 'absolute', maxWidth: '170px' }}
           ref={dropdownRef}
         >

--- a/ui/components/ui/tabs/snaps/dropdown-tab/dropdown-tab.js
+++ b/ui/components/ui/tabs/snaps/dropdown-tab/dropdown-tab.js
@@ -92,7 +92,7 @@ export const DropdownTab = ({
       style={{ cursor: 'pointer', overflow: 'hidden' }}
       title={selectedOptionName}
     >
-      <Box display={Display.Flex} alignItems={AlignItems.center} padding={2}>
+      <Box display={Display.Flex} alignItems={AlignItems.flexStart} padding={2}>
         <Text
           variant={TextVariant.inherit}
           style={{
@@ -103,7 +103,13 @@ export const DropdownTab = ({
         >
           {selectedOptionName}
         </Text>
-        <Box paddingLeft={1} paddingRight={1} onClick={openDropdown}>
+        <Box
+          display={Display.Flex}
+          alignItems={AlignItems.flexStart}
+          paddingLeft={1}
+          paddingRight={1}
+          onClick={openDropdown}
+        >
           <Icon name={IconName.ArrowDown} size={IconSize.Sm} />
         </Box>
       </Box>

--- a/ui/components/ui/tabs/snaps/dropdown-tab/dropdown-tab.js
+++ b/ui/components/ui/tabs/snaps/dropdown-tab/dropdown-tab.js
@@ -1,7 +1,6 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
-import Box from '../../../box';
 import {
   AlignItems,
   BlockSize,
@@ -14,7 +13,13 @@ import {
   FlexWrap,
   TextVariant,
 } from '../../../../../helpers/constants/design-system';
-import { Icon, IconName, IconSize, Text } from '../../../../component-library';
+import {
+  Box,
+  Icon,
+  IconName,
+  IconSize,
+  Text,
+} from '../../../../component-library';
 
 export const DropdownTab = ({
   activeClassName,
@@ -87,7 +92,7 @@ export const DropdownTab = ({
       style={{ cursor: 'pointer', overflow: 'hidden' }}
       title={selectedOptionName}
     >
-      <Box alignItems={AlignItems.center} padding={2}>
+      <Box display={Display.Flex} alignItems={AlignItems.center} padding={2}>
         <Text
           variant={TextVariant.inherit}
           style={{

--- a/ui/components/ui/tabs/snaps/dropdown-tab/dropdown-tab.test.js
+++ b/ui/components/ui/tabs/snaps/dropdown-tab/dropdown-tab.test.js
@@ -36,7 +36,7 @@ describe('DropdownTab', () => {
   it('registers selection', () => {
     const { container, getByText } = render(<DropdownTab {...args} />);
 
-    fireEvent.click(container.firstChild);
+    fireEvent.click(container.firstChild.firstChild.lastChild);
 
     const element = getByText(args.options[1].name);
 

--- a/ui/components/ui/tabs/snaps/dropdown-tab/dropdown-tab.test.js
+++ b/ui/components/ui/tabs/snaps/dropdown-tab/dropdown-tab.test.js
@@ -36,7 +36,10 @@ describe('DropdownTab', () => {
   it('registers selection', () => {
     const { container, getByText } = render(<DropdownTab {...args} />);
 
-    fireEvent.click(container.firstChild.firstChild.lastChild);
+    // Find the clickable element (icon box) in the dropdown that contains
+    // ArrowDown icon by walking the nested elements
+    const clickableIconBox = container.firstChild.firstChild.lastChild;
+    fireEvent.click(clickableIconBox);
 
     const element = getByText(args.options[1].name);
 


### PR DESCRIPTION
## **Description**
This PR will fix dropdown behaviour when multiple transaction insight snaps are available.
This PR will also refactor code in terms of removing deprecated UI components and constants.

## **Manual testing steps**
1. Install multiple transaction insight Snaps.
2. Got to test dapp and send test transaction.
3. By clicking on the tab text, dropdown should not open.
4. By clicking on the dropdown arrow icon, dropdown should open.

## **Screenshots/Recordings**
### **Before** and **After**
Note: Before and after UI is the same, only click behaviour is changed. Only the padding of the clickable area is increased for small amount as requested from UI/UX engineer.

![Screenshot 2023-09-25 at 13 13 18](https://github.com/MetaMask/metamask-extension/assets/13301024/4b42ca91-60da-4453-af06-4e6ff720edb7)
![Screenshot 2023-09-25 at 13 13 34](https://github.com/MetaMask/metamask-extension/assets/13301024/a2b6ffe2-0785-407b-b3ec-fe83e474512a)


## **Related issues**
Fixes: https://github.com/MetaMask/metamask-extension/issues/20885

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've clearly explained:
  - [ ] What problem this PR is solving.
  - [ ] How this problem was solved.
  - [ ] How reviewers can test my changes.
- [ ] I’ve indicated what issue this PR is linked to: Fixes #???
- [ ] I’ve included tests if applicable.
- [ ] I’ve documented any added code.
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)).
- [ ] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
