### PR TITLE
fix: Reduce Dapp Viewed log events

### DIFF
--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -461,6 +461,11 @@ export async function loadStateFromPersistence() {
  * @returns
  */
 function shouldEmitEvent(metaMetricsId) {
+  // If the metametricsId is not set, we should not emit the event.
+  if (!metaMetricsId) {
+    return false;
+  }
+
   const lastPart = metaMetricsId.slice(-4);
 
   // Convert the last part from hexadecimal to an integer.

--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -61,7 +61,11 @@ import rawFirstTimeState from './first-time-state';
 import getFirstPreferredLangCode from './lib/get-first-preferred-lang-code';
 import getObjStructure from './lib/getObjStructure';
 import setupEnsIpfsResolver from './lib/ens-ipfs/setup';
-import { deferredPromise, getPlatform } from './lib/util';
+import {
+  deferredPromise,
+  getPlatform,
+  shouldEmitDappViewedEvent,
+} from './lib/util';
 
 /* eslint-enable import/first */
 
@@ -454,29 +458,6 @@ export async function loadStateFromPersistence() {
 }
 
 /**
- * Determines whether to emit a MetaMetrics event for a given metaMetricsId.
- * Relies on the last 4 characters of the metametricsId. Assumes the IDs are evenly distributed.
- *
- * @param {*} metaMetricsId - The metametricsId to use for the event.
- * @returns
- */
-function shouldEmitEvent(metaMetricsId) {
-  // If the metametricsId is not set, we should not emit the event.
-  if (!metaMetricsId) {
-    return false;
-  }
-
-  const lastPart = metaMetricsId.slice(-4);
-
-  // Convert the last part from hexadecimal to an integer.
-  const numericValue = parseInt(lastPart, 16);
-
-  // Check if numericValue modulo 100 equals 0.
-  // This condition will be true for approximately 1 out of every 100 metametricsIds
-  return numericValue % 100 === 0;
-}
-
-/**
  * Emit event of DappViewed,
  * which should only be tracked only after a user opts into metrics and connected to the dapp
  *
@@ -489,7 +470,8 @@ function emitDappViewedMetricEvent(
   connectSitePermissions,
   preferencesController,
 ) {
-  if (!shouldEmitEvent(controller.metaMetricsController.state.metaMetricsId)) {
+  const { metaMetricsId } = controller.metaMetricsController.state;
+  if (!shouldEmitDappViewedEvent(metaMetricsId)) {
     return;
   }
 

--- a/app/scripts/lib/util.test.js
+++ b/app/scripts/lib/util.test.js
@@ -15,6 +15,7 @@ import {
 } from '../../../shared/constants/app';
 import { isPrefixedFormattedHexString } from '../../../shared/modules/network.utils';
 import {
+  shouldEmitDappViewedEvent,
   addUrlProtocolPrefix,
   deferredPromise,
   formatTxMetaForRpcResult,
@@ -252,6 +253,19 @@ describe('app utils', () => {
       reject(new Error('different message'));
 
       await expect(promise).resolves.toBe('test');
+    });
+  });
+
+  describe('shouldEmitDappViewedEvent', () => {
+    it('should return true for valid metrics IDs', () => {
+      expect(shouldEmitDappViewedEvent('fake-metrics-id-fd20')).toStrictEqual(
+        true,
+      );
+    });
+    it('should return false for invalid metrics IDs', () => {
+      expect(
+        shouldEmitDappViewedEvent('fake-metrics-id-invalid'),
+      ).toStrictEqual(false);
     });
   });
 

--- a/app/scripts/lib/util.ts
+++ b/app/scripts/lib/util.ts
@@ -276,6 +276,25 @@ export function isWebUrl(urlString: string): boolean {
   );
 }
 
+/**
+ * Determines whether to emit a MetaMetrics event for a given metaMetricsId.
+ * Relies on the last 4 characters of the metametricsId. Assumes the IDs are evenly distributed.
+ * If metaMetricsIds are distributed evenly, this should be a 1% sample rate
+ *
+ * @param metaMetricsId - The metametricsId to use for the event.
+ * @returns Whether to emit the event or not.
+ */
+export function shouldEmitDappViewedEvent(metaMetricsId: string): boolean {
+  if (metaMetricsId === null) {
+    return false;
+  }
+
+  const lastFourCharacters = metaMetricsId.slice(-4);
+  const lastFourCharactersAsNumber = parseInt(lastFourCharacters, 16);
+
+  return lastFourCharactersAsNumber % 100 === 0;
+}
+
 type FormattedTransactionMeta = {
   blockHash: string | null;
   blockNumber: string | null;

--- a/test/e2e/tests/metrics/dapp-viewed.spec.js
+++ b/test/e2e/tests/metrics/dapp-viewed.spec.js
@@ -75,7 +75,7 @@ describe('Dapp viewed Event @no-mmi', function () {
         dapp: true,
         fixtures: new FixtureBuilder()
           .withMetaMetricsController({
-            metaMetricsId: 'fake-metrics-id',
+            metaMetricsId: 'fake-metrics-id-fd20', // 1% sample rate for dapp viewed event
             participateInMetaMetrics: true,
           })
           .build(),
@@ -111,7 +111,7 @@ describe('Dapp viewed Event @no-mmi', function () {
         dapp: true,
         fixtures: new FixtureBuilder()
           .withMetaMetricsController({
-            metaMetricsId: 'fake-metrics-id',
+            metaMetricsId: 'fake-metrics-id-fd20',
             participateInMetaMetrics: true,
           })
           .build(),
@@ -150,7 +150,7 @@ describe('Dapp viewed Event @no-mmi', function () {
         dapp: true,
         fixtures: new FixtureBuilder()
           .withMetaMetricsController({
-            metaMetricsId: 'fake-metrics-id',
+            metaMetricsId: 'fake-metrics-id-fd20',
             participateInMetaMetrics: true,
           })
           .build(),
@@ -194,7 +194,7 @@ describe('Dapp viewed Event @no-mmi', function () {
         dapp: true,
         fixtures: new FixtureBuilder()
           .withMetaMetricsController({
-            metaMetricsId: 'fake-metrics-id',
+            metaMetricsId: 'fake-metrics-id-fd20',
             participateInMetaMetrics: true,
           })
           .build(),
@@ -232,7 +232,7 @@ describe('Dapp viewed Event @no-mmi', function () {
         dapp: true,
         fixtures: new FixtureBuilder()
           .withMetaMetricsController({
-            metaMetricsId: 'fake-metrics-id',
+            metaMetricsId: 'fake-metrics-id-fd20',
             participateInMetaMetrics: true,
           })
           .build(),
@@ -286,7 +286,7 @@ describe('Dapp viewed Event @no-mmi', function () {
         dapp: true,
         fixtures: new FixtureBuilder()
           .withMetaMetricsController({
-            metaMetricsId: 'fake-metrics-id',
+            metaMetricsId: 'fake-metrics-id-fd20',
             participateInMetaMetrics: true,
           })
           .build(),

--- a/test/e2e/tests/metrics/dapp-viewed.spec.js
+++ b/test/e2e/tests/metrics/dapp-viewed.spec.js
@@ -65,6 +65,34 @@ const waitForDappConnected = async (driver) => {
 };
 
 describe('Dapp viewed Event @no-mmi', function () {
+  const validFakeMetricsId = 'fake-metrics-fd20';
+  it('is not sent when metametrics ID is not valid', async function () {
+    async function mockSegment(mockServer) {
+      return [await mockedDappViewedEndpoint(mockServer)];
+    }
+
+    await withFixtures(
+      {
+        dapp: true,
+        fixtures: new FixtureBuilder()
+          .withMetaMetricsController({
+            metaMetricsId: 'invalid-metrics-id',
+            participateInMetaMetrics: true,
+          })
+          .build(),
+        title: this.test.fullTitle(),
+        testSpecificMock: mockSegment,
+      },
+      async ({ driver, mockedEndpoint: mockedEndpoints }) => {
+        await driver.navigate();
+        await unlockWallet(driver);
+        await connectToDapp(driver);
+        const events = await getEventPayloads(driver, mockedEndpoints);
+        assert.equal(events.length, 0);
+      },
+    );
+  });
+
   it('is sent when navigating to dapp with no account connected', async function () {
     async function mockSegment(mockServer) {
       return [await mockedDappViewedEndpoint(mockServer)];
@@ -75,7 +103,7 @@ describe('Dapp viewed Event @no-mmi', function () {
         dapp: true,
         fixtures: new FixtureBuilder()
           .withMetaMetricsController({
-            metaMetricsId: 'fake-metrics-id-fd20', // 1% sample rate for dapp viewed event
+            metaMetricsId: validFakeMetricsId, // 1% sample rate for dapp viewed event
             participateInMetaMetrics: true,
           })
           .build(),
@@ -111,7 +139,7 @@ describe('Dapp viewed Event @no-mmi', function () {
         dapp: true,
         fixtures: new FixtureBuilder()
           .withMetaMetricsController({
-            metaMetricsId: 'fake-metrics-id-fd20',
+            metaMetricsId: validFakeMetricsId,
             participateInMetaMetrics: true,
           })
           .build(),
@@ -150,7 +178,7 @@ describe('Dapp viewed Event @no-mmi', function () {
         dapp: true,
         fixtures: new FixtureBuilder()
           .withMetaMetricsController({
-            metaMetricsId: 'fake-metrics-id-fd20',
+            metaMetricsId: validFakeMetricsId,
             participateInMetaMetrics: true,
           })
           .build(),
@@ -194,7 +222,7 @@ describe('Dapp viewed Event @no-mmi', function () {
         dapp: true,
         fixtures: new FixtureBuilder()
           .withMetaMetricsController({
-            metaMetricsId: 'fake-metrics-id-fd20',
+            metaMetricsId: validFakeMetricsId,
             participateInMetaMetrics: true,
           })
           .build(),
@@ -232,7 +260,7 @@ describe('Dapp viewed Event @no-mmi', function () {
         dapp: true,
         fixtures: new FixtureBuilder()
           .withMetaMetricsController({
-            metaMetricsId: 'fake-metrics-id-fd20',
+            metaMetricsId: validFakeMetricsId,
             participateInMetaMetrics: true,
           })
           .build(),
@@ -286,7 +314,7 @@ describe('Dapp viewed Event @no-mmi', function () {
         dapp: true,
         fixtures: new FixtureBuilder()
           .withMetaMetricsController({
-            metaMetricsId: 'fake-metrics-id-fd20',
+            metaMetricsId: validFakeMetricsId,
             participateInMetaMetrics: true,
           })
           .build(),

--- a/test/e2e/tests/metrics/permissions-approved.spec.js
+++ b/test/e2e/tests/metrics/permissions-approved.spec.js
@@ -50,7 +50,7 @@ describe('Permissions Approved Event', function () {
         dapp: true,
         fixtures: new FixtureBuilder()
           .withMetaMetricsController({
-            metaMetricsId: 'fake-metrics-id',
+            metaMetricsId: 'fake-metrics-fd20',
             participateInMetaMetrics: true,
           })
           .build(),


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
This PR attempts to throttle the "Dapp Viewed" event to a smaller sample rate of 1%. Currently it's at 100%.
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->
We introduce a util function called `shouldEmitDappViewedEvent` to filter in multiple places, and also fixed any resulting e2e test failures with "fake-metrics-id-fd20" which was necessary to pass the `shouldEmitDappViewedEvent()` filter in any tests that called `requestEthereumAccountsHandler()` in `request-accounts.js` or `emitDappViewedMetricEvent()` in `background.js`.
Added a simple unit test for the `shouldEmitDappViewedEvent` helper for passing and failing MetaMetrics IDs.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/24118?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/2353

## **Manual testing steps**

1. Run app with `yarn start`
2. Open some new tabs, and pull up the [Test Dapp](https://metamask.github.io/test-dapp/) in one of those tabs, 
3. When switching between tabs to the test dapp, if your metametricsId does not pass the sampling filter, there should be no new "Dapp Viewed" event logged for your Metametrics ID.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [X] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
