### PR TITLE
Rename `coreKeyringController` to `keyringController`

### DIFF
--- a/app/scripts/lib/snap-keyring/snap-keyring.ts
+++ b/app/scripts/lib/snap-keyring/snap-keyring.ts
@@ -29,7 +29,7 @@ export const getAccountsBySnapId = async (
  *
  * @param getSnapController - A function that retrieves the Snap Controller instance.
  * @param getApprovalController - A function that retrieves the Approval Controller instance.
- * @param getCoreKeyringController - A function that retrieves the Core Keyring Controller instance.
+ * @param getKeyringController - A function that retrieves the Keyring Controller instance.
  * @param removeAccountHelper - A function to help remove an account based on its address.
  * @returns The constructed SnapKeyring builder instance with the following methods:
  * - `saveState`: Persists all keyrings in the keyring controller.
@@ -39,17 +39,17 @@ export const getAccountsBySnapId = async (
 export const snapKeyringBuilder = (
   getSnapController: () => SnapController,
   getApprovalController: () => ApprovalController,
-  getCoreKeyringController: () => KeyringController,
+  getKeyringController: () => KeyringController,
   removeAccountHelper: (address: string) => Promise<any>,
 ) => {
   const builder = (() => {
     return new SnapKeyring(getSnapController() as any, {
       addressExists: async (address) => {
-        const addresses = await getCoreKeyringController().getAccounts();
+        const addresses = await getKeyringController().getAccounts();
         return addresses.includes(address.toLowerCase());
       },
       saveState: async () => {
-        await getCoreKeyringController().persistAllKeyrings();
+        await getKeyringController().persistAllKeyrings();
       },
       addAccount: async (
         _address: string,
@@ -75,7 +75,7 @@ export const snapKeyringBuilder = (
           if (confirmationResult) {
             try {
               await handleUserInput(confirmationResult);
-              await getCoreKeyringController().persistAllKeyrings();
+              await getKeyringController().persistAllKeyrings();
               await getApprovalController().success({
                 message: t('snapAccountCreated') ?? 'Your account is ready!',
                 header: [snapAuthorshipHeader],
@@ -127,7 +127,7 @@ export const snapKeyringBuilder = (
             try {
               await removeAccountHelper(address);
               await handleUserInput(confirmationResult);
-              await getCoreKeyringController().persistAllKeyrings();
+              await getKeyringController().persistAllKeyrings();
               await getApprovalController().success({
                 message: t('snapAccountRemoved') ?? 'Account removed',
                 header: [snapAuthorshipHeader],

--- a/app/scripts/metamask-controller.actions.test.js
+++ b/app/scripts/metamask-controller.actions.test.js
@@ -177,7 +177,7 @@ describe('MetaMaskController', function () {
         ]),
         Promise.resolve(1).then(() => {
           keyringControllerState1 = JSON.stringify(
-            metamaskController.coreKeyringController.state,
+            metamaskController.keyringController.state,
           );
           metamaskController.importAccountWithStrategy('privateKey', [
             importPrivkey,
@@ -185,7 +185,7 @@ describe('MetaMaskController', function () {
         }),
         Promise.resolve(2).then(() => {
           keyringControllerState2 = JSON.stringify(
-            metamaskController.coreKeyringController.state,
+            metamaskController.keyringController.state,
           );
         }),
       ]);

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -857,13 +857,13 @@ export default class MetamaskController extends EventEmitter {
     ///: BEGIN:ONLY_INCLUDE_IN(keyring-snaps)
     const getSnapController = () => this.snapController;
     const getApprovalController = () => this.approvalController;
-    const getCoreKeyringController = () => this.coreKeyringController;
+    const getKeyringController = () => this.keyringController;
 
     additionalKeyrings.push(
       snapKeyringBuilder(
         getSnapController,
         getApprovalController,
-        getCoreKeyringController,
+        getKeyringController,
         (address) => this.removeAccount(address),
       ),
     );
@@ -892,7 +892,7 @@ export default class MetamaskController extends EventEmitter {
       ],
     });
 
-    this.coreKeyringController = new KeyringController({
+    this.keyringController = new KeyringController({
       keyringBuilders: additionalKeyrings,
       state: initState.KeyringController,
       encryptor: opts.encryptor || undefined,
@@ -949,8 +949,8 @@ export default class MetamaskController extends EventEmitter {
       permissionSpecifications: {
         ...getPermissionSpecifications({
           getIdentities,
-          getAllAccounts: this.coreKeyringController.getAccounts.bind(
-            this.coreKeyringController,
+          getAllAccounts: this.keyringController.getAccounts.bind(
+            this.keyringController,
           ),
           captureKeyringTypesWithMissingIdentities: (
             identities = {},
@@ -961,7 +961,7 @@ export default class MetamaskController extends EventEmitter {
             );
             const keyringTypesWithMissingIdentities =
               accountsMissingIdentities.map((address) =>
-                this.coreKeyringController.getAccountKeyringType(address),
+                this.keyringController.getAccountKeyringType(address),
               );
 
             const identitiesCount = Object.keys(identities || {}).length;
@@ -1247,8 +1247,8 @@ export default class MetamaskController extends EventEmitter {
         this.networkController.state.providerConfig.chainId,
       preferencesStore: this.preferencesController.store,
       txHistoryLimit: 60,
-      signTransaction: this.coreKeyringController.signTransaction.bind(
-        this.coreKeyringController,
+      signTransaction: this.keyringController.signTransaction.bind(
+        this.keyringController,
       ),
       provider: this.provider,
       blockTracker: this.blockTracker,
@@ -1400,7 +1400,7 @@ export default class MetamaskController extends EventEmitter {
           `${this.approvalController.name}:addRequest`,
           `${this.approvalController.name}:acceptRequest`,
           `${this.approvalController.name}:rejectRequest`,
-          `${this.coreKeyringController.name}:decryptMessage`,
+          `${this.keyringController.name}:decryptMessage`,
         ],
       }),
       metricsEvent: this.metaMetricsController.trackEvent.bind(
@@ -1418,13 +1418,12 @@ export default class MetamaskController extends EventEmitter {
         ],
       }),
       getEncryptionPublicKey:
-        this.coreKeyringController.getEncryptionPublicKey.bind(
-          this.coreKeyringController,
+        this.keyringController.getEncryptionPublicKey.bind(
+          this.keyringController,
         ),
-      getAccountKeyringType:
-        this.coreKeyringController.getAccountKeyringType.bind(
-          this.coreKeyringController,
-        ),
+      getAccountKeyringType: this.keyringController.getAccountKeyringType.bind(
+        this.keyringController,
+      ),
       getState: this.getState.bind(this),
       metricsEvent: this.metaMetricsController.trackEvent.bind(
         this.metaMetricsController,
@@ -1436,9 +1435,9 @@ export default class MetamaskController extends EventEmitter {
         name: 'SignatureController',
         allowedActions: [
           `${this.approvalController.name}:addRequest`,
-          `${this.coreKeyringController.name}:signMessage`,
-          `${this.coreKeyringController.name}:signPersonalMessage`,
-          `${this.coreKeyringController.name}:signTypedMessage`,
+          `${this.keyringController.name}:signMessage`,
+          `${this.keyringController.name}:signPersonalMessage`,
+          `${this.keyringController.name}:signTypedMessage`,
         ],
       }),
       isEthSignEnabled: () =>
@@ -1467,7 +1466,7 @@ export default class MetamaskController extends EventEmitter {
     ///: BEGIN:ONLY_INCLUDE_IN(build-mmi)
     this.mmiController = new MMIController({
       mmiConfigurationController: this.mmiConfigurationController,
-      keyringController: this.coreKeyringController,
+      keyringController: this.keyringController,
       txController: this.txController,
       securityProviderRequest: this.securityProviderRequest.bind(this),
       preferencesController: this.preferencesController,
@@ -1733,7 +1732,7 @@ export default class MetamaskController extends EventEmitter {
       AppStateController: this.appStateController.store,
       AppMetadataController: this.appMetadataController.store,
       TransactionController: this.txController.store,
-      KeyringController: this.coreKeyringController,
+      KeyringController: this.keyringController,
       PreferencesController: this.preferencesController.store,
       MetaMetricsController: this.metaMetricsController.store,
       AddressBookController: this.addressBookController,
@@ -1785,7 +1784,7 @@ export default class MetamaskController extends EventEmitter {
         AppMetadataController: this.appMetadataController.store,
         NetworkController: this.networkController,
         CachedBalancesController: this.cachedBalancesController.store,
-        KeyringController: this.coreKeyringController,
+        KeyringController: this.keyringController,
         PreferencesController: this.preferencesController.store,
         MetaMetricsController: this.metaMetricsController.store,
         AddressBookController: this.addressBookController,
@@ -1932,11 +1931,11 @@ export default class MetamaskController extends EventEmitter {
    * @returns {SnapKeyring}
    */
   async getSnapKeyring() {
-    let [snapKeyring] = this.coreKeyringController.getKeyringsByType(
+    let [snapKeyring] = this.keyringController.getKeyringsByType(
       KeyringType.snap,
     );
     if (!snapKeyring) {
-      snapKeyring = await this.coreKeyringController.addNewKeyring(
+      snapKeyring = await this.keyringController.addNewKeyring(
         KeyringType.snap,
       );
     }
@@ -2295,7 +2294,7 @@ export default class MetamaskController extends EventEmitter {
    * @returns {object} status
    */
   getState() {
-    const { vault } = this.coreKeyringController.state;
+    const { vault } = this.keyringController.state;
     const isInitialized = Boolean(vault);
 
     const flatState = this.memStore.getFlatState();
@@ -2331,7 +2330,7 @@ export default class MetamaskController extends EventEmitter {
       addressBookController,
       alertController,
       appStateController,
-      coreKeyringController,
+      keyringController,
       nftController,
       nftDetectionController,
       currencyRateController,
@@ -2457,17 +2456,15 @@ export default class MetamaskController extends EventEmitter {
 
       // qr hardware devices
       submitQRHardwareCryptoHDKey:
-        coreKeyringController.submitQRCryptoHDKey.bind(coreKeyringController),
+        keyringController.submitQRCryptoHDKey.bind(keyringController),
       submitQRHardwareCryptoAccount:
-        coreKeyringController.submitQRCryptoAccount.bind(coreKeyringController),
-      cancelSyncQRHardware: coreKeyringController.cancelQRSynchronization.bind(
-        coreKeyringController,
-      ),
-      submitQRHardwareSignature: coreKeyringController.submitQRSignature.bind(
-        coreKeyringController,
-      ),
+        keyringController.submitQRCryptoAccount.bind(keyringController),
+      cancelSyncQRHardware:
+        keyringController.cancelQRSynchronization.bind(keyringController),
+      submitQRHardwareSignature:
+        keyringController.submitQRSignature.bind(keyringController),
       cancelQRHardwareSignRequest:
-        coreKeyringController.cancelQRSignRequest.bind(coreKeyringController),
+        keyringController.cancelQRSignRequest.bind(keyringController),
 
       // vault management
       submitPassword: this.submitPassword.bind(this),
@@ -2950,7 +2947,7 @@ export default class MetamaskController extends EventEmitter {
 
   async exportAccount(address, password) {
     await this.verifyPassword(password);
-    return this.coreKeyringController.exportAccount(password, address);
+    return this.keyringController.exportAccount(password, address);
   }
 
   async getTokenStandardAndDetails(address, userAddress, tokenId) {
@@ -3047,11 +3044,11 @@ export default class MetamaskController extends EventEmitter {
   async createNewVaultAndKeychain(password) {
     const releaseLock = await this.createVaultMutex.acquire();
     try {
-      const vault = await this.coreKeyringController.createNewVaultAndKeychain(
+      const vault = await this.keyringController.createNewVaultAndKeychain(
         password,
       );
 
-      const accounts = await this.coreKeyringController.getAccounts();
+      const accounts = await this.keyringController.getAccounts();
       this.preferencesController.setAddresses(accounts);
       this.selectFirstIdentity();
 
@@ -3098,13 +3095,13 @@ export default class MetamaskController extends EventEmitter {
       this.txController.txStateManager.clearUnapprovedTxs();
 
       // create new vault
-      const vault = await this.coreKeyringController.createNewVaultAndRestore(
+      const vault = await this.keyringController.createNewVaultAndRestore(
         password,
         this._convertMnemonicToWordlistIndices(seedPhraseAsBuffer),
       );
 
       const ethQuery = new EthQuery(this.provider);
-      accounts = await this.coreKeyringController.getAccounts();
+      accounts = await this.keyringController.getAccounts();
       lastBalance = await this.getBalance(
         accounts[accounts.length - 1],
         ethQuery,
@@ -3113,15 +3110,15 @@ export default class MetamaskController extends EventEmitter {
       // seek out the first zero balance
       while (lastBalance !== '0x0') {
         const { addedAccountAddress } =
-          await this.coreKeyringController.addNewAccount(accounts.length);
-        accounts = await this.coreKeyringController.getAccounts();
+          await this.keyringController.addNewAccount(accounts.length);
+        accounts = await this.keyringController.getAccounts();
         lastBalance = await this.getBalance(addedAccountAddress, ethQuery);
       }
 
       // remove extra zero balance account potentially created from seeking ahead
       if (accounts.length > 1 && lastBalance === '0x0') {
         await this.removeAccount(accounts[accounts.length - 1]);
-        accounts = await this.coreKeyringController.getAccounts();
+        accounts = await this.keyringController.getAccounts();
       }
 
       // This must be set as soon as possible to communicate to the
@@ -3201,7 +3198,7 @@ export default class MetamaskController extends EventEmitter {
    * @param {string} password - The user's password
    */
   async submitPassword(password) {
-    await this.coreKeyringController.submitPassword(password);
+    await this.keyringController.submitPassword(password);
 
     ///: BEGIN:ONLY_INCLUDE_IN(build-mmi)
     this.mmiController.onSubmitPassword();
@@ -3259,7 +3256,7 @@ export default class MetamaskController extends EventEmitter {
       const { loginToken, loginSalt } =
         await this.extension.storage.session.get(['loginToken', 'loginSalt']);
       if (loginToken && loginSalt) {
-        const { vault } = this.coreKeyringController.state;
+        const { vault } = this.keyringController.state;
 
         const jsonVault = JSON.parse(vault);
 
@@ -3271,10 +3268,7 @@ export default class MetamaskController extends EventEmitter {
           return;
         }
 
-        await this.coreKeyringController.submitEncryptionKey(
-          loginToken,
-          loginSalt,
-        );
+        await this.keyringController.submitEncryptionKey(loginToken, loginSalt);
       }
     } catch (e) {
       // If somehow this login token doesn't work properly,
@@ -3294,7 +3288,7 @@ export default class MetamaskController extends EventEmitter {
    * @param {string} password - The user's password
    */
   async verifyPassword(password) {
-    await this.coreKeyringController.verifyPassword(password);
+    await this.keyringController.verifyPassword(password);
   }
 
   /**
@@ -3317,7 +3311,7 @@ export default class MetamaskController extends EventEmitter {
    * Gets the mnemonic of the user's primary keyring.
    */
   getPrimaryKeyringMnemonic() {
-    const [keyring] = this.coreKeyringController.getKeyringsByType(
+    const [keyring] = this.keyringController.getKeyringsByType(
       KeyringType.hdKeyTree,
     );
     if (!keyring.mnemonic) {
@@ -3332,8 +3326,7 @@ export default class MetamaskController extends EventEmitter {
     const custodyType = this.custodyController.getCustodyTypeByAddress(
       toChecksumHexAddress(address),
     );
-    const keyring =
-      this.coreKeyringController.getKeyringsByType(custodyType)[0];
+    const keyring = this.keyringController.getKeyringsByType(custodyType)[0];
     return keyring?.getAccountDetails(address) ? keyring : undefined;
   }
   ///: END:ONLY_INCLUDE_IN
@@ -3370,11 +3363,9 @@ export default class MetamaskController extends EventEmitter {
           'MetamaskController:getKeyringForDevice - Unknown device',
         );
     }
-    let [keyring] = await this.coreKeyringController.getKeyringsByType(
-      keyringName,
-    );
+    let [keyring] = await this.keyringController.getKeyringsByType(keyringName);
     if (!keyring) {
-      keyring = await this.coreKeyringController.addNewKeyring(keyringName);
+      keyring = await this.keyringController.addNewKeyring(keyringName);
     }
     if (hdPath && keyring.setHdPath) {
       keyring.setHdPath(hdPath);
@@ -3428,7 +3419,7 @@ export default class MetamaskController extends EventEmitter {
 
     // Merge with existing accounts
     // and make sure addresses are not repeated
-    const oldAccounts = await this.coreKeyringController.getAccounts();
+    const oldAccounts = await this.keyringController.getAccounts();
     const accountsToTrack = [
       ...new Set(
         oldAccounts.concat(accounts.map((a) => a.address.toLowerCase())),
@@ -3470,7 +3461,7 @@ export default class MetamaskController extends EventEmitter {
    * @returns {'hardware' | 'imported' | 'MetaMask'}
    */
   async getAccountType(address) {
-    const keyringType = await this.coreKeyringController.getAccountKeyringType(
+    const keyringType = await this.keyringController.getAccountKeyringType(
       address,
     );
     switch (keyringType) {
@@ -3495,9 +3486,7 @@ export default class MetamaskController extends EventEmitter {
    * @returns {'ledger' | 'lattice' | 'N/A' | string}
    */
   async getDeviceModel(address) {
-    const keyring = await this.coreKeyringController.getKeyringForAccount(
-      address,
-    );
+    const keyring = await this.keyringController.getKeyringForAccount(address);
     switch (keyring.type) {
       case KeyringType.trezor:
         return keyring.getModel();
@@ -3544,11 +3533,11 @@ export default class MetamaskController extends EventEmitter {
     const keyring = await this.getKeyringForDevice(deviceName, hdPath);
 
     keyring.setAccountToUnlock(index);
-    const oldAccounts = await this.coreKeyringController.getAccounts();
-    const keyState = await this.coreKeyringController.addNewAccountForKeyring(
+    const oldAccounts = await this.keyringController.getAccounts();
+    const keyState = await this.keyringController.addNewAccountForKeyring(
       keyring,
     );
-    const newAccounts = await this.coreKeyringController.getAccounts();
+    const newAccounts = await this.keyringController.getAccounts();
     this.preferencesController.setAddresses(newAccounts);
     newAccounts.forEach((address) => {
       if (!oldAccounts.includes(address)) {
@@ -3588,10 +3577,11 @@ export default class MetamaskController extends EventEmitter {
       await new Promise((resolve) => setTimeout(resolve, 5_000));
     }
 
-    const oldAccounts = await this.coreKeyringController.getAccounts();
+    const oldAccounts = await this.keyringController.getAccounts();
 
-    const { addedAccountAddress } =
-      await this.coreKeyringController.addNewAccount(accountCount);
+    const { addedAccountAddress } = await this.keyringController.addNewAccount(
+      accountCount,
+    );
 
     if (!oldAccounts.includes(addedAccountAddress)) {
       this.preferencesController.setSelectedAddress(addedAccountAddress);
@@ -3612,7 +3602,7 @@ export default class MetamaskController extends EventEmitter {
    */
   async verifySeedPhrase() {
     return this._convertEnglishWordlistIndicesToCodepoints(
-      await this.coreKeyringController.verifySeedPhrase(),
+      await this.keyringController.verifySeedPhrase(),
     );
   }
 
@@ -3693,11 +3683,9 @@ export default class MetamaskController extends EventEmitter {
     this.custodyController.removeAccount(address);
     ///: END:ONLY_INCLUDE_IN(build-mmi)
 
-    const keyring = await this.coreKeyringController.getKeyringForAccount(
-      address,
-    );
+    const keyring = await this.keyringController.getKeyringForAccount(address);
     // Remove account from the keyring
-    await this.coreKeyringController.removeAccount(address);
+    await this.keyringController.removeAccount(address);
     const updatedKeyringAccounts = keyring ? await keyring.getAccounts() : {};
     if (updatedKeyringAccounts?.length === 0) {
       keyring.destroy?.();
@@ -3716,10 +3704,7 @@ export default class MetamaskController extends EventEmitter {
    */
   async importAccountWithStrategy(strategy, args) {
     const { importedAccountAddress } =
-      await this.coreKeyringController.importAccountWithStrategy(
-        strategy,
-        args,
-      );
+      await this.keyringController.importAccountWithStrategy(strategy, args);
     // set new account as selected
     this.preferencesController.setSelectedAddress(importedAccountAddress);
   }
@@ -4655,7 +4640,7 @@ export default class MetamaskController extends EventEmitter {
    * @returns {boolean} Whether the extension is unlocked.
    */
   isUnlocked() {
-    return this.coreKeyringController.state.isUnlocked;
+    return this.keyringController.state.isUnlocked;
   }
 
   //=============================================================================
@@ -4845,7 +4830,7 @@ export default class MetamaskController extends EventEmitter {
    * Locks MetaMask
    */
   setLocked() {
-    const [trezorKeyring] = this.coreKeyringController.getKeyringsByType(
+    const [trezorKeyring] = this.keyringController.getKeyringsByType(
       KeyringType.trezor,
     );
     if (trezorKeyring) {
@@ -4856,7 +4841,7 @@ export default class MetamaskController extends EventEmitter {
       this.clearLoginArtifacts();
     }
 
-    return this.coreKeyringController.setLocked();
+    return this.keyringController.setLocked();
   }
 
   removePermissionsFor = (subjects) => {

--- a/app/scripts/metamask-controller.test.js
+++ b/app/scripts/metamask-controller.test.js
@@ -318,11 +318,11 @@ describe('MetaMaskController', () => {
       });
 
       jest.spyOn(
-        metamaskController.coreKeyringController,
+        metamaskController.keyringController,
         'createNewVaultAndKeychain',
       );
       jest.spyOn(
-        metamaskController.coreKeyringController,
+        metamaskController.keyringController,
         'createNewVaultAndRestore',
       );
       jest
@@ -349,9 +349,9 @@ describe('MetaMaskController', () => {
         ]);
       });
 
-      it('adds private key to keyrings in core KeyringController', async () => {
+      it('adds private key to keyrings in KeyringController', async () => {
         const simpleKeyrings =
-          metamaskController.coreKeyringController.getKeyringsByType(
+          metamaskController.keyringController.getKeyringsByType(
             KeyringType.imported,
           );
         const pubAddressHexArr = await simpleKeyrings[0].getAccounts();
@@ -366,7 +366,7 @@ describe('MetaMaskController', () => {
 
       it('adds 1 account', async () => {
         const keyringAccounts =
-          await metamaskController.coreKeyringController.getAccounts();
+          await metamaskController.keyringController.getAccounts();
         expect(keyringAccounts[keyringAccounts.length - 1]).toStrictEqual(
           '0xe18035bf8712672935fdb4e5e431b1a0183d2dfc',
         );
@@ -386,7 +386,7 @@ describe('MetaMaskController', () => {
           metamaskController.preferencesController.store.getState().identities,
         );
         const addresses =
-          await metamaskController.coreKeyringController.getAccounts();
+          await metamaskController.keyringController.getAccounts();
 
         identities.forEach((identity) => {
           expect(addresses).toContain(identity);
@@ -400,15 +400,15 @@ describe('MetaMaskController', () => {
 
     describe('setLocked', () => {
       it('should lock KeyringController', async () => {
-        jest.spyOn(metamaskController.coreKeyringController, 'setLocked');
+        jest.spyOn(metamaskController.keyringController, 'setLocked');
 
         await metamaskController.setLocked();
 
         expect(
-          metamaskController.coreKeyringController.setLocked,
+          metamaskController.keyringController.setLocked,
         ).toHaveBeenCalled();
         expect(
-          metamaskController.coreKeyringController.state.isUnlocked,
+          metamaskController.keyringController.state.isUnlocked,
         ).toStrictEqual(false);
       });
     });
@@ -440,7 +440,7 @@ describe('MetaMaskController', () => {
         await metamaskController.createNewVaultAndRestore(password, TEST_SEED);
 
         expect(
-          metamaskController.coreKeyringController.createNewVaultAndRestore,
+          metamaskController.keyringController.createNewVaultAndRestore,
         ).toHaveBeenCalledTimes(2);
       });
 
@@ -626,31 +626,31 @@ describe('MetaMaskController', () => {
       });
 
       it('should add the Trezor Hardware keyring', async () => {
-        jest.spyOn(metamaskController.coreKeyringController, 'addNewKeyring');
+        jest.spyOn(metamaskController.keyringController, 'addNewKeyring');
         await metamaskController
           .connectHardware(HardwareDeviceNames.trezor, 0)
           .catch(() => null);
         const keyrings =
-          await metamaskController.coreKeyringController.getKeyringsByType(
+          await metamaskController.keyringController.getKeyringsByType(
             KeyringType.trezor,
           );
         expect(
-          metamaskController.coreKeyringController.addNewKeyring,
+          metamaskController.keyringController.addNewKeyring,
         ).toHaveBeenCalledWith(KeyringType.trezor);
         expect(keyrings).toHaveLength(1);
       });
 
       it('should add the Ledger Hardware keyring', async () => {
-        jest.spyOn(metamaskController.coreKeyringController, 'addNewKeyring');
+        jest.spyOn(metamaskController.keyringController, 'addNewKeyring');
         await metamaskController
           .connectHardware(HardwareDeviceNames.ledger, 0)
           .catch(() => null);
         const keyrings =
-          await metamaskController.coreKeyringController.getKeyringsByType(
+          await metamaskController.keyringController.getKeyringsByType(
             KeyringType.ledger,
           );
         expect(
-          metamaskController.coreKeyringController.addNewKeyring,
+          metamaskController.keyringController.addNewKeyring,
         ).toHaveBeenCalledWith(KeyringType.ledger);
         expect(keyrings).toHaveLength(1);
       });
@@ -672,7 +672,7 @@ describe('MetaMaskController', () => {
           mnemonic: uint8ArrayMnemonic,
         };
         jest
-          .spyOn(metamaskController.coreKeyringController, 'getKeyringsByType')
+          .spyOn(metamaskController.keyringController, 'getKeyringsByType')
           .mockReturnValue([mockHDKeyring]);
 
         const recoveredMnemonic =
@@ -720,7 +720,7 @@ describe('MetaMaskController', () => {
           .catch(() => null);
         await metamaskController.forgetDevice(HardwareDeviceNames.trezor);
         const keyrings =
-          await metamaskController.coreKeyringController.getKeyringsByType(
+          await metamaskController.keyringController.getKeyringsByType(
             KeyringType.trezor,
           );
 
@@ -733,20 +733,20 @@ describe('MetaMaskController', () => {
     describe('unlockHardwareWalletAccount', () => {
       const accountToUnlock = 10;
       beforeEach(async () => {
-        await metamaskController.coreKeyringController.createNewVaultAndRestore(
+        await metamaskController.keyringController.createNewVaultAndRestore(
           'password',
           TEST_SEED,
         );
         jest.spyOn(window, 'open').mockReturnValue();
         jest
           .spyOn(
-            metamaskController.coreKeyringController,
+            metamaskController.keyringController,
             'addNewAccountForKeyring',
           )
           .mockReturnValue('0x123');
 
         jest
-          .spyOn(metamaskController.coreKeyringController, 'getAccounts')
+          .spyOn(metamaskController.keyringController, 'getAccounts')
           .mockResolvedValueOnce(['0x1'])
           .mockResolvedValueOnce(['0x2'])
           .mockResolvedValueOnce(['0x3']);
@@ -769,7 +769,7 @@ describe('MetaMaskController', () => {
 
       it('should set unlockedAccount in the keyring', async () => {
         const keyrings =
-          await metamaskController.coreKeyringController.getKeyringsByType(
+          await metamaskController.keyringController.getKeyringsByType(
             KeyringType.trezor,
           );
         expect(keyrings[0].unlockedAccount).toStrictEqual(accountToUnlock);
@@ -777,13 +777,13 @@ describe('MetaMaskController', () => {
 
       it('should call keyringController.addNewAccount', async () => {
         expect(
-          metamaskController.coreKeyringController.addNewAccountForKeyring,
+          metamaskController.keyringController.addNewAccountForKeyring,
         ).toHaveBeenCalledTimes(1);
       });
 
       it('should call keyringController.getAccounts', async () => {
         expect(
-          metamaskController.coreKeyringController.getAccounts,
+          metamaskController.keyringController.getAccounts,
         ).toHaveBeenCalledTimes(2);
       });
 
@@ -825,7 +825,7 @@ describe('MetaMaskController', () => {
         await metamaskController.createNewVaultAndKeychain('password');
         await metamaskController.addNewAccount(1);
         const getAccounts =
-          await metamaskController.coreKeyringController.getAccounts();
+          await metamaskController.keyringController.getAccounts();
         expect(getAccounts).toHaveLength(2);
       });
     });
@@ -884,17 +884,14 @@ describe('MetaMaskController', () => {
           destroy: jest.fn(),
         };
         jest
-          .spyOn(metamaskController.coreKeyringController, 'removeAccount')
+          .spyOn(metamaskController.keyringController, 'removeAccount')
           .mockReturnValue();
         jest
           .spyOn(metamaskController, 'removeAllAccountPermissions')
           .mockReturnValue();
 
         jest
-          .spyOn(
-            metamaskController.coreKeyringController,
-            'getKeyringForAccount',
-          )
+          .spyOn(metamaskController.keyringController, 'getKeyringForAccount')
           .mockResolvedValue(mockKeyring);
 
         ret = await metamaskController.removeAccount(addressToRemove);
@@ -902,7 +899,7 @@ describe('MetaMaskController', () => {
 
       it('should call keyringController.removeAccount', async () => {
         expect(
-          metamaskController.coreKeyringController.removeAccount,
+          metamaskController.keyringController.removeAccount,
         ).toHaveBeenCalledWith(addressToRemove);
       });
       it('should call metamaskController.removeAllAccountPermissions', async () => {
@@ -913,9 +910,9 @@ describe('MetaMaskController', () => {
       it('should return address', async () => {
         expect(ret).toStrictEqual('0x1');
       });
-      it('should call coreKeyringController.getKeyringForAccount', async () => {
+      it('should call keyringController.getKeyringForAccount', async () => {
         expect(
-          metamaskController.coreKeyringController.getKeyringForAccount,
+          metamaskController.keyringController.getKeyringForAccount,
         ).toHaveBeenCalledWith(addressToRemove);
       });
       it('should call keyring.destroy', async () => {


### PR DESCRIPTION
## **Description**
When migrating from `@metamask/eth-keyring-controller` to `@metamask/keyring-controller`, as we had to migrate all the interactions in different PRs (and potentially different releases), we needed a way to use both at the same time: this led to having `MetamaskController.keyringController` (old) and `MetamaskController.coreKeyringController` (new).

As all interactions have been migrated and `@metamask/eth-keyring-controller` is no longer used, we can rename all `coreKeyringController` variables to `keyringController`, to match all the other controllers.

Nothing should be changed in terms of functionality 

## **Related issues**

* Fixes #20511

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained:
  - [x] What problem this PR is solving.
  - [x] How this problem was solved.
  - [x] How reviewers can test my changes.
- [x] I’ve indicated what issue this PR is linked to: Fixes #???
- [x] I’ve included tests if applicable.
- [x] I’ve documented any added code.
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)).
- [x] I’ve properly set the pull request status:
  - [x] In case it's not yet "ready for review", I've set it to "draft".
  - [x] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
