### PR TITLE
Fix overflowing snap UI

### DIFF
--- a/ui/components/app/snaps/snap-ui-markdown/snap-ui-markdown.js
+++ b/ui/components/app/snaps/snap-ui-markdown/snap-ui-markdown.js
@@ -19,7 +19,7 @@ const Paragraph = (props) => (
     {...props}
     variant={TextVariant.bodyMd}
     className="snap-ui-markdown__text"
-    overflowWrap={OverflowWrap.BreakWord}
+    overflowWrap={OverflowWrap.Anywhere}
     color={TextColor.inherit}
   />
 );

--- a/ui/components/app/snaps/snap-ui-renderer/snap-ui-renderer.js
+++ b/ui/components/app/snaps/snap-ui-renderer/snap-ui-renderer.js
@@ -42,7 +42,7 @@ export const UI_MAPPING = {
     props: {
       variant: TypographyVariant.H4,
       fontWeight: FontWeight.Bold,
-      overflowWrap: OverflowWrap.BreakWord,
+      overflowWrap: OverflowWrap.Anywhere,
     },
   }),
   text: (props) => ({


### PR DESCRIPTION
## **Description**

Fixes an issue with certain types of snap UI overflowing their container.

## **Related issues**

Fixes: https://github.com/MetaMask/snaps/issues/2078

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

![image](https://github.com/MetaMask/metamask-extension/assets/1561200/3e78dba1-442c-4216-9cdb-d4883c08aedc)

### **After**

![image](https://github.com/MetaMask/metamask-extension/assets/1561200/e828c6d9-1ef4-4da1-8657-204822a6ad3f)
