### PR TITLE
Fix #22938 - UX - Multichain - Send Flow - Update ENS address upon network change

### DIFF
--- a/ui/ducks/domains.js
+++ b/ui/ducks/domains.js
@@ -228,14 +228,15 @@ export async function fetchResolutions({ domain, address, chainId, state }) {
   return filteredResults;
 }
 
-export function lookupDomainName(domainName) {
+export function lookupDomainName(domainName, forceInitialize = false) {
   return async (dispatch, getState) => {
     const trimmedDomainName = domainName.trim();
     let state = getState();
-    if (state[name].stage === 'UNINITIALIZED') {
+    if (state[name].stage === 'UNINITIALIZED' || forceInitialize) {
       await dispatch(initializeDomainSlice());
     }
     state = getState();
+    let address;
     if (
       state[name].stage === 'NO_NETWORK_SUPPORT' &&
       !(
@@ -247,7 +248,6 @@ export function lookupDomainName(domainName) {
       await dispatch(domainNotSupported());
     } else {
       log.info(`Resolvers attempting to resolve name: ${trimmedDomainName}`);
-      let address;
       let fetchedResolutions;
       let hasSnapResolution = false;
       let error;
@@ -287,6 +287,7 @@ export function lookupDomainName(domainName) {
         }),
       );
     }
+    return address;
   };
 }
 

--- a/ui/ducks/send/send.js
+++ b/ui/ducks/send/send.js
@@ -717,6 +717,7 @@ export const initializeSendState = createAsyncThunk(
     return {
       account,
       newEnsAddress,
+      ens,
       chainId: getCurrentChainId(state),
       tokens: getTokens(state),
       chainHasChanged,
@@ -1636,6 +1637,9 @@ const slice = createSlice({
           }
           if (action.payload.newEnsAddress) {
             draftTransaction.recipient.address = action.payload.newEnsAddress;
+          }
+          if (action.payload.ens) {
+            draftTransaction.recipient.nickname = action.payload.ens;
           }
         }
         slice.caseReducers.updateGasFeeEstimates(state, {

--- a/ui/ducks/send/send.js
+++ b/ui/ducks/send/send.js
@@ -91,7 +91,7 @@ import {
   getTokens,
 } from '../metamask/metamask';
 
-import { resetDomainResolution } from '../domains';
+import { lookupDomainName, resetDomainResolution } from '../domains';
 import {
   isBurnAddress,
   isValidHexAddress,
@@ -618,6 +618,16 @@ export const initializeSendState = createAsyncThunk(
       );
     }
 
+    // If the user selects an ENS recipient and then changes the chain,
+    // the ENS address for the new chain may differ from the previous chain
+    // In this case, we should immediately trigger another lookup for the
+    // correct address on the new chain
+    const ens = draftTransaction.recipient.nickname;
+    let newEnsAddress = null;
+    if (chainHasChanged && isValidDomainName(ens)) {
+      newEnsAddress = await thunkApi.dispatch(lookupDomainName(ens, true));
+    }
+
     // Default gasPrice to 1 gwei if all estimation fails, this is only used
     // for gasLimit estimation and won't be set directly in state. Instead, we
     // will return the gasFeeEstimates and gasEstimateType so that the reducer
@@ -706,6 +716,7 @@ export const initializeSendState = createAsyncThunk(
 
     return {
       account,
+      newEnsAddress,
       chainId: getCurrentChainId(state),
       tokens: getTokens(state),
       chainHasChanged,
@@ -1622,6 +1633,9 @@ const slice = createSlice({
               draftTransaction.fromAccount?.balance ??
               state.selectedAccount.balance;
             draftTransaction.asset.details = null;
+          }
+          if (action.payload.newEnsAddress) {
+            draftTransaction.recipient.address = action.payload.newEnsAddress;
           }
         }
         slice.caseReducers.updateGasFeeEstimates(state, {

--- a/ui/pages/confirmations/send/send-content/add-recipient/domain-input.component.js
+++ b/ui/pages/confirmations/send/send-content/add-recipient/domain-input.component.js
@@ -32,6 +32,7 @@ export default class DomainInput extends Component {
     internalSearch: PropTypes.bool,
     userInput: PropTypes.string,
     onChange: PropTypes.func.isRequired,
+    chainId: PropTypes.string.isRequired,
     onReset: PropTypes.func.isRequired,
     lookupDomainName: PropTypes.func.isRequired,
     initializeDomainSlice: PropTypes.func.isRequired,
@@ -41,6 +42,13 @@ export default class DomainInput extends Component {
   componentDidMount() {
     this.props.initializeDomainSlice();
   }
+
+  componentDidUpdate = (prevProps) => {
+    const { chainId, userInput } = this.props;
+    if (prevProps.chainId !== chainId) {
+      this.onChange({ target: { value: userInput } });
+    }
+  };
 
   onPaste = (event) => {
     if (event.clipboardData.items?.length) {

--- a/ui/pages/confirmations/send/send-content/add-recipient/domain-input.container.js
+++ b/ui/pages/confirmations/send/send-content/add-recipient/domain-input.container.js
@@ -5,7 +5,13 @@ import {
   initializeDomainSlice,
   resetDomainResolution,
 } from '../../../../../ducks/domains';
+import { getCurrentChainId } from '../../../../../selectors';
 import DomainInput from './domain-input.component';
+
+// Trigger onChange when chainId changes using MapStateToProps
+function mapStateToProps(state) {
+  return { chainId: getCurrentChainId(state) };
+}
 
 function mapDispatchToProps(dispatch) {
   return {
@@ -21,4 +27,4 @@ function mapDispatchToProps(dispatch) {
   };
 }
 
-export default connect(null, mapDispatchToProps)(DomainInput);
+export default connect(mapStateToProps, mapDispatchToProps)(DomainInput);


### PR DESCRIPTION
## **Description**

Changing the network mid-send can effect ENS domains in a negative way.  Namely, an ENS domain can have a different addresses per chain.  This PR ensure that ENS lookups are done when the user changes chains.

## **Related issues**

Fixes:  https://github.com/MetaMask/metamask-extension/issues/22938

## **Manual testing steps**

### Scenario 1
0.  Have an ENS with two different address for Mainnet and Goerli
1.  Enter the new send flow
2. Type in the ENS on Mainnet -- see a search result with the correct address
3. Change the network picker to Goerli
4. See the address change in the search result

### Scenario 2
0.  Have an ENS with two different address for Mainnet and Goerli
1.  Enter the new send flow
2. Type in the ENS on Mainnet -- see a search result with the correct address
3. Click the search result (you'll go to the Amount screen)
4. Change the network picker to Goerli
5. See the address change in the recipient field change
6. Execute the transaction
7. Ensure token sent to correct address

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

(In the GitHub issue)

### **After**

Coming....

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've clearly explained what problem this PR is solving and how it is solved.
- [ ] I've linked related issues
- [ ] I've included manual testing steps
- [ ] I've included screenshots/recordings if applicable
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [ ] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
