### PR TITLE
V11.6.0 cherry pick 9104a2

### DIFF
--- a/ui/pages/confirm-transaction-base/confirm-transaction-base.component.js
+++ b/ui/pages/confirm-transaction-base/confirm-transaction-base.component.js
@@ -735,11 +735,10 @@ export default class ConfirmTransactionBase extends Component {
 
     if (accountType === 'custody') {
       txData.custodyStatus = 'created';
+      txData.metadata = txData.metadata || {};
 
       if (isNoteToTraderSupported) {
-        txData.metadata = {
-          note: noteText,
-        };
+        txData.metadata.note = noteText;
       }
 
       txData.metadata.custodianPublishesTransaction =

--- a/ui/pages/confirm-transaction-base/confirm-transaction-base.test.js
+++ b/ui/pages/confirm-transaction-base/confirm-transaction-base.test.js
@@ -246,6 +246,112 @@ describe('Confirm Transaction Base', () => {
     expect(getByTestId('note-tab')).toBeInTheDocument();
   });
 
+  it('handleMMISubmit calls sendTransaction correctly when isNoteToTraderSupported is false', async () => {
+    const newMockedStore = {
+      ...mockedStore,
+      appState: {
+        ...mockedStore.appState,
+        gasLoadingAnimationIsShowing: false,
+      },
+      confirmTransaction: {
+        ...mockedStore.confirmTransaction,
+        txData: {
+          ...mockedStore.confirmTransaction.txData,
+          custodyStatus: true,
+        },
+      },
+      metamask: {
+        ...mockedStore.metamask,
+        accounts: {
+          [mockTxParamsFromAddress]: {
+            balance: '0x1000000000000000000',
+            address: mockTxParamsFromAddress,
+          },
+        },
+        gasEstimateType: GasEstimateTypes.feeMarket,
+        selectedNetworkClientId: NetworkType.mainnet,
+        networksMetadata: {
+          ...mockedStore.metamask.networksMetadata,
+          [NetworkType.mainnet]: {
+            EIPS: {
+              1559: true,
+            },
+            status: NetworkStatus.Available,
+          },
+        },
+        customGas: {
+          gasLimit: '0x5208',
+          gasPrice: '0x59682f00',
+        },
+        noGasPrice: false,
+        keyrings: [
+          {
+            type: 'Custody',
+            accounts: ['0x123456789'],
+          },
+        ],
+        custodyAccountDetails: {
+          [mockTxParamsFromAddress]: {
+            address: mockTxParamsFromAddress,
+            details: 'details',
+            custodyType: 'testCustody - Saturn',
+            custodianName: 'saturn-dev',
+          },
+        },
+        mmiConfiguration: {
+          custodians: [
+            {
+              envName: 'saturn-dev',
+              displayName: 'Saturn Custody',
+              isNoteToTraderSupported: false,
+            },
+          ],
+        },
+      },
+      send: {
+        ...mockedStore.send,
+        gas: {
+          ...mockedStore.send.gas,
+          gasEstimateType: GasEstimateTypes.legacy,
+          gasFeeEstimates: {
+            low: '0',
+            medium: '1',
+            high: '2',
+          },
+        },
+        hasSimulationError: false,
+        userAcknowledgedGasMissing: false,
+        submitting: false,
+        hardwareWalletRequiresConnection: false,
+        gasIsLoading: false,
+        gasFeeIsCustom: true,
+      },
+    };
+
+    const store = configureMockStore(middleware)(newMockedStore);
+    const sendTransaction = jest
+      .fn()
+      .mockResolvedValue(newMockedStore.confirmTransaction.txData);
+    const showCustodianDeepLink = jest.fn();
+    const setWaitForConfirmDeepLinkDialog = jest.fn();
+
+    const { getByTestId } = renderWithProvider(
+      <ConfirmTransactionBase
+        actionKey="confirm"
+        sendTransaction={sendTransaction}
+        showCustodianDeepLink={showCustodianDeepLink}
+        setWaitForConfirmDeepLinkDialog={setWaitForConfirmDeepLinkDialog}
+        toAddress={mockPropsToAddress}
+        toAccounts={[{ address: mockPropsToAddress }]}
+        isMainBetaFlask={false}
+      />,
+      store,
+    );
+    const confirmButton = getByTestId('page-container-footer-next');
+    fireEvent.click(confirmButton);
+    expect(sendTransaction).toHaveBeenCalled();
+  });
+
   it('handleMainSubmit calls sendTransaction correctly', async () => {
     const newMockedStore = {
       ...mockedStore,


### PR DESCRIPTION
## **Description**
[Original PR
](https://github.com/MetaMask/metamask-extension/pull/21959)

FIX: Currently all transactions in MMI will fail if Note To Trader is not
enabled for a specific custodian

This is due to the metadata property on a txData being set in a
conditional that does not always evaluate true.

This PR defines this property outside the conditional.

## **Related issues**

Fixes: MMI Jira Ticket MMI-4124

## **Manual testing steps**


1. Disable note to trader in Saturn Custody
2. Confirm a transaction
3. Observe that no error is thrown


## **Screenshots/Recordings**


### **Before**

![image](https://github.com/MetaMask/metamask-extension/assets/1504499/c3cc47d0-ad15-4ec6-8519-36ca4732e631)

### **After**

(No error)

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained what problem this PR is solving and how it is solved.
- [x] I've linked related issues
- [x] I've included manual testing steps
- [x] I've included screenshots/recordings if applicable
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [x] I’ve properly set the pull request status:
  - [x] In case it's not yet "ready for review", I've set it to "draft".
  - [x] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
