### PR TITLE
fix: Fix #24320: Prevent editing of safe-transfer-from transactions

### DIFF
--- a/test/e2e/tests/tokens/nft/send-nft.spec.js
+++ b/test/e2e/tests/tokens/nft/send-nft.spec.js
@@ -104,12 +104,13 @@ describe('Send NFT', function () {
 
         // Fill the send NFT form and confirm the transaction
         await driver.clickElement('[data-testid="home__nfts-tab"]');
-        // await sleep(100000);
 
         const erc1155Token = await driver.findElement('.nft-item__container');
         await driver.scrollToElement(erc1155Token);
         await driver.delay(1000);
-        await driver.clickElement('.nft-item__container');
+        await driver.clickElement(
+          '.nft-item__container .mm-badge-wrapper__badge-container',
+        );
 
         await driver.clickElement({ text: 'Send', tag: 'button' });
         await driver.fill(
@@ -128,26 +129,12 @@ describe('Send NFT', function () {
           tag: 'button',
         });
 
-        // Edit the NFT, ensure same address, and move forward
-        await driver.clickElement(
+        // Ensure that this type of NFT is not editable for now
+        // https://github.com/MetaMask/metamask-extension/issues/24320
+        const editButtonPresent = await driver.isElementPresent(
           '[data-testid="confirm-page-back-edit-button"]',
         );
-
-        const recipient = await driver.findElement(
-          '.ens-input__selected-input__title',
-        );
-
-        assert.equal(
-          await recipient.getText(),
-          '0xc427d562164062a23a5cff596a4a3208e72acd28',
-        );
-
-        await driver.fill('input[placeholder="0"]', '1');
-
-        await driver.clickElement({
-          text: isMultichain ? 'Continue' : 'Next',
-          tag: 'button',
-        });
+        assert.equal(editButtonPresent, false);
 
         // Confirm the send
         await driver.clickElement({ text: 'Confirm', tag: 'button' });

--- a/ui/pages/confirmations/confirm-transaction/confirm-token-transaction-switch.js
+++ b/ui/pages/confirmations/confirm-transaction/confirm-token-transaction-switch.js
@@ -144,14 +144,6 @@ export default function ConfirmTokenTransactionSwitch({ transaction }) {
             decimals={decimals}
             image={tokenImage}
             tokenAddress={tokenAddress}
-            onEdit={async ({ txData }) => {
-              const { id } = txData;
-              await dispatch(
-                editExistingTransaction(AssetType.NFT, id.toString()),
-              );
-              dispatch(clearConfirmTransaction());
-              history.push(SEND_ROUTE);
-            }}
             toAddress={toAddress}
             tokenAmount={tokenAmount}
             tokenId={tokenId}


### PR DESCRIPTION
## **Description**

Ensures that ERC1155s sends are no longer editable

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/24319?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/24320

## **Manual testing steps**

See issue for STRs

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
