### PR TITLE
cherry-pick: fix confirmation page not loading if re-design is enabled

### DIFF
--- a/ui/pages/confirmations/utils/confirm.ts
+++ b/ui/pages/confirmations/utils/confirm.ts
@@ -6,9 +6,6 @@ import { Json } from '@metamask/utils';
 export const REDESIGN_APPROVAL_TYPES = [
   ApprovalType.EthSignTypedData,
   ApprovalType.PersonalSign,
-  ...(process.env.ENABLE_CONFIRMATION_REDESIGN
-    ? [ApprovalType.Transaction]
-    : []),
 ] as const;
 
 export const REDESIGN_TRANSACTION_TYPES = [


### PR DESCRIPTION
## **Description**

fix: confirmation page not loading if re-design is enabled

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/24510

## **Manual testing steps**

1. Build the wallet yarn dist or yarn start with the feature flag on ENABLE_CONFIRMATION_REDESIGN
2. Start a tx
3. After adding a recipient and amount, proceed to the next screen
4. Confirmation page opens successfully

## **Screenshots/Recordings**

![Screenshot 2024-05-14 at 7 16 29 PM](https://github.com/MetaMask/metamask-extension/assets/2182307/5291a22c-398e-4e0c-b4e1-5c474f34bb11)

## **Pre-merge author checklist**

- [X] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
