### PR TITLE
fix: Ensure smart transaction modal is shown for users upgrading from previous versions

### DIFF
--- a/shared/modules/selectors/smart-transactions.ts
+++ b/shared/modules/selectors/smart-transactions.ts
@@ -13,7 +13,7 @@ import {
 type SmartTransactionsMetaMaskState = {
   metamask: {
     preferences: {
-      smartTransactionsOptInStatus: boolean | null;
+      smartTransactionsOptInStatus?: boolean | null;
     };
     internalAccounts: {
       selectedAccount: string;
@@ -62,7 +62,7 @@ type SmartTransactionsMetaMaskState = {
 export const getSmartTransactionsOptInStatus = (
   state: SmartTransactionsMetaMaskState,
 ): boolean | null => {
-  return state.metamask.preferences?.smartTransactionsOptInStatus;
+  return state.metamask.preferences?.smartTransactionsOptInStatus ?? null;
 };
 
 export const getCurrentChainSupportsSmartTransactions = (


### PR DESCRIPTION
## **Description**

This fixes a bug I found while testing v11.15.1. The bug is that currently only new users will see the "Enable Smart Transactions" modal. People who already have metamask installed and then update to v11.15.1 will not see the "Enable Smart Transactions" modal. This means that existing users won't be notified that they can turn this functionality on.

The reason is that `getIsSmartTransactionsOptInModalAvailable` only returns true if the result of `getSmartTransactionsOptInStatus(state)` is `null`. That depends on the `smartTransactionsOptInStatus` property, from the preferences controller. That property is set within the `preferencesController.preferences` property, which is an object, within `initState` of the the preferences controller. `initState` is always over written by pre-existing state if it existis (via the `...opts.initState,` line). If a user is updating to v11.15.1 from a previous version, `preferencesController.preferences` from the previous version will overwrite the default `preferencesController.preferences`, and so `smartTransactionsOptInStatus` will be `undefined` (and not `null`).

The simple fix applied here is for `getSmartTransactionsOptInStatus` to return `null` if `smartTransactionsOptInStatus` is undefined.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/24377?quickstart=1)

## **Manual testing steps**

1. Locally build and install v11.14.5 and onboard
2. Build this branch and update the existing local build to the build generated by this branch
3. open metamask and you should see the "Enable Smart Transactions" modal

Follow the above 3 steps on `develop` or on `Version-v11.15.1`, and there will be no modal shown on step three.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
