### PR TITLE
Send `CONNECTION_CLOSING` from Inpage to alert Background to end stream

### DIFF
--- a/app/scripts/contentscript.js
+++ b/app/scripts/contentscript.js
@@ -225,6 +225,13 @@ const setupPageStreams = () => {
     name: CONTENT_SCRIPT,
     target: INPAGE,
   });
+  pageStream.on('data', (event) => {
+    if (event.data?.method === 'CONNECTION_CLOSING') {
+      console.log('contentscript should close connection')
+      // destroyExtensionStreams()
+    }
+    console.log("page stream data", event, event.data.method)
+  });
 
   // create and connect channel muxers
   // so we can handle the channels individually

--- a/app/scripts/inpage.js
+++ b/app/scripts/inpage.js
@@ -40,6 +40,7 @@ import shouldInjectProvider from '../../shared/modules/provider-injection';
 // contexts
 const CONTENT_SCRIPT = 'metamask-contentscript';
 const INPAGE = 'metamask-inpage';
+const PROVIDER = 'metamask-provider';
 
 restoreContextAfterImports();
 
@@ -66,5 +67,45 @@ if (shouldInjectProvider()) {
       icon: process.env.METAMASK_BUILD_ICON,
       rdns: process.env.METAMASK_BUILD_APP_ID,
     },
+  });
+
+  setTimeout(() => {
+    console.log('posted fake CONNECTION_CLOSING from inpage')
+    window.postMessage(
+      {
+        target: CONTENT_SCRIPT, // the post-message-stream "target"
+        data: {
+          // this object gets passed to obj-multiplex
+          name: PROVIDER, // the obj-multiplex channel name
+          data: {
+            jsonrpc: '2.0',
+            method: 'CONNECTION_CLOSING',
+          },
+        },
+      },
+      window.location.origin,
+    );
+  }, 5000)
+
+  window.addEventListener('pagehide', (event) => {
+    if (event.persisted) {
+      console.log("Page being persisted")
+      return
+    }
+    console.log('Page has become hidden', event)
+    // window.postMessage(
+    //   {
+    //     target: CONTENT_SCRIPT, // the post-message-stream "target"
+    //     data: {
+    //       // this object gets passed to obj-multiplex
+    //       name: PROVIDER, // the obj-multiplex channel name
+    //       data: {
+    //         jsonrpc: '2.0',
+    //         method: 'CONNECTION_CLOSING',
+    //       },
+    //     },
+    //   },
+    //   window.location.origin,
+    // );
   });
 }

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -4325,9 +4325,23 @@ export default class MetamaskController extends EventEmitter {
     // setup multiplexing
     const mux = setupMultiplex(connectionStream);
 
+    const metamaskProviderStream = mux.createStream('metamask-provider')
+
+    metamaskProviderStream.on('data', (event) => {
+      if(event.method === 'CONNECTION_CLOSING') {
+        console.log('background should end connection')
+        // metamaskProviderStream.destroy()
+        connectionStream.destroy()
+        return
+      }
+      console.log("metamaskProviderStream", event)
+    })
+
+
+
     // messages between inpage and background
     this.setupProviderConnection(
-      mux.createStream('metamask-provider'),
+      metamaskProviderStream,
       sender,
       _subjectType,
     );

--- a/shared/constants/app.ts
+++ b/shared/constants/app.ts
@@ -83,6 +83,7 @@ export const SNAP_MANAGE_ACCOUNTS_CONFIRMATION_TYPES = {
  * Custom messages to send and be received by the extension
  */
 export const EXTENSION_MESSAGES = {
+  CONNECTION_CLOSING: 'CONNECTION_CLOSING',
   CONNECTION_READY: 'CONNECTION_READY',
   READY: 'METAMASK_EXTENSION_READY',
 } as const;


### PR DESCRIPTION
## **Description**

This is a failed attempt at fix "premature close" error by sending a new `CONNECTION_CLOSING` message from inpage -> contentscript -> background -> MetaMaskController so that MetaMaskController can end the mux stream / connection stream. Unfortunately, this doesn't seem to work since calling destroy on both the metamask-provider mux stream and contentscript <-> background connection stream both result in a "premature close" error still.

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've clearly explained what problem this PR is solving and how it is solved.
- [ ] I've linked related issues
- [ ] I've included manual testing steps
- [ ] I've included screenshots/recordings if applicable
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [ ] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
