### PR TITLE
Fix `useTransactionInsightSnaps`

### DIFF
--- a/ui/hooks/snaps/useTransactionInsightSnaps.js
+++ b/ui/hooks/snaps/useTransactionInsightSnaps.js
@@ -90,7 +90,7 @@ export function useTransactionInsightSnaps({
         ///: END:ONLY_INCLUDE_IF
       }
     }
-    if (transaction) {
+    if (transaction && Object.keys(transaction).length > 0) {
       fetchInsight();
     }
     return () => {


### PR DESCRIPTION
The hook would just check if the transaction param is truthy, when it could be an empty object. Updated the check to account for that.