### PR TITLE
Show total fees when simulaton fails.

### DIFF
--- a/ui/components/app/transaction-detail-item/index.scss
+++ b/ui/components/app/transaction-detail-item/index.scss
@@ -1,5 +1,6 @@
 .transaction-detail-item {
   color: var(--color-text-alternative);
+  margin-bottom: 8px;
 
   &__row {
     display: flex;

--- a/ui/pages/confirm-transaction-base/confirm-transaction-base.component.js
+++ b/ui/pages/confirm-transaction-base/confirm-transaction-base.component.js
@@ -17,7 +17,6 @@ import UserPreferencedCurrencyDisplay from '../../components/app/user-preference
 
 import { PRIMARY, SECONDARY } from '../../helpers/constants/common';
 import TextField from '../../components/ui/text-field';
-import SimulationErrorMessage from '../../components/ui/simulation-error-message';
 import { MetaMetricsEventCategory } from '../../../shared/constants/metametrics';
 import { getMethodName } from '../../helpers/utils/metrics';
 import {
@@ -429,20 +428,6 @@ export default class ConfirmTransactionBase extends Component {
       </div>
     ) : null;
 
-    const simulationFailureWarning = () => (
-      <div
-        className="confirm-page-container-content__error-container"
-        key="confirm-transaction-base_simulation-error-container"
-      >
-        <SimulationErrorMessage
-          userAcknowledgedGasMissing={userAcknowledgedGasMissing}
-          setUserAcknowledgedGasMissing={() =>
-            this.setUserAcknowledgedGasMissing()
-          }
-        />
-      </div>
-    );
-
     return (
       <div className="confirm-page-container-content__details">
         <TransactionAlerts
@@ -457,16 +442,15 @@ export default class ConfirmTransactionBase extends Component {
           isBuyableChain={isBuyableChain}
           tokenSymbol={tokenSymbol}
         />
-        <TransactionDetail
-          disableEditGasFeeButton
-          disabled={isDisabled()}
-          userAcknowledgedGasMissing={userAcknowledgedGasMissing}
-          onEdit={
-            renderSimulationFailureWarning ? null : () => this.handleEditGas()
-          }
-          rows={[
-            renderSimulationFailureWarning && simulationFailureWarning(),
-            !renderSimulationFailureWarning && (
+        {!renderSimulationFailureWarning && (
+          <TransactionDetail
+            disableEditGasFeeButton
+            disabled={isDisabled()}
+            userAcknowledgedGasMissing={userAcknowledgedGasMissing}
+            onEdit={
+              renderSimulationFailureWarning ? null : () => this.handleEditGas()
+            }
+            rows={[
               <div key="confirm-transaction-base_confirm-gas-display">
                 <ConfirmGasDisplay
                   userAcknowledgedGasMissing={userAcknowledgedGasMissing}
@@ -476,38 +460,35 @@ export default class ConfirmTransactionBase extends Component {
                   useCurrencyRateCheck={useCurrencyRateCheck}
                   txData={txData}
                 />
-              </div>
-            ),
-          ]}
-        />
+              </div>,
+            ]}
+          />
+        )}
         <TransactionDetail
           disableEditGasFeeButton
           disabled={isDisabled()}
           userAcknowledgedGasMissing={userAcknowledgedGasMissing}
           rows={[
-            !renderSimulationFailureWarning && (
-              <TransactionDetailItem
-                key="confirm-transaction-base-total-item"
-                detailTitle={t('total')}
-                detailText={
-                  useCurrencyRateCheck &&
-                  renderTotalDetailText(getTotalAmount())
-                }
-                detailTotal={renderTotalMaxAmount(true)}
-                subTitle={t('transactionDetailGasTotalSubtitle')}
-                subText={
-                  <div className="confirm-page-container-content__total-amount">
-                    <LoadingHeartBeat
-                      estimateUsed={this.props.txData?.userFeeLevel}
-                    />
-                    <strong key="editGasSubTextAmountLabel">
-                      {t('editGasSubTextAmountLabel')}
-                    </strong>{' '}
-                    {renderTotalMaxAmount(true)}
-                  </div>
-                }
-              />
-            ),
+            <TransactionDetailItem
+              key="confirm-transaction-base-total-item"
+              detailTitle={t('total')}
+              detailText={
+                useCurrencyRateCheck && renderTotalDetailText(getTotalAmount())
+              }
+              detailTotal={renderTotalMaxAmount(true)}
+              subTitle={t('transactionDetailGasTotalSubtitle')}
+              subText={
+                <div className="confirm-page-container-content__total-amount">
+                  <LoadingHeartBeat
+                    estimateUsed={this.props.txData?.userFeeLevel}
+                  />
+                  <strong key="editGasSubTextAmountLabel">
+                    {t('editGasSubTextAmountLabel')}
+                  </strong>{' '}
+                  {renderTotalMaxAmount(true)}
+                </div>
+              }
+            />,
           ]}
         />
         {nonceField}

--- a/ui/pages/confirm-transaction-base/confirm-transaction-base.component.js
+++ b/ui/pages/confirm-transaction-base/confirm-transaction-base.component.js
@@ -17,6 +17,7 @@ import UserPreferencedCurrencyDisplay from '../../components/app/user-preference
 
 import { PRIMARY, SECONDARY } from '../../helpers/constants/common';
 import TextField from '../../components/ui/text-field';
+import SimulationErrorMessage from '../../components/ui/simulation-error-message';
 import { MetaMetricsEventCategory } from '../../../shared/constants/metametrics';
 import { getMethodName } from '../../helpers/utils/metrics';
 import {
@@ -428,6 +429,20 @@ export default class ConfirmTransactionBase extends Component {
       </div>
     ) : null;
 
+    const simulationFailureWarning = () => (
+      <div
+        className="confirm-page-container-content__error-container"
+        key="confirm-transaction-base_simulation-error-container"
+      >
+        <SimulationErrorMessage
+          userAcknowledgedGasMissing={userAcknowledgedGasMissing}
+          setUserAcknowledgedGasMissing={() =>
+            this.setUserAcknowledgedGasMissing()
+          }
+        />
+      </div>
+    );
+
     return (
       <div className="confirm-page-container-content__details">
         <TransactionAlerts
@@ -442,15 +457,16 @@ export default class ConfirmTransactionBase extends Component {
           isBuyableChain={isBuyableChain}
           tokenSymbol={tokenSymbol}
         />
-        {!renderSimulationFailureWarning && (
-          <TransactionDetail
-            disableEditGasFeeButton
-            disabled={isDisabled()}
-            userAcknowledgedGasMissing={userAcknowledgedGasMissing}
-            onEdit={
-              renderSimulationFailureWarning ? null : () => this.handleEditGas()
-            }
-            rows={[
+        {renderSimulationFailureWarning && simulationFailureWarning()}
+        <TransactionDetail
+          disableEditGasFeeButton
+          disabled={isDisabled()}
+          userAcknowledgedGasMissing={userAcknowledgedGasMissing}
+          onEdit={
+            renderSimulationFailureWarning ? null : () => this.handleEditGas()
+          }
+          rows={[
+            !renderSimulationFailureWarning && (
               <div key="confirm-transaction-base_confirm-gas-display">
                 <ConfirmGasDisplay
                   userAcknowledgedGasMissing={userAcknowledgedGasMissing}
@@ -460,10 +476,10 @@ export default class ConfirmTransactionBase extends Component {
                   useCurrencyRateCheck={useCurrencyRateCheck}
                   txData={txData}
                 />
-              </div>,
-            ]}
-          />
-        )}
+              </div>
+            ),
+          ]}
+        />
         <TransactionDetail
           disableEditGasFeeButton
           disabled={isDisabled()}

--- a/ui/pages/confirm-transaction-base/confirm-transaction-base.component.js
+++ b/ui/pages/confirm-transaction-base/confirm-transaction-base.component.js
@@ -457,7 +457,6 @@ export default class ConfirmTransactionBase extends Component {
           isBuyableChain={isBuyableChain}
           tokenSymbol={tokenSymbol}
         />
-        {renderSimulationFailureWarning && simulationFailureWarning()}
         <TransactionDetail
           disableEditGasFeeButton
           disabled={isDisabled()}
@@ -466,6 +465,7 @@ export default class ConfirmTransactionBase extends Component {
             renderSimulationFailureWarning ? null : () => this.handleEditGas()
           }
           rows={[
+            renderSimulationFailureWarning && simulationFailureWarning(),
             !renderSimulationFailureWarning && (
               <div key="confirm-transaction-base_confirm-gas-display">
                 <ConfirmGasDisplay

--- a/ui/pages/confirm-transaction-base/confirm-transaction-base.test.js
+++ b/ui/pages/confirm-transaction-base/confirm-transaction-base.test.js
@@ -225,6 +225,21 @@ describe('Confirm Transaction Base', () => {
     expect(queryByText('Layer 2 gas fee')).not.toBeInTheDocument();
   });
 
+  it('should render only total fee details if simulation fails', () => {
+    mockedStore.send.hasSimulationError = true;
+    const store = configureMockStore(middleware)(mockedStore);
+    const { queryByText } = renderWithProvider(
+      <ConfirmTransactionBase actionKey="confirm" />,
+      store,
+    );
+
+    expect(queryByText('Total')).toBeInTheDocument();
+    expect(queryByText('Amount + gas fee')).toBeInTheDocument();
+
+    expect(queryByText('Estimated fee')).not.toBeInTheDocument();
+    expect(queryByText('Fee details')).not.toBeInTheDocument();
+  });
+
   it('should contain L1 L2 fee details for optimism', () => {
     mockedStore.metamask.providerConfig.chainId = CHAIN_IDS.OPTIMISM;
     mockedStore.confirmTransaction.txData.chainId = CHAIN_IDS.OPTIMISM;


### PR DESCRIPTION
## **Description**
Whenever the transaction is going to fail (for any reason - i.e. trying to send a token you don't own) the gas section disappears from the Confirmation screen, it should show the total gas section. The fix is to remove the condition that hides the total gas section.

## **Related issues**

Fixes: #22339 

## **Manual testing steps**

1. Select Mainnet
2. Go to this contract https://etherscan.io/token/0xB8c77482e45F1F44dE1745F52C74426C631bDD52#writeContract
3. Connect the wallet
4. Click transfer
5. Add any recipient and an amount greater than your balance
6. See confirmation screen without gas (Shown in Before Screenshot below)
7. Checkout this branch
8. Repeast 2-5
9. See confirmation screen with gas (Shown in After Screenshow below)

## **Screenshots/Recordings**

### **Before**
![image](https://github.com/MetaMask/metamask-extension/assets/44811/84e3cf3e-71db-4bd8-a6f4-5d7ce49f09ab)

### **After**
<img width="1087" alt="Screenshot 2024-01-09 at 00 08 30" src="https://github.com/MetaMask/metamask-extension/assets/44811/bb149912-df46-4e0f-b026-b077f6b7544b">

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained what problem this PR is solving and how it is solved.
- [x] I've linked related issues
- [x] I've included manual testing steps
- [x] I've included screenshots/recordings if applicable
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [x] I’ve properly set the pull request status:
  - [] In case it's not yet "ready for review", I've set it to "draft".
  - [x] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
