### PR TITLE
fix: simulation metrics performance

### DIFF
--- a/ui/pages/confirmations/hooks/useTransactionEventFragment.js
+++ b/ui/pages/confirmations/hooks/useTransactionEventFragment.js
@@ -17,19 +17,22 @@ export const useTransactionEventFragment = () => {
     }),
   );
 
+  const fragmentExists = Boolean(fragment);
+  const gasTransactionId = transaction?.id;
+
   const updateTransactionEventFragment = useCallback(
     async (params, _transactionId) => {
-      const transactionId = _transactionId || transaction?.id;
+      const transactionId = _transactionId || gasTransactionId;
 
       if (!transactionId) {
         return;
       }
-      if (!fragment) {
+      if (!fragmentExists) {
         await createTransactionEventFragment(transactionId);
       }
       updateEventFragment(`transaction-added-${transactionId}`, params);
     },
-    [fragment, transaction],
+    [fragmentExists, gasTransactionId],
   );
 
   return {


### PR DESCRIPTION
## **Description**

The simulation metrics provided via the `useSimulationMetrics` hook were causing excessive calls to `updateTransactionEventFragment`.

This was due to the dependencies of `updateTransactionEventFragment` being very broad, meaning the function reference was changing very frequently.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/23992?quickstart=1)

## **Related issues**

## **Manual testing steps**

1. High level regression of simulation component.
2. Login to metrics debugger on Segment website.
3. Create transaction in extension.
4. Reject transaction.
5. Verify simulation metrics are in `Transaction Rejected` event.

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
