### PR TITLE
fix: Fix #23284 - UX: Multichain: Send flow - Prevent changing account when dapp-suggested send

### DIFF
--- a/test/e2e/tests/dapp-interactions/dapp-tx-edit.spec.js
+++ b/test/e2e/tests/dapp-interactions/dapp-tx-edit.spec.js
@@ -94,4 +94,44 @@ describe('Editing confirmations of dapp initiated contract interactions', functi
       },
     );
   });
+
+  it('should show a disabled Account Picker on a simple ETH send edit initiated by a dapp', async function () {
+    await withFixtures(
+      {
+        dapp: true,
+        fixtures: new FixtureBuilder()
+          .withPermissionControllerConnectedToTestDapp()
+          .build(),
+        ganacheOptions: defaultGanacheOptions,
+        smartContract,
+        title: this.test.fullTitle(),
+      },
+      async ({ driver }) => {
+        await unlockWallet(driver);
+
+        await openDapp(driver);
+        await driver.clickElement('#sendButton');
+        await driver.waitUntilXWindowHandles(3);
+        const windowHandles = await driver.getAllWindowHandles();
+
+        await driver.switchToWindowWithTitle(
+          WINDOW_TITLES.Dialog,
+          windowHandles,
+        );
+
+        await driver.waitForSelector({
+          css: '.confirm-page-container-summary__action__name',
+          text: 'Sending ETH',
+        });
+        await driver.clickElement(
+          '[data-testid="confirm-page-back-edit-button"]',
+        );
+
+        const accountPicker = await driver.findElement(
+          '[data-testid="send-page-account-picker"]',
+        );
+        assert.equal(await accountPicker.isEnabled(), false);
+      },
+    );
+  });
 });

--- a/test/e2e/tests/transaction/send-edit.spec.js
+++ b/test/e2e/tests/transaction/send-edit.spec.js
@@ -9,9 +9,6 @@ const FixtureBuilder = require('../../fixture-builder');
 
 describe('Editing Confirm Transaction', function () {
   it('goes back from confirm page to edit eth value, gas price and gas limit', async function () {
-    if (process.env.MULTICHAIN) {
-      return;
-    }
     await withFixtures(
       {
         fixtures: new FixtureBuilder()
@@ -78,9 +75,6 @@ describe('Editing Confirm Transaction', function () {
   });
 
   it('goes back from confirm page to edit eth value, baseFee, priorityFee and gas limit - 1559 V2', async function () {
-    if (process.env.MULTICHAIN) {
-      return;
-    }
     await withFixtures(
       {
         fixtures: new FixtureBuilder()

--- a/ui/components/multichain/pages/send/components/account-picker.tsx
+++ b/ui/components/multichain/pages/send/components/account-picker.tsx
@@ -14,7 +14,7 @@ import { I18nContext } from '../../../../../contexts/i18n';
 import { AccountListMenu } from '../../..';
 import { SendPageRow } from '.';
 
-export const SendPageAccountPicker = () => {
+export const SendPageAccountPicker = ({ disabled = false }) => {
   const t = useContext(I18nContext);
   const internalAccount = useSelector(getSelectedInternalAccount);
 
@@ -26,6 +26,7 @@ export const SendPageAccountPicker = () => {
       <AccountPicker
         className="multichain-send-page__account-picker"
         address={internalAccount.address}
+        disabled={disabled}
         name={internalAccount.metadata.name}
         onClick={() => setShowAccountPicker(true)}
         showAddress

--- a/ui/components/multichain/pages/send/send.js
+++ b/ui/components/multichain/pages/send/send.js
@@ -35,6 +35,8 @@ import {
 } from '../../../../helpers/constants/routes';
 import { MetaMetricsEventCategory } from '../../../../../shared/constants/metametrics';
 import { getMostRecentOverviewPage } from '../../../../ducks/history/history';
+import { getUnapprovedTransactions } from '../../../../selectors';
+import { ORIGIN_METAMASK } from '../../../../../shared/constants/app';
 import {
   SendPageAccountPicker,
   SendPageContent,
@@ -138,6 +140,18 @@ export const SendPage = () => {
 
   const sendErrors = useSelector(getSendErrors);
   const isInvalidSendForm = useSelector(isSendFormInvalid);
+
+  // We should not allow the account picker to be editable if
+  // it was launched from a dapp
+  let isDappSuggestedEdit = false;
+  const unapprovedTxs = useSelector(getUnapprovedTransactions);
+  if (sendStage === SEND_STAGES.EDIT) {
+    const unapprovedTransaction = unapprovedTxs[draftTransactionID];
+    if (unapprovedTransaction?.origin !== ORIGIN_METAMASK) {
+      isDappSuggestedEdit = true;
+    }
+  }
+
   const submitDisabled =
     (isInvalidSendForm && sendErrors.gasFee !== INSUFFICIENT_FUNDS_ERROR) ||
     requireContractAddressAcknowledgement;
@@ -157,7 +171,7 @@ export const SendPage = () => {
         {t('sendAToken')}
       </Header>
       <Content>
-        <SendPageAccountPicker />
+        <SendPageAccountPicker disabled={isDappSuggestedEdit} />
         <SendPageRecipientInput />
         {draftTransactionExists &&
         [SEND_STAGES.EDIT, SEND_STAGES.DRAFT].includes(sendStage) ? (

--- a/ui/components/multichain/pages/send/send.test.js
+++ b/ui/components/multichain/pages/send/send.test.js
@@ -292,6 +292,30 @@ describe('SendPage', () => {
       // Ensure we start a new draft transaction when its missing.
       expect(startNewDraftTransaction).toHaveBeenCalledTimes(1);
     });
+
+    it('should render with account picker disabled when dapp-suggested send', async () => {
+      const modifiedState = {
+        ...baseStore,
+        metamask: {
+          ...baseStore.metamask,
+          pinnedAccountList: [
+            '0xec1adf982415d2ef5ec55899b9bfb8bc0f29251b',
+            '0xeb9e64b93097bc15f01f13eae97015c57ab64823',
+          ],
+          hiddenAccountList: [],
+        },
+        send: {
+          ...baseStore.send,
+          stage: SEND_STAGES.EDIT,
+        },
+      };
+
+      const {
+        result: { getByTestId },
+      } = await render(modifiedState);
+
+      expect(getByTestId('send-page-account-picker')).toBeDisabled();
+    });
   });
 
   describe('footer buttons', () => {


### PR DESCRIPTION
## **Description**

Allowing the user to change the "from address" of a dapp-suggested send could be problematic; this PR prevents changing the from address in that case.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/23431?quickstart=1)

## **Related issues**

Fixes: #23284

## **Manual testing steps**

1. Open the Test Dapp
2. Click the "Send" button
3. When the MetaMask popup displays, click "Edit"
4. See the AccountPicker disabled.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've clearly explained what problem this PR is solving and how it is solved.
- [ ] I've linked related issues
- [ ] I've included manual testing steps
- [ ] I've included screenshots/recordings if applicable
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [ ] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
