### PR TITLE
feat: fetch token fiat amount on import confirmation modal

### DIFF
--- a/app/scripts/lib/setupSentry.js
+++ b/app/scripts/lib/setupSentry.js
@@ -336,6 +336,7 @@ export const SENTRY_UI_STATE = {
     nextNonce: true,
     pendingTokens: false,
     welcomeScreenSeen: true,
+    confirmationExchangeRates: true,
     useSafeChainsListValidation: true,
     ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
     addSnapAccountEnabled: false,

--- a/test/e2e/tests/state-snapshots/errors-after-init-opt-in-ui-state.json
+++ b/test/e2e/tests/state-snapshots/errors-after-init-opt-in-ui-state.json
@@ -18,6 +18,7 @@
     "networkConfigurations": "object",
     "addressBook": "object",
     "contractExchangeRates": "object",
+    "confirmationExchangeRates": {},
     "contractExchangeRatesByChainId": "object",
     "pendingTokens": "object",
     "customNonceValue": "",

--- a/ui/components/multichain/import-tokens-modal/import-tokens-modal-confirm.js
+++ b/ui/components/multichain/import-tokens-modal/import-tokens-modal-confirm.js
@@ -79,7 +79,7 @@ export const ImportTokensModalConfirm = () => {
                       variant={TextVariant.bodySm}
                       color={TextColor.textAlternative}
                     >
-                      {symbol}
+                      <TokenBalance token={token} />
                     </Text>
                   </Box>
                 </Box>

--- a/ui/components/multichain/import-tokens-modal/import-tokens-modal-confirm.js
+++ b/ui/components/multichain/import-tokens-modal/import-tokens-modal-confirm.js
@@ -94,6 +94,7 @@ export const ImportTokensModalConfirm = () => {
                       variant: TextVariant.bodyLgMedium,
                     }}
                     token={token}
+                    showFiat
                   />
                 </Box>
               </Box>

--- a/ui/components/multichain/import-tokens-modal/import-tokens-modal.js
+++ b/ui/components/multichain/import-tokens-modal/import-tokens-modal.js
@@ -9,7 +9,10 @@ import { useDispatch, useSelector } from 'react-redux';
 import { useHistory } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import { getTokenTrackerLink } from '@metamask/etherscan-link/dist/token-tracker-link';
-import { fetchAndMapExchangeRates } from '@metamask/assets-controllers';
+import {
+  fetchTokenContractExchangeRates,
+  CodefiTokenPricesServiceV2,
+} from '@metamask/assets-controllers';
 import { Tab, Tabs } from '../../ui/tabs';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import {
@@ -376,14 +379,15 @@ export const ImportTokensModal = ({ onClose }) => {
         undefined,
     );
 
-    const finalArr = tmpTokensToDispatch.map((obj) => obj.address);
+    const tokenAddresses = tmpTokensToDispatch.map((obj) => obj.address);
     if (tmpTokensToDispatch.length !== 0) {
       try {
-        const result = await fetchAndMapExchangeRates(
+        const result = await fetchTokenContractExchangeRates({
+          tokenPricesService: new CodefiTokenPricesServiceV2(),
           nativeCurrency,
-          finalArr,
+          tokenAddresses,
           chainId,
-        );
+        });
         // dispatch action
         dispatch(setConfirmationExchangeRates(result));
       } catch (err) {
@@ -517,7 +521,7 @@ export const ImportTokensModal = ({ onClose }) => {
         >
           {t('importTokensCamelCase')}
         </ModalHeader>
-        <Box>
+        <Box className="import-tokens-modal__body">
           <Tabs t={t} tabsClassName="import-tokens-modal__tabs">
             {showSearchTab ? (
               <Tab

--- a/ui/components/multichain/import-tokens-modal/import-tokens-modal.js
+++ b/ui/components/multichain/import-tokens-modal/import-tokens-modal.js
@@ -9,10 +9,6 @@ import { useDispatch, useSelector } from 'react-redux';
 import { useHistory } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import { getTokenTrackerLink } from '@metamask/etherscan-link/dist/token-tracker-link';
-import {
-  fetchTokenContractExchangeRates,
-  CodefiTokenPricesServiceV2,
-} from '@metamask/assets-controllers';
 import { Tab, Tabs } from '../../ui/tabs';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import {
@@ -86,6 +82,7 @@ import {
 import {
   checkExistingAddresses,
   getURLHostName,
+  fetchTokenExchangeRates,
 } from '../../../helpers/utils/util';
 import { tokenInfoGetter } from '../../../helpers/utils/token-util';
 import { MetaMetricsContext } from '../../../contexts/metametrics';
@@ -381,18 +378,13 @@ export const ImportTokensModal = ({ onClose }) => {
 
     const tokenAddresses = tmpTokensToDispatch.map((obj) => obj.address);
     if (tmpTokensToDispatch.length !== 0) {
-      try {
-        const result = await fetchTokenContractExchangeRates({
-          tokenPricesService: new CodefiTokenPricesServiceV2(),
-          nativeCurrency,
-          tokenAddresses,
-          chainId,
-        });
-        // dispatch action
-        dispatch(setConfirmationExchangeRates(result));
-      } catch (err) {
-        // ignore
-      }
+      const result = await fetchTokenExchangeRates(
+        nativeCurrency,
+        tokenAddresses,
+        chainId,
+      );
+      // dispatch action
+      dispatch(setConfirmationExchangeRates(result));
     }
     setMode('confirm');
   };

--- a/ui/components/multichain/import-tokens-modal/import-tokens-modal.test.js
+++ b/ui/components/multichain/import-tokens-modal/import-tokens-modal.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { fireEvent, waitFor } from '@testing-library/react';
+import { act, fireEvent, waitFor } from '@testing-library/react';
 import { renderWithProvider } from '../../../../test/lib/render-helpers';
 
 import configureStore from '../../../store/store';
@@ -7,6 +7,7 @@ import {
   clearPendingTokens,
   getTokenStandardAndDetails,
   setPendingTokens,
+  setConfirmationExchangeRates,
 } from '../../../store/actions';
 import mockState from '../../../../test/data/mock-state.json';
 import { TokenStandard } from '../../../../shared/constants/transaction';
@@ -22,6 +23,9 @@ jest.mock('../../../store/actions', () => ({
   clearPendingTokens: jest
     .fn()
     .mockImplementation(() => ({ type: 'CLEAR_PENDING_TOKENS' })),
+  setConfirmationExchangeRates: jest
+    .fn()
+    .mockImplementation(() => ({ type: 'SET_CONFIRMATION_EXCHANGE_RATES' })),
 }));
 
 describe('ImportTokensModal', () => {
@@ -178,21 +182,27 @@ describe('ImportTokensModal', () => {
 
       expect(getByText('Next')).not.toBeDisabled();
 
-      fireEvent.click(getByText('Next'));
-
-      expect(setPendingTokens).toHaveBeenCalledWith({
-        customToken: {
-          address: tokenAddress,
-          decimals: Number(tokenPrecision),
-          standard: TokenStandard.ERC20,
-          symbol: tokenSymbol,
-          name: '',
-        },
-        selectedTokens: {},
-        tokenAddressList: [],
+      act(() => {
+        fireEvent.click(getByText('Next'));
       });
 
-      expect(getByText('Import')).toBeInTheDocument();
+      await waitFor(() => {
+        expect(setPendingTokens).toHaveBeenCalledWith({
+          customToken: {
+            address: tokenAddress,
+            decimals: Number(tokenPrecision),
+            standard: TokenStandard.ERC20,
+            symbol: tokenSymbol,
+            name: '',
+          },
+          selectedTokens: {},
+          tokenAddressList: [],
+        });
+
+        expect(setConfirmationExchangeRates).toHaveBeenCalled();
+
+        expect(getByText('Import')).toBeInTheDocument();
+      });
     });
 
     it('cancels out of import token flow', () => {

--- a/ui/components/multichain/import-tokens-modal/index.scss
+++ b/ui/components/multichain/import-tokens-modal/index.scss
@@ -12,6 +12,14 @@
     }
   }
 
+  &__body::-webkit-scrollbar {
+    display: none;
+  }
+
+  &__body{
+    overflow-y: auto;
+  }
+
   &__confirmation-list {
     overflow-y: scroll;
     overflow: auto;

--- a/ui/components/multichain/import-tokens-modal/index.scss
+++ b/ui/components/multichain/import-tokens-modal/index.scss
@@ -16,7 +16,7 @@
     display: none;
   }
 
-  &__body{
+  &__body {
     overflow-y: auto;
   }
 

--- a/ui/components/ui/token-balance/token-balance.js
+++ b/ui/components/ui/token-balance/token-balance.js
@@ -2,11 +2,24 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import CurrencyDisplay from '../currency-display';
 import { useTokenTracker } from '../../../hooks/useTokenTracker';
+import { useTokenFiatAmount } from '../../../hooks/useTokenFiatAmount';
+import { useIsOriginalTokenSymbol } from '../../../hooks/useIsOriginalTokenSymbol';
+import { Text } from '../../component-library';
 
-export default function TokenBalance({ className, token, ...restProps }) {
+export default function TokenBalance({
+  className,
+  token,
+  showFiat,
+  ...restProps
+}) {
   const { tokensWithBalances } = useTokenTracker({ tokens: [token] });
-
-  const { string, symbol } = tokensWithBalances[0] || {};
+  const { string, symbol, address } = tokensWithBalances[0] || {};
+  const formattedFiat = useTokenFiatAmount(address, string, symbol);
+  const isOriginalTokenSymbol = useIsOriginalTokenSymbol(address, symbol);
+  const fiatValue = isOriginalTokenSymbol ? formattedFiat : null;
+  if (showFiat) {
+    return <Text>{fiatValue}</Text>;
+  }
   return (
     <CurrencyDisplay
       className={className}
@@ -24,6 +37,7 @@ TokenBalance.propTypes = {
     decimals: PropTypes.number,
     symbol: PropTypes.string,
   }).isRequired,
+  showFiat: PropTypes.bool,
 };
 
 TokenBalance.defaultProps = {

--- a/ui/components/ui/token-balance/token-balance.js
+++ b/ui/components/ui/token-balance/token-balance.js
@@ -5,6 +5,10 @@ import { useTokenTracker } from '../../../hooks/useTokenTracker';
 import { useTokenFiatAmount } from '../../../hooks/useTokenFiatAmount';
 import { useIsOriginalTokenSymbol } from '../../../hooks/useIsOriginalTokenSymbol';
 import { Text } from '../../component-library';
+import {
+  FontWeight,
+  TextVariant,
+} from '../../../helpers/constants/design-system';
 
 export default function TokenBalance({
   className,
@@ -18,7 +22,11 @@ export default function TokenBalance({
   const isOriginalTokenSymbol = useIsOriginalTokenSymbol(address, symbol);
   const fiatValue = isOriginalTokenSymbol ? formattedFiat : null;
   if (showFiat) {
-    return <Text>{fiatValue}</Text>;
+    return (
+      <Text fontWeight={FontWeight.Medium} variant={TextVariant.bodyMd}>
+        {fiatValue}
+      </Text>
+    );
   }
   return (
     <CurrencyDisplay

--- a/ui/ducks/metamask/metamask.js
+++ b/ui/ducks/metamask/metamask.js
@@ -29,6 +29,7 @@ const initialState = {
   networkConfigurations: {},
   addressBook: [],
   contractExchangeRates: {},
+  confirmationExchangeRates: {},
   pendingTokens: {},
   customNonceValue: '',
   useBlockie: false,
@@ -177,6 +178,11 @@ export default function reduceMetamask(state = initialState, action) {
         nextNonce: action.payload,
       };
     }
+    case actionConstants.SET_CONFIRMATION_EXCHANGE_RATES:
+      return {
+        ...metamaskState,
+        confirmationExchangeRates: action.value,
+      };
 
     ///: BEGIN:ONLY_INCLUDE_IF(desktop)
     case actionConstants.FORCE_DISABLE_DESKTOP: {

--- a/ui/helpers/utils/util.js
+++ b/ui/helpers/utils/util.js
@@ -3,7 +3,11 @@ import abi from 'human-standard-token-abi';
 import BigNumber from 'bignumber.js';
 import * as ethUtil from 'ethereumjs-util';
 import { DateTime } from 'luxon';
-import { getFormattedIpfsUrl } from '@metamask/assets-controllers';
+import {
+  getFormattedIpfsUrl,
+  fetchTokenContractExchangeRates,
+  CodefiTokenPricesServiceV2,
+} from '@metamask/assets-controllers';
 import * as lodash from 'lodash';
 import bowser from 'bowser';
 ///: BEGIN:ONLY_INCLUDE_IF(snaps)
@@ -675,4 +679,29 @@ export const checkTokenIdExists = (address, tokenId, obj) => {
     });
   }
   return false;
+};
+
+/**
+ * Retrieves token prices
+ *
+ * @param {string} nativeCurrency - native currency to fetch prices for.
+ * @param {Hex[]} tokenAddresses - set of contract addresses
+ * @param {Hex} chainId - current chainId
+ * @returns The prices for the requested tokens.
+ */
+export const fetchTokenExchangeRates = async (
+  nativeCurrency,
+  tokenAddresses,
+  chainId,
+) => {
+  try {
+    return await fetchTokenContractExchangeRates({
+      tokenPricesService: new CodefiTokenPricesServiceV2(),
+      nativeCurrency,
+      tokenAddresses,
+      chainId,
+    });
+  } catch (err) {
+    return {};
+  }
 };

--- a/ui/hooks/useTokenFiatAmount.js
+++ b/ui/hooks/useTokenFiatAmount.js
@@ -4,6 +4,7 @@ import {
   getTokenExchangeRates,
   getCurrentCurrency,
   getShouldShowFiat,
+  getConfirmationExchangeRates,
 } from '../selectors';
 import { getTokenFiatAmount } from '../helpers/utils/token-util';
 import { getConversionRate } from '../ducks/metamask/metamask';
@@ -33,17 +34,21 @@ export function useTokenFiatAmount(
     getTokenExchangeRates,
     shallowEqual,
   );
+  const confirmationExchangeRates = useSelector(getConfirmationExchangeRates);
+  const mergedRates = {
+    ...contractExchangeRates,
+    ...confirmationExchangeRates,
+  };
   const conversionRate = useSelector(getConversionRate);
   const currentCurrency = useSelector(getCurrentCurrency);
   const userPrefersShownFiat = useSelector(getShouldShowFiat);
   const showFiat = overrides.showFiat ?? userPrefersShownFiat;
-  const contractExchangeTokenKey = Object.keys(contractExchangeRates).find(
-    (key) => isEqualCaseInsensitive(key, tokenAddress),
+  const contractExchangeTokenKey = Object.keys(mergedRates).find((key) =>
+    isEqualCaseInsensitive(key, tokenAddress),
   );
   const tokenExchangeRate =
     overrides.exchangeRate ??
-    (contractExchangeTokenKey &&
-      contractExchangeRates[contractExchangeTokenKey]);
+    (contractExchangeTokenKey && mergedRates[contractExchangeTokenKey]);
   const formattedFiat = useMemo(
     () =>
       getTokenFiatAmount(

--- a/ui/pages/confirm-add-suggested-token/confirm-add-suggested-token.test.js
+++ b/ui/pages/confirm-add-suggested-token/confirm-add-suggested-token.test.js
@@ -57,6 +57,12 @@ jest.mock('../../store/actions', () => ({
   rejectPendingApproval: jest.fn().mockReturnValue({ type: 'test' }),
 }));
 
+jest.mock('../../hooks/useIsOriginalTokenSymbol', () => {
+  return {
+    useIsOriginalTokenSymbol: jest.fn(),
+  };
+});
+
 const renderComponent = (tokens = []) => {
   const store = configureStore({
     metamask: {

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -460,6 +460,10 @@ export function getAllTokens(state) {
   return state.metamask.allTokens;
 }
 
+export const getConfirmationExchangeRates = (state) => {
+  return state.metamask.confirmationExchangeRates;
+};
+
 export function getSelectedAccount(state) {
   const accounts = getMetaMaskAccounts(state);
   const selectedAccount = getSelectedInternalAccount(state);

--- a/ui/store/actionConstants.ts
+++ b/ui/store/actionConstants.ts
@@ -2,6 +2,8 @@ export const GO_HOME = 'GO_HOME';
 // modal state
 export const MODAL_OPEN = 'UI_MODAL_OPEN';
 export const MODAL_CLOSE = 'UI_MODAL_CLOSE';
+export const SET_CONFIRMATION_EXCHANGE_RATES =
+  'SET_CONFIRMATION_EXCHANGE_RATES';
 // alert state
 export const ALERT_OPEN = 'UI_ALERT_OPEN';
 export const ALERT_CLOSE = 'UI_ALERT_CLOSE';

--- a/ui/store/actions.ts
+++ b/ui/store/actions.ts
@@ -2464,6 +2464,13 @@ export function hideImportNftsModal(): Action {
   };
 }
 
+export function setConfirmationExchangeRates(value: Record<string, any>) {
+  return {
+    type: actionConstants.SET_CONFIRMATION_EXCHANGE_RATES,
+    value,
+  };
+}
+
 export function showIpfsModal(): Action {
   return {
     type: actionConstants.SHOW_IPFS_MODAL_OPEN,


### PR DESCRIPTION
## **Description**

The goal of this PR is to fetch user token fiat balance on the import modal confirmation page.
There is an ongoing PR on core to enable this:
https://github.com/MetaMask/core/pull/3657



## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MMASSETS-88
also design wise relates to this PR  https://github.com/MetaMask/metamask-extension/pull/21704

## **Manual testing steps**

1. Go to home page
2. Click on import tokens button
3. Select a token
4. Click import
5. Notice the token balance in fiat on the confirmation page

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

![image](https://github.com/MetaMask/metamask-extension/assets/10994169/a7513ded-2960-4c6d-972d-8bb1d673f0df)
### **After**

![image](https://github.com/MetaMask/metamask-extension/assets/10994169/1232ba09-9769-476d-b4f8-12415ac55f2c)


## **Pre-merge author checklist**

- [] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've clearly explained what problem this PR is solving and how it is solved.
- [ ] I've linked related issues
- [ ] I've included manual testing steps
- [ ] I've included screenshots/recordings if applicable
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [ ] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
