### PR TITLE
fix: increase PBKDF2 iterations for Snaps state encryption

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -2257,7 +2257,7 @@ export default class MetamaskController extends EventEmitter {
    * Constructor helper for getting Snap permission specifications.
    */
   getSnapPermissionSpecifications() {
-    const snapEncryptor = encryptorFactory(10_000);
+    const snapEncryptor = encryptorFactory(600_000);
 
     return {
       ...buildSnapEndowmentSpecifications(Object.keys(ExcludedSnapEndowments)),


### PR DESCRIPTION
## **Description**

Increases the number of PBKDF2 iterations used for encryption of Snaps state to `600_000`.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/23243?quickstart=1)

## **Related issues**

Closes https://github.com/MetaMask/MetaMask-planning/issues/2155

## **Manual testing steps**

1. Install the manageState example Snap (or any state that uses state) from https://metamask.github.io/snaps/test-snaps/latest/ on a previous version of MetaMask
2. Replace the build with the build of this PR
3. Make sure that the Snap can still load the state (e.g. on the test-snaps page that the state shows up)
