### PR TITLE
fix: asset list showing fiat symbol instead of native

### DIFF
--- a/ui/components/app/asset-list/asset-list.js
+++ b/ui/components/app/asset-list/asset-list.js
@@ -175,12 +175,9 @@ const AssetList = ({ onClickAsset }) => {
             : null
         }
         tokenSymbol={
-          showPrimaryCurrency(
-            isOriginalNativeSymbol,
-            useNativeCurrencyAsPrimaryCurrency,
-          )
+          useNativeCurrencyAsPrimaryCurrency
             ? primaryCurrencyProperties.suffix
-            : null
+            : secondaryCurrencyProperties.suffix
         }
         secondary={
           showFiat &&


### PR DESCRIPTION
## **Description**

Problem: With `Primary currency = Fiat`, the home page showed Ethereum's symbol as `USD` instead of `ETH`.

## **Related issues**


## **Manual testing steps**

- Set primary currency in settings to Fiat
- Ethereum's symbol should be "ETH" on the home page

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

https://github.com/MetaMask/metamask-extension/assets/3500406/1238aa4c-9a01-464d-8a87-1496744175d2


### **After**

https://github.com/MetaMask/metamask-extension/assets/3500406/7495e8c6-51a4-4bbd-9f96-5d12a8508a6c


<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've clearly explained what problem this PR is solving and how it is solved.
- [ ] I've linked related issues
- [ ] I've included manual testing steps
- [ ] I've included screenshots/recordings if applicable
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [ ] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
