### PR TITLE
Update snaps E2E tests for test-snaps 2.2.2 

### DIFF
--- a/test/e2e/snaps/enums.js
+++ b/test/e2e/snaps/enums.js
@@ -1,3 +1,3 @@
 module.exports = {
-  TEST_SNAPS_WEBSITE_URL: 'https://metamask.github.io/snaps/test-snaps/2.2.1/',
+  TEST_SNAPS_WEBSITE_URL: 'https://metamask.github.io/snaps/test-snaps/2.2.2/',
 };

--- a/test/e2e/snaps/enums.js
+++ b/test/e2e/snaps/enums.js
@@ -1,3 +1,4 @@
 module.exports = {
-  TEST_SNAPS_WEBSITE_URL: 'https://metamask.github.io/snaps/test-snaps/2.1.0/',
+  // TEST_SNAPS_WEBSITE_URL: 'https://metamask.github.io/snaps/test-snaps/2.1.0/',
+  TEST_SNAPS_WEBSITE_URL: 'http://localhost:9000/',
 };

--- a/test/e2e/snaps/enums.js
+++ b/test/e2e/snaps/enums.js
@@ -1,4 +1,3 @@
 module.exports = {
-  // TEST_SNAPS_WEBSITE_URL: 'https://metamask.github.io/snaps/test-snaps/2.1.0/',
-  TEST_SNAPS_WEBSITE_URL: 'http://localhost:9000/',
+  TEST_SNAPS_WEBSITE_URL: 'https://metamask.github.io/snaps/test-snaps/2.2.1/',
 };

--- a/test/e2e/snaps/test-snap-get-locale.spec.js
+++ b/test/e2e/snaps/test-snap-get-locale.spec.js
@@ -1,4 +1,3 @@
-const { strict: assert } = require('assert');
 const { withFixtures } = require('../helpers');
 const FixtureBuilder = require('../fixture-builder');
 const { TEST_SNAPS_WEBSITE_URL } = require('./enums');
@@ -74,44 +73,16 @@ describe('Test Snap Get Locale', function () {
         // wait for npm installation success
         await driver.waitForSelector({
           css: '#connectgetlocale',
-          text: 'Reconnect to Get Locale Snap',
+          text: 'Reconnect to Localization Snap',
         });
 
         // click on alert dialog
         await driver.clickElement('#sendGetLocaleHelloButton');
-        await driver.delay(500);
-
-        // switch to dialog popup
-        windowHandles = await driver.waitUntilXWindowHandles(3, 1000, 10000);
-        await driver.switchToWindowWithTitle(
-          'MetaMask Notification',
-          windowHandles,
-        );
-        await driver.delay(500);
-
-        // check dialog contents
-        const result = await driver.findElement('.snap-ui-renderer__panel');
-        await driver.scrollToElement(result);
-        await driver.delay(500);
-        assert.equal(
-          await result.getText(),
-          'Hello https://metamask.github.io!\nThis is a dialog!',
-        );
-
-        // click ok button
-        await driver.clickElement({
-          text: 'OK',
-          tag: 'button',
-        });
-
-        // switch back to test snaps tab
-        windowHandles = await driver.waitUntilXWindowHandles(2, 1000, 10000);
-        await driver.switchToWindowWithTitle('Test Snaps', windowHandles);
 
         // check for result correctness
         await driver.waitForSelector({
           css: '#getLocaleResult',
-          text: 'null',
+          text: '"Hello, world!"',
         });
 
         // try switching language to dansk
@@ -149,24 +120,12 @@ describe('Test Snap Get Locale', function () {
 
         // click on alert dialog
         await driver.clickElement('#sendGetLocaleHelloButton');
-        await driver.delay(500);
 
-        // switch to dialog popup
-        windowHandles = await driver.waitUntilXWindowHandles(3, 1000, 10000);
-        await driver.switchToWindowWithTitle(
-          'MetaMask Notification',
-          windowHandles,
-        );
-        await driver.delay(500);
-
-        // check dialog contents for dansk result
-        const result2 = await driver.findElement('.snap-ui-renderer__panel');
-        await driver.scrollToElement(result2);
-        await driver.delay(500);
-        assert.equal(
-          await result2.getText(),
-          'Hej https://metamask.github.io!\nDette er en dialog!',
-        );
+        // check for result correctness
+        await driver.waitForSelector({
+          css: '#getLocaleResult',
+          text: '"Hej, verden!"',
+        });
       },
     );
   });

--- a/test/e2e/snaps/test-snap-managestate.spec.js
+++ b/test/e2e/snaps/test-snap-managestate.spec.js
@@ -77,7 +77,6 @@ describe('Test Snap manageState', function () {
           text: 'Reconnect to Manage State Snap',
         });
 
