### PR TITLE
fix: Signature Redesign Disabled confirm button with missing ScrollToBottom button with 16px or less scroll buffer

### DIFF
--- a/ui/hooks/useScrollRequired.js
+++ b/ui/hooks/useScrollRequired.js
@@ -8,9 +8,14 @@ import { debounce } from 'lodash';
  * The hook expects both the `ref` and the `onScroll` handler to be passed to the scrolling element.
  *
  * @param dependencies - Any optional hook dependencies for updating the scroll state.
+ * @param opt
+ * @param {number} opt.offsetPxFromBottom
  * @returns Flags for isScrollable and isScrollToBottom, a ref to use for the scrolling content, a scrollToBottom function and a onScroll handler.
  */
-export const useScrollRequired = (dependencies = []) => {
+export const useScrollRequired = (
+  dependencies = [],
+  { offsetPxFromBottom = 16 } = {},
+) => {
   const ref = useRef(null);
 
   const [hasScrolledToBottomState, setHasScrolledToBottom] = useState(false);
@@ -28,7 +33,9 @@ export const useScrollRequired = (dependencies = []) => {
       isScrollable &&
       // Add 16px to the actual scroll position to trigger setIsScrolledToBottom sooner.
       // This avoids the problem where a user has scrolled down to the bottom and it's not detected.
-      Math.round(ref.current.scrollTop) + ref.current.offsetHeight + 16 >=
+      Math.round(ref.current.scrollTop) +
+        ref.current.offsetHeight +
+        offsetPxFromBottom >=
         ref.current.scrollHeight;
 
     setIsScrollable(isScrollable);

--- a/ui/pages/confirmations/components/confirm/scroll-to-bottom/scroll-to-bottom.test.tsx
+++ b/ui/pages/confirmations/components/confirm/scroll-to-bottom/scroll-to-bottom.test.tsx
@@ -14,13 +14,15 @@ const mockState = {
   },
 };
 
+const mockSetHasScrolledToBottom = jest.fn();
+
 const mockUseScrollRequiredResult = {
   hasScrolledToBottom: false,
   isScrollable: false,
   isScrolledToBottom: false,
   onScroll: jest.fn(),
   scrollToBottom: jest.fn(),
-  setHasScrolledToBottom: jest.fn(),
+  setHasScrolledToBottom: mockSetHasScrolledToBottom,
   ref: {
     current: {},
   },
@@ -130,6 +132,15 @@ describe('ScrollToBottom', () => {
       expect(mockScrollTo).toHaveBeenCalledWith(0, 0);
 
       window.HTMLDivElement.prototype.scrollTo = originalScrollTo;
+    });
+
+    it('resets setHasScrolledToBottom to false when the confirmation changes', () => {
+      renderWithProvider(
+        <ScrollToBottom>foobar</ScrollToBottom>,
+        configureMockStore([])(mockState),
+      );
+
+      expect(mockSetHasScrolledToBottom).toHaveBeenCalledWith(false);
     });
 
     describe('when user has scrolled to the bottom', () => {

--- a/ui/pages/confirmations/components/confirm/scroll-to-bottom/scroll-to-bottom.tsx
+++ b/ui/pages/confirmations/components/confirm/scroll-to-bottom/scroll-to-bottom.tsx
@@ -62,11 +62,8 @@ const ScrollToBottom = ({ children }: ContentProps) => {
       currentRef.scrollTo(0, 0);
     }
 
-    const currentRefIsScrollable =
-      currentRef.scrollHeight > currentRef.clientHeight;
-
-    setHasScrolledToBottom(!currentRefIsScrollable);
-  }, [currentConfirmation?.id, previousId, ref, setHasScrolledToBottom]);
+    setHasScrolledToBottom(false);
+  }, [currentConfirmation?.id, previousId, ref?.current]);
 
   useEffect(() => {
     dispatch(

--- a/ui/pages/confirmations/components/confirm/scroll-to-bottom/scroll-to-bottom.tsx
+++ b/ui/pages/confirmations/components/confirm/scroll-to-bottom/scroll-to-bottom.tsx
@@ -42,7 +42,7 @@ const ScrollToBottom = ({ children }: ContentProps) => {
     scrollToBottom,
     setHasScrolledToBottom,
     ref,
-  } = useScrollRequired([currentConfirmation?.id]);
+  } = useScrollRequired([currentConfirmation?.id], { offsetPxFromBottom: 0 });
 
   /**
    * Scroll to the top of the page when the confirmation changes. This happens

--- a/ui/pages/confirmations/components/confirm/scroll-to-bottom/scroll-to-bottom.tsx
+++ b/ui/pages/confirmations/components/confirm/scroll-to-bottom/scroll-to-bottom.tsx
@@ -53,13 +53,20 @@ const ScrollToBottom = ({ children }: ContentProps) => {
       return;
     }
 
-    setHasScrolledToBottom(false);
-
-    const scrollTo = (ref?.current as null | HTMLDivElement)?.scrollTo;
-    if (typeof scrollTo === 'function') {
-      (ref?.current as null | HTMLDivElement)?.scrollTo(0, 0);
+    const currentRef = ref?.current as null | HTMLDivElement;
+    if (!currentRef) {
+      return;
     }
-  }, [currentConfirmation?.id, previousId, setHasScrolledToBottom]);
+
+    if (typeof currentRef.scrollTo === 'function') {
+      currentRef.scrollTo(0, 0);
+    }
+
+    const currentRefIsScrollable =
+      currentRef.scrollHeight > currentRef.clientHeight;
+
+    setHasScrolledToBottom(!currentRefIsScrollable);
+  }, [currentConfirmation?.id, previousId, ref, setHasScrolledToBottom]);
 
   useEffect(() => {
     dispatch(


### PR DESCRIPTION
## **Description**

- Removes 16px buffer
- Allow optional scroll buffer in useScrollRequired hook

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/24485

## **Manual testing steps**

1. Create sign request from OpenSea login
2. Observe scroll behavior 

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

https://github.com/MetaMask/metamask-extension/assets/20778143/1b436528-b285-41c0-a365-98ce2aed7eec

### **After**

https://github.com/MetaMask/metamask-extension/assets/20778143/4a42022a-1473-4f9c-b3a5-459510f221c2

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
