### PR TITLE
fix(ci): Fix bot update LavaMoat policy command

### DIFF
--- a/.github/workflows/update-lavamoat-policies.yml
+++ b/.github/workflows/update-lavamoat-policies.yml
@@ -107,6 +107,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - prepare
+      - update-lavamoat-build-policy
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -122,6 +123,12 @@ jobs:
           cache: 'yarn'
       - name: Install dependencies from cache
         run: yarn --immutable --immutable-cache
+      - name: Restore build policy
+        uses: actions/cache/restore@v3
+        with:
+          path: lavamoat/build-system
+          key: cache-build-${{ needs.prepare.outputs.COMMIT_SHA }}
+          fail-on-cache-miss: true
       - name: Update LavaMoat ${{ matrix.build-type }} policy
         run: yarn lavamoat:webapp:auto:ci '--build-types=${{ matrix.build-type }}'
         env:


### PR DESCRIPTION
## **Description**

The `@metamaskbot update-policies` command now updates the build policy prior to attempting to update the webapp policies. This ensures that the command works even in situations when a build policy error is causing the build to fail. Previously the webapp policies would fail to update in that situation, because updating the webapp policy involves running the build script successfully.

## **Related issues**

Fixes #22053

## **Manual testing steps**

The problem can be demonstrated with this PR: https://github.com/MetaMask/metamask-extension/pull/22056

This can't easily be tested because this command is only run from the main branch. We could test it from a fork, that would take some time to setup, and it might not be worth it in this case. The consequences of failure here are quite low, this is just a convenience script. We could make an exception here and test it live.

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained what problem this PR is solving and how it is solved.
- [x] I've linked related issues
- [x] I've included manual testing steps
- [x] I've included screenshots/recordings if applicable
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [x] I’ve properly set the pull request status:
  - [x] In case it's not yet "ready for review", I've set it to "draft".
  - [x] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
