### PR TITLE
e2e: ignore failures in test-e2e-mmi-playwright

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,6 @@ orbs:
   codecov: codecov/codecov@3.2.2
   slack: circleci/slack@4.12.5
 
-
 rc_branch_only: &rc_branch_only
   filters:
     branches:
@@ -1079,8 +1078,8 @@ jobs:
       - run:
           name: test:e2e:chrome:mmi
           command: |
-            SHARD="$((${CIRCLE_NODE_INDEX}+1))"; xvfb-run yarn playwright test --shard=${SHARD}/${CIRCLE_NODE_TOTAL}
-          no_output_timeout: 20m
+            SHARD="$((${CIRCLE_NODE_INDEX}+1))"; xvfb-run yarn playwright test --shard=${SHARD}/${CIRCLE_NODE_TOTAL} || true
+          no_output_timeout: 5m
       - slack/notify:
           branch_pattern: Version-v*
           event: fail


### PR DESCRIPTION
## **Description**

It's a little distracting and hard to parse when every single CircleCI run fails, because `test-e2e-mmi-playwright - OPTIONAL` fails.  It's not a blocker: you can still merge anyway, because `all-tests-pass` doesn't depend on it.  But I think it makes everything harder to read.

My proposal is to add `|| true` to the end of the run command, so it always returns success.  You can still drill in and see which tests failed: https://app.circleci.com/pipelines/github/MetaMask/metamask-extension/63528/workflows/d999fa29-ff85-45ca-9032-cd375908c6a1/jobs/2027036/tests

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained what problem this PR is solving and how it is solved.
- [ ] I've linked related issues
- [ ] I've included manual testing steps
- [ ] I've included screenshots/recordings if applicable
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [x] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [x] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
