### PR TITLE
Stop blocking display of transaction approval window on resolution of ppom security alert response

### DIFF
--- a/app/scripts/controllers/app-state.js
+++ b/app/scripts/controllers/app-state.js
@@ -65,6 +65,7 @@ export default class AppStateController extends EventEmitter {
         '0x539': true,
       },
       surveyLinkLastClickedOrClosed: null,
+      signatureSecurityAlertResponses: {},
     });
     this.timer = null;
 
@@ -441,8 +442,19 @@ export default class AppStateController extends EventEmitter {
       },
     });
   }
-
   ///: END:ONLY_INCLUDE_IF
+
+  addSignatureSecurityAlertResponse(securityAlertResponse) {
+    const currentState = this.store.getState();
+    const { signatureSecurityAlertResponses } = currentState; //
+    this.store.updateState({
+      signatureSecurityAlertResponses: {
+        ...signatureSecurityAlertResponses,
+        [securityAlertResponse.securityAlertId]: securityAlertResponse,
+      },
+    });
+  }
+
   /**
    * A setter for the currentPopupId which indicates the id of popup window that's currently active
    *

--- a/app/scripts/controllers/app-state.js
+++ b/app/scripts/controllers/app-state.js
@@ -446,7 +446,7 @@ export default class AppStateController extends EventEmitter {
 
   addSignatureSecurityAlertResponse(securityAlertResponse) {
     const currentState = this.store.getState();
-    const { signatureSecurityAlertResponses } = currentState; //
+    const { signatureSecurityAlertResponses } = currentState;
     this.store.updateState({
       signatureSecurityAlertResponses: {
         ...signatureSecurityAlertResponses,

--- a/app/scripts/lib/ppom/ppom-middleware.test.ts
+++ b/app/scripts/lib/ppom/ppom-middleware.test.ts
@@ -91,7 +91,7 @@ describe('PPOMMiddleware', () => {
     const usePPOM = async () => {
       throw new Error('some error');
     };
-    const middlewareFunction = createMiddleWare(usePPOM);
+    const middlewareFunction = createMiddleWare({ usePPOM });
     const req = {
       method: 'eth_sendTransaction',
       securityAlertResponse: undefined,

--- a/app/scripts/lib/ppom/ppom-middleware.ts
+++ b/app/scripts/lib/ppom/ppom-middleware.ts
@@ -92,14 +92,14 @@ export function createPPOMMiddleware(
             securityAlertId,
           };
           appStateController.addSignatureSecurityAlertResponse({
-            reason: 'loading',
-            result_type: 'validation_in_progress',
+            reason: BlockaidResultType.Loading,
+            result_type: BlockaidReason.inProgress,
             securityAlertId,
           });
         } else {
           req.securityAlertResponse = {
-            reason: 'loading',
-            result_type: 'validation_in_progress',
+            reason: BlockaidResultType.Loading,
+            result_type: BlockaidReason.inProgress,
             securityAlertId,
           };
         }

--- a/app/scripts/lib/ppom/ppom-middleware.ts
+++ b/app/scripts/lib/ppom/ppom-middleware.ts
@@ -77,12 +77,13 @@ export function createPPOMMiddleware(
           } catch (error: any) {
             sentry?.captureException(error);
             console.error('Error validating JSON RPC using PPOM: ', error);
-            req.securityAlertResponse = {
+            const securityAlertResponse = {
               result_type: BlockaidResultType.Failed,
               reason: BlockaidReason.failed,
               description:
                 'Validating the confirmation failed by throwing error.',
             };
+            updateSecurityAlertResponseByTxId(req, securityAlertResponse);
           }
         });
 

--- a/app/scripts/lib/ppom/ppom-middleware.ts
+++ b/app/scripts/lib/ppom/ppom-middleware.ts
@@ -8,19 +8,11 @@ import {
   BlockaidResultType,
 } from '../../../../shared/constants/security-provider';
 import { CHAIN_IDS } from '../../../../shared/constants/network';
+import { SIGNING_METHODS } from '../../../../shared/constants/transaction';
 import { PreferencesController } from '../../controllers/preferences';
 import { SecurityAlertResponse } from '../transaction/util';
 
 const { sentry } = global as any;
-
-export const SIGNING_METHODS = Object.freeze([
-  'eth_sign',
-  'eth_signTypedData',
-  'eth_signTypedData_v1',
-  'eth_signTypedData_v3',
-  'eth_signTypedData_v4',
-  'personal_sign',
-]);
 
 const CONFIRMATION_METHODS = Object.freeze([
   'eth_sendRawTransaction',

--- a/app/scripts/lib/setupSentry.js
+++ b/app/scripts/lib/setupSentry.js
@@ -211,6 +211,7 @@ export const SENTRY_BACKGROUND_STATE = {
     selectedAddress: false,
     snapRegistryList: false,
     theme: true,
+    signatureSecurityAlertResponses: false,
     transactionSecurityCheckEnabled: true,
     use4ByteResolution: true,
     useAddressBarEnsResolution: true,

--- a/app/scripts/lib/transaction/util.test.ts
+++ b/app/scripts/lib/transaction/util.test.ts
@@ -380,8 +380,8 @@ describe('Transaction Utils', () => {
         ).toHaveBeenCalledWith(TRANSACTION_PARAMS_MOCK, {
           ...TRANSACTION_OPTIONS_MOCK,
           securityAlertResponse: {
-            reason: 'testReason',
-            result_type: 'testResultType',
+            reason: 'loading',
+            result_type: 'validation_in_progress',
           },
         });
 

--- a/app/scripts/lib/transaction/util.test.ts
+++ b/app/scripts/lib/transaction/util.test.ts
@@ -16,6 +16,15 @@ import {
   addTransaction,
 } from './util';
 
+jest.mock('uuid', () => {
+  const actual = jest.requireActual('uuid');
+
+  return {
+    ...actual,
+    v4: jest.fn(),
+  };
+});
+
 const TRANSACTION_PARAMS_MOCK: TransactionParams = {
   from: '0x1',
 };

--- a/app/scripts/lib/transaction/util.ts
+++ b/app/scripts/lib/transaction/util.ts
@@ -38,6 +38,7 @@ export type SecurityAlertResponse = {
   features?: string[];
   result_type: string;
   providerRequestsCount?: Record<string, number>;
+  securityAlertId?: string;
 };
 
 type FinalAddTransactionRequest = BaseAddTransactionRequest & {

--- a/app/scripts/lib/transaction/util.ts
+++ b/app/scripts/lib/transaction/util.ts
@@ -169,8 +169,8 @@ export async function addTransaction(
       });
 
       request.transactionOptions.securityAlertResponse = {
-        reason: 'loading',
-        result_type: 'validation_in_progress',
+        reason: BlockaidResultType.Loading,
+        result_type: BlockaidReason.inProgress,
         securityAlertId,
       };
     } catch (e) {

--- a/app/scripts/lib/transaction/util.ts
+++ b/app/scripts/lib/transaction/util.ts
@@ -3,6 +3,10 @@ import {
   TransactionController,
   TransactionMeta,
   TransactionParams,
+  WalletDevice,
+  TransactionType,
+  SendFlowHistoryEntry,
+  Result,
 } from '@metamask/transaction-controller';
 import {
   AddUserOperationOptions,
@@ -12,11 +16,45 @@ import {
 import { PPOMController } from '@metamask/ppom-validator';
 import { captureException } from '@sentry/browser';
 import { addHexPrefix } from 'ethereumjs-util';
+import { v4 as uuid } from 'uuid';
 import { SUPPORTED_CHAIN_IDS } from '../ppom/ppom-middleware';
+import {
+  BlockaidReason,
+  BlockaidResultType,
+} from '../../../../shared/constants/security-provider';
 ///: END:ONLY_INCLUDE_IF
 
+/**
+ * Type for security alert response from transaction validator.
+ */
+export type SecurityAlertResponse = {
+  reason: string;
+  features?: string[];
+  result_type: string;
+  providerRequestsCount?: Record<string, number>;
+  securityAlertId?: string;
+};
+
 export type AddTransactionOptions = NonNullable<
