### PR TITLE
feat: Adding MetaMetrics data deletion to Security & Privacy

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -968,6 +968,9 @@
   "connectionRequest": {
     "message": "Connection request"
   },
+  "consensysPrivacyPolicy": {
+    "message": "Consensys Privacy Policy"
+  },
   "contactUs": {
     "message": "Contact us"
   },
@@ -1268,6 +1271,16 @@
   },
   "deleteContact": {
     "message": "Delete contact"
+  },
+  "deleteMetaMetricsData": {
+    "message": "Delete MetaMetrics data"
+  },
+  "deleteMetaMetricsDataDescription": {
+    "message": "This will delete historical MetaMetrics data associated with your wallet. $1 Your wallet and accounts will remain exactly as they are now after this data has been deleted. This process may take up to 60 days. View the $2",
+    "description": "$1 will have the text with bold font (deleteMetaMetricsDataDescriptionBold) regarding metametrics and $2 will have text saying Consensys Privacy Policy "
+  },
+  "deleteMetaMetricsDataDescriptionBold": {
+    "message": "MetaMetrics data is anonymized usage and diagnostic data."
   },
   "deleteNetwork": {
     "message": "Delete network?"

--- a/ui/pages/settings/security-tab/security-tab.component.js
+++ b/ui/pages/settings/security-tab/security-tab.component.js
@@ -27,6 +27,7 @@ import {
   BUTTON_SIZES,
   Box,
   Text,
+  ButtonPrimary,
 } from '../../../components/component-library';
 import TextField from '../../../components/ui/text-field';
 import ToggleButton from '../../../components/ui/toggle-button';
@@ -356,6 +357,44 @@ export default class SecurityTab extends PureComponent {
             offLabel={t('off')}
             onLabel={t('on')}
           />
+        </div>
+      </Box>
+    );
+  }
+
+  renderDeleteMetaMetricsData() {
+    const { t } = this.context;
+
+    return (
+      <Box
+        className="settings-page__content-row"
+        data-testid="delete-metametrics-data"
+        display={Display.Flex}
+        flexDirection={FlexDirection.Column}
+        gap={4}
+      >
+        <div className="settings-page__content-item">
+          <span>{t('deleteMetaMetricsData')}</span>
+          <div className="settings-page__content-description">
+            {t('deleteMetaMetricsDataDescription', [
+              <b key="delete-MetaMetrics-Data-Desc-Bold">
+                {t('deleteMetaMetricsDataDescriptionBold')}
+              </b>,
+              <a
+                href={CONSENSYS_PRIVACY_LINK}
+                target="_blank"
+                rel="noopener noreferrer"
+                key="metametrics-consensys-privacy-link"
+              >
+                {t('consensysPrivacyPolicy')}
+              </a>,
+            ])}
+          </div>
+        </div>
+        <div className="settings-page__content-item-col">
+          <ButtonPrimary className="settings-page__button" onClick={() => {}}>
+            {t('deleteMetaMetricsData')}
+          </ButtonPrimary>
         </div>
       </Box>
     );
@@ -1109,6 +1148,7 @@ export default class SecurityTab extends PureComponent {
         </span>
         <div className="settings-page__content-padded">
           {this.renderMetaMetricsOptIn()}
+          {this.renderDeleteMetaMetricsData()}
         </div>
       </div>
     );


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/24504?quickstart=1)

## **Related issues**

Fixes: #24406 

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**
<img width="358" alt="Screenshot 2024-05-13 at 5 22 35 PM" src="https://github.com/MetaMask/metamask-extension/assets/43930900/89b89bdc-3397-4ba2-9a04-8813cb3d4a38">

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
