### PR TITLE
Enable snap lifecycle hooks and getLocale in stable

### DIFF
--- a/shared/constants/permissions.test.js
+++ b/shared/constants/permissions.test.js
@@ -12,7 +12,6 @@ describe('EndowmentPermissions', () => {
     // test, so we re-add them here.
     expect(Object.keys(EndowmentPermissions).sort()).toStrictEqual(
       [
-        'endowment:lifecycle-hooks',
         'endowment:name-lookup',
         'endowment:page-home',
         ...Object.keys(endowmentPermissionBuilders).filter(

--- a/shared/constants/snaps/permissions.ts
+++ b/shared/constants/snaps/permissions.ts
@@ -5,9 +5,9 @@ export const EndowmentPermissions = Object.freeze({
   'endowment:ethereum-provider': 'endowment:ethereum-provider',
   'endowment:rpc': 'endowment:rpc',
   'endowment:webassembly': 'endowment:webassembly',
+  'endowment:lifecycle-hooks': 'endowment:lifecycle-hooks',
   ///: BEGIN:ONLY_INCLUDE_IN(build-flask)
   'endowment:page-home': 'endowment:page-home',
-  'endowment:lifecycle-hooks': 'endowment:lifecycle-hooks',
   'endowment:name-lookup': 'endowment:name-lookup',
   ///: END:ONLY_INCLUDE_IN
   ///: BEGIN:ONLY_INCLUDE_IN(keyring-snaps)
@@ -17,11 +17,6 @@ export const EndowmentPermissions = Object.freeze({
 
 // Methods / permissions in external packages that we are temporarily excluding.
 export const ExcludedSnapPermissions = Object.freeze({
-  // TODO: Enable in Flask
-  ///: BEGIN:ONLY_INCLUDE_IN(build-main)
-  snap_getLocale:
-    'This permission is still in development and therefore not available.',
-  ///: END:ONLY_INCLUDE_IN
   eth_accounts:
     'eth_accounts is disabled. For more information please see https://github.com/MetaMask/snaps/issues/990.',
 });
@@ -29,8 +24,6 @@ export const ExcludedSnapPermissions = Object.freeze({
 export const ExcludedSnapEndowments = Object.freeze({
   ///: BEGIN:ONLY_INCLUDE_IN(build-main)
   'endowment:page-home':
-    'This endowment is experimental and therefore not available.',
-  'endowment:lifecycle-hooks':
     'This endowment is experimental and therefore not available.',
   'endowment:name-lookup':
     'This permission is still in development and therefore not available.',

--- a/test/e2e/run-all.js
+++ b/test/e2e/run-all.js
@@ -8,9 +8,7 @@ const { exitWithError } = require('../../development/lib/exit-with-error');
 const { loadBuildTypesConfig } = require('../../development/lib/build-type');
 
 // These tests should only be run on Flask for now.
-const FLASK_ONLY_TESTS = [
-  'petnames.spec.js',
-];
+const FLASK_ONLY_TESTS = ['petnames.spec.js'];
 
 const getTestPathsForTestDir = async (testDir) => {
   const testFilenames = await fs.promises.readdir(testDir, {

--- a/test/e2e/run-all.js
+++ b/test/e2e/run-all.js
@@ -9,8 +9,6 @@ const { loadBuildTypesConfig } = require('../../development/lib/build-type');
 
 // These tests should only be run on Flask for now.
 const FLASK_ONLY_TESTS = [
-  'test-snap-lifecycle.spec.js',
-  'test-snap-get-locale.spec.js',
   'petnames.spec.js',
 ];
 


### PR DESCRIPTION
## **Description**

Enables two permissions in stable:
- `endowment:lifecycle-hooks`
- `snap_getLocale`

These are already fully implemented in Flask, this just enables them to be used in stable as well.

With this PR we also enable their E2E tests in stable.