### PR TITLE
[MMI] show unsupported networks message in address tooltip

### DIFF
--- a/ui/components/multichain/address-copy-button/address-copy-button.js
+++ b/ui/components/multichain/address-copy-button/address-copy-button.js
@@ -2,9 +2,11 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { toChecksumHexAddress } from '@metamask/controller-utils';
+///: BEGIN:ONLY_INCLUDE_IN(build-mmi)
 import { useSelector } from 'react-redux';
 import { getIsCustodianSupportedChain } from '../../../selectors/institutional/selectors';
 import { getProviderConfig } from '../../../ducks/metamask/metamask';
+///: END:ONLY_INCLUDE_IN
 import { ButtonBase, IconName } from '../../component-library';
 import {
   BackgroundColor,
@@ -33,22 +35,26 @@ export const AddressCopyButton = ({
   const [copied, handleCopy] = useCopyToClipboard(MINUTE);
   const t = useI18nContext();
 
+  ///: BEGIN:ONLY_INCLUDE_IN(build-mmi)
   const isCustodianSupportedChain = useSelector(getIsCustodianSupportedChain);
   const { nickname, type: networkType } = useSelector(getProviderConfig);
+  ///: END:ONLY_INCLUDE_IN
 
-  const tooltipTitle = copied ? t('copiedExclamation') : t('copyToClipboard');
+  const tooltipText = copied ? t('copiedExclamation') : t('copyToClipboard');
+  let tooltipTitle = tooltipText;
+
+  ///: BEGIN:ONLY_INCLUDE_IN(build-mmi)
+  tooltipTitle = isCustodianSupportedChain
+    ? tooltipText
+    : t('custodyWrongChain', [nickname || networkType]);
+  ///: END:ONLY_INCLUDE_IN
 
   return (
-    <Tooltip
-      position="bottom"
-      title={
-        isCustodianSupportedChain
-          ? tooltipTitle
-          : t('custodyWrongChain', [nickname || networkType])
-      }
-    >
+    <Tooltip position="bottom" title={tooltipTitle}>
       <ButtonBase
+        ///: BEGIN:ONLY_INCLUDE_IN(build-mmi)
         disabled={!isCustodianSupportedChain}
+        ///: END:ONLY_INCLUDE_IN
         backgroundColor={BackgroundColor.primaryMuted}
         onClick={() => {
           handleCopy(checksummedAddress);

--- a/ui/components/multichain/address-copy-button/address-copy-button.js
+++ b/ui/components/multichain/address-copy-button/address-copy-button.js
@@ -2,6 +2,9 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { toChecksumHexAddress } from '@metamask/controller-utils';
+import { useSelector } from 'react-redux';
+import { getIsCustodianSupportedChain } from '../../../selectors/institutional/selectors';
+import { getProviderConfig } from '../../../ducks/metamask/metamask';
 import { ButtonBase, IconName } from '../../component-library';
 import {
   BackgroundColor,
@@ -30,9 +33,22 @@ export const AddressCopyButton = ({
   const [copied, handleCopy] = useCopyToClipboard(MINUTE);
   const t = useI18nContext();
 
+  const isCustodianSupportedChain = useSelector(getIsCustodianSupportedChain);
+  const { nickname, type: networkType } = useSelector(getProviderConfig);
+
+  const tooltipTitle = copied ? t('copiedExclamation') : t('copyToClipboard');
+
   return (
-    <Tooltip position="bottom" title={copied ? t('copiedExclamation') : null}>
+    <Tooltip
+      position="bottom"
+      title={
+        isCustodianSupportedChain
+          ? tooltipTitle
+          : t('custodyWrongChain', [nickname || networkType])
+      }
+    >
       <ButtonBase
+        disabled={!isCustodianSupportedChain}
         backgroundColor={BackgroundColor.primaryMuted}
         onClick={() => {
           handleCopy(checksummedAddress);

--- a/ui/components/multichain/address-copy-button/address-copy-button.test.js
+++ b/ui/components/multichain/address-copy-button/address-copy-button.test.js
@@ -1,16 +1,14 @@
 import React from 'react';
 import configureMockStore from 'redux-mock-store';
-import { renderWithProvider } from '../../../../test/lib/render-helpers';
 import copyToClipboard from 'copy-to-clipboard';
-import mockState from '../../../../test/data/mock-state.json';
-import { COPY_OPTIONS } from '../../../../shared/constants/copy';
-
 import { fireEvent } from '@testing-library/react';
 import { toChecksumHexAddress } from '@metamask/controller-utils';
+import { renderWithProvider } from '../../../../test/lib/render-helpers';
+import mockState from '../../../../test/data/mock-state.json';
+import { COPY_OPTIONS } from '../../../../shared/constants/copy';
 import { shortenAddress } from '../../../helpers/utils/util';
-import { AddressCopyButton } from '.';
-
 import { getIsCustodianSupportedChain } from '../../../selectors/institutional/selectors';
+import { AddressCopyButton } from '.';
 
 jest.mock('copy-to-clipboard');
 

--- a/ui/components/multichain/address-copy-button/address-copy-button.test.js
+++ b/ui/components/multichain/address-copy-button/address-copy-button.test.js
@@ -5,15 +5,12 @@ import copyToClipboard from 'copy-to-clipboard';
 import mockState from '../../../../test/data/mock-state.json';
 import { COPY_OPTIONS } from '../../../../shared/constants/copy';
 
-import { fireEvent, render } from '@testing-library/react';
+import { fireEvent } from '@testing-library/react';
 import { toChecksumHexAddress } from '@metamask/controller-utils';
 import { shortenAddress } from '../../../helpers/utils/util';
 import { AddressCopyButton } from '.';
 
-import {
-  getCustodyAccountDetails,
-  getIsCustodianSupportedChain,
-} from '../../../selectors/institutional/selectors';
+import { getIsCustodianSupportedChain } from '../../../selectors/institutional/selectors';
 
 jest.mock('copy-to-clipboard');
 

--- a/ui/components/multichain/address-copy-button/address-copy-button.test.js
+++ b/ui/components/multichain/address-copy-button/address-copy-button.test.js
@@ -1,14 +1,42 @@
 import React from 'react';
+import configureMockStore from 'redux-mock-store';
+import { renderWithProvider } from '../../../../test/lib/render-helpers';
+import copyToClipboard from 'copy-to-clipboard';
+import mockState from '../../../../test/data/mock-state.json';
+import { COPY_OPTIONS } from '../../../../shared/constants/copy';
+
 import { fireEvent, render } from '@testing-library/react';
 import { toChecksumHexAddress } from '@metamask/controller-utils';
 import { shortenAddress } from '../../../helpers/utils/util';
 import { AddressCopyButton } from '.';
 
+import {
+  getCustodyAccountDetails,
+  getIsCustodianSupportedChain,
+} from '../../../selectors/institutional/selectors';
+
+jest.mock('copy-to-clipboard');
+
+jest.mock('../../../selectors/institutional/selectors', () => {
+  const mockGetCustodyAccountDetails = jest.fn(() => undefined);
+  const mockGetisCustodianSupportedChain = jest.fn(() => true);
+
+  return {
+    getCustodyAccountDetails: mockGetCustodyAccountDetails,
+    getIsCustodianSupportedChain: mockGetisCustodianSupportedChain,
+  };
+});
+
 const SAMPLE_ADDRESS = '0x0dcd5d886577d5081b0c52e242ef29e70be3e7bc';
 
 describe('AccountListItem', () => {
+  const mockStore = configureMockStore()(mockState);
+
   it('renders the full address by default', () => {
-    render(<AddressCopyButton address={SAMPLE_ADDRESS} />);
+    renderWithProvider(
+      <AddressCopyButton address={SAMPLE_ADDRESS} />,
+      mockStore,
+    );
     expect(
       document.querySelector('[data-testid="address-copy-button-text"]')
         .textContent,
@@ -16,7 +44,10 @@ describe('AccountListItem', () => {
   });
 
   it('renders a shortened address when it should', () => {
-    render(<AddressCopyButton address={SAMPLE_ADDRESS} shorten />);
+    renderWithProvider(
+      <AddressCopyButton address={SAMPLE_ADDRESS} shorten />,
+      mockStore,
+    );
     expect(
       document.querySelector('[data-testid="address-copy-button-text"]')
         .textContent,
@@ -24,10 +55,60 @@ describe('AccountListItem', () => {
   });
 
   it('changes icon when clicked', () => {
-    render(<AddressCopyButton address={SAMPLE_ADDRESS} />);
+    renderWithProvider(
+      <AddressCopyButton address={SAMPLE_ADDRESS} />,
+      mockStore,
+    );
     fireEvent.click(document.querySelector('button'));
     expect(document.querySelector('.mm-icon').style.maskImage).toContain(
       'copy-success.svg',
     );
+  });
+
+  it('should render correctly', () => {
+    const { container } = renderWithProvider(
+      <AddressCopyButton address={SAMPLE_ADDRESS} />,
+      mockStore,
+    );
+
+    const tooltipTitle = container.querySelector(
+      '[data-original-title="Copy to clipboard"]',
+    );
+
+    expect(tooltipTitle).toBeInTheDocument();
+  });
+
+  it('should copy checksum address to clipboard when button is clicked', () => {
+    const { queryByTestId } = renderWithProvider(
+      <AddressCopyButton address={SAMPLE_ADDRESS} />,
+      mockStore,
+    );
+
+    const button = queryByTestId('address-copy-button-text');
+
+    fireEvent.click(button);
+
+    expect(copyToClipboard).toHaveBeenCalledWith(
+      '0x0DCD5D886577d5081B0c52e242Ef29E70Be3E7bc',
+      COPY_OPTIONS,
+    );
+  });
+
+  it('should render correctly if isCustodianSupportedChain to false', () => {
+    getIsCustodianSupportedChain.mockReturnValue(false);
+
+    const { container, queryByTestId } = renderWithProvider(
+      <AddressCopyButton address={SAMPLE_ADDRESS} />,
+      mockStore,
+    );
+
+    const tooltipTitle = container.querySelector(
+      '[data-original-title="This account is not set up for use with goerli"]',
+    );
+
+    const button = queryByTestId('address-copy-button-text');
+
+    expect(button).toBeDisabled();
+    expect(tooltipTitle).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## **Description**

In MMI we don't support all networks therefore we want to prevent the user from copying the account address while at the same time show in the tooltip that information.

## **Related issues**

Fixes: #

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
We would allow to copy the address and don't show any message.

### **After**
When connecting to a weird network like [Boba](https://chainlist.org/chain/288):

<img width="354" alt="Screenshot 2023-11-08 at 14 13 03" src="https://github.com/MetaMask/metamask-extension/assets/1125631/ee5ccf0b-4625-4c33-bd09-18d5811c605a">


<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've clearly explained what problem this PR is solving and how it is solved.
- [ ] I've linked related issues
- [ ] I've included manual testing steps
- [ ] I've included screenshots/recordings if applicable
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [ ] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
