### PR TITLE
fix: Lazy load token, asset, and avatar images

### DIFF
--- a/ui/components/app/incoming-trasaction-toggle/__snapshots__/incoming-transaction-toggle.test.js.snap
+++ b/ui/components/app/incoming-trasaction-toggle/__snapshots__/incoming-transaction-toggle.test.js.snap
@@ -28,6 +28,7 @@ exports[`IncomingTransactionToggle should render existing incoming transaction p
           <img
             alt="Ethereum Mainnet logo"
             class="mm-avatar-network__network-image"
+            loading="lazy"
             src="./images/eth_logo.svg"
           />
         </div>
@@ -115,6 +116,7 @@ exports[`IncomingTransactionToggle should render existing incoming transaction p
           <img
             alt="Linea Mainnet logo"
             class="mm-avatar-network__network-image"
+            loading="lazy"
             src="./images/linea-logo-mainnet.svg"
           />
         </div>
@@ -451,6 +453,7 @@ exports[`IncomingTransactionToggle should render existing incoming transaction p
           <img
             alt="Linea Goerli logo"
             class="mm-avatar-network__network-image"
+            loading="lazy"
             src="./images/linea-logo-testnet.png"
           />
         </div>
@@ -538,6 +541,7 @@ exports[`IncomingTransactionToggle should render existing incoming transaction p
           <img
             alt="Linea Sepolia logo"
             class="mm-avatar-network__network-image"
+            loading="lazy"
             src="./images/linea-logo-testnet.png"
           />
         </div>

--- a/ui/components/app/nfts-items/nfts-items.js
+++ b/ui/components/app/nfts-items/nfts-items.js
@@ -126,6 +126,7 @@ export default function NftsItems({
           alt={collectionName}
           src={getAssetImageURL(collectionImage, ipfsGateway)}
           className="nfts-items__collection-image"
+          loading="lazy"
         />
       );
     }

--- a/ui/components/app/nfts-tab/nfts-tab.js
+++ b/ui/components/app/nfts-tab/nfts-tab.js
@@ -148,7 +148,7 @@ export default function NftsTab() {
               justifyContent={JustifyContent.center}
             >
               <Box justifyContent={JustifyContent.center}>
-                <img src="./images/no-nfts.svg" />
+                <img src="./images/no-nfts.svg" loading="lazy" />
               </Box>
               <Box
                 marginTop={4}

--- a/ui/components/app/token-cell/__snapshots__/token-cell.test.js.snap
+++ b/ui/components/app/token-cell/__snapshots__/token-cell.test.js.snap
@@ -20,11 +20,13 @@ exports[`Token Cell should match snapshot 1`] = `
           <img
             aria-hidden="true"
             class="mm-avatar-token__token-image--blurred"
+            loading="lazy"
             src="./images/test_image.svg"
           />
           <img
             alt="TEST logo"
             class="mm-avatar-token__token-image--size-reduced"
+            loading="lazy"
             src="./images/test_image.svg"
           />
         </div>

--- a/ui/components/component-library/avatar-favicon/avatar-favicon.tsx
+++ b/ui/components/component-library/avatar-favicon/avatar-favicon.tsx
@@ -46,6 +46,7 @@ export const AvatarFavicon: AvatarFaviconComponent = React.forwardRef(
             className="mm-avatar-favicon__image"
             src={src}
             alt={t('logo', [name])}
+            loading="lazy"
           />
         ) : (
           <Icon

--- a/ui/components/component-library/avatar-network/__snapshots__/avatar-network.test.tsx.snap
+++ b/ui/components/component-library/avatar-network/__snapshots__/avatar-network.test.tsx.snap
@@ -9,6 +9,7 @@ exports[`AvatarNetwork should render correctly 1`] = `
     <img
       alt="ethereum logo"
       class="mm-avatar-network__network-image"
+      loading="lazy"
       src="./images/eth_logo.svg"
     />
   </div>

--- a/ui/components/component-library/avatar-network/avatar-network.tsx
+++ b/ui/components/component-library/avatar-network/avatar-network.tsx
@@ -70,6 +70,7 @@ export const AvatarNetwork: AvatarNetworkComponent = React.forwardRef(
                   showHalo ? 'mm-avatar-network__network-image--blurred' : ''
                 }
                 aria-hidden="true"
+                loading="lazy"
               />
             )}
             <img
@@ -81,6 +82,7 @@ export const AvatarNetwork: AvatarNetworkComponent = React.forwardRef(
               onError={handleOnError}
               src={src}
               alt={`${name} logo` || 'network logo'}
+              loading="lazy"
             />
           </>
         )}

