### PR TITLE
fix(#23072): display ENS in confirmation screen

### DIFF
--- a/ui/components/ui/sender-to-recipient/sender-to-recipient.component.js
+++ b/ui/components/ui/sender-to-recipient/sender-to-recipient.component.js
@@ -114,6 +114,7 @@ export function RecipientWithAddress({
   const [showNicknamePopovers, setShowNicknamePopovers] = useState(false);
   const [addressCopied, setAddressCopied] = useState(false);
   const petnamesEnabled = usePetnamesEnabled();
+  const hasRecipientEns = Boolean(recipientEns);
 
   let tooltipHtml = <p>{t('copiedExclamation')}</p>;
   if (!addressCopied) {
@@ -152,20 +153,20 @@ export function RecipientWithAddress({
           }
         }}
       >
-        {!petnamesEnabled && (
+        {(!petnamesEnabled || hasRecipientEns) && (
           <div className="sender-to-recipient__sender-icon">
             <Identicon address={checksummedRecipientAddress} diameter={24} />
           </div>
         )}
         <Tooltip
           position="bottom"
-          disabled={!recipientName}
+          disabled={!recipientName || hasRecipientEns}
           html={tooltipHtml}
           wrapperClassName="sender-to-recipient__tooltip-wrapper"
           containerClassName="sender-to-recipient__tooltip-container"
           onHidden={() => setAddressCopied(false)}
         >
-          {petnamesEnabled ? (
+          {petnamesEnabled && !hasRecipientEns ? (
             <Name
               value={checksummedRecipientAddress}
               type={NameType.ETHEREUM_ADDRESS}
@@ -180,7 +181,8 @@ export function RecipientWithAddress({
           )}
         </Tooltip>
       </div>
-      {showNicknamePopovers && !petnamesEnabled ? (
+      {(showNicknamePopovers && !petnamesEnabled) ||
+      (showNicknamePopovers && hasRecipientEns) ? (
         <NicknamePopovers
           onClose={() => setShowNicknamePopovers(false)}
           address={checksummedRecipientAddress}


### PR DESCRIPTION
## **Description**

This PR displays ENS in confirmation screen when recipient is added as ENS instead of an address

## **Related issues**

Fixes: #23072 

## **Manual testing steps**

1. Select Mainnet
2. Click Send
3. Add an ENS recipient ie vitalik.eth
4. Proceed to the next screen
5. See ENS is displayed

## **Screenshots/Recordings**


### **Before**

[<!-- [screenshots/recordings] -->](https://github.com/MetaMask/metamask-extension/assets/7896429/7f123ee6-075f-4b3c-9802-827129a0be79)

### **After**


https://github.com/MetaMask/metamask-extension/assets/7896429/7d06c4b3-338d-44fa-b332-9e7014d65060


## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained what problem this PR is solving and how it is solved.
- [x] I've linked related issues
- [x] I've included manual testing steps
- [x] I've included screenshots/recordings if applicable
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [x] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [x] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
