### PR TITLE
UX: Multichain: Use contants for AssetListConversionButton variants

### DIFF
--- a/ui/components/app/asset-list/asset-list.js
+++ b/ui/components/app/asset-list/asset-list.js
@@ -38,6 +38,7 @@ import { Display } from '../../../helpers/constants/design-system';
 
 import { ReceiveModal } from '../../multichain/receive-modal';
 import { useAccountTotalFiatBalance } from '../../../hooks/useAccountTotalFiatBalance';
+import { ASSET_LIST_CONVERSION_BUTTON_VARIANT_TYPES } from '../../multichain/asset-list-conversion-button/asset-list-conversion-button';
 
 const AssetList = ({ onClickAsset }) => {
   const [showDetectedTokens, setShowDetectedTokens] = useState(false);
@@ -115,7 +116,7 @@ const AssetList = ({ onClickAsset }) => {
         >
           {shouldShowBuy ? (
             <AssetListConversionButton
-              variant="buy"
+              variant={ASSET_LIST_CONVERSION_BUTTON_VARIANT_TYPES.BUY}
               onClick={() => {
                 openBuyCryptoInPdapp();
                 trackEvent({
@@ -133,7 +134,7 @@ const AssetList = ({ onClickAsset }) => {
           ) : null}
           {shouldShowReceive ? (
             <AssetListConversionButton
-              variant="receive"
+              variant={ASSET_LIST_CONVERSION_BUTTON_VARIANT_TYPES.RECEIVE}
               onClick={() => setShowReceiveModal(true)}
             />
           ) : null}

--- a/ui/components/app/nfts-tab/nfts-tab.js
+++ b/ui/components/app/nfts-tab/nfts-tab.js
@@ -25,6 +25,7 @@ import { Box, ButtonLink, IconName, Text } from '../../component-library';
 import NFTsDetectionNoticeNFTsTab from '../nfts-detection-notice-nfts-tab/nfts-detection-notice-nfts-tab';
 import NftsItems from '../nfts-items';
 import { AssetListConversionButton } from '../../multichain';
+import { ASSET_LIST_CONVERSION_BUTTON_VARIANT_TYPES } from '../../multichain/asset-list-conversion-button/asset-list-conversion-button';
 
 export default function NftsTab() {
   const useNftDetection = useSelector(getUseNftDetection);
@@ -76,7 +77,7 @@ export default function NftsTab() {
               paddingTop={4}
             >
               <AssetListConversionButton
-                variant="nft"
+                variant={ASSET_LIST_CONVERSION_BUTTON_VARIANT_TYPES.NFT}
                 onClick={() =>
                   global.platform.openTab({ url: ZENDESK_URLS.NFT_TOKENS })
                 }

--- a/ui/components/multichain/asset-list-conversion-button/asset-list-conversion-button.js
+++ b/ui/components/multichain/asset-list-conversion-button/asset-list-conversion-button.js
@@ -84,5 +84,7 @@ AssetListConversionButton.propTypes = {
   /**
    * Text within the button body
    */
-  variant: PropTypes.oneOf(['buy', 'receive', 'nft']),
+  variant: PropTypes.oneOf(
+    Object.values(ASSET_LIST_CONVERSION_BUTTON_VARIANT_TYPES),
+  ),
 };

--- a/ui/components/multichain/asset-list-conversion-button/asset-list-conversion-button.js
+++ b/ui/components/multichain/asset-list-conversion-button/asset-list-conversion-button.js
@@ -10,20 +10,26 @@ import {
 
 import { useI18nContext } from '../../../hooks/useI18nContext';
 
+export const ASSET_LIST_CONVERSION_BUTTON_VARIANT_TYPES = {
+  BUY: 'buy',
+  RECEIVE: 'receive',
+  NFT: 'nft',
+};
+
 const ASSET_LIST_CONVERSION_BUTTON_VARIANTS = {
-  buy: {
+  [ASSET_LIST_CONVERSION_BUTTON_VARIANT_TYPES.BUY]: {
     color: 'var(--color-info-default)',
     backgroundImage: 'url(/images/token-list-buy-background.png)',
     text: 'buy',
     icon: IconName.Add,
   },
-  receive: {
+  [ASSET_LIST_CONVERSION_BUTTON_VARIANT_TYPES.RECEIVE]: {
     color: 'var(--color-flask-default)',
     backgroundImage: 'url(/images/token-list-receive-background.png)',
     text: 'receive',
     icon: IconName.Arrow2Down,
   },
-  nft: {
+  [ASSET_LIST_CONVERSION_BUTTON_VARIANT_TYPES.NFT]: {
     color: 'var(--color-error-alternative)',
     backgroundImage: 'url(/images/token-list-nfts-background.png)',
     text: 'nftLearnMore',

--- a/ui/components/multichain/asset-list-conversion-button/asset-list-conversion-button.stories.js
+++ b/ui/components/multichain/asset-list-conversion-button/asset-list-conversion-button.stories.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { ASSET_LIST_CONVERSION_BUTTON_VARIANT_TYPES } from './asset-list-conversion-button';
 import { AssetListConversionButton } from '.';
 
 export default {
@@ -12,7 +13,6 @@ export default {
   args: {
     variant: 'buy',
     onClick: () => undefined,
-    onClose: () => undefined,
   },
 };
 
@@ -20,6 +20,9 @@ export const DefaultStory = (args) => <AssetListConversionButton {...args} />;
 DefaultStory.storyName = 'Default';
 
 export const ReceiveStory = (args) => (
-  <AssetListConversionButton {...args} variant="receive" />
+  <AssetListConversionButton
+    {...args}
+    variant={ASSET_LIST_CONVERSION_BUTTON_VARIANT_TYPES.RECEIVE}
+  />
 );
 ReceiveStory.storyName = 'Receive';


### PR DESCRIPTION
## **Description**
Since we're expecting one of three strings for the variant of `AssetListConversionButton`, we should make those keys a constant to be imported and used.

## **Manual testing steps**

No functional change.


## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've clearly explained:
  - [ ] What problem this PR is solving.
  - [ ] How this problem was solved.
  - [ ] How reviewers can test my changes.
- [ ] I’ve indicated what issue this PR is linked to: Fixes #???
- [ ] I’ve included tests if applicable.
- [ ] I’ve documented any added code.
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)).
- [ ] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
