### PR TITLE
feat: show tooltip and icon when network is busy

### DIFF
--- a/test/e2e/tests/network/network-error.spec.js
+++ b/test/e2e/tests/network/network-error.spec.js
@@ -72,7 +72,9 @@ describe('Gas API fallback', function () {
 
         await driver.clickElement({ text: 'Next', tag: 'button' });
 
-        const error = await driver.isElementPresent('[data-testid="network-busy-tooltip"]');
+        const error = await driver.isElementPresent(
+          '[data-testid="network-busy-tooltip"]',
+        );
 
         assert.equal(error, true, 'Network error is present');
       },

--- a/test/e2e/tests/network/network-error.spec.js
+++ b/test/e2e/tests/network/network-error.spec.js
@@ -72,11 +72,7 @@ describe('Gas API fallback', function () {
 
         await driver.clickElement({ text: 'Next', tag: 'button' });
 
-        await driver.findElement('.transaction-alerts');
-
-        const error = await driver.isElementPresent({
-          text: 'Network is busy. Gas prices are high and estimates are less accurate.',
-        });
+        const error = await driver.isElementPresent('[data-testid="network-busy-tooltip"]');
 
         assert.equal(error, true, 'Network error is present');
       },

--- a/ui/pages/confirmations/components/gas-details-item/gas-details-item.js
+++ b/ui/pages/confirmations/components/gas-details-item/gas-details-item.js
@@ -3,8 +3,16 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
 import { useSelector } from 'react-redux';
-import { Text } from '../../../../components/component-library';
-import { TextColor } from '../../../../helpers/constants/design-system';
+import {
+  Icon,
+  IconName,
+  IconSize,
+  Text,
+} from '../../../../components/component-library';
+import {
+  IconColor,
+  TextColor,
+} from '../../../../helpers/constants/design-system';
 import { PRIMARY, SECONDARY } from '../../../../helpers/constants/common';
 import { PriorityLevels } from '../../../../../shared/constants/gas';
 import {
@@ -29,6 +37,7 @@ import EditGasFeeIcon from '../edit-gas-fee-icon/edit-gas-fee-icon';
 import GasTiming from '../gas-timing/gas-timing.component';
 import TransactionDetailItem from '../transaction-detail-item/transaction-detail-item.component';
 import UserPreferencedCurrencyDisplay from '../../../../components/app/user-preferenced-currency-display';
+import Tooltip from '../../../../components/ui/tooltip';
 
 const GasDetailsItem = ({
   'data-testid': dataTestId,
@@ -50,10 +59,12 @@ const GasDetailsItem = ({
   const {
     estimateUsed,
     hasSimulationError,
+    isNetworkBusy,
     maximumCostInHexWei: hexMaximumTransactionFee,
     minimumCostInHexWei: hexMinimumTransactionFee,
     maxPriorityFeePerGas,
     maxFeePerGas,
+    supportsEIP1559,
   } = useGasFeeContext();
 
   const { useNativeCurrencyAsPrimaryCurrency } = useSelector(getPreferences);
@@ -89,11 +100,31 @@ const GasDetailsItem = ({
     hexWEIToDecGWEI(transactionData.txParams?.maxFeePerGas ?? '0x0')
   ).toString();
 
+  const detailTitle = () => {
+    if (supportsEIP1559 && isNetworkBusy) {
+      return (
+        <>
+          <Text>{t('estimatedFee')}</Text>
+          <Tooltip interactive position="top" html={t('networkIsBusy')}>
+            &nbsp;&nbsp;
+            <Icon
+              data-testid="network-busy-tooltip"
+              name={IconName.Danger}
+              size={IconSize.Sm}
+              color={IconColor.errorDefault}
+              marginTop={2}
+            />
+          </Tooltip>
+        </>
+      );
+    }
+    return <Text>{t('estimatedFee')}</Text>;
+  };
   return (
     <TransactionDetailItem
       key="gas-details-item"
       data-testid={dataTestId}
-      detailTitle={<Text>{t('estimatedFee')}</Text>}
+      detailTitle={detailTitle()}
       detailTitleColor={TextColor.textDefault}
       detailText={
         Object.keys(draftTransaction).length === 0 && (

--- a/ui/pages/confirmations/components/gas-details-item/gas-details-item.test.js
+++ b/ui/pages/confirmations/components/gas-details-item/gas-details-item.test.js
@@ -217,6 +217,44 @@ describe('GasDetailsItem', () => {
     });
   });
 
+  it('does not render icon if txParams.type is set to 0x0', async () => {
+    await render({
+      contextProps: {
+        gasFeeEstimates: {
+          high: {
+            suggestedMaxPriorityFeePerGas: '1',
+          },
+        },
+        gasFeeEstimatesByChainId: {
+          ...mockState.metamask.gasFeeEstimatesByChainId,
+          '0x5': {
+            gasFeeEstimates: {
+              high: {
+                suggestedMaxPriorityFeePerGas: '1',
+              },
+              networkCongestion: 0.7,
+            },
+          },
+        },
+        transaction: {
+          txParams: {
+            type: '0x0',
+          },
+          userFeeLevel: 'medium',
+          dappSuggestedGasFees: {
+            maxPriorityFeePerGas: '0x38D7EA4C68000',
+            maxFeePerGas: '0x38D7EA4C68000',
+          },
+        },
+      },
+    });
+    await waitFor(() => {
+      expect(
+        screen.queryByTestId('network-busy-tooltip'),
+      ).not.toBeInTheDocument();
+    });
+  });
+
   it('renders icon if network is busy', async () => {
     await render({
       contextProps: {

--- a/ui/pages/confirmations/components/gas-details-item/gas-details-item.test.js
+++ b/ui/pages/confirmations/components/gas-details-item/gas-details-item.test.js
@@ -207,4 +207,51 @@ describe('GasDetailsItem', () => {
       expect(screen.queryAllByText('ETH').length).toBeGreaterThan(0);
     });
   });
+
+  it('does not render icon if network is not busy', async () => {
+    await render();
+    await waitFor(() => {
+      expect(
+        screen.queryByTestId('network-busy-tooltip'),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  it('renders icon if network is busy', async () => {
+    await render({
+      contextProps: {
+        gasFeeEstimates: {
+          high: {
+            suggestedMaxPriorityFeePerGas: '1',
+          },
+        },
+        gasFeeEstimatesByChainId: {
+          ...mockState.metamask.gasFeeEstimatesByChainId,
+          '0x5': {
+            gasFeeEstimates: {
+              high: {
+                suggestedMaxPriorityFeePerGas: '1',
+              },
+              networkCongestion: 0.7,
+            },
+          },
+        },
+        transaction: {
+          txParams: {
+            gas: '0x52081',
+            maxFeePerGas: '0x38D7EA4C68000',
+          },
+          userFeeLevel: 'medium',
+          dappSuggestedGasFees: {
+            maxPriorityFeePerGas: '0x38D7EA4C68000',
+            maxFeePerGas: '0x38D7EA4C68000',
+          },
+        },
+      },
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('network-busy-tooltip')).toBeInTheDocument();
+    });
+  });
 });

--- a/ui/pages/confirmations/components/transaction-alerts/transaction-alerts.js
+++ b/ui/pages/confirmations/components/transaction-alerts/transaction-alerts.js
@@ -35,7 +35,7 @@ const TransactionAlerts = ({
   txData,
   isUsingPaymaster,
 }) => {
-  const { estimateUsed, hasSimulationError, supportsEIP1559, isNetworkBusy } =
+  const { estimateUsed, hasSimulationError, supportsEIP1559 } =
     useGasFeeContext();
 
   ///: BEGIN:ONLY_INCLUDE_IF(build-main,build-beta,build-flask)
@@ -124,11 +124,6 @@ const TransactionAlerts = ({
           {t('lowPriorityMessage')}
         </BannerAlert>
       )}
-      {supportsEIP1559 && isNetworkBusy ? (
-        <BannerAlert severity={SEVERITIES.WARNING}>
-          {t('networkIsBusy')}
-        </BannerAlert>
-      ) : null}
       {isSendingZero && (
         <BannerAlert severity={SEVERITIES.WARNING}>
           {t('sendingZeroAmount', [currentTokenSymbol])}

--- a/ui/pages/confirmations/components/transaction-alerts/transaction-alerts.js
+++ b/ui/pages/confirmations/components/transaction-alerts/transaction-alerts.js
@@ -35,7 +35,11 @@ const TransactionAlerts = ({
   txData,
   isUsingPaymaster,
 }) => {
-  const { estimateUsed, hasSimulationError, supportsEIP1559 } =
+  const { estimateUsed, hasSimulationError,
+    ///: BEGIN:ONLY_INCLUDE_IF(build-main,build-beta,build-flask)
+    supportsEIP1559
+    ///: END:ONLY_INCLUDE_IF
+  } =
     useGasFeeContext();
 
   ///: BEGIN:ONLY_INCLUDE_IF(build-main,build-beta,build-flask)
@@ -96,8 +100,8 @@ const TransactionAlerts = ({
                 {pendingTransactions?.length === 1
                   ? t('pendingTransactionSingle', [pendingTransactions?.length])
                   : t('pendingTransactionMultiple', [
-                      pendingTransactions?.length,
-                    ])}
+                    pendingTransactions?.length,
+                  ])}
               </strong>{' '}
               {t('pendingTransactionInfo')}
               {t('learnCancelSpeeedup', [

--- a/ui/pages/confirmations/components/transaction-alerts/transaction-alerts.js
+++ b/ui/pages/confirmations/components/transaction-alerts/transaction-alerts.js
@@ -35,12 +35,13 @@ const TransactionAlerts = ({
   txData,
   isUsingPaymaster,
 }) => {
-  const { estimateUsed, hasSimulationError,
+  const {
+    estimateUsed,
+    hasSimulationError,
     ///: BEGIN:ONLY_INCLUDE_IF(build-main,build-beta,build-flask)
-    supportsEIP1559
+    supportsEIP1559,
     ///: END:ONLY_INCLUDE_IF
-  } =
-    useGasFeeContext();
+  } = useGasFeeContext();
 
   ///: BEGIN:ONLY_INCLUDE_IF(build-main,build-beta,build-flask)
   const pendingTransactions = useSelector(submittedPendingTransactionsSelector);
@@ -100,8 +101,8 @@ const TransactionAlerts = ({
                 {pendingTransactions?.length === 1
                   ? t('pendingTransactionSingle', [pendingTransactions?.length])
                   : t('pendingTransactionMultiple', [
-                    pendingTransactions?.length,
-                  ])}
+                      pendingTransactions?.length,
+                    ])}
               </strong>{' '}
               {t('pendingTransactionInfo')}
               {t('learnCancelSpeeedup', [

--- a/ui/pages/confirmations/components/transaction-alerts/transaction-alerts.test.js
+++ b/ui/pages/confirmations/components/transaction-alerts/transaction-alerts.test.js
@@ -333,52 +333,6 @@ describe('TransactionAlerts', () => {
         ).not.toBeInTheDocument();
       });
     });
-
-    describe('if isNetworkBusy from useGasFeeContext is truthy', () => {
-      it('informs the user that the network is busy', () => {
-        const { getByText } = render({
-          useGasFeeContextValue: {
-            supportsEIP1559: true,
-            isNetworkBusy: true,
-          },
-          componentProps: {
-            txData: {
-              txParams: {
-                value: '0x1',
-              },
-            },
-          },
-        });
-        expect(
-          getByText(
-            'Network is busy. Gas prices are high and estimates are less accurate.',
-          ),
-        ).toBeInTheDocument();
-      });
-    });
-
-    describe('if isNetworkBusy from useGasFeeContext is falsy', () => {
-      it('does not inform the user that the network is busy', () => {
-        const { queryByText } = render({
-          useGasFeeContextValue: {
-            supportsEIP1559: true,
-            isNetworkBusy: false,
-          },
-          componentProps: {
-            txData: {
-              txParams: {
-                value: '0x1',
-              },
-            },
-          },
-        });
-        expect(
-          queryByText(
-            'Network is busy. Gas prices are high and estimates are less accurate.',
-          ),
-        ).not.toBeInTheDocument();
-      });
-    });
   });
 
   describe('when supportsEIP1559 from useGasFeeContext is falsy', () => {
@@ -462,29 +416,6 @@ describe('TransactionAlerts', () => {
         expect(
           queryByText(
             'Future transactions will queue after this one. This price was last seen was some time ago.',
-          ),
-        ).not.toBeInTheDocument();
-      });
-    });
-
-    describe('if isNetworkBusy from useGasFeeContext is truthy', () => {
-      it('does not inform the user that the network is busy', () => {
-        const { queryByText } = render({
-          useGasFeeContextValue: {
-            supportsEIP1559: false,
-            isNetworkBusy: true,
-          },
-          componentProps: {
-            txData: {
-              txParams: {
-                value: '0x1',
-              },
-            },
-          },
-        });
-        expect(
-          queryByText(
-            'Network is busy. Gas prices are high and estimates are less accurate.',
           ),
         ).not.toBeInTheDocument();
       });


### PR DESCRIPTION
## **Description**
Replace "network is busy" warning with a tooltip. This will help clean up our current transactions confirmations while the redesign is in the works. Whenever the network is busy warning is shown on EIP-1559 confirmations. This excludes Legacy confirmations.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/24104?quickstart=1)

## **Related issues**

Fixes: [#2246](https://github.com/MetaMask/MetaMask-planning/issues/2246)

## **Manual testing steps**

1. Add/Enable Sepolia test network
2. Open testdapp and perform eip1559 transaction a couple of times till the busy icon is shown


## **Screenshots/Recordings**

### **Before**

<img width="357" alt="Screenshot 2024-04-17 at 13 23 53" src="https://github.com/MetaMask/metamask-extension/assets/44811/610e58a5-c05f-4ad7-8dcf-1218de3cabd5">

### **After**

<img width="359" alt="Screenshot 2024-04-17 at 13 21 56" src="https://github.com/MetaMask/metamask-extension/assets/44811/ce6ec437-ccdd-45ba-bd97-1dc99cc3d7b1">

<img width="364" alt="Screenshot 2024-04-18 at 10 46 37" src="https://github.com/MetaMask/metamask-extension/assets/44811/bedbb85f-5749-4ea0-8255-df1f98ff3c68">

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
