### PR TITLE
fix: crash when connecting to multiple Snaps at once

### DIFF
--- a/ui/components/app/snaps/snap-connect-cell/snap-connect-cell.js
+++ b/ui/components/app/snaps/snap-connect-cell/snap-connect-cell.js
@@ -18,12 +18,12 @@ import {
 import Tooltip from '../../../ui/tooltip/tooltip';
 import { useI18nContext } from '../../../../hooks/useI18nContext';
 import SnapAvatar from '../snap-avatar/snap-avatar';
-import { getSnapManifest } from '../../../../selectors';
+import { getSnapMetadata } from '../../../../selectors';
 
 export default function SnapConnectCell({ origin, snapId }) {
   const t = useI18nContext();
   const { name: snapName } = useSelector((state) =>
-    getSnapManifest(state, snapId),
+    getSnapMetadata(state, snapId),
   );
 
   return (


### PR DESCRIPTION
## **Description**

Fixes a crash when a user tries to connect to multiple Snaps at once. As part of a localization change we accidentally used the wrong selector to get the snap name. This PR swaps that selector for one that more gracefully handles the Snap not being present in the state.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/23646?quickstart=1)
