### PR TITLE
Add support for ENS on Sepolia

### DIFF
--- a/package.json
+++ b/package.json
@@ -330,7 +330,7 @@
     "eth-method-registry": "^3.0.0",
     "eth-rpc-errors": "^4.0.2",
     "eth-sig-util": "^3.0.0",
-    "ethereum-ens-network-map": "^1.0.2",
+    "ethereum-ens-network-map": "npm:@optidomains/ethereum-ens-network-map@2.0.0",
     "ethereumjs-abi": "^0.6.4",
     "ethereumjs-util": "^7.0.10",
     "extension-port-stream": "^3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -16802,10 +16802,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ethereum-ens-network-map@npm:^1.0.2":
-  version: 1.0.2
-  resolution: "ethereum-ens-network-map@npm:1.0.2"
-  checksum: 34fa160f2b1ee8ec31bfe3dcec7b4becd4a6110acde171f43b9c28e0adc126dbded9dc6747d03088b6c99f04582887e6a23cb24b718321712c85208965835ea1
+"ethereum-ens-network-map@npm:@optidomains/ethereum-ens-network-map@2.0.0":
+  version: 2.0.0
+  resolution: "@optidomains/ethereum-ens-network-map@npm:2.0.0"
+  checksum: 1c95d0a32227697f01b74c6c62100317d64f8113dce9c029b0c19604b017a4cc097d96a3c7a77acd6ccc799d47a14ba5bd2133d0af165f195a55693d833d9a59
   languageName: node
   linkType: hard
 
@@ -24184,7 +24184,7 @@ __metadata:
     eth-method-registry: "npm:^3.0.0"
     eth-rpc-errors: "npm:^4.0.2"
     eth-sig-util: "npm:^3.0.0"
-    ethereum-ens-network-map: "npm:^1.0.2"
+    ethereum-ens-network-map: "npm:@optidomains/ethereum-ens-network-map@2.0.0"
     ethereumjs-abi: "npm:^0.6.4"
     ethereumjs-util: "npm:^7.0.10"
     extension-port-stream: "npm:^3.0.0"


### PR DESCRIPTION
## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This pull request introduces support for ENS exclusively on Sepolia, without including any other domains. We achieved this by switching the `ethereum-ens-network-map` package to our own fork, `npm:@optidomains/ethereum-ens-network-map@2.0.0`.

We have opted for an exact package version to ensure safety, preventing the package from being secretly updated without the Metamask team's approval.

The `ethereum-ens-network-map` package has been left unmaintained for years. By merging this pull request, we commit to maintaining the package moving forward, including but not limited to supporting any ENS domain name in the future, such as those on the Holesky testnet.

## **Related issues**

Fixes: #22797

## **Manual testing steps**

1. Open the extension. The Welcome Back screen is displayed.
2. Proceed to unlock the wallet with a password (minimum of 8 characters). The Ether balance and wallet address are displayed on the overview, with the selected network being Ethereum Mainnet.
3. Switch networks to a test network, such as Sepolia. The Sepolia balance and wallet address are displayed on the overview, with the selected network being Sepolia.
4. Proceed to the Send flow.
5. Enter an ENS address, for example, chomtana.eth. A matching result appears in the recipient list, showing both the ENS address and the hexadecimal address.
6. Select the matching recipient. The send screen displays the ENS and hexadecimal addresses in the recipient field.
7. Enter an amount, for example, 0.01.
8. Proceed to the confirmation screen. The recipient's ENS address is displayed.
9. Confirm the transaction. The transaction is then listed in the activity list.

For e2e testing, I don't think additional e2e tests are needed.

The current one in ens.spec.js with mock infura should be sufficient.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="261" alt="image" src="https://github.com/MetaMask/metamask-extension/assets/4103490/19268589-b41a-4ace-bf00-ed2d8e484063">

https://github.com/MetaMask/metamask-extension/assets/4103490/eb665b5f-a63c-4bdd-ac06-544b38594278

### **After**

<img width="263" alt="image" src="https://github.com/MetaMask/metamask-extension/assets/4103490/80edd111-897e-4f1e-918d-4d1dfd499bfc">

<img width="261" alt="image" src="https://github.com/MetaMask/metamask-extension/assets/4103490/e9422df5-c8f2-4801-ab6b-125cf56e9909">

https://github.com/MetaMask/metamask-extension/assets/4103490/718316c3-4a79-472d-b5ea-275bea715684

## **Pre-merge author checklist**

- [X] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've clearly explained what problem this PR is solving and how it is solved.
- [X] I've linked related issues
- [X] I've included manual testing steps
- [X] I've included screenshots/recordings if applicable
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [X] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [X] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [X] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [X] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
