### PR TITLE
feat: create ConfirmTitle component

### DIFF
--- a/ui/components/app/confirm/title/index.ts
+++ b/ui/components/app/confirm/title/index.ts
@@ -1,0 +1,1 @@
+export { ConfirmTitle } from './title';

--- a/ui/components/app/confirm/title/title.test.tsx
+++ b/ui/components/app/confirm/title/title.test.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { ConfirmTitle } from './title';
+
+describe('ConfirmTitle', () => {
+  it('renders the title and subtitle correctly', () => {
+    const title = 'Confirmation Title';
+    const subtitle = 'Confirmation Subtitle';
+
+    const { getByText } = render(
+      <ConfirmTitle title={title} subtitle={subtitle} />,
+    );
+
+    expect(getByText(title)).toBeInTheDocument();
+    expect(getByText(subtitle)).toBeInTheDocument();
+  });
+});

--- a/ui/components/app/confirm/title/title.tsx
+++ b/ui/components/app/confirm/title/title.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { Text } from '../../../component-library';
+import {
+  TextVariant,
+  TextAlign,
+  TextColor,
+} from '../../../../helpers/constants/design-system';
+
+interface ConfirmTitleProps {
+  title: string;
+  subtitle: string;
+}
+
+export const ConfirmTitle: React.FC<ConfirmTitleProps> = ({
+  title,
+  subtitle,
+}) => {
+  return (
+    <>
+      <Text
+        variant={TextVariant.headingLg}
+        paddingTop={4}
+        paddingBottom={2}
+        textAlign={TextAlign.Center}
+      >
+        {title}
+      </Text>
+      <Text
+        paddingBottom={4}
+        color={TextColor.textAlternative}
+        textAlign={TextAlign.Center}
+      >
+        {subtitle}
+      </Text>
+    </>
+  );
+};


### PR DESCRIPTION
## **Description**

New component to display the confirmation title and subtitle

Todo: get title and subtitle using hooks

Note: no storybook page created for this. We can display this within the confirm page storybook page(s) when we create it. see: https://storybook.js.org/docs/writing-stories/build-pages-with-storybook#args-composition-for-presentational-screens

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/21282

## **Manual testing steps**

## **Screenshots/Recordings**

see blue box in below image:
<img width="693" alt="confirmtitle" src="https://github.com/MetaMask/metamask-extension/assets/20778143/4582858f-9574-40a9-aee4-cbcfc7c517f9">

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've clearly explained what problem this PR is solving and how it is solved.
- [ ] I've linked related issues
- [ ] I've included manual testing steps
- [ ] I've included screenshots/recordings if applicable
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [ ] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
