### PR TITLE
[MMI] Auto-switching to the first custodian wallet when importing accounts

### DIFF
--- a/ui/pages/institutional/custody/custody.js
+++ b/ui/pages/institutional/custody/custody.js
@@ -53,6 +53,7 @@ import {
 import PulseLoader from '../../../components/ui/pulse-loader/pulse-loader';
 import ConfirmConnectCustodianModal from '../confirm-connect-custodian-modal';
 import { findCustodianByDisplayName } from '../../../helpers/utils/institutional/find-by-custodian-name';
+import { setSelectedAddress } from '../../../store/actions';
 
 const GK8_DISPLAY_NAME = 'gk8';
 
@@ -610,6 +611,8 @@ const CustodyPage = () => {
                 const selectedCustodian = custodians.find(
                   (custodian) => custodian.envName === selectedCustodianName,
                 );
+                const accountKeys = Object.keys(selectedAccounts);
+                const lastAccountKey = accountKeys[accountKeys.length - 1];
 
                 await dispatch(
                   mmiActions.connectCustodyAddresses(
@@ -618,6 +621,8 @@ const CustodyPage = () => {
                     selectedAccounts,
                   ),
                 );
+
+                dispatch(setSelectedAddress(lastAccountKey.toLowerCase()));
 
                 trackEvent({
                   category: MetaMetricsEventCategory.MMI,

--- a/ui/pages/institutional/custody/custody.js
+++ b/ui/pages/institutional/custody/custody.js
@@ -611,8 +611,7 @@ const CustodyPage = () => {
                 const selectedCustodian = custodians.find(
                   (custodian) => custodian.envName === selectedCustodianName,
                 );
-                const accountKeys = Object.keys(selectedAccounts);
-                const lastAccountKey = accountKeys[accountKeys.length - 1];
+                const firstAccountKey = Object.keys(selectedAccounts).shift();
 
                 await dispatch(
                   mmiActions.connectCustodyAddresses(
@@ -622,7 +621,7 @@ const CustodyPage = () => {
                   ),
                 );
 
-                dispatch(setSelectedAddress(lastAccountKey.toLowerCase()));
+                dispatch(setSelectedAddress(firstAccountKey.toLowerCase()));
 
                 trackEvent({
                   category: MetaMetricsEventCategory.MMI,


### PR DESCRIPTION
## **Description**

Auto-switching to the first custodian wallet when importing accounts

## **Manual testing steps**

1. When 1 or multiple wallets are imported, the extension should auto-switch to the first wallet in the list after import is completed.

## **Screenshots/Recordings**

[Auto-Switching feature - Watch Video](https://www.loom.com/share/517e7dc26c844576956698a7bb872925)

## **Pre-merge author checklist**

- [X] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've clearly explained:
  - [X] What problem this PR is solving.
  - [X] How this problem was solved.
  - [X] How reviewers can test my changes.
- [X] I’ve indicated what issue this PR is linked to: Fixes #???
- [X] I’ve included tests if applicable.
- [X] I’ve documented any added code.
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)).
- [X] I’ve properly set the pull request status:
  - [X] In case it's not yet "ready for review", I've set it to "draft".
  - [X] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [X] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [X] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
