### PR TITLE
fix: center messages for loading spinner

### DIFF
--- a/ui/components/ui/loading-screen/loading-screen.component.js
+++ b/ui/components/ui/loading-screen/loading-screen.component.js
@@ -2,6 +2,12 @@ import React, { isValidElement } from 'react';
 import PropTypes from 'prop-types';
 import Spinner from '../spinner';
 import { Box } from '../../component-library';
+import {
+  AlignItems,
+  Display,
+  FlexDirection,
+  JustifyContent,
+} from '../../../helpers/constants/design-system';
 
 const LoadingScreen = ({
   header,
@@ -16,7 +22,7 @@ const LoadingScreen = ({
     return isValidElement(loadingMessage) ? (
       loadingMessage
     ) : (
-      <span>{loadingMessage}</span>
+      <span style={{ textAlign: 'center' }}>{loadingMessage}</span>
     );
   };
 
@@ -31,7 +37,14 @@ const LoadingScreen = ({
           />
         )}
       </Box>
-      <Box>{renderMessage()}</Box>
+      <Box
+        display={Display.Flex}
+        flexDirection={FlexDirection.Row}
+        justifyContent={JustifyContent.center}
+        alignItems={AlignItems.center}
+      >
+        {renderMessage()}
+      </Box>
     </Box>
   );
 };

--- a/ui/pages/confirm-transaction/__snapshots__/confirm-transaction.test.js.snap
+++ b/ui/pages/confirm-transaction/__snapshots__/confirm-transaction.test.js.snap
@@ -276,7 +276,7 @@ exports[`Confirmation Transaction Page should display the Loading component when
     </div>
   </div>
   <div
-    class="mm-box"
+    class="mm-box mm-box--display-flex mm-box--flex-direction-row mm-box--justify-content-center mm-box--align-items-center"
   />
 </div>
 `;


### PR DESCRIPTION
## **Description**

This PR centers the text that is displayed under the loading spinner

## **Manual testing steps**

1. Click on send using a ledger account
2. Enter any amount and click next
3. Confirm the transaction
4. See the loading message

## **Screenshots/Recordings**

### **Before**

![image](https://github.com/MetaMask/metamask-extension/assets/96463427/747bf578-5d3a-46f5-8c6f-14489b67780c)

### **After**
![Screenshot 2023-10-11 at 17 36 58](https://github.com/MetaMask/metamask-extension/assets/96463427/945a59d7-2944-4c4e-ac4b-a26f23d49273)



## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained:
  - [x] What problem this PR is solving.
  - [x] How this problem was solved.
  - [x] How reviewers can test my changes.
- [ ] I’ve indicated what issue this PR is linked to: Fixes #???
- [x] I’ve included tests if applicable.
- [x] I’ve documented any added code.
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)).
- [x] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [x] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
