### PR TITLE
UX: Release the empty asset banners

### DIFF
--- a/test/e2e/metamask-ui.spec.js
+++ b/test/e2e/metamask-ui.spec.js
@@ -446,6 +446,9 @@ describe('MetaMask @no-mmi', function () {
     });
 
     it('checks balance', async function () {
+      if (process.env.MULTICHAIN) {
+        return;
+      }
       await driver.clickElement({
         text: 'Tokens',
         tag: 'button',

--- a/test/e2e/metamask-ui.spec.js
+++ b/test/e2e/metamask-ui.spec.js
@@ -446,9 +446,6 @@ describe('MetaMask @no-mmi', function () {
     });
 
     it('checks balance', async function () {
-      if (process.env.MULTICHAIN) {
-        return;
-      }
       await driver.clickElement({
         text: 'Tokens',
         tag: 'button',

--- a/ui/components/app/asset-list/asset-list.js
+++ b/ui/components/app/asset-list/asset-list.js
@@ -106,8 +106,8 @@ const AssetList = ({ onClickAsset }) => {
 
   const balanceIsZero = Number(totalFiatBalance) === 0;
   const isBuyableChain = useSelector(getIsBuyableChain);
-  const shouldShowBuy = isBuyableChain && balanceIsZero;
-  const shouldShowReceive = balanceIsZero;
+  const shouldShowBuy = isBuyableChain && balanceIsZero && !process.env.IN_TEST;
+  const shouldShowReceive = balanceIsZero && !process.env.IN_TEST;
   const { openBuyCryptoInPdapp } = useRamps();
   const defaultSwapsToken = useSelector(getSwapsDefaultToken);
 

--- a/ui/components/app/asset-list/asset-list.js
+++ b/ui/components/app/asset-list/asset-list.js
@@ -106,8 +106,8 @@ const AssetList = ({ onClickAsset }) => {
 
   const balanceIsZero = Number(totalFiatBalance) === 0;
   const isBuyableChain = useSelector(getIsBuyableChain);
-  const shouldShowBuy = isBuyableChain && balanceIsZero && !process.env.IN_TEST;
-  const shouldShowReceive = balanceIsZero && !process.env.IN_TEST;
+  const shouldShowBuy = isBuyableChain && balanceIsZero;
+  const shouldShowReceive = balanceIsZero;
   const { openBuyCryptoInPdapp } = useRamps();
   const defaultSwapsToken = useSelector(getSwapsDefaultToken);
 
@@ -161,58 +161,55 @@ const AssetList = ({ onClickAsset }) => {
             />
           ) : null}
         </Box>
-      ) : (
-        <>
-          <TokenListItem
-            onClick={() => onClickAsset(nativeCurrency)}
-            title={nativeCurrency}
-            primary={
-              showPrimaryCurrency(
-                isOriginalNativeSymbol,
-                useNativeCurrencyAsPrimaryCurrency,
-              )
-                ? primaryCurrencyProperties.value ??
-                  secondaryCurrencyProperties.value
-                : null
-            }
-            tokenSymbol={
-              showPrimaryCurrency(
-                isOriginalNativeSymbol,
-                useNativeCurrencyAsPrimaryCurrency,
-              )
-                ? primaryCurrencyProperties.suffix
-                : null
-            }
-            secondary={
-              showFiat &&
-              showSecondaryCurrency(
-                isOriginalNativeSymbol,
-                useNativeCurrencyAsPrimaryCurrency,
-              )
-                ? secondaryCurrencyDisplay
-                : undefined
-            }
-            tokenImage={balanceIsLoading ? null : primaryTokenImage}
-            isOriginalTokenSymbol={isOriginalNativeSymbol}
-            isNativeCurrency
-          />
-          <TokenList
-            tokens={tokensWithBalances}
-            loading={loading}
-            onTokenClick={(tokenAddress) => {
-              onClickAsset(tokenAddress);
-              trackEvent({
-                event: MetaMetricsEventName.TokenScreenOpened,
-                category: MetaMetricsEventCategory.Navigation,
-                properties: {
-                  token_symbol: primaryCurrencyProperties.suffix,
-                  location: 'Home',
-                },
-              });
-            }}
-          />
-        </>
-      )}
+      ) : null}
+      <TokenListItem
+        onClick={() => onClickAsset(nativeCurrency)}
+        title={nativeCurrency}
+        primary={
+          showPrimaryCurrency(
+            isOriginalNativeSymbol,
+            useNativeCurrencyAsPrimaryCurrency,
+          )
+            ? primaryCurrencyProperties.value ??
+              secondaryCurrencyProperties.value
+            : null
+        }
+        tokenSymbol={
+          showPrimaryCurrency(
+            isOriginalNativeSymbol,
+            useNativeCurrencyAsPrimaryCurrency,
+          )
+            ? primaryCurrencyProperties.suffix
+            : null
+        }
+        secondary={
+          showFiat &&
+          showSecondaryCurrency(
+            isOriginalNativeSymbol,
+            useNativeCurrencyAsPrimaryCurrency,
+          )
+            ? secondaryCurrencyDisplay
+            : undefined
+        }
+        tokenImage={balanceIsLoading ? null : primaryTokenImage}
+        isOriginalTokenSymbol={isOriginalNativeSymbol}
+        isNativeCurrency
+      />
+      <TokenList
+        tokens={tokensWithBalances}
+        loading={loading}
+        onTokenClick={(tokenAddress) => {
+          onClickAsset(tokenAddress);
+          trackEvent({
+            event: MetaMetricsEventName.TokenScreenOpened,
+            category: MetaMetricsEventCategory.Navigation,
+            properties: {
+              token_symbol: primaryCurrencyProperties.suffix,
+              location: 'Home',
+            },
+          });
+        }}
+      />
       <Box marginTop={detectedTokens.length > 0 ? 0 : 4}>
         <ImportTokenLink margin={4} marginBottom={2} />
       </Box>

--- a/ui/components/app/asset-list/asset-list.js
+++ b/ui/components/app/asset-list/asset-list.js
@@ -123,7 +123,7 @@ const AssetList = ({ onClickAsset }) => {
             margin={4}
           />
         )}
-      {process.env.MULTICHAIN && (shouldShowBuy || shouldShowReceive) ? (
+      {shouldShowBuy || shouldShowReceive ? (
         <Box
           paddingInlineStart={4}
           paddingInlineEnd={4}

--- a/ui/components/app/nfts-tab/nfts-tab.js
+++ b/ui/components/app/nfts-tab/nfts-tab.js
@@ -49,7 +49,7 @@ export default function NftsTab() {
   };
 
   const hasAnyNfts = Object.keys(collections).length > 0;
-  const showNftBanner = process.env.MULTICHAIN && hasAnyNfts === false;
+  const showNftBanner = hasAnyNfts === false;
 
   if (nftsLoading) {
     return <div className="nfts-tab__loading">{t('loadingNFTs')}</div>;


### PR DESCRIPTION
## **Description**

Releases the empty balance banners on the asset list screen and NFTs screen

## **Related issues**

Fixes:

## **Manual testing steps**

1. Create a new wallet with 0 assets
2. See the visual banners to buy and receive
3. Switch to the NFTs tab
4. See the NFT banner
5. Populate the account with assets and NFTs
6. The banners go away

## **Screenshots/Recordings**

### **Before**

N/A

### **After**


<img width="363" alt="SCR-20231211-kwec" src="https://github.com/MetaMask/metamask-extension/assets/46655/951a5d46-557e-4f56-9cc6-e24b2fbf8ace">


<img width="926" alt="SCR-20231207-jqqw" src="https://github.com/MetaMask/metamask-extension/assets/46655/4021f93f-c5db-47cf-bca5-581953bf0d2b">


## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've clearly explained what problem this PR is solving and how it is solved.
- [ ] I've linked related issues
- [ ] I've included manual testing steps
- [ ] I've included screenshots/recordings if applicable
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [ ] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
