### PR TITLE
fix: Updated avatar favicon props for single account disconnect toast

### DIFF
--- a/ui/components/multichain/pages/connections/connections.tsx
+++ b/ui/components/multichain/pages/connections/connections.tsx
@@ -334,9 +334,9 @@ export const Connections = () => {
                 onClose={() => setShowAccountDisconnectedToast('')}
                 startAdornment={
                   <AvatarFavicon
-                    name={connectedSubjectsMetadata.name}
+                    name={connectedSiteMetadata.name}
                     size={AvatarFaviconSize.Sm}
-                    src={connectedSubjectsMetadata.iconUrl}
+                    src={connectedSiteMetadata.iconUrl}
                   />
                 }
               />


### PR DESCRIPTION
This PR ensures that when a single account is disconnected from the Dapp via connections. It shouldn't break the page and disconnects smoothle


## **Related issues**

Fixes: #23790

## **Manual testing steps**

1. Run extension with Multichain flag
2. Connect a single account to uniswap
3. Go to connections page, click on disconnect account.
4. It should disconnect the account

## **Screenshots/Recordings**


### **Before**




https://github.com/MetaMask/metamask-extension/assets/39872794/f4356be1-e6b8-4319-b2a0-be5439173fbe


### **After**
https://github.com/MetaMask/metamask-extension/assets/39872794/779ababe-d6a2-4f9a-aca8-d09284dd4aee



## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
