### PR TITLE
UX: Fix alignment of legacy connect text

### DIFF
--- a/ui/components/app/alerts/unconnected-account-alert/unconnected-account-alert.js
+++ b/ui/components/app/alerts/unconnected-account-alert/unconnected-account-alert.js
@@ -22,7 +22,7 @@ import Checkbox from '../../../ui/check-box';
 import Tooltip from '../../../ui/tooltip';
 import ConnectedAccountsList from '../../connected-accounts-list';
 import { useI18nContext } from '../../../../hooks/useI18nContext';
-import { Box, Icon, IconName } from '../../../component-library';
+import { Icon, IconName, Text } from '../../../component-library';
 
 const { ERROR, LOADING } = ALERT_STATE;
 
@@ -63,7 +63,7 @@ const UnconnectedAccountAlert = () => {
             className="unconnected-account-alert__checkbox-label"
             htmlFor="unconnectedAccount_dontShowThisAgain"
           >
-            <Box>{t('dontShowThisAgain')}</Box>
+            <Text>{t('dontShowThisAgain')}</Text>
             <Tooltip
               position="top"
               title={t('alertDisableTooltip')}

--- a/ui/components/app/alerts/unconnected-account-alert/unconnected-account-alert.js
+++ b/ui/components/app/alerts/unconnected-account-alert/unconnected-account-alert.js
@@ -22,7 +22,7 @@ import Checkbox from '../../../ui/check-box';
 import Tooltip from '../../../ui/tooltip';
 import ConnectedAccountsList from '../../connected-accounts-list';
 import { useI18nContext } from '../../../../hooks/useI18nContext';
-import { Icon, IconName } from '../../../component-library';
+import { Box, Icon, IconName } from '../../../component-library';
 
 const { ERROR, LOADING } = ALERT_STATE;
 
@@ -63,7 +63,7 @@ const UnconnectedAccountAlert = () => {
             className="unconnected-account-alert__checkbox-label"
             htmlFor="unconnectedAccount_dontShowThisAgain"
           >
-            {t('dontShowThisAgain')}
+            <Box>{t('dontShowThisAgain')}</Box>
             <Tooltip
               position="top"
               title={t('alertDisableTooltip')}

--- a/ui/components/app/alerts/unconnected-account-alert/unconnected-account-alert.scss
+++ b/ui/components/app/alerts/unconnected-account-alert/unconnected-account-alert.scss
@@ -43,7 +43,7 @@
 
   &__checkbox {
     margin-right: 8px;
-    padding-top: 1px; // better alignment with rest of content
+    margin-top: -2px;
   }
 
   &__checkbox-label {
@@ -53,6 +53,7 @@
     margin-top: auto;
     margin-bottom: auto;
     color: var(--color-text-alternative);
+    align-items: center;
   }
 
   &__checkbox-label-tooltip {


### PR DESCRIPTION
## **Description**

While on a call today, Erik Marks pointed out that the checkbox label text for connecting to another account was misaligned.  This PR fixes said issue.  As we're presently working on the new Connections UI, this shim seems reasonable.


## **Manual testing steps**

1. Go to Uniswap
2. Connect with account 1
3. Switch to account 2
4. See the modal asking the user if they want to connect this new account
5. See the properly aligned text

## **Screenshots/Recordings**

### **Before**

![image](https://github.com/MetaMask/metamask-extension/assets/46655/2cc6aa48-7c1b-4657-83f5-9b130b6fb8bc)


### **After**

<img width="563" alt="SCR-20231025-scga" src="https://github.com/MetaMask/metamask-extension/assets/46655/7fce379f-0b0a-47c9-ae25-d9116ed8bc56">


## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've clearly explained what problem this PR is solving and how it is solved.
- [ ] I've linked related issues
- [ ] I've included manual testing steps
- [ ] I've included screenshots/recordings if applicable
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)).
- [ ] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
