### PR TITLE
Fix: Hide loading spinner when async transaction approval modal is present

### DIFF
--- a/test/e2e/tests/swaps/swaps-notifications.spec.js
+++ b/test/e2e/tests/swaps/swaps-notifications.spec.js
@@ -181,7 +181,6 @@ describe('Swaps - notifications @no-mmi', function () {
           title: 'Very high slippage',
           text: 'Slippage tolerance must be 15% or less. Anything higher will result in a bad rate.',
         });
-        await driver.fill('input[data-testid*="slippage"]', '4');
       },
     );
   });

--- a/ui/pages/routes/routes.component.js
+++ b/ui/pages/routes/routes.component.js
@@ -113,6 +113,9 @@ import { EXTENSION_ERROR_PAGE_TYPES } from '../../../shared/constants/desktop';
 import {
   ENVIRONMENT_TYPE_NOTIFICATION,
   ENVIRONMENT_TYPE_POPUP,
+  ///: BEGIN:ONLY_INCLUDE_IN(keyring-snaps)
+  SNAP_MANAGE_ACCOUNTS_CONFIRMATION_TYPES,
+  ///: END:ONLY_INCLUDE_IN
 } from '../../../shared/constants/app';
 import { NETWORK_TYPES } from '../../../shared/constants/network';
 import { getEnvironmentType } from '../../../app/scripts/lib/util';
@@ -179,6 +182,7 @@ export default class Routes extends Component {
     ///: BEGIN:ONLY_INCLUDE_IN(keyring-snaps)
     isShowKeyringSnapRemovalResultModal: PropTypes.bool.isRequired,
     hideShowKeyringSnapRemovalResultModal: PropTypes.func.isRequired,
+    pendingConfirmations: PropTypes.object.isRequired,
     ///: END:ONLY_INCLUDE_IN
   };
 
@@ -593,6 +597,7 @@ export default class Routes extends Component {
       ///: BEGIN:ONLY_INCLUDE_IN(keyring-snaps)
       isShowKeyringSnapRemovalResultModal,
       hideShowKeyringSnapRemovalResultModal,
+      pendingConfirmations,
       ///: END:ONLY_INCLUDE_IN
     } = this.props;
 
