### PR TITLE
test: set `snap-account-abstraction-keyring` to a fixed version

### DIFF
--- a/test/e2e/constants.ts
+++ b/test/e2e/constants.ts
@@ -20,7 +20,7 @@ export const BUNDLER_URL = 'http://localhost:3000/rpc';
 
 /* URL of the 4337 account snap site. */
 export const ERC_4337_ACCOUNT_SNAP_URL =
-  'https://metamask.github.io/snap-account-abstraction-keyring/latest/';
+  'https://metamask.github.io/snap-account-abstraction-keyring/0.2.2/';
 
 /* Salt used to generate the 4337 account. */
 export const ERC_4337_ACCOUNT_SALT = '0x1';


### PR DESCRIPTION
## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Set the version of the `snap-account-abstraction-keyring` to 0.2.2 instead of pointing to the latest version. This change is required to avoid breaking the CI in case a new version of the snap is not compatible with the current state of the E2E tests. 

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/23440?quickstart=1)

## **Related issues**

No related issue

## **Manual testing steps**

No manual test required.

## **Screenshots/Recordings**

Not applicable

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained what problem this PR is solving and how it is solved.
- [x] I've linked related issues
- [x] I've included manual testing steps
- [x] I've included screenshots/recordings if applicable
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [x] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
