### PR TITLE
feat: Add retry policy to the data deletion service

### DIFF
--- a/app/scripts/controllers/metametrics-data-deletion/services/services.ts
+++ b/app/scripts/controllers/metametrics-data-deletion/services/services.ts
@@ -1,47 +1,204 @@
+import { hasProperty, isObject } from '@metamask/utils';
+import {
+  circuitBreaker,
+  ConsecutiveBreaker,
+  ExponentialBackoff,
+  handleAll,
+  type IPolicy,
+  retry,
+  wrap,
+  CircuitState,
+} from 'cockatiel';
 import getFetchWithTimeout from '../../../../../shared/modules/fetch-with-timeout';
 import { CurrentRegulationStatus, RegulationId } from '../types';
 
-const analyticsDataDeletionSourceId =
+const DEFAULT_ANALYTICS_DATA_DELETION_SOURCE_ID =
   process.env.ANALYTICS_DATA_DELETION_SOURCE_ID;
-const analyticsDataDeletionEndpoint =
+const DEFAULT_ANALYTICS_DATA_DELETION_ENDPOINT =
   process.env.ANALYTICS_DATA_DELETION_ENDPOINT;
 
 const fetchWithTimeout = getFetchWithTimeout();
 
-export async function createDataDeletionRegulationTask(
-  metaMetricsId: string,
-): Promise<RegulationId> {
-  if (!analyticsDataDeletionEndpoint || !analyticsDataDeletionSourceId) {
-    throw new Error('Segment API source ID or endpoint not found');
-  }
+const RETRIES = 3;
+// Each update attempt will result (1 + retries) calls if the server is down
+const MAX_CONSECUTIVE_FAILURES = (1 + RETRIES) * 3;
 
-  const response = await fetchWithTimeout(
-    `${analyticsDataDeletionEndpoint}/regulations/sources/${analyticsDataDeletionSourceId}`,
-    {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/vnd.segment.v1+json' },
-      body: JSON.stringify({
-        regulationType: 'DELETE_ONLY',
-        subjectType: 'USER_ID',
-        subjectIds: [metaMetricsId],
-      }),
-    },
+const DEFAULT_DEGRADED_THRESHOLD = 5_000;
+
+const CIRCUIT_BREAK_DURATION = 30 * 60 * 1000;
+
+/**
+ * Type guard for Fetch network responses with a `statusCode` property.
+ *
+ * @param response - A suspected Fetch network response.
+ * @returns A type checked Fetch network response.
+ */
+function isValidResponse(
+  response: unknown,
+): response is { statusCode: number } {
+  return (
+    isObject(response) &&
+    hasProperty(response, 'statusCode') &&
+    typeof response.statusCode === 'number'
   );
-  return response.json();
 }
 
-export async function fetchDeletionRegulationStatus(
-  deleteRegulationId: string,
-): Promise<CurrentRegulationStatus> {
-  if (!analyticsDataDeletionEndpoint) {
-    throw new Error('Segment API source ID or endpoint not found');
+/**
+ * Returns `true` if the parameter is a Fetch network response with a status code that indiciates
+ * server failure.
+ *
+ * @param response - The response to check.
+ * @returns `true` if the response indicates a server failure, `false` otherwise.
+ */
+function onServerFailure(response: unknown) {
+  return isValidResponse(response) && response.statusCode >= 500;
+}
+
+/**
+ * Create a Cockatiel retry policy.
+ *
+ * This policy uses a retry and circuit breaker strategy. Callbacks are accepted for circuit breaks
+ * and degraded responses as well.
+ *
+ * @param args - Arguments
+ * @param args.circuitBreakDuration - The amount of time to wait when the circuit breaks
+ * from too many consecutive failures.
+ * @param args.degradedThreshold - The threshold between "normal" and "degrated" service,
+ * in milliseconds.
+ * @param args.maximumConsecutiveFailures - The maximum number of consecutive failures
+ * allowed before breaking the circuit and pausing further updates.
+ * @param args.onBreak - An event handler for when the circuit breaks, useful for capturing
+ * metrics about network failures.
+ * @param args.onDegraded - An event handler for when the circuit remains closed, but requests
+ * are failing or resolving too slowly (i.e. resolving more slowly than the `degradedThreshold`).
+ * @param args.retries - Number of retry attempts.
+ * @returns A Cockatiel retry policy.
+ */
+function createRetryPolicy({
+  circuitBreakDuration,
+  degradedThreshold,
+  maximumConsecutiveFailures,
+  onBreak,
+  onDegraded,
+  retries,
+}: {
+  circuitBreakDuration: number;
+  degradedThreshold: number;
+  maximumConsecutiveFailures: number;
+  onBreak?: () => void;
+  onDegraded?: () => void;
+  retries: number;
+}) {
+  const retryPolicy = retry(handleAll.orWhenResult(onServerFailure), {
+    maxAttempts: retries,
+    backoff: new ExponentialBackoff(),
+  });
+  const circuitBreakerPolicy = circuitBreaker(handleAll, {
+    halfOpenAfter: circuitBreakDuration,
+    breaker: new ConsecutiveBreaker(maximumConsecutiveFailures),
+  });
+  if (onBreak) {
+    circuitBreakerPolicy.onBreak(onBreak);
   }
-  const response = await fetchWithTimeout(
-    `${analyticsDataDeletionEndpoint}/regulations/${deleteRegulationId}`,
-    {
-      method: 'GET',
-      headers: { 'Content-Type': 'application/vnd.segment.v1+json' },
-    },
-  );
-  return response.json();
+  if (onDegraded) {
+    retryPolicy.onGiveUp(() => {
+      if (circuitBreakerPolicy.state === CircuitState.Closed) {
+        onDegraded();
+      }
+    });
+    retryPolicy.onSuccess(({ duration }) => {
+      if (
+        circuitBreakerPolicy.state === CircuitState.Closed &&
+        duration > degradedThreshold
+      ) {
+        onDegraded();
+      }
+    });
+  }
+  return wrap(retryPolicy, circuitBreakerPolicy);
+}
+
+export class DataDeletionService {
+  #analyticsDataDeletionEndpoint: string;
+
+  #analyticsDataDeletionSourceId: string;
+
+  #fetchStatusPolicy: IPolicy;
+
+  #createDataDeletionTaskPolicy: IPolicy;
+
+  constructor({
+    analyticsDataDeletionEndpoint = DEFAULT_ANALYTICS_DATA_DELETION_ENDPOINT,
+    analyticsDataDeletionSourceId = DEFAULT_ANALYTICS_DATA_DELETION_SOURCE_ID,
+    onBreak,
+    onDegraded,
+  }: {
+    analyticsDataDeletionEndpoint?: string;
+    analyticsDataDeletionSourceId?: string;
+    onBreak?: () => void;
+    onDegraded?: () => void;
+  } = {}) {
+    if (!analyticsDataDeletionEndpoint) {
+      throw new Error('Missing ANALYTICS_DATA_DELETION_ENDPOINT');
+    } else if (!analyticsDataDeletionSourceId) {
+      throw new Error('Missing ANALYTICS_DATA_DELETION_SOURCE_ID');
+    }
+    this.#analyticsDataDeletionEndpoint = analyticsDataDeletionEndpoint;
+    this.#analyticsDataDeletionSourceId = analyticsDataDeletionSourceId;
+    this.#createDataDeletionTaskPolicy = createRetryPolicy({
+      circuitBreakDuration: CIRCUIT_BREAK_DURATION,
+      degradedThreshold: DEFAULT_DEGRADED_THRESHOLD,
+      maximumConsecutiveFailures: MAX_CONSECUTIVE_FAILURES,
+      onBreak,
+      onDegraded,
+      retries: RETRIES,
+    });
+    this.#fetchStatusPolicy = createRetryPolicy({
+      circuitBreakDuration: CIRCUIT_BREAK_DURATION,
+      degradedThreshold: DEFAULT_DEGRADED_THRESHOLD,
+      maximumConsecutiveFailures: MAX_CONSECUTIVE_FAILURES,
+      onBreak,
+      onDegraded,
+      retries: RETRIES,
+    });
+  }
+
+  async createDataDeletionRegulationTask(
+    metaMetricsId: string,
+  ): Promise<RegulationId> {
+    const response = await this.#createDataDeletionTaskPolicy.execute(() =>
+      fetchWithTimeout(
+        `${this.#analyticsDataDeletionEndpoint}/regulations/sources/${
+          this.#analyticsDataDeletionSourceId
+        }`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/vnd.segment.v1+json' },
+          body: JSON.stringify({
+            regulationType: 'DELETE_ONLY',
+            subjectType: 'USER_ID',
+            subjectIds: [metaMetricsId],
+          }),
+        },
+      ),
+    );
+    return response.json();
+  }
+
+  async fetchDeletionRegulationStatus(
+    deleteRegulationId: string,
+  ): Promise<CurrentRegulationStatus> {
+    const response = await this.#fetchStatusPolicy.execute(() =>
+      fetchWithTimeout(
+        `${
+          this.#analyticsDataDeletionEndpoint
+        }/regulations/${deleteRegulationId}`,
+        {
+          method: 'GET',
+          headers: { 'Content-Type': 'application/vnd.segment.v1+json' },
+        },
+      ),
+    );
+    return response.json();
+  }
 }

