### PR TITLE
feat: show checksum address when removing snap account

### DIFF
--- a/ui/pages/remove-snap-account/remove-snap-account.test.tsx
+++ b/ui/pages/remove-snap-account/remove-snap-account.test.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import configureMockStore from 'redux-mock-store';
+import { renderWithProvider } from '../../../test/lib/render-helpers';
+import { toChecksumHexAddress } from '../../../shared/modules/hexstring-utils';
+import mockState from '../../../test/data/mock-state.json';
+import RemoveSnapAccount from './remove-snap-account';
+
+const defaultProps = {
+  snapId: 'npm:@mock-snap',
+  snapName: 'mock-name',
+  publicAddress: '0x0dcd5d886577d5081b0c52e242ef29e70be3e7bc',
+};
+
+describe('RemoveSnapAccount', () => {
+  it('should return checksum address', async () => {
+    const mockStore = configureMockStore([])(mockState);
+    const { getByText } = renderWithProvider(
+      <RemoveSnapAccount {...defaultProps} />,
+      mockStore,
+    );
+
+    const expectedCheckSumAddress = toChecksumHexAddress(
+      defaultProps.publicAddress,
+    );
+
+    expect(getByText(expectedCheckSumAddress)).toBeInTheDocument();
+  });
+});

--- a/ui/pages/remove-snap-account/remove-snap-account.tsx
+++ b/ui/pages/remove-snap-account/remove-snap-account.tsx
@@ -8,6 +8,7 @@ import {
   Display,
   FlexDirection,
 } from '../../helpers/constants/design-system';
+import { toChecksumHexAddress } from '../../../shared/modules/hexstring-utils';
 import { RemoveSnapAccountContent } from './components';
 
 export interface RemoveSnapAccountProps {
@@ -42,7 +43,7 @@ const RemoveSnapAccount = ({
         <RemoveSnapAccountContent
           snapName={snapName}
           snapId={snapId}
-          publicAddress={publicAddress}
+          publicAddress={toChecksumHexAddress(publicAddress)}
         />
       </Box>
     </Box>


### PR DESCRIPTION
## **Description**

This pr will change the address to a checksum address on the remove snap account popup. 

## **Manual testing steps**

1. Start MM Flask
2. Go to https://metamask.github.io/snap-simple-keyring/latest/
3. Install the snap
4. Create an account
5. Copy the uuid of the account
6. Go to remove account and paste the uuid
7. Click the remove account button
8. A new popup should appear with the checksum address 

## **Screenshots/Recordings**

### **Before**

<img width="359" alt="Screenshot 2023-10-09 at 09 52 18" src="https://github.com/MetaMask/metamask-extension/assets/96463427/53643e5e-ecbf-47d3-9235-cd2b37b26327">


### **After**

<img width="358" alt="Screenshot 2023-10-09 at 09 50 08" src="https://github.com/MetaMask/metamask-extension/assets/96463427/db577c3a-cc0e-46de-9fc3-25f8ceabd571">

## **Related issues**

Resolves https://github.com/MetaMask/accounts-planning/issues/73

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained:
  - [x] What problem this PR is solving.
  - [x] How this problem was solved.
  - [x] How reviewers can test my changes.
- [x] I’ve indicated what issue this PR is linked to: Fixes #???
- [ x] I’ve included tests if applicable.
- [x] I’ve documented any added code.
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)).
- [x] I’ve properly set the pull request status:
  - [x] In case it's not yet "ready for review", I've set it to "draft".
  - [x] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
