### PR TITLE
feat(2184): modify dapp visited event in terms of isFirstVisited

### DIFF
--- a/app/scripts/lib/rpc-method-middleware/handlers/request-accounts.js
+++ b/app/scripts/lib/rpc-method-middleware/handlers/request-accounts.js
@@ -108,6 +108,12 @@ async function requestEthereumAccountsHandler(
     res.result = accounts;
     const numberOfConnectedAccounts =
       getPermissionsForOrigin(origin).eth_accounts.caveats[0].value.length;
+    // first time connection to dapp will lead to no log in the permissionHistory
+    // and if user has connected to dapp before, the dapp origin will be included in the permissionHistory state
+    // we will leverage that to identify `is_first_visit` for metrics
+    const isFirstVisit = !Object.keys(metamaskState.permissionHistory).includes(
+      origin,
+    );
     sendMetrics({
       event: MetaMetricsEventName.DappViewed,
       category: MetaMetricsEventCategory.InpageProvider,
@@ -115,7 +121,7 @@ async function requestEthereumAccountsHandler(
         url: origin,
       },
       properties: {
-        is_first_visit: true,
+        is_first_visit: isFirstVisit,
         number_of_accounts: Object.keys(metamaskState.accounts).length,
         number_of_accounts_connected: numberOfConnectedAccounts,
       },


### PR DESCRIPTION
## **Description**
Modifty `is_first_visit` property in dapp viewed events to remove the haradcoded value.

- When we track the first time a dapp visit is recorded, it will be set as `true` 
- When user completely disconnects and connects again to a given dapp, this property will be set as false. 
- The rest logic remains the same

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/23659?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/2184

## **Manual testing steps**

1. Open background.html from extension management page
2. Disconnect from a previous connected dapp
3. Connect again and check events in networks starting from `batch`
4. The one under `Dapp_viewed` should have property `is_first_visit` as false

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->


https://github.com/MetaMask/metamask-extension/assets/12678455/dc834b1d-eeac-462e-9bdd-9b8fee5b07e3


## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've clearly explained what problem this PR is solving and how it is solved.
- [ ] I've linked related issues
- [ ] I've included manual testing steps
- [ ] I've included screenshots/recordings if applicable
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [ ] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
