### PR TITLE
UX: fixed badge color when no account is connected

### DIFF
--- a/ui/components/multichain/connected-site-menu/__snapshots__/connected-site-menu.test.js.snap
+++ b/ui/components/multichain/connected-site-menu/__snapshots__/connected-site-menu.test.js.snap
@@ -29,10 +29,10 @@ exports[`Connected Site Menu should render the site menu in connected state 1`] 
           </div>
           <div
             class="mm-box mm-badge-wrapper__badge-container"
-            style="bottom: -1px; right: -2px; z-index: 1;"
+            style="bottom: -1px; right: -4px; z-index: 1;"
           >
             <div
-              class="mm-box multichain-connected-site-menu__badge not-connected mm-box--background-color-success-default mm-box--rounded-full mm-box--border-color-success-default mm-box--border-width-2 box--border-style-solid"
+              class="mm-box multichain-connected-site-menu__badge mm-box--background-color-success-default mm-box--rounded-full mm-box--border-color-background-default mm-box--border-width-3 box--border-style-solid"
             />
           </div>
         </div>
@@ -71,10 +71,10 @@ exports[`Connected Site Menu should render the site menu in not connected state 
           </div>
           <div
             class="mm-box mm-badge-wrapper__badge-container"
-            style="bottom: -1px; right: -2px; z-index: 1;"
+            style="bottom: -1px; right: -4px; z-index: 1;"
           >
             <div
-              class="mm-box multichain-connected-site-menu__badge not-connected mm-box--background-color-icon-alternative mm-box--rounded-full mm-box--border-color-success-default mm-box--border-width-2 box--border-style-solid"
+              class="mm-box multichain-connected-site-menu__badge mm-box--background-color-icon-alternative mm-box--rounded-full mm-box--border-color-background-default mm-box--border-width-3 box--border-style-solid"
             />
           </div>
         </div>

--- a/ui/components/multichain/connected-site-menu/connected-site-menu.js
+++ b/ui/components/multichain/connected-site-menu/connected-site-menu.js
@@ -46,10 +46,8 @@ export const ConnectedSiteMenu = ({
   const connectedOrigin = useSelector(getOriginOfCurrentTab);
   const connectedSubjectsMetadata = subjectMetadata[connectedOrigin];
   const isConnectedtoOtherAccountOrSnap =
-    Boolean(connectedSubjectsMetadata?.iconUrl) ||
     status === STATUS_CONNECTED_TO_ANOTHER_ACCOUNT ||
     status === STATUS_CONNECTED_TO_SNAP;
-
   return (
     <Box
       className={classNames('multichain-connected-site-menu', className)}
@@ -74,7 +72,7 @@ export const ConnectedSiteMenu = ({
           positionObj={
             isConnectedtoOtherAccountOrSnap
               ? { bottom: -1, right: -2, zIndex: 1 }
-              : { bottom: 2, right: -4, zIndex: 1 }
+              : { bottom: -1, right: -4, zIndex: 1 }
           }
           badge={
             <Box


### PR DESCRIPTION
Currently, in extension when no account is connected, it's still showing the green border for the connected status in app-header. This PR fix that issue


## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to app header, and match the following cases with attached screenshots
2. check the badge icon and tooltip when extension is not connected to dapp
3. check the badge icon and tooltip when extension and selected account is connected to dapp
4. check the badge icon and tooltip when extension is connected to dapp, but not the current account

## **Screenshots/Recordings**


### **Before**
![Screenshot 2024-02-22 at 10 13 29 PM](https://github.com/MetaMask/metamask-extension/assets/39872794/e08428fc-a22e-40d5-883a-f41b82d80e65)


### **After**
![Screenshot 2024-02-22 at 10 11 41 PM](https://github.com/MetaMask/metamask-extension/assets/39872794/359411ee-bfdd-432a-b720-e7ba62c925ef)

![Screenshot 2024-02-22 at 10 12 01 PM](https://github.com/MetaMask/metamask-extension/assets/39872794/ce1abd1e-71a4-416e-a50f-7ab3ba434726)
![Screenshot 2024-02-22 at 10 12 35 PM](https://github.com/MetaMask/metamask-extension/assets/39872794/f8557875-4771-412e-a77f-7697eecdf9c0)

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've clearly explained what problem this PR is solving and how it is solved.
- [ ] I've linked related issues
- [ ] I've included manual testing steps
- [ ] I've included screenshots/recordings if applicable
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [ ] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
