### PR TITLE
fix: newline display in signature request content.

### DIFF
--- a/ui/components/app/confirm/info/row/text.tsx
+++ b/ui/components/app/confirm/info/row/text.tsx
@@ -19,7 +19,7 @@ export const ConfirmInfoRowText = ({ text }: ConfirmInfoRowTextProps) => {
       flexWrap={FlexWrap.Wrap}
       gap={2}
     >
-      <Text color={TextColor.inherit} style={{ whiteSpace: 'pre' }}>
+      <Text color={TextColor.inherit} style={{ whiteSpace: 'pre-wrap' }}>
         {text}
       </Text>
     </Box>

--- a/ui/components/app/confirm/info/row/text.tsx
+++ b/ui/components/app/confirm/info/row/text.tsx
@@ -19,7 +19,9 @@ export const ConfirmInfoRowText = ({ text }: ConfirmInfoRowTextProps) => {
       flexWrap={FlexWrap.Wrap}
       gap={2}
     >
-      <Text color={TextColor.inherit}>{text}</Text>
+      <Text color={TextColor.inherit} style={{ whiteSpace: 'pre' }}>
+        {text}
+      </Text>
     </Box>
   );
 };

--- a/ui/pages/confirmations/components/confirm/info/__snapshots__/info.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/info/__snapshots__/info.test.tsx.snap
@@ -65,7 +65,7 @@ exports[`Info renders info section for personal sign request 1`] = `
       >
         <p
           class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
-          style="white-space: pre;"
+          style="white-space: pre-wrap;"
         >
           Example \`personal_sign\` message
         </p>
@@ -227,7 +227,7 @@ exports[`Info renders info section for typed sign request 1`] = `
           >
             <p
               class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
-              style="white-space: pre;"
+              style="white-space: pre-wrap;"
             >
               Mail
             </p>
@@ -274,7 +274,7 @@ exports[`Info renders info section for typed sign request 1`] = `
                   >
                     <p
                       class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
-                      style="white-space: pre;"
+                      style="white-space: pre-wrap;"
                     >
                       Cow
                     </p>
@@ -387,7 +387,7 @@ exports[`Info renders info section for typed sign request 1`] = `
                   >
                     <p
                       class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
-                      style="white-space: pre;"
+                      style="white-space: pre-wrap;"
                     >
                       Bob
                     </p>
@@ -484,7 +484,7 @@ exports[`Info renders info section for typed sign request 1`] = `
               >
                 <p
                   class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
-                  style="white-space: pre;"
+                  style="white-space: pre-wrap;"
                 >
                   Hello, Bob!
                 </p>

--- a/ui/pages/confirmations/components/confirm/info/__snapshots__/info.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/info/__snapshots__/info.test.tsx.snap
@@ -65,6 +65,7 @@ exports[`Info renders info section for personal sign request 1`] = `
       >
         <p
           class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
+          style="white-space: pre;"
         >
           Example \`personal_sign\` message
         </p>
@@ -226,6 +227,7 @@ exports[`Info renders info section for typed sign request 1`] = `
           >
             <p
               class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
+              style="white-space: pre;"
             >
               Mail
             </p>
@@ -272,6 +274,7 @@ exports[`Info renders info section for typed sign request 1`] = `
                   >
                     <p
                       class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
+                      style="white-space: pre;"
                     >
                       Cow
                     </p>
@@ -384,6 +387,7 @@ exports[`Info renders info section for typed sign request 1`] = `
                   >
                     <p
                       class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
+                      style="white-space: pre;"
                     >
                       Bob
                     </p>
@@ -480,6 +484,7 @@ exports[`Info renders info section for typed sign request 1`] = `
               >
                 <p
                   class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
+                  style="white-space: pre;"
                 >
                   Hello, Bob!
                 </p>

--- a/ui/pages/confirmations/components/confirm/info/personal-sign/__snapshots__/personal-sign.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/info/personal-sign/__snapshots__/personal-sign.test.tsx.snap
@@ -65,6 +65,7 @@ exports[`PersonalSignInfo handle reverse string properly 1`] = `
       >
         <p
           class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
