### PR TITLE
feat: UX: Multichain: Add Connect/Disconnect to AccountListItem

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -1396,6 +1396,9 @@
   "disconnect": {
     "message": "Disconnect"
   },
+  "disconnectAccount": {
+    "message": "Disconnect account"
+  },
   "disconnectAllAccounts": {
     "message": "Disconnect all accounts"
   },

--- a/ui/components/multichain/account-list-item-menu/account-list-item-menu.js
+++ b/ui/components/multichain/account-list-item-menu/account-list-item-menu.js
@@ -36,6 +36,7 @@ import {
 } from '../../../../shared/constants/metametrics';
 import {
   addPermittedAccount,
+  removePermittedAccount,
   showModal,
   updateAccountsList,
   updateHiddenAccountsList,
@@ -70,7 +71,6 @@ export const AccountListItemMenu = ({
 
   const pinnedAccountList = useSelector(getPinnedAccountsList);
   const hiddenAccountList = useSelector(getHiddenAccountsList);
-  const shouldRenderConnectAccount = process.env.MULTICHAIN && !isConnected;
 
   ///: BEGIN:ONLY_INCLUDE_IF(build-mmi)
   const isCustodial = keyring?.type ? /Custody/u.test(keyring.type) : false;
@@ -178,19 +178,29 @@ export const AccountListItemMenu = ({
     >
       <ModalFocus restoreFocus initialFocusRef={anchorElement}>
         <div onKeyDown={handleKeyDown} ref={popoverDialogRef}>
-          {shouldRenderConnectAccount ? (
+          {process.env.MULTICHAIN ? (
             <Box display={[Display.Flex, Display.None]}>
               <MenuItem
                 data-testid="account-list-menu-connect-account"
                 onClick={() => {
-                  dispatch(
-                    addPermittedAccount(activeTabOrigin, identity.address),
-                  );
+                  if (isConnected) {
+                    dispatch(
+                      removePermittedAccount(activeTabOrigin, identity.address),
+                    );
+                  } else {
+                    dispatch(
+                      addPermittedAccount(activeTabOrigin, identity.address),
+                    );
+                  }
                   onClose();
                 }}
-                iconName={IconName.UserCircleLink}
+                iconName={
+                  isConnected ? IconName.Logout : IconName.UserCircleLink
+                }
               >
-                <Text variant={TextVariant.bodySm}>{t('connectAccount')}</Text>
+                <Text variant={TextVariant.bodySm}>
+                  {isConnected ? t('disconnectAccount') : t('connectAccount')}
+                </Text>
               </MenuItem>
             </Box>
           ) : null}


### PR DESCRIPTION
## **Description**

We recently added a "Connect account" menu item to the `AccountListItem` component, and then show nothing if already connected.   I think it makes sense to offer both connect and disconnect instead of a menu item just disappearing.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/23816?quickstart=1)

## **Related issues**

Fixes: N/A

## **Manual testing steps**

1. Go to any dapp, connect to it
2. Open the AccountListMenu, click the three-dot menu of the connected account, choose "Disconnect Account"
3. Click the three-dot menu again, click "Connect account"
4. All works as expected

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A

### **After**


https://github.com/MetaMask/metamask-extension/assets/46655/e917f6be-3aae-4748-8201-c173118ebedc



## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
