### PR TITLE
fix: rewrite snaps metadata selector to fix re-rendering

### DIFF
--- a/ui/pages/confirmations/confirmation/templates/__snapshots__/create-snap-account.test.js.snap
+++ b/ui/pages/confirmations/confirmation/templates/__snapshots__/create-snap-account.test.js.snap
@@ -25,7 +25,7 @@ exports[`create-snap-account confirmation should match snapshot 1`] = `
                 class="mm-box mm-text mm-avatar-base mm-avatar-base--size-lg mm-text--body-lg-medium mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-alternative mm-box--background-color-background-alternative mm-box--rounded-full"
                 style="border-width: 0px;"
               >
-                m
+                T
               </div>
               <div
                 class="mm-box mm-badge-wrapper__badge-container mm-badge-wrapper__badge-container--circular-bottom-right"
@@ -48,7 +48,7 @@ exports[`create-snap-account confirmation should match snapshot 1`] = `
             <p
               class="mm-box mm-text mm-text--body-md mm-text--font-weight-medium mm-text--ellipsis mm-box--color-text-default"
             >
-              @metamask/snap-test
+              Test Snap
             </p>
             <p
               class="mm-box mm-text mm-text--body-sm mm-text--ellipsis mm-box--color-text-alternative"

--- a/ui/pages/confirmations/confirmation/templates/__snapshots__/remove-snap-account.test.js.snap
+++ b/ui/pages/confirmations/confirmation/templates/__snapshots__/remove-snap-account.test.js.snap
@@ -25,7 +25,7 @@ exports[`remove-snap-account confirmation should match snapshot 1`] = `
                 class="mm-box mm-text mm-avatar-base mm-avatar-base--size-lg mm-text--body-lg-medium mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-alternative mm-box--background-color-background-alternative mm-box--rounded-full"
                 style="border-width: 0px;"
               >
-                m
+                T
               </div>
               <div
                 class="mm-box mm-badge-wrapper__badge-container mm-badge-wrapper__badge-container--circular-bottom-right"
@@ -48,7 +48,7 @@ exports[`remove-snap-account confirmation should match snapshot 1`] = `
             <p
               class="mm-box mm-text mm-text--body-md mm-text--font-weight-medium mm-text--ellipsis mm-box--color-text-default"
             >
-              @metamask/snap-test
+              Test Snap
             </p>
             <p
               class="mm-box mm-text mm-text--body-sm mm-text--ellipsis mm-box--color-text-alternative"

--- a/ui/pages/confirmations/confirmation/templates/create-snap-account.test.js
+++ b/ui/pages/confirmations/confirmation/templates/create-snap-account.test.js
@@ -23,6 +23,7 @@ const mockBaseStore = {
       [mockSnapOrigin]: {
         id: mockSnapOrigin,
         manifest: {
+          proposedName: 'Test Snap',
           description: 'Test Snap',
         },
       },

--- a/ui/pages/confirmations/confirmation/templates/remove-snap-account.test.js
+++ b/ui/pages/confirmations/confirmation/templates/remove-snap-account.test.js
@@ -33,6 +33,7 @@ const mockBaseStore = {
       [mockSnapOrigin]: {
         id: mockSnapOrigin,
         manifest: {
+          proposedName: 'Test Snap',
           description: 'Test Snap',
         },
       },

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -1492,6 +1492,10 @@ export function getSnaps(state) {
   return state.metamask.snaps;
 }
 
+export function getLocale(state) {
+  return state.metamask.currentLocale;
+}
+
 export const getSnap = createDeepEqualSelector(
   getSnaps,
   (_, snapId) => snapId,
@@ -1501,25 +1505,31 @@ export const getSnap = createDeepEqualSelector(
 );
 
 /**
- * Get a selector that returns the snap manifest for a given `snapId`.
+ * Get a selector that returns all Snaps metadata (name and description) for all Snaps.
  *
  * @param {object} state - The Redux state object.
- * @param {string} snapId - The snap ID to get the manifest for.
- * @returns {object | undefined} The snap manifest.
+ * @returns {object} An object mapping all installed snaps to their metadata, which contains the snap name and description.
  */
-export const getSnapManifest = createDeepEqualSelector(
-  (state) => state.metamask.currentLocale,
-  (state, snapId) => getSnap(state, snapId),
-  (locale, snap) => {
-    if (!snap?.localizationFiles) {
-      return snap?.manifest;
-    }
+export const getSnapsMetadata = createDeepEqualSelector(
+  getLocale,
+  getSnaps,
+  (locale, snaps) => {
+    return Object.values(snaps).reduce((snapsMetadata, snap) => {
+      const snapId = snap.id;
+      const manifest = snap.localizationFiles
+        ? getLocalizedSnapManifest(
+            snap.manifest,
+            locale,
+            snap.localizationFiles,
+          )
+        : snap.manifest;
 
-    return getLocalizedSnapManifest(
-      snap.manifest,
-      locale,
-      snap.localizationFiles,
-    );
+      snapsMetadata[snapId] = {
+        name: manifest.proposedName,
+        description: manifest.description,
+      };
+      return snapsMetadata;
+    }, {});
   },
 );
 
@@ -1532,35 +1542,14 @@ export const getSnapManifest = createDeepEqualSelector(
  * @returns {object} An object containing the snap name and description.
  */
 export const getSnapMetadata = createDeepEqualSelector(
-  (state, snapId) => getSnapManifest(state, snapId),
+  getSnapsMetadata,
   (_, snapId) => snapId,
-  (manifest, snapId) => {
-    return {
-      // The snap manifest may not be available if the Snap is not installed, so
-      // we use the snap ID as the name in that case.
-      name: manifest?.proposedName ?? (snapId ? stripSnapPrefix(snapId) : null),
-      description: manifest?.description,
-    };
-  },
-);
-
-/**
- * Get a selector that returns all snaps metadata (name and description) for a
- * given `snapId`.
- *
- * @param {object} state - The Redux state object.
- * @returns {object} An object mapping all installed snaps to their metadata, which contains the snap name and description.
- */
-export const getSnapsMetadata = createDeepEqualSelector(
-  (state) => state,
-  (state) => {
-    return Object.keys(getSnaps(state));
-  },
-  (state, snapIds) => {
-    return snapIds.reduce((snapsMetadata, snapId) => {
-      snapsMetadata[snapId] = getSnapMetadata(state, snapId);
-      return snapsMetadata;
-    }, {});
+  (metadata, snapId) => {
+    return (
+      metadata[snapId] ?? {
+        name: snapId ? stripSnapPrefix(snapId) : null,
+      }
+    );
   },
 );
 


### PR DESCRIPTION
## **Description**

Rewrites the `getSnapsMetadata` and `getSnapMetadata` selectors to make them effectively memoized. Previously they would require the entire state and thus often cause re-renders even though the relevant state had not changed. While rewriting the functions, I also made a few simplifications.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/24344?quickstart=1)
