### PR TITLE
Capture error in migration 105 if selectedAddress is not a string

### DIFF
--- a/app/scripts/migrations/105.test.ts
+++ b/app/scripts/migrations/105.test.ts
@@ -6,6 +6,15 @@ import { migrate } from './105';
 const MOCK_ADDRESS = '0x0';
 const MOCK_ADDRESS_2 = '0x1';
 
+const sentryCaptureExceptionMock = jest.fn();
+
+global.sentry = {
+  startSession: jest.fn(),
+  endSession: jest.fn(),
+  toggleSession: jest.fn(),
+  captureException: sentryCaptureExceptionMock,
+};
+
 function addressToUUID(address: string): string {
   return uuid({
     random: sha256FromString(address).slice(0, 16),

--- a/app/scripts/migrations/105.test.ts
+++ b/app/scripts/migrations/105.test.ts
@@ -257,5 +257,24 @@ describe('migration #105', () => {
         },
       });
     });
+
+    it('captures an exception if the selectedAddress state is invalid', async () => {
+      const oldData = {
+        PreferencesController: {
+          identities: {},
+          selectedAddress: undefined,
+        },
+      };
+      const oldStorage = {
+        meta: { version: 103 },
+        data: oldData,
+      };
+      await migrate(oldStorage);
+
+      expect(sentryCaptureExceptionMock).toHaveBeenCalledTimes(1);
+      expect(sentryCaptureExceptionMock).toHaveBeenCalledWith(
+        new Error(`state.PreferencesController?.selectedAddress is undefined`),
+      );
+    });
   });
 });

--- a/app/scripts/migrations/105.ts
+++ b/app/scripts/migrations/105.ts
@@ -102,6 +102,14 @@ function createSelectedAccountForAccountsController(
 ) {
   const selectedAddress = state.PreferencesController?.selectedAddress;
 
+  if (typeof selectedAddress !== 'string') {
+    global.sentry?.captureException?.(
+      new Error(
+        `state.PreferencesController?.selectedAddress is ${selectedAddress}`,
+      ),
+    );
+  }
+
   const selectedAccount = Object.values<InternalAccount>(
     state.AccountsController.internalAccounts.accounts,
   ).find((account: InternalAccount) => {


### PR DESCRIPTION
## **Description**

We are seeing an error in prod that could only be explained if a migration fails. This PR adds some error handling to better detect and monitor one possible source of migration failure.

The prod error is:
> TypeError getSelectedInternalAccount(ui/selectors/selectors.js)
> Cannot read properties of undefined (reading 'selectedAccount')
https://metamask.sentry.io/issues/4999905586/?project=273505&query=is%3Aunresolved+release%3A11.10.0+is%3Anew&referrer=issue-stream&statsPeriod=7d&stream_index=9

## **Manual testing steps**

Unit tests should pass. Also:

1. Build this branch and install metamask
2. During the onboarding flow, make sure to opt _in_ to metametrics
3. Run the following script in the background console
```
chrome.storage.local.get(({ data, meta }) => chrome.storage.local.set({ data: { ...data, PreferencesController: {selectedAddress: undefined} }, meta: {...meta, version: 104} }, () => { window.location.reload() }))
```
You should see a network request to sentry with `state.PreferencesController?.selectedAddress is  undefined` in the payload

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've clearly explained what problem this PR is solving and how it is solved.
- [ ] I've linked related issues
- [ ] I've included manual testing steps
- [ ] I've included screenshots/recordings if applicable
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [ ] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
