### PR TITLE
fix(CI): Fix shallow checkout

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,11 +57,11 @@ aliases:
       git fetch --depth 1 origin "$CIRCLE_SHA1"
 
       if [ -n "${CIRCLE_TAG-}" ]; then
-        echo "Checkout out tag '${CIRCLE_TAG}' at commit '${CIRCLE_SHA1}'"
+        echo "Checkout tag '${CIRCLE_TAG}' at commit '${CIRCLE_SHA1}'"
         git checkout "$CIRCLE_TAG"
         git reset --hard "$CIRCLE_SHA1"
       else
-        echo "Checkout out branch '${CIRCLE_BRANCH}' at commit '${CIRCLE_SHA1}'"
+        echo "Checkout branch '${CIRCLE_BRANCH}' at commit '${CIRCLE_SHA1}'"
         git checkout -B "$CIRCLE_BRANCH" "$CIRCLE_SHA1"
       fi
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,7 +58,8 @@ aliases:
 
       if [ -n "${CIRCLE_TAG-}" ]; then
         echo "Checkout out tag '${CIRCLE_TAG}' at commit '${CIRCLE_SHA1}'"
-        git checkout "$CIRCLE_SHA1"
+        git checkout "$CIRCLE_TAG"
+        git reset --hard "$CIRCLE_SHA1"
       else
         echo "Checkout out branch '${CIRCLE_BRANCH}' at commit '${CIRCLE_SHA1}'"
         git checkout -B "$CIRCLE_BRANCH" "$CIRCLE_SHA1"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,33 +47,21 @@ aliases:
       set -u
       set -o pipefail
 
-      # This Shallow Git Clone code is adapted from what the standard CircleCI `checkout` command does for the case of an external PR (link to example below):
-      # https://app.circleci.com/pipelines/github/MetaMask/metamask-extension/49817/workflows/dc195ea6-ac06-4de1-9edf-4c949427b5fb/jobs/1430976/parallel-runs/0/steps/0-101
-      ### git clone --no-checkout "$CIRCLE_REPOSITORY_URL" .
-      ### git fetch --force origin +refs/pull/18748/head:refs/remotes/origin/pull/18748
-      ### git checkout --force -B "$CIRCLE_BRANCH" "$CIRCLE_SHA1"
-      ### git --no-pager log --no-color -n 1 --format='HEAD is now at %h %s'
-
       # Set up SSH access
       # This SSH key is the current github.com SSH key as of June 2023, but it will need to be changed whenever github changes their key (probably every few years)
       GITHUB_SSH_KEY="AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl"
       mkdir -p ~/.ssh
       echo github.com ssh-ed25519 $GITHUB_SSH_KEY >> ~/.ssh/known_hosts
 
-      # Take a different clone path depending on if it's a tag, a PR from an external repo, or the normal case
+      git clone --depth 1 --no-checkout "$CIRCLE_REPOSITORY_URL" .
+      git fetch --depth 1 origin "$CIRCLE_SHA1"
+
       if [ -n "${CIRCLE_TAG-}" ]; then
-        # tag
-        git clone --depth 1 --no-checkout "$CIRCLE_REPOSITORY_URL" .
-        git fetch --depth 1 --force origin "+refs/tags/${CIRCLE_TAG}:refs/tags/${CIRCLE_TAG}"
-        git checkout --force -q "$CIRCLE_TAG" "$CIRCLE_SHA1"
-      elif [[ "$CIRCLE_BRANCH" =~ ^pull\/* ]]; then
-        # pull request
-        git clone --depth 1 --no-checkout "$CIRCLE_REPOSITORY_URL" .
-        git fetch --depth 1 --force origin "${CIRCLE_BRANCH}/head:remotes/origin/${CIRCLE_BRANCH}"
-        git checkout --force -B "$CIRCLE_BRANCH" "$CIRCLE_SHA1"
+        echo "Checkout out tag '${CIRCLE_TAG}' at commit '${CIRCLE_SHA1}'"
+        git checkout "$CIRCLE_SHA1"
       else
-        # normal case
-        git clone --depth 1 "$CIRCLE_REPOSITORY_URL" --branch "$CIRCLE_BRANCH" .
+        echo "Checkout out branch '${CIRCLE_BRANCH}' at commit '${CIRCLE_SHA1}'"
+        git checkout -B "$CIRCLE_BRANCH" "$CIRCLE_SHA1"
       fi
 
 workflows:

--- a/test/e2e/helpers.js
+++ b/test/e2e/helpers.js
@@ -331,6 +331,7 @@ const completeImportSRPOnboardingFlow = async (
   // pin extension
   await driver.clickElement('[data-testid="pin-extension-next"]');
   await driver.clickElement('[data-testid="pin-extension-done"]');
+  throw new Error('Example error');
 };
 
 const completeImportSRPOnboardingFlowWordByWord = async (

--- a/test/e2e/helpers.js
+++ b/test/e2e/helpers.js
@@ -331,7 +331,6 @@ const completeImportSRPOnboardingFlow = async (
   // pin extension
   await driver.clickElement('[data-testid="pin-extension-next"]');
   await driver.clickElement('[data-testid="pin-extension-done"]');
-  throw new Error('Example error');
 };
 
 const completeImportSRPOnboardingFlowWordByWord = async (


### PR DESCRIPTION
## **Description**

The shallow checkout step in CI has been checking out the wrong commit in many workflows. It worked correctly for builds from forks, but builds from this repository would use the latest commit from the given branch, rather than the specific commit that the workflow was triggered for. And for tags, it was using the correct commit, but the checkout would fail if the commit wasn't what the tag currently pointed at.

The shallow checkout script has been updated to use a simpler set of commands which are the same for builds on this repository and on forks. The new checkout script will always checkout the current commit, represented by the `CIRCLE_SHA1` environment variable.

## **Related issues**

Fixes #22579

## **Manual testing steps**

See that the checkout step works correctly in the CI workflow for this PR, and that it has the expected console message.

The behavior for a fork can be seen here: https://github.com/MetaMask/metamask-extension/pull/22561

The behavior for a tag is not easily tested because we don't trigger CircleCI workflows from tags, but you can run the git commands locally to see that they work.

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained what problem this PR is solving and how it is solved.
- [x] I've linked related issues
- [x] I've included manual testing steps
- [x] I've included screenshots/recordings if applicable
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [x] I’ve properly set the pull request status:
  - [x] In case it's not yet "ready for review", I've set it to "draft".
  - [x] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
