### PR TITLE
fix: Clicking on the redirection link doesn't close the notification

### DIFF
--- a/ui/pages/confirmation/templates/__snapshots__/snap-account-redirect.test.js.snap
+++ b/ui/pages/confirmation/templates/__snapshots__/snap-account-redirect.test.js.snap
@@ -183,6 +183,7 @@ exports[`snap-account-redirect confirmation should match snapshot 1`] = `
                       <button
                         aria-label=""
                         class="mm-box mm-button-icon mm-button-icon--size-sm mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-primary-default mm-box--background-color-transparent mm-box--rounded-lg"
+                        data-testid="snap-account-redirect-url-icon"
                       >
                         <span
                           class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"

--- a/ui/pages/confirmation/templates/snap-account-redirect.js
+++ b/ui/pages/confirmation/templates/snap-account-redirect.js
@@ -18,6 +18,8 @@ function getValues(pendingApproval, t, actions, _history) {
     return {};
   };
 
+  const conditionalProps = getConditionalProps();
+
   return {
     content: [
       {
@@ -29,12 +31,13 @@ function getValues(pendingApproval, t, actions, _history) {
           snapId,
           snapName,
           isBlockedUrl,
+          ...conditionalProps,
         },
       },
     ],
     cancelText: t('close'),
     onCancel: () => actions.resolvePendingApproval(pendingApproval.id, false),
-    ...getConditionalProps(),
+    ...conditionalProps,
   };
 }
 

--- a/ui/pages/snap-account-redirect/__snapshots__/create-snap-redirect.test.tsx.snap
+++ b/ui/pages/snap-account-redirect/__snapshots__/create-snap-redirect.test.tsx.snap
@@ -19,7 +19,7 @@ exports[`<SnapAccountRedirect /> renders the url and message when provided and i
             class="mm-box mm-text mm-avatar-base mm-avatar-base--size-lg mm-text--body-lg-medium mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-alternative mm-box--background-color-background-alternative mm-box--rounded-full mm-box--border-color-border-default box--border-style-solid box--border-width-1"
             style="border-width: 0px;"
           >
-            ?
+            m
           </div>
           <div
             class="mm-box mm-badge-wrapper__badge-container mm-badge-wrapper__badge-container--circular-bottom-right"
