### PR TITLE
fix: (cherry-pick Version v11.17.0) Fix confirmation redesign disabled "Confirm" button with 16px or less scroll buffer

### DIFF
--- a/ui/hooks/useScrollRequired.js
+++ b/ui/hooks/useScrollRequired.js
@@ -8,9 +8,14 @@ import { debounce } from 'lodash';
  * The hook expects both the `ref` and the `onScroll` handler to be passed to the scrolling element.
  *
  * @param dependencies - Any optional hook dependencies for updating the scroll state.
+ * @param opt
+ * @param {number} opt.offsetPxFromBottom
  * @returns Flags for isScrollable and isScrollToBottom, a ref to use for the scrolling content, a scrollToBottom function and a onScroll handler.
  */
-export const useScrollRequired = (dependencies = []) => {
+export const useScrollRequired = (
+  dependencies = [],
+  { offsetPxFromBottom = 16 } = {},
+) => {
   const ref = useRef(null);
 
   const [hasScrolledToBottomState, setHasScrolledToBottom] = useState(false);
@@ -28,7 +33,9 @@ export const useScrollRequired = (dependencies = []) => {
       isScrollable &&
       // Add 16px to the actual scroll position to trigger setIsScrolledToBottom sooner.
       // This avoids the problem where a user has scrolled down to the bottom and it's not detected.
-      Math.round(ref.current.scrollTop) + ref.current.offsetHeight + 16 >=
+      Math.round(ref.current.scrollTop) +
+        ref.current.offsetHeight +
+        offsetPxFromBottom >=
         ref.current.scrollHeight;
 
     setIsScrollable(isScrollable);

--- a/ui/pages/confirmations/components/confirm/scroll-to-bottom/scroll-to-bottom.test.tsx
+++ b/ui/pages/confirmations/components/confirm/scroll-to-bottom/scroll-to-bottom.test.tsx
@@ -14,13 +14,15 @@ const mockState = {
   },
 };
 
+const mockSetHasScrolledToBottom = jest.fn();
+
 const mockUseScrollRequiredResult = {
   hasScrolledToBottom: false,
   isScrollable: false,
   isScrolledToBottom: false,
   onScroll: jest.fn(),
   scrollToBottom: jest.fn(),
-  setHasScrolledToBottom: jest.fn(),
+  setHasScrolledToBottom: mockSetHasScrolledToBottom,
   ref: {
     current: {},
   },
@@ -130,6 +132,15 @@ describe('ScrollToBottom', () => {
       expect(mockScrollTo).toHaveBeenCalledWith(0, 0);
 
       window.HTMLDivElement.prototype.scrollTo = originalScrollTo;
+    });
+
+    it('resets setHasScrolledToBottom to false when the confirmation changes', () => {
+      renderWithProvider(
+        <ScrollToBottom>foobar</ScrollToBottom>,
+        configureMockStore([])(mockState),
+      );
+
+      expect(mockSetHasScrolledToBottom).toHaveBeenCalledWith(false);
     });
 
     describe('when user has scrolled to the bottom', () => {

--- a/ui/pages/confirmations/components/confirm/scroll-to-bottom/scroll-to-bottom.tsx
+++ b/ui/pages/confirmations/components/confirm/scroll-to-bottom/scroll-to-bottom.tsx
@@ -42,7 +42,7 @@ const ScrollToBottom = ({ children }: ContentProps) => {
     scrollToBottom,
     setHasScrolledToBottom,
     ref,
-  } = useScrollRequired([currentConfirmation?.id]);
+  } = useScrollRequired([currentConfirmation?.id], { offsetPxFromBottom: 0 });
 
   /**
    * Scroll to the top of the page when the confirmation changes. This happens
@@ -53,13 +53,17 @@ const ScrollToBottom = ({ children }: ContentProps) => {
       return;
     }
 
-    setHasScrolledToBottom(false);
-
-    const scrollTo = (ref?.current as null | HTMLDivElement)?.scrollTo;
-    if (typeof scrollTo === 'function') {
-      (ref?.current as null | HTMLDivElement)?.scrollTo(0, 0);
+    const currentRef = ref?.current as null | HTMLDivElement;
+    if (!currentRef) {
+      return;
     }
-  }, [currentConfirmation?.id, previousId, setHasScrolledToBottom]);
+
+    if (typeof currentRef.scrollTo === 'function') {
+      currentRef.scrollTo(0, 0);
+    }
+
+    setHasScrolledToBottom(false);
+  }, [currentConfirmation?.id, previousId, ref?.current]);
 
   useEffect(() => {
     dispatch(


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Cherry-pick [0e775fd](https://github.com/MetaMask/metamask-extension/commit/0e775fd910ff794456e2cd79a0b0eabef4ca96c4) (https://github.com/MetaMask/metamask-extension/pull/24489) into v11.17.0

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/24527?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/24485

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
