### PR TITLE
fix: close banner to avoid error with e2e tests

### DIFF
--- a/test/e2e/mmi/Dockerfile
+++ b/test/e2e/mmi/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/playwright:v1.40.0-focal AS build
+FROM mcr.microsoft.com/playwright:v1.41.0-focal AS build
 
 WORKDIR '/usr/src/app'
 

--- a/test/e2e/mmi/pageObjects/mmi-accountMenu-page.ts
+++ b/test/e2e/mmi/pageObjects/mmi-accountMenu-page.ts
@@ -38,14 +38,6 @@ export class MMIAccountMenuPage {
 
   async accountsMenu() {
     await this.accountsMenuBtn.click();
-
-    const bannerCloseButton = this.page.locator(
-      '.mm-banner-base__close-button',
-    );
-
-    if ((await bannerCloseButton.count()) > 0) {
-      await bannerCloseButton.click();
-    }
   }
 
   async setDialog() {
@@ -110,6 +102,15 @@ export class MMIAccountMenuPage {
     const accountsFunds = dialog.locator(
       '.multichain-account-list-item__content',
     );
+
+    const bannerCloseButton = accountsFunds.locator(
+      '.mm-banner-base__close-button',
+    );
+
+    if ((await bannerCloseButton.count()) > 0) {
+      await bannerCloseButton.click();
+    }
+
     await test.expect
       .soft(dialog)
       .toHaveScreenshot(screenshotName, { mask: [accountsFunds] });

--- a/test/e2e/mmi/pageObjects/mmi-accountMenu-page.ts
+++ b/test/e2e/mmi/pageObjects/mmi-accountMenu-page.ts
@@ -144,7 +144,7 @@ export class MMIAccountMenuPage {
       accountNames.push(accountName);
     }
 
-    await this.page.getByRole('button', { name: /close/iu }).click();
+    await this.page.getByRole('button', { name: /close/iu }).first().click();
     return accountNames;
   }
 }

--- a/test/e2e/mmi/pageObjects/mmi-accountMenu-page.ts
+++ b/test/e2e/mmi/pageObjects/mmi-accountMenu-page.ts
@@ -100,11 +100,7 @@ export class MMIAccountMenuPage {
       .getByRole('dialog')
       .filter({ hasText: 'Select an account' });
 
-    const bannerCloseButton = dialog.locator('.mm-banner-base__close-button');
-
-    if ((await bannerCloseButton.count()) > 0) {
-      await bannerCloseButton.click();
-    }
+    await dialog.locator('.mm-banner-base__close-button').click();
 
     const accountsFunds = dialog.locator(
       '.multichain-account-list-item__content',

--- a/test/e2e/mmi/pageObjects/mmi-accountMenu-page.ts
+++ b/test/e2e/mmi/pageObjects/mmi-accountMenu-page.ts
@@ -100,7 +100,11 @@ export class MMIAccountMenuPage {
       .getByRole('dialog')
       .filter({ hasText: 'Select an account' });
 
-    await dialog.locator('.mm-banner-base__close-button').click();
+    const bannerCloseButton = dialog.locator('.mm-banner-base__close-button');
+
+    if ((await bannerCloseButton.count()) > 0) {
+      await bannerCloseButton.click();
+    }
 
     const accountsFunds = dialog.locator(
       '.multichain-account-list-item__content',

--- a/test/e2e/mmi/pageObjects/mmi-accountMenu-page.ts
+++ b/test/e2e/mmi/pageObjects/mmi-accountMenu-page.ts
@@ -42,7 +42,8 @@ export class MMIAccountMenuPage {
     const bannerCloseButton = this.page.locator(
       '.mm-banner-base__close-button',
     );
-    if (await bannerCloseButton.isVisible()) {
+
+    if ((await bannerCloseButton.count()) > 0) {
       await bannerCloseButton.click();
     }
   }

--- a/test/e2e/mmi/pageObjects/mmi-accountMenu-page.ts
+++ b/test/e2e/mmi/pageObjects/mmi-accountMenu-page.ts
@@ -99,17 +99,16 @@ export class MMIAccountMenuPage {
     const dialog = this.page
       .getByRole('dialog')
       .filter({ hasText: 'Select an account' });
-    const accountsFunds = dialog.locator(
-      '.multichain-account-list-item__content',
-    );
 
-    const bannerCloseButton = accountsFunds.locator(
-      '.mm-banner-base__close-button',
-    );
+    const bannerCloseButton = dialog.locator('.mm-banner-base__close-button');
 
     if ((await bannerCloseButton.count()) > 0) {
       await bannerCloseButton.click();
     }
+
+    const accountsFunds = dialog.locator(
+      '.multichain-account-list-item__content',
+    );
 
     await test.expect
       .soft(dialog)

--- a/test/e2e/mmi/pageObjects/mmi-accountMenu-page.ts
+++ b/test/e2e/mmi/pageObjects/mmi-accountMenu-page.ts
@@ -144,7 +144,9 @@ export class MMIAccountMenuPage {
       accountNames.push(accountName);
     }
 
-    await this.page.getByRole('button', { name: /close/iu }).first().click();
+    await this.page.locator('.mm-banner-base__close-button').click();
+
+    await this.page.getByRole('button', { name: /close/iu }).click();
     return accountNames;
   }
 }

--- a/test/e2e/mmi/pageObjects/mmi-accountMenu-page.ts
+++ b/test/e2e/mmi/pageObjects/mmi-accountMenu-page.ts
@@ -146,7 +146,7 @@ export class MMIAccountMenuPage {
 
     await this.page.locator('.mm-banner-base__close-button').click();
 
-    await this.page.getByRole('button', { name: /close/iu }).click();
+    await this.page.getByRole('button', { name: /close/iu }).first().click();
     return accountNames;
   }
 }

--- a/test/e2e/mmi/pageObjects/mmi-accountMenu-page.ts
+++ b/test/e2e/mmi/pageObjects/mmi-accountMenu-page.ts
@@ -38,6 +38,13 @@ export class MMIAccountMenuPage {
 
   async accountsMenu() {
     await this.accountsMenuBtn.click();
+
+    const bannerCloseButton = this.page.locator(
+      '.mm-banner-base__close-button',
+    );
+    if (await bannerCloseButton.isVisible()) {
+      await bannerCloseButton.click();
+    }
   }
 
   async setDialog() {
@@ -143,8 +150,6 @@ export class MMIAccountMenuPage {
       const accountName = await accounts.nth(i).getByRole('button').innerText();
       accountNames.push(accountName);
     }
-
-    await this.page.locator('.mm-banner-base__close-button').click();
 
     await this.page.getByRole('button', { name: /close/iu }).first().click();
     return accountNames;

--- a/test/e2e/mmi/pageObjects/mmi-accountMenu-page.ts
+++ b/test/e2e/mmi/pageObjects/mmi-accountMenu-page.ts
@@ -95,16 +95,9 @@ export class MMIAccountMenuPage {
   }
 
   async accountMenuScreenshot(screenshotName: string) {
-    await this.accountsMenu();
     const dialog = this.page
       .getByRole('dialog')
       .filter({ hasText: 'Select an account' });
-
-    const bannerCloseButton = dialog.locator('.mm-banner-base__close-button');
-
-    if ((await bannerCloseButton.count()) > 0) {
-      await bannerCloseButton.click();
-    }
 
     const accountsFunds = dialog.locator(
       '.multichain-account-list-item__content',
@@ -154,5 +147,13 @@ export class MMIAccountMenuPage {
 
     await this.page.getByRole('button', { name: /close/iu }).first().click();
     return accountNames;
+  }
+
+  async closeBanner() {
+    await this.page
+      .getByRole('dialog')
+      .filter({ hasText: 'Select an account' })
+      .locator('.mm-banner-base__close-button')
+      .click();
   }
 }

--- a/test/e2e/mmi/specs/visual.spec.ts
+++ b/test/e2e/mmi/specs/visual.spec.ts
@@ -51,6 +51,8 @@ test.describe('MMI visual', () => {
 
     const accountsPopup = new MMIAccountMenuPage(page);
 
+    await accountsPopup.accountsMenu();
+    await accountsPopup.closeBanner();
     await accountsPopup.accountMenuScreenshot('connect_custodian.png');
     await accountsPopup.connectCustodian(
       process.env.MMI_E2E_CUSTODIAN_NAME as string,
@@ -58,6 +60,7 @@ test.describe('MMI visual', () => {
     );
 
     // Check accounts added from Custodian
+    await accountsPopup.accountsMenu();
     await accountsPopup.accountMenuScreenshot('custody_accounts_selection.png');
 
     // Check remove custodian token screen (aborted before removed)


### PR DESCRIPTION
## **Description**

Update action in mmi acount menu page to fix E2E tests.

Currently, the presence of a banner makes it so that there are two buttons with the same role. The banner needs to be closed so that the correct one can be selected and screenshot tests work.

## **Related issues**

Fixes:

## **Manual testing steps**

It only affects E2E tests, so no manual testing needed.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

### **After**


## **Pre-merge author checklist**

- [X] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've clearly explained what problem this PR is solving and how it is solved.
- [X] I've linked related issues
- [X] I've included manual testing steps
- [X] I've included screenshots/recordings if applicable
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [X] I’ve properly set the pull request status:
  - [X] In case it's not yet "ready for review", I've set it to "draft".
  - [X] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
