### PR TITLE
chore(ci): Reduce e2e attempts from 3 to 2 in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1100,7 +1100,7 @@ jobs:
           command: |
             if .circleci/scripts/test-run-e2e.sh
             then
-              timeout 20m yarn test:e2e:chrome --retries 2
+              timeout 20m yarn test:e2e:chrome --retries 1
             fi
           no_output_timeout: 5m
       - store_artifacts:
@@ -1127,7 +1127,7 @@ jobs:
           command: |
             if .circleci/scripts/test-run-e2e.sh
             then
-              timeout 20m yarn test:e2e:chrome --retries 2
+              timeout 20m yarn test:e2e:chrome --retries 1
             fi
           no_output_timeout: 5m
           environment:
@@ -1156,7 +1156,7 @@ jobs:
           command: |
             if .circleci/scripts/test-run-e2e.sh
             then
-              timeout 20m yarn test:e2e:chrome --retries 2
+              timeout 20m yarn test:e2e:chrome --retries 1
             fi
           no_output_timeout: 5m
           environment:
@@ -1185,7 +1185,7 @@ jobs:
           command: |
             if .circleci/scripts/test-run-e2e.sh
             then
-              timeout 20m yarn test:e2e:chrome:rpc --retries 2
+              timeout 20m yarn test:e2e:chrome:rpc --retries 1
             fi
           no_output_timeout: 5m
       - store_artifacts:
@@ -1212,7 +1212,7 @@ jobs:
           command: |
             if .circleci/scripts/test-run-e2e.sh
             then
-              yarn test:e2e:chrome:multi-provider --retries 2
+              yarn test:e2e:chrome:multi-provider --retries 1
             fi
           no_output_timeout: 5m
       - store_artifacts:
@@ -1238,7 +1238,7 @@ jobs:
           command: |
             if .circleci/scripts/test-run-e2e.sh
             then
-              timeout 20m yarn test:e2e:chrome:rpc --retries 2 --build-type=mmi
+              timeout 20m yarn test:e2e:chrome:rpc --retries 1 --build-type=mmi
             fi
           no_output_timeout: 5m
       - store_artifacts:
@@ -1258,7 +1258,7 @@ jobs:
           command: |
             if .circleci/scripts/test-run-e2e.sh
             then
-              yarn test:e2e:single test/e2e/vault-decryption-chrome.spec.js --browser chrome --retries 2
+              yarn test:e2e:single test/e2e/vault-decryption-chrome.spec.js --browser chrome --retries 1
             fi
           no_output_timeout: 5m
 
@@ -1281,7 +1281,7 @@ jobs:
             export ENABLE_MV3=false
             if .circleci/scripts/test-run-e2e.sh
             then
-              timeout 20m yarn test:e2e:firefox:flask --retries 2
+              timeout 20m yarn test:e2e:firefox:flask --retries 1
             fi
           no_output_timeout: 5m
       - store_artifacts:
@@ -1308,7 +1308,7 @@ jobs:
           command: |
             if .circleci/scripts/test-run-e2e.sh
             then
-              timeout 20m yarn test:e2e:chrome:flask --retries 2
+              timeout 20m yarn test:e2e:chrome:flask --retries 1
             fi
           no_output_timeout: 5m
       - store_artifacts:
@@ -1335,7 +1335,7 @@ jobs:
           command: |
             if .circleci/scripts/test-run-e2e.sh
             then
-              timeout 20m yarn test:e2e:chrome:mmi --retries 2 --build-type=mmi
+              timeout 20m yarn test:e2e:chrome:mmi --retries 1 --build-type=mmi
             fi
           no_output_timeout: 5m
       - store_artifacts:
@@ -1404,7 +1404,7 @@ jobs:
             export ENABLE_MV3=false
             if .circleci/scripts/test-run-e2e.sh
             then
-              timeout 20m yarn test:e2e:firefox --retries 2
+              timeout 20m yarn test:e2e:firefox --retries 1
             fi
           no_output_timeout: 5m
       - store_artifacts:
@@ -1432,7 +1432,7 @@ jobs:
             export ENABLE_MV3=false
             if .circleci/scripts/test-run-e2e.sh
             then
-              timeout 20m yarn test:e2e:firefox --retries 2
+              timeout 20m yarn test:e2e:firefox --retries 1
             fi
           no_output_timeout: 5m
           environment:


### PR DESCRIPTION
## **Description**


This reduces:
- E2E CI retries from 2 to 1 (ie attempts 2 times instead of 3 times)
- The average cost and time to run individual CI jobs
- Feedback loops for e2e errors
- Success rate (and therefore hopefully introduction rate) of flaky tests
- Success rate (and therefore hopefully introduction rate) of inconsistent application behavior which relies on specific CI conditions to pass E2E tests

Non-E2E CI jobs have their existing retry count unchanged.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/24531?quickstart=1)

## **Related issues**


## **Manual testing steps**

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
