### PR TITLE
UX: set notification popup title differently on test builds

### DIFF
--- a/app/notification.html
+++ b/app/notification.html
@@ -3,10 +3,15 @@
   <head>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta charset="utf-8" />
+
+    {{ @if (it.isTest) }}
     <title>MetaMask Dialog</title>
-    {{@if(it.isMMI)}}
+    {{ #elif (it.isMMI) }}
     <title>MetaMask Institutional</title>
+    {{ #else }}
+    <title>MetaMask</title>
     {{/if}}
+
     <style>
       #app-content {
         display: flex;

--- a/development/build/scripts.js
+++ b/development/build/scripts.js
@@ -735,6 +735,9 @@ function createFactoredBuild({
               browserPlatforms,
               applyLavaMoat,
               isMMI: buildType === 'mmi',
+              isTest:
+                buildTarget === BUILD_TARGETS.TEST ||
+                buildTarget === BUILD_TARGETS.TEST_DEV,
             });
             renderHtmlFile({
               htmlName: 'home',
@@ -1282,7 +1285,13 @@ function renderJavaScriptLoader({
   });
 }
 
-function renderHtmlFile({ htmlName, browserPlatforms, applyLavaMoat, isMMI }) {
+function renderHtmlFile({
+  htmlName,
+  browserPlatforms,
+  applyLavaMoat,
+  isMMI,
+  isTest,
+}) {
   if (applyLavaMoat === undefined) {
     throw new Error(
       'build/scripts/renderHtmlFile - must specify "applyLavaMoat" option',
@@ -1291,7 +1300,7 @@ function renderHtmlFile({ htmlName, browserPlatforms, applyLavaMoat, isMMI }) {
   const htmlFilePath = `./app/${htmlName}.html`;
   const htmlTemplate = readFileSync(htmlFilePath, 'utf8');
 
-  const htmlOutput = Sqrl.render(htmlTemplate, { isMMI });
+  const htmlOutput = Sqrl.render(htmlTemplate, { isMMI, isTest });
   browserPlatforms.forEach((platform) => {
     const dest = `./dist/${platform}/${htmlName}.html`;
     // we dont have a way of creating async events atm

--- a/test/e2e/tests/ppom-blockaid-alert-metrics.spec.js
+++ b/test/e2e/tests/ppom-blockaid-alert-metrics.spec.js
@@ -2,12 +2,13 @@ const { strict: assert } = require('assert');
 const FixtureBuilder = require('../fixture-builder');
 const { mockServerJsonRpc } = require('../mock-server-json-rpc');
 const {
-  WINDOW_TITLES,
   defaultGanacheOptions,
+  getEventPayloads,
   openDapp,
+  switchToNotificationWindow,
   unlockWallet,
   withFixtures,
-  getEventPayloads,
+  WINDOW_TITLES,
 } = require('../helpers');
 
 const selectedAddress = '0x5cfe73b6021e818b776b421b1c4db2474086a7e1';
@@ -282,35 +283,21 @@ describe('Confirmation Security Alert - Blockaid @no-mmi', function () {
         await driver.clickElement('#maliciousApprovalButton');
 
         // Wait for confirmation pop-up
-        let windowHandles = await driver.waitUntilXWindowHandles(3);
-        await driver.switchToWindowWithTitle(
-          WINDOW_TITLES.Notification,
-          windowHandles,
-        );
+        await switchToNotificationWindow(driver, 3);
 
         // Wait for confirmation pop-up to close
         await driver.clickElement({ text: 'Reject', tag: 'button' });
-        await driver.switchToWindowWithTitle(
-          WINDOW_TITLES.TestDApp,
-          windowHandles,
-        );
+        await driver.switchToWindowWithTitle(WINDOW_TITLES.TestDApp);
 
         // Click TestDapp button to send JSON-RPC request
         await driver.clickElement('#maliciousPermit');
 
         // Wait for confirmation pop-up
-        windowHandles = await driver.waitUntilXWindowHandles(3);
-        await driver.switchToWindowWithTitle(
-          WINDOW_TITLES.Notification,
-          windowHandles,
-        );
+        await switchToNotificationWindow(driver, 3);
 
         // Wait for confirmation pop-up to close
         await driver.clickElement({ text: 'Reject', tag: 'button' });
-        await driver.switchToWindowWithTitle(
-          WINDOW_TITLES.TestDApp,
-          windowHandles,
-        );
+        await driver.switchToWindowWithTitle(WINDOW_TITLES.TestDApp);
 
         const events = await getEventPayloads(driver, mockedEndpoints);
 

--- a/test/e2e/tests/ppom-blockaid-alert-metrics.spec.js
+++ b/test/e2e/tests/ppom-blockaid-alert-metrics.spec.js
@@ -2,13 +2,12 @@ const { strict: assert } = require('assert');
 const FixtureBuilder = require('../fixture-builder');
 const { mockServerJsonRpc } = require('../mock-server-json-rpc');
 const {
+  WINDOW_TITLES,
   defaultGanacheOptions,
-  getEventPayloads,
   openDapp,
-  switchToNotificationWindow,
   unlockWallet,
   withFixtures,
-  WINDOW_TITLES,
+  getEventPayloads,
 } = require('../helpers');
 
 const selectedAddress = '0x5cfe73b6021e818b776b421b1c4db2474086a7e1';
@@ -283,21 +282,35 @@ describe('Confirmation Security Alert - Blockaid @no-mmi', function () {
         await driver.clickElement('#maliciousApprovalButton');
 
         // Wait for confirmation pop-up
-        await switchToNotificationWindow(driver, 3);
+        let windowHandles = await driver.waitUntilXWindowHandles(3);
+        await driver.switchToWindowWithTitle(
+          WINDOW_TITLES.Notification,
+          windowHandles,
+        );
 
         // Wait for confirmation pop-up to close
         await driver.clickElement({ text: 'Reject', tag: 'button' });
-        await driver.switchToWindowWithTitle(WINDOW_TITLES.TestDApp);
+        await driver.switchToWindowWithTitle(
+          WINDOW_TITLES.TestDApp,
+          windowHandles,
+        );
 
         // Click TestDapp button to send JSON-RPC request
         await driver.clickElement('#maliciousPermit');
 
         // Wait for confirmation pop-up
-        await switchToNotificationWindow(driver, 3);
+        windowHandles = await driver.waitUntilXWindowHandles(3);
+        await driver.switchToWindowWithTitle(
+          WINDOW_TITLES.Notification,
+          windowHandles,
+        );
 
         // Wait for confirmation pop-up to close
         await driver.clickElement({ text: 'Reject', tag: 'button' });
-        await driver.switchToWindowWithTitle(WINDOW_TITLES.TestDApp);
+        await driver.switchToWindowWithTitle(
+          WINDOW_TITLES.TestDApp,
+          windowHandles,
+        );
 
         const events = await getEventPayloads(driver, mockedEndpoints);
 


### PR DESCRIPTION
## **Description**

On a standard build, the notification popup window title will be just `MetaMask`

For E2E tests, it is necessary to set it to something different, so it will be `MetaMask Dialog`

## **Related issues**

Followup to #21680

## **Manual testing steps**

1. On a standard build, go to https://metamask.github.io/test-dapp/ and prompt a popup
2. Confirm that the window's title is just `MetaMask`
3. Confirm that the E2E tests still work

## **Screenshots/Recordings**

### **Standard Build**

![image](https://github.com/MetaMask/metamask-extension/assets/539738/619188dc-0645-4826-9000-798a0b4e7d03)

### **Test Build**

![image](https://github.com/MetaMask/metamask-extension/assets/539738/67835aab-fde7-4cb1-99f4-eafc2106b33c)


## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained what problem this PR is solving and how it is solved.
- [x] I've linked related issues
- [x] I've included manual testing steps
- [x] I've included screenshots/recordings if applicable
- [x] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [x] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [x] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.