### PR TITLE
ci(OOM): bump resource size on prep-build-storybook and test-storybook

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,6 +22,13 @@ executors:
     environment:
       FONTCONFIG_PATH: /etc/fonts
       NODE_OPTIONS: --max_old_space_size=4096
+  node-browsers-large:
+    docker:
+      - image: cimg/node:20.11-browsers
+    resource_class: medium+
+    environment:
+      FONTCONFIG_PATH: /etc/fonts
+      NODE_OPTIONS: --max_old_space_size=4096
   shellcheck:
     docker:
       - image: koalaman/shellcheck-alpine@sha256:dfaf08fab58c158549d3be64fb101c626abc5f16f341b569092577ae207db199
@@ -726,7 +733,7 @@ jobs:
             - builds-test-multichain
 
   prep-build-storybook:
-    executor: node-browsers-medium-plus
+    executor: node-browsers-large
     steps:
       - run: *shallow-git-clone
       - attach_workspace:
@@ -777,7 +784,7 @@ jobs:
           command: yarn verify-locales --quiet
 
   test-storybook:
-    executor: node-browsers-medium-plus
+    executor: node-browsers-large
     steps:
       - run: *shallow-git-clone
       - attach_workspace:


### PR DESCRIPTION
## **Description**

#22843 went a little too far to reduce CircleCI credits (this was kind of expected, as we were being aggressive)

`prep-build-storybook` and `test-storybook` are now crashing frequently from OOM errors

This PR bumps the resource size on `prep-build-storybook` and `test-storybook` back to `large`

## **Related issues**

Partial undo of #22843

## **Manual testing steps**
## **Screenshots/Recordings**
## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained what problem this PR is solving and how it is solved.
- [x] I've linked related issues
- [ ] I've included manual testing steps
- [ ] I've included screenshots/recordings if applicable
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [x] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [x] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.