### PR TITLE
fix: keep notifications when disabling on a device

### DIFF
--- a/app/scripts/controllers/metamask-notifications/metamask-notifications.test.ts
+++ b/app/scripts/controllers/metamask-notifications/metamask-notifications.test.ts
@@ -182,54 +182,6 @@ describe('metamask-notifications - checkAccountsPresence()', () => {
   });
 });
 
-describe('metamask-notifications - setMetamaskNotificationsEnabled()', () => {
-  test('flips enabled state', async () => {
-    const { messenger, mockIsSignedIn } = mockNotificationMessenger();
-    mockIsSignedIn.mockReturnValue(true);
-
-    const controller = new MetamaskNotificationsController({
-      messenger,
-      state: { ...defaultState, isMetamaskNotificationsEnabled: false },
-    });
-
-    await controller.setMetamaskNotificationsEnabled(true);
-
-    expect(controller.state.isMetamaskNotificationsEnabled).toBe(true);
-  });
-});
-
-describe('metamask-notifications - setMetamaskNotificationsFeatureSeen()', () => {
-  test('flips state when the method is called', async () => {
-    const { messenger, mockIsSignedIn } = mockNotificationMessenger();
-    mockIsSignedIn.mockReturnValue(true);
-
-    const controller = new MetamaskNotificationsController({
-      messenger,
-      state: { ...defaultState, isMetamaskNotificationsFeatureSeen: false },
-    });
-
-    await controller.setMetamaskNotificationsFeatureSeen();
-
-    expect(controller.state.isMetamaskNotificationsFeatureSeen).toBe(true);
-  });
-
-  test('does not update if auth is not enabled', async () => {
-    const { messenger, mockIsSignedIn } = mockNotificationMessenger();
-    mockIsSignedIn.mockReturnValue(false); // state is off.
-
-    const controller = new MetamaskNotificationsController({
-      messenger,
-      state: { ...defaultState, isMetamaskNotificationsFeatureSeen: false },
-    });
-
-    await expect(() =>
-      controller.setMetamaskNotificationsFeatureSeen(),
-    ).rejects.toThrow();
-
-    expect(controller.state.isMetamaskNotificationsFeatureSeen).toBe(false); // this flag was never flipped
-  });
-});
-
 describe('metamask-notifications - setFeatureAnnouncementsEnabled()', () => {
   test('flips state when the method is called', async () => {
     const { messenger, mockIsSignedIn } = mockNotificationMessenger();

--- a/app/scripts/controllers/metamask-notifications/metamask-notifications.ts
+++ b/app/scripts/controllers/metamask-notifications/metamask-notifications.ts
@@ -372,7 +372,7 @@ export class MetamaskNotificationsController extends BaseController<
     state,
   }: {
     messenger: MetamaskNotificationsControllerMessenger;
-    state?: MetamaskNotificationsControllerState;
+    state?: Partial<MetamaskNotificationsControllerState>;
   }) {
     super({
       messenger,
@@ -382,6 +382,7 @@ export class MetamaskNotificationsController extends BaseController<
     });
 
     this.#registerMessageHandlers();
+    this.#clearLoadingStates();
     this.#accounts.initialize();
     this.#accounts.subscribe();
     this.#pushNotifications.subscribe();
@@ -402,6 +403,15 @@ export class MetamaskNotificationsController extends BaseController<
       `${controllerName}:selectIsMetamaskNotificationsEnabled`,
       this.selectIsMetamaskNotificationsEnabled.bind(this),
     );
+  }
+
+  #clearLoadingStates(): void {
+    this.update((state) => {
+      state.isUpdatingMetamaskNotifications = false;
+      state.isCheckingAccountsPresence = false;
+      state.isFetchingMetamaskNotifications = false;
+      state.isUpdatingMetamaskNotificationsAccount = [];
+    });
   }
 
   #assertAuthEnabled() {
@@ -762,6 +772,12 @@ export class MetamaskNotificationsController extends BaseController<
     try {
       this.#setIsUpdatingMetamaskNotifications(true);
 
+      // Disable Push Notifications
+      const userStorage = await this.#getUserStorage();
+      this.#assertUserStorage(userStorage);
+      const UUIDs = MetamaskNotificationsUtils.getAllUUIDs(userStorage);
+      await this.#pushNotifications.disablePushNotifications(UUIDs);
+
       // Clear Notification States (toggles and list)
       this.update((state) => {
         state.isMetamaskNotificationsEnabled = false;
@@ -831,13 +847,12 @@ export class MetamaskNotificationsController extends BaseController<
 
       // Update User Storage
       await this.#storage.setNotificationStorage(JSON.stringify(userStorage));
-      this.#clearUpdatingAccountsState(accounts);
-
       return userStorage;
     } catch (err) {
-      this.#clearUpdatingAccountsState(accounts);
       log.error('Failed to delete OnChain triggers', err);
       throw new Error('Failed to delete OnChain triggers');
+    } finally {
+      this.#clearUpdatingAccountsState(accounts);
     }
   }
 
@@ -874,7 +889,7 @@ export class MetamaskNotificationsController extends BaseController<
         MetamaskNotificationsUtils.upsertAddressTriggers(a, userStorage),
       );
 
