### PR TITLE
fix(mv3): use correct file paths in mv3 test builds

### DIFF
--- a/development/build/scripts.js
+++ b/development/build/scripts.js
@@ -458,9 +458,12 @@ async function createManifestV3AppInitializationBundle({
   // Code below is used to set statsMode to true when testing in MV3
   // This is used to capture module initialisation stats using lavamoat.
   if (isTestBuild(buildTarget)) {
-    const content = readFileSync('./dist/chrome/runtime-lavamoat.js', 'utf8');
+    const content = readFileSync(
+      './dist/chrome/scripts/runtime-lavamoat.js',
+      'utf8',
+    );
     const fileOutput = content.replace('statsMode = false', 'statsMode = true');
-    writeFileSync('./dist/chrome/runtime-lavamoat.js', fileOutput);
+    writeFileSync('./dist/chrome/scripts/runtime-lavamoat.js', fileOutput);
   }
 
   console.log(`Bundle end: service worker app-init.js`);


### PR DESCRIPTION
## **Description**

Prior to this PR, `yarn start:test:mv3` would fail. The error was:

![Screenshot from 2024-04-16 13-33-01](https://github.com/MetaMask/metamask-extension/assets/7499938/faec8f91-282d-4aea-a89b-dee6dbc5b3e0)

The problem was introduced in https://github.com/MetaMask/metamask-extension/pull/23672

That PR has the following in the description:

...The manifest file sometimes references files using a path relative to both the repo and the bundled extension (background.html and popup.html) and sometimes it doesn't (inpage.js lives in the scripts folder).
This PR makes the paths relative to the repo (and the bundled extension).

The problem is that there were two instances of the file paths that were not updated. Those instances only applied to mv3 test builds. This PR updates those instances.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/24060?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/2378

## **Manual testing steps**

1. `yarn start:test:mv3` should successfully create a build

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
