### PR TITLE
test: Fix popup flakiness in e2e tests

### DIFF
--- a/test/e2e/accounts/common.ts
+++ b/test/e2e/accounts/common.ts
@@ -203,7 +203,7 @@ export async function disconnectFromTestDapp(driver: Driver) {
   await driver.switchToWindowWithTitle(WINDOW_TITLES.ExtensionInFullScreenView);
   await driver.clickElement('[data-testid="account-options-menu-button"]');
   await driver.clickElement({ text: 'All Permissions', tag: 'div' });
-  await driver.clickElement({ text: 'Got it', tag: 'button' });
+  await driver.clickElementAndWaitToDisappear('{ text: "Got it", tag: "button" }');
   await driver.clickElement({
     text: '127.0.0.1:8080',
     tag: 'p',

--- a/test/e2e/accounts/common.ts
+++ b/test/e2e/accounts/common.ts
@@ -203,7 +203,7 @@ export async function disconnectFromTestDapp(driver: Driver) {
   await driver.switchToWindowWithTitle(WINDOW_TITLES.ExtensionInFullScreenView);
   await driver.clickElement('[data-testid="account-options-menu-button"]');
   await driver.clickElement({ text: 'All Permissions', tag: 'div' });
-  await driver.clickElementAndWaitToDisappear('{ text: "Got it", tag: "button" }');
+  await driver.clickElementAndWaitToDisappear({ text: 'Got it', tag: 'button' });
   await driver.clickElement({
     text: '127.0.0.1:8080',
     tag: 'p',

--- a/test/e2e/tests/dapp-interactions/dapp-interactions.spec.js
+++ b/test/e2e/tests/dapp-interactions/dapp-interactions.spec.js
@@ -84,7 +84,10 @@ describe('Dapp interactions', function () {
         );
 
         await driver.clickElement({ text: 'All Permissions', tag: 'div' });
-        await driver.clickElement({ text: 'Got it', tag: 'button' });
+        await driver.clickElementAndWaitToDisappear({
+          text: 'Got it',
+          tag: 'button',
+        });
 
         const connectedDapp1 = await driver.isElementPresent({
           text: '127.0.0.1:8080',

--- a/test/e2e/tests/dapp-interactions/permissions.spec.js
+++ b/test/e2e/tests/dapp-interactions/permissions.spec.js
@@ -54,7 +54,10 @@ describe('Permissions', function () {
           text: 'All Permissions',
           tag: 'div',
         });
-        await driver.clickElement({ text: 'Got it', tag: 'button' });
+        await driver.clickElementAndWaitToDisappear({
+          text: 'Got it',
+          tag: 'button',
+        });
         await driver.waitForSelector({
           text: '127.0.0.1:8080',
           tag: 'p',

--- a/test/e2e/tests/multichain/connection-page.spec.js
+++ b/test/e2e/tests/multichain/connection-page.spec.js
@@ -140,7 +140,10 @@ describe('Connections page', function () {
           '[data-testid ="account-options-menu-button"]',
         );
         await driver.clickElement({ text: 'All Permissions', tag: 'div' });
-        await driver.clickElement({ text: 'Got it', tag: 'button' });
+        await driver.clickElementAndWaitToDisappear({
+          text: 'Got it',
+          tag: 'button',
+        });
         await driver.clickElement({
           text: '127.0.0.1:8080',
           tag: 'p',

--- a/test/e2e/tests/petnames/petnames-signatures.spec.js
+++ b/test/e2e/tests/petnames/petnames-signatures.spec.js
@@ -71,7 +71,10 @@ async function showThirdPartyDetails(driver) {
 }
 
 async function closeThirdPartyDetails(driver) {
-  await driver.clickElement({ text: 'Got it', tag: 'button' });
+  await driver.clickElementAndWaitToDisappear({
+    text: 'Got it',
+    tag: 'button',
+  });
 }
 
 async function expectProposedNames(driver, value, options) {

--- a/test/e2e/tests/signature/signature-request.spec.js
+++ b/test/e2e/tests/signature/signature-request.spec.js
@@ -341,7 +341,10 @@ async function verifyAndAssertSignTypedData(
     verifyContractDetailsButton.click();
     await driver.findElement({ text: 'Third-party details', tag: 'h5' });
     await driver.findElement('[data-testid="recipient"]');
-    await driver.clickElement({ text: 'Got it', tag: 'button' });
+    await driver.clickElementAndWaitToDisappear({
+      text: 'Got it',
+      tag: 'button',
+    });
   }
   const messageNumber = type === signatureRequestType.signTypedDataV3 ? 4 : 0;
   assert.equal(await messages[messageNumber].getText(), expectedMessage);

--- a/test/e2e/tests/tokens/custom-token-add-approve.spec.js
+++ b/test/e2e/tests/tokens/custom-token-add-approve.spec.js
@@ -123,7 +123,7 @@ describe('Create token, approve token and approve token without gas', function (
 
         assert.equal(await modalTitle.getText(), 'Third-party details');
 
-        await driver.clickElement({
+        await driver.clickElementAndWaitToDisappear({
           text: 'Got it',
           tag: 'button',
         });

--- a/test/e2e/webdriver/driver.js
+++ b/test/e2e/webdriver/driver.js
@@ -378,8 +378,8 @@ class Driver {
    * For scenarios where the clicked element, such as a notification or popup, needs to disappear afterward.
    * The wait ensures that subsequent interactions are not obscured by the initial notification or popup element.
    *
-   * @param {string} rawLocator - The locator used to identify the element to be clicked
-   * @param {number} timeout - The maximum time in ms to wait for the element to disappear after clicking.
+   * @param rawLocator - The locator used to identify the element to be clicked
+   * @param timeout - The maximum time in ms to wait for the element to disappear after clicking.
    */
   async clickElementAndWaitToDisappear(rawLocator, timeout = 2000) {
     const element = await this.findClickableElement(rawLocator);


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->
This PR is the following step of #24580. When user clicks "Got it" to close the popup, this PR will wait for the popup to be closed before continue to next step, which will help avoid race conditions.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/24671?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

Run multiple updated tests locally to see they are less flaky.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
