### PR TITLE
Cherry-pick fix: decimals and fiat conversion crashes in simulation (#24422) into Version-v11.16.0

### DIFF
--- a/ui/pages/confirmations/components/simulation-details/useBalanceChanges.test.ts
+++ b/ui/pages/confirmations/components/simulation-details/useBalanceChanges.test.ts
@@ -41,8 +41,10 @@ const ETH_TO_FIAT_RATE = 3;
 
 const ERC20_TOKEN_ADDRESS_1_MOCK: Hex = '0x0erc20_1';
 const ERC20_TOKEN_ADDRESS_2_MOCK: Hex = '0x0erc20_2';
+const ERC20_TOKEN_ADDRESS_3_MOCK: Hex = '0x0erc20_3';
 const ERC20_DECIMALS_1_MOCK = 3;
 const ERC20_DECIMALS_2_MOCK = 4;
+const ERC20_DECIMALS_INVALID_MOCK = 'xyz';
 const ERC20_TO_FIAT_RATE_1_MOCK = 1.5;
 const ERC20_TO_FIAT_RATE_2_MOCK = 6;
 
@@ -68,9 +70,10 @@ describe('useBalanceChanges', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockGetTokenStandardAndDetails.mockImplementation((address: Hex) => {
-      const decimalMap: Record<Hex, number> = {
+      const decimalMap: Record<Hex, number | string> = {
         [ERC20_TOKEN_ADDRESS_1_MOCK]: ERC20_DECIMALS_1_MOCK,
         [ERC20_TOKEN_ADDRESS_2_MOCK]: ERC20_DECIMALS_2_MOCK,
+        [ERC20_TOKEN_ADDRESS_3_MOCK]: ERC20_DECIMALS_INVALID_MOCK,
       };
       if (decimalMap[address]) {
         return Promise.resolve({
@@ -253,6 +256,41 @@ describe('useBalanceChanges', () => {
 
       expect(result.current.value[0].amount.decimalPlaces()).toBe(18);
     });
+
+    it('uses default decimals when token details are not valid numbers', async () => {
+      const { result, waitForNextUpdate } = setupHook([
+        {
+          ...dummyBalanceChange,
+          difference: DIFFERENCE_1_MOCK,
+          isDecrease: true,
+          address: ERC20_TOKEN_ADDRESS_3_MOCK,
+          standard: SimulationTokenStandard.erc20,
+        },
+      ]);
+
+      await waitForNextUpdate();
+
+      expect(result.current.value[0].amount.decimalPlaces()).toBe(18);
+    });
+
+    it('handles token fiat rate with more than 15 significant digits', async () => {
+      mockFetchTokenExchangeRates.mockResolvedValue({
+        [ERC20_TOKEN_ADDRESS_1_MOCK]: 0.1234567890123456,
+      });
+      const { result, waitForNextUpdate } = setupHook([
+        {
+          ...dummyBalanceChange,
+          difference: DIFFERENCE_1_MOCK,
+          isDecrease: true,
+          address: ERC20_TOKEN_ADDRESS_1_MOCK,
+          standard: SimulationTokenStandard.erc20,
+        },
+      ]);
+
+      await waitForNextUpdate();
+
+      expect(result.current.value[0].fiatAmount).toBe(-0.002098765413209875);
+    });
   });
 
   describe('with native balance change', () => {
@@ -285,6 +323,19 @@ describe('useBalanceChanges', () => {
           fiatAmount: Number('-16119.010925996032'),
         },
       ]);
+    });
+
+    it('handles native fiat rate with more than 15 significant digits', async () => {
+      mockGetConversionRate.mockReturnValue(0.1234567890123456);
+      const { result, waitForNextUpdate } = setupHook({
+        ...dummyBalanceChange,
+        difference: DIFFERENCE_ETH_MOCK,
+        isDecrease: true,
+      });
+
+      await waitForNextUpdate();
+
+      expect(result.current.value[0].fiatAmount).toBe(-663.3337769927953);
     });
 
     it('handles no native balance change', async () => {

--- a/ui/pages/confirmations/components/simulation-details/useBalanceChanges.ts
+++ b/ui/pages/confirmations/components/simulation-details/useBalanceChanges.ts
@@ -25,6 +25,11 @@ const NATIVE_DECIMALS = 18;
 
 const ERC20_DEFAULT_DECIMALS = 18;
 
+// See https://github.com/MikeMcl/bignumber.js/issues/11#issuecomment-23053776
+function convertNumberToStringWithPrecisionWarning(value: number): string {
+  return String(value);
+}
+
 // Converts a SimulationTokenStandard to a TokenStandard
 function convertStandard(standard: SimulationTokenStandard) {
   switch (standard) {
@@ -55,8 +60,17 @@ function getAssetAmount(
 // Fetches the decimals for the given token address.
 async function fetchErc20Decimals(address: Hex): Promise<number> {
   try {
-    const { decimals } = await getTokenStandardAndDetails(address);
-    return decimals ? parseInt(decimals, 10) : ERC20_DEFAULT_DECIMALS;
+    const { decimals: decStr } = await getTokenStandardAndDetails(address);
+    if (!decStr) {
+      return ERC20_DEFAULT_DECIMALS;
+    }
+    for (const radix of [10, 16]) {
+      const parsedDec = parseInt(decStr, radix);
+      if (isFinite(parsedDec)) {
+        return parsedDec;
+      }
+    }
+    return ERC20_DEFAULT_DECIMALS;
   } catch {
     return ERC20_DEFAULT_DECIMALS;
   }
@@ -106,7 +120,9 @@ function getNativeBalanceChange(
   }
   const asset = NATIVE_ASSET_IDENTIFIER;
   const amount = getAssetAmount(nativeBalanceChange, NATIVE_DECIMALS);
-  const fiatAmount = amount.times(nativeFiatRate).toNumber();
+  const fiatAmount = amount
+    .times(convertNumberToStringWithPrecisionWarning(nativeFiatRate))
+    .toNumber();
   return { asset, amount, fiatAmount };
 }
 
@@ -129,7 +145,9 @@ function getTokenBalanceChanges(
 
     const fiatRate = erc20FiatRates[tokenBc.address];
     const fiatAmount = fiatRate
-      ? amount.times(fiatRate).toNumber()
+      ? amount
+          .times(convertNumberToStringWithPrecisionWarning(fiatRate))
+          .toNumber()
       : FIAT_UNAVAILABLE;
 
     return { asset, amount, fiatAmount };


### PR DESCRIPTION
Cherry-pick 603b1b5900c0de3c70cdacb2ae00473a46848bac (#24422) into Version-v11.16.0

**Merge conflict resolved:**
```typescript
// Compiles the balance change for the native asset
function getNativeBalanceChange(
  nativeBalanceChange: SimulationBalanceChange | undefined,
  nativeFiatRate: number,
): BalanceChange | undefined {
  if (!nativeBalanceChange) {
    return undefined;
  }
  const asset = NATIVE_ASSET_IDENTIFIER;
  const amount = getAssetAmount(nativeBalanceChange, NATIVE_DECIMALS);
<<<<<<< HEAD - REJECTED
  const fiatAmount = amount.times(nativeFiatRate).toNumber();
======= ACCEPTED:
  const fiatAmount = amount
    .times(convertNumberToStringWithPrecisionWarning(nativeFiatRate))
    .toNumber();
>>>>>>> 603b1b5900 (fix: decimals and fiat conversion crashes in simulation (#24422))
  return { asset, amount, fiatAmount };
}
```