### PR TITLE
Hotfix: TS lint error asset picker modal

### DIFF
--- a/ui/components/component-library/text-field-search/text-field-search.types.ts
+++ b/ui/components/component-library/text-field-search/text-field-search.types.ts
@@ -19,7 +19,7 @@ type MakePropsOptional<T> = {
 };
 
 export interface TextFieldSearchStyleUtilityProps
-  extends Omit<TextFieldProps<'input'>, 'type'> {
+  extends Omit<TextFieldProps<'input'>, 'type' | 'size'> {
   /**
    * The value of the TextFieldSearch
    */
@@ -54,6 +54,10 @@ export interface TextFieldSearchStyleUtilityProps
    * Attributes applied to the `input` element.
    */
   inputProps?: InputProps<'input'>;
+  /**
+   * The size of the TextFieldSearch
+   */
+  size?: TextFieldSearchSize;
 }
 
 export type TextFieldSearchProps<C extends React.ElementType> =

--- a/ui/components/multichain/asset-picker-amount/asset-picker-modal/asset-picker-modal.tsx
+++ b/ui/components/multichain/asset-picker-amount/asset-picker-modal/asset-picker-modal.tsx
@@ -15,6 +15,8 @@ import {
   Text,
   ButtonLink,
   ButtonLinkSize,
+  ButtonIconSize,
+  TextFieldSearchSize,
 } from '../../../component-library';
 import {
   BlockSize,
@@ -265,7 +267,7 @@ export function AssetPickerModal({
                     width={BlockSize.Full}
                     clearButtonOnClick={() => setSearchQuery('')}
                     clearButtonProps={{
-                      size: Size.SM,
+                      size: ButtonIconSize.Sm,
                     }}
                     showClearButton={true}
                     className="asset-picker-modal__search-list"
@@ -273,7 +275,7 @@ export function AssetPickerModal({
                       'data-testid': 'asset-picker-modal-search-input',
                     }}
                     endAccessory={null}
-                    size={Size.LG}
+                    size={TextFieldSearchSize.Lg}
                   />
                 </Box>
                 <Box className="tokens-main-view-modal">
@@ -361,7 +363,7 @@ export function AssetPickerModal({
                     width={BlockSize.Full}
                     clearButtonOnClick={() => setSearchQuery('')}
                     clearButtonProps={{
-                      size: Size.SM,
+                      size: ButtonIconSize.Sm,
                     }}
                     showClearButton={true}
                     className="asset-picker-modal__search-list"
@@ -369,7 +371,7 @@ export function AssetPickerModal({
                       'data-testid': 'asset-picker-modal-search-input',
                     }}
                     endAccessory={null}
-                    size={Size.LG}
+                    size={TextFieldSearchSize.Lg}
                   />
                 </Box>
                 {hasAnyNfts ? (

--- a/ui/components/multichain/asset-picker-amount/asset-picker-modal/asset-picker-modal.tsx
+++ b/ui/components/multichain/asset-picker-amount/asset-picker-modal/asset-picker-modal.tsx
@@ -20,7 +20,6 @@ import {
 } from '../../../component-library';
 import {
   BlockSize,
-  Size,
   BorderRadius,
   BackgroundColor,
   TextColor,


### PR DESCRIPTION
## **Description**
Fix TS lint issue on asset modal picker and fix size prop on TextFieldSearch

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
<img width="1058" alt="Screenshot 2023-12-12 at 9 28 50 AM" src="https://github.com/MetaMask/metamask-extension/assets/26469696/5d0d3da6-334f-42e1-992a-2d343089c1d2">

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained what problem this PR is solving and how it is solved.
- [x] I've linked related issues
- [ ] I've included manual testing steps
- [x] I've included screenshots/recordings if applicable
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [x] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [x] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
