### PR TITLE
Move native token value below Fiat within Token list

### DIFF
--- a/ui/components/app/token-cell/__snapshots__/token-cell.test.js.snap
+++ b/ui/components/app/token-cell/__snapshots__/token-cell.test.js.snap
@@ -43,24 +43,36 @@ exports[`Token Cell should match snapshot 1`] = `
         style="flex-grow: 1; overflow: hidden;"
       >
         <div
-          class="mm-box mm-box--display-flex mm-box--gap-1 mm-box--justify-content-space-between mm-box--align-items-center"
+          class="mm-box mm-box--display-flex mm-box--gap-1 mm-box--flex-direction-row mm-box--align-items-center"
         >
           <div
             class="mm-box mm-box--display-inline-block mm-box--width-1/3"
           >
+<<<<<<< HEAD
             <span
               class="mm-box mm-text mm-text--body-md mm-text--font-weight-medium mm-text--ellipsis mm-box--color-text-default"
+=======
+            <p
+              class="mm-box mm-text mm-text--body-lg-medium mm-text--ellipsis mm-box--color-text-default"
+              data-testid="multichain-token-list-item-symbol"
+>>>>>>> 592455bb43 (chaos story alignment)
             >
               TEST
             </span>
           </div>
-          <p
-            class="mm-box mm-text mm-text--body-lg-medium mm-text--font-weight-medium mm-text--ellipsis mm-text--text-align-end mm-box--width-2/3 mm-box--color-text-default"
-            data-testid="multichain-token-list-item-secondary-value"
+          <div
+            class="mm-box mm-box--justify-content-flex-end mm-box--width-2/3"
+            style="overflow: hidden;"
           >
-            5.00
-          </p>
+            <p
+              class="mm-box mm-text mm-text--body-lg-medium mm-text--font-weight-medium mm-text--ellipsis mm-text--text-align-end mm-box--color-text-default"
+              data-testid="multichain-token-list-item-secondary-value"
+            >
+              5.00
+            </p>
+          </div>
         </div>
+<<<<<<< HEAD
         <p
           class="mm-box mm-text mm-text--body-md mm-box--color-text-alternative"
           data-testid="multichain-token-list-item-value"
@@ -70,6 +82,47 @@ exports[`Token Cell should match snapshot 1`] = `
           TEST
 
         </p>
+=======
+        <div
+          class="mm-box mm-box--display-flex mm-box--gap-1 mm-box--flex-direction-row mm-box--align-items-center"
+        >
+          <div
+            class="mm-box mm-box--width-1/3"
+          >
+            <p
+              class="mm-box mm-text mm-text--body-md mm-text--font-weight-medium mm-text--ellipsis mm-box--color-text-alternative"
+              data-testid="multichain-token-list-item-token-name"
+            >
+              TEST
+            </p>
+          </div>
+          <div
+            class="mm-box mm-box--width-2/3"
+            style="overflow: hidden;"
+          >
+            <div>
+              <div
+                aria-describedby="tippy-tooltip-1"
+                class=""
+                data-original-title="null"
+                data-tooltipped=""
+                style="display: inline;"
+                tabindex="0"
+              >
+                <p
+                  class="mm-box mm-text mm-text--body-md mm-text--font-weight-medium mm-text--ellipsis mm-text--text-align-end mm-box--color-text-alternative"
+                  data-testid="multichain-token-list-item-value"
+                >
+                  5.000
+                   
+                  TEST
+                   
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+>>>>>>> 592455bb43 (chaos story alignment)
       </div>
     </a>
   </div>

--- a/ui/components/app/token-cell/__snapshots__/token-cell.test.js.snap
+++ b/ui/components/app/token-cell/__snapshots__/token-cell.test.js.snap
@@ -43,7 +43,7 @@ exports[`Token Cell should match snapshot 1`] = `
         style="flex-grow: 1; overflow: hidden;"
       >
         <div
-          class="mm-box mm-box--display-flex mm-box--gap-1 mm-box--justify-content-space-between"
+          class="mm-box mm-box--display-flex mm-box--gap-1 mm-box--justify-content-space-between mm-box--align-items-center"
         >
           <div
             class="mm-box mm-box--display-inline-block mm-box--width-1/3"
@@ -55,7 +55,7 @@ exports[`Token Cell should match snapshot 1`] = `
             </span>
           </div>
           <p
