### PR TITLE
ci(resources): update parallelism and resource class for e2e tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -812,7 +812,7 @@ jobs:
 
   test-e2e-chrome:
     executor: node-browsers-large
-    parallelism: 16
+    parallelism: 20
     steps:
       - run: *shallow-git-clone
       - run:
@@ -842,7 +842,7 @@ jobs:
 
   test-e2e-chrome-multichain:
     executor: node-browsers-large
-    parallelism: 16
+    parallelism: 20
     steps:
       - run: *shallow-git-clone
       - run:
@@ -871,7 +871,7 @@ jobs:
           path: test/test-results/e2e
   test-e2e-chrome-mv3:
     executor: node-browsers-large
-    parallelism: 16
+    parallelism: 20
     steps:
       - run: *shallow-git-clone
       - run:
@@ -1048,7 +1048,7 @@ jobs:
 
   test-e2e-firefox:
     executor: node-browsers-large
-    parallelism: 16
+    parallelism: 20
     steps:
       - run: *shallow-git-clone
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -812,7 +812,7 @@ jobs:
 
   test-e2e-chrome:
     executor: node-browsers-large
-    parallelism: 20
+    parallelism: 24
     steps:
       - run: *shallow-git-clone
       - run:
@@ -842,7 +842,7 @@ jobs:
 
   test-e2e-chrome-multichain:
     executor: node-browsers-large
-    parallelism: 20
+    parallelism: 24
     steps:
       - run: *shallow-git-clone
       - run:
@@ -871,7 +871,7 @@ jobs:
           path: test/test-results/e2e
   test-e2e-chrome-mv3:
     executor: node-browsers-large
-    parallelism: 20
+    parallelism: 24
     steps:
       - run: *shallow-git-clone
       - run:
@@ -1048,7 +1048,7 @@ jobs:
 
   test-e2e-firefox:
     executor: node-browsers-large
-    parallelism: 20
+    parallelism: 24
     steps:
       - run: *shallow-git-clone
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -811,8 +811,8 @@ jobs:
           command: yarn depcheck
 
   test-e2e-chrome:
-    executor: node-browsers
-    parallelism: 12
+    executor: node-browsers-large
+    parallelism: 16
     steps:
       - run: *shallow-git-clone
       - run:
@@ -841,8 +841,8 @@ jobs:
           path: test/test-results/e2e
 
   test-e2e-chrome-multichain:
-    executor: node-browsers
-    parallelism: 12
+    executor: node-browsers-large
+    parallelism: 16
     steps:
       - run: *shallow-git-clone
       - run:
@@ -870,8 +870,8 @@ jobs:
       - store_test_results:
           path: test/test-results/e2e
   test-e2e-chrome-mv3:
-    executor: node-browsers
-    parallelism: 12
+    executor: node-browsers-large
+    parallelism: 16
     steps:
       - run: *shallow-git-clone
       - run:
@@ -1047,8 +1047,8 @@ jobs:
           path: test/test-results/e2e
 
   test-e2e-firefox:
-    executor: node-browsers-medium-plus
-    parallelism: 12
+    executor: node-browsers-large
+    parallelism: 16
     steps:
       - run: *shallow-git-clone
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -957,8 +957,8 @@ jobs:
           path: test/test-results/e2e
 
   test-e2e-firefox-flask:
-    executor: node-browsers
-    parallelism: 8
+    executor: node-browsers-large
+    parallelism: 16
     steps:
       - run: *shallow-git-clone
       - run:
@@ -987,8 +987,8 @@ jobs:
           path: test/test-results/e2e
 
   test-e2e-chrome-flask:
-    executor: node-browsers
-    parallelism: 8
+    executor: node-browsers-large
+    parallelism: 16
     steps:
       - run: *shallow-git-clone
       - run:
@@ -1017,8 +1017,8 @@ jobs:
           path: test/test-results/e2e
 
   test-e2e-chrome-mmi:
-    executor: node-browsers
-    parallelism: 8
+    executor: node-browsers-large
+    parallelism: 16
     steps:
       - run: *shallow-git-clone
       - run:


### PR DESCRIPTION
## **Description**
Update the resource class for all e2e test runners and bump up parallelism to reduce wait time for e2e tests.

## **Related issues**
N/A

## **Manual testing steps**
1. Go to circle ci and compare develop test run times to this branch times

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
<img width="677" alt="Screenshot 2023-11-01 at 8 51 59 AM" src="https://github.com/MetaMask/metamask-extension/assets/4448075/0efa8bb8-bff7-48b2-950b-dc3f1009c1b8">

**test-e2e-firefox timings**
<img width="1682" alt="Screenshot 2023-11-01 at 8 52 51 AM" src="https://github.com/MetaMask/metamask-extension/assets/4448075/5de08f5c-0c31-4f44-a554-a2af80dca64e">

**test-e2e-firefox resources**
<img width="1699" alt="Screenshot 2023-11-01 at 8 53 30 AM" src="https://github.com/MetaMask/metamask-extension/assets/4448075/ab51c7ed-a76d-4ff0-a57e-c4bfa056a44f">

### **After**
<img width="658" alt="Screenshot 2023-11-01 at 8 54 08 AM" src="https://github.com/MetaMask/metamask-extension/assets/4448075/28e91a80-a5ac-4c1a-ae03-709b1653e1fb">

**test-e2e-firefox timings*(
<img width="1704" alt="Screenshot 2023-11-01 at 8 54 57 AM" src="https://github.com/MetaMask/metamask-extension/assets/4448075/67fbf24b-b845-402b-85e2-42fa947fe8b0">

**test-e2e-firefox resources**
<img width="1675" alt="Screenshot 2023-11-01 at 8 55 31 AM" src="https://github.com/MetaMask/metamask-extension/assets/4448075/9c2b36a5-d9ab-4f24-a584-4ab9fab49990">


## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained what problem this PR is solving and how it is solved.
- [x] I've linked related issues
- [x] I've included manual testing steps
- [x] I've included screenshots/recordings if applicable
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [x] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [x] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
