### PR TITLE
chore: disabling static color hex stylelint rule for specific files

### DIFF
--- a/development/ts-migration-dashboard/app/styles/custom-elements.scss
+++ b/development/ts-migration-dashboard/app/styles/custom-elements.scss
@@ -1,3 +1,7 @@
+/*
+Disabling Stylelint's hex color rule here because the TypeScript migration dashboard, being external to the main app, doesn't use design tokens.
+*/
+/* stylelint-disable color-no-hex */
 :root {
   --blue-gray-350: hsl(209deg 13.7% 62.4%);
   --blue-gray-100: hsl(209.8deg 16.5% 89%);

--- a/development/ts-migration-dashboard/app/styles/tippy.scss
+++ b/development/ts-migration-dashboard/app/styles/tippy.scss
@@ -1,3 +1,7 @@
+/*
+Disabling Stylelint's hex color rule here because the TypeScript migration dashboard, being external to the main app, doesn't use design tokens.
+*/
+/* stylelint-disable color-no-hex */
 .tippy-touch {
   cursor: pointer !important;
 }

--- a/ui/css/design-system/pending-colors.scss
+++ b/ui/css/design-system/pending-colors.scss
@@ -1,6 +1,9 @@
 /**
   These colors are pending to be approved for the design system's design-token package
+  Disabling Stylelint's hex color rule so this file is ignored.
+  Before adding a color here make sure that there isn't a design token available.
 **/
+/* stylelint-disable color-no-hex */
 
 /**
  * Dark Theme Colors

--- a/ui/css/utilities/colors.scss
+++ b/ui/css/utilities/colors.scss
@@ -1,3 +1,8 @@
+/*
+Disabling Stylelint's hex color rule so this file is ignored.
+Before adding a color here make sure that there isn't a design token available.
+*/
+/* stylelint-disable color-no-hex */
 :root {
   // Accents
   // Everything below this line is part of the new color system
@@ -12,3 +17,4 @@
   // Required for the QR reader to work properly
   --qr-code-white-background: #fff;
 }
+/* stylelint-enable color-no-hex */

--- a/ui/css/utilities/colors.scss
+++ b/ui/css/utilities/colors.scss
@@ -17,4 +17,3 @@ Before adding a color here make sure that there isn't a design token available.
   // Required for the QR reader to work properly
   --qr-code-white-background: #fff;
 }
-/* stylelint-enable color-no-hex */


### PR DESCRIPTION
## **Description**

This PR addresses the need to refine our linting process by excluding specific files from the 'color-no-hex' rule, as outlined in [Issue #23097](https://github.com/MetaMask/metamask-extension/issues/23097). The motivation behind this change is to prevent lint warning blindness among developers by focusing on meaningful lint warnings that are relevant to the main application. By updating our lint configuration to ignore certain files where static hex color values are permissible, we aim to maintain the effectiveness of our linting process while acknowledging the unique requirements of standalone or external parts of our project.

### **Improvement/Solution**
- Updated the lint configuration to exclude specific files from the 'color-no-hex' rule.
- Identified files where static hex color values are permissible due to their standalone nature or external usage.

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/23097

## **Manual testing steps**

1. Pull this branch
2. Run `yarn lint` 
3. Notice that there shouldn't be any static hex value warnings from stylelint

## **Screenshots/Recordings**

### **Before**
Below screencast shows warnings that should be ignored

https://github.com/MetaMask/metamask-extension/assets/8112138/6cd7d6ea-44da-4b7e-b594-931e9b22a007


### **After**
Below screencast shows no more stylelint warnings for static hex

https://github.com/MetaMask/metamask-extension/assets/8112138/a483fe16-eb82-46ae-8666-e62da418a95a

Linting still works as intended for other files


https://github.com/MetaMask/metamask-extension/assets/8112138/e2e43b34-ea6b-430b-8d2b-a7f662e30e0d


## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained what problem this PR is solving and how it is solved.
- [x] I've linked related issues.
- [x] I've included manual testing steps.
- [x] I’ve included tests if applicable.
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable.
- [x] I’ve applied the right labels on the PR.
- [x] I’ve properly set the pull request status to "ready for review".

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g., pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the issue it closes and includes the necessary testing evidence.

This PR template is filled out with a concise description of the changes, the motivation behind them, and the solution provided. It also includes a link to the related issue, outlines the manual testing steps, and adheres to the pre-merge checklists for both the author and the reviewer.