### PR TITLE
fix: Hex data should be cleared out during ERC20 Send

### DIFF
--- a/test/jest/mocks.js
+++ b/test/jest/mocks.js
@@ -142,6 +142,7 @@ export const getInitialSendStateWithExistingTxState = (draftTxState) => ({
         ...draftTxState.recipient,
       },
       history: draftTxState.history ?? [],
+      userInputHexData: draftTxState.userInputHexData ?? null,
       // Use this key if you want to console.log inside the send.js file.
       test: draftTxState.test ?? 'yo',
     },

--- a/ui/ducks/send/send.js
+++ b/ui/ducks/send/send.js
@@ -964,6 +964,7 @@ const slice = createSlice({
         slice.caseReducers.updateAmountToMax(state);
       } else if (initialAssetSet === false) {
         slice.caseReducers.updateSendAmount(state, { payload: '0x0' });
+        slice.caseReducers.updateUserInputHexData(state, { payload: '' });
       }
       // validate send state
       slice.caseReducers.validateSendState(state);

--- a/ui/ducks/send/send.test.js
+++ b/ui/ducks/send/send.test.js
@@ -481,6 +481,33 @@ describe('Send Slice', () => {
         );
       });
 
+      it('should update hex data if its not the initial asset set', () => {
+        const updateAssetState = getInitialSendStateWithExistingTxState({
+          asset: {
+            type: 'old type',
+            balance: 'old balance',
+          },
+          userInputHexData: '0xTestHexData',
+        });
+
+        const action = {
+          type: 'send/updateAsset',
+          payload: {
+            asset: {
+              type: 'new type',
+              balance: 'new balance',
+            },
+            initialAssetSet: false,
+          },
+        };
+
+        const result = sendReducer(updateAssetState, action);
+
+        const draftTransaction = getTestUUIDTx(result);
+
+        expect(draftTransaction.userInputHexData).toStrictEqual('');
+      });
+
       it('should nullify old contract address error when asset types is not TOKEN', () => {
         const recipientErrorState = getInitialSendStateWithExistingTxState({
           recipient: {


### PR DESCRIPTION
## **Description**
whenever I am performing an ERC20 Send, if I change the asset to ETH, I can see how the Hex Data field is not empty, and it's displaying the data for the previous ERC20 Send. This should not be the case, and Hex Data should be cleared whenever the asset is changed to ETH.

Notice in practice, this hex data is not submited to the network (which is good) but the UI displays it as if there were Hex Data on the Edit screen.

solution: props are read-only , If you need to modify a value based on the props, you should create and manage state within the component.

## **Manual testing steps**

1 - Enable Hex Data from Advanced Settings
2 - Import an ERC20 toekn
3 - Click Send ERC20 token
4 - Add recipient
5 - Add amount and click Next
6 - Click Edit
7 - Change asset for ETH
8 - See how Hex data is not empty - it should be

### **Before**

https://user-images.githubusercontent.com/54408225/238333724-3b0bba4f-3ee5-4609-a092-3a920fa4b10a.mp4

## **Related issues**

_Fixes #19140

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained:
  - [x] What problem this PR is solving.
  - [x] How this problem was solved.
  - [x] How reviewers can test my changes.
- [x] I’ve indicated what issue this PR is linked to: Fixes #???
- [x] I’ve included tests if applicable.
- [ ] I’ve documented any added code.
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)).
- [x] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [x] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
