### PR TITLE
Implement goerli deprecation warning

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -1233,6 +1233,9 @@
   "deprecatedAuroraNetworkMsg": {
     "message": "MetaMask will be deprecating support for Aurora network. Please add it as a custom network if you want to continue to use it"
   },
+  "deprecatedGoerliNetworkMsg": {
+    "message": "Due to the protocol changes of Ethereum: Goerli test network may not work as reliably and will be deprecated soon."
+  },
   "description": {
     "message": "Description"
   },

--- a/test/e2e/tests/deprecated-networks.spec.js
+++ b/test/e2e/tests/deprecated-networks.spec.js
@@ -1,0 +1,34 @@
+const { strict: assert } = require('assert');
+const FixtureBuilder = require('../fixture-builder');
+const { withFixtures, unlockWallet } = require('../helpers');
+
+describe('Deprecated networks', function () {
+  it('When selecting the Goerli test network, the users should see a warning message', async function () {
+    await withFixtures(
+      {
+        dapp: true,
+        fixtures: new FixtureBuilder().build(),
+        title: this.test.fullTitle(),
+      },
+      async ({ driver }) => {
+        await unlockWallet(driver);
+
+        await driver.clickElement('[data-testid="network-display"]');
+
+        await driver.clickElement({ text: 'Goerli' });
+
+        const deprecationWarningText =
+          'Due to the protocol changes of Ethereum: Goerli test network may not work as reliably and will be deprecated soon.';
+        const isDeprecationWarningDisplayed = await driver.isElementPresent({
+          text: deprecationWarningText,
+        });
+
+        assert.equal(
+          isDeprecationWarningDisplayed,
+          true,
+          'Goerli deprecation warning is not displayed',
+        );
+      },
+    );
+  });
+});

--- a/ui/components/ui/deprecated-networks/deprecated-networks.js
+++ b/ui/components/ui/deprecated-networks/deprecated-networks.js
@@ -10,19 +10,28 @@ import {
 import { getCurrentChainId } from '../../../selectors';
 import { getCompletedOnboarding } from '../../../ducks/metamask/metamask';
 import { BannerAlert, Box, ButtonLink } from '../../component-library';
+import { CHAIN_IDS } from '../../../../shared/constants/network';
 
 export default function DeprecatedNetworks() {
   const currentChainID = useSelector(getCurrentChainId);
   const [isShowingWarning, setIsShowingWarning] = useState(false);
   const completedOnboarding = useSelector(getCompletedOnboarding);
   const t = useI18nContext();
+
+  // To add a deprecation warning to a network, add it to the array
+  // `DEPRECATED_NETWORKS` and as a new case to `getDeprecationWarningCopy()`
+  const DEPRECATED_NETWORKS = [CHAIN_IDS.AURORA, CHAIN_IDS.GOERLI];
+
   useEffect(() => {
-    if (completedOnboarding && currentChainID === '0x4e454152') {
+    if (completedOnboarding && DEPRECATED_NETWORKS.includes(currentChainID)) {
       setIsShowingWarning(true);
     } else {
       setIsShowingWarning(false);
     }
   }, [currentChainID, completedOnboarding]);
+
+  const { bannerAlertDescription, actionBtnLinkURL } =
+    getDeprecationWarningCopy(t, currentChainID);
 
   return isShowingWarning ? (
     <Box
@@ -33,16 +42,31 @@ export default function DeprecatedNetworks() {
     >
       <BannerAlert
         severity={Severity.Warning}
-        description={t('deprecatedAuroraNetworkMsg')}
+        description={bannerAlertDescription}
         onClose={() => setIsShowingWarning(false)}
         actionButtonLabel={t('learnMoreUpperCase')}
         actionButtonProps={{
           className: 'deprecated-networks__content__inline-link',
-          href: 'https://mainnet.aurora.dev/',
+          href: actionBtnLinkURL,
           variant: ButtonLink,
           externalLink: true,
         }}
       />
     </Box>
   ) : null;
+}
+
+function getDeprecationWarningCopy(t, currentChainID) {
+  let bannerAlertDescription, actionBtnLinkURL;
+
+  if (currentChainID === CHAIN_IDS.AURORA) {
+    bannerAlertDescription = t('deprecatedAuroraNetworkMsg');
+    actionBtnLinkURL = 'https://mainnet.aurora.dev/';
+  } else if (currentChainID === CHAIN_IDS.GOERLI) {
+    bannerAlertDescription = t('deprecatedGoerliNetworkMsg');
+    actionBtnLinkURL =
+      'https://github.com/eth-clients/goerli#goerli-goerlitzer-testnet';
+  }
+
+  return { bannerAlertDescription, actionBtnLinkURL };
 }


### PR DESCRIPTION
## **Description**

This PR introduces a deprecation warning for the Goerli testnet. This warning shows up when the user selects that network.

## **Related issues**

Fixes: [1659](https://app.zenhub.com/workspaces/snaps-615b3a7c08d2b20015eb6c4e/issues/gh/metamask/metamask-planning/1659)

## **Manual testing steps**

1. Switch to Goerli
2. The warning should be shown
3. Close the warning
4. Refresh the extension
5. The warning should be shown
6. Switch to another network
7. The warning will not be shown

## **Screenshots/Recordings**

### **Before**

N/A

### **After**

<img width="358" alt="Screenshot 2023-12-13 at 11 58 28" src="https://github.com/MetaMask/metamask-extension/assets/13814744/28007532-e288-4e87-a2dc-b6ed5e0d1ddd">

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've clearly explained what problem this PR is solving and how it is solved.
- [ ] I've linked related issues
- [ ] I've included manual testing steps
- [ ] I've included screenshots/recordings if applicable
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [ ] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
