### PR TITLE
Stop doing ppom validation on metamask swaps

### DIFF
--- a/app/scripts/lib/transaction/util.test.ts
+++ b/app/scripts/lib/transaction/util.test.ts
@@ -425,6 +425,50 @@ describe('Transaction Utils', () => {
 
         expect(request.ppomController.usePPOM).toHaveBeenCalledTimes(0);
       });
+
+      it('does not validate if blockaid is enabled and chain id is supported, but transaction type is swap', async () => {
+        const swapRequest = { ...request };
+        swapRequest.transactionOptions.type = TransactionType.swap;
+        await addTransaction({
+          ...swapRequest,
+          securityAlertsEnabled: true,
+          chainId: '0x1',
+        });
+
+        expect(
+          request.transactionController.addTransaction,
+        ).toHaveBeenCalledTimes(1);
+        expect(
+          request.transactionController.addTransaction,
+        ).toHaveBeenCalledWith(TRANSACTION_PARAMS_MOCK, {
+          ...TRANSACTION_OPTIONS_MOCK,
+          type: TransactionType.swap,
+        });
+
+        expect(request.ppomController.usePPOM).toHaveBeenCalledTimes(0);
+      });
+
+      it('does not validate if blockaid is enabled and chain id is supported, but transaction type is swapApproval', async () => {
+        const swapRequest = { ...request };
+        swapRequest.transactionOptions.type = TransactionType.swapApproval;
+        await addTransaction({
+          ...swapRequest,
+          securityAlertsEnabled: true,
+          chainId: '0x1',
+        });
+
+        expect(
+          request.transactionController.addTransaction,
+        ).toHaveBeenCalledTimes(1);
+        expect(
+          request.transactionController.addTransaction,
+        ).toHaveBeenCalledWith(TRANSACTION_PARAMS_MOCK, {
+          ...TRANSACTION_OPTIONS_MOCK,
+          type: TransactionType.swapApproval,
+        });
+
+        expect(request.ppomController.usePPOM).toHaveBeenCalledTimes(0);
+      });
     });
 
     describe('when blockaid is disabled', () => {

--- a/app/scripts/lib/transaction/util.ts
+++ b/app/scripts/lib/transaction/util.ts
@@ -109,6 +109,11 @@ export async function addDappTransaction(
   return (await waitForHash()) as string;
 }
 
+const PPOM_EXCLUDED_TRANSACTION_TYPES = [
+  TransactionType.swap,
+  TransactionType.swapApproval,
+];
+
 export async function addTransaction(
   request: AddTransactionRequest,
   ///: BEGIN:ONLY_INCLUDE_IF(blockaid)
@@ -127,7 +132,11 @@ export async function addTransaction(
     chainId,
   } = request;
 
-  if (securityAlertsEnabled && SUPPORTED_CHAIN_IDS.includes(chainId)) {
+  if (
+    securityAlertsEnabled &&
+    SUPPORTED_CHAIN_IDS.includes(chainId) &&
+    !PPOM_EXCLUDED_TRANSACTION_TYPES.includes(transactionOptions.type)
+  ) {
     try {
       const ppomRequest = {
         method: 'eth_sendTransaction',

--- a/app/scripts/lib/transaction/util.ts
+++ b/app/scripts/lib/transaction/util.ts
@@ -109,10 +109,12 @@ export async function addDappTransaction(
   return (await waitForHash()) as string;
 }
 
+///: BEGIN:ONLY_INCLUDE_IF(blockaid)
 const PPOM_EXCLUDED_TRANSACTION_TYPES = [
   TransactionType.swap,
   TransactionType.swapApproval,
 ];
+///: END:ONLY_INCLUDE_IF
 
 export async function addTransaction(
   request: AddTransactionRequest,

--- a/app/scripts/lib/transaction/util.ts
+++ b/app/scripts/lib/transaction/util.ts
@@ -132,10 +132,14 @@ export async function addTransaction(
     chainId,
   } = request;
 
+  const typeIsExcludedFromPPOM =
+    transactionOptions.type &&
+    PPOM_EXCLUDED_TRANSACTION_TYPES.includes(transactionOptions.type);
+
   if (
     securityAlertsEnabled &&
     SUPPORTED_CHAIN_IDS.includes(chainId) &&
-    !PPOM_EXCLUDED_TRANSACTION_TYPES.includes(transactionOptions.type)
+    !typeIsExcludedFromPPOM
   ) {
     try {
       const ppomRequest = {


### PR DESCRIPTION
## **Description**

We do not need to validate MetaMask swaps with our ppom validation because we know they are safe (they go to a smart contract we control). Doing this validation on swaps has a performance cost and an unnecessary cost on the provider.

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/22791

## **Manual testing steps**

1. Perform a swap
2. Inspect state logs to verify that there is no `securityAlertResponse` property on the transaction metadata
3. Perform a simple send
4. Inspect state logs to verify that there is a `securityAlertResponse` property on the transaction metadata

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained what problem this PR is solving and how it is solved.
- [x] I've linked related issues
- [x] I've included manual testing steps
- [x] I've included screenshots/recordings if applicable
- [x] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [ ] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
