### PR TITLE
fix: hide installing Snaps from list

### DIFF
--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -6,6 +6,7 @@ import { ApprovalType } from '@metamask/controller-utils';
 import {
   stripSnapPrefix,
   getLocalizedSnapManifest,
+  SnapStatus,
 } from '@metamask/snaps-utils';
 import { memoize } from 'lodash';
 import semver from 'semver';
@@ -2407,7 +2408,10 @@ export function getIsDesktopEnabled(state) {
 export function getSnapsList(state) {
   const snaps = getSnaps(state);
   return Object.entries(snaps)
-    .filter(([_key, snap]) => !snap.preinstalled)
+    .filter(
+      ([_key, snap]) =>
+        !snap.preinstalled && snap.status !== SnapStatus.Installing,
+    )
     .map(([key, snap]) => {
       const targetSubjectMetadata = getTargetSubjectMetadata(state, snap?.id);
       return {


### PR DESCRIPTION
## **Description**

Hides installing Snaps from the Snaps menu until they have finished installation to prevent a bad state where users could modify Snaps before they were fully installed.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/24215?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/snaps/issues/2354

