### PR TITLE
UX: Remove PickerNetwork active background color change when disabled

### DIFF
--- a/ui/components/component-library/picker-network/picker-network.scss
+++ b/ui/components/component-library/picker-network/picker-network.scss
@@ -3,7 +3,7 @@
 
   height: var(--picker-network-height);
 
-  &:active {
+  &:not([disabled]):active {
     background-color: var(--color-background-default-hover);
   }
 }


### PR DESCRIPTION
## **Description**
At present, when the user `mousedown`'s on the `PickerNetwork`, the background color changes via `:active`.  When the `PickerNetwork` is disabled, I believe we should remove this `:active` color change, since the network can't be changed.

## **Manual testing steps**

1.  Click the "Send" button
2. See the PickerNetwork disabled
3. Mouse down on the disabled PickerNetwork
4. See no backward change


## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've clearly explained:
  - [ ] What problem this PR is solving.
  - [ ] How this problem was solved.
  - [ ] How reviewers can test my changes.
- [ ] I’ve indicated what issue this PR is linked to: Fixes #???
- [ ] I’ve included tests if applicable.
- [ ] I’ve documented any added code.
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)).
- [ ] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
