### PR TITLE
Fix breaking jest test for asset-list

### DIFF
--- a/ui/components/app/user-preferenced-currency-display/user-preferenced-currency-display.component.js
+++ b/ui/components/app/user-preferenced-currency-display/user-preferenced-currency-display.component.js
@@ -42,7 +42,7 @@ export default function UserPreferencedCurrencyDisplay({
     currency,
     showEthLogo,
     nativeCurrency,
-    currentNetwork.nickname,
+    currentNetwork?.nickname,
     currentNetwork?.rpcPrefs?.imageUrl,
   ]);
   return (

--- a/ui/hooks/useAccountTotalFiatBalance.test.js
+++ b/ui/hooks/useAccountTotalFiatBalance.test.js
@@ -96,7 +96,7 @@ describe('useAccountTotalFiatBalance', () => {
     );
     expect(result.current).toStrictEqual({
       formattedFiat: '$9.41',
-      totalWeiBalance: '14ba1e6a08a9ec',
+      totalWeiBalance: '14ba1e6a08a9ed',
       totalFiatBalance: '9.41',
       tokensWithBalances: [
         {


### PR DESCRIPTION
Fixes the current jest error on `develop` branch:

```
TypeError: Cannot read properties of undefined (reading 'nickname')

      43 |     showEthLogo,
      44 |     nativeCurrency,
    > 45 |     currentNetwork.nickname,
         |                    ^
      46 |     currentNetwork?.rpcPrefs?.imageUrl,
      47 |   ]);
      48 |   return (

      at nickname (ui/components/app/user-preferenced-currency-display/user-preferenced-currency-display.component.js:45:20)
      at renderWithHooks (node_modules/react-dom/cjs/react-dom.development.js:16260:18)
      at mountIndeterminateComponent (node_modules/react-dom/cjs/react-dom.development.js:18794:13)
      at beginWork$1 (node_modules/react-dom/cjs/react-dom.development.js:20162:16)
```

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've clearly explained:
  - [ ] What problem this PR is solving.
  - [ ] How this problem was solved.
  - [ ] How reviewers can test my changes.
- [ ] I’ve indicated what issue this PR is linked to: Fixes #???
- [ ] I’ve included tests if applicable.
- [ ] I’ve documented any added code.
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)).
- [ ] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
