### PR TITLE
chore: bump snaps packages

### DIFF
--- a/app/scripts/lib/SnapsNameProvider.test.ts
+++ b/app/scripts/lib/SnapsNameProvider.test.ts
@@ -1,5 +1,4 @@
 import { NameType } from '@metamask/name-controller';
-// @ts-expect-error see: https://github.com/MetaMask/snaps/pull/2174
 import { HandlerType } from '@metamask/snaps-utils';
 import {
   GetAllSnaps,

--- a/app/scripts/lib/SnapsNameProvider.ts
+++ b/app/scripts/lib/SnapsNameProvider.ts
@@ -12,7 +12,6 @@ import {
   AddressLookupResult,
   Snap as TruncatedSnap,
 } from '@metamask/snaps-sdk';
-// @ts-expect-error see: https://github.com/MetaMask/snaps/pull/2174
 import { HandlerType } from '@metamask/snaps-utils';
 import log from 'loglevel';
 import {

--- a/app/scripts/lib/snap-keyring/metrics.ts
+++ b/app/scripts/lib/snap-keyring/metrics.ts
@@ -2,7 +2,6 @@ import { RestrictedControllerMessenger } from '@metamask/base-controller';
 import { KeyringControllerGetKeyringForAccountAction } from '@metamask/keyring-controller';
 import { AccountsControllerGetSelectedAccountAction } from '@metamask/accounts-controller';
 import { GetSnap } from '@metamask/snaps-controllers';
-// @ts-expect-error see: https://github.com/MetaMask/snaps/pull/2174
 import { Snap } from '@metamask/snaps-utils';
 
 type AllowedActions =

--- a/builds.yml
+++ b/builds.yml
@@ -27,7 +27,7 @@ buildTypes:
       - SEGMENT_WRITE_KEY_REF: SEGMENT_PROD_WRITE_KEY
       - ALLOW_LOCAL_SNAPS: false
       - REQUIRE_SNAPS_ALLOWLIST: true
-      - IFRAME_EXECUTION_ENVIRONMENT_URL: https://execution.metamask.io/iframe/5.0.0/index.html
+      - IFRAME_EXECUTION_ENVIRONMENT_URL: https://execution.metamask.io/iframe/5.0.1/index.html
       - ACCOUNT_SNAPS_DIRECTORY_URL: https://snaps.metamask.io/account-management
     # Main build uses the default browser manifest
     manifestOverrides: false
@@ -65,7 +65,7 @@ buildTypes:
       - SEGMENT_FLASK_WRITE_KEY
       - ALLOW_LOCAL_SNAPS: true
       - REQUIRE_SNAPS_ALLOWLIST: false
-      - IFRAME_EXECUTION_ENVIRONMENT_URL: https://execution.metamask.io/iframe/5.0.0/index.html
+      - IFRAME_EXECUTION_ENVIRONMENT_URL: https://execution.metamask.io/iframe/5.0.1/index.html
       - SUPPORT_LINK: https://metamask-flask.zendesk.com/hc
       - SUPPORT_REQUEST_LINK: https://metamask-flask.zendesk.com/hc/en-us/requests/new
       - INFURA_ENV_KEY_REF: INFURA_FLASK_PROJECT_ID
@@ -86,7 +86,7 @@ buildTypes:
       - SEGMENT_FLASK_WRITE_KEY
       - ALLOW_LOCAL_SNAPS: true
       - REQUIRE_SNAPS_ALLOWLIST: false
-      - IFRAME_EXECUTION_ENVIRONMENT_URL: https://execution.metamask.io/iframe/5.0.0/index.html
+      - IFRAME_EXECUTION_ENVIRONMENT_URL: https://execution.metamask.io/iframe/5.0.1/index.html
       - SUPPORT_LINK: https://metamask-flask.zendesk.com/hc
       - SUPPORT_REQUEST_LINK: https://metamask-flask.zendesk.com/hc/en-us/requests/new
       - INFURA_ENV_KEY_REF: INFURA_FLASK_PROJECT_ID
@@ -107,7 +107,7 @@ buildTypes:
       - SEGMENT_WRITE_KEY_REF: SEGMENT_MMI_WRITE_KEY
       - ALLOW_LOCAL_SNAPS: false
       - REQUIRE_SNAPS_ALLOWLIST: true
-      - IFRAME_EXECUTION_ENVIRONMENT_URL: https://execution.metamask.io/iframe/5.0.0/index.html
+      - IFRAME_EXECUTION_ENVIRONMENT_URL: https://execution.metamask.io/iframe/5.0.1/index.html
       - MMI_CONFIGURATION_SERVICE_URL: https://configuration.metamask-institutional.io/v2/configuration/default
       - SUPPORT_LINK: https://mmi-support.zendesk.com/hc/en-us
       - SUPPORT_REQUEST_LINK: https://mmi-support.zendesk.com/hc/en-us/requests/new

--- a/builds.yml
+++ b/builds.yml
@@ -27,7 +27,7 @@ buildTypes:
       - SEGMENT_WRITE_KEY_REF: SEGMENT_PROD_WRITE_KEY
       - ALLOW_LOCAL_SNAPS: false
       - REQUIRE_SNAPS_ALLOWLIST: true
-      - IFRAME_EXECUTION_ENVIRONMENT_URL: https://execution.metamask.io/iframe/4.0.1/index.html
+      - IFRAME_EXECUTION_ENVIRONMENT_URL: https://execution.metamask.io/iframe/5.0.0/index.html
       - ACCOUNT_SNAPS_DIRECTORY_URL: https://snaps.metamask.io/account-management
     # Main build uses the default browser manifest
     manifestOverrides: false
@@ -65,7 +65,7 @@ buildTypes:
       - SEGMENT_FLASK_WRITE_KEY
       - ALLOW_LOCAL_SNAPS: true
       - REQUIRE_SNAPS_ALLOWLIST: false
-      - IFRAME_EXECUTION_ENVIRONMENT_URL: https://execution.metamask.io/iframe/4.0.1/index.html
+      - IFRAME_EXECUTION_ENVIRONMENT_URL: https://execution.metamask.io/iframe/5.0.0/index.html
       - SUPPORT_LINK: https://metamask-flask.zendesk.com/hc
       - SUPPORT_REQUEST_LINK: https://metamask-flask.zendesk.com/hc/en-us/requests/new
       - INFURA_ENV_KEY_REF: INFURA_FLASK_PROJECT_ID
@@ -86,7 +86,7 @@ buildTypes:
       - SEGMENT_FLASK_WRITE_KEY
       - ALLOW_LOCAL_SNAPS: true
       - REQUIRE_SNAPS_ALLOWLIST: false
-      - IFRAME_EXECUTION_ENVIRONMENT_URL: https://execution.metamask.io/iframe/4.0.1/index.html
+      - IFRAME_EXECUTION_ENVIRONMENT_URL: https://execution.metamask.io/iframe/5.0.0/index.html
       - SUPPORT_LINK: https://metamask-flask.zendesk.com/hc
       - SUPPORT_REQUEST_LINK: https://metamask-flask.zendesk.com/hc/en-us/requests/new
       - INFURA_ENV_KEY_REF: INFURA_FLASK_PROJECT_ID
@@ -107,7 +107,7 @@ buildTypes:
       - SEGMENT_WRITE_KEY_REF: SEGMENT_MMI_WRITE_KEY
       - ALLOW_LOCAL_SNAPS: false
       - REQUIRE_SNAPS_ALLOWLIST: true
-      - IFRAME_EXECUTION_ENVIRONMENT_URL: https://execution.metamask.io/iframe/4.0.1/index.html
+      - IFRAME_EXECUTION_ENVIRONMENT_URL: https://execution.metamask.io/iframe/5.0.0/index.html
       - MMI_CONFIGURATION_SERVICE_URL: https://configuration.metamask-institutional.io/v2/configuration/default
       - SUPPORT_LINK: https://mmi-support.zendesk.com/hc/en-us
       - SUPPORT_REQUEST_LINK: https://mmi-support.zendesk.com/hc/en-us/requests/new

--- a/lavamoat/browserify/beta/policy.json
+++ b/lavamoat/browserify/beta/policy.json
@@ -1833,6 +1833,7 @@
     },
     "@metamask/snaps-sdk": {
       "globals": {
+        "assert": true,
         "fetch": true
       },
       "packages": {
@@ -1909,10 +1910,7 @@
         "@metamask/utils": true,
         "@metamask/utils>@noble/hashes": true,
         "@metamask/utils>@scure/base": true,
-        "browserify": true,
         "browserify>buffer": true,
-        "browserify>path-browserify": true,
-        "browserify>process": true,
         "chalk": true,
         "semver": true,
         "superstruct": true
@@ -2588,11 +2586,6 @@
       "packages": {
         "browserify>stream-http": true,
         "browserify>url": true
-      }
-    },
-    "browserify>path-browserify": {
-      "packages": {
-        "browserify>process": true
       }
     },
     "browserify>process": {

--- a/lavamoat/browserify/beta/policy.json
+++ b/lavamoat/browserify/beta/policy.json
@@ -1833,7 +1833,6 @@
     },
     "@metamask/snaps-sdk": {
       "globals": {
-        "assert": true,
         "fetch": true
       },
       "packages": {

--- a/lavamoat/browserify/desktop/policy.json
+++ b/lavamoat/browserify/desktop/policy.json
@@ -1984,7 +1984,7 @@
         "chrome.offscreen.createDocument": true,
         "chrome.offscreen.hasDocument": true,
         "clearTimeout": true,
-        "document.getElementById": true,
+        "document": true,
         "fetch.bind": true,
         "setTimeout": true
       },
@@ -2097,6 +2097,7 @@
     },
     "@metamask/snaps-sdk": {
       "globals": {
+        "assert": true,
         "fetch": true
       },
       "packages": {
@@ -2173,10 +2174,7 @@
         "@metamask/utils": true,
         "@metamask/utils>@noble/hashes": true,
         "@metamask/utils>@scure/base": true,
-        "browserify": true,
         "browserify>buffer": true,
-        "browserify>path-browserify": true,
-        "browserify>process": true,
         "chalk": true,
         "semver": true,
         "superstruct": true

--- a/lavamoat/browserify/desktop/policy.json
+++ b/lavamoat/browserify/desktop/policy.json
@@ -1984,7 +1984,7 @@
         "chrome.offscreen.createDocument": true,
         "chrome.offscreen.hasDocument": true,
         "clearTimeout": true,
-        "document": true,
+        "document.getElementById": true,
         "fetch.bind": true,
         "setTimeout": true
       },
@@ -2097,7 +2097,6 @@
     },
     "@metamask/snaps-sdk": {
       "globals": {
-        "assert": true,
         "fetch": true
       },
       "packages": {

--- a/lavamoat/browserify/flask/policy.json
+++ b/lavamoat/browserify/flask/policy.json
@@ -2018,7 +2018,7 @@
         "chrome.offscreen.createDocument": true,
         "chrome.offscreen.hasDocument": true,
         "clearTimeout": true,
-        "document.getElementById": true,
+        "document": true,
         "fetch.bind": true,
         "setTimeout": true
       },
@@ -2131,6 +2131,7 @@
     },
     "@metamask/snaps-sdk": {
       "globals": {
+        "assert": true,
         "fetch": true
       },
       "packages": {
@@ -2207,10 +2208,7 @@
         "@metamask/utils": true,
         "@metamask/utils>@noble/hashes": true,
         "@metamask/utils>@scure/base": true,
-        "browserify": true,
         "browserify>buffer": true,
-        "browserify>path-browserify": true,
-        "browserify>process": true,
         "chalk": true,
         "semver": true,
         "superstruct": true

--- a/lavamoat/browserify/flask/policy.json
+++ b/lavamoat/browserify/flask/policy.json
@@ -2018,7 +2018,7 @@
         "chrome.offscreen.createDocument": true,
         "chrome.offscreen.hasDocument": true,
         "clearTimeout": true,
-        "document": true,
+        "document.getElementById": true,
         "fetch.bind": true,
         "setTimeout": true
       },
@@ -2131,7 +2131,6 @@
     },
     "@metamask/snaps-sdk": {
       "globals": {
-        "assert": true,
         "fetch": true
       },
       "packages": {

--- a/lavamoat/browserify/main/policy.json
+++ b/lavamoat/browserify/main/policy.json
@@ -1941,7 +1941,7 @@
         "chrome.offscreen.createDocument": true,
         "chrome.offscreen.hasDocument": true,
         "clearTimeout": true,
-        "document": true,
+        "document.getElementById": true,
         "fetch.bind": true,
         "setTimeout": true
       },
@@ -2054,7 +2054,6 @@
     },
     "@metamask/snaps-sdk": {
       "globals": {
-        "assert": true,
         "fetch": true
       },
       "packages": {

--- a/lavamoat/browserify/main/policy.json
+++ b/lavamoat/browserify/main/policy.json
@@ -1941,7 +1941,7 @@
         "chrome.offscreen.createDocument": true,
         "chrome.offscreen.hasDocument": true,
         "clearTimeout": true,
-        "document.getElementById": true,
+        "document": true,
         "fetch.bind": true,
         "setTimeout": true
       },
@@ -2054,6 +2054,7 @@
     },
     "@metamask/snaps-sdk": {
       "globals": {
+        "assert": true,
         "fetch": true
       },
       "packages": {
@@ -2130,10 +2131,7 @@
         "@metamask/utils": true,
         "@metamask/utils>@noble/hashes": true,
         "@metamask/utils>@scure/base": true,
-        "browserify": true,
         "browserify>buffer": true,
-        "browserify>path-browserify": true,
-        "browserify>process": true,
         "chalk": true,
         "semver": true,
         "superstruct": true

--- a/lavamoat/browserify/mmi/policy.json
+++ b/lavamoat/browserify/mmi/policy.json
@@ -2039,7 +2039,7 @@
         "chrome.offscreen.createDocument": true,
         "chrome.offscreen.hasDocument": true,
         "clearTimeout": true,
-        "document": true,
+        "document.getElementById": true,
         "fetch.bind": true,
         "setTimeout": true
       },
@@ -2152,7 +2152,6 @@
     },
     "@metamask/snaps-sdk": {
       "globals": {
-        "assert": true,
         "fetch": true
       },
       "packages": {

--- a/lavamoat/browserify/mmi/policy.json
+++ b/lavamoat/browserify/mmi/policy.json
@@ -2039,7 +2039,7 @@
         "chrome.offscreen.createDocument": true,
         "chrome.offscreen.hasDocument": true,
         "clearTimeout": true,
-        "document.getElementById": true,
+        "document": true,
         "fetch.bind": true,
         "setTimeout": true
       },
@@ -2152,6 +2152,7 @@
     },
     "@metamask/snaps-sdk": {
       "globals": {
+        "assert": true,
         "fetch": true
       },
       "packages": {
@@ -2228,10 +2229,7 @@
         "@metamask/utils": true,
         "@metamask/utils>@noble/hashes": true,
         "@metamask/utils>@scure/base": true,
-        "browserify": true,
         "browserify>buffer": true,
-        "browserify>path-browserify": true,
-        "browserify>process": true,
         "chalk": true,
         "semver": true,
         "superstruct": true

--- a/package.json
+++ b/package.json
@@ -218,7 +218,7 @@
     "nonce-tracker@npm:^3.0.0": "patch:nonce-tracker@npm%3A3.0.0#~/.yarn/patches/nonce-tracker-npm-3.0.0-c5e9a93f9d.patch",
     "@trezor/connect-web": "9.0.11",
     "lavamoat-core@npm:^15.1.1": "patch:lavamoat-core@npm%3A15.1.1#~/.yarn/patches/lavamoat-core-npm-15.1.1-51fbe39988.patch",
-    "@metamask/snaps-sdk": "^2.1.0"
+    "@metamask/snaps-sdk": "^3.0.0"
   },
   "dependencies": {
     "@babel/runtime": "^7.23.2",
@@ -292,11 +292,11 @@
     "@metamask/selected-network-controller": "^6.0.0",
     "@metamask/signature-controller": "^12.0.0",
     "@metamask/smart-transactions-controller": "^6.2.2",
-    "@metamask/snaps-controllers": "^5.0.1",
-    "@metamask/snaps-execution-environments": "^4.0.0",
-    "@metamask/snaps-rpc-methods": "^6.0.0",
-    "@metamask/snaps-sdk": "^2.1.0",
-    "@metamask/snaps-utils": "^6.1.0",
+    "@metamask/snaps-controllers": "^6.0.0",
+    "@metamask/snaps-execution-environments": "^5.0.1",
+    "@metamask/snaps-rpc-methods": "^7.0.0",
+    "@metamask/snaps-sdk": "^3.0.0",
+    "@metamask/snaps-utils": "^7.0.0",
     "@metamask/transaction-controller": "^23.1.0",
     "@metamask/user-operation-controller": "^4.0.0",
     "@metamask/utils": "^8.2.1",

--- a/package.json
+++ b/package.json
@@ -218,7 +218,7 @@
     "nonce-tracker@npm:^3.0.0": "patch:nonce-tracker@npm%3A3.0.0#~/.yarn/patches/nonce-tracker-npm-3.0.0-c5e9a93f9d.patch",
     "@trezor/connect-web": "9.0.11",
     "lavamoat-core@npm:^15.1.1": "patch:lavamoat-core@npm%3A15.1.1#~/.yarn/patches/lavamoat-core-npm-15.1.1-51fbe39988.patch",
-    "@metamask/snaps-sdk": "^3.0.0"
+    "@metamask/snaps-sdk": "^3.0.1"
   },
   "dependencies": {
     "@babel/runtime": "^7.23.2",
@@ -292,11 +292,11 @@
     "@metamask/selected-network-controller": "^6.0.0",
     "@metamask/signature-controller": "^12.0.0",
     "@metamask/smart-transactions-controller": "^6.2.2",
-    "@metamask/snaps-controllers": "^6.0.0",
+    "@metamask/snaps-controllers": "^6.0.1",
     "@metamask/snaps-execution-environments": "^5.0.1",
-    "@metamask/snaps-rpc-methods": "^7.0.0",
-    "@metamask/snaps-sdk": "^3.0.0",
-    "@metamask/snaps-utils": "^7.0.0",
+    "@metamask/snaps-rpc-methods": "^7.0.1",
+    "@metamask/snaps-sdk": "^3.0.1",
+    "@metamask/snaps-utils": "^7.0.1",
     "@metamask/transaction-controller": "^23.1.0",
     "@metamask/user-operation-controller": "^4.0.0",
     "@metamask/utils": "^8.2.1",

--- a/ui/components/app/snaps/keyring-snap-removal-warning/keyring-snap-removal-warning.test.tsx
+++ b/ui/components/app/snaps/keyring-snap-removal-warning/keyring-snap-removal-warning.test.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { waitFor, fireEvent } from '@testing-library/react';
 import configureMockStore from 'redux-mock-store';
-// @ts-expect-error see: https://github.com/MetaMask/snaps/pull/2174
 import { Snap } from '@metamask/snaps-utils';
 import mockStore from '../../../../../test/data/mock-state.json';
 import { renderWithProvider } from '../../../../../test/jest';

--- a/ui/components/app/snaps/keyring-snap-removal-warning/keyring-snap-removal-warning.tsx
+++ b/ui/components/app/snaps/keyring-snap-removal-warning/keyring-snap-removal-warning.tsx
@@ -1,6 +1,5 @@
 import React, { useState, useEffect } from 'react';
 import { getAccountLink } from '@metamask/etherscan-link';
-// @ts-expect-error see: https://github.com/MetaMask/snaps/pull/2174
 import { Snap } from '@metamask/snaps-utils';
 import { useSelector } from 'react-redux';
 import {

--- a/ui/components/app/snaps/snap-ui-renderer/components/form.ts
+++ b/ui/components/app/snaps/snap-ui-renderer/components/form.ts
@@ -4,6 +4,7 @@ import { UIComponentFactory } from './types';
 
 export const form: UIComponentFactory<Form> = ({ element, ...params }) => ({
   element: 'SnapUIForm',
+  // @ts-expect-error This seems to be compatibility issue between superstruct and this repo.
   children: element.children.map((children) =>
     mapToTemplate({
       element: children,

--- a/ui/components/app/snaps/snap-ui-renderer/components/form.ts
+++ b/ui/components/app/snaps/snap-ui-renderer/components/form.ts
@@ -4,7 +4,6 @@ import { UIComponentFactory } from './types';
 
 export const form: UIComponentFactory<Form> = ({ element, ...params }) => ({
   element: 'SnapUIForm',
-  // @ts-expect-error This is a problem with the types generated in the snaps repo.
   children: element.children.map((children) =>
     mapToTemplate({
       element: children,

--- a/ui/components/app/snaps/snap-ui-renderer/utils.ts
+++ b/ui/components/app/snaps/snap-ui-renderer/utils.ts
@@ -12,6 +12,7 @@ export const mapToTemplate = (params: MapToTemplateParams) => {
   const { type } = params.element;
   params.elementKeyIndex.value += 1;
   const indexKey = `${params.rootKey}_snap_ui_element_${type}__${params.elementKeyIndex.value}`;
+  // @ts-expect-error This seems to be compatibility issue between superstruct and this repo.
   const mapped = COMPONENT_MAPPING[type](params as any);
   return { ...mapped, key: indexKey };
 };

--- a/ui/components/app/snaps/snap-ui-renderer/utils.ts
+++ b/ui/components/app/snaps/snap-ui-renderer/utils.ts
@@ -12,7 +12,6 @@ export const mapToTemplate = (params: MapToTemplateParams) => {
   const { type } = params.element;
   params.elementKeyIndex.value += 1;
   const indexKey = `${params.rootKey}_snap_ui_element_${type}__${params.elementKeyIndex.value}`;
-  // @ts-expect-error This is a problem with the types generated in the snaps repo.
   const mapped = COMPONENT_MAPPING[type](params as any);
   return { ...mapped, key: indexKey };
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -4739,14 +4739,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/permission-controller@npm:^8.0.0":
-  version: 8.0.0
-  resolution: "@metamask/permission-controller@npm:8.0.0"
+"@metamask/permission-controller@npm:^8.0.0, @metamask/permission-controller@npm:^8.0.1":
+  version: 8.0.1
+  resolution: "@metamask/permission-controller@npm:8.0.1"
   dependencies:
     "@metamask/base-controller": "npm:^4.1.1"
-    "@metamask/controller-utils": "npm:^8.0.2"
+    "@metamask/controller-utils": "npm:^8.0.3"
     "@metamask/json-rpc-engine": "npm:^7.3.2"
-    "@metamask/rpc-errors": "npm:^6.1.0"
+    "@metamask/rpc-errors": "npm:^6.2.1"
     "@metamask/utils": "npm:^8.3.0"
     "@types/deep-freeze-strict": "npm:^1.1.0"
     deep-freeze-strict: "npm:^1.1.1"
@@ -4754,7 +4754,7 @@ __metadata:
     nanoid: "npm:^3.1.31"
   peerDependencies:
     "@metamask/approval-controller": ^5.1.2
-  checksum: cbd418473fc90c210c5d1a50278be2adb62737ad027bd68433651e4de290d178f53e7018c60ac749227f6951c6cab8fef54073b375a5391461a4ae63a9b67706
+  checksum: ab10e4e1f9b3424ed4453289f772c5a7c62178b0459ffbea23282b2cd6d1e75c2deab01e647e6558369fa45cba3b6555c1b72f2354d57389e9480979182f769d
   languageName: node
   linkType: hard
 
@@ -5084,22 +5084,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/snaps-controllers@npm:^5.0.1":
-  version: 5.0.1
-  resolution: "@metamask/snaps-controllers@npm:5.0.1"
+"@metamask/snaps-controllers@npm:^6.0.0":
+  version: 6.0.1
+  resolution: "@metamask/snaps-controllers@npm:6.0.1"
   dependencies:
     "@metamask/approval-controller": "npm:^5.1.2"
     "@metamask/base-controller": "npm:^4.1.0"
     "@metamask/json-rpc-engine": "npm:^7.3.2"
     "@metamask/object-multiplex": "npm:^2.0.0"
-    "@metamask/permission-controller": "npm:^8.0.0"
+    "@metamask/permission-controller": "npm:^8.0.1"
     "@metamask/phishing-controller": "npm:^8.0.2"
     "@metamask/post-message-stream": "npm:^8.0.0"
-    "@metamask/rpc-errors": "npm:^6.1.0"
+    "@metamask/rpc-errors": "npm:^6.2.1"
     "@metamask/snaps-registry": "npm:^3.0.0"
-    "@metamask/snaps-rpc-methods": "npm:^6.0.0"
-    "@metamask/snaps-sdk": "npm:^2.1.0"
-    "@metamask/snaps-utils": "npm:^6.1.0"
+    "@metamask/snaps-rpc-methods": "npm:^7.0.1"
+    "@metamask/snaps-sdk": "npm:^3.0.1"
+    "@metamask/snaps-utils": "npm:^7.0.1"
     "@metamask/utils": "npm:^8.3.0"
     "@xstate/fsm": "npm:^2.0.0"
     browserify-zlib: "npm:^0.2.0"
@@ -5112,30 +5112,30 @@ __metadata:
     readable-web-to-node-stream: "npm:^3.0.2"
     tar-stream: "npm:^3.1.7"
   peerDependencies:
-    "@metamask/snaps-execution-environments": ^4.0.1
+    "@metamask/snaps-execution-environments": ^5.0.1
   peerDependenciesMeta:
     "@metamask/snaps-execution-environments":
       optional: true
-  checksum: b6607a5f15081b62273282d9b462be945277db54b1e772f75df4d68d01a7a3b1d5214d9b4bb619759ac2159121bbe59bfbbeab0513f27e663984afee26060187
+  checksum: c9ef312edb7af3d062afe57a3db1593f3001caf3a30d219d3a1cedee9c2a652d64e5cb6bf02b5f89fb648a0385c44025d16b3d7b420e4209be947f7b99edea06
   languageName: node
   linkType: hard
 
-"@metamask/snaps-execution-environments@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "@metamask/snaps-execution-environments@npm:4.0.0"
+"@metamask/snaps-execution-environments@npm:^5.0.1":
+  version: 5.0.1
+  resolution: "@metamask/snaps-execution-environments@npm:5.0.1"
   dependencies:
     "@metamask/json-rpc-engine": "npm:^7.3.2"
     "@metamask/object-multiplex": "npm:^2.0.0"
     "@metamask/post-message-stream": "npm:^8.0.0"
     "@metamask/providers": "npm:^14.0.2"
-    "@metamask/rpc-errors": "npm:^6.1.0"
-    "@metamask/snaps-sdk": "npm:^2.0.0"
-    "@metamask/snaps-utils": "npm:^6.0.0"
+    "@metamask/rpc-errors": "npm:^6.2.1"
+    "@metamask/snaps-sdk": "npm:^3.0.1"
+    "@metamask/snaps-utils": "npm:^7.0.1"
     "@metamask/utils": "npm:^8.3.0"
     nanoid: "npm:^3.1.31"
     readable-stream: "npm:^3.6.2"
     superstruct: "npm:^1.0.3"
-  checksum: ac5fa23b3b315fae833141e859441a3911786a44f0760e940dac4ce8ebc640d96919013362e4850f7fa484276fe1d123516efafa10c732c90da1d2538f62e9a7
+  checksum: 3f26984fc62d0f510368e36ec0c81513641edcd0fbb434ba1ba8602c9969b60de4318e65cad99b75780aca11d80226cf50a039a9a881d0af211bde40ac5f0bd3
   languageName: node
   linkType: hard
 
@@ -5183,33 +5183,33 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/snaps-rpc-methods@npm:^6.0.0":
-  version: 6.0.0
-  resolution: "@metamask/snaps-rpc-methods@npm:6.0.0"
+"@metamask/snaps-rpc-methods@npm:^7.0.0, @metamask/snaps-rpc-methods@npm:^7.0.1":
+  version: 7.0.1
+  resolution: "@metamask/snaps-rpc-methods@npm:7.0.1"
   dependencies:
     "@metamask/key-tree": "npm:^9.0.0"
-    "@metamask/permission-controller": "npm:^8.0.0"
-    "@metamask/rpc-errors": "npm:^6.1.0"
-    "@metamask/snaps-sdk": "npm:^2.0.0"
-    "@metamask/snaps-utils": "npm:^6.0.0"
+    "@metamask/permission-controller": "npm:^8.0.1"
+    "@metamask/rpc-errors": "npm:^6.2.1"
+    "@metamask/snaps-sdk": "npm:^3.0.1"
+    "@metamask/snaps-utils": "npm:^7.0.1"
     "@metamask/utils": "npm:^8.3.0"
     "@noble/hashes": "npm:^1.3.1"
     superstruct: "npm:^1.0.3"
-  checksum: 4eaf8f8170d986331a45f158a5dea1051ab602d82057afe9d6464fc43f66015442ab29ecc72e1a9914af87c5627c9d215294f269c46951ecc803f295f2647d0d
+  checksum: c85359e96fd8fc69bb05d538e19434c23be2ec90ea8080ade5eac173e11997e7c78b44e0c1231eb8bb15fbbc75c55763471c139b99ba5ae999b6daf7113e8250
   languageName: node
   linkType: hard
 
-"@metamask/snaps-sdk@npm:^2.1.0":
-  version: 2.1.0
-  resolution: "@metamask/snaps-sdk@npm:2.1.0"
+"@metamask/snaps-sdk@npm:^3.0.0":
+  version: 3.0.1
+  resolution: "@metamask/snaps-sdk@npm:3.0.1"
   dependencies:
     "@metamask/key-tree": "npm:^9.0.0"
     "@metamask/providers": "npm:^14.0.2"
-    "@metamask/rpc-errors": "npm:^6.1.0"
+    "@metamask/rpc-errors": "npm:^6.2.1"
     "@metamask/utils": "npm:^8.3.0"
     fast-xml-parser: "npm:^4.3.4"
     superstruct: "npm:^1.0.3"
-  checksum: 539e1a478c89a249c0ed56d705fd4c3614c4d45d0fd8fa9a2c0d781b18d171d60944d3106e65afc68a9f52997d5ff1a4728be697e2405e56bcf2df8bf9af0bea
+  checksum: 3317d04549d359b9b2ba775f3b347b8071a6c2268917303673739e8425d007814ef8e08faba98fa58ca44bbdd6ba4293093de6ec5815998acc629cfd0bcb31ba
   languageName: node
   linkType: hard
 
@@ -5243,19 +5243,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/snaps-utils@npm:^6.0.0, @metamask/snaps-utils@npm:^6.1.0":
-  version: 6.1.0
-  resolution: "@metamask/snaps-utils@npm:6.1.0"
+"@metamask/snaps-utils@npm:^7.0.0, @metamask/snaps-utils@npm:^7.0.1":
+  version: 7.0.1
+  resolution: "@metamask/snaps-utils@npm:7.0.1"
   dependencies:
     "@babel/core": "npm:^7.23.2"
     "@babel/types": "npm:^7.23.0"
     "@metamask/base-controller": "npm:^4.1.0"
     "@metamask/key-tree": "npm:^9.0.0"
-    "@metamask/permission-controller": "npm:^8.0.0"
-    "@metamask/rpc-errors": "npm:^6.1.0"
+    "@metamask/permission-controller": "npm:^8.0.1"
+    "@metamask/rpc-errors": "npm:^6.2.1"
     "@metamask/slip44": "npm:^3.1.0"
     "@metamask/snaps-registry": "npm:^3.0.0"
-    "@metamask/snaps-sdk": "npm:^2.1.0"
+    "@metamask/snaps-sdk": "npm:^3.0.1"
     "@metamask/utils": "npm:^8.3.0"
     "@noble/hashes": "npm:^1.3.1"
     "@scure/base": "npm:^1.1.1"
@@ -5268,7 +5268,7 @@ __metadata:
     ses: "npm:^1.1.0"
     superstruct: "npm:^1.0.3"
     validate-npm-package-name: "npm:^5.0.0"
-  checksum: 8e2b25abbca14571de58eb5c4aa8d1289ed7f2406bb1961214e1a04bbb29bba99c49c59f43fec227c07cca4c6506a1446c4163e4cd8f1ddf3d25b6fd4ff1b697
+  checksum: 84d1897a032b321f326ccacd16376e39433d5d44b07ccd6f5b525833984ef82c7ea55ce6bc8239639b6eeb55c4c5470c22a06fd2d2e7ce05fb98cc1bd617b856
   languageName: node
   linkType: hard
 
@@ -24597,11 +24597,11 @@ __metadata:
     "@metamask/selected-network-controller": "npm:^6.0.0"
     "@metamask/signature-controller": "npm:^12.0.0"
     "@metamask/smart-transactions-controller": "npm:^6.2.2"
-    "@metamask/snaps-controllers": "npm:^5.0.1"
-    "@metamask/snaps-execution-environments": "npm:^4.0.0"
-    "@metamask/snaps-rpc-methods": "npm:^6.0.0"
-    "@metamask/snaps-sdk": "npm:^2.1.0"
-    "@metamask/snaps-utils": "npm:^6.1.0"
+    "@metamask/snaps-controllers": "npm:^6.0.0"
+    "@metamask/snaps-execution-environments": "npm:^5.0.1"
+    "@metamask/snaps-rpc-methods": "npm:^7.0.0"
+    "@metamask/snaps-sdk": "npm:^3.0.0"
+    "@metamask/snaps-utils": "npm:^7.0.0"
     "@metamask/test-dapp": "npm:^8.2.0"
     "@metamask/transaction-controller": "npm:^23.1.0"
     "@metamask/user-operation-controller": "npm:^4.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5084,7 +5084,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/snaps-controllers@npm:^6.0.0":
+"@metamask/snaps-controllers@npm:^6.0.1":
   version: 6.0.1
   resolution: "@metamask/snaps-controllers@npm:6.0.1"
   dependencies:
@@ -5183,7 +5183,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/snaps-rpc-methods@npm:^7.0.0, @metamask/snaps-rpc-methods@npm:^7.0.1":
+"@metamask/snaps-rpc-methods@npm:^7.0.1":
   version: 7.0.1
   resolution: "@metamask/snaps-rpc-methods@npm:7.0.1"
   dependencies:
@@ -5199,7 +5199,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/snaps-sdk@npm:^3.0.0":
+"@metamask/snaps-sdk@npm:^3.0.1":
   version: 3.0.1
   resolution: "@metamask/snaps-sdk@npm:3.0.1"
   dependencies:
@@ -5243,7 +5243,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/snaps-utils@npm:^7.0.0, @metamask/snaps-utils@npm:^7.0.1":
+"@metamask/snaps-utils@npm:^7.0.1":
   version: 7.0.1
   resolution: "@metamask/snaps-utils@npm:7.0.1"
   dependencies:
@@ -24597,11 +24597,11 @@ __metadata:
     "@metamask/selected-network-controller": "npm:^6.0.0"
     "@metamask/signature-controller": "npm:^12.0.0"
     "@metamask/smart-transactions-controller": "npm:^6.2.2"
-    "@metamask/snaps-controllers": "npm:^6.0.0"
+    "@metamask/snaps-controllers": "npm:^6.0.1"
     "@metamask/snaps-execution-environments": "npm:^5.0.1"
-    "@metamask/snaps-rpc-methods": "npm:^7.0.0"
-    "@metamask/snaps-sdk": "npm:^3.0.0"
-    "@metamask/snaps-utils": "npm:^7.0.0"
+    "@metamask/snaps-rpc-methods": "npm:^7.0.1"
+    "@metamask/snaps-sdk": "npm:^3.0.1"
+    "@metamask/snaps-utils": "npm:^7.0.1"
     "@metamask/test-dapp": "npm:^8.2.0"
     "@metamask/transaction-controller": "npm:^23.1.0"
     "@metamask/user-operation-controller": "npm:^4.0.0"


### PR DESCRIPTION
## **Description**
Bump snaps packages to latest and deals with breaking changes.

Summary of changes in the snaps deps:
- Packages are now built using `tsup`
- Enforce JSON-RPC response size limits
- Add sizing limits for custom UI
- Properly validate links contained in rows