### PR TITLE
fix: Reduce appInstalledEvent timeout delay

### DIFF
--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -977,7 +977,7 @@ const addAppInstalledEvent = () => {
   setTimeout(() => {
     // If the controller is not set yet, we wait and try to add the "App Installed" event again.
     addAppInstalledEvent();
-  }, 1000);
+  }, 500);
 };
 
 // On first install, open a new tab with MetaMask

--- a/test/e2e/tests/metrics/app-installed.spec.js
+++ b/test/e2e/tests/metrics/app-installed.spec.js
@@ -5,6 +5,7 @@ const {
   onboardingBeginCreateNewWallet,
   onboardingChooseMetametricsOption,
   getEventPayloads,
+  tinyDelayMs,
 } = require('../../helpers');
 const FixtureBuilder = require('../../fixture-builder');
 
@@ -49,7 +50,7 @@ describe('App Installed Events @no-mmi', function () {
       },
       async ({ driver, mockedEndpoint: mockedEndpoints }) => {
         await driver.navigate();
-
+        await driver.delay(tinyDelayMs);
         await onboardingBeginCreateNewWallet(driver);
         await onboardingChooseMetametricsOption(driver, true);
 


### PR DESCRIPTION
## **Description**

This improves on a flaky test. I noticed this when working on mv3 e2e tests, although I believe it is the same problem discussed here https://github.com/MetaMask/metamask-extension/pull/24016/files#r1580648050

app-installed.spec.js expects an api request to segment. It is possible for the test to get to the point where it checks for that request before the request has been made. Decreasing the timeout delay in background.js, means the request will be called sooner, in time for the test to correctly assert.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/24695?quickstart=1)

## **Manual testing steps**

e2e tests should pass

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
