### PR TITLE
test: fix flaky test `Migrate Opensea to Blockaid Banner @no-mmi Shows up on Token Approval transaction confirmations`

### DIFF
--- a/test/e2e/tests/ppom/migrate-opensea-to-blockaid-banner.spec.js
+++ b/test/e2e/tests/ppom/migrate-opensea-to-blockaid-banner.spec.js
@@ -1,12 +1,12 @@
-const { connectAccountToTestDapp } = require('../../accounts/common');
 const FixtureBuilder = require('../../fixture-builder');
 const {
   defaultGanacheOptions,
-  unlockWallet,
+  logInWithBalanceValidation,
   withFixtures,
   openDapp,
   WINDOW_TITLES,
 } = require('../../helpers');
+const { SMART_CONTRACTS } = require('../../seeder/smart-contracts');
 
 describe('Migrate Opensea to Blockaid Banner @no-mmi', function () {
   const ONE_CLICK_CONFIRMATIONS_USING_BLOCKAID = [
@@ -31,17 +31,15 @@ describe('Migrate Opensea to Blockaid Banner @no-mmi', function () {
             .withPreferencesController({
               hasMigratedFromOpenSeaToBlockaid: true,
             })
+            .withPermissionControllerConnectedToTestDapp()
             .build(),
           ganacheOptions: defaultGanacheOptions,
           title: this.test.fullTitle(),
         },
-        async ({ driver }) => {
-          await unlockWallet(driver);
+        async ({ driver, ganacheServer }) => {
+          await logInWithBalanceValidation(driver, ganacheServer);
           await openDapp(driver);
 
-          await connectAccountToTestDapp(driver);
-
-          await driver.switchToWindowWithTitle(WINDOW_TITLES.TestDApp);
           await driver.clickElement(`#${confirmation.testDAppBtnId}`);
           await driver.delay(2000);
 
@@ -53,37 +51,25 @@ describe('Migrate Opensea to Blockaid Banner @no-mmi', function () {
   });
 
   it('Shows up on Token Approval transaction confirmations', async function () {
+    const smartContract = SMART_CONTRACTS.HST;
     await withFixtures(
       {
         dapp: true,
         fixtures: new FixtureBuilder()
           .withPreferencesController({ hasMigratedFromOpenSeaToBlockaid: true })
+          .withPermissionControllerConnectedToTestDapp()
           .build(),
         ganacheOptions: defaultGanacheOptions,
+        smartContract,
         title: this.test.fullTitle(),
       },
-      async ({ driver }) => {
-        await unlockWallet(driver);
-        await openDapp(driver);
+      async ({ driver, contractRegistry, ganacheServer }) => {
+        const contractAddress = await contractRegistry.getContractAddress(
+          smartContract,
+        );
+        await logInWithBalanceValidation(driver, ganacheServer);
+        await openDapp(driver, contractAddress);
 
-        await connectAccountToTestDapp(driver);
-
-        await driver.switchToWindowWithTitle(WINDOW_TITLES.TestDApp);
-        await driver.findClickableElement('#createToken');
-        await driver.clickElement('#createToken');
-        await driver.delay(2000);
-
-        await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
-        await driver.findClickableElements({
-          text: 'Confirm',
-          tag: 'button',
-        });
-        await driver.clickElement({
-          text: 'Confirm',
-          tag: 'button',
-        });
-
-        await driver.switchToWindowWithTitle(WINDOW_TITLES.TestDApp);
         await driver.clickElement({ text: 'Approve Tokens', tag: 'button' });
         await driver.delay(2000);
 


### PR DESCRIPTION
## **Description**
This PR attempts to fix the flaky test `Migrate Opensea to Blockaid Banner @no-mmi Shows up on Token Approval transaction confirmations`

This test fails whenever we click Create Token for deploying an ERC20 token, as the popup is not triggered and we remain in the test dapp.

I haven't been able to reproduce this failure locally. However, after looking into the code and the context of flakiness, I can confirm that:
- I've seen that we are doing several unnecessary steps for the test setup, like connecting to the test dapp, or deploying an ERC20 contract. This can be achieved by fixtures, so I've added the fixtures and got rid of a good chunk of the code. The good part is that the test failure precisely happens on the test setup, which is now removed
- It might be that  there is a race condition between the Connect to the test Dapp and the Create Token steps, where the dapp has not yet the connected address for triggering the Create Token but the button is already enabled, resulting in the error in the test dapp `unknown account` and popup not being opened (see video below). However, those 2 steps are now removed from the test, meaning any potential race condition at this point won't happen anymore
- I've added the `logInWithBalanceValidation` instead of the `unlockWallet` to make sure the balance is loaded before triggering the interaction

For the above points, I have strong reasons for wanting to implement the changes on this PR, despite not being 100% sure of the above being the root cause.



[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/24739?quickstart=1)

## **Related issues**

Fixes: another item of this list https://github.com/MetaMask/metamask-extension/issues/24603

## **Manual testing steps**

1. Run this test locally several times `yarn test:e2e:single test/e2e/tests/ppom/migrate-opensea-to-blockaid-banner.spec.js --browser=firefox --leave-running --retryUntilFailure --retries=10
2. Check ci jobs 

## **Screenshots/Recordings**


![Screenshot from 2024-05-23 11-14-32](https://github.com/MetaMask/metamask-extension/assets/54408225/3357dc1b-9e86-479a-86b0-8da3d401b631)

![image](https://github.com/MetaMask/metamask-extension/assets/54408225/3bdf4e21-948f-4c41-aae7-b2858d4313a6)


This is not the test environment, however here I demonstrate how would look like if the create token is triggered before the dapp has the connected account resolved

https://github.com/MetaMask/metamask-extension/assets/54408225/1121af80-bb95-4201-86db-ff37bb99c3e7



<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
