### PR TITLE
fix: fix css

### DIFF
--- a/ui/components/multichain/import-tokens-modal/import-tokens-modal.js
+++ b/ui/components/multichain/import-tokens-modal/import-tokens-modal.js
@@ -475,7 +475,7 @@ export const ImportTokensModal = ({ onClose }) => {
         >
           {t('importTokensCamelCase')}
         </ModalHeader>
-        <Box>
+        <Box className="import-tokens-modal__body">
           <Tabs t={t} tabsClassName="import-tokens-modal__tabs">
             {showSearchTab ? (
               <Tab

--- a/ui/components/multichain/import-tokens-modal/index.scss
+++ b/ui/components/multichain/import-tokens-modal/index.scss
@@ -12,6 +12,14 @@
     }
   }
 
+  &__body::-webkit-scrollbar {
+    display: none;
+  }
+
+  &__body {
+    overflow-y: auto;
+  }
+
   &__confirmation-list {
     overflow-y: scroll;
     overflow: auto;


### PR DESCRIPTION
## **Description**

Fixes css on import token modal when recizing the window on expanded view.


## **Manual testing steps**

1. Go to home page
2. Click import tokens
3. Go on expand view
4. Resize the bottom of the window

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
![image](https://github.com/MetaMask/metamask-extension/assets/10994169/67f9eccc-677e-462f-845c-df03de6ac77a)
### **After**

![image](https://github.com/MetaMask/metamask-extension/assets/10994169/b53d26bc-8584-4756-b2fc-4c49e46fc6e6)

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've clearly explained what problem this PR is solving and how it is solved.
- [ ] I've linked related issues
- [ ] I've included manual testing steps
- [ ] I've included screenshots/recordings if applicable
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [ ] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
