### PR TITLE
fix: transaction created after a pending signature request does not load on page and show continuous spinner

### DIFF
--- a/ui/pages/confirmations/components/confirm-page-container/confirm-page-container-navigation/confirm-page-container-navigation.component.js
+++ b/ui/pages/confirmations/components/confirm-page-container/confirm-page-container-navigation/confirm-page-container-navigation.component.js
@@ -52,8 +52,9 @@ const ConfirmPageContainerNavigation = () => {
   const onNextTx = (txId) => {
     if (txId) {
       dispatch(clearConfirmTransaction());
+      const position = enumUnapprovedTxs.indexOf(txId);
       history.push(
-        unconfirmedTransactions[currentPosition]?.msgParams
+        unconfirmedTransactions[position]?.msgParams
           ? `${CONFIRM_TRANSACTION_ROUTE}/${txId}${SIGNATURE_REQUEST_PATH}`
           : `${CONFIRM_TRANSACTION_ROUTE}/${txId}`,
       );


### PR DESCRIPTION
## **Description**

Whenever I have a pending Signature, if I then trigger a transaction from a dapp, I see MM stays loading indefinetly

## **Related issues**

Fixes: MetaMask/metamask-extension#24122

## **Manual testing steps**

1. Go to the test dapp
2. Trigger a Signature
3. Do not Accept/Reject
4. Now trigger a tx
5. Navigate to the tx
6. See MM stays loading indefinitely and the tx is never rendered

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [X] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
