### PR TITLE
e2e: fixing automatic installation of webdriver

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -824,9 +824,6 @@ jobs:
           name: Move test zips to builds
           command: mv ./builds-test ./builds
       - run:
-          name: Activate Selenium Manager for Chrome
-          command: node_modules/selenium-webdriver/bin/linux/selenium-manager --browser chrome
-      - run:
           name: test:e2e:chrome
           command: |
             if .circleci/scripts/test-run-e2e.sh
@@ -854,9 +851,6 @@ jobs:
           name: Move test zips to builds
           command: mv ./builds-test-multichain ./builds
       - run:
-          name: Activate Selenium Manager for Chrome
-          command: node_modules/selenium-webdriver/bin/linux/selenium-manager --browser chrome
-      - run:
           name: test:e2e:chrome-multichain
           command: |
             if .circleci/scripts/test-run-e2e.sh
@@ -869,6 +863,7 @@ jobs:
           destination: test-artifacts
       - store_test_results:
           path: test/test-results/e2e
+
   test-e2e-chrome-mv3:
     executor: node-browsers-large
     parallelism: 24
@@ -882,9 +877,6 @@ jobs:
       - run:
           name: Move test zips to builds
           command: mv ./builds-test-mv3 ./builds
-      - run:
-          name: Activate Selenium Manager for Chrome
-          command: node_modules/selenium-webdriver/bin/linux/selenium-manager --browser chrome
       - run:
           name: test:e2e:chrome
           command: |
@@ -911,9 +903,6 @@ jobs:
           name: Move test zips to builds
           command: mv ./builds-test ./builds
       - run:
-          name: Activate Selenium Manager for Chrome
-          command: node_modules/selenium-webdriver/bin/linux/selenium-manager --browser chrome
-      - run:
           name: test:e2e:chrome:rpc
           command: |
             if .circleci/scripts/test-run-e2e.sh
@@ -939,9 +928,6 @@ jobs:
       - run:
           name: Move test zips to builds
           command: mv ./builds-test-mmi ./builds
-      - run:
-          name: Activate Selenium Manager for Chrome
-          command: node_modules/selenium-webdriver/bin/linux/selenium-manager --browser chrome
       - run:
           name: test:e2e:chrome:rpc
           command: |
@@ -970,9 +956,6 @@ jobs:
           name: Move test zips to builds
           command: mv ./builds-test-flask ./builds
       - run:
-          name: Activate Selenium Manager for Firefox
-          command: node_modules/selenium-webdriver/bin/linux/selenium-manager --browser firefox
-      - run:
           name: test:e2e:firefox:flask
           command: |
             if .circleci/scripts/test-run-e2e.sh
@@ -999,9 +982,6 @@ jobs:
       - run:
           name: Move test zips to builds
           command: mv ./builds-test-flask ./builds
-      - run:
-          name: Activate Selenium Manager for Chrome
-          command: node_modules/selenium-webdriver/bin/linux/selenium-manager --browser chrome
       - run:
           name: test:e2e:chrome:flask
           command: |
@@ -1030,9 +1010,6 @@ jobs:
           name: Move test zips to builds
           command: mv ./builds-test-mmi ./builds
       - run:
-          name: Activate Selenium Manager for Chrome
-          command: node_modules/selenium-webdriver/bin/linux/selenium-manager --browser chrome
-      - run:
           name: test:e2e:chrome:mmi
           command: |
             if .circleci/scripts/test-run-e2e.sh
@@ -1060,9 +1037,6 @@ jobs:
           name: Move test zips to builds
           command: mv ./builds-test ./builds
       - run:
-          name: Activate Selenium Manager for Firefox
-          command: node_modules/selenium-webdriver/bin/linux/selenium-manager --browser firefox
-      - run:
           name: test:e2e:firefox
           command: |
             if .circleci/scripts/test-run-e2e.sh
@@ -1089,9 +1063,6 @@ jobs:
           name: Move test zips to builds
           command: mv ./builds-test ./builds
       - run:
-          name: Activate Selenium Manager for Chrome
-          command: node_modules/selenium-webdriver/bin/linux/selenium-manager --browser chrome
-      - run:
           name: Run page load benchmark
           command: yarn benchmark:chrome --out test-artifacts/chrome/benchmark/pageload.json --retries 2
       - store_artifacts:
