### PR TITLE
Ad/fix selected network controller domain setting

### DIFF
--- a/app/scripts/lib/rpc-method-middleware/handlers/switch-ethereum-chain.js
+++ b/app/scripts/lib/rpc-method-middleware/handlers/switch-ethereum-chain.js
@@ -26,7 +26,6 @@ const switchEthereumChain = {
     setActiveNetwork: true,
     requestUserApproval: true,
     getNetworkConfigurations: true,
-    getNetworkClientIdForDomain: true,
     getProviderConfig: true,
   },
 };

--- a/app/scripts/migrations/110.test.ts
+++ b/app/scripts/migrations/110.test.ts
@@ -1,0 +1,132 @@
+import { migrate, version } from './110';
+
+describe('migration #110', () => {
+  it('updates the version metadata', async () => {
+    const oldStorage = {
+      meta: { version: 109 },
+      data: {},
+    };
+
+    const newStorage = await migrate(oldStorage);
+
+    expect(newStorage.meta).toStrictEqual({ version });
+  });
+
+  it('does nothing if SelectedNetworkController is not present', async () => {
+    const oldState = {
+      OtherController: {},
+    };
+
+    const transformedState = await migrate({
+      meta: { version: 109 },
+      data: oldState,
+    });
+
+    expect(transformedState.data).toEqual(oldState);
+  });
+
+  it('resets domains if SelectedNetworkController state is present', async () => {
+    const oldState = {
+      SelectedNetworkController: {
+        domains: {
+          metamask: 'ropsten',
+          otherDomain: 'value',
+        },
+      },
+    };
+
+    const expectedState = {
+      SelectedNetworkController: {
+        domains: {
+          metamask: 'ropsten', // Should keep existing metamask domain
+        },
+      },
+    };
+
+    const transformedState = await migrate({
+      meta: { version: 109 },
+      data: oldState,
+    });
+
+    expect(transformedState.data).toEqual(expectedState);
+  });
+
+  it('sets metamask domain if already present', async () => {
+    const oldState = {
+      SelectedNetworkController: {
+        domains: {
+          metamask: 'value',
+        },
+      },
+    };
+
+    const expectedState = {
+      SelectedNetworkController: {
+        domains: {
+          metamask: 'value',
+        },
+      },
+    };
+
+    const transformedState = await migrate({
+      meta: { version: 109 },
+      data: oldState,
+    });
+
+    expect(transformedState.data).toEqual(expectedState);
+  });
+
+  it('does nothing to domains if already only contains metamask with correct value', async () => {
+    const oldState = {
+      SelectedNetworkController: {
+        domains: {
+          metamask: 'mainnet',
+        },
+      },
+    };
+
+    const expectedState = {
+      ...oldState, // No change expected
+    };
+
+    const transformedState = await migrate({
+      meta: { version: 109 },
+      data: oldState,
+    });
+
+    expect(transformedState.data).toEqual(expectedState);
+  });
+
+  it('handles complex state transformations correctly', async () => {
+    const oldState = {
+      SelectedNetworkController: {
+        domains: {
+          metamask: 'kovan',
+          otherDomain1: 'value1',
+          otherDomain2: 'value2',
+        },
+      },
+      OtherController: {
+        someData: 'dataValue',
+      },
+    };
+
+    const expectedState = {
+      SelectedNetworkController: {
+        domains: {
+          metamask: 'kovan', // Only keep the metamask domain
+        },
+      },
+      OtherController: {
+        someData: 'dataValue', // Other data remains unchanged
+      },
+    };
+
+    const transformedState = await migrate({
+      meta: { version: 109 },
+      data: oldState,
+    });
+
+    expect(transformedState.data).toEqual(expectedState);
+  });
+});

