### PR TITLE
Fix: Remove Unnecessary sync calls in _onKeyringControllerUpdate

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -4601,27 +4601,11 @@ export default class MetamaskController extends EventEmitter {
    * @private
    */
   async _onKeyringControllerUpdate(state) {
-    const {
-      keyrings,
-      encryptionKey: loginToken,
-      encryptionSalt: loginSalt,
-    } = state;
-    const addresses = keyrings.reduce(
-      (acc, { accounts }) => acc.concat(accounts),
-      [],
-    );
+    const { encryptionKey: loginToken, encryptionSalt: loginSalt } = state;
 
     if (isManifestV3) {
       await this.extension.storage.session.set({ loginToken, loginSalt });
     }
-
-    if (!addresses.length) {
-      return;
-    }
-
-    // Ensure preferences + identities controller know about all addresses
-    this.preferencesController.syncAddresses(addresses);
-    this.accountTracker.syncWithAddresses(addresses);
   }
 
   /**


### PR DESCRIPTION
## **Description**

This PR removes an unnecessary sync calls in `_onKeyringControllerUpdate`, the PreferencesController and AccountTracker currently already subscribes to the keyring state change.

Subscriptions were added in this PR.
https://github.com/MetaMask/metamask-extension/pull/20478

## **Related issues**

## **Manual testing steps**

## **Screenshots/Recordings**

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained what problem this PR is solving and how it is solved.
- [ ] I've linked related issues
- [ ] I've included manual testing steps
- [ ] I've included screenshots/recordings if applicable
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [x] I’ve properly set the pull request status:
  - [] In case it's not yet "ready for review", I've set it to "draft".
  - [x] In case it's "ready for review", I've changed it from "draft" to "non-draft".
