### PR TITLE
fix: dynamic UI cherry-picks for RC

### DIFF
--- a/ui/components/app/snaps/snap-ui-renderer/components/types.ts
+++ b/ui/components/app/snaps/snap-ui-renderer/components/types.ts
@@ -2,7 +2,8 @@ import { Component } from '@metamask/snaps-sdk';
 
 export type UIComponentParams<T extends Component> = {
   element: T;
-  elementKeyIndex: number;
+  elementKeyIndex: { value: number };
+  rootKey: string;
   form?: string;
 };
 

--- a/ui/components/app/snaps/snap-ui-renderer/snap-ui-renderer.js
+++ b/ui/components/app/snaps/snap-ui-renderer/snap-ui-renderer.js
@@ -1,7 +1,7 @@
 import React, { memo, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { isComponent } from '@metamask/snaps-sdk';
-
+import { nanoid } from '@reduxjs/toolkit';
 import { useSelector } from 'react-redux';
 
 import { isEqual } from 'lodash';
@@ -51,7 +51,7 @@ const SnapUIRendererComponent = ({
 
   const isValidComponent = content && isComponent(content);
 
-  const elementKeyIndex = 0;
+  const elementKeyIndex = { value: 0 };
 
   // sections are memoized to avoid useless re-renders if one of the parents element re-renders.
   const sections = useMemo(
@@ -59,6 +59,7 @@ const SnapUIRendererComponent = ({
       isValidComponent &&
       mapToTemplate({
         element: content,
+        rootKey: nanoid(),
         elementKeyIndex,
       }),
     [content, isValidComponent, elementKeyIndex],

--- a/ui/components/app/snaps/snap-ui-renderer/snap-ui-renderer.js
+++ b/ui/components/app/snaps/snap-ui-renderer/snap-ui-renderer.js
@@ -74,7 +74,7 @@ const SnapUIRendererComponent = ({
         isCollapsed={isCollapsed}
         onClick={onClick}
         boxProps={boxProps}
-        isLoading={isLoading}
+        isLoading
       />
     );
   }

--- a/ui/components/app/snaps/snap-ui-renderer/utils.ts
+++ b/ui/components/app/snaps/snap-ui-renderer/utils.ts
@@ -3,14 +3,15 @@ import { COMPONENT_MAPPING } from './components';
 
 export type MapToTemplateParams = {
   element: Component;
-  elementKeyIndex: number;
+  elementKeyIndex: { value: number };
+  rootKey: string;
   form?: string;
 };
 
 export const mapToTemplate = (params: MapToTemplateParams) => {
   const { type } = params.element;
-  params.elementKeyIndex += 1;
-  const indexKey = `snap_ui_element_${type}__${params.elementKeyIndex}`;
+  params.elementKeyIndex.value += 1;
+  const indexKey = `${params.rootKey}_snap_ui_element_${type}__${params.elementKeyIndex.value}`;
   // @ts-expect-error This is a problem with the types generated in the snaps repo.
   const mapped = COMPONENT_MAPPING[type](params as any);
   return { ...mapped, key: indexKey };

--- a/ui/pages/confirmations/confirmation/templates/index.js
+++ b/ui/pages/confirmations/confirmation/templates/index.js
@@ -148,18 +148,9 @@ function getAttenuatedDispatch(dispatch) {
  * @param {Function} t - Translation function.
  * @param {Function} dispatch - Redux dispatch function.
  * @param {object} history - The application's history object.
- * @param {Function} setInputState - A function that can be used to record the
- * state of input fields in the templated component.
  * @param {object} data - The data object passed into the template from the confimation page.
  */
-export function getTemplateValues(
-  pendingApproval,
-  t,
-  dispatch,
-  history,
-  setInputState,
-  data,
-) {
+export function getTemplateValues(pendingApproval, t, dispatch, history, data) {
   const fn = APPROVAL_TEMPLATES[pendingApproval.type]?.getValues;
   if (!fn) {
     throw new Error(
@@ -168,14 +159,7 @@ export function getTemplateValues(
   }
 
   const safeActions = getAttenuatedDispatch(dispatch);
-  const values = fn(
-    pendingApproval,
-    t,
-    safeActions,
-    history,
-    setInputState,
-    data,
-  );
+  const values = fn(pendingApproval, t, safeActions, history, data);
   const extraneousKeys = omit(values, ALLOWED_TEMPLATE_KEYS);
   const safeValues = pick(values, ALLOWED_TEMPLATE_KEYS);
   if (extraneousKeys.length > 0) {


### PR DESCRIPTION
## **Description**

Cherry-picks the following commits to the RC:
https://github.com/MetaMask/metamask-extension/commit/d914bbdcfc5fc0e4b7bb3c7ee1edee39eb8783f9
https://github.com/MetaMask/metamask-extension/commit/6abfd32523e611feb836728edd76a453a4a8c639
https://github.com/MetaMask/metamask-extension/commit/cd5a2043589db77bea7d3d405bab41d16e80dd98

They are all minor fixes for the dynamic UI system for Snaps shipping in 11.12.
