### PR TITLE
ci: fix prep-deps in PRs from external contributors

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ executors:
     resource_class: small
     environment:
       FONTCONFIG_PATH: /etc/fonts
-      NODE_OPTIONS: --max_old_space_size=1536
+      NODE_OPTIONS: --max_old_space_size=2048
   node-browsers-medium:
     docker:
       - image: cimg/node:20.11-browsers

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ executors:
     resource_class: small
     environment:
       FONTCONFIG_PATH: /etc/fonts
-      NODE_OPTIONS: --max_old_space_size=1024
+      NODE_OPTIONS: --max_old_space_size=1536
   node-browsers-medium:
     docker:
       - image: cimg/node:20.11-browsers

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -377,7 +377,7 @@ jobs:
           command: .circleci/scripts/release-create-release-pr.sh
 
   prep-deps:
-    executor: node-browsers-small
+    executor: node-browsers-medium
     steps:
       - run: *shallow-git-clone
       - run:


### PR DESCRIPTION
## **Description**

It took a long time but we figured it out, it was running out of memory depending on the state of the cache.

"Two PRs in different fork repos will have different caches" https://circleci.com/docs/oss/#caching

We just increased the `--max_old_space_size` in `node-browsers-small` and it worked sometimes, but not all the time, so we bumped the resource class to `medium`.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/23414?quickstart=1)

## **Related issues**

Fixes: #23207 

## **Manual testing steps**
## **Screenshots/Recordings**
## **Pre-merge author checklist**
## **Pre-merge reviewer checklist**