### PR TITLE
Fixes #23026 - UX - Multichain - Send flow - Fix tabs in popup

### DIFF
--- a/ui/components/multichain/pages/send/index.scss
+++ b/ui/components/multichain/pages/send/index.scss
@@ -9,6 +9,7 @@
     .tabs__list {
       border-bottom: 0;
       background-color: transparent;
+      position: relative;
 
       .tab {
         width: 50%;


### PR DESCRIPTION
## **Description**

The `<Tabs>` component is `position: sticky` which is problematic.  Removing that positioning for now; we can improve in the future to make the stickiness better.

## **Related issues**

Fixes:  https://github.com/MetaMask/metamask-extension/issues/23026

## **Manual testing steps**

1. Open the new send flow in popup with 10+ contacts
2. Scroll down
3. See tabs overlap content

## **Screenshots/Recordings**

### **Before**

<img width="356" alt="SCR-20240216-nilk" src="https://github.com/MetaMask/metamask-extension/assets/46655/17cdd78a-aeec-4489-a0eb-137e64138924">

### **After**


https://github.com/MetaMask/metamask-extension/assets/46655/4c9cdbc8-a7b5-4fa4-b831-2cba03aed56a




## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've clearly explained what problem this PR is solving and how it is solved.
- [ ] I've linked related issues
- [ ] I've included manual testing steps
- [ ] I've included screenshots/recordings if applicable
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [ ] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
