### PR TITLE
fix: Fix tooltip distance

### DIFF
--- a/ui/components/multichain/connect-accounts-modal/connect-accounts-modal-list.tsx
+++ b/ui/components/multichain/connect-accounts-modal/connect-accounts-modal-list.tsx
@@ -77,11 +77,7 @@ export const ConnectAccountsModalList: React.FC<ConnectAccountsListProps> = ({
                 ])}
                 position="top"
               >
-                <Icon
-                  name={IconName.Info}
-                  color={IconColor.iconMuted}
-                  marginInlineEnd={1}
-                />
+                <Icon name={IconName.Info} color={IconColor.iconMuted} />
               </Tooltip>
               {t('permissions')}
             </Text>

--- a/ui/components/multichain/connect-accounts-modal/connect-accounts-modal-list.tsx
+++ b/ui/components/multichain/connect-accounts-modal/connect-accounts-modal-list.tsx
@@ -71,11 +71,17 @@ export const ConnectAccountsModalList: React.FC<ConnectAccountsListProps> = ({
               display={Display.Flex}
             >
               <Tooltip
+                distance={75}
                 html={t('connectedAccountsListTooltip', [
                   <strong>{getURLHost(activeTabOrigin)}</strong>,
                 ])}
+                position="top"
               >
-                <Icon name={IconName.Info} color={IconColor.iconMuted} />
+                <Icon
+                  name={IconName.Info}
+                  color={IconColor.iconMuted}
+                  marginInlineEnd={1}
+                />
               </Tooltip>
               {t('permissions')}
             </Text>

--- a/ui/components/multichain/connect-accounts-modal/connect-accounts-modal-list.tsx
+++ b/ui/components/multichain/connect-accounts-modal/connect-accounts-modal-list.tsx
@@ -71,13 +71,17 @@ export const ConnectAccountsModalList: React.FC<ConnectAccountsListProps> = ({
               display={Display.Flex}
             >
               <Tooltip
-                distance={75}
+                distance={10}
                 html={t('connectedAccountsListTooltip', [
                   <strong>{getURLHost(activeTabOrigin)}</strong>,
                 ])}
                 position="top"
               >
-                <Icon name={IconName.Info} color={IconColor.iconMuted} />
+                <Icon
+                  marginInlineEnd={2}
+                  name={IconName.Info}
+                  color={IconColor.iconMuted}
+                />
               </Tooltip>
               {t('permissions')}
             </Text>

--- a/ui/components/ui/tooltip/tooltip.js
+++ b/ui/components/ui/tooltip/tooltip.js
@@ -10,6 +10,7 @@ export default class Tooltip extends PureComponent {
     html: null,
     interactive: undefined,
     onHidden: null,
+    distance: 0,
     position: 'left',
     offset: 0,
     open: undefined,
@@ -28,6 +29,7 @@ export default class Tooltip extends PureComponent {
     containerClassName: PropTypes.string,
     disabled: PropTypes.bool,
     html: PropTypes.node,
+    distance: PropTypes.number,
     interactive: PropTypes.bool,
     offset: PropTypes.number,
     onHidden: PropTypes.func,
@@ -54,6 +56,7 @@ export default class Tooltip extends PureComponent {
       html,
       interactive,
       size,
+      distance,
       title,
       trigger,
       onHidden,
@@ -79,6 +82,7 @@ export default class Tooltip extends PureComponent {
         className={containerClassName}
         disabled={disabled}
         hideOnClick={false}
+        distance={distance}
         html={html}
         interactive={interactive}
         onHidden={onHidden}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

The permissions tooltip is not displaying correctly within the connect accounts modal. Additionally there should be a 4px spacing between the tooltip info icon and the permissions text label.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/24098?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/23859

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="355" alt="Screenshot 2024-04-18 at 03 21 07" src="https://github.com/MetaMask/metamask-extension/assets/11148144/11f93d28-074c-4885-ab36-e4347dd0c892">


### **After**

<img width="374" alt="Screenshot 2024-04-18 at 03 13 02" src="https://github.com/MetaMask/metamask-extension/assets/11148144/9007d51d-a39d-4b31-9133-9b14d648993b">


## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