+          style="white-space: pre;"
         >
           Sign into \\u202E EVIL
         </p>
@@ -139,6 +140,7 @@ exports[`PersonalSignInfo renders correctly for personal sign request 1`] = `
       >
         <p
           class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
+          style="white-space: pre;"
         >
           Example \`personal_sign\` message
         </p>

--- a/ui/pages/confirmations/components/confirm/info/personal-sign/__snapshots__/personal-sign.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/info/personal-sign/__snapshots__/personal-sign.test.tsx.snap
@@ -65,7 +65,7 @@ exports[`PersonalSignInfo handle reverse string properly 1`] = `
       >
         <p
           class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
-          style="white-space: pre;"
+          style="white-space: pre-wrap;"
         >
           Sign into \\u202E EVIL
         </p>
@@ -140,7 +140,7 @@ exports[`PersonalSignInfo renders correctly for personal sign request 1`] = `
       >
         <p
           class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
-          style="white-space: pre;"
+          style="white-space: pre-wrap;"
         >
           Example \`personal_sign\` message
         </p>

--- a/ui/pages/confirmations/components/confirm/info/typed-sign-v1/__snapshots__/typed-sign-v1.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/info/typed-sign-v1/__snapshots__/typed-sign-v1.test.tsx.snap
@@ -88,6 +88,7 @@ exports[`TypedSignInfo correctly renders typed sign data request 1`] = `
               >
                 <p
                   class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
+                  style="white-space: pre;"
                 >
                   Hi, Alice!
                 </p>
@@ -111,6 +112,7 @@ exports[`TypedSignInfo correctly renders typed sign data request 1`] = `
               >
                 <p
                   class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
+                  style="white-space: pre;"
                 >
                   1337
                 </p>

--- a/ui/pages/confirmations/components/confirm/info/typed-sign-v1/__snapshots__/typed-sign-v1.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/info/typed-sign-v1/__snapshots__/typed-sign-v1.test.tsx.snap
@@ -88,7 +88,7 @@ exports[`TypedSignInfo correctly renders typed sign data request 1`] = `
               >
                 <p
                   class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
-                  style="white-space: pre;"
+                  style="white-space: pre-wrap;"
                 >
                   Hi, Alice!
                 </p>
@@ -112,7 +112,7 @@ exports[`TypedSignInfo correctly renders typed sign data request 1`] = `
               >
                 <p
                   class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
-                  style="white-space: pre;"
+                  style="white-space: pre-wrap;"
                 >
                   1337
                 </p>

--- a/ui/pages/confirmations/components/confirm/info/typed-sign/__snapshots__/typed-sign.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/info/typed-sign/__snapshots__/typed-sign.test.tsx.snap
@@ -154,7 +154,7 @@ exports[`TypedSignInfo renders origin for typed sign data request 1`] = `
           >
             <p
               class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
-              style="white-space: pre;"
+              style="white-space: pre-wrap;"
             >
               Mail
             </p>
@@ -201,7 +201,7 @@ exports[`TypedSignInfo renders origin for typed sign data request 1`] = `
                   >
                     <p
                       class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
-                      style="white-space: pre;"
+                      style="white-space: pre-wrap;"
                     >
                       Cow
                     </p>
@@ -314,7 +314,7 @@ exports[`TypedSignInfo renders origin for typed sign data request 1`] = `
                   >
                     <p
                       class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
-                      style="white-space: pre;"
+                      style="white-space: pre-wrap;"
                     >
                       Bob
                     </p>
