### PR TITLE
bump selected network controller to 9.0.0

### DIFF
--- a/app/scripts/lib/setupSentry.js
+++ b/app/scripts/lib/setupSentry.js
@@ -239,7 +239,7 @@ export const SENTRY_BACKGROUND_STATE = {
     useTokenDetection: true,
     useRequestQueue: true,
   },
-  SelectedNetworkController: { domains: false, perDomainNetwork: true },
+  SelectedNetworkController: { domains: false },
   SignatureController: {
     unapprovedMsgCount: true,
     unapprovedMsgs: false,

--- a/app/scripts/migrations/111.test.ts
+++ b/app/scripts/migrations/111.test.ts
@@ -38,7 +38,6 @@ describe('migration #111', () => {
   it('resets domains if SelectedNetworkController state is present', async () => {
     const oldState = {
       SelectedNetworkController: {
-        perDomainNetwork: true,
         domains: {
           metamask: 'ropsten',
           otherDomain: 'value',
@@ -48,7 +47,6 @@ describe('migration #111', () => {
 
     const expectedState = {
       SelectedNetworkController: {
-        perDomainNetwork: true,
         domains: {},
       },
     };
@@ -64,7 +62,6 @@ describe('migration #111', () => {
   it('resets domains if existing state only contains metamask', async () => {
     const oldState = {
       SelectedNetworkController: {
-        perDomainNetwork: false,
         domains: {
           metamask: 'mainnet',
         },
@@ -73,7 +70,6 @@ describe('migration #111', () => {
 
     const expectedState = {
       SelectedNetworkController: {
-        perDomainNetwork: false,
         domains: {},
       },
     };
@@ -89,7 +85,6 @@ describe('migration #111', () => {
   it('handles complex state transformations correctly', async () => {
     const oldState = {
       SelectedNetworkController: {
-        perDomainNetwork: false,
         domains: {
           metamask: 'kovan',
           otherDomain1: 'value1',
@@ -103,7 +98,6 @@ describe('migration #111', () => {
 
     const expectedState = {
       SelectedNetworkController: {
-        perDomainNetwork: false,
         domains: {},
       },
       OtherController: {
@@ -122,9 +116,7 @@ describe('migration #111', () => {
   it('should capture an exception if SelectedNetworkController is in state but is not an object', async () => {
     const oldData = {
       other: 'data',
-      SelectedNetworkController: {
-        perDomainNetwork: false,
-      },
+      SelectedNetworkController: {},
     };
     const oldStorage = {
       meta: {
@@ -167,7 +159,6 @@ describe('migration #111', () => {
     const oldData = {
       other: 'data',
       SelectedNetworkController: {
-        perDomainNetwork: false,
         domains: 'not an object',
       },
     };

--- a/app/scripts/migrations/111.test.ts
+++ b/app/scripts/migrations/111.test.ts
@@ -38,6 +38,7 @@ describe('migration #111', () => {
   it('resets domains if SelectedNetworkController state is present', async () => {
     const oldState = {
       SelectedNetworkController: {
+        perDomainNetwork: true,
         domains: {
           metamask: 'ropsten',
           otherDomain: 'value',
@@ -47,6 +48,7 @@ describe('migration #111', () => {
 
     const expectedState = {
       SelectedNetworkController: {
+        perDomainNetwork: true,
         domains: {},
       },
     };
@@ -62,6 +64,7 @@ describe('migration #111', () => {
   it('resets domains if existing state only contains metamask', async () => {
     const oldState = {
       SelectedNetworkController: {
+        perDomainNetwork: false,
         domains: {
           metamask: 'mainnet',
         },
@@ -70,6 +73,7 @@ describe('migration #111', () => {
 
     const expectedState = {
       SelectedNetworkController: {
+        perDomainNetwork: false,
         domains: {},
       },
     };
@@ -85,6 +89,7 @@ describe('migration #111', () => {
   it('handles complex state transformations correctly', async () => {
     const oldState = {
       SelectedNetworkController: {
+        perDomainNetwork: false,
         domains: {
           metamask: 'kovan',
           otherDomain1: 'value1',
@@ -98,6 +103,7 @@ describe('migration #111', () => {
 
     const expectedState = {
       SelectedNetworkController: {
+        perDomainNetwork: false,
         domains: {},
       },
       OtherController: {
@@ -116,7 +122,9 @@ describe('migration #111', () => {
   it('should capture an exception if SelectedNetworkController is in state but is not an object', async () => {
     const oldData = {
       other: 'data',
-      SelectedNetworkController: {},
+      SelectedNetworkController: {
+        perDomainNetwork: false,
+      },
     };
     const oldStorage = {
       meta: {
@@ -159,6 +167,7 @@ describe('migration #111', () => {
     const oldData = {
       other: 'data',
       SelectedNetworkController: {
+        perDomainNetwork: false,
         domains: 'not an object',
       },
     };

--- a/app/scripts/migrations/112.test.ts
+++ b/app/scripts/migrations/112.test.ts
@@ -1,4 +1,3 @@
-
 import { migrate, version } from './112';
 
 const sentryCaptureExceptionMock = jest.fn();
@@ -58,13 +57,12 @@ describe('migration #112', () => {
     expect(transformedState.data).toEqual(expectedState);
   });
 
-
   it('should capture an exception if SelectedNetworkController.perDomainNetwork is in state but is not a boolean', async () => {
     const oldData = {
       other: 'data',
       SelectedNetworkController: {
         perDomainNetwork: 123,
-        domains: {}
+        domains: {},
       },
     };
     const oldStorage = {
@@ -78,7 +76,9 @@ describe('migration #112', () => {
 
     expect(sentryCaptureExceptionMock).toHaveBeenCalledTimes(1);
     expect(sentryCaptureExceptionMock).toHaveBeenCalledWith(
-      new Error(`state.SelectedNetworkController.perDomainNetwork is type: number`),
+      new Error(
+        `state.SelectedNetworkController.perDomainNetwork is type: number`,
+      ),
     );
   });
 
@@ -86,8 +86,8 @@ describe('migration #112', () => {
     const oldData = {
       other: 'data',
       SelectedNetworkController: {
-        domains: {}
-      }
+        domains: {},
+      },
     };
     const oldStorage = {
       meta: {

--- a/app/scripts/migrations/112.test.ts
+++ b/app/scripts/migrations/112.test.ts
@@ -13,7 +13,7 @@ describe('migration #112', () => {
 
   it('updates the version metadata', async () => {
     const oldStorage = {
-      meta: { version: 110 },
+      meta: { version: 111 },
       data: {},
     };
 
@@ -28,7 +28,7 @@ describe('migration #112', () => {
     };
 
     const transformedState = await migrate({
-      meta: { version: 110 },
+      meta: { version: 111 },
       data: oldState,
     });
 
@@ -50,7 +50,7 @@ describe('migration #112', () => {
     };
 
     const transformedState = await migrate({
-      meta: { version: 110 },
+      meta: { version: 111 },
       data: oldState,
     });
 
@@ -67,7 +67,7 @@ describe('migration #112', () => {
     };
     const oldStorage = {
       meta: {
-        version: 93,
+        version: 111,
       },
       data: oldData,
     };
@@ -91,7 +91,7 @@ describe('migration #112', () => {
     };
     const oldStorage = {
       meta: {
-        version: 93,
+        version: 111,
       },
       data: oldData,
     };

--- a/app/scripts/migrations/112.test.ts
+++ b/app/scripts/migrations/112.test.ts
@@ -1,0 +1,108 @@
+
+import { migrate, version } from './112';
+
+const sentryCaptureExceptionMock = jest.fn();
+
+global.sentry = {
+  captureException: sentryCaptureExceptionMock,
+};
+
+describe('migration #112', () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('updates the version metadata', async () => {
+    const oldStorage = {
+      meta: { version: 110 },
+      data: {},
+    };
+
+    const newStorage = await migrate(oldStorage);
+
+    expect(newStorage.meta).toStrictEqual({ version });
+  });
+
+  it('does nothing if SelectedNetworkController is not present', async () => {
+    const oldState = {
+      OtherController: {},
+    };
+
+    const transformedState = await migrate({
+      meta: { version: 110 },
+      data: oldState,
+    });
+
+    expect(transformedState.data).toEqual(oldState);
+  });
+
+  it('deletes the perDomainNetwork property', async () => {
+    const oldState = {
+      SelectedNetworkController: {
+        perDomainNetwork: true,
+        domains: {},
+      },
+    };
+
+    const expectedState = {
+      SelectedNetworkController: {
+        domains: {},
+      },
+    };
+
+    const transformedState = await migrate({
+      meta: { version: 110 },
+      data: oldState,
+    });
+
+    expect(transformedState.data).toEqual(expectedState);
+  });
+
+
+  it('should capture an exception if SelectedNetworkController.perDomainNetwork is in state but is not a boolean', async () => {
+    const oldData = {
+      other: 'data',
+      SelectedNetworkController: {
+        perDomainNetwork: 123,
+        domains: {}
+      },
+    };
+    const oldStorage = {
+      meta: {
+        version: 93,
+      },
+      data: oldData,
+    };
+
+    await migrate(oldStorage);
+
+    expect(sentryCaptureExceptionMock).toHaveBeenCalledTimes(1);
+    expect(sentryCaptureExceptionMock).toHaveBeenCalledWith(
+      new Error(`state.SelectedNetworkController.perDomainNetwork is type: number`),
+    );
+  });
+
+  it('should capture an exception if SelectedNetworkController is in state but there is no perDomainNetwork property', async () => {
+    const oldData = {
+      other: 'data',
+      SelectedNetworkController: {
+        domains: {}
+      }
+    };
+    const oldStorage = {
+      meta: {
+        version: 93,
+      },
+      data: oldData,
+    };
+
+    await migrate(oldStorage);
+
+    expect(sentryCaptureExceptionMock).toHaveBeenCalledTimes(1);
+    expect(sentryCaptureExceptionMock).toHaveBeenCalledWith(
+      new Error(
+        `state.SelectedNetworkController.perDomainNetwork is missing from SelectedNetworkController state`,
+      ),
+    );
+  });
+});

--- a/app/scripts/migrations/112.ts
+++ b/app/scripts/migrations/112.ts
@@ -1,0 +1,59 @@
+import { cloneDeep } from 'lodash';
+import { hasProperty, isObject } from '@metamask/utils';
+
+type VersionedData = {
+  meta: { version: number };
+  data: Record<string, unknown>;
+};
+
+export const version = 111;
+
+/**
+ * Fully remove perDomainNetwork setting from selectedNetworkController
+ *
+ * @param originalVersionedData - Versioned MetaMask extension state, exactly what we persist to dist.
+ * @param originalVersionedData.meta - State metadata.
+ * @param originalVersionedData.meta.version - The current state version.
+ * @param originalVersionedData.data - The persisted MetaMask state, keyed by controller.
+ * @returns Updated versioned MetaMask extension state.
+ */
+export async function migrate(
+  originalVersionedData: VersionedData,
+): Promise<VersionedData> {
+  const versionedData = cloneDeep(originalVersionedData);
+  versionedData.meta.version = version;
+  transformState(versionedData.data);
+  return versionedData;
+}
+
+function transformState(state: Record<string, any>) {
+  if (!hasProperty(state, 'SelectedNetworkController')) {
+    return state;
+  }
+
+  if (!isObject(state.SelectedNetworkController)) {
+    global.sentry?.captureException?.(
+      new Error(
+        `state.SelectedNetworkController is type: ${typeof state.SelectedNetworkController}`,
+      ),
+    );
+    state.SelectedNetworkController = {};
+  } else if (!hasProperty(state.SelectedNetworkController, 'perDomainNetwork')) {
+    global.sentry?.captureException?.(
+      new Error(
+        `state.SelectedNetworkController.perDomainNetwork is missing from SelectedNetworkController state`,
+      ),
+    );
+  } else if (typeof state.SelectedNetworkController.perDomainNetwork !== 'boolean') {
+    global.sentry?.captureException?.(
+      new Error(
+        `state.SelectedNetworkController.perDomainNetwork is type: ${typeof state
+          .SelectedNetworkController.perDomainNetwork}`,
+      ),
+    );
+  }
+
+  delete state.SelectedNetworkController.perDomainNetwork;
+
+  return state;
+}

--- a/app/scripts/migrations/112.ts
+++ b/app/scripts/migrations/112.ts
@@ -38,13 +38,17 @@ function transformState(state: Record<string, any>) {
       ),
     );
     state.SelectedNetworkController = {};
-  } else if (!hasProperty(state.SelectedNetworkController, 'perDomainNetwork')) {
+  } else if (
+    !hasProperty(state.SelectedNetworkController, 'perDomainNetwork')
+  ) {
     global.sentry?.captureException?.(
       new Error(
         `state.SelectedNetworkController.perDomainNetwork is missing from SelectedNetworkController state`,
       ),
     );
-  } else if (typeof state.SelectedNetworkController.perDomainNetwork !== 'boolean') {
+  } else if (
+    typeof state.SelectedNetworkController.perDomainNetwork !== 'boolean'
+  ) {
     global.sentry?.captureException?.(
       new Error(
         `state.SelectedNetworkController.perDomainNetwork is type: ${typeof state

--- a/app/scripts/migrations/112.ts
+++ b/app/scripts/migrations/112.ts
@@ -6,7 +6,7 @@ type VersionedData = {
   data: Record<string, unknown>;
 };
 
-export const version = 111;
+export const version = 112;
 
 /**
  * Fully remove perDomainNetwork setting from selectedNetworkController

--- a/app/scripts/migrations/index.js
+++ b/app/scripts/migrations/index.js
@@ -122,6 +122,7 @@ const migrations = [
   require('./109'),
   require('./110'),
   require('./111'),
+  require('./112'),
 ];
 
 export default migrations;

--- a/package.json
+++ b/package.json
@@ -290,7 +290,7 @@
     "@metamask/rate-limit-controller": "^3.0.0",
     "@metamask/safe-event-emitter": "^2.0.0",
     "@metamask/scure-bip39": "^2.0.3",
-    "@metamask/selected-network-controller": "^8.0.0",
+    "@metamask/selected-network-controller": "^9.0.0",
     "@metamask/signature-controller": "^12.0.0",
     "@metamask/smart-transactions-controller": "^6.2.2",
     "@metamask/snaps-controllers": "^6.0.1",

--- a/test/e2e/fixture-builder.js
+++ b/test/e2e/fixture-builder.js
@@ -191,7 +191,6 @@ function defaultFixture(inputChainId = CHAIN_IDS.LOCALHOST) {
       },
       SelectedNetworkController: {
         domains: {},
-        perDomainNetwork: false,
       },
       SmartTransactionsController: {
         smartTransactionsState: {
@@ -317,7 +316,6 @@ function onboardingFixture() {
       },
       SelectedNetworkController: {
         domains: {},
-        perDomainNetwork: false,
       },
       SmartTransactionsController: {
         smartTransactionsState: {
@@ -863,13 +861,15 @@ class FixtureBuilder {
   }
 
   withSelectedNetworkControllerPerDomain() {
-    return this.withSelectedNetworkController({
-      domains: {
-        [DAPP_URL]: 'networkConfigurationId',
-        [DAPP_ONE_URL]: '76e9cd59-d8e2-47e7-b369-9c205ccb602c',
-      },
-      perDomainNetwork: true,
-    });
+    return merge(
+      this.withSelectedNetworkController({
+        domains: {
+          [DAPP_URL]: 'networkConfigurationId',
+          [DAPP_ONE_URL]: '76e9cd59-d8e2-47e7-b369-9c205ccb602c',
+        },
+      }),
+      this.withPreferencesControllerUseRequestQueueEnabled(),
+    );
   }
 
   withPreferencesControllerUseRequestQueueEnabled() {

--- a/test/e2e/tests/state-snapshots/errors-after-init-opt-in-background-state.json
+++ b/test/e2e/tests/state-snapshots/errors-after-init-opt-in-background-state.json
@@ -185,8 +185,7 @@
     "selectedAddress": "string"
   },
   "SelectedNetworkController": {
-    "domains": "object",
-    "perDomainNetwork": false
+    "domains": "object"
   },
   "SignatureController": {
     "unapprovedMsgs": "object",

--- a/test/e2e/tests/state-snapshots/errors-after-init-opt-in-ui-state.json
+++ b/test/e2e/tests/state-snapshots/errors-after-init-opt-in-ui-state.json
@@ -163,7 +163,6 @@
     "allNfts": "object",
     "ignoredNfts": "object",
     "domains": "object",
-    "perDomainNetwork": false,
     "logs": "object",
     "methodData": "object",
     "lastFetchedBlockNumbers": "object",

--- a/test/e2e/tests/state-snapshots/errors-before-init-opt-in-background-state.json
+++ b/test/e2e/tests/state-snapshots/errors-before-init-opt-in-background-state.json
@@ -114,7 +114,6 @@
       "useRequestQueue": false
     },
     "SelectedNetworkController": {
-      "perDomainNetwork": false,
       "domains": "object"
     },
     "SmartTransactionsController": {

--- a/test/e2e/tests/state-snapshots/errors-before-init-opt-in-ui-state.json
+++ b/test/e2e/tests/state-snapshots/errors-before-init-opt-in-ui-state.json
@@ -114,7 +114,6 @@
       "useRequestQueue": false
     },
     "SelectedNetworkController": {
-      "perDomainNetwork": false,
       "domains": "object"
     },
     "SmartTransactionsController": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5055,18 +5055,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/selected-network-controller@npm:^8.0.0":
-  version: 8.0.0
-  resolution: "@metamask/selected-network-controller@npm:8.0.0"
+"@metamask/selected-network-controller@npm:^9.0.0":
+  version: 9.0.0
+  resolution: "@metamask/selected-network-controller@npm:9.0.0"
   dependencies:
     "@metamask/base-controller": "npm:^4.1.1"
     "@metamask/json-rpc-engine": "npm:^7.3.2"
     "@metamask/network-controller": "npm:^17.2.0"
+    "@metamask/permission-controller": "npm:^8.0.1"
     "@metamask/swappable-obj-proxy": "npm:^2.2.0"
     "@metamask/utils": "npm:^8.3.0"
   peerDependencies:
     "@metamask/network-controller": ^17.2.0
-  checksum: 20669a83f7bcf6847b15c76200c312b141beedafbe2e6913437c0116693fc42f7d729c4dcd66a90c975589e14a3f51170f7d43a78f1637a442c738e8b92214f4
+    "@metamask/permission-controller": ^8.0.1
+  checksum: 5b784e1bb3623226408cc20c4263766a0fb495dacb052de38bb8a1bfab6786e8ce36938b3faa4a7e53d9f284046d5bff189e3104217cb7ccc8587d51a5f8e293
   languageName: node
   linkType: hard
 
@@ -24858,7 +24860,7 @@ __metadata:
     "@metamask/rate-limit-controller": "npm:^3.0.0"
     "@metamask/safe-event-emitter": "npm:^2.0.0"
     "@metamask/scure-bip39": "npm:^2.0.3"
-    "@metamask/selected-network-controller": "npm:^8.0.0"
+    "@metamask/selected-network-controller": "npm:^9.0.0"
     "@metamask/signature-controller": "npm:^12.0.0"
     "@metamask/smart-transactions-controller": "npm:^6.2.2"
     "@metamask/snaps-controllers": "npm:^6.0.1"


### PR DESCRIPTION
## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/23277?quickstart=1)

This PR is really just clean up for things that have been moved into their respective controllers. The only true removal of code is that we no longer have a feature flag in the selectedNetworkController state, and we use the preferencesController.getUseRequestQueue instead. 

Functionally there should be no difference.

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to settings > experimental > Select networks for each site and toggle this setting *on*
2. go to test dapp and create a permission
3. from the dapp, switch networks
4. switch networks manually
5. disconnect from the dapp
6. make a few api calls from test dapp and ensure they are occuring on the correct network / working as expected
7. Go to settings > experimental > Select networks for each site and toggle this setting *off*
8. repeat above steps and ensure nothing out of the ordinary

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained what problem this PR is solving and how it is solved.
- [x] I've linked related issues
- [x] I've included manual testing steps
- [x] I've included screenshots/recordings if applicable
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [x] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
