### PR TITLE
fix: SnapUIRenderer rendering an empty delineator when loading

### DIFF
--- a/ui/components/app/snaps/snap-ui-renderer/snap-ui-renderer.js
+++ b/ui/components/app/snaps/snap-ui-renderer/snap-ui-renderer.js
@@ -74,7 +74,7 @@ const SnapUIRendererComponent = ({
         isCollapsed={isCollapsed}
         onClick={onClick}
         boxProps={boxProps}
-        isLoading={isLoading}
+        isLoading={true}
       />
     );
   }

--- a/ui/components/app/snaps/snap-ui-renderer/snap-ui-renderer.js
+++ b/ui/components/app/snaps/snap-ui-renderer/snap-ui-renderer.js
@@ -74,7 +74,7 @@ const SnapUIRendererComponent = ({
         isCollapsed={isCollapsed}
         onClick={onClick}
         boxProps={boxProps}
-        isLoading={true}
+        isLoading
       />
     );
   }


### PR DESCRIPTION
## **Description**

In the SnapUIRenderer the parent will pass `isLoading` via props to signal whether the request to the Snap to show the UI has finished loading, however since we shipped dynamic UI there is a slight delay in that request resolving and the actual UI being ready to display. Instead of showing an empty delineator during this time, this PR forces the loading state to be present.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/23267?quickstart=1)

## **Manual testing steps**

1. Go to a Snaps home page
2. Notice that it doesn't show an empty state in between loading and the content showing up

