### PR TITLE
fix(21300): bring back appInstalled event when opt in

### DIFF
--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -262,6 +262,27 @@ browser.runtime.onConnectExternal.addListener(async (...args) => {
  * @property {number} version - The latest migration version that has been run.
  */
 
+// It adds the "App Installed" event into a queue of events, which will be tracked only after a user opts into metrics.
+const addAppInstalledEvent = () => {
+  if (controller) {
+    controller.metaMetricsController.updateTraits({
+      [MetaMetricsUserTrait.InstallDateExt]: new Date()
+        .toISOString()
+        .split('T')[0], // yyyy-mm-dd
+    });
+    controller.metaMetricsController.addEventBeforeMetricsOptIn({
+      category: MetaMetricsEventCategory.App,
+      event: MetaMetricsEventName.AppInstalled,
+      properties: {},
+    });
+    return;
+  }
+  setTimeout(() => {
+    // If the controller is not set yet, we wait and try to add the "App Installed" event again.
+    addAppInstalledEvent();
+  }, 1000);
+};
+
 /**
  * Initializes the MetaMask controller, and sets up all platform configuration.
  *
@@ -295,6 +316,9 @@ async function initialize() {
       isFirstMetaMaskControllerSetup,
       initData.meta,
     );
+
+    await fireFirstInstallActions();
+
     if (!isManifestV3) {
       await loadPhishingWarningPage();
     }
@@ -303,6 +327,24 @@ async function initialize() {
     resolveInitialization();
   } catch (error) {
     rejectInitialization(error);
+  }
+}
+
+/**
+ * Store the value `isFirstTimeInstalled` as true when first time install the extension
+ * where we would stack AppInstalled events
+ * and open the extension automatically
+ * Finally we set the flag as false so they won't be triggered for updating
+ */
+async function fireFirstInstallActions() {
+  const sessionData = await localStore.get();
+  const isFirstTimeInstalled = sessionData?.isFirstTimeInstalled === undefined;
+  if (isFirstTimeInstalled) {
+    if (!(process.env.METAMASK_DEBUG || process.env.IN_TEST)) {
+      addAppInstalledEvent();
+      platform.openExtensionInBrowser();
+    }
+    await localStore.set({ isFirstTimeInstalled: false });
   }
 }
 
@@ -877,38 +919,6 @@ async function triggerUi() {
     }
   }
 }
-
-// It adds the "App Installed" event into a queue of events, which will be tracked only after a user opts into metrics.
-const addAppInstalledEvent = () => {
-  if (controller) {
-    controller.metaMetricsController.updateTraits({
-      [MetaMetricsUserTrait.InstallDateExt]: new Date()
-        .toISOString()
-        .split('T')[0], // yyyy-mm-dd
-    });
-    controller.metaMetricsController.addEventBeforeMetricsOptIn({
-      category: MetaMetricsEventCategory.App,
-      event: MetaMetricsEventName.AppInstalled,
-      properties: {},
-    });
-    return;
-  }
-  setTimeout(() => {
-    // If the controller is not set yet, we wait and try to add the "App Installed" event again.
-    addAppInstalledEvent();
-  }, 1000);
-};
-
-// On first install, open a new tab with MetaMask
-browser.runtime.onInstalled.addListener(({ reason }) => {
-  if (
-    reason === 'install' &&
-    !(process.env.METAMASK_DEBUG || process.env.IN_TEST)
-  ) {
-    addAppInstalledEvent();
-    platform.openExtensionInBrowser();
-  }
-});
 
 function setupSentryGetStateGlobal(store) {
   global.stateHooks.getSentryAppState = function () {


### PR DESCRIPTION
## **Description**
This is a regression coming from https://github.com/MetaMask/metamask-extension/pull/21015, where now we are loading all the files async, the browser onInstall event is not defined when `background.js` is loaded, hence the listener is not fired. We have 2 actions: send `AppInstalled` event and open the app automatically, which are not captured. 
The fix is to rely on local storage to set a flag and use it as an indicator to fire actions.

## **Manual testing steps**

1. download the build zip
2. load extension and open `background.html` to inspect
3. expect extension is opened automatically
4. onboard and select 'agree' when asking to opt in metrics 
5. check network and filter through 'batch'
6. you should see 2 metric events
7. refresh the extension, and repeat, you will see the same events

## **Screenshots/Recordings**

_If applicable, add screenshots and/or recordings to visualize the before and after of your change._

### **Before**

see https://github.com/MetaMask/metamask-extension/issues/21300

### **After**

https://github.com/MetaMask/metamask-extension/assets/12678455/fd79c82b-445f-48e4-a8b2-68ec98562059


## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/21300

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've clearly explained:
  - [ ] What problem this PR is solving.
  - [ ] How this problem was solved.
  - [ ] How reviewers can test my changes.
- [ ] I’ve indicated what issue this PR is linked to: Fixes #???
- [ ] I’ve included tests if applicable.
- [ ] I’ve documented any added code.
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)).
- [ ] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
