### PR TITLE
fix: do not automatically clear trailing zeros in input

### DIFF
--- a/ui/components/app/currency-input/currency-input.js
+++ b/ui/components/app/currency-input/currency-input.js
@@ -148,6 +148,12 @@ export default function CurrencyInput({
       console.log(`overridden to ${inputValueIfBackspaced}`);
       decimalizedHexValue = inputValueIfBackspaced;
     }
+
+    // do not update if they already match
+    if (Number(decimalizedHexValue) === Number(tokenDecimalValue)) {
+      return;
+    }
+
     const { newTokenDecimalValue, newFiatDecimalValue } =
       processNewDecimalValue(decimalizedHexValue);
 

--- a/ui/components/app/currency-input/currency-input.js
+++ b/ui/components/app/currency-input/currency-input.js
@@ -124,17 +124,42 @@ export default function CurrencyInput({
       return;
     }
 
-    const decimalizedHexValue = new Numeric(hexValue, 16)
+    let decimalizedHexValue = new Numeric(hexValue, 16)
       .toBase(10)
       .shiftedBy(assetDecimals)
       .toString();
 
+    const inputValueIfBackspaced = tokenDecimalValue.slice(
+      0,
+      tokenDecimalValue.length - 1,
+    );
+
+    const isLastZeroOrDotJustExposed =
+      inputValueIfBackspaced.endsWith('0') ||
+      inputValueIfBackspaced.endsWith('.');
+
+    const isBackspacedInputEqualToNewValue =
+      Number(inputValueIfBackspaced) === Number(decimalizedHexValue);
+
+    const isInputLikelyBackspaced =
+      isLastZeroOrDotJustExposed && isBackspacedInputEqualToNewValue;
+
+    if (isInputLikelyBackspaced) {
+      console.log(`overridden to ${inputValueIfBackspaced}`);
+      decimalizedHexValue = inputValueIfBackspaced;
+    }
     const { newTokenDecimalValue, newFiatDecimalValue } =
       processNewDecimalValue(decimalizedHexValue);
 
     setTokenDecimalValue(newTokenDecimalValue);
     setFiatDecimalValue(newFiatDecimalValue);
-  }, [hexValue, assetDecimals, processNewDecimalValue, isTokenPrimary]);
+  }, [
+    hexValue,
+    assetDecimals,
+    processNewDecimalValue,
+    isTokenPrimary,
+    tokenDecimalValue,
+  ]);
 
   const renderSwapButton = () => {
     if (swapIcon) {

--- a/ui/components/app/currency-input/currency-input.js
+++ b/ui/components/app/currency-input/currency-input.js
@@ -145,7 +145,6 @@ export default function CurrencyInput({
       isLastZeroOrDotJustExposed && isBackspacedInputEqualToNewValue;
 
     if (isInputLikelyBackspaced) {
-      console.log(`overridden to ${inputValueIfBackspaced}`);
       decimalizedHexValue = inputValueIfBackspaced;
     }
 

--- a/ui/components/app/currency-input/hooks/useProcessNewDecimalValue.test.tsx
+++ b/ui/components/app/currency-input/hooks/useProcessNewDecimalValue.test.tsx
@@ -4,13 +4,13 @@ import useProcessNewDecimalValue from './useProcessNewDecimalValue';
 
 const renderUseProcessNewDecimalValue = (
   assetDecimals: number,
-  isFiatPrimary: boolean,
+  isTokenPrimary: boolean,
   tokenToFiatConversionRate: Numeric,
 ) => {
   return renderHook(() =>
     useProcessNewDecimalValue(
       assetDecimals,
-      isFiatPrimary,
+      isTokenPrimary,
       tokenToFiatConversionRate,
     ),
   );

--- a/ui/components/app/currency-input/hooks/useProcessNewDecimalValue.test.tsx
+++ b/ui/components/app/currency-input/hooks/useProcessNewDecimalValue.test.tsx
@@ -161,4 +161,19 @@ describe('useProcessNewDecimalValue', () => {
       newTokenDecimalValue: '1',
     });
   });
+
+  it('Token is primary; extra decimals', () => {
+    const {
+      result: { current: processingFunction },
+    } = renderUseProcessNewDecimalValue(4, true, new Numeric(0.5, 10));
+
+    expect(processingFunction('1.00')).toStrictEqual({
+      newFiatDecimalValue: '0.50',
+      newTokenDecimalValue: '1.00',
+    });
+    expect(processingFunction('0.1000')).toStrictEqual({
+      newFiatDecimalValue: '0.05',
+      newTokenDecimalValue: '0.1000',
+    });
+  });
 });

--- a/ui/components/app/currency-input/hooks/useProcessNewDecimalValue.tsx
+++ b/ui/components/app/currency-input/hooks/useProcessNewDecimalValue.tsx
@@ -51,9 +51,13 @@ export default function useProcessNewDecimalValue(
         newTokenDecimalValue = truncateToDecimals(numericDecimalValue);
       } else {
         newFiatDecimalValue = numericDecimalValue.toFixed(2);
+
+        const exactTokenValue = numericDecimalValue.divide(
+          tokenToFiatConversionRate,
+        );
         newTokenDecimalValue = tokenToFiatConversionRate
           ? truncateToDecimals(
-              numericDecimalValue.divide(tokenToFiatConversionRate),
+              exactTokenValue,
               MAX_DECIMALS_TOKEN_SECONDARY,
             )
           : undefined;

--- a/ui/components/app/currency-input/hooks/useProcessNewDecimalValue.tsx
+++ b/ui/components/app/currency-input/hooks/useProcessNewDecimalValue.tsx
@@ -48,10 +48,10 @@ export default function useProcessNewDecimalValue(
       } else {
         newFiatDecimalValue = numericDecimalValue.toFixed(2);
 
-        const exactTokenValue = numericDecimalValue.divide(
-          tokenToFiatConversionRate,
-        );
-        newTokenDecimalValue = tokenToFiatConversionRate
+        const exactTokenValue = tokenToFiatConversionRate
+          ? numericDecimalValue.divide(tokenToFiatConversionRate)
+          : undefined;
+        newTokenDecimalValue = exactTokenValue
           ? truncateToDecimals(
               exactTokenValue,
               Math.min(

--- a/ui/components/app/currency-input/hooks/useProcessNewDecimalValue.tsx
+++ b/ui/components/app/currency-input/hooks/useProcessNewDecimalValue.tsx
@@ -28,16 +28,9 @@ export default function useProcessNewDecimalValue(
 
       const truncateToDecimals = (
         numeric: Numeric,
-        maxDecimals = assetDecimals,
+        numDigitsAfterDecimal: number,
       ) => {
-        const digitsAfterDecimal = numeric.toString().split('.')[1] || '';
-
-        const maxPossibleDecimals = Math.min(maxDecimals, assetDecimals);
-
-        const digitsCutoff = Math.min(
-          digitsAfterDecimal.length,
-          maxPossibleDecimals,
-        );
+        const digitsCutoff = Math.min(numDigitsAfterDecimal, assetDecimals);
 
         return numeric.toFixed(digitsCutoff);
       };
@@ -48,7 +41,10 @@ export default function useProcessNewDecimalValue(
         newFiatDecimalValue = tokenToFiatConversionRate
           ? numericDecimalValue.times(tokenToFiatConversionRate).toFixed(2)
           : undefined;
-        newTokenDecimalValue = truncateToDecimals(numericDecimalValue);
+        newTokenDecimalValue = truncateToDecimals(
+          numericDecimalValue,
+          getNumDigitsAfterDecimal(newDecimalValue),
+        );
       } else {
         newFiatDecimalValue = numericDecimalValue.toFixed(2);
 
@@ -58,7 +54,10 @@ export default function useProcessNewDecimalValue(
         newTokenDecimalValue = tokenToFiatConversionRate
           ? truncateToDecimals(
               exactTokenValue,
-              MAX_DECIMALS_TOKEN_SECONDARY,
+              Math.min(
+                getNumDigitsAfterDecimal(exactTokenValue.toString()),
+                MAX_DECIMALS_TOKEN_SECONDARY,
+              ),
             )
           : undefined;
       }

--- a/ui/components/app/currency-input/hooks/useProcessNewDecimalValue.tsx
+++ b/ui/components/app/currency-input/hooks/useProcessNewDecimalValue.tsx
@@ -3,6 +3,12 @@ import { Numeric } from '../../../../../shared/modules/Numeric';
 
 const MAX_DECIMALS_TOKEN_SECONDARY = 6;
 
+const getNumDigitsAfterDecimal = (value: string) => {
+  const digitsAfterDecimal = String(value).split('.')[1] || '';
+
+  return digitsAfterDecimal.length;
+};
+
 /**
  * A hook that creates a function which processes a new decimal value and returns the new fiat and token decimal values
  *


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

The trailing zeros automatically get removed when the user backspaces such that they exposes a zero. This PR prevents this behavior.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/23788?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to the send flow and make the token primary (if it isn't already)
2. Type in a decimal with multiple trailing zeros followed by a non-zero number (e.g., 1.000001)
3. Backspace the last digit and ensure the trailing zeros remain

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

https://github.com/MetaMask/metamask-extension/assets/44588480/11678e8d-b0e2-4998-b14d-ea7f655e7365

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

https://github.com/MetaMask/metamask-extension/assets/44588480/10d1934c-4288-42b7-81a2-d49c22a2adfa



## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
