### PR TITLE
fix: stop updating registry if user only has preinstalled Snaps

### DIFF
--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -910,8 +910,8 @@ export function setupController(
   ///: END:ONLY_INCLUDE_IF
 
   ///: BEGIN:ONLY_INCLUDE_IF(snaps)
-  // Updates the snaps registry and check for newly blocked snaps to block if the user has at least one snap installed.
-  if (Object.keys(controller.snapController.state.snaps).length > 0) {
+  // Updates the snaps registry and check for newly blocked snaps to block if the user has at least one snap installed that isn't preinstalled.
+  if (Object.values(controller.snapController.state.snaps).filter(snap => !snap.preinstalled).length > 0) {
     controller.snapController.updateBlockedSnaps();
   }
   ///: END:ONLY_INCLUDE_IF

--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -911,7 +911,11 @@ export function setupController(
 
   ///: BEGIN:ONLY_INCLUDE_IF(snaps)
   // Updates the snaps registry and check for newly blocked snaps to block if the user has at least one snap installed that isn't preinstalled.
-  if (Object.values(controller.snapController.state.snaps).filter(snap => !snap.preinstalled).length > 0) {
+  if (
+    Object.values(controller.snapController.state.snaps).filter(
+      (snap) => !snap.preinstalled,
+    ).length > 0
+  ) {
     controller.snapController.updateBlockedSnaps();
   }
   ///: END:ONLY_INCLUDE_IF

--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -912,9 +912,9 @@ export function setupController(
   ///: BEGIN:ONLY_INCLUDE_IF(snaps)
   // Updates the snaps registry and check for newly blocked snaps to block if the user has at least one snap installed that isn't preinstalled.
   if (
-    Object.values(controller.snapController.state.snaps).filter(
+    Object.values(controller.snapController.state.snaps).some(
       (snap) => !snap.preinstalled,
-    ).length > 0
+    )
   ) {
     controller.snapController.updateBlockedSnaps();
   }


### PR DESCRIPTION
## **Description**

Stops updating registry if the user only has preinstalled Snaps. Otherwise every MetaMask instance would start fetching the registry unnecessarily once we start using preinstalled Snaps. We can wait with using the registry until the user has started to use Snaps that they choose to install themselves.