### PR TITLE
cherrypick: fix: Move "SettingsUpdated" event into v11.15.3

### DIFF
--- a/ui/pages/settings/advanced-tab/advanced-tab.component.js
+++ b/ui/pages/settings/advanced-tab/advanced-tab.component.js
@@ -287,13 +287,6 @@ export default class AdvancedTab extends PureComponent {
             value={smartTransactionsOptInStatus}
             onToggle={(oldValue) => {
               const newValue = !oldValue;
-              this.context.trackEvent({
-                category: MetaMetricsEventCategory.Settings,
-                event: MetaMetricsEventName.SettingsUpdated,
-                properties: {
-                  stx_opt_in: newValue,
-                },
-              });
               setSmartTransactionsOptInStatus(newValue);
             }}
             offLabel={t('off')}

--- a/ui/store/actions.ts
+++ b/ui/store/actions.ts
@@ -91,6 +91,8 @@ import {
   MetaMetricsPageOptions,
   MetaMetricsPagePayload,
   MetaMetricsReferrerObject,
+  MetaMetricsEventCategory,
+  MetaMetricsEventName,
 } from '../../shared/constants/metametrics';
 import { parseSmartTransactionsError } from '../pages/swaps/swaps.util';
 import { isEqualCaseInsensitive } from '../../shared/modules/string-utils';
@@ -3082,6 +3084,13 @@ export function setShowExtensionInFullSizeView(value: boolean) {
 }
 
 export function setSmartTransactionsOptInStatus(value: boolean) {
+  trackMetaMetricsEvent({
+    category: MetaMetricsEventCategory.Settings,
+    event: MetaMetricsEventName.SettingsUpdated,
+    properties: {
+      stx_opt_in: value,
+    },
+  });
   return setPreference('smartTransactionsOptInStatus', value);
 }
 


### PR DESCRIPTION
Cherry-pick f77eac57f9da62618c69fcf6f9cb86cbcbd0ada2 (#24394) into v11.15.3