--- a/app/scripts/controllers/metametrics-data-deletion/services/services.ts
+++ b/app/scripts/controllers/metametrics-data-deletion/services/services.ts
@@ -13,9 +13,9 @@ import getFetchWithTimeout from '../../../../../shared/modules/fetch-with-timeou
 import { CurrentRegulationStatus, RegulationId } from '../types';
 
 const DEFAULT_ANALYTICS_DATA_DELETION_SOURCE_ID =
-  process.env.ANALYTICS_DATA_DELETION_SOURCE_ID;
+  process.env.ANALYTICS_DATA_DELETION_SOURCE_ID ?? 'test';
 const DEFAULT_ANALYTICS_DATA_DELETION_ENDPOINT =
-  process.env.ANALYTICS_DATA_DELETION_ENDPOINT;
+  process.env.ANALYTICS_DATA_DELETION_ENDPOINT ?? 'https://metametrics.metamask.test/';
 
 const fetchWithTimeout = getFetchWithTimeout();
 

--- a/app/scripts/controllers/metametrics-data-deletion/services/services.ts
+++ b/app/scripts/controllers/metametrics-data-deletion/services/services.ts
@@ -15,7 +15,8 @@ import { CurrentRegulationStatus, RegulationId } from '../types';
 const DEFAULT_ANALYTICS_DATA_DELETION_SOURCE_ID =
   process.env.ANALYTICS_DATA_DELETION_SOURCE_ID ?? 'test';
 const DEFAULT_ANALYTICS_DATA_DELETION_ENDPOINT =
