### PR TITLE
[MMI] prevent back button from showing when we are in popup view

### DIFF
--- a/ui/pages/institutional/connect-custody/__snapshots__/account-list.test.js.snap
+++ b/ui/pages/institutional/connect-custody/__snapshots__/account-list.test.js.snap
@@ -29,7 +29,7 @@ exports[`CustodyAccountList renders accounts 1`] = `
             class="mm-box mm-box--margin-left-2 mm-box--display-flex mm-box--flex-direction-column mm-box--width-full"
           >
             <label
-              class="mm-box mm-text mm-label mm-label--html-for custody-account-list__item__title mm-text--body-md mm-text--font-weight-medium mm-box--margin-top-2 mm-box--margin-left-2 mm-box--display-flex mm-box--align-items-center mm-box--color-text-default"
+              class="mm-box mm-text mm-label mm-label--html-for custody-account-list__item__title mm-text--body-md mm-text--font-weight-medium mm-box--margin-top-2 mm-box--display-flex mm-box--align-items-center mm-box--color-text-default"
               for="address-0"
             >
               <span
@@ -104,7 +104,7 @@ exports[`CustodyAccountList renders accounts 1`] = `
             class="mm-box mm-box--margin-left-2 mm-box--display-flex mm-box--flex-direction-column mm-box--width-full"
           >
             <label
-              class="mm-box mm-text mm-label mm-label--html-for custody-account-list__item__title mm-text--body-md mm-text--font-weight-medium mm-box--margin-top-2 mm-box--margin-left-2 mm-box--display-flex mm-box--align-items-center mm-box--color-text-default"
+              class="mm-box mm-text mm-label mm-label--html-for custody-account-list__item__title mm-text--body-md mm-text--font-weight-medium mm-box--margin-top-2 mm-box--display-flex mm-box--align-items-center mm-box--color-text-default"
               for="address-1"
             >
               <span

--- a/ui/pages/institutional/connect-custody/account-list.js
+++ b/ui/pages/institutional/connect-custody/account-list.js
@@ -23,8 +23,8 @@ import {
   IconName,
   IconSize,
   ButtonLink,
-  BUTTON_VARIANT,
-  BUTTON_SIZES,
+  ButtonSize,
+  ButtonVariant,
   Text,
 } from '../../../components/component-library';
 import { useCopyToClipboard } from '../../../hooks/useCopyToClipboard';
