### PR TITLE
UX: Release showing total account balance

### DIFF
--- a/ui/components/multichain/account-list-item/account-list-item.js
+++ b/ui/components/multichain/account-list-item/account-list-item.js
@@ -98,9 +98,7 @@ export const AccountListItem = ({
   const { totalWeiBalance, orderedTokenList } = useAccountTotalFiatBalance(
     identity.address,
   );
-  const balanceToTranslate = process.env.MULTICHAIN
-    ? totalWeiBalance
-    : identity.balance;
+  const balanceToTranslate = totalWeiBalance;
 
   // If this is the selected item in the Account menu,
   // scroll the item into view


### PR DESCRIPTION
## **Description**

This PR releases functionality that shows the user's total account value in the home screen and the account menu.

## **Related issues**

Fixes:

## **Manual testing steps**

1. Create an account with native balance and token balances
2. On the home screen, see the fiat sum of all tokens
3. Open the account list, see the fiat sum of all tokens on each account

## **Screenshots/Recordings**

### **Before**



### **After**

<img width="641" alt="SCR-20231207-mvsx" src="https://github.com/MetaMask/metamask-extension/assets/46655/aec72ece-b85b-4a9e-93a5-1e71f5c420a1">
<img width="937" alt="SCR-20231207-mvnz" src="https://github.com/MetaMask/metamask-extension/assets/46655/7acdd1bf-25d2-4abc-a308-fef38cb523bc">




## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've clearly explained what problem this PR is solving and how it is solved.
- [ ] I've linked related issues
- [ ] I've included manual testing steps
- [ ] I've included screenshots/recordings if applicable
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [ ] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
