### PR TITLE
feat(Snaps Dynamic Permissions): Adds support for Snaps dynamic permissions

### DIFF
--- a/app/_locales/de/messages.json
+++ b/app/_locales/de/messages.json
@@ -358,9 +358,6 @@
   "allowThisSiteTo": {
     "message": "Erlauben Sie dieser Seite:"
   },
-  "allowThisSnapTo": {
-    "message": "Erlauben Sie diesem Snap Folgendes:"
-  },
   "allowWithdrawAndSpend": {
     "message": "$1 erlauben, bis zu dem folgenden Betrag abzuheben und auszugeben:",
     "description": "The url of the site that requested permission to 'withdraw and spend'"

--- a/app/_locales/el/messages.json
+++ b/app/_locales/el/messages.json
@@ -358,9 +358,6 @@
   "allowThisSiteTo": {
     "message": "Επιτρέψτε σε αυτόν τον ιστότοπο να:"
   },
-  "allowThisSnapTo": {
-    "message": "Επιτρέψτε αυτό το snap να:"
-  },
   "allowWithdrawAndSpend": {
     "message": "Επιτρέψτε στο $1 να κάνει ανάληψη και να ξοδέψει μέχρι το ακόλουθο ποσό:",
     "description": "The url of the site that requested permission to 'withdraw and spend'"

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -4394,6 +4394,10 @@
     "message": "$1 wants to connect to $2. Only continue if you trust this website.",
     "description": "$2 is the snap and $1 is the dapp requesting connection to the snap."
   },
+  "snapPermissionRequestWarning": {
+    "message": "$1 are requesting the following permissions. Only continue if you trust $2.",
+    "description": "$1 is a Snap name, $2 is the Snap name."
+  },
   "snapConnections": {
     "message": "Snap Connections"
   },

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -385,9 +385,6 @@
   "allowThisSiteTo": {
     "message": "Allow this site to:"
   },
-  "allowThisSnapTo": {
-    "message": "Allow this snap to:"
-  },
   "allowWithdrawAndSpend": {
     "message": "Allow $1 to withdraw and spend up to the following amount:",
     "description": "The url of the site that requested permission to 'withdraw and spend'"
@@ -4394,10 +4391,6 @@
     "message": "$1 wants to connect to $2. Only continue if you trust this website.",
     "description": "$2 is the snap and $1 is the dapp requesting connection to the snap."
   },
-  "snapPermissionRequestWarning": {
-    "message": "$1 are requesting the following permissions. Only continue if you trust $2.",
-    "description": "$1 is a Snap name, $2 is the Snap name."
-  },
   "snapConnections": {
     "message": "Snap Connections"
   },
@@ -4445,6 +4438,10 @@
   "snapInstallationErrorTitle": {
     "message": "Installation failed",
     "description": "Error title used when snap installation fails."
+  },
+  "snapPermissionRequestWarning": {
+    "message": "$1 are requesting the following permissions. Only continue if you trust $2.",
+    "description": "$1 is a Snap name, $2 is the Snap name."
   },
   "snapResultError": {
     "message": "Error"

--- a/app/_locales/es/messages.json
+++ b/app/_locales/es/messages.json
@@ -358,9 +358,6 @@
   "allowThisSiteTo": {
     "message": "Permitir que este sitio haga lo siguiente:"
   },
-  "allowThisSnapTo": {
-    "message": "Permitir que este snap haga:"
-  },
   "allowWithdrawAndSpend": {
     "message": "Permitir que se retire $1 y gastar hasta el siguiente importe:",
     "description": "The url of the site that requested permission to 'withdraw and spend'"

--- a/app/_locales/fr/messages.json
+++ b/app/_locales/fr/messages.json
@@ -358,9 +358,6 @@
   "allowThisSiteTo": {
     "message": "Autoriser ce site à :"
   },
-  "allowThisSnapTo": {
-    "message": "Autoriser ce snap à :"
-  },
   "allowWithdrawAndSpend": {
     "message": "Permettre à $1 de retirer et de dépenser jusqu’au montant suivant :",
     "description": "The url of the site that requested permission to 'withdraw and spend'"

--- a/app/_locales/hi/messages.json
+++ b/app/_locales/hi/messages.json
@@ -358,9 +358,6 @@
   "allowThisSiteTo": {
     "message": "इस साइट को इसकी अनुमति दें:"
   },
-  "allowThisSnapTo": {
-    "message": "इस Snap को इसकी अनुमति दें:"
-  },
   "allowWithdrawAndSpend": {
     "message": "$1 को निम्नलिखित तक अमाउंट निकालने और खर्च करने की अनुमति दें:",
     "description": "The url of the site that requested permission to 'withdraw and spend'"

--- a/app/_locales/id/messages.json
+++ b/app/_locales/id/messages.json
@@ -358,9 +358,6 @@
   "allowThisSiteTo": {
     "message": "Izinkan situs ini untuk:"
   },
-  "allowThisSnapTo": {
-    "message": "Izinkan snap ini untuk:"
-  },
   "allowWithdrawAndSpend": {
     "message": "Izinkan $1 untuk menarik dan menggunakan hingga jumlah berikut:",
     "description": "The url of the site that requested permission to 'withdraw and spend'"

--- a/app/_locales/ja/messages.json
+++ b/app/_locales/ja/messages.json
@@ -358,9 +358,6 @@
   "allowThisSiteTo": {
     "message": "このサイトに次の操作を許可します"
   },
-  "allowThisSnapTo": {
-    "message": "このsnapに次の操作を許可します:"
-  },
   "allowWithdrawAndSpend": {
     "message": "$1に以下の額までの引き出しと使用を許可します。",
     "description": "The url of the site that requested permission to 'withdraw and spend'"

--- a/app/_locales/ko/messages.json
+++ b/app/_locales/ko/messages.json
@@ -358,9 +358,6 @@
   "allowThisSiteTo": {
     "message": "다음에 이 사이트를 허용:"
   },
-  "allowThisSnapTo": {
-    "message": "다음에 이 스냅을 허용:"
-  },
   "allowWithdrawAndSpend": {
     "message": "$1에서 다음 금액까지 인출 및 지출하도록 허용:",
     "description": "The url of the site that requested permission to 'withdraw and spend'"

--- a/app/_locales/pt/messages.json
+++ b/app/_locales/pt/messages.json
@@ -358,9 +358,6 @@
   "allowThisSiteTo": {
     "message": "Permitir que esse site:"
   },
-  "allowThisSnapTo": {
-    "message": "Permitir que esse snap:"
-  },
   "allowWithdrawAndSpend": {
     "message": "Permitir que $1 saque e gaste até o seguinte valor:",
     "description": "The url of the site that requested permission to 'withdraw and spend'"

--- a/app/_locales/ru/messages.json
+++ b/app/_locales/ru/messages.json
@@ -358,9 +358,6 @@
   "allowThisSiteTo": {
     "message": "Разрешить этому сайту:"
   },
-  "allowThisSnapTo": {
-    "message": "Разрешить этот snap к:"
-  },
   "allowWithdrawAndSpend": {
     "message": "Разрешить $1 снять и потратить до следующей суммы:",
     "description": "The url of the site that requested permission to 'withdraw and spend'"

--- a/app/_locales/tl/messages.json
+++ b/app/_locales/tl/messages.json
@@ -358,9 +358,6 @@
   "allowThisSiteTo": {
     "message": "Payagan ang site na ito na:"
   },
-  "allowThisSnapTo": {
-    "message": "Payagan ang snap na ito sa:"
-  },
   "allowWithdrawAndSpend": {
     "message": "Payagan ang $1 na mag-withdraw at gastusin ang sumusunod na halaga:",
     "description": "The url of the site that requested permission to 'withdraw and spend'"

--- a/app/_locales/tr/messages.json
+++ b/app/_locales/tr/messages.json
@@ -358,9 +358,6 @@
   "allowThisSiteTo": {
     "message": "Bu sitenin şunu yapmasına izin ver:"
   },
-  "allowThisSnapTo": {
-    "message": "Bu snap için şuna izin verin:"
-  },
   "allowWithdrawAndSpend": {
     "message": "$1 için şu tutara kadar para çekme ve harcama izni ver:",
     "description": "The url of the site that requested permission to 'withdraw and spend'"

--- a/app/_locales/vi/messages.json
+++ b/app/_locales/vi/messages.json
@@ -358,9 +358,6 @@
   "allowThisSiteTo": {
     "message": "Cho phép trang web này:"
   },
-  "allowThisSnapTo": {
-    "message": "Cho phép Snap này:"
-  },
   "allowWithdrawAndSpend": {
     "message": "Cho phép $1 rút và chi tiêu tối đa số tiền sau đây:",
     "description": "The url of the site that requested permission to 'withdraw and spend'"

--- a/app/_locales/zh_CN/messages.json
+++ b/app/_locales/zh_CN/messages.json
@@ -358,9 +358,6 @@
   "allowThisSiteTo": {
     "message": "允许此网站："
   },
-  "allowThisSnapTo": {
-    "message": "允许此 Snap："
-  },
   "allowWithdrawAndSpend": {
     "message": "允许 $1 提取和消费最高以下金额：",
     "description": "The url of the site that requested permission to 'withdraw and spend'"

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -4897,9 +4897,9 @@ export default class MetamaskController extends EventEmitter {
             { origin },
             requestedPermissions,
           ),
-        revokePermissions: async (revokedPermissions) => {
+        revokePermissions: (revokedPermissions) => {
           const revokeParams = { [origin]: revokedPermissions };
-          await this.permissionController.revokePermissions(revokeParams);
+          this.permissionController.revokePermissions(revokeParams);
         },
         getPermissions: this.permissionController.getPermissions.bind(
           this.permissionController,

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -4897,6 +4897,10 @@ export default class MetamaskController extends EventEmitter {
             { origin },
             requestedPermissions,
           ),
+        revokePermissions: async (revokedPermissions) => {
+          const revokeParams = { [origin]: revokedPermissions };
+          await this.permissionController.revokePermissions(revokeParams);
+        },
         getPermissions: this.permissionController.getPermissions.bind(
           this.permissionController,
           origin,
@@ -4914,6 +4918,11 @@ export default class MetamaskController extends EventEmitter {
         getIsLocked: () => {
           return !this.appStateController.isUnlocked();
         },
+        getOriginSnap: this.controllerMessenger.call.bind(
+          this.controllerMessenger,
+          'SnapController:get',
+          origin,
+        ),
         ///: END:ONLY_INCLUDE_IF
         ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
         hasPermission: this.permissionController.hasPermission.bind(

--- a/ui/components/app/permission-page-container/index.scss
+++ b/ui/components/app/permission-page-container/index.scss
@@ -44,8 +44,6 @@
     overflow-y: auto;
     flex-direction: column;
     color: var(--color-text-default);
-    padding-left: 24px;
-    padding-right: 24px;
     margin-top: 2px;
 
     a,
@@ -92,12 +90,12 @@
     color: var(--color-text-default);
   }
 
-  &__permissions-container {
-    width: 100%;
-    display: flex;
-    flex-direction: column;
-    margin-top: 38px;
-  }
+  //&__permissions-container {
+  //  width: 100%;
+  //  display: flex;
+  //  flex-direction: column;
+  //  margin-top: 38px;
+  //}
 
   @include screen-sm-max {
     &__title {

--- a/ui/components/app/permission-page-container/permission-page-container-content/permission-page-container-content.component.js
+++ b/ui/components/app/permission-page-container/permission-page-container-content/permission-page-container-content.component.js
@@ -6,6 +6,13 @@ import { SubjectType } from '@metamask/permission-controller';
 import PermissionsConnectHeader from '../../permissions-connect-header';
 import Tooltip from '../../../ui/tooltip';
 import PermissionsConnectPermissionList from '../../permissions-connect-permission-list';
+import { getSnapName } from '../../../../helpers/utils/util';
+import { Text, Box } from '../../../component-library';
+import {
+  Display,
+  FontWeight,
+  TextVariant,
+} from '../../../../helpers/constants/design-system';
 
 export default class PermissionPageContainerContent extends PureComponent {
   static propTypes = {
@@ -34,12 +41,10 @@ export default class PermissionPageContainerContent extends PureComponent {
     const { selectedPermissions, subjectMetadata } = this.props;
 
     return (
-      <div className="permission-approval-container__content__requested">
-        <PermissionsConnectPermissionList
-          permissions={selectedPermissions}
-          targetSubjectMetadata={subjectMetadata}
-        />
-      </div>
+      <PermissionsConnectPermissionList
+        permissions={selectedPermissions}
+        targetSubjectMetadata={subjectMetadata}
+      />
     );
   }
 
@@ -105,7 +110,28 @@ export default class PermissionPageContainerContent extends PureComponent {
 
     ///: BEGIN:ONLY_INCLUDE_IF(snaps)
     if (subjectMetadata.subjectType === SubjectType.Snap) {
-      return t('allowThisSnapTo');
+      const snapFriendlyName = getSnapName(
+        subjectMetadata.origin,
+        subjectMetadata,
+      );
+      return t('snapPermissionRequestWarning', [
+        <Text
+          as="span"
+          key="snapNameFirstTime"
+          variant={TextVariant.bodyMd}
+          fontWeight={FontWeight.Medium}
+        >
+          {snapFriendlyName}
+        </Text>,
+        <Text
+          as="span"
+          key="snapNameSecondTime"
+          variant={TextVariant.bodyMd}
+          fontWeight={FontWeight.Medium}
+        >
+          {snapFriendlyName}
+        </Text>,
+      ]);
     }
     ///: END:ONLY_INCLUDE_IF
 
@@ -132,9 +158,7 @@ export default class PermissionPageContainerContent extends PureComponent {
             siteOrigin={subjectMetadata.origin}
             subjectType={subjectMetadata.subjectType}
           />
-          <section className="permission-approval-container__permissions-container">
-            {this.renderRequestedPermissions()}
-          </section>
+          <Box display={Display.Flex}>{this.renderRequestedPermissions()}</Box>
         </div>
       </div>
     );

--- a/ui/components/app/permission-page-container/permission-page-container.component.js
+++ b/ui/components/app/permission-page-container/permission-page-container.component.js
@@ -198,7 +198,11 @@ export default class PermissionPageContainer extends Component {
             onCancel={() => this.onCancel()}
             cancelText={this.context.t('cancel')}
             onSubmit={() => this.onSubmit()}
-            submitText={this.context.t('connect')}
+            submitText={
+              targetSubjectMetadata?.subjectType === SubjectType.Snap
+                ? this.context.t('confirm')
+                : this.context.t('connect')
+            }
             buttonSizeLarge={false}
           />
         </div>

--- a/ui/components/app/permissions-connect-header/permissions-connect-header.component.js
+++ b/ui/components/app/permissions-connect-header/permissions-connect-header.component.js
@@ -5,11 +5,12 @@ import classnames from 'classnames';
 import { SubjectType } from '@metamask/permission-controller';
 ///: END:ONLY_INCLUDE_IF
 import SiteOrigin from '../../ui/site-origin';
-import Box from '../../ui/box';
 import {
-  FLEX_DIRECTION,
+  Display,
+  FlexDirection,
   JustifyContent,
 } from '../../../helpers/constants/design-system';
+import { Box } from '../../component-library';
 
 export default class PermissionsConnectHeader extends Component {
   static propTypes = {
@@ -71,8 +72,11 @@ export default class PermissionsConnectHeader extends Component {
     return (
       <Box
         className={classnames('permissions-connect-header', className)}
-        flexDirection={FLEX_DIRECTION.COLUMN}
+        display={Display.Flex}
+        flexDirection={FlexDirection.Column}
         justifyContent={JustifyContent.center}
+        paddingLeft={6}
+        paddingRight={6}
         {...boxProps}
       >
         {this.renderHeaderIcon()}

--- a/ui/components/app/permissions-connect-permission-list/index.scss
+++ b/ui/components/app/permissions-connect-permission-list/index.scss
@@ -1,5 +1,8 @@
 .permissions-connect-permission-list {
   width: 100%;
+  margin-top: 38px;
+  padding-left: 24px;
+  padding-right: 24px;
 
   .permission {
     @include H6;

--- a/ui/components/app/permissions-connect-permission-list/permissions-connect-permission-list.js
+++ b/ui/components/app/permissions-connect-permission-list/permissions-connect-permission-list.js
@@ -1,10 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { SubjectType } from '@metamask/permission-controller';
 import {
   getRightIcon,
   getWeightedPermissions,
 } from '../../../helpers/utils/permission';
 import { useI18nContext } from '../../../hooks/useI18nContext';
+import SnapPermissionsList from '../snaps/snap-permissions-list';
 
 /**
  * Get one or more permission descriptions for a permission name.
@@ -31,7 +33,13 @@ export default function PermissionsConnectPermissionList({
 }) {
   const t = useI18nContext();
 
-  return (
+  return targetSubjectMetadata.subjectType === SubjectType.Snap ? (
+    <SnapPermissionsList
+      snapId={targetSubjectMetadata.origin}
+      permissions={permissions || {}}
+      targetSubjectMetadata={targetSubjectMetadata}
+    />
+  ) : (
     <div className="permissions-connect-permission-list">
       {getWeightedPermissions(t, permissions, targetSubjectMetadata).map(
         getDescriptionNode,


### PR DESCRIPTION
## **Description**
The purpose of this PR is to enable **Snaps Dynamic Permissions** feature.
This PR adds missing hooks required by the `Dynamic Permissions` feature and adds additional changes to the UI to correctly support Dynamic Permissions requests in approval popup.

Related PR: https://github.com/MetaMask/snaps/pull/2088

Dynamic Permissions feature is specified in [SIP-14](https://github.com/MetaMask/SIPs/blob/main/SIPS/sip-14.md).

## Rules to follow before merging this PR
**Merge this PR only into the release PR of Snaps packages that contain changes on the related PR for Snaps packages:** https://github.com/MetaMask/snaps/pull/2088

_Target PR: Snaps packages release._

**TODO:** Change target PR to the one that releases `Snaps` packages with `Dynamic Permissions`.

## **Related issues**
Related task: https://github.com/MetaMask/snaps/issues/1821

## **Manual testing steps**
1. Create a Snap example that invokes following RPC methods: `snap_requestPermissions`, `snap_getPermissions`, `snap_revokePermissions`.
2. Test each of the method invocations.
3. When requesting permissions, approval request popup should appear.
4. When revoking permissions, approval request popup **should not** appear.
5. Requested permissions should appear in the Snaps settings page only after approval.
6. Getting granted Snaps permissions is reserved for Snap only and will not be shown anywhere within MetaMask extension.

Snap code examples:
- snap_requestPermissions
```typescript
const premissionRequestResult = await snap.request({
    method: 'snap_requestPermissions',
    params: {
      'endowment:network-access': {},
      'endowment:webassembly': {},
      'endowment:ethereum-provider': {},
      snap_getBip44Entropy: [
        {
          coinType: 3,
        },
        {
          coinType: 1,
        },
      ],
    },
  });
```

- snap_getPermissions
```typescript
const permissions = await snap.request({
    method: 'snap_getPermissions',
});
```

- snap_revokePermissions
```typescript
const revokePermissionsResult = await snap.request({
    method: 'snap_revokePermissions',
    params: {
      'endowment:network-access': {},
      'endowment:webassembly': {},
      'endowment:ethereum-provider': {},
      snap_getBip44Entropy: [
        {
          coinType: 3,
        },
        {
          coinType: 1,
        },
      ],
    },
  });
```

## **Screenshots/Recordings**
### **Before**
TODO: Show to related screens which have the code living in the same components, etc.

### **After**
![Screenshot 2024-02-14 at 15 26 29](https://github.com/MetaMask/metamask-extension/assets/13301024/681a9aa4-a50b-4123-aeb5-2ed7b87a076c)

### End to end testing TODO
- Create new example Snap that uses `Dynamic Permissions` features (all three methods).
- Create e2e tests for testing `Dynamic Permissions` requests.

## **Pre-merge author checklist**
- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've clearly explained what problem this PR is solving and how it is solved.
- [ ] I've linked related issues
- [ ] I've included manual testing steps
- [ ] I've included screenshots/recordings if applicable
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [ ] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**
- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
