### PR TITLE
Await account render after unlock before checking for mocked endpoint…

### DIFF
--- a/test/e2e/metrics/unlock-wallet.spec.js
+++ b/test/e2e/metrics/unlock-wallet.spec.js
@@ -2,6 +2,7 @@ const { strict: assert } = require('assert');
 const {
   withFixtures,
   unlockWallet,
+  waitForAccountRendered,
   defaultGanacheOptions,
 } = require('../helpers');
 const FixtureBuilder = require('../fixture-builder');
@@ -35,6 +36,7 @@ describe('Unlock wallet', function () {
       async ({ driver, mockedEndpoint }) => {
         await driver.navigate();
         await unlockWallet(driver);
+        await waitForAccountRendered(driver);
         await driver.wait(async () => {
           const isPending = await mockedEndpoint.isPending();
           return isPending === false;


### PR DESCRIPTION
… resolution in unlock-wallet.spec.js

## **Description**

Fixes the flakiness of the `should send first three Page metric events upon fullscreen page load` test when run as part of the ` test-e2e-chrome-mmi ` job. While this seems to fix the issue, I don't have a 100% definite explanation. My hypothesis in making the change in this PR is that occasionaly on mmi builds the e2e tests would take longer to get past the unlock stage than expected, and so it is possible that not all metrics requests that the `unlock-wallet.spec.js` test is waiiting for have be made by the time the test starts looking for them.

Anecdotal evidence seems to suggest that this has worked, and that this test is passing.

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've clearly explained:
  - [ ] What problem this PR is solving.
  - [ ] How this problem was solved.
  - [ ] How reviewers can test my changes.
- [ ] I’ve indicated what issue this PR is linked to: Fixes #???
- [ ] I’ve included tests if applicable.
- [ ] I’ve documented any added code.
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)).
- [ ] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
