### PR TITLE
Remove CurrencyRateController start in background constructor

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -739,11 +739,6 @@ export default class MetamaskController extends EventEmitter {
       messenger: currencyRateMessenger,
       state: initState.CurrencyController,
     });
-    if (this.preferencesController.store.getState().useCurrencyRateCheck) {
-      this.currencyRateController.startPollingByNetworkClientId(
-        this.networkController.state.selectedNetworkClientId,
-      );
-    }
 
     const phishingControllerMessenger = this.controllerMessenger.getRestricted({
       name: 'PhishingController',

--- a/test/e2e/tests/state-snapshots/errors-after-init-opt-in-ui-state.json
+++ b/test/e2e/tests/state-snapshots/errors-after-init-opt-in-ui-state.json
@@ -116,8 +116,8 @@
     "currencyRates": {
       "ETH": {
         "conversionDate": "number",
-        "conversionRate": 1700,
-        "usdConversionRate": 1700
+        "conversionRate": 1300,
+        "usdConversionRate": 1300
       }
     },
     "alertEnabledness": { "unconnectedAccount": true, "web3ShimUsage": true },


### PR DESCRIPTION
## **Description**

Cryptocompare reported a spike in API requests. This is the result of incorrectly starting CurrencyRateController polling on MetaMask extension background startup. This PR fixes the issue by removing the logic that was starting CurrencyRateController polling in the constructor.

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/pull/21549

## **Manual testing steps**

1. Open network debug on background.html
2. Restart extension
3. No cryptocompare requests should be seen
4. Open wallet UI
5. One cryptocompare request should be seen
6. Wait 3mins
7. Another cryptocompare request should be seen
8. Close UI
9. Wait 3mins
10. No additional cryptocompare requests should be seen 

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

Note the requests made before the UI is open, but that they are stopped after UI is opened then closed for the first time.

https://github.com/MetaMask/metamask-extension/assets/918701/c66eabd0-363b-467a-87e3-5628daa95395

### **After** 

https://github.com/MetaMask/metamask-extension/assets/918701/3676fa9d-4b6f-4c4d-941d-eac7b0ab7194

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained what problem this PR is solving and how it is solved.
- [x] I've linked related issues
- [x] I've included manual testing steps
- [x] I've included screenshots/recordings if applicable
- [x] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [x] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [x] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
