### PR TITLE
fix(Snaps): Add label prop to Snap UI input

### DIFF
--- a/ui/components/app/snaps/snap-ui-renderer/components/input.ts
+++ b/ui/components/app/snaps/snap-ui-renderer/components/input.ts
@@ -7,6 +7,7 @@ export const input: UIComponentFactory<Input> = ({ element, form }) => ({
   props: {
     id: element.name,
     placeholder: element.placeholder,
+    label: element.label,
     textFieldProps: {
       type: element.inputType,
     },


### PR DESCRIPTION
## **Description**

I forgot to expose the `label` prop of the Snap custom UI `input` component. This PR fixes it.

## **Manual testing steps**

1. Spin up a custom UI screen with an input with a label
2. The label should render

## **Screenshots/Recordings**

![image](https://github.com/MetaMask/metamask-extension/assets/13910212/f96fd383-c006-4a04-af4c-609803f4b50f)

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've clearly explained what problem this PR is solving and how it is solved.
- [ ] I've linked related issues
- [ ] I've included manual testing steps
- [ ] I've included screenshots/recordings if applicable
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [ ] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