@@ -411,7 +411,7 @@ exports[`TypedSignInfo renders origin for typed sign data request 1`] = `
               >
                 <p
                   class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
-                  style="white-space: pre;"
+                  style="white-space: pre-wrap;"
                 >
                   Hello, Bob!
                 </p>
@@ -577,7 +577,7 @@ exports[`TypedSignInfo should render message for typed sign v3 request 1`] = `
           >
             <p
               class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
-              style="white-space: pre;"
+              style="white-space: pre-wrap;"
             >
               Mail
             </p>
@@ -624,7 +624,7 @@ exports[`TypedSignInfo should render message for typed sign v3 request 1`] = `
                   >
                     <p
                       class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
-                      style="white-space: pre;"
+                      style="white-space: pre-wrap;"
                     >
                       Cow
                     </p>
@@ -737,7 +737,7 @@ exports[`TypedSignInfo should render message for typed sign v3 request 1`] = `
                   >
                     <p
                       class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
-                      style="white-space: pre;"
+                      style="white-space: pre-wrap;"
                     >
                       Bob
                     </p>
@@ -834,7 +834,7 @@ exports[`TypedSignInfo should render message for typed sign v3 request 1`] = `
               >
                 <p
                   class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
-                  style="white-space: pre;"
+                  style="white-space: pre-wrap;"
                 >
                   Hello, Bob!
                 </p>
@@ -1000,7 +1000,7 @@ exports[`TypedSignInfo should render message for typed sign v4 request 1`] = `
           >
             <p
               class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
-              style="white-space: pre;"
+              style="white-space: pre-wrap;"
             >
               Mail
             </p>
@@ -1031,7 +1031,7 @@ exports[`TypedSignInfo should render message for typed sign v4 request 1`] = `
               >
                 <p
                   class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
-                  style="white-space: pre;"
+                  style="white-space: pre-wrap;"
                 >
                   Hello, Bob!
                 </p>
@@ -1071,7 +1071,7 @@ exports[`TypedSignInfo should render message for typed sign v4 request 1`] = `
                   >
                     <p
                       class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
-                      style="white-space: pre;"
+                      style="white-space: pre-wrap;"
                     >
                       Cow
                     </p>
@@ -1360,7 +1360,7 @@ exports[`TypedSignInfo should render message for typed sign v4 request 1`] = `
                       >
                         <p
                           class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
-                          style="white-space: pre;"
+                          style="white-space: pre-wrap;"
                         >
                           Bob
                         </p>

--- a/ui/pages/confirmations/components/confirm/info/typed-sign/__snapshots__/typed-sign.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/info/typed-sign/__snapshots__/typed-sign.test.tsx.snap
@@ -154,6 +154,7 @@ exports[`TypedSignInfo renders origin for typed sign data request 1`] = `
           >
             <p
               class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
+              style="white-space: pre;"
             >
               Mail
             </p>
@@ -200,6 +201,7 @@ exports[`TypedSignInfo renders origin for typed sign data request 1`] = `
                   >
                     <p
                       class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
+                      style="white-space: pre;"
                     >
                       Cow
                     </p>
@@ -312,6 +314,7 @@ exports[`TypedSignInfo renders origin for typed sign data request 1`] = `
                   >
                     <p
                       class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
+                      style="white-space: pre;"
                     >
                       Bob
                     </p>
@@ -408,6 +411,7 @@ exports[`TypedSignInfo renders origin for typed sign data request 1`] = `
               >
                 <p
                   class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
+                  style="white-space: pre;"
                 >
                   Hello, Bob!
                 </p>
@@ -573,6 +577,7 @@ exports[`TypedSignInfo should render message for typed sign v3 request 1`] = `
           >
             <p
               class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
+              style="white-space: pre;"
             >
               Mail
             </p>
@@ -619,6 +624,7 @@ exports[`TypedSignInfo should render message for typed sign v3 request 1`] = `
                   >
                     <p
                       class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
+                      style="white-space: pre;"
                     >
                       Cow
                     </p>
@@ -731,6 +737,7 @@ exports[`TypedSignInfo should render message for typed sign v3 request 1`] = `
                   >
                     <p
                       class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
