### PR TITLE
Token amount sent displays 0 when input contains no decimals

### DIFF
--- a/ui/hooks/useTokenDisplayValue.js
+++ b/ui/hooks/useTokenDisplayValue.js
@@ -43,7 +43,8 @@ export function useTokenDisplayValue(
       // and a token object has been provided
       token &&
       // and the provided token object contains a defined decimal value we need to calculate amount
-      token.decimals &&
+      token.decimals !== null &&
+      token.decimals !== undefined &&
       // and we are able to parse the token detail we to calculate amount from the raw data
       tokenValue,
   );

--- a/ui/hooks/useTokenDisplayValue.test.js
+++ b/ui/hooks/useTokenDisplayValue.test.js
@@ -115,6 +115,17 @@ const tests = [
     tokenValue: '25500000',
     displayValue: '25.5',
   },
+  {
+    token: {
+      symbol: 'MTK',
+      decimals: 0,
+    },
+    tokenData: {
+      args: 'decoded-params11',
+    },
+    tokenValue: '25',
+    displayValue: '25',
+  },
 ];
 
 describe('useTokenDisplayValue', () => {


### PR DESCRIPTION
## **Description**
Description

Problem: After sending a token with an amount that doesn’t include decimals (ie 3, 5, 2), the transaction history displays the actual amount sent as 0. If the amount sent has a decimal (ie. 3.1, 0.2), this bug does not exist.

Expected Behavior: The amount I send should be reflected in the transaction history.

the problem is related to the fact that in Javascript , the boolean expression of `0` return `false`

## **Manual testing steps**

1 - GIVEN I am on the "Activity" page
2 - AFTER I send a token with a decimal amount
3 - WHEN I view the previous transaction
4 - THEN I see the correct token amount sent

### **Before**

[_[screenshot]_
](https://user-images.githubusercontent.com/54408225/224984691-a046903b-681e-4414-a740-1d70ece3b7d3.mp4)

### **After**

https://user-images.githubusercontent.com/26223211/265502035-a4f4e162-3c58-48f0-9699-d2131b8de30d.mov

## **Related issues**

_Fixes #18139

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained:
  - [x] What problem this PR is solving.
  - [x] How this problem was solved.
  - [x] How reviewers can test my changes.
- [x] I’ve indicated what issue this PR is linked to: Fixes #???
- [x] I’ve included tests if applicable.
- [ ] I’ve documented any added code.
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)).
- [x] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [x] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
