### PR TITLE
fix: Add opensea security alert deprecation warning in typed signatures

### DIFF
--- a/test/e2e/tests/ppom/migrate-opensea-to-blockaid-banner.spec.js
+++ b/test/e2e/tests/ppom/migrate-opensea-to-blockaid-banner.spec.js
@@ -9,34 +9,51 @@ const {
 } = require('../../helpers');
 
 describe('Migrate Opensea to Blockaid Banner @no-mmi', function () {
-  it('Shows up on simple send transaction', async function () {
-    await withFixtures(
-      {
-        dapp: true,
-        fixtures: new FixtureBuilder()
-          .withPreferencesController({ hasMigratedFromOpenSeaToBlockaid: true })
-          .build(),
-        ganacheOptions: defaultGanacheOptions,
-        title: this.test.fullTitle(),
-      },
-      async ({ driver }) => {
-        await driver.navigate();
-        await unlockWallet(driver);
-        await openDapp(driver);
+  const ONE_CLICK_CONFIRMATIONS_USING_BLOCKAID = [
+    { name: 'Personal Sign signature', testDAppBtnId: 'personalSign' },
+    { name: 'Sign Typed Data signature', testDAppBtnId: 'signTypedData' },
+    { name: 'Sign Typed Data v3 signature', testDAppBtnId: 'signTypedDataV3' },
+    { name: 'Sign Typed Data v4 signature', testDAppBtnId: 'signTypedDataV4' },
+    { name: 'Sign Permit signature', testDAppBtnId: 'signPermit' },
+    { name: 'Simple Send transaction', testDAppBtnId: 'sendButton' },
+    {
+      name: 'Contract Interaction transaction',
+      testDAppBtnId: 'deployMultisigButton',
+    },
+  ];
 
-        await connectAccountToTestDapp(driver);
+  ONE_CLICK_CONFIRMATIONS_USING_BLOCKAID.forEach((confirmation) => {
+    it(`Shows up on ${confirmation.name} confirmations`, async function () {
+      await withFixtures(
+        {
+          dapp: true,
+          fixtures: new FixtureBuilder()
+            .withPreferencesController({
+              hasMigratedFromOpenSeaToBlockaid: true,
+            })
+            .build(),
+          ganacheOptions: defaultGanacheOptions,
+          title: this.test.fullTitle(),
+        },
+        async ({ driver }) => {
+          await driver.navigate();
+          await unlockWallet(driver);
+          await openDapp(driver);
 
-        await driver.switchToWindowWithTitle(WINDOW_TITLES.TestDApp);
-        await driver.clickElement('#sendButton');
-        await driver.delay(2000);
+          await connectAccountToTestDapp(driver);
 
-        await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
-        await driver.waitForSelector({ text: 'Heads up!', tag: 'p' });
-      },
-    );
+          await driver.switchToWindowWithTitle(WINDOW_TITLES.TestDApp);
+          await driver.clickElement(`#${confirmation.testDAppBtnId}`);
+          await driver.delay(2000);
+
+          await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
+          await driver.waitForSelector({ text: 'Heads up!', tag: 'p' });
+        },
+      );
+    });
   });
 
-  it('Shows up on token approval', async function () {
+  it('Shows up on Token Approval transaction confirmations', async function () {
     await withFixtures(
       {
         dapp: true,
@@ -70,61 +87,6 @@ describe('Migrate Opensea to Blockaid Banner @no-mmi', function () {
 
         await driver.switchToWindowWithTitle(WINDOW_TITLES.TestDApp);
         await driver.clickElement({ text: 'Approve Tokens', tag: 'button' });
-        await driver.delay(2000);
-
-        await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
-        await driver.waitForSelector({ text: 'Heads up!', tag: 'p' });
-      },
-    );
-  });
-
-  it('Shows up on personal signature', async function () {
-    await withFixtures(
-      {
-        dapp: true,
-        fixtures: new FixtureBuilder()
-          .withPreferencesController({ hasMigratedFromOpenSeaToBlockaid: true })
-          .build(),
-        ganacheOptions: defaultGanacheOptions,
-        title: this.test.fullTitle(),
-      },
-      async ({ driver }) => {
-        await driver.navigate();
-        await unlockWallet(driver);
-        await openDapp(driver);
-
-        await connectAccountToTestDapp(driver);
-
-        await driver.switchToWindowWithTitle(WINDOW_TITLES.TestDApp);
-        await driver.clickElement('#personalSign');
-        await driver.delay(2000);
-
-        await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
-        await driver.waitForSelector({ text: 'Heads up!', tag: 'p' });
-      },
-    );
-  });
-
-  it('Shows up on contract interaction', async function () {
-    await withFixtures(
-      {
-        dapp: true,
-        fixtures: new FixtureBuilder()
-          .withPreferencesController({ hasMigratedFromOpenSeaToBlockaid: true })
-          .build(),
-        ganacheOptions: defaultGanacheOptions,
-        title: this.test.fullTitle(),
-      },
-      async ({ driver }) => {
-        await driver.navigate();
-        await unlockWallet(driver);
-        await openDapp(driver);
-
-        await connectAccountToTestDapp(driver);
-
-        await driver.switchToWindowWithTitle(WINDOW_TITLES.TestDApp);
-
-        await driver.clickElement('#deployMultisigButton');
         await driver.delay(2000);
 
         await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);

--- a/ui/pages/confirmations/components/signature-request/signature-request.js
+++ b/ui/pages/confirmations/components/signature-request/signature-request.js
@@ -13,11 +13,15 @@ import {
   resolvePendingApproval,
   completedTx,
   rejectPendingApproval,
+  dismissOpenSeaToBlockaidBanner,
 } from '../../../../store/actions';
 import {
   doesAddressRequireLedgerHidConnection,
   getSubjectMetadata,
   getTotalUnapprovedMessagesCount,
+  getHasDismissedOpenSeaToBlockaidBanner,
+  getIsNetworkSupportedByBlockaid,
+  getHasMigratedFromOpenSeaToBlockaid,
   ///: BEGIN:ONLY_INCLUDE_IF(build-mmi)
   accountsWithSendEtherInfoSelector,
   getSelectedAccount,
@@ -55,6 +59,7 @@ import {
   TextColor,
   TextVariant,
   Size,
+  Severity,
   ///: BEGIN:ONLY_INCLUDE_IF(build-mmi)
   IconColor,
   BackgroundColor,
@@ -68,6 +73,7 @@ import {
   ButtonLink,
   TagUrl,
   Text,
+  BannerAlert,
   ///: BEGIN:ONLY_INCLUDE_IF(build-mmi)
   Icon,
   IconName,
@@ -208,6 +214,25 @@ const SignatureRequest = ({
     primaryType,
   } = parseMessage(data);
 
+  const hasMigratedFromOpenSeaToBlockaid = useSelector(
+    getHasMigratedFromOpenSeaToBlockaid,
+  );
+  const isNetworkSupportedByBlockaid = useSelector(
+    getIsNetworkSupportedByBlockaid,
+  );
+  const hasDismissedOpenSeaToBlockaidBanner = useSelector(
+    getHasDismissedOpenSeaToBlockaidBanner,
+  );
+
+  const showOpenSeaToBlockaidBannerAlert =
+    hasMigratedFromOpenSeaToBlockaid &&
+    !isNetworkSupportedByBlockaid &&
+    !hasDismissedOpenSeaToBlockaidBanner;
+
+  const handleCloseOpenSeaToBlockaidBannerAlert = () => {
+    dispatch(dismissOpenSeaToBlockaidBanner());
+  };
+
   return (
     <>
       <div className="signature-request">
@@ -224,6 +249,23 @@ const SignatureRequest = ({
             <BlockaidBannerAlert txData={txData} margin={[4, 4, 0, 4]} />
             ///: END:ONLY_INCLUDE_IF
           }
+          {showOpenSeaToBlockaidBannerAlert ? (
+            <BannerAlert
+              severity={Severity.Info}
+              title={t('openSeaToBlockaidTitle')}
+              description={t('openSeaToBlockaidDescription')}
+              actionButtonLabel={t('openSeaToBlockaidBtnLabel')}
+              actionButtonProps={{
+                href: 'https://snaps.metamask.io/transaction-insights',
+                externalLink: true,
+              }}
+              marginBottom={4}
+              marginLeft={4}
+              marginTop={4}
+              marginRight={4}
+              onClose={handleCloseOpenSeaToBlockaidBannerAlert}
+            />
+          ) : null}
           {(txData?.securityProviderResponse?.flagAsDangerous !== undefined &&
             txData?.securityProviderResponse?.flagAsDangerous !==
               SECURITY_PROVIDER_MESSAGE_SEVERITY.NOT_MALICIOUS) ||


### PR DESCRIPTION
## **Description**

This PR continues the work of #23743, adding the BannerAlert component to typed signature confirmations. The end to end tests were updated to cover more cases.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/23767?quickstart=1)

## **Related issues**

Fixes: #23766

## **Manual testing steps**

See #23743

## **Screenshots/Recordings**

### **After**

<!-- [screenshots/recordings] -->

<img width="472" alt="Screenshot 2024-03-27 at 17 43 54" src="https://github.com/MetaMask/metamask-extension/assets/13814744/ec1421a3-3522-4306-9af1-ad96a6bb21b7">


## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
