### PR TITLE
Adding Textarea component

### DIFF
--- a/ui/components/component-library/component-library-components.scss
+++ b/ui/components/component-library/component-library-components.scss
@@ -34,6 +34,7 @@
 @import 'picker-network/picker-network';
 @import 'tag-url/tag-url';
 @import 'text-field/text-field';
+@import 'textarea/textarea';
 @import 'text-field-search/text-field-search';
 @import 'form-text-field/form-text-field';
 @import 'banner-alert/banner-alert';

--- a/ui/components/component-library/textarea/README.mdx
+++ b/ui/components/component-library/textarea/README.mdx
@@ -1,0 +1,148 @@
+import { Story, Canvas, ArgTypes } from '@storybook/addon-docs';
+
+import { Textarea } from './textarea';
+
+# Textarea
+
+`Textarea` lets user enter multiple lines of text data into a boxed field
+
+<Canvas>
+  <Story id="components-componentlibrary-textarea--default-story" />
+</Canvas>
+
+## Props
+
+<ArgTypes of={Textarea} />
+
+### Auto Focus
+
+Use the `autoFocus` prop to focus the `Textarea` during the first mount
+
+To view story see [Canvas tab](/story/components-componentlibrary-textarea--auto-complete). Removing it from docs because created annoying reading experience 😁
+
+```jsx
+import { Textarea } from '../../component-library';
+
+<Textarea autoFocus />;
+```
+
+### Cols Rows
+
+Use the `cols` and `rows` props to set the number of columns and rows of the `Textarea`
+
+- The `cols` prop specifies the visible width of a `Textarea`
+- The `rows` prop specifies the visible height of a `Textarea`, in lines.
+
+<Canvas>
+  <Story id="components-componentlibrary-textarea--cols-rows" />
+</Canvas>
+
+```jsx
+import { Textarea } from '../../component-library';
+
+<Textarea cols={50} rows={4} />;
+```
+
+### Default Value
+
+Use the `defaultValue` prop to set the default value of the `Textarea`
+
+<Canvas>
+  <Story id="components-componentlibrary-textarea--default-value" />
+</Canvas>
+
+```jsx
+import { Textarea } from '../../component-library';
+
+<Textarea defaultValue="default value" />;
+```
+
+### Disabled
+
+Use the `disabled` prop to set the disabled state of the `Textarea`
+
+<Canvas>
+  <Story id="components-componentlibrary-textarea--disabled" />
+</Canvas>
+
+```jsx
+import { Textarea } from '../../component-library';
+
+<Textarea disabled />;
+```
+
+### Error
+
+Use the `error` prop to set the error state of the `Textarea`
+
+<Canvas>
+  <Story id="components-componentlibrary-textarea--error-story" />
+</Canvas>
+
+```jsx
+import { Textarea } from '../../component-library';
+
+<Textarea error />;
+```
+
+### Max Length
+
+Use the `maxLength` prop to set the maximum allowed input characters for the `Textarea`
+
+<Canvas>
+  <Story id="components-componentlibrary-textarea--max-length" />
+</Canvas>
+
+```jsx
+import { Textarea } from '../../component-library';
+
+<Textarea maxLength={13} />;
+```
+
+### Read Only
+
+Use the `readOnly` prop to set the `Textarea` to read only.
+
+<Canvas>
+  <Story id="components-componentlibrary-textarea--read-only" />
+</Canvas>
+
+```jsx
+import { Textarea } from '../../component-library';
+
+<Textarea readOnly />;
+```
+
+### Required
+
+Use the `required` prop to set the `Textarea` to required. Currently there is no visual difference to the `Textarea` when required.
+
+<Canvas>
+  <Story id="components-componentlibrary-textarea--required" />
+</Canvas>
+
+```jsx
+import { Textarea } from '../../component-library';
+
+// Currently no visual difference
+<Textarea required />;
+```
+
+### Resize
+
+Use the `resize` prop to set the resize state of the `Textarea`. Defaults to `TextareaResize.Vertical`.
+
+<Canvas>
+  <Story id="components-componentlibrary-textarea--resize" />
+</Canvas>
+
+```jsx
+import { Textarea, TextareaResize } from '../../component-library';
+
+<Textarea resize={TextareaResize.Vertical} />
+<Textarea resize={TextareaResize.Horizontal} />
+<Textarea resize={TextareaResize.None} />
+<Textarea resize={TextareaResize.Both} />
+<Textarea resize={TextareaResize.Inherit} />
+<Textarea resize={TextareaResize.Initial} />
+```

