### PR TITLE
feat: added path for connect accounts when no account is connected

### DIFF
--- a/ui/components/multichain/pages/connections/connections.tsx
+++ b/ui/components/multichain/pages/connections/connections.tsx
@@ -63,7 +63,9 @@ export const Connections = () => {
   const subjectMetadata: { [key: string]: any } = useSelector(
     getConnectedSitesList,
   );
-  const connectedSubjectsMetadata = subjectMetadata[activeTabOrigin];
+  const { openMetaMaskTabs } = useSelector((state: any) => state.appState);
+  const { id } = useSelector((state: any) => state.activeTab);
+
   const connectedAccounts = useSelector(
     getOrderedConnectedAccountsForActiveTab,
   );
@@ -76,16 +78,20 @@ export const Connections = () => {
 
   const currentTabHasNoAccounts =
     !permittedAccountsByOrigin[activeTabOrigin]?.length;
-  let tabToConnect;
+  let tabToConnect: { origin: any } = { origin: null };
   if (activeTabOrigin && currentTabHasNoAccounts && !openMetaMaskTabs[id]) {
     tabToConnect = {
       origin: activeTabOrigin,
     };
   }
   const requestAccountsPermission = async () => {
-    const id = await dispatch(requestAccountsPermissionWithId(origin));
+    const id = await dispatch(
+      requestAccountsPermissionWithId(tabToConnect.origin),
+    );
     history.push(`${CONNECT_ROUTE}/${id}`);
   };
+  const connectedSubjectsMetadata = subjectMetadata[activeTabOrigin];
+
   return (
     <Page data-testid="connections-page" className="connections-page">
       <Header
@@ -132,7 +138,7 @@ export const Connections = () => {
         </Box>
       </Header>
       <Content padding={0}>
-        {connectedSubjectsMetadata ? (
+        {connectedSubjectsMetadata && mergeAccounts.length > 0 ? (
           <Tabs defaultActiveTabKey="connections">
             {
               // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -178,7 +184,7 @@ export const Connections = () => {
         ) : null}
       </Content>
       <Footer>
-        {connectedSubjectsMetadata ? (
+        {connectedSubjectsMetadata && mergeAccounts.length > 0 ? (
           <Box
             display={Display.Flex}
             gap={2}

--- a/ui/components/multichain/pages/connections/connections.tsx
+++ b/ui/components/multichain/pages/connections/connections.tsx
@@ -48,9 +48,9 @@ import { mergeAccounts } from '../../account-list-menu/account-list-menu';
 import { AccountListItem, AccountListItemMenuTypes } from '../..';
 import { Content, Footer, Header, Page } from '../page';
 import { ConnectAccountsModal } from '../../connect-accounts-modal/connect-accounts-modal';
+import { requestAccountsPermissionWithId } from '../../../../store/actions';
 import { AccountType, ConnectedSites } from './components/connections.types';
 import { NoConnectionContent } from './components/no-connection';
-import { requestAccountsPermissionWithId } from '../../../../store/actions';
 
 export const Connections = () => {
   const t = useI18nContext();
@@ -85,10 +85,10 @@ export const Connections = () => {
     };
   }
   const requestAccountsPermission = async () => {
-    const id = await dispatch(
+    const requestId = await dispatch(
       requestAccountsPermissionWithId(tabToConnect.origin),
     );
-    history.push(`${CONNECT_ROUTE}/${id}`);
+    history.push(`${CONNECT_ROUTE}/${requestId}`);
   };
   const connectedSubjectsMetadata = subjectMetadata[activeTabOrigin];
 


### PR DESCRIPTION
This PR is to implement the flow when no account is connected to the connections flow

## **Related issues**

Fixes: [2218](https://app.zenhub.com/workspaces/metamask-wallet-ux-63529dce65cbb100265a3842/issues/gh/metamask/metamask-planning/2218)

## **Manual testing steps**

1. Go to Connections Page when no dapp is connected
2. Click on Connect Accounts button and it should take to the existing connect accounts flow
3. Connect account. Check the list is updated

## **Screenshots/Recordings**


### **Before**

NA
### **After**

https://github.com/MetaMask/metamask-extension/assets/39872794/fe777df7-8079-401b-a251-a0679961dcc0



## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've clearly explained what problem this PR is solving and how it is solved.
- [ ] I've linked related issues
- [ ] I've included manual testing steps
- [ ] I've included screenshots/recordings if applicable
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [ ] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
