### PR TITLE
`PreferencesController` reacts to `KeyringController` state changes

### DIFF
--- a/app/scripts/controllers/detect-tokens.test.js
+++ b/app/scripts/controllers/detect-tokens.test.js
@@ -259,6 +259,7 @@ describe('DetectTokensController', function () {
       networkConfigurations: {},
       onAccountRemoved: sinon.stub(),
       controllerMessenger: preferencesControllerMessenger,
+      onKeyringStateChange: sinon.stub(),
     });
     preferences.setUseTokenDetection(true);
 

--- a/app/scripts/controllers/mmi-controller.test.js
+++ b/app/scripts/controllers/mmi-controller.test.js
@@ -47,6 +47,7 @@ describe('MMIController', function () {
         onAccountRemoved: jest.fn(),
         provider: {},
         networkConfigurations: {},
+        onKeyringStateChange: jest.fn(),
       }),
       appStateController: new AppStateController({
         addUnlockListener: jest.fn(),

--- a/app/scripts/controllers/preferences.js
+++ b/app/scripts/controllers/preferences.js
@@ -119,6 +119,16 @@ export default class PreferencesController {
     this.store.setMaxListeners(13);
     this.tokenListController = opts.tokenListController;
 
+    opts.onKeyringStateChange((state) => {
+      const accounts = new Set();
+      for (const keyring of state.keyrings) {
+        for (const address of keyring.accounts) {
+          accounts.add(address);
+        }
+      }
+      this.syncAddresses(Array.from(accounts));
+    });
+
     global.setPreference = (key, value) => {
       return this.setFeatureFlag(key, value);
     };

--- a/app/scripts/controllers/preferences.js
+++ b/app/scripts/controllers/preferences.js
@@ -126,7 +126,9 @@ export default class PreferencesController {
           accounts.add(address);
         }
       }
-      this.syncAddresses(Array.from(accounts));
+      if (accounts.size > 0) {
+        this.syncAddresses(Array.from(accounts));
+      }
     });
 
     global.setPreference = (key, value) => {

--- a/app/scripts/controllers/preferences.test.js
+++ b/app/scripts/controllers/preferences.test.js
@@ -24,6 +24,7 @@ const NETWORK_CONFIGURATION_DATA = {
 describe('preferences controller', () => {
   let preferencesController;
   let tokenListController;
+  let onKeyringStateChangeListener;
 
   beforeEach(() => {
     const tokenListMessenger = new ControllerMessenger().getRestricted({
@@ -41,6 +42,9 @@ describe('preferences controller', () => {
       initLangCode: 'en_US',
       tokenListController,
       networkConfigurations: NETWORK_CONFIGURATION_DATA,
+      onKeyringStateChange: (listener) => {
+        onKeyringStateChangeListener = listener;
+      },
     });
   });
 
@@ -361,6 +365,24 @@ describe('preferences controller', () => {
         [CHAIN_IDS.SEPOLIA]: true,
         [CHAIN_IDS.LINEA_GOERLI]: true,
       });
+    });
+  });
+
+  describe('onKeyringStateChange', () => {
+    it('should sync the identities with the keyring', () => {
+      const mockKeyringControllerState = {
+        keyrings: [
+          {
+            accounts: ['0x1', '0x2', '0x3', '0x4'],
+          },
+        ],
+      };
+
+      onKeyringStateChangeListener(mockKeyringControllerState);
+
+      expect(
+        Object.keys(preferencesController.store.getState().identities),
+      ).toStrictEqual(mockKeyringControllerState.keyrings[0].accounts);
     });
   });
 

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -513,6 +513,11 @@ export default class MetamaskController extends EventEmitter {
       tokenListController: this.tokenListController,
       provider: this.provider,
       networkConfigurations: this.networkController.state.networkConfigurations,
+      onKeyringStateChange: (listener) =>
+        this.controllerMessenger.subscribe(
+          'KeyringController:stateChange',
+          listener,
+        ),
     });
 
     this.assetsContractController = new AssetsContractController(


### PR DESCRIPTION
## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->
These changes make the `PreferencesController` responsible for updating its state with available identities everytime the `KeyringController` state changes, as opposed to other components directly calling `syncAddresses`.

This PR does not eliminate redundant calls, which will be addressed in separate PRs for readability

## **Related issues**

Fixes: #22594 

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've clearly explained what problem this PR is solving and how it is solved.
- [ ] I've linked related issues
- [ ] I've included manual testing steps
- [ ] I've included screenshots/recordings if applicable
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [ ] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
