### PR TITLE
Fix NaN issue in Product Tour Popover

### DIFF
--- a/ui/components/multichain/product-tour-popover/product-tour-popover.js
+++ b/ui/components/multichain/product-tour-popover/product-tour-popover.js
@@ -110,9 +110,10 @@ export const ProductTour = ({
             paddingTop={2}
             color={TextColor.infoInverse}
             variant={TextVariant.bodyMd}
+            data-testid="multichain-product-tour-menu-popover-step-counter"
           >
             {currentStep && totalSteps
-              ? { currentStep } / { totalSteps }
+              ? `${currentStep} / ${totalSteps}`
               : null}
           </Text>
           <ButtonBase

--- a/ui/components/multichain/product-tour-popover/product-tour-popover.test.js
+++ b/ui/components/multichain/product-tour-popover/product-tour-popover.test.js
@@ -28,4 +28,16 @@ describe('DetectedTokensBanner', () => {
     );
     expect(prevIcon).toBeInTheDocument();
   });
+  it('should render correct steps', () => {
+    const { getByText } = render(
+      <ProductTour
+        anchorElement={document.body}
+        {...props}
+        prevIcon
+        currentStep={2}
+        totalSteps={5}
+      />,
+    );
+    expect(getByText('2 / 5')).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## **Description**
The Popover is displaying NaN because the '/' was not being treated as a string.
Fixed that and added a test to help prevent it in the future.
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/23100?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/pull/22905/files#r1498090474

## **Manual testing steps**

1. Fresh install of metamask, open popup
2. Verify that the product tour popover starts by displaying 1/3
3. run tests with `yarn jest ui/components/multichain/product-tour-popover/product-tour-popover.test.js`
4. Verify new test passes 'should render correct steps' or fails under the right circumstances

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->
<img width="353" alt="image" src="https://github.com/MetaMask/metamask-extension/assets/10986371/dfd8e9d8-a8db-4426-aea9-5208fa2a24d7">


## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've clearly explained what problem this PR is solving and how it is solved.
- [ ] I've linked related issues
- [ ] I've included manual testing steps
- [ ] I've included screenshots/recordings if applicable
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [ ] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