-            class="mm-box mm-text mm-text--body-md mm-text--font-weight-medium mm-text--text-align-end mm-box--width-2/3 mm-box--color-text-default"
+            class="mm-box mm-text mm-text--body-lg-medium mm-text--font-weight-medium mm-text--ellipsis mm-text--text-align-end mm-box--width-2/3 mm-box--color-text-default"
             data-testid="multichain-token-list-item-secondary-value"
           >
             5.00
@@ -66,9 +66,9 @@ exports[`Token Cell should match snapshot 1`] = `
           data-testid="multichain-token-list-item-value"
         >
           5.000
-           
+
           TEST
-           
+
         </p>
       </div>
     </a>

--- a/ui/components/app/token-cell/token-cell.test.js
+++ b/ui/components/app/token-cell/token-cell.test.js
@@ -109,14 +109,14 @@ describe('Token Cell', () => {
   });
 
   it('should render the correct token and filter by symbol and address', () => {
-    const { queryByText, getByAltText } = renderWithProvider(
+    const { getByTestId, getByAltText } = renderWithProvider(
       <TokenCell {...props} />,
       mockStore,
     );
 
     const image = getByAltText('TEST logo');
 
-    expect(queryByText('TEST')).toBeInTheDocument();
+    expect(getByTestId('multichain-token-list-item-value')).toBeInTheDocument();
     expect(image).toBeInTheDocument();
     expect(image).toHaveAttribute('src', './images/test_image.svg');
   });

--- a/ui/components/multichain/token-list-item/__snapshots__/token-list-item.test.js.snap
+++ b/ui/components/multichain/token-list-item/__snapshots__/token-list-item.test.js.snap
@@ -38,7 +38,7 @@ exports[`TokenListItem should render correctly 1`] = `
         style="flex-grow: 1; overflow: hidden;"
       >
         <div
-          class="mm-box mm-box--display-flex mm-box--gap-1 mm-box--justify-content-space-between"
+          class="mm-box mm-box--display-flex mm-box--gap-1 mm-box--justify-content-space-between mm-box--align-items-center"
         >
           <div
             class="mm-box mm-box--display-inline-block mm-box--width-1/3"
@@ -48,7 +48,7 @@ exports[`TokenListItem should render correctly 1`] = `
             />
           </div>
           <p
-            class="mm-box mm-text mm-text--body-md mm-text--font-weight-medium mm-text--text-align-end mm-box--width-2/3 mm-box--color-text-default"
+            class="mm-box mm-text mm-text--body-lg-medium mm-text--font-weight-medium mm-text--ellipsis mm-text--text-align-end mm-box--width-2/3 mm-box--color-text-default"
             data-testid="multichain-token-list-item-secondary-value"
           />
         </div>
@@ -56,8 +56,8 @@ exports[`TokenListItem should render correctly 1`] = `
           class="mm-box mm-text mm-text--body-md mm-box--color-text-alternative"
           data-testid="multichain-token-list-item-value"
         >
-           
-           
+
+
         </p>
       </div>
     </a>