+                      style="white-space: pre;"
                     >
                       Bob
                     </p>
@@ -827,6 +834,7 @@ exports[`TypedSignInfo should render message for typed sign v3 request 1`] = `
               >
                 <p
                   class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
+                  style="white-space: pre;"
                 >
                   Hello, Bob!
                 </p>
@@ -992,6 +1000,7 @@ exports[`TypedSignInfo should render message for typed sign v4 request 1`] = `
           >
             <p
               class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
+              style="white-space: pre;"
             >
               Mail
             </p>
@@ -1022,6 +1031,7 @@ exports[`TypedSignInfo should render message for typed sign v4 request 1`] = `
               >
                 <p
                   class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
+                  style="white-space: pre;"
                 >
                   Hello, Bob!
                 </p>
@@ -1061,6 +1071,7 @@ exports[`TypedSignInfo should render message for typed sign v4 request 1`] = `
                   >
                     <p
                       class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
+                      style="white-space: pre;"
                     >
                       Cow
                     </p>
@@ -1349,6 +1360,7 @@ exports[`TypedSignInfo should render message for typed sign v4 request 1`] = `
                       >
                         <p
                           class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
+                          style="white-space: pre;"
                         >
                           Bob
                         </p>

--- a/ui/pages/confirmations/components/confirm/row/__snapshots__/dataTree.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/row/__snapshots__/dataTree.test.tsx.snap
@@ -23,6 +23,7 @@ exports[`DataTree correctly renders reverse strings 1`] = `
       >
         <p
           class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
+          style="white-space: pre;"
         >
           Sign into \\u202E EVIL
         </p>
@@ -46,6 +47,7 @@ exports[`DataTree correctly renders reverse strings 1`] = `
       >
         <p
           class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
+          style="white-space: pre;"
         >
           1337
         </p>
@@ -78,6 +80,7 @@ exports[`DataTree should match snapshot 1`] = `
       >
         <p
           class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
+          style="white-space: pre;"
         >
           Hello, Bob!
         </p>
@@ -117,6 +120,7 @@ exports[`DataTree should match snapshot 1`] = `
           >
             <p
               class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
+              style="white-space: pre;"
             >
               Cow
             </p>
@@ -334,6 +338,7 @@ exports[`DataTree should match snapshot 1`] = `
               >
                 <p
                   class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
+                  style="white-space: pre;"
                 >
                   Bob
                 </p>
@@ -592,6 +597,7 @@ exports[`DataTree should match snapshot 1`] = `
       >
         <p
           class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
+          style="white-space: pre;"
         >
           0x
         </p>

--- a/ui/pages/confirmations/components/confirm/row/__snapshots__/dataTree.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/row/__snapshots__/dataTree.test.tsx.snap
@@ -23,7 +23,7 @@ exports[`DataTree correctly renders reverse strings 1`] = `
       >
         <p
           class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
-          style="white-space: pre;"
+          style="white-space: pre-wrap;"
         >
           Sign into \\u202E EVIL
         </p>
@@ -47,7 +47,7 @@ exports[`DataTree correctly renders reverse strings 1`] = `
       >
         <p
           class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
-          style="white-space: pre;"
+          style="white-space: pre-wrap;"
         >
           1337
         </p>
@@ -80,7 +80,7 @@ exports[`DataTree should match snapshot 1`] = `
       >
         <p
           class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
-          style="white-space: pre;"
+          style="white-space: pre-wrap;"
         >
           Hello, Bob!
         </p>
@@ -120,7 +120,7 @@ exports[`DataTree should match snapshot 1`] = `
           >
             <p
               class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
-              style="white-space: pre;"
+              style="white-space: pre-wrap;"
             >
               Cow
             </p>
@@ -338,7 +338,7 @@ exports[`DataTree should match snapshot 1`] = `
               >
                 <p
                   class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
