### PR TITLE
test: adds blockaid multiple network support test

### DIFF
--- a/test/e2e/mock-e2e.js
+++ b/test/e2e/mock-e2e.js
@@ -102,6 +102,9 @@ async function setupMocking(server, testSpecificMock, { chainId }) {
     .forPost(
       'https://arbitrum-mainnet.infura.io/v3/00000000000000000000000000000000',
     )
+    .withJsonBodyIncluding({
+      method: 'eth_chainId',
+    })
     .thenCallback(() => {
       return {
         statusCode: 200,

--- a/test/e2e/tests/ppom-blockaid-alert-networks-support.spec.js
+++ b/test/e2e/tests/ppom-blockaid-alert-networks-support.spec.js
@@ -92,11 +92,11 @@ describe('PPOM Blockaid Alert - Multiple Networks Support @no-mmi', function () 
 
         assert(
           bannerAlertFoundByTitle,
-          `Banner alert not found. Expected Title: ${expectedTitle} \nExpected reason: transfer_farming\n`,
+          `Banner alert not found. Expected Title: ${expectedTitle} \nExpected reason: approval_farming\n`,
         );
         assert(
           bannerAlertText.includes(expectedDescriptionMainnet),
-          `Unexpected banner alert description. Expected: ${expectedDescriptionMainnet} \nExpected reason: transfer_farming\n`,
+          `Unexpected banner alert description. Expected: ${expectedDescriptionMainnet} \nExpected reason: approval_farming\n`,
         );
 
         await driver.clickElement({ text: 'Reject', tag: 'button' });
@@ -139,11 +139,11 @@ describe('PPOM Blockaid Alert - Multiple Networks Support @no-mmi', function () 
 
         assert(
           bannerAlertFoundByTitle,
-          `Banner alert not found. Expected Title: ${expectedTitle} \nExpected reason: transfer_farming\n`,
+          `Banner alert not found. Expected Title: ${expectedTitle} \nExpected reason: raw_native_token_transfer\n`,
         );
         assert(
           bannerAlertText.includes(expectedDescriptionArbitrum),
-          `Unexpected banner alert description. Expected: ${expectedDescriptionArbitrum} \nExpected reason: transfer_farming\n`,
+          `Unexpected banner alert description. Expected: ${expectedDescriptionArbitrum} \nExpected reason: raw_native_token_transfer\n`,
         );
       },
     );

--- a/test/e2e/tests/ppom-blockaid-alert-networks-support.spec.js
+++ b/test/e2e/tests/ppom-blockaid-alert-networks-support.spec.js
@@ -1,0 +1,151 @@
+const { strict: assert } = require('assert');
+const FixtureBuilder = require('../fixture-builder');
+const { mockServerJsonRpc } = require('../mock-server-json-rpc');
+const {
+  WINDOW_TITLES,
+  defaultGanacheOptions,
+  openDapp,
+  unlockWallet,
+  withFixtures,
+} = require('../helpers');
+
+async function mockInfura(mockServer) {
+  await mockServerJsonRpc(mockServer, [
+    ['eth_blockNumber'],
+    ['eth_call'],
+    ['eth_estimateGas'],
+    ['eth_feeHistory'],
+    ['eth_gasPrice'],
+    ['eth_getBalance'],
+    ['eth_getBlockByNumber'],
+    ['eth_getCode'],
+    ['eth_getTransactionCount'],
+  ]);
+}
+
+async function mockInfuraWithMaliciousResponses(mockServer) {
+  await mockInfura(mockServer);
+  await mockServer
+    .forPost()
+    .withJsonBodyIncluding({
+      method: 'debug_traceCall',
+      params: [{ accessList: [], data: '0x00000000' }],
+    })
+    .thenCallback(async (req) => {
+      return {
+        statusCode: 200,
+        json: {
+          jsonrpc: '2.0',
+          id: (await req.body.getJson()).id,
+          error: {
+            message:
+              'The method debug_traceCall does not exist/is not available',
+          },
+        },
+      };
+    });
+}
+
+describe('PPOM Blockaid Alert - Multiple Networks Support @no-mmi', function () {
+  it('should show banner alert after switchinig to another supported network', async function () {
+    await withFixtures(
+      {
+        dapp: true,
+        fixtures: new FixtureBuilder()
+          .withNetworkControllerOnMainnet()
+          .withPermissionControllerConnectedToTestDapp()
+          .withPreferencesController({
+            securityAlertsEnabled: true,
+          })
+          .build(),
+        defaultGanacheOptions,
+        testSpecificMock: mockInfuraWithMaliciousResponses,
+        title: this.test.fullTitle(),
+      },
+
+      async ({ driver }) => {
+        const expectedTitle = 'This is a deceptive request';
+        const expectedDescriptionMainnet =
+          'If you approve this request, you might lose your assets.';
+
+        const expectedDescriptionArbitrum =
+          'If you approve this request, a third party known for scams will take all your assets.';
+
+        await unlockWallet(driver);
+        await openDapp(driver);
+
+        // Click TestDapp button to send JSON-RPC request
+        await driver.clickElement('#maliciousTradeOrder');
+
+        // Wait for confirmation pop-up
+        await driver.waitUntilXWindowHandles(3);
+        await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
+
+        const bannerAlertSelector =
+          '[data-testid="security-provider-banner-alert"]';
+
+        let bannerAlertFoundByTitle = await driver.findElement({
+          css: bannerAlertSelector,
+          text: expectedTitle,
+        });
+        let bannerAlertText = await bannerAlertFoundByTitle.getText();
+
+        assert(
+          bannerAlertFoundByTitle,
+          `Banner alert not found. Expected Title: ${expectedTitle} \nExpected reason: transfer_farming\n`,
+        );
+        assert(
+          bannerAlertText.includes(expectedDescriptionMainnet),
+          `Unexpected banner alert description. Expected: ${expectedDescriptionMainnet} \nExpected reason: transfer_farming\n`,
+        );
+
+        await driver.clickElement({ text: 'Reject', tag: 'button' });
+        await driver.waitUntilXWindowHandles(2);
+        await driver.switchToWindowWithTitle(
+          WINDOW_TITLES.ExtensionInFullScreenView,
+        );
+
+        // switch network to arbitrum
+        await driver.clickElement('[data-testid="network-display"]');
+
+        await driver.clickElement({ tag: 'button', text: 'Add network' });
+        await driver.clickElement({
+          tag: 'button',
+          text: 'Add',
+        });
+
+        await driver.clickElement({ tag: 'a', text: 'View all details' });
+
+        await driver.clickElement({ tag: 'button', text: 'Close' });
+        await driver.clickElement({ tag: 'button', text: 'Approve' });
+        await driver.clickElement({
+          tag: 'h6',
+          text: 'Switch to Arbitrum One',
+        });
+
+        await driver.switchToWindowWithTitle(WINDOW_TITLES.TestDApp);
+        // Click TestDapp button to send JSON-RPC request
+        await driver.clickElement('#maliciousRawEthButton');
+
+        // Wait for confirmation pop-up
+        await driver.waitUntilXWindowHandles(3);
+        await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
+
+        bannerAlertFoundByTitle = await driver.findElement({
+          css: bannerAlertSelector,
+          text: expectedTitle,
+        });
+        bannerAlertText = await bannerAlertFoundByTitle.getText();
+
+        assert(
+          bannerAlertFoundByTitle,
+          `Banner alert not found. Expected Title: ${expectedTitle} \nExpected reason: transfer_farming\n`,
+        );
+        assert(
+          bannerAlertText.includes(expectedDescriptionArbitrum),
+          `Unexpected banner alert description. Expected: ${expectedDescriptionArbitrum} \nExpected reason: transfer_farming\n`,
+        );
+      },
+    );
+  });
+});


### PR DESCRIPTION
## **Description**

This PR adds an e2e spec for testing Blockaid support to multiple networks. This verifies that:
- We initially display the malicious warning for Mainnet
- We switch to another supported network and we continue to display the malicious warning (in this case Arbitrum)


## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/993

## **Manual testing steps**

1. Check circle ci job
2. Alternatively, run the test locally `yarn test:e2e:single test/e2e/tests/ppom-blockaid-alert-networks-support.spec.js --browser=chrome`

## **Screenshots/Recordings**

![Screenshot from 2024-01-29 11-43-34](https://github.com/MetaMask/metamask-extension/assets/54408225/589c302c-4be4-44f0-b5d0-df57ac814951)


## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained what problem this PR is solving and how it is solved.
- [x] I've linked related issues
- [x] I've included manual testing steps
- [x] I've included screenshots/recordings if applicable
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [x] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
