### PR TITLE
Mocking IPFS requests on erc1155 tests

### DIFF
--- a/test/e2e/tests/nft/remove-erc1155.spec.js
+++ b/test/e2e/tests/nft/remove-erc1155.spec.js
@@ -7,6 +7,16 @@ const {
 const { SMART_CONTRACTS } = require('../../seeder/smart-contracts');
 const FixtureBuilder = require('../../fixture-builder');
 
+async function mockIPFSRequest(mockServer) {
+  return [
+    await mockServer
+      .forGet(
+        'https://bafkreifvhjdf6ve4jfv6qytqtux5nd4nwnelioeiqx5x2ez5yrgrzk7ypi.ipfs.dweb.link/',
+      )
+      .thenCallback(() => ({ statusCode: 200 })),
+  ];
+}
+
 describe('Remove ERC1155 NFT', function () {
   const smartContract = SMART_CONTRACTS.ERC1155;
   const ganacheOptions = {
@@ -27,6 +37,7 @@ describe('Remove ERC1155 NFT', function () {
         ganacheOptions,
         smartContract,
         title: this.test.fullTitle(),
+        testSpecificMock: mockIPFSRequest,
       },
       async ({ driver }) => {
         await driver.navigate();

--- a/test/e2e/tests/nft/view-erc1155-details.spec.js
+++ b/test/e2e/tests/nft/view-erc1155-details.spec.js
@@ -2,10 +2,19 @@ const {
   convertToHexValue,
   withFixtures,
   unlockWallet,
-  regularDelayMs,
 } = require('../../helpers');
 const { SMART_CONTRACTS } = require('../../seeder/smart-contracts');
 const FixtureBuilder = require('../../fixture-builder');
+
+async function mockIPFSRequest(mockServer) {
+  return [
+    await mockServer
+      .forGet(
+        'https://bafkreifvhjdf6ve4jfv6qytqtux5nd4nwnelioeiqx5x2ez5yrgrzk7ypi.ipfs.dweb.link/',
+      )
+      .thenCallback(() => ({ statusCode: 200 })),
+  ];
+}
 
 describe('View ERC1155 NFT details', function () {
   const smartContract = SMART_CONTRACTS.ERC1155;
@@ -27,6 +36,7 @@ describe('View ERC1155 NFT details', function () {
         ganacheOptions,
         smartContract,
         title: this.test.fullTitle(),
+        testSpecificMock: mockIPFSRequest,
       },
       async ({ driver }) => {
         await driver.navigate();
@@ -35,8 +45,6 @@ describe('View ERC1155 NFT details', function () {
         // Click to open the NFT details page and check displayed account
         await driver.clickElement('[data-testid="home__nfts-tab"]');
 
-        // wait for the image to load
-        await driver.delay(regularDelayMs);
         await driver.clickElement('.nft-item__container');
 
         await driver.findElement({


### PR DESCRIPTION
## **Description**

Previously, on #21628, a delay to await image load was introduced to fix the flakiness on the `user should be able to view ERC1155 NFT details` test. This PR changes the fix to mocking the IPFS response and adds a mock to the `user should be able to remove ERC1155 NFT on details page` test too.

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've clearly explained what problem this PR is solving and how it is solved.
- [ ] I've linked related issues
- [ ] I've included manual testing steps
- [ ] I've included screenshots/recordings if applicable
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [ ] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
