### PR TITLE
Fix `send max` issue

### DIFF
--- a/ui/ducks/confirm-transaction/confirm-transaction.duck.js
+++ b/ui/ducks/confirm-transaction/confirm-transaction.duck.js
@@ -56,7 +56,6 @@ const initState = {
 
 // Reducer
 export default function reducer(state = initState, action = {}) {
-  // console.log({ state });
   switch (action.type) {
     case UPDATE_TX_DATA:
       return {

--- a/ui/ducks/confirm-transaction/confirm-transaction.duck.js
+++ b/ui/ducks/confirm-transaction/confirm-transaction.duck.js
@@ -34,6 +34,7 @@ const UPDATE_TRANSACTION_AMOUNTS = createActionType(
 const UPDATE_TRANSACTION_FEES = createActionType('UPDATE_TRANSACTION_FEES');
 const UPDATE_TRANSACTION_TOTALS = createActionType('UPDATE_TRANSACTION_TOTALS');
 const UPDATE_NONCE = createActionType('UPDATE_NONCE');
+const SET_MAX_VALUE_MODE = createActionType('SET_MAX_VALUE_MODE');
 
 // Initial state
 const initState = {
@@ -50,10 +51,12 @@ const initState = {
   hexTransactionFee: '',
   hexTransactionTotal: '',
   nonce: '',
+  maxValueMode: {},
 };
 
 // Reducer
 export default function reducer(state = initState, action = {}) {
+  // console.log({ state });
   switch (action.type) {
     case UPDATE_TX_DATA:
       return {
@@ -119,7 +122,18 @@ export default function reducer(state = initState, action = {}) {
         nonce: action.payload,
       };
     case CLEAR_CONFIRM_TRANSACTION:
-      return initState;
+      return {
+        ...initState,
+        maxValueMode: state.maxValueMode,
+      };
+    case SET_MAX_VALUE_MODE:
+      return {
+        ...state,
+        maxValueMode: {
+          ...state.maxValueMode,
+          [action.payload.transactionId]: action.payload.enabled,
+        },
+      };
     default:
       return state;
   }
@@ -306,5 +320,15 @@ export function setTransactionToConfirm(transactionId) {
 export function clearConfirmTransaction() {
   return {
     type: CLEAR_CONFIRM_TRANSACTION,
+  };
+}
+
+export function setMaxValueMode(transactionId, enabled) {
+  return {
+    type: SET_MAX_VALUE_MODE,
+    payload: {
+      transactionId,
+      enabled,
+    },
   };
 }

--- a/ui/ducks/confirm-transaction/confirm-transaction.duck.test.js
+++ b/ui/ducks/confirm-transaction/confirm-transaction.duck.test.js
@@ -21,6 +21,7 @@ const initialState = {
   hexTransactionFee: '',
   hexTransactionTotal: '',
   nonce: '',
+  maxValueMode: {},
 };
 
 const UPDATE_TX_DATA = 'metamask/confirm-transaction/UPDATE_TX_DATA';
@@ -34,6 +35,7 @@ const UPDATE_TRANSACTION_TOTALS =
 const UPDATE_NONCE = 'metamask/confirm-transaction/UPDATE_NONCE';
 const CLEAR_CONFIRM_TRANSACTION =
   'metamask/confirm-transaction/CLEAR_CONFIRM_TRANSACTION';
+const SET_MAX_VALUE_MODE = 'metamask/confirm-transaction/SET_MAX_VALUE_MODE';
 
 describe('Confirm Transaction Duck', () => {
   describe('State changes', () => {
@@ -54,6 +56,9 @@ describe('Confirm Transaction Duck', () => {
       hexTransactionFee: '0x1319718a5000',
       hexTransactionTotal: '',
       nonce: '0x0',
+      maxValueMode: {
+        '123abc': true,
+      },
     };
 
     it('should initialize state', () => {
@@ -171,12 +176,39 @@ describe('Confirm Transaction Duck', () => {
       });
     });
 
+    it("shouldn't clear maxValueMode when receiving a CLEAR_CONFIRM_TRANSACTION action", () => {
+      expect(
+        ConfirmTransactionReducer(mockState, {
+          type: CLEAR_CONFIRM_TRANSACTION,
+        }),
+      ).toStrictEqual({
+        ...initialState,
+        maxValueMode: mockState.maxValueMode,
+      });
+    });
+
+    it('should set max value mode', () => {
+      const mockId = '123abc';
+      expect(
+        ConfirmTransactionReducer(mockState, {
+          type: SET_MAX_VALUE_MODE,
+          payload: {
+            transactionId: mockId,
+            enabled: false,
+          },
+        }).maxValueMode[mockId],
+      ).toBe(false);
+    });
+
     it('should clear confirmTransaction when receiving a FETCH_DATA_END action', () => {
       expect(
         ConfirmTransactionReducer(mockState, {
           type: CLEAR_CONFIRM_TRANSACTION,
         }),
-      ).toStrictEqual(initialState);
+      ).toStrictEqual({
+        ...initialState,
+        maxValueMode: mockState.maxValueMode,
+      });
     });
   });
 

--- a/ui/ducks/send/send.js
+++ b/ui/ducks/send/send.js
@@ -114,6 +114,7 @@ import {
 } from '../../../shared/lib/transactions-controller-utils';
 import { Numeric } from '../../../shared/modules/Numeric';
 import { EtherDenomination } from '../../../shared/constants/common';
+import { setMaxValueMode } from '../confirm-transaction/confirm-transaction.duck';
 import {
   estimateGasLimitForSend,
   generateTransactionParams,
@@ -2307,10 +2308,11 @@ export function resetSendState() {
 export function signTransaction() {
   return async (dispatch, getState) => {
     const state = getState();
-    const { stage, eip1559support } = state[name];
+    const { stage, eip1559support, amountMode } = state[name];
     const txParams = generateTransactionParams(state[name]);
     const draftTransaction =
       state[name].draftTransactions[state[name].currentTransactionUUID];
+
     if (stage === SEND_STAGES.EDIT) {
       // When dealing with the edit flow there is already a transaction in
       // state that we must update, this branch is responsible for that logic.
@@ -2381,11 +2383,19 @@ export function signTransaction() {
         ),
       );
 
-      dispatch(
+      const { id } = await dispatch(
         addTransactionAndRouteToConfirmationPage(txParams, {
           sendFlowHistory: draftTransaction.history,
           type: transactionType,
         }),
+      );
+
+      dispatch(
+        setMaxValueMode(
+          id,
+          amountMode === AMOUNT_MODES.MAX &&
+            draftTransaction.asset.type === AssetType.native,
+        ),
       );
     }
   };

--- a/ui/ducks/send/send.js
+++ b/ui/ducks/send/send.js
@@ -2390,7 +2390,7 @@ export function signTransaction() {
         }),
       );
 
-      dispatch(
+      await dispatch(
         setMaxValueMode(
           transactionId,
           amountMode === AMOUNT_MODES.MAX &&

--- a/ui/ducks/send/send.js
+++ b/ui/ducks/send/send.js
@@ -2383,7 +2383,7 @@ export function signTransaction() {
         ),
       );
 
-      const { id } = await dispatch(
+      const { id: transactionId } = await dispatch(
         addTransactionAndRouteToConfirmationPage(txParams, {
           sendFlowHistory: draftTransaction.history,
           type: transactionType,
@@ -2392,7 +2392,7 @@ export function signTransaction() {
 
       dispatch(
         setMaxValueMode(
-          id,
+          transactionId,
           amountMode === AMOUNT_MODES.MAX &&
             draftTransaction.asset.type === AssetType.native,
         ),

--- a/ui/ducks/send/send.test.js
+++ b/ui/ducks/send/send.test.js
@@ -2612,7 +2612,7 @@ describe('Send Slice', () => {
 
         const actionResult = store.getActions();
 
-        expect(actionResult).toHaveLength(2);
+        expect(actionResult).toHaveLength(3);
         expect(actionResult[0]).toMatchObject({
           type: 'send/addHistoryEntry',
           payload:

--- a/ui/pages/confirm-transaction-base/confirm-transaction-base.component.js
+++ b/ui/pages/confirm-transaction-base/confirm-transaction-base.component.js
@@ -244,7 +244,6 @@ export default class ConfirmTransactionBase extends Component {
       hexMaximumTransactionFee !== prevHexMaximumTransactionFee &&
       useMaxValue
     ) {
-      console.log('updateValueToMax');
       this.updateValueToMax();
     }
   }

--- a/ui/pages/confirm-transaction-base/confirm-transaction-base.component.js
+++ b/ui/pages/confirm-transaction-base/confirm-transaction-base.component.js
@@ -155,6 +155,8 @@ export default class ConfirmTransactionBase extends Component {
     updateTransaction: PropTypes.func,
     isUsingPaymaster: PropTypes.bool,
     isSigningOrSubmitting: PropTypes.bool,
+    useMaxValue: PropTypes.bool,
+    maxValue: PropTypes.string,
   };
 
   state = {
@@ -182,6 +184,8 @@ export default class ConfirmTransactionBase extends Component {
       tryReverseResolveAddress,
       isEthGasPrice,
       setDefaultHomeActiveTabName,
+      hexMaximumTransactionFee,
+      useMaxValue,
     } = this.props;
     const {
       customNonceValue: prevCustomNonceValue,
@@ -189,6 +193,7 @@ export default class ConfirmTransactionBase extends Component {
       toAddress: prevToAddress,
       transactionStatus: prevTxStatus,
       isEthGasPrice: prevIsEthGasPrice,
+      hexMaximumTransactionFee: prevHexMaximumTransactionFee,
     } = prevProps;
     const statusUpdated = transactionStatus !== prevTxStatus;
     const txDroppedOrConfirmed =
@@ -233,6 +238,14 @@ export default class ConfirmTransactionBase extends Component {
           ethGasPriceWarning: '',
         });
       }
+    }
+
+    if (
+      hexMaximumTransactionFee !== prevHexMaximumTransactionFee &&
+      useMaxValue
+    ) {
+      console.log("updateValueToMax");
+      this.updateValueToMax();
     }
   }
 
@@ -321,6 +334,18 @@ export default class ConfirmTransactionBase extends Component {
 
   setUserAcknowledgedGasMissing() {
     this.setState({ userAcknowledgedGasMissing: true });
+  }
+
+  updateValueToMax() {
+    const { maxValue: value, txData, updateTransaction } = this.props;
+
+    updateTransaction({
+      ...txData,
+      txParams: {
+        ...txData.txParams,
+        value,
+      },
+    });
   }
 
   renderDetails() {

--- a/ui/pages/confirm-transaction-base/confirm-transaction-base.component.js
+++ b/ui/pages/confirm-transaction-base/confirm-transaction-base.component.js
@@ -244,7 +244,7 @@ export default class ConfirmTransactionBase extends Component {
       hexMaximumTransactionFee !== prevHexMaximumTransactionFee &&
       useMaxValue
     ) {
-      console.log("updateValueToMax");
+      console.log('updateValueToMax');
       this.updateValueToMax();
     }
   }


### PR DESCRIPTION
## **Description**

Currently "send max" eth experience is broken. It doesn't recalculate the send amount due to gas changes while confirming transaction.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Related issues**

Fixes:

## **Manual testing steps**

See before/after recordings

## **Screenshots/Recordings**

### **Before**

https://github.com/MetaMask/metamask-extension/assets/7644512/f07d7105-af31-465b-a930-0a6c0639c06b

### **After**

https://github.com/MetaMask/metamask-extension/assets/7644512/1413ef5f-985d-4cdb-b750-f7ba5c132207

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've clearly explained what problem this PR is solving and how it is solved.
- [ ] I've linked related issues
- [ ] I've included manual testing steps
- [ ] I've included screenshots/recordings if applicable
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [ ] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
