### PR TITLE
Rewrite logic which checks creates noTxHashError in MMI code fence

### DIFF
--- a/app/scripts/controllers/transactions/pending-tx-tracker.js
+++ b/app/scripts/controllers/transactions/pending-tx-tracker.js
@@ -194,8 +194,11 @@ export default class PendingTransactionTracker extends EventEmitter {
     let hasNoHash = !txHash;
 
     ///: BEGIN:ONLY_INCLUDE_IN(build-mmi)
-    // Don't emit noTxHashErr for custodian transactions
-    hasNoHash ||= !txMeta.custodyId;
+    // Some custodian transactions don't have a hash by the time they are
+    // marked as pending, so don't emit a noTxHash error for them
+
+    hasNoHash = hasNoHash && !txMeta.custodyId;
+
     ///: END:ONLY_INCLUDE_IN
 
     if (hasNoHash) {


### PR DESCRIPTION
## **Description**

Non-custodial transactions are broken in MMI because the logic used to manage `noTxHashError` is faulty. Previously, it would always set noTxHash to true if the transaction was non-custodial.

## **Related issues**

Fixes: Jira ticket MMI-4063

## **Manual testing steps**

1. Use an MMI build type
2. Send a transaction with a HD or hardware wallet.


### **Before**

![image](https://github.com/MetaMask/metamask-extension/assets/1504499/2b8b40db-63f4-42ad-89b2-93faf039b3c1)


### **After**

<img width="369" alt="image" src="https://github.com/MetaMask/metamask-extension/assets/1504499/ac88dbf5-0f33-4327-acee-53c23db3ab80">

## **Pre-merge author checklist**

- [X] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've clearly explained what problem this PR is solving and how it is solved.
- [X] I've linked related issues
- [X] I've included manual testing steps
- [X] I've included screenshots/recordings if applicable
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)).
- [X] I’ve properly set the pull request status:
  - [X] In case it's not yet "ready for review", I've set it to "draft".
  - [X] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [X] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [X] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
