### PR TITLE
Fixing deprecation messages for BUTTON_VARIANT and BUTTON_SIZES

### DIFF
--- a/ui/components/component-library/button/index.ts
+++ b/ui/components/component-library/button/index.ts
@@ -5,7 +5,7 @@ export { ButtonSize, ButtonVariant } from './button.types';
 export type { ButtonProps } from './button.types';
 
 /**
- * @deprecated `BUTTON_VARIANT` const has been deprecated in favor of the `ButtonVariant` enum which can still be imported from `ui/components/component-library`
+ * @deprecated `BUTTON_SIZES` const has been deprecated in favor of the `ButtonSize` enum which can still be imported from `ui/components/component-library`
  */
 export const BUTTON_SIZES = {
   SM: Size.SM,
@@ -15,7 +15,7 @@ export const BUTTON_SIZES = {
   AUTO: Size.auto,
 };
 /**
- * @deprecated `BUTTON_SIZES` const has been deprecated in favor of the `ButtonSize` enum which can still be imported from `ui/components/component-library`
+ * @deprecated `BUTTON_VARIANT` const has been deprecated in favor of the `ButtonVariant` enum which can still be imported from `ui/components/component-library`
  */
 export const BUTTON_VARIANT = {
   PRIMARY: 'primary',


### PR DESCRIPTION
## **Description**
This PR addresses an issue with the deprecation messages for the `BUTTON_VARIANT` and `BUTTON_SIZES` constants. Currently, the messages are misplaced and do not correspond to the correct constants. This update ensures that each deprecation message is correctly placed above its respective deprecated constant, improving clarity and accuracy.

## **Related issues**

Fixes: N/A

## **Manual testing steps**

1. Pull this branch
2. Search for `BUTTON_VARIANT`
3. Hover over the constant to see the correct deprecation notice
4. Repeat for `BUTTON_SIZES`

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

![Screenshot 2024-01-08 at 8 52 55 AM](https://github.com/MetaMask/metamask-extension/assets/8112138/98102aec-6b4b-4de7-96e0-db68e033ec50)
![Screenshot 2024-01-08 at 8 53 40 AM](https://github.com/MetaMask/metamask-extension/assets/8112138/c8d3cfeb-e771-46de-a7b2-1eae9d810c61)


### **After**

![Screenshot 2024-01-08 at 8 54 16 AM](https://github.com/MetaMask/metamask-extension/assets/8112138/1698971f-d7e0-47e1-a1ba-4c006da96d24)
![Screenshot 2024-01-08 at 8 54 41 AM](https://github.com/MetaMask/metamask-extension/assets/8112138/8340fa4d-05e6-4363-b21c-22d4141a3cd2)


## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained what problem this PR is solving and how it is solved.
- [x] I've linked related issues
- [x] I've included manual testing steps
- [x] I've included screenshots/recordings if applicable
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [x] I’ve properly set the pull request status:
  - [] In case it's not yet "ready for review", I've set it to "draft".
  - [x] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
