### PR TITLE
UX: Multichain: Send: AccountPicker Wiring

### DIFF
--- a/ui/components/multichain/account-list-menu/account-list-menu.js
+++ b/ui/components/multichain/account-list-menu/account-list-menu.js
@@ -37,7 +37,7 @@ import {
   getIsAddSnapAccountEnabled,
   ///: END:ONLY_INCLUDE_IN
 } from '../../../selectors';
-import { toggleAccountMenu, setSelectedAccount } from '../../../store/actions';
+import { setSelectedAccount } from '../../../store/actions';
 import {
   MetaMetricsEventAccountType,
   MetaMetricsEventCategory,
@@ -66,7 +66,11 @@ const ACTION_MODES = {
   IMPORT: 'import',
 };
 
-export const AccountListMenu = ({ onClose }) => {
+export const AccountListMenu = ({
+  onClose,
+  showAccountCreation = true,
+  accountListItemProps = {},
+}) => {
   const t = useI18nContext();
   const trackEvent = useContext(MetaMetricsContext);
   const accounts = useSelector(getMetaMaskAccountsOrdered);
@@ -132,7 +136,7 @@ export const AccountListMenu = ({ onClose }) => {
             <CreateAccount
               onActionComplete={(confirmed) => {
                 if (confirmed) {
-                  dispatch(toggleAccountMenu());
+                  onClose();
                 } else {
                   setActionMode(ACTION_MODES.LIST);
                 }
@@ -150,7 +154,7 @@ export const AccountListMenu = ({ onClose }) => {
             <ImportAccount
               onActionComplete={(confirmed) => {
                 if (confirmed) {
-                  dispatch(toggleAccountMenu());
+                  onClose();
                 } else {
                   setActionMode(ACTION_MODES.LIST);
                 }
@@ -205,7 +209,7 @@ export const AccountListMenu = ({ onClose }) => {
                 size={Size.SM}
                 startIconName={IconName.Hardware}
                 onClick={() => {
-                  dispatch(toggleAccountMenu());
+                  onClose();
                   trackEvent({
                     category: MetaMetricsEventCategory.Navigation,
                     event: MetaMetricsEventName.AccountAddSelected,
@@ -234,7 +238,7 @@ export const AccountListMenu = ({ onClose }) => {
                     size={Size.SM}
                     startIconName={IconName.Snaps}
                     onClick={() => {
-                      dispatch(toggleAccountMenu());
+                      onClose();
                       getEnvironmentType() === ENVIRONMENT_TYPE_POPUP
                         ? global.platform.openExtensionInBrowser(
                             ADD_SNAP_ACCOUNT_ROUTE,
@@ -257,7 +261,7 @@ export const AccountListMenu = ({ onClose }) => {
                   size={Size.SM}
                   startIconName={IconName.Custody}
                   onClick={() => {
-                    dispatch(toggleAccountMenu());
+                    onClose();
                     trackEvent({
                       category: MetaMetricsEventCategory.Navigation,
                       event:
@@ -323,7 +327,7 @@ export const AccountListMenu = ({ onClose }) => {
                 return (
                   <AccountListItem
                     onClick={() => {
-                      dispatch(toggleAccountMenu());
+                      onClose();
                       trackEvent({
                         category: MetaMetricsEventCategory.Navigation,
                         event: MetaMetricsEventName.NavAccountSwitched,
@@ -340,30 +344,33 @@ export const AccountListMenu = ({ onClose }) => {
                     connectedAvatar={connectedSite?.iconUrl}
                     connectedAvatarName={connectedSite?.name}
                     showOptions
+                    {...accountListItemProps}
                   />
                 );
               })}
             </Box>
             {/* Add / Import / Hardware button */}
-            <Box
-              paddingTop={2}
-              paddingBottom={4}
-              paddingLeft={4}
-              paddingRight={4}
-              alignItems={AlignItems.center}
-              display={Display.Flex}
-            >
-              <ButtonSecondary
-                startIconName={IconName.Add}
-                variant={ButtonVariant.Secondary}
-                size={ButtonSecondarySize.Lg}
-                block
-                onClick={() => setActionMode(ACTION_MODES.MENU)}
-                data-testid="multichain-account-menu-popover-action-button"
+            {showAccountCreation ? (
+              <Box
+                paddingTop={2}
+                paddingBottom={4}
+                paddingLeft={4}
+                paddingRight={4}
+                alignItems={AlignItems.center}
+                display={Display.Flex}
               >
-                {t('addImportAccount')}
-              </ButtonSecondary>
-            </Box>
+                <ButtonSecondary
+                  startIconName={IconName.Add}
+                  variant={ButtonVariant.Secondary}
+                  size={ButtonSecondarySize.Lg}
+                  block
+                  onClick={() => setActionMode(ACTION_MODES.MENU)}
+                  data-testid="multichain-account-menu-popover-action-button"
+                >
+                  {t('addImportAccount')}
+                </ButtonSecondary>
+              </Box>
+            ) : null}
           </>
         ) : null}
       </ModalContent>
@@ -376,4 +383,12 @@ AccountListMenu.propTypes = {
    * Function that executes when the menu closes
    */
   onClose: PropTypes.func.isRequired,
+  /**
+   * Represents if the button to create new accounts should display
+   */
+  showAccountCreation: PropTypes.bool,
+  /**
+   * Props to pass to the AccountListItem,
+   */
+  accountListItemProps: PropTypes.object,
 };

--- a/ui/components/multichain/account-list-menu/account-list-menu.test.js
+++ b/ui/components/multichain/account-list-menu/account-list-menu.test.js
@@ -14,13 +14,8 @@ import {
 import { AccountListMenu } from '.';
 
 ///: BEGIN:ONLY_INCLUDE_IN(keyring-snaps)
-const mockToggleAccountMenu = jest.fn();
+const mockOnClose = jest.fn();
 const mockGetEnvironmentType = jest.fn();
-
-jest.mock('../../../store/actions.ts', () => ({
-  ...jest.requireActual('../../../store/actions.ts'),
-  toggleAccountMenu: () => mockToggleAccountMenu,
-}));
 
 jest.mock('../../../../app/scripts/lib/util', () => ({
   ...jest.requireActual('../../../../app/scripts/lib/util'),
@@ -114,11 +109,7 @@ describe('AccountListMenu', () => {
         },
       },
     });
-    const props = { onClose: () => jest.fn() };
-    const { container } = renderWithProvider(
-      <AccountListMenu {...props} />,
-      mockStore,
-    );
+    const { container } = renderWithProvider(<AccountListMenu />, mockStore);
     const searchBox = container.querySelector('input[type=search]');
     expect(searchBox).not.toBeInTheDocument();
   });
@@ -202,7 +193,7 @@ describe('AccountListMenu', () => {
 
   ///: BEGIN:ONLY_INCLUDE_IN(keyring-snaps)
   describe('addSnapAccountButton', () => {
-    const renderWithState = (state, props = { onClose: () => jest.fn() }) => {
+    const renderWithState = (state, props = { onClose: mockOnClose }) => {
       const store = configureStore({
         ...mockState,
         ...{
@@ -246,7 +237,7 @@ describe('AccountListMenu', () => {
 
       fireEvent.click(addSnapAccountButton);
       await waitFor(() => {
-        expect(mockToggleAccountMenu).toHaveBeenCalled();
+        expect(mockOnClose).toHaveBeenCalled();
       });
     });
 

--- a/ui/components/multichain/pages/send/send.js
+++ b/ui/components/multichain/pages/send/send.js
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import React, { useContext, useState } from 'react';
 import { useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
 import { Content, Footer, Header, Page } from '../page';
@@ -28,7 +28,7 @@ import {
   getMetaMaskAccountsOrdered,
   getSelectedIdentity,
 } from '../../../../selectors';
-import { AccountPicker, AccountListItem } from '../..';
+import { AccountPicker, AccountListItem, AccountListMenu } from '../..';
 import DomainInput from '../../../../pages/send/send-content/add-recipient/domain-input.component';
 
 export const SendPage = () => {
@@ -39,6 +39,7 @@ export const SendPage = () => {
 
   // Account
   const identity = useSelector(getSelectedIdentity);
+  const [showAccountPicker, setShowAccountPicker] = useState(false);
 
   // Your Accounts
   const accounts = useSelector(getMetaMaskAccountsOrdered);
@@ -81,7 +82,7 @@ export const SendPage = () => {
           <AccountPicker
             address={identity.address}
             name={identity.name}
-            onClick={() => undefined}
+            onClick={() => setShowAccountPicker(true)}
             showAddress
             borderColor={BorderColor.borderDefault}
             borderWidth={1}
@@ -103,6 +104,13 @@ export const SendPage = () => {
             }}
             width={BlockSize.Full}
           />
+          {showAccountPicker ? (
+            <AccountListMenu
+              accountListItemProps={{ showOptions: false }}
+              showAccountCreation={false}
+              onClose={() => setShowAccountPicker(false)}
+            />
+          ) : null}
         </SendPageRow>
         <SendPageRow>
           <Label paddingBottom={2}>{t('to')}</Label>


### PR DESCRIPTION
## **Description**
Provides the wiring for the AccountPicker in the new send flow.

## **Manual testing steps**

1.  Enter new send flow
2. The AccountPicker should have the current network as its value
3. Click the AccountPicker to choose a new account
4. See selected account change

## **Screenshots/Recordings**
Coming soon

## **Related issues**

Fixes https://github.com/MetaMask/MetaMask-planning/issues/1446

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've clearly explained:
  - [ ] What problem this PR is solving.
  - [ ] How this problem was solved.
  - [ ] How reviewers can test my changes.
- [ ] I’ve indicated what issue this PR is linked to: Fixes #???
- [ ] I’ve included tests if applicable.
- [ ] I’ve documented any added code.
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)).
- [ ] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
