### PR TITLE
fix: Only prevent the service worker timestamp save if initState.PreferencesController?.enableMV3TimestampSave is false

### DIFF
--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -291,7 +291,7 @@ async function initialize() {
     if (isManifestV3) {
       // Save the timestamp immediately and then every `SAVE_TIMESTAMP_INTERVAL`
       // miliseconds. This keeps the service worker alive.
-      if (initState.PreferencesController?.enableMV3TimestampSave) {
+      if (initState.PreferencesController?.enableMV3TimestampSave !== false) {
         const SAVE_TIMESTAMP_INTERVAL_MS = 2 * 1000;
 
         saveTimestamp();


### PR DESCRIPTION
## **Description**

This if block was added to allow us to easily toggle off the timestamp saving at an interval. (https://github.com/MetaMask/metamask-extension/pull/24326)

`enableMV3TimestampSave` defaults to true in the preferences controller, but on first install of the extension, before the preferences controller has been initialized, it will be `undefined`.

We should ensure that this timestamp saving behaviour is able to occur on first install of the extension by only preventing it if `enableMV3TimestampSave` is explicitly `false`.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/24697?quickstart=1)

## **Manual testing steps**

Repro broken:
1. On develop, put a console log inside the `if` block that this PR modifies
2. Build and install and start to use metamask. Notice that the console log does on occur.

Test fix:
1. On this branch, put a console log inside the `if` block that this PR modifies
2. Build and install and start to use metamask. Notice that the console log does occur.

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