--- a/ui/components/component-library/avatar-token/__snapshots__/avatar-token.test.tsx.snap
+++ b/ui/components/component-library/avatar-token/__snapshots__/avatar-token.test.tsx.snap
@@ -9,6 +9,7 @@ exports[`AvatarToken should render correctly 1`] = `
     <img
       alt="ast logo"
       class="mm-avatar-token__token-image"
+      loading="lazy"
       src="./AST.png"
     />
   </div>

--- a/ui/components/component-library/avatar-token/avatar-token.tsx
+++ b/ui/components/component-library/avatar-token/avatar-token.tsx
@@ -69,6 +69,7 @@ export const AvatarToken: AvatarTokenComponent = React.forwardRef(
                   showHalo ? 'mm-avatar-token__token-image--blurred' : ''
                 }
                 aria-hidden="true"
+                loading="lazy"
               />
             )}
             <img
@@ -80,6 +81,7 @@ export const AvatarToken: AvatarTokenComponent = React.forwardRef(
               onError={handleOnError}
               src={src}
               alt={`${name} logo` || 'token logo'}
+              loading="lazy"
             />
           </>
         )}

--- a/ui/components/multichain/account-picker/__snapshots__/account-picker.test.js.snap
+++ b/ui/components/multichain/account-picker/__snapshots__/account-picker.test.js.snap
@@ -15,6 +15,7 @@ exports[`AccountPicker renders properly 1`] = `
         <img
           alt=""
           height="16"
+          loading="lazy"
           src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA4IDgiIHNoYXBlLXJlbmRlcmluZz0ib3B0aW1pemVTcGVlZCIgd2lkdGg9IjY0IiBoZWlnaHQ9IjY0Ij48cGF0aCBmaWxsPSJoc2woMTM5IDg5JSA1OSUpIiBkPSJNMCwwSDhWOEgweiIvPjxwYXRoIGZpbGw9ImhzbCgzMjEgOTIlIDU2JSkiIGQ9Ik0xLDJoMXYxaC0xek02LDJoMXYxaC0xek0yLDJoMXYxaC0xek01LDJoMXYxaC0xek0zLDJoMXYxaC0xek00LDJoMXYxaC0xek0zLDNoMXYxaC0xek00LDNoMXYxaC0xek0wLDRoMXYxaC0xek03LDRoMXYxaC0xek0yLDRoMXYxaC0xek01LDRoMXYxaC0xek0wLDZoMXYxaC0xek03LDZoMXYxaC0xek0xLDZoMXYxaC0xek02LDZoMXYxaC0xek0zLDZoMXYxaC0xek00LDZoMXYxaC0xek0wLDdoMXYxaC0xek03LDdoMXYxaC0xek0yLDdoMXYxaC0xek01LDdoMXYxaC0xek0zLDdoMXYxaC0xek00LDdoMXYxaC0xeiIvPjxwYXRoIGZpbGw9ImhzbCgzMjUgNDclIDU1JSkiIGQ9Ik0xLDBoMXYxaC0xek02LDBoMXYxaC0xek0zLDFoMXYxaC0xek00LDFoMXYxaC0xek0wLDVoMXYxaC0xek03LDVoMXYxaC0xeiIvPjwvc3ZnPg=="
           style="border-radius: 50%;"
           width="16"
