### PR TITLE
refactor: disable push notifications for mv2.

### DIFF
--- a/app/scripts/controllers/push-platform-notifications/push-platform-notifications.test.ts
+++ b/app/scripts/controllers/push-platform-notifications/push-platform-notifications.test.ts
@@ -13,6 +13,8 @@ const MOCK_FCM_TOKEN = 'mockFcmToken';
 const MOCK_TRIGGERS = ['uuid1', 'uuid2'];
 
 describe('PushPlatformNotificationsController', () => {
+  process.env.ENABLE_MV3 = 'true';
+
   describe('enablePushNotifications', () => {
     afterEach(() => {
       jest.clearAllMocks();

--- a/app/scripts/controllers/push-platform-notifications/push-platform-notifications.test.ts
+++ b/app/scripts/controllers/push-platform-notifications/push-platform-notifications.test.ts
@@ -13,89 +13,99 @@ const MOCK_FCM_TOKEN = 'mockFcmToken';
 const MOCK_TRIGGERS = ['uuid1', 'uuid2'];
 
 describe('PushPlatformNotificationsController', () => {
-  process.env.ENABLE_MV3 = 'true';
-
-  describe('enablePushNotifications', () => {
-    afterEach(() => {
-      jest.clearAllMocks();
+  if (!process.env.ENABLE_MV3) {
+    it('No MV2 tests, this functionality is not enabled', () => {
+      expect(true).toBe(true);
     });
+  }
 
-    it('should update the state with the fcmToken', async () => {
-      await withController(async ({ controller, messenger }) => {
-        mockAuthBearerTokenCall(messenger);
-        jest
-          .spyOn(services, 'activatePushNotifications')
-          .mockResolvedValue(MOCK_FCM_TOKEN);
+  if (process.env.ENABLE_MV3) {
+    describe('enablePushNotifications', () => {
+      afterEach(() => {
+        jest.clearAllMocks();
+      });
 
-        const unsubscribeMock = jest.fn();
-        jest
-          .spyOn(services, 'listenToPushNotifications')
-          .mockResolvedValue(unsubscribeMock);
+      it('should update the state with the fcmToken', async () => {
+        await withController(async ({ controller, messenger }) => {
+          mockAuthBearerTokenCall(messenger);
+          jest
+            .spyOn(services, 'activatePushNotifications')
+            .mockResolvedValue(MOCK_FCM_TOKEN);
 
-        await controller.enablePushNotifications(MOCK_TRIGGERS);
-        expect(controller.state.fcmToken).toBe(MOCK_FCM_TOKEN);
+          const unsubscribeMock = jest.fn();
+          jest
+            .spyOn(services, 'listenToPushNotifications')
+            .mockResolvedValue(unsubscribeMock);
 
-        expect(services.listenToPushNotifications).toHaveBeenCalled();
+          await controller.enablePushNotifications(MOCK_TRIGGERS);
+          expect(controller.state.fcmToken).toBe(MOCK_FCM_TOKEN);
+
+          expect(services.listenToPushNotifications).toHaveBeenCalled();
+        });
+      });
+
+      it('should fail if a jwt token is not provided', async () => {
+        await withController(async ({ messenger, controller }) => {
+          mockAuthBearerTokenCall(messenger).mockResolvedValue(
+            null as unknown as string,
+          );
+          await expect(
+            controller.enablePushNotifications([]),
+          ).rejects.toThrow();
+        });
       });
     });
 
-    it('should fail if a jwt token is not provided', async () => {
-      await withController(async ({ messenger, controller }) => {
-        mockAuthBearerTokenCall(messenger).mockResolvedValue(
-          null as unknown as string,
-        );
-        await expect(controller.enablePushNotifications([])).rejects.toThrow();
+    describe('disablePushNotifications', () => {
+      afterEach(() => {
+        jest.clearAllMocks();
+      });
+
+      it('should update the state removing the fcmToken', async () => {
+        await withController(async ({ messenger, controller }) => {
+          mockAuthBearerTokenCall(messenger);
+          await controller.disablePushNotifications(MOCK_TRIGGERS);
+          expect(controller.state.fcmToken).toBe('');
+        });
+      });
+
+      it('should fail if a jwt token is not provided', async () => {
+        await withController(async ({ messenger, controller }) => {
+          mockAuthBearerTokenCall(messenger).mockResolvedValue(
+            null as unknown as string,
+          );
+          await expect(
+            controller.disablePushNotifications([]),
+          ).rejects.toThrow();
+        });
       });
     });
-  });
 
-  describe('disablePushNotifications', () => {
-    afterEach(() => {
-      jest.clearAllMocks();
-    });
+    describe('updateTriggerPushNotifications', () => {
+      afterEach(() => {
+        jest.clearAllMocks();
+      });
 
-    it('should update the state removing the fcmToken', async () => {
-      await withController(async ({ messenger, controller }) => {
-        mockAuthBearerTokenCall(messenger);
-        await controller.disablePushNotifications(MOCK_TRIGGERS);
-        expect(controller.state.fcmToken).toBe('');
+      it('should call updateTriggerPushNotifications with the correct parameters', async () => {
+        await withController(async ({ messenger, controller }) => {
+          mockAuthBearerTokenCall(messenger);
+          const spy = jest
+            .spyOn(services, 'updateTriggerPushNotifications')
+            .mockResolvedValue({
+              isTriggersLinkedToPushNotifications: true,
+            });
+
+          await controller.updateTriggerPushNotifications(MOCK_TRIGGERS);
+
+          expect(spy).toHaveBeenCalledWith(
+            controller.state.fcmToken,
+            MOCK_JWT,
+            MOCK_TRIGGERS,
+          );
+        });
       });
     });
-
-    it('should fail if a jwt token is not provided', async () => {
-      await withController(async ({ messenger, controller }) => {
-        mockAuthBearerTokenCall(messenger).mockResolvedValue(
-          null as unknown as string,
-        );
-        await expect(controller.disablePushNotifications([])).rejects.toThrow();
-      });
-    });
-  });
-
-  describe('updateTriggerPushNotifications', () => {
-    afterEach(() => {
-      jest.clearAllMocks();
-    });
-
-    it('should call updateTriggerPushNotifications with the correct parameters', async () => {
-      await withController(async ({ messenger, controller }) => {
-        mockAuthBearerTokenCall(messenger);
-        const spy = jest
-          .spyOn(services, 'updateTriggerPushNotifications')
-          .mockResolvedValue({
-            isTriggersLinkedToPushNotifications: true,
-          });
-
-        await controller.updateTriggerPushNotifications(MOCK_TRIGGERS);
-
-        expect(spy).toHaveBeenCalledWith(
-          controller.state.fcmToken,
-          MOCK_JWT,
-          MOCK_TRIGGERS,
-        );
-      });
-    });
-  });
+  }
 });
 
 // Test helper functions

--- a/app/scripts/controllers/push-platform-notifications/push-platform-notifications.ts
+++ b/app/scripts/controllers/push-platform-notifications/push-platform-notifications.ts
@@ -143,6 +143,12 @@ export class PushPlatformNotificationsController extends BaseController<
    * @param UUIDs - An array of UUIDs to enable push notifications for.
    */
   public async enablePushNotifications(UUIDs: string[]) {
+    // TEMP: disabling push notifications if browser does not support MV3.
+    // Will need work to support firefox on MV2
+    if (!process.env.ENABLE_MV3) {
+      return;
+    }
+
     const bearerToken = await this.#getAndAssertBearerToken();
 
     try {
@@ -181,6 +187,12 @@ export class PushPlatformNotificationsController extends BaseController<
    * @param UUIDs - An array of UUIDs for which push notifications should be disabled.
    */
   public async disablePushNotifications(UUIDs: string[]) {
+    // TEMP: disabling push notifications if browser does not support MV3.
+    // Will need work to support firefox on MV2
+    if (!process.env.ENABLE_MV3) {
+      return;
+    }
+
     const bearerToken = await this.#getAndAssertBearerToken();
     let isPushNotificationsDisabled: boolean;
 
@@ -221,6 +233,12 @@ export class PushPlatformNotificationsController extends BaseController<
    * @param UUIDs - An array of UUIDs that should trigger push notifications.
    */
   public async updateTriggerPushNotifications(UUIDs: string[]) {
+    // TEMP: disabling push notifications if browser does not support MV3.
+    // Will need work to support firefox on MV2
+    if (!process.env.ENABLE_MV3) {
+      return;
+    }
+
     const bearerToken = await this.#getAndAssertBearerToken();
 
     try {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Due to the limitations of setting up push notifications & service workers, MV2 will need different logic compared to MV3.
The notifications team will soon setup MV2 push notifications (i.e. push notifications for firefox).

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/24662?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
