### PR TITLE
fix: new-network button label colors are not readable in light mode

### DIFF
--- a/ui/components/ui/new-network-info/index.scss
+++ b/ui/components/ui/new-network-info/index.scss
@@ -16,7 +16,7 @@
       }
 
       a:hover > span {
-        color: var(--color-text-default);
+        color: var(--inherit);
       }
     }
 

--- a/ui/components/ui/new-network-info/new-network-info.js
+++ b/ui/components/ui/new-network-info/new-network-info.js
@@ -99,11 +99,7 @@ export default function NewNetworkInfo() {
               size={ButtonPrimarySize.Md}
               className="footer__button"
             >
-              <Text
-                variant={TextVariant.bodySm}
-                as="h6"
-                color={TextColor.textDefault}
-              >
+              <Text variant={TextVariant.bodySm} as="h6" color={Color.inherit}>
                 {t('recoveryPhraseReminderConfirm')}
               </Text>
             </Button>


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This fixes the style of footer buttons in the new-network component so they are readable in both light and dark mode.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/23988?quickstart=1)

## **Related issues**

Fixes: [23725](https://github.com/MetaMask/metamask-extension/issues/23725)

## **Manual testing steps**

1. Turn on dark mode setting in extension
2. Add a new network
3. Verify that "Got it" button text is black
4. Verify that "Learn to bridge" button text is blue
5. Verify that "Learn to bridge" button text is black on hover
6. Turn on light mode setting in extension
2. Add a new network
3. Verify that "Got it" button text is white
4. Verify that "Learn to bridge" button text is blue
5. Verify that "Learn to bridge" button text is white on hover

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
![image](https://github.com/MetaMask/metamask-extension/assets/100321200/365fc1e7-e874-4bd6-aa12-3de97f0396d3)


### **After**

<img width="341" alt="Screenshot 2024-04-11 at 10 59 23 AM" src="https://github.com/MetaMask/metamask-extension/assets/100321200/63f45351-3601-4ee7-9c5b-f74cb3fe3f85">


## **Pre-merge author checklist**

- [X] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
