### PR TITLE
Patches ^15.1.0 of gas-fee-controller, to avoid uneccesary sentry errors

### DIFF
--- a/.yarn/patches/@metamask-gas-fee-controller-npm-15.1.1-f8009af091.patch
+++ b/.yarn/patches/@metamask-gas-fee-controller-npm-15.1.1-f8009af091.patch
@@ -1,0 +1,14 @@
+diff --git a/dist/chunk-JVVQPARV.js b/dist/chunk-JVVQPARV.js
+index f7a7f488466dcbed3e81367536288bdf777aa8d0..8886810b552684a3737d51e7cf9aece868eb1a2f 100644
+--- a/dist/chunk-JVVQPARV.js
++++ b/dist/chunk-JVVQPARV.js
+@@ -32,7 +32,8 @@ var metadata = {
+   },
+   gasFeeEstimates: { persist: true, anonymous: false },
+   estimatedGasFeeTimeBounds: { persist: true, anonymous: false },
+-  gasEstimateType: { persist: true, anonymous: false }
++  gasEstimateType: { persist: true, anonymous: false },
++  nonRPCGasFeeApisDisabled: { persist: true, anonymous: false },
+ };
+ var name = "GasFeeController";
+ var defaultState = {

--- a/package.json
+++ b/package.json
@@ -239,7 +239,8 @@
     "@metamask/network-controller@npm:^18.0.1": "patch:@metamask/network-controller@npm%3A18.0.1#~/.yarn/patches/@metamask-network-controller-npm-18.0.1-c4d0cfaecd.patch",
     "@metamask/network-controller@npm:^17.2.1": "patch:@metamask/network-controller@npm%3A18.0.1#~/.yarn/patches/@metamask-network-controller-npm-18.0.1-c4d0cfaecd.patch",
     "@metamask/keyring-controller@npm:^13.0.0": "patch:@metamask/keyring-controller@npm%3A13.0.0#~/.yarn/patches/@metamask-keyring-controller-npm-13.0.0-d94816a680.patch",
-    "@metamask/gas-fee-controller@npm:^14.0.1": "patch:@metamask/gas-fee-controller@npm%3A14.0.1#~/.yarn/patches/@metamask-gas-fee-controller-npm-14.0.1-59e9d16a4e.patch"
+    "@metamask/gas-fee-controller@npm:^14.0.1": "patch:@metamask/gas-fee-controller@npm%3A14.0.1#~/.yarn/patches/@metamask-gas-fee-controller-npm-14.0.1-59e9d16a4e.patch",
+    "@metamask/gas-fee-controller@npm:^15.1.0": "patch:@metamask/gas-fee-controller@npm%3A15.1.1#~/.yarn/patches/@metamask-gas-fee-controller-npm-15.1.1-f8009af091.patch"
   },
   "dependencies": {
     "@babel/runtime": "patch:@babel/runtime@npm%3A7.24.0#~/.yarn/patches/@babel-runtime-npm-7.24.0-7eb1dd11a2.patch",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4715,7 +4715,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/gas-fee-controller@npm:^15.1.0":
+"@metamask/gas-fee-controller@npm:15.1.1":
   version: 15.1.1
   resolution: "@metamask/gas-fee-controller@npm:15.1.1"
   dependencies:
@@ -4754,6 +4754,27 @@ __metadata:
   peerDependencies:
     "@metamask/network-controller": ^18.0.0
   checksum: 93ff5edb72ce5c877c2bb35de09795ee824ea0709ca16569cdc98d957f286c56e61e9df643afd1bbde862d8ba8593eb9d56511b519201d2a975dade15a89a7a0
+  languageName: node
+  linkType: hard
+
+"@metamask/gas-fee-controller@patch:@metamask/gas-fee-controller@npm%3A15.1.1#~/.yarn/patches/@metamask-gas-fee-controller-npm-15.1.1-f8009af091.patch":
+  version: 15.1.1
+  resolution: "@metamask/gas-fee-controller@patch:@metamask/gas-fee-controller@npm%3A15.1.1#~/.yarn/patches/@metamask-gas-fee-controller-npm-15.1.1-f8009af091.patch::version=15.1.1&hash=ba220a"
+  dependencies:
+    "@metamask/base-controller": "npm:^5.0.2"
+    "@metamask/controller-utils": "npm:^9.1.0"
+    "@metamask/eth-query": "npm:^4.0.0"
+    "@metamask/ethjs-unit": "npm:^0.3.0"
+    "@metamask/network-controller": "npm:^18.1.0"
+    "@metamask/polling-controller": "npm:^6.0.2"
+    "@metamask/utils": "npm:^8.3.0"
+    "@types/bn.js": "npm:^5.1.5"
+    "@types/uuid": "npm:^8.3.0"
+    bn.js: "npm:^5.2.1"
+    uuid: "npm:^8.3.2"
+  peerDependencies:
+    "@metamask/network-controller": ^18.0.0
+  checksum: 3b928bad468aa1d90cc09a0ef4d2058aaa84238b25c4b8bbb476d6682d33d47976d1c615aaef026e34580b1ad06d663318bc0ae0664d8908feb46b83d56a6ba3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## **Description**

There is an error happening in the background of v11.15.x:

![Screenshot from 2024-05-07 17-39-13](https://github.com/MetaMask/metamask-extension/assets/7499938/935e3aaf-cfe4-46e8-a927-ce5f7e203bbb)

I don't believe this affects user experience, but it will create a lot of unnecessary noise on sentry. This problem is fixed in  https://github.com/MetaMask/core/pull/4245, but that is not released. To unblock the v11.15.3 release, this PR adds the change from that core PR as a patch. Meanwhile, we will make sure that patch lands in develop very soon.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/24416?quickstart=1)

## **Manual testing steps**

1. The error in the above screenshot should no longer appear in the background console

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
