### PR TITLE
fix: duplicate React keys in dynamic UI causing artifacts

### DIFF
--- a/ui/components/app/snaps/snap-ui-renderer/components/types.ts
+++ b/ui/components/app/snaps/snap-ui-renderer/components/types.ts
@@ -2,7 +2,8 @@ import { Component } from '@metamask/snaps-sdk';
 
 export type UIComponentParams<T extends Component> = {
   element: T;
-  elementKeyIndex: number;
+  elementKeyIndex: { value: number };
+  rootKey: string;
   form?: string;
 };
 

--- a/ui/components/app/snaps/snap-ui-renderer/snap-ui-renderer.js
+++ b/ui/components/app/snaps/snap-ui-renderer/snap-ui-renderer.js
@@ -1,7 +1,7 @@
 import React, { memo, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { isComponent } from '@metamask/snaps-sdk';
-
+import { nanoid } from '@reduxjs/toolkit';
 import { useSelector } from 'react-redux';
 
 import { isEqual } from 'lodash';
@@ -51,7 +51,7 @@ const SnapUIRendererComponent = ({
 
   const isValidComponent = content && isComponent(content);
 
-  const elementKeyIndex = 0;
+  const elementKeyIndex = { value: 0 };
 
   // sections are memoized to avoid useless re-renders if one of the parents element re-renders.
   const sections = useMemo(
@@ -59,6 +59,7 @@ const SnapUIRendererComponent = ({
       isValidComponent &&
       mapToTemplate({
         element: content,
+        rootKey: nanoid(),
         elementKeyIndex,
       }),
     [content, isValidComponent, elementKeyIndex],

--- a/ui/components/app/snaps/snap-ui-renderer/utils.ts
+++ b/ui/components/app/snaps/snap-ui-renderer/utils.ts
@@ -3,7 +3,7 @@ import { COMPONENT_MAPPING } from './components';
 
 export type MapToTemplateParams = {
   element: Component;
-  elementKeyIndex: { value: number; };
+  elementKeyIndex: { value: number };
   rootKey: string;
   form?: string;
 };

--- a/ui/components/app/snaps/snap-ui-renderer/utils.ts
+++ b/ui/components/app/snaps/snap-ui-renderer/utils.ts
@@ -3,14 +3,15 @@ import { COMPONENT_MAPPING } from './components';
 
 export type MapToTemplateParams = {
   element: Component;
-  elementKeyIndex: number;
+  elementKeyIndex: { value: number; };
+  rootKey: string;
   form?: string;
 };
 
 export const mapToTemplate = (params: MapToTemplateParams) => {
   const { type } = params.element;
-  params.elementKeyIndex += 1;
-  const indexKey = `snap_ui_element_${type}__${params.elementKeyIndex}`;
+  params.elementKeyIndex.value += 1;
+  const indexKey = `${params.rootKey}_snap_ui_element_${type}__${params.elementKeyIndex.value}`;
   // @ts-expect-error This is a problem with the types generated in the snaps repo.
   const mapped = COMPONENT_MAPPING[type](params as any);
   return { ...mapped, key: indexKey };


### PR DESCRIPTION
## **Description**

This PR fixes two problems that cause the same bug. We are currently not effectively generating unique keys for components used in Snaps custom UI. This becomes a problem especially when using dynamic UI and re-rendering the screen where React is unable to clean up the previous screen and may fail to remove old components.

The fix is two-fold: First, we need to always have a unique suffix ("root key") for our keys, so that changing the UI content always re-renders the entire screen and cleans out old components. Secondly, we need to restore a trick that was used before recent changes to `elementKeyIndex`. When using an object container for `elementKeyIndex` we can reference the same number value across recursion. In a recent PR this trick was removed in favor of simply passing a number, but passing the number passes the literal value and thus results in duplicates keys in potentially complex component trees.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/23139?quickstart=1)