@@ -26,6 +27,7 @@ exports[`AccountPicker renders properly 1`] = `
         <img
           alt=""
           height="16"
+          loading="lazy"
           src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA4IDgiIHNoYXBlLXJlbmRlcmluZz0ib3B0aW1pemVTcGVlZCIgd2lkdGg9IjY0IiBoZWlnaHQ9IjY0Ij48cGF0aCBmaWxsPSJoc2woMTM5IDg5JSA1OSUpIiBkPSJNMCwwSDhWOEgweiIvPjxwYXRoIGZpbGw9ImhzbCgzMjEgOTIlIDU2JSkiIGQ9Ik0xLDJoMXYxaC0xek02LDJoMXYxaC0xek0yLDJoMXYxaC0xek01LDJoMXYxaC0xek0zLDJoMXYxaC0xek00LDJoMXYxaC0xek0zLDNoMXYxaC0xek00LDNoMXYxaC0xek0wLDRoMXYxaC0xek03LDRoMXYxaC0xek0yLDRoMXYxaC0xek01LDRoMXYxaC0xek0wLDZoMXYxaC0xek03LDZoMXYxaC0xek0xLDZoMXYxaC0xek02LDZoMXYxaC0xek0zLDZoMXYxaC0xek00LDZoMXYxaC0xek0wLDdoMXYxaC0xek03LDdoMXYxaC0xek0yLDdoMXYxaC0xek01LDdoMXYxaC0xek0zLDdoMXYxaC0xek00LDdoMXYxaC0xeiIvPjxwYXRoIGZpbGw9ImhzbCgzMjUgNDclIDU1JSkiIGQ9Ik0xLDBoMXYxaC0xek02LDBoMXYxaC0xek0zLDFoMXYxaC0xek00LDFoMXYxaC0xek0wLDVoMXYxaC0xek03LDVoMXYxaC0xeiIvPjwvc3ZnPg=="
           style="border-radius: 50%;"
           width="16"

--- a/ui/components/multichain/asset-picker-amount/asset-picker-modal/asset-picker-modal.tsx
+++ b/ui/components/multichain/asset-picker-amount/asset-picker-modal/asset-picker-modal.tsx
@@ -353,7 +353,7 @@ export function AssetPickerModal({
                       justifyContent={JustifyContent.center}
                     >
                       <Box justifyContent={JustifyContent.center}>
-                        <img src="./images/no-nfts.svg" />
+                        <img src="./images/no-nfts.svg" alt="" loading="lazy" />
                       </Box>
                       <Box
                         display={Display.Flex}

--- a/ui/components/multichain/asset-picker-amount/asset-picker/__snapshots__/asset-picker.test.tsx.snap
+++ b/ui/components/multichain/asset-picker-amount/asset-picker/__snapshots__/asset-picker.test.tsx.snap
@@ -18,11 +18,13 @@ exports[`AssetPicker matches snapshot 1`] = `
           <img
             aria-hidden="true"
             class="mm-avatar-token__token-image--blurred"
+            loading="lazy"
             src="./images/eth_logo.svg"
           />
           <img
             alt="undefined logo"
             class="mm-avatar-token__token-image--size-reduced"
+            loading="lazy"
             src="./images/eth_logo.svg"
           />
         </div>

--- a/ui/components/multichain/avatar-group/__snapshots__/avatar-group.test.tsx.snap
+++ b/ui/components/multichain/avatar-group/__snapshots__/avatar-group.test.tsx.snap
@@ -19,6 +19,7 @@ exports[`AvatarGroup should render AvatarGroup component 1`] = `
           <img
             alt="AVAX logo"
             class="mm-avatar-token__token-image"
+            loading="lazy"
             src="./images/avax-token.svg"
           />
         </div>
@@ -33,6 +34,7 @@ exports[`AvatarGroup should render AvatarGroup component 1`] = `
           <img
             alt="OP logo"
             class="mm-avatar-token__token-image"
