### PR TITLE
UX: Send Flow: Use constants for contacts and accounts tabs

### DIFF
--- a/ui/components/multichain/pages/send/components/recipient.tsx
+++ b/ui/components/multichain/pages/send/components/recipient.tsx
@@ -25,6 +25,9 @@ import { ellipsify } from '../../../../../pages/send/send.utils';
 import { Tab, Tabs } from '../../../../ui/tabs';
 import { SendPageAddressBook, SendPageRow, SendPageYourAccount } from '.';
 
+const CONTACTS_TAB_KEY = 'contacts';
+const ACCOUNTS_TAB_KEY = 'accounts';
+
 const renderExplicitAddress = (
   address: string,
   nickname: string,
@@ -101,18 +104,20 @@ export const SendPageRecipient = () => {
     );
   } else {
     contents = (
-      <Tabs defaultActiveTabKey={userInput ? 'contacts' : 'accounts'}>
+      <Tabs
+        defaultActiveTabKey={userInput ? CONTACTS_TAB_KEY : ACCOUNTS_TAB_KEY}
+      >
         {
           // eslint-disable-next-line @typescript-eslint/ban-ts-comment
           // @ts-ignore
-          <Tab tabKey="accounts" name={t('yourAccounts')}>
+          <Tab tabKey={ACCOUNTS_TAB_KEY} name={t('yourAccounts')}>
             <SendPageYourAccount />
           </Tab>
         }
         {
           // eslint-disable-next-line @typescript-eslint/ban-ts-comment
           // @ts-ignore
-          <Tab tabKey="contacts" name={t('contacts')}>
+          <Tab tabKey={CONTACTS_TAB_KEY} name={t('contacts')}>
             <SendPageAddressBook />
           </Tab>
         }


### PR DESCRIPTION
## **Description**

Instead of repeating constant strings, we may as well use constant variables.

## **Related issues**

Fixes: N/A

## **Manual testing steps**

N/A: Not functional

## **Screenshots/Recordings**

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've clearly explained what problem this PR is solving and how it is solved.
- [ ] I've linked related issues
- [ ] I've included manual testing steps
- [ ] I've included screenshots/recordings if applicable
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [ ] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
