### PR TITLE
Replaced deprecated ConfirmPageContainerWarning with BannerAlter from…

### DIFF
--- a/ui/pages/confirm-approve/confirm-approve-content/confirm-approve-content.component.js
+++ b/ui/pages/confirm-approve/confirm-approve-content/confirm-approve-content.component.js
@@ -16,8 +16,8 @@ import {
   IconColor,
   TextVariant,
   AlignItems,
+  Severity,
 } from '../../../helpers/constants/design-system';
-import { ConfirmPageContainerWarning } from '../../../components/app/confirm-page-container/confirm-page-container-content';
 import LedgerInstructionField from '../../../components/app/ledger-instruction-field';
 ///: BEGIN:ONLY_INCLUDE_IF(blockaid)
 import BlockaidBannerAlert from '../../../components/app/security-provider-banner-alert/blockaid-banner-alert/blockaid-banner-alert';
@@ -33,6 +33,7 @@ import {
   IconName,
   Text,
   Box,
+  BannerAlert,
 } from '../../../components/component-library';
 import TransactionDetailItem from '../../../components/app/transaction-detail-item/transaction-detail-item.component';
 import UserPreferencedCurrencyDisplay from '../../../components/app/user-preferenced-currency-display';
@@ -560,7 +561,7 @@ export default class ConfirmApproveContent extends Component {
         )}
         {warning && (
           <div className="confirm-approve-content__custom-nonce-warning">
-            <ConfirmPageContainerWarning warning={warning} />
+            <BannerAlert severity={Severity.Warning}>{warning}</BannerAlert>
           </div>
         )}
         <Box

--- a/ui/pages/token-allowance/token-allowance.js
+++ b/ui/pages/token-allowance/token-allowance.js
@@ -14,6 +14,7 @@ import {
   FLEX_DIRECTION,
   FontWeight,
   JustifyContent,
+  Severity,
   TextAlign,
   TextColor,
   TextVariant,
@@ -69,8 +70,7 @@ import { useSimulationFailureWarning } from '../../hooks/useSimulationFailureWar
 import SimulationErrorMessage from '../../components/ui/simulation-error-message';
 import LedgerInstructionField from '../../components/app/ledger-instruction-field/ledger-instruction-field';
 import SecurityProviderBannerMessage from '../../components/app/security-provider-banner-message/security-provider-banner-message';
-import { Icon, IconName, Text } from '../../components/component-library';
-import { ConfirmPageContainerWarning } from '../../components/app/confirm-page-container/confirm-page-container-content';
+import { BannerAlert, Icon, IconName, Text } from '../../components/component-library';
 import CustomNonce from '../../components/app/custom-nonce';
 import FeeDetailsComponent from '../../components/app/fee-details-component/fee-details-component';
 
@@ -387,7 +387,7 @@ export default function TokenAllowance({
       )}
       {warning && (
         <Box className="token-allowance-container__custom-nonce-warning">
-          <ConfirmPageContainerWarning warning={warning} />
+          <BannerAlert severity={Severity.Warning}>{warning}</BannerAlert>
         </Box>
       )}
       <Box


### PR DESCRIPTION
## **Description**
Replaced deprecated ConfirmPageContainerWarning with BannerAlter from component-library in:
`ui\pages\token-allowance\token-allowance.js` and
`ui\pages\confirm-approve\confirm-approve-content\confirm-approve-content.component.js`

## **Related issues**

Fixes: #20466
