### PR TITLE
fix: Prevent trackEvent being called multiple times for

### DIFF
--- a/ui/components/app/asset-list/asset-list.js
+++ b/ui/components/app/asset-list/asset-list.js
@@ -64,13 +64,13 @@ const AssetList = ({ onClickAsset }) => {
   const selectedAccountBalance = useSelector(getSelectedAccountCachedBalance);
   const nativeCurrency = useSelector(getNativeCurrency);
   const showFiat = useSelector(getShouldShowFiat);
-  const currentNetwork = useSelector(getCurrentNetwork);
+  const { chainId, nickname } = useSelector(getCurrentNetwork);
   const currentLocale = useSelector(getCurrentLocale);
   const isMainnet = useSelector(getIsMainnet);
   const { useNativeCurrencyAsPrimaryCurrency } = useSelector(getPreferences);
   const { ticker, type } = useSelector(getProviderConfig);
   const isOriginalNativeSymbol = useIsOriginalNativeTokenSymbol(
-    currentNetwork.chainId,
+    chainId,
     ticker,
     type,
   );
@@ -132,9 +132,9 @@ const AssetList = ({ onClickAsset }) => {
         event: MetaMetricsEventName.EmptyBuyBannerDisplayed,
         category: MetaMetricsEventCategory.Navigation,
         properties: {
-          chain_id: currentNetwork.chainId,
+          chain_id: chainId,
           locale: currentLocale,
-          network: currentNetwork.nickname,
+          network: nickname,
           referrer: ORIGIN_METAMASK,
         },
       });
@@ -144,9 +144,9 @@ const AssetList = ({ onClickAsset }) => {
         event: MetaMetricsEventName.EmptyReceiveBannerDisplayed,
         category: MetaMetricsEventCategory.Navigation,
         properties: {
-          chain_id: currentNetwork.chainId,
+          chain_id: chainId,
           locale: currentLocale,
-          network: currentNetwork.nickname,
+          network: nickname,
           referrer: ORIGIN_METAMASK,
         },
       });
@@ -155,7 +155,8 @@ const AssetList = ({ onClickAsset }) => {
     shouldShowBuy,
     shouldShowReceive,
     trackEvent,
-    currentNetwork,
+    chainId,
+    nickname,
     currentLocale,
   ]);
 
@@ -194,7 +195,7 @@ const AssetList = ({ onClickAsset }) => {
                     properties: {
                       location: 'Home',
                       text: 'Buy',
-                      chain_id: currentNetwork.chainId,
+                      chain_id: chainId,
                       token_symbol: defaultSwapsToken,
                     },
                   });


### PR DESCRIPTION
## **Description**

The `trackEvent` calls for `EmptyBuyBannerDisplayed` and `EmptyReceiveBannerDisplayed` are being called far too many times on the home screen.  This PR ensures the event is tracked only once per tab render.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/23633?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/2265

## **Manual testing steps**

1. Add a logpoint or breakpoint to `ui/components/app/asset-list/asset-list.js`'s useEffect to ensure the event is only tracked once.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've clearly explained what problem this PR is solving and how it is solved.
- [ ] I've linked related issues
- [ ] I've included manual testing steps
- [ ] I've included screenshots/recordings if applicable
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [ ] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
