### PR TITLE
Add additional snap installation metrics

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -2391,6 +2391,49 @@ export default class MetamaskController extends EventEmitter {
     );
 
     ///: BEGIN:ONLY_INCLUDE_IF(snaps)
+
+    this.controllerMessenger.subscribe(
+      `${this.snapController.name}:snapInstallStarted`,
+      (snapId, origin, isUpdate) => {
+        const snapCategory = this._getSnapMetadata(snapId)?.category;
+        this.metaMetricsController.trackEvent({
+          event: isUpdate
+            ? MetaMetricsEventName.SnapUpdateStarted
+            : MetaMetricsEventName.SnapInstallStarted,
+          category: MetaMetricsEventCategory.Snaps,
+          properties: {
+            snap_id: snapId,
+            origin,
+            snap_category: snapCategory,
+          },
+        });
+      },
+    );
+
+    this.controllerMessenger.subscribe(
+      `${this.snapController.name}:snapInstallFailed`,
+      (snapId, origin, isUpdate, error) => {
+        const isRejected = error.includes('User rejected the request.');
+        const failedEvent = isUpdate
+          ? MetaMetricsEventName.SnapUpdateFailed
+          : MetaMetricsEventName.SnapInstallFailed;
+        const rejectedEvent = isUpdate
+          ? MetaMetricsEventName.SnapUpdateRejected
+          : MetaMetricsEventName.SnapInstallRejected;
+
+        const snapCategory = this._getSnapMetadata(snapId)?.category;
+        this.metaMetricsController.trackEvent({
+          event: isRejected ? rejectedEvent : failedEvent,
+          category: MetaMetricsEventCategory.Snaps,
+          properties: {
+            snap_id: snapId,
+            origin,
+            snap_category: snapCategory,
+          },
+        });
+      },
+    );
+
     this.controllerMessenger.subscribe(
       `${this.snapController.name}:snapInstalled`,
       (truncatedSnap, origin) => {

--- a/shared/constants/metametrics.ts
+++ b/shared/constants/metametrics.ts
@@ -659,8 +659,14 @@ export enum MetaMetricsEventName {
   ExitedSwaps = 'Exited Swaps',
   SwapError = 'Swap Error',
   ///: BEGIN:ONLY_INCLUDE_IF(snaps)
+  SnapInstallStarted = 'Snap Install Started',
+  SnapInstallFailed = 'Snap Install Failed',
+  SnapInstallRejected = 'Snap Update Rejected',
   SnapInstalled = 'Snap Installed',
   SnapUninstalled = 'Snap Uninstalled',
+  SnapUpdateStarted = 'Snap Update Started',
+  SnapUpdateRejected = 'Snap Update Rejected',
+  SnapUpdateFailed = 'Snap Update Failed',
   SnapUpdated = 'Snap Updated',
   SnapExportUsed = 'Snap Export Used',
   ///: END:ONLY_INCLUDE_IF


### PR DESCRIPTION
## **Description**

Adds additional snap installation metrics to be collected via the **opt-in** MetaMetrics program. 

Adds events for when snap installation and updating is started and ended prematurely (either rejected or otherwise failed).

## **Related issues**

Closes: https://github.com/MetaMask/MetaMask-planning/issues/1839
