### PR TITLE
fix: fix fiat eth display

### DIFF
--- a/test/e2e/helpers.js
+++ b/test/e2e/helpers.js
@@ -826,16 +826,11 @@ const TEST_SEED_PHRASE_TWO =
 
 // Usually happens when onboarded to make sure the state is retrieved from metamaskState properly, or after txn is made
 const locateAccountBalanceDOM = async (driver, ganacheServer) => {
-  const balance = (await ganacheServer.getFiatBalance()).toLocaleString(
-    undefined,
-    {
-      minimumFractionDigits: 2,
-    },
-  );
+  const balance = await ganacheServer.getBalance();
 
   await driver.findElement({
     css: '[data-testid="eth-overview__primary-currency"]',
-    text: `$ ${balance} USD`,
+    text: `$ ${balance} ETH`,
   });
 };
 

--- a/test/e2e/helpers.js
+++ b/test/e2e/helpers.js
@@ -830,7 +830,7 @@ const locateAccountBalanceDOM = async (driver, ganacheServer) => {
 
   await driver.findElement({
     css: '[data-testid="eth-overview__primary-currency"]',
-    text: `$ ${balance} ETH`,
+    text: `${balance} ETH`,
   });
 };
 

--- a/test/e2e/tests/contract-interactions.spec.js
+++ b/test/e2e/tests/contract-interactions.spec.js
@@ -90,7 +90,7 @@ describe('Deploy contract and call contract methods', function () {
         const balance = await driver.findElement(
           '[data-testid="eth-overview__primary-currency"]',
         );
-        assert.equal(await balance.getText(), '$37,399.05\nUSD');
+        assert.equal(await balance.getText(), '21.9994\nETH');
       },
     );
   });

