### PR TITLE
remove analytics tracking from create-password

### DIFF
--- a/ui/pages/onboarding-flow/create-password/create-password.js
+++ b/ui/pages/onboarding-flow/create-password/create-password.js
@@ -36,11 +36,7 @@ import {
 ///: END:ONLY_INCLUDE_IF
 import { PASSWORD_MIN_LENGTH } from '../../../helpers/constants/common';
 import ZENDESK_URLS from '../../../helpers/constants/zendesk-url';
-import {
-  getFirstTimeFlowType,
-  getCurrentKeyring,
-  getMetaMetricsId,
-} from '../../../selectors';
+import { getFirstTimeFlowType, getCurrentKeyring } from '../../../selectors';
 import { FIRST_TIME_FLOW_TYPES } from '../../../helpers/constants/onboarding';
 import { MetaMetricsContext } from '../../../contexts/metametrics';
 import {
@@ -67,24 +63,6 @@ export default function CreatePassword({
   const firstTimeFlowType = useSelector(getFirstTimeFlowType);
   const trackEvent = useContext(MetaMetricsContext);
   const currentKeyring = useSelector(getCurrentKeyring);
-
-  const participateInMetaMetrics = useSelector((state) =>
-    Boolean(state.metamask.participateInMetaMetrics),
-  );
-  const metametricsId = useSelector(getMetaMetricsId);
-  const base64MetametricsId = Buffer.from(metametricsId ?? '').toString(
-    'base64',
-  );
-  const shouldInjectMetametricsIframe = Boolean(
-    participateInMetaMetrics && base64MetametricsId,
-  );
-  const analyticsIframeQuery = {
-    mmi: base64MetametricsId,
-    env: 'production',
-  };
-  const analyticsIframeUrl = `https://start.metamask.io/?${new URLSearchParams(
-    analyticsIframeQuery,
-  )}`;
 
   useEffect(() => {
     if (currentKeyring) {
@@ -389,13 +367,6 @@ export default function CreatePassword({
           }
         </form>
       </Box>
-      {shouldInjectMetametricsIframe ? (
-        <iframe
-          src={analyticsIframeUrl}
-          className="create-password__analytics-iframe"
-          data-testid="create-password-iframe"
-        />
-      ) : null}
     </div>
   );
 }

--- a/ui/pages/onboarding-flow/create-password/create-password.test.js
+++ b/ui/pages/onboarding-flow/create-password/create-password.test.js
@@ -26,7 +26,6 @@ describe('Onboarding Create Password', () => {
     metamask: {
       identities: {},
       selectedAddress: '',
-      metaMetricsId: '0x00000000',
     },
   };
 
@@ -391,40 +390,6 @@ describe('Onboarding Create Password', () => {
           ONBOARDING_COMPLETION_ROUTE,
         );
       });
-    });
-  });
-
-  describe('Analytics IFrame', () => {
-    it('should inject iframe when participating in metametrics', () => {
-      const state = {
-        ...mockState,
-        metamask: {
-          ...mockState.metamask,
-          participateInMetaMetrics: true,
-        },
-      };
-      const mockStore = configureMockStore()(state);
-      const { queryByTestId } = renderWithProvider(
-        <CreatePassword />,
-        mockStore,
-      );
-      expect(queryByTestId('create-password-iframe')).toBeInTheDocument();
-    });
-
-    it('should not inject iframe when participating in metametrics', () => {
-      const state = {
-        ...mockState,
-        metamask: {
-          ...mockState.metamask,
-          participateInMetaMetrics: false,
-        },
-      };
-      const mockStore = configureMockStore()(state);
-      const { queryByTestId } = renderWithProvider(
-        <CreatePassword />,
-        mockStore,
-      );
-      expect(queryByTestId('create-password-iframe')).not.toBeInTheDocument();
     });
   });
 });

--- a/ui/pages/onboarding-flow/create-password/index.scss
+++ b/ui/pages/onboarding-flow/create-password/index.scss
@@ -46,12 +46,4 @@
       width: 100%;
     }
   }
-
-  &__analytics-iframe {
-    width: 1px;
-    height: 1px;
-    position: absolute;
-    top: -9999px;
-    left: -9999px;
-  }
 }


### PR DESCRIPTION
## **Description**

Remove the tracking pixel from the create-password UI, as a step towards removing it from the extension entirely. See https://github.com/MetaMask/metamask-extension/pull/20693

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've clearly explained what problem this PR is solving and how it is solved.
- [ ] I've linked related issues
- [ ] I've included manual testing steps
- [ ] I've included screenshots/recordings if applicable
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [ ] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
