### PR TITLE
fix: fix a date in a test

### DIFF
--- a/app/scripts/controllers/metamask-notifications/mocks/mock-feature-announcements.ts
+++ b/app/scripts/controllers/metamask-notifications/mocks/mock-feature-announcements.ts
@@ -201,7 +201,7 @@ export function createMockFeatureAnnouncementAPIResult(): ContentfulResult {
 export function createMockFeatureAnnouncementRaw(): FeatureAnnouncementRawNotification {
   return {
     type: TRIGGER_TYPES.FEATURES_ANNOUNCEMENT,
-    createdAt: '2024-04-09T13:24:01.872Z',
+    createdAt: '2999-04-09T13:24:01.872Z',
     data: {
       id: 'dont-miss-out-on-airdrops-and-new-nft-mints',
       category: 'ANNOUNCEMENT',


### PR DESCRIPTION
## **Description**

A test was failing because one of the mocked objects was being filtered out and thus no longer tested. I updated the test file with a very future date (2999). At that point, I don't think we'll have a problem anymore.