### PR TITLE
feat: integrating existing blockaid alert banner into redesigned signature request pages

### DIFF
--- a/ui/pages/confirmations/components/confirm/blockaid-alert/blockaid-alert.tsx
+++ b/ui/pages/confirmations/components/confirm/blockaid-alert/blockaid-alert.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { useSelector } from 'react-redux';
+
+import {
+  currentConfirmationSelector,
+} from '../../../../../selectors';
+import { SecurityAlertResponse } from '../../../types/confirm';
+import BlockaidBannerAlert from '../../security-provider-banner-alert/blockaid-banner-alert';
+
+type SignatureSecurityAlertResponsesState = {
+  metamask: {
+    signatureSecurityAlertResponses: SecurityAlertResponse[]
+  }
+}
+
+// todo: this component can be deleted once new alert imlementation is added
+const BlockaidAlert = () => {
+  const currentConfirmation = useSelector(currentConfirmationSelector);
+  const signatureSecurityAlertResponses = useSelector(
+    (state: SignatureSecurityAlertResponsesState) => state.metamask.signatureSecurityAlertResponses
+  );
+
+  if (!currentConfirmation?.securityAlertResponse?.securityAlertId) {
+    return null;
+  }
+
+  return (
+    <BlockaidBannerAlert
+      txData={{
+        ...currentConfirmation,
+        securityAlertResponse:
+          signatureSecurityAlertResponses?.[
+            currentConfirmation?.securityAlertResponse?.securityAlertId as any
+          ],
+      }}
+    />
+  );
+};
+
+export default BlockaidAlert;

--- a/ui/pages/confirmations/components/confirm/blockaid-alert/blockaid-alert.tsx
+++ b/ui/pages/confirmations/components/confirm/blockaid-alert/blockaid-alert.tsx
@@ -1,23 +1,22 @@
 import React from 'react';
 import { useSelector } from 'react-redux';
 
-import {
-  currentConfirmationSelector,
-} from '../../../../../selectors';
+import { currentConfirmationSelector } from '../../../../../selectors';
 import { SecurityAlertResponse } from '../../../types/confirm';
 import BlockaidBannerAlert from '../../security-provider-banner-alert/blockaid-banner-alert';
 
 type SignatureSecurityAlertResponsesState = {
   metamask: {
-    signatureSecurityAlertResponses: SecurityAlertResponse[]
-  }
-}
+    signatureSecurityAlertResponses: SecurityAlertResponse[];
+  };
+};
 
 // todo: this component can be deleted once new alert imlementation is added
 const BlockaidAlert = () => {
   const currentConfirmation = useSelector(currentConfirmationSelector);
   const signatureSecurityAlertResponses = useSelector(
-    (state: SignatureSecurityAlertResponsesState) => state.metamask.signatureSecurityAlertResponses
+    (state: SignatureSecurityAlertResponsesState) =>
+      state.metamask.signatureSecurityAlertResponses,
   );
 
   if (!currentConfirmation?.securityAlertResponse?.securityAlertId) {

--- a/ui/pages/confirmations/components/confirm/blockaid-alert/index.tsx
+++ b/ui/pages/confirmations/components/confirm/blockaid-alert/index.tsx
@@ -1,0 +1,1 @@
+export { default as BlockaidAlert } from './blockaid-alert';

--- a/ui/pages/confirmations/confirm/confirm.tsx
+++ b/ui/pages/confirmations/confirm/confirm.tsx
@@ -13,6 +13,7 @@ import { Content, Page } from '../../../components/multichain/pages/page';
 import { BackgroundColor } from '../../../helpers/constants/design-system';
 import setCurrentConfirmation from '../hooks/setCurrentConfirmation';
 import syncConfirmPath from '../hooks/syncConfirmPath';
+import { BlockaidAlert } from '../components/confirm/blockaid-alert';
 
 const Confirm = () => {
   setCurrentConfirmation();
@@ -28,6 +29,12 @@ const Confirm = () => {
         ///: END:ONLY_INCLUDE_IF
       }
       <Content backgroundColor={BackgroundColor.backgroundAlternative}>
+        {
+          // todo: section below is to be removed once new alerts implementation is there
+          ///: BEGIN:ONLY_INCLUDE_IF(blockaid)
+          <BlockaidAlert />
+          ///: END:ONLY_INCLUDE_IF
+        }
         <Title />
         <ScrollToBottom>
           <Box padding={4}>

--- a/ui/pages/confirmations/types/confirm.ts
+++ b/ui/pages/confirmations/types/confirm.ts
@@ -1,6 +1,14 @@
 import { ApprovalControllerState } from '@metamask/approval-controller';
 import { TransactionType } from '@metamask/transaction-controller';
 
+export type SecurityAlertResponse = {
+  reason: string;
+  features?: string[];
+  result_type: string;
+  providerRequestsCount?: Record<string, number>;
+  securityAlertId?: string;
+};
+
 export type SignatureRequestType = {
   chainId?: string;
   id: string;
@@ -11,6 +19,7 @@ export type SignatureRequestType = {
   };
   type: TransactionType;
   custodyId?: string;
+  securityAlertResponse: SecurityAlertResponse;
 };
 
 export type Confirmation = SignatureRequestType;

--- a/ui/pages/confirmations/types/confirm.ts
+++ b/ui/pages/confirmations/types/confirm.ts
@@ -19,7 +19,7 @@ export type SignatureRequestType = {
   };
   type: TransactionType;
   custodyId?: string;
-  securityAlertResponse: SecurityAlertResponse;
+  securityAlertResponse?: SecurityAlertResponse;
 };
 
 export type Confirmation = SignatureRequestType;


### PR DESCRIPTION
## **Description**

Integrating existing blockaid alert banner into redesigned signature request pages. This is done to be abe to release signature request pages before new alerts system is developed.

## **Related issues**

Fixes: MetaMask/metamask-extension#23586

## **Manual testing steps**

1. Enable re-designed pages locally
2. Got to test dapp
3. Submit malicious permit
4. Check blockaid banner in re-designed pages

## **Screenshots/Recordings**
![Screenshot 2024-03-25 at 1 34 35 PM](https://github.com/MetaMask/metamask-extension/assets/2182307/9cfe735c-085a-4cbf-9e0e-cd206d0ad3b1)

## **Pre-merge author checklist**

- [X] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
