### PR TITLE
[cherry-pick 831cd9d]fix: update @blockaid/ppom_release package to 1.4.5 (#23603)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [11.13.1]
+
 ## [11.13.0]
 
 ## [11.10.0]
@@ -4392,7 +4394,8 @@ Update styles and spacing on the critical error page  ([#20350](https://github.c
 - Added the ability to restore accounts from seed words.
 
 
-[Unreleased]: https://github.com/MetaMask/metamask-extension/compare/v11.13.0...HEAD
+[Unreleased]: https://github.com/MetaMask/metamask-extension/compare/v11.13.1...HEAD
+[11.13.1]: https://github.com/MetaMask/metamask-extension/compare/v11.13.0...v11.13.1
 [11.13.0]: https://github.com/MetaMask/metamask-extension/compare/v11.10.0...v11.13.0
 [11.10.0]: https://github.com/MetaMask/metamask-extension/compare/v11.9.5...v11.10.0
 [11.9.5]: https://github.com/MetaMask/metamask-extension/compare/v11.9.4...v11.9.5

--- a/package.json
+++ b/package.json
@@ -220,7 +220,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.23.2",
-    "@blockaid/ppom_release": "^1.4.4",
+    "@blockaid/ppom_release": "^1.4.5",
     "@ensdomains/content-hash": "^2.5.7",
     "@ethereumjs/common": "^3.1.1",
     "@ethereumjs/tx": "^4.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metamask-crx",
-  "version": "11.13.0",
+  "version": "11.13.1",
   "private": true,
   "repository": {
     "type": "git",

--- a/ui/pages/confirmations/components/security-provider-banner-alert/blockaid-banner-alert/__snapshots__/blockaid-banner-alert.test.js.snap
+++ b/ui/pages/confirmations/components/security-provider-banner-alert/blockaid-banner-alert/__snapshots__/blockaid-banner-alert.test.js.snap
@@ -51,7 +51,7 @@ exports[`Blockaid Banner Alert should render 'danger' UI when securityAlertRespo
               Something doesn't look right? 
               <a
                 class="mm-box mm-text mm-button-base mm-button-link mm-button-link--size-inherit mm-text--body-md-medium mm-box--padding-0 mm-box--padding-right-0 mm-box--padding-left-0 mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-primary-default mm-box--background-color-transparent"
-                href="https://blockaid-false-positive-portal.metamask.io?data=%7B%22blockaidVersion%22%3A%221.4.4%22%2C%22classification%22%3A%22set_approval_for_all%22%2C%22resultType%22%3A%22Malicious%22%7D&utm_source=metamask-ppom"
+                href="https://blockaid-false-positive-portal.metamask.io?data=%7B%22blockaidVersion%22%3A%221.4.5%22%2C%22classification%22%3A%22set_approval_for_all%22%2C%22resultType%22%3A%22Malicious%22%7D&utm_source=metamask-ppom"
                 rel="noopener noreferrer"
                 target="_blank"
               >
@@ -144,7 +144,7 @@ exports[`Blockaid Banner Alert should render 'warning' UI when securityAlertResp
               Something doesn't look right? 
               <a
                 class="mm-box mm-text mm-button-base mm-button-link mm-button-link--size-inherit mm-text--body-md-medium mm-box--padding-0 mm-box--padding-right-0 mm-box--padding-left-0 mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-primary-default mm-box--background-color-transparent"
-                href="https://blockaid-false-positive-portal.metamask.io?data=%7B%22blockaidVersion%22%3A%221.4.4%22%2C%22classification%22%3A%22error%22%2C%22resultType%22%3A%22Error%22%7D&utm_source=metamask-ppom"
+                href="https://blockaid-false-positive-portal.metamask.io?data=%7B%22blockaidVersion%22%3A%221.4.5%22%2C%22classification%22%3A%22error%22%2C%22resultType%22%3A%22Error%22%7D&utm_source=metamask-ppom"
                 rel="noopener noreferrer"
                 target="_blank"
               >
@@ -237,7 +237,7 @@ exports[`Blockaid Banner Alert should render 'warning' UI when securityAlertResp
               Something doesn't look right? 
               <a
                 class="mm-box mm-text mm-button-base mm-button-link mm-button-link--size-inherit mm-text--body-md-medium mm-box--padding-0 mm-box--padding-right-0 mm-box--padding-left-0 mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-primary-default mm-box--background-color-transparent"
-                href="https://blockaid-false-positive-portal.metamask.io?data=%7B%22blockaidVersion%22%3A%221.4.4%22%2C%22classification%22%3A%22set_approval_for_all%22%2C%22resultType%22%3A%22Warning%22%7D&utm_source=metamask-ppom"
+                href="https://blockaid-false-positive-portal.metamask.io?data=%7B%22blockaidVersion%22%3A%221.4.5%22%2C%22classification%22%3A%22set_approval_for_all%22%2C%22resultType%22%3A%22Warning%22%7D&utm_source=metamask-ppom"
                 rel="noopener noreferrer"
                 target="_blank"
               >
@@ -331,7 +331,7 @@ exports[`Blockaid Banner Alert should render details section even when features 
                 Something doesn't look right? 
                 <a
                   class="mm-box mm-text mm-button-base mm-button-link mm-button-link--size-inherit mm-text--body-md-medium mm-box--padding-0 mm-box--padding-right-0 mm-box--padding-left-0 mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-primary-default mm-box--background-color-transparent"
-                  href="https://blockaid-false-positive-portal.metamask.io?data=%7B%22blockaidVersion%22%3A%221.4.4%22%2C%22classification%22%3A%22set_approval_for_all%22%2C%22resultType%22%3A%22Warning%22%7D&utm_source=metamask-ppom"
+                  href="https://blockaid-false-positive-portal.metamask.io?data=%7B%22blockaidVersion%22%3A%221.4.5%22%2C%22classification%22%3A%22set_approval_for_all%22%2C%22resultType%22%3A%22Warning%22%7D&utm_source=metamask-ppom"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -438,7 +438,7 @@ exports[`Blockaid Banner Alert should render details when provided 1`] = `
                 Something doesn't look right? 
                 <a
                   class="mm-box mm-text mm-button-base mm-button-link mm-button-link--size-inherit mm-text--body-md-medium mm-box--padding-0 mm-box--padding-right-0 mm-box--padding-left-0 mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-primary-default mm-box--background-color-transparent"
-                  href="https://blockaid-false-positive-portal.metamask.io?data=%7B%22blockaidVersion%22%3A%221.4.4%22%2C%22classification%22%3A%22set_approval_for_all%22%2C%22resultType%22%3A%22Warning%22%2C%22reproduce%22%3A%22%5B%5C%22Operator%20is%20an%20EOA%5C%22%2C%5C%22Operator%20is%20untrusted%20according%20to%20previous%20activity%5C%22%5D%22%7D&utm_source=metamask-ppom"
+                  href="https://blockaid-false-positive-portal.metamask.io?data=%7B%22blockaidVersion%22%3A%221.4.5%22%2C%22classification%22%3A%22set_approval_for_all%22%2C%22resultType%22%3A%22Warning%22%2C%22reproduce%22%3A%22%5B%5C%22Operator%20is%20an%20EOA%5C%22%2C%5C%22Operator%20is%20untrusted%20according%20to%20previous%20activity%5C%22%5D%22%7D&utm_source=metamask-ppom"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
@@ -533,7 +533,7 @@ exports[`Blockaid Banner Alert should render link to report url 1`] = `
                 Something doesn't look right? 
                 <a
                   class="mm-box mm-text mm-button-base mm-button-link mm-button-link--size-inherit mm-text--body-md-medium mm-box--padding-0 mm-box--padding-right-0 mm-box--padding-left-0 mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-primary-default mm-box--background-color-transparent"
-                  href="https://blockaid-false-positive-portal.metamask.io?data=%7B%22blockaidVersion%22%3A%221.4.4%22%2C%22classification%22%3A%22set_approval_for_all%22%2C%22resultType%22%3A%22Warning%22%7D&utm_source=metamask-ppom"
+                  href="https://blockaid-false-positive-portal.metamask.io?data=%7B%22blockaidVersion%22%3A%221.4.5%22%2C%22classification%22%3A%22set_approval_for_all%22%2C%22resultType%22%3A%22Warning%22%7D&utm_source=metamask-ppom"
                   rel="noopener noreferrer"
                   target="_blank"
                 >

--- a/yarn.lock
+++ b/yarn.lock
@@ -1690,10 +1690,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@blockaid/ppom_release@npm:^1.4.4":
-  version: 1.4.4
-  resolution: "@blockaid/ppom_release@npm:1.4.4"
-  checksum: 71f6276b21a59bc3b16d3335a266d199071e98009bb789ce26ab066da650b72068dff7743c3fbe86fef6dcbcef1eccef0e90362686283865b34514a956a5f4cd
+"@blockaid/ppom_release@npm:^1.4.5":
+  version: 1.4.5
+  resolution: "@blockaid/ppom_release@npm:1.4.5"
+  checksum: 653b75922951f0b73b0c9a1e3621a29d5a8d7569fbfc9e9ac89b0e14161eacc712dfe8a656107df2453b37ce1b40e59cd287dfcb6bdc73982771e3b90dfa5cca
   languageName: node
   linkType: hard
 
@@ -24845,7 +24845,7 @@ __metadata:
     "@babel/preset-typescript": "npm:^7.23.2"
     "@babel/register": "npm:^7.22.15"
     "@babel/runtime": "npm:^7.23.2"
-    "@blockaid/ppom_release": "npm:^1.4.4"
+    "@blockaid/ppom_release": "npm:^1.4.5"
     "@ensdomains/content-hash": "npm:^2.5.7"
     "@ethereumjs/common": "npm:^3.1.1"
     "@ethereumjs/tx": "npm:^4.1.1"


### PR DESCRIPTION
There were two merge conflicts resolved when cherry-picking - they were conflicts with the live above the PPOM version number in package.json and yarn.lock.