### PR TITLE
Confirm button should be red when request is flagged as malicious on extension

### DIFF
--- a/test/e2e/tests/ppom-blockaid-alert-simple-send.spec.js
+++ b/test/e2e/tests/ppom-blockaid-alert-simple-send.spec.js
@@ -207,6 +207,7 @@ describe('Simple Send Security Alert - Blockaid @no-mmi', function () {
         dapp: true,
         fixtures: new FixtureBuilder()
           .withNetworkControllerOnMainnet()
+          .withPermissionControllerConnectedToTestDapp()
           .withPreferencesController({
             securityAlertsEnabled: true,
           })

--- a/test/e2e/tests/ppom-blockaid-alert-simple-send.spec.js
+++ b/test/e2e/tests/ppom-blockaid-alert-simple-send.spec.js
@@ -207,7 +207,6 @@ describe('Simple Send Security Alert - Blockaid @no-mmi', function () {
         dapp: true,
         fixtures: new FixtureBuilder()
           .withNetworkControllerOnMainnet()
-          .withPermissionControllerConnectedToTestDapp()
           .withPreferencesController({
             securityAlertsEnabled: true,
           })

--- a/ui/components/ui/page-container/page-container-footer/page-container-footer.component.test.js
+++ b/ui/components/ui/page-container/page-container-footer/page-container-footer.component.test.js
@@ -51,5 +51,26 @@ describe('Page Footer', () => {
 
       expect(props.onSubmit).toHaveBeenCalled();
     });
+
+    it('has danger class defined if type is danger', () => {
+      const { queryByTestId } = renderWithProvider(
+        <PageFooter {...props} submitButtonType="danger" />,
+      );
+
+      const submitButton = queryByTestId('page-container-footer-next');
+
+      expect(submitButton.className).toContain('danger');
+    });
+
+    it('has danger-primary class defined if type is danger-primary', () => {
+      const { queryByTestId } = renderWithProvider(
+        <PageFooter {...props} submitButtonType="danger-primary" />,
+      );
+
+      const submitButton = queryByTestId('page-container-footer-next');
+
+      console.log(submitButton.className);
+      expect(submitButton.className).toContain('danger-primary');
+    });
   });
 });

--- a/ui/pages/confirmations/components/confirm-page-container/confirm-page-container-content/confirm-page-container-content.component.js
+++ b/ui/pages/confirmations/components/confirm-page-container/confirm-page-container-content/confirm-page-container-content.component.js
@@ -17,6 +17,7 @@ import {
 } from '../../../../../helpers/constants/error-keys';
 import { Severity } from '../../../../../helpers/constants/design-system';
 
