### PR TITLE
fix: Fix a crash in the connected accounts modal

### DIFF
--- a/ui/components/app/connected-accounts-permissions/connected-accounts-permissions.js
+++ b/ui/components/app/connected-accounts-permissions/connected-accounts-permissions.js
@@ -2,6 +2,7 @@ import classnames from 'classnames';
 import PropTypes from 'prop-types';
 import React, { useState } from 'react';
 import { flatten } from 'lodash';
+import { useSelector } from 'react-redux';
 import {
   Box,
   ButtonIcon,
@@ -20,10 +21,13 @@ import {
   JustifyContent,
   TextVariant,
 } from '../../../helpers/constants/design-system';
+import { getSnapName } from '../../../helpers/utils/util';
+import { getSnapsMetadata } from '../../../selectors';
 
 const ConnectedAccountsPermissions = ({ permissions }) => {
   const t = useI18nContext();
   const [expanded, setExpanded] = useState(false);
+  const snapsMetadata = useSelector(getSnapsMetadata);
 
   const toggleExpanded = () => {
     setExpanded((_expanded) => !_expanded);
@@ -39,6 +43,7 @@ const ConnectedAccountsPermissions = ({ permissions }) => {
         t,
         permissionName: key,
         permissionValue: value,
+        getSubjectName: getSnapName(snapsMetadata),
       }),
     ),
   );


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Fixes a crash in the connected accounts modal that would only happen if the connected dapp had a connected Snap. The `getSubjectName` function was not provided and thus would fail when trying to resolve the Snap name. 

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/23928?quickstart=1)

## **Manual testing steps**

1. Go to https://snaps.metamask.io/
2. Install at least one snap
3. Click the "connected accounts" icon in the top right
