### PR TITLE
Cypherpunk2024/eth overview faucet snap with modal Eth Overview Button Modal SnapListItem

### DIFF
--- a/app/scripts/controllers/faucets/faucet.ts
+++ b/app/scripts/controllers/faucets/faucet.ts
@@ -1,0 +1,181 @@
+import type {
+  ControllerStateChangeEvent,
+  RestrictedControllerMessenger,
+} from '@metamask/base-controller';
+import { BaseController } from '@metamask/base-controller';
+import { BUYABLE_TEST_CHAINS_MAP } from '../../../../shared/constants/network';
+
+const controllerName = 'FaucetController';
+
+const getDefaultState = () => ({
+  faucetSources: {},
+});
+
+const stateMetadata = {
+  faucetSources: { persist: false, anonymous: false },
+};
+
+export type SourceEntry = {
+  label: string;
+};
+
+export type FaucetControllerState = {
+  // Type > Value > Variation > Entry
+  faucetSources: Record<string, SourceEntry>;
+};
+
+
+export type FaucetStateChange = ControllerStateChangeEvent<
+  typeof controllerName,
+  FaucetControllerState
+>;
+
+export type FaucetControllerMessenger = RestrictedControllerMessenger<
+  typeof controllerName,
+  never,
+  never,
+  never,
+  never
+>;
+
+export type BUYABLE_TEST_CHAINS_IDS = keyof typeof BUYABLE_TEST_CHAINS_MAP;
+
+/** The metadata for a faucet provider. */
+export type FaucetProviderMetadata = {
+  /**
+   * IDs for each alternate source of faucets.
+   * Keyed by the buyable test chains.
+   */
+  sourceIds: Record<BUYABLE_TEST_CHAINS_IDS, string[]>;
+
+  /**
+   * Friendly labels to describe each source of faucets.
+   * Keyed by the source ID.
+   */
+  sourceLabels: Record<string, string>;
+};
+
+/** The request data to send test eth to given address. */
+export type FaucetProviderRequest = {
+  /** faucet source id to request test token */
+  sourceId: string;
+  chainId: BUYABLE_TEST_CHAINS_IDS;
+
+  /** The address value to get test tokens sent to. */
+  address: string;
+};
+
+export type FaucetProviderSourceResult = {
+  /**
+   * Trx hash of the transaction that sent test token to the address.
+   */
+  txHash?: string;
+
+  /**
+   * An error that occurred while getting test token from faucet.
+   * Undefined if there was no error.
+   */
+  error?: unknown;
+};
+
+export type FaucetProvider = {
+  /**
+   * Returns metadata about the faucet provider.
+   */
+  getMetadata(): FaucetProviderMetadata;
+
+  /**
+   * Calls faucet API to get test token.
+   *
+   * @param request - The request data including the value to propose names for.
+   */
+  sendETH(request: FaucetProviderRequest): Promise<FaucetProviderSourceResult>;
+};
+
+
+export type FaucetControllerOptions = {
+  messenger: FaucetControllerMessenger;
+  providers: FaucetProvider[];
+  state?: Partial<FaucetControllerState>;
+};
+
+
+/**
+ * Controller for abstracting faucet providers.
+ */
+export class FaucetController extends BaseController<
+  typeof controllerName,
+  FaucetControllerState,
+  FaucetControllerMessenger
+> {
+  #providers: FaucetProvider[];
+
+  /**
+   * Construct a Faucet controller.
+   *
+   * @param options - Controller options.
+   * @param options.messenger - Restricted controller messenger for the faucet controller.
+   * @param options.providers - Array of faucet provider instances to get test tokens.
+   * @param options.state - Initial state to set on the controller.
+   */
+  constructor({
+    messenger,
+    providers,
+    state,
+  }: FaucetControllerOptions) {
+    super({
+      name: controllerName,
+      metadata: stateMetadata,
+      messenger,
+      state: { ...getDefaultState(), ...state },
+    });
+
+    console.log('INIT FAUCET PROVIDERS', providers);
+
+    this.#providers = providers;
+  }
+  async getProviderTestToken(
+    request: FaucetProviderRequest,
+  ): Promise<FaucetProviderSourceResult | undefined> {
+    let responseError: unknown | undefined;
+    let response: FaucetProviderSourceResult | undefined;
+
+    console.log('FAUCET CONTROLLER, getProviderTestToken', request);
+
+    const provider = this.#providers.find((provider) =>
+      this.#getSourceIds(provider, request.chainId).includes(request.sourceId),
+    );
+
+    if (!provider) {
+      const ProviderNotFoundError = new Error('Faucet provider not found');
+      console.log(ProviderNotFoundError);
+      return {
+        error: ProviderNotFoundError,
+      };
+    }
+
+    console.log('FAUCET PROVIDER', provider);
+
+    try {
+      response = await provider.sendETH(request);
+      responseError = response.error;
+    } catch (error) {
+      responseError = error;
+    }
+
+    return { txHash: response?.txHash , error: responseError };
+  }
+
+  getAllSourceIds(chainId: BUYABLE_TEST_CHAINS_IDS): string[] {
+    return (
+      this.#providers
+        .map((provider) => this.#getSourceIds(provider, chainId))
+        .flat()
+    );
+  }
+
+  #getSourceIds(provider: FaucetProvider, chainId: BUYABLE_TEST_CHAINS_IDS): string[] {
+    return provider.getMetadata().sourceIds[chainId];
+  }
+
+}

