### PR TITLE
Feat/add mm e2e mmi build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,243 +70,259 @@ aliases:
       fi
 
 workflows:
-  test_and_release:
+  # test_and_release:
+  #   jobs:
+  #     - create_release_pull_request:
+  #         <<: *rc_branch_only
+  #         requires:
+  #           - prep-deps
+  #     - trigger-beta-build:
+  #         requires:
+  #           - prep-deps
+  #     - prep-deps
+  #     - test-deps-audit:
+  #         requires:
+  #           - prep-deps
+  #     - test-deps-depcheck:
+  #         requires:
+  #           - prep-deps
+  #     - test-yarn-dedupe:
+  #         requires:
+  #           - prep-deps
+  #     - validate-lavamoat-allow-scripts:
+  #         requires:
+  #           - prep-deps
+  #     - validate-lavamoat-policy-build:
+  #         requires:
+  #           - prep-deps
+  #     - validate-lavamoat-policy-webapp:
+  #         matrix:
+  #           parameters:
+  #             build-type: [main, beta, flask, mmi, desktop]
+  #         requires:
+  #           - prep-deps
+  #     - prep-build-mmi:
+  #         requires:
+  #           - prep-deps
+  #     - prep-build:
+  #         requires:
+  #           - prep-deps
+  #     - prep-build-desktop:
+  #         filters:
+  #           branches:
+  #             ignore: master
+  #         requires:
+  #           - prep-deps
+  #     - prep-build-flask:
+  #         requires:
+  #           - prep-deps
+  #     - prep-build-test:
+  #         requires:
+  #           - prep-deps
+  #     - prep-build-test-mv3:
+  #         requires:
+  #           - prep-deps
+  #     - prep-build-test-flask:
+  #         requires:
+  #           - prep-deps
+  #     - prep-build-test-mmi:
+  #         requires:
+  #           - prep-deps
+  #     - prep-build-storybook:
+  #         requires:
+  #           - prep-deps
+  #     - prep-build-ts-migration-dashboard:
+  #         requires:
+  #           - prep-deps
+  #     - test-lint:
+  #         requires:
+  #           - prep-deps
+  #     - test-lint-shellcheck
+  #     - test-lint-lockfile:
+  #         requires:
+  #           - prep-deps
+  #     - test-lint-changelog:
+  #         requires:
+  #           - prep-deps
+  #     - test-e2e-chrome:
+  #         requires:
+  #           - prep-build-test
+  #     - test-e2e-firefox:
+  #         requires:
+  #           - prep-build-test
+  #     - test-e2e-chrome-rpc:
+  #         requires:
+  #           - prep-build-test
+  #     - test-e2e-chrome-snaps:
+  #         requires:
+  #           - prep-build-test
+  #     - test-e2e-firefox-snaps:
+  #         requires:
+  #           - prep-build-test
+  #     - test-e2e-chrome-snaps-mmi:
+  #         requires:
+  #           - prep-build-test-mmi
+  #     - test-e2e-chrome-snaps-flask:
+  #         requires:
+  #           - prep-build-test-flask
+  #     - test-e2e-firefox-snaps-flask:
+  #         requires:
+  #           - prep-build-test-flask
+  #     - test-e2e-chrome-mmi:
+  #         requires:
+  #           - prep-build-test-mmi
+  #     - test-e2e-chrome-rpc-mmi:
+  #         requires:
+  #           - prep-build-test-mmi
+  #     - test-e2e-chrome-mv3:
+  #         requires:
+  #           - prep-build-test-mv3
+  #     - test-unit-mocha:
+  #         requires:
+  #           - prep-deps
+  #     - test-unit-jest-main:
+  #         requires:
+  #           - prep-deps
+  #     - test-unit-jest-development:
+  #         requires:
+  #           - prep-deps
+  #     - upload-and-validate-coverage:
+  #         requires:
+  #           - test-unit-jest-main
+  #           - test-unit-jest-development
+  #           - test-unit-mocha
+  #     - test-unit-global:
+  #         requires:
+  #           - prep-deps
+  #     - test-storybook:
+  #         requires:
+  #           - prep-deps
+  #           - prep-build-storybook
+  #     - validate-source-maps:
+  #         requires:
+  #           - prep-build
+  #     - validate-source-maps-beta:
+  #         requires:
+  #           - trigger-beta-build
+  #     - validate-source-maps-desktop:
+  #         filters:
+  #           branches:
+  #             ignore: master
+  #         requires:
+  #           - prep-build-desktop
+  #     - validate-source-maps-mmi:
+  #         requires:
+  #           - prep-build-mmi
+  #     - validate-source-maps-flask:
+  #         requires:
+  #           - prep-build-flask
+  #     - test-mozilla-lint:
+  #         requires:
+  #           - prep-deps
+  #           - prep-build
+  #     - test-mozilla-lint-desktop:
+  #         filters:
+  #           branches:
+  #             ignore: master
+  #         requires:
+  #           - prep-deps
+  #           - prep-build-desktop
+  #     - test-mozilla-lint-flask:
+  #         requires:
+  #           - prep-deps
+  #           - prep-build-flask
+  #     - all-tests-pass:
+  #         requires:
+  #           - test-deps-depcheck
+  #           - validate-lavamoat-allow-scripts
+  #           - validate-lavamoat-policy-build
+  #           - validate-lavamoat-policy-webapp
+  #           - test-lint
+  #           - test-lint-shellcheck
+  #           - test-lint-lockfile
+  #           - test-lint-changelog
+  #           - test-unit-jest-main
+  #           - test-unit-jest-development
+  #           - test-unit-global
+  #           - test-unit-mocha
+  #           - upload-and-validate-coverage
+  #           - validate-source-maps
+  #           - validate-source-maps-beta
+  #           - validate-source-maps-desktop
+  #           - validate-source-maps-flask
+  #           - validate-source-maps-mmi
+  #           - test-mozilla-lint
+  #           - test-mozilla-lint-desktop
+  #           - test-mozilla-lint-flask
+  #           - test-e2e-chrome
+  #           - test-e2e-firefox
+  #           - test-e2e-chrome-snaps
+  #           - test-e2e-chrome-snaps-mmi
+  #           - test-e2e-firefox-snaps
+  #           - test-e2e-chrome-snaps-flask
+  #           - test-e2e-firefox-snaps-flask
+  #           - test-e2e-chrome-mmi
+  #           - test-e2e-chrome-rpc-mmi
+  #           - test-storybook
+  #     - benchmark:
+  #         requires:
+  #           - prep-build-test
+  #     - user-actions-benchmark:
+  #         requires:
+  #           - prep-build-test
+  #     - stats-module-load-init:
+  #         requires:
+  #           - prep-build-test-mv3
+  #     - job-publish-prerelease:
+  #         requires:
+  #           - prep-deps
+  #           - prep-build
+  #           - trigger-beta-build
+  #           - prep-build-desktop
+  #           - prep-build-mmi
+  #           - prep-build-flask
+  #           - prep-build-storybook
+  #           - prep-build-ts-migration-dashboard
+  #           - prep-build-test-mv3
+  #           - benchmark
+  #           - user-actions-benchmark
+  #           - stats-module-load-init
+  #           - all-tests-pass
+  #     - job-publish-release:
+  #         filters:
+  #           branches:
+  #             only: master
+  #         requires:
+  #           - prep-deps
+  #           - prep-build
+  #           - prep-build-desktop
+  #           - prep-build-mmi
+  #           - prep-build-flask
+  #           - all-tests-pass
+  #     - job-publish-storybook:
+  #         filters:
+  #           branches:
+  #             only: develop
+  #         requires:
+  #           - prep-build-storybook
+  #     - job-publish-ts-migration-dashboard:
+  #         filters:
+  #           branches:
+  #             only: develop
+  #         requires:
+  #           - prep-build-ts-migration-dashboard
+
+
+  pipeline_test:
     jobs:
