### PR TITLE
feat: Set switchNetworkDetails info and show toast when switchEthereumChain is called from dApp

### DIFF
--- a/app/scripts/lib/rpc-method-middleware/handlers/switch-ethereum-chain.js
+++ b/app/scripts/lib/rpc-method-middleware/handlers/switch-ethereum-chain.js
@@ -24,6 +24,7 @@ const switchEthereumChain = {
     setNetworkClientIdForDomain: true,
     setProviderType: true,
     setActiveNetwork: true,
+    setSwitchedNetworkDetails: true,
     requestUserApproval: true,
     getNetworkConfigurations: true,
     getProviderConfig: true,
@@ -66,6 +67,7 @@ async function switchEthereumChainHandler(
     requestUserApproval,
     getProviderConfig,
     hasPermissions,
+    setSwitchedNetworkDetails,
   },
 ) {
   if (!req.params?.[0] || typeof req.params[0] !== 'object') {
@@ -140,6 +142,7 @@ async function switchEthereumChainHandler(
         type: ApprovalType.SwitchEthereumChain,
         requestData,
       });
+
       if (
         Object.values(BUILT_IN_INFURA_NETWORKS)
           .map(({ chainId: id }) => id)
@@ -149,6 +152,13 @@ async function switchEthereumChainHandler(
       } else {
         await setActiveNetwork(approvedRequestData.id);
       }
+
+      // Ensure toast displays for change
+      await setSwitchedNetworkDetails({
+        networkClientId: approvedRequestData.type || approvedRequestData.id,
+        origin: req.origin,
+      });
+
       if (hasPermissions(req.origin)) {
         setNetworkClientIdForDomain(req.origin, networkClientId);
       }

--- a/app/scripts/lib/rpc-method-middleware/handlers/switch-ethereum-chain.js
+++ b/app/scripts/lib/rpc-method-middleware/handlers/switch-ethereum-chain.js
@@ -154,10 +154,12 @@ async function switchEthereumChainHandler(
       }
 
       // Ensure toast displays for change
-      await setSwitchedNetworkDetails({
-        networkClientId: approvedRequestData.type || approvedRequestData.id,
-        origin: req.origin,
-      });
+      if (process.env.MULTICHAIN) {
+        await setSwitchedNetworkDetails({
+          networkClientId: approvedRequestData.type || approvedRequestData.id,
+          origin: req.origin,
+        });
+      }
 
       if (hasPermissions(req.origin)) {
         setNetworkClientIdForDomain(req.origin, networkClientId);

--- a/app/scripts/lib/rpc-method-middleware/handlers/switch-ethereum-chain.test.js
+++ b/app/scripts/lib/rpc-method-middleware/handlers/switch-ethereum-chain.test.js
@@ -25,6 +25,7 @@ describe('switchEthereumChainHandler', () => {
   it('should call setProviderType when switching to a built in infura network', async () => {
     const mockSetProviderType = jest.fn();
     const mockSetActiveNetwork = jest.fn();
+    const mockSetSwitchedNetworkDetails = jest.fn();
     const switchEthereumChainHandler = switchEthereumChain.implementation;
     await switchEthereumChainHandler(
       {
@@ -42,6 +43,7 @@ describe('switchEthereumChainHandler', () => {
         findNetworkConfigurationBy: () => MOCK_MAINNET_CONFIGURATION,
         setProviderType: mockSetProviderType,
         setActiveNetwork: mockSetActiveNetwork,
+        setSwitchedNetworkDetails: mockSetSwitchedNetworkDetails,
         requestUserApproval: mockRequestUserApproval,
       },
     );
@@ -49,11 +51,13 @@ describe('switchEthereumChainHandler', () => {
     expect(mockSetProviderType).toHaveBeenCalledWith(
       MOCK_MAINNET_CONFIGURATION.type,
     );
+    expect(mockSetSwitchedNetworkDetails).toHaveBeenCalledTimes(1);
   });
 
   it('should call setProviderType when switching to a built in infura network, when chainId from request is lower case', async () => {
     const mockSetProviderType = jest.fn();
     const mockSetActiveNetwork = jest.fn();
+    const mockSetSwitchedNetworkDetails = jest.fn();
     const switchEthereumChainHandler = switchEthereumChain.implementation;
     await switchEthereumChainHandler(
       {
@@ -71,6 +75,7 @@ describe('switchEthereumChainHandler', () => {
         findNetworkConfigurationBy: () => MOCK_LINEA_MAINNET_CONFIGURATION,
         setProviderType: mockSetProviderType,
         setActiveNetwork: mockSetActiveNetwork,
+        setSwitchedNetworkDetails: mockSetSwitchedNetworkDetails,
         requestUserApproval: mockRequestUserApproval,
       },
     );
@@ -78,11 +83,14 @@ describe('switchEthereumChainHandler', () => {
     expect(mockSetProviderType).toHaveBeenCalledWith(
       MOCK_LINEA_MAINNET_CONFIGURATION.type,
     );
+    expect(mockSetSwitchedNetworkDetails).toHaveBeenCalledTimes(1);
   });
 
   it('should call setProviderType when switching to a built in infura network, when chainId from request is upper case', async () => {
     const mockSetProviderType = jest.fn();
     const mockSetActiveNetwork = jest.fn();
+    const mockSetSwitchedNetworkDetails = jest.fn();
+
     const switchEthereumChainHandler = switchEthereumChain.implementation;
     await switchEthereumChainHandler(
       {
@@ -100,6 +108,7 @@ describe('switchEthereumChainHandler', () => {
         findNetworkConfigurationBy: () => MOCK_LINEA_MAINNET_CONFIGURATION,
         setProviderType: mockSetProviderType,
         setActiveNetwork: mockSetActiveNetwork,
+        setSwitchedNetworkDetails: mockSetSwitchedNetworkDetails,
         requestUserApproval: mockRequestUserApproval,
       },
     );
@@ -107,11 +116,13 @@ describe('switchEthereumChainHandler', () => {
     expect(mockSetProviderType).toHaveBeenCalledWith(
       MOCK_LINEA_MAINNET_CONFIGURATION.type,
     );
+    expect(mockSetSwitchedNetworkDetails).toHaveBeenCalledTimes(1);
   });
 
   it('should call setActiveNetwork when switching to a custom network', async () => {
     const mockSetProviderType = jest.fn();
     const mockSetActiveNetwork = jest.fn();
+    const mockSetSwitchedNetworkDetails = jest.fn();
     const switchEthereumChainHandler = switchEthereumChain.implementation;
     await switchEthereumChainHandler(
       {
@@ -129,6 +140,7 @@ describe('switchEthereumChainHandler', () => {
         findNetworkConfigurationBy: () => MOCK_MAINNET_CONFIGURATION,
         setProviderType: mockSetProviderType,
         setActiveNetwork: mockSetActiveNetwork,
+        setSwitchedNetworkDetails: mockSetSwitchedNetworkDetails,
         requestUserApproval: mockRequestUserApproval,
       },
     );
@@ -136,5 +148,6 @@ describe('switchEthereumChainHandler', () => {
     expect(mockSetActiveNetwork).toHaveBeenCalledWith(
       MOCK_MAINNET_CONFIGURATION.id,
     );
+    expect(mockSetSwitchedNetworkDetails).toHaveBeenCalledTimes(1);
   });
 });

--- a/app/scripts/lib/rpc-method-middleware/handlers/switch-ethereum-chain.test.js
+++ b/app/scripts/lib/rpc-method-middleware/handlers/switch-ethereum-chain.test.js
@@ -51,7 +51,6 @@ describe('switchEthereumChainHandler', () => {
     expect(mockSetProviderType).toHaveBeenCalledWith(
       MOCK_MAINNET_CONFIGURATION.type,
     );
-    expect(mockSetSwitchedNetworkDetails).toHaveBeenCalledTimes(1);
   });
 
   it('should call setProviderType when switching to a built in infura network, when chainId from request is lower case', async () => {
@@ -83,7 +82,6 @@ describe('switchEthereumChainHandler', () => {
     expect(mockSetProviderType).toHaveBeenCalledWith(
       MOCK_LINEA_MAINNET_CONFIGURATION.type,
     );
-    expect(mockSetSwitchedNetworkDetails).toHaveBeenCalledTimes(1);
   });
 
   it('should call setProviderType when switching to a built in infura network, when chainId from request is upper case', async () => {
@@ -116,7 +114,6 @@ describe('switchEthereumChainHandler', () => {
     expect(mockSetProviderType).toHaveBeenCalledWith(
       MOCK_LINEA_MAINNET_CONFIGURATION.type,
     );
-    expect(mockSetSwitchedNetworkDetails).toHaveBeenCalledTimes(1);
   });
 
   it('should call setActiveNetwork when switching to a custom network', async () => {
@@ -148,6 +145,5 @@ describe('switchEthereumChainHandler', () => {
     expect(mockSetActiveNetwork).toHaveBeenCalledWith(
       MOCK_MAINNET_CONFIGURATION.id,
     );
-    expect(mockSetSwitchedNetworkDetails).toHaveBeenCalledTimes(1);
   });
 });

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -4998,6 +4998,9 @@ export default class MetamaskController extends EventEmitter {
         setActiveNetwork: (networkClientId) => {
           this.networkController.setActiveNetwork(networkClientId);
         },
+        setSwitchedNetworkDetails: (detailsObj) => {
+          this.appStateController.setSwitchedNetworkDetails(detailsObj);
+        },
         findNetworkClientIdByChainId:
           this.networkController.findNetworkClientIdByChainId.bind(
             this.networkController,

--- a/ui/index.js
+++ b/ui/index.js
@@ -21,7 +21,6 @@ import {
   getSelectedInternalAccount,
   getUnapprovedTransactions,
   getNetworkToAutomaticallySwitchTo,
-  getSwitchedNetworkDetails,
 } from './selectors';
 import { ALERT_STATE } from './ducks/alerts';
 import {
@@ -194,12 +193,6 @@ async function startApp(metamaskState, backgroundConnection, opts) {
           getOriginOfCurrentTab(state),
         ),
       );
-    } else if (getSwitchedNetworkDetails(state)) {
-      // It's possible that old details could exist if the user
-      // opened the toast but then didn't close it
-      // Clear out any existing switchedNetworkDetails
-      // if the user didn't just change the dapp network
-      await store.dispatch(actions.clearSwitchedNetworkDetails(null));
     }
   }
 


### PR DESCRIPTION

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/23785?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/1780

## **Manual testing steps**

0.  Have extension opened in full screen mode in tab 1
1. In tab 2, go to app.uniswap.org, starting on Mainnet
2. Switch to Arbitrum via the dapp
3. Open the popup
4. See the network switched toast details!
5. Open the full screen tab
6. See the network switched toast details! 

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A

### **After**


https://github.com/MetaMask/metamask-extension/assets/46655/bffbd5a1-0d0b-4d51-bae7-bc2fb9d74388





## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
