### PR TITLE
Remove derived `targetSubjectMetadata` from state and use props

### DIFF
--- a/ui/pages/permissions-connect/permissions-connect.component.js
+++ b/ui/pages/permissions-connect/permissions-connect.component.js
@@ -164,19 +164,6 @@ export default class PermissionConnect extends Component {
     }
   }
 
-  static getDerivedStateFromProps(props, state) {
-    const { permissionsRequest, targetSubjectMetadata } = props;
-    const { targetSubjectMetadata: savedMetadata } = state;
-
-    if (
-      permissionsRequest &&
-      savedMetadata.origin !== targetSubjectMetadata?.origin
-    ) {
-      return { targetSubjectMetadata };
-    }
-    return null;
-  }
-
   componentDidUpdate(prevProps) {
     const { permissionsRequest, lastConnectedInfo } = this.props;
     const { redirecting, origin } = this.state;
@@ -353,13 +340,13 @@ export default class PermissionConnect extends Component {
       approvePendingApproval,
       rejectPendingApproval,
       setSnapsInstallPrivacyWarningShownStatus,
+      targetSubjectMetadata,
       ///: END:ONLY_INCLUDE_IN
     } = this.props;
     const {
       selectedAccountAddresses,
       permissionsApproved,
       redirecting,
-      targetSubjectMetadata,
       ///: BEGIN:ONLY_INCLUDE_IN(snaps)
       snapsInstallPrivacyWarningShown,
       ///: END:ONLY_INCLUDE_IN

--- a/ui/pages/permissions-connect/permissions-connect.component.js
+++ b/ui/pages/permissions-connect/permissions-connect.component.js
@@ -331,6 +331,7 @@ export default class PermissionConnect extends Component {
       connectPath,
       confirmPermissionPath,
       hideTopBar,
+      targetSubjectMetadata,
       ///: BEGIN:ONLY_INCLUDE_IN(snaps)
       snapsConnectPath,
       snapInstallPath,
@@ -340,7 +341,6 @@ export default class PermissionConnect extends Component {
       approvePendingApproval,
       rejectPendingApproval,
       setSnapsInstallPrivacyWarningShownStatus,
-      targetSubjectMetadata,
       ///: END:ONLY_INCLUDE_IN
     } = this.props;
     const {


### PR DESCRIPTION
## **Description**

This updates the `permissions-connect.component.js` component logic, removing the derived state that was introduced long ago. This old logic was outdated when we introduced the selector `getTargetSubjectMetadata` and was causing `targetSubjectMetadata` to be `null` rathen than passed to the child component.

## **Related issues**

Fixes: #21534

## **Manual testing steps**

1. Try to install a Snap
2. Verify that on the install screen you can see the snap name

## **Screenshots/Recordings**

### **Before**

![image](https://github.com/MetaMask/metamask-extension/assets/13910212/a29b9f70-7aa3-47e4-aa86-6e029097a913)

### **After**

![image](https://github.com/MetaMask/metamask-extension/assets/13910212/c313d342-1a7e-4e26-9268-aa88e8e4e981)