### PR TITLE
fix: improve hww import copy

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -4107,7 +4107,7 @@
     "message": "Turn on NFT detection in Settings"
   },
   "selectPathHelp": {
-    "message": "If you don't see the accounts you expect, try switching the HD path."
+    "message": "If you don't see the accounts you expect, try switching the HD path or current selected network in the top left menu."
   },
   "selectType": {
     "message": "Select Type"

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -4107,7 +4107,7 @@
     "message": "Turn on NFT detection in Settings"
   },
   "selectPathHelp": {
-    "message": "If you don't see the accounts you expect, try switching the HD path or current selected network in the top left menu."
+    "message": "If you don't see the accounts you expect, try switching the HD path or current selected network."
   },
   "selectType": {
     "message": "Select Type"


### PR DESCRIPTION
Weird experience report: When importing an account with a "not my usual" network selected, (Linea, this time), it'll show all the hardware wallet's accounts as empty if they're empty on that network, which can be briefly alarming.

One simple mitigation: Expand the copy to include "or try switching the network (in the top left menu)" (done in this PR).
