### PR TITLE
docs: [E2E] Update readme for e2e tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,23 +109,24 @@ For Jest debugging guide using Node.js, see [docs/tests/jest.md](docs/tests/jest
 
 ### Running E2E Tests
 
-Our e2e test suite ensures the MetaMask extension functions correctly across both Firefox and Chrome browsers. Here's how to get started with e2e testing:
+Our e2e test suite can be run on either Firefox or Chrome. Here's how to get started with e2e testing:
 
 #### Preparing a Test Build
 
 Before running e2e tests, you'll need a test build. You have two options:
 
 1. Use `yarn download-builds:test` to quickly download and unzip test builds for Chrome and Firefox into the `./dist/` folder.
-2. Create a Custom Test Build: For testing against different build types, use `yarn build:test`. This command allows you to generate test builds for various types, including:
-    - `build:test` for main build
-    - `build:test:flask` for flask build
-    - `build:test:mmi` for mmi build
-    - `build:test:mv3` for mv3 build
+2. Create a custom test build: for testing against different build types, use `yarn build:test`. This command allows you to generate test builds for various types, including:
+    - `yarn build:test` for main build
+    - `yarn build:test:flask` for flask build
+    - `yarn build:test:mmi` for mmi build
+    - `yarn build:test:mv3` for mv3 build
 
 #### Running Tests
 Once you have your test build ready, choose the browser for your e2e tests:
 - For Firefox, run `yarn test:e2e:firefox`.
 - For Chrome, run `yarn test:e2e:chrome`.
+
 These scripts support additional options for debugging. Use `--help`to see all available options.
 
 #### Running a single e2e test

--- a/README.md
+++ b/README.md
@@ -109,15 +109,24 @@ For Jest debugging guide using Node.js, see [docs/tests/jest.md](docs/tests/jest
 
 ### Running E2E Tests
 
-Our e2e test suite can be run on either Firefox or Chrome.
+Our e2e test suite ensures the MetaMask extension functions correctly across both Firefox and Chrome browsers. Here's how to get started with e2e testing:
 
-1. **required** `yarn build:test` to create a test build.
-2. run tests, targeting the browser:
+#### Preparing a Test Build
 
-- Firefox e2e tests can be run with `yarn test:e2e:firefox`.
-- Chrome e2e tests can be run with `yarn test:e2e:chrome`. The `chromedriver` package major version must match the major version of your local Chrome installation. If they don't match, update whichever is behind before running Chrome e2e tests.
+Before running e2e tests, you'll need a test build. You have two options:
 
-These test scripts all support additional options, which might be helpful for debugging. Run the script with the flag `--help` to see all options.
+1. Use `yarn download-builds:test` to quickly download and unzip test builds for Chrome and Firefox into the `./dist/` folder.
+2. Create a Custom Test Build: For testing against different build types, use `yarn build:test`. This command allows you to generate test builds for various types, including:
+    - `build:test` for main build
+    - `build:test:flask` for flask build
+    - `build:test:mmi` for mmi build
+    - `build:test:mv3` for mv3 build
+
+#### Running Tests
+Once you have your test build ready, choose the browser for your e2e tests:
+- For Firefox, run `yarn test:e2e:firefox`.
+- For Chrome, run `yarn test:e2e:chrome`.
+These scripts support additional options for debugging. Use `--help`to see all available options.
 
 #### Running a single e2e test
 
@@ -138,7 +147,7 @@ Single e2e tests can be run with `yarn test:e2e:single test/e2e/tests/TEST_NAME.
 ```
 
 For example, to run the `account-details` tests using Chrome, with debug logging and with the browser set to remain open upon failure, you would use:
-`yarn test:e2e:single test/e2e/tests/account-details.spec.js --browser=chrome --debug --leave-running`
+`yarn test:e2e:single test/e2e/tests/account-menu/account-details.spec.js --browser=chrome --debug --leave-running`
 
 #### Running specific builds types e2e test
 

--- a/README.md
+++ b/README.md
@@ -150,6 +150,19 @@ Single e2e tests can be run with `yarn test:e2e:single test/e2e/tests/TEST_NAME.
 For example, to run the `account-details` tests using Chrome, with debug logging and with the browser set to remain open upon failure, you would use:
 `yarn test:e2e:single test/e2e/tests/account-menu/account-details.spec.js --browser=chrome --debug --leave-running`
 
+
+#### Running e2e tests against specific feature flag
+While developing new features, we often use feature flags. As we prepare to make these features generally available (GA), we remove the feature flags. Existing feature flags are listed in the `.metamaskrc.dist` file. To execute e2e tests with a particular feature flag enabled, it's necessary to first generate a test build with that feature flag activated. There are two ways to achieve this:
+
+- To enable a feature flag in your local configuration, you should first ensure you have a `.metamaskrc` file copied from `.metamaskrc.dist`. Then, within your local `.metamaskrc` file, you can set the desired feature flag to true. Following this, a test build with the feature flag enabled can be created by executing `yarn build:test`.
+
+- Alternatively, for enabling a feature flag directly during the test build creation, you can pass the parameter as true via the command line. For instance, activating the MULTICHAIN feature flag can be done by running `MULTICHAIN=1 yarn build:test`. This method allows for quick adjustments to feature flags without altering the .metamaskrc file.
+
+Once you've created a test build with the desired feature flag enabled, proceed to run your tests as usual. Your tests will now run against the version of the extension with the specific feature flag activated. For example:
+`yarn test:e2e:single test/e2e/tests/account-menu/account-details.spec.js --browser=chrome --debug --leave-running`
+
+This approach ensures that your e2e tests accurately reflect the user experience for the upcoming GA features.
+
 #### Running specific builds types e2e test
 
 Different build types have different e2e tests sets. In order to run them look in the `package.json` file. You will find:

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Our e2e test suite can be run on either Firefox or Chrome. Here's how to get sta
 
 #### Preparing a Test Build
 
-Before running e2e tests, you'll need a test build. You have two options:
+Before running e2e tests, ensure you've run `yarn install` to download ependencies. Next, you'll need a test build. You have 3 options:
 
 1. Use `yarn download-builds:test` to quickly download and unzip test builds for Chrome and Firefox into the `./dist/` folder.
 2. Create a custom test build: for testing against different build types, use `yarn build:test`. This command allows you to generate test builds for various types, including:
@@ -121,6 +121,12 @@ Before running e2e tests, you'll need a test build. You have two options:
     - `yarn build:test:flask` for flask build
     - `yarn build:test:mmi` for mmi build
     - `yarn build:test:mv3` for mv3 build
+3. Start a test build with live changes: `yarn start:test` is particularly useful for development. It starts a test build that automatically recompiles application code upon changes. This option is ideal for iterative testing and development. This command also allows you to generate test builds for various types, including:
+    - `yarn start:test` for main build
+    - `yarn start:test:flask` for flask build
+    - `yarn start:test:mv3` for mv3 build
+
+Note: The `yarn start:test` command (which initiates the testDev build type) has LavaMoat disabled for both the build system and the application, offering a streamlined testing experience during development. On the other hand, `yarn build:test` enables LavaMoat for enhanced security in both the build system and application, mirroring production environments more closely.
 
 #### Running Tests
 Once you have your test build ready, choose the browser for your e2e tests:
@@ -156,7 +162,7 @@ While developing new features, we often use feature flags. As we prepare to make
 
 - To enable a feature flag in your local configuration, you should first ensure you have a `.metamaskrc` file copied from `.metamaskrc.dist`. Then, within your local `.metamaskrc` file, you can set the desired feature flag to true. Following this, a test build with the feature flag enabled can be created by executing `yarn build:test`.
 
-- Alternatively, for enabling a feature flag directly during the test build creation, you can pass the parameter as true via the command line. For instance, activating the MULTICHAIN feature flag can be done by running `MULTICHAIN=1 yarn build:test`. This method allows for quick adjustments to feature flags without altering the .metamaskrc file.
+- Alternatively, for enabling a feature flag directly during the test build creation, you can pass the parameter as true via the command line. For instance, activating the MULTICHAIN feature flag can be done by running `MULTICHAIN=1 yarn build:test` or `MULTICHAIN=1 yarn start:test` . This method allows for quick adjustments to feature flags without altering the `.metamaskrc` file.
 
 Once you've created a test build with the desired feature flag enabled, proceed to run your tests as usual. Your tests will now run against the version of the extension with the specific feature flag activated. For example:
 `yarn test:e2e:single test/e2e/tests/account-menu/account-details.spec.js --browser=chrome --debug --leave-running`

--- a/README.md
+++ b/README.md
@@ -113,15 +113,16 @@ Our e2e test suite can be run on either Firefox or Chrome. Here's how to get sta
 
 #### Preparing a Test Build
 
-Before running e2e tests, ensure you've run `yarn install` to download ependencies. Next, you'll need a test build. You have 3 options:
+Before running e2e tests, ensure you've run `yarn install` to download dependencies. Next, you'll need a test build. You have 3 options:
 
-1. Use `yarn download-builds:test` to quickly download and unzip test builds for Chrome and Firefox into the `./dist/` folder.
+1. Use `yarn download-builds:test` to quickly download and unzip test builds for Chrome and Firefox into the `./dist/` folder. This method is fast and convenient for standard testing.
 2. Create a custom test build: for testing against different build types, use `yarn build:test`. This command allows you to generate test builds for various types, including:
     - `yarn build:test` for main build
     - `yarn build:test:flask` for flask build
     - `yarn build:test:mmi` for mmi build
     - `yarn build:test:mv3` for mv3 build
-3. Start a test build with live changes: `yarn start:test` is particularly useful for development. It starts a test build that automatically recompiles application code upon changes. This option is ideal for iterative testing and development. This command also allows you to generate test builds for various types, including:
+3. Start a test build with live changes: `yarn start:test` is particularly useful for development. It starts a test build that automatically recompiles application code upon changes.This option is ideal for iterative testing and development.
+This command also allows you to generate test builds for various types, including:
     - `yarn start:test` for main build
     - `yarn start:test:flask` for flask build
     - `yarn start:test:mv3` for mv3 build


### PR DESCRIPTION
## **Description**

This PR updates the E2E testing instructions in our README to enhance clarity and usability. The updates focus on:

-  Simplified Test Build Preparation: Instructions have been added for easier and quicker preparation of test builds: use `yarn download-builds:test` to download pre-built test builds.
- Guidance on specific types of test builds: Clear instructions are now provided for running tests on different build types, ensuring contributors can accurately test against their desired build types.
- Add instructions to run e2e tests against specific feature flag
-  Remove the manual Chrome driver update process from readme, as our E2E tests now automatically download the latest Chrome driver.
- Updated the test path for an example.

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/2187

## **Manual testing steps**

Try to follow readme to run e2e tests to see if it's clear.


## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained what problem this PR is solving and how it is solved.
- [x] I've linked related issues
- [x] I've included manual testing steps
- [x] I've included screenshots/recordings if applicable
- [x] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [ ] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
