### PR TITLE
Remove onAccountRemoved from preferencesController

### DIFF
--- a/app/scripts/controllers/preferences.js
+++ b/app/scripts/controllers/preferences.js
@@ -118,9 +118,6 @@ export default class PreferencesController {
     this.store.setMaxListeners(13);
     this.tokenListController = opts.tokenListController;
 
-    // subscribe to account removal
-    opts.onAccountRemoved((address) => this.removeAddress(address));
-
     global.setPreference = (key, value) => {
       return this.setFeatureFlag(key, value);
     };

--- a/app/scripts/controllers/preferences.test.js
+++ b/app/scripts/controllers/preferences.test.js
@@ -40,7 +40,6 @@ describe('preferences controller', () => {
     preferencesController = new PreferencesController({
       initLangCode: 'en_US',
       tokenListController,
-      onAccountRemoved: jest.fn(),
       networkConfigurations: NETWORK_CONFIGURATION_DATA,
     });
   });
@@ -105,61 +104,6 @@ describe('preferences controller', () => {
           address: '0x7e57e277',
         },
       });
-    });
-  });
-
-  describe('onAccountRemoved', () => {
-    it('should remove an address from state', () => {
-      const testAddress = '0xda22le';
-      let accountRemovedListener;
-      const onAccountRemoved = (callback) => {
-        accountRemovedListener = callback;
-      };
-      preferencesController = new PreferencesController({
-        initLangCode: 'en_US',
-        tokenListController,
-        initState: {
-          identities: {
-            [testAddress]: {
-              name: 'Account 1',
-              address: testAddress,
-            },
-          },
-        },
-        onAccountRemoved,
-        networkConfigurations: NETWORK_CONFIGURATION_DATA,
-      });
-
-      accountRemovedListener(testAddress);
-
-      expect(
-        preferencesController.store.getState().identities['0xda22le'],
-      ).toStrictEqual(undefined);
-    });
-
-    it('should throw an error if address not found', () => {
-      const testAddress = '0xda22le';
-      let accountRemovedListener;
-      const onAccountRemoved = (callback) => {
-        accountRemovedListener = callback;
-      };
-      preferencesController = new PreferencesController({
-        initLangCode: 'en_US',
-        tokenListController,
-        initState: {
-          identities: {
-            '0x7e57e2': {
-              name: 'Account 1',
-              address: '0x7e57e2',
-            },
-          },
-        },
-        onAccountRemoved,
-        networkConfigurations: NETWORK_CONFIGURATION_DATA,
-      });
-      expect(() => {
-        accountRemovedListener(testAddress);
-      }).toThrow(`${testAddress} can't be deleted cause it was not found`);
     });
   });
 

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -492,10 +492,6 @@ export default class MetamaskController extends EventEmitter {
     this.preferencesController = new PreferencesController({
       initState: initState.PreferencesController,
       initLangCode: opts.initLangCode,
-      onAccountRemoved: this.controllerMessenger.subscribe.bind(
-        this.controllerMessenger,
-        'KeyringController:accountRemoved',
-      ),
       tokenListController: this.tokenListController,
       provider: this.provider,
       networkConfigurations: this.networkController.state.networkConfigurations,


### PR DESCRIPTION
## **Description**

When removing an account, `_onKeyringControllerUpdate` and `onAccountRemoval` to be fired. Both of these actions would call removeAddress on the preferences controller.

This PR fixes the issue where removal of accounts causes this error `opts.onAccountRemoved((address) => this.removeAddress(address));`. 

Sentry Reference
https://metamask.sentry.io/issues/4564435320/?project=273505&query=is%3Aunresolved+can%27t+be+deleted+cause+it+was+not+found&referrer=issue-stream&sort=freq&statsPeriod=90d&stream_index=0

## **Related issues**

Fixes: [#
](https://github.com/MetaMask/metamask-extension/issues/21759)

## **Manual testing steps**

## **Screenshots/Recordings**

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained what problem this PR is solving and how it is solved.
- [x] I've linked related issues
- [x] I've included manual testing steps
- [x] I've included screenshots/recordings if applicable
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [x] I’ve properly set the pull request status:
  - [x] In case it's not yet "ready for review", I've set it to "draft".
  - [x] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
