### PR TITLE
Ignored ripple-lib deprecation advisory, as we do not depend on it in MetaMask

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -94,6 +94,10 @@ npmAuditIgnoreAdvisories:
   # @types/webextension-polyfill
   - 'webextension-polyfill-ts (deprecation)'
 
+  # Imported in @trezor/blockchain-link@npm:2.1.8, but not actually depended on
+  # by MetaMask
+  - 'ripple-lib (deprecation)'
+
 npmRegistries:
   'https://npm.pkg.github.com':
     npmAlwaysAuth: true


### PR DESCRIPTION


## **Description**
This PR addresses a `yarn audit` failure that we currently see on develop. The failure is due to the deprecation of the `ripple-lib` library used within `@trezor/blockchain-link@npm:2.1.8`. Although imported in one of our dependencies, MetaMask does not depend on that library, and it's code is not used by our codebase. We can safely ignore this advisory.

## **Manual testing steps**

Not needed. Builds should pass without a `yarn audit` warning


