### PR TITLE
fix: duplicate simulation metrics [DUPLICATE]

### DIFF
--- a/ui/pages/confirmations/components/simulation-details/simulation-details.tsx
+++ b/ui/pages/confirmations/components/simulation-details/simulation-details.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import {
   SimulationData,
   SimulationError,
@@ -30,6 +30,7 @@ import { useSimulationMetrics } from './useSimulationMetrics';
 export type SimulationDetailsProps = {
   simulationData?: SimulationData;
   transactionId: string;
+  enableMetrics?: boolean;
 };
 
 /**
@@ -146,38 +147,27 @@ const SimulationDetailsLayout: React.FC<{
   </Box>
 );
 
-function useLoadingTime() {
-  const [loadingStart] = useState(Date.now());
-  const [loadingTime, setLoadingTime] = useState<number | undefined>();
-
-  const setLoadingComplete = () => {
-    if (loadingTime === undefined) {
-      setLoadingTime((Date.now() - loadingStart) / 1000);
-    }
-  };
-
-  return { loadingTime, setLoadingComplete };
-}
-
 /**
  * Preview of a transaction's effects using simulation data.
  *
  * @param props
  * @param props.simulationData - The simulation data to display.
  * @param props.transactionId - The ID of the transaction being simulated.
+ * @param props.enableMetrics - Whether to enable simulation metrics.
  */
 export const SimulationDetails: React.FC<SimulationDetailsProps> = ({
   simulationData,
   transactionId,
+  enableMetrics = false,
 }: SimulationDetailsProps) => {
   const t = useI18nContext();
-  const { loadingTime, setLoadingComplete } = useLoadingTime();
   const balanceChangesResult = useBalanceChanges(simulationData);
   const loading = !simulationData || balanceChangesResult.pending;
 
   useSimulationMetrics({
+    enableMetrics,
     balanceChanges: balanceChangesResult.value,
-    loadingTime,
+    loading,
     simulationData,
     transactionId,
   });
@@ -189,8 +179,6 @@ export const SimulationDetails: React.FC<SimulationDetailsProps> = ({
       ></SimulationDetailsLayout>
     );
   }
-
-  setLoadingComplete();
 
   const { error } = simulationData;
 

--- a/ui/pages/confirmations/components/simulation-details/useLoadingTime.test.ts
+++ b/ui/pages/confirmations/components/simulation-details/useLoadingTime.test.ts
@@ -1,0 +1,43 @@
+import { renderHook, act } from '@testing-library/react-hooks';
+import { useLoadingTime } from './useLoadingTime';
+
+describe('useLoadingTime', () => {
+  beforeAll(() => {
+    jest.useFakeTimers();
+  });
+
+  afterAll(() => {
+    jest.useRealTimers();
+  });
+
+  it('should return the loading time when setLoadingComplete is called', () => {
+    const { result } = renderHook(() => useLoadingTime());
+
+    expect(result.current.loadingTime).toBeUndefined();
+
+    act(() => {
+      jest.advanceTimersByTime(2000);
+      result.current.setLoadingComplete();
+    });
+
+    expect(result.current.loadingTime).toBeCloseTo(2);
+  });
+
+  it('should not update the loading time if setLoadingComplete is called multiple times', () => {
+    const { result } = renderHook(() => useLoadingTime());
+
+    act(() => {
+      jest.advanceTimersByTime(1000);
+      result.current.setLoadingComplete();
+    });
+
+    expect(result.current.loadingTime).toBeCloseTo(1);
+
+    act(() => {
+      jest.advanceTimersByTime(1000);
+      result.current.setLoadingComplete();
+    });
+
+    expect(result.current.loadingTime).toBeCloseTo(1);
+  });
+});

--- a/ui/pages/confirmations/components/simulation-details/useLoadingTime.ts
+++ b/ui/pages/confirmations/components/simulation-details/useLoadingTime.ts
@@ -1,0 +1,13 @@
+import { useState } from 'react';
+
+export function useLoadingTime() {
+  const [loadingStart] = useState(Date.now());
+  const [loadingTime, setLoadingTime] = useState<number | undefined>();
+
+  const setLoadingComplete = () => {
+    if (loadingTime === undefined) {
+      setLoadingTime((Date.now() - loadingStart) / 1000);
+    }
+  };
+  return { loadingTime, setLoadingComplete };
+}

--- a/ui/pages/confirmations/components/simulation-details/useSimulationMetrics.ts
+++ b/ui/pages/confirmations/components/simulation-details/useSimulationMetrics.ts
@@ -18,12 +18,14 @@ import {
 } from '../../../../../shared/constants/metametrics';
 import { calculateTotalFiat } from './fiat-display';
 import { BalanceChange } from './types';
+import { useLoadingTime } from './useLoadingTime';
 
 export type UseSimulationMetricsProps = {
   balanceChanges: BalanceChange[];
-  loadingTime?: number;
+  loading: boolean;
   simulationData?: SimulationData;
   transactionId: string;
+  enableMetrics: boolean;
 };
 
 export enum SimulationResponseType {
@@ -54,10 +56,17 @@ export enum PetnameType {
 
 export function useSimulationMetrics({
   balanceChanges,
-  loadingTime,
+  loading,
   simulationData,
   transactionId,
+  enableMetrics,
 }: UseSimulationMetricsProps) {
+  const { loadingTime, setLoadingComplete } = useLoadingTime();
+
+  if (!loading) {
+    setLoadingComplete();
+  }
+
   const displayNameRequests: UseDisplayNameRequest[] = balanceChanges.map(
     ({ asset }) => ({
       value: asset.address ?? '',
@@ -113,10 +122,12 @@ export function useSimulationMetrics({
 
   const params = { properties, sensitiveProperties };
 
-  const shouldSkipMetrics = [
-    SimulationErrorCode.ChainNotSupported,
-    SimulationErrorCode.Disabled,
-  ].includes(simulationData?.error?.code as SimulationErrorCode);
+  const shouldSkipMetrics =
+    !enableMetrics ||
+    [
+      SimulationErrorCode.ChainNotSupported,
+      SimulationErrorCode.Disabled,
+    ].includes(simulationData?.error?.code as SimulationErrorCode);
 
   useEffect(() => {
     if (shouldSkipMetrics) {
@@ -129,6 +140,8 @@ export function useSimulationMetrics({
     updateTransactionEventFragment,
     transactionId,
     JSON.stringify(params),
+    loading,
+    setLoadingComplete,
   ]);
 }
 

--- a/ui/pages/confirmations/components/simulation-details/useSimulationMetrics.ts
+++ b/ui/pages/confirmations/components/simulation-details/useSimulationMetrics.ts
@@ -140,8 +140,6 @@ export function useSimulationMetrics({
     updateTransactionEventFragment,
     transactionId,
     JSON.stringify(params),
-    loading,
-    setLoadingComplete,
   ]);
 }
 

--- a/ui/pages/confirmations/confirm-transaction-base/confirm-transaction-base.component.js
+++ b/ui/pages/confirmations/confirm-transaction-base/confirm-transaction-base.component.js
@@ -493,6 +493,7 @@ export default class ConfirmTransactionBase extends Component {
       <SimulationDetails
         simulationData={simulationData}
         transactionId={txData.id}
+        enableMetrics
       />
     );
 


### PR DESCRIPTION
> [!WARNING]
> This is a duplicate of https://github.com/MetaMask/metamask-extension/pull/24194
> **This PR was merged into a feature branch and was not merged into develop.** 
## **Description**
This PR addresses the issue of duplicate or replaced metrics when the SimulationDetails component is used on the smart transaction status confirmation.

Changes:

* Add `enableMetrics` property on the SimulationDetails component which is `false` by default.

By making these changes, we prevent redundant metrics from being tracked.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/24167?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/2373

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
