### PR TITLE
test/e2e: allow overriding some browser settings via env vars

### DIFF
--- a/.metamaskrc.dist
+++ b/.metamaskrc.dist
@@ -14,3 +14,10 @@ INFURA_PROJECT_ID=00000000000
 ;PHISHING_WARNING_PAGE_URL=
 BLOCKAID_FILE_CDN=
 BLOCKAID_PUBLIC_KEY=
+
+; Change this to override built-in intercepting https proxy for e2e tests
+; SELENIUM_HTTPS_PROXY='http://127.0.0.1:8000'
+; Set this to 1 to make e2e tests run browser in headless mode
+; SELENIUM_HEADLESS=
+; Set this to 1 to make chrome e2e tests disable DoH/DoT and use system DNS
+; SELENIUM_USE_SYSTEM_DNS=

--- a/test/e2e/webdriver/chrome.js
+++ b/test/e2e/webdriver/chrome.js
@@ -7,7 +7,9 @@ const { ThenableWebDriver } = require('selenium-webdriver'); // eslint-disable-l
  *
  * @type {string}
  */
-const HTTPS_PROXY_HOST = '127.0.0.1:8000';
+const HTTPS_PROXY_HOST = `${
+  process.env.SELENIUM_HTTPS_PROXY || '127.0.0.1:8000'
+}`;
 
 /**
  * A wrapper around a {@code WebDriver} instance exposing Chrome-specific functionality
@@ -34,11 +36,21 @@ class ChromeDriver {
     } else {
       args.push('--log-level=3');
     }
+    if (process.env.SELENIUM_HEADLESS) {
+      args.push('--headless=new');
+    }
     const options = new chrome.Options().addArguments(args);
     options.setAcceptInsecureCerts(true);
     options.setUserPreferences({
       'download.default_directory': `${process.cwd()}/test-artifacts/downloads`,
     });
+    // Allow disabling DoT local testing
+    if (process.env.SELENIUM_DISABLE_DOT) {
+      options.setLocalState({
+        'dns_over_https.mode': 'off',
+        'dns_over_https.templates': '',
+      });
+    }
     const builder = new Builder()
       .forBrowser('chrome')
       .setChromeOptions(options);

--- a/test/e2e/webdriver/chrome.js
+++ b/test/e2e/webdriver/chrome.js
@@ -16,7 +16,11 @@ const HTTPS_PROXY_HOST = `${
  */
 class ChromeDriver {
   static async build({ openDevToolsForTabs, port }) {
-    const args = [`--proxy-server=${HTTPS_PROXY_HOST}`]; // Set proxy in the way that doesn't interfere with Selenium Manager
+    const args = [
+      `--proxy-server=${HTTPS_PROXY_HOST}`, // Set proxy in the way that doesn't interfere with Selenium Manager
+      '--disable-features=OptimizationGuideModelDownloading,OptimizationHintsFetching,OptimizationTargetPredicition,OptimizationHints,NetworkTimeServiceQuerying',  // Stop chrome from calling home so much (auto-downloads of AI models; time sync)
+      '--disable-component-update', // Stop chrome from calling home so much (auto-update)
+    ];
 
     if (process.env.MULTIPROVIDER) {
       args.push(

--- a/test/e2e/webdriver/chrome.js
+++ b/test/e2e/webdriver/chrome.js
@@ -41,6 +41,8 @@ class ChromeDriver {
       args.push('--log-level=3');
     }
     if (process.env.SELENIUM_HEADLESS) {
+      // TODO: Remove notice and consider non-experimental when results are consistent
+      console.warn('*** Running e2e tests in headless mode is experimental and some tests are known to fail for unknown reasons');
       args.push('--headless=new');
     }
     const options = new chrome.Options().addArguments(args);

--- a/test/e2e/webdriver/chrome.js
+++ b/test/e2e/webdriver/chrome.js
@@ -42,7 +42,9 @@ class ChromeDriver {
     }
     if (process.env.SELENIUM_HEADLESS) {
       // TODO: Remove notice and consider non-experimental when results are consistent
-      console.warn('*** Running e2e tests in headless mode is experimental and some tests are known to fail for unknown reasons');
+      console.warn(
+        '*** Running e2e tests in headless mode is experimental and some tests are known to fail for unknown reasons',
+      );
       args.push('--headless=new');
     }
     const options = new chrome.Options().addArguments(args);

--- a/test/e2e/webdriver/chrome.js
+++ b/test/e2e/webdriver/chrome.js
@@ -51,7 +51,7 @@ class ChromeDriver {
       'download.default_directory': `${process.cwd()}/test-artifacts/downloads`,
     });
     // Allow disabling DoT local testing
-    if (process.env.SELENIUM_DISABLE_DOT) {
+    if (process.env.SELENIUM_USE_SYSTEM_DN) {
       options.setLocalState({
         'dns_over_https.mode': 'off',
         'dns_over_https.templates': '',

--- a/test/e2e/webdriver/chrome.js
+++ b/test/e2e/webdriver/chrome.js
@@ -18,7 +18,7 @@ class ChromeDriver {
   static async build({ openDevToolsForTabs, port }) {
     const args = [
       `--proxy-server=${HTTPS_PROXY_HOST}`, // Set proxy in the way that doesn't interfere with Selenium Manager
-      '--disable-features=OptimizationGuideModelDownloading,OptimizationHintsFetching,OptimizationTargetPredicition,OptimizationHints,NetworkTimeServiceQuerying',  // Stop chrome from calling home so much (auto-downloads of AI models; time sync)
+      '--disable-features=OptimizationGuideModelDownloading,OptimizationHintsFetching,OptimizationTargetPredicition,OptimizationHints,NetworkTimeServiceQuerying', // Stop chrome from calling home so much (auto-downloads of AI models; time sync)
       '--disable-component-update', // Stop chrome from calling home so much (auto-update)
     ];
 

--- a/test/e2e/webdriver/firefox.js
+++ b/test/e2e/webdriver/firefox.js
@@ -21,7 +21,9 @@ const TEMP_PROFILE_PATH_PREFIX = path.join(os.tmpdir(), 'MetaMask-Fx-Profile');
 /**
  * Proxy host to use for HTTPS requests
  */
-const HTTPS_PROXY_HOST = { ip: '127.0.0.1', port: 8000 };
+const HTTPS_PROXY_HOST = new URL(
+  process.env.SELENIUM_HTTPS_PROXY || 'http://127.0.0.1:8000',
+);
 
 /**
  * A wrapper around a {@code WebDriver} instance exposing Firefox-specific functionality
@@ -41,8 +43,11 @@ class FirefoxDriver {
 
     // Set proxy in the way that doesn't interfere with Selenium Manager
     options.setPreference('network.proxy.type', 1);
-    options.setPreference('network.proxy.ssl', HTTPS_PROXY_HOST.ip);
-    options.setPreference('network.proxy.ssl_port', HTTPS_PROXY_HOST.port);
+    options.setPreference('network.proxy.ssl', HTTPS_PROXY_HOST.hostname);
+    options.setPreference(
+      'network.proxy.ssl_port',
+      parseInt(HTTPS_PROXY_HOST.port, 10),
+    );
 
     options.setAcceptInsecureCerts(true);
     options.setPreference('browser.download.folderList', 2);
@@ -52,6 +57,9 @@ class FirefoxDriver {
     );
     if (process.env.CI === 'true') {
       options.setBinary('/opt/firefox/firefox');
+    }
+    if (process.env.SELENIUM_HEADLESS) {
+      options.headless();
     }
     const builder = new Builder()
       .forBrowser('firefox')

--- a/test/e2e/webdriver/firefox.js
+++ b/test/e2e/webdriver/firefox.js
@@ -59,6 +59,8 @@ class FirefoxDriver {
       options.setBinary('/opt/firefox/firefox');
     }
     if (process.env.SELENIUM_HEADLESS) {
+      // TODO: Remove notice and consider non-experimental when results are consistent
+      console.warn('*** Running e2e tests in headless mode is experimental and some tests are known to fail for unknown reasons');
       options.headless();
     }
     const builder = new Builder()

--- a/test/e2e/webdriver/firefox.js
+++ b/test/e2e/webdriver/firefox.js
@@ -60,7 +60,9 @@ class FirefoxDriver {
     }
     if (process.env.SELENIUM_HEADLESS) {
       // TODO: Remove notice and consider non-experimental when results are consistent
-      console.warn('*** Running e2e tests in headless mode is experimental and some tests are known to fail for unknown reasons');
+      console.warn(
+        '*** Running e2e tests in headless mode is experimental and some tests are known to fail for unknown reasons',
+      );
       options.headless();
     }
     const builder = new Builder()


### PR DESCRIPTION
## **Description**

Allow configuring some browser behavior for local e2e testing using the following environment variables:

- Override https proxy: `SELENIUM_HTTPS_PROXY`
- Disable DNS-over-TLS for chromium (using system DNS): `SELENIUM_USE_SYSTEM_DNS`
- Enable headless mode: `SELENIUM_HEADLESS`

Also disables some unnecessary phoning-home to Google servers by chromium during testing.

## **Related issues**

Fixes:

## **Manual testing steps**

1. Create test build: `yarn build:test`
2. Start a local http proxy listening on e.g. `127.0.0.1:1234`
3. chromium: Initiate headless e2e test with DoT disabled `SELENIUM_HTTPS_PROXY=http://127.0.0.1:1234 SELENIUM_USE_SYSTEM_DNS=1 SELENIUM_HEADLESS=1 yarn test:e2e:chrome --build-type main`
  - observe queries hitting your proxy, tests executing with no browser window opening, and no DoT requests being made
4. firefox: Initiate headless e2e test: `SELENIUM_HTTPS_PROXY=http://127.0.0.1:1234  SELENIUM_HEADLESS=1 yarn test:e2e:firefox --build-type main`
  - observe queries hitting your proxy, tests executing with no browser window opening


## **Screenshots/Recordings**

### **Before**


### **After**


## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained what problem this PR is solving and how it is solved.
- [x] I've linked related issues
- [x] I've included manual testing steps
- [x] I've included screenshots/recordings if applicable
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [x] I’ve properly set the pull request status:
  - [x] In case it's not yet "ready for review", I've set it to "draft".
  - [x] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
