### PR TITLE
fix: bump snaps-registry to fix validation issues

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -5246,14 +5246,14 @@ __metadata:
   linkType: hard
 
 "@metamask/snaps-registry@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "@metamask/snaps-registry@npm:3.0.0"
+  version: 3.0.1
+  resolution: "@metamask/snaps-registry@npm:3.0.1"
   dependencies:
-    "@metamask/utils": "npm:^8.1.0"
+    "@metamask/utils": "npm:^8.3.0"
     "@noble/curves": "npm:^1.2.0"
     "@noble/hashes": "npm:^1.3.2"
     superstruct: "npm:^1.0.3"
-  checksum: 3c6066807f214cf2cad1dc084b928dcd5b2c98cb09e3e38111ef56ed199f643abb2f035d1a57b7452de197643f6d0b4749541d05764723eb0c6a6f27ae314b06
+  checksum: fa981560e13b4ecb077123d7123d7afe9327c06a7f29b71ca760a5e87138738b9e8075f3b9a983231ba5f5df70537eea08e3d2496b7275d649f9337f5a263154
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## **Description**

Bumps `snaps-registry` to the latest version. This package contains the validation logic for the Snaps registry. This validation logic was flawed for signatures of certain lengths and caused a production outage.

For more context: https://github.com/MetaMask/snaps-registry/pull/471

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/23380?quickstart=1)