### PR TITLE
lavamoat-core patch: add regex cache

### DIFF
--- a/.yarn/patches/lavamoat-core-npm-15.1.1-51fbe39988.patch
+++ b/.yarn/patches/lavamoat-core-npm-15.1.1-51fbe39988.patch
@@ -1,3 +1,33 @@
+diff --git a/src/kernelCoreTemplate.js b/src/kernelCoreTemplate.js
+index 752a9c0f0179c1249bd4c3fdb62c216543f01ce2..39fccc6a004218ce7233cbf95db4ffe24907b856 100644
+--- a/src/kernelCoreTemplate.js
++++ b/src/kernelCoreTemplate.js
+@@ -70,6 +70,8 @@
+     const { prepareCompartmentGlobalFromConfig } = templateRequire('makePrepareRealmGlobalFromConfig')({ createFunctionWrapper })
+     const { strictScopeTerminator } = templateRequire('strict-scope-terminator')
+ 
++    // cache regular expressions to work around https://github.com/MetaMask/metamask-extension/issues/21006
++    const regexCache = new Map()
+     const scuttleOpts = generateScuttleOpts(scuttleGlobalThis)
+     const moduleCache = new Map()
+     const packageCompartmentCache = new Map()
+@@ -126,10 +128,15 @@
+         if (!except.startsWith('/')) {
+           return except
+         }
++        if (regexCache.has(except)) {
++          return regexCache.get(except)
++        }
+         const parts = except.split('/')
+         const pattern = parts.slice(1, -1).join('/')
+         const flags = parts[parts.length - 1]
+-        return new RegExp(pattern, flags)
++        const re = new RegExp(pattern, flags)
++        regexCache.set(except, re)
++        return re
+       }
+     }
+ 
 diff --git a/src/loadPolicy.js b/src/loadPolicy.js
 index f0ca3c4991a64f316f4e7199867439dd9ab09354..11296dd253b8dc1afd4cc870a0207c280fb728d9 100644
 --- a/src/loadPolicy.js

--- a/yarn.lock
+++ b/yarn.lock
@@ -23396,13 +23396,13 @@ __metadata:
 
 "lavamoat-core@patch:lavamoat-core@npm%3A15.1.1#~/.yarn/patches/lavamoat-core-npm-15.1.1-51fbe39988.patch":
   version: 15.1.1
-  resolution: "lavamoat-core@patch:lavamoat-core@npm%3A15.1.1#~/.yarn/patches/lavamoat-core-npm-15.1.1-51fbe39988.patch::version=15.1.1&hash=bfc3f7"
+  resolution: "lavamoat-core@patch:lavamoat-core@npm%3A15.1.1#~/.yarn/patches/lavamoat-core-npm-15.1.1-51fbe39988.patch::version=15.1.1&hash=95165a"
   dependencies:
     json-stable-stringify: "npm:1.0.2"
     lavamoat-tofu: "npm:^7.1.0"
     merge-deep: "npm:3.0.3"
     type-fest: "npm:4.7.1"
-  checksum: 9178bb1cd8e4f9944de1f0d2f3910b21f2dd9428ca335e6a08a048917b852d9ebc4e6593d66a7f9076441aad1fc1d997a45afcfc24535eccac59968aa3781f3e
+  checksum: e408e3fd65987e0083a4649da3b158ace2eb55379add58a2a0c9a2d1b9b5aee86d03dd44dc616796a5c1c07f303c0691db7c41877b2c3cc4ce86d80af229844b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## **Description**

Patch lavamoat-core to utilize regex cache

## **Related issues**

- Targeting: #22521 
- Lifted from: https://github.com/LavaMoat/LavaMoat/pull/876
  - https://github.com/LavaMoat/LavaMoat/pull/909

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've clearly explained what problem this PR is solving and how it is solved.
- [ ] I've linked related issues
- [ ] I've included manual testing steps
- [ ] I've included screenshots/recordings if applicable
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [ ] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
