### PR TITLE
e2e: repeat prep-build commands 3 times and log errors as artifacts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,6 @@ orbs:
   codecov: codecov/codecov@3.2.2
   slack: circleci/slack@4.12.5
 
-
 rc_branch_only: &rc_branch_only
   filters:
     branches:
@@ -64,6 +63,23 @@ aliases:
         echo "Checkout branch '${CIRCLE_BRANCH}' at commit '${CIRCLE_SHA1}'"
         git checkout -B "$CIRCLE_BRANCH" "$CIRCLE_SHA1"
       fi
+
+commands:
+  repeat3:
+    description: 'Repeat this command 3 times, until it succeeds'
+    parameters:
+      command:
+        type: string
+    steps:
+      - run:
+          name: repeat3 << parameters.command >>
+          command: |
+            (mkdir -p repeat3 && << parameters.command >>) ||
+            (echo 'fail1' > repeat3/fail1.txt && << parameters.command >>) ||
+            (echo 'fail2' > repeat3/fail2.txt && << parameters.command >>) ||
+            echo 'fail3' > repeat3/fail3.txt
+      - store_artifacts:
+          path: repeat3
 
 workflows:
   test_and_release:
@@ -424,8 +440,7 @@ jobs:
       - run: *shallow-git-clone
       - attach_workspace:
           at: .
-      - run:
-          name: Validate LavaMoat build policy
+      - repeat3:
           command: yarn lavamoat:build:auto
       - run:
           name: Check working tree
@@ -440,8 +455,7 @@ jobs:
       - run: *shallow-git-clone
       - attach_workspace:
           at: .
-      - run:
-          name: Validate LavaMoat << parameters.build-type >>  policy
+      - repeat3:
           command: yarn lavamoat:webapp:auto:ci '--build-types=<< parameters.build-type >>'
       - run:
           name: Check working tree
@@ -460,8 +474,7 @@ jobs:
                 pattern: /^master$/
                 value: << pipeline.git.branch >>
           steps:
-            - run:
-                name: build:dist
+            - repeat3:
                 command: yarn build dist
       - when:
           condition:
@@ -469,8 +482,7 @@ jobs:
               pattern: /^master$/
               value: << pipeline.git.branch >>
           steps:
-            - run:
-                name: build:prod
+            - repeat3:
                 command: yarn build prod
       - run:
           name: build:debug
@@ -487,8 +499,7 @@ jobs:
       - run: *shallow-git-clone
       - attach_workspace:
           at: .
-      - run:
-          name: build:dist
+      - repeat3:
           command: yarn build --build-type desktop dist
       - run:
           name: build:debug
@@ -518,8 +529,7 @@ jobs:
                 pattern: /^master$/
                 value: << pipeline.git.branch >>
           steps:
-            - run:
-                name: build:dist
+            - repeat3:
                 command: yarn build --build-type mmi dist
       - when:
           condition:
@@ -527,8 +537,7 @@ jobs:
               pattern: /^master$/
               value: << pipeline.git.branch >>
           steps:
-            - run:
-                name: build:prod
+            - repeat3:
                 command: yarn build --build-type mmi prod
       - run:
           name: build:debug
@@ -561,8 +570,7 @@ jobs:
                 pattern: /^master$/
                 value: << pipeline.git.branch >>
           steps:
-            - run:
-                name: build:dist
+            - repeat3:
                 command: yarn build --build-type flask dist
       - when:
           condition:
@@ -570,8 +578,7 @@ jobs:
               pattern: /^master$/
               value: << pipeline.git.branch >>
           steps:
-            - run:
-                name: build:prod
+            - repeat3:
                 command: yarn build --build-type flask prod
       - run:
           name: build:debug
@@ -594,8 +601,7 @@ jobs:
       - run: *shallow-git-clone
       - attach_workspace:
           at: .
-      - run:
-          name: Build extension for testing
+      - repeat3:
           command: yarn build:test:flask
       - run:
           name: Move test build to 'dist-test-flask' to avoid conflict with production build
@@ -615,8 +621,7 @@ jobs:
       - run: *shallow-git-clone
       - attach_workspace:
           at: .
-      - run:
-          name: Build extension for testing
+      - repeat3:
           command: yarn build:test:mmi
       - run:
           name: Move test build to 'dist-test' to avoid conflict with production build
@@ -662,8 +667,7 @@ jobs:
       - run: *shallow-git-clone
       - attach_workspace:
           at: .
-      - run:
-          name: Build extension in mv3 for testing
+      - repeat3:
           command: yarn build:test:mv3
       - run:
           name: Move test build to 'dist-test' to avoid conflict with production build
@@ -683,8 +687,7 @@ jobs:
       - run: *shallow-git-clone
       - attach_workspace:
           at: .
-      - run:
-          name: Build extension for testing
+      - repeat3:
           command: yarn build:test
       - run:
           name: Move test build to 'dist-test' to avoid conflict with production build
@@ -700,13 +703,14 @@ jobs:
 
   prep-build-multichain-test:
     executor: node-browsers-medium-plus
+    environment:
+      MULTICHAIN: 1
     steps:
       - run: *shallow-git-clone
       - attach_workspace:
           at: .
-      - run:
-          name: Build extension for testing
-          command: MULTICHAIN=1 yarn build:test
+      - repeat3:
+          command: yarn build:test
       - run:
           name: Move test build to 'dist-test' to avoid conflict with production build
           command: mv ./dist ./dist-test-multichain


### PR DESCRIPTION
## **Description**

If a `prep-build` step hits a `process out of memory` error, it will `echo 'fail1' > repeat3/fail1.txt` and try again.

It will try two more times, creating `fail2.txt` and `fail3.txt`, then upload those files to `store_artifacts`.

Later, when we write code to automatically collect metrics, it can query the CircleCI API to look for these files.

There's an alternative approach I considered, that writes about failures to an XML file and uploads that to `store_test_results`, but I think it might get confusing to see build steps and test steps together in the Insights report.  The Insights page does log build step success rate though https://app.circleci.com/insights/github/MetaMask/metamask-extension/workflows/test_and_release/jobs?branch=develop

## **Related issues**

Progresses: #21006

## **Manual testing steps**
## **Screenshots/Recordings**
## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained what problem this PR is solving and how it is solved.
- [x] I've linked related issues
- [ ] I've included manual testing steps
- [ ] I've included screenshots/recordings if applicable
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [x] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [x] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
