### PR TITLE
Adding `ModalFooter` component

### DIFF
--- a/ui/components/component-library/component-library-components.scss
+++ b/ui/components/component-library/component-library-components.scss
@@ -42,6 +42,7 @@
 @import 'modal-content/modal-content';
 @import 'modal-overlay/modal-overlay';
 @import 'modal-body/modal-body';
+@import 'modal-footer/modal-footer';
 @import 'popover/popover';
 @import 'select-button/select-button';
 @import 'select-wrapper/select-wrapper';

--- a/ui/components/component-library/index.ts
+++ b/ui/components/component-library/index.ts
@@ -79,6 +79,8 @@ export { Modal, useModalContext } from './modal';
 export type { ModalProps } from './modal';
 export { ModalBody } from './modal-body';
 export type { ModalBodyProps } from './modal-body';
+export { ModalFooter } from './modal-footer';
+export type { ModalFooterProps } from './modal-footer';
 
 // Molecules
 export { BannerBase } from './banner-base';

--- a/ui/components/component-library/modal-content/README.mdx
+++ b/ui/components/component-library/modal-content/README.mdx
@@ -74,6 +74,7 @@ import {
   ModalContentSize,
   ModalHeader,
   ModalBody,
+  ModalFooter,
 } from '../../component-library';
 
 <ModalContent size={ModalContentSize.Sm}>
