### PR TITLE
ci: conditionally run optional MMI test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -414,7 +414,7 @@ jobs:
             echo "Labels found: $LABELS"
 
             # Check if "mmi-team" label is present
-            if [[ $LABELS == *"mmi-team"* ]]; then
+            if [[ $LABELS == *"type-refactor"* ]]; then
               echo "mmi-team label found."
               # You can create a file or an environment variable to signal the next steps
               echo 'export RUN_MMI="true"' >> $BASH_ENV

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,6 +66,16 @@ aliases:
         echo "Checkout branch '${CIRCLE_BRANCH}' at commit '${CIRCLE_SHA1}'"
         git checkout -B "$CIRCLE_BRANCH" "$CIRCLE_SHA1"
       fi
+  # Check if MMI Optional tests should run
+  - &check-mmi-optional
+    name: Check if MMI Optional tests should run
+    command: |
+      if [[ "${CIRCLE_BRANCH}" == "develop" || "${RUN_MMI_OPTIONAL}" == "true" ]]; then
+        echo "Running MMI Optional tests"
+      else
+        echo "Skipping MMI Optional tests"
+        circleci-agent step halt
+      fi
 
 workflows:
   test_and_release:
@@ -133,6 +143,7 @@ workflows:
       - prep-build-test-mmi-playwright:
           requires:
             - prep-deps
+            - check-pr-tag
       - prep-build-storybook:
           requires:
             - prep-deps
@@ -176,7 +187,6 @@ workflows:
       - test-e2e-mmi-playwright - OPTIONAL:
           requires:
             - prep-build-test-mmi-playwright
-            - check-pr-tag
       - test-e2e-chrome-rpc-mmi:
           requires:
             - prep-build-test-mmi
@@ -415,11 +425,11 @@ jobs:
             if echo "$LABEL_NAMES" | grep -qw "team-mmi"; then
               echo "team-mmi tag found."
               # You can create a file or an environment variable to signal the next steps
-              echo 'export RUN_MMI="true"' >> $BASH_ENV
+              echo 'export RUN_MMI_OPTIONAL="true"' >> $BASH_ENV
               source $BASH_ENV
             else
               echo "team-mmi tag not found."
-              echo 'export RUN_MMI="false"' >> $BASH_ENV
+              echo 'export RUN_MMI_OPTIONAL="false"' >> $BASH_ENV
               source $BASH_ENV
             fi
 
@@ -687,6 +697,7 @@ jobs:
   prep-build-test-mmi-playwright:
     executor: node-browsers-medium-plus
     steps:
+      - run: *check-mmi-optional
       - run: *shallow-git-clone
       - attach_workspace:
           at: .
@@ -1168,15 +1179,7 @@ jobs:
     executor: playwright
     parallelism: 2
     steps:
-      - run:
-          name: Check if the test should run
-          command: |
-            if [[ "${CIRCLE_BRANCH}" == "develop" || "${RUN_MMI}" == "true" ]]; then
-              echo "Running E2E tests"
-            else
-              echo "Conditions not met, skipping E2E tests."
-              circleci-agent step halt
-            fi
+      - run: *check-mmi-optional
       - run: *shallow-git-clone
       - attach_workspace:
           at: .

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,7 +74,7 @@ aliases:
         echo "Running MMI Optional tests"
       else
         echo "Skipping MMI Optional tests"
-        circleci-agent step halt
+        circleci step halt
       fi
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1184,10 +1184,10 @@ jobs:
     executor: playwright
     parallelism: 2
     steps:
-      - run: *check-mmi-optional
       - run: *shallow-git-clone
       - attach_workspace:
           at: .
+      - run: *check-mmi-optional
       - run:
           name: Move test build to dist
           command: mv ./dist-test-mmi-playwright ./dist

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,7 +73,7 @@ aliases:
       at: .
     name: Check if MMI Optional tests should run
     command: |
