### PR TITLE
fix: simulation details should show fiat values for most erc20 tokens

### DIFF
--- a/ui/pages/confirmations/components/simulation-details/amount-pill.test.tsx
+++ b/ui/pages/confirmations/components/simulation-details/amount-pill.test.tsx
@@ -11,6 +11,14 @@ import {
   TokenAssetIdentifier,
 } from './types';
 
+jest.mock('react-redux', () => ({
+  useSelector: jest.fn((selector) => selector()),
+}));
+
+jest.mock('../../../../ducks/locale/locale', () => ({
+  getIntlLocale: jest.fn(() => 'en-US'),
+}));
+
 jest.mock('../../../../components/ui/tooltip', () => ({
   __esModule: true,
   default: jest.fn(({ children }) => children),

--- a/ui/pages/confirmations/components/simulation-details/amount-pill.test.tsx
+++ b/ui/pages/confirmations/components/simulation-details/amount-pill.test.tsx
@@ -11,14 +11,6 @@ import {
   TokenAssetIdentifier,
 } from './types';
 
-jest.mock('react-redux', () => ({
-  useSelector: jest.fn((selector) => selector()),
-}));
-
-jest.mock('../../../../ducks/locale/locale', () => ({
-  getIntlLocale: jest.fn(() => 'en-US'),
-}));
-
 jest.mock('../../../../components/ui/tooltip', () => ({
   __esModule: true,
   default: jest.fn(({ children }) => children),

--- a/ui/pages/confirmations/components/simulation-details/useBalanceChanges.test.ts
+++ b/ui/pages/confirmations/components/simulation-details/useBalanceChanges.test.ts
@@ -59,7 +59,7 @@ const dummyBalanceChange = {
   newBalance: '0xIGNORE' as Hex,
 };
 
-const pendingImpl = () =>
+const PENDING_PROMISE = () =>
   new Promise(() => {
     /* unresolved promise */
   });
@@ -93,7 +93,7 @@ describe('useBalanceChanges', () => {
     });
 
     it('returns pending=true while fetching token decimals', async () => {
-      mockGetTokenStandardAndDetails.mockImplementation(pendingImpl);
+      mockGetTokenStandardAndDetails.mockImplementation(PENDING_PROMISE);
       const simulationData: SimulationData = {
         nativeBalanceChange: undefined,
         tokenBalanceChanges: [
@@ -117,7 +117,7 @@ describe('useBalanceChanges', () => {
     });
 
     it('returns pending=true while fetching token fiat rates', async () => {
-      mockFetchTokenExchangeRates.mockImplementation(pendingImpl);
+      mockFetchTokenExchangeRates.mockImplementation(PENDING_PROMISE);
       const simulationData: SimulationData = {
         nativeBalanceChange: undefined,
         tokenBalanceChanges: [

--- a/ui/pages/confirmations/components/simulation-details/useBalanceChanges.test.ts
+++ b/ui/pages/confirmations/components/simulation-details/useBalanceChanges.test.ts
@@ -6,9 +6,9 @@ import {
 } from '@metamask/transaction-controller';
 import { TokenStandard } from '../../../../../shared/constants/transaction';
 import { getConversionRate } from '../../../../ducks/metamask/metamask';
-import { getTokenExchangeRates } from '../../../../selectors';
 import { getTokenStandardAndDetails } from '../../../../store/actions';
 import { Numeric } from '../../../../../shared/modules/Numeric';
+import { fetchTokenExchangeRates } from '../../../../helpers/utils/util';
 import { useBalanceChanges } from './useBalanceChanges';
 import { FIAT_UNAVAILABLE } from './types';
 
@@ -21,8 +21,12 @@ jest.mock('../../../../ducks/metamask/metamask', () => ({
 }));
 
 jest.mock('../../../../selectors', () => ({
-  getTokenExchangeRates: jest.fn(),
-  getConfirmationExchangeRates: jest.fn().mockReturnValue({}),
+  getCurrentChainId: jest.fn(),
+  getCurrentCurrency: jest.fn(),
+}));
+
+jest.mock('../../../../helpers/utils/util', () => ({
+  fetchTokenExchangeRates: jest.fn(),
 }));
 
 jest.mock('../../../../store/actions', () => ({
@@ -30,8 +34,8 @@ jest.mock('../../../../store/actions', () => ({
 }));
 
 const mockGetConversionRate = getConversionRate as jest.Mock;
-const mockGetTokenExchangeRates = getTokenExchangeRates as unknown as jest.Mock;
 const mockGetTokenStandardAndDetails = getTokenStandardAndDetails as jest.Mock;
+const mockFetchTokenExchangeRates = fetchTokenExchangeRates as jest.Mock;
 
 const ETH_TO_FIAT_RATE = 3;
 
@@ -39,8 +43,8 @@ const ERC20_TOKEN_ADDRESS_1_MOCK: Hex = '0x0erc20_1';
 const ERC20_TOKEN_ADDRESS_2_MOCK: Hex = '0x0erc20_2';
 const ERC20_DECIMALS_1_MOCK = 3;
 const ERC20_DECIMALS_2_MOCK = 4;
-const ERC20_TO_ETH_RATE_1_MOCK = 0.5;
-const ERC20_TO_ETH_RATE_2_MOCK = 2;
+const ERC20_TO_FIAT_RATE_1_MOCK = 1.5;
+const ERC20_TO_FIAT_RATE_2_MOCK = 6;
 
 const NFT_TOKEN_ADDRESS_MOCK: Hex = '0x0nft';
 
@@ -55,6 +59,11 @@ const dummyBalanceChange = {
   newBalance: '0xIGNORE' as Hex,
 };
 
+const pendingImpl = () =>
+  new Promise(() => {
+    /* unresolved promise */
+  });
+
 describe('useBalanceChanges', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -68,38 +77,68 @@ describe('useBalanceChanges', () => {
       });
     });
     mockGetConversionRate.mockReturnValue(ETH_TO_FIAT_RATE);
-    mockGetTokenExchangeRates.mockReturnValue({
-      [ERC20_TOKEN_ADDRESS_1_MOCK]: ERC20_TO_ETH_RATE_1_MOCK,
-      [ERC20_TOKEN_ADDRESS_2_MOCK]: ERC20_TO_ETH_RATE_2_MOCK,
+    mockFetchTokenExchangeRates.mockResolvedValue({
+      [ERC20_TOKEN_ADDRESS_1_MOCK]: ERC20_TO_FIAT_RATE_1_MOCK,
+      [ERC20_TOKEN_ADDRESS_2_MOCK]: ERC20_TO_FIAT_RATE_2_MOCK,
     });
   });
 
-  it('handles no simulation data', async () => {
-    const { result, waitForNextUpdate } = renderHook(() =>
-      useBalanceChanges(undefined),
-    );
-    expect(result.current).toEqual({ pending: expect.any(Boolean), value: [] });
-    await waitForNextUpdate();
-  });
+  describe('pending states', () => {
+    it('returns pending=true if no simulation data', async () => {
+      const { result, waitForNextUpdate } = renderHook(() =>
+        useBalanceChanges(undefined),
+      );
+      expect(result.current).toEqual({ pending: true, value: [] });
+      await waitForNextUpdate();
+    });
 
-  it('returns pending state when fetching token details', async () => {
-    const simulationData: SimulationData = {
-      nativeBalanceChange: undefined,
-      tokenBalanceChanges: [
-        {
-          ...dummyBalanceChange,
-          difference: DIFFERENCE_1_MOCK,
-          isDecrease: true,
-          address: ERC20_TOKEN_ADDRESS_1_MOCK,
-          standard: SimulationTokenStandard.erc20,
-        },
-      ],
-    };
-    const { result, unmount } = renderHook(() =>
-      useBalanceChanges(simulationData),
-    );
-    expect(result.current).toEqual({ pending: true, value: [] });
-    unmount();
+    it('returns pending=true while fetching token decimals', async () => {
+      mockGetTokenStandardAndDetails.mockImplementation(pendingImpl);
+      const simulationData: SimulationData = {
+        nativeBalanceChange: undefined,
+        tokenBalanceChanges: [
+          {
+            ...dummyBalanceChange,
+            difference: DIFFERENCE_1_MOCK,
+            isDecrease: true,
+            address: ERC20_TOKEN_ADDRESS_1_MOCK,
+            standard: SimulationTokenStandard.erc20,
+          },
+        ],
+      };
+      const { result, unmount, waitForNextUpdate } = renderHook(() =>
+        useBalanceChanges(simulationData),
+      );
+
+      await waitForNextUpdate();
+
+      expect(result.current).toEqual({ pending: true, value: [] });
+      unmount();
+    });
+
+    it('returns pending=true while fetching token fiat rates', async () => {
+      mockFetchTokenExchangeRates.mockImplementation(pendingImpl);
+      const simulationData: SimulationData = {
+        nativeBalanceChange: undefined,
+        tokenBalanceChanges: [
+          {
+            ...dummyBalanceChange,
+            difference: DIFFERENCE_1_MOCK,
+            isDecrease: true,
+            address: ERC20_TOKEN_ADDRESS_1_MOCK,
+            standard: SimulationTokenStandard.erc20,
+          },
+        ],
+      };
+      const { result, unmount, waitForNextUpdate } = renderHook(() =>
+        useBalanceChanges(simulationData),
+      );
+
+      await waitForNextUpdate();
+
+      expect(result.current).toEqual({ pending: true, value: [] });
+      unmount();
+    });
   });
 
   describe('with token balance changes', () => {

--- a/ui/pages/confirmations/components/simulation-details/useBalanceChanges.ts
+++ b/ui/pages/confirmations/components/simulation-details/useBalanceChanges.ts
@@ -27,7 +27,7 @@ const NATIVE_DECIMALS = 18;
 const ERC20_DEFAULT_DECIMALS = 18;
 
 // Converts a SimulationTokenStandard to a TokenStandard
-const convertStandard = (standard: SimulationTokenStandard) => {
+function convertStandard(standard: SimulationTokenStandard) {
   switch (standard) {
     case SimulationTokenStandard.erc20:
       return TokenStandard.ERC20;
@@ -38,24 +38,24 @@ const convertStandard = (standard: SimulationTokenStandard) => {
     default:
       throw new Error(`Unknown token standard: ${standard}`);
   }
-};
+}
 
 // Calculates the asset amount based on the balance change and decimals
-const getAssetAmount = (
+function getAssetAmount(
   { isDecrease: isNegative, difference: quantity }: SimulationBalanceChange,
   decimals: number,
-): Amount => {
+): Amount {
   const numeric = Numeric.from(quantity, 16)
     .times(isNegative ? -1 : 1, 10)
     .toBase(10)
     .shiftedBy(decimals);
   return { isNegative, quantity, decimals, numeric };
-};
+}
 
 // Fetches token details for all the token addresses in the SimulationTokenBalanceChanges
-const fetchErc20Decimals = async (
+async function fetchErc20Decimals(
   addresses: Hex[],
-): Promise<Record<Hex, number>> => {
+): Promise<Record<Hex, number>> {
   const uniqueAddresses = [
     ...new Set(addresses.map((address) => address.toLowerCase())),
   ];
@@ -68,13 +68,13 @@ const fetchErc20Decimals = async (
       decimals ? parseInt(decimals, 10) : ERC20_DEFAULT_DECIMALS,
     ]),
   );
-};
+}
 
-const fetchTokenFiatRates = async (
+async function fetchTokenFiatRates(
   fiatCurrency: string,
   erc20TokenAddresses: Hex[],
   chainId: Hex,
-): Promise<ContractExchangeRates> => {
+): Promise<ContractExchangeRates> {
   const tokenRates = await fetchTokenExchangeRates(
     fiatCurrency,
     erc20TokenAddresses,
@@ -87,7 +87,7 @@ const fetchTokenFiatRates = async (
       rate,
     ]),
   );
-};
+}
 
 // Compiles the balance change for the native asset
 function getNativeBalanceChange(
@@ -153,7 +153,7 @@ export const useBalanceChanges = (
 
   const erc20FiatRates = useAsyncResultOrThrow(
     () => fetchTokenFiatRates(fiatCurrency, erc20TokenAddresses, chainId),
-    [JSON.stringify(erc20TokenAddresses), fiatCurrency],
+    [JSON.stringify(erc20TokenAddresses), chainId, fiatCurrency],
   );
 
   if (erc20Decimals.pending || erc20FiatRates.pending || !simulationData) {

--- a/ui/pages/confirmations/components/simulation-details/useBalanceChanges.ts
+++ b/ui/pages/confirmations/components/simulation-details/useBalanceChanges.ts
@@ -69,6 +69,25 @@ const fetchErc20Decimals = async (
   );
 };
 
+const fetchTokenFiatRates = async (
+  fiatCurrency: string,
+  erc20TokenAddresses: Hex[],
+  chainId: Hex,
+) => {
+  const tokenRates = await fetchTokenExchangeRates(
+    fiatCurrency,
+    erc20TokenAddresses,
+    chainId,
+  );
+
+  return Object.fromEntries(
+    Object.entries(tokenRates).map(([address, rate]) => [
+      address.toLowerCase(),
+      rate,
+    ]),
+  );
+};
+
 // Compiles the balance change for the native asset
 function getNativeBalanceChange(
   nativeBalanceChange: SimulationBalanceChange | undefined,
@@ -129,7 +148,7 @@ export const useBalanceChanges = (
   );
 
   const erc20FiatRates = useAsyncResultOrThrow(
-    () => fetchTokenExchangeRates(fiatCurrency, erc20TokenAddresses, chainId),
+    () => fetchTokenFiatRates(fiatCurrency, erc20TokenAddresses, chainId),
     [JSON.stringify(erc20TokenAddresses), fiatCurrency],
   );
 

--- a/ui/pages/confirmations/components/simulation-details/useBalanceChanges.ts
+++ b/ui/pages/confirmations/components/simulation-details/useBalanceChanges.ts
@@ -6,6 +6,7 @@ import {
   SimulationTokenBalanceChange,
   SimulationTokenStandard,
 } from '@metamask/transaction-controller';
+import { ContractExchangeRates } from '@metamask/assets-controllers';
 import { useAsyncResultOrThrow } from '../../../../hooks/useAsyncResult';
 import { getTokenStandardAndDetails } from '../../../../store/actions';
 import { TokenStandard } from '../../../../../shared/constants/transaction';
@@ -73,7 +74,7 @@ const fetchTokenFiatRates = async (
   fiatCurrency: string,
   erc20TokenAddresses: Hex[],
   chainId: Hex,
-) => {
+): Promise<ContractExchangeRates> => {
   const tokenRates = await fetchTokenExchangeRates(
     fiatCurrency,
     erc20TokenAddresses,
@@ -138,7 +139,10 @@ export const useBalanceChanges = (
   const fiatCurrency = useSelector(getCurrentCurrency);
   const nativeFiatRate = useSelector(getConversionRate);
 
-  const erc20TokenAddresses = (simulationData?.tokenBalanceChanges ?? [])
+  const { nativeBalanceChange, tokenBalanceChanges = [] } =
+    simulationData ?? {};
+
+  const erc20TokenAddresses = tokenBalanceChanges
     .filter((tbc) => tbc.standard === SimulationTokenStandard.erc20)
     .map((tbc) => tbc.address);
 
@@ -157,11 +161,11 @@ export const useBalanceChanges = (
   }
 
   const nativeChange = getNativeBalanceChange(
-    simulationData.nativeBalanceChange,
+    nativeBalanceChange,
     nativeFiatRate,
   );
   const tokenChanges = getTokenBalanceChanges(
-    simulationData.tokenBalanceChanges,
+    tokenBalanceChanges,
     erc20Decimals.value,
     erc20FiatRates.value,
   );


### PR DESCRIPTION
## **Description**
Previously, SimulationDetails only showed fiat rates for erc20 tokens that were already in the user's wallet.
With this PR, SimulationDetails component will fetch the token fiat rates for all erc20 tokens involved in a transaction simulation. 

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/24086?quickstart=1)

## **Related issues**

Fixes:https://github.com/MetaMask/MetaMask-planning/issues/2361

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

![image](https://github.com/MetaMask/metamask-extension/assets/507015/35cbb7f0-47a9-488e-9ae5-df8e80a11f3b)

### **After**

![image](https://github.com/MetaMask/metamask-extension/assets/507015/13d12bb3-2d23-4982-91d1-d39d3b66b03a)

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
