### PR TITLE
UX: Show names for the accounts in Send Flow

### DIFF
--- a/test/e2e/tests/address-book.spec.js
+++ b/test/e2e/tests/address-book.spec.js
@@ -99,7 +99,12 @@ describe('Address Book', function () {
         );
         await driver.clickElement({ text: 'Settings', tag: 'div' });
         await driver.clickElement({ text: 'Contacts', tag: 'div' });
-        await driver.clickElement({ text: 'Test Name 1', tag: 'p' });
+        if (process.env.MULTICHAIN) {
+          await driver.clickElement({
+            text: 'Test Name 1',
+            css: '.address-list-item__label',
+          })
+        } else { await driver.clickElement({ text: 'Test Name 1', tag: 'p' }) }
 
         await driver.clickElement({ text: 'Edit', tag: 'button' });
         const inputUsername = await driver.findElement('#nickname');

--- a/test/e2e/tests/address-book.spec.js
+++ b/test/e2e/tests/address-book.spec.js
@@ -103,8 +103,10 @@ describe('Address Book', function () {
           await driver.clickElement({
             text: 'Test Name 1',
             css: '.address-list-item__label',
-          })
-        } else { await driver.clickElement({ text: 'Test Name 1', tag: 'p' }) }
+          });
+        } else {
+          await driver.clickElement({ text: 'Test Name 1', tag: 'p' });
+        }
 
         await driver.clickElement({ text: 'Edit', tag: 'button' });
         const inputUsername = await driver.findElement('#nickname');

