### PR TITLE
feat: Hide the "retry" button for Smart Transactions, show cancelled STX only for Swaps

### DIFF
--- a/ui/components/app/transaction-list-item/transaction-list-item.component.js
+++ b/ui/components/app/transaction-list-item/transaction-list-item.component.js
@@ -65,6 +65,7 @@ import EditGasPopover from '../../../pages/confirmations/components/edit-gas-pop
 import { MetaMetricsContext } from '../../../contexts/metametrics';
 import { ActivityListItem } from '../../multichain';
 import { abortTransactionSigning } from '../../../store/actions';
+import { getIsSmartTransaction } from '../../../../shared/modules/selectors';
 
 function TransactionListItemInner({
   transactionGroup,
@@ -81,6 +82,7 @@ function TransactionListItemInner({
   const { supportsEIP1559 } = useGasFeeContext();
   const { openModal } = useTransactionModalContext();
   const testNetworkBackgroundColor = useSelector(getTestNetworkBackgroundColor);
+  const isSmartTransaction = useSelector(getIsSmartTransaction);
   const dispatch = useDispatch();
 
   const {
@@ -402,7 +404,8 @@ function TransactionListItemInner({
             !isCustodian &&
             ///: END:ONLY_INCLUDE_IF
             status === TransactionStatus.failed &&
-            !isSwap
+            !isSwap &&
+            !isSmartTransaction
           }
           showSpeedUp={
             ///: BEGIN:ONLY_INCLUDE_IF(build-mmi)

--- a/ui/selectors/transactions.js
+++ b/ui/selectors/transactions.js
@@ -103,8 +103,18 @@ export const smartTransactionsListSelector = (state) => {
     getCurrentChainId(state)
   ]
     ?.filter((stx) => {
-      const { txParams } = stx;
-      return txParams?.from === selectedAddress && !stx.confirmed;
+      const isCancelledSmartTransaction = stx.status?.startsWith('cancelled');
+      return (
+        stx.txParams?.from === selectedAddress &&
+        !stx.confirmed &&
+        (!isCancelledSmartTransaction ||
+          // We only want to show cancelled Smart Transactions for Swaps in Activity,
+          // since other transaction types will show the "Failed" status in Activity instead,
+          // because they are mostly processed via the TransactionController. In the future, we
+          // should have the same behavior for Swaps as well, so all transaction types
+          // would be handled the same way for Smart Transactions.
+          (isCancelledSmartTransaction && stx.type === TransactionType.swap))
+      );
     })
     .map((stx) => ({
       ...stx,


### PR DESCRIPTION
## **Description**
- Hide the "retry" button for Smart Transactions
- Show cancelled smart transaction only for Swaps in the Activity tab

## **Related issues**

Fixes:

## **Manual testing steps**

Hide the "retry" button for Smart Transactions
- Before submitting a non-swap transaction (e.g. Send), set custom gas fees super low, so the transaction would fail
- Submit it
- Once it gets cancelled, go to the Activity tab and open the transaction detail
- There is no "retry" button if Smart Transactions are enabled

Show cancelled smart transaction only for Swaps in the Activity tab
- Before submitting a non-swap transaction, set custom gas fees super low, so the transaction would fail
- Submit it
- Once it gets cancelled, in the Activity tab you will now only see one item in the list with the failed transaction (before you could see two for the same transaction: "Cancelled" and "Failed", which wasn't needed)

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
