### PR TITLE
Fix next button key event handling on token approval page

### DIFF
--- a/ui/components/app/desktop-enable-button/__snapshots__/desktop-enable-button.component.test.js.snap
+++ b/ui/components/app/desktop-enable-button/__snapshots__/desktop-enable-button.component.test.js.snap
@@ -4,8 +4,6 @@ exports[`Desktop Enable Button should match snapshot 1`] = `
 <div>
   <button
     class="button btn--rounded btn-primary btn--large"
-    role="button"
-    tabindex="0"
   >
     Enable Desktop App
   </button>

--- a/ui/components/app/modal/__snapshots__/modal.component.test.js.snap
+++ b/ui/components/app/modal/__snapshots__/modal.component.test.js.snap
@@ -13,15 +13,11 @@ exports[`Modal Component should render a modal with a cancel and a submit button
     >
       <button
         class="button btn--rounded btn-secondary modal-container__footer-button"
-        role="button"
-        tabindex="0"
       >
         Cancel
       </button>
       <button
         class="button btn--rounded btn-primary modal-container__footer-button"
-        role="button"
-        tabindex="0"
       >
         Submit
       </button>
@@ -56,15 +52,11 @@ exports[`Modal Component should render a modal with a header 1`] = `
     >
       <button
         class="button btn--rounded btn-secondary modal-container__footer-button"
-        role="button"
-        tabindex="0"
       >
         Cancel
       </button>
       <button
         class="button btn--rounded btn-primary modal-container__footer-button"
-        role="button"
-        tabindex="0"
       >
         Submit
       </button>
@@ -109,15 +101,11 @@ exports[`Modal Component should render a modal with children 1`] = `
     >
       <button
         class="button btn--rounded btn-secondary modal-container__footer-button"
-        role="button"
-        tabindex="0"
       >
         Cancel
       </button>
       <button
         class="button btn--rounded btn-primary modal-container__footer-button"
-        role="button"
-        tabindex="0"
       >
         Submit
       </button>
@@ -139,15 +127,11 @@ exports[`Modal Component should render a modal with different button types 1`] =
     >
       <button
         class="button btn--rounded btn-default modal-container__footer-button"
-        role="button"
-        tabindex="0"
       >
         Cancel
       </button>
       <button
         class="button btn--rounded btn-default modal-container__footer-button"
-        role="button"
-        tabindex="0"
       >
         Submit
       </button>

--- a/ui/components/app/modals/confirm-delete-network/__snapshots__/confirm-delete-network.test.js.snap
+++ b/ui/components/app/modals/confirm-delete-network/__snapshots__/confirm-delete-network.test.js.snap
@@ -28,15 +28,11 @@ exports[`Confirm Delete Network should match snapshot 1`] = `
     >
       <button
         class="button btn--rounded btn-secondary modal-container__footer-button"
-        role="button"
-        tabindex="0"
       >
         Cancel
       </button>
       <button
         class="button btn--rounded btn-danger-primary modal-container__footer-button"
-        role="button"
-        tabindex="0"
       >
         Delete
       </button>

--- a/ui/components/app/modals/confirm-remove-account/__snapshots__/confirm-remove-account.test.js.snap
+++ b/ui/components/app/modals/confirm-remove-account/__snapshots__/confirm-remove-account.test.js.snap
@@ -136,15 +136,11 @@ exports[`Confirm Remove Account should match snapshot 1`] = `
     >
       <button
         class="button btn--rounded btn-secondary modal-container__footer-button"
-        role="button"
-        tabindex="0"
       >
         Nevermind
       </button>
       <button
         class="button btn--rounded btn-primary modal-container__footer-button"
-        role="button"
-        tabindex="0"
       >
         Remove
       </button>

--- a/ui/components/app/modals/confirm-reset-account/__snapshots__/confirm-reset-account.test.js.snap
+++ b/ui/components/app/modals/confirm-reset-account/__snapshots__/confirm-reset-account.test.js.snap
@@ -28,15 +28,11 @@ exports[`Confirm Reset Account should match snapshot 1`] = `
     >
       <button
         class="button btn--rounded btn-secondary modal-container__footer-button"
-        role="button"
-        tabindex="0"
       >
         [nevermind]
       </button>
       <button
         class="button btn--rounded btn-danger-primary modal-container__footer-button"
-        role="button"
-        tabindex="0"
       >
         [clear]
       </button>

--- a/ui/components/app/modals/customize-nonce/__snapshots__/customize-nonce.test.js.snap
+++ b/ui/components/app/modals/customize-nonce/__snapshots__/customize-nonce.test.js.snap
@@ -99,15 +99,11 @@ exports[`Customize Nonce should match snapshot 1`] = `
     >
       <button
         class="button btn--rounded btn-secondary modal-container__footer-button"
