### PR TITLE
[DOCS] fix broken link to husky in README under 'git hooks'

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ To get quick feedback from our shared code quality fitness functions before comm
 
 You can read more about them in our [testing documentation](./docs/testing.md#fitness-functions-measuring-progress-in-code-quality-and-preventing-regressions-using-custom-git-hooks).
 
-If you are using VS Code and are unable to make commits from the source control sidebar due to a "command not found" error, try these steps from the [Husky docs](https://typicode.github.io/husky/troubleshooting.html#command-not-found).
+If you are using VS Code and are unable to make commits from the source control sidebar due to a "command not found" error, try these steps from the [Husky docs](https://typicode.github.io/husky/troubleshoot.html#command-not-found).
 
 ## Contributing
 


### PR DESCRIPTION
Quick fix to the README.

Old link points to https://typicode.github.io/husky/troubleshooting.html#command-not-found

Correct link is: https://typicode.github.io/husky/troubleshoot.html#command-not-found