### PR TITLE
Fix: migrations/088: handle null chainId

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ executors:
     resource_class: small
     environment:
       FONTCONFIG_PATH: /etc/fonts
-      NODE_OPTIONS: --max_old_space_size=1536
+      NODE_OPTIONS: --max_old_space_size=2048
   node-browsers-medium:
     docker:
       - image: cimg/node:20.11-browsers

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ executors:
     resource_class: small
     environment:
       FONTCONFIG_PATH: /etc/fonts
-      NODE_OPTIONS: --max_old_space_size=1024
+      NODE_OPTIONS: --max_old_space_size=1536
   node-browsers-medium:
     docker:
       - image: cimg/node:20.11-browsers

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -377,7 +377,7 @@ jobs:
           command: .circleci/scripts/release-create-release-pr.sh
 
   prep-deps:
-    executor: node-browsers-small
+    executor: node-browsers-medium
     steps:
       - run: *shallow-git-clone
       - run:

--- a/app/scripts/migrations/088.ts
+++ b/app/scripts/migrations/088.ts
@@ -38,6 +38,17 @@ export async function migrate(
   return versionedData;
 }
 
+function chainIdShouldBeDeleted(chainId: string): boolean {
+  try {
+    toHex(chainId);
+  } catch (e) {
+    // The actual migration will fail, but warn instead of deleting the `chainId` key here
+    log.warn(`migration/088: toHex(chainId) failed: "${chainId}"`);
+  }
+
+  return chainId === 'undefined' || chainId === 'null';
+}
+
 function migrateData(state: Record<string, unknown>): void {
   if (hasProperty(state, 'NftController') && isObject(state.NftController)) {
     const nftControllerState = state.NftController;
@@ -59,7 +70,7 @@ function migrateData(state: Record<string, unknown>): void {
 
           if (isObject(nftContractsByChainId)) {
             for (const chainId of Object.keys(nftContractsByChainId)) {
-              if (chainId === 'undefined' || chainId === undefined) {
+              if (chainIdShouldBeDeleted(chainId)) {
                 delete nftContractsByChainId[chainId];
               }
             }
@@ -96,7 +107,7 @@ function migrateData(state: Record<string, unknown>): void {
 
           if (isObject(nftsByChainId)) {
             for (const chainId of Object.keys(nftsByChainId)) {
-              if (chainId === 'undefined' || chainId === undefined) {
+              if (chainIdShouldBeDeleted(chainId)) {
                 delete nftsByChainId[chainId];
               }
             }
@@ -142,7 +153,7 @@ function migrateData(state: Record<string, unknown>): void {
       for (const chainId of Object.keys(
         tokenListControllerState.tokensChainsCache,
       )) {
-        if (chainId === 'undefined' || chainId === undefined) {
+        if (chainIdShouldBeDeleted(chainId)) {
           delete tokenListControllerState.tokensChainsCache[chainId];
         }
       }
@@ -183,7 +194,7 @@ function migrateData(state: Record<string, unknown>): void {
       const { allTokens } = tokensControllerState;
 
       for (const chainId of Object.keys(allTokens)) {
-        if (chainId === 'undefined' || chainId === undefined) {
+        if (chainIdShouldBeDeleted(chainId)) {
           delete allTokens[chainId];
         }
       }
@@ -212,7 +223,7 @@ function migrateData(state: Record<string, unknown>): void {
       const { allIgnoredTokens } = tokensControllerState;
 
       for (const chainId of Object.keys(allIgnoredTokens)) {
-        if (chainId === 'undefined' || chainId === undefined) {
+        if (chainIdShouldBeDeleted(chainId)) {
           delete allIgnoredTokens[chainId];
         }
       }
@@ -241,7 +252,7 @@ function migrateData(state: Record<string, unknown>): void {
       const { allDetectedTokens } = tokensControllerState;
 
       for (const chainId of Object.keys(allDetectedTokens)) {
-        if (chainId === 'undefined' || chainId === undefined) {
+        if (chainIdShouldBeDeleted(chainId)) {
           delete allDetectedTokens[chainId];
         }
       }


### PR DESCRIPTION
## **Description**

My Metamask was stuck in the "loader spinning" state and the log showed that migration 088 failed with "invalid character".

I traced the problem down to the `state.TokensController.allTokens` object having a `null` key which migration 088 was trying to convert to a hex string and use as a `chainId`.

This patch updates `migrations/088.ts` to handle `null` in addition to `undefined` where the code expects a `chainId`.

## **Related issues**

This is very similar to PR #20345 and issue #20297.

## **Manual testing steps**

1. Copy "Local Extension Settings" directory from Metamask to my own dev copy
2. Started Metamask, all migrations now pass

## **Screenshots/Recordings**

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained what problem this PR is solving and how it is solved.
- [x] I've linked related issues
- [x] I've included manual testing steps
- [ ] I've included screenshots/recordings if applicable
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [x] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [x] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
