### PR TITLE
Fix sentry sessions

### DIFF
--- a/app/scripts/controllers/metametrics.js
+++ b/app/scripts/controllers/metametrics.js
@@ -449,11 +449,16 @@ export default class MetaMetricsController {
    */
   async setParticipateInMetaMetrics(participateInMetaMetrics) {
     let { metaMetricsId } = this.state;
-    if (participateInMetaMetrics && !metaMetricsId) {
+    if (participateInMetaMetrics) {
       // We also need to start sentry automatic session tracking at this point
       await globalThis.sentry?.startSession();
       metaMetricsId = this.generateMetaMetricsId();
-    } else if (participateInMetaMetrics === false) {
+    } else if (
+      participateInMetaMetrics === false &&
+      // We don't need to end the sentry session if the user is onboarding (and
+      // `metaMetricsId` is falsy)
+      metaMetricsId
+    ) {
       // We also need to stop sentry automatic session tracking at this point
       await globalThis.sentry?.endSession();
     }

--- a/app/scripts/lib/setupSentry.js
+++ b/app/scripts/lib/setupSentry.js
@@ -526,7 +526,7 @@ export default function setupSentry({ release, getState }) {
   const startSession = async () => {
     const hub = Sentry.getCurrentHub?.();
     const options = hub.getClient?.().getOptions?.() ?? {};
-    if (hub && (await getMetaMetricsEnabled()) === true) {
+    if (hub) {
       options.autoSessionTracking = true;
       hub.startSession();
     }
@@ -540,7 +540,7 @@ export default function setupSentry({ release, getState }) {
   const endSession = async () => {
     const hub = Sentry.getCurrentHub?.();
     const options = hub.getClient?.().getOptions?.() ?? {};
-    if (hub && (await getMetaMetricsEnabled()) === false) {
+    if (hub) {
       options.autoSessionTracking = false;
       hub.endSession();
     }

--- a/app/scripts/lib/setupSentry.js
+++ b/app/scripts/lib/setupSentry.js
@@ -480,22 +480,21 @@ export default function setupSentry({ release, getState }) {
      * via our beforeSend or FilterEvents integration. To avoid sending a
      * request before we have the state tree and can validate the users
      * preferences, we initiate this to false. Later, in startSession and
-     * endSession we modify this option and start the session or end the
-     * session manually.
+     * endSession we start the session or end the session manually.
      *
-     * In sentry-install we call toggleSession after the page loads and state
-     * is available, this handles initiating the session for a user who has
-     * opted into MetaMetrics. This script is ran in both the background and UI
-     * so it should be effective at starting the session in both places.
+     * In sentry-install we call toggleSession after the page loads and state is
+     * available, this handles initiating the session for a user who has opted
+     * into MetaMetrics. This script is ran in both the background and UI so it
+     * should be effective at starting the session in both places.
      *
      * In the MetaMetricsController the session is manually started or stopped
      * when the user opts in or out of MetaMetrics. This occurs in the
      * setParticipateInMetaMetrics function which is exposed to the UI via the
      * MetaMaskController.
      *
-     * In actions.ts, after sending the updated participateInMetaMetrics flag
-     * to the background, we call toggleSession to ensure sentry is kept in
-     * sync with the user's preference.
+     * In actions.ts, after sending the updated participateInMetaMetrics flag to
+     * the background, we call toggleSession to ensure sentry is kept in sync
+     * with the user's preference.
      *
      * Types for the global Sentry object, and the new methods added as part of
      * this effort were added to global.d.ts in the types folder.
@@ -536,8 +535,11 @@ export default function setupSentry({ release, getState }) {
       (isSessionStarted === undefined || isSessionStarted === false) &&
       isMetaMetricsEnabled === true
     ) {
-      Sentry.getCurrentHub().startSession();
-      Sentry.getCurrentHub().captureSession();
+      try {
+        Sentry.getCurrentHub().startSession();
+      } finally {
+        Sentry.getCurrentHub().captureSession();
+      }
 
       global.sentry.isSessionStarted = true;
     }
@@ -557,8 +559,11 @@ export default function setupSentry({ release, getState }) {
       isSessionStarted === true &&
       isMetaMetricsEnabled === false
     ) {
-      Sentry.getCurrentHub().captureSession(true);
-      Sentry.getCurrentHub().endSession();
+      try {
+        Sentry.getCurrentHub().captureSession(true);
+      } finally {
+        Sentry.getCurrentHub().endSession();
+      }
 
       global.sentry.isSessionStarted = false;
     }

--- a/app/scripts/lib/setupSentry.js
+++ b/app/scripts/lib/setupSentry.js
@@ -483,7 +483,7 @@ export default function setupSentry({ release, getState }) {
      * endSession we modify this option and start the session or end the
      * session manually.
      *
-     * In sentry-install we call toggleSession after the page loads and state
+     * In sentry-install we call startSession after the page loads and state
      * is available, this handles initiating the session for a user who has
      * opted into MetaMetrics. This script is ran in both the background and UI
      * so it should be effective at starting the session in both places.
@@ -492,10 +492,6 @@ export default function setupSentry({ release, getState }) {
      * when the user opts in or out of MetaMetrics. This occurs in the
      * setParticipateInMetaMetrics function which is exposed to the UI via the
      * MetaMaskController.
-     *
-     * In actions.ts, after sending the updated participateInMetaMetrics flag
-     * to the background, we call toggleSession to ensure sentry is kept in
-     * sync with the user's preference.
      *
      * Types for the global Sentry object, and the new methods added as part of
      * this effort were added to global.d.ts in the types folder.
@@ -550,35 +546,10 @@ export default function setupSentry({ release, getState }) {
     }
   };
 
-  /**
-   * Call the appropriate method (either startSession or endSession) depending
-   * on the state of metaMetrics optin and the state of autoSessionTracking on
-   * the Sentry client.
-   */
-  const toggleSession = async () => {
-    const hub = Sentry.getCurrentHub?.();
-    const options = hub.getClient?.().getOptions?.() ?? {
-      autoSessionTracking: false,
-    };
-    const isMetaMetricsEnabled = await getMetaMetricsEnabled();
-    if (
-      isMetaMetricsEnabled === true &&
-      options.autoSessionTracking === false
-    ) {
-      await startSession();
-    } else if (
-      isMetaMetricsEnabled === false &&
-      options.autoSessionTracking === true
-    ) {
-      await endSession();
-    }
-  };
-
   return {
     ...Sentry,
     startSession,
     endSession,
-    toggleSession,
   };
 }
 

--- a/app/scripts/lib/setupSentry.js
+++ b/app/scripts/lib/setupSentry.js
@@ -530,11 +530,7 @@ export default function setupSentry({ release, getState }) {
     const { isSessionStarted } = global.sentry;
     const isMetaMetricsEnabled = await getMetaMetricsEnabled();
 
-    if (
-      isHubDefined &&
-      (isSessionStarted === undefined || isSessionStarted === false) &&
-      isMetaMetricsEnabled === true
-    ) {
+    if (isHubDefined && !isSessionStarted && isMetaMetricsEnabled === true) {
       try {
         Sentry.getCurrentHub().startSession();
       } finally {
@@ -580,10 +576,7 @@ export default function setupSentry({ release, getState }) {
     const { isSessionStarted } = global.sentry;
     const isMetaMetricsEnabled = await getMetaMetricsEnabled();
 
-    if (
-      (isSessionStarted === undefined || isSessionStarted === false) &&
-      isMetaMetricsEnabled === false
-    ) {
+    if (!isSessionStarted && isMetaMetricsEnabled === false) {
       await startSession();
     } else if (isSessionStarted === true && isMetaMetricsEnabled === true) {
       await endSession();

--- a/app/scripts/lib/setupSentry.js
+++ b/app/scripts/lib/setupSentry.js
@@ -527,8 +527,8 @@ export default function setupSentry({ release, getState }) {
    * not been started, start a new sentry session.
    */
   const startSession = async () => {
-    const isHubDefined = !!Sentry.getCurrentHub();
-    const isSessionStarted = global.sentry.isSessionStarted;
+    const isHubDefined = Boolean(Sentry.getCurrentHub());
+    const { isSessionStarted } = global.sentry;
     if (isHubDefined && !isSessionStarted) {
       Sentry.getCurrentHub().startSession();
       Sentry.getCurrentHub().captureSession();
@@ -542,11 +542,10 @@ export default function setupSentry({ release, getState }) {
    * already been started, end the current sentry session.
    */
   const endSession = async () => {
-    const isHubDefined = !!Sentry.getCurrentHub();
-    const isSessionStarted = global.sentry.isSessionStarted;
+    const isHubDefined = Boolean(Sentry.getCurrentHub());
+    const { isSessionStarted } = global.sentry;
     if (isHubDefined && isSessionStarted) {
-      const endSession = true;
-      Sentry.getCurrentHub().captureSession(endSession);
+      Sentry.getCurrentHub().captureSession(true);
       Sentry.getCurrentHub().endSession();
 
       global.sentry.isSessionStarted = false;
@@ -561,10 +560,10 @@ export default function setupSentry({ release, getState }) {
    * previously been started.
    */
   const toggleSession = async () => {
-    const isSessionStarted = global.sentry.isSessionStarted;
-    const isMetaMetricsEnabled = (await getMetaMetricsEnabled()) === true;
+    const { isSessionStarted } = global.sentry;
+    const isMetaMetricsEnabled = await getMetaMetricsEnabled();
     if (
-      (isSessionStarted === undefined && isMetaMetricsEnabled) ||
+      (isSessionStarted === undefined && isMetaMetricsEnabled === true) ||
       isSessionStarted === false
     ) {
       await startSession();

--- a/app/scripts/lib/setupSentry.js
+++ b/app/scripts/lib/setupSentry.js
@@ -529,7 +529,13 @@ export default function setupSentry({ release, getState }) {
   const startSession = async () => {
     const isHubDefined = Boolean(Sentry.getCurrentHub());
     const { isSessionStarted } = global.sentry;
-    if (isHubDefined && !isSessionStarted) {
+    const isMetaMetricsEnabled = await getMetaMetricsEnabled();
+
+    if (
+      isHubDefined &&
+      (isSessionStarted === undefined || isSessionStarted === false) &&
+      isMetaMetricsEnabled === true
+    ) {
       Sentry.getCurrentHub().startSession();
       Sentry.getCurrentHub().captureSession();
 
@@ -544,7 +550,13 @@ export default function setupSentry({ release, getState }) {
   const endSession = async () => {
     const isHubDefined = Boolean(Sentry.getCurrentHub());
     const { isSessionStarted } = global.sentry;
-    if (isHubDefined && isSessionStarted) {
+    const isMetaMetricsEnabled = await getMetaMetricsEnabled();
+
+    if (
+      isHubDefined &&
+      isSessionStarted === true &&
+      isMetaMetricsEnabled === false
+    ) {
       Sentry.getCurrentHub().captureSession(true);
       Sentry.getCurrentHub().endSession();
 
@@ -562,12 +574,13 @@ export default function setupSentry({ release, getState }) {
   const toggleSession = async () => {
     const { isSessionStarted } = global.sentry;
     const isMetaMetricsEnabled = await getMetaMetricsEnabled();
+
     if (
-      (isSessionStarted === undefined && isMetaMetricsEnabled === true) ||
-      isSessionStarted === false
+      (isSessionStarted === undefined || isSessionStarted === false) &&
+      isMetaMetricsEnabled === false
     ) {
       await startSession();
-    } else if (isSessionStarted === true) {
+    } else if (isSessionStarted === true && isMetaMetricsEnabled === true) {
       await endSession();
     }
   };

--- a/app/scripts/lib/setupSentry.js
+++ b/app/scripts/lib/setupSentry.js
@@ -528,7 +528,12 @@ export default function setupSentry({ release, getState }) {
     const options = hub.getClient?.().getOptions?.() ?? {};
     if (hub) {
       options.autoSessionTracking = true;
-      hub.startSession();
+
+      try {
+        Sentry.getCurrentHub().startSession();
+      } finally {
+        Sentry.getCurrentHub().captureSession();
+      }
     }
   };
 
@@ -542,7 +547,14 @@ export default function setupSentry({ release, getState }) {
     const options = hub.getClient?.().getOptions?.() ?? {};
     if (hub) {
       options.autoSessionTracking = false;
-      hub.endSession();
+
+      try {
+        // https://getsentry.github.io/sentry-javascript/classes/_sentry_browser.Hub.html#captureSession
+        const isEndingSession = true;
+        Sentry.getCurrentHub().captureSession(isEndingSession);
+      } finally {
+        Sentry.getCurrentHub().endSession();
+      }
     }
   };
 

--- a/development/build/scripts.js
+++ b/development/build/scripts.js
@@ -78,6 +78,7 @@ const scuttlingConfigBase = {
     encodeURIComponent: '',
     console: '',
     crypto: '',
+    Map: '',
     // {clear/set}Timeout are "this sensitive"
     clearTimeout: 'window',
     setTimeout: 'window',

--- a/development/build/scripts.js
+++ b/development/build/scripts.js
@@ -78,7 +78,6 @@ const scuttlingConfigBase = {
     encodeURIComponent: '',
     console: '',
     crypto: '',
-    Map: '',
     // {clear/set}Timeout are "this sensitive"
     clearTimeout: 'window',
     setTimeout: 'window',

--- a/lavamoat/browserify/beta/policy.json
+++ b/lavamoat/browserify/beta/policy.json
@@ -2233,13 +2233,14 @@
         "__SENTRY_DEBUG__": true,
         "__SENTRY_RELEASE__": true,
         "indexedDB.open": true,
+        "performance.timeOrigin": true,
         "setTimeout": true
       },
       "packages": {
         "@sentry/browser>@sentry-internal/tracing": true,
         "@sentry/browser>@sentry/core": true,
         "@sentry/browser>@sentry/replay": true,
-        "@sentry/utils": true
+        "@sentry/browser>@sentry/utils": true
       }
     },
     "@sentry/browser>@sentry-internal/tracing": {
@@ -2250,11 +2251,42 @@
         "__SENTRY_DEBUG__": true,
         "addEventListener": true,
         "performance.getEntriesByType": true,
-        "removeEventListener": true
+        "performance.timeOrigin": true,
+        "removeEventListener": true,
+        "setTimeout": true
       },
       "packages": {
-        "@sentry/browser>@sentry/core": true,
-        "@sentry/utils": true
+        "@sentry/browser>@sentry-internal/tracing>@sentry/utils": true,
+        "@sentry/browser>@sentry/core": true
+      }
+    },
+    "@sentry/browser>@sentry-internal/tracing>@sentry/utils": {
+      "globals": {
+        "CustomEvent": true,
+        "DOMError": true,
+        "DOMException": true,
+        "EdgeRuntime": true,
+        "Element": true,
+        "ErrorEvent": true,
+        "Event": true,
+        "Headers": true,
+        "Request": true,
+        "Response": true,
+        "TextEncoder": true,
+        "URL": true,
+        "XMLHttpRequest.prototype": true,
+        "__SENTRY_BROWSER_BUNDLE__": true,
+        "__SENTRY_DEBUG__": true,
+        "clearTimeout": true,
+        "console.error": true,
+        "document": true,
+        "new": true,
+        "setInterval": true,
+        "setTimeout": true,
+        "target": true
+      },
+      "packages": {
+        "browserify>process": true
       }
     },
     "@sentry/browser>@sentry/core": {
@@ -2268,7 +2300,36 @@
         "setTimeout": true
       },
       "packages": {
-        "@sentry/utils": true
+        "@sentry/browser>@sentry/core>@sentry/utils": true
+      }
+    },
+    "@sentry/browser>@sentry/core>@sentry/utils": {
+      "globals": {
+        "CustomEvent": true,
+        "DOMError": true,
+        "DOMException": true,
+        "EdgeRuntime": true,
+        "Element": true,
+        "ErrorEvent": true,
+        "Event": true,
+        "Headers": true,
+        "Request": true,
+        "Response": true,
+        "TextEncoder": true,
+        "URL": true,
+        "XMLHttpRequest.prototype": true,
+        "__SENTRY_BROWSER_BUNDLE__": true,
+        "__SENTRY_DEBUG__": true,
+        "clearTimeout": true,
+        "console.error": true,
+        "document": true,
+        "new": true,
+        "setInterval": true,
+        "setTimeout": true,
+        "target": true
+      },
+      "packages": {
+        "browserify>process": true
       }
     },
     "@sentry/browser>@sentry/replay": {
@@ -2277,46 +2338,104 @@
         "CSSConditionRule": true,
         "CSSGroupingRule": true,
         "CSSMediaRule": true,
+        "CSSRule": true,
         "CSSSupportsRule": true,
         "DragEvent": true,
         "Element": true,
         "FormData": true,
-        "HTMLCanvasElement": true,
-        "HTMLElement.prototype": true,
+        "HTMLElement": true,
         "HTMLFormElement": true,
-        "HTMLImageElement": true,
-        "HTMLInputElement.prototype": true,
-        "HTMLOptionElement.prototype": true,
-        "HTMLSelectElement.prototype": true,
-        "HTMLTextAreaElement.prototype": true,
         "Headers": true,
-        "ImageData": true,
         "MouseEvent": true,
         "MutationObserver": true,
+        "Node.DOCUMENT_FRAGMENT_NODE": true,
         "Node.prototype.contains": true,
-        "PerformanceObserver": true,
+        "PointerEvent": true,
         "TextEncoder": true,
         "URL": true,
         "URLSearchParams": true,
         "Worker": true,
         "Zone": true,
+        "__RRWEB_EXCLUDE_IFRAME__": true,
+        "__RRWEB_EXCLUDE_SHADOW_DOM__": true,
         "__SENTRY_DEBUG__": true,
+        "__SENTRY_EXCLUDE_REPLAY_WORKER__": true,
         "__rrMutationObserver": true,
+        "addEventListener": true,
         "clearTimeout": true,
         "console.error": true,
         "console.warn": true,
+        "customElements.get": true,
         "document": true,
         "innerHeight": true,
         "innerWidth": true,
         "location.href": true,
-        "pageXOffset": true,
-        "pageYOffset": true,
+        "location.origin": true,
+        "parent": true,
         "requestAnimationFrame": true,
         "setTimeout": true
       },
       "packages": {
+        "@sentry/browser>@sentry-internal/tracing": true,
         "@sentry/browser>@sentry/core": true,
-        "@sentry/utils": true,
+        "@sentry/browser>@sentry/replay>@sentry/utils": true
+      }
+    },
+    "@sentry/browser>@sentry/replay>@sentry/utils": {
+      "globals": {
+        "CustomEvent": true,
+        "DOMError": true,
+        "DOMException": true,
+        "EdgeRuntime": true,
+        "Element": true,
+        "ErrorEvent": true,
+        "Event": true,
+        "Headers": true,
+        "Request": true,
+        "Response": true,
+        "TextEncoder": true,
+        "URL": true,
+        "XMLHttpRequest.prototype": true,
+        "__SENTRY_BROWSER_BUNDLE__": true,
+        "__SENTRY_DEBUG__": true,
+        "clearTimeout": true,
+        "console.error": true,
+        "document": true,
+        "new": true,
+        "setInterval": true,
+        "setTimeout": true,
+        "target": true
+      },
+      "packages": {
+        "browserify>process": true
+      }
+    },
+    "@sentry/browser>@sentry/utils": {
+      "globals": {
+        "CustomEvent": true,
+        "DOMError": true,
+        "DOMException": true,
+        "EdgeRuntime": true,
+        "Element": true,
+        "ErrorEvent": true,
+        "Event": true,
+        "Headers": true,
+        "Request": true,
+        "Response": true,
+        "TextEncoder": true,
+        "URL": true,
+        "XMLHttpRequest.prototype": true,
+        "__SENTRY_BROWSER_BUNDLE__": true,
+        "__SENTRY_DEBUG__": true,
+        "clearTimeout": true,
+        "console.error": true,
+        "document": true,
+        "new": true,
+        "setInterval": true,
+        "setTimeout": true,
+        "target": true
+      },
+      "packages": {
         "browserify>process": true
       }
     },

--- a/lavamoat/browserify/beta/policy.json
+++ b/lavamoat/browserify/beta/policy.json
@@ -2233,12 +2233,28 @@
         "__SENTRY_DEBUG__": true,
         "__SENTRY_RELEASE__": true,
         "indexedDB.open": true,
+        "performance.timeOrigin": true,
         "setTimeout": true
       },
       "packages": {
+        "@sentry/browser>@sentry-internal/feedback": true,
         "@sentry/browser>@sentry-internal/tracing": true,
         "@sentry/browser>@sentry/core": true,
         "@sentry/browser>@sentry/replay": true,
+        "@sentry/utils": true
+      }
+    },
+    "@sentry/browser>@sentry-internal/feedback": {
+      "globals": {
+        "FormData": true,
+        "HTMLFormElement": true,
+        "Node": true,
+        "__SENTRY_DEBUG__": true,
+        "clearTimeout": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "@sentry/browser>@sentry/core": true,
         "@sentry/utils": true
       }
     },
@@ -2250,7 +2266,9 @@
         "__SENTRY_DEBUG__": true,
         "addEventListener": true,
         "performance.getEntriesByType": true,
-        "removeEventListener": true
+        "performance.timeOrigin": true,
+        "removeEventListener": true,
+        "setTimeout": true
       },
       "packages": {
         "@sentry/browser>@sentry/core": true,
@@ -2277,47 +2295,48 @@
         "CSSConditionRule": true,
         "CSSGroupingRule": true,
         "CSSMediaRule": true,
+        "CSSRule": true,
         "CSSSupportsRule": true,
+        "Document": true,
         "DragEvent": true,
         "Element": true,
         "FormData": true,
-        "HTMLCanvasElement": true,
-        "HTMLElement.prototype": true,
+        "HTMLElement": true,
         "HTMLFormElement": true,
-        "HTMLImageElement": true,
-        "HTMLInputElement.prototype": true,
-        "HTMLOptionElement.prototype": true,
-        "HTMLSelectElement.prototype": true,
-        "HTMLTextAreaElement.prototype": true,
         "Headers": true,
-        "ImageData": true,
         "MouseEvent": true,
         "MutationObserver": true,
+        "Node.DOCUMENT_FRAGMENT_NODE": true,
         "Node.prototype.contains": true,
-        "PerformanceObserver": true,
+        "PointerEvent": true,
         "TextEncoder": true,
         "URL": true,
         "URLSearchParams": true,
         "Worker": true,
         "Zone": true,
+        "__RRWEB_EXCLUDE_IFRAME__": true,
+        "__RRWEB_EXCLUDE_SHADOW_DOM__": true,
         "__SENTRY_DEBUG__": true,
+        "__SENTRY_EXCLUDE_REPLAY_WORKER__": true,
         "__rrMutationObserver": true,
+        "addEventListener": true,
         "clearTimeout": true,
         "console.error": true,
         "console.warn": true,
+        "customElements.get": true,
         "document": true,
         "innerHeight": true,
         "innerWidth": true,
         "location.href": true,
-        "pageXOffset": true,
-        "pageYOffset": true,
+        "location.origin": true,
+        "parent": true,
         "requestAnimationFrame": true,
         "setTimeout": true
       },
       "packages": {
+        "@sentry/browser>@sentry-internal/tracing": true,
         "@sentry/browser>@sentry/core": true,
-        "@sentry/utils": true,
-        "browserify>process": true
+        "@sentry/utils": true
       }
     },
     "@sentry/integrations": {
@@ -2327,11 +2346,11 @@
         "console.log": true
       },
       "packages": {
-        "@sentry/utils": true,
+        "@sentry/integrations>@sentry/utils": true,
         "localforage": true
       }
     },
-    "@sentry/utils": {
+    "@sentry/integrations>@sentry/utils": {
       "globals": {
         "CustomEvent": true,
         "DOMError": true,
@@ -2351,6 +2370,35 @@
         "console.error": true,
         "document": true,
         "new": true,
+        "setTimeout": true,
+        "target": true
+      },
+      "packages": {
+        "browserify>process": true
+      }
+    },
+    "@sentry/utils": {
+      "globals": {
+        "CustomEvent": true,
+        "DOMError": true,
+        "DOMException": true,
+        "EdgeRuntime": true,
+        "Element": true,
+        "ErrorEvent": true,
+        "Event": true,
+        "Headers": true,
+        "Request": true,
+        "Response": true,
+        "TextEncoder": true,
+        "URL": true,
+        "XMLHttpRequest.prototype": true,
+        "__SENTRY_BROWSER_BUNDLE__": true,
+        "__SENTRY_DEBUG__": true,
+        "clearTimeout": true,
+        "console.error": true,
+        "document": true,
+        "new": true,
+        "setInterval": true,
         "setTimeout": true,
         "target": true
       },

--- a/lavamoat/browserify/beta/policy.json
+++ b/lavamoat/browserify/beta/policy.json
@@ -2240,7 +2240,7 @@
         "@sentry/browser>@sentry-internal/tracing": true,
         "@sentry/browser>@sentry/core": true,
         "@sentry/browser>@sentry/replay": true,
-        "@sentry/browser>@sentry/utils": true
+        "@sentry/utils": true
       }
     },
     "@sentry/browser>@sentry-internal/tracing": {
@@ -2256,37 +2256,8 @@
         "setTimeout": true
       },
       "packages": {
-        "@sentry/browser>@sentry-internal/tracing>@sentry/utils": true,
-        "@sentry/browser>@sentry/core": true
-      }
-    },
-    "@sentry/browser>@sentry-internal/tracing>@sentry/utils": {
-      "globals": {
-        "CustomEvent": true,
-        "DOMError": true,
-        "DOMException": true,
-        "EdgeRuntime": true,
-        "Element": true,
-        "ErrorEvent": true,
-        "Event": true,
-        "Headers": true,
-        "Request": true,
-        "Response": true,
-        "TextEncoder": true,
-        "URL": true,
-        "XMLHttpRequest.prototype": true,
-        "__SENTRY_BROWSER_BUNDLE__": true,
-        "__SENTRY_DEBUG__": true,
-        "clearTimeout": true,
-        "console.error": true,
-        "document": true,
-        "new": true,
-        "setInterval": true,
-        "setTimeout": true,
-        "target": true
-      },
-      "packages": {
-        "browserify>process": true
+        "@sentry/browser>@sentry/core": true,
+        "@sentry/utils": true
       }
     },
     "@sentry/browser>@sentry/core": {
@@ -2300,36 +2271,7 @@
         "setTimeout": true
       },
       "packages": {
-        "@sentry/browser>@sentry/core>@sentry/utils": true
-      }
-    },
-    "@sentry/browser>@sentry/core>@sentry/utils": {
-      "globals": {
-        "CustomEvent": true,
-        "DOMError": true,
-        "DOMException": true,
-        "EdgeRuntime": true,
-        "Element": true,
-        "ErrorEvent": true,
-        "Event": true,
-        "Headers": true,
-        "Request": true,
-        "Response": true,
-        "TextEncoder": true,
-        "URL": true,
-        "XMLHttpRequest.prototype": true,
-        "__SENTRY_BROWSER_BUNDLE__": true,
-        "__SENTRY_DEBUG__": true,
-        "clearTimeout": true,
-        "console.error": true,
-        "document": true,
-        "new": true,
-        "setInterval": true,
-        "setTimeout": true,
-        "target": true
-      },
-      "packages": {
-        "browserify>process": true
+        "@sentry/utils": true
       }
     },
     "@sentry/browser>@sentry/replay": {
@@ -2378,65 +2320,7 @@
       "packages": {
         "@sentry/browser>@sentry-internal/tracing": true,
         "@sentry/browser>@sentry/core": true,
-        "@sentry/browser>@sentry/replay>@sentry/utils": true
-      }
-    },
-    "@sentry/browser>@sentry/replay>@sentry/utils": {
-      "globals": {
-        "CustomEvent": true,
-        "DOMError": true,
-        "DOMException": true,
-        "EdgeRuntime": true,
-        "Element": true,
-        "ErrorEvent": true,
-        "Event": true,
-        "Headers": true,
-        "Request": true,
-        "Response": true,
-        "TextEncoder": true,
-        "URL": true,
-        "XMLHttpRequest.prototype": true,
-        "__SENTRY_BROWSER_BUNDLE__": true,
-        "__SENTRY_DEBUG__": true,
-        "clearTimeout": true,
-        "console.error": true,
-        "document": true,
-        "new": true,
-        "setInterval": true,
-        "setTimeout": true,
-        "target": true
-      },
-      "packages": {
-        "browserify>process": true
-      }
-    },
-    "@sentry/browser>@sentry/utils": {
-      "globals": {
-        "CustomEvent": true,
-        "DOMError": true,
-        "DOMException": true,
-        "EdgeRuntime": true,
-        "Element": true,
-        "ErrorEvent": true,
-        "Event": true,
-        "Headers": true,
-        "Request": true,
-        "Response": true,
-        "TextEncoder": true,
-        "URL": true,
-        "XMLHttpRequest.prototype": true,
-        "__SENTRY_BROWSER_BUNDLE__": true,
-        "__SENTRY_DEBUG__": true,
-        "clearTimeout": true,
-        "console.error": true,
-        "document": true,
-        "new": true,
-        "setInterval": true,
-        "setTimeout": true,
-        "target": true
-      },
-      "packages": {
-        "browserify>process": true
+        "@sentry/utils": true
       }
     },
     "@sentry/integrations": {
@@ -2446,11 +2330,11 @@
         "console.log": true
       },
       "packages": {
-        "@sentry/utils": true,
+        "@sentry/integrations>@sentry/utils": true,
         "localforage": true
       }
     },
-    "@sentry/utils": {
+    "@sentry/integrations>@sentry/utils": {
       "globals": {
         "CustomEvent": true,
         "DOMError": true,
@@ -2470,6 +2354,35 @@
         "console.error": true,
         "document": true,
         "new": true,
+        "setTimeout": true,
+        "target": true
+      },
+      "packages": {
+        "browserify>process": true
+      }
+    },
+    "@sentry/utils": {
+      "globals": {
+        "CustomEvent": true,
+        "DOMError": true,
+        "DOMException": true,
+        "EdgeRuntime": true,
+        "Element": true,
+        "ErrorEvent": true,
+        "Event": true,
+        "Headers": true,
+        "Request": true,
+        "Response": true,
+        "TextEncoder": true,
+        "URL": true,
+        "XMLHttpRequest.prototype": true,
+        "__SENTRY_BROWSER_BUNDLE__": true,
+        "__SENTRY_DEBUG__": true,
+        "clearTimeout": true,
+        "console.error": true,
+        "document": true,
+        "new": true,
+        "setInterval": true,
         "setTimeout": true,
         "target": true
       },

--- a/lavamoat/browserify/beta/policy.json
+++ b/lavamoat/browserify/beta/policy.json
@@ -2233,7 +2233,6 @@
         "__SENTRY_DEBUG__": true,
         "__SENTRY_RELEASE__": true,
         "indexedDB.open": true,
-        "performance.timeOrigin": true,
         "setTimeout": true
       },
       "packages": {
@@ -2251,9 +2250,7 @@
         "__SENTRY_DEBUG__": true,
         "addEventListener": true,
         "performance.getEntriesByType": true,
-        "performance.timeOrigin": true,
-        "removeEventListener": true,
-        "setTimeout": true
+        "removeEventListener": true
       },
       "packages": {
         "@sentry/browser>@sentry/core": true,
@@ -2280,47 +2277,47 @@
         "CSSConditionRule": true,
         "CSSGroupingRule": true,
         "CSSMediaRule": true,
-        "CSSRule": true,
         "CSSSupportsRule": true,
         "DragEvent": true,
         "Element": true,
         "FormData": true,
-        "HTMLElement": true,
+        "HTMLCanvasElement": true,
+        "HTMLElement.prototype": true,
         "HTMLFormElement": true,
+        "HTMLImageElement": true,
+        "HTMLInputElement.prototype": true,
+        "HTMLOptionElement.prototype": true,
+        "HTMLSelectElement.prototype": true,
+        "HTMLTextAreaElement.prototype": true,
         "Headers": true,
+        "ImageData": true,
         "MouseEvent": true,
         "MutationObserver": true,
-        "Node.DOCUMENT_FRAGMENT_NODE": true,
         "Node.prototype.contains": true,
-        "PointerEvent": true,
+        "PerformanceObserver": true,
         "TextEncoder": true,
         "URL": true,
         "URLSearchParams": true,
         "Worker": true,
         "Zone": true,
-        "__RRWEB_EXCLUDE_IFRAME__": true,
-        "__RRWEB_EXCLUDE_SHADOW_DOM__": true,
         "__SENTRY_DEBUG__": true,
-        "__SENTRY_EXCLUDE_REPLAY_WORKER__": true,
         "__rrMutationObserver": true,
-        "addEventListener": true,
         "clearTimeout": true,
         "console.error": true,
         "console.warn": true,
-        "customElements.get": true,
         "document": true,
         "innerHeight": true,
         "innerWidth": true,
         "location.href": true,
-        "location.origin": true,
-        "parent": true,
+        "pageXOffset": true,
+        "pageYOffset": true,
         "requestAnimationFrame": true,
         "setTimeout": true
       },
       "packages": {
-        "@sentry/browser>@sentry-internal/tracing": true,
         "@sentry/browser>@sentry/core": true,
-        "@sentry/utils": true
+        "@sentry/utils": true,
+        "browserify>process": true
       }
     },
     "@sentry/integrations": {
@@ -2330,35 +2327,8 @@
         "console.log": true
       },
       "packages": {
-        "@sentry/integrations>@sentry/utils": true,
+        "@sentry/utils": true,
         "localforage": true
-      }
-    },
-    "@sentry/integrations>@sentry/utils": {
-      "globals": {
-        "CustomEvent": true,
-        "DOMError": true,
-        "DOMException": true,
-        "Element": true,
-        "ErrorEvent": true,
-        "Event": true,
-        "Headers": true,
-        "Request": true,
-        "Response": true,
-        "TextEncoder": true,
-        "URL": true,
-        "XMLHttpRequest.prototype": true,
-        "__SENTRY_BROWSER_BUNDLE__": true,
-        "__SENTRY_DEBUG__": true,
-        "clearTimeout": true,
-        "console.error": true,
-        "document": true,
-        "new": true,
-        "setTimeout": true,
-        "target": true
-      },
-      "packages": {
-        "browserify>process": true
       }
     },
     "@sentry/utils": {
@@ -2366,7 +2336,6 @@
         "CustomEvent": true,
         "DOMError": true,
         "DOMException": true,
-        "EdgeRuntime": true,
         "Element": true,
         "ErrorEvent": true,
         "Event": true,
@@ -2382,7 +2351,6 @@
         "console.error": true,
         "document": true,
         "new": true,
-        "setInterval": true,
         "setTimeout": true,
         "target": true
       },

--- a/lavamoat/browserify/desktop/policy.json
+++ b/lavamoat/browserify/desktop/policy.json
@@ -2486,13 +2486,14 @@
         "__SENTRY_DEBUG__": true,
         "__SENTRY_RELEASE__": true,
         "indexedDB.open": true,
+        "performance.timeOrigin": true,
         "setTimeout": true
       },
       "packages": {
         "@sentry/browser>@sentry-internal/tracing": true,
         "@sentry/browser>@sentry/core": true,
         "@sentry/browser>@sentry/replay": true,
-        "@sentry/utils": true
+        "@sentry/browser>@sentry/utils": true
       }
     },
     "@sentry/browser>@sentry-internal/tracing": {
@@ -2503,11 +2504,42 @@
         "__SENTRY_DEBUG__": true,
         "addEventListener": true,
         "performance.getEntriesByType": true,
-        "removeEventListener": true
+        "performance.timeOrigin": true,
+        "removeEventListener": true,
+        "setTimeout": true
       },
       "packages": {
-        "@sentry/browser>@sentry/core": true,
-        "@sentry/utils": true
+        "@sentry/browser>@sentry-internal/tracing>@sentry/utils": true,
+        "@sentry/browser>@sentry/core": true
+      }
+    },
+    "@sentry/browser>@sentry-internal/tracing>@sentry/utils": {
+      "globals": {
+        "CustomEvent": true,
+        "DOMError": true,
+        "DOMException": true,
+        "EdgeRuntime": true,
+        "Element": true,
+        "ErrorEvent": true,
+        "Event": true,
+        "Headers": true,
+        "Request": true,
+        "Response": true,
+        "TextEncoder": true,
+        "URL": true,
+        "XMLHttpRequest.prototype": true,
+        "__SENTRY_BROWSER_BUNDLE__": true,
+        "__SENTRY_DEBUG__": true,
+        "clearTimeout": true,
+        "console.error": true,
+        "document": true,
+        "new": true,
+        "setInterval": true,
+        "setTimeout": true,
+        "target": true
+      },
+      "packages": {
+        "browserify>process": true
       }
     },
     "@sentry/browser>@sentry/core": {
@@ -2521,7 +2553,36 @@
         "setTimeout": true
       },
       "packages": {
-        "@sentry/utils": true
+        "@sentry/browser>@sentry/core>@sentry/utils": true
+      }
+    },
+    "@sentry/browser>@sentry/core>@sentry/utils": {
+      "globals": {
+        "CustomEvent": true,
+        "DOMError": true,
+        "DOMException": true,
+        "EdgeRuntime": true,
+        "Element": true,
+        "ErrorEvent": true,
+        "Event": true,
+        "Headers": true,
+        "Request": true,
+        "Response": true,
+        "TextEncoder": true,
+        "URL": true,
+        "XMLHttpRequest.prototype": true,
+        "__SENTRY_BROWSER_BUNDLE__": true,
+        "__SENTRY_DEBUG__": true,
+        "clearTimeout": true,
+        "console.error": true,
+        "document": true,
+        "new": true,
+        "setInterval": true,
+        "setTimeout": true,
+        "target": true
+      },
+      "packages": {
+        "browserify>process": true
       }
     },
     "@sentry/browser>@sentry/replay": {
@@ -2530,46 +2591,104 @@
         "CSSConditionRule": true,
         "CSSGroupingRule": true,
         "CSSMediaRule": true,
+        "CSSRule": true,
         "CSSSupportsRule": true,
         "DragEvent": true,
         "Element": true,
         "FormData": true,
-        "HTMLCanvasElement": true,
-        "HTMLElement.prototype": true,
+        "HTMLElement": true,
         "HTMLFormElement": true,
-        "HTMLImageElement": true,
-        "HTMLInputElement.prototype": true,
-        "HTMLOptionElement.prototype": true,
-        "HTMLSelectElement.prototype": true,
-        "HTMLTextAreaElement.prototype": true,
         "Headers": true,
-        "ImageData": true,
         "MouseEvent": true,
         "MutationObserver": true,
+        "Node.DOCUMENT_FRAGMENT_NODE": true,
         "Node.prototype.contains": true,
-        "PerformanceObserver": true,
+        "PointerEvent": true,
         "TextEncoder": true,
         "URL": true,
         "URLSearchParams": true,
         "Worker": true,
         "Zone": true,
+        "__RRWEB_EXCLUDE_IFRAME__": true,
+        "__RRWEB_EXCLUDE_SHADOW_DOM__": true,
         "__SENTRY_DEBUG__": true,
+        "__SENTRY_EXCLUDE_REPLAY_WORKER__": true,
         "__rrMutationObserver": true,
+        "addEventListener": true,
         "clearTimeout": true,
         "console.error": true,
         "console.warn": true,
+        "customElements.get": true,
         "document": true,
         "innerHeight": true,
         "innerWidth": true,
         "location.href": true,
-        "pageXOffset": true,
-        "pageYOffset": true,
+        "location.origin": true,
+        "parent": true,
         "requestAnimationFrame": true,
         "setTimeout": true
       },
       "packages": {
+        "@sentry/browser>@sentry-internal/tracing": true,
         "@sentry/browser>@sentry/core": true,
-        "@sentry/utils": true,
+        "@sentry/browser>@sentry/replay>@sentry/utils": true
+      }
+    },
+    "@sentry/browser>@sentry/replay>@sentry/utils": {
+      "globals": {
+        "CustomEvent": true,
+        "DOMError": true,
+        "DOMException": true,
+        "EdgeRuntime": true,
+        "Element": true,
+        "ErrorEvent": true,
+        "Event": true,
+        "Headers": true,
+        "Request": true,
+        "Response": true,
+        "TextEncoder": true,
+        "URL": true,
+        "XMLHttpRequest.prototype": true,
+        "__SENTRY_BROWSER_BUNDLE__": true,
+        "__SENTRY_DEBUG__": true,
+        "clearTimeout": true,
+        "console.error": true,
+        "document": true,
+        "new": true,
+        "setInterval": true,
+        "setTimeout": true,
+        "target": true
+      },
+      "packages": {
+        "browserify>process": true
+      }
+    },
+    "@sentry/browser>@sentry/utils": {
+      "globals": {
+        "CustomEvent": true,
+        "DOMError": true,
+        "DOMException": true,
+        "EdgeRuntime": true,
+        "Element": true,
+        "ErrorEvent": true,
+        "Event": true,
+        "Headers": true,
+        "Request": true,
+        "Response": true,
+        "TextEncoder": true,
+        "URL": true,
+        "XMLHttpRequest.prototype": true,
+        "__SENTRY_BROWSER_BUNDLE__": true,
+        "__SENTRY_DEBUG__": true,
+        "clearTimeout": true,
+        "console.error": true,
+        "document": true,
+        "new": true,
+        "setInterval": true,
+        "setTimeout": true,
+        "target": true
+      },
+      "packages": {
         "browserify>process": true
       }
     },

--- a/lavamoat/browserify/desktop/policy.json
+++ b/lavamoat/browserify/desktop/policy.json
@@ -2486,7 +2486,6 @@
         "__SENTRY_DEBUG__": true,
         "__SENTRY_RELEASE__": true,
         "indexedDB.open": true,
-        "performance.timeOrigin": true,
         "setTimeout": true
       },
       "packages": {
@@ -2504,9 +2503,7 @@
         "__SENTRY_DEBUG__": true,
         "addEventListener": true,
         "performance.getEntriesByType": true,
-        "performance.timeOrigin": true,
-        "removeEventListener": true,
-        "setTimeout": true
+        "removeEventListener": true
       },
       "packages": {
         "@sentry/browser>@sentry/core": true,
@@ -2533,47 +2530,47 @@
         "CSSConditionRule": true,
         "CSSGroupingRule": true,
         "CSSMediaRule": true,
-        "CSSRule": true,
         "CSSSupportsRule": true,
         "DragEvent": true,
         "Element": true,
         "FormData": true,
-        "HTMLElement": true,
+        "HTMLCanvasElement": true,
+        "HTMLElement.prototype": true,
         "HTMLFormElement": true,
+        "HTMLImageElement": true,
+        "HTMLInputElement.prototype": true,
+        "HTMLOptionElement.prototype": true,
+        "HTMLSelectElement.prototype": true,
+        "HTMLTextAreaElement.prototype": true,
         "Headers": true,
+        "ImageData": true,
         "MouseEvent": true,
         "MutationObserver": true,
-        "Node.DOCUMENT_FRAGMENT_NODE": true,
         "Node.prototype.contains": true,
-        "PointerEvent": true,
+        "PerformanceObserver": true,
         "TextEncoder": true,
         "URL": true,
         "URLSearchParams": true,
         "Worker": true,
         "Zone": true,
-        "__RRWEB_EXCLUDE_IFRAME__": true,
-        "__RRWEB_EXCLUDE_SHADOW_DOM__": true,
         "__SENTRY_DEBUG__": true,
-        "__SENTRY_EXCLUDE_REPLAY_WORKER__": true,
         "__rrMutationObserver": true,
-        "addEventListener": true,
         "clearTimeout": true,
         "console.error": true,
         "console.warn": true,
-        "customElements.get": true,
         "document": true,
         "innerHeight": true,
         "innerWidth": true,
         "location.href": true,
-        "location.origin": true,
-        "parent": true,
+        "pageXOffset": true,
+        "pageYOffset": true,
         "requestAnimationFrame": true,
         "setTimeout": true
       },
       "packages": {
-        "@sentry/browser>@sentry-internal/tracing": true,
         "@sentry/browser>@sentry/core": true,
-        "@sentry/utils": true
+        "@sentry/utils": true,
+        "browserify>process": true
       }
     },
     "@sentry/integrations": {
@@ -2583,35 +2580,8 @@
         "console.log": true
       },
       "packages": {
-        "@sentry/integrations>@sentry/utils": true,
+        "@sentry/utils": true,
         "localforage": true
-      }
-    },
-    "@sentry/integrations>@sentry/utils": {
-      "globals": {
-        "CustomEvent": true,
-        "DOMError": true,
-        "DOMException": true,
-        "Element": true,
-        "ErrorEvent": true,
-        "Event": true,
-        "Headers": true,
-        "Request": true,
-        "Response": true,
-        "TextEncoder": true,
-        "URL": true,
-        "XMLHttpRequest.prototype": true,
-        "__SENTRY_BROWSER_BUNDLE__": true,
-        "__SENTRY_DEBUG__": true,
-        "clearTimeout": true,
-        "console.error": true,
-        "document": true,
-        "new": true,
-        "setTimeout": true,
-        "target": true
-      },
-      "packages": {
-        "browserify>process": true
       }
     },
     "@sentry/utils": {
@@ -2619,7 +2589,6 @@
         "CustomEvent": true,
         "DOMError": true,
         "DOMException": true,
-        "EdgeRuntime": true,
         "Element": true,
         "ErrorEvent": true,
         "Event": true,
@@ -2635,7 +2604,6 @@
         "console.error": true,
         "document": true,
         "new": true,
-        "setInterval": true,
         "setTimeout": true,
         "target": true
       },

--- a/lavamoat/browserify/desktop/policy.json
+++ b/lavamoat/browserify/desktop/policy.json
@@ -2493,7 +2493,7 @@
         "@sentry/browser>@sentry-internal/tracing": true,
         "@sentry/browser>@sentry/core": true,
         "@sentry/browser>@sentry/replay": true,
-        "@sentry/browser>@sentry/utils": true
+        "@sentry/utils": true
       }
     },
     "@sentry/browser>@sentry-internal/tracing": {
@@ -2509,37 +2509,8 @@
         "setTimeout": true
       },
       "packages": {
-        "@sentry/browser>@sentry-internal/tracing>@sentry/utils": true,
-        "@sentry/browser>@sentry/core": true
-      }
-    },
-    "@sentry/browser>@sentry-internal/tracing>@sentry/utils": {
-      "globals": {
-        "CustomEvent": true,
-        "DOMError": true,
-        "DOMException": true,
-        "EdgeRuntime": true,
-        "Element": true,
-        "ErrorEvent": true,
-        "Event": true,
-        "Headers": true,
-        "Request": true,
-        "Response": true,
-        "TextEncoder": true,
-        "URL": true,
-        "XMLHttpRequest.prototype": true,
-        "__SENTRY_BROWSER_BUNDLE__": true,
-        "__SENTRY_DEBUG__": true,
-        "clearTimeout": true,
-        "console.error": true,
-        "document": true,
-        "new": true,
-        "setInterval": true,
-        "setTimeout": true,
-        "target": true
-      },
-      "packages": {
-        "browserify>process": true
+        "@sentry/browser>@sentry/core": true,
+        "@sentry/utils": true
       }
     },
     "@sentry/browser>@sentry/core": {
@@ -2553,36 +2524,7 @@
         "setTimeout": true
       },
       "packages": {
-        "@sentry/browser>@sentry/core>@sentry/utils": true
-      }
-    },
-    "@sentry/browser>@sentry/core>@sentry/utils": {
-      "globals": {
-        "CustomEvent": true,
-        "DOMError": true,
-        "DOMException": true,
-        "EdgeRuntime": true,
-        "Element": true,
-        "ErrorEvent": true,
-        "Event": true,
-        "Headers": true,
-        "Request": true,
-        "Response": true,
-        "TextEncoder": true,
-        "URL": true,
-        "XMLHttpRequest.prototype": true,
-        "__SENTRY_BROWSER_BUNDLE__": true,
-        "__SENTRY_DEBUG__": true,
-        "clearTimeout": true,
-        "console.error": true,
-        "document": true,
-        "new": true,
-        "setInterval": true,
-        "setTimeout": true,
-        "target": true
-      },
-      "packages": {
-        "browserify>process": true
+        "@sentry/utils": true
       }
     },
     "@sentry/browser>@sentry/replay": {
@@ -2631,65 +2573,7 @@
       "packages": {
         "@sentry/browser>@sentry-internal/tracing": true,
         "@sentry/browser>@sentry/core": true,
-        "@sentry/browser>@sentry/replay>@sentry/utils": true
-      }
-    },
-    "@sentry/browser>@sentry/replay>@sentry/utils": {
-      "globals": {
-        "CustomEvent": true,
-        "DOMError": true,
-        "DOMException": true,
-        "EdgeRuntime": true,
-        "Element": true,
-        "ErrorEvent": true,
-        "Event": true,
-        "Headers": true,
-        "Request": true,
-        "Response": true,
-        "TextEncoder": true,
-        "URL": true,
-        "XMLHttpRequest.prototype": true,
-        "__SENTRY_BROWSER_BUNDLE__": true,
-        "__SENTRY_DEBUG__": true,
-        "clearTimeout": true,
-        "console.error": true,
-        "document": true,
-        "new": true,
-        "setInterval": true,
-        "setTimeout": true,
-        "target": true
-      },
-      "packages": {
-        "browserify>process": true
-      }
-    },
-    "@sentry/browser>@sentry/utils": {
-      "globals": {
-        "CustomEvent": true,
-        "DOMError": true,
-        "DOMException": true,
-        "EdgeRuntime": true,
-        "Element": true,
-        "ErrorEvent": true,
-        "Event": true,
-        "Headers": true,
-        "Request": true,
-        "Response": true,
-        "TextEncoder": true,
-        "URL": true,
-        "XMLHttpRequest.prototype": true,
-        "__SENTRY_BROWSER_BUNDLE__": true,
-        "__SENTRY_DEBUG__": true,
-        "clearTimeout": true,
-        "console.error": true,
-        "document": true,
-        "new": true,
-        "setInterval": true,
-        "setTimeout": true,
-        "target": true
-      },
-      "packages": {
-        "browserify>process": true
+        "@sentry/utils": true
       }
     },
     "@sentry/integrations": {
@@ -2699,11 +2583,11 @@
         "console.log": true
       },
       "packages": {
-        "@sentry/utils": true,
+        "@sentry/integrations>@sentry/utils": true,
         "localforage": true
       }
     },
-    "@sentry/utils": {
+    "@sentry/integrations>@sentry/utils": {
       "globals": {
         "CustomEvent": true,
         "DOMError": true,
@@ -2723,6 +2607,35 @@
         "console.error": true,
         "document": true,
         "new": true,
+        "setTimeout": true,
+        "target": true
+      },
+      "packages": {
+        "browserify>process": true
+      }
+    },
+    "@sentry/utils": {
+      "globals": {
+        "CustomEvent": true,
+        "DOMError": true,
+        "DOMException": true,
+        "EdgeRuntime": true,
+        "Element": true,
+        "ErrorEvent": true,
+        "Event": true,
+        "Headers": true,
+        "Request": true,
+        "Response": true,
+        "TextEncoder": true,
+        "URL": true,
+        "XMLHttpRequest.prototype": true,
+        "__SENTRY_BROWSER_BUNDLE__": true,
+        "__SENTRY_DEBUG__": true,
+        "clearTimeout": true,
+        "console.error": true,
+        "document": true,
+        "new": true,
+        "setInterval": true,
         "setTimeout": true,
         "target": true
       },

--- a/lavamoat/browserify/desktop/policy.json
+++ b/lavamoat/browserify/desktop/policy.json
@@ -2486,12 +2486,28 @@
         "__SENTRY_DEBUG__": true,
         "__SENTRY_RELEASE__": true,
         "indexedDB.open": true,
+        "performance.timeOrigin": true,
         "setTimeout": true
       },
       "packages": {
+        "@sentry/browser>@sentry-internal/feedback": true,
         "@sentry/browser>@sentry-internal/tracing": true,
         "@sentry/browser>@sentry/core": true,
         "@sentry/browser>@sentry/replay": true,
+        "@sentry/utils": true
+      }
+    },
+    "@sentry/browser>@sentry-internal/feedback": {
+      "globals": {
+        "FormData": true,
+        "HTMLFormElement": true,
+        "Node": true,
+        "__SENTRY_DEBUG__": true,
+        "clearTimeout": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "@sentry/browser>@sentry/core": true,
         "@sentry/utils": true
       }
     },
@@ -2503,7 +2519,9 @@
         "__SENTRY_DEBUG__": true,
         "addEventListener": true,
         "performance.getEntriesByType": true,
-        "removeEventListener": true
+        "performance.timeOrigin": true,
+        "removeEventListener": true,
+        "setTimeout": true
       },
       "packages": {
         "@sentry/browser>@sentry/core": true,
@@ -2530,47 +2548,48 @@
         "CSSConditionRule": true,
         "CSSGroupingRule": true,
         "CSSMediaRule": true,
+        "CSSRule": true,
         "CSSSupportsRule": true,
+        "Document": true,
         "DragEvent": true,
         "Element": true,
         "FormData": true,
-        "HTMLCanvasElement": true,
-        "HTMLElement.prototype": true,
+        "HTMLElement": true,
         "HTMLFormElement": true,
-        "HTMLImageElement": true,
-        "HTMLInputElement.prototype": true,
-        "HTMLOptionElement.prototype": true,
-        "HTMLSelectElement.prototype": true,
-        "HTMLTextAreaElement.prototype": true,
         "Headers": true,
-        "ImageData": true,
         "MouseEvent": true,
         "MutationObserver": true,
+        "Node.DOCUMENT_FRAGMENT_NODE": true,
         "Node.prototype.contains": true,
-        "PerformanceObserver": true,
+        "PointerEvent": true,
         "TextEncoder": true,
         "URL": true,
         "URLSearchParams": true,
         "Worker": true,
         "Zone": true,
+        "__RRWEB_EXCLUDE_IFRAME__": true,
+        "__RRWEB_EXCLUDE_SHADOW_DOM__": true,
         "__SENTRY_DEBUG__": true,
+        "__SENTRY_EXCLUDE_REPLAY_WORKER__": true,
         "__rrMutationObserver": true,
+        "addEventListener": true,
         "clearTimeout": true,
         "console.error": true,
         "console.warn": true,
+        "customElements.get": true,
         "document": true,
         "innerHeight": true,
         "innerWidth": true,
         "location.href": true,
-        "pageXOffset": true,
-        "pageYOffset": true,
+        "location.origin": true,
+        "parent": true,
         "requestAnimationFrame": true,
         "setTimeout": true
       },
       "packages": {
+        "@sentry/browser>@sentry-internal/tracing": true,
         "@sentry/browser>@sentry/core": true,
-        "@sentry/utils": true,
-        "browserify>process": true
+        "@sentry/utils": true
       }
     },
     "@sentry/integrations": {
@@ -2580,11 +2599,11 @@
         "console.log": true
       },
       "packages": {
-        "@sentry/utils": true,
+        "@sentry/integrations>@sentry/utils": true,
         "localforage": true
       }
     },
-    "@sentry/utils": {
+    "@sentry/integrations>@sentry/utils": {
       "globals": {
         "CustomEvent": true,
         "DOMError": true,
@@ -2604,6 +2623,35 @@
         "console.error": true,
         "document": true,
         "new": true,
+        "setTimeout": true,
+        "target": true
+      },
+      "packages": {
+        "browserify>process": true
+      }
+    },
+    "@sentry/utils": {
+      "globals": {
+        "CustomEvent": true,
+        "DOMError": true,
+        "DOMException": true,
+        "EdgeRuntime": true,
+        "Element": true,
+        "ErrorEvent": true,
+        "Event": true,
+        "Headers": true,
+        "Request": true,
+        "Response": true,
+        "TextEncoder": true,
+        "URL": true,
+        "XMLHttpRequest.prototype": true,
+        "__SENTRY_BROWSER_BUNDLE__": true,
+        "__SENTRY_DEBUG__": true,
+        "clearTimeout": true,
+        "console.error": true,
+        "document": true,
+        "new": true,
+        "setInterval": true,
         "setTimeout": true,
         "target": true
       },

--- a/lavamoat/browserify/flask/policy.json
+++ b/lavamoat/browserify/flask/policy.json
@@ -2540,7 +2540,6 @@
         "__SENTRY_DEBUG__": true,
         "__SENTRY_RELEASE__": true,
         "indexedDB.open": true,
-        "performance.timeOrigin": true,
         "setTimeout": true
       },
       "packages": {
@@ -2558,9 +2557,7 @@
         "__SENTRY_DEBUG__": true,
         "addEventListener": true,
         "performance.getEntriesByType": true,
-        "performance.timeOrigin": true,
-        "removeEventListener": true,
-        "setTimeout": true
+        "removeEventListener": true
       },
       "packages": {
         "@sentry/browser>@sentry/core": true,
@@ -2587,47 +2584,47 @@
         "CSSConditionRule": true,
         "CSSGroupingRule": true,
         "CSSMediaRule": true,
-        "CSSRule": true,
         "CSSSupportsRule": true,
         "DragEvent": true,
         "Element": true,
         "FormData": true,
-        "HTMLElement": true,
+        "HTMLCanvasElement": true,
+        "HTMLElement.prototype": true,
         "HTMLFormElement": true,
+        "HTMLImageElement": true,
+        "HTMLInputElement.prototype": true,
+        "HTMLOptionElement.prototype": true,
+        "HTMLSelectElement.prototype": true,
+        "HTMLTextAreaElement.prototype": true,
         "Headers": true,
+        "ImageData": true,
         "MouseEvent": true,
         "MutationObserver": true,
-        "Node.DOCUMENT_FRAGMENT_NODE": true,
         "Node.prototype.contains": true,
-        "PointerEvent": true,
+        "PerformanceObserver": true,
         "TextEncoder": true,
         "URL": true,
         "URLSearchParams": true,
         "Worker": true,
         "Zone": true,
-        "__RRWEB_EXCLUDE_IFRAME__": true,
-        "__RRWEB_EXCLUDE_SHADOW_DOM__": true,
         "__SENTRY_DEBUG__": true,
-        "__SENTRY_EXCLUDE_REPLAY_WORKER__": true,
         "__rrMutationObserver": true,
-        "addEventListener": true,
         "clearTimeout": true,
         "console.error": true,
         "console.warn": true,
-        "customElements.get": true,
         "document": true,
         "innerHeight": true,
         "innerWidth": true,
         "location.href": true,
-        "location.origin": true,
-        "parent": true,
+        "pageXOffset": true,
+        "pageYOffset": true,
         "requestAnimationFrame": true,
         "setTimeout": true
       },
       "packages": {
-        "@sentry/browser>@sentry-internal/tracing": true,
         "@sentry/browser>@sentry/core": true,
-        "@sentry/utils": true
+        "@sentry/utils": true,
+        "browserify>process": true
       }
     },
     "@sentry/integrations": {
@@ -2637,35 +2634,8 @@
         "console.log": true
       },
       "packages": {
-        "@sentry/integrations>@sentry/utils": true,
+        "@sentry/utils": true,
         "localforage": true
-      }
-    },
-    "@sentry/integrations>@sentry/utils": {
-      "globals": {
-        "CustomEvent": true,
-        "DOMError": true,
-        "DOMException": true,
-        "Element": true,
-        "ErrorEvent": true,
-        "Event": true,
-        "Headers": true,
-        "Request": true,
-        "Response": true,
-        "TextEncoder": true,
-        "URL": true,
-        "XMLHttpRequest.prototype": true,
-        "__SENTRY_BROWSER_BUNDLE__": true,
-        "__SENTRY_DEBUG__": true,
-        "clearTimeout": true,
-        "console.error": true,
-        "document": true,
-        "new": true,
-        "setTimeout": true,
-        "target": true
-      },
-      "packages": {
-        "browserify>process": true
       }
     },
     "@sentry/utils": {
@@ -2673,7 +2643,6 @@
         "CustomEvent": true,
         "DOMError": true,
         "DOMException": true,
-        "EdgeRuntime": true,
         "Element": true,
         "ErrorEvent": true,
         "Event": true,
@@ -2689,7 +2658,6 @@
         "console.error": true,
         "document": true,
         "new": true,
-        "setInterval": true,
         "setTimeout": true,
         "target": true
       },

--- a/lavamoat/browserify/flask/policy.json
+++ b/lavamoat/browserify/flask/policy.json
@@ -2540,13 +2540,14 @@
         "__SENTRY_DEBUG__": true,
         "__SENTRY_RELEASE__": true,
         "indexedDB.open": true,
+        "performance.timeOrigin": true,
         "setTimeout": true
       },
       "packages": {
         "@sentry/browser>@sentry-internal/tracing": true,
         "@sentry/browser>@sentry/core": true,
         "@sentry/browser>@sentry/replay": true,
-        "@sentry/utils": true
+        "@sentry/browser>@sentry/utils": true
       }
     },
     "@sentry/browser>@sentry-internal/tracing": {
@@ -2557,11 +2558,42 @@
         "__SENTRY_DEBUG__": true,
         "addEventListener": true,
         "performance.getEntriesByType": true,
-        "removeEventListener": true
+        "performance.timeOrigin": true,
+        "removeEventListener": true,
+        "setTimeout": true
       },
       "packages": {
-        "@sentry/browser>@sentry/core": true,
-        "@sentry/utils": true
+        "@sentry/browser>@sentry-internal/tracing>@sentry/utils": true,
+        "@sentry/browser>@sentry/core": true
+      }
+    },
+    "@sentry/browser>@sentry-internal/tracing>@sentry/utils": {
+      "globals": {
+        "CustomEvent": true,
+        "DOMError": true,
+        "DOMException": true,
+        "EdgeRuntime": true,
+        "Element": true,
+        "ErrorEvent": true,
+        "Event": true,
+        "Headers": true,
+        "Request": true,
+        "Response": true,
+        "TextEncoder": true,
+        "URL": true,
+        "XMLHttpRequest.prototype": true,
+        "__SENTRY_BROWSER_BUNDLE__": true,
+        "__SENTRY_DEBUG__": true,
+        "clearTimeout": true,
+        "console.error": true,
+        "document": true,
+        "new": true,
+        "setInterval": true,
+        "setTimeout": true,
+        "target": true
+      },
+      "packages": {
+        "browserify>process": true
       }
     },
     "@sentry/browser>@sentry/core": {
@@ -2575,7 +2607,36 @@
         "setTimeout": true
       },
       "packages": {
-        "@sentry/utils": true
+        "@sentry/browser>@sentry/core>@sentry/utils": true
+      }
+    },
+    "@sentry/browser>@sentry/core>@sentry/utils": {
+      "globals": {
+        "CustomEvent": true,
+        "DOMError": true,
+        "DOMException": true,
+        "EdgeRuntime": true,
+        "Element": true,
+        "ErrorEvent": true,
+        "Event": true,
+        "Headers": true,
+        "Request": true,
+        "Response": true,
+        "TextEncoder": true,
+        "URL": true,
+        "XMLHttpRequest.prototype": true,
+        "__SENTRY_BROWSER_BUNDLE__": true,
+        "__SENTRY_DEBUG__": true,
+        "clearTimeout": true,
+        "console.error": true,
+        "document": true,
+        "new": true,
+        "setInterval": true,
+        "setTimeout": true,
+        "target": true
+      },
+      "packages": {
+        "browserify>process": true
       }
     },
     "@sentry/browser>@sentry/replay": {
@@ -2584,46 +2645,104 @@
         "CSSConditionRule": true,
         "CSSGroupingRule": true,
         "CSSMediaRule": true,
+        "CSSRule": true,
         "CSSSupportsRule": true,
         "DragEvent": true,
         "Element": true,
         "FormData": true,
-        "HTMLCanvasElement": true,
-        "HTMLElement.prototype": true,
+        "HTMLElement": true,
         "HTMLFormElement": true,
-        "HTMLImageElement": true,
-        "HTMLInputElement.prototype": true,
-        "HTMLOptionElement.prototype": true,
-        "HTMLSelectElement.prototype": true,
-        "HTMLTextAreaElement.prototype": true,
         "Headers": true,
-        "ImageData": true,
         "MouseEvent": true,
         "MutationObserver": true,
+        "Node.DOCUMENT_FRAGMENT_NODE": true,
         "Node.prototype.contains": true,
-        "PerformanceObserver": true,
+        "PointerEvent": true,
         "TextEncoder": true,
         "URL": true,
         "URLSearchParams": true,
         "Worker": true,
         "Zone": true,
+        "__RRWEB_EXCLUDE_IFRAME__": true,
+        "__RRWEB_EXCLUDE_SHADOW_DOM__": true,
         "__SENTRY_DEBUG__": true,
+        "__SENTRY_EXCLUDE_REPLAY_WORKER__": true,
         "__rrMutationObserver": true,
+        "addEventListener": true,
         "clearTimeout": true,
         "console.error": true,
         "console.warn": true,
+        "customElements.get": true,
         "document": true,
         "innerHeight": true,
         "innerWidth": true,
         "location.href": true,
-        "pageXOffset": true,
-        "pageYOffset": true,
+        "location.origin": true,
+        "parent": true,
         "requestAnimationFrame": true,
         "setTimeout": true
       },
       "packages": {
+        "@sentry/browser>@sentry-internal/tracing": true,
         "@sentry/browser>@sentry/core": true,
-        "@sentry/utils": true,
+        "@sentry/browser>@sentry/replay>@sentry/utils": true
+      }
+    },
+    "@sentry/browser>@sentry/replay>@sentry/utils": {
+      "globals": {
+        "CustomEvent": true,
+        "DOMError": true,
+        "DOMException": true,
+        "EdgeRuntime": true,
+        "Element": true,
+        "ErrorEvent": true,
+        "Event": true,
+        "Headers": true,
+        "Request": true,
+        "Response": true,
+        "TextEncoder": true,
+        "URL": true,
+        "XMLHttpRequest.prototype": true,
+        "__SENTRY_BROWSER_BUNDLE__": true,
+        "__SENTRY_DEBUG__": true,
+        "clearTimeout": true,
+        "console.error": true,
+        "document": true,
+        "new": true,
+        "setInterval": true,
+        "setTimeout": true,
+        "target": true
+      },
+      "packages": {
+        "browserify>process": true
+      }
+    },
+    "@sentry/browser>@sentry/utils": {
+      "globals": {
+        "CustomEvent": true,
+        "DOMError": true,
+        "DOMException": true,
+        "EdgeRuntime": true,
+        "Element": true,
+        "ErrorEvent": true,
+        "Event": true,
+        "Headers": true,
+        "Request": true,
+        "Response": true,
+        "TextEncoder": true,
+        "URL": true,
+        "XMLHttpRequest.prototype": true,
+        "__SENTRY_BROWSER_BUNDLE__": true,
+        "__SENTRY_DEBUG__": true,
+        "clearTimeout": true,
+        "console.error": true,
+        "document": true,
+        "new": true,
+        "setInterval": true,
+        "setTimeout": true,
+        "target": true
+      },
+      "packages": {
         "browserify>process": true
       }
     },

--- a/lavamoat/browserify/flask/policy.json
+++ b/lavamoat/browserify/flask/policy.json
@@ -2540,12 +2540,28 @@
         "__SENTRY_DEBUG__": true,
         "__SENTRY_RELEASE__": true,
         "indexedDB.open": true,
+        "performance.timeOrigin": true,
         "setTimeout": true
       },
       "packages": {
+        "@sentry/browser>@sentry-internal/feedback": true,
         "@sentry/browser>@sentry-internal/tracing": true,
         "@sentry/browser>@sentry/core": true,
         "@sentry/browser>@sentry/replay": true,
+        "@sentry/utils": true
+      }
+    },
+    "@sentry/browser>@sentry-internal/feedback": {
+      "globals": {
+        "FormData": true,
+        "HTMLFormElement": true,
+        "Node": true,
+        "__SENTRY_DEBUG__": true,
+        "clearTimeout": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "@sentry/browser>@sentry/core": true,
         "@sentry/utils": true
       }
     },