-        role="button"
-        tabindex="0"
       >
         Cancel
       </button>
       <button
         class="button btn--rounded btn-primary modal-container__footer-button"
-        role="button"
-        tabindex="0"
       >
         Save
       </button>

--- a/ui/components/app/modals/hide-token-confirmation-modal/__snapshots__/hide-token-confirmation-modal.test.js.snap
+++ b/ui/components/app/modals/hide-token-confirmation-modal/__snapshots__/hide-token-confirmation-modal.test.js.snap
@@ -73,16 +73,12 @@ exports[`Hide Token Confirmation Modal should match snapshot 1`] = `
         <button
           class="button btn--rounded btn-secondary hide-token-confirmation__button"
           data-testid="hide-token-confirmation__cancel"
-          role="button"
-          tabindex="0"
         >
           Cancel
         </button>
         <button
           class="button btn--rounded btn-primary hide-token-confirmation__button"
           data-testid="hide-token-confirmation__hide"
-          role="button"
-          tabindex="0"
         >
           Hide
         </button>

--- a/ui/components/app/modals/reject-transactions/__snapshots__/reject-transactions.test.js.snap
+++ b/ui/components/app/modals/reject-transactions/__snapshots__/reject-transactions.test.js.snap
@@ -34,15 +34,11 @@ exports[`Reject Transactions Model should match snapshot 1`] = `
     >
       <button
         class="button btn--rounded btn-secondary modal-container__footer-button"
-        role="button"
-        tabindex="0"
       >
         [cancel]
       </button>
       <button
         class="button btn--rounded btn-primary modal-container__footer-button"
-        role="button"
-        tabindex="0"
       >
         [rejectAll]
       </button>

--- a/ui/components/app/modals/transaction-confirmed/__snapshots__/transaction-confirmed.test.js.snap
+++ b/ui/components/app/modals/transaction-confirmed/__snapshots__/transaction-confirmed.test.js.snap
@@ -32,8 +32,6 @@ exports[`Transaction Confirmed should match snapshot 1`] = `
     >
       <button
         class="button btn--rounded btn-primary modal-container__footer-button"
-        role="button"
-        tabindex="0"
       >
         [ok]
       </button>

--- a/ui/components/app/nft-details/__snapshots__/nft-details.test.js.snap
+++ b/ui/components/app/nft-details/__snapshots__/nft-details.test.js.snap
@@ -94,8 +94,6 @@ exports[`NFT Details should match minimal props and state snapshot 1`] = `
           <button
             class="button btn--rounded btn-primary nft-details__send-button"
             data-testid="nft-send-button"
-            role="button"
-            tabindex="0"
           >
             Send
           </button>

--- a/ui/components/app/signature-request-original/__snapshots__/signature-request-original.test.js.snap
+++ b/ui/components/app/signature-request-original/__snapshots__/signature-request-original.test.js.snap
@@ -248,16 +248,12 @@ exports[`SignatureRequestOriginal should match snapshot 1`] = `
         <button
           class="button btn--rounded btn-secondary page-container__footer-button page-container__footer-button__cancel"
           data-testid="page-container-footer-cancel"
-          role="button"
-          tabindex="0"
         >
           Reject
         </button>
         <button
           class="button btn--rounded btn-primary page-container__footer-button"
           data-testid="page-container-footer-next"
-          role="button"
-          tabindex="0"
         >
           Sign
         </button>

--- a/ui/components/app/signature-request-siwe/__snapshots__/signature-request-siwe.test.js.snap
+++ b/ui/components/app/signature-request-siwe/__snapshots__/signature-request-siwe.test.js.snap
@@ -392,16 +392,12 @@ https://example.com/my-web2-claim.json
         <button
           class="button btn--rounded btn-secondary page-container__footer-button page-container__footer-button__cancel"
           data-testid="page-container-footer-cancel"
-          role="button"
-          tabindex="0"
         >
           Cancel
         </button>
         <button
           class="button btn--rounded btn-primary page-container__footer-button"
           data-testid="page-container-footer-next"
-          role="button"
-          tabindex="0"
         >
           Sign-In
         </button>

--- a/ui/components/app/signature-request/__snapshots__/signature-request.test.js.snap
+++ b/ui/components/app/signature-request/__snapshots__/signature-request.test.js.snap
@@ -750,16 +750,12 @@ exports[`Signature Request Component render should match snapshot when we are us
         <button
           class="button btn--rounded btn-secondary page-container__footer-button page-container__footer-button__cancel"
           data-testid="page-container-footer-cancel"