--- a/app/scripts/migrations/110.ts
+++ b/app/scripts/migrations/110.ts
@@ -1,0 +1,51 @@
+import { cloneDeep } from 'lodash';
+import { hasProperty, isObject } from '@metamask/utils';
+import { SelectedNetworkControllerState } from '@metamask/selected-network-controller';
+
+type VersionedData = {
+  meta: { version: number };
+  data: Record<string, unknown>;
+};
+
+export const version = 110;
+
+/**
+ * Reset all values for SelectedNetworkController.state.domains
+ * These values are associated with an experimental feature flag and should be reset before proceeding with
+ * the feature development.
+ *
+ * @param originalVersionedData - Versioned MetaMask extension state, exactly what we persist to dist.
+ * @param originalVersionedData.meta - State metadata.
+ * @param originalVersionedData.meta.version - The current state version.
+ * @param originalVersionedData.data - The persisted MetaMask state, keyed by controller.
+ * @returns Updated versioned MetaMask extension state.
+ */
+export async function migrate(
+  originalVersionedData: VersionedData,
+): Promise<VersionedData> {
+  const versionedData = cloneDeep(originalVersionedData);
+  versionedData.meta.version = version;
+  transformState(versionedData.data);
+  return versionedData;
+}
+
+function transformState(state: Record<string, any>) {
+  if (
+    !hasProperty(state, 'SelectedNetworkController') ||
+    !isObject(state.SelectedNetworkController) ||
+    !hasProperty(state.SelectedNetworkController, 'domains') ||
+    !isObject(state.SelectedNetworkController.domains)
+  ) {
+    return state;
+  }
+
+  const domains: SelectedNetworkControllerState['domains'] = {};
+  if (state.SelectedNetworkController.domains.metamask) {
+    (domains as any).metamask =
+      state.SelectedNetworkController.domains.metamask;
+  }
+
+  state.SelectedNetworkController.domains = domains;
+
+  return state;
+}

--- a/app/scripts/migrations/index.js
+++ b/app/scripts/migrations/index.js
@@ -120,6 +120,7 @@ const migrations = [
   require('./107'),
   require('./108'),
   require('./109'),
+  require('./110'),
 ];
 
 export default migrations;

--- a/package.json
+++ b/package.json
@@ -218,7 +218,8 @@
     "nonce-tracker@npm:^3.0.0": "patch:nonce-tracker@npm%3A3.0.0#~/.yarn/patches/nonce-tracker-npm-3.0.0-c5e9a93f9d.patch",
     "@trezor/connect-web": "9.0.11",
     "lavamoat-core@npm:^15.1.1": "patch:lavamoat-core@npm%3A15.1.1#~/.yarn/patches/lavamoat-core-npm-15.1.1-51fbe39988.patch",
