### PR TITLE
fix: add fallback method for currency formatter in `useFiatFormatter` hook

### DIFF
--- a/ui/hooks/useFiatFormatter.test.ts
+++ b/ui/hooks/useFiatFormatter.test.ts
@@ -44,4 +44,16 @@ describe('useFiatFormatter', () => {
     expect(getIntlLocale).toHaveBeenCalledTimes(1);
     expect(getCurrentCurrency).toHaveBeenCalledTimes(1);
   });
+
+  it('should gracefully handle unknown currencies by returning amount followed by currency code', () => {
+    mockGetCurrentCurrency.mockReturnValue('storj');
+
+    const { result } = renderHook(() => useFiatFormatter());
+    const formatFiat = result.current;
+
+    // Testing the fallback formatting for an unknown currency
+    expect(formatFiat(1000)).toBe('1000 storj');
+    expect(formatFiat(500.5)).toBe('500.5 storj');
+    expect(formatFiat(0)).toBe('0 storj');
+  });
 });

--- a/ui/hooks/useFiatFormatter.ts
+++ b/ui/hooks/useFiatFormatter.ts
@@ -22,9 +22,14 @@ export const useFiatFormatter = (): FiatFormatter => {
   const fiatCurrency = useSelector(getCurrentCurrency);
 
   return (fiatAmount: number) => {
-    return Intl.NumberFormat(locale, {
-      style: 'currency',
-      currency: fiatCurrency,
-    }).format(fiatAmount);
+    try {
+      return new Intl.NumberFormat(locale, {
+        style: 'currency',
+        currency: fiatCurrency,
+      }).format(fiatAmount);
+    } catch (error) {
+      // Fallback for unknown or unsupported currencies
+      return `${fiatAmount} ${fiatCurrency}`;
+    }
   };
 };


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR goal is to add a fallback for unknown currency formats to render it `${amount} ${currency}` format.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/24563?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/24558

## **Manual testing steps**

1. Go to Settings > General
2. Change your currency to Storj
3. Start a send transaction on Ethereum with any value
4. MM doesn't crash and shows `amount storj`

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
