### PR TITLE
fix(22476): fix flaky dapp viewed with two accounts e2e test

### DIFF
--- a/test/e2e/tests/metrics/dapp-viewed.spec.js
+++ b/test/e2e/tests/metrics/dapp-viewed.spec.js
@@ -248,6 +248,7 @@ describe('Dapp viewed Event @no-mmi', function () {
           text: 'Connect',
           tag: 'button',
         });
+        await driver.waitUntilXWindowHandles(3);
         await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
         await driver.clickElement(
           '[data-testid="choose-account-list-operate-all-check-box"]',


### PR DESCRIPTION
## **Description**
Fix the flaky `Dapp viewed Event @no-mmi test is sent when connecting dapp with two accounts`
<img width="1505" alt="Screenshot 2024-01-10 at 14 18 11" src="https://github.com/MetaMask/metamask-extension/assets/12678455/d85efaa3-fc56-4b2b-90cf-318081b8cf40">

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've clearly explained what problem this PR is solving and how it is solved.
- [ ] I've linked related issues
- [ ] I've included manual testing steps
- [ ] I've included screenshots/recordings if applicable
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [ ] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
