### PR TITLE
Add All Permissions button to global menu, metrics

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -389,6 +389,9 @@
     "message": "Allow $1 to withdraw and spend up to the following amount:",
     "description": "The url of the site that requested permission to 'withdraw and spend'"
   },
+  "allPermissions": {
+    "message": "All Permissions"
+  },
   "amount": {
     "message": "Amount"
   },

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -362,6 +362,9 @@
     "message": "All of your $1",
     "description": "$1 is the symbol or name of the token that the user is approving spending"
   },
+  "allPermissions": {
+    "message": "All Permissions"
+  },
   "allYourNFTsOf": {
     "message": "All of your NFTs from $1",
     "description": "$1 is a link to contract on the block explorer when we're not able to retrieve a erc721 or erc1155 name"
@@ -388,9 +391,6 @@
   "allowWithdrawAndSpend": {
     "message": "Allow $1 to withdraw and spend up to the following amount:",
     "description": "The url of the site that requested permission to 'withdraw and spend'"
-  },
-  "allPermissions": {
-    "message": "All Permissions"
   },
   "amount": {
     "message": "Amount"

--- a/shared/constants/metametrics.ts
+++ b/shared/constants/metametrics.ts
@@ -542,6 +542,7 @@ export enum MetaMetricsEventName {
   NavAccountDetailsOpened = 'Account Details Opened',
   NavConnectedSitesOpened = 'Connected Sites Opened',
   NavMainMenuOpened = 'Main Menu Opened',
+  NavPermissionsOpened = 'Permissions Opened',
   NavNetworkMenuOpened = 'Network Menu Opened',
   NavSettingsOpened = 'Settings Opened',
   NavAccountSwitched = 'Account Switched',

--- a/ui/components/multichain/global-menu/global-menu.js
+++ b/ui/components/multichain/global-menu/global-menu.js
@@ -9,6 +9,7 @@ import {
   ///: BEGIN:ONLY_INCLUDE_IF(snaps)
   NOTIFICATIONS_ROUTE,
   SNAPS_ROUTE,
+  PERMISSIONS,
   ///: END:ONLY_INCLUDE_IF(snaps)
 } from '../../../helpers/constants/routes';
 import { lockMetamask } from '../../../store/actions';
@@ -180,6 +181,25 @@ export const GlobalMenu = ({ closeMenu, anchorElement, isOpen }) => {
       >
         {t('connectedSites')}
       </MenuItem>
+      {process.env.MULTICHAIN ? (
+        <MenuItem
+          iconName={IconName.SecurityTick}
+          onClick={() => {
+            history.push(PERMISSIONS);
+            trackEvent({
+              event: MetaMetricsEventName.NavPermissionsOpened,
+              category: MetaMetricsEventCategory.Navigation,
+              properties: {
+                location: METRICS_LOCATION,
+              },
+            });
+            closeMenu();
+          }}
+          data-testid="global-menu-connected-sites"
+        >
+          {t('allPermissions')}
+        </MenuItem>
+      ) : null}
 
       {
         ///: BEGIN:ONLY_INCLUDE_IF(build-mmi)


### PR DESCRIPTION
## **Description**
Adding the button for All Permissions to the global menu, and relevant Metametrics.
TODO: We want a new story to remove Connected Sites and the global menu item to access it, during cleanup.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/1940

## **Manual testing steps**

1. yarn && MULTICHAIN=1 yarn start
2. open extension popup view
3. open global menu in top-right and verify that All Permissions is an option and it Navi

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**
![image](https://github.com/MetaMask/metamask-extension/assets/10986371/879830fe-4b73-49b1-8b1b-7d0ebe1af404)

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [X] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've clearly explained what problem this PR is solving and how it is solved.
- [X] I've linked related issues
- [X] I've included manual testing steps
- [X] I've included screenshots/recordings if applicable
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [X] I’ve properly set the pull request status:
  - [X] In case it's not yet "ready for review", I've set it to "draft".
  - [X] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
