### PR TITLE
fix: Properly remove `setInputState` from confirmation template

### DIFF
--- a/ui/pages/confirmations/confirmation/templates/index.js
+++ b/ui/pages/confirmations/confirmation/templates/index.js
@@ -150,13 +150,7 @@ function getAttenuatedDispatch(dispatch) {
  * @param {object} history - The application's history object.
  * @param {object} data - The data object passed into the template from the confimation page.
  */
-export function getTemplateValues(
-  pendingApproval,
-  t,
-  dispatch,
-  history,
-  data,
-) {
+export function getTemplateValues(pendingApproval, t, dispatch, history, data) {
   const fn = APPROVAL_TEMPLATES[pendingApproval.type]?.getValues;
   if (!fn) {
     throw new Error(
@@ -165,13 +159,7 @@ export function getTemplateValues(
   }
 
   const safeActions = getAttenuatedDispatch(dispatch);
-  const values = fn(
-    pendingApproval,
-    t,
-    safeActions,
-    history,
-    data,
-  );
+  const values = fn(pendingApproval, t, safeActions, history, data);
   const extraneousKeys = omit(values, ALLOWED_TEMPLATE_KEYS);
   const safeValues = pick(values, ALLOWED_TEMPLATE_KEYS);
   if (extraneousKeys.length > 0) {

--- a/ui/pages/confirmations/confirmation/templates/index.js
+++ b/ui/pages/confirmations/confirmation/templates/index.js
@@ -148,8 +148,6 @@ function getAttenuatedDispatch(dispatch) {
  * @param {Function} t - Translation function.
  * @param {Function} dispatch - Redux dispatch function.
  * @param {object} history - The application's history object.
- * @param {Function} setInputState - A function that can be used to record the
- * state of input fields in the templated component.
  * @param {object} data - The data object passed into the template from the confimation page.
  */
 export function getTemplateValues(
@@ -157,7 +155,6 @@ export function getTemplateValues(
   t,
   dispatch,
   history,
-  setInputState,
   data,
 ) {
   const fn = APPROVAL_TEMPLATES[pendingApproval.type]?.getValues;
@@ -173,7 +170,6 @@ export function getTemplateValues(
     t,
     safeActions,
     history,
-    setInputState,
     data,
   );
   const extraneousKeys = omit(values, ALLOWED_TEMPLATE_KEYS);


### PR DESCRIPTION
## **Description**

In https://github.com/MetaMask/metamask-extension/pull/22828 we intended to remove `setInputState` from the values passed in `getTemplateValues` for confirmations as it is no longer needed. We forgot to remove it from the function itself. This PR fixes that. This makes sure that confirmation templates now again get their `data`.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/23147?quickstart=1)