### PR TITLE
UX: Multichain: Revert "Fix #22938 - UX - Multichain - Send Flow - Update ENS address upon network change"

### DIFF
--- a/ui/ducks/domains.js
+++ b/ui/ducks/domains.js
@@ -243,15 +243,14 @@ export async function fetchResolutions({ domain, chainId, state }) {
   return filteredResults;
 }
 
-export function lookupDomainName(domainName, forceInitialize = false) {
+export function lookupDomainName(domainName) {
   return async (dispatch, getState) => {
     const trimmedDomainName = domainName.trim();
     let state = getState();
-    if (state[name].stage === 'UNINITIALIZED' || forceInitialize) {
+    if (state[name].stage === 'UNINITIALIZED') {
       await dispatch(initializeDomainSlice());
     }
     state = getState();
-    let address;
     if (
       state[name].stage === 'NO_NETWORK_SUPPORT' &&
       !(
@@ -264,6 +263,7 @@ export function lookupDomainName(domainName, forceInitialize = false) {
     } else {
       await dispatch(lookupStart(trimmedDomainName));
       log.info(`Resolvers attempting to resolve name: ${trimmedDomainName}`);
+      let address;
       let fetchedResolutions;
       let hasSnapResolution = false;
       let error;
@@ -314,7 +314,6 @@ export function lookupDomainName(domainName, forceInitialize = false) {
         }),
       );
     }
-    return address;
   };
 }
 

--- a/ui/ducks/send/send.js
+++ b/ui/ducks/send/send.js
@@ -90,7 +90,7 @@ import {
   getTokens,
 } from '../metamask/metamask';
 
-import { lookupDomainName, resetDomainResolution } from '../domains';
+import { resetDomainResolution } from '../domains';
 import {
   isBurnAddress,
   isValidHexAddress,
@@ -618,16 +618,6 @@ export const initializeSendState = createAsyncThunk(
       );
     }
 
-    // If the user selects an ENS recipient and then changes the chain,
-    // the ENS address for the new chain may differ from the previous chain
-    // In this case, we should immediately trigger another lookup for the
-    // correct address on the new chain
-    const ens = draftTransaction.recipient.nickname;
-    let newEnsAddress = null;
-    if (chainHasChanged && isValidDomainName(ens)) {
-      newEnsAddress = await thunkApi.dispatch(lookupDomainName(ens, true));
-    }
-
     // Default gasPrice to 1 gwei if all estimation fails, this is only used
     // for gasLimit estimation and won't be set directly in state. Instead, we
     // will return the gasFeeEstimates and gasEstimateType so that the reducer
@@ -716,8 +706,6 @@ export const initializeSendState = createAsyncThunk(
 
     return {
       account,
-      newEnsAddress,
-      ens,
       chainId: getCurrentChainId(state),
       tokens: getTokens(state),
       chainHasChanged,
@@ -1624,12 +1612,6 @@ const slice = createSlice({
               draftTransaction.fromAccount?.balance ??
               state.selectedAccount.balance;
             draftTransaction.asset.details = null;
-          }
-          if (action.payload.newEnsAddress) {
-            draftTransaction.recipient.address = action.payload.newEnsAddress;
-          }
-          if (action.payload.ens) {
-            draftTransaction.recipient.nickname = action.payload.ens;
           }
         }
         slice.caseReducers.updateGasFeeEstimates(state, {

--- a/ui/pages/confirmations/send/send-content/add-recipient/domain-input.component.js
+++ b/ui/pages/confirmations/send/send-content/add-recipient/domain-input.component.js
@@ -32,7 +32,6 @@ export default class DomainInput extends Component {
     internalSearch: PropTypes.bool,
     userInput: PropTypes.string,
     onChange: PropTypes.func.isRequired,
-    chainId: PropTypes.string.isRequired,
     onReset: PropTypes.func.isRequired,
     lookupDomainName: PropTypes.func.isRequired,
     initializeDomainSlice: PropTypes.func.isRequired,
@@ -42,13 +41,6 @@ export default class DomainInput extends Component {
   componentDidMount() {
     this.props.initializeDomainSlice();
   }
-
-  componentDidUpdate = (prevProps) => {
-    const { chainId, userInput } = this.props;
-    if (prevProps.chainId !== chainId) {
-      this.onChange({ target: { value: userInput } });
-    }
-  };
 
   onPaste = (event) => {
     if (event.clipboardData.items?.length) {

--- a/ui/pages/confirmations/send/send-content/add-recipient/domain-input.container.js
+++ b/ui/pages/confirmations/send/send-content/add-recipient/domain-input.container.js
@@ -5,13 +5,7 @@ import {
   initializeDomainSlice,
   resetDomainResolution,
 } from '../../../../../ducks/domains';
-import { getCurrentChainId } from '../../../../../selectors';
 import DomainInput from './domain-input.component';
-
-// Trigger onChange when chainId changes using MapStateToProps
-function mapStateToProps(state) {
-  return { chainId: getCurrentChainId(state) };
-}
 
 function mapDispatchToProps(dispatch) {
   return {
@@ -27,4 +21,4 @@ function mapDispatchToProps(dispatch) {
   };
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(DomainInput);
+export default connect(null, mapDispatchToProps)(DomainInput);


### PR DESCRIPTION
## **Description**

Now that we're no longer allowing network changing in the send flow, we no longer need this ENS patch.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/23709?quickstart=1)

## **Related issues**

Fixes: N/A

## **Manual testing steps**

1. Ensure ENS works during initial send phase.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
