### PR TITLE
UX: Multichain: Send Flow: Add setup and cleanup hooks

### DIFF
--- a/ui/components/multichain/pages/send/components/account-picker.js
+++ b/ui/components/multichain/pages/send/components/account-picker.js
@@ -1,0 +1,50 @@
+import React, { useContext } from 'react';
+import { useSelector } from 'react-redux';
+import { getSelectedIdentity } from '../../../../../selectors';
+import { Label } from '../../../../component-library';
+import { AccountPicker } from '../../../account-picker';
+import {
+  BlockSize,
+  BorderColor,
+  Display,
+  JustifyContent,
+  TextAlign,
+} from '../../../../../helpers/constants/design-system';
+import { I18nContext } from '../../../../../contexts/i18n';
+import { SendPageRow } from '.';
+
+export const SendPageAccountPicker = () => {
+  const t = useContext(I18nContext);
+  const identity = useSelector(getSelectedIdentity);
+
+  return (
+    <SendPageRow>
+      <Label paddingBottom={2}>{t('from')}</Label>
+      <AccountPicker
+        address={identity.address}
+        name={identity.name}
+        onClick={() => undefined}
+        showAddress
+        borderColor={BorderColor.borderDefault}
+        borderWidth={1}
+        paddingTop={4}
+        paddingBottom={4}
+        block
+        justifyContent={JustifyContent.flexStart}
+        addressProps={{
+          display: Display.Flex,
+          textAlign: TextAlign.Start,
+        }}
+        labelProps={{
+          style: { flexGrow: 1, textAlign: 'start' },
+          paddingInlineStart: 2,
+        }}
+        textProps={{
+          display: Display.Flex,
+          width: BlockSize.Full,
+        }}
+        width={BlockSize.Full}
+      />
+    </SendPageRow>
+  );
+};

--- a/ui/components/multichain/pages/send/components/index.js
+++ b/ui/components/multichain/pages/send/components/index.js
@@ -1,0 +1,4 @@
+export { SendPageRow } from './send-page-row';
+export { SendPageAccountPicker } from './account-picker';
+export { SendPageNetworkPicker } from './network-picker';
+export { SendPageYourAccount } from './your-accounts';

--- a/ui/components/multichain/pages/send/components/network-picker.js
+++ b/ui/components/multichain/pages/send/components/network-picker.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import { useSelector } from 'react-redux';
+import { getCurrentNetwork } from '../../../../../selectors';
+import { PickerNetwork } from '../../../../component-library';
+import { SendPageRow } from '.';
+
+export const SendPageNetworkPicker = () => {
+  const currentNetwork = useSelector(getCurrentNetwork);
+
+  return (
+    <SendPageRow>
+      <PickerNetwork
+        label={currentNetwork?.nickname}
+        src={currentNetwork?.rpcPrefs?.imageUrl}
+      />
+    </SendPageRow>
+  );
+};

--- a/ui/components/multichain/pages/send/components/send-page-row.js
+++ b/ui/components/multichain/pages/send/components/send-page-row.js
@@ -1,0 +1,25 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Box } from '../../../../component-library';
+import {
+  Display,
+  FlexDirection,
+} from '../../../../../helpers/constants/design-system';
+
+export const SendPageRow = ({ children }) => (
+  <Box
+    display={Display.Flex}
+    paddingBottom={6}
+    flexDirection={FlexDirection.Column}
+  >
+    {children}
+  </Box>
+);
+
+SendPageRow.propTypes = {
+  children: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.node),
+    PropTypes.node,
+    PropTypes.string,
+  ]).isRequired,
+};

--- a/ui/components/multichain/pages/send/components/your-accounts.js
+++ b/ui/components/multichain/pages/send/components/your-accounts.js
@@ -1,0 +1,27 @@
+import React, { useContext } from 'react';
+import { useSelector } from 'react-redux';
+import { Label } from '../../../../component-library';
+import { getMetaMaskAccountsOrdered } from '../../../../../selectors';
+import { AccountListItem } from '../../..';
+import { I18nContext } from '../../../../../contexts/i18n';
+import { SendPageRow } from '.';
+
+export const SendPageYourAccount = () => {
+  const t = useContext(I18nContext);
+
+  // Your Accounts
+  const accounts = useSelector(getMetaMaskAccountsOrdered);
+
+  return (
+    <SendPageRow>
+      <Label paddingBottom={2}>{t('yourAccounts')}</Label>
+      {accounts.map((account) => (
+        <AccountListItem
+          identity={account}
+          key={account.address}
+          onClick={() => undefined}
+        />
+      ))}
+    </SendPageRow>
+  );
+};

