### PR TITLE
Decouple `MetaMetrics` controller calls from `TransactionController`

### DIFF
--- a/app/scripts/controllers/transactions/index.js
+++ b/app/scripts/controllers/transactions/index.js
@@ -781,13 +781,13 @@ export default class TransactionController extends EventEmitter {
     const txMeta = this.txStateManager.getTransaction(transactionId);
     const { properties, sensitiveProperties } =
       await this._buildEventFragmentProperties(txMeta);
-    this._createTransactionEventFragment(
-      txMeta,
+    this.emit('transaction-metric', {
+      actionId,
       event,
       properties,
       sensitiveProperties,
-      actionId,
-    );
+      txMeta,
+    });
   }
 
   startIncomingTransactionPolling() {
@@ -2565,7 +2565,7 @@ export default class TransactionController extends EventEmitter {
       event,
       properties,
       sensitiveProperties,
-      transactionMeta: txMeta,
+      txMeta,
     });
   }
 

--- a/app/scripts/controllers/transactions/index.js
+++ b/app/scripts/controllers/transactions/index.js
@@ -787,6 +787,7 @@ export default class TransactionController extends EventEmitter {
       properties,
       sensitiveProperties,
       transactionMeta: txMeta,
+      skipFinalize: true,
     });
   }
 

--- a/app/scripts/controllers/transactions/index.js
+++ b/app/scripts/controllers/transactions/index.js
@@ -786,7 +786,7 @@ export default class TransactionController extends EventEmitter {
       event,
       properties,
       sensitiveProperties,
-      txMeta,
+      transactionMeta: txMeta,
     });
   }
 
@@ -2565,7 +2565,7 @@ export default class TransactionController extends EventEmitter {
       event,
       properties,
       sensitiveProperties,
-      txMeta,
+      transactionMeta: txMeta,
     });
   }
 

--- a/app/scripts/controllers/transactions/index.js
+++ b/app/scripts/controllers/transactions/index.js
@@ -776,8 +776,16 @@ export default class TransactionController extends EventEmitter {
    *  fragment for
    * @param {valueOf<TransactionMetaMetricsEvent>} event - event type to create
    * @param {string} actionId - actionId passed from UI
+   * @param {boolean} isFragmentExists - whether fragment exist or not
+   * @param {object} updateParams - Update payload sent from UI
    */
-  async createTransactionEventFragment(transactionId, event, actionId) {
+  async createOrUpdateTransactionEventFragment(
+    transactionId,
+    event,
+    actionId,
+    isFragmentExists,
+    updateParams,
+  ) {
     const txMeta = this.txStateManager.getTransaction(transactionId);
     const { properties, sensitiveProperties } =
       await this._buildEventFragmentProperties(txMeta);
@@ -787,7 +795,10 @@ export default class TransactionController extends EventEmitter {
       properties,
       sensitiveProperties,
       transactionMeta: txMeta,
+      skipCreate: isFragmentExists,
+      skipUpdate: false,
       skipFinalize: true,
+      updateParams,
     });
   }
 

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -1402,11 +1402,7 @@ export default class MetamaskController extends EventEmitter {
           );
         }
 
