### PR TITLE
increase token symbol length to 64

### DIFF
--- a/app/_locales/am/messages.json
+++ b/app/_locales/am/messages.json
@@ -678,8 +678,8 @@
   "symbol": {
     "message": "ምልክት"
   },
-  "symbolBetweenZeroTwelve": {
-    "message": "ምልክቱ 11 ቁምፊዎች ወይም ከዚያ ያነሰ መሆን አለበት።"
+  "symbolBetweenZeroSixtyFour": {
+    "message": "ምልክቱ 64 ቁምፊዎች ወይም ከዚያ ያነሰ መሆን አለበት።"
   },
   "terms": {
     "message": "የአጠቃቀም ደንቦች"

--- a/app/_locales/ar/messages.json
+++ b/app/_locales/ar/messages.json
@@ -690,8 +690,8 @@
   "symbol": {
     "message": "رمز"
   },
-  "symbolBetweenZeroTwelve": {
-    "message": "يجب أن يكون الرمز 11 حرفًا أو أقل."
+  "symbolBetweenZeroSixtyFour": {
+    "message": "يجب أن يكون الرمز 64 حرفًا أو أقل."
   },
   "terms": {
     "message": "شروط الاستخدام"

--- a/app/_locales/bg/messages.json
+++ b/app/_locales/bg/messages.json
@@ -689,8 +689,8 @@
   "symbol": {
     "message": "Символ"
   },
-  "symbolBetweenZeroTwelve": {
-    "message": "Символът трябва да е 11 символа или по-малко."
+  "symbolBetweenZeroSixtyFour": {
+    "message": "Символът трябва да е 64 символа или по-малко."
   },
   "terms": {
     "message": "Условия за ползване"

--- a/app/_locales/bn/messages.json
+++ b/app/_locales/bn/messages.json
@@ -687,8 +687,8 @@
   "symbol": {
     "message": "প্রতীক"
   },
-  "symbolBetweenZeroTwelve": {
-    "message": "প্রতীকটি 11 টি অক্ষর বা তার চেয়ে কম হতে হবে।"
+  "symbolBetweenZeroSixtyFour": {
+    "message": "প্রতীকটি 64 টি অক্ষর বা তার চেয়ে কম হতে হবে।"
   },
   "terms": {
     "message": "ব্যবহারের শর্তাবলী"

--- a/app/_locales/ca/messages.json
+++ b/app/_locales/ca/messages.json
@@ -674,8 +674,8 @@
   "symbol": {
     "message": "Símbol"
   },
-  "symbolBetweenZeroTwelve": {
-    "message": "El símbol ha de tenir com a mínim 11 caràcters."
+  "symbolBetweenZeroSixtyFour": {
+    "message": "El símbol ha de tenir com a mínim 64 caràcters."
   },
   "terms": {
     "message": "Condicions d'ús"

--- a/app/_locales/cs/messages.json
+++ b/app/_locales/cs/messages.json
@@ -322,8 +322,8 @@
   "supportCenter": {
     "message": "Navštivte naše centrum podpory"
   },
-  "symbolBetweenZeroTwelve": {
-    "message": "Symbol musí mít 11 nebo méně znaků."
+  "symbolBetweenZeroSixtyFour": {
+    "message": "Symbol musí mít 64 nebo méně znaků."
   },
   "terms": {
     "message": "Podmínky použití"

--- a/app/_locales/da/messages.json
+++ b/app/_locales/da/messages.json
@@ -668,8 +668,8 @@
   "switchNetworks": {
     "message": "Skift Netværk"
   },
-  "symbolBetweenZeroTwelve": {
-    "message": "Symbolet skal være mindst 11 tegn."
+  "symbolBetweenZeroSixtyFour": {
+    "message": "Symbolet skal være mindst 64 tegn."
   },
   "terms": {
     "message": "Brugsbetingelser"

--- a/app/_locales/de/messages.json
+++ b/app/_locales/de/messages.json
@@ -4297,7 +4297,7 @@
     "message": "Symbol"
   },
   "symbolBetweenZeroTwelve": {
-    "message": "Das Symbol darf maximal 11 Zeichen lang sein."
+    "message": "Das Symbol darf maximal 64 Zeichen lang sein."
   },
   "tenPercentIncreased": {
     "message": "10 % Erhöhung"

--- a/app/_locales/el/messages.json
+++ b/app/_locales/el/messages.json
@@ -4296,8 +4296,8 @@
   "symbol": {
     "message": "Σύμβολο"
   },
-  "symbolBetweenZeroTwelve": {
-    "message": "Το σύμβολο πρέπει να αποτελείται από 11 ή λιγότερους χαρακτήρες."
+  "symbolBetweenZeroSixtyFour": {
+    "message": "Το σύμβολο πρέπει να αποτελείται από 64 ή λιγότερους χαρακτήρες."
   },
   "tenPercentIncreased": {
     "message": "10% αύξηση"

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -5121,8 +5121,8 @@
   "symbol": {
     "message": "Symbol"
   },
-  "symbolBetweenZeroTwelve": {
-    "message": "Symbol must be 11 characters or fewer."
+  "symbolBetweenZeroSixtyFour": {
+    "message": "Symbol must be 64 characters or fewer."
   },
   "tenPercentIncreased": {
     "message": "10% increase"

--- a/app/_locales/es/messages.json
+++ b/app/_locales/es/messages.json
@@ -4296,8 +4296,8 @@
   "symbol": {
     "message": "Símbolo"
   },
-  "symbolBetweenZeroTwelve": {
-    "message": "El símbolo debe tener 11 caracteres o menos."
+  "symbolBetweenZeroSixtyFour": {
+    "message": "El símbolo debe tener 64 caracteres o menos."
   },
   "tenPercentIncreased": {
     "message": "10 % de aumento"

--- a/app/_locales/es_419/messages.json
+++ b/app/_locales/es_419/messages.json
@@ -2300,8 +2300,8 @@
   "symbol": {
     "message": "Símbolo"
   },
-  "symbolBetweenZeroTwelve": {
-    "message": "El símbolo debe tener 11 caracteres o menos."
+  "symbolBetweenZeroSixtyFour": {
+    "message": "El símbolo debe tener 64 caracteres o menos."
   },
   "tenPercentIncreased": {
     "message": "10% de aumento"

--- a/app/_locales/et/messages.json
+++ b/app/_locales/et/messages.json
@@ -683,8 +683,8 @@
   "symbol": {
     "message": "Sümbol"
   },
-  "symbolBetweenZeroTwelve": {
-    "message": "Sümbol peab olema 11 tähemärki või vähem."
+  "symbolBetweenZeroSixtyFour": {
+    "message": "Sümbol peab olema 64 tähemärki või vähem."
   },
   "terms": {
     "message": "Teenusetingimused"

--- a/app/_locales/fa/messages.json
+++ b/app/_locales/fa/messages.json
@@ -693,8 +693,8 @@
   "symbol": {
     "message": "سمبول"
   },
-  "symbolBetweenZeroTwelve": {
-    "message": "نماد باید 11 کاراکتر یا کمتر باشد."
+  "symbolBetweenZeroSixtyFour": {
+    "message": "نماد باید 64 کاراکتر یا کمتر باشد."
   },
   "terms": {
     "message": "شرایط استفاده"

--- a/app/_locales/fi/messages.json
+++ b/app/_locales/fi/messages.json
@@ -690,8 +690,8 @@
   "symbol": {
     "message": "Symboli"
   },
-  "symbolBetweenZeroTwelve": {
-    "message": "Symbolin on oltava 11 merkkiä tai vähemmän."
+  "symbolBetweenZeroSixtyFour": {
+    "message": "Symbolin on oltava 64 merkkiä tai vähemmän."
   },
   "terms": {
     "message": "Käyttöehdot"

--- a/app/_locales/fil/messages.json
+++ b/app/_locales/fil/messages.json
@@ -611,8 +611,8 @@
   "symbol": {
     "message": "Simbolo"
   },
-  "symbolBetweenZeroTwelve": {
-    "message": "Ang simbolo ay dapat na 11 character o mas kaunti."
+  "symbolBetweenZeroSixtyFour": {
+    "message": "Ang simbolo ay dapat na 64 character o mas kaunti."
   },
   "terms": {
     "message": "Mga Tuntunin ng Paggamit"

--- a/app/_locales/fr/messages.json
+++ b/app/_locales/fr/messages.json
@@ -4299,8 +4299,8 @@
   "symbol": {
     "message": "Symbole"
   },
-  "symbolBetweenZeroTwelve": {
-    "message": "Le symbole doit comporter 11 caractères ou moins."
+  "symbolBetweenZeroSixtyFour": {
+    "message": "Le symbole doit comporter 64 caractères ou moins."
   },
   "tenPercentIncreased": {
     "message": "Augmentation de 10 %"

--- a/app/_locales/he/messages.json
+++ b/app/_locales/he/messages.json
@@ -690,8 +690,8 @@
   "symbol": {
     "message": "סמל"
   },
-  "symbolBetweenZeroTwelve": {
-    "message": "הסמל חייב להיות 11 תווים או פחות."
+  "symbolBetweenZeroSixtyFour": {
+    "message": "הסמל חייב להיות 64 תווים או פחות."
   },
   "terms": {
     "message": "תנאי שימוש"

--- a/app/_locales/hi/messages.json
+++ b/app/_locales/hi/messages.json
@@ -4296,8 +4296,8 @@
   "symbol": {
     "message": "प्रतीक"
   },
-  "symbolBetweenZeroTwelve": {
-    "message": "प्रतीक 11 करैक्टर या उससे कम का होना चाहिए।"
+  "symbolBetweenZeroSixtyFour": {
+    "message": "प्रतीक 64 करैक्टर या उससे कम का होना चाहिए।"
   },
   "tenPercentIncreased": {
     "message": "10% बढ़ोत्तरी"

--- a/app/_locales/hn/messages.json
+++ b/app/_locales/hn/messages.json
@@ -287,8 +287,8 @@
   "supportCenter": {
     "message": "हमारे सहायता केंद्र पर जाएं"
   },
-  "symbolBetweenZeroTwelve": {
-    "message": "प्रतीक 11 वर्ण या उससे कम का होना चाहिए।"
+  "symbolBetweenZeroSixtyFour": {
+    "message": "प्रतीक 64 वर्ण या उससे कम का होना चाहिए।"
   },
   "terms": {
     "message": "उपयोग की शर्तें"

--- a/app/_locales/hr/messages.json
+++ b/app/_locales/hr/messages.json
@@ -686,8 +686,8 @@
   "symbol": {
     "message": "Simbol"
   },
-  "symbolBetweenZeroTwelve": {
-    "message": "Simbol mora biti 11 znakova ili manje."
+  "symbolBetweenZeroSixtyFour": {
+    "message": "Simbol mora biti 64 znakova ili manje."
   },
   "terms": {
     "message": "Odredbe uporabe"

--- a/app/_locales/ht/messages.json
+++ b/app/_locales/ht/messages.json
@@ -497,8 +497,8 @@
   "supportCenter": {
     "message": "Vizite Sant Sipò Nou"
   },
-  "symbolBetweenZeroTwelve": {
-    "message": "Senbòl yo dwe 11 karaktè oswa mwens."
+  "symbolBetweenZeroSixtyFour": {
+    "message": "Senbòl yo dwe 64 karaktè oswa mwens."
   },
   "terms": {
     "message": "Tèm pou itilize"

--- a/app/_locales/hu/messages.json
+++ b/app/_locales/hu/messages.json
@@ -686,8 +686,8 @@
   "symbol": {
     "message": "Szimbólum"
   },
-  "symbolBetweenZeroTwelve": {
-    "message": "A szimbólum 0 és 12 karakter között kell legyen."
+  "symbolBetweenZeroSixtyFour": {
+    "message": "A szimbólum 0 és 64 karakter között kell legyen."
   },
   "terms": {
     "message": "Használati feltételek"

--- a/app/_locales/id/messages.json
+++ b/app/_locales/id/messages.json
@@ -4296,8 +4296,8 @@
   "symbol": {
     "message": "Simbol"
   },
-  "symbolBetweenZeroTwelve": {
-    "message": "Simbol harus terdiri dari 11 karakter atau lebih sedikit."
+  "symbolBetweenZeroSixtyFour": {
+    "message": "Simbol harus terdiri dari 64 karakter atau lebih sedikit."
   },
   "tenPercentIncreased": {
     "message": "Meningkat 10%"

--- a/app/_locales/it/messages.json
+++ b/app/_locales/it/messages.json
@@ -1671,8 +1671,8 @@
   "symbol": {
     "message": "Simbolo"
   },
-  "symbolBetweenZeroTwelve": {
-    "message": "Il simbolo deve essere lungo tra 0 e 12 caratteri."
+  "symbolBetweenZeroSixtyFour": {
+    "message": "Il simbolo deve essere lungo tra 0 e 64 caratteri."
   },
   "terms": {
     "message": "Termini di Uso"

--- a/app/_locales/ja/messages.json
+++ b/app/_locales/ja/messages.json
@@ -4296,8 +4296,8 @@
   "symbol": {
     "message": "シンボル"
   },
-  "symbolBetweenZeroTwelve": {
-    "message": "シンボルは11文字以下にする必要があります。"
+  "symbolBetweenZeroSixtyFour": {
+    "message": "シンボルは64文字以下にする必要があります。"
   },
   "tenPercentIncreased": {
     "message": "10%の増加"

--- a/app/_locales/kn/messages.json
+++ b/app/_locales/kn/messages.json
@@ -693,8 +693,8 @@
   "symbol": {
     "message": "ಚಿಹ್ನೆ"
   },
-  "symbolBetweenZeroTwelve": {
-    "message": "ಚಿಹ್ನೆಯು 0 ಮತ್ತು 12 ಅಕ್ಷರಗಳ ನಡುವೆ ಇರಬೇಕು."
+  "symbolBetweenZeroSixtyFour": {
+    "message": "ಚಿಹ್ನೆಯು 0 ಮತ್ತು 64 ಅಕ್ಷರಗಳ ನಡುವೆ ಇರಬೇಕು."
   },
   "terms": {
     "message": "ಬಳಕೆಯ ನಿಯಮಗಳು"

--- a/app/_locales/ko/messages.json
+++ b/app/_locales/ko/messages.json
@@ -4296,8 +4296,8 @@
   "symbol": {
     "message": "기호"
   },
-  "symbolBetweenZeroTwelve": {
-    "message": "기호는 11자 이하여야 합니다."
+  "symbolBetweenZeroSixtyFour": {
+    "message": "기호는 64자 이하여야 합니다."
   },
   "tenPercentIncreased": {
     "message": "10% 인상"

--- a/app/_locales/lt/messages.json
+++ b/app/_locales/lt/messages.json
@@ -693,8 +693,8 @@
   "symbol": {
     "message": "Simbolis"
   },
-  "symbolBetweenZeroTwelve": {
-    "message": "Simbolis turi būti ne ilgesnis nei 11 simbolių."
+  "symbolBetweenZeroSixtyFour": {
+    "message": "Simbolis turi būti ne ilgesnis nei 64 simbolių."
   },
   "terms": {
     "message": "Naudojimo sąlygos"

--- a/app/_locales/lv/messages.json
+++ b/app/_locales/lv/messages.json
@@ -689,8 +689,8 @@
   "symbol": {
     "message": "Simbols"
   },
-  "symbolBetweenZeroTwelve": {
-    "message": "Simbolā nedrīkst būt vairāk par 11 rakstzīmēm."
+  "symbolBetweenZeroSixtyFour": {
+    "message": "Simbolā nedrīkst būt vairāk par 64 rakstzīmēm."
   },
   "terms": {
     "message": "Lietošanas noteikumi"

--- a/app/_locales/ms/messages.json
+++ b/app/_locales/ms/messages.json
@@ -673,8 +673,8 @@
   "symbol": {
     "message": "Simbol"
   },
-  "symbolBetweenZeroTwelve": {
-    "message": "Simbol mestilah 11 aksara atau kurang."
+  "symbolBetweenZeroSixtyFour": {
+    "message": "Simbol mestilah 64 aksara atau kurang."
   },
   "terms": {
     "message": "Syarat-syarat Penggunaan"

--- a/app/_locales/nl/messages.json
+++ b/app/_locales/nl/messages.json
@@ -280,8 +280,8 @@
   "supportCenter": {
     "message": "Bezoek ons ​​ondersteuningscentrum"
   },
-  "symbolBetweenZeroTwelve": {
-    "message": "Symbool moet 11 tekens of minder zijn."
+  "symbolBetweenZeroSixtyFour": {
+    "message": "Symbool moet 64 tekens of minder zijn."
   },
   "terms": {
     "message": "Gebruiksvoorwaarden"

--- a/app/_locales/no/messages.json
+++ b/app/_locales/no/messages.json
@@ -671,8 +671,8 @@
   "switchNetworks": {
     "message": "Bytt nettverk "
   },
-  "symbolBetweenZeroTwelve": {
-    "message": "Symbolet må være 11 tegn eller færre."
+  "symbolBetweenZeroSixtyFour": {
+    "message": "Symbolet må være 64 tegn eller færre."
   },
   "terms": {
     "message": "Brukervilkår"

--- a/app/_locales/ph/messages.json
+++ b/app/_locales/ph/messages.json
@@ -1596,8 +1596,8 @@
   "symbol": {
     "message": "Simbolo"
   },
-  "symbolBetweenZeroTwelve": {
-    "message": "Dapat ay 11 character o mas kaunti ang simbolo."
+  "symbolBetweenZeroSixtyFour": {
+    "message": "Dapat ay 64 character o mas kaunti ang simbolo."
   },
   "terms": {
     "message": "Mga Tuntunin ng Paggamit"

--- a/app/_locales/pl/messages.json
+++ b/app/_locales/pl/messages.json
@@ -684,8 +684,8 @@
   "switchNetworks": {
     "message": "Zmień sieci"
   },
-  "symbolBetweenZeroTwelve": {
-    "message": "Symbol musi mieć maksymalnie 11 znaków."
+  "symbolBetweenZeroSixtyFour": {
+    "message": "Symbol musi mieć maksymalnie 64 znaków."
   },
   "terms": {
     "message": "Regulamin"

--- a/app/_locales/pt/messages.json
+++ b/app/_locales/pt/messages.json
@@ -4300,8 +4300,8 @@
   "symbol": {
     "message": "Símbolo"
   },
-  "symbolBetweenZeroTwelve": {
-    "message": "O símbolo deve ter 11 caracteres ou menos."
+  "symbolBetweenZeroSixtyFour": {
+    "message": "O símbolo deve ter 64 caracteres ou menos."
   },
   "tenPercentIncreased": {
     "message": "10% de aumento"

--- a/app/_locales/pt_BR/messages.json
+++ b/app/_locales/pt_BR/messages.json
@@ -2304,8 +2304,8 @@
   "symbol": {
     "message": "Símbolo"
   },
-  "symbolBetweenZeroTwelve": {
-    "message": "O símbolo deve ter até 11 caracteres."
+  "symbolBetweenZeroSixtyFour": {
+    "message": "O símbolo deve ter até 64 caracteres."
   },
   "tenPercentIncreased": {
     "message": "10% de aumento"

--- a/app/_locales/ro/messages.json
+++ b/app/_locales/ro/messages.json
@@ -680,8 +680,8 @@
   "symbol": {
     "message": "Simbol"
   },
-  "symbolBetweenZeroTwelve": {
-    "message": "Simbolul trebuie să fie de 11 caractere sau mai puțin."
+  "symbolBetweenZeroSixtyFour": {
+    "message": "Simbolul trebuie să fie de 64 caractere sau mai puțin."
   },
   "terms": {
     "message": "Termeni și condiții"

--- a/app/_locales/ru/messages.json
+++ b/app/_locales/ru/messages.json
@@ -4296,8 +4296,8 @@
   "symbol": {
     "message": "Символ"
   },
-  "symbolBetweenZeroTwelve": {
-    "message": "Символ должен состоять из 11 или менее знаков."
+  "symbolBetweenZeroSixtyFour": {
+    "message": "Символ должен состоять из 64 или менее знаков."
   },
   "tenPercentIncreased": {
     "message": "Увеличение на 10%"

--- a/app/_locales/sk/messages.json
+++ b/app/_locales/sk/messages.json
@@ -662,8 +662,8 @@
   "switchNetworks": {
     "message": "Prepnúť siete"
   },
-  "symbolBetweenZeroTwelve": {
-    "message": "Symbol musí být mezi 0 a 12 znaky."
+  "symbolBetweenZeroSixtyFour": {
+    "message": "Symbol musí být mezi 0 a 64 znaky."
   },
   "terms": {
     "message": "Podmínky použití"

--- a/app/_locales/sl/messages.json
+++ b/app/_locales/sl/messages.json
@@ -681,8 +681,8 @@
   "symbol": {
     "message": "Simbol"
   },
-  "symbolBetweenZeroTwelve": {
-    "message": "Simbol mora biti največ 11 znakov ali manj."
+  "symbolBetweenZeroSixtyFour": {
+    "message": "Simbol mora biti največ 64 znakov ali manj."
   },
   "terms": {
     "message": "Pogoji uporabe"

--- a/app/_locales/sr/messages.json
+++ b/app/_locales/sr/messages.json
@@ -684,8 +684,8 @@
   "symbol": {
     "message": "Simbol"
   },
-  "symbolBetweenZeroTwelve": {
-    "message": "Simbol mora biti 11 znakova ili manje."
+  "symbolBetweenZeroSixtyFour": {
+    "message": "Simbol mora biti 64 znakova ili manje."
   },
   "terms": {
     "message": "Uslovi korišćenja"

--- a/app/_locales/sv/messages.json
+++ b/app/_locales/sv/messages.json
@@ -674,8 +674,8 @@
   "switchNetworks": {
     "message": "Växla nätverk"
   },
-  "symbolBetweenZeroTwelve": {
-    "message": "Symbolen måste vara 11 tecken eller färre."
+  "symbolBetweenZeroSixtyFour": {
+    "message": "Symbolen måste vara 64 tecken eller färre."
   },
   "terms": {
     "message": "Användarvillkor"

--- a/app/_locales/sw/messages.json
+++ b/app/_locales/sw/messages.json
@@ -671,8 +671,8 @@
   "symbol": {
     "message": "Ishara"
   },
-  "symbolBetweenZeroTwelve": {
-    "message": "Alama lazima iwe na herufi 11 au chache."
+  "symbolBetweenZeroSixtyFour": {
+    "message": "Alama lazima iwe na herufi 64 au chache."
   },
   "terms": {
     "message": "Masharti ya Matumizi"

--- a/app/_locales/ta/messages.json
+++ b/app/_locales/ta/messages.json
@@ -389,8 +389,8 @@
   "supportCenter": {
     "message": "எங்கள் ஆதரவு மையத்தைப் பார்வையிடவும்"
   },
-  "symbolBetweenZeroTwelve": {
-    "message": "கசின்னம் 11 எழுத்துக்கள் அல்லது குறைவாக இருக்க வேண்டும்."
+  "symbolBetweenZeroSixtyFour": {
+    "message": "கசின்னம் 64 எழுத்துக்கள் அல்லது குறைவாக இருக்க வேண்டும்."
   },
   "terms": {
     "message": "பயன்பாட்டு விதிமுறைகளை"

--- a/app/_locales/th/messages.json
+++ b/app/_locales/th/messages.json
@@ -356,8 +356,8 @@
   "symbol": {
     "message": "เครื่องหมาย"
   },
-  "symbolBetweenZeroTwelve": {
-    "message": "สัญลักษณ์จะต้องมีความยาว 11 ตัวอักษร"
+  "symbolBetweenZeroSixtyFour": {
+    "message": "สัญลักษณ์จะต้องมีความยาว 64 ตัวอักษร"
   },
   "terms": {
     "message": "ข้อตกลงในการใช้งาน"

--- a/app/_locales/tl/messages.json
+++ b/app/_locales/tl/messages.json
@@ -4296,8 +4296,8 @@
   "symbol": {
     "message": "Simbolo"
   },
-  "symbolBetweenZeroTwelve": {
-    "message": "Dapat ay 11 character o mas kaunti ang simbolo."
+  "symbolBetweenZeroSixtyFour": {
+    "message": "Dapat ay 64 character o mas kaunti ang simbolo."
   },
   "tenPercentIncreased": {
     "message": "10% na dagdag"

--- a/app/_locales/tr/messages.json
+++ b/app/_locales/tr/messages.json
@@ -4296,8 +4296,8 @@
   "symbol": {
     "message": "Sembol"
   },
-  "symbolBetweenZeroTwelve": {
-    "message": "Sembol en fazla 11 karakter olmalıdır."
+  "symbolBetweenZeroSixtyFour": {
+    "message": "Sembol en fazla 64 karakter olmalıdır."
   },
   "tenPercentIncreased": {
     "message": "%10 artış"

--- a/app/_locales/uk/messages.json
+++ b/app/_locales/uk/messages.json
@@ -693,8 +693,8 @@
   "symbol": {
     "message": "Символ"
   },
-  "symbolBetweenZeroTwelve": {
-    "message": "Символ повинен містити 11 символів або менше."
+  "symbolBetweenZeroSixtyFour": {
+    "message": "Символ повинен містити 64 символів або менше."
   },
   "terms": {
     "message": "Умови використання"

--- a/app/_locales/vi/messages.json
+++ b/app/_locales/vi/messages.json
@@ -4296,8 +4296,8 @@
   "symbol": {
     "message": "Ký hiệu"
   },
-  "symbolBetweenZeroTwelve": {
-    "message": "Ký hiệu không được dài quá 11 ký tự."
+  "symbolBetweenZeroSixtyFour": {
+    "message": "Ký hiệu không được dài quá 64 ký tự."
   },
   "tenPercentIncreased": {
     "message": "Tăng 10%"

--- a/app/_locales/zh_CN/messages.json
+++ b/app/_locales/zh_CN/messages.json
@@ -4296,8 +4296,8 @@
   "symbol": {
     "message": "符号"
   },
-  "symbolBetweenZeroTwelve": {
-    "message": "符号不得超过11个字符。"
+  "symbolBetweenZeroSixtyFour": {
+    "message": "符号不得超过64个字符。"
   },
   "tenPercentIncreased": {
     "message": "增加10%"

--- a/app/_locales/zh_TW/messages.json
+++ b/app/_locales/zh_TW/messages.json
@@ -1324,8 +1324,8 @@
   "symbol": {
     "message": "符號"
   },
-  "symbolBetweenZeroTwelve": {
-    "message": "符號不得超過 11 個字元。"
+  "symbolBetweenZeroSixtyFour": {
+    "message": "符號不得超過 64 個字元。"
   },
   "terms": {
     "message": "使用條款"

--- a/ui/components/multichain/import-tokens-modal/import-tokens-modal.js
+++ b/ui/components/multichain/import-tokens-modal/import-tokens-modal.js
@@ -253,8 +253,8 @@ export const ImportTokensModal = ({ onClose }) => {
     const symbolLength = symbol.length;
     let symbolError = null;
 
-    if (symbolLength <= 0 || symbolLength >= 12) {
-      symbolError = t('symbolBetweenZeroTwelve');
+    if (symbolLength <= 0 || symbolLength > 64) {
+      symbolError = t('symbolBetweenZeroSixtyFour');
     }
 
     setCustomSymbol(symbol);


### PR DESCRIPTION
## **Description**

Increase the token symbol length to 64. 

With the increase of token derivatives, token symbol lengths are also increasing. 

When adding tokens to the wallet by RPC call, Metamask expects the token symbol to match that on the contract _and_ the symbol to be below 12 characters.

For many tokens (like tenderize's LSTs) this results in a deadlock if the token symbol on the contract has a greater length than 12.

Since Metamask already truncates display of long symbols on the UI, we could allow token symbols up to 64 characters (32 bytes), which equals a single word in the EVM.

This should both be a sufficient length for 99% of token symbols as well as provide a sufficient upper bound.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/PR?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/9243

Same implementation as an earlier PR that increases the length to 12: https://github.com/MetaMask/metamask-extension/pull/5816


## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained what problem this PR is solving and how it is solved.
- [x] I've linked related issues
- [ ] I've included manual testing steps
- [ ] I've included screenshots/recordings if applicable
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [ ] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
