### PR TITLE
Fix re-rendering problems on signature screens

### DIFF
--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -1080,6 +1080,31 @@ export const getAllConnectedAccounts = createDeepEqualSelector(
   },
 );
 
+export const getMemoizedCurrentChainId = createDeepEqualSelector(
+  getCurrentChainId,
+  (chainId) => chainId,
+);
+
+export const getMemoizedTxId = createDeepEqualSelector(
+  (state) => state.appState.txId,
+  (txId) => txId,
+);
+
+export const getMemoizedUnapprovedMessages = createDeepEqualSelector(
+  (state) => state.metamask.unapprovedMsgs,
+  (unapprovedMsgs) => unapprovedMsgs,
+);
+
+export const getMemoizedUnapprovedPersonalMessages = createDeepEqualSelector(
+  (state) => state.metamask.unapprovedPersonalMsgs,
+  (unapprovedPersonalMsgs) => unapprovedPersonalMsgs,
+);
+
+export const getMemoizedUnapprovedTypedMessages = createDeepEqualSelector(
+  (state) => state.metamask.unapprovedTypedMessages,
+  (unapprovedTypedMessages) => unapprovedTypedMessages,
+);
+
 ///: BEGIN:ONLY_INCLUDE_IF(snaps)
 export function getSnaps(state) {
   return state.metamask.snaps;


### PR DESCRIPTION
## **Description**

Rewrites part of the logic for computing the `txData` prop used in all signature screens. Thereby fixing re-rendering problems on these screens and making them more performant. This is also a blocker for snaps signature insights.