### PR TITLE
fix: 2 Duplicated Signature requests events are triggered for any signature

### DIFF
--- a/ui/components/app/signature-request-original/signature-request-original.component.js
+++ b/ui/components/app/signature-request-original/signature-request-original.component.js
@@ -44,11 +44,6 @@ import {
   ///: END:ONLY_INCLUDE_IN
 } from '../../component-library';
 ///: BEGIN:ONLY_INCLUDE_IN(blockaid)
-import {
-  MetaMetricsEventCategory,
-  MetaMetricsEventName,
-} from '../../../../shared/constants/metametrics';
-import { getBlockaidMetricsParams } from '../../../helpers/utils/metrics';
 import BlockaidBannerAlert from '../security-provider-banner-alert/blockaid-banner-alert/blockaid-banner-alert';
 ///: END:ONLY_INCLUDE_IN
 import ConfirmPageContainerNavigation from '../confirm-page-container/confirm-page-container-navigation';
@@ -95,26 +90,6 @@ export default class SignatureRequestOriginal extends Component {
   state = {
     showSignatureRequestWarning: false,
   };
-
-  ///: BEGIN:ONLY_INCLUDE_IN(blockaid)
-  componentDidMount() {
-    const { txData } = this.props;
-    if (txData.securityAlertResponse) {
-      const blockaidMetricsParams = getBlockaidMetricsParams(
-        txData.securityAlertResponse,
-      );
-
-      this.context.trackEvent({
-        category: MetaMetricsEventCategory.Transactions,
-        event: MetaMetricsEventName.SignatureRequested,
-        properties: {
-          action: 'Sign Request',
-          ...blockaidMetricsParams,
-        },
-      });
-    }
-  }
-  ///: END:ONLY_INCLUDE_IN
 
   msgHexToText = (hex) => {
     try {

--- a/ui/components/app/signature-request/signature-request.js
+++ b/ui/components/app/signature-request/signature-request.js
@@ -96,7 +96,6 @@ import { showCustodyConfirmLink } from '../../../store/institutional/institution
 import { useMMICustodySignMessage } from '../../../hooks/useMMICustodySignMessage';
 ///: END:ONLY_INCLUDE_IN
 ///: BEGIN:ONLY_INCLUDE_IN(blockaid)
-import { getBlockaidMetricsParams } from '../../../helpers/utils/metrics';
 import BlockaidBannerAlert from '../security-provider-banner-alert/blockaid-banner-alert/blockaid-banner-alert';
 ///: END:ONLY_INCLUDE_IN
 
@@ -254,27 +253,6 @@ const SignatureRequest = ({ txData }) => {
     isNotification,
     trackEvent,
   ]);
-  ///: END:ONLY_INCLUDE_IN
-
-  ///: BEGIN:ONLY_INCLUDE_IN(blockaid)
-  useEffect(() => {
-    if (txData.securityAlertResponse) {
-      const blockaidMetricsParams = getBlockaidMetricsParams(
-        txData.securityAlertResponse,
-      );
-
-      trackEvent({
-        category: MetaMetricsEventCategory.Transactions,
-        event: MetaMetricsEventName.SignatureRequested,
-        properties: {
-          action: 'Sign Request',
-          type,
-          version,
-          ...blockaidMetricsParams,
-        },
-      });
-    }
-  }, []);
   ///: END:ONLY_INCLUDE_IN
 
   return (


### PR DESCRIPTION
## **Description**

When you click on a signature request that is flagged by PPOM, 2 events are sent to metrics instead of 1.

### Expected behavior

Just 1 Signature request should be triggered for a Signature event flagged by PPOM

## **Related issues**

Fixes: #21770 

## **Manual testing steps**

1. Launch MM
2. Open background console and open the network app, make sure it's recording network requests
3. Open testdapp
4. Click on any of the signature requests for PPOM e.g Malicious Trade Order
5. Go to background console network tab and see 2 signature requests called as shown in the video
6. Checkout this branch, build and run MM
7. Repeat steps 2-4
8. On the background console, you should now see only 1 signature request sent.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

[<!-- [screenshots/recordings] -->](https://github.com/MetaMask/metamask-extension/assets/54408225/926b1da1-deac-45b3-91d9-f55f5da6cbe6)

### **After**

https://github.com/MetaMask/metamask-extension/assets/44811/f7f32a58-dcff-4a76-8bdb-6579d6693b88

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained what problem this PR is solving and how it is solved.
- [x] I've linked related issues
- [x] I've included manual testing steps
- [x] I've included screenshots/recordings if applicable
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [x] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [x] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