-        // await driver.delay(1000);
         await driver.pasteIntoField('#dataManageState', '23');
         const snapButton2 = await driver.findElement(
           '#retrieveManageStateResult',

--- a/test/e2e/snaps/test-snap-managestate.spec.js
+++ b/test/e2e/snaps/test-snap-managestate.spec.js
@@ -115,7 +115,8 @@ describe('Test Snap manageState', function () {
         // repeat the same above steps to check unencrypted state management
         // enter data and send
         await driver.pasteIntoField('#dataUnencryptedManageState', '23');
-        await driver.scrollToElement(snapButton2);
+        const snapButton3 = await driver.findElement('#clearManageState');
+        await driver.scrollToElement(snapButton3);
         await driver.delay(1000);
         await driver.clickElement('#sendUnencryptedManageState');
 

--- a/test/e2e/snaps/test-snap-managestate.spec.js
+++ b/test/e2e/snaps/test-snap-managestate.spec.js
@@ -1,4 +1,3 @@
-const { strict: assert } = require('assert');
 const { withFixtures } = require('../helpers');
 const FixtureBuilder = require('../fixture-builder');
 const { TEST_SNAPS_WEBSITE_URL } = require('./enums');
@@ -78,51 +77,74 @@ describe('Test Snap manageState', function () {
           text: 'Reconnect to Manage State Snap',
         });
 
-        await driver.delay(1000);
+        // await driver.delay(1000);
         await driver.pasteIntoField('#dataManageState', '23');
         const snapButton2 = await driver.findElement(
           '#retrieveManageStateResult',
         );
         await driver.scrollToElement(snapButton2);
-        await driver.delay(1000);
         await driver.clickElement('#sendManageState');
 
         // check the results of the public key test
-        await driver.delay(1000);
-        const manageStateResult = await driver.findElement(
-          '#sendManageStateResult',
-        );
-        assert.equal(await manageStateResult.getText(), 'true');
+        await driver.waitForSelector({
+          css: '#sendManageStateResult',
+          text: 'true',
+        });
 
         // check the results
-        await driver.delay(1000);
-        const retrieveManageStateResult = await driver.findElement(
-          '#retrieveManageStateResult',
-        );
-        assert.equal(
-          await retrieveManageStateResult.getText(),
-          '{ "items": [ "23" ] }',
-        );
+        await driver.waitForSelector({
+          css: '#retrieveManageStateResult',
+          text: '"23"',
+        });
 
         // click clear results
         await driver.clickElement('#clearManageState');
 
         // check if true
-        await driver.delay(1000);
-        const clearManageStateResult = await driver.findElement(
-          '#clearManageStateResult',
-        );
-        assert.equal(await clearManageStateResult.getText(), 'true');
+        await driver.waitForSelector({
+          css: '#clearManageStateResult',
+          text: 'true',
+        });
 
         // check result array is empty
+        await driver.waitForSelector({
+          css: '#retrieveManageStateResult',
+          text: '[]',
+        });
+
+        // repeat the same above steps to check unencrypted state management
+        // enter data and send
+        await driver.pasteIntoField('#dataUnencryptedManageState', '23');
+        await driver.scrollToElement(snapButton2);
         await driver.delay(1000);
-        const retrieveManageStateResult2 = await driver.findElement(
-          '#retrieveManageStateResult',
-        );
-        assert.equal(
-          await retrieveManageStateResult2.getText(),
-          '{ "items": [] }',
-        );
+        await driver.clickElement('#sendUnencryptedManageState');
+
+        // check the results of the public key test
+        await driver.waitForSelector({
+          css: '#sendUnencryptedManageStateResult',
+          text: 'true',
+        });
+
+        // check the results
+        await driver.waitForSelector({
+          css: '#retrieveManageStateUnencryptedResult',
+          text: '"23"',
+        });
+
+        // click clear results
+        await driver.clickElement('#clearUnencryptedManageState');
+
+        // check if true
+        await driver.waitForSelector({
+          css: '#clearUnencryptedManageStateResult',
+          text: 'true',
+        });
+
+        // check result array is empty
+        await driver.waitForSelector({
+          css: '#retrieveManageStateUnencryptedResult',
+          text: '[]',
+        });
       },
     );
   });


### PR DESCRIPTION
This PR adds testing for unencrypted storage for snaps, and updates the get-locale test to function properly.
It also updates the tests for speed and removal of asserts in favor of wait for selectors.

Closes https://github.com/MetaMask/MetaMask-planning/issues/1630