### PR TITLE
fix: ERC20 Custom Token shows incorrect icon

### DIFF
--- a/ui/components/app/token-cell/token-cell.js
+++ b/ui/components/app/token-cell/token-cell.js
@@ -4,11 +4,13 @@ import { useSelector } from 'react-redux';
 import { getTokenList } from '../../../selectors';
 import { useTokenFiatAmount } from '../../../hooks/useTokenFiatAmount';
 import { TokenListItem } from '../../multichain';
+import { isEqualCaseInsensitive } from '../../../../shared/modules/string-utils';
 
 export default function TokenCell({ address, image, symbol, string, onClick }) {
   const tokenList = useSelector(getTokenList);
   const tokenData = Object.values(tokenList).find(
-    (token) => token.symbol === symbol && token.address === address,
+    (token) =>
+      token.symbol === symbol && isEqualCaseInsensitive(token.address, address),
   );
   const title = tokenData?.name || symbol;
   const tokenImage = tokenData?.iconUrl || image;

--- a/ui/components/app/token-cell/token-cell.test.js
+++ b/ui/components/app/token-cell/token-cell.test.js
@@ -56,7 +56,7 @@ describe('Token Cell', () => {
       erc20: true,
       symbol: 'TEST',
       decimals: 18,
-      address: '0xAnotherToken',
+      address: '0xANoTherToKen',
       iconUrl: './images/test_image.svg',
       aggregators: [],
     },


### PR DESCRIPTION
## **Description**
In custom token section, by inputing token address it showed the correct token icon but after clicking on import and land on main wallet screen, token icon is not displayed.

the problem comes from the fact that filter is case sensitive.
the solution is to add the case insensitive check

## **Manual testing steps**

1 - choose the develop branch and import SAND token.
2 - After importing you will see that the icon is not displayed

## **Screenshots/Recordings**


### **Before**

<img width="1422" alt="Screenshot 2023-10-24 at 01 29 38" src="https://github.com/MetaMask/metamask-extension/assets/26223211/83e75a95-6387-42f1-b7be-21bd4d61a094">


### **After**

<img width="1227" alt="Screenshot 2023-10-24 at 01 30 30" src="https://github.com/MetaMask/metamask-extension/assets/26223211/d531eede-56cd-4114-a950-ff48b284d111">


## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained:
  - [x] What problem this PR is solving.
  - [x] How this problem was solved.
  - [x] How reviewers can test my changes.
- [ ] I’ve indicated what issue this PR is linked to: Fixes #???
- [x] I’ve included tests if applicable.
- [x] I’ve documented any added code.
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)).
- [x] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [x] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
