### PR TITLE
Adding ConnectionsHeader component

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -358,6 +358,9 @@
   "alerts": {
     "message": "Alerts"
   },
+  "allButtonLink": {
+    "message": "All"
+  },
   "allCustodianAccountsConnectedSubtitle": {
     "message": "You have either already connected all your custodian accounts or don’t have any account to connect to MetaMask Institutional."
   },
@@ -2403,6 +2406,15 @@
   },
   "metamaskInstitutionalVersion": {
     "message": "MetaMask Institutional Version"
+  },
+  "metamaskNotConnected1": {
+    "message": "MetaMask isn’t connected to this site."
+  },
+  "metamaskNotConnected2": {
+    "message": "To connect to a web3 site, find and click"
+  },
+  "metamaskNotConnected3": {
+    "message": "connect"
   },
   "metamaskSwapsOfflineDescription": {
     "message": "MetaMask Swaps is undergoing maintenance. Please check back later."

--- a/ui/components/multichain/connections-header/connections-header.js
+++ b/ui/components/multichain/connections-header/connections-header.js
@@ -1,31 +1,69 @@
-import React, { useRef } from 'react';
+import React from 'react';
+import { useSelector } from 'react-redux';
 import {
   AlignItems,
+  BackgroundColor,
   BlockSize,
+  BorderStyle,
   Display,
-  FlexDirection,
   JustifyContent,
 } from '../../../helpers/constants/design-system';
-import { useI18nContext } from '../../../hooks/useI18nContext';
-import { Box, Text } from '../../component-library';
+import { HeaderBase, TagUrl, Text } from '../../component-library';
+import { getURLHost, isExtensionUrl } from '../../../helpers/utils/util';
+import {
+  getConnectedSubjectsForAllAddresses,
+  getOriginOfCurrentTab,
+  getSelectedAddress,
+} from '../../../selectors';
+// import { useI18nContext } from '../../../hooks/useI18nContext';
 
 export const ConnectionsHeader = () => {
-  const t = useI18nContext();
-  const menuRef = useRef(false);
+  // const t = useI18nContext();
+  const selectedAddress = useSelector(getSelectedAddress);
+  const currentTabOrigin = useSelector(getOriginOfCurrentTab);
+  const currentTabURLHost = isExtensionUrl(currentTabOrigin)
+    ? 'MetaMask'
+    : getURLHost(currentTabOrigin);
+  // TODO change from 'Metamask' to  default for extension
+  const connectedSites = useSelector(getConnectedSubjectsForAllAddresses);
+  const connectedSite = connectedSites[selectedAddress]?.find(
+    ({ origin }) => origin === currentTabOrigin,
+  );
+  const connectedAvatar = connectedSite?.iconUrl;
   return (
-    <Box
-      className="connections-header"
-      display={Display.Flex}
-      flexDirection={FlexDirection.Row}
-      alignItems={AlignItems.center}
+    <HeaderBase
+      style={{ 'box-shadow': '0px 2px 16px 0px rgba(0, 0, 0, 0.10)' }}
+      // TODO take out inline style
+      endAccessory={<Text as="a">All</Text>}
+      // TODO use t('all') instead of 'All'
+      childrenWrapperProps={{
+        className: 'connections-header-children-wrapper',
+        display: Display.Flex,
+        alignItems: AlignItems.center,
+        justifyContent: JustifyContent.center,
+        padding: 4,
+      }}
+      endAccessoryWrapperProps={{
+        className: 'connections-header-end-accessory-wrapper',
+        display: Display.Flex,
+        alignItems: AlignItems.center,
+        justifyContent: JustifyContent.flexEnd,
+        padding: 4,
+      }}
+      width={BlockSize.Full}
     >
-      <Text>{t('connections')}</Text>
-      <Box
-        ref={menuRef}
-        display={Display.Flex}
-        justifyContent={JustifyContent.flexEnd}
-        width={BlockSize.Full}
-      ></Box>
-    </Box>
+      {/* TODO handle overflow for long sitenames */}
+      <TagUrl
+        className="connections-header-tag-url"
+        label={currentTabURLHost}
+        borderStyle={BorderStyle.none}
+        labelProps={{ ellipsis: true }}
+        avatarFaviconProps={{
+          backgroundColor: BackgroundColor.backgroundDefault,
+        }}
+        src={connectedAvatar}
+        showLockIcon
+      />
+    </HeaderBase>
   );
 };

--- a/ui/components/multichain/connections-header/connections-header.js
+++ b/ui/components/multichain/connections-header/connections-header.js
@@ -1,0 +1,31 @@
+import React, { useRef } from 'react';
+import {
+  AlignItems,
+  BlockSize,
+  Display,
+  FlexDirection,
+  JustifyContent,
+} from '../../../helpers/constants/design-system';
+import { useI18nContext } from '../../../hooks/useI18nContext';
+import { Box, Text } from '../../component-library';
+
+export const ConnectionsHeader = () => {
+  const t = useI18nContext();
+  const menuRef = useRef(false);
+  return (
+    <Box
+      className="connections-header"
+      display={Display.Flex}
+      flexDirection={FlexDirection.Row}
+      alignItems={AlignItems.center}
+    >
+      <Text>{t('connections')}</Text>
+      <Box
+        ref={menuRef}
+        display={Display.Flex}
+        justifyContent={JustifyContent.flexEnd}
+        width={BlockSize.Full}
+      ></Box>
+    </Box>
+  );
+};

--- a/ui/components/multichain/connections-header/connections-header.js
+++ b/ui/components/multichain/connections-header/connections-header.js
@@ -1,30 +1,45 @@
 import React from 'react';
 import { useSelector } from 'react-redux';
+import PropTypes from 'prop-types';
+import { useHistory } from 'react-router-dom';
 import {
   AlignItems,
   BackgroundColor,
   BlockSize,
   BorderStyle,
+  Color,
   Display,
+  FlexDirection,
   JustifyContent,
+  TextColor,
 } from '../../../helpers/constants/design-system';
-import { HeaderBase, TagUrl, Text } from '../../component-library';
+import {
+  ButtonIcon,
+  ButtonIconSize,
+  ButtonLink,
+  HeaderBase,
+  IconName,
+  TagUrl,
+} from '../../component-library';
 import { getURLHost, isExtensionUrl } from '../../../helpers/utils/util';
 import {
   getConnectedSubjectsForAllAddresses,
   getOriginOfCurrentTab,
   getSelectedAddress,
 } from '../../../selectors';
-// import { useI18nContext } from '../../../hooks/useI18nContext';
+import { useI18nContext } from '../../../hooks/useI18nContext';
+import { DEFAULT_ROUTE } from '../../../helpers/constants/routes';
 
-export const ConnectionsHeader = () => {
-  // const t = useI18nContext();
+export const ConnectionsHeader = ({ hostName }) => {
   const selectedAddress = useSelector(getSelectedAddress);
   const currentTabOrigin = useSelector(getOriginOfCurrentTab);
-  const currentTabURLHost = isExtensionUrl(currentTabOrigin)
-    ? 'MetaMask'
-    : getURLHost(currentTabOrigin);
-  // TODO change from 'Metamask' to  default for extension
+  const t = useI18nContext();
+  const history = useHistory();
+  const currentTabURLHost =
+    hostName ??
+    (isExtensionUrl(currentTabOrigin)
+      ? t('currentExtension')
+      : getURLHost(currentTabOrigin));
   const connectedSites = useSelector(getConnectedSubjectsForAllAddresses);
   const connectedSite = connectedSites[selectedAddress]?.find(
     ({ origin }) => origin === currentTabOrigin,
@@ -32,17 +47,30 @@ export const ConnectionsHeader = () => {
   const connectedAvatar = connectedSite?.iconUrl;
   return (
     <HeaderBase
-      style={{ 'box-shadow': '0px 2px 16px 0px rgba(0, 0, 0, 0.10)' }}
-      // TODO take out inline style
-      endAccessory={<Text as="a">All</Text>}
-      // TODO use t('all') instead of 'All'
-      childrenWrapperProps={{
-        className: 'connections-header-children-wrapper',
+      className="connections-header"
+      width={BlockSize.Full}
+      startAccessory={
+        <ButtonIcon
+          ariaLabel="Back"
+          iconName={IconName.ArrowLeft}
+          className="connections-header__start-accessory"
+          color={Color.iconDefault}
+          onClick={() => history.push(DEFAULT_ROUTE)}
+          size={ButtonIconSize.Sm}
+        />
+      }
+      startAccessoryWrapperProps={{
+        className: 'connections-header__start-accessory-wrapper',
         display: Display.Flex,
         alignItems: AlignItems.center,
         justifyContent: JustifyContent.center,
         padding: 4,
       }}
+      endAccessory={
+        <ButtonLink color={TextColor.primaryDefault} onClick>
+          {t('allButtonLink')}
+        </ButtonLink>
+      }
       endAccessoryWrapperProps={{
         className: 'connections-header-end-accessory-wrapper',
         display: Display.Flex,
@@ -50,20 +78,36 @@ export const ConnectionsHeader = () => {
         justifyContent: JustifyContent.flexEnd,
         padding: 4,
       }}
-      width={BlockSize.Full}
+      childrenWrapperProps={{
+        className: 'connections-header__child-accessory-wrapper',
+        display: Display.Flex,
+        justifyContent: JustifyContent.center,
+        paddingTop: 4,
+        paddingBottom: 4,
+        flexDirection: FlexDirection.Row,
+      }}
     >
-      {/* TODO handle overflow for long sitenames */}
       <TagUrl
         className="connections-header-tag-url"
+        display={Display.Flex}
+        justifyContent={JustifyContent.center}
+        width={BlockSize.Full}
         label={currentTabURLHost}
         borderStyle={BorderStyle.none}
-        labelProps={{ ellipsis: true }}
+        labelProps={{
+          className: 'connections-header__title',
+        }}
         avatarFaviconProps={{
-          backgroundColor: BackgroundColor.backgroundDefault,
+          backgroundColor: BackgroundColor.transparent,
         }}
         src={connectedAvatar}
+        backgroundColor={BackgroundColor.transparent}
         showLockIcon
       />
     </HeaderBase>
   );
+};
+
+ConnectionsHeader.propTypes = {
+  hostName: PropTypes.string,
 };

--- a/ui/components/multichain/connections-header/connections-header.js
+++ b/ui/components/multichain/connections-header/connections-header.js
@@ -46,12 +46,13 @@ export const ConnectionsHeader = ({ hostName }) => {
   );
   const connectedAvatar = connectedSite?.iconUrl;
   return (
+    // TODO: change this to header component when it's ready
     <HeaderBase
       className="connections-header"
       width={BlockSize.Full}
       startAccessory={
         <ButtonIcon
-          ariaLabel="Back"
+          ariaLabel={t('back')}
           iconName={IconName.ArrowLeft}
           className="connections-header__start-accessory"
           color={Color.iconDefault}
@@ -67,7 +68,7 @@ export const ConnectionsHeader = ({ hostName }) => {
         padding: 4,
       }}
       endAccessory={
-        <ButtonLink color={TextColor.primaryDefault} onClick>
+        <ButtonLink color={TextColor.primaryDefault}>
           {t('allButtonLink')}
         </ButtonLink>
       }

--- a/ui/components/multichain/connections-header/connections-header.js
+++ b/ui/components/multichain/connections-header/connections-header.js
@@ -17,7 +17,6 @@ import {
   ButtonIcon,
   ButtonIconSize,
   ButtonLink,
-  HeaderBase,
   IconName,
   TagUrl,
 } from '../../component-library';
@@ -29,6 +28,7 @@ import {
 } from '../../../selectors';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import { DEFAULT_ROUTE } from '../../../helpers/constants/routes';
+import { Header } from '../pages/page';
 
 export const ConnectionsHeader = ({ hostName }) => {
   const selectedAddress = useSelector(getSelectedAddress);
@@ -46,10 +46,8 @@ export const ConnectionsHeader = ({ hostName }) => {
   );
   const connectedAvatar = connectedSite?.iconUrl;
   return (
-    // TODO: change this to header component when it's ready
-    <HeaderBase
+    <Header
       className="connections-header"
-      width={BlockSize.Full}
       startAccessory={
         <ButtonIcon
           ariaLabel={t('back')}
@@ -65,7 +63,6 @@ export const ConnectionsHeader = ({ hostName }) => {
         display: Display.Flex,
         alignItems: AlignItems.center,
         justifyContent: JustifyContent.center,
-        padding: 4,
       }}
       endAccessory={
         <ButtonLink color={TextColor.primaryDefault}>
@@ -77,14 +74,11 @@ export const ConnectionsHeader = ({ hostName }) => {
         display: Display.Flex,
         alignItems: AlignItems.center,
         justifyContent: JustifyContent.flexEnd,
-        padding: 4,
       }}
       childrenWrapperProps={{
         className: 'connections-header__child-accessory-wrapper',
         display: Display.Flex,
         justifyContent: JustifyContent.center,
-        paddingTop: 4,
-        paddingBottom: 4,
         flexDirection: FlexDirection.Row,
       }}
     >
@@ -105,7 +99,7 @@ export const ConnectionsHeader = ({ hostName }) => {
         backgroundColor={BackgroundColor.transparent}
         showLockIcon
       />
-    </HeaderBase>
+    </Header>
   );
 };
 

--- a/ui/components/multichain/connections-header/connections-header.scss
+++ b/ui/components/multichain/connections-header/connections-header.scss
@@ -1,9 +1,3 @@
-// .connections-header-children-wrapper{
-//   flex:0 0 auto;
-// }
-// .connections-header-end-accessory-wrapper{
-//   flex:0 0 auto;
-// }
-// .connections-header-tag-url{
-//   flex:0 0 auto;
-// }
+.connections-header {
+  box-shadow: var(--shadow-size-md) var(--color-shadow-default);
+}

--- a/ui/components/multichain/connections-header/connections-header.scss
+++ b/ui/components/multichain/connections-header/connections-header.scss
@@ -1,0 +1,10 @@
+.connections-header__popover {
+  z-index: $popover-in-modal-z-index;
+  overflow: hidden;
+  min-width: 225px;
+  max-width: 225px;
+
+  &-menu{
+    width: 100%;
+  }
+}

--- a/ui/components/multichain/connections-header/connections-header.scss
+++ b/ui/components/multichain/connections-header/connections-header.scss
@@ -1,10 +1,9 @@
-.connections-header__popover {
-  z-index: $popover-in-modal-z-index;
-  overflow: hidden;
-  min-width: 225px;
-  max-width: 225px;
-
-  &-menu{
-    width: 100%;
-  }
-}
+// .connections-header-children-wrapper{
+//   flex:0 0 auto;
+// }
+// .connections-header-end-accessory-wrapper{
+//   flex:0 0 auto;
+// }
+// .connections-header-tag-url{
+//   flex:0 0 auto;
+// }

--- a/ui/components/multichain/connections-header/connections-header.stories.js
+++ b/ui/components/multichain/connections-header/connections-header.stories.js
@@ -7,3 +7,11 @@ export default {
 export const DefaultStory = () => <ConnectionsHeader />;
 
 DefaultStory.storyName = 'Default';
+
+export const ChaosStory = () => (
+  <div style={{ width: '400px', border: '1px solid red', background: 'pink' }}>
+    <ConnectionsHeader hostName="some.weird.hostname.weve.never.heard.of.tld" />
+  </div>
+);
+
+ChaosStory.storyName = 'Chaos';

--- a/ui/components/multichain/connections-header/connections-header.stories.js
+++ b/ui/components/multichain/connections-header/connections-header.stories.js
@@ -1,0 +1,9 @@
+import React from 'react';
+import { ConnectionsHeader } from './connections-header';
+
+export default {
+  title: 'Components/Multichain/ConnectionsHeader',
+};
+export const DefaultStory = () => <ConnectionsHeader />;
+
+DefaultStory.storyName = 'Default';

--- a/ui/components/multichain/connections-header/connections-header.stories.js
+++ b/ui/components/multichain/connections-header/connections-header.stories.js
@@ -9,7 +9,7 @@ export const DefaultStory = () => <ConnectionsHeader />;
 DefaultStory.storyName = 'Default';
 
 export const ChaosStory = () => (
-  <div style={{ width: '400px', border: '1px solid red', background: 'pink' }}>
+  <div style={{ width: '400px' }}>
     <ConnectionsHeader hostName="some.weird.hostname.weve.never.heard.of.tld" />
   </div>
 );

--- a/ui/components/multichain/connections-header/index.js
+++ b/ui/components/multichain/connections-header/index.js
@@ -1,0 +1,1 @@
+export { ConnectionsHeader } from './connections-header';

--- a/ui/components/multichain/index.js
+++ b/ui/components/multichain/index.js
@@ -12,6 +12,7 @@ export { ImportTokenLink } from './import-token-link';
 export { TokenListItem } from './token-list-item';
 export { AddressCopyButton } from './address-copy-button';
 export { ConnectedSiteMenu } from './connected-site-menu';
+export { ConnectionsHeader } from './connections-header';
 export { NetworkListItem } from './network-list-item';
 export { NetworkListMenu } from './network-list-menu';
 export { ProductTour } from './product-tour-popover';

--- a/ui/components/multichain/multichain-components.scss
+++ b/ui/components/multichain/multichain-components.scss
@@ -13,6 +13,7 @@
 @import 'account-picker/index';
 @import 'activity-list-item/index';
 @import 'app-footer/app-footer';
+@import 'connections-header/connections-header';
 @import 'app-header/app-header';
 @import 'connected-site-menu/index';
 @import 'account-list-menu/';

--- a/ui/components/multichain/pages/connections/components/site-not-connected.js
+++ b/ui/components/multichain/pages/connections/components/site-not-connected.js
@@ -1,0 +1,34 @@
+import React from 'react';
+import { Box, Text } from '../../../../component-library';
+import {
+  AlignItems,
+  BlockSize,
+  Display,
+  FlexDirection,
+  JustifyContent,
+  TextColor,
+} from '../../../../../helpers/constants/design-system';
+import { useI18nContext } from '../../../../../hooks/useI18nContext';
+
+export const SiteNotConnected = () => {
+  const t = useI18nContext();
+  return (
+    <Box
+      data-testid="site-not-connected"
+      display={Display.Flex}
+      flexDirection={FlexDirection.Column}
+      justifyContent={JustifyContent.center}
+      alignItems={AlignItems.center}
+      height={BlockSize.Full}
+      gap={2}
+    >
+      <Text>{t('metamaskNotConnected1')}</Text>
+      <Text color={TextColor.textAlternative}>
+        {t('metamaskNotConnected2')}{' '}
+        <Text color={TextColor.textAlternative} as="strong">
+          {t('metamaskNotConnected3')}
+        </Text>
+      </Text>
+    </Box>
+  );
+};

--- a/ui/components/multichain/pages/connections/components/site-not-connected.js
+++ b/ui/components/multichain/pages/connections/components/site-not-connected.js
@@ -25,9 +25,7 @@ export const SiteNotConnected = () => {
       <Text>{t('metamaskNotConnected1')}</Text>
       <Text color={TextColor.textAlternative}>
         {t('metamaskNotConnected2')}{' '}
-        <Text color={TextColor.textAlternative} as="strong">
-          {t('metamaskNotConnected3')}
-        </Text>
+        <strong>{t('metamaskNotConnected3')}</strong>
       </Text>
     </Box>
   );

--- a/ui/components/multichain/pages/connections/components/site-not-connected.stories.js
+++ b/ui/components/multichain/pages/connections/components/site-not-connected.stories.js
@@ -1,0 +1,9 @@
+import React from 'react';
+import { SiteNotConnected } from './site-not-connected';
+
+export default {
+  title: 'Components/Multichain/SiteNotConnected',
+};
+export const DefaultStory = () => <SiteNotConnected />;
+
+DefaultStory.storyName = 'Default';

--- a/ui/components/multichain/pages/connections/connections.js
+++ b/ui/components/multichain/pages/connections/connections.js
@@ -1,34 +1,20 @@
 import React from 'react';
-import { Box, Text } from '../../../component-library';
+import { Box } from '../../../component-library';
 import {
-  AlignItems,
   BlockSize,
   Display,
   FlexDirection,
-  JustifyContent,
-  TextColor,
 } from '../../../../helpers/constants/design-system';
-import { useI18nContext } from '../../../../hooks/useI18nContext';
+import { ConnectionsHeader } from '../../connections-header';
+import { SiteNotConnected } from './components/site-not-connected';
 
-export const Connections = () => {
-  const t = useI18nContext();
-  return (
-    <Box
-      data-testid="site-not-connected"
-      display={Display.Flex}
-      flexDirection={FlexDirection.Column}
-      justifyContent={JustifyContent.center}
-      alignItems={AlignItems.center}
-      height={BlockSize.Full}
-      gap={2}
-    >
-      <Text>{t('metamaskNotConnected1')}</Text>
-      <Text color={TextColor.textAlternative}>
-        {t('metamaskNotConnected2')}{' '}
-        <Text color={TextColor.textAlternative} as="strong">
-          {t('metamaskNotConnected3')}
-        </Text>
-      </Text>
-    </Box>
-  );
-};
+export const Connections = () => (
+  <Box
+    display={Display.Flex}
+    flexDirection={FlexDirection.Column}
+    width={BlockSize.Full}
+  >
+    <ConnectionsHeader />
+    <SiteNotConnected />
+  </Box>
+);

--- a/ui/components/multichain/pages/connections/connections.js
+++ b/ui/components/multichain/pages/connections/connections.js
@@ -1,5 +1,5 @@
 import React from 'react';
 
 export const Connections = () => {
-  return <div></div>;
+  return <div>Connections inner content</div>;
 };

--- a/ui/components/multichain/pages/connections/connections.js
+++ b/ui/components/multichain/pages/connections/connections.js
@@ -8,11 +8,13 @@ import {
   JustifyContent,
   TextColor,
 } from '../../../../helpers/constants/design-system';
+import { useI18nContext } from '../../../../hooks/useI18nContext';
 
 export const Connections = () => {
-  // TODO use translations here
+  const t = useI18nContext();
   return (
     <Box
+      data-testid="site-not-connected"
       display={Display.Flex}
       flexDirection={FlexDirection.Column}
       justifyContent={JustifyContent.center}
@@ -20,11 +22,11 @@ export const Connections = () => {
       height={BlockSize.Full}
       gap={2}
     >
-      <Text>MetaMask isn’t connected to this site</Text>
+      <Text>{t('metamaskNotConnected1')}</Text>
       <Text color={TextColor.textAlternative}>
-        To connect to a web3 site, find and click{' '}
+        {t('metamaskNotConnected2')}{' '}
         <Text color={TextColor.textAlternative} as="strong">
-          connect
+          {t('metamaskNotConnected3')}
         </Text>
       </Text>
     </Box>

--- a/ui/components/multichain/pages/connections/connections.js
+++ b/ui/components/multichain/pages/connections/connections.js
@@ -1,5 +1,32 @@
 import React from 'react';
+import { Box, Text } from '../../../component-library';
+import {
+  AlignItems,
+  BlockSize,
+  Display,
+  FlexDirection,
+  JustifyContent,
+  TextColor,
+} from '../../../../helpers/constants/design-system';
 
 export const Connections = () => {
-  return <div>Connections inner content</div>;
+  // TODO use translations here
+  return (
+    <Box
+      display={Display.Flex}
+      flexDirection={FlexDirection.Column}
+      justifyContent={JustifyContent.center}
+      alignItems={AlignItems.center}
+      height={BlockSize.Full}
+      gap={2}
+    >
+      <Text>MetaMask isn’t connected to this site</Text>
+      <Text color={TextColor.textAlternative}>
+        To connect to a web3 site, find and click{' '}
+        <Text color={TextColor.textAlternative} as="strong">
+          connect
+        </Text>
+      </Text>
+    </Box>
+  );
 };

--- a/ui/components/multichain/pages/connections/connections.js
+++ b/ui/components/multichain/pages/connections/connections.js
@@ -13,6 +13,7 @@ export const Connections = () => (
     display={Display.Flex}
     flexDirection={FlexDirection.Column}
     width={BlockSize.Full}
+    height={BlockSize.Full}
   >
     <ConnectionsHeader />
     <SiteNotConnected />

--- a/ui/components/multichain/pages/connections/connections.stories.js
+++ b/ui/components/multichain/pages/connections/connections.stories.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import { Connections } from './connections';
+
+export default {
+  title: 'Components/Multichain/Connections',
+};
+export const DefaultStory = () => (
+  <div
+    style={{
+      width: '400px',
+      height: '600px',
+      border: '1px solid red',
+    }}
+  >
+    <Connections />
+  </div>
+);
+
+DefaultStory.storyName = 'Default';

--- a/ui/components/multichain/pages/connections/connections.stories.js
+++ b/ui/components/multichain/pages/connections/connections.stories.js
@@ -9,7 +9,6 @@ export const DefaultStory = () => (
     style={{
       width: '400px',
       height: '600px',
-      border: '1px solid red',
     }}
   >
     <Connections />

--- a/ui/components/multichain/pages/connections/index.js
+++ b/ui/components/multichain/pages/connections/index.js
@@ -1,1 +1,2 @@
 export { Connections } from './connections';
+export { SiteNotConnected } from './components/site-not-connected';

--- a/ui/components/multichain/pages/page/components/header/header.js
+++ b/ui/components/multichain/pages/page/components/header/header.js
@@ -1,8 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
-import { HeaderBase, Text } from '../../../../../component-library';
+import { Box, HeaderBase, Text } from '../../../../../component-library';
 import {
+  AlignItems,
+  BackgroundColor,
   BlockSize,
   Display,
   TextAlign,
@@ -17,26 +19,28 @@ export const Header = ({
   ...props
 }) => {
   return (
-    <HeaderBase
-      padding={4}
-      width={BlockSize.Full}
-      className={classnames('multichain-page-header', className)}
-      startAccessory={startAccessory}
-      endAccessory={endAccessory}
-      {...props}
-    >
-      <Text
-        as="div"
-        display={Display.Block}
-        variant={TextVariant.bodyMdBold}
-        textAlign={TextAlign.Center}
-        paddingInlineStart={8}
-        paddingInlineEnd={8}
-        ellipsis
+    <Box className="multichain-page-header">
+      <HeaderBase
+        padding={4}
+        width={BlockSize.Full}
+        className={classnames('multichain-page-header__contents', className)}
+        startAccessory={startAccessory}
+        endAccessory={endAccessory}
+        {...props}
       >
-        {children}
-      </Text>
-    </HeaderBase>
+        <Text
+          as="div"
+          display={Display.Block}
+          variant={TextVariant.bodyMdBold}
+          textAlign={TextAlign.Center}
+          paddingInlineStart={8}
+          paddingInlineEnd={8}
+          ellipsis
+        >
+          {children}
+        </Text>
+      </HeaderBase>
+    </Box>
   );
 };
 

--- a/ui/components/multichain/pages/page/components/header/header.js
+++ b/ui/components/multichain/pages/page/components/header/header.js
@@ -26,6 +26,7 @@ export const Header = ({
       {...props}
     >
       <Text
+        as="div"
         display={Display.Block}
         variant={TextVariant.bodyMdBold}
         textAlign={TextAlign.Center}

--- a/ui/components/multichain/pages/page/components/header/index.scss
+++ b/ui/components/multichain/pages/page/components/header/index.scss
@@ -1,0 +1,33 @@
+.multichain-page-header {
+  $height-screen-sm-max: 100%;
+  $width-screen-sm-min: 85vw;
+  $width-screen-md-min: 80vw;
+  $width-screen-lg-min: 62vw;
+
+  flex-flow: column nowrap;
+  z-index: 55;
+  min-height: 64px;
+
+  &__contents {
+    display: grid;
+    grid-template-columns: 1fr 2fr 1fr;
+    height: 64px;
+
+    @include screen-sm-max {
+      height: $height-screen-sm-max;
+    }
+
+    @include screen-sm-min {
+      width: $width-screen-sm-min;
+    }
+
+    @include screen-md-min {
+      width: $width-screen-md-min;
+    }
+
+    @include screen-lg-min {
+      width: $width-screen-lg-min;
+    }
+
+  }
+}

--- a/ui/pages/routes/routes.component.js
+++ b/ui/pages/routes/routes.component.js
@@ -36,7 +36,6 @@ import {
   ImportTokensModal,
   SelectActionModal,
   AppFooter,
-  ConnectionsHeader,
 } from '../../components/multichain';
 import UnlockPage from '../unlock-page';
 import Alerts from '../../components/app/alerts';
@@ -406,17 +405,6 @@ export default class Routes extends Component {
     );
   }
 
-  showConnectionHeader() {
-    const { location } = this.props;
-
-    return Boolean(
-      matchPath(location.pathname, {
-        path: CONNECTIONS,
-        exact: true,
-      }),
-    );
-  }
-
   onEditTransactionPage() {
     return (
       this.props.sendStage === SEND_STAGES.EDIT ||
@@ -466,7 +454,12 @@ export default class Routes extends Component {
       return true;
     }
 
-    const isConnectionsPage = this.showConnectionHeader();
+    const isConnectionsPage = Boolean(
+      matchPath(location.pathname, {
+        path: CONNECTIONS,
+        exact: true,
+      }),
+    );
 
     if (isConnectionsPage) {
       return true;
@@ -627,9 +620,6 @@ export default class Routes extends Component {
         <Modal />
         <Alert visible={this.props.alertOpen} msg={alertMessage} />
         {!this.hideAppHeader() && <AppHeader location={location} />}
-        {this.showConnectionHeader() && (
-          <ConnectionsHeader location={location} />
-        )}
         {this.showOnboardingHeader() && <OnboardingAppHeader />}
         {
           ///: BEGIN:ONLY_INCLUDE_IN(build-mmi)

--- a/ui/pages/routes/routes.component.js
+++ b/ui/pages/routes/routes.component.js
@@ -36,6 +36,7 @@ import {
   ImportTokensModal,
   SelectActionModal,
   AppFooter,
+  ConnectionsHeader,
 } from '../../components/multichain';
 import UnlockPage from '../unlock-page';
 import Alerts from '../../components/app/alerts';
@@ -521,6 +522,17 @@ export default class Routes extends Component {
     );
   }
 
+  showConnectionHeader() {
+    const { location } = this.props;
+
+    return Boolean(
+      matchPath(location.pathname, {
+        path: CONNECTIONS,
+        exact: true,
+      }),
+    );
+  }
+
   onAppHeaderClick = async () => {
     const { prepareToLeaveSwaps } = this.props;
     if (this.onSwapsPage()) {
@@ -609,6 +621,9 @@ export default class Routes extends Component {
         <Modal />
         <Alert visible={this.props.alertOpen} msg={alertMessage} />
         {!this.hideAppHeader() && <AppHeader location={location} />}
+        {this.showConnectionHeader() && (
+          <ConnectionsHeader location={location} />
+        )}
         {this.showOnboardingHeader() && <OnboardingAppHeader />}
         {
           ///: BEGIN:ONLY_INCLUDE_IN(build-mmi)

--- a/ui/pages/routes/routes.component.js
+++ b/ui/pages/routes/routes.component.js
@@ -406,6 +406,17 @@ export default class Routes extends Component {
     );
   }
 
+  showConnectionHeader() {
+    const { location } = this.props;
+
+    return Boolean(
+      matchPath(location.pathname, {
+        path: CONNECTIONS,
+        exact: true,
+      }),
+    );
+  }
+
   onEditTransactionPage() {
     return (
       this.props.sendStage === SEND_STAGES.EDIT ||
@@ -452,6 +463,12 @@ export default class Routes extends Component {
     );
 
     if (isInitializing && !this.onInitializationUnlockPage()) {
+      return true;
+    }
+
+    const isConnectionsPage = this.showConnectionHeader();
+
+    if (isConnectionsPage) {
       return true;
     }
 
@@ -518,17 +535,6 @@ export default class Routes extends Component {
       matchPath(location.pathname, {
         path: ONBOARDING_ROUTE,
         exact: false,
-      }),
-    );
-  }
-
-  showConnectionHeader() {
-    const { location } = this.props;
-
-    return Boolean(
-      matchPath(location.pathname, {
-        path: CONNECTIONS,
-        exact: true,
       }),
     );
   }


### PR DESCRIPTION
Fixes: https://github.com/MetaMask/MetaMask-planning/issues/1225
See: [Zenhub](https://app.zenhub.com/workspaces/metamask-extension-63529dce65cbb100265a3842/issues/gh/metamask/metamask-planning/1225)

This PR is to add the Connections Header component.
Logic for "All" button and hiding of the "Go Back" arrow will be  added in future PRs.

## Screenshots/Screencaps
<!-- How does it look now? Drag your file(s) below this line: -->
<img width="374" alt="image" src="https://github.com/MetaMask/metamask-extension/assets/10986371/51ad1965-4092-4590-81b1-946ce2b9cf27">

<img width="368" alt="image" src="https://github.com/MetaMask/metamask-extension/assets/10986371/090846ff-715b-412d-b3e3-c16bb2212519">

## Manual Testing Steps
1. run `yarn storybook`
2. Search for ConnectionsHeader component and see the Default and Chaos stories to see overflow interactions
Once we have the Bottom Navbar in:
1. Visit a site that is not currently connected to your wallet
2. Click on Connections
3. See that the "MetaMask isn’t connected to this site. To connect to a web3 site, find and click connect" message is displayed.
4. Check that the global icon is displayed as a fallback icon.

Icon Testing:
1. Visit a site that is currently connected to your wallet
2. Click on Connections
3. Check that the dapp icon is displayed if available, or the fallback global icon is displayed.



<!--
How should reviewers and QA manually test your changes? For instance:

- Go to this screen
- Do this
- Then do this
-->

## Pre-merge author checklist

- [ ] I've clearly explained:
  - [ ] What problem this PR is solving
  - [ ] How this problem was solved
  - [ ] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.
