### PR TITLE
fix(14311): display explorer domain instead of hardcoded Etherscan explorer name

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -1842,6 +1842,9 @@
   "generalCameraErrorTitle": {
     "message": "Something went wrong...."
   },
+  "genericExplorerView": {
+    "message": "View account on $1"
+  },
   "globalTitle": {
     "message": "Global menu"
   },

--- a/app/_locales/fr/messages.json
+++ b/app/_locales/fr/messages.json
@@ -1666,6 +1666,9 @@
   "general": {
     "message": "Général"
   },
+  "genericExplorerView": {
+    "message": "Afficher le compte sur $1"
+  },
   "globalTitle": {
     "message": "Menu global"
   },

--- a/ui/pages/create-account/connect-hardware/account-list.js
+++ b/ui/pages/create-account/connect-hardware/account-list.js
@@ -99,6 +99,12 @@ class AccountList extends Component {
           const checked =
             this.props.selectedAccounts.includes(account.index) ||
             accountAlreadyConnected;
+          const accountLink = getAccountLink(
+            account.address,
+            chainId,
+            rpcPrefs,
+          );
+          const blockExplorerDomain = getURLHostName(accountLink);
 
           return (
             <div
@@ -136,18 +142,13 @@ class AccountList extends Component {
               <a
                 className="hw-account-list__item__link"
                 onClick={() => {
-                  const accountLink = getAccountLink(
-                    account.address,
-                    chainId,
-                    rpcPrefs,
-                  );
                   this.context.trackEvent({
                     category: MetaMetricsEventCategory.Accounts,
                     event: 'Clicked Block Explorer Link',
                     properties: {
                       actions: 'Hardware Connect',
                       link_type: 'Account Tracker',
-                      block_explorer_domain: getURLHostName(accountLink),
+                      block_explorer_domain: blockExplorerDomain,
                     },
                   });
                   global.platform.openTab({
@@ -156,7 +157,9 @@ class AccountList extends Component {
                 }}
                 target="_blank"
                 rel="noopener noreferrer"
-                title={this.context.t('etherscanView')}
+                title={this.context.t('genericExplorerView', [
+                  blockExplorerDomain,
+                ])}
               >
                 <i
                   className="fa fa-share-square"

--- a/ui/pages/create-account/connect-hardware/account-list.test.js
+++ b/ui/pages/create-account/connect-hardware/account-list.test.js
@@ -82,6 +82,13 @@ describe('AccountList', () => {
     ).toHaveLength(2);
   });
 
+  it('renders AccountList component and find expected titles on explorer links', () => {
+    render();
+    expect(screen.getAllByTitle('View account on etherscan.io')).toHaveLength(
+      5,
+    );
+  });
+
   it('disables the Prev button as the first account has an index of 0', () => {
     render();
 


### PR DESCRIPTION
## **Description**

This PR displays the explorer domain on hover on account list links instead of the currently hardcoded Etherscan explorer name (not matter what was the selected network)

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/14311

## **Manual testing steps**

1. Go to Add hardware wallet
2. On the ledger device, unlock it if necessary and select Eth app
3. On the Connect a hardware wallet page, Click on Ledger and then continue
4. On the browser, click on the nano and then continue
5. On the account list, hover on any explorer links. It should match the selected network explorer domain.

## **Screenshots/Recordings**

### **Before**
<img width="1242" alt="Capture d’écran 2024-01-11 à 10 40 34" src="https://github.com/MetaMask/metamask-extension/assets/574787/c52381aa-c0ae-4785-b624-dc1311e4ffda">

### **After**
<img width="1327" alt="Capture d’écran 2024-01-11 à 10 55 55" src="https://github.com/MetaMask/metamask-extension/assets/574787/3771a5b7-7d98-4c18-bb38-6998903ff74d">
<img width="1273" alt="Capture d’écran 2024-01-11 à 10 56 42" src="https://github.com/MetaMask/metamask-extension/assets/574787/f2f02ce7-5bfe-4c69-920f-6d439206cb11">


## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained what problem this PR is solving and how it is solved.
- [x] I've linked related issues
- [x] I've included manual testing steps
- [x] I've included screenshots/recordings if applicable
- [x] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [x] I’ve properly set the pull request status:
  - [x] In case it's not yet "ready for review", I've set it to "draft".
  - [x] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
