### PR TITLE
fix: update nft ownership

### DIFF
--- a/ui/components/app/nfts-tab/nfts-tab.js
+++ b/ui/components/app/nfts-tab/nfts-tab.js
@@ -82,6 +82,12 @@ export default function NftsTab() {
     });
   }, [showNftBanner, trackEvent, currentNetwork, currentLocale]);
 
+  useEffect(() => {
+    if (hasAnyNfts) {
+      checkAndUpdateAllNftsOwnershipStatus();
+    }
+  }, [hasAnyNfts]);
+
   if (nftsLoading) {
     return <div className="nfts-tab__loading">{t('loadingNFTs')}</div>;
   }

--- a/ui/components/app/nfts-tab/nfts-tab.test.js
+++ b/ui/components/app/nfts-tab/nfts-tab.test.js
@@ -258,6 +258,24 @@ describe('NFT Items', () => {
     });
   });
 
+  describe('Update ownership status', () => {
+    it('should update ownership status when it has NFTS', () => {
+      render({
+        selectedAddress: ACCOUNT_1,
+        nfts: NFTS,
+      });
+      expect(checkAndUpdateAllNftsOwnershipStatusStub).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not update ownership status when it does not have NFTS', () => {
+      render({
+        selectedAddress: ACCOUNT_1,
+        nfts: [],
+      });
+      expect(checkAndUpdateAllNftsOwnershipStatusStub).toHaveBeenCalledTimes(0);
+    });
+  });
+
   describe('Collections', () => {
     it('should render the name of the collections and number of NFTs in each collection if current account/chainId combination has NFTs', () => {
       render({


### PR DESCRIPTION
## **Description**

This PR triggers making a call to refresh NFT ownership status once the user clicks on nfts tab.
Some users might still see NFTs on the NFT tab as if the NFT is still owned, when in reality it should appear as "previously owned". This instance can happen when a user does not manually transfer the NFT but sells it on a marketplace.


## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
