### PR TITLE
Remove user-data-dir usage in tests on mv3 builds

### DIFF
--- a/test/e2e/webdriver/chrome.js
+++ b/test/e2e/webdriver/chrome.js
@@ -35,13 +35,8 @@ class ChromeDriver {
       args.push('--auto-open-devtools-for-tabs');
     }
 
-    if (process.env.ENABLE_MV3) {
-      args.push('--log-level=0');
-      args.push('--enable-logging');
-      args.push(`--user-data-dir=${process.cwd()}/test-artifacts/chrome`);
-    } else {
-      args.push('--log-level=3');
-    }
+    args.push('--log-level=3');
+    args.push('--enable-logging');
 
     if (process.env.CI || process.env.CODESPACES) {
       args.push('--disable-gpu');


### PR DESCRIPTION
## **Description**

"The user data directory contains profile data such as history, bookmarks, and cookies, as well as other per-installation local state."

We are using the `user-data-dir` command and unnecessarily caching such data in the `test-artefacts/` directory. With local testing, and seemingly with test run as part of the same job on CI, it can be seen that this cached data has persistence between test runs, and can thereby cause flakiness. Locally, it seems that old builds of the extension can be cached. On CI, it seems that things like our fetch cache can be persisted between browser sessions.

I do not believe this is actually used for any purpose, and we can reduce flakiness by removing it.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/24696?quickstart=1)

## **Manual testing steps**

all e2e tests should pass

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
