### PR TITLE
fix: Update avatarType prop to be optional

### DIFF
--- a/ui/components/multichain/avatar-group/avatar-group.types.tsx
+++ b/ui/components/multichain/avatar-group/avatar-group.types.tsx
@@ -8,7 +8,7 @@ export interface AvatarGroupProps extends StyleUtilityProps {
   /** * Limit to show only a certain number of tokens and extras in Text */
   limit: number;
   /** * Type of Avatar: Token/Account */
-  avatarType: AvatarType;
+  avatarType?: AvatarType;
   /** * List of Avatar Tokens */
   members: {
     /** * Image of Avatar Token */


### PR DESCRIPTION
## **Description**
Fixing AvatarGroup tsx test failures due to avatarType being a required type
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/23184?quickstart=1)

## **Related issues**

Fixes: #23080

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've clearly explained what problem this PR is solving and how it is solved.
- [ ] I've linked related issues
- [ ] I've included manual testing steps
- [ ] I've included screenshots/recordings if applicable
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [ ] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
