### PR TITLE
fix(browser-passworder): `isVaultUpdated` should not return promise

### DIFF
--- a/app/scripts/lib/encryptor-factory.test.ts
+++ b/app/scripts/lib/encryptor-factory.test.ts
@@ -1,0 +1,170 @@
+import { encryptorFactory } from './encryptor-factory';
+import * as browserPassworder from '@metamask/browser-passworder';
+
+jest.mock('@metamask/browser-passworder');
+
+const mockIterations = 100;
+const mockPassword = 'password';
+const mockData = 'data';
+
+describe('encryptorFactory', () => {
+  const mockBrowserPassworder = browserPassworder as jest.Mocked<
+    typeof browserPassworder
+  >;
+
+  it('should return an object with browser passworder methods', () => {
+    const encryptor = encryptorFactory(mockIterations);
+
+    [
+      'encrypt',
+      'encryptWithDetail',
+      'encryptWithKey',
+      'decrypt',
+      'decryptWithDetail',
+      'decryptWithKey',
+      'keyFromPassword',
+      'importKey',
+      'isVaultUpdated',
+    ].map((method) => {
+      expect(encryptor).toHaveProperty(method);
+    });
+  });
+
+  describe('encrypt', () => {
+    it('should call browser-passworder.encrypt with the given password, data, and iterations', async () => {
+      const encryptor = encryptorFactory(mockIterations);
+
+      await encryptor.encrypt(mockPassword, mockData);
+
+      expect(mockBrowserPassworder.encrypt).toHaveBeenCalledWith(
+        mockPassword,
+        mockData,
+        undefined,
+        undefined,
+        {
+          algorithm: 'PBKDF2',
+          params: {
+            iterations: mockIterations,
+          },
+        },
+      );
+    });
+
+    it('should return the result of browser-passworder.encrypt', async () => {
+      const encryptor = encryptorFactory(mockIterations);
+      const mockResult = 'result';
+      mockBrowserPassworder.encrypt.mockResolvedValue(mockResult);
+
+      expect(await encryptor.encrypt(mockPassword, mockData)).toBe(mockResult);
+    });
+  });
+
+  describe('encryptWithDetail', () => {
+    it('should call browser-passworder.encryptWithDetail with the given password, object, and iterations', async () => {
+      const encryptor = encryptorFactory(mockIterations);
+
+      await encryptor.encryptWithDetail(mockPassword, { foo: 'bar' }, 'salt');
+
+      expect(mockBrowserPassworder.encryptWithDetail).toHaveBeenCalledWith(
+        mockPassword,
+        { foo: 'bar' },
+        'salt',
+        {
+          algorithm: 'PBKDF2',
+          params: {
+            iterations: mockIterations,
+          },
+        },
+      );
+    });
+
+    it('should return the result of browser-passworder.encryptWithDetail', async () => {
+      const encryptor = encryptorFactory(mockIterations);
+      const mockResult = {
+        vault: 'vault',
+        exportedKeyString: 'salt',
+      };
+      mockBrowserPassworder.encryptWithDetail.mockResolvedValue(mockResult);
+
+      expect(
+        await encryptor.encryptWithDetail(mockPassword, { foo: 'bar' }, 'salt'),
+      ).toBe(mockResult);
+    });
+  });
+
+  describe('decrypt', () => {
+    it('should call browser-passworder.decrypt with the given password, data, and iterations', async () => {
+      const encryptor = encryptorFactory(mockIterations);
+
+      await encryptor.decrypt(mockPassword, mockData);
+
+      expect(mockBrowserPassworder.decrypt).toHaveBeenCalledWith(
+        mockPassword,
+        mockData,
+      );
+    });
+
+    it('should return the result of browser-passworder.decrypt', async () => {
+      const encryptor = encryptorFactory(mockIterations);
+      const mockResult = 'result';
+      mockBrowserPassworder.decrypt.mockResolvedValue(mockResult);
+
+      expect(await encryptor.decrypt(mockPassword, mockData)).toBe(mockResult);
+    });
+  });
+
+  describe('decryptWithDetail', () => {
+    it('should call browser-passworder.decryptWithDetail with the given password and object', async () => {
+      const encryptor = encryptorFactory(mockIterations);
+
+      await encryptor.decryptWithDetail(mockPassword, mockData);
+
+      expect(mockBrowserPassworder.decryptWithDetail).toHaveBeenCalledWith(
+        mockPassword,
+        mockData,
+      );
+    });
+
+    it('should return the result of browser-passworder.decryptWithDetail', async () => {
+      const encryptor = encryptorFactory(mockIterations);
+      const mockResult = {
+        exportedKeyString: 'key',
+        vault: 'data',
+        salt: 'salt',
+      };
+      mockBrowserPassworder.decryptWithDetail.mockResolvedValue(mockResult);
+
+      expect(await encryptor.decryptWithDetail(mockPassword, mockData)).toBe(
+        mockResult,
+      );
+    });
+  });
+
+  describe('isVaultUpdated', () => {
+    it('should call browser-passworder.isVaultUpdated with the given vault and iterations', () => {
+      const encryptor = encryptorFactory(mockIterations);
+      const mockVault = 'vault';
+
+      encryptor.isVaultUpdated(mockVault);
+
+      expect(mockBrowserPassworder.isVaultUpdated).toHaveBeenCalledWith(
+        mockVault,
+        {
+          algorithm: 'PBKDF2',
+          params: {
+            iterations: mockIterations,
+          },
+        },
+      );
+    });
+
+    it('should return the result of browser-passworder.isVaultUpdated', () => {
+      const encryptor = encryptorFactory(mockIterations);
+      const mockResult = false;
+      const mockVault = 'vault';
+      mockBrowserPassworder.isVaultUpdated.mockReturnValue(mockResult);
+
+      expect(encryptor.isVaultUpdated(mockVault)).toBe(mockResult);
+    });
+  });
+});

