### PR TITLE
cherry-pick: display native ticker and logo for current chain and render near-zero amounts in simulations (#23711)

### DIFF
--- a/shared/modules/Numeric.test.ts
+++ b/shared/modules/Numeric.test.ts
@@ -373,6 +373,24 @@ describe('Numeric', () => {
       });
     });
 
+    describe('isZero', () => {
+      it('should return true for positive zero', () => {
+        expect(new Numeric(0, 10).isZero()).toStrictEqual(true);
+      });
+
+      it('should return true for negative 0', () => {
+        expect(new Numeric(-0, 10).isZero()).toStrictEqual(true);
+      });
+
+      it('should return false for positive non-zero', () => {
+        expect(new Numeric(10, 10).isZero()).toStrictEqual(false);
+      });
+
+      it('should return false for negative non-zero', () => {
+        expect(new Numeric(-10, 10).isZero()).toStrictEqual(false);
+      });
+    });
+
     describe('applyConversionRate', () => {
       it('should multiply the value by the conversionRate supplied', () => {
         expect(

--- a/shared/modules/Numeric.ts
+++ b/shared/modules/Numeric.ts
@@ -540,6 +540,13 @@ export class Numeric {
     return new Numeric(this.value.abs(), this.base, this.denomination);
   }
 
+  /**
+   * Checks if the Numeric value is zero.
+   */
+  isZero() {
+    return this.value.isZero();
+  }
+
   greaterThan(
     comparator: Numeric | NumericValue,
     base?: NumericBase,

--- a/test/e2e/tests/simulation-details/simulation-details.spec.ts
+++ b/test/e2e/tests/simulation-details/simulation-details.spec.ts
@@ -91,7 +91,7 @@ export async function mockRequest(
   }
 
 
-describe.skip('Simulation Details', () => {
+describe('Simulation Details', () => {
   it('renders send eth transaction', async function (this: Mocha.Context) {
     const mockRequests = async (mockServer: MockttpServer) => {
       await mockRequest(mockServer, SEND_ETH_REQUEST_MOCK);

--- a/ui/hooks/useCurrencyDisplay.js
+++ b/ui/hooks/useCurrencyDisplay.js
@@ -12,6 +12,10 @@ import { TEST_NETWORK_TICKER_MAP } from '../../shared/constants/network';
 import { Numeric } from '../../shared/modules/Numeric';
 import { EtherDenomination } from '../../shared/constants/common';
 
+export const MIN_DISPLAY_AMOUNT = '<0.000001';
+
+export const DEFAULT_PRECISION_DECIMALS = 6;
+
 /**
  * Defines the shape of the options parameter for useCurrencyDisplay
  *
@@ -53,7 +57,6 @@ export function useCurrencyDisplay(
   const isUserPreferredCurrency = currency === currentCurrency;
 
   const value = useMemo(() => {
-    let ethDisplayValue;
     if (displayValue) {
       return displayValue;
     }
@@ -61,17 +64,15 @@ export function useCurrencyDisplay(
       currency === nativeCurrency ||
       (!isUserPreferredCurrency && !nativeCurrency)
     ) {
-      ethDisplayValue = new Numeric(inputValue, 16, EtherDenomination.WEI)
+      const ethDisplayValue = new Numeric(inputValue, 16, EtherDenomination.WEI)
         .toDenomination(denomination || EtherDenomination.ETH)
-        .round(numberOfDecimals || 6)
+        .round(numberOfDecimals || DEFAULT_PRECISION_DECIMALS)
         .toBase(10)
         .toString();
 
-      if (ethDisplayValue === '0' && inputValue && Number(inputValue) !== 0) {
-        ethDisplayValue = '<0.000001';
-      }
-
-      return ethDisplayValue;
+      return ethDisplayValue === '0' && inputValue && Number(inputValue) !== 0
+        ? MIN_DISPLAY_AMOUNT
+        : ethDisplayValue;
     } else if (isUserPreferredCurrency && conversionRate) {
       return formatCurrency(
         getValueFromWeiHex({

--- a/ui/pages/confirmations/components/simulation-details/amount-pill.tsx
+++ b/ui/pages/confirmations/components/simulation-details/amount-pill.tsx
@@ -11,7 +11,20 @@ import {
 } from '../../../../helpers/constants/design-system';
 import { hexToDecimal } from '../../../../../shared/modules/conversion.utils';
 import { TokenStandard } from '../../../../../shared/constants/transaction';
+import {
+  DEFAULT_PRECISION_DECIMALS,
+  MIN_DISPLAY_AMOUNT,
+} from '../../../../hooks/useCurrencyDisplay';
 import { Amount, AssetIdentifier } from './types';
+
+// Format an amount for display.
+const formatAmount = (amount: Amount): string => {
+  const displayAmount = amount.numeric.abs().round(DEFAULT_PRECISION_DECIMALS);
+
+  return displayAmount.isZero() && !amount.numeric.isZero()
+    ? MIN_DISPLAY_AMOUNT
+    : displayAmount.toString();
+};
 
 /**
  * Displays a pill with an amount and a background color indicating whether the amount
@@ -35,13 +48,15 @@ export const AmountPill: React.FC<{
 
   const amountParts: string[] = [amount.isNegative ? '-' : '+'];
 
-  const hideAmount = asset.standard === TokenStandard.ERC721;
-  if (!hideAmount) {
-    amountParts.push(amount.numeric.abs().round(6).toString());
+  if (asset.standard !== TokenStandard.ERC721) {
+    // ERC721 amounts are always 1 and don't need to be displayed.
+    amountParts.push(formatAmount(amount));
   }
+
   if (asset.tokenId) {
     amountParts.push(`#${hexToDecimal(asset.tokenId)}`);
   }
+
   return (
     <Text
       display={Display.Flex}

--- a/ui/pages/confirmations/components/simulation-details/asset-pill.test.tsx
+++ b/ui/pages/confirmations/components/simulation-details/asset-pill.test.tsx
@@ -3,8 +3,17 @@ import { render, screen } from '@testing-library/react';
 import { NameType } from '@metamask/name-controller';
 import { TokenStandard } from '../../../../../shared/constants/transaction';
 import Name from '../../../../components/app/name';
+import { renderWithProvider } from '../../../../../test/lib/render-helpers';
+import configureStore from '../../../../store/store';
+import { CHAIN_IDS } from '../../../../../shared/constants/network';
+import { AvatarNetwork } from '../../../../components/component-library/avatar-network';
 import { AssetPill } from './asset-pill';
-import { NativeAssetIdentifier, TokenAssetIdentifier } from './types';
+import { NATIVE_ASSET_IDENTIFIER, TokenAssetIdentifier } from './types';
+
+jest.mock('../../../../components/component-library/avatar-network', () => ({
+  AvatarNetworkSize: { Sm: 'Sm' },
+  AvatarNetwork: jest.fn(() => null),
+}));
 
 jest.mock('../../../../components/app/name', () => ({
   __esModule: true,
@@ -16,12 +25,41 @@ describe('AssetPill', () => {
     jest.clearAllMocks();
   });
 
-  it('renders EthAssetPill when asset native', () => {
-    const asset: NativeAssetIdentifier = { standard: TokenStandard.none };
+  describe('Native Asset', () => {
+    const cases = [
+      {
+        chainId: CHAIN_IDS.MAINNET,
+        expected: {
+          ticker: 'ETH',
+          imgSrc: './images/eth_logo.svg',
+        },
+      },
+      {
+        chainId: CHAIN_IDS.POLYGON,
+        expected: {
+          ticker: 'MATIC',
+          imgSrc: './images/matic-token.svg',
+        },
+      },
+    ];
 
-    render(<AssetPill asset={asset} />);
+    it.each(cases)('renders chain $chainId', ({ chainId, expected }) => {
+      const store = configureStore({
+        metamask: { providerConfig: { chainId, ticker: expected.ticker } },
+      });
 
-    expect(screen.getByText('ETH')).toBeInTheDocument();
+      renderWithProvider(<AssetPill asset={NATIVE_ASSET_IDENTIFIER} />, store);
+
+      expect(screen.getByText(expected.ticker)).toBeInTheDocument();
+
+      expect(AvatarNetwork).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: expected.ticker,
+          src: expected.imgSrc,
+        }),
+        {},
+      );
+    });
   });
 
   it('renders Name component with correct props when asset standard is not none', () => {

--- a/ui/pages/confirmations/components/simulation-details/asset-pill.tsx
+++ b/ui/pages/confirmations/components/simulation-details/asset-pill.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import { NameType } from '@metamask/name-controller';
+import { useSelector } from 'react-redux';
 import {
-  AvatarToken,
-  AvatarTokenSize,
+  AvatarNetwork,
+  AvatarNetworkSize,
   Box,
   Text,
 } from '../../../../components/component-library';
@@ -16,31 +17,31 @@ import {
 } from '../../../../helpers/constants/design-system';
 import Name from '../../../../components/app/name';
 import { TokenStandard } from '../../../../../shared/constants/transaction';
-import { ETH_TOKEN_IMAGE_URL } from '../../../../../shared/constants/network';
+import { getNativeCurrencyImage } from '../../../../selectors';
+import { getNativeCurrency } from '../../../../ducks/metamask/metamask';
 import { AssetIdentifier } from './types';
 
-const ETH_TICKER = 'ETH';
+const NativeAssetPill: React.FC = () => {
+  const ticker = useSelector(getNativeCurrency);
+  const imgSrc = useSelector(getNativeCurrencyImage);
 
-const EthAssetPill: React.FC = () => (
-  <Box
-    display={Display.Flex}
-    flexDirection={FlexDirection.Row}
-    borderRadius={BorderRadius.pill}
-    alignItems={AlignItems.center}
-    backgroundColor={BackgroundColor.backgroundAlternative}
-    gap={1}
-    style={{
-      padding: '2px 8px 2px 4px',
-    }}
-  >
-    <AvatarToken
-      name="eth"
-      size={AvatarTokenSize.Sm}
-      src={ETH_TOKEN_IMAGE_URL}
-    />
-    <Text variant={TextVariant.bodyMd}>{ETH_TICKER}</Text>
-  </Box>
-);
+  return (
+    <Box
+      display={Display.Flex}
+      flexDirection={FlexDirection.Row}
+      borderRadius={BorderRadius.pill}
+      alignItems={AlignItems.center}
+      backgroundColor={BackgroundColor.backgroundAlternative}
+      gap={1}
+      style={{
+        padding: '2px 8px 2px 4px',
+      }}
+    >
+      <AvatarNetwork name={ticker} size={AvatarNetworkSize.Sm} src={imgSrc} />
+      <Text variant={TextVariant.bodyMd}>{ticker}</Text>
+    </Box>
+  );
+};
 
 /**
  * Displays a pill with an asset's icon and name.
@@ -50,7 +51,7 @@ const EthAssetPill: React.FC = () => (
  */
 export const AssetPill: React.FC<{ asset: AssetIdentifier }> = ({ asset }) => {
   if (asset.standard === TokenStandard.none) {
-    return <EthAssetPill />;
+    return <NativeAssetPill />;
   }
   return (
     <Name

--- a/ui/pages/confirmations/components/simulation-details/simulation-details.stories.tsx
+++ b/ui/pages/confirmations/components/simulation-details/simulation-details.stories.tsx
@@ -7,6 +7,7 @@ import mockState from '../../../../../test/data/mock-state.json';
 import { Hex } from '@metamask/utils';
 import { SimulationTokenStandard } from '@metamask/transaction-controller';
 import { NameType } from '@metamask/name-controller';
+import { CHAIN_IDS } from '../../../../../shared/constants/network';
 
 const DUMMY_BALANCE_CHANGE = {
   previousBalance: '0xIGNORED' as Hex,
@@ -73,6 +74,17 @@ const storeMock = configureStore({
   },
 });
 
+const storeMockPolygon = configureStore({
+  metamask: {
+    ...mockState.metamask,
+    providerConfig: {
+      ...mockState.metamask.providerConfig,
+      chainId: CHAIN_IDS.POLYGON,
+      ticker: 'MATIC',
+    },
+  },
+});
+
 const meta: Meta<typeof SimulationDetails> = {
   title: 'Components/App/SimulationDetails',
   component: SimulationDetails,
@@ -119,6 +131,33 @@ export const MultipleTokens: Story = {
       }],
     },
   },
+};
+
+export const SendSmallAmount: Story = {
+  args: {
+    simulationData: {
+      nativeBalanceChange: {
+        ...DUMMY_BALANCE_CHANGE,
+        difference: '0x123',
+        isDecrease: true,
+      },
+      tokenBalanceChanges: [],
+    },
+  },
+};
+
+export const MaticNativeAsset: Story = {
+  args: {
+    simulationData: {
+      nativeBalanceChange: {
+        ...DUMMY_BALANCE_CHANGE,
+        difference: '0x123456',
+        isDecrease: true,
+      },
+      tokenBalanceChanges: [],
+    },
+  },
+  decorators: [(story) => <Provider store={storeMockPolygon}>{story()}</Provider>],
 };
 
 

--- a/ui/pages/confirmations/components/simulation-details/types.ts
+++ b/ui/pages/confirmations/components/simulation-details/types.ts
@@ -2,6 +2,10 @@ import { Hex } from '@metamask/utils';
 import { TokenStandard } from '../../../../../shared/constants/transaction';
 import { Numeric } from '../../../../../shared/modules/Numeric';
 
+export const NATIVE_ASSET_IDENTIFIER: NativeAssetIdentifier = {
+  standard: TokenStandard.none,
+};
+
 /**
  * Describes an amount of fiat.
  */

--- a/ui/pages/confirmations/components/simulation-details/useBalanceChanges.ts
+++ b/ui/pages/confirmations/components/simulation-details/useBalanceChanges.ts
@@ -20,11 +20,10 @@ import {
   Amount,
   BalanceChange,
   FIAT_UNAVAILABLE,
-  NativeAssetIdentifier,
+  NATIVE_ASSET_IDENTIFIER,
   TokenAssetIdentifier,
 } from './types';
 
-const NATIVE_ASSET: NativeAssetIdentifier = { standard: TokenStandard.none };
 const NATIVE_DECIMALS = 18;
 const ERC20_DEFAULT_DECIMALS = 18;
 const EMPTY_TOKEN_BALANCE_CHANGES: SimulationTokenBalanceChange[] = [];
@@ -83,7 +82,7 @@ function getNativeBalanceChange(
   if (!nativeBalanceChange) {
     return undefined;
   }
-  const asset = NATIVE_ASSET;
+  const asset = NATIVE_ASSET_IDENTIFIER;
   const amount = getAssetAmount(nativeBalanceChange, NATIVE_DECIMALS);
   const fiatAmount = amount.numeric
     .applyConversionRate(nativeFiatRate)


### PR DESCRIPTION
Cherry-pick of PR #23711 for issues [#2295](https://github.com/MetaMask/MetaMask-planning/issues/2295) and [#2296](https://github.com/MetaMask/MetaMask-planning/issues/2296).

No conflicts.