### PR TITLE
Move native token value below Fiat within Token list

### DIFF
--- a/ui/components/app/asset-list/asset-list.js
+++ b/ui/components/app/asset-list/asset-list.js
@@ -49,6 +49,7 @@ import {
   showPrimaryCurrency,
   showSecondaryCurrency,
 } from '../../../../shared/modules/currency-display.utils';
+import { roundToDecimalPlacesRemovingExtraZeroes } from '../../../helpers/utils/util';
 
 const AssetList = ({ onClickAsset }) => {
   const [showDetectedTokens, setShowDetectedTokens] = useState(false);
@@ -105,7 +106,10 @@ const AssetList = ({ onClickAsset }) => {
 
   const { tokensWithBalances, totalFiatBalance, totalWeiBalance, loading } =
     useAccountTotalFiatBalance(selectedAddress, shouldHideZeroBalanceTokens);
-
+  const roundedTokensWithBalances = tokensWithBalances.forEach((token) => {
+    // token.string is the balance displayed in the TokenList UI
+    token.string = roundToDecimalPlacesRemovingExtraZeroes(token.string, 5);
+  });
   const balanceIsZero = Number(totalFiatBalance) === 0;
   const isBuyableChain = useSelector(getIsBuyableChain);
   const shouldShowBuy = isBuyableChain && balanceIsZero;
@@ -205,7 +209,7 @@ const AssetList = ({ onClickAsset }) => {
         isStakeable={isStakeable}
       />
       <TokenList
-        tokens={tokensWithBalances}
+        tokens={roundedTokensWithBalances}
         loading={loading}
         onTokenClick={(tokenAddress) => {
           onClickAsset(tokenAddress);

--- a/ui/components/app/asset-list/asset-list.js
+++ b/ui/components/app/asset-list/asset-list.js
@@ -106,7 +106,7 @@ const AssetList = ({ onClickAsset }) => {
 
   const { tokensWithBalances, totalFiatBalance, totalWeiBalance, loading } =
     useAccountTotalFiatBalance(selectedAddress, shouldHideZeroBalanceTokens);
-  const roundedTokensWithBalances = tokensWithBalances.forEach((token) => {
+  tokensWithBalances.forEach((token) => {
     // token.string is the balance displayed in the TokenList UI
     token.string = roundToDecimalPlacesRemovingExtraZeroes(token.string, 5);
   });
@@ -209,7 +209,7 @@ const AssetList = ({ onClickAsset }) => {
         isStakeable={isStakeable}
       />
       <TokenList
-        tokens={roundedTokensWithBalances}
+        tokens={tokensWithBalances}
         loading={loading}
         onTokenClick={(tokenAddress) => {
           onClickAsset(tokenAddress);

--- a/ui/components/app/token-cell/__snapshots__/token-cell.test.js.snap
+++ b/ui/components/app/token-cell/__snapshots__/token-cell.test.js.snap
@@ -43,7 +43,7 @@ exports[`Token Cell should match snapshot 1`] = `
         style="flex-grow: 1; overflow: hidden;"
       >
         <div
-          class="mm-box mm-box--display-flex mm-box--gap-1 mm-box--justify-content-space-between"
+          class="mm-box mm-box--display-flex mm-box--gap-1 mm-box--flex-direction-row mm-box--justify-content-space-between"
         >
           <div
             class="mm-box mm-box--display-inline-block mm-box--width-1/3"
@@ -61,15 +61,34 @@ exports[`Token Cell should match snapshot 1`] = `
             5.00
           </p>
         </div>
-        <p
-          class="mm-box mm-text mm-text--body-md mm-box--color-text-alternative"
-          data-testid="multichain-token-list-item-value"
+        <div
+          class="mm-box mm-box--display-flex mm-box--gap-1 mm-box--flex-direction-row mm-box--justify-content-space-between"
         >
-          5.000
-           
-          TEST
-           
-        </p>
+          <div
+            class="mm-box mm-box--width-1/3"
+          >
+            <p
+              class="mm-box mm-text mm-text--body-md mm-text--font-weight-medium mm-text--ellipsis mm-box--color-text-alternative"
+              data-testid="multichain-token-list-item-token-name"
+            >
+              TEST
+            </p>
+          </div>
+          <div
+            class="mm-box mm-box--width-2/3"
+            style="overflow: hidden;"
+          >
+            <p
+              class="mm-box mm-text mm-text--body-md mm-text--font-weight-medium mm-text--text-align-end mm-box--color-text-alternative"
+              data-testid="multichain-token-list-item-value"
+            >
+              5.000
+               
+              TEST
+               
+            </p>
+          </div>
+        </div>
       </div>
     </a>
   </div>

--- a/ui/components/app/token-cell/token-cell.test.js
+++ b/ui/components/app/token-cell/token-cell.test.js
@@ -109,14 +109,14 @@ describe('Token Cell', () => {
   });
 
   it('should render the correct token and filter by symbol and address', () => {
-    const { queryByText, getByAltText } = renderWithProvider(
+    const { getByTestId, getByAltText } = renderWithProvider(
       <TokenCell {...props} />,
       mockStore,
     );
 
     const image = getByAltText('TEST logo');
 
-    expect(queryByText('TEST')).toBeInTheDocument();
+    expect(getByTestId('multichain-token-list-item-value')).toBeInTheDocument();
     expect(image).toBeInTheDocument();
     expect(image).toHaveAttribute('src', './images/test_image.svg');
   });

--- a/ui/components/multichain/token-list-item/__snapshots__/token-list-item.test.js.snap
+++ b/ui/components/multichain/token-list-item/__snapshots__/token-list-item.test.js.snap
@@ -38,7 +38,7 @@ exports[`TokenListItem should render correctly 1`] = `
         style="flex-grow: 1; overflow: hidden;"
       >
         <div
-          class="mm-box mm-box--display-flex mm-box--gap-1 mm-box--justify-content-space-between"
+          class="mm-box mm-box--display-flex mm-box--gap-1 mm-box--flex-direction-row mm-box--justify-content-space-between"
         >
           <div
             class="mm-box mm-box--display-inline-block mm-box--width-1/3"
@@ -52,13 +52,30 @@ exports[`TokenListItem should render correctly 1`] = `
             data-testid="multichain-token-list-item-secondary-value"
           />
         </div>
-        <p
-          class="mm-box mm-text mm-text--body-md mm-box--color-text-alternative"
-          data-testid="multichain-token-list-item-value"
+        <div
+          class="mm-box mm-box--display-flex mm-box--gap-1 mm-box--flex-direction-row mm-box--justify-content-space-between"
         >
-           
-           
-        </p>
+          <div
+            class="mm-box mm-box--width-1/3"
+          >
+            <p
+              class="mm-box mm-text mm-text--body-md mm-text--font-weight-medium mm-text--ellipsis mm-box--color-text-alternative"
+              data-testid="multichain-token-list-item-token-name"
+            />
+          </div>
+          <div
+            class="mm-box mm-box--width-2/3"
+            style="overflow: hidden;"
+          >
+            <p
+              class="mm-box mm-text mm-text--body-md mm-text--font-weight-medium mm-text--text-align-end mm-box--color-text-alternative"
+              data-testid="multichain-token-list-item-value"
+            >
+               
+               
+            </p>
+          </div>
+        </div>
       </div>
     </a>
   </div>

--- a/ui/components/multichain/token-list-item/token-list-item.js
+++ b/ui/components/multichain/token-list-item/token-list-item.js
@@ -200,6 +200,7 @@ export const TokenListItem = ({
         >
           <Box
             display={Display.Flex}
+            flexDirection={FlexDirection.Row}
             justifyContent={JustifyContent.spaceBetween}
             gap={1}
           >
@@ -222,10 +223,10 @@ export const TokenListItem = ({
                   >
                     {isStakeable ? (
                       <>
-                        {tokenTitle} {stakeableTitle}
+                        {tokenSymbol} {stakeableTitle}
                       </>
                     ) : (
-                      tokenTitle
+                      tokenSymbol
                     )}
                   </Text>
                 </Tooltip>
@@ -238,10 +239,10 @@ export const TokenListItem = ({
                 >
                   {isStakeable ? (
                     <Box display={Display.InlineBlock}>
-                      {tokenTitle} {stakeableTitle}
+                      {tokenSymbol} {stakeableTitle}
                     </Box>
                   ) : (
-                    tokenTitle
+                    tokenSymbol
                   )}
                 </Text>
               )}
@@ -271,12 +272,37 @@ export const TokenListItem = ({
               </Text>
             )}
           </Box>
-          <Text
-            color={TextColor.textAlternative}
-            data-testid="multichain-token-list-item-value"
+          <Box
+            display={Display.Flex}
+            flexDirection={FlexDirection.Row}
+            justifyContent={JustifyContent.spaceBetween}
+            gap={1}
           >
-            {primary} {tokenSymbol}{' '}
-          </Text>
+            <Box width={BlockSize.OneThird}>
+              {/* bottom left */}
+              <Text
+                fontWeight={FontWeight.Medium}
+                variant={TextVariant.bodyMd}
+                color={TextColor.textAlternative}
+                data-testid="multichain-token-list-item-token-name" //
+                ellipsis
+              >
+                {tokenTitle}
+              </Text>
+            </Box>
+            <Box style={{ overflow: 'hidden' }} width={BlockSize.TwoThirds}>
+              {/* bottom right */}
+              <Text
+                data-testid="multichain-token-list-item-value"
+                color={TextColor.textAlternative}
+                fontWeight={FontWeight.Medium}
+                variant={TextVariant.bodyMd}
+                textAlign={TextAlign.End}
+              >
+                {primary} {tokenSymbol}{' '}
+              </Text>
+            </Box>
+          </Box>
         </Box>
       </Box>
       {showScamWarningModal ? (


### PR DESCRIPTION
## **Description**
We want to be more consistent in the way we show fiat values across different components, as well as aligning with mobile UX.
This PR shifts the token value to the right side of the cell, and replaces the old native token value with the full name of the token. 
We also round token balances to 5 decimal places to prevent overflow now.
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Related issues**

Fixes: #21132

## **Manual testing steps**

1. Go to extension Tokens Listing screen
2. Verify that cells have Token Symbol in top left, Token Name in bottom left
3. Verify that cells have Primary Currency in the top right, and Secondary currency in the bottom right 
4. Verify that native token balances are rounded to 5 decimal places

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->
<img width="342" alt="image" src="https://github.com/MetaMask/metamask-extension/assets/10986371/5ca960cf-1ed6-4482-8e16-fc1005a59749">

### **After**

<!-- [screenshots/recordings] -->
<img width="352" alt="image" src="https://github.com/MetaMask/metamask-extension/assets/10986371/a8d70e03-3a4f-4b46-9794-b5dc776e880d">

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained what problem this PR is solving and how it is solved.
- [x] I've linked related issues
- [x] I've included manual testing steps
- [x] I've included screenshots/recordings if applicable
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [x] I’ve properly set the pull request status:
  - [x] In case it's not yet "ready for review", I've set it to "draft".
  - [x] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