@@ -2557,7 +2573,9 @@
         "__SENTRY_DEBUG__": true,
         "addEventListener": true,
         "performance.getEntriesByType": true,
-        "removeEventListener": true
+        "performance.timeOrigin": true,
+        "removeEventListener": true,
+        "setTimeout": true
       },
       "packages": {
         "@sentry/browser>@sentry/core": true,
@@ -2584,47 +2602,48 @@
         "CSSConditionRule": true,
         "CSSGroupingRule": true,
         "CSSMediaRule": true,
+        "CSSRule": true,
         "CSSSupportsRule": true,
+        "Document": true,
         "DragEvent": true,
         "Element": true,
         "FormData": true,
-        "HTMLCanvasElement": true,
-        "HTMLElement.prototype": true,
+        "HTMLElement": true,
         "HTMLFormElement": true,
-        "HTMLImageElement": true,
-        "HTMLInputElement.prototype": true,
-        "HTMLOptionElement.prototype": true,
-        "HTMLSelectElement.prototype": true,
-        "HTMLTextAreaElement.prototype": true,
         "Headers": true,
-        "ImageData": true,
         "MouseEvent": true,
         "MutationObserver": true,
+        "Node.DOCUMENT_FRAGMENT_NODE": true,
         "Node.prototype.contains": true,
-        "PerformanceObserver": true,
+        "PointerEvent": true,
         "TextEncoder": true,
         "URL": true,
         "URLSearchParams": true,
         "Worker": true,
         "Zone": true,
+        "__RRWEB_EXCLUDE_IFRAME__": true,
+        "__RRWEB_EXCLUDE_SHADOW_DOM__": true,
         "__SENTRY_DEBUG__": true,
+        "__SENTRY_EXCLUDE_REPLAY_WORKER__": true,
         "__rrMutationObserver": true,
+        "addEventListener": true,
         "clearTimeout": true,
         "console.error": true,
         "console.warn": true,
+        "customElements.get": true,
         "document": true,
         "innerHeight": true,
         "innerWidth": true,
         "location.href": true,
-        "pageXOffset": true,
-        "pageYOffset": true,
+        "location.origin": true,
+        "parent": true,
         "requestAnimationFrame": true,
         "setTimeout": true
       },
       "packages": {
+        "@sentry/browser>@sentry-internal/tracing": true,
         "@sentry/browser>@sentry/core": true,
-        "@sentry/utils": true,
-        "browserify>process": true
+        "@sentry/utils": true
       }
     },
     "@sentry/integrations": {
@@ -2634,11 +2653,11 @@
         "console.log": true
       },
       "packages": {
-        "@sentry/utils": true,
+        "@sentry/integrations>@sentry/utils": true,
         "localforage": true
       }
     },
