### PR TITLE
fix: fix missing Snap name on permission list

### DIFF
--- a/ui/pages/permissions-connect/snaps/snap-install/snap-install.js
+++ b/ui/pages/permissions-connect/snaps/snap-install/snap-install.js
@@ -186,6 +186,7 @@ export default function SnapInstall({
             <Box marginLeft={4} marginRight={4} display={Display.Flex}>
               <SnapPermissionsList
                 snapId={targetSubjectMetadata.origin}
+                snapName={snapName}
                 permissions={requestState.permissions || {}}
               />
             </Box>


### PR DESCRIPTION
## **Description**

Fixes a missing prop causing the Snap name to not be present in the permission list.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/23627?quickstart=1)

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="376" alt="Screenshot 2024-03-21 at 15 17 15" src="https://github.com/MetaMask/metamask-extension/assets/1561200/00e28024-54ee-45d8-8a6d-66b04948502e">

### **After**

<img width="381" alt="Screenshot 2024-03-21 at 15 17 50" src="https://github.com/MetaMask/metamask-extension/assets/1561200/54dfa829-e1dd-4fa5-ad53-168c44f73aa7">