-                  style="white-space: pre;"
+                  style="white-space: pre-wrap;"
                 >
                   Bob
                 </p>
@@ -597,7 +597,7 @@ exports[`DataTree should match snapshot 1`] = `
       >
         <p
           class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
-          style="white-space: pre;"
+          style="white-space: pre-wrap;"
         >
           0x
         </p>

--- a/ui/pages/confirmations/components/confirm/row/typed-sign-data-v1/__snapshots__/typedSignDataV1.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/row/typed-sign-data-v1/__snapshots__/typedSignDataV1.test.tsx.snap
@@ -30,7 +30,7 @@ exports[`ConfirmInfoRowTypedSignData should match snapshot 1`] = `
           >
             <p
               class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
-              style="white-space: pre;"
+              style="white-space: pre-wrap;"
             >
               Hi, Alice!
             </p>
@@ -54,7 +54,7 @@ exports[`ConfirmInfoRowTypedSignData should match snapshot 1`] = `
           >
             <p
               class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
-              style="white-space: pre;"
+              style="white-space: pre-wrap;"
             >
               1337
             </p>

--- a/ui/pages/confirmations/components/confirm/row/typed-sign-data-v1/__snapshots__/typedSignDataV1.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/row/typed-sign-data-v1/__snapshots__/typedSignDataV1.test.tsx.snap
@@ -30,6 +30,7 @@ exports[`ConfirmInfoRowTypedSignData should match snapshot 1`] = `
           >
             <p
               class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
+              style="white-space: pre;"
             >
               Hi, Alice!
             </p>
@@ -53,6 +54,7 @@ exports[`ConfirmInfoRowTypedSignData should match snapshot 1`] = `
           >
             <p
               class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
+              style="white-space: pre;"
             >
               1337
             </p>

--- a/ui/pages/confirmations/components/confirm/row/typed-sign-data/__snapshots__/typedSignData.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/row/typed-sign-data/__snapshots__/typedSignData.test.tsx.snap
@@ -23,6 +23,7 @@ exports[`ConfirmInfoRowTypedSignData should match snapshot 1`] = `
       >
         <p
           class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
+          style="white-space: pre;"
         >
           Mail
         </p>
@@ -53,6 +54,7 @@ exports[`ConfirmInfoRowTypedSignData should match snapshot 1`] = `
           >
             <p
               class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
+              style="white-space: pre;"
             >
               Hello, Bob!
             </p>
@@ -92,6 +94,7 @@ exports[`ConfirmInfoRowTypedSignData should match snapshot 1`] = `
               >
                 <p
                   class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
+                  style="white-space: pre;"
                 >
                   Cow
                 </p>
@@ -380,6 +383,7 @@ exports[`ConfirmInfoRowTypedSignData should match snapshot 1`] = `
                   >
                     <p
                       class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
+                      style="white-space: pre;"
                     >
                       Bob
                     </p>

--- a/ui/pages/confirmations/components/confirm/row/typed-sign-data/__snapshots__/typedSignData.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/row/typed-sign-data/__snapshots__/typedSignData.test.tsx.snap
@@ -23,7 +23,7 @@ exports[`ConfirmInfoRowTypedSignData should match snapshot 1`] = `
       >
         <p
           class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
-          style="white-space: pre;"
+          style="white-space: pre-wrap;"
         >
           Mail
         </p>
@@ -54,7 +54,7 @@ exports[`ConfirmInfoRowTypedSignData should match snapshot 1`] = `
           >
             <p
               class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
-              style="white-space: pre;"
+              style="white-space: pre-wrap;"
             >
               Hello, Bob!
             </p>
@@ -94,7 +94,7 @@ exports[`ConfirmInfoRowTypedSignData should match snapshot 1`] = `
               >
                 <p
                   class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
