### PR TITLE
fix: 'Next' button on the confirmation screen is unavailable when attempting to put first-party contract as recipient address.

### DIFF
--- a/ui/pages/confirmations/send/send-footer/send-footer.component.js
+++ b/ui/pages/confirmations/send/send-footer/send-footer.component.js
@@ -99,7 +99,7 @@ export default class SendFooter extends Component {
         onCancel={() => this.onCancel()}
         onSubmit={(e) => this.onSubmit(e)}
         disabled={
-          this.props.disabled && sendErrors.gasFee !== INSUFFICIENT_FUNDS_ERROR
+          this.props.disabled && sendErrors.gasFee === INSUFFICIENT_FUNDS_ERROR
         }
         cancelText={sendStage === SEND_STAGES.EDIT ? t('reject') : t('cancel')}
       />


### PR DESCRIPTION
## **Description**

The initial i.e-> check this.props.disabled && sendErrors.gasFee !== INSUFFICIENT_FUNDS_ERROR was checking if gasFee was not equal to insufficient funds which was causing the issue and i corrected it to check for equality.
[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/PR?quickstart=1)

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've clearly explained what problem this PR is solving and how it is solved.
- [ ] I've linked related issues
- [ ] I've included manual testing steps
- [ ] I've included screenshots/recordings if applicable
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [ ] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
