### PR TITLE
fix: currency preferences toggle not displayed

### DIFF
--- a/ui/pages/settings/settings-tab/settings-tab.container.js
+++ b/ui/pages/settings/settings-tab/settings-tab.container.js
@@ -18,7 +18,7 @@ const mapStateToProps = (state, ownProps) => {
   } = state;
   const {
     currentCurrency,
-    nativeCurrency,
+    providerConfig: { ticker: nativeCurrency },
     useBlockie,
     currentLocale,
     selectedAddress,

--- a/ui/pages/settings/settings-tab/settings-tab.test.js
+++ b/ui/pages/settings/settings-tab/settings-tab.test.js
@@ -63,6 +63,14 @@ describe('Settings Tab', () => {
     ).toHaveBeenCalled();
   });
 
+  it('should display currency symbol for native token', async () => {
+    const { getByText } = renderWithProvider(<SettingsTab />, mockStore);
+
+    const textElement = getByText('ETH');
+
+    expect(textElement).toBeInTheDocument();
+  });
+
   it('clicks jazzicon', () => {
     const { queryByTestId } = renderWithProvider(<SettingsTab />, mockStore);
 


### PR DESCRIPTION
## **Description**
when the user goes to settings to change the primary currency symbol, the native token symbol is not displayed correctly ( see photo below )


## **Manual testing steps**

1. go to the develop branch
2. go to settings
3. find the primary currency symbol
4. fiat is displayed correctly as long as the native token symbol is not displayed

## **Screenshots/Recordings**

### **Before**

<img width="1147" alt="Screenshot 2023-11-22 at 10 32 38" src="https://github.com/MetaMask/metamask-extension/assets/26223211/aed704d9-a59f-4126-8a91-daef0ce0bd83">

### **After**
![Screenshot 2023-11-23 at 14 31 03](https://github.com/MetaMask/metamask-extension/assets/26223211/a46d97c9-26b1-4b63-a960-8a7ec76f8831)


## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained what problem this PR is solving and how it is solved.
- [ ] I've linked related issues
- [x] I've included manual testing steps
- [x] I've included screenshots/recordings if applicable
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [x] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [x] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
