### PR TITLE
fix: Fix success message for LavaMoat policy update script

### DIFF
--- a/development/generate-lavamoat-policies.js
+++ b/development/generate-lavamoat-policies.js
@@ -45,7 +45,7 @@ async function start() {
   );
 
   const buildCommand = devMode ? 'build:dev' : 'build';
-  await concurrently(
+  const { result } = concurrently(
     (Array.isArray(buildTypes) ? buildTypes : [buildTypes]).map(
       (buildType) => ({
         command: `yarn ${buildCommand} scripts:dist --policy-only --lint-fence-files=false --build-type=${buildType}`,
@@ -60,6 +60,7 @@ async function start() {
       maxProcesses: parallel ? buildTypes.length : 1,
     },
   );
+  await result;
 
   console.log('Policy file(s) successfully generated!');
 }


### PR DESCRIPTION
## **Description**

The LavaMoat policy update script now waits until the policy update has finished before printing the success message.

This bug was caused by the false assumption that `concurrently` returns a Promise. Instead it returns an object. The result of the command is provided as the `result` property of this returned object, which is a Promise.

See here for more details: https://github.com/open-cli-tools/concurrently#concurrentlycommands-options

## **Related issues**

Fixes #22057

## **Manual testing steps**

1. Run `yarn lavamoat:webapp:auto --build-types main`

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

N/A

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained what problem this PR is solving and how it is solved.
- [x] I've linked related issues
- [x] I've included manual testing steps
- [x] I've included screenshots/recordings if applicable
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [x] I’ve properly set the pull request status:
  - [x] In case it's not yet "ready for review", I've set it to "draft".
  - [x] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
