### PR TITLE
fix: Fix phishing warning page unresponsiveness

### DIFF
--- a/package.json
+++ b/package.json
@@ -405,7 +405,7 @@
     "@metamask/eslint-config-nodejs": "^9.0.0",
     "@metamask/eslint-config-typescript": "^9.0.1",
     "@metamask/forwarder": "^1.1.0",
-    "@metamask/phishing-warning": "^3.0.0",
+    "@metamask/phishing-warning": "^3.0.3",
     "@metamask/test-dapp": "^7.3.1",
     "@playwright/test": "^1.39.0",
     "@sentry/cli": "^2.19.4",

--- a/test/e2e/tests/phishing-controller/phishing-detection.spec.js
+++ b/test/e2e/tests/phishing-controller/phishing-detection.spec.js
@@ -174,7 +174,7 @@ describe('Phishing Detection', function () {
         });
         assert.equal(
           await driver.getCurrentUrl(),
-          `https://github.com/MetaMask/eth-phishing-detect/issues/new?title=[Legitimate%20Site%20Blocked]%20127.0.0.1&body=http%3A%2F%2F127.0.0.1%3A8080%2F`,
+          `https://github.com/MetaMask/eth-phishing-detect/issues/new?title=[Legitimate%20Site%20Blocked]%20127.0.0.1&body=http%3A%2F%2F127.0.0.1%2F`,
         );
       },
     );
@@ -213,7 +213,7 @@ describe('Phishing Detection', function () {
           await driver.getCurrentUrl(),
           `https://github.com/MetaMask/eth-phishing-detect/issues/new?title=[Legitimate%20Site%20Blocked]%20${encodeURIComponent(
             phishingSite.hostname,
-          )}&body=${encodeURIComponent(phishingSite.href)}`,
+          )}&body=${encodeURIComponent(new URL(phishingSite.href).hostname)}`,
         );
       },
     );

--- a/test/e2e/tests/phishing-controller/phishing-detection.spec.js
+++ b/test/e2e/tests/phishing-controller/phishing-detection.spec.js
@@ -213,7 +213,7 @@ describe('Phishing Detection', function () {
           await driver.getCurrentUrl(),
           `https://github.com/MetaMask/eth-phishing-detect/issues/new?title=[Legitimate%20Site%20Blocked]%20${encodeURIComponent(
             phishingSite.hostname,
-          )}&body=${encodeURIComponent(new URL(phishingSite.href).hostname)}`,
+          )}&body=${encodeURIComponent(`${phishingSite.origin}/`)}`,
         );
       },
     );
@@ -247,7 +247,7 @@ describe('Phishing Detection', function () {
         });
         assert.equal(
           await driver.getCurrentUrl(),
-          `https://github.com/phishfort/phishfort-lists/issues/new?title=[Legitimate%20Site%20Blocked]%20127.0.0.1&body=http%3A%2F%2F127.0.0.1%3A8080%2F`,
+          `https://github.com/phishfort/phishfort-lists/issues/new?title=[Legitimate%20Site%20Blocked]%20127.0.0.1&body=http%3A%2F%2F127.0.0.1%2F`,
         );
       },
     );

--- a/yarn.lock
+++ b/yarn.lock
@@ -4704,19 +4704,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/phishing-warning@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "@metamask/phishing-warning@npm:3.0.0"
+"@metamask/phishing-warning@npm:^3.0.3":
+  version: 3.0.3
+  resolution: "@metamask/phishing-warning@npm:3.0.3"
   dependencies:
     "@metamask/design-tokens": "npm:^1.12.0"
     "@metamask/object-multiplex": "npm:^2.0.0"
     "@metamask/post-message-stream": "npm:^7.0.0"
     eth-phishing-detect: "npm:^1.2.0"
     globalthis: "npm:1.0.1"
-    punycode: "npm:^2.3.0"
+    punycode: "npm:^2.3.1"
     readable-stream: "npm:^3.6.2"
-    ses: "npm:^0.18.8"
-  checksum: 86aeb3c46fb1f47d59017d8de60545d11cf16d3784c9cb3adcfe4b9c8f775c06889ced2ed816c75a87581bbe5919db11b2f3176b095f46b62d3bb31560ecd008
+    ses: "npm:^1.1.0"
+  checksum: 12702062f0fb84b029d330d1f05a7d6cd6bdc28e7bc0f3507267944a93e5274d1c92920fb2d96dbce7997d949af14a1ca0726ee6485527ec9663577c1393bda2
   languageName: node
   linkType: hard
 
@@ -24773,7 +24773,7 @@ __metadata:
     "@metamask/obs-store": "npm:^8.1.0"
     "@metamask/permission-controller": "npm:^7.1.0"
     "@metamask/phishing-controller": "npm:^8.0.0"
-    "@metamask/phishing-warning": "npm:^3.0.0"
+    "@metamask/phishing-warning": "npm:^3.0.3"
     "@metamask/polling-controller": "npm:^4.0.0"
     "@metamask/post-message-stream": "npm:^7.0.0"
     "@metamask/ppom-validator": "npm:^0.10.0"
@@ -28786,7 +28786,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"punycode@npm:^2.1.0, punycode@npm:^2.1.1, punycode@npm:^2.3.0":
+"punycode@npm:^2.1.0, punycode@npm:^2.1.1, punycode@npm:^2.3.1":
   version: 2.3.1
   resolution: "punycode@npm:2.3.1"
   checksum: febdc4362bead22f9e2608ff0171713230b57aff9dddc1c273aa2a651fbd366f94b7d6a71d78342a7c0819906750351ca7f2edd26ea41b626d87d6a13d1bd059


### PR DESCRIPTION
## **Description**

The phishing warning page was unresponsive on Chrome v122. This update resolves the issue.

See changelog for details: https://github.com/MetaMask/phishing-warning/blob/main/CHANGELOG.md#303

## **Related issues**

Related to the issue described in #22533

## **Manual testing steps**

1. Navigate to a blocked site
2. See that the phishing warning page shows up
3. Ensure that the three buttons/links work correctly ("report a detection problem", "continue to the site", and "Back to safety")

Testing on Chrome Canary (v122) is recommended, that's the only browser we've confirmed as not working previous to this PR.

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained what problem this PR is solving and how it is solved.
- [x] I've linked related issues
- [x] I've included manual testing steps
- [x] I've included screenshots/recordings if applicable
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [x] I’ve properly set the pull request status:
  - [x] In case it's not yet "ready for review", I've set it to "draft".
  - [x] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
