### PR TITLE
Fix token rates controller not started

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -769,6 +769,8 @@ export default class MetamaskController extends EventEmitter {
       },
       initState.TokenRatesController,
     );
+    this.tokenRatesController.start();
+
     this.preferencesController.store.subscribe(
       previousValueComparator((prevState, currState) => {
         const { useCurrencyRateCheck: prevUseCurrencyRateCheck } = prevState;


### PR DESCRIPTION
## **Description**

Fixes an issue where the `TokenRatesController` was never started, causing ERC20 token conversion rates to not be available.

This was caused when the assets controller package was upgraded to include this change: https://github.com/MetaMask/core/pull/1501.  Which required it to be explicitly started.

## **Manual testing steps**

Try to send an ERC20 token like USDC, and verify a conversion rate shows 

## **Screenshots/Recordings**

### **Before**

<img width="392" alt="Screenshot 2023-10-04 at 4 41 30 PM" src="https://github.com/MetaMask/metamask-extension/assets/3500406/b417ef32-4a03-4389-9f93-de9b553c8eb1">


### **After**

<img width="384" alt="Screenshot 2023-10-04 at 4 42 19 PM" src="https://github.com/MetaMask/metamask-extension/assets/3500406/341511e0-50c9-419c-a5e0-4e043e058468">


## **Related issues**


## **Pre-merge author checklist**

- [x I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained:
  - [x] What problem this PR is solving.
  - [x] How this problem was solved.
  - [x] How reviewers can test my changes.
- [ ] I’ve indicated what issue this PR is linked to: Fixes #???
- [ ] I’ve included tests if applicable.
- [ ] I’ve documented any added code.
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)).
- [x] I’ve properly set the pull request status:
  - [x] In case it's not yet "ready for review", I've set it to "draft".
  - [x] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
