### PR TITLE
feat: bump snaps packages and support `InputChangeEvent` for dynamic UI

### DIFF
--- a/builds.yml
+++ b/builds.yml
@@ -27,7 +27,7 @@ buildTypes:
       - SEGMENT_WRITE_KEY_REF: SEGMENT_PROD_WRITE_KEY
       - ALLOW_LOCAL_SNAPS: false
       - REQUIRE_SNAPS_ALLOWLIST: true
-      - IFRAME_EXECUTION_ENVIRONMENT_URL: https://execution.metamask.io/iframe/5.0.1/index.html
+      - IFRAME_EXECUTION_ENVIRONMENT_URL: https://execution.metamask.io/iframe/5.0.2/index.html
       - ACCOUNT_SNAPS_DIRECTORY_URL: https://snaps.metamask.io/account-management
     # Main build uses the default browser manifest
     manifestOverrides: false
@@ -65,7 +65,7 @@ buildTypes:
       - SEGMENT_FLASK_WRITE_KEY
       - ALLOW_LOCAL_SNAPS: true
       - REQUIRE_SNAPS_ALLOWLIST: false
-      - IFRAME_EXECUTION_ENVIRONMENT_URL: https://execution.metamask.io/iframe/5.0.1/index.html
+      - IFRAME_EXECUTION_ENVIRONMENT_URL: https://execution.metamask.io/iframe/5.0.2/index.html
       - SUPPORT_LINK: https://metamask-flask.zendesk.com/hc
       - SUPPORT_REQUEST_LINK: https://metamask-flask.zendesk.com/hc/en-us/requests/new
       - INFURA_ENV_KEY_REF: INFURA_FLASK_PROJECT_ID
@@ -86,7 +86,7 @@ buildTypes:
       - SEGMENT_FLASK_WRITE_KEY
       - ALLOW_LOCAL_SNAPS: true
       - REQUIRE_SNAPS_ALLOWLIST: false
-      - IFRAME_EXECUTION_ENVIRONMENT_URL: https://execution.metamask.io/iframe/5.0.1/index.html
+      - IFRAME_EXECUTION_ENVIRONMENT_URL: https://execution.metamask.io/iframe/5.0.2/index.html
       - SUPPORT_LINK: https://metamask-flask.zendesk.com/hc
       - SUPPORT_REQUEST_LINK: https://metamask-flask.zendesk.com/hc/en-us/requests/new
       - INFURA_ENV_KEY_REF: INFURA_FLASK_PROJECT_ID
@@ -107,7 +107,7 @@ buildTypes:
       - SEGMENT_WRITE_KEY_REF: SEGMENT_MMI_WRITE_KEY
       - ALLOW_LOCAL_SNAPS: false
       - REQUIRE_SNAPS_ALLOWLIST: true
-      - IFRAME_EXECUTION_ENVIRONMENT_URL: https://execution.metamask.io/iframe/5.0.1/index.html
+      - IFRAME_EXECUTION_ENVIRONMENT_URL: https://execution.metamask.io/iframe/5.0.2/index.html
       - MMI_CONFIGURATION_SERVICE_URL: https://configuration.metamask-institutional.io/v2/configuration/default
       - SUPPORT_LINK: https://mmi-support.zendesk.com/hc/en-us
       - SUPPORT_REQUEST_LINK: https://mmi-support.zendesk.com/hc/en-us/requests/new

--- a/lavamoat/browserify/beta/policy.json
+++ b/lavamoat/browserify/beta/policy.json
@@ -202,8 +202,8 @@
     "@ethereumjs/tx>ethereum-cryptography>@scure/bip32": {
       "packages": {
         "@ethereumjs/tx>ethereum-cryptography>@noble/curves": true,
-        "@metamask/utils>@noble/hashes": true,
-        "@metamask/utils>@scure/base": true
+        "@metamask/utils>@scure/base": true,
+        "@noble/hashes": true
       }
     },
     "@ethersproject/abi": {
@@ -743,7 +743,7 @@
         "TextEncoder": true
       },
       "packages": {
-        "@metamask/utils>@noble/hashes": true,
+        "@noble/hashes": true,
         "browserify>buffer": true,
         "nock>debug": true,
         "semver": true,
@@ -1855,7 +1855,7 @@
         "@metamask/snaps-sdk>@metamask/key-tree": true,
         "@metamask/snaps-utils": true,
         "@metamask/utils": true,
-        "@metamask/utils>@noble/hashes": true,
+        "@noble/hashes": true,
         "superstruct": true
       }
     },
@@ -1875,8 +1875,8 @@
         "@metamask/scure-bip39": true,
         "@metamask/snaps-sdk>@metamask/key-tree>@metamask/utils": true,
         "@metamask/snaps-sdk>@metamask/key-tree>@noble/ed25519": true,
-        "@metamask/utils>@noble/hashes": true,
         "@metamask/utils>@scure/base": true,
+        "@noble/hashes": true,
         "eth-lattice-keyring>@noble/secp256k1": true
       }
     },
