### PR TITLE
feat(23015): convert level 5 files for metamask-controller to ts

### DIFF
--- a/app/scripts/controllers/permissions/enums.js
+++ b/app/scripts/controllers/permissions/enums.js
@@ -1,5 +1,0 @@
-export const NOTIFICATION_NAMES = {
-  accountsChanged: 'metamask_accountsChanged',
-  unlockStateChanged: 'metamask_unlockStateChanged',
-  chainChanged: 'metamask_chainChanged',
-};

--- a/app/scripts/controllers/permissions/enums.ts
+++ b/app/scripts/controllers/permissions/enums.ts
@@ -1,0 +1,5 @@
+export enum NOTIFICATION_NAMES {
+  accountsChanged = 'metamask_accountsChanged',
+  unlockStateChanged = 'metamask_unlockStateChanged',
+  chainChanged = 'metamask_chainChanged',
+}

--- a/app/scripts/lib/rpc-method-middleware/handlers/index.ts
+++ b/app/scripts/lib/rpc-method-middleware/handlers/index.ts
@@ -1,3 +1,4 @@
+import { MESSAGE_TYPE } from '../../../../../shared/constants/app';
 import addEthereumChain from './add-ethereum-chain';
 import ethAccounts from './eth-accounts';
 import getProviderState from './get-provider-state';
@@ -16,7 +17,15 @@ import mmiSetAccountAndNetwork from './institutional/mmi-set-account-and-network
 import mmiOpenAddHardwareWallet from './institutional/mmi-open-add-hardware-wallet';
 ///: END:ONLY_INCLUDE_IF
 
-const handlers = [
+type MessageType = (typeof MESSAGE_TYPE)[keyof typeof MESSAGE_TYPE];
+
+type HandlerInterface = {
+  methodNames: MessageType[];
+  implementation: unknown;
+  hookNames?: { [key: string]: boolean };
+};
+
+const handlers: HandlerInterface[] = [
   addEthereumChain,
   ethAccounts,
   getProviderState,
@@ -34,4 +43,5 @@ const handlers = [
   mmiOpenAddHardwareWallet,
   ///: END:ONLY_INCLUDE_IF
 ];
+
 export default handlers;


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Fixes https://github.com/MetaMask/metamask-extension/issues/23015

Converting the level 5 dependency files to typescript for contributing to metamask-controller.js.
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/23888?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
