### PR TITLE
Fix flakiness on `user-actions-benchmark.js`

### DIFF
--- a/test/e2e/user-actions-benchmark.js
+++ b/test/e2e/user-actions-benchmark.js
@@ -11,6 +11,7 @@ const {
   convertToHexValue,
   withFixtures,
   openActionMenuAndStartSendFlow,
+  logInWithBalanceValidation,
 } = require('./helpers');
 const FixtureBuilder = require('./fixture-builder');
 
@@ -65,10 +66,9 @@ async function confirmTx() {
       fixtures: new FixtureBuilder().build(),
       ganacheOptions,
     },
-    async ({ driver }) => {
+    async ({ driver, ganacheServer }) => {
       await driver.navigate();
-      await driver.fill('#password', 'correct horse battery staple');
-      await driver.press('#password', driver.Key.ENTER);
+      await logInWithBalanceValidation(driver, ganacheServer);
 
       await openActionMenuAndStartSendFlow(driver);
       if (process.env.MULTICHAIN) {
@@ -82,8 +82,12 @@ async function confirmTx() {
       const inputAmount = await driver.findElement('.unit-input__input');
       await inputAmount.fill('1');
 
+      await driver.waitForSelector({ text: 'Next', tag: 'button' });
       await driver.clickElement({ text: 'Next', tag: 'button' });
+
       const timestampBeforeAction = new Date();
+
+      await driver.waitForSelector({ text: 'Confirm', tag: 'button' });
       await driver.clickElement({ text: 'Confirm', tag: 'button' });
 
       await driver.clickElement('[data-testid="home__activity-tab"]');


### PR DESCRIPTION
## **Description**

`user-actions-benchmark.js` failed roughly 20% of the time due to a race condition that meant the ganache balance was undefined before the test started. This caused insufficient balance errors.

<img width="640" alt="Screenshot 2023-11-03 at 10 46 51" src="https://github.com/MetaMask/metamask-extension/assets/13814744/00f79861-51c6-4fd1-b7e1-81dd98878469">

The fix is awaiting the ganache balance after unlocking the wallet using `logInWithBalanceValidation()` such as is used in `test/e2e/tests/send-eth.spec.js`.