### PR TITLE
test: fix flaky test `Import ERC1155 NFT should be able to import an ERC1155 NFT that user owns`

### DIFF
--- a/test/e2e/mock-e2e.js
+++ b/test/e2e/mock-e2e.js
@@ -577,6 +577,17 @@ async function setupMocking(server, testSpecificMock, { chainId }) {
   await mockLensNameProvider(server);
   await mockTokenNameProvider(server, chainId);
 
+  // IPFS endpoint for NFT metadata
+  await server
+    .forGet(
+      'https://bafybeidxfmwycgzcp4v2togflpqh2gnibuexjy4m4qqwxp7nh3jx5zlh4y.ipfs.dweb.link/1.json',
+    )
+    .thenCallback(() => {
+      return {
+        statusCode: 200,
+      };
+    });
+
   /**
    * Returns an array of alphanumerically sorted hostnames that were requested
    * during the current test suite.


### PR DESCRIPTION
## **Description**
This PR fixes the flaky tests related to ERC1155 token imports.
The problem is that whenever we import a token, we are making a call to IPFS, which was currently not mocked. This caused that anytime that the response took long, the test failed.

The fix is simply add a mock for the IPFS request.

However, this shows that we have a bug in the Import process, as we should be able to import the token even if the IPFS call has not ended. Now, it might take several minutes, and we can import the token once we get the timeout response `504`.
 I opened an issue [here](https://github.com/MetaMask/metamask-extension/issues/24710)


## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/24604

## **Manual testing steps**

1. Run the test multiple times `yarn test:e2e:single test/e2e/tests/tokens/nft/import-erc1155.spec.js --browser=firefox --leave-running --retryUntilFailure --retries=10`
2. Check ci

## **Screenshots/Recordings**

![Screenshot from 2024-05-22 15-42-15](https://github.com/MetaMask/metamask-extension/assets/54408225/2dbd4f9f-8e22-47da-9aaa-4e5b002b47d8)


https://github.com/MetaMask/metamask-extension/assets/54408225/a397575b-52a9-47d7-8243-c0fec734e6d8



## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
