### PR TITLE
docs: add schema validation for manifest json files

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,5 +2,13 @@
   "editor.defaultFormatter": "rvest.vs-code-prettier-eslint",
   "editor.tabSize": 2,
   "files.trimTrailingWhitespace": true,
-  "javascript.preferences.importModuleSpecifier": "relative"
+  "javascript.preferences.importModuleSpecifier": "relative",
+  "json.schemas": [
+    {
+      "fileMatch": [
+        "app/manifest/*/*.json"
+      ],
+      "url": "https://json.schemastore.org/chrome-manifest"
+    }
+  ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,9 +5,7 @@
   "javascript.preferences.importModuleSpecifier": "relative",
   "json.schemas": [
     {
-      "fileMatch": [
-        "app/manifest/*/*.json"
-      ],
+      "fileMatch": ["app/manifest/*/*.json"],
       "url": "https://json.schemastore.org/chrome-manifest"
     }
   ]


### PR DESCRIPTION
## **Description**

Adds schema validation for manifest.json files for VSCode users.

This PR adds tooltip documentation showing what manifest.json keys do:

<img width="654" alt="image" src="https://github.com/MetaMask/metamask-extension/assets/187813/e843cc3f-bdd5-42fe-81b9-e26ef2fa3eaa">


And shows errors when values are used that aren't permitted by the schema:

<img width="675" alt="image" src="https://github.com/MetaMask/metamask-extension/assets/187813/c7a02bb0-78b0-4c0e-a84b-3ef1c3289ae7">


## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained what problem this PR is solving and how it is solved.
- [ ] I've linked related issues
- [ ] I've included manual testing steps
- [x] I've included screenshots/recordings if applicable
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [ ] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [x] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
