### PR TITLE
Add third party details for offchain signatures

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -961,6 +961,12 @@
   "contractNFT": {
     "message": "NFT contract"
   },
+  "assetOrFulfilmentContract": {
+    "message": "Asset/Fulfilment contract"
+  },
+  "thirdPartyBeneficiary": {
+    "message": "Beneficiary"
+  },
   "contractRequestingAccess": {
     "message": "Third party requesting access"
   },

--- a/ui/pages/confirmations/components/signature-request/signature-request.js
+++ b/ui/pages/confirmations/components/signature-request/signature-request.js
@@ -354,6 +354,7 @@ const SignatureRequest = ({
             rpcPrefs={rpcPrefs}
             onClose={() => setShowContractDetails(false)}
             isContractRequestingSignature
+            fullSignatureRequest={data}
           />
         )}
         {unapprovedMessagesCount > 1 ? (


### PR DESCRIPTION
## **Description**

This enhancement will add third party details to the "View third-party details" popup for offchain signatures, like we have for onchain signatures (such as `setApprovalForAll`). 

For example: when a permit signature is requesting spending on a users ERC20 balance, MetaMask UI shows only the ERC20 token contract in the third-party details popup when it should show the spender as well. Arguably, the third party in these types of messages is the `spender` and not the `verifyingContract`.

We already have this breakdown of contract and spender for onchain signatures, such as `setApprovalForAll()` - see screenshot below
<img width="361" alt="Screenshot 2024-03-06 at 20 32 40" src="https://github.com/MetaMask/metamask-extension/assets/2313704/eaea72fc-eb41-4ca6-aed4-a8c40ecac69e">

This change will modify the popup to extract relevant keys from structured sign typed data standards (such as permit or 0x orders) and show the user the third-party beneficiary.

<img width="361" alt="Screenshot 2024-03-06 at 20 34 00" src="https://github.com/MetaMask/metamask-extension/assets/2313704/a5bef9d1-760a-4afd-867f-da79a8582b3e">
<img width="361" alt="Screenshot 2024-03-06 at 20 34 13" src="https://github.com/MetaMask/metamask-extension/assets/2313704/b490d5cc-a55a-4c91-9ea2-7cd4711ca380">

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page https://metamask.github.io/test-dapp/
2. Test various signatures that give some sort of third-party spending approval

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="361" alt="Screenshot 2024-03-06 at 20 38 11" src="https://github.com/MetaMask/metamask-extension/assets/2313704/c1dfc875-c27f-4d67-826c-d138c5f15207">
<img width="361" alt="Screenshot 2024-03-06 at 20 38 23" src="https://github.com/MetaMask/metamask-extension/assets/2313704/0014a141-190e-4395-ae9e-586e37c1d7ee">


### **After**

<img width="361" alt="Screenshot 2024-03-06 at 20 34 00" src="https://github.com/MetaMask/metamask-extension/assets/2313704/a5bef9d1-760a-4afd-867f-da79a8582b3e">
<img width="361" alt="Screenshot 2024-03-06 at 20 34 13" src="https://github.com/MetaMask/metamask-extension/assets/2313704/b490d5cc-a55a-4c91-9ea2-7cd4711ca380">

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've clearly explained what problem this PR is solving and how it is solved.
- [ ] I've linked related issues
- [ ] I've included manual testing steps
- [ ] I've included screenshots/recordings if applicable
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [ ] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
