### PR TITLE
fix(action): be more restrictive on the release branch format

### DIFF
--- a/.github/workflows/create-bug-report.yml
+++ b/.github/workflows/create-bug-report.yml
@@ -9,7 +9,7 @@ jobs:
       - name: Extract version from branch name if release branch
         id: extract_version
         run: |
-          if [[ "$GITHUB_REF" == "refs/heads/Version-v"* ]]; then
+          if [[ "$GITHUB_REF" =~ ^refs/heads/Version-v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             version="${GITHUB_REF#refs/heads/Version-v}"
             echo "New release branch($version), continue next steps"
             echo "version=$version" >> "$GITHUB_ENV"


### PR DESCRIPTION
## **Description**

Every time a new release branch with format `Version-vx.y.z` is created, it triggers the creation of a bug report called: "vx.y.z Bug Report".
This works fine, but the problem we have is that it sometimes also creates bug reports in situations where we don’t want it, like when someone creates a branch called `Version-vx.y.z-cherry-pick-swaps-content`. This commit adds more restrictions in the regex in order to prevent that.

This fix adds more restrictions in the regex in order to prevent that.

[Same PR for Mobile](https://github.com/MetaMask/metamask-mobile/pull/8052)

## **Related issues**

Fixes: NA

## **Manual testing steps**

- See manual testing steps in initial PR: https://github.com/MetaMask/metamask-mobile/pull/6967

## **Screenshots/Recordings**

- Example bug report which has been created while we didn't want it: https://github.com/MetaMask/mobile-planning/issues/1402

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained what problem this PR is solving and how it is solved.
- [ ] I've linked related issues
- [x] I've included manual testing steps
- [x] I've included screenshots/recordings if applicable
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [x] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [x] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
