### PR TITLE
**DO-NOT-MERGE** Disable Snaps allowlist for testing purposes

### DIFF
--- a/app/scripts/lib/keyring-snaps-permissions.ts
+++ b/app/scripts/lib/keyring-snaps-permissions.ts
@@ -46,6 +46,21 @@ const ALLOWED_PROTOCOLS: string[] = [
 ];
 
 /**
+ * List of local domains.
+ */
+const LOCAL_DOMAINS: string[] = ['localhost', '127.0.0.1'];
+
+/**
+ * Checks if the value is a boolean and returns its value.
+ *
+ * @param value - Value to check.
+ * @returns `true` if the value is a boolean and `true`, `false` otherwise.
+ */
+function asBoolean(value: unknown): boolean {
+  return typeof value === 'boolean' && value;
+}
+
+/**
  * Checks if the protocol of the origin is allowed.
  *
  * @param origin - The origin to check.
@@ -53,7 +68,16 @@ const ALLOWED_PROTOCOLS: string[] = [
  */
 export function isProtocolAllowed(origin: string): boolean {
   try {
-    const url = new URL(origin);
+    const url: URL = new URL(origin);
+
+    // For testing, allow local domains regardless of the protocol.
+    if (
+      asBoolean(process.env.ALLOW_LOCAL_SNAPS) &&
+      LOCAL_DOMAINS.includes(url.hostname)
+    ) {
+      return true;
+    }
+
     return ALLOWED_PROTOCOLS.includes(url.protocol);
   } catch (error) {
     return false;

--- a/builds.yml
+++ b/builds.yml
@@ -24,10 +24,10 @@ buildTypes:
       - SEGMENT_PROD_WRITE_KEY
       - INFURA_ENV_KEY_REF: INFURA_PROD_PROJECT_ID
       - SEGMENT_WRITE_KEY_REF: SEGMENT_PROD_WRITE_KEY
-      - ALLOW_LOCAL_SNAPS: false
-      - REQUIRE_SNAPS_ALLOWLIST: true
+      - ALLOW_LOCAL_SNAPS: true # !!! DON'T MERGE THIS !!!
+      - REQUIRE_SNAPS_ALLOWLIST: false # !!! DON'T MERGE THIS !!!
       - IFRAME_EXECUTION_ENVIRONMENT_URL: https://execution.consensys.io/3.0.0/index.html
-      - KEYRING_SNAPS_REGISTRY_URL: https://metamask.github.io/keyring-snaps-registry/prod/registry.json
+      - KEYRING_SNAPS_REGISTRY_URL: https://metamask.github.io/keyring-snaps-registry/dev/registry.json # !!! DON'T MERGE THIS !!!
     # Main build uses the default browser manifest
     manifestOverrides: false
 


### PR DESCRIPTION
## **Description**

🔴 **DO NOT MERGE THIS PR**

This PR disables the Snap allowlist requirements in order to allow developers to test the account Snaps feature in stable.