### PR TITLE
fix: Blockaid What's New os theme -> dark mode

### DIFF
--- a/ui/hooks/useTheme.ts
+++ b/ui/hooks/useTheme.ts
@@ -18,8 +18,9 @@ const validThemes = Object.values(ThemeType).filter((theme) => {
  */
 export function useTheme() {
   const settingTheme = useSelector(getTheme);
+  const [theme, setTheme] = useState(settingTheme);
 
-  const [theme, setTheme] = useState(() => {
+  useEffect(() => {
     const result =
       !settingTheme || settingTheme === ThemeType.os
         ? document.documentElement.getAttribute('data-theme')
@@ -30,16 +31,10 @@ export function useTheme() {
       console.warn(
         `useTheme: Invalid theme resolved to "${result}". Defaulting to "${ThemeType.light}".`,
       );
-      return ThemeType.light;
+      setTheme(ThemeType.light);
     }
 
-    return result;
-  });
-
-  useEffect(() => {
-    if (settingTheme) {
-      setTheme(settingTheme);
-    }
+    setTheme(result);
   }, [settingTheme]);
 
   return theme;


### PR DESCRIPTION
## **Description**

Fix Blockaid What's New image when user setting is OS and their OS setting is dark mode 

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/22646
Related to: https://github.com/MetaMask/metamask-extension/pull/22613

## **Manual testing steps**

1. Have a new instance of the wallet to populate the What's New modal
2. Test the UI with different settings and when OS is light and dark mode


## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've clearly explained what problem this PR is solving and how it is solved.
- [ ] I've linked related issues
- [ ] I've included manual testing steps
- [ ] I've included screenshots/recordings if applicable
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [ ] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
