### PR TITLE
Disable blockaid e2e until we resolve test flakiness

### DIFF
--- a/test/e2e/flask/ppom-blockaid-alert.spec.js
+++ b/test/e2e/flask/ppom-blockaid-alert.spec.js
@@ -30,7 +30,8 @@ async function mockInfura(mockServer) {
  *
  * @see {@link https://wobbly-nutmeg-8a5.notion.site/MM-E2E-Testing-1e51b617f79240a49cd3271565c6e12d}
  */
-describe('Confirmation Security Alert - Blockaid', function () {
+// eslint-disable-next-line mocha/no-skipped-tests
+describe.skip('Confirmation Security Alert - Blockaid', function () {
   it('should not show security alerts for benign requests', async function () {
     await withFixtures(
       {


### PR DESCRIPTION
This disables e2e tests that are very flaky. We can re-enable once the flakiness is resolved.