### PR TITLE
fix: Move "SettingsUpdated" event into the "setSmartTransactionsOptInStatus" function

### DIFF
--- a/ui/pages/settings/advanced-tab/advanced-tab.component.js
+++ b/ui/pages/settings/advanced-tab/advanced-tab.component.js
@@ -287,13 +287,6 @@ export default class AdvancedTab extends PureComponent {
             value={smartTransactionsOptInStatus}
             onToggle={(oldValue) => {
               const newValue = !oldValue;
-              this.context.trackEvent({
-                category: MetaMetricsEventCategory.Settings,
-                event: MetaMetricsEventName.SettingsUpdated,
-                properties: {
-                  stx_opt_in: newValue,
-                },
-              });
               setSmartTransactionsOptInStatus(newValue);
             }}
             offLabel={t('off')}

--- a/ui/store/actions.ts
+++ b/ui/store/actions.ts
@@ -91,6 +91,8 @@ import {
   MetaMetricsPageOptions,
   MetaMetricsPagePayload,
   MetaMetricsReferrerObject,
+  MetaMetricsEventCategory,
+  MetaMetricsEventName,
 } from '../../shared/constants/metametrics';
 import { parseSmartTransactionsError } from '../pages/swaps/swaps.util';
 import { isEqualCaseInsensitive } from '../../shared/modules/string-utils';
@@ -3080,6 +3082,13 @@ export function setShowExtensionInFullSizeView(value: boolean) {
 }
 
 export function setSmartTransactionsOptInStatus(value: boolean) {
+  trackMetaMetricsEvent({
+    category: MetaMetricsEventCategory.Settings,
+    event: MetaMetricsEventName.SettingsUpdated,
+    properties: {
+      stx_opt_in: value,
+    },
+  });
   return setPreference('smartTransactionsOptInStatus', value);
 }
 


### PR DESCRIPTION
## **Description**
Move the "SettingsUpdated" event with the "stx_opt_in" prop into the "setSmartTransactionsOptInStatus" function.

## **Related issues**

Fixes:

## **Manual testing steps**
1. Install the extension
2. Opt in or opt out from Smart Transactions in the modal window or from Advanced Settings
3. See the "Settings Updated" event triggered

## **Screenshots/Recordings**


## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