-    "@sentry/utils": {
+    "@sentry/integrations>@sentry/utils": {
       "globals": {
         "CustomEvent": true,
         "DOMError": true,
@@ -2658,6 +2677,35 @@
         "console.error": true,
         "document": true,
         "new": true,
+        "setTimeout": true,
+        "target": true
+      },
+      "packages": {
+        "browserify>process": true
+      }
+    },
+    "@sentry/utils": {
+      "globals": {
+        "CustomEvent": true,
+        "DOMError": true,
+        "DOMException": true,
+        "EdgeRuntime": true,
+        "Element": true,
+        "ErrorEvent": true,
+        "Event": true,
+        "Headers": true,
+        "Request": true,
+        "Response": true,
+        "TextEncoder": true,
+        "URL": true,
+        "XMLHttpRequest.prototype": true,
+        "__SENTRY_BROWSER_BUNDLE__": true,
+        "__SENTRY_DEBUG__": true,
+        "clearTimeout": true,
+        "console.error": true,
+        "document": true,
+        "new": true,
+        "setInterval": true,
         "setTimeout": true,
         "target": true
       },

--- a/lavamoat/browserify/flask/policy.json
+++ b/lavamoat/browserify/flask/policy.json
@@ -2547,7 +2547,7 @@
         "@sentry/browser>@sentry-internal/tracing": true,
         "@sentry/browser>@sentry/core": true,
         "@sentry/browser>@sentry/replay": true,
-        "@sentry/browser>@sentry/utils": true
+        "@sentry/utils": true
       }
     },
     "@sentry/browser>@sentry-internal/tracing": {
@@ -2563,37 +2563,8 @@
         "setTimeout": true
       },
       "packages": {
-        "@sentry/browser>@sentry-internal/tracing>@sentry/utils": true,
-        "@sentry/browser>@sentry/core": true
-      }
-    },
-    "@sentry/browser>@sentry-internal/tracing>@sentry/utils": {
-      "globals": {
-        "CustomEvent": true,
-        "DOMError": true,
-        "DOMException": true,
-        "EdgeRuntime": true,
-        "Element": true,
-        "ErrorEvent": true,
-        "Event": true,
-        "Headers": true,
-        "Request": true,
-        "Response": true,
-        "TextEncoder": true,
-        "URL": true,
-        "XMLHttpRequest.prototype": true,
-        "__SENTRY_BROWSER_BUNDLE__": true,
-        "__SENTRY_DEBUG__": true,
-        "clearTimeout": true,
-        "console.error": true,
-        "document": true,
-        "new": true,
-        "setInterval": true,
-        "setTimeout": true,
-        "target": true
-      },
-      "packages": {
-        "browserify>process": true
+        "@sentry/browser>@sentry/core": true,
+        "@sentry/utils": true
       }
     },
     "@sentry/browser>@sentry/core": {
@@ -2607,36 +2578,7 @@
         "setTimeout": true
       },
       "packages": {
-        "@sentry/browser>@sentry/core>@sentry/utils": true
-      }
-    },
-    "@sentry/browser>@sentry/core>@sentry/utils": {
-      "globals": {
-        "CustomEvent": true,
-        "DOMError": true,
-        "DOMException": true,
-        "EdgeRuntime": true,
-        "Element": true,
-        "ErrorEvent": true,
-        "Event": true,
-        "Headers": true,
-        "Request": true,
-        "Response": true,
-        "TextEncoder": true,
-        "URL": true,
-        "XMLHttpRequest.prototype": true,
-        "__SENTRY_BROWSER_BUNDLE__": true,
-        "__SENTRY_DEBUG__": true,
-        "clearTimeout": true,
-        "console.error": true,
-        "document": true,
-        "new": true,
-        "setInterval": true,
-        "setTimeout": true,
-        "target": true
-      },
-      "packages": {
-        "browserify>process": true
+        "@sentry/utils": true
       }
     },
     "@sentry/browser>@sentry/replay": {
@@ -2685,65 +2627,7 @@
       "packages": {
         "@sentry/browser>@sentry-internal/tracing": true,
         "@sentry/browser>@sentry/core": true,
-        "@sentry/browser>@sentry/replay>@sentry/utils": true
-      }
-    },
-    "@sentry/browser>@sentry/replay>@sentry/utils": {
-      "globals": {
-        "CustomEvent": true,
-        "DOMError": true,
-        "DOMException": true,
-        "EdgeRuntime": true,
-        "Element": true,
-        "ErrorEvent": true,
-        "Event": true,
-        "Headers": true,
-        "Request": true,
-        "Response": true,
-        "TextEncoder": true,
-        "URL": true,
-        "XMLHttpRequest.prototype": true,
-        "__SENTRY_BROWSER_BUNDLE__": true,
-        "__SENTRY_DEBUG__": true,
-        "clearTimeout": true,
-        "console.error": true,
-        "document": true,
-        "new": true,
-        "setInterval": true,
-        "setTimeout": true,
-        "target": true
-      },
-      "packages": {
-        "browserify>process": true
-      }
-    },
-    "@sentry/browser>@sentry/utils": {
-      "globals": {
-        "CustomEvent": true,
-        "DOMError": true,
-        "DOMException": true,
-        "EdgeRuntime": true,
-        "Element": true,
-        "ErrorEvent": true,
-        "Event": true,
-        "Headers": true,
-        "Request": true,
-        "Response": true,
-        "TextEncoder": true,
-        "URL": true,
-        "XMLHttpRequest.prototype": true,
-        "__SENTRY_BROWSER_BUNDLE__": true,
-        "__SENTRY_DEBUG__": true,
-        "clearTimeout": true,
-        "console.error": true,
-        "document": true,
-        "new": true,
-        "setInterval": true,
-        "setTimeout": true,
-        "target": true
-      },
-      "packages": {
-        "browserify>process": true
+        "@sentry/utils": true
       }
     },
     "@sentry/integrations": {
@@ -2753,11 +2637,11 @@
         "console.log": true
       },
       "packages": {
-        "@sentry/utils": true,
+        "@sentry/integrations>@sentry/utils": true,
         "localforage": true
       }
     },
