### PR TITLE
ci(chore): make multichain tests non required

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -252,7 +252,6 @@ workflows:
             - test-mozilla-lint-desktop
             - test-mozilla-lint-flask
             - test-e2e-chrome
-            - test-e2e-chrome-multichain
             - test-e2e-firefox
             - test-e2e-chrome-flask
             - test-e2e-firefox-flask
@@ -842,7 +841,7 @@ jobs:
 
   test-e2e-chrome-multichain:
     executor: node-browsers
-    parallelism: 8
+    parallelism: 12
     steps:
       - run: *shallow-git-clone
       - run:
@@ -871,7 +870,7 @@ jobs:
           path: test/test-results/e2e
   test-e2e-chrome-mv3:
     executor: node-browsers
-    parallelism: 8
+    parallelism: 12
     steps:
       - run: *shallow-git-clone
       - run:


### PR DESCRIPTION
## **Description**
1. Removes multichain e2e tests from the requirements for all-tests-pass
2. Ups the parallelism of anywhere where all main tests are ran to 12.

## **Related issues**


## **Manual testing steps**

1. See that develop currently has lots of failing prs into it due to the accounts snaps test failing on multinetwork.
2. See that this branch no longer has that issue. 

## **Screenshots/Recordings**
N/A
### **Before**
N/A
### **After**
N/A
## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained what problem this PR is solving and how it is solved.
- [ ] I've linked related issues
- [x] I've included manual testing steps
- [x] I've included screenshots/recordings if applicable
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [ ] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
