### PR TITLE
Fix: metrics details for toggling blockaid settings

### DIFF
--- a/shared/constants/metametrics.ts
+++ b/shared/constants/metametrics.ts
@@ -559,6 +559,7 @@ export enum MetaMetricsEventName {
   PublicAddressCopied = 'Public Address Copied',
   QuoteError = 'Quote Error',
   ServiceWorkerRestarted = 'Service Worker Restarted',
+  SettingsUpdated = 'Settings Updated',
   SignatureApproved = 'Signature Approved',
   SignatureFailed = 'Signature Failed',
   SignatureRejected = 'Signature Rejected',

--- a/ui/pages/settings/experimental-tab/experimental-tab.component.js
+++ b/ui/pages/settings/experimental-tab/experimental-tab.component.js
@@ -86,10 +86,9 @@ export default class ExperimentalTab extends PureComponent {
       this.props;
     this.context.trackEvent({
       category: MetaMetricsEventCategory.Settings,
-      event: 'Enabled/Disable security_alerts_enabled',
+      event: 'Settings Updated',
       properties: {
-        action: 'Enabled/Disable security_alerts_enabled',
-        legacy_event: true,
+        security_alerts_enabled: newValue,
       },
     });
     setSecurityAlertsEnabled(newValue);

--- a/ui/pages/settings/experimental-tab/experimental-tab.component.js
+++ b/ui/pages/settings/experimental-tab/experimental-tab.component.js
@@ -7,9 +7,7 @@ import {
 } from '../../../helpers/utils/settings-search';
 import {
   MetaMetricsEventCategory,
-  ///: BEGIN:ONLY_INCLUDE_IN(keyring-snaps)
   MetaMetricsEventName,
-  ///: END:ONLY_INCLUDE_IN
 } from '../../../../shared/constants/metametrics';
 ///: BEGIN:ONLY_INCLUDE_IN(build-main)
 import { showSnapAccountExperimentalToggle } from '../../../../shared/modules/snap-accounts';
@@ -86,7 +84,7 @@ export default class ExperimentalTab extends PureComponent {
       this.props;
     this.context.trackEvent({
       category: MetaMetricsEventCategory.Settings,
-      event: 'Settings Updated',
+      event: MetaMetricsEventName.SettingsUpdated,
       properties: {
         blockaid_alerts_enabled: newValue,
       },
@@ -109,7 +107,7 @@ export default class ExperimentalTab extends PureComponent {
       this.props;
     this.context.trackEvent({
       category: MetaMetricsEventCategory.Settings,
-      event: 'Settings Updated',
+      event: MetaMetricsEventName.SettingsUpdated,
       properties: {
         opensea_alerts_enabled: newValue,
       },

--- a/ui/pages/settings/experimental-tab/experimental-tab.component.js
+++ b/ui/pages/settings/experimental-tab/experimental-tab.component.js
@@ -88,7 +88,7 @@ export default class ExperimentalTab extends PureComponent {
       category: MetaMetricsEventCategory.Settings,
       event: 'Settings Updated',
       properties: {
-        security_alerts_enabled: newValue,
+        blockaid_alerts_enabled: newValue,
       },
     });
     setSecurityAlertsEnabled(newValue);
@@ -109,10 +109,9 @@ export default class ExperimentalTab extends PureComponent {
       this.props;
     this.context.trackEvent({
       category: MetaMetricsEventCategory.Settings,
-      event: 'Enabled/Disable TransactionSecurityCheck',
+      event: 'Settings Updated',
       properties: {
-        action: 'Enabled/Disable TransactionSecurityCheck',
-        legacy_event: true,
+        opensea_alerts_enabled: newValue,
       },
     });
     setTransactionSecurityCheckEnabled(newValue);


### PR DESCRIPTION
## **Description**
Fix the metrics event while enabling / disabling blockaid in settings page.

## **Manual testing steps**

_1. Enable / disable blockaid in settings -> experimental page
_2. Verify metrics generated in segment

## **Related issues**

_Fixes MetaMask/MetaMask-planning#1462

## **Pre-merge author checklist**

- [X] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've clearly explained:
  - [X] What problem this PR is solving.
  - [ ] How this problem was solved.
  - [X] How reviewers can test my changes.
- [X] I’ve indicated what issue this PR is linked to: Fixes #???
- [ ] I’ve included tests if applicable.
- [ ] I’ve documented any added code.
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)).
- [X] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [X] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
