### PR TITLE
Add deprecated comment on `displayWarning`

### DIFF
--- a/ui/store/actions.ts
+++ b/ui/store/actions.ts
@@ -2147,7 +2147,7 @@ export function createCancelTransaction(
         [txId, customGasSettings, { ...options, actionId }],
         (err, newState) => {
           if (err) {
-            // dispatch(displayWarning(err));
+            dispatch(displayWarning(err));
             reject(err);
             return;
           }

--- a/ui/store/actions.ts
+++ b/ui/store/actions.ts
@@ -2639,9 +2639,14 @@ export function hideLoadingIndication(): Action {
 }
 
 /**
- * @param payload - The error message to display.
- * @deprecated The `displayWarning` function is now obsolete and does not impact the UI.
- * This action is currently unused and is slated for removal in upcoming versions.
+ * An action creator for display a warning to the user in various places in the
+ * UI. It will not be cleared until a new warning replaces it or `hideWarning`
+ * is called.
+ *
+ * @deprecated This way of displaying a warning is confusing for users and
+ * should no longer be used.
+ * @param {string} text - The warning text to show.
+ * @returns The action to display the warning.
  */
 export function displayWarning(payload: unknown): PayloadAction<string> {
   if (isErrorWithMessage(payload)) {

--- a/ui/store/actions.ts
+++ b/ui/store/actions.ts
@@ -2639,6 +2639,7 @@ export function hideLoadingIndication(): Action {
 }
 
 /**
+ * @param payload - The error message to display.
  * @deprecated The `displayWarning` function is now obsolete and does not impact the UI.
  * This action is currently unused and is slated for removal in upcoming versions.
  */

--- a/ui/store/actions.ts
+++ b/ui/store/actions.ts
@@ -2147,7 +2147,7 @@ export function createCancelTransaction(
         [txId, customGasSettings, { ...options, actionId }],
         (err, newState) => {
           if (err) {
-            dispatch(displayWarning(err));
+            // dispatch(displayWarning(err));
             reject(err);
             return;
           }
@@ -2638,6 +2638,10 @@ export function hideLoadingIndication(): Action {
   };
 }
 
+/**
+ * @deprecated The `displayWarning` function is now obsolete and does not impact the UI.
+ * This action is currently unused and is slated for removal in upcoming versions.
+ */
 export function displayWarning(payload: unknown): PayloadAction<string> {
   if (isErrorWithMessage(payload)) {
     return {

--- a/ui/store/actions.ts
+++ b/ui/store/actions.ts
@@ -2645,7 +2645,7 @@ export function hideLoadingIndication(): Action {
  *
  * @deprecated This way of displaying a warning is confusing for users and
  * should no longer be used.
- * @param text - The warning text to show.
+ * @param payload - The warning to show.
  * @returns The action to display the warning.
  */
 export function displayWarning(payload: unknown): PayloadAction<string> {

--- a/ui/store/actions.ts
+++ b/ui/store/actions.ts
@@ -2645,7 +2645,7 @@ export function hideLoadingIndication(): Action {
  *
  * @deprecated This way of displaying a warning is confusing for users and
  * should no longer be used.
- * @param {string} text - The warning text to show.
+ * @param text - The warning text to show.
  * @returns The action to display the warning.
  */
 export function displayWarning(payload: unknown): PayloadAction<string> {


### PR DESCRIPTION
## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR aims to mark `displayWarning` as deprecated. 

## **Related issues**

N/A

## **Manual testing steps**

No functional change

## **Screenshots/Recordings**

N/A

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've clearly explained what problem this PR is solving and how it is solved.
- [ ] I've linked related issues
- [ ] I've included manual testing steps
- [ ] I've included screenshots/recordings if applicable
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [ ] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
