### PR TITLE
fix(e2e): PR blocker "Send ETH from inside MetaMask..." on test-e2e-chrome-mmi

### DIFF
--- a/test/e2e/tests/send-eth.spec.js
+++ b/test/e2e/tests/send-eth.spec.js
@@ -175,6 +175,9 @@ describe('Send ETH', function () {
           if (process.env.MULTICHAIN) {
             await driver.clickElement({ text: 'Continue', tag: 'button' });
           } else {
+            // We need to wait for the text "Max Fee: 0.000xxxx ETH" before clicking Next
+            await driver.findElement({ text: '0.000', tag: 'span' });
+
             await driver.findClickableElement({
               text: 'Next',
               tag: 'button',


### PR DESCRIPTION
## **Description**

Fixes the test "Send ETH from inside MetaMask finds the transaction in the transactions list when sending to a Multisig Address" that has been failing on `test-e2e-chrome-mmi`

The problem was that it was clicking the Next button too early.  We need to wait for the gas fee to update before clicking Next.

This should perhaps be really fixed in the Extension code, but for now I just changed the E2E test to unblock it.

## **Related issues**

Fixes: problem introduced in #22186 

## **Manual testing steps**
## **Screenshots/Recordings**
## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained what problem this PR is solving and how it is solved.
- [x] I've linked related issues
- [ ] I've included manual testing steps
- [ ] I've included screenshots/recordings if applicable
- [x] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [x] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [x] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
