### PR TITLE
fix: simulation erc20 decimals error

### DIFF
--- a/ui/pages/confirmations/components/simulation-details/useBalanceChanges.test.ts
+++ b/ui/pages/confirmations/components/simulation-details/useBalanceChanges.test.ts
@@ -72,9 +72,12 @@ describe('useBalanceChanges', () => {
         [ERC20_TOKEN_ADDRESS_1_MOCK]: ERC20_DECIMALS_1_MOCK,
         [ERC20_TOKEN_ADDRESS_2_MOCK]: ERC20_DECIMALS_2_MOCK,
       };
-      return Promise.resolve({
-        decimals: decimalMap[address]?.toString() ?? undefined,
-      });
+      if (decimalMap[address]) {
+        return Promise.resolve({
+          decimals: decimalMap[address]?.toString() ?? undefined,
+        });
+      }
+      return Promise.reject(new Error('Unable to determine token standard'));
     });
     mockGetConversionRate.mockReturnValue(ETH_TO_FIAT_RATE);
     mockFetchTokenExchangeRates.mockResolvedValue({

--- a/ui/pages/confirmations/components/simulation-details/useBalanceChanges.ts
+++ b/ui/pages/confirmations/components/simulation-details/useBalanceChanges.ts
@@ -52,21 +52,28 @@ function getAssetAmount(
   return { isNegative, quantity, decimals, numeric };
 }
 
+// Fetches the decimals for the given token address.
+async function fetchErc20Decimals(address: Hex): Promise<number> {
+  try {
+    const { decimals } = await getTokenStandardAndDetails(address);
+    return decimals ? parseInt(decimals, 10) : ERC20_DEFAULT_DECIMALS;
+  } catch {
+    return ERC20_DEFAULT_DECIMALS;
+  }
+}
+
 // Fetches token details for all the token addresses in the SimulationTokenBalanceChanges
-async function fetchErc20Decimals(
+async function fetchAllErc20Decimals(
   addresses: Hex[],
 ): Promise<Record<Hex, number>> {
   const uniqueAddresses = [
-    ...new Set(addresses.map((address) => address.toLowerCase())),
+    ...new Set(addresses.map((address) => address.toLowerCase() as Hex)),
   ];
-  const tokenInfos = await Promise.all(
-    uniqueAddresses.map((address) => getTokenStandardAndDetails(address)),
+  const allDecimals = await Promise.all(
+    uniqueAddresses.map(fetchErc20Decimals),
   );
   return Object.fromEntries(
-    tokenInfos.map(({ decimals }, index) => [
-      uniqueAddresses[index],
-      decimals ? parseInt(decimals, 10) : ERC20_DEFAULT_DECIMALS,
-    ]),
+    allDecimals.map((decimals, i) => [uniqueAddresses[i], decimals]),
   );
 }
 
@@ -147,7 +154,7 @@ export const useBalanceChanges = (
     .map((tbc) => tbc.address);
 
   const erc20Decimals = useAsyncResultOrThrow(
-    () => fetchErc20Decimals(erc20TokenAddresses),
+    () => fetchAllErc20Decimals(erc20TokenAddresses),
     [JSON.stringify(erc20TokenAddresses)],
   );
 


### PR DESCRIPTION
## **Description**
Previously the simulation code assumed that `getTokenStandardAndDetails` returns undefined when it cannot determine the decimals for a contract. 

This PR surrounds the call to `getTokenStandardAndDetails` in a try / catch and, if it fails, returns the default ERC20 decimals.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/24116?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/2388

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