+            loading="lazy"
             src="./images/optimism.svg"
           />
         </div>
@@ -47,6 +49,7 @@ exports[`AvatarGroup should render AvatarGroup component 1`] = `
           <img
             alt="MATIC logo"
             class="mm-avatar-token__token-image"
+            loading="lazy"
             src="./images/matic-token.svg"
           />
         </div>
@@ -61,6 +64,7 @@ exports[`AvatarGroup should render AvatarGroup component 1`] = `
           <img
             alt="ETH logo"
             class="mm-avatar-token__token-image"
+            loading="lazy"
             src="./images/eth_logo.svg"
           />
         </div>

--- a/ui/components/multichain/badge-status/__snapshots__/badge-status.test.js.snap
+++ b/ui/components/multichain/badge-status/__snapshots__/badge-status.test.js.snap
@@ -24,6 +24,7 @@ exports[`Badge Status should render correctly 1`] = `
             <img
               alt=""
               height="32"
+              loading="lazy"
               src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA4IDgiIHNoYXBlLXJlbmRlcmluZz0ib3B0aW1pemVTcGVlZCIgd2lkdGg9IjY0IiBoZWlnaHQ9IjY0Ij48cGF0aCBmaWxsPSJoc2woMTM5IDg5JSA1OSUpIiBkPSJNMCwwSDhWOEgweiIvPjxwYXRoIGZpbGw9ImhzbCgzMjEgOTIlIDU2JSkiIGQ9Ik0xLDJoMXYxaC0xek02LDJoMXYxaC0xek0yLDJoMXYxaC0xek01LDJoMXYxaC0xek0zLDJoMXYxaC0xek00LDJoMXYxaC0xek0zLDNoMXYxaC0xek00LDNoMXYxaC0xek0wLDRoMXYxaC0xek03LDRoMXYxaC0xek0yLDRoMXYxaC0xek01LDRoMXYxaC0xek0wLDZoMXYxaC0xek03LDZoMXYxaC0xek0xLDZoMXYxaC0xek02LDZoMXYxaC0xek0zLDZoMXYxaC0xek00LDZoMXYxaC0xek0wLDdoMXYxaC0xek03LDdoMXYxaC0xek0yLDdoMXYxaC0xek01LDdoMXYxaC0xek0zLDdoMXYxaC0xek00LDdoMXYxaC0xeiIvPjxwYXRoIGZpbGw9ImhzbCgzMjUgNDclIDU1JSkiIGQ9Ik0xLDBoMXYxaC0xek02LDBoMXYxaC0xek0zLDFoMXYxaC0xek00LDFoMXYxaC0xek0wLDVoMXYxaC0xek03LDVoMXYxaC0xeiIvPjwvc3ZnPg=="
               style="border-radius: 50%;"
               width="32"

--- a/ui/components/multichain/connected-site-menu/__snapshots__/connected-site-menu.test.js.snap
+++ b/ui/components/multichain/connected-site-menu/__snapshots__/connected-site-menu.test.js.snap
@@ -24,6 +24,7 @@ exports[`Connected Site Menu should render the site menu in connected state 1`] 
             <img
               alt="Uniswap logo"
               class="mm-avatar-favicon__image"
+              loading="lazy"
               src="https://uniswap.org/favicon.ico"
             />
           </div>
@@ -66,6 +67,7 @@ exports[`Connected Site Menu should render the site menu in not connected state 
             <img
               alt="Uniswap logo"
               class="mm-avatar-favicon__image"
+              loading="lazy"
               src="https://uniswap.org/favicon.ico"
             />
           </div>
