### PR TITLE
fix: add img role to avatar for improved screen reader experience

### DIFF
--- a/ui/components/app/confirm/info/__snapshots__/info.test.tsx.snap
+++ b/ui/components/app/confirm/info/__snapshots__/info.test.tsx.snap
@@ -26,6 +26,7 @@ exports[`ConfirmInfo should match snapshot 1`] = `
         >
           <div
             class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-account mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full mm-box--border-color-transparent box--border-style-solid box--border-width-1"
+            role="img"
           >
             <div
               class="mm-avatar-account__jazzicon"

--- a/ui/components/app/confirm/info/row/__snapshots__/address.test.tsx.snap
+++ b/ui/components/app/confirm/info/row/__snapshots__/address.test.tsx.snap
@@ -10,6 +10,7 @@ exports[`ConfirmInfoRowAddress renders appropriately with PetNames disabled with
     >
       <div
         class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-account mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full mm-box--border-color-transparent box--border-style-solid box--border-width-1"
+        role="img"
       >
         <div
           class="mm-avatar-account__jazzicon"
@@ -72,6 +73,7 @@ exports[`ConfirmInfoRowAddress renders appropriately with PetNames disabled with
     >
       <div
         class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-account mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full mm-box--border-color-transparent box--border-style-solid box--border-width-1"
+        role="img"
       >
         <div
           class="mm-avatar-account__jazzicon"
@@ -134,6 +136,7 @@ exports[`ConfirmInfoRowAddress renders appropriately with PetNames disabled with
     >
       <div
         class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-account mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full mm-box--border-color-transparent box--border-style-solid box--border-width-1"
+        role="img"
       >
         <div
           class="mm-avatar-account__jazzicon"
@@ -196,6 +199,7 @@ exports[`ConfirmInfoRowAddress renders appropriately with PetNames disabled with
     >
       <div
         class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-account mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full mm-box--border-color-transparent box--border-style-solid box--border-width-1"
+        role="img"
       >
         <div
           class="mm-avatar-account__jazzicon"
@@ -258,6 +262,7 @@ exports[`ConfirmInfoRowAddress renders appropriately with PetNames disabled with
     >
       <div
         class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-account mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full mm-box--border-color-transparent box--border-style-solid box--border-width-1"
+        role="img"
       >
         <div
           class="mm-avatar-account__jazzicon"

--- a/ui/components/app/incoming-trasaction-toggle/__snapshots__/incoming-transaction-toggle.test.js.snap
+++ b/ui/components/app/incoming-trasaction-toggle/__snapshots__/incoming-transaction-toggle.test.js.snap
@@ -24,6 +24,7 @@ exports[`IncomingTransactionToggle should render existing incoming transaction p
       >
         <div
           class="mm-box mm-text mm-avatar-base mm-avatar-base--size-sm mm-avatar-network mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full mm-box--border-color-transparent box--border-style-solid box--border-width-1"
+          role="img"
         >
           <img
             alt="Ethereum Mainnet logo"
@@ -111,6 +112,7 @@ exports[`IncomingTransactionToggle should render existing incoming transaction p
       >
         <div
           class="mm-box mm-text mm-avatar-base mm-avatar-base--size-sm mm-avatar-network mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full mm-box--border-color-transparent box--border-style-solid box--border-width-1"
+          role="img"
         >
           <img
             alt="Linea Mainnet logo"
@@ -198,6 +200,7 @@ exports[`IncomingTransactionToggle should render existing incoming transaction p
       >
         <div
           class="mm-box mm-text mm-avatar-base mm-avatar-base--size-sm mm-avatar-network mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full mm-box--border-color-transparent box--border-style-solid box--border-width-1"
+          role="img"
         >
           F
         </div>
@@ -281,6 +284,7 @@ exports[`IncomingTransactionToggle should render existing incoming transaction p
       >
         <div
           class="mm-box mm-text mm-avatar-base mm-avatar-base--size-sm mm-avatar-network mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full mm-box--border-color-transparent box--border-style-solid box--border-width-1"
+          role="img"
         >
           G
         </div>
@@ -364,6 +368,7 @@ exports[`IncomingTransactionToggle should render existing incoming transaction p
       >
         <div
           class="mm-box mm-text mm-avatar-base mm-avatar-base--size-sm mm-avatar-network mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full mm-box--border-color-transparent box--border-style-solid box--border-width-1"
+          role="img"
         >
           S
         </div>
@@ -447,6 +452,7 @@ exports[`IncomingTransactionToggle should render existing incoming transaction p
       >
         <div
           class="mm-box mm-text mm-avatar-base mm-avatar-base--size-sm mm-avatar-network mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full mm-box--border-color-transparent box--border-style-solid box--border-width-1"
+          role="img"
         >
           <img
             alt="Linea Goerli logo"
@@ -534,6 +540,7 @@ exports[`IncomingTransactionToggle should render existing incoming transaction p
       >
         <div
           class="mm-box mm-text mm-avatar-base mm-avatar-base--size-sm mm-avatar-network mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full mm-box--border-color-transparent box--border-style-solid box--border-width-1"
+          role="img"
         >
           <img
             alt="Linea Sepolia logo"

--- a/ui/components/app/nft-details/__snapshots__/nft-details.test.js.snap
+++ b/ui/components/app/nft-details/__snapshots__/nft-details.test.js.snap
@@ -65,6 +65,7 @@ exports[`NFT Details should match minimal props and state snapshot 1`] = `
               <div
                 class="mm-box mm-text mm-avatar-base mm-avatar-base--size-sm mm-avatar-network nft-item__network-badge mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full mm-box--border-color-background-default mm-box--border-width-2 box--border-style-solid"
                 data-testid="nft-network-badge"
+                role="img"
               >
                 C
               </div>

--- a/ui/components/app/token-cell/__snapshots__/token-cell.test.js.snap
+++ b/ui/components/app/token-cell/__snapshots__/token-cell.test.js.snap
@@ -16,6 +16,7 @@ exports[`Token Cell should match snapshot 1`] = `
       >
         <div
           class="mm-box mm-text mm-avatar-base mm-avatar-base--size-md mm-avatar-token mm-avatar-token--with-halo mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full"
+          role="img"
         >
           <img
             aria-hidden="true"
@@ -33,6 +34,7 @@ exports[`Token Cell should match snapshot 1`] = `
         >
           <div
             class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-network mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--rounded-full mm-box--border-color-border-muted box--border-style-solid box--border-width-1"
+            role="img"
           >
             ?
           </div>

--- a/ui/components/component-library/avatar-account/__snapshots__/avatar-account.test.tsx.snap
+++ b/ui/components/component-library/avatar-account/__snapshots__/avatar-account.test.tsx.snap
@@ -5,6 +5,7 @@ exports[`AvatarAccount should render correctly 1`] = `
   <div
     class="mm-box mm-text mm-avatar-base mm-avatar-base--size-md mm-avatar-account mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full"
     data-testid="avatar-account"
+    role="img"
   >
     <div
       class="mm-avatar-account__jazzicon"

--- a/ui/components/component-library/avatar-base/__snapshots__/avatar-base.test.tsx.snap
+++ b/ui/components/component-library/avatar-base/__snapshots__/avatar-base.test.tsx.snap
@@ -5,6 +5,7 @@ exports[`AvatarBase should render correctly 1`] = `
   <div
     class="mm-box mm-text mm-avatar-base mm-avatar-base--size-md mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full"
     data-testid="avatar-base"
+    role="img"
   />
 </div>
 `;

--- a/ui/components/component-library/avatar-base/avatar-base.test.tsx
+++ b/ui/components/component-library/avatar-base/avatar-base.test.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable jest/require-top-level-describe */
-import { render, screen } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import React from 'react';
 
 import {

--- a/ui/components/component-library/avatar-base/avatar-base.test.tsx
+++ b/ui/components/component-library/avatar-base/avatar-base.test.tsx
@@ -55,12 +55,12 @@ describe('AvatarBase', () => {
   });
   // children
   it('should render children', () => {
-    render(
+    const { container } = render(
       <AvatarBase data-testid="avatar-base">
         <img width="100%" src="./images/arbitrum.svg" />
       </AvatarBase>,
     );
-    const image = screen.getByRole('img');
+    const image = container.querySelector('img');
     expect(image).toBeDefined();
     expect(image).toHaveAttribute('src', './images/arbitrum.svg');
   });

--- a/ui/components/component-library/avatar-base/avatar-base.tsx
+++ b/ui/components/component-library/avatar-base/avatar-base.tsx
@@ -51,6 +51,7 @@ export const AvatarBase: AvatarBaseComponent = React.forwardRef(
         )}
         ref={ref}
         as="div"
+        role="img"
         display={Display.Flex}
         justifyContent={JustifyContent.center}
         alignItems={AlignItems.center}

--- a/ui/components/component-library/avatar-favicon/__snapshots__/avatar-favicon.test.tsx.snap
+++ b/ui/components/component-library/avatar-favicon/__snapshots__/avatar-favicon.test.tsx.snap
@@ -5,6 +5,7 @@ exports[`AvatarFavicon should render correctly 1`] = `
   <div
     class="mm-box mm-text mm-avatar-base mm-avatar-base--size-md mm-avatar-favicon mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full mm-box--border-color-transparent box--border-style-solid box--border-width-1"
     data-testid="avatar-favicon"
+    role="img"
   >
     <span
       class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-icon-default"

--- a/ui/components/component-library/avatar-favicon/avatar-favicon.test.tsx
+++ b/ui/components/component-library/avatar-favicon/avatar-favicon.test.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable jest/require-top-level-describe */
-import { render, screen } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import React from 'react';
 
 import { IconName } from '..';

--- a/ui/components/component-library/avatar-favicon/avatar-favicon.test.tsx
+++ b/ui/components/component-library/avatar-favicon/avatar-favicon.test.tsx
@@ -21,8 +21,10 @@ describe('AvatarFavicon', () => {
   });
 
   it('should render image of Avatar Favicon', () => {
-    render(<AvatarFavicon data-testid="avatar-favicon" {...args} />);
-    const image = screen.getByRole('img');
+    const { container } = render(
+      <AvatarFavicon data-testid="avatar-favicon" {...args} />,
+    );
+    const image = container.querySelector('img');
     expect(image).toBeDefined();
     expect(image).toHaveAttribute('src', args.src);
   });

--- a/ui/components/component-library/avatar-icon/__snapshots__/avatar-icon.test.tsx.snap
+++ b/ui/components/component-library/avatar-icon/__snapshots__/avatar-icon.test.tsx.snap
@@ -5,6 +5,7 @@ exports[`AvatarIcon should render correctly 1`] = `
   <div
     class="mm-box mm-text mm-avatar-base mm-avatar-base--size-md mm-avatar-icon mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-primary-default mm-box--background-color-primary-muted mm-box--rounded-full mm-box--border-color-transparent box--border-style-solid box--border-width-1"
     data-testid="avatar-icon"
+    role="img"
   >
     <span
       class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"

--- a/ui/components/component-library/avatar-network/__snapshots__/avatar-network.test.tsx.snap
+++ b/ui/components/component-library/avatar-network/__snapshots__/avatar-network.test.tsx.snap
@@ -5,6 +5,7 @@ exports[`AvatarNetwork should render correctly 1`] = `
   <div
     class="mm-box mm-text mm-avatar-base mm-avatar-base--size-md mm-avatar-network mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full mm-box--border-color-transparent box--border-style-solid box--border-width-1"
     data-testid="avatar-network"
+    role="img"
   >
     <img
       alt="ethereum logo"

--- a/ui/components/component-library/avatar-network/avatar-network.test.tsx
+++ b/ui/components/component-library/avatar-network/avatar-network.test.tsx
@@ -26,8 +26,10 @@ describe('AvatarNetwork', () => {
   });
 
   it('should render image of Avatar Network', () => {
-    render(<AvatarNetwork data-testid="avatar-network" {...args} />);
-    const image = screen.getByRole('img');
+    const { container } = render(
+      <AvatarNetwork data-testid="avatar-network" {...args} />,
+    );
+    const image = container.querySelector('img');
     expect(image).toBeDefined();
     expect(image).toHaveAttribute('src', args.src);
   });
@@ -40,8 +42,10 @@ describe('AvatarNetwork', () => {
   });
 
   it('should render halo effect if showHalo is true and image url is there', () => {
-    render(<AvatarNetwork data-testid="avatar-network" {...args} showHalo />);
-    const image = screen.getAllByRole('img', { hidden: true });
+    const { container } = render(
+      <AvatarNetwork data-testid="avatar-network" {...args} showHalo />,
+    );
+    const image = container.querySelectorAll('img');
     expect(image[1]).toHaveClass(
       'mm-avatar-network__network-image--size-reduced',
     );

--- a/ui/components/component-library/avatar-network/avatar-network.test.tsx
+++ b/ui/components/component-library/avatar-network/avatar-network.test.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable jest/require-top-level-describe */
-import { render, screen } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import React from 'react';
 
 import {

--- a/ui/components/component-library/avatar-token/__snapshots__/avatar-token.test.tsx.snap
+++ b/ui/components/component-library/avatar-token/__snapshots__/avatar-token.test.tsx.snap
@@ -5,6 +5,7 @@ exports[`AvatarToken should render correctly 1`] = `
   <div
     class="mm-box mm-text mm-avatar-base mm-avatar-base--size-md mm-avatar-token mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full"
     data-testid="avatar-token"
+    role="img"
   >
     <img
       alt="ast logo"

--- a/ui/components/component-library/avatar-token/avatar-token.test.tsx
+++ b/ui/components/component-library/avatar-token/avatar-token.test.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable jest/require-top-level-describe */
-import { render, screen } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import React from 'react';
 import {
   BackgroundColor,
@@ -24,8 +24,10 @@ describe('AvatarToken', () => {
   });
 
   it('should render image Avatar', () => {
-    render(<AvatarToken {...args} data-testid="avatar-token" />);
-    const image = screen.getByRole('img');
+    const { container } = render(
+      <AvatarToken {...args} data-testid="avatar-token" />,
+    );
+    const image = container.querySelector('img');
     expect(image).toBeDefined();
     expect(image).toHaveAttribute('src', args.src);
   });
@@ -38,8 +40,10 @@ describe('AvatarToken', () => {
   });
 
   it('should render halo effect if showHalo is true and image url is there', () => {
-    render(<AvatarToken {...args} data-testid="avatar-token" showHalo />);
-    const image = screen.getAllByRole('img', { hidden: true });
+    const { container } = render(
+      <AvatarToken {...args} data-testid="avatar-token" showHalo />,
+    );
+    const image = container.querySelectorAll('img');
     expect(image[1]).toHaveClass('mm-avatar-token__token-image--size-reduced');
   });
 

--- a/ui/components/component-library/picker-network/__snapshots__/picker-network.test.tsx.snap
+++ b/ui/components/component-library/picker-network/__snapshots__/picker-network.test.tsx.snap
@@ -8,6 +8,7 @@ exports[`PickerNetwork should render the label inside the PickerNetwork 1`] = `
   >
     <div
       class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-network mm-picker-network__avatar-network mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full mm-box--border-color-transparent box--border-style-solid box--border-width-1"
+      role="img"
     >
       I
     </div>

--- a/ui/components/component-library/picker-network/picker-network.test.tsx
+++ b/ui/components/component-library/picker-network/picker-network.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import React from 'react';
 
 import { IconName } from '..';

--- a/ui/components/component-library/picker-network/picker-network.test.tsx
+++ b/ui/components/component-library/picker-network/picker-network.test.tsx
@@ -14,14 +14,14 @@ describe('PickerNetwork', () => {
     expect(container).toMatchSnapshot();
   });
   it('should render correct Avatar inside Picker Network', () => {
-    render(
+    const { container } = render(
       <PickerNetwork
         data-testid="picker-network"
         label="Imported"
         src="./images/matic-token.svg"
       />,
     );
-    const image = screen.getByRole('img');
+    const image = container.querySelector('img');
     expect(image).toBeDefined();
     expect(image).toHaveAttribute('src', './images/matic-token.svg');
   });

--- a/ui/components/component-library/tag-url/__snapshots__/tag-url.test.tsx.snap
+++ b/ui/components/component-library/tag-url/__snapshots__/tag-url.test.tsx.snap
@@ -8,6 +8,7 @@ exports[`TagUrl should render the label inside the TagUrl 1`] = `
   >
     <div
       class="mm-box mm-text mm-avatar-base mm-avatar-base--size-md mm-avatar-favicon mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full mm-box--border-color-transparent box--border-style-solid box--border-width-1"
+      role="img"
     >
       <span
         class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-icon-default"

--- a/ui/components/component-library/tag-url/tag-url.test.tsx
+++ b/ui/components/component-library/tag-url/tag-url.test.tsx
@@ -26,7 +26,7 @@ describe('TagUrl', () => {
   });
 
   it('should render correct Avatar in TagUrl', () => {
-    render(
+    const { container } = render(
       <TagUrl
         data-testid="tag-url"
         label="https://app.uniswap.org"
@@ -34,7 +34,7 @@ describe('TagUrl', () => {
         src="https://1inch.exchange/assets/favicon/favicon-32x32.png"
       />,
     );
-    const image = screen.getByRole('img');
+    const image = container.querySelector('img');
     expect(image).toBeDefined();
     expect(image).toHaveAttribute(
       'src',

--- a/ui/components/multichain/account-list-item/__snapshots__/account-list-item.test.js.snap
+++ b/ui/components/multichain/account-list-item/__snapshots__/account-list-item.test.js.snap
@@ -7,6 +7,7 @@ exports[`AccountListItem renders AccountListItem component and shows account nam
   >
     <div
       class="mm-box mm-text mm-avatar-base mm-avatar-base--size-md mm-avatar-account mm-text--body-sm mm-text--text-transform-uppercase mm-box--margin-inline-end-2 mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full mm-box--border-color-transparent box--border-style-solid box--border-width-1"
+      role="img"
     >
       <div
         class="mm-avatar-account__jazzicon"
@@ -104,6 +105,7 @@ exports[`AccountListItem renders AccountListItem component and shows account nam
         >
           <div
             class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-token mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full mm-box--border-color-border-default box--border-style-solid box--border-width-1"
+            role="img"
           >
             E
           </div>

--- a/ui/components/multichain/account-picker/__snapshots__/account-picker.test.js.snap
+++ b/ui/components/multichain/account-picker/__snapshots__/account-picker.test.js.snap
@@ -11,6 +11,7 @@ exports[`AccountPicker renders properly 1`] = `
     >
       <div
         class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-account mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full mm-box--border-color-background-default box--border-style-solid box--border-width-1"
+        role="img"
       >
         <img
           alt=""

--- a/ui/components/multichain/address-list-item/__snapshots__/address-list-item.test.tsx.snap
+++ b/ui/components/multichain/address-list-item/__snapshots__/address-list-item.test.tsx.snap
@@ -7,6 +7,7 @@ exports[`AddressListItem renders the address and label 1`] = `
   >
     <div
       class="mm-box mm-text mm-avatar-base mm-avatar-base--size-sm mm-avatar-account mm-text--body-sm mm-text--text-transform-uppercase mm-box--margin-inline-end-2 mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full mm-box--border-color-transparent box--border-style-solid box--border-width-1"
+      role="img"
     >
       <div
         class="mm-avatar-account__jazzicon"

--- a/ui/components/multichain/app-header/__snapshots__/app-header.test.js.snap
+++ b/ui/components/multichain/app-header/__snapshots__/app-header.test.js.snap
@@ -213,6 +213,7 @@ exports[`App Header should match snapshot 1`] = `
         >
           <div
             class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-network mm-picker-network__avatar-network mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full mm-box--border-color-transparent box--border-style-solid box--border-width-1"
+            role="img"
           >
             C
           </div>
@@ -239,6 +240,7 @@ exports[`App Header should match snapshot 1`] = `
           >
             <div
               class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-account mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full mm-box--border-color-background-default box--border-style-solid box--border-width-1"
+              role="img"
             >
               <div
                 class="mm-avatar-account__jazzicon"

--- a/ui/components/multichain/asset-picker-amount/asset-picker/__snapshots__/asset-picker.test.tsx.snap
+++ b/ui/components/multichain/asset-picker-amount/asset-picker/__snapshots__/asset-picker.test.tsx.snap
@@ -13,6 +13,7 @@ exports[`AssetPicker matches snapshot 1`] = `
       >
         <div
           class="mm-box mm-text mm-avatar-base mm-avatar-base--size-md mm-avatar-token mm-avatar-token--with-halo mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full"
+          role="img"
         >
           <img
             aria-hidden="true"

--- a/ui/components/multichain/asset-picker-amount/asset-picker/asset-picker.test.tsx
+++ b/ui/components/multichain/asset-picker-amount/asset-picker/asset-picker.test.tsx
@@ -57,14 +57,17 @@ describe('AssetPicker', () => {
     };
     const mockAssetChange = jest.fn();
 
-    const { getByText, getByRole } = render(
+    const { getByText, container } = render(
       <Provider store={store('NATIVE')}>
         <AssetPicker asset={asset} onAssetChange={() => mockAssetChange()} />
       </Provider>,
     );
     expect(getByText('NATIVE')).toBeInTheDocument();
-    expect(getByRole('img')).toBeInTheDocument();
-    expect(getByRole('img')).toHaveAttribute('src', './images/eth_logo.svg');
+    expect(container.querySelector('img')).toBeInTheDocument();
+    expect(container.querySelector('img')).toHaveAttribute(
+      'src',
+      './images/eth_logo.svg',
+    );
   });
 
   it('native: renders overflowing symbol and image', () => {
@@ -74,14 +77,17 @@ describe('AssetPicker', () => {
     };
     const mockAssetChange = jest.fn();
 
-    const { getByText, getByRole } = render(
+    const { getByText, container } = render(
       <Provider store={store('NATIVE TOKEN')}>
         <AssetPicker asset={asset} onAssetChange={() => mockAssetChange()} />
       </Provider>,
     );
     expect(getByText('NATIVE...')).toBeInTheDocument();
-    expect(getByRole('img')).toBeInTheDocument();
-    expect(getByRole('img')).toHaveAttribute('src', './images/eth_logo.svg');
+    expect(container.querySelector('img')).toBeInTheDocument();
+    expect(container.querySelector('img')).toHaveAttribute(
+      'src',
+      './images/eth_logo.svg',
+    );
   });
 
   it('token: renders symbol and image', () => {
@@ -96,7 +102,7 @@ describe('AssetPicker', () => {
     };
     const mockAssetChange = jest.fn();
 
-    const { getByText, getByRole } = render(
+    const { getByText, container } = render(
       <Provider
         store={store("SHOULDN'T MATTER", {
           'token address': { iconUrl: 'token icon url' },
@@ -106,8 +112,11 @@ describe('AssetPicker', () => {
       </Provider>,
     );
     expect(getByText('symbol')).toBeInTheDocument();
-    expect(getByRole('img')).toBeInTheDocument();
-    expect(getByRole('img')).toHaveAttribute('src', 'token icon url');
+    expect(container.querySelector('img')).toBeInTheDocument();
+    expect(container.querySelector('img')).toHaveAttribute(
+      'src',
+      'token icon url',
+    );
   });
 
   it('token: renders symbol and image overflowing', () => {
@@ -122,7 +131,7 @@ describe('AssetPicker', () => {
     };
     const mockAssetChange = jest.fn();
 
-    const { getByText, getByRole } = render(
+    const { getByText, container } = render(
       <Provider
         store={store("SHOULDN'T MATTER", {
           'token address': { iconUrl: 'token icon url' },
@@ -132,8 +141,11 @@ describe('AssetPicker', () => {
       </Provider>,
     );
     expect(getByText('symbol...')).toBeInTheDocument();
-    expect(getByRole('img')).toBeInTheDocument();
-    expect(getByRole('img')).toHaveAttribute('src', 'token icon url');
+    expect(container.querySelector('img')).toBeInTheDocument();
+    expect(container.querySelector('img')).toHaveAttribute(
+      'src',
+      'token icon url',
+    );
   });
 
   it('token: renders symbol and image falls back', () => {

--- a/ui/components/multichain/avatar-group/__snapshots__/avatar-group.test.tsx.snap
+++ b/ui/components/multichain/avatar-group/__snapshots__/avatar-group.test.tsx.snap
@@ -15,6 +15,7 @@ exports[`AvatarGroup should render AvatarGroup component 1`] = `
       >
         <div
           class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-token mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full"
+          role="img"
         >
           <img
             alt="AVAX logo"
@@ -29,6 +30,7 @@ exports[`AvatarGroup should render AvatarGroup component 1`] = `
       >
         <div
           class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-token mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full"
+          role="img"
         >
           <img
             alt="OP logo"
@@ -43,6 +45,7 @@ exports[`AvatarGroup should render AvatarGroup component 1`] = `
       >
         <div
           class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-token mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full"
+          role="img"
         >
           <img
             alt="MATIC logo"
@@ -57,6 +60,7 @@ exports[`AvatarGroup should render AvatarGroup component 1`] = `
       >
         <div
           class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-token mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full"
+          role="img"
         >
           <img
             alt="ETH logo"

--- a/ui/components/multichain/badge-status/__snapshots__/badge-status.test.js.snap
+++ b/ui/components/multichain/badge-status/__snapshots__/badge-status.test.js.snap
@@ -20,6 +20,7 @@ exports[`Badge Status should render correctly 1`] = `
         >
           <div
             class="mm-box mm-text mm-avatar-base mm-avatar-base--size-md mm-avatar-account mm-text--body-sm mm-text--text-transform-uppercase mm-box--margin-inline-end-2 mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full mm-box--border-color-transparent box--border-style-solid box--border-width-1"
+            role="img"
           >
             <img
               alt=""

--- a/ui/components/multichain/connected-site-menu/__snapshots__/connected-site-menu.test.js.snap
+++ b/ui/components/multichain/connected-site-menu/__snapshots__/connected-site-menu.test.js.snap
@@ -20,6 +20,7 @@ exports[`Connected Site Menu should render the site menu in connected state 1`] 
         >
           <div
             class="mm-box mm-text mm-avatar-base mm-avatar-base--size-sm mm-avatar-favicon mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full mm-box--border-color-transparent box--border-style-solid box--border-width-1"
+            role="img"
           >
             <img
               alt="Uniswap logo"
@@ -62,6 +63,7 @@ exports[`Connected Site Menu should render the site menu in not connected state 
         >
           <div
             class="mm-box mm-text mm-avatar-base mm-avatar-base--size-sm mm-avatar-favicon mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full mm-box--border-color-transparent box--border-style-solid box--border-width-1"
+            role="img"
           >
             <img
               alt="Uniswap logo"
@@ -104,6 +106,7 @@ exports[`Connected Site Menu should render the site menu in not connected to cur
         >
           <div
             class="mm-box mm-text mm-avatar-base mm-avatar-base--size-sm mm-avatar-favicon mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full mm-box--border-color-transparent box--border-style-solid box--border-width-1"
+            role="img"
           >
             <img
               alt="Uniswap logo"

--- a/ui/components/multichain/network-list-item/__snapshots__/network-list-item.test.js.snap
+++ b/ui/components/multichain/network-list-item/__snapshots__/network-list-item.test.js.snap
@@ -7,6 +7,7 @@ exports[`NetworkListItem renders properly 1`] = `
   >
     <div
       class="mm-box mm-text mm-avatar-base mm-avatar-base--size-md mm-avatar-network mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full mm-box--border-color-transparent box--border-style-solid box--border-width-1"
+      role="img"
     >
       <img
         alt="Polygon logo"

--- a/ui/components/multichain/notification-detail-collection/notification-detail-collection.test.tsx
+++ b/ui/components/multichain/notification-detail-collection/notification-detail-collection.test.tsx
@@ -22,8 +22,10 @@ describe('NotificationDetailCollection', () => {
   });
 
   it('renders the main image and the badge image', () => {
-    render(<NotificationDetailCollection {...defaultProps} />);
-    const images = screen.getAllByRole('img');
+    const { container } = render(
+      <NotificationDetailCollection {...defaultProps} />,
+    );
+    const images = container.querySelectorAll('img');
     expect(images.length).toBe(2);
     expect(images[0]).toHaveAttribute('src', defaultProps.icon.src);
     expect(images[1]).toHaveAttribute('src', defaultProps.icon.badgeSrc);

--- a/ui/components/multichain/pages/connections/__snapshots__/connections.test.tsx.snap
+++ b/ui/components/multichain/pages/connections/__snapshots__/connections.test.tsx.snap
@@ -78,6 +78,7 @@ exports[`Connections Content should render correctly 1`] = `
               />
               <div
                 class="mm-box mm-text mm-avatar-base mm-avatar-base--size-md mm-avatar-account mm-text--body-sm mm-text--text-transform-uppercase mm-box--margin-inline-end-2 mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full mm-box--border-color-transparent box--border-style-solid box--border-width-1"
+                role="img"
               >
                 <div
                   class="mm-avatar-account__jazzicon"
@@ -175,6 +176,7 @@ exports[`Connections Content should render correctly 1`] = `
                   >
                     <div
                       class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-token mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full mm-box--border-color-border-default box--border-style-solid box--border-width-1"
+                      role="img"
                     >
                       E
                     </div>

--- a/ui/components/multichain/pages/permissions-page/__snapshots__/permissions-page.test.js.snap
+++ b/ui/components/multichain/pages/permissions-page/__snapshots__/permissions-page.test.js.snap
@@ -66,6 +66,7 @@ exports[`All Connections render renders correctly 1`] = `
               <div
                 class="mm-box mm-text mm-avatar-base mm-avatar-base--size-md mm-avatar-favicon mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full mm-box--border-color-transparent box--border-style-solid box--border-width-1"
                 data-testid="connection-list-item__avatar-favicon"
+                role="img"
               >
                 <img
                   alt="avatar-favicon logo"
@@ -79,6 +80,7 @@ exports[`All Connections render renders correctly 1`] = `
                 <div
                   class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-network mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
                   data-testid="connection-list-item__avatar-network-badge"
+                  role="img"
                 >
                   <img
                     alt="Ethereum Mainnet logo"
@@ -126,6 +128,7 @@ exports[`All Connections render renders correctly 1`] = `
                     >
                       <div
                         class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-account mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full mm-box--border-color-background-default box--border-style-solid box--border-width-1"
+                        role="img"
                       >
                         <div
                           class="mm-avatar-account__jazzicon"
@@ -202,6 +205,7 @@ exports[`All Connections render renders correctly 1`] = `
             >
               <div
                 class="mm-box mm-text mm-avatar-base mm-avatar-base--size-md mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-alternative mm-box--background-color-background-alternative mm-box--rounded-full"
+                role="img"
                 style="border-width: 0px;"
               >
                 m
@@ -211,6 +215,7 @@ exports[`All Connections render renders correctly 1`] = `
               >
                 <div
                   class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-icon mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-primary-default mm-box--background-color-info-default mm-box--rounded-full mm-box--border-color-background-default mm-box--border-width-0 box--border-style-solid box--border-width-1"
+                  role="img"
                 >
                   <span
                     class="mm-box mm-icon mm-icon--size-xs mm-box--display-inline-block mm-box--color-info-inverse"
@@ -253,6 +258,7 @@ exports[`All Connections render renders correctly 1`] = `
             >
               <div
                 class="mm-box mm-text mm-avatar-base mm-avatar-base--size-md mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-alternative mm-box--background-color-background-alternative mm-box--rounded-full"
+                role="img"
                 style="border-width: 0px;"
               >
                 m
@@ -262,6 +268,7 @@ exports[`All Connections render renders correctly 1`] = `
               >
                 <div
                   class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-icon mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-primary-default mm-box--background-color-info-default mm-box--rounded-full mm-box--border-color-background-default mm-box--border-width-0 box--border-style-solid box--border-width-1"
+                  role="img"
                 >
                   <span
                     class="mm-box mm-icon mm-icon--size-xs mm-box--display-inline-block mm-box--color-info-inverse"
@@ -304,6 +311,7 @@ exports[`All Connections render renders correctly 1`] = `
             >
               <div
                 class="mm-box mm-text mm-avatar-base mm-avatar-base--size-md mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-alternative mm-box--background-color-background-alternative mm-box--rounded-full"
+                role="img"
                 style="border-width: 0px;"
               >
                 m
@@ -313,6 +321,7 @@ exports[`All Connections render renders correctly 1`] = `
               >
                 <div
                   class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-icon mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-primary-default mm-box--background-color-info-default mm-box--rounded-full mm-box--border-color-background-default mm-box--border-width-0 box--border-style-solid box--border-width-1"
+                  role="img"
                 >
                   <span
                     class="mm-box mm-icon mm-icon--size-xs mm-box--display-inline-block mm-box--color-info-inverse"

--- a/ui/components/multichain/pages/send/__snapshots__/send.test.js.snap
+++ b/ui/components/multichain/pages/send/__snapshots__/send.test.js.snap
@@ -56,6 +56,7 @@ exports[`SendPage render and initialization should render correctly even when a 
             >
               <div
                 class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-account mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full mm-box--border-color-background-default box--border-style-solid box--border-width-1"
+                role="img"
               >
                 <div
                   class="mm-avatar-account__jazzicon"
@@ -186,6 +187,7 @@ exports[`SendPage render and initialization should render correctly even when a 
                 >
                   <div
                     class="mm-box mm-text mm-avatar-base mm-avatar-base--size-md mm-avatar-account mm-text--body-sm mm-text--text-transform-uppercase mm-box--margin-inline-end-2 mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full mm-box--border-color-transparent box--border-style-solid box--border-width-1"
+                    role="img"
                   >
                     <div
                       class="mm-avatar-account__jazzicon"
@@ -281,6 +283,7 @@ exports[`SendPage render and initialization should render correctly even when a 
                       >
                         <div
                           class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-token mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full mm-box--border-color-border-default box--border-style-solid box--border-width-1"
+                          role="img"
                         >
                           ?
                         </div>

--- a/ui/components/multichain/pages/send/components/__snapshots__/account-picker.test.tsx.snap
+++ b/ui/components/multichain/pages/send/components/__snapshots__/account-picker.test.tsx.snap
@@ -20,6 +20,7 @@ exports[`SendPageAccountPicker render renders correctly 1`] = `
       >
         <div
           class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-account mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full mm-box--border-color-background-default box--border-style-solid box--border-width-1"
+          role="img"
         >
           <div
             class="mm-avatar-account__jazzicon"

--- a/ui/components/multichain/pages/send/components/__snapshots__/network-picker.test.tsx.snap
+++ b/ui/components/multichain/pages/send/components/__snapshots__/network-picker.test.tsx.snap
@@ -11,6 +11,7 @@ exports[`SendPageNetworkPicker render renders correctly 1`] = `
     >
       <div
         class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-network mm-picker-network__avatar-network mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full mm-box--border-color-transparent box--border-style-solid box--border-width-1"
+        role="img"
       >
         C
       </div>

--- a/ui/components/multichain/pages/send/components/__snapshots__/your-accounts.test.tsx.snap
+++ b/ui/components/multichain/pages/send/components/__snapshots__/your-accounts.test.tsx.snap
@@ -10,6 +10,7 @@ exports[`SendPageYourAccounts render renders correctly 1`] = `
     >
       <div
         class="mm-box mm-text mm-avatar-base mm-avatar-base--size-md mm-avatar-account mm-text--body-sm mm-text--text-transform-uppercase mm-box--margin-inline-end-2 mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full mm-box--border-color-transparent box--border-style-solid box--border-width-1"
+        role="img"
       >
         <div
           class="mm-avatar-account__jazzicon"
@@ -107,6 +108,7 @@ exports[`SendPageYourAccounts render renders correctly 1`] = `
           >
             <div
               class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-token mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full mm-box--border-color-border-default box--border-style-solid box--border-width-1"
+              role="img"
             >
               E
             </div>
@@ -138,6 +140,7 @@ exports[`SendPageYourAccounts render renders correctly 1`] = `
     >
       <div
         class="mm-box mm-text mm-avatar-base mm-avatar-base--size-md mm-avatar-account mm-text--body-sm mm-text--text-transform-uppercase mm-box--margin-inline-end-2 mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full mm-box--border-color-transparent box--border-style-solid box--border-width-1"
+        role="img"
       >
         <div
           class="mm-avatar-account__jazzicon"
@@ -235,6 +238,7 @@ exports[`SendPageYourAccounts render renders correctly 1`] = `
           >
             <div
               class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-token mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full mm-box--border-color-border-default box--border-style-solid box--border-width-1"
+              role="img"
             >
               E
             </div>
@@ -266,6 +270,7 @@ exports[`SendPageYourAccounts render renders correctly 1`] = `
     >
       <div
         class="mm-box mm-text mm-avatar-base mm-avatar-base--size-md mm-avatar-account mm-text--body-sm mm-text--text-transform-uppercase mm-box--margin-inline-end-2 mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full mm-box--border-color-transparent box--border-style-solid box--border-width-1"
+        role="img"
       >
         <div
           class="mm-avatar-account__jazzicon"
@@ -363,6 +368,7 @@ exports[`SendPageYourAccounts render renders correctly 1`] = `
           >
             <div
               class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-token mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full mm-box--border-color-border-default box--border-style-solid box--border-width-1"
+              role="img"
             >
               E
             </div>
@@ -403,6 +409,7 @@ exports[`SendPageYourAccounts render renders correctly 1`] = `
     >
       <div
         class="mm-box mm-text mm-avatar-base mm-avatar-base--size-md mm-avatar-account mm-text--body-sm mm-text--text-transform-uppercase mm-box--margin-inline-end-2 mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full mm-box--border-color-transparent box--border-style-solid box--border-width-1"
+        role="img"
       >
         <div
           class="mm-avatar-account__jazzicon"
@@ -500,6 +507,7 @@ exports[`SendPageYourAccounts render renders correctly 1`] = `
           >
             <div
               class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-token mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full mm-box--border-color-border-default box--border-style-solid box--border-width-1"
+              role="img"
             >
               E
             </div>
@@ -531,6 +539,7 @@ exports[`SendPageYourAccounts render renders correctly 1`] = `
     >
       <div
         class="mm-box mm-text mm-avatar-base mm-avatar-base--size-md mm-avatar-account mm-text--body-sm mm-text--text-transform-uppercase mm-box--margin-inline-end-2 mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full mm-box--border-color-transparent box--border-style-solid box--border-width-1"
+        role="img"
       >
         <div
           class="mm-avatar-account__jazzicon"
@@ -628,6 +637,7 @@ exports[`SendPageYourAccounts render renders correctly 1`] = `
           >
             <div
               class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-token mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full mm-box--border-color-border-default box--border-style-solid box--border-width-1"
+              role="img"
             >
               E
             </div>
@@ -672,6 +682,7 @@ exports[`SendPageYourAccounts render renders correctly 1`] = `
     >
       <div
         class="mm-box mm-text mm-avatar-base mm-avatar-base--size-md mm-avatar-account mm-text--body-sm mm-text--text-transform-uppercase mm-box--margin-inline-end-2 mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full mm-box--border-color-transparent box--border-style-solid box--border-width-1"
+        role="img"
       >
         <div
           class="mm-avatar-account__jazzicon"
@@ -769,6 +780,7 @@ exports[`SendPageYourAccounts render renders correctly 1`] = `
           >
             <div
               class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-token mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full mm-box--border-color-border-default box--border-style-solid box--border-width-1"
+              role="img"
             >
               E
             </div>

--- a/ui/components/multichain/toast/__snapshots__/toast.test.tsx.snap
+++ b/ui/components/multichain/toast/__snapshots__/toast.test.tsx.snap
@@ -14,6 +14,7 @@ exports[`Toast should render Toast component 1`] = `
       >
         <div
           class="mm-box mm-text mm-avatar-base mm-avatar-base--size-md mm-avatar-account mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full mm-box--border-color-transparent box--border-style-solid box--border-width-1"
+          role="img"
         >
           <div
             class="mm-avatar-account__jazzicon"

--- a/ui/components/multichain/token-list-item/__snapshots__/token-list-item.test.js.snap
+++ b/ui/components/multichain/token-list-item/__snapshots__/token-list-item.test.js.snap
@@ -16,6 +16,7 @@ exports[`TokenListItem should render correctly 1`] = `
       >
         <div
           class="mm-box mm-text mm-avatar-base mm-avatar-base--size-md mm-avatar-token mm-avatar-token--with-halo mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full mm-box--border-color-border-default box--border-style-solid box--border-width-1"
+          role="img"
         >
           ?
         </div>
@@ -24,6 +25,7 @@ exports[`TokenListItem should render correctly 1`] = `
         >
           <div
             class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-network mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full mm-box--border-color-border-muted box--border-style-solid box--border-width-1"
+            role="img"
           >
             <img
               alt="Ethereum Mainnet logo"

--- a/ui/pages/confirmations/components/confirm/header/__snapshots__/header.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/header/__snapshots__/header.test.tsx.snap
@@ -57,6 +57,7 @@ exports[`Header should match snapshot 1`] = `
         </div>
         <div
           class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-network confirm_header__avatar-network mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full mm-box--border-color-transparent box--border-style-solid box--border-width-1"
+          role="img"
         >
           C
         </div>

--- a/ui/pages/confirmations/components/confirm/info/__snapshots__/info.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/info/__snapshots__/info.test.tsx.snap
@@ -138,6 +138,7 @@ exports[`Info renders info section for typed sign request 1`] = `
         >
           <div
             class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-account mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full mm-box--border-color-transparent box--border-style-solid box--border-width-1"
+            role="img"
           >
             <div
               class="mm-avatar-account__jazzicon"
@@ -298,6 +299,7 @@ exports[`Info renders info section for typed sign request 1`] = `
                     >
                       <div
                         class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-account mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full mm-box--border-color-transparent box--border-style-solid box--border-width-1"
+                        role="img"
                       >
                         <div
                           class="mm-avatar-account__jazzicon"
@@ -410,6 +412,7 @@ exports[`Info renders info section for typed sign request 1`] = `
                     >
                       <div
                         class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-account mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full mm-box--border-color-transparent box--border-style-solid box--border-width-1"
+                        role="img"
                       >
                         <div
                           class="mm-avatar-account__jazzicon"

--- a/ui/pages/confirmations/components/confirm/info/typed-sign/__snapshots__/typed-sign.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/info/typed-sign/__snapshots__/typed-sign.test.tsx.snap
@@ -66,6 +66,7 @@ exports[`TypedSignInfo renders origin for typed sign data request 1`] = `
         >
           <div
             class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-account mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full mm-box--border-color-transparent box--border-style-solid box--border-width-1"
+            role="img"
           >
             <div
               class="mm-avatar-account__jazzicon"
@@ -226,6 +227,7 @@ exports[`TypedSignInfo renders origin for typed sign data request 1`] = `
                     >
                       <div
                         class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-account mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full mm-box--border-color-transparent box--border-style-solid box--border-width-1"
+                        role="img"
                       >
                         <div
                           class="mm-avatar-account__jazzicon"
@@ -338,6 +340,7 @@ exports[`TypedSignInfo renders origin for typed sign data request 1`] = `
                     >
                       <div
                         class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-account mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full mm-box--border-color-transparent box--border-style-solid box--border-width-1"
+                        role="img"
                       >
                         <div
                           class="mm-avatar-account__jazzicon"
@@ -485,6 +488,7 @@ exports[`TypedSignInfo should render message for typed sign v3 request 1`] = `
         >
           <div
             class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-account mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full mm-box--border-color-transparent box--border-style-solid box--border-width-1"
+            role="img"
           >
             <div
               class="mm-avatar-account__jazzicon"
@@ -645,6 +649,7 @@ exports[`TypedSignInfo should render message for typed sign v3 request 1`] = `
                     >
                       <div
                         class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-account mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full mm-box--border-color-transparent box--border-style-solid box--border-width-1"
+                        role="img"
                       >
                         <div
                           class="mm-avatar-account__jazzicon"
@@ -757,6 +762,7 @@ exports[`TypedSignInfo should render message for typed sign v3 request 1`] = `
                     >
                       <div
                         class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-account mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full mm-box--border-color-transparent box--border-style-solid box--border-width-1"
+                        role="img"
                       >
                         <div
                           class="mm-avatar-account__jazzicon"
@@ -904,6 +910,7 @@ exports[`TypedSignInfo should render message for typed sign v4 request 1`] = `
         >
           <div
             class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-account mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full mm-box--border-color-transparent box--border-style-solid box--border-width-1"
+            role="img"
           >
             <div
               class="mm-avatar-account__jazzicon"
@@ -1103,6 +1110,7 @@ exports[`TypedSignInfo should render message for typed sign v4 request 1`] = `
                         >
                           <div
                             class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-account mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full mm-box--border-color-transparent box--border-style-solid box--border-width-1"
+                            role="img"
                           >
                             <div
                               class="mm-avatar-account__jazzicon"
@@ -1174,6 +1182,7 @@ exports[`TypedSignInfo should render message for typed sign v4 request 1`] = `
                         >
                           <div
                             class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-account mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full mm-box--border-color-transparent box--border-style-solid box--border-width-1"
+                            role="img"
                           >
                             <div
                               class="mm-avatar-account__jazzicon"
@@ -1245,6 +1254,7 @@ exports[`TypedSignInfo should render message for typed sign v4 request 1`] = `
                         >
                           <div
                             class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-account mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full mm-box--border-color-transparent box--border-style-solid box--border-width-1"
+                            role="img"
                           >
                             <div
                               class="mm-avatar-account__jazzicon"
@@ -1391,6 +1401,7 @@ exports[`TypedSignInfo should render message for typed sign v4 request 1`] = `
                             >
                               <div
                                 class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-account mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full mm-box--border-color-transparent box--border-style-solid box--border-width-1"
+                                role="img"
                               >
                                 <div
                                   class="mm-avatar-account__jazzicon"
@@ -1462,6 +1473,7 @@ exports[`TypedSignInfo should render message for typed sign v4 request 1`] = `
                             >
                               <div
                                 class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-account mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full mm-box--border-color-transparent box--border-style-solid box--border-width-1"
+                                role="img"
                               >
                                 <div
                                   class="mm-avatar-account__jazzicon"
@@ -1533,6 +1545,7 @@ exports[`TypedSignInfo should render message for typed sign v4 request 1`] = `
                             >
                               <div
                                 class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-account mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full mm-box--border-color-transparent box--border-style-solid box--border-width-1"
+                                role="img"
                               >
                                 <div
                                   class="mm-avatar-account__jazzicon"

--- a/ui/pages/confirmations/components/confirm/row/__snapshots__/dataTree.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/row/__snapshots__/dataTree.test.tsx.snap
@@ -159,6 +159,7 @@ exports[`DataTree should match snapshot 1`] = `
                 >
                   <div
                     class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-account mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full mm-box--border-color-transparent box--border-style-solid box--border-width-1"
+                    role="img"
                   >
                     <div
                       class="mm-avatar-account__jazzicon"
@@ -230,6 +231,7 @@ exports[`DataTree should match snapshot 1`] = `
                 >
                   <div
                     class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-account mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full mm-box--border-color-transparent box--border-style-solid box--border-width-1"
+                    role="img"
                   >
                     <div
                       class="mm-avatar-account__jazzicon"
@@ -376,6 +378,7 @@ exports[`DataTree should match snapshot 1`] = `
                     >
                       <div
                         class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-account mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full mm-box--border-color-transparent box--border-style-solid box--border-width-1"
+                        role="img"
                       >
                         <div
                           class="mm-avatar-account__jazzicon"
@@ -447,6 +450,7 @@ exports[`DataTree should match snapshot 1`] = `
                     >
                       <div
                         class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-account mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full mm-box--border-color-transparent box--border-style-solid box--border-width-1"
+                        role="img"
                       >
                         <div
                           class="mm-avatar-account__jazzicon"
@@ -518,6 +522,7 @@ exports[`DataTree should match snapshot 1`] = `
                     >
                       <div
                         class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-account mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full mm-box--border-color-transparent box--border-style-solid box--border-width-1"
+                        role="img"
                       >
                         <div
                           class="mm-avatar-account__jazzicon"

--- a/ui/pages/confirmations/components/confirm/row/typed-sign-data/__snapshots__/typedSignData.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/row/typed-sign-data/__snapshots__/typedSignData.test.tsx.snap
@@ -134,6 +134,7 @@ exports[`ConfirmInfoRowTypedSignData should match snapshot 1`] = `
                     >
                       <div
                         class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-account mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full mm-box--border-color-transparent box--border-style-solid box--border-width-1"
+                        role="img"
                       >
                         <div
                           class="mm-avatar-account__jazzicon"
@@ -205,6 +206,7 @@ exports[`ConfirmInfoRowTypedSignData should match snapshot 1`] = `
                     >
                       <div
                         class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-account mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full mm-box--border-color-transparent box--border-style-solid box--border-width-1"
+                        role="img"
                       >
                         <div
                           class="mm-avatar-account__jazzicon"
@@ -276,6 +278,7 @@ exports[`ConfirmInfoRowTypedSignData should match snapshot 1`] = `
                     >
                       <div
                         class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-account mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full mm-box--border-color-transparent box--border-style-solid box--border-width-1"
+                        role="img"
                       >
                         <div
                           class="mm-avatar-account__jazzicon"
@@ -422,6 +425,7 @@ exports[`ConfirmInfoRowTypedSignData should match snapshot 1`] = `
                         >
                           <div
                             class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-account mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full mm-box--border-color-transparent box--border-style-solid box--border-width-1"
+                            role="img"
                           >
                             <div
                               class="mm-avatar-account__jazzicon"
@@ -493,6 +497,7 @@ exports[`ConfirmInfoRowTypedSignData should match snapshot 1`] = `
                         >
                           <div
                             class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-account mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full mm-box--border-color-transparent box--border-style-solid box--border-width-1"
+                            role="img"
                           >
                             <div
                               class="mm-avatar-account__jazzicon"
@@ -564,6 +569,7 @@ exports[`ConfirmInfoRowTypedSignData should match snapshot 1`] = `
                         >
                           <div
                             class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-account mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full mm-box--border-color-transparent box--border-style-solid box--border-width-1"
+                            role="img"
                           >
                             <div
                               class="mm-avatar-account__jazzicon"

--- a/ui/pages/confirmations/components/signature-request/__snapshots__/signature-request.test.js.snap
+++ b/ui/pages/confirmations/components/signature-request/__snapshots__/signature-request.test.js.snap
@@ -183,6 +183,7 @@ exports[`Signature Request Component render should match snapshot when we are us
         >
           <div
             class="mm-box mm-text mm-avatar-base mm-avatar-base--size-md mm-avatar-favicon mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full mm-box--border-color-transparent box--border-style-solid box--border-width-1"
+            role="img"
           >
             <span
               class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-icon-default"
@@ -954,6 +955,7 @@ exports[`Signature Request Component render should match snapshot when we want t
         >
           <div
             class="mm-box mm-text mm-avatar-base mm-avatar-base--size-md mm-avatar-favicon mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full mm-box--border-color-transparent box--border-style-solid box--border-width-1"
+            role="img"
           >
             <span
               class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-icon-default"

--- a/ui/pages/confirmations/confirm-send-ether/__snapshots__/confirm-send-ether.test.js.snap
+++ b/ui/pages/confirmations/confirm-send-ether/__snapshots__/confirm-send-ether.test.js.snap
@@ -297,6 +297,7 @@ exports[`ConfirmSendEther should render correct information for for confirm send
               >
                 <div
                   class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-network mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full mm-box--border-color-transparent box--border-style-solid box--border-width-1"
+                  role="img"
                 >
                   C
                 </div>

--- a/ui/pages/confirmations/confirm-signature-request/__snapshots__/index.test.js.snap
+++ b/ui/pages/confirmations/confirm-signature-request/__snapshots__/index.test.js.snap
@@ -182,6 +182,7 @@ exports[`Confirm Signature Request Component render should match snapshot 1`] = 
         >
           <div
             class="mm-box mm-text mm-avatar-base mm-avatar-base--size-md mm-avatar-favicon mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full mm-box--border-color-transparent box--border-style-solid box--border-width-1"
+            role="img"
           >
             <span
               class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-icon-default"

--- a/ui/pages/confirmations/confirm/__snapshots__/confirm.test.tsx.snap
+++ b/ui/pages/confirmations/confirm/__snapshots__/confirm.test.tsx.snap
@@ -63,6 +63,7 @@ exports[`Confirm matches snapshot for personal signature type 1`] = `
             </div>
             <div
               class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-network confirm_header__avatar-network mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full mm-box--border-color-transparent box--border-style-solid box--border-width-1"
+              role="img"
             >
               C
             </div>
@@ -295,6 +296,7 @@ exports[`Confirm should match snapshot for typed sign signature 1`] = `
             </div>
             <div
               class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-network confirm_header__avatar-network mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full mm-box--border-color-transparent box--border-style-solid box--border-width-1"
+              role="img"
             >
               C
             </div>
@@ -435,6 +437,7 @@ exports[`Confirm should match snapshot for typed sign signature 1`] = `
                 >
                   <div
                     class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-account mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full mm-box--border-color-transparent box--border-style-solid box--border-width-1"
+                    role="img"
                   >
                     <div
                       class="mm-avatar-account__jazzicon"
@@ -634,6 +637,7 @@ exports[`Confirm should match snapshot for typed sign signature 1`] = `
                                 >
                                   <div
                                     class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-account mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full mm-box--border-color-transparent box--border-style-solid box--border-width-1"
+                                    role="img"
                                   >
                                     <div
                                       class="mm-avatar-account__jazzicon"
@@ -705,6 +709,7 @@ exports[`Confirm should match snapshot for typed sign signature 1`] = `
                                 >
                                   <div
                                     class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-account mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full mm-box--border-color-transparent box--border-style-solid box--border-width-1"
+                                    role="img"
                                   >
                                     <div
                                       class="mm-avatar-account__jazzicon"
@@ -776,6 +781,7 @@ exports[`Confirm should match snapshot for typed sign signature 1`] = `
                                 >
                                   <div
                                     class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-account mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full mm-box--border-color-transparent box--border-style-solid box--border-width-1"
+                                    role="img"
                                   >
                                     <div
                                       class="mm-avatar-account__jazzicon"
@@ -922,6 +928,7 @@ exports[`Confirm should match snapshot for typed sign signature 1`] = `
                                     >
                                       <div
                                         class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-account mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full mm-box--border-color-transparent box--border-style-solid box--border-width-1"
+                                        role="img"
                                       >
                                         <div
                                           class="mm-avatar-account__jazzicon"
@@ -993,6 +1000,7 @@ exports[`Confirm should match snapshot for typed sign signature 1`] = `
                                     >
                                       <div
                                         class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-account mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full mm-box--border-color-transparent box--border-style-solid box--border-width-1"
+                                        role="img"
                                       >
                                         <div
                                           class="mm-avatar-account__jazzicon"
@@ -1064,6 +1072,7 @@ exports[`Confirm should match snapshot for typed sign signature 1`] = `
                                     >
                                       <div
                                         class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-account mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full mm-box--border-color-transparent box--border-style-solid box--border-width-1"
+                                        role="img"
                                       >
                                         <div
                                           class="mm-avatar-account__jazzicon"

--- a/ui/pages/confirmations/confirmation/templates/__snapshots__/create-snap-account.test.js.snap
+++ b/ui/pages/confirmations/confirmation/templates/__snapshots__/create-snap-account.test.js.snap
@@ -23,6 +23,7 @@ exports[`create-snap-account confirmation should match snapshot 1`] = `
             >
               <div
                 class="mm-box mm-text mm-avatar-base mm-avatar-base--size-lg mm-text--body-lg-medium mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-alternative mm-box--background-color-background-alternative mm-box--rounded-full"
+                role="img"
                 style="border-width: 0px;"
               >
                 m
@@ -32,6 +33,7 @@ exports[`create-snap-account confirmation should match snapshot 1`] = `
               >
                 <div
                   class="mm-box mm-text mm-avatar-base mm-avatar-base--size-sm mm-avatar-icon mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-primary-default mm-box--background-color-info-default mm-box--rounded-full mm-box--border-color-background-default mm-box--border-width-2 box--border-style-solid"
+                  role="img"
                 >
                   <span
                     class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-info-inverse"
@@ -61,6 +63,7 @@ exports[`create-snap-account confirmation should match snapshot 1`] = `
           >
             <div
               class="mm-box mm-text mm-avatar-base mm-avatar-base--size-md mm-avatar-icon snaps-authorship-header__button mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-muted mm-box--background-color-background-alternative mm-box--rounded-full mm-box--border-color-transparent box--border-style-solid box--border-width-1"
+              role="img"
             >
               <span
                 class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
@@ -81,6 +84,7 @@ exports[`create-snap-account confirmation should match snapshot 1`] = `
             >
               <div
                 class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xl mm-avatar-icon mm-text--body-lg-medium mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-primary-default mm-box--background-color-primary-muted mm-box--rounded-full mm-box--border-color-transparent box--border-style-solid box--border-width-1"
+                role="img"
               >
                 <span
                   class="mm-box mm-icon mm-icon--size-xl mm-box--display-inline-block mm-box--color-inherit"

--- a/ui/pages/confirmations/confirmation/templates/__snapshots__/error.test.js.snap
+++ b/ui/pages/confirmations/confirmation/templates/__snapshots__/error.test.js.snap
@@ -22,6 +22,7 @@ exports[`error template matches the snapshot 1`] = `
         >
           <div
             class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xl mm-avatar-icon mm-text--body-lg-medium mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-error-default mm-box--background-color-error-muted mm-box--rounded-full mm-box--border-color-transparent box--border-style-solid box--border-width-1"
+            role="img"
           >
             <span
               class="mm-box mm-icon mm-icon--size-xl mm-box--display-inline-block mm-box--color-inherit"

--- a/ui/pages/confirmations/confirmation/templates/__snapshots__/remove-snap-account.test.js.snap
+++ b/ui/pages/confirmations/confirmation/templates/__snapshots__/remove-snap-account.test.js.snap
@@ -23,6 +23,7 @@ exports[`remove-snap-account confirmation should match snapshot 1`] = `
             >
               <div
                 class="mm-box mm-text mm-avatar-base mm-avatar-base--size-lg mm-text--body-lg-medium mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-alternative mm-box--background-color-background-alternative mm-box--rounded-full"
+                role="img"
                 style="border-width: 0px;"
               >
                 m
@@ -32,6 +33,7 @@ exports[`remove-snap-account confirmation should match snapshot 1`] = `
               >
                 <div
                   class="mm-box mm-text mm-avatar-base mm-avatar-base--size-sm mm-avatar-icon mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-primary-default mm-box--background-color-info-default mm-box--rounded-full mm-box--border-color-background-default mm-box--border-width-2 box--border-style-solid"
+                  role="img"
                 >
                   <span
                     class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-info-inverse"
@@ -61,6 +63,7 @@ exports[`remove-snap-account confirmation should match snapshot 1`] = `
           >
             <div
               class="mm-box mm-text mm-avatar-base mm-avatar-base--size-md mm-avatar-icon snaps-authorship-header__button mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-muted mm-box--background-color-background-alternative mm-box--rounded-full mm-box--border-color-transparent box--border-style-solid box--border-width-1"
+              role="img"
             >
               <span
                 class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
@@ -84,6 +87,7 @@ exports[`remove-snap-account confirmation should match snapshot 1`] = `
               >
                 <div
                   class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xl mm-avatar-icon mm-text--body-lg-medium mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-error-default mm-box--background-color-error-muted mm-box--rounded-full mm-box--border-color-transparent box--border-style-solid box--border-width-1"
+                  role="img"
                 >
                   <span
                     class="mm-box mm-icon mm-icon--size-xl mm-box--display-inline-block mm-box--color-inherit"
@@ -108,6 +112,7 @@ exports[`remove-snap-account confirmation should match snapshot 1`] = `
                   />
                   <div
                     class="mm-box mm-text mm-avatar-base mm-avatar-base--size-md mm-avatar-account mm-text--body-sm mm-text--text-transform-uppercase mm-box--margin-inline-end-2 mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full mm-box--border-color-transparent box--border-style-solid box--border-width-1"
+                    role="img"
                   >
                     <div
                       class="mm-avatar-account__jazzicon"
@@ -203,6 +208,7 @@ exports[`remove-snap-account confirmation should match snapshot 1`] = `
                       >
                         <div
                           class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-token mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full mm-box--border-color-border-default box--border-style-solid box--border-width-1"
+                          role="img"
                         >
                           ?
                         </div>

--- a/ui/pages/confirmations/confirmation/templates/__snapshots__/snap-account-redirect.test.js.snap
+++ b/ui/pages/confirmations/confirmation/templates/__snapshots__/snap-account-redirect.test.js.snap
@@ -23,6 +23,7 @@ exports[`snap-account-redirect confirmation should match snapshot 1`] = `
             >
               <div
                 class="mm-box mm-text mm-avatar-base mm-avatar-base--size-lg mm-text--body-lg-medium mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-alternative mm-box--background-color-background-alternative mm-box--rounded-full"
+                role="img"
                 style="border-width: 0px;"
               >
                 ?
@@ -32,6 +33,7 @@ exports[`snap-account-redirect confirmation should match snapshot 1`] = `
               >
                 <div
                   class="mm-box mm-text mm-avatar-base mm-avatar-base--size-sm mm-avatar-icon mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-primary-default mm-box--background-color-info-default mm-box--rounded-full mm-box--border-color-background-default mm-box--border-width-2 box--border-style-solid"
+                  role="img"
                 >
                   <span
                     class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-info-inverse"
@@ -57,6 +59,7 @@ exports[`snap-account-redirect confirmation should match snapshot 1`] = `
           >
             <div
               class="mm-box mm-text mm-avatar-base mm-avatar-base--size-md mm-avatar-icon snaps-authorship-header__button mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-muted mm-box--background-color-background-alternative mm-box--rounded-full mm-box--border-color-transparent box--border-style-solid box--border-width-1"
+              role="img"
             >
               <span
                 class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
@@ -98,6 +101,7 @@ exports[`snap-account-redirect confirmation should match snapshot 1`] = `
                   >
                     <div
                       class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-icon snap-delineator__header__icon mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-primary-default mm-box--background-color-info-default mm-box--rounded-full mm-box--border-color-transparent box--border-style-solid box--border-width-1"
+                      role="img"
                     >
                       <span
                         class="mm-box mm-icon mm-icon--size-xs mm-box--display-inline-block mm-box--color-info-inverse"

--- a/ui/pages/confirmations/confirmation/templates/__snapshots__/success.test.js.snap
+++ b/ui/pages/confirmations/confirmation/templates/__snapshots__/success.test.js.snap
@@ -22,6 +22,7 @@ exports[`success template matches the snapshot 1`] = `
         >
           <div
             class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xl mm-avatar-icon mm-text--body-lg-medium mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-success-default mm-box--background-color-success-muted mm-box--rounded-full mm-box--border-color-transparent box--border-style-solid box--border-width-1"
+            role="img"
           >
             <span
               class="mm-box mm-icon mm-icon--size-xl mm-box--display-inline-block mm-box--color-inherit"

--- a/ui/pages/confirmations/confirmation/templates/__snapshots__/switch-ethereum-chain.test.js.snap
+++ b/ui/pages/confirmations/confirmation/templates/__snapshots__/switch-ethereum-chain.test.js.snap
@@ -55,6 +55,7 @@ exports[`switch-ethereum-chain confirmation should match snapshot 1`] = `
           >
             <div
               class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xl mm-avatar-network mm-text--body-lg-medium mm-text--text-transform-uppercase mm-box--margin-bottom-2 mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full mm-box--border-color-transparent box--border-style-solid box--border-width-1"
+              role="img"
             >
               T
             </div>
@@ -80,6 +81,7 @@ exports[`switch-ethereum-chain confirmation should match snapshot 1`] = `
           >
             <div
               class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xl mm-avatar-network mm-text--body-lg-medium mm-text--text-transform-uppercase mm-box--margin-bottom-2 mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full mm-box--border-color-transparent box--border-style-solid box--border-width-1"
+              role="img"
             >
               T
             </div>
@@ -174,6 +176,7 @@ exports[`switch-ethereum-chain confirmation should show alert if there are pendi
           >
             <div
               class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xl mm-avatar-network mm-text--body-lg-medium mm-text--text-transform-uppercase mm-box--margin-bottom-2 mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full mm-box--border-color-transparent box--border-style-solid box--border-width-1"
+              role="img"
             >
               T
             </div>
@@ -199,6 +202,7 @@ exports[`switch-ethereum-chain confirmation should show alert if there are pendi
           >
             <div
               class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xl mm-avatar-network mm-text--body-lg-medium mm-text--text-transform-uppercase mm-box--margin-bottom-2 mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full mm-box--border-color-transparent box--border-style-solid box--border-width-1"
+              role="img"
             >
               T
             </div>

--- a/ui/pages/settings/security-tab/__snapshots__/security-tab.test.js.snap
+++ b/ui/pages/settings/security-tab/__snapshots__/security-tab.test.js.snap
@@ -400,6 +400,7 @@ exports[`Security Tab should match snapshot 1`] = `
           >
             <div
               class="mm-box mm-text mm-avatar-base mm-avatar-base--size-sm mm-avatar-network mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full mm-box--border-color-transparent box--border-style-solid box--border-width-1"
+              role="img"
             >
               <img
                 alt="Custom Mainnet RPC logo"
@@ -487,6 +488,7 @@ exports[`Security Tab should match snapshot 1`] = `
           >
             <div
               class="mm-box mm-text mm-avatar-base mm-avatar-base--size-sm mm-avatar-network mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full mm-box--border-color-transparent box--border-style-solid box--border-width-1"
+              role="img"
             >
               <img
                 alt="Linea Mainnet logo"
@@ -574,6 +576,7 @@ exports[`Security Tab should match snapshot 1`] = `
           >
             <div
               class="mm-box mm-text mm-avatar-base mm-avatar-base--size-sm mm-avatar-network mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full mm-box--border-color-transparent box--border-style-solid box--border-width-1"
+              role="img"
             >
               C
             </div>
@@ -657,6 +660,7 @@ exports[`Security Tab should match snapshot 1`] = `
           >
             <div
               class="mm-box mm-text mm-avatar-base mm-avatar-base--size-sm mm-avatar-network mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full mm-box--border-color-transparent box--border-style-solid box--border-width-1"
+              role="img"
             >
               S
             </div>
@@ -740,6 +744,7 @@ exports[`Security Tab should match snapshot 1`] = `
           >
             <div
               class="mm-box mm-text mm-avatar-base mm-avatar-base--size-sm mm-avatar-network mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full mm-box--border-color-transparent box--border-style-solid box--border-width-1"
+              role="img"
             >
               <img
                 alt="Linea Goerli logo"
@@ -827,6 +832,7 @@ exports[`Security Tab should match snapshot 1`] = `
           >
             <div
               class="mm-box mm-text mm-avatar-base mm-avatar-base--size-sm mm-avatar-network mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full mm-box--border-color-transparent box--border-style-solid box--border-width-1"
+              role="img"
             >
               <img
                 alt="Linea Sepolia logo"

--- a/ui/pages/snap-account-redirect/__snapshots__/create-snap-redirect.test.tsx.snap
+++ b/ui/pages/snap-account-redirect/__snapshots__/create-snap-redirect.test.tsx.snap
@@ -17,6 +17,7 @@ exports[`<SnapAccountRedirect /> renders the url and message when provided and i
         >
           <div
             class="mm-box mm-text mm-avatar-base mm-avatar-base--size-lg mm-text--body-lg-medium mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-alternative mm-box--background-color-background-alternative mm-box--rounded-full"
+            role="img"
             style="border-width: 0px;"
           >
             m
@@ -26,6 +27,7 @@ exports[`<SnapAccountRedirect /> renders the url and message when provided and i
           >
             <div
               class="mm-box mm-text mm-avatar-base mm-avatar-base--size-sm mm-avatar-icon mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-primary-default mm-box--background-color-info-default mm-box--rounded-full mm-box--border-color-background-default mm-box--border-width-2 box--border-style-solid"
+              role="img"
             >
               <span
                 class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-info-inverse"
@@ -55,6 +57,7 @@ exports[`<SnapAccountRedirect /> renders the url and message when provided and i
       >
         <div
           class="mm-box mm-text mm-avatar-base mm-avatar-base--size-md mm-avatar-icon snaps-authorship-header__button mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-muted mm-box--background-color-background-alternative mm-box--rounded-full mm-box--border-color-transparent box--border-style-solid box--border-width-1"
+          role="img"
         >
           <span
             class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
@@ -96,6 +99,7 @@ exports[`<SnapAccountRedirect /> renders the url and message when provided and i
               >
                 <div
                   class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-icon snap-delineator__header__icon mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-primary-default mm-box--background-color-info-default mm-box--rounded-full mm-box--border-color-transparent box--border-style-solid box--border-width-1"
+                  role="img"
                 >
                   <span
                     class="mm-box mm-icon mm-icon--size-xs mm-box--display-inline-block mm-box--color-info-inverse"


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

To improve the accessibility of our Avatar components, especially when a screen reader is used, we propose adding the role="img" attribute to these components. This enhancement aims to prevent screen readers from reading out the fallback letter, providing a more meaningful and contextually appropriate description. For instance, when tabbing through networks in the extension, the screen reader should announce "S, Sepolia" instead of just "S". This change will ensure our UI is more accessible and user-friendly for individuals relying on screen readers.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/23832?quickstart=1)

## **Related issues**

Fixes: #23251 

## **Manual testing steps**

1. Turn on your computers screen reader (mac: CMD + F5)
2. Run local build of extension 
3. Tab to a component that uses an avatar component (e.g. see screenshot for example component) 

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

https://github.com/MetaMask/metamask-extension/assets/8112138/ec6ab28f-8fbf-4cd2-b0ea-787f82d7bcae

<!-- [screenshots/recordings] -->

### **After**

https://github.com/MetaMask/metamask-extension/assets/26469696/18b6d1b8-7268-49f3-92b4-4ec10ef382bc


<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
