### PR TITLE
chore(ci): skip check-pr-tag job if not PR

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -408,6 +408,9 @@ jobs:
             #!/bin/bash
 
             GH_LABEL=team-mmi
+            if [ -z "$CIRCLE_PULL_REQUESTS" ]; then
+              exit 0
+            fi
 
             echo $CIRCLE_PULL_REQUESTS | sed 's/,/\n/g'
 


### PR DESCRIPTION
## **Description**

Skip `check-pr-tag` job when there is no associated PR.

Fix [failing](https://app.circleci.com/pipelines/github/MetaMask/metamask-extension/78928/workflows/4d59b259-806d-4ad0-8c54-66b3c61702a2/jobs/2758001) CI check on `develop`.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/24379?quickstart=1)

## **Related issues**

- Follow-up to #24193

## **Manual testing steps**


## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
