### PR TITLE
Cherry pick hook fix to RC

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -4861,7 +4861,7 @@ export default class MetamaskController extends EventEmitter {
           origin,
         ),
         getIsLocked: () => {
-          return !this.appStateController.isUnlocked;
+          return !this.appStateController.isUnlocked();
         },
         ///: END:ONLY_INCLUDE_IF
         ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)


### PR DESCRIPTION
## **Description**

Cherry-picks https://github.com/MetaMask/metamask-extension/commit/8ec8643f3f975ddccbe2b623d038d13f8e5bda78 to the RC.

This fixes the `getIsLocked` hook, which would previously always return `false`. We were using the result of `appStateController.isUnlocked`, but that's a function rather than a boolean.
