### PR TITLE
fix(#21175): safe access of image

### DIFF
--- a/ui/components/app/nfts-items/nfts-items.js
+++ b/ui/components/app/nfts-items/nfts-items.js
@@ -192,7 +192,7 @@ export default function NftsItems({
                 ipfsGateway,
               );
               const nftImageAlt = getNftImageAlt(nft);
-              const isImageHosted = image.startsWith('https:');
+              const isImageHosted = image?.startsWith('https:');
               const nftImageURL = imageOriginal?.startsWith('ipfs')
                 ? nftImage
                 : image;


### PR DESCRIPTION
## **Description**
Fixes #21175 . Found a regression during personal usage of the extension. @jiexi already fixed this in a PR #20916 to update the assets-controller but this single line change is being pulled forward for a hotfix

## **Manual testing steps**
Use steps from issue which are:
1. Install the extension (develop and then this branch)
2. Import a wallet with NFTs
3. Enable autodetection and open sea
4. See the homescreen won't load and error is cannot access startsWith of undefined. On this branch that is resolved

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained:
  - [x] What problem this PR is solving.
  - [x] How this problem was solved.
  - [x] How reviewers can test my changes.
- [x] I’ve indicated what issue this PR is linked to: Fixes #???
- [ ] I’ve included tests if applicable.
- [ ] I’ve documented any added code.
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)).
- [x] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
