### PR TITLE
test: Wait for connection dialog to close

### DIFF
--- a/test/e2e/tests/request-queuing/switch-network.spec.js
+++ b/test/e2e/tests/request-queuing/switch-network.spec.js
@@ -60,6 +60,9 @@ describe('Request Queuing Switch Network on Dapp Send Tx while on different netw
           css: '[data-testid="page-container-footer-next"]',
         });
 
+        // Wait for Connecting notification to close.
+        await driver.waitUntilXWindowHandles(2);
+
         await driver.switchToWindowWithTitle(
           WINDOW_TITLES.ExtensionInFullScreenView,
         );


### PR DESCRIPTION
## **Description**

There are still instances of flaky `request-queuing/switch-network.spec.js` tests which I believe has to do with the connect notification still persisting while proceeding to run in slower browser such as firefox. https://app.circleci.com/pipelines/github/MetaMask/metamask-extension/72312/workflows/4c6f47fa-6e67-4228-b54c-e139288b4409/jobs/2447165/tests#failed-test-0

This handles the case by waiting for the window handles to be be 2, the extension and the dapp, before moving on.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/23354?quickstart=1)

## **Related issues**

Fixes: #23326 properly

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained what problem this PR is solving and how it is solved.
- [x] I've linked related issues
- [ ] I've included manual testing steps
- [ ] I've included screenshots/recordings if applicable
- [x] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [x] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [x] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
