### PR TITLE
fix: crypto balance should be displayed if we have scam network warning

### DIFF
--- a/ui/components/app/token-cell/__snapshots__/token-cell.test.js.snap
+++ b/ui/components/app/token-cell/__snapshots__/token-cell.test.js.snap
@@ -53,20 +53,6 @@ exports[`Token Cell should match snapshot 1`] = `
             >
               TEST
             </span>
-          </div>
-          <p
-            class="mm-box mm-text mm-text--body-md mm-text--font-weight-medium mm-text--text-align-end mm-box--width-2/3 mm-box--color-text-default"
-            data-testid="multichain-token-list-item-secondary-value"
-          >
-            5.00
-          </p>
-        </div>
-        <div
-          class="mm-box mm-box--display-flex mm-box--gap-1 mm-box--flex-direction-row mm-box--justify-content-space-between"
-        >
-          <div
-            class="mm-box mm-box--width-1/3"
-          >
             <p
               class="mm-box mm-text mm-text--body-md mm-text--font-weight-medium mm-text--ellipsis mm-box--color-text-alternative"
               data-testid="multichain-token-list-item-token-name"
@@ -75,9 +61,14 @@ exports[`Token Cell should match snapshot 1`] = `
             </p>
           </div>
           <div
-            class="mm-box mm-box--width-2/3"
-            style="overflow: hidden;"
+            class="mm-box mm-box--display-flex mm-box--flex-direction-column mm-box--align-items-flex-end mm-box--width-2/3"
           >
+            <p
+              class="mm-box mm-text mm-text--body-md mm-text--font-weight-medium mm-text--text-align-end mm-box--width-2/3 mm-box--color-text-default"
+              data-testid="multichain-token-list-item-secondary-value"
+            >
+              5.00
+            </p>
             <p
               class="mm-box mm-text mm-text--body-md mm-text--font-weight-medium mm-text--text-align-end mm-box--color-text-alternative"
               data-testid="multichain-token-list-item-value"
@@ -88,6 +79,9 @@ exports[`Token Cell should match snapshot 1`] = `
             </p>
           </div>
         </div>
+        <div
+          class="mm-box mm-box--display-flex mm-box--gap-1 mm-box--flex-direction-row mm-box--justify-content-space-between"
+        />
       </div>
     </a>
   </div>

--- a/ui/components/multichain/token-list-item/__snapshots__/token-list-item.test.js.snap
+++ b/ui/components/multichain/token-list-item/__snapshots__/token-list-item.test.js.snap
@@ -45,27 +45,18 @@ exports[`TokenListItem should render correctly 1`] = `
             <span
               class="mm-box mm-text mm-text--body-md mm-text--font-weight-medium mm-text--ellipsis mm-box--color-text-default"
             />
-          </div>
-          <p
-            class="mm-box mm-text mm-text--body-md mm-text--font-weight-medium mm-text--text-align-end mm-box--width-2/3 mm-box--color-text-default"
-            data-testid="multichain-token-list-item-secondary-value"
-          />
-        </div>
-        <div
-          class="mm-box mm-box--display-flex mm-box--gap-1 mm-box--flex-direction-row mm-box--justify-content-space-between"
-        >
-          <div
-            class="mm-box mm-box--width-1/3"
-          >
             <p
               class="mm-box mm-text mm-text--body-md mm-text--font-weight-medium mm-text--ellipsis mm-box--color-text-alternative"
               data-testid="multichain-token-list-item-token-name"
             />
           </div>
           <div
-            class="mm-box mm-box--width-2/3"
-            style="overflow: hidden;"
+            class="mm-box mm-box--display-flex mm-box--flex-direction-column mm-box--align-items-flex-end mm-box--width-2/3"
           >
+            <p
+              class="mm-box mm-text mm-text--body-md mm-text--font-weight-medium mm-text--text-align-end mm-box--width-2/3 mm-box--color-text-default"
+              data-testid="multichain-token-list-item-secondary-value"
+            />
             <p
               class="mm-box mm-text mm-text--body-md mm-text--font-weight-medium mm-text--text-align-end mm-box--color-text-alternative"
               data-testid="multichain-token-list-item-value"
