### PR TITLE
cherry-pick: Adds opensea to blockaid migration BannerAlert (#23743)

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -3300,6 +3300,15 @@
   "openSeaNew": {
     "message": "OpenSea"
   },
+  "openSeaToBlockaidBtnLabel": {
+    "message": "Explore Snaps"
+  },
+  "openSeaToBlockaidDescription": {
+    "message": "Security alerts are no longer available on this network. Installing a Snap may improve your security."
+  },
+  "openSeaToBlockaidTitle": {
+    "message": "Heads up!"
+  },
   "operationFailed": {
     "message": "Operation Failed"
   },

--- a/app/scripts/controllers/preferences.js
+++ b/app/scripts/controllers/preferences.js
@@ -52,6 +52,7 @@ export default class PreferencesController {
         eth_sign: false,
       },
       useMultiAccountBalanceChecker: true,
+      hasDismissedOpenSeaToBlockaidBanner: false,
       useSafeChainsListValidation: true,
       // set to true means the dynamic list from the API is being used
       // set to false will be using the static list from contract-metadata
@@ -189,6 +190,14 @@ export default class PreferencesController {
    */
   setUseMultiAccountBalanceChecker(val) {
     this.store.updateState({ useMultiAccountBalanceChecker: val });
+  }
+
+  /**
+   * Setter for the `dismissOpenSeaToBlockaidBanner` property
+   *
+   */
+  dismissOpenSeaToBlockaidBanner() {
+    this.store.updateState({ hasDismissedOpenSeaToBlockaidBanner: true });
   }
 
   /**

--- a/app/scripts/controllers/preferences.test.js
+++ b/app/scripts/controllers/preferences.test.js
@@ -199,6 +199,23 @@ describe('preferences controller', () => {
     });
   });
 
+  describe('dismissOpenSeaToBlockaidBanner', () => {
+    it('hasDismissedOpenSeaToBlockaidBanner should default to false', () => {
+      expect(
+        preferencesController.store.getState()
+          .hasDismissedOpenSeaToBlockaidBanner,
+      ).toStrictEqual(false);
+    });
+
+    it('should set the hasDismissedOpenSeaToBlockaidBanner property in state', () => {
+      preferencesController.dismissOpenSeaToBlockaidBanner();
+      expect(
+        preferencesController.store.getState()
+          .hasDismissedOpenSeaToBlockaidBanner,
+      ).toStrictEqual(true);
+    });
+  });
+
   describe('setUseSafeChainsListValidation', function () {
     it('should default to true', function () {
       const state = preferencesController.store.getState();

--- a/app/scripts/lib/setupSentry.js
+++ b/app/scripts/lib/setupSentry.js
@@ -237,6 +237,7 @@ export const SENTRY_BACKGROUND_STATE = {
     useTokenDetection: true,
     useRequestQueue: true,
     useTransactionSimulations: true,
+    hasDismissedOpenSeaToBlockaidBanner: true,
   },
   SelectedNetworkController: { domains: false },
   SignatureController: {

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -2879,6 +2879,10 @@ export default class MetamaskController extends EventEmitter {
         preferencesController.setUseMultiAccountBalanceChecker.bind(
           preferencesController,
         ),
+      dismissOpenSeaToBlockaidBanner:
+        preferencesController.dismissOpenSeaToBlockaidBanner.bind(
+          preferencesController,
+        ),
       setUseSafeChainsListValidation:
         preferencesController.setUseSafeChainsListValidation.bind(
           preferencesController,

--- a/app/scripts/migrations/114.test.ts
+++ b/app/scripts/migrations/114.test.ts
@@ -21,7 +21,7 @@ describe('migration #114', () => {
   });
 
   describe('deprecates transactionSecurityCheckEnabled in PreferencesController', () => {
-    it('sets securityAlertsEnabled to true if transactionSecurityCheckEnabled is true', async () => {
+    it('sets securityAlertsEnabled and hasMigratedFromOpenSeaToBlockaid to true if transactionSecurityCheckEnabled is true', async () => {
       const oldStorage = {
         PreferencesController: {
           transactionSecurityCheckEnabled: true,
@@ -32,6 +32,7 @@ describe('migration #114', () => {
       const expectedState = {
         PreferencesController: {
           securityAlertsEnabled: true,
+          hasMigratedFromOpenSeaToBlockaid: true,
         },
       };
 

--- a/app/scripts/migrations/114.ts
+++ b/app/scripts/migrations/114.ts
@@ -43,6 +43,7 @@ function transformState(state: Record<string, any>) {
   ) {
     if (state.PreferencesController.transactionSecurityCheckEnabled) {
       state.PreferencesController.securityAlertsEnabled = true;
+      state.PreferencesController.hasMigratedFromOpenSeaToBlockaid = true;
     }
 
     delete state.PreferencesController.transactionSecurityCheckEnabled;

--- a/test/e2e/tests/ppom/migrate-opensea-to-blockaid-banner.spec.js
+++ b/test/e2e/tests/ppom/migrate-opensea-to-blockaid-banner.spec.js
@@ -1,0 +1,135 @@
+const { connectAccountToTestDapp } = require('../../accounts/common');
+const FixtureBuilder = require('../../fixture-builder');
+const {
+  defaultGanacheOptions,
+  unlockWallet,
+  withFixtures,
+  openDapp,
+  WINDOW_TITLES,
+} = require('../../helpers');
+
+describe('Migrate Opensea to Blockaid Banner @no-mmi', function () {
+  it('Shows up on simple send transaction', async function () {
+    await withFixtures(
+      {
+        dapp: true,
+        fixtures: new FixtureBuilder()
+          .withPreferencesController({ hasMigratedFromOpenSeaToBlockaid: true })
+          .build(),
+        ganacheOptions: defaultGanacheOptions,
+        title: this.test.fullTitle(),
+      },
+      async ({ driver }) => {
+        await driver.navigate();
+        await unlockWallet(driver);
+        await openDapp(driver);
+
+        await connectAccountToTestDapp(driver);
+
+        await driver.switchToWindowWithTitle(WINDOW_TITLES.TestDApp);
+        await driver.clickElement('#sendButton');
+        await driver.delay(2000);
+
+        await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
+        await driver.waitForSelector({ text: 'Heads up!', tag: 'p' });
+      },
+    );
+  });
+
+  it('Shows up on token approval', async function () {
+    await withFixtures(
+      {
+        dapp: true,
+        fixtures: new FixtureBuilder()
+          .withPreferencesController({ hasMigratedFromOpenSeaToBlockaid: true })
+          .build(),
+        ganacheOptions: defaultGanacheOptions,
+        title: this.test.fullTitle(),
+      },
+      async ({ driver }) => {
+        await driver.navigate();
+        await unlockWallet(driver);
+        await openDapp(driver);
+
+        await connectAccountToTestDapp(driver);
+
+        await driver.switchToWindowWithTitle(WINDOW_TITLES.TestDApp);
+        await driver.findClickableElement('#createToken');
+        await driver.clickElement('#createToken');
+        await driver.delay(2000);
+
+        await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
+        await driver.findClickableElements({
+          text: 'Confirm',
+          tag: 'button',
+        });
+        await driver.clickElement({
+          text: 'Confirm',
+          tag: 'button',
+        });
+
+        await driver.switchToWindowWithTitle(WINDOW_TITLES.TestDApp);
+        await driver.clickElement({ text: 'Approve Tokens', tag: 'button' });
+        await driver.delay(2000);
+
+        await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
+        await driver.waitForSelector({ text: 'Heads up!', tag: 'p' });
+      },
+    );
+  });
+
+  it('Shows up on personal signature', async function () {
+    await withFixtures(
+      {
+        dapp: true,
+        fixtures: new FixtureBuilder()
+          .withPreferencesController({ hasMigratedFromOpenSeaToBlockaid: true })
+          .build(),
+        ganacheOptions: defaultGanacheOptions,
+        title: this.test.fullTitle(),
+      },
+      async ({ driver }) => {
+        await driver.navigate();
+        await unlockWallet(driver);
+        await openDapp(driver);
+
+        await connectAccountToTestDapp(driver);
+
+        await driver.switchToWindowWithTitle(WINDOW_TITLES.TestDApp);
+        await driver.clickElement('#personalSign');
+        await driver.delay(2000);
+
+        await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
+        await driver.waitForSelector({ text: 'Heads up!', tag: 'p' });
+      },
+    );
+  });
+
+  it('Shows up on contract interaction', async function () {
+    await withFixtures(
+      {
+        dapp: true,
+        fixtures: new FixtureBuilder()
+          .withPreferencesController({ hasMigratedFromOpenSeaToBlockaid: true })
+          .build(),
+        ganacheOptions: defaultGanacheOptions,
+        title: this.test.fullTitle(),
+      },
+      async ({ driver }) => {
+        await driver.navigate();
+        await unlockWallet(driver);
+        await openDapp(driver);
+
+        await connectAccountToTestDapp(driver);
+
+        await driver.switchToWindowWithTitle(WINDOW_TITLES.TestDApp);
+
+        await driver.clickElement('#deployMultisigButton');
+        await driver.delay(2000);
+
+        await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
+        await driver.waitForSelector({ text: 'Heads up!', tag: 'p' });
+      },
+    );
+  });
+});

--- a/test/e2e/tests/state-snapshots/errors-after-init-opt-in-background-state.json
+++ b/test/e2e/tests/state-snapshots/errors-after-init-opt-in-background-state.json
@@ -155,6 +155,7 @@
     "addSnapAccountEnabled": "boolean",
     "advancedGasFee": {},
     "featureFlags": {},
+    "hasDismissedOpenSeaToBlockaidBanner": false,
     "incomingTransactionsPreferences": {},
     "knownMethodData": "object",
     "currentLocale": "en",

--- a/test/e2e/tests/state-snapshots/errors-after-init-opt-in-ui-state.json
+++ b/test/e2e/tests/state-snapshots/errors-after-init-opt-in-ui-state.json
@@ -74,6 +74,7 @@
     "showAccountBanner": true,
     "trezorModel": null,
     "hadAdvancedGasFeesSetPriorToMigration92_3": false,
+    "hasDismissedOpenSeaToBlockaidBanner": false,
     "nftsDropdownState": {},
     "termsOfUseLastAgreed": "number",
     "qrHardware": {},

--- a/ui/pages/confirmations/components/signature-request-original/signature-request-original.component.js
+++ b/ui/pages/confirmations/components/signature-request-original/signature-request-original.component.js
@@ -26,6 +26,7 @@ import {
   TextAlign,
   TextColor,
   Size,
+  Severity,
   ///: BEGIN:ONLY_INCLUDE_IF(build-mmi)
   IconColor,
   Display,
@@ -36,6 +37,7 @@ import {
 } from '../../../../helpers/constants/design-system';
 import {
   ButtonLink,
+  BannerAlert,
   ///: BEGIN:ONLY_INCLUDE_IF(build-mmi)
   Box,
   Icon,
@@ -85,6 +87,10 @@ export default class SignatureRequestOriginal extends Component {
     mostRecentOverviewPage: PropTypes.string.isRequired,
     resolvePendingApproval: PropTypes.func.isRequired,
     completedTx: PropTypes.func.isRequired,
+    hasMigratedFromOpenSeaToBlockaid: PropTypes.bool.isRequired,
+    isNetworkSupportedByBlockaid: PropTypes.bool.isRequired,
+    hasDismissedOpenSeaToBlockaidBanner: PropTypes.bool.isRequired,
+    dismissOpenSeaToBlockaidBanner: PropTypes.func.isRequired,
     ///: BEGIN:ONLY_INCLUDE_IF(build-mmi)
     // Used to show a warning if the signing account is not the selected account
     // Largely relevant for contract wallet custodians
@@ -129,6 +135,8 @@ export default class SignatureRequestOriginal extends Component {
   };
 
   renderBody = () => {
+    const { t } = this.context;
+
     let rows;
     const notice = `${this.context.t('youSign')}:`;
 
@@ -150,6 +158,20 @@ export default class SignatureRequestOriginal extends Component {
       ? subjectMetadata?.[txData.msgParams.origin]
       : null;
 
+    const {
+      hasMigratedFromOpenSeaToBlockaid,
+      isNetworkSupportedByBlockaid,
+      hasDismissedOpenSeaToBlockaidBanner,
+      dismissOpenSeaToBlockaidBanner,
+    } = this.props;
+    const showOpenSeaToBlockaidBannerAlert =
+      hasMigratedFromOpenSeaToBlockaid &&
+      !isNetworkSupportedByBlockaid &&
+      !hasDismissedOpenSeaToBlockaidBanner;
+    const handleCloseOpenSeaToBlockaidBannerAlert = () => {
+      dismissOpenSeaToBlockaidBanner();
+    };
+
     return (
       <div className="request-signature__body">
         {
@@ -162,6 +184,23 @@ export default class SignatureRequestOriginal extends Component {
             securityProviderResponse={txData.securityProviderResponse}
           />
         )}
+        {showOpenSeaToBlockaidBannerAlert ? (
+          <BannerAlert
+            severity={Severity.Info}
+            title={t('openSeaToBlockaidTitle')}
+            description={t('openSeaToBlockaidDescription')}
+            actionButtonLabel={t('openSeaToBlockaidBtnLabel')}
+            actionButtonProps={{
+              href: 'https://snaps.metamask.io/transaction-insights',
+              externalLink: true,
+            }}
+            marginBottom={4}
+            marginLeft={4}
+            marginTop={4}
+            marginRight={4}
+            onClose={handleCloseOpenSeaToBlockaidBannerAlert}
+          />
+        ) : null}
         {
           ///: BEGIN:ONLY_INCLUDE_IF(build-mmi)
           this.props.selectedAccount.address ===

--- a/ui/pages/confirmations/components/signature-request-original/signature-request-original.container.js
+++ b/ui/pages/confirmations/components/signature-request-original/signature-request-original.container.js
@@ -8,6 +8,7 @@ import {
   rejectPendingApproval,
   rejectAllMessages,
   completedTx,
+  dismissOpenSeaToBlockaidBanner,
 } from '../../../../store/actions';
 ///: BEGIN:ONLY_INCLUDE_IF(build-mmi)
 // eslint-disable-next-line import/order
@@ -22,6 +23,9 @@ import {
   doesAddressRequireLedgerHidConnection,
   unconfirmedMessagesHashSelector,
   getTotalUnapprovedMessagesCount,
+  getIsNetworkSupportedByBlockaid,
+  getHasDismissedOpenSeaToBlockaidBanner,
+  getHasMigratedFromOpenSeaToBlockaid,
   ///: BEGIN:ONLY_INCLUDE_IF(build-mmi)
   getAccountType,
   getSelectedInternalAccount,
@@ -44,6 +48,12 @@ function mapStateToProps(state, ownProps) {
   const messagesList = unconfirmedMessagesHashSelector(state);
   const messagesCount = getTotalUnapprovedMessagesCount(state);
 
+  const hasMigratedFromOpenSeaToBlockaid =
+    getHasMigratedFromOpenSeaToBlockaid(state);
+  const hasDismissedOpenSeaToBlockaidBanner =
+    getHasDismissedOpenSeaToBlockaidBanner(state);
+  const isNetworkSupportedByBlockaid = getIsNetworkSupportedByBlockaid(state);
+
   return {
     requester: null,
     requesterAddress: null,
@@ -55,6 +65,9 @@ function mapStateToProps(state, ownProps) {
     subjectMetadata: getSubjectMetadata(state),
     messagesList,
     messagesCount,
+    hasMigratedFromOpenSeaToBlockaid,
+    hasDismissedOpenSeaToBlockaidBanner,
+    isNetworkSupportedByBlockaid,
     ///: BEGIN:ONLY_INCLUDE_IF(build-mmi)
     accountType: getAccountType(state),
     selectedAccount: getSelectedInternalAccount(state),
@@ -90,6 +103,8 @@ mapDispatchToProps = function (dispatch) {
     cancelAllApprovals: (messagesList) => {
       dispatch(rejectAllMessages(messagesList));
     },
+    dismissOpenSeaToBlockaidBanner: () =>
+      dispatch(dismissOpenSeaToBlockaidBanner()),
   };
 };
 

--- a/ui/pages/confirmations/confirm-transaction-base/confirm-transaction-base.component.js
+++ b/ui/pages/confirmations/confirm-transaction-base/confirm-transaction-base.component.js
@@ -65,6 +65,8 @@ import SnapAccountTransactionLoadingScreen from '../../snap-account-transaction-
 import { isHardwareKeyring } from '../../../helpers/utils/hardware';
 import FeeDetailsComponent from '../components/fee-details-component/fee-details-component';
 import { SimulationDetails } from '../components/simulation-details';
+import { BannerAlert } from '../../../components/component-library';
+import { Severity } from '../../../helpers/constants/design-system';
 
 export default class ConfirmTransactionBase extends Component {
   static contextTypes = {
@@ -168,6 +170,10 @@ export default class ConfirmTransactionBase extends Component {
     useMaxValue: PropTypes.bool,
     maxValue: PropTypes.string,
     isMultiLayerFeeNetwork: PropTypes.bool,
+    hasMigratedFromOpenSeaToBlockaid: PropTypes.bool,
+    hasDismissedOpenSeaToBlockaidBanner: PropTypes.bool,
+    dismissOpenSeaToBlockaidBanner: PropTypes.func,
+    isNetworkSupportedByBlockaid: PropTypes.bool,
   };
 
   state = {
@@ -393,6 +399,10 @@ export default class ConfirmTransactionBase extends Component {
       tokenSymbol,
       isUsingPaymaster,
       isMultiLayerFeeNetwork,
+      hasMigratedFromOpenSeaToBlockaid,
+      hasDismissedOpenSeaToBlockaidBanner,
+      dismissOpenSeaToBlockaidBanner,
+      isNetworkSupportedByBlockaid,
     } = this.props;
 
     const { t } = this.context;
@@ -516,8 +526,33 @@ export default class ConfirmTransactionBase extends Component {
       />
     );
 
+    const showOpenSeaToBlockaidBannerAlert =
+      hasMigratedFromOpenSeaToBlockaid &&
+      !isNetworkSupportedByBlockaid &&
+      !hasDismissedOpenSeaToBlockaidBanner;
+    const handleCloseOpenSeaToBlockaidBannerAlert = () => {
+      dismissOpenSeaToBlockaidBanner();
+    };
+
     return (
       <div className="confirm-page-container-content__details">
+        {showOpenSeaToBlockaidBannerAlert ? (
+          <BannerAlert
+            severity={Severity.Info}
+            title={t('openSeaToBlockaidTitle')}
+            description={t('openSeaToBlockaidDescription')}
+            actionButtonLabel={t('openSeaToBlockaidBtnLabel')}
+            actionButtonProps={{
+              href: 'https://snaps.metamask.io/transaction-insights',
+              externalLink: true,
+            }}
+            marginBottom={4}
+            marginLeft={4}
+            marginTop={4}
+            marginRight={4}
+            onClose={handleCloseOpenSeaToBlockaidBannerAlert}
+          />
+        ) : null}
         <TransactionAlerts
           txData={txData}
           setUserAcknowledgedGasMissing={() =>

--- a/ui/pages/confirmations/confirm-transaction-base/confirm-transaction-base.container.js
+++ b/ui/pages/confirmations/confirm-transaction-base/confirm-transaction-base.container.js
@@ -25,6 +25,7 @@ import {
   addToAddressBook,
   updateTransaction,
   updateEditableParams,
+  dismissOpenSeaToBlockaidBanner,
 } from '../../../store/actions';
 import { isBalanceSufficient } from '../send/send.utils';
 import { shortenAddress, valuesFor } from '../../../helpers/utils/util';
@@ -52,6 +53,9 @@ import {
   getUnapprovedTransactions,
   getInternalAccountByAddress,
   getApprovedAndSignedTransactions,
+  getHasDismissedOpenSeaToBlockaidBanner,
+  getHasMigratedFromOpenSeaToBlockaid,
+  getIsNetworkSupportedByBlockaid,
 } from '../../../selectors';
 import { getMostRecentOverviewPage } from '../../../ducks/history/history';
 import {
@@ -269,6 +273,12 @@ const mapStateToProps = (state, ownProps) => {
   const isUserOpContractDeployError =
     fullTxData.isUserOperation && type === TransactionType.deployContract;
 
+  const hasMigratedFromOpenSeaToBlockaid =
+    getHasMigratedFromOpenSeaToBlockaid(state);
+  const hasDismissedOpenSeaToBlockaidBanner =
+    getHasDismissedOpenSeaToBlockaidBanner(state);
+  const isNetworkSupportedByBlockaid = getIsNetworkSupportedByBlockaid(state);
+
   return {
     balance,
     fromAddress,
@@ -335,6 +345,9 @@ const mapStateToProps = (state, ownProps) => {
     custodianPublishesTransaction,
     rpcUrl,
     ///: END:ONLY_INCLUDE_IF
+    hasMigratedFromOpenSeaToBlockaid,
+    hasDismissedOpenSeaToBlockaidBanner,
+    isNetworkSupportedByBlockaid,
   };
 };
 
@@ -425,6 +438,8 @@ export const mapDispatchToProps = (dispatch) => {
     setWaitForConfirmDeepLinkDialog: (wait) =>
       dispatch(mmiActions.setWaitForConfirmDeepLinkDialog(wait)),
     ///: END:ONLY_INCLUDE_IF
+    dismissOpenSeaToBlockaidBanner: () =>
+      dispatch(dismissOpenSeaToBlockaidBanner()),
   };
 };
 

--- a/ui/pages/confirmations/token-allowance/token-allowance.js
+++ b/ui/pages/confirmations/token-allowance/token-allowance.js
@@ -14,6 +14,7 @@ import {
   FLEX_DIRECTION,
   FontWeight,
   JustifyContent,
+  Severity,
   TextAlign,
   TextColor,
   TextVariant,
@@ -36,6 +37,9 @@ import {
   getTargetAccountWithSendEtherInfo,
   getCustomNonceValue,
   getNextSuggestedNonce,
+  getHasMigratedFromOpenSeaToBlockaid,
+  getIsNetworkSupportedByBlockaid,
+  getHasDismissedOpenSeaToBlockaidBanner,
 } from '../../../selectors';
 import { NETWORK_TO_NAME_MAP } from '../../../../shared/constants/network';
 import {
@@ -45,6 +49,7 @@ import {
   updateAndApproveTx,
   getNextNonce,
   updateCustomNonce,
+  dismissOpenSeaToBlockaidBanner,
 } from '../../../store/actions';
 import { clearConfirmTransaction } from '../../../ducks/confirm-transaction/confirm-transaction.duck';
 import { getMostRecentOverviewPage } from '../../../ducks/history/history';
@@ -71,7 +76,12 @@ import { useSimulationFailureWarning } from '../hooks/useSimulationFailureWarnin
 import SimulationErrorMessage from '../components/simulation-error-message';
 import LedgerInstructionField from '../components/ledger-instruction-field/ledger-instruction-field';
 import SecurityProviderBannerMessage from '../components/security-provider-banner-message/security-provider-banner-message';
-import { Icon, IconName, Text } from '../../../components/component-library';
+import {
+  BannerAlert,
+  Icon,
+  IconName,
+  Text,
+} from '../../../components/component-library';
 import { ConfirmPageContainerWarning } from '../components/confirm-page-container/confirm-page-container-content';
 import CustomNonce from '../components/custom-nonce';
 import FeeDetailsComponent from '../components/fee-details-component/fee-details-component';
@@ -336,6 +346,25 @@ export default function TokenAllowance({
     txData.securityAlertResponse?.result_type === BlockaidResultType.Malicious
       ? 'danger-primary'
       : 'primary';
+
+  const hasMigratedFromOpenSeaToBlockaid = useSelector(
+    getHasMigratedFromOpenSeaToBlockaid,
+  );
+  const isNetworkSupportedByBlockaid = useSelector(
+    getIsNetworkSupportedByBlockaid,
+  );
+  const hasDismissedOpenSeaToBlockaidBanner = useSelector(
+    getHasDismissedOpenSeaToBlockaidBanner,
+  );
+
+  const showOpenSeaToBlockaidBannerAlert =
+    hasMigratedFromOpenSeaToBlockaid &&
+    !isNetworkSupportedByBlockaid &&
+    !hasDismissedOpenSeaToBlockaidBanner;
+
+  const handleCloseOpenSeaToBlockaidBannerAlert = () => {
+    dispatch(dismissOpenSeaToBlockaidBanner());
+  };
   return (
     <Box className="token-allowance-container page-container">
       <Box>
@@ -387,6 +416,23 @@ export default function TokenAllowance({
         <BlockaidBannerAlert txData={txData} margin={[4, 4, 0, 4]} />
         ///: END:ONLY_INCLUDE_IF
       }
+      {showOpenSeaToBlockaidBannerAlert ? (
+        <BannerAlert
+          severity={Severity.Info}
+          title={t('openSeaToBlockaidTitle')}
+          description={t('openSeaToBlockaidDescription')}
+          actionButtonLabel={t('openSeaToBlockaidBtnLabel')}
+          actionButtonProps={{
+            href: 'https://snaps.metamask.io/transaction-insights',
+            externalLink: true,
+          }}
+          marginBottom={4}
+          marginLeft={4}
+          marginTop={4}
+          marginRight={4}
+          onClose={handleCloseOpenSeaToBlockaidBannerAlert}
+        />
+      ) : null}
       {isSuspiciousResponse(txData?.securityProviderResponse) && (
         <SecurityProviderBannerMessage
           securityProviderResponse={txData.securityProviderResponse}

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -104,6 +104,7 @@ import {
   SURVEY_END_TIME,
   SURVEY_START_TIME,
 } from '../helpers/constants/survey';
+import { SUPPORTED_CHAIN_IDS } from '../../app/scripts/lib/ppom/ppom-middleware';
 import {
   getCurrentNetworkTransactions,
   getUnapprovedTransactions,
@@ -1786,6 +1787,13 @@ export function getCurrentNetwork(state) {
   return allNetworks.find(filter);
 }
 
+export function getIsNetworkSupportedByBlockaid(state) {
+  const currentChainId = getCurrentChainId(state);
+  const isSupported = SUPPORTED_CHAIN_IDS.includes(currentChainId);
+
+  return isSupported;
+}
+
 export function getAllEnabledNetworks(state) {
   const nonTestNetworks = getNonTestNetworks(state);
   const allNetworks = getAllNetworks(state);
@@ -2250,6 +2258,14 @@ export const useSafeChainsListValidationSelector = (state) => {
 export function getShowFiatInTestnets(state) {
   const { showFiatInTestnets } = getPreferences(state);
   return showFiatInTestnets;
+}
+
+export function getHasMigratedFromOpenSeaToBlockaid(state) {
+  return Boolean(state.metamask.hasMigratedFromOpenSeaToBlockaid);
+}
+
+export function getHasDismissedOpenSeaToBlockaidBanner(state) {
+  return Boolean(state.metamask.hasDismissedOpenSeaToBlockaidBanner);
 }
 
 /**

--- a/ui/selectors/selectors.test.js
+++ b/ui/selectors/selectors.test.js
@@ -526,6 +526,40 @@ describe('Selectors', () => {
     });
   });
 
+  describe('#getIsNetworkSupportedByBlockaid', () => {
+    it('returns true if current network is Linea', () => {
+      const modifiedMockState = {
+        ...mockState,
+        metamask: {
+          ...mockState.metamask,
+          providerConfig: {
+            ...mockState.metamask.providerConfig,
+            chainId: CHAIN_IDS.LINEA_MAINNET,
+          },
+        },
+      };
+      const isSupported =
+        selectors.getIsNetworkSupportedByBlockaid(modifiedMockState);
+      expect(isSupported).toBe(true);
+    });
+
+    it('returns false if current network is Goerli', () => {
+      const modifiedMockState = {
+        ...mockState,
+        metamask: {
+          ...mockState.metamask,
+          providerConfig: {
+            ...mockState.metamask.providerConfig,
+            chainId: CHAIN_IDS.GOERLI,
+          },
+        },
+      };
+      const isSupported =
+        selectors.getIsNetworkSupportedByBlockaid(modifiedMockState);
+      expect(isSupported).toBe(false);
+    });
+  });
+
   describe('#getAllEnabledNetworks', () => {
     it('returns only Mainnet and Linea with showTestNetworks off', () => {
       const networks = selectors.getAllEnabledNetworks({

--- a/ui/store/actions.ts
+++ b/ui/store/actions.ts
@@ -3168,6 +3168,23 @@ export function setUseMultiAccountBalanceChecker(
   };
 }
 
+export function dismissOpenSeaToBlockaidBanner(): ThunkAction<
+  void,
+  MetaMaskReduxState,
+  unknown,
+  AnyAction
+> {
+  return (dispatch: MetaMaskReduxDispatch) => {
+    // skipping loading indication as it blips in the UI and looks weird
+    log.debug(`background.dismissOpenSeaToBlockaidBanner`);
+    callBackgroundMethod('dismissOpenSeaToBlockaidBanner', [], (err) => {
+      if (err) {
+        dispatch(displayWarning(err));
+      }
+    });
+  };
+}
+
 export function setUseSafeChainsListValidation(
   val: boolean,
 ): ThunkAction<void, MetaMaskReduxState, unknown, AnyAction> {


### PR DESCRIPTION
Cherry-pick of #23743

## **Description**

This adds a notice to transaction and signature confirmations for users who have been automatically migrated from the security alerts by Open Sea to security alerts by Blockaid (see #23460) and are on networks that are not supported by Blockaid. The notice can be dismissed and is not shown again once that happens.

The PR adds e2e tests to verify the change for simple send, token approval, personal signature, and contract interaction.

We intend to remove this notice after a few releases.


