### PR TITLE
feat(mock-segment): add -v/--verbose option

### DIFF
--- a/development/README.md
+++ b/development/README.md
@@ -21,6 +21,8 @@ To start the [Mock Segment API](./mock-segment.js):
     node development/mock-segment.js
     ```
 
+    > You can also provide the `-v`/`--verbose` option to dump more information from the events.
+
 Events triggered whilst using the extension will be logged to the console of the Mock Segment API.
 
 More information on the API and its usage can be found [here](./mock-segment.js#L28).

--- a/development/mock-segment.js
+++ b/development/mock-segment.js
@@ -4,16 +4,27 @@ const { parsePort } = require('./lib/parse-port');
 
 const DEFAULT_PORT = 9090;
 const prefix = '[mock-segment]';
+const options = {
+  verbose: false,
+};
+
+function asJson(o) {
+  return JSON.stringify(o, null, 2);
+}
 
 function onRequest(request, response, events) {
   console.log(`${prefix}: ${request.method} ${request.url}`);
   const eventDescriptions = events.map((event) => {
     if (event.type === 'track') {
-      return event.event;
+      return `${event.event}${
+        options.verbose ? ` ${asJson(event.properties)}` : ''
+      }`;
     } else if (event.type === 'page') {
       return event.name;
     }
-    return `[Unrecognized event type: ${event.type}]`;
+    return `[Unrecognized event type: ${event.type}]${
+      options.verbose ? ` ${asJson(event)}` : ''
+    }`;
   });
   console.log(`${prefix}: Events received: ${eventDescriptions.join(', ')}`);
 
@@ -56,6 +67,11 @@ const main = async () => {
       }
       port = parsePort(args[1]);
       args.splice(0, 2);
+    }
+
+    if (/^(--verbose|-v)$/u.test(args[0])) {
+      options.verbose = true;
+      args.splice(0, 1);
     }
   }
 


### PR DESCRIPTION
## **Description**

Adds a `-v` or `--verbose` option flag to dump event properties or event itself in case of non-identified events.

I've found it useful while adding new metrics to MM.

## **Related issues**

Fixes: N/A

## **Manual testing steps**

1. Run local mock server with `node development/mock-segment.js -v` (or `--verbose`)
2. Follow [those instructions](https://github.com/MetaMask/metamask-extension/blob/develop/development/README.md#debugging-with-the-mock-segment-api) to setup MM with your local server
3. Use your extension to trigger metametrics events (you should see them logged in your `mock-segment.js` server logs)

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained what problem this PR is solving and how it is solved.
- [ ] I've linked related issues
- [x] I've included manual testing steps
- [ ] I've included screenshots/recordings if applicable
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [x] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [x] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
