### PR TITLE
feat: set default 4337 entrypoint in flask

### DIFF
--- a/builds.yml
+++ b/builds.yml
@@ -70,6 +70,7 @@ buildTypes:
       - INFURA_ENV_KEY_REF: INFURA_FLASK_PROJECT_ID
       - SEGMENT_WRITE_KEY_REF: SEGMENT_FLASK_WRITE_KEY
       - ACCOUNT_SNAPS_DIRECTORY_URL: https://metamask.github.io/snaps-directory-staging/main/account-management
+      - EIP_4337_ENTRYPOINT: '0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789'
     isPrerelease: true
     manifestOverrides: ./app/build-types/flask/manifest/
     buildNameOverride: MetaMask Flask

--- a/development/build/set-environment-variables.js
+++ b/development/build/set-environment-variables.js
@@ -26,9 +26,9 @@ module.exports.setEnvironmentVariables = function setEnvironmentVariables({
 }) {
   variables.set({
     DEBUG: isDevBuild || isTestBuild ? variables.getMaybe('DEBUG') : undefined,
-    EIP_4337_ENTRYPOINT:
-      variables.getMaybe('EIP_4337_ENTRYPOINT') ||
-      (isTestBuild ? '0x18b06605539dc02ecD3f7AB314e38eB7c1dA5c9b' : undefined),
+    EIP_4337_ENTRYPOINT: isTestBuild
+      ? '0x18b06605539dc02ecD3f7AB314e38eB7c1dA5c9b'
+      : variables.getMaybe('EIP_4337_ENTRYPOINT'),
     IN_TEST: isTestBuild,
     INFURA_PROJECT_ID: getInfuraProjectId({
       buildType,


### PR DESCRIPTION
## **Description**

This PR adds a default value for the `EIP_4337_ENTRYPOINT` in flask

## **Related issues**

## **Manual testing steps**

1. Install the snap from the AA reference snap and set it up in MM Flask
2. Add bundler URL in the companion Dapp
3. Create an account
4. Send a transaction from within MM

## **Screenshots/Recordings**

Not applicable

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
