### PR TITLE
fix: allow onboarding and unlocking wallet without Infura mainnet connectivity

### DIFF
--- a/ui/components/multichain/network-list-menu/network-list-menu.js
+++ b/ui/components/multichain/network-list-menu/network-list-menu.js
@@ -426,7 +426,6 @@ export const NetworkListMenu = ({ onClose }) => {
           <Box padding={4}>
             <ButtonSecondary
               size={ButtonSecondarySize.Lg}
-              disabled={!isUnlocked}
               startIconName={IconName.Add}
               block
               onClick={() => {

--- a/ui/components/multichain/network-list-menu/network-list-menu.js
+++ b/ui/components/multichain/network-list-menu/network-list-menu.js
@@ -414,7 +414,7 @@ export const NetworkListMenu = ({ onClose }) => {
             <Text>{t('showTestnetNetworks')}</Text>
             <ToggleButton
               value={showTestNetworks}
-              disabled={currentlyOnTestNetwork || !isUnlocked}
+              disabled={currentlyOnTestNetwork}
               onToggle={handleToggle}
             />
           </Box>

--- a/ui/components/multichain/network-list-menu/network-list-menu.test.js
+++ b/ui/components/multichain/network-list-menu/network-list-menu.test.js
@@ -114,9 +114,9 @@ describe('NetworkListMenu', () => {
     expect(queryByText('Chain 5')).not.toBeInTheDocument();
   });
 
-  it('disables the "Add Network" button when MetaMask is locked', () => {
+  it('enables the "Add Network" button when MetaMask is locked', () => {
     const { queryByText } = render(false, '0x5', 'chain5', false);
-    expect(queryByText('Add network')).toBeDisabled();
+    expect(queryByText('Add network')).toBeEnabled();
   });
 
   it('enables the "Add Network" button when MetaMask is true', () => {


### PR DESCRIPTION
## **Description**

Fixes issue where custom networks are not configurable until after wallet is unlocked.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/23388?quickstart=1)

## **Related issues**

- Resolves #23333 
- https://github.com/MetaMask/metamask-extension/issues/22713
- Origin: https://github.com/MetaMask/metamask-extension/pull/20277

## **Manual testing steps**

0. Fresh wallet, disconnect internet, custom RPC node
1. Open MetaMask
2. Add custom RPC node
3. Complete onboarding

## **Screenshots/Recordings**


### **Before**


https://github.com/MetaMask/metamask-extension/assets/109787230/fe0e0930-8b0a-4ffe-b110-2f98afa26bab



### **After**


https://github.com/MetaMask/metamask-extension/assets/109787230/9794319c-e45f-4539-8837-a8e293373725



## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained what problem this PR is solving and how it is solved.
- [x] I've linked related issues
- [x] I've included manual testing steps
- [x] I've included screenshots/recordings if applicable
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [x] I’ve properly set the pull request status:
  - [x] In case it's not yet "ready for review", I've set it to "draft".
  - [x] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
