### PR TITLE
feat: Remove SIWE mismatch account warning

### DIFF
--- a/ui/components/app/signature-request-siwe/signature-request-siwe-header/signature-request-siwe-header.js
+++ b/ui/components/app/signature-request-siwe/signature-request-siwe-header/signature-request-siwe-header.js
@@ -48,9 +48,7 @@ export default function SignatureRequestSIWEHeader({
       {fromAccount && (
         <AccountListItem
           account={fromAccount}
-          ///: BEGIN:ONLY_INCLUDE_IN(build-mmi)
           hideDefaultMismatchWarning
-          ///: END:ONLY_INCLUDE_IN
           className="signature-request-siwe-header__account-list-item"
         />
       )}


### PR DESCRIPTION
## **Description**

Removes the mismatch account warning from SIWE


See https://github.com/MetaMask/metamask-extension/issues/20893#issuecomment-1739654436 for details

## **Manual testing steps**

See issue ticket for repro steps https://github.com/MetaMask/metamask-extension/issues/20893

## **Screenshots/Recordings**

_If applicable, add screenshots and/or recordings to visualize the before and after of your change._

### **Before**

<img width="384" alt="Screenshot 2023-09-28 at 8 35 55 PM" src="https://github.com/MetaMask/metamask-extension/assets/20778143/5f00f92d-5a1a-4c0e-a38f-5d251c359b3e">


### **After**

<img width="372" alt="Screenshot 2023-09-28 at 8 59 04 PM" src="https://github.com/MetaMask/metamask-extension/assets/20778143/1202d823-7180-45f8-b26d-fd8909e838ca">


_[screenshot]_

## **Related issues**

Fixes https://github.com/MetaMask/metamask-extension/issues/20893

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've clearly explained:
  - [ ] What problem this PR is solving.
  - [ ] How this problem was solved.
  - [ ] How reviewers can test my changes.
- [ ] I’ve indicated what issue this PR is linked to: Fixes #???
- [ ] I’ve included tests if applicable.
- [ ] I’ve documented any added code.
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)).
- [ ] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
