### PR TITLE
fix: cache subject metadata for redirect

### DIFF
--- a/ui/components/ui/icon-with-fallback/icon-with-fallback.component.js
+++ b/ui/components/ui/icon-with-fallback/icon-with-fallback.component.js
@@ -28,7 +28,7 @@ const IconWithFallback = ({
   };
 
   return (
-    <div className={classnames(wrapperClassName)}>
+    <div className={classnames(wrapperClassName)} style={style}>
       {!iconError && icon ? (
         <img
           onError={handleOnError}

--- a/ui/pages/confirm-add-suggested-nft/__snapshots__/confirm-add-suggested-nft.test.js.snap
+++ b/ui/pages/confirm-add-suggested-nft/__snapshots__/confirm-add-suggested-nft.test.js.snap
@@ -69,6 +69,7 @@ exports[`ConfirmAddSuggestedNFT Component should match snapshot 1`] = `
                 </div>
                 <div
                   class="network-account-balance-header__network-account__ident-icon-ethereum"
+                  style="height: 16px; width: 16px;"
                 >
                   <img
                     alt="Ethereum Mainnet"
@@ -124,6 +125,7 @@ exports[`ConfirmAddSuggestedNFT Component should match snapshot 1`] = `
                 >
                   <div
                     class=""
+                    style="height: 24px; width: 24px;"
                   >
                     <span
                       class="icon-with-fallback__fallback"
@@ -279,6 +281,7 @@ exports[`ConfirmAddSuggestedNFT Component should match snapshot 1`] = `
               </div>
               <div
                 class="network-account-balance-header__network-account__ident-icon-ethereum"
+                style="height: 16px; width: 16px;"
               >
                 <img
                   alt="Ethereum Mainnet"
@@ -334,6 +337,7 @@ exports[`ConfirmAddSuggestedNFT Component should match snapshot 1`] = `
               >
                 <div
                   class=""
+                  style="height: 24px; width: 24px;"
                 >
                   <span
                     class="icon-with-fallback__fallback"

--- a/ui/pages/confirmations/components/signature-request-header/__snapshots__/signature-request-header.test.js.snap
+++ b/ui/pages/confirmations/components/signature-request-header/__snapshots__/signature-request-header.test.js.snap
@@ -57,6 +57,7 @@ exports[`SignatureRequestHeader should match snapshot 1`] = `
         </div>
         <div
           class="network-account-balance-header__network-account__ident-icon-ethereum--gray"
+          style="height: 16px; width: 16px;"
         >
           <span
             class="icon-with-fallback__fallback"

--- a/ui/pages/confirmations/components/signature-request-original/__snapshots__/signature-request-original.test.js.snap
+++ b/ui/pages/confirmations/components/signature-request-original/__snapshots__/signature-request-original.test.js.snap
@@ -133,6 +133,7 @@ exports[`SignatureRequestOriginal should match snapshot 1`] = `
             </div>
             <div
               class="network-account-balance-header__network-account__ident-icon-ethereum--gray"
+              style="height: 16px; width: 16px;"
             >
               <span
                 class="icon-with-fallback__fallback"
@@ -193,6 +194,7 @@ exports[`SignatureRequestOriginal should match snapshot 1`] = `
             >
               <div
                 class=""
+                style="height: 24px; width: 24px;"
               >
                 <span
                   class="icon-with-fallback__fallback"

--- a/ui/pages/confirmations/components/signature-request-siwe/__snapshots__/signature-request-siwe.test.js.snap
+++ b/ui/pages/confirmations/components/signature-request-siwe/__snapshots__/signature-request-siwe.test.js.snap
@@ -130,6 +130,7 @@ exports[`SignatureRequestSIWE (Sign in with Ethereum) should match snapshot 1`] 
           </div>
           <div
             class="network-account-balance-header__network-account__ident-icon-ethereum--gray"
+            style="height: 16px; width: 16px;"
           >
             <span
               class="icon-with-fallback__fallback"
@@ -192,6 +193,7 @@ exports[`SignatureRequestSIWE (Sign in with Ethereum) should match snapshot 1`] 
               >
                 <div
                   class=""
+                  style="height: 24px; width: 24px;"
                 >
                   <img
                     alt="icon"

--- a/ui/pages/confirmations/components/signature-request/__snapshots__/signature-request.test.js.snap
+++ b/ui/pages/confirmations/components/signature-request/__snapshots__/signature-request.test.js.snap
@@ -130,6 +130,7 @@ exports[`Signature Request Component render should match snapshot when we are us
             </div>
             <div
               class="network-account-balance-header__network-account__ident-icon-ethereum--gray"
+              style="height: 16px; width: 16px;"
             >
               <span
                 class="icon-with-fallback__fallback"
@@ -901,6 +902,7 @@ exports[`Signature Request Component render should match snapshot when we want t
             </div>
             <div
               class="network-account-balance-header__network-account__ident-icon-ethereum--gray"
+              style="height: 16px; width: 16px;"
             >
               <span
                 class="icon-with-fallback__fallback"

--- a/ui/pages/confirmations/confirm-signature-request/__snapshots__/index.test.js.snap
+++ b/ui/pages/confirmations/confirm-signature-request/__snapshots__/index.test.js.snap
@@ -130,6 +130,7 @@ exports[`Confirm Signature Request Component render should match snapshot 1`] = 
             </div>
             <div
               class="network-account-balance-header__network-account__ident-icon-ethereum--gray"
+              style="height: 16px; width: 16px;"
             >
               <span
                 class="icon-with-fallback__fallback"

--- a/ui/pages/confirmations/token-allowance/__snapshots__/token-allowance.test.js.snap
+++ b/ui/pages/confirmations/token-allowance/__snapshots__/token-allowance.test.js.snap
@@ -149,6 +149,7 @@ exports[`TokenAllowancePage when mounted should match snapshot 1`] = `
           </div>
           <div
             class="network-account-balance-header__network-account__ident-icon-ethereum--gray"
+            style="height: 16px; width: 16px;"
           >
             <span
               class="icon-with-fallback__fallback"

--- a/ui/pages/permissions-connect/redirect/permissions-redirect.component.js
+++ b/ui/pages/permissions-connect/redirect/permissions-redirect.component.js
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import React, { useContext, useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import SiteIcon from '../../../components/ui/site-icon';
 import Box from '../../../components/ui/box';
@@ -18,6 +18,16 @@ import {
 
 export default function PermissionsRedirect({ subjectMetadata }) {
   const t = useContext(I18nContext);
+  const [cachedSubjectMetadata, setCachedSubjectMetadata] =
+    useState(subjectMetadata);
+
+  // While this redirecting screen is showing, the subject metadata will become invalidated
+  // for that reason we cache the last seen valid subject metadata and show that.
+  useEffect(() => {
+    if (subjectMetadata && subjectMetadata.origin) {
+      setCachedSubjectMetadata(subjectMetadata);
+    }
+  }, [subjectMetadata]);
 
   return (
     <div className="permissions-redirect">
@@ -30,8 +40,8 @@ export default function PermissionsRedirect({ subjectMetadata }) {
         </Typography>
         <div className="permissions-redirect__icons">
           <SiteIcon
-            icon={subjectMetadata.iconUrl}
-            name={subjectMetadata.name}
+            icon={cachedSubjectMetadata.iconUrl}
+            name={cachedSubjectMetadata.name}
             size={64}
             className="permissions-redirect__site-icon"
           />


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Caches subject metadata on the permission redirect screen, fixing the problem where the dapp icon would disappear while redirecting. Also fixes the centering on this icon as well as multiple other icons in the app.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/23999?quickstart=1)


## **Manual testing steps**

1. Connect to any dapp
2. Notice the difference in the redirection screen

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

https://github.com/MetaMask/metamask-extension/assets/1561200/5b7a3ccc-47a8-4f95-932b-f544e998f331

### **After**

https://github.com/MetaMask/metamask-extension/assets/1561200/dc331711-388b-4d53-a869-e89618742119
