### PR TITLE
[MMI] Removed unused methods

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -3114,14 +3114,6 @@ export default class MetamaskController extends EventEmitter {
         this.custodyController.setWaitForConfirmDeepLinkDialog.bind(
           this.custodyController,
         ),
-      setCustodianConnectRequest:
-        this.custodyController.setCustodianConnectRequest.bind(
-          this.custodyController,
-        ),
-      getCustodianConnectRequest:
-        this.custodyController.getCustodianConnectRequest.bind(
-          this.custodyController,
-        ),
       getMmiConfiguration:
         this.mmiConfigurationController.getConfiguration.bind(
           this.mmiConfigurationController,

--- a/ui/pages/institutional/confirm-add-custodian-token/confirm-add-custodian-token.js
+++ b/ui/pages/institutional/confirm-add-custodian-token/confirm-add-custodian-token.js
@@ -74,14 +74,6 @@ const ConfirmAddCustodianToken = () => {
 
             await dispatch(setProviderType(networkType));
           }
-
-          await dispatch(
-            mmiActions.setCustodianConnectRequest({
-              token: connectRequest.token,
-              envName: connectRequest.environment,
-              custodianType: connectRequest.service,
-            }),
-          );
         }
 
         await dispatch(

--- a/ui/pages/institutional/confirm-add-custodian-token/confirm-add-custodian-token.test.js
+++ b/ui/pages/institutional/confirm-add-custodian-token/confirm-add-custodian-token.test.js
@@ -8,14 +8,9 @@ const mockedRemoveAddTokenConnectRequest = jest
   .fn()
   .mockReturnValue({ type: 'TYPE' });
 
-const mockedSetCustodianConnectRequest = jest
-  .fn()
-  .mockReturnValue({ type: 'TYPE' });
-
 jest.mock('../../../store/institutional/institution-background', () => ({
   mmiActionsFactory: () => ({
     removeAddTokenConnectRequest: mockedRemoveAddTokenConnectRequest,
-    setCustodianConnectRequest: mockedSetCustodianConnectRequest,
   }),
 }));
 
@@ -131,59 +126,6 @@ describe('Confirm Add Custodian Token', () => {
         origin: 'origin',
         environment: 'jupiter',
         token: 'testToken',
-      });
-    });
-  });
-
-  it('clicks the confirm button without chainId and calls setCustodianConnectRequest with custodianName comming from the environment connectRequest', async () => {
-    const customMockedStore = {
-      metamask: {
-        providerConfig: {
-          type: 'test',
-        },
-        preferences: {
-          useNativeCurrencyAsPrimaryCurrency: true,
-        },
-        institutionalFeatures: {
-          connectRequests: [
-            {
-              labels: [
-                {
-                  key: 'service',
-                  value: 'test',
-                },
-              ],
-              origin: 'origin',
-              token: '',
-              feature: 'custodian',
-              service: 'JSONRPC',
-              environment: 'jsonrpc',
-            },
-          ],
-        },
-      },
-      history: {
-        push: '/',
-        mostRecentOverviewPage: '/',
-      },
-    };
-
-    const customStore = configureMockStore()(customMockedStore);
-
-    renderWithProvider(<ConfirmAddCustodianToken />, customStore);
-
-    await waitFor(() => {
-      const confirmButton = screen.getByTestId('confirm-btn');
-      fireEvent.click(confirmButton);
-    });
-
-    expect(screen.getByTestId('pulse-loader')).toBeInTheDocument();
-
-    await waitFor(() => {
-      expect(mockedSetCustodianConnectRequest).toHaveBeenCalledWith({
-        token: '',
-        custodianType: 'JSONRPC',
-        envName: 'jsonrpc',
       });
     });
   });

--- a/ui/pages/institutional/interactive-replacement-token-page/interactive-replacement-token-page.test.js
+++ b/ui/pages/institutional/interactive-replacement-token-page/interactive-replacement-token-page.test.js
@@ -44,7 +44,7 @@ const mockedRemoveAddTokenConnectRequest = jest
 const mockedSetCustodianNewRefreshToken = jest
   .fn()
   .mockReturnValue({ type: 'TYPE' });
