### PR TITLE
Autosuggest Ticker Symbols for Network form (user initiated)

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -4720,6 +4720,9 @@
   "suggestedBy": {
     "message": "Suggested by"
   },
+  "suggestedTokenSymbol":{
+    "message": "Suggested ticker symbol:"
+  },
   "support": {
     "message": "Support"
   },

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -4720,7 +4720,7 @@
   "suggestedBy": {
     "message": "Suggested by"
   },
-  "suggestedTokenSymbol":{
+  "suggestedTokenSymbol": {
     "message": "Suggested ticker symbol:"
   },
   "support": {

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -716,7 +716,7 @@
     "message": "This Chain ID is currently used by the $1 network."
   },
   "chainListReturnedDifferentTickerSymbol": {
-    "message": "This network doesn’t match its associated chain ID or name. Many popular tokens use the name [$1], making it a target for scams. Scammers may trick you into sending them more valuable currency in return. Verify everything before you continue.",
+    "message": "This network doesn’t match its associated chain ID or name. Many popular tokens use the name $1, making it a target for scams. Scammers may trick you into sending them more valuable currency in return. Verify everything before you continue.",
     "description": "$1 is the symbol of the network that was returned by the chain list"
   },
   "chooseYourNetwork": {

--- a/test/e2e/tests/add-custom-network.spec.js
+++ b/test/e2e/tests/add-custom-network.spec.js
@@ -712,12 +712,7 @@ async function failCandidateNetworkValidation(driver) {
     tag: 'h6',
   };
   await driver.waitForSelector(chainIdValidationMessageRawLocator);
-
-  const tickerSymbolValidationMessageRawLocator = {
-    text: 'Ticker symbol verification data is currently unavailable, make sure that the symbol you have entered is correct. It will impact the conversion rates that you see for this network',
-    tag: 'h6',
-  };
-  await driver.waitForSelector(tickerSymbolValidationMessageRawLocator);
+  await driver.waitForSelector('[data-testid="network-form-ticker-warning"]');
 
   const saveButtonRawLocator = {
     text: 'Save',

--- a/test/e2e/tests/add-custom-network.spec.js
+++ b/test/e2e/tests/add-custom-network.spec.js
@@ -697,14 +697,14 @@ async function failCandidateNetworkValidation(driver) {
     networkNameInputEl,
     newRPCURLInputEl,
     chainIDInputEl,
-    currencySymbolInputEl,
+    ,
     blockExplorerURLInputEl,
   ] = await driver.findElements('input');
 
   await networkNameInputEl.fill('cheapETH');
   await newRPCURLInputEl.fill('https://unresponsive-rpc.url');
   await chainIDInputEl.fill(toHex(777));
-  await currencySymbolInputEl.fill('cTH');
+  await driver.fill('[data-testid="network-form-ticker-input"]', 'cTH');
   await blockExplorerURLInputEl.fill('https://block-explorer.url');
 
   const chainIdValidationMessageRawLocator = {
@@ -804,14 +804,14 @@ async function candidateNetworkIsNotValidated(driver) {
     networkNameInputEl,
     newRPCURLInputEl,
     chainIDInputEl,
-    currencySymbolInputEl,
+    ,
     blockExplorerURLInputEl,
   ] = await driver.findElements('input');
 
   await networkNameInputEl.fill('cheapETH');
   await newRPCURLInputEl.fill('https://responsive-rpc.url/');
   await chainIDInputEl.fill(TEST_CHAIN_ID);
-  await currencySymbolInputEl.fill('cTH');
+  await driver.fill('[data-testid="network-form-ticker-input"]', 'cTH');
   await blockExplorerURLInputEl.fill('https://block-explorer.url');
 
   const saveButtonRawLocator = {

--- a/ui/components/component-library/form-text-field/form-text-field.js
+++ b/ui/components/component-library/form-text-field/form-text-field.js
@@ -147,7 +147,7 @@ FormTextField.propTypes = {
   /**
    * The content of the HelpText component
    */
-  helpText: PropTypes.string,
+  helpText: PropTypes.oneOfType([PropTypes.node, PropTypes.string]),
   /**
    * Props that are applied to the HelpText component
    */

--- a/ui/pages/onboarding-flow/add-network-modal/__snapshots__/add-network-modal.test.js.snap
+++ b/ui/pages/onboarding-flow/add-network-modal/__snapshots__/add-network-modal.test.js.snap
@@ -152,34 +152,26 @@ exports[`Add Network Modal should render 1`] = `
         </label>
       </div>
       <div
-        class="form-field"
+        class="box mm-form-text-field box--display-flex box--flex-direction-column"
+        data-testid="network-form-ticker"
       >
         <label
-          class="mm-box"
+          class="mm-box mm-text mm-label mm-form-text-field__label mm-text--body-sm mm-text--font-weight-bold mm-box--padding-top-1 mm-box--padding-bottom-1 mm-box--display-inline-flex mm-box--align-items-center mm-box--color-text-default"
         >
-          <div
-            class="form-field__heading"
-          >
-            <div
-              class="mm-box form-field__heading-title mm-box--display-flex mm-box--align-items-baseline"
-            >
-              <h6
-                class="mm-box mm-text mm-text--body-sm-bold mm-box--display-inline-block mm-box--color-text-default"
-              >
-                Currency symbol
-              </h6>
-              
-              
-            </div>
-            
-          </div>
+          Currency symbol
+        </label>
+        <div
+          class="box mm-text-field mm-text-field--size-md mm-text-field--truncate mm-form-text-field__text-field box--display-inline-flex box--flex-direction-row box--align-items-center box--background-color-background-default box--rounded-sm box--border-width-1 box--border-style-solid"
+        >
           <input
-            class="form-field__input"
+            autocomplete="off"
+            class="mm-box mm-text mm-input mm-input--disable-state-styles mm-text-field__input mm-text--body-sm mm-box--margin-0 mm-box--padding-0 mm-box--padding-right-4 mm-box--padding-left-2 mm-box--color-text-default mm-box--background-color-transparent mm-box--border-style-none"
+            data-testid="network-form-ticker-input"
+            focused="false"
             type="text"
             value=""
           />
-          
-        </label>
+        </div>
       </div>
       <div
         class="form-field"

--- a/ui/pages/settings/networks-tab/networks-form/networks-form.js
+++ b/ui/pages/settings/networks-tab/networks-form/networks-form.js
@@ -42,6 +42,11 @@ import {
   showModal,
   upsertNetworkConfiguration,
 } from '../../../../store/actions';
+import { Text } from '../../../../components/component-library';
+import {
+  TextColor,
+  TextVariant,
+} from '../../../../helpers/constants/design-system';
 
 /**
  * Attempts to convert the given chainId to a decimal string, for display
@@ -93,6 +98,7 @@ const NetworksForm = ({
   const [rpcUrl, setRpcUrl] = useState(selectedNetwork?.rpcUrl || '');
   const [chainId, setChainId] = useState(selectedNetwork?.chainId || '');
   const [ticker, setTicker] = useState(selectedNetwork?.ticker || '');
+  const [suggestedTicker, setSuggestedTicker] = useState('');
   const [blockExplorerUrl, setBlockExplorerUrl] = useState(
     selectedNetwork?.blockExplorerUrl || '',
   );
@@ -407,6 +413,7 @@ const NetworksForm = ({
             warningMessage = t('chainListReturnedDifferentTickerSymbol', [
               returnedTickerSymbol,
             ]);
+            setSuggestedTicker(returnedTickerSymbol);
           }
         }
       }
@@ -704,6 +711,25 @@ const NetworksForm = ({
           value={ticker}
           disabled={viewOnly}
         />
+        {suggestedTicker ? (
+          <Text
+            as="span"
+            variant={TextVariant.bodySm}
+            color={TextColor.textDefault}
+          >
+            Suggested ticker symbol:{' '}
+            <Text
+              as="span"
+              variant={TextVariant.bodySm}
+              color={TextColor.primaryDefault}
+              onClick={() => {
+                setTicker(suggestedTicker);
+              }}
+            >
+              {suggestedTicker}
+            </Text>
+          </Text>
+        ) : null}
         <FormField
           error={errors.blockExplorerUrl?.msg || ''}
           onChange={(value) => {

--- a/ui/pages/settings/networks-tab/networks-form/networks-form.js
+++ b/ui/pages/settings/networks-tab/networks-form/networks-form.js
@@ -17,6 +17,7 @@ import {
   MetaMetricsNetworkEventSource,
 } from '../../../../../shared/constants/metametrics';
 import {
+  BUILT_IN_NETWORKS,
   FEATURED_RPCS,
   infuraProjectId,
 } from '../../../../../shared/constants/network';
@@ -43,6 +44,7 @@ import {
   upsertNetworkConfiguration,
 } from '../../../../store/actions';
 import {
+  ButtonLink,
   FormTextField,
   HelpText,
   HelpTextSeverity,
@@ -131,6 +133,15 @@ const NetworksForm = ({
           url: 'https://chainid.network/chains.json',
           functionName: 'getSafeChainsList',
         });
+        Object.values(BUILT_IN_NETWORKS).forEach((network) => {
+          const index = chainList.findIndex(
+            (chain) =>
+              chain.chainId.toString() === getDisplayChainId(network.chainId),
+          );
+          if (network.ticker && index !== -1) {
+            chainList[index].nativeCurrency.symbol = network.ticker;
+          }
+        });
         safeChainsList.current = chainList;
       } catch (error) {
         log.warn('Failed to fetch chainList from chainid.network', error);
@@ -149,6 +160,7 @@ const NetworksForm = ({
     setBlockExplorerUrl(selectedNetwork?.blockExplorerUrl);
     setErrors({});
     setWarnings({});
+    setSuggestedTicker('');
     setIsSubmitting(false);
     setIsEditing(false);
     setPreviousNetwork(selectedNetwork);
@@ -245,11 +257,7 @@ const NetworksForm = ({
 
   const autoSuggestTicker = useCallback((formChainId) => {
     const decimalChainId = getDisplayChainId(formChainId);
-    if (
-      !decimalChainId ||
-      decimalChainId.trim() === '' ||
-      safeChainsList.current.length === 0
-    ) {
+    if (decimalChainId.trim() === '' || safeChainsList.current.length === 0) {
       setSuggestedTicker('');
       return;
     }
@@ -738,16 +746,17 @@ const NetworksForm = ({
                 color={TextColor.textDefault}
               >
                 {t('suggestedTokenSymbol')}{' '}
-                <Text
-                  as="span"
+                <ButtonLink
+                  as="button"
                   variant={TextVariant.bodySm}
                   color={TextColor.primaryDefault}
                   onClick={() => {
                     setTicker(suggestedTicker);
                   }}
+                  style={{ verticalAlign: 'baseline' }}
                 >
                   {suggestedTicker}
-                </Text>
+                </ButtonLink>
               </Text>
             ) : null
           }

--- a/ui/pages/settings/networks-tab/networks-form/networks-form.js
+++ b/ui/pages/settings/networks-tab/networks-form/networks-form.js
@@ -243,26 +243,26 @@ const NetworksForm = ({
     dispatch,
   ]);
 
-  const autoSuggestTicker = useCallback(
-    async (formChainId) => {
-      if (!formChainId || safeChainsList.current.length === 0) {
-        return;
-      }
-      const matchedChain = safeChainsList.current?.find(
-        (chain) => chain.chainId.toString() === formChainId,
-      );
-      if (matchedChain === undefined) {
-        setSuggestedTicker('');
-        return;
-      }
-
-      const returnedTickerSymbol = matchedChain.nativeCurrency?.symbol;
-      if (returnedTickerSymbol !== ticker) {
-        setSuggestedTicker(returnedTickerSymbol);
-      }
-    },
-    [ticker],
-  );
+  const autoSuggestTicker = useCallback((formChainId) => {
+    const decimalChainId = getDisplayChainId(formChainId);
+    if (
+      !decimalChainId ||
+      decimalChainId.trim() === '' ||
+      safeChainsList.current.length === 0
+    ) {
+      setSuggestedTicker('');
+      return;
+    }
+    const matchedChain = safeChainsList.current?.find(
+      (chain) => chain.chainId.toString() === decimalChainId,
+    );
+    if (matchedChain === undefined) {
+      setSuggestedTicker('');
+      return;
+    }
+    const returnedTickerSymbol = matchedChain.nativeCurrency?.symbol;
+    setSuggestedTicker(returnedTickerSymbol);
+  }, []);
 
   const hasErrors = () => {
     return Object.keys(errors).some((key) => {
@@ -421,8 +421,9 @@ const NetworksForm = ({
     async (formChainId, formTickerSymbol) => {
       let warningKey;
       let warningMessage;
+      const decimalChainId = getDisplayChainId(formChainId);
 
-      if (!formChainId || !formTickerSymbol) {
+      if (!decimalChainId || !formTickerSymbol) {
         return null;
       }
 
@@ -431,7 +432,7 @@ const NetworksForm = ({
         warningMessage = t('failedToFetchTickerSymbolData');
       } else {
         const matchedChain = safeChainsList.current?.find(
-          (chain) => chain.chainId.toString() === formChainId,
+          (chain) => chain.chainId.toString() === decimalChainId,
         );
 
         if (matchedChain === undefined) {
@@ -761,7 +762,11 @@ const NetworksForm = ({
             paddingBottom: 1,
             paddingTop: 1,
           }}
-          inputProps={{ paddingLeft: 2, variant: TextVariant.bodySm }}
+          inputProps={{
+            paddingLeft: 2,
+            variant: TextVariant.bodySm,
+            'data-testid': 'network-form-ticker-input',
+          }}
           value={ticker}
           disabled={viewOnly}
         />

--- a/ui/pages/settings/networks-tab/networks-form/networks-form.js
+++ b/ui/pages/settings/networks-tab/networks-form/networks-form.js
@@ -42,8 +42,14 @@ import {
   showModal,
   upsertNetworkConfiguration,
 } from '../../../../store/actions';
-import { Text } from '../../../../components/component-library';
 import {
+  FormTextField,
+  HelpText,
+  HelpTextSeverity,
+  Text,
+} from '../../../../components/component-library';
+import {
+  FontWeight,
   TextColor,
   TextVariant,
 } from '../../../../helpers/constants/design-system';
@@ -695,40 +701,53 @@ const NetworksForm = ({
           disabled={viewOnly}
           tooltipText={viewOnly ? null : t('networkSettingsChainIdDescription')}
         />
-        <FormField
-          warning={warnings.ticker?.msg || ''}
-          warningProps={{
-            'data-testid': 'network-form-ticker-warning',
-            style: {
-              color: 'var(--color-warning-default)',
-            },
-          }}
-          onChange={(value) => {
+        <FormTextField
+          data-testid="network-form-ticker"
+          helpText={
+            suggestedTicker ? (
+              <Text
+                as="span"
+                variant={TextVariant.bodySm}
+                color={TextColor.textDefault}
+              >
+                {t('suggestedTokenSymbol')}{' '}
+                <Text
+                  as="span"
+                  variant={TextVariant.bodySm}
+                  color={TextColor.primaryDefault}
+                  onClick={() => {
+                    setTicker(suggestedTicker);
+                  }}
+                >
+                  {suggestedTicker}
+                </Text>
+              </Text>
+            ) : null
+          }
+          onChange={(e) => {
             setIsEditing(true);
-            setTicker(value);
+            setTicker(e.target.value);
+            console.log(ticker, e.target.value);
           }}
-          titleText={t('currencySymbol')}
+          label={t('currencySymbol')}
+          labelProps={{
+            variant: TextVariant.bodySm,
+            fontWeight: FontWeight.Bold,
+            paddingBottom: 1,
+            paddingTop: 1,
+          }}
+          inputProps={{ paddingLeft: 2, variant: TextVariant.bodySm }}
           value={ticker}
           disabled={viewOnly}
         />
-        {suggestedTicker ? (
-          <Text
-            as="span"
-            variant={TextVariant.bodySm}
-            color={TextColor.textDefault}
+        {warnings.ticker?.msg ? (
+          <HelpText
+            severity={HelpTextSeverity.Warning}
+            marginTop={1}
+            data-testid="network-form-ticker-warning"
           >
-            Suggested ticker symbol:{' '}
-            <Text
-              as="span"
-              variant={TextVariant.bodySm}
-              color={TextColor.primaryDefault}
-              onClick={() => {
-                setTicker(suggestedTicker);
-              }}
-            >
-              {suggestedTicker}
-            </Text>
-          </Text>
+            {warnings.ticker?.msg}
+          </HelpText>
         ) : null}
         <FormField
           error={errors.blockExplorerUrl?.msg || ''}

--- a/ui/pages/settings/networks-tab/networks-form/networks-form.js
+++ b/ui/pages/settings/networks-tab/networks-form/networks-form.js
@@ -745,7 +745,7 @@ const NetworksForm = ({
                 variant={TextVariant.bodySm}
                 color={TextColor.textDefault}
               >
-                {t('suggestedTokenSymbol')}{' '}
+                {t('suggestedTokenSymbol')}
                 <ButtonLink
                   as="button"
                   variant={TextVariant.bodySm}
@@ -753,6 +753,8 @@ const NetworksForm = ({
                   onClick={() => {
                     setTicker(suggestedTicker);
                   }}
+                  paddingLeft={1}
+                  paddingRight={1}
                   style={{ verticalAlign: 'baseline' }}
                 >
                   {suggestedTicker}
@@ -785,7 +787,7 @@ const NetworksForm = ({
             marginTop={1}
             data-testid="network-form-ticker-warning"
           >
-            {warnings.ticker?.msg}
+            {warnings.ticker.msg}
           </HelpText>
         ) : null}
         <FormField

--- a/ui/pages/settings/networks-tab/networks-form/networks-form.test.js
+++ b/ui/pages/settings/networks-tab/networks-form/networks-form.test.js
@@ -198,9 +198,7 @@ describe('NetworkForm Component', () => {
     renderComponent(propNewNetwork);
     const chainIdField = screen.getByRole('textbox', { name: 'Chain ID' });
     const rpcUrlField = screen.getByRole('textbox', { name: 'New RPC URL' });
-    const currencySymbolField = screen.getByRole('textbox', {
-      name: 'Currency symbol',
-    });
+    const currencySymbolField = screen.getByTestId('network-form-ticker-input');
 
     fireEvent.change(chainIdField, {
       target: { value: '1' },
@@ -258,9 +256,7 @@ describe('NetworkForm Component', () => {
     renderComponent(propNewNetwork);
 
     const chainIdField = screen.getByRole('textbox', { name: 'Chain ID' });
-    const currencySymbolField = screen.getByRole('textbox', {
-      name: 'Currency symbol',
-    });
+    const currencySymbolField = screen.getByTestId('network-form-ticker-input');
 
     fireEvent.change(chainIdField, {
       target: { value: '1234' },


### PR DESCRIPTION
## **Description**
We want to show a "Suggested ticker symbol" as user enters in their ChainID in the Network form, which should help provide additional context to keep users from getting scammed. 

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Related issues**

Fixes: [#1488](https://github.com/MetaMask/MetaMask-planning/issues/1488)

## **Manual testing steps**
1. Open extension
2. Go to the Settings > Networks
3. Add New Network or Edit an existing network
4. Type 137 into chain id field make sure that the "Suggested ticker symbol" changes dynamically as you type.
5. Type 'ETH' in the Currency Symbol field, and the mismatch warning and suggested ticker should show as 'MATIC'.
6. Click the Suggested ticker symbol once and the "Currency symbol" textfield in the form should auto-populate as 'MATIC'.
7. Continue to edit the Currency Symbol field, the mismatch warning should show again.

## **Screenshots/Recordings**
<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

https://github.com/MetaMask/metamask-extension/assets/10986371/184277c4-4965-497c-bf32-8675cd101ab2

## **Pre-merge author checklist**

- [X] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've clearly explained what problem this PR is solving and how it is solved.
- [X] I've linked related issues
- [X] I've included manual testing steps
- [X] I've included screenshots/recordings if applicable
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [X] I’ve properly set the pull request status:
  - [X] In case it's not yet "ready for review", I've set it to "draft".
  - [X] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
