### PR TITLE
cherry-pick feat: disable stx opt-in modal (#24715) into v11.15.6

### DIFF
--- a/ui/pages/home/home.component.js
+++ b/ui/pages/home/home.component.js
@@ -846,8 +846,10 @@ export default class Home extends PureComponent {
       !process.env.IN_TEST &&
       !newNetworkAddedConfigurationId;
 
+    // TODO(dbrans): temporary fix to disable the smart transactions opt-in modal
+    // in 11.15 to unblock the release. Change this line in 11.16.
     const showSmartTransactionsOptInModal =
-      canSeeModals && isSmartTransactionsOptInModalAvailable;
+      false && canSeeModals && isSmartTransactionsOptInModalAvailable;
 
     const showWhatsNew =
       canSeeModals &&


### PR DESCRIPTION
cherry-pick feat: disable stx opt-in modal 20e51e6d4853d0214422547806f32e8b6de81040 (#24715) into v11.15.6

no merge conflicts

To make sure the stx opt-in modal still pops up for users who install 11.15.6 and then update at a later time:
I followed these steps:
1. Create a build off the cherry-pick branch (this PR). Install and onboard. Verify no modal is shown
2. Create the revert of this PR
3. Create a build off the revert branch
4. Manually upgrade the build from step 1 to the build from step 3
5. Open and unlock metamask, verify that the opt-in modal is shown
