### PR TITLE
fix: "Transaction Finalized" metrics event on transaction confirmation

### DIFF
--- a/app/scripts/lib/transaction/metrics.test.ts
+++ b/app/scripts/lib/transaction/metrics.test.ts
@@ -607,7 +607,7 @@ describe('Transaction metrics', () => {
       mockTransactionMeta.submittedTime = 123;
 
       await handleTransactionConfirmed(mockTransactionMetricsRequest, {
-        transactionMeta: mockTransactionMeta,
+        ...mockTransactionMeta,
         actionId: mockActionId,
         // TODO: Replace `any` with type
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -665,7 +665,7 @@ describe('Transaction metrics', () => {
       mockTransactionMetaWithBlockaid.submittedTime = 123;
 
       await handleTransactionConfirmed(mockTransactionMetricsRequest, {
-        transactionMeta: mockTransactionMetaWithBlockaid,
+        ...mockTransactionMetaWithBlockaid,
         actionId: mockActionId,
         // TODO: Replace `any` with type
         // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/app/scripts/lib/transaction/metrics.ts
+++ b/app/scripts/lib/transaction/metrics.ts
@@ -102,6 +102,11 @@ export type TransactionEventPayload = {
   error?: string;
 };
 
+export type TransactionMetaEventPayload = TransactionMeta & {
+  actionId?: string;
+  error?: string;
+};
+
 /**
  * This function is called when a transaction is added to the controller.
  *
@@ -197,7 +202,7 @@ export const handleTransactionFailed = async (
  */
 export const handleTransactionConfirmed = async (
   transactionMetricsRequest: TransactionMetricsRequest,
-  transactionEventPayload: TransactionEventPayload,
+  transactionEventPayload: TransactionMetaEventPayload,
 ) => {
   if (Object.keys(transactionEventPayload).length === 0) {
     return;
@@ -206,7 +211,7 @@ export const handleTransactionConfirmed = async (
   // TODO: Replace `any` with type
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const extraParams = {} as Record<string, any>;
-  const transactionMeta = transactionEventPayload;
+  const transactionMeta = { ...transactionEventPayload };
   const { txReceipt } = transactionMeta;
 
   extraParams.gas_used = txReceipt?.gasUsed;

--- a/app/scripts/lib/transaction/metrics.ts
+++ b/app/scripts/lib/transaction/metrics.ts
@@ -224,6 +224,7 @@ export const handleTransactionConfirmed = async (
     eventName: TransactionMetaMetricsEvent.finalized,
     extraParams,
     transactionEventPayload: {
+      actionId: transactionMeta.actionId,
       transactionMeta,
     },
     transactionMetricsRequest,

--- a/app/scripts/lib/transaction/metrics.ts
+++ b/app/scripts/lib/transaction/metrics.ts
@@ -199,14 +199,14 @@ export const handleTransactionConfirmed = async (
   transactionMetricsRequest: TransactionMetricsRequest,
   transactionEventPayload: TransactionEventPayload,
 ) => {
-  if (!transactionEventPayload.transactionMeta) {
+  if (Object.keys(transactionEventPayload).length === 0) {
     return;
   }
 
   // TODO: Replace `any` with type
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const extraParams = {} as Record<string, any>;
-  const { transactionMeta } = transactionEventPayload;
+  const transactionMeta = transactionEventPayload;
   const { txReceipt } = transactionMeta;
 
   extraParams.gas_used = txReceipt?.gasUsed;
@@ -223,7 +223,9 @@ export const handleTransactionConfirmed = async (
   await createUpdateFinalizeTransactionEventFragment({
     eventName: TransactionMetaMetricsEvent.finalized,
     extraParams,
-    transactionEventPayload,
+    transactionEventPayload: {
+      transactionMeta,
+    },
     transactionMetricsRequest,
   });
 };


### PR DESCRIPTION
0de97df36f brought in a number of breaking changes as it updated the transaction controller.

One of the breaking changes was changing the shape of the object included in the event when a transaction is confirmed:
![Screenshot from 2024-05-02 01-59-38](https://github.com/MetaMask/metamask-extension/assets/7499938/4009876d-0f71-40ed-91db-d6acbeddff85)
(https://github.com/MetaMask/core/pull/3827/files#diff-96bc10c64242a8e23f5835532988319189239bdf40f556b86199dcbcc41c7bfcL1353-R1646)

The `handleTransactionConfirmed` handler in `app/scripts/lib/transaction/metrics.ts` was not updated to accommodate this difference. So its `if (!transactionEventPayload.transactionMeta) {` condition was always being hit, and the function was returning early. This PR corrects that, and thereby fixes the "Transaction Finalzied" event


<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/24338?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/24339

## **Manual testing steps**

1. Setup metamask so that it will send metrics events. This requires building with the `SEGMENT_WRITE_KEY` set, and setting "Participate in MetaMetrics" to true.
2. Open the background console and the network tab
3. Go through the send flow and confirm a transaction
4. Once it is no longer pending and is confirmed, you should see a network request to segment, with "Transaction Finalized" in the payload

## **Screenshots/Recordings**


https://github.com/MetaMask/metamask-extension/assets/7499938/2f8acba3-5518-477b-988f-fb121444a816



- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
