### PR TITLE
Cherry-pick bump SmartTransactionController to 10.0.1 into v11.15.4

### DIFF
--- a/lavamoat/browserify/mmi/policy.json
+++ b/lavamoat/browserify/mmi/policy.json
@@ -756,12 +756,6 @@
         "@metamask/obs-store": true
       }
     },
-    "@metamask-institutional/portfolio-dashboard": {
-      "globals": {
-        "console.log": true,
-        "fetch": true
-      }
-    },
     "@metamask-institutional/rpc-allowlist": {
       "globals": {
         "URL": true

--- a/package.json
+++ b/package.json
@@ -317,7 +317,7 @@
     "@metamask/scure-bip39": "^2.0.3",
     "@metamask/selected-network-controller": "^9.0.0",
     "@metamask/signature-controller": "^12.0.0",
-    "@metamask/smart-transactions-controller": "^10.0.0",
+    "@metamask/smart-transactions-controller": "^10.0.1",
     "@metamask/snaps-controllers": "^6.0.4",
     "@metamask/snaps-execution-environments": "^5.0.4",
     "@metamask/snaps-rpc-methods": "^7.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3863,9 +3863,9 @@ __metadata:
   linkType: hard
 
 "@metamask-institutional/portfolio-dashboard@npm:^1.4.0":
-  version: 1.4.0
-  resolution: "@metamask-institutional/portfolio-dashboard@npm:1.4.0"
-  checksum: c973305d5b4088d5ae45300fc016f3cbc15232d1c8b734201a352b2296de8f21d0c1e5d9bfc6d1d164e5784e5128aaf2f6ca4370a9f6e99db3f5685a8266a5a0
+  version: 1.4.1
+  resolution: "@metamask-institutional/portfolio-dashboard@npm:1.4.1"
+  checksum: 75573d236d2dd709bcf8d0c92f69eb71f07de4ed02ef3f5122f2acf5cf29e41c9e17b14c67cea4f200e64ce2e9a6c60bc5e85508f77aa904f9bbbcf65e5efb10
   languageName: node
   linkType: hard
 
@@ -3994,7 +3994,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/approval-controller@npm:^6.0.0, @metamask/approval-controller@npm:^6.0.1":
+"@metamask/approval-controller@npm:^6.0.0":
   version: 6.0.1
   resolution: "@metamask/approval-controller@npm:6.0.1"
   dependencies:
@@ -4003,6 +4003,18 @@ __metadata:
     "@metamask/utils": "npm:^8.3.0"
     nanoid: "npm:^3.1.31"
   checksum: f7c61caf2fffb64c93ad4aa195bf251447367ed96ce207ac1b78327a6a2d5ae68705521735baafa8af8366f1b35ddbd398a15cfdb18082fd7218e2c26fcd42d9
+  languageName: node
+  linkType: hard
+
+"@metamask/approval-controller@npm:^6.0.1":
+  version: 6.0.2
+  resolution: "@metamask/approval-controller@npm:6.0.2"
+  dependencies:
+    "@metamask/base-controller": "npm:^5.0.2"
+    "@metamask/rpc-errors": "npm:^6.2.1"
+    "@metamask/utils": "npm:^8.3.0"
+    nanoid: "npm:^3.1.31"
+  checksum: 63fae925a9792ef8bdc8ec7be39e4f303fbcd676a2349a0e40b7734958b7712e0454acd2cb338fc368d220e89377f9825f50868145796e94da41d631cb499908
   languageName: node
   linkType: hard
 
@@ -4779,13 +4791,13 @@ __metadata:
   linkType: hard
 
 "@metamask/json-rpc-engine@npm:^8.0.1":
-  version: 8.0.1
-  resolution: "@metamask/json-rpc-engine@npm:8.0.1"
+  version: 8.0.2
+  resolution: "@metamask/json-rpc-engine@npm:8.0.2"
   dependencies:
     "@metamask/rpc-errors": "npm:^6.2.1"
     "@metamask/safe-event-emitter": "npm:^3.0.0"
     "@metamask/utils": "npm:^8.3.0"
-  checksum: 340ea9be62f65b69ae552571f0176af23097e874bae276aa2349f13086dbd018ce58a4b9bbd902eff81ab959b143fb2821930564a5739353312968210308cff7
+  checksum: f088f4b648b9b55875b56e8237853e7282f13302a9db6a1f9bba06314dfd6cd0a23b3d27f8fde05a157b97ebb03b67bc2699ba455c99553dfb2ecccd73ab3474
   languageName: node
   linkType: hard
 
@@ -4963,17 +4975,17 @@ __metadata:
   linkType: hard
 
 "@metamask/message-manager@npm:^8.0.1":
-  version: 8.0.1
-  resolution: "@metamask/message-manager@npm:8.0.1"
+  version: 8.0.2
+  resolution: "@metamask/message-manager@npm:8.0.2"
   dependencies:
-    "@metamask/base-controller": "npm:^5.0.1"
-    "@metamask/controller-utils": "npm:^9.0.1"
+    "@metamask/base-controller": "npm:^5.0.2"
+    "@metamask/controller-utils": "npm:^9.1.0"
     "@metamask/eth-sig-util": "npm:^7.0.1"
     "@metamask/utils": "npm:^8.3.0"
     "@types/uuid": "npm:^8.3.0"
     jsonschema: "npm:^1.2.4"
     uuid: "npm:^8.3.2"
-  checksum: 5c8c09e2cc96341b1e59bce821fe3f78bc40188c3895a9d1f27fa6c888e0e92eebade4d1abc4f9ca67733a8e2028d579649a98eb9cd026ae6cee184160c7c0cc
+  checksum: 4db369c80e8fc217706241d6f26d80435f6aaf50eba954abf8b0930b6bf8918d2d8e4c42386af7c60066bb6933b49adbb5a0df6b58f3cc5168de17ee3d3f0144
   languageName: node
   linkType: hard
 
@@ -5497,9 +5509,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/smart-transactions-controller@npm:^10.0.0":
-  version: 10.0.0
-  resolution: "@metamask/smart-transactions-controller@npm:10.0.0"
+"@metamask/smart-transactions-controller@npm:^10.0.1":
+  version: 10.0.1
+  resolution: "@metamask/smart-transactions-controller@npm:10.0.1"
   dependencies:
     "@babel/runtime": "npm:^7.24.1"
     "@ethereumjs/tx": "npm:^5.2.1"
@@ -5515,7 +5527,7 @@ __metadata:
     events: "npm:^3.3.0"
     fast-json-patch: "npm:^3.1.0"
     lodash: "npm:^4.17.21"
-  checksum: f0a3d466761a43171f122d5d00afb80d20ec89689f2194d8f8397c5d698d303d47edf1ba75932b08b8d08156a0e5a21c1e0fd474bcd3b926cda3806e52071bbe
+  checksum: ff8c14257ed733161650f1527c136eac0b31bafd1c027af839a492bb8995c236d517a140a6c5201ed1b34726ef9c2674c1ab4830e5dc54546586601532546715
   languageName: node
   linkType: hard
 
@@ -5943,8 +5955,8 @@ __metadata:
   linkType: hard
 
 "@metamask/utils@npm:^8.0.0, @metamask/utils@npm:^8.1.0, @metamask/utils@npm:^8.2.0, @metamask/utils@npm:^8.2.1, @metamask/utils@npm:^8.3.0":
-  version: 8.3.0
-  resolution: "@metamask/utils@npm:8.3.0"
+  version: 8.4.0
+  resolution: "@metamask/utils@npm:8.4.0"
   dependencies:
     "@ethereumjs/tx": "npm:^4.2.0"
     "@noble/hashes": "npm:^1.3.1"
@@ -5954,7 +5966,8 @@ __metadata:
     pony-cause: "npm:^2.1.10"
     semver: "npm:^7.5.4"
     superstruct: "npm:^1.0.3"
-  checksum: 728a4f6b3ab14223a487e8974a21b1917e470ff2c131afc0b8a6a6823839d6cf7454243ddb0ff695ceebede62feaf628f4d32b4b529bb5c044c6c95576a142ef
+    uuid: "npm:^9.0.1"
+  checksum: 5ce14d4e1630bf9269ab3b5cf3e05f393776b806c5be10a503128a3bc1d3aee891465d1f3937f537fdecec355a202a99ab70ae74f9bd37d51d3730c98c8f3dfc
   languageName: node
   linkType: hard
 
@@ -25004,7 +25017,7 @@ __metadata:
     "@metamask/scure-bip39": "npm:^2.0.3"
     "@metamask/selected-network-controller": "npm:^9.0.0"
     "@metamask/signature-controller": "npm:^12.0.0"
-    "@metamask/smart-transactions-controller": "npm:^10.0.0"
+    "@metamask/smart-transactions-controller": "npm:^10.0.1"
     "@metamask/snaps-controllers": "npm:^6.0.4"
     "@metamask/snaps-execution-environments": "npm:^5.0.4"
     "@metamask/snaps-rpc-methods": "npm:^7.0.2"
@@ -34801,12 +34814,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"uuid@npm:^9.0.0":
-  version: 9.0.0
-  resolution: "uuid@npm:9.0.0"
+"uuid@npm:^9.0.0, uuid@npm:^9.0.1":
+  version: 9.0.1
+  resolution: "uuid@npm:9.0.1"
   bin:
     uuid: dist/bin/uuid
-  checksum: 23857699a616d1b48224bc2b8440eae6e57d25463c3a0200e514ba8279dfa3bde7e92ea056122237839cfa32045e57d8f8f4a30e581d720fd72935572853ae2e
+  checksum: 9d0b6adb72b736e36f2b1b53da0d559125ba3e39d913b6072f6f033e0c87835b414f0836b45bcfaf2bdf698f92297fea1c3cc19b0b258bc182c9c43cc0fab9f2
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3994,19 +3994,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/approval-controller@npm:^6.0.0":
-  version: 6.0.1
-  resolution: "@metamask/approval-controller@npm:6.0.1"
-  dependencies:
-    "@metamask/base-controller": "npm:^5.0.1"
-    "@metamask/rpc-errors": "npm:^6.2.1"
-    "@metamask/utils": "npm:^8.3.0"
-    nanoid: "npm:^3.1.31"
-  checksum: f7c61caf2fffb64c93ad4aa195bf251447367ed96ce207ac1b78327a6a2d5ae68705521735baafa8af8366f1b35ddbd398a15cfdb18082fd7218e2c26fcd42d9
-  languageName: node
-  linkType: hard
-
-"@metamask/approval-controller@npm:^6.0.1":
+"@metamask/approval-controller@npm:^6.0.0, @metamask/approval-controller@npm:^6.0.1":
   version: 6.0.2
   resolution: "@metamask/approval-controller@npm:6.0.2"
   dependencies:


### PR DESCRIPTION
Cherry-pick  6813ea06f81c003f846631c13f9441d712f7470c (#24461) into v11.15.4

### Merge conflict in package.json
Resolution: ACCEPT HEAD + `"@metamask/smart-transactions-controller": "^10.0.1",`
```
    "@metamask/safe-event-emitter": "^3.1.1",
    "@metamask/scure-bip39": "^2.0.3",
    "@metamask/selected-network-controller": "^9.0.0",
    "@metamask/signature-controller": "^12.0.0",
<<<<<<< HEAD
    "@metamask/smart-transactions-controller": "^10.0.0",
    "@metamask/snaps-controllers": "^6.0.4",
    "@metamask/snaps-execution-environments": "^5.0.4",
    "@metamask/snaps-rpc-methods": "^7.0.2",
    "@metamask/snaps-sdk": "^3.2.0",
    "@metamask/snaps-utils": "^7.1.0",
=======
    "@metamask/smart-transactions-controller": "^10.0.1",
    "@metamask/snaps-controllers": "patch:@metamask/snaps-controllers@npm%3A8.0.0#~/.yarn/patches/@metamask-snaps-controllers-npm-8.0.0-7e59688855.patch",
    "@metamask/snaps-execution-environments": "^6.0.2",
    "@metamask/snaps-rpc-methods": "^8.0.0",
    "@metamask/snaps-sdk": "^4.0.1",
    "@metamask/snaps-utils": "^7.1.1",
>>>>>>> 6813ea06f8 (fix: Bump @metamask/smart-transactions-controller to v10.0.1 (#24461))
    "@metamask/transaction-controller": "^28.1.1",
    "@metamask/user-operation-controller": "^6.0.0",
    "@metamask/utils": "^8.2.1",

