### PR TITLE
Cherry-pick fix stopgap for BigNumber shift NaN issue (#24691) into v11.16.0

### DIFF
--- a/ui/pages/confirmations/components/simulation-details/useBalanceChanges.ts
+++ b/ui/pages/confirmations/components/simulation-details/useBalanceChanges.ts
@@ -140,7 +140,10 @@ function getTokenBalanceChanges(
     };
 
     const decimals =
-      asset.standard === TokenStandard.ERC20 ? erc20Decimals[asset.address] : 0;
+      // TODO(dbrans): stopgap for https://github.com/MetaMask/metamask-extension/issues/24690
+      asset.standard === TokenStandard.ERC20
+        ? erc20Decimals[asset.address] ?? ERC20_DEFAULT_DECIMALS
+        : 0;
     const amount = getAssetAmount(tokenBc, decimals);
 
     const fiatRate = erc20FiatRates[tokenBc.address];


### PR DESCRIPTION
Cherry-pick fix stopgap for BigNumber shift NaN issue 4233f9ed062e2d84250c45f17e8bb0dd2dafaaab (#24691) into v11.16.0.

There was a merge conflict – I rejected `HEAD` and accepted `4233f9ed06`.
```typescript
    const decimals =
<<<<<<< HEAD
      asset.standard === TokenStandard.ERC20 ? erc20Decimals[asset.address] : 0;
=======
      // TODO(dbrans): stopgap for https://github.com/MetaMask/metamask-extension/issues/24690
      asset.standard === TokenStandard.ERC20
        ? erc20Decimals[asset.address] ?? ERC20_DEFAULT_DECIMALS
        : 0;
>>>>>>> 4233f9ed06 (fix: stopgap for BigNumber shift NaN issue (#24691))
    const amount = getAssetAmount(tokenBc, decimals);
```