@@ -108,6 +110,7 @@ exports[`Connected Site Menu should render the site menu in not connected to cur
             <img
               alt="Uniswap logo"
               class="mm-avatar-favicon__image"
+              loading="lazy"
               src="https://uniswap.org/favicon.ico"
             />
           </div>

--- a/ui/components/multichain/network-list-item/__snapshots__/network-list-item.test.js.snap
+++ b/ui/components/multichain/network-list-item/__snapshots__/network-list-item.test.js.snap
@@ -11,6 +11,7 @@ exports[`NetworkListItem renders properly 1`] = `
       <img
         alt="Polygon logo"
         class="mm-avatar-network__network-image"
+        loading="lazy"
         src="./images/matic-token.svg"
       />
     </div>

--- a/ui/components/multichain/network-list-menu/network-list-menu.js
+++ b/ui/components/multichain/network-list-menu/network-list-menu.js
@@ -298,6 +298,7 @@ export const NetworkListMenu = ({ onClose }) => {
                   <img
                     src="./images/dragging-animation.svg"
                     alt="drag-and-drop"
+                    loading="lazy"
                   />
                 </Box>
               }

--- a/ui/components/multichain/pages/permissions-page/__snapshots__/permissions-page.test.js.snap
+++ b/ui/components/multichain/pages/permissions-page/__snapshots__/permissions-page.test.js.snap
@@ -64,6 +64,7 @@ exports[`All Connections render renders correctly 1`] = `
                 <img
                   alt="avatar-favicon logo"
                   class="mm-avatar-favicon__image"
+                  loading="lazy"
                   src="https://metamask.github.io/test-dapp/metamask-fox.svg"
                 />
               </div>
@@ -77,6 +78,7 @@ exports[`All Connections render renders correctly 1`] = `
                   <img
                     alt="Ethereum Mainnet logo"
                     class="mm-avatar-network__network-image"
+                    loading="lazy"
                     src="./images/eth_logo.svg"
                   />
                 </div>

--- a/ui/components/multichain/token-list-item/__snapshots__/token-list-item.test.js.snap
+++ b/ui/components/multichain/token-list-item/__snapshots__/token-list-item.test.js.snap
@@ -28,6 +28,7 @@ exports[`TokenListItem should render correctly 1`] = `
             <img
               alt="Ethereum Mainnet logo"
               class="mm-avatar-network__network-image"
+              loading="lazy"
               src="./images/eth_logo.svg"
             />
           </div>

--- a/ui/components/ui/icon-with-fallback/icon-with-fallback.component.js
+++ b/ui/components/ui/icon-with-fallback/icon-with-fallback.component.js
@@ -36,6 +36,7 @@ const IconWithFallback = ({
           style={style}
           className={className}
           alt={name || 'icon'}
+          loading="lazy"
           {...props}
         />
       ) : (

--- a/ui/components/ui/identicon/__snapshots__/identicon.component.test.js.snap
+++ b/ui/components/ui/identicon/__snapshots__/identicon.component.test.js.snap
@@ -54,6 +54,7 @@ exports[`Identicon should match snapshot with custom image and className props 1
   <img
     alt=""
     class="identicon test-image"
+    loading="lazy"
     src="test-image"
     style="height: 46px; width: 46px; border-radius: 23px;"
   />

--- a/ui/components/ui/identicon/blockieIdenticon/blockieIdenticon.component.js
+++ b/ui/components/ui/identicon/blockieIdenticon/blockieIdenticon.component.js
@@ -12,6 +12,7 @@ const BlockieIdenticon = ({ address, diameter, alt = '', borderRadius }) => {
         borderRadius,
       }}
       alt={alt}
+      loading="lazy"
     />
   );
 };

--- a/ui/components/ui/identicon/identicon.component.js
+++ b/ui/components/ui/identicon/identicon.component.js
@@ -105,6 +105,7 @@ export default class Identicon extends Component {
         onError={() => {
           this.setState({ imageLoadingError: true });
         }}
+        loading="lazy"
       />
     );
   }

