### PR TITLE
Fix unit tests on develop following merge of #21166 with #21959

### DIFF
--- a/ui/pages/confirm-transaction-base/confirm-transaction-base.test.js
+++ b/ui/pages/confirm-transaction-base/confirm-transaction-base.test.js
@@ -31,6 +31,7 @@ setBackgroundConnection({
   promisifiedBackground: jest.fn(),
   tryReverseResolveAddress: jest.fn(),
   getNextNonce: jest.fn(),
+  updateTransaction: jest.fn().mockResolvedValue(),
 });
 
 const mockTxParamsFromAddress = '0x123456789';
@@ -348,7 +349,8 @@ describe('Confirm Transaction Base', () => {
       store,
     );
     const confirmButton = getByTestId('page-container-footer-next');
-    fireEvent.click(confirmButton);
+    await fireEvent.click(confirmButton);
+
     expect(sendTransaction).toHaveBeenCalled();
   });
 


### PR DESCRIPTION
Unit tests are failing on develop

#21166 was merged after #21959 but did not have that commit on the branch. #21166 introduced a `updateTransaction` call to `handleMMISubmit` in `confirm-transaction-base.component.js`, and #21959 introduced a unit test that results in a call to `handleMMISubmit`. For the unit tests to now pass, we need to include a mock of `updateTransaction` within the `setBackgroundConnection` call within `confirm-transaction-base.test.js`. Because `updateTransaction` is async, we also need to introduce an await within the unit test.