### PR TITLE
UX: Multichain: Send Flow: Wire Network Picker

### DIFF
--- a/ui/components/multichain/pages/send/__snapshots__/send.test.js.snap
+++ b/ui/components/multichain/pages/send/__snapshots__/send.test.js.snap
@@ -41,6 +41,7 @@ exports[`SendPage render renders correctly 1`] = `
       >
         <button
           class="mm-box mm-picker-network mm-box--padding-right-4 mm-box--padding-left-2 mm-box--display-flex mm-box--gap-2 mm-box--align-items-center mm-box--background-color-background-alternative mm-box--rounded-pill"
+          data-testid="send-page-network-picker"
         >
           <div
             class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-network mm-picker-network__avatar-network mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full mm-box--border-color-transparent box--border-style-solid box--border-width-1"

--- a/ui/components/multichain/pages/send/send.js
+++ b/ui/components/multichain/pages/send/send.js
@@ -1,5 +1,5 @@
 import React, { useContext } from 'react';
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
 import { Content, Footer, Header, Page } from '../page';
 import { I18nContext } from '../../../../contexts/i18n';
@@ -30,9 +30,11 @@ import {
 } from '../../../../selectors';
 import { AccountPicker, AccountListItem } from '../..';
 import DomainInput from '../../../../pages/send/send-content/add-recipient/domain-input.component';
+import { toggleNetworkMenu } from '../../../../store/actions';
 
 export const SendPage = () => {
   const t = useContext(I18nContext);
+  const dispatch = useDispatch();
 
   // Network
   const currentNetwork = useSelector(getCurrentNetwork);
@@ -74,6 +76,8 @@ export const SendPage = () => {
           <PickerNetwork
             label={currentNetwork?.nickname}
             src={currentNetwork?.rpcPrefs?.imageUrl}
+            onClick={() => dispatch(toggleNetworkMenu())}
+            data-testid="send-page-network-picker"
           />
         </SendPageRow>
         <SendPageRow>

--- a/ui/components/multichain/pages/send/send.test.js
+++ b/ui/components/multichain/pages/send/send.test.js
@@ -9,8 +9,13 @@ const store = configureStore(mockState);
 describe('SendPage', () => {
   describe('render', () => {
     it('renders correctly', () => {
-      const { container } = renderWithProvider(<SendPage />, store);
+      const { container, getByTestId } = renderWithProvider(
+        <SendPage />,
+        store,
+      );
       expect(container).toMatchSnapshot();
+
+      expect(getByTestId('send-page-network-picker')).toBeInTheDocument();
     });
   });
 });


### PR DESCRIPTION
## **Description**

Wires the `PickerNetwork` for the new send flow

## **Manual testing steps**

1. Enter the send flow
2. PickerNetwork starts with current network
3. Switch networks using PickerNetwork
4. See the new network represented in the send page

## **Screenshots/Recordings**

Coming soon.

## **Related issues**

Fixes https://github.com/MetaMask/MetaMask-planning/issues/1445

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've clearly explained:
  - [ ] What problem this PR is solving.
  - [ ] How this problem was solved.
  - [ ] How reviewers can test my changes.
- [ ] I’ve indicated what issue this PR is linked to: Fixes #???
- [ ] I’ve included tests if applicable.
- [ ] I’ve documented any added code.
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)).
- [ ] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