@@ -41,16 +41,21 @@ exports[`<SnapAccountRedirect /> renders the url and message when provided and i
       >
         <p
           class="mm-box mm-text mm-text--body-md mm-text--font-weight-medium mm-text--ellipsis mm-box--color-text-default"
-        />
+        >
+          @metamask/snap-simple-keyring
+        </p>
         <p
           class="mm-box mm-text mm-text--body-sm mm-text--ellipsis mm-box--color-text-alternative"
-        />
+        >
+          @metamask/snap-simple-keyring
+        </p>
       </div>
       <div
         class="mm-box mm-box--margin-left-auto"
       >
-        <button
+        <a
           class="mm-box mm-text mm-button-base snap-version mm-button-link mm-button-link--size-auto mm-text--body-md-medium mm-box--padding-0 mm-box--padding-right-0 mm-box--padding-left-0 mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-primary-default mm-box--background-color-transparent"
+          href="https://www.npmjs.com/package/@metamask/snap-simple-keyring"
           target="_blank"
         >
           <span
@@ -104,7 +109,7 @@ exports[`<SnapAccountRedirect /> renders the url and message when provided and i
               />
             </div>
           </span>
-        </button>
+        </a>
       </div>
     </div>
     <div

--- a/ui/pages/snap-account-redirect/__snapshots__/create-snap-redirect.test.tsx.snap
+++ b/ui/pages/snap-account-redirect/__snapshots__/create-snap-redirect.test.tsx.snap
@@ -182,6 +182,7 @@ exports[`<SnapAccountRedirect /> renders the url and message when provided and i
                   <button
                     aria-label=""
                     class="mm-box mm-button-icon mm-button-icon--size-sm mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-primary-default mm-box--background-color-transparent mm-box--rounded-lg"
+                    data-testid="snap-account-redirect-url-icon"
                   >
                     <span
                       class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"

--- a/ui/pages/snap-account-redirect/components/redirect-url-icon.tsx
+++ b/ui/pages/snap-account-redirect/components/redirect-url-icon.tsx
@@ -14,6 +14,7 @@ interface RedirectUrlIconProps {
 const RedirectUrlIcon = ({ url, onSubmit }: RedirectUrlIconProps) => {
   return (
     <ButtonIcon
+      data-testid={'snap-account-redirect-url-icon'}
       onClick={() => {
         global.platform.openTab({ url });
         onSubmit?.();

--- a/ui/pages/snap-account-redirect/components/redirect-url-icon.tsx
+++ b/ui/pages/snap-account-redirect/components/redirect-url-icon.tsx
@@ -8,13 +8,15 @@ import { IconColor } from '../../../helpers/constants/design-system';
 
 interface RedirectUrlIconProps {
   url: string;
+  onSubmit?: () => void;
 }
 
-const RedirectUrlIcon = ({ url }: RedirectUrlIconProps) => {
+const RedirectUrlIcon = ({ url, onSubmit }: RedirectUrlIconProps) => {
   return (
     <ButtonIcon
       onClick={() => {
         global.platform.openTab({ url });
+        onSubmit?.();
       }}
       iconName={IconName.Export}
       color={IconColor.primaryDefault}

--- a/ui/pages/snap-account-redirect/components/snap-account-redirect-context.tsx
+++ b/ui/pages/snap-account-redirect/components/snap-account-redirect-context.tsx
@@ -25,6 +25,7 @@ const SnapAccountRedirectContent = ({
   snapName,
   isBlockedUrl,
   message,
+  onSubmit,
 }: SnapAccountRedirectProps) => {
   const t = useI18nContext();
   const learnMoreAboutBlockedUrls =
@@ -89,6 +90,7 @@ const SnapAccountRedirectContent = ({
             snapName={snapName}
             url={url}
             message={message}
+            onSubmit={onSubmit}
           />
         ) : null}
       </Box>

--- a/ui/pages/snap-account-redirect/components/snap-account-redirect-message.tsx
+++ b/ui/pages/snap-account-redirect/components/snap-account-redirect-message.tsx
@@ -9,7 +9,11 @@ const SnapAccountRedirectMessage = ({
   snapName,
   url,
   message,
-}: Pick<SnapAccountRedirectProps, 'snapName' | 'url' | 'message'>) => {
+  onSubmit,
+}: Pick<
+  SnapAccountRedirectProps,
+  'snapName' | 'url' | 'message' | 'onSubmit'
+>) => {
   /* eslint-disable no-negated-condition */
   return (
     <SnapDelineator
@@ -26,7 +30,7 @@ const SnapAccountRedirectMessage = ({
       ) : null}
       {url.length > 0 ? (
         <Box paddingTop={2} display={Display.Flex}>
-          <UrlDisplayBox url={url} />
+          <UrlDisplayBox url={url} onSubmit={onSubmit} />
         </Box>
       ) : null}
     </SnapDelineator>

--- a/ui/pages/snap-account-redirect/components/url-display-box.tsx
+++ b/ui/pages/snap-account-redirect/components/url-display-box.tsx
@@ -12,7 +12,10 @@ import {
 import { Box, Text } from '../../../components/component-library';
 import RedirectUrlIcon from './redirect-url-icon';
 
-const UrlDisplayBox = ({ url }: Pick<SnapAccountRedirectProps, 'url'>) => {
+const UrlDisplayBox = ({
+  url,
+  onSubmit,
+}: Pick<SnapAccountRedirectProps, 'url' | 'onSubmit'>) => {
   return (
     <Box
       display={Display.InlineFlex}
@@ -31,7 +34,7 @@ const UrlDisplayBox = ({ url }: Pick<SnapAccountRedirectProps, 'url'>) => {
       >
         {url}
       </Text>
-      <RedirectUrlIcon url={url} />
+      <RedirectUrlIcon url={url} onSubmit={onSubmit} />
     </Box>
   );
 };

--- a/ui/pages/snap-account-redirect/create-snap-redirect.test.tsx
+++ b/ui/pages/snap-account-redirect/create-snap-redirect.test.tsx
@@ -17,7 +17,7 @@ global.platform = {
 
 const mockUrl = 'https://metamask.github.io/snap-simple-keyring/1.0.0/';
 const mockSnapName = 'Snap Simple Keyring';
-const mockSnapId = '@metamask/snap-simple-keyring';
+const mockSnapId = 'npm:@metamask/snap-simple-keyring';
 const mockMessage = 'Redirecting to Snap Simple Keyring';
 
 describe('<SnapAccountRedirect />', () => {

--- a/ui/pages/snap-account-redirect/create-snap-redirect.test.tsx
+++ b/ui/pages/snap-account-redirect/create-snap-redirect.test.tsx
@@ -113,4 +113,24 @@ describe('<SnapAccountRedirect />', () => {
     );
     expect(queryByTestId('snap-account-redirect-message-container')).toBeNull();
   });
+  it('calls onSubmit prop when provided and the redirect button is clicked', () => {
+    const mockOnSubmit = jest.fn();
+    const { getByTestId } = renderWithProvider(
+      <SnapAccountRedirect
+        snapId={mockSnapId}
+        url={mockUrl}
+        snapName={mockSnapName}
+        isBlockedUrl={false}
+        message={mockMessage}
+        onSubmit={mockOnSubmit}
+      />,
+      store,
+    );
+
+    const redirectUrlIcon = getByTestId('snap-account-redirect-url-icon');
+    redirectUrlIcon.click();
+
+    expect(mockOnSubmit).toHaveBeenCalled();
+    expect(global.platform.openTab).toHaveBeenCalledWith({ url: mockUrl });
+  });
 });

--- a/ui/pages/snap-account-redirect/create-snap-redirect.test.tsx
+++ b/ui/pages/snap-account-redirect/create-snap-redirect.test.tsx
@@ -17,12 +17,14 @@ global.platform = {
 
 const mockUrl = 'https://metamask.github.io/snap-simple-keyring/1.0.0/';
 const mockSnapName = 'Snap Simple Keyring';
+const mockSnapId = '@metamask/snap-simple-keyring';
 const mockMessage = 'Redirecting to Snap Simple Keyring';
 
 describe('<SnapAccountRedirect />', () => {
   it('renders the url and message when provided and isBlockedUrl is false', () => {
     const { getByTestId, container } = renderWithProvider(
       <SnapAccountRedirect
+        snapId={mockSnapId}
         url={mockUrl}
         snapName={mockSnapName}
         isBlockedUrl={false}
@@ -44,6 +46,7 @@ describe('<SnapAccountRedirect />', () => {
   it('renders alert banner and does not render message or url when isBlockedUrl is true', () => {
     const { queryByTestId } = renderWithProvider(
       <SnapAccountRedirect
+        snapId={mockSnapId}
         url={mockUrl}
         snapName={mockSnapName}
         isBlockedUrl={true}
@@ -65,6 +68,7 @@ describe('<SnapAccountRedirect />', () => {
   it('does not render URL display box when URL is empty', () => {
     const { queryByTestId } = renderWithProvider(
       <SnapAccountRedirect
+        snapId={mockSnapId}
         url=""
         snapName={mockSnapName}
         isBlockedUrl={false}
@@ -81,6 +85,7 @@ describe('<SnapAccountRedirect />', () => {
   it('does not render message when message is empty', () => {
     const { queryByTestId } = renderWithProvider(
       <SnapAccountRedirect
+        snapId={mockSnapId}
         url={mockUrl}
         snapName={mockSnapName}
         isBlockedUrl={false}
@@ -98,6 +103,7 @@ describe('<SnapAccountRedirect />', () => {
   it('does not render message/url box when message and url are empty', () => {
     const { queryByTestId } = renderWithProvider(
       <SnapAccountRedirect
+        snapId={mockSnapId}
         url={''}
         snapName={''}
         isBlockedUrl={false}

--- a/ui/pages/snap-account-redirect/snap-account-redirect.tsx
+++ b/ui/pages/snap-account-redirect/snap-account-redirect.tsx
@@ -16,6 +16,7 @@ export interface SnapAccountRedirectProps {
   snapName: string;
   isBlockedUrl: boolean;
   message: string;
+  onSubmit?: () => void;
 }
 
 const SnapAccountRedirect = ({
@@ -24,6 +25,7 @@ const SnapAccountRedirect = ({
   snapName,
   isBlockedUrl,
   message,
+  onSubmit,
 }: SnapAccountRedirectProps) => {
   return (
     <Box
@@ -45,6 +47,7 @@ const SnapAccountRedirect = ({
       >
         <SnapAccountRedirectContent
           url={url}
+          onSubmit={onSubmit}
           snapId={snapId}
           snapName={snapName}
           isBlockedUrl={isBlockedUrl}


### PR DESCRIPTION
## **Description**

### What
Ensure that when the user click on the redirect URL, the metamask window is closed after they are redirected

### How
The `snap-account-redirect` template has access `resolvePendingApproval` callback which will close the specified approval. All I did was pass this callback down to the child component and call it when the user click on the `RedirectUrlIcon`

## **Related issues**

Fixes: https://github.com/MetaMask/accounts-planning/issues/158

## **Manual testing steps**

1. run this branch locally and build using `yarn start:flask`
2. open the new dist in your browser
3. import/create an account
4. open https://metamask.github.io/snap-simple-keyring/latest/
5. click create account and then approval the account creation
6. turn off `Use Synchronous Approval
` in the Snap Simple Keyring dapp

<img width="361" alt="Screenshot 2024-01-10 at 4 31 14 PM" src="https://github.com/MetaMask/metamask-extension/assets/22918444/ddbd99a4-8953-41bc-9c3a-47fffa649f03">

7. you should see a new snap account in your Metamask

<img width="336" alt="Screenshot 2024-01-10 at 4 29 18 PM" src="https://github.com/MetaMask/metamask-extension/assets/22918444/f70c7941-7990-4428-83cd-cdea40e937c6">

8. navigate to https://metamask.github.io/test-dapp/
9. connect the test dapp
10. scroll down and click on `personal sign`
11. accept the personal sign request
12. a second pop up should appear redirecting you to the Snap Simple Keyring Site
13. `Click on the icon beside the URL`

<img width="363" alt="Screenshot 2024-01-17 at 3 20 55 PM" src="https://github.com/MetaMask/metamask-extension/assets/22918444/33446f25-1cc4-4d16-adb4-4780aafd7d6f">


14. The notification window should close and open [this URL](https://metamask.github.io/snap-simple-keyring/latest/) in a new tab



## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

https://github.com/MetaMask/metamask-extension/assets/22918444/077c7076-6582-4136-a7f7-2d7a59da46ec

### **After**


https://github.com/MetaMask/metamask-extension/assets/22918444/7224f4fe-b1b4-4964-aed8-77e4fd773bbe


With a blocked URL, this field is not present. This fix worked with this case...

https://github.com/MetaMask/metamask-extension/assets/22918444/b151ade9-bc9b-4c42-983d-926beaa91158



## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained what problem this PR is solving and how it is solved.
- [x] I've linked related issues
- [x] I've included manual testing steps
- [x] I've included screenshots/recordings if applicable
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [x] I’ve properly set the pull request status:
  - [x] In case it's not yet "ready for review", I've set it to "draft".
  - [x] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
