### PR TITLE
fix: asset list showing fiat symbol instead of native

### DIFF
--- a/ui/components/app/asset-list/asset-list.js
+++ b/ui/components/app/asset-list/asset-list.js
@@ -200,12 +200,9 @@ const AssetList = ({ onClickAsset }) => {
             : null
         }
         tokenSymbol={
-          showPrimaryCurrency(
-            isOriginalNativeSymbol,
-            useNativeCurrencyAsPrimaryCurrency,
-          )
+          useNativeCurrencyAsPrimaryCurrency
             ? primaryCurrencyProperties.suffix
-            : null
+            : secondaryCurrencyProperties.suffix
         }
         secondary={
           showFiat &&


### PR DESCRIPTION
Cherry pick https://github.com/MetaMask/metamask-extension/pull/22760