### PR TITLE
fix: snap avatar colors

### DIFF
--- a/ui/components/app/snaps/snap-avatar/snap-avatar.js
+++ b/ui/components/app/snaps/snap-avatar/snap-avatar.js
@@ -64,7 +64,9 @@ const SnapAvatar = ({
     >
       {iconUrl ? (
         <AvatarFavicon
-          style={{ "background-color": 'var(--color-background-alternative-hover)' }}
+          style={{
+            'background-color': 'var(--color-background-alternative-hover)',
+          }}
           size={avatarSize}
           src={iconUrl}
           name={snapName}
@@ -76,7 +78,10 @@ const SnapAvatar = ({
           alignItems={AlignItems.center}
           justifyContent={JustifyContent.center}
           color={TextColor.textAlternative}
-          style={{ borderWidth: '0px', "background-color": 'var(--color-background-alternative-hover)' }}
+          style={{
+            borderWidth: '0px',
+            'background-color': 'var(--color-background-alternative-hover)',
+          }}
         >
           {fallbackIcon}
         </AvatarBase>

--- a/ui/components/app/snaps/snap-avatar/snap-avatar.js
+++ b/ui/components/app/snaps/snap-avatar/snap-avatar.js
@@ -53,7 +53,7 @@ const SnapAvatar = ({
           iconName={IconName.Snaps}
           size={badgeSize}
           backgroundColor={IconColor.infoDefault}
-          borderColor={BackgroundColor.backgroundDefault}
+          borderColor={BackgroundColor.backgroundAlternative}
           borderWidth={borderWidth}
           iconProps={{
             color: IconColor.infoInverse,
@@ -64,7 +64,7 @@ const SnapAvatar = ({
     >
       {iconUrl ? (
         <AvatarFavicon
-          backgroundColor={BackgroundColor.backgroundAlternative}
+          style={{ "background-color": 'var(--color-background-alternative-hover)' }}
           size={avatarSize}
           src={iconUrl}
           name={snapName}
@@ -76,8 +76,7 @@ const SnapAvatar = ({
           alignItems={AlignItems.center}
           justifyContent={JustifyContent.center}
           color={TextColor.textAlternative}
-          style={{ borderWidth: '0px' }}
-          backgroundColor={BackgroundColor.backgroundAlternative}
+          style={{ borderWidth: '0px', "background-color": 'var(--color-background-alternative-hover)' }}
         >
           {fallbackIcon}
         </AvatarBase>

--- a/ui/pages/confirmations/confirmation/templates/__snapshots__/create-snap-account.test.js.snap
+++ b/ui/pages/confirmations/confirmation/templates/__snapshots__/create-snap-account.test.js.snap
@@ -31,7 +31,7 @@ exports[`create-snap-account confirmation should match snapshot 1`] = `
                 class="mm-box mm-badge-wrapper__badge-container mm-badge-wrapper__badge-container--circular-bottom-right"
               >
                 <div
-                  class="mm-box mm-text mm-avatar-base mm-avatar-base--size-sm mm-avatar-icon mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-primary-default mm-box--background-color-info-default mm-box--rounded-full mm-box--border-color-background-default mm-box--border-width-2 box--border-style-solid"
+                  class="mm-box mm-text mm-avatar-base mm-avatar-base--size-sm mm-avatar-icon mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-primary-default mm-box--background-color-info-default mm-box--rounded-full mm-box--border-color-background-alternative mm-box--border-width-2 box--border-style-solid"
                 >
                   <span
                     class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-info-inverse"

--- a/ui/pages/confirmations/confirmation/templates/__snapshots__/remove-snap-account.test.js.snap
+++ b/ui/pages/confirmations/confirmation/templates/__snapshots__/remove-snap-account.test.js.snap
@@ -31,7 +31,7 @@ exports[`remove-snap-account confirmation should match snapshot 1`] = `
                 class="mm-box mm-badge-wrapper__badge-container mm-badge-wrapper__badge-container--circular-bottom-right"
               >
                 <div
-                  class="mm-box mm-text mm-avatar-base mm-avatar-base--size-sm mm-avatar-icon mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-primary-default mm-box--background-color-info-default mm-box--rounded-full mm-box--border-color-background-default mm-box--border-width-2 box--border-style-solid"
+                  class="mm-box mm-text mm-avatar-base mm-avatar-base--size-sm mm-avatar-icon mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-primary-default mm-box--background-color-info-default mm-box--rounded-full mm-box--border-color-background-alternative mm-box--border-width-2 box--border-style-solid"
                 >
                   <span
                     class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-info-inverse"

--- a/ui/pages/confirmations/confirmation/templates/__snapshots__/snap-account-redirect.test.js.snap
+++ b/ui/pages/confirmations/confirmation/templates/__snapshots__/snap-account-redirect.test.js.snap
@@ -31,7 +31,7 @@ exports[`snap-account-redirect confirmation should match snapshot 1`] = `
                 class="mm-box mm-badge-wrapper__badge-container mm-badge-wrapper__badge-container--circular-bottom-right"
               >
                 <div
-                  class="mm-box mm-text mm-avatar-base mm-avatar-base--size-sm mm-avatar-icon mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-primary-default mm-box--background-color-info-default mm-box--rounded-full mm-box--border-color-background-default mm-box--border-width-2 box--border-style-solid"
+                  class="mm-box mm-text mm-avatar-base mm-avatar-base--size-sm mm-avatar-icon mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-primary-default mm-box--background-color-info-default mm-box--rounded-full mm-box--border-color-background-alternative mm-box--border-width-2 box--border-style-solid"
                 >
                   <span
                     class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-info-inverse"

--- a/ui/pages/snap-account-redirect/__snapshots__/create-snap-redirect.test.tsx.snap
+++ b/ui/pages/snap-account-redirect/__snapshots__/create-snap-redirect.test.tsx.snap
@@ -25,7 +25,7 @@ exports[`<SnapAccountRedirect /> renders the url and message when provided and i
             class="mm-box mm-badge-wrapper__badge-container mm-badge-wrapper__badge-container--circular-bottom-right"
           >
             <div
-              class="mm-box mm-text mm-avatar-base mm-avatar-base--size-sm mm-avatar-icon mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-primary-default mm-box--background-color-info-default mm-box--rounded-full mm-box--border-color-background-default mm-box--border-width-2 box--border-style-solid"
+              class="mm-box mm-text mm-avatar-base mm-avatar-base--size-sm mm-avatar-icon mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-primary-default mm-box--background-color-info-default mm-box--rounded-full mm-box--border-color-background-alternative mm-box--border-width-2 box--border-style-solid"
             >
               <span
                 class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-info-inverse"


### PR DESCRIPTION
## **Description**

Adjusts the background and border color of `SnapAvatar` by request of @eriknson. I had to use `style` since the color we wanna use is not available in `BackgroundColor`.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/24346?quickstart=1)