### PR TITLE
add popover onClickOutside

### DIFF
--- a/ui/components/component-library/popover/README.mdx
+++ b/ui/components/component-library/popover/README.mdx
@@ -200,6 +200,24 @@ const handleClick = () => {
 </Popover>;
 ```
 
+### onClickOutside
+
+`onClickOutside` is a callback function that is invoked when the user clicks outside of the `Popover` component
+
+```jsx
+import { Popover } from '../../component-library';
+
+const [isOpen, setIsOpen] = useState(false);
+
+const handleClick = () => {
+  setIsOpen(!isOpen);
+};
+
+<Popover onClickOutside={() => setIsOpen(false)}>
+  Press esc key to close
+</Popover>;
+```
+
 ### With PopoverHeader
 
 Using the `PopoverHeader` component to add a header to the `Popover` component. The `PopoverHeader` is used to show common elements such as title, back button, and close button.

--- a/ui/components/component-library/popover/popover.stories.tsx
+++ b/ui/components/component-library/popover/popover.stories.tsx
@@ -769,6 +769,49 @@ export const OnPressEscKey: StoryFn<typeof Popover> = (args) => {
   );
 };
 
+export const OnClickOutside: StoryFn<typeof Popover> = (args) => {
+  const [referenceElement, setReferenceElement] = useState();
+  const [isOpen, setIsOpen] = useState(false);
+
+  // Set Popover Ref
+  const setBoxRef = (ref) => {
+    setReferenceElement(ref);
+  };
+
+  const handleClick = () => {
+    setIsOpen(!isOpen);
+  };
+
+  const handleClickOutside = () => {
+    setIsOpen(false);
+  };
+
+  return (
+    <>
+      <Box
+        ref={setBoxRef}
+        onClick={handleClick}
+        backgroundColor={BackgroundColor.primaryAlternative}
+        style={{ width: 200, height: 200 }}
+        color={TextColor.primaryInverse}
+        as="button"
+      >
+        Click to open
+      </Box>
+      <Popover
+        referenceElement={referenceElement}
+        onClickOutside={handleClickOutside}
+        isOpen={isOpen}
+        {...args}
+      >
+        Click outside to close
+      </Popover>
+    </>
+  );
+};
+
+OnClickOutside.storyName = 'onClickOutside';
+
 export const WithPopoverHeader: StoryFn<typeof Popover> = (args) => {
   const [refTitleElement, setRefTitleElement] = useState();
   const [isOpen, setIsOpen] = useState(true);

--- a/ui/components/component-library/popover/popover.test.tsx
+++ b/ui/components/component-library/popover/popover.test.tsx
@@ -181,73 +181,110 @@ describe('Popover', () => {
       getByTestId('popover').querySelector('.mm-popover__arrow');
     expect(arrowElement).toHaveClass('mm-popover__arrow');
   });
-});
 
-test('should render Popover with isPortal set to false', () => {
-  const { getByTestId } = render(
-    <div>
+  test('should render Popover with isPortal set to false', () => {
+    const { getByTestId } = render(
+      <div>
+        <Popover
+          data-testid="popover"
+          isOpen={true}
+          position={PopoverPosition.Bottom}
+          isPortal={false}
+        >
+          <p>Popover content</p>
+        </Popover>
+      </div>,
+    );
+    // Check that the Popover is rendered inside the body DOM
+    expect(getByTestId('popover')).toBeInTheDocument();
+  });
+
+  test('should render Popover with isPortal set to true', () => {
+    const { getByTestId } = render(
+      <div>
+        <Popover data-testid="popover" isOpen={true} isPortal={true}>
+          <p>Popover content</p>
+        </Popover>
+      </div>,
+    );
+
+    expect(getByTestId('popover')).toBeTruthy();
+  });
+
+  test('should add reference-hidden classname when referenceHidden prop is true', () => {
+    const { getByTestId } = render(
+      <div>
+        <Popover data-testid="popover" isOpen={true} referenceHidden={true}>
+          <p>Popover content</p>
+        </Popover>
+      </div>,
+    );
+
+    expect(getByTestId('popover')).toHaveClass('mm-popover--reference-hidden');
+  });
+
+  const EscKeyTestComponent = () => {
+    const [isOpen, setIsOpen] = useState(true);
+
+    return (
       <Popover
-        data-testid="popover"
-        isOpen={true}
-        position={PopoverPosition.Bottom}
-        isPortal={false}
+        isOpen={isOpen}
+        referenceHidden={false}
+        onPressEscKey={() => setIsOpen(false)}
       >
-        <p>Popover content</p>
+        Press esc key to close
       </Popover>
-    </div>,
-  );
-  // Check that the Popover is rendered inside the body DOM
-  expect(getByTestId('popover')).toBeInTheDocument();
-});
+    );
+  };
 
-test('should render Popover with isPortal set to true', () => {
-  const { getByTestId } = render(
-    <div>
-      <Popover data-testid="popover" isOpen={true} isPortal={true}>
-        <p>Popover content</p>
-      </Popover>
-    </div>,
-  );
+  test('Press esc key to close fires', () => {
+    // Render the component
+    const { getByText, queryByText } = render(<EscKeyTestComponent />);
 
-  expect(getByTestId('popover')).toBeTruthy();
-});
+    // Assert that the popover is initially visible
+    expect(getByText('Press esc key to close')).toBeVisible();
 
-test('should add reference-hidden classname when referenceHidden prop is true', () => {
-  const { getByTestId } = render(
-    <div>
-      <Popover data-testid="popover" isOpen={true} referenceHidden={true}>
-        <p>Popover content</p>
-      </Popover>
-    </div>,
-  );
+    // Trigger the "Escape" key press event
+    fireEvent.keyDown(document, { key: 'Escape' });
 
-  expect(getByTestId('popover')).toHaveClass('mm-popover--reference-hidden');
-});
+    // Assert that the popover closes
+    expect(queryByText('Press esc key to close')).not.toBeInTheDocument();
+  });
 
-const EscKeyTestComponent = () => {
-  const [isOpen, setIsOpen] = useState(true);
+  const ClickOutsideTestComponent = () => {
+    const [isOpen, setIsOpen] = useState(true);
 
-  return (
-    <Popover
-      isOpen={isOpen}
-      referenceHidden={false}
-      onPressEscKey={() => setIsOpen(false)}
-    >
-      Press esc key to close
-    </Popover>
-  );
-};
+    const handleOnClickOutside = () => {
+      setIsOpen(false);
+    };
 
-test('Press esc key to close fires', () => {
-  // Render the component
-  const { getByText, queryByText } = render(<EscKeyTestComponent />);
+    return (
+      <div>
+        <Popover
+          isOpen={isOpen}
+          referenceHidden={false}
+          onClickOutside={handleOnClickOutside}
+        >
+          Click outside to close
+        </Popover>
+        <div data-testid="outside-click-target">Click outside</div>
+      </div>
+    );
+  };
 
-  // Assert that the popover is initially visible
-  expect(getByText('Press esc key to close')).toBeVisible();
+  test('Close popover when clicking outside using onClickOutside prop', () => {
+    const { getByText, getByTestId, queryByText } = render(
+      <ClickOutsideTestComponent />,
+    );
 
-  // Trigger the "Escape" key press event
-  fireEvent.keyDown(document, { key: 'Escape' });
+    // Assert that the popover is initially open
+    expect(getByText('Click outside to close')).toBeVisible();
 
-  // Assert that the popover closes
-  expect(queryByText('Press esc key to close')).not.toBeInTheDocument();
+    // Simulate a click event outside the popover
+    const outsideClickTarget = getByTestId('outside-click-target');
+    fireEvent.click(outsideClickTarget);
+
+    // Assert that the popover is closed after the click event
+    expect(queryByText('Click outside to close')).not.toBeInTheDocument();
+  });
 });

--- a/ui/components/component-library/popover/popover.types.ts
+++ b/ui/components/component-library/popover/popover.types.ts
@@ -96,6 +96,10 @@ export interface PopoverStyleUtilityProps extends StyleUtilityProps {
    * Pass a close function for the escape key callback to close the Popover
    */
   onPressEscKey?: () => void;
+  /**
+   * On click outside callback to close the Popover
+   */
+  onClickOutside?: () => void;
 }
 
 export type PopoverProps<C extends React.ElementType> =


### PR DESCRIPTION
## **Description**
Add additional functionality to Popover component to support an onClickOutside callback to give the dev more flexibility on the state of when the Popover should be opened and closed.

## **Related issues**

Fixes: #21732 

## **Manual testing steps**

1. Run localhost of this PR
2. Visit http://localhost:6006/?path=/story/components-componentlibrary-popover--on-click-outside
3. Click to open Popover
4. Click Popover to confirm it DOES **NOT** close
5. Click somewhere outside of the Popover to confirm it DOES close

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
n/a
<!-- [screenshots/recordings] -->

### **After**

https://github.com/MetaMask/metamask-extension/assets/26469696/7ffff799-e7c8-4ae6-9cfc-5fa9a2916451


<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [X] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've clearly explained what problem this PR is solving and how it is solved.
- [X] I've linked related issues
- [x] I've included manual testing steps
- [x] I've included screenshots/recordings if applicable
- [x] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [x] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [x] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
