### PR TITLE
chore: adding design tokens eslint plugin `color-no-hex` rule 

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -18,6 +18,10 @@ module.exports = {
   ignorePatterns: readFileSync('.prettierignore', 'utf8').trim().split('\n'),
   // eslint's parser, esprima, is not compatible with ESM, so use the babel parser instead
   parser: '@babel/eslint-parser',
+  plugins: ['@metamask/design-tokens'],
+  rules: {
+    '@metamask/design-tokens/color-no-hex': 'warn',
+  },
   overrides: [
     /**
      * == Modules ==
@@ -437,6 +441,19 @@ module.exports = {
             allowSeparatedGroups: false,
           },
         ],
+      },
+    },
+    /**
+     * Don't check for static hex values in .test, .spec or .stories files
+     */
+    {
+      files: [
+        '**/*.test.{js,ts,tsx}',
+        '**/*.spec.{js,ts,tsx}',
+        '**/*.stories.{js,ts,tsx}',
+      ],
+      rules: {
+        '@metamask/design-tokens/color-no-hex': 'off',
       },
     },
   ],

--- a/app/scripts/controllers/preferences.js
+++ b/app/scripts/controllers/preferences.js
@@ -442,7 +442,8 @@ export default class PreferencesController {
    */
   syncAddresses(addresses) {
     if (!Array.isArray(addresses) || addresses.length === 0) {
-      throw new Error('Expected non-empty array of addresses. Error #11201');
+      // eslint-disable-next-line @metamask/design-tokens/color-no-hex
+      throw new Error('Expected non-empty array of addresses. Error #11201'); // not a hex color value
     }
 
     const { identities, lostIdentities } = this.store.getState();

--- a/package.json
+++ b/package.json
@@ -434,6 +434,7 @@
     "@metamask/eslint-config-mocha": "^9.0.0",
     "@metamask/eslint-config-nodejs": "^9.0.0",
     "@metamask/eslint-config-typescript": "^9.0.1",
+    "@metamask/eslint-plugin-design-tokens": "^1.1.0",
     "@metamask/forwarder": "^1.1.0",
     "@metamask/phishing-warning": "^3.0.3",
     "@metamask/test-bundler": "^1.0.0",

--- a/test/e2e/tests/metrics/mock-data.js
+++ b/test/e2e/tests/metrics/mock-data.js
@@ -1,3 +1,4 @@
+/* eslint-disable @metamask/design-tokens/color-no-hex*/
 const TOKENS_API_MOCK_RESULT = [
   {
     name: 'Ethereum',

--- a/ui/components/ui/metafox-logo/horizontal-logo.js
+++ b/ui/components/ui/metafox-logo/horizontal-logo.js
@@ -1,3 +1,4 @@
+/* eslint-disable @metamask/design-tokens/color-no-hex*/
 import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { ThemeType } from '../../../../shared/constants/preferences';

--- a/ui/helpers/constants/settings.js
+++ b/ui/helpers/constants/settings.js
@@ -1,3 +1,4 @@
+/* eslint-disable @metamask/design-tokens/color-no-hex*/
 import { IconName } from '../../components/component-library';
 import {
   ALERTS_ROUTE,

--- a/ui/pages/confirmations/components/edit-gas-fee-popover/network-statistics/status-slider/status-slider.js
+++ b/ui/pages/confirmations/components/edit-gas-fee-popover/network-statistics/status-slider/status-slider.js
@@ -1,3 +1,4 @@
+/* eslint-disable @metamask/design-tokens/color-no-hex*/
 import React from 'react';
 
 import { NetworkCongestionThresholds } from '../../../../../../../shared/constants/gas';
@@ -5,6 +6,7 @@ import { useGasFeeContext } from '../../../../../../contexts/gasFee';
 import { useI18nContext } from '../../../../../../hooks/useI18nContext';
 import { NetworkStabilityTooltip } from '../tooltips';
 
+/* eslint-disable @metamask/design-tokens/color-no-hex */
 const GRADIENT_COLORS = [
   '#037DD6',
   '#1876C8',
@@ -18,6 +20,7 @@ const GRADIENT_COLORS = [
   '#C54055',
   '#D73A49',
 ];
+/* eslint-enable @metamask/design-tokens/color-no-hex */
 
 const determineStatusInfo = (givenNetworkCongestion) => {
   const networkCongestion = givenNetworkCongestion ?? 0.5;

--- a/ui/pages/confirmations/components/edit-gas-fee-popover/network-statistics/status-slider/status-slider.js
+++ b/ui/pages/confirmations/components/edit-gas-fee-popover/network-statistics/status-slider/status-slider.js
@@ -1,4 +1,3 @@
-/* eslint-disable @metamask/design-tokens/color-no-hex*/
 import React from 'react';
 
 import { NetworkCongestionThresholds } from '../../../../../../../shared/constants/gas';

--- a/ui/pages/institutional/pin-mmi-billboard/pin-mmi-billboard.js
+++ b/ui/pages/institutional/pin-mmi-billboard/pin-mmi-billboard.js
@@ -1,3 +1,4 @@
+/* eslint-disable @metamask/design-tokens/color-no-hex*/
 import React from 'react';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 

--- a/ui/pages/onboarding-flow/pin-extension/pin-billboard.js
+++ b/ui/pages/onboarding-flow/pin-extension/pin-billboard.js
@@ -1,3 +1,4 @@
+/* eslint-disable @metamask/design-tokens/color-no-hex*/
 import React from 'react';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 

--- a/ui/pages/settings/networks-tab/networks-tab.constants.js
+++ b/ui/pages/settings/networks-tab/networks-tab.constants.js
@@ -9,7 +9,8 @@ import {
 const defaultNetworksData = [
   {
     labelKey: NETWORK_TYPES.MAINNET,
-    iconColor: '#29B6AF',
+    // eslint-disable-next-line @metamask/design-tokens/color-no-hex
+    iconColor: '#29B6AF', // third party color
     providerType: NETWORK_TYPES.MAINNET,
     rpcUrl: getRpcUrl({
       network: NETWORK_TYPES.MAINNET,
@@ -21,7 +22,8 @@ const defaultNetworksData = [
   },
   {
     labelKey: NETWORK_TYPES.SEPOLIA,
-    iconColor: '#CFB5F0',
+    // eslint-disable-next-line @metamask/design-tokens/color-no-hex
+    iconColor: '#CFB5F0', // third party color
     providerType: NETWORK_TYPES.SEPOLIA,
     rpcUrl: getRpcUrl({
       network: NETWORK_TYPES.SEPOLIA,
@@ -33,7 +35,8 @@ const defaultNetworksData = [
   },
   {
     labelKey: NETWORK_TYPES.LINEA_SEPOLIA,
-    iconColor: '#61dfff',
+    // eslint-disable-next-line @metamask/design-tokens/color-no-hex
+    iconColor: '#61dfff', // third party color
     providerType: NETWORK_TYPES.LINEA_SEPOLIA,
     rpcUrl: getRpcUrl({
       network: NETWORK_TYPES.LINEA_SEPOLIA,
@@ -45,7 +48,8 @@ const defaultNetworksData = [
   },
   {
     labelKey: NETWORK_TYPES.LINEA_MAINNET,
-    iconColor: '#121212',
+    // eslint-disable-next-line @metamask/design-tokens/color-no-hex
+    iconColor: '#121212', // third party color
     providerType: NETWORK_TYPES.LINEA_MAINNET,
     rpcUrl: getRpcUrl({
       network: NETWORK_TYPES.LINEA_MAINNET,

--- a/ui/pages/swaps/loading-swaps-quotes/background-animation.js
+++ b/ui/pages/swaps/loading-swaps-quotes/background-animation.js
@@ -1,3 +1,4 @@
+/* eslint-disable @metamask/design-tokens/color-no-hex*/
 import React from 'react';
 
 export default function BackgroundAnimation() {

--- a/ui/pages/swaps/loading-swaps-quotes/loading-swaps-quotes-stories-metadata.js
+++ b/ui/pages/swaps/loading-swaps-quotes/loading-swaps-quotes-stories-metadata.js
@@ -1,3 +1,4 @@
+/* eslint-disable @metamask/design-tokens/color-no-hex*/
 export const storiesMetadata = {
   totle: {
     color: '#283B4C',

--- a/ui/pages/swaps/main-quote-summary/quote-backdrop.js
+++ b/ui/pages/swaps/main-quote-summary/quote-backdrop.js
@@ -1,3 +1,4 @@
+/* eslint-disable @metamask/design-tokens/color-no-hex*/
 import React from 'react';
 import PropTypes from 'prop-types';
 

--- a/ui/pages/swaps/mascot-background-animation/mascot-background-animation.js
+++ b/ui/pages/swaps/mascot-background-animation/mascot-background-animation.js
@@ -1,3 +1,4 @@
+/* eslint-disable @metamask/design-tokens/color-no-hex*/
 import EventEmitter from 'events';
 import React, { useRef } from 'react';
 

--- a/ui/pages/swaps/swaps-util-test-constants.js
+++ b/ui/pages/swaps/swaps-util-test-constants.js
@@ -1,3 +1,4 @@
+import { lightTheme } from '@metamask/design-tokens';
 import { ETH_SWAPS_TOKEN_OBJECT } from '../../../shared/constants/swaps';
 
 export const TRADES_BASE_PROD_URL =
@@ -161,12 +162,12 @@ export const MOCK_TRADE_RESPONSE_2 = MOCK_TRADE_RESPONSE_1.map((trade) => ({
 
 export const AGGREGATOR_METADATA = {
   agg1: {
-    color: '#283B4C',
+    color: lightTheme.colors.text.default,
     title: 'agg1',
     icon: 'data:image/png;base64,iVBORw0KGgoAAA',
   },
   agg2: {
-    color: '#283B4C',
+    color: lightTheme.colors.text.default,
     title: 'agg2',
     icon: 'data:image/png;base64,iVBORw0KGgoAAA',
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -4350,6 +4350,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@metamask/eslint-plugin-design-tokens@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "@metamask/eslint-plugin-design-tokens@npm:1.1.0"
+  checksum: 21ee903ed25eb1edb3b6f4fc4e426dc48bde0ad5d338618b5b820a11dc5f33a2706527063dca8b50e9049d3c6743781c5ae33d5860088deabc1f250659815a94
+  languageName: node
+  linkType: hard
+
 "@metamask/eth-hd-keyring@npm:^7.0.1":
   version: 7.0.1
   resolution: "@metamask/eth-hd-keyring@npm:7.0.1"
@@ -24836,6 +24843,7 @@ __metadata:
     "@metamask/eslint-config-mocha": "npm:^9.0.0"
     "@metamask/eslint-config-nodejs": "npm:^9.0.0"
     "@metamask/eslint-config-typescript": "npm:^9.0.1"
+    "@metamask/eslint-plugin-design-tokens": "npm:^1.1.0"
     "@metamask/eth-json-rpc-filters": "npm:^7.0.0"
     "@metamask/eth-json-rpc-middleware": "npm:^12.1.0"
     "@metamask/eth-keyring-controller": "npm:^16.0.0"


### PR DESCRIPTION
## **Description**

This PR introduces the [@metamask/eslint-plugin-design-tokens](https://github.com/MetaMask/eslint-plugin-metamask-design-tokens) library to the MetaMask extension codebase, along with the implementation of the [color-no-hex](https://github.com/MetaMask/eslint-plugin-design-tokens/blob/main/docs/rules/color-no-hex.md) rule. This rule aims to prevent the use of static hex color values in our `.js`, `.ts` and `.tsx` files encouraging instead the adoption of design tokens. The motivation behind this change is to ensure our styling remains consistent with the MetaMask design system, enhancing themability, accessibility, and overall alignment with our design principles. Additionally, this update is a crucial step towards enabling the seamless rollout of future brand evolution within MetaMask, ensuring that our UI can adapt to new design standards with minimal effort.

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/24111

## **Manual testing steps**

To ensure the successful integration of the `eslint-plugin-design-tokens` and the effectiveness of the `color-no-hex` rule:
1. Install the updated dependencies by running `yarn install`.
2. Execute `yarn lint:check` to identify any instances of static hex color values.
3. Review the linting output and update any flagged instances to use the corresponding design tokens.
4. Navigate through the extension's UI to verify that the updates maintain visual consistency and adhere to the design system.

## **Screenshots/Recordings**

### **Before**

https://github.com/MetaMask/metamask-extension/assets/8112138/b883f26c-f0e1-4356-b828-58531a76799a

### **After**

https://github.com/MetaMask/metamask-extension/assets/8112138/bb9b0d53-ef8b-44bf-a913-b6ae73b6df4d

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability.
- [x] I’ve included tests if applicable.
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable.
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g., pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.