### PR TITLE
Fix: OpenSea supply -> total_supply

### DIFF
--- a/.yarn/patches/@metamask-assets-controllers-npm-22.0.0-6af3715fb2.patch
+++ b/.yarn/patches/@metamask-assets-controllers-npm-22.0.0-6af3715fb2.patch
@@ -1,0 +1,49 @@
+diff --git a/dist/NftController.d.ts b/dist/NftController.d.ts
+index 47c42447f3c478f6d27a0e33fb8be420d8f06ebe..b0ff779b081532bd6a6aea61229f0a9e74330b8f 100644
+--- a/dist/NftController.d.ts
++++ b/dist/NftController.d.ts
+@@ -69,7 +69,7 @@ export declare type OpenSeaV2Contract = {
+     collection: string;
+     contract_standard: string;
+     name: string;
+-    supply: number;
++    total_supply?: number;
+ };
+ export declare type OpenSeaV2Collection = {
+     collection: string;
+@@ -88,6 +88,7 @@ export declare type OpenSeaV2Collection = {
+     telegram_url?: string;
+     twitter_username?: string;
+     instagram_username?: string;
++    total_supply?: number;
+ };
+ /**
+  * @type Nft
+diff --git a/dist/assetsUtil.js b/dist/assetsUtil.js
+index fe75a02edc78db998f9e095ef9310552d2889ad0..df741a3f2e553afb7c44658193f4d708da2712e4 100644
+--- a/dist/assetsUtil.js
++++ b/dist/assetsUtil.js
+@@ -320,18 +320,18 @@ exports.mapOpenSeaDetailedNftV2ToV1 = mapOpenSeaDetailedNftV2ToV1;
+  * @returns The contract in the v1 schema.
+  */
+ function mapOpenSeaContractV2ToV1(contract, collection) {
+-    var _a, _b, _c;
++    var _a, _b, _c, _d, _e, _f, _g;
+     return {
+         address: contract.address,
+         asset_contract_type: null,
+         created_date: null,
+         schema_name: contract.contract_standard.toUpperCase(),
+         symbol: null,
+-        total_supply: contract.supply.toString(),
+-        description: (_a = collection === null || collection === void 0 ? void 0 : collection.description) !== null && _a !== void 0 ? _a : null,
+-        external_link: (_b = collection === null || collection === void 0 ? void 0 : collection.project_url) !== null && _b !== void 0 ? _b : null,
++        total_supply: (_d = (_b = (_a = collection === null || collection === void 0 ? void 0 : collection.total_supply) === null || _a === void 0 ? void 0 : _a.toString()) !== null && _b !== void 0 ? _b : (_c = contract.total_supply) === null || _c === void 0 ? void 0 : _c.toString()) !== null && _d !== void 0 ? _d : null,
++        description: (_e = collection === null || collection === void 0 ? void 0 : collection.description) !== null && _e !== void 0 ? _e : null,
++        external_link: (_f = collection === null || collection === void 0 ? void 0 : collection.project_url) !== null && _f !== void 0 ? _f : null,
+         collection: {
+-            name: (_c = collection === null || collection === void 0 ? void 0 : collection.name) !== null && _c !== void 0 ? _c : contract.name,
++            name: (_g = collection === null || collection === void 0 ? void 0 : collection.name) !== null && _g !== void 0 ? _g : contract.name,
+             image_url: collection === null || collection === void 0 ? void 0 : collection.image_url,
+         },
+     };

--- a/package.json
+++ b/package.json
@@ -245,7 +245,7 @@
     "@metamask/address-book-controller": "^3.0.0",
     "@metamask/announcement-controller": "^4.0.0",
     "@metamask/approval-controller": "^3.4.0",
-    "@metamask/assets-controllers": "^22.0.0",
+    "@metamask/assets-controllers": "patch:@metamask/assets-controllers@npm%3A22.0.0#~/.yarn/patches/@metamask-assets-controllers-npm-22.0.0-6af3715fb2.patch",
     "@metamask/base-controller": "^3.2.0",
     "@metamask/browser-passworder": "^4.1.0",
     "@metamask/contract-metadata": "^2.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3835,7 +3835,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/assets-controllers@npm:^22.0.0":
+"@metamask/assets-controllers@npm:22.0.0":
   version: 22.0.0
   resolution: "@metamask/assets-controllers@npm:22.0.0"
   dependencies:
@@ -3868,6 +3868,42 @@ __metadata:
     "@metamask/network-controller": ^17.0.0
     "@metamask/preferences-controller": ^5.0.0
   checksum: 78ee0bb01b0bfb9ca876ea868583b47217b51f08c7839ce45f13236c70e175edc2a1243a3c930c8c24574dd266c267fe46c85a42b377d83239084528d3361713
+  languageName: node
+  linkType: hard
+
+"@metamask/assets-controllers@patch:@metamask/assets-controllers@npm%3A22.0.0#~/.yarn/patches/@metamask-assets-controllers-npm-22.0.0-6af3715fb2.patch":
+  version: 22.0.0
+  resolution: "@metamask/assets-controllers@patch:@metamask/assets-controllers@npm%3A22.0.0#~/.yarn/patches/@metamask-assets-controllers-npm-22.0.0-6af3715fb2.patch::version=22.0.0&hash=95a1c6"
+  dependencies:
+    "@ethersproject/address": "npm:^5.7.0"
+    "@ethersproject/bignumber": "npm:^5.7.0"
+    "@ethersproject/contracts": "npm:^5.7.0"
+    "@ethersproject/providers": "npm:^5.7.0"
+    "@metamask/abi-utils": "npm:^2.0.2"
+    "@metamask/approval-controller": "npm:^5.0.0"
+    "@metamask/base-controller": "npm:^4.0.0"
+    "@metamask/contract-metadata": "npm:^2.4.0"
+    "@metamask/controller-utils": "npm:^8.0.0"
+    "@metamask/eth-query": "npm:^4.0.0"
+    "@metamask/metamask-eth-abis": "npm:3.0.0"
+    "@metamask/network-controller": "npm:^17.0.0"
+    "@metamask/polling-controller": "npm:^3.0.0"
+    "@metamask/preferences-controller": "npm:^5.0.0"
+    "@metamask/rpc-errors": "npm:^6.1.0"
+    "@metamask/utils": "npm:^8.2.0"
+    "@types/uuid": "npm:^8.3.0"
+    async-mutex: "npm:^0.2.6"
+    cockatiel: "npm:3.1.1"
+    ethereumjs-util: "npm:^7.0.10"
+    lodash: "npm:^4.17.21"
+    multiformats: "npm:^9.5.2"
+    single-call-balance-checker-abi: "npm:^1.0.0"
+    uuid: "npm:^8.3.2"
+  peerDependencies:
+    "@metamask/approval-controller": ^5.0.0
+    "@metamask/network-controller": ^17.0.0
+    "@metamask/preferences-controller": ^5.0.0
+  checksum: 96bc121cbd60be3ac75e25254df554a5f90a7b606f970ccbbdba5941c0018d13ec525d2db8e92023bf9b7afcdb3fde09bcf26e4ba2382614b23903b7aafa7d6d
   languageName: node
   linkType: hard
 
@@ -24353,7 +24389,7 @@ __metadata:
     "@metamask/address-book-controller": "npm:^3.0.0"
     "@metamask/announcement-controller": "npm:^4.0.0"
     "@metamask/approval-controller": "npm:^3.4.0"
-    "@metamask/assets-controllers": "npm:^22.0.0"
+    "@metamask/assets-controllers": "patch:@metamask/assets-controllers@npm%3A22.0.0#~/.yarn/patches/@metamask-assets-controllers-npm-22.0.0-6af3715fb2.patch"
     "@metamask/auto-changelog": "npm:^2.1.0"
     "@metamask/base-controller": "npm:^3.2.0"
     "@metamask/browser-passworder": "npm:^4.1.0"


### PR DESCRIPTION
## **Description**

OpenSea renamed the field `supply`, which used to be required, to `total_supply`.  Fixes the error:

`undefined is not an object (evaluating 'contract.supply.toString')`

Which prevented some NFTs from loading.  A more accurate `total_supply` was also added to the collection object, which is now preferred to the one on the contract.

## **Related issues**


## **Manual testing steps**

1. Import a wallet containing NFTs on mainnet
2. Enable NFT autodetection in settings, verify the NFTs appear
3. Verify descriptions, collection/token images are correct

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained what problem this PR is solving and how it is solved.
- [ ] I've linked related issues
- [x] I've included manual testing steps
- [ ] I've included screenshots/recordings if applicable
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [x] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [x] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
