### PR TITLE
fix: fix typo in snap install rejected metric

### DIFF
--- a/shared/constants/metametrics.ts
+++ b/shared/constants/metametrics.ts
@@ -663,7 +663,7 @@ export enum MetaMetricsEventName {
   ///: BEGIN:ONLY_INCLUDE_IF(snaps)
   SnapInstallStarted = 'Snap Install Started',
   SnapInstallFailed = 'Snap Install Failed',
-  SnapInstallRejected = 'Snap Update Rejected',
+  SnapInstallRejected = 'Snap Install Rejected',
   SnapInstalled = 'Snap Installed',
   SnapUninstalled = 'Snap Uninstalled',
   SnapUpdateStarted = 'Snap Update Started',


### PR DESCRIPTION
## **Description**

Fixes a typo in the name for the `SnapInstallRejected` MetaMetrics event.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/23618?quickstart=1)