-    "@sentry/utils": {
+    "@sentry/integrations>@sentry/utils": {
       "globals": {
         "CustomEvent": true,
         "DOMError": true,
@@ -2777,6 +2661,35 @@
         "console.error": true,
         "document": true,
         "new": true,
+        "setTimeout": true,
+        "target": true
+      },
+      "packages": {
+        "browserify>process": true
+      }
+    },
+    "@sentry/utils": {
+      "globals": {
+        "CustomEvent": true,
+        "DOMError": true,
+        "DOMException": true,
+        "EdgeRuntime": true,
+        "Element": true,
+        "ErrorEvent": true,
+        "Event": true,
+        "Headers": true,
+        "Request": true,
+        "Response": true,
+        "TextEncoder": true,
+        "URL": true,
+        "XMLHttpRequest.prototype": true,
+        "__SENTRY_BROWSER_BUNDLE__": true,
+        "__SENTRY_DEBUG__": true,
+        "clearTimeout": true,
+        "console.error": true,
+        "document": true,
+        "new": true,
+        "setInterval": true,
         "setTimeout": true,
         "target": true
       },

--- a/lavamoat/browserify/main/policy.json
+++ b/lavamoat/browserify/main/policy.json
@@ -2463,13 +2463,14 @@
         "__SENTRY_DEBUG__": true,
         "__SENTRY_RELEASE__": true,
         "indexedDB.open": true,
+        "performance.timeOrigin": true,
         "setTimeout": true
       },
       "packages": {
         "@sentry/browser>@sentry-internal/tracing": true,
         "@sentry/browser>@sentry/core": true,
         "@sentry/browser>@sentry/replay": true,
-        "@sentry/utils": true
+        "@sentry/browser>@sentry/utils": true
       }
     },
     "@sentry/browser>@sentry-internal/tracing": {
@@ -2480,11 +2481,42 @@
         "__SENTRY_DEBUG__": true,
         "addEventListener": true,
         "performance.getEntriesByType": true,
-        "removeEventListener": true
+        "performance.timeOrigin": true,
+        "removeEventListener": true,
+        "setTimeout": true
       },
       "packages": {
-        "@sentry/browser>@sentry/core": true,
-        "@sentry/utils": true
+        "@sentry/browser>@sentry-internal/tracing>@sentry/utils": true,
+        "@sentry/browser>@sentry/core": true
+      }
+    },
+    "@sentry/browser>@sentry-internal/tracing>@sentry/utils": {
+      "globals": {
+        "CustomEvent": true,
+        "DOMError": true,
+        "DOMException": true,
+        "EdgeRuntime": true,
+        "Element": true,
+        "ErrorEvent": true,
+        "Event": true,
+        "Headers": true,
+        "Request": true,
+        "Response": true,
+        "TextEncoder": true,
+        "URL": true,
+        "XMLHttpRequest.prototype": true,
+        "__SENTRY_BROWSER_BUNDLE__": true,
+        "__SENTRY_DEBUG__": true,
+        "clearTimeout": true,
+        "console.error": true,
+        "document": true,
+        "new": true,
+        "setInterval": true,
+        "setTimeout": true,
+        "target": true
+      },
+      "packages": {
+        "browserify>process": true
       }
     },
     "@sentry/browser>@sentry/core": {
@@ -2498,7 +2530,36 @@
         "setTimeout": true
       },
       "packages": {
-        "@sentry/utils": true
+        "@sentry/browser>@sentry/core>@sentry/utils": true
+      }
+    },
+    "@sentry/browser>@sentry/core>@sentry/utils": {
+      "globals": {
+        "CustomEvent": true,
+        "DOMError": true,
+        "DOMException": true,
+        "EdgeRuntime": true,
+        "Element": true,
+        "ErrorEvent": true,
+        "Event": true,
+        "Headers": true,
+        "Request": true,
+        "Response": true,
+        "TextEncoder": true,
+        "URL": true,
+        "XMLHttpRequest.prototype": true,
+        "__SENTRY_BROWSER_BUNDLE__": true,
+        "__SENTRY_DEBUG__": true,
+        "clearTimeout": true,
+        "console.error": true,
+        "document": true,
+        "new": true,
+        "setInterval": true,
+        "setTimeout": true,
+        "target": true
+      },
+      "packages": {
+        "browserify>process": true
       }
     },
     "@sentry/browser>@sentry/replay": {
@@ -2507,46 +2568,104 @@
         "CSSConditionRule": true,
         "CSSGroupingRule": true,
         "CSSMediaRule": true,
+        "CSSRule": true,
         "CSSSupportsRule": true,
         "DragEvent": true,
         "Element": true,
         "FormData": true,
-        "HTMLCanvasElement": true,
-        "HTMLElement.prototype": true,
+        "HTMLElement": true,
         "HTMLFormElement": true,
-        "HTMLImageElement": true,
-        "HTMLInputElement.prototype": true,
-        "HTMLOptionElement.prototype": true,
-        "HTMLSelectElement.prototype": true,
-        "HTMLTextAreaElement.prototype": true,
         "Headers": true,
-        "ImageData": true,
         "MouseEvent": true,
         "MutationObserver": true,
+        "Node.DOCUMENT_FRAGMENT_NODE": true,
         "Node.prototype.contains": true,
-        "PerformanceObserver": true,
+        "PointerEvent": true,
         "TextEncoder": true,
         "URL": true,
         "URLSearchParams": true,
         "Worker": true,
         "Zone": true,
+        "__RRWEB_EXCLUDE_IFRAME__": true,
+        "__RRWEB_EXCLUDE_SHADOW_DOM__": true,
         "__SENTRY_DEBUG__": true,
+        "__SENTRY_EXCLUDE_REPLAY_WORKER__": true,
         "__rrMutationObserver": true,
+        "addEventListener": true,
         "clearTimeout": true,
         "console.error": true,
         "console.warn": true,
+        "customElements.get": true,
         "document": true,
         "innerHeight": true,
         "innerWidth": true,
         "location.href": true,
-        "pageXOffset": true,
-        "pageYOffset": true,
+        "location.origin": true,
+        "parent": true,
         "requestAnimationFrame": true,
         "setTimeout": true
       },
       "packages": {
+        "@sentry/browser>@sentry-internal/tracing": true,
         "@sentry/browser>@sentry/core": true,
-        "@sentry/utils": true,
+        "@sentry/browser>@sentry/replay>@sentry/utils": true
+      }
+    },
+    "@sentry/browser>@sentry/replay>@sentry/utils": {
+      "globals": {
+        "CustomEvent": true,
+        "DOMError": true,
+        "DOMException": true,
+        "EdgeRuntime": true,
+        "Element": true,
+        "ErrorEvent": true,
+        "Event": true,
+        "Headers": true,
+        "Request": true,
+        "Response": true,
+        "TextEncoder": true,
+        "URL": true,
+        "XMLHttpRequest.prototype": true,
+        "__SENTRY_BROWSER_BUNDLE__": true,
+        "__SENTRY_DEBUG__": true,
+        "clearTimeout": true,
+        "console.error": true,
+        "document": true,
+        "new": true,
+        "setInterval": true,
+        "setTimeout": true,
+        "target": true
+      },
+      "packages": {
+        "browserify>process": true
+      }
+    },
+    "@sentry/browser>@sentry/utils": {
+      "globals": {
+        "CustomEvent": true,
+        "DOMError": true,
+        "DOMException": true,
+        "EdgeRuntime": true,
+        "Element": true,
+        "ErrorEvent": true,
+        "Event": true,
+        "Headers": true,
+        "Request": true,
+        "Response": true,
+        "TextEncoder": true,
+        "URL": true,
+        "XMLHttpRequest.prototype": true,
+        "__SENTRY_BROWSER_BUNDLE__": true,
+        "__SENTRY_DEBUG__": true,
+        "clearTimeout": true,
+        "console.error": true,
+        "document": true,
+        "new": true,
+        "setInterval": true,
+        "setTimeout": true,
+        "target": true
+      },
+      "packages": {
         "browserify>process": true
       }
     },

