### PR TITLE
fix: remove requirement for EIP-55 address when parsing SIWE message

### DIFF
--- a/.yarn/patches/@spruceid-siwe-parser-npm-2.1.0-060b7ede7a.patch
+++ b/.yarn/patches/@spruceid-siwe-parser-npm-2.1.0-060b7ede7a.patch
@@ -1,0 +1,51 @@
+diff --git a/dist/abnf.js b/dist/abnf.js
+index 15caf986714ddc2276571d17c35bf392941fa346..0eeac1eeb94284e201fb0bbaea887c0f3d060aaa 100644
+--- a/dist/abnf.js
++++ b/dist/abnf.js
+@@ -290,9 +290,6 @@ class ParsedMessage {
+         if (this.domain.length === 0) {
+             throw new Error("Domain cannot be empty.");
+         }
+-        if (!(0, utils_1.isEIP55Address)(this.address)) {
+-            throw new Error("Address not conformant to EIP-55.");
+-        }
+     }
+ }
+ exports.ParsedMessage = ParsedMessage;
+diff --git a/dist/regex.js b/dist/regex.js
+index 4740a7c271db7fb2b5f0885727053e1165e8e392..cbfa067030a975ae645ef68baa3b963059e89f2c 100644
+--- a/dist/regex.js
++++ b/dist/regex.js
+@@ -55,9 +55,7 @@ class ParsedMessage {
+             throw new Error("Domain cannot be empty.");
+         }
+         this.address = (_b = match === null || match === void 0 ? void 0 : match.groups) === null || _b === void 0 ? void 0 : _b.address;
+-        if (!(0, utils_1.isEIP55Address)(this.address)) {
+-            throw new Error("Address not conformant to EIP-55.");
+-        }
++
+         this.statement = (_c = match === null || match === void 0 ? void 0 : match.groups) === null || _c === void 0 ? void 0 : _c.statement;
+         this.uri = (_d = match === null || match === void 0 ? void 0 : match.groups) === null || _d === void 0 ? void 0 : _d.uri;
+         if (!uri.isUri(this.uri)) {
+diff --git a/lib/abnf.ts b/lib/abnf.ts
+index a7e5fcfaefdf39bac8bf0b5ee2d6e12cee4b07f0..6d022a2bd17ec5d7158b34e978a946465520aa74 100644
+--- a/lib/abnf.ts
++++ b/lib/abnf.ts
+@@ -1,6 +1,6 @@
+ import apgApi from "apg-js/src/apg-api/api";
+ import apgLib from "apg-js/src/apg-lib/node-exports";
+-import { isEIP55Address, parseIntegerNumber } from "./utils";
++import { parseIntegerNumber } from "./utils";
+ 
+ const GRAMMAR = `
+ sign-in-with-ethereum =
+@@ -358,9 +358,5 @@ export class ParsedMessage {
+ 		if (this.domain.length === 0) {
+ 			throw new Error("Domain cannot be empty.");
+ 		}
+-
+-		if (!isEIP55Address(this.address)) {
+-			throw new Error("Address not conformant to EIP-55.");
+-		}
+ 	}
+ }

--- a/package.json
+++ b/package.json
@@ -241,7 +241,8 @@
     "@metamask/network-controller@npm:^17.2.1": "patch:@metamask/network-controller@npm%3A18.1.0#~/.yarn/patches/@metamask-network-controller-npm-18.1.0-680908c29a.patch",
     "@metamask/network-controller@npm:^18.1.0": "patch:@metamask/network-controller@npm%3A18.1.0#~/.yarn/patches/@metamask-network-controller-npm-18.1.0-680908c29a.patch",
     "@metamask/keyring-controller@npm:^13.0.0": "patch:@metamask/keyring-controller@npm%3A13.0.0#~/.yarn/patches/@metamask-keyring-controller-npm-13.0.0-d94816a680.patch",
-    "@spruceid/siwe-parser@npm:1.1.3": "2.1.0"
+    "@spruceid/siwe-parser@npm:1.1.3": "patch:@spruceid/siwe-parser@npm%3A2.1.0#~/.yarn/patches/@spruceid-siwe-parser-npm-2.1.0-060b7ede7a.patch",
+    "@spruceid/siwe-parser@npm:2.1.0": "patch:@spruceid/siwe-parser@npm%3A2.1.0#~/.yarn/patches/@spruceid-siwe-parser-npm-2.1.0-060b7ede7a.patch"
   },
   "dependencies": {
     "@babel/runtime": "patch:@babel/runtime@npm%3A7.24.0#~/.yarn/patches/@babel-runtime-npm-7.24.0-7eb1dd11a2.patch",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7273,6 +7273,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@spruceid/siwe-parser@patch:@spruceid/siwe-parser@npm%3A2.1.0#~/.yarn/patches/@spruceid-siwe-parser-npm-2.1.0-060b7ede7a.patch":
+  version: 2.1.0
+  resolution: "@spruceid/siwe-parser@patch:@spruceid/siwe-parser@npm%3A2.1.0#~/.yarn/patches/@spruceid-siwe-parser-npm-2.1.0-060b7ede7a.patch::version=2.1.0&hash=22ff08"
+  dependencies:
+    "@noble/hashes": "npm:^1.1.2"
+    apg-js: "npm:^4.1.1"
+    uri-js: "npm:^4.4.1"
+    valid-url: "npm:^1.0.9"
+  checksum: 6a6f7fbf7a43a63a3e9cf7fadd4ef2bc700d3933ed65db1b5d57262cc1b502bb2d00e741b3b315c705897c34dcf6b9031c4963e6e72e8608d593f1bfdaf32169
+  languageName: node
+  linkType: hard
+
 "@storybook/addon-a11y@npm:^7.4.6":
   version: 7.4.6
   resolution: "@storybook/addon-a11y@npm:7.4.6"


### PR DESCRIPTION
Base branch is https://github.com/MetaMask/metamask-extension/pull/24138

## **Description**

Upon testing the new `@spruceid/siwe-parser` changes, @digiwand noticed that message parsing would fail when using the  [MetaMask Test dApp](https://metamask.github.io/test-dapp/). During this investigation, it was identified that the parsing failed due to the [isEIP55Address](https://github.com/spruceid/siwe/blob/4290e1fb3702c97ffee16112492216ad4c4654c1/packages/siwe-parser/lib/abnf.ts#L362-L364) check. 

This is due to the fact that an EIP-55 address is case sensitive, but MetaMask lowercases the wallet address before returning it to an `eth_accounts` call. This means that when dApps attempt to request a SIWE message (using this lowecase address), the operation would fail to parse.

This change removes that check, and provides the consistent experience we have already been giving prior to the `@spruceid/siwe-parser` v2 upgrade.

## **Related issues**

Adds to https://github.com/MetaMask/metamask-extension/pull/24138

## **Pre-merge author checklist**

- [X] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
