### PR TITLE
fix: host permissions for cx.metamask.io

### DIFF
--- a/app/manifest/v2/_base.json
+++ b/app/manifest/v2/_base.json
@@ -67,6 +67,7 @@
     "http://localhost:8545/",
     "https://*.infura.io/",
     "https://*.codefi.network/",
+    "https://*.cx.metamask.io/",
     "https://chainid.network/chains.json",
     "https://lattice.gridplus.io/*",
     "activeTab",


### PR DESCRIPTION
## **Description**

When host permissions do not exist for a given domain, firefox sets cors policy to cross-origin.
This was preventing getting the blockaid files from our cdn and thus making the feature unusable in firefox.

This is fixed by adding `"https://*.cx.metamask.io/"` to the manifest file permissions.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/23958?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Install the extension in Firefox
2. Make sure that you have security alerts enabled.
3. Go to the test-dapp
4. Try a malicous transaction
5. You should see the `This is a deceptive request`.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="1187" alt="Screenshot 2024-04-11 at 10 25 37" src="https://github.com/MetaMask/metamask-extension/assets/15957235/1d9dd06b-33d7-408b-846e-08162f0c9a27">

### **After**

<img width="1310" alt="Screenshot 2024-04-11 at 09 48 46" src="https://github.com/MetaMask/metamask-extension/assets/15957235/365d4226-ff2b-44f4-82fc-a35f6c00e01d">

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
