### PR TITLE
Fix #21169 - Ensure Copy format is plain text

### DIFF
--- a/shared/constants/copy.ts
+++ b/shared/constants/copy.ts
@@ -1,0 +1,3 @@
+export const COPY_OPTIONS = {
+  format: 'text/plain',
+};

--- a/ui/components/app/nft-details/nft-details.test.js
+++ b/ui/components/app/nft-details/nft-details.test.js
@@ -8,6 +8,7 @@ import { startNewDraftTransaction } from '../../../ducks/send';
 import { renderWithProvider } from '../../../../test/lib/render-helpers';
 import mockState from '../../../../test/data/mock-state.json';
 import { DEFAULT_ROUTE, SEND_ROUTE } from '../../../helpers/constants/routes';
+import { COPY_OPTIONS } from '../../../../shared/constants/copy';
 import { AssetType } from '../../../../shared/constants/transaction';
 import {
   removeAndIgnoreNft,
@@ -111,7 +112,7 @@ describe('NFT Details', () => {
     const copyAddressButton = queryByTestId('nft-address-copy');
     fireEvent.click(copyAddressButton);
 
-    expect(copyToClipboard).toHaveBeenCalledWith(nfts[5].address);
+    expect(copyToClipboard).toHaveBeenCalledWith(nfts[5].address, COPY_OPTIONS);
   });
 
   it('should navigate to draft transaction send route with ERC721 data', async () => {

--- a/ui/components/app/selected-account/selected-account-component.test.js
+++ b/ui/components/app/selected-account/selected-account-component.test.js
@@ -4,6 +4,7 @@ import copyToClipboard from 'copy-to-clipboard';
 import { fireEvent } from '@testing-library/react';
 import { renderWithProvider } from '../../../../test/lib/render-helpers';
 import mockState from '../../../../test/data/mock-state.json';
+import { COPY_OPTIONS } from '../../../../shared/constants/copy';
 import {
   getCustodyAccountDetails,
   getIsCustodianSupportedChain,
@@ -68,6 +69,7 @@ describe('SelectedAccount Component', () => {
 
     expect(copyToClipboard).toHaveBeenCalledWith(
       '0x0DCD5D886577d5081B0c52e242Ef29E70Be3E7bc',
+      COPY_OPTIONS,
     );
   });
 

--- a/ui/components/app/selected-account/selected-account.component.js
+++ b/ui/components/app/selected-account/selected-account.component.js
@@ -13,6 +13,7 @@ import CustodyLabels from '../../institutional/custody-labels/custody-labels';
 ///: END:ONLY_INCLUDE_IN
 import { Icon, IconName, IconSize } from '../../component-library';
 import { IconColor } from '../../../helpers/constants/design-system';
+import { COPY_OPTIONS } from '../../../../shared/constants/copy';
 
 class SelectedAccount extends Component {
   state = {
@@ -104,7 +105,7 @@ class SelectedAccount extends Component {
                 () => this.setState({ copied: false }),
                 SECOND * 3,
               );
-              copyToClipboard(checksummedAddress);
+              copyToClipboard(checksummedAddress, COPY_OPTIONS);
             }}
           >
             <div className="selected-account__name">

--- a/ui/components/app/transaction-decoding/components/decoding/address/address.component.js
+++ b/ui/components/app/transaction-decoding/components/decoding/address/address.component.js
@@ -10,6 +10,7 @@ import {
   getMemoizedAddressBook,
 } from '../../../../../../selectors';
 import NicknamePopovers from '../../../../modals/nickname-popovers';
+import { COPY_OPTIONS } from '../../../../../../../shared/constants/copy';
 
 const Address = ({
   checksummedRecipientAddress,
@@ -47,7 +48,7 @@ const Address = ({
     <div
       className="tx-insight tx-insight-component tx-insight-component-address"
       onClick={() => {
-        copyToClipboard(checksummedRecipientAddress);
+        copyToClipboard(checksummedRecipientAddress, COPY_OPTIONS);
         if (onRecipientClick) {
           onRecipientClick();
         }

--- a/ui/components/app/transaction-list-item-details/transaction-list-item-details.component.js
+++ b/ui/components/app/transaction-list-item-details/transaction-list-item-details.component.js
@@ -29,6 +29,7 @@ import { getURLHostName } from '../../../helpers/utils/util';
 import TransactionDecoding from '../transaction-decoding';
 import { NETWORKS_ROUTE } from '../../../helpers/constants/routes';
 import TransactionInsightsDeprecationAlert from '../confirm-data/transaction-insights-deprecation-alert';
+import { COPY_OPTIONS } from '../../../../shared/constants/copy';
 
 export default class TransactionListItemDetails extends PureComponent {
   static contextTypes = {
@@ -138,7 +139,7 @@ export default class TransactionListItemDetails extends PureComponent {
     });
 
     this.setState({ justCopied: true }, () => {
-      copyToClipboard(hash);
+      copyToClipboard(hash, COPY_OPTIONS);
       setTimeout(() => this.setState({ justCopied: false }), SECOND);
     });
   };

--- a/ui/components/ui/sender-to-recipient/sender-to-recipient.component.js
+++ b/ui/components/ui/sender-to-recipient/sender-to-recipient.component.js
@@ -8,6 +8,7 @@ import { shortenAddress } from '../../../helpers/utils/util';
 import AccountMismatchWarning from '../account-mismatch-warning/account-mismatch-warning.component';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import { toChecksumHexAddress } from '../../../../shared/modules/hexstring-utils';
+import { COPY_OPTIONS } from '../../../../shared/constants/copy';
 import NicknamePopovers from '../../app/modals/nickname-popovers';
 import { Icon, IconName } from '../../component-library';
 import {
@@ -51,7 +52,7 @@ function SenderAddress({
       )}
       onClick={() => {
         setAddressCopied(true);
-        copyToClipboard(checksummedSenderAddress);
+        copyToClipboard(checksummedSenderAddress, COPY_OPTIONS);
         if (onSenderClick) {
           onSenderClick();
         }
@@ -130,7 +131,7 @@ export function RecipientWithAddress({
         onClick={() => {
           if (recipientIsOwnedAccount) {
             setAddressCopied(true);
-            copyToClipboard(checksummedRecipientAddress);
+            copyToClipboard(checksummedRecipientAddress, COPY_OPTIONS);
           } else {
             setShowNicknamePopovers(true);
             if (onRecipientClick) {

--- a/ui/hooks/useCopyToClipboard.js
+++ b/ui/hooks/useCopyToClipboard.js
@@ -1,6 +1,7 @@
 import { useState, useCallback } from 'react';
 import copyToClipboard from 'copy-to-clipboard';
 import { MINUTE } from '../../shared/constants/time';
+import { COPY_OPTIONS } from '../../shared/constants/copy';
 import { useTimeout } from './useTimeout';
 
 /**
@@ -15,7 +16,7 @@ export function useCopyToClipboard(delay = DEFAULT_DELAY) {
   const [copied, setCopied] = useState(false);
   const startTimeout = useTimeout(
     () => {
-      copyToClipboard(' ');
+      copyToClipboard(' ', COPY_OPTIONS);
       setCopied(false);
     },
     delay,
@@ -26,7 +27,7 @@ export function useCopyToClipboard(delay = DEFAULT_DELAY) {
     (text) => {
       setCopied(true);
       startTimeout();
-      copyToClipboard(text);
+      copyToClipboard(text, COPY_OPTIONS);
     },
     [startTimeout],
   );

--- a/ui/index.js
+++ b/ui/index.js
@@ -10,6 +10,7 @@ import { AlertTypes } from '../shared/constants/alerts';
 import { maskObject } from '../shared/modules/object.utils';
 import { SENTRY_UI_STATE } from '../app/scripts/lib/setupSentry';
 import { ENVIRONMENT_TYPE_POPUP } from '../shared/constants/app';
+import { COPY_OPTIONS } from '../shared/constants/copy';
 import switchDirection from '../shared/lib/switch-direction';
 import { setupLocale } from '../shared/lib/error-utils';
 import * as actions from './store/actions';
@@ -274,7 +275,7 @@ window.logState = function (toClipboard) {
     if (err) {
       console.error(err.message);
     } else if (toClipboard) {
-      copyToClipboard(result);
+      copyToClipboard(result, COPY_OPTIONS);
       console.log('State log copied');
     } else {
       console.log(result);

--- a/ui/pages/confirm-approve/confirm-approve-content/confirm-approve-content.component.js
+++ b/ui/pages/confirm-approve/confirm-approve-content/confirm-approve-content.component.js
@@ -41,6 +41,7 @@ import UserPreferencedCurrencyDisplay from '../../../components/app/user-prefere
 import { PRIMARY, SECONDARY } from '../../../helpers/constants/common';
 import { ConfirmGasDisplay } from '../../../components/app/confirm-gas-display';
 import CustomNonce from '../../../components/app/custom-nonce';
+import { COPY_OPTIONS } from '../../../../shared/constants/copy';
 
 export default class ConfirmApproveContent extends Component {
   static contextTypes = {
@@ -274,7 +275,7 @@ export default class ConfirmApproveContent extends Component {
           <div className="confirm-approve-content__medium-text">
             <ButtonIcon
               ariaLabel="copy"
-              onClick={() => copyToClipboard(toAddress)}
+              onClick={() => copyToClipboard(toAddress, COPY_OPTIONS)}
               color={IconColor.iconDefault}
               iconName={
                 this.state.copied ? IconName.CopySuccess : IconName.Copy
@@ -420,7 +421,7 @@ export default class ConfirmApproveContent extends Component {
         <span
           className="confirm-approve-content__approval-asset-title"
           onClick={() => {
-            copyToClipboard(tokenAddress);
+            copyToClipboard(tokenAddress, COPY_OPTIONS);
           }}
           title={tokenAddress}
         >

--- a/ui/pages/confirm-decrypt-message/confirm-decrypt-message.component.js
+++ b/ui/pages/confirm-decrypt-message/confirm-decrypt-message.component.js
@@ -17,6 +17,7 @@ import { Icon, IconName } from '../../components/component-library';
 import { IconColor } from '../../helpers/constants/design-system';
 import { formatCurrency } from '../../helpers/utils/confirm-tx.util';
 import { getValueFromWeiHex } from '../../../shared/modules/conversion.utils';
+import { COPY_OPTIONS } from '../../../shared/constants/copy';
 
 export default class ConfirmDecryptMessage extends Component {
   static contextTypes = {
@@ -50,7 +51,7 @@ export default class ConfirmDecryptMessage extends Component {
   };
 
   copyMessage = () => {
-    copyToClipboard(this.state.rawMessage);
+    copyToClipboard(this.state.rawMessage, COPY_OPTIONS);
     this.context.trackEvent({
       category: MetaMetricsEventCategory.Messages,
       event: 'Copy',


### PR DESCRIPTION
## **Description**
After doing some research, our usage of `copy-to-clipboard` uses the default options, one of which is `format` that defaults to `text/html`.  Since we only want the address copied, we should use the `text/plain` format.

## **Manual testing steps**

1.  Click any "copy to clipboard" button.
2. Ensure the output is plain text and not html

## **Related issues**

Fixes #21169 

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've clearly explained:
  - [ ] What problem this PR is solving.
  - [ ] How this problem was solved.
  - [ ] How reviewers can test my changes.
- [ ] I’ve indicated what issue this PR is linked to: Fixes #???
- [ ] I’ve included tests if applicable.
- [ ] I’ve documented any added code.
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)).
- [ ] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
