### PR TITLE
test: Attempt to make the test/e2e/tests/request-queuing/ui.spec.js test less flaky

### DIFF
--- a/test/e2e/tests/request-queuing/ui.spec.js
+++ b/test/e2e/tests/request-queuing/ui.spec.js
@@ -75,6 +75,10 @@ async function selectDappClickSendGetNetwork(driver, dappUrl) {
 }
 
 describe('Request-queue UI changes', function () {
+  if (!process.env.MULTICHAIN) {
+    return;
+  }
+
   it('UI should show network specific to domain @no-mmi', async function () {
     const port = 8546;
     const chainId = 1338;


### PR DESCRIPTION

## **Description**

Isolating  the request queueing E2E to just when MULTICHAIN is on.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/24417?quickstart=1)

## **Related issues**

Fixes: N/A

## **Manual testing steps**

1. N/A, it's an E2E

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
