### PR TITLE
UX: Send flow:  Wire submit button

### DIFF
--- a/ui/components/multichain/pages/send/__snapshots__/send.test.js.snap
+++ b/ui/components/multichain/pages/send/__snapshots__/send.test.js.snap
@@ -903,8 +903,7 @@ exports[`SendPage render renders correctly 1`] = `
         Cancel
       </button>
       <button
-        class="mm-box mm-text mm-button-base mm-button-base--size-lg mm-button-base--disabled mm-button-base--block mm-button-primary mm-button-primary--disabled mm-text--body-md-medium mm-box--padding-0 mm-box--padding-right-4 mm-box--padding-left-4 mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-primary-inverse mm-box--background-color-primary-default mm-box--rounded-pill"
-        disabled=""
+        class="mm-box mm-text mm-button-base mm-button-base--size-lg mm-button-base--block mm-button-primary mm-text--body-md-medium mm-box--padding-0 mm-box--padding-right-4 mm-box--padding-left-4 mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-primary-inverse mm-box--background-color-primary-default mm-box--rounded-pill"
       >
         Confirm
       </button>

--- a/ui/components/multichain/pages/send/send.js
+++ b/ui/components/multichain/pages/send/send.js
@@ -16,13 +16,22 @@ import {
   SEND_STAGES,
   getDraftTransactionExists,
   getDraftTransactionID,
+  getSendErrors,
   getSendStage,
+  isSendFormInvalid,
   resetSendState,
+  signTransaction,
   startNewDraftTransaction,
 } from '../../../../ducks/send';
 import { AssetType } from '../../../../../shared/constants/transaction';
+import { MetaMetricsContext } from '../../../../contexts/metametrics';
+import { INSUFFICIENT_FUNDS_ERROR } from '../../../../pages/send/send.constants';
 import { cancelTx, showQrScanner } from '../../../../store/actions';
-import { DEFAULT_ROUTE } from '../../../../helpers/constants/routes';
+import {
+  CONFIRM_TRANSACTION_ROUTE,
+  DEFAULT_ROUTE,
+} from '../../../../helpers/constants/routes';
+import { MetaMetricsEventCategory } from '../../../../../shared/constants/metametrics';
 import { getMostRecentOverviewPage } from '../../../../ducks/history/history';
 import {
   SendPageAccountPicker,
@@ -43,6 +52,7 @@ export const SendPage = () => {
 
   const history = useHistory();
   const location = useLocation();
+  const trackEvent = useContext(MetaMetricsContext);
 
   const cleanup = useCallback(() => {
     dispatch(resetSendState());
@@ -87,7 +97,7 @@ export const SendPage = () => {
     };
   }, [dispatch, cleanup]);
 
-  const onCancel = useCallback(() => {
+  const onCancel = () => {
     if (draftTransactionID) {
       dispatch(cancelTx({ id: draftTransactionID }));
     }
@@ -96,7 +106,29 @@ export const SendPage = () => {
     const nextRoute =
       sendStage === SEND_STAGES.EDIT ? DEFAULT_ROUTE : mostRecentOverviewPage;
     history.push(nextRoute);
-  });
+  };
+
+  const onSubmit = async (event) => {
+    event.preventDefault();
+
+    await dispatch(signTransaction());
+
+    trackEvent({
+      category: MetaMetricsEventCategory.Transactions,
+      event: 'Complete',
+      properties: {
+        action: 'Edit Screen',
+        legacy_event: true,
+      },
+    });
+    history.push(CONFIRM_TRANSACTION_ROUTE);
+  };
+
+  // Submit button
+  const sendErrors = useSelector(getSendErrors);
+  const isInvalidSendForm = useSelector(isSendFormInvalid);
+  const submitDisabled =
+    isInvalidSendForm && sendErrors.gasFee !== INSUFFICIENT_FUNDS_ERROR;
 
   return (
     <Page className="multichain-send-page">
@@ -122,7 +154,12 @@ export const SendPage = () => {
         <ButtonSecondary onClick={onCancel} size={ButtonSecondarySize.Lg} block>
           {t('cancel')}
         </ButtonSecondary>
-        <ButtonPrimary size={ButtonPrimarySize.Lg} block disabled>
+        <ButtonPrimary
+          onClick={onSubmit}
+          size={ButtonPrimarySize.Lg}
+          disabled={submitDisabled}
+          block
+        >
           {t('confirm')}
         </ButtonPrimary>
       </Footer>


### PR DESCRIPTION
## **Description**

Wires up the Send button's disabled status for the new Send page.

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/1451

## **Manual testing steps**

1. Enter new send flow
2. Select a recipient
3. See the confirm button enabled
4. Submit to see transaction go through

## **Screenshots/Recordings**

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've clearly explained what problem this PR is solving and how it is solved.
- [ ] I've linked related issues
- [ ] I've included manual testing steps
- [ ] I've included screenshots/recordings if applicable
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [ ] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
