### PR TITLE
UX: Send Flow: Show amount error with component

### DIFF
--- a/ui/components/multichain/asset-picker-amount/asset-picker-amount.stories.tsx
+++ b/ui/components/multichain/asset-picker-amount/asset-picker-amount.stories.tsx
@@ -56,7 +56,7 @@ ErrorStory.decorators = [
     <Provider
       store={store({
         asset: { type: AssetType.native },
-        amount: { error: 'bad' },
+        amount: { error: 'insufficientFunds' },
       })}
     >
       {story()}

--- a/ui/components/multichain/asset-picker-amount/asset-picker-amount.tsx
+++ b/ui/components/multichain/asset-picker-amount/asset-picker-amount.tsx
@@ -40,6 +40,7 @@ export const AssetPickerAmount = () => {
   const dispatch = useDispatch();
   const t = useI18nContext();
   const { asset, amount } = useSelector(getCurrentDraftTransaction);
+  const { error } = amount;
 
   if (!asset) {
     throw new Error('No asset is drafted for sending');
@@ -65,7 +66,6 @@ export const AssetPickerAmount = () => {
         borderWidth={2}
       >
         <AssetPicker asset={asset} />
-
         {asset.type === AssetType.native ? (
           <UserPreferencedCurrencyInput
             // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -99,7 +99,7 @@ export const AssetPickerAmount = () => {
       </Box>
       <Box display={Display.Flex}>
         <Text
-          color={TextColor.textAlternative}
+          color={error ? TextColor.errorDefault : TextColor.textAlternative}
           marginRight={1}
           variant={TextVariant.bodySm}
         >
@@ -112,11 +112,11 @@ export const AssetPickerAmount = () => {
             value={asset.balance}
             type={PRIMARY}
             textProps={{
-              color: TextColor.textAlternative,
+              color: error ? TextColor.errorDefault : TextColor.textAlternative,
               variant: TextVariant.bodySm,
             }}
             suffixProps={{
-              color: TextColor.textAlternative,
+              color: error ? TextColor.errorDefault : TextColor.textAlternative,
               variant: TextVariant.bodySm,
             }}
           />
@@ -125,10 +125,22 @@ export const AssetPickerAmount = () => {
           // @ts-ignore: Details should be defined for token assets
           <TokenBalance
             token={asset.details}
-            textProps={{ color: TextColor.textAlternative }}
-            suffixProps={{ color: TextColor.textAlternative }}
+            textProps={{
+              color: error ? TextColor.errorDefault : TextColor.textAlternative,
+            }}
+            suffixProps={{
+              color: error ? TextColor.errorDefault : TextColor.textAlternative,
+            }}
           />
         )}
+        {error ? (
+          <Text
+            variant={TextVariant.bodySm}
+            color={TextColor.errorDefault}
+          >
+            .{' '}{t(error)}
+          </Text>
+        ) : null}
       </Box>
     </Box>
   );

--- a/ui/components/multichain/asset-picker-amount/asset-picker-amount.tsx
+++ b/ui/components/multichain/asset-picker-amount/asset-picker-amount.tsx
@@ -35,7 +35,6 @@ import MaxClearButton from './max-clear-button';
 import AssetPicker from './asset-picker/asset-picker';
 
 // A component that combines an asset picker with an input for the amount to send.
-// Work in progress.
 export const AssetPickerAmount = () => {
   const dispatch = useDispatch();
   const t = useI18nContext();
@@ -45,6 +44,10 @@ export const AssetPickerAmount = () => {
   if (!asset) {
     throw new Error('No asset is drafted for sending');
   }
+
+  const balanceColor = error
+    ? TextColor.errorDefault
+    : TextColor.textAlternative;
 
   return (
     <Box className="asset-picker-amount">
@@ -98,11 +101,7 @@ export const AssetPickerAmount = () => {
         )}
       </Box>
       <Box display={Display.Flex}>
-        <Text
-          color={error ? TextColor.errorDefault : TextColor.textAlternative}
-          marginRight={1}
-          variant={TextVariant.bodySm}
-        >
+        <Text color={balanceColor} marginRight={1} variant={TextVariant.bodySm}>
           {t('balance')}:
         </Text>
         {asset.type === AssetType.native ? (
@@ -112,11 +111,11 @@ export const AssetPickerAmount = () => {
             value={asset.balance}
             type={PRIMARY}
             textProps={{
-              color: error ? TextColor.errorDefault : TextColor.textAlternative,
+              color: balanceColor,
               variant: TextVariant.bodySm,
             }}
             suffixProps={{
-              color: error ? TextColor.errorDefault : TextColor.textAlternative,
+              color: balanceColor,
               variant: TextVariant.bodySm,
             }}
           />
@@ -126,10 +125,10 @@ export const AssetPickerAmount = () => {
           <TokenBalance
             token={asset.details}
             textProps={{
-              color: error ? TextColor.errorDefault : TextColor.textAlternative,
+              color: balanceColor,
             }}
             suffixProps={{
-              color: error ? TextColor.errorDefault : TextColor.textAlternative,
+              color: balanceColor,
             }}
           />
         )}

--- a/ui/components/multichain/asset-picker-amount/asset-picker-amount.tsx
+++ b/ui/components/multichain/asset-picker-amount/asset-picker-amount.tsx
@@ -134,11 +134,8 @@ export const AssetPickerAmount = () => {
           />
         )}
         {error ? (
-          <Text
-            variant={TextVariant.bodySm}
-            color={TextColor.errorDefault}
-          >
-            .{' '}{t(error)}
+          <Text variant={TextVariant.bodySm} color={TextColor.errorDefault}>
+            . {t(error)}
           </Text>
         ) : null}
       </Box>


### PR DESCRIPTION
## **Description**

While the `AssetPickerAmount` does highlight the amount in read when there's an error, it does not show the actual error text, which could cause confusion for the user.  This PR adds the error text to the component.

## **Related issues**

Fixes: N/A

## **Manual testing steps**

1. Open the new send flow
2. Choose a recipient
3. Enter a super large amount
4. See error text

## **Screenshots/Recordings**

### **Before**

N/A

### **After**

<img width="442" alt="SCR-20231114-mybe" src="https://github.com/MetaMask/metamask-extension/assets/46655/ca64741c-6c34-4a1e-9a1a-ff217070f852">



## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've clearly explained what problem this PR is solving and how it is solved.
- [ ] I've linked related issues
- [ ] I've included manual testing steps
- [ ] I've included screenshots/recordings if applicable
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [ ] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
