### PR TITLE
Improve mnemonic restoring

### DIFF
--- a/app/scripts/metamask-controller.test.js
+++ b/app/scripts/metamask-controller.test.js
@@ -642,6 +642,40 @@ describe('MetaMaskController', () => {
       });
     });
 
+    describe('#createNewVaultAndRestore - Nonce Detection', () => {
+      it('should continue with accounts having non-zero nonce', async () => {
+        const password = 'password123';
+        jest.spyOn(metamaskController, 'getBalance').mockResolvedValue('0x0');
+        jest.spyOn(metamaskController, 'getNonce').mockResolvedValue('0x1'); // Mock a non-zero nonce
+
+        // Call the restore function
+        await metamaskController.createNewVaultAndRestore(password, TEST_SEED);
+
+        // Expectation: The restoration should not stop at the first account with zero balance
+        // You need to adjust this based on your implementation details
+        expect(
+          metamaskController.keyringController.addNewAccount,
+        ).toHaveBeenCalled();
+      });
+    });
+
+    describe('#createNewVaultAndRestore - Account Skipping', () => {
+      it('should skip after 10 consecutive empty accounts', async () => {
+        const password = 'password123';
+        jest.spyOn(metamaskController, 'getBalance').mockResolvedValue('0x0');
+        jest.spyOn(metamaskController, 'getNonce').mockResolvedValue('0x0'); // Mock a zero nonce
+
+        // Call the restore function
+        await metamaskController.createNewVaultAndRestore(password, TEST_SEED);
+
+        // Expectation: The restoration should stop after checking 10 consecutive accounts with zero balance and nonce
+        // Adjust this based on how many times you expect the addNewAccount function to be called
+        expect(
+          metamaskController.keyringController.addNewAccount,
+        ).toHaveBeenCalledTimes(10);
+      });
+    });
+
     describe('#getBalance', () => {
       it('should return the balance known by accountTracker', async () => {
         const accounts = {};


### PR DESCRIPTION
Per [this twitter thread](https://x.com/0xg23/status/1740877983542603910).

Improves account restoring in two ways:
- Generates the next 10 accounts to check if they "are active".
- Adds non-zero nonce check to the "is active" check (along with balance & token balances).