### PR TITLE
fix: patch controller-utils to add linea sepolia network type

### DIFF
--- a/.yarn/patches/@metamask-controller-utils-patch-a87ddc3d4b.patch
+++ b/.yarn/patches/@metamask-controller-utils-patch-a87ddc3d4b.patch
@@ -1,0 +1,12 @@
+diff --git a/dist/types.js b/dist/types.js
+index c59368ae1b156162acec2aacb6d593c5122e9b09..012bb5197bbeaa5738b8144a540d3db8aa8cb85c 100644
+--- a/dist/types.js
++++ b/dist/types.js
+@@ -9,6 +9,7 @@ exports.InfuraNetworkType = {
+     goerli: 'goerli',
+     sepolia: 'sepolia',
+     'linea-goerli': 'linea-goerli',
++    "linea-sepolia": "linea-sepolia",
+     'linea-mainnet': 'linea-mainnet',
+ };
+ /**

--- a/package.json
+++ b/package.json
@@ -272,7 +272,7 @@
     "@metamask/base-controller": "^4.1.0",
     "@metamask/browser-passworder": "^4.3.0",
     "@metamask/contract-metadata": "^2.3.1",
-    "@metamask/controller-utils": "patch:@metamask/controller-utils@npm%3A8.0.4#~/.yarn/patches/@metamask-controller-utils-npm-8.0.4-077edd6162.patch",
+    "@metamask/controller-utils": "patch:@metamask/controller-utils@patch%3A@metamask/controller-utils@npm%253A8.0.4%23~/.yarn/patches/@metamask-controller-utils-npm-8.0.4-077edd6162.patch%3A%3Aversion=8.0.4&hash=0d2618#~/.yarn/patches/@metamask-controller-utils-patch-a87ddc3d4b.patch",
     "@metamask/design-tokens": "^2.1.1",
     "@metamask/desktop": "^0.3.0",
     "@metamask/ens-controller": "^9.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4157,7 +4157,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/controller-utils@patch:@metamask/controller-utils@npm%3A8.0.4#~/.yarn/patches/@metamask-controller-utils-npm-8.0.4-077edd6162.patch":
+"@metamask/controller-utils@patch:@metamask/controller-utils@npm%3A8.0.4#~/.yarn/patches/@metamask-controller-utils-npm-8.0.4-077edd6162.patch::version=8.0.4&hash=0d2618":
   version: 8.0.4
   resolution: "@metamask/controller-utils@patch:@metamask/controller-utils@npm%3A8.0.4#~/.yarn/patches/@metamask-controller-utils-npm-8.0.4-077edd6162.patch::version=8.0.4&hash=0d2618"
   dependencies:
@@ -4169,6 +4169,21 @@ __metadata:
     eth-ens-namehash: "npm:^2.0.8"
     fast-deep-equal: "npm:^3.1.3"
   checksum: 280f8250164bfce90dba0151bd008ce03cc12a3272802d7056d8eae9f294020d4ef7dad22ed88d720651e6c3171203dc40c911875b78adcc4a6bc47ed91d9977
+  languageName: node
+  linkType: hard
+
+"@metamask/controller-utils@patch:@metamask/controller-utils@patch%3A@metamask/controller-utils@npm%253A8.0.4%23~/.yarn/patches/@metamask-controller-utils-npm-8.0.4-077edd6162.patch%3A%3Aversion=8.0.4&hash=0d2618#~/.yarn/patches/@metamask-controller-utils-patch-a87ddc3d4b.patch":
+  version: 8.0.4
+  resolution: "@metamask/controller-utils@patch:@metamask/controller-utils@patch%3A@metamask/controller-utils@npm%253A8.0.4%23~/.yarn/patches/@metamask-controller-utils-npm-8.0.4-077edd6162.patch%3A%3Aversion=8.0.4&hash=0d2618#~/.yarn/patches/@metamask-controller-utils-patch-a87ddc3d4b.patch::version=8.0.4&hash=a96588"
+  dependencies:
+    "@ethereumjs/util": "npm:^8.1.0"
+    "@metamask/eth-query": "npm:^4.0.0"
+    "@metamask/ethjs-unit": "npm:^0.3.0"
+    "@metamask/utils": "npm:^8.3.0"
+    "@spruceid/siwe-parser": "npm:1.1.3"
+    eth-ens-namehash: "npm:^2.0.8"
+    fast-deep-equal: "npm:^3.1.3"
+  checksum: e57683ab281515bcc55835e563792285e10b3ed6715b601356c114870fc94882b5c7c143c36f47b4d690a8a5e9008543457ecd4be5d20cf92e139638a20cad22
   languageName: node
   linkType: hard
 
@@ -24689,7 +24704,7 @@ __metadata:
     "@metamask/browser-passworder": "npm:^4.3.0"
     "@metamask/build-utils": "npm:^1.0.0"
     "@metamask/contract-metadata": "npm:^2.3.1"
-    "@metamask/controller-utils": "patch:@metamask/controller-utils@npm%3A8.0.4#~/.yarn/patches/@metamask-controller-utils-npm-8.0.4-077edd6162.patch"
+    "@metamask/controller-utils": "patch:@metamask/controller-utils@patch%3A@metamask/controller-utils@npm%253A8.0.4%23~/.yarn/patches/@metamask-controller-utils-npm-8.0.4-077edd6162.patch%3A%3Aversion=8.0.4&hash=0d2618#~/.yarn/patches/@metamask-controller-utils-patch-a87ddc3d4b.patch"
     "@metamask/design-tokens": "npm:^2.1.1"
     "@metamask/desktop": "npm:^0.3.0"
     "@metamask/ens-controller": "npm:^9.0.0"


### PR DESCRIPTION

## **Description**

Creates a patch for controller-utils to be able to get "linea-sepolia" from NetworkType

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/23727?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
