### PR TITLE
fix: Improve flakiness of await driver.findElements in 'importing multiple tokens from search' test

### DIFF
--- a/test/e2e/tests/tokens/import-tokens.spec.js
+++ b/test/e2e/tests/tokens/import-tokens.spec.js
@@ -85,8 +85,9 @@ describe('Import flow', function () {
           '[data-testid="token-list-loading-message"]',
         );
 
-        const items = await driver.findElements('.multichain-token-list-item');
-        assert.equal(items.length, 4);
+        const expectedTokenListElementsAreFound =
+          await driver.elementCountBecomesN('.multichain-token-list-item', 4);
+        assert.equal(expectedTokenListElementsAreFound, true);
       },
     );
   });

--- a/test/e2e/webdriver/driver.js
+++ b/test/e2e/webdriver/driver.js
@@ -110,6 +110,15 @@ until.elementIsNotPresent = function elementIsNotPresent(locator) {
   });
 };
 
+until.foundElementCountIs = function foundElementCountIs(locator, n) {
+  console.log('locator', locator);
+  return new Condition(`Element count is ${n}`, function (driver) {
+    return driver.findElements(locator).then(function (elements) {
+      return elements.length === n;
+    });
+  });
+};
+
 /**
  * This is MetaMask's custom E2E test driver, wrapping the Selenium WebDriver.
  * For Selenium WebDriver API documentation, see:
@@ -257,6 +266,20 @@ class Driver {
       const empty = elemText === '';
       return !empty;
     }, this.timeout);
+  }
+
+  async elementCountBecomesN(rawLocator, n, timeout = this.timeout) {
+    const locator = this.buildLocator(rawLocator);
+    try {
+      await this.driver.wait(until.foundElementCountIs(locator, n), timeout);
+      return true;
+    } catch (e) {
+      const elements = await this.findElements(locator);
+      console.error(
+        `Waiting for count of ${locator} elements to be ${n}, but it is ${elements.length}`,
+      );
+      return false;
+    }
   }
 
   /**

--- a/test/e2e/webdriver/driver.js
+++ b/test/e2e/webdriver/driver.js
@@ -111,7 +111,6 @@ until.elementIsNotPresent = function elementIsNotPresent(locator) {
 };
 
 until.foundElementCountIs = function foundElementCountIs(locator, n) {
-  console.log('locator', locator);
   return new Condition(`Element count is ${n}`, function (driver) {
     return driver.findElements(locator).then(function (elements) {
       return elements.length === n;


### PR DESCRIPTION
## **Description**

This improves on a flaky test that I noticed while working to get mv3 tests to pass. I think it is flaky on mv2 as well. The bug is not visually reproducible manually, but I saw it fail twice on CI.

The test clicks "import-tokens-modal-import-button", then waits for for the loading spinner to be not present, and then finds tokens in the list. It finds the token list as a group and then checks that the expected number are present.

The problem is that the list is not fully populated at the exact same time that the loading spinner is removed.

The fix is to rewrite the test so that it waits for the expected number of tokens to be rendered (instead of assuming the token list is immediately in the fully populated state).

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/24694?quickstart=1)

## **Manual testing steps**

This test should continue to pass on all e2e jobs

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
