### PR TITLE
chore: bump `@metamask/test-dapp` to `^8.3.0`

### DIFF
--- a/package.json
+++ b/package.json
@@ -409,7 +409,7 @@
     "@metamask/forwarder": "^1.1.0",
     "@metamask/phishing-warning": "^3.0.3",
     "@metamask/test-bundler": "^1.0.0",
-    "@metamask/test-dapp": "^8.2.0",
+    "@metamask/test-dapp": "^8.3.0",
     "@playwright/test": "^1.39.0",
     "@sentry/cli": "^2.19.4",
     "@storybook/addon-a11y": "^7.4.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5454,10 +5454,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/test-dapp@npm:^8.2.0":
-  version: 8.2.0
-  resolution: "@metamask/test-dapp@npm:8.2.0"
-  checksum: e2359cac8379682542ec53792037438eede1f30711915bb918d655a2e9d51afcaeabe01665a9bf31b41bfc1a7d05ec86e82dcf4e5a09a2df9b3d7156778f2f98
+"@metamask/test-dapp@npm:^8.3.0":
+  version: 8.3.0
+  resolution: "@metamask/test-dapp@npm:8.3.0"
+  checksum: 57fe2d164b01d5bc732121bec1ef135bf66a054f6d38d826fc8bc35b224d6f3070f44f06371a978fad9c29a83d42e67762f60a50bce9be5ff9e7c83aaae71b32
   languageName: node
   linkType: hard
 
@@ -24892,7 +24892,7 @@ __metadata:
     "@metamask/snaps-sdk": "npm:^3.1.1"
     "@metamask/snaps-utils": "npm:^7.0.3"
     "@metamask/test-bundler": "npm:^1.0.0"
-    "@metamask/test-dapp": "npm:^8.2.0"
+    "@metamask/test-dapp": "npm:^8.3.0"
     "@metamask/transaction-controller": "npm:^23.1.0"
     "@metamask/user-operation-controller": "npm:^4.0.0"
     "@metamask/utils": "npm:^8.2.1"


### PR DESCRIPTION
## **Description**

Bumps the test dapp version to fix a broken e2e test with the new provider v16.0.0 version being adopted [here](https://github.com/MetaMask/metamask-extension/pull/23375) 

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/23463?quickstart=1)

## **Related issues**

See: https://github.com/MetaMask/test-dapp/pull/301
See: https://github.com/MetaMask/metamask-extension/pull/23375

## **Manual testing steps**

No user facing changes

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained what problem this PR is solving and how it is solved.
- [x] I've linked related issues
- [ ] I've included manual testing steps
- [ ] I've included screenshots/recordings if applicable
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [x] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [x] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
