### PR TITLE
feat: UX: Multichain: Close other popups when new popup is opened

### DIFF
--- a/app/scripts/controllers/app-state.js
+++ b/app/scripts/controllers/app-state.js
@@ -70,6 +70,7 @@ export default class AppStateController extends EventEmitter {
       // States used for displaying the changed network toast
       switchedNetworkDetails: null,
       switchedNetworkNeverShowMessage: false,
+      currentExtensionPopupId: undefined,
     });
     this.timer = null;
 
@@ -405,7 +406,17 @@ export default class AppStateController extends EventEmitter {
   }
 
   /**
-   * Track which network MetaMask has just automatically switched to, or call this with `null` to clear that state.
+   * Sets a unique ID for the current extension popup
+   *
+   * @param currentExtensionPopupId
+   */
+  setCurrentExtensionPopupId(currentExtensionPopupId) {
+    this.store.updateState({ currentExtensionPopupId });
+  }
+
+  /**
+   * Sets an object with networkName and appName
+   * or `null` if the message is meant to be cleared
    *
    * @param {{ origin: string, networkClientId: string } | null} switchedNetworkDetails - Details about the network that MetaMask just switched to.
    */

--- a/app/scripts/controllers/app-state.js
+++ b/app/scripts/controllers/app-state.js
@@ -70,7 +70,7 @@ export default class AppStateController extends EventEmitter {
       // States used for displaying the changed network toast
       switchedNetworkDetails: null,
       switchedNetworkNeverShowMessage: false,
-      currentExtensionPopupId: undefined,
+      currentExtensionPopupId: 0,
     });
     this.timer = null;
 

--- a/app/scripts/lib/setupSentry.js
+++ b/app/scripts/lib/setupSentry.js
@@ -86,6 +86,7 @@ export const SENTRY_BACKGROUND_STATE = {
     browserEnvironment: true,
     connectedStatusPopoverHasBeenShown: true,
     currentPopupId: false,
+    currentExtensionPopupId: false,
     defaultHomeActiveTabName: true,
     fullScreenGasPollTokens: true,
     hadAdvancedGasFeesSetPriorToMigration92_3: true,

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -3098,6 +3098,8 @@ export default class MetamaskController extends EventEmitter {
       // AppStateController
       setLastActiveTime:
         appStateController.setLastActiveTime.bind(appStateController),
+      setCurrentExtensionPopupId:
+        appStateController.setCurrentExtensionPopupId.bind(appStateController),
       setDefaultHomeActiveTabName:
         appStateController.setDefaultHomeActiveTabName.bind(appStateController),
       setConnectedStatusPopoverHasBeenShown:

--- a/test/e2e/tests/state-snapshots/errors-after-init-opt-in-background-state.json
+++ b/test/e2e/tests/state-snapshots/errors-after-init-opt-in-background-state.json
@@ -47,7 +47,8 @@
     "surveyLinkLastClickedOrClosed": "object",
     "signatureSecurityAlertResponses": "object",
     "switchedNetworkDetails": "object",
-    "switchedNetworkNeverShowMessage": "boolean"
+    "switchedNetworkNeverShowMessage": "boolean",
+    "currentExtensionPopupId": "number"
   },
   "ApprovalController": {
     "pendingApprovals": "object",

--- a/test/e2e/tests/state-snapshots/errors-after-init-opt-in-ui-state.json
+++ b/test/e2e/tests/state-snapshots/errors-after-init-opt-in-ui-state.json
@@ -84,6 +84,7 @@
     "signatureSecurityAlertResponses": "object",
     "switchedNetworkDetails": "object",
     "switchedNetworkNeverShowMessage": "boolean",
+    "currentExtensionPopupId": "number",
     "currentAppVersion": "string",
     "previousAppVersion": "",
     "previousMigrationVersion": 0,

--- a/ui/index.js
+++ b/ui/index.js
@@ -22,6 +22,7 @@ import {
   getUnapprovedTransactions,
   getNetworkToAutomaticallySwitchTo,
   getSwitchedNetworkDetails,
+  getUseRequestQueue,
 } from './selectors';
 import { ALERT_STATE } from './ducks/alerts';
 import {
@@ -180,6 +181,19 @@ async function startApp(metamaskState, backgroundConnection, opts) {
     );
   }
 
+  // global metamask api - used by tooling
+  global.metamask = {
+    updateCurrentLocale: (code) => {
+      store.dispatch(actions.updateCurrentLocale(code));
+    },
+    setProviderType: (type) => {
+      store.dispatch(actions.setProviderType(type));
+    },
+    setFeatureFlag: (key, value) => {
+      store.dispatch(actions.setFeatureFlag(key, value));
+    },
+  };
+
   if (process.env.MULTICHAIN) {
     // This block autoswitches chains based on the last chain used
     // for a given dapp, when there are no pending confimrations
@@ -201,20 +215,18 @@ async function startApp(metamaskState, backgroundConnection, opts) {
       // if the user didn't just change the dapp network
       await store.dispatch(actions.clearSwitchedNetworkDetails());
     }
-  }
 
-  // global metamask api - used by tooling
-  global.metamask = {
-    updateCurrentLocale: (code) => {
-      store.dispatch(actions.updateCurrentLocale(code));
-    },
-    setProviderType: (type) => {
-      store.dispatch(actions.setProviderType(type));
-    },
-    setFeatureFlag: (key, value) => {
-      store.dispatch(actions.setFeatureFlag(key, value));
-    },
-  };
+    // Register this window as the current popup
+    // and set in background state
+    if (
+      getUseRequestQueue(state) &&
+      getEnvironmentType() === ENVIRONMENT_TYPE_POPUP
+    ) {
+      const thisPopupId = Date.now();
+      global.metamask.id = thisPopupId;
+      await actions.setCurrentExtensionPopupId(thisPopupId);
+    }
+  }
 
   // start app
   render(<Root store={store} />, opts.container);

--- a/ui/index.js
+++ b/ui/index.js
@@ -224,7 +224,7 @@ async function startApp(metamaskState, backgroundConnection, opts) {
     ) {
       const thisPopupId = Date.now();
       global.metamask.id = thisPopupId;
-      await actions.setCurrentExtensionPopupId(thisPopupId);
+      await store.dispatch(actions.setCurrentExtensionPopupId(thisPopupId));
     }
   }
 

