### PR TITLE
feat: port MMI related logic to personal sign page

### DIFF
--- a/ui/hooks/useMMIConfirmations.ts
+++ b/ui/hooks/useMMIConfirmations.ts
@@ -1,0 +1,48 @@
+import { TransactionType } from '@metamask/transaction-controller';
+import { useCallback } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+
+import { currentConfirmationSelector } from '../pages/confirmations/selectors';
+import { getAccountType } from '../selectors';
+import { completedTx, showModal } from '../store/actions';
+import { mmiActionsFactory } from '../store/institutional/institution-background';
+
+export function useMMIConfirmationInfo() {
+  const dispatch = useDispatch();
+  const currentConfirmation = useSelector(currentConfirmationSelector);
+  const accountType = useSelector(getAccountType);
+
+  const mmiOnSignCallback = useCallback(async () => {
+    if (
+      !currentConfirmation ||
+      currentConfirmation.type !== TransactionType.personalSign
+    ) {
+      return;
+    }
+    try {
+      dispatch(completedTx(currentConfirmation.id));
+    } catch (err: any) {
+      dispatch(
+        showModal({
+          name: 'TRANSACTION_FAILED',
+          errorMessage: err.message,
+          closeNotification: true,
+          operationFailed: true,
+        }),
+      );
+    } finally {
+      if (accountType === 'custody') {
+        const mmiActions = mmiActionsFactory();
+        dispatch(mmiActions.setWaitForConfirmDeepLinkDialog(true));
+      }
+    }
+  }, []);
+
+  return {
+    mmiSubmitDisabled:
+      currentConfirmation &&
+      currentConfirmation.type === TransactionType.personalSign &&
+      Boolean(currentConfirmation?.custodyId),
+    mmiOnSignCallback,
+  };
+}

--- a/ui/pages/confirmations/components/confirm/footer/footer.stories.tsx
+++ b/ui/pages/confirmations/components/confirm/footer/footer.stories.tsx
@@ -1,10 +1,28 @@
 import React from 'react';
+import { Provider } from 'react-redux';
+
+import mockState from '../../../../../../test/data/mock-state.json';
+import configureStore from '../../../../../store/store';
+
 import Footer from './footer';
+
+const store = configureStore({
+  metamask: {
+    ...mockState.metamask,
+  },
+  confirm: {
+    currentConfirmation: {
+      msgParams: {
+        from: '0x0dcd5d886577d5081b0c52e242ef29e70be3e7bc',
+      },
+    },
+  },
+});
 
 const Story = {
   title: 'Confirmations/Components/Confirm/Footer',
   component: Footer,
-  args: {},
+  decorators: [(story: any) => <Provider store={store}>{story()}</Provider>],
 };
 
 export default Story;

--- a/ui/pages/confirmations/components/confirm/footer/footer.test.tsx
+++ b/ui/pages/confirmations/components/confirm/footer/footer.test.tsx
@@ -4,7 +4,10 @@ import mockState from '../../../../../../test/data/mock-state.json';
 import { fireEvent, renderWithProvider } from '../../../../../../test/jest';
 import * as Actions from '../../../../../store/actions';
 import configureStore from '../../../../../store/store';
