### PR TITLE
Security provider metrics fix

### DIFF
--- a/app/scripts/controllers/metametrics.js
+++ b/app/scripts/controllers/metametrics.js
@@ -756,6 +756,13 @@ export default class MetaMetricsController {
         : null;
     ///: END:ONLY_INCLUDE_IN
     const { traits, previousUserTraits } = this.store.getState();
+    let securityProvider;
+    if (metamaskState.securityAlertsEnabled) {
+      securityProvider = 'blockaid';
+    }
+    if (metamaskState.transactionSecurityCheckEnabled) {
+      securityProvider = 'opensea';
+    }
     /** @type {MetaMetricsTraits} */
     const currentTraits = {
       [MetaMetricsUserTrait.AddressBookEntries]: sum(
@@ -799,8 +806,9 @@ export default class MetaMetricsController {
       [MetaMetricsUserTrait.MmiAccountAddress]: mmiAccountAddress,
       [MetaMetricsUserTrait.MmiIsCustodian]: Boolean(mmiAccountAddress),
       ///: END:ONLY_INCLUDE_IN
-      [MetaMetricsUserTrait.SecurityProviders]:
-        metamaskState.transactionSecurityCheckEnabled ? ['opensea'] : [],
+      [MetaMetricsUserTrait.SecurityProviders]: securityProvider
+        ? [securityProvider]
+        : [],
       ///: BEGIN:ONLY_INCLUDE_IN(petnames)
       [MetaMetricsUserTrait.PetnameAddressCount]:
         this._getPetnameAddressCount(metamaskState),

--- a/app/scripts/controllers/metametrics.test.js
+++ b/app/scripts/controllers/metametrics.test.js
@@ -1025,6 +1025,7 @@ describe('MetaMetricsController', function () {
         ledgerTransportType: 'web-hid',
         openSeaEnabled: true,
         useNftDetection: false,
+        securityAlertsEnabled: true,
         theme: 'default',
         useTokenDetection: true,
         desktopEnabled: false,
@@ -1083,7 +1084,7 @@ describe('MetaMetricsController', function () {
         [MetaMetricsUserTrait.Theme]: 'default',
         [MetaMetricsUserTrait.TokenDetectionEnabled]: true,
         [MetaMetricsUserTrait.DesktopEnabled]: false,
-        [MetaMetricsUserTrait.SecurityProviders]: [],
+        [MetaMetricsUserTrait.SecurityProviders]: ['blockaid'],
         ///: BEGIN:ONLY_INCLUDE_IN(build-mmi)
         [MetaMetricsUserTrait.MmiExtensionId]: 'testid',
         [MetaMetricsUserTrait.MmiAccountAddress]: null,


### PR DESCRIPTION
## **Description**
The PR fixes bug that user traits property `security_providers` should be set to `blockaid` if user has blockaid enabled.

## **Manual testing steps**

_1. Enable blockaid for user
_2. User identify event should have `security_providers` set to `blockaid`

## **Related issues**

_Fixes: MetaMask/MetaMask-planning#1459

## **Pre-merge author checklist**

- [X] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've clearly explained:
  - [X] What problem this PR is solving.
  - [ ] How this problem was solved.
  - [X] How reviewers can test my changes.
- [X] I’ve indicated what issue this PR is linked to: Fixes #???
- [X] I’ve included tests if applicable.
- [ ] I’ve documented any added code.
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)).
- [X] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [X] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
