### PR TITLE
feat: Confirmation redesign - Remove the scheme ("https://","http://") from the InfoRowUrl value

### DIFF
--- a/ui/components/app/confirm/info/row/__snapshots__/url.test.tsx.snap
+++ b/ui/components/app/confirm/info/row/__snapshots__/url.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ConfirmInfoRowUrl renders a URL, protocol, and warning icon when the protocol is "http" 1`] = `
+exports[`ConfirmInfoRowUrl renders a URL, and warning icon when the protocol is "http" 1`] = `
 <div>
   <div
     class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-wrap-wrap mm-box--align-items-center"
@@ -17,7 +17,7 @@ exports[`ConfirmInfoRowUrl renders a URL, protocol, and warning icon when the pr
     <p
       class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
     >
-      http://www.example.com/
+      www.example.com/
     </p>
   </div>
 </div>
@@ -31,7 +31,7 @@ exports[`ConfirmInfoRowUrl should match snapshot 1`] = `
     <p
       class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
     >
-      https://example.com
+      example.com
     </p>
   </div>
 </div>

--- a/ui/components/app/confirm/info/row/url.test.tsx
+++ b/ui/components/app/confirm/info/row/url.test.tsx
@@ -14,21 +14,21 @@ describe('ConfirmInfoRowUrl', () => {
     const { getByText } = render(
       <ConfirmInfoRowUrl url="https://www.example.com" />,
     );
-    expect(getByText('https://www.example.com')).toBeInTheDocument();
+    expect(getByText('www.example.com')).toBeInTheDocument();
   });
 
   it('renders a URL with a path', () => {
     const { getByText } = render(
       <ConfirmInfoRowUrl url="https://www.example.com/foo" />,
     );
-    expect(getByText('https://www.example.com/foo')).toBeInTheDocument();
+    expect(getByText('www.example.com/foo')).toBeInTheDocument();
   });
 
-  it('renders a URL, protocol, and warning icon when the protocol is "http"', () => {
+  it('renders a URL, and warning icon when the protocol is "http"', () => {
     const { container, getByText } = render(
       <ConfirmInfoRowUrl url="http://www.example.com/" />,
     );
-    expect(getByText('http://www.example.com/')).toBeInTheDocument();
+    expect(getByText('www.example.com/')).toBeInTheDocument();
     expect(getByText('HTTP')).toBeInTheDocument();
     expect(container.querySelector('.mm-icon')).toBeInTheDocument();
     expect(container).toMatchSnapshot();

--- a/ui/components/app/confirm/info/row/url.tsx
+++ b/ui/components/app/confirm/info/row/url.tsx
@@ -32,7 +32,7 @@ export const ConfirmInfoRowUrl = ({ url }: ConfirmInfoRowUrlProps) => {
 
   const isHTTP = urlObject?.protocol === 'http:';
 
-  const urlWithoutProtocol = url.replace(/https?:\/\//u, '');
+  const urlWithoutProtocol = url?.replace(/https?:\/\//u, '');
 
   return (
     <Box

--- a/ui/components/app/confirm/info/row/url.tsx
+++ b/ui/components/app/confirm/info/row/url.tsx
@@ -32,6 +32,8 @@ export const ConfirmInfoRowUrl = ({ url }: ConfirmInfoRowUrlProps) => {
 
   const isHTTP = urlObject?.protocol === 'http:';
 
+  const urlWithoutProtocol = url.replace(/https?:\/\//, '');
+
   return (
     <Box
       display={Display.Flex}
@@ -59,7 +61,7 @@ export const ConfirmInfoRowUrl = ({ url }: ConfirmInfoRowUrlProps) => {
           HTTP
         </Text>
       )}
-      <Text color={TextColor.inherit}>{url}</Text>
+      <Text color={TextColor.inherit}>{urlWithoutProtocol}</Text>
     </Box>
   );
 };

--- a/ui/components/app/confirm/info/row/url.tsx
+++ b/ui/components/app/confirm/info/row/url.tsx
@@ -32,7 +32,7 @@ export const ConfirmInfoRowUrl = ({ url }: ConfirmInfoRowUrlProps) => {
 
   const isHTTP = urlObject?.protocol === 'http:';
 
-  const urlWithoutProtocol = url.replace(/https?:\/\//, '');
+  const urlWithoutProtocol = url.replace(/https?:\/\//u, '');
 
   return (
     <Box

--- a/ui/pages/confirmations/components/confirm/info/__snapshots__/info.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/info/__snapshots__/info.test.tsx.snap
@@ -39,7 +39,7 @@ exports[`Info renders info section for personal sign request 1`] = `
         <p
           class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
         >
-          https://metamask.github.io
+          metamask.github.io
         </p>
       </div>
     </div>