--- a/ui/pages/routes/routes.component.js
+++ b/ui/pages/routes/routes.component.js
@@ -197,6 +197,8 @@ export default class Routes extends Component {
     neverShowSwitchedNetworkMessage: PropTypes.bool.isRequired,
     automaticallySwitchNetwork: PropTypes.func.isRequired,
     unapprovedTransactions: PropTypes.number.isRequired,
+    currentExtensionPopupId: PropTypes.number,
+    useRequestQueue: PropTypes.bool,
     ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
     isShowKeyringSnapRemovalResultModal: PropTypes.bool.isRequired,
     hideShowKeyringSnapRemovalResultModal: PropTypes.func.isRequired,
@@ -253,6 +255,8 @@ export default class Routes extends Component {
       activeTabOrigin,
       unapprovedTransactions,
       isUnlocked,
+      useRequestQueue,
+      currentExtensionPopupId,
     } = this.props;
     if (theme !== prevProps.theme) {
       this.setTheme();
@@ -276,6 +280,18 @@ export default class Routes extends Component {
         networkToAutomaticallySwitchTo,
         activeTabOrigin,
       );
+    }
+
+    // Terminate the popup when another popup is opened
+    // if the user is using RPC queueing
+    if (
+      useRequestQueue &&
+      process.env.MULTICHAIN &&
+      currentExtensionPopupId !== undefined &&
+      global.metamask.id !== undefined &&
+      currentExtensionPopupId !== global.metamask.id
+    ) {
+      window.close();
     }
   }
 

--- a/ui/pages/routes/routes.container.js
+++ b/ui/pages/routes/routes.container.js
@@ -22,6 +22,7 @@ import {
   getNeverShowSwitchedNetworkMessage,
   getNetworkToAutomaticallySwitchTo,
   getNumberOfAllUnapprovedTransactionsAndMessages,
+  getUseRequestQueue,
 } from '../../selectors';
 import {
   lockMetamask,
@@ -115,6 +116,8 @@ function mapStateToProps(state) {
     unapprovedTransactions:
       getNumberOfAllUnapprovedTransactionsAndMessages(state),
     neverShowSwitchedNetworkMessage: getNeverShowSwitchedNetworkMessage(state),
+    currentExtensionPopupId: state.metamask.currentExtensionPopupId,
+    useRequestQueue: getUseRequestQueue(state),
     ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
     isShowKeyringSnapRemovalResultModal:
       state.appState.showKeyringRemovalSnapModal,

--- a/ui/store/actions.ts
+++ b/ui/store/actions.ts
@@ -2244,6 +2244,21 @@ export function clearSwitchedNetworkDetails(): ThunkAction<
   };
 }
 
+/**
+ * Update the currentPopupid generated when the user opened the popup
+ *
+ * @param id - The Snap interface ID.
+ * @returns Promise Resolved on successfully submitted background request.
+ */
+export async function setCurrentExtensionPopupId(
+  id: number,
+): ThunkAction<void, MetaMaskReduxState, unknown, AnyAction> {
+  return async (dispatch: MetaMaskReduxDispatch) => {
+    await submitRequestToBackground<void>('setCurrentExtensionPopupId', [id]);
+    await forceUpdateMetamaskState(dispatch);
+  };
+}
+
 export function abortTransactionSigning(
   transactionId: string,
   // TODO: Replace `any` with type

--- a/ui/store/actions.ts
+++ b/ui/store/actions.ts
@@ -2250,7 +2250,7 @@ export function clearSwitchedNetworkDetails(): ThunkAction<
  * @param id - The Snap interface ID.
  * @returns Promise Resolved on successfully submitted background request.
  */
-export async function setCurrentExtensionPopupId(
+export function setCurrentExtensionPopupId(
   id: number,
 ): ThunkAction<void, MetaMaskReduxState, unknown, AnyAction> {
   return async (dispatch: MetaMaskReduxDispatch) => {


### PR DESCRIPTION
## **Description**

This PR closes previously opened MetaMask popups (those opened by clicking the fox icon in the extensions bar) when a new popup is opened.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/23379?quickstart=1)

## **Related issues**

Fixes:  https://github.com/MetaMask/MetaMask-planning/issues/1779

## **Manual testing steps**

1. `MULTICHAIN=1 yarn start`
2. Turn on the RPC queuing toggle in Experiment settings
3.  Open one browser window and click the MetaMask fox logo, wait for the popup to open
4.  Open another browser window, click the MetaMask fox logo
5. See the first window's popup close.

## **Screenshots/Recordings**

### **Before**

N/A

### **After**


https://github.com/MetaMask/metamask-extension/assets/46655/2d6f953e-f4a8-492d-8e81-f94d59a76ffc




## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've clearly explained what problem this PR is solving and how it is solved.
- [ ] I've linked related issues
- [ ] I've included manual testing steps
- [ ] I've included screenshots/recordings if applicable
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [ ] I’ve properly set the pull request status:
  - [ ] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