@@ -1886,7 +1886,7 @@
         "TextEncoder": true
       },
       "packages": {
-        "@metamask/utils>@noble/hashes": true,
+        "@noble/hashes": true,
         "browserify>buffer": true,
         "nock>debug": true,
         "semver": true,
@@ -1935,8 +1935,8 @@
         "@metamask/snaps-utils>rfdc": true,
         "@metamask/snaps-utils>validate-npm-package-name": true,
         "@metamask/utils": true,
-        "@metamask/utils>@noble/hashes": true,
         "@metamask/utils>@scure/base": true,
+        "@noble/hashes": true,
         "chalk": true,
         "semver": true,
         "superstruct": true
@@ -2061,19 +2061,13 @@
         "TextEncoder": true
       },
       "packages": {
-        "@metamask/utils>@noble/hashes": true,
         "@metamask/utils>@scure/base": true,
         "@metamask/utils>pony-cause": true,
+        "@noble/hashes": true,
         "browserify>buffer": true,
         "nock>debug": true,
         "semver": true,
         "superstruct": true
-      }
-    },
-    "@metamask/utils>@noble/hashes": {
-      "globals": {
-        "TextEncoder": true,
-        "crypto": true
       }
     },
     "@metamask/utils>@scure/base": {
@@ -2122,6 +2116,12 @@
     "@ngraveio/bc-ur>jsbi": {
       "globals": {
         "define": true
+      }
+    },
+    "@noble/hashes": {
+      "globals": {
+        "TextEncoder": true,
+        "crypto": true
       }
     },
     "@popperjs/core": {

--- a/lavamoat/browserify/beta/policy.json
+++ b/lavamoat/browserify/beta/policy.json
@@ -1937,7 +1937,6 @@
         "@metamask/utils": true,
         "@metamask/utils>@noble/hashes": true,
         "@metamask/utils>@scure/base": true,
-        "browserify>buffer": true,
         "chalk": true,
         "semver": true,
         "superstruct": true

--- a/lavamoat/browserify/desktop/policy.json
+++ b/lavamoat/browserify/desktop/policy.json
@@ -2201,7 +2201,6 @@
         "@metamask/utils": true,
         "@metamask/utils>@noble/hashes": true,
         "@metamask/utils>@scure/base": true,
-        "browserify>buffer": true,
         "chalk": true,
         "semver": true,
         "superstruct": true

--- a/lavamoat/browserify/desktop/policy.json
+++ b/lavamoat/browserify/desktop/policy.json
@@ -202,8 +202,8 @@
     "@ethereumjs/tx>ethereum-cryptography>@scure/bip32": {
       "packages": {
         "@ethereumjs/tx>ethereum-cryptography>@noble/curves": true,
-        "@metamask/utils>@noble/hashes": true,
-        "@metamask/utils>@scure/base": true
+        "@metamask/utils>@scure/base": true,
+        "@noble/hashes": true
       }
     },
     "@ethersproject/abi": {
@@ -743,7 +743,7 @@
         "TextEncoder": true
       },
       "packages": {
-        "@metamask/utils>@noble/hashes": true,
+        "@noble/hashes": true,
         "browserify>buffer": true,
         "nock>debug": true,
         "semver": true,
@@ -2119,7 +2119,7 @@
         "@metamask/snaps-sdk>@metamask/key-tree": true,
         "@metamask/snaps-utils": true,
         "@metamask/utils": true,
-        "@metamask/utils>@noble/hashes": true,
+        "@noble/hashes": true,
         "superstruct": true
       }
     },
@@ -2139,8 +2139,8 @@
         "@metamask/scure-bip39": true,
         "@metamask/snaps-sdk>@metamask/key-tree>@metamask/utils": true,
         "@metamask/snaps-sdk>@metamask/key-tree>@noble/ed25519": true,
-        "@metamask/utils>@noble/hashes": true,
         "@metamask/utils>@scure/base": true,
+        "@noble/hashes": true,
         "eth-lattice-keyring>@noble/secp256k1": true
       }
     },
@@ -2150,7 +2150,7 @@
         "TextEncoder": true
       },
       "packages": {
-        "@metamask/utils>@noble/hashes": true,
+        "@noble/hashes": true,
         "browserify>buffer": true,
         "nock>debug": true,
         "semver": true,
@@ -2199,8 +2199,8 @@
         "@metamask/snaps-utils>rfdc": true,
         "@metamask/snaps-utils>validate-npm-package-name": true,
         "@metamask/utils": true,
-        "@metamask/utils>@noble/hashes": true,
         "@metamask/utils>@scure/base": true,
+        "@noble/hashes": true,
         "chalk": true,
         "semver": true,
         "superstruct": true
@@ -2210,7 +2210,7 @@
       "packages": {
         "@metamask/snaps-utils>@metamask/snaps-registry>@noble/curves": true,
         "@metamask/utils": true,
-        "@metamask/utils>@noble/hashes": true,
+        "@noble/hashes": true,
         "superstruct": true
       }
     },
@@ -2219,7 +2219,7 @@
         "TextEncoder": true
       },
       "packages": {
-        "@metamask/utils>@noble/hashes": true
+        "@noble/hashes": true
       }
     },
     "@metamask/snaps-utils>cron-parser": {
@@ -2341,19 +2341,13 @@
         "TextEncoder": true
       },
       "packages": {
-        "@metamask/utils>@noble/hashes": true,
         "@metamask/utils>@scure/base": true,
         "@metamask/utils>pony-cause": true,
+        "@noble/hashes": true,
         "browserify>buffer": true,
         "nock>debug": true,
         "semver": true,
         "superstruct": true
-      }
-    },
-    "@metamask/utils>@noble/hashes": {
-      "globals": {
-        "TextEncoder": true,
-        "crypto": true
       }
     },
     "@metamask/utils>@scure/base": {
@@ -2402,6 +2396,12 @@
     "@ngraveio/bc-ur>jsbi": {
       "globals": {
         "define": true
+      }
+    },
+    "@noble/hashes": {
+      "globals": {
+        "TextEncoder": true,
+        "crypto": true
       }
     },
     "@popperjs/core": {

--- a/lavamoat/browserify/flask/policy.json
+++ b/lavamoat/browserify/flask/policy.json
@@ -202,8 +202,8 @@
     "@ethereumjs/tx>ethereum-cryptography>@scure/bip32": {
       "packages": {
         "@ethereumjs/tx>ethereum-cryptography>@noble/curves": true,
-        "@metamask/utils>@noble/hashes": true,
-        "@metamask/utils>@scure/base": true
+        "@metamask/utils>@scure/base": true,
+        "@noble/hashes": true
       }
     },
     "@ethersproject/abi": {
@@ -743,7 +743,7 @@
         "TextEncoder": true
       },
       "packages": {
-        "@metamask/utils>@noble/hashes": true,
+        "@noble/hashes": true,
         "browserify>buffer": true,
         "nock>debug": true,
         "semver": true,
@@ -2153,7 +2153,7 @@
         "@metamask/snaps-sdk>@metamask/key-tree": true,
         "@metamask/snaps-utils": true,
         "@metamask/utils": true,
-        "@metamask/utils>@noble/hashes": true,
+        "@noble/hashes": true,
         "superstruct": true
       }
     },
@@ -2173,8 +2173,8 @@
         "@metamask/scure-bip39": true,
         "@metamask/snaps-sdk>@metamask/key-tree>@metamask/utils": true,
         "@metamask/snaps-sdk>@metamask/key-tree>@noble/ed25519": true,
-        "@metamask/utils>@noble/hashes": true,
         "@metamask/utils>@scure/base": true,
+        "@noble/hashes": true,
         "eth-lattice-keyring>@noble/secp256k1": true
       }
     },
@@ -2184,7 +2184,7 @@
         "TextEncoder": true
       },
       "packages": {
-        "@metamask/utils>@noble/hashes": true,
+        "@noble/hashes": true,
         "browserify>buffer": true,
         "nock>debug": true,
         "semver": true,
@@ -2233,8 +2233,8 @@
         "@metamask/snaps-utils>rfdc": true,
         "@metamask/snaps-utils>validate-npm-package-name": true,
         "@metamask/utils": true,
-        "@metamask/utils>@noble/hashes": true,
         "@metamask/utils>@scure/base": true,
+        "@noble/hashes": true,
         "chalk": true,
         "semver": true,
         "superstruct": true
@@ -2244,7 +2244,7 @@
       "packages": {
         "@metamask/snaps-utils>@metamask/snaps-registry>@noble/curves": true,
         "@metamask/utils": true,
-        "@metamask/utils>@noble/hashes": true,
+        "@noble/hashes": true,
         "superstruct": true
       }
     },
