### PR TITLE
feat: replace confirmation re-design code fencing with env variable

### DIFF
--- a/.metamaskrc.dist
+++ b/.metamaskrc.dist
@@ -21,3 +21,4 @@ BLOCKAID_PUBLIC_KEY=
 ; SELENIUM_HEADLESS=
 ; Set this to 1 to make chrome e2e tests disable DoH/DoT and use system DNS
 ; SELENIUM_USE_SYSTEM_DNS=
+ENABLE_CONFIRMATION_REDESIGN=

--- a/builds.yml
+++ b/builds.yml
@@ -143,7 +143,6 @@ features:
     env:
       - BLOCKAID_FILE_CDN: static.cx.metamask.io/api/v1/confirmations/ppom
       - BLOCKAID_PUBLIC_KEY: 066ad3e8af5583385e312c156d238055215d5f25247c1e91055afa756cb98a88
-  conf-redesign:
   ###
   # Build Type code extensions. Things like different support links, warning pages, banners
   ###
@@ -262,7 +261,8 @@ env:
   - MULTICHAIN: ''
   # Determines if feature flagged Multichain Transactions should be used
   - TRANSACTION_MULTICHAIN: ''
-
+  # Used to enable confirmation redesigned pages
+  - ENABLE_CONFIRMATION_REDESIGN: ''
   ###
   # Meta variables
   ###

--- a/ui/pages/confirmations/components/confirm/footer/footer.tsx
+++ b/ui/pages/confirmations/components/confirm/footer/footer.tsx
@@ -9,7 +9,9 @@ import {
 } from '../../../../../components/component-library';
 import { Footer as PageFooter } from '../../../../../components/multichain/pages/page';
 import { useI18nContext } from '../../../../../hooks/useI18nContext';
+///: BEGIN:ONLY_INCLUDE_IF(build-mmi)
 import { useMMIConfirmations } from '../../../../../hooks/useMMIConfirmations';
