### PR TITLE
Experiment with onChange handler

### DIFF
--- a/ui/components/app/snaps/snap-ui-input/snap-ui-input.tsx
+++ b/ui/components/app/snaps/snap-ui-input/snap-ui-input.tsx
@@ -31,6 +31,7 @@ export const SnapUIInput: FunctionComponent<
     setValue(event.target.value);
     handleInputChange(name, event.target.value ?? null, form);
   };
+
   return (
     <FormTextField
       className="snap-ui-renderer__input"

--- a/ui/components/app/snaps/snap-ui-renderer/components/input.ts
+++ b/ui/components/app/snaps/snap-ui-renderer/components/input.ts
@@ -13,5 +13,7 @@ export const input: UIComponentFactory<Input> = ({ element, form }) => ({
     },
     name: element.name,
     form,
+    error: element.error !== undefined,
+    helpText: element.error,
   },
 });

--- a/ui/components/app/snaps/snap-ui-renderer/snap-ui-renderer.js
+++ b/ui/components/app/snaps/snap-ui-renderer/snap-ui-renderer.js
@@ -51,19 +51,18 @@ const SnapUIRendererComponent = ({
 
   const isValidComponent = content && isComponent(content);
 
-  const elementKeyIndex = { value: 0 };
-
   // sections are memoized to avoid useless re-renders if one of the parents element re-renders.
   const sections = useMemo(
     () =>
       isValidComponent &&
       mapToTemplate({
+        map: {},
         element: content,
-        rootKey: nanoid(),
-        elementKeyIndex,
       }),
-    [content, isValidComponent, elementKeyIndex],
+    [content, isValidComponent],
   );
+
+  console.log(sections);
 
   if (isLoading || !content) {
     return (
@@ -74,7 +73,7 @@ const SnapUIRendererComponent = ({
         isCollapsed={isCollapsed}
         onClick={onClick}
         boxProps={boxProps}
-        isLoading={isLoading}
+        isLoading
       />
     );
   }
@@ -97,6 +96,7 @@ const SnapUIRendererComponent = ({
     );
   }
 
+  console.log('Re-render renderer');
   return (
     <SnapDelineator
       snapName={snapName}

--- a/ui/components/app/snaps/snap-ui-renderer/utils.ts
+++ b/ui/components/app/snaps/snap-ui-renderer/utils.ts
@@ -1,17 +1,44 @@
 import { Component } from '@metamask/snaps-sdk';
+import { memoize } from 'lodash';
 import { COMPONENT_MAPPING } from './components';
+import { sha256 } from '@noble/hashes/sha256';
+import { bytesToHex, remove0x } from '@metamask/utils';
 
 export type MapToTemplateParams = {
+  map: Record<string, number>;
   element: Component;
-  elementKeyIndex: { value: number };
-  rootKey: string;
   form?: string;
 };
 
+const generateHash = memoize((component: Component) => {
+  const { type, name } = component;
+  const value =
+    typeof component.value === 'string'
+      ? component.value.slice(0, 5000)
+      : component.value;
+  return remove0x(
+    bytesToHex(
+      sha256(
+        JSON.stringify({
+          type,
+          name: name ?? null,
+          value,
+        }),
+      ),
+    ),
+  );
+});
+
+function generateKey(map: Record<string, number>, component: Component) {
+  const hash = generateHash(component);
+  const count = (map[hash] ?? 0) + 1;
+  map[hash] = count;
+  return `${hash}_${count}`;
+}
+
 export const mapToTemplate = (params: MapToTemplateParams) => {
   const { type } = params.element;
-  params.elementKeyIndex.value += 1;
-  const indexKey = `${params.rootKey}_snap_ui_element_${type}__${params.elementKeyIndex.value}`;
+  const indexKey = generateKey(params.map, params.element);
   // @ts-expect-error This seems to be compatibility issue between superstruct and this repo.
   const mapped = COMPONENT_MAPPING[type](params as any);
   return { ...mapped, key: indexKey };


### PR DESCRIPTION
## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/23271?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've clearly explained what problem this PR is solving and how it is solved.
- [ ] I've linked related issues
- [ ] I've included manual testing steps
- [ ] I've included screenshots/recordings if applicable
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [ ] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