--- a/test/e2e/tests/incremental-security.spec.js
+++ b/test/e2e/tests/incremental-security.spec.js
@@ -112,10 +112,10 @@ describe('Incremental Security', function () {
         // should have the correct amount of eth
         let currencyDisplay = await driver.waitForSelector({
           css: '.currency-display-component__text',
-          text: '$1,700.00',
+          text: '1',
         });
         let balance = await currencyDisplay.getText();
-        assert.strictEqual(balance, '$1,700.00');
+        assert.strictEqual(balance, '1');
 
         // backs up the Secret Recovery Phrase
         // should show a backup reminder
@@ -163,11 +163,11 @@ describe('Incremental Security', function () {
         // should have the correct amount of eth
         currencyDisplay = await driver.waitForSelector({
           css: '.currency-display-component__text',
-          text: '$1,700.00',
+          text: '1',
         });
         balance = await currencyDisplay.getText();
 
-        assert.strictEqual(balance, '$1,700.00');
+        assert.strictEqual(balance, '1');
 
         // The previous currencyDisplay wait already serves as the guard here for the assertElementNotPresent
         await driver.assertElementNotPresent('.backup-notification');

--- a/test/e2e/tests/localization.spec.js
+++ b/test/e2e/tests/localization.spec.js
@@ -2,7 +2,7 @@ const { strict: assert } = require('assert');
 const {
   defaultGanacheOptions,
   withFixtures,
-  unlockWallet,
+  logInWithBalanceValidation,
 } = require('../helpers');
 const FixtureBuilder = require('../fixture-builder');
 
@@ -23,13 +23,15 @@ describe('Localization', function () {
         ganacheOptions: defaultGanacheOptions,
         title: this.test.fullTitle(),
       },
-      async ({ driver }) => {
-        await unlockWallet(driver);
+      async ({ driver, ganacheServer }) => {
+        await logInWithBalanceValidation(driver, ganacheServer);
 
+        await driver.clickElement('[data-testid="home__asset-tab"]');
         const secondaryBalance = await driver.findElement(
-          '[data-testid="eth-overview__primary-currency"]',
+          '[data-testid="multichain-token-list-item-value"]',
         );
         const secondaryBalanceText = await secondaryBalance.getText();
+
         const [fiatAmount, fiatUnit] = secondaryBalanceText
           .trim()
           .split(/\s+/u);

--- a/test/e2e/tests/lock-account.spec.js
+++ b/test/e2e/tests/lock-account.spec.js
@@ -30,7 +30,7 @@ describe('Lock and unlock', function () {
         const walletBalance = await driver.findElement(
           '.eth-overview__primary-balance',
         );
-        assert.equal(await walletBalance.getText(), '$42,500.00\nUSD');
+        assert.equal(await walletBalance.getText(), '25\nETH');
       },
     );
   });

--- a/test/e2e/tests/metamask-responsive-ui.spec.js
+++ b/test/e2e/tests/metamask-responsive-ui.spec.js
@@ -74,7 +74,7 @@ describe('MetaMask Responsive UI', function () {
         // assert balance
         await driver.findElement({
           css: '[data-testid="eth-overview__primary-currency"]',
-          text: `$ 0.00 USD`,
+          text: `0 ETH`,
         });
       },
     );

--- a/test/e2e/tests/migrate-old-vault.spec.js
+++ b/test/e2e/tests/migrate-old-vault.spec.js
@@ -32,7 +32,7 @@ describe('Migrate vault with old encryption', function () {
         const walletBalance = await driver.findElement(
           '.eth-overview__primary-balance',
         );
-        assert.equal(await walletBalance.getText(), '$42,500.00\nUSD');
+        assert.equal(await walletBalance.getText(), '25\nETH');
       },
     );
   });

--- a/test/e2e/tests/settings/account-token-list.spec.js
+++ b/test/e2e/tests/settings/account-token-list.spec.js
@@ -60,10 +60,6 @@ describe('Settings', function () {
         );
         await driver.clickElement('[data-testid="home__asset-tab"]');
 
-        const tokenListAmount = await driver.findElement(
-          '.eth-overview__primary-container',
-        );
-        assert.equal(await tokenListAmount.getText(), '$42,500.00\nUSD');
         await driver.clickElement('[data-testid="account-menu-icon"]');
         const accountTokenValue = await driver.waitForSelector(
           '.multichain-account-list-item .multichain-account-list-item__asset',

--- a/test/e2e/tests/transaction/send-eth.spec.js
+++ b/test/e2e/tests/transaction/send-eth.spec.js
@@ -187,7 +187,7 @@ describe('Send ETH', function () {
           // Go back to home screen to check txn
           await driver.findElement({
             css: '[data-testid="eth-overview__primary-currency"]',
-            text: '$42,496.38',
+            text: '23.9978 ETH',
           });
           await driver.clickElement('[data-testid="home__activity-tab"]');
 
@@ -219,7 +219,7 @@ describe('Send ETH', function () {
           await driver.assertElementNotPresent('.loading-overlay__spinner');
           await driver.findElement({
             css: '[data-testid="eth-overview__primary-currency"]',
-            text: '$42,500.00',
+            text: '25ETH',
           });
 
           await openActionMenuAndStartSendFlow(driver);
@@ -435,7 +435,7 @@ describe('Send ETH', function () {
             await driver.assertElementNotPresent('.loading-overlay__spinner');
             await driver.findElement({
               css: '[data-testid="eth-overview__primary-currency"]',
-              text: '$42,500.00',
+              text: '25 ETH',
             });
 
             await openActionMenuAndStartSendFlow(driver);

--- a/ui/components/app/wallet-overview/eth-overview.js
+++ b/ui/components/app/wallet-overview/eth-overview.js
@@ -73,7 +73,7 @@ import { showPrimaryCurrency } from '../../../../shared/modules/currency-display
 import { TEST_NETWORKS } from '../../../../shared/constants/network';
 import WalletOverview from './wallet-overview';
 
-const EthOverview = ({ className, showAddress }) => {
+const EthOverview = ({ className, showAddress, fiatOverride }) => {
   const dispatch = useDispatch();
   const t = useContext(I18nContext);
   const trackEvent = useContext(MetaMetricsContext);
@@ -109,9 +109,16 @@ const EthOverview = ({ className, showAddress }) => {
     selectedAddress,
     shouldHideZeroBalanceTokens,
   );
+
   const showFiatInTestnets = useSelector(getShowFiatInTestnets);
   const showFiat =
     TEST_NETWORKS.includes(currentNetwork?.nickname) && !showFiatInTestnets;
+
+  const showFiatOverride =
+    // eslint-disable-next-line no-negated-condition
+    fiatOverride !== undefined
+      ? fiatOverride
+      : !showFiat || !TEST_NETWORKS.includes(currentNetwork?.nickname);
 
   let balanceToUse = totalWeiBalance;
 
@@ -242,10 +249,7 @@ const EthOverview = ({ className, showAddress }) => {
                       ? PRIMARY
                       : SECONDARY
                   }
-                  showFiat={
-                    !showFiat ||
-                    !TEST_NETWORKS.includes(currentNetwork?.nickname)
-                  }
+                  showFiat={showFiatOverride}
                   ethNumberOfDecimals={4}
                   hideTitle
                 />
@@ -461,6 +465,7 @@ const EthOverview = ({ className, showAddress }) => {
 EthOverview.propTypes = {
   className: PropTypes.string,
   showAddress: PropTypes.bool,
+  fiatOverride: PropTypes.bool,
 };
 
 export default EthOverview;

--- a/ui/pages/home/home.component.js
+++ b/ui/pages/home/home.component.js
@@ -882,6 +882,7 @@ export default class Home extends PureComponent {
                 <EthOverview
                   showAddress
                   mmiPortfolioEnabled={mmiPortfolioEnabled}
+                  fiatOverride={false}
                 />
                 ///: END:ONLY_INCLUDE_IF
               }

--- a/ui/pages/home/home.component.js
+++ b/ui/pages/home/home.component.js
@@ -874,7 +874,7 @@ export default class Home extends PureComponent {
             <div className="home__balance-wrapper">
               {
                 ///: BEGIN:ONLY_INCLUDE_IF(build-main,build-beta,build-flask)
-                <EthOverview showAddress />
+                <EthOverview showAddress fiatOverride={false} />
                 ///: END:ONLY_INCLUDE_IF
               }
               {


### PR DESCRIPTION
## **Description**

Fix display of fiat balance when user chooses fiat and ETH balance when user chooses ETH in settings.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/23519?quickstart=1)

## **Related issues**

Fixes:https://github.com/MetaMask/metamask-extension/issues/23514

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've clearly explained what problem this PR is solving and how it is solved.
- [ ] I've linked related issues
- [ ] I've included manual testing steps
- [ ] I've included screenshots/recordings if applicable
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [ ] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