--- a/lavamoat/browserify/main/policy.json
+++ b/lavamoat/browserify/main/policy.json
@@ -2463,7 +2463,6 @@
         "__SENTRY_DEBUG__": true,
         "__SENTRY_RELEASE__": true,
         "indexedDB.open": true,
-        "performance.timeOrigin": true,
         "setTimeout": true
       },
       "packages": {
@@ -2481,9 +2480,7 @@
         "__SENTRY_DEBUG__": true,
         "addEventListener": true,
         "performance.getEntriesByType": true,
-        "performance.timeOrigin": true,
-        "removeEventListener": true,
-        "setTimeout": true
+        "removeEventListener": true
       },
       "packages": {
         "@sentry/browser>@sentry/core": true,
@@ -2510,47 +2507,47 @@
         "CSSConditionRule": true,
         "CSSGroupingRule": true,
         "CSSMediaRule": true,
-        "CSSRule": true,
         "CSSSupportsRule": true,
         "DragEvent": true,
         "Element": true,
         "FormData": true,
-        "HTMLElement": true,
+        "HTMLCanvasElement": true,
+        "HTMLElement.prototype": true,
         "HTMLFormElement": true,
+        "HTMLImageElement": true,
+        "HTMLInputElement.prototype": true,
+        "HTMLOptionElement.prototype": true,
+        "HTMLSelectElement.prototype": true,
+        "HTMLTextAreaElement.prototype": true,
         "Headers": true,
+        "ImageData": true,
         "MouseEvent": true,
         "MutationObserver": true,
-        "Node.DOCUMENT_FRAGMENT_NODE": true,
         "Node.prototype.contains": true,
-        "PointerEvent": true,
+        "PerformanceObserver": true,
         "TextEncoder": true,
         "URL": true,
         "URLSearchParams": true,
         "Worker": true,
         "Zone": true,
-        "__RRWEB_EXCLUDE_IFRAME__": true,
-        "__RRWEB_EXCLUDE_SHADOW_DOM__": true,
         "__SENTRY_DEBUG__": true,
-        "__SENTRY_EXCLUDE_REPLAY_WORKER__": true,
         "__rrMutationObserver": true,
-        "addEventListener": true,
         "clearTimeout": true,
         "console.error": true,
         "console.warn": true,
-        "customElements.get": true,
         "document": true,
         "innerHeight": true,
         "innerWidth": true,
         "location.href": true,
-        "location.origin": true,
-        "parent": true,
+        "pageXOffset": true,
+        "pageYOffset": true,
         "requestAnimationFrame": true,
         "setTimeout": true
       },
       "packages": {
-        "@sentry/browser>@sentry-internal/tracing": true,
         "@sentry/browser>@sentry/core": true,
-        "@sentry/utils": true
+        "@sentry/utils": true,
+        "browserify>process": true
       }
     },
     "@sentry/integrations": {
@@ -2560,35 +2557,8 @@
         "console.log": true
       },
       "packages": {
-        "@sentry/integrations>@sentry/utils": true,
+        "@sentry/utils": true,
         "localforage": true
-      }
-    },
-    "@sentry/integrations>@sentry/utils": {
-      "globals": {
-        "CustomEvent": true,
-        "DOMError": true,
-        "DOMException": true,
-        "Element": true,
-        "ErrorEvent": true,
-        "Event": true,
-        "Headers": true,
-        "Request": true,
-        "Response": true,
-        "TextEncoder": true,
-        "URL": true,
-        "XMLHttpRequest.prototype": true,
-        "__SENTRY_BROWSER_BUNDLE__": true,
-        "__SENTRY_DEBUG__": true,
-        "clearTimeout": true,
-        "console.error": true,
-        "document": true,
-        "new": true,
-        "setTimeout": true,
-        "target": true
-      },
-      "packages": {
-        "browserify>process": true
       }
     },
     "@sentry/utils": {
@@ -2596,7 +2566,6 @@
         "CustomEvent": true,
         "DOMError": true,
         "DOMException": true,
-        "EdgeRuntime": true,
         "Element": true,
         "ErrorEvent": true,
         "Event": true,
@@ -2612,7 +2581,6 @@
         "console.error": true,
         "document": true,
         "new": true,
-        "setInterval": true,
         "setTimeout": true,
         "target": true
       },

--- a/lavamoat/browserify/main/policy.json
+++ b/lavamoat/browserify/main/policy.json
@@ -2463,12 +2463,28 @@
         "__SENTRY_DEBUG__": true,
         "__SENTRY_RELEASE__": true,
         "indexedDB.open": true,
+        "performance.timeOrigin": true,
         "setTimeout": true
       },
       "packages": {
+        "@sentry/browser>@sentry-internal/feedback": true,
         "@sentry/browser>@sentry-internal/tracing": true,
         "@sentry/browser>@sentry/core": true,
         "@sentry/browser>@sentry/replay": true,
+        "@sentry/utils": true
+      }
+    },
+    "@sentry/browser>@sentry-internal/feedback": {
+      "globals": {
+        "FormData": true,
+        "HTMLFormElement": true,
+        "Node": true,
+        "__SENTRY_DEBUG__": true,
+        "clearTimeout": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "@sentry/browser>@sentry/core": true,
         "@sentry/utils": true
       }
     },
@@ -2480,7 +2496,9 @@
         "__SENTRY_DEBUG__": true,
         "addEventListener": true,
         "performance.getEntriesByType": true,
-        "removeEventListener": true
+        "performance.timeOrigin": true,
+        "removeEventListener": true,
+        "setTimeout": true
       },
       "packages": {
         "@sentry/browser>@sentry/core": true,
@@ -2507,47 +2525,48 @@
         "CSSConditionRule": true,
         "CSSGroupingRule": true,
         "CSSMediaRule": true,
+        "CSSRule": true,
         "CSSSupportsRule": true,
+        "Document": true,
         "DragEvent": true,
         "Element": true,
         "FormData": true,
-        "HTMLCanvasElement": true,
-        "HTMLElement.prototype": true,
+        "HTMLElement": true,
         "HTMLFormElement": true,
-        "HTMLImageElement": true,
-        "HTMLInputElement.prototype": true,
-        "HTMLOptionElement.prototype": true,
-        "HTMLSelectElement.prototype": true,
-        "HTMLTextAreaElement.prototype": true,
         "Headers": true,
-        "ImageData": true,
         "MouseEvent": true,
         "MutationObserver": true,
+        "Node.DOCUMENT_FRAGMENT_NODE": true,
         "Node.prototype.contains": true,
-        "PerformanceObserver": true,
+        "PointerEvent": true,
         "TextEncoder": true,
         "URL": true,
         "URLSearchParams": true,
         "Worker": true,
         "Zone": true,
+        "__RRWEB_EXCLUDE_IFRAME__": true,
+        "__RRWEB_EXCLUDE_SHADOW_DOM__": true,
         "__SENTRY_DEBUG__": true,
+        "__SENTRY_EXCLUDE_REPLAY_WORKER__": true,
         "__rrMutationObserver": true,
+        "addEventListener": true,
         "clearTimeout": true,
         "console.error": true,
         "console.warn": true,
+        "customElements.get": true,
         "document": true,
         "innerHeight": true,
         "innerWidth": true,
         "location.href": true,
-        "pageXOffset": true,
-        "pageYOffset": true,
+        "location.origin": true,
+        "parent": true,
         "requestAnimationFrame": true,
         "setTimeout": true
       },
       "packages": {
+        "@sentry/browser>@sentry-internal/tracing": true,
         "@sentry/browser>@sentry/core": true,
-        "@sentry/utils": true,
-        "browserify>process": true
+        "@sentry/utils": true
       }
     },
     "@sentry/integrations": {
@@ -2557,11 +2576,11 @@
         "console.log": true
       },
       "packages": {
-        "@sentry/utils": true,
+        "@sentry/integrations>@sentry/utils": true,
         "localforage": true
       }
     },
-    "@sentry/utils": {
+    "@sentry/integrations>@sentry/utils": {
       "globals": {
         "CustomEvent": true,
         "DOMError": true,
@@ -2581,6 +2600,35 @@
         "console.error": true,
         "document": true,
         "new": true,
+        "setTimeout": true,
+        "target": true
+      },
+      "packages": {
+        "browserify>process": true
+      }
+    },
+    "@sentry/utils": {
+      "globals": {
+        "CustomEvent": true,
+        "DOMError": true,
+        "DOMException": true,
+        "EdgeRuntime": true,
+        "Element": true,
+        "ErrorEvent": true,
+        "Event": true,
+        "Headers": true,
+        "Request": true,
+        "Response": true,
+        "TextEncoder": true,
+        "URL": true,
+        "XMLHttpRequest.prototype": true,
+        "__SENTRY_BROWSER_BUNDLE__": true,
+        "__SENTRY_DEBUG__": true,
+        "clearTimeout": true,
+        "console.error": true,
+        "document": true,
+        "new": true,
+        "setInterval": true,
         "setTimeout": true,
         "target": true
       },

--- a/lavamoat/browserify/main/policy.json
+++ b/lavamoat/browserify/main/policy.json
@@ -2470,7 +2470,7 @@
         "@sentry/browser>@sentry-internal/tracing": true,
         "@sentry/browser>@sentry/core": true,
         "@sentry/browser>@sentry/replay": true,
-        "@sentry/browser>@sentry/utils": true
+        "@sentry/utils": true
       }
     },
     "@sentry/browser>@sentry-internal/tracing": {
@@ -2486,37 +2486,8 @@
         "setTimeout": true
       },
       "packages": {
-        "@sentry/browser>@sentry-internal/tracing>@sentry/utils": true,
-        "@sentry/browser>@sentry/core": true
-      }
-    },
-    "@sentry/browser>@sentry-internal/tracing>@sentry/utils": {
-      "globals": {
-        "CustomEvent": true,
-        "DOMError": true,
-        "DOMException": true,
-        "EdgeRuntime": true,
-        "Element": true,
-        "ErrorEvent": true,
-        "Event": true,
-        "Headers": true,
-        "Request": true,
-        "Response": true,
-        "TextEncoder": true,
-        "URL": true,
-        "XMLHttpRequest.prototype": true,
-        "__SENTRY_BROWSER_BUNDLE__": true,
-        "__SENTRY_DEBUG__": true,
-        "clearTimeout": true,
-        "console.error": true,
-        "document": true,
-        "new": true,
-        "setInterval": true,
-        "setTimeout": true,
-        "target": true
-      },
-      "packages": {
-        "browserify>process": true
+        "@sentry/browser>@sentry/core": true,
+        "@sentry/utils": true
       }
     },
     "@sentry/browser>@sentry/core": {
@@ -2530,36 +2501,7 @@
         "setTimeout": true
       },
       "packages": {
-        "@sentry/browser>@sentry/core>@sentry/utils": true
-      }
-    },
-    "@sentry/browser>@sentry/core>@sentry/utils": {
-      "globals": {
-        "CustomEvent": true,
-        "DOMError": true,
-        "DOMException": true,
-        "EdgeRuntime": true,
-        "Element": true,
-        "ErrorEvent": true,
-        "Event": true,
-        "Headers": true,
-        "Request": true,
-        "Response": true,
-        "TextEncoder": true,
-        "URL": true,
-        "XMLHttpRequest.prototype": true,
-        "__SENTRY_BROWSER_BUNDLE__": true,
-        "__SENTRY_DEBUG__": true,
-        "clearTimeout": true,
-        "console.error": true,
-        "document": true,
-        "new": true,
-        "setInterval": true,
-        "setTimeout": true,
-        "target": true
-      },
-      "packages": {
-        "browserify>process": true
+        "@sentry/utils": true
       }
     },
     "@sentry/browser>@sentry/replay": {
@@ -2608,65 +2550,7 @@
       "packages": {
         "@sentry/browser>@sentry-internal/tracing": true,
         "@sentry/browser>@sentry/core": true,
-        "@sentry/browser>@sentry/replay>@sentry/utils": true
-      }
-    },
-    "@sentry/browser>@sentry/replay>@sentry/utils": {
-      "globals": {
-        "CustomEvent": true,
-        "DOMError": true,
-        "DOMException": true,
-        "EdgeRuntime": true,
-        "Element": true,
-        "ErrorEvent": true,
-        "Event": true,
-        "Headers": true,
-        "Request": true,
-        "Response": true,
-        "TextEncoder": true,
-        "URL": true,
-        "XMLHttpRequest.prototype": true,
-        "__SENTRY_BROWSER_BUNDLE__": true,
-        "__SENTRY_DEBUG__": true,
-        "clearTimeout": true,
-        "console.error": true,
-        "document": true,
-        "new": true,
-        "setInterval": true,
-        "setTimeout": true,
-        "target": true
-      },
-      "packages": {
-        "browserify>process": true
-      }
-    },
-    "@sentry/browser>@sentry/utils": {
-      "globals": {
-        "CustomEvent": true,
-        "DOMError": true,
-        "DOMException": true,
-        "EdgeRuntime": true,
-        "Element": true,
-        "ErrorEvent": true,
-        "Event": true,
-        "Headers": true,
-        "Request": true,
-        "Response": true,
-        "TextEncoder": true,
-        "URL": true,
-        "XMLHttpRequest.prototype": true,
-        "__SENTRY_BROWSER_BUNDLE__": true,
-        "__SENTRY_DEBUG__": true,
-        "clearTimeout": true,
-        "console.error": true,
-        "document": true,
-        "new": true,
-        "setInterval": true,
-        "setTimeout": true,
-        "target": true
-      },
-      "packages": {
-        "browserify>process": true
+        "@sentry/utils": true
       }
     },
     "@sentry/integrations": {
@@ -2676,11 +2560,11 @@
         "console.log": true
       },
       "packages": {
-        "@sentry/utils": true,
+        "@sentry/integrations>@sentry/utils": true,
         "localforage": true
       }
     },
-    "@sentry/utils": {
+    "@sentry/integrations>@sentry/utils": {
       "globals": {
         "CustomEvent": true,
         "DOMError": true,
@@ -2700,6 +2584,35 @@
         "console.error": true,
         "document": true,
         "new": true,
+        "setTimeout": true,
+        "target": true
+      },
+      "packages": {
+        "browserify>process": true
+      }
+    },
+    "@sentry/utils": {
+      "globals": {
+        "CustomEvent": true,
+        "DOMError": true,
+        "DOMException": true,
+        "EdgeRuntime": true,
+        "Element": true,
+        "ErrorEvent": true,
+        "Event": true,
+        "Headers": true,
+        "Request": true,
+        "Response": true,
+        "TextEncoder": true,
+        "URL": true,
+        "XMLHttpRequest.prototype": true,
+        "__SENTRY_BROWSER_BUNDLE__": true,
+        "__SENTRY_DEBUG__": true,
+        "clearTimeout": true,
+        "console.error": true,
+        "document": true,
+        "new": true,
+        "setInterval": true,
         "setTimeout": true,
         "target": true
       },

--- a/lavamoat/browserify/mmi/policy.json
+++ b/lavamoat/browserify/mmi/policy.json
@@ -2541,12 +2541,28 @@
         "__SENTRY_DEBUG__": true,
         "__SENTRY_RELEASE__": true,
         "indexedDB.open": true,
+        "performance.timeOrigin": true,
         "setTimeout": true
       },
       "packages": {
+        "@sentry/browser>@sentry-internal/feedback": true,
         "@sentry/browser>@sentry-internal/tracing": true,
         "@sentry/browser>@sentry/core": true,
         "@sentry/browser>@sentry/replay": true,
+        "@sentry/utils": true
+      }
+    },
+    "@sentry/browser>@sentry-internal/feedback": {
+      "globals": {
+        "FormData": true,
+        "HTMLFormElement": true,
+        "Node": true,
+        "__SENTRY_DEBUG__": true,
+        "clearTimeout": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "@sentry/browser>@sentry/core": true,
         "@sentry/utils": true
       }
     },
@@ -2558,7 +2574,9 @@
         "__SENTRY_DEBUG__": true,
         "addEventListener": true,
         "performance.getEntriesByType": true,
-        "removeEventListener": true
+        "performance.timeOrigin": true,
+        "removeEventListener": true,
+        "setTimeout": true
       },
       "packages": {
         "@sentry/browser>@sentry/core": true,
@@ -2585,47 +2603,48 @@
         "CSSConditionRule": true,
         "CSSGroupingRule": true,
         "CSSMediaRule": true,
+        "CSSRule": true,
         "CSSSupportsRule": true,
+        "Document": true,
         "DragEvent": true,
         "Element": true,
         "FormData": true,
-        "HTMLCanvasElement": true,
-        "HTMLElement.prototype": true,
+        "HTMLElement": true,
         "HTMLFormElement": true,
-        "HTMLImageElement": true,
-        "HTMLInputElement.prototype": true,
-        "HTMLOptionElement.prototype": true,
-        "HTMLSelectElement.prototype": true,
-        "HTMLTextAreaElement.prototype": true,
         "Headers": true,
-        "ImageData": true,
         "MouseEvent": true,
         "MutationObserver": true,
+        "Node.DOCUMENT_FRAGMENT_NODE": true,
         "Node.prototype.contains": true,
-        "PerformanceObserver": true,
+        "PointerEvent": true,
         "TextEncoder": true,
         "URL": true,
         "URLSearchParams": true,
         "Worker": true,
         "Zone": true,
+        "__RRWEB_EXCLUDE_IFRAME__": true,
+        "__RRWEB_EXCLUDE_SHADOW_DOM__": true,
         "__SENTRY_DEBUG__": true,
+        "__SENTRY_EXCLUDE_REPLAY_WORKER__": true,
         "__rrMutationObserver": true,
+        "addEventListener": true,
         "clearTimeout": true,
         "console.error": true,
         "console.warn": true,
+        "customElements.get": true,
         "document": true,
         "innerHeight": true,
         "innerWidth": true,
         "location.href": true,
-        "pageXOffset": true,
-        "pageYOffset": true,
+        "location.origin": true,
+        "parent": true,
         "requestAnimationFrame": true,
         "setTimeout": true
       },
       "packages": {
+        "@sentry/browser>@sentry-internal/tracing": true,
         "@sentry/browser>@sentry/core": true,
-        "@sentry/utils": true,
-        "browserify>process": true
+        "@sentry/utils": true
       }
     },
     "@sentry/integrations": {
@@ -2635,11 +2654,11 @@
         "console.log": true
       },
       "packages": {
-        "@sentry/utils": true,
+        "@sentry/integrations>@sentry/utils": true,
         "localforage": true
       }
     },
