### PR TITLE
feat: change user storage KDF

### DIFF
--- a/app/scripts/controllers/user-storage/encryption.test.ts
+++ b/app/scripts/controllers/user-storage/encryption.test.ts
@@ -1,9 +1,11 @@
+import { createMockFullUserStorage } from '../metamask-notifications/mocks/mock-notification-user-storage';
 import encryption, { createSHA256Hash } from './encryption';
 
 describe('encryption tests', () => {
   const PASSWORD = '123';
   const DATA1 = 'Hello World';
   const DATA2 = JSON.stringify({ foo: 'bar' });
+  const DATA3 = JSON.stringify(createMockFullUserStorage());
 
   it('Should encrypt and decrypt data', () => {
     function actEncryptDecrypt(data: string) {
@@ -13,12 +15,12 @@ describe('encryption tests', () => {
     }
 
     expect(actEncryptDecrypt(DATA1)).toBe(DATA1);
-
     expect(actEncryptDecrypt(DATA2)).toBe(DATA2);
+    expect(actEncryptDecrypt(DATA3)).toBe(DATA3);
   });
 
   it('Should decrypt some existing data', () => {
-    const encryptedData = `{"v":"1","d":"R+sCbzS6clo5iLbSzBr889miNfHhCBmOCk2CFwTH55IkbOIL9f5Nm2t0nmWOVtFbjLpnj6cKyw==","iterations":900000}`;
+    const encryptedData = `{"v":"1","t":"script","d":"0lK5v9r3zkIoab2nNNeTr9TUAm+bllGH72SQKuIOWehIjpfXGN9kGQHVSC/bY7pJN8VDF4vmjw==","o":{"N":16384,"r":8,"p":1,"dkLen":16}}`;
     const result = encryption.decryptString(encryptedData, PASSWORD);
     expect(result).toBe(DATA1);
   });

--- a/app/scripts/controllers/user-storage/encryption.ts
+++ b/app/scripts/controllers/user-storage/encryption.ts
@@ -1,13 +1,26 @@
-import { pbkdf2 } from '@noble/hashes/pbkdf2';
+import { scrypt } from '@noble/hashes/scrypt';
 import { sha256 } from '@noble/hashes/sha256';
 import { utf8ToBytes, concatBytes, bytesToHex } from '@noble/hashes/utils';
 import { gcm } from '@noble/ciphers/aes';
 import { randomBytes } from '@noble/ciphers/webcrypto';
 
 export type EncryptedPayload = {
-  v: '1'; // version
-  d: string; // data
-  iterations: number;
+  // version
+  v: '1';
+
+  // encryption type - script
+  t: 'script';
+
+  // data
+  d: string;
+
+  // encryption options - script
+  o: {
+    N: number;
+    r: number;
+    p: number;
+    dkLen: number;
+  };
 };
 
 function byteArrayToBase64(byteArray: Uint8Array) {
@@ -28,9 +41,13 @@ class EncryptorDecryptor {
 
   #ALGORITHM_KEY_SIZE: number = 16; // 16 bytes
 
-  #PBKDF2_SALT_SIZE: number = 16; // 16 bytes
+  #SCRYPT_SALT_SIZE: number = 16; // 16 bytes
 
-  #PBKDF2_ITERATIONS: number = 900_000;
+  #SCRYPT_N: number = 2 ** 14; // CPU/memory cost parameter (must be a power of 2, > 1)
+
+  #SCRYPT_r: number = 8; // Block size parameter
+
+  #SCRYPT_p: number = 1; // Parallelization parameter
 
   encryptString(plaintext: string, password: string): string {
     try {
@@ -45,7 +62,9 @@ class EncryptorDecryptor {
     try {
       const encryptedData: EncryptedPayload = JSON.parse(encryptedDataStr);
       if (encryptedData.v === '1') {
-        return this.#decryptStringV1(encryptedData, password);
+        if (encryptedData.t === 'script') {
+          return this.#decryptStringV1(encryptedData, password);
+        }
       }
       throw new Error(`Unsupported encrypted data payload - ${encryptedData}`);
     } catch (e) {
@@ -55,11 +74,13 @@ class EncryptorDecryptor {
   }
 
   #encryptStringV1(plaintext: string, password: string): string {
-    const salt = randomBytes(this.#PBKDF2_SALT_SIZE);
+    const salt = randomBytes(this.#SCRYPT_SALT_SIZE);
 
     // Derive a key using PBKDF2.
-    const key = pbkdf2(sha256, password, salt, {
-      c: this.#PBKDF2_ITERATIONS,
+    const key = scrypt(password, salt, {
+      N: this.#SCRYPT_N,
+      r: this.#SCRYPT_r,
+      p: this.#SCRYPT_p,
       dkLen: this.#ALGORITHM_KEY_SIZE,
     });
 
@@ -75,15 +96,21 @@ class EncryptorDecryptor {
 
     const encryptedPayload: EncryptedPayload = {
       v: '1',
+      t: 'script',
       d: encryptedData,
-      iterations: this.#PBKDF2_ITERATIONS,
+      o: {
+        N: this.#SCRYPT_N,
+        r: this.#SCRYPT_r,
+        p: this.#SCRYPT_p,
+        dkLen: this.#ALGORITHM_KEY_SIZE,
+      },
     };
 
     return JSON.stringify(encryptedPayload);
   }
 
   #decryptStringV1(data: EncryptedPayload, password: string): string {
-    const { iterations, d: base64CiphertextAndNonceAndSalt } = data;
+    const { o, d: base64CiphertextAndNonceAndSalt } = data;
 
     // Decode the base64.
     const ciphertextAndNonceAndSalt = base64ToByteArray(
@@ -91,16 +118,18 @@ class EncryptorDecryptor {
     );
 
     // Create buffers of salt and ciphertextAndNonce.
-    const salt = ciphertextAndNonceAndSalt.slice(0, this.#PBKDF2_SALT_SIZE);
+    const salt = ciphertextAndNonceAndSalt.slice(0, this.#SCRYPT_SALT_SIZE);
     const ciphertextAndNonce = ciphertextAndNonceAndSalt.slice(
-      this.#PBKDF2_SALT_SIZE,
+      this.#SCRYPT_SALT_SIZE,
       ciphertextAndNonceAndSalt.length,
     );
 
     // Derive the key using PBKDF2.
-    const key = pbkdf2(sha256, password, salt, {
-      c: iterations,
-      dkLen: this.#ALGORITHM_KEY_SIZE,
+    const key = scrypt(password, salt, {
+      N: o.N,
+      r: o.r,
+      p: o.p,
+      dkLen: o.dkLen,
     });
 
     // Decrypt and return result.

--- a/app/scripts/controllers/user-storage/encryption.ts
+++ b/app/scripts/controllers/user-storage/encryption.ts
@@ -43,7 +43,7 @@ class EncryptorDecryptor {
 
   #SCRYPT_SALT_SIZE: number = 16; // 16 bytes
 
-  #SCRYPT_N: number = 2 ** 14; // CPU/memory cost parameter (must be a power of 2, > 1)
+  #SCRYPT_N: number = 2 ** 17; // CPU/memory cost parameter (must be a power of 2, > 1)
 
   #SCRYPT_r: number = 8; // Block size parameter
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This is a demo PR/Branch for changing the key hashing on user storage to Script.
We could also demo Argon2, but [@noble has not audited this yet](https://github.com/paulmillr/noble-hashes?tab=readme-ov-file#security).

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/24541?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
