### PR TITLE
chore: Prevent reusing Yarn cache across Yarn versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -361,17 +361,22 @@ jobs:
     executor: node-browsers
     steps:
       - run: *shallow-git-clone
+      - run:
+          name: Save Yarn version
+          command: |
+            yarn --version > /tmp/YARN_VERSION
       - restore_cache:
           keys:
             # First try to get the specific cache for the checksum of the yarn.lock file.
             # This cache key lookup will fail if the lock file is modified and a cache
             # has not yet been persisted for the new checksum.
-            - dependency-cache-v1-{{ checksum "yarn.lock" }}
+            - dependency-cache-{{ checksum "/tmp/YARN_VERSION" }}-{{ checksum "yarn.lock" }}
             # To prevent having to do a full install of every node_module when
             # dependencies change, restore from the last known cache of any
-            # branch/checksum, the install step will remove cached items that are no longer
-            # required and add the new dependencies, and the cache will be persisted.
-            - dependency-cache-v1-
+            # branch/checksum with the same Yarn version, the install step will remove
+            # cached items that are no longer required and add the new dependencies, and
+            # the cache will be persisted.
+            - dependency-cache-{{ checksum "/tmp/YARN_VERSION" }}-
       - gh/install
       - run:
           name: Install dependencies


### PR DESCRIPTION
## **Description**

The Yarn cache will no longer be reused across Yarn versions in our CircleCI pipeline. This should prevent bugs in the event that the lockfile format changes again, or the checksum method used by Yarn.

We saw this problem when we upgraded from Yarn v3 to v4 on our main branch. We prepared a backport release that was still using v3, and it resulted in lockfile errors that we didn't catch until 2 releases later.

## **Manual testing steps**

See that CI completes successfully using the correct cache key

## **Related issues**

None

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained:
  - [x] What problem this PR is solving.
  - [x] How this problem was solved.
  - [x] How reviewers can test my changes.
- [ ] I’ve indicated what issue this PR is linked to: Fixes #???
- [x] I’ve included tests if applicable.
- [x] I’ve documented any added code.
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)).
- [x] I’ve properly set the pull request status:
  - [x] In case it's not yet "ready for review", I've set it to "draft".
  - [x] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
