### PR TITLE
fix(offscreen): Fix error loading offscreen document in prod

### DIFF
--- a/lavamoat/browserify/beta/policy.json
+++ b/lavamoat/browserify/beta/policy.json
@@ -2195,6 +2195,13 @@
         "crypto.getRandomValues": true
       }
     },
+    "@metamask/snaps-execution-environments": {
+      "packages": {
+        "@metamask/post-message-stream": true,
+        "@metamask/snaps-utils": true,
+        "@metamask/utils": true
+      }
+    },
     "@metamask/snaps-rpc-methods": {
       "packages": {
         "@metamask/permission-controller": true,

--- a/lavamoat/browserify/desktop/policy.json
+++ b/lavamoat/browserify/desktop/policy.json
@@ -2500,6 +2500,13 @@
         "queueMicrotask": true
       }
     },
+    "@metamask/snaps-execution-environments": {
+      "packages": {
+        "@metamask/post-message-stream": true,
+        "@metamask/snaps-utils": true,
+        "@metamask/utils": true
+      }
+    },
     "@metamask/snaps-rpc-methods": {
       "packages": {
         "@metamask/permission-controller": true,

--- a/lavamoat/browserify/flask/policy.json
+++ b/lavamoat/browserify/flask/policy.json
@@ -2552,6 +2552,13 @@
         "queueMicrotask": true
       }
     },
+    "@metamask/snaps-execution-environments": {
+      "packages": {
+        "@metamask/post-message-stream": true,
+        "@metamask/snaps-utils": true,
+        "@metamask/utils": true
+      }
+    },
     "@metamask/snaps-rpc-methods": {
       "packages": {
         "@metamask/permission-controller": true,

--- a/lavamoat/browserify/main/policy.json
+++ b/lavamoat/browserify/main/policy.json
@@ -1829,6 +1829,13 @@
         "eslint>optionator>fast-levenshtein": true
       }
     },
+    "@metamask/snaps-execution-environments": {
+      "packages": {
+        "@metamask/post-message-stream": true,
+        "@metamask/snaps-utils": true,
+        "@metamask/utils": true
+      }
+    },
     "@metamask/post-message-stream": {
       "globals": {
         "MessageEvent.prototype": true,

--- a/lavamoat/browserify/main/policy.json
+++ b/lavamoat/browserify/main/policy.json
@@ -1829,13 +1829,6 @@
         "eslint>optionator>fast-levenshtein": true
       }
     },
-    "@metamask/snaps-execution-environments": {
-      "packages": {
-        "@metamask/post-message-stream": true,
-        "@metamask/snaps-utils": true,
-        "@metamask/utils": true
-      }
-    },
     "@metamask/post-message-stream": {
       "globals": {
         "MessageEvent.prototype": true,
@@ -2472,6 +2465,13 @@
     "@metamask/snaps-controllers>tar-stream>streamx>queue-tick": {
       "globals": {
         "queueMicrotask": true
+      }
+    },
+    "@metamask/snaps-execution-environments": {
+      "packages": {
+        "@metamask/post-message-stream": true,
+        "@metamask/snaps-utils": true,
+        "@metamask/utils": true
       }
     },
     "@metamask/snaps-rpc-methods": {

--- a/lavamoat/browserify/mmi/policy.json
+++ b/lavamoat/browserify/mmi/policy.json
@@ -2606,6 +2606,13 @@
         "queueMicrotask": true
       }
     },
+    "@metamask/snaps-execution-environments": {
+      "packages": {
+        "@metamask/post-message-stream": true,
+        "@metamask/snaps-utils": true,
+        "@metamask/utils": true
+      }
+    },
     "@metamask/snaps-rpc-methods": {
       "packages": {
         "@metamask/permission-controller": true,

--- a/lavamoat/browserify/policy-override.json
+++ b/lavamoat/browserify/policy-override.json
@@ -1,5 +1,12 @@
 {
   "resources": {
+    "@metamask/snaps-execution-environments": {
+      "packages": {
+        "@metamask/post-message-stream": true,
+        "@metamask/snaps-utils": true,
+        "@metamask/utils": true
+      }
+    },
     "@metamask/controllers>web3-provider-engine>eth-json-rpc-middleware>node-fetch": {
       "globals": {
         "fetch": true

--- a/offscreen/offscreen.html
+++ b/offscreen/offscreen.html
@@ -5,6 +5,6 @@
     <title>MetaMask Offscreen Page</title>
   </head>
   <body>
-    <script type="text/javascript" src="./load-offscreen.js"></script>
+    <script src="./load-offscreen.js"></script>
   </body>
 </html>

--- a/offscreen/offscreen.html
+++ b/offscreen/offscreen.html
@@ -5,10 +5,6 @@
     <title>MetaMask Offscreen Page</title>
   </head>
   <body>
-    <script src="./load-offscreen.js"></script>
-    <iframe
-      src="https://metamask.github.io/eth-ledger-bridge-keyring"
-      allow="hid"
-    ></iframe>
+    <script type="text/javascript" src="./load-offscreen.js"></script>
   </body>
 </html>

--- a/offscreen/scripts/ledger.ts
+++ b/offscreen/scripts/ledger.ts
@@ -17,7 +17,11 @@ const LEDGER_KEYRING_IFRAME_CONNECTED_EVENT = 'ledger-connection-event';
 const callbackProcessor = new CallbackProcessor();
 
 export default function init() {
-  const iframe = document.querySelector('iframe');
+  const iframe = document.createElement('iframe');
+  iframe.style.display = 'none';
+  iframe.src = 'https://metamask.github.io/eth-ledger-bridge-keyring';
+  iframe.allow = 'hid';
+  document.body.appendChild(iframe);
   // This listener receives action responses from the live ledger iframe
   // Then forwards the response to the offscreen bridge
   window.addEventListener('message', ({ origin, data, source }) => {

--- a/offscreen/scripts/ledger.ts
+++ b/offscreen/scripts/ledger.ts
@@ -18,7 +18,6 @@ const callbackProcessor = new CallbackProcessor();
 
 export default function init() {
   const iframe = document.createElement('iframe');
-  iframe.style.display = 'none';
   iframe.src = 'https://metamask.github.io/eth-ledger-bridge-keyring';
   iframe.allow = 'hid';
   document.body.appendChild(iframe);


### PR DESCRIPTION
## **Description**
There was an error with the offscreen document, thus all snaps and hardware wallets, in production mv3 builds because of some strange interaction with loading the offscreen document with an iframe already attached to it. In addition this seems to have hidden some policy issues which this PR also resolves. The solution was to load the iframe dynamically instead of having it as part of the offscreen.html file. This is the same thing that snaps does and I Have validated that ledger and snaps both work in this branch using `yarn dist:mv3`

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/24083?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Pull this branch
2. run `yarn`
3. run `yarn dist:mv3`
4. Install the built extension and go to https://metamask.github.io/snaps/test-snaps/2.4.0/ 
5. Install a snap and validate that it works. 

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