@@ -2253,7 +2253,7 @@
         "TextEncoder": true
       },
       "packages": {
-        "@metamask/utils>@noble/hashes": true
+        "@noble/hashes": true
       }
     },
     "@metamask/snaps-utils>cron-parser": {
@@ -2375,19 +2375,13 @@
         "TextEncoder": true
       },
       "packages": {
-        "@metamask/utils>@noble/hashes": true,
         "@metamask/utils>@scure/base": true,
         "@metamask/utils>pony-cause": true,
+        "@noble/hashes": true,
         "browserify>buffer": true,
         "nock>debug": true,
         "semver": true,
         "superstruct": true
-      }
-    },
-    "@metamask/utils>@noble/hashes": {
-      "globals": {
-        "TextEncoder": true,
-        "crypto": true
       }
     },
     "@metamask/utils>@scure/base": {
@@ -2436,6 +2430,12 @@
     "@ngraveio/bc-ur>jsbi": {
       "globals": {
         "define": true
+      }
+    },
+    "@noble/hashes": {
+      "globals": {
+        "TextEncoder": true,
+        "crypto": true
       }
     },
     "@popperjs/core": {

--- a/lavamoat/browserify/flask/policy.json
+++ b/lavamoat/browserify/flask/policy.json
@@ -2235,7 +2235,6 @@
         "@metamask/utils": true,
         "@metamask/utils>@noble/hashes": true,
         "@metamask/utils>@scure/base": true,
-        "browserify>buffer": true,
         "chalk": true,
         "semver": true,
         "superstruct": true

--- a/lavamoat/browserify/main/policy.json
+++ b/lavamoat/browserify/main/policy.json
@@ -202,8 +202,8 @@
     "@ethereumjs/tx>ethereum-cryptography>@scure/bip32": {
       "packages": {
         "@ethereumjs/tx>ethereum-cryptography>@noble/curves": true,
-        "@metamask/utils>@noble/hashes": true,
-        "@metamask/utils>@scure/base": true
+        "@metamask/utils>@scure/base": true,
+        "@noble/hashes": true
       }
     },
     "@ethersproject/abi": {
@@ -743,7 +743,7 @@
         "TextEncoder": true
       },
       "packages": {
-        "@metamask/utils>@noble/hashes": true,
+        "@noble/hashes": true,
         "browserify>buffer": true,
         "nock>debug": true,
         "semver": true,
@@ -2076,7 +2076,7 @@
         "@metamask/snaps-sdk>@metamask/key-tree": true,
         "@metamask/snaps-utils": true,
         "@metamask/utils": true,
-        "@metamask/utils>@noble/hashes": true,
+        "@noble/hashes": true,
         "superstruct": true
       }
     },
@@ -2096,8 +2096,8 @@
         "@metamask/scure-bip39": true,
         "@metamask/snaps-sdk>@metamask/key-tree>@metamask/utils": true,
         "@metamask/snaps-sdk>@metamask/key-tree>@noble/ed25519": true,
-        "@metamask/utils>@noble/hashes": true,
         "@metamask/utils>@scure/base": true,
+        "@noble/hashes": true,
         "eth-lattice-keyring>@noble/secp256k1": true
       }
     },
@@ -2107,7 +2107,7 @@
         "TextEncoder": true
       },
       "packages": {
-        "@metamask/utils>@noble/hashes": true,
+        "@noble/hashes": true,
         "browserify>buffer": true,
         "nock>debug": true,
         "semver": true,
@@ -2156,8 +2156,8 @@
         "@metamask/snaps-utils>rfdc": true,
         "@metamask/snaps-utils>validate-npm-package-name": true,
         "@metamask/utils": true,
-        "@metamask/utils>@noble/hashes": true,
         "@metamask/utils>@scure/base": true,
+        "@noble/hashes": true,
         "chalk": true,
         "semver": true,
         "superstruct": true
@@ -2167,7 +2167,7 @@
       "packages": {
         "@metamask/snaps-utils>@metamask/snaps-registry>@noble/curves": true,
         "@metamask/utils": true,
-        "@metamask/utils>@noble/hashes": true,
+        "@noble/hashes": true,
         "superstruct": true
       }
     },
@@ -2176,7 +2176,7 @@
         "TextEncoder": true
       },
       "packages": {
-        "@metamask/utils>@noble/hashes": true
+        "@noble/hashes": true
       }
     },
     "@metamask/snaps-utils>cron-parser": {
@@ -2298,19 +2298,13 @@
         "TextEncoder": true
       },
       "packages": {
-        "@metamask/utils>@noble/hashes": true,
         "@metamask/utils>@scure/base": true,
         "@metamask/utils>pony-cause": true,
+        "@noble/hashes": true,
         "browserify>buffer": true,
         "nock>debug": true,
         "semver": true,
         "superstruct": true
-      }
-    },
-    "@metamask/utils>@noble/hashes": {
-      "globals": {
-        "TextEncoder": true,
-        "crypto": true
       }
     },
     "@metamask/utils>@scure/base": {
@@ -2359,6 +2353,12 @@
     "@ngraveio/bc-ur>jsbi": {
       "globals": {
         "define": true
+      }
+    },
+    "@noble/hashes": {
+      "globals": {
+        "TextEncoder": true,
+        "crypto": true
       }
     },
     "@popperjs/core": {

--- a/lavamoat/browserify/main/policy.json
+++ b/lavamoat/browserify/main/policy.json
@@ -2158,7 +2158,6 @@
         "@metamask/utils": true,
         "@metamask/utils>@noble/hashes": true,
         "@metamask/utils>@scure/base": true,
-        "browserify>buffer": true,
         "chalk": true,
         "semver": true,
         "superstruct": true

--- a/lavamoat/browserify/mmi/policy.json
+++ b/lavamoat/browserify/mmi/policy.json
@@ -202,8 +202,8 @@
     "@ethereumjs/tx>ethereum-cryptography>@scure/bip32": {
       "packages": {
         "@ethereumjs/tx>ethereum-cryptography>@noble/curves": true,
-        "@metamask/utils>@noble/hashes": true,
-        "@metamask/utils>@scure/base": true
+        "@metamask/utils>@scure/base": true,
+        "@noble/hashes": true
       }
     },
     "@ethersproject/abi": {
@@ -875,7 +875,7 @@
         "TextEncoder": true
       },
       "packages": {
-        "@metamask/utils>@noble/hashes": true,
+        "@noble/hashes": true,
         "browserify>buffer": true,
         "nock>debug": true,
         "semver": true,
@@ -2174,7 +2174,7 @@
         "@metamask/snaps-sdk>@metamask/key-tree": true,
         "@metamask/snaps-utils": true,
         "@metamask/utils": true,
-        "@metamask/utils>@noble/hashes": true,
+        "@noble/hashes": true,
         "superstruct": true
       }
     },
@@ -2194,8 +2194,8 @@
         "@metamask/scure-bip39": true,
         "@metamask/snaps-sdk>@metamask/key-tree>@metamask/utils": true,
         "@metamask/snaps-sdk>@metamask/key-tree>@noble/ed25519": true,
-        "@metamask/utils>@noble/hashes": true,
         "@metamask/utils>@scure/base": true,
+        "@noble/hashes": true,
         "eth-lattice-keyring>@noble/secp256k1": true
       }
     },
