### PR TITLE
fix: fix overflow in Snaps list

### DIFF
--- a/ui/components/app/snaps/snap-list-item/snap-list-item.js
+++ b/ui/components/app/snaps/snap-list-item/snap-list-item.js
@@ -47,11 +47,17 @@ const SnapListItem = ({
         <Box>
           <SnapAvatar snapId={snapId} />
         </Box>
-        <Box paddingLeft={4} paddingRight={4} width={BlockSize.Full}>
+        <Box
+          paddingLeft={4}
+          paddingRight={4}
+          width={BlockSize.Full}
+          style={{ overflow: 'hidden' }}
+        >
           <Text
             className="snap-list-item__title"
             color={Color.textDefault}
             variant={TextVariant.bodyMd}
+            ellipsis
           >
             {name}
           </Text>
@@ -59,6 +65,7 @@ const SnapListItem = ({
             className="snap-list-item__url"
             color={Color.textAlternative}
             variant={TextVariant.bodySm}
+            ellipsis
           >
             {packageName}
           </Text>


### PR DESCRIPTION
## **Description**

Fixes an issue where long Snap IDs or names would overflow in the Snaps list component.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/23517?quickstart=1)


## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

![image](https://github.com/MetaMask/metamask-extension/assets/1561200/3f7984ea-ad0e-4c61-9f94-d4f79b3d220f)

### **After**

![image](https://github.com/MetaMask/metamask-extension/assets/1561200/0dc40a9b-a082-4aa0-b423-2b58c6ddf7f1)
