### PR TITLE
fix: ERC721 name does not display when approving token

### DIFF
--- a/ui/helpers/utils/token-util.js
+++ b/ui/helpers/utils/token-util.js
@@ -242,7 +242,7 @@ export async function getAssetDetails(
         isEqualCaseInsensitive(tokenAddress, address) && _tokenId === tokenId,
     );
 
-    if (existingNft) {
+    if (existingNft && (existingNft.name || existingNft.symbol)) {
       return {
         toAddress,
         ...existingNft,

--- a/ui/helpers/utils/token-util.test.js
+++ b/ui/helpers/utils/token-util.test.js
@@ -1,0 +1,161 @@
+import { TokenStandard } from '../../../shared/constants/transaction';
+import { parseStandardTokenTransactionData } from '../../../shared/modules/transaction.utils';
+import { getTokenStandardAndDetails } from '../../store/actions';
+import { getAssetDetails } from './token-util';
+
+jest.mock('../../../shared/modules/transaction.utils', () => ({
+  parseStandardTokenTransactionData: jest.fn(),
+}));
+
+jest.mock('../../store/actions', () => ({
+  getTokenStandardAndDetails: jest.fn(),
+}));
+
+describe('getAssetDetails', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return asset details for an erc721 token transaction', async () => {
+    const erc721Params = {
+      tokenAddress: '0xAddrEssToken',
+      currentUserAddress: '0xAddrEss',
+      transactionData: '0xTransactionData',
+      existingNfts: [
+        {
+          address: '0xAddrEss',
+          name: null,
+          standard: 'ERC721',
+          tokenId: '1',
+          tokenURI: 'tokenURI',
+        },
+      ],
+    };
+    parseStandardTokenTransactionData.mockReturnValue({
+      args: { id: 1, to: '0xtoAddRess' },
+    });
+    getTokenStandardAndDetails.mockReturnValue({
+      name: 'myToken',
+      symbol: 'MTK',
+      standard: TokenStandard.ERC721,
+    });
+    const result = await getAssetDetails(
+      erc721Params.currentUserAddress,
+      erc721Params.tokenAddress,
+      erc721Params.transactionData,
+      erc721Params.existingNfts,
+    );
+
+    // should be called if name is null
+    expect(getTokenStandardAndDetails).toHaveBeenCalled();
+    expect(result.name).toStrictEqual('myToken');
+    expect(result.symbol).toStrictEqual('MTK');
+    expect(result.standard).toStrictEqual(TokenStandard.ERC721);
+  });
+
+  it('should return asset details for an erc721 token transaction without calling api if name is not null', async () => {
+    const erc721ParamsWithName = {
+      tokenAddress: '0xAddrEssToken',
+      currentUserAddress: '0xAddrEss',
+      transactionData: '0xTransactionData',
+      existingNfts: [
+        {
+          address: '0xAddrEss',
+          name: 'myToken',
+          symbol: 'MTK',
+          standard: 'ERC721',
+          tokenId: '1',
+          tokenURI: 'tokenURI',
+        },
+      ],
+    };
+    parseStandardTokenTransactionData.mockReturnValue({
+      args: { id: 1, to: '0xtoAddRess' },
+    });
+    getTokenStandardAndDetails.mockReturnValue({
+      name: 'myToken',
+      symbol: 'MTK',
+      standard: TokenStandard.ERC721,
+    });
+    const result = await getAssetDetails(
+      erc721ParamsWithName.currentUserAddress,
+      erc721ParamsWithName.tokenAddress,
+      erc721ParamsWithName.transactionData,
+      erc721ParamsWithName.existingNfts,
+    );
+
+    // should not be called if name is not null
+    expect(getTokenStandardAndDetails).not.toHaveBeenCalled();
+    expect(result.name).toStrictEqual('myToken');
+    expect(result.symbol).toStrictEqual('MTK');
+    expect(result.standard).toStrictEqual(TokenStandard.ERC721);
+  });
+
+  it('should return the correct asset details for an erc721 token transaction without calling api if symbol is not null', async () => {
+    const erc721ParamsWithName = {
+      tokenAddress: '0xAddrEssToken',
+      currentUserAddress: '0xAddrEss',
+      transactionData: '0xTransactionData',
+      existingNfts: [
+        {
+          address: '0xAddrEss',
+          name: null,
+          symbol: 'MTK',
+          standard: 'ERC721',
+          tokenId: '1',
+          tokenURI: 'tokenURI',
+        },
+      ],
+    };
+    parseStandardTokenTransactionData.mockReturnValue({
+      args: { id: 1, to: '0xtoAddRess' },
+    });
+    getTokenStandardAndDetails.mockReturnValue({
+      name: 'myToken',
+      symbol: 'MTK',
+      standard: TokenStandard.ERC721,
+    });
+    const result = await getAssetDetails(
+      erc721ParamsWithName.currentUserAddress,
+      erc721ParamsWithName.tokenAddress,
+      erc721ParamsWithName.transactionData,
+      erc721ParamsWithName.existingNfts,
+    );
+
+    // should not be called if name is not null
+    expect(getTokenStandardAndDetails).not.toHaveBeenCalled();
+    expect(result.name).toStrictEqual(null);
+    expect(result.symbol).toStrictEqual('MTK');
+    expect(result.standard).toStrictEqual(TokenStandard.ERC721);
+  });
+
+  it('should return the correct asset details for an erc20 token transaction', async () => {
+    const erc20Params = {
+      tokenAddress: '0xAddrEssToken',
+      currentUserAddress: '0xAccouNtAddress',
+      transactionData: '0xTransactionData',
+    };
+    parseStandardTokenTransactionData.mockReturnValue({
+      args: { to: '0xtoAddRess' },
+    });
+    getTokenStandardAndDetails.mockReturnValue({
+      name: 'myERC20Token',
+      symbol: 'MTK',
+      standard: TokenStandard.ERC20,
+    });
+    const result = await getAssetDetails(
+      erc20Params.currentUserAddress,
+      erc20Params.tokenAddress,
+      erc20Params.transactionData,
+      erc20Params.existingNfts,
+    );
+
+    expect(getTokenStandardAndDetails).toHaveBeenCalled();
+    expect(result.name).toStrictEqual('myERC20Token');
+    expect(result.symbol).toStrictEqual('MTK');
+  });
+});


### PR DESCRIPTION
## **Description**

whenever we are approving an ERC721 token, we can see how the collection name is not displayed if an nft was imported.
if it's not imported it works fine.

Expected behavior
The collection name should be displayed in the same way it's done for Set Approval For All / Revoke screens.

## **Related issues**

Fixes: #[21756](https://github.com/MetaMask/metamask-extension/issues/21756)

## **Manual testing steps**

1. Go to metamask E2E test dapp and deploy ERC721 contract
2. Mint an NFT
3. watch this NFT ( or import it to metamask )
4. execute the method Approve

## **Screenshots/Recordings**

### **Before**

<img width="359" alt="before" src="https://github.com/MetaMask/metamask-extension/assets/26223211/0184016e-24f8-4b8d-b1a6-756be695eaf3">

### **After**
<img width="358" alt="after" src="https://github.com/MetaMask/metamask-extension/assets/26223211/41206001-7c5b-4c89-838c-e4da1799c893">

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained what problem this PR is solving and how it is solved.
- [x] I've linked related issues
- [x] I've included manual testing steps
- [x] I've included screenshots/recordings if applicable
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [x] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [x] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
