### PR TITLE
Lazy load scripts and imagery for MetaMask pages

### DIFF
--- a/app/home.html
+++ b/app/home.html
@@ -12,10 +12,10 @@
   </head>
   <body>
     <div id="app-content">
-      <img class="loading-logo" src="./images/logo/metamask-fox.svg" alt="" />
-      <img class="loading-spinner" src="./images/spinner.gif" alt="" />
+      <img class="loading-logo" src="./images/logo/metamask-fox.svg" alt="" loading="lazy" />
+      <img class="loading-spinner" src="./images/spinner.gif" alt="" loading="lazy" />
     </div>
     <div id="popover-content"></div>
-    <script src="./load-app.js" type="text/javascript" charset="utf-8"></script>
+    <script src="./load-app.js" type="text/javascript" charset="utf-8" async></script>
   </body>
 </html>

--- a/app/loading.html
+++ b/app/loading.html
@@ -33,7 +33,7 @@
 </head>
 <body>
   <div id="div-logo">
-    <img id="logo" src="./images/enslogo.svg">
+    <img id="logo" src="./images/enslogo.svg" loading="lazy">
     <h1 class="center">MetaMask is querying ENS ...</h1>
   </div>
 </body>

--- a/app/notification.html
+++ b/app/notification.html
@@ -32,10 +32,10 @@
   </head>
   <body class="notification">
     <div id="app-content">
-      <img id="loading__logo" src="./images/logo/metamask-fox.svg" alt="" />
-      <img id="loading__spinner" src="./images/spinner.gif" alt="" />
+      <img id="loading__logo" src="./images/logo/metamask-fox.svg" alt="" loading="lazy" />
+      <img id="loading__spinner" src="./images/spinner.gif" alt="" loading="lazy" />
     </div>
     <div id="popover-content"></div>
-    <script src="./load-app.js" type="text/javascript" charset="utf-8"></script>
+    <script src="./load-app.js" type="text/javascript" charset="utf-8" async></script>
   </body>
 </html>

--- a/app/popup.html
+++ b/app/popup.html
@@ -9,10 +9,10 @@
   </head>
   <body style="width:357px; height:600px;">
     <div id="app-content">
-      <img class="loading-logo" src="./images/logo/metamask-fox.svg" alt="" />
-      <img class="loading-spinner" src="./images/spinner.gif" alt="" />
+      <img class="loading-logo" src="./images/logo/metamask-fox.svg" alt="" loading="lazy" />
+      <img class="loading-spinner" src="./images/spinner.gif" alt="" loading="lazy" />
     </div>
     <div id="popover-content"></div>
-    <script src="./load-app.js" type="text/javascript" charset="utf-8"></script>
+    <script src="./load-app.js" type="text/javascript" charset="utf-8" async></script>
   </body>
 </html>


### PR DESCRIPTION
## **Description**

Experiment to lazy load all front-end resources for the extension.

## **Related issues**

Fixes: N/A

## **Manual testing steps**

1. Use the extension in full screen and popup
2. Everything loads and works.

## **Screenshots/Recordings**

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've clearly explained what problem this PR is solving and how it is solved.
- [ ] I've linked related issues
- [ ] I've included manual testing steps
- [ ] I've included screenshots/recordings if applicable
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [ ] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
