### PR TITLE
Fix #21716 - Fix alignment of NFT send button

### DIFF
--- a/ui/components/app/nft-details/__snapshots__/nft-details.test.js.snap
+++ b/ui/components/app/nft-details/__snapshots__/nft-details.test.js.snap
@@ -89,7 +89,7 @@ exports[`NFT Details should match minimal props and state snapshot 1`] = `
           </h5>
         </div>
         <div
-          class="box box--display-flex box--flex-direction-row box--width-1/2"
+          class="box box--display-flex box--flex-direction-row"
         >
           <button
             class="button btn--rounded btn-primary nft-details__send-button"

--- a/ui/components/app/nft-details/nft-details.js
+++ b/ui/components/app/nft-details/nft-details.js
@@ -143,11 +143,7 @@ export default function NftDetails({ nft }) {
       return <div style={{ height: '30px' }} />;
     }
     return (
-      <Box
-        display={Display.Flex}
-        width={inPopUp ? BlockSize.Full : BlockSize.Half}
-        margin={inPopUp ? [4, 0] : null}
-      >
+      <Box display={Display.Flex} margin={inPopUp ? [4, 0] : null}>
         <Button
           type="primary"
           onClick={onSend}

--- a/ui/components/app/nft-details/nft-details.js
+++ b/ui/components/app/nft-details/nft-details.js
@@ -13,7 +13,6 @@ import {
   OverflowWrap,
   FlexDirection,
   Display,
-  BlockSize,
 } from '../../../helpers/constants/design-system';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import {


### PR DESCRIPTION
## **Description**

Fixes alignment of the Send button in the NFT popup.

## **Related issues**

Fixes: #21716

## **Manual testing steps**

1. Open the MetaMask popup
2. Click on any NFT
3. See the send button properly aligned

## **Screenshots/Recordings**

### **Before**

![281055315-8c6219d7-3eff-49b1-976b-b586744e9849](https://github.com/MetaMask/metamask-extension/assets/46655/3a1648de-0585-46db-a634-4f264bb244c1)

### **After**

<img width="364" alt="SCR-20231113-nebq" src="https://github.com/MetaMask/metamask-extension/assets/46655/498192b5-c20b-474b-88ed-782f113472c6">

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've clearly explained what problem this PR is solving and how it is solved.
- [ ] I've linked related issues
- [ ] I've included manual testing steps
- [ ] I've included screenshots/recordings if applicable
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [ ] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
