### PR TITLE
fix: Fix confirmation tx totals on layer 2 networks and for erc20 transfers

### DIFF
--- a/ui/pages/confirmations/confirm-transaction-base/confirm-transaction-base.component.js
+++ b/ui/pages/confirmations/confirm-transaction-base/confirm-transaction-base.component.js
@@ -7,6 +7,8 @@ import {
 import ConfirmPageContainer from '../components/confirm-page-container';
 import { isBalanceSufficient } from '../send/send.utils';
 import { DEFAULT_ROUTE } from '../../../helpers/constants/routes';
+import fetchEstimatedL1Fee from '../../../helpers/utils/optimism/fetchEstimatedL1Fee';
+
 import {
   INSUFFICIENT_FUNDS_ERROR_KEY,
   GAS_LIMIT_TOO_LOW_ERROR_KEY,
@@ -47,7 +49,7 @@ import { MIN_GAS_LIMIT_DEC } from '../send/send.constants';
 
 import { NETWORK_TO_NAME_MAP } from '../../../../shared/constants/network';
 import {
-  addHexes,
+  sumHexes,
   hexToDecimal,
 } from '../../../../shared/modules/conversion.utils';
 import TransactionAlerts from '../components/transaction-alerts';
@@ -163,6 +165,7 @@ export default class ConfirmTransactionBase extends Component {
     isUserOpContractDeployError: PropTypes.bool,
     useMaxValue: PropTypes.bool,
     maxValue: PropTypes.string,
+    isMultiLayerFeeNetwork: PropTypes.bool,
   };
 
   state = {
@@ -173,6 +176,7 @@ export default class ConfirmTransactionBase extends Component {
     editingGas: false,
     userAcknowledgedGasMissing: false,
     showWarningModal: false,
+    estimatedL1Fees: 0,
     ///: BEGIN:ONLY_INCLUDE_IF(build-mmi)
     noteText: '',
     ///: END:ONLY_INCLUDE_IF
@@ -192,6 +196,7 @@ export default class ConfirmTransactionBase extends Component {
       setDefaultHomeActiveTabName,
       hexMaximumTransactionFee,
       useMaxValue,
+      txData,
     } = this.props;
     const {
       customNonceValue: prevCustomNonceValue,
@@ -246,11 +251,21 @@ export default class ConfirmTransactionBase extends Component {
       }
     }
 
-    if (
-      hexMaximumTransactionFee !== prevHexMaximumTransactionFee &&
-      useMaxValue
-    ) {
-      this.updateValueToMax();
+    if (hexMaximumTransactionFee !== prevHexMaximumTransactionFee) {
+      fetchEstimatedL1Fee(txData?.chainId, txData)
+        .then((result) => {
+          this.setState({
+            estimatedL1Fees: result,
+          });
+        })
+        .catch((_err) => {
+          this.setState({
+            estimatedL1Fees: 0,
+          });
+        });
+      if (useMaxValue) {
+        this.updateValueToMax();
+      }
     }
   }
 
@@ -381,10 +396,11 @@ export default class ConfirmTransactionBase extends Component {
       useCurrencyRateCheck,
       tokenSymbol,
       isUsingPaymaster,
+      isMultiLayerFeeNetwork,
     } = this.props;
 
     const { t } = this.context;
-    const { userAcknowledgedGasMissing } = this.state;
+    const { userAcknowledgedGasMissing, estimatedL1Fees } = this.state;
 
     const { valid } = this.getErrorKey();
     const isDisabled = () => {
@@ -398,9 +414,10 @@ export default class ConfirmTransactionBase extends Component {
     const networkName = NETWORK_TO_NAME_MAP[txData.chainId];
 
     const getTotalAmount = (useMaxFee) => {
-      return addHexes(
+      return sumHexes(
         txData.txParams.value,
         useMaxFee ? hexMaximumTransactionFee : hexMinimumTransactionFee,
+        isMultiLayerFeeNetwork ? estimatedL1Fees : 0,
       );
     };
 

--- a/ui/pages/confirmations/confirm-transaction-base/confirm-transaction-base.component.js
+++ b/ui/pages/confirmations/confirm-transaction-base/confirm-transaction-base.component.js
@@ -438,8 +438,11 @@ export default class ConfirmTransactionBase extends Component {
       }
 
       // Token send
-      return useNativeCurrencyAsPrimaryCurrency
+      const primaryTotal = useMaxFee
         ? primaryTotalTextOverrideMaxAmount
+        : primaryTotalTextOverride;
+      return useNativeCurrencyAsPrimaryCurrency
+        ? primaryTotal
         : secondaryTotalTextOverride;
     };
 


### PR DESCRIPTION
## **Description**

While testing https://github.com/MetaMask/metamask-extension/pull/23510, I discovered that total fees had some inaccuracies in two cases:
1. On OP layer 2 networks, the rendered total on the confirmation screen was not including the estimated layer 1 fees (as it does in the 'Estimated Fees' section)
2. For confirmations of the ERC20 transfers, the rendered total that is supposed to be ERC20 token + estimated fee was actually ERC20 token + maximum fee.

The fix for 1 was to bring in fetching of layer1 multi-network fee data into the confirmation-transaction-base component.

The fix for 2 is just to make sure that when we are rendering the transaction detail line where `useMax` is false, we choose the correct token fee to render (see the new `primaryFee` variable introduced in this PR).

These two fixes are included in separate commits


### **Before: Layer 2 total fees**
![Screenshot from 2024-03-14 22-43-28](https://github.com/MetaMask/metamask-extension/assets/7499938/1d80ba80-3e54-4a94-97e6-daa0f17b8fd7)

### **After: Layer 2 total fees**
![Screenshot from 2024-03-14 23-46-02](https://github.com/MetaMask/metamask-extension/assets/7499938/3fe61964-df99-4c46-af3c-c49aaf9f0c0f)

### **Before: ERC20 sends**
![Screenshot from 2024-03-14 23-59-29](https://github.com/MetaMask/metamask-extension/assets/7499938/e132e060-92c5-4a69-84e9-8fb6c7da2d99)


### **After: ERC20 sends**

![Screenshot from 2024-03-15 00-15-03](https://github.com/MetaMask/metamask-extension/assets/7499938/4d25dca9-c493-478a-84ce-c3b04b1c7a58)


## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've clearly explained what problem this PR is solving and how it is solved.
- [ ] I've linked related issues
- [ ] I've included manual testing steps
- [ ] I've included screenshots/recordings if applicable
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [ ] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
