### PR TITLE
Add loading message to deprecated networks

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -889,7 +889,7 @@
     "message": "Connecting to $1"
   },
   "connectingToDeprecatedNetwork": {
-    "message": "'$1' has been deprecated and may have stopped working. Select another network."
+    "message": "'$1' is being phased out and may not work. Try another network."
   },
   "connectingToGoerli": {
     "message": "Connecting to Goerli test network"
@@ -1227,8 +1227,8 @@
   "deprecatedAuroraNetworkMsg": {
     "message": "MetaMask will be deprecating support for Aurora network. Please add it as a custom network if you want to continue to use it"
   },
-  "deprecatedGoerliNetworkMsg": {
-    "message": "Due to the protocol changes of Ethereum: Goerli test network may not work as reliably and will be deprecated soon."
+  "deprecatedGoerliNtwrkMsg": {
+    "message": "Because of updates to the Ethereum system, the Goerli test network will be phased out soon."
   },
   "description": {
     "message": "Description"

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -888,6 +888,9 @@
   "connectingTo": {
     "message": "Connecting to $1"
   },
+  "connectingToDeprecatedNetwork": {
+    "message": "'$1' has been deprecated and may have stopped working. Select another network."
+  },
   "connectingToGoerli": {
     "message": "Connecting to Goerli test network"
   },

--- a/shared/constants/network.ts
+++ b/shared/constants/network.ts
@@ -201,6 +201,11 @@ const CHAINLIST_CHAIN_IDS_MAP = {
   ACALA_NETWORK: '0x313',
 } as const;
 
+// To add a deprecation warning to a network, add it to the array
+// `DEPRECATED_NETWORKS` and as a new case to `getDeprecationWarningCopy() in
+// `ui/components/ui/deprecated-networks/deprecated-networks.js`.
+export const DEPRECATED_NETWORKS = [CHAIN_IDS.AURORA, CHAIN_IDS.GOERLI];
+
 /**
  * The largest possible chain ID we can handle.
  * Explanation: https://gist.github.com/rekmarks/a47bd5f2525936c4b8eee31a16345553

--- a/test/e2e/tests/deprecated-networks.spec.js
+++ b/test/e2e/tests/deprecated-networks.spec.js
@@ -18,7 +18,7 @@ describe('Deprecated networks', function () {
         await driver.clickElement({ text: 'Goerli' });
 
         const deprecationWarningText =
-          'Due to the protocol changes of Ethereum: Goerli test network may not work as reliably and will be deprecated soon.';
+          'Because of updates to the Ethereum system, the Goerli test network will be phased out soon.';
         const isDeprecationWarningDisplayed = await driver.isElementPresent({
           text: deprecationWarningText,
         });

--- a/ui/components/app/loading-network-screen/loading-network-screen.component.js
+++ b/ui/components/app/loading-network-screen/loading-network-screen.component.js
@@ -57,7 +57,7 @@ export default class LoadingNetworkScreen extends PureComponent {
       return loadingMessage;
     }
     const { providerConfig, providerId } = this.props;
-    console.log({ providerConfig });
+
     const providerName = providerConfig.type;
     const { t } = this.context;
 

--- a/ui/components/app/loading-network-screen/loading-network-screen.component.js
+++ b/ui/components/app/loading-network-screen/loading-network-screen.component.js
@@ -2,7 +2,10 @@ import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import LoadingScreen from '../../ui/loading-screen';
 import { SECOND } from '../../../../shared/constants/time';
-import { NETWORK_TYPES } from '../../../../shared/constants/network';
+import {
+  DEPRECATED_NETWORKS,
+  NETWORK_TYPES,
+} from '../../../../shared/constants/network';
 import Popover from '../../ui/popover/popover.component';
 import {
   ButtonPrimary,
@@ -54,8 +57,16 @@ export default class LoadingNetworkScreen extends PureComponent {
       return loadingMessage;
     }
     const { providerConfig, providerId } = this.props;
+    console.log({ providerConfig });
     const providerName = providerConfig.type;
     const { t } = this.context;
+
+    if (DEPRECATED_NETWORKS.includes(providerConfig.chainId)) {
+      const deprecatedNetworkName =
+        providerConfig.nickname || providerConfig.type;
+
+      return t('connectingToDeprecatedNetwork', [deprecatedNetworkName]);
+    }
 
     switch (providerName) {
       case NETWORK_TYPES.MAINNET:

--- a/ui/components/ui/deprecated-networks/deprecated-networks.js
+++ b/ui/components/ui/deprecated-networks/deprecated-networks.js
@@ -62,7 +62,7 @@ function getDeprecationWarningCopy(t, currentChainID) {
     bannerAlertDescription = t('deprecatedAuroraNetworkMsg');
     actionBtnLinkURL = 'https://mainnet.aurora.dev/';
   } else if (currentChainID === CHAIN_IDS.GOERLI) {
-    bannerAlertDescription = t('deprecatedGoerliNetworkMsg');
+    bannerAlertDescription = t('deprecatedGoerliNtwrkMsg');
     actionBtnLinkURL =
       'https://github.com/eth-clients/goerli#goerli-goerlitzer-testnet';
   }

--- a/ui/components/ui/deprecated-networks/deprecated-networks.js
+++ b/ui/components/ui/deprecated-networks/deprecated-networks.js
@@ -10,17 +10,16 @@ import {
 import { getCurrentChainId } from '../../../selectors';
 import { getCompletedOnboarding } from '../../../ducks/metamask/metamask';
 import { BannerAlert, Box, ButtonLink } from '../../component-library';
-import { CHAIN_IDS } from '../../../../shared/constants/network';
+import {
+  CHAIN_IDS,
+  DEPRECATED_NETWORKS,
+} from '../../../../shared/constants/network';
 
 export default function DeprecatedNetworks() {
   const currentChainID = useSelector(getCurrentChainId);
   const [isShowingWarning, setIsShowingWarning] = useState(false);
   const completedOnboarding = useSelector(getCompletedOnboarding);
   const t = useI18nContext();
-
-  // To add a deprecation warning to a network, add it to the array
-  // `DEPRECATED_NETWORKS` and as a new case to `getDeprecationWarningCopy()`
-  const DEPRECATED_NETWORKS = [CHAIN_IDS.AURORA, CHAIN_IDS.GOERLI];
 
   useEffect(() => {
     if (completedOnboarding && DEPRECATED_NETWORKS.includes(currentChainID)) {


### PR DESCRIPTION
## **Description**

After networks are deprecated, some users may continue to use them. If the node RPC provider is unresponsive, the user will see a message warning to change the network.

This PR also tweaks the copy introduced on https://github.com/MetaMask/metamask-extension/pull/22264

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

### **Before**

N/A

### **After**

<img width="1312" alt="Screenshot 2023-12-18 at 15 22 39" src="https://github.com/MetaMask/metamask-extension/assets/13814744/6297573e-aa40-49ac-b943-cb7e6e7291d9">

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've clearly explained what problem this PR is solving and how it is solved.
- [ ] I've linked related issues
- [ ] I've included manual testing steps
- [ ] I've included screenshots/recordings if applicable
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [ ] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
