### PR TITLE
Fix `getIsLocked` hook

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -4907,7 +4907,7 @@ export default class MetamaskController extends EventEmitter {
           origin,
         ),
         getIsLocked: () => {
-          return !this.appStateController.isUnlocked;
+          return !this.appStateController.isUnlocked();
         },
         ///: END:ONLY_INCLUDE_IF
         ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)


### PR DESCRIPTION
## **Description**

This fixes the `getIsLocked` hook, which would previously always return `false`. We were using the result of `appStateController.isUnlocked`, but that's a function rather than a boolean.