### PR TITLE
chore(test/e2e): Fix request-queueing/ui.spec.js

### DIFF
--- a/test/e2e/tests/request-queuing/ui.spec.js
+++ b/test/e2e/tests/request-queuing/ui.spec.js
@@ -48,8 +48,8 @@ async function openDappAndSwitchChain(driver, dappUrl, chainId) {
       params: [{ chainId }],
     });
 
-    driver.executeScript(
-      `return window.ethereum.request(${switchChainRequest})`,
+    await driver.executeScript(
+      `window.ethereum.request(${switchChainRequest})`,
     );
 
     await driver.delay(veryLargeDelayMs);


### PR DESCRIPTION
## **Description**

` request-queueing/ui.spec.js` has been particularly flaky. In particular, the problem was described as follows:

> The test stalls for 10+ seconds locally at detecting 4 windows:
> await driver.waitUntilXWindowHandles(numHandles)
> The test is doing exactly what it's meant to but the waitUntilXWindowHandles call is taking an eternity

I noticed that this line in particular in the `waitUntilXWindowHandles` helper method seemed to take a long time to resolve in only one case:
`windowHandles = await this.driver.getAllWindowHandles();`

So the problem seemed to be not with our `waitUntilXWindowHandles` itself, but something related to selenium- webdriver's own `getAllWindowHandles` method

From this stack overflow post, it seems that others have had trouble with having `getAllWindowHandles` resolve when `executeScript` is not resolved https://stackoverflow.com/questions/64687179/calling-getwindowhandles-again-causing-timeout

So the attempted fix, which worked on three successive local runs, is to properly await the executeScript that happens before the `getAllWindowHandles` call in question. We also need to remove the `return` from the script to be executed, so that webdriver-selenium is not waiting for a returned promise to resolve.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/24440?quickstart=1)


## **Manual testing steps**

1. ` request-queueing/ui.spec.js` should pass in automated tests and not be flaky


## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
