### PR TITLE
[MMI] Rely in custodian environment name (envName) for method findCustodianByDisplayName 

### DIFF
--- a/ui/helpers/utils/institutional/find-by-custodian-name.test.ts
+++ b/ui/helpers/utils/institutional/find-by-custodian-name.test.ts
@@ -1,6 +1,6 @@
-import { findCustodianByDisplayName } from './find-by-custodian-name';
+import { findCustodianByEnvName } from './find-by-custodian-name';
 
-describe('findCustodianByDisplayName', () => {
+describe('findCustodianByEnvName', () => {
   const custodians = [
     {
       type: 'JSONRPC',
@@ -33,21 +33,21 @@ describe('findCustodianByDisplayName', () => {
       version: 2,
     },
   ];
-  it('should return the custodian if the display name is found in custodianKey', () => {
-    const displayName = 'Qredo';
-    const custodian = findCustodianByDisplayName(displayName, custodians);
-    expect(custodian?.name).toBe('Qredo');
+  it('should return the custodian if the env name is found in custodianKey', () => {
+    const envName = 'Qredo';
+    const custodian = findCustodianByEnvName(envName, custodians);
+    expect(custodian?.envName).toBe('qredo');
   });
 
-  it('should return the custodian if the display name is found in custodianDisplayName', () => {
-    const displayName = 'Saturn Custody';
-    const custodian = findCustodianByDisplayName(displayName, custodians);
-    expect(custodian?.name).toContain('Saturn');
+  it('should return the custodian if the env name is found in custodianDisplayName', () => {
+    const envName = 'Saturn Custody';
+    const custodian = findCustodianByEnvName(envName, custodians);
+    expect(custodian?.envName).toContain('saturn');
   });
 
   it('should return null if no matching custodian is found', () => {
-    const displayName = 'Non-existent Custodian';
-    const custodian = findCustodianByDisplayName(displayName, custodians);
+    const envName = 'Non-existent Custodian';
+    const custodian = findCustodianByEnvName(envName, custodians);
     expect(custodian).toBeNull();
   });
 });

--- a/ui/helpers/utils/institutional/find-by-custodian-name.ts
+++ b/ui/helpers/utils/institutional/find-by-custodian-name.ts
@@ -13,24 +13,20 @@ type Custodian = {
   version: number;
 };
 
-// TODO (Bernardo) - There can be multiple custodian with the same name, envName should be used instead
-export function findCustodianByDisplayName(
-  displayName: string,
+export function findCustodianByEnvName(
+  envName: string,
   custodians: Custodian[],
 ): Custodian | null {
-  const formatedDisplayName = displayName.toLowerCase();
+  const formatedEnvName = envName.toLowerCase();
 
   if (!custodians) {
     return null;
   }
 
   for (const custodian of custodians) {
-    const custodianName = custodian.name.toLowerCase();
+    const custodianName = custodian.envName.toLowerCase();
 
-    if (
-      custodianName.length !== 0 &&
-      formatedDisplayName.includes(custodianName)
-    ) {
+    if (custodianName.length !== 0 && formatedEnvName.includes(custodianName)) {
       return custodian;
     }
   }

--- a/ui/pages/institutional/confirm-add-custodian-token/confirm-add-custodian-token.js
+++ b/ui/pages/institutional/confirm-add-custodian-token/confirm-add-custodian-token.js
@@ -31,7 +31,7 @@ import {
   MetaMetricsEventName,
 } from '../../../../shared/constants/metametrics';
 import { getInstitutionalConnectRequests } from '../../../ducks/institutional/institutional';
-import { findCustodianByDisplayName } from '../../../helpers/utils/institutional/find-by-custodian-name';
+import { findCustodianByEnvName } from '../../../helpers/utils/institutional/find-by-custodian-name';
 
 const ConfirmAddCustodianToken = () => {
   const t = useContext(I18nContext);
@@ -125,7 +125,10 @@ const ConfirmAddCustodianToken = () => {
   const custodianLabel =
     connectRequest.labels?.find((label) => label.key === 'service')?.value ||
     t('custodian');
-  const custodian = findCustodianByDisplayName(custodianLabel, custodians);
+  const custodian = findCustodianByEnvName(
+    connectRequest.environment,
+    custodians,
+  );
 
   return (
     <Box className="page-container">

--- a/ui/pages/institutional/custody/custody.js
+++ b/ui/pages/institutional/custody/custody.js
@@ -53,7 +53,7 @@ import {
 } from '../../../../shared/constants/metametrics';
 import PulseLoader from '../../../components/ui/pulse-loader/pulse-loader';
 import ConfirmConnectCustodianModal from '../confirm-connect-custodian-modal';
-import { findCustodianByDisplayName } from '../../../helpers/utils/institutional/find-by-custodian-name';
+import { findCustodianByEnvName } from '../../../helpers/utils/institutional/find-by-custodian-name';
 import { setSelectedAddress } from '../../../store/actions';
 
 const GK8_DISPLAY_NAME = 'gk8';
@@ -125,8 +125,8 @@ const CustodyPage = () => {
 
     async function handleButtonClick(custodian) {
       try {
-        const custodianByDisplayName = findCustodianByDisplayName(
-          custodian.displayName,
+        const custodianByDisplayName = findCustodianByEnvName(
+          custodian.envName,
           custodians,
         );
 


### PR DESCRIPTION
## **Description**

Currently, in findCustodianByDisplayName we are using the displayName as the filtering value, when in fact we can have the same name being used by two custodian instances, example Saturn or Liminal. So it should be better to filter by envName instead since we are guaranteed to have unique names there.

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MMI-4565

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained what problem this PR is solving and how it is solved.
- [x] I've linked related issues
- [x] I've included manual testing steps
- [x] I've included screenshots/recordings if applicable
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [x] I’ve properly set the pull request status:
  - [x] In case it's not yet "ready for review", I've set it to "draft".
  - [x] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
