### PR TITLE
fix: skip flaky errors.spec test

### DIFF
--- a/test/e2e/fixture-builder.js
+++ b/test/e2e/fixture-builder.js
@@ -1514,7 +1514,7 @@ class FixtureBuilder {
 
   build() {
     this.fixture.meta = {
-      version: 74,
+      version: 84,
     };
     return this.fixture;
   }

--- a/test/e2e/fixture-builder.js
+++ b/test/e2e/fixture-builder.js
@@ -1514,7 +1514,7 @@ class FixtureBuilder {
 
   build() {
     this.fixture.meta = {
-      version: 84,
+      version: 74,
     };
     return this.fixture;
   }

--- a/test/e2e/tests/errors.spec.js
+++ b/test/e2e/tests/errors.spec.js
@@ -373,6 +373,7 @@ describe('Sentry errors', function () {
     });
 
     // todo: reenable this test https://github.com/MetaMask/metamask-extension/issues/21807
+    // eslint-disable-next-line mocha/no-skipped-tests
     it.skip('should capture migration log breadcrumbs when there is an invariant state error in a migration', async function () {
       await withFixtures(
         {
@@ -410,6 +411,10 @@ describe('Sentry errors', function () {
             (breadcrumb) =>
               breadcrumb.message.match(/(Running migration \d+)/u)[1],
           );
+
+          const firstMigrationLog = migrationLogMessages[0];
+          const lastMigrationLog =
+            migrationLogMessages[migrationLogMessages.length - 1];
 
           assert.equal(migrationLogMessages.length, 8);
           assert.equal(firstMigrationLog, 'Running migration 75');

--- a/test/e2e/tests/errors.spec.js
+++ b/test/e2e/tests/errors.spec.js
@@ -402,6 +402,7 @@ describe('Sentry errors', function () {
           const mockTextBody = mockedRequest.body.text.split('\n');
           const mockJsonBody = JSON.parse(mockTextBody[2]);
           const breadcrumbs = mockJsonBody?.breadcrumbs ?? [];
+
           const migrationLogBreadcrumbs = breadcrumbs.filter((breadcrumb) => {
             return breadcrumb.message?.match(/Running migration \d+/u);
           });
@@ -416,13 +417,9 @@ describe('Sentry errors', function () {
               migrationLogMessages.length === 21,
           );
 
-          // const firstMigrationLog = migrationLogMessages[0];
-          // const lastMigrationLog =
-          //   migrationLogMessages[migrationLogMessages.length - 1];
-
-          // assert.equal(migrationLogMessages.length, 8);
-          // assert.equal(firstMigrationLog, 'Running migration 75');
-          // assert.equal(lastMigrationLog, 'Running migration 82');
+          assert.equal(migrationLogMessages.length, 11);
+          assert.equal(firstMigrationLog, 'Running migration 85');
+          assert.equal(lastMigrationLog, 'Running migration 92');
         },
       );
     });

--- a/test/e2e/tests/errors.spec.js
+++ b/test/e2e/tests/errors.spec.js
@@ -372,7 +372,8 @@ describe('Sentry errors', function () {
       );
     });
 
-    it('should capture migration log breadcrumbs when there is an invariant state error in a migration', async function () {
+    // todo: reenable this test https://github.com/MetaMask/metamask-extension/issues/21807
+    it.skip('should capture migration log breadcrumbs when there is an invariant state error in a migration', async function () {
       await withFixtures(
         {
           fixtures: {
@@ -402,7 +403,6 @@ describe('Sentry errors', function () {
           const mockTextBody = mockedRequest.body.text.split('\n');
           const mockJsonBody = JSON.parse(mockTextBody[2]);
           const breadcrumbs = mockJsonBody?.breadcrumbs ?? [];
-
           const migrationLogBreadcrumbs = breadcrumbs.filter((breadcrumb) => {
             return breadcrumb.message?.match(/Running migration \d+/u);
           });
@@ -410,16 +410,10 @@ describe('Sentry errors', function () {
             (breadcrumb) =>
               breadcrumb.message.match(/(Running migration \d+)/u)[1],
           );
-          // Temporarily allow either 8 or 10, until we get to the bottom of this
-          assert(
-            migrationLogMessages.length === 8 ||
-              migrationLogMessages.length === 10 ||
-              migrationLogMessages.length === 21,
-          );
 
-          assert.equal(migrationLogMessages.length, 11);
-          assert.equal(firstMigrationLog, 'Running migration 85');
-          assert.equal(lastMigrationLog, 'Running migration 92');
+          assert.equal(migrationLogMessages.length, 8);
+          assert.equal(firstMigrationLog, 'Running migration 75');
+          assert.equal(lastMigrationLog, 'Running migration 82');
         },
       );
     });


### PR DESCRIPTION
## **Description**

The end-to-end test that was originally flaky doesn't send sentry events for all migrations, only a subset of them.

I am still not 100% sure about the original source of the flakiness. One possible explanation is that migrations take a variable amount of time to run.

This PR skips the flaky test until we understand more about the root cause.

## **Related issues**

Fixes: #

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've clearly explained what problem this PR is solving and how it is solved.
- [ ] I've linked related issues
- [ ] I've included manual testing steps
- [ ] I've included screenshots/recordings if applicable
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [ ] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
