### PR TITLE
test: fix: ppom-middleware tests

### DIFF
--- a/app/scripts/lib/ppom/ppom-middleware.test.ts
+++ b/app/scripts/lib/ppom/ppom-middleware.test.ts
@@ -108,7 +108,7 @@ describe('PPOMMiddleware', () => {
     );
   });
 
-  it('adds validation response to confirmation requests for supported networks', async () => {
+  it('adds validation response to confirmation requests on supported networks', async () => {
     const validateMock = jest.fn().mockImplementation(() =>
       Promise.resolve({
         result_type: BlockaidResultType.Malicious,

--- a/app/scripts/lib/ppom/ppom-middleware.test.ts
+++ b/app/scripts/lib/ppom/ppom-middleware.test.ts
@@ -108,7 +108,7 @@ describe('PPOMMiddleware', () => {
     );
   });
 
-  it('adds validation response to confirmation requests', async () => {
+  it('adds validation response to confirmation requests for supported networks', async () => {
     const validateMock = jest.fn().mockImplementation(() =>
       Promise.resolve({
         result_type: BlockaidResultType.Malicious,
@@ -124,6 +124,7 @@ describe('PPOMMiddleware', () => {
     };
     const mockUpdateSecurityAlertResponseByTxId = jest.fn();
     const middlewareFunction = createMiddleWare(usePPOM, {
+      chainId: '0xa',
       mockUpdateSecurityAlertResponseByTxId,
     });
     const req = {

--- a/app/scripts/lib/ppom/ppom-middleware.test.ts
+++ b/app/scripts/lib/ppom/ppom-middleware.test.ts
@@ -166,10 +166,9 @@ describe('PPOMMiddleware', () => {
     expect(req.securityAlertResponse).toBeUndefined();
   });
 
-  it('should not do validation if user is not on mainnet', async () => {
+  it('does not do validation if user is not on a supported network', async () => {
     const usePPOM = async () => Promise.resolve('VALIDATION_RESULT');
     const middlewareFunction = createMiddleWare(usePPOM, {
-      securityAlertsEnabled: false,
       chainId: '0x2',
     });
     const req = {

--- a/app/scripts/lib/ppom/ppom-middleware.test.ts
+++ b/app/scripts/lib/ppom/ppom-middleware.test.ts
@@ -25,9 +25,12 @@ Object.defineProperty(globalThis, 'performance', {
 
 const createMiddleWare = (
   usePPOM?: any,
-  securityAlertsEnabled?: boolean,
-  chainId?: Hex,
+  options: {
+    securityAlertsEnabled?: boolean;
+    chainId?: Hex;
+  } = {},
 ) => {
+  const { securityAlertsEnabled, chainId } = options;
   const usePPOMMock = jest.fn();
   const ppomController = {
     usePPOM: usePPOM || usePPOMMock,
@@ -52,7 +55,7 @@ const createMiddleWare = (
     preferenceController as any,
     networkController as any,
     appStateController as any,
-    () => undefined,
+    mockUpdateSecurityAlertResponseByTxId,
   );
 };
 
@@ -94,7 +97,9 @@ describe('PPOMMiddleware', () => {
 
   it('should not do validation if user has not enabled preference', async () => {
     const usePPOM = async () => Promise.resolve('VALIDATION_RESULT');
-    const middlewareFunction = createMiddleWare(usePPOM, false);
+    const middlewareFunction = createMiddleWare(usePPOM, {
+      securityAlertsEnabled: false,
+    });
     const req = {
       ...JsonRpcRequestStruct,
       method: 'eth_sendTransaction',
@@ -106,7 +111,10 @@ describe('PPOMMiddleware', () => {
 
   it('should not do validation if user is not on mainnet', async () => {
     const usePPOM = async () => Promise.resolve('VALIDATION_RESULT');
-    const middlewareFunction = createMiddleWare(usePPOM, false, '0x2');
+    const middlewareFunction = createMiddleWare(usePPOM, {
+      securityAlertsEnabled: false,
+      chainId: '0x2',
+    });
     const req = {
       ...JsonRpcRequestStruct,
       method: 'eth_sendTransaction',

--- a/app/scripts/lib/ppom/ppom-middleware.test.ts
+++ b/app/scripts/lib/ppom/ppom-middleware.test.ts
@@ -88,7 +88,7 @@ describe('PPOMMiddleware', () => {
     expect(usePPOMMock).toHaveBeenCalledTimes(1);
   });
 
-  it('should add validation response on confirmation requests', async () => {
+  it('adds loading response to confirmation requests while validation is in progress', async () => {
     const usePPOM = async () => Promise.resolve('VALIDATION_RESULT');
     const middlewareFunction = createMiddleWare(usePPOM);
     const req = {
@@ -101,7 +101,11 @@ describe('PPOMMiddleware', () => {
       { ...JsonRpcResponseStruct },
       () => undefined,
     );
-    expect(req.securityAlertResponse).toBeDefined();
+
+    expect(req.securityAlertResponse.reason).toBe(BlockaidResultType.Loading);
+    expect(req.securityAlertResponse.result_type).toBe(
+      BlockaidReason.inProgress,
+    );
   });
 
   it('should not do validation if user has not enabled preference', async () => {

--- a/app/scripts/lib/ppom/ppom-middleware.test.ts
+++ b/app/scripts/lib/ppom/ppom-middleware.test.ts
@@ -153,7 +153,7 @@ describe('PPOMMiddleware', () => {
     });
   });
 
-  it('should not do validation if user has not enabled preference', async () => {
+  it('does not do validation if the user has not enabled the preference', async () => {
     const usePPOM = async () => Promise.resolve('VALIDATION_RESULT');
     const middlewareFunction = createMiddleWare(usePPOM, {
       securityAlertsEnabled: false,
@@ -219,7 +219,7 @@ describe('PPOMMiddleware', () => {
     });
   });
 
-  it('should call next method when ppomController.usePPOM completes', async () => {
+  it('calls next method when ppomController.usePPOM completes', async () => {
     const ppom = {
       validateJsonRpc: () => undefined,
     };
@@ -236,7 +236,7 @@ describe('PPOMMiddleware', () => {
     expect(nextMock).toHaveBeenCalledTimes(1);
   });
 
-  it('should call next method when ppomController.usePPOM throws error', async () => {
+  it('calls next method when ppomController.usePPOM throws error', async () => {
     const usePPOM = async (_callback: any) => {
       throw Error('Some error');
     };
@@ -249,8 +249,7 @@ describe('PPOMMiddleware', () => {
     );
     expect(nextMock).toHaveBeenCalledTimes(1);
   });
-
-  it('should call ppom.validateJsonRpc when invoked', async () => {
+  it('calls ppom.validateJsonRpc when invoked', async () => {
     const validateMock = jest.fn();
     const ppom = {
       validateJsonRpc: validateMock,
@@ -267,7 +266,7 @@ describe('PPOMMiddleware', () => {
     expect(validateMock).toHaveBeenCalledTimes(1);
   });
 
-  it('should not call ppom.validateJsonRpc when request is not for confirmation method', async () => {
+  it('does not call ppom.validateJsonRpc when request is not for confirmation method', async () => {
     const validateMock = jest.fn();
     const ppom = {
       validateJsonRpc: validateMock,


### PR DESCRIPTION
## **Description**

Fix and update ppom-middleware tests

Fix:
- test with usePPOM did not test expected thown error
  - great find by @cryptotavares 
  - test was throwing an unexpected error rather than the thrown error in the mocked method
  - the error was passing the usePPOM param as an object rather than a promise
- validation test did not test validation, but rather loading. Updated test to reflect testing loading
- added validation test
- test to check non-supported network was faulty
  - updated phrase to mention non-supported networks rather than non-eth-mainnet networks
  - removed securityProviderEnabled: false check, which blocked the test from testing

Updates:
- remove "should" prefix from test phrases
-  updates createMiddleware helper method to use an options param for optional parameters

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/23571
Related to: https://github.com/MetaMask/metamask-extension/pull/23480

## **Manual testing steps**

1. `yarn jest app/scripts/lib/ppom/ppom-middleware.test.ts`

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
