### PR TITLE
Updating zkSync Block Explorer URL

### DIFF
--- a/shared/constants/network.ts
+++ b/shared/constants/network.ts
@@ -993,7 +993,7 @@ export const FEATURED_RPCS: RPCDefinition[] = [
     rpcUrl: `https://mainnet.era.zksync.io`,
     ticker: CURRENCY_SYMBOLS.ETH,
     rpcPrefs: {
-      blockExplorerUrl: 'https://explorer.zksync.io/',
+      blockExplorerUrl: 'https://era.zksync.network/',
       imageUrl: ZK_SYNC_ERA_TOKEN_IMAGE_URL,
     },
   },

--- a/shared/constants/swaps.ts
+++ b/shared/constants/swaps.ts
@@ -161,7 +161,7 @@ const POLYGON_DEFAULT_BLOCK_EXPLORER_URL = 'https://polygonscan.com/';
 const AVALANCHE_DEFAULT_BLOCK_EXPLORER_URL = 'https://snowtrace.io/';
 const OPTIMISM_DEFAULT_BLOCK_EXPLORER_URL = 'https://optimistic.etherscan.io/';
 const ARBITRUM_DEFAULT_BLOCK_EXPLORER_URL = 'https://arbiscan.io/';
-const ZKSYNC_DEFAULT_BLOCK_EXPLORER_URL = 'https://explorer.zksync.io/';
+const ZKSYNC_DEFAULT_BLOCK_EXPLORER_URL = 'https://era.zksync.network/';
 const LINEA_DEFAULT_BLOCK_EXPLORER_URL = 'https://lineascan.build/';
 
 export const SMART_SWAPS_FAQ_AND_RISK_DISCLOSURES_URL =


### PR DESCRIPTION
## **Description**

<!--
zkSync's official block explorer has changed to one that uses Etherscan's indexing + UX. We would like Metamask UI to point to this one over the prior one.

1. What is the reason for the change? While our existing natively-built blockchain explorer works well, we know developers and users are more comfortable with Etherscan UX.
2. What is the improvement/solution? In response, we have partnered with Etherscan to use their solution for the zkSync ERA network. This explorer lives at the new URL.
-->

## **Related issues**

Fixes: N/A

## **Manual testing steps**

1. Go to metamask
2. Switch your network to zkSync ERA
3. Click on the ... button on the top right and click on "View on Explorer". Ensure it redirects to era.zksync.network.

## **Screenshots/Recordings**


### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've clearly explained what problem this PR is solving and how it is solved.
- [ ] I've linked related issues
- [ ] I've included manual testing steps
- [ ] I've included screenshots/recordings if applicable
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [ ] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
