### PR TITLE
Fix `Text` `inherit` variant

### DIFF
--- a/ui/components/component-library/text/text.scss
+++ b/ui/components/component-library/text/text.scss
@@ -27,6 +27,14 @@ $text-variants: (
 }
 
 .mm-text {
+  &--inherit {
+    font-family: inherit;
+    font-weight: inherit;
+    font-size: inherit;
+    line-height: inherit;
+    letter-spacing: inherit;
+  }
+
   // Set default styles
   font-family: var(--font-family-sans);
 
@@ -78,13 +86,7 @@ $text-variants: (
     }
   }
 
-  &--inherit {
-    font-family: inherit;
-    font-weight: inherit;
-    font-size: inherit;
-    line-height: inherit;
-    letter-spacing: inherit;
-  }
+
 
   &--ellipsis {
     text-overflow: ellipsis;

--- a/ui/components/component-library/text/text.scss
+++ b/ui/components/component-library/text/text.scss
@@ -27,14 +27,6 @@ $text-variants: (
 }
 
 .mm-text {
-  &--inherit {
-    font-family: inherit;
-    font-weight: inherit;
-    font-size: inherit;
-    line-height: inherit;
-    letter-spacing: inherit;
-  }
-
   // Set default styles
   font-family: var(--font-family-sans);
 
@@ -54,6 +46,14 @@ $text-variants: (
         }
       }
     }
+  }
+
+  &--inherit {
+    font-family: inherit;
+    font-weight: inherit;
+    font-size: inherit;
+    line-height: inherit;
+    letter-spacing: inherit;
   }
 
   @each $weight in $font-weight {


### PR DESCRIPTION
## **Description**

This moves the `Text` component `&--inherit` class higher in the CSS hierarchi to avoid it overwriting any passed props.

## **Related issues**

Fixes: #21626 

## **Manual testing steps**

1. Create a `Text` component with a `bodyMd` variant and add a `fontWeight` prop (like `bold`)
2. Observe in the console the `font-weight` attribute you just set not being overwrited by `inherit`

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've clearly explained what problem this PR is solving and how it is solved.
- [ ] I've linked related issues
- [ ] I've included manual testing steps
- [ ] I've included screenshots/recordings if applicable
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [ ] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
