### PR TITLE
Fixes an issue cancelling a permission request

### DIFF
--- a/ui/components/app/permission-page-container/permission-page-container.component.js
+++ b/ui/components/app/permission-page-container/permission-page-container.component.js
@@ -57,7 +57,7 @@ export default class PermissionPageContainer extends Component {
   state = {};
 
   getRequestedPermissions() {
-    return Object.entries(this.props.request.permissions).reduce(
+    return Object.entries(this.props.request.permissions ?? {}).reduce(
       (acc, [permissionName, permissionValue]) => {
         ///: BEGIN:ONLY_INCLUDE_IF(snaps)
         if (permissionName === RestrictedMethods.wallet_snap) {


### PR DESCRIPTION
## **Description**

I introduced a bug in #22850 which can be reproduced by going to the test-dapp, starting a permission request flow, proceeding to the next screen and cancelling it again. This fixes the problem by guarding against `permissions` being `null`.

## **Manual testing steps**

1. Go to the test-dapp
2. Connect
3. Click next
4. Click cancel
5. See that the extension does not crash
