### PR TITLE
fix: remove banner in account list menu component

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -159,9 +159,6 @@
   "accountsConnected": {
     "message": "Accounts connected"
   },
-  "accountsPinningBannerDescription": {
-    "message": "Keep tabs on what matters by pinning or hiding accounts"
-  },
   "active": {
     "message": "Active"
   },

--- a/ui/components/multichain/account-list-menu/account-list-menu.js
+++ b/ui/components/multichain/account-list-menu/account-list-menu.js
@@ -358,27 +358,6 @@ export const AccountListMenu = ({
                 />
               </Box>
             ) : null}
-            {/* Accounts Pinning Update Banner */}
-            {showBanner ? (
-              <BannerBase
-                className="network-list-menu__banner"
-                marginLeft={4}
-                marginRight={4}
-                backgroundColor={BackgroundColor.backgroundAlternative}
-                startAccessory={
-                  <Box
-                    display={Display.Flex}
-                    alignItems={AlignItems.center}
-                    justifyContent={JustifyContent.center}
-                  >
-                    <img src="./images/pinning-animation.svg" alt="pinning" />
-                  </Box>
-                }
-                onClose={() => hideAccountBanner()}
-                description={t('accountsPinningBannerDescription')}
-                marginBottom={4}
-              />
-            ) : null}
             {/* Account list block */}
             <Box className="multichain-account-menu-popover__list">
               {searchResults.length === 0 && searchQuery !== '' ? (

--- a/ui/components/multichain/account-list-menu/account-list-menu.js
+++ b/ui/components/multichain/account-list-menu/account-list-menu.js
@@ -4,7 +4,6 @@ import { useHistory } from 'react-router-dom';
 import Fuse from 'fuse.js';
 import { useDispatch, useSelector } from 'react-redux';
 import {
-  BannerBase,
   Box,
   ButtonLink,
   ButtonSecondary,
@@ -26,11 +25,9 @@ import {
 } from '..';
 import {
   AlignItems,
-  BackgroundColor,
   BlockSize,
   Display,
   FlexDirection,
-  JustifyContent,
   Size,
   TextColor,
 } from '../../../helpers/constants/design-system';
@@ -46,10 +43,8 @@ import {
   ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
   getIsAddSnapAccountEnabled,
   ///: END:ONLY_INCLUDE_IF
-  getOnboardedInThisUISession,
-  getShowAccountBanner,
 } from '../../../selectors';
-import { hideAccountBanner, setSelectedAccount } from '../../../store/actions';
+import { setSelectedAccount } from '../../../store/actions';
 import {
   MetaMetricsEventAccountType,
   MetaMetricsEventCategory,
@@ -64,7 +59,6 @@ import {
 import { getEnvironmentType } from '../../../../app/scripts/lib/util';
 import { ENVIRONMENT_TYPE_POPUP } from '../../../../shared/constants/app';
 import { getAccountLabel } from '../../../helpers/utils/accounts';
-import { getCompletedOnboarding } from '../../../ducks/metamask/metamask';
 import { HiddenAccountList } from './hidden-account-list';
 
 const ACTION_MODES = {
@@ -126,11 +120,6 @@ export const AccountListMenu = ({
 
   const [searchQuery, setSearchQuery] = useState('');
   const [actionMode, setActionMode] = useState(ACTION_MODES.LIST);
-  const completedOnboarding = useSelector(getCompletedOnboarding);
-  const onboardedInThisUISession = useSelector(getOnboardedInThisUISession);
-  const showAccountBanner = useSelector(getShowAccountBanner);
-  const showBanner =
-    completedOnboarding && !onboardedInThisUISession && showAccountBanner;
 
   let searchResults = updatedAccountsList;
   if (searchQuery) {


### PR DESCRIPTION
## **Description**

This pull request removes the banner that was previously displayed in the AccountListMenu component.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/23447?quickstart=1)

## **Related issues**

Fixes: [23321](https://github.com/MetaMask/metamask-extension/issues/23321)

## **Manual testing steps**

1. Go to the account dropdown.
2. See that the banner is now gone.

## **Screenshots/Recordings**

### **Before**
![Screenshot 2024-03-13 at 21 07 08](https://github.com/MetaMask/metamask-extension/assets/96463427/50b18fee-ff72-48a7-bd87-010748561614)

### **After**
![Screenshot 2024-03-13 at 21 04 26](https://github.com/MetaMask/metamask-extension/assets/96463427/09c5ba24-7ecd-4fc1-a73e-f5c8b8548167)

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained what problem this PR is solving and how it is solved.
- [x] I've linked related issues
- [x] I've included manual testing steps
- [ ] I've included screenshots/recordings if applicable
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [ ] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
