### PR TITLE
fix: Fix warning about missing strong random number source

### DIFF
--- a/lavamoat/browserify/beta/policy.json
+++ b/lavamoat/browserify/beta/policy.json
@@ -431,6 +431,9 @@
       }
     },
     "@ethersproject/providers>@ethersproject/random": {
+      "globals": {
+        "crypto.getRandomValues": true
+      },
       "packages": {
         "@ethersproject/abi>@ethersproject/bytes": true,
         "@ethersproject/abi>@ethersproject/logger": true
@@ -3525,11 +3528,6 @@
       }
     },
     "ethereumjs-wallet>randombytes": {
-      "globals": {
-        "crypto.getRandomValues": true
-      }
-    },
-    "ethers>@ethersproject/random": {
       "globals": {
         "crypto.getRandomValues": true
       }

--- a/lavamoat/browserify/desktop/policy.json
+++ b/lavamoat/browserify/desktop/policy.json
@@ -431,6 +431,9 @@
       }
     },
     "@ethersproject/providers>@ethersproject/random": {
+      "globals": {
+        "crypto.getRandomValues": true
+      },
       "packages": {
         "@ethersproject/abi>@ethersproject/bytes": true,
         "@ethersproject/abi>@ethersproject/logger": true
@@ -3926,11 +3929,6 @@
       }
     },
     "ethereumjs-wallet>randombytes": {
-      "globals": {
-        "crypto.getRandomValues": true
-      }
-    },
-    "ethers>@ethersproject/random": {
       "globals": {
         "crypto.getRandomValues": true
       }

--- a/lavamoat/browserify/flask/policy.json
+++ b/lavamoat/browserify/flask/policy.json
@@ -431,6 +431,9 @@
       }
     },
     "@ethersproject/providers>@ethersproject/random": {
+      "globals": {
+        "crypto.getRandomValues": true
+      },
       "packages": {
         "@ethersproject/abi>@ethersproject/bytes": true,
         "@ethersproject/abi>@ethersproject/logger": true
@@ -3972,11 +3975,6 @@
       }
     },
     "ethereumjs-wallet>randombytes": {
-      "globals": {
-        "crypto.getRandomValues": true
-      }
-    },
-    "ethers>@ethersproject/random": {
       "globals": {
         "crypto.getRandomValues": true
       }

--- a/lavamoat/browserify/main/policy.json
+++ b/lavamoat/browserify/main/policy.json
@@ -431,6 +431,9 @@
       }
     },
     "@ethersproject/providers>@ethersproject/random": {
+      "globals": {
+        "crypto.getRandomValues": true
+      },
       "packages": {
         "@ethersproject/abi>@ethersproject/bytes": true,
         "@ethersproject/abi>@ethersproject/logger": true
@@ -3895,11 +3898,6 @@
       }
     },
     "ethereumjs-wallet>randombytes": {
-      "globals": {
-        "crypto.getRandomValues": true
-      }
-    },
-    "ethers>@ethersproject/random": {
       "globals": {
         "crypto.getRandomValues": true
       }

--- a/lavamoat/browserify/mmi/policy.json
+++ b/lavamoat/browserify/mmi/policy.json
@@ -431,6 +431,9 @@
       }
     },
     "@ethersproject/providers>@ethersproject/random": {
+      "globals": {
+        "crypto.getRandomValues": true
+      },
       "packages": {
         "@ethersproject/abi>@ethersproject/bytes": true,
         "@ethersproject/abi>@ethersproject/logger": true
@@ -3939,11 +3942,6 @@
       }
     },
     "ethereumjs-wallet>randombytes": {
-      "globals": {
-        "crypto.getRandomValues": true
-      }
-    },
-    "ethers>@ethersproject/random": {
       "globals": {
         "crypto.getRandomValues": true
       }

--- a/lavamoat/browserify/policy-override.json
+++ b/lavamoat/browserify/policy-override.json
@@ -39,7 +39,7 @@
         "removeEventListener": true
       }
     },
-    "ethers>@ethersproject/random": {
+    "@ethersproject/providers>@ethersproject/random": {
       "globals": {
         "crypto.getRandomValues": true
       }


### PR DESCRIPTION
## **Description**

A warning about missing a strong random number source appears in the console when the extension starts. This warning comes from `@ethersproject/random`, which prints this if it thinks it's running in a browser but cannot access `crypto.getRandomValues`.

That package was unable to use `crypto.getRandomValues` due to a mistake in our LavaMoat policy. The auto-generated policy failed to notice that this API was used by this package. We had previously fixed this by using a policy override, but since then the path of the package has changed (so the override did not take effect).

The policy override has been updated to use the correct package path. The warning should no longer appear now.

Note that we don't appear to be relying on this package for anything; this warning appears on import, not upon us actually using it to get random numbers. This package is likely only appearing in the bundle due to lack of effective tree shaking in our build system. The package is brought in by `@ethersproject/providers`, which appears to be using it in a module we don't use, for purposes that are not security-critical. The impact of this problem was just the extra console warning.

## **Related issues**

Fixes #21926

## **Manual testing steps**

1. Start the extension
2. Open dev tools for any UI, and see whether the warning is present

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained what problem this PR is solving and how it is solved.
- [x] I've linked related issues
- [x] I've included manual testing steps
- [x] I've included screenshots/recordings if applicable
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [x] I’ve properly set the pull request status:
  - [x] In case it's not yet "ready for review", I've set it to "draft".
  - [x] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