@@ -74,6 +65,9 @@ exports[`TokenListItem should render correctly 1`] = `
             </p>
           </div>
         </div>
+        <div
+          class="mm-box mm-box--display-flex mm-box--gap-1 mm-box--flex-direction-row mm-box--justify-content-space-between"
+        />
       </div>
     </div>
   </div>

--- a/ui/components/multichain/token-list-item/token-list-item.js
+++ b/ui/components/multichain/token-list-item/token-list-item.js
@@ -39,6 +39,7 @@ import {
   getCurrentNetwork,
   getMetaMetricsId,
   getNativeCurrencyImage,
+  getPreferences,
   getTestNetworkBackgroundColor,
 } from '../../../selectors';
 import Tooltip from '../../ui/tooltip';
@@ -77,10 +78,12 @@ export const TokenListItem = ({
 
   // Scam warning
   const showScamWarning = isNativeCurrency && !isOriginalTokenSymbol;
+
   const dispatch = useDispatch();
   const [showScamWarningModal, setShowScamWarningModal] = useState(false);
   const environmentType = getEnvironmentType();
   const providerConfig = useSelector(getProviderConfig);
+  const { useNativeCurrencyAsPrimaryCurrency } = useSelector(getPreferences);
   const isFullScreen = environmentType === ENVIRONMENT_TYPE_FULLSCREEN;
   const history = useHistory();
 
@@ -249,41 +252,6 @@ export const TokenListItem = ({
                   )}
                 </Text>
               )}
-            </Box>
-
-            {showScamWarning ? (
-              <ButtonIcon
-                iconName={IconName.Danger}
-                onClick={(e) => {
-                  e.preventDefault();
-                  e.stopPropagation();
-                  setShowScamWarningModal(true);
-                }}
-                color={IconColor.errorDefault}
-                size={IconSize.Lg}
-                backgroundColor={BackgroundColor.transparent}
-              />
-            ) : (
-              <Text
-                fontWeight={FontWeight.Medium}
-                variant={TextVariant.bodyMd}
-                width={isStakeable ? BlockSize.Half : BlockSize.TwoThirds}
-                textAlign={TextAlign.End}
-                data-testid="multichain-token-list-item-secondary-value"
-                ellipsis={isStakeable}
-              >
-                {secondary}
-              </Text>
-            )}
-          </Box>
-          <Box
-            display={Display.Flex}
-            flexDirection={FlexDirection.Row}
-            justifyContent={JustifyContent.spaceBetween}
-            gap={1}
-          >
-            <Box width={BlockSize.OneThird}>
-              {/* bottom left */}
               <Text
                 fontWeight={FontWeight.Medium}
                 variant={TextVariant.bodyMd}
@@ -294,19 +262,85 @@ export const TokenListItem = ({
                 {tokenTitle}
               </Text>
             </Box>
-            <Box style={{ overflow: 'hidden' }} width={BlockSize.TwoThirds}>
-              {/* bottom right */}
-              <Text
-                data-testid="multichain-token-list-item-value"
-                color={TextColor.textAlternative}
-                fontWeight={FontWeight.Medium}
-                variant={TextVariant.bodyMd}
-                textAlign={TextAlign.End}
+
+            {showScamWarning ? (
+              <Box
+                display={Display.Flex}
+                flexDirection={FlexDirection.Column}
+                width={isStakeable ? BlockSize.Half : BlockSize.TwoThirds}
+                alignItems={AlignItems.flexEnd}
               >
-                {primary} {isNativeCurrency ? '' : tokenSymbol}
-              </Text>
-            </Box>
+                <ButtonIcon
+                  iconName={IconName.Danger}
+                  onClick={(e) => {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    setShowScamWarningModal(true);
+                  }}
+                  color={IconColor.errorDefault}
+                  size={IconSize.Md}
+                  backgroundColor={BackgroundColor.transparent}
+                  data-testid="scam-warning"
+                />
+
+                {useNativeCurrencyAsPrimaryCurrency ? (
+                  <Text
+                    fontWeight={FontWeight.Medium}
+                    variant={TextVariant.bodyMd}
+                    width={isStakeable ? BlockSize.Half : BlockSize.TwoThirds}
+                    textAlign={TextAlign.End}
+                    data-testid="multichain-token-list-item-secondary-value"
+                    ellipsis={isStakeable}
+                  >
+                    {secondary}
+                  </Text>
+                ) : (
+                  <Text
+                    data-testid="multichain-token-list-item-value"
+                    color={TextColor.textAlternative}
+                    fontWeight={FontWeight.Medium}
+                    variant={TextVariant.bodyMd}
+                    textAlign={TextAlign.End}
+                  >
+                    {primary} {isNativeCurrency ? '' : tokenSymbol}
+                  </Text>
+                )}
+              </Box>
+            ) : (
+              <Box
+                display={Display.Flex}
+                flexDirection={FlexDirection.Column}
+                width={isStakeable ? BlockSize.Half : BlockSize.TwoThirds}
+                alignItems={AlignItems.flexEnd}
+              >
+                <Text
+                  fontWeight={FontWeight.Medium}
+                  variant={TextVariant.bodyMd}
+                  width={isStakeable ? BlockSize.Half : BlockSize.TwoThirds}
+                  textAlign={TextAlign.End}
+                  data-testid="multichain-token-list-item-secondary-value"
+                  ellipsis={isStakeable}
+                >
+                  {secondary}
+                </Text>
+                <Text
+                  data-testid="multichain-token-list-item-value"
+                  color={TextColor.textAlternative}
+                  fontWeight={FontWeight.Medium}
+                  variant={TextVariant.bodyMd}
+                  textAlign={TextAlign.End}
+                >
+                  {primary} {isNativeCurrency ? '' : tokenSymbol}
+                </Text>
+              </Box>
+            )}
           </Box>
+          <Box
+            display={Display.Flex}
+            flexDirection={FlexDirection.Row}
+            justifyContent={JustifyContent.spaceBetween}
+            gap={1}
+          ></Box>
         </Box>
       </Box>
       {showScamWarningModal ? (

--- a/ui/components/multichain/token-list-item/token-list-item.test.js
+++ b/ui/components/multichain/token-list-item/token-list-item.test.js
@@ -20,6 +20,9 @@ const state = {
     },
     useTokenDetection: false,
     currencyRates: {},
+    preferences: {
+      useNativeCurrencyAsPrimaryCurrency: false,
+    },
   },
 };
 
@@ -52,6 +55,58 @@ describe('TokenListItem', () => {
     expect(getByTestId('multichain-token-list-item')).toHaveClass(
       'multichain-token-list-item-test',
     );
+  });
+
+  it('should render crypto balance with warning scam', () => {
+    const store = configureMockStore()(state);
+    const propsToUse = {
+      primary: '11.9751 ETH',
+      isNativeCurrency: true,
+      isOriginalTokenSymbol: false,
+    };
+    const { getByText } = renderWithProvider(
+      <TokenListItem {...propsToUse} />,
+      store,
+    );
+    expect(getByText('11.9751 ETH')).toBeInTheDocument();
+  });
+
+  it('should display warning scam modal', () => {
+    const store = configureMockStore()(state);
+    const propsToUse = {
+      primary: '11.9751 ETH',
+      isNativeCurrency: true,
+      isOriginalTokenSymbol: false,
+    };
+    const { getByTestId, getByText } = renderWithProvider(
+      <TokenListItem {...propsToUse} />,
+      store,
+    );
+
+    const warningScamModal = getByTestId('scam-warning');
+    fireEvent.click(warningScamModal);
+
+    expect(getByText('This is a potential scam')).toBeInTheDocument();
+  });
+
+  it('should render crypto balance if useNativeCurrencyAsPrimaryCurrency is false', () => {
+    const store = configureMockStore()({
+      ...state,
+      preferences: {
+        useNativeCurrencyAsPrimaryCurrency: false,
+      },
+    });
+    const propsToUse = {
+      primary: '11.9751 ETH',
+      isNativeCurrency: true,
+      isOriginalTokenSymbol: false,
+    };
+
+    const { getByText } = renderWithProvider(
+      <TokenListItem {...propsToUse} />,
+      store,
+    );
+    expect(getByText('11.9751 ETH')).toBeInTheDocument();
   });
 
   it('handles click action and fires onClick', () => {


### PR DESCRIPTION
## **Description**

the crypto balance is not displayed correctly when there's a scam warning on the network.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/23645?quickstart=1)

## **Related issues**

Fixes:  #23644 23644

## **Manual testing steps**

1. Go to Netwrok edit and choose polygon
2. change symbol from MATIC to ETH
3. go to general settings
4. change crypto primary toggle from fiat to Crypto
5. go to the wallet page and check the crypto balance

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**


https://github.com/MetaMask/metamask-extension/assets/26223211/eba494b3-9dac-4659-98d2-71bf00a995e7


### **After**


https://github.com/MetaMask/metamask-extension/assets/26223211/11e2dd6f-e817-40bb-80e5-e13aad15c239


## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained what problem this PR is solving and how it is solved.
- [x] I've linked related issues
- [x] I've included manual testing steps
- [x] I've included screenshots/recordings if applicable
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [x] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [x] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
