### PR TITLE
e2e: Add more information to error messages in CircleCI

### DIFF
--- a/test/e2e/helpers.js
+++ b/test/e2e/helpers.js
@@ -223,6 +223,12 @@ async function withFixtures(options, testSuite) {
         await driver.navigate(PAGES.BACKGROUND);
       }
     }
+
+    // Add information to the end of the error message that should surface in the "Tests" tab of CircleCI
+    if (process.env.CIRCLE_NODE_INDEX) {
+      error.message += `\n  (Ran on CircleCI Node ${process.env.CIRCLE_NODE_INDEX} of ${process.env.CIRCLE_NODE_TOTAL}, Job ${process.env.CIRCLE_JOB})`;
+    }
+
     throw error;
   } finally {
     if (!failed || process.env.E2E_LEAVE_RUNNING !== 'true') {


### PR DESCRIPTION
## **Description**

When you see an error message in the Tests tab of CircleCI, it does not tell you which node it failed on.  This means that if you want to look at extra information in the console log, you need to search the console log of up to 24 Parallel Runs.

This PR adds information like this to the error message:
`(Ran on CircleCI Node 14 of 16, Job test-e2e-chrome-flask)`

And now it's much easier to find the correct console log!

## **Related issues**
## **Manual testing steps**

1. Look for the error in a failed test on this PR, like this one: https://app.circleci.com/pipelines/github/MetaMask/metamask-extension/68439/workflows/5b9aaf5a-2b75-419c-97d8-f59d14f97b4e/jobs/2265448/tests

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

![image](https://github.com/MetaMask/metamask-extension/assets/539738/aa57c028-598b-4f12-a643-4b9a6d3acdc4)

### **After**

![image](https://github.com/MetaMask/metamask-extension/assets/539738/6bd40906-9bcc-4509-ba1d-b7bac4a84fe6)

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained what problem this PR is solving and how it is solved.
- [ ] I've linked related issues
- [x] I've included manual testing steps
- [x] I've included screenshots/recordings if applicable
- [ ] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [x] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [x] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
