### PR TITLE
chore: add spellchecker extension recommendation for VSCode developers; add lavamoat & blockaid to workspace dictionary

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,3 +1,6 @@
 {
-  "recommendations": ["rvest.vs-code-prettier-eslint"]
+  "recommendations": [
+    "rvest.vs-code-prettier-eslint",
+    "streetsidesoftware.code-spell-checker"
+  ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,5 @@
 {
+  "cSpell.words": ["blockaid", "lavamoat"],
   "editor.defaultFormatter": "rvest.vs-code-prettier-eslint",
   "editor.tabSize": 2,
   "files.trimTrailingWhitespace": true,


### PR DESCRIPTION
This adds a new extension recommendation for developers using VSCode: `Code Spell Checker`. It is optional to install, but when installed is useful for catching misspellings in code, comments, prose, etc.

Two downsides to using the extension:

 * It can be noisy in some files that use a lot of abbreviations, "PPOM"-related files come to mind.
 * VSCode may take an extra ~500ms to open the MM extension workspace.

See the `Code Spell Checker` VSCode extension documentation for details: https://marketplace.visualstudio.com/items?itemName=streetsidesoftware.code-spell-checker

## To Test:

 * Install the extension into VSCode by using the link in the extension's page linked above to install, or in VSCode press `Ctrl/Cmd+ Shift + X`, then search for "Code Spell Checker" (by "Street Side Software")
  * open any file
  * type a word that is mispelled.
  * Place text cursor within the word then either press `Ctrl/Cmd + .` or click the lightbulb icon that appears.

## Examples:

### Misspellings will show a squiggly underline:

![example](https://github.com/MetaMask/metamask-extension/assets/187813/eba04aa9-3a9f-40dc-b500-3a45f11162f4)

### Demonstrating Suggestions and Add to Dictionary:

![suggestions](https://github.com/MetaMask/metamask-extension/assets/187813/3b4f63a2-9a60-4792-966a-2a233c58cfbc)

### Tooltip of a misspelling:

![image](https://github.com/MetaMask/metamask-extension/assets/187813/3eb67cd6-d628-4a40-9666-121f47eba653)

### VSCode "Problems" panel:

![image](https://github.com/MetaMask/metamask-extension/assets/187813/42f7b0c2-40cb-4248-b1ad-0a4bb44146da)

### Misspellings are highlighted in blue (dark mode) in the VSCode scroll bar:

![image](https://github.com/MetaMask/metamask-extension/assets/187813/cc2af787-0b2c-4e94-ac5d-01ccf7ae0261)

--- 

This PR only adds two words to the dictionary: lavamoat and blockaid, just to get things started. I expect many more domain-specific words and abbreviations will be added over time.

If you hate this idea, let me know!

<!--

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?


[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/23210?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**


### **Before**


### **After**


## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've clearly explained what problem this PR is solving and how it is solved.
- [ ] I've linked related issues
- [ ] I've included manual testing steps
- [ ] I've included screenshots/recordings if applicable
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [ ] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
