### PR TITLE
Patch tar-stream to fix a race condition when installing snaps

### DIFF
--- a/.yarn/patches/tar-stream-npm-3.1.6-ce3ac17e49.patch
+++ b/.yarn/patches/tar-stream-npm-3.1.6-ce3ac17e49.patch
@@ -1,0 +1,22 @@
+diff --git a/headers.js b/headers.js
+index 56c3e9b26844d3e10a805cf850cdd09a172fa710..aa1a6c45d1623d9b94a5e065bd2872f0c4be4915 100644
+--- a/headers.js
++++ b/headers.js
+@@ -34,7 +34,7 @@ exports.decodePax = function decodePax (buf) {
+   while (buf.length) {
+     let i = 0
+     while (i < buf.length && buf[i] !== 32) i++
+-    const len = parseInt(buf.subarray(0, i).toString(), 10)
++    const len = parseInt(b4a.toString(buf.subarray(0, i)), 10)
+     if (!len) return result
+ 
+     const b = b4a.toString(buf.subarray(i + 1, len - 1))
+@@ -304,7 +304,7 @@ function decodeOct (val, offset, length) {
+     const end = clamp(indexOf(val, 32, offset, val.length), val.length, val.length)
+     while (offset < end && val[offset] === 0) offset++
+     if (end === offset) return 0
+-    return parseInt(val.subarray(offset, end).toString(), 8)
++    return parseInt(b4a.toString(val.subarray(offset, end)), 8)
+   }
+ }
+ 

--- a/package.json
+++ b/package.json
@@ -218,7 +218,8 @@
     "@metamask/eth-keyring-controller@npm:^13.0.1": "patch:@metamask/eth-keyring-controller@npm%3A13.0.1#~/.yarn/patches/@metamask-eth-keyring-controller-npm-13.0.1-06ff83faad.patch",
     "nonce-tracker@npm:^3.0.0": "patch:nonce-tracker@npm%3A3.0.0#~/.yarn/patches/nonce-tracker-npm-3.0.0-c5e9a93f9d.patch",
     "@trezor/connect-web": "9.0.11",
-    "lavamoat-core@npm:^15.1.1": "patch:lavamoat-core@npm%3A15.1.1#~/.yarn/patches/lavamoat-core-npm-15.1.1-51fbe39988.patch"
+    "lavamoat-core@npm:^15.1.1": "patch:lavamoat-core@npm%3A15.1.1#~/.yarn/patches/lavamoat-core-npm-15.1.1-51fbe39988.patch",
+    "tar-stream@npm:^3.1.6": "patch:tar-stream@npm%3A3.1.6#~/.yarn/patches/tar-stream-npm-3.1.6-ce3ac17e49.patch"
   },
   "dependencies": {
     "@babel/runtime": "^7.23.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -32862,6 +32862,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tar-stream@npm:3.1.6":
+  version: 3.1.6
+  resolution: "tar-stream@npm:3.1.6"
+  dependencies:
+    b4a: "npm:^1.6.4"
+    fast-fifo: "npm:^1.2.0"
+    streamx: "npm:^2.15.0"
+  checksum: 2c32e0d57de778ae415357bfb126a512a384e9bfb8e234920455ad65282181a3765515bbd80392ab8e7e630158376ec7de46b18ab86a33d256a7dcc43b0648b7
+  languageName: node
+  linkType: hard
+
 "tar-stream@npm:^2.1.4":
   version: 2.2.0
   resolution: "tar-stream@npm:2.2.0"
@@ -32875,14 +32886,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tar-stream@npm:^3.1.6":
+"tar-stream@patch:tar-stream@npm%3A3.1.6#~/.yarn/patches/tar-stream-npm-3.1.6-ce3ac17e49.patch":
   version: 3.1.6
-  resolution: "tar-stream@npm:3.1.6"
+  resolution: "tar-stream@patch:tar-stream@npm%3A3.1.6#~/.yarn/patches/tar-stream-npm-3.1.6-ce3ac17e49.patch::version=3.1.6&hash=f45d58"
   dependencies:
     b4a: "npm:^1.6.4"
     fast-fifo: "npm:^1.2.0"
     streamx: "npm:^2.15.0"
-  checksum: 2c32e0d57de778ae415357bfb126a512a384e9bfb8e234920455ad65282181a3765515bbd80392ab8e7e630158376ec7de46b18ab86a33d256a7dcc43b0648b7
+  checksum: 517d101950f47c96c581f2bf4886dcb48ee55a1dc47dd8aec6d3512450d6470fc9fbe0704e22379a289caee5034ea3e8586596b2c15cd5ee135588481ac415b1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## **Description**

`tar-stream` has a bug where it randomly fails to decode tar headers due to mixing of `Uint8Array` and polyfilled `Buffer`. I have upstreamed a fix for this, but while we wait for it to be released, this patch should fix the issue!

Context on the bug: https://github.com/mafintosh/tar-stream/pull/164