### PR TITLE
Ignore @metamask/snaps-ui deprecation

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -111,6 +111,11 @@ npmAuditIgnoreAdvisories:
   # remove this.
   - '@metamask/types (deprecation)'
 
+  # @metamask/keyring-api also depends on @metamask/snaps-ui which is
+  # deprecated. Replacing that dependency with @metamask/snaps-sdk will remove
+  # this.
+  - '@metamask/snaps-ui (deprecation)'
+
 npmRegistries:
   'https://npm.pkg.github.com':
     npmAlwaysAuth: true


### PR DESCRIPTION


## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

`@metamask/snaps-ui` is indirectly used by `@metamask/keyring-api` but is deprecated, so we are getting an audit failure. Replacing `@metamask/snaps-ui` with `@metamask/snaps-sdk` will solve this but in the meantime we are ignoring this deprecation to unblock further merges.

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained what problem this PR is solving and how it is solved.
- [x] I've linked related issues
- [x] I've included manual testing steps
- [x] I've included screenshots/recordings if applicable
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [x] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