-                  style="white-space: pre;"
+                  style="white-space: pre-wrap;"
                 >
                   Cow
                 </p>
@@ -383,7 +383,7 @@ exports[`ConfirmInfoRowTypedSignData should match snapshot 1`] = `
                   >
                     <p
                       class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
-                      style="white-space: pre;"
+                      style="white-space: pre-wrap;"
                     >
                       Bob
                     </p>

--- a/ui/pages/confirmations/confirm/__snapshots__/confirm.test.tsx.snap
+++ b/ui/pages/confirmations/confirm/__snapshots__/confirm.test.tsx.snap
@@ -205,6 +205,7 @@ exports[`Confirm matches snapshot for personal signature type 1`] = `
               >
                 <p
                   class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
+                  style="white-space: pre;"
                 >
                   Example \`personal_sign\` message
                 </p>
@@ -525,6 +526,7 @@ exports[`Confirm should match snapshot for typed sign signature 1`] = `
                   >
                     <p
                       class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
+                      style="white-space: pre;"
                     >
                       Mail
                     </p>
@@ -555,6 +557,7 @@ exports[`Confirm should match snapshot for typed sign signature 1`] = `
                       >
                         <p
                           class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
+                          style="white-space: pre;"
                         >
                           Hello, Bob!
                         </p>
@@ -594,6 +597,7 @@ exports[`Confirm should match snapshot for typed sign signature 1`] = `
                           >
                             <p
                               class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
+                              style="white-space: pre;"
                             >
                               Cow
                             </p>
@@ -882,6 +886,7 @@ exports[`Confirm should match snapshot for typed sign signature 1`] = `
                               >
                                 <p
                                   class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
+                                  style="white-space: pre;"
                                 >
                                   Bob
                                 </p>

--- a/ui/pages/confirmations/confirm/__snapshots__/confirm.test.tsx.snap
+++ b/ui/pages/confirmations/confirm/__snapshots__/confirm.test.tsx.snap
@@ -205,7 +205,7 @@ exports[`Confirm matches snapshot for personal signature type 1`] = `
               >
                 <p
                   class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
-                  style="white-space: pre;"
+                  style="white-space: pre-wrap;"
                 >
                   Example \`personal_sign\` message
                 </p>
@@ -526,7 +526,7 @@ exports[`Confirm should match snapshot for typed sign signature 1`] = `
                   >
                     <p
                       class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
-                      style="white-space: pre;"
+                      style="white-space: pre-wrap;"
                     >
                       Mail
                     </p>
@@ -557,7 +557,7 @@ exports[`Confirm should match snapshot for typed sign signature 1`] = `
                       >
                         <p
                           class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
-                          style="white-space: pre;"
+                          style="white-space: pre-wrap;"
                         >
                           Hello, Bob!
                         </p>
@@ -597,7 +597,7 @@ exports[`Confirm should match snapshot for typed sign signature 1`] = `
                           >
                             <p
                               class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
-                              style="white-space: pre;"
+                              style="white-space: pre-wrap;"
                             >
                               Cow
                             </p>
@@ -886,7 +886,7 @@ exports[`Confirm should match snapshot for typed sign signature 1`] = `
                               >
                                 <p
                                   class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
-                                  style="white-space: pre;"
+                                  style="white-space: pre-wrap;"
                                 >
                                   Bob
                                 </p>


### PR DESCRIPTION
## **Description**

Newline is not preserved in re-designed signature pages.

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/24480

## **Manual testing steps**

1. To to test DAPP
2. Submit a signature request with new lines
3. Ensure that new lines are preserved

## **Screenshots/Recordings**
<img width="361" alt="Screenshot 2024-05-13 at 4 20 06 PM" src="https://github.com/MetaMask/metamask-extension/assets/2182307/ac7eb8b0-63f5-4132-9318-ae66af3d72bd">

## **Pre-merge author checklist**

- [X] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
