### PR TITLE
chore(refactor:test): unify environment variables for setting headless modes

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,6 +1,7 @@
 import type { PlaywrightTestConfig } from '@playwright/test';
 import { devices } from '@playwright/test';
 import dotenv from 'dotenv';
+import { isHeadless } from './test/helpers/env';
 
 dotenv.config({ path: './test/e2e/mmi/.env' });
 const logOutputFolder = './public/playwright/playwright-reports';
@@ -42,8 +43,8 @@ const config: PlaywrightTestConfig = {
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on',
     video: 'off',
-    // Run tests headless in local
-    headless: process.env.HEADLESS === 'true',
+    /* Run tests headless in local */
+    headless: isHeadless('PLAYWRIGHT'),
   },
 
   /* Configure projects for major browsers */

--- a/test/e2e/mmi/helpers/extension-loader.ts
+++ b/test/e2e/mmi/helpers/extension-loader.ts
@@ -2,6 +2,7 @@ import path from 'path';
 import { test as base, chromium } from '@playwright/test';
 
 import { isHeadless } from '../../../helpers/env';
+
 const extensionPath = path.join(__dirname, '../../../../dist/chrome');
 
 export const test = base.extend({

--- a/test/e2e/mmi/helpers/extension-loader.ts
+++ b/test/e2e/mmi/helpers/extension-loader.ts
@@ -1,6 +1,7 @@
 import path from 'path';
 import { test as base, chromium } from '@playwright/test';
 
+import { isHeadless } from '../../../helpers/env';
 const extensionPath = path.join(__dirname, '../../../../dist/chrome');
 
 export const test = base.extend({
@@ -10,7 +11,7 @@ export const test = base.extend({
       headless: false,
       args: [`--disable-extensions-except=${extensionPath}`],
     };
-    if (process.env.HEADLESS === 'true') {
+    if (isHeadless('PLAYWRIGHT')) {
       launchOptions.args.push('--headless=new');
     }
     const context = await chromium.launchPersistentContext('', launchOptions);

--- a/test/e2e/webdriver/chrome.js
+++ b/test/e2e/webdriver/chrome.js
@@ -1,6 +1,7 @@
 const { Builder } = require('selenium-webdriver');
 const chrome = require('selenium-webdriver/chrome');
 const { ThenableWebDriver } = require('selenium-webdriver'); // eslint-disable-line no-unused-vars -- this is imported for JSDoc
+const { isHeadless } = require('../../helpers/env');
 
 /**
  * Proxy host to use for HTTPS requests
@@ -42,7 +43,7 @@ class ChromeDriver {
       args.push('--disable-gpu');
     }
 
-    if (process.env.SELENIUM_HEADLESS) {
+    if (isHeadless('SELENIUM')) {
       // TODO: Remove notice and consider non-experimental when results are consistent
       console.warn(
         '*** Running e2e tests in headless mode is experimental and some tests are known to fail for unknown reasons',

--- a/test/e2e/webdriver/firefox.js
+++ b/test/e2e/webdriver/firefox.js
@@ -9,6 +9,7 @@ const {
 } = require('selenium-webdriver');
 const firefox = require('selenium-webdriver/firefox');
 const { retry } = require('../../../development/lib/retry');
+const { isHeadless } = require('../../helpers/env');
 
 /**
  * The prefix for temporary Firefox profiles. All Firefox profiles used for e2e tests
@@ -58,7 +59,7 @@ class FirefoxDriver {
     if (process.env.CI === 'true') {
       options.setBinary('/opt/firefox/firefox');
     }
-    if (process.env.SELENIUM_HEADLESS) {
+    if (isHeadless('SELENIUM')) {
       // TODO: Remove notice and consider non-experimental when results are consistent
       console.warn(
         '*** Running e2e tests in headless mode is experimental and some tests are known to fail for unknown reasons',

--- a/test/helpers/env.ts
+++ b/test/helpers/env.ts
@@ -1,0 +1,36 @@
+import { env } from 'process';
+
+type HeadlessCapableServiceName = 'SELENIUM' | 'PLAYWRIGHT';
+
+export function isHeadless(serviceName: HeadlessCapableServiceName): boolean {
+  if (serviceName) {
+    const serviceKey = `${serviceName}_HEADLESS`;
+    if (env[serviceKey]) {
+      return parseBoolean(env[serviceKey]);
+    }
+  }
+  return !!env.HEADLESS && parseBoolean(env.HEADLESS);
+}
+
+export function parseBoolean(value: undefined | string): boolean {
+  if (!value) {
+    return false;
+  }
+  if (typeof value === 'boolean') {
+    return value;
+  }
+  if (typeof value !== 'string') {
+    throw new Error(`Not-a-Boolean: '${value}'`);
+  }
+  switch(value.toLowerCase().trim()) {
+    case 'false':
+    case '0':
+    case '':
+      return false;
+    case 'true':
+    case '1':
+      return true;
+    default:
+      throw new Error(`Not-a-Boolean: '${value}'`);
+  }
+}

--- a/test/helpers/env.ts
+++ b/test/helpers/env.ts
@@ -9,7 +9,7 @@ export function isHeadless(serviceName: HeadlessCapableServiceName): boolean {
       return parseBoolean(env[serviceKey]);
     }
   }
-  return !!env.HEADLESS && parseBoolean(env.HEADLESS);
+  return Boolean(env.HEADLESS) && parseBoolean(env.HEADLESS);
 }
 
 export function parseBoolean(value: undefined | string): boolean {
@@ -22,7 +22,7 @@ export function parseBoolean(value: undefined | string): boolean {
   if (typeof value !== 'string') {
     throw new Error(`Not-a-Boolean: '${value}'`);
   }
-  switch(value.toLowerCase().trim()) {
+  switch (value.toLowerCase().trim()) {
     case 'false':
     case '0':
     case '':


### PR DESCRIPTION
## **Description**


- Three environment variables are now recognized:
    - `SELENIUM_HEADLESS`: Explicitly set headless mode for Selenium
    - `PLAYWRIGHT_HEADLESS`: Explicitly set headless mode for Playwright
    - `HEADLESS`: Set headless mode wherevere supported
- More consistent and lenient parsing of boolean value
    - `"true"` (case-insensitive) || `"1"` = `true`
    - `"false"` (case-insensitive) || `"0"` || (any falsey value) = `false`
    - Any other value throws an error.
- Behavior should be retained for all previously recognized values
- Default is `false`, as previously

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/24499?quickstart=1)

## **Related issues**
- #22877
- #21886


## **Manual testing steps**
Any of the below format could be used:-
HEADLESS yarn test:e2e:single test/e2e/tests/settings/show-hex-data.spec.js --browser=chrome --debug --leave-running   
HEADLESS=1 yarn test:e2e:single test/e2e/tests/settings/show-hex-data.spec.js --browser=chrome --debug --leave-running   
SELENIUM_HEADLESS=1 yarn test:e2e:single test/e2e/tests/settings/show-hex-data.spec.js --browser=chrome --debug --leave-running

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
