### PR TITLE
feat: replace snap buttons with button links

### DIFF
--- a/ui/components/app/app-components.scss
+++ b/ui/components/app/app-components.scss
@@ -22,6 +22,7 @@
 @import 'snaps/snap-install-warning/index';
 @import 'snaps/snap-ui-renderer/index';
 @import 'snaps/snap-ui-markdown/index';
+@import 'snaps/snap-ui-button/index';
 @import 'snaps/snap-delineator/index';
 @import 'snaps/snap-list-item/index';
 @import 'snaps/copyable/index';

--- a/ui/components/app/snaps/snap-ui-button/index.scss
+++ b/ui/components/app/snaps/snap-ui-button/index.scss
@@ -1,0 +1,10 @@
+.snap-ui-button {
+  background: none;
+  color: var(--color-primary-default);
+  text-align: center;
+
+  &:hover {
+    cursor: pointer;
+    color: var(--color-primary-alternative);
+  }
+}

--- a/ui/components/app/snaps/snap-ui-button/index.scss
+++ b/ui/components/app/snaps/snap-ui-button/index.scss
@@ -2,17 +2,14 @@
   background: none;
   text-align: center;
 
-  &--variant-primary:not(&--disabled) {
+  &:not(&--disabled) {
     &:hover {
       cursor: pointer;
-      color: var(--color-primary-alternative);
+      opacity: 0.75;
     }
   }
 
-  &--variant-destructive:not(&--disabled) {
-    &:hover {
-      cursor: pointer;
-      color: var(--color-error-alternative);
-    }
+  &--disabled {
+    cursor: default !important;
   }
 }

--- a/ui/components/app/snaps/snap-ui-button/index.scss
+++ b/ui/components/app/snaps/snap-ui-button/index.scss
@@ -1,10 +1,18 @@
 .snap-ui-button {
   background: none;
-  color: var(--color-primary-default);
   text-align: center;
 
-  &:hover {
-    cursor: pointer;
-    color: var(--color-primary-alternative);
+  &--variant-primary:not(&--disabled) {
+    &:hover {
+      cursor: pointer;
+      color: var(--color-primary-alternative);
+    }
+  }
+
+  &--variant-destructive:not(&--disabled) {
+    &:hover {
+      cursor: pointer;
+      color: var(--color-error-alternative);
+    }
   }
 }

--- a/ui/components/app/snaps/snap-ui-button/snap-ui-button.tsx
+++ b/ui/components/app/snaps/snap-ui-button/snap-ui-button.tsx
@@ -1,6 +1,6 @@
 import React, { FunctionComponent, MouseEvent as ReactMouseEvent } from 'react';
 import { ButtonType, UserInputEventType } from '@metamask/snaps-sdk';
-import { Button, ButtonProps } from '../../../component-library';
+import { ButtonLink, ButtonLinkProps, ButtonProps } from '../../../component-library';
 import { useSnapInterfaceContext } from '../../../../contexts/snaps';
 
 export type SnapUIButtonProps = {
@@ -8,7 +8,7 @@ export type SnapUIButtonProps = {
 };
 
 export const SnapUIButton: FunctionComponent<
-  SnapUIButtonProps & ButtonProps<'button'>
+  SnapUIButtonProps & ButtonLinkProps<'button'>
 > = ({ name, children, type, ...props }) => {
   const { handleEvent } = useSnapInterfaceContext();
 
@@ -21,7 +21,7 @@ export const SnapUIButton: FunctionComponent<
   };
 
   return (
-    <Button
+    <ButtonLink
       className="snap-ui-renderer__button"
       id={name}
       type={type}
@@ -30,6 +30,6 @@ export const SnapUIButton: FunctionComponent<
       {...props}
     >
       {children}
-    </Button>
+    </ButtonLink>
   );
 };

--- a/ui/components/app/snaps/snap-ui-button/snap-ui-button.tsx
+++ b/ui/components/app/snaps/snap-ui-button/snap-ui-button.tsx
@@ -1,7 +1,8 @@
 import React, { FunctionComponent, MouseEvent as ReactMouseEvent } from 'react';
 import { ButtonType, UserInputEventType } from '@metamask/snaps-sdk';
-import { ButtonLink, ButtonLinkProps, ButtonProps } from '../../../component-library';
+import { ButtonLinkProps, Text } from '../../../component-library';
 import { useSnapInterfaceContext } from '../../../../contexts/snaps';
+import { FontWeight } from '../../../../helpers/constants/design-system';
 
 export type SnapUIButtonProps = {
   name?: string;
@@ -12,7 +13,7 @@ export const SnapUIButton: FunctionComponent<
 > = ({ name, children, type, ...props }) => {
   const { handleEvent } = useSnapInterfaceContext();
 
-  const handleClick = (event: ReactMouseEvent<HTMLElement>) => {
+  const handleClick = (event: ReactMouseEvent<any>) => {
     if (type === ButtonType.Button) {
       event.preventDefault();
     }
@@ -21,15 +22,16 @@ export const SnapUIButton: FunctionComponent<
   };
 
   return (
-    <ButtonLink
-      className="snap-ui-renderer__button"
+    <Text
+      className="snap-ui-button"
+      as="button"
       id={name}
       type={type}
+      fontWeight={FontWeight.Medium}
       onClick={handleClick}
-      block
       {...props}
     >
       {children}
-    </ButtonLink>
+    </Text>
   );
 };

--- a/ui/components/app/snaps/snap-ui-button/snap-ui-button.tsx
+++ b/ui/components/app/snaps/snap-ui-button/snap-ui-button.tsx
@@ -25,13 +25,13 @@ export const SnapUIButton: FunctionComponent<
   children,
   type,
   variant = 'primary',
-  disabled,
-  className,
+  disabled = false,
+  className = '',
   ...props
 }) => {
   const { handleEvent } = useSnapInterfaceContext();
 
-  const handleClick = (event: ReactMouseEvent<any>) => {
+  const handleClick = (event: ReactMouseEvent<HTMLElement>) => {
     if (type === ButtonType.Button) {
       event.preventDefault();
     }
@@ -39,9 +39,9 @@ export const SnapUIButton: FunctionComponent<
     handleEvent({ event: UserInputEventType.ButtonClickEvent, name });
   };
 
-  const overridenVariant = disabled ? 'disabled' : variant;
+  const overriddenVariant = disabled ? 'disabled' : variant;
 
-  const color = COLORS[overridenVariant];
+  const color = COLORS[overriddenVariant as keyof typeof COLORS];
 
   return (
     <Text

--- a/ui/components/app/snaps/snap-ui-button/snap-ui-button.tsx
+++ b/ui/components/app/snaps/snap-ui-button/snap-ui-button.tsx
@@ -1,16 +1,34 @@
 import React, { FunctionComponent, MouseEvent as ReactMouseEvent } from 'react';
+import classnames from 'classnames';
 import { ButtonType, UserInputEventType } from '@metamask/snaps-sdk';
 import { ButtonLinkProps, Text } from '../../../component-library';
 import { useSnapInterfaceContext } from '../../../../contexts/snaps';
-import { FontWeight } from '../../../../helpers/constants/design-system';
+import {
+  FontWeight,
+  TextColor,
+} from '../../../../helpers/constants/design-system';
 
 export type SnapUIButtonProps = {
   name?: string;
 };
 
+const COLORS = {
+  primary: TextColor.infoDefault,
+  destructive: TextColor.errorDefault,
+  disabled: TextColor.textMuted,
+};
+
 export const SnapUIButton: FunctionComponent<
   SnapUIButtonProps & ButtonLinkProps<'button'>
-> = ({ name, children, type, ...props }) => {
+> = ({
+  name,
+  children,
+  type,
+  variant = 'primary',
+  disabled,
+  className,
+  ...props
+}) => {
   const { handleEvent } = useSnapInterfaceContext();
 
   const handleClick = (event: ReactMouseEvent<any>) => {
@@ -21,14 +39,24 @@ export const SnapUIButton: FunctionComponent<
     handleEvent({ event: UserInputEventType.ButtonClickEvent, name });
   };
 
+  const overridenVariant = disabled ? 'disabled' : variant;
+
+  const color = COLORS[overridenVariant];
+
   return (
     <Text
-      className="snap-ui-button"
+      className={classnames(className, 'snap-ui-button', {
+        'snap-ui-button--variant-primary': variant === 'primary',
+        'snap-ui-button--variant-destructive': variant === 'destructive',
+        'snap-ui-button--disabled': disabled,
+      })}
       as="button"
       id={name}
       type={type}
       fontWeight={FontWeight.Medium}
       onClick={handleClick}
+      color={color}
+      disabled={disabled}
       {...props}
     >
       {children}

--- a/ui/components/app/snaps/snap-ui-button/snap-ui-button.tsx
+++ b/ui/components/app/snaps/snap-ui-button/snap-ui-button.tsx
@@ -46,8 +46,6 @@ export const SnapUIButton: FunctionComponent<
   return (
     <Text
       className={classnames(className, 'snap-ui-button', {
-        'snap-ui-button--variant-primary': variant === 'primary',
-        'snap-ui-button--variant-destructive': variant === 'destructive',
         'snap-ui-button--disabled': disabled,
       })}
       as="button"

--- a/ui/components/app/snaps/snap-ui-renderer/components/button.ts
+++ b/ui/components/app/snaps/snap-ui-renderer/components/button.ts
@@ -5,7 +5,7 @@ export const button: UIComponentFactory<ButtonElement> = ({ element }) => ({
   element: 'SnapUIButton',
   props: {
     type: element.props.type,
-    variant: element.props.variant === 'destructive' ? 'secondary' : 'primary', // TODO: Support the new variants for the buttons
+    variant: element.props.variant,
     name: element.props.name,
     disabled: element.props.disabled,
   },


### PR DESCRIPTION
## **Description**

Replaces the current snap buttons with smaller button links.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/23610?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/snaps/issues/2298

## **Screenshots/Recordings**

![image](https://github.com/MetaMask/metamask-extension/assets/1561200/00d65bf1-2507-4304-bbbb-4dab31adbe5f)