-        function finalizeEventFragment({
-          eventName,
-          txMeta,
-          finalizeEvent,
-        }) {
+        function finalizeEventFragment({ eventName, txMeta, finalizeEvent }) {
           let id;
           let payload;
           switch (eventName) {

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -117,6 +117,7 @@ import {
   TransactionStatus,
   TransactionType,
   TokenStandard,
+  TransactionMetaMetricsEvent,
 } from '../../shared/constants/transaction';
 import {
   GAS_API_BASE_URL,
@@ -1272,23 +1273,6 @@ export default class MetamaskController extends EventEmitter {
       ),
       provider: this.provider,
       blockTracker: this.blockTracker,
-      createEventFragment: this.metaMetricsController.createEventFragment.bind(
-        this.metaMetricsController,
-      ),
-      updateEventFragment: this.metaMetricsController.updateEventFragment.bind(
-        this.metaMetricsController,
-      ),
-      finalizeEventFragment:
-        this.metaMetricsController.finalizeEventFragment.bind(
-          this.metaMetricsController,
-        ),
-      getEventFragmentById:
-        this.metaMetricsController.getEventFragmentById.bind(
-          this.metaMetricsController,
-        ),
-      trackMetaMetricsEvent: this.metaMetricsController.trackEvent.bind(
-        this.metaMetricsController,
-      ),
       getParticipateInMetrics: () =>
         this.metaMetricsController.state.participateInMetaMetrics,
       getEIP1559GasFeeEstimates:
@@ -1310,6 +1294,129 @@ export default class MetamaskController extends EventEmitter {
           `${this.approvalController.name}:rejectRequest`,
         ],
       }),
+    });
+
+    this.txController.on(
+      'transaction-metric',
+      ({
+        actionId,
+        event,
+        properties,
+        sensitiveProperties,
+        transactionMeta,
+      }) => {
+        const isSubmitted = [
+          TransactionMetaMetricsEvent.finalized,
+          TransactionMetaMetricsEvent.submitted,
+        ].includes(event);
+        const uniqueIdentifier = `transaction-${
+          isSubmitted ? 'submitted' : 'added'
+        }-${transactionMeta.id}`;
+
+        const fragment =
+          this.metaMetricsController.getEventFragmentById(uniqueIdentifier);
+        if (typeof fragment !== 'undefined') {
+          return;
+        }
+
+        let id;
+        switch (event) {
+          case TransactionMetaMetricsEvent.added:
+            this.metaMetricsController.createEventFragment({
+              category: MetaMetricsEventCategory.Transactions,
+              initialEvent: TransactionMetaMetricsEvent.added,
+              successEvent: TransactionMetaMetricsEvent.approved,
+              failureEvent: TransactionMetaMetricsEvent.rejected,
+              properties,
+              sensitiveProperties,
+              persist: true,
+              uniqueIdentifier,
+              actionId,
+            });
+            break;
+
+          // If the user approves a transaction, finalize the transaction added
+          // event fragment.
+          case TransactionMetaMetricsEvent.approved:
+            id = `transaction-added-${transactionMeta.id}`;
+            this.metaMetricsController.createEventFragment({
+              category: MetaMetricsEventCategory.Transactions,
+              successEvent: TransactionMetaMetricsEvent.approved,
+              failureEvent: TransactionMetaMetricsEvent.rejected,
+              properties,
+              sensitiveProperties,
+              persist: true,
+              uniqueIdentifier,
+              actionId,
+            });
+            this.metaMetricsController.updateEventFragment(id, {
+              properties,
+              sensitiveProperties,
+            });
+            this.metaMetricsController.finalizeEventFragment(id);
+            break;
+
+          // If the user rejects a transaction, finalize the transaction added
+          // event fragment. with the abandoned flag set.
+          case TransactionMetaMetricsEvent.rejected:
+            id = `transaction-added-${transactionMeta.id}`;
+            this.metaMetricsController.createEventFragment({
+              category: MetaMetricsEventCategory.Transactions,
+              successEvent: TransactionMetaMetricsEvent.approved,
+              failureEvent: TransactionMetaMetricsEvent.rejected,
+              properties,
+              sensitiveProperties,
+              persist: true,
+              uniqueIdentifier,
+              actionId,
+            });
+            this.metaMetricsController.updateEventFragment(id, {
+              properties,
+              sensitiveProperties,
+            });
+            this.metaMetricsController.finalizeEventFragment(id, {
+              abandoned: true,
+            });
+            break;
+
+          case TransactionMetaMetricsEvent.submitted:
+            this.metaMetricsController.createEventFragment({
+              category: MetaMetricsEventCategory.Transactions,
+              initialEvent: TransactionMetaMetricsEvent.submitted,
+              successEvent: TransactionMetaMetricsEvent.finalized,
+              properties,
+              sensitiveProperties,
+              persist: true,
+              uniqueIdentifier,
+              actionId,
+            });
+            break;
+
+          case TransactionMetaMetricsEvent.finalized:
+            id = `transaction-submitted-${transactionMeta.id}`;
+            this.metaMetricsController.createEventFragment({
+              category: MetaMetricsEventCategory.Transactions,
+              successEvent: TransactionMetaMetricsEvent.finalized,
+              properties,
+              sensitiveProperties,
+              persist: true,
+              uniqueIdentifier,
+              actionId,
+            });
+            this.metaMetricsController.updateEventFragment(id, {
+              properties,
+              sensitiveProperties,
+            });
+            this.metaMetricsController.finalizeEventFragment(id);
+            break;
+          default:
+            break;
+        }
+      },
+    );
+
+    this.txController.on('transaction-swap-metric', (payload) => {
+      this.metaMetricsController.trackEvent(payload);
     });
 
     this.txController.on(`tx:status-update`, async (txId, status) => {

--- a/app/scripts/metamask-controller.test.js
+++ b/app/scripts/metamask-controller.test.js
@@ -1824,7 +1824,7 @@ describe('MetaMaskController', () => {
           ).toHaveBeenCalledTimes(1);
           expect(
             localController.metaMetricsController.finalizeEventFragment,
-          ).toHaveBeenCalledWith(expectedId);
+          ).toHaveBeenCalledWith(expectedId, undefined);
         });
 
         it('should create,update & finalize event fragment when transaction rejected', () => {
@@ -1952,7 +1952,7 @@ describe('MetaMaskController', () => {
           ).toHaveBeenCalledTimes(1);
           expect(
             localController.metaMetricsController.finalizeEventFragment,
-          ).toHaveBeenCalledWith(expectedId);
+          ).toHaveBeenCalledWith(expectedId, undefined);
         });
       });
 

