### PR TITLE
feat: UX: Multichain: Show 'connect account' toast when current account isn't connected

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -136,6 +136,9 @@
   "accountIdenticon": {
     "message": "Account identicon"
   },
+  "accountIsntConnectedToastText": {
+    "message": "$1 isn't connected to $2"
+  },
   "accountName": {
     "message": "Account name"
   },

--- a/ui/components/app/alerts/alerts.js
+++ b/ui/components/app/alerts/alerts.js
@@ -18,7 +18,7 @@ const Alerts = ({ history }) => {
   if (_invalidCustomNetworkAlertIsOpen) {
     return <InvalidCustomNetworkAlert history={history} />;
   }
-  if (_unconnectedAccountAlertIsOpen) {
+  if (_unconnectedAccountAlertIsOpen && !process.env.MULTICHAIN) {
     return <UnconnectedAccountAlert />;
   }
 

--- a/ui/components/multichain/index.js
+++ b/ui/components/multichain/index.js
@@ -24,3 +24,4 @@ export { AvatarGroup } from './avatar-group';
 export { AssetPickerAmount } from './asset-picker-amount';
 export { AddressListItem } from './address-list-item';
 export { ConnectedStatus } from './connected-status';
+export { Toast, ToastContainer } from './toast';

--- a/ui/components/multichain/multichain-components.scss
+++ b/ui/components/multichain/multichain-components.scss
@@ -27,3 +27,4 @@
 @import 'asset-picker-amount';
 @import 'asset-picker-amount/asset-picker';
 @import 'asset-picker-amount/asset-picker-modal';
+@import 'toast';

--- a/ui/components/multichain/toast/__snapshots__/toast.test.tsx.snap
+++ b/ui/components/multichain/toast/__snapshots__/toast.test.tsx.snap
@@ -1,0 +1,85 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Toast should render Toast component 1`] = `
+<div>
+  <div
+    class="mm-box mm-banner-base mm-box--padding-3 mm-box--display-flex mm-box--gap-2 mm-box--background-color-background-default mm-box--rounded-sm"
+    data-theme="light"
+  >
+    <div
+      class="mm-box mm-box--min-width-0"
+    >
+      <div
+        class="mm-box mm-box--display-flex mm-box--gap-4"
+      >
+        <div
+          class="mm-box mm-text mm-avatar-base mm-avatar-base--size-md mm-avatar-account mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full mm-box--border-color-transparent box--border-style-solid box--border-width-1"
+        >
+          <div
+            class="mm-avatar-account__jazzicon"
+          >
+            <div
+              style="border-radius: 50px; overflow: hidden; padding: 0px; margin: 0px; width: 32px; height: 32px; display: inline-block; background: rgb(24, 165, 242);"
+            >
+              <svg
+                height="32"
+                width="32"
+                x="0"
+                y="0"
+              >
+                <rect
+                  fill="#018E8C"
+                  height="32"
+                  transform="translate(6.427263444332595 -1.7203295797723996) rotate(470.8 16 16)"
+                  width="32"
+                  x="0"
+                  y="0"
+                />
+                <rect
+                  fill="#F93301"
+                  height="32"
+                  transform="translate(1.1564119766476293 16.128853746500315) rotate(198.5 16 16)"
+                  width="32"
+                  x="0"
+                  y="0"
+                />
+                <rect
+                  fill="#FA6800"
+                  height="32"
+                  transform="translate(22.348080171264016 5.115369684577057) rotate(148.9 16 16)"
+                  width="32"
+                  x="0"
+                  y="0"
+                />
+              </svg>
+            </div>
+          </div>
+        </div>
+        <div
+          class="mm-box"
+        >
+          <p
+            class="mm-box mm-text mm-text--body-md mm-box--color-text-default"
+          >
+            This is the Toast text
+          </p>
+          <button
+            class="mm-box mm-text mm-button-base mm-button-link mm-button-link--size-auto mm-text--body-md-medium mm-box--padding-0 mm-box--padding-right-0 mm-box--padding-left-0 mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-primary-default mm-box--background-color-transparent"
+          >
+            Take some action
+          </button>
+        </div>
+      </div>
+    </div>
+    <button
+      aria-label="[close]"
+      class="mm-box mm-button-icon mm-button-icon--size-sm mm-banner-base__close-button mm-box--margin-left-auto mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-default mm-box--background-color-transparent mm-box--rounded-lg"
+    >
+      <span
+        class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
+        style="mask-image: url('./images/icons/close.svg');"
+      />
+    </button>
+  </div>
+</div>
+`;

--- a/ui/components/multichain/toast/index.scss
+++ b/ui/components/multichain/toast/index.scss
@@ -1,0 +1,7 @@
+.toasts-container {
+  position: sticky;
+  bottom: 10px;
+  margin-inline-start: 10px;
+  margin-inline-end: 10px;
+  z-index: 200;
+}

--- a/ui/components/multichain/toast/index.ts
+++ b/ui/components/multichain/toast/index.ts
@@ -1,0 +1,1 @@
+export { ToastContainer, Toast } from './toast';

--- a/ui/components/multichain/toast/toast.stories.tsx
+++ b/ui/components/multichain/toast/toast.stories.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import testData from '../../../../.storybook/test-data';
+import { AvatarAccount, AvatarAccountSize } from '../../component-library';
+import { BorderColor } from '../../../helpers/constants/design-system';
+import { Toast } from '.';
+
+const [chaosAddress] = Object.keys(testData.metamask.identities);
+
+const CHAOS_IDENTITY = {
+  ...testData.metamask.identities[chaosAddress],
+  balance: '0x152387ad22c3f0',
+  keyring: {
+    type: 'HD Key Tree',
+  },
+};
+
+export default {
+  title: 'Components/Multichain/Toast',
+  argTypes: {
+    startAdornment: {
+      control: 'text',
+    },
+    text: {
+      control: 'text',
+    },
+    actionText: {
+      control: 'text',
+    },
+    onActionClick: {
+      action: 'onClick',
+    },
+    onClose: {
+      action: 'onClick',
+    },
+  },
+  args: {
+    startAdornment: (<AvatarAccount
+    address={CHAOS_IDENTITY.address}
+    size={AvatarAccountSize.Md}
+    borderColor={BorderColor.transparent}
+  />),
+    text: 'This is the Toast text',
+    actionText: 'Take some action',
+    onActionClick: () => undefined,
+    onClose: () => undefined,
+  },
+};
+
+export const DefaultStory = (args) => <Toast {...args} />;
+
+DefaultStory.storyName = 'Default';

--- a/ui/components/multichain/toast/toast.test.tsx
+++ b/ui/components/multichain/toast/toast.test.tsx
@@ -1,0 +1,55 @@
+/* eslint-disable jest/require-top-level-describe */
+import React from 'react';
+import { fireEvent, render } from '@testing-library/react';
+import testData from '../../../../.storybook/test-data';
+import { AvatarAccount, AvatarAccountSize } from '../../component-library';
+import { BorderColor } from '../../../helpers/constants/design-system';
+import { Toast } from '.';
+
+const CHAOS_IDENTITY: any = {
+  ...testData.metamask.identities['0x64a845a5b02460acf8a3d84503b0d68d028b4bb4'],
+  balance: '0x152387ad22c3f0',
+  keyring: {
+    type: 'HD Key Tree',
+  },
+};
+
+const onActionClick = jest.fn();
+const onClose = jest.fn();
+
+const ToastArgs = {
+  startAdornment: (
+    <AvatarAccount
+      address={CHAOS_IDENTITY.address}
+      size={AvatarAccountSize.Md}
+      borderColor={BorderColor.transparent}
+    />
+  ),
+  text: 'This is the Toast text',
+  actionText: 'Take some action',
+  onActionClick,
+  onClose,
+};
+
+describe('Toast', () => {
+  it('should render Toast component', () => {
+    const { container } = render(<Toast {...ToastArgs} />);
+    expect(container).toMatchSnapshot();
+  });
+
+  it('executes onActionClick properly', () => {
+    const { getByText } = render(<Toast {...ToastArgs} />);
+    fireEvent.click(getByText(ToastArgs.actionText));
+    expect(onActionClick).toHaveBeenCalled();
+  });
+
+  it('executes onClose properly', () => {
+    render(<Toast {...ToastArgs} />);
+    const closeButton = document.querySelector('.mm-banner-base__close-button');
+    if (closeButton) {
+      fireEvent.click(closeButton);
+    }
+    expect(closeButton).toBeDefined();
+    expect(onActionClick).toHaveBeenCalled();
+  });
+});

--- a/ui/components/multichain/toast/toast.tsx
+++ b/ui/components/multichain/toast/toast.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { ThemeType } from '../../../../shared/constants/preferences';
+import { BannerBase, Box, ButtonLink, Text } from '../../component-library';
+import { Display } from '../../../helpers/constants/design-system';
+
+export const ToastContainer = ({
+  children,
+}: {
+  children: React.ReactNode | string;
+}) => <Box className="toasts-container">{children}</Box>;
+
+export const Toast = ({
+  startAdornment,
+  text,
+  actionText,
+  onActionClick,
+  onClose,
+}: {
+  startAdornment: React.ReactNode | React.ReactNode[];
+  text: string;
+  actionText: string;
+  onActionClick: () => void;
+  onClose: () => void;
+}) => {
+  const { theme } = document.documentElement.dataset;
+
+  return (
+    <BannerBase
+      data-theme={theme === ThemeType.light ? ThemeType.dark : ThemeType.light}
+      onClose={onClose}
+    >
+      <Box display={Display.Flex} gap={4}>
+        {startAdornment}
+        <Box>
+          <Text>{text}</Text>
+          {actionText && onActionClick ? (
+            <ButtonLink onClick={onActionClick}>{actionText}</ButtonLink>
+          ) : null}
+        </Box>
+      </Box>
+    </BannerBase>
+  );
+};

--- a/ui/pages/routes/routes.component.js
+++ b/ui/pages/routes/routes.component.js
@@ -37,6 +37,8 @@ import {
   AccountDetails,
   ImportNftsModal,
   ImportTokensModal,
+  ToastContainer,
+  Toast,
 } from '../../components/multichain';
 import UnlockPage from '../unlock-page';
 import Alerts from '../../components/app/alerts';
@@ -121,7 +123,11 @@ import { SEND_STAGES } from '../../ducks/send';
 import DeprecatedNetworks from '../../components/ui/deprecated-networks/deprecated-networks';
 import NewNetworkInfo from '../../components/ui/new-network-info/new-network-info';
 import { ThemeType } from '../../../shared/constants/preferences';
-import { Box } from '../../components/component-library';
+import {
+  AvatarAccount,
+  AvatarAccountSize,
+  Box,
+} from '../../components/component-library';
 import { ToggleIpfsModal } from '../../components/app/nft-default-image/toggle-ipfs-modal';
 ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
 import KeyringSnapRemovalResult from '../../components/app/modals/keyring-snap-removal-modal';
@@ -129,10 +135,16 @@ import KeyringSnapRemovalResult from '../../components/app/modals/keyring-snap-r
 
 import { SendPage } from '../../components/multichain/pages/send';
 import { DeprecatedNetworkModal } from '../settings/deprecated-network-modal/DeprecatedNetworkModal';
+import { getURLHost } from '../../helpers/utils/util';
+import { BorderColor } from '../../helpers/constants/design-system';
+import { MILLISECOND } from '../../../shared/constants/time';
 
 export default class Routes extends Component {
   static propTypes = {
     currentCurrency: PropTypes.string,
+    account: PropTypes.object,
+    activeTabOrigin: PropTypes.string,
+    showConnectAccountToast: PropTypes.bool.isRequired,
     setCurrentCurrencyToUSD: PropTypes.func,
     isLoading: PropTypes.bool,
     loadingMessage: PropTypes.string,
@@ -176,6 +188,7 @@ export default class Routes extends Component {
     hideImportTokensModal: PropTypes.func.isRequired,
     isDeprecatedNetworkModalOpen: PropTypes.bool.isRequired,
     hideDeprecatedNetworkModal: PropTypes.func.isRequired,
+    addPermittedAccount: PropTypes.func.isRequired,
     ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
     isShowKeyringSnapRemovalResultModal: PropTypes.bool.isRequired,
     hideShowKeyringSnapRemovalResultModal: PropTypes.func.isRequired,
@@ -188,12 +201,24 @@ export default class Routes extends Component {
     metricsEvent: PropTypes.func,
   };
 
-  handleOsTheme() {
-    const osTheme = window?.matchMedia('(prefers-color-scheme: dark)')?.matches
-      ? ThemeType.dark
-      : ThemeType.light;
+  state = {
+    hideConnectAccountToast: false,
+  };
 
-    document.documentElement.setAttribute('data-theme', osTheme);
+  getTheme() {
+    const { theme } = this.props;
+    if (theme === ThemeType.os) {
+      if (window?.matchMedia('(prefers-color-scheme: dark)')?.matches) {
+        return ThemeType.dark;
+      }
+      return ThemeType.light;
+    }
+    return theme;
+  }
+
+  setTheme() {
+    const theme = this.getTheme();
+    document.documentElement.setAttribute('data-theme', theme);
   }
 
   ///: BEGIN:ONLY_INCLUDE_IF(desktop)
@@ -213,14 +238,14 @@ export default class Routes extends Component {
   ///: END:ONLY_INCLUDE_IF
 
   componentDidUpdate(prevProps) {
-    const { theme } = this.props;
+    const { theme, account } = this.props;
 
     if (theme !== prevProps.theme) {
-      if (theme === ThemeType.os) {
-        this.handleOsTheme();
-      } else {
-        document.documentElement.setAttribute('data-theme', theme);
-      }
+      this.setTheme();
+    }
+
+    if (prevProps.account?.address !== account?.address) {
+      this.setState({ hideConnectAccountToast: false });
     }
   }
 
@@ -230,7 +255,6 @@ export default class Routes extends Component {
       pageChanged,
       setCurrentCurrencyToUSD,
       history,
-      theme,
       showExtensionInFullSizeView,
     } = this.props;
 
@@ -248,11 +272,8 @@ export default class Routes extends Component {
         pageChanged(locationObj.pathname);
       }
     });
-    if (theme === ThemeType.os) {
-      this.handleOsTheme();
-    } else {
-      document.documentElement.setAttribute('data-theme', theme);
-    }
+
+    this.setTheme();
   }
 
   renderRoutes() {
@@ -552,6 +573,9 @@ export default class Routes extends Component {
 
   render() {
     const {
+      account,
+      activeTabOrigin,
+      showConnectAccountToast,
       isLoading,
       isUnlocked,
       alertMessage,
@@ -581,6 +605,7 @@ export default class Routes extends Component {
       hideIpfsModal,
       hideImportTokensModal,
       hideDeprecatedNetworkModal,
+      addPermittedAccount,
       ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
       isShowKeyringSnapRemovalResultModal,
       hideShowKeyringSnapRemovalResultModal,
@@ -680,6 +705,40 @@ export default class Routes extends Component {
           {this.renderRoutes()}
         </Box>
         {isUnlocked ? <Alerts history={this.props.history} /> : null}
+        <ToastContainer>
+          {showConnectAccountToast && !this.state.hideConnectAccountToast ? (
+            <Toast
+              startAdornment={
+                <AvatarAccount
+                  address={account.address}
+                  size={AvatarAccountSize.Md}
+                  borderColor={BorderColor.transparent}
+                />
+              }
+              text={this.context.t('accountIsntConnectedToastText', [
+                account?.metadata?.name,
+                getURLHost(activeTabOrigin),
+              ])}
+              actionText={this.context.t('connectAccount')}
+              onActionClick={() => {
+                // Connect this account
+                addPermittedAccount(activeTabOrigin, account.address);
+                // Use setTimeout to prevent React re-render from
+                // hiding the tooltip
+                setTimeout(() => {
+                  // Trigger a mouseenter on the header's connection icon
+                  // to display the informative connection tooltip
+                  document
+                    .querySelector(
+                      '[data-testid="connection-menu"] [data-tooltipped]',
+                    )
+                    ?.dispatchEvent(new CustomEvent('mouseenter', {}));
+                }, 250 * MILLISECOND);
+              }}
+              onClose={() => this.setState({ hideConnectAccountToast: true })}
+            />
+          ) : null}
+        </ToastContainer>
       </div>
     );
   }

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -470,10 +470,14 @@ export function getSelectedAccount(state) {
   const accounts = getMetaMaskAccounts(state);
   const selectedAccount = getSelectedInternalAccount(state);
 
-  return {
-    ...selectedAccount,
-    ...accounts[selectedAccount.address],
-  };
+  // At the time of onboarding there is no selected account
+  if (selectedAccount) {
+    return {
+      ...selectedAccount,
+      ...accounts[selectedAccount.address],
+    };
+  }
+  return undefined;
 }
 
 export function getTargetAccount(state, targetAddress) {


### PR DESCRIPTION
## **Description**

When the user opens MetaMask on a dApp where the current account is *not* connected but another is, show a toast to the user asking if they'd like to connect this account.

## **Related issues**

Fixes:https://app.zenhub.com/workspaces/metamask-wallet-ux-63529dce65cbb100265a3842/issues/gh/metamask/metamask-planning/1977

## **Manual testing steps**

1.  Select Account 1
2. Go to Uniswap, connect to the dApp
3. Switch to Account 2
4. Open MetaMask, see the connection toast
5. Click to connect; see toast disappear and connection tooltip display

## **Screenshots/Recordings**

### **Before**

N/A

### **After**


https://github.com/MetaMask/metamask-extension/assets/46655/132ced9e-f90f-42a0-a63f-4d595f4c593d




## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've clearly explained what problem this PR is solving and how it is solved.
- [ ] I've linked related issues
- [ ] I've included manual testing steps
- [ ] I've included screenshots/recordings if applicable
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [ ] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
