### PR TITLE
fix: Make ConnectAccountToast respect setting for multichain

### DIFF
--- a/ui/pages/routes/routes.container.js
+++ b/ui/pages/routes/routes.container.js
@@ -47,6 +47,7 @@ import { pageChanged } from '../../ducks/history/history';
 import { prepareToLeaveSwaps } from '../../ducks/swaps/swaps';
 import { getSendStage } from '../../ducks/send';
 import {
+  getAlertEnabledness,
   getIsUnlocked,
   getProviderConfig,
 } from '../../ducks/metamask/metamask';
@@ -62,11 +63,13 @@ function mapStateToProps(state) {
 
   // If there is more than one connected account to activeTabOrigin,
   // *BUT* the current account is not one of them, show the banner
+  const allowShowAccountSetting = getAlertEnabledness(state).unconnectedAccount;
   const account = getSelectedAccount(state);
   const activeTabOrigin = activeTab?.origin;
   const connectedAccounts = getPermittedAccountsForCurrentTab(state);
   const showConnectAccountToast = Boolean(
-    account &&
+    allowShowAccountSetting &&
+      account &&
       activeTabOrigin &&
       connectedAccounts.length > 0 &&
       !connectedAccounts.find((address) => address === account.address),


### PR DESCRIPTION
## **Description**

The toast for connecting an unconnected account on a given dapp can be turned on and off via settings toggle.  Presently the toast always displays regardless of the setting, so this PR makes the toast respect the user setting.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/24474?quickstart=1)

## **Related issues**

Fixes: N/A

## **Manual testing steps**

1.  Make sure MetaMask has 2 accounts; be on Account 1
2. Go to MetaMask Portfolio dapp, connect Account 1
3. Open MetaMask and switch to Account 2
4. See the "Connect this account?" toast
5. Click the three-dot menu, choose "Settings", and click "Alerts"
6. Toggle off the "Browsing a website with an unconnected account selected" setting
7. Return to the home screen
8. No longer see the toast

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

(the toast always displays)

### **After**


https://github.com/MetaMask/metamask-extension/assets/46655/7d1e4636-28d2-461b-a477-1085cb7a24a7



## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