--- a/app/scripts/metamask-controller.test.js
+++ b/app/scripts/metamask-controller.test.js
@@ -111,7 +111,9 @@ jest.mock('../../shared/modules/mv3.utils', () => ({
 const mockSCHubEvent = jest.fn();
 jest.mock('@metamask/signature-controller', () => {
   return {
-    SignatureController(...args) {
+    // Object shorthand prevents this mock to be used with "new" keyword
+    // eslint-disable-next-line object-shorthand
+    SignatureController: function (...args) {
       const { SignatureController } = jest.requireActual(
         '@metamask/signature-controller',
       );
@@ -131,24 +133,14 @@ jest.mock(
         './controllers/transactions',
       ).default;
 
-      jest
-        .spyOn(TransactionController.prototype, 'updateIncomingTransactions')
-        .mockImplementation();
-      jest
-        .spyOn(
-          TransactionController.prototype,
-          'startIncomingTransactionPolling',
-        )
-        .mockImplementation();
-      jest
-        .spyOn(
-          TransactionController.prototype,
-          'stopIncomingTransactionPolling',
-        )
-        .mockImplementation();
-
       const controller = new TransactionController(...args);
+
+      /* eslint-disable jest/prefer-spy-on */
+      controller.updateIncomingTransactions = jest.fn();
+      controller.startIncomingTransactionPolling = jest.fn();
+      controller.stopIncomingTransactionPolling = jest.fn();
       controller.on = mockTCEvent;
+      /* eslint-enable */
 
       return controller;
     },
@@ -166,23 +158,17 @@ jest.mock(
         './controllers/metametrics',
       ).default;
 
-      MetaMetricsController.prototype.getEventFragmentById =
-        mockMetaMetricsControllerGetEventFragmentById;
-      jest
-        .spyOn(MetaMetricsController.prototype, 'createEventFragment')
-        .mockImplementation();
-      jest
-        .spyOn(MetaMetricsController.prototype, 'updateEventFragment')
-        .mockImplementation();
-      jest
-        .spyOn(MetaMetricsController.prototype, 'finalizeEventFragment')
-        .mockImplementation();
-      jest
-        .spyOn(MetaMetricsController.prototype, 'trackEvent')
-        .mockImplementation();
-
       const controller = new MetaMetricsController(...args);
+
+      /* eslint-disable jest/prefer-spy-on */
+      controller.getEventFragmentById =
+        mockMetaMetricsControllerGetEventFragmentById;
+      controller.createEventFragment = jest.fn();
+      controller.updateEventFragment = jest.fn();
+      controller.finalizeEventFragment = jest.fn();
+      controller.trackEvent = jest.fn();
       controller.on = mockTCEvent;
+      /* eslint-enable */
 
       return controller;
     },

--- a/ui/components/app/advanced-gas-fee-popover/advanced-gas-fee-defaults/advanced-gas-fee-defaults.test.js
+++ b/ui/components/app/advanced-gas-fee-popover/advanced-gas-fee-defaults/advanced-gas-fee-defaults.test.js
@@ -29,7 +29,7 @@ jest.mock('../../../../store/actions', () => ({
   removePollingTokenFromAppState: jest.fn(),
   setAdvancedGasFee: jest.fn(),
   updateEventFragment: jest.fn(),
-  createTransactionEventFragment: jest.fn(),
+  createOrUpdateTransactionEventFragment: jest.fn(),
 }));
 
 const render = (defaultGasParams, contextParams) => {

--- a/ui/components/app/advanced-gas-fee-popover/advanced-gas-fee-popover.test.js
+++ b/ui/components/app/advanced-gas-fee-popover/advanced-gas-fee-popover.test.js
@@ -18,7 +18,7 @@ jest.mock('../../../store/actions', () => ({
     .mockImplementation(() => Promise.resolve()),
   addPollingTokenToAppState: jest.fn(),
   removePollingTokenFromAppState: jest.fn(),
-  createTransactionEventFragment: jest.fn(),
+  createOrUpdateTransactionEventFragment: jest.fn(),
 }));
 
 jest.mock('../../../contexts/transaction-modal', () => ({

--- a/ui/components/app/cancel-speedup-popover/cancel-speedup-popover.test.js
+++ b/ui/components/app/cancel-speedup-popover/cancel-speedup-popover.test.js
@@ -57,7 +57,7 @@ jest.mock('../../../store/actions', () => ({
   removePollingTokenFromAppState: jest.fn(),
   updateTransactionGasFees: () => ({ type: 'UPDATE_TRANSACTION_PARAMS' }),
   updatePreviousGasParams: () => ({ type: 'UPDATE_TRANSACTION_PARAMS' }),
-  createTransactionEventFragment: jest.fn(),
+  createOrUpdateTransactionEventFragment: jest.fn(),
 }));
 
 jest.mock('../../../contexts/transaction-modal', () => ({

--- a/ui/components/app/edit-gas-fee-button/edit-gas-fee-button.test.js
+++ b/ui/components/app/edit-gas-fee-button/edit-gas-fee-button.test.js
@@ -22,7 +22,7 @@ jest.mock('../../../store/actions', () => ({
     .fn()
     .mockImplementation(() => Promise.resolve()),
   addPollingTokenToAppState: jest.fn(),
-  createTransactionEventFragment: jest.fn(),
+  createOrUpdateTransactionEventFragment: jest.fn(),
 }));
 
 const render = ({ componentProps, contextProps } = {}) => {

--- a/ui/components/app/edit-gas-fee-popover/edit-gas-fee-popover.test.js
+++ b/ui/components/app/edit-gas-fee-popover/edit-gas-fee-popover.test.js
@@ -19,7 +19,7 @@ jest.mock('../../../store/actions', () => ({
     .fn()
     .mockImplementation(() => Promise.resolve()),
   addPollingTokenToAppState: jest.fn(),
-  createTransactionEventFragment: jest.fn(),
+  createOrUpdateTransactionEventFragment: jest.fn(),
 }));
 
 jest.mock('../../../contexts/transaction-modal', () => ({

--- a/ui/components/app/edit-gas-fee-popover/edit-gas-item/edit-gas-item.test.js
+++ b/ui/components/app/edit-gas-fee-popover/edit-gas-item/edit-gas-item.test.js
@@ -26,7 +26,7 @@ jest.mock('../../../../store/actions', () => ({
   getGasFeeTimeEstimate: jest
     .fn()
     .mockImplementation(() => Promise.resolve('unknown')),
-  createTransactionEventFragment: jest.fn(),
+  createOrUpdateTransactionEventFragment: jest.fn(),
 }));
 
 const MOCK_FEE_ESTIMATE = {

--- a/ui/components/app/transaction-detail/transaction-detail.component.test.js
+++ b/ui/components/app/transaction-detail/transaction-detail.component.test.js
@@ -18,7 +18,7 @@ jest.mock('../../../store/actions', () => ({
     .fn()
     .mockImplementation(() => Promise.resolve()),
   addPollingTokenToAppState: jest.fn(),
-  createTransactionEventFragment: jest.fn(),
+  createOrUpdateTransactionEventFragment: jest.fn(),
 }));
 
 const render = ({ componentProps, contextProps } = {}) => {

--- a/ui/hooks/useTransactionEventFragment.js
+++ b/ui/hooks/useTransactionEventFragment.js
@@ -2,10 +2,7 @@ import { useCallback } from 'react';
 import { useSelector } from 'react-redux';
 
 import { useGasFeeContext } from '../contexts/gasFee';
-import {
-  createTransactionEventFragment,
-  updateEventFragment,
-} from '../store/actions';
+import { createOrUpdateTransactionEventFragment } from '../store/actions';
 import { selectMatchingFragment } from '../selectors';
 import { TransactionMetaMetricsEvent } from '../../shared/constants/transaction';
 
@@ -23,13 +20,12 @@ export const useTransactionEventFragment = () => {
       if (!transaction || !transaction.id) {
         return;
       }
-      if (!fragment) {
-        await createTransactionEventFragment(
-          transaction.id,
-          TransactionMetaMetricsEvent.approved,
-        );
-      }
-      updateEventFragment(`transaction-added-${transaction.id}`, params);
+      await createOrUpdateTransactionEventFragment(
+        transaction.id,
+        TransactionMetaMetricsEvent.approved,
+        Boolean(fragment),
+        params,
+      );
     },
     [fragment, transaction],
   );

--- a/ui/pages/send/send-content/send-content.component.test.js
+++ b/ui/pages/send/send-content/send-content.component.test.js
@@ -16,7 +16,7 @@ jest.mock('../../../store/actions', () => ({
   getGasFeeEstimatesAndStartPolling: jest.fn().mockResolvedValue(),
   addPollingTokenToAppState: jest.fn(),
   removePollingTokenFromAppState: jest.fn(),
-  createTransactionEventFragment: jest.fn(),
+  createOrUpdateTransactionEventFragment: jest.fn(),
   getGasFeeTimeEstimate: jest.fn().mockResolvedValue('unknown'),
 }));
 

--- a/ui/pages/swaps/fee-card/fee-card.test.js
+++ b/ui/pages/swaps/fee-card/fee-card.test.js
@@ -57,7 +57,7 @@ const generateUseSelectorRouter = () => (selector) => {
 setBackgroundConnection({
   getGasFeeTimeEstimate: jest.fn(),
   getGasFeeEstimatesAndStartPolling: jest.fn(),
-  createTransactionEventFragment: jest.fn(),
+  createOrUpdateTransactionEventFragment: jest.fn(),
 });
 
 const createProps = (customProps = {}) => {

--- a/ui/pages/token-allowance/token-allowance.test.js
+++ b/ui/pages/token-allowance/token-allowance.test.js
@@ -107,7 +107,7 @@ jest.mock('../../store/actions', () => ({
   removePollingTokenFromAppState: jest.fn(),
   updateTransactionGasFees: () => ({ type: 'UPDATE_TRANSACTION_PARAMS' }),
   updatePreviousGasParams: () => ({ type: 'UPDATE_TRANSACTION_PARAMS' }),
-  createTransactionEventFragment: jest.fn(),
+  createOrUpdateTransactionEventFragment: jest.fn(),
   getNextNonce: () => jest.fn(),
   showModal: () => mockShowModal,
   updateCustomNonce: () => ({ type: 'UPDATE_TRANSACTION_PARAMS' }),

--- a/ui/store/actions.ts
+++ b/ui/store/actions.ts
@@ -4136,15 +4136,19 @@ export function createEventFragment(
   ]);
 }
 
-export function createTransactionEventFragment(
+export function createOrUpdateTransactionEventFragment(
   transactionId: string,
   event: TransactionMetaMetricsEvent,
+  isFragmentExist: boolean,
+  updateParameters: any,
 ): Promise<string> {
   const actionId = generateActionId();
-  return submitRequestToBackground('createTransactionEventFragment', [
+  return submitRequestToBackground('createOrUpdateTransactionEventFragment', [
     transactionId,
     event,
     actionId,
+    isFragmentExist,
+    updateParameters,
   ]);
 }
 


### PR DESCRIPTION
## **Description**
With ongoing effort of `TransactionController` alignment between mobile and extension, this PR aims to decouple `MetaMetricsController` functions from `TransactionController` and targets to make `MetaMetrics` event triggers client specific.

## **Manual testing steps**

No functional changes. 

## **Related issues**

Fixes https://github.com/MetaMask/MetaMask-planning/issues/1053

## **Pre-merge author checklist**

- [X] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've clearly explained:
  - [X] What problem this PR is solving.
  - [X] How this problem was solved.
  - [X] How reviewers can test my changes.
- [X] I’ve indicated what issue this PR is linked to: Fixes #???
- [X] I’ve included tests if applicable.
- [X] I’ve documented any added code.
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)).
- [x] I’ve properly set the pull request status:
  - [x] In case it's not yet "ready for review", I've set it to "draft".
  - [x] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