-      - create_release_pull_request:
-          <<: *rc_branch_only
-          requires:
-            - prep-deps
-      - trigger-beta-build:
-          requires:
-            - prep-deps
       - prep-deps
-      - test-deps-audit:
-          requires:
-            - prep-deps
-      - test-deps-depcheck:
-          requires:
-            - prep-deps
-      - test-yarn-dedupe:
-          requires:
-            - prep-deps
-      - validate-lavamoat-allow-scripts:
-          requires:
-            - prep-deps
-      - validate-lavamoat-policy-build:
-          requires:
-            - prep-deps
-      - validate-lavamoat-policy-webapp:
-          matrix:
-            parameters:
-              build-type: [main, beta, flask, mmi, desktop]
-          requires:
-            - prep-deps
-      - prep-build-mmi:
-          requires:
-            - prep-deps
-      - prep-build:
-          requires:
-            - prep-deps
-      - prep-build-desktop:
-          filters:
-            branches:
-              ignore: master
-          requires:
-            - prep-deps
-      - prep-build-flask:
-          requires:
-            - prep-deps
-      - prep-build-test:
-          requires:
-            - prep-deps
-      - prep-build-test-mv3:
-          requires:
-            - prep-deps
-      - prep-build-test-flask:
-          requires:
-            - prep-deps
       - prep-build-test-mmi:
           requires:
             - prep-deps
