### PR TITLE
Fix `AvatarAccount` type

### DIFF
--- a/ui/components/component-library/avatar-account/avatar-account.types.ts
+++ b/ui/components/component-library/avatar-account/avatar-account.types.ts
@@ -23,7 +23,7 @@ export const AvatarAccountDiameter: Record<AvatarAccountSize, number> = {
 };
 
 export interface AvatarAccountStyleUtilityProps
-  extends Omit<AvatarBaseStyleUtilityProps, 'size' | 'variant'> {
+  extends Omit<AvatarBaseStyleUtilityProps, 'size' | 'variant' | 'children'> {
   /**
    * The size of the AvatarAccount.
    * Possible values could be 'AvatarAccountSize.Xs', 'AvatarAccountSize.Sm', 'AvatarAccountSize.Md', 'AvatarAccountSize.Lg', 'AvatarAccountSize.Xl'


### PR DESCRIPTION
## **Description**

Fixes a type issue with `AvatarAccount`. Since it inherits props from `AvatarBase` it expects `children`:
```
error TS2741: Property 'children' is missing in type '{ address: string; size: AvatarAccountSize.Xs; borderColor: BorderColor.transparent; }' but required in type 'AvatarAccountStyleUtilityProps'.
````

This PR fixes that!