### PR TITLE
Remove CODEOWNERS entry for Flask files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,7 +9,6 @@
 
 *                                    @MetaMask/extension-devs
 **/snaps/**                          @MetaMask/snaps-devs
-**/flask/**                          @MetaMask/extension-devs @MetaMask/snaps-devs
 development/                         @MetaMask/extension-devs @kumavis
 lavamoat/                            @MetaMask/extension-devs @MetaMask/supply-chain @MetaMask/snaps-devs
 


### PR DESCRIPTION
## **Description**

Since many teams are now building features in and shipping to Flask the snaps team does not need to be a specific CODEOWNER of the `**/flask/**` paths. By removing this line in the CODEOWNERS file, these files will be owned by `extension-devs` once again.