### PR TITLE
refactor: remove extraneous `charset` attribute from `script` tags in all `utf-8` HTML5 documents

### DIFF
--- a/app/background.html
+++ b/app/background.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
   </head>
   <body>
-    <script src="./load-background.js" type="text/javascript" charset="utf-8"></script>
-    <script src="./chromereload.js" type="text/javascript" charset="utf-8"></script>
+    <script src="./load-background.js" type="text/javascript"></script>
+    <script src="./chromereload.js" type="text/javascript"></script>
   </body>
 </html>

--- a/app/home.html
+++ b/app/home.html
@@ -16,6 +16,6 @@
       <img class="loading-spinner" src="./images/spinner.gif" alt="" loading="lazy" />
     </div>
     <div id="popover-content"></div>
-    <script src="./load-app.js" type="text/javascript" charset="utf-8" async></script>
+    <script src="./load-app.js" type="text/javascript" async></script>
   </body>
 </html>

--- a/app/loading.html
+++ b/app/loading.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
 <html lang="en" dir="ltr">
 <head>
-  <script src="./snow.js" type="text/javascript"  charset="utf-8"></script>
-  <script src="./use-snow.js" type="text/javascript" charset="utf-8"></script>
   <meta charset="UTF-8">
+  <script src="./snow.js" type="text/javascript"></script>
+  <script src="./use-snow.js" type="text/javascript"></script>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
   <title>MetaMask Loading</title>

--- a/app/notification.html
+++ b/app/notification.html
@@ -50,11 +50,6 @@
       />
     </div>
     <div id="popover-content"></div>
-    <script
-      src="./load-app.js"
-      type="text/javascript"
-      charset="utf-8"
-      async
-    ></script>
+    <script src="./load-app.js" type="text/javascript" async></script>
   </body>
 </html>

--- a/app/popup.html
+++ b/app/popup.html
@@ -12,6 +12,6 @@
       <img class="loading-spinner" src="./images/spinner.gif" alt="" loading="lazy" />
     </div>
     <div id="popover-content"></div>
-    <script src="./load-app.js" type="text/javascript" charset="utf-8" async></script>
+    <script src="./load-app.js" type="text/javascript" async></script>
   </body>
 </html>

--- a/app/trezor-usb-permissions.html
+++ b/app/trezor-usb-permissions.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
 <html lang="en" dir="ltr">
 <head>
-  <script src="./snow.js" type="text/javascript"  charset="utf-8"></script>
-  <script src="./use-snow.js" type="text/javascript" charset="utf-8"></script>
     <meta charset="UTF-8" />
+  <script src="./snow.js" type="text/javascript"></script>
+  <script src="./use-snow.js" type="text/javascript"></script>
     <meta http-equiv="X-UA-Compatible" content="IE=Edge" />
     <meta name="viewport" content="width=device-width,initial-scale=1.0,maximum-scale=1.0,user-scalable=0" />
     <title>TrezorConnect | Trezor</title>

--- a/development/charts/flamegraph/chart/index.html
+++ b/development/charts/flamegraph/chart/index.html
@@ -70,7 +70,7 @@
     </div>
 
     <!-- D3.js -->
-    <script src="https://d3js.org/d3.v7.js" charset="utf-8"></script>
+    <script src="https://d3js.org/d3.v7.js"></script>
 
     <!-- d3-flamegraph -->
     <script type="text/javascript" src="../lib/d3-flamegraph.js"></script>

--- a/development/ts-migration-dashboard/app/public/index.html
+++ b/development/ts-migration-dashboard/app/public/index.html
@@ -8,6 +8,6 @@
   </head>
   <body>
     <div id="app"></div>
-    <script src="index.js" type="text/javascript" charset="utf-8"></script>
+    <script src="index.js" type="text/javascript"></script>
   </body>
 </html>


### PR DESCRIPTION
The html spec living standard says:

> Authors should not specify a charset attribute on a script element.

from https://html.spec.whatwg.org/dev/obsolete.html#obsolete-but-conforming-features


<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.


## **Description**



[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/23675?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
-->