@@ -616,6 +621,23 @@ export default class Routes extends Component {
       windowType !== ENVIRONMENT_TYPE_NOTIFICATION &&
       isUnlocked &&
       !shouldShowSeedPhraseReminder;
+
+    let shouldShowLoadingPage = isLoading;
+
+    ///: BEGIN:ONLY_INCLUDE_IN(keyring-snaps)
+    shouldShowLoadingPage =
+      isLoading &&
+      !pendingConfirmations.type ===
+        SNAP_MANAGE_ACCOUNTS_CONFIRMATION_TYPES.showSnapAccountRedirect;
+    ///: END:ONLY_INCLUDE_IN
+
+    console.log(
+      'SNAPS/ shouldShowLoadingPage',
+      shouldShowLoadingPage,
+      JSON.stringify(pendingConfirmations, 2, null),
+      !pendingConfirmations.type ===
+        SNAP_MANAGE_ACCOUNTS_CONFIRMATION_TYPES.showSnapAccountRedirect,
+    );
 
     return (
       <div
@@ -669,7 +691,9 @@ export default class Routes extends Component {
           ///: END:ONLY_INCLUDE_IN
         }
         <Box className="main-container-wrapper">
-          {isLoading ? <Loading loadingMessage={loadMessage} /> : null}
+          {shouldShowLoadingPage ? (
+            <Loading loadingMessage={loadMessage} />
+          ) : null}
           {!isLoading && isNetworkLoading ? <LoadingNetwork /> : null}
           {this.renderRoutes()}
         </Box>

--- a/ui/pages/routes/routes.component.js
+++ b/ui/pages/routes/routes.component.js
@@ -622,22 +622,14 @@ export default class Routes extends Component {
       isUnlocked &&
       !shouldShowSeedPhraseReminder;
 
-    let shouldShowLoadingPage = isLoading;
+    let isLoadingShown = isLoading;
 
     ///: BEGIN:ONLY_INCLUDE_IN(keyring-snaps)
-    shouldShowLoadingPage =
+    isLoadingShown =
       isLoading &&
       !pendingConfirmations.type ===
         SNAP_MANAGE_ACCOUNTS_CONFIRMATION_TYPES.showSnapAccountRedirect;
     ///: END:ONLY_INCLUDE_IN
-
-    console.log(
-      'SNAPS/ shouldShowLoadingPage',
-      shouldShowLoadingPage,
-      JSON.stringify(pendingConfirmations, 2, null),
-      !pendingConfirmations.type ===
-        SNAP_MANAGE_ACCOUNTS_CONFIRMATION_TYPES.showSnapAccountRedirect,
-    );
 
     return (
       <div
@@ -691,9 +683,7 @@ export default class Routes extends Component {
           ///: END:ONLY_INCLUDE_IN
         }
         <Box className="main-container-wrapper">
-          {shouldShowLoadingPage ? (
-            <Loading loadingMessage={loadMessage} />
-          ) : null}
+          {isLoadingShown ? <Loading loadingMessage={loadMessage} /> : null}
           {!isLoading && isNetworkLoading ? <LoadingNetwork /> : null}
           {this.renderRoutes()}
         </Box>

--- a/ui/pages/routes/routes.component.js
+++ b/ui/pages/routes/routes.component.js
@@ -627,7 +627,7 @@ export default class Routes extends Component {
     ///: BEGIN:ONLY_INCLUDE_IN(keyring-snaps)
     isLoadingShown =
       isLoading &&
-      !pendingConfirmations.type ===
+      pendingConfirmations.type !==
         SNAP_MANAGE_ACCOUNTS_CONFIRMATION_TYPES.showSnapAccountRedirect;
     ///: END:ONLY_INCLUDE_IN
 

--- a/ui/pages/routes/routes.component.js
+++ b/ui/pages/routes/routes.component.js
@@ -182,7 +182,7 @@ export default class Routes extends Component {
     ///: BEGIN:ONLY_INCLUDE_IN(keyring-snaps)
     isShowKeyringSnapRemovalResultModal: PropTypes.bool.isRequired,
     hideShowKeyringSnapRemovalResultModal: PropTypes.func.isRequired,
-    pendingConfirmations: PropTypes.object.isRequired,
+    pendingConfirmations: PropTypes.array.isRequired,
     ///: END:ONLY_INCLUDE_IN
   };
 

--- a/ui/pages/routes/routes.component.js
+++ b/ui/pages/routes/routes.component.js
@@ -627,8 +627,11 @@ export default class Routes extends Component {
     ///: BEGIN:ONLY_INCLUDE_IN(keyring-snaps)
     isLoadingShown =
       isLoading &&
-      pendingConfirmations.type !==
-        SNAP_MANAGE_ACCOUNTS_CONFIRMATION_TYPES.showSnapAccountRedirect;
+      !pendingConfirmations.some(
+        (confirmation) =>
+          confirmation.type ===
+          SNAP_MANAGE_ACCOUNTS_CONFIRMATION_TYPES.showSnapAccountRedirect,
+      );
     ///: END:ONLY_INCLUDE_IN
 
     return (

--- a/ui/pages/routes/routes.container.js
+++ b/ui/pages/routes/routes.container.js
@@ -12,6 +12,9 @@ import {
   getCurrentChainId,
   getShouldShowSeedPhraseReminder,
   isCurrentProviderCustom,
+  ///: BEGIN:ONLY_INCLUDE_IN(keyring-snaps)
+  getUnapprovedConfirmations,
+  ///: END:ONLY_INCLUDE_IN
 } from '../../selectors';
 import {
   lockMetamask,
@@ -78,6 +81,7 @@ function mapStateToProps(state) {
     ///: BEGIN:ONLY_INCLUDE_IN(keyring-snaps)
     isShowKeyringSnapRemovalResultModal:
       state.appState.showKeyringRemovalSnapModal,
+    pendingConfirmations: getUnapprovedConfirmations(state),
     ///: END:ONLY_INCLUDE_IN
   };
 }

--- a/ui/pages/swaps/prepare-swap-page/smart-transactions-popover.tsx
+++ b/ui/pages/swaps/prepare-swap-page/smart-transactions-popover.tsx
@@ -71,10 +71,10 @@ export default function SmartTransactionsPopover({
             marginBottom={3}
             style={{ listStyle: 'inside' }}
           >
-            <li>{t('stxBenefit1')}</li>
-            <li>{t('stxBenefit2')}</li>
-            <li>{t('stxBenefit3')}</li>
-            <li>
+            <li key="stxBenefit1">{t('stxBenefit1')}</li>
+            <li key="stxBenefit2">{t('stxBenefit2')}</li>
+            <li key="stxBenefit3">{t('stxBenefit3')}</li>
+            <li key="stxBenefit4">
               {t('stxBenefit4')}
               <Text as="span" fontWeight={FontWeight.Normal}>
                 {' *'}
@@ -88,6 +88,7 @@ export default function SmartTransactionsPopover({
                 href={SMART_SWAPS_FAQ_AND_RISK_DISCLOSURES_URL}
                 externalLink
                 display={Display.Inline}
+                key="smartSwapsDescription2"
               >
                 {t('faqAndRiskDisclosures')}
               </ButtonLink>,


### PR DESCRIPTION
## **Description**
Prior to this change, the transaction spinner would load infinitely when an snap account send a transaction in async mode. This is a problem for multi party compute snaps since we prompt the user to complete the signing of the transaction on the snap website. This new change detects if the approval modal is open and then hides the spinner. 

This is an example response for the pending confirmations

```js
[
    {
        "id": "b7749d90-8341-11ee-82f4-c904b44c9d3f",
        "origin": "metamask",
        "type": "showSnapAccountRedirect",
        "time": 1700002876919,
        "requestData": {
            "txId": "b7749d90-8341-11ee-82f4-c904b44c9d3f"
        },
        "requestState": null,
        "expectsResult": true
    }
]
```

I was able to show/hide the spinner by checking if any of the sub objects within the pendingConfirmations array contained the type `showSnapAccountRedirect`

## **Related issues**

Fixes: #

## **Manual testing steps**

1. You will need an account with funds to test this change. Test net funds suffice.
2. Navigate to the snap simple keyring site: https://metamask.github.io/snap-simple-keyring/1.0.1/
3. Create an account, the extension should prompt you to allow this account addition. accept this approval flow. 
4. open the extension, and click the account list at the top. you should see a new account in your list with the tag `Snaps (Beta)`
5. Fund this new account by sending a small amount of funds to your new snap account
6. Navigate back to the Snap Simple Keyring site: https://metamask.github.io/snap-simple-keyring/1.0.1/
7. Turn off `Use Synchronous Approval` so that the toggle is grey

<img width="319" alt="Screenshot 2023-10-31 at 3 15 46 PM" src="https://github.com/MetaMask/metamask-extension/assets/22918444/6061a916-5791-471e-bbf9-597bdffcf021">

9. Navigate back to the extension, select your new snap account and send a transaction (assuming you have funded this new account)
10. Confirm the transaction
11. `The spinner should only load for a second`
12. there should be an approval pop up triggered that prompts you to redirect to the `Snap Simple Keyring` site
13. you can approve the transaction by clicking `list request` on the Snap Simple Keyring site, copying the `request id` and pasting it into the `Approve request` box.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

https://github.com/MetaMask/metamask-extension/assets/22918444/da6489f6-0613-4f5f-8da8-f654eaf6e35d

### **After**


https://github.com/MetaMask/metamask-extension/assets/22918444/813a3c2f-7a03-495e-ba52-c5a118216ec0



## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained what problem this PR is solving and how it is solved.
- [ ] I've linked related issues
- [x] I've included manual testing steps
- [x] I've included screenshots/recordings if applicable
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [x] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [x] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