-    "@sentry/utils": {
+    "@sentry/integrations>@sentry/utils": {
       "globals": {
         "CustomEvent": true,
         "DOMError": true,
@@ -2659,6 +2678,35 @@
         "console.error": true,
         "document": true,
         "new": true,
+        "setTimeout": true,
+        "target": true
+      },
+      "packages": {
+        "browserify>process": true
+      }
+    },
+    "@sentry/utils": {
+      "globals": {
+        "CustomEvent": true,
+        "DOMError": true,
+        "DOMException": true,
+        "EdgeRuntime": true,
+        "Element": true,
+        "ErrorEvent": true,
+        "Event": true,
+        "Headers": true,
+        "Request": true,
+        "Response": true,
+        "TextEncoder": true,
+        "URL": true,
+        "XMLHttpRequest.prototype": true,
+        "__SENTRY_BROWSER_BUNDLE__": true,
+        "__SENTRY_DEBUG__": true,
+        "clearTimeout": true,
+        "console.error": true,
+        "document": true,
+        "new": true,
+        "setInterval": true,
         "setTimeout": true,
         "target": true
       },

--- a/lavamoat/browserify/mmi/policy.json
+++ b/lavamoat/browserify/mmi/policy.json
@@ -2541,13 +2541,14 @@
         "__SENTRY_DEBUG__": true,
         "__SENTRY_RELEASE__": true,
         "indexedDB.open": true,
+        "performance.timeOrigin": true,
         "setTimeout": true
       },
       "packages": {
         "@sentry/browser>@sentry-internal/tracing": true,
         "@sentry/browser>@sentry/core": true,
         "@sentry/browser>@sentry/replay": true,
-        "@sentry/utils": true
+        "@sentry/browser>@sentry/utils": true
       }
     },
     "@sentry/browser>@sentry-internal/tracing": {
@@ -2558,11 +2559,42 @@
         "__SENTRY_DEBUG__": true,
         "addEventListener": true,
         "performance.getEntriesByType": true,
-        "removeEventListener": true
+        "performance.timeOrigin": true,
+        "removeEventListener": true,
+        "setTimeout": true
       },
       "packages": {
-        "@sentry/browser>@sentry/core": true,
-        "@sentry/utils": true
+        "@sentry/browser>@sentry-internal/tracing>@sentry/utils": true,
+        "@sentry/browser>@sentry/core": true
+      }
+    },
+    "@sentry/browser>@sentry-internal/tracing>@sentry/utils": {
+      "globals": {
+        "CustomEvent": true,
+        "DOMError": true,
+        "DOMException": true,
+        "EdgeRuntime": true,
+        "Element": true,
+        "ErrorEvent": true,
+        "Event": true,
+        "Headers": true,
+        "Request": true,
+        "Response": true,
+        "TextEncoder": true,
+        "URL": true,
+        "XMLHttpRequest.prototype": true,
+        "__SENTRY_BROWSER_BUNDLE__": true,
+        "__SENTRY_DEBUG__": true,
+        "clearTimeout": true,
+        "console.error": true,
+        "document": true,
+        "new": true,
+        "setInterval": true,
+        "setTimeout": true,
+        "target": true
+      },
+      "packages": {
+        "browserify>process": true
       }
     },
     "@sentry/browser>@sentry/core": {
@@ -2576,7 +2608,36 @@
         "setTimeout": true
       },
       "packages": {
-        "@sentry/utils": true
+        "@sentry/browser>@sentry/core>@sentry/utils": true
+      }
+    },
+    "@sentry/browser>@sentry/core>@sentry/utils": {
+      "globals": {
+        "CustomEvent": true,
+        "DOMError": true,
+        "DOMException": true,
+        "EdgeRuntime": true,
+        "Element": true,
+        "ErrorEvent": true,
+        "Event": true,
+        "Headers": true,
+        "Request": true,
+        "Response": true,
+        "TextEncoder": true,
+        "URL": true,
+        "XMLHttpRequest.prototype": true,
+        "__SENTRY_BROWSER_BUNDLE__": true,
+        "__SENTRY_DEBUG__": true,
+        "clearTimeout": true,
+        "console.error": true,
+        "document": true,
+        "new": true,
+        "setInterval": true,
+        "setTimeout": true,
+        "target": true
+      },
+      "packages": {
+        "browserify>process": true
       }
     },
     "@sentry/browser>@sentry/replay": {
@@ -2585,46 +2646,104 @@
         "CSSConditionRule": true,
         "CSSGroupingRule": true,
         "CSSMediaRule": true,
+        "CSSRule": true,
         "CSSSupportsRule": true,
         "DragEvent": true,
         "Element": true,
         "FormData": true,
-        "HTMLCanvasElement": true,
-        "HTMLElement.prototype": true,
+        "HTMLElement": true,
         "HTMLFormElement": true,
-        "HTMLImageElement": true,
-        "HTMLInputElement.prototype": true,
-        "HTMLOptionElement.prototype": true,
-        "HTMLSelectElement.prototype": true,
-        "HTMLTextAreaElement.prototype": true,
         "Headers": true,
-        "ImageData": true,
         "MouseEvent": true,
         "MutationObserver": true,
+        "Node.DOCUMENT_FRAGMENT_NODE": true,
         "Node.prototype.contains": true,
-        "PerformanceObserver": true,
+        "PointerEvent": true,
         "TextEncoder": true,
         "URL": true,
         "URLSearchParams": true,
         "Worker": true,
         "Zone": true,
+        "__RRWEB_EXCLUDE_IFRAME__": true,
+        "__RRWEB_EXCLUDE_SHADOW_DOM__": true,
         "__SENTRY_DEBUG__": true,
+        "__SENTRY_EXCLUDE_REPLAY_WORKER__": true,
         "__rrMutationObserver": true,
+        "addEventListener": true,
         "clearTimeout": true,
         "console.error": true,
         "console.warn": true,
+        "customElements.get": true,
         "document": true,
         "innerHeight": true,
         "innerWidth": true,
         "location.href": true,
-        "pageXOffset": true,
-        "pageYOffset": true,
+        "location.origin": true,
+        "parent": true,
         "requestAnimationFrame": true,
         "setTimeout": true
       },
       "packages": {
+        "@sentry/browser>@sentry-internal/tracing": true,
         "@sentry/browser>@sentry/core": true,
-        "@sentry/utils": true,
+        "@sentry/browser>@sentry/replay>@sentry/utils": true
+      }
+    },
+    "@sentry/browser>@sentry/replay>@sentry/utils": {
+      "globals": {
+        "CustomEvent": true,
+        "DOMError": true,
+        "DOMException": true,
+        "EdgeRuntime": true,
+        "Element": true,
+        "ErrorEvent": true,
+        "Event": true,
+        "Headers": true,
+        "Request": true,
+        "Response": true,
+        "TextEncoder": true,
+        "URL": true,
+        "XMLHttpRequest.prototype": true,
+        "__SENTRY_BROWSER_BUNDLE__": true,
+        "__SENTRY_DEBUG__": true,
+        "clearTimeout": true,
+        "console.error": true,
+        "document": true,
+        "new": true,
+        "setInterval": true,
+        "setTimeout": true,
+        "target": true
+      },
+      "packages": {
+        "browserify>process": true
+      }
+    },
+    "@sentry/browser>@sentry/utils": {
+      "globals": {
+        "CustomEvent": true,
+        "DOMError": true,
+        "DOMException": true,
+        "EdgeRuntime": true,
+        "Element": true,
+        "ErrorEvent": true,
+        "Event": true,
+        "Headers": true,
+        "Request": true,
+        "Response": true,
+        "TextEncoder": true,
+        "URL": true,
+        "XMLHttpRequest.prototype": true,
+        "__SENTRY_BROWSER_BUNDLE__": true,
+        "__SENTRY_DEBUG__": true,
+        "clearTimeout": true,
+        "console.error": true,
+        "document": true,
+        "new": true,
+        "setInterval": true,
+        "setTimeout": true,
+        "target": true
+      },
+      "packages": {
         "browserify>process": true
       }
     },

--- a/lavamoat/browserify/mmi/policy.json
+++ b/lavamoat/browserify/mmi/policy.json
@@ -2541,7 +2541,6 @@
         "__SENTRY_DEBUG__": true,
         "__SENTRY_RELEASE__": true,
         "indexedDB.open": true,
-        "performance.timeOrigin": true,
         "setTimeout": true
       },
       "packages": {
@@ -2559,9 +2558,7 @@
         "__SENTRY_DEBUG__": true,
         "addEventListener": true,
         "performance.getEntriesByType": true,
-        "performance.timeOrigin": true,
-        "removeEventListener": true,
-        "setTimeout": true
+        "removeEventListener": true
       },
       "packages": {
         "@sentry/browser>@sentry/core": true,
@@ -2588,47 +2585,47 @@
         "CSSConditionRule": true,
         "CSSGroupingRule": true,
         "CSSMediaRule": true,
-        "CSSRule": true,
         "CSSSupportsRule": true,
         "DragEvent": true,
         "Element": true,
         "FormData": true,
-        "HTMLElement": true,
+        "HTMLCanvasElement": true,
+        "HTMLElement.prototype": true,
         "HTMLFormElement": true,
+        "HTMLImageElement": true,
+        "HTMLInputElement.prototype": true,
+        "HTMLOptionElement.prototype": true,
+        "HTMLSelectElement.prototype": true,
+        "HTMLTextAreaElement.prototype": true,
         "Headers": true,
+        "ImageData": true,
         "MouseEvent": true,
         "MutationObserver": true,
-        "Node.DOCUMENT_FRAGMENT_NODE": true,
         "Node.prototype.contains": true,
-        "PointerEvent": true,
+        "PerformanceObserver": true,
         "TextEncoder": true,
         "URL": true,
         "URLSearchParams": true,
         "Worker": true,
         "Zone": true,
-        "__RRWEB_EXCLUDE_IFRAME__": true,
-        "__RRWEB_EXCLUDE_SHADOW_DOM__": true,
         "__SENTRY_DEBUG__": true,
-        "__SENTRY_EXCLUDE_REPLAY_WORKER__": true,
         "__rrMutationObserver": true,
-        "addEventListener": true,
         "clearTimeout": true,
         "console.error": true,
         "console.warn": true,
-        "customElements.get": true,
         "document": true,
         "innerHeight": true,
         "innerWidth": true,
         "location.href": true,
-        "location.origin": true,
-        "parent": true,
+        "pageXOffset": true,
+        "pageYOffset": true,
         "requestAnimationFrame": true,
         "setTimeout": true
       },
       "packages": {
-        "@sentry/browser>@sentry-internal/tracing": true,
         "@sentry/browser>@sentry/core": true,
-        "@sentry/utils": true
+        "@sentry/utils": true,
+        "browserify>process": true
       }
     },
     "@sentry/integrations": {
@@ -2638,35 +2635,8 @@
         "console.log": true
       },
       "packages": {
-        "@sentry/integrations>@sentry/utils": true,
+        "@sentry/utils": true,
         "localforage": true
-      }
-    },
-    "@sentry/integrations>@sentry/utils": {
-      "globals": {
-        "CustomEvent": true,
-        "DOMError": true,
-        "DOMException": true,
-        "Element": true,
-        "ErrorEvent": true,
-        "Event": true,
-        "Headers": true,
-        "Request": true,
-        "Response": true,
-        "TextEncoder": true,
-        "URL": true,
-        "XMLHttpRequest.prototype": true,
-        "__SENTRY_BROWSER_BUNDLE__": true,
-        "__SENTRY_DEBUG__": true,
-        "clearTimeout": true,
-        "console.error": true,
-        "document": true,
-        "new": true,
-        "setTimeout": true,
-        "target": true
-      },
-      "packages": {
-        "browserify>process": true
       }
     },
     "@sentry/utils": {
@@ -2674,7 +2644,6 @@
         "CustomEvent": true,
         "DOMError": true,
         "DOMException": true,
-        "EdgeRuntime": true,
         "Element": true,
         "ErrorEvent": true,
         "Event": true,
@@ -2690,7 +2659,6 @@
         "console.error": true,
         "document": true,
         "new": true,
-        "setInterval": true,
         "setTimeout": true,
         "target": true
       },

--- a/lavamoat/browserify/mmi/policy.json
+++ b/lavamoat/browserify/mmi/policy.json
@@ -2548,7 +2548,7 @@
         "@sentry/browser>@sentry-internal/tracing": true,
         "@sentry/browser>@sentry/core": true,
         "@sentry/browser>@sentry/replay": true,
-        "@sentry/browser>@sentry/utils": true
+        "@sentry/utils": true
       }
     },
     "@sentry/browser>@sentry-internal/tracing": {
@@ -2564,37 +2564,8 @@
         "setTimeout": true
       },
       "packages": {
-        "@sentry/browser>@sentry-internal/tracing>@sentry/utils": true,
-        "@sentry/browser>@sentry/core": true
-      }
-    },
-    "@sentry/browser>@sentry-internal/tracing>@sentry/utils": {
-      "globals": {
-        "CustomEvent": true,
-        "DOMError": true,
-        "DOMException": true,
-        "EdgeRuntime": true,
-        "Element": true,
-        "ErrorEvent": true,
-        "Event": true,
-        "Headers": true,
-        "Request": true,
-        "Response": true,
-        "TextEncoder": true,
-        "URL": true,
-        "XMLHttpRequest.prototype": true,
-        "__SENTRY_BROWSER_BUNDLE__": true,
-        "__SENTRY_DEBUG__": true,
-        "clearTimeout": true,
-        "console.error": true,
-        "document": true,
-        "new": true,
-        "setInterval": true,
-        "setTimeout": true,
-        "target": true
-      },
-      "packages": {
-        "browserify>process": true
+        "@sentry/browser>@sentry/core": true,
+        "@sentry/utils": true
       }
     },
     "@sentry/browser>@sentry/core": {
@@ -2608,36 +2579,7 @@
         "setTimeout": true
       },
       "packages": {
-        "@sentry/browser>@sentry/core>@sentry/utils": true
-      }
-    },
-    "@sentry/browser>@sentry/core>@sentry/utils": {
-      "globals": {
-        "CustomEvent": true,
-        "DOMError": true,
-        "DOMException": true,
-        "EdgeRuntime": true,
-        "Element": true,
-        "ErrorEvent": true,
-        "Event": true,
-        "Headers": true,
-        "Request": true,
-        "Response": true,
-        "TextEncoder": true,
-        "URL": true,
-        "XMLHttpRequest.prototype": true,
-        "__SENTRY_BROWSER_BUNDLE__": true,
-        "__SENTRY_DEBUG__": true,
-        "clearTimeout": true,
-        "console.error": true,
-        "document": true,
-        "new": true,
-        "setInterval": true,
-        "setTimeout": true,
-        "target": true
-      },
-      "packages": {
-        "browserify>process": true
+        "@sentry/utils": true
       }
     },
     "@sentry/browser>@sentry/replay": {
@@ -2686,65 +2628,7 @@
       "packages": {
         "@sentry/browser>@sentry-internal/tracing": true,
         "@sentry/browser>@sentry/core": true,
-        "@sentry/browser>@sentry/replay>@sentry/utils": true
-      }
-    },
-    "@sentry/browser>@sentry/replay>@sentry/utils": {
-      "globals": {
-        "CustomEvent": true,
-        "DOMError": true,
-        "DOMException": true,
-        "EdgeRuntime": true,
-        "Element": true,
-        "ErrorEvent": true,
-        "Event": true,
-        "Headers": true,
-        "Request": true,
-        "Response": true,
-        "TextEncoder": true,
-        "URL": true,
-        "XMLHttpRequest.prototype": true,
-        "__SENTRY_BROWSER_BUNDLE__": true,
-        "__SENTRY_DEBUG__": true,
-        "clearTimeout": true,
-        "console.error": true,
-        "document": true,
-        "new": true,
-        "setInterval": true,
-        "setTimeout": true,
-        "target": true
-      },
-      "packages": {
-        "browserify>process": true
-      }
-    },
-    "@sentry/browser>@sentry/utils": {
-      "globals": {
-        "CustomEvent": true,
-        "DOMError": true,
-        "DOMException": true,
-        "EdgeRuntime": true,
-        "Element": true,
-        "ErrorEvent": true,
-        "Event": true,
-        "Headers": true,
-        "Request": true,
-        "Response": true,
-        "TextEncoder": true,
-        "URL": true,
-        "XMLHttpRequest.prototype": true,
-        "__SENTRY_BROWSER_BUNDLE__": true,
-        "__SENTRY_DEBUG__": true,
-        "clearTimeout": true,
-        "console.error": true,
-        "document": true,
-        "new": true,
-        "setInterval": true,
-        "setTimeout": true,
-        "target": true
-      },
-      "packages": {
-        "browserify>process": true
+        "@sentry/utils": true
       }
     },
     "@sentry/integrations": {
@@ -2754,11 +2638,11 @@
         "console.log": true
       },
       "packages": {
-        "@sentry/utils": true,
+        "@sentry/integrations>@sentry/utils": true,
         "localforage": true
       }
     },
-    "@sentry/utils": {
+    "@sentry/integrations>@sentry/utils": {
       "globals": {
         "CustomEvent": true,
         "DOMError": true,
@@ -2778,6 +2662,35 @@
         "console.error": true,
         "document": true,
         "new": true,
+        "setTimeout": true,
+        "target": true
+      },
+      "packages": {
+        "browserify>process": true
+      }
+    },
+    "@sentry/utils": {
+      "globals": {
+        "CustomEvent": true,
+        "DOMError": true,
+        "DOMException": true,
+        "EdgeRuntime": true,
+        "Element": true,
+        "ErrorEvent": true,
+        "Event": true,
+        "Headers": true,
+        "Request": true,
+        "Response": true,
+        "TextEncoder": true,
+        "URL": true,
+        "XMLHttpRequest.prototype": true,
+        "__SENTRY_BROWSER_BUNDLE__": true,
+        "__SENTRY_DEBUG__": true,
+        "clearTimeout": true,
+        "console.error": true,
+        "document": true,
+        "new": true,
+        "setInterval": true,
         "setTimeout": true,
         "target": true
       },

--- a/lavamoat/build-system/policy.json
+++ b/lavamoat/build-system/policy.json
@@ -1086,16 +1086,6 @@
         "react>object-assign": true
       }
     },
