### PR TITLE
Add logs on new extension version updates and put them in state logs

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -156,6 +156,7 @@ import {
   MetaMetricsEventCategory,
   MetaMetricsEventName,
 } from '../../shared/constants/metametrics';
+import { LOG_EVENT } from '../../shared/constants/logs';
 
 import {
   getTokenIdParam,
@@ -320,9 +321,8 @@ export default class MetamaskController extends EventEmitter {
         this.loggingController.add({
           type: LogType.GenericLog,
           data: {
-            event: 'Extension version update',
+            event: LOG_EVENT.VERSION_UPDATE,
             previousVersion: details.previousVersion,
-            timestamp: Date.now(),
             version,
           },
         });

--- a/app/scripts/metamask-controller.test.js
+++ b/app/scripts/metamask-controller.test.js
@@ -23,10 +23,10 @@ import { NETWORK_TYPES } from '../../shared/constants/network';
 import { createTestProviderTools } from '../../test/stub/provider';
 import { HardwareDeviceNames } from '../../shared/constants/hardware-wallets';
 import { KeyringType } from '../../shared/constants/keyring';
+import { LOG_EVENT } from '../../shared/constants/logs';
 import { deferredPromise } from './lib/util';
 import TransactionController from './controllers/transactions';
 import MetaMaskController from './metamask-controller';
-import { LOG_EVENT } from '../../shared/constants/logs';
 
 const Ganache = require('../../test/e2e/ganache');
 

--- a/app/scripts/metamask-controller.test.js
+++ b/app/scripts/metamask-controller.test.js
@@ -26,6 +26,7 @@ import { KeyringType } from '../../shared/constants/keyring';
 import { deferredPromise } from './lib/util';
 import TransactionController from './controllers/transactions';
 import MetaMaskController from './metamask-controller';
+import { LOG_EVENT } from '../../shared/constants/logs';
 
 const Ganache = require('../../test/e2e/ganache');
 
@@ -368,9 +369,8 @@ describe('MetaMaskController', () => {
         expect(localController.loggingController.add).toHaveBeenCalledWith({
           type: LogType.GenericLog,
           data: {
-            event: 'Extension version update',
+            event: LOG_EVENT.VERSION_UPDATE,
             previousVersion: mockOnInstalledEventDetails.previousVersion,
-            timestamp: expect.any(Number),
             version: mockVersion,
           },
         });

--- a/shared/constants/logs.ts
+++ b/shared/constants/logs.ts
@@ -1,0 +1,4 @@
+// This constant used for event property while logging events by LoggingController
+export const LOG_EVENT = {
+  VERSION_UPDATE: 'Extension version update',
+}

--- a/shared/constants/logs.ts
+++ b/shared/constants/logs.ts
@@ -1,4 +1,4 @@
 // This constant used for event property while logging events by LoggingController
 export const LOG_EVENT = {
   VERSION_UPDATE: 'Extension version update',
-}
+};

--- a/ui/index.js
+++ b/ui/index.js
@@ -240,14 +240,27 @@ function setupStateHooks(store) {
     const reduxState = store.getState();
     return maskObject(reduxState, SENTRY_UI_STATE);
   };
+  window.stateHooks.getLogs = function () {
+    // These logs are logged by LoggingController
+    const reduxState = store.getState();
+    const { logs } = reduxState.metamask;
+
+    const logsArray = Object.values(logs).sort((a, b) => {
+      return a.timestamp - b.timestamp;
+    });
+
+    return logsArray;
+  };
 }
 
 window.logStateString = async function (cb) {
   const state = await window.stateHooks.getCleanAppState();
+  const logs = window.stateHooks.getLogs();
   browser.runtime
     .getPlatformInfo()
     .then((platform) => {
       state.platform = platform;
+      state.logs = logs;
       const stateString = JSON.stringify(state, null, 2);
       cb(null, stateString);
     })


### PR DESCRIPTION
## **Description**

This PR aims to implement logs on new extension version install & first time event. LoggingController logs are intended to extend "State Logs", hence this PR also includes that change. Later, we will also implement `SignatureController` logs on this task: https://github.com/MetaMask/MetaMask-planning/issues/1321

## **Manual testing steps**

I couldn't find a appropriate way to test this manually because `onInstalled` event (my guess) could only triggered by Chrome itself. Tested these but no luck
1. Change package.json versions on dev env back and forth
2. Change dist versions back and forth & use "update" button on chrome extension tab
3. Changed dist version manifest.json manually and "update" button on chrome extension tab 

These are updating the version of extension which shown in the extension tab (chrome://extensions/) but not triggering the event.

But the log exporter works as expected because earlier I made some tests for signatures, here is the exported JSON.

[MetaMask state logs.txt](https://github.com/MetaMask/metamask-extension/files/12740832/MetaMask.state.logs.txt)

## **Screenshots/Recordings**

N/A

## **Related issues**

Fixes https://github.com/MetaMask/metamask-extension/issues/19478

## **Pre-merge author checklist**

- [X] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've clearly explained:
  - [X] What problem this PR is solving.
  - [X] How this problem was solved.
  - [X] How reviewers can test my changes.
- [X] I’ve indicated what issue this PR is linked to: Fixes #???
- [X] I’ve included tests if applicable.
- [X] I’ve documented any added code.
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)).
- [X] I’ve properly set the pull request status:
  - [X] In case it's not yet "ready for review", I've set it to "draft".
  - [X] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
