### PR TITLE
Update discover snaps CTA link

### DIFF
--- a/ui/pages/snaps/snaps-list/snap-list.js
+++ b/ui/pages/snaps/snaps-list/snap-list.js
@@ -153,11 +153,7 @@ const SnapList = () => {
                   >
                     <ButtonLink
                       size={Size.auto}
-                      href={
-                        snapsList.length > 0
-                          ? 'https://snaps.metamask.io/'
-                          : 'https://metamask.io/snaps/'
-                      }
+                      href="https://snaps.metamask.io/"
                       target="_blank"
                       endIconName={IconName.Export}
                     >


### PR DESCRIPTION
## **Description**


Updates the "discover snaps" CTA link to always point to snaps.metamask.io.

## **Related issues**

Fixes: https://github.com/MetaMask/snaps/issues/2180