@@ -1115,9 +1086,6 @@ jobs:
           name: Move test zips to builds
           command: mv ./builds-test ./builds
       - run:
-          name: Activate Selenium Manager for Chrome
-          command: node_modules/selenium-webdriver/bin/linux/selenium-manager --browser chrome
-      - run:
           name: Run page load benchmark
           command: yarn user-actions-benchmark:chrome --out test-artifacts/chrome/benchmark/user_actions.json --retries 2
       - store_artifacts:
@@ -1140,9 +1108,6 @@ jobs:
       - run:
           name: Move test zips to builds
           command: mv ./builds-test-mv3 ./builds
-      - run:
-          name: Activate Selenium Manager for Chrome
-          command: node_modules/selenium-webdriver/bin/linux/selenium-manager --browser chrome
       - run:
           name: Run page load benchmark
           command: |

--- a/test/e2e/tests/custom-rpc-history.spec.js
+++ b/test/e2e/tests/custom-rpc-history.spec.js
@@ -160,7 +160,15 @@ describe('Stores custom RPC history', function () {
         });
 
         await rpcUrlInput.clear();
-        await rpcUrlInput.sendKeys(newRpcUrl);
+
+        // We cannot use sendKeys() here, because a network request will be fired after each
+        // keypress, and the privacy snapshot will show:
+        // `New hosts found: l,lo,loc,loca,local,localh,localho,localhos`
+        // In the longer term, we may want to debounce this
+        await driver.pasteIntoField(
+          '.form-field:nth-of-type(2) input[type="text"]',
+          newRpcUrl,
+        );
 
         await driver.findElement({
           text: 'Could not fetch chain ID. Is your RPC URL correct?',

--- a/test/e2e/webdriver/chrome.js
+++ b/test/e2e/webdriver/chrome.js
@@ -1,6 +1,5 @@
 const { Builder } = require('selenium-webdriver');
 const chrome = require('selenium-webdriver/chrome');
-const proxy = require('selenium-webdriver/proxy');
 const { ThenableWebDriver } = require('selenium-webdriver'); // eslint-disable-line no-unused-vars -- this is imported for JSDoc
 
 /**
@@ -15,7 +14,10 @@ const HTTPS_PROXY_HOST = '127.0.0.1:8000';
  */
 class ChromeDriver {
   static async build({ openDevToolsForTabs, port }) {
-    const args = [`load-extension=${process.cwd()}/dist/chrome`];
+    const args = [
+      `load-extension=${process.cwd()}/dist/chrome`,
+      `--proxy-server=${HTTPS_PROXY_HOST}`, // Set proxy in the way that doesn't interfere with Selenium Manager
+    ];
     if (openDevToolsForTabs) {
       args.push('--auto-open-devtools-for-tabs');
     }
@@ -28,7 +30,6 @@ class ChromeDriver {
       args.push('--log-level=3');
     }
     const options = new chrome.Options().addArguments(args);
-    options.setProxy(proxy.manual({ https: HTTPS_PROXY_HOST }));
     options.setAcceptInsecureCerts(true);
     options.setUserPreferences({
       'download.default_directory': `${process.cwd()}/test-artifacts/downloads`,


### PR DESCRIPTION
## **Description**

Before this PR, to run E2E locally, most people had to run this or similar
`node_modules/selenium-webdriver/bin/macos/selenium-manager --browser chrome`

But actually Selenium Manager is **supposed** to be automatic, and just transparently work.

After some investigation, I determined the problem to be the proxy.  Selenium Manager was trying to download the drivers through the proxy, and it wasn't working.

I changed the format of the proxy from `options.setProxy` to individual Chrome and Firefox options, and it works now.

## **Related issues**

This is an alternative to #21688 

## **Manual testing steps**

1. Delete your `~/.cache/selenium` folder (if you don't do this, you're not properly testing Selenium Manager, and the chromedriver/geckodriver may already be there)
2. Run your favorite E2E test on both Firefox and Chrome

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained what problem this PR is solving and how it is solved.
- [x] I've linked related issues
- [x] I've included manual testing steps
- [ ] I've included screenshots/recordings if applicable
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [x] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [x] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
