### PR TITLE
test: [Snaps E2E] add more snaps localization testing

### DIFF
--- a/test/e2e/snaps/test-snap-get-locale.spec.js
+++ b/test/e2e/snaps/test-snap-get-locale.spec.js
@@ -47,6 +47,12 @@ describe('Test Snap Get Locale', function () {
           tag: 'button',
         });
 
+        // look for the snap name
+        await driver.waitForSelector({
+          text: 'Localization Example Snap',
+          tag: 'p',
+        });
+
         await driver.waitForSelector({ text: 'Install' });
 
         await driver.clickElementSafe('[data-testid="snap-install-scroll"]');
@@ -114,6 +120,20 @@ describe('Test Snap Get Locale', function () {
 
         // try to select dansk from the list
         await driver.clickElement({ text: 'Dansk', tag: 'option' });
+
+        // click on the global action menu
+        await driver.waitForSelector(
+          '[data-testid="account-options-menu-button"]',
+        );
+        await driver.clickElement(
+          '[data-testid="account-options-menu-button"]',
+        );
+
+        // try to click on snaps
+        await driver.clickElement({ text: 'Snaps', tag: 'div' });
+
+        // check for localized snap title
+        await driver.waitForSelector({ text: 'Oversættelses Eksempel Snap' });
 
         // switch back to test snaps tab
         windowHandles = await driver.waitUntilXWindowHandles(2, 1000, 10000);


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
This PR adds checks for snap name localization to the snaps localization E2E test.
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/23796?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/1653

## **Manual testing steps**

1. Run this as a single test locally.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
