### PR TITLE
feat: set useRequestQueue on by default

### DIFF
--- a/app/scripts/controllers/preferences.js
+++ b/app/scripts/controllers/preferences.js
@@ -60,7 +60,7 @@ export default class PreferencesController {
       useNftDetection: false,
       use4ByteResolution: true,
       useCurrencyRateCheck: true,
-      useRequestQueue: false,
+      useRequestQueue: true,
       openSeaEnabled: false,
       ///: BEGIN:ONLY_INCLUDE_IF(blockaid)
       securityAlertsEnabled: true,

--- a/app/scripts/lib/backup.test.js
+++ b/app/scripts/lib/backup.test.js
@@ -169,7 +169,7 @@ const jsonData = JSON.stringify({
     theme: 'light',
     customNetworkListEnabled: false,
     textDirection: 'auto',
-    useRequestQueue: false,
+    useRequestQueue: true,
   },
   internalAccounts: {
     accounts: {

--- a/app/scripts/migrations/119.test.ts
+++ b/app/scripts/migrations/119.test.ts
@@ -1,0 +1,66 @@
+import { migrate, version } from './119';
+
+const oldVersion = 118;
+
+describe('migration #119', () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('updates the version metadata', async () => {
+    const oldStorage = {
+      meta: {
+        version: oldVersion,
+      },
+      data: {},
+    };
+
+    const newStorage = await migrate(oldStorage);
+
+    expect(newStorage.meta).toStrictEqual({ version });
+  });
+
+  describe('set useRequestQueue to true in PreferencesController', () => {
+    it('sets useRequestQueue to true', async () => {
+      const oldStorage = {
+        PreferencesController: {
+          useRequestQueue: false,
+        },
+      };
+
+      const expectedState = {
+        PreferencesController: {
+          useRequestQueue: true,
+        },
+      };
+
+      const transformedState = await migrate({
+        meta: { version: oldVersion },
+        data: oldStorage,
+      });
+
+      expect(transformedState.data).toEqual(expectedState);
+    });
+
+    it('should not update useRequestQueue value if it was set true in initial state', async () => {
+      const oldStorage = {
+        PreferencesController: {
+          useRequestQueue: true,
+        },
+      };
+
+      const expectedState = {
+        PreferencesController: {
+          useRequestQueue: true,
+        },
+      };
+
+      const transformedState = await migrate({
+        meta: { version: oldVersion },
+        data: oldStorage,
+      });
+
+      expect(transformedState.data).toEqual(expectedState);
+    });
+  });
+});

--- a/app/scripts/migrations/119.ts
+++ b/app/scripts/migrations/119.ts
@@ -1,0 +1,52 @@
+import { cloneDeep } from 'lodash';
+import { hasProperty, isObject } from '@metamask/utils';
+
+type VersionedData = {
+  meta: { version: number };
+  data: Record<string, unknown>;
+};
+
+export const version = 119;
+
+/**
+ * This migration sets preference useRequestQueue to true
+ *
+ * @param originalVersionedData - Versioned MetaMask extension state, exactly what we persist to dist.
+ * @param originalVersionedData.meta - State metadata.
+ * @param originalVersionedData.meta.version - The current state version.
+ * @param originalVersionedData.data - The persisted MetaMask state, keyed by controller.
+ * @returns Updated versioned MetaMask extension state.
+ */
+export async function migrate(
+  originalVersionedData: VersionedData,
+): Promise<VersionedData> {
+  const versionedData = cloneDeep(originalVersionedData);
+  versionedData.meta.version = version;
+  transformState(versionedData.data);
+  return versionedData;
+}
+
+// TODO: Replace `any` with specific type
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function transformState(state: Record<string, any>) {
+  if (!hasProperty(state, 'PreferencesController')) {
+    return state;
+  }
+
+  if (!isObject(state.PreferencesController)) {
+    const controllerType = typeof state.PreferencesController;
+    global.sentry?.captureException?.(
+      new Error(`state.PreferencesController is type: ${controllerType}`),
+    );
+    state.PreferencesController = {};
+  }
+
+  if (
+    state.PreferencesController.useRequestQueue === false ||
+    state.PreferencesController.useRequestQueue === undefined
+  ) {
+    state.PreferencesController.useRequestQueue = true;
+  }
+
+  return state;
+}

--- a/app/scripts/migrations/index.js
+++ b/app/scripts/migrations/index.js
@@ -129,6 +129,7 @@ const migrations = [
   require('./116'),
   require('./117'),
   require('./118'),
+  require('./119'),
 ];
 
 export default migrations;

--- a/test/e2e/fixture-builder.js
+++ b/test/e2e/fixture-builder.js
@@ -190,7 +190,7 @@ function defaultFixture(inputChainId = CHAIN_IDS.LOCALHOST) {
         useTokenDetection: false,
         useCurrencyRateCheck: true,
         useMultiAccountBalanceChecker: true,
-        useRequestQueue: false,
+        useRequestQueue: true,
       },
       SelectedNetworkController: {
         domains: {},
@@ -317,7 +317,7 @@ function onboardingFixture() {
         useTokenDetection: false,
         useCurrencyRateCheck: true,
         useMultiAccountBalanceChecker: true,
-        useRequestQueue: false,
+        useRequestQueue: true,
       },
       SelectedNetworkController: {
         domains: {},

--- a/test/e2e/json-rpc/switchEthereumChain.spec.js
+++ b/test/e2e/json-rpc/switchEthereumChain.spec.js
@@ -29,6 +29,28 @@ describe('Switch Ethereum Chain for two dapps', function () {
       async ({ driver }) => {
         await unlockWallet(driver);
 
+        // Open settings menu button
+        const accountOptionsMenuSelector =
+          '[data-testid="account-options-menu-button"]';
+        await driver.waitForSelector(accountOptionsMenuSelector);
+        await driver.clickElement(accountOptionsMenuSelector);
+
+        // Click settings from dropdown menu
+        const globalMenuSettingsSelector =
+          '[data-testid="global-menu-settings"]';
+        await driver.waitForSelector(globalMenuSettingsSelector);
+        await driver.clickElement(globalMenuSettingsSelector);
+
+        // Click Experimental tab
+        const experimentalTabRawLocator = {
+          text: 'Experimental',
+          tag: 'div',
+        };
+        await driver.clickElement(experimentalTabRawLocator);
+
+        // Toggle off request queue setting (on by default now)
+        await driver.clickElement('.request-queue-toggle');
+
         // open two dapps
         await openDapp(driver, undefined, DAPP_URL);
         await openDapp(driver, undefined, DAPP_ONE_URL);
@@ -98,6 +120,28 @@ describe('Switch Ethereum Chain for two dapps', function () {
       },
       async ({ driver }) => {
         await unlockWallet(driver);
+
+        // Open settings menu button
+        const accountOptionsMenuSelector =
+          '[data-testid="account-options-menu-button"]';
+        await driver.waitForSelector(accountOptionsMenuSelector);
+        await driver.clickElement(accountOptionsMenuSelector);
+
+        // Click settings from dropdown menu
+        const globalMenuSettingsSelector =
+          '[data-testid="global-menu-settings"]';
+        await driver.waitForSelector(globalMenuSettingsSelector);
+        await driver.clickElement(globalMenuSettingsSelector);
+
+        // Click Experimental tab
+        const experimentalTabRawLocator = {
+          text: 'Experimental',
+          tag: 'div',
+        };
+        await driver.clickElement(experimentalTabRawLocator);
+
+        // Toggle off request queue setting (on by default now)
+        await driver.clickElement('.request-queue-toggle');
 
         // open two dapps
         await openDapp(driver, undefined, DAPP_URL);
@@ -171,6 +215,28 @@ describe('Switch Ethereum Chain for two dapps', function () {
       async ({ driver }) => {
         await unlockWallet(driver);
 
+        // Open settings menu button
+        const accountOptionsMenuSelector =
+          '[data-testid="account-options-menu-button"]';
+        await driver.waitForSelector(accountOptionsMenuSelector);
+        await driver.clickElement(accountOptionsMenuSelector);
+
+        // Click settings from dropdown menu
+        const globalMenuSettingsSelector =
+          '[data-testid="global-menu-settings"]';
+        await driver.waitForSelector(globalMenuSettingsSelector);
+        await driver.clickElement(globalMenuSettingsSelector);
+
+        // Click Experimental tab
+        const experimentalTabRawLocator = {
+          text: 'Experimental',
+          tag: 'div',
+        };
+        await driver.clickElement(experimentalTabRawLocator);
+
+        // Toggle off request queue setting (on by default now)
+        await driver.clickElement('.request-queue-toggle');
+
         // open two dapps
         await openDapp(driver, undefined, DAPP_URL);
         await openDapp(driver, undefined, DAPP_ONE_URL);
@@ -243,6 +309,28 @@ describe('Switch Ethereum Chain for two dapps', function () {
       },
       async ({ driver }) => {
         await unlockWallet(driver);
+
+        // Open settings menu button
+        const accountOptionsMenuSelector =
+          '[data-testid="account-options-menu-button"]';
+        await driver.waitForSelector(accountOptionsMenuSelector);
+        await driver.clickElement(accountOptionsMenuSelector);
+
+        // Click settings from dropdown menu
+        const globalMenuSettingsSelector =
+          '[data-testid="global-menu-settings"]';
+        await driver.waitForSelector(globalMenuSettingsSelector);
+        await driver.clickElement(globalMenuSettingsSelector);
+
+        // Click Experimental tab
+        const experimentalTabRawLocator = {
+          text: 'Experimental',
+          tag: 'div',
+        };
+        await driver.clickElement(experimentalTabRawLocator);
+
+        // Toggle off request queue setting (on by default now)
+        await driver.clickElement('.request-queue-toggle');
 
         // open two dapps
         await openDapp(driver, undefined, DAPP_URL);

--- a/test/e2e/restore/MetaMaskUserData.json
+++ b/test/e2e/restore/MetaMaskUserData.json
@@ -41,7 +41,7 @@
     },
     "theme": "light",
     "useBlockie": false,
-    "useRequestQueue": false,
+    "useRequestQueue": true,
     "useNftDetection": false,
     "useNonceField": false,
     "usePhishDetect": true,

--- a/test/e2e/tests/dapp-interactions/provider-api.spec.js
+++ b/test/e2e/tests/dapp-interactions/provider-api.spec.js
@@ -9,47 +9,6 @@ const {
 const FixtureBuilder = require('../../fixture-builder');
 
 describe('MetaMask', function () {
-  it('provider should inform dapp when switching networks', async function () {
-    await withFixtures(
-      {
-        dapp: true,
-        fixtures: new FixtureBuilder()
-          .withPermissionControllerConnectedToTestDapp()
-          .build(),
-        ganacheOptions: defaultGanacheOptions,
-        title: this.test.fullTitle(),
-      },
-      async ({ driver, ganacheServer }) => {
-        const addresses = await ganacheServer.getAccounts();
-        const publicAddress = addresses[0];
-        await unlockWallet(driver);
-
-        await openDapp(driver);
-        const chainIdDiv = await driver.waitForSelector({
-          css: '#chainId',
-          text: '0x539',
-        });
-        assert.equal(await chainIdDiv.getText(), '0x539');
-
-        const windowHandles = await driver.getAllWindowHandles();
-        await driver.switchToWindow(windowHandles[0]);
-
-        await driver.clickElement('[data-testid="network-display"]');
-        await driver.clickElement({ text: 'Ethereum Mainnet', tag: 'p' });
-
-        await driver.switchToWindowWithTitle('E2E Test Dapp', windowHandles);
-        const switchedChainIdDiv = await driver.waitForSelector({
-          css: '#chainId',
-          text: '0x1',
-        });
-        const accountsDiv = await driver.findElement('#accounts');
-
-        assert.equal(await switchedChainIdDiv.getText(), '0x1');
-        assert.equal(await accountsDiv.getText(), publicAddress);
-      },
-    );
-  });
-
   it('should reject unsupported methods', async function () {
     await withFixtures(
       {

--- a/test/e2e/tests/metrics/state-snapshots/errors-after-init-opt-in-background-state.json
+++ b/test/e2e/tests/metrics/state-snapshots/errors-after-init-opt-in-background-state.json
@@ -153,7 +153,7 @@
     "useNftDetection": false,
     "use4ByteResolution": true,
     "useCurrencyRateCheck": true,
-    "useRequestQueue": false,
+    "useRequestQueue": true,
     "openSeaEnabled": false,
     "securityAlertsEnabled": "boolean",
     "addSnapAccountEnabled": "boolean",

--- a/test/e2e/tests/metrics/state-snapshots/errors-after-init-opt-in-ui-state.json
+++ b/test/e2e/tests/metrics/state-snapshots/errors-after-init-opt-in-ui-state.json
@@ -107,7 +107,7 @@
     "useTokenDetection": false,
     "useNftDetection": false,
     "useCurrencyRateCheck": true,
-    "useRequestQueue": false,
+    "useRequestQueue": true,
     "openSeaEnabled": false,
     "securityAlertsEnabled": "boolean",
     "addSnapAccountEnabled": "boolean",

--- a/test/e2e/tests/metrics/state-snapshots/errors-before-init-opt-in-background-state.json
+++ b/test/e2e/tests/metrics/state-snapshots/errors-before-init-opt-in-background-state.json
@@ -113,7 +113,7 @@
       "useTokenDetection": false,
       "useCurrencyRateCheck": true,
       "useMultiAccountBalanceChecker": true,
-      "useRequestQueue": false
+      "useRequestQueue": true
     },
     "SelectedNetworkController": { "domains": "object" },
     "SmartTransactionsController": {

--- a/test/e2e/tests/metrics/state-snapshots/errors-before-init-opt-in-ui-state.json
+++ b/test/e2e/tests/metrics/state-snapshots/errors-before-init-opt-in-ui-state.json
@@ -113,7 +113,7 @@
       "useTokenDetection": false,
       "useCurrencyRateCheck": true,
       "useMultiAccountBalanceChecker": true,
-      "useRequestQueue": false
+      "useRequestQueue": true
     },
     "SelectedNetworkController": { "domains": "object" },
     "SmartTransactionsController": {


### PR DESCRIPTION
 This PR is to ensure that `useRequestQueue` is set to `true` by default. After setting it to true, it turn the setting on for all users while keeping the toggle, since this is a state update. This PR also includes a migration.

## **Related issues**

Fixes: #23985 

## **Manual testing steps**

1. Go to settings > Experimental
2. Check `Select networks for each site` toggle is on
3. Toggle should work properly

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**


![Screenshot 2024-04-29 at 12 43 31 PM](https://github.com/MetaMask/metamask-extension/assets/39872794/6bdc6f49-6f20-44f1-a063-f9edd1dba09b)

### **After**

![Screenshot 2024-04-29 at 12 43 03 PM](https://github.com/MetaMask/metamask-extension/assets/39872794/19fce2fa-d0cb-43b8-8731-7b64c6d33975)



## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
