### PR TITLE
fix: Fixed flaky test for user operations

### DIFF
--- a/test/e2e/flask/user-operations.spec.ts
+++ b/test/e2e/flask/user-operations.spec.ts
@@ -111,7 +111,7 @@ async function createSwap(driver: Driver) {
 
 async function confirmTransaction(driver: Driver) {
   await switchToNotificationWindow(driver);
-  await driver.clickElement({ text: 'Confirm' });
+  await driver.clickElement({ text: 'Confirm', css: '[data-testid="page-container-footer-next" ]' });
 }
 
 async function openConfirmedTransaction(driver: Driver) {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR fixes the flaky test for user operations scenario. 
The web element may not have been recognized by the text name; therefore, I included the attribute with value data-testid="page-container-footer-next" for better identification of the element.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/23852?quickstart=1)

## **Related issues**

Fixes: #23851 

## **Manual testing steps**

Run the test in codespace or locally --> Checkout to the branch
yarn install
yarn start:flask
yarn test:e2e:single test/e2e/flask/user-operations.spec.ts  --debug --leave-running


## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
