### PR TITLE
Fix issue with calling `getUnlockPromise` multiple times

### DIFF
--- a/app/scripts/controllers/app-state.js
+++ b/app/scripts/controllers/app-state.js
@@ -442,6 +442,10 @@ export default class AppStateController extends EventEmitter {
   }
 
   _requestApproval() {
+    // If we already have a pending request this is a no-op
+    if (this._approvalRequestId) {
+      return;
+    }
     this._approvalRequestId = uuid();
 
     this.messagingSystem
@@ -455,7 +459,8 @@ export default class AppStateController extends EventEmitter {
         true,
       )
       .catch(() => {
-        // Intentionally ignored as promise not currently used
+        // If the promise fails, we allow a new popup to be triggered
+        this._approvalRequestId = null;
       });
   }
 


### PR DESCRIPTION
## **Description**

Fix an issue with calling `getUnlockPromise` multiple times. Since the function now uses the ApprovalController, users would receive the following internal error: 
```RPC Error: Request of type 'unlock' already pending for origin metamask. Please wait. ``` 

This PR changes the logic slightly and makes `_requestApproval` a no-op if there is already a pending approval. It also makes sure to reset the current approval ID if the user rejects the initial popup.

## **Manual testing steps**

1. Install the BIP-32 and BIP-44 snap from here: https://metamask.github.io/snaps/test-snaps/latest/
2. Click the Get Public Key button for both without signing in to MetaMask
3. Notice no errors in the browser console
4. Sign in to MetaMask
5. Notice the public keys are populated.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

https://github.com/MetaMask/metamask-extension/assets/1561200/f20d382f-6067-4ab0-8fc3-252efcf0e9d8

### **After**

https://github.com/MetaMask/metamask-extension/assets/1561200/b90a70a1-d51c-419c-a3fd-98aadcaae625