-
+import {
+  LedgerTransportTypes,
+  WebHIDConnectedStatuses,
+} from '../../../../../../shared/constants/hardware-wallets';
 import Footer from './footer';
 
 jest.mock('react-redux', () => ({
@@ -12,12 +15,7 @@ jest.mock('react-redux', () => ({
   useDispatch: () => jest.fn(),
 }));
 
-jest.mock('react-redux', () => ({
-  ...jest.requireActual('react-redux'),
-  useDispatch: () => jest.fn(),
-}));
-
-const render = () => {
+const render = (args = {}) => {
   const store = configureStore({
     metamask: {
       ...mockState.metamask,
@@ -29,6 +27,7 @@ const render = () => {
         },
       },
     },
+    ...args,
   });
 
   return renderWithProvider(<Footer />, store);
@@ -60,11 +59,33 @@ describe('ConfirmFooter', () => {
 
   it('invoke action resolvePendingApproval when submit button is clicked', () => {
     const { getAllByRole } = render();
-    const cancelButton = getAllByRole('button')[1];
+    const submitButton = getAllByRole('button')[1];
     const resolveSpy = jest
       .spyOn(Actions, 'resolvePendingApproval')
       .mockImplementation(() => ({} as any));
-    fireEvent.click(cancelButton);
+    fireEvent.click(submitButton);
     expect(resolveSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('disables submit button if required LedgerHidConnection is not yet established', () => {
+    const { getAllByRole } = render({
+      metamask: {
+        ...mockState.metamask,
+        ledgerTransportType: LedgerTransportTypes.webhid,
+      },
+      confirm: {
+        currentConfirmation: {
+          msgParams: {
+            from: '0xc42edfcc21ed14dda456aa0756c153f7985d8813',
+          },
+        },
+      },
+      appState: {
+        ...mockState.appState,
+        ledgerWebHidConnectedStatus: WebHIDConnectedStatuses.notConnected,
+      },
+    });
+    const submitButton = getAllByRole('button')[1];
+    expect(submitButton).toBeDisabled();
   });
 });

--- a/ui/pages/confirmations/components/confirm/footer/footer.tsx
+++ b/ui/pages/confirmations/components/confirm/footer/footer.tsx
@@ -8,16 +8,34 @@ import {
   ButtonVariant,
 } from '../../../../../components/component-library';
 import { Footer as PageFooter } from '../../../../../components/multichain/pages/page';
-import { currentConfirmationSelector } from '../../../../../selectors';
+import { useI18nContext } from '../../../../../hooks/useI18nContext';
+import { useMMIConfirmationInfo } from '../../../../../hooks/useMMIConfirmations';
+import { doesAddressRequireLedgerHidConnection } from '../../../../../selectors';
 import {
   rejectPendingApproval,
   resolvePendingApproval,
 } from '../../../../../store/actions';
-import { useI18nContext } from '../../../../../hooks/useI18nContext';
+import { currentConfirmationSelector } from '../../../selectors';
 
 const Footer = () => {
   const t = useI18nContext();
   const currentConfirmation = useSelector(currentConfirmationSelector);
+  ///: BEGIN:ONLY_INCLUDE_IF(build-mmi)
+  const { mmiOnSignCallback, mmiSubmitDisabled } = useMMIConfirmationInfo();
+  ///: END:ONLY_INCLUDE_IF
+
+  let from: string | undefined;
+  // todo: extend to other confirmation types
+  if (currentConfirmation?.msgParams) {
+    from = currentConfirmation?.msgParams?.from;
+  }
+  const hardwareWalletRequiresConnection = useSelector((state) => {
+    if (from) {
+      return doesAddressRequireLedgerHidConnection(state, from);
+    }
+    return false;
+  });
+
   const dispatch = useDispatch();
 
   const onCancel = useCallback(() => {
@@ -37,6 +55,9 @@ const Footer = () => {
       return;
     }
     dispatch(resolvePendingApproval(currentConfirmation.id, undefined));
+    ///: BEGIN:ONLY_INCLUDE_IF(build-mmi)
+    mmiOnSignCallback();
+    ///: END:ONLY_INCLUDE_IF
   }, [currentConfirmation]);
 
   return (
@@ -49,7 +70,17 @@ const Footer = () => {
       >
         {t('cancel')}
       </Button>
-      <Button block onClick={onSubmit} size={ButtonSize.Lg}>
+      <Button
+        block
+        onClick={onSubmit}
+        size={ButtonSize.Lg}
+        disabled={
+          ///: BEGIN:ONLY_INCLUDE_IF(build-mmi)
+          mmiSubmitDisabled ||
+          ///: END:ONLY_INCLUDE_IF
+          hardwareWalletRequiresConnection
+        }
+      >
         {t('confirm')}
       </Button>
     </PageFooter>

--- a/ui/pages/confirmations/components/confirm/nav/nav.tsx
+++ b/ui/pages/confirmations/components/confirm/nav/nav.tsx
@@ -3,8 +3,6 @@ import React, { useCallback, useMemo } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useHistory } from 'react-router-dom';
 
-import { ApprovalType } from '@metamask/controller-utils';
-
 import {
   Box,
   Button,
@@ -36,12 +34,7 @@ import {
   pendingConfirmationsSortedSelector,
 } from '../../../../../selectors';
 import { rejectPendingApproval } from '../../../../../store/actions';
-
-const SignatureApprovalTypes = [
-  ApprovalType.EthSign,
-  ApprovalType.PersonalSign,
-  ApprovalType.EthSignTypedData,
-];
+import { isSignatureApprovalRequest } from '../../../utils';
 
 const Nav = () => {
   const history = useHistory();
@@ -68,8 +61,10 @@ const Nav = () => {
       // In new routing all confirmations will support
       // "/confirm-transaction/<confirmation_id>"
       history.replace(
-        `${CONFIRM_TRANSACTION_ROUTE}/${nextConfirmation.id}${
-          SignatureApprovalTypes.includes(nextConfirmation.type as ApprovalType)
+        `${CONFIRM_TRANSACTION_ROUTE}/${
+          pendingConfirmations[currentConfirmationPosition + pos].id
+        }${
+          isSignatureApprovalRequest(nextConfirmation)
             ? SIGNATURE_REQUEST_PATH
             : ''
         }`,

--- a/ui/pages/confirmations/hooks/syncConfirmPath.ts
+++ b/ui/pages/confirmations/hooks/syncConfirmPath.ts
@@ -3,7 +3,7 @@ import { useSelector } from 'react-redux';
 import { useHistory, useParams } from 'react-router-dom';
 
 import { CONFIRM_TRANSACTION_ROUTE } from '../../../helpers/constants/routes';
-import { currentConfirmationSelector } from '../../../selectors/confirm';
+import { currentConfirmationSelector } from '../selectors/confirm';
 
 const syncConfirmPath = () => {
   const history = useHistory();

--- a/ui/pages/confirmations/selectors/confirm.test.ts
+++ b/ui/pages/confirmations/selectors/confirm.test.ts
@@ -1,7 +1,7 @@
 import { ApprovalType } from '@metamask/controller-utils';
 import { TransactionType } from '@metamask/transaction-controller';
+import { ConfirmMetamaskState } from '../types/confirm';
 import {
-  ConfirmMetamaskState,
   currentConfirmationSelector,
   latestPendingConfirmationSelector,
   pendingConfirmationsSelector,

--- a/ui/pages/confirmations/selectors/confirm.ts
+++ b/ui/pages/confirmations/selectors/confirm.ts
@@ -1,31 +1,7 @@
 import { ApprovalType } from '@metamask/controller-utils';
-import { ApprovalControllerState } from '@metamask/approval-controller';
-import { TransactionType } from '@metamask/transaction-controller';
 
-import { getPendingApprovals } from './approvals';
-
-type SignatureRequestType = {
-  chainId?: string;
-  id: string;
-  msgParams?: {
-    from: string;
-    origin: string;
-    data: string;
-  };
-  type: TransactionType;
-};
-
-type Confirmation = SignatureRequestType;
-
-export type ConfirmMetamaskState = {
-  confirm: {
-    currentConfirmation?: Confirmation;
-  };
-  metamask: {
-    pendingApprovals: ApprovalControllerState['pendingApprovals'];
-    approvalFlows: ApprovalControllerState['approvalFlows'];
-  };
-};
+import { getPendingApprovals } from '../../../selectors/approvals';
+import { ConfirmMetamaskState } from '../types/confirm';
 
 const ConfirmationApprovalTypes = [
   ApprovalType.EthSign,

--- a/ui/pages/confirmations/selectors/index.ts
+++ b/ui/pages/confirmations/selectors/index.ts
@@ -1,0 +1,1 @@
+export * from './confirm';

--- a/ui/pages/confirmations/types/confirm.ts
+++ b/ui/pages/confirmations/types/confirm.ts
@@ -1,0 +1,26 @@
+import { ApprovalControllerState } from '@metamask/approval-controller';
+import { TransactionType } from '@metamask/transaction-controller';
+
+export type SignatureRequestType = {
+  chainId?: string;
+  id: string;
+  msgParams?: {
+    from: string;
+    origin: string;
+    data: string;
+  };
+  type: TransactionType;
+  custodyId?: string;
+};
+
+export type Confirmation = SignatureRequestType;
+
+export type ConfirmMetamaskState = {
+  confirm: {
+    currentConfirmation?: Confirmation;
+  };
+  metamask: {
+    pendingApprovals: ApprovalControllerState['pendingApprovals'];
+    approvalFlows: ApprovalControllerState['approvalFlows'];
+  };
+};

--- a/ui/pages/confirmations/utils/confirm.test.ts
+++ b/ui/pages/confirmations/utils/confirm.test.ts
@@ -1,0 +1,21 @@
+import { ApprovalRequest } from '@metamask/approval-controller';
+import { ApprovalType } from '@metamask/controller-utils';
+
+import { isSignatureApprovalRequest } from './confirm';
+
+describe('confirm util', () => {
+  describe('isSignatureApprovalRequest', () => {
+    it('returns true for signature approval requests', () => {
+      const result = isSignatureApprovalRequest({
+        type: ApprovalType.PersonalSign,
+      } as ApprovalRequest<any>);
+      expect(result).toStrictEqual(true);
+    });
+    it('returns false for request not of type signature', () => {
+      const result = isSignatureApprovalRequest({
+        type: ApprovalType.Transaction,
+      } as ApprovalRequest<any>);
+      expect(result).toStrictEqual(false);
+    });
+  });
+});

--- a/ui/pages/confirmations/utils/confirm.ts
+++ b/ui/pages/confirmations/utils/confirm.ts
@@ -1,0 +1,13 @@
+import { ApprovalRequest } from '@metamask/approval-controller';
+import { ApprovalType } from '@metamask/controller-utils';
+import { Json } from '@metamask/utils';
+
+const SignatureApprovalTypes = [
+  ApprovalType.EthSign,
+  ApprovalType.PersonalSign,
+  ApprovalType.EthSignTypedData,
+];
+
+export const isSignatureApprovalRequest = (
+  request: ApprovalRequest<Record<string, Json>>,
+) => SignatureApprovalTypes.includes(request.type as ApprovalType);

--- a/ui/pages/confirmations/utils/index.ts
+++ b/ui/pages/confirmations/utils/index.ts
@@ -1,0 +1,1 @@
+export * from './confirm';

--- a/ui/selectors/index.js
+++ b/ui/selectors/index.js
@@ -1,4 +1,4 @@
-export * from './confirm';
+export * from '../pages/confirmations/selectors/confirm';
 export * from './confirm-transaction';
 export * from './custom-gas';
 export * from './first-time-flow';


### PR DESCRIPTION
## **Description**

Port current personal sign MMI related logic to new designs.

## **Related issues**

Fixes: MetaMask/metamask-extension#22970

## **Manual testing steps**
NA

## **Screenshots/Recordings**
NA

## **Pre-merge author checklist**

- [X] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've clearly explained what problem this PR is solving and how it is solved.
- [X] I've linked related issues
- [ ] I've included manual testing steps
- [ ] I've included screenshots/recordings if applicable
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [X] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [X] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
