### PR TITLE
style: Enforce using `type` instead of `interface` with `@typescript-eslint/consistent-type-definitions` rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -162,9 +162,9 @@ module.exports = {
         'import/namespace': 'off',
         'import/default': 'off',
         'import/no-named-as-default-member': 'off',
-        // Disabled due to incompatibility with Record<string, unknown>.
+        // Set to ban interfaces due to their incompatibility with Record<string, unknown>.
         // See: <https://github.com/Microsoft/TypeScript/issues/15300#issuecomment-702872440>
-        '@typescript-eslint/consistent-type-definitions': 'off',
+        '@typescript-eslint/consistent-type-definitions': ['error', 'type'],
         // Modified to include the 'ignoreRestSiblings' option.
         // TODO: Migrate this rule change back into `@metamask/eslint-config`
         '@typescript-eslint/no-unused-vars': [

--- a/app/scripts/controllers/mmi-controller.ts
+++ b/app/scripts/controllers/mmi-controller.ts
@@ -42,7 +42,7 @@ import MetaMetricsController from './metametrics';
 import { getPermissionBackgroundApiMethods } from './permissions';
 import { PreferencesController } from './preferences';
 
-interface UpdateCustodianTransactionsParameters {
+type UpdateCustodianTransactionsParameters = {
   keyring: CustodyKeyring;
   type: string;
   txList: string[];
@@ -51,7 +51,7 @@ interface UpdateCustodianTransactionsParameters {
   txStateManager: any;
   getPendingNonce: (address: string) => Promise<number>;
   setTxHash: (txId: string, txHash: string) => void;
-}
+};
 
 export default class MMIController extends EventEmitter {
   public opts: MMIControllerOptions;

--- a/app/scripts/controllers/mmi-controller.ts
+++ b/app/scripts/controllers/mmi-controller.ts
@@ -806,7 +806,6 @@ export default class MMIController extends EventEmitter {
       });
     }
 
-    // @ts-expect-error not relevant
     this.signatureController.setMessageMetadata(messageId, signature);
 
     return this.getState();

--- a/app/scripts/lib/util.ts
+++ b/app/scripts/lib/util.ts
@@ -180,11 +180,11 @@ export const isValidDate = (d: Date | number) => {
  * @property {() => void} reject - A function that rejects the Promise.
  */
 
-interface DeferredPromise {
+type DeferredPromise = {
   promise: Promise<any>;
   resolve?: () => void;
   reject?: () => void;
-}
+};
 
 /**
  * Create a defered Promise.
@@ -274,7 +274,7 @@ export function isWebUrl(urlString: string): boolean {
   );
 }
 
-interface FormattedTransactionMeta {
+type FormattedTransactionMeta = {
   blockHash: string | null;
   blockNumber: string | null;
   from: string;
@@ -293,7 +293,7 @@ interface FormattedTransactionMeta {
   type: TransactionEnvelopeType;
   accessList: AccessList | null;
   transactionIndex: string | null;
-}
+};
 
 export function formatTxMetaForRpcResult(
   txMeta: TransactionMeta,

--- a/app/scripts/migrations/096.ts
+++ b/app/scripts/migrations/096.ts
@@ -33,9 +33,9 @@ export async function migrate(
   return versionedData;
 }
 
-interface NetworkConfiguration {
+type NetworkConfiguration = {
   chainId: Record<string, any>;
-}
+};
 
 function transformState(state: Record<string, unknown>) {
   if (

--- a/app/scripts/migrations/105.test.ts
+++ b/app/scripts/migrations/105.test.ts
@@ -21,15 +21,15 @@ function addressToUUID(address: string): string {
   });
 }
 
-interface Identity {
+type Identity = {
   name: string;
   address: string;
   lastSelected?: number;
-}
+};
 
-interface Identities {
+type Identities = {
   [key: string]: Identity;
-}
+};
 
 function createMockPreferenceControllerState(
   identities: Identity[] = [{ name: 'Account 1', address: MOCK_ADDRESS }],

--- a/app/scripts/migrations/105.ts
+++ b/app/scripts/migrations/105.ts
@@ -12,11 +12,11 @@ type VersionedData = {
   data: Record<string, unknown>;
 };
 
-interface Identity {
+type Identity = {
   name: string;
   address: string;
   lastSelected?: number;
-}
+};
 
 export const version = 105;
 

--- a/app/scripts/migrations/107.ts
+++ b/app/scripts/migrations/107.ts
@@ -3,17 +3,17 @@ import { hasProperty, isObject } from '@metamask/utils';
 
 export const version = 107;
 
-interface AccountBalance {
+type AccountBalance = {
   address: string;
   balance: string;
-}
+};
 
-interface AccountTrackerControllerState {
+type AccountTrackerControllerState = {
   accountsByChainId: Record<string, Record<string, AccountBalance>>;
   accounts: Record<string, AccountBalance>;
   currentBlockGasLimit: string;
   currentBlockGasLimitByChainId: Record<string, string>;
-}
+};
 
 /**
  * Migrates state from the now removed CachedBalancesController to the AccountTrackerController and formats it accordingly.

--- a/development/fitness-functions/rules/index.ts
+++ b/development/fitness-functions/rules/index.ts
@@ -14,11 +14,11 @@ const RULES: IRule[] = [
   },
 ];
 
-interface IRule {
+type IRule = {
   name: string;
   fn: (diff: string) => boolean;
   docURL?: string;
-}
+};
 
 function runFitnessFunctionRule(rule: IRule, diff: string): void {
   const { name, fn, docURL } = rule;

--- a/shared/constants/gas.ts
+++ b/shared/constants/gas.ts
@@ -85,7 +85,7 @@ export enum NetworkCongestionThresholds {
   busy = 0.66,
 }
 
-export interface TxGasFees {
+export type TxGasFees = {
   /** Maxmimum number of units of gas to use for this transaction. */
   gasLimit: string;
   /** Price per gas for legacy txs */
@@ -111,4 +111,4 @@ export interface TxGasFees {
   userEditedGasLimit: string;
   /** Estimate level user selected. */
   userFeeLevel: string;
-}
+};

--- a/shared/constants/mmi-controller.ts
+++ b/shared/constants/mmi-controller.ts
@@ -9,7 +9,7 @@ import AppStateController from '../../app/scripts/controllers/app-state';
 import AccountTracker from '../../app/scripts/lib/account-tracker';
 import MetaMetricsController from '../../app/scripts/controllers/metametrics';
 
-export interface MMIControllerOptions {
+export type MMIControllerOptions = {
   mmiConfigurationController: MmiConfigurationController;
   keyringController: any;
   preferencesController: PreferencesController;
@@ -36,36 +36,36 @@ export interface MMIControllerOptions {
   setTxStatusSubmitted: (txId: string) => void;
   setTxStatusFailed: (txId: string) => void;
   updateTransaction: (txMeta: any) => void;
-}
+};
 
-export interface ISignedEvent {
+export type ISignedEvent = {
   signature: Signature;
   messageId: string;
-}
+};
 
-export interface IInteractiveRefreshTokenChangeEvent {
+export type IInteractiveRefreshTokenChangeEvent = {
   url: string;
   oldRefreshToken: string;
-}
+};
 
-export interface IConnectCustodyAddresses {
+export type IConnectCustodyAddresses = {
   custodianType: string;
   custodianName: string;
   accounts: string[];
-}
+};
 
-export interface Label {
+export type Label = {
   key: string;
   value: string;
-}
+};
 
-export interface Signature {
+export type Signature = {
   custodian_transactionId?: string;
   from: string;
-}
+};
 
-export interface NetworkConfiguration {
+export type NetworkConfiguration = {
   id: string;
   chainId: string;
   setActiveNetwork: (chainId: string) => void;
-}
+};

--- a/shared/constants/swaps.ts
+++ b/shared/constants/swaps.ts
@@ -26,7 +26,7 @@ export const MAX_ALLOWED_SLIPPAGE = 15;
 // in place of the token address that ERC-20 tokens have
 const DEFAULT_TOKEN_ADDRESS = '0x0000000000000000000000000000000000000000';
 
-export interface SwapsTokenObject {
+export type SwapsTokenObject = {
   /**
    * The symbol of token object
    */
@@ -47,7 +47,7 @@ export interface SwapsTokenObject {
    * URL for token icon
    */
   iconUrl: string;
-}
+};
 
 export const ETH_SWAPS_TOKEN_OBJECT: SwapsTokenObject = {
   symbol: CURRENCY_SYMBOLS.ETH,

--- a/shared/modules/i18n.ts
+++ b/shared/modules/i18n.ts
@@ -9,23 +9,23 @@ const fetchWithTimeout = getFetchWithTimeout();
 // and in i18n lib, the translated message is an object (I18NMessage) with message & description -
 // message is the string that will replace the translationKey, and that message may contain replacement variables such as $1, $2, etc.
 // Description is key describing the usage of the message.
-export interface I18NMessage {
+export type I18NMessage = {
   message: string;
   description?: string;
-}
+};
 
 // The overall translation file is made of same entries
 // translationKey (string) and the I18NMessage as the value.
-export interface I18NMessageDict {
+export type I18NMessageDict = {
   [translationKey: string]: I18NMessage;
-}
+};
 
 export type I18NSubstitution = string | (() => any) | object;
 
 // A parameterized type (or generic type) of maps that use the same structure (translationKey) key
-interface I18NMessageDictMap<R> {
+type I18NMessageDictMap<R> = {
   [translationKey: string]: R;
-}
+};
 
 export const FALLBACK_LOCALE = 'en';
 

--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -38,12 +38,12 @@ declare class MessageSender {
   url?: string;
 }
 
-export interface LedgerIframeMissingResponse {
+export type LedgerIframeMissingResponse = {
   success: false;
   payload: {
     error: Error;
   };
-}
+};
 
 type ResponseType =
   | Unsuccessful
@@ -60,7 +60,7 @@ type ResponseType =
  * input values so that the correct type can be inferred in the callback
  * method
  */
-interface sendMessage {
+type sendMessage = {
   (
     extensionId: string,
     message: Record<string, unknown>,
@@ -196,7 +196,7 @@ interface sendMessage {
     message: Record<string, unknown>,
     callback?: (response: ResponseType) => void,
   ): void;
-}
+};
 
 declare class Runtime {
   onMessage: {
@@ -237,6 +237,8 @@ export declare global {
   var chrome: Chrome;
 
   namespace jest {
+    // The interface is being used for declaration merging, which is an acceptable exception to this rule.
+    // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
     interface Matchers<R> {
       toBeFulfilled(): Promise<R>;
       toNeverResolve(): Promise<R>;

--- a/types/react-tippy.d.ts
+++ b/types/react-tippy.d.ts
@@ -21,7 +21,7 @@ declare module 'react-tippy' {
   export type Size = 'small' | 'regular' | 'big';
   export type Theme = 'dark' | 'light' | 'transparent';
 
-  export interface TooltipProps {
+  export type TooltipProps = {
     title?: string;
     disabled?: boolean;
     open?: boolean;
@@ -60,7 +60,7 @@ declare module 'react-tippy' {
     theme?: Theme;
     className?: string;
     style?: React.CSSProperties;
-  }
+  };
 
   export class Tooltip extends React.Component<TooltipProps> {}
 

--- a/types/react.d.ts
+++ b/types/react.d.ts
@@ -3,6 +3,9 @@ declare namespace React {
   import * as CSS from 'csstype';
 
   // Add custom CSS properties so that they can be used in `style` props
+  // This interface was created before this ESLint rule was added.
+  // Convert to a `type` in a future major version.
+  // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
   export interface CSSProperties extends CSS.Properties<string | number> {
     '--progress'?: string;
   }

--- a/ui/components/app/confirm/info/info.tsx
+++ b/ui/components/app/confirm/info/info.tsx
@@ -73,9 +73,9 @@ export type ConfirmInfoRowConfig = {
   variant?: ConfirmInfoRowVariant;
 };
 
-interface ConfirmInfoProps {
+type ConfirmInfoProps = {
   rowConfigs: ConfirmInfoRowConfig[];
-}
+};
 
 /**
  * ConfirmInfo receives a custom config object and displays a list of ConfirmInfoRow components

--- a/ui/components/app/incoming-trasaction-toggle/incoming-transaction-toggle.tsx
+++ b/ui/components/app/incoming-trasaction-toggle/incoming-transaction-toggle.tsx
@@ -13,7 +13,7 @@ import { PolymorphicRef } from '../../component-library/box';
 import { TEST_CHAINS } from '../../../../shared/constants/network';
 import NetworkToggle from './network-toggle';
 
-interface IncomingTransactionToggleProps {
+type IncomingTransactionToggleProps = {
   wrapperRef?: PolymorphicRef<any>;
   incomingTransactionsPreferences: Record<string, boolean>;
   allNetworks: Record<string, any>[];
@@ -21,7 +21,7 @@ interface IncomingTransactionToggleProps {
     chainId: string,
     isAllEnabledValue: boolean,
   ) => void;
-}
+};
 
 const IncomingTransactionToggle = ({
   wrapperRef,

--- a/ui/components/app/incoming-trasaction-toggle/network-toggle.tsx
+++ b/ui/components/app/incoming-trasaction-toggle/network-toggle.tsx
@@ -23,17 +23,17 @@ import Tooltip from '../../ui/tooltip';
 
 const MAXIMUM_CHARACTERS_WITHOUT_TOOLTIP = 20;
 
-interface NetworkPreferences {
+type NetworkPreferences = {
   isShowIncomingTransactions: boolean;
   label: string;
   imageUrl: string;
-}
+};
 
-interface NetworkToggleProps {
+type NetworkToggleProps = {
   networkPreferences: NetworkPreferences;
   toggleSingleNetwork: (chainId: string, value: boolean) => void;
   chainId: string;
-}
+};
 
 const NetworkToggle = ({
   networkPreferences,

--- a/ui/components/app/name/name-details/name-details.tsx
+++ b/ui/components/app/name/name-details/name-details.tsx
@@ -59,12 +59,12 @@ import { usePetnamesMetrics } from './metrics';
 
 const UPDATE_DELAY = 1000 * 2; // 2 Seconds
 
-export interface NameDetailsProps {
+export type NameDetailsProps = {
   onClose: () => void;
   sourcePriority?: string[];
   type: NameType;
   value: string;
-}
+};
 
 type ProposedNameOption = Required<FormComboFieldOption> & {
   sourceId: string;

--- a/ui/components/app/name/name.tsx
+++ b/ui/components/app/name/name.tsx
@@ -14,7 +14,7 @@ import { useDisplayName } from '../../../hooks/useDisplayName';
 import Identicon from '../../ui/identicon';
 import NameDetails from './name-details/name-details';
 
-export interface NameProps {
+export type NameProps = {
   /** Whether to prevent the modal from opening when the component is clicked. */
   disableEdit?: boolean;
 
@@ -26,7 +26,7 @@ export interface NameProps {
 
   /** The raw value to display the name of. */
   value: string;
-}
+};
 
 function formatValue(value: string, type: NameType): string {
   switch (type) {

--- a/ui/components/app/srp-quiz-modal/types.ts
+++ b/ui/components/app/srp-quiz-modal/types.ts
@@ -10,7 +10,7 @@ export enum QuizStage {
   rightAnswerQuestionTwo = 'right_answer_question_two',
 }
 
-export interface IQuizInformationProps {
+export type IQuizInformationProps = {
   /**
    * The icon to display in the modal should use <Icon /> component
    */
@@ -37,6 +37,6 @@ export interface IQuizInformationProps {
     size?: ButtonSize;
     'data-testid'?: string;
   }[];
-}
+};
 
 export type JSXDict = { [key: string]: () => JSX.Element };

--- a/ui/components/component-library/avatar-account/avatar-account.types.ts
+++ b/ui/components/component-library/avatar-account/avatar-account.types.ts
@@ -22,6 +22,9 @@ export const AvatarAccountDiameter: Record<AvatarAccountSize, number> = {
   [AvatarAccountSize.Xl]: 48,
 };
 
+// This interface was created before this ESLint rule was added.
+// Convert to a `type` in a future major version.
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export interface AvatarAccountStyleUtilityProps
   extends Omit<AvatarBaseStyleUtilityProps, 'size' | 'variant' | 'children'> {
   /**

--- a/ui/components/component-library/avatar-account/avatar-account.types.ts
+++ b/ui/components/component-library/avatar-account/avatar-account.types.ts
@@ -22,8 +22,7 @@ export const AvatarAccountDiameter: Record<AvatarAccountSize, number> = {
   [AvatarAccountSize.Xl]: 48,
 };
 
-// This interface was created before this ESLint rule was added.
-// Convert to a `type` in a future major version.
+// TODO: Convert to a `type` in a future major version.
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export interface AvatarAccountStyleUtilityProps
   extends Omit<AvatarBaseStyleUtilityProps, 'size' | 'variant' | 'children'> {

--- a/ui/components/component-library/avatar-base/avatar-base.types.ts
+++ b/ui/components/component-library/avatar-base/avatar-base.types.ts
@@ -14,8 +14,7 @@ export enum AvatarBaseSize {
   Xl = 'xl',
 }
 
-// This interface was created before this ESLint rule was added.
-// Convert to a `type` in a future major version.
+// TODO: Convert to a `type` in a future major version.
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export interface AvatarBaseStyleUtilityProps extends TextStyleUtilityProps {
   /**

--- a/ui/components/component-library/avatar-base/avatar-base.types.ts
+++ b/ui/components/component-library/avatar-base/avatar-base.types.ts
@@ -14,6 +14,9 @@ export enum AvatarBaseSize {
   Xl = 'xl',
 }
 
+// This interface was created before this ESLint rule was added.
+// Convert to a `type` in a future major version.
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export interface AvatarBaseStyleUtilityProps extends TextStyleUtilityProps {
   /**
    * The size of the AvatarBase.

--- a/ui/components/component-library/avatar-favicon/avatar-favicon.types.ts
+++ b/ui/components/component-library/avatar-favicon/avatar-favicon.types.ts
@@ -11,6 +11,9 @@ export enum AvatarFaviconSize {
   Xl = 'xl',
 }
 
+// This interface was created before this ESLint rule was added.
+// Convert to a `type` in a future major version.
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export interface AvatarFaviconStyleUtilityProps
   extends Omit<AvatarBaseStyleUtilityProps, 'size' | 'children'> {
   /**

--- a/ui/components/component-library/avatar-favicon/avatar-favicon.types.ts
+++ b/ui/components/component-library/avatar-favicon/avatar-favicon.types.ts
@@ -11,8 +11,7 @@ export enum AvatarFaviconSize {
   Xl = 'xl',
 }
 
-// This interface was created before this ESLint rule was added.
-// Convert to a `type` in a future major version.
+// TODO: Convert to a `type` in a future major version.
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export interface AvatarFaviconStyleUtilityProps
   extends Omit<AvatarBaseStyleUtilityProps, 'size' | 'children'> {

--- a/ui/components/component-library/avatar-icon/avatar-icon.types.ts
+++ b/ui/components/component-library/avatar-icon/avatar-icon.types.ts
@@ -19,6 +19,9 @@ export const avatarIconSizeToIconSize: Record<AvatarIconSize, IconSize> = {
   [AvatarIconSize.Xl]: IconSize.Xl,
 };
 
+// This interface was created before this ESLint rule was added.
+// Convert to a `type` in a future major version.
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export interface AvatarIconStyleUtilityProps
   extends Omit<AvatarBaseStyleUtilityProps, 'size' | 'children' | 'color'> {
   /**

--- a/ui/components/component-library/avatar-icon/avatar-icon.types.ts
+++ b/ui/components/component-library/avatar-icon/avatar-icon.types.ts
@@ -19,8 +19,7 @@ export const avatarIconSizeToIconSize: Record<AvatarIconSize, IconSize> = {
   [AvatarIconSize.Xl]: IconSize.Xl,
 };
 
-// This interface was created before this ESLint rule was added.
-// Convert to a `type` in a future major version.
+// TODO: Convert to a `type` in a future major version.
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export interface AvatarIconStyleUtilityProps
   extends Omit<AvatarBaseStyleUtilityProps, 'size' | 'children' | 'color'> {

--- a/ui/components/component-library/avatar-network/avatar-network.types.ts
+++ b/ui/components/component-library/avatar-network/avatar-network.types.ts
@@ -12,8 +12,7 @@ export enum AvatarNetworkSize {
 /**
  * Props for the AvatarNetwork component
  */
-// This interface was created before this ESLint rule was added.
-// Convert to a `type` in a future major version.
+// TODO: Convert to a `type` in a future major version.
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export interface AvatarNetworkStyleUtilityProps
   extends Omit<AvatarBaseStyleUtilityProps, 'size' | 'children'> {

--- a/ui/components/component-library/avatar-network/avatar-network.types.ts
+++ b/ui/components/component-library/avatar-network/avatar-network.types.ts
@@ -12,6 +12,9 @@ export enum AvatarNetworkSize {
 /**
  * Props for the AvatarNetwork component
  */
+// This interface was created before this ESLint rule was added.
+// Convert to a `type` in a future major version.
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export interface AvatarNetworkStyleUtilityProps
   extends Omit<AvatarBaseStyleUtilityProps, 'size' | 'children'> {
   /**

--- a/ui/components/component-library/avatar-token/avatar-token.types.ts
+++ b/ui/components/component-library/avatar-token/avatar-token.types.ts
@@ -12,8 +12,7 @@ export enum AvatarTokenSize {
 /**
  * Props for the AvatarToken component
  */
-// This interface was created before this ESLint rule was added.
-// Convert to a `type` in a future major version.
+// TODO: Convert to a `type` in a future major version.
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export interface AvatarTokenStyleUtilityProps
   extends Omit<AvatarBaseStyleUtilityProps, 'size' | 'children'> {

--- a/ui/components/component-library/avatar-token/avatar-token.types.ts
+++ b/ui/components/component-library/avatar-token/avatar-token.types.ts
@@ -12,6 +12,9 @@ export enum AvatarTokenSize {
 /**
  * Props for the AvatarToken component
  */
+// This interface was created before this ESLint rule was added.
+// Convert to a `type` in a future major version.
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export interface AvatarTokenStyleUtilityProps
   extends Omit<AvatarBaseStyleUtilityProps, 'size' | 'children'> {
   /**

--- a/ui/components/component-library/badge-wrapper/badge-wrapper.types.ts
+++ b/ui/components/component-library/badge-wrapper/badge-wrapper.types.ts
@@ -18,6 +18,9 @@ export enum BadgeWrapperAnchorElementShape {
   circular = 'circular',
 }
 
+// This interface was created before this ESLint rule was added.
+// Convert to a `type` in a future major version.
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export interface BadgeWrapperStyleUtilityProps extends StyleUtilityProps {
   /**
    * The element to be wrapped by the BadgeWrapper and for the badge to be positioned on top of

--- a/ui/components/component-library/badge-wrapper/badge-wrapper.types.ts
+++ b/ui/components/component-library/badge-wrapper/badge-wrapper.types.ts
@@ -18,8 +18,7 @@ export enum BadgeWrapperAnchorElementShape {
   circular = 'circular',
 }
 
-// This interface was created before this ESLint rule was added.
-// Convert to a `type` in a future major version.
+// TODO: Convert to a `type` in a future major version.
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export interface BadgeWrapperStyleUtilityProps extends StyleUtilityProps {
   /**

--- a/ui/components/component-library/banner-alert/banner-alert.types.ts
+++ b/ui/components/component-library/banner-alert/banner-alert.types.ts
@@ -9,6 +9,9 @@ export enum BannerAlertSeverity {
   Warning = 'warning',
 }
 
+// This interface was created before this ESLint rule was added.
+// Convert to a `type` in a future major version.
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export interface BannerAlertStyleUtilityProps
   extends BannerBaseStyleUtilityProps {
   /**

--- a/ui/components/component-library/banner-alert/banner-alert.types.ts
+++ b/ui/components/component-library/banner-alert/banner-alert.types.ts
@@ -9,8 +9,7 @@ export enum BannerAlertSeverity {
   Warning = 'warning',
 }
 
-// This interface was created before this ESLint rule was added.
-// Convert to a `type` in a future major version.
+// TODO: Convert to a `type` in a future major version.
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export interface BannerAlertStyleUtilityProps
   extends BannerBaseStyleUtilityProps {

--- a/ui/components/component-library/banner-base/banner-base.types.ts
+++ b/ui/components/component-library/banner-base/banner-base.types.ts
@@ -17,8 +17,7 @@ type MakePropsOptional<T> = {
   [K in keyof T]?: T[K];
 };
 
-// This interface was created before this ESLint rule was added.
-// Convert to a `type` in a future major version.
+// TODO: Convert to a `type` in a future major version.
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export interface BannerBaseStyleUtilityProps extends StyleUtilityProps {
   /**

--- a/ui/components/component-library/banner-base/banner-base.types.ts
+++ b/ui/components/component-library/banner-base/banner-base.types.ts
@@ -17,6 +17,9 @@ type MakePropsOptional<T> = {
   [K in keyof T]?: T[K];
 };
 
+// This interface was created before this ESLint rule was added.
+// Convert to a `type` in a future major version.
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export interface BannerBaseStyleUtilityProps extends StyleUtilityProps {
   /**
    * The title of the BannerBase

--- a/ui/components/component-library/banner-tip/banner-tip.types.ts
+++ b/ui/components/component-library/banner-tip/banner-tip.types.ts
@@ -7,6 +7,9 @@ export enum BannerTipLogoType {
   Chat = 'chat',
 }
 
+// This interface was created before this ESLint rule was added.
+// Convert to a `type` in a future major version.
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export interface BannerTipStyleUtilityProps
   extends BannerBaseStyleUtilityProps {
   /**

--- a/ui/components/component-library/banner-tip/banner-tip.types.ts
+++ b/ui/components/component-library/banner-tip/banner-tip.types.ts
@@ -7,8 +7,7 @@ export enum BannerTipLogoType {
   Chat = 'chat',
 }
 
-// This interface was created before this ESLint rule was added.
-// Convert to a `type` in a future major version.
+// TODO: Convert to a `type` in a future major version.
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export interface BannerTipStyleUtilityProps
   extends BannerBaseStyleUtilityProps {

--- a/ui/components/component-library/box/box.types.ts
+++ b/ui/components/component-library/box/box.types.ts
@@ -83,9 +83,9 @@ export type StylePropValueType =
   | IconColorArray
   | undefined;
 
-export interface ClassNamesObject {
+export type ClassNamesObject = {
   [key: string]: any;
-}
+};
 
 export type FlexDirectionArray = [
   FlexDirection,
@@ -223,7 +223,7 @@ export type PolymorphicComponentPropWithRef<
 /**
  * Includes all style utility props. This should be used to extend the props of a component.
  */
-export interface StyleUtilityProps {
+export type StyleUtilityProps = {
   /**
    * The flex direction of the component.
    * Use the FlexDirection enum from '../../../helpers/constants/design-system';
@@ -422,7 +422,7 @@ export interface StyleUtilityProps {
    * TODO: Allow data- attributes.
    */
   'data-testid'?: string;
-}
+};
 /**
  * Box component props.
  */

--- a/ui/components/component-library/box/box.types.ts
+++ b/ui/components/component-library/box/box.types.ts
@@ -426,6 +426,9 @@ export interface StyleUtilityProps {
 /**
  * Box component props.
  */
+// This interface was created before this ESLint rule was added.
+// Convert to a `type` in a future major version.
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 interface Props extends StyleUtilityProps {
   /**
    * The content of the Box component.

--- a/ui/components/component-library/box/box.types.ts
+++ b/ui/components/component-library/box/box.types.ts
@@ -426,8 +426,7 @@ export type StyleUtilityProps = {
 /**
  * Box component props.
  */
-// This interface was created before this ESLint rule was added.
-// Convert to a `type` in a future major version.
+// TODO: Convert to a `type` in a future major version.
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 interface Props extends StyleUtilityProps {
   /**

--- a/ui/components/component-library/button-base/button-base.types.ts
+++ b/ui/components/component-library/button-base/button-base.types.ts
@@ -13,6 +13,9 @@ export enum ButtonBaseSize {
 
 export type ValidButtonTagType = 'button' | 'a';
 
+// This interface was created before this ESLint rule was added.
+// Convert to a `type` in a future major version.
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export interface ButtonBaseStyleUtilityProps
   extends Omit<TextStyleUtilityProps, 'as' | 'children' | 'ellipsis'> {
   /**

--- a/ui/components/component-library/button-base/button-base.types.ts
+++ b/ui/components/component-library/button-base/button-base.types.ts
@@ -13,8 +13,7 @@ export enum ButtonBaseSize {
 
 export type ValidButtonTagType = 'button' | 'a';
 
-// This interface was created before this ESLint rule was added.
-// Convert to a `type` in a future major version.
+// TODO: Convert to a `type` in a future major version.
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export interface ButtonBaseStyleUtilityProps
   extends Omit<TextStyleUtilityProps, 'as' | 'children' | 'ellipsis'> {

--- a/ui/components/component-library/button-icon/button-icon.types.ts
+++ b/ui/components/component-library/button-icon/button-icon.types.ts
@@ -16,8 +16,7 @@ type MakePropsOptional<T> = {
   [K in keyof T]?: T[K];
 };
 
-// This interface was created before this ESLint rule was added.
-// Convert to a `type` in a future major version.
+// TODO: Convert to a `type` in a future major version.
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export interface ButtonIconStyleUtilityProps extends StyleUtilityProps {
   /**

--- a/ui/components/component-library/button-icon/button-icon.types.ts
+++ b/ui/components/component-library/button-icon/button-icon.types.ts
@@ -16,6 +16,9 @@ type MakePropsOptional<T> = {
   [K in keyof T]?: T[K];
 };
 
+// This interface was created before this ESLint rule was added.
+// Convert to a `type` in a future major version.
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export interface ButtonIconStyleUtilityProps extends StyleUtilityProps {
   /**
    * String that adds an accessible name for ButtonIcon

--- a/ui/components/component-library/button-link/button-link.types.ts
+++ b/ui/components/component-library/button-link/button-link.types.ts
@@ -11,8 +11,7 @@ export enum ButtonLinkSize {
   Inherit = 'inherit',
 }
 
-// This interface was created before this ESLint rule was added.
-// Convert to a `type` in a future major version.
+// TODO: Convert to a `type` in a future major version.
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export interface ButtonLinkStyleUtilityProps
   extends Omit<ButtonBaseStyleUtilityProps, 'size'> {

--- a/ui/components/component-library/button-link/button-link.types.ts
+++ b/ui/components/component-library/button-link/button-link.types.ts
@@ -11,6 +11,9 @@ export enum ButtonLinkSize {
   Inherit = 'inherit',
 }
 
+// This interface was created before this ESLint rule was added.
+// Convert to a `type` in a future major version.
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export interface ButtonLinkStyleUtilityProps
   extends Omit<ButtonBaseStyleUtilityProps, 'size'> {
   /**

--- a/ui/components/component-library/button-primary/button-primary.types.ts
+++ b/ui/components/component-library/button-primary/button-primary.types.ts
@@ -8,6 +8,10 @@ export enum ButtonPrimarySize {
 }
 
 export type ValidButtonTagType = 'button' | 'a';
+
+// This interface was created before this ESLint rule was added.
+// Convert to a `type` in a future major version.
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export interface ButtonPrimaryStyleUtilityProps
   extends Omit<ButtonBaseStyleUtilityProps, 'size'> {
   /**

--- a/ui/components/component-library/button-primary/button-primary.types.ts
+++ b/ui/components/component-library/button-primary/button-primary.types.ts
@@ -9,8 +9,7 @@ export enum ButtonPrimarySize {
 
 export type ValidButtonTagType = 'button' | 'a';
 
-// This interface was created before this ESLint rule was added.
-// Convert to a `type` in a future major version.
+// TODO: Convert to a `type` in a future major version.
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export interface ButtonPrimaryStyleUtilityProps
   extends Omit<ButtonBaseStyleUtilityProps, 'size'> {

--- a/ui/components/component-library/button-secondary/button-secondary.types.ts
+++ b/ui/components/component-library/button-secondary/button-secondary.types.ts
@@ -7,6 +7,9 @@ export enum ButtonSecondarySize {
   Lg = 'lg',
 }
 
+// This interface was created before this ESLint rule was added.
+// Convert to a `type` in a future major version.
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export interface ButtonSecondaryStyleUtilityProps
   extends Omit<ButtonBaseStyleUtilityProps, 'size'> {
   /**

--- a/ui/components/component-library/button-secondary/button-secondary.types.ts
+++ b/ui/components/component-library/button-secondary/button-secondary.types.ts
@@ -7,8 +7,7 @@ export enum ButtonSecondarySize {
   Lg = 'lg',
 }
 
-// This interface was created before this ESLint rule was added.
-// Convert to a `type` in a future major version.
+// TODO: Convert to a `type` in a future major version.
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export interface ButtonSecondaryStyleUtilityProps
   extends Omit<ButtonBaseStyleUtilityProps, 'size'> {

--- a/ui/components/component-library/checkbox/checkbox.types.ts
+++ b/ui/components/component-library/checkbox/checkbox.types.ts
@@ -4,8 +4,7 @@ import type {
   PolymorphicComponentPropWithRef,
 } from '../box';
 
-// This interface was created before this ESLint rule was added.
-// Convert to a `type` in a future major version.
+// TODO: Convert to a `type` in a future major version.
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export interface CheckboxStyleUtilityProps extends StyleUtilityProps {
   /*

--- a/ui/components/component-library/checkbox/checkbox.types.ts
+++ b/ui/components/component-library/checkbox/checkbox.types.ts
@@ -4,6 +4,9 @@ import type {
   PolymorphicComponentPropWithRef,
 } from '../box';
 
+// This interface was created before this ESLint rule was added.
+// Convert to a `type` in a future major version.
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export interface CheckboxStyleUtilityProps extends StyleUtilityProps {
   /*
    * Additional classNames to be added to the Checkbox component

--- a/ui/components/component-library/container/container.types.ts
+++ b/ui/components/component-library/container/container.types.ts
@@ -9,8 +9,7 @@ export enum ContainerMaxWidth {
   Lg = 'lg',
 }
 
-// This interface was created before this ESLint rule was added.
-// Convert to a `type` in a future major version.
+// TODO: Convert to a `type` in a future major version.
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export interface ContainerStyleUtilityProps extends StyleUtilityProps {
   /*

--- a/ui/components/component-library/container/container.types.ts
+++ b/ui/components/component-library/container/container.types.ts
@@ -9,6 +9,9 @@ export enum ContainerMaxWidth {
   Lg = 'lg',
 }
 
+// This interface was created before this ESLint rule was added.
+// Convert to a `type` in a future major version.
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export interface ContainerStyleUtilityProps extends StyleUtilityProps {
   /*
    * Additional classNames to be added to the Container component

--- a/ui/components/component-library/form-text-field/form-text-field.types.ts
+++ b/ui/components/component-library/form-text-field/form-text-field.types.ts
@@ -13,8 +13,7 @@ export enum FormTextFieldSize {
   Lg = 'lg',
 }
 
-// This interface was created before this ESLint rule was added.
-// Convert to a `type` in a future major version.
+// TODO: Convert to a `type` in a future major version.
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export interface FormTextFieldStyleUtilityProps
   extends Omit<TextFieldStyleUtilityProps, 'size' | 'type'> {
@@ -40,8 +39,7 @@ export interface FormTextFieldStyleUtilityProps
   helpTextProps?: HelpTextProps<'div'>;
 }
 
-// This interface was created before this ESLint rule was added.
-// Convert to a `type` in a future major version.
+// TODO: Convert to a `type` in a future major version.
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export interface FormTextFieldWithLabelProps
   extends FormTextFieldStyleUtilityProps {
@@ -57,8 +55,7 @@ export interface FormTextFieldWithLabelProps
   id: string; // id is required when label is provided
 }
 
-// This interface was created before this ESLint rule was added.
-// Convert to a `type` in a future major version.
+// TODO: Convert to a `type` in a future major version.
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export interface FormTextFieldWithoutLabelProps
   extends FormTextFieldStyleUtilityProps {

--- a/ui/components/component-library/form-text-field/form-text-field.types.ts
+++ b/ui/components/component-library/form-text-field/form-text-field.types.ts
@@ -13,6 +13,9 @@ export enum FormTextFieldSize {
   Lg = 'lg',
 }
 
+// This interface was created before this ESLint rule was added.
+// Convert to a `type` in a future major version.
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export interface FormTextFieldStyleUtilityProps
   extends Omit<TextFieldStyleUtilityProps, 'size' | 'type'> {
   /*
@@ -37,6 +40,9 @@ export interface FormTextFieldStyleUtilityProps
   helpTextProps?: HelpTextProps<'div'>;
 }
 
+// This interface was created before this ESLint rule was added.
+// Convert to a `type` in a future major version.
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export interface FormTextFieldWithLabelProps
   extends FormTextFieldStyleUtilityProps {
   /*
@@ -51,6 +57,9 @@ export interface FormTextFieldWithLabelProps
   id: string; // id is required when label is provided
 }
 
+// This interface was created before this ESLint rule was added.
+// Convert to a `type` in a future major version.
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export interface FormTextFieldWithoutLabelProps
   extends FormTextFieldStyleUtilityProps {
   /*

--- a/ui/components/component-library/header-base/header-base.types.ts
+++ b/ui/components/component-library/header-base/header-base.types.ts
@@ -6,8 +6,7 @@ import type {
   BoxProps,
 } from '../box';
 
-// This interface was created before this ESLint rule was added.
-// Convert to a `type` in a future major version.
+// TODO: Convert to a `type` in a future major version.
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export interface HeaderBaseStyleUtilityProps extends StyleUtilityProps {
   /**

--- a/ui/components/component-library/header-base/header-base.types.ts
+++ b/ui/components/component-library/header-base/header-base.types.ts
@@ -6,6 +6,9 @@ import type {
   BoxProps,
 } from '../box';
 
+// This interface was created before this ESLint rule was added.
+// Convert to a `type` in a future major version.
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export interface HeaderBaseStyleUtilityProps extends StyleUtilityProps {
   /**
    * The children is the title area of the HeaderBase

--- a/ui/components/component-library/help-text/help-text.types.ts
+++ b/ui/components/component-library/help-text/help-text.types.ts
@@ -10,6 +10,9 @@ export enum HelpTextSeverity {
   Info = Severity.Info,
 }
 
+// This interface was created before this ESLint rule was added.
+// Convert to a `type` in a future major version.
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export interface HelpTextStyleUtilityProps extends TextStyleUtilityProps {
   severity?: HelpTextSeverity | Severity;
   /**

--- a/ui/components/component-library/help-text/help-text.types.ts
+++ b/ui/components/component-library/help-text/help-text.types.ts
@@ -10,8 +10,7 @@ export enum HelpTextSeverity {
   Info = Severity.Info,
 }
 
-// This interface was created before this ESLint rule was added.
-// Convert to a `type` in a future major version.
+// TODO: Convert to a `type` in a future major version.
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export interface HelpTextStyleUtilityProps extends TextStyleUtilityProps {
   severity?: HelpTextSeverity | Severity;

--- a/ui/components/component-library/icon/icon.types.ts
+++ b/ui/components/component-library/icon/icon.types.ts
@@ -184,6 +184,9 @@ export enum IconName {
   PlusMinus = 'plus-minus',
 }
 
+// This interface was created before this ESLint rule was added.
+// Convert to a `type` in a future major version.
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export interface IconStyleUtilityProps extends StyleUtilityProps {
   /**
    * The name of the icon to display. Use the IconName enum

--- a/ui/components/component-library/icon/icon.types.ts
+++ b/ui/components/component-library/icon/icon.types.ts
@@ -184,8 +184,7 @@ export enum IconName {
   PlusMinus = 'plus-minus',
 }
 
-// This interface was created before this ESLint rule was added.
-// Convert to a `type` in a future major version.
+// TODO: Convert to a `type` in a future major version.
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export interface IconStyleUtilityProps extends StyleUtilityProps {
   /**

--- a/ui/components/component-library/input/input.types.ts
+++ b/ui/components/component-library/input/input.types.ts
@@ -13,6 +13,9 @@ export enum InputType {
   Search = 'search',
 }
 
+// This interface was created before this ESLint rule was added.
+// Convert to a `type` in a future major version.
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export interface InputStyleProps extends StyleUtilityProps {
   /**
    * Autocomplete allows the browser to predict the value based on earlier typed values

--- a/ui/components/component-library/input/input.types.ts
+++ b/ui/components/component-library/input/input.types.ts
@@ -13,8 +13,7 @@ export enum InputType {
   Search = 'search',
 }
 
-// This interface was created before this ESLint rule was added.
-// Convert to a `type` in a future major version.
+// TODO: Convert to a `type` in a future major version.
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export interface InputStyleProps extends StyleUtilityProps {
   /**

--- a/ui/components/component-library/label/label.types.ts
+++ b/ui/components/component-library/label/label.types.ts
@@ -1,8 +1,7 @@
 import type { PolymorphicComponentPropWithRef } from '../box';
 import type { TextStyleUtilityProps } from '../text';
 
-// This interface was created before this ESLint rule was added.
-// Convert to a `type` in a future major version.
+// TODO: Convert to a `type` in a future major version.
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export interface LabelStyleUtilityProps extends TextStyleUtilityProps {
   /**

--- a/ui/components/component-library/label/label.types.ts
+++ b/ui/components/component-library/label/label.types.ts
@@ -1,6 +1,9 @@
 import type { PolymorphicComponentPropWithRef } from '../box';
 import type { TextStyleUtilityProps } from '../text';
 
+// This interface was created before this ESLint rule was added.
+// Convert to a `type` in a future major version.
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export interface LabelStyleUtilityProps extends TextStyleUtilityProps {
   /**
    * The id of the input associated with the label

--- a/ui/components/component-library/modal-body/modal-body.types.ts
+++ b/ui/components/component-library/modal-body/modal-body.types.ts
@@ -5,8 +5,7 @@ import type {
   PolymorphicComponentPropWithRef,
 } from '../box';
 
-// This interface was created before this ESLint rule was added.
-// Convert to a `type` in a future major version.
+// TODO: Convert to a `type` in a future major version.
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export interface ModalBodyStyleUtilityProps extends StyleUtilityProps {
   /**

--- a/ui/components/component-library/modal-body/modal-body.types.ts
+++ b/ui/components/component-library/modal-body/modal-body.types.ts
@@ -5,6 +5,9 @@ import type {
   PolymorphicComponentPropWithRef,
 } from '../box';
 
+// This interface was created before this ESLint rule was added.
+// Convert to a `type` in a future major version.
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export interface ModalBodyStyleUtilityProps extends StyleUtilityProps {
   /**
    * Additional className to add to the ModalBody

--- a/ui/components/component-library/modal-content/modal-content.types.ts
+++ b/ui/components/component-library/modal-content/modal-content.types.ts
@@ -19,8 +19,7 @@ export enum ModalContentSize {
   Lg = 'lg',
 }
 
-// This interface was created before this ESLint rule was added.
-// Convert to a `type` in a future major version.
+// TODO: Convert to a `type` in a future major version.
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export interface ModalContentStyleUtilityProps extends StyleUtilityProps {
   /**

--- a/ui/components/component-library/modal-content/modal-content.types.ts
+++ b/ui/components/component-library/modal-content/modal-content.types.ts
@@ -19,6 +19,9 @@ export enum ModalContentSize {
   Lg = 'lg',
 }
 
+// This interface was created before this ESLint rule was added.
+// Convert to a `type` in a future major version.
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export interface ModalContentStyleUtilityProps extends StyleUtilityProps {
   /**
    * The additional className of the ModalContent component

--- a/ui/components/component-library/modal-focus/modal-focus.types.ts
+++ b/ui/components/component-library/modal-focus/modal-focus.types.ts
@@ -1,10 +1,10 @@
 import React from 'react';
 
-export interface FocusableElement {
+export type FocusableElement = {
   focus(options?: FocusOptions): void;
-}
+};
 
-export interface ModalFocusProps {
+export type ModalFocusProps = {
   /**
    * The `ref` of the element to receive focus initially
    */
@@ -32,4 +32,4 @@ export interface ModalFocusProps {
    * @default false
    */
   autoFocus?: boolean;
-}
+};

--- a/ui/components/component-library/modal-footer/modal-footer.types.ts
+++ b/ui/components/component-library/modal-footer/modal-footer.types.ts
@@ -7,8 +7,7 @@ import type {
 } from '../box';
 import type { ButtonProps } from '../button';
 
-// This interface was created before this ESLint rule was added.
-// Convert to a `type` in a future major version.
+// TODO: Convert to a `type` in a future major version.
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export interface ModalFooterStyleUtilityProps extends StyleUtilityProps {
   /**

--- a/ui/components/component-library/modal-footer/modal-footer.types.ts
+++ b/ui/components/component-library/modal-footer/modal-footer.types.ts
@@ -7,6 +7,9 @@ import type {
 } from '../box';
 import type { ButtonProps } from '../button';
 
+// This interface was created before this ESLint rule was added.
+// Convert to a `type` in a future major version.
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export interface ModalFooterStyleUtilityProps extends StyleUtilityProps {
   /**
    * Additional className to add to the ModalFooter

--- a/ui/components/component-library/modal-header/modal-header.types.ts
+++ b/ui/components/component-library/modal-header/modal-header.types.ts
@@ -2,8 +2,7 @@ import React from 'react';
 import type { ButtonIconProps } from '../button-icon/button-icon.types';
 import type { HeaderBaseStyleUtilityProps } from '../header-base';
 
-// This interface was created before this ESLint rule was added.
-// Convert to a `type` in a future major version.
+// TODO: Convert to a `type` in a future major version.
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export interface ModalHeaderProps extends HeaderBaseStyleUtilityProps {
   /**

--- a/ui/components/component-library/modal-header/modal-header.types.ts
+++ b/ui/components/component-library/modal-header/modal-header.types.ts
@@ -2,6 +2,9 @@ import React from 'react';
 import type { ButtonIconProps } from '../button-icon/button-icon.types';
 import type { HeaderBaseStyleUtilityProps } from '../header-base';
 
+// This interface was created before this ESLint rule was added.
+// Convert to a `type` in a future major version.
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export interface ModalHeaderProps extends HeaderBaseStyleUtilityProps {
   /**
    * The contents within the ModalHeader positioned middle (popular for title use case)

--- a/ui/components/component-library/modal-overlay/modal-overlay.types.ts
+++ b/ui/components/component-library/modal-overlay/modal-overlay.types.ts
@@ -4,8 +4,7 @@ import type {
   PolymorphicComponentPropWithRef,
 } from '../box';
 
-// This interface was created before this ESLint rule was added.
-// Convert to a `type` in a future major version.
+// TODO: Convert to a `type` in a future major version.
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export interface ModalOverlayStyleUtilityProps extends StyleUtilityProps {
   /**

--- a/ui/components/component-library/modal-overlay/modal-overlay.types.ts
+++ b/ui/components/component-library/modal-overlay/modal-overlay.types.ts
@@ -4,6 +4,9 @@ import type {
   PolymorphicComponentPropWithRef,
 } from '../box';
 
+// This interface was created before this ESLint rule was added.
+// Convert to a `type` in a future major version.
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export interface ModalOverlayStyleUtilityProps extends StyleUtilityProps {
   /**
    * onClick handler for the overlay

--- a/ui/components/component-library/modal/modal.types.ts
+++ b/ui/components/component-library/modal/modal.types.ts
@@ -1,7 +1,6 @@
 import type { ModalFocusProps } from '../modal-focus';
 
-// This interface was created before this ESLint rule was added.
-// Convert to a `type` in a future major version.
+// TODO: Convert to a `type` in a future major version.
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export interface ModalProps extends ModalFocusProps {
   /**

--- a/ui/components/component-library/modal/modal.types.ts
+++ b/ui/components/component-library/modal/modal.types.ts
@@ -1,5 +1,8 @@
 import type { ModalFocusProps } from '../modal-focus';
 
+// This interface was created before this ESLint rule was added.
+// Convert to a `type` in a future major version.
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export interface ModalProps extends ModalFocusProps {
   /**
    * If the modal is open or not

--- a/ui/components/component-library/picker-network/picker-network.types.ts
+++ b/ui/components/component-library/picker-network/picker-network.types.ts
@@ -6,6 +6,9 @@ import { IconProps } from '../icon/icon.types';
 import { AvatarNetworkProps } from '../avatar-network/avatar-network.types';
 import { TextProps } from '../text';
 
+// This interface was created before this ESLint rule was added.
+// Convert to a `type` in a future major version.
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export interface PickerNetworkStyleUtilityProps extends StyleUtilityProps {
   /**
    * The src accepts the string of the image to be rendered

--- a/ui/components/component-library/picker-network/picker-network.types.ts
+++ b/ui/components/component-library/picker-network/picker-network.types.ts
@@ -6,8 +6,7 @@ import { IconProps } from '../icon/icon.types';
 import { AvatarNetworkProps } from '../avatar-network/avatar-network.types';
 import { TextProps } from '../text';
 
-// This interface was created before this ESLint rule was added.
-// Convert to a `type` in a future major version.
+// TODO: Convert to a `type` in a future major version.
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export interface PickerNetworkStyleUtilityProps extends StyleUtilityProps {
   /**

--- a/ui/components/component-library/popover-header/popover-header.types.ts
+++ b/ui/components/component-library/popover-header/popover-header.types.ts
@@ -2,8 +2,7 @@ import React from 'react';
 import type { ButtonIconProps } from '../button-icon/button-icon.types';
 import type { HeaderBaseStyleUtilityProps } from '../header-base';
 
-// This interface was created before this ESLint rule was added.
-// Convert to a `type` in a future major version.
+// TODO: Convert to a `type` in a future major version.
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export interface PopoverHeaderProps extends HeaderBaseStyleUtilityProps {
   /**

--- a/ui/components/component-library/popover-header/popover-header.types.ts
+++ b/ui/components/component-library/popover-header/popover-header.types.ts
@@ -2,6 +2,9 @@ import React from 'react';
 import type { ButtonIconProps } from '../button-icon/button-icon.types';
 import type { HeaderBaseStyleUtilityProps } from '../header-base';
 
+// This interface was created before this ESLint rule was added.
+// Convert to a `type` in a future major version.
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export interface PopoverHeaderProps extends HeaderBaseStyleUtilityProps {
   /**
    * The contents within the PopoverHeader positioned middle (popular for title use case)

--- a/ui/components/component-library/popover/popover.types.ts
+++ b/ui/components/component-library/popover/popover.types.ts
@@ -26,8 +26,7 @@ export enum PopoverRole {
   Dialog = 'dialog',
 }
 
-// This interface was created before this ESLint rule was added.
-// Convert to a `type` in a future major version.
+// TODO: Convert to a `type` in a future major version.
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export interface PopoverStyleUtilityProps extends StyleUtilityProps {
   /**

--- a/ui/components/component-library/popover/popover.types.ts
+++ b/ui/components/component-library/popover/popover.types.ts
@@ -26,6 +26,9 @@ export enum PopoverRole {
   Dialog = 'dialog',
 }
 
+// This interface was created before this ESLint rule was added.
+// Convert to a `type` in a future major version.
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export interface PopoverStyleUtilityProps extends StyleUtilityProps {
   /**
    * The contents within the Popover

--- a/ui/components/component-library/select-button/select-button.types.ts
+++ b/ui/components/component-library/select-button/select-button.types.ts
@@ -12,6 +12,9 @@ export enum SelectButtonSize {
   Lg = 'lg',
 }
 
+// This interface was created before this ESLint rule was added.
+// Convert to a `type` in a future major version.
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export interface SelectButtonStyleUtilityProps extends StyleUtilityProps {
   /*
    * Additional classNames to be added to the SelectButton component

--- a/ui/components/component-library/select-button/select-button.types.ts
+++ b/ui/components/component-library/select-button/select-button.types.ts
@@ -12,8 +12,7 @@ export enum SelectButtonSize {
   Lg = 'lg',
 }
 
-// This interface was created before this ESLint rule was added.
-// Convert to a `type` in a future major version.
+// TODO: Convert to a `type` in a future major version.
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export interface SelectButtonStyleUtilityProps extends StyleUtilityProps {
   /*

--- a/ui/components/component-library/select-option/select-option.types.ts
+++ b/ui/components/component-library/select-option/select-option.types.ts
@@ -3,8 +3,7 @@ import type {
   PolymorphicComponentPropWithRef,
 } from '../box';
 
-// This interface was created before this ESLint rule was added.
-// Convert to a `type` in a future major version.
+// TODO: Convert to a `type` in a future major version.
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export interface SelectOptionStyleUtilityProps extends StyleUtilityProps {
   /*

--- a/ui/components/component-library/select-option/select-option.types.ts
+++ b/ui/components/component-library/select-option/select-option.types.ts
@@ -3,6 +3,9 @@ import type {
   PolymorphicComponentPropWithRef,
 } from '../box';
 
+// This interface was created before this ESLint rule was added.
+// Convert to a `type` in a future major version.
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export interface SelectOptionStyleUtilityProps extends StyleUtilityProps {
   /*
    * Additional classNames to be added to the SelectOption component

--- a/ui/components/component-library/select-wrapper/select-wrapper.types.ts
+++ b/ui/components/component-library/select-wrapper/select-wrapper.types.ts
@@ -21,8 +21,7 @@ export type SelectContextType = {
   placeholder: any;
 };
 
-// This interface was created before this ESLint rule was added.
-// Convert to a `type` in a future major version.
+// TODO: Convert to a `type` in a future major version.
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export interface SelectWrapperStyleUtilityProps extends StyleUtilityProps {
   /**

--- a/ui/components/component-library/select-wrapper/select-wrapper.types.ts
+++ b/ui/components/component-library/select-wrapper/select-wrapper.types.ts
@@ -21,6 +21,9 @@ export type SelectContextType = {
   placeholder: any;
 };
 
+// This interface was created before this ESLint rule was added.
+// Convert to a `type` in a future major version.
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export interface SelectWrapperStyleUtilityProps extends StyleUtilityProps {
   /**
    * Additional classNames to be added to the SelectWrapper component.

--- a/ui/components/component-library/tag-url/tag-url.types.ts
+++ b/ui/components/component-library/tag-url/tag-url.types.ts
@@ -8,8 +8,7 @@ import { IconProps } from '../icon';
 import { TextProps } from '../text';
 import { ButtonLinkProps } from '../button-link';
 
-// This interface was created before this ESLint rule was added.
-// Convert to a `type` in a future major version.
+// TODO: Convert to a `type` in a future major version.
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export interface TagUrlStyleUtilityProps extends StyleUtilityProps {
   /**

--- a/ui/components/component-library/tag-url/tag-url.types.ts
+++ b/ui/components/component-library/tag-url/tag-url.types.ts
@@ -8,6 +8,9 @@ import { IconProps } from '../icon';
 import { TextProps } from '../text';
 import { ButtonLinkProps } from '../button-link';
 
+// This interface was created before this ESLint rule was added.
+// Convert to a `type` in a future major version.
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export interface TagUrlStyleUtilityProps extends StyleUtilityProps {
   /**
    * The src accepts the string of the image to be rendered

--- a/ui/components/component-library/tag/tag.types.ts
+++ b/ui/components/component-library/tag/tag.types.ts
@@ -5,6 +5,9 @@ import type {
 } from '../box';
 import { IconName, IconProps } from '../icon';
 
+// This interface was created before this ESLint rule was added.
+// Convert to a `type` in a future major version.
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export interface TagStyleUtilityProps extends StyleUtilityProps {
   /**
    * The text content of the Tag component, can either be a string or ReactNode

--- a/ui/components/component-library/tag/tag.types.ts
+++ b/ui/components/component-library/tag/tag.types.ts
@@ -5,8 +5,7 @@ import type {
 } from '../box';
 import { IconName, IconProps } from '../icon';
 
-// This interface was created before this ESLint rule was added.
-// Convert to a `type` in a future major version.
+// TODO: Convert to a `type` in a future major version.
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export interface TagStyleUtilityProps extends StyleUtilityProps {
   /**

--- a/ui/components/component-library/text-field-search/text-field-search.types.ts
+++ b/ui/components/component-library/text-field-search/text-field-search.types.ts
@@ -18,8 +18,7 @@ type MakePropsOptional<T> = {
   [K in keyof T]?: T[K];
 };
 
-// This interface was created before this ESLint rule was added.
-// Convert to a `type` in a future major version.
+// TODO: Convert to a `type` in a future major version.
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export interface TextFieldSearchStyleUtilityProps
   extends Omit<TextFieldProps<'input'>, 'type' | 'size'> {

--- a/ui/components/component-library/text-field-search/text-field-search.types.ts
+++ b/ui/components/component-library/text-field-search/text-field-search.types.ts
@@ -18,6 +18,9 @@ type MakePropsOptional<T> = {
   [K in keyof T]?: T[K];
 };
 
+// This interface was created before this ESLint rule was added.
+// Convert to a `type` in a future major version.
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export interface TextFieldSearchStyleUtilityProps
   extends Omit<TextFieldProps<'input'>, 'type' | 'size'> {
   /**

--- a/ui/components/component-library/text-field/text-field.types.ts
+++ b/ui/components/component-library/text-field/text-field.types.ts
@@ -20,6 +20,9 @@ export enum TextFieldType {
   Search = 'search',
 }
 
+// This interface was created before this ESLint rule was added.
+// Convert to a `type` in a future major version.
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export interface TextFieldStyleUtilityProps
   extends Omit<StyleUtilityProps, 'type'> {
   /**

--- a/ui/components/component-library/text-field/text-field.types.ts
+++ b/ui/components/component-library/text-field/text-field.types.ts
@@ -20,8 +20,7 @@ export enum TextFieldType {
   Search = 'search',
 }
 
-// This interface was created before this ESLint rule was added.
-// Convert to a `type` in a future major version.
+// TODO: Convert to a `type` in a future major version.
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export interface TextFieldStyleUtilityProps
   extends Omit<StyleUtilityProps, 'type'> {

--- a/ui/components/component-library/text/text.types.ts
+++ b/ui/components/component-library/text/text.types.ts
@@ -75,7 +75,7 @@ export type ValidTagType =
   | 'a'
   | 'button';
 
-  // This interface was created before this ESLint rule was added.
+// This interface was created before this ESLint rule was added.
 // Convert to a `type` in a future major version.
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export interface TextStyleUtilityProps extends StyleUtilityProps {

--- a/ui/components/component-library/text/text.types.ts
+++ b/ui/components/component-library/text/text.types.ts
@@ -75,6 +75,9 @@ export type ValidTagType =
   | 'a'
   | 'button';
 
+  // This interface was created before this ESLint rule was added.
+// Convert to a `type` in a future major version.
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export interface TextStyleUtilityProps extends StyleUtilityProps {
   /**
    * Additional className to assign the Text component

--- a/ui/components/component-library/text/text.types.ts
+++ b/ui/components/component-library/text/text.types.ts
@@ -75,8 +75,7 @@ export type ValidTagType =
   | 'a'
   | 'button';
 
-// This interface was created before this ESLint rule was added.
-// Convert to a `type` in a future major version.
+// TODO: Convert to a `type` in a future major version.
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export interface TextStyleUtilityProps extends StyleUtilityProps {
   /**

--- a/ui/components/component-library/textarea/textarea.types.ts
+++ b/ui/components/component-library/textarea/textarea.types.ts
@@ -13,8 +13,7 @@ export enum TextareaResize {
   Inherit = 'inherit',
 }
 
-// This interface was created before this ESLint rule was added.
-// Convert to a `type` in a future major version.
+// TODO: Convert to a `type` in a future major version.
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export interface TextareaStyleUtilityProps extends StyleUtilityProps {
   /**

--- a/ui/components/component-library/textarea/textarea.types.ts
+++ b/ui/components/component-library/textarea/textarea.types.ts
@@ -13,6 +13,9 @@ export enum TextareaResize {
   Inherit = 'inherit',
 }
 
+// This interface was created before this ESLint rule was added.
+// Convert to a `type` in a future major version.
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export interface TextareaStyleUtilityProps extends StyleUtilityProps {
   /**
    * If `true`, the textarea will be focused during the first mount.

--- a/ui/components/multichain/address-list-item/address-list-item.tsx
+++ b/ui/components/multichain/address-list-item/address-list-item.tsx
@@ -23,11 +23,11 @@ import { getUseBlockie } from '../../../selectors';
 import { shortenAddress } from '../../../helpers/utils/util';
 import Tooltip from '../../ui/tooltip';
 
-interface AddressListItemProps {
+type AddressListItemProps = {
   address: string;
   label: string;
   onClick: () => void;
-}
+};
 
 export const AddressListItem = ({
   address,

--- a/ui/components/multichain/asset-picker-amount/asset-picker-modal/asset-picker-modal.tsx
+++ b/ui/components/multichain/asset-picker-amount/asset-picker-modal/asset-picker-modal.tsx
@@ -58,13 +58,13 @@ import { TokenListItem } from '../../token-list-item';
 import { useNftsCollections } from '../../../../hooks/useNftsCollections';
 import ZENDESK_URLS from '../../../../helpers/constants/zendesk-url';
 
-interface AssetPickerModalProps {
+type AssetPickerModalProps = {
   isOpen: boolean;
   onClose: () => void;
   asset: Asset;
-}
+};
 
-interface NFT {
+type NFT = {
   address: string;
   description: string | null;
   favorite: boolean;
@@ -74,13 +74,13 @@ interface NFT {
   standard: TokenStandard;
   tokenId: string;
   tokenURI?: string;
-}
+};
 
-interface Collection {
+type Collection = {
   collectionName: string;
   collectionImage: string | null;
   nfts: NFT[];
-}
+};
 
 export function AssetPickerModal({
   isOpen,

--- a/ui/components/multichain/avatar-group/avatar-group.types.tsx
+++ b/ui/components/multichain/avatar-group/avatar-group.types.tsx
@@ -2,6 +2,9 @@ import { BorderColor } from '../../../helpers/constants/design-system';
 import { AvatarTokenSize } from '../../component-library';
 import type { StyleUtilityProps } from '../../component-library/box';
 
+// This interface was created before this ESLint rule was added.
+// Convert to a `type` in a future major version.
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export interface AvatarGroupProps extends StyleUtilityProps {
   /** * Additional class name for the AvatarGroup component */
   className?: string;

--- a/ui/components/multichain/avatar-group/avatar-group.types.tsx
+++ b/ui/components/multichain/avatar-group/avatar-group.types.tsx
@@ -2,8 +2,7 @@ import { BorderColor } from '../../../helpers/constants/design-system';
 import { AvatarTokenSize } from '../../component-library';
 import type { StyleUtilityProps } from '../../component-library/box';
 
-// This interface was created before this ESLint rule was added.
-// Convert to a `type` in a future major version.
+// TODO: Convert to a `type` in a future major version.
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export interface AvatarGroupProps extends StyleUtilityProps {
   /** * Additional class name for the AvatarGroup component */

--- a/ui/components/multichain/badge-status/badge-status.types.tsx
+++ b/ui/components/multichain/badge-status/badge-status.types.tsx
@@ -4,8 +4,7 @@ import {
 } from '../../../helpers/constants/design-system';
 import type { StyleUtilityProps } from '../../component-library/box';
 
-// This interface was created before this ESLint rule was added.
-// Convert to a `type` in a future major version.
+// TODO: Convert to a `type` in a future major version.
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export interface BadgeStatusProps extends StyleUtilityProps {
   /** * Additional class name for the ImportTokenLink component. */

--- a/ui/components/multichain/badge-status/badge-status.types.tsx
+++ b/ui/components/multichain/badge-status/badge-status.types.tsx
@@ -4,6 +4,9 @@ import {
 } from '../../../helpers/constants/design-system';
 import type { StyleUtilityProps } from '../../component-library/box';
 
+// This interface was created before this ESLint rule was added.
+// Convert to a `type` in a future major version.
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export interface BadgeStatusProps extends StyleUtilityProps {
   /** * Additional class name for the ImportTokenLink component. */
   className?: string;

--- a/ui/components/multichain/connected-accounts-menu/connected-accounts-menu.types.ts
+++ b/ui/components/multichain/connected-accounts-menu/connected-accounts-menu.types.ts
@@ -1,3 +1,3 @@
-export interface Identity {
+export type Identity = {
   address: string;
-}
+};

--- a/ui/components/multichain/import-token-link/import-token-link.types.ts
+++ b/ui/components/multichain/import-token-link/import-token-link.types.ts
@@ -1,5 +1,8 @@
 import type { StyleUtilityProps } from '../../component-library/box';
 
+// This interface was created before this ESLint rule was added.
+// Convert to a `type` in a future major version.
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export interface ImportTokenLinkProps extends StyleUtilityProps {
   /** * Additional class name for the ImportTokenLink component. */
   className?: string;

--- a/ui/components/multichain/import-token-link/import-token-link.types.ts
+++ b/ui/components/multichain/import-token-link/import-token-link.types.ts
@@ -1,7 +1,6 @@
 import type { StyleUtilityProps } from '../../component-library/box';
 
-// This interface was created before this ESLint rule was added.
-// Convert to a `type` in a future major version.
+// TODO: Convert to a `type` in a future major version.
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export interface ImportTokenLinkProps extends StyleUtilityProps {
   /** * Additional class name for the ImportTokenLink component. */

--- a/ui/components/multichain/notification-detail-address/notification-detail-address.tsx
+++ b/ui/components/multichain/notification-detail-address/notification-detail-address.tsx
@@ -10,10 +10,10 @@ import {
 } from '../../../helpers/constants/design-system';
 import { shortenAddress } from '../../../helpers/utils/util';
 
-export interface NotificationDetailAddressProps {
+export type NotificationDetailAddressProps = {
   side: string;
   address: string;
-}
+};
 
 const SideText: FC<{ side: string }> = ({ side }) => (
   <Text variant={TextVariant.bodyLgMedium} fontWeight={FontWeight.Medium}>

--- a/ui/components/multichain/notification-detail-asset/notification-detail-asset.tsx
+++ b/ui/components/multichain/notification-detail-asset/notification-detail-asset.tsx
@@ -17,23 +17,23 @@ import {
   TextColor,
 } from '../../../helpers/constants/design-system';
 
-interface BadgeProps {
+type BadgeProps = {
   src: string;
   position?: BadgeWrapperPosition;
-}
+};
 
-interface IconProps {
+type IconProps = {
   src: string;
   badge?: BadgeProps;
-}
+};
 
-export interface NotificationDetailAssetProps {
+export type NotificationDetailAssetProps = {
   icon: IconProps;
   label: string;
   detail: string;
   fiatValue?: string;
   value?: string;
-}
+};
 
 const createTextComponent = (
   variant: TextVariant,

--- a/ui/components/multichain/notification-detail-collection/notification-detail-collection.tsx
+++ b/ui/components/multichain/notification-detail-collection/notification-detail-collection.tsx
@@ -19,16 +19,16 @@ import {
   TextColor,
 } from '../../../helpers/constants/design-system';
 
-interface IconProps {
+type IconProps = {
   src: string;
   badgeSrc: string;
-}
+};
 
-export interface NotificationDetailCollectionProps {
+export type NotificationDetailCollectionProps = {
   icon: IconProps;
   label: string;
   collection: string;
-}
+};
 
 export const NotificationDetailCollection: FC<
   NotificationDetailCollectionProps

--- a/ui/components/multichain/notification-detail-copy-button/notification-detail-copy-button.tsx
+++ b/ui/components/multichain/notification-detail-copy-button/notification-detail-copy-button.tsx
@@ -19,11 +19,11 @@ import Tooltip from '../../ui/tooltip/tooltip';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import { MINUTE } from '../../../../shared/constants/time';
 
-export interface NotificationDetailCopyButtonProps {
+export type NotificationDetailCopyButtonProps = {
   text: string;
   displayText: string;
   color?: TextColor;
-}
+};
 
 /**
  * A component to display a button that copies a given text to the clipboard when clicked.

--- a/ui/components/multichain/notification-detail-info/notification-detail-info.tsx
+++ b/ui/components/multichain/notification-detail-info/notification-detail-info.tsx
@@ -10,18 +10,18 @@ import {
   TextColor,
 } from '../../../helpers/constants/design-system';
 
-interface IconProps {
+type IconProps = {
   iconName: IconName;
   color: TextColor;
   backgroundColor: BackgroundColor;
-}
+};
 
-export interface NotificationDetailInfoProps {
+export type NotificationDetailInfoProps = {
   icon: IconProps;
   label: string;
   detail: string;
   action?: JSX.Element;
-}
+};
 
 /**
  * A component to display a notification detail with an icon, a label, a detail, and an action.

--- a/ui/components/multichain/notification-detail-network-fee/notification-detail-network-fee.tsx
+++ b/ui/components/multichain/notification-detail-network-fee/notification-detail-network-fee.tsx
@@ -23,14 +23,14 @@ import {
   FlexDirection,
 } from '../../../helpers/constants/design-system';
 
-export interface NotificationDetailNetworkFeeProps {
+export type NotificationDetailNetworkFeeProps = {
   networkFee: string;
   gasLimit: string;
   gasUsed: string;
   baseFee: string;
   priorityFee: string;
   maxFee: string;
-}
+};
 
 const FeeDetail = ({ label, value }: { label: string; value: string }) => (
   <Box

--- a/ui/components/multichain/notification-detail-nft/notification-detail-nft.tsx
+++ b/ui/components/multichain/notification-detail-nft/notification-detail-nft.tsx
@@ -7,13 +7,13 @@ import {
   JustifyContent,
 } from '../../../helpers/constants/design-system';
 
-export interface NotificationDetailNftProps {
+export type NotificationDetailNftProps = {
   networkName: string;
   networkSrc: string;
   tokenName: string;
   tokenId: string;
   tokenSrc: string;
-}
+};
 
 /**
  * A component that renders a notification detail for an NFT.

--- a/ui/components/multichain/notification-detail-title/notification-detail-title.tsx
+++ b/ui/components/multichain/notification-detail-title/notification-detail-title.tsx
@@ -11,10 +11,10 @@ import {
 } from '../../../helpers/constants/design-system';
 import { Box, Text } from '../../component-library';
 
-export interface NotificationDetailTitleProps {
+export type NotificationDetailTitleProps = {
   title: string;
   date?: string;
-}
+};
 
 /**
  * NotificationDetailTitle component.

--- a/ui/components/multichain/notification-detail/notification-detail.tsx
+++ b/ui/components/multichain/notification-detail/notification-detail.tsx
@@ -12,13 +12,13 @@ import {
   TextAlign,
 } from '../../../helpers/constants/design-system';
 
-export interface NotificationDetailProps {
+export type NotificationDetailProps = {
   icon: JSX.Element;
   primaryTextLeft: JSX.Element;
   primaryTextRight?: JSX.Element;
   secondaryTextLeft: JSX.Element;
   secondaryTextRight?: JSX.Element;
-}
+};
 
 /**
  * `NotificationDetail` is a component that displays a single notification item.

--- a/ui/components/multichain/notification-list-item-icon/notification-list-item-icon.tsx
+++ b/ui/components/multichain/notification-list-item-icon/notification-list-item-icon.tsx
@@ -26,16 +26,16 @@ export enum NotificationListItemIconType {
   Nft = 'nft',
 }
 
-export interface BadgeProps {
+export type BadgeProps = {
   icon: IconName;
   position?: BadgeWrapperPosition;
-}
+};
 
-export interface NotificationListItemIconProps {
+export type NotificationListItemIconProps = {
   type: NotificationListItemIconType;
   value: string;
   badge?: BadgeProps;
-}
+};
 
 const AvatarTokenComponent = ({ src }: { src: string }): JSX.Element => (
   <AvatarToken

--- a/ui/components/multichain/notification-list-item-text/notification-list-item-text.tsx
+++ b/ui/components/multichain/notification-list-item-text/notification-list-item-text.tsx
@@ -8,16 +8,16 @@ import {
 } from '../../../helpers/constants/design-system';
 import { getRandomKey } from '../../../helpers/utils/notification.util';
 
-export interface NotificationListItemTextItemProps {
+export type NotificationListItemTextItemProps = {
   text: string;
   highlighted?: boolean;
-}
+};
 
-export interface NotificationListItemTextProps {
+export type NotificationListItemTextProps = {
   items: NotificationListItemTextItemProps[];
   variant?: TextVariant;
   color?: TextColor;
-}
+};
 
 /**
  * A component to render a list of notification item titles

--- a/ui/components/multichain/notification-list-item/notification-list-item.tsx
+++ b/ui/components/multichain/notification-list-item/notification-list-item.tsx
@@ -19,7 +19,7 @@ import { NotificationListItemIcon } from '../notification-list-item-icon';
 import { NotificationListItemText } from '../notification-list-item-text';
 import { formatMenuItemDate } from '../../../helpers/utils/notification.util';
 
-export interface NotificationListItemProps {
+export type NotificationListItemProps = {
   id: string;
   isRead: boolean;
   icon: NotificationListItemIconProps;
@@ -27,7 +27,7 @@ export interface NotificationListItemProps {
   description: NotificationListItemTextProps;
   createdAt: Date;
   amount?: string;
-}
+};
 
 /**
  * `NotificationListItem` is a component that displays a single notification item.

--- a/ui/components/multichain/notification-list-snap-button/notification-list-snap-button.tsx
+++ b/ui/components/multichain/notification-list-snap-button/notification-list-snap-button.tsx
@@ -3,10 +3,10 @@ import React, { FC } from 'react';
 import { Button, ButtonVariant, IconName } from '../../component-library';
 import { BlockSize } from '../../../helpers/constants/design-system';
 
-export interface NotificationListSnapButtonProps {
+export type NotificationListSnapButtonProps = {
   onClick: () => void;
   text: string;
-}
+};
 
 export const NotificationListSnapButton: FC<
   NotificationListSnapButtonProps

--- a/ui/components/multichain/pages/connections/components/connections.types.tsx
+++ b/ui/components/multichain/pages/connections/components/connections.types.tsx
@@ -1,24 +1,24 @@
 import { type InternalAccount } from '@metamask/keyring-api';
 
 // Define ConnectedSite interface
-export interface ConnectedSite {
+export type ConnectedSite = {
   iconUrl: string;
   name: string;
   origin: string;
   subjectType: string;
   extensionId: string | null;
   // Add other properties as needed
-}
+};
 
 // Define ConnectedSites interface
-export interface ConnectedSites {
+export type ConnectedSites = {
   [address: string]: ConnectedSite[]; // Index signature
-}
+};
 
 // Define KeyringType interface
-export interface KeyringType {
+export type KeyringType = {
   type: string;
-}
+};
 
 // Define AccountType interface
 export type AccountType = InternalAccount & {

--- a/ui/components/multichain/pages/page/components/content/content.tsx
+++ b/ui/components/multichain/pages/page/components/content/content.tsx
@@ -8,6 +8,9 @@ import {
 } from '../../../../../../helpers/constants/design-system';
 import type { StyleUtilityProps } from '../../../../../component-library/box';
 
+// This interface was created before this ESLint rule was added.
+// Convert to a `type` in a future major version.
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 interface ContentProps extends StyleUtilityProps {
   /**
    * Elements that go in the page content section

--- a/ui/components/multichain/pages/page/components/content/content.tsx
+++ b/ui/components/multichain/pages/page/components/content/content.tsx
@@ -8,8 +8,7 @@ import {
 } from '../../../../../../helpers/constants/design-system';
 import type { StyleUtilityProps } from '../../../../../component-library/box';
 
-// This interface was created before this ESLint rule was added.
-// Convert to a `type` in a future major version.
+// TODO: Convert to a `type` in a future major version.
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 interface ContentProps extends StyleUtilityProps {
   /**

--- a/ui/components/multichain/pages/page/components/footer/footer.tsx
+++ b/ui/components/multichain/pages/page/components/footer/footer.tsx
@@ -8,8 +8,7 @@ import {
 
 import type { StyleUtilityProps } from '../../../../../component-library/box';
 
-// This interface was created before this ESLint rule was added.
-// Convert to a `type` in a future major version.
+// TODO: Convert to a `type` in a future major version.
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 interface FooterProps extends StyleUtilityProps {
   /**

--- a/ui/components/multichain/pages/page/components/footer/footer.tsx
+++ b/ui/components/multichain/pages/page/components/footer/footer.tsx
@@ -8,6 +8,9 @@ import {
 
 import type { StyleUtilityProps } from '../../../../../component-library/box';
 
+// This interface was created before this ESLint rule was added.
+// Convert to a `type` in a future major version.
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 interface FooterProps extends StyleUtilityProps {
   /**
    * Elements that go in the page footer

--- a/ui/components/multichain/pages/page/components/header/header.tsx
+++ b/ui/components/multichain/pages/page/components/header/header.tsx
@@ -10,6 +10,9 @@ import {
 
 import type { StyleUtilityProps } from '../../../../../component-library/box';
 
+// This interface was created before this ESLint rule was added.
+// Convert to a `type` in a future major version.
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 interface HeaderProps extends StyleUtilityProps {
   /**
    * Elements that go in the page footer

--- a/ui/components/multichain/pages/page/components/header/header.tsx
+++ b/ui/components/multichain/pages/page/components/header/header.tsx
@@ -10,8 +10,7 @@ import {
 
 import type { StyleUtilityProps } from '../../../../../component-library/box';
 
-// This interface was created before this ESLint rule was added.
-// Convert to a `type` in a future major version.
+// TODO: Convert to a `type` in a future major version.
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 interface HeaderProps extends StyleUtilityProps {
   /**

--- a/ui/components/multichain/pages/page/page.tsx
+++ b/ui/components/multichain/pages/page/page.tsx
@@ -12,8 +12,7 @@ import {
 
 import type { StyleUtilityProps } from '../../../component-library/box';
 
-// This interface was created before this ESLint rule was added.
-// Convert to a `type` in a future major version.
+// TODO: Convert to a `type` in a future major version.
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 interface PageProps extends StyleUtilityProps {
   /**

--- a/ui/components/multichain/pages/page/page.tsx
+++ b/ui/components/multichain/pages/page/page.tsx
@@ -12,6 +12,9 @@ import {
 
 import type { StyleUtilityProps } from '../../../component-library/box';
 
+// This interface was created before this ESLint rule was added.
+// Convert to a `type` in a future major version.
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 interface PageProps extends StyleUtilityProps {
   /**
    * Elements that go in the page footer

--- a/ui/components/ui/box/box.d.ts
+++ b/ui/components/ui/box/box.d.ts
@@ -186,8 +186,7 @@ export type BackgroundColorArray = [
  *
  * Help to migrate this component by submitting a PR
  */
-// This interface was created before this ESLint rule was added.
-// Convert to a `type` in a future major version.
+// TODO: Convert to a `type` in a future major version.
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export interface BoxProps extends React.HTMLAttributes<HTMLElement> {
   /**

--- a/ui/components/ui/box/box.d.ts
+++ b/ui/components/ui/box/box.d.ts
@@ -186,6 +186,9 @@ export type BackgroundColorArray = [
  *
  * Help to migrate this component by submitting a PR
  */
+// This interface was created before this ESLint rule was added.
+// Convert to a `type` in a future major version.
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export interface BoxProps extends React.HTMLAttributes<HTMLElement> {
   /**
    * The content of the Box component.

--- a/ui/components/ui/form-combo-field/form-combo-field.tsx
+++ b/ui/components/ui/form-combo-field/form-combo-field.tsx
@@ -13,13 +13,13 @@ import { FormTextField } from '../../component-library/form-text-field/deprecate
 import { I18nContext } from '../../../contexts/i18n';
 import { Display, IconColor } from '../../../helpers/constants/design-system';
 
-export interface FormComboFieldOption {
+export type FormComboFieldOption = {
   value: string;
   primaryLabel?: string;
   secondaryLabel?: string;
-}
+};
 
-export interface FormComboFieldProps<Option extends FormComboFieldOption> {
+export type FormComboFieldProps<Option extends FormComboFieldOption> = {
   /** Whether to hide the 'no option' when there are no options to display. */
   hideDropdownIfNoOptions?: boolean;
 
@@ -45,7 +45,7 @@ export interface FormComboFieldProps<Option extends FormComboFieldOption> {
 
   /** The value to display in the field. */
   value: string;
-}
+};
 
 function Option({
   option,

--- a/ui/ducks/app/app.ts
+++ b/ui/ducks/app/app.ts
@@ -6,7 +6,7 @@ import {
 } from '../../../shared/constants/hardware-wallets';
 import * as actionConstants from '../../store/actionConstants';
 
-interface AppState {
+type AppState = {
   shouldClose: boolean;
   menuOpen: boolean;
   modal: {
@@ -84,11 +84,11 @@ interface AppState {
   ///: BEGIN:ONLY_INCLUDE_IF(snaps)
   snapsInstallPrivacyWarningShown: boolean;
   ///: END:ONLY_INCLUDE_IF
-}
+};
 
-interface AppSliceState {
+type AppSliceState = {
   appState: AppState;
-}
+};
 
 // default state
 const initialState: AppState = {

--- a/ui/hooks/experiences/useRamps.ts
+++ b/ui/hooks/experiences/useRamps.ts
@@ -4,10 +4,10 @@ import type { Hex } from '@metamask/utils';
 import { ChainId } from '../../../shared/constants/network';
 import { getCurrentChainId, getMetaMetricsId } from '../../selectors';
 
-interface IUseRamps {
+type IUseRamps = {
   openBuyCryptoInPdapp: VoidFunction;
   getBuyURI: (chainId: ChainId) => string;
-}
+};
 
 const portfolioUrl = process.env.PORTFOLIO_URL;
 

--- a/ui/hooks/useModalProps.ts
+++ b/ui/hooks/useModalProps.ts
@@ -1,10 +1,10 @@
 import { useSelector, useDispatch } from 'react-redux';
 import { hideModal } from '../store/actions';
 
-interface ModalProps {
+type ModalProps = {
   props: Record<string, any>;
   hideModal: () => void;
-}
+};
 
 export function useModalProps(): ModalProps {
   const modalProps = useSelector((state: any) => {

--- a/ui/pages/create-snap-account/create-snap-account.tsx
+++ b/ui/pages/create-snap-account/create-snap-account.tsx
@@ -22,10 +22,10 @@ import {
 import SnapAuthorshipHeader from '../../components/app/snaps/snap-authorship-header';
 import { useI18nContext } from '../../hooks/useI18nContext';
 
-export interface CreateSnapAccountProps {
+export type CreateSnapAccountProps = {
   snapId: string;
   snapName: string;
-}
+};
 
 const CreateSnapAccount = ({ snapId, snapName }: CreateSnapAccountProps) => {
   const t = useI18nContext();

--- a/ui/pages/remove-snap-account/remove-snap-account.tsx
+++ b/ui/pages/remove-snap-account/remove-snap-account.tsx
@@ -23,11 +23,11 @@ import { useI18nContext } from '../../hooks/useI18nContext';
 import SnapAuthorshipHeader from '../../components/app/snaps/snap-authorship-header';
 import { SnapAccountCard } from './snap-account-card';
 
-export interface RemoveSnapAccountProps {
+export type RemoveSnapAccountProps = {
   snapId: string;
   snapName: string;
   publicAddress: string;
-}
+};
 
 const RemoveSnapAccount = ({
   snapId,

--- a/ui/pages/settings/deprecated-network-modal/DeprecatedNetworkModal.tsx
+++ b/ui/pages/settings/deprecated-network-modal/DeprecatedNetworkModal.tsx
@@ -20,9 +20,9 @@ import {
 } from '../../../helpers/constants/design-system';
 import ZENDESK_URLS from '../../../helpers/constants/zendesk-url';
 
-interface DeprecatedNetworkModalProps {
+type DeprecatedNetworkModalProps = {
   onClose: () => void;
-}
+};
 
 export const DeprecatedNetworkModal = ({
   onClose,

--- a/ui/pages/snap-account-redirect/components/redirect-url-icon.tsx
+++ b/ui/pages/snap-account-redirect/components/redirect-url-icon.tsx
@@ -6,10 +6,10 @@ import {
 } from '../../../components/component-library';
 import { IconColor } from '../../../helpers/constants/design-system';
 
-interface RedirectUrlIconProps {
+type RedirectUrlIconProps = {
   url: string;
   onSubmit?: () => void;
-}
+};
 
 const RedirectUrlIcon = ({ url, onSubmit }: RedirectUrlIconProps) => {
   return (

--- a/ui/pages/snap-account-redirect/snap-account-redirect.tsx
+++ b/ui/pages/snap-account-redirect/snap-account-redirect.tsx
@@ -10,14 +10,14 @@ import {
 import SnapAuthorshipHeader from '../../components/app/snaps/snap-authorship-header';
 import { SnapAccountRedirectContent } from './components';
 
-export interface SnapAccountRedirectProps {
+export type SnapAccountRedirectProps = {
   url: string;
   snapId: string;
   snapName: string;
   isBlockedUrl: boolean;
   message: string;
   onSubmit?: () => void;
-}
+};
 
 const SnapAccountRedirect = ({
   url,

--- a/ui/pages/swaps/prepare-swap-page/slippage-notification-modal.tsx
+++ b/ui/pages/swaps/prepare-swap-page/slippage-notification-modal.tsx
@@ -21,13 +21,13 @@ import {
 } from '../../../../shared/constants/swaps';
 import SwapsBannerAlert from '../swaps-banner-alert/swaps-banner-alert';
 
-interface Props {
+type Props = {
   isOpen: boolean;
   slippageErrorKey: string;
   setSlippageNotificationModalOpened: (isOpen: boolean) => void;
   onSwapSubmit: (opts: { acknowledgedSlippage: boolean }) => void;
   currentSlippage: number;
-}
+};
 
 export default function SlippageNotificationModal({
   isOpen,

--- a/ui/pages/swaps/prepare-swap-page/smart-transactions-popover.tsx
+++ b/ui/pages/swaps/prepare-swap-page/smart-transactions-popover.tsx
@@ -24,11 +24,11 @@ import { ModalContent } from '../../../components/component-library/modal-conten
 import { ModalHeader } from '../../../components/component-library/modal-header/deprecated';
 import { SMART_SWAPS_FAQ_AND_RISK_DISCLOSURES_URL } from '../../../../shared/constants/swaps';
 
-interface Props {
+type Props = {
   onStartSwapping: () => void;
   onManageStxInSettings: () => void;
   isOpen: boolean;
-}
+};
 
 export default function SmartTransactionsPopover({
   onStartSwapping,

--- a/ui/pages/swaps/swaps.util.ts
+++ b/ui/pages/swaps/swaps.util.ts
@@ -49,11 +49,11 @@ const USD_CURRENCY_CODE = 'usd';
 
 const clientIdHeader = { 'X-Client-Id': SWAPS_CLIENT_ID };
 
-interface Validator {
+type Validator = {
   property: string;
   type: string;
   validator: (a: string) => boolean;
-}
+};
 
 const TOKEN_VALIDATORS: Validator[] = [
   {

--- a/ui/store/actions.ts
+++ b/ui/store/actions.ts
@@ -2621,13 +2621,13 @@ export function hideDeprecatedNetworkModal(): Action {
 /**
  * TODO: this should be moved somewhere else when it makese sense to do so
  */
-interface NftDropDownState {
+type NftDropDownState = {
   [address: string]: {
     [chainId: string]: {
       [nftAddress: string]: boolean;
     };
   };
-}
+};
 
 export function updateNftDropDownState(
   value: NftDropDownState,
@@ -2638,12 +2638,12 @@ export function updateNftDropDownState(
   };
 }
 
-interface QrCodeData {
+type QrCodeData = {
   // Address when a Ethereum Address has been detected
   type?: 'address' | string;
   // contains an address key when Ethereum Address detected
   values?: { address?: string } & Json;
-}
+};
 
 /**
  * This action will receive two types of values via qrCodeData
@@ -2861,12 +2861,12 @@ export function showSendTokenPage(): Action {
 }
 
 // TODO: Lift to shared folder when it makes sense
-interface TemporaryFeatureFlagDef {
+type TemporaryFeatureFlagDef = {
   [feature: string]: boolean;
-}
-interface TemporaryPreferenceFlagDef {
+};
+type TemporaryPreferenceFlagDef = {
   [preference: string]: boolean | object;
-}
+};
 
 export function setFeatureFlag(
   feature: string,
@@ -4461,12 +4461,12 @@ export function fetchSmartTransactionFees(
   };
 }
 
-interface TemporarySmartTransactionGasFees {
+type TemporarySmartTransactionGasFees = {
   maxFeePerGas: string;
   maxPriorityFeePerGas: string;
   gas: string;
   value: string;
-}
+};
 
 const createSignedTransactions = async (
   unsignedTransaction: Partial<TransactionParams> & { chainId: string },

--- a/ui/store/store.ts
+++ b/ui/store/store.ts
@@ -17,7 +17,7 @@ import type { NetworkStatus } from '../../shared/constants/network';
  *
  * TODO: Replace this
  */
-export interface TemporaryMessageDataType {
+export type TemporaryMessageDataType = {
   id: string;
   type: string;
   msgParams: {
@@ -30,11 +30,11 @@ export interface TemporaryMessageDataType {
   };
   status?: string;
   ///: END:ONLY_INCLUDE_IF
-}
+};
 
-export interface MessagesIndexedById {
+export type MessagesIndexedById = {
   [id: string]: TemporaryMessageDataType;
-}
+};
 
 /**
  * This interface is a temporary interface to describe the state tree that is
@@ -45,7 +45,7 @@ export interface MessagesIndexedById {
  * state received from the background takes precedence over anything in the
  * metamask reducer.
  */
-interface TemporaryBackgroundState {
+type TemporaryBackgroundState = {
   addressBook: {
     [chainId: string]: {
       name: string;
@@ -89,7 +89,7 @@ interface TemporaryBackgroundState {
     };
     selectedAccount: string;
   };
-}
+};
 
 type RootReducerReturnType = ReturnType<typeof rootReducer>;
 


### PR DESCRIPTION
## **Description**

### Motivation

`interface` usage is banned in MetaMask codebases. With TypeScript conversion efforts in progress, it's time to enforce `type` usage over `interface` in the extension codebase as well, especially for new contributions in TypeScript. 

There are a few reasons for banning `interface`:
- Interfaces do not extend `Record` or have a `string` index signature by default, making them incompatible with the data/state objects we use.
- The feature set of type aliases is a strict superset of that of interfaces (including `extends`, `implements`).
  - Declaration merging is an exception, but this is not a practice we want to encourage.

For more context, see these links for previous discussions on this topic:
- https://github.com/MetaMask/eslint-config/pull/216
- https://github.com/MetaMask/core/pull/1933

### Explanation

The `@typescript-eslint/consistent-type-definitions` has been configured with the `["error", "type"]` options, which will prevent the `interface` keyword from being introduced into the codebase in the future.

Existing instances of `interface` usage in the codebase were converted to type alias definitions. 

For the following exceptions, the `interface` keyword was preserved with a `eslint-disable` directive, and a TODO comment was added for future conversion.

1. If the `interface` is declared with an `extends` keyword.
  - This is because of possible type accuracy issues with the eslint autofix appending the extending interface as an intersection (`&`).
2. If the `interface` is used for declaration merging. 
  - This is the only use case for interfaces that is not supported by type aliases, and is therefore a valid exception to the ESLint rule.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/23439?quickstart=1)

## **Related issues**

- Closes https://github.com/MetaMask/metamask-extension/issues/23442

## **Manual testing steps**

## **Screenshots/Recordings**

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained what problem this PR is solving and how it is solved.
- [x] I've linked related issues
- [ ] I've included manual testing steps
- [ ] I've included screenshots/recordings if applicable
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [x] I’ve properly set the pull request status:
  - [x] In case it's not yet "ready for review", I've set it to "draft".
  - [x] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