-      const hasNewTriggers =
+      const newTriggers =
         MetamaskNotificationsUtils.traverseUserStorageTriggers(userStorage, {
           mapTrigger: (t) => {
             if (t.enabled === false) {
@@ -885,7 +900,7 @@ export class MetamaskNotificationsController extends BaseController<
         });
 
       // Create any missing triggers.
-      if (hasNewTriggers.length > 0) {
+      if (newTriggers.length > 0) {
         // Write te updated userStorage (where triggers are disabled)
         await this.#storage.setNotificationStorage(JSON.stringify(userStorage));
 
@@ -919,13 +934,12 @@ export class MetamaskNotificationsController extends BaseController<
 
       // Update the userStorage (where triggers are enabled)
       await this.#storage.setNotificationStorage(JSON.stringify(userStorage));
-      this.#clearUpdatingAccountsState(accounts);
-
       return userStorage;
     } catch (err) {
-      this.#clearUpdatingAccountsState(accounts);
       log.error('Failed to update OnChain triggers', err);
       throw new Error('Failed to update OnChain triggers');
+    } finally {
+      this.#clearUpdatingAccountsState(accounts);
     }
   }
 

--- a/app/scripts/controllers/metamask-notifications/mocks/mock-notification-user-storage.ts
+++ b/app/scripts/controllers/metamask-notifications/mocks/mock-notification-user-storage.ts
@@ -63,10 +63,10 @@ export function createMockUserStorageWithTriggers(
 }
 
 export function createMockFullUserStorage(
-  props: { triggersEnabled?: boolean } = {},
+  props: { triggersEnabled?: boolean; address?: string } = {},
 ): UserStorage {
   return initializeUserStorage(
-    [{ address: MOCK_USER_STORAGE_ACCOUNT }],
+    [{ address: props.address ?? MOCK_USER_STORAGE_ACCOUNT }],
     props.triggersEnabled ?? true,
   );
 }

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -3686,14 +3686,6 @@ export default class MetamaskController extends EventEmitter {
         metamaskNotificationsController.setFeatureAnnouncementsEnabled.bind(
           metamaskNotificationsController,
         ),
-      setMetamaskNotificationsEnabled:
-        metamaskNotificationsController.setMetamaskNotificationsEnabled.bind(
-          metamaskNotificationsController,
-        ),
-      setMetamaskNotificationsFeatureSeen:
-        metamaskNotificationsController.setMetamaskNotificationsFeatureSeen.bind(
-          metamaskNotificationsController,
-        ),
       enablePushNotifications:
         pushPlatformNotificationsController.enablePushNotifications.bind(
           pushPlatformNotificationsController,

--- a/ui/hooks/metamask-notifications/useNotifications.test.tsx
+++ b/ui/hooks/metamask-notifications/useNotifications.test.tsx
@@ -18,13 +18,11 @@ jest.mock('../../store/actions', () => ({
   createOnChainTriggers: jest.fn(),
   deleteOnChainTriggersByAccount: jest.fn(),
   fetchAndUpdateMetamaskNotifications: jest.fn(),
-  setMetamaskNotificationsEnabled: jest.fn(),
   setSnapNotificationsEnabled: jest.fn(),
   setFeatureAnnouncementsEnabled: jest.fn(),
   markMetamaskNotificationsAsRead: jest.fn(),
   showLoadingIndication: jest.fn(),
   hideLoadingIndication: jest.fn(),
-  setMetamaskNotificationsFeatureSeen: jest.fn(),
   disableMetamaskNotifications: jest.fn(),
 }));
 

--- a/ui/store/actions.test.js
+++ b/ui/store/actions.test.js
@@ -2551,50 +2551,6 @@ describe('Actions', () => {
     });
   });
 
-  describe('#setMetamaskNotificationsEnabled', () => {
-    afterEach(() => {
-      sinon.restore();
-    });
-
-    it('calls setMetamaskNotificationsEnabled in the background with correct parameters', async () => {
-      const store = mockStore();
-      const state = true;
-
-      const setMetamaskNotificationsEnabledStub = sinon
-        .stub()
-        .callsFake((_, cb) => cb());
-
-      background.getApi.returns({
-        setMetamaskNotificationsEnabled: setMetamaskNotificationsEnabledStub,
-      });
-      setBackgroundConnection(background.getApi());
-
-      await store.dispatch(actions.setMetamaskNotificationsEnabled(state));
-      expect(setMetamaskNotificationsEnabledStub.calledOnceWith(state)).toBe(
-        true,
-      );
-    });
-
-    it('handles errors when setMetamaskNotificationsEnabled fails', async () => {
-      const store = mockStore();
-      const state = false;
-      const error = new Error('Failed to set notifications enabled state');
-
-      const setMetamaskNotificationsEnabledStub = sinon
-        .stub()
-        .callsFake((_, cb) => cb(error));
-
-      background.getApi.returns({
-        setMetamaskNotificationsEnabled: setMetamaskNotificationsEnabledStub,
-      });
-      setBackgroundConnection(background.getApi());
-
-      await expect(
-        store.dispatch(actions.setMetamaskNotificationsEnabled(state)),
-      ).rejects.toThrow(error);
-    });
-  });
-
   describe('#setSnapNotificationsEnabled', () => {
     afterEach(() => {
       sinon.restore();
@@ -2775,47 +2731,6 @@ describe('Actions', () => {
       ];
 
       expect(store.getActions()).toStrictEqual(expectedActions);
-    });
-  });
-
-  describe('setMetamaskNotificationsFeatureSeen', () => {
-    afterEach(() => {
-      sinon.restore();
-    });
-
-    it('should call setMetamaskNotificationsFeatureSeen in the background', async () => {
-      const store = mockStore();
-      const setMetamaskNotificationsFeatureSeenStub = sinon
-        .stub()
-        .callsFake((cb) => cb());
-
-      background.getApi.returns({
-        setMetamaskNotificationsFeatureSeen:
-          setMetamaskNotificationsFeatureSeenStub,
-      });
-      setBackgroundConnection(background.getApi());
-
-      await store.dispatch(actions.setMetamaskNotificationsFeatureSeen());
-      expect(setMetamaskNotificationsFeatureSeenStub.calledOnce).toBe(true);
-    });
-
-    it('should handle errors when setMetamaskNotificationsFeatureSeen fails', async () => {
-      const store = mockStore();
-      const error = new Error('Failed to mark notifications feature as seen');
-
-      const setMetamaskNotificationsFeatureSeenStub = sinon
-        .stub()
-        .callsFake((cb) => cb(error));
-
-      background.getApi.returns({
-        setMetamaskNotificationsFeatureSeen:
-          setMetamaskNotificationsFeatureSeenStub,
-      });
-      setBackgroundConnection(background.getApi());
-
-      await expect(
-        store.dispatch(actions.setMetamaskNotificationsFeatureSeen()),
-      ).rejects.toThrow(error);
     });
   });
 });

--- a/ui/store/actions.ts
+++ b/ui/store/actions.ts
@@ -5399,31 +5399,6 @@ export function markMetamaskNotificationsAsRead(
 }
 
 /**
- * Enables or disables MetaMask notifications.
- *
- * This function sends a request to the background script to toggle the enabled state of MetaMask notifications.
- * Upon success, it dispatches an action with type `SET_METAMASK_NOTIFICATIONS_ENABLED` to update the Redux state.
- * If the operation encounters an error, it logs the error message and rethrows the error to ensure it is handled appropriately.
- *
- * @param state - A boolean indicating whether to enable (true) or disable (false) MetaMask notifications.
- * @returns A thunk action that, when dispatched, attempts to set the enabled state of MetaMask notifications.
- */
-export function setMetamaskNotificationsEnabled(
-  state: boolean,
-): ThunkAction<void, MetaMaskReduxState, unknown, AnyAction> {
-  return async () => {
-    try {
-      await submitRequestToBackground('setMetamaskNotificationsEnabled', [
-        state,
-      ]);
-    } catch (error) {
-      logErrorWithMessage(error);
-      throw error;
-    }
-  };
-}
-
-/**
  * Enables or disables Snap notifications.
  *
  * This function sends a request to the background script to toggle the enabled state of Snap notifications.
@@ -5537,30 +5512,6 @@ export function showConfirmTurnOnMetamaskNotifications(): ThunkAction<
         name: 'TURN_ON_METAMASK_NOTIFICATIONS',
       }),
     );
-  };
-}
-
-/**
- * Marks the MetaMask notifications feature as seen by the user.
- *
- * This function sends a request to the background script to mark the MetaMask notifications feature as seen.
- * This is typically used to track if a user has been introduced to the notifications feature to avoid redundant prompts.
- * If the operation fails, it logs the error message.
- *
- * @returns A thunk action that, when dispatched, marks the MetaMask notifications feature as seen.
- */
-export function setMetamaskNotificationsFeatureSeen(): ThunkAction<
-  void,
-  unknown,
-  AnyAction
-> {
-  return async () => {
-    try {
-      await submitRequestToBackground('setMetamaskNotificationsFeatureSeen');
-    } catch (error) {
-      log.error(error);
-      throw error;
-    }
   };
 }
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Since a user can have notifications on multiple platforms (e.g. portfolio, mobile, extension). When we disable notifications we do not want to actually delete notifications - as these notifications can be used by other platforms.

However we should disable push notifications.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/24663?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
