### PR TITLE
fix import NFT notice condition

### DIFF
--- a/ui/components/app/nfts-detection-notice-import-nfts/nfts-detection-notice-import-nfts.js
+++ b/ui/components/app/nfts-detection-notice-import-nfts/nfts-detection-notice-import-nfts.js
@@ -1,10 +1,11 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { useHistory } from 'react-router-dom';
 import { BannerAlert } from '../../component-library';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import { SECURITY_ROUTE } from '../../../helpers/constants/routes';
 
-export default function NftsDetectionNoticeImportNFTs() {
+export default function NftsDetectionNoticeImportNFTs({ onActionButtonClick }) {
   const t = useI18nContext();
   const history = useHistory();
 
@@ -15,6 +16,7 @@ export default function NftsDetectionNoticeImportNFTs() {
       actionButtonOnClick={(e) => {
         e.preventDefault();
         history.push(`${SECURITY_ROUTE}#opensea-api`);
+        onActionButtonClick?.();
       }}
     >
       {t('newNFTDetectedInImportNFTsMessage', [
@@ -25,3 +27,7 @@ export default function NftsDetectionNoticeImportNFTs() {
     </BannerAlert>
   );
 }
+
+NftsDetectionNoticeImportNFTs.propTypes = {
+  onActionButtonClick: PropTypes.func.isRequired,
+};

--- a/ui/components/multichain/import-nfts-modal/import-nfts-modal.js
+++ b/ui/components/multichain/import-nfts-modal/import-nfts-modal.js
@@ -26,7 +26,6 @@ import {
   getIsMainnet,
   getOpenSeaEnabled,
   getSelectedAddress,
-  getUseNftDetection,
 } from '../../../selectors';
 import {
   addNftVerifyOwnership,
@@ -58,7 +57,6 @@ export const ImportNftsModal = ({ onClose }) => {
   const t = useI18nContext();
   const history = useHistory();
   const dispatch = useDispatch();
-  const useNftDetection = useSelector(getUseNftDetection);
   const isDisplayNFTMediaToggleEnabled = useSelector(getOpenSeaEnabled);
   const isMainnet = useSelector(getIsMainnet);
   const nftsDropdownState = useSelector(getNftsDropdownState);

--- a/ui/components/multichain/import-nfts-modal/import-nfts-modal.js
+++ b/ui/components/multichain/import-nfts-modal/import-nfts-modal.js
@@ -24,6 +24,7 @@ import { useI18nContext } from '../../../hooks/useI18nContext';
 import {
   getCurrentChainId,
   getIsMainnet,
+  getOpenSeaEnabled,
   getSelectedAddress,
   getUseNftDetection,
 } from '../../../selectors';
@@ -58,6 +59,7 @@ export const ImportNftsModal = ({ onClose }) => {
   const history = useHistory();
   const dispatch = useDispatch();
   const useNftDetection = useSelector(getUseNftDetection);
+  const isDisplayNFTMediaToggleEnabled = useSelector(getOpenSeaEnabled);
   const isMainnet = useSelector(getIsMainnet);
   const nftsDropdownState = useSelector(getNftsDropdownState);
   const selectedAddress = useSelector(getSelectedAddress);
@@ -162,7 +164,7 @@ export const ImportNftsModal = ({ onClose }) => {
           {t('importNFT')}
         </ModalHeader>
         <Box>
-          {isMainnet && !useNftDetection ? (
+          {isMainnet && !isDisplayNFTMediaToggleEnabled ? (
             <Box marginTop={6}>
               <NftsDetectionNoticeImportNFTs />
             </Box>

--- a/ui/components/multichain/import-nfts-modal/import-nfts-modal.js
+++ b/ui/components/multichain/import-nfts-modal/import-nfts-modal.js
@@ -164,7 +164,7 @@ export const ImportNftsModal = ({ onClose }) => {
         <Box>
           {isMainnet && !isDisplayNFTMediaToggleEnabled ? (
             <Box marginTop={6}>
-              <NftsDetectionNoticeImportNFTs />
+              <NftsDetectionNoticeImportNFTs onActionButtonClick={onClose} />
             </Box>
           ) : null}
           {nftAddFailed && (


### PR DESCRIPTION
## **Description**

[We recently changed](https://github.com/MetaMask/metamask-extension/pull/20981) the copy on some parts of the NFT flows, including this import NFT screen. The previous logic was to show the notice if autodetect functionality was enabled, but with the new copy, a new condition is more appropriate. This PR changes that condition.

Edit from Dan M: This PR also now addresses a small UX issue. The "Import NFT" modal is now automatically closed if the user clicks the link to settings in the import NFT notice. This could have been done in a separate PR, however it is related to the functional testing of the present PR, so I decided to include it.


## **Manual testing steps**

(From DanM: the strikethroughs and italics below are my edits, I think the original was a typo, but I am leaving here so others can audit my changes)
1. Turn off Display NFT Media
2. Click import NFT
3. The notice ~~does not~~  _does_ appear.
4. Turn on Display NFT Media
5. Click import NFT
6. The notice ~~does~~ _does not_ appear.

scenario 2:
1. Turn off Display NFT Media
2. Click import NFT
3. Click "Turn on Display NFT Media". You should be taken to the settings page and the modal should be closed.
4. Once on the settings page, click the "Turn on Display NFT Media toggle"
5. Return to the home screen and click "Import NFT"
6. The notice does not appear.