### PR TITLE
fix: keyring snap removal modal flashing regular modal

### DIFF
--- a/ui/pages/settings/snaps/view-snap/view-snap.js
+++ b/ui/pages/settings/snaps/view-snap/view-snap.js
@@ -66,6 +66,7 @@ function ViewSnap() {
   const [isShowingRemoveWarning, setIsShowingRemoveWarning] = useState(false);
   const [isDescriptionOpen, setIsDescriptionOpen] = useState(false);
   const [isOverflowing, setIsOverflowing] = useState(false);
+  const [isRemovingKeyringSnap, setIsRemovingKeyringSnap] = useState(false);
 
   // eslint-disable-next-line no-unused-vars -- Main build does not use setKeyringAccounts
   const [keyringAccounts, setKeyringAccounts] = useState([]);
@@ -230,7 +231,8 @@ function ViewSnap() {
           <SnapRemoveWarning
             isOpen={
               isShowingRemoveWarning &&
-              (!isKeyringSnap || keyringAccounts.length === 0)
+              (!isKeyringSnap || keyringAccounts.length === 0) &&
+              !isRemovingKeyringSnap
             }
             onCancel={() => setIsShowingRemoveWarning(false)}
             onSubmit={async () => {
@@ -250,6 +252,7 @@ function ViewSnap() {
                 onBack={() => setIsShowingRemoveWarning(false)}
                 onSubmit={async () => {
                   try {
+                    setIsRemovingKeyringSnap(true);
                     await dispatch(removeSnap(snap.id));
                     setIsShowingRemoveWarning(false);
                     dispatch(
@@ -266,12 +269,14 @@ function ViewSnap() {
                         result: KeyringSnapRemovalResultStatus.Failed,
                       }),
                     );
+                  } finally {
+                    setIsRemovingKeyringSnap(false);
                   }
                 }}
                 isOpen={
                   isShowingRemoveWarning &&
                   isKeyringSnap &&
-                  keyringAccounts.length > 0
+                  keyringAccounts.length >= 0
                 }
               />
             </>

--- a/ui/pages/settings/snaps/view-snap/view-snap.js
+++ b/ui/pages/settings/snaps/view-snap/view-snap.js
@@ -276,7 +276,7 @@ function ViewSnap() {
                 isOpen={
                   isShowingRemoveWarning &&
                   isKeyringSnap &&
-                  keyringAccounts.length >= 0
+                  keyringAccounts.length > 0
                 }
               />
             </>

--- a/ui/pages/settings/snaps/view-snap/view-snap.js
+++ b/ui/pages/settings/snaps/view-snap/view-snap.js
@@ -66,6 +66,7 @@ function ViewSnap() {
   const [isShowingRemoveWarning, setIsShowingRemoveWarning] = useState(false);
   const [isDescriptionOpen, setIsDescriptionOpen] = useState(false);
   const [isOverflowing, setIsOverflowing] = useState(false);
+  // eslint-disable-next-line no-unused-vars -- Main build does not use setIsRemovingKeyringSnap
   const [isRemovingKeyringSnap, setIsRemovingKeyringSnap] = useState(false);
 
   // eslint-disable-next-line no-unused-vars -- Main build does not use setKeyringAccounts


### PR DESCRIPTION
## **Description**

This PR fixes the condition when Snap Accounts that take time to be removed causes the default snap removal modal to be shown.

## **Manual testing steps**

1. Start metamask flask
2. Install [Snap Simple Keyring version 0.2.2](https://metamask.github.io/snap-simple-keyring/0.2.2/)
3. Create an account 
4. On the metamask extension, click on settings
5. Click on snaps
6. Select the Snap Simple Keyring
7.  Click on `Remove Metamask Snap Simple Keyring`
8.  Click `Continue`
9.  Enter the snap name and click `Remove Snap`
10. See that the default snap removal modal does not appear

## **Related issues**

Resolves https://github.com/MetaMask/accounts-planning/issues/101

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained:
  - [x] What problem this PR is solving.
  - [x] How this problem was solved.
  - [x] How reviewers can test my changes.
- [x] I’ve indicated what issue this PR is linked to: Fixes #???
- [ ] I’ve included tests if applicable.
- [x] I’ve documented any added code.
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)).
- [x] I’ve properly set the pull request status:
  - [x] In case it's not yet "ready for review", I've set it to "draft".
  - [x] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
