### PR TITLE
fix: Memoize network selectors to improve performance

### DIFF
--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -1296,7 +1296,7 @@ export const getConnectedSitesList = createDeepEqualSelector(
   },
 );
 
-export const getNonTestNetworks = createSelector(
+export const getNonTestNetworks = createDeepEqualSelector(
   getNetworkConfigurations,
   (networkConfigurations = {}) => {
     return [
@@ -1344,7 +1344,7 @@ export const getNonTestNetworks = createSelector(
   },
 );
 
-export const getTestNetworks = createSelector(
+export const getTestNetworks = createDeepEqualSelector(
   getNetworkConfigurations,
   (networkConfigurations = {}) => {
     return [
@@ -1389,7 +1389,7 @@ export const getTestNetworks = createSelector(
   },
 );
 
-export const getAllNetworks = createSelector(
+export const getAllNetworks = createDeepEqualSelector(
   getNonTestNetworks,
   getTestNetworks,
   (nonTestNetworks, testNetworks) => {
@@ -1884,7 +1884,7 @@ export function getNetworkConfigurations(state) {
   return state.metamask.networkConfigurations;
 }
 
-export const getCurrentNetwork = createSelector(
+export const getCurrentNetwork = createDeepEqualSelector(
   getAllNetworks,
   getProviderConfig,
   (allNetworks, providerConfig) => {
@@ -1903,7 +1903,7 @@ export function getIsNetworkSupportedByBlockaid(state) {
   return isSupported;
 }
 
-export const getAllEnabledNetworks = createSelector(
+export const getAllEnabledNetworks = createDeepEqualSelector(
   getNonTestNetworks,
   getAllNetworks,
   getShowTestNetworks,

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -1296,6 +1296,112 @@ export const getConnectedSitesList = createDeepEqualSelector(
   },
 );
 
+export const getNonTestNetworks = createSelector(
+  getNetworkConfigurations,
+  (networkConfigurations = {}) => {
+    return [
+      // Mainnet always first
+      {
+        chainId: CHAIN_IDS.MAINNET,
+        nickname: MAINNET_DISPLAY_NAME,
+        rpcUrl: CHAIN_ID_TO_RPC_URL_MAP[CHAIN_IDS.MAINNET],
+        rpcPrefs: {
+          imageUrl: ETH_TOKEN_IMAGE_URL,
+        },
+        providerType: NETWORK_TYPES.MAINNET,
+        ticker: CURRENCY_SYMBOLS.ETH,
+        id: NETWORK_TYPES.MAINNET,
+        removable: false,
+      },
+      {
+        chainId: CHAIN_IDS.LINEA_MAINNET,
+        nickname: LINEA_MAINNET_DISPLAY_NAME,
+        rpcUrl: CHAIN_ID_TO_RPC_URL_MAP[CHAIN_IDS.LINEA_MAINNET],
+        rpcPrefs: {
+          imageUrl: LINEA_MAINNET_TOKEN_IMAGE_URL,
+        },
+        providerType: NETWORK_TYPES.LINEA_MAINNET,
+        ticker: TEST_NETWORK_TICKER_MAP[NETWORK_TYPES.LINEA_MAINNET],
+        id: NETWORK_TYPES.LINEA_MAINNET,
+        removable: false,
+      },
+      // Custom networks added by the user
+      ...Object.values(networkConfigurations)
+        .filter(({ chainId }) => ![CHAIN_IDS.LOCALHOST].includes(chainId))
+        .map((network) => ({
+          ...network,
+          rpcPrefs: {
+            ...network.rpcPrefs,
+            // Provide an image based on chainID if a network
+            // has been added without an image
+            imageUrl:
+              network?.rpcPrefs?.imageUrl ??
+              CHAIN_ID_TO_NETWORK_IMAGE_URL_MAP[network.chainId],
+          },
+          removable: true,
+        })),
+    ];
+  },
+);
+
+export const getTestNetworks = createSelector(
+  getNetworkConfigurations,
+  (networkConfigurations = {}) => {
+    return [
+      {
+        chainId: CHAIN_IDS.SEPOLIA,
+        nickname: SEPOLIA_DISPLAY_NAME,
+        rpcUrl: CHAIN_ID_TO_RPC_URL_MAP[CHAIN_IDS.SEPOLIA],
+        providerType: NETWORK_TYPES.SEPOLIA,
+        ticker: TEST_NETWORK_TICKER_MAP[NETWORK_TYPES.SEPOLIA],
+        id: NETWORK_TYPES.SEPOLIA,
+        removable: false,
+      },
+      {
+        chainId: CHAIN_IDS.LINEA_GOERLI,
+        nickname: LINEA_GOERLI_DISPLAY_NAME,
+        rpcUrl: CHAIN_ID_TO_RPC_URL_MAP[CHAIN_IDS.LINEA_GOERLI],
+        rpcPrefs: {
+          imageUrl: LINEA_GOERLI_TOKEN_IMAGE_URL,
+        },
+        providerType: NETWORK_TYPES.LINEA_GOERLI,
+        ticker: TEST_NETWORK_TICKER_MAP[NETWORK_TYPES.LINEA_GOERLI],
+        id: NETWORK_TYPES.LINEA_GOERLI,
+        removable: false,
+      },
+      {
+        chainId: CHAIN_IDS.LINEA_SEPOLIA,
+        nickname: LINEA_SEPOLIA_DISPLAY_NAME,
+        rpcUrl: CHAIN_ID_TO_RPC_URL_MAP[CHAIN_IDS.LINEA_SEPOLIA],
+        rpcPrefs: {
+          imageUrl: LINEA_SEPOLIA_TOKEN_IMAGE_URL,
+        },
+        providerType: NETWORK_TYPES.LINEA_SEPOLIA,
+        ticker: TEST_NETWORK_TICKER_MAP[NETWORK_TYPES.LINEA_SEPOLIA],
+        id: NETWORK_TYPES.LINEA_SEPOLIA,
+        removable: false,
+      },
+      // Localhosts
+      ...Object.values(networkConfigurations)
+        .filter(({ chainId }) => chainId === CHAIN_IDS.LOCALHOST)
+        .map((network) => ({ ...network, removable: true })),
+    ];
+  },
+);
+
+export const getAllNetworks = createSelector(
+  getNonTestNetworks,
+  getTestNetworks,
+  (nonTestNetworks, testNetworks) => {
+    return [
+      // Mainnet and custom networks
+      ...nonTestNetworks,
+      // Test networks
+      ...testNetworks,
+    ];
+  },
+);
+
 export const getConnectedSitesListWithNetworkInfo = createDeepEqualSelector(
   getConnectedSitesList,
   getAllDomains,
@@ -1778,16 +1884,17 @@ export function getNetworkConfigurations(state) {
   return state.metamask.networkConfigurations;
 }
 
-export function getCurrentNetwork(state) {
-  const allNetworks = getAllNetworks(state);
-  const providerConfig = getProviderConfig(state);
-
-  const filter =
-    providerConfig.type === 'rpc'
-      ? (network) => network.id === providerConfig.id
-      : (network) => network.id === providerConfig.type;
-  return allNetworks.find(filter);
-}
+export const getCurrentNetwork = createSelector(
+  getAllNetworks,
+  getProviderConfig,
+  (allNetworks, providerConfig) => {
+    const filter =
+      providerConfig.type === 'rpc'
+        ? (network) => network.id === providerConfig.id
+        : (network) => network.id === providerConfig.type;
+    return allNetworks.find(filter);
+  },
+);
 
 export function getIsNetworkSupportedByBlockaid(state) {
   const currentChainId = getCurrentChainId(state);
@@ -1796,115 +1903,14 @@ export function getIsNetworkSupportedByBlockaid(state) {
   return isSupported;
 }
 
-export function getAllEnabledNetworks(state) {
-  const nonTestNetworks = getNonTestNetworks(state);
-  const allNetworks = getAllNetworks(state);
-  const showTestnetNetworks = getShowTestNetworks(state);
-
-  return showTestnetNetworks ? allNetworks : nonTestNetworks;
-}
-
-export function getTestNetworks(state) {
-  const networkConfigurations = getNetworkConfigurations(state) || {};
-
-  return [
-    {
-      chainId: CHAIN_IDS.SEPOLIA,
-      nickname: SEPOLIA_DISPLAY_NAME,
-      rpcUrl: CHAIN_ID_TO_RPC_URL_MAP[CHAIN_IDS.SEPOLIA],
-      providerType: NETWORK_TYPES.SEPOLIA,
-      ticker: TEST_NETWORK_TICKER_MAP[NETWORK_TYPES.SEPOLIA],
-      id: NETWORK_TYPES.SEPOLIA,
-      removable: false,
-    },
-    {
-      chainId: CHAIN_IDS.LINEA_GOERLI,
-      nickname: LINEA_GOERLI_DISPLAY_NAME,
-      rpcUrl: CHAIN_ID_TO_RPC_URL_MAP[CHAIN_IDS.LINEA_GOERLI],
-      rpcPrefs: {
-        imageUrl: LINEA_GOERLI_TOKEN_IMAGE_URL,
-      },
-      providerType: NETWORK_TYPES.LINEA_GOERLI,
-      ticker: TEST_NETWORK_TICKER_MAP[NETWORK_TYPES.LINEA_GOERLI],
-      id: NETWORK_TYPES.LINEA_GOERLI,
-      removable: false,
-    },
-    {
-      chainId: CHAIN_IDS.LINEA_SEPOLIA,
-      nickname: LINEA_SEPOLIA_DISPLAY_NAME,
-      rpcUrl: CHAIN_ID_TO_RPC_URL_MAP[CHAIN_IDS.LINEA_SEPOLIA],
-      rpcPrefs: {
-        imageUrl: LINEA_SEPOLIA_TOKEN_IMAGE_URL,
-      },
-      providerType: NETWORK_TYPES.LINEA_SEPOLIA,
-      ticker: TEST_NETWORK_TICKER_MAP[NETWORK_TYPES.LINEA_SEPOLIA],
-      id: NETWORK_TYPES.LINEA_SEPOLIA,
-      removable: false,
-    },
-    // Localhosts
-    ...Object.values(networkConfigurations)
-      .filter(({ chainId }) => chainId === CHAIN_IDS.LOCALHOST)
-      .map((network) => ({ ...network, removable: true })),
-  ];
-}
-
-export function getNonTestNetworks(state) {
-  const networkConfigurations = getNetworkConfigurations(state) || {};
-
-  return [
-    // Mainnet always first
-    {
-      chainId: CHAIN_IDS.MAINNET,
-      nickname: MAINNET_DISPLAY_NAME,
-      rpcUrl: CHAIN_ID_TO_RPC_URL_MAP[CHAIN_IDS.MAINNET],
-      rpcPrefs: {
-        imageUrl: ETH_TOKEN_IMAGE_URL,
-      },
-      providerType: NETWORK_TYPES.MAINNET,
-      ticker: CURRENCY_SYMBOLS.ETH,
-      id: NETWORK_TYPES.MAINNET,
-      removable: false,
-    },
-    {
-      chainId: CHAIN_IDS.LINEA_MAINNET,
-      nickname: LINEA_MAINNET_DISPLAY_NAME,
-      rpcUrl: CHAIN_ID_TO_RPC_URL_MAP[CHAIN_IDS.LINEA_MAINNET],
-      rpcPrefs: {
-        imageUrl: LINEA_MAINNET_TOKEN_IMAGE_URL,
-      },
-      providerType: NETWORK_TYPES.LINEA_MAINNET,
-      ticker: TEST_NETWORK_TICKER_MAP[NETWORK_TYPES.LINEA_MAINNET],
-      id: NETWORK_TYPES.LINEA_MAINNET,
-      removable: false,
-    },
-    // Custom networks added by the user
-    ...Object.values(networkConfigurations)
-      .filter(({ chainId }) => ![CHAIN_IDS.LOCALHOST].includes(chainId))
-      .map((network) => ({
-        ...network,
-        rpcPrefs: {
-          ...network.rpcPrefs,
-          // Provide an image based on chainID if a network
-          // has been added without an image
-          imageUrl:
-            network?.rpcPrefs?.imageUrl ??
-            CHAIN_ID_TO_NETWORK_IMAGE_URL_MAP[network.chainId],
-        },
-        removable: true,
-      })),
-  ];
-}
-
-export function getAllNetworks(state) {
-  const networks = [
-    // Mainnet and custom networks
-    ...getNonTestNetworks(state),
-    // Test networks
-    ...getTestNetworks(state),
-  ];
-
-  return networks;
-}
+export const getAllEnabledNetworks = createSelector(
+  getNonTestNetworks,
+  getAllNetworks,
+  getShowTestNetworks,
+  (nonTestNetworks, allNetworks, showTestnetNetworks) => {
+    return showTestnetNetworks ? allNetworks : nonTestNetworks;
+  },
+);
 
 export function getIsOptimism(state) {
   return (


### PR DESCRIPTION

## **Description**

This PR shifts to using `reselect`'s `createSelector` to memoize network-related selectors.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/23775?quickstart=1)

## **Related issues**

Fixes: N/A

## **Manual testing steps**

1. Create, switch, and add networks
2. Ensure everything works properly

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
