### PR TITLE
fix: fix import address with non checksum Adr

### DIFF
--- a/ui/helpers/utils/util.js
+++ b/ui/helpers/utils/util.js
@@ -689,12 +689,13 @@ export const checkTokenIdExists = (address, tokenId, obj) => {
     // Convert to decimal
     convertedTokenId = hexToDecimal(tokenId);
   }
-
-  if (obj[address]) {
-    const value = obj[address];
+  // Convert the input address to checksum address
+  const checkSumAdr = toChecksumHexAddress(address);
+  if (obj[checkSumAdr]) {
+    const value = obj[checkSumAdr];
     return lodash.some(value.nfts, (nft) => {
       return (
-        nft.address === address &&
+        nft.address === checkSumAdr &&
         (isEqualCaseInsensitive(nft.tokenId, tokenId) ||
           isEqualCaseInsensitive(nft.tokenId, convertedTokenId.toString()))
       );

--- a/ui/helpers/utils/util.test.js
+++ b/ui/helpers/utils/util.test.js
@@ -1,5 +1,5 @@
 import Bowser from 'bowser';
-import { BN } from 'ethereumjs-util';
+import { BN, toChecksumAddress } from 'ethereumjs-util';
 import { CHAIN_IDS } from '../../../shared/constants/network';
 import { addHexPrefixToObjectValues } from '../../../shared/lib/swaps-utils';
 import { toPrecisionWithoutTrailingZeros } from '../../../shared/lib/transactions-controller-utils';
@@ -944,11 +944,11 @@ describe('util', () => {
           },
         ],
       },
-      '0x2df920B180c58766951395c26ecF1EC206343334': {
+      '0x2dF920B180C58766951395C26ecF1Ec206343334': {
         collectionName: 'toto',
         nfts: [
           {
-            address: '0x2df920B180c58766951395c26ecF1EC206343334',
+            address: '0x2dF920B180C58766951395C26ecF1Ec206343334',
             description: 'toto',
             favorite: false,
             name: 'toto#3453',
@@ -970,14 +970,11 @@ describe('util', () => {
         ],
       },
     };
-    it('should return true if it exists', () => {
-      expect(
-        util.checkTokenIdExists(
-          '0x2df920B180c58766951395c26ecF1EC206343334',
-          '3453',
-          data,
-        ),
-      ).toBeTruthy();
+    it('should return true if it exists regardless if the entered value is checksum address or not', () => {
+      const adr = '0x2df920B180c58766951395c26ecF1EC206343334';
+      const checksumAdre = toChecksumAddress(adr);
+      expect(util.checkTokenIdExists(adr, '3453', data)).toBeTruthy();
+      expect(util.checkTokenIdExists(checksumAdre, '3453', data)).toBeTruthy();
     });
 
     it('should return true if it exists in decimal format', () => {


### PR DESCRIPTION
## **Description**


This PR fixes a reported issue here https://github.com/MetaMask/metamask-extension/issues/21227
The issue happens when the user tries to import an NFT with a non checksum address.
If you try to import an NFT with a contract address that is a valid Checksum address twice; you will be able to see the error "NFT already imported".
If it is an address that is not checksum; it will allow you to import the NFT twice.

The fix converts the input address to a checksum address and compares it to the user's NFT object.



## **Related issues**

Fixes: #https://github.com/MetaMask/metamask-extension/issues/21227

## **Manual testing steps**

1. Mint an NFT
2. Import the NFT the first time with decimal
3. Click on import NFT and enter the nonChecksumAddress of the contract
4. Input the NFT ID and you should see the error

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

For this test, we deployed a contract: this is the contract address from etherscan: 0x80AcDDE51B1f379AE60f72203bfD24D4d6D4412d (Which is a valid checksum address)
And this is the address we will test with: 0x80acdde51b1f379ae60f72203bfd24d4d6d4412d (which is a non valid checksum address)

Using the valid checksum address you should see:

![image](https://github.com/MetaMask/metamask-extension/assets/10994169/8854fa1c-1954-4479-82d9-1355fcff58e3)

Using the non valid checksum address you see:

![image](https://github.com/MetaMask/metamask-extension/assets/10994169/fb4e8039-14d9-47a7-86bc-9104a64a46df)


### **After**

Still Works with valid checksum address for decimal
![image](https://github.com/MetaMask/metamask-extension/assets/10994169/6ab4419f-c7a7-4e71-9936-39723dea976c)

Still works with valid checksum address for hex
![image](https://github.com/MetaMask/metamask-extension/assets/10994169/bf1d79e3-ed9e-4033-8b99-0d42938e5a5e)

Works with non valid checksum address decimal using (0x80acdde51b1f379ae60f72203bfd24d4d6d4412d)

![image](https://github.com/MetaMask/metamask-extension/assets/10994169/8c6d408d-3aca-45d8-ae67-c0c11acd97e5)

Works with non valid checksum address for hex 

![image](https://github.com/MetaMask/metamask-extension/assets/10994169/887150c4-97bc-4d7f-847e-7919fde68600)


## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained what problem this PR is solving and how it is solved.
- [x] I've linked related issues
- [x] I've included manual testing steps
- [x] I've included screenshots/recordings if applicable
- [ ] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [ ] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
