### PR TITLE
Added launch.json configuration to run E2E tests

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -16,6 +16,30 @@
       "windows": {
         "program": "${workspaceFolder}/node_modules/jest/bin/jest"
       }
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Test E2E: current file",
+      "cwd": "${workspaceFolder}",
+      "runtimeExecutable": "yarn",
+      "runtimeArgs": [
+        "test:e2e:single",
+        "${relativeFile}",
+        "--browser=${input:browserToUse}",
+        "--debug"
+      ],
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen"
+    }
+  ],
+  "inputs": [
+    {
+      "type": "pickString",
+      "id": "browserToUse",
+      "description": "Which browser do you want to test with?",
+      "options": ["chrome", "firefox"],
+      "default": "chrome"
     }
   ],
   "version": "0.2.0"


### PR DESCRIPTION
## **Description**

Adds an easy way to run and debug E2E tests in VSCode by pressing F5

## **Related issues**

Builds upon: #22416

## **Manual testing steps**

1. Open a spec.js or spec.ts file
2. If you want to, set a breakpoint
3. Press F5 to start debugging
4. A menu opens up at the top, choose a browser
5. The current E2E test should run in your chosen browser
6. If you had set a breakpoint, it should stop at the breakpoint

## **Screenshots/Recordings**

![image](https://github.com/MetaMask/metamask-extension/assets/539738/cef0b319-432e-4010-8e9f-e638a1afab54)

![image](https://github.com/MetaMask/metamask-extension/assets/539738/a2986b72-4158-43a3-b4aa-4f14ef63af82)


## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained what problem this PR is solving and how it is solved.
- [x] I've linked related issues
- [x] I've included manual testing steps
- [x] I've included screenshots/recordings if applicable
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [x] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [x] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
