### PR TITLE
ci: increase available memory for lavamoat policy validation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,13 +11,13 @@ executors:
       - image: cimg/node:18.18-browsers
     resource_class: medium+
     environment:
-      NODE_OPTIONS: --max_old_space_size=4096
+      NODE_OPTIONS: --max_old_space_size=5000
   node-browsers-large:
     docker:
       - image: cimg/node:18.18-browsers
     resource_class: large
     environment:
-      NODE_OPTIONS: --max_old_space_size=4096
+      NODE_OPTIONS: --max_old_space_size=6000
   shellcheck:
     docker:
       - image: koalaman/shellcheck-alpine@sha256:dfaf08fab58c158549d3be64fb101c626abc5f16f341b569092577ae207db199

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -432,7 +432,7 @@ jobs:
           command: .circleci/scripts/check-working-tree.sh
 
   validate-lavamoat-policy-webapp:
-    executor: node-browsers-medium-plus
+    executor: node-browsers-large
     parameters:
       build-type:
         type: string


### PR DESCRIPTION
## **Description**

This may be masking over a legitimate memory leak in dev/integration-tooling that should be addressed but may still help unblock PRs failing vaidation due to this (example: https://app.circleci.com/pipelines/github/MetaMask/metamask-extension/67296/workflows/6b17e7f1-81ce-4498-a7b0-cbae640a4c0e/jobs/2209921, https://app.circleci.com/pipelines/github/MetaMask/metamask-extension/67282/workflows/58fc8713-cd37-4b97-ae2c-52593b7e5ffd/jobs/2209156)

## **Related issues**

- #21006
- #22521
- https://github.com/LavaMoat/LavaMoat/pull/867

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've clearly explained what problem this PR is solving and how it is solved.
- [ ] I've linked related issues
- [ ] I've included manual testing steps
- [ ] I've included screenshots/recordings if applicable
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [ ] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
