### PR TITLE
Revert "feat: Add metrics for provider calls coming from ppom on extenson (#21482)

### DIFF
--- a/app/scripts/lib/createRPCMethodTrackingMiddleware.js
+++ b/app/scripts/lib/createRPCMethodTrackingMiddleware.js
@@ -199,16 +199,6 @@ export default function createRPCMethodTrackingMiddleware({
         const paramsExamplePassword = req?.params?.[2];
 
         ///: BEGIN:ONLY_INCLUDE_IN(blockaid)
-        if (req.securityAlertResponse?.providerRequestsCount) {
-          Object.keys(req.securityAlertResponse.providerRequestsCount).forEach(
-            (key) => {
-              const metricKey = `ppom_${key}_count`;
-              eventProperties[metricKey] =
-                req.securityAlertResponse.providerRequestsCount[key];
-            },
-          );
-        }
-
         eventProperties.security_alert_response =
           req.securityAlertResponse?.result_type ??
           BlockaidResultType.NotApplicable;

--- a/app/scripts/lib/createRPCMethodTrackingMiddleware.test.js
+++ b/app/scripts/lib/createRPCMethodTrackingMiddleware.test.js
@@ -143,47 +143,6 @@ describe('createRPCMethodTrackingMiddleware', () => {
       });
     });
 
-    it(`should track an event with correct blockaid parameters when providerRequestsCount is provided`, async () => {
-      const req = {
-        method: MESSAGE_TYPE.ETH_SIGN,
-        origin: 'some.dapp',
-        securityAlertResponse: {
-          result_type: BlockaidResultType.Malicious,
-          reason: BlockaidReason.maliciousDomain,
-          providerRequestsCount: {
-            eth_call: 5,
-            eth_getCode: 3,
-          },
-        },
-      };
-
-      const res = {
-        error: null,
-      };
-      const { next } = getNext();
-      await handler(req, res, next);
-      expect(trackEvent).toHaveBeenCalledTimes(1);
-      /**
-       * TODO:
-       * toMatchObject matches even if the the matched object does not contain some of the properties of the expected object
-       * I'm not sure why toMatchObject is used but we should probably check the other tests in this file for correctness in
-       * another PR.
-       *
-       */
-      expect(trackEvent.mock.calls[0][0]).toStrictEqual({
-        category: 'inpage_provider',
-        event: MetaMetricsEventName.SignatureRequested,
-        properties: {
-          signature_type: MESSAGE_TYPE.ETH_SIGN,
-          security_alert_response: BlockaidResultType.Malicious,
-          security_alert_reason: BlockaidReason.maliciousDomain,
-          ppom_eth_call_count: 5,
-          ppom_eth_getCode_count: 3,
-        },
-        referrer: { url: 'some.dapp' },
-      });
-    });
-
     it(`should track a ${MetaMetricsEventName.SignatureApproved} event if the user approves`, async () => {
       const req = {
         method: MESSAGE_TYPE.ETH_SIGN_TYPED_DATA_V4,

--- a/app/scripts/lib/transaction-metrics.ts
+++ b/app/scripts/lib/transaction-metrics.ts
@@ -773,20 +773,6 @@ async function buildEventFragmentProperties({
   }
   ///: END:ONLY_INCLUDE_IN
 
-  ///: BEGIN:ONLY_INCLUDE_IN(blockaid)
-  const additionalBlockaidParams = {} as Record<string, any>;
-
-  if (securityProviderResponse?.providerRequestsCount) {
-    Object.keys(securityProviderResponse.providerRequestsCount).forEach(
-      (key) => {
-        const metricKey = `ppom_${key}_count`;
-        additionalBlockaidParams[metricKey] =
-          securityProviderResponse.providerRequestsCount[key];
-      },
-    );
-  }
-  ///: END:ONLY_INCLUDE_IN
-
   /** The transaction status property is not considered sensitive and is now included in the non-anonymous event */
   let properties = {
     chain_id: chainId,
@@ -813,7 +799,6 @@ async function buildEventFragmentProperties({
       securityAlertResponse?.result_type ?? BlockaidResultType.NotApplicable,
     security_alert_reason:
       securityAlertResponse?.reason ?? BlockaidReason.notApplicable,
-    ...additionalBlockaidParams,
     ///: END:ONLY_INCLUDE_IN
   } as Record<string, any>;
 


### PR DESCRIPTION
…nsion (#21482)"

This reverts commit 0a261a802231200276c8aae0d7271785c3a015e3.

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Related issues**

Fixes: #

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've clearly explained what problem this PR is solving and how it is solved.
- [ ] I've linked related issues
- [ ] I've included manual testing steps
- [ ] I've included screenshots/recordings if applicable
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [ ] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