-let mockedGetCustodianConnectRequest = jest
+let mockedGetCustodianAccounts = jest
   .fn()
   .mockReturnValue(async () => await custodianAccounts);
 
@@ -52,7 +52,7 @@ jest.mock('../../../store/institutional/institution-background', () => ({
   mmiActionsFactory: () => ({
     removeAddTokenConnectRequest: mockedRemoveAddTokenConnectRequest,
     setCustodianNewRefreshToken: mockedSetCustodianNewRefreshToken,
-    getCustodianAccounts: mockedGetCustodianConnectRequest,
+    getCustodianAccounts: mockedGetCustodianAccounts,
   }),
   showInteractiveReplacementTokenBanner: () =>
     mockedShowInteractiveReplacementTokenBanner,
@@ -203,7 +203,7 @@ describe('Interactive Replacement Token Page', function () {
   });
 
   it('should reject if there are errors', async () => {
-    mockedGetCustodianConnectRequest = jest.fn().mockReturnValue(async () => {
+    mockedGetCustodianAccounts = jest.fn().mockReturnValue(async () => {
       throw new Error();
     });
 

--- a/ui/store/institutional/institution-background.test.js
+++ b/ui/store/institutional/institution-background.test.js
@@ -40,8 +40,6 @@ describe('Institution Actions', () => {
         getCustodianToken: jest.fn(),
         getCustodianJWTList: jest.fn(),
         removeAddTokenConnectRequest: jest.fn(),
-        setCustodianConnectRequest: jest.fn(),
-        getCustodianConnectRequest: jest.fn(),
         getMmiConfiguration: jest.fn(),
         getAllCustodianAccountsWithToken: jest.fn(),
         setWaitForConfirmDeepLinkDialog: jest.fn(),
@@ -85,7 +83,6 @@ describe('Institution Actions', () => {
         custodians: [],
       });
       mmiActions.getCustodianToken({});
-      mmiActions.getCustodianConnectRequest();
       mmiActions.getCustodianTransactionDeepLink('0xAddress', 'txId');
       mmiActions.getCustodianConfirmDeepLink('txId');
       mmiActions.getCustodianSignMessageDeepLink('0xAddress', 'custodyTxId');
@@ -98,11 +95,6 @@ describe('Institution Actions', () => {
         origin: 'origin',
         token: 'token',
         environment: 'jupiter',
-      });
-      mmiActions.setCustodianConnectRequest({
-        token: 'token',
-        custodianType: 'custodianType',
-        envName: 'jupiter',
       });
       const setWaitForConfirmDeepLinkDialog =
         mmiActions.setWaitForConfirmDeepLinkDialog(true);

--- a/ui/store/institutional/institution-background.ts
+++ b/ui/store/institutional/institution-background.ts
@@ -219,20 +219,6 @@ export function mmiActionsFactory() {
         environment,
         token,
       }),
-    setCustodianConnectRequest: ({
-      token,
-      custodianType,
-      envName,
-    }: {
-      token: string;
-      custodianType: string;
-      envName: string;
-    }) =>
-      createAsyncAction('setCustodianConnectRequest', [
-        { token, custodianType, envName },
-      ]),
-    getCustodianConnectRequest: () =>
-      createAsyncAction('getCustodianConnectRequest', []),
     getMmiConfiguration: () => createAsyncAction('getMmiConfiguration', []),
     getAllCustodianAccountsWithToken: (custodyType: string, token: string) =>
       createAsyncAction('getAllCustodianAccountsWithToken', [


### PR DESCRIPTION
## **Description**

In the `CustodyController` institutional package, we have two methods, `getCustodianConnectRequest` and `setCustodianConnectRequest`, that are not being used in the monorepo, so this ticket aims to remove them.

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MMI-4578

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained what problem this PR is solving and how it is solved.
- [x] I've linked related issues
- [x] I've included manual testing steps
- [x] I've included screenshots/recordings if applicable
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [ ] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
