### PR TITLE
perf: force update state after snap request

### DIFF
--- a/ui/components/app/snaps/snap-home-page/useSnapHome.js
+++ b/ui/components/app/snaps/snap-home-page/useSnapHome.js
@@ -1,6 +1,9 @@
 import { useEffect, useState } from 'react';
-import { handleSnapRequest, forceUpdateMetamaskState } from '../../../../store/actions';
 import { useDispatch } from 'react-redux';
+import {
+  handleSnapRequest,
+  forceUpdateMetamaskState,
+} from '../../../../store/actions';
 
 export function useSnapHome({ snapId }) {
   const dispatch = useDispatch();

--- a/ui/components/app/snaps/snap-home-page/useSnapHome.js
+++ b/ui/components/app/snaps/snap-home-page/useSnapHome.js
@@ -1,7 +1,9 @@
 import { useEffect, useState } from 'react';
-import { handleSnapRequest } from '../../../../store/actions';
+import { handleSnapRequest, forceUpdateMetamaskState } from '../../../../store/actions';
+import { useDispatch } from 'react-redux';
 
 export function useSnapHome({ snapId }) {
+  const dispatch = useDispatch();
   const [loading, setLoading] = useState(true);
   const [data, setData] = useState(undefined);
   const [error, setError] = useState(undefined);
@@ -24,6 +26,7 @@ export function useSnapHome({ snapId }) {
         });
         if (!cancelled) {
           setData(newData);
+          forceUpdateMetamaskState(dispatch);
         }
       } catch (err) {
         if (!cancelled) {

--- a/ui/hooks/snaps/useSignatureInsights.js
+++ b/ui/hooks/snaps/useSignatureInsights.js
@@ -2,7 +2,11 @@ import { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { getSignatureOriginCaveat } from '@metamask/snaps-rpc-methods';
 import { SeverityLevel } from '@metamask/snaps-sdk';
-import { deleteInterface, handleSnapRequest, forceUpdateMetamaskState } from '../../store/actions';
+import {
+  deleteInterface,
+  handleSnapRequest,
+  forceUpdateMetamaskState,
+} from '../../store/actions';
 import {
   getSignatureInsightSnapIds,
   getPermissionSubjectsDeepEqual,
@@ -99,7 +103,9 @@ export function useSignatureInsights({ txData }) {
         setData(reformattedData);
         setWarnings(insightWarnings);
         setLoading(false);
-        forceUpdateMetamaskState(dispatch);
+        if (reformattedData.length > 0) {
+          forceUpdateMetamaskState(dispatch);
+        }
       }
     }
     if (Object.keys(txData).length > 0) {

--- a/ui/hooks/snaps/useSignatureInsights.js
+++ b/ui/hooks/snaps/useSignatureInsights.js
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { getSignatureOriginCaveat } from '@metamask/snaps-rpc-methods';
 import { SeverityLevel } from '@metamask/snaps-sdk';
-import { deleteInterface, handleSnapRequest } from '../../store/actions';
+import { deleteInterface, handleSnapRequest, forceUpdateMetamaskState } from '../../store/actions';
 import {
   getSignatureInsightSnapIds,
   getPermissionSubjectsDeepEqual,
@@ -99,6 +99,7 @@ export function useSignatureInsights({ txData }) {
         setData(reformattedData);
         setWarnings(insightWarnings);
         setLoading(false);
+        forceUpdateMetamaskState(dispatch);
       }
     }
     if (Object.keys(txData).length > 0) {

--- a/ui/hooks/snaps/useTransactionInsightSnaps.js
+++ b/ui/hooks/snaps/useTransactionInsightSnaps.js
@@ -1,8 +1,8 @@
 import { useEffect, useState } from 'react';
-import { useSelector } from 'react-redux';
+import { useSelector, useDispatch } from 'react-redux';
 import { getTransactionOriginCaveat } from '@metamask/snaps-rpc-methods';
 import { SeverityLevel } from '@metamask/snaps-sdk';
-import { handleSnapRequest } from '../../store/actions';
+import { handleSnapRequest, forceUpdateMetamaskState } from '../../store/actions';
 import { getPermissionSubjectsDeepEqual } from '../../selectors';
 
 const INSIGHT_PERMISSION = 'endowment:transaction-insight';
@@ -13,6 +13,7 @@ export function useTransactionInsightSnaps({
   origin,
   insightSnaps,
 }) {
+  const dispatch = useDispatch();
   const subjects = useSelector(getPermissionSubjectsDeepEqual);
 
   const [loading, setLoading] = useState(true);
@@ -75,6 +76,7 @@ export function useTransactionInsightSnaps({
         setData(reformattedData);
         setLoading(false);
         setHasFetchedInsight(true);
+        forceUpdateMetamaskState(dispatch);
       }
     }
     if (transaction && Object.keys(transaction).length > 0) {

--- a/ui/hooks/snaps/useTransactionInsightSnaps.js
+++ b/ui/hooks/snaps/useTransactionInsightSnaps.js
@@ -2,7 +2,10 @@ import { useEffect, useState } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { getTransactionOriginCaveat } from '@metamask/snaps-rpc-methods';
 import { SeverityLevel } from '@metamask/snaps-sdk';
-import { handleSnapRequest, forceUpdateMetamaskState } from '../../store/actions';
+import {
+  handleSnapRequest,
+  forceUpdateMetamaskState,
+} from '../../store/actions';
 import { getPermissionSubjectsDeepEqual } from '../../selectors';
 
 const INSIGHT_PERMISSION = 'endowment:transaction-insight';
@@ -76,7 +79,9 @@ export function useTransactionInsightSnaps({
         setData(reformattedData);
         setLoading(false);
         setHasFetchedInsight(true);
-        forceUpdateMetamaskState(dispatch);
+        if (reformattedData.length > 0) {
+          forceUpdateMetamaskState(dispatch);
+        }
       }
     }
     if (transaction && Object.keys(transaction).length > 0) {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Adds logic to force update the MetaMask state after requests to Snaps that create interfaces. This reduces the latency of the first viewing of the home page as the state is synced instantly and not debounced.