@@ -83,6 +84,7 @@ import {
   <ModalBody>
     <Text marginBottom={4}>This ModalContent is using size: sm</Text>
   </ModalBody>
+  <ModalFooter onSubmit={handleOnClose}>
 </ModalContent>;
 
 <ModalContent size={ModalContentSize.Md}>
@@ -97,6 +99,7 @@ import {
     This ModalContent is using size: lg
   </ModalHeader>
   <Text marginBottom={4}>This ModalContent is using size: lg</Text>
+  <ModalFooter onSubmit={handleOnClose}>
 </ModalContent>;
 
 /* Using a className
@@ -112,5 +115,6 @@ import {
     This ModalContent has size set using modalDialogProps and adding a className
     setting a max width (max-width: 800px)
   </Text>
+  <ModalFooter onSubmit={handleOnClose}>
 </ModalContent>;
 ```

--- a/ui/components/component-library/modal-content/modal-content.stories.tsx
+++ b/ui/components/component-library/modal-content/modal-content.stories.tsx
@@ -11,6 +11,7 @@ import {
   Modal,
   ModalHeader,
   ModalBody,
+  ModalFooter,
 } from '..';
 
 import { ModalContent } from './modal-content';
@@ -65,15 +66,10 @@ export const DefaultStory: StoryFn<typeof ModalContent> = (args) => {
           <ModalBody>
             <Text>Modal Content</Text>
           </ModalBody>
-          <Box padding={4}>
-            <Button
-              variant={ButtonVariant.Primary}
-              onClick={handleOnClick}
-              block
-            >
-              Close
-            </Button>
-          </Box>
+          <ModalFooter
+            onSubmit={handleOnClick}
+            submitButtonProps={{ children: 'Close' }}
+          />
         </ModalContent>
       </Modal>
     </>
@@ -97,21 +93,19 @@ export const Children: StoryFn<typeof ModalContent> = (args) => {
           <ModalHeader marginBottom={4}>Modal Header</ModalHeader>
           <ModalBody>
             <Text marginBottom={4}>
-              The ModalContent with ModalHeader and Text components as children
+              The ModalContent with ModalHeader, ModalBody, ModalFooter as
+              children
             </Text>
-            <Button
-              marginBottom={4}
-              variant={ButtonVariant.Primary}
-              onClick={handleOnClick}
-            >
-              Close
-            </Button>
             <LoremIpsum />
             <LoremIpsum />
             <LoremIpsum />
             <LoremIpsum />
             <LoremIpsum />
           </ModalBody>
+          <ModalFooter
+            onSubmit={handleOnClick}
+            submitButtonProps={{ children: 'Close' }}
+          />
         </ModalContent>
       </Modal>
     </>
@@ -185,11 +179,10 @@ export const Size: StoryFn<typeof ModalContent> = (args) => {
                 )}
               </Text>
             </ModalBody>
-            <Box padding={4}>
-              <Button onClick={() => setCurrentSize(null)} block>
-                Close
-              </Button>
-            </Box>
+            <ModalFooter
+              onSubmit={() => setCurrentSize(null)}
+              submitButtonProps={{ children: 'Close' }}
+            />
           </ModalContent>
         </Modal>
       )}

--- a/ui/components/component-library/modal-footer/README.mdx
+++ b/ui/components/component-library/modal-footer/README.mdx
@@ -1,0 +1,147 @@
+import { Controls, Canvas } from '@storybook/blocks';
+
+import * as ModalFooterStories from './modal-footer.stories';
+
+# ModalFooter
+
+`ModalFooter` is a footer component that handles the submit and cancel buttons of the [`Modal`](?path=/docs/components-componentlibrary-modal--docs)
+
+<Canvas of={ModalFooterStories.DefaultStory} />
+
+## Props
+
+<Controls of={ModalFooterStories.DefaultStory} />
+
+### On Submit
+
+The `onSubmit` prop is a function that will be called when the submit button is clicked.
+
+<Canvas of={ModalFooterStories.OnSubmit} />
+
+```jsx
+import { ModalFooter } from '../../component-library';
+
+<ModalFooter onSubmit={handleOnSubmit} />;
+```
+
+### On Cancel
+
+The `onCancel` prop is a function that will be called when the cancel button is clicked.
+
+<Canvas of={ModalFooterStories.OnCancel} />
+
+```jsx
+import { ModalFooter } from '../../component-library';
+
+<ModalFooter onCancel={handleOnCancel} />;
+```
+
+### Submit Button Props Cancel Button Props
+
+The `submitButtonProps` and `cancelButtonProps` props are objects that will be spread onto the submit and cancel buttons respectively. This allows you to pass in any valid `Button` props to the submit and cancel buttons. Ideally button strings are short but if they are long the submit and cancel buttons will stack vertically.
+
+Note: The stacking of the submit and cancel button will not work if you construct your own `ModalFooter` component using the `Button` components. Additonal CSS is needed.
+
+<Canvas of={ModalFooterStories.SubmitButtonPropsCancelButtonProps} />
+
+```jsx
+import { ModalFooter } from '../../component-library';
+
+<ModalFooter
+  onSubmit={handleOnSubmit}
+  submitButtonProps={{ children: 'I want to approve' }}
+  onCancel={handleOnCancel}
+  cancelButtonProps={{
+    children: 'Cancel this',
+  }}
+/>;
+```
+
+### Children
+
+Use the `children` prop to pass any in any valid React children to the `ModalFooter`. The children will appear above the submit and cancel buttons and outside of the internal `Container` component. If you require children above the buttons, you can build your own `ModalFooter` component using the `Button` and `Container` components.
+
+<Canvas of={ModalFooterStories.Children} />
+
+```jsx
+import {
+  BlockSize,
+  Display,
+  FlexDirection,
+} from '../../../helpers/constants/design-system';
+import {
+  ModalFooter,
+  Checkbox,
+  Container,
+  ContainerMaxWidth,
+} from '../../component-library';
+
+const [checked, setChecked] = React.useState(false);
+const handleCheckboxChange = () => setChecked(!checked);
+
+<ModalFooter
+  display={Display.Flex}
+  flexDirection={FlexDirection.Column}
+  alignItems={AlignItems.flexStart}
+  gap={4}
+  onSubmit={handleOnSubmit}
+  onCancel={handleOnCancel}
+>
+  <Container
+    maxWidth={ContainerMaxWidth.Sm}
+    marginLeft="auto"
+    marginRight="auto"
+    marginBottom={4}
+  >
+    <Checkbox
+      label="I agree to the terms and conditions"
+      isChecked={checked}
+      onChange={handleCheckboxChange}
+    />
+  </Container>
+</ModalFooter>;
+```
+
+### Container Props
+
+The `ModalFooter` has an internal container that prevents the buttons from being large widths. You can override these props by passing in a `containerProps` prop. Below shows the `Container` with different `maxWidth` and `backgroundColor` props. To see the button retain it's width at different `ModalContent` sizes see the [ModalContent size story](?path=/story/components-componentlibrary-modalcontent--size).
+
+- Light red shows the `Container` bounding box
+- Light blue shows the `ModalFooter` bounding box
+
+<Canvas of={ModalFooterStories.ContainerProps} />
+
+```jsx
+import {
+  ModalFooter,
+  Box,
+  Display,
+  FlexDirection,
+  BackgroundColor,
+  ContainerMaxWidth,
+} from '../../component-library';
+
+<Box display={Display.Flex} flexDirection={FlexDirection.Column} gap={4}>
+  <ModalFooter
+    containerProps={{
+      maxWidth: ContainerMaxWidth.Md,
+      backgroundColor: BackgroundColor.errorMuted,
+    }}
+    backgroundColor={BackgroundColor.primaryMuted}
+  />
+  <ModalFooter
+    containerProps={{
+      maxWidth: ContainerMaxWidth.Lg,
+      backgroundColor: BackgroundColor.errorMuted,
+    }}
+    backgroundColor={BackgroundColor.primaryMuted}
+  />
+  <ModalFooter
+    containerProps={{
+      maxWidth: null,
+      backgroundColor: BackgroundColor.errorMuted,
+    }}
+    backgroundColor={BackgroundColor.primaryMuted}
+  />
+</Box>;
+```

--- a/ui/components/component-library/modal-footer/__snapshots__/modal-footer.test.tsx.snap
+++ b/ui/components/component-library/modal-footer/__snapshots__/modal-footer.test.tsx.snap
@@ -1,0 +1,13 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ModalFooter should match snapshot 1`] = `
+<div>
+  <div
+    class="mm-box mm-modal-footer mm-box--padding-top-4 mm-box--padding-right-4 mm-box--padding-left-4"
+  >
+    <div
+      class="mm-box mm-container mm-container--max-width-sm mm-box--margin-right-auto mm-box--margin-left-auto mm-box--display-flex mm-box--gap-4 mm-box--flex-wrap-wrap mm-box--align-items-center"
+    />
+  </div>
+</div>
+`;

--- a/ui/components/component-library/modal-footer/index.ts
+++ b/ui/components/component-library/modal-footer/index.ts
@@ -1,0 +1,6 @@
+export { ModalFooter } from './modal-footer';
+export type {
+  ModalFooterProps,
+  ModalFooterComponent,
+  ModalFooterStyleUtilityProps,
+} from './modal-footer.types';

--- a/ui/components/component-library/modal-footer/modal-footer.scss
+++ b/ui/components/component-library/modal-footer/modal-footer.scss
@@ -1,0 +1,7 @@
+.mm-modal-footer {
+  &__button {
+    // wrap buttons if content overflows the width of the button
+    // button take up all available space whether horizontally or vertically aligned
+    flex: 1 0 auto;
+  }
+}

--- a/ui/components/component-library/modal-footer/modal-footer.stories.tsx
+++ b/ui/components/component-library/modal-footer/modal-footer.stories.tsx
@@ -1,0 +1,167 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { Box, Container, Checkbox, ContainerMaxWidth } from '..';
+import {
+  BackgroundColor,
+  Display,
+  FlexDirection,
+} from '../../../helpers/constants/design-system';
+import { ModalFooter } from './modal-footer';
+
+import README from './README.mdx';
+
+const meta: Meta<typeof ModalFooter> = {
+  title: 'Components/ComponentLibrary/ModalFooter',
+  component: ModalFooter,
+  parameters: {
+    docs: {
+      page: README,
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof ModalFooter>;
+
+export const DefaultStory: Story = {
+  argTypes: {
+    className: {
+      control: 'text',
+    },
+    children: {
+      control: 'text',
+    },
+    submitButtonProps: {
+      control: 'object',
+    },
+    onSubmit: {
+      action: 'onSubmit',
+    },
+    cancelButtonProps: {
+      control: 'object',
+    },
+    onCancel: {
+      action: 'onCancel',
+    },
+  },
+};
+
+DefaultStory.storyName = 'Default';
+
+export const OnSubmit: Story = {
+  argTypes: {
+    onSubmit: {
+      action: 'onSubmit',
+    },
+  },
+  render: (args) => <ModalFooter {...args} />,
+};
+
+export const OnCancel: Story = {
+  argTypes: {
+    onCancel: {
+      action: 'onCancel',
+    },
+  },
+  render: (args) => <ModalFooter {...args} />,
+};
+
+export const SubmitButtonPropsCancelButtonProps: Story = {
+  argTypes: {
+    onSubmit: {
+      action: 'onSubmit',
+    },
+    onCancel: {
+      action: 'onCancel',
+    },
+  },
+  args: {
+    submitButtonProps: {
+      children: 'I want to approve',
+    },
+    cancelButtonProps: {
+      children: 'Cancel this',
+    },
+  },
+};
+
+export const ContainerProps: Story = {
+  argTypes: {
+    onCancel: {
+      action: 'onCancel',
+    },
+    onSubmit: {
+      action: 'onSubmit',
+    },
+  },
+  args: {
+    containerProps: {
+      maxWidth: null,
+    },
+  },
+  render: (args) => {
+    return (
+      <Box display={Display.Flex} flexDirection={FlexDirection.Column} gap={4}>
+        <ModalFooter
+          {...args}
+          containerProps={{
+            maxWidth: ContainerMaxWidth.Md,
+            backgroundColor: BackgroundColor.errorMuted,
+          }}
+          backgroundColor={BackgroundColor.primaryMuted}
+        />
+        <ModalFooter
+          {...args}
+          containerProps={{
+            maxWidth: ContainerMaxWidth.Lg,
+            backgroundColor: BackgroundColor.errorMuted,
+          }}
+          backgroundColor={BackgroundColor.primaryMuted}
+        />
+        <ModalFooter
+          {...args}
+          containerProps={{
+            maxWidth: null,
+            backgroundColor: BackgroundColor.errorMuted,
+          }}
+          backgroundColor={BackgroundColor.primaryMuted}
+        />
+      </Box>
+    );
+  },
+};
+
+export const Children: Story = {
+  argTypes: {
+    onCancel: {
+      action: 'onCancel',
+    },
+    onSubmit: {
+      action: 'onSubmit',
+    },
+  },
+  args: {
+    children: 'Lorem ipsum dolor sit ',
+  },
+  render: (args) => {
+    const [checked, setChecked] = React.useState(false);
+    const handleCheckboxChange = () => setChecked(!checked);
+    return (
+      <ModalFooter {...args}>
+        <Container
+          maxWidth={ContainerMaxWidth.Sm}
+          marginLeft="auto"
+          marginRight="auto"
+          marginBottom={4}
+        >
+          <Checkbox
+            label="I agree to the terms and conditions"
+            isChecked={checked}
+            onChange={handleCheckboxChange}
+          />
+        </Container>
+      </ModalFooter>
+    );
+  },
+};

--- a/ui/components/component-library/modal-footer/modal-footer.test.tsx
+++ b/ui/components/component-library/modal-footer/modal-footer.test.tsx
@@ -1,0 +1,98 @@
+import React from 'react';
+import { renderWithProvider } from '../../../../test/jest';
+
+import { ModalFooter } from './modal-footer';
+
+describe('ModalFooter', () => {
+  it('should render ModalFooter without error', () => {
+    const { getByTestId } = renderWithProvider(
+      <ModalFooter data-testid="modal-footer" />,
+    );
+    expect(getByTestId('modal-footer')).toBeDefined();
+    expect(getByTestId('modal-footer')).toHaveClass('mm-modal-footer');
+  });
+  it('should match snapshot', () => {
+    const { container } = renderWithProvider(<ModalFooter />);
+    expect(container).toMatchSnapshot();
+  });
+  it('should render with and additional className', () => {
+    const { getByTestId } = renderWithProvider(
+      <ModalFooter data-testid="modal-footer" className="test-class" />,
+    );
+    expect(getByTestId('modal-footer')).toHaveClass('test-class');
+  });
+  it('should fire the onSubmit function when clicked and pass additional props to the confirm button', () => {
+    const onSubmit = jest.fn();
+    const { getByText, getByTestId } = renderWithProvider(
+      <ModalFooter
+        onSubmit={onSubmit}
+        submitButtonProps={{
+          'data-testid': 'confirm-button',
+        }}
+      />,
+    );
+    getByText('Confirm').click();
+    expect(onSubmit).toHaveBeenCalled();
+    expect(getByTestId('confirm-button')).toBeDefined();
+  });
+  it('should render the confirm button with custom class without overriding the default class', () => {
+    const onSubmit = jest.fn();
+    const { getByText } = renderWithProvider(
+      <ModalFooter
+        onSubmit={onSubmit}
+        submitButtonProps={{
+          className: 'test-class',
+        }}
+      />,
+    );
+    expect(getByText('Confirm')).toHaveClass(
+      'mm-modal-footer__button test-class',
+    );
+  });
+  it('should fire the onCancel function when clicked and pass additional props to the cancel button', () => {
+    const onCancel = jest.fn();
+    const { getByText, getByTestId } = renderWithProvider(
+      <ModalFooter
+        onCancel={onCancel}
+        cancelButtonProps={{
+          'data-testid': 'cancel-button',
+        }}
+      />,
+    );
+    getByText('Cancel').click();
+    expect(onCancel).toHaveBeenCalled();
+    expect(getByTestId('cancel-button')).toBeDefined();
+  });
+  it('should render the cancel button with custom class without overriding the default class', () => {
+    const onCancel = jest.fn();
+    const { getByText } = renderWithProvider(
+      <ModalFooter
+        onCancel={onCancel}
+        cancelButtonProps={{
+          className: 'test-class',
+        }}
+      />,
+    );
+    expect(getByText('Cancel')).toHaveClass(
+      'mm-modal-footer__button test-class',
+    );
+  });
+  it('should render children', () => {
+    const { getByText } = renderWithProvider(
+      <ModalFooter>
+        <div>Test</div>
+      </ModalFooter>,
+    );
+    expect(getByText('Test')).toBeDefined();
+  });
+  it('should render with containerProps', () => {
+    const { getByTestId } = renderWithProvider(
+      <ModalFooter
+        containerProps={{
+          'data-testid': 'container',
+        }}
+      />,
+    );
+    expect(getByTestId('container')).toBeDefined();
+  });
+});

--- a/ui/components/component-library/modal-footer/modal-footer.tsx
+++ b/ui/components/component-library/modal-footer/modal-footer.tsx
@@ -1,0 +1,87 @@
+import React from 'react';
+import classnames from 'classnames';
+import { useI18nContext } from '../../../hooks/useI18nContext';
+import {
+  AlignItems,
+  Display,
+  FlexWrap,
+} from '../../../helpers/constants/design-system';
+import type { PolymorphicRef, BoxProps } from '../box';
+import type { ButtonProps } from '../button';
+import {
+  Box,
+  Button,
+  ButtonSize,
+  ButtonVariant,
+  Container,
+  ContainerMaxWidth,
+} from '..';
+import { ModalFooterProps, ModalFooterComponent } from './modal-footer.types';
+
+export const ModalFooter: ModalFooterComponent = React.forwardRef(
+  <C extends React.ElementType = 'footer'>(
+    {
+      className = '',
+      children,
+      submitButtonProps,
+      onSubmit,
+      cancelButtonProps,
+      onCancel,
+      containerProps,
+      ...props
+    }: ModalFooterProps<C>,
+    ref?: PolymorphicRef<C>,
+  ) => {
+    const t = useI18nContext();
+    return (
+      <Box
+        className={classnames('mm-modal-footer', className)}
+        ref={ref}
+        paddingLeft={4}
+        paddingRight={4}
+        paddingTop={4}
+        {...(props as BoxProps<C>)}
+      >
+        {children}
+        <Container
+          maxWidth={ContainerMaxWidth.Sm}
+          display={Display.Flex}
+          alignItems={AlignItems.center}
+          flexWrap={FlexWrap.Wrap}
+          marginLeft="auto"
+          marginRight="auto"
+          gap={4}
+          {...containerProps}
+        >
+          {onCancel && (
+            <Button
+              onClick={onCancel}
+              children={t('cancel')}
+              variant={ButtonVariant.Secondary}
+              {...(cancelButtonProps as ButtonProps<'button'>)}
+              size={ButtonSize.Lg} // TODO: There is a type issue with using variant, size and spreading props after size
+              className={classnames(
+                'mm-modal-footer__button',
+                cancelButtonProps?.className || '',
+              )}
+            />
+          )}
+          {onSubmit && (
+            <Button
+              size={ButtonSize.Lg}
+              onClick={onSubmit}
+              children={t('confirm')}
+              {...submitButtonProps}
+              className={classnames(
+                'mm-modal-footer__button',
+                submitButtonProps?.className || '',
+              )}
+            />
+          )}
+        </Container>
+      </Box>
+    );
+  },
+);
+
+export default ModalFooter;

--- a/ui/components/component-library/modal-footer/modal-footer.types.ts
+++ b/ui/components/component-library/modal-footer/modal-footer.types.ts
@@ -1,0 +1,46 @@
+import React from 'react';
+import type { ContainerProps } from '../container';
+
+import type {
+  StyleUtilityProps,
+  PolymorphicComponentPropWithRef,
+} from '../box';
+import type { ButtonProps } from '../button';
+
+export interface ModalFooterStyleUtilityProps extends StyleUtilityProps {
+  /**
+   * Additional className to add to the ModalFooter
+   */
+  className?: string;
+  /**
+   * The custom content of the ModalFooter
+   */
+  children?: React.ReactNode;
+  /**
+   * The submit button click event handler if this exists the submit button will be displayed
+   */
+  onSubmit?: () => void;
+  /**
+   * Additional props to pass to the submit button
+   */
+  submitButtonProps?: ButtonProps<'button'>;
+  /**
+   * The cancel button click event handler if this exists the cancel button will be displayed
+   */
+  onCancel?: () => void;
+  /**
+   * Additional props to pass to the cancel button
+   */
+  cancelButtonProps?: ButtonProps<'button'>;
+  /**
+   * Additional props to pass to the internal Container component that wraps the buttons
+   */
+  containerProps?: ContainerProps<'div'>;
+}
+
+export type ModalFooterProps<C extends React.ElementType> =
+  PolymorphicComponentPropWithRef<C, ModalFooterStyleUtilityProps>;
+
+export type ModalFooterComponent = <C extends React.ElementType = 'footer'>(
+  props: ModalFooterProps<C>,
+) => React.ReactElement | null;

--- a/ui/components/component-library/modal/README.mdx
+++ b/ui/components/component-library/modal/README.mdx
@@ -33,7 +33,7 @@ When the modal opens:
 
 ```jsx
 import React, { useState, useRef } from 'react';
-import { Modal, ModalOverlay, ModalContent, ModalHeader, ModalBody, Text, Button } from '../../component-library';
+import { Modal, ModalOverlay, ModalContent, ModalHeader, ModalBody, ModalFooter, Text, Button } from '../../component-library';
 
 const [open, setOpen] = useState(false);
 
@@ -58,6 +58,7 @@ const handleOnClose = () => {
     <ModalBody>
       <Text>ModalBody children</Text>
     </ModalBody>
+    <ModalFooter onSubmit={handleOnClose} onCancel={handleOnCancel}>
   </ModalContent>
 </Modal>
 ```

--- a/ui/components/component-library/modal/modal.stories.tsx
+++ b/ui/components/component-library/modal/modal.stories.tsx
@@ -9,15 +9,15 @@ import {
   ModalContent,
   ModalHeader,
   ModalBody,
+  ModalFooter,
   Text,
   Button,
   ButtonLink,
   ButtonLinkSize,
-  ButtonVariant,
+  TextFieldSearch,
   IconName,
   Box,
 } from '..';
-import { TextFieldSearch } from '../text-field-search/deprecated';
 import { Modal } from './modal';
 
 import README from './README.mdx';
@@ -131,7 +131,6 @@ const Template: StoryFn<typeof Modal> = (args) => {
             >
               {showMoreModalContent ? 'Hide' : 'Show more'}
             </ButtonLink>
-
             {showMoreModalContent && (
               <>
                 <LoremIpsum marginTop={8} />
@@ -143,10 +142,7 @@ const Template: StoryFn<typeof Modal> = (args) => {
               </>
             )}
           </ModalBody>
-          <Box padding={4} display={Display.Flex} gap={4}>
-            <Button variant={ButtonVariant.Secondary}>Cancel</Button>
-            <Button>Confirm</Button>
-          </Box>
+          <ModalFooter onSubmit={handleOnClose} onCancel={handleOnClose} />
         </ModalContent>
       </Modal>
       {showLoremIpsum && (
@@ -190,7 +186,7 @@ IsClosedOnEscapeKey.args = {
 };
 
 export const InitialFocusRef: StoryFn<typeof Modal> = (args) => {
-  const inputRef = React.useRef<HTMLDivElement>(null);
+  const inputRef = React.useRef<HTMLInputElement>(null);
   const [{ isOpen }, updateArgs] = useArgs();
   const handleOnClick = () => {
     updateArgs({ isOpen: true });


### PR DESCRIPTION
## **Description**

Creating the `ModalFooter` component to provide a consistent consolidated footer for all Modal UI

## **Related issues**

Fixes: #18034

## **Manual testing steps**

1. Go to the storybook build of this PR
2. Search `ModalFooter` in the search bar
3. Find `ModalFooter` component
4. Read documentation, check stories, check controls

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

No `ModalFooter` component existed before. I have added before after to other modal sub components in comments

### **After**

https://github.com/MetaMask/metamask-extension/assets/8112138/bc2067b6-26f5-4576-97ec-43e8f9389af5

100% test coverage

<img width="672" alt="Screenshot 2024-01-04 at 6 08 57 PM" src="https://github.com/MetaMask/metamask-extension/assets/8112138/acf634bc-74b2-4144-a31f-185d6bda72f5">

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained what problem this PR is solving and how it is solved.
- [x] I've linked related issues
- [x] I've included manual testing steps
- [x] I've included screenshots/recordings if applicable
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [x] I’ve properly set the pull request status:
  - [x] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