--- a/app/scripts/controllers/faucets/faucet.ts
+++ b/app/scripts/controllers/faucets/faucet.ts
@@ -130,8 +130,6 @@ export class FaucetController extends BaseController<
       state: { ...getDefaultState(), ...state },
     });
 
-    console.log('INIT FAUCET PROVIDERS', providers);
-
     this.#providers = providers;
   }
   async getProviderTestToken(
@@ -140,21 +138,16 @@ export class FaucetController extends BaseController<
     let responseError: unknown | undefined;
     let response: FaucetProviderSourceResult | undefined;
 
-    console.log('FAUCET CONTROLLER, getProviderTestToken', request);
-
     const provider = this.#providers.find((provider) =>
       this.#getSourceIds(provider, request.chainId).includes(request.sourceId),
     );
 
     if (!provider) {
       const ProviderNotFoundError = new Error('Faucet provider not found');
-      console.log(ProviderNotFoundError);
       return {
         error: ProviderNotFoundError,
       };
     }
-
-    console.log('FAUCET PROVIDER', provider);
 
     try {
       response = await provider.sendETH(request);

--- a/app/scripts/lib/SnapsFaucetProvider.ts
+++ b/app/scripts/lib/SnapsFaucetProvider.ts
@@ -99,7 +99,7 @@ export class SnapsFaucetProvider implements FaucetProvider {
         'SnapController:handleRequest',
         {
           snapId: snap.id,
-          origin: '',
+          origin: 'metamask',
           handler: HandlerType.OnRpcRequest,
           request: {
             jsonrpc: '2.0',

--- a/app/scripts/lib/SnapsFaucetProvider.ts
+++ b/app/scripts/lib/SnapsFaucetProvider.ts
@@ -70,10 +70,8 @@ export class SnapsFaucetProvider implements FaucetProvider {
   async sendETH(
     request: FaucetProviderRequest,
   ): Promise<FaucetProviderSourceResult> {
-    console.log('SnapsFaucetProvider:sendETH', request);
     const faucetSnap = this.#messenger.call('SnapController:get', request.sourceId);
 
-    console.log('SnapsFaucetProvider:sendETH:faucetSnap', faucetSnap);
     if (!faucetSnap) {
       throw new Error('Faucet snap not found');
     };
@@ -121,11 +119,6 @@ export class SnapsFaucetProvider implements FaucetProvider {
 
       resultError = error;
     }
-
-    console.log('SnapsFaucetProvider:#getSnapSendEth', {
-      txHash,
-      resultError,
-    });
 
     return {
       txHash,

--- a/app/scripts/lib/SnapsFaucetProvider.ts
+++ b/app/scripts/lib/SnapsFaucetProvider.ts
@@ -1,0 +1,135 @@
+import { GetPermissionControllerState } from '@metamask/permission-controller';
+import {
+  SnapId,
+  Snap as TruncatedSnap,
+} from '@metamask/snaps-sdk';
+import { HandlerType } from '@metamask/snaps-utils';
+import log from 'loglevel';
+import {
+  GetAllSnaps,
+  GetSnap,
+  HandleSnapRequest,
+} from '@metamask/snaps-controllers';
+import { RestrictedControllerMessenger } from '@metamask/base-controller';
+import { FaucetProvider, FaucetProviderMetadata, FaucetProviderRequest, FaucetProviderSourceResult } from '../controllers/faucets/faucet';
+import { CHAIN_IDS } from '../../../shared/constants/network';
+
+// HARCODED SNAP ID
+// We need to find a way to get this snap id dynamically.
+// The name provider snaps have its own endowment - maybe that is what we need,
+// but it is a stretch for the hackathon time frame
+const snapId = 'local:http://localhost:8080' as SnapId;
+
+type AllowedActions =
+  | GetAllSnaps
+  | GetSnap
+  | HandleSnapRequest
+  | GetPermissionControllerState;
+
+export type SnapsFaucetProviderMessenger = RestrictedControllerMessenger<
+  'SnapsFaucetProvider',
+  AllowedActions,
+  never,
+  AllowedActions['type'],
+  never
+>;
+
+export class SnapsFaucetProvider implements FaucetProvider {
+  #messenger: SnapsFaucetProviderMessenger;
+
+  constructor({ messenger }: { messenger: SnapsFaucetProviderMessenger }) {
+    this.#messenger = messenger;
+  }
+
+  getMetadata(): FaucetProviderMetadata {
+    const snaps = this.#getFaucetLookupSnaps();
+
+    const sourceIds = {
+      [CHAIN_IDS.SEPOLIA]: snaps.map((snap) => snap.id),
+    };
+
+    const sourceLabels = snaps.reduce(
+      (acc: FaucetProviderMetadata['sourceLabels'], snap) => {
+        const snapDetails = this.#messenger.call('SnapController:get', snap.id);
+        const snapName = snapDetails?.manifest.proposedName;
+
+        return {
+          ...acc,
+          [snap.id]: snapName || snap.id,
+        };
+      },
+      {},
+    );
+
+    return {
+      sourceIds,
+      sourceLabels,
+    };
+  }
+
+  async sendETH(
+    request: FaucetProviderRequest,
+  ): Promise<FaucetProviderSourceResult> {
+    console.log('SnapsFaucetProvider:sendETH', request);
+    const faucetSnap = this.#messenger.call('SnapController:get', request.sourceId);
+
+    console.log('SnapsFaucetProvider:sendETH:faucetSnap', faucetSnap);
+    if (!faucetSnap) {
+      throw new Error('Faucet snap not found');
+    };
+
+    return await this.#getSnapSendEth(faucetSnap, request);
+  }
+
+  #getFaucetLookupSnaps(): TruncatedSnap[] {
+    const snap = this.#messenger.call('SnapController:get', snapId);
+
+    return snap ? [snap] : [];
+  }
+
+  async #getSnapSendEth(
+    snap: TruncatedSnap,
+    request: Omit<FaucetProviderRequest, 'sourceId'>,
+  ): Promise<FaucetProviderSourceResult> {
+    const { chainId: chainIdHex, address } = request;
+
+    let txHash;
+    let resultError;
+
+    try {
+      const result = (await this.#messenger.call(
+        'SnapController:handleRequest',
+        {
+          snapId: snap.id,
+          origin: '',
+          handler: HandlerType.OnRpcRequest,
+          request: {
+            jsonrpc: '2.0',
+            method: 'sendETH',
+            params: { chainIdHex, address },
+          },
+        },
+      )) as { txHash: string } | null;
+
+      txHash = result?.txHash;
+    } catch (error) {
+      log.error('Snap faucet provider request failed', {
+        snapId: snap.id,
+        request: { chainIdHex, address },
+        error,
+      });
+
+      resultError = error;
+    }
+
+    console.log('SnapsFaucetProvider:#getSnapSendEth', {
+      txHash,
+      resultError,
+    });
+
+    return {
+      txHash,
+      error: resultError,
+    };
+  }
+}

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -324,6 +324,8 @@ import UserStorageController from './controllers/user-storage/user-storage-contr
 import { WeakRefObjectMap } from './lib/WeakRefObjectMap';
 
 import { PushPlatformNotificationsController } from './controllers/push-platform-notifications/push-platform-notifications';
+import { FaucetController } from './controllers/faucets/faucet';
+import { SnapsFaucetProvider } from './lib/SnapsFaucetProvider';
 
 export const METAMASK_CONTROLLER_EVENTS = {
   // Fired after state changes that impact the extension badge (unapproved msg count)
@@ -1902,6 +1904,26 @@ export default class MetamaskController extends EventEmitter {
       nameController: this.nameController,
       messenger: petnamesBridgeMessenger,
     }).init();
+
+    this.faucetController = new FaucetController({
+      messenger: this.controllerMessenger.getRestricted({
+        name: 'FaucetController',
+        allowedActions: [],
+      }),
+      providers: [
+        new SnapsFaucetProvider({
+          messenger: this.controllerMessenger.getRestricted({
+            name: 'SnapsFaucetProvider',
+            allowedActions: [
+              'SnapController:getAll',
+              'SnapController:get',
+              'SnapController:handleRequest',
+            ],
+          }),
+        }),
+      ],
+      state: initState.FaucetController,
+    });
 
     this.userOperationController = new UserOperationController({
       entrypoint: process.env.EIP_4337_ENTRYPOINT,
@@ -3577,6 +3599,11 @@ export default class MetamaskController extends EventEmitter {
         this.nameController,
       ),
       setName: this.nameController.setName.bind(this.nameController),
+      getFaucetProvidersByChain: this.faucetController.getAllSourceIds.bind(
+        this.faucetController,
+      ),
+      getFaucetProviderTestToken:
+        this.faucetController.getProviderTestToken.bind(this.faucetController),
     };
   }
 

--- a/shared/constants/network.ts
+++ b/shared/constants/network.ts
@@ -999,6 +999,12 @@ export const BUYABLE_CHAINS_MAP: {
   },
 };
 
+export const BUYABLE_TEST_CHAINS_MAP = {
+  [CHAIN_IDS.SEPOLIA]: {
+    network: SEPOLIA_DISPLAY_NAME,
+  },
+} as const;
+
 export const FEATURED_RPCS: RPCDefinition[] = [
   {
     chainId: CHAIN_IDS.ARBITRUM,

--- a/ui/components/app/snaps/snap-list-item/snap-list-item.js
+++ b/ui/components/app/snaps/snap-list-item/snap-list-item.js
@@ -20,6 +20,7 @@ import {
 import SnapAvatar from '../snap-avatar';
 
 const SnapListItem = ({
+  className,
   name,
   packageName,
   onClick,
@@ -28,7 +29,7 @@ const SnapListItem = ({
 }) => {
   return (
     <Box
-      className="snap-list-item"
+      className={`snap-list-item ${className}`}
       data-testid={snapId}
       display={Display.Flex}
       alignItems={AlignItems.center}
@@ -85,6 +86,10 @@ const SnapListItem = ({
 };
 
 SnapListItem.propTypes = {
+  /**
+   * Optional classnames
+   */
+  className: PropTypes.string,
   /**
    * Name of the snap
    */

--- a/ui/components/app/wallet-overview/eth-overview.js
+++ b/ui/components/app/wallet-overview/eth-overview.js
@@ -284,17 +284,16 @@ const EthOverview = ({ className, showAddress }) => {
                       token_symbol: defaultSwapsToken,
                     },
                   });
+                }
 
-                  if (isBuyableTestChain) {
-                    console.log('Clicking this shit');
-                    await dispatch(
-                      getFaucetProviderTestToken({
-                        chainId,
-                        sourceId: 'local:http://localhost:8080',
-                        address: account.address,
-                      }),
-                    );
-                  }
+                if (isBuyableTestChain) {
+                  await dispatch(
+                    getFaucetProviderTestToken({
+                      chainId,
+                      sourceId: 'local:http://localhost:8080',
+                      address: account.address,
+                    }),
+                  );
                 }
               }}
               tooltipRender={(contents) =>

--- a/ui/components/app/wallet-overview/index.scss
+++ b/ui/components/app/wallet-overview/index.scss
@@ -27,6 +27,21 @@
   }
 }
 
+.wallet-overview__modal-faucet {
+  .snap-list-item {
+    cursor: pointer;
+    transition: opacity .25s;
+
+    &.is-selected {
+      cursor: initial;
+      background: var(--color-background-alternative);
+    }
+    &.is-notSelected:not(:hover) {
+      opacity: 40%;
+    }
+  }
+}
+
 %asset-buttons {
   min-width: initial;
   width: 100px;

--- a/ui/components/app/wallet-overview/modal-faucet.tsx
+++ b/ui/components/app/wallet-overview/modal-faucet.tsx
@@ -1,0 +1,138 @@
+import React, { useState, useCallback } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+// import { captureException } from '@sentry/browser';
+import SnapListItem from '../snaps/snap-list-item';
+import {
+  Box,
+  ButtonPrimary,
+  ButtonPrimarySize,
+  Modal,
+  ModalContent,
+  ModalHeader,
+  ModalOverlay,
+  ModalFooter,
+  Text,
+} from '../../component-library';
+import {
+  Display,
+  FlexDirection,
+  TextAlign,
+  TextColor,
+} from '../../../helpers/constants/design-system';
+import { getSnapsList } from '../../../selectors';
+import { getFaucetProviderTestToken } from '../../../store/actions';
+import { BUYABLE_TEST_CHAINS_IDS } from '../../../../app/scripts/controllers/faucets/faucet';
+
+type ModalFaucetProps = {
+  accountAddress: string;
+  chainId: BUYABLE_TEST_CHAINS_IDS;
+  faucetSnapSourceIds: string[];
+  onClose: () => void;
+};
+
+const ModalFaucet: React.FC<ModalFaucetProps> = ({
+  accountAddress,
+  chainId,
+  faucetSnapSourceIds,
+  onClose,
+}) => {
+  const dispatch = useDispatch();
+
+  const [selectedSnapId, setSelectedSnapId] = useState(null);
+  // const [error, setError] = useState<string>('');
+
+  const snapsList = useSelector((state) =>
+    getSnapsList(state, faucetSnapSourceIds),
+  );
+
+  const handleClose = useCallback(async () => {
+    onClose();
+  }, [dispatch, onClose]);
+
+  // const handleError = useCallback(
+  //   (message: string, e: Error) => {
+  //     const errorMessage = `${message} Please try again or contact support if the problem persists.`;
+  //     console.error(message, e);
+  //     setError(errorMessage);
+  //     captureException(e);
+  //   },
+  //   [setError],
+  // );
+
+  return (
+    <Modal
+      className="wallet-overview__modal-faucet"
+      isOpen
+      onClose={handleClose}
+    >
+      <ModalOverlay />
+      <ModalContent>
+        <ModalHeader onClose={handleClose}>Faucet</ModalHeader>
+        {/* {error && <Text color={TextColor.errorDefault}>{error}</Text>} */}
+        <Text
+          as="p"
+          paddingRight={2}
+          paddingLeft={2}
+          color={TextColor.textDefault}
+          textAlign={TextAlign.Center}
+        >
+          Select a MetaMask Snap Faucet
+        </Text>
+        <Box
+          padding={4}
+          display={Display.Flex}
+          flexDirection={FlexDirection.Column}
+        >
+          {snapsList.map((snap) => {
+            const isSelected = selectedSnapId === snap.id;
+
+            let className = '';
+            if (selectedSnapId) {
+              className = isSelected ? 'is-selected' : 'is-notSelected';
+            }
+
+            return (
+              <SnapListItem
+                className={className}
+                key={snap.key}
+                packageName={snap.packageName}
+                name={snap.name}
+                onClick={() => {
+                  setSelectedSnapId(snap.id);
+                }}
+                snapId={snap.id}
+                showUpdateDot={isSelected}
+              />
+            );
+          })}
+        </Box>
+        <ModalFooter>
+          <ButtonPrimary
+            onClick={() => {
+              if (!selectedSnapId) {
+                return;
+              }
+
+              // FIXME: we could add back in await here and handle response
+              dispatch(
+                getFaucetProviderTestToken({
+                  chainId,
+                  sourceId: selectedSnapId,
+                  address: accountAddress,
+                }),
+              );
+              onClose();
+            }}
+            size={ButtonPrimarySize.Lg}
+            block
+            disabled={!selectedSnapId}
+          >
+            Receive ETH
+          </ButtonPrimary>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  );
+};
+
+export default ModalFaucet;

--- a/ui/components/ui/icon-button/icon-button.scss
+++ b/ui/components/ui/icon-button/icon-button.scss
@@ -6,9 +6,13 @@
   align-items: center;
   background-color: unset;
   text-align: center;
-  width: 60px;
+  width: 72px;
 
   @include design-system.H7;
+
+  @include design-system.screen-sm-max {
+    width: 56px;
+  }
 
   font-size: 13px;
   cursor: pointer;

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -2436,14 +2436,17 @@ export function getIsDesktopEnabled(state) {
  * To get all installed snaps with proper metadata
  *
  * @param {*} state
+ * @param snapIds
  * @returns Boolean
  */
-export function getSnapsList(state) {
+export function getSnapsList(state, snapIds) {
   const snaps = getSnaps(state);
   return Object.entries(snaps)
     .filter(
       ([_key, snap]) =>
-        !snap.preinstalled && snap.status !== SnapStatus.Installing,
+        !snap.preinstalled &&
+        snap.status !== SnapStatus.Installing &&
+        (!snapIds || snapIds.includes(snap.id)),
     )
     .map(([key, snap]) => {
       const targetSubjectMetadata = getTargetSubjectMetadata(state, snap?.id);

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -49,6 +49,7 @@ import {
   POLYGON_ZKEVM_DISPLAY_NAME,
   MOONBEAM_DISPLAY_NAME,
   MOONRIVER_DISPLAY_NAME,
+  BUYABLE_TEST_CHAINS_MAP,
 } from '../../shared/constants/network';
 import {
   WebHIDConnectedStatuses,
@@ -1262,6 +1263,12 @@ export function getIsBuyableChain(state) {
   const chainId = getCurrentChainId(state);
   return Object.keys(BUYABLE_CHAINS_MAP).includes(chainId);
 }
+
+export function getIsFaucetBuyableChain(state) {
+  const chainId = getCurrentChainId(state);
+  return Object.keys(BUYABLE_TEST_CHAINS_MAP).includes(chainId);
+}
+
 export function getNativeCurrencyImage(state) {
   const chainId = getCurrentChainId(state);
   return CHAIN_ID_TOKEN_IMAGE_MAP[chainId];

--- a/ui/store/actions.ts
+++ b/ui/store/actions.ts
@@ -115,7 +115,10 @@ import {
 } from '../../shared/modules/error';
 import { ThemeType } from '../../shared/constants/preferences';
 import { FirstTimeFlowType } from '../../shared/constants/onboarding';
-import { FaucetProviderRequest } from '../../app/scripts/controllers/faucets/faucet';
+import {
+  BUYABLE_TEST_CHAINS_IDS,
+  FaucetProviderRequest,
+} from '../../app/scripts/controllers/faucets/faucet';
 import * as actionConstants from './actionConstants';
 ///: BEGIN:ONLY_INCLUDE_IF(build-mmi)
 import { updateCustodyState } from './institutional/institution-actions';
@@ -5067,6 +5070,22 @@ export function setName(
 ): ThunkAction<void, MetaMaskReduxState, unknown, AnyAction> {
   return (async () => {
     await submitRequestToBackground<void>('setName', [request]);
+    // TODO: Replace `any` with type
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  }) as any;
+}
+
+export function getFaucetProvidersByChain(
+  chainId: BUYABLE_TEST_CHAINS_IDS,
+): ThunkAction<void, MetaMaskReduxState, unknown, AnyAction> {
+  return (async () => {
+    console.log(
+      'submitRequestToBackground > getFaucetProvidersByChain',
+      chainId,
+    );
+    await submitRequestToBackground<void>('getFaucetProvidersByChain', [
+      chainId,
+    ]);
     // TODO: Replace `any` with type
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
   }) as any;

--- a/ui/store/actions.ts
+++ b/ui/store/actions.ts
@@ -115,6 +115,7 @@ import {
 } from '../../shared/modules/error';
 import { ThemeType } from '../../shared/constants/preferences';
 import { FirstTimeFlowType } from '../../shared/constants/onboarding';
+import { FaucetProviderRequest } from '../../app/scripts/controllers/faucets/faucet';
 import * as actionConstants from './actionConstants';
 ///: BEGIN:ONLY_INCLUDE_IF(build-mmi)
 import { updateCustodyState } from './institutional/institution-actions';
@@ -5066,6 +5067,22 @@ export function setName(
 ): ThunkAction<void, MetaMaskReduxState, unknown, AnyAction> {
   return (async () => {
     await submitRequestToBackground<void>('setName', [request]);
+    // TODO: Replace `any` with type
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  }) as any;
+}
+
+export function getFaucetProviderTestToken(
+  request: FaucetProviderRequest,
+): ThunkAction<void, MetaMaskReduxState, unknown, AnyAction> {
+  return (async () => {
+    console.log(
+      'submitRequestToBackground > getFaucetProviderTestToken',
+      request,
+    );
+    await submitRequestToBackground<void>('getFaucetProviderTestToken', [
+      request,
+    ]);
     // TODO: Replace `any` with type
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
   }) as any;


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

PR created to stash work

- Eth Overview "Faucet" button
- Modal that contains selectable Snaps List 

![CleanShot 2024-05-12 at 10 10 46@2x](https://github.com/MetaMask/metamask-extension/assets/20778143/d2cc01bc-ac29-490c-95a5-048e005f188c)
![CleanShot 2024-05-12 at 13 46 02@2x](https://github.com/MetaMask/metamask-extension/assets/20778143/9a6b66ac-3ba3-4d11-a5ce-b860e634f7db)


[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/24501?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
