### PR TITLE
Fix issue where per dapp selected network state is enabled without the request queue experimental toggle enabled

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -512,11 +512,6 @@ export default class MetamaskController extends EventEmitter {
       }),
     });
 
-    // turn on perDappSelectedNetwork feature flag
-    this.selectedNetworkController.update((state) => {
-      state.perDomainNetwork = true;
-    });
-
     this.tokenListController = new TokenListController({
       chainId: this.networkController.state.providerConfig.chainId,
       preventPollingOnNetworkRestart: initState.TokenListController
@@ -2587,9 +2582,7 @@ export default class MetamaskController extends EventEmitter {
           preferencesController,
         ),
       ///: END:ONLY_INCLUDE_IN
-      setUseRequestQueue: preferencesController.setUseRequestQueue.bind(
-        preferencesController,
-      ),
+      setUseRequestQueue: this.setUseRequestQueue.bind(this),
       setIpfsGateway: preferencesController.setIpfsGateway.bind(
         preferencesController,
       ),
@@ -4061,6 +4054,17 @@ export default class MetamaskController extends EventEmitter {
     this.preferencesController.setPasswordForgotten(false);
     this.sendUpdate();
   }
+
+  //=============================================================================
+  // REQUEST QUEUE
+  //=============================================================================
+
+  setUseRequestQueue = (value) => {
+    this.preferencesController.setUseRequestQueue(value);
+    this.selectedNetworkController.update((state) => {
+      state.perDomainNetwork = true;
+    });
+  };
 
   //=============================================================================
   // SETUP

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -4062,7 +4062,7 @@ export default class MetamaskController extends EventEmitter {
   setUseRequestQueue = (value) => {
     this.preferencesController.setUseRequestQueue(value);
     this.selectedNetworkController.update((state) => {
-      state.perDomainNetwork = true;
+      state.perDomainNetwork = value;
     });
   };
 

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -4059,12 +4059,12 @@ export default class MetamaskController extends EventEmitter {
   // REQUEST QUEUE
   //=============================================================================
 
-  setUseRequestQueue = (value) => {
+  setUseRequestQueue(value) {
     this.preferencesController.setUseRequestQueue(value);
     this.selectedNetworkController.update((state) => {
       state.perDomainNetwork = value;
     });
-  };
+  }
 
   //=============================================================================
   // SETUP


### PR DESCRIPTION
In https://github.com/MetaMask/metamask-extension/pull/21522, the `perDomainNetwork` state was left as always enabled. This state should be toggled on and off with the `Select networks for each site` experimental setting.

Fixes: #21876

## **Manual testing steps**

Pertaining to the fix for #21876
1. Load MetaMask and the test dapp: https://metamask.github.io/test-dapp/
2. Switch to Sepolia and connect MetaMask to the test dapp
3. Switch to Goerli --> Notice that no TST tokens are displayed
4. Switch to Sepolia again
5. In the test dapp, deploy erc-20 contract
6. Confirm the request
7. Proceed to add token/watch asset 
8. Confirm the request
9. In the tokens list, see that the TST token is present on Sepolia

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained what problem this PR is solving and how it is solved.
- [x] I've linked related issues
- [x] I've included manual testing steps
- [x] I've included screenshots/recordings if applicable
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [x] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
