### PR TITLE
fix: update to OP sepolia

### DIFF
--- a/shared/constants/network.ts
+++ b/shared/constants/network.ts
@@ -119,7 +119,8 @@ export const CHAIN_IDS = {
   BSC: '0x38',
   BSC_TESTNET: '0x61',
   OPTIMISM: '0xa',
-  OPTIMISM_TESTNET: '0x1a4',
+  OPTIMISM_TESTNET: '0xaa37dc',
+  OPTIMISM_GOERLI: '0x1a4',
   BASE: '0x2105',
   BASE_TESTNET: '0x14a33',
   OPBNB: '0xcc',
@@ -208,7 +209,7 @@ export const DEPRECATED_NETWORKS = [
   CHAIN_IDS.AURORA,
   CHAIN_IDS.GOERLI,
   CHAIN_IDS.ARBITRUM_GOERLI,
-  CHAIN_IDS.OPTIMISM_TESTNET,
+  CHAIN_IDS.OPTIMISM_GOERLI,
 ];
 
 /**
@@ -763,7 +764,7 @@ export const ETHERSCAN_SUPPORTED_NETWORKS = {
   },
   [CHAIN_IDS.OPTIMISM_TESTNET]: {
     domain: defaultEtherscanDomain,
-    subdomain: `${defaultEtherscanSubdomainPrefix}-goerli-optimistic`,
+    subdomain: `${defaultEtherscanSubdomainPrefix}-sepolia-optimistic`,
   },
   [CHAIN_IDS.POLYGON]: {
     domain: 'polygonscan.com',
@@ -833,6 +834,7 @@ export const BUYABLE_CHAINS_MAP: {
     ChainId,
     | typeof CHAIN_IDS.LOCALHOST
     | typeof CHAIN_IDS.OPTIMISM_TESTNET
+    | typeof CHAIN_IDS.OPTIMISM_GOERLI
     | typeof CHAIN_IDS.BASE_TESTNET
     | typeof CHAIN_IDS.BASE
     | typeof CHAIN_IDS.OPBNB_TESTNET

--- a/test/e2e/tests/deprecated-networks.spec.js
+++ b/test/e2e/tests/deprecated-networks.spec.js
@@ -117,7 +117,7 @@ describe('Deprecated networks', function () {
   });
 
   it('Should show deprecation warning when switching to Optimism goerli testnet', async function () {
-    const TEST_CHAIN_ID = CHAIN_IDS.OPTIMISM_TESTNET;
+    const TEST_CHAIN_ID = CHAIN_IDS.OPTIMISM_GOERLI;
     async function mockRPCURLAndChainId(mockServer) {
       return [
         await mockServer

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -1721,7 +1721,8 @@ export function getAllNetworks(state) {
 export function getIsOptimism(state) {
   return (
     getCurrentChainId(state) === CHAIN_IDS.OPTIMISM ||
-    getCurrentChainId(state) === CHAIN_IDS.OPTIMISM_TESTNET
+    getCurrentChainId(state) === CHAIN_IDS.OPTIMISM_TESTNET ||
+    getCurrentChainId(state) === CHAIN_IDS.OPTIMISM_GOERLI
   );
 }
 


### PR DESCRIPTION
## **Description**

Updates reference in the code to OPTIMISM_TESTNET(0x1a4) to OPTIMISM_TESTNET(0xaa37dc)

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/23170?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/2130

## **Manual testing steps**

1. ADD OP Goerli testnet
2. You should still see deprecation warning
3. ADD OP Sepolia testnet
4. You should not see deprecation warning
5. Make transactions on OP goerli and OP sepolia
6. You should not have any errors

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

https://github.com/MetaMask/metamask-extension/assets/10994169/3138fef6-52cf-4cd9-8a7e-d4839d95b357



### **After**


https://github.com/MetaMask/metamask-extension/assets/10994169/b0eef173-54aa-429d-8cb5-d2dee52361c9



## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've clearly explained what problem this PR is solving and how it is solved.
- [ ] I've linked related issues
- [ ] I've included manual testing steps
- [ ] I've included screenshots/recordings if applicable
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [ ] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
