### PR TITLE
Adds ModalBody component to AccountDetails modal

### DIFF
--- a/ui/components/multichain/account-details/account-details.js
+++ b/ui/components/multichain/account-details/account-details.js
@@ -31,6 +31,7 @@ import {
   Text,
   ModalContent,
   ModalHeader,
+  ModalBody,
 } from '../../component-library';
 import { AddressCopyButton } from '../address-copy-button';
 import { AccountDetailsAuthenticate } from './account-details-authenticate';
@@ -91,47 +92,49 @@ export const AccountDetails = ({ address }) => {
           >
             {attemptingExport ? t('showPrivateKey') : avatar}
           </ModalHeader>
-          {attemptingExport ? (
-            <>
-              <Box
-                display={Display.Flex}
-                alignItems={AlignItems.center}
-                flexDirection={FlexDirection.Column}
-              >
-                {avatar}
-                <Text
-                  marginTop={2}
-                  marginBottom={2}
-                  variant={TextVariant.bodyLgMedium}
-                  style={{ wordBreak: 'break-word' }}
+          <ModalBody>
+            {attemptingExport ? (
+              <>
+                <Box
+                  display={Display.Flex}
+                  alignItems={AlignItems.center}
+                  flexDirection={FlexDirection.Column}
                 >
-                  {name}
-                </Text>
-                <AddressCopyButton address={address} shorten />
-              </Box>
-              {privateKey ? (
-                <AccountDetailsKey
-                  accountName={name}
-                  onClose={onClose}
-                  privateKey={privateKey}
-                />
-              ) : (
-                <AccountDetailsAuthenticate
-                  address={address}
-                  onCancel={onClose}
-                  setPrivateKey={setPrivateKey}
-                  setShowHoldToReveal={setShowHoldToReveal}
-                />
-              )}
-            </>
-          ) : (
-            <AccountDetailsDisplay
-              accounts={accounts}
-              accountName={name}
-              address={address}
-              onExportClick={() => setAttemptingExport(true)}
-            />
-          )}
+                  {avatar}
+                  <Text
+                    marginTop={2}
+                    marginBottom={2}
+                    variant={TextVariant.bodyLgMedium}
+                    style={{ wordBreak: 'break-word' }}
+                  >
+                    {name}
+                  </Text>
+                  <AddressCopyButton address={address} shorten />
+                </Box>
+                {privateKey ? (
+                  <AccountDetailsKey
+                    accountName={name}
+                    onClose={onClose}
+                    privateKey={privateKey}
+                  />
+                ) : (
+                  <AccountDetailsAuthenticate
+                    address={address}
+                    onCancel={onClose}
+                    setPrivateKey={setPrivateKey}
+                    setShowHoldToReveal={setShowHoldToReveal}
+                  />
+                )}
+              </>
+            ) : (
+              <AccountDetailsDisplay
+                accounts={accounts}
+                accountName={name}
+                address={address}
+                onExportClick={() => setAttemptingExport(true)}
+              />
+            )}
+          </ModalBody>
         </ModalContent>
       </Modal>
 


### PR DESCRIPTION
## **Description**
Adds missing padding by using the newly created `ModalBody` component.

## **Related issues**

Fixes: N/A

## **Manual testing steps**

1. Go to the account details modal
2. See that there is adequate padding 

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="363" alt="Screenshot 2024-02-01 at 9 02 37 AM" src="https://github.com/MetaMask/metamask-extension/assets/8112138/e599cab5-fa94-48d4-b372-56dd9b1a0101">


### **After**


<img width="362" alt="Screenshot 2024-02-01 at 9 04 03 AM" src="https://github.com/MetaMask/metamask-extension/assets/8112138/ec8e9465-7cf0-4c3d-b946-48ee7f715ed2">



https://github.com/MetaMask/metamask-extension/assets/8112138/b1182f6e-adbf-4bdb-bc6a-eb560bf42bdf



## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained what problem this PR is solving and how it is solved.
- [x] I've linked related issues
- [x] I've included manual testing steps
- [x] I've included screenshots/recordings if applicable
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [ x I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [x] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
