### PR TITLE
fix: Deduplicate accounts in `addMorePermittedAccounts()`

### DIFF
--- a/app/scripts/controllers/permissions/background-api.js
+++ b/app/scripts/controllers/permissions/background-api.js
@@ -7,13 +7,13 @@ import {
 export function getPermissionBackgroundApiMethods(permissionController) {
   return {
     addPermittedAccount: (origin, account) => {
-      const existing = permissionController.getCaveat(
+      const { value: existingAccounts } = permissionController.getCaveat(
         origin,
         RestrictedMethods.eth_accounts,
         CaveatTypes.restrictReturnedAccounts,
       );
 
-      if (existing.value.includes(account)) {
+      if (existingAccounts.includes(account)) {
         return;
       }
 
@@ -21,11 +21,11 @@ export function getPermissionBackgroundApiMethods(permissionController) {
         origin,
         RestrictedMethods.eth_accounts,
         CaveatTypes.restrictReturnedAccounts,
-        [...existing.value, account],
+        [...existingAccounts, account],
       );
     },
 
-    // To add more than one accounts when already connected to the dapp
+    // To add more than one account when already connected to the dapp
     addMorePermittedAccounts: (origin, accounts) => {
       const { value: existingAccounts } = permissionController.getCaveat(
         origin,
@@ -50,19 +50,19 @@ export function getPermissionBackgroundApiMethods(permissionController) {
     },
 
     removePermittedAccount: (origin, account) => {
-      const existing = permissionController.getCaveat(
+      const { value: existingAccounts } = permissionController.getCaveat(
         origin,
         RestrictedMethods.eth_accounts,
         CaveatTypes.restrictReturnedAccounts,
       );
 
-      if (!existing.value.includes(account)) {
-        return;
-      }
-
-      const remainingAccounts = existing.value.filter(
+      const remainingAccounts = existingAccounts.filter(
         (existingAccount) => existingAccount !== account,
       );
+
+      if (remainingAccounts.length === existingAccounts.length) {
+        return;
+      }
 
       if (remainingAccounts.length === 0) {
         permissionController.revokePermission(

--- a/app/scripts/controllers/permissions/background-api.js
+++ b/app/scripts/controllers/permissions/background-api.js
@@ -27,17 +27,25 @@ export function getPermissionBackgroundApiMethods(permissionController) {
 
     // To add more than one accounts when already connected to the dapp
     addMorePermittedAccounts: (origin, accounts) => {
-      const existing = permissionController.getCaveat(
+      const { value: existingAccounts } = permissionController.getCaveat(
         origin,
         RestrictedMethods.eth_accounts,
         CaveatTypes.restrictReturnedAccounts,
       );
-      // Since this function will be called for unconnected accounts, we dodn't need an extra check
+
+      const updatedAccounts = Array.from(
+        new Set([...existingAccounts, ...accounts]),
+      );
+
+      if (updatedAccounts.length === existingAccounts.length) {
+        return;
+      }
+
       permissionController.updateCaveat(
         origin,
         RestrictedMethods.eth_accounts,
         CaveatTypes.restrictReturnedAccounts,
-        [...existing.value, ...accounts],
+        updatedAccounts,
       );
     },
 

--- a/app/scripts/controllers/permissions/background-api.test.js
+++ b/app/scripts/controllers/permissions/background-api.test.js
@@ -34,7 +34,7 @@ describe('permission background API methods', () => {
       );
     });
 
-    it('does not add a permitted account', () => {
+    it('does not add an already permitted account', () => {
       const permissionController = {
         getCaveat: jest.fn().mockImplementationOnce(() => {
           return { type: CaveatTypes.restrictReturnedAccounts, value: ['0x1'] };
@@ -45,6 +45,140 @@ describe('permission background API methods', () => {
       getPermissionBackgroundApiMethods(
         permissionController,
       ).addPermittedAccount('foo.com', '0x1');
+      expect(permissionController.getCaveat).toHaveBeenCalledTimes(1);
+      expect(permissionController.getCaveat).toHaveBeenCalledWith(
+        'foo.com',
+        RestrictedMethods.eth_accounts,
+        CaveatTypes.restrictReturnedAccounts,
+      );
+
+      expect(permissionController.updateCaveat).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('addMorePermittedAccounts', () => {
+    it('adds a permitted account', () => {
+      const permissionController = {
+        getCaveat: jest.fn().mockImplementationOnce(() => {
+          return { type: CaveatTypes.restrictReturnedAccounts, value: ['0x1'] };
+        }),
+        updateCaveat: jest.fn(),
+      };
+
+      getPermissionBackgroundApiMethods(
+        permissionController,
+      ).addMorePermittedAccounts('foo.com', ['0x2']);
+
+      expect(permissionController.getCaveat).toHaveBeenCalledTimes(1);
+      expect(permissionController.getCaveat).toHaveBeenCalledWith(
+        'foo.com',
+        RestrictedMethods.eth_accounts,
+        CaveatTypes.restrictReturnedAccounts,
+      );
+
+      expect(permissionController.updateCaveat).toHaveBeenCalledTimes(1);
+      expect(permissionController.updateCaveat).toHaveBeenCalledWith(
+        'foo.com',
+        RestrictedMethods.eth_accounts,
+        CaveatTypes.restrictReturnedAccounts,
+        ['0x1', '0x2'],
+      );
+    });
+
+    it('adds multiple permitted accounts', () => {
+      const permissionController = {
+        getCaveat: jest.fn().mockImplementationOnce(() => {
+          return { type: CaveatTypes.restrictReturnedAccounts, value: ['0x1'] };
+        }),
+        updateCaveat: jest.fn(),
+      };
+
+      getPermissionBackgroundApiMethods(
+        permissionController,
+      ).addMorePermittedAccounts('foo.com', ['0x2', '0x3']);
+
+      expect(permissionController.getCaveat).toHaveBeenCalledTimes(1);
+      expect(permissionController.getCaveat).toHaveBeenCalledWith(
+        'foo.com',
+        RestrictedMethods.eth_accounts,
+        CaveatTypes.restrictReturnedAccounts,
+      );
+
+      expect(permissionController.updateCaveat).toHaveBeenCalledTimes(1);
+      expect(permissionController.updateCaveat).toHaveBeenCalledWith(
+        'foo.com',
+        RestrictedMethods.eth_accounts,
+        CaveatTypes.restrictReturnedAccounts,
+        ['0x1', '0x2', '0x3'],
+      );
+    });
+
+    it.failing('adds multiple permitted accounts (partial overlap)', () => {
+      const permissionController = {
+        getCaveat: jest.fn().mockImplementationOnce(() => {
+          return {
+            type: CaveatTypes.restrictReturnedAccounts,
+            value: ['0x1', '0x2', '0x3'],
+          };
+        }),
+        updateCaveat: jest.fn(),
+      };
+
+      getPermissionBackgroundApiMethods(
+        permissionController,
+      ).addMorePermittedAccounts('foo.com', ['0x2', '0x4']);
+
+      expect(permissionController.getCaveat).toHaveBeenCalledTimes(1);
+      expect(permissionController.getCaveat).toHaveBeenCalledWith(
+        'foo.com',
+        RestrictedMethods.eth_accounts,
+        CaveatTypes.restrictReturnedAccounts,
+      );
+
+      expect(permissionController.updateCaveat).toHaveBeenCalledTimes(1);
+      expect(permissionController.updateCaveat).toHaveBeenCalledWith(
+        'foo.com',
+        RestrictedMethods.eth_accounts,
+        CaveatTypes.restrictReturnedAccounts,
+        ['0x1', '0x2', '0x3', '0x4'],
+      );
+    });
+
+    it.failing('does not add an already permitted account', () => {
+      const permissionController = {
+        getCaveat: jest.fn().mockImplementationOnce(() => {
+          return { type: CaveatTypes.restrictReturnedAccounts, value: ['0x1'] };
+        }),
+        updateCaveat: jest.fn(),
+      };
+
+      getPermissionBackgroundApiMethods(
+        permissionController,
+      ).addMorePermittedAccounts('foo.com', ['0x1']);
+      expect(permissionController.getCaveat).toHaveBeenCalledTimes(1);
+      expect(permissionController.getCaveat).toHaveBeenCalledWith(
+        'foo.com',
+        RestrictedMethods.eth_accounts,
+        CaveatTypes.restrictReturnedAccounts,
+      );
+
+      expect(permissionController.updateCaveat).not.toHaveBeenCalled();
+    });
+
+    it.failing('does not add multiple already permitted accounts', () => {
+      const permissionController = {
+        getCaveat: jest.fn().mockImplementationOnce(() => {
+          return {
+            type: CaveatTypes.restrictReturnedAccounts,
+            value: ['0x1', '0x2', '0x3'],
+          };
+        }),
+        updateCaveat: jest.fn(),
+      };
+
+      getPermissionBackgroundApiMethods(
+        permissionController,
+      ).addMorePermittedAccounts('foo.com', ['0x1', '0x3']);
       expect(permissionController.getCaveat).toHaveBeenCalledTimes(1);
       expect(permissionController.getCaveat).toHaveBeenCalledWith(
         'foo.com',

--- a/app/scripts/controllers/permissions/background-api.test.js
+++ b/app/scripts/controllers/permissions/background-api.test.js
@@ -113,7 +113,7 @@ describe('permission background API methods', () => {
       );
     });
 
-    it.failing('adds multiple permitted accounts (partial overlap)', () => {
+    it('adds multiple permitted accounts (partial overlap)', () => {
       const permissionController = {
         getCaveat: jest.fn().mockImplementationOnce(() => {
           return {
@@ -144,7 +144,7 @@ describe('permission background API methods', () => {
       );
     });
 
-    it.failing('does not add an already permitted account', () => {
+    it('does not add an already permitted account', () => {
       const permissionController = {
         getCaveat: jest.fn().mockImplementationOnce(() => {
           return { type: CaveatTypes.restrictReturnedAccounts, value: ['0x1'] };
@@ -165,7 +165,7 @@ describe('permission background API methods', () => {
       expect(permissionController.updateCaveat).not.toHaveBeenCalled();
     });
 
-    it.failing('does not add multiple already permitted accounts', () => {
+    it('does not add multiple already permitted accounts', () => {
       const permissionController = {
         getCaveat: jest.fn().mockImplementationOnce(() => {
           return {


### PR DESCRIPTION
## Description

The `addMorePermittedAccounts()` background API method is used to manually connect multiple accounts at once to an unconnected dapp. While we do not currently permit the possibility of passing already-permitted accounts to this method, it is inappropriate for a permissions-related method to include no defensive measures against being sent bad data.

Consequently, this PR ensures that accounts added via `addMorePermittedAccounts()` are deduplicated, and the method ignores any already-permitted accounts, returning early if no unpermitted accounts are added. Also adds tests for the method, which was previously completely untested.

## **Manual testing steps**

1. Go to an unconnected dapp
2. Three dot menu -> Connected sites
3. Manually connect to the dapp

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