+///: END:ONLY_INCLUDE_IF
 import { doesAddressRequireLedgerHidConnection } from '../../../../../selectors';
 import {
   rejectPendingApproval,

--- a/ui/pages/confirmations/components/index.scss
+++ b/ui/pages/confirmations/components/index.scss
@@ -10,11 +10,9 @@
 @import 'approve-content-card/index';
 @import 'confirmation-warning-modal/index';
 @import 'confirm-page-container/index';
-///: BEGIN:ONLY_INCLUDE_IF(conf-redesign)
 @import 'confirm/header/header.scss';
 @import 'confirm/scroll-to-bottom';
 @import 'confirm/nav/nav.scss';
-///: END:ONLY_INCLUDE_IF
 @import 'contract-details-modal/index';
 @import 'custom-nonce/index';
 @import 'edit-gas-display/index';

--- a/ui/pages/confirmations/confirm-transaction/confirm-transaction.component.js
+++ b/ui/pages/confirmations/confirm-transaction/confirm-transaction.component.js
@@ -12,9 +12,7 @@ import ConfirmTransactionSwitch from '../confirm-transaction-switch';
 
 import { ORIGIN_METAMASK } from '../../../../shared/constants/app';
 
-///: BEGIN:ONLY_INCLUDE_IF(conf-redesign)
 import useCurrentConfirmation from '../hooks/useCurrentConfirmation';
-///: END:ONLY_INCLUDE_IF
 import {
   clearConfirmTransaction,
   setTransactionToConfirm,
@@ -46,9 +44,7 @@ import {
   gasFeeStopPollingByPollingToken,
 } from '../../../store/actions';
 import ConfirmSignatureRequest from '../confirm-signature-request';
-///: BEGIN:ONLY_INCLUDE_IF(conf-redesign)
 import Confirm from '../confirm/confirm';
-///: END:ONLY_INCLUDE_IF
 import usePolling from '../../../hooks/usePolling';
 import ConfirmTokenTransactionSwitch from './confirm-token-transaction-switch';
 
@@ -77,10 +73,7 @@ const ConfirmTransaction = () => {
   ]);
   const [transaction, setTransaction] = useState(getTransaction);
   const use4ByteResolution = useSelector(use4ByteResolutionSelector);
-
-  ///: BEGIN:ONLY_INCLUDE_IF(conf-redesign)
   const { currentConfirmation } = useCurrentConfirmation();
-  ///: END:ONLY_INCLUDE_IF
 
   useEffect(() => {
     const tx = getTransaction();
@@ -170,7 +163,6 @@ const ConfirmTransaction = () => {
     use4ByteResolution,
   ]);
 
-  ///: BEGIN:ONLY_INCLUDE_IF(conf-redesign)
   // Code below is required as we need to support both new and old confirmation pages,
   // It takes care to render <Confirm /> component for confirmations of type Personal Sign.
   // Once we migrate all confirmations to new designs we can get rid of this code
@@ -178,7 +170,6 @@ const ConfirmTransaction = () => {
   if (currentConfirmation) {
     return <Confirm />;
   }
-  ///: END:ONLY_INCLUDE_IF
 
   if (isValidTokenMethod && isValidTransactionId) {
     return <ConfirmTokenTransactionSwitch transaction={transaction} />;

--- a/ui/pages/confirmations/hooks/useCurrentConfirmation.test.ts
+++ b/ui/pages/confirmations/hooks/useCurrentConfirmation.test.ts
@@ -3,6 +3,8 @@ import { ApprovalType } from '@metamask/controller-utils';
 import { renderHookWithProvider } from '../../../../test/lib/render-helpers';
 import useCurrentConfirmation from './useCurrentConfirmation';
 
+process.env.ENABLE_CONFIRMATION_REDESIGN = 'true';
+
 const mockState = {
   metamask: {
     unapprovedPersonalMsgs: {

--- a/ui/pages/confirmations/hooks/useCurrentConfirmation.test.ts
+++ b/ui/pages/confirmations/hooks/useCurrentConfirmation.test.ts
@@ -3,8 +3,6 @@ import { ApprovalType } from '@metamask/controller-utils';
 import { renderHookWithProvider } from '../../../../test/lib/render-helpers';
 import useCurrentConfirmation from './useCurrentConfirmation';
 
-process.env.ENABLE_CONFIRMATION_REDESIGN = 'true';
-
 const mockState = {
   metamask: {
     unapprovedPersonalMsgs: {
@@ -28,6 +26,14 @@ const mockState = {
 };
 
 describe('useCurrentConfirmation', () => {
+  beforeAll(() => {
+    process.env.ENABLE_CONFIRMATION_REDESIGN = 'true';
+  });
+
+  afterAll(() => {
+    process.env.ENABLE_CONFIRMATION_REDESIGN = 'false';
+  });
+
   it('should return current confirmation', () => {
     const { result } = renderHookWithProvider(
       () => useCurrentConfirmation(),

--- a/ui/pages/confirmations/hooks/useCurrentConfirmation.ts
+++ b/ui/pages/confirmations/hooks/useCurrentConfirmation.ts
@@ -29,6 +29,9 @@ const useCurrentConfirmation = () => {
     useState<Record<string, unknown>>();
 
   useEffect(() => {
+    if (!process.env.ENABLE_CONFIRMATION_REDESIGN) {
+      return;
+    }
     let pendingConfirmation: Approval | undefined;
     if (paramsTransactionId) {
       if (paramsTransactionId === currentConfirmation?.id) {


### PR DESCRIPTION
## **Description**
Add env variable to enable confirmation re-design and remove code fencing.

## **Related issues**

Fixes: MetaMask/metamask-extension#23600

## **Manual testing steps**
1. Enable `ENABLE_CONFIRMATION_REDESIGN` locally and start the app
2. In test dapp submit personal sign request
3. You should see request in re-designed pages

## **Screenshots/Recordings**
NA

## **Pre-merge author checklist**

- [X] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