-      RUN_MMI_OPTIONAL=$(cat /RUN_MMI_OPTIONAL)
+      RUN_MMI_OPTIONAL=$(cat RUN_MMI_OPTIONAL)
       if [[ "${CIRCLE_BRANCH}" == "develop" || "${RUN_MMI_OPTIONAL}" == "true" ]]; then
         echo "Running MMI Optional tests"
       else

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,6 +66,7 @@ aliases:
         echo "Checkout branch '${CIRCLE_BRANCH}' at commit '${CIRCLE_SHA1}'"
         git checkout -B "$CIRCLE_BRANCH" "$CIRCLE_SHA1"
       fi
+
   # Check if MMI Optional tests should run
   - &check-mmi-optional
     name: Check if MMI Optional tests should run

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,6 +77,50 @@ workflows:
       - trigger-beta-build:
           requires:
             - prep-deps
+      - check-pr-tag:
+          docker:
+            - image: cimg/base:stable
+          environment:
+            GITHUB_REPO: '$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME'
+          steps:
+            - run:
+                name: Check for MMI Team Tag
+                command: |
+                  #!/bin/bash
+
+                  # GitHub Personal Access Token for API Authentication
+                  GITHUB_TOKEN="${GITHUB_TOKEN}"
+                  GITHUB_REPO="${GITHUB_REPO}"
+                  BRANCH="${CIRCLE_BRANCH}"
+
+                  # Fetch the PR number associated with the current branch
+                  PR_NUMBER=$(curl -s -H "Authorization: token ${GITHUB_TOKEN}" \
+                      "https://api.github.com/repos/${GITHUB_REPO}/pulls" | jq --arg BRANCH "$BRANCH" '.[] | select(.head.ref==$BRANCH) | .number')
+
+                  if [ -z "$PR_NUMBER" ]; then
+                    echo "No PR found for branch $BRANCH."
+                    exit 0
+                  fi
+
+                  echo "PR Number: $PR_NUMBER"
+
+                  # Fetch labels for the PR
+                  LABELS=$(curl -s -H "Authorization: token ${GITHUB_TOKEN}" \
+                      "https://api.github.com/repos/${GITHUB_REPO}/issues/${PR_NUMBER}/labels" | jq -r '.[].name')
+
+                  echo "Labels found: $LABELS"
+
+                  # Check if "mmi-team" label is present
+                  if [[ $LABELS == *"mmi-team"* ]]; then
+                    echo "mmi-team label found."
+                    # You can create a file or an environment variable to signal the next steps
+                    echo 'export RUN_MMI="true"' >> $BASH_ENV
+                    source $BASH_ENV
+                  else
+                    echo "mmi-team label not found."
+                    echo 'export RUN_MMI="false"' >> $BASH_ENV
+                    source $BASH_ENV
+                  fi
       - prep-deps
       - test-deps-audit:
           requires:
@@ -175,6 +219,7 @@ workflows:
       - test-e2e-mmi-playwright - OPTIONAL:
           requires:
             - prep-build-test-mmi-playwright
+            - check-pr-tag
       - test-e2e-chrome-rpc-mmi:
           requires:
             - prep-build-test-mmi
@@ -1118,6 +1163,15 @@ jobs:
     executor: playwright
     parallelism: 2
     steps:
+      - run:
+        name: Check if the test should run
+        command: |
+          if [[ "${CIRCLE_BRANCH}" == "develop" || "${RUN_MMI}" == "true" ]]; then
+            echo "Running E2E tests"
+            # Place your E2E test commands here
+          else
+            echo "Conditions not met, skipping E2E tests."
+          fi
       - run: *shallow-git-clone
       - attach_workspace:
           at: .

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -435,6 +435,8 @@ jobs:
               # assign the RUN_MMI_OPTIONAL variable to false
               echo "false" > ./RUN_MMI_OPTIONAL
             fi
+      - store_artifacts:
+          path: RUN_MMI_OPTIONAL
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -435,8 +435,6 @@ jobs:
               # assign the RUN_MMI_OPTIONAL variable to false
               echo "false" > ./RUN_MMI_OPTIONAL
             fi