--- a/ui/components/multichain/token-list-item/__snapshots__/token-list-item.test.js.snap
+++ b/ui/components/multichain/token-list-item/__snapshots__/token-list-item.test.js.snap
@@ -38,20 +38,32 @@ exports[`TokenListItem should render correctly 1`] = `
         style="flex-grow: 1; overflow: hidden;"
       >
         <div
-          class="mm-box mm-box--display-flex mm-box--gap-1 mm-box--justify-content-space-between mm-box--align-items-center"
+          class="mm-box mm-box--display-flex mm-box--gap-1 mm-box--flex-direction-row mm-box--align-items-center"
         >
           <div
             class="mm-box mm-box--display-inline-block mm-box--width-1/3"
           >
+<<<<<<< HEAD
             <span
               class="mm-box mm-text mm-text--body-md mm-text--font-weight-medium mm-text--ellipsis mm-box--color-text-default"
+=======
+            <p
+              class="mm-box mm-text mm-text--body-lg-medium mm-text--ellipsis mm-box--color-text-default"
+              data-testid="multichain-token-list-item-symbol"
+>>>>>>> 592455bb43 (chaos story alignment)
             />
           </div>
-          <p
-            class="mm-box mm-text mm-text--body-lg-medium mm-text--font-weight-medium mm-text--ellipsis mm-text--text-align-end mm-box--width-2/3 mm-box--color-text-default"
-            data-testid="multichain-token-list-item-secondary-value"
-          />
+          <div
+            class="mm-box mm-box--justify-content-flex-end mm-box--width-2/3"
+            style="overflow: hidden;"
+          >
+            <p
+              class="mm-box mm-text mm-text--body-lg-medium mm-text--font-weight-medium mm-text--ellipsis mm-text--text-align-end mm-box--color-text-default"
+              data-testid="multichain-token-list-item-secondary-value"
+            />
+          </div>
         </div>
+<<<<<<< HEAD
         <p
           class="mm-box mm-text mm-text--body-md mm-box--color-text-alternative"
           data-testid="multichain-token-list-item-value"
@@ -59,6 +71,43 @@ exports[`TokenListItem should render correctly 1`] = `
 
 
         </p>
+=======
+        <div
+          class="mm-box mm-box--display-flex mm-box--gap-1 mm-box--flex-direction-row mm-box--align-items-center"
+        >
+          <div
+            class="mm-box mm-box--width-1/3"
+          >
+            <p
+              class="mm-box mm-text mm-text--body-md mm-text--font-weight-medium mm-text--ellipsis mm-box--color-text-alternative"
+              data-testid="multichain-token-list-item-token-name"
+            />
+          </div>
+          <div
+            class="mm-box mm-box--width-2/3"
+            style="overflow: hidden;"
+          >
+            <div>
+              <div
+                aria-describedby="tippy-tooltip-1"
+                class=""
+                data-original-title="null"
+                data-tooltipped=""
+                style="display: inline;"
+                tabindex="0"
+              >
+                <p
+                  class="mm-box mm-text mm-text--body-md mm-text--font-weight-medium mm-text--ellipsis mm-text--text-align-end mm-box--color-text-alternative"
+                  data-testid="multichain-token-list-item-value"
+                >
+                   
+                   
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+>>>>>>> 592455bb43 (chaos story alignment)
       </div>
     </a>
   </div>

