### PR TITLE
fix: Transaction Confirmation incorrectly showing max instead of estimated fees and total

### DIFF
--- a/ui/pages/confirmations/components/confirm-gas-display/__snapshots__/confirm-gas-display.test.js.snap
+++ b/ui/pages/confirmations/components/confirm-gas-display/__snapshots__/confirm-gas-display.test.js.snap
@@ -42,12 +42,12 @@ exports[`ConfirmGasDisplay should match snapshot 1`] = `
             </button>
             <div
               class="mm-box currency-display-component mm-box--display-flex mm-box--flex-wrap-wrap mm-box--align-items-center"
-              title="0.00147"
+              title="0.001197"
             >
               <span
                 class="mm-box mm-text currency-display-component__text mm-text--inherit mm-text--ellipsis mm-box--color-text-default"
               >
-                0.00147
+                0.001197
               </span>
             </div>
           </div>
@@ -60,12 +60,12 @@ exports[`ConfirmGasDisplay should match snapshot 1`] = `
           >
             <div
               class="mm-box currency-display-component mm-box--display-flex mm-box--flex-wrap-wrap mm-box--align-items-center"
-              title="0.00147 ETH"
+              title="0.001197 ETH"
             >
               <span
                 class="mm-box mm-text currency-display-component__text mm-text--inherit mm-text--ellipsis mm-box--color-text-default"
               >
-                0.00147
+                0.001197
               </span>
               <span
                 class="mm-box mm-text currency-display-component__suffix mm-text--inherit mm-box--margin-inline-start-1 mm-box--color-text-default"

--- a/ui/pages/confirmations/components/gas-details-item/gas-details-item.js
+++ b/ui/pages/confirmations/components/gas-details-item/gas-details-item.js
@@ -74,7 +74,6 @@ const GasDetailsItem = ({
 
   const useCurrencyRateCheck = useSelector(getUseCurrencyRateCheck);
   const getTransactionFeeTotal = useMemo(() => {
-    console.log('getTransactionFeeTotal: ', { hexMinimumTransactionFee });
     if (isMultiLayerFeeNetwork) {
       return sumHexes(hexMinimumTransactionFee, estimatedL1Fees || 0);
     }

--- a/ui/pages/confirmations/components/gas-details-item/gas-details-item.js
+++ b/ui/pages/confirmations/components/gas-details-item/gas-details-item.js
@@ -65,6 +65,7 @@ const GasDetailsItem = ({
     estimateUsed,
     hasSimulationError,
     maximumCostInHexWei: hexMaximumTransactionFee,
+    minimumCostInHexWei: hexMinimumTransactionFee,
     maxPriorityFeePerGas,
     maxFeePerGas,
   } = useGasFeeContext();
@@ -72,8 +73,16 @@ const GasDetailsItem = ({
   const { useNativeCurrencyAsPrimaryCurrency } = useSelector(getPreferences);
 
   const useCurrencyRateCheck = useSelector(getUseCurrencyRateCheck);
-
   const getTransactionFeeTotal = useMemo(() => {
+    console.log('getTransactionFeeTotal: ', { hexMinimumTransactionFee });
+    if (isMultiLayerFeeNetwork) {
+      return sumHexes(hexMinimumTransactionFee, estimatedL1Fees || 0);
+    }
+
+    return hexMinimumTransactionFee;
+  }, [isMultiLayerFeeNetwork, hexMinimumTransactionFee, estimatedL1Fees]);
+
+  const getMaxTransactionFeeTotal = useMemo(() => {
     if (isMultiLayerFeeNetwork) {
       return sumHexes(hexMaximumTransactionFee, estimatedL1Fees || 0);
     }
@@ -156,7 +165,9 @@ const GasDetailsItem = ({
               <UserPreferencedCurrencyDisplay
                 key="editGasSubTextFeeAmount"
                 type={PRIMARY}
-                value={getTransactionFeeTotal || draftHexMaximumTransactionFee}
+                value={
+                  getMaxTransactionFeeTotal || draftHexMaximumTransactionFee
+                }
                 hideLabel={!useNativeCurrencyAsPrimaryCurrency}
               />
             </div>

--- a/ui/pages/confirmations/confirm-transaction-base/confirm-transaction-base.component.js
+++ b/ui/pages/confirmations/confirm-transaction-base/confirm-transaction-base.component.js
@@ -537,7 +537,7 @@ export default class ConfirmTransactionBase extends Component {
               detailText={
                 useCurrencyRateCheck && renderTotalDetailText(getTotalAmount())
               }
-              detailTotal={renderTotalMaxAmount(true)}
+              detailTotal={renderTotalMaxAmount(false)}
               subTitle={t('transactionDetailGasTotalSubtitle')}
               subText={
                 <div className="confirm-page-container-content__total-amount">


### PR DESCRIPTION
## **Description**
The Transaction Confirmation screen is incorrectly showing max fees and totals where estimated values should be:
We should show the estimated and max fee and total independently:

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/23203?quickstart=1)

## **Related issues**

Fixes: [#2112](https://github.com/MetaMask/MetaMask-planning/issues/2112)

## **Manual testing steps**

1. Launch MM
2. Perform a send transaction
3. See how the Estimate fees and max fees are the same
4. Checkout this branch
5. Build and launch MM
6. Perform a send transaction
7. See how the estimate fees and max fees are not the same and estimate is less than max

## **Screenshots/Recordings**

### **Before**

https://github.com/MetaMask/metamask-extension/assets/44811/9f553918-e56b-4a01-a119-7c67ff1593ca

### **After**

https://github.com/MetaMask/metamask-extension/assets/44811/883e808b-a85f-43fe-a03a-6df9556b66d3

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained what problem this PR is solving and how it is solved.
- [x] I've linked related issues
- [x] I've included manual testing steps
- [x] I've included screenshots/recordings if applicable
- [ ] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [x] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [x] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
