### PR TITLE
Only get snap name if it's a snap dialog

### DIFF
--- a/ui/pages/confirmation/confirmation.js
+++ b/ui/pages/confirmation/confirmation.js
@@ -216,11 +216,6 @@ export default function ConfirmationPage({
     getTargetSubjectMetadata(state, pendingConfirmation?.origin),
   );
 
-  // When pendingConfirmation is undefined, this will also be undefined
-  const snapName =
-    targetSubjectMetadata &&
-    getSnapName(pendingConfirmation?.origin, targetSubjectMetadata);
-
   const SNAP_DIALOG_TYPE = [
     ApprovalType.SnapDialogAlert,
     ApprovalType.SnapDialogConfirmation,
@@ -228,6 +223,12 @@ export default function ConfirmationPage({
   ];
 
   const isSnapDialog = SNAP_DIALOG_TYPE.includes(pendingConfirmation?.type);
+
+  // When pendingConfirmation is undefined, this will also be undefined
+  const snapName =
+    isSnapDialog &&
+    targetSubjectMetadata &&
+    getSnapName(pendingConfirmation?.origin, targetSubjectMetadata);
   ///: END:ONLY_INCLUDE_IN
 
   const INPUT_STATE_CONFIRMATIONS = [


### PR DESCRIPTION
## **Description**
This fixes a regression in v11.0.0 where if you would try to switch network it would crash the confirmation.

It adds a condition to only get the snap name if the confirmation is a snap dialog.


https://github.com/MetaMask/metamask-extension/assets/13910212/b2fc06b2-6cd7-48b3-a08b-4bd562b97bcd



## **Manual testing steps**

From the issue: 
- Go to [luxy.io](https://luxy.io/) (this is not the website that I have been working on, but from another developer with the same issue, since mine aren't deployed to production yet).
- First login into your MetaMask extension (check that your MetaMask is the latest 11.0.0 version) and switch to one of the non-supported networks for the [luxy.io](https://luxy.io/) website, so that after connecting you will get the switch network button (I connected to Goerli, but any testnet would work).
- Click on the Connect button in the top right and click on the Sign button.
- Now you should see a Network not supported button in the top right, if you don't see it, switch to some other network manually in your MetaMask. Click on the Network not supported button and select the Ethereum network button in the opened modal.
- After clicking on the Ethereum button, MetaMask should try to switch the network.

## **Related issues**

Fixes #21040

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained:
  - [x] What problem this PR is solving.
  - [x] How this problem was solved.
  - [x] How reviewers can test my changes.
- [x] I’ve indicated what issue this PR is linked to: Fixes #???
- [x] I’ve included tests if applicable.
- [x] I’ve documented any added code.
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)).
- [x] I’ve properly set the pull request status:
  - [x] In case it's not yet "ready for review", I've set it to "draft".
  - [x] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
