### PR TITLE
Changed the drop down class name and type of selection

### DIFF
--- a/test/e2e/tests/onboarding.spec.js
+++ b/test/e2e/tests/onboarding.spec.js
@@ -117,12 +117,11 @@ describe('MetaMask onboarding @no-mmi', function () {
 
         await driver.clickElement('[data-testid="metametrics-no-thanks"]');
 
-        const dropdowns = await driver.findElements('select');
-        const dropdownElement = dropdowns[1];
-        await dropdownElement.click();
-        const options = await dropdownElement.findElements(
-          By.tagName('option'),
+        const dropdownElement = await driver.findElement(
+          '.import-srp__number-of-words-dropdown',
         );
+        await dropdownElement.click();
+        const options = await dropdownElement.findElements(By.css('option'));
 
         const iterations = options.length;
 


### PR DESCRIPTION
## **Description**

Fixing flaky test "Check if user select different type of secret recovery phrase" modified the dropdown to specifically select the element related to the secret recovery phrase, distinguishing it from another dropdown used for language selection. Additionally, updated the method to find elements by using a CSS selector for option selection.

## **Related issues**

#22714

