### PR TITLE
Fix tooltip icon coloring in row component

### DIFF
--- a/ui/components/app/confirm/shared/info/row/row.tsx
+++ b/ui/components/app/confirm/shared/info/row/row.tsx
@@ -48,6 +48,12 @@ const TOOLTIP_ICONS = {
   [ConfirmInfoRowVariant.Warning]: IconName.Warning,
 };
 
+const TOOLTIP_ICON_COLORS = {
+  [ConfirmInfoRowVariant.Default]: Color.iconMuted,
+  [ConfirmInfoRowVariant.Critical]: Color.errorAlternative,
+  [ConfirmInfoRowVariant.Warning]: Color.warningAlternative,
+};
+
 export const ConfirmInfoRowContext = createContext({
   variant: ConfirmInfoRowVariant.Default,
 });
@@ -92,7 +98,7 @@ export const ConfirmInfoRow = ({
             <Icon
               name={TOOLTIP_ICONS[variant]}
               marginLeft={1}
-              color={TEXT_COLORS[variant] as unknown as IconColor}
+              color={TOOLTIP_ICON_COLORS[variant] as unknown as IconColor}
             />
           </Tooltip>
         )}


### PR DESCRIPTION
## **Description**

By request of @eriknson this PR changes the color of the tooltip icon for the default variant of `ConfirmInfoRow`.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

![image](https://github.com/MetaMask/metamask-extension/assets/1561200/7cd0b841-e8e2-4563-843e-cca6bb85bd2a)

### **After**

![image](https://github.com/MetaMask/metamask-extension/assets/1561200/cc3d4a85-2204-41e0-97f4-62dba8d15bdd)
