### PR TITLE
e2e: fixing the test-e2e-chrome-mmi problem from forks

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "benchmark:firefox": "SELENIUM_BROWSER=firefox ts-node test/e2e/benchmark.js",
     "build:test": "BLOCKAID_FILE_CDN=static.metafi-dev.codefi.network/api/v1/confirmations/ppom SEGMENT_HOST='https://api.segment.io' SEGMENT_WRITE_KEY='FAKE' SENTRY_DSN_DEV=https://fake@sentry.io/0000000 yarn build test",
     "build:test:flask": "yarn build test --build-type flask",
-    "build:test:mmi": "yarn build test --build-type mmi",
+    "build:test:mmi": "SEGMENT_HOST='https://api.segment.io' SEGMENT_WRITE_KEY='FAKE' yarn build test --build-type mmi",
     "build:test:mv3": "ENABLE_MV3=true SEGMENT_HOST='https://api.segment.io' SEGMENT_WRITE_KEY='FAKE' SENTRY_DSN_DEV=https://fake@sentry.io/0000000 yarn build test",
     "build:test:dev:mv3": "ENABLE_MV3=true SEGMENT_HOST='https://api.segment.io' SEGMENT_WRITE_KEY='FAKE' SENTRY_DSN_DEV=https://fake@sentry.io/0000000 yarn build:dev testDev --apply-lavamoat=false",
     "test": "yarn lint && yarn test:unit && yarn test:unit:jest",


### PR DESCRIPTION
## **Description**

All PRs from forks are failing on the build job `test-e2e-chrome-mmi`, specifically on `test/e2e/tests/metrics/unlock-wallet.spec.js`.  They are failing because the MetaMetrics env variables were not set if you're on a fork.

So I added `SEGMENT_HOST='https://api.segment.io' SEGMENT_WRITE_KEY='FAKE'` to `build:test:mmi`

This PR itself is deliberately from a fork.