### PR TITLE
cherry-pick: Security setting layout fix

### DIFF
--- a/ui/pages/settings/security-tab/__snapshots__/security-tab.test.js.snap
+++ b/ui/pages/settings/security-tab/__snapshots__/security-tab.test.js.snap
@@ -34,15 +34,19 @@ exports[`Security Tab should match snapshot 1`] = `
     <div
       class="settings-page__security-tab-sub-header"
     >
+      <span>
+        Security alerts
+      </span>
+    </div>
+    <div
+      class="settings-page__content-padded"
+    >
       <div
         class="mm-box settings-page__content-row mm-box--display-flex mm-box--gap-4 mm-box--flex-direction-row mm-box--justify-content-space-between"
       >
         <div
           class="settings-page__content-item"
         >
-          <span>
-            Security alerts
-          </span>
           <div
             class="settings-page__content-description"
           >
@@ -100,10 +104,14 @@ exports[`Security Tab should match snapshot 1`] = `
             >
               <span
                 class="toggle-button__label-off"
-              />
+              >
+                Off
+              </span>
               <span
                 class="toggle-button__label-on"
-              />
+              >
+                On
+              </span>
             </div>
           </label>
         </div>

--- a/ui/pages/settings/security-tab/security-tab.component.js
+++ b/ui/pages/settings/security-tab/security-tab.component.js
@@ -190,45 +190,50 @@ export default class SecurityTab extends PureComponent {
     const { securityAlertsEnabled } = this.props;
 
     return (
-      <div
-        ref={this.settingsRefs[15]}
-        className="settings-page__security-tab-sub-header"
-      >
-        <Box
-          ref={this.settingsRefs[2]}
-          className="settings-page__content-row"
-          display={Display.Flex}
-          flexDirection={FlexDirection.Row}
-          justifyContent={JustifyContent.spaceBetween}
-          gap={4}
+      <>
+        <div
+          ref={this.settingsRefs[15]}
+          className="settings-page__security-tab-sub-header"
         >
-          <div className="settings-page__content-item">
-            <span>{t('securityAlerts')}</span>
-            <div className="settings-page__content-description">
-              {t('securityAlertsDescription', [
-                <a
-                  key="learn_more_link"
-                  href={SECURITY_ALERTS_LEARN_MORE_LINK}
-                  rel="noreferrer"
-                  target="_blank"
-                >
-                  {t('learnMoreUpperCase')}
-                </a>,
-              ])}
-            </div>
-          </div>
-
-          <div
-            className="settings-page__content-item-col"
-            data-testid="securityAlert"
+          <span>{t('securityAlerts')}</span>
+        </div>
+        <div className="settings-page__content-padded">
+          <Box
+            ref={this.settingsRefs[2]}
+            className="settings-page__content-row"
+            display={Display.Flex}
+            flexDirection={FlexDirection.Row}
+            justifyContent={JustifyContent.spaceBetween}
+            gap={4}
           >
-            <ToggleButton
-              value={securityAlertsEnabled}
-              onToggle={this.toggleSecurityAlert.bind(this)}
-            />
-          </div>
-        </Box>
-      </div>
+            <div className="settings-page__content-item">
+              <div className="settings-page__content-description">
+                {t('securityAlertsDescription', [
+                  <a
+                    key="learn_more_link"
+                    href={SECURITY_ALERTS_LEARN_MORE_LINK}
+                    rel="noreferrer"
+                    target="_blank"
+                  >
+                    {t('learnMoreUpperCase')}
+                  </a>,
+                ])}
+              </div>
+            </div>
+            <div
+              className="settings-page__content-item-col"
+              data-testid="securityAlert"
+            >
+              <ToggleButton
+                value={securityAlertsEnabled}
+                onToggle={this.toggleSecurityAlert.bind(this)}
+                offLabel={t('off')}
+                onLabel={t('on')}
+              />
+            </div>
+          </Box>
+        </div>
+      </>
     );
   }
 


### PR DESCRIPTION
## **Description**
Cherry-pick for security settings layout fix: https://github.com/MetaMask/metamask-extension/issues/23684

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/23684

## **Manual testing steps**

1. Go to security tab in settings
2. Check layout of security alert option

## **Screenshots/Recordings**
![Screenshot 2024-03-26 at 2 49 12 PM](https://github.com/MetaMask/metamask-extension/assets/2182307/ff6dc3a3-1c41-443f-b0ee-9eb8fd73528c)

## **Pre-merge author checklist**

- [X] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
