### PR TITLE
fix: Update filtering of STX for the Activity list

### DIFF
--- a/ui/selectors/transactions.js
+++ b/ui/selectors/transactions.js
@@ -4,6 +4,7 @@ import {
   TransactionStatus,
   TransactionType,
 } from '@metamask/transaction-controller';
+import { SmartTransactionStatuses } from '@metamask/smart-transactions-controller/dist/types';
 import {
   PRIORITY_STATUS_HASH,
   PENDING_STATUS_HASH,
@@ -19,6 +20,12 @@ import { createDeepEqualSelector } from './util';
 const INVALID_INITIAL_TRANSACTION_TYPES = [
   TransactionType.cancel,
   TransactionType.retry,
+];
+const allowedSwapsSmartTransactionStatusesForActivityList = [
+  SmartTransactionStatuses.PENDING,
+  SmartTransactionStatuses.UNKNOWN,
+  SmartTransactionStatuses.RESOLVED,
+  SmartTransactionStatuses.CANCELLED,
 ];
 
 export const unapprovedMsgsSelector = (state) => state.metamask.unapprovedMsgs;
@@ -102,18 +109,25 @@ export const smartTransactionsListSelector = (state) => {
   return state.metamask.smartTransactionsState?.smartTransactions?.[
     getCurrentChainId(state)
   ]
-    ?.filter((stx) => {
-      const isCancelledSmartTransaction = stx.status?.startsWith('cancelled');
+    ?.filter((smartTransaction) => {
+      if (
+        smartTransaction.txParams?.from !== selectedAddress ||
+        smartTransaction.confirmed
+      ) {
+        return false;
+      }
+      if (smartTransaction.status === SmartTransactionStatuses.PENDING) {
+        return true;
+      }
+      // In the future we should have the same behavior for Swaps and non-Swaps transactions.
+      // For that we need to submit Smart Swaps via the TransactionController as we do for
+      // non-Swaps Smart Transactions.
       return (
-        stx.txParams?.from === selectedAddress &&
-        !stx.confirmed &&
-        (!isCancelledSmartTransaction ||
-          // We only want to show cancelled Smart Transactions for Swaps in Activity,
-          // since other transaction types will show the "Failed" status in Activity instead,
-          // because they are mostly processed via the TransactionController. In the future, we
-          // should have the same behavior for Swaps as well, so all transaction types
-          // would be handled the same way for Smart Transactions.
-          (isCancelledSmartTransaction && stx.type === TransactionType.swap))
+        (smartTransaction.type === TransactionType.swap ||
+          smartTransaction.type === TransactionType.swapApproval) &&
+        allowedSwapsSmartTransactionStatusesForActivityList.includes(
+          smartTransaction.status,
+        )
       );
     })
     .map((stx) => ({

--- a/ui/selectors/transactions.js
+++ b/ui/selectors/transactions.js
@@ -22,11 +22,9 @@ const INVALID_INITIAL_TRANSACTION_TYPES = [
   TransactionType.retry,
 ];
 
-// The statuses listed below are permitted in the Activity list for Smart Swaps because
-// a Smart Swap with these statuses hasn't been added to the TransactionController's regular transaction list yet.
-// The SUCCESS status is not allowed because once a Smart Swap is successful,
-// the "this.confirmExternalTransaction" function is called, which moves the transaction
-// to the regular transaction list in the TransactionController.
+// The statuses listed below are allowed in the Activity list for Smart Swaps.
+// SUCCESS and REVERTED statuses are excluded because smart transactions with 
+// those statuses are already in the regular transaction list.
 // TODO: When Swaps and non-Swaps transactions are treated the same,
 // we will only allow the PENDING smart transaction status in the Activity list.
 const allowedSwapsSmartTransactionStatusesForActivityList = [

--- a/ui/selectors/transactions.js
+++ b/ui/selectors/transactions.js
@@ -23,7 +23,7 @@ const INVALID_INITIAL_TRANSACTION_TYPES = [
 ];
 
 // The statuses listed below are allowed in the Activity list for Smart Swaps.
-// SUCCESS and REVERTED statuses are excluded because smart transactions with 
+// SUCCESS and REVERTED statuses are excluded because smart transactions with
 // those statuses are already in the regular transaction list.
 // TODO: When Swaps and non-Swaps transactions are treated the same,
 // we will only allow the PENDING smart transaction status in the Activity list.

--- a/ui/selectors/transactions.js
+++ b/ui/selectors/transactions.js
@@ -21,11 +21,19 @@ const INVALID_INITIAL_TRANSACTION_TYPES = [
   TransactionType.cancel,
   TransactionType.retry,
 ];
+
+// The statuses listed below are permitted in the Activity list for Smart Swaps because
+// a Smart Swap with these statuses hasn't been added to the TransactionController's regular transaction list yet.
+// The SUCCESS status is not allowed because once a Smart Swap is successful,
+// the "this.confirmExternalTransaction" function is called, which moves the transaction
+// to the regular transaction list in the TransactionController.
+// TODO: When Swaps and non-Swaps transactions are treated the same,
+// we will only allow the PENDING smart transaction status in the Activity list.
 const allowedSwapsSmartTransactionStatusesForActivityList = [
   SmartTransactionStatuses.PENDING,
   SmartTransactionStatuses.UNKNOWN,
   SmartTransactionStatuses.RESOLVED,
-  SmartTransactionStatuses.CANCELLED,
+  SmartTransactionStatuses.CANCELLED, // Other CANCELLED_ statuses are deprecated.
 ];
 
 export const unapprovedMsgsSelector = (state) => state.metamask.unapprovedMsgs;
@@ -116,6 +124,7 @@ export const smartTransactionsListSelector = (state) => {
       ) {
         return false;
       }
+      // If a swap or non-swap smart transaction is pending, we want to show it in the Activity list.
       if (smartTransaction.status === SmartTransactionStatuses.PENDING) {
         return true;
       }

--- a/ui/selectors/transactions.js
+++ b/ui/selectors/transactions.js
@@ -31,7 +31,7 @@ const allowedSwapsSmartTransactionStatusesForActivityList = [
   SmartTransactionStatuses.PENDING,
   SmartTransactionStatuses.UNKNOWN,
   SmartTransactionStatuses.RESOLVED,
-  SmartTransactionStatuses.CANCELLED, // Other CANCELLED_ statuses are deprecated.
+  SmartTransactionStatuses.CANCELLED,
 ];
 
 export const unapprovedMsgsSelector = (state) => state.metamask.unapprovedMsgs;

--- a/ui/selectors/transactions.test.js
+++ b/ui/selectors/transactions.test.js
@@ -1,6 +1,13 @@
 import { ApprovalType } from '@metamask/controller-utils';
 import { EthAccountType } from '@metamask/keyring-api';
-import { TransactionStatus } from '@metamask/transaction-controller';
+import {
+  TransactionStatus,
+  TransactionType,
+} from '@metamask/transaction-controller';
+import {
+  SmartTransactionStatuses,
+  SmartTransactionMinedTx,
+} from '@metamask/smart-transactions-controller/dist/types';
 import { CHAIN_IDS } from '../../shared/constants/network';
 import {
   ETH_4337_METHODS,
@@ -15,6 +22,7 @@ import {
   submittedPendingTransactionsSelector,
   hasTransactionPendingApprovals,
   getApprovedAndSignedTransactions,
+  smartTransactionsListSelector,
 } from './transactions';
 
 describe('Transaction Selectors', () => {
@@ -126,6 +134,255 @@ describe('Transaction Selectors', () => {
 
       expect(Array.isArray(msgSelector)).toStrictEqual(true);
       expect(msgSelector).toStrictEqual([msg]);
+    });
+  });
+  describe('smartTransactionsListSelector', () => {
+    const createSmartTransaction = (customParams = {}) => {
+      return {
+        uuid: 'uuid1',
+        status: customParams.status || SmartTransactionStatuses.SUCCESS,
+        type: customParams.type || TransactionType.contractInteraction,
+        cancellable: false,
+        confirmed: customParams.confirmed ?? false,
+        statusMetadata: {
+          cancellationFeeWei: 36777567771000,
+          cancellationReason:
+            customParams.cancellationReason || 'not_cancelled',
+          deadlineRatio: 0.6400288486480713,
+          minedHash: customParams.minedHash || '',
+          minedTx: customParams.minedTx || '',
+        },
+        txParams: {
+          from: customParams.fromAddress || '0xAddress',
+          to: '0xRecipient',
+        },
+      };
+    };
+
+    const createState = (smartTransaction) => {
+      return {
+        metamask: {
+          providerConfig: {
+            nickname: 'mainnet',
+            chainId: CHAIN_IDS.MAINNET,
+          },
+          featureFlags: {},
+          internalAccounts: {
+            accounts: {
+              'cf8dace4-9439-4bd4-b3a8-88c821c8fcb3': {
+                id: 'cf8dace4-9439-4bd4-b3a8-88c821c8fcb3',
+                address: '0xAddress',
+              },
+              metadata: {
+                name: 'Test Account',
+                keyring: {
+                  type: 'HD Key Tree',
+                },
+              },
+            },
+            selectedAccount: 'cf8dace4-9439-4bd4-b3a8-88c821c8fcb3',
+          },
+          smartTransactionsState: {
+            liveness: true,
+            fees: null,
+            smartTransactions: {
+              [CHAIN_IDS.MAINNET]: smartTransaction ? [smartTransaction] : [],
+            },
+          },
+        },
+      };
+    };
+
+    it('returns an empty array if there are no smart transactions in state', () => {
+      const state = createState();
+      state.metamask.smartTransactionsState.smartTransactions = {
+        [CHAIN_IDS.MAINNET]: [],
+      };
+
+      const result = smartTransactionsListSelector(state);
+
+      expect(result).toStrictEqual([]);
+    });
+
+    it('does not return a confirmed transaction with status "success"', () => {
+      const smartTransaction = createSmartTransaction({
+        minedHash:
+          '0x55ad39634ee10d417b6e190cfd3736098957e958879cffe78f1f00f4fd2654d6',
+        minedTx: SmartTransactionMinedTx.SUCCESS,
+        confirmed: true,
+      });
+      const state = createState(smartTransaction);
+
+      const result = smartTransactionsListSelector(state);
+
+      const expected = [];
+      expect(result).toStrictEqual(expected);
+    });
+
+    it('does not return a confirmed transaction with status "reverted"', () => {
+      const smartTransaction = createSmartTransaction({
+        minedTx: SmartTransactionMinedTx.REVERTED,
+        confirmed: true,
+      });
+      const state = createState(smartTransaction);
+
+      const result = smartTransactionsListSelector(state);
+
+      const expected = [];
+      expect(result).toStrictEqual(expected);
+    });
+
+    it('does not return a confirmed transaction', () => {
+      const smartTransaction = createSmartTransaction({
+        confirmed: true,
+      });
+      const state = createState(smartTransaction);
+
+      const result = smartTransactionsListSelector(state);
+
+      const expected = [];
+      expect(result).toStrictEqual(expected);
+    });
+
+    it('does not return an unconfirmed transaction with status "pending" for a different from address', () => {
+      const smartTransaction = createSmartTransaction({
+        status: SmartTransactionStatuses.PENDING,
+        fromAddress: '0xAddress2',
+      });
+      const state = createState(smartTransaction);
+
+      const result = smartTransactionsListSelector(state);
+
+      const expected = [];
+      expect(result).toStrictEqual(expected);
+    });
+
+    it('returns an unconfirmed transaction with status "pending"', () => {
+      const smartTransaction = createSmartTransaction({
+        status: SmartTransactionStatuses.PENDING,
+      });
+      const state = createState(smartTransaction);
+
+      const result = smartTransactionsListSelector(state);
+
+      const expected = [
+        {
+          ...smartTransaction,
+          isSmartTransaction: true,
+        },
+      ];
+      expect(result).toStrictEqual(expected);
+    });
+
+    it('returns an unconfirmed transaction with status "cancelled" and type "swap"', () => {
+      const smartTransaction = createSmartTransaction({
+        status: SmartTransactionStatuses.PENDING,
+        type: TransactionType.swap,
+      });
+      const state = createState(smartTransaction);
+
+      const result = smartTransactionsListSelector(state);
+
+      const expected = [
+        {
+          ...smartTransaction,
+          isSmartTransaction: true,
+        },
+      ];
+      expect(result).toStrictEqual(expected);
+    });
+
+    it('returns an unconfirmed transaction with status "cancelled" and type "swapApproval"', () => {
+      const smartTransaction = createSmartTransaction({
+        status: SmartTransactionStatuses.PENDING,
+        type: TransactionType.swapApproval,
+      });
+      const state = createState(smartTransaction);
+
+      const result = smartTransactionsListSelector(state);
+
+      const expected = [
+        {
+          ...smartTransaction,
+          isSmartTransaction: true,
+        },
+      ];
+      expect(result).toStrictEqual(expected);
+    });
+
+    it('returns an unconfirmed transaction with status "unknown" and type "swap"', () => {
+      const smartTransaction = createSmartTransaction({
+        status: SmartTransactionStatuses.UNKNOWN,
+        type: TransactionType.swap,
+      });
+      const state = createState(smartTransaction);
+
+      const result = smartTransactionsListSelector(state);
+
+      const expected = [
+        {
+          ...smartTransaction,
+          isSmartTransaction: true,
+        },
+      ];
+      expect(result).toStrictEqual(expected);
+    });
+
+    it('returns an unconfirmed transaction with status "resolved" and type "swap"', () => {
+      const smartTransaction = createSmartTransaction({
+        status: SmartTransactionStatuses.RESOLVED,
+        type: TransactionType.swap,
+      });
+      const state = createState(smartTransaction);
+
+      const result = smartTransactionsListSelector(state);
+
+      const expected = [
+        {
+          ...smartTransaction,
+          isSmartTransaction: true,
+        },
+      ];
+      expect(result).toStrictEqual(expected);
+    });
+
+    it('does not return an unconfirmed transaction with status "cancelled" and type "simpleSend"', () => {
+      const smartTransaction = createSmartTransaction({
+        status: SmartTransactionStatuses.CANCELLED,
+        type: TransactionType.simpleSend,
+      });
+      const state = createState(smartTransaction);
+
+      const result = smartTransactionsListSelector(state);
+
+      const expected = [];
+      expect(result).toStrictEqual(expected);
+    });
+
+    it('does not return an unconfirmed transaction with status "unknown" and type "simpleSend"', () => {
+      const smartTransaction = createSmartTransaction({
+        status: SmartTransactionStatuses.UNKNOWN,
+        type: TransactionType.simpleSend,
+      });
+      const state = createState(smartTransaction);
+
+      const result = smartTransactionsListSelector(state);
+
+      const expected = [];
+      expect(result).toStrictEqual(expected);
+    });
+
+    it('does not return an unconfirmed transaction with status "reverted" and type "simpleSend"', () => {
+      const smartTransaction = createSmartTransaction({
+        status: SmartTransactionStatuses.REVERTED,
+        type: TransactionType.simpleSend,
+      });
+      const state = createState(smartTransaction);
+
+      const result = smartTransactionsListSelector(state);
+
+      const expected = [];
+      expect(result).toStrictEqual(expected);
     });
   });
 


### PR DESCRIPTION
## **Description**

Update filtering of STX for the Activity list. There was a rare edge case when we showed a duplicated transaction in the Activity list when the transaction status was "unknown" due to reverting on chain. Now backend returns "reverted" for such transactions instead of "unknown", but just in case we have updated client-side code to only show "unknown" non-swaps transactions once in the Activity list.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/24540?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Have at least one smart transaction submitted e.g. on Sepolia
2. In the `smartTransactionsListSelector` function you can artificially add a new smart transaction with the status "unknown". It should not show up in the Activity list.
```
const smartTransactions =
    state.metamask.smartTransactionsState?.smartTransactions?.[
      getCurrentChainId(state)
    ];
const smartTransactionsCopy = [...smartTransactions];
smartTransactionsCopy.push({
  ...smartTransactions[0],
  status: 'unknown',
  type: 'contractInteraction',
  statusMetadata: {
    ...smartTransactions[0].statusMetadata,
    minedTx: 'unknown',
  },
});
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
