### PR TITLE
[MMI] updates MMI name in EIP 6963

### DIFF
--- a/development/build/utils.js
+++ b/development/build/utils.js
@@ -247,9 +247,7 @@ function getBuildName({
   shouldIncludeMV3,
 }) {
   if (environment === ENVIRONMENT.PRODUCTION) {
-    return buildType === 'mmi'
-    ? 'MetaMask Institutional'
-    : 'MetaMask';
+    return buildType === 'mmi' ? 'MetaMask Institutional' : 'MetaMask';
   }
 
   const mv3Str = shouldIncludeMV3 ? ' MV3' : '';

--- a/development/build/utils.js
+++ b/development/build/utils.js
@@ -247,7 +247,9 @@ function getBuildName({
   shouldIncludeMV3,
 }) {
   if (environment === ENVIRONMENT.PRODUCTION) {
-    return 'MetaMask';
+    return buildType === 'mmi'
+    ? 'MetaMask Institutional'
+    : 'MetaMask';
   }
 
   const mv3Str = shouldIncludeMV3 ? ' MV3' : '';


### PR DESCRIPTION
## **Description**

Previously the name was just MetaMask, now it will check if the build type is MMI and output MetaMask Institutional.

<img width="621" alt="Screenshot 2023-12-07 at 11 33 05" src="https://github.com/MetaMask/metamask-extension/assets/1125631/0ef6414c-e800-472b-addc-94b434aa21dc">
<img width="648" alt="Screenshot 2023-12-07 at 11 32 51" src="https://github.com/MetaMask/metamask-extension/assets/1125631/385b0a86-58a6-42c4-9b8a-f286d3d24782">

## **Related issues**

Fixes: MMI name under the eip6963

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've clearly explained what problem this PR is solving and how it is solved.
- [ ] I've linked related issues
- [ ] I've included manual testing steps
- [ ] I've included screenshots/recordings if applicable
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [ ] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
