### PR TITLE
chore: quoteXPathText utility function for e2e tests

### DIFF
--- a/test/e2e/webdriver/driver.js
+++ b/test/e2e/webdriver/driver.js
@@ -11,6 +11,7 @@ const {
 const cssToXPath = require('css-to-xpath');
 const { sprintf } = require('sprintf-js');
 const { retry } = require('../../../development/lib/retry');
+const { quoteXPathText } = require('../../helpers/quoteXPathText');
 
 const PAGES = {
   BACKGROUND: 'background',
@@ -186,17 +187,10 @@ class Driver {
           .toXPath();
         return By.xpath(xpath);
       }
-      // If the text to be selected contains single or double quotation marks
-      // it can cause the xpath selector to be invalid. `textToLocate` results
-      // in a string that won't be invalidated by the presence of quotation
-      // marks within the text the test is trying to find
-      const textToLocate = locator.text.match(/"/u)
-        ? `'${locator.text}'`
-        : `"${locator.text}"`;
+
+      const quoted = quoteXPathText(locator.text);
       // The tag prop is optional and further refines which elements match
-      return By.xpath(
-        `//${locator.tag ?? '*'}[contains(text(), ${textToLocate})]`,
-      );
+      return By.xpath(`//${locator.tag ?? '*'}[contains(text(), ${quoted})]`);
     }
     throw new Error(
       `The locator '${locator}' is not supported by the E2E test driver`,

--- a/test/helpers/quoteXPathText.ts
+++ b/test/helpers/quoteXPathText.ts
@@ -1,3 +1,10 @@
+/**
+ * Quote text so it can be used in an xpath expression,
+ * often used to locate an element by its text.
+ *
+ * @param s - The text to quote. May contain single or double quotes.
+ * @returns The quoted text.
+ */
 export function quoteXPathText(s: string = '') {
   if (!s.includes('"')) {
     return `"${s}"`;

--- a/test/helpers/quoteXPathText.ts
+++ b/test/helpers/quoteXPathText.ts
@@ -1,0 +1,11 @@
+export function quoteXPathText(s: string = '') {
+  if (!s.includes('"')) {
+    return `"${s}"`;
+  }
+  if (!s.includes("'")) {
+    return `'${s}'`;
+  }
+  // If it's really necessary to escape both, you can use the concat function.
+  // Something like: return `concat('${s.replace(/'/g, "',\"'\",'')}')`;
+  throw new Error('The text should not contain both single and double quotes');
+}


### PR DESCRIPTION
## **Description**

Utility function for e2e tests to quote text within an xpath expression. The text itself may contain quotes.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/24557?quickstart=1)

## **Related issues**

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
