### PR TITLE
Fix snaps website link pointing to the wrong URL

### DIFF
--- a/ui/components/app/snaps/snap-authorship-expanded/snap-authorship-expanded.js
+++ b/ui/components/app/snaps/snap-authorship-expanded/snap-authorship-expanded.js
@@ -178,7 +178,7 @@ const SnapAuthorshipExpanded = ({ snapId, className, snap }) => {
               alignItems={AlignItems.flexEnd}
             >
               <ButtonLink
-                href={installOrigin.origin}
+                href={safeWebsite}
                 target="_blank"
                 overflowWrap={OverflowWrap.Anywhere}
               >


### PR DESCRIPTION
## **Description**

Fixes the snaps website link pointing to the wrong URL.

Testing steps:
1. Install https://snaps.metamask.io/snap/npm/tezos-metamask-snap/
2. Click website link in snap settings
3. See that you are navigated to https://metamask.tezos.com/
