### PR TITLE
fix: Further refactor provider url blocklist matching

### DIFF
--- a/shared/modules/provider-injection.js
+++ b/shared/modules/provider-injection.js
@@ -84,16 +84,13 @@ function blockedDomainCheck() {
     'cdn.shopify.com/s/javascripts/tricorder/xtld-read-only-frame.html',
   ];
 
-  const { hostname } = window.location;
-  const path = window.location.pathname;
+  const { hostname, pathname } = window.location;
 
-  const blockedDomainFound = blockedDomains.some(
-    (blockedDomain) =>
-      blockedDomain === hostname || hostname.endsWith(`.${blockedDomain}`),
+  return (
+      blockedDomains.some((blockedDomain) =>
+        blockedDomain === hostname || hostname.endsWith(`.${blockedDomain}`)
+    ) || blockedHrefs.some((blockedHref) =>
+      (hostname + pathname).includes(blockedHref)
+    )
   );
-  const blockedHrefFound = blockedHrefs.some((blockedHref) =>
-    (hostname + path).includes(blockedHref),
-  );
-
-  return blockedDomainFound || blockedHrefFound;
 }

--- a/shared/modules/provider-injection.js
+++ b/shared/modules/provider-injection.js
@@ -87,10 +87,12 @@ function blockedDomainCheck() {
   const { hostname, pathname } = window.location;
 
   return (
-      blockedDomains.some((blockedDomain) =>
-        blockedDomain === hostname || hostname.endsWith(`.${blockedDomain}`)
-    ) || blockedHrefs.some((blockedHref) =>
-      (hostname + pathname).includes(blockedHref)
+    blockedDomains.some(
+      (blockedDomain) =>
+        blockedDomain === hostname || hostname.endsWith(`.${blockedDomain}`),
+    ) ||
+    blockedHrefs.some((blockedHref) =>
+      (hostname + pathname).includes(blockedHref),
     )
   );
 }


### PR DESCRIPTION
Targeting #23134


- YMMV but I find it more readable without the intermediary `const`s. Plus, we can return early if domain matches
- Currently `blockedHref` matches if *any* part of the url contains the matching pattern. This changes it to only match at the beginning (requiring domain to match).