-  process.env.ANALYTICS_DATA_DELETION_ENDPOINT ?? 'https://metametrics.metamask.test/';
+  process.env.ANALYTICS_DATA_DELETION_ENDPOINT ??
+  'https://metametrics.metamask.test/';
 
 const fetchWithTimeout = getFetchWithTimeout();
 

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -327,6 +327,7 @@ import UserStorageController from './controllers/user-storage/user-storage-contr
 import { PushPlatformNotificationsController } from './controllers/push-platform-notifications/push-platform-notifications';
 import { MetamaskNotificationsController } from './controllers/metamask-notifications/metamask-notifications';
 import MetaMetricsDataDeletionController from './controllers/metametrics-data-deletion/metametrics-data-deletion';
+import { DataDeletionService } from './controllers/metametrics-data-deletion/services/services';
 
 export const METAMASK_CONTROLLER_EVENTS = {
   // Fired after state changes that impact the extension badge (unapproved msg count)
@@ -744,12 +745,14 @@ export default class MetamaskController extends EventEmitter {
       this.metaMetricsController.handleMetaMaskStateUpdate(update);
     });
 
+    const dataDeletionService = new DataDeletionService();
     const metaMetricsDataDeletionMessenger =
       this.controllerMessenger.getRestricted({
         name: 'MetaMetricsDataDeletionController',
       });
     this.metaMetricsDataDeletionController =
       new MetaMetricsDataDeletionController({
+        dataDeletionService,
         messenger: metaMetricsDataDeletionMessenger,
         state: initState.metaMetricsDataDeletionController,
         metaMetricsStore: this.metaMetricsController.store,

--- a/lavamoat/browserify/beta/policy.json
+++ b/lavamoat/browserify/beta/policy.json
@@ -802,7 +802,6 @@
         "@metamask/abi-utils": true,
         "@metamask/assets-controllers>@metamask/base-controller": true,
         "@metamask/assets-controllers>@metamask/polling-controller": true,
-        "@metamask/assets-controllers>cockatiel": true,
         "@metamask/assets-controllers>multiformats": true,
         "@metamask/contract-metadata": true,
         "@metamask/controller-utils": true,
@@ -812,6 +811,7 @@
         "@metamask/providers>@metamask/rpc-errors": true,
         "@metamask/utils": true,
         "bn.js": true,
+        "cockatiel": true,
         "lodash": true,
         "single-call-balance-checker-abi": true,
         "uuid": true,
@@ -844,19 +844,6 @@
       },
       "packages": {
         "immer": true
-      }
-    },
-    "@metamask/assets-controllers>cockatiel": {
-      "globals": {
-        "AbortController": true,
-        "AbortSignal": true,
-        "WeakRef": true,
-        "clearTimeout": true,
-        "performance": true,
-        "setTimeout": true
-      },
-      "packages": {
-        "browserify>process": true
       }
     },
     "@metamask/assets-controllers>multiformats": {
@@ -3080,6 +3067,19 @@
       "globals": {
         "classNames": "write",
         "define": true
+      }
+    },
+    "cockatiel": {
+      "globals": {
+        "AbortController": true,
+        "AbortSignal": true,
+        "WeakRef": true,
+        "clearTimeout": true,
+        "performance": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "browserify>process": true
       }
     },
     "copy-to-clipboard": {

--- a/lavamoat/browserify/desktop/policy.json
+++ b/lavamoat/browserify/desktop/policy.json
@@ -802,7 +802,6 @@
         "@metamask/abi-utils": true,
         "@metamask/assets-controllers>@metamask/base-controller": true,
         "@metamask/assets-controllers>@metamask/polling-controller": true,
-        "@metamask/assets-controllers>cockatiel": true,
         "@metamask/assets-controllers>multiformats": true,
         "@metamask/contract-metadata": true,
         "@metamask/controller-utils": true,
@@ -812,6 +811,7 @@
         "@metamask/providers>@metamask/rpc-errors": true,
         "@metamask/utils": true,
         "bn.js": true,
+        "cockatiel": true,
         "lodash": true,
         "single-call-balance-checker-abi": true,
         "uuid": true,
@@ -844,19 +844,6 @@
       },
       "packages": {
         "immer": true
-      }
-    },
-    "@metamask/assets-controllers>cockatiel": {
-      "globals": {
-        "AbortController": true,
-        "AbortSignal": true,
-        "WeakRef": true,
-        "clearTimeout": true,
-        "performance": true,
-        "setTimeout": true
-      },
-      "packages": {
-        "browserify>process": true
       }
     },
     "@metamask/assets-controllers>multiformats": {
@@ -3413,6 +3400,19 @@
       "globals": {
         "classNames": "write",
         "define": true
+      }
+    },
+    "cockatiel": {
+      "globals": {
+        "AbortController": true,
+        "AbortSignal": true,
+        "WeakRef": true,
+        "clearTimeout": true,
+        "performance": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "browserify>process": true
       }
     },
     "copy-to-clipboard": {

--- a/lavamoat/browserify/flask/policy.json
+++ b/lavamoat/browserify/flask/policy.json
@@ -802,7 +802,6 @@
         "@metamask/abi-utils": true,
         "@metamask/assets-controllers>@metamask/base-controller": true,
         "@metamask/assets-controllers>@metamask/polling-controller": true,
-        "@metamask/assets-controllers>cockatiel": true,
         "@metamask/assets-controllers>multiformats": true,
         "@metamask/contract-metadata": true,
         "@metamask/controller-utils": true,
@@ -812,6 +811,7 @@
         "@metamask/providers>@metamask/rpc-errors": true,
         "@metamask/utils": true,
         "bn.js": true,
+        "cockatiel": true,
         "lodash": true,
         "single-call-balance-checker-abi": true,
         "uuid": true,
@@ -844,19 +844,6 @@
       },
       "packages": {
         "immer": true
-      }
-    },
-    "@metamask/assets-controllers>cockatiel": {
-      "globals": {
-        "AbortController": true,
-        "AbortSignal": true,
-        "WeakRef": true,
-        "clearTimeout": true,
-        "performance": true,
-        "setTimeout": true
-      },
-      "packages": {
-        "browserify>process": true
       }
     },
     "@metamask/assets-controllers>multiformats": {
@@ -3465,6 +3452,19 @@
       "globals": {
         "classNames": "write",
         "define": true
+      }
+    },
+    "cockatiel": {
+      "globals": {
+        "AbortController": true,
+        "AbortSignal": true,
+        "WeakRef": true,
+        "clearTimeout": true,
+        "performance": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "browserify>process": true
       }
     },
     "copy-to-clipboard": {

--- a/lavamoat/browserify/main/policy.json
+++ b/lavamoat/browserify/main/policy.json
@@ -802,7 +802,6 @@
         "@metamask/abi-utils": true,
         "@metamask/assets-controllers>@metamask/base-controller": true,
         "@metamask/assets-controllers>@metamask/polling-controller": true,
-        "@metamask/assets-controllers>cockatiel": true,
         "@metamask/assets-controllers>multiformats": true,
         "@metamask/contract-metadata": true,
         "@metamask/controller-utils": true,
@@ -812,6 +811,7 @@
         "@metamask/providers>@metamask/rpc-errors": true,
         "@metamask/utils": true,
         "bn.js": true,
+        "cockatiel": true,
         "lodash": true,
         "single-call-balance-checker-abi": true,
         "uuid": true,
@@ -844,19 +844,6 @@
       },
       "packages": {
         "immer": true
-      }
-    },
-    "@metamask/assets-controllers>cockatiel": {
-      "globals": {
-        "AbortController": true,
-        "AbortSignal": true,
-        "WeakRef": true,
-        "clearTimeout": true,
-        "performance": true,
-        "setTimeout": true
-      },
-      "packages": {
-        "browserify>process": true
       }
     },
     "@metamask/assets-controllers>multiformats": {
@@ -3380,6 +3367,19 @@
       "globals": {
         "classNames": "write",
         "define": true
+      }
+    },
+    "cockatiel": {
+      "globals": {
+        "AbortController": true,
+        "AbortSignal": true,
+        "WeakRef": true,
+        "clearTimeout": true,
+        "performance": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "browserify>process": true
       }
     },
     "copy-to-clipboard": {

--- a/lavamoat/browserify/mmi/policy.json
+++ b/lavamoat/browserify/mmi/policy.json
@@ -987,7 +987,6 @@
         "@metamask/abi-utils": true,
         "@metamask/assets-controllers>@metamask/base-controller": true,
         "@metamask/assets-controllers>@metamask/polling-controller": true,
-        "@metamask/assets-controllers>cockatiel": true,
         "@metamask/assets-controllers>multiformats": true,
         "@metamask/contract-metadata": true,
         "@metamask/controller-utils": true,
@@ -997,6 +996,7 @@
         "@metamask/providers>@metamask/rpc-errors": true,
         "@metamask/utils": true,
         "bn.js": true,
+        "cockatiel": true,
         "lodash": true,
         "single-call-balance-checker-abi": true,
         "uuid": true,
@@ -1029,19 +1029,6 @@
       },
       "packages": {
         "immer": true
-      }
-    },
-    "@metamask/assets-controllers>cockatiel": {
-      "globals": {
-        "AbortController": true,
-        "AbortSignal": true,
-        "WeakRef": true,
-        "clearTimeout": true,
-        "performance": true,
-        "setTimeout": true
-      },
-      "packages": {
-        "browserify>process": true
       }
     },
     "@metamask/assets-controllers>multiformats": {
@@ -3565,6 +3552,19 @@
       "globals": {
         "classNames": "write",
         "define": true
+      }
+    },
+    "cockatiel": {
+      "globals": {
+        "AbortController": true,
+        "AbortSignal": true,
+        "WeakRef": true,
+        "clearTimeout": true,
+        "performance": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "browserify>process": true
       }
     },
     "copy-to-clipboard": {

--- a/package.json
+++ b/package.json
@@ -356,6 +356,7 @@
     "bn.js": "^5.2.1",
     "bowser": "^2.11.0",
     "classnames": "^2.2.6",
+    "cockatiel": "^3.1.2",
     "contentful": "^10.8.7",
     "copy-to-clipboard": "^3.3.3",
     "currency-formatter": "^1.4.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -25173,6 +25173,7 @@ __metadata:
     chalk: "npm:^4.1.2"
     chokidar: "npm:^3.5.3"
     classnames: "npm:^2.2.6"
+    cockatiel: "npm:^3.1.2"
     concurrently: "npm:^8.2.2"
     contentful: "npm:^10.8.7"
     copy-to-clipboard: "npm:^3.3.3"


### PR DESCRIPTION
## **Description**

The data deletion service now uses a retry policy. It has been refactored into a class so that the retry state may be stored as an instance variable. The service is now injected as well, rather than imported, to keep it decoupled from the controller and make testing easier.

The new service class and retry policy is modelled after the token price service in core: https://github.com/MetaMask/core/blob/3165e87096300a66e06bd949dde736f90ca24fbc/packages/assets-controllers/src/token-prices-service/codefi-v2.ts


[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/24716?quickstart=1)

## **Related issues**

This is a suggested change for #24503

## **Manual testing steps**

N/A

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

(omitting - not applicable as this isn't targeting `develop`)

- [] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
