### PR TITLE
Update PickerNetwork to using BlockSize.Max enum 

### DIFF
--- a/ui/components/component-library/picker-network/README.mdx
+++ b/ui/components/component-library/picker-network/README.mdx
@@ -48,7 +48,7 @@ import { PickerNetwork } from '../../ui/component-library';
 
 ### Width
 
-The width of the `PickerNetwork` is set to auto by default. Use the style utility `width` prop with the `BlockSize` enum to set the width of the `PickerNetwork` component.
+The width of the `PickerNetwork` is set to `width: max-content;` using the `BlockSize.Max` enum by default. Use the style utility `width` prop with the `BlockSize` enum to adjust the width of the `PickerNetwork` component.
 
 <Canvas>
   <Story id="components-componentlibrary-pickernetwork--width" />

--- a/ui/components/component-library/picker-network/__snapshots__/picker-network.test.tsx.snap
+++ b/ui/components/component-library/picker-network/__snapshots__/picker-network.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`PickerNetwork should render the label inside the PickerNetwork 1`] = `
 <div>
   <button
-    class="mm-box mm-picker-network mm-box--padding-right-4 mm-box--padding-left-2 mm-box--display-flex mm-box--gap-2 mm-box--align-items-center mm-box--background-color-background-alternative mm-box--rounded-pill"
+    class="mm-box mm-picker-network mm-box--padding-right-4 mm-box--padding-left-2 mm-box--display-flex mm-box--gap-2 mm-box--align-items-center mm-box--width-max mm-box--background-color-background-alternative mm-box--rounded-pill"
     data-testid="picker-network"
   >
     <div

--- a/ui/components/component-library/picker-network/picker-network.tsx
+++ b/ui/components/component-library/picker-network/picker-network.tsx
@@ -7,6 +7,7 @@ import {
   IconColor,
   BackgroundColor,
   Display,
+  BlockSize,
 } from '../../../helpers/constants/design-system';
 import {
   AvatarNetwork,
@@ -48,6 +49,7 @@ export const PickerNetwork: PickerNetworkComponent = React.forwardRef(
         gap={2}
         borderRadius={BorderRadius.pill}
         display={Display.Flex}
+        width={BlockSize.Max}
         {...(props as BoxProps<C>)}
       >
         <AvatarNetwork

--- a/ui/components/multichain/app-header/__snapshots__/app-header.test.js.snap
+++ b/ui/components/multichain/app-header/__snapshots__/app-header.test.js.snap
@@ -207,7 +207,7 @@ exports[`App Header should match snapshot 1`] = `
     >
       <div>
         <button
-          class="mm-box mm-picker-network multichain-app-header__contents__network-picker mm-box--margin-2 mm-box--padding-right-4 mm-box--padding-left-2 mm-box--display-none mm-box--sm:display-flex mm-box--gap-2 mm-box--align-items-center mm-box--background-color-background-alternative mm-box--rounded-pill"
+          class="mm-box mm-picker-network multichain-app-header__contents__network-picker mm-box--margin-2 mm-box--padding-right-4 mm-box--padding-left-2 mm-box--display-none mm-box--sm:display-flex mm-box--gap-2 mm-box--align-items-center mm-box--width-max mm-box--background-color-background-alternative mm-box--rounded-pill"
           data-testid="network-display"
           disabled=""
         >


### PR DESCRIPTION
## **Description**
A recent update to the PickerNetwork removed the styles for width: max-content; to allow the width to be adjusted to 100% using the width prop and BlockSize enum. This PR allows for that but also sets the intended max-content styles using the BlockSize.Max enum

## **Manual testing steps**

_1. Go to the storybook build in this PR
_2. Search for PickerNetwork
_3. See the max-contnent styles applied in the Label and Src stories 

## **Screenshots/Recordings**

### **Before**

https://github.com/MetaMask/metamask-extension/assets/8112138/341e7802-fd82-4b39-b963-313a078b9733

### **After**

https://github.com/MetaMask/metamask-extension/assets/8112138/244d97b4-4322-49d3-9461-7738824c01d0

## **Related issues**

_Fixes #???_

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've clearly explained:
  - [ ] What problem this PR is solving.
  - [ ] How this problem was solved.
  - [ ] How reviewers can test my changes.
- [ ] I’ve indicated what issue this PR is linked to: Fixes #???
- [ ] I’ve included tests if applicable.
- [ ] I’ve documented any added code.
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)).
- [ ] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