--- a/ui/components/component-library/textarea/README.mdx
+++ b/ui/components/component-library/textarea/README.mdx
@@ -57,18 +57,18 @@ import { Textarea } from '../../component-library';
 <Textarea defaultValue="default value" />;
 ```
 
-### Disabled
+### IsDisabled
 
-Use the `disabled` prop to set the disabled state of the `Textarea`
+Use the `isDisabled` prop to set the disabled state of the `Textarea`
 
 <Canvas>
-  <Story id="components-componentlibrary-textarea--disabled" />
+  <Story id="components-componentlibrary-textarea--is-disabled" />
 </Canvas>
 
 ```jsx
 import { Textarea } from '../../component-library';
 
-<Textarea disabled />;
+<Textarea isDisabled />;
 ```
 
 ### Error

--- a/ui/components/component-library/textarea/__snapshots__/textarea.test.tsx.snap
+++ b/ui/components/component-library/textarea/__snapshots__/textarea.test.tsx.snap
@@ -1,0 +1,10 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Textarea should render correctly 1`] = `
+<div>
+  <textarea
+    class="mm-box mm-text mm-textarea mm-textarea--resize-vertical mm-text--body-md mm-box--padding-top-1 mm-box--padding-right-4 mm-box--padding-bottom-1 mm-box--padding-left-4 mm-box--color-text-default mm-box--background-color-background-default mm-box--rounded-sm mm-box--border-color-border-default mm-box--border-width-1 box--border-style-solid"
+    resize="vertical"
+  />
+</div>
+`;

--- a/ui/components/component-library/textarea/index.ts
+++ b/ui/components/component-library/textarea/index.ts
@@ -1,0 +1,6 @@
+export { Textarea } from './textarea';
+export type {
+  TextareaProps,
+  TextareaStyleUtilityProps,
+} from './textarea.types';
+export { TextareaResize } from './textarea.types';

--- a/ui/components/component-library/textarea/index.ts
+++ b/ui/components/component-library/textarea/index.ts
@@ -2,5 +2,6 @@ export { Textarea } from './textarea';
 export type {
   TextareaProps,
   TextareaStyleUtilityProps,
+  TextareaComponent,
 } from './textarea.types';
 export { TextareaResize } from './textarea.types';

--- a/ui/components/component-library/textarea/textarea.scss
+++ b/ui/components/component-library/textarea/textarea.scss
@@ -1,0 +1,13 @@
+.mm-textarea {
+  $resize: none, both, horizontal, vertical, initial, inherit;
+
+  &--disabled {
+    opacity: 0.5;
+  }
+
+  @each $size in $resize {
+    &--resize-#{$size} {
+      resize: $size;
+    }
+  }
+}