-      - store_artifacts:
-          path: RUN_MMI_OPTIONAL
       - persist_to_workspace:
           root: .
           paths:
@@ -706,10 +704,10 @@ jobs:
   prep-build-test-mmi-playwright:
     executor: node-browsers-medium-plus
     steps:
+      - attach_workspace:
+        at: .
       - run: *check-mmi-optional
       - run: *shallow-git-clone
-      - attach_workspace:
-          at: .
       - run:
           name: Build MMI extension for Playwright e2e
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -704,10 +704,10 @@ jobs:
   prep-build-test-mmi-playwright:
     executor: node-browsers-medium-plus
     steps:
-      - attach_workspace:
-        at: .
       - run: *check-mmi-optional
       - run: *shallow-git-clone
+      - attach_workspace:
+          at: .
       - run:
           name: Build MMI extension for Playwright e2e
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1166,14 +1166,14 @@ jobs:
     parallelism: 2
     steps:
       - run:
-        name: Check if the test should run
-        command: |
-          if [[ "${CIRCLE_BRANCH}" == "develop" || "${RUN_MMI}" == "true" ]]; then
-            echo "Running E2E tests"
-          else
-            echo "Conditions not met, skipping E2E tests."
-            circleci-agent step halt
-          fi
+          name: Check if the test should run
+          command: |
+            if [[ "${CIRCLE_BRANCH}" == "develop" || "${RUN_MMI}" == "true" ]]; then
+              echo "Running E2E tests"
+            else
+              echo "Conditions not met, skipping E2E tests."
+              circleci-agent step halt
+            fi
       - run: *shallow-git-clone
       - attach_workspace:
           at: .

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -378,8 +378,6 @@ jobs:
   check-pr-tag:
     docker:
       - image: cimg/base:stable
-    environment:
-      GITHUB_REPO: '$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME'
     steps:
       - run:
           name: Check for MMI Team Tag
@@ -388,13 +386,12 @@ jobs:
 
             # GitHub Personal Access Token for API Authentication
             GITHUB_TOKEN="${GITHUB_TOKEN}"
-            GITHUB_REPO="${GITHUB_REPO}"
             BRANCH="${CIRCLE_BRANCH}"
 
             # Fetch the PRs associated with the current branch and check the response
             PR_RESPONSE=$(curl -s -H "Authorization: token ${GITHUB_TOKEN}" \
-              "https://api.github.com/repos/${GITHUB_REPO}/pulls?state=open&head=${CIRCLE_PROJECT_USERNAME}:${BRANCH}")
-            echo "https://api.github.com/repos/${GITHUB_REPO}/pulls?state=open&head=${CIRCLE_PROJECT_USERNAME}:${BRANCH}"
+              "https://api.github.com/repos/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME/pulls?state=open&head=${CIRCLE_PROJECT_USERNAME}:${BRANCH}")
+            echo "https://api.github.com/repos/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME/pulls?state=open&head=${CIRCLE_PROJECT_USERNAME}:${BRANCH}"
             # Check if the response contains valid JSON
             if ! echo "$PR_RESPONSE" | jq empty; then
                 echo "Failed to parse JSON response."

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,8 +69,11 @@ aliases:
 
   # Check if MMI Optional tests should run
   - &check-mmi-optional
+    attach_workspace:
+      at: .
     name: Check if MMI Optional tests should run
     command: |
+      RUN_MMI_OPTIONAL=$(cat /RUN_MMI_OPTIONAL)
       if [[ "${CIRCLE_BRANCH}" == "develop" || "${RUN_MMI_OPTIONAL}" == "true" ]]; then
         echo "Running MMI Optional tests"
       else
@@ -425,14 +428,17 @@ jobs:
             # Check if "team-mmi" label is present
             if echo "$LABEL_NAMES" | grep -qw "team-mmi"; then
               echo "team-mmi tag found."
