### PR TITLE
UX: Ensure CURRENCY_SYMBOLS is available to all builds

### DIFF
--- a/ui/components/multichain/balance-overview/balance-overview.js
+++ b/ui/components/multichain/balance-overview/balance-overview.js
@@ -33,9 +33,7 @@ import {
   TextColor,
   TextVariant,
 } from '../../../helpers/constants/design-system';
-///: BEGIN:ONLY_INCLUDE_IN(build-main,build-beta,build-flask)
 import { CURRENCY_SYMBOLS } from '../../../../shared/constants/network';
-///: END:ONLY_INCLUDE_IN
 
 export const BalanceOverview = ({ balance, loading }) => {
   const trackEvent = useContext(MetaMetricsContext);


### PR DESCRIPTION
## **Description**
@DDDDDanica pointed out in a [recent PR](https://github.com/MetaMask/metamask-extension/pull/20678#discussion_r1312363401) that a given constant would only be available build type, where it should be available for all.

## **Manual testing steps**

_1. Run `MULTICHAIN=1 yarn start`
_2.  Ensure balance-overview.js displays properly at the top of the tokens page


## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've clearly explained:
  - [ ] What problem this PR is solving.
  - [ ] How this problem was solved.
  - [ ] How reviewers can test my changes.
- [ ] I’ve indicated what issue this PR is linked to: Fixes #???
- [ ] I’ve included tests if applicable.
- [ ] I’ve documented any added code.
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)).
- [ ] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
