### PR TITLE
UX: Added account hiding in the Account List Menu

### DIFF
--- a/.storybook/test-data.js
+++ b/.storybook/test-data.js
@@ -32,6 +32,7 @@ const state = {
     },
     orderedNetworkList: [],
     pinnedAccountList: [],
+    hiddenAccountList: [],
     tokenList: {
       '0x514910771af9ca656af840dff83e8264ecf986ca': {
         address: '0x514910771af9ca656af840dff83e8264ecf986ca',

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -1889,6 +1889,9 @@
   "hexData": {
     "message": "Hex data"
   },
+  "hiddenAccounts": {
+    "message": "Hidden accounts"
+  },
   "hide": {
     "message": "Hide"
   },

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -1892,6 +1892,9 @@
   "hide": {
     "message": "Hide"
   },
+  "hideAccount": {
+    "message": "Hide account"
+  },
   "hideFullTransactionDetails": {
     "message": "Hide full transaction details"
   },
@@ -4163,6 +4166,9 @@
   },
   "show": {
     "message": "Show"
+  },
+  "showAccount": {
+    "message": "Show account"
   },
   "showFiatConversionInTestnets": {
     "message": "Show conversion on test networks"

--- a/app/scripts/controllers/account-order.ts
+++ b/app/scripts/controllers/account-order.ts
@@ -25,8 +25,8 @@ export type AccountOrderControllerupdateAccountsListAction = {
 
 // Describes the action for updating the accounts list
 export type AccountOrderControllerhideAccountsListAction = {
-  type: `${typeof controllerName}:hideAccountsList`;
-  handler: AccountOrderController['hideAccountsList'];
+  type: `${typeof controllerName}:updateHiddenAccountsList`;
+  handler: AccountOrderController['updateHiddenAccountsList'];
 };
 
 // Union of all possible actions for the messenger
@@ -113,7 +113,7 @@ export class AccountOrderController extends BaseController<
    * @param accountList - The list of accounts to hide in the state.
    */
 
-  hideAccountsList(accountList: []) {
+  updateHiddenAccountsList(accountList: []) {
     this.update((state) => {
       state.hiddenAccountList = accountList;
       return state;

--- a/app/scripts/controllers/account-order.ts
+++ b/app/scripts/controllers/account-order.ts
@@ -14,6 +14,7 @@ export type AccountAddress = string;
 // State shape for AccountOrderController
 export type AccountOrderControllerState = {
   pinnedAccountList: AccountAddress[];
+  hiddenAccountList: AccountAddress[];
 };
 
 // Describes the action for updating the accounts list
@@ -22,9 +23,16 @@ export type AccountOrderControllerupdateAccountsListAction = {
   handler: AccountOrderController['updateAccountsList'];
 };
 
+// Describes the action for updating the accounts list
+export type AccountOrderControllerhideAccountsListAction = {
+  type: `${typeof controllerName}:hideAccountsList`;
+  handler: AccountOrderController['hideAccountsList'];
+};
+
 // Union of all possible actions for the messenger
 export type AccountOrderControllerMessengerActions =
-  AccountOrderControllerupdateAccountsListAction;
+  | AccountOrderControllerupdateAccountsListAction
+  | AccountOrderControllerhideAccountsListAction;
 
 // Type for the messenger of AccountOrderController
 export type AccountOrderControllerMessenger = RestrictedControllerMessenger<
@@ -38,11 +46,16 @@ export type AccountOrderControllerMessenger = RestrictedControllerMessenger<
 // Default state for the controller
 const defaultState = {
   pinnedAccountList: [],
+  hiddenAccountList: [],
 };
 
 // Metadata for the controller state
 const metadata = {
   pinnedAccountList: {
+    persist: true,
+    anonymous: true,
+  },
+  hiddenAccountList: {
     persist: true,
     anonymous: true,
   },
@@ -90,6 +103,19 @@ export class AccountOrderController extends BaseController<
   updateAccountsList(accountList: []) {
     this.update((state) => {
       state.pinnedAccountList = accountList;
+      return state;
+    });
+  }
+
+  /**
+   * Hides the accounts list in the state with the provided list of accounts.
+   *
+   * @param accountList - The list of accounts to hide in the state.
+   */
+
+  hideAccountsList(accountList: []) {
+    this.update((state) => {
+      state.hiddenAccountList = accountList;
       return state;
     });
   }

--- a/app/scripts/lib/setupSentry.js
+++ b/app/scripts/lib/setupSentry.js
@@ -56,6 +56,7 @@ export const SENTRY_BACKGROUND_STATE = {
   },
   AccountOrderController: {
     pinnedAccountList: [],
+    hiddenAccountList: [],
   },
   AppMetadataController: {
     currentAppVersion: true,

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -3124,7 +3124,7 @@ export default class MetamaskController extends EventEmitter {
       updateCaveat: this.updateCaveat.bind(this),
       updateNetworksList: this.updateNetworksList.bind(this),
       updateAccountsList: this.updateAccountsList.bind(this),
-      hideAccountsList: this.hideAccountsList.bind(this),
+      updateHiddenAccountsList: this.updateHiddenAccountsList.bind(this),
       getPhishingResult: async (website) => {
         await phishingController.maybeUpdateState();
 
@@ -5498,9 +5498,9 @@ export default class MetamaskController extends EventEmitter {
     }
   };
 
-  hideAccountsList = (hiddenAccountList) => {
+  updateHiddenAccountsList = (hiddenAccountList) => {
     try {
-      this.accountOrderController.hideAccountsList(hiddenAccountList);
+      this.accountOrderController.updateHiddenAccountsList(hiddenAccountList);
     } catch (err) {
       log.error(err.message);
       throw err;

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -3124,6 +3124,7 @@ export default class MetamaskController extends EventEmitter {
       updateCaveat: this.updateCaveat.bind(this),
       updateNetworksList: this.updateNetworksList.bind(this),
       updateAccountsList: this.updateAccountsList.bind(this),
+      hideAccountsList: this.hideAccountsList.bind(this),
       getPhishingResult: async (website) => {
         await phishingController.maybeUpdateState();
 
@@ -5491,6 +5492,15 @@ export default class MetamaskController extends EventEmitter {
   updateAccountsList = (pinnedAccountList) => {
     try {
       this.accountOrderController.updateAccountsList(pinnedAccountList);
+    } catch (err) {
+      log.error(err.message);
+      throw err;
+    }
+  };
+
+  hideAccountsList = (hiddenAccountList) => {
+    try {
+      this.accountOrderController.hideAccountsList(hiddenAccountList);
     } catch (err) {
       log.error(err.message);
       throw err;

--- a/test/data/mock-state.json
+++ b/test/data/mock-state.json
@@ -436,6 +436,7 @@
     "openSeaEnabled": true,
     "orderedNetworkList": [],
     "pinnedAccountList": [],
+    "hiddenAccountList": [],
     "advancedGasFee": {
       "0x5": {
         "maxBaseFee": "75",

--- a/test/e2e/fixture-builder.js
+++ b/test/e2e/fixture-builder.js
@@ -186,6 +186,7 @@ function defaultFixture() {
       },
       AccountOrderController: {
         pinnedAccountList: [],
+        hiddenAccountList: [],
       },
       AppStateController: {
         browserEnvironment: {},

--- a/test/e2e/tests/add-account.spec.js
+++ b/test/e2e/tests/add-account.spec.js
@@ -157,12 +157,11 @@ describe('Add account', function () {
         });
 
         // Check address of 2nd account
-        const accountTwoSelector = await findAnotherAccountFromAccountList(
-          driver,
-          2,
-          'Account 2',
-        );
-        await driver.clickElement(accountTwoSelector);
+        await driver.clickElement('[data-testid="account-menu-icon"]');
+        await driver.clickElement({
+          css: `.multichain-account-list-item__account-name__button`,
+          text: 'Account 2',
+        });
 
         await driver.findElement({
           css: process.env.MULTICHAIN

--- a/test/e2e/tests/import-flow.spec.js
+++ b/test/e2e/tests/import-flow.spec.js
@@ -12,6 +12,7 @@ const {
   openActionMenuAndStartSendFlow,
   unlockWallet,
   WALLET_PASSWORD,
+  waitForAccountRendered,
 } = require('../helpers');
 const FixtureBuilder = require('../fixture-builder');
 const { emptyHtmlPage } = require('../mock-e2e');
@@ -297,12 +298,13 @@ describe('Import flow @no-mmi', function () {
       },
       async ({ driver }) => {
         await unlockWallet(driver);
-
+        await waitForAccountRendered(driver);
         // Imports an account with JSON file
         await driver.clickElement('[data-testid="account-menu-icon"]');
         await driver.clickElement(
           '[data-testid="multichain-account-menu-popover-action-button"]',
         );
+
         await driver.clickElement({ text: 'Import account', tag: 'button' });
 
         await driver.clickElement('.dropdown__select');
@@ -323,19 +325,17 @@ describe('Import flow @no-mmi', function () {
           '[data-testid="import-account-confirm-button"]',
         );
 
+        await waitForAccountRendered(driver);
         // New imported account has correct name and label
         await driver.findClickableElement({
           css: '[data-testid="account-menu-icon"]',
           text: 'Account 4',
         });
 
-        const accountMenuItemSelector = await findAnotherAccountFromAccountList(
-          driver,
-          4,
-          'Account 4',
-        );
+        await driver.clickElement('[data-testid="account-menu-icon"]');
+
         await driver.findElement({
-          css: `${accountMenuItemSelector} .mm-tag`,
+          css: `.multichain-account-list-item--selected .multichain-account-list-item__content .mm-tag`,
           text: 'Imported',
         });
 

--- a/test/e2e/tests/import-flow.spec.js
+++ b/test/e2e/tests/import-flow.spec.js
@@ -8,7 +8,6 @@ const {
   largeDelayMs,
   completeImportSRPOnboardingFlow,
   completeImportSRPOnboardingFlowWordByWord,
-  findAnotherAccountFromAccountList,
   openActionMenuAndStartSendFlow,
   unlockWallet,
   WALLET_PASSWORD,
@@ -232,14 +231,9 @@ describe('Import flow @no-mmi', function () {
           css: '[data-testid="account-menu-icon"]',
           text: 'Account 4',
         });
-
-        const accountMenuItemSelector = await findAnotherAccountFromAccountList(
-          driver,
-          4,
-          'Account 4',
-        );
+        await driver.clickElement('[data-testid="account-menu-icon"]');
         await driver.findElement({
-          css: `${accountMenuItemSelector} .mm-tag`,
+          css: `.multichain-account-list-item--selected .multichain-account-list-item__content .mm-tag`,
           text: 'Imported',
         });
 

--- a/test/e2e/tests/state-snapshots/errors-after-init-opt-in-background-state.json
+++ b/test/e2e/tests/state-snapshots/errors-after-init-opt-in-background-state.json
@@ -1,5 +1,8 @@
 {
-  "AccountOrderController": { "pinnedAccountList": {} },
+  "AccountOrderController": {
+    "pinnedAccountList": {},
+    "hiddenAccountList": {}
+  },
   "AccountTracker": {
     "accounts": "object",
     "accountsByChainId": "object"

--- a/test/e2e/tests/state-snapshots/errors-after-init-opt-in-ui-state.json
+++ b/test/e2e/tests/state-snapshots/errors-after-init-opt-in-ui-state.json
@@ -132,6 +132,7 @@
     "announcements": "object",
     "orderedNetworkList": { "0": "string", "1": "string", "2": "string" },
     "pinnedAccountList": {},
+    "hiddenAccountList": {},
     "gasFeeEstimates": {},
     "gasFeeEstimatesByChainId": {},
     "estimatedGasFeeTimeBounds": {},

--- a/test/e2e/tests/state-snapshots/errors-before-init-opt-in-background-state.json
+++ b/test/e2e/tests/state-snapshots/errors-before-init-opt-in-background-state.json
@@ -10,7 +10,10 @@
     },
     "AnnouncementController": { "announcements": "object" },
     "NetworkOrderController": { "orderedNetworkList": {} },
-    "AccountOrderController": { "pinnedAccountList": {} },
+    "AccountOrderController": {
+      "pinnedAccountList": {},
+      "hiddenAccountList": {}
+    },
     "AppStateController": {
       "browserEnvironment": {},
       "nftsDropdownState": {},

--- a/test/e2e/tests/state-snapshots/errors-before-init-opt-in-ui-state.json
+++ b/test/e2e/tests/state-snapshots/errors-before-init-opt-in-ui-state.json
@@ -10,7 +10,10 @@
     },
     "AnnouncementController": { "announcements": "object" },
     "NetworkOrderController": { "orderedNetworkList": {} },
-    "AccountOrderController": { "pinnedAccountList": {} },
+    "AccountOrderController": {
+      "pinnedAccountList": {},
+      "hiddenAccountList": {}
+    },
     "AppStateController": {
       "browserEnvironment": {},
       "nftsDropdownState": {},

--- a/ui/components/multichain/account-list-item-menu/account-list-item-menu.js
+++ b/ui/components/multichain/account-list-item-menu/account-list-item-menu.js
@@ -213,7 +213,7 @@ export const AccountListItemMenu = ({
               iconName={isHidden ? IconName.Eye : IconName.EyeSlash}
             >
               <Text variant={TextVariant.bodySm}>
-                {isHidden ? t('showAccount') : t('showAccount')}
+                {isHidden ? t('showAccount') : t('hideAccount')}
               </Text>
             </MenuItem>
           ) : null}

--- a/ui/components/multichain/account-list-item-menu/account-list-item-menu.js
+++ b/ui/components/multichain/account-list-item-menu/account-list-item-menu.js
@@ -146,6 +146,9 @@ export const AccountListItemMenu = ({
 
   const handleHidding = (address) => {
     const updatedHiddenAccountList = [...hiddenAccountList, address];
+    if (pinnedAccountList.includes(address)) {
+      handleUnpinning(address);
+    }
     dispatch(hideAccountsList(updatedHiddenAccountList));
   };
 
@@ -153,7 +156,7 @@ export const AccountListItemMenu = ({
     const updatedHiddenAccountList = hiddenAccountList.filter(
       (item) => item !== address,
     );
-    dispatch(updateAccountsList(updatedHiddenAccountList));
+    dispatch(hideAccountsList(updatedHiddenAccountList));
   };
 
   return (
@@ -182,7 +185,7 @@ export const AccountListItemMenu = ({
             textProps={{ variant: TextVariant.bodySm }}
             address={identity.address}
           />
-          {process.env.NETWORK_ACCOUNT_DND ? (
+          {process.env.NETWORK_ACCOUNT_DND && !isHidden ? (
             <MenuItem
               data-testid="account-list-menu-pin"
               onClick={() => {
@@ -210,7 +213,7 @@ export const AccountListItemMenu = ({
               iconName={isHidden ? IconName.Eye : IconName.EyeSlash}
             >
               <Text variant={TextVariant.bodySm}>
-                {isHidden ? t('unpin') : t('pinToTop')}
+                {isHidden ? t('showAccount') : t('showAccount')}
               </Text>
             </MenuItem>
           ) : null}

--- a/ui/components/multichain/account-list-item-menu/account-list-item-menu.js
+++ b/ui/components/multichain/account-list-item-menu/account-list-item-menu.js
@@ -34,9 +34,9 @@ import {
   MetaMetricsEventName,
 } from '../../../../shared/constants/metametrics';
 import {
-  hideAccountsList,
   showModal,
   updateAccountsList,
+  updateHiddenAccountsList,
 } from '../../../store/actions';
 import { TextVariant } from '../../../helpers/constants/design-system';
 import { formatAccountType } from '../../../helpers/utils/metrics';
@@ -149,14 +149,14 @@ export const AccountListItemMenu = ({
     if (pinnedAccountList.includes(address)) {
       handleUnpinning(address);
     }
-    dispatch(hideAccountsList(updatedHiddenAccountList));
+    dispatch(updateHiddenAccountsList(updatedHiddenAccountList));
   };
 
   const handleUnhidding = (address) => {
     const updatedHiddenAccountList = hiddenAccountList.filter(
       (item) => item !== address,
     );
-    dispatch(hideAccountsList(updatedHiddenAccountList));
+    dispatch(updateHiddenAccountsList(updatedHiddenAccountList));
   };
 
   return (

--- a/ui/components/multichain/account-list-item/account-list-item.js
+++ b/ui/components/multichain/account-list-item/account-list-item.js
@@ -289,7 +289,7 @@ export const AccountListItem = ({
           isRemovable={identity.keyring.type !== KeyringType.hdKeyTree}
           closeMenu={closeMenu}
           isPinned={process.env.NETWORK_ACCOUNT_DND ? isPinned : null}
-          ishidden={process.env.NETWORK_ACCOUNT_DND ? isHidden : null}
+          isHidden={process.env.NETWORK_ACCOUNT_DND ? isHidden : null}
         />
       ) : null}
     </Box>

--- a/ui/components/multichain/account-list-item/account-list-item.js
+++ b/ui/components/multichain/account-list-item/account-list-item.js
@@ -286,7 +286,7 @@ export const AccountListItem = ({
           identity={identity}
           onClose={() => setAccountOptionsMenuOpen(false)}
           isOpen={accountOptionsMenuOpen}
-          isRemovable={identity.keyring.type !== KeyringType.hdKeyTree}
+          isRemovable={identity.keyring?.type !== KeyringType.hdKeyTree}
           closeMenu={closeMenu}
           isPinned={process.env.NETWORK_ACCOUNT_DND ? isPinned : null}
           isHidden={process.env.NETWORK_ACCOUNT_DND ? isHidden : null}

--- a/ui/components/multichain/account-list-item/account-list-item.js
+++ b/ui/components/multichain/account-list-item/account-list-item.js
@@ -62,6 +62,7 @@ export const AccountListItem = ({
   connectedAvatarName,
   isPinned = false,
   showOptions = false,
+  isHidden = false,
 }) => {
   const t = useI18nContext();
   const [accountOptionsMenuOpen, setAccountOptionsMenuOpen] = useState(false);
@@ -148,6 +149,9 @@ export const AccountListItem = ({
             >
               {process.env.NETWORK_ACCOUNT_DND && isPinned ? (
                 <Icon name={IconName.Pin} size={IconSize.Xs} />
+              ) : null}
+              {process.env.NETWORK_ACCOUNT_DND && isHidden ? (
+                <Icon name={IconName.Eye} size={IconSize.Xs} />
               ) : null}
               <Text
                 as="button"
@@ -285,6 +289,7 @@ export const AccountListItem = ({
           isRemovable={identity.keyring.type !== KeyringType.hdKeyTree}
           closeMenu={closeMenu}
           isPinned={process.env.NETWORK_ACCOUNT_DND ? isPinned : null}
+          ishidden={process.env.NETWORK_ACCOUNT_DND ? isHidden : null}
         />
       ) : null}
     </Box>
@@ -332,6 +337,10 @@ AccountListItem.propTypes = {
    * Represents pinned accounts
    */
   isPinned: PropTypes.bool,
+  /**
+   * Represents hidden accounts
+   */
+  isHidden: PropTypes.bool,
 };
 
 AccountListItem.displayName = 'AccountListItem';

--- a/ui/components/multichain/account-list-item/account-list-item.js
+++ b/ui/components/multichain/account-list-item/account-list-item.js
@@ -151,7 +151,7 @@ export const AccountListItem = ({
                 <Icon name={IconName.Pin} size={IconSize.Xs} />
               ) : null}
               {process.env.NETWORK_ACCOUNT_DND && isHidden ? (
-                <Icon name={IconName.Eye} size={IconSize.Xs} />
+                <Icon name={IconName.EyeSlash} size={IconSize.Xs} />
               ) : null}
               <Text
                 as="button"

--- a/ui/components/multichain/account-list-menu/account-list-menu.js
+++ b/ui/components/multichain/account-list-menu/account-list-menu.js
@@ -407,7 +407,7 @@ export const AccountListMenu = ({
               })}
             </Box>
             {/* Hidden Accounts, this component shows hidden accounts in account list Item*/}
-            {hiddenAddresses.length > 0 ? (
+            {process.env.NETWORK_ACCOUNT_DND && hiddenAddresses.length > 0 ? (
               <HiddenAccountList onClose={onClose} />
             ) : null}
 

--- a/ui/components/multichain/account-list-menu/account-list-menu.js
+++ b/ui/components/multichain/account-list-menu/account-list-menu.js
@@ -111,6 +111,7 @@ export const AccountListMenu = ({
   const history = useHistory();
   const dispatch = useDispatch();
   const hiddenAddresses = useSelector(getHiddenAccountsList);
+  const updatedAccountsList = useSelector(getUpdatedAndSortedAccounts);
   ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
   const addSnapAccountEnabled = useSelector(getIsAddSnapAccountEnabled);
   ///: END:ONLY_INCLUDE_IF
@@ -119,8 +120,7 @@ export const AccountListMenu = ({
   const [actionMode, setActionMode] = useState(ACTION_MODES.LIST);
 
   let searchResults = process.env.NETWORK_ACCOUNT_DND
-    ? // eslint-disable-next-line react-hooks/rules-of-hooks
-      useSelector(getUpdatedAndSortedAccounts)
+    ? updatedAccountsList
     : accounts;
   if (searchQuery) {
     const fuse = new Fuse(accounts, {

--- a/ui/components/multichain/account-list-menu/account-list-menu.js
+++ b/ui/components/multichain/account-list-menu/account-list-menu.js
@@ -380,6 +380,11 @@ export const AccountListMenu = ({
                         ? Boolean(account.pinned)
                         : null
                     }
+                    isHidden={
+                      process.env.NETWORK_ACCOUNT_DND
+                        ? Boolean(account.hidden)
+                        : null
+                    }
                     {...accountListItemProps}
                   />
                 );

--- a/ui/components/multichain/account-list-menu/account-list-menu.js
+++ b/ui/components/multichain/account-list-menu/account-list-menu.js
@@ -356,37 +356,46 @@ export const AccountListMenu = ({
                 );
 
                 return (
-                  <AccountListItem
-                    onClick={() => {
-                      onClose();
-                      trackEvent({
-                        category: MetaMetricsEventCategory.Navigation,
-                        event: MetaMetricsEventName.NavAccountSwitched,
-                        properties: {
-                          location: 'Main Menu',
-                        },
-                      });
-                      dispatch(setSelectedAccount(account.address));
-                    }}
-                    identity={account}
+                  <Box
+                    className={
+                      account.hidden
+                        ? 'multichain-account-menu-popover__list--menu-item-hidden'
+                        : 'multichain-account-menu-popover__list--menu-item'
+                    }
                     key={account.address}
-                    selected={selectedAccount.address === account.address}
-                    closeMenu={onClose}
-                    connectedAvatar={connectedSite?.iconUrl}
-                    connectedAvatarName={connectedSite?.name}
-                    showOptions
-                    isPinned={
-                      process.env.NETWORK_ACCOUNT_DND
-                        ? Boolean(account.pinned)
-                        : null
-                    }
-                    isHidden={
-                      process.env.NETWORK_ACCOUNT_DND
-                        ? Boolean(account.hidden)
-                        : null
-                    }
-                    {...accountListItemProps}
-                  />
+                  >
+                    <AccountListItem
+                      onClick={() => {
+                        onClose();
+                        trackEvent({
+                          category: MetaMetricsEventCategory.Navigation,
+                          event: MetaMetricsEventName.NavAccountSwitched,
+                          properties: {
+                            location: 'Main Menu',
+                          },
+                        });
+                        dispatch(setSelectedAccount(account.address));
+                      }}
+                      identity={account}
+                      key={account.address}
+                      selected={selectedAccount.address === account.address}
+                      closeMenu={onClose}
+                      connectedAvatar={connectedSite?.iconUrl}
+                      connectedAvatarName={connectedSite?.name}
+                      showOptions
+                      isPinned={
+                        process.env.NETWORK_ACCOUNT_DND
+                          ? Boolean(account.pinned)
+                          : null
+                      }
+                      isHidden={
+                        process.env.NETWORK_ACCOUNT_DND
+                          ? Boolean(account.hidden)
+                          : null
+                      }
+                      {...accountListItemProps}
+                    />
+                  </Box>
                 );
               })}
             </Box>

--- a/ui/components/multichain/account-list-menu/hidden-account-list.js
+++ b/ui/components/multichain/account-list-menu/hidden-account-list.js
@@ -1,0 +1,145 @@
+import React, { useContext, useState } from 'react';
+import PropTypes from 'prop-types';
+import { useDispatch, useSelector } from 'react-redux';
+import {
+  MetaMetricsEventCategory,
+  MetaMetricsEventName,
+} from '../../../../shared/constants/metametrics';
+import { MetaMetricsContext } from '../../../contexts/metametrics';
+import {
+  AlignItems,
+  BackgroundColor,
+  BlockSize,
+  Display,
+  IconColor,
+  JustifyContent,
+} from '../../../helpers/constants/design-system';
+import { useI18nContext } from '../../../hooks/useI18nContext';
+import {
+  getConnectedSubjectsForAllAddresses,
+  getHiddenAccountsList,
+  getMetaMaskAccountsOrdered,
+  getOriginOfCurrentTab,
+  getSelectedAccount,
+} from '../../../selectors';
+import { setSelectedAccount } from '../../../store/actions';
+import {
+  AvatarIcon,
+  Box,
+  Icon,
+  IconName,
+  IconSize,
+  Text,
+} from '../../component-library';
+import { AccountListItem } from '../account-list-item';
+
+export const HiddenAccountList = ({ onClose }) => {
+  const t = useI18nContext();
+  const trackEvent = useContext(MetaMetricsContext);
+  const dispatch = useDispatch();
+  const hiddenAddresses = useSelector(getHiddenAccountsList);
+  const accounts = useSelector(getMetaMaskAccountsOrdered);
+  const selectedAccount = useSelector(getSelectedAccount);
+  const connectedSites = useSelector(getConnectedSubjectsForAllAddresses);
+  const currentTabOrigin = useSelector(getOriginOfCurrentTab);
+  const filteredHiddenAccounts = accounts.filter((account) =>
+    hiddenAddresses.includes(account.address),
+  );
+  const [showListItem, setShowListItem] = useState(false);
+  return (
+    <>
+      <Box
+        as="button"
+        onClick={() => setShowListItem(!showListItem)}
+        backgroundColor={BackgroundColor.backgroundDefault}
+        display={Display.Flex}
+        padding={4}
+        alignItems={AlignItems.center}
+        width={BlockSize.Full}
+        justifyContent={JustifyContent.spaceBetween}
+      >
+        <Box
+          display={Display.Flex}
+          alignItems={AlignItems.center}
+          width={BlockSize.TwoThirds}
+          gap={2}
+        >
+          <AvatarIcon
+            iconName={IconName.EyeSlash}
+            color={IconColor.infoDefault}
+            backgroundColor={BackgroundColor.infoMuted}
+          />
+          <Box display={Display.Flex}>
+            <Text>{t('hiddenAccounts')}</Text>
+          </Box>
+        </Box>
+        <Box
+          gap={1}
+          display={Display.Flex}
+          alignItems={AlignItems.center}
+          width={BlockSize.OneThird}
+          justifyContent={JustifyContent.flexEnd}
+        >
+          <Text>{hiddenAddresses.length}</Text>
+          <Icon
+            name={showListItem ? IconName.ArrowUp : IconName.ArrowDown}
+            size={IconSize.Sm}
+          />
+        </Box>
+      </Box>
+      {showListItem ? (
+        <Box>
+          {filteredHiddenAccounts.map((account) => {
+            const connectedSite = connectedSites[account.address]?.find(
+              ({ origin }) => origin === currentTabOrigin,
+            );
+            return (
+              <Box
+                className="multichain-account-menu-popover__list--menu-item-hidden"
+                key={account.address}
+              >
+                <AccountListItem
+                  onClick={() => {
+                    onClose();
+                    trackEvent({
+                      category: MetaMetricsEventCategory.Navigation,
+                      event: MetaMetricsEventName.NavAccountSwitched,
+                      properties: {
+                        location: 'Main Menu',
+                      },
+                    });
+                    dispatch(setSelectedAccount(account.address));
+                  }}
+                  identity={account}
+                  key={account.address}
+                  selected={selectedAccount.address === account.address}
+                  closeMenu={onClose}
+                  connectedAvatar={connectedSite?.iconUrl}
+                  connectedAvatarName={connectedSite?.name}
+                  showOptions
+                  isPinned={
+                    process.env.NETWORK_ACCOUNT_DND
+                      ? Boolean(account.pinned)
+                      : null
+                  }
+                  isHidden={
+                    process.env.NETWORK_ACCOUNT_DND
+                      ? Boolean(account.hidden)
+                      : null
+                  }
+                />
+              </Box>
+            );
+          })}
+        </Box>
+      ) : null}
+    </>
+  );
+};
+
+HiddenAccountList.propTypes = {
+  /**
+   * Function that executes when the menu closes
+   */
+  onClose: PropTypes.func.isRequired,
+};

--- a/ui/components/multichain/account-list-menu/hidden-account-list.js
+++ b/ui/components/multichain/account-list-menu/hidden-account-list.js
@@ -84,6 +84,7 @@ export const HiddenAccountList = ({ onClose }) => {
           <Icon
             name={showListItem ? IconName.ArrowUp : IconName.ArrowDown}
             size={IconSize.Sm}
+            color={IconColor.iconDefault}
           />
         </Box>
       </Box>

--- a/ui/components/multichain/account-list-menu/index.scss
+++ b/ui/components/multichain/account-list-menu/index.scss
@@ -9,5 +9,9 @@
 
   &__list {
     overflow: auto;
+
+    &--menu-item-hidden{
+      opacity: 0.5;
+    }
   }
 }

--- a/ui/components/multichain/account-list-menu/index.scss
+++ b/ui/components/multichain/account-list-menu/index.scss
@@ -10,7 +10,7 @@
   &__list {
     overflow: auto;
 
-    &--menu-item-hidden{
+    &--menu-item-hidden {
       opacity: 0.5;
     }
   }

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -1277,6 +1277,10 @@ export function getPinnedAccountsList(state) {
   return state.metamask.pinnedAccountList;
 }
 
+export function getHiddenAccountsList(state) {
+  return state.metamask.hiddenAccountList;
+}
+
 export function getShowRecoveryPhraseReminder(state) {
   const {
     recoveryPhraseReminderLastShown,
@@ -1840,10 +1844,17 @@ export function getCustomTokenAmount(state) {
 export function getUpdatedAndSortedAccounts(state) {
   const accounts = getMetaMaskAccountsOrdered(state);
   const pinnedAddresses = getPinnedAccountsList(state);
+  const hiddenAddresses = getHiddenAccountsList(state);
 
   accounts.forEach((account) => {
     account.pinned = Boolean(pinnedAddresses?.includes(account.address));
   });
+
+  accounts.forEach((account) => {
+    account.hidden = Boolean(hiddenAddresses?.includes(account.address));
+  });
+
+  console.log(accounts);
 
   const notPinnedAccounts = accounts.filter(
     (account) => !pinnedAddresses.includes(account.address),

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -1856,17 +1856,31 @@ export function getUpdatedAndSortedAccounts(state) {
 
   console.log(accounts);
 
-  const notPinnedAccounts = accounts.filter(
-    (account) => !pinnedAddresses.includes(account.address),
-  );
-
   const sortedPinnedAccounts = pinnedAddresses
     .map((address) => accounts.find((account) => account.address === address))
     .filter((account) =>
-      Boolean(account && pinnedAddresses.includes(account.address)),
+      Boolean(
+        account &&
+          pinnedAddresses.includes(account.address) &&
+          !hiddenAddresses.includes(account.address),
+      ),
     );
 
-  const sortedSearchResults = [...sortedPinnedAccounts, ...notPinnedAccounts];
+  const notPinnedAccounts = accounts.filter(
+    (account) =>
+      !pinnedAddresses.includes(account.address) &&
+      !hiddenAddresses.includes(account.address),
+  );
+
+  const filteredHiddenAccounts = accounts.filter((account) =>
+    hiddenAddresses.includes(account.address),
+  );
+
+  const sortedSearchResults = [
+    ...sortedPinnedAccounts,
+    ...notPinnedAccounts,
+    ...filteredHiddenAccounts,
+  ];
 
   return sortedSearchResults;
 }

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -1847,22 +1847,17 @@ export function getUpdatedAndSortedAccounts(state) {
   const hiddenAddresses = getHiddenAccountsList(state);
 
   accounts.forEach((account) => {
-    account.pinned = Boolean(pinnedAddresses?.includes(account.address));
+    account.pinned = Boolean(pinnedAddresses.includes(account.address));
+    account.hidden = Boolean(hiddenAddresses.includes(account.address));
   });
-
-  accounts.forEach((account) => {
-    account.hidden = Boolean(hiddenAddresses?.includes(account.address));
-  });
-
-  console.log(accounts);
 
   const sortedPinnedAccounts = pinnedAddresses
-    .map((address) => accounts.find((account) => account.address === address))
+    ?.map((address) => accounts.find((account) => account.address === address))
     .filter((account) =>
       Boolean(
         account &&
           pinnedAddresses.includes(account.address) &&
-          !hiddenAddresses.includes(account.address),
+          !hiddenAddresses?.includes(account.address),
       ),
     );
 

--- a/ui/selectors/selectors.test.js
+++ b/ui/selectors/selectors.test.js
@@ -990,30 +990,35 @@ describe('Selectors', () => {
         balance: '0x0',
         name: 'Test Account 2',
         pinned: true,
+        hidden: false,
       },
       {
         address: '0xeb9e64b93097bc15f01f13eae97015c57ab64823',
         balance: '0x0',
         name: 'Test Account 3',
         pinned: true,
+        hidden: false,
       },
       {
         address: '0x0dcd5d886577d5081b0c52e242ef29e70be3e7bc',
         name: 'Test Account',
         balance: '0x0',
         pinned: false,
+        hidden: false,
       },
       {
         address: '0xc42edfcc21ed14dda456aa0756c153f7985d8813',
         name: 'Test Ledger 1',
         balance: '0x0',
         pinned: false,
+        hidden: false,
       },
       {
         name: 'Custody test',
         address: '0xca8f1F0245530118D0cf14a06b01Daf8f76Cf281',
         balance: '0x0',
         pinned: false,
+        hidden: false,
       },
     ];
     expect(

--- a/ui/store/actions.ts
+++ b/ui/store/actions.ts
@@ -3612,11 +3612,13 @@ export function updateAccountsList(
  *
  * @param hiddenAccountList
  */
-export function hideAccountsList(
+export function updateHiddenAccountsList(
   hiddenAccountList: [],
 ): ThunkAction<void, MetaMaskReduxState, unknown, AnyAction> {
   return async () => {
-    await submitRequestToBackground('hideAccountsList', [hiddenAccountList]);
+    await submitRequestToBackground('updateHiddenAccountsList', [
+      hiddenAccountList,
+    ]);
   };
 }
 

--- a/ui/store/actions.ts
+++ b/ui/store/actions.ts
@@ -3607,6 +3607,19 @@ export function updateAccountsList(
   };
 }
 
+/**
+ * Hides account in the accounts list
+ *
+ * @param hiddenAccountList
+ */
+export function hideAccountsList(
+  hiddenAccountList: [],
+): ThunkAction<void, MetaMaskReduxState, unknown, AnyAction> {
+  return async () => {
+    await submitRequestToBackground('hideAccountsList', [hiddenAccountList]);
+  };
+}
+
 ///: BEGIN:ONLY_INCLUDE_IF(snaps)
 /**
  * Updates the caveat value for the specified origin, permission and caveat type.


### PR DESCRIPTION
## **Description**

This PR add the functionality to hide an account in the account list

Note: This feature is behind a feature flag so we will add tests while removing the feature flag

## **Related issues**

Fixes: #21655 

## **Manual testing steps**

1. Run extension with `NETWORK_ACCOUNT_DND=1 yarn start`
2. Go to Account List Menu
3. Click on Account Options, hide account
4. See another section of hidden accounts in account list menu
5. In Hidden list of accounts, you can't pin the accounts. First you have to unhide the account and then can pin.
6. When we hide a pinned account, it should be unpinned first and then hidden

## **Screenshots/Recordings**


https://github.com/MetaMask/metamask-extension/assets/39872794/a20c4bbc-cdc8-4f21-ab1e-3f46b2842d59



## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained what problem this PR is solving and how it is solved.
- [x] I've linked related issues
- [x] I've included manual testing steps
- [x] I've included screenshots/recordings if applicable
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [x] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
