### PR TITLE
UX: Fixed network picker in header

### DIFF
--- a/ui/components/multichain/app-header/app-header.js
+++ b/ui/components/multichain/app-header/app-header.js
@@ -234,6 +234,9 @@ export const AppHeader = ({ location }) => {
                       src={currentNetwork?.rpcPrefs?.imageUrl}
                       label={currentNetwork?.nickname}
                       aria-label={t('networkMenu')}
+                      labelProps={{
+                        display: Display.None,
+                      }}
                       onClick={(e) => {
                         e.stopPropagation();
                         e.preventDefault();

--- a/ui/components/multichain/app-header/app-header.scss
+++ b/ui/components/multichain/app-header/app-header.scss
@@ -33,10 +33,6 @@
       max-width: 250px;
     }
 
-    &--avatar-network p {
-      display: none;
-    }
-
     &__container {
       width: fit-content;
     }


### PR DESCRIPTION
## **Description**
With the picker network change, we updated the label from p to span tag. But this wasn't updated in app-header to handle the change in popup view

## **Manual testing steps**

_1. Step1:_ Open the Popup View
_2. Step2:_ Check that picker network looks correct


## **Screenshots/Recordings**


### **Before**

![Screenshot 2023-10-13 at 6 41 33 PM](https://github.com/MetaMask/metamask-extension/assets/39872794/33a3ec52-dc5a-42ec-8bc0-a63d23b11b90)


### **After**

![Screenshot 2023-10-13 at 6 41 11 PM](https://github.com/MetaMask/metamask-extension/assets/39872794/f968b600-7704-40ac-ab09-70a95c7b36cb)


## **Related issues**

_Fixes #???_

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've clearly explained:
  - [ ] What problem this PR is solving.
  - [ ] How this problem was solved.
  - [ ] How reviewers can test my changes.
- [ ] I’ve indicated what issue this PR is linked to: Fixes #???
- [ ] I’ve included tests if applicable.
- [ ] I’ve documented any added code.
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)).
- [ ] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
