### PR TITLE
Use findVisibleElement instead of findElement in ipfs-toggle.spec.js

### DIFF
--- a/test/e2e/tests/ipfs-toggle.spec.js
+++ b/test/e2e/tests/ipfs-toggle.spec.js
@@ -38,7 +38,7 @@ describe('Settings', function () {
         );
         await importedNftImage.click();
         // check for default image
-        const nftDefaultImage = await driver.findElement(
+        const nftDefaultImage = await driver.findVisibleElement(
           '[data-testid=nft-default-image]',
         );
         assert.equal(await nftDefaultImage.isDisplayed(), true);
@@ -48,7 +48,9 @@ describe('Settings', function () {
           text: 'Show',
           tag: 'button',
         });
-        const toggleIpfsModal = await driver.findElement('.toggle-ipfs-modal');
+        const toggleIpfsModal = await driver.findVisibleElement(
+          '.toggle-ipfs-modal',
+        );
         assert.equal(await toggleIpfsModal.isDisplayed(), true);
 
         // Toggle on ipfs when click on confirm button in modal


### PR DESCRIPTION
## **Description**
The e2e test modified in this PR can be flaky. For example, on the v11.2.0 branch it consistently passes on chrome but fails on firefox. Locally, on firefox, it only succeeds about 30% of the time.

The problem is that the test has some assertions about whether elements are displayed (using the `element.isDisplayed()` method), in the case of this test, these elements are images, which take longer to load/render then plain html divs or text. As a result, the `driver.findElement` method can find the element before it is displayed, and so calling `isDisplayed` immediately after `driver.findElement` resolves can intermittently fail.

The solution is to replace `driver.findElement` with `driver.findVisibleElement`, which will only resolve when the image element is actually displayed.

After making this change, I ran the test 7 times locally, and they passed 100%.

## **Manual testing steps**

Not needed, e2e tests should pass

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained:
  - [x] What problem this PR is solving.
  - [x] How this problem was solved.
  - [x] How reviewers can test my changes.
- [ ] I’ve indicated what issue this PR is linked to: Fixes #???
- [x] I’ve included tests if applicable.
- [ ] I’ve documented any added code.
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)).
- [ ] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
