### PR TITLE
fix: Updated selector for the test networks

### DIFF
--- a/ui/components/multichain/pages/permissions-page/connection-list-item.js
+++ b/ui/components/multichain/pages/permissions-page/connection-list-item.js
@@ -28,6 +28,7 @@ import {
 import { getURLHost } from '../../../../helpers/utils/util';
 import SnapAvatar from '../../../app/snaps/snap-avatar/snap-avatar';
 import { ConnectionListTooltip } from './connection-list-tooltip/connection-list-tooltip';
+import { getAvatarNetworkColor } from '../../../../helpers/utils/accounts';
 
 export const ConnectionListItem = ({ connection, onClick }) => {
   const t = useI18nContext();
@@ -69,6 +70,7 @@ export const ConnectionListItem = ({ connection, onClick }) => {
                 src={connection.networkIconUrl}
                 borderWidth={1}
                 borderColor={BackgroundColor.backgroundDefault}
+                backgroundColor={getAvatarNetworkColor(connection.networkName)}
               />
             }
           >

--- a/ui/components/multichain/pages/permissions-page/connection-list-item.js
+++ b/ui/components/multichain/pages/permissions-page/connection-list-item.js
@@ -27,8 +27,8 @@ import {
 } from '../../../component-library';
 import { getURLHost } from '../../../../helpers/utils/util';
 import SnapAvatar from '../../../app/snaps/snap-avatar/snap-avatar';
-import { ConnectionListTooltip } from './connection-list-tooltip/connection-list-tooltip';
 import { getAvatarNetworkColor } from '../../../../helpers/utils/accounts';
+import { ConnectionListTooltip } from './connection-list-tooltip/connection-list-tooltip';
 
 export const ConnectionListItem = ({ connection, onClick }) => {
   const t = useI18nContext();

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -1436,7 +1436,6 @@ export const getConnectedSitesList = createDeepEqualSelector(
   getAllConnectedAccounts,
   (connectedSubjectsForAllAddresses, identities, connectedAddresses) => {
     const sitesList = {};
-    console.log(sitesList)
     connectedAddresses.forEach((connectedAddress) => {
       connectedSubjectsForAllAddresses[connectedAddress].forEach((app) => {
         const siteKey = app.origin;
@@ -1469,7 +1468,7 @@ export const getConnectedSitesListWithNetworkInfo = createDeepEqualSelector(
         (network) => network.id === domains[siteKey],
       );
       // For the testnets, if we do not have an image, we will have a fallback string
-      sitesList[siteKey].networkIconUrl = connectedNetwork.rpcPrefs ? connectedNetwork.rpcPrefs.imageUrl : '';
+      sitesList[siteKey].networkIconUrl = connectedNetwork.rpcPrefs?.imageUrl || ''
       sitesList[siteKey].networkName = connectedNetwork.nickname;
     });
     return sitesList;

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -1468,7 +1468,8 @@ export const getConnectedSitesListWithNetworkInfo = createDeepEqualSelector(
         (network) => network.id === domains[siteKey],
       );
       // For the testnets, if we do not have an image, we will have a fallback string
-      sitesList[siteKey].networkIconUrl = connectedNetwork.rpcPrefs?.imageUrl || ''
+      sitesList[siteKey].networkIconUrl =
+        connectedNetwork.rpcPrefs?.imageUrl || '';
       sitesList[siteKey].networkName = connectedNetwork.nickname;
     });
     return sitesList;

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -1436,6 +1436,7 @@ export const getConnectedSitesList = createDeepEqualSelector(
   getAllConnectedAccounts,
   (connectedSubjectsForAllAddresses, identities, connectedAddresses) => {
     const sitesList = {};
+    console.log(sitesList)
     connectedAddresses.forEach((connectedAddress) => {
       connectedSubjectsForAllAddresses[connectedAddress].forEach((app) => {
         const siteKey = app.origin;
@@ -1467,7 +1468,8 @@ export const getConnectedSitesListWithNetworkInfo = createDeepEqualSelector(
       const connectedNetwork = networks.find(
         (network) => network.id === domains[siteKey],
       );
-      sitesList[siteKey].networkIconUrl = connectedNetwork.rpcPrefs.imageUrl;
+      // For the testnets, if we do not have an image, we will have a fallback string
+      sitesList[siteKey].networkIconUrl = connectedNetwork.rpcPrefs ? connectedNetwork.rpcPrefs.imageUrl : '';
       sitesList[siteKey].networkName = connectedNetwork.nickname;
     });
     return sitesList;


### PR DESCRIPTION
This PR is to ensure that the permissions page renders list of all the permissions with the current networks. For a few networks, we don't have the rpcPrefs that was causing the siteKey nd the rpcPrefs to be undefined.
This PR also makes sure that the defined background color is there for the test networks that doesn't have a logo


## **Related issues**

Fixes: #23812 #23793 


## **Manual testing steps**

1. Connect an account on Uniswap
2. Open the popup
3. Open the three-dot menu and choose "All Permissions"
4. It should render the permission with the accounts

## **Screenshots/Recordings**


### **Before**

https://github.com/MetaMask/metamask-extension/assets/39872794/4fc1e04c-fde3-4905-a8b8-b16c75d9f7d1



### **After**

https://github.com/MetaMask/metamask-extension/assets/39872794/c56a60cb-24e6-4857-ac29-2539bb0f6645



## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
