### PR TITLE
test:e2e: skip benign ppom blockaid alert

### DIFF
--- a/test/e2e/tests/ppom-blockaid-alert.spec.js
+++ b/test/e2e/tests/ppom-blockaid-alert.spec.js
@@ -146,7 +146,13 @@ async function mockInfuraWithMaliciousResponses(mockServer) {
  * @see {@link https://wobbly-nutmeg-8a5.notion.site/MM-E2E-Testing-1e51b617f79240a49cd3271565c6e12d}
  */
 describe('Confirmation Security Alert - Blockaid @no-mmi', function () {
-  it('should not show security alerts for benign requests', async function () {
+  /**
+   * todo: fix test
+   *
+   * @see {@link https://github.com/MetaMask/MetaMask-planning/issues/1766}
+   */
+  // eslint-disable-next-line mocha/no-skipped-tests
+  it.skip('should not show security alerts for benign requests', async function () {
     await withFixtures(
       {
         dapp: true,


### PR DESCRIPTION
## **Description**

this test is timing out. 

The PPOM Blockaid benign test is causing a ScriptTimeoutError is and blocking the test suite from succeeding.

Slack thread:
https://consensys.slack.com/archives/GTQAGKY5V/p1701360449093619
from @brad-decker's investigation:

> [..] we get a "success" message followed by "process not stopped" then the next test case starts executing.

> even though our logs say "success on testcase" mocha is getting it as a failure due to a timeout of 8000ms



skipping this test for now to unblock PRs as we investigate a resolution

```
INFO: Created TensorFlow Lite XNNPACK delegate for CPU.
WARNING: Attempting to use a delegate that only supports static-sized tensors with a graph that has dynamic-sized tensors (tensor#39 is a dynamic-sized tensor).
<?xml version="1.0" encoding="UTF-8"?>
<testsuites name="Mocha Tests" time="68.975" tests="3" failures="1" skipped="1">
  <testsuite name="Root Suite" timestamp="2023-11-30T18:55:35" tests="0" time="0.000" failures="0">
  </testsuite>
  <testsuite name="Confirmation Security Alert - Blockaid @no-mmi" timestamp="2023-11-30T18:55:35" tests="3" file="/home/circleci/project/test/e2e/tests/ppom-blockaid-alert.spec.js" time="68.973" failures="1">
    <testcase name="Confirmation Security Alert - Blockaid @no-mmi should not show security alerts for benign requests" time="53.060" classname="should not show security alerts for benign requests">
      <failure message="script timeout
  (Session info: chrome=119.0.6045.105)" type="ScriptTimeoutError"><![CDATA[ScriptTimeoutError: script timeout
  (Session info: chrome=119.0.6045.105)
    at Object.throwDecodedError (node_modules/selenium-webdriver/lib/error.js:524:15)
    at parseHttpResponse (node_modules/selenium-webdriver/lib/http.js:601:13)
    at Executor.execute (node_modules/selenium-webdriver/lib/http.js:529:28)
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
    at thenableWebDriverProxy.execute (node_modules/selenium-webdriver/lib/webdriver.js:745:17)
    at /home/circleci/project/test/e2e/tests/ppom-blockaid-alert.spec.js:165:29
    at withFixtures (test/e2e/helpers.js:125:9)
    at Context.<anonymous> (test/e2e/tests/ppom-blockaid-alert.spec.js:137:8)]]></failure>
    </testcase>
    <testcase name="Confirmation Security Alert - Blockaid @no-mmi should show &quot;Request may not be safe&quot; if the PPOM request fails to check transaction" time="15.886" classname="should show &quot;Request may not be safe&quot; if the PPOM request fails to check transaction">
    </testcase>
```

## **Related issues**

partial fix: https://github.com/MetaMask/MetaMask-planning/issues/1766

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've clearly explained what problem this PR is solving and how it is solved.
- [ ] I've linked related issues
- [ ] I've included manual testing steps
- [ ] I've included screenshots/recordings if applicable
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [ ] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
