### PR TITLE
fix: checkmark icon missing after token import

### DIFF
--- a/ui/pages/home/index.scss
+++ b/ui/pages/home/index.scss
@@ -200,8 +200,7 @@
     }
 
     &-icon {
-      @include design-system.H3;
-
+      font-size: 24px;
       margin-inline-end: 12px;
       color: var(--color-success-default);
     }


### PR DESCRIPTION
## **Description**

After importing an erc20 token, the popup message was not rendering the checkmark icon.

The icon is from font-awesome, and their CSS works fine.  But when we add `@include design-system.H3`, it overrode the font-family, breaking the icon.

Fixed by setting font size directly rather than bringing the whole H3.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/24005?quickstart=1)

## **Related issues**


## **Manual testing steps**

1. Import an erc20 token, either manually or via autodetection
2. Verify the green popup message has a checkmark icon

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="349" alt="Screenshot 2024-04-12 at 10 58 57 AM" src="https://github.com/MetaMask/metamask-extension/assets/3500406/14878f22-b355-4eb5-97c6-feb317d8775f">


### **After**

<img width="354" alt="Screenshot 2024-04-12 at 12 00 30 PM" src="https://github.com/MetaMask/metamask-extension/assets/3500406/8bca68da-645c-44a1-b754-4e529070ae50">



## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