--- a/ui/components/multichain/address-list-item/__snapshots__/address-list-item.test.tsx.snap
+++ b/ui/components/multichain/address-list-item/__snapshots__/address-list-item.test.tsx.snap
@@ -1,0 +1,121 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AddressListItem renders the address and label 1`] = `
+<div>
+  <button
+    class="mm-box address-list-item mm-box--padding-4 mm-box--display-flex mm-box--align-items-center mm-box--width-full mm-box--background-color-transparent"
+  >
+    <div
+      class="mm-box mm-text mm-avatar-base mm-avatar-base--size-sm mm-avatar-account mm-text--body-sm mm-text--text-transform-uppercase mm-box--margin-inline-end-2 mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full mm-box--border-color-transparent box--border-style-solid box--border-width-1"
+    >
+      <div
+        class="mm-avatar-account__jazzicon"
+      >
+        <div
+          style="border-radius: 50px; overflow: hidden; padding: 0px; margin: 0px; width: 24px; height: 24px; display: inline-block; background: rgb(3, 73, 94);"
+        >
+          <svg
+            height="24"
+            width="24"
+            x="0"
+            y="0"
+          >
+            <rect
+              fill="#F5D800"
+              height="24"
+              transform="translate(-1.6948137315966292 7.490045892231985) rotate(238.2 12 12)"
+              width="24"
+              x="0"
+              y="0"
+            />
+            <rect
+              fill="#1888F2"
+              height="24"
+              transform="translate(2.6987555575750655 10.47254609666851) rotate(211.2 12 12)"
+              width="24"
+              x="0"
+              y="0"
+            />
+            <rect
+              fill="#017E8E"
+              height="24"
+              transform="translate(4.1286145552783005 -17.188975454864387) rotate(404.9 12 12)"
+              width="24"
+              x="0"
+              y="0"
+            />
+          </svg>
+        </div>
+      </div>
+    </div>
+    <div
+      class="mm-box mm-box--display-flex mm-box--flex-direction-column"
+      style="overflow: hidden;"
+    >
+      <p
+        class="mm-box mm-text address-list-item__label mm-text--body-md-medium mm-text--text-align-left mm-box--padding-0 mm-box--width-full mm-box--color-text-default"
+      >
+        <span>
+          <div
+            aria-describedby="tippy-tooltip-1"
+            class=""
+            data-original-title="'m' is similar to 'rn'."
+            data-tooltipped=""
+            style="display: inline;"
+            tabindex="0"
+          >
+            <span
+              class="confusable__point"
+            >
+              m
+            </span>
+          </div>
+        </span>
+        e
+        t
+        a
+        <span>
+          <div
+            aria-describedby="tippy-tooltip-2"
+            class=""
+            data-original-title="'m' is similar to 'rn'."
+            data-tooltipped=""
+            style="display: inline;"
+            tabindex="0"
+          >
+            <span
+              class="confusable__point"
+            >
+              m
+            </span>
+          </div>
+        </span>
+        a
+        s
+        k
+        .
+        e
+        t
+        h
+      </p>
+      <div
+        class="mm-box mm-text mm-text--body-sm mm-text--ellipsis mm-box--color-text-alternative"
+        data-testid="address-list-item-address"
+      >
+        <div>
+          <div
+            aria-describedby="tippy-tooltip-3"
+            class=""
+            data-original-title="0x0c54FcCd2e384b4BB6f2E405Bf5Cbc15a017AaFb"
+            data-tooltipped=""
+            style="display: inline;"
+            tabindex="0"
+          >
+            0x0c54F...7AaFb
+          </div>
+        </div>
+      </div>
+    </div>
+  </button>
+</div>
+`;

--- a/ui/components/multichain/address-list-item/address-list-item.stories.tsx
+++ b/ui/components/multichain/address-list-item/address-list-item.stories.tsx
@@ -55,4 +55,4 @@ export const ConfusableStory = (args) => (
   </Box>
 );
 ConfusableStory.storyName = 'Confusable';
-ConfusableStory.args = { label: <Confusable input={LABEL} /> };
+ConfusableStory.args = { label: '👻.eth' };

--- a/ui/components/multichain/address-list-item/address-list-item.stories.tsx
+++ b/ui/components/multichain/address-list-item/address-list-item.stories.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import Confusable from '../../ui/confusable';
 import { Box } from '../../component-library';
 import { AddressListItem } from '.';
 

--- a/ui/components/multichain/address-list-item/address-list-item.test.tsx
+++ b/ui/components/multichain/address-list-item/address-list-item.test.tsx
@@ -24,10 +24,10 @@ const render = () => {
 
 describe('AddressListItem', () => {
   it('renders the address and label', () => {
-    const { getByText } = render();
+    const { getByText, container } = render();
+    expect(container).toMatchSnapshot();
 
     expect(getByText(shortenAddress(SAMPLE_ADDRESS))).toBeInTheDocument();
-    expect(getByText(SAMPLE_LABEL)).toBeInTheDocument();
   });
 
   it('fires onClick when the item is clicked', () => {

--- a/ui/components/multichain/address-list-item/address-list-item.tsx
+++ b/ui/components/multichain/address-list-item/address-list-item.tsx
@@ -1,6 +1,7 @@
 import React, { ReactChild } from 'react';
 
 import { useSelector } from 'react-redux';
+import Confusable from '../../ui/confusable';
 import {
   AvatarAccount,
   Box,
@@ -17,20 +18,21 @@ import {
   BlockSize,
   BackgroundColor,
   TextColor,
+  AlignItems,
 } from '../../../helpers/constants/design-system';
 import { getUseBlockie } from '../../../selectors';
 import { shortenAddress } from '../../../helpers/utils/util';
 import Tooltip from '../../ui/tooltip';
 
 interface AddressListItemProps {
-  label: string | ReactChild;
   address: string;
+  label: string;
   onClick: () => void;
 }
 
 export const AddressListItem = ({
-  label,
   address,
+  label,
   onClick,
 }: AddressListItemProps) => {
   const useBlockie = useSelector(getUseBlockie);
@@ -47,6 +49,7 @@ export const AddressListItem = ({
       width={BlockSize.Full}
       backgroundColor={BackgroundColor.transparent}
       className="address-list-item"
+      alignItems={AlignItems.center}
     >
       <AvatarAccount
         borderColor={BorderColor.transparent}
@@ -72,7 +75,7 @@ export const AddressListItem = ({
           ellipsis
           className="address-list-item__label"
         >
-          {label}
+          {label ? <Confusable input={label} /> : shortenAddress(address)}
         </Text>
         <Text
           variant={TextVariant.bodySm}

--- a/ui/components/multichain/address-list-item/address-list-item.tsx
+++ b/ui/components/multichain/address-list-item/address-list-item.tsx
@@ -1,5 +1,4 @@
-import React, { ReactChild } from 'react';
-
+import React from 'react';
 import { useSelector } from 'react-redux';
 import Confusable from '../../ui/confusable';
 import {
@@ -72,7 +71,6 @@ export const AddressListItem = ({
           padding={0}
           width={BlockSize.Full}
           textAlign={TextAlign.Left}
-          ellipsis
           className="address-list-item__label"
         >
           {label ? <Confusable input={label} /> : shortenAddress(address)}

--- a/ui/components/multichain/pages/send/components/recipient.tsx
+++ b/ui/components/multichain/pages/send/components/recipient.tsx
@@ -36,7 +36,7 @@ const renderExplicitAddress = (
   return (
     <AddressListItem
       address={address}
-      label={<Confusable input={nickname} />}
+      label={nickname}
       onClick={() => {
         dispatch(
           addHistoryEntry(
@@ -55,7 +55,7 @@ export const SendPageRecipient = () => {
   const dispatch = useDispatch();
 
   const recipient = useSelector(getRecipient);
-  const userInput = useSelector(getRecipientUserInput);
+  const userInput = useSelector(getRecipientUserInput) || '';
 
   const domainResolution = useSelector(getDomainResolution);
   const domainError = useSelector(getDomainError);
@@ -85,7 +85,7 @@ export const SendPageRecipient = () => {
   } else if (domainResolution && !recipient.error) {
     contents = renderExplicitAddress(
       domainResolution,
-      addressBookEntryName ?? userInput,
+      addressBookEntryName || userInput,
       'ENS resolution',
       dispatch,
     );

--- a/ui/components/multichain/pages/send/components/recipient.tsx
+++ b/ui/components/multichain/pages/send/components/recipient.tsx
@@ -19,7 +19,6 @@ import {
   Box,
 } from '../../../../component-library';
 import { getAddressBookEntry } from '../../../../../selectors';
-import Confusable from '../../../../ui/confusable';
 import { Tab, Tabs } from '../../../../ui/tabs';
 import { AddressListItem } from '../../../address-list-item';
 import { SendPageAddressBook, SendPageRow, SendPageYourAccounts } from '.';


### PR DESCRIPTION
This PR is to show the account name when the user search for an account .

## **Related issues**

Fixes:

## **Manual testing steps**

1. Run extension via MULTICHAIN=1 yarn start
2. Go to send flow
3. search for ens account, test.eth
4. Look both the account name and address shows up

## **Screenshots/Recordings**


### **Before**
![Screenshot 2024-02-06 at 3 45 59 PM](https://github.com/MetaMask/metamask-extension/assets/39872794/9a44a1cd-50c8-4bf2-84fc-f517d47597b7)




### **After**
![Screenshot 2024-02-06 at 3 44 32 PM](https://github.com/MetaMask/metamask-extension/assets/39872794/6f88067b-efa2-415a-862b-bcd43f9f4e27)


## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've clearly explained what problem this PR is solving and how it is solved.
- [ ] I've linked related issues
- [ ] I've included manual testing steps
- [ ] I've included screenshots/recordings if applicable
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [ ] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
