### PR TITLE
fix: UX: Multichain: Sendflow: Show pinned accounts in send flow

### DIFF
--- a/ui/components/multichain/pages/send/__snapshots__/send.test.js.snap
+++ b/ui/components/multichain/pages/send/__snapshots__/send.test.js.snap
@@ -261,7 +261,7 @@ exports[`SendPage render and initialization should render correctly even when a 
                           <button
                             class="mm-box mm-text multichain-account-list-item__account-name__button mm-text--body-md-medium mm-text--ellipsis mm-text--text-align-left mm-box--padding-0 mm-box--width-full mm-box--color-text-default mm-box--background-color-transparent"
                           >
-                            Account 1
+                            Test Account
                           </button>
                         </div>
                         <div

--- a/ui/components/multichain/pages/send/components/__snapshots__/your-accounts.test.tsx.snap
+++ b/ui/components/multichain/pages/send/components/__snapshots__/your-accounts.test.tsx.snap
@@ -322,7 +322,7 @@ exports[`SendPageYourAccounts render renders correctly 1`] = `
               <button
                 class="mm-box mm-text multichain-account-list-item__account-name__button mm-text--body-md-medium mm-text--ellipsis mm-text--text-align-left mm-box--padding-0 mm-box--width-full mm-box--color-text-default mm-box--background-color-transparent"
               >
-                Test Ledger 1
+                Ledger Hardware 2
               </button>
             </div>
             <div
@@ -386,6 +386,15 @@ exports[`SendPageYourAccounts render renders correctly 1`] = `
               </div>
             </div>
           </div>
+        </div>
+        <div
+          class="mm-box mm-tag mm-box--padding-right-1 mm-box--padding-left-1 mm-box--display-flex mm-box--gap-1 mm-box--align-items-center mm-box--background-color-background-default mm-box--rounded-pill mm-box--border-color-border-default mm-box--border-width-1 box--border-style-solid"
+        >
+          <p
+            class="mm-box mm-text mm-text--body-xs mm-box--color-text-alternative"
+          >
+            Ledger
+          </p>
         </div>
       </div>
     </div>
@@ -578,7 +587,7 @@ exports[`SendPageYourAccounts render renders correctly 1`] = `
               <button
                 class="mm-box mm-text multichain-account-list-item__account-name__button mm-text--body-md-medium mm-text--ellipsis mm-text--text-align-left mm-box--padding-0 mm-box--width-full mm-box--color-text-default mm-box--background-color-transparent"
               >
-                Custody test
+                Test Account 4
               </button>
             </div>
             <div

--- a/ui/components/multichain/pages/send/components/your-accounts.tsx
+++ b/ui/components/multichain/pages/send/components/your-accounts.tsx
@@ -1,26 +1,33 @@
 import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { getMetaMaskAccountsOrdered } from '../../../../../selectors';
+import {
+  getUpdatedAndSortedAccounts,
+  getInternalAccounts,
+} from '../../../../../selectors';
 import { AccountListItem } from '../../..';
 import {
   addHistoryEntry,
   updateRecipient,
   updateRecipientUserInput,
 } from '../../../../../ducks/send';
+import { mergeAccounts } from '../../../account-list-menu/account-list-menu';
 import { SendPageRow } from '.';
 
 export const SendPageYourAccounts = () => {
   const dispatch = useDispatch();
 
   // Your Accounts
-  const accounts = useSelector(getMetaMaskAccountsOrdered);
+  const accounts = useSelector(getUpdatedAndSortedAccounts);
+  const internalAccounts = useSelector(getInternalAccounts);
+  const mergedAccounts = mergeAccounts(accounts, internalAccounts);
 
   return (
     <SendPageRow>
-      {accounts.map((account: any) => (
+      {mergedAccounts.map((account: any) => (
         <AccountListItem
           identity={account}
           key={account.address}
+          isPinned={Boolean(account.pinned)}
           onClick={() => {
             dispatch(
               addHistoryEntry(

--- a/ui/components/multichain/pages/send/send.test.js
+++ b/ui/components/multichain/pages/send/send.test.js
@@ -192,7 +192,17 @@ describe('SendPage', () => {
     };
 
     it('should initialize the ENS slice on render', () => {
-      const store = configureMockStore(middleware)(baseStore);
+      const store = configureMockStore(middleware)({
+        ...baseStore,
+        metamask: {
+          ...baseStore.metamask,
+          pinnedAccountList: [
+            '0xec1adf982415d2ef5ec55899b9bfb8bc0f29251b',
+            '0xeb9e64b93097bc15f01f13eae97015c57ab64823',
+          ],
+          hiddenAccountList: [],
+        },
+      });
       renderWithProvider(<SendPage />, store);
       const actions = store.getActions();
       expect(actions).toStrictEqual(
@@ -207,6 +217,14 @@ describe('SendPage', () => {
     it('should render correctly even when a draftTransaction does not exist', () => {
       const modifiedStore = {
         ...baseStore,
+        metamask: {
+          ...baseStore.metamask,
+          pinnedAccountList: [
+            '0xec1adf982415d2ef5ec55899b9bfb8bc0f29251b',
+            '0xeb9e64b93097bc15f01f13eae97015c57ab64823',
+          ],
+          hiddenAccountList: [],
+        },
         send: {
           ...baseStore.send,
           currentTransactionUUID: null,


### PR DESCRIPTION
## **Description**

This PR accomplishes two improvements:

1.  `mergeAccounts` is used to ensure AccountListItems get the proper labels (i.e. "Snaps account")
2. Pinned accounts will be sorted to the top

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/23176?quickstart=1)

## **Related issues**

Fixes: N/A

## **Manual testing steps**

1. `MULTICHAIN=1 yarn start`
2. Go to the Send page
3. See pinned accounts at the top

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

(Accounts were just in line)

### **After**

<img width="420" alt="SCR-20240226-jnov" src="https://github.com/MetaMask/metamask-extension/assets/46655/c78e2726-fbea-4028-9b5f-fada30b29759">


## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've clearly explained what problem this PR is solving and how it is solved.
- [ ] I've linked related issues
- [ ] I've included manual testing steps
- [ ] I've included screenshots/recordings if applicable
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [ ] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