@@ -2205,7 +2205,7 @@
         "TextEncoder": true
       },
       "packages": {
-        "@metamask/utils>@noble/hashes": true,
+        "@noble/hashes": true,
         "browserify>buffer": true,
         "nock>debug": true,
         "semver": true,
@@ -2254,8 +2254,8 @@
         "@metamask/snaps-utils>rfdc": true,
         "@metamask/snaps-utils>validate-npm-package-name": true,
         "@metamask/utils": true,
-        "@metamask/utils>@noble/hashes": true,
         "@metamask/utils>@scure/base": true,
+        "@noble/hashes": true,
         "chalk": true,
         "semver": true,
         "superstruct": true
@@ -2265,7 +2265,7 @@
       "packages": {
         "@metamask/snaps-utils>@metamask/snaps-registry>@noble/curves": true,
         "@metamask/utils": true,
-        "@metamask/utils>@noble/hashes": true,
+        "@noble/hashes": true,
         "superstruct": true
       }
     },
@@ -2274,7 +2274,7 @@
         "TextEncoder": true
       },
       "packages": {
-        "@metamask/utils>@noble/hashes": true
+        "@noble/hashes": true
       }
     },
     "@metamask/snaps-utils>cron-parser": {
@@ -2396,19 +2396,13 @@
         "TextEncoder": true
       },
       "packages": {
-        "@metamask/utils>@noble/hashes": true,
         "@metamask/utils>@scure/base": true,
         "@metamask/utils>pony-cause": true,
+        "@noble/hashes": true,
         "browserify>buffer": true,
         "nock>debug": true,
         "semver": true,
         "superstruct": true
-      }
-    },
-    "@metamask/utils>@noble/hashes": {
-      "globals": {
-        "TextEncoder": true,
-        "crypto": true
       }
     },
     "@metamask/utils>@scure/base": {
@@ -2457,6 +2451,12 @@
     "@ngraveio/bc-ur>jsbi": {
       "globals": {
         "define": true
+      }
+    },
+    "@noble/hashes": {
+      "globals": {
+        "TextEncoder": true,
+        "crypto": true
       }
     },
     "@popperjs/core": {

--- a/lavamoat/browserify/mmi/policy.json
+++ b/lavamoat/browserify/mmi/policy.json
@@ -2256,7 +2256,6 @@
         "@metamask/utils": true,
         "@metamask/utils>@noble/hashes": true,
         "@metamask/utils>@scure/base": true,
-        "browserify>buffer": true,
         "chalk": true,
         "semver": true,
         "superstruct": true

--- a/lavamoat/build-system/policy.json
+++ b/lavamoat/build-system/policy.json
@@ -1295,24 +1295,24 @@
         "TextEncoder": true
       },
       "packages": {
-        "@metamask/utils>@noble/hashes": true,
         "@metamask/utils>@scure/base": true,
         "@metamask/utils>pony-cause": true,
+        "@noble/hashes": true,
         "nock>debug": true,
         "semver": true,
         "superstruct": true
-      }
-    },
-    "@metamask/utils>@noble/hashes": {
-      "globals": {
-        "TextEncoder": true,
-        "crypto": true
       }
     },
     "@metamask/utils>@scure/base": {
       "globals": {
         "TextDecoder": true,
         "TextEncoder": true
+      }
+    },
+    "@noble/hashes": {
+      "globals": {
+        "TextEncoder": true,
+        "crypto": true
       }
     },
     "@sentry/cli>which": {

--- a/package.json
+++ b/package.json
@@ -216,7 +216,7 @@
     "nonce-tracker@npm:^3.0.0": "patch:nonce-tracker@npm%3A3.0.0#~/.yarn/patches/nonce-tracker-npm-3.0.0-c5e9a93f9d.patch",
     "@trezor/connect-web": "9.0.11",
     "lavamoat-core@npm:^15.1.1": "patch:lavamoat-core@npm%3A15.1.1#~/.yarn/patches/lavamoat-core-npm-15.1.1-51fbe39988.patch",
-    "@metamask/snaps-sdk": "^3.0.1"
+    "@metamask/snaps-sdk": "^3.1.0"
   },
   "dependencies": {
     "@babel/runtime": "^7.23.2",
@@ -293,11 +293,11 @@
     "@metamask/selected-network-controller": "^8.0.0",
     "@metamask/signature-controller": "^12.0.0",
     "@metamask/smart-transactions-controller": "^6.2.2",
-    "@metamask/snaps-controllers": "^6.0.1",
-    "@metamask/snaps-execution-environments": "^5.0.1",
+    "@metamask/snaps-controllers": "^6.0.2",
+    "@metamask/snaps-execution-environments": "^5.0.2",
     "@metamask/snaps-rpc-methods": "^7.0.1",
-    "@metamask/snaps-sdk": "^3.0.1",
-    "@metamask/snaps-utils": "^7.0.1",
+    "@metamask/snaps-sdk": "^3.1.0",
+    "@metamask/snaps-utils": "^7.0.2",
     "@metamask/transaction-controller": "^23.1.0",
     "@metamask/user-operation-controller": "^4.0.0",
     "@metamask/utils": "^8.2.1",

--- a/package.json
+++ b/package.json
@@ -302,6 +302,7 @@
     "@metamask/user-operation-controller": "^4.0.0",
     "@metamask/utils": "^8.2.1",
     "@ngraveio/bc-ur": "^1.1.6",
+    "@noble/hashes": "^1.3.3",
     "@popperjs/core": "^2.4.0",
     "@reduxjs/toolkit": "^1.6.2",
     "@segment/loosely-validate-event": "^2.0.0",

--- a/ui/components/app/snaps/snap-ui-button/snap-ui-button.tsx
+++ b/ui/components/app/snaps/snap-ui-button/snap-ui-button.tsx
@@ -17,7 +17,7 @@ export const SnapUIButton: FunctionComponent<
       event.preventDefault();
     }
 
