### PR TITLE
chore(ts): Use FirstTimeFlowType enum

### DIFF
--- a/.storybook/test-data.js
+++ b/.storybook/test-data.js
@@ -5,6 +5,7 @@ import { NetworkStatus } from '@metamask/network-controller';
 import { EthAccountType, EthMethod } from '@metamask/keyring-api';
 import { CHAIN_IDS } from '../shared/constants/network';
 import { copyable, divider, heading, panel, text } from '@metamask/snaps-sdk';
+import { FirstTimeFlowType } from '../shared/constants/onboarding';
 
 const state = {
   invalidCustomNetwork: {
@@ -670,7 +671,7 @@ const state = {
       [CHAIN_IDS.OPTIMISM_TESTNET]: false,
       [CHAIN_IDS.AVALANCHE_TESTNET]: true,
     },
-    firstTimeFlowType: 'create',
+    firstTimeFlowType: FirstTimeFlowType.create,
     completedOnboarding: true,
     knownMethodData: {
       '0x60806040': {

--- a/test/e2e/fixture-builder.js
+++ b/test/e2e/fixture-builder.js
@@ -5,6 +5,7 @@ const {
 const { merge } = require('lodash');
 const { toHex } = require('@metamask/controller-utils');
 const { NetworkStatus } = require('@metamask/network-controller');
+const { FirstTimeFlowType } = require('../../shared/constants/onboarding');
 const { CHAIN_IDS, NETWORK_TYPES } = require('../../shared/constants/network');
 const { SMART_CONTRACTS } = require('./seeder/smart-contracts');
 const { DAPP_URL, DAPP_ONE_URL } = require('./helpers');
@@ -145,7 +146,7 @@ function defaultFixture(inputChainId = CHAIN_IDS.LOCALHOST) {
       },
       OnboardingController: {
         completedOnboarding: true,
-        firstTimeFlowType: 'import',
+        firstTimeFlowType: FirstTimeFlowType.import,
         onboardingTabs: {},
         seedPhraseBackedUp: true,
       },

--- a/ui/helpers/constants/onboarding.js
+++ b/ui/helpers/constants/onboarding.js
@@ -1,6 +1,0 @@
-const FIRST_TIME_FLOW_TYPES = {
-  IMPORT: 'import',
-  CREATE: 'create',
-};
-
-export { FIRST_TIME_FLOW_TYPES };

--- a/ui/pages/home/home.component.js
+++ b/ui/pages/home/home.component.js
@@ -14,6 +14,7 @@ import NftsTab from '../../components/app/nfts-tab';
 import TermsOfUsePopup from '../../components/app/terms-of-use-popup';
 import RecoveryPhraseReminder from '../../components/app/recovery-phrase-reminder';
 import WhatsNewPopup from '../../components/app/whats-new-popup';
+import { FirstTimeFlowType } from '../../../shared/constants/onboarding';
 ///: END:ONLY_INCLUDE_IF
 import HomeNotification from '../../components/app/home-notification';
 import MultipleNotifications from '../../components/app/multiple-notifications';
@@ -76,7 +77,6 @@ import {
   ///: END:ONLY_INCLUDE_IF
 } from '../../helpers/constants/routes';
 import ZENDESK_URLS from '../../helpers/constants/zendesk-url';
-import { FirstTimeFlowType } from '../../../shared/constants/onboarding';
 ///: BEGIN:ONLY_INCLUDE_IF(build-main)
 import { SUPPORT_LINK } from '../../../shared/lib/ui-utils';
 ///: END:ONLY_INCLUDE_IF

--- a/ui/pages/home/home.component.js
+++ b/ui/pages/home/home.component.js
@@ -78,6 +78,7 @@ import {
 import ZENDESK_URLS from '../../helpers/constants/zendesk-url';
 ///: BEGIN:ONLY_INCLUDE_IF(build-main)
 import { SUPPORT_LINK } from '../../../shared/lib/ui-utils';
+import { FirstTimeFlowType } from '../../../shared/constants/onboarding';
 ///: END:ONLY_INCLUDE_IF
 ///: BEGIN:ONLY_INCLUDE_IF(build-beta)
 import BetaHomeFooter from './beta/beta-home-footer.component';
@@ -815,7 +816,8 @@ export default class Home extends PureComponent {
     ///: BEGIN:ONLY_INCLUDE_IF(build-main,build-beta,build-flask)
     const showWhatsNew =
       completedOnboarding &&
-      (!onboardedInThisUISession || firstTimeFlowType === 'import') &&
+      (!onboardedInThisUISession ||
+        firstTimeFlowType === FirstTimeFlowType.import) &&
       announcementsToShow &&
       showWhatsNewPopup &&
       !process.env.IN_TEST &&

--- a/ui/pages/home/home.component.js
+++ b/ui/pages/home/home.component.js
@@ -76,9 +76,9 @@ import {
   ///: END:ONLY_INCLUDE_IF
 } from '../../helpers/constants/routes';
 import ZENDESK_URLS from '../../helpers/constants/zendesk-url';
+import { FirstTimeFlowType } from '../../../shared/constants/onboarding';
 ///: BEGIN:ONLY_INCLUDE_IF(build-main)
 import { SUPPORT_LINK } from '../../../shared/lib/ui-utils';
-import { FirstTimeFlowType } from '../../../shared/constants/onboarding';
 ///: END:ONLY_INCLUDE_IF
 ///: BEGIN:ONLY_INCLUDE_IF(build-beta)
 import BetaHomeFooter from './beta/beta-home-footer.component';

--- a/ui/pages/onboarding-flow/create-password/create-password.js
+++ b/ui/pages/onboarding-flow/create-password/create-password.js
@@ -39,7 +39,6 @@ import {
   getCurrentKeyring,
   getMetaMetricsId,
 } from '../../../selectors';
-import { FIRST_TIME_FLOW_TYPES } from '../../../helpers/constants/onboarding';
 import { MetaMetricsContext } from '../../../contexts/metametrics';
 import {
   MetaMetricsEventCategory,
@@ -52,6 +51,7 @@ import {
   IconName,
   Text,
 } from '../../../components/component-library';
+import { FirstTimeFlowType } from '../../../../shared/constants/onboarding';
 
 export default function CreatePassword({
   createNewAccount,
@@ -92,7 +92,7 @@ export default function CreatePassword({
 
   useEffect(() => {
     if (currentKeyring) {
-      if (firstTimeFlowType === FIRST_TIME_FLOW_TYPES.IMPORT) {
+      if (firstTimeFlowType === FirstTimeFlowType.import) {
         ///: BEGIN:ONLY_INCLUDE_IF(build-main,build-beta,build-flask)
         history.replace(ONBOARDING_COMPLETION_ROUTE);
         ///: END:ONLY_INCLUDE_IF
@@ -205,7 +205,7 @@ export default function CreatePassword({
     // If secretRecoveryPhrase is defined we are in import wallet flow
     if (
       secretRecoveryPhrase &&
-      firstTimeFlowType === FIRST_TIME_FLOW_TYPES.IMPORT
+      firstTimeFlowType === FirstTimeFlowType.import
     ) {
       await importWithRecoveryPhrase(password, secretRecoveryPhrase);
       ///: BEGIN:ONLY_INCLUDE_IF(build-main,build-beta,build-flask)
@@ -253,7 +253,7 @@ export default function CreatePassword({
       {
         ///: BEGIN:ONLY_INCLUDE_IF(build-main,build-beta,build-flask)
         secretRecoveryPhrase &&
-        firstTimeFlowType === FIRST_TIME_FLOW_TYPES.IMPORT ? (
+        firstTimeFlowType === FirstTimeFlowType.import ? (
           <TwoStepProgressBar
             stage={twoStepStages.PASSWORD_CREATE}
             marginBottom={4}
@@ -374,7 +374,7 @@ export default function CreatePassword({
             <Button
               data-testid={
                 secretRecoveryPhrase &&
-                firstTimeFlowType === FIRST_TIME_FLOW_TYPES.IMPORT
+                firstTimeFlowType === FirstTimeFlowType.import
                   ? 'create-password-import'
                   : 'create-password-wallet'
               }
@@ -385,7 +385,7 @@ export default function CreatePassword({
               onClick={handleCreate}
             >
               {secretRecoveryPhrase &&
-              firstTimeFlowType === FIRST_TIME_FLOW_TYPES.IMPORT
+              firstTimeFlowType === FirstTimeFlowType.import
                 ? t('importMyWallet')
                 : t('createNewWallet')}
             </Button>

--- a/ui/pages/onboarding-flow/create-password/create-password.test.js
+++ b/ui/pages/onboarding-flow/create-password/create-password.test.js
@@ -7,7 +7,7 @@ import {
   ONBOARDING_SECURE_YOUR_WALLET_ROUTE,
   ONBOARDING_COMPLETION_ROUTE,
 } from '../../../helpers/constants/routes';
-import { FIRST_TIME_FLOW_TYPES } from '../../../helpers/constants/onboarding';
+import { FirstTimeFlowType } from '../../../../shared/constants/onboarding';
 import CreatePassword from './create-password';
 
 const mockHistoryPush = jest.fn();
@@ -338,7 +338,7 @@ describe('Onboarding Create Password', () => {
       ...mockState,
       metamask: {
         ...mockState.metamask,
-        firstTimeFlowType: FIRST_TIME_FLOW_TYPES.IMPORT,
+        firstTimeFlowType: FirstTimeFlowType.import,
       },
     };
 

--- a/ui/pages/onboarding-flow/create-password/create-password.test.js
+++ b/ui/pages/onboarding-flow/create-password/create-password.test.js
@@ -55,7 +55,7 @@ describe('Onboarding Create Password', () => {
         ...initializedMockState,
         metamask: {
           ...initializedMockState.metamask,
-          firstTimeFlowType: 'import',
+          firstTimeFlowType: FirstTimeFlowType.import,
         },
       };
       const mockStore = configureMockStore()(importFirstTimeFlowState);

--- a/ui/pages/onboarding-flow/metametrics/metametrics.js
+++ b/ui/pages/onboarding-flow/metametrics/metametrics.js
@@ -31,6 +31,7 @@ import {
 } from '../../../components/component-library';
 
 import Box from '../../../components/ui/box/box';
+import { FirstTimeFlowType } from '../../../../shared/constants/onboarding';
 
 export default function OnboardingMetametrics() {
   const t = useI18nContext();
@@ -51,7 +52,7 @@ export default function OnboardingMetametrics() {
           event: MetaMetricsEventName.WalletSetupStarted,
           properties: {
             account_type:
-              firstTimeFlowType === 'create'
+              firstTimeFlowType === FirstTimeFlowType.create
                 ? MetaMetricsEventAccountType.Default
                 : MetaMetricsEventAccountType.Imported,
           },

--- a/ui/pages/onboarding-flow/metametrics/metametrics.test.js
+++ b/ui/pages/onboarding-flow/metametrics/metametrics.test.js
@@ -9,6 +9,7 @@ import {
   onboardingMetametricsDisagree,
 } from '../../../../app/_locales/en/messages.json';
 import { setParticipateInMetaMetrics } from '../../../store/actions';
+import { FirstTimeFlowType } from '../../../../shared/constants/onboarding';
 import OnboardingMetametrics from './metametrics';
 
 const mockPushHistory = jest.fn();
@@ -35,7 +36,7 @@ describe('Onboarding Metametrics Component', () => {
 
   const mockState = {
     metamask: {
-      firstTimeFlowType: 'create',
+      firstTimeFlowType: FirstTimeFlowType.create,
       participateInMetaMetrics: '',
     },
   };

--- a/ui/pages/onboarding-flow/pin-extension/pin-extension.js
+++ b/ui/pages/onboarding-flow/pin-extension/pin-extension.js
@@ -32,12 +32,12 @@ import OnboardingPinMmiBillboard from '../../institutional/pin-mmi-billboard/pin
 import { Text } from '../../../components/component-library';
 ///: BEGIN:ONLY_INCLUDE_IF(build-main,build-beta,build-flask)
 import { MetaMetricsContext } from '../../../contexts/metametrics';
-import { FIRST_TIME_FLOW_TYPES } from '../../../helpers/constants/onboarding';
 import { getFirstTimeFlowType } from '../../../selectors';
 import {
   MetaMetricsEventCategory,
   MetaMetricsEventName,
 } from '../../../../shared/constants/metametrics';
+import { FirstTimeFlowType } from '../../../../shared/constants/onboarding';
 import OnboardingPinBillboard from './pin-billboard';
 ///: END:ONLY_INCLUDE_IF
 
@@ -62,10 +62,8 @@ export default function OnboardingPinExtension() {
         event: MetaMetricsEventName.OnboardingWalletSetupComplete,
         properties: {
           wallet_setup_type:
-            firstTimeFlowType === FIRST_TIME_FLOW_TYPES.IMPORT
-              ? 'import'
-              : 'new',
-          new_wallet: firstTimeFlowType === FIRST_TIME_FLOW_TYPES.CREATE,
+            firstTimeFlowType === FirstTimeFlowType.import ? 'import' : 'new',
+          new_wallet: firstTimeFlowType === FirstTimeFlowType.create,
         },
       });
       history.push(DEFAULT_ROUTE);

--- a/ui/pages/onboarding-flow/welcome/welcome.js
+++ b/ui/pages/onboarding-flow/welcome/welcome.js
@@ -40,8 +40,8 @@ import {
   ONBOARDING_IMPORT_WITH_SRP_ROUTE,
   ///: END:ONLY_INCLUDE_IF
 } from '../../../helpers/constants/routes';
-import { FIRST_TIME_FLOW_TYPES } from '../../../helpers/constants/onboarding';
 import { getFirstTimeFlowType, getCurrentKeyring } from '../../../selectors';
+import { FirstTimeFlowType } from '../../../../shared/constants/onboarding';
 
 export default function OnboardingWelcome() {
   const t = useI18nContext();
@@ -56,7 +56,7 @@ export default function OnboardingWelcome() {
   // have already imported or created a wallet
   useEffect(() => {
     if (currentKeyring) {
-      if (firstTimeFlowType === FIRST_TIME_FLOW_TYPES.IMPORT) {
+      if (firstTimeFlowType === FirstTimeFlowType.import) {
         history.replace(ONBOARDING_COMPLETION_ROUTE);
       } else {
         history.replace(ONBOARDING_SECURE_YOUR_WALLET_ROUTE);
@@ -66,7 +66,7 @@ export default function OnboardingWelcome() {
   const trackEvent = useContext(MetaMetricsContext);
 
   const onCreateClick = async () => {
-    dispatch(setFirstTimeFlowType('create'));
+    dispatch(setFirstTimeFlowType(FirstTimeFlowType.create));
     trackEvent({
       category: MetaMetricsEventCategory.Onboarding,
       event: MetaMetricsEventName.OnboardingWalletCreationStarted,

--- a/ui/pages/onboarding-flow/welcome/welcome.test.js
+++ b/ui/pages/onboarding-flow/welcome/welcome.test.js
@@ -13,6 +13,7 @@ import {
   ONBOARDING_SECURE_YOUR_WALLET_ROUTE,
   ONBOARDING_COMPLETION_ROUTE,
 } from '../../../helpers/constants/routes';
+import { FirstTimeFlowType } from '../../../../shared/constants/onboarding';
 import OnboardingWelcome from './welcome';
 
 const mockHistoryReplace = jest.fn();
@@ -73,7 +74,7 @@ describe('Onboarding Welcome Component', () => {
         ...initializedMockState,
         metamask: {
           ...initializedMockState.metamask,
-          firstTimeFlowType: 'import',
+          firstTimeFlowType: FirstTimeFlowType.import,
         },
       };
       const mockStore = configureMockStore([thunk])(importFirstTimeFlowState);
@@ -102,7 +103,9 @@ describe('Onboarding Welcome Component', () => {
       fireEvent.click(createWallet);
 
       expect(setTermsOfUseLastAgreed).toHaveBeenCalled();
-      expect(setFirstTimeFlowType).toHaveBeenCalledWith('create');
+      expect(setFirstTimeFlowType).toHaveBeenCalledWith(
+        FirstTimeFlowType.create,
+      );
     });
 
     it('should set first time flow to import and route to metametrics', () => {

--- a/ui/selectors/first-time-flow.js
+++ b/ui/selectors/first-time-flow.js
@@ -1,3 +1,4 @@
+import { FirstTimeFlowType } from '../../shared/constants/onboarding';
 import {
   DEFAULT_ROUTE,
   ONBOARDING_CREATE_PASSWORD_ROUTE,
@@ -8,9 +9,9 @@ export function getFirstTimeFlowTypeRoute(state) {
   const { firstTimeFlowType } = state.metamask;
 
   let nextRoute;
-  if (firstTimeFlowType === 'create') {
+  if (firstTimeFlowType === FirstTimeFlowType.create) {
     nextRoute = ONBOARDING_CREATE_PASSWORD_ROUTE;
-  } else if (firstTimeFlowType === 'import') {
+  } else if (firstTimeFlowType === FirstTimeFlowType.import) {
     nextRoute = ONBOARDING_IMPORT_WITH_SRP_ROUTE;
   } else {
     nextRoute = DEFAULT_ROUTE;

--- a/ui/store/actions.ts
+++ b/ui/store/actions.ts
@@ -111,6 +111,7 @@ import {
   logErrorWithMessage,
 } from '../../shared/modules/error';
 import { ThemeType } from '../../shared/constants/preferences';
+import { FirstTimeFlowType } from '../../shared/constants/onboarding';
 import * as actionConstants from './actionConstants';
 ///: BEGIN:ONLY_INCLUDE_IF(build-mmi)
 import { updateCustodyState } from './institutional/institution-actions';
@@ -3858,7 +3859,7 @@ export function rejectAllMessages(
 }
 
 export function setFirstTimeFlowType(
-  type: 'create' | 'import',
+  type: FirstTimeFlowType,
 ): ThunkAction<void, MetaMaskReduxState, unknown, AnyAction> {
   return (dispatch: MetaMaskReduxDispatch) => {
     log.debug(`background.setFirstTimeFlowType`);


### PR DESCRIPTION
## **Description**
As part of #23056 we discovered that it will be necessary to introduce a new "type" of firstTimeFlow which is 'restore'. In order to reason about those changes I wanted to shift to using an enum for FirstTimeFlowType which can actually be null, 'import' or 'create' at present. @NiranjanaBinoy converted the onboarding controller to typescript and introduced the enum in https://github.com/MetaMask/metamask-extension/pull/23461 and this PR propogates its usages. 

## **Related issues**

## **Manual testing steps**
1. There should be no testing required as this is not a functional change. However, validating that onboarding still works as intended is viable, and hopefully any bugs will be severe enough to be caught In CI.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained what problem this PR is solving and how it is solved.
- [x] I've linked related issues
- [x] I've included manual testing steps
- [x] I've included screenshots/recordings if applicable
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [x] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [x] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
