### PR TITLE
Remove identities associated to the hardware keyring when forgetting the device

### DIFF
--- a/app/scripts/controllers/preferences.js
+++ b/app/scripts/controllers/preferences.js
@@ -118,9 +118,6 @@ export default class PreferencesController {
     this.store.setMaxListeners(13);
     this.tokenListController = opts.tokenListController;
 
-    // subscribe to account removal
-    opts.onAccountRemoved((address) => this.removeAddress(address));
-
     global.setPreference = (key, value) => {
       return this.setFeatureFlag(key, value);
     };

--- a/app/scripts/controllers/preferences.test.js
+++ b/app/scripts/controllers/preferences.test.js
@@ -40,7 +40,6 @@ describe('preferences controller', () => {
     preferencesController = new PreferencesController({
       initLangCode: 'en_US',
       tokenListController,
-      onAccountRemoved: jest.fn(),
       networkConfigurations: NETWORK_CONFIGURATION_DATA,
     });
   });
@@ -105,61 +104,6 @@ describe('preferences controller', () => {
           address: '0x7e57e277',
         },
       });
-    });
-  });
-
-  describe('onAccountRemoved', () => {
-    it('should remove an address from state', () => {
-      const testAddress = '0xda22le';
-      let accountRemovedListener;
-      const onAccountRemoved = (callback) => {
-        accountRemovedListener = callback;
-      };
-      preferencesController = new PreferencesController({
-        initLangCode: 'en_US',
-        tokenListController,
-        initState: {
-          identities: {
-            [testAddress]: {
-              name: 'Account 1',
-              address: testAddress,
-            },
-          },
-        },
-        onAccountRemoved,
-        networkConfigurations: NETWORK_CONFIGURATION_DATA,
-      });
-
-      accountRemovedListener(testAddress);
-
-      expect(
-        preferencesController.store.getState().identities['0xda22le'],
-      ).toStrictEqual(undefined);
-    });
-
-    it('should throw an error if address not found', () => {
-      const testAddress = '0xda22le';
-      let accountRemovedListener;
-      const onAccountRemoved = (callback) => {
-        accountRemovedListener = callback;
-      };
-      preferencesController = new PreferencesController({
-        initLangCode: 'en_US',
-        tokenListController,
-        initState: {
-          identities: {
-            '0x7e57e2': {
-              name: 'Account 1',
-              address: '0x7e57e2',
-            },
-          },
-        },
-        onAccountRemoved,
-        networkConfigurations: NETWORK_CONFIGURATION_DATA,
-      });
-      expect(() => {
-        accountRemovedListener(testAddress);
-      }).toThrow(`${testAddress} can't be deleted cause it was not found`);
     });
   });
 

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -3508,6 +3508,11 @@ export default class MetamaskController extends EventEmitter {
    */
   async forgetDevice(deviceName) {
     const keyring = await this.getKeyringForDevice(deviceName);
+
+    for (const address of keyring.accounts) {
+      await this.removeAccount(address);
+    }
+
     keyring.forgetDevice();
     return true;
   }

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -489,10 +489,6 @@ export default class MetamaskController extends EventEmitter {
     this.preferencesController = new PreferencesController({
       initState: initState.PreferencesController,
       initLangCode: opts.initLangCode,
-      onAccountRemoved: this.controllerMessenger.subscribe.bind(
-        this.controllerMessenger,
-        'KeyringController:accountRemoved',
-      ),
       tokenListController: this.tokenListController,
       provider: this.provider,
       networkConfigurations: this.networkController.state.networkConfigurations,

--- a/app/scripts/metamask-controller.test.js
+++ b/app/scripts/metamask-controller.test.js
@@ -765,12 +765,19 @@ describe('MetaMaskController', () => {
     });
 
     describe('forgetDevice', () => {
-      let localMetaMaskController;
+      it('should throw if it receives an unknown device name', async () => {
+        const result = metamaskController.forgetDevice(
+          'Some random device name',
+        );
+        await expect(result).rejects.toThrow(
+          'MetamaskController:getKeyringForDevice - Unknown device',
+        );
+      });
 
-      beforeEach(async () => {
+      it('should remove the identities when the device is forgotten', async () => {
         jest.spyOn(window, 'open').mockReturnValue();
 
-        localMetaMaskController = new MetaMaskController({
+        const localMetaMaskController = new MetaMaskController({
           showUserConfirmation: noop,
           encryptor: {
             encrypt(_, object) {
@@ -804,27 +811,17 @@ describe('MetaMaskController', () => {
           isFirstMetaMaskControllerSetup: true,
         });
 
-        localMetaMaskController.keyringController.createNewVaultAndKeychain(
+        await localMetaMaskController.keyringController.createNewVaultAndKeychain(
           'password',
         );
 
-        localMetaMaskController.keyringController.addNewKeyring(
+        await localMetaMaskController.keyringController.addNewKeyring(
           'Trezor Hardware',
           {
             accounts: ['0x123'],
           },
         );
-      });
-      it('should throw if it receives an unknown device name', async () => {
-        const result = metamaskController.forgetDevice(
-          'Some random device name',
-        );
-        await expect(result).rejects.toThrow(
-          'MetamaskController:getKeyringForDevice - Unknown device',
-        );
-      });
 
-      it('should remove the identities when the device is forgotten', async () => {
         await localMetaMaskController.forgetDevice(HardwareDeviceNames.trezor);
         const { identities: updatedIdentities } =
           localMetaMaskController.preferencesController.store.getState();


### PR DESCRIPTION
## **Description**

This pr fixes the issue where the identities of a hardware wallet were not removed when removing the device. 

## **Related issues**

Fixes: #21742

## **Manual testing steps**

1. Connect a ledger
2. Add a ledger account
3. Go to connect a ledger again 
4. Click on forget device
5. Check to see the ledger account was removed from the UI

## **Screenshots/Recordings**

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained what problem this PR is solving and how it is solved.
- [x] I've linked related issues
- [x] I've included manual testing steps
- [x] I've included screenshots/recordings if applicable
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [x] I’ve properly set the pull request status:
  - [x] In case it's not yet "ready for review", I've set it to "draft".
  - [x] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