-    handleEvent(UserInputEventType.ButtonClickEvent, name);
+    handleEvent({ event: UserInputEventType.ButtonClickEvent, name });
   };
 
   return (

--- a/ui/components/app/snaps/snap-ui-form/snap-ui-form.tsx
+++ b/ui/components/app/snaps/snap-ui-form/snap-ui-form.tsx
@@ -5,7 +5,6 @@ import { Box } from '../../../component-library';
 import {
   Display,
   FlexDirection,
-  TextColor,
 } from '../../../../helpers/constants/design-system';
 
 export type SnapUIFormProps = {

--- a/ui/components/app/snaps/snap-ui-form/snap-ui-form.tsx
+++ b/ui/components/app/snaps/snap-ui-form/snap-ui-form.tsx
@@ -1,6 +1,12 @@
 import React, { FormEvent, FunctionComponent } from 'react';
 import { UserInputEventType } from '@metamask/snaps-sdk';
 import { useSnapInterfaceContext } from '../../../../contexts/snaps';
+import { Box } from '../../../component-library';
+import {
+  Display,
+  FlexDirection,
+  TextColor,
+} from '../../../../helpers/constants/design-system';
 
 export type SnapUIFormProps = {
   name: string;
@@ -18,8 +24,15 @@ export const SnapUIForm: FunctionComponent<SnapUIFormProps> = ({
   };
 
   return (
-    <form className="snap-ui-renderer__form" onSubmit={handleSubmit} id={name}>
+    <Box
+      as="form"
+      className="snap-ui-renderer__form"
+      onSubmit={handleSubmit}
+      id={name}
+      display={Display.Flex}
+      flexDirection={FlexDirection.Column}
+    >
       {children}
-    </form>
+    </Box>
   );
 };

--- a/ui/components/app/snaps/snap-ui-form/snap-ui-form.tsx
+++ b/ui/components/app/snaps/snap-ui-form/snap-ui-form.tsx
@@ -19,7 +19,7 @@ export const SnapUIForm: FunctionComponent<SnapUIFormProps> = ({
 
   const handleSubmit = (event: FormEvent<HTMLElement>) => {
     event.preventDefault();
-    handleEvent(UserInputEventType.FormSubmitEvent, name);
+    handleEvent({ event: UserInputEventType.FormSubmitEvent, name });
   };
 
   return (

--- a/ui/components/app/snaps/snap-ui-input/snap-ui-input.tsx
+++ b/ui/components/app/snaps/snap-ui-input/snap-ui-input.tsx
@@ -31,6 +31,7 @@ export const SnapUIInput: FunctionComponent<
     setValue(event.target.value);
     handleInputChange(name, event.target.value ?? null, form);
   };
+
   return (
     <FormTextField
       className="snap-ui-renderer__input"

--- a/ui/components/app/snaps/snap-ui-renderer/components/input.ts
+++ b/ui/components/app/snaps/snap-ui-renderer/components/input.ts
@@ -13,5 +13,7 @@ export const input: UIComponentFactory<Input> = ({ element, form }) => ({
     },
     name: element.name,
     form,
+    error: element.error !== undefined,
+    helpText: element.error,
   },
 });

--- a/ui/components/app/snaps/snap-ui-renderer/components/types.ts
+++ b/ui/components/app/snaps/snap-ui-renderer/components/types.ts
@@ -1,9 +1,8 @@
 import { Component } from '@metamask/snaps-sdk';
 
 export type UIComponentParams<T extends Component> = {
+  map: Record<string, number>;
   element: T;
-  elementKeyIndex: { value: number };
-  rootKey: string;
   form?: string;
 };
 

--- a/ui/components/app/snaps/snap-ui-renderer/snap-ui-renderer.js
+++ b/ui/components/app/snaps/snap-ui-renderer/snap-ui-renderer.js
@@ -1,7 +1,6 @@
 import React, { memo, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { isComponent } from '@metamask/snaps-sdk';
-import { nanoid } from '@reduxjs/toolkit';
 import { useSelector } from 'react-redux';
 
 import { isEqual } from 'lodash';
@@ -51,18 +50,15 @@ const SnapUIRendererComponent = ({
 
   const isValidComponent = content && isComponent(content);
 
-  const elementKeyIndex = { value: 0 };
-
   // sections are memoized to avoid useless re-renders if one of the parents element re-renders.
   const sections = useMemo(
     () =>
       isValidComponent &&
       mapToTemplate({
+        map: {},
         element: content,
-        rootKey: nanoid(),
-        elementKeyIndex,
       }),
-    [content, isValidComponent, elementKeyIndex],
+    [content, isValidComponent],
   );
 
   if (isLoading || !content) {

--- a/ui/components/app/snaps/snap-ui-renderer/utils.ts
+++ b/ui/components/app/snaps/snap-ui-renderer/utils.ts
@@ -1,17 +1,44 @@
 import { Component } from '@metamask/snaps-sdk';
+import { memoize } from 'lodash';
+import { sha256 } from '@noble/hashes/sha256';
+import { bytesToHex, remove0x } from '@metamask/utils';
 import { COMPONENT_MAPPING } from './components';
 
 export type MapToTemplateParams = {
+  map: Record<string, number>;
   element: Component;
-  elementKeyIndex: { value: number };
-  rootKey: string;
   form?: string;
 };
 
+const generateHash = memoize((component: Component) => {
+  const { type, name } = component;
+  const value =
+    typeof component.value === 'string'
+      ? component.value.slice(0, 5000)
+      : component.value;
+  return remove0x(
+    bytesToHex(
+      sha256(
+        JSON.stringify({
+          type,
+          name: name ?? null,
+          value,
+        }),
+      ),
+    ),
+  );
+});
+
+function generateKey(map: Record<string, number>, component: Component) {
+  const hash = generateHash(component);
+  const count = (map[hash] ?? 0) + 1;
+  map[hash] = count;
+  return `${hash}_${count}`;
+}
+
 export const mapToTemplate = (params: MapToTemplateParams) => {
   const { type } = params.element;
-  params.elementKeyIndex.value += 1;
-  const indexKey = `${params.rootKey}_snap_ui_element_${type}__${params.elementKeyIndex.value}`;
+  const indexKey = generateKey(params.map, params.element);
   // @ts-expect-error This seems to be compatibility issue between superstruct and this repo.
   const mapped = COMPONENT_MAPPING[type](params as any);
   return { ...mapped, key: indexKey };

--- a/ui/components/app/snaps/snap-ui-renderer/utils.ts
+++ b/ui/components/app/snaps/snap-ui-renderer/utils.ts
@@ -10,6 +10,14 @@ export type MapToTemplateParams = {
   form?: string;
 };
 
+/**
+ * A memoized function for generating a hash that represents a Snap UI component.
+ *
+ * This can be used to generate React keys for components.
+ *
+ * @param component - The component.
+ * @returns A hash as a string.
+ */
 const generateHash = memoize((component: Component) => {
   const { type, name } = component;
   const value =
@@ -29,6 +37,15 @@ const generateHash = memoize((component: Component) => {
   );
 });
 
+/**
+ * Generate a React key to be used for a Snap UI component.
+ *
+ * This function also handles collisions between duplicate keys.
+ *
+ * @param map - A map of previously used keys to be used for collision handling.
+ * @param component - The component.
+ * @returns A key.
+ */
 function generateKey(map: Record<string, number>, component: Component) {
   const hash = generateHash(component);
   const count = (map[hash] ?? 0) + 1;

--- a/ui/contexts/snaps/snap-interface.tsx
+++ b/ui/contexts/snaps/snap-interface.tsx
@@ -16,7 +16,12 @@ import { getMemoizedInterface } from '../../selectors';
 import { handleSnapRequest, updateInterfaceState } from '../../store/actions';
 import { mergeValue } from './utils';
 
-export type HandleEvent = (event: UserInputEventType, name?: string) => void;
+export type HandleEvent = (
+  event: UserInputEventType,
+  name?: string,
+  value?: string,
+  flush?: boolean,
+) => void;
 
 export type HandleInputChange = (
   name: string,
@@ -72,8 +77,8 @@ export const SnapInterfaceContextProvider: FunctionComponent<
 
   // The submittion of user input events is debounced to avoid crashing the snap if
   // there's too much events sent at the same time
-  const snapRequestDebounced: HandleEvent = debounce(
-    (event, name) =>
+  const snapRequestDebounced = debounce(
+    (event, name, value) =>
       handleSnapRequest({
         snapId,
         origin: '',
@@ -85,7 +90,7 @@ export const SnapInterfaceContextProvider: FunctionComponent<
             event: {
               type: event,
               name,
-              value: internalState.current[name],
+              value,
             },
             id: interfaceId,
           },
@@ -105,12 +110,30 @@ export const SnapInterfaceContextProvider: FunctionComponent<
    * Handle the submission of an user input event to the Snap.
    *
    * @param event - The event object.
-   * @param name - The name of the component emmitting the event.
+   * @param name - The name of the component emitting the event.
+   * @param value - The value of the component emitting the event.
+   * @param flush - Optional flag to indicate whether the debounce should be flushed.
    */
-  const handleEvent: HandleEvent = (event, name) => {
+  const handleEvent: HandleEvent = (
+    event,
+    name,
+    value = internalState.current[name],
+    flush = false,
+  ) => {
+    // We always flush the debounced request for updating the state.
     updateStateDebounced.flush();
-    snapRequestDebounced(event, name);
+    snapRequestDebounced(event, name, value);
+
+    if (flush) {
+      snapRequestDebounced.flush();
+    }
   };
+
+  const handleInputChangeDebounced = debounce(
+    (name, value) =>
+      handleEvent(UserInputEventType.InputChangeEvent, name, value, true),
+    400,
+  );
 
   /**
    * Handle the value change of an input.
@@ -125,6 +148,7 @@ export const SnapInterfaceContextProvider: FunctionComponent<
 
     internalState.current = state;
     updateStateDebounced(state);
+    handleInputChangeDebounced(name, value);
   };
 
   /**

--- a/ui/contexts/snaps/snap-interface.tsx
+++ b/ui/contexts/snaps/snap-interface.tsx
@@ -16,12 +16,12 @@ import { getMemoizedInterface } from '../../selectors';
 import { handleSnapRequest, updateInterfaceState } from '../../store/actions';
 import { mergeValue } from './utils';
 
-export type HandleEvent = (
-  event: UserInputEventType,
-  name?: string,
-  value?: string,
-  flush?: boolean,
-) => void;
+export type HandleEvent = (args: {
+  event: UserInputEventType;
+  name?: string;
+  value?: string;
+  flush?: boolean;
+}) => void;
 
 export type HandleInputChange = (
   name: string,
@@ -122,17 +122,18 @@ export const SnapInterfaceContextProvider: FunctionComponent<
   /**
    * Handle the submission of an user input event to the Snap.
    *
-   * @param event - The event object.
-   * @param name - The name of the component emitting the event.
-   * @param value - The value of the component emitting the event.
-   * @param flush - Optional flag to indicate whether the debounce should be flushed.
+   * @param options - An options bag.
+   * @param options.event - The event type.
+   * @param options.name - The name of the component emitting the event.
+   * @param options.value - The value of the component emitting the event.
+   * @param options.flush - Optional flag to indicate whether the debounce should be flushed.
    */
-  const handleEvent: HandleEvent = (
+  const handleEvent: HandleEvent = ({
     event,
     name,
     value = internalState.current[name],
     flush = false,
-  ) => {
+  }) => {
     // We always flush the debounced request for updating the state.
     updateStateDebounced.flush();
     const fn = THROTTLED_EVENTS.includes(event)
@@ -149,7 +150,12 @@ export const SnapInterfaceContextProvider: FunctionComponent<
 
   const handleInputChangeDebounced = debounce(
     (name, value) =>
-      handleEvent(UserInputEventType.InputChangeEvent, name, value, true),
+      handleEvent({
+        event: UserInputEventType.InputChangeEvent,
+        name,
+        value,
+        flush: true,
+      }),
     300,
   );
 

--- a/ui/contexts/snaps/snap-interface.tsx
+++ b/ui/contexts/snaps/snap-interface.tsx
@@ -3,7 +3,7 @@ import {
   InterfaceState,
   UserInputEventType,
 } from '@metamask/snaps-sdk';
-import { debounce } from 'lodash';
+import { debounce, throttle } from 'lodash';
 import React, {
   FunctionComponent,
   createContext,
@@ -45,6 +45,14 @@ export type SnapInterfaceContextProviderProps = {
   snapId: string;
 };
 
+// We want button clicks to be instant and therefore use throttling
+// to protect the Snap
+// Any event not in this array will be debounced instead of throttled
+const THROTTLED_EVENTS = [
+  UserInputEventType.ButtonClickEvent,
+  UserInputEventType.FormSubmitEvent,
+];
+
 /**
  * The Snap interface context provider that handles all the interface state operations.
  *
@@ -75,29 +83,34 @@ export const SnapInterfaceContextProvider: FunctionComponent<
     internalState.current = initialState;
   }, [initialState]);
 
-  // The submittion of user input events is debounced to avoid crashing the snap if
-  // there's too much events sent at the same time
-  const snapRequestDebounced = debounce(
-    (event, name, value) =>
-      handleSnapRequest({
-        snapId,
-        origin: '',
-        handler: 'onUserInput',
-        request: {
-          jsonrpc: '2.0',
-          method: ' ',
-          params: {
-            event: {
-              type: event,
-              name,
-              value,
-            },
-            id: interfaceId,
+  const rawSnapRequestFunction = (
+    event: UserInputEventType,
+    name?: string,
+    value?: string,
+  ) =>
+    handleSnapRequest({
+      snapId,
+      origin: '',
+      handler: 'onUserInput',
+      request: {
+        jsonrpc: '2.0',
+        method: ' ',
+        params: {
+          event: {
+            type: event,
+            // TODO: Allow null in the types and simplify this
+            ...(name !== undefined && name !== null ? { name } : {}),
+            ...(value !== undefined && value !== null ? { value } : {}),
           },
+          id: interfaceId,
         },
-      }),
-    200,
-  );
+      },
+    });
+
+  // The submittion of user input events is debounced or throttled to avoid crashing the snap if
+  // there's too much events sent at the same time
+  const snapRequestDebounced = debounce(rawSnapRequestFunction, 200);
+  const snapRequestThrottled = throttle(rawSnapRequestFunction, 200);
 
   // The update of the state is debounced to avoid crashes due to too much
   // updates in a short amount of time.
@@ -122,17 +135,22 @@ export const SnapInterfaceContextProvider: FunctionComponent<
   ) => {
     // We always flush the debounced request for updating the state.
     updateStateDebounced.flush();
-    snapRequestDebounced(event, name, value);
+    const fn = THROTTLED_EVENTS.includes(event)
+      ? snapRequestThrottled
+      : snapRequestDebounced;
+    fn(event, name, value);
 
+    // Certain events have their own debounce or throttling logic
+    // and therefore may want to flush
     if (flush) {
-      snapRequestDebounced.flush();
+      fn.flush();
     }
   };
 
   const handleInputChangeDebounced = debounce(
     (name, value) =>
       handleEvent(UserInputEventType.InputChangeEvent, name, value, true),
-    400,
+    300,
   );
 
   /**
@@ -148,7 +166,7 @@ export const SnapInterfaceContextProvider: FunctionComponent<
 
     internalState.current = state;
     updateStateDebounced(state);
-    handleInputChangeDebounced(name, value);
+    handleInputChangeDebounced(name, value ?? '');
   };
 
   /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -3894,15 +3894,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/approval-controller@npm:^5.1.1, @metamask/approval-controller@npm:^5.1.2":
-  version: 5.1.2
-  resolution: "@metamask/approval-controller@npm:5.1.2"
+"@metamask/approval-controller@npm:^5.1.1, @metamask/approval-controller@npm:^5.1.2, @metamask/approval-controller@npm:^5.1.3":
+  version: 5.1.3
+  resolution: "@metamask/approval-controller@npm:5.1.3"
   dependencies:
     "@metamask/base-controller": "npm:^4.1.1"
-    "@metamask/rpc-errors": "npm:^6.1.0"
+    "@metamask/rpc-errors": "npm:^6.2.1"
     "@metamask/utils": "npm:^8.3.0"
     nanoid: "npm:^3.1.31"
-  checksum: 827ff7b40f15cd8c20378fb008d664cbd319667cbcb9440166b30889bd154c61367078aa8646c66de1d0f02e6c72aa279c197e6431804fd97226299bbfaeb4ba
+  checksum: 6d13cae814ee2a7301a6c17d071fef9c7bcdf9a3499c090178052a659be7d9d7bc93b609ec0f84a139ce873be0aff62e0b235b50d2f327c354d0d4e4fa19cea1
   languageName: node
   linkType: hard
 
@@ -5188,11 +5188,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/snaps-controllers@npm:^6.0.1":
-  version: 6.0.1
-  resolution: "@metamask/snaps-controllers@npm:6.0.1"
+"@metamask/snaps-controllers@npm:^6.0.2":
+  version: 6.0.2
+  resolution: "@metamask/snaps-controllers@npm:6.0.2"
   dependencies:
-    "@metamask/approval-controller": "npm:^5.1.2"
+    "@metamask/approval-controller": "npm:^5.1.3"
     "@metamask/base-controller": "npm:^4.1.0"
     "@metamask/json-rpc-engine": "npm:^7.3.2"
     "@metamask/object-multiplex": "npm:^2.0.0"
@@ -5202,8 +5202,8 @@ __metadata:
     "@metamask/rpc-errors": "npm:^6.2.1"
     "@metamask/snaps-registry": "npm:^3.0.0"
     "@metamask/snaps-rpc-methods": "npm:^7.0.1"
-    "@metamask/snaps-sdk": "npm:^3.0.1"
-    "@metamask/snaps-utils": "npm:^7.0.1"
+    "@metamask/snaps-sdk": "npm:^3.1.0"
+    "@metamask/snaps-utils": "npm:^7.0.2"
     "@metamask/utils": "npm:^8.3.0"
     "@xstate/fsm": "npm:^2.0.0"
     browserify-zlib: "npm:^0.2.0"
@@ -5216,30 +5216,30 @@ __metadata:
     readable-web-to-node-stream: "npm:^3.0.2"
     tar-stream: "npm:^3.1.7"
   peerDependencies:
-    "@metamask/snaps-execution-environments": ^5.0.1
+    "@metamask/snaps-execution-environments": ^5.0.2
   peerDependenciesMeta:
     "@metamask/snaps-execution-environments":
       optional: true
-  checksum: c9ef312edb7af3d062afe57a3db1593f3001caf3a30d219d3a1cedee9c2a652d64e5cb6bf02b5f89fb648a0385c44025d16b3d7b420e4209be947f7b99edea06
+  checksum: d2ae84d8eb2643a86c1cf261683b2e38dc380433c2a227ffbe3216a1e215009b1da54254cd0a2f8fef850086a609e4d5253558fe71416efce487b4c8c93443c1
   languageName: node
   linkType: hard
 
-"@metamask/snaps-execution-environments@npm:^5.0.1":
-  version: 5.0.1
-  resolution: "@metamask/snaps-execution-environments@npm:5.0.1"
+"@metamask/snaps-execution-environments@npm:^5.0.2":
+  version: 5.0.2
+  resolution: "@metamask/snaps-execution-environments@npm:5.0.2"
   dependencies:
     "@metamask/json-rpc-engine": "npm:^7.3.2"
     "@metamask/object-multiplex": "npm:^2.0.0"
     "@metamask/post-message-stream": "npm:^8.0.0"
     "@metamask/providers": "npm:^14.0.2"
     "@metamask/rpc-errors": "npm:^6.2.1"
-    "@metamask/snaps-sdk": "npm:^3.0.1"
-    "@metamask/snaps-utils": "npm:^7.0.1"
+    "@metamask/snaps-sdk": "npm:^3.1.0"
+    "@metamask/snaps-utils": "npm:^7.0.2"
     "@metamask/utils": "npm:^8.3.0"
     nanoid: "npm:^3.1.31"
     readable-stream: "npm:^3.6.2"
     superstruct: "npm:^1.0.3"
-  checksum: 3f26984fc62d0f510368e36ec0c81513641edcd0fbb434ba1ba8602c9969b60de4318e65cad99b75780aca11d80226cf50a039a9a881d0af211bde40ac5f0bd3
+  checksum: bd27af18f9258326d88954fa96f51ca0bdbe12570aaf1671a7275fef3456aefb419be3f7ffb8ebc371318bb5c2a867b6f412414c1fff1d6089471926750c0c51
   languageName: node
   linkType: hard
 
@@ -5303,9 +5303,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/snaps-sdk@npm:^3.0.1":
-  version: 3.0.1
-  resolution: "@metamask/snaps-sdk@npm:3.0.1"
+"@metamask/snaps-sdk@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "@metamask/snaps-sdk@npm:3.1.0"
   dependencies:
     "@metamask/key-tree": "npm:^9.0.0"
     "@metamask/providers": "npm:^14.0.2"
@@ -5313,7 +5313,7 @@ __metadata:
     "@metamask/utils": "npm:^8.3.0"
     fast-xml-parser: "npm:^4.3.4"
     superstruct: "npm:^1.0.3"
-  checksum: 3317d04549d359b9b2ba775f3b347b8071a6c2268917303673739e8425d007814ef8e08faba98fa58ca44bbdd6ba4293093de6ec5815998acc629cfd0bcb31ba
+  checksum: 4ec1a9f7183302e85f41f522ce42d3084da0805ee86b3cfecefed2f3782e831a4e569e884c698449ed17772b616b7bd83a4cc45d6426ac488b6c1e5ba1f34c3c
   languageName: node
   linkType: hard
 
@@ -5347,9 +5347,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/snaps-utils@npm:^7.0.1":
-  version: 7.0.1
-  resolution: "@metamask/snaps-utils@npm:7.0.1"
+"@metamask/snaps-utils@npm:^7.0.1, @metamask/snaps-utils@npm:^7.0.2":
+  version: 7.0.2
+  resolution: "@metamask/snaps-utils@npm:7.0.2"
   dependencies:
     "@babel/core": "npm:^7.23.2"
     "@babel/types": "npm:^7.23.0"
@@ -5359,7 +5359,7 @@ __metadata:
     "@metamask/rpc-errors": "npm:^6.2.1"
     "@metamask/slip44": "npm:^3.1.0"
     "@metamask/snaps-registry": "npm:^3.0.0"
-    "@metamask/snaps-sdk": "npm:^3.0.1"
+    "@metamask/snaps-sdk": "npm:^3.1.0"
     "@metamask/utils": "npm:^8.3.0"
     "@noble/hashes": "npm:^1.3.1"
     "@scure/base": "npm:^1.1.1"
@@ -5372,7 +5372,7 @@ __metadata:
     ses: "npm:^1.1.0"
     superstruct: "npm:^1.0.3"
     validate-npm-package-name: "npm:^5.0.0"
-  checksum: 84d1897a032b321f326ccacd16376e39433d5d44b07ccd6f5b525833984ef82c7ea55ce6bc8239639b6eeb55c4c5470c22a06fd2d2e7ce05fb98cc1bd617b856
+  checksum: f8e98db5f8314aceb23059aac2b697ed512d1a87ba434fac7cdac1a152bff4a38a217e703c680b75b26309189d1f2145e10cc217afd7c2f4578c67f1a8e986dd
   languageName: node
   linkType: hard
 
@@ -24861,11 +24861,11 @@ __metadata:
     "@metamask/selected-network-controller": "npm:^8.0.0"
     "@metamask/signature-controller": "npm:^12.0.0"
     "@metamask/smart-transactions-controller": "npm:^6.2.2"
-    "@metamask/snaps-controllers": "npm:^6.0.1"
-    "@metamask/snaps-execution-environments": "npm:^5.0.1"
+    "@metamask/snaps-controllers": "npm:^6.0.2"
+    "@metamask/snaps-execution-environments": "npm:^5.0.2"
     "@metamask/snaps-rpc-methods": "npm:^7.0.1"
-    "@metamask/snaps-sdk": "npm:^3.0.1"
-    "@metamask/snaps-utils": "npm:^7.0.1"
+    "@metamask/snaps-sdk": "npm:^3.1.0"
+    "@metamask/snaps-utils": "npm:^7.0.2"
     "@metamask/test-bundler": "npm:^1.0.0"
     "@metamask/test-dapp": "npm:^8.2.0"
     "@metamask/transaction-controller": "npm:^23.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5600,7 +5600,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@noble/hashes@npm:1.3.3, @noble/hashes@npm:^1.0.0, @noble/hashes@npm:^1.2.0, @noble/hashes@npm:^1.3.1, @noble/hashes@npm:^1.3.2, @noble/hashes@npm:~1.3.0, @noble/hashes@npm:~1.3.1":
+"@noble/hashes@npm:1.3.3, @noble/hashes@npm:^1.0.0, @noble/hashes@npm:^1.2.0, @noble/hashes@npm:^1.3.1, @noble/hashes@npm:^1.3.2, @noble/hashes@npm:^1.3.3, @noble/hashes@npm:~1.3.0, @noble/hashes@npm:~1.3.1":
   version: 1.3.3
   resolution: "@noble/hashes@npm:1.3.3"
   checksum: 1025ddde4d24630e95c0818e63d2d54ee131b980fe113312d17ed7468bc18f54486ac86c907685759f8a7e13c2f9b9e83ec7b67d1cc20836f36b5e4a65bb102d
@@ -24872,6 +24872,7 @@ __metadata:
     "@metamask/user-operation-controller": "npm:^4.0.0"
     "@metamask/utils": "npm:^8.2.1"
     "@ngraveio/bc-ur": "npm:^1.1.6"
+    "@noble/hashes": "npm:^1.3.3"
     "@playwright/test": "npm:^1.39.0"
     "@popperjs/core": "npm:^2.4.0"
     "@reduxjs/toolkit": "npm:^1.6.2"


### PR DESCRIPTION
## **Description**

Bump snaps packages to latest, primarily to support `InputChangeEvent`. Also includes changes to the dynamic UI functionality to enable `InputChangeEvent`.

`InputChangeEvent` will fire 300ms after the last change to any input form input and trigger the `onUserInput` export in the Snap. This PR also changes the way keys are generated for each section of the Snap UI. The previous logic for generating keys was replaced with a hashing scheme that includes more values from the component in order to be more resistant to duplicates without constantly re-rendering.

Summary of changes in the snaps deps:
- Improve timeout handling when the execution environment fails to load
- Bump LavaMoat
- Add `InputChangeEvent`
- Add `error` prop to `input` component