--- a/ui/components/multichain/token-list-item/token-list-item.js
+++ b/ui/components/multichain/token-list-item/token-list-item.js
@@ -74,7 +74,7 @@ export const TokenListItem = ({
   const trackEvent = useContext(MetaMetricsContext);
   const metaMetricsId = useSelector(getMetaMetricsId);
   const chainId = useSelector(getCurrentChainId);
-
+  const TOKEN_VALUE_THRESHOLD = 8;
   // Scam warning
   const showScamWarning = isNativeCurrency && !isOriginalTokenSymbol;
   const dispatch = useDispatch();
@@ -130,6 +130,20 @@ export const TokenListItem = ({
   // Used for badge icon
   const currentNetwork = useSelector(getCurrentNetwork);
   const testNetworkBackgroundColor = useSelector(getTestNetworkBackgroundColor);
+  const wrapInTooltip = (jsxElement, control, threshold = 12) => {
+    return control?.length > threshold ? (
+      <Tooltip
+        position="bottom"
+        interactive
+        html={control}
+        tooltipInnerClassName="multichain-token-list-item__tooltip"
+      >
+        {jsxElement}
+      </Tooltip>
+    ) : (
+      <>{jsxElement}</>
+    );
+  };
 
   return (
     <Box
@@ -191,7 +205,6 @@ export const TokenListItem = ({
             }
           />
         </BadgeWrapper>
-        {/* TODO:// chaos story alignment */}
         <Box
           className="multichain-token-list-item__container-cell--text-container"
           display={Display.Flex}
@@ -201,10 +214,11 @@ export const TokenListItem = ({
         >
           <Box
             display={Display.Flex}
-            justifyContent={JustifyContent.spaceBetween}
+            flexDirection={FlexDirection.Row}
             alignItems={AlignItems.center}
             gap={1}
           >
+<<<<<<< HEAD
             <Box
               width={isStakeable ? BlockSize.Half : BlockSize.OneThird}
               display={Display.InlineBlock}
@@ -268,55 +282,110 @@ export const TokenListItem = ({
                 textAlign={TextAlign.End}
                 data-testid="multichain-token-list-item-secondary-value"
                 ellipsis={isStakeable}
+=======
+            <Box width={BlockSize.OneThird}>
+              {
+                // top left
+                wrapInTooltip(
+                  <Text
+                    variant={TextVariant.bodyLgMedium}
+                    data-testid="multichain-token-list-item-symbol"
+                    ellipsis
+                  >
+                    {tokenSymbol}
+                  </Text>,
+                  `${tokenSymbol}`,
+                )
+              }
+            </Box>
+            {showScamWarning ? (
+              <Box
+                display={Display.Flex}
+                style={{ overflow: 'hidden' }}
+                width={BlockSize.TwoThirds}
+                justifyContent={JustifyContent.flexEnd}
+>>>>>>> 592455bb43 (chaos story alignment)
               >
-                {secondary}
-              </Text>
+                <ButtonIcon
+                  iconName={IconName.Danger}
+                  onClick={(e) => {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    setShowScamWarningModal(true);
+                  }}
+                  color={IconColor.errorDefault}
+                  size={IconSize.Lg}
+                  backgroundColor={BackgroundColor.transparent}
+                />
+              </Box>
+            ) : (
+              <Box
+                style={{ overflow: 'hidden' }}
+                width={BlockSize.TwoThirds}
+                justifyContent={JustifyContent.flexEnd}
+              >
+                {
+                  // top right
+                  wrapInTooltip(
+                    <Text
+                      fontWeight={FontWeight.Medium}
+                      variant={TextVariant.bodyLgMedium}
+                      textAlign={TextAlign.End}
+                      data-testid="multichain-token-list-item-secondary-value"
+                      ellipsis
+                    >
+                      {secondary}
+                    </Text>,
+                    secondary,
+                    TOKEN_VALUE_THRESHOLD,
+                  )
+                }
+              </Box>
             )}
           </Box>
           <Box
+            flexDirection={FlexDirection.Row}
             display={Display.Flex}
-            justifyContent={JustifyContent.spaceBetween}
             alignItems={AlignItems.center}
             gap={1}
           >
-            {title?.length > 12 ? (
-              <Tooltip
-                position="bottom"
-                interactive
-                html={title}
-                tooltipInnerClassName="multichain-token-list-item__tooltip"
-              >
-                <Text
-                  fontWeight={FontWeight.Medium}
-                  variant={TextVariant.bodyMd}
-                  color={TextColor.textAlternative}
-                  // data-testid="multichain-token-list-item-token-name"
-                  ellipsis
-                >
-                  {tokenTitle}
-                </Text>
-              </Tooltip>
-            ) : (
-              <Text
-                fontWeight={FontWeight.Medium}
-                variant={TextVariant.bodyMd}
-                color={TextColor.textAlternative}
-                // data-testid="multichain-token-list-item-token-name"
-                ellipsis
-              >
-                {tokenTitle}
-              </Text>
-            )}
-            <Text
-              fontWeight={FontWeight.Medium}
-              variant={TextVariant.bodyMd}
-              width={BlockSize.TwoThirds}
-              textAlign={TextAlign.End}
-              color={TextColor.textAlternative}
-              data-testid="multichain-token-list-item-value"
-            >
-              {primary} {tokenSymbol}{' '}
-            </Text>
+            <Box width={BlockSize.OneThird}>
+              {
+                // bottom left
+                wrapInTooltip(
+                  <Text
+                    fontWeight={FontWeight.Medium}
+                    variant={TextVariant.bodyMd}
+                    color={TextColor.textAlternative}
+                    data-testid="multichain-token-list-item-token-name" //
+                    ellipsis
+                  >
+                    {tokenTitle}
+                  </Text>,
+                  title,
+                )
+              }
+            </Box>
+
+            <Box style={{ overflow: 'hidden' }} width={BlockSize.TwoThirds}>
+              {
+                // bottom right
+                wrapInTooltip(
+                  <Text
+                    fontWeight={FontWeight.Medium}
+                    variant={TextVariant.bodyMd}
+                    color={TextColor.textAlternative}
+                    textAlign={TextAlign.End}
+                    data-testid="multichain-token-list-item-value"
+                    ellipsis
+                  >
+                    {primary} {tokenSymbol}{' '}
+                  </Text>,
+                  `${primary} ${tokenSymbol} `,
+                  TOKEN_VALUE_THRESHOLD,
+                )
+              }
+            </Box>
           </Box>
         </Box>
       </Box>

--- a/ui/components/multichain/token-list-item/token-list-item.js
+++ b/ui/components/multichain/token-list-item/token-list-item.js
@@ -191,6 +191,7 @@ export const TokenListItem = ({
             }
           />
         </BadgeWrapper>
+        {/* TODO:// chaos story alignment */}
         <Box
           className="multichain-token-list-item__container-cell--text-container"
           display={Display.Flex}
@@ -201,6 +202,7 @@ export const TokenListItem = ({
           <Box
             display={Display.Flex}
             justifyContent={JustifyContent.spaceBetween}
+            alignItems={AlignItems.center}
             gap={1}
           >
             <Box
@@ -271,12 +273,51 @@ export const TokenListItem = ({
               </Text>
             )}
           </Box>
-          <Text
-            color={TextColor.textAlternative}
-            data-testid="multichain-token-list-item-value"
+          <Box
+            display={Display.Flex}
+            justifyContent={JustifyContent.spaceBetween}
+            alignItems={AlignItems.center}
+            gap={1}
           >
-            {primary} {tokenSymbol}{' '}
-          </Text>
+            {title?.length > 12 ? (
+              <Tooltip
+                position="bottom"
+                interactive
+                html={title}
+                tooltipInnerClassName="multichain-token-list-item__tooltip"
+              >
+                <Text
+                  fontWeight={FontWeight.Medium}
+                  variant={TextVariant.bodyMd}
+                  color={TextColor.textAlternative}
+                  // data-testid="multichain-token-list-item-token-name"
+                  ellipsis
+                >
+                  {tokenTitle}
+                </Text>
+              </Tooltip>
+            ) : (
+              <Text
+                fontWeight={FontWeight.Medium}
+                variant={TextVariant.bodyMd}
+                color={TextColor.textAlternative}
+                // data-testid="multichain-token-list-item-token-name"
+                ellipsis
+              >
+                {tokenTitle}
+              </Text>
+            )}
+            <Text
+              fontWeight={FontWeight.Medium}
+              variant={TextVariant.bodyMd}
+              width={BlockSize.TwoThirds}
+              textAlign={TextAlign.End}
+              color={TextColor.textAlternative}
+              data-testid="multichain-token-list-item-value"
+            >
+              {primary} {tokenSymbol}{' '}
+            </Text>
+          </Box>
         </Box>
       </Box>
       {showScamWarningModal ? (

--- a/ui/components/multichain/token-list-item/token-list-item.js
+++ b/ui/components/multichain/token-list-item/token-list-item.js
@@ -218,7 +218,6 @@ export const TokenListItem = ({
             alignItems={AlignItems.center}
             gap={1}
           >
-<<<<<<< HEAD
             <Box
               width={isStakeable ? BlockSize.Half : BlockSize.OneThird}
               display={Display.InlineBlock}
@@ -238,10 +237,10 @@ export const TokenListItem = ({
                   >
                     {isStakeable ? (
                       <>
-                        {tokenTitle} {stakeableTitle}
+                        {tokenSymbol} {stakeableTitle}
                       </>
                     ) : (
-                      tokenTitle
+                      tokenSymbol
                     )}
                   </Text>
                 </Tooltip>
@@ -282,29 +281,6 @@ export const TokenListItem = ({
                 textAlign={TextAlign.End}
                 data-testid="multichain-token-list-item-secondary-value"
                 ellipsis={isStakeable}
-=======
-            <Box width={BlockSize.OneThird}>
-              {
-                // top left
-                wrapInTooltip(
-                  <Text
-                    variant={TextVariant.bodyLgMedium}
-                    data-testid="multichain-token-list-item-symbol"
-                    ellipsis
-                  >
-                    {tokenSymbol}
-                  </Text>,
-                  `${tokenSymbol}`,
-                )
-              }
-            </Box>
-            {showScamWarning ? (
-              <Box
-                display={Display.Flex}
-                style={{ overflow: 'hidden' }}
-                width={BlockSize.TwoThirds}
-                justifyContent={JustifyContent.flexEnd}
->>>>>>> 592455bb43 (chaos story alignment)
               >
                 <ButtonIcon
                   iconName={IconName.Danger}
@@ -317,31 +293,30 @@ export const TokenListItem = ({
                   size={IconSize.Lg}
                   backgroundColor={BackgroundColor.transparent}
                 />
-              </Box>
-            ) : (
-              <Box
-                style={{ overflow: 'hidden' }}
-                width={BlockSize.TwoThirds}
-                justifyContent={JustifyContent.flexEnd}
-              >
-                {
-                  // top right
-                  wrapInTooltip(
-                    <Text
-                      fontWeight={FontWeight.Medium}
-                      variant={TextVariant.bodyLgMedium}
-                      textAlign={TextAlign.End}
-                      data-testid="multichain-token-list-item-secondary-value"
-                      ellipsis
-                    >
-                      {secondary}
-                    </Text>,
-                    secondary,
-                    TOKEN_VALUE_THRESHOLD,
-                  )
-                }
-              </Box>
+              </Text>
             )}
+            <Box
+              style={{ overflow: 'hidden' }}
+              width={BlockSize.TwoThirds}
+              justifyContent={JustifyContent.flexEnd}
+            >
+              {
+                // top right
+                wrapInTooltip(
+                  <Text
+                    fontWeight={FontWeight.Medium}
+                    variant={TextVariant.bodyLgMedium}
+                    textAlign={TextAlign.End}
+                    data-testid="multichain-token-list-item-secondary-value"
+                    ellipsis
+                  >
+                    {secondary}
+                  </Text>,
+                  secondary,
+                  TOKEN_VALUE_THRESHOLD,
+                )
+              }
+            </Box>
           </Box>
           <Box
             flexDirection={FlexDirection.Row}


### PR DESCRIPTION
## **Description**
We want to be more consistent in the way we show fiat values across different components, as well as aligning with mobile UX.
This PR shifts the token value to the right side of the cell, and replaces the old native token value with the full name of the token. 
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Related issues**

Fixes: #21132

## **Manual testing steps**

1. Go to extension Tokens Listing screen
2. Verify that cells have Token Symbol in top left, Token Name in bottom left
3. Verify that cells have Primary Currency in the top right, and Secondary currency in the bottom right 

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->
![image](https://github.com/MetaMask/metamask-extension/assets/10986371/0a00cb80-8e40-4a23-8ca4-7dfc1170bd59)

### **After**

<!-- [screenshots/recordings] -->
<img width="360" alt="image" src="https://github.com/MetaMask/metamask-extension/assets/10986371/54666fe2-880c-4771-8611-3703b9a7ad3a">

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained what problem this PR is solving and how it is solved.
- [x] I've linked related issues
- [x] I've included manual testing steps
- [x] I've included screenshots/recordings if applicable
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [x] I’ve properly set the pull request status:
  - [x] In case it's not yet "ready for review", I've set it to "draft".
  - [x] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
