### PR TITLE
Use a translation for Linea

### DIFF
--- a/ui/pages/swaps/prepare-swap-page/review-quote.js
+++ b/ui/pages/swaps/prepare-swap-page/review-quote.js
@@ -269,6 +269,8 @@ export default function ReviewQuote({ setReceiveToAmount }) {
         return t('networkNameArbitrum');
       case CHAIN_IDS.ZKSYNC_ERA:
         return t('networkNameZkSyncEra');
+      case CHAIN_IDS.LINEA_MAINNET:
+        return t('networkNameLinea');
       default:
         throw new Error('This network is not supported for token swaps');
     }


### PR DESCRIPTION
## **Description**

Adds a missing translation usage for Linea.

## Manual Testing Steps
1. Run the extension locally via this command: `SWAPS_USE_DEV_APIS=1 yarn start`
1. Check Swaps


