### PR TITLE
fix(snaps): Use MarkDown styling in links

### DIFF
--- a/ui/components/app/snaps/snap-ui-markdown/index.scss
+++ b/ui/components/app/snaps/snap-ui-markdown/index.scss
@@ -4,15 +4,4 @@
       font-style: revert;
     }
   }
-
-  &__link {
-    & > span:last-child {
-      margin-inline-start: 2px;
-    }
-
-    & .mm-icon--size-inherit {
-      // Fixes the icon misalignment in ButtonLink when using ButtonLinkSize.Inherit
-      top: 0.1em;
-    }
-  }
 }

--- a/ui/components/app/snaps/snap-ui-markdown/snap-ui-markdown.js
+++ b/ui/components/app/snaps/snap-ui-markdown/snap-ui-markdown.js
@@ -5,11 +5,14 @@ import {
   TextVariant,
   OverflowWrap,
   TextColor,
+  Display,
 } from '../../../../helpers/constants/design-system';
 import {
   ButtonLink,
   ButtonLinkSize,
+  Icon,
   IconName,
+  IconSize,
   Text,
 } from '../../../component-library';
 import SnapLinkWarning from '../snap-link-warning';
@@ -27,13 +30,15 @@ const Paragraph = (props) => (
 const Link = ({ onClick, children, ...rest }) => (
   <ButtonLink
     {...rest}
+    as="a"
     onClick={onClick}
     externalLink
     size={ButtonLinkSize.Inherit}
-    endIconName={IconName.Export}
+    display={Display.Inline}
     className="snap-ui-markdown__link"
   >
     {children}
+    <Icon name={IconName.Export} size={IconSize.Inherit} marginLeft={1} />
   </ButtonLink>
 );
 


### PR DESCRIPTION
## **Description**

This fixes the snaps custom UI links that would not use the MarkDown styling.

It also allow links to break word and not go to next line if it overflows.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/23840?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Create a link inside a bold/italic block of MarkDown text in a snap_dialog.
2. Look if the link has styling.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

![image](https://github.com/MetaMask/metamask-extension/assets/13910212/cc20f2e6-182d-4a6e-9455-6030f59a8017)

### **After**

<img width="472" alt="Screenshot 2024-04-03 at 15 12 41" src="https://github.com/MetaMask/metamask-extension/assets/13910212/301ce162-638f-416d-83e2-3d1425ed82eb">


## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
