### PR TITLE
fix: gas fee editing in advance gas fee modals

### DIFF
--- a/ui/pages/confirmations/components/advanced-gas-fee-popover/advanced-gas-fee-inputs/base-fee-input/base-fee-input.js
+++ b/ui/pages/confirmations/components/advanced-gas-fee-popover/advanced-gas-fee-inputs/base-fee-input/base-fee-input.js
@@ -78,8 +78,10 @@ const BaseFeeInput = () => {
 
   const [baseFee, setBaseFee] = useState(defaultBaseFee);
   useEffect(() => {
-    setBaseFee(defaultBaseFee);
-  }, [defaultBaseFee, setBaseFee]);
+    if (maxBaseFeeNumber === null) {
+      setBaseFee(defaultBaseFee);
+    }
+  }, [maxBaseFeeNumber, defaultBaseFee, setBaseFee]);
 
   const [baseFeeInPrimaryCurrency] = useCurrencyDisplay(
     decGWEIToHexWEI(baseFee * gasLimit),

--- a/ui/pages/confirmations/components/advanced-gas-fee-popover/advanced-gas-fee-inputs/base-fee-input/base-fee-input.js
+++ b/ui/pages/confirmations/components/advanced-gas-fee-popover/advanced-gas-fee-inputs/base-fee-input/base-fee-input.js
@@ -76,12 +76,14 @@ const BaseFeeInput = () => {
       ? advancedGasFeeValues.maxBaseFee
       : maxFeePerGas;
 
-  const [baseFee, setBaseFee] = useState(defaultBaseFee);
+  const [baseFee, setBaseFee] = useState(
+    defaultBaseFee > 0 ? defaultBaseFee : undefined,
+  );
   useEffect(() => {
-    if (maxBaseFeeNumber === null) {
+    if (baseFee === undefined && defaultBaseFee > 0) {
       setBaseFee(defaultBaseFee);
     }
-  }, [maxBaseFeeNumber, defaultBaseFee, setBaseFee]);
+  }, [baseFee, defaultBaseFee, setBaseFee]);
 
   const [baseFeeInPrimaryCurrency] = useCurrencyDisplay(
     decGWEIToHexWEI(baseFee * gasLimit),

--- a/ui/pages/confirmations/components/advanced-gas-fee-popover/advanced-gas-fee-inputs/priority-fee-input/priority-fee-input.js
+++ b/ui/pages/confirmations/components/advanced-gas-fee-popover/advanced-gas-fee-inputs/priority-fee-input/priority-fee-input.js
@@ -78,8 +78,10 @@ const PriorityFeeInput = () => {
 
   const [priorityFee, setPriorityFee] = useState(defaultPriorityFee);
   useEffect(() => {
-    setPriorityFee(defaultPriorityFee);
-  }, [defaultPriorityFee, setPriorityFee]);
+    if (maxPriorityFeePerGasNumber === null) {
+      setPriorityFee(defaultPriorityFee);
+    }
+  }, [maxPriorityFeePerGasNumber, defaultPriorityFee, setPriorityFee]);
 
   const { currency, numberOfDecimals } = useUserPreferencedCurrency(PRIMARY);
 

--- a/ui/pages/confirmations/components/advanced-gas-fee-popover/advanced-gas-fee-inputs/priority-fee-input/priority-fee-input.js
+++ b/ui/pages/confirmations/components/advanced-gas-fee-popover/advanced-gas-fee-inputs/priority-fee-input/priority-fee-input.js
@@ -76,12 +76,14 @@ const PriorityFeeInput = () => {
       ? advancedGasFeeValues.priorityFee
       : maxPriorityFeePerGas;
 
-  const [priorityFee, setPriorityFee] = useState(defaultPriorityFee);
+  const [priorityFee, setPriorityFee] = useState(
+    defaultPriorityFee > 0 ? defaultPriorityFee : undefined,
+  );
   useEffect(() => {
-    if (maxPriorityFeePerGasNumber === null) {
+    if (priorityFee === undefined && defaultPriorityFee > 0) {
       setPriorityFee(defaultPriorityFee);
     }
-  }, [maxPriorityFeePerGasNumber, defaultPriorityFee, setPriorityFee]);
+  }, [priorityFee, defaultPriorityFee, setPriorityFee]);
 
   const { currency, numberOfDecimals } = useUserPreferencedCurrency(PRIMARY);
 


### PR DESCRIPTION
## **Description**

Fix for user unable to manually edit gas fee in advance gas fee editing modal.

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/24260

## **Manual testing steps**

1. Go to advance gas fee editing modal
2. Manually edit gas fee
3. New edited gas value should be retained

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [X] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