--- a/ui/pages/confirm-add-suggested-nft/__snapshots__/confirm-add-suggested-nft.test.js.snap
+++ b/ui/pages/confirm-add-suggested-nft/__snapshots__/confirm-add-suggested-nft.test.js.snap
@@ -73,6 +73,7 @@ exports[`ConfirmAddSuggestedNFT Component should match snapshot 1`] = `
                 >
                   <img
                     alt="Ethereum Mainnet"
+                    loading="lazy"
                     src="./images/eth_logo.svg"
                     style="height: 16px; width: 16px;"
                   />
@@ -285,6 +286,7 @@ exports[`ConfirmAddSuggestedNFT Component should match snapshot 1`] = `
               >
                 <img
                   alt="Ethereum Mainnet"
+                  loading="lazy"
                   src="./images/eth_logo.svg"
                   style="height: 16px; width: 16px;"
                 />

--- a/ui/pages/confirmations/components/signature-request-siwe/__snapshots__/signature-request-siwe.test.js.snap
+++ b/ui/pages/confirmations/components/signature-request-siwe/__snapshots__/signature-request-siwe.test.js.snap
@@ -197,6 +197,7 @@ exports[`SignatureRequestSIWE (Sign in with Ethereum) should match snapshot 1`] 
                 >
                   <img
                     alt="icon"
+                    loading="lazy"
                     src="https://example-dapp.website/favicon-32x32.png"
                     style="height: 24px; width: 24px;"
                   />

