### PR TITLE
chore(test/e2e): Fix onboarding/onboarding.spec.js flaky test

### DIFF
--- a/test/e2e/tests/onboarding/onboarding.spec.js
+++ b/test/e2e/tests/onboarding/onboarding.spec.js
@@ -159,6 +159,9 @@ describe('MetaMask onboarding @no-mmi', function () {
         // metrics
         await driver.clickElement('[data-testid="metametrics-no-thanks"]');
 
+        // wait for password screen
+        await driver.waitForSelector('[data-testid="create-password-new"]');
+
         // Fill in confirm password field with incorrect password
         await driver.fill(
           '[data-testid="create-password-new"]',

--- a/test/e2e/webdriver/driver.js
+++ b/test/e2e/webdriver/driver.js
@@ -462,7 +462,6 @@ class Driver {
       until.elementLocated(locator),
       this.timeout,
     );
-    await this.driver.wait(until.elementIsVisible(element), this.timeout); // Trying waiting before wrapElementWithAPI call
     return wrapElementWithAPI(element, this);
   }
 

--- a/test/e2e/webdriver/driver.js
+++ b/test/e2e/webdriver/driver.js
@@ -462,6 +462,7 @@ class Driver {
       until.elementLocated(locator),
       this.timeout,
     );
+    await this.driver.wait(until.elementIsVisible(element), this.timeout); // Trying waiting before wrapElementWithAPI call
     return wrapElementWithAPI(element, this);
   }
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Flaky test: "MetaMask onboarding @no-mmi Verify that the user has been redirected to the correct page after creating a password for their new wallet"         
Attempting to fix by adding `await driver.findElement('[data-testid="create-password-new"]');`before trying to fill.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/24488?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
