### PR TITLE
[WIP]: fetch token fiat balance before import

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -3312,6 +3312,8 @@ export default class MetamaskController extends EventEmitter {
       addDetectedTokens:
         tokensController.addDetectedTokens.bind(tokensController),
       addImportedTokens: tokensController.addTokens.bind(tokensController),
+      addTemporaryTokens:
+        tokensController.addTemporaryTokens.bind(tokensController),
       ignoreTokens: tokensController.ignoreTokens.bind(tokensController),
       getBalancesInSingleCall:
         assetsContractController.getBalancesInSingleCall.bind(

--- a/ui/components/multichain/import-tokens-modal/import-tokens-modal-confirm.js
+++ b/ui/components/multichain/import-tokens-modal/import-tokens-modal-confirm.js
@@ -23,7 +23,6 @@ import { getPendingTokens } from '../../../ducks/metamask/metamask';
 export const ImportTokensModalConfirm = ({ onBackClick, onImportClick }) => {
   const t = useI18nContext();
   const pendingTokens = useSelector(getPendingTokens);
-
   return (
     <Box paddingTop={4} paddingBottom={4}>
       <Text textAlign={TextAlign.Center}>{t('likeToImportTokens')}</Text>
@@ -47,7 +46,7 @@ export const ImportTokensModalConfirm = ({ onBackClick, onImportClick }) => {
           className="import-tokens-modal__confirm-token-list"
         >
           {Object.entries(pendingTokens).map(([address, token]) => {
-            const { name, symbol } = token;
+            const { name } = token;
             return (
               <Box
                 key={address}
@@ -70,7 +69,7 @@ export const ImportTokensModalConfirm = ({ onBackClick, onImportClick }) => {
                       variant={TextVariant.bodySm}
                       color={TextColor.textAlternative}
                     >
-                      {symbol}
+                      <TokenBalance token={token} />
                     </Text>
                   </Box>
                 </Box>
@@ -78,7 +77,7 @@ export const ImportTokensModalConfirm = ({ onBackClick, onImportClick }) => {
                   className="import-tokens-modal__token-balance"
                   alignItems={AlignItems.flexStart}
                 >
-                  <TokenBalance token={token} />
+                  <TokenBalance token={token} showFiat />
                 </Box>
               </Box>
             );

--- a/ui/components/ui/token-balance/token-balance.js
+++ b/ui/components/ui/token-balance/token-balance.js
@@ -2,11 +2,24 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import CurrencyDisplay from '../currency-display';
 import { useTokenTracker } from '../../../hooks/useTokenTracker';
+import { useTokenFiatAmount } from '../../../hooks/useTokenFiatAmount';
+import { useIsOriginalTokenSymbol } from '../../../hooks/useIsOriginalTokenSymbol';
+import { Text } from '../../component-library';
 
-export default function TokenBalance({ className, token, ...restProps }) {
+export default function TokenBalance({
+  className,
+  token,
+  showFiat,
+  ...restProps
+}) {
   const { tokensWithBalances } = useTokenTracker({ tokens: [token] });
-
-  const { string, symbol } = tokensWithBalances[0] || {};
+  const { string, symbol, address } = tokensWithBalances[0] || {};
+  const formattedFiat = useTokenFiatAmount(address, string, symbol);
+  const isOriginalTokenSymbol = useIsOriginalTokenSymbol(address, symbol);
+  const fiatValue = isOriginalTokenSymbol ? formattedFiat : null;
+  if (showFiat) {
+    return <Text>{fiatValue}</Text>;
+  }
   return (
     <CurrencyDisplay
       className={className}
@@ -24,6 +37,7 @@ TokenBalance.propTypes = {
     decimals: PropTypes.number,
     symbol: PropTypes.string,
   }).isRequired,
+  showFiat: PropTypes.bool,
 };
 
 TokenBalance.defaultProps = {

--- a/ui/store/actions.ts
+++ b/ui/store/actions.ts
@@ -1869,6 +1869,24 @@ export function addImportedTokens(
   };
 }
 
+export function addTemporaryTokens(
+  tokensToImport: Token[],
+  networkClientId?: NetworkClientId,
+): ThunkAction<void, MetaMaskReduxState, unknown, AnyAction> {
+  return async (dispatch: MetaMaskReduxDispatch) => {
+    try {
+      await submitRequestToBackground('addTemporaryTokens', [
+        tokensToImport,
+        networkClientId,
+      ]);
+    } catch (error) {
+      logErrorWithMessage(error);
+    } finally {
+      await forceUpdateMetamaskState(dispatch);
+    }
+  };
+}
+
 /**
  * To add ignored token addresses to state
  *


### PR DESCRIPTION
## **Description**

Display the user's token fiat balance on the import token confirmation page before it is imported.

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've clearly explained what problem this PR is solving and how it is solved.
- [ ] I've linked related issues
- [ ] I've included manual testing steps
- [ ] I've included screenshots/recordings if applicable
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [ ] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
