### PR TITLE
fix: Disable button in case all accounts are connected

### DIFF
--- a/ui/components/multichain/connect-accounts-modal/connect-accounts-modal.tsx
+++ b/ui/components/multichain/connect-accounts-modal/connect-accounts-modal.tsx
@@ -12,7 +12,9 @@ export const ConnectAccountsModal = ({
   onAccountsUpdate: () => void;
   activeTabOrigin: string;
 }) => {
-  const accounts = useSelector(getUnconnectedAccounts);
+  const accounts = useSelector((state) =>
+    getUnconnectedAccounts(state, activeTabOrigin),
+  );
   const [selectedAccounts, setSelectedAccounts] = useState<string[]>([]);
 
   const handleAccountClick = (address: string) => {

--- a/ui/components/multichain/pages/connections/connections.tsx
+++ b/ui/components/multichain/pages/connections/connections.tsx
@@ -72,7 +72,6 @@ import { NoConnectionContent } from './components/no-connection';
 
 export const Connections = () => {
   const t = useI18nContext();
-  const unconnectedAccounts = useSelector(getUnconnectedAccounts);
   const dispatch = useDispatch();
   const history = useHistory();
   const [showConnectAccountsModal, setShowConnectAccountsModal] =
@@ -106,7 +105,9 @@ export const Connections = () => {
   // TODO: Replace `any` with type
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const { id } = useSelector((state: any) => state.activeTab);
-
+  const unconnectedAccounts = useSelector((state) =>
+    getUnconnectedAccounts(state, activeTabOrigin),
+  );
   const connectedAccounts = useSelector((state) =>
     getOrderedConnectedAccountsForConnectedDapp(state, activeTabOrigin),
   );

--- a/ui/components/multichain/pages/connections/connections.tsx
+++ b/ui/components/multichain/pages/connections/connections.tsx
@@ -28,6 +28,7 @@ import {
   getPermittedAccountsForCurrentTab,
   getSelectedAccount,
   getSubjectMetadata,
+  getUnconnectedAccounts,
 } from '../../../../selectors';
 import {
   AvatarFavicon,
@@ -71,6 +72,7 @@ import { NoConnectionContent } from './components/no-connection';
 
 export const Connections = () => {
   const t = useI18nContext();
+  const unconnectedAccounts = useSelector(getUnconnectedAccounts);
   const dispatch = useDispatch();
   const history = useHistory();
   const [showConnectAccountsModal, setShowConnectAccountsModal] =
@@ -358,6 +360,7 @@ export const Connections = () => {
                 size={ButtonSize.Lg}
                 block
                 variant={ButtonVariant.Secondary}
+                disabled={unconnectedAccounts.length === 0}
                 startIconName={IconName.Add}
                 onClick={() => setShowConnectAccountsModal(true)}
               >

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -2319,7 +2319,10 @@ export function getCustomTokenAmount(state) {
 
 export function getUnconnectedAccounts(state, activeTab) {
   const accounts = getMetaMaskAccountsOrdered(state);
-  const connectedAccounts = getOrderedConnectedAccountsForConnectedDapp(state, activeTab);
+  const connectedAccounts = getOrderedConnectedAccountsForConnectedDapp(
+    state,
+    activeTab,
+  );
   const unConnectedAccounts = accounts.filter((account) => {
     return !connectedAccounts.some(
       (connectedAccount) => connectedAccount.address === account.address,

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -118,6 +118,7 @@ import {
   getConnectedSubjectsForAllAddresses,
   ///: END:ONLY_INCLUDE_IF
   getOrderedConnectedAccountsForActiveTab,
+  getOrderedConnectedAccountsForConnectedDapp,
 } from './permissions';
 import { createDeepEqualSelector } from './util';
 
@@ -2316,9 +2317,9 @@ export function getCustomTokenAmount(state) {
   return state.appState.customTokenAmount;
 }
 
-export function getUnconnectedAccounts(state) {
+export function getUnconnectedAccounts(state, activeTab) {
   const accounts = getMetaMaskAccountsOrdered(state);
-  const connectedAccounts = getOrderedConnectedAccountsForActiveTab(state);
+  const connectedAccounts = getOrderedConnectedAccountsForConnectedDapp(state, activeTab);
   const unConnectedAccounts = accounts.filter((account) => {
     return !connectedAccounts.some(
       (connectedAccount) => connectedAccount.address === account.address,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

When there are no accounts to connect the Connect more accounts button on the screen should be disabled rather than showing an empty modal

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/24084?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to Connections page
2. After connecting all accounts, try adding more, the button to Connect more accounts should be disabled

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<img width="362" alt="Screenshot 2024-04-17 at 16 28 15" src="https://github.com/MetaMask/metamask-extension/assets/11148144/07678250-3e3d-4485-9f46-ce144aa92835">

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
