### PR TITLE
[cherry-pick Confirmations Metrics PRs] fix: After triggering a Transaction, a Signature request metrics even…

### DIFF
--- a/app/scripts/lib/transaction/metrics.test.ts
+++ b/app/scripts/lib/transaction/metrics.test.ts
@@ -17,7 +17,10 @@ import {
 } from '../../../../shared/constants/metametrics';
 import { TRANSACTION_ENVELOPE_TYPE_NAMES } from '../../../../shared/lib/transactions-controller-utils';
 ///: BEGIN:ONLY_INCLUDE_IN(blockaid)
-import { BlockaidReason } from '../../../../shared/constants/security-provider';
+import {
+  BlockaidReason,
+  BlockaidResultType,
+} from '../../../../shared/constants/security-provider';
 ///: END:ONLY_INCLUDE_IN(blockaid)
 import {
   handleTransactionAdded,
@@ -107,8 +110,9 @@ describe('Transaction metrics', () => {
     // copy mockTransactionMeta and add blockaid data
     mockTransactionMetaWithBlockaid = {
       ...JSON.parse(JSON.stringify(mockTransactionMeta)),
-      securityProviderResponse: {
-        flagAsDangerous: 1,
+      securityAlertResponse: {
+        result_type: BlockaidResultType.Malicious,
+        reason: BlockaidReason.maliciousDomain,
         providerRequestsCount: {
           eth_call: 5,
           eth_getCode: 3,
@@ -230,6 +234,8 @@ describe('Transaction metrics', () => {
         persist: true,
         properties: {
           ...expectedProperties,
+          security_alert_reason: BlockaidReason.maliciousDomain,
+          security_alert_response: 'Malicious',
           ui_customizations: ['flagged_as_malicious'],
           ppom_eth_call_count: 5,
           ppom_eth_getCode_count: 3,
@@ -315,6 +321,8 @@ describe('Transaction metrics', () => {
         properties: {
           ...expectedProperties,
           ui_customizations: ['flagged_as_malicious'],
+          security_alert_reason: BlockaidReason.maliciousDomain,
+          security_alert_response: 'Malicious',
           ppom_eth_call_count: 5,
           ppom_eth_getCode_count: 3,
         },
@@ -330,6 +338,8 @@ describe('Transaction metrics', () => {
           properties: {
             ...expectedProperties,
             ui_customizations: ['flagged_as_malicious'],
+            security_alert_reason: BlockaidReason.maliciousDomain,
+            security_alert_response: 'Malicious',
             ppom_eth_call_count: 5,
             ppom_eth_getCode_count: 3,
           },
@@ -442,6 +452,8 @@ describe('Transaction metrics', () => {
         properties: {
           ...expectedProperties,
           ui_customizations: ['flagged_as_malicious'],
+          security_alert_reason: BlockaidReason.maliciousDomain,
+          security_alert_response: 'Malicious',
           ppom_eth_call_count: 5,
           ppom_eth_getCode_count: 3,
         },
@@ -460,6 +472,8 @@ describe('Transaction metrics', () => {
           properties: {
             ...expectedProperties,
             ui_customizations: ['flagged_as_malicious'],
+            security_alert_reason: BlockaidReason.maliciousDomain,
+            security_alert_response: 'Malicious',
             ppom_eth_call_count: 5,
             ppom_eth_getCode_count: 3,
           },
@@ -627,6 +641,8 @@ describe('Transaction metrics', () => {
         properties: {
           ...expectedProperties,
           ui_customizations: ['flagged_as_malicious'],
+          security_alert_reason: BlockaidReason.maliciousDomain,
+          security_alert_response: 'Malicious',
           ppom_eth_call_count: 5,
           ppom_eth_getCode_count: 3,
         },
@@ -647,6 +663,8 @@ describe('Transaction metrics', () => {
           properties: {
             ...expectedProperties,
             ui_customizations: ['flagged_as_malicious'],
+            security_alert_reason: BlockaidReason.maliciousDomain,
+            security_alert_response: 'Malicious',
             ppom_eth_call_count: 5,
             ppom_eth_getCode_count: 3,
           },
@@ -750,6 +768,8 @@ describe('Transaction metrics', () => {
         properties: {
           ...expectedProperties,
           ui_customizations: ['flagged_as_malicious'],
+          security_alert_reason: BlockaidReason.maliciousDomain,
+          security_alert_response: 'Malicious',
           ppom_eth_call_count: 5,
           ppom_eth_getCode_count: 3,
         },
@@ -769,6 +789,8 @@ describe('Transaction metrics', () => {
           properties: {
             ...expectedProperties,
             ui_customizations: ['flagged_as_malicious'],
+            security_alert_reason: BlockaidReason.maliciousDomain,
+            security_alert_response: 'Malicious',
             ppom_eth_call_count: 5,
             ppom_eth_getCode_count: 3,
           },
@@ -867,6 +889,8 @@ describe('Transaction metrics', () => {
         properties: {
           ...expectedProperties,
           ui_customizations: ['flagged_as_malicious'],
+          security_alert_reason: BlockaidReason.maliciousDomain,
+          security_alert_response: 'Malicious',
           ppom_eth_call_count: 5,
           ppom_eth_getCode_count: 3,
         },
@@ -882,6 +906,8 @@ describe('Transaction metrics', () => {
           properties: {
             ...expectedProperties,
             ui_customizations: ['flagged_as_malicious'],
+            security_alert_reason: BlockaidReason.maliciousDomain,
+            security_alert_response: 'Malicious',
             ppom_eth_call_count: 5,
             ppom_eth_getCode_count: 3,
           },

--- a/ui/components/app/signature-request-original/signature-request-original.component.js
+++ b/ui/components/app/signature-request-original/signature-request-original.component.js
@@ -44,11 +44,6 @@ import {
   ///: END:ONLY_INCLUDE_IN
 } from '../../component-library';
 ///: BEGIN:ONLY_INCLUDE_IN(blockaid)
-import {
-  MetaMetricsEventCategory,
-  MetaMetricsEventName,
-} from '../../../../shared/constants/metametrics';
-import { getBlockaidMetricsParams } from '../../../helpers/utils/metrics';
 import BlockaidBannerAlert from '../security-provider-banner-alert/blockaid-banner-alert/blockaid-banner-alert';
 ///: END:ONLY_INCLUDE_IN
 import ConfirmPageContainerNavigation from '../confirm-page-container/confirm-page-container-navigation';
@@ -95,26 +90,6 @@ export default class SignatureRequestOriginal extends Component {
   state = {
     showSignatureRequestWarning: false,
   };
-
-  ///: BEGIN:ONLY_INCLUDE_IN(blockaid)
-  componentDidMount() {
-    const { txData } = this.props;
-    if (txData.securityAlertResponse) {
-      const blockaidMetricsParams = getBlockaidMetricsParams(
-        txData.securityAlertResponse,
-      );
-
-      this.context.trackEvent({
-        category: MetaMetricsEventCategory.Transactions,
-        event: MetaMetricsEventName.SignatureRequested,
-        properties: {
-          action: 'Sign Request',
-          ...blockaidMetricsParams,
-        },
-      });
-    }
-  }
-  ///: END:ONLY_INCLUDE_IN
 
   msgHexToText = (hex) => {
     try {

--- a/ui/components/app/signature-request-siwe/signature-request-siwe.js
+++ b/ui/components/app/signature-request-siwe/signature-request-siwe.js
@@ -89,7 +89,7 @@ export default function SignatureRequestSIWE({ txData }) {
         },
       });
     }
-  }, [txData?.securityAlertResponse]);
+  }, []);
   ///: END:ONLY_INCLUDE_IN
 
   const {

--- a/ui/components/app/signature-request/signature-request.js
+++ b/ui/components/app/signature-request/signature-request.js
@@ -96,7 +96,6 @@ import { showCustodyConfirmLink } from '../../../store/institutional/institution
 import { useMMICustodySignMessage } from '../../../hooks/useMMICustodySignMessage';
 ///: END:ONLY_INCLUDE_IN
 ///: BEGIN:ONLY_INCLUDE_IN(blockaid)
-import { getBlockaidMetricsParams } from '../../../helpers/utils/metrics';
 import BlockaidBannerAlert from '../security-provider-banner-alert/blockaid-banner-alert/blockaid-banner-alert';
 ///: END:ONLY_INCLUDE_IN
 
@@ -254,27 +253,6 @@ const SignatureRequest = ({ txData }) => {
     isNotification,
     trackEvent,
   ]);
-  ///: END:ONLY_INCLUDE_IN
-
-  ///: BEGIN:ONLY_INCLUDE_IN(blockaid)
-  useEffect(() => {
-    if (txData.securityAlertResponse) {
-      const blockaidMetricsParams = getBlockaidMetricsParams(
-        txData.securityAlertResponse,
-      );
-
-      trackEvent({
-        category: MetaMetricsEventCategory.Transactions,
-        event: MetaMetricsEventName.SignatureRequested,
-        properties: {
-          action: 'Sign Request',
-          type,
-          version,
-          ...blockaidMetricsParams,
-        },
-      });
-    }
-  }, []);
   ///: END:ONLY_INCLUDE_IN
 
   return (

--- a/ui/components/app/transaction-alerts/transaction-alerts.js
+++ b/ui/components/app/transaction-alerts/transaction-alerts.js
@@ -2,7 +2,6 @@ import React, {
   ///: BEGIN:ONLY_INCLUDE_IN(blockaid)
   useCallback,
   useContext,
-  useEffect,
   ///: END:ONLY_INCLUDE_IN
 } from 'react';
 import PropTypes from 'prop-types';
@@ -33,7 +32,6 @@ import {
   MetaMetricsEventCategory,
   MetaMetricsEventName,
 } from '../../../../shared/constants/metametrics';
-import { getBlockaidMetricsParams } from '../../../helpers/utils/metrics';
 ///: END:ONLY_INCLUDE_IN
 
 const TransactionAlerts = ({
@@ -72,25 +70,6 @@ const TransactionAlerts = ({
 
   ///: BEGIN:ONLY_INCLUDE_IN(blockaid)
   const trackEvent = useContext(MetaMetricsContext);
-  ///: END:ONLY_INCLUDE_IN
-
-  ///: BEGIN:ONLY_INCLUDE_IN(blockaid)
-  useEffect(() => {
-    if (txData.securityAlertResponse) {
-      const blockaidMetricsParams = getBlockaidMetricsParams(
-        txData.securityAlertResponse,
-      );
-
-      trackEvent({
-        category: MetaMetricsEventCategory.Transactions,
-        event: MetaMetricsEventName.SignatureRequested,
-        properties: {
-          action: 'Sign Request',
-          ...blockaidMetricsParams,
-        },
-      });
-    }
-  }, [txData?.securityAlertResponse]);
   ///: END:ONLY_INCLUDE_IN
 
   ///: BEGIN:ONLY_INCLUDE_IN(blockaid)

--- a/ui/helpers/utils/metrics.js
+++ b/ui/helpers/utils/metrics.js
@@ -39,6 +39,10 @@ export const getBlockaidMetricsParams = (securityAlertResponse = null) => {
       additionalParams.ui_customizations = ['flagged_as_malicious'];
     }
 
+    if (resultType === BlockaidResultType.Failed) {
+      additionalParams.ui_customizations = ['security_alert_failed'];
+    }
+
     if (resultType !== BlockaidResultType.Benign) {
       additionalParams.security_alert_reason = BlockaidReason.notApplicable;
 

--- a/ui/pages/confirm-approve/confirm-approve-content/confirm-approve-content.component.js
+++ b/ui/pages/confirm-approve/confirm-approve-content/confirm-approve-content.component.js
@@ -23,11 +23,6 @@ import { ConfirmPageContainerWarning } from '../../../components/app/confirm-pag
 import LedgerInstructionField from '../../../components/app/ledger-instruction-field';
 ///: BEGIN:ONLY_INCLUDE_IN(blockaid)
 import BlockaidBannerAlert from '../../../components/app/security-provider-banner-alert/blockaid-banner-alert/blockaid-banner-alert';
-import { getBlockaidMetricsParams } from '../../../helpers/utils/metrics';
-import {
-  MetaMetricsEventCategory,
-  MetaMetricsEventName,
-} from '../../../../shared/constants/metametrics';
 ///: END:ONLY_INCLUDE_IN
 import { isSuspiciousResponse } from '../../../../shared/modules/security-provider.utils';
 
@@ -102,26 +97,6 @@ export default class ConfirmApproveContent extends Component {
     copied: false,
     setShowContractDetails: false,
   };
-
-  ///: BEGIN:ONLY_INCLUDE_IN(blockaid)
-  componentDidMount() {
-    const { txData } = this.props;
-    if (txData.securityAlertResponse) {
-      const blockaidMetricsParams = getBlockaidMetricsParams(
-        txData.securityAlertResponse,
-      );
-
-      this.context.trackEvent({
-        category: MetaMetricsEventCategory.Transactions,
-        event: MetaMetricsEventName.SignatureRequested,
-        properties: {
-          action: 'Sign Request',
-          ...blockaidMetricsParams,
-        },
-      });
-    }
-  }
-  ///: END:ONLY_INCLUDE_IN
 
   renderApproveContentCard({
     showHeader = true,

--- a/ui/pages/token-allowance/token-allowance.js
+++ b/ui/pages/token-allowance/token-allowance.js
@@ -63,12 +63,6 @@ import {
 import { isSuspiciousResponse } from '../../../shared/modules/security-provider.utils';
 ///: BEGIN:ONLY_INCLUDE_IN(blockaid)
 import BlockaidBannerAlert from '../../components/app/security-provider-banner-alert/blockaid-banner-alert/blockaid-banner-alert';
-import { getBlockaidMetricsParams } from '../../helpers/utils/metrics';
-import {
-  MetaMetricsEventCategory,
-  MetaMetricsEventName,
-} from '../../../shared/constants/metametrics';
-import { MetaMetricsContext } from '../../contexts/metametrics';
 ///: END:ONLY_INCLUDE_IN
 import { ConfirmPageContainerNavigation } from '../../components/app/confirm-page-container';
 import { useSimulationFailureWarning } from '../../hooks/useSimulationFailureWarning';
@@ -142,29 +136,6 @@ export default function TokenAllowance({
   const useCurrencyRateCheck = useSelector(getUseCurrencyRateCheck);
   const nextNonce = useSelector(getNextSuggestedNonce);
   const customNonceValue = useSelector(getCustomNonceValue);
-
-  ///: BEGIN:ONLY_INCLUDE_IN(blockaid)
-  const trackEvent = useContext(MetaMetricsContext);
-  ///: END:ONLY_INCLUDE_IN
-
-  ///: BEGIN:ONLY_INCLUDE_IN(blockaid)
-  useEffect(() => {
-    if (txData.securityAlertResponse) {
-      const blockaidMetricsParams = getBlockaidMetricsParams(
-        txData.securityAlertResponse,
-      );
-
-      trackEvent({
-        category: MetaMetricsEventCategory.Transactions,
-        event: MetaMetricsEventName.SignatureRequested,
-        properties: {
-          action: 'Sign Request',
-          ...blockaidMetricsParams,
-        },
-      });
-    }
-  }, [txData?.securityAlertResponse]);
-  ///: END:ONLY_INCLUDE_IN
 
   /**
    * We set the customSpendingCap to the dappProposedTokenAmount, if provided, rather than setting customTokenAmount


### PR DESCRIPTION
## **Description**
This PR cherry picks the Confirmations metrics fixes for:
- https://github.com/MetaMask/metamask-extension/pull/21753
- https://github.com/MetaMask/metamask-extension/issues/21738
- In this branch I am seeing this fixed https://github.com/MetaMask/metamask-extension/issues/21770