-              # You can create a file or an environment variable to signal the next steps
-              echo 'export RUN_MMI_OPTIONAL="true"' >> $BASH_ENV
-              source $BASH_ENV
+              # assign the RUN_MMI_OPTIONAL variable to true
+              echo "true" > RUN_MMI_OPTIONAL
             else
               echo "team-mmi tag not found."
-              echo 'export RUN_MMI_OPTIONAL="false"' >> $BASH_ENV
-              source $BASH_ENV
+              # assign the RUN_MMI_OPTIONAL variable to false
+              echo "false" > RUN_MMI_OPTIONAL
             fi
+      - persist_to_workspace:
+          root: .
+          paths:
+            - RUN_MMI_OPTIONAL
 
   prep-deps:
     executor: node-browsers-medium

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1170,9 +1170,9 @@ jobs:
         command: |
           if [[ "${CIRCLE_BRANCH}" == "develop" || "${RUN_MMI}" == "true" ]]; then
             echo "Running E2E tests"
-            # Place your E2E test commands here
           else
             echo "Conditions not met, skipping E2E tests."
+            circleci-agent step halt
           fi
       - run: *shallow-git-clone
       - attach_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,7 +73,7 @@ aliases:
       at: .
     name: Check if MMI Optional tests should run
     command: |
-      RUN_MMI_OPTIONAL=$(cat RUN_MMI_OPTIONAL)
+      RUN_MMI_OPTIONAL=$(cat ./RUN_MMI_OPTIONAL)
       if [[ "${CIRCLE_BRANCH}" == "develop" || "${RUN_MMI_OPTIONAL}" == "true" ]]; then
         echo "Running MMI Optional tests"
       else
@@ -429,11 +429,11 @@ jobs:
             if echo "$LABEL_NAMES" | grep -qw "team-mmi"; then
               echo "team-mmi tag found."
               # assign the RUN_MMI_OPTIONAL variable to true
-              echo "true" > RUN_MMI_OPTIONAL
+              echo "true" > ./RUN_MMI_OPTIONAL
             else
               echo "team-mmi tag not found."
               # assign the RUN_MMI_OPTIONAL variable to false
-              echo "false" > RUN_MMI_OPTIONAL
+              echo "false" > ./RUN_MMI_OPTIONAL
             fi
       - persist_to_workspace:
           root: .

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,8 +69,6 @@ aliases:
 
   # Check if MMI Optional tests should run
   - &check-mmi-optional
-    attach_workspace:
-      at: .
     name: Check if MMI Optional tests should run
     command: |
       RUN_MMI_OPTIONAL=$(cat ./RUN_MMI_OPTIONAL)
@@ -704,10 +702,10 @@ jobs:
   prep-build-test-mmi-playwright:
     executor: node-browsers-medium-plus
     steps:
-      - run: *check-mmi-optional
       - run: *shallow-git-clone
       - attach_workspace:
           at: .
+      - run: *check-mmi-optional
       - run:
           name: Build MMI extension for Playwright e2e
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,50 +77,7 @@ workflows:
       - trigger-beta-build:
           requires:
             - prep-deps
