### PR TITLE
fix: ensure ppom works on mv3 builds

### DIFF
--- a/app/manifest/v3/chrome.json
+++ b/app/manifest/v3/chrome.json
@@ -1,6 +1,6 @@
 {
   "content_security_policy": {
-    "extension_pages": "script-src 'self'; object-src 'none'; frame-ancestors 'none';"
+    "extension_pages": "script-src 'self' 'wasm-unsafe-eval'; object-src 'none'; frame-ancestors 'none';"
   },
   "externally_connectable": {
     "matches": ["https://metamask.io/*"],

--- a/development/build/static.js
+++ b/development/build/static.js
@@ -208,7 +208,7 @@ function getCopyTargets(
     allCopyTargets.push({
       src: getPathInsideNodeModules('@blockaid/ppom_release', '/'),
       pattern: '*.wasm',
-      dest: '',
+      dest: process.env.ENABLE_MV3 ? 'scripts/' : '',
     });
   }
 


### PR DESCRIPTION
## **Description**

This PR fixes ppom/blockaid on mv3 builds. There were two separate problems to fix:
1. The content_security_policy in the manifest needed to be updated to include `'wasm-unsafe-eval'`, as is done in the MV2 manifest.
2. The `input = fetch(input);` call in `__wbg_init` in `app/scripts/lib/ppom/ppom.js` was being called with the file path `./ppom_bg.wasm`. However, `app-init.js` has recently been moved inside of the `scripts` directory within the build (i.e. within the dist and build directories), so the path to fetch, from within the mv3 service worker, would have to be `../ppom_bg.wasm`. The fix is to move the ppom_bg.wasm file into the `scripts` directory as well, when building for mv3.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/24115?quickstart=1)

## **Related issues**

Fixes:  https://github.com/MetaMask/MetaMask-planning/issues/2377

## **Manual testing steps**

1. `yarn dist:mv3`
2. Install with an account that has enough mainnet eth to send a transaction (you don't actually need to send one, you just need to create one and can then reject it)
3. Go to https://metamask.github.io/test-dapp/
4. Connect and then click "Malicious Eth Transfer"
5. You should see a blockaid warning

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
