### PR TITLE
Update swaps controller ethereum provider on demand instead of on network events

### DIFF
--- a/app/scripts/controllers/swaps.js
+++ b/app/scripts/controllers/swaps.js
@@ -259,6 +259,7 @@ export default class SwapsController {
 
     if (chainId !== this._ethersProviderChainId) {
       this.ethersProvider = new Web3Provider(this.provider);
+      this._ethersProviderChainId = chainId;
     }
 
     const {

--- a/app/scripts/controllers/swaps.js
+++ b/app/scripts/controllers/swaps.js
@@ -113,7 +113,6 @@ export default class SwapsController {
   constructor(
     {
       getBufferedGasLimit,
-      networkController,
       provider,
       getProviderConfig,
       getTokenRatesState,
@@ -155,8 +154,7 @@ export default class SwapsController {
 
     this.provider = provider;
     this.ethersProvider = new Web3Provider(provider);
-    this._ethersProviderChainId =
-      networkController.state.providerConfig.chainId;
+    this._ethersProviderChainId = this._getCurrentChainId();
   }
 
   async fetchSwapsNetworkConfig(chainId) {

--- a/app/scripts/controllers/swaps.test.js
+++ b/app/scripts/controllers/swaps.test.js
@@ -835,7 +835,7 @@ describe('SwapsController', function () {
           chainId: CHAIN_IDS.MAINNET,
         });
 
-        const newEthersInstance = swapsController.ethersProvider;
+        const newEthersInstance = _swapsController.ethersProvider;
         assert.strictEqual(
           currentEthersInstance,
           newEthersInstance,

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -1565,10 +1565,6 @@ export default class MetamaskController extends EventEmitter {
         // This handler is misnamed. We must listen to networkDidChange
         // to ensure the network provider has been set by the time we
         // try to use it in this controller
-        onNetworkStateChange: networkControllerMessenger.subscribe.bind(
-          networkControllerMessenger,
-          'NetworkController:networkDidChange',
-        ),
         provider: this.provider,
         getProviderConfig: () => this.networkController.state.providerConfig,
         getTokenRatesState: () => this.tokenRatesController.state,

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -1561,10 +1561,6 @@ export default class MetamaskController extends EventEmitter {
 
           return { gasLimit, simulationFails };
         },
-        networkController: this.networkController,
-        // This handler is misnamed. We must listen to networkDidChange
-        // to ensure the network provider has been set by the time we
-        // try to use it in this controller
         provider: this.provider,
         getProviderConfig: () => this.networkController.state.providerConfig,
         getTokenRatesState: () => this.tokenRatesController.state,


### PR DESCRIPTION
## **Description**

While QAing v11.5.2, this issue was discovered:

1. Add a network, through the popular network list, that you have tokens on.
2. use "+ Import tokens" form to import a token that that you have on this network
3. try to swap that token for the network's native currency, fetching quotes will fail and an "Error fetching quotes" message will be shown

We thought we fixed this with https://github.com/MetaMask/metamask-extension/pull/21923, but the case of adding a network and then immediately trying to swap an erc20 token on that network, was not covered by that solution.

The reasons for that are detailed extensively here https://consensys.slack.com/archives/GTQAGKY5V/p1700700399190349

tldr: When the `NetworkDidChange` event occurs during the network adding flow, the network's status is not yet "Available" and so the swaps controller subscriber for network changes does allow the provider to update

The fix in this PR, which also covers the problem addressed by the aforementioned PR, is to only update the swaps controller's ethersProvider at the time it is needed, within the `fetchAndSetQuotes`, and to stop subscribing to network controller changes. 

## **Manual testing steps**

1. Add a network, through the popular network list, that you have tokens on.
2. use "+ Import tokens" form to import a token that that you have on this network
3. try to swap that token for the network's native currency, fetching quotes should succeed


### **Before**


https://github.com/MetaMask/metamask-extension/assets/7499938/acc62c6c-ac67-41be-a4a9-78e7d9941043



### **After**


https://github.com/MetaMask/metamask-extension/assets/7499938/3eeea1c2-9d14-4f56-9a66-4669af9ae0e1



## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained what problem this PR is solving and how it is solved.
- [x] I've linked related issues
- [x] I've included manual testing steps
- [x] I've included screenshots/recordings if applicable
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [x] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
