### PR TITLE
feat(confirmation): change the NetworkDisplay component to PickerNetw…

### DIFF
--- a/ui/pages/confirmation/confirmation.js
+++ b/ui/pages/confirmation/confirmation.js
@@ -15,12 +15,19 @@ import log from 'loglevel';
 ///: BEGIN:ONLY_INCLUDE_IF(snaps)
 import { ApprovalType } from '@metamask/controller-utils';
 ///: END:ONLY_INCLUDE_IF
+import { getProviderConfig } from '../../ducks/metamask/metamask';
+import { NETWORK_TYPES } from '../../../shared/constants/network';
+import { getNetworkLabelKey } from '../../helpers/utils/i18n-helper';
 import fetchWithCache from '../../../shared/lib/fetch-with-cache';
 import Box from '../../components/ui/box';
 import MetaMaskTemplateRenderer from '../../components/app/metamask-template-renderer';
 import ConfirmationWarningModal from '../../components/app/confirmation-warning-modal';
 import { DEFAULT_ROUTE } from '../../helpers/constants/routes';
-import { Size, TextColor } from '../../helpers/constants/design-system';
+import {
+  BackgroundColor,
+  BorderColor,
+  Display,
+} from '../../helpers/constants/design-system';
 import { useI18nContext } from '../../hooks/useI18nContext';
 import {
   ///: BEGIN:ONLY_INCLUDE_IF(snaps)
@@ -31,10 +38,15 @@ import {
   getApprovalFlows,
   getTotalUnapprovedCount,
   useSafeChainsListValidationSelector,
+  getCurrentNetwork,
+  getTestNetworkBackgroundColor,
 } from '../../selectors';
-import NetworkDisplay from '../../components/app/network-display/network-display';
 import Callout from '../../components/ui/callout';
-import { Icon, IconName } from '../../components/component-library';
+import {
+  Icon,
+  IconName,
+  PickerNetwork,
+} from '../../components/component-library';
 import Loading from '../../components/ui/loading-screen';
 ///: BEGIN:ONLY_INCLUDE_IF(snaps)
 import SnapAuthorshipHeader from '../../components/app/snaps/snap-authorship-header';
@@ -204,6 +216,10 @@ export default function ConfirmationPage({
   const useSafeChainsListValidation = useSelector(
     useSafeChainsListValidationSelector,
   );
+  const networkProviderConfig = useSelector(getProviderConfig);
+  const currentNetwork = useSelector(getCurrentNetwork);
+  const testNetworkBackgroundColor = useSelector(getTestNetworkBackgroundColor);
+
   const [approvalFlowLoadingText, setApprovalFlowLoadingText] = useState(null);
   const [currentPendingConfirmation, setCurrentPendingConfirmation] =
     useState(0);
@@ -445,9 +461,20 @@ export default function ConfirmationPage({
       <div className="confirmation-page__content">
         {templatedValues.networkDisplay ? (
           <Box justifyContent="center" marginTop={2}>
-            <NetworkDisplay
-              indicatorSize={Size.XS}
-              labelProps={{ color: TextColor.textDefault }}
+            <PickerNetwork
+              as="div"
+              src={currentNetwork?.rpcPrefs?.imageUrl}
+              label={
+                networkProviderConfig?.type === NETWORK_TYPES.RPC
+                  ? networkProviderConfig?.nickname ?? t('privateNetwork')
+                  : t(getNetworkLabelKey(networkProviderConfig?.type))
+              }
+              backgroundColor={BackgroundColor.transparent}
+              borderColor={BorderColor.borderMuted}
+              iconProps={{ display: Display.None }}
+              avatarNetworkProps={{
+                backgroundColor: testNetworkBackgroundColor,
+              }}
             />
           </Box>
         ) : null}

--- a/ui/pages/confirmation/templates/__snapshots__/add-ethereum-chain.test.js.snap
+++ b/ui/pages/confirmation/templates/__snapshots__/add-ethereum-chain.test.js.snap
@@ -12,26 +12,22 @@ exports[`add-ethereum-chain confirmation should match snapshot 1`] = `
         class="box box--margin-top-2 box--flex-direction-row box--justify-content-center box--display-flex"
       >
         <div
-          class="network-display chip chip--with-left-icon chip--border-color-border-muted chip--background-color-undefined chip--max-content"
-          data-testid="network-display"
+          class="mm-box mm-picker-network mm-box--padding-right-4 mm-box--padding-left-2 mm-box--display-flex mm-box--gap-2 mm-box--align-items-center mm-box--background-color-transparent mm-box--rounded-pill mm-box--border-color-border-muted box--border-style-solid box--border-width-1"
         >
           <div
-            class="chip__left-icon"
+            class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-network mm-picker-network__avatar-network mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full mm-box--border-color-transparent box--border-style-solid box--border-width-1"
           >
-            <div
-              class="color-indicator color-indicator--filled color-indicator--color-icon-muted color-indicator--size-xs"
-              data-testid="color-icon-icon-muted"
-            >
-              <span
-                class="color-indicator__inner-circle"
-              />
-            </div>
+            T
           </div>
           <span
-            class="box box--margin-top-1 box--margin-bottom-1 box--flex-direction-row typography chip__label typography--h7 typography--weight-normal typography--style-normal typography--color-text-default"
+            class="mm-box mm-text mm-text--body-sm mm-text--ellipsis mm-box--color-text-default"
           >
             Test initial state
           </span>
+          <span
+            class="mm-box mm-picker-network__arrow-down-icon mm-icon mm-icon--size-xs mm-box--margin-left-auto mm-box--display-none mm-box--color-icon-default"
+            style="mask-image: url('./images/icons/arrow-down.svg');"
+          />
         </div>
       </div>
       <h3
@@ -215,26 +211,22 @@ exports[`add-ethereum-chain confirmation should match snapshot 2`] = `
         class="box box--margin-top-2 box--flex-direction-row box--justify-content-center box--display-flex"
       >
         <div
-          class="network-display chip chip--with-left-icon chip--border-color-border-muted chip--background-color-undefined chip--max-content"
-          data-testid="network-display"
+          class="mm-box mm-picker-network mm-box--padding-right-4 mm-box--padding-left-2 mm-box--display-flex mm-box--gap-2 mm-box--align-items-center mm-box--background-color-transparent mm-box--rounded-pill mm-box--border-color-border-muted box--border-style-solid box--border-width-1"
         >
           <div
-            class="chip__left-icon"
+            class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-network mm-picker-network__avatar-network mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full mm-box--border-color-transparent box--border-style-solid box--border-width-1"
           >
-            <div
-              class="color-indicator color-indicator--filled color-indicator--color-icon-muted color-indicator--size-xs"
-              data-testid="color-icon-icon-muted"
-            >
-              <span
-                class="color-indicator__inner-circle"
-              />
-            </div>
+            T
           </div>
           <span
-            class="box box--margin-top-1 box--margin-bottom-1 box--flex-direction-row typography chip__label typography--h7 typography--weight-normal typography--style-normal typography--color-text-default"
+            class="mm-box mm-text mm-text--body-sm mm-text--ellipsis mm-box--color-text-default"
           >
             Test initial state
           </span>
+          <span
+            class="mm-box mm-picker-network__arrow-down-icon mm-icon mm-icon--size-xs mm-box--margin-left-auto mm-box--display-none mm-box--color-icon-default"
+            style="mask-image: url('./images/icons/arrow-down.svg');"
+          />
         </div>
       </div>
       <h3

--- a/ui/pages/confirmation/templates/__snapshots__/switch-ethereum-chain.test.js.snap
+++ b/ui/pages/confirmation/templates/__snapshots__/switch-ethereum-chain.test.js.snap
@@ -12,26 +12,22 @@ exports[`switch-ethereum-chain confirmation should match snapshot 1`] = `
         class="box box--margin-top-2 box--flex-direction-row box--justify-content-center box--display-flex"
       >
         <div
-          class="network-display chip chip--with-left-icon chip--border-color-border-muted chip--background-color-undefined chip--max-content"
-          data-testid="network-display"
+          class="mm-box mm-picker-network mm-box--padding-right-4 mm-box--padding-left-2 mm-box--display-flex mm-box--gap-2 mm-box--align-items-center mm-box--background-color-transparent mm-box--rounded-pill mm-box--border-color-border-muted box--border-style-solid box--border-width-1"
         >
           <div
-            class="chip__left-icon"
+            class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-network mm-picker-network__avatar-network mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full mm-box--border-color-transparent box--border-style-solid box--border-width-1"
           >
-            <div
-              class="color-indicator color-indicator--filled color-indicator--color-icon-muted color-indicator--size-xs"
-              data-testid="color-icon-icon-muted"
-            >
-              <span
-                class="color-indicator__inner-circle"
-              />
-            </div>
+            T
           </div>
           <span
-            class="box box--margin-top-1 box--margin-bottom-1 box--flex-direction-row typography chip__label typography--h7 typography--weight-normal typography--style-normal typography--color-text-default"
+            class="mm-box mm-text mm-text--body-sm mm-text--ellipsis mm-box--color-text-default"
           >
             Test initial state
           </span>
+          <span
+            class="mm-box mm-picker-network__arrow-down-icon mm-icon mm-icon--size-xs mm-box--margin-left-auto mm-box--display-none mm-box--color-icon-default"
+            style="mask-image: url('./images/icons/arrow-down.svg');"
+          />
         </div>
       </div>
       <h3
@@ -133,26 +129,22 @@ exports[`switch-ethereum-chain confirmation should show alert if there are pendi
         class="box box--margin-top-2 box--flex-direction-row box--justify-content-center box--display-flex"
       >
         <div
-          class="network-display chip chip--with-left-icon chip--border-color-border-muted chip--background-color-undefined chip--max-content"
-          data-testid="network-display"
+          class="mm-box mm-picker-network mm-box--padding-right-4 mm-box--padding-left-2 mm-box--display-flex mm-box--gap-2 mm-box--align-items-center mm-box--background-color-transparent mm-box--rounded-pill mm-box--border-color-border-muted box--border-style-solid box--border-width-1"
         >
           <div
-            class="chip__left-icon"
+            class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-network mm-picker-network__avatar-network mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full mm-box--border-color-transparent box--border-style-solid box--border-width-1"
           >
-            <div
-              class="color-indicator color-indicator--filled color-indicator--color-icon-muted color-indicator--size-xs"
-              data-testid="color-icon-icon-muted"
-            >
-              <span
-                class="color-indicator__inner-circle"
-              />
-            </div>
+            T
           </div>
           <span
-            class="box box--margin-top-1 box--margin-bottom-1 box--flex-direction-row typography chip__label typography--h7 typography--weight-normal typography--style-normal typography--color-text-default"
+            class="mm-box mm-text mm-text--body-sm mm-text--ellipsis mm-box--color-text-default"
           >
             Test initial state
           </span>
+          <span
+            class="mm-box mm-picker-network__arrow-down-icon mm-icon mm-icon--size-xs mm-box--margin-left-auto mm-box--display-none mm-box--color-icon-default"
+            style="mask-image: url('./images/icons/arrow-down.svg');"
+          />
         </div>
       </div>
       <h3

--- a/ui/pages/confirmation/templates/create-snap-account.test.js
+++ b/ui/pages/confirmation/templates/create-snap-account.test.js
@@ -17,11 +17,16 @@ const mockApproval = {
   origin: mockSnapOrigin,
   snapName: mockSnapName,
 };
+const providerConfig = {
+  type: 'test',
+  chainId: '0x5',
+};
 const mockBaseStore = {
   metamask: {
     pendingApprovals: {
       [mockApprovalId]: mockApproval,
     },
+    providerConfig,
     approvalFlows: [],
     subjectMetadata: {},
   },

--- a/ui/pages/confirmation/templates/error.test.js
+++ b/ui/pages/confirmation/templates/error.test.js
@@ -29,12 +29,16 @@ const mockApproval = {
     message: 'Error message',
   },
 };
-
+const providerConfig = {
+  type: 'test',
+  chainId: '0x5',
+}
 const mockBaseStore = {
   metamask: {
     pendingApprovals: {
       [mockApprovalId]: mockApproval,
     },
+    providerConfig,
     approvalFlows: [],
     subjectMetadata: {},
   },

--- a/ui/pages/confirmation/templates/error.test.js
+++ b/ui/pages/confirmation/templates/error.test.js
@@ -32,7 +32,7 @@ const mockApproval = {
 const providerConfig = {
   type: 'test',
   chainId: '0x5',
-}
+};
 const mockBaseStore = {
   metamask: {
     pendingApprovals: {

--- a/ui/pages/confirmation/templates/remove-snap-account.test.js
+++ b/ui/pages/confirmation/templates/remove-snap-account.test.js
@@ -14,6 +14,7 @@ const mockSnapOrigin = 'npm:@metamask/snap-test';
 const mockSnapName = 'Test Snap Account Name';
 const mockPublicAddress = '0x000000000000000000000000000000000000000';
 const providerConfig = {
+  type: 'test',
   chainId: '0x5',
 };
 const mockApproval = {


### PR DESCRIPTION
This is fixing a 2nd instance of https://github.com/MetaMask/metamask-extension/issues/20485.

Changes to test files are required because the **providerConfig** prop is required for PickerNetwork components while it wasn't required for NetworkDisplay.