@@ -113,7 +113,7 @@ exports[`Info renders info section for typed sign request 1`] = `
         <p
           class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
         >
-          https://metamask.github.io
+          metamask.github.io
         </p>
       </div>
     </div>

--- a/ui/pages/confirmations/components/confirm/info/personal-sign/__snapshots__/personal-sign.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/info/personal-sign/__snapshots__/personal-sign.test.tsx.snap
@@ -39,7 +39,7 @@ exports[`PersonalSignInfo handle reverse string properly 1`] = `
         <p
           class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
         >
-          https://metamask.github.io
+          metamask.github.io
         </p>
       </div>
     </div>
@@ -113,7 +113,7 @@ exports[`PersonalSignInfo renders correctly for personal sign request 1`] = `
         <p
           class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
         >
-          https://metamask.github.io
+          metamask.github.io
         </p>
       </div>
     </div>

--- a/ui/pages/confirmations/components/confirm/info/typed-sign-v1/__snapshots__/typed-sign-v1.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/info/typed-sign-v1/__snapshots__/typed-sign-v1.test.tsx.snap
@@ -39,7 +39,7 @@ exports[`TypedSignInfo correctly renders typed sign data request 1`] = `
         <p
           class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
         >
-          https://metamask.github.io
+          metamask.github.io
         </p>
       </div>
     </div>

--- a/ui/pages/confirmations/components/confirm/info/typed-sign/__snapshots__/typed-sign.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/info/typed-sign/__snapshots__/typed-sign.test.tsx.snap
@@ -41,7 +41,7 @@ exports[`TypedSignInfo renders origin for typed sign data request 1`] = `
         <p
           class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
         >
-          https://metamask.github.io
+          metamask.github.io
         </p>
       </div>
     </div>
@@ -460,7 +460,7 @@ exports[`TypedSignInfo should render message for typed sign v3 request 1`] = `
         <p
           class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
         >
-          https://metamask.github.io
+          metamask.github.io
         </p>
       </div>
     </div>
@@ -879,7 +879,7 @@ exports[`TypedSignInfo should render message for typed sign v4 request 1`] = `
         <p
           class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
         >
-          https://metamask.github.io
+          metamask.github.io
         </p>
       </div>
     </div>

--- a/ui/pages/confirmations/confirm/__snapshots__/confirm.test.tsx.snap
+++ b/ui/pages/confirmations/confirm/__snapshots__/confirm.test.tsx.snap
@@ -178,7 +178,7 @@ exports[`Confirm matches snapshot for personal signature type 1`] = `
                 <p
                   class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
                 >
-                  https://metamask.github.io
+                  metamask.github.io
                 </p>
               </div>
             </div>
@@ -410,7 +410,7 @@ exports[`Confirm should match snapshot for typed sign signature 1`] = `
                 <p
                   class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
                 >
-                  https://metamask.github.io
+                  metamask.github.io
                 </p>
               </div>
             </div>


### PR DESCRIPTION
## **Description**

Remove the scheme ("https://","http://") from the InfoRowUrl value. If the URL displayed is "HTTP" it is shown as a label to the left of the text value. There is no need to display the scheme of the URL text value.

Figma: https://www.figma.com/file/7kYok9B46ohR6h47cksRAz/Confirmation-redesign-V1?type=design&node-id=1735-8556&mode=design&t=6PRcdkYIuz1RF6ek-0
Storybook Prod: https://metamask.github.io/metamask-storybook/?path=/docs/components-app-confirm-inforowurl--docs

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/24105?quickstart=1)

## **Related issues**

Fixes: #23968 

## **Manual testing steps**

1. Enable conf redesign in .metamaskrc (ENABLE_CONFIRMATION_REDESIGN=1)
2. Run metamask
3. Open an http url
4. Type the code below in the console
5. You should see the HTTP label
6. Open testdapp and click on Personal Sign
7. You should not see the HTTP label

```
ethereum.request({
  method: 'wallet_requestPermissions',
  params: [{ eth_accounts: {} }],
});


const msg = "Hello World".toString('hex');

const from = [the connected account]

ethereum.request({
  method: 'personal_sign',
  params: [msg, from, 'Example password'],
});
```

## **Screenshots/Recordings**

### **Before**

<img width="365" alt="Screenshot 2024-04-18 at 11 08 12" src="https://github.com/MetaMask/metamask-extension/assets/44811/ff054fb6-4700-4e4b-84ac-51b4de752d46">


### **After**

<img width="363" alt="Screenshot 2024-04-18 at 11 14 27" src="https://github.com/MetaMask/metamask-extension/assets/44811/5b0c0885-eba3-4ac3-8507-31d1f47d1c8d">

<img width="365" alt="Screenshot 2024-04-18 at 11 15 00" src="https://github.com/MetaMask/metamask-extension/assets/44811/9e7c72aa-b310-4021-b5f5-d5a4b0eb3085">


## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
