### PR TITLE
feat: Show simulation details on the Smart Transactions status page for native balance changes

### DIFF
--- a/ui/pages/smart-transactions/smart-transaction-status-page/index.scss
+++ b/ui/pages/smart-transactions/smart-transaction-status-page/index.scss
@@ -25,12 +25,10 @@
   }
 
   // Slightly overwrite the default SimulationDetails layout to look better on the Smart Transaction status page.
-  .simulation-details {
-    &__layout {
-      margin-left: 0;
-      margin-right: 0;
-      width: 100%;
-      text-align: left;
-    }
+  .simulation-details-layout {
+    margin-left: 0;
+    margin-right: 0;
+    width: 100%;
+    text-align: left;
   }
 }

--- a/ui/pages/smart-transactions/smart-transaction-status-page/smart-transaction-status-page.tsx
+++ b/ui/pages/smart-transactions/smart-transaction-status-page/smart-transaction-status-page.tsx
@@ -454,7 +454,8 @@ export const SmartTransactionStatusPage = ({
   }, []);
 
   const canShowSimulationDetails =
-    fullTxData.simulationData?.tokenBalanceChanges?.length > 0;
+    fullTxData.simulationData?.tokenBalanceChanges?.length > 0 ||
+    fullTxData.simulationData?.nativeBalanceChange;
   const uuid = smartTransaction?.uuid;
   const portfolioSmartTransactionStatusUrl =
     uuid && chainId


### PR DESCRIPTION
## **Description**
Show simulation details on the Smart Transactions status page for native balance changes, e.g. when using the Send feature. This PR also includes a class name fix.

## **Related issues**

Fixes:

## **Manual testing steps**

1. Enable Smart Transactions
2. Try to use the Send feature on Sepolia testnet
3. See that it shows the Simulation Details section on the Smart Transactions status page

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
