### PR TITLE
fix: Revert "Set FONTCONFIG_PATH on CircleCI containers (#22657)"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,6 @@ executors:
       - image: cimg/node:20.11-browsers
     resource_class: small
     environment:
-      FONTCONFIG_PATH: /etc/fonts
       NODE_OPTIONS: --max_old_space_size=2048
   node-browsers-medium:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,14 +13,12 @@ executors:
       - image: cimg/node:20.11-browsers
     resource_class: medium
     environment:
-      FONTCONFIG_PATH: /etc/fonts
       NODE_OPTIONS: --max_old_space_size=3072
   node-browsers-medium-plus:
     docker:
       - image: cimg/node:20.11-browsers
     resource_class: medium+
     environment:
-      FONTCONFIG_PATH: /etc/fonts
       NODE_OPTIONS: --max_old_space_size=4096
   shellcheck:
     docker:


### PR DESCRIPTION


## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This reverts commit 391807f4ad9cb34947281c4ba4e3784fcf47ee4b. Setting this environment variable does not seem to prevent Fontconfig-related errors from appearing in tests, as described in the original commit.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/23523?quickstart=1)

## **Related issues**

Relates to https://github.com/MetaMask/metamask-extension/issues/22564.

## **Manual testing steps**

No manual testing steps are needed since this is simply a change to the CircleCI config.

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained what problem this PR is solving and how it is solved.
- [x] I've linked related issues
- [x] I've included manual testing steps
- [x] I've included screenshots/recordings if applicable
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [ ] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [x] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