-    "@lavamoat/allow-scripts>@npmcli/run-script>node-gyp>npmlog>gauge>has-unicode": {
-      "builtin": {
-        "os.type": true
-      },
-      "globals": {
-        "process.env.LANG": true,
-        "process.env.LC_ALL": true,
-        "process.env.LC_CTYPE": true
-      }
-    },
     "@lavamoat/allow-scripts>@npmcli/run-script>node-gyp>npmlog>gauge>string-width": {
       "packages": {
         "@lavamoat/allow-scripts>@npmcli/run-script>node-gyp>npmlog>gauge>string-width>is-fullwidth-code-point": true,
@@ -1111,11 +1101,6 @@
     "@lavamoat/allow-scripts>@npmcli/run-script>node-gyp>npmlog>gauge>strip-ansi": {
       "packages": {
         "@lavamoat/allow-scripts>@npmcli/run-script>node-gyp>npmlog>gauge>strip-ansi>ansi-regex": true
-      }
-    },
-    "@lavamoat/allow-scripts>@npmcli/run-script>node-gyp>npmlog>gauge>wide-align": {
-      "packages": {
-        "yargs>string-width": true
       }
     },
     "@lavamoat/lavapack": {
@@ -4983,7 +4968,6 @@
         "@lavamoat/allow-scripts>@npmcli/run-script>node-gyp>npmlog": true,
         "gulp-watch>chokidar>fsevents>node-pre-gyp>detect-libc": true,
         "gulp-watch>chokidar>fsevents>node-pre-gyp>nopt": true,
-        "gulp-watch>chokidar>fsevents>node-pre-gyp>npmlog": true,
         "gulp-watch>chokidar>fsevents>node-pre-gyp>rimraf": true,
         "gulp-watch>chokidar>fsevents>node-pre-gyp>semver": true
       }
@@ -5041,18 +5025,7 @@
       },
       "packages": {
         "@storybook/core>@storybook/core-server>x-default-browser>default-browser-id>untildify>os-homedir": true,
-        "gulp-watch>chokidar>fsevents>node-pre-gyp>nopt>osenv>os-homedir": true,
         "gulp-watch>chokidar>fsevents>node-pre-gyp>nopt>osenv>os-tmpdir": true
-      }
-    },
-    "gulp-watch>chokidar>fsevents>node-pre-gyp>nopt>osenv>os-homedir": {
-      "builtin": {
-        "os.homedir": true
-      },
-      "globals": {
-        "process.env": true,
-        "process.getuid": true,
-        "process.platform": true
       }
     },
     "gulp-watch>chokidar>fsevents>node-pre-gyp>nopt>osenv>os-tmpdir": {
@@ -5063,70 +5036,6 @@
         "process.env.TMPDIR": true,
         "process.env.windir": true,
         "process.platform": true
-      }
-    },
-    "gulp-watch>chokidar>fsevents>node-pre-gyp>npmlog": {
-      "builtin": {
-        "events.EventEmitter": true,
-        "util": true
-      },
-      "globals": {
-        "process.nextTick": true,
-        "process.stderr": true
-      },
-      "packages": {
-        "@lavamoat/allow-scripts>@npmcli/run-script>node-gyp>npmlog>console-control-strings": true,
-        "gulp-watch>chokidar>fsevents>node-pre-gyp>npmlog>are-we-there-yet": true,
-        "gulp-watch>chokidar>fsevents>node-pre-gyp>npmlog>gauge": true,
-        "nyc>yargs>set-blocking": true
-      }
-    },
-    "gulp-watch>chokidar>fsevents>node-pre-gyp>npmlog>are-we-there-yet": {
-      "builtin": {
-        "events.EventEmitter": true,
-        "util.inherits": true
-      },
-      "packages": {
-        "koa>delegates": true,
-        "readable-stream": true
-      }
-    },
-    "gulp-watch>chokidar>fsevents>node-pre-gyp>npmlog>gauge": {
-      "builtin": {
-        "util.format": true
-      },
-      "globals": {
-        "clearInterval": true,
-        "process": true,
-        "setImmediate": true,
-        "setInterval": true
-      },
-      "packages": {
-        "@lavamoat/allow-scripts>@npmcli/run-script>node-gyp>npmlog>console-control-strings": true,
-        "@lavamoat/allow-scripts>@npmcli/run-script>node-gyp>npmlog>gauge>has-unicode": true,
-        "@lavamoat/allow-scripts>@npmcli/run-script>node-gyp>npmlog>gauge>wide-align": true,
-        "gulp-watch>chokidar>fsevents>node-pre-gyp>npmlog>gauge>aproba": true,
-        "gulp-watch>chokidar>fsevents>node-pre-gyp>npmlog>gauge>string-width": true,
-        "gulp-watch>chokidar>fsevents>node-pre-gyp>npmlog>gauge>strip-ansi": true,
-        "nyc>signal-exit": true,
-        "react>object-assign": true
-      }
-    },
-    "gulp-watch>chokidar>fsevents>node-pre-gyp>npmlog>gauge>string-width": {
-      "packages": {
-        "gulp-watch>chokidar>fsevents>node-pre-gyp>npmlog>gauge>string-width>is-fullwidth-code-point": true,
-        "gulp-watch>chokidar>fsevents>node-pre-gyp>npmlog>gauge>strip-ansi": true,
-        "gulp>gulp-cli>yargs>string-width>code-point-at": true
-      }
-    },
-    "gulp-watch>chokidar>fsevents>node-pre-gyp>npmlog>gauge>string-width>is-fullwidth-code-point": {
-      "packages": {
-        "gulp>gulp-cli>yargs>string-width>is-fullwidth-code-point>number-is-nan": true
-      }
-    },
-    "gulp-watch>chokidar>fsevents>node-pre-gyp>npmlog>gauge>strip-ansi": {
-      "packages": {
-        "gulp-watch>chokidar>fsevents>node-pre-gyp>npmlog>gauge>strip-ansi>ansi-regex": true
       }
     },
     "gulp-watch>chokidar>fsevents>node-pre-gyp>rimraf": {
@@ -6533,13 +6442,6 @@
       },
       "packages": {
         "chalk>supports-color>has-flag": true
-      }
-    },
-    "mockttp>portfinder>mkdirp": {
-      "builtin": {
-        "fs": true,
-        "path.dirname": true,
-        "path.resolve": true
       }
     },
     "nock>debug": {
@@ -8161,7 +8063,14 @@
         "path.dirname": true
       },
       "packages": {
-        "mockttp>portfinder>mkdirp": true
+        "stylelint>file-entry-cache>flat-cache>write>mkdirp": true
+      }
+    },
+    "stylelint>file-entry-cache>flat-cache>write>mkdirp": {
+      "builtin": {
+        "fs": true,
+        "path.dirname": true,
+        "path.resolve": true
       }
     },
     "stylelint>global-modules": {

--- a/lavamoat/build-system/policy.json
+++ b/lavamoat/build-system/policy.json
@@ -1086,6 +1086,16 @@
         "react>object-assign": true
       }
     },
