### PR TITLE
Build types can now override build name

### DIFF
--- a/builds.yml
+++ b/builds.yml
@@ -48,7 +48,7 @@ buildTypes:
     isPrerelease: true
     # Folder which contains overrides to browser manifests
     manifestOverrides: ./app/build-types/beta/manifest/
-    buildNameOverride: false
+    buildNameOverride: MetaMask Beta
 
   flask:
     # Code surrounded using code fences for that feature
@@ -73,7 +73,7 @@ buildTypes:
       - KEYRING_SNAPS_REGISTRY_URL: https://metamask.github.io/keyring-snaps-registry/dev/registry.json
     isPrerelease: true
     manifestOverrides: ./app/build-types/flask/manifest/
-    buildNameOverride: false
+    buildNameOverride: MetaMask Flask
 
   desktop:
     features:

--- a/builds.yml
+++ b/builds.yml
@@ -31,6 +31,9 @@ buildTypes:
       - KEYRING_SNAPS_REGISTRY_URL: https://metamask.github.io/keyring-snaps-registry/prod/registry.json
     # Main build uses the default browser manifest
     manifestOverrides: false
+    # Build name used in multiple user-readable places
+    # eg. eip6963
+    buildNameOverride: MetaMask
 
   beta:
     features:
@@ -45,6 +48,7 @@ buildTypes:
     isPrerelease: true
     # Folder which contains overrides to browser manifests
     manifestOverrides: ./app/build-types/beta/manifest/
+    buildNameOverride: false
 
   flask:
     # Code surrounded using code fences for that feature
@@ -69,6 +73,7 @@ buildTypes:
       - KEYRING_SNAPS_REGISTRY_URL: https://metamask.github.io/keyring-snaps-registry/dev/registry.json
     isPrerelease: true
     manifestOverrides: ./app/build-types/flask/manifest/
+    buildNameOverride: false
 
   desktop:
     features:
@@ -89,6 +94,7 @@ buildTypes:
       - KEYRING_SNAPS_REGISTRY_URL: https://metamask.github.io/keyring-snaps-registry/prod/registry.json
     isPrerelease: true
     manifestOverrides: ./app/build-types/desktop/manifest/
+    buildNameOverride: false
 
   mmi:
     features:
@@ -109,6 +115,7 @@ buildTypes:
     # Leaving it on for backwards compatibility
     isPrerelease: true
     manifestOverrides: ./app/build-types/mmi/manifest/
+    buildNameOverride: MetaMask Institutional
 
 # Build types are composed of a set of features.
 # Each feature can have code fences that add new code

--- a/development/build/utils.js
+++ b/development/build/utils.js
@@ -246,24 +246,19 @@ function getBuildName({
   shouldIncludeSnow,
   shouldIncludeMV3,
 }) {
-  if (environment === ENVIRONMENT.PRODUCTION) {
-    switch (buildType) {
-      case 'main':
-        return `MetaMask`;
-      case 'mmi':
-        return `MetaMask Institutional`;
-      default:
-        return `MetaMask ${capitalize(buildType)}`;
-    }
+  const config = loadBuildTypesConfig();
+
+  let name =
+    config.buildTypes[buildType].buildNameOverride ||
+    `MetaMask ${capitalize(buildType)}`;
+
+  if (environment !== ENVIRONMENT.PRODUCTION) {
+    const mv3Str = shouldIncludeMV3 ? ' MV3' : '';
+    const lavamoatStr = applyLavaMoat ? ' lavamoat' : '';
+    const snowStr = shouldIncludeSnow ? ' snow' : '';
+    name += `${mv3Str}${lavamoatStr}${snowStr}`;
   }
-
-  const mv3Str = shouldIncludeMV3 ? ' MV3' : '';
-  const lavamoatStr = applyLavaMoat ? ' lavamoat' : '';
-  const snowStr = shouldIncludeSnow ? ' snow' : '';
-
-  return buildType === 'mmi'
-    ? `MetaMask Institutional${mv3Str}`
-    : `MetaMask ${capitalize(buildType)}${mv3Str}${lavamoatStr}${snowStr}`;
+  return name;
 }
 
 /**

--- a/development/lib/build-type.js
+++ b/development/lib/build-type.js
@@ -67,6 +67,7 @@ const BuildTypeStruct = object({
   env: optional(EnvArrayStruct),
   isPrerelease: optional(boolean()),
   manifestOverrides: union([string(), literal(false)]),
+  buildNameOverride: union([string(), literal(false)]),
 });
 
 const CopyAssetStruct = object({ src: string(), dest: string() });


### PR DESCRIPTION
## **Description**

This PR improves upon #22090 by extracting build name generation from hardcoded code into `builds.yml` declaration file

## **Related issues**


## **Manual testing steps**

1. `yarn build prod`
2. `yarn build prod --build-type mmi`
3. `yarn build prod --build-type flask`
4. Add each build to your browser
5. Visit [eip6963.org](https://eip6963.org/)
6. Verify names

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**
<img width="474" alt="image" src="https://github.com/MetaMask/metamask-extension/assets/1614945/07e69eca-32c9-43ce-a8d5-eb97744eb162">


<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained what problem this PR is solving and how it is solved.
- [x] I've linked related issues
- [x] I've included manual testing steps
- [x] I've included screenshots/recordings if applicable
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [ ] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
