### PR TITLE
fix: Use double quotes in in xpath text locator in driver.buildLocator

### DIFF
--- a/test/e2e/webdriver/driver.js
+++ b/test/e2e/webdriver/driver.js
@@ -186,9 +186,16 @@ class Driver {
           .toXPath();
         return By.xpath(xpath);
       }
+      // If the text to be selected contains single or double quotation marks
+      // it can cause the xpath selector to be invalid. `textToLocate` results
+      // in a string that won't be invalidated by the presence of quotation
+      // marks within the text the test is trying to find
+      const textToLocate = locator.text.match(/"/u)
+        ? `'${locator.text}'`
+        : `"${locator.text}"`;
       // The tag prop is optional and further refines which elements match
       return By.xpath(
-        `//${locator.tag ?? '*'}[contains(text(), "${locator.text}")]`,
+        `//${locator.tag ?? '*'}[contains(text(), ${textToLocate})]`,
       );
     }
     throw new Error(

--- a/test/e2e/webdriver/driver.js
+++ b/test/e2e/webdriver/driver.js
@@ -188,7 +188,7 @@ class Driver {
       }
       // The tag prop is optional and further refines which elements match
       return By.xpath(
-        `//${locator.tag ?? '*'}[contains(text(), '${locator.text}')]`,
+        `//${locator.tag ?? '*'}[contains(text(), "${locator.text}")]`,
       );
     }
     throw new Error(


### PR DESCRIPTION
## **Description**

`test/e2e/vault-decryption-chrome.spec.js` currently fails on `develop`. This started failing after https://github.com/MetaMask/metamask-extension/pull/24525 was merged. The error was:

```
Element [object Object] not found (JavascriptError: javascript error: {"status":32,"value":"Unable to locate an element with the xpath expression //button[contains(text(), 'Don't enable enhanced protection')] because of the following error:\nSyntaxError: Failed to execute 'evaluate' on 'Document': The string '//button[contains(text(), 'Don't enable enhanced protection')]' is not a valid XPath expression."}
```

That PR changed a selector to select based on the text "Don't enable enhanced protection". Having an unescaped single quote inside single quotes was the problem. The solution in this PR is just to use double quotes in the `By.xpath` call in the `buildLocator` driver method (that all of our custom find functions depend on)

Note: the test that is failing only runs on the develop branch and on release branches, which is why the PR was able to be merged.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/24539?quickstart=1)

## **Manual testing steps**

1. Checkout this branch
2. Run `yarn && yarn dist`
3. Run `yarn test:e2e:single test/e2e/vault-decryption-chrome.spec.js --browser chrome`

The tests should pass. Doing the same on `develop` results in the above mentioned failure/error

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
