### PR TITLE
Fix issue connecting to dapps that dont use eth_accounts

### DIFF
--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -15,7 +15,7 @@ import debounce from 'debounce-stream';
 import log from 'loglevel';
 import browser from 'webextension-polyfill';
 import { storeAsStream } from '@metamask/obs-store';
-import { isObject } from '@metamask/utils';
+import { hasProperty, isObject } from '@metamask/utils';
 ///: BEGIN:ONLY_INCLUDE_IF(snaps)
 import { ApprovalType } from '@metamask/controller-utils';
 ///: END:ONLY_INCLUDE_IF
@@ -466,6 +466,12 @@ function emitDappViewedMetricEvent(
   connectSitePermissions,
   preferencesController,
 ) {
+  // A dapp may have other permissions than eth_accounts.
+  // Since we are only interested in dapps that use Ethereum accounts, we bail out otherwise.
+  if (!hasProperty(connectSitePermissions.permissions, 'eth_accounts')) {
+    return;
+  }
+
   const numberOfTotalAccounts = Object.keys(
     preferencesController.store.getState().identities,
   ).length;


### PR DESCRIPTION
## **Description**

Fixes an issue with connecting to dapps that have permissions (e.g. for snaps) but don't leverage `eth_accounts`. 

A flawed assumption was made in which we assumed that dapps that have permissions always have `eth_accounts`, that is not the case. The applied fix bails out of the function in question if `eth_accounts` is not present as it is expected to be.

## **Manual testing steps**

1. Disconnect from `metamask.github.io`
2. Open https://metamask.github.io/snaps/test-snaps/latest/
3. Install a snap
4. Refresh the page and notice that you can still use the dapp