### PR TITLE
Simplify logic to disconnect from a snap

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -3165,7 +3165,10 @@ export default class MetamaskController extends EventEmitter {
       ),
       dismissNotifications: this.dismissNotifications.bind(this),
       markNotificationsAsRead: this.markNotificationsAsRead.bind(this),
-      updateCaveat: this.updateCaveat.bind(this),
+      disconnectOriginFromSnap: this.controllerMessenger.call.bind(
+        this.controllerMessenger,
+        'SnapController:disconnectOrigin',
+      ),
       updateNetworksList: this.updateNetworksList.bind(this),
       updateAccountsList: this.updateAccountsList.bind(this),
       updateHiddenAccountsList: this.updateHiddenAccountsList.bind(this),

--- a/ui/components/app/connected-sites-list/connected-snaps.js
+++ b/ui/components/app/connected-sites-list/connected-snaps.js
@@ -15,9 +15,7 @@ import {
   TextVariant,
 } from '../../../helpers/constants/design-system';
 import ConnectedAccountsListOptions from '../connected-accounts-list/connected-accounts-list-options';
-import {
-  getOriginOfCurrentTab,
-} from '../../../selectors';
+import { getOriginOfCurrentTab } from '../../../selectors';
 import { disconnectOriginFromSnap } from '../../../store/actions';
 import { getSnapRoute } from '../../../helpers/utils/util';
 

--- a/ui/components/app/connected-sites-list/connected-snaps.js
+++ b/ui/components/app/connected-sites-list/connected-snaps.js
@@ -1,9 +1,7 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { useHistory } from 'react-router-dom';
-import { WALLET_SNAP_PERMISSION_KEY } from '@metamask/snaps-utils';
 import { useDispatch, useSelector } from 'react-redux';
-import { SnapCaveatType } from '@metamask/snaps-rpc-methods';
 import { Box, IconName, IconSize, Text } from '../../component-library';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import { MenuItem } from '../../ui/menu';
