### PR TITLE
chore: update confirmations codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -52,8 +52,8 @@ privacy-snapshot.json                @MetaMask/extension-privacy-reviewers
 # who were involved with the Codespaces project.
 .devcontainer/                       @MetaMask/library-admins @HowardBraham @plasmacorral
 
-# Confirmations UX team to own code for confirmations on UI.
-ui/pages/confirmations               @MetaMask/confirmations-ux @MetaMask/confirmations-system-team
+# Confirmations team to own code for confirmations on UI.
+ui/pages/confirmations               @MetaMask/confirmations
 
 # MMI team is responsible for code related with Institutioanl version of MetaMask
 ui/pages/institutional               @MetaMask/mmi


### PR DESCRIPTION
## **Description**

Updates the codeowners file to reference the new Confirmations team.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/24427?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
