### PR TITLE
fix: fix settings button redirection

### DIFF
--- a/ui/components/multichain/import-tokens-modal/import-tokens-modal.js
+++ b/ui/components/multichain/import-tokens-modal/import-tokens-modal.js
@@ -95,7 +95,6 @@ import {
   MetaMetricsEventName,
   MetaMetricsTokenEventSource,
 } from '../../../../shared/constants/metametrics';
-import { getMostRecentOverviewPage } from '../../../ducks/history/history';
 import { ImportTokensModalConfirm } from './import-tokens-modal-confirm';
 
 export const ImportTokensModal = ({ onClose }) => {
@@ -124,7 +123,6 @@ export const ImportTokensModal = ({ onClose }) => {
     ({ metamask }) => metamask.useTokenDetection,
   );
   const networkName = useSelector(getTokenDetectionSupportNetworkByChainId);
-  const mostRecentOverviewPage = useSelector(getMostRecentOverviewPage);
   const nativeCurrency = useSelector(getNativeCurrency);
 
   // Custom token stuff
@@ -606,10 +604,10 @@ export const ImportTokensModal = ({ onClose }) => {
                                   type="link"
                                   key="import-token-token-detection-announcement"
                                   onClick={() => {
+                                    onClose();
                                     history.push(
                                       `${SECURITY_ROUTE}#auto-detect-tokens`,
                                     );
-                                    history.push(mostRecentOverviewPage);
                                   }}
                                 >
                                   {t('inYourSettings')}


### PR DESCRIPTION
## **Description**

Fixes redirection to settings page on import tokens modal (non mainnet network exp : Linea Goerli)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Switch to Linea goerli testnet
2. Click import tokens
3. You should see a banner, click on "enable from settings" you should be redirected to settings page

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

https://github.com/MetaMask/metamask-extension/assets/10994169/dbfc1028-aced-466a-88af-8013def6c02d

### **After**

https://github.com/MetaMask/metamask-extension/assets/10994169/efd4daf5-50e7-4155-8e3f-b7ac07898a1d


## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've clearly explained what problem this PR is solving and how it is solved.
- [ ] I've linked related issues
- [ ] I've included manual testing steps
- [ ] I've included screenshots/recordings if applicable
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [ ] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
