### PR TITLE
Optimize markAllAsRead fn for unread notifications

### DIFF
--- a/ui/pages/notifications/notifications.js
+++ b/ui/pages/notifications/notifications.js
@@ -77,7 +77,9 @@ export default function Notifications() {
   const markAllAsRead = () => {
     const unreadNotificationIds = unreadNotifications.map(({ id }) => id);
 
-    dispatch(markNotificationsAsRead(unreadNotificationIds));
+    if (unreadNotificationIds.length > 0) {
+      dispatch(markNotificationsAsRead(unreadNotificationIds));
+    }
   };
 
   const markAsRead = (notificationToMark) => {


### PR DESCRIPTION
## **Description**

1. Refactored the 'markAllAsRead' function for improved efficiency.
2. Added a check to ensure the 'dispatch' action is only called when there are unread notifications.


## **Related issues**

Fixes: #

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've clearly explained what problem this PR is solving and how it is solved.
- [ ] I've linked related issues
- [ ] I've included manual testing steps
- [ ] I've included screenshots/recordings if applicable
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [ ] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
