### PR TITLE
fix: fix network name displayed on confirmation page header

### DIFF
--- a/ui/pages/confirmations/hooks/useConfirmationNetworkInfo.test.ts
+++ b/ui/pages/confirmations/hooks/useConfirmationNetworkInfo.test.ts
@@ -4,10 +4,20 @@ import useConfirmationNetworkInfo from './useConfirmationNetworkInfo';
 
 describe('useConfirmationNetworkInfo', () => {
   it('returns display name and image when confirmation chainId is present', () => {
+    const providerConfig = {
+      chainId: '0x1',
+      rpcPrefs: { blockExplorerUrl: 'https://etherscan.io' },
+      ticker: 'ETH',
+      type: 'mainnet',
+    };
     const { result } = renderHookWithProvider(
       () => useConfirmationNetworkInfo(),
       {
         ...mockState,
+        metamask: {
+          ...mockState.metamask,
+          providerConfig,
+        },
         confirm: {
           currentConfirmation: { id: '1', chainId: '0x1' },
         },
@@ -27,6 +37,8 @@ describe('useConfirmationNetworkInfo', () => {
           ...mockState.metamask,
           providerConfig: {
             chainId: '0x7',
+            type: 'rpc',
+            id: 'testNetworkConfigurationId',
           },
           networkConfigurations: {
             ...mockState.metamask.networkConfigurations,
@@ -71,5 +83,46 @@ describe('useConfirmationNetworkInfo', () => {
 
     expect(result.current.networkDisplayName).toBe('');
     expect(result.current.networkImageUrl).toBe('');
+  });
+
+  it('returns correct details about custom network', () => {
+    const customNetwork = {
+      chainId: '0x1',
+      id: '2f9ae569-1d3e-492b-8741-cb10c2434f91',
+      nickname: 'Flashbots Protect',
+      rpcPrefs: { imageUrl: './images/eth_logo.svg' },
+      rpcUrl: 'https://rpc.flashbots.net',
+      ticker: 'ETH',
+      removable: true,
+    };
+    const providerConfig = {
+      chainId: '0x1',
+      id: '2f9ae569-1d3e-492b-8741-cb10c2434f91',
+      nickname: 'Flashbots Protect',
+      rpcPrefs: {},
+      rpcUrl: 'https://rpc.flashbots.net',
+      ticker: 'ETH',
+      type: 'rpc',
+    };
+    const { result } = renderHookWithProvider(
+      () => useConfirmationNetworkInfo(),
+      {
+        ...mockState,
+        metamask: {
+          ...mockState.metamask,
+          providerConfig,
+          networkConfigurations: {
+            ...mockState.metamask.networkConfigurations,
+            [customNetwork.id]: customNetwork,
+          },
+        },
+        confirm: {
+          currentConfirmation: { id: '1', chainId: '0x1' },
+        },
+      },
+    );
+
+    expect(result.current.networkDisplayName).toBe('Flashbots Protect');
+    expect(result.current.networkImageUrl).toBe('./images/eth_logo.svg');
   });
 });

--- a/ui/pages/confirmations/hooks/useConfirmationNetworkInfo.ts
+++ b/ui/pages/confirmations/hooks/useConfirmationNetworkInfo.ts
@@ -31,7 +31,7 @@ function useConfirmationNetworkInfo() {
     confirmationNetwork = allNetworks.find(
       ({ id, chainId }) =>
         chainId === currentChainId &&
-        (providerConfig.type === 'rpc'
+        (providerConfig.type === NETWORK_TYPES.RPC
           ? id === providerConfig.id
           : id === providerConfig.type),
     );

--- a/ui/pages/confirmations/hooks/useConfirmationNetworkInfo.ts
+++ b/ui/pages/confirmations/hooks/useConfirmationNetworkInfo.ts
@@ -29,11 +29,16 @@ function useConfirmationNetworkInfo() {
     const currentChainId =
       currentConfirmation?.chainId ?? providerConfig.chainId;
     confirmationNetwork = allNetworks.find(
-      ({ chainId }) => chainId === currentChainId,
+      ({ id, chainId }) =>
+        chainId === currentChainId &&
+        (providerConfig.type === 'rpc'
+          ? id === providerConfig.id
+          : id === providerConfig.type),
     );
+
     if (confirmationNetwork) {
-      const { nickname, providerType, type } = confirmationNetwork;
-      if (providerType === NETWORK_TYPES.RPC || type === NETWORK_TYPES.RPC) {
+      const { nickname } = confirmationNetwork;
+      if (providerConfig.type === NETWORK_TYPES.RPC) {
         networkDisplayName = nickname ?? t('privateNetwork');
       } else {
         networkDisplayName =


### PR DESCRIPTION
## **Description**
fix network name displayed on confirmation page header. network name are displayed wrong in 2 cases:

1. custom network
2. custom network with chain_id same as already defined network

## **Related issues**

Fixes: MetaMask/metamask-extension#23686

## **Manual testing steps**

1. Enable redesign locally
2. Add custom network
3. Submit a personal sign on custom network and check header

## **Screenshots/Recordings**
![Screenshot 2024-03-25 at 9 42 50 PM](https://github.com/MetaMask/metamask-extension/assets/2182307/44a827f4-15ec-4e72-bfee-ecd2300eba2e)
![Screenshot 2024-03-25 at 9 42 32 PM](https://github.com/MetaMask/metamask-extension/assets/2182307/00153de7-a289-429e-b394-3d2be21be4f9)

## **Pre-merge author checklist**

- [X] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
