### PR TITLE
fix: revert aggregated fiat balance on home page

### DIFF
--- a/test/e2e/helpers.js
+++ b/test/e2e/helpers.js
@@ -833,16 +833,11 @@ const TEST_SEED_PHRASE_TWO =
 
 // Usually happens when onboarded to make sure the state is retrieved from metamaskState properly, or after txn is made
 const locateAccountBalanceDOM = async (driver, ganacheServer) => {
-  const balance = (await ganacheServer.getFiatBalance()).toLocaleString(
-    undefined,
-    {
-      minimumFractionDigits: 2,
-    },
-  );
+  const balance = await ganacheServer.getBalance();
 
   await driver.findElement({
     css: '[data-testid="eth-overview__primary-currency"]',
-    text: `$ ${balance} USD`,
+    text: `${balance} ETH`,
   });
 };
 

--- a/test/e2e/tests/contract-interactions.spec.js
+++ b/test/e2e/tests/contract-interactions.spec.js
@@ -1,4 +1,3 @@
-const { strict: assert } = require('assert');
 const {
   defaultGanacheOptions,
   withFixtures,
@@ -6,6 +5,7 @@ const {
   unlockWallet,
   largeDelayMs,
   WINDOW_TITLES,
+  locateAccountBalanceDOM,
 } = require('../helpers');
 
 const { SMART_CONTRACTS } = require('../seeder/smart-contracts');
@@ -25,7 +25,7 @@ describe('Deploy contract and call contract methods', function () {
         smartContract,
         title: this.test.fullTitle(),
       },
-      async ({ driver, contractRegistry }) => {
+      async ({ driver, contractRegistry, ganacheServer }) => {
         const contractAddress = await contractRegistry.getContractAddress(
           smartContract,
         );
@@ -87,10 +87,7 @@ describe('Deploy contract and call contract methods', function () {
         await driver.switchToWindowWithTitle(
           WINDOW_TITLES.ExtensionInFullScreenView,
         );
-        const balance = await driver.findElement(
-          '[data-testid="eth-overview__primary-currency"]',
-        );
-        assert.equal(await balance.getText(), '$37,399.05\nUSD');
+        await locateAccountBalanceDOM(driver, ganacheServer);
       },
     );
   });

--- a/test/e2e/tests/incremental-security.spec.js
+++ b/test/e2e/tests/incremental-security.spec.js
@@ -112,10 +112,10 @@ describe('Incremental Security', function () {
         // should have the correct amount of eth
         let currencyDisplay = await driver.waitForSelector({
           css: '.currency-display-component__text',
-          text: '$1,700.00',
+          text: '1',
         });
         let balance = await currencyDisplay.getText();
-        assert.strictEqual(balance, '$1,700.00');
+        assert.strictEqual(balance, '1');
 
         // backs up the Secret Recovery Phrase
         // should show a backup reminder
@@ -163,11 +163,11 @@ describe('Incremental Security', function () {
         // should have the correct amount of eth
         currencyDisplay = await driver.waitForSelector({
           css: '.currency-display-component__text',
-          text: '$1,700.00',
+          text: '1',
         });
         balance = await currencyDisplay.getText();
 
-        assert.strictEqual(balance, '$1,700.00');
+        assert.strictEqual(balance, '1');
 
         // The previous currencyDisplay wait already serves as the guard here for the assertElementNotPresent
         await driver.assertElementNotPresent('.backup-notification');

--- a/test/e2e/tests/localization.spec.js
+++ b/test/e2e/tests/localization.spec.js
@@ -27,7 +27,7 @@ describe('Localization', function () {
         await unlockWallet(driver);
 
         const secondaryBalance = await driver.findElement(
-          '[data-testid="eth-overview__primary-currency"]',
+          '[data-testid="eth-overview__secondary-currency"]',
         );
         const secondaryBalanceText = await secondaryBalance.getText();
         const [fiatAmount, fiatUnit] = secondaryBalanceText

--- a/test/e2e/tests/lock-account.spec.js
+++ b/test/e2e/tests/lock-account.spec.js
@@ -30,7 +30,7 @@ describe('Lock and unlock', function () {
         const walletBalance = await driver.findElement(
           '.eth-overview__primary-balance',
         );
-        assert.equal(await walletBalance.getText(), '$42,500.00\nUSD');
+        assert.equal(/^25\s*ETH$/u.test(await walletBalance.getText()), true);
       },
     );
   });

--- a/test/e2e/tests/metamask-responsive-ui.spec.js
+++ b/test/e2e/tests/metamask-responsive-ui.spec.js
@@ -72,10 +72,10 @@ describe('MetaMask Responsive UI', function () {
         await driver.clickElement('[data-testid="pin-extension-done"]');
         await driver.assertElementNotPresent('.loading-overlay__spinner');
         // assert balance
-        await driver.findElement({
-          css: '[data-testid="eth-overview__primary-currency"]',
-          text: `$ 0.00 USD`,
-        });
+        const balance = await driver.findElement(
+          '[data-testid="eth-overview__primary-currency"]',
+        );
+        assert.ok(/^0\sETH$/u.test(await balance.getText()));
       },
     );
   });

--- a/test/e2e/tests/migrate-old-vault.spec.js
+++ b/test/e2e/tests/migrate-old-vault.spec.js
@@ -32,7 +32,7 @@ describe('Migrate vault with old encryption', function () {
         const walletBalance = await driver.findElement(
           '.eth-overview__primary-balance',
         );
-        assert.equal(await walletBalance.getText(), '$42,500.00\nUSD');
+        assert.equal(/^25\s*ETH$/u.test(await walletBalance.getText()), true);
       },
     );
   });

--- a/test/e2e/tests/settings/account-token-list.spec.js
+++ b/test/e2e/tests/settings/account-token-list.spec.js
@@ -64,7 +64,7 @@ describe('Settings', function () {
         const tokenListAmount = await driver.findElement(
           '.eth-overview__primary-container',
         );
-        assert.equal(await tokenListAmount.getText(), '$42,500.00\nUSD');
+        assert.equal(await tokenListAmount.getText(), '25\nETH');
         await driver.clickElement('[data-testid="account-menu-icon"]');
         const accountTokenValue = await driver.waitForSelector(
           '.multichain-account-list-item .multichain-account-list-item__asset',

--- a/test/e2e/tests/transaction/send-eth.spec.js
+++ b/test/e2e/tests/transaction/send-eth.spec.js
@@ -187,10 +187,10 @@ describe('Send ETH', function () {
           await driver.clickElement({ text: 'Confirm', tag: 'button' });
 
           // Go back to home screen to check txn
-          await driver.findElement({
-            css: '[data-testid="eth-overview__primary-currency"]',
-            text: '$42,496.38',
-          });
+          const balance = await driver.findElement(
+            '[data-testid="eth-overview__primary-currency"]',
+          );
+          assert.ok(/^[\d.]+\sETH$/u.test(await balance.getText()));
           await driver.clickElement('[data-testid="home__activity-tab"]');
 
           await driver.findElement(
@@ -219,10 +219,10 @@ describe('Send ETH', function () {
           await unlockWallet(driver);
 
           await driver.assertElementNotPresent('.loading-overlay__spinner');
-          await driver.findElement({
-            css: '[data-testid="eth-overview__primary-currency"]',
-            text: '$42,500.00',
-          });
+          const balance = await driver.findElement(
+            '[data-testid="eth-overview__primary-currency"]',
+          );
+          assert.ok(/^[\d.]+\sETH$/u.test(await balance.getText()));
 
           await openActionMenuAndStartSendFlow(driver);
           // choose to scan via QR code
@@ -435,10 +435,10 @@ describe('Send ETH', function () {
             await unlockWallet(driver);
 
             await driver.assertElementNotPresent('.loading-overlay__spinner');
-            await driver.findElement({
-              css: '[data-testid="eth-overview__primary-currency"]',
-              text: '$42,500.00',
-            });
+            const balance = await driver.findElement(
+              '[data-testid="eth-overview__primary-currency"]',
+            );
+            assert.ok(/^[\d.]+\sETH$/u.test(await balance.getText()));
 
             await openActionMenuAndStartSendFlow(driver);
             await driver.fill(

--- a/ui/components/app/wallet-overview/eth-overview.js
+++ b/ui/components/app/wallet-overview/eth-overview.js
@@ -32,16 +32,14 @@ import {
   getCurrentChainId,
   getPreferences,
   getSelectedInternalAccount,
-  getShouldHideZeroBalanceTokens,
-  getCurrentNetwork,
   getSelectedAccountCachedBalance,
-  getShowFiatInTestnets,
   ///: BEGIN:ONLY_INCLUDE_IF(build-main,build-beta,build-flask)
   getSwapsDefaultToken,
   getCurrentKeyring,
   getIsBridgeChain,
   getIsBuyableChain,
   getMetaMetricsId,
+  getShouldShowFiat,
   ///: END:ONLY_INCLUDE_IF
 } from '../../../selectors';
 ///: BEGIN:ONLY_INCLUDE_IF(build-main,build-beta,build-flask)
@@ -66,11 +64,9 @@ import { IconColor } from '../../../helpers/constants/design-system';
 import useRamps from '../../../hooks/experiences/useRamps';
 import { getPortfolioUrl } from '../../../helpers/utils/portfolio';
 ///: END:ONLY_INCLUDE_IF
-import { useAccountTotalFiatBalance } from '../../../hooks/useAccountTotalFiatBalance';
 import { useIsOriginalNativeTokenSymbol } from '../../../hooks/useIsOriginalNativeTokenSymbol';
 import { getProviderConfig } from '../../../ducks/metamask/metamask';
 import { showPrimaryCurrency } from '../../../../shared/modules/currency-display.utils';
-import { TEST_NETWORKS } from '../../../../shared/constants/network';
 import WalletOverview from './wallet-overview';
 
 const EthOverview = ({ className, showAddress }) => {
@@ -88,10 +84,10 @@ const EthOverview = ({ className, showAddress }) => {
   const defaultSwapsToken = useSelector(getSwapsDefaultToken);
   ///: END:ONLY_INCLUDE_IF
   const balanceIsCached = useSelector(isBalanceCached);
+  const showFiat = useSelector(getShouldShowFiat);
   const { useNativeCurrencyAsPrimaryCurrency } = useSelector(getPreferences);
   const chainId = useSelector(getCurrentChainId);
   const { ticker, type } = useSelector(getProviderConfig);
-  const currentNetwork = useSelector(getCurrentNetwork);
   const balance = useSelector(getSelectedAccountCachedBalance);
   const isOriginalNativeSymbol = useIsOriginalNativeTokenSymbol(
     chainId,
@@ -99,26 +95,7 @@ const EthOverview = ({ className, showAddress }) => {
     type,
   );
 
-  // Total fiat balance
   const account = useSelector(getSelectedInternalAccount);
-  const selectedAddress = account.address;
-  const shouldHideZeroBalanceTokens = useSelector(
-    getShouldHideZeroBalanceTokens,
-  );
-  const { totalWeiBalance } = useAccountTotalFiatBalance(
-    selectedAddress,
-    shouldHideZeroBalanceTokens,
-  );
-  const showFiatInTestnets = useSelector(getShowFiatInTestnets);
-  const showFiat =
-    TEST_NETWORKS.includes(currentNetwork?.nickname) && !showFiatInTestnets;
-
-  let balanceToUse = totalWeiBalance;
-
-  if (showFiat) {
-    balanceToUse = balance;
-  }
-
   const isSwapsChain = useSelector(getIsSwapsChain);
   const isSigningEnabled =
     account.methods.includes(EthMethod.SignTransaction) ||
@@ -226,14 +203,14 @@ const EthOverview = ({ className, showAddress }) => {
         >
           <div className="eth-overview__balance">
             <div className="eth-overview__primary-container">
-              {balanceToUse ? (
+              {balance ? (
                 <UserPreferencedCurrencyDisplay
                   style={{ display: 'contents' }}
                   className={classnames('eth-overview__primary-balance', {
                     'eth-overview__cached-balance': balanceIsCached,
                   })}
                   data-testid="eth-overview__primary-currency"
-                  value={balanceToUse}
+                  value={balance}
                   type={
                     showPrimaryCurrency(
                       isOriginalNativeSymbol,
@@ -241,10 +218,6 @@ const EthOverview = ({ className, showAddress }) => {
                     )
                       ? PRIMARY
                       : SECONDARY
-                  }
-                  showFiat={
-                    !showFiat ||
-                    !TEST_NETWORKS.includes(currentNetwork?.nickname)
                   }
                   ethNumberOfDecimals={4}
                   hideTitle
@@ -259,6 +232,19 @@ const EthOverview = ({ className, showAddress }) => {
                 <span className="eth-overview__cached-star">*</span>
               ) : null}
             </div>
+            {showFiat && isOriginalNativeSymbol && balance && (
+              <UserPreferencedCurrencyDisplay
+                className={classnames({
+                  'eth-overview__cached-secondary-balance': balanceIsCached,
+                  'eth-overview__secondary-balance': !balanceIsCached,
+                })}
+                data-testid="eth-overview__secondary-currency"
+                value={balance}
+                type={SECONDARY}
+                ethNumberOfDecimals={4}
+                hideTitle
+              />
+            )}
           </div>
         </Tooltip>
       }

--- a/ui/components/app/wallet-overview/eth-overview.js
+++ b/ui/components/app/wallet-overview/eth-overview.js
@@ -28,6 +28,7 @@ import UserPreferencedCurrencyDisplay from '../user-preferenced-currency-display
 import { PRIMARY, SECONDARY } from '../../../helpers/constants/common';
 import {
   isBalanceCached,
+  getShouldShowFiat,
   getIsSwapsChain,
   getCurrentChainId,
   getPreferences,
@@ -39,7 +40,6 @@ import {
   getIsBridgeChain,
   getIsBuyableChain,
   getMetaMetricsId,
-  getShouldShowFiat,
   ///: END:ONLY_INCLUDE_IF
 } from '../../../selectors';
 ///: BEGIN:ONLY_INCLUDE_IF(build-main,build-beta,build-flask)

--- a/ui/components/app/wallet-overview/eth-overview.test.js
+++ b/ui/components/app/wallet-overview/eth-overview.test.js
@@ -172,7 +172,7 @@ describe('EthOverview', () => {
 
       const primaryBalance = queryByTestId(ETH_OVERVIEW_PRIMARY_CURRENCY);
       expect(primaryBalance).toBeInTheDocument();
-      expect(primaryBalance).toHaveTextContent('$0.00USD');
+      expect(primaryBalance).toHaveTextContent('<0.000001ETH');
       expect(queryByText('*')).not.toBeInTheDocument();
     });
 
@@ -203,7 +203,7 @@ describe('EthOverview', () => {
 
       const primaryBalance = queryByTestId(ETH_OVERVIEW_PRIMARY_CURRENCY);
       expect(primaryBalance).toBeInTheDocument();
-      expect(primaryBalance).toHaveTextContent('$0.02USD');
+      expect(primaryBalance).toHaveTextContent('0.0104ETH');
       expect(queryByText('*')).toBeInTheDocument();
     });
 


### PR DESCRIPTION
## **Description**

Partial revert of home page balance changes from https://github.com/MetaMask/metamask-extension/pull/22186

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/23614?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've clearly explained what problem this PR is solving and how it is solved.
- [ ] I've linked related issues
- [ ] I've included manual testing steps
- [ ] I've included screenshots/recordings if applicable
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [ ] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
