### PR TITLE
feat: UX MULTICHAIN: Added toast in the connections flow components

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -890,6 +890,9 @@
     "message": "$1 can see the account balance, address, activity, and suggest transactions to approve for connected accounts.",
     "description": "$1 is the origin name"
   },
+  "connectedAccountsToast": {
+    "message": "Connected accounts updated"
+  },
   "connectedSites": {
     "message": "Connected sites"
   },
@@ -1414,6 +1417,14 @@
   },
   "disconnectThisAccount": {
     "message": "Disconnect this account"
+  },
+  "disconnectedAllAccountsToast": {
+    "message": "All accounts disconnected from $1",
+    "description": "$1 is name of the dapp`"
+  },
+  "disconnectedSingleAccountToast": {
+    "message": "$1 disconnected from $2",
+    "description": "$1 is name of the name and $2 represents the dapp name`"
   },
   "discoverSnaps": {
     "message": "Discover Snaps",

--- a/ui/components/multichain/account-list-item/account-list-item.js
+++ b/ui/components/multichain/account-list-item/account-list-item.js
@@ -77,6 +77,7 @@ export const AccountListItem = ({
   currentTabOrigin,
   isActive = false,
   startAccessory,
+  onActionClick,
 }) => {
   const t = useI18nContext();
   const [accountOptionsMenuOpen, setAccountOptionsMenuOpen] = useState(false);
@@ -377,6 +378,7 @@ export const AccountListItem = ({
           closeMenu={closeMenu}
           disableAccountSwitcher={isSingleAccount}
           isOpen={accountOptionsMenuOpen}
+          onActionClick={onActionClick}
         />
       )}
     </Box>
@@ -423,6 +425,10 @@ AccountListItem.propTypes = {
    * Function that closes the menu
    */
   closeMenu: PropTypes.func,
+  /**
+   * Function to set account name to show disconnect toast when an account is disconnected
+   */
+  onActionClick: PropTypes.func,
   /**
    * File location of the avatar icon
    */

--- a/ui/components/multichain/account-list-item/account-list-item.js
+++ b/ui/components/multichain/account-list-item/account-list-item.js
@@ -428,7 +428,7 @@ AccountListItem.propTypes = {
   /**
    * Function to set account name to show disconnect toast when an account is disconnected
    */
-  onActionClick: PropTypes.func,
+  onActionClick: PropTypes.func.isRequired,
   /**
    * File location of the avatar icon
    */

--- a/ui/components/multichain/account-list-item/account-list-item.js
+++ b/ui/components/multichain/account-list-item/account-list-item.js
@@ -428,7 +428,7 @@ AccountListItem.propTypes = {
   /**
    * Function to set account name to show disconnect toast when an account is disconnected
    */
-  onActionClick: PropTypes.func.isRequired,
+  onActionClick: PropTypes.func,
   /**
    * File location of the avatar icon
    */

--- a/ui/components/multichain/connect-accounts-modal/connect-account-modal.types.ts
+++ b/ui/components/multichain/connect-accounts-modal/connect-account-modal.types.ts
@@ -23,6 +23,7 @@ export type ConnectAccountsListProps = {
   deselectAll: () => void;
   selectAll: () => void;
   handleAccountClick: (address: string) => void;
+  onAccountsUpdate: () => void;
   selectedAccounts: string[];
   accounts: AccountType[];
   checked: boolean;

--- a/ui/components/multichain/connect-accounts-modal/connect-accounts-modal-list.tsx
+++ b/ui/components/multichain/connect-accounts-modal/connect-accounts-modal-list.tsx
@@ -39,6 +39,7 @@ export const ConnectAccountsModalList: React.FC<ConnectAccountsListProps> = ({
   accounts,
   checked,
   isIndeterminate,
+  onAccountsUpdate,
 }) => {
   const t = useI18nContext();
   const activeTabOrigin = useSelector(getOriginOfCurrentTab);
@@ -47,7 +48,6 @@ export const ConnectAccountsModalList: React.FC<ConnectAccountsListProps> = ({
     <Modal isOpen onClose={onClose} data-testid="connect-more-accounts">
       <ModalOverlay />
       <ModalContent>
-        {/* Todo: Replace this with i18 text */}
         <ModalHeader
           data-testid="connect-more-accounts-title"
           onClose={onClose}
@@ -104,9 +104,11 @@ export const ConnectAccountsModalList: React.FC<ConnectAccountsListProps> = ({
                 addMorePermittedAccounts(activeTabOrigin, selectedAccounts),
               );
               onClose();
+              onAccountsUpdate();
             }}
             size={ButtonPrimarySize.Lg}
             block
+            disabled={selectedAccounts.length === 0}
           >
             {t('confirm')}
           </ButtonPrimary>

--- a/ui/components/multichain/connect-accounts-modal/connect-accounts-modal.stories.tsx
+++ b/ui/components/multichain/connect-accounts-modal/connect-accounts-modal.stories.tsx
@@ -11,6 +11,7 @@ export default {
   },
   args: {
     onClose: () => ({}),
+    onAccountsUpdate: () => ({}),
     handleAccountClick: () => ({}),
     deselectAll: () => ({}),
     selectAll: () => ({}),

--- a/ui/components/multichain/connect-accounts-modal/connect-accounts-modal.test.tsx
+++ b/ui/components/multichain/connect-accounts-modal/connect-accounts-modal.test.tsx
@@ -7,6 +7,7 @@ import { ConnectAccountsModalList } from './connect-accounts-modal-list';
 const render = () => {
   const props = {
     onClose: () => ({}),
+    onAccountsUpdate: () => ({}),
     handleAccountClick: () => ({}),
     deselectAll: () => ({}),
     selectAll: () => ({}),

--- a/ui/components/multichain/connect-accounts-modal/connect-accounts-modal.tsx
+++ b/ui/components/multichain/connect-accounts-modal/connect-accounts-modal.tsx
@@ -3,7 +3,13 @@ import { useSelector } from 'react-redux';
 import { getUnconnectedAccounts } from '../../../selectors/selectors';
 import { ConnectAccountsModalList } from './connect-accounts-modal-list';
 
-export const ConnectAccountsModal = ({ onClose }: { onClose: () => void }) => {
+export const ConnectAccountsModal = ({
+  onClose,
+  onAccountsUpdate,
+}: {
+  onClose: () => void;
+  onAccountsUpdate: () => void;
+}) => {
   const accounts = useSelector(getUnconnectedAccounts);
   const [selectedAccounts, setSelectedAccounts] = useState<string[]>([]);
 
@@ -58,6 +64,7 @@ export const ConnectAccountsModal = ({ onClose }: { onClose: () => void }) => {
       checked={checked}
       isIndeterminate={isIndeterminate}
       onClose={onClose}
+      onAccountsUpdate={onAccountsUpdate}
     />
   );
 };

--- a/ui/components/multichain/connected-accounts-menu/connected-accounts-menu.test.tsx
+++ b/ui/components/multichain/connected-accounts-menu/connected-accounts-menu.test.tsx
@@ -24,6 +24,7 @@ const DEFAULT_PROPS = {
   anchorElement: null,
   disableAccountSwitcher: false,
   closeMenu: jest.fn(),
+  onActionClick: jest.fn(),
 };
 
 const renderComponent = (props = {}, stateChanges = {}) => {

--- a/ui/components/multichain/connected-accounts-menu/connected-accounts-menu.tsx
+++ b/ui/components/multichain/connected-accounts-menu/connected-accounts-menu.tsx
@@ -36,6 +36,7 @@ export const ConnectedAccountsMenu = ({
   disableAccountSwitcher = false,
   onClose,
   closeMenu,
+  onActionClick,
 }: {
   isOpen: boolean;
   identity: Identity;
@@ -43,6 +44,7 @@ export const ConnectedAccountsMenu = ({
   disableAccountSwitcher: boolean;
   onClose: () => void;
   closeMenu: () => void;
+  onActionClick: (mesg: string) => void;
 }) => {
   const activeTabOrigin = useSelector(getOriginOfCurrentTab);
   const dispatch = useDispatch();
@@ -134,6 +136,7 @@ export const ConnectedAccountsMenu = ({
               iconColor={IconColor.errorDefault}
               data-testid="disconnect-menu-item"
               onClick={() => {
+                onActionClick(identity.metadata.name);
                 dispatch(
                   removePermittedAccount(activeTabOrigin, identity.address),
                 );

--- a/ui/components/multichain/connected-accounts-menu/connected-accounts-menu.tsx
+++ b/ui/components/multichain/connected-accounts-menu/connected-accounts-menu.tsx
@@ -44,7 +44,7 @@ export const ConnectedAccountsMenu = ({
   disableAccountSwitcher: boolean;
   onClose: () => void;
   closeMenu: () => void;
-  onActionClick: (mesg: string) => void;
+  onActionClick: (message: string) => void;
 }) => {
   const activeTabOrigin = useSelector(getOriginOfCurrentTab);
   const dispatch = useDispatch();

--- a/ui/components/multichain/pages/connections/__snapshots__/connections.test.tsx.snap
+++ b/ui/components/multichain/pages/connections/__snapshots__/connections.test.tsx.snap
@@ -218,27 +218,31 @@ exports[`Connections Content should render correctly 1`] = `
         class="mm-box multichain-page-footer mm-box--padding-4 mm-box--display-flex mm-box--gap-4 mm-box--width-full"
       >
         <div
-          class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-direction-column mm-box--width-full"
-          data-test-id="connections-button"
+          class="mm-box mm-box--display-flex mm-box--gap-4 mm-box--flex-direction-column mm-box--width-full"
         >
-          <button
-            class="mm-box mm-text mm-button-base mm-button-base--size-lg mm-button-base--block mm-button-secondary mm-text--body-md-medium mm-box--padding-0 mm-box--padding-right-4 mm-box--padding-left-4 mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-primary-default mm-box--background-color-transparent mm-box--rounded-pill mm-box--border-color-primary-default box--border-style-solid box--border-width-1"
+          <div
+            class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-direction-column mm-box--width-full"
+            data-test-id="connections-button"
           >
-            <span
-              class="mm-box mm-icon mm-icon--size-sm mm-box--margin-inline-end-1 mm-box--display-inline-block mm-box--color-inherit"
-              style="mask-image: url('./images/icons/add.svg');"
-            />
-            Connect more accounts
-          </button>
-          <button
-            class="mm-box mm-text mm-button-base mm-button-base--size-lg mm-button-base--block mm-button-secondary mm-button-secondary--type-danger mm-text--body-md-medium mm-box--padding-0 mm-box--padding-right-4 mm-box--padding-left-4 mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-error-default mm-box--background-color-transparent mm-box--rounded-pill mm-box--border-color-error-default box--border-style-solid box--border-width-1"
-          >
-            <span
-              class="mm-box mm-icon mm-icon--size-sm mm-box--margin-inline-end-1 mm-box--display-inline-block mm-box--color-inherit"
-              style="mask-image: url('./images/icons/logout.svg');"
-            />
-            Disconnect all accounts
-          </button>
+            <button
+              class="mm-box mm-text mm-button-base mm-button-base--size-lg mm-button-base--block mm-button-secondary mm-text--body-md-medium mm-box--padding-0 mm-box--padding-right-4 mm-box--padding-left-4 mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-primary-default mm-box--background-color-transparent mm-box--rounded-pill mm-box--border-color-primary-default box--border-style-solid box--border-width-1"
+            >
+              <span
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-inline-end-1 mm-box--display-inline-block mm-box--color-inherit"
+                style="mask-image: url('./images/icons/add.svg');"
+              />
+              Connect more accounts
+            </button>
+            <button
+              class="mm-box mm-text mm-button-base mm-button-base--size-lg mm-button-base--block mm-button-secondary mm-button-secondary--type-danger mm-text--body-md-medium mm-box--padding-0 mm-box--padding-right-4 mm-box--padding-left-4 mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-error-default mm-box--background-color-transparent mm-box--rounded-pill mm-box--border-color-error-default box--border-style-solid box--border-width-1"
+            >
+              <span
+                class="mm-box mm-icon mm-icon--size-sm mm-box--margin-inline-end-1 mm-box--display-inline-block mm-box--color-inherit"
+                style="mask-image: url('./images/icons/logout.svg');"
+              />
+              Disconnect all accounts
+            </button>
+          </div>
         </div>
       </div>
     </div>

--- a/ui/components/multichain/pages/connections/connections.tsx
+++ b/ui/components/multichain/pages/connections/connections.tsx
@@ -299,8 +299,6 @@ export const Connections = () => {
                     src={connectedSubjectsMetadata.iconUrl}
                   />
                 }
-                actionText={''}
-                onActionClick={() => null}
               />
             </ToastContainer>
           ) : null}
@@ -320,8 +318,6 @@ export const Connections = () => {
                     src={connectedSiteMetadata.iconUrl}
                   />
                 }
-                actionText={''}
-                onActionClick={() => null}
               />
             </ToastContainer>
           ) : null}
@@ -340,8 +336,6 @@ export const Connections = () => {
                     src={connectedSubjectsMetadata.iconUrl}
                   />
                 }
-                actionText={''}
-                onActionClick={() => null}
               />
             </ToastContainer>
           ) : null}

--- a/ui/components/multichain/pages/connections/connections.tsx
+++ b/ui/components/multichain/pages/connections/connections.tsx
@@ -27,6 +27,7 @@ import {
   getPermissionSubjects,
   getPermittedAccountsByOrigin,
   getSelectedAccount,
+  getSubjectMetadata,
 } from '../../../../selectors';
 import {
   AvatarFavicon,
@@ -93,6 +94,8 @@ export const Connections = () => {
   const subjectMetadata: { [key: string]: any } = useSelector(
     getConnectedSitesList,
   );
+  const siteMetadata = useSelector(getSubjectMetadata);
+  const connectedSiteMetadata = siteMetadata[activeTabOrigin];
   const { openMetaMaskTabs } = useSelector((state: any) => state.appState);
   const { id } = useSelector((state: any) => state.activeTab);
 
@@ -348,7 +351,13 @@ export const Connections = () => {
                 onClose={() =>
                   setShowDisconnectedAllAccountsUpdatedToast(false)
                 }
-                startAdornment={''}
+                startAdornment={
+                  <AvatarFavicon
+                    name={connectedSiteMetadata.name}
+                    size={AvatarFaviconSize.Sm}
+                    src={connectedSiteMetadata.iconUrl}
+                  />
+                }
                 actionText={''}
                 onActionClick={() => null}
               />

--- a/ui/components/multichain/pages/connections/connections.tsx
+++ b/ui/components/multichain/pages/connections/connections.tsx
@@ -287,44 +287,6 @@ export const Connections = () => {
           width={BlockSize.Full}
           gap={4}
         >
-          {connectedSubjectsMetadata && mergeAccounts.length > 0 ? (
-            <Box
-              display={Display.Flex}
-              gap={2}
-              flexDirection={FlexDirection.Column}
-              width={BlockSize.Full}
-              data-test-id="connections-button"
-            >
-              <Button
-                size={ButtonSize.Lg}
-                block
-                variant={ButtonVariant.Secondary}
-                startIconName={IconName.Add}
-                onClick={() => setShowConnectAccountsModal(true)}
-              >
-                {t('connectMoreAccounts')}
-              </Button>
-              <Button
-                size={ButtonSize.Lg}
-                block
-                variant={ButtonVariant.Secondary}
-                startIconName={IconName.Logout}
-                danger
-                onClick={() => setShowDisconnectAllModal(true)}
-              >
-                {t('disconnectAllAccounts')}
-              </Button>
-            </Box>
-          ) : (
-            <ButtonPrimary
-              size={ButtonPrimarySize.Lg}
-              block
-              data-test-id="no-connections-button"
-              onClick={() => dispatch(requestAccountsPermission())}
-            >
-              {t('connectAccounts')}
-            </ButtonPrimary>
-          )}
           {showConnectedAccountsUpdatedToast ? (
             <ToastContainer>
               <Toast
@@ -383,6 +345,44 @@ export const Connections = () => {
               />
             </ToastContainer>
           ) : null}
+          {connectedSubjectsMetadata && mergeAccounts.length > 0 ? (
+            <Box
+              display={Display.Flex}
+              gap={2}
+              flexDirection={FlexDirection.Column}
+              width={BlockSize.Full}
+              data-test-id="connections-button"
+            >
+              <Button
+                size={ButtonSize.Lg}
+                block
+                variant={ButtonVariant.Secondary}
+                startIconName={IconName.Add}
+                onClick={() => setShowConnectAccountsModal(true)}
+              >
+                {t('connectMoreAccounts')}
+              </Button>
+              <Button
+                size={ButtonSize.Lg}
+                block
+                variant={ButtonVariant.Secondary}
+                startIconName={IconName.Logout}
+                danger
+                onClick={() => setShowDisconnectAllModal(true)}
+              >
+                {t('disconnectAllAccounts')}
+              </Button>
+            </Box>
+          ) : (
+            <ButtonPrimary
+              size={ButtonPrimarySize.Lg}
+              block
+              data-test-id="no-connections-button"
+              onClick={() => dispatch(requestAccountsPermission())}
+            >
+              {t('connectAccounts')}
+            </ButtonPrimary>
+          )}
         </Box>
       </Footer>
     </Page>

--- a/ui/components/multichain/toast/toast.tsx
+++ b/ui/components/multichain/toast/toast.tsx
@@ -18,8 +18,8 @@ export const Toast = ({
 }: {
   startAdornment: React.ReactNode | React.ReactNode[];
   text: string;
-  actionText: string;
-  onActionClick: () => void;
+  actionText?: string;
+  onActionClick?: () => void;
   onClose: () => void;
 }) => {
   const { theme } = document.documentElement.dataset;


### PR DESCRIPTION
This PR is to add toast in the following scenarios:
1. Show Toast when an account is disconnected
2. Show a toast when all accounts are disconnected
3. Show Toast when a new account is connected

## **Related issues**

Fixes: [https://github.com/MetaMask/MetaMask-planning/issues/2281](https://github.com/MetaMask/MetaMask-planning/issues/2281)

## **Manual testing steps**

1. Run extension with Multichain flag
2. Connect with Dapp
3. Go the connections page
4. Connect a new account by connect more accounts flow, toast should up when you add new account
5. Disconnect all accounts, toast should show up
6. Disconnect a single account, toast should show up

## **Screenshots/Recordings**


### **Before**

NA
### **After**

### When a new account is connected

https://github.com/MetaMask/metamask-extension/assets/39872794/eb3066cf-13f2-47bb-854a-2923df915117


### When a single account is disconnected

https://github.com/MetaMask/metamask-extension/assets/39872794/d39bd064-f066-4d14-8f21-8e2fad6e4e99



### When all accounts are disconnected

https://github.com/MetaMask/metamask-extension/assets/39872794/73237bff-8e9c-4096-bc2b-5e0f4c41c372



## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've clearly explained what problem this PR is solving and how it is solved.
- [ ] I've linked related issues
- [ ] I've included manual testing steps
- [ ] I've included screenshots/recordings if applicable
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [ ] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