@@ -19,9 +17,8 @@ import {
 import ConnectedAccountsListOptions from '../connected-accounts-list/connected-accounts-list-options';
 import {
   getOriginOfCurrentTab,
-  getPermissionSubjects,
 } from '../../../selectors';
-import { removePermissionsFor, updateCaveat } from '../../../store/actions';
+import { disconnectOriginFromSnap } from '../../../store/actions';
 import { getSnapRoute } from '../../../helpers/utils/util';
 
 export default function ConnectedSnaps({ connectedSubjects }) {
@@ -29,31 +26,10 @@ export default function ConnectedSnaps({ connectedSubjects }) {
   const t = useI18nContext();
   const history = useHistory();
   const dispatch = useDispatch();
-  const subjects = useSelector(getPermissionSubjects);
   const connectedOrigin = useSelector(getOriginOfCurrentTab);
 
   const onDisconnect = (snapId) => {
-    const caveatValue =
-      subjects[connectedOrigin].permissions[WALLET_SNAP_PERMISSION_KEY]
-        .caveats[0].value;
-    const newCaveatValue = { ...caveatValue };
-    delete newCaveatValue[snapId];
-    if (Object.keys(newCaveatValue).length > 0) {
-      dispatch(
-        updateCaveat(
-          connectedOrigin,
-          WALLET_SNAP_PERMISSION_KEY,
-          SnapCaveatType.SnapIds,
-          newCaveatValue,
-        ),
-      );
-    } else {
-      dispatch(
-        removePermissionsFor({
-          [connectedOrigin]: [WALLET_SNAP_PERMISSION_KEY],
-        }),
-      );
-    }
+    dispatch(disconnectOriginFromSnap(connectedOrigin, snapId));
   };
 
   const renderListItemOptions = (snapId) => {

--- a/ui/pages/snaps/snap-view/snap-settings.js
+++ b/ui/pages/snaps/snap-view/snap-settings.js
@@ -30,8 +30,7 @@ import KeyringSnapRemovalWarning from '../../../components/app/snaps/keyring-sna
 ///: END:ONLY_INCLUDE_IF
 import {
   removeSnap,
-  removePermissionsFor,
-  updateCaveat,
+  disconnectOriginFromSnap,
   updateSnap,
   ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
   showKeyringSnapRemovalModal,
@@ -116,27 +115,7 @@ function SnapSettings({ snapId }) {
   ///: END:ONLY_INCLUDE_IF
 
   const onDisconnect = (connectedOrigin) => {
-    const caveatValue =
-      subjects[connectedOrigin].permissions[WALLET_SNAP_PERMISSION_KEY]
-        .caveats[0].value;
-    const newCaveatValue = { ...caveatValue };
-    delete newCaveatValue[snapId];
-    if (Object.keys(newCaveatValue).length > 0) {
-      dispatch(
-        updateCaveat(
-          connectedOrigin,
-          WALLET_SNAP_PERMISSION_KEY,
-          SnapCaveatType.SnapIds,
-          newCaveatValue,
-        ),
-      );
-    } else {
-      dispatch(
-        removePermissionsFor({
-          [connectedOrigin]: [WALLET_SNAP_PERMISSION_KEY],
-        }),
-      );
-    }
+    dispatch(disconnectOriginFromSnap(connectedOrigin, snap.id));
   };
 
   const snapName = getSnapName(snap.id, targetSubjectMetadata);

--- a/ui/pages/snaps/snap-view/snap-settings.js
+++ b/ui/pages/snaps/snap-view/snap-settings.js
@@ -6,10 +6,6 @@ import React, {
 } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
-import {
-  SnapCaveatType,
-  WALLET_SNAP_PERMISSION_KEY,
-} from '@metamask/snaps-rpc-methods';
 import { useHistory } from 'react-router-dom';
 import semver from 'semver';
 import { useI18nContext } from '../../../hooks/useI18nContext';

--- a/ui/pages/snaps/snap-view/snap-settings.js
+++ b/ui/pages/snaps/snap-view/snap-settings.js
@@ -37,7 +37,6 @@ import {
   getSnaps,
   getSubjectsWithSnapPermission,
   getPermissions,
-  getPermissionSubjects,
   getTargetSubjectMetadata,
   getSnapLatestVersion,
   ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
@@ -88,14 +87,13 @@ function SnapSettings({ snapId }) {
   const permissions = useSelector(
     (state) => snap && getPermissions(state, snap.id),
   );
-  const subjects = useSelector((state) => getPermissionSubjects(state));
   const targetSubjectMetadata = useSelector((state) =>
     getTargetSubjectMetadata(state, snap?.id),
   );
 
   let isKeyringSnap = false;
   ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
-  isKeyringSnap = Boolean(subjects[snap?.id]?.permissions?.snap_manageAccounts);
+  isKeyringSnap = Boolean(permissions?.snap_manageAccounts);
 
   useEffect(() => {
     if (isKeyringSnap) {

--- a/ui/pages/snaps/snap-view/snap-view.test.js
+++ b/ui/pages/snaps/snap-view/snap-view.test.js
@@ -11,8 +11,7 @@ jest.mock('../../../store/actions.ts', () => {
     disableSnap: jest.fn(),
     enableSnap: jest.fn(),
     removeSnap: jest.fn(),
-    removePermissionsFor: jest.fn(),
-    updateCaveat: jest.fn(),
+    disconnectOriginFromSnap: jest.fn(),
     getPhishingResult: jest.fn().mockImplementation(() => {
       return {
         result: false,

--- a/ui/store/actions.ts
+++ b/ui/store/actions.ts
@@ -1294,6 +1294,15 @@ export function revokeDynamicSnapPermissions(
   };
 }
 
+/**
+ * Disconnects a given origin from a snap.
+ *
+ * This revokes the permission granted to the origin
+ * that provides the capability to communicate with a snap.
+ *
+ * @param origin - The origin.
+ * @param snapId - The snap ID.
+ */
 export function disconnectOriginFromSnap(
   origin: string,
   snapId: string,

--- a/ui/store/actions.ts
+++ b/ui/store/actions.ts
@@ -1294,6 +1294,16 @@ export function revokeDynamicSnapPermissions(
   };
 }
 
+export function disconnectOriginFromSnap(
+  origin: string,
+  snapId: string,
+): ThunkAction<void, MetaMaskReduxState, unknown, AnyAction> {
+  return async (dispatch: MetaMaskReduxDispatch) => {
+    await submitRequestToBackground('disconnectOriginFromSnap', [origin, snapId]);
+    await forceUpdateMetamaskState(dispatch);
+  };
+}
+
 ///: END:ONLY_INCLUDE_IF
 ///: BEGIN:ONLY_INCLUDE_IF(desktop)
 
@@ -3690,35 +3700,6 @@ export function updateHiddenAccountsList(
     ]);
   };
 }
-
-///: BEGIN:ONLY_INCLUDE_IF(snaps)
-/**
- * Updates the caveat value for the specified origin, permission and caveat type.
- *
- * @param origin
- * @param target
- * @param caveatType
- * @param caveatValue
- */
-export function updateCaveat(
-  origin: string,
-  target: string,
-  caveatType: string,
-  caveatValue: Record<string, Json>,
-): ThunkAction<void, MetaMaskReduxState, unknown, AnyAction> {
-  return (dispatch) => {
-    callBackgroundMethod(
-      'updateCaveat',
-      [origin, target, caveatType, caveatValue],
-      (err) => {
-        if (err) {
-          dispatch(displayWarning(err));
-        }
-      },
-    );
-  };
-}
-///: END:ONLY_INCLUDE_IF
 
 // Pending Approvals
 

--- a/ui/store/actions.ts
+++ b/ui/store/actions.ts
@@ -1299,7 +1299,10 @@ export function disconnectOriginFromSnap(
   snapId: string,
 ): ThunkAction<void, MetaMaskReduxState, unknown, AnyAction> {
   return async (dispatch: MetaMaskReduxDispatch) => {
-    await submitRequestToBackground('disconnectOriginFromSnap', [origin, snapId]);
+    await submitRequestToBackground('disconnectOriginFromSnap', [
+      origin,
+      snapId,
+    ]);
     await forceUpdateMetamaskState(dispatch);
   };
 }


### PR DESCRIPTION
## **Description**

Simplifies the logic required to disconnect from a snap by leveraging upstreamed logic in the SnapController. This means that we can remove duplicated high-complexity code from a few places in the codebase and just let the SnapController handle the request instead.

There should be no functional changes from this change.

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/18451

## **Manual testing steps**

1. Install a snap from [snaps.metamask.io](https://snaps.metamask.io/)
2. Disconnect from the snap via the settings menu
3. Install another snap from [snaps.metamask.io](https://snaps.metamask.io/)
4. Disconnect from the snap via the "connected sites menu"