+import { BlockaidResultType } from '../../../../../../shared/constants/security-provider';
 import { ConfirmPageContainerSummary, ConfirmPageContainerWarning } from '.';
 
 export default class ConfirmPageContainerContent extends Component {
@@ -64,6 +65,7 @@ export default class ConfirmPageContainerContent extends Component {
     ///: BEGIN:ONLY_INCLUDE_IF(build-mmi)
     noteComponent: PropTypes.node,
     ///: END:ONLY_INCLUDE_IF
+    txData: PropTypes.object,
   };
 
   renderContent() {
@@ -181,6 +183,7 @@ export default class ConfirmPageContainerContent extends Component {
       ///: BEGIN:ONLY_INCLUDE_IF(build-main,build-beta,build-flask)
       openBuyCryptoInPdapp,
       ///: END:ONLY_INCLUDE_IF
+      txData,
     } = this.props;
 
     const { t } = this.context;
@@ -190,6 +193,12 @@ export default class ConfirmPageContainerContent extends Component {
 
     const showIsSigningOrSubmittingError =
       errorKey === IS_SIGNING_OR_SUBMITTING;
+
+    const submitButtonType =
+      txData?.securityAlertResponse?.result_type ===
+      BlockaidResultType.Malicious
+        ? 'danger-primary'
+        : 'primary';
 
     return (
       <div
@@ -272,6 +281,7 @@ export default class ConfirmPageContainerContent extends Component {
           onSubmit={onSubmit}
           submitText={submitText}
           disabled={disabled}
+          submitButtonType={submitButtonType}
         >
           {unapprovedTxCount > 1 ? (
             <a onClick={onCancelAll}>{rejectNText}</a>

--- a/ui/pages/confirmations/components/confirm-page-container/confirm-page-container.component.js
+++ b/ui/pages/confirmations/components/confirm-page-container/confirm-page-container.component.js
@@ -61,6 +61,7 @@ import {
 } from '../../../../../shared/constants/metametrics';
 ///: END:ONLY_INCLUDE_IF
 
+import { BlockaidResultType } from '../../../../../shared/constants/security-provider';
 import {
   ConfirmPageContainerHeader,
   ConfirmPageContainerContent,
@@ -195,6 +196,9 @@ const ConfirmPageContainer = (props) => {
     fetchCollectionBalance,
     collectionBalance,
   ]);
+
+  const isMaliciousRequest =
+    txData.securityAlertResponse?.result_type === BlockaidResultType.Malicious;
 
   return (
     <GasFeeContextProvider transaction={currentTransaction}>
@@ -348,7 +352,8 @@ const ConfirmPageContainer = (props) => {
             onSubmit={topLevelHandleSubmit}
             submitText={t('confirm')}
             submitButtonType={
-              isSetApproveForAll && isApprovalOrRejection
+              (isSetApproveForAll && isApprovalOrRejection) ||
+              isMaliciousRequest
                 ? 'danger-primary'
                 : 'primary'
             }

--- a/ui/pages/confirmations/components/signature-request-original/signature-request-original.component.js
+++ b/ui/pages/confirmations/components/signature-request-original/signature-request-original.component.js
@@ -58,6 +58,7 @@ import SnapLegacyAuthorshipHeader from '../../../../components/app/snaps/snap-le
 ///: BEGIN:ONLY_INCLUDE_IF(build-flask)
 import InsightWarnings from '../../../../components/app/snaps/insight-warnings';
 ///: END:ONLY_INCLUDE_IF
+import { BlockaidResultType } from '../../../../../shared/constants/security-provider';
 import SignatureRequestOriginalWarning from './signature-request-original-warning';
 
 export default class SignatureRequestOriginal extends Component {
@@ -323,6 +324,10 @@ export default class SignatureRequestOriginal extends Component {
     } = this.props;
     const { t } = this.context;
 
+    const submitButtonType =
+      txData.securityAlertResponse?.result_type === BlockaidResultType.Malicious
+        ? 'danger-primary'
+        : 'primary';
     return (
       <PageContainerFooter
         cancelText={t('reject')}
@@ -352,6 +357,7 @@ export default class SignatureRequestOriginal extends Component {
           ///: END:ONLY_INCLUDE_IF
           hardwareWalletRequiresConnection
         }
+        submitButtonType={submitButtonType}
       />
     );
   };

--- a/ui/pages/confirmations/components/signature-request-siwe/signature-request-siwe.js
+++ b/ui/pages/confirmations/components/signature-request-siwe/signature-request-siwe.js
@@ -47,6 +47,7 @@ import SignatureRequestHeader from '../signature-request-header';
 ///: BEGIN:ONLY_INCLUDE_IF(build-flask)
 import InsightWarnings from '../../../../components/app/snaps/insight-warnings';
 ///: END:ONLY_INCLUDE_IF
+import { BlockaidResultType } from '../../../../../shared/constants/security-provider';
 import Header from './signature-request-siwe-header';
 import Message from './signature-request-siwe-message';
 
@@ -137,6 +138,12 @@ export default function SignatureRequestSIWE({
 
   const rejectNText = t('rejectRequestsN', [messagesCount]);
 
+  const submitButtonType =
+    txData.securityAlertResponse?.result_type ===
+      BlockaidResultType.Malicious || !isSIWEDomainValid
+      ? 'danger-primary'
+      : 'primary';
+
   return (
     <>
       <div className="signature-request-siwe">
@@ -211,7 +218,7 @@ export default function SignatureRequestSIWE({
           }}
           cancelText={t('cancel')}
           submitText={t('signin')}
-          submitButtonType={isSIWEDomainValid ? 'primary' : 'danger-primary'}
+          submitButtonType={submitButtonType}
         />
         {messagesCount > 1 ? (
           <Button

--- a/ui/pages/confirmations/components/signature-request/signature-request-footer/signature-request-footer.component.js
+++ b/ui/pages/confirmations/components/signature-request/signature-request-footer/signature-request-footer.component.js
@@ -8,6 +8,7 @@ export default class SignatureRequestFooter extends PureComponent {
     cancelAction: PropTypes.func.isRequired,
     signAction: PropTypes.func.isRequired,
     disabled: PropTypes.bool,
+    submitButtonType: PropTypes.string,
   };
 
   static contextTypes = {
@@ -15,7 +16,12 @@ export default class SignatureRequestFooter extends PureComponent {
   };
 
   render() {
-    const { cancelAction, signAction, disabled = false } = this.props;
+    const {
+      submitButtonType,
+      cancelAction,
+      signAction,
+      disabled = false,
+    } = this.props;
     return (
       <PageContainerFooter
         cancelText={this.context.t('reject')}
@@ -23,6 +29,7 @@ export default class SignatureRequestFooter extends PureComponent {
         onCancel={cancelAction}
         onSubmit={signAction}
         disabled={disabled}
+        submitButtonType={submitButtonType}
       />
     );
   }

--- a/ui/pages/confirmations/components/signature-request/signature-request.js
+++ b/ui/pages/confirmations/components/signature-request/signature-request.js
@@ -45,7 +45,10 @@ import LedgerInstructionField from '../ledger-instruction-field';
 import ContractDetailsModal from '../contract-details-modal';
 import { MetaMetricsContext } from '../../../../contexts/metametrics';
 import { MetaMetricsEventCategory } from '../../../../../shared/constants/metametrics';
-import { SECURITY_PROVIDER_MESSAGE_SEVERITY } from '../../../../../shared/constants/security-provider';
+import {
+  BlockaidResultType,
+  SECURITY_PROVIDER_MESSAGE_SEVERITY,
+} from '../../../../../shared/constants/security-provider';
 
 import {
   TextAlign,
@@ -152,6 +155,11 @@ const SignatureRequest = ({
     const sanitizedMessage = sanitizeMessage(message, primaryType, types);
     return { sanitizedMessage, domain, primaryType };
   });
+
+  const submitButtonType =
+    txData.securityAlertResponse?.result_type === BlockaidResultType.Malicious
+      ? 'danger-primary'
+      : 'primary';
 
   const onSign = async () => {
     ///: BEGIN:ONLY_INCLUDE_IF(build-mmi)
@@ -337,6 +345,7 @@ const SignatureRequest = ({
             hardwareWalletRequiresConnection ||
             (messageIsScrollable && !hasScrolledMessage)
           }
+          submitButtonType={submitButtonType}
         />
         {showContractDetails && (
           <ContractDetailsModal

--- a/ui/pages/confirmations/token-allowance/token-allowance.js
+++ b/ui/pages/confirmations/token-allowance/token-allowance.js
@@ -75,6 +75,7 @@ import { Icon, IconName, Text } from '../../../components/component-library';
 import { ConfirmPageContainerWarning } from '../components/confirm-page-container/confirm-page-container-content';
 import CustomNonce from '../components/custom-nonce';
 import FeeDetailsComponent from '../components/fee-details-component/fee-details-component';
+import { BlockaidResultType } from '../../../../shared/constants/security-provider';
 
 const ALLOWED_HOSTS = ['portfolio.metamask.io'];
 
@@ -331,6 +332,10 @@ export default function TokenAllowance({
     </Box>
   );
 
+  const submitButtonType =
+    txData.securityAlertResponse?.result_type === BlockaidResultType.Malicious
+      ? 'danger-primary'
+      : 'primary';
   return (
     <Box className="token-allowance-container page-container">
       <Box>
@@ -622,6 +627,7 @@ export default function TokenAllowance({
         disabled={
           inputChangeInProgress || disableNextButton || disableApproveButton
         }
+        submitButtonType={submitButtonType}
       >
         {unapprovedTxCount > 1 && (
           <Button


### PR DESCRIPTION
## **Description**

On extension, when a transaction or signature request is flagged as malicious, the Confirm or Sign button should be red.

## **Related issues**

Fixes: [#1994](https://github.com/MetaMask/MetaMask-planning/issues/1994)

## **Manual testing steps**

1. Run MM
2. Open testdapp
3. Perform blockaid transactions and see that the confirm/sign button shows the primary (blue) color
4. Checkout this branch
5. Repeat 2-3, but this time notice the confirm/sign button shows the danger (red) color

## **Screenshots/Recordings**

### **Before**

https://github.com/MetaMask/metamask-extension/assets/44811/32b6cf67-76e1-4e44-9944-af20486822cf

### **After**

Uploading after_button_red.mov…

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained what problem this PR is solving and how it is solved.
- [x] I've linked related issues
- [x] I've included manual testing steps
- [x] I've included screenshots/recordings if applicable
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [x] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [x] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
