### PR TITLE
chore: use Firefox ServiceBuilder and add geckodriver path for e2e in Linux + Firefox snap

### DIFF
--- a/.metamaskrc.dist
+++ b/.metamaskrc.dist
@@ -21,7 +21,8 @@ BLOCKAID_PUBLIC_KEY=
 ; SELENIUM_HEADLESS=
 ; Set this to 1 to make chrome e2e tests disable DoH/DoT and use system DNS
 ; SELENIUM_USE_SYSTEM_DNS=
-
+; Set this to true to enable the snap path for the Firefox WebDriver (Linux)
+; FIREFOX_SNAP=
 
 ENABLE_CONFIRMATION_REDESIGN=
 

--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ Note: The `yarn start:test` command (which initiates the testDev build type) has
 Once you have your test build ready, choose the browser for your e2e tests:
 
 - For Firefox, run `yarn test:e2e:firefox`.
+  - Note:  If you are running Firefox as a snap package on Linux, ensure you enable the appropriate environment variable: `FIREFOX_SNAP=true yarn test:e2e:firefox`
 - For Chrome, run `yarn test:e2e:chrome`.
 
 These scripts support additional options for debugging. Use `--help`to see all available options.

--- a/test/e2e/webdriver/firefox.js
+++ b/test/e2e/webdriver/firefox.js
@@ -65,6 +65,10 @@ class FirefoxDriver {
       );
       options.headless();
     }
+    // For cases where Firefox is installed as snap (Linux)
+    if (process.env.FIREFOX_SNAP === 'true') {
+      process.env.PATH = `/snap/bin/geckodriver`;
+    }
     const builder = new Builder()
       .forBrowser('firefox')
       .setFirefoxOptions(options);

--- a/test/e2e/webdriver/firefox.js
+++ b/test/e2e/webdriver/firefox.js
@@ -65,17 +65,21 @@ class FirefoxDriver {
       );
       options.headless();
     }
-    // For cases where Firefox is installed as snap (Linux)
-    if (process.env.FIREFOX_SNAP === 'true') {
-      process.env.PATH = `/snap/bin/geckodriver`;
-    }
+
     const builder = new Builder()
       .forBrowser('firefox')
       .setFirefoxOptions(options);
+
+    // For cases where Firefox is installed as snap (Linux)
+    const service = process.env.FIREFOX_SNAP
+      ? new firefox.ServiceBuilder('/snap/bin/geckodriver')
+      : new firefox.ServiceBuilder();
+
     if (port) {
-      const service = new firefox.ServiceBuilder().setPort(port);
-      builder.setFirefoxService(service);
+      service.setPort(port);
     }
+
+    builder.setFirefoxService(service);
     const driver = builder.build();
     const fxDriver = new FirefoxDriver(driver);
 

--- a/test/e2e/webdriver/firefox.js
+++ b/test/e2e/webdriver/firefox.js
@@ -65,14 +65,14 @@ class FirefoxDriver {
       );
       options.headless();
     }
-
     const builder = new Builder()
       .forBrowser('firefox')
       .setFirefoxOptions(options);
 
     // For cases where Firefox is installed as snap (Linux)
+    const FF_SNAP_GECKO_PATH = '/snap/bin/geckodriver';
     const service = process.env.FIREFOX_SNAP
-      ? new firefox.ServiceBuilder('/snap/bin/geckodriver')
+      ? new firefox.ServiceBuilder(FF_SNAP_GECKO_PATH)
       : new firefox.ServiceBuilder();
 
     if (port) {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
In this PR we enable an envar which fixes the e2e for running against Firefox, when the browser is installed as a snap (Linux). 
For doing so, we need to leverage the Firefox [ServiceBuilder class](https://www.selenium.dev/documentation/webdriver/drivers/service/).
Using the service class by default is something that we already do [in Chrome](https://github.com/MetaMask/metamask-extension/blob/develop/test/e2e/webdriver/chrome.js#L75). 
For Firefox, we only did this in the case a custom port was passed. Now it's done always, and in the case we pass a port, we configure it as we did.



[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/24703?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Check ci FF tests continue to work normally
2. If you are on Linux, install FF as snap and run a test with the flag `FIREFOX_SNAP=true yarn test:e2e:single test/e2e/tests/tokens/nft/import-erc1155.spec.js --browser=firefox`

## **Screenshots/Recordings**

### **Before**
![Screenshot from 2024-05-22 09-13-26](https://github.com/MetaMask/metamask-extension/assets/54408225/51c1dc17-80e7-4cdb-928f-40985f63456d)


### **After**




https://github.com/MetaMask/metamask-extension/assets/54408225/05cdd8d4-64d7-4224-8b28-3f1dc4c2fd00




## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
