### PR TITLE
Version v11.6.2

### DIFF
--- a/.yarn/patches/@metamask-snaps-controllers-npm-3.3.0-3ef659301e.patch
+++ b/.yarn/patches/@metamask-snaps-controllers-npm-3.3.0-3ef659301e.patch
@@ -1,0 +1,36 @@
+diff --git a/dist/cjs/snaps/SnapController.js b/dist/cjs/snaps/SnapController.js
+index aa27e91be65db39e9ae29527b65f8b804c2a9039..7fea7d4adfe9523be48d2507553ffdd7cdd6b4a1 100644
+--- a/dist/cjs/snaps/SnapController.js
++++ b/dist/cjs/snaps/SnapController.js
+@@ -1614,13 +1614,9 @@ async function assertSnapRpcRequestResult(handlerType, result) {
+     switch(handlerType){
+         case _snapsutils.HandlerType.OnTransaction:
+             (0, _utils.assertStruct)(result, _snapsutils.OnTransactionResponseStruct);
+-            await _class_private_method_get(this, _triggerPhishingListUpdate, triggerPhishingListUpdate).call(this);
+-            (0, _snapsui.assertUILinksAreSafe)(result.content, _class_private_method_get(this, _checkPhishingList, checkPhishingList).bind(this));
+             break;
+         case _snapsutils.HandlerType.OnHomePage:
+             (0, _utils.assertStruct)(result, _snapsutils.OnHomePageResponseStruct);
+-            await _class_private_method_get(this, _triggerPhishingListUpdate, triggerPhishingListUpdate).call(this);
+-            (0, _snapsui.assertUILinksAreSafe)(result.content, _class_private_method_get(this, _checkPhishingList, checkPhishingList).bind(this));
+             break;
+         default:
+             break;
+diff --git a/dist/esm/snaps/SnapController.js b/dist/esm/snaps/SnapController.js
+index f07c31e764aeaf2e79f5a0e84b9d0f0d8fd5cd93..cb70a7292b74c33a5364ce2cd4f3d1af18368594 100644
+--- a/dist/esm/snaps/SnapController.js
++++ b/dist/esm/snaps/SnapController.js
+@@ -1593,13 +1593,9 @@ async function assertSnapRpcRequestResult(handlerType, result) {
+     switch(handlerType){
+         case HandlerType.OnTransaction:
+             assertStruct(result, OnTransactionResponseStruct);
+-            await _class_private_method_get(this, _triggerPhishingListUpdate, triggerPhishingListUpdate).call(this);
+-            assertUILinksAreSafe(result.content, _class_private_method_get(this, _checkPhishingList, checkPhishingList).bind(this));
+             break;
+         case HandlerType.OnHomePage:
+             assertStruct(result, OnHomePageResponseStruct);
+-            await _class_private_method_get(this, _triggerPhishingListUpdate, triggerPhishingListUpdate).call(this);
+-            assertUILinksAreSafe(result.content, _class_private_method_get(this, _checkPhishingList, checkPhishingList).bind(this));
+             break;
+         default:
+             break;

--- a/.yarn/patches/@metamask-snaps-rpc-methods-npm-3.3.0-51796eb3cb.patch
+++ b/.yarn/patches/@metamask-snaps-rpc-methods-npm-3.3.0-51796eb3cb.patch
@@ -1,0 +1,52 @@
+diff --git a/dist/cjs/restricted/dialog.js b/dist/cjs/restricted/dialog.js
+index 037a374ee23d24143975708669253cc99da0b3f7..22aa902c3947ae1379df51734f6cecdd958d3acb 100644
+--- a/dist/cjs/restricted/dialog.js
++++ b/dist/cjs/restricted/dialog.js
+@@ -104,8 +104,6 @@ function getDialogImplementation({ showDialog, isOnPhishingList, maybeUpdatePhis
+         const validatedType = getValidatedType(params);
+         const validatedParams = getValidatedParams(params, structs[validatedType]);
+         const { content } = validatedParams;
+-        await maybeUpdatePhishingList();
+-        (0, _snapsui.assertUILinksAreSafe)(content, isOnPhishingList);
+         const placeholder = validatedParams.type === DialogType.Prompt ? validatedParams.placeholder : undefined;
+         return showDialog(origin, validatedType, content, placeholder);
+     };
+diff --git a/dist/cjs/restricted/notify.js b/dist/cjs/restricted/notify.js
+index c9d9b7e3a250919ffcf4cc8f97e8c11fe9d272b6..c5d9fb0d833777eb3aa7d57071dade116373fd67 100644
+--- a/dist/cjs/restricted/notify.js
++++ b/dist/cjs/restricted/notify.js
+@@ -61,8 +61,6 @@ function getImplementation({ showNativeNotification, showInAppNotification, isOn
+     return async function implementation(args) {
+         const { params, context: { origin } } = args;
+         const validatedParams = getValidatedParams(params);
+-        await maybeUpdatePhishingList();
+-        (0, _snapsui.assertLinksAreSafe)(validatedParams.message, isOnPhishingList);
+         switch(validatedParams.type){
+             case NotificationType.Native:
+                 return await showNativeNotification(origin, validatedParams);
+diff --git a/dist/esm/restricted/dialog.js b/dist/esm/restricted/dialog.js
+index 018801436c3675c5a1f6fa4647eaaaeb6847c90f..21c49b73584bd4cccd892cd4cdf2459695e4f064 100644
+--- a/dist/esm/restricted/dialog.js
++++ b/dist/esm/restricted/dialog.js
+@@ -94,8 +94,6 @@ const structs = {
+         const validatedType = getValidatedType(params);
+         const validatedParams = getValidatedParams(params, structs[validatedType]);
+         const { content } = validatedParams;
+-        await maybeUpdatePhishingList();
+-        assertUILinksAreSafe(content, isOnPhishingList);
+         const placeholder = validatedParams.type === DialogType.Prompt ? validatedParams.placeholder : undefined;
+         return showDialog(origin, validatedType, content, placeholder);
+     };
+diff --git a/dist/esm/restricted/notify.js b/dist/esm/restricted/notify.js
+index b33d163d6fb8741c05d5a6acc0ef3735c239e11b..51673869dc50e764f2ce7ee77838adba8dd8e5f6 100644
+--- a/dist/esm/restricted/notify.js
++++ b/dist/esm/restricted/notify.js
+@@ -52,8 +52,6 @@ export const notifyBuilder = Object.freeze({
+     return async function implementation(args) {
+         const { params, context: { origin } } = args;
+         const validatedParams = getValidatedParams(params);
+-        await maybeUpdatePhishingList();
+-        assertLinksAreSafe(validatedParams.message, isOnPhishingList);
+         switch(validatedParams.type){
+             case NotificationType.Native:
+                 return await showNativeNotification(origin, validatedParams);

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4214,7 +4214,7 @@ Update styles and spacing on the critical error page  ([#20350](https://github.c
 - Added the ability to restore accounts from seed words.
 
 [Unreleased]: https://github.com/MetaMask/metamask-extension/compare/v11.6.2...HEAD
-[11.6.1]: https://github.com/MetaMask/metamask-extension/compare/v11.6.1...v11.6.2
+[11.6.2]: https://github.com/MetaMask/metamask-extension/compare/v11.6.1...v11.6.2
 [11.6.1]: https://github.com/MetaMask/metamask-extension/compare/v11.6.0...v11.6.1
 [11.6.0]: https://github.com/MetaMask/metamask-extension/compare/v11.5.2...v11.6.0
 [11.5.2]: https://github.com/MetaMask/metamask-extension/compare/v11.5.1...v11.5.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [11.6.2]
+
 ## [11.6.1]
 ### Fixed
 - Updates MMI extension package to the latest version since it includes a fix for the Tx status from custodian transactions. ([#22065](https://github.com/MetaMask/metamask-extension/pull/22065))
@@ -4209,7 +4211,8 @@ Update styles and spacing on the critical error page  ([#20350](https://github.c
 ### Uncategorized
 - Added the ability to restore accounts from seed words.
 
-[Unreleased]: https://github.com/MetaMask/metamask-extension/compare/v11.6.1...HEAD
+[Unreleased]: https://github.com/MetaMask/metamask-extension/compare/v11.6.2...HEAD
+[11.6.1]: https://github.com/MetaMask/metamask-extension/compare/v11.6.1...v11.6.2
 [11.6.1]: https://github.com/MetaMask/metamask-extension/compare/v11.6.0...v11.6.1
 [11.6.0]: https://github.com/MetaMask/metamask-extension/compare/v11.5.2...v11.6.0
 [11.5.2]: https://github.com/MetaMask/metamask-extension/compare/v11.5.1...v11.5.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [11.6.2]
 ### Fixed
-- Fixed a problem with including links in snaps custom UI ([#22086](https://github.com/MetaMask/metamask-extension/pull/22086))
+- Fixed a problem with including links in Snaps custom UI ([#22086](https://github.com/MetaMask/metamask-extension/pull/22086))
 
 ## [11.6.1]
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [11.6.2]
+### Fixed
+- Fixed a problem with including links in snaps custom UI ([#22086](https://github.com/MetaMask/metamask-extension/pull/22086))
 
 ## [11.6.1]
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metamask-crx",
-  "version": "11.6.1",
+  "version": "11.6.2",
   "private": true,
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -208,7 +208,9 @@
     "@metamask/signature-controller@^6.1.2": "patch:@metamask/signature-controller@npm%3A6.1.2#~/.yarn/patches/@metamask-signature-controller-npm-6.1.2-f60d8a4960.patch",
     "semver@7.3.7": "^7.5.4",
     "semver@7.3.8": "^7.5.4",
-    "@metamask/eth-keyring-controller@npm:^13.0.1": "patch:@metamask/eth-keyring-controller@npm%3A13.0.1#~/.yarn/patches/@metamask-eth-keyring-controller-npm-13.0.1-06ff83faad.patch"
+    "@metamask/eth-keyring-controller@npm:^13.0.1": "patch:@metamask/eth-keyring-controller@npm%3A13.0.1#~/.yarn/patches/@metamask-eth-keyring-controller-npm-13.0.1-06ff83faad.patch",
+    "@metamask/snaps-controllers": "patch:@metamask/snaps-controllers@npm%3A3.3.0#~/.yarn/patches/@metamask-snaps-controllers-npm-3.3.0-3ef659301e.patch",
+    "@metamask/snaps-rpc-methods": "patch:@metamask/snaps-rpc-methods@npm%3A3.3.0#~/.yarn/patches/@metamask-snaps-rpc-methods-npm-3.3.0-51796eb3cb.patch"
   },
   "dependencies": {
     "@babel/runtime": "^7.23.2",
@@ -280,8 +282,8 @@
     "@metamask/signature-controller": "^6.1.2",
     "@metamask/slip44": "^3.1.0",
     "@metamask/smart-transactions-controller": "^6.2.2",
-    "@metamask/snaps-controllers": "^3.3.0",
-    "@metamask/snaps-rpc-methods": "^3.3.0",
+    "@metamask/snaps-controllers": "patch:@metamask/snaps-controllers@npm%3A3.3.0#~/.yarn/patches/@metamask-snaps-controllers-npm-3.3.0-3ef659301e.patch",
+    "@metamask/snaps-rpc-methods": "patch:@metamask/snaps-rpc-methods@npm%3A3.3.0#~/.yarn/patches/@metamask-snaps-rpc-methods-npm-3.3.0-51796eb3cb.patch",
     "@metamask/snaps-ui": "^3.1.0",
     "@metamask/snaps-utils": "^3.3.0",
     "@metamask/utils": "^8.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4868,7 +4868,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/snaps-controllers@npm:^3.0.0, @metamask/snaps-controllers@npm:^3.3.0":
+"@metamask/snaps-controllers@npm:3.3.0":
   version: 3.3.0
   resolution: "@metamask/snaps-controllers@npm:3.3.0"
   dependencies:
@@ -4903,6 +4903,41 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@metamask/snaps-controllers@patch:@metamask/snaps-controllers@npm%3A3.3.0#~/.yarn/patches/@metamask-snaps-controllers-npm-3.3.0-3ef659301e.patch":
+  version: 3.3.0
+  resolution: "@metamask/snaps-controllers@patch:@metamask/snaps-controllers@npm%3A3.3.0#~/.yarn/patches/@metamask-snaps-controllers-npm-3.3.0-3ef659301e.patch::version=3.3.0&hash=d5b5b0"
+  dependencies:
+    "@metamask/approval-controller": "npm:^4.0.0"
+    "@metamask/base-controller": "npm:^3.2.0"
+    "@metamask/json-rpc-engine": "npm:^7.1.1"
+    "@metamask/object-multiplex": "npm:^1.2.0"
+    "@metamask/permission-controller": "npm:^5.0.0"
+    "@metamask/phishing-controller": "npm:^7.0.0"
+    "@metamask/post-message-stream": "npm:^7.0.0"
+    "@metamask/rpc-errors": "npm:^6.1.0"
+    "@metamask/snaps-registry": "npm:^2.1.0"
+    "@metamask/snaps-rpc-methods": "npm:^3.3.0"
+    "@metamask/snaps-ui": "npm:^3.1.0"
+    "@metamask/snaps-utils": "npm:^3.3.0"
+    "@metamask/utils": "npm:^8.1.0"
+    "@xstate/fsm": "npm:^2.0.0"
+    concat-stream: "npm:^2.0.0"
+    get-npm-tarball-url: "npm:^2.0.3"
+    gunzip-maybe: "npm:^1.4.2"
+    immer: "npm:^9.0.6"
+    json-rpc-middleware-stream: "npm:^5.0.0"
+    nanoid: "npm:^3.1.31"
+    readable-web-to-node-stream: "npm:^3.0.2"
+    tar-stream: "npm:^3.1.6"
+  peerDependencies:
+    "@metamask/snaps-execution-environments": ^3.2.0
+  peerDependenciesMeta:
+    "@metamask/snaps-execution-environments":
+      optional: true
+  checksum: 1a2e1c0e1f2aee965e8bb1255a84b001c99369c0d45ebafd2f89b8bdc4a87391f1889323d5ecbb0826b736f02295b812003bd8f53a3f8576d94134c52ec62bdc
+  languageName: node
+  linkType: hard
+
 "@metamask/snaps-registry@npm:^2.1.0":
   version: 2.1.0
   resolution: "@metamask/snaps-registry@npm:2.1.0"
@@ -4914,7 +4949,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/snaps-rpc-methods@npm:^3.3.0":
+"@metamask/snaps-rpc-methods@npm:3.3.0":
   version: 3.3.0
   resolution: "@metamask/snaps-rpc-methods@npm:3.3.0"
   dependencies:
@@ -4927,6 +4962,22 @@ __metadata:
     "@noble/hashes": "npm:^1.3.1"
     superstruct: "npm:^1.0.3"
   checksum: 4242ddb31fa35858d1f8607640798a70ec878ee22371c0bcf50a6b23f45439b442b49a54b43d54489449aed1600b07880e531520a68e5cb617df462c16ce2baf
+  languageName: node
+  linkType: hard
+
+"@metamask/snaps-rpc-methods@patch:@metamask/snaps-rpc-methods@npm%3A3.3.0#~/.yarn/patches/@metamask-snaps-rpc-methods-npm-3.3.0-51796eb3cb.patch":
+  version: 3.3.0
+  resolution: "@metamask/snaps-rpc-methods@patch:@metamask/snaps-rpc-methods@npm%3A3.3.0#~/.yarn/patches/@metamask-snaps-rpc-methods-npm-3.3.0-51796eb3cb.patch::version=3.3.0&hash=07ec25"
+  dependencies:
+    "@metamask/key-tree": "npm:^9.0.0"
+    "@metamask/permission-controller": "npm:^5.0.0"
+    "@metamask/rpc-errors": "npm:^6.1.0"
+    "@metamask/snaps-ui": "npm:^3.1.0"
+    "@metamask/snaps-utils": "npm:^3.3.0"
+    "@metamask/utils": "npm:^8.1.0"
+    "@noble/hashes": "npm:^1.3.1"
+    superstruct: "npm:^1.0.3"
+  checksum: d9b5a5f021f24f0825dc55461b95364bef49a3743b6bb304262ae290c93fe204d250a3675fe4f959acab3d8cd92c661d6503529a08956c4059b7384a21e5a505
   languageName: node
   linkType: hard
 
@@ -24047,8 +24098,8 @@ __metadata:
     "@metamask/signature-controller": "npm:^6.1.2"
     "@metamask/slip44": "npm:^3.1.0"
     "@metamask/smart-transactions-controller": "npm:^6.2.2"
-    "@metamask/snaps-controllers": "npm:^3.3.0"
-    "@metamask/snaps-rpc-methods": "npm:^3.3.0"
+    "@metamask/snaps-controllers": "patch:@metamask/snaps-controllers@npm%3A3.3.0#~/.yarn/patches/@metamask-snaps-controllers-npm-3.3.0-3ef659301e.patch"
+    "@metamask/snaps-rpc-methods": "patch:@metamask/snaps-rpc-methods@npm%3A3.3.0#~/.yarn/patches/@metamask-snaps-rpc-methods-npm-3.3.0-51796eb3cb.patch"
     "@metamask/snaps-ui": "npm:^3.1.0"
     "@metamask/snaps-utils": "npm:^3.3.0"
     "@metamask/test-dapp": "npm:^7.2.0"


### PR DESCRIPTION
A hotfix release to fix a regression in the snaps dependencies included in Version 11.6.0 of the client release.

See https://github.com/MetaMask/metamask-extension/pull/22086 for more details.