### PR TITLE
fix: reset asset state on selectAccountChanged

### DIFF
--- a/ui/ducks/send/send.js
+++ b/ui/ducks/send/send.js
@@ -1636,6 +1636,19 @@ const slice = createSlice({
             if (draftTransaction?.asset.type === AssetType.native) {
               draftTransaction.asset.balance = action.payload.account.balance;
             }
+
+            // If selected account was changed and selected asset is a token then
+            // reset asset to native asset
+            if (draftTransaction?.asset.type === AssetType.token) {
+              draftTransaction.asset.type =
+                draftTransactionInitialState.asset.type;
+              draftTransaction.asset.error =
+                draftTransactionInitialState.asset.error;
+              draftTransaction.asset.details =
+                draftTransactionInitialState.asset.details;
+              draftTransaction.asset.balance = action.payload.account.balance;
+            }
+
             slice.caseReducers.validateAmountField(state);
             slice.caseReducers.validateGasField(state);
             slice.caseReducers.validateSendState(state);

--- a/ui/ducks/send/send.test.js
+++ b/ui/ducks/send/send.test.js
@@ -1143,6 +1143,53 @@ describe('Send Slice', () => {
           action.payload.account.address,
         );
       });
+      it('should reset to native asset on selectedAccount changed', () => {
+        const olderState = {
+          ...INITIAL_SEND_STATE_FOR_EXISTING_DRAFT,
+          selectedAccount: {
+            balance: '0x3',
+            address: mockAddress1,
+          },
+          draftTransactions: {
+            'test-uuid': {
+              ...draftTransactionInitialState,
+              asset: {
+                type: AssetType.token,
+                error: null,
+                details: {
+                  address: 'tokenAddress',
+                  symbol: 'tokenSymbol',
+                  decimals: 'tokenDecimals',
+                },
+                balance: '0x2',
+              },
+            },
+          },
+        };
+
+        const action = {
+          type: 'SELECTED_ACCOUNT_CHANGED',
+          payload: {
+            account: {
+              address: '0xDifferentAddress',
+              balance: '0x1',
+            },
+          },
+        };
+
+        const result = sendReducer(olderState, action);
+        expect(result.selectedAccount.balance).toStrictEqual(
+          action.payload.account.balance,
+        );
+        expect(result.selectedAccount.address).toStrictEqual(
+          action.payload.account.address,
+        );
+
+        expect(result.draftTransactions['test-uuid'].asset).toStrictEqual({
+          ...draftTransactionInitialState.asset,
+          balance: action.payload.account.balance,
+        });
+      });
 
       it('should gracefully handle missing account in payload', () => {
         const olderState = {


### PR DESCRIPTION
## **Description**
This PR fixes two issues mentioned here:
https://github.com/MetaMask/metamask-extension/issues/15836
https://github.com/MetaMask/metamask-extension/issues/14684

Currently, if you are sending an ERC20 token on one account. And then you switch to another account that does not have that entered amount, Metamask still allows for the transaction to be confirmed which will fail eventually.

The current fix resets the "asset" field in the state to the native currency when the user changes the selected account.

## **Manual testing steps**

Make sure you have two accounts with any ERC20 tokens, (in our exp: USDC)
_1. Click on the ERC20 token, USDC, and click on "send"
_2. If you have for exp 102 USDC, put in the amount field "100"
_3. Switch the account to another account that does not have the entered amount, and you should see in assets the native currency exp "ETH" instead of "USDC" and the amount should be back to zero.

## **Screenshots/Recordings**

_If applicable, add screenshots and/or recordings to visualize the before and after of your change._

### **Before**

In this test, we have two accounts; one with 102 USDC the other with 20 USDC.

We will start with account 3 and attempt to send 100 USDC to another account:

![image](https://github.com/MetaMask/metamask-extension/assets/10994169/f4d55f03-a2a2-4bbc-b2a9-890dc4a20050)

Switch to another account that does not have the required amount

![image](https://github.com/MetaMask/metamask-extension/assets/10994169/b1370e99-f48a-4038-a403-b210c89dc267)

Notice that there is no confirmation of the amount and you can click on confirm 

![image](https://github.com/MetaMask/metamask-extension/assets/10994169/bb0a9631-68af-4d81-8037-56c9c0d6c1de)

### **After**

![image](https://github.com/MetaMask/metamask-extension/assets/10994169/bfa5082f-6f88-473b-9ef8-189c1d93e0f7)

Switch to another account 

![image](https://github.com/MetaMask/metamask-extension/assets/10994169/90e9cd7f-d94e-4b1b-848d-97e341435dea)

Notice that we have now the native currency ETH selected

and if you attempt now to send more USDC than what you have 

![image](https://github.com/MetaMask/metamask-extension/assets/10994169/97783977-9640-432f-aa00-80412ed07d12)

## **Related issues**

[_Fixes #MMASSETS-41](https://consensyssoftware.atlassian.net/browse/MMASSETS-41)

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained:
  - [ ] What problem this PR is solving.
  - [ ] How this problem was solved.
  - [ ] How reviewers can test my changes.
- [x] I’ve indicated what issue this PR is linked to: Fixes #???
- [x] I’ve included tests if applicable.
- [x] I’ve documented any added code.
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)).
- [ ] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
