### PR TITLE
refactor: make manifest content scripts relative to their dev location

### DIFF
--- a/app/manifest/v2/_base.json
+++ b/app/manifest/v2/_base.json
@@ -31,12 +31,12 @@
     {
       "matches": ["file://*/*", "http://*/*", "https://*/*"],
       "js": [
-        "disable-console.js",
-        "lockdown-install.js",
-        "lockdown-run.js",
-        "lockdown-more.js",
-        "contentscript.js",
-        "inpage.js"
+        "scripts/disable-console.js",
+        "scripts/lockdown-install.js",
+        "scripts/lockdown-run.js",
+        "scripts/lockdown-more.js",
+        "scripts/contentscript.js",
+        "scripts/inpage.js"
       ],
       "run_at": "document_start",
       "all_frames": true

--- a/app/manifest/v3/_base.json
+++ b/app/manifest/v3/_base.json
@@ -14,7 +14,7 @@
   },
   "author": "https://metamask.io",
   "background": {
-    "service_worker": "app-init.js"
+    "service_worker": "scripts/app-init.js"
   },
   "commands": {
     "_execute_browser_action": {
@@ -30,11 +30,11 @@
     {
       "matches": ["file://*/*", "http://*/*", "https://*/*"],
       "js": [
-        "disable-console.js",
-        "lockdown-install.js",
-        "lockdown-run.js",
-        "lockdown-more.js",
-        "contentscript.js"
+        "scripts/disable-console.js",
+        "scripts/lockdown-install.js",
+        "scripts/lockdown-run.js",
+        "scripts/lockdown-more.js",
+        "scripts/contentscript.js"
       ],
       "run_at": "document_start",
       "all_frames": true

--- a/app/scripts/app-init.js
+++ b/app/scripts/app-init.js
@@ -57,27 +57,27 @@ function importAllScripts() {
     throw new Error('Missing APPLY_LAVAMOAT environment variable');
   }
 
-  loadFile('./sentry-install.js');
+  loadFile('./scripts/sentry-install.js');
 
   // eslint-disable-next-line no-undef
   const isWorker = !self.document;
   if (!isWorker) {
-    loadFile('./snow.js');
+    loadFile('./scripts/snow.js');
   }
 
-  loadFile('./use-snow.js');
+  loadFile('./scripts/use-snow.js');
 
   // Always apply LavaMoat in e2e test builds, so that we can capture initialization stats
   if (testMode || applyLavaMoat) {
-    loadFile('./runtime-lavamoat.js');
-    loadFile('./lockdown-more.js');
-    loadFile('./policy-load.js');
+    loadFile('./scripts/runtime-lavamoat.js');
+    loadFile('./scripts/lockdown-more.js');
+    loadFile('./scripts/policy-load.js');
   } else {
-    loadFile('./init-globals.js');
-    loadFile('./lockdown-install.js');
-    loadFile('./lockdown-run.js');
-    loadFile('./lockdown-more.js');
-    loadFile('./runtime-cjs.js');
+    loadFile('./scripts/init-globals.js');
+    loadFile('./scripts/lockdown-install.js');
+    loadFile('./scripts/lockdown-run.js');
+    loadFile('./scripts/lockdown-more.js');
+    loadFile('./scripts/runtime-cjs.js');
   }
 
   // This environment variable is set to a string of comma-separated relative file paths.
@@ -145,7 +145,7 @@ const registerInPageContentScript = async () => {
       {
         id: 'inpage',
         matches: ['file://*/*', 'http://*/*', 'https://*/*'],
-        js: ['inpage.js'],
+        js: ['scripts/inpage.js'],
         runAt: 'document_start',
         world: 'MAIN',
       },

--- a/development/build/scripts.js
+++ b/development/build/scripts.js
@@ -58,7 +58,7 @@ const {
 
 // map dist files to bag of needed native APIs against LM scuttling
 const scuttlingConfigBase = {
-  'sentry-install.js': {
+  'scripts/sentry-install.js': {
     // globals sentry need to function
     window: '',
     navigator: '',
@@ -96,8 +96,8 @@ const mv3ScuttlingConfig = { ...scuttlingConfigBase };
 
 const standardScuttlingConfig = {
   ...scuttlingConfigBase,
-  'sentry-install.js': {
-    ...scuttlingConfigBase['sentry-install.js'],
+  'scripts/sentry-install.js': {
+    ...scuttlingConfigBase['scripts/sentry-install.js'],
     document: '',
   },
 };
@@ -400,7 +400,7 @@ function createScriptTasks({
       browserPlatforms,
       buildTarget,
       buildType,
-      destFilepath: `${label}.js`,
+      destFilepath: `scripts/${label}.js`,
       entryFilepath: `./app/scripts/${label}.js`,
       ignoredFiles,
       label,
@@ -424,7 +424,7 @@ function createScriptTasks({
       browserPlatforms,
       buildTarget,
       buildType,
-      destFilepath: `${label}.js`,
+      destFilepath: `scripts/${label}.js`,
       entryFilepath: `./app/scripts/${label}.js`,
       ignoredFiles,
       label,
@@ -452,7 +452,7 @@ function createScriptTasks({
         buildTarget,
         buildType,
         browserPlatforms,
-        destFilepath: `${inpage}.js`,
+        destFilepath: `scripts/${inpage}.js`,
         entryFilepath: `./app/scripts/${inpage}.js`,
         label: inpage,
         ignoredFiles,
@@ -467,25 +467,29 @@ function createScriptTasks({
         if (process.env.ENABLE_MV3) {
           return;
         }
-        // stringify inpage.js into itself, and then make it inject itself into the page
+        // stringify scripts/inpage.js into itself, and then make it inject itself into the page
         browserPlatforms.forEach((browser) => {
           makeSelfInjecting(
-            path.join(__dirname, `../../dist/${browser}/${inpage}.js`),
+            path.join(__dirname, `../../dist/${browser}/scripts/${inpage}.js`),
           );
         });
-        // delete the inpage.js source map, as it no longer represents inpage.js
-        // and so `yarn source-map-explorer` can't handle it. It's also not
-        // useful anyway, as inpage.js is injected as a `script.textContent`,
-        // and not tracked in Sentry or browsers devtools anyway.
+        // delete the scripts/inpage.js source map, as it no longer represents
+        // scripts/inpage.js and so `yarn source-map-explorer` can't handle it.
+        // It's also not useful anyway, as scripts/inpage.js is injected as a
+        // `script.textContent`, and not tracked in Sentry or browsers devtools
+        // anyway.
         unlinkSync(
-          path.join(__dirname, `../../dist/sourcemaps/${inpage}.js.map`),
+          path.join(
+            __dirname,
+            `../../dist/sourcemaps/scripts/${inpage}.js.map`,
+          ),
         );
       },
       createNormalBundle({
         buildTarget,
         buildType,
         browserPlatforms,
-        destFilepath: `${contentscript}.js`,
+        destFilepath: `scripts/${contentscript}.js`,
         entryFilepath: `./app/scripts/${contentscript}.js`,
         label: contentscript,
         ignoredFiles,
@@ -559,7 +563,7 @@ async function createManifestV3AppInitializationBundle({
     browserPlatforms: mv3BrowserPlatforms,
     buildTarget,
     buildType,
-    destFilepath: 'app-init.js',
+    destFilepath: 'scripts/app-init.js',
     entryFilepath: './app/scripts/app-init.js',
     extraEnvironmentVariables,
     ignoredFiles,
@@ -718,7 +722,7 @@ function createFactoredBuild({
       // add lavamoat policy loader file to packer output
       moduleGroupPackerStream.push(
         new Vinyl({
-          path: 'policy-load.js',
+          path: 'scripts/policy-load.js',
           contents: lavapack.makePolicyLoaderStream(lavamoatOpts),
         }),
       );
@@ -1280,18 +1284,22 @@ function renderJavaScriptLoader({
   );
 
   const securityScripts = applyLavaMoat
-    ? ['./runtime-lavamoat.js', './lockdown-more.js', './policy-load.js']
+    ? [
+        './scripts/runtime-lavamoat.js',
+        './scripts/lockdown-more.js',
+        './scripts/policy-load.js',
+      ]
     : [
-        './lockdown-install.js',
-        './lockdown-run.js',
-        './lockdown-more.js',
-        './runtime-cjs.js',
+        './scripts/lockdown-install.js',
+        './scripts/lockdown-run.js',
+        './scripts/lockdown-more.js',
+        './scripts/runtime-cjs.js',
       ];
 
   const requiredScripts = [
-    './snow.js',
-    './use-snow.js',
-    './sentry-install.js',
+    './scripts/snow.js',
+    './scripts/use-snow.js',
+    './scripts/sentry-install.js',
     ...securityScripts,
     ...jsBundles,
   ];

--- a/development/build/static.js
+++ b/development/build/static.js
@@ -155,46 +155,46 @@ function getCopyTargets(
       src: shouldIncludeSnow
         ? `./node_modules/@lavamoat/snow/snow.prod.js`
         : EMPTY_JS_FILE,
-      dest: `snow.js`,
+      dest: `scripts/snow.js`,
     },
     {
       src: shouldIncludeSnow ? `./app/scripts/use-snow.js` : EMPTY_JS_FILE,
-      dest: `use-snow.js`,
+      dest: `scripts/use-snow.js`,
     },
     {
       src: shouldIncludeLockdown
         ? getPathInsideNodeModules('ses', 'dist/lockdown.umd.min.js')
         : EMPTY_JS_FILE,
-      dest: `lockdown-install.js`,
+      dest: `scripts/lockdown-install.js`,
     },
     {
       src: './app/scripts/init-globals.js',
-      dest: 'init-globals.js',
+      dest: 'scripts/init-globals.js',
     },
     {
       src: './app/scripts/load-app.js',
-      dest: 'load-app.js',
+      dest: 'scripts/load-app.js',
     },
     {
       src: shouldIncludeLockdown
         ? `./app/scripts/lockdown-run.js`
         : EMPTY_JS_FILE,
-      dest: `lockdown-run.js`,
+      dest: `scripts/lockdown-run.js`,
     },
     {
       src: shouldIncludeLockdown
         ? `./app/scripts/lockdown-more.js`
         : EMPTY_JS_FILE,
-      dest: `lockdown-more.js`,
+      dest: `scripts/lockdown-more.js`,
     },
     {
       src: getPathInsideNodeModules('@lavamoat/lavapack', 'src/runtime-cjs.js'),
-      dest: `runtime-cjs.js`,
+      dest: `scripts/runtime-cjs.js`,
       pattern: '',
     },
     {
       src: getPathInsideNodeModules('@lavamoat/lavapack', 'src/runtime.js'),
-      dest: `runtime-lavamoat.js`,
+      dest: `scripts/runtime-lavamoat.js`,
       pattern: '',
     },
     {

--- a/development/sourcemap-validator.js
+++ b/development/sourcemap-validator.js
@@ -10,7 +10,7 @@ const fsAsync = pify(fs);
 //
 // Utility to help check if sourcemaps are working
 //
-// searches `dist/chrome/inpage.js` for "new Error" statements
+// searches `dist/chrome/scripts/inpage.js` for "new Error" statements
 // and prints their source lines using the sourcemaps.
 // if not working it may error or print minified garbage
 //
@@ -25,8 +25,8 @@ async function start() {
     `common-0.js`,
     `background-0.js`,
     `ui-0.js`,
-    `contentscript.js`,
-    // `inpage.js`, skipped because the validator can't sample the inlined `inpage.js` script
+    `scripts/contentscript.js`,
+    // `scripts/inpage.js`, skipped because the validator can't sample the inlined `scripts/inpage.js` script
   ];
   let valid = true;
 

--- a/test/e2e/mv3-perf-stats/bundle-size.js
+++ b/test/e2e/mv3-perf-stats/bundle-size.js
@@ -17,17 +17,17 @@ const { exitWithError } = require('../../../development/lib/exit-with-error');
  */
 
 const backgroundFiles = [
-  'runtime-lavamoat.js',
-  'lockdown-more.js',
-  'sentry-install.js',
-  'policy-load.js',
+  'scripts/runtime-lavamoat.js',
+  'scripts/lockdown-more.js',
+  'scripts/sentry-install.js',
+  'scripts/policy-load.js',
 ];
 
 const uiFiles = [
-  'sentry-install.js',
-  'runtime-lavamoat.js',
-  'lockdown-more.js',
-  'policy-load.js',
+  'scripts/sentry-install.js',
+  'scripts/runtime-lavamoat.js',
+  'scripts/lockdown-more.js',
+  'scripts/policy-load.js',
 ];
 
 const BackgroundFileRegex = /background-[0-9]*.js/u;


### PR DESCRIPTION
The webpack build system I'm working on uses the extension manifest JSON files to determine the entry points of the application. The manifest file _sometimes_ references files using a path relative to both the repo and the bundled extension (background.html and popup.html) and sometimes it doesn't (`inpage.js` lives in the `scripts` folder).

This PR makes the paths relative to the repo (and the bundled extension).

<!--



## **Description**



[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/23672?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
-->