### PR TITLE
fix: Fix low performance issue of AccountList

### DIFF
--- a/ui/components/multichain/account-list-item/account-list-item.js
+++ b/ui/components/multichain/account-list-item/account-list-item.js
@@ -48,7 +48,6 @@ import {
 } from '../../../../shared/constants/metametrics';
 import { MetaMetricsContext } from '../../../contexts/metametrics';
 import {
-  getAddressConnectedSubjectMap,
   getCurrentNetwork,
   getNativeCurrencyImage,
   getShowFiatInTestnets,
@@ -115,14 +114,7 @@ export const AccountListItem = ({
   const trackEvent = useContext(MetaMetricsContext);
   const primaryTokenImage = useSelector(getNativeCurrencyImage);
   const nativeCurrency = useSelector(getNativeCurrency);
-  const addressConnectedSubjectMap = useSelector(getAddressConnectedSubjectMap);
-  const selectedAddressSubjectMap =
-    addressConnectedSubjectMap[identity.address];
-  const currentTabIsConnectedToSelectedAddress = Boolean(
-    selectedAddressSubjectMap && selectedAddressSubjectMap[currentTabOrigin],
-  );
-  const isConnected =
-    currentTabOrigin && currentTabIsConnectedToSelectedAddress;
+  const isConnected = !!connectedAvatar;
   const isSingleAccount = accountsCount === 1;
 
   return (


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

### 1. What is the reason for the change?

https://github.com/MetaMask/metamask-extension/issues/23913

This bug has caused widespread user lag, especially as more and more sites are connected. 
The reason is that when each account list item is loaded, it re-traverses **all subjects map** !
  
Assuming that the user has M connected sites and N accounts, the time complexity of `getAddressConnectedSubjectMap` is: `M * N`, and the time complexity of loading `AccountList` is: `M * N * N.`
I have hundreds of connected sites and 30 accounts. When I open the AccountList, it freezes for 3 seconds!

### 2. What is the improvement/solution?

However, `getAddressConnectedSubjectMap` is completely unnecessary because `connectedAvatar` already indicates whether this item is connected.
So, `isConnected = !!connectedAvatar` is perfect.

## **Related issues**

Fixes:https://github.com/MetaMask/metamask-extension/issues/23913

## **Manual testing steps**

0. Have hundreds of connected nodes and at least 30 accounts.
1. Compile and package with MULTICHAIN ​​= 1
2. Click to switch the account drop-down list on the home page
3. The accounts list pops up very quickly, and does not affect the display logic of `shouldRenderConnectAccount`

(`isConnected` will only affect the logic of `shouldRenderConnectAccount` )

## **Screenshots/Recordings**
unnecessary

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

I have read the CLA Document and I hereby sign the CLA