-          role="button"
-          tabindex="0"
         >
           Reject
         </button>
         <button
           class="button btn--rounded btn-primary page-container__footer-button"
           data-testid="page-container-footer-next"
-          role="button"
-          tabindex="0"
         >
           Sign
         </button>
@@ -1525,16 +1521,12 @@ exports[`Signature Request Component render should match snapshot when we want t
         <button
           class="button btn--rounded btn-secondary page-container__footer-button page-container__footer-button__cancel"
           data-testid="page-container-footer-cancel"
-          role="button"
-          tabindex="0"
         >
           Reject
         </button>
         <button
           class="button btn--rounded btn-primary page-container__footer-button"
           data-testid="page-container-footer-next"
-          role="button"
-          tabindex="0"
         >
           Sign
         </button>

--- a/ui/components/app/transaction-breakdown/transaction-breakdown-row/__snapshots__/transaction-breakdown-row.component.test.js.snap
+++ b/ui/components/app/transaction-breakdown/transaction-breakdown-row/__snapshots__/transaction-breakdown-row.component.test.js.snap
@@ -18,8 +18,6 @@ exports[`TransactionBreakdownRow Component should match snapshot 1`] = `
     >
       <button
         class="button btn--rounded btn-default"
-        role="button"
-        tabindex="0"
       >
         Button
       </button>

--- a/ui/components/ui/button/button.component.js
+++ b/ui/components/ui/button/button.component.js
@@ -53,7 +53,7 @@ const Button = ({
   } else if (submit) {
     buttonProps.type = 'submit';
   }
-  if (typeof buttonProps.onClick === 'function') {
+  if (type === 'link' && typeof buttonProps.onClick === 'function') {
     buttonProps.onKeyUp ??= (event) => {
       if (event.key === 'Enter') {
         buttonProps.onClick();

--- a/ui/components/ui/page-container/page-container-footer/__snapshots__/page-container-footer.component.test.js.snap
+++ b/ui/components/ui/page-container/page-container-footer/__snapshots__/page-container-footer.component.test.js.snap
@@ -9,16 +9,12 @@ exports[`Page Footer should match snapshot 1`] = `
       <button
         class="button btn--rounded btn-secondary page-container__footer-button page-container__footer-button__cancel"
         data-testid="page-container-footer-cancel"
-        role="button"
-        tabindex="0"
       >
         Cancel
       </button>
       <button
         class="button btn--rounded btn-default page-container__footer-button"
         data-testid="page-container-footer-next"
-        role="button"
-        tabindex="0"
       >
         Submit
       </button>
@@ -36,16 +32,12 @@ exports[`Page Footer should render a secondary footer inside page-container__foo
       <button
         class="button btn--rounded btn-secondary page-container__footer-button page-container__footer-button__cancel"
         data-testid="page-container-footer-cancel"
-        role="button"
-        tabindex="0"
       >
         [cancel]
       </button>
       <button
         class="button btn--rounded btn-primary page-container__footer-button"
         data-testid="page-container-footer-next"
-        role="button"
-        tabindex="0"
       >
         [next]
       </button>

--- a/ui/pages/confirm-add-suggested-nft/__snapshots__/confirm-add-suggested-nft.test.js.snap
+++ b/ui/pages/confirm-add-suggested-nft/__snapshots__/confirm-add-suggested-nft.test.js.snap
@@ -203,16 +203,12 @@ exports[`ConfirmAddSuggestedNFT Component should match snapshot 1`] = `
             <button
               class="button btn--rounded btn-secondary page-container__footer-button page-container__footer-button__cancel"
               data-testid="page-container-footer-cancel"
-              role="button"
-              tabindex="0"
             >
               Cancel
             </button>
             <button
               class="button btn--rounded btn-primary page-container__footer-button"
               data-testid="page-container-footer-next"
-              role="button"
-              tabindex="0"
             >
               Add NFT
             </button>
@@ -417,16 +413,12 @@ exports[`ConfirmAddSuggestedNFT Component should match snapshot 1`] = `
           <button
             class="button btn--rounded btn-secondary page-container__footer-button page-container__footer-button__cancel"
             data-testid="page-container-footer-cancel"
-            role="button"
-            tabindex="0"
           >
             Cancel
           </button>
           <button
             class="button btn--rounded btn-primary page-container__footer-button"
             data-testid="page-container-footer-next"
-            role="button"
-            tabindex="0"
           >
             Add NFT
           </button>

--- a/ui/pages/confirm-decrypt-message/__snapshots__/confirm-decrypt-message.component.test.js.snap
+++ b/ui/pages/confirm-decrypt-message/__snapshots__/confirm-decrypt-message.component.test.js.snap
@@ -247,16 +247,12 @@ exports[`ConfirmDecryptMessage Component should match snapshot when preference i
         <button
           class="button btn--rounded btn-secondary page-container__footer-button page-container__footer-button__cancel"
           data-testid="page-container-footer-cancel"
-          role="button"
-          tabindex="0"
         >
           Cancel
         </button>
         <button
           class="button btn--rounded btn-primary page-container__footer-button"
           data-testid="page-container-footer-next"
-          role="button"
-          tabindex="0"
         >
           Decrypt
         </button>
@@ -513,16 +509,12 @@ exports[`ConfirmDecryptMessage Component should match snapshot when preference i
         <button
           class="button btn--rounded btn-secondary page-container__footer-button page-container__footer-button__cancel"
           data-testid="page-container-footer-cancel"
-          role="button"
-          tabindex="0"
         >
           Cancel
         </button>
         <button
           class="button btn--rounded btn-primary page-container__footer-button"
           data-testid="page-container-footer-next"
-          role="button"
-          tabindex="0"
         >
           Decrypt
         </button>

--- a/ui/pages/confirm-encryption-public-key/__snapshots__/confirm-encryption-public-key.component.test.js.snap
+++ b/ui/pages/confirm-encryption-public-key/__snapshots__/confirm-encryption-public-key.component.test.js.snap
@@ -231,16 +231,12 @@ exports[`ConfirmDecryptMessage Component should match snapshot when preference i
         <button
           class="button btn--rounded btn-secondary page-container__footer-button page-container__footer-button__cancel"
           data-testid="page-container-footer-cancel"
-          role="button"
-          tabindex="0"
         >
           Cancel
         </button>
         <button
           class="button btn--rounded btn-primary page-container__footer-button"
           data-testid="page-container-footer-next"
-          role="button"
-          tabindex="0"
         >
           Provide
         </button>
@@ -481,16 +477,12 @@ exports[`ConfirmDecryptMessage Component should match snapshot when preference i
         <button
           class="button btn--rounded btn-secondary page-container__footer-button page-container__footer-button__cancel"
           data-testid="page-container-footer-cancel"
-          role="button"
-          tabindex="0"
         >
           Cancel
         </button>
         <button
           class="button btn--rounded btn-primary page-container__footer-button"
           data-testid="page-container-footer-next"
-          role="button"
-          tabindex="0"
         >
           Provide
         </button>

--- a/ui/pages/confirm-send-ether/__snapshots__/confirm-send-ether.test.js.snap
+++ b/ui/pages/confirm-send-ether/__snapshots__/confirm-send-ether.test.js.snap
@@ -650,16 +650,12 @@ exports[`ConfirmSendEther should render correct information for for confirm send
           <button
             class="button btn--rounded btn-secondary page-container__footer-button page-container__footer-button__cancel"
             data-testid="page-container-footer-cancel"
-            role="button"
-            tabindex="0"
           >
             Reject
           </button>
           <button
             class="button btn--rounded btn-primary page-container__footer-button"
             data-testid="page-container-footer-next"
-            role="button"
-            tabindex="0"
           >
             Confirm
           </button>

--- a/ui/pages/confirm-signature-request/__snapshots__/index.test.js.snap
+++ b/ui/pages/confirm-signature-request/__snapshots__/index.test.js.snap
@@ -749,16 +749,12 @@ exports[`Confirm Signature Request Component render should match snapshot 1`] = 
         <button
           class="button btn--rounded btn-secondary page-container__footer-button page-container__footer-button__cancel"
           data-testid="page-container-footer-cancel"
-          role="button"
-          tabindex="0"
         >
           Reject
         </button>
         <button
           class="button btn--rounded btn-primary page-container__footer-button"
           data-testid="page-container-footer-next"
-          role="button"
-          tabindex="0"
         >
           Sign
         </button>

--- a/ui/pages/confirm-transaction-base/__snapshots__/confirm-transaction-base.test.js.snap
+++ b/ui/pages/confirm-transaction-base/__snapshots__/confirm-transaction-base.test.js.snap
@@ -513,8 +513,6 @@ exports[`Confirm Transaction Base should match snapshot 1`] = `
           <button
             class="button btn--rounded btn-secondary page-container__footer-button page-container__footer-button__cancel"
             data-testid="page-container-footer-cancel"
-            role="button"
-            tabindex="0"
           >
             Reject
           </button>
@@ -522,8 +520,6 @@ exports[`Confirm Transaction Base should match snapshot 1`] = `
             class="button btn--rounded btn-primary page-container__footer-button"
             data-testid="page-container-footer-next"
             disabled=""
-            role="button"
-            tabindex="0"
           >
             Confirm
           </button>

--- a/ui/pages/confirmation/templates/__snapshots__/add-ethereum-chain.test.js.snap
+++ b/ui/pages/confirmation/templates/__snapshots__/add-ethereum-chain.test.js.snap
@@ -188,16 +188,12 @@ exports[`add-ethereum-chain confirmation should match snapshot 1`] = `
         <button
           class="button btn--rounded btn-secondary"
           data-testid="confirmation-cancel-button"
-          role="button"
-          tabindex="0"
         >
           Cancel
         </button>
         <button
           class="button btn--rounded btn-primary"
           data-testid="confirmation-submit-button"
-          role="button"
-          tabindex="0"
         >
           Approve
         </button>

--- a/ui/pages/confirmation/templates/__snapshots__/create-snap-account.test.js.snap
+++ b/ui/pages/confirmation/templates/__snapshots__/create-snap-account.test.js.snap
@@ -181,16 +181,12 @@ exports[`create-snap-account confirmation should match snapshot 2`] = `
         <button
           class="button btn--rounded btn-secondary"
           data-testid="confirmation-cancel-button"
-          role="button"
-          tabindex="0"
         >
           Cancel
         </button>
         <button
           class="button btn--rounded btn-primary"
           data-testid="confirmation-submit-button"
-          role="button"
-          tabindex="0"
         >
           Create
         </button>

--- a/ui/pages/confirmation/templates/__snapshots__/error.test.js.snap
+++ b/ui/pages/confirmation/templates/__snapshots__/error.test.js.snap
@@ -58,8 +58,6 @@ exports[`error template matches the snapshot 1`] = `
         <button
           class="button btn--rounded btn-primary centered"
           data-testid="confirmation-submit-button"
-          role="button"
-          tabindex="0"
         >
           Ok
         </button>

--- a/ui/pages/confirmation/templates/__snapshots__/remove-snap-account.test.js.snap
+++ b/ui/pages/confirmation/templates/__snapshots__/remove-snap-account.test.js.snap
@@ -227,16 +227,12 @@ exports[`remove-snap-account confirmation should match snapshot 1`] = `
         <button
           class="button btn--rounded btn-secondary"
           data-testid="confirmation-cancel-button"
-          role="button"
-          tabindex="0"
         >
           Cancel
         </button>
         <button
           class="button btn--rounded btn-primary"
           data-testid="confirmation-submit-button"
-          role="button"
-          tabindex="0"
         >
           Remove
         </button>

--- a/ui/pages/confirmation/templates/__snapshots__/success.test.js.snap
+++ b/ui/pages/confirmation/templates/__snapshots__/success.test.js.snap
@@ -49,8 +49,6 @@ exports[`success template matches the snapshot 1`] = `
         <button
           class="button btn--rounded btn-primary centered"
           data-testid="confirmation-submit-button"
-          role="button"
-          tabindex="0"
         >
           Ok
         </button>

--- a/ui/pages/confirmation/templates/__snapshots__/switch-ethereum-chain.test.js.snap
+++ b/ui/pages/confirmation/templates/__snapshots__/switch-ethereum-chain.test.js.snap
@@ -104,16 +104,12 @@ exports[`switch-ethereum-chain confirmation should match snapshot 1`] = `
         <button
           class="button btn--rounded btn-secondary"
           data-testid="confirmation-cancel-button"
-          role="button"
-          tabindex="0"
         >
           Cancel
         </button>
         <button
           class="button btn--rounded btn-primary"
           data-testid="confirmation-submit-button"
-          role="button"
-          tabindex="0"
         >
           Switch network
         </button>
@@ -260,16 +256,12 @@ exports[`switch-ethereum-chain confirmation should show alert if there are pendi
         <button
           class="button btn--rounded btn-secondary"
           data-testid="confirmation-cancel-button"
-          role="button"
-          tabindex="0"
         >
           Cancel
         </button>
         <button
           class="button btn--rounded btn-primary"
           data-testid="confirmation-submit-button"
-          role="button"
-          tabindex="0"
         >
           Switch network
         </button>

--- a/ui/pages/desktop-error/__snapshots__/desktop-error.test.js.snap
+++ b/ui/pages/desktop-error/__snapshots__/desktop-error.test.js.snap
@@ -32,8 +32,6 @@ exports[`Desktop Error page should render connection lost page 1`] = `
       <button
         class="button btn--rounded btn-primary"
         id="desktop-error-button-open-or-download-mmd"
-        role="button"
-        tabindex="0"
       >
         Open MetaMask Desktop
       </button>
@@ -44,8 +42,6 @@ exports[`Desktop Error page should render connection lost page 1`] = `
       <button
         class="button btn--rounded btn-primary"
         id="desktop-error-button-disable-mmd"
-        role="button"
-        tabindex="0"
       >
         Disable MetaMask Desktop
       </button>
@@ -86,8 +82,6 @@ exports[`Desktop Error page should render critical error page 1`] = `
       <button
         class="button btn--rounded btn-primary"
         id="desktop-error-button-restart-mm"
-        role="button"
-        tabindex="0"
       >
         Restart MetaMask
       </button>
@@ -98,8 +92,6 @@ exports[`Desktop Error page should render critical error page 1`] = `
       <button
         class="button btn--rounded btn-primary"
         id="desktop-error-button-disable-mmd"
-        role="button"
-        tabindex="0"
       >
         Disable MetaMask Desktop
       </button>
@@ -140,8 +132,6 @@ exports[`Desktop Error page should render default error page 1`] = `
       <button
         class="button btn--rounded btn-primary"
         id="desktop-error-button-return-mm-home"
-        role="button"
-        tabindex="0"
       >
         Return MetaMask Home
       </button>
@@ -182,8 +172,6 @@ exports[`Desktop Error page should render desktop app outdated page 1`] = `
       <button
         class="button btn--rounded btn-primary"
         id="desktop-error-button-update-mmd"
-        role="button"
-        tabindex="0"
       >
         Update MetaMask Desktop
       </button>
@@ -224,8 +212,6 @@ exports[`Desktop Error page should render extension outdated page 1`] = `
       <button
         class="button btn--rounded btn-primary"
         id="desktop-error-button-update-extension"
-        role="button"
-        tabindex="0"
       >
         Update MetaMask Extension
       </button>
@@ -271,8 +257,6 @@ exports[`Desktop Error page should render not found page 1`] = `
       <button
         class="button btn--rounded btn-primary"
         id="desktop-error-button-download-mmd"
-        role="button"
-        tabindex="0"
       >
         Download MetaMask Desktop
       </button>
@@ -320,8 +304,6 @@ exports[`Desktop Error page should render pairing key not match page 1`] = `
       <button
         class="button btn--rounded btn-primary"
         id="desktop-error-button-navigate-settings"
-        role="button"
-        tabindex="0"
       >
         Return to Settings Page
       </button>
@@ -362,8 +344,6 @@ exports[`Desktop Error page should render route not found page 1`] = `
       <button
         class="button btn--rounded btn-primary"
         id="desktop-error-button-navigate-settings"
-        role="button"
-        tabindex="0"
       >
         Return to Settings Page
       </button>

--- a/ui/pages/onboarding-flow/add-network-modal/__snapshots__/add-network-modal.test.js.snap
+++ b/ui/pages/onboarding-flow/add-network-modal/__snapshots__/add-network-modal.test.js.snap
@@ -221,16 +221,12 @@ exports[`Add Network Modal should render 1`] = `
     >
       <button
         class="button btn--rounded btn-secondary"
-        role="button"
-        tabindex="0"
       >
         Cancel
       </button>
       <button
         class="button btn--rounded btn-primary"
         disabled=""
-        role="button"
-        tabindex="0"
       >
         Save
       </button>

--- a/ui/pages/onboarding-flow/create-password/__snapshots__/create-password.test.js.snap
+++ b/ui/pages/onboarding-flow/create-password/__snapshots__/create-password.test.js.snap
@@ -177,8 +177,6 @@ exports[`Onboarding Create Password Render should match snapshot 1`] = `
         <button
           class="button btn--rounded btn-primary btn--large create-password__form--submit-button"
           disabled=""
-          role="button"
-          tabindex="0"
         >
           Continue
         </button>
@@ -186,8 +184,6 @@ exports[`Onboarding Create Password Render should match snapshot 1`] = `
           class="button btn--rounded btn-primary btn--large create-password__form--submit-button"
           data-testid="create-password-wallet"
           disabled=""
-          role="button"
-          tabindex="0"
         >
           Create a new wallet
         </button>

--- a/ui/pages/onboarding-flow/metametrics/__snapshots__/metametrics.test.js.snap
+++ b/ui/pages/onboarding-flow/metametrics/__snapshots__/metametrics.test.js.snap
@@ -137,16 +137,12 @@ exports[`Onboarding Metametrics Component should match snapshot 1`] = `
       <button
         class="button btn--rounded btn-primary btn--large"
         data-testid="metametrics-i-agree"
-        role="button"
-        tabindex="0"
       >
         I agree
       </button>
       <button
         class="button btn--rounded btn-secondary btn--large"
         data-testid="metametrics-no-thanks"
-        role="button"
-        tabindex="0"
       >
         No thanks
       </button>

--- a/ui/pages/onboarding-flow/recovery-phrase/__snapshots__/review-recovery-phrase.test.js.snap
+++ b/ui/pages/onboarding-flow/recovery-phrase/__snapshots__/review-recovery-phrase.test.js.snap
@@ -288,8 +288,6 @@ exports[`Review Recovery Phrase Component should match snapshot 1`] = `
       <button
         class="button btn--rounded btn-primary recovery-phrase__footer--button"
         data-testid="recovery-phrase-reveal"
-        role="button"
-        tabindex="0"
       >
         Reveal Secret Recovery Phrase
       </button>
@@ -610,8 +608,6 @@ exports[`Review Recovery Phrase Component should match snapshot after reveal rec
         <button
           class="button btn--rounded btn-primary recovery-phrase__footer--button"
           data-testid="recovery-phrase-next"
-          role="button"
-          tabindex="0"
         >
           Next
         </button>

--- a/ui/pages/send/send-footer/__snapshots__/send-footer.test.js.snap
+++ b/ui/pages/send/send-footer/__snapshots__/send-footer.test.js.snap
@@ -9,16 +9,12 @@ exports[`SendFooter Component Component Update should match snapshot when compon
       <button
         class="button btn--rounded btn-secondary page-container__footer-button page-container__footer-button__cancel"
         data-testid="page-container-footer-cancel"
-        role="button"
-        tabindex="0"
       >
         [cancel]
       </button>
       <button
         class="button btn--rounded btn-primary page-container__footer-button"
         data-testid="page-container-footer-next"
-        role="button"
-        tabindex="0"
       >
         [next]
       </button>
@@ -36,16 +32,12 @@ exports[`SendFooter Component should match snapshot 1`] = `
       <button
         class="button btn--rounded btn-secondary page-container__footer-button page-container__footer-button__cancel"
         data-testid="page-container-footer-cancel"
-        role="button"
-        tabindex="0"
       >
         Cancel
       </button>
       <button
         class="button btn--rounded btn-primary page-container__footer-button"
         data-testid="page-container-footer-next"
-        role="button"
-        tabindex="0"
       >
         Next
       </button>

--- a/ui/pages/settings/advanced-tab/__snapshots__/advanced-tab.component.test.js.snap
+++ b/ui/pages/settings/advanced-tab/__snapshots__/advanced-tab.component.test.js.snap
@@ -29,8 +29,6 @@ exports[`AdvancedTab Component should match snapshot 1`] = `
         >
           <button
             class="button btn--rounded btn-secondary btn--large"
-            role="button"
-            tabindex="0"
           >
             Download state logs
           </button>
@@ -61,8 +59,6 @@ exports[`AdvancedTab Component should match snapshot 1`] = `
         >
           <button
             class="button btn--rounded btn-danger btn--large settings-tab__button--red"
-            role="button"
-            tabindex="0"
           >
             Clear activity tab data
           </button>
@@ -378,8 +374,6 @@ exports[`AdvancedTab Component should match snapshot 1`] = `
           <button
             class="button btn--rounded btn-primary settings-tab__rpc-save-button"
             data-testid="auto-lockout-button"
-            role="button"
-            tabindex="0"
           >
             Save
           </button>
@@ -411,8 +405,6 @@ exports[`AdvancedTab Component should match snapshot 1`] = `
           <button
             class="button btn--rounded btn-secondary btn--large"
             data-testid="backup-button"
-            role="button"
-            tabindex="0"
           >
             Backup
           </button>

--- a/ui/pages/settings/experimental-tab/__snapshots__/experimental-tab.test.js.snap
+++ b/ui/pages/settings/experimental-tab/__snapshots__/experimental-tab.test.js.snap
@@ -277,8 +277,6 @@ exports[`ExperimentalTab with desktop enabled renders ExperimentalTab component 
       >
         <button
           class="button btn--rounded btn-primary btn--large"
-          role="button"
-          tabindex="0"
         >
           Disable Desktop App
         </button>

--- a/ui/pages/swaps/swaps-footer/__snapshots__/swaps-footer.test.js.snap
+++ b/ui/pages/swaps/swaps-footer/__snapshots__/swaps-footer.test.js.snap
@@ -15,16 +15,12 @@ exports[`SwapsFooter renders the component with initial props 1`] = `
           <button
             class="button btn--rounded btn-secondary page-container__footer-button page-container__footer-button__cancel swaps-footer__custom-page-container-footer-button-class"
             data-testid="page-container-footer-cancel"
-            role="button"
-            tabindex="0"
           >
             Back
           </button>
           <button
             class="button btn--rounded btn-primary page-container__footer-button swaps-footer__custom-page-container-footer-button-class"
             data-testid="page-container-footer-next"
-            role="button"
-            tabindex="0"
           >
             submitText
           </button>

--- a/ui/pages/token-allowance/__snapshots__/token-allowance.test.js.snap
+++ b/ui/pages/token-allowance/__snapshots__/token-allowance.test.js.snap
@@ -454,16 +454,12 @@ exports[`TokenAllowancePage when mounted should match snapshot 1`] = `
         <button
           class="button btn--rounded btn-secondary page-container__footer-button page-container__footer-button__cancel"
           data-testid="page-container-footer-cancel"
-          role="button"
-          tabindex="0"
         >
           Reject
         </button>
         <button
           class="button btn--rounded btn-primary page-container__footer-button"
           data-testid="page-container-footer-next"
-          role="button"
-          tabindex="0"
         >
           Next
         </button>

--- a/ui/pages/unlock-page/__snapshots__/unlock-page.test.js.snap
+++ b/ui/pages/unlock-page/__snapshots__/unlock-page.test.js.snap
@@ -60,9 +60,7 @@ exports[`Unlock Page should match snapshot 1`] = `
         class="button btn--rounded btn-default"
         data-testid="unlock-submit"
         disabled=""
-        role="button"
         style="margin-top: 20px; height: 60px; font-weight: 400; box-shadow: none; border-radius: 100px;"
-        tabindex="0"
         variant="contained"
       >
         Unlock


### PR DESCRIPTION
## **Description**
Click next button in approval flow approves the whole transaction. I found there was flaw with old button component and hitting enter was causing `onClick` to be called twice. PR fixes event handling on the button.

## **Manual testing steps**

_1. Try to approve a token
_2. Tab to next button and hit enter
_3. It should page-2 of approval flow

## **Screenshots/Recordings**

_If applicable, add screenshots and/or recordings to visualize the before and after of your change._

### **Before**

https://github.com/MetaMask/metamask-extension/assets/2182307/c7014492-b753-4f3f-8d38-4f7c381ffca8

### **After**

https://github.com/MetaMask/metamask-extension/assets/2182307/b92256e7-6b4e-40cb-af06-388aec7dcf32

## **Related issues**

_Fixes #21195

## **Pre-merge author checklist**

- [X] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've clearly explained:
  - [X] What problem this PR is solving.
  - [X] How this problem was solved.
  - [X] How reviewers can test my changes.
- [X] I’ve indicated what issue this PR is linked to: Fixes #???
- [ ] I’ve included tests if applicable.
- [X] I’ve documented any added code.
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)).
- [X] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [X] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
