### PR TITLE
fix: currency displayed for user balance in re-designed confirmation header info modal

### DIFF
--- a/ui/components/app/confirm/info/row/currency.test.tsx
+++ b/ui/components/app/confirm/info/row/currency.test.tsx
@@ -9,14 +9,9 @@ import { ConfirmInfoRowCurrency } from './currency';
 // TODO: Replace `any` with type
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const render = (props: Record<string, any> = {}) => {
+  const { metamask } = mockState;
   const store = configureStore({
-    metamask: {
-      ...mockState.metamask,
-      preferences: {
-        ...mockState.metamask.preferences,
-        useNativeCurrencyAsPrimaryCurrency: false,
-      },
-    },
+    metamask,
   });
 
   return renderWithProvider(

--- a/ui/components/app/confirm/info/row/currency.tsx
+++ b/ui/components/app/confirm/info/row/currency.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import { PRIMARY } from '../../../../../helpers/constants/common';
 import {
   AlignItems,
   Display,
@@ -34,7 +35,7 @@ export const ConfirmInfoRowCurrency = ({
     {currency ? (
       <CurrencyDisplay currency={currency} value={`${value}`} />
     ) : (
-      <UserPreferencedCurrencyDisplay value={`${value}`} />
+      <UserPreferencedCurrencyDisplay type={PRIMARY} value={`${value}`} />
     )}
   </Box>
 );

--- a/ui/pages/confirmations/hooks/useConfirmationRecipientInfo.ts
+++ b/ui/pages/confirmations/hooks/useConfirmationRecipientInfo.ts
@@ -11,11 +11,11 @@ function useConfirmationRecipientInfo() {
   const currentConfirmation = useSelector(
     currentConfirmationSelector,
   ) as Confirmation;
+  const allAccounts = useSelector(accountsWithSendEtherInfoSelector);
 
   let senderAddress, senderName;
   if (currentConfirmation) {
     const { from } = getConfirmationSender(currentConfirmation);
-    const allAccounts = useSelector(accountsWithSendEtherInfoSelector);
     const fromAccount = getAccountByAddress(allAccounts, from);
 
     senderAddress = from;


### PR DESCRIPTION
## **Description**
Fix currency displayed for user balance in re-designed confirmation header info modal

Fix currency used
## **Related issues**

Fixes: #23690

## **Manual testing steps**

1. Set primary currency as ETH in settings
2. Enable re-designs and submit personal sign request
3. Check currency displayed for account balance in header

## **Screenshots/Recordings**
<img width="357" alt="Screenshot 2024-05-01 at 8 09 18 PM" src="https://github.com/MetaMask/metamask-extension/assets/2182307/b7056cb8-b150-4f4c-9889-8068c86c158a">

## **Pre-merge author checklist**

- [X] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
