### PR TITLE
add audit exclusion for ethereum-cryptography (deprecation)

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -98,6 +98,14 @@ npmAuditIgnoreAdvisories:
   # by MetaMask
   - 'ripple-lib (deprecation)'
 
+  # Brought in by ethereumjs-utils, which is used in the extension and in many
+  # other dependencies. At the time of this exclusion, the extension has three
+  # old versions of ethereumjs-utils which should be upgraded to
+  # @ethereumjs/utils throughout our owned repositories. However even doing
+  # that may be insufficient due to dependencies we do not own still relying
+  # upon old versions of ethereumjs-utils.
+  - 'ethereum-cryptography (deprecation)'
+
 npmRegistries:
   'https://npm.pkg.github.com':
     npmAlwaysAuth: true


### PR DESCRIPTION
## **Description**
Adds the deprecation notice for old versions of ethereum-cryptography to our ignore list with instructions for how we could remove the exception in the future. 

## **Manual testing steps**
1. run yarn audit or wait for CI to pass

### **Before**
<img width="628" alt="Screenshot 2023-10-05 at 10 48 17 AM" src="https://github.com/MetaMask/metamask-extension/assets/4448075/f9b096ee-3db3-414c-aca6-6f439c150fa3">

### **After**
<img width="257" alt="Screenshot 2023-10-05 at 10 49 45 AM" src="https://github.com/MetaMask/metamask-extension/assets/4448075/77e08f89-649f-4653-8584-65f4935c26bc">


## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained:
  - [x] What problem this PR is solving.
  - [x] How this problem was solved.
  - [x] How reviewers can test my changes.
- [ ] I’ve indicated what issue this PR is linked to: Fixes #???
- [ ] I’ve included tests if applicable.
- [x] I’ve documented any added code.
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)).
- [x] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [x] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
