### PR TITLE
Simplify notifications implementation

### DIFF
--- a/ui/components/app/connected-sites-list/connected-snaps.js
+++ b/ui/components/app/connected-sites-list/connected-snaps.js
@@ -7,7 +7,6 @@ import { SnapCaveatType } from '@metamask/rpc-methods';
 import { Box, IconName, IconSize, Text } from '../../component-library';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import { MenuItem } from '../../ui/menu';
-import { SNAPS_VIEW_ROUTE } from '../../../helpers/constants/routes';
 import SnapAvatar from '../snaps/snap-avatar';
 import {
   AlignItems,
@@ -23,6 +22,7 @@ import {
   getPermissionSubjects,
 } from '../../../selectors';
 import { removePermissionsFor, updateCaveat } from '../../../store/actions';
+import { getSnapRoute } from '../../../helpers/utils/util';
 
 export default function ConnectedSnaps({ connectedSubjects }) {
   const [showOptions, setShowOptions] = useState();
@@ -74,9 +74,7 @@ export default function ConnectedSnaps({ connectedSubjects }) {
         </MenuItem>
         <MenuItem
           iconName={IconName.Setting}
-          onClick={() =>
-            history.push(`${SNAPS_VIEW_ROUTE}/${encodeURIComponent(snapId)}`)
-          }
+          onClick={() => history.push(getSnapRoute(snapId))}
         >
           {t('snapsSettings')}
         </MenuItem>

--- a/ui/components/app/snaps/snap-content-footer/snap-content-footer.js
+++ b/ui/components/app/snaps/snap-content-footer/snap-content-footer.js
@@ -4,7 +4,6 @@ import PropTypes from 'prop-types';
 import { useHistory } from 'react-router-dom';
 
 import { useI18nContext } from '../../../../hooks/useI18nContext';
-import { SNAPS_VIEW_ROUTE } from '../../../../helpers/constants/routes';
 import {
   TextVariant,
   JustifyContent,
@@ -23,6 +22,7 @@ import {
   IconName,
   Text,
 } from '../../../component-library';
+import { getSnapRoute } from '../../../../helpers/utils/util';
 
 export default function SnapContentFooter({ snapName, snapId }) {
   const t = useI18nContext();
@@ -30,7 +30,7 @@ export default function SnapContentFooter({ snapName, snapId }) {
 
   const handleNameClick = (e) => {
     e.stopPropagation();
-    history.push(`${SNAPS_VIEW_ROUTE}/${encodeURIComponent(snapId)}`);
+    history.push(getSnapRoute(snapId));
   };
 
   return (

--- a/ui/helpers/utils/util.js
+++ b/ui/helpers/utils/util.js
@@ -37,6 +37,7 @@ import {
 // formatData :: ( date: <Unix Timestamp> ) -> String
 import { isEqualCaseInsensitive } from '../../../shared/modules/string-utils';
 import { hexToDecimal } from '../../../shared/modules/conversion.utils';
+import { SNAPS_VIEW_ROUTE } from '../constants/routes';
 
 export function formatDate(date, format = "M/d/y 'at' T") {
   if (!date) {
@@ -602,6 +603,10 @@ export const getSnapName = (snapId, subjectMetadata) => {
   }
 
   return subjectMetadata?.name ?? removeSnapIdPrefix(snapId);
+};
+
+export const getSnapRoute = (snapId) => {
+  return `${SNAPS_VIEW_ROUTE}/${encodeURIComponent(snapId)}`;
 };
 
 export const getDedupedSnaps = (request, permissions) => {

--- a/ui/pages/keyring-snaps/snap-account-detail-page/snap-account-detail-page.tsx
+++ b/ui/pages/keyring-snaps/snap-account-detail-page/snap-account-detail-page.tsx
@@ -17,13 +17,11 @@ import {
   TextColor,
   TextVariant,
 } from '../../../helpers/constants/design-system';
-import {
-  ADD_SNAP_ACCOUNT_ROUTE,
-  SNAPS_VIEW_ROUTE,
-} from '../../../helpers/constants/routes';
+import { ADD_SNAP_ACCOUNT_ROUTE } from '../../../helpers/constants/routes';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import { getSnapRegistry, getSnaps } from '../../../selectors';
 import { SnapDetails } from '../new-snap-account-page';
+import { getSnapRoute } from '../../../helpers/utils/util';
 import Detail from './detail';
 import { SnapDetailHeader } from './header';
 
@@ -147,13 +145,7 @@ export default function SnapAccountDetailPage() {
             <Box>
               <Button
                 variant={ButtonVariant.Link}
-                onClick={() =>
-                  history.push(
-                    `${SNAPS_VIEW_ROUTE}/${encodeURIComponent(
-                      currentSnap.snapId,
-                    )}`,
-                  )
-                }
+                onClick={() => history.push(getSnapRoute(currentSnap.snapId))}
               >
                 {t('snapDetailManageSnap')}
               </Button>

--- a/ui/pages/notifications/notification.test.js
+++ b/ui/pages/notifications/notification.test.js
@@ -19,27 +19,24 @@ describe('Notifications', () => {
         notifications: {
           test: {
             id: 'test',
-            origin: 'test',
+            origin: 'npm:@metamask/notifications-example-snap',
             createdDate: 1652967897732,
             readDate: null,
             message: 'foo',
           },
           test2: {
             id: 'test2',
-            origin: 'test',
+            origin: 'npm:@metamask/notifications-example-snap',
             createdDate: 1652967897732,
             readDate: null,
             message: 'bar',
           },
         },
-        snaps: {
-          test: {
-            enabled: true,
-            id: 'test',
-            manifest: {
-              proposedName: 'Notification Example Snap',
-              description: 'A notification example snap.',
-            },
+        subjectMetadata: {
+          'npm:@metamask/notifications-example-snap': {
+            name: 'Notifications Example Snap',
+            version: '1.2.3',
+            subjectType: 'snap',
           },
         },
       },
@@ -76,29 +73,37 @@ describe('Notifications', () => {
 });
 
 describe('NotificationItem', () => {
-  const render = (props) => renderWithProvider(<NotificationItem {...props} />);
+  const render = (params, props) => {
+    const store = configureStore({
+      ...params,
+    });
+
+    return renderWithProvider(<NotificationItem {...props} />, store);
+  };
+
   it('can render notification item', () => {
+    const mockStore = {
+      metamask: {
+        subjectMetadata: {
+          'npm:@metamask/notifications-example-snap': {
+            name: 'Notifications Example Snap',
+            version: '1.2.3',
+            subjectType: 'snap',
+          },
+        },
+      },
+    };
     const props = {
       notification: {
         id: 'test',
-        origin: 'test',
+        origin: 'npm:@metamask/notifications-example-snap',
         createdDate: 1652967897732,
         readDate: null,
         message: 'Hello, http://localhost:8086!',
       },
-      snaps: [
-        {
-          id: 'test',
-          tabMessage: () => 'test snap name',
-          descriptionMessage: () => 'test description',
-          sectionMessage: () => 'test section Message',
-          route: '/test',
-          icon: 'test',
-        },
-      ],
       onItemClick: jest.fn(),
     };
-    const { getByText } = render(props);
+    const { getByText } = render(mockStore, props);
 
     expect(getByText(props.notification.message)).toBeDefined();
   });

--- a/ui/pages/notifications/notifications.js
+++ b/ui/pages/notifications/notifications.js
@@ -3,10 +3,14 @@ import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { useDispatch, useSelector } from 'react-redux';
 import { useHistory } from 'react-router-dom';
-import { formatDate } from '../../helpers/utils/util';
+import {
+  formatDate,
+  getSnapName,
+  getSnapRoute,
+} from '../../helpers/utils/util';
 import {
   getNotifications,
-  getSnapsRouteObjects,
+  getTargetSubjectMetadata,
   getUnreadNotifications,
 } from '../../selectors';
 import { DEFAULT_ROUTE } from '../../helpers/constants/routes';
@@ -23,18 +27,19 @@ import {
 } from '../../components/component-library';
 import { Color } from '../../helpers/constants/design-system';
 
-export function NotificationItem({ notification, snaps, onItemClick }) {
+export function NotificationItem({ notification, onItemClick }) {
   const { message, origin, createdDate, readDate } = notification;
   const history = useHistory();
   const t = useI18nContext();
+  const targetSubjectMetadata = useSelector((state) =>
+    getTargetSubjectMetadata(state, origin),
+  );
 
-  const snap = snaps.find(({ id: snapId }) => {
-    return snapId === origin;
-  });
+  const snapName = getSnapName(origin, targetSubjectMetadata);
 
   const handleNameClick = (e) => {
     e.stopPropagation();
-    history.push(snap.route);
+    history.push(getSnapRoute(origin));
   };
 
   const handleItemClick = () => onItemClick(notification);
@@ -53,7 +58,7 @@ export function NotificationItem({ notification, snaps, onItemClick }) {
           {t('notificationsInfos', [
             formatDate(createdDate, "LLLL d',' yyyy 'at' t"),
             <Button type="inline" onClick={handleNameClick} key="button">
-              {snap.tabMessage()}
+              {snapName}
             </Button>,
           ])}
         </p>
@@ -67,7 +72,6 @@ export default function Notifications() {
   const dispatch = useDispatch();
   const t = useI18nContext();
   const notifications = useSelector(getNotifications);
-  const snapsRouteObject = useSelector(getSnapsRouteObjects);
   const unreadNotifications = useSelector(getUnreadNotifications);
 
   const markAllAsRead = () => {
@@ -119,7 +123,6 @@ export default function Notifications() {
           notifications.map((notification, id) => (
             <NotificationItem
               notification={notification}
-              snaps={snapsRouteObject}
               key={id}
               onItemClick={markAsRead}
             />
@@ -142,6 +145,5 @@ NotificationItem.propTypes = {
     createdDate: PropTypes.number.isRequired,
     readDate: PropTypes.number,
   }),
-  snaps: PropTypes.array.isRequired,
   onItemClick: PropTypes.func.isRequired,
 };

--- a/ui/pages/snaps/snaps-list/snap-list.js
+++ b/ui/pages/snaps/snaps-list/snap-list.js
@@ -17,10 +17,7 @@ import {
   TextVariant,
   BackgroundColor,
 } from '../../../helpers/constants/design-system';
-import {
-  DEFAULT_ROUTE,
-  SNAPS_VIEW_ROUTE,
-} from '../../../helpers/constants/routes';
+import { DEFAULT_ROUTE } from '../../../helpers/constants/routes';
 import { getSnapsList } from '../../../selectors';
 import { handleSettingsRefs } from '../../../helpers/utils/settings-search';
 import {
@@ -39,13 +36,14 @@ import {
   Header,
   Page,
 } from '../../../components/multichain/pages/page';
+import { getSnapRoute } from '../../../helpers/utils/util';
 
 const SnapList = () => {
   const t = useI18nContext();
   const history = useHistory();
   const settingsRef = useRef();
   const onClick = (snap) => {
-    history.push(`${SNAPS_VIEW_ROUTE}/${encodeURIComponent(snap.id)}`);
+    history.push(getSnapRoute(snap.id));
   };
 
   useEffect(() => {

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -101,7 +101,6 @@ import {
 } from './transactions';
 ///: BEGIN:ONLY_INCLUDE_IN(snaps)
 // eslint-disable-next-line import/order
-import { SNAPS_VIEW_ROUTE } from '../helpers/constants/routes';
 import { getPermissionSubjects } from './permissions';
 ///: END:ONLY_INCLUDE_IN
 import { createDeepEqualSelector } from './util';

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -965,19 +965,6 @@ export const getNotifySnaps = createDeepEqualSelector(
   },
 );
 
-export const getSnapsRouteObjects = createSelector(getSnaps, (snaps) => {
-  return Object.values(snaps).map((snap) => {
-    return {
-      id: snap.id,
-      tabMessage: () => snap.manifest.proposedName,
-      descriptionMessage: () => snap.manifest.description,
-      sectionMessage: () => snap.manifest.description,
-      route: `${SNAPS_VIEW_ROUTE}/${encodeURIComponent(snap.id)}`,
-      icon: 'fa fa-flask',
-    };
-  });
-});
-
 /**
  * @typedef {object} Notification
  * @property {string} id - A unique identifier for the notification


### PR DESCRIPTION
## **Description**

- Removes `getSnapsRouteObjects` and uses `getSnapName` instead
- Replaces duplicated code for generating the route to a specific snap with a utility function

This should not need any additional QA.