### PR TITLE
Cherry-pick 67eb0bca9e (#22997) to v11.10.0

### DIFF
--- a/ui/helpers/utils/optimism/buildUnserializedTransaction.js
+++ b/ui/helpers/utils/optimism/buildUnserializedTransaction.js
@@ -22,7 +22,7 @@ function buildTransactionCommon(txMeta) {
     // Optimism only supports type-0 transactions; it does not support any of
     // the newer EIPs since EIP-155. Source:
     // <https://github.com/ethereum-optimism/optimism/blob/develop/specs/l2geth/transaction-types.md>
-    defaultHardfork: Hardfork.SpuriousDragon,
+    defaultHardfork: Hardfork.London,
   });
 }
 


### PR DESCRIPTION
### Cherry pick of #22997 to v11.10.0. That PR's description is below

Update the hardfork in the transaction common used to estimate L1 optimism fees to London, fixing display of Layer 1 optimsim fees

The bug was that Layer 1 fees were not being displayed on the confirmation screen for transactions on Optimism.

This was because `estimatedL1Fees` was null, because `fetchEstimatedL1Fee` was failing, because
`TransactionFactory.fromTxData(txParams, { common })` in `buildUnserializedTransaction` was throwing an error, because `txParams` has a `type` === `2`, but EIP-1559 transactions are not supported on the spurious dragon hardfork, which is what was being used in the `common` configuration of that `TransactionFactory.fromTxData` call.

This became a problem after
https://github.com/MetaMask/core/pull/3817/files. That PR correctly fixed a bug which could result in the transaction type being removed from the `txMeta.txParams` when `addTransaction` in the tx controller was called. With that bug fix, there was now a `type` present on the `txParams` that got passed to the aforementioned
`TransactionFactory.fromTxData` call. Prior to that bug fix, there was no `type` on `txParams` at that point, the ethereumjs-tx TransactionFactory was treating these transactions as legacy transactions, and so was constructing a type 0 transaction, and the fact that the hardfork was spurious dragon was not a problem

This PR fixes the problem by updating the hardfork param used in the `common` configuration of that `TransactionFactory.fromTxData` call. This should not have a functional effect, as this will cause no change in data and value of the tx passed to the smart contract to generate an fee estimate, except that this may result in more accurate L1 fee estimates (that is not certain though).

Fixes: #22945

1. Create a transaction on OP Mainnet
2. Click "Fee details" on the confirmation screen
3.  The layer 1 fee details should be visible

![Screenshot from 2024-02-16
09-27-25](https://github.com/MetaMask/metamask-extension/assets/7499938/6c759096-f393-4101-b9af-a3542e313571)
