### PR TITLE
ci: Update validate-conventional-commits.yml

### DIFF
--- a/.github/workflows/validate-conventional-commits.yml
+++ b/.github/workflows/validate-conventional-commits.yml
@@ -1,6 +1,8 @@
 name: Validate Conventional Commit Title
 on:
   pull_request:
+    branches:
+      - develop
     types: [opened, edited, reopened]
 
 jobs:


### PR DESCRIPTION
Currently we are validating the PR title of PRs made against release branches and master, but this breaks our release branching and PR processes. For release candidate PRs, we don't want a conventional commit title. This PR updates the conventional commit validation workflow. As a result of this PR, we now follow the same approach as mobile https://github.com/MetaMask/metamask-mobile/blob/ef5febdc0964884352486b91b2cfe0e11f3fda29/.github/workflows/pr-title-linter.yml