### PR TITLE
Fix: PPOM e2e infura calls failure

### DIFF
--- a/test/e2e/tests/ppom-blockaid-alert-metrics.spec.js
+++ b/test/e2e/tests/ppom-blockaid-alert-metrics.spec.js
@@ -8,6 +8,7 @@ const {
   unlockWallet,
   withFixtures,
   getEventPayloads,
+  switchToNotificationWindow,
 } = require('../helpers');
 
 const selectedAddress = '0x5cfe73b6021e818b776b421b1c4db2474086a7e1';
@@ -282,14 +283,12 @@ describe('Confirmation Security Alert - Blockaid @no-mmi', function () {
         await driver.clickElement('#maliciousApprovalButton');
 
         // Wait for confirmation pop-up
-        let windowHandles = await driver.waitUntilXWindowHandles(3);
-        await driver.switchToWindowWithTitle(
-          WINDOW_TITLES.Notification,
-          windowHandles,
-        );
+        await switchToNotificationWindow(driver, 3);
 
         // Wait for confirmation pop-up to close
         await driver.clickElement({ text: 'Reject', tag: 'button' });
+
+        const windowHandles = await driver.waitUntilXWindowHandles(3);
         await driver.switchToWindowWithTitle(
           WINDOW_TITLES.TestDApp,
           windowHandles,
@@ -299,11 +298,7 @@ describe('Confirmation Security Alert - Blockaid @no-mmi', function () {
         await driver.clickElement('#maliciousPermit');
 
         // Wait for confirmation pop-up
-        windowHandles = await driver.waitUntilXWindowHandles(3);
-        await driver.switchToWindowWithTitle(
-          WINDOW_TITLES.Notification,
-          windowHandles,
-        );
+        await switchToNotificationWindow(driver, 3);
 
         // Wait for confirmation pop-up to close
         await driver.clickElement({ text: 'Reject', tag: 'button' });
@@ -324,7 +319,6 @@ describe('Confirmation Security Alert - Blockaid @no-mmi', function () {
             ppom_eth_chainId_count: 1,
             ppom_eth_getBlockByNumber_count: 1,
             ppom_debug_traceCall_count: 3,
-            ppom_eth_getBalance_count: 2,
             ppom_eth_call_count: 1,
           },
           userId: 'fake-metrics-id',
@@ -344,8 +338,6 @@ describe('Confirmation Security Alert - Blockaid @no-mmi', function () {
               events[0].properties.ppom_eth_getBlockByNumber_count,
             ppom_debug_traceCall_count:
               events[0].properties.ppom_debug_traceCall_count,
-            ppom_eth_getBalance_count:
-              events[0].properties.ppom_eth_getBalance_count,
             ppom_eth_call_count: events[0].properties.ppom_eth_call_count,
           },
           userId: events[0].userId,
@@ -361,7 +353,6 @@ describe('Confirmation Security Alert - Blockaid @no-mmi', function () {
             ppom_eth_chainId_count: 1,
             ppom_eth_getBlockByNumber_count: 1,
             ppom_eth_call_count: 1,
-            ppom_eth_getBalance_count: 1,
             ppom_debug_traceCall_count: 1,
           },
           userId: 'fake-metrics-id',
@@ -379,8 +370,6 @@ describe('Confirmation Security Alert - Blockaid @no-mmi', function () {
             ppom_eth_getBlockByNumber_count:
               events[1].properties.ppom_eth_getBlockByNumber_count,
             ppom_eth_call_count: events[1].properties.ppom_eth_call_count,
-            ppom_eth_getBalance_count:
-              events[1].properties.ppom_eth_getBalance_count,
             ppom_debug_traceCall_count:
               events[1].properties.ppom_debug_traceCall_count,
           },

--- a/test/e2e/tests/send-eth.spec.js
+++ b/test/e2e/tests/send-eth.spec.js
@@ -368,7 +368,10 @@ describe('Send ETH from inside MetaMask to a Multisig Address', function () {
     await withFixtures(
       {
         fixtures: new FixtureBuilder().build(),
-        ganacheOptions: defaultGanacheOptions,
+        ganacheOptions: {
+          ...defaultGanacheOptions,
+          hardfork: 'london',
+        },
         smartContract,
         title: this.test.fullTitle(),
       },


### PR DESCRIPTION
## **Description**

ppom metrics is failing because on CI we get this from ppom calls

```
ppom_eth_call_count: 1,
ppom_eth_chainId_count: 1,
ppom_eth_getBlockByNumber_count: 1,
ppom_debug_traceCall_count: 1,
```

But if we run same test manually, we get this

```
ppom_eth_chainId_count: 1,
ppom_eth_getBlockByNumber_count: 1,
ppom_eth_call_count: 1,
ppom_eth_getBalance_count: 1,
ppom_debug_traceCall_count: 1,
```

One quick fix is to remove the check for the getBalance in e2e (first part of this PR)

The second part of this PR is to fix why the e2e sometimes fail on Firefox with timeout errors

this code
```
        await driver.switchToWindowWithTitle(
          WINDOW_TITLES.Notification,
          windowHandles,
        );
```

waits for a window with title `Notification`, but the title of the window is `Metamask Dialog`. 

The other changes in this PR fixes the flaky `test/e2e/tests/send-eth.spec.js` tests. I have explained the reason for the changes in the PR comments.

## **Related issues**

## **Manual testing steps**

1. Checkout develop
2. Build test
3. run `SELENIUM_BROWSER=chrome yarn test:e2e:single test/e2e/tests/ppom-blockaid-alert-metrics.spec.js`
4. See that it fails
5. checkout this branch and repeat 2, 3
6. See that it passed

## **Screenshots/Recordings**

### **Before**
<img width="610" alt="Screenshot 2023-12-12 at 17 05 50" src="https://github.com/MetaMask/metamask-extension/assets/44811/d621e40f-0c22-455e-8945-feda2bb6c9c7">

### **After**
<img width="1710" alt="Screenshot 2023-12-12 at 13 56 01" src="https://github.com/MetaMask/metamask-extension/assets/44811/81022677-8c63-46df-8cb5-08009720ab8a">

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained what problem this PR is solving and how it is solved.
- [x] I've linked related issues
- [x] I've included manual testing steps
- [x] I've included screenshots/recordings if applicable
- [ ] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [x] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [x] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