+    "@lavamoat/allow-scripts>@npmcli/run-script>node-gyp>npmlog>gauge>has-unicode": {
+      "builtin": {
+        "os.type": true
+      },
+      "globals": {
+        "process.env.LANG": true,
+        "process.env.LC_ALL": true,
+        "process.env.LC_CTYPE": true
+      }
+    },
     "@lavamoat/allow-scripts>@npmcli/run-script>node-gyp>npmlog>gauge>string-width": {
       "packages": {
         "@lavamoat/allow-scripts>@npmcli/run-script>node-gyp>npmlog>gauge>string-width>is-fullwidth-code-point": true,
@@ -1101,6 +1111,11 @@
     "@lavamoat/allow-scripts>@npmcli/run-script>node-gyp>npmlog>gauge>strip-ansi": {
       "packages": {
         "@lavamoat/allow-scripts>@npmcli/run-script>node-gyp>npmlog>gauge>strip-ansi>ansi-regex": true
+      }
+    },
+    "@lavamoat/allow-scripts>@npmcli/run-script>node-gyp>npmlog>gauge>wide-align": {
+      "packages": {
+        "yargs>string-width": true
       }
     },
     "@lavamoat/lavapack": {
@@ -4968,6 +4983,7 @@
         "@lavamoat/allow-scripts>@npmcli/run-script>node-gyp>npmlog": true,
         "gulp-watch>chokidar>fsevents>node-pre-gyp>detect-libc": true,
         "gulp-watch>chokidar>fsevents>node-pre-gyp>nopt": true,
+        "gulp-watch>chokidar>fsevents>node-pre-gyp>npmlog": true,
         "gulp-watch>chokidar>fsevents>node-pre-gyp>rimraf": true,
         "gulp-watch>chokidar>fsevents>node-pre-gyp>semver": true
       }
@@ -5025,7 +5041,18 @@
       },
       "packages": {
         "@storybook/core>@storybook/core-server>x-default-browser>default-browser-id>untildify>os-homedir": true,
+        "gulp-watch>chokidar>fsevents>node-pre-gyp>nopt>osenv>os-homedir": true,
         "gulp-watch>chokidar>fsevents>node-pre-gyp>nopt>osenv>os-tmpdir": true
+      }
+    },
+    "gulp-watch>chokidar>fsevents>node-pre-gyp>nopt>osenv>os-homedir": {
+      "builtin": {
+        "os.homedir": true
+      },
+      "globals": {
+        "process.env": true,
+        "process.getuid": true,
+        "process.platform": true
       }
     },
     "gulp-watch>chokidar>fsevents>node-pre-gyp>nopt>osenv>os-tmpdir": {
@@ -5036,6 +5063,70 @@
         "process.env.TMPDIR": true,
         "process.env.windir": true,
         "process.platform": true
+      }
+    },
+    "gulp-watch>chokidar>fsevents>node-pre-gyp>npmlog": {
+      "builtin": {
+        "events.EventEmitter": true,
+        "util": true
+      },
+      "globals": {
+        "process.nextTick": true,
+        "process.stderr": true
+      },
+      "packages": {
+        "@lavamoat/allow-scripts>@npmcli/run-script>node-gyp>npmlog>console-control-strings": true,
+        "gulp-watch>chokidar>fsevents>node-pre-gyp>npmlog>are-we-there-yet": true,
+        "gulp-watch>chokidar>fsevents>node-pre-gyp>npmlog>gauge": true,
+        "nyc>yargs>set-blocking": true
+      }
+    },
+    "gulp-watch>chokidar>fsevents>node-pre-gyp>npmlog>are-we-there-yet": {
+      "builtin": {
+        "events.EventEmitter": true,
+        "util.inherits": true
+      },
+      "packages": {
+        "koa>delegates": true,
+        "readable-stream": true
+      }
+    },
+    "gulp-watch>chokidar>fsevents>node-pre-gyp>npmlog>gauge": {
+      "builtin": {
+        "util.format": true
+      },
+      "globals": {
+        "clearInterval": true,
+        "process": true,
+        "setImmediate": true,
+        "setInterval": true
+      },
+      "packages": {
+        "@lavamoat/allow-scripts>@npmcli/run-script>node-gyp>npmlog>console-control-strings": true,
+        "@lavamoat/allow-scripts>@npmcli/run-script>node-gyp>npmlog>gauge>has-unicode": true,
+        "@lavamoat/allow-scripts>@npmcli/run-script>node-gyp>npmlog>gauge>wide-align": true,
+        "gulp-watch>chokidar>fsevents>node-pre-gyp>npmlog>gauge>aproba": true,
+        "gulp-watch>chokidar>fsevents>node-pre-gyp>npmlog>gauge>string-width": true,
+        "gulp-watch>chokidar>fsevents>node-pre-gyp>npmlog>gauge>strip-ansi": true,
+        "nyc>signal-exit": true,
+        "react>object-assign": true
+      }
+    },
+    "gulp-watch>chokidar>fsevents>node-pre-gyp>npmlog>gauge>string-width": {
+      "packages": {
+        "gulp-watch>chokidar>fsevents>node-pre-gyp>npmlog>gauge>string-width>is-fullwidth-code-point": true,
+        "gulp-watch>chokidar>fsevents>node-pre-gyp>npmlog>gauge>strip-ansi": true,
+        "gulp>gulp-cli>yargs>string-width>code-point-at": true
+      }
+    },
+    "gulp-watch>chokidar>fsevents>node-pre-gyp>npmlog>gauge>string-width>is-fullwidth-code-point": {
+      "packages": {
+        "gulp>gulp-cli>yargs>string-width>is-fullwidth-code-point>number-is-nan": true
+      }
+    },
+    "gulp-watch>chokidar>fsevents>node-pre-gyp>npmlog>gauge>strip-ansi": {
+      "packages": {
+        "gulp-watch>chokidar>fsevents>node-pre-gyp>npmlog>gauge>strip-ansi>ansi-regex": true
       }
     },
     "gulp-watch>chokidar>fsevents>node-pre-gyp>rimraf": {
@@ -6442,6 +6533,13 @@
       },
       "packages": {
         "chalk>supports-color>has-flag": true
+      }
+    },
+    "mockttp>portfinder>mkdirp": {
+      "builtin": {
+        "fs": true,
+        "path.dirname": true,
+        "path.resolve": true
       }
     },
     "nock>debug": {
@@ -8063,14 +8161,7 @@
         "path.dirname": true
       },
       "packages": {
-        "stylelint>file-entry-cache>flat-cache>write>mkdirp": true
-      }
-    },
-    "stylelint>file-entry-cache>flat-cache>write>mkdirp": {
-      "builtin": {
-        "fs": true,
-        "path.dirname": true,
-        "path.resolve": true
+        "mockttp>portfinder>mkdirp": true
       }
     },
     "stylelint>global-modules": {

--- a/package.json
+++ b/package.json
@@ -300,7 +300,7 @@
     "@popperjs/core": "^2.4.0",
     "@reduxjs/toolkit": "^1.6.2",
     "@segment/loosely-validate-event": "^2.0.0",
-    "@sentry/browser": "^7.53.0",
+    "@sentry/browser": "^7.81.1",
     "@sentry/integrations": "^7.53.0",
     "@sentry/types": "^7.53.0",
     "@sentry/utils": "^7.53.0",

--- a/package.json
+++ b/package.json
@@ -300,7 +300,7 @@
     "@popperjs/core": "^2.4.0",
     "@reduxjs/toolkit": "^1.6.2",
     "@segment/loosely-validate-event": "^2.0.0",
-    "@sentry/browser": "^7.81.1",
+    "@sentry/browser": "^7.53.0",
     "@sentry/integrations": "^7.53.0",
     "@sentry/types": "^7.53.0",
     "@sentry/utils": "^7.53.0",

--- a/ui/store/actions.ts
+++ b/ui/store/actions.ts
@@ -2938,12 +2938,6 @@ export function setParticipateInMetaMetrics(
             reject(err);
             return;
           }
-          /**
-           * We need to inform sentry that the user's optin preference may have
-           * changed. The logic to determine which way to toggle is in the
-           * toggleSession handler in setupSentry.js.
-           */
-          window.sentry?.toggleSession();
 
           dispatch({
             type: actionConstants.SET_PARTICIPATE_IN_METAMETRICS,

--- a/yarn.lock
+++ b/yarn.lock
@@ -6312,29 +6312,39 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sentry-internal/tracing@npm:7.53.0":
-  version: 7.53.0
-  resolution: "@sentry-internal/tracing@npm:7.53.0"
+"@sentry-internal/feedback@npm:7.88.0":
+  version: 7.88.0
+  resolution: "@sentry-internal/feedback@npm:7.88.0"
   dependencies:
-    "@sentry/core": "npm:7.53.0"
-    "@sentry/types": "npm:7.53.0"
-    "@sentry/utils": "npm:7.53.0"
-    tslib: "npm:^1.9.3"
-  checksum: 0c449ee967ca568128842649f1eb16e6674c562cbf54436b74f02a2f5ef62ca9d402622a955cdfcfc9b2e158f5d98b21964f6be8164001a2c53b67c1bd00d290
+    "@sentry/core": "npm:7.88.0"
+    "@sentry/types": "npm:7.88.0"
+    "@sentry/utils": "npm:7.88.0"
+  checksum: 487ed6aafef84fb91d97f511d55a96f7a512b790c04dcc90e7fe2a58a9b6b79a4e90692b75e7d9bda07b1b4b90f57d011037ac8162c0e007b4ebb3d2af3f2dd5
   languageName: node
   linkType: hard
 
-"@sentry/browser@npm:^7.53.0":
-  version: 7.53.0
-  resolution: "@sentry/browser@npm:7.53.0"
+"@sentry-internal/tracing@npm:7.88.0":
+  version: 7.88.0
+  resolution: "@sentry-internal/tracing@npm:7.88.0"
   dependencies:
-    "@sentry-internal/tracing": "npm:7.53.0"
-    "@sentry/core": "npm:7.53.0"
-    "@sentry/replay": "npm:7.53.0"
-    "@sentry/types": "npm:7.53.0"
-    "@sentry/utils": "npm:7.53.0"
-    tslib: "npm:^1.9.3"
-  checksum: 4902ddbaab5281e0f1de121bc6120e812cd86ae62139980c62316235f9f685c5f377ccbabdc7160062bb496dc4e7f2e6799fb1a762a89692a177a4457225c55f
+    "@sentry/core": "npm:7.88.0"
+    "@sentry/types": "npm:7.88.0"
+    "@sentry/utils": "npm:7.88.0"
+  checksum: d6c1967778830f01285abb4756e0bffd346b8f8d11daee5d559078a3409c6324111dddbbe7332fc6fd28530cddfb8f378c64e8d6c0f305767b7d265198fd0237
+  languageName: node
+  linkType: hard
+
+"@sentry/browser@npm:^7.81.1":
+  version: 7.88.0
+  resolution: "@sentry/browser@npm:7.88.0"
+  dependencies:
+    "@sentry-internal/feedback": "npm:7.88.0"
+    "@sentry-internal/tracing": "npm:7.88.0"
+    "@sentry/core": "npm:7.88.0"
+    "@sentry/replay": "npm:7.88.0"
+    "@sentry/types": "npm:7.88.0"
+    "@sentry/utils": "npm:7.88.0"
+  checksum: 268c789f9df8a985a5595e53dec4f50a2479d311e4ef70759eab6938f469ad43698a514e91bcab39ff5e2bbc83a31a0466bb2ddbdc174377ee00cabbe39f5650
   languageName: node
   linkType: hard
 
@@ -6353,14 +6363,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sentry/core@npm:7.53.0":
-  version: 7.53.0
-  resolution: "@sentry/core@npm:7.53.0"
+"@sentry/core@npm:7.88.0":
+  version: 7.88.0
+  resolution: "@sentry/core@npm:7.88.0"
   dependencies:
-    "@sentry/types": "npm:7.53.0"
-    "@sentry/utils": "npm:7.53.0"
-    tslib: "npm:^1.9.3"
-  checksum: 3c69eca4c0f4215a041170c7632bf55fc70d01a888dce0de7f9876a6333aa1db93f5ef59147719e01f1a54f74e40f1201fad9570a17cf01349d1b1fc91e0ee0d
+    "@sentry/types": "npm:7.88.0"
+    "@sentry/utils": "npm:7.88.0"
+  checksum: 9dd1ce272b359feb265f1db75a79488dd7e379e6a4c5efb2dca5df7b0e4370c684bc8028b80c2ea584ecc29c22b4264cd6e37b6598578df1300b2270c944ed1d
   languageName: node
   linkType: hard
 
@@ -6376,31 +6385,48 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sentry/replay@npm:7.53.0":
-  version: 7.53.0
-  resolution: "@sentry/replay@npm:7.53.0"
+"@sentry/replay@npm:7.88.0":
+  version: 7.88.0
+  resolution: "@sentry/replay@npm:7.88.0"
   dependencies:
-    "@sentry/core": "npm:7.53.0"
-    "@sentry/types": "npm:7.53.0"
-    "@sentry/utils": "npm:7.53.0"
-  checksum: 8ba1e72ae42eb20ab779554ad39cdcd6e74cc4457250599e7b7d8db411dd2f706d11b9e25bda6116640273529b28e5328498730ae1d3f8c130e1e276933d715d
+    "@sentry-internal/tracing": "npm:7.88.0"
+    "@sentry/core": "npm:7.88.0"
+    "@sentry/types": "npm:7.88.0"
+    "@sentry/utils": "npm:7.88.0"
+  checksum: 1b008e717c1e1021c8c4a9b3d1eeb7181a6e22e86e1291939f268d7bf9ecefc73bd378371b5f2a0fba84f4c983207818b8e1ec7e7e1dae3701af6fd67d4a882e
   languageName: node
   linkType: hard
 
-"@sentry/types@npm:7.53.0, @sentry/types@npm:^7.53.0":
+"@sentry/types@npm:7.53.0":
   version: 7.53.0
   resolution: "@sentry/types@npm:7.53.0"
   checksum: ea05e60594529bd7b59c6ba9cfecb5066a2a20af60194b67772769e4e02d54fd2da2e8124c90b3f0b4fbabd47499e7ccea833efaa819f7643b9d45c50aead5c3
   languageName: node
   linkType: hard
 
-"@sentry/utils@npm:7.53.0, @sentry/utils@npm:^7.53.0":
+"@sentry/types@npm:7.88.0, @sentry/types@npm:^7.53.0":
+  version: 7.88.0
+  resolution: "@sentry/types@npm:7.88.0"
+  checksum: 316a4efcf8bf9a20118d34b5fa6a25df890bd1c41302d0dc8f4f3ca07d3ef7d138e8bfd8e3ad4ec1390eebdac2fd4ece370037d6db094a5fbe5f2a49c26aa1b9
+  languageName: node
+  linkType: hard
+
+"@sentry/utils@npm:7.53.0":
   version: 7.53.0
   resolution: "@sentry/utils@npm:7.53.0"
   dependencies:
     "@sentry/types": "npm:7.53.0"
     tslib: "npm:^1.9.3"
   checksum: 38732598c57db770f307e5869c4d68e95f53715970b3cf0d24e37ced5ef3d43af3560b2efd5a1362891a5340224ce34cf073695986b3a8b1958f4a09b614ee6e
+  languageName: node
+  linkType: hard
+
+"@sentry/utils@npm:7.88.0, @sentry/utils@npm:^7.53.0":
+  version: 7.88.0
+  resolution: "@sentry/utils@npm:7.88.0"
+  dependencies:
+    "@sentry/types": "npm:7.88.0"
+  checksum: 65f41c05da520b8a0bb4df0e727ae5d332f17517b427402ea1176297a70e977a88f90d0e01400279f49d1ad2cd4695580d67a6777f0c1391c477ab04672dc337
   languageName: node
   linkType: hard
 
@@ -24332,7 +24358,7 @@ __metadata:
     "@popperjs/core": "npm:^2.4.0"
     "@reduxjs/toolkit": "npm:^1.6.2"
     "@segment/loosely-validate-event": "npm:^2.0.0"
-    "@sentry/browser": "npm:^7.53.0"
+    "@sentry/browser": "npm:^7.81.1"
     "@sentry/cli": "npm:^2.19.4"
     "@sentry/integrations": "npm:^7.53.0"
     "@sentry/types": "npm:^7.53.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6385,21 +6385,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sentry/types@npm:7.53.0, @sentry/types@npm:^7.53.0":
+"@sentry/types@npm:7.53.0":
   version: 7.53.0
   resolution: "@sentry/types@npm:7.53.0"
   checksum: ea05e60594529bd7b59c6ba9cfecb5066a2a20af60194b67772769e4e02d54fd2da2e8124c90b3f0b4fbabd47499e7ccea833efaa819f7643b9d45c50aead5c3
   languageName: node
   linkType: hard
 
-"@sentry/types@npm:7.83.0":
+"@sentry/types@npm:7.83.0, @sentry/types@npm:^7.53.0":
   version: 7.83.0
   resolution: "@sentry/types@npm:7.83.0"
   checksum: 257b37678c7ea8624d4cdd9a18ccacbdb53a84be90ab6c0f3a6d6d30e8bc021f72a02a09dcf17ba6b1a9f6797580b89b827a3fcd0bc851185e7fc695ae68fbc3
   languageName: node
   linkType: hard
 
-"@sentry/utils@npm:7.53.0, @sentry/utils@npm:^7.53.0":
+"@sentry/utils@npm:7.53.0":
   version: 7.53.0
   resolution: "@sentry/utils@npm:7.53.0"
   dependencies:
@@ -6409,7 +6409,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sentry/utils@npm:7.83.0":
+"@sentry/utils@npm:7.83.0, @sentry/utils@npm:^7.53.0":
   version: 7.83.0
   resolution: "@sentry/utils@npm:7.83.0"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -6312,29 +6312,27 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sentry-internal/tracing@npm:7.53.0":
-  version: 7.53.0
-  resolution: "@sentry-internal/tracing@npm:7.53.0"
+"@sentry-internal/tracing@npm:7.83.0":
+  version: 7.83.0
+  resolution: "@sentry-internal/tracing@npm:7.83.0"
   dependencies:
-    "@sentry/core": "npm:7.53.0"
-    "@sentry/types": "npm:7.53.0"
-    "@sentry/utils": "npm:7.53.0"
-    tslib: "npm:^1.9.3"
-  checksum: 0c449ee967ca568128842649f1eb16e6674c562cbf54436b74f02a2f5ef62ca9d402622a955cdfcfc9b2e158f5d98b21964f6be8164001a2c53b67c1bd00d290
+    "@sentry/core": "npm:7.83.0"
+    "@sentry/types": "npm:7.83.0"
+    "@sentry/utils": "npm:7.83.0"
+  checksum: 7f5d2a2490f15b907c57fbc96ad3fa34a63f585433e0dfefa82400d363004ddff1e5e3b5c40436679b80a8f2afb7cb18f2802d7134ae44f607f0104a352811c3
   languageName: node
   linkType: hard
 
-"@sentry/browser@npm:^7.53.0":
-  version: 7.53.0
-  resolution: "@sentry/browser@npm:7.53.0"
+"@sentry/browser@npm:^7.81.1":
+  version: 7.83.0
+  resolution: "@sentry/browser@npm:7.83.0"
   dependencies:
-    "@sentry-internal/tracing": "npm:7.53.0"
-    "@sentry/core": "npm:7.53.0"
-    "@sentry/replay": "npm:7.53.0"
-    "@sentry/types": "npm:7.53.0"
-    "@sentry/utils": "npm:7.53.0"
-    tslib: "npm:^1.9.3"
-  checksum: 4902ddbaab5281e0f1de121bc6120e812cd86ae62139980c62316235f9f685c5f377ccbabdc7160062bb496dc4e7f2e6799fb1a762a89692a177a4457225c55f
+    "@sentry-internal/tracing": "npm:7.83.0"
+    "@sentry/core": "npm:7.83.0"
+    "@sentry/replay": "npm:7.83.0"
+    "@sentry/types": "npm:7.83.0"
+    "@sentry/utils": "npm:7.83.0"
+  checksum: a4d2181dc36d7946b3af133bf9249be3bb3bd6d3eb34c70352c42445416934a98cb537ed7b827b77277ce60cb902e81aa86b5d94bf8de036aedf1f54d301ba78
   languageName: node
   linkType: hard
 
@@ -6353,14 +6351,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sentry/core@npm:7.53.0":
-  version: 7.53.0
-  resolution: "@sentry/core@npm:7.53.0"
+"@sentry/core@npm:7.83.0":
+  version: 7.83.0
+  resolution: "@sentry/core@npm:7.83.0"
   dependencies:
-    "@sentry/types": "npm:7.53.0"
-    "@sentry/utils": "npm:7.53.0"
-    tslib: "npm:^1.9.3"
-  checksum: 3c69eca4c0f4215a041170c7632bf55fc70d01a888dce0de7f9876a6333aa1db93f5ef59147719e01f1a54f74e40f1201fad9570a17cf01349d1b1fc91e0ee0d
+    "@sentry/types": "npm:7.83.0"
+    "@sentry/utils": "npm:7.83.0"
+  checksum: c75cca15b750180d73975309d44ff3309a369b60f95c1c01f679b868a3eca43ace768d026aa11333c7cc1bc147a947f5f2b507ec72803033e4e3f87ea895cf7b
   languageName: node
   linkType: hard
 
@@ -6376,14 +6373,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sentry/replay@npm:7.53.0":
-  version: 7.53.0
-  resolution: "@sentry/replay@npm:7.53.0"
+"@sentry/replay@npm:7.83.0":
+  version: 7.83.0
+  resolution: "@sentry/replay@npm:7.83.0"
   dependencies:
-    "@sentry/core": "npm:7.53.0"
-    "@sentry/types": "npm:7.53.0"
-    "@sentry/utils": "npm:7.53.0"
-  checksum: 8ba1e72ae42eb20ab779554ad39cdcd6e74cc4457250599e7b7d8db411dd2f706d11b9e25bda6116640273529b28e5328498730ae1d3f8c130e1e276933d715d
+    "@sentry-internal/tracing": "npm:7.83.0"
+    "@sentry/core": "npm:7.83.0"
+    "@sentry/types": "npm:7.83.0"
+    "@sentry/utils": "npm:7.83.0"
+  checksum: 6e2f1960db208c0723537ffcdc8a7370d97ac2df2103d18ecf824c9b69ac83d76ebf29d37833d7a45ef435f480f0553da7148682d8110031074dd7b3c4936ca7
   languageName: node
   linkType: hard
 
@@ -6394,6 +6392,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@sentry/types@npm:7.83.0":
+  version: 7.83.0
+  resolution: "@sentry/types@npm:7.83.0"
+  checksum: 257b37678c7ea8624d4cdd9a18ccacbdb53a84be90ab6c0f3a6d6d30e8bc021f72a02a09dcf17ba6b1a9f6797580b89b827a3fcd0bc851185e7fc695ae68fbc3
+  languageName: node
+  linkType: hard
+
 "@sentry/utils@npm:7.53.0, @sentry/utils@npm:^7.53.0":
   version: 7.53.0
   resolution: "@sentry/utils@npm:7.53.0"
@@ -6401,6 +6406,15 @@ __metadata:
     "@sentry/types": "npm:7.53.0"
     tslib: "npm:^1.9.3"
   checksum: 38732598c57db770f307e5869c4d68e95f53715970b3cf0d24e37ced5ef3d43af3560b2efd5a1362891a5340224ce34cf073695986b3a8b1958f4a09b614ee6e
+  languageName: node
+  linkType: hard
+
+"@sentry/utils@npm:7.83.0":
+  version: 7.83.0
+  resolution: "@sentry/utils@npm:7.83.0"
+  dependencies:
+    "@sentry/types": "npm:7.83.0"
+  checksum: f0e4ef51f32e610ec8a33a43566e6f900e88e5f6c31aaf9a325f1b44a65ec882fa6e46122e23451afb0f2cf8f77bd766cc9684f9e40730c7193814d01d94daa4
   languageName: node
   linkType: hard
 
@@ -24332,7 +24346,7 @@ __metadata:
     "@popperjs/core": "npm:^2.4.0"
     "@reduxjs/toolkit": "npm:^1.6.2"
     "@segment/loosely-validate-event": "npm:^2.0.0"
-    "@sentry/browser": "npm:^7.53.0"
+    "@sentry/browser": "npm:^7.81.1"
     "@sentry/cli": "npm:^2.19.4"
     "@sentry/integrations": "npm:^7.53.0"
     "@sentry/types": "npm:^7.53.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6312,27 +6312,29 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sentry-internal/tracing@npm:7.83.0":
-  version: 7.83.0
-  resolution: "@sentry-internal/tracing@npm:7.83.0"
+"@sentry-internal/tracing@npm:7.53.0":
+  version: 7.53.0
+  resolution: "@sentry-internal/tracing@npm:7.53.0"
   dependencies:
-    "@sentry/core": "npm:7.83.0"
-    "@sentry/types": "npm:7.83.0"
-    "@sentry/utils": "npm:7.83.0"
-  checksum: 7f5d2a2490f15b907c57fbc96ad3fa34a63f585433e0dfefa82400d363004ddff1e5e3b5c40436679b80a8f2afb7cb18f2802d7134ae44f607f0104a352811c3
+    "@sentry/core": "npm:7.53.0"
+    "@sentry/types": "npm:7.53.0"
+    "@sentry/utils": "npm:7.53.0"
+    tslib: "npm:^1.9.3"
+  checksum: 0c449ee967ca568128842649f1eb16e6674c562cbf54436b74f02a2f5ef62ca9d402622a955cdfcfc9b2e158f5d98b21964f6be8164001a2c53b67c1bd00d290
   languageName: node
   linkType: hard
 
-"@sentry/browser@npm:^7.81.1":
-  version: 7.83.0
-  resolution: "@sentry/browser@npm:7.83.0"
+"@sentry/browser@npm:^7.53.0":
+  version: 7.53.0
+  resolution: "@sentry/browser@npm:7.53.0"
   dependencies:
-    "@sentry-internal/tracing": "npm:7.83.0"
-    "@sentry/core": "npm:7.83.0"
-    "@sentry/replay": "npm:7.83.0"
-    "@sentry/types": "npm:7.83.0"
-    "@sentry/utils": "npm:7.83.0"
-  checksum: a4d2181dc36d7946b3af133bf9249be3bb3bd6d3eb34c70352c42445416934a98cb537ed7b827b77277ce60cb902e81aa86b5d94bf8de036aedf1f54d301ba78
+    "@sentry-internal/tracing": "npm:7.53.0"
+    "@sentry/core": "npm:7.53.0"
+    "@sentry/replay": "npm:7.53.0"
+    "@sentry/types": "npm:7.53.0"
+    "@sentry/utils": "npm:7.53.0"
+    tslib: "npm:^1.9.3"
+  checksum: 4902ddbaab5281e0f1de121bc6120e812cd86ae62139980c62316235f9f685c5f377ccbabdc7160062bb496dc4e7f2e6799fb1a762a89692a177a4457225c55f
   languageName: node
   linkType: hard
 
@@ -6351,13 +6353,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sentry/core@npm:7.83.0":
-  version: 7.83.0
-  resolution: "@sentry/core@npm:7.83.0"
+"@sentry/core@npm:7.53.0":
+  version: 7.53.0
+  resolution: "@sentry/core@npm:7.53.0"
   dependencies:
-    "@sentry/types": "npm:7.83.0"
-    "@sentry/utils": "npm:7.83.0"
-  checksum: c75cca15b750180d73975309d44ff3309a369b60f95c1c01f679b868a3eca43ace768d026aa11333c7cc1bc147a947f5f2b507ec72803033e4e3f87ea895cf7b
+    "@sentry/types": "npm:7.53.0"
+    "@sentry/utils": "npm:7.53.0"
+    tslib: "npm:^1.9.3"
+  checksum: 3c69eca4c0f4215a041170c7632bf55fc70d01a888dce0de7f9876a6333aa1db93f5ef59147719e01f1a54f74e40f1201fad9570a17cf01349d1b1fc91e0ee0d
   languageName: node
   linkType: hard
 
@@ -6373,48 +6376,31 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sentry/replay@npm:7.83.0":
-  version: 7.83.0
-  resolution: "@sentry/replay@npm:7.83.0"
+"@sentry/replay@npm:7.53.0":
+  version: 7.53.0
+  resolution: "@sentry/replay@npm:7.53.0"
   dependencies:
-    "@sentry-internal/tracing": "npm:7.83.0"
-    "@sentry/core": "npm:7.83.0"
-    "@sentry/types": "npm:7.83.0"
-    "@sentry/utils": "npm:7.83.0"
-  checksum: 6e2f1960db208c0723537ffcdc8a7370d97ac2df2103d18ecf824c9b69ac83d76ebf29d37833d7a45ef435f480f0553da7148682d8110031074dd7b3c4936ca7
+    "@sentry/core": "npm:7.53.0"
+    "@sentry/types": "npm:7.53.0"
+    "@sentry/utils": "npm:7.53.0"
+  checksum: 8ba1e72ae42eb20ab779554ad39cdcd6e74cc4457250599e7b7d8db411dd2f706d11b9e25bda6116640273529b28e5328498730ae1d3f8c130e1e276933d715d
   languageName: node
   linkType: hard
 
-"@sentry/types@npm:7.53.0":
+"@sentry/types@npm:7.53.0, @sentry/types@npm:^7.53.0":
   version: 7.53.0
   resolution: "@sentry/types@npm:7.53.0"
   checksum: ea05e60594529bd7b59c6ba9cfecb5066a2a20af60194b67772769e4e02d54fd2da2e8124c90b3f0b4fbabd47499e7ccea833efaa819f7643b9d45c50aead5c3
   languageName: node
   linkType: hard
 
-"@sentry/types@npm:7.83.0, @sentry/types@npm:^7.53.0":
-  version: 7.83.0
-  resolution: "@sentry/types@npm:7.83.0"
-  checksum: 257b37678c7ea8624d4cdd9a18ccacbdb53a84be90ab6c0f3a6d6d30e8bc021f72a02a09dcf17ba6b1a9f6797580b89b827a3fcd0bc851185e7fc695ae68fbc3
-  languageName: node
-  linkType: hard
-
-"@sentry/utils@npm:7.53.0":
+"@sentry/utils@npm:7.53.0, @sentry/utils@npm:^7.53.0":
   version: 7.53.0
   resolution: "@sentry/utils@npm:7.53.0"
   dependencies:
     "@sentry/types": "npm:7.53.0"
     tslib: "npm:^1.9.3"
   checksum: 38732598c57db770f307e5869c4d68e95f53715970b3cf0d24e37ced5ef3d43af3560b2efd5a1362891a5340224ce34cf073695986b3a8b1958f4a09b614ee6e
-  languageName: node
-  linkType: hard
-
-"@sentry/utils@npm:7.83.0, @sentry/utils@npm:^7.53.0":
-  version: 7.83.0
-  resolution: "@sentry/utils@npm:7.83.0"
-  dependencies:
-    "@sentry/types": "npm:7.83.0"
-  checksum: f0e4ef51f32e610ec8a33a43566e6f900e88e5f6c31aaf9a325f1b44a65ec882fa6e46122e23451afb0f2cf8f77bd766cc9684f9e40730c7193814d01d94daa4
   languageName: node
   linkType: hard
 
@@ -24346,7 +24332,7 @@ __metadata:
     "@popperjs/core": "npm:^2.4.0"
     "@reduxjs/toolkit": "npm:^1.6.2"
     "@segment/loosely-validate-event": "npm:^2.0.0"
-    "@sentry/browser": "npm:^7.81.1"
+    "@sentry/browser": "npm:^7.53.0"
     "@sentry/cli": "npm:^2.19.4"
     "@sentry/integrations": "npm:^7.53.0"
     "@sentry/types": "npm:^7.53.0"


### PR DESCRIPTION
## **Description**

The session count in our Sentry dashboard has decreased drastically since v11.1.0.

It seems that the only time the session count is incremented is when using `captureException` and `captureMessage` methods. This explains why the session count is much lower than previously but not zero. It also explains a crash rate close to but different than 100% — because `captureMessage` is much less used than captureException on our repository.

### Investigation Notes & Fix

The `toggleSession()` function call inside `setParticipateInMetaMetrics()` in the `ui/store/actions.ts` file is redundant, as both `onboarding/metametrics.js` (for onboarding) and `ui/pages/settings/security-tab/security-tab.component.js` (for the toggling flow) call `setParticipateInMetaMetrics()` on the MetaMetrics controller that starts or stops the session appropriately and updates the state directly. Moreover, by the time `toggleSession()` is called inside `setParticipateInMetaMetrics()` in the `ui/store/actions.ts` file, the `participateInMetaMetrics` property in the MetaMetrics controller state has not yet been updated. After removing that `toggleSession()` function call, we can see that the state is changed on both flows by using `copy(await window.stateHooks.getCleanAppState())`.

We also don’t need to use `getMetaMetricsEnabled()` for `startSession()` and `endSession()` anymore because `setParticipateInMetaMetrics()` is explicitly called with an argument that dictates whether to call the start session or end session methods. As such, I removed `getMetaMetricsEnabled` from the conditions on `startSession` and `endSession`.

Using `Hub.captureSession` and `Hub.captureSession(true)` on start and end session respectively yields the right behaviour for the `https://sentry.io/api/<project_id>/envelope/?sentry_key=<project secret>` requests. When starting a session the request payload includes `"init": true` and when ending a session, the request payload includes `"init": false` and a `"duration"` property.

Finally, the sessions are still not captured on the sentry dashboard, unless the `@sentry/browser` package is updated. This may be because we used the newer version for testing with [`sentry-example`](https://github.com/MetaMask/sentry-example/), and two different package versions on the same project may confuse the dashboard internals. Upgrading the package to the latest version fixes this.

### Summary of changes:
- Remove redundant `toggleSession()` function call from `setParticipateInMetaMetrics` in `ui/store/actions.ts`.
- Remove `toggleSession()` function definition from `app/scripts/lib/setupSentry.js` because it’s not used anymore.
- Remove usage of `getMetaMetricsEnabled()` inside `startSession()` and `endSession()` in `app/scripts/lib/setupSentry.js` because repeated calls for both methods are not possible.
- Update sentry browser package version from ^7.53.0 to ^7.81.1 so the sessions are logged on the sentry dashboard.


## **Manual testing steps**

1. Create a new project on sentry as per the [documentation](https://github.com/MetaMask/metamask-extension/blob/1195f7c2fa7ee7b43db2fa62dcb85e26300bbbb0/README.md?plain=1#L24)
2. Remove the extension completely
3. Build the extension using `yarn dist`
4. Install the extension from the `dist` folder
5. Open the dev tools on the network tab for the UI and background processes.
6. Onboard opting into MetaMetrics
7. See the Sentry request with type “session” and “init” true.
8. You should now see the sessions on Releases > Adoption.

7. Reload the Extension on the Extension tab
9. Repeat Steps 5-8

10. Reload the Extension UI in the browser
11. Repeat Steps 5-8

12. When opting in and out of metametrics, Sentry session requests should be visible as well.

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've clearly explained what problem this PR is solving and how it is solved.
- [ ] I've linked related issues
- [ ] I've included manual testing steps
- [ ] I've included screenshots/recordings if applicable
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [ ] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
