### PR TITLE
Version v11.15.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [11.15.2]
+### Fixed
+- Ensure smart transaction modal is shown for users upgrading from previous versions ([#24377](https://github.com/MetaMask/metamask-extension/pull/24377))
+
 ## [11.15.1]
 ### Changed
 - Restores 11.15.0, and also incorporates the 11.14.4 and 11.14.5 changes
@@ -4673,7 +4677,8 @@ Update styles and spacing on the critical error page  ([#20350](https://github.c
 - Added the ability to restore accounts from seed words.
 
 
-[Unreleased]: https://github.com/MetaMask/metamask-extension/compare/v11.15.1...HEAD
+[Unreleased]: https://github.com/MetaMask/metamask-extension/compare/v11.15.2...HEAD
+[11.15.2]: https://github.com/MetaMask/metamask-extension/compare/v11.15.1...v11.15.2
 [11.15.1]: https://github.com/MetaMask/metamask-extension/compare/v11.15.0...v11.15.1
 [11.15.0]: https://github.com/MetaMask/metamask-extension/compare/v11.14.5...v11.15.0
 [11.14.5]: https://github.com/MetaMask/metamask-extension/compare/v11.14.4...v11.14.5

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metamask-crx",
-  "version": "11.15.1",
+  "version": "11.15.2",
   "private": true,
   "repository": {
     "type": "git",

--- a/shared/modules/selectors/smart-transactions.ts
+++ b/shared/modules/selectors/smart-transactions.ts
@@ -13,7 +13,7 @@ import {
 type SmartTransactionsMetaMaskState = {
   metamask: {
     preferences: {
-      smartTransactionsOptInStatus: boolean | null;
+      smartTransactionsOptInStatus?: boolean | null;
     };
     internalAccounts: {
       selectedAccount: string;
@@ -62,7 +62,7 @@ type SmartTransactionsMetaMaskState = {
 export const getSmartTransactionsOptInStatus = (
   state: SmartTransactionsMetaMaskState,
 ): boolean | null => {
-  return state.metamask.preferences?.smartTransactionsOptInStatus;
+  return state.metamask.preferences?.smartTransactionsOptInStatus ?? null;
 };
 
 export const getCurrentChainSupportsSmartTransactions = (


### PR DESCRIPTION
Manual testing steps:

1. Download v11.14.5 from the releases page (https://github.com/MetaMask/metamask-extension/releases/download/v11.14.5/metamask-chrome-11.14.5.zip)
2. Unzip
3. go to chrome://extensions and "Load unpacked", selecting the file that was just unzipped
4. Install and onboard
5. Download v11.15.1 from the releases page (https://github.com/MetaMask/metamask-extension/releases/download/v11.15.1/metamask-chrome-11.15.1.zip)
6. Unzip
7. Delete the contents of the unzipped v11.14.5 folder
8. Copy the contents of the unzipped v11.15.1 to the v11.14.5 folder
9. Go to chrome://extensions and reload the extension installed in step 3
10. install and onboard
11. Notice that there is no "Enable smart transactions" modal shown to the user
12. Download the build posted by MetaMask bot below (https://output.circle-artifacts.com/output/job/e99a3fdb-e19c-496f-8816-d90dfeab0975/artifacts/0/builds/metamask-chrome-11.15.2.zip)
13. Repeat steps 6->10 with this build
14. you should now see an "Enable Smart Transaction" modal