### PR TITLE
fix:UX: MULTICHAIN: Updated the active logic for connected accounts

### DIFF
--- a/ui/components/multichain/pages/connections/connections.tsx
+++ b/ui/components/multichain/pages/connections/connections.tsx
@@ -86,7 +86,7 @@ export const Connections = () => {
   const selectedAccount = useSelector(getSelectedAccount);
   const internalAccounts = useSelector(getInternalAccounts);
   const mergedAccounts = mergeAccounts(connectedAccounts, internalAccounts);
-  console.log(mergedAccounts);
+
   const permittedAccountsByOrigin = useSelector(
     getPermittedAccountsByOrigin,
   ) as { [key: string]: any[] };

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -2209,22 +2209,27 @@ export function getUpdatedAndSortedAccounts(state) {
   });
 
   // Find the account with the most recent lastSelected timestamp among accounts with metadata
+  const accountsWithLastSelected = accounts.filter(
+    (account) => account.connections && account.lastSelected,
+  );
 
-  const mostRecentAccount = accounts
-    .filter((account) => account.connections && account.lastSelected)
-    .reduce((prev, current) => {
-      return prev.lastSelected > current.lastSelected ? prev : current;
-    });
+  const mostRecentAccount =
+    accountsWithLastSelected.length > 0
+      ? accountsWithLastSelected.reduce((prev, current) => {
+          return prev.lastSelected > current.lastSelected ? prev : current;
+        })
+      : null;
 
   accounts.forEach((account) => {
     account.pinned = Boolean(pinnedAddresses.includes(account.address));
     account.hidden = Boolean(hiddenAddresses.includes(account.address));
-    if (account.id === mostRecentAccount.id) {
+    if (mostRecentAccount && account.id === mostRecentAccount.id) {
       account.active = true;
     } else {
       account.active = false;
     }
   });
+
   const sortedPinnedAccounts = pinnedAddresses
     ?.map((address) => accounts.find((account) => account.address === address))
     .filter((account) =>

--- a/ui/selectors/selectors.test.js
+++ b/ui/selectors/selectors.test.js
@@ -1165,7 +1165,9 @@ describe('Selectors', () => {
         balance: '0x0',
         pinned: false,
         hidden: false,
-        active: true,
+        active: false,
+        connections: true,
+        lastSelected: undefined,
       },
       {
         address: '0xc42edfcc21ed14dda456aa0756c153f7985d8813',


### PR DESCRIPTION
This PR ensures that we have correct active status for connected accounts

## **Related issues**

Fixes: [https://github.com/MetaMask/MetaMask-planning/issues/2309](https://github.com/MetaMask/MetaMask-planning/issues/2309)

## **Manual testing steps**

1. Run extension with Multichain Flag
2. connect with a dapp
3. in the account list menu, the last selected connected account, should be active.
4. If the currently selected account is connected, it should be active
5. Check same for connections page

## **Screenshots/Recordings**


### **Before**

NA
### **After**

https://github.com/MetaMask/metamask-extension/assets/39872794/c658aea2-9c21-4ad8-a3bb-9b7987ac9221



## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
