### PR TITLE
ci: fix "Open in GitHub Codespaces" on forked repos

### DIFF
--- a/.github/workflows/codespaces-update-badge.yml
+++ b/.github/workflows/codespaces-update-badge.yml
@@ -13,6 +13,7 @@ jobs:
     permissions:
       pull-requests: write
     env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       PR_NUMBER: ${{ github.event.pull_request.number }}
 
       # This use of an ENV variable is necessary to avoid an injection attack, see:

--- a/.github/workflows/codespaces-update-badge.yml
+++ b/.github/workflows/codespaces-update-badge.yml
@@ -1,0 +1,31 @@
+name: Codespaces
+
+on:
+  pull_request_target:
+    types: [opened, reopened]
+
+jobs:
+  codespaces-update-badge:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+
+      # This use of an ENV variable is necessary to avoid an injection attack, see:
+      # https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions
+      BODY: ${{ github.event.pull_request.body }}
+
+    steps:
+      - name: Replace the text in the Codespaces badge with the PR number
+        run: |
+          #!/bin/bash
+
+          # Bash replace syntax
+          NEW_BODY="${BODY/PR?quickstart=1/$PR_NUMBER?quickstart=1}"
+
+          # If the body has changed as a result of the replace, use the GitHub API to update the PR
+          if [ "$NEW_BODY" != "$BODY" ]; then
+            gh api /repos/MetaMask/metamask-extension/pulls/${{github.event.pull_request.number}} -f body="$NEW_BODY"
+          fi

--- a/.github/workflows/codespaces-update-badge.yml
+++ b/.github/workflows/codespaces-update-badge.yml
@@ -1,11 +1,6 @@
 name: Codespaces
 
 on:
-  pull_request:
-    types:
-      - edited
-      - opened
-      - reopened
   pull_request_target:
     types:
       - edited

--- a/.github/workflows/codespaces-update-badge.yml
+++ b/.github/workflows/codespaces-update-badge.yml
@@ -13,7 +13,6 @@ jobs:
     permissions:
       pull-requests: write
     env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       PR_NUMBER: ${{ github.event.pull_request.number }}
 
       # This use of an ENV variable is necessary to avoid an injection attack, see:

--- a/.github/workflows/codespaces-update-badge.yml
+++ b/.github/workflows/codespaces-update-badge.yml
@@ -1,6 +1,8 @@
 name: Codespaces
 
 on:
+  pull_request:
+    types: [opened, reopened]
   pull_request_target:
     types: [opened, reopened]
 

--- a/.github/workflows/codespaces-update-badge.yml
+++ b/.github/workflows/codespaces-update-badge.yml
@@ -2,9 +2,15 @@ name: Codespaces
 
 on:
   pull_request:
-    types: [opened, reopened]
+    types:
+      - edited
+      - opened
+      - reopened
   pull_request_target:
-    types: [opened, reopened]
+    types:
+      - edited
+      - opened
+      - reopened
 
 jobs:
   codespaces-update-badge:

--- a/.github/workflows/fitness-functions.yml
+++ b/.github/workflows/fitness-functions.yml
@@ -33,28 +33,3 @@ jobs:
           # then saved to a file called "diff".
           git diff "$(git merge-base "origin/$BASE_REF" HEAD)" HEAD -- . > ./diff
           npm run fitness-functions -- "ci" "./diff"
-
-  update-codespaces-badge:
-    runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
-    env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      PR_NUMBER: ${{ github.event.pull_request.number }}
-
-      # This use of an ENV variable is neccessary to avoid an injection attack, see:
-      # https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions
-      BODY: ${{ github.event.pull_request.body }}
-
-    steps:
-      - name: Replace the text in the Codespaces badge with the PR number
-        run: |
-          #!/bin/bash
-
-          # Bash replace syntax
-          NEW_BODY="${BODY/PR?quickstart=1/$PR_NUMBER?quickstart=1}"
-
-          # If the body has changed as a result of the replace, use the GitHub API to update the PR
-          if [ "$NEW_BODY" != "$BODY" ]; then
-            gh api /repos/MetaMask/metamask-extension/pulls/${{github.event.pull_request.number}} -f body="$NEW_BODY"
-          fi


### PR DESCRIPTION
## **Description**

@plasmacorral noticed that the "Open in GitHub Codespaces" badge is broken on forked repositories.  This is because the bot doesn't have proper permissions.

[Discussion on stack overflow](https://stackoverflow.com/questions/75744849/permission-to-repo-denied-to-github-actions-for-pr-coming-from-a-fork-only)

This was previously sharing a GitHub Action with Fitness Functions, but now it can't because it has to trigger on `pull_request_target`, so it moved to a separate Action.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/23477?quickstart=1)

## **Related issues**
## **Manual testing steps**
This can be seen working on a PR targeting this as base (which is how pull_request_target works): https://github.com/MetaMask/metamask-extension/pull/23478
## **Screenshots/Recordings**
## **Pre-merge author checklist**
## **Pre-merge reviewer checklist**