-      - check-pr-tag:
-          docker:
-            - image: cimg/base:stable
-          environment:
-            GITHUB_REPO: '$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME'
-          steps:
-            - run:
-                name: Check for MMI Team Tag
-                command: |
-                  #!/bin/bash
-
-                  # GitHub Personal Access Token for API Authentication
-                  GITHUB_TOKEN="${GITHUB_TOKEN}"
-                  GITHUB_REPO="${GITHUB_REPO}"
-                  BRANCH="${CIRCLE_BRANCH}"
-
-                  # Fetch the PR number associated with the current branch
-                  PR_NUMBER=$(curl -s -H "Authorization: token ${GITHUB_TOKEN}" \
-                      "https://api.github.com/repos/${GITHUB_REPO}/pulls" | jq --arg BRANCH "$BRANCH" '.[] | select(.head.ref==$BRANCH) | .number')
-
-                  if [ -z "$PR_NUMBER" ]; then
-                    echo "No PR found for branch $BRANCH."
-                    exit 0
-                  fi
-
-                  echo "PR Number: $PR_NUMBER"
-
-                  # Fetch labels for the PR
-                  LABELS=$(curl -s -H "Authorization: token ${GITHUB_TOKEN}" \
-                      "https://api.github.com/repos/${GITHUB_REPO}/issues/${PR_NUMBER}/labels" | jq -r '.[].name')
-
-                  echo "Labels found: $LABELS"
-
-                  # Check if "mmi-team" label is present
-                  if [[ $LABELS == *"mmi-team"* ]]; then
-                    echo "mmi-team label found."
-                    # You can create a file or an environment variable to signal the next steps
-                    echo 'export RUN_MMI="true"' >> $BASH_ENV
-                    source $BASH_ENV
-                  else
-                    echo "mmi-team label not found."
-                    echo 'export RUN_MMI="false"' >> $BASH_ENV
-                    source $BASH_ENV
-                  fi
+      - check-pr-tag
       - prep-deps
       - test-deps-audit:
           requires:
@@ -417,6 +374,51 @@ jobs:
       - run:
           name: Create GitHub Pull Request for version
           command: .circleci/scripts/release-create-release-pr.sh
+
+  check-pr-tag:
+    docker:
+      - image: cimg/base:stable
+    environment:
+      GITHUB_REPO: '$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME'
+    steps:
+      - run:
+          name: Check for MMI Team Tag
+          command: |
+            #!/bin/bash
+
+            # GitHub Personal Access Token for API Authentication
+            GITHUB_TOKEN="${GITHUB_TOKEN}"
+            GITHUB_REPO="${GITHUB_REPO}"
+            BRANCH="${CIRCLE_BRANCH}"
+
+            # Fetch the PR number associated with the current branch
+            PR_NUMBER=$(curl -s -H "Authorization: token ${GITHUB_TOKEN}" \
+                "https://api.github.com/repos/${GITHUB_REPO}/pulls" | jq --arg BRANCH "$BRANCH" '.[] | select(.head.ref==$BRANCH) | .number')
+
+            if [ -z "$PR_NUMBER" ]; then
+              echo "No PR found for branch $BRANCH."
+              exit 0
+            fi
+
+            echo "PR Number: $PR_NUMBER"
+
+            # Fetch labels for the PR
+            LABELS=$(curl -s -H "Authorization: token ${GITHUB_TOKEN}" \
+                "https://api.github.com/repos/${GITHUB_REPO}/issues/${PR_NUMBER}/labels" | jq -r '.[].name')
+
+            echo "Labels found: $LABELS"
+
+            # Check if "mmi-team" label is present
+            if [[ $LABELS == *"mmi-team"* ]]; then
+              echo "mmi-team label found."
+              # You can create a file or an environment variable to signal the next steps
+              echo 'export RUN_MMI="true"' >> $BASH_ENV
+              source $BASH_ENV
+            else
+              echo "mmi-team label not found."
+              echo 'export RUN_MMI="false"' >> $BASH_ENV
+              source $BASH_ENV
+            fi
 
   prep-deps:
     executor: node-browsers-medium

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -391,20 +391,25 @@ jobs:
             GITHUB_REPO="${GITHUB_REPO}"
             BRANCH="${CIRCLE_BRANCH}"
 
-            # Fetch the PR number associated with the current branch
-            PR_NUMBER=$(curl -s -H "Authorization: token ${GITHUB_TOKEN}" \
-                "https://api.github.com/repos/${GITHUB_REPO}/pulls" | jq --arg BRANCH "$BRANCH" '.[] | select(.head.ref==$BRANCH) | .number')
+            # Fetch the PRs associated with the current branch and check the response
+            PR_RESPONSE=$(curl -s -H "Authorization: token ${GITHUB_TOKEN}" \
+              "https://api.github.com/repos/${GITHUB_REPO}/pulls?state=open&head=${CIRCLE_PROJECT_USERNAME}:${BRANCH}")
 