--- a/ui/components/component-library/textarea/textarea.scss
+++ b/ui/components/component-library/textarea/textarea.scss
@@ -1,8 +1,10 @@
 .mm-textarea {
   $resize: none, both, horizontal, vertical, initial, inherit;
 
-  &--disabled {
-    opacity: 0.5;
+  &--is-disabled,
+  &:disabled {
+    opacity: var(--opacity-disabled);
+    cursor: not-allowed;
   }
 
   @each $size in $resize {

--- a/ui/components/component-library/textarea/textarea.stories.tsx
+++ b/ui/components/component-library/textarea/textarea.stories.tsx
@@ -1,0 +1,158 @@
+import React from 'react';
+import { StoryFn, Meta } from '@storybook/react';
+import { useArgs } from '@storybook/client-api';
+
+import {
+  FlexDirection,
+  Display,
+} from '../../../helpers/constants/design-system';
+import { Box } from '..';
+import { TextareaResize } from './textarea.types';
+import { Textarea } from './textarea';
+
+import README from './README.mdx';
+
+export default {
+  title: 'Components/ComponentLibrary/Textarea',
+  component: Textarea,
+  parameters: {
+    docs: {
+      page: README,
+    },
+  },
+  argTypes: {
+    autoFocus: {
+      control: 'boolean',
+    },
+    className: {
+      control: 'text',
+    },
+    cols: {
+      control: 'number',
+    },
+    defaultValue: {
+      control: 'text',
+    },
+    disabled: {
+      control: 'boolean',
+    },
+    error: {
+      control: 'boolean',
+    },
+    id: {
+      control: 'text',
+    },
+    name: {
+      control: 'text',
+    },
+    onBlur: {
+      action: 'onBlur',
+    },
+    onChange: {
+      action: 'onChange',
+    },
+    onClick: {
+      action: 'onClick',
+    },
+    onFocus: {
+      action: 'onFocus',
+    },
+    placeholder: {
+      control: 'text',
+    },
+    readOnly: {
+      control: 'boolean',
+    },
+    required: {
+      control: 'boolean',
+    },
+    resize: {
+      control: {
+        type: 'select',
+        options: Object.values(TextareaResize),
+      },
+    },
+    rows: {
+      control: 'number',
+    },
+    value: {
+      control: 'text',
+    },
+  },
+  args: {
+    placeholder: 'Placeholder...',
+  },
+} as Meta<typeof Textarea>;
+
+const Template: StoryFn<typeof Textarea> = (args) => {
+  const [{ value }, updateArgs] = useArgs();
+  const handleOnChange = (e) => {
+    updateArgs({ value: e.target.value });
+  };
+  return <Textarea {...args} value={value} onChange={handleOnChange} />;
+};
+
+export const DefaultStory = Template.bind({});
+DefaultStory.storyName = 'Default';
+
+export const AutoFocus = Template.bind({});
+AutoFocus.args = { autoFocus: true, placeholder: 'Auto focus' };
+
+export const ColsRows = Template.bind({});
+ColsRows.args = { cols: 50, rows: 4, placeholder: 'cols: 50, rows: 4' };
+
+export const DefaultValue = Template.bind({});
+DefaultValue.args = { defaultValue: 'Default value' };
+
+export const Disabled = Template.bind({});
+Disabled.args = { disabled: true, placeholder: 'Disabled' };
+
+export const ErrorStory = Template.bind({});
+ErrorStory.args = { error: true, placeholder: 'Error' };
+ErrorStory.storyName = 'Error';
+
+export const MaxLength = Template.bind({});
+MaxLength.args = { maxLength: 13, value: 'Max length 13' };
+
+export const ReadOnly = Template.bind({});
+ReadOnly.args = { readOnly: true, value: 'Read only' };
+
+// eslint-disable-next-line @typescript-eslint/no-shadow
+export const Required = Template.bind({});
+Required.args = { required: true, placeholder: 'Required' };
+
+// eslint-disable-next-line @typescript-eslint/no-shadow
+export const Resize: StoryFn<typeof Textarea> = (args) => (
+  <Box display={Display.Flex} flexDirection={FlexDirection.Column} gap={4}>
+    <Textarea
+      {...args}
+      resize={TextareaResize.Vertical}
+      placeholder={`Resize ${TextareaResize.Vertical} resize={TextareaResize.Vertical}`}
+    />
+    <Textarea
+      {...args}
+      resize={TextareaResize.Horizontal}
+      placeholder={`Resize ${TextareaResize.Horizontal} resize={TextareaResize.Horizontal}`}
+    />
+    <Textarea
+      {...args}
+      resize={TextareaResize.None}
+      placeholder={`Resize ${TextareaResize.None} resize={TextareaResize.None}`}
+    />
+    <Textarea
+      {...args}
+      resize={TextareaResize.Both}
+      placeholder={`Resize ${TextareaResize.Both} resize={TextareaResize.Both}`}
+    />
+    <Textarea
+      {...args}
+      resize={TextareaResize.Inherit}
+      placeholder={`Resize ${TextareaResize.Inherit} resize={TextareaResize.Inherit}`}
+    />
+    <Textarea
+      {...args}
+      resize={TextareaResize.Initial}
+      placeholder={`Resize ${TextareaResize.Initial} resize={TextareaResize.Initial}`}
+    />
+  </Box>
+);

--- a/ui/components/component-library/textarea/textarea.stories.tsx
+++ b/ui/components/component-library/textarea/textarea.stories.tsx
@@ -33,7 +33,7 @@ export default {
     defaultValue: {
       control: 'text',
     },
-    disabled: {
+    isDisabled: {
       control: 'boolean',
     },
     error: {
@@ -104,8 +104,8 @@ ColsRows.args = { cols: 50, rows: 4, placeholder: 'cols: 50, rows: 4' };
 export const DefaultValue = Template.bind({});
 DefaultValue.args = { defaultValue: 'Default value' };
 
-export const Disabled = Template.bind({});
-Disabled.args = { disabled: true, placeholder: 'Disabled' };
+export const IsDisabled = Template.bind({});
+IsDisabled.args = { disabled: true, placeholder: 'Disabled' };
 
 export const ErrorStory = Template.bind({});
 ErrorStory.args = { error: true, placeholder: 'Error' };

--- a/ui/components/component-library/textarea/textarea.test.tsx
+++ b/ui/components/component-library/textarea/textarea.test.tsx
@@ -1,0 +1,168 @@
+/* eslint-disable jest/require-top-level-describe */
+import React from 'react';
+import { fireEvent, render } from '@testing-library/react';
+import { renderWithUserEvent } from '../../../../test/lib/render-helpers';
+
+import { TextareaResize } from './textarea.types';
+import { Textarea } from './textarea';
+
+describe('Textarea', () => {
+  it('should render correctly', () => {
+    const { getByRole, container } = render(<Textarea />);
+    expect(getByRole('textbox')).toBeDefined();
+    expect(container).toMatchSnapshot();
+  });
+  it('should render and be able to input text', () => {
+    const { getByTestId } = render(<Textarea data-testid="textarea" />);
+    const textarea = getByTestId('textarea') as HTMLTextAreaElement;
+    expect(textarea.value).toBe(''); // initial value is empty string
+    fireEvent.change(textarea, { target: { value: 'text value' } });
+    expect(textarea.value).toBe('text value');
+    fireEvent.change(textarea, { target: { value: '' } }); // reset value
+    expect(textarea.value).toBe(''); // value is empty string after reset
+  });
+  it('should render with focused state when clicked', async () => {
+    const { getByTestId, user } = renderWithUserEvent(
+      <Textarea data-testid="textarea" />,
+    );
+    const textarea = getByTestId('textarea');
+    await user.click(textarea);
+    expect(textarea).toHaveFocus();
+  });
+  it('should render and fire onFocus and onBlur events', async () => {
+    const onFocus = jest.fn();
+    const onBlur = jest.fn();
+    const { getByTestId, user } = renderWithUserEvent(
+      <Textarea onFocus={onFocus} onBlur={onBlur} data-testid="textarea" />,
+    );
+
+    const textarea = getByTestId('textarea');
+    await user.click(textarea);
+    expect(onFocus).toHaveBeenCalledTimes(1);
+    fireEvent.blur(textarea);
+    expect(onBlur).toHaveBeenCalledTimes(1);
+  });
+  it('should render and fire onChange event', async () => {
+    const onChange = jest.fn();
+    const { getByTestId, user } = renderWithUserEvent(
+      <Textarea onChange={onChange} data-testid="textarea" />,
+    );
+    const textarea = getByTestId('textarea');
+    await user.type(textarea, '123');
+    expect(textarea).toHaveValue('123');
+    expect(onChange).toHaveBeenCalledTimes(3);
+  });
+  it('should render and fire onClick event', async () => {
+    const onClick = jest.fn();
+    const { getByTestId, user } = renderWithUserEvent(
+      <Textarea data-testid="textarea" onClick={onClick} />,
+    );
+    const textarea = getByTestId('textarea');
+
+    await user.click(textarea);
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+  it('should render with rows and cols', () => {
+    const { getByRole } = render(<Textarea rows={4} cols={50} />);
+    const textarea = getByRole('textbox') as HTMLTextAreaElement;
+    expect(textarea.rows).toBe(4);
+    expect(textarea.cols).toBe(50);
+  });
+  it('should render with autoFocus', () => {
+    const { getByRole } = render(<Textarea autoFocus />);
+    expect(getByRole('textbox')).toHaveFocus();
+  });
+  it('should render with a defaultValue', () => {
+    const { getByRole } = render(
+      <Textarea
+        defaultValue="default value"
+        data-testid="textarea-default-value"
+      />,
+    );
+    const textarea = getByRole('textbox') as HTMLTextAreaElement;
+    expect(textarea.value).toBe('default value');
+  });
+  it('should render in disabled state and not focus or be clickable', async () => {
+    const mockOnClick = jest.fn();
+    const mockOnFocus = jest.fn();
+    const { getByRole, getByTestId, user } = renderWithUserEvent(
+      <Textarea
+        disabled
+        onFocus={mockOnFocus}
+        onClick={mockOnClick}
+        data-testid="textarea"
+      />,
+    );
+
+    const textarea = getByTestId('textarea');
+
+    await user.click(textarea);
+    expect(getByRole('textbox')).toBeDisabled();
+    expect(mockOnClick).toHaveBeenCalledTimes(0);
+    expect(mockOnFocus).toHaveBeenCalledTimes(0);
+  });
+  it('should render with error state when error is true', () => {
+    const { getByTestId } = render(
+      <Textarea error data-testid="textarea-error" />,
+    );
+    const textarea = getByTestId('textarea-error');
+    expect(textarea).toHaveAttribute('aria-invalid', 'true');
+    expect(textarea).toHaveClass('mm-box--border-color-error-default');
+  });
+
+  it('should render with readOnly attr when readOnly is true', async () => {
+    const { getByTestId, getByRole, user } = renderWithUserEvent(
+      <Textarea readOnly data-testid="read-only" />,
+    );
+    const textarea = getByTestId('read-only') as HTMLTextAreaElement;
+    await user.type(textarea, '1234567890');
+    expect(textarea.value).toBe('');
+    expect(getByRole('textbox')).toHaveAttribute('readonly', '');
+  });
+
+  it('should render with required attr when required is true', () => {
+    const { getByTestId } = render(
+      <Textarea required data-testid="textarea-required" />,
+    );
+    expect(getByTestId('textarea-required')).toHaveAttribute('required', '');
+  });
+
+  it('renders a textarea with resize behavior', () => {
+    const { getByTestId } = render(
+      <>
+        <Textarea
+          resize={TextareaResize.Horizontal}
+          data-testid="resize-horizontal"
+        />
+        <Textarea
+          resize={TextareaResize.Vertical}
+          data-testid="resize-vertical"
+        />
+        <Textarea resize={TextareaResize.None} data-testid="resize-none" />
+        <Textarea resize={TextareaResize.Both} data-testid="resize-both" />
+        <Textarea
+          resize={TextareaResize.Inherit}
+          data-testid="resize-inherit"
+        />
+        <Textarea
+          resize={TextareaResize.Initial}
+          data-testid="resize-initial"
+        />
+      </>,
+    );
+    expect(getByTestId('resize-horizontal')).toHaveClass(
+      'mm-textarea--resize-horizontal',
+    );
+    expect(getByTestId('resize-vertical')).toHaveClass(
+      'mm-textarea--resize-vertical',
+    );
+    expect(getByTestId('resize-none')).toHaveClass('mm-textarea--resize-none');
+    expect(getByTestId('resize-both')).toHaveClass('mm-textarea--resize-both');
+    expect(getByTestId('resize-inherit')).toHaveClass(
+      'mm-textarea--resize-inherit',
+    );
+    expect(getByTestId('resize-initial')).toHaveClass(
+      'mm-textarea--resize-initial',
+    );
+  });
+});

--- a/ui/components/component-library/textarea/textarea.test.tsx
+++ b/ui/components/component-library/textarea/textarea.test.tsx
@@ -87,33 +87,45 @@ describe('Textarea', () => {
     const mockOnFocus = jest.fn();
     const { getByRole, getByTestId, user } = renderWithUserEvent(
       <>
-        <Textarea isDisabled onFocus={mockOnFocus} onClick={mockOnClick} />
+        <Textarea
+          isDisabled
+          onFocus={mockOnFocus}
+          onClick={mockOnClick}
+          data-testid="textarea"
+        />
       </>,
     );
 
-    const textarea = getByRole('textarea');
+    const textarea = getByRole('textbox');
 
     await user.click(textarea);
-    expect(getByTestId('textbox')).toBeDisabled();
+    expect(getByTestId('textarea')).toBeDisabled();
     expect(mockOnClick).toHaveBeenCalledTimes(0);
     expect(mockOnFocus).toHaveBeenCalledTimes(0);
   });
+
   it('should render in disabled state using disabled prop and not focus or be clickable', async () => {
     const mockOnClick = jest.fn();
     const mockOnFocus = jest.fn();
     const { getByRole, getByTestId, user } = renderWithUserEvent(
       <>
-        <Textarea disabled onFocus={mockOnFocus} onClick={mockOnClick} />
+        <Textarea
+          disabled
+          onFocus={mockOnFocus}
+          onClick={mockOnClick}
+          data-testid="textarea"
+        />
       </>,
     );
 
-    const textarea = getByRole('textarea');
+    const textarea = getByRole('textbox');
 
     await user.click(textarea);
-    expect(getByTestId('textbox')).toBeDisabled();
+    expect(getByTestId('textarea')).toBeDisabled();
     expect(mockOnClick).toHaveBeenCalledTimes(0);
     expect(mockOnFocus).toHaveBeenCalledTimes(0);
   });
+
   it('should render with error state when error is true', () => {
     const { getByTestId } = render(
       <Textarea error data-testid="textarea-error" />,

--- a/ui/components/component-library/textarea/textarea.test.tsx
+++ b/ui/components/component-library/textarea/textarea.test.tsx
@@ -82,22 +82,35 @@ describe('Textarea', () => {
     const textarea = getByRole('textbox') as HTMLTextAreaElement;
     expect(textarea.value).toBe('default value');
   });
-  it('should render in disabled state and not focus or be clickable', async () => {
+  it('should render in disabled state using isDisabled prop and not focus or be clickable', async () => {
     const mockOnClick = jest.fn();
     const mockOnFocus = jest.fn();
     const { getByRole, getByTestId, user } = renderWithUserEvent(
-      <Textarea
-        disabled
-        onFocus={mockOnFocus}
-        onClick={mockOnClick}
-        data-testid="textarea"
-      />,
+      <>
+        <Textarea isDisabled onFocus={mockOnFocus} onClick={mockOnClick} />
+      </>,
     );
 
-    const textarea = getByTestId('textarea');
+    const textarea = getByRole('textarea');
 
     await user.click(textarea);
-    expect(getByRole('textbox')).toBeDisabled();
+    expect(getByTestId('textbox')).toBeDisabled();
+    expect(mockOnClick).toHaveBeenCalledTimes(0);
+    expect(mockOnFocus).toHaveBeenCalledTimes(0);
+  });
+  it('should render in disabled state using disabled prop and not focus or be clickable', async () => {
+    const mockOnClick = jest.fn();
+    const mockOnFocus = jest.fn();
+    const { getByRole, getByTestId, user } = renderWithUserEvent(
+      <>
+        <Textarea disabled onFocus={mockOnFocus} onClick={mockOnClick} />
+      </>,
+    );
+
+    const textarea = getByRole('textarea');
+
+    await user.click(textarea);
+    expect(getByTestId('textbox')).toBeDisabled();
     expect(mockOnClick).toHaveBeenCalledTimes(0);
     expect(mockOnFocus).toHaveBeenCalledTimes(0);
   });

--- a/ui/components/component-library/textarea/textarea.tsx
+++ b/ui/components/component-library/textarea/textarea.tsx
@@ -1,0 +1,104 @@
+import React from 'react';
+import classnames from 'classnames';
+
+import {
+  BorderRadius,
+  BackgroundColor,
+  BorderColor,
+} from '../../../helpers/constants/design-system';
+
+import { Text } from '..';
+import { TextProps } from '../text';
+
+import { PolymorphicRef } from '../box';
+import {
+  TextareaComponent,
+  TextareaProps,
+  TextareaResize,
+} from './textarea.types';
+
+export const Textarea: TextareaComponent = React.forwardRef(
+  <C extends React.ElementType = 'textarea'>(
+    {
+      autoFocus,
+      className = '',
+      defaultValue,
+      disabled,
+      error,
+      id,
+      resize = TextareaResize.Vertical,
+      rows,
+      cols,
+      maxLength,
+      name,
+      onBlur,
+      onChange,
+      onClick,
+      onFocus,
+      placeholder,
+      readOnly,
+      required,
+      value,
+      ...props
+    }: TextareaProps<C>,
+    ref?: PolymorphicRef<C>,
+  ) => {
+    const handleClick = (event: React.MouseEvent<HTMLTextAreaElement>) => {
+      if (onClick && !disabled) {
+        onClick?.(event);
+      }
+    };
+
+    const handleBlur = (event: React.FocusEvent<HTMLTextAreaElement>) => {
+      onBlur?.(event);
+    };
+
+    const handleFocus = (event: React.FocusEvent<HTMLTextAreaElement>) => {
+      onFocus?.(event);
+    };
+
+    return (
+      <Text
+        className={classnames(
+          'mm-textarea',
+          `mm-textarea--resize-${resize}`,
+          {
+            'mm-textarea--disabled': Boolean(disabled),
+          },
+          className,
+        )}
+        as="textarea"
+        ref={ref}
+        placeholder={placeholder}
+        readOnly={readOnly}
+        required={required}
+        autoFocus={autoFocus}
+        defaultValue={defaultValue}
+        disabled={disabled}
+        {...(error && { 'aria-invalid': error })}
+        id={id}
+        maxLength={maxLength}
+        name={name}
+        value={value}
+        onBlur={handleBlur}
+        onChange={onChange}
+        onClick={handleClick}
+        onFocus={handleFocus}
+        resize={resize}
+        rows={rows}
+        cols={cols}
+        backgroundColor={BackgroundColor.backgroundDefault}
+        borderColor={
+          error ? BorderColor.errorDefault : BorderColor.borderDefault
+        }
+        borderRadius={BorderRadius.SM}
+        borderWidth={1}
+        paddingBottom={1}
+        paddingLeft={4}
+        paddingRight={4}
+        paddingTop={1}
+        {...(props as TextProps<C>)}
+      />
+    );
+  },
+);

--- a/ui/components/component-library/textarea/textarea.tsx
+++ b/ui/components/component-library/textarea/textarea.tsx
@@ -23,7 +23,8 @@ export const Textarea: TextareaComponent = React.forwardRef(
       autoFocus,
       className = '',
       defaultValue,
-      disabled,
+      isDisabled,
+      disabled, // to allow our components to maintain intuitive building and support native HTML attribute
       error,
       id,
       resize = TextareaResize.Vertical,
@@ -44,7 +45,7 @@ export const Textarea: TextareaComponent = React.forwardRef(
     ref?: PolymorphicRef<C>,
   ) => {
     const handleClick = (event: React.MouseEvent<HTMLTextAreaElement>) => {
-      if (onClick && !disabled) {
+      if (onClick && (!isDisabled || !disabled)) {
         onClick?.(event);
       }
     };
@@ -63,7 +64,7 @@ export const Textarea: TextareaComponent = React.forwardRef(
           'mm-textarea',
           `mm-textarea--resize-${resize}`,
           {
-            'mm-textarea--disabled': Boolean(disabled),
+            'mm-textarea--disabled': Boolean(isDisabled || disabled),
           },
           className,
         )}
@@ -74,7 +75,7 @@ export const Textarea: TextareaComponent = React.forwardRef(
         required={required}
         autoFocus={autoFocus}
         defaultValue={defaultValue}
-        disabled={disabled}
+        disabled={isDisabled || disabled}
         {...(error && { 'aria-invalid': error })}
         id={id}
         maxLength={maxLength}

--- a/ui/components/component-library/textarea/textarea.types.ts
+++ b/ui/components/component-library/textarea/textarea.types.ts
@@ -1,0 +1,100 @@
+import React from 'react';
+import type {
+  PolymorphicComponentPropWithRef,
+  StyleUtilityProps,
+} from '../box';
+
+export enum TextareaResize {
+  None = 'none',
+  Both = 'both',
+  Horizontal = 'horizontal',
+  Vertical = 'vertical',
+  Initial = 'initial',
+  Inherit = 'inherit',
+}
+
+export interface TextareaStyleUtilityProps extends StyleUtilityProps {
+  /**
+   * If `true`, the textarea will be focused during the first mount.
+   */
+  autoFocus?: boolean;
+  /**
+   * An additional className to apply to the textarea
+   */
+  className?: string;
+  /**
+   * The default textarea value, useful when not controlling the component.
+   */
+  defaultValue?: string;
+  /**
+   * If `true`, the textarea will be disabled.
+   */
+  disabled?: boolean;
+  /**
+   * If `true`, the textarea will indicate an error
+   */
+  error?: boolean;
+  /**
+   * The id of the textarea element.
+   */
+  id?: string;
+  /**
+   * Max number of characters to allow
+   */
+  maxLength?: number;
+  /**
+   * Name attribute of the textarea element.
+   */
+  name?: string;
+  /**
+   * Callback fired on blur
+   */
+  onBlur?: (event: React.FocusEvent<HTMLTextAreaElement>) => void;
+  /**
+   * Callback fired when the value is changed.
+   */
+  onChange?: (event: React.ChangeEvent<HTMLTextAreaElement>) => void;
+  /**
+   * Callback fired when the Textarea is clicked on
+   */
+  onClick?: (event: React.MouseEvent<HTMLTextAreaElement>) => void;
+  /**
+   * Callback fired on focus
+   */
+  onFocus?: (event: React.FocusEvent<HTMLTextAreaElement>) => void;
+  /**
+   * The short hint displayed in the textarea before the user enters a value.
+   */
+  placeholder?: string;
+  /**
+   * It prevents the user from changing the value of the field (not from interacting with the field).
+   */
+  readOnly?: boolean;
+  /**
+   * If `true`, the textarea will be required. Currently no visual difference is shown.
+   */
+  required?: boolean;
+  /**
+   * The resize property specifies whether or not an element is resizable by the user.
+   */
+  resize?: TextareaResize;
+  /**
+   * Number of rows to display when multiline option is set to true
+   */
+  rows?: number;
+  /**
+   * Number of columns to display when multiline option is set to true
+   */
+  cols?: number;
+  /**
+   * The textarea value, required for a controlled component.
+   */
+  value?: string | number;
+}
+
+export type TextareaProps<C extends React.ElementType> =
+  PolymorphicComponentPropWithRef<C, TextareaStyleUtilityProps>;
+
+export type TextareaComponent = <C extends React.ElementType = 'textarea'>(
+  props: TextareaProps<C>,
+) => React.ReactElement | null;

--- a/ui/components/component-library/textarea/textarea.types.ts
+++ b/ui/components/component-library/textarea/textarea.types.ts
@@ -29,6 +29,10 @@ export interface TextareaStyleUtilityProps extends StyleUtilityProps {
   /**
    * If `true`, the textarea will be disabled.
    */
+  isDisabled?: boolean;
+  /*
+   * Please use the `isDisabled` prop instead, this prop is added only for backwards compatibility and intuitive HTML support
+   */
   disabled?: boolean;
   /**
    * If `true`, the textarea will indicate an error

--- a/ui/components/ui/textarea/textarea.js
+++ b/ui/components/ui/textarea/textarea.js
@@ -19,8 +19,7 @@ import { RESIZE } from './textarea.constants';
  * See storybook documentation for BannerAlert here:
  * {@see {@link https://metamask.github.io/metamask-storybook/?path=/docs/components-componentlibrary-textarea--default-story#textarea}}
  *
- * Help to replace `<TextArea />` with `Textarea` by submitting a PR against
-
+ * Help to replace `<TextArea />` with `<Textarea />` by submitting a PR
  */
 
 const TextArea = ({

--- a/ui/components/ui/textarea/textarea.js
+++ b/ui/components/ui/textarea/textarea.js
@@ -13,6 +13,16 @@ import {
 import Box from '../box';
 import { RESIZE } from './textarea.constants';
 
+/**
+ * @deprecated `<TextArea />` has been deprecated in favor of the `<Textarea />`
+ * component in ./ui/components/component-library/textarea/textarea.tsx.
+ * See storybook documentation for BannerAlert here:
+ * {@see {@link https://metamask.github.io/metamask-storybook/?path=/docs/components-componentlibrary-textarea--default-story#textarea}}
+ *
+ * Help to replace `<TextArea />` with `Textarea` by submitting a PR against
+
+ */
+
 const TextArea = ({
   className,
   value,


### PR DESCRIPTION
## **Description**
Currently, there multiple textarea components in the codebase. This PR creates a `Textarea` component and adds it to the component-library folder as the single source of truth using the conventions and added benefits of style utility props. Once this PR has been merged we can deprecated the other instances of the textarea components

## **Related issues**

Fixes: #21606

## **Manual testing steps**

1. Go to the storybook build of this PR
2. Search for `Textarea` in the search box. Select the component-library version
3. Check the documentation, stories and controls
4. Check component API aligns with [insight report](https://www.figma.com/file/aGW8sk6X6Jf9ac0MRMD4kX/TextField%2C-Textarea%2C-Label%2C-HelpText-Audit-and-Insight-Report?type=whiteboard&node-id=1004%3A27&t=xDkmiY3xqRJRzynp-1)

## **Screenshots/Recordings**

### **Before**
State TextArea component exists but is not used and can be removed

https://github.com/MetaMask/metamask-extension/assets/8112138/8829018f-7813-4445-9961-54081629a735

### **After**
New `Textarea` component built in typescript with comprehensive docs

https://github.com/MetaMask/metamask-extension/assets/8112138/d30d2ba5-826f-44f9-b217-ed7fe4f61674

100% unit test coverage 

<img width="756" alt="Screenshot 2023-10-30 at 2 06 58 PM" src="https://github.com/MetaMask/metamask-extension/assets/8112138/3337ba48-1e26-4d44-87e2-7f349ca7de69">

Deprecating old `TextArea` component

![Screenshot 2023-12-13 at 5 42 26 PM](https://github.com/MetaMask/metamask-extension/assets/8112138/3fc9d957-337f-4c5e-9494-e61027282a83)


## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained what problem this PR is solving and how it is solved.
- [x] I've linked related issues
- [x] I've included manual testing steps
- [x] I've included screenshots/recordings if applicable
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [x] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [x] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