--- a/ui/pages/confirmations/confirm-approve/confirm-approve-content/__snapshots__/confirm-approve-content.component.test.js.snap
+++ b/ui/pages/confirmations/confirm-approve/confirm-approve-content/__snapshots__/confirm-approve-content.component.test.js.snap
@@ -17,6 +17,7 @@ exports[`ConfirmApproveContent Component should render Confirm approve page corr
           <img
             alt="https://metamask.github.io/test-dapp/"
             class="url-icon confirm-approve-content__siteimage-identicon"
+            loading="lazy"
             src="https://metamask.github.io/test-dapp/metamask-fox.svg"
           />
         </div>
@@ -187,6 +188,7 @@ exports[`ConfirmApproveContent Component should render Confirm approve page corr
           <img
             alt="https://metamask.github.io/test-dapp/"
             class="url-icon confirm-approve-content__siteimage-identicon"
+            loading="lazy"
             src="https://metamask.github.io/test-dapp/metamask-fox.svg"
           />
         </div>
@@ -368,6 +370,7 @@ exports[`ConfirmApproveContent Component should render Confirm approve page corr
           <img
             alt="https://metamask.github.io/test-dapp/"
             class="url-icon confirm-approve-content__siteimage-identicon"
+            loading="lazy"
             src="https://metamask.github.io/test-dapp/metamask-fox.svg"
           />
         </div>
@@ -549,6 +552,7 @@ exports[`ConfirmApproveContent Component should render Confirm approve page corr
           <img
             alt="https://metamask.github.io/test-dapp/"
             class="url-icon confirm-approve-content__siteimage-identicon"
+            loading="lazy"
             src="https://metamask.github.io/test-dapp/metamask-fox.svg"
           />
         </div>

--- a/ui/pages/confirmations/token-allowance/__snapshots__/token-allowance.test.js.snap
+++ b/ui/pages/confirmations/token-allowance/__snapshots__/token-allowance.test.js.snap
@@ -204,6 +204,7 @@ exports[`TokenAllowancePage when mounted should match snapshot 1`] = `
           <img
             alt="https://metamask.github.io"
             class="url-icon token-allowance-container__icon-display-content__siteimage-identicon"
+            loading="lazy"
             src="https://metamask.github.io/test-dapp/metamask-fox.svg"
           />
         </div>

--- a/ui/pages/settings/security-tab/__snapshots__/security-tab.test.js.snap
+++ b/ui/pages/settings/security-tab/__snapshots__/security-tab.test.js.snap
@@ -560,6 +560,7 @@ exports[`Security Tab should match snapshot 1`] = `
               <img
                 alt="Custom Mainnet RPC logo"
                 class="mm-avatar-network__network-image"
+                loading="lazy"
                 src="./images/eth_logo.svg"
               />
             </div>
@@ -647,6 +648,7 @@ exports[`Security Tab should match snapshot 1`] = `
               <img
                 alt="Linea Mainnet logo"
                 class="mm-avatar-network__network-image"
+                loading="lazy"
                 src="./images/linea-logo-mainnet.svg"
               />
             </div>
@@ -900,6 +902,7 @@ exports[`Security Tab should match snapshot 1`] = `
               <img
                 alt="Linea Sepolia logo"
                 class="mm-avatar-network__network-image"
+                loading="lazy"
                 src="./images/linea-logo-testnet.png"
               />
             </div>
@@ -987,6 +990,7 @@ exports[`Security Tab should match snapshot 1`] = `
               <img
                 alt="Linea Goerli logo"
                 class="mm-avatar-network__network-image"
+                loading="lazy"
                 src="./images/linea-logo-testnet.png"
               />
             </div>

--- a/ui/pages/swaps/dropdown-search-list/__snapshots__/dropdown-search-list.test.js.snap
+++ b/ui/pages/swaps/dropdown-search-list/__snapshots__/dropdown-search-list.test.js.snap
@@ -19,6 +19,7 @@ exports[`DropdownSearchList renders the component with initial props 1`] = `
           <img
             alt="symbol"
             class="url-icon dropdown-search-list__selector-closed-icon"
+            loading="lazy"
             src="iconUrl"
           />
         </div>

--- a/ui/pages/swaps/searchable-item-list/__snapshots__/searchable-item-list.test.js.snap
+++ b/ui/pages/swaps/searchable-item-list/__snapshots__/searchable-item-list.test.js.snap
@@ -48,6 +48,7 @@ exports[`SearchableItemList renders the component with initial props 2`] = `
     <img
       alt="primaryLabel"
       class="url-icon"
+      loading="lazy"
       src="iconUrl"
     />
   </div>

--- a/ui/pages/swaps/searchable-item-list/item-list/__snapshots__/item-list.component.test.js.snap
+++ b/ui/pages/swaps/searchable-item-list/item-list/__snapshots__/item-list.component.test.js.snap
@@ -12,6 +12,7 @@ exports[`ItemList renders the component with initial props 1`] = `
     <img
       alt="primaryLabel"
       class="url-icon"
+      loading="lazy"
       src="iconUrl"
     />
   </div>

--- a/ui/pages/swaps/selected-token/__snapshots__/selected-token.test.js.snap
+++ b/ui/pages/swaps/selected-token/__snapshots__/selected-token.test.js.snap
@@ -16,6 +16,7 @@ exports[`SelectedToken renders the component with initial props 1`] = `
         <img
           alt="ETH"
           class="url-icon dropdown-search-list__selector-closed-icon"
+          loading="lazy"
           src="iconUrl"
         />
       </div>

--- a/ui/pages/swaps/view-quote/__snapshots__/view-quote.test.js.snap
+++ b/ui/pages/swaps/view-quote/__snapshots__/view-quote.test.js.snap
@@ -17,6 +17,7 @@ exports[`ViewQuote renders the component with EIP-1559 enabled 1`] = `
     <img
       alt="DAI"
       class="url-icon main-quote-summary__icon"
+      loading="lazy"
       src="https://foo.bar/logo.png"
     />
   </div>
@@ -89,6 +90,7 @@ exports[`ViewQuote renders the component with initial props 1`] = `
     <img
       alt="DAI"
       class="url-icon main-quote-summary__icon"
+      loading="lazy"
       src="https://foo.bar/logo.png"
     />
   </div>


### PR DESCRIPTION

## **Description**

This is an experiment in lazy loading frequently used image locations

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/24689?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
