### PR TITLE
Fix #22987 - UX - Multichain - Send flow - Select NFTs tab in Asset Picker when an NFT is selected

### DIFF
--- a/ui/components/multichain/asset-picker-amount/asset-picker-modal/asset-picker-modal.tsx
+++ b/ui/components/multichain/asset-picker-amount/asset-picker-modal/asset-picker-modal.tsx
@@ -232,6 +232,8 @@ export function AssetPickerModal({
     onClose();
   };
 
+  const defaultActiveTabKey = asset?.type === AssetType.NFT ? 'nfts' : 'tokens';
+
   return (
     <Modal
       className="asset-picker-modal"
@@ -245,7 +247,10 @@ export function AssetPickerModal({
           {t('selectAToken')}
         </ModalHeader>
         <Box style={{ flexGrow: '1' }}>
-          <Tabs defaultActiveTabKey="details" tabsClassName="modal-tab__tabs">
+          <Tabs
+            defaultActiveTabKey={defaultActiveTabKey}
+            tabsClassName="modal-tab__tabs"
+          >
             {
               // eslint-disable-next-line @typescript-eslint/ban-ts-comment
               // @ts-ignore


### PR DESCRIPTION

## **Description**

When the user is in the new send flow and an NFT has been selected as the asset to send, if the user re-opens the AssetPicker, the NFTs tab should display immediately

## **Related issues**

Fixes: #22987

## **Manual testing steps**

1. Start the new send flow
2. Choose a recipient
3. Click the asset picker, choose an NFT as the asset
4. Click the asset picker again
5. See the NFT tab display by default

## **Screenshots/Recordings**

### **Before**

N/A

### **After**


https://github.com/MetaMask/metamask-extension/assets/46655/5e4bf3ce-05cd-4955-af7a-289d050f6cba



## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've clearly explained what problem this PR is solving and how it is solved.
- [ ] I've linked related issues
- [ ] I've included manual testing steps
- [ ] I've included screenshots/recordings if applicable
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [ ] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
