### PR TITLE
feat: UX: Multichain: Close other popups when new popup is opened

### DIFF
--- a/app/scripts/controllers/app-state.js
+++ b/app/scripts/controllers/app-state.js
@@ -53,6 +53,7 @@ export default class AppStateController extends EventEmitter {
       showAccountBanner: true,
       trezorModel: null,
       currentPopupId: undefined,
+      currentExtensionPopupId: undefined,
       // This key is only used for checking if the user had set advancedGasFee
       // prior to Migration 92.3 where we split out the setting to support
       // multiple networks.
@@ -521,6 +522,10 @@ export default class AppStateController extends EventEmitter {
     this.store.updateState({
       currentPopupId,
     });
+  }
+
+  setCurrentExtensionPopupId(currentExtensionPopupId) {
+    this.store.updateState({ currentExtensionPopupId });
   }
 
   /**

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -3106,6 +3106,8 @@ export default class MetamaskController extends EventEmitter {
       // AppStateController
       setLastActiveTime:
         appStateController.setLastActiveTime.bind(appStateController),
+      setCurrentExtensionPopupId:
+        appStateController.setCurrentExtensionPopupId.bind(appStateController),
       setDefaultHomeActiveTabName:
         appStateController.setDefaultHomeActiveTabName.bind(appStateController),
       setConnectedStatusPopoverHasBeenShown:

--- a/ui/index.js
+++ b/ui/index.js
@@ -21,6 +21,7 @@ import {
   getSelectedInternalAccount,
   getUnapprovedTransactions,
   getNetworkToAutomaticallySwitchTo,
+  getUseRequestQueue,
 } from './selectors';
 import { ALERT_STATE } from './ducks/alerts';
 import {
@@ -209,6 +210,18 @@ async function startApp(metamaskState, backgroundConnection, opts) {
       store.dispatch(actions.setFeatureFlag(key, value));
     },
   };
+
+  // Register this window as the current popup
+  // and set in background state
+  if (
+    process.env.MULTICHAIN &&
+    getUseRequestQueue(state) &&
+    getEnvironmentType() === ENVIRONMENT_TYPE_POPUP
+  ) {
+    const thisPopupId = Date.now();
+    global.metamask.id = thisPopupId;
+    actions.setCurrentExtensionPopupId(thisPopupId);
+  }
 
   // start app
   render(<Root store={store} />, opts.container);

--- a/ui/pages/routes/routes.component.js
+++ b/ui/pages/routes/routes.component.js
@@ -197,6 +197,8 @@ export default class Routes extends Component {
     neverShowSwitchedNetworkMessage: PropTypes.bool.isRequired,
     automaticallySwitchNetwork: PropTypes.func.isRequired,
     unapprovedTransactions: PropTypes.number.isRequired,
+    currentExtensionPopupId: PropTypes.number,
+    useRequestQueue: PropTypes.bool,
     ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
     isShowKeyringSnapRemovalResultModal: PropTypes.bool.isRequired,
     hideShowKeyringSnapRemovalResultModal: PropTypes.func.isRequired,
@@ -253,7 +255,10 @@ export default class Routes extends Component {
       activeTabOrigin,
       unapprovedTransactions,
       isUnlocked,
+      useRequestQueue,
+      currentExtensionPopupId,
     } = this.props;
+
     if (theme !== prevProps.theme) {
       this.setTheme();
     }
@@ -276,6 +281,18 @@ export default class Routes extends Component {
         networkToAutomaticallySwitchTo,
         activeTabOrigin,
       );
+    }
+
+    // Terminate the popup when another popup is opened
+    // if the user is using RPC queueing
+    if (
+      useRequestQueue &&
+      process.env.MULTICHAIN &&
+      currentExtensionPopupId !== undefined &&
+      global.metamask.id !== undefined &&
+      currentExtensionPopupId !== global.metamask.id
+    ) {
+      window.close();
     }
   }
 

--- a/ui/pages/routes/routes.container.js
+++ b/ui/pages/routes/routes.container.js
@@ -23,6 +23,7 @@ import {
   getNeverShowSwitchedNetworkMessage,
   getNetworkToAutomaticallySwitchTo,
   getNumberOfAllUnapprovedTransactions,
+  getUseRequestQueue,
 } from '../../selectors';
 import {
   lockMetamask,
@@ -128,6 +129,9 @@ function mapStateToProps(state) {
     networkToAutomaticallySwitchTo,
     unapprovedTransactions: getNumberOfAllUnapprovedTransactions(state),
     neverShowSwitchedNetworkMessage: getNeverShowSwitchedNetworkMessage(state),
+    currentExtensionPopupId: state.metamask.currentExtensionPopupId,
+    useRequestQueue: getUseRequestQueue(state),
+
     ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
     isShowKeyringSnapRemovalResultModal:
       state.appState.showKeyringRemovalSnapModal,

--- a/ui/store/actions.ts
+++ b/ui/store/actions.ts
@@ -4944,6 +4944,16 @@ export function updateInterfaceState(
 }
 
 /**
+ * Update the currentPopupid generated when the user opened the popup
+ *
+ * @param id - The Snap interface ID.
+ * @returns Promise Resolved on successfully submitted background request.
+ */
+export async function setCurrentExtensionPopupId(id: number) {
+  await submitRequestToBackground<void>('setCurrentExtensionPopupId', [id]);
+}
+
+/**
  * Delete the Snap interface from state.
  *
  * @param id - The Snap interface ID.


### PR DESCRIPTION
## **Description**

This PR closes previously opened MetaMask popups (those opened by clicking the fox icon in the extensions bar) when a new popup is opened.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/23379?quickstart=1)

## **Related issues**

Fixes:  https://github.com/MetaMask/MetaMask-planning/issues/1779

## **Manual testing steps**

1. `MULTICHAIN=1 yarn start`
2. Turn on the RPC queuing toggle in Experiment settings
3.  Open one browser window and click the MetaMask fox logo, wait for the popup to open
4.  Open another browser window, click the MetaMask fox logo
5. See the first window's popup close.

## **Screenshots/Recordings**

### **Before**

N/A

### **After**


https://github.com/MetaMask/metamask-extension/assets/46655/2d6f953e-f4a8-492d-8e81-f94d59a76ffc




## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've clearly explained what problem this PR is solving and how it is solved.
- [ ] I've linked related issues
- [ ] I've included manual testing steps
- [ ] I've included screenshots/recordings if applicable
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [ ] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
