### PR TITLE
Fix/ap 63/add message to loading for hw and snap accounts

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -2280,6 +2280,12 @@
   "loadingNFTs": {
     "message": "Loading NFTs..."
   },
+  "loadingScreenHardwareWalletMessage": {
+    "message": "Please complete the transaction on the hardware wallet."
+  },
+  "loadingScreenSnapMessage": {
+    "message": "Please complete the transaction on the Snap."
+  },
   "loadingTokens": {
     "message": "Loading tokens..."
   },

--- a/ui/components/ui/loading-screen/loading-screen.component.js
+++ b/ui/components/ui/loading-screen/loading-screen.component.js
@@ -1,6 +1,7 @@
 import React, { isValidElement } from 'react';
 import PropTypes from 'prop-types';
 import Spinner from '../spinner';
+import { Box } from '../../component-library';
 
 const LoadingScreen = ({
   header,
@@ -20,18 +21,18 @@ const LoadingScreen = ({
   };
 
   return (
-    <div className="loading-overlay">
+    <Box className="loading-overlay">
       {header}
-      <div className="loading-overlay__container">
+      <Box className="loading-overlay__container" marginBottom={3}>
         {showLoadingSpinner && (
           <Spinner
             color="var(--color-warning-default)"
             className="loading-overlay__spinner"
           />
         )}
-        {renderMessage()}
-      </div>
-    </div>
+      </Box>
+      <Box>{renderMessage()}</Box>
+    </Box>
   );
 };
 

--- a/ui/pages/confirm-transaction-base/confirm-transaction-base.component.js
+++ b/ui/pages/confirm-transaction-base/confirm-transaction-base.component.js
@@ -55,7 +55,9 @@ import { ConfirmTitle } from '../../components/app/confirm-title';
 import { ConfirmSubTitle } from '../../components/app/confirm-subtitle';
 import { ConfirmGasDisplay } from '../../components/app/confirm-gas-display';
 import updateTxData from '../../../shared/modules/updateTxData';
+///: BEGIN:ONLY_INCLUDE_IN(keyring-snaps)
 import { KeyringType } from '../../../shared/constants/keyring';
+///: END:ONLY_INCLUDE_IN
 import { isHardwareKeyring } from '../../helpers/utils/hardware';
 
 export default class ConfirmTransactionBase extends Component {

--- a/ui/pages/confirm-transaction-base/confirm-transaction-base.component.js
+++ b/ui/pages/confirm-transaction-base/confirm-transaction-base.component.js
@@ -55,6 +55,8 @@ import { ConfirmTitle } from '../../components/app/confirm-title';
 import { ConfirmSubTitle } from '../../components/app/confirm-subtitle';
 import { ConfirmGasDisplay } from '../../components/app/confirm-gas-display';
 import updateTxData from '../../../shared/modules/updateTxData';
+import { KeyringType } from '../../../shared/constants/keyring';
+import { isHardwareKeyring } from '../../helpers/utils/hardware';
 
 export default class ConfirmTransactionBase extends Component {
   static contextTypes = {
@@ -96,6 +98,7 @@ export default class ConfirmTransactionBase extends Component {
     unapprovedTxCount: PropTypes.number,
     customGas: PropTypes.object,
     addToAddressBookIfNew: PropTypes.func,
+    keyringForAccount: PropTypes.object,
     // Component props
     actionKey: PropTypes.string,
     contentComponent: PropTypes.node,
@@ -630,7 +633,27 @@ export default class ConfirmTransactionBase extends Component {
       addToAddressBookIfNew,
       toAccounts,
       toAddress,
+      keyringForAccount,
     } = this.props;
+
+    let loadingIndicatorMessage;
+
+    switch (keyringForAccount?.type) {
+      ///: BEGIN:ONLY_INCLUDE_IN(keyring-snaps)
+      case KeyringType.snap:
+        loadingIndicatorMessage = this.context.t('loadingScreenSnapMessage');
+        break;
+      ///: END:ONLY_INCLUDE_IN
+      default:
+        if (isHardwareKeyring(keyringForAccount?.type)) {
+          loadingIndicatorMessage = this.context.t(
+            'loadingScreenHardwareWalletMessage',
+          );
+        } else {
+          loadingIndicatorMessage = null;
+        }
+        break;
+    }
 
     updateTxData({
       txData,
@@ -654,7 +677,11 @@ export default class ConfirmTransactionBase extends Component {
       () => {
         this._removeBeforeUnload();
 
-        sendTransaction(txData)
+        sendTransaction(
+          txData,
+          false, // hideLoadingIndicator
+          loadingIndicatorMessage, // loadingIndicatorMessage
+        )
           .then(() => {
             if (!this._isMounted) {
               return;

--- a/ui/pages/confirm-transaction-base/confirm-transaction-base.container.js
+++ b/ui/pages/confirm-transaction-base/confirm-transaction-base.container.js
@@ -51,6 +51,7 @@ import {
   getNativeCurrency,
   getSendToAccounts,
   getProviderConfig,
+  findKeyringForAddress,
 } from '../../ducks/metamask/metamask';
 import {
   addHexPrefix,
@@ -145,6 +146,7 @@ const mapStateToProps = (state, ownProps) => {
 
   const { balance } = accounts[fromAddress];
   const { name: fromName } = identities[fromAddress];
+  const keyring = findKeyringForAddress(state, fromAddress);
 
   const isSendingAmount =
     type === TransactionType.simpleSend || !isEmptyHexString(amount);
@@ -276,6 +278,7 @@ const mapStateToProps = (state, ownProps) => {
     chainId,
     isBuyableChain,
     useCurrencyRateCheck: getUseCurrencyRateCheck(state),
+    keyringForAccount: keyring,
     ///: BEGIN:ONLY_INCLUDE_IN(build-mmi)
     accountType,
     isNoteToTraderSupported,
@@ -310,8 +313,18 @@ export const mapDispatchToProps = (dispatch) => {
     },
     cancelTransaction: ({ id }) => dispatch(cancelTx({ id })),
     cancelAllTransactions: (txList) => dispatch(cancelTxs(txList)),
-    sendTransaction: (txData) =>
-      dispatch(updateAndApproveTx(customNonceMerge(txData))),
+    sendTransaction: (
+      txData,
+      dontShowLoadingIndicator,
+      loadingIndicatorMessage,
+    ) =>
+      dispatch(
+        updateAndApproveTx(
+          customNonceMerge(txData),
+          dontShowLoadingIndicator,
+          loadingIndicatorMessage,
+        ),
+      ),
     getNextNonce: () => dispatch(getNextNonce()),
     setDefaultHomeActiveTabName: (tabName) =>
       dispatch(setDefaultHomeActiveTabName(tabName)),

--- a/ui/pages/confirm-transaction/__snapshots__/confirm-transaction.test.js.snap
+++ b/ui/pages/confirm-transaction/__snapshots__/confirm-transaction.test.js.snap
@@ -2,10 +2,10 @@
 
 exports[`Confirmation Transaction Page should display the Loading component when the transaction is invalid 1`] = `
 <div
-  class="loading-overlay"
+  class="mm-box loading-overlay"
 >
   <div
-    class="loading-overlay__container"
+    class="mm-box loading-overlay__container mm-box--margin-bottom-3"
   >
     <div
       class="spinner loading-overlay__spinner"
@@ -275,5 +275,8 @@ exports[`Confirmation Transaction Page should display the Loading component when
       </svg>
     </div>
   </div>
+  <div
+    class="mm-box"
+  />
 </div>
 `;

--- a/ui/store/actions.ts
+++ b/ui/store/actions.ts
@@ -1039,6 +1039,7 @@ export async function addTransactionAndWaitForPublish(
 export function updateAndApproveTx(
   txMeta: TransactionMeta,
   dontShowLoadingIndicator: boolean,
+  loadingIndicatorMessage: string,
 ): ThunkAction<
   Promise<TransactionMeta | null>,
   MetaMaskReduxState,
@@ -1046,7 +1047,8 @@ export function updateAndApproveTx(
   AnyAction
 > {
   return (dispatch: MetaMaskReduxDispatch) => {
-    !dontShowLoadingIndicator && dispatch(showLoadingIndication());
+    !dontShowLoadingIndicator &&
+      dispatch(showLoadingIndication(loadingIndicatorMessage));
     return new Promise((resolve, reject) => {
       const actionId = generateActionId();
       callBackgroundMethod(


### PR DESCRIPTION
## **Description**

This PR adds a loading message to the loading indicator for Hardware Wallet and Snap Accounts. Previously, when a transaction was made and not confirmed on the device, MetaMask would stay in a loading state indefinitely, which could be confusing for users. With this change, a loading message is displayed to indicate that the transaction is waiting for confirmation on the device. This improves the user experience and makes it clear that the transaction is still in progress.

## **Manual testing steps**

1. Using a Snap (using async flow) or HW account 
2. Click send
3. Send any amount of eth and confirm transaction
4. Don't approve the transaction on the hardware device or snap account
5. See the new loading message

## **Screenshots/Recordings**

### **Before**

![snap-loading-screen2](https://github.com/MetaMask/metamask-extension/assets/96463427/9fadbca7-682a-4ace-81b3-9b62289f453e)

### **After**

![snap-loading-screen](https://github.com/MetaMask/metamask-extension/assets/96463427/5b035bdd-a345-4814-9a34-739298e37378)

## **Related issues**

Resolves https://github.com/MetaMask/accounts-planning/issues/63

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained:
  - [x] What problem this PR is solving.
  - [x] How this problem was solved.
  - [x] How reviewers can test my changes.
- [x] I’ve indicated what issue this PR is linked to: Fixes #???
- [ ] I’ve included tests if applicable.
- [ ] I’ve documented any added code.
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)).
- [x] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
