### PR TITLE
fix: Prevent legacy <UnconnectedAccountAlert/> component from displaying

### DIFF
--- a/ui/components/app/alerts/alerts.js
+++ b/ui/components/app/alerts/alerts.js
@@ -2,24 +2,16 @@ import React from 'react';
 import { useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
 
-import { alertIsOpen as unconnectedAccountAlertIsOpen } from '../../../ducks/alerts/unconnected-account';
 import { alertIsOpen as invalidCustomNetworkAlertIsOpen } from '../../../ducks/alerts/invalid-custom-network';
 import InvalidCustomNetworkAlert from './invalid-custom-network-alert';
-import UnconnectedAccountAlert from './unconnected-account-alert';
 
 const Alerts = ({ history }) => {
   const _invalidCustomNetworkAlertIsOpen = useSelector(
     invalidCustomNetworkAlertIsOpen,
   );
-  const _unconnectedAccountAlertIsOpen = useSelector(
-    unconnectedAccountAlertIsOpen,
-  );
 
   if (_invalidCustomNetworkAlertIsOpen) {
     return <InvalidCustomNetworkAlert history={history} />;
-  }
-  if (_unconnectedAccountAlertIsOpen) {
-    return <UnconnectedAccountAlert />;
   }
 
   return null;


### PR DESCRIPTION

## **Description**

In the PR to release Multichain v1 (https://github.com/MetaMask/metamask-extension/pull/24362) we didn't prevent the legacy `<UnconnectedAccountAlert/>` from displaying, which is problematic -- it overlays the toast and isn't desired.  This PR prevents that legacy component from ever displaying.

## **Related issues**

Fixes: N/A

## **Manual testing steps**

1. Go to MetaMask Portfolio dApp
2. Connect Account 1
3. Open MetaMask, switch to Account 2
4. Don't see old `<UnconnectedAccountAlert/>` component

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

See the old component

### **After**

See only the toast

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
