### PR TITLE
feat: Slightly update UI for the STX Opt In modal

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -1493,6 +1493,9 @@
   "done": {
     "message": "Done"
   },
+  "dontEnableEnhancedProtection": {
+    "message": "Don't enable enhanced protection"
+  },
   "dontShowThisAgain": {
     "message": "Don't show this again"
   },
@@ -3003,9 +3006,6 @@
   },
   "noSnaps": {
     "message": "You don't have any snaps installed."
-  },
-  "noThanks": {
-    "message": "No thanks"
   },
   "noTransactions": {
     "message": "You have no transactions"
@@ -4570,7 +4570,7 @@
     "message": "99.5% success rate"
   },
   "smartTransactionsBenefit2": {
-    "message": "Transaction protection"
+    "message": "Saves you money"
   },
   "smartTransactionsBenefit3": {
     "message": "Real-time updates"
@@ -4583,7 +4583,7 @@
     "description": "$1 is an external link to learn more about Smart Transactions"
   },
   "smartTransactionsOptItModalTitle": {
-    "message": "Transactions just got smarter"
+    "message": "Enhanced Transaction Protection"
   },
   "snapAccountCreated": {
     "message": "Account created"

--- a/test/e2e/mmi/pageObjects/mmi-signup-page.ts
+++ b/test/e2e/mmi/pageObjects/mmi-signup-page.ts
@@ -44,7 +44,9 @@ export class MMISignUpPage {
       'button:has-text("Confirm Secret Recovery Phrase")',
     );
     this.agreeBtn = page.locator('button:has-text("I agree")');
-    this.noThanksBtn = page.locator('button:has-text("No thanks")');
+    this.noThanksBtn = page.locator(
+      'button:has-text("Don\'t enable enhanced protection")',
+    );
     this.passwordTxt = page.getByTestId('create-password-new');
     this.passwordConfirmTxt = page.getByTestId('create-password-confirm');
     this.agreeCheck = page.getByTestId('create-new-vault__terms-checkbox');

--- a/test/e2e/vault-decryption-chrome.spec.js
+++ b/test/e2e/vault-decryption-chrome.spec.js
@@ -50,7 +50,10 @@ async function getExtensionStorageFilePath(driver) {
  */
 async function closePopoverIfPresent(driver) {
   const popoverButtonSelector = '[data-testid="popover-close"]';
-  const linkNoThanks = { text: 'No thanks', tag: 'button' };
+  const linkNoThanks = {
+    text: "Don't enable enhanced protection",
+    tag: 'button',
+  };
   await driver.clickElementSafe(popoverButtonSelector);
   await driver.clickElementSafe(linkNoThanks);
 }

--- a/ui/components/app/smart-transactions/smart-transactions-opt-in-modal.tsx
+++ b/ui/components/app/smart-transactions/smart-transactions-opt-in-modal.tsx
@@ -89,7 +89,7 @@ const NoThanksLink = ({
       width={BlockSize.Full}
       className="mm-smart-transactions-opt-in-modal__no-thanks-link"
     >
-      {t('noThanks')}
+      {t('dontEnableEnhancedProtection')}
     </Button>
   );
 };
@@ -149,10 +149,7 @@ const Benefits = () => {
         text={t('smartTransactionsBenefit1')}
         iconName={IconName.Confirmation}
       />
-      <Benefit
-        text={t('smartTransactionsBenefit2')}
-        iconName={IconName.SecurityTick}
-      />
+      <Benefit text={t('smartTransactionsBenefit2')} iconName={IconName.Coin} />
       <Benefit
         text={t('smartTransactionsBenefit3')}
         iconName={IconName.Clock}


### PR DESCRIPTION
## **Description**

Some slight UI updates to the STX Opt In modal.

## **Related issues**

Fixes:

## **Manual testing steps**

1. Install the extension from scratch
2. Check the updated Opt In modal

## **Screenshots/Recordings**

<img width="354" alt="image" src="https://github.com/MetaMask/metamask-extension/assets/80175477/81302fbf-aa20-43cc-a23b-e6528b3999b6">


## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
