### PR TITLE
Resolve network names using SLIP44 when applicable

### DIFF
--- a/ui/helpers/utils/util.js
+++ b/ui/helpers/utils/util.js
@@ -591,7 +591,23 @@ export function getSnapDerivationPathName(path, curve) {
       lodash.isEqual(derivationPath.path, path),
   );
 
-  return pathMetadata?.name ?? null;
+  if (pathMetadata) {
+    return pathMetadata.name;
+  }
+
+  // If the curve is secp256k1 and the path is a valid BIP44 path
+  // we try looking for the network/protocol name in SLIP44
+  if (
+    curve === 'secp256k1' &&
+    path[0] === 'm' &&
+    path[1] === `44'` &&
+    path[2].endsWith(`'`)
+  ) {
+    const coinType = path[2].slice(0, -1);
+    return coinTypeToProtocolName(coinType) ?? null;
+  }
+
+  return null;
 }
 
 export const removeSnapIdPrefix = (snapId) =>


### PR DESCRIPTION
## **Description**

Resolve network names using SLIP44 when using `snap_getBip32Entropy` if the derivation path purpose is `44`. This effectively reduces the overhead of maintaining the `SNAPS_DERIVATION_PATHS` list and prevents confusion with unknown paths.

This does not need additional QA at release.

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/21673

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
<img width="363" alt="Screenshot 2023-11-03 at 11 26 43" src="https://github.com/MetaMask/metamask-extension/assets/1561200/e99b2bed-c8ba-424d-8f6e-5ec944ca2f9c">

<!-- [screenshots/recordings] -->

### **After**
<img width="367" alt="Screenshot 2023-11-03 at 11 25 26" src="https://github.com/MetaMask/metamask-extension/assets/1561200/a52eed72-c9c0-496a-8300-1c9255f4ada5">

<!-- [screenshots/recordings] -->