### PR TITLE
fix: updated connections page to use getPermittedAccountsForSelectedTab

### DIFF
--- a/ui/components/multichain/pages/connections/connections.tsx
+++ b/ui/components/multichain/pages/connections/connections.tsx
@@ -25,7 +25,7 @@ import {
   getOrderedConnectedAccountsForConnectedDapp,
   getPermissionSubjects,
   getPermittedAccountsByOrigin,
-  getPermittedAccountsForCurrentTab,
+  getPermittedAccountsForSelectedTab,
   getSelectedAccount,
   getSubjectMetadata,
 } from '../../../../selectors';
@@ -135,7 +135,10 @@ export const Connections = () => {
     history.push(`${CONNECT_ROUTE}/${requestId}`);
   };
   const connectedSubjectsMetadata = subjectMetadata[activeTabOrigin];
-  const permittedAccounts = useSelector(getPermittedAccountsForCurrentTab);
+
+  const permittedAccounts = useSelector((state) =>
+    getPermittedAccountsForSelectedTab(state, activeTabOrigin),
+  );
 
   const disconnectAllAccounts = () => {
     const subject = (subjects as SubjectsType)[activeTabOrigin];


### PR DESCRIPTION
Since SubjectMetadata is not reliable, to get the connected status we updated the code in this PR [24022](https://github.com/MetaMask/metamask-extension/pull/24022) to use getPermittedAccountsForCurrentTab to get the connected accounts, but this is always dependent on activeTabOrigin and to access it based on the different permissions we are updating it to use getPermittedAccountsForSelectedTab

## **Related issues**

Fixes: #24066 

## **Manual testing steps**

1. Run extension with Multichain
2. Go to Permissions Page after connecting extension with different dapps
3. Check the accounts are listed on connections Page


## **Screenshots/Recordings**


### **Before**

https://github.com/MetaMask/metamask-extension/assets/39872794/3f6995a0-e8c0-4506-83af-5c1256ad8f84



### **After**

https://github.com/MetaMask/metamask-extension/assets/39872794/536d75c6-c0dd-4906-b339-e95cddfe926d



## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
