### PR TITLE
Fix: Select snap account after being added

### DIFF
--- a/app/scripts/lib/snap-keyring/snap-keyring.ts
+++ b/app/scripts/lib/snap-keyring/snap-keyring.ts
@@ -55,7 +55,7 @@ export const snapKeyringBuilder = (
         await getKeyringController().persistAllKeyrings();
       },
       addAccount: async (
-        _address: string,
+        address: string,
         origin: string,
         handleUserInput: (accepted: boolean) => Promise<void>,
       ) => {
@@ -79,7 +79,7 @@ export const snapKeyringBuilder = (
             try {
               await handleUserInput(confirmationResult);
               await getKeyringController().persistAllKeyrings();
-              getPreferencesController().setSelectedAddress(_address);
+              getPreferencesController().setSelectedAddress(address);
               await getApprovalController().success({
                 message: t('snapAccountCreated') ?? 'Your account is ready!',
                 header: [snapAuthorshipHeader],

--- a/app/scripts/lib/snap-keyring/snap-keyring.ts
+++ b/app/scripts/lib/snap-keyring/snap-keyring.ts
@@ -8,6 +8,7 @@ import type { KeyringController } from '@metamask/keyring-controller';
 import { SNAP_MANAGE_ACCOUNTS_CONFIRMATION_TYPES } from '../../../../shared/constants/app';
 import { t } from '../../translate';
 import MetamaskController from '../../metamask-controller';
+import PreferencesController from 'app/scripts/controllers/preferences';
 
 /**
  * Get the addresses of the accounts managed by a given Snap.
@@ -30,6 +31,7 @@ export const getAccountsBySnapId = async (
  * @param getSnapController - A function that retrieves the Snap Controller instance.
  * @param getApprovalController - A function that retrieves the Approval Controller instance.
  * @param getKeyringController - A function that retrieves the Keyring Controller instance.
+ * @param getPreferencesController - A function that retrieves the Preferences Controller instance.
  * @param removeAccountHelper - A function to help remove an account based on its address.
  * @returns The constructed SnapKeyring builder instance with the following methods:
  * - `saveState`: Persists all keyrings in the keyring controller.
@@ -40,6 +42,7 @@ export const snapKeyringBuilder = (
   getSnapController: () => SnapController,
   getApprovalController: () => ApprovalController,
   getKeyringController: () => KeyringController,
+  getPreferencesController: () => PreferencesController,
   removeAccountHelper: (address: string) => Promise<any>,
 ) => {
   const builder = (() => {
@@ -76,6 +79,7 @@ export const snapKeyringBuilder = (
             try {
               await handleUserInput(confirmationResult);
               await getKeyringController().persistAllKeyrings();
+              getPreferencesController().setSelectedAddress(_address);
               await getApprovalController().success({
                 message: t('snapAccountCreated') ?? 'Your account is ready!',
                 header: [snapAuthorshipHeader],

--- a/app/scripts/lib/snap-keyring/snap-keyring.ts
+++ b/app/scripts/lib/snap-keyring/snap-keyring.ts
@@ -8,7 +8,7 @@ import type { KeyringController } from '@metamask/keyring-controller';
 import { SNAP_MANAGE_ACCOUNTS_CONFIRMATION_TYPES } from '../../../../shared/constants/app';
 import { t } from '../../translate';
 import MetamaskController from '../../metamask-controller';
-import PreferencesController from 'app/scripts/controllers/preferences';
+import PreferencesController from '../../controllers/preferences';
 
 /**
  * Get the addresses of the accounts managed by a given Snap.

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -873,12 +873,14 @@ export default class MetamaskController extends EventEmitter {
     const getSnapController = () => this.snapController;
     const getApprovalController = () => this.approvalController;
     const getKeyringController = () => this.keyringController;
+    const getPreferencesController = () => this.preferencesController;
 
     additionalKeyrings.push(
       snapKeyringBuilder(
         getSnapController,
         getApprovalController,
         getKeyringController,
+        getPreferencesController,
         (address) => this.removeAccount(address),
       ),
     );

--- a/test/e2e/accounts/test-create-snap-account.spec.js
+++ b/test/e2e/accounts/test-create-snap-account.spec.js
@@ -177,6 +177,15 @@ describe('Create Snap Account', function () {
           tag: 'p',
           text: 'Successful request',
         });
+
+        await driver.switchToWindowWithTitle(
+          WINDOW_TITLES.ExtensionInFullScreenView,
+        );
+
+        await driver.findElement({
+          css: '[data-testid="account-menu-icon"]',
+          text: 'Account 2',
+        });
       },
     );
   });


### PR DESCRIPTION
## **Description**

This PR fixes the issue where a new Snap account is not selected after creation.

## **Manual testing steps**

1. Go to (https://metamask.github.io/snap-simple-keyring/latest/) 
2. Press the `Create account` dropdown and then click `Create Account`
3.  On the popup click `Create`
4. On the metamask extension see that the selected account is the new Snap account.

## **Screenshots/Recordings**

### **Before**
![selectsnapaccount1](https://github.com/MetaMask/metamask-extension/assets/96463427/a84d2357-b286-4197-94b1-2d50a209bafd)


### **After**
![select-snap-account2](https://github.com/MetaMask/metamask-extension/assets/96463427/3c5bb4b9-beaa-46db-b9fe-31b4941b3fd6)


## **Related issues**

Resolves https://github.com/MetaMask/accounts-planning/issues/99

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained:
  - [x] What problem this PR is solving.
  - [x] How this problem was solved.
  - [x] How reviewers can test my changes.
- [x] I’ve indicated what issue this PR is linked to: Fixes #???
- [x] I’ve included tests if applicable.
- [x] I’ve documented any added code.
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)).
- [x] I’ve properly set the pull request status:
  - [x] In case it's not yet "ready for review", I've set it to "draft".
  - [x] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