-  Parameters<TransactionController['addTransaction']>[1]
+  Parameters<
+    (
+      txParams: TransactionParams,
+      options?: {
+        actionId?: string;
+        deviceConfirmedOn?: WalletDevice;
+        method?: string;
+        origin?: string;
+        requireApproval?: boolean | undefined;
+        securityAlertResponse?: SecurityAlertResponse;
+        sendFlowHistory?: SendFlowHistoryEntry[];
+        swaps?: {
+          hasApproveTx?: boolean;
+          meta?: Partial<TransactionMeta>;
+        };
+        type?: TransactionType;
+      },
+    ) => Promise<Result>
+  >[1]
 >;
 
 type BaseAddTransactionRequest = {
@@ -28,17 +66,6 @@ type BaseAddTransactionRequest = {
   transactionParams: TransactionParams;
   transactionController: TransactionController;
   userOperationController: UserOperationController;
-};
-
-/**
- * Type for security alert response from transaction validator.
- */
-export type SecurityAlertResponse = {
-  reason: string;
-  features?: string[];
-  result_type: string;
-  providerRequestsCount?: Record<string, number>;
-  securityAlertId?: string;
 };
 
 type FinalAddTransactionRequest = BaseAddTransactionRequest & {
@@ -86,7 +113,7 @@ export async function addTransaction(
   request: AddTransactionRequest,
   ///: BEGIN:ONLY_INCLUDE_IF(blockaid)
   updateSecurityAlertResponseByTxId: (
-    reqId: string | undefined,
+    req: AddTransactionOptions | undefined,
     securityAlertResponse: SecurityAlertResponse,
   ) => void,
   ///: END:ONLY_INCLUDE_IF
@@ -116,21 +143,35 @@ export async function addTransaction(
         ],
       };
 
+      const securityAlertId = uuid();
+
       ppomController.usePPOM(async (ppom) => {
         try {
-          const securityAlertResponse = ppom.validateJsonRpc(ppomRequest);
+          const securityAlertResponse = await ppom.validateJsonRpc(ppomRequest);
           updateSecurityAlertResponseByTxId(
-            transactionOptions.actionId,
+            request.transactionOptions,
             securityAlertResponse,
           );
         } catch (e) {
           captureException(e);
+          console.error('Error validating JSON RPC using PPOM: ', e);
+          const securityAlertResponse = {
+            result_type: BlockaidResultType.Failed,
+            reason: BlockaidReason.failed,
+            description:
+              'Validating the confirmation failed by throwing error.',
+          };
+          updateSecurityAlertResponseByTxId(
+            request.transactionOptions,
+            securityAlertResponse,
+          );
         }
       });
 
       request.transactionOptions.securityAlertResponse = {
         reason: 'loading',
         result_type: 'validation_in_progress',
+        securityAlertId,
       };
     } catch (e) {
       captureException(e);

--- a/app/scripts/lib/transaction/util.ts
+++ b/app/scripts/lib/transaction/util.ts
@@ -84,10 +84,12 @@ export async function addDappTransaction(
 
 export async function addTransaction(
   request: AddTransactionRequest,
+  ///: BEGIN:ONLY_INCLUDE_IF(blockaid)
   updateSecurityAlertResponseByTxId: (
     reqId: string | undefined,
     securityAlertResponse: SecurityAlertResponse,
   ) => void,
+  ///: END:ONLY_INCLUDE_IF
 ): Promise<TransactionMeta> {
   ///: BEGIN:ONLY_INCLUDE_IF(blockaid)
   const {

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -2986,6 +2986,7 @@ export default class MetamaskController extends EventEmitter {
             transactionOptions,
             waitForSubmit: false,
           }),
+          this.updateSecurityAlertResponseByTxId.bind(this),
         ),
       addTransactionAndWaitForPublish: (
         transactionParams,
@@ -2997,6 +2998,7 @@ export default class MetamaskController extends EventEmitter {
             transactionOptions,
             waitForSubmit: true,
           }),
+          this.updateSecurityAlertResponseByTxId.bind(this),
         ),
       createTransactionEventFragment:
         createTransactionEventFragmentWithTxId.bind(
@@ -4251,6 +4253,24 @@ export default class MetamaskController extends EventEmitter {
     }
   };
 
+  async updateSecurityAlertResponseByTxId(reqId, securityAlertResponse) {
+    let foundTransaction = false;
+
+    while (!foundTransaction) {
+      foundTransaction = this.txController.state.transactions.find(
+        (meta) => meta.actionId === reqId,
+      );
+      if (!foundTransaction) {
+        await new Promise((resolve) => setTimeout(resolve, 100));
+      }
+    }
+
+    this.txController.updateSecurityAlertResponse(
+      foundTransaction.id,
+      securityAlertResponse,
+    );
+  }
+
   //=============================================================================
   // PASSWORD MANAGEMENT
   //=============================================================================
@@ -4643,6 +4663,7 @@ export default class MetamaskController extends EventEmitter {
         this.ppomController,
         this.preferencesController,
         this.networkController,
+        this.updateSecurityAlertResponseByTxId.bind(this),
       ),
     );
     ///: END:ONLY_INCLUDE_IF

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -143,7 +143,11 @@ import { BrowserRuntimePostMessageStream } from '@metamask/post-message-stream';
 import { toChecksumHexAddress } from '../../shared/modules/hexstring-utils';
 ///: END:ONLY_INCLUDE_IF
 
-import { AssetType, TokenStandard } from '../../shared/constants/transaction';
+import {
+  AssetType,
+  TokenStandard,
+  SIGNING_METHODS,
+} from '../../shared/constants/transaction';
 import {
   GAS_API_BASE_URL,
   GAS_DEV_API_BASE_URL,
@@ -228,10 +232,7 @@ import { AddressBookPetnamesBridge } from './lib/AddressBookPetnamesBridge';
 import { AccountIdentitiesPetnamesBridge } from './lib/AccountIdentitiesPetnamesBridge';
 
 ///: BEGIN:ONLY_INCLUDE_IF(blockaid)
-import {
-  createPPOMMiddleware,
-  SIGNING_METHODS,
-} from './lib/ppom/ppom-middleware';
+import { createPPOMMiddleware } from './lib/ppom/ppom-middleware';
 import * as PPOMModule from './lib/ppom/ppom';
 ///: END:ONLY_INCLUDE_IF
 import {

--- a/app/scripts/metamask-controller.test.js
+++ b/app/scripts/metamask-controller.test.js
@@ -1084,6 +1084,9 @@ describe('MetaMaskController', () => {
 
       beforeEach(() => {
         initializeMockMiddlewareLog();
+        metamaskController.preferencesController.setSecurityAlertsEnabled(
+          false,
+        );
       });
 
       afterAll(() => {

--- a/shared/constants/security-provider.ts
+++ b/shared/constants/security-provider.ts
@@ -49,6 +49,7 @@ export enum BlockaidReason {
   // MetaMask defined reasons
   failed = 'Failed',
   notApplicable = 'NotApplicable',
+  inProgress = 'validation_in_progress',
 }
 
 export enum BlockaidResultType {
@@ -59,6 +60,7 @@ export enum BlockaidResultType {
   // MetaMask defined result types
   Failed = 'Failed',
   NotApplicable = 'NotApplicable',
+  Loading = 'loading',
 }
 
 /**

--- a/shared/constants/transaction.ts
+++ b/shared/constants/transaction.ts
@@ -10,6 +10,15 @@ export const IN_PROGRESS_TRANSACTION_STATUSES = [
   TransactionStatus.submitted,
 ];
 
+export const SIGNING_METHODS = Object.freeze([
+  'eth_sign',
+  'eth_signTypedData',
+  'eth_signTypedData_v1',
+  'eth_signTypedData_v3',
+  'eth_signTypedData_v4',
+  'personal_sign',
+]);
+
 ///: BEGIN:ONLY_INCLUDE_IF(build-mmi)
 /**
  * Status for finalized transactions.

--- a/test/e2e/helpers.js
+++ b/test/e2e/helpers.js
@@ -710,6 +710,25 @@ const openActionMenuAndStartSendFlow = async (driver) => {
   await driver.clickElement('[data-testid="eth-overview-send"]');
 };
 
+const sendScreenToConfirmScreen = async (
+  driver,
+  recipientAddress,
+  quantity,
+) => {
+  // TODO: Update Test when Multichain Send Flow is added
+  if (process.env.MULTICHAIN) {
+    return;
+  }
+  await openActionMenuAndStartSendFlow(driver);
+  await driver.fill('[data-testid="ens-input"]', recipientAddress);
+  await driver.fill('.unit-input__input', quantity);
+  await driver.clickElement({
+    text: 'Next',
+    tag: 'button',
+    css: '[data-testid="page-container-footer-next"]',
+  });
+};
+
 const sendTransaction = async (
   driver,
   recipientAddress,
@@ -1011,6 +1030,7 @@ module.exports = {
   multipleGanacheOptions,
   defaultGanacheOptions,
   sendTransaction,
+  sendScreenToConfirmScreen,
   findAnotherAccountFromAccountList,
   unlockWallet,
   logInWithBalanceValidation,

--- a/test/e2e/helpers.js
+++ b/test/e2e/helpers.js
@@ -715,10 +715,6 @@ const sendScreenToConfirmScreen = async (
   recipientAddress,
   quantity,
 ) => {
-  // TODO: Update Test when Multichain Send Flow is added
-  if (process.env.MULTICHAIN) {
-    return;
-  }
   await openActionMenuAndStartSendFlow(driver);
   await driver.fill('[data-testid="ens-input"]', recipientAddress);
   await driver.fill('.unit-input__input', quantity);

--- a/test/e2e/tests/ppom-blockaid-alert-simple-send.spec.js
+++ b/test/e2e/tests/ppom-blockaid-alert-simple-send.spec.js
@@ -1,0 +1,249 @@
+const { strict: assert } = require('assert');
+const FixtureBuilder = require('../fixture-builder');
+const { mockServerJsonRpc } = require('../mock-server-json-rpc');
+
+const {
+  defaultGanacheOptions,
+  withFixtures,
+  sendScreenToConfirmScreen,
+  unlockWallet,
+} = require('../helpers');
+
+const bannerAlertSelector = '[data-testid="security-provider-banner-alert"]';
+const mockMaliciousAddress = '0x5fbdb2315678afecb367f032d93f642f64180aa3';
+const mockBenignAddress = '0x50587E46C5B96a3F6f9792922EC647F13E6EFAE4';
+
+const expectedMaliciousTitle = 'This is a deceptive request';
+const expectedMaliciousDescription =
+  'If you approve this request, a third party known for scams will take all your assets.';
+
+async function mockInfura(mockServer) {
+  await mockServerJsonRpc(mockServer, [
+    ['eth_blockNumber'],
+    ['eth_call'],
+    ['eth_estimateGas'],
+    ['eth_feeHistory'],
+    ['eth_gasPrice'],
+    ['eth_getBalance'],
+    ['eth_getBlockByNumber'],
+    ['eth_getCode'],
+    ['eth_getTransactionCount'],
+  ]);
+}
+
+async function mockInfuraWithBenignResponses(mockServer) {
+  await mockInfura(mockServer);
+
+  await mockServer
+    .forPost()
+    .withJsonBodyIncluding({
+      method: 'debug_traceCall',
+    })
+    .thenCallback(async (req) => {
+      return {
+        statusCode: 200,
+        json: {
+          jsonrpc: '2.0',
+          id: (await req.body.getJson()).id,
+          result: {
+            type: 'CALL',
+            from: '0x0000000000000000000000000000000000000000',
+            to: '0xd46e8dd67c5d32be8058bb8eb970870f07244567',
+            value: '0xde0b6b3a7640000',
+            gas: '0x16c696eb7',
+            gasUsed: '0x0',
+            input: '0x',
+            output: '0x',
+          },
+        },
+      };
+    });
+}
+
+async function mockInfuraWithMaliciousResponses(mockServer) {
+  await mockInfura(mockServer);
+
+  await mockServer
+    .forPost()
+    .withJsonBodyIncluding({
+      method: 'debug_traceCall',
+      params: [{ accessList: [], data: '0x00000000' }],
+    })
+    .thenCallback(async (req) => {
+      return {
+        statusCode: 200,
+        json: {
+          jsonrpc: '2.0',
+          id: (await req.body.getJson()).id,
+          result: {
+            calls: [
+              {
+                error: 'execution reverted',
+                from: '0x0000000000000000000000000000000000000000',
+                gas: '0x1d55c2cb',
+                gasUsed: '0x39c',
+                input: '0x00000000',
+                to: mockMaliciousAddress,
+                type: 'DELEGATECALL',
+                value: '0x0',
+              },
+            ],
+            error: 'execution reverted',
+            from: '0x0000000000000000000000000000000000000000',
+            gas: '0x1dcd6500',
+            gasUsed: '0x721e',
+            input: '0x00000000',
+            to: mockMaliciousAddress,
+            type: 'CALL',
+            value: '0x0',
+          },
+        },
+      };
+    });
+}
+
+async function mockInfuraWithFailedResponses(mockServer) {
+  await mockInfura(mockServer);
+
+  await mockServer
+    .forPost()
+    .withJsonBodyIncluding({
+      method: 'debug_traceCall',
+      params: [{ accessList: [], data: '0x00000000' }],
+    })
+    .thenCallback(() => {
+      return {
+        statusCode: 500,
+      };
+    });
+}
+
+/**
+ * Tests various Blockaid PPOM security alerts. Some other tests live in separate files due to
+ * the need for more sophisticated JSON-RPC mock requests. Some example PPOM Blockaid
+ * requests and responses are provided here:
+ *
+ * @see {@link https://wobbly-nutmeg-8a5.notion.site/MM-E2E-Testing-1e51b617f79240a49cd3271565c6e12d}
+ */
+describe('Simple Send Security Alert - Blockaid @no-mmi', function () {
+  /**
+   * todo: fix test
+   *
+   * @see {@link https://github.com/MetaMask/MetaMask-planning/issues/1766}
+   */
+  // eslint-disable-next-line mocha/no-skipped-tests
+  it('should not show security alerts for benign requests', async function () {
+    await withFixtures(
+      {
+        dapp: true,
+        fixtures: new FixtureBuilder()
+          .withNetworkControllerOnMainnet()
+          .withPreferencesController({
+            securityAlertsEnabled: true,
+          })
+          .build(),
+        defaultGanacheOptions,
+        testSpecificMock: mockInfuraWithBenignResponses,
+        title: this.test.fullTitle(),
+      },
+
+      async ({ driver }) => {
+        // await driver.delay(10000)
+        await unlockWallet(driver);
+
+        await sendScreenToConfirmScreen(driver, mockBenignAddress, '1');
+        // await driver.delay(100000)
+        const isPresent = await driver.isElementPresent(bannerAlertSelector);
+        assert.equal(isPresent, false, `Banner alert unexpectedly found.`);
+      },
+    );
+  });
+
+  /**
+   * Disclaimer: This test does not test all reason types. e.g. 'blur_farming',
+   * 'malicious_domain'. Some other tests are found in other files:
+   * e.g. test/e2e/flask/ppom-blockaid-alert-<name>.spec.js
+   */
+  it('should show security alerts for malicious requests', async function () {
+    await withFixtures(
+      {
+        dapp: true,
+        fixtures: new FixtureBuilder()
+          .withNetworkControllerOnMainnet()
+          .withPreferencesController({
+            securityAlertsEnabled: true,
+          })
+          .build(),
+        defaultGanacheOptions,
+        testSpecificMock: mockInfuraWithMaliciousResponses,
+        title: this.test.fullTitle(),
+      },
+
+      async ({ driver }) => {
+        await unlockWallet(driver);
+
+        await sendScreenToConfirmScreen(
+          driver,
+          '0x985c30949c92df7a0bd42e0f3e3d539ece98db24',
+          '1',
+        );
+
+        // Find element by title
+        const bannerAlertFoundByTitle = await driver.findElement({
+          css: bannerAlertSelector,
+          text: expectedMaliciousTitle,
+        });
+        const bannerAlertText = await bannerAlertFoundByTitle.getText();
+
+        assert(
+          bannerAlertFoundByTitle,
+          `Banner alert not found. Expected Title: ${expectedMaliciousTitle}`,
+        );
+        assert(
+          bannerAlertText.includes(expectedMaliciousDescription),
+          `Unexpected banner alert description. Expected: ${expectedMaliciousDescription}`,
+        );
+      },
+    );
+  });
+
+  it('should show "Request may not be safe" if the PPOM request fails to check transaction', async function () {
+    await withFixtures(
+      {
+        dapp: true,
+        fixtures: new FixtureBuilder()
+          .withNetworkControllerOnMainnet()
+          .withPreferencesController({
+            securityAlertsEnabled: true,
+          })
+          .build(),
+        defaultGanacheOptions,
+        testSpecificMock: mockInfuraWithFailedResponses,
+        title: this.test.fullTitle(),
+      },
+
+      async ({ driver }) => {
+        // await driver.delay(10000)
+        await unlockWallet(driver);
+
+        await sendScreenToConfirmScreen(
+          driver,
+          '0x985c30949c92df7a0bd42e0f3e3d539ece98db24',
+          '1',
+        );
+        // await driver.delay(100000)
+        const expectedTitle = 'Request may not be safe';
+
+        const bannerAlert = await driver.findElement({
+          css: bannerAlertSelector,
+          text: expectedTitle,
+        });
+
+        assert(
+          bannerAlert,
+          `Banner alert not found. Expected Title: ${expectedTitle}`,
+        );
+      },
+    );
+  });
+});

--- a/test/e2e/tests/ppom-blockaid-alert-simple-send.spec.js
+++ b/test/e2e/tests/ppom-blockaid-alert-simple-send.spec.js
@@ -126,12 +126,9 @@ async function mockInfuraWithFailedResponses(mockServer) {
  * @see {@link https://wobbly-nutmeg-8a5.notion.site/MM-E2E-Testing-1e51b617f79240a49cd3271565c6e12d}
  */
 describe('Simple Send Security Alert - Blockaid @no-mmi', function () {
-  /**
-   * todo: fix test
-   *
-   * @see {@link https://github.com/MetaMask/MetaMask-planning/issues/1766}
-   */
-  // eslint-disable-next-line mocha/no-skipped-tests
+  if (process.env.MULTICHAIN) {
+    return;
+  }
   it('should not show security alerts for benign requests', async function () {
     await withFixtures(
       {

--- a/test/e2e/tests/state-snapshots/errors-after-init-opt-in-background-state.json
+++ b/test/e2e/tests/state-snapshots/errors-after-init-opt-in-background-state.json
@@ -32,6 +32,7 @@
     "outdatedBrowserWarningLastShown": "number",
     "nftsDetectionNoticeDismissed": false,
     "showTestnetMessageInDropdown": true,
+    "signatureSecurityAlertResponses": "object",
     "showBetaHeader": false,
     "showProductTour": true,
     "showNetworkBanner": true,

--- a/test/e2e/tests/state-snapshots/errors-after-init-opt-in-ui-state.json
+++ b/test/e2e/tests/state-snapshots/errors-after-init-opt-in-ui-state.json
@@ -67,6 +67,7 @@
     "outdatedBrowserWarningLastShown": "number",
     "nftsDetectionNoticeDismissed": false,
     "showTestnetMessageInDropdown": true,
+    "signatureSecurityAlertResponses": "object",
     "showBetaHeader": false,
     "showProductTour": true,
     "showNetworkBanner": true,

--- a/ui/components/app/security-provider-banner-alert/blockaid-banner-alert/blockaid-banner-alert.js
+++ b/ui/components/app/security-provider-banner-alert/blockaid-banner-alert/blockaid-banner-alert.js
@@ -60,7 +60,10 @@ function BlockaidBannerAlert({ txData, ...props }) {
   const t = useContext(I18nContext);
   const { updateTransactionEventFragment } = useTransactionEventFragment();
 
-  if (!securityAlertResponse) {
+  if (
+    !securityAlertResponse ||
+    Object.keys(securityAlertResponse).length === 0
+  ) {
     return null;
   } else if (securityAlertResponse.reason === 'loading') {
     return <LoadingIndicator isLoading />;

--- a/ui/components/app/security-provider-banner-alert/blockaid-banner-alert/blockaid-banner-alert.js
+++ b/ui/components/app/security-provider-banner-alert/blockaid-banner-alert/blockaid-banner-alert.js
@@ -18,6 +18,7 @@ import {
 import { Text } from '../../../component-library';
 
 import SecurityProviderBannerAlert from '../security-provider-banner-alert';
+import LoadingIndicator from '../../../ui/loading-indicator';
 import { getReportUrl } from './blockaid-banner-utils';
 
 const zlib = require('zlib');
@@ -61,6 +62,8 @@ function BlockaidBannerAlert({ txData, ...props }) {
 
   if (!securityAlertResponse) {
     return null;
+  } else if (securityAlertResponse.reason === 'loading') {
+    return <LoadingIndicator isLoading />;
   }
 
   const {

--- a/ui/pages/confirm-signature-request/index.js
+++ b/ui/pages/confirm-signature-request/index.js
@@ -58,9 +58,13 @@ const ConfirmTxScreen = ({ match }) => {
     getTotalUnapprovedSignatureRequestCount,
   );
   const sendTo = useSelector(getSendTo);
-  const { identities, currentCurrency, blockGasLimit } = useSelector(
-    (state) => state.metamask,
-  );
+
+  const {
+    identities,
+    currentCurrency,
+    blockGasLimit,
+    signatureSecurityAlertResponses,
+  } = useSelector((state) => state.metamask);
   const unapprovedMsgs = useSelector(getMemoizedUnapprovedMessages);
   const unapprovedPersonalMsgs = useSelector(
     getMemoizedUnapprovedPersonalMessages,
@@ -68,6 +72,7 @@ const ConfirmTxScreen = ({ match }) => {
   const unapprovedTypedMessages = useSelector(
     getMemoizedUnapprovedTypedMessages,
   );
+
   const unapprovedTxs = useSelector(getUnapprovedTransactions);
   const currentNetworkTxList = useSelector(getCurrentNetworkTransactions);
   const chainId = useSelector(getMemoizedCurrentChainId);
@@ -193,6 +198,15 @@ const ConfirmTxScreen = ({ match }) => {
     unapprovedTxs,
     unapprovedTypedMessages,
   ]);
+
+  const resolvedSecurityAlertResponse =
+    signatureSecurityAlertResponses?.[
+      txData.securityAlertResponse?.securityAlertId
+    ];
+
+  if (resolvedSecurityAlertResponse) {
+    txData.securityAlertResponse = resolvedSecurityAlertResponse;
+  }
 
   const targetSubjectMetadata = useSelector((state) =>
     getTargetSubjectMetadata(state, txData.msgParams?.origin),


### PR DESCRIPTION
## **Description**

Solves this problem:

For people on slow networks, the amount of time it takes from "Dapp button click" -> "Popup notification window appears" might be a problem. When blockaid is toggled off, and the network is throttled to slow via the chrome dev tools, I see a ~3 second worse case for this time, but when blockaid is toggled on, I see a 12 second (or even a bit longer) worst case scenario for this time.

The risk here is that users unexpectedly see a longer delay then usual, and so think they need to click the button again, and then get shown multiple confirmation requests and confirm all of them, leading to fund loss.

This can happen on either slow internet connections, or if an infura request is taking longer than usual (which could effect people regardless of internet connection). Yesterday when I first saw this issue, I wasn't slowing down my connection, but it still took ~20 seconds to open. Probably a somewhat rare case (because as I mentioned I didn't notice any problems again until I intentionally throttled the network requests), but even if it only affected 10% of users only once a month, that would be enough to get plenty of "why did metamask just take 20 seconds to open a confirmation window?!?" complaints.


<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've clearly explained what problem this PR is solving and how it is solved.
- [ ] I've linked related issues
- [ ] I've included manual testing steps
- [ ] I've included screenshots/recordings if applicable
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [ ] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