-      - prep-build-storybook:
-          requires:
-            - prep-deps
-      - prep-build-ts-migration-dashboard:
-          requires:
-            - prep-deps
-      - test-lint:
-          requires:
-            - prep-deps
-      - test-lint-shellcheck
-      - test-lint-lockfile:
-          requires:
-            - prep-deps
-      - test-lint-changelog:
-          requires:
-            - prep-deps
-      - test-e2e-chrome:
-          requires:
-            - prep-build-test
-      - test-e2e-firefox:
-          requires:
-            - prep-build-test
-      - test-e2e-chrome-rpc:
-          requires:
-            - prep-build-test
-      - test-e2e-chrome-snaps:
-          requires:
-            - prep-build-test
-      - test-e2e-firefox-snaps:
-          requires:
-            - prep-build-test
-      - test-e2e-chrome-snaps-flask:
-          requires:
-            - prep-build-test-flask
-      - test-e2e-firefox-snaps-flask:
-          requires:
-            - prep-build-test-flask
-      - test-e2e-chrome-mmi:
+      - test-e2e-chrome-snaps-mmi:
           requires:
             - prep-build-test-mmi
-      - test-e2e-chrome-rpc-mmi:
-          requires:
-            - prep-build-test-mmi
-      - test-e2e-chrome-mv3:
-          requires:
-            - prep-build-test-mv3
-      - test-unit-mocha:
-          requires:
-            - prep-deps
-      - test-unit-jest-main:
-          requires:
-            - prep-deps
-      - test-unit-jest-development:
-          requires:
-            - prep-deps
-      - upload-and-validate-coverage:
-          requires:
-            - test-unit-jest-main
-            - test-unit-jest-development
-            - test-unit-mocha
-      - test-unit-global:
-          requires:
-            - prep-deps
-      - test-storybook:
-          requires:
-            - prep-deps
-            - prep-build-storybook
-      - validate-source-maps:
-          requires:
-            - prep-build
-      - validate-source-maps-beta:
-          requires:
-            - trigger-beta-build
-      - validate-source-maps-desktop:
-          filters:
-            branches:
-              ignore: master
-          requires:
-            - prep-build-desktop
-      - validate-source-maps-mmi:
-          requires:
-            - prep-build-mmi
-      - validate-source-maps-flask:
-          requires:
-            - prep-build-flask
-      - test-mozilla-lint:
-          requires:
-            - prep-deps
-            - prep-build
-      - test-mozilla-lint-desktop:
-          filters:
-            branches:
-              ignore: master
-          requires:
-            - prep-deps
-            - prep-build-desktop
-      - test-mozilla-lint-flask:
-          requires:
-            - prep-deps
-            - prep-build-flask
-      - all-tests-pass:
-          requires:
-            - test-deps-depcheck
-            - validate-lavamoat-allow-scripts
-            - validate-lavamoat-policy-build
-            - validate-lavamoat-policy-webapp
-            - test-lint
-            - test-lint-shellcheck
-            - test-lint-lockfile
-            - test-lint-changelog
-            - test-unit-jest-main
-            - test-unit-jest-development
-            - test-unit-global
-            - test-unit-mocha
-            - upload-and-validate-coverage
-            - validate-source-maps
-            - validate-source-maps-beta
-            - validate-source-maps-desktop
-            - validate-source-maps-flask
-            - validate-source-maps-mmi
-            - test-mozilla-lint
-            - test-mozilla-lint-desktop
-            - test-mozilla-lint-flask
-            - test-e2e-chrome
-            - test-e2e-firefox
-            - test-e2e-chrome-snaps
-            - test-e2e-firefox-snaps
-            - test-e2e-chrome-snaps-flask
-            - test-e2e-firefox-snaps-flask
-            - test-e2e-chrome-mmi
-            - test-e2e-chrome-rpc-mmi
-            - test-storybook
-      - benchmark:
-          requires:
-            - prep-build-test
-      - user-actions-benchmark:
-          requires:
-            - prep-build-test
-      - stats-module-load-init:
-          requires:
-            - prep-build-test-mv3
-      - job-publish-prerelease:
-          requires:
-            - prep-deps
-            - prep-build
-            - trigger-beta-build
-            - prep-build-desktop
-            - prep-build-mmi
-            - prep-build-flask
-            - prep-build-storybook
-            - prep-build-ts-migration-dashboard
-            - prep-build-test-mv3
-            - benchmark
-            - user-actions-benchmark
-            - stats-module-load-init
-            - all-tests-pass
-      - job-publish-release:
-          filters:
-            branches:
-              only: master
-          requires:
-            - prep-deps
-            - prep-build
-            - prep-build-desktop
-            - prep-build-mmi
-            - prep-build-flask
-            - all-tests-pass
-      - job-publish-storybook:
-          filters:
-            branches:
-              only: develop
-          requires:
-            - prep-build-storybook
-      - job-publish-ts-migration-dashboard:
-          filters:
-            branches:
-              only: develop
-          requires:
-            - prep-build-ts-migration-dashboard
+
 
 jobs:
   trigger-beta-build:
