### PR TITLE
fix: Blockaid disable disclosure scrollToBottom

### DIFF
--- a/ui/components/app/transaction-list-item-details/transaction-list-item-details.component.js
+++ b/ui/components/app/transaction-list-item-details/transaction-list-item-details.component.js
@@ -380,7 +380,11 @@ export default class TransactionListItemDetails extends PureComponent {
               }
               {transactionGroup.initialTransaction.type !==
                 TransactionType.incoming && (
-                <Disclosure title={t('activityLog')} size="small">
+                <Disclosure
+                  title={t('activityLog')}
+                  size="small"
+                  isScrollToBottomOnOpen
+                >
                   <TransactionActivityLog
                     transactionGroup={transactionGroup}
                     className="transaction-list-item-details__transaction-activity-log"

--- a/ui/components/ui/disclosure/__snapshots__/disclosure.test.js.snap
+++ b/ui/components/ui/disclosure/__snapshots__/disclosure.test.js.snap
@@ -4,6 +4,7 @@ exports[`Disclosure matches snapshot with title prop 1`] = `
 <div>
   <div
     class="disclosure"
+    data-testid="disclosure"
   >
     <details>
       <summary
@@ -32,6 +33,7 @@ exports[`Disclosure matches snapshot without title prop 1`] = `
 <div>
   <div
     class="disclosure"
+    data-testid="disclosure"
   >
     Test
   </div>

--- a/ui/components/ui/disclosure/__snapshots__/disclosure.test.js.snap
+++ b/ui/components/ui/disclosure/__snapshots__/disclosure.test.js.snap
@@ -1,0 +1,39 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Disclosure matches snapshot with title prop 1`] = `
+<div>
+  <div
+    class="disclosure"
+  >
+    <details>
+      <summary
+        class="disclosure__summary"
+      >
+        <span
+          class="mm-box disclosure__summary--icon mm-icon mm-icon--size-sm mm-box--margin-inline-end-2 mm-box--display-inline-block mm-box--color-inherit"
+          style="mask-image: url('./images/icons/add.svg');"
+        />
+        Test Title
+      </summary>
+      <div
+        class="disclosure__content small"
+      >
+        Test
+      </div>
+      <div
+        class="disclosure__footer"
+      />
+    </details>
+  </div>
+</div>
+`;
+
+exports[`Disclosure matches snapshot without title prop 1`] = `
+<div>
+  <div
+    class="disclosure"
+  >
+    Test
+  </div>
+</div>
+`;

--- a/ui/components/ui/disclosure/disclosure.js
+++ b/ui/components/ui/disclosure/disclosure.js
@@ -58,9 +58,7 @@ const Disclosure = ({
   const [open, setOpen] = useState(false);
 
   const scrollToBottom = () => {
-    disclosureFooterEl &&
-      disclosureFooterEl.current &&
-      disclosureFooterEl.current.scrollIntoView({ behavior: 'smooth' });
+    disclosureFooterEl?.current?.scrollIntoView({ behavior: 'smooth' });
   };
 
   useEffect(() => {

--- a/ui/components/ui/disclosure/disclosure.js
+++ b/ui/components/ui/disclosure/disclosure.js
@@ -47,7 +47,13 @@ const renderSummaryByType = (variant, title, size) => {
   }
 };
 
-const Disclosure = ({ children, title, size, variant }) => {
+const Disclosure = ({
+  children,
+  isScrollToBottomOnOpen,
+  title,
+  size,
+  variant,
+}) => {
   const disclosureFooterEl = useRef(null);
   const [open, setOpen] = useState(false);
 
@@ -58,10 +64,10 @@ const Disclosure = ({ children, title, size, variant }) => {
   };
 
   useEffect(() => {
-    if (open) {
+    if (isScrollToBottomOnOpen && open) {
       scrollToBottom();
     }
-  }, [open]);
+  }, [isScrollToBottomOnOpen, open]);
 
   return (
     <div className="disclosure" onClick={() => setOpen((state) => !state)}>
@@ -83,12 +89,14 @@ const Disclosure = ({ children, title, size, variant }) => {
 
 Disclosure.propTypes = {
   children: PropTypes.node.isRequired,
+  isScrollToBottomOnOpen: PropTypes.bool,
   size: PropTypes.string,
   title: PropTypes.string,
   variant: PropTypes.string,
 };
 
 Disclosure.defaultProps = {
+  isScrollToBottomOnOpen: false,
   size: 'normal',
   title: null,
   variant: DisclosureVariant.Default,

--- a/ui/components/ui/disclosure/disclosure.js
+++ b/ui/components/ui/disclosure/disclosure.js
@@ -70,7 +70,11 @@ const Disclosure = ({
   }, [isScrollToBottomOnOpen, open]);
 
   return (
-    <div className="disclosure" onClick={() => setOpen((state) => !state)}>
+    <div
+      className="disclosure"
+      data-testid="disclosure"
+      onClick={() => setOpen((state) => !state)}
+    >
       {title ? (
         <details>
           {renderSummaryByType(variant, title)}

--- a/ui/components/ui/disclosure/disclosure.test.js
+++ b/ui/components/ui/disclosure/disclosure.test.js
@@ -1,0 +1,97 @@
+import React, { useRef } from 'react';
+import { fireEvent, render, waitFor } from '@testing-library/react';
+import Disclosure from './disclosure';
+
+jest.mock('react', () => {
+  const originReact = jest.requireActual('react');
+  const mockUseRef = jest.fn();
+  return {
+    ...originReact,
+    useRef: mockUseRef,
+  };
+});
+
+describe('Disclosure', () => {
+  it('matches snapshot without title prop', () => {
+    const { container } = render(<Disclosure variant="">Test</Disclosure>);
+    expect(container).toMatchSnapshot();
+  });
+
+  it('matches snapshot with title prop', () => {
+    const { container } = render(
+      <Disclosure title="Test Title" size="small">
+        Test
+      </Disclosure>,
+    );
+    expect(container).toMatchSnapshot();
+  });
+
+  it('renders content', () => {
+    const { container, getByText, rerender } = render(
+      <Disclosure title="Test Title">Test</Disclosure>,
+    );
+    expect(getByText('Test Title')).toBeInTheDocument();
+    expect(container.querySelector('.disclosure__content').textContent).toBe(
+      'Test',
+    );
+
+    expect(
+      container.querySelector('.disclosure__content.normal'),
+    ).toBeInTheDocument();
+
+    rerender(
+      <Disclosure title="Test Title" size="small">
+        Test
+      </Disclosure>,
+    );
+
+    expect(
+      container.querySelector('.disclosure__content.small'),
+    ).toBeInTheDocument();
+  });
+
+  describe('when clicking on disclosure', () => {
+    it.skip('toggles open state', async () => {
+      const { container } = render(
+        <Disclosure title="Test Title">Test</Disclosure>,
+      );
+      const element = container.querySelector('.disclosure');
+      const elementDetails = container.querySelector('.disclosure > details');
+
+      expect(elementDetails).not.toHaveAttribute('open');
+      fireEvent.click(element);
+
+      await waitFor(() => {
+        expect(container.querySelector('details')).toHaveAttribute('open');
+      });
+    });
+
+    it('does not scroll down on open by default or when isScrollToBottomOnOpen is false', () => {
+      const spyScrollIntoView = jest.fn();
+      const mockRef = { current: { scrollIntoView: spyScrollIntoView } };
+      useRef.mockReturnValueOnce(mockRef);
+
+      const { container } = render(
+        <Disclosure title="Test Title">Test</Disclosure>,
+      );
+      const element = container.querySelector('.disclosure');
+      fireEvent.click(element);
+      expect(spyScrollIntoView).not.toHaveBeenCalled();
+    });
+
+    it.skip('scrolls down on open when isScrollToBottomOnOpen is true', () => {
+      const spyScrollIntoView = jest.fn();
+      const mockRef = { current: { scrollIntoView: spyScrollIntoView } };
+      useRef.mockReturnValueOnce(mockRef);
+
+      const { container } = render(
+        <Disclosure title="Test Title">Test</Disclosure>,
+      );
+      const element = container.querySelector('.disclosure');
+
+      expect(spyScrollIntoView).not.toHaveBeenCalled();
+      fireEvent.click(element);
+      expect(spyScrollIntoView).toHaveBeenCalled();
+    });
+  });
+});

--- a/ui/components/ui/disclosure/disclosure.test.js
+++ b/ui/components/ui/disclosure/disclosure.test.js
@@ -1,15 +1,6 @@
-import React, { useRef } from 'react';
-import { fireEvent, render, waitFor } from '@testing-library/react';
+import React from 'react';
+import { fireEvent, render } from '@testing-library/react';
 import Disclosure from './disclosure';
-
-jest.mock('react', () => {
-  const originReact = jest.requireActual('react');
-  const mockUseRef = jest.fn();
-  return {
-    ...originReact,
-    useRef: mockUseRef,
-  };
-});
 
 describe('Disclosure', () => {
   it('matches snapshot without title prop', () => {
@@ -51,47 +42,39 @@ describe('Disclosure', () => {
   });
 
   describe('when clicking on disclosure', () => {
-    it.skip('toggles open state', async () => {
-      const { container } = render(
-        <Disclosure title="Test Title">Test</Disclosure>,
-      );
-      const element = container.querySelector('.disclosure');
-      const elementDetails = container.querySelector('.disclosure > details');
-
-      expect(elementDetails).not.toHaveAttribute('open');
-      fireEvent.click(element);
-
-      await waitFor(() => {
-        expect(container.querySelector('details')).toHaveAttribute('open');
-      });
-    });
-
     it('does not scroll down on open by default or when isScrollToBottomOnOpen is false', () => {
-      const spyScrollIntoView = jest.fn();
-      const mockRef = { current: { scrollIntoView: spyScrollIntoView } };
-      useRef.mockReturnValueOnce(mockRef);
+      const mockScrollIntoView = jest.fn();
+      const originalScrollIntoView =
+        window.HTMLElement.prototype.scrollIntoView;
+      window.HTMLElement.prototype.scrollIntoView = mockScrollIntoView;
 
-      const { container } = render(
+      const { getByTestId } = render(
         <Disclosure title="Test Title">Test</Disclosure>,
       );
-      const element = container.querySelector('.disclosure');
+      const element = getByTestId('disclosure');
       fireEvent.click(element);
-      expect(spyScrollIntoView).not.toHaveBeenCalled();
+      expect(mockScrollIntoView).not.toHaveBeenCalled();
+      window.HTMLElement.prototype.scrollIntoView = originalScrollIntoView;
     });
 
-    it.skip('scrolls down on open when isScrollToBottomOnOpen is true', () => {
-      const spyScrollIntoView = jest.fn();
-      const mockRef = { current: { scrollIntoView: spyScrollIntoView } };
-      useRef.mockReturnValueOnce(mockRef);
+    it('scrolls down on open when isScrollToBottomOnOpen is true', () => {
+      const mockScrollIntoView = jest.fn();
+      const originalScrollIntoView =
+        window.HTMLElement.prototype.scrollIntoView;
+      window.HTMLElement.prototype.scrollIntoView = mockScrollIntoView;
 
-      const { container } = render(
-        <Disclosure title="Test Title">Test</Disclosure>,
+      const { getByTestId } = render(
+        <Disclosure title="Test Title" isScrollToBottomOnOpen>
+          Test
+        </Disclosure>,
       );
-      const element = container.querySelector('.disclosure');
+      const element = getByTestId('disclosure');
 
-      expect(spyScrollIntoView).not.toHaveBeenCalled();
       fireEvent.click(element);
-      expect(spyScrollIntoView).toHaveBeenCalled();
+      expect(mockScrollIntoView).toHaveBeenCalledWith({
+        behavior: 'smooth',
+      });
+      window.HTMLElement.prototype.scrollIntoView = originalScrollIntoView;
     });
   });
 });

--- a/ui/pages/confirmations/components/security-provider-banner-alert/__snapshots__/security-provider-banner-alert.test.js.snap
+++ b/ui/pages/confirmations/components/security-provider-banner-alert/__snapshots__/security-provider-banner-alert.test.js.snap
@@ -25,6 +25,7 @@ exports[`Security Provider Banner Alert should match snapshot 1`] = `
       </p>
       <div
         class="disclosure"
+        data-testid="disclosure"
       >
         <details>
           <summary
@@ -104,6 +105,7 @@ exports[`Security Provider Banner Alert should render disclosure component if no
       </p>
       <div
         class="disclosure"
+        data-testid="disclosure"
       >
         <details>
           <summary

--- a/ui/pages/confirmations/components/security-provider-banner-alert/blockaid-banner-alert/__snapshots__/blockaid-banner-alert.test.js.snap
+++ b/ui/pages/confirmations/components/security-provider-banner-alert/blockaid-banner-alert/__snapshots__/blockaid-banner-alert.test.js.snap
@@ -24,6 +24,7 @@ exports[`Blockaid Banner Alert should render 'danger' UI when securityAlertRespo
     </p>
     <div
       class="disclosure"
+      data-testid="disclosure"
     >
       <details>
         <summary
@@ -116,6 +117,7 @@ exports[`Blockaid Banner Alert should render 'warning' UI when securityAlertResp
     </p>
     <div
       class="disclosure"
+      data-testid="disclosure"
     >
       <details>
         <summary
@@ -208,6 +210,7 @@ exports[`Blockaid Banner Alert should render 'warning' UI when securityAlertResp
     </p>
     <div
       class="disclosure"
+      data-testid="disclosure"
     >
       <details>
         <summary
@@ -301,6 +304,7 @@ exports[`Blockaid Banner Alert should render details section even when features 
       </p>
       <div
         class="disclosure"
+        data-testid="disclosure"
       >
         <details>
           <summary
@@ -395,6 +399,7 @@ exports[`Blockaid Banner Alert should render details when provided 1`] = `
       </p>
       <div
         class="disclosure"
+        data-testid="disclosure"
       >
         <details>
           <summary
@@ -501,6 +506,7 @@ exports[`Blockaid Banner Alert should render link to report url 1`] = `
       </p>
       <div
         class="disclosure"
+        data-testid="disclosure"
       >
         <details>
           <summary


### PR DESCRIPTION
## **Description**

Replaces default Disclosure scrollToBottom behavior to fix issue where opening Blockaid Banner Alert "See Details" would scroll to the bottom

Adds tests for Disclosure component 

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/21187

## **Manual testing steps**


## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

![sdlg5Rty3W](https://github.com/MetaMask/metamask-extension/assets/20778143/6d74bb25-09f7-406f-a75d-73664f4d6e2d)


### **After**

![ZHn0VM0UwG](https://github.com/MetaMask/metamask-extension/assets/20778143/a12a31fe-90e1-4f5b-92ec-a83ad957b994)


## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've clearly explained what problem this PR is solving and how it is solved.
- [ ] I've linked related issues
- [ ] I've included manual testing steps
- [ ] I've included screenshots/recordings if applicable
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [ ] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
