### PR TITLE
fix: enable Snaps home pages in stable

### DIFF
--- a/shared/constants/permissions.test.js
+++ b/shared/constants/permissions.test.js
@@ -15,7 +15,6 @@ describe('EndowmentPermissions', () => {
     expect(Object.keys(EndowmentPermissions).sort()).toStrictEqual(
       [
         'endowment:name-lookup',
-        'endowment:page-home',
         'endowment:signature-insight',
         ...Object.keys(endowmentPermissionBuilders).filter(
           (targetName) =>

--- a/shared/constants/snaps/permissions.ts
+++ b/shared/constants/snaps/permissions.ts
@@ -6,8 +6,8 @@ export const EndowmentPermissions = Object.freeze({
   'endowment:rpc': 'endowment:rpc',
   'endowment:webassembly': 'endowment:webassembly',
   'endowment:lifecycle-hooks': 'endowment:lifecycle-hooks',
-  ///: BEGIN:ONLY_INCLUDE_IF(build-flask)
   'endowment:page-home': 'endowment:page-home',
+  ///: BEGIN:ONLY_INCLUDE_IF(build-flask)
   'endowment:signature-insight': 'endowment:signature-insight',
   'endowment:name-lookup': 'endowment:name-lookup',
   ///: END:ONLY_INCLUDE_IF
@@ -24,8 +24,6 @@ export const ExcludedSnapPermissions = Object.freeze({
 
 export const ExcludedSnapEndowments = Object.freeze({
   ///: BEGIN:ONLY_INCLUDE_IF(build-main)
-  'endowment:page-home':
-    'This endowment is experimental and therefore not available.',
   'endowment:name-lookup':
     'This endowment is experimental and therefore not available.',
   'endowment:signature-insight':

--- a/test/e2e/run-all.js
+++ b/test/e2e/run-all.js
@@ -11,7 +11,6 @@ const { loadBuildTypesConfig } = require('../../development/lib/build-type');
 const FLASK_ONLY_TESTS = [
   'test-snap-txinsights-v2.spec.js',
   'test-snap-namelookup.spec.js',
-  'test-snap-homepage.spec.js',
   'test-snap-siginsights.spec.js',
 ];
 


### PR DESCRIPTION
## **Description**

Enables Snaps home pages in stable. We thought we had already done this, but it turns out we forgot enable it.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/23383?quickstart=1)
