### PR TITLE
Remove unnecessary redirection / code from Swaps, update content

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -1507,6 +1507,9 @@
   "enableFromSettings": {
     "message": " Enable it from Settings."
   },
+  "enableSmartSwaps": {
+    "message": "Enable Smart Swaps"
+  },
   "enableSnap": {
     "message": "Enable"
   },
@@ -4592,9 +4595,6 @@
   },
   "stakeDescription": {
     "message": "Stake your crypto to earn rewards"
-  },
-  "startSwapping": {
-    "message": "Start swapping"
   },
   "stateLogError": {
     "message": "Error in retrieving state logs."

--- a/ui/pages/swaps/prepare-swap-page/review-quote.js
+++ b/ui/pages/swaps/prepare-swap-page/review-quote.js
@@ -40,7 +40,6 @@ import {
   signAndSendTransactions,
   getBackgroundSwapRouteState,
   swapsQuoteSelected,
-  getSwapsQuoteRefreshTime,
   getReviewSwapClickedTimestamp,
   getSmartTransactionsOptInStatus,
   signAndSendSwapsSmartTransaction,
@@ -68,9 +67,7 @@ import {
 } from '../../../selectors';
 import { getNativeCurrency, getTokens } from '../../../ducks/metamask/metamask';
 import {
-  safeRefetchQuotes,
   setCustomApproveTxData,
-  setSwapsErrorKey,
   showModal,
   setSwapsQuotesPollingLimitEnabled,
 } from '../../../store/actions';
@@ -97,7 +94,6 @@ import {
 } from '../swaps.util';
 import { useTokenTracker } from '../../../hooks/useTokenTracker';
 import {
-  QUOTES_EXPIRED_ERROR,
   SLIPPAGE_HIGH_ERROR,
   SLIPPAGE_LOW_ERROR,
   MAX_ALLOWED_SLIPPAGE,
@@ -156,7 +152,6 @@ export default function ReviewQuote({ setReceiveToAmount }) {
   const t = useContext(I18nContext);
   const trackEvent = useContext(MetaMetricsContext);
 
-  const [dispatchedSafeRefetch, setDispatchedSafeRefetch] = useState(false);
   const [submitClicked, setSubmitClicked] = useState(false);
   const [selectQuotePopoverShown, setSelectQuotePopoverShown] = useState(false);
   const [warningHidden] = useState(false); // TODO: Check when to use setWarningHidden
@@ -214,7 +209,6 @@ export default function ReviewQuote({ setReceiveToAmount }) {
   const topQuote = useSelector(getTopQuote, isEqual);
   const usedQuote = selectedQuote || topQuote;
   const tradeValue = usedQuote?.trade?.value ?? '0x0';
-  const swapsQuoteRefreshTime = useSelector(getSwapsQuoteRefreshTime);
   const defaultSwapsToken = useSelector(getSwapsDefaultToken, isEqual);
   const chainId = useSelector(getCurrentChainId);
   const nativeCurrencySymbol = useSelector(getNativeCurrency);
@@ -555,26 +549,6 @@ export default function ReviewQuote({ setReceiveToAmount }) {
     dispatch,
     isSmartTransaction,
     balanceError,
-  ]);
-
-  useEffect(() => {
-    const currentTime = Date.now();
-    const timeSinceLastFetched = currentTime - quotesLastFetched;
-    if (
-      timeSinceLastFetched > swapsQuoteRefreshTime &&
-      !dispatchedSafeRefetch
-    ) {
-      setDispatchedSafeRefetch(true);
-      dispatch(safeRefetchQuotes());
-    } else if (timeSinceLastFetched > swapsQuoteRefreshTime) {
-      dispatch(setSwapsErrorKey(QUOTES_EXPIRED_ERROR));
-    }
-  }, [
-    quotesLastFetched,
-    dispatchedSafeRefetch,
-    dispatch,
-    history,
-    swapsQuoteRefreshTime,
   ]);
 
   useEffect(() => {

--- a/ui/pages/swaps/prepare-swap-page/review-quote.js
+++ b/ui/pages/swaps/prepare-swap-page/review-quote.js
@@ -78,7 +78,6 @@ import {
   ASSET_ROUTE,
   DEFAULT_ROUTE,
   AWAITING_SWAP_ROUTE,
-  SWAPS_NOTIFICATION_ROUTE,
   PREPARE_SWAP_ROUTE,
 } from '../../../helpers/constants/routes';
 import { CHAIN_IDS } from '../../../../shared/constants/network';
@@ -569,7 +568,6 @@ export default function ReviewQuote({ setReceiveToAmount }) {
       dispatch(safeRefetchQuotes());
     } else if (timeSinceLastFetched > swapsQuoteRefreshTime) {
       dispatch(setSwapsErrorKey(QUOTES_EXPIRED_ERROR));
-      history.push(SWAPS_NOTIFICATION_ROUTE);
     }
   }, [
     quotesLastFetched,

--- a/ui/pages/swaps/prepare-swap-page/smart-transactions-popover.tsx
+++ b/ui/pages/swaps/prepare-swap-page/smart-transactions-popover.tsx
@@ -99,7 +99,7 @@ export default function SmartTransactionsPopover({
             onClick={onStartSwapping}
             width={BlockSize.Full}
           >
-            {t('startSwapping')}
+            {t('enableSmartSwaps')}
           </Button>
           <Button
             type="link"


### PR DESCRIPTION
## **Description**
This PR solves 3 things:
- There was an issue with duplicated redirection to the Notification Page (which we already do [here](https://github.com/MetaMask/metamask-extension/blob/develop/ui/pages/swaps/prepare-swap-page/prepare-swap-page.js#L721)), which caused unnecessary redirects between the Prepare Swap Page and Notification Page in Swaps.
- Also, we had some duplicated code that was not needed after Swaps redesign and because of that we showed the Notification Page (see the screenshot), instead of fetching quotes again on the Prepare Swap Page, which would save users some time.
- Update content (Start swapping -> Enable Smart Swaps)

Why the removed code was not needed:
- Quotes fetching is done in the prepare-swap-page component: https://github.com/MetaMask/metamask-extension/blob/develop/ui/pages/swaps/prepare-swap-page/prepare-swap-page.js#L628
- `this.setSwapsErrorKey(QUOTES_EXPIRED_ERROR);` is done in the SwapsController: https://github.com/MetaMask/metamask-extension/blob/develop/app/scripts/controllers/swaps.js#L440

The functions that were used from the deleted code are still used in the old Swaps design (our fallback solution). Once we will be cleaning up the old Swaps design code, those functions will be removed as well.

## **Screenshots**
Updated content: 
![image](https://github.com/MetaMask/metamask-extension/assets/80175477/d52d44ba-f192-4aca-a819-cd84700d0a65)

Notification page:
![image](https://github.com/MetaMask/metamask-extension/assets/80175477/105a1908-1e0f-439d-aab3-1df95ad65fed)

## **Testing Steps**
Test 1 - make sure Swaps work and we still show the Notification Page if a user stayed on the Prepare Swap Page too long with everything filled in

Test 2 - Show the Prepare Swap Page instead of the Notification Page after clicking on the "Try Again" link:
- Open Swaps
- Make sure Smart Swap is enabled
- Make a swap and immediately cancel it
- Wait on the Smart Transaction Status page for 5 minutes
- Click on the "Try Again" button
- See that you will be redirected to Prepare Swap Page and new quotes fetching will start instead of going to the Notification Page