### PR TITLE
fix cursor pointer to checkbox

### DIFF
--- a/ui/components/component-library/checkbox/checkbox.scss
+++ b/ui/components/component-library/checkbox/checkbox.scss
@@ -1,4 +1,6 @@
 .mm-checkbox {
+  cursor: pointer;
+
   &__input-wrapper {
     position: relative;
   }

--- a/ui/components/component-library/checkbox/checkbox.scss
+++ b/ui/components/component-library/checkbox/checkbox.scss
@@ -1,6 +1,4 @@
 .mm-checkbox {
-  cursor: pointer;
-
   &__input-wrapper {
     position: relative;
   }
@@ -13,6 +11,7 @@
 
     &:hover:not(:disabled) {
       background-color: var(--color-background-default-hover);
+      cursor: pointer;
     }
 
     &:focus {


### PR DESCRIPTION
## **Description**
 Fix the cursor to be a pointer on the hover for `checkbox` component. See screen recordings 

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/23786?quickstart=1)

## **Related issues**

Fixes: 

## **Manual testing steps**

1. Run stoybook
2. View and hover [Checkbox component](http://localhost:6006/?path=/docs/components-componentlibrary-checkbox--docs)
3. Confirm you see the pointer cursor 

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

https://github.com/MetaMask/metamask-extension/assets/26469696/3bdca80e-ca5b-4090-b0e0-c74c76c775d7

### **After**

https://github.com/MetaMask/metamask-extension/assets/26469696/830e6c7b-c622-46b1-a841-413597d4e216


<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