@@ -1024,6 +1040,43 @@ jobs:
             if .circleci/scripts/test-run-e2e.sh
             then
               yarn test:e2e:firefox:snaps --retries 2 --debug --build-type=flask
+            fi
+          no_output_timeout: 20m
+      - run:
+          name: Merge JUnit report
+          command: |
+            if [ "$(ls -A test/test-results/e2e)" ]; then
+              yarn test:e2e:report
+            fi
+          when: always
+      - store_artifacts:
+          path: test-artifacts
+          destination: test-artifacts
+      - store_test_results:
+          path: test/test-results/e2e.xml
+
+  test-e2e-chrome-snaps-mmi:
+    executor: node-browsers
+    parallelism: 4
+    steps:
+      - run: *shallow-git-clone
+      - run:
+          name: Re-Install Chrome
+          command: ./.circleci/scripts/chrome-install.sh
+      - attach_workspace:
+          at: .
+      - run:
+          name: Move test build to dist
+          command: mv ./dist-test-mmi ./dist
+      - run:
+          name: Move test zips to builds
+          command: mv ./builds-test-mmi ./builds
+      - run:
+          name: test:e2e:chrome:snaps
+          command: |
+            if .circleci/scripts/test-run-e2e.sh
+            then
+              yarn test:e2e:chrome:snaps --retries 2 --debug --build-type=mmi
             fi
           no_output_timeout: 20m
       - run:


### PR DESCRIPTION
## **Description**
Currently MMI extension is assuming that all snaps MM extension features should work under MMI but this is not been tested in the pipeline.

This PR adds Metamask snaps e2e tests run in the circle ci pipeline for a MMI build generated extension. There are a set failing tests marked as @no-mmi so that when running the tests with yarn test:e2e:chrome:mmi will do SELENIUM_BROWSER=chrome node test/e2e/run-all.js --mmi passing --mmi as param.

This is a first step to improve MMI test coverage and regression. Next steps will be reviewed and updated tests if required

## **Manual testing steps**

_1. Step1:_
_2. Step2:_
_3. ..._

## **Screenshots/Recordings**

_If applicable, add screenshots and/or recordings to visualize the before and after of your change._

### **Before**

_[screenshot]_

### **After**

_[screenshot]_

## **Related issues**

_Fixes #???_

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've clearly explained:
  - [ ] What problem this PR is solving.
  - [ ] How this problem was solved.
  - [ ] How reviewers can test my changes.
- [ ] I’ve indicated what issue this PR is linked to: Fixes #???
- [ ] I’ve included tests if applicable.
- [ ] I’ve documented any added code.
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)).
- [ ] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
