### PR TITLE
Fix custom headers in result pages

### DIFF
--- a/ui/pages/confirmation/confirmation.js
+++ b/ui/pages/confirmation/confirmation.js
@@ -18,14 +18,8 @@ import Box from '../../components/ui/box';
 import MetaMaskTemplateRenderer from '../../components/app/metamask-template-renderer';
 import ConfirmationWarningModal from '../../components/app/confirmation-warning-modal';
 import { DEFAULT_ROUTE } from '../../helpers/constants/routes';
-import {
-  AlignItems,
-  FLEX_DIRECTION,
-  Size,
-  TextColor,
-} from '../../helpers/constants/design-system';
+import { Size, TextColor } from '../../helpers/constants/design-system';
 import { useI18nContext } from '../../hooks/useI18nContext';
-import { useOriginMetadata } from '../../hooks/useOriginMetadata';
 import {
   ///: BEGIN:ONLY_INCLUDE_IN(snaps)
   getTargetSubjectMetadata,
@@ -37,7 +31,6 @@ import {
 } from '../../selectors';
 import NetworkDisplay from '../../components/app/network-display/network-display';
 import Callout from '../../components/ui/callout';
-import SiteOrigin from '../../components/ui/site-origin';
 import { Icon, IconName } from '../../components/component-library';
 import Loading from '../../components/ui/loading-screen';
 ///: BEGIN:ONLY_INCLUDE_IN(snaps)
@@ -185,7 +178,6 @@ export default function ConfirmationPage({
   const [currentPendingConfirmation, setCurrentPendingConfirmation] =
     useState(0);
   const pendingConfirmation = pendingConfirmations[currentPendingConfirmation];
-  const originMetadata = useOriginMetadata(pendingConfirmation?.origin) || {};
   const [alertState, dismissAlert] = useAlertState(pendingConfirmation, {
     unapprovedTxsCount,
   });
@@ -368,29 +360,6 @@ export default function ConfirmationPage({
             />
           </Box>
         ) : null}
-        {
-          ///: BEGIN:ONLY_INCLUDE_IN(snaps)
-          !isSnapDialog &&
-            ///: END:ONLY_INCLUDE_IN
-            pendingConfirmation.origin === 'metamask' && (
-              <Box
-                alignItems={AlignItems.center}
-                paddingTop={2}
-                paddingRight={4}
-                paddingLeft={4}
-                paddingBottom={4}
-                flexDirection={FLEX_DIRECTION.COLUMN}
-              >
-                <SiteOrigin
-                  chip
-                  siteOrigin={originMetadata.origin}
-                  title={originMetadata.origin}
-                  iconSrc={originMetadata.iconUrl}
-                  iconName={originMetadata.hostname}
-                />
-              </Box>
-            )
-        }
         {
           ///: BEGIN:ONLY_INCLUDE_IN(snaps)
           isSnapDialog && (

--- a/ui/pages/confirmation/templates/__snapshots__/error.test.js.snap
+++ b/ui/pages/confirmation/templates/__snapshots__/error.test.js.snap
@@ -8,14 +8,14 @@ exports[`error template matches the snapshot 1`] = `
     <div
       class="confirmation-page__content"
     >
+      <h2
+        class="box box--margin-top-1 box--margin-bottom-1 box--flex-direction-row typography typography--h2 typography--weight-normal typography--style-normal typography--color-text-default"
+      >
+        Error mock
+      </h2>
       <div
         class="box box--padding-4 box--flex-direction-column box--align-items-center box--height-full box--display-flex"
       >
-        <h2
-          class="box box--margin-top-1 box--margin-bottom-1 box--flex-direction-row typography typography--h2 typography--weight-normal typography--style-normal typography--color-text-default"
-        >
-          Error mock
-        </h2>
         <div
           class="box box--padding-top-2 box--padding-bottom-2 box--flex-direction-column box--justify-content-center box--align-items-center box--height-full box--display-flex"
         >
@@ -33,7 +33,7 @@ exports[`error template matches the snapshot 1`] = `
             Error
           </h3>
           <div
-            class="box box--flex-direction-row box--align-items-center box--text-align-center box--display-flex"
+            class="box box--gap-1 box--flex-direction-row box--align-items-center box--text-align-center box--display-flex"
           >
             <div
               class="actionable-message actionable-message--danger"

--- a/ui/pages/confirmation/templates/__snapshots__/success.test.js.snap
+++ b/ui/pages/confirmation/templates/__snapshots__/success.test.js.snap
@@ -8,14 +8,14 @@ exports[`success template matches the snapshot 1`] = `
     <div
       class="confirmation-page__content"
     >
+      <h2
+        class="box box--margin-top-1 box--margin-bottom-1 box--flex-direction-row typography typography--h2 typography--weight-normal typography--style-normal typography--color-text-default"
+      >
+        Success mock
+      </h2>
       <div
         class="box box--padding-4 box--flex-direction-column box--align-items-center box--height-full box--display-flex"
       >
-        <h2
-          class="box box--margin-top-1 box--margin-bottom-1 box--flex-direction-row typography typography--h2 typography--weight-normal typography--style-normal typography--color-text-default"
-        >
-          Success mock
-        </h2>
         <div
           class="box box--padding-top-2 box--padding-bottom-2 box--flex-direction-column box--justify-content-center box--align-items-center box--height-full box--display-flex"
         >
@@ -33,7 +33,7 @@ exports[`success template matches the snapshot 1`] = `
             Success
           </h3>
           <div
-            class="box box--flex-direction-row box--align-items-center box--text-align-center box--display-flex"
+            class="box box--gap-1 box--flex-direction-row box--align-items-center box--text-align-center box--display-flex"
           >
             Success message
           </div>

--- a/ui/pages/confirmation/templates/error.js
+++ b/ui/pages/confirmation/templates/error.js
@@ -10,13 +10,14 @@ import {
   IconColor,
   BackgroundColor,
 } from '../../../helpers/constants/design-system';
-import { processError } from '../util';
+import { processError, processHeader } from '../util';
 
 function getValues(pendingApproval, t, actions, _history) {
   return {
     content: [
+      ...processHeader(pendingApproval.requestData.header),
       {
-        key: 'header',
+        key: 'container',
         element: 'Box',
         props: {
           flexDirection: FlexDirection.Column,
@@ -25,7 +26,6 @@ function getValues(pendingApproval, t, actions, _history) {
           padding: 4,
         },
         children: [
-          ...(pendingApproval.requestData.header || []),
           {
             key: 'content',
             element: 'Box',
@@ -66,6 +66,7 @@ function getValues(pendingApproval, t, actions, _history) {
                 props: {
                   alignItems: AlignItems.center,
                   textAlign: TextAlign.Center,
+                  gap: 1,
                 },
                 children: processError(
                   pendingApproval.requestData.error,

--- a/ui/pages/confirmation/templates/error.test.js
+++ b/ui/pages/confirmation/templates/error.test.js
@@ -18,9 +18,9 @@ const mockApproval = {
     header: [
       {
         key: 'headerText',
-        element: 'Typography',
+        name: 'Typography',
         children: 'Error mock',
-        props: {
+        properties: {
           variant: 'h2',
           class: 'header-mock-class',
         },

--- a/ui/pages/confirmation/templates/success.js
+++ b/ui/pages/confirmation/templates/success.js
@@ -10,13 +10,14 @@ import {
   IconColor,
   BackgroundColor,
 } from '../../../helpers/constants/design-system';
-import { processString } from '../util';
+import { processHeader, processString } from '../util';
 
 function getValues(pendingApproval, t, actions, _history) {
   return {
     content: [
+      ...processHeader(pendingApproval.requestData.header),
       {
-        key: 'header',
+        key: 'container',
         element: 'Box',
         props: {
           flexDirection: FlexDirection.Column,
@@ -25,7 +26,6 @@ function getValues(pendingApproval, t, actions, _history) {
           padding: 4,
         },
         children: [
-          ...(pendingApproval.requestData.header || []),
           {
             key: 'content',
             element: 'Box',
@@ -66,6 +66,7 @@ function getValues(pendingApproval, t, actions, _history) {
                 props: {
                   alignItems: AlignItems.center,
                   textAlign: TextAlign.Center,
+                  gap: 1,
                 },
                 children: processString(
                   pendingApproval.requestData.message,

--- a/ui/pages/confirmation/templates/success.test.js
+++ b/ui/pages/confirmation/templates/success.test.js
@@ -18,9 +18,9 @@ const mockApproval = {
     header: [
       {
         key: 'headerText',
-        element: 'Typography',
+        name: 'Typography',
         children: 'Success mock',
-        props: {
+        properties: {
           variant: 'h2',
           class: 'header-mock-class',
         },

--- a/ui/pages/confirmation/util.test.ts
+++ b/ui/pages/confirmation/util.test.ts
@@ -1,5 +1,5 @@
 import { ResultComponent } from '@metamask/approval-controller';
-import { processError, processString } from './util';
+import { processError, processHeader, processString } from './util';
 
 const FALLBACK_MESSAGE = 'Fallback Message';
 const mockResultComponent: ResultComponent = {
@@ -37,6 +37,7 @@ describe('processError', () => {
       props: { type: 'danger', message: 'Error Message' },
     });
   });
+
   it('returns TemplateRendererComponent when input is a ResultComponent', () => {
     const result = processError(mockResultComponent, FALLBACK_MESSAGE);
     expect(result).toEqual(expectedTemplateRendererComponent);
@@ -53,8 +54,21 @@ describe('processString', () => {
     const result = processString('Hello', FALLBACK_MESSAGE);
     expect(result).toEqual(['Hello']);
   });
+
   it('returns TemplateRendererComponent when input is a ResultComponent', () => {
     const result = processString(mockResultComponent, FALLBACK_MESSAGE);
     expect(result).toEqual(expectedTemplateRendererComponent);
+  });
+});
+
+describe('processHeader', () => {
+  it('returns undefined when input is not defined', () => {
+    const result = processHeader(undefined);
+    expect(result).toBeUndefined();
+  });
+
+  it('returns array when input is array', () => {
+    const result = processHeader(['Hello', mockResultComponent]);
+    expect(result).toEqual(['Hello', expectedTemplateRendererComponent]);
   });
 });

--- a/ui/pages/confirmation/util.ts
+++ b/ui/pages/confirmation/util.ts
@@ -57,6 +57,22 @@ export function processString(
 }
 
 /**
+ * Processes a header configuration and returns a value compatible with the template renderer.
+ *
+ * @param header - The header configuration to process.
+ * @returns The processed header.
+ */
+export function processHeader(
+  header: (string | ResultComponent)[] | undefined,
+):
+  | string
+  | TemplateRendererComponent
+  | (string | TemplateRendererComponent)[]
+  | undefined {
+  return convertResultComponents(header);
+}
+
+/**
  * Applies bold formatting to the message.
  *
  * @param message - The input message to apply bold formatting to.


### PR DESCRIPTION
## **Description**

Fixes support for the `header` property when using the standardised result pages by calling `ApprovalController.success` or `ApprovalController.error`.

Also removes the `SiteOrigin` component from the `ConfirmationPage` component as an incorrect condition meant it has not been used for the last 6 months and so reintroducing it without validation may cause undesirable visual changes.

## **Manual Testing Steps**

Not currently in use, fixing for adoption in progress.

## **Screenshots**

<img width="357" alt="success_page_header" src="https://github.com/MetaMask/metamask-extension/assets/19745142/5f8ac42c-3087-4c11-8e23-4ef4d5536043">

<img width="358" alt="error_page_header" src="https://github.com/MetaMask/metamask-extension/assets/19745142/bec8c9b5-8153-489f-bfdb-71876138496d">

## **Pre-merge Author Checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained:
  - [x] What problem this PR is solving.
  - [x] How this problem was solved.
  - [x] How reviewers can test my changes.
- [x] I’ve indicated what issue this PR is linked to: Fixes #???
- [x] I’ve included tests if applicable.
- [x] I’ve documented any added code.
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)).
- [x] I’ve properly set the pull request status:
  - [x] In case it's not yet "ready for review", I've set it to "draft".
  - [x] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
