### PR TITLE
fix details overflow in banner alert for long strings

### DIFF
--- a/ui/components/app/security-provider-banner-alert/blockaid-banner-alert/__snapshots__/blockaid-banner-alert.test.js.snap
+++ b/ui/components/app/security-provider-banner-alert/blockaid-banner-alert/__snapshots__/blockaid-banner-alert.test.js.snap
@@ -414,7 +414,7 @@ exports[`Blockaid Banner Alert should render details when provided 1`] = `
             class="disclosure__content normal"
           >
             <ul
-              class="mm-box mm-text mm-text--body-md mm-text--overflow-wrap-break-word mm-box--color-text-default"
+              class="mm-box mm-text mm-text--body-md mm-text--overflow-wrap-anywhere mm-box--color-text-default"
             >
               <li>
                 • 

--- a/ui/components/app/security-provider-banner-alert/blockaid-banner-alert/blockaid-banner-alert.js
+++ b/ui/components/app/security-provider-banner-alert/blockaid-banner-alert/blockaid-banner-alert.js
@@ -89,7 +89,7 @@ function BlockaidBannerAlert({ txData, ...props }) {
   );
 
   const details = features?.length ? (
-    <Text as="ul" overflowWrap={OverflowWrap.BreakWord}>
+    <Text as="ul" overflowWrap={OverflowWrap.Anywhere}>
       {features.map((feature, i) => (
         <li key={`blockaid-detail-${i}`}>• {feature}</li>
       ))}


### PR DESCRIPTION
Fixes #22792

## **Description**
When unfolding details with long strings (i.e. an address) in the Blockaid banner alert, the banner style is affected in a bad way, see screenshots below.

The solution is to use:
overflow-wrap: anywhere; 
instead of:
overflow-wrap: break-word; 

Have tested for macos 10.15.7 on the following browsers:
  Brave: 1.62.156 Chromium: 121.0.6167.139
  Firefox: 122.0.1
  Chrome : 121.0.6167.160
  Edge: 121.0.2277.106

## **Manual testing steps**

1. Enable Blockaid (Settings > Experimental > Blockaid)
2. Select 
3. Ethereum Mainnet
4. Go to the test dapp [](https://metamask.github.io/test-dapp/)
5. Trigger 'Sign Permit'
6. Click 'See details'

## **Screenshots**

### **Before**
![22792_folded](https://github.com/MetaMask/metamask-extension/assets/3285576/0b7cb623-b6be-42b4-b0ae-605f5cae6e16)
![22792_before_unfolded](https://github.com/MetaMask/metamask-extension/assets/3285576/da342934-b8ea-4e1e-b90b-5b03c0075f4a)


### **After**
![22792_after_unfolded](https://github.com/MetaMask/metamask-extension/assets/3285576/7eb151be-f179-4c72-86dc-4efc6683733f)


## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained what problem this PR is solving and how it is solved.
- [x] I've linked related issues
- [x] I've included manual testing steps
- [x] I've included screenshots/recordings if applicable
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [ ] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