-            if [ -z "$PR_NUMBER" ]; then
-              echo "No PR found for branch $BRANCH."
-              exit 0
+            # Check if the response contains valid JSON
+            if ! echo "$PR_RESPONSE" | jq empty; then
+                echo "Failed to parse JSON response."
+                echo "$PR_RESPONSE"
+                exit 1
             fi
 
-            echo "PR Number: $PR_NUMBER"
+            # Check if we received an array of PRs
+            if ! echo "$PR_RESPONSE" | jq -e '. | type == "array"'; then
+                echo "Expected an array of PRs, got something else."
+                exit 1
+            fi
 
-            # Fetch labels for the PR
-            LABELS=$(curl -s -H "Authorization: token ${GITHUB_TOKEN}" \
-                "https://api.github.com/repos/${GITHUB_REPO}/issues/${PR_NUMBER}/labels" | jq -r '.[].name')
+            # Extract the PR number
+            LABELS=$(echo "$PR_RESPONSE" | jq -r '.[0].labels // empty')
 
             echo "Labels found: $LABELS"
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -406,19 +406,19 @@ jobs:
                 exit 1
             fi
 
-            # Extract the PR number
-            LABELS=$(echo "$PR_RESPONSE" | jq -r '.[0].labels // empty')
+            # Extract label names from the PR_RESPONSE
+            LABEL_NAMES=$(echo "$PR_RESPONSE" | jq -r '.[0].labels[].name')
 
-            echo "Labels found: $LABELS"
+            echo "Labels found: $LABEL_NAMES"
 
-            # Check if "mmi-team" label is present
-            if [[ $LABELS == *"type-refactor"* ]]; then
-              echo "mmi-team label found."
+            # Check if "team-mmi" label is present
+            if echo "$LABEL_NAMES" | grep -qw "team-mmi"; then
+              echo "team-mmi tag found."
               # You can create a file or an environment variable to signal the next steps
               echo 'export RUN_MMI="true"' >> $BASH_ENV
               source $BASH_ENV
             else
-              echo "mmi-team label not found."
+              echo "team-mmi tag not found."
               echo 'export RUN_MMI="false"' >> $BASH_ENV
               source $BASH_ENV
             fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -394,7 +394,7 @@ jobs:
             # Fetch the PRs associated with the current branch and check the response
             PR_RESPONSE=$(curl -s -H "Authorization: token ${GITHUB_TOKEN}" \
               "https://api.github.com/repos/${GITHUB_REPO}/pulls?state=open&head=${CIRCLE_PROJECT_USERNAME}:${BRANCH}")
-
+            echo "https://api.github.com/repos/${GITHUB_REPO}/pulls?state=open&head=${CIRCLE_PROJECT_USERNAME}:${BRANCH}"
             # Check if the response contains valid JSON
             if ! echo "$PR_RESPONSE" | jq empty; then
                 echo "Failed to parse JSON response."
@@ -404,6 +404,7 @@ jobs:
 
             # Check if we received an array of PRs
             if ! echo "$PR_RESPONSE" | jq -e '. | type == "array"'; then
+                echo "$PR_RESPONSE"
                 echo "Expected an array of PRs, got something else."
                 exit 1
             fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -720,6 +720,7 @@ jobs:
       - persist_to_workspace:
           root: .
           paths:
+            - RUN_MMI_OPTIONAL
             - dist-test-mmi-playwright
             - builds-test-mmi-playwright
       - store_artifacts:


### PR DESCRIPTION
In CI, the Optional MMI job fails for various reasons, and this causes our GitHub checks to _look_ like they've failed (❌) even though the failure is allowed.

To minimize the PRs this failure affects I've configured CI to run only when a PR is labeled with `team-mmi` or the branch is `develop`.


<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.


## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?


[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/23831?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
-->