### PR TITLE
Change maxWorkers default to half your CPUs

### DIFF
--- a/test/run-unit-tests.js
+++ b/test/run-unit-tests.js
@@ -1,3 +1,4 @@
+const { availableParallelism } = require('os');
 const { hideBin } = require('yargs/helpers');
 const yargs = require('yargs/yargs');
 const { runCommand, runInShell } = require('../development/lib/run-command');
@@ -133,10 +134,10 @@ async function start() {
         })
         .option('maxWorkers', {
           alias: ['mw'],
-          default: 2,
+          default: availableParallelism(),
           demandOption: false,
           description:
-            'The safer way to increase performance locally, sets the number of processes to use internally. Recommended 2',
+            'The safer way to increase performance locally, sets the number of processes to use internally. Defaults to using node os.availableParallelism to determine the maxWorkers.',
           type: 'number',
         })
         .strict(),


### PR DESCRIPTION
## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->
Currently the unit tests take a very long time to run locally. The maxWorkers is defaulted to 2, and on a big machine this is wasting a lot of time waiting for tests to pass. This PR makes the tests use half your cpu, and on my machine it made the tests run in roughly 1/5 the time. 

## **Related issues**

replaces https://github.com/MetaMask/metamask-extension/pull/20058

## **Manual testing steps**

Just run the tests as you normally would

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained what problem this PR is solving and how it is solved.
- [x] I've linked related issues
- [x] I've included manual testing steps
- [x] I've included screenshots/recordings if applicable
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [x] I’ve properly set the pull request status:
  - [x] In case it's not yet "ready for review", I've set it to "draft".
  - [x] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
