### PR TITLE
Fix/issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -26,10 +26,10 @@ body:
      label: Expected behavior
      description: What did you expect to happen?
  - type: textarea
-   id: screenshot
+   id: screenshot-recording
    attributes:
-     label: Screenshots
-     description: Please include screenshots if applicable!
+     label: Screenshots/Recordings
+     description: Please include screenshots/recordings if applicable! (https://recordit.co/ is recommended)
  - type: textarea
    id: reproduce
    attributes:

--- a/.github/scripts/check-issue-template-and-add-labels.ts
+++ b/.github/scripts/check-issue-template-and-add-labels.ts
@@ -36,7 +36,7 @@ const generalIssueTemplateTitles = [
 const bugReportTemplateTitles = [
   '### Describe the bug',
   '### Expected behavior',
-  '### Screenshots',
+  '### Screenshots/Recordings',
   '### Steps to reproduce',
   '### Error messages or log output',
   '### Version',

--- a/.github/scripts/check-issue-template-and-add-labels.ts
+++ b/.github/scripts/check-issue-template-and-add-labels.ts
@@ -55,7 +55,7 @@ const externalContributorLabelDescription = `Issue or PR created by user outside
 
 // Craft invalid issue template label
 const invalidIssueTemplateLabelName = `INVALID-ISSUE-TEMPLATE`;
-const invalidIssueTemplateLabelColor = 'B60205'; // red
+const invalidIssueTemplateLabelColor = 'EDEDED'; // grey
 const invalidIssueTemplateLabelDescription = `Issue's body doesn't match any issue template.`;
 
 main().catch((error: Error): void => {


### PR DESCRIPTION
## **Description**
Tiny update in the issue template to encourage the use or recordings rather than screenshots.
Other tiny update to make invalid template label less agressive (color turned from red to grey).

## **Manual testing steps**

- Create a new issue on this [test repo](https://github.com/gauthierpetetin-test/repo_test/issues/new?assignees=&labels=type-bug&projects=&template=bug-report-extension.yml&title=%5BBug%5D%3A+).
- The created issue shall include a section called "Screenshots/Recordings".
- Edit the issue by removing a section from the template.
- A grey invalid template label shall appear on the issue after ~30s.

## **Screenshots/Recordings**

NA

### **Before**

NA

### **After**

NA

## **Related issues**

NA

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained:
  - [x] What problem this PR is solving.
  - [x] How this problem was solved.
  - [x] How reviewers can test my changes.
- [ ] I’ve indicated what issue this PR is linked to: Fixes #???
- [ ] I’ve included tests if applicable.
- [ ] I’ve documented any added code.
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)).
- [x] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [x] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