-    "tar-stream@npm:^3.1.6": "patch:tar-stream@npm%3A3.1.6#~/.yarn/patches/tar-stream-npm-3.1.6-ce3ac17e49.patch"
+    "tar-stream@npm:^3.1.6": "patch:tar-stream@npm%3A3.1.6#~/.yarn/patches/tar-stream-npm-3.1.6-ce3ac17e49.patch",
+    "socks": "^2.7.3"
   },
   "dependencies": {
     "@babel/runtime": "^7.23.2",
@@ -289,7 +290,7 @@
     "@metamask/rate-limit-controller": "^3.0.0",
     "@metamask/safe-event-emitter": "^2.0.0",
     "@metamask/scure-bip39": "^2.0.3",
-    "@metamask/selected-network-controller": "^6.0.0",
+    "@metamask/selected-network-controller": "^8.0.0",
     "@metamask/signature-controller": "^12.0.0",
     "@metamask/smart-transactions-controller": "^6.2.2",
     "@metamask/snaps-controllers": "^4.1.0",

--- a/ui/components/ui/new-network-info/new-network-info.js
+++ b/ui/components/ui/new-network-info/new-network-info.js
@@ -42,29 +42,29 @@ export default function NewNetworkInfo() {
     setFirstTimeUsedNetwork(providerConfig.chainId);
   };
 
-  const checkTokenDetection = useCallback(async () => {
-    try {
-      const fetchedTokenData = await fetchWithCache({
-        url: `${TOKEN_API_METASWAP_CODEFI_URL}${providerConfig.chainId}`,
-        functionName: 'getIsTokenDetectionSupported',
-      });
-      const isTokenDetectionSupported = !fetchedTokenData?.error;
-      setTokenDetectionSupported(isTokenDetectionSupported);
-      setIsLoading(false);
-    } catch {
-      // If there's any error coming from getIsTokenDetectionSupported
-      // we would like to catch this error and simply return false for the state
-      // and this will be handled in UI naturally
-      setTokenDetectionSupported(false);
-      setIsLoading(false);
-    }
-  }, [providerConfig.chainId]);
+  // const checkTokenDetection = useCallback(async () => {
+  //   try {
+  //     const fetchedTokenData = await fetchWithCache({
+  //       url: `${TOKEN_API_METASWAP_CODEFI_URL}${providerConfig.chainId}`,
+  //       functionName: 'getIsTokenDetectionSupported',
+  //     });
+  //     const isTokenDetectionSupported = !fetchedTokenData?.error;
+  //     setTokenDetectionSupported(isTokenDetectionSupported);
+  //     setIsLoading(false);
+  //   } catch {
+  //     // If there's any error coming from getIsTokenDetectionSupported
+  //     // we would like to catch this error and simply return false for the state
+  //     // and this will be handled in UI naturally
+  //     setTokenDetectionSupported(false);
+  //     setIsLoading(false);
+  //   }
+  // }, [providerConfig.chainId]);
 
-  useEffect(() => {
-    checkTokenDetection();
-    // we want to only fetch once
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  // useEffect(() => {
+  //   checkTokenDetection();
+  //   // we want to only fetch once
+  //   // eslint-disable-next-line react-hooks/exhaustive-deps
+  // }, []);
 
   return (
     !isLoading &&

--- a/yarn.lock
+++ b/yarn.lock
@@ -4709,18 +4709,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/selected-network-controller@npm:^6.0.0":
-  version: 6.0.0
-  resolution: "@metamask/selected-network-controller@npm:6.0.0"
+"@metamask/selected-network-controller@file:../core/packages/selected-network-controller::locator=metamask-crx%40workspace%3A.":
+  version: 8.0.0
+  resolution: "@metamask/selected-network-controller@file:../core/packages/selected-network-controller#../core/packages/selected-network-controller::hash=0e02d7&locator=metamask-crx%40workspace%3A."
   dependencies:
-    "@metamask/base-controller": "npm:^4.0.1"
-    "@metamask/json-rpc-engine": "npm:^7.3.1"
-    "@metamask/network-controller": "npm:^17.1.0"
-    "@metamask/swappable-obj-proxy": "npm:^2.1.0"
-    "@metamask/utils": "npm:^8.2.0"
+    "@metamask/base-controller": "npm:^4.1.1"
+    "@metamask/json-rpc-engine": "npm:^7.3.2"
+    "@metamask/network-controller": "npm:^17.2.0"
+    "@metamask/swappable-obj-proxy": "npm:^2.2.0"
+    "@metamask/utils": "npm:^8.3.0"
   peerDependencies:
-    "@metamask/network-controller": ^17.1.0
-  checksum: 06108b93af648cbb8bed337459e579f1a314cd0d1d8405e4a9501a5933c961664170bdb9022dbbbb08066b577869b07b6f00f84a3076b3ae8fdc2fc8c4ea4c9c
+    "@metamask/network-controller": ^17.2.0
+  checksum: 7675d6c587dd5c967a9857b35d25cf9c2a96889841e7362f599cf2a5c653447eca1a0476e58cde78f5eb2296dc2a46075fe40ca70ec474dc2eaec4c056728d5e
   languageName: node
   linkType: hard
 
@@ -24136,7 +24136,7 @@ __metadata:
     "@metamask/rate-limit-controller": "npm:^3.0.0"
     "@metamask/safe-event-emitter": "npm:^2.0.0"
     "@metamask/scure-bip39": "npm:^2.0.3"
-    "@metamask/selected-network-controller": "npm:^6.0.0"
+    "@metamask/selected-network-controller": "npm:^8.0.0"
     "@metamask/signature-controller": "npm:^12.0.0"
     "@metamask/smart-transactions-controller": "npm:^6.2.2"
     "@metamask/snaps-controllers": "npm:^4.1.0"
@@ -31003,7 +31003,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"socks@npm:^2.6.1, socks@npm:^2.6.2, socks@npm:^2.7.1":
+"socks@npm:^2.7.3":
   version: 2.8.0
   resolution: "socks@npm:2.8.0"
   dependencies:


### PR DESCRIPTION
Currently the `SelectedNetworkController` adds any and all domains the user visits to its `domains` state whether or not the user has connected to these sites. This PR cleans up the undesired state caused by this bug and adds a check for existing permissions for an origin before adding it to `domains` state going forward