### PR TITLE
temp: test preinstalled snaps mv3 bug

### DIFF
--- a/app/scripts/controllers/authentication/authentication-controller.ts
+++ b/app/scripts/controllers/authentication/authentication-controller.ts
@@ -162,6 +162,11 @@ export default class AuthenticationController extends BaseController<
     });
   }
 
+  public async getPublicKey() {
+    const key = await this.#snapGetPublicKey();
+    return key;
+  }
+
   public async getBearerToken(): Promise<string> {
     this.#assertLoggedIn();
 

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -1444,6 +1444,17 @@ export default class MetamaskController extends EventEmitter {
         state: initState.PushPlatformNotificationsController,
       });
 
+    const test = async () => {
+      try {
+        console.log('AUTH: START TEST');
+        const x = await this.authenticationController.getPublicKey();
+        console.log('AUTH: ', x);
+      } catch (e) {
+        console.error('AUTH: UNABLE TO TEST', e);
+      }
+    };
+    test();
+
     // account tracker watches balances, nonces, and any code at their address
     this.accountTracker = new AccountTracker({
       provider: this.provider,


### PR DESCRIPTION
This might just be a red herring. Was able to test this using our pre-installed snap & refreshing the build/service worker.

[See showcase/example](https://www.loom.com/share/a4529e68488e496ebe6a7a37aa99edb3?sid=d43b0d86-ea6b-40d0-a5f0-2bdc4df71f38)

To run:
```
1. `nvm use && yarn && yarn start:mv3`
2. Create an account or import an account.
3. Open service worker logs
4. Test restarting the extension through the extension manager. Depending on your machine it might take a few clicks to potentially have >1 service worker.
```