### PR TITLE
feat(sentry): enable performance monitoring

### DIFF
--- a/app/scripts/lib/setupSentry.js
+++ b/app/scripts/lib/setupSentry.js
@@ -501,6 +501,15 @@ export default function setupSentry({ release, getState }) {
       new ExtraErrorData(),
     ],
     release,
+    /**
+     * Setting a value for `tracesSampleRate` enables performance monitoring in Sentry.
+     * Once performance monitoring is enabled, transactions are sent to Sentry every time
+     * a user loads a page or navigates within the app.
+     * Since the amount of traffic the app gets is important, this means a lot of
+     * transactions are sent. By setting `tracesSampleRate` to a value lower than 1.0, we
+     * reduce the volume of transactions to a more reasonable amount.
+     */
+    tracesSampleRate: 0.01,
     beforeSend: (report) => rewriteReport(report, getState),
     beforeBreadcrumb: beforeBreadcrumb(getState),
   });


### PR DESCRIPTION
## **Description**

Setting a value for `tracesSampleRate` enables performance monitoring in Sentry. Once performance monitoring is enabled, transactions are sent to Sentry every time a user loads a page or navigates within the app. Since the amount of traffic the app gets is important, this means a lot of transactions are sent. By setting `tracesSampleRate` to a value lower than 1.0, we reduce the volume of transactions to a more reasonable amount.

[Sentry documentation](https://docs.sentry.io/platforms/javascript/performance/#configure)
[Mobile implementation](https://github.com/MetaMask/metamask-mobile/blob/756209bbbd4a79955926d19dcd4a646b813275b2/app/util/sentryUtils.js#L156C5-L156C30)

## **Related issues**

- None

## **Manual testing steps**

- None

## **Screenshots/Recordings**

- None

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained what problem this PR is solving and how it is solved.
- [ ] I've linked related issues
- [ ] I've included manual testing steps
- [ ] I've included screenshots/recordings if applicable
- [ ] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [x] I’ve properly set the pull request status:
  - [x] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
