### PR TITLE
Persist MetaMetrics ID on toggle off

### DIFF
--- a/.storybook/test-data.js
+++ b/.storybook/test-data.js
@@ -4,6 +4,7 @@ import { NetworkType } from '@metamask/controller-utils';
 import { NetworkStatus } from '@metamask/network-controller';
 import { EthAccountType, EthMethod } from '@metamask/keyring-api';
 import { CHAIN_IDS } from '../shared/constants/network';
+import { MetaMetricsParticipation } from '../shared/constants/metametrics';
 
 const state = {
   invalidCustomNetwork: {
@@ -649,7 +650,7 @@ const state = {
         name: 'Approve Tokens',
       },
     },
-    participateInMetaMetrics: true,
+    metaMetricsParticipationMode: MetaMetricsParticipation.Participate,
     nextNonce: 71,
     connectedStatusPopoverHasBeenShown: true,
     swapsWelcomeMessageHasBeenShown: true,
@@ -1257,11 +1258,11 @@ const state = {
       '0xc2377d11fec1c3b7dd88c4854240ee5e3ed0d9f63b00456d98d80320337b827f',
     currentCurrency: 'usd',
     currencyRates: {
-      "ETH": {
+      ETH: {
         conversionDate: 1620710825.03,
         conversionRate: 3910.28,
         usdConversionRate: 3910.28,
-      }
+      },
     },
     ticker: 'ETH',
     alertEnabledness: {

--- a/app/scripts/controllers/metametrics.js
+++ b/app/scripts/controllers/metametrics.js
@@ -154,7 +154,7 @@ export default class MetaMetricsController {
     const segmentApiCalls = initState?.segmentApiCalls || {};
 
     this.store = new ObservableStore({
-      metaMetricsParticipation: MetaMetricsParticipation.NotChosen,
+      metaMetricsParticipationMode: MetaMetricsParticipation.NotChosen,
       metaMetricsId: null,
       eventsBeforeMetricsOptIn: [],
       traits: {},

--- a/app/scripts/lib/createRPCMethodTrackingMiddleware.js
+++ b/app/scripts/lib/createRPCMethodTrackingMiddleware.js
@@ -7,6 +7,7 @@ import {
   MetaMetricsEventCategory,
   MetaMetricsEventName,
   MetaMetricsEventUiCustomization,
+  MetaMetricsParticipation,
 } from '../../../shared/constants/metametrics';
 import { SECOND } from '../../../shared/constants/time';
 
@@ -148,11 +149,12 @@ export default function createRPCMethodTrackingMiddleware({
       rateLimitType === RATE_LIMIT_TYPES.RATE_LIMITED &&
       typeof rateLimitTimeouts[method] !== 'undefined';
 
-    // Get the participateInMetaMetrics state to determine if we should track
-    // anything. This is extra redundancy because this value is checked in
-    // the metametrics controller's trackEvent method as well.
+    // Get the `metaMetricsParticipationMode` from state to determine if we
+    // should track anything. This is extra redundancy because this value is
+    // checked in the metametrics controller's trackEvent method as well.
     const userParticipatingInMetaMetrics =
-      getMetricsState().participateInMetaMetrics === true;
+      getMetricsState().metaMetricsParticipationMode ===
+      MetaMetricsParticipation.Participate;
 
     // Get the event type, each of which has APPROVED, REJECTED and REQUESTED
     // keys for the various events in the flow.

--- a/app/scripts/lib/createRPCMethodTrackingMiddleware.test.js
+++ b/app/scripts/lib/createRPCMethodTrackingMiddleware.test.js
@@ -4,6 +4,7 @@ import { MESSAGE_TYPE } from '../../../shared/constants/app';
 import {
   MetaMetricsEventName,
   MetaMetricsEventUiCustomization,
+  MetaMetricsParticipation,
 } from '../../../shared/constants/metametrics';
 import { SECOND } from '../../../shared/constants/time';
 import {
@@ -13,7 +14,9 @@ import {
 import createRPCMethodTrackingMiddleware from './createRPCMethodTrackingMiddleware';
 
 const trackEvent = jest.fn();
-const metricsState = { participateInMetaMetrics: null };
+const metricsState = {
+  metaMetricsParticipationMode: MetaMetricsParticipation.NotChosen,
+};
 const getMetricsState = () => metricsState;
 
 let flagAsDangerous = 0;
@@ -69,10 +72,11 @@ jest.mock('@metamask/controller-utils', () => ({
 describe('createRPCMethodTrackingMiddleware', () => {
   afterEach(() => {
     jest.resetAllMocks();
-    metricsState.participateInMetaMetrics = null;
+    metricsState.metaMetricsParticipationMode =
+      MetaMetricsParticipation.NotChosen;
   });
 
-  describe('before participateInMetaMetrics is set', () => {
+  describe('before metaMetricsParticipationMode is set', () => {
     it('should not track an event for a signature request', async () => {
       const req = {
         method: MESSAGE_TYPE.ETH_SIGN,
@@ -89,9 +93,10 @@ describe('createRPCMethodTrackingMiddleware', () => {
     });
   });
 
-  describe('participateInMetaMetrics is set to false', () => {
+  describe('metaMetricsParticipationMode is set to `DoNotParticipate`', () => {
     beforeEach(() => {
-      metricsState.participateInMetaMetrics = false;
+      metricsState.metaMetricsParticipationMode =
+        MetaMetricsParticipation.DoNotParticipate;
     });
 
     it('should not track an event for a signature request', async () => {
@@ -110,9 +115,10 @@ describe('createRPCMethodTrackingMiddleware', () => {
     });
   });
 
-  describe('participateInMetaMetrics is set to true', () => {
+  describe('metaMetricsParticipationMode is set to `Participate`', () => {
     beforeEach(() => {
-      metricsState.participateInMetaMetrics = true;
+      metricsState.metaMetricsParticipationMode =
+        MetaMetricsParticipation.Participate;
     });
 
     it(`should immediately track a ${MetaMetricsEventName.SignatureRequested} event`, async () => {

--- a/app/scripts/lib/setupSentry.js
+++ b/app/scripts/lib/setupSentry.js
@@ -127,7 +127,7 @@ export const SENTRY_BACKGROUND_STATE = {
     eventsBeforeMetricsOptIn: false,
     fragments: false,
     metaMetricsId: true,
-    participateInMetaMetrics: true,
+    metaMetricsParticipationMode: true,
     previousUserTraits: false,
     segmentApiCalls: false,
     traits: false,

--- a/app/scripts/lib/setupSentry.js
+++ b/app/scripts/lib/setupSentry.js
@@ -485,7 +485,7 @@ export default function setupSentry({ release, getState }) {
      *
      * In the MetaMetricsController the session is manually started or stopped
      * when the user opts in or out of MetaMetrics. This occurs in the
-     * setParticipateInMetaMetrics function which is exposed to the UI via the
+     * `setMetaMetricsParticipation` function which is exposed to the UI via the
      * MetaMaskController.
      *
      * In actions.ts, after sending the updated participateInMetaMetrics flag

--- a/app/scripts/lib/setupSentry.js
+++ b/app/scripts/lib/setupSentry.js
@@ -128,7 +128,7 @@ export const SENTRY_BACKGROUND_STATE = {
     eventsBeforeMetricsOptIn: false,
     fragments: false,
     metaMetricsId: true,
-    metaMetricsParticipationMode: MetaMetricsParticipation.Participate,
+    metaMetricsParticipationMode: true,
     previousUserTraits: false,
     segmentApiCalls: false,
     traits: false,

--- a/app/scripts/lib/setupSentry.js
+++ b/app/scripts/lib/setupSentry.js
@@ -4,6 +4,7 @@ import { Dedupe, ExtraErrorData } from '@sentry/integrations';
 import { AllProperties } from '../../../shared/modules/object.utils';
 import { FilterEvents } from './sentry-filter-events';
 import extractEthjsErrorMessage from './extractEthjsErrorMessage';
+import { MetaMetricsParticipation } from '../../../shared/constants/metametrics';
 
 /* eslint-disable prefer-destructuring */
 // Destructuring breaks the inlining of the environment variables
@@ -127,7 +128,7 @@ export const SENTRY_BACKGROUND_STATE = {
     eventsBeforeMetricsOptIn: false,
     fragments: false,
     metaMetricsId: true,
-    metaMetricsParticipationMode: true,
+    metaMetricsParticipationMode: MetaMetricsParticipation.Participate,
     previousUserTraits: false,
     segmentApiCalls: false,
     traits: false,

--- a/app/scripts/lib/transaction/metrics.ts
+++ b/app/scripts/lib/transaction/metrics.ts
@@ -26,6 +26,7 @@ import {
   MetaMetricsEventFragment,
   MetaMetricsEventName,
   MetaMetricsPageObject,
+  MetaMetricsParticipation,
   MetaMetricsReferrerObject,
 } from '../../../../shared/constants/metametrics';
 import { GasRecommendations } from '../../../../shared/constants/gas';
@@ -73,7 +74,7 @@ export type TransactionMetricsRequest = {
   // doesn't include some properties used in buildEventFragmentProperties,
   // hence returning any here to avoid type errors.
   getEIP1559GasFeeEstimates(options?: FetchGasFeeEstimateOptions): Promise<any>;
-  getParticipateInMetrics: () => boolean;
+  getParticipateInMetrics: () => MetaMetricsParticipation;
   getSelectedAddress: () => string;
   getTokenStandardAndDetails: () => {
     decimals?: string;
@@ -361,7 +362,10 @@ export const handlePostTransactionBalanceUpdate = async (
     approvalTransactionMeta?: TransactionMeta;
   },
 ) => {
-  if (getParticipateInMetrics() && transactionMeta.swapMetaData) {
+  if (
+    getParticipateInMetrics() === MetaMetricsParticipation.Participate &&
+    transactionMeta.swapMetaData
+  ) {
     if (transactionMeta.txReceipt?.status === '0x0') {
       trackEvent({
         event: 'Swap Failed',

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -2750,8 +2750,8 @@ export default class MetamaskController extends EventEmitter {
         preferencesController.setUseAddressBarEnsResolution.bind(
           preferencesController,
         ),
-      setParticipateInMetaMetrics:
-        metaMetricsController.setParticipateInMetaMetrics.bind(
+      setMetaMetricsParticipation:
+        metaMetricsController.setMetaMetricsParticipation.bind(
           metaMetricsController,
         ),
       setCurrentLocale: preferencesController.setCurrentLocale.bind(
@@ -5271,7 +5271,7 @@ export default class MetamaskController extends EventEmitter {
           this.metaMetricsController,
         ),
       getParticipateInMetrics: () =>
-        this.metaMetricsController.state.participateInMetaMetrics,
+        this.metaMetricsController.state.metaMetricsParticipationMode,
       trackEvent: this.metaMetricsController.trackEvent.bind(
         this.metaMetricsController,
       ),

--- a/app/scripts/migrations/106.test.ts
+++ b/app/scripts/migrations/106.test.ts
@@ -1,0 +1,197 @@
+import { MetaMetricsParticipation } from '../../../shared/constants/metametrics';
+import { migrate } from './106';
+
+describe('migration #78', () => {
+  it('should update the version metadata', async () => {
+    const oldStorage = {
+      meta: { version: 105 },
+      data: {},
+    };
+    const newStorage = await migrate(oldStorage);
+
+    expect(newStorage.meta).toStrictEqual({ version: 106 });
+  });
+
+  it('should set `metaMetricsParticipationMode` to `NotChosen` if `participateInMetaMetrics` is `null`', async () => {
+    const oldStorage = {
+      meta: { version: 105 },
+      data: {
+        MetaMetricsController: {
+          participateInMetaMetrics: null,
+        },
+      },
+    };
+    const newStorage = await migrate(oldStorage);
+
+    expect(newStorage).toStrictEqual({
+      meta: { version: 106 },
+      data: {
+        MetaMetricsController: {
+          metaMetricsParticipationMode: MetaMetricsParticipation.NotChosen,
+        },
+      },
+    });
+  });
+
+  it('should set `metaMetricsParticipationMode` to `NotChosen` if `participateInMetaMetrics` is `undefined`', async () => {
+    const oldStorage = {
+      meta: { version: 105 },
+      data: { MetaMetricsController: {} },
+    };
+    const newStorage = await migrate(oldStorage);
+    expect(newStorage).toStrictEqual({
+      meta: { version: 106 },
+      data: {
+        MetaMetricsController: {
+          metaMetricsParticipationMode: MetaMetricsParticipation.NotChosen,
+        },
+      },
+    });
+  });
+
+  it('should set `metaMetricsParticipationMode` to `DoNotParticipate` if `participateInMetaMetrics` is `false`', async () => {
+    const oldStorage = {
+      meta: { version: 105 },
+      data: { MetaMetricsController: { participateInMetaMetrics: false } },
+    };
+    const newStorage = await migrate(oldStorage);
+    expect(newStorage).toStrictEqual({
+      meta: { version: 106 },
+      data: {
+        MetaMetricsController: {
+          metaMetricsParticipationMode:
+            MetaMetricsParticipation.DoNotParticipate,
+        },
+      },
+    });
+  });
+
+  it('should set `metaMetricsParticipationMode` to `Participate` if `participateInMetaMetrics` is `true`', async () => {
+    const oldStorage = {
+      meta: {
+        version: 105,
+      },
+      data: {
+        MetaMetricsController: { participateInMetaMetrics: true },
+      },
+    };
+    const newStorage = await migrate(oldStorage);
+    expect(newStorage).toStrictEqual({
+      meta: {
+        version: 106,
+      },
+      data: {
+        MetaMetricsController: {
+          metaMetricsParticipationMode: MetaMetricsParticipation.Participate,
+        },
+      },
+    });
+  });
+
+  it('should not change `metaMetricsParticipationMode` if it is already set and `participateInMetaMetrics` is `true`', async () => {
+    const oldStorage = {
+      meta: {
+        version: 105,
+      },
+      data: {
+        MetaMetricsController: {
+          participateInMetaMetrics: true,
+          metaMetricsParticipationMode:
+            MetaMetricsParticipation.DoNotParticipate,
+        },
+      },
+    };
+    const newStorage = await migrate(oldStorage);
+    expect(newStorage).toStrictEqual({
+      meta: {
+        version: 106,
+      },
+      data: {
+        MetaMetricsController: {
+          metaMetricsParticipationMode:
+            MetaMetricsParticipation.DoNotParticipate,
+        },
+      },
+    });
+  });
+
+  it('should not change `metaMetricsParticipationMode` if it is already set and `participateInMetaMetrics` is `false`', async () => {
+    const oldStorage = {
+      meta: {
+        version: 105,
+      },
+      data: {
+        MetaMetricsController: {
+          participateInMetaMetrics: false,
+          metaMetricsParticipationMode: MetaMetricsParticipation.Participate,
+        },
+      },
+    };
+    const newStorage = await migrate(oldStorage);
+    expect(newStorage).toStrictEqual({
+      meta: {
+        version: 106,
+      },
+      data: {
+        MetaMetricsController: {
+          metaMetricsParticipationMode: MetaMetricsParticipation.Participate,
+        },
+      },
+    });
+  });
+
+  it('should not change `metaMetricsParticipationMode` if it is already set and `participateInMetaMetrics` is `null`', async () => {
+    const oldStorage = {
+      meta: {
+        version: 105,
+      },
+      data: {
+        MetaMetricsController: {
+          metaMetricsParticipationMode: MetaMetricsParticipation.Participate,
+        },
+      },
+    };
+    const newStorage = await migrate(oldStorage);
+    expect(newStorage).toStrictEqual({
+      meta: {
+        version: 106,
+      },
+      data: {
+        MetaMetricsController: {
+          metaMetricsParticipationMode: MetaMetricsParticipation.Participate,
+        },
+      },
+    });
+  });
+
+  it('should not alter any other data', async () => {
+    const oldStorage = {
+      meta: {
+        version: 105,
+      },
+      data: {
+        MetaMetricsController: {
+          segmentApiCalls: { 1: ['test'] },
+          fragments: { 1: ['test'] },
+          metaMetricsId: '0x00',
+        },
+        SomeOtherController: { foo: 'bar' },
+      },
+    };
+    const newStorage = await migrate(oldStorage);
+    expect(newStorage).toStrictEqual({
+      meta: {
+        version: 106,
+      },
+      data: {
+        MetaMetricsController: {
+          metaMetricsParticipationMode: MetaMetricsParticipation.NotChosen,
+          segmentApiCalls: { 1: ['test'] },
+          fragments: { 1: ['test'] },
+          metaMetricsId: '0x00',
+        },
+        SomeOtherController: { foo: 'bar' },
+      },
+    });
+  });
+});

--- a/app/scripts/migrations/106.ts
+++ b/app/scripts/migrations/106.ts
@@ -1,0 +1,61 @@
+import { cloneDeep } from 'lodash';
+import { MetaMetricsParticipation } from '../../../shared/constants/metametrics';
+
+type MetaMaskState = Record<string, any>;
+type VersionedState = {
+  meta: { version: number };
+  data: MetaMaskState;
+};
+
+export const version = 106;
+
+/**
+ * Prior to this version of the data structure, the MetaMetrics Controller had
+ * a 'participateInMetaMetrics' key in its store that was a boolean value. The
+ * problem with this mechanism is that we defaulted this value to null and used
+ * the null value as a way to determine if the user had not yet opted in or out
+ * of metrics. This was predominately used in the onboarding flow, but has also
+ * been used elsewhere for edge cases. This migration moves away this boolean
+ * flag and towards a enum where the value may be 'NOT_STARTED', 'PARTICIPATE'
+ * or 'DO_NOT_PARTICIPATE'. The new store key is 'metaMetricsParticipatonMode'.
+ *
+ * @param originalVersionedData
+ */
+export async function migrate(
+  originalVersionedData: VersionedState,
+): Promise<VersionedState> {
+  const versionedData = cloneDeep(originalVersionedData);
+  versionedData.meta.version = version;
+
+  const state = versionedData.data;
+  const newState = transformState(state);
+  versionedData.data = newState;
+
+  return versionedData;
+}
+
+function transformState(state: MetaMaskState): MetaMaskState {
+  const MetaMetricsController = state?.MetaMetricsController || {};
+
+  let metaMetricsParticipationMode =
+    MetaMetricsController?.metaMetricsParticipationMode ??
+    MetaMetricsParticipation.NotChosen;
+
+  if (MetaMetricsController.metaMetricsParticipationMode === undefined) {
+    if (MetaMetricsController?.participateInMetaMetrics === false) {
+      metaMetricsParticipationMode = MetaMetricsParticipation.DoNotParticipate;
+    } else if (MetaMetricsController?.participateInMetaMetrics === true) {
+      metaMetricsParticipationMode = MetaMetricsParticipation.Participate;
+    }
+  }
+
+  delete MetaMetricsController.participateInMetaMetrics;
+
+  return {
+    ...state,
+    MetaMetricsController: {
+      ...MetaMetricsController,
+      metaMetricsParticipationMode,
+    },
+  };
+}

--- a/app/scripts/migrations/index.js
+++ b/app/scripts/migrations/index.js
@@ -116,6 +116,7 @@ const migrations = [
   require('./103'),
   require('./104'),
   require('./105'),
+  require('./106'),
 ];
 
 export default migrations;

--- a/shared/constants/metametrics.ts
+++ b/shared/constants/metametrics.ts
@@ -465,6 +465,15 @@ export enum MetaMetricsUserTrait {
 }
 
 /**
+ * Describes the participation mode that a user has opted into for MetaMetrics.
+ */
+export enum MetaMetricsParticipation {
+  NotChosen = 'Not Chosen',
+  Participate = 'Participate',
+  DoNotParticipate = 'Do Not Participate',
+}
+
+/**
  * Mixpanel converts the zero address value to a truly anonymous event, which
  * speeds up reporting
  */

--- a/test/e2e/fixture-builder.js
+++ b/test/e2e/fixture-builder.js
@@ -6,6 +6,7 @@ const { merge } = require('lodash');
 const { toHex } = require('@metamask/controller-utils');
 const { NetworkStatus } = require('@metamask/network-controller');
 const { CHAIN_IDS, NETWORK_TYPES } = require('../../shared/constants/network');
+import { MetaMetricsParticipation } from '../../shared/constants/metametrics';
 const { SMART_CONTRACTS } = require('./seeder/smart-contracts');
 const { DAPP_URL, DAPP_ONE_URL } = require('./helpers');
 
@@ -236,7 +237,7 @@ function defaultFixture() {
         eventsBeforeMetricsOptIn: [],
         fragments: {},
         metaMetricsId: null,
-        participateInMetaMetrics: false,
+        metaMetricsParticipationMode: MetaMetricsParticipation.DoNotParticipate,
         traits: {},
       },
       NetworkController: {

--- a/test/e2e/fixture-builder.js
+++ b/test/e2e/fixture-builder.js
@@ -237,7 +237,7 @@ function defaultFixture() {
         eventsBeforeMetricsOptIn: [],
         fragments: {},
         metaMetricsId: null,
-        metaMetricsParticipationMode: MetaMetricsParticipation.DoNotParticipate,
+        participateInMetaMetrics: false,
         traits: {},
       },
       NetworkController: {

--- a/test/e2e/tests/errors.spec.js
+++ b/test/e2e/tests/errors.spec.js
@@ -378,7 +378,7 @@ describe('Sentry errors', function () {
 
     // todo: reenable this test https://github.com/MetaMask/metamask-extension/issues/21807
     // eslint-disable-next-line mocha/no-skipped-tests
-    it('should capture migration log breadcrumbs when there is an invariant state error in a migration', async function () {
+    it.skip('should capture migration log breadcrumbs when there is an invariant state error in a migration', async function () {
       await withFixtures(
         {
           fixtures: {

--- a/test/e2e/tests/errors.spec.js
+++ b/test/e2e/tests/errors.spec.js
@@ -8,6 +8,9 @@ const { isObject } = require('@metamask/utils');
 const { SENTRY_UI_STATE } = require('../../../app/scripts/lib/setupSentry');
 const FixtureBuilder = require('../fixture-builder');
 const { convertToHexValue, withFixtures } = require('../helpers');
+const {
+  MetaMetricsParticipation,
+} = require('../../../shared/constants/metametrics');
 
 /**
  * Derive a UI state field from a background state field.
@@ -375,7 +378,7 @@ describe('Sentry errors', function () {
 
     // todo: reenable this test https://github.com/MetaMask/metamask-extension/issues/21807
     // eslint-disable-next-line mocha/no-skipped-tests
-    it.skip('should capture migration log breadcrumbs when there is an invariant state error in a migration', async function () {
+    it('should capture migration log breadcrumbs when there is an invariant state error in a migration', async function () {
       await withFixtures(
         {
           fixtures: {
@@ -501,6 +504,7 @@ describe('Sentry errors', function () {
           const mockTextBody = mockedRequest.body.text.split('\n');
           const mockJsonBody = JSON.parse(mockTextBody[2]);
           const appState = mockJsonBody?.extra?.appState;
+
           assert.deepStrictEqual(Object.keys(appState), [
             'browser',
             'version',

--- a/test/e2e/tests/state-snapshots/errors-before-init-opt-in-background-state.json
+++ b/test/e2e/tests/state-snapshots/errors-before-init-opt-in-background-state.json
@@ -53,7 +53,7 @@
       "eventsBeforeMetricsOptIn": "object",
       "fragments": "object",
       "metaMetricsId": "fake-metrics-id",
-      "participateInMetaMetrics": true,
+      "participateInMetaMetrics": "boolean",
       "traits": "object"
     },
     "NetworkController": {
@@ -100,13 +100,13 @@
       "selectedAddress": "string",
       "theme": "light",
       "useBlockie": false,
-      "useRequestQueue": false,
       "useNftDetection": false,
       "useNonceField": false,
       "usePhishDetect": true,
       "useTokenDetection": false,
       "useCurrencyRateCheck": true,
-      "useMultiAccountBalanceChecker": true
+      "useMultiAccountBalanceChecker": true,
+      "useRequestQueue": false
     },
     "SmartTransactionsController": {
       "smartTransactionsState": {
@@ -124,9 +124,7 @@
       "ignoredTokens": "object",
       "tokens": "object"
     },
-    "TransactionController": {
-      "transactions": "object"
-    },
+    "TransactionController": { "transactions": "object" },
     "config": "object",
     "firstTimeInfo": "object"
   }

--- a/test/e2e/tests/state-snapshots/errors-before-init-opt-in-ui-state.json
+++ b/test/e2e/tests/state-snapshots/errors-before-init-opt-in-ui-state.json
@@ -53,7 +53,7 @@
       "eventsBeforeMetricsOptIn": "object",
       "fragments": "object",
       "metaMetricsId": "fake-metrics-id",
-      "participateInMetaMetrics": true,
+      "participateInMetaMetrics": "boolean",
       "traits": "object"
     },
     "NetworkController": {

--- a/ui/ducks/metamask/metamask.js
+++ b/ui/ducks/metamask/metamask.js
@@ -18,6 +18,7 @@ import {
 import * as actionConstants from '../../store/actionConstants';
 import { updateTransactionGasFees } from '../../store/actions';
 import { setCustomGasLimit, setCustomGasPrice } from '../gas/gas.duck';
+import { MetaMetricsParticipation } from '../../../shared/constants/metametrics';
 
 const initialState = {
   isInitialized: false,
@@ -47,7 +48,7 @@ const initialState = {
   completedOnboarding: false,
   knownMethodData: {},
   use4ByteResolution: true,
-  participateInMetaMetrics: null,
+  metaMetricsParticipationMode: MetaMetricsParticipation.NotChosen,
   nextNonce: null,
   currencyRates: {
     ETH: {
@@ -135,7 +136,7 @@ export default function reduceMetamask(state = initialState, action) {
     case actionConstants.SET_PARTICIPATE_IN_METAMETRICS:
       return {
         ...metamaskState,
-        participateInMetaMetrics: action.value,
+        metaMetricsParticipationMode: action.value,
       };
 
     case actionConstants.CLOSE_WELCOME_SCREEN:

--- a/ui/pages/onboarding-flow/create-password/create-password.js
+++ b/ui/pages/onboarding-flow/create-password/create-password.js
@@ -46,6 +46,7 @@ import { MetaMetricsContext } from '../../../contexts/metametrics';
 import {
   MetaMetricsEventCategory,
   MetaMetricsEventName,
+  MetaMetricsParticipation,
 } from '../../../../shared/constants/metametrics';
 import { Icon, IconName } from '../../../components/component-library';
 
@@ -68,15 +69,18 @@ export default function CreatePassword({
   const trackEvent = useContext(MetaMetricsContext);
   const currentKeyring = useSelector(getCurrentKeyring);
 
-  const participateInMetaMetrics = useSelector((state) =>
-    Boolean(state.metamask.participateInMetaMetrics),
+  const metaMetricsParticipationMode = useSelector(
+    (state) =>
+      // TODO PEDRO FIG: where is this value being set on the metamask state?
+      state.metamask.metaMetricsParticipationMode,
   );
   const metametricsId = useSelector(getMetaMetricsId);
   const base64MetametricsId = Buffer.from(metametricsId ?? '').toString(
     'base64',
   );
   const shouldInjectMetametricsIframe = Boolean(
-    participateInMetaMetrics && base64MetametricsId,
+    metaMetricsParticipationMode === MetaMetricsParticipation.Participate &&
+      base64MetametricsId,
   );
   const analyticsIframeQuery = {
     mmi: base64MetametricsId,

--- a/ui/pages/onboarding-flow/create-password/create-password.test.js
+++ b/ui/pages/onboarding-flow/create-password/create-password.test.js
@@ -8,6 +8,7 @@ import {
   ONBOARDING_COMPLETION_ROUTE,
 } from '../../../helpers/constants/routes';
 import { FIRST_TIME_FLOW_TYPES } from '../../../helpers/constants/onboarding';
+import { MetaMetricsParticipation } from '../../../../shared/constants/metametrics';
 import CreatePassword from './create-password';
 
 const mockHistoryPush = jest.fn();
@@ -400,7 +401,7 @@ describe('Onboarding Create Password', () => {
         ...mockState,
         metamask: {
           ...mockState.metamask,
-          participateInMetaMetrics: true,
+          metaMetricsParticipationMode: MetaMetricsParticipation.Participate,
         },
       };
       const mockStore = configureMockStore()(state);
@@ -416,7 +417,8 @@ describe('Onboarding Create Password', () => {
         ...mockState,
         metamask: {
           ...mockState.metamask,
-          participateInMetaMetrics: false,
+          metaMetricsParticipationMode:
+            MetaMetricsParticipation.DoNotParticipate,
         },
       };
       const mockStore = configureMockStore()(state);

--- a/ui/pages/onboarding-flow/metametrics/metametrics.js
+++ b/ui/pages/onboarding-flow/metametrics/metametrics.js
@@ -11,7 +11,7 @@ import {
 } from '../../../helpers/constants/design-system';
 import Button from '../../../components/ui/button';
 import { useI18nContext } from '../../../hooks/useI18nContext';
-import { setParticipateInMetaMetrics } from '../../../store/actions';
+import { setMetaMetricsParticipation } from '../../../store/actions';
 import {
   getFirstTimeFlowTypeRoute,
   getFirstTimeFlowType,
@@ -21,6 +21,7 @@ import {
   MetaMetricsEventAccountType,
   MetaMetricsEventCategory,
   MetaMetricsEventName,
+  MetaMetricsParticipation,
 } from '../../../../shared/constants/metametrics';
 
 import { MetaMetricsContext } from '../../../contexts/metametrics';
@@ -43,7 +44,9 @@ export default function OnboardingMetametrics() {
   const trackEvent = useContext(MetaMetricsContext);
 
   const onConfirm = async () => {
-    const [, metaMetricsId] = await dispatch(setParticipateInMetaMetrics(true));
+    const [, metaMetricsId] = await dispatch(
+      setMetaMetricsParticipation(MetaMetricsParticipation.Participate),
+    );
     try {
       trackEvent(
         {
@@ -68,7 +71,9 @@ export default function OnboardingMetametrics() {
   };
 
   const onCancel = async () => {
-    await dispatch(setParticipateInMetaMetrics(false));
+    await dispatch(
+      setMetaMetricsParticipation(MetaMetricsParticipation.DoNotParticipate),
+    );
     history.push(nextRoute);
   };
 

--- a/ui/pages/onboarding-flow/metametrics/metametrics.test.js
+++ b/ui/pages/onboarding-flow/metametrics/metametrics.test.js
@@ -8,7 +8,8 @@ import {
   onboardingMetametricsAgree,
   onboardingMetametricsDisagree,
 } from '../../../../app/_locales/en/messages.json';
-import { setParticipateInMetaMetrics } from '../../../store/actions';
+import { setMetaMetricsParticipation } from '../../../store/actions';
+import { MetaMetricsParticipation } from '../../../../shared/constants/metametrics';
 import OnboardingMetametrics from './metametrics';
 
 const mockPushHistory = jest.fn();
@@ -25,7 +26,7 @@ jest.mock('react-router-dom', () => {
 });
 
 jest.mock('../../../store/actions.ts', () => ({
-  setParticipateInMetaMetrics: jest
+  setMetaMetricsParticipation: jest
     .fn()
     .mockReturnValue(jest.fn((val) => Promise.resolve([val]))),
 }));
@@ -36,7 +37,7 @@ describe('Onboarding Metametrics Component', () => {
   const mockState = {
     metamask: {
       firstTimeFlowType: 'create',
-      participateInMetaMetrics: '',
+      metaMetricsParticipationMode: '',
     },
   };
 
@@ -57,7 +58,7 @@ describe('Onboarding Metametrics Component', () => {
     expect(container).toMatchSnapshot();
   });
 
-  it('should set setParticipateInMetaMetrics to true when clicking agree', async () => {
+  it('should set `setMetaMetricsParticipation` to `Participate` when clicking agree', async () => {
     const { queryByText } = renderWithProvider(
       <OnboardingMetametrics />,
       mockStore,
@@ -68,14 +69,16 @@ describe('Onboarding Metametrics Component', () => {
     fireEvent.click(confirmAgree);
 
     await waitFor(() => {
-      expect(setParticipateInMetaMetrics).toHaveBeenCalledWith(true);
+      expect(setMetaMetricsParticipation).toHaveBeenCalledWith(
+        MetaMetricsParticipation.Participate,
+      );
       expect(mockPushHistory).toHaveBeenCalledWith(
         ONBOARDING_CREATE_PASSWORD_ROUTE,
       );
     });
   });
 
-  it('should set setParticipateInMetaMetrics to false when clicking cancel', async () => {
+  it('should set `setMetaMetricsParticipation` to `DoNotParticipate` when clicking cancel', async () => {
     const { queryByText } = renderWithProvider(
       <OnboardingMetametrics />,
       mockStore,
@@ -86,7 +89,9 @@ describe('Onboarding Metametrics Component', () => {
     fireEvent.click(confirmCancel);
 
     await waitFor(() => {
-      expect(setParticipateInMetaMetrics).toHaveBeenCalledWith(false);
+      expect(setMetaMetricsParticipation).toHaveBeenCalledWith(
+        MetaMetricsParticipation.DoNotParticipate,
+      );
       expect(mockPushHistory).toHaveBeenCalledWith(
         ONBOARDING_CREATE_PASSWORD_ROUTE,
       );

--- a/ui/pages/onboarding-flow/welcome/welcome.js
+++ b/ui/pages/onboarding-flow/welcome/welcome.js
@@ -21,12 +21,15 @@ import { MetaMetricsContext } from '../../../contexts/metametrics';
 import {
   MetaMetricsEventCategory,
   MetaMetricsEventName,
+  ///: BEGIN:ONLY_INCLUDE_IN(build-mmi)
+  MetaMetricsParticipation,
+  ///: END:ONLY_INCLUDE_IN
 } from '../../../../shared/constants/metametrics';
 import {
   setFirstTimeFlowType,
   setTermsOfUseLastAgreed,
   ///: BEGIN:ONLY_INCLUDE_IN(build-mmi)
-  setParticipateInMetaMetrics,
+  setMetaMetricsParticipation,
   ///: END:ONLY_INCLUDE_IN
 } from '../../../store/actions';
 import {
@@ -81,7 +84,9 @@ export default function OnboardingWelcome() {
     ///: END:ONLY_INCLUDE_IN
 
     ///: BEGIN:ONLY_INCLUDE_IN(build-mmi)
-    await dispatch(setParticipateInMetaMetrics(false));
+    await dispatch(
+      setMetaMetricsParticipation(MetaMetricsParticipation.DoNotParticipate),
+    );
     history.push(ONBOARDING_CREATE_PASSWORD_ROUTE);
     ///: END:ONLY_INCLUDE_IN
   };
@@ -116,7 +121,9 @@ export default function OnboardingWelcome() {
     ///: END:ONLY_INCLUDE_IN
 
     ///: BEGIN:ONLY_INCLUDE_IN(build-mmi)
-    await dispatch(setParticipateInMetaMetrics(false));
+    await dispatch(
+      setMetaMetricsParticipation(MetaMetricsParticipation.DoNotParticipate),
+    );
     history.push(ONBOARDING_IMPORT_WITH_SRP_ROUTE);
     ///: END:ONLY_INCLUDE_IN
   };

--- a/ui/pages/onboarding-flow/welcome/welcome.test.js
+++ b/ui/pages/onboarding-flow/welcome/welcome.test.js
@@ -29,7 +29,7 @@ jest.mock('../../../store/actions.ts', () => ({
       return type;
     }),
   ),
-  setParticipateInMetaMetrics: jest.fn().mockReturnValue(
+  setMetaMetricsParticipation: jest.fn().mockReturnValue(
     jest.fn((type) => {
       return type;
     }),

--- a/ui/pages/settings/security-tab/__snapshots__/security-tab.test.js.snap
+++ b/ui/pages/settings/security-tab/__snapshots__/security-tab.test.js.snap
@@ -1436,7 +1436,7 @@ exports[`Security Tab should match snapshot 1`] = `
         </div>
         <div
           class="settings-page__content-item-col"
-          data-testid="participateInMetaMetrics"
+          data-testid="metaMetricsParticipationMode"
         >
           <label
             class="toggle-button toggle-button--off"

--- a/ui/pages/settings/security-tab/security-tab.component.js
+++ b/ui/pages/settings/security-tab/security-tab.component.js
@@ -10,6 +10,7 @@ import {
   MetaMetricsEventCategory,
   MetaMetricsEventKeyType,
   MetaMetricsEventName,
+  MetaMetricsParticipation,
 } from '../../../../shared/constants/metametrics';
 import { IPFS_DEFAULT_GATEWAY_URL } from '../../../../shared/constants/network';
 import {
@@ -56,8 +57,8 @@ export default class SecurityTab extends PureComponent {
     setOpenSeaEnabled: PropTypes.func,
     useNftDetection: PropTypes.bool,
     setUseNftDetection: PropTypes.func,
-    participateInMetaMetrics: PropTypes.bool.isRequired,
-    setParticipateInMetaMetrics: PropTypes.func.isRequired,
+    metaMetricsParticipationMode: PropTypes.bool.isRequired,
+    setMetaMetricsParticipation: PropTypes.func.isRequired,
     incomingTransactionsPreferences: PropTypes.object.isRequired,
     allNetworks: PropTypes.array.isRequired,
     setIncomingTransactionsPreferences: PropTypes.func.isRequired,
@@ -265,7 +266,7 @@ export default class SecurityTab extends PureComponent {
 
   renderMetaMetricsOptIn() {
     const { t } = this.context;
-    const { participateInMetaMetrics, setParticipateInMetaMetrics } =
+    const { metaMetricsParticipationMode, setMetaMetricsParticipation } =
       this.props;
 
     return (
@@ -286,11 +287,17 @@ export default class SecurityTab extends PureComponent {
 
         <div
           className="settings-page__content-item-col"
-          data-testid="participateInMetaMetrics"
+          data-testid="metaMetricsParticipationMode"
         >
           <ToggleButton
-            value={participateInMetaMetrics}
-            onToggle={(value) => setParticipateInMetaMetrics(!value)}
+            value={metaMetricsParticipationMode}
+            onToggle={(value) => {
+              setMetaMetricsParticipation(
+                value === MetaMetricsParticipation.Participate
+                  ? MetaMetricsParticipation.DoNotParticipate
+                  : MetaMetricsParticipation.Participate,
+              );
+            }}
             offLabel={t('off')}
             onLabel={t('on')}
           />

--- a/ui/pages/settings/security-tab/security-tab.container.js
+++ b/ui/pages/settings/security-tab/security-tab.container.js
@@ -4,7 +4,7 @@ import { compose } from 'redux';
 import {
   setIncomingTransactionsPreferences,
   setIpfsGateway,
-  setParticipateInMetaMetrics,
+  setMetaMetricsParticipation,
   setUseCurrencyRateCheck,
   setUseMultiAccountBalanceChecker,
   setUsePhishDetect,
@@ -29,7 +29,7 @@ const mapStateToProps = (state) => {
 
   const {
     incomingTransactionsPreferences,
-    participateInMetaMetrics,
+    metaMetricsParticipationMode,
     usePhishDetect,
     useTokenDetection,
     ipfsGateway,
@@ -51,7 +51,7 @@ const mapStateToProps = (state) => {
     warning,
     incomingTransactionsPreferences,
     allNetworks,
-    participateInMetaMetrics,
+    metaMetricsParticipationMode,
     usePhishDetect,
     useTokenDetection,
     ipfsGateway,
@@ -72,8 +72,8 @@ const mapDispatchToProps = (dispatch) => {
   return {
     setIncomingTransactionsPreferences: (chainId, value) =>
       dispatch(setIncomingTransactionsPreferences(chainId, value)),
-    setParticipateInMetaMetrics: (val) =>
-      dispatch(setParticipateInMetaMetrics(val)),
+    setMetaMetricsParticipation: (val) =>
+      dispatch(setMetaMetricsParticipation(val)),
     setUsePhishDetect: (val) => dispatch(setUsePhishDetect(val)),
     setUseCurrencyRateCheck: (val) => dispatch(setUseCurrencyRateCheck(val)),
     setUseTokenDetection: (val) => dispatch(setUseTokenDetection(val)),

--- a/ui/pages/settings/security-tab/security-tab.test.js
+++ b/ui/pages/settings/security-tab/security-tab.test.js
@@ -98,7 +98,9 @@ describe('Security Tab', () => {
   });
 
   it('toggles metaMetrics', async () => {
-    expect(await toggleCheckbox('participateInMetaMetrics', false)).toBe(true);
+    expect(await toggleCheckbox('metaMetricsParticipationMode', false)).toBe(
+      true,
+    );
   });
 
   it('toggles SRP Quiz', async () => {

--- a/ui/pages/settings/settings-tab/settings-tab.container.js
+++ b/ui/pages/settings/settings-tab/settings-tab.container.js
@@ -5,7 +5,7 @@ import {
   updateCurrentLocale,
   setUseNativeCurrencyAsPrimaryCurrencyPreference,
   setHideZeroBalanceTokens,
-  setParticipateInMetaMetrics,
+  setMetaMetricsParticipation,
   setTheme,
 } from '../../../store/actions';
 import { getTokenList, getPreferences, getTheme } from '../../../selectors';
@@ -52,8 +52,8 @@ const mapDispatchToProps = (dispatch) => {
     setUseNativeCurrencyAsPrimaryCurrencyPreference: (value) => {
       return dispatch(setUseNativeCurrencyAsPrimaryCurrencyPreference(value));
     },
-    setParticipateInMetaMetrics: (val) =>
-      dispatch(setParticipateInMetaMetrics(val)),
+    setMetaMetricsParticipation: (val) =>
+      dispatch(setMetaMetricsParticipation(val)),
     setHideZeroBalanceTokens: (value) =>
       dispatch(setHideZeroBalanceTokens(value)),
     setTheme: (val) => dispatch(setTheme(val)),

--- a/ui/pages/unlock-page/unlock-page.stories.js
+++ b/ui/pages/unlock-page/unlock-page.stories.js
@@ -30,7 +30,7 @@ DefaultStory.storyName = 'Default';
 
 DefaultStory.args = {
   forceUpdateMetamaskState: () => ({
-    participateInMetaMetrics: true,
+    metaMetricsParticipationMode: true,
   }),
 };
 

--- a/ui/store/actions.test.js
+++ b/ui/store/actions.test.js
@@ -7,7 +7,10 @@ import MetaMaskController from '../../app/scripts/metamask-controller';
 import { HardwareDeviceNames } from '../../shared/constants/hardware-wallets';
 import { GAS_LIMITS } from '../../shared/constants/gas';
 import { ORIGIN_METAMASK } from '../../shared/constants/app';
-import { MetaMetricsNetworkEventSource } from '../../shared/constants/metametrics';
+import {
+  MetaMetricsNetworkEventSource,
+  MetaMetricsParticipation,
+} from '../../shared/constants/metametrics';
 import * as actions from './actions';
 import { setBackgroundConnection } from './background-connection';
 
@@ -1626,26 +1629,30 @@ describe('Actions', () => {
     });
   });
 
-  describe('#setParticipateInMetaMetrics', () => {
+  describe('#setMetaMetricsParticipation', () => {
     beforeAll(() => {
       window.sentry = {
         toggleSession: jest.fn(),
         endSession: jest.fn(),
       };
     });
-    it('sets participateInMetaMetrics to true', async () => {
+    it('sets metaMetricsParticipationMode to `Participate`', async () => {
       const store = mockStore();
-      const setParticipateInMetaMetricsStub = jest.fn((_, cb) => cb());
+      const setMetaMetricsParticipationStub = jest.fn((_, cb) => cb());
 
       background.getApi.returns({
-        setParticipateInMetaMetrics: setParticipateInMetaMetricsStub,
+        setMetaMetricsParticipation: setMetaMetricsParticipationStub,
       });
 
       setBackgroundConnection(background.getApi());
 
-      await store.dispatch(actions.setParticipateInMetaMetrics(true));
-      expect(setParticipateInMetaMetricsStub).toHaveBeenCalledWith(
-        true,
+      await store.dispatch(
+        actions.setMetaMetricsParticipation(
+          MetaMetricsParticipation.Participate,
+        ),
+      );
+      expect(setMetaMetricsParticipationStub).toHaveBeenCalledWith(
+        MetaMetricsParticipation.Participate,
         expect.anything(),
       );
       expect(window.sentry.toggleSession).toHaveBeenCalled();

--- a/ui/store/actions.ts
+++ b/ui/store/actions.ts
@@ -78,6 +78,7 @@ import {
   MetaMetricsPageObject,
   MetaMetricsPageOptions,
   MetaMetricsPagePayload,
+  MetaMetricsParticipation,
   MetaMetricsReferrerObject,
 } from '../../shared/constants/metametrics';
 import { parseSmartTransactionsError } from '../pages/swaps/swaps.util';
@@ -2917,20 +2918,20 @@ export function setAccountDetailsAddress(address: string) {
   };
 }
 
-export function setParticipateInMetaMetrics(
-  participationPreference: boolean,
+export function setMetaMetricsParticipation(
+  participationMode: MetaMetricsParticipation,
 ): ThunkAction<
-  Promise<[boolean, string]>,
+  Promise<[MetaMetricsParticipation, string]>,
   MetaMaskReduxState,
   unknown,
   AnyAction
 > {
   return (dispatch: MetaMaskReduxDispatch) => {
-    log.debug(`background.setParticipateInMetaMetrics`);
+    log.debug(`background.setMetaMetricsParticipation`);
     return new Promise((resolve, reject) => {
       callBackgroundMethod<string>(
-        'setParticipateInMetaMetrics',
-        [participationPreference],
+        'setMetaMetricsParticipation',
+        [participationMode],
         (err, metaMetricsId) => {
           log.debug(err);
           if (err) {
@@ -2947,9 +2948,9 @@ export function setParticipateInMetaMetrics(
 
           dispatch({
             type: actionConstants.SET_PARTICIPATE_IN_METAMETRICS,
-            value: participationPreference,
+            value: participationMode,
           });
-          resolve([participationPreference, metaMetricsId as string]);
+          resolve([participationMode, metaMetricsId as string]);
         },
       );
     });


### PR DESCRIPTION
## **Description**

This PR makes two changes:

1. Changes logic in the MetaMetrics controller so that the MetaMetrics ID persists when the user disables MetaMetrics data collection.

2. Changes the boolean `metaMetricsParticipation` property in the controller state to a property `metaMetricsParticipationMode` that takes an enum that includes `Participate`, `DoNotParticipate` and `NotChosen`. This work borrows heavily from @brad-decker's PR #16744.

## **Related issues**

Fixes: #21728

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've clearly explained what problem this PR is solving and how it is solved.
- [ ] I've linked related issues
- [ ] I've included manual testing steps
- [ ] I've included screenshots/recordings if applicable
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [ ] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