--- a/ui/components/multichain/pages/send/send.js
+++ b/ui/components/multichain/pages/send/send.js
@@ -1,5 +1,6 @@
-import React, { useContext } from 'react';
-import { Content, Footer, Header, Page } from '../page';
+import React, { useCallback, useContext, useEffect, useRef } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { useLocation } from 'react-router-dom';
 import { I18nContext } from '../../../../contexts/i18n';
 import {
   ButtonIcon,
@@ -11,16 +12,72 @@ import {
   IconName,
   Label,
 } from '../../../component-library';
+import { Content, Footer, Header, Page } from '../page';
 import DomainInput from '../../../../pages/send/send-content/add-recipient/domain-input.component';
-import { SendPageNetworkPicker } from './components/network-picker';
+import {
+  getDraftTransactionExists,
+  resetSendState,
+  startNewDraftTransaction,
+} from '../../../../ducks/send';
+import { AssetType } from '../../../../../shared/constants/transaction';
+import { showQrScanner } from '../../../../store/actions';
 import {
   SendPageAccountPicker,
   SendPageRow,
   SendPageYourAccount,
+  SendPageNetworkPicker,
 } from './components';
 
 export const SendPage = () => {
   const t = useContext(I18nContext);
+  const dispatch = useDispatch();
+
+  const startedNewDraftTransaction = useRef(false);
+  const draftTransactionExists = useSelector(getDraftTransactionExists);
+  const location = useLocation();
+
+  const cleanup = useCallback(() => {
+    dispatch(resetSendState());
+  }, [dispatch]);
+
+  /**
+   * It is possible to route to this page directly, either by typing in the url
+   * or by clicking the browser back button after progressing to the confirm
+   * screen. In the case where a draft transaction does not yet exist, this
+   * hook is responsible for creating it. We will assume that this is a native
+   * asset send.
+   */
+  useEffect(() => {
+    if (
+      draftTransactionExists === false &&
+      startedNewDraftTransaction.current === false
+    ) {
+      startedNewDraftTransaction.current = true;
+      dispatch(startNewDraftTransaction({ type: AssetType.native }));
+    }
+  }, [draftTransactionExists, dispatch]);
+
+  useEffect(() => {
+    window.addEventListener('beforeunload', cleanup);
+  }, [cleanup]);
+
+  useEffect(() => {
+    if (location.search === '?scan=true') {
+      dispatch(showQrScanner());
+
+      // Clear the queryString param after showing the modal
+      const [cleanUrl] = window.location.href.split('?');
+      window.history.pushState({}, null, `${cleanUrl}`);
+      window.location.hash = '#send';
+    }
+  }, [location, dispatch]);
+
+  useEffect(() => {
+    return () => {
+      dispatch(resetSendState());
+      window.removeEventListener('beforeunload', cleanup);
+    };
+  }, [dispatch, cleanup]);
 
   return (
     <Page className="multichain-send-page">


### PR DESCRIPTION
## **Description**
This mimics the current setup and cleanup work on the Send page, including:

1.  Creating the draft transaction
2. Resetting send state when the send page is left
3. Shows the QR scanner as necessary

## **Manual testing steps**

No manual testing here as it relies on the UI to be truly tested

## **Related issues**

_Fixes #???_

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've clearly explained:
  - [ ] What problem this PR is solving.
  - [ ] How this problem was solved.
  - [ ] How reviewers can test my changes.
- [ ] I’ve indicated what issue this PR is linked to: Fixes #???
- [ ] I’ve included tests if applicable.
- [ ] I’ve documented any added code.
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)).
- [ ] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