@@ -42,6 +42,7 @@ export default function CustodyAccountList({
   onCancel,
   onAddAccounts,
   custody,
+  children,
 }) {
   const t = useI18nContext();
   const [copied, handleCopy] = useCopyToClipboard();
@@ -52,6 +53,7 @@ export default function CustodyAccountList({
   return (
     <Box className="page-container">
       <Box padding={4} className="page-container__content">
+        {children}
         <Box
           display={Display.Flex}
           flexDirection={FlexDirection.Column}
@@ -103,7 +105,6 @@ export default function CustodyAccountList({
                   <Label
                     display={Display.Flex}
                     marginTop={2}
-                    marginLeft={2}
                     htmlFor={`address-${idx}`}
                     className="custody-account-list__item__title"
                   >
@@ -185,8 +186,8 @@ export default function CustodyAccountList({
             <Button
               data-testid="custody-account-cancel-button"
               block
-              variant={BUTTON_VARIANT.SECONDARY}
-              size={BUTTON_SIZES.LG}
+              variant={ButtonVariant.Secondary}
+              size={ButtonSize.Lg}
               className="custody-account-list__button"
               onClick={onCancel}
             >
@@ -195,8 +196,8 @@ export default function CustodyAccountList({
             <Button
               data-testid="custody-account-connect-button"
               block
-              variant={BUTTON_VARIANT.PRIMARY}
-              size={BUTTON_SIZES.LG}
+              variant={ButtonVariant.Primary}
+              size={ButtonSize.Lg}
               className="custody-account-list__button"
               disabled={disabled}
               onClick={() => onAddAccounts(custody)}

--- a/ui/pages/institutional/connect-custody/account-list.js
+++ b/ui/pages/institutional/connect-custody/account-list.js
@@ -219,4 +219,5 @@ CustodyAccountList.propTypes = {
   onAddAccounts: PropTypes.func,
   onCancel: PropTypes.func,
   rawList: PropTypes.bool,
+  children: PropTypes.node,
 };

--- a/ui/pages/institutional/connect-custody/index.scss
+++ b/ui/pages/institutional/connect-custody/index.scss
@@ -6,7 +6,7 @@
     border-bottom: 1px solid #d2d8dd;
 
     input {
-      margin: 12px 0 0 10px;
+      margin: 12px 0 0 4px;
     }
 
     &__title {

--- a/ui/pages/institutional/custody/custody.js
+++ b/ui/pages/institutional/custody/custody.js
@@ -560,15 +560,104 @@ const CustodyPage = () => {
         </>
       )}
       {accounts && accounts.length > 0 && (
-        <>
-          <Box padding={[5, 7, 2]} width={BlockSize.Full}>
+        <CustodyAccountList
+          custody={selectedCustodianName}
+          accounts={accounts}
+          onAccountChange={(account) => {
+            setSelectedAccounts((prevSelectedAccounts) => {
+              const updatedSelectedAccounts = { ...prevSelectedAccounts };
+
+              if (updatedSelectedAccounts[account.address]) {
+                delete updatedSelectedAccounts[account.address];
+              } else {
+                updatedSelectedAccounts[account.address] = {
+                  name: account.name,
+                  custodianDetails: account.custodianDetails,
+                  labels: account.labels,
+                  token: currentJwt,
+                  apiUrl,
+                  chainId: account.chainId,
+                  custodyType: selectedCustodianType,
+                  custodyName: selectedCustodianName,
+                };
+              }
+
+              return updatedSelectedAccounts;
+            });
+          }}
+          selectedAccounts={selectedAccounts}
+          onAddAccounts={async () => {
+            try {
+              const selectedCustodian = custodians.find(
+                (custodian) => custodian.envName === selectedCustodianName,
+              );
+              const firstAccountKey = Object.keys(selectedAccounts).shift();
+
+              await dispatch(
+                mmiActions.connectCustodyAddresses(
+                  selectedCustodianType,
+                  selectedCustodianName,
+                  selectedAccounts,
+                ),
+              );
+
+              dispatch(setSelectedAddress(firstAccountKey.toLowerCase()));
+
+              trackEvent({
+                category: MetaMetricsEventCategory.MMI,
+                event: MetaMetricsEventName.CustodialAccountsConnected,
+                properties: {
+                  custodian: selectedCustodianName,
+                  numberOfAccounts: Object.keys(selectedAccounts).length,
+                  chainId,
+                },
+              });
+
+              history.push({
+                pathname: CUSTODY_ACCOUNT_DONE_ROUTE,
+                state: {
+                  imgSrc: selectedCustodian && selectedCustodian.iconUrl,
+                  title: t('custodianAccountAddedTitle', [
+                    (selectedCustodian && selectedCustodian.displayName) ||
+                      'Custodian',
+                  ]),
+                  description: t('custodianAccountAddedDesc'),
+                },
+              });
+            } catch (e) {
+              setSelectError(e.message);
+            }
+          }}
+          onCancel={() => {
+            setAccounts(null);
+            setSelectedCustodianName(null);
+            setSelectedCustodianType(null);
+            setSelectedAccounts({});
+            setCurrentJwt('');
+            setApiUrl('');
+            setAddNewTokenClicked(false);
+
+            history.push(DEFAULT_ROUTE);
+
+            trackEvent({
+              category: MetaMetricsEventCategory.MMI,
+              event: MetaMetricsEventName.CustodianConnectionCanceled,
+              properties: {
+                custodian: selectedCustodianName,
+                numberOfAccounts: Object.keys(selectedAccounts).length,
+                chainId,
+              },
+            });
+          }}
+        >
+          <Box paddingTop={4} paddingBottom={4} width={BlockSize.Full}>
             <Text as="h4">{t('selectAnAccount')}</Text>
             <Text marginTop={2} marginBottom={2}>
               {t('selectAnAccountHelp')}
             </Text>
           </Box>
           <Box
-            padding={[5, 7, 0]}
+            paddingBottom={4}
             display={Display.Flex}
             flexDirection={FlexDirection.Row}
             justifyContent={JustifyContent.flexStart}
@@ -579,111 +668,22 @@ const CustodyPage = () => {
               id="selectAllAccounts"
               data-testid={`select-all-accounts-selected-${isCheckBoxSelected}`}
               name="selectAllAccounts"
-              marginRight={2}
               marginLeft={2}
               value={{}}
               onChange={(e) => setSelectAllAccounts(e)}
               checked={isCheckBoxSelected}
             />
-            <Label htmlFor="selectAllAccounts">{t('selectAllAccounts')}</Label>
+            <Label marginLeft={2} htmlFor="selectAllAccounts">
+              {t('selectAllAccounts')}
+            </Label>
           </Box>
-          <CustodyAccountList
-            custody={selectedCustodianName}
-            accounts={accounts}
-            onAccountChange={(account) => {
-              setSelectedAccounts((prevSelectedAccounts) => {
-                const updatedSelectedAccounts = { ...prevSelectedAccounts };
-
-                if (updatedSelectedAccounts[account.address]) {
-                  delete updatedSelectedAccounts[account.address];
-                } else {
-                  updatedSelectedAccounts[account.address] = {
-                    name: account.name,
-                    custodianDetails: account.custodianDetails,
-                    labels: account.labels,
-                    token: currentJwt,
-                    apiUrl,
-                    chainId: account.chainId,
-                    custodyType: selectedCustodianType,
-                    custodyName: selectedCustodianName,
-                  };
-                }
-
-                return updatedSelectedAccounts;
-              });
-            }}
-            selectedAccounts={selectedAccounts}
-            onAddAccounts={async () => {
-              try {
-                const selectedCustodian = custodians.find(
-                  (custodian) => custodian.envName === selectedCustodianName,
-                );
-                const firstAccountKey = Object.keys(selectedAccounts).shift();
-
-                await dispatch(
-                  mmiActions.connectCustodyAddresses(
-                    selectedCustodianType,
-                    selectedCustodianName,
-                    selectedAccounts,
-                  ),
-                );
-
-                dispatch(setSelectedAddress(firstAccountKey.toLowerCase()));
-
-                trackEvent({
-                  category: MetaMetricsEventCategory.MMI,
-                  event: MetaMetricsEventName.CustodialAccountsConnected,
-                  properties: {
-                    custodian: selectedCustodianName,
-                    numberOfAccounts: Object.keys(selectedAccounts).length,
-                    chainId,
-                  },
-                });
-
-                history.push({
-                  pathname: CUSTODY_ACCOUNT_DONE_ROUTE,
-                  state: {
-                    imgSrc: selectedCustodian && selectedCustodian.iconUrl,
-                    title: t('custodianAccountAddedTitle', [
-                      (selectedCustodian && selectedCustodian.displayName) ||
-                        'Custodian',
-                    ]),
-                    description: t('custodianAccountAddedDesc'),
-                  },
-                });
-              } catch (e) {
-                setSelectError(e.message);
-              }
-            }}
-            onCancel={() => {
-              setAccounts(null);
-              setSelectedCustodianName(null);
-              setSelectedCustodianType(null);
-              setSelectedAccounts({});
-              setCurrentJwt('');
-              setApiUrl('');
-              setAddNewTokenClicked(false);
-
-              history.push(DEFAULT_ROUTE);
-
-              trackEvent({
-                category: MetaMetricsEventCategory.MMI,
-                event: MetaMetricsEventName.CustodianConnectionCanceled,
-                properties: {
-                  custodian: selectedCustodianName,
-                  numberOfAccounts: Object.keys(selectedAccounts).length,
-                  chainId,
-                },
-              });
-            }}
-          />
-        </>
+        </CustodyAccountList>
       )}
       {accounts && accounts.length === 0 && (
-        <>
+        <Box className="page-container">
           <Box
             data-testid="custody-accounts-empty"
-            padding={[6, 7, 2]}
+            padding={7}
             className="page-container__content"
           >
             <Text
@@ -708,7 +708,7 @@ const CustodyPage = () => {
               {t('close')}
             </Button>
           </Box>
-        </>
+        </Box>
       )}
 
       {isConfirmConnectCustodianModalVisible && (

--- a/ui/pages/institutional/custody/custody.js
+++ b/ui/pages/institutional/custody/custody.js
@@ -352,7 +352,9 @@ const CustodyPage = () => {
     setConnectError('');
     setSelectError('');
 
-    history.push(CUSTODY_ACCOUNT_ROUTE);
+    window.innerWidth > 400
+      ? history.push(CUSTODY_ACCOUNT_ROUTE)
+      : global.platform.closeCurrentWindow();
   };
 
   const setSelectAllAccounts = (e) => {
@@ -451,23 +453,25 @@ const CustodyPage = () => {
             className="page-container__content"
             width={BlockSize.Full}
           >
-            <Box
-              display={Display.Flex}
-              alignItems={AlignItems.center}
-              marginBottom={4}
-              marginTop={4}
-            >
-              <ButtonIcon
-                data-testid="custody-back-button"
-                ariaLabel={t('back')}
-                iconName={IconName.ArrowLeft}
-                size={IconSize.Sm}
-                color={Color.iconDefault}
-                onClick={cancelConnectCustodianToken}
-                display={[Display.Flex]}
-              />
-              <Text>{t('back')}</Text>
-            </Box>
+            {window.innerWidth > 400 && (
+              <Box
+                display={Display.Flex}
+                alignItems={AlignItems.center}
+                marginBottom={4}
+                marginTop={4}
+              >
+                <ButtonIcon
+                  data-testid="custody-back-button"
+                  ariaLabel={t('back')}
+                  iconName={IconName.ArrowLeft}
+                  size={IconSize.Sm}
+                  color={Color.iconDefault}
+                  onClick={cancelConnectCustodianToken}
+                  display={[Display.Flex]}
+                />
+                <Text>{t('back')}</Text>
+              </Box>
+            )}
             {selectedCustodianImage && (
               <Box display={Display.Flex} alignItems={AlignItems.center}>
                 <img


### PR DESCRIPTION
## **Description**

We don't want the user to have the option to go "back" when it's in the custodian connect form view, this should only be possible in "expand" mode.
Also if the user clicks Cancel in this view, the popup should close, instead of going a step back like it does in "expand" mode.
Fixes some css styles in our UI.

## **Related issues**

Fixes: #

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've clearly explained what problem this PR is solving and how it is solved.
- [ ] I've linked related issues
- [ ] I've included manual testing steps
- [ ] I've included screenshots/recordings if applicable
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [ ] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