--- a/app/scripts/lib/encryptor-factory.test.ts
+++ b/app/scripts/lib/encryptor-factory.test.ts
@@ -1,5 +1,5 @@
-import { encryptorFactory } from './encryptor-factory';
 import * as browserPassworder from '@metamask/browser-passworder';
+import { encryptorFactory } from './encryptor-factory';
 
 jest.mock('@metamask/browser-passworder');
 
@@ -25,7 +25,7 @@ describe('encryptorFactory', () => {
       'keyFromPassword',
       'importKey',
       'isVaultUpdated',
-    ].map((method) => {
+    ].forEach((method) => {
       expect(encryptor).toHaveProperty(method);
     });
   });

--- a/app/scripts/lib/encryptor-factory.test.ts
+++ b/app/scripts/lib/encryptor-factory.test.ts
@@ -8,6 +8,10 @@ const mockPassword = 'password';
 const mockData = 'data';
 
 describe('encryptorFactory', () => {
+  afterEach(async () => {
+    jest.resetAllMocks();
+  });
+
   const mockBrowserPassworder = browserPassworder as jest.Mocked<
     typeof browserPassworder
   >;

--- a/app/scripts/lib/encryptor-factory.ts
+++ b/app/scripts/lib/encryptor-factory.ts
@@ -57,7 +57,7 @@ const encryptWithDetailFactory =
  * @param iterations - The number of iterations to use for the PBKDF2 algorithm.
  * @returns A function that checks if the vault was encrypted with the given number of iterations.
  */
-const isVaultUpdatedFactory = (iterations: number) => async (vault: string) =>
+const isVaultUpdatedFactory = (iterations: number) => (vault: string) =>
   isVaultUpdated(vault, {
     algorithm: 'PBKDF2',
     params: {


### PR DESCRIPTION
## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

The encryptor factory currently constructs `isVaultUpdated` as an async function, but the underlying browser-passworder's method does not return a promise, and KeyringController does not await it. This means that `isVaultUpdated` will always return a truthy value when not awaited, never updating the vault _before_ a user action.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/23573?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've clearly explained what problem this PR is solving and how it is solved.
- [ ] I've linked related issues
- [ ] I've included manual testing steps
- [ ] I've included screenshots/recordings if applicable
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [ ] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
