### PR TITLE
cherry-pick – chore: bump transaction-controller to 29.0.2 (#24701) into v11.16.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -329,7 +329,7 @@
     "@metamask/snaps-rpc-methods": "8.0.0",
     "@metamask/snaps-sdk": "4.0.1",
     "@metamask/snaps-utils": "7.2.0",
-    "@metamask/transaction-controller": "^28.1.1",
+    "@metamask/transaction-controller": "^29.0.2",
     "@metamask/user-operation-controller": "^6.0.0",
     "@metamask/utils": "^8.2.1",
     "@ngraveio/bc-ur": "^1.1.12",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4004,7 +4004,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/approval-controller@npm:^6.0.0, @metamask/approval-controller@npm:^6.0.1":
+"@metamask/approval-controller@npm:^6.0.0, @metamask/approval-controller@npm:^6.0.1, @metamask/approval-controller@npm:^6.0.2":
   version: 6.0.2
   resolution: "@metamask/approval-controller@npm:6.0.2"
   dependencies:
@@ -4461,14 +4461,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/eth-json-rpc-provider@npm:^3.0.1":
-  version: 3.0.1
-  resolution: "@metamask/eth-json-rpc-provider@npm:3.0.1"
+"@metamask/eth-json-rpc-provider@npm:^3.0.1, @metamask/eth-json-rpc-provider@npm:^3.0.2":
+  version: 3.0.2
+  resolution: "@metamask/eth-json-rpc-provider@npm:3.0.2"
   dependencies:
-    "@metamask/json-rpc-engine": "npm:^8.0.1"
+    "@metamask/json-rpc-engine": "npm:^8.0.2"
     "@metamask/safe-event-emitter": "npm:^3.0.0"
     "@metamask/utils": "npm:^8.3.0"
-  checksum: 1c5fdbf7ff90520a961f970edbffb3f6999e0b80ba64a374f5c18eddf4df1fa27dfc463903a237e1b17ee1d55e8d07d2e44306c6e9c36050f63749efd10238ee
+  checksum: 63778defd3055633cbf0aed2d6fd0f8a1d866908be7b16b516fdb26ae6dcd34b2aefdfed80828c2af105a30ec3c16d7d0894bc6a73e2661515bcad6b6b6be4e2
   languageName: node
   linkType: hard
 
@@ -4809,7 +4809,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/json-rpc-engine@npm:^8.0.1":
+"@metamask/json-rpc-engine@npm:^8.0.1, @metamask/json-rpc-engine@npm:^8.0.2":
   version: 8.0.2
   resolution: "@metamask/json-rpc-engine@npm:8.0.2"
   dependencies:
@@ -5067,6 +5067,28 @@ __metadata:
     immer: "npm:^9.0.6"
     uuid: "npm:^8.3.2"
   checksum: cc3751205de1514333a99a638fc6fa7bdaa7fac505e32531fb1a71af5e9839e994de79c59ab91b08bdc8d3fbb4bb17330a677adf75754e5f56745d6d68e56515
+  languageName: node
+  linkType: hard
+
+"@metamask/network-controller@npm:^18.1.1":
+  version: 18.1.1
+  resolution: "@metamask/network-controller@npm:18.1.1"
+  dependencies:
+    "@metamask/base-controller": "npm:^5.0.2"
+    "@metamask/controller-utils": "npm:^9.1.0"
+    "@metamask/eth-json-rpc-infura": "npm:^9.1.0"
+    "@metamask/eth-json-rpc-middleware": "npm:^12.1.0"
+    "@metamask/eth-json-rpc-provider": "npm:^3.0.2"
+    "@metamask/eth-query": "npm:^4.0.0"
+    "@metamask/json-rpc-engine": "npm:^8.0.2"
+    "@metamask/rpc-errors": "npm:^6.2.1"
+    "@metamask/swappable-obj-proxy": "npm:^2.2.0"
+    "@metamask/utils": "npm:^8.3.0"
+    async-mutex: "npm:^0.2.6"
+    eth-block-tracker: "npm:^8.0.0"
+    immer: "npm:^9.0.6"
+    uuid: "npm:^8.3.2"
+  checksum: 1542b223851df1b316e5c5387712356dbbd84b6acd10b221d9802e5699a5d6baf6f1065da784fe0a2663b3843f82ce92270f94244e1d68f83aa3978e6c7ed76d
   languageName: node
   linkType: hard
 
@@ -5841,7 +5863,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/transaction-controller@npm:^28.1.0, @metamask/transaction-controller@npm:^28.1.1":
+"@metamask/transaction-controller@npm:^28.1.0":
   version: 28.1.1
   resolution: "@metamask/transaction-controller@npm:28.1.1"
   dependencies:
@@ -5873,6 +5895,41 @@ __metadata:
     "@metamask/gas-fee-controller": ^15.0.0
     "@metamask/network-controller": ^18.0.0
   checksum: 01e6f0e1431e56cc0ef986cbfa99cf37e0a44aade14419c69d815be77847bb33b43049b90c6e6961bb5070ecfe1420c893db8a68c0fd6977d5ec28d9853d6554
+  languageName: node
+  linkType: hard
+
+"@metamask/transaction-controller@npm:^29.0.2":
+  version: 29.1.0
+  resolution: "@metamask/transaction-controller@npm:29.1.0"
+  dependencies:
+    "@ethereumjs/common": "npm:^3.2.0"
+    "@ethereumjs/tx": "npm:^4.2.0"
+    "@ethereumjs/util": "npm:^8.1.0"
+    "@ethersproject/abi": "npm:^5.7.0"
+    "@ethersproject/contracts": "npm:^5.7.0"
+    "@ethersproject/providers": "npm:^5.7.0"
+    "@metamask/approval-controller": "npm:^6.0.2"
+    "@metamask/base-controller": "npm:^5.0.2"
+    "@metamask/controller-utils": "npm:^9.1.0"
+    "@metamask/eth-query": "npm:^4.0.0"
+    "@metamask/gas-fee-controller": "npm:^15.1.2"
+    "@metamask/metamask-eth-abis": "npm:^3.1.1"
+    "@metamask/network-controller": "npm:^18.1.1"
+    "@metamask/rpc-errors": "npm:^6.2.1"
+    "@metamask/utils": "npm:^8.3.0"
+    async-mutex: "npm:^0.2.6"
+    bn.js: "npm:^5.2.1"
+    eth-method-registry: "npm:^4.0.0"
+    fast-json-patch: "npm:^3.1.1"
+    lodash: "npm:^4.17.21"
+    nonce-tracker: "npm:^3.0.0"
+    uuid: "npm:^8.3.2"
+  peerDependencies:
+    "@babel/runtime": ^7.23.9
+    "@metamask/approval-controller": ^6.0.0
+    "@metamask/gas-fee-controller": ^15.0.0
+    "@metamask/network-controller": ^18.0.0
+  checksum: 4b96d17d0bcc0f13ac72a94a3b4f3c3dd0f31a13aa6ae74b343ebe2d77e9aeb636b28c14ab23f08c6d8c6b66158c93f34243cf551f4c12d06b4ea8e87ae4ae64
   languageName: node
   linkType: hard
 
@@ -24836,7 +24893,7 @@ __metadata:
     "@metamask/snaps-utils": "npm:7.2.0"
     "@metamask/test-bundler": "npm:^1.0.0"
     "@metamask/test-dapp": "npm:^8.4.0"
-    "@metamask/transaction-controller": "npm:^28.1.1"
+    "@metamask/transaction-controller": "npm:^29.0.2"
     "@metamask/user-operation-controller": "npm:^6.0.0"
     "@metamask/utils": "npm:^8.2.1"
     "@ngraveio/bc-ur": "npm:^1.1.12"


### PR DESCRIPTION
cherry-pick – chore: bump transaction-controller to 29.0.2 637c0f3a088c1ed92756a50d9bd7f8b59fce1cff (#24701) into v11.16.0

Notes:
* Dan ran 
  1. git cherry-pick 637c0f3
  1. git checkout HEAD -- yarn.lock (so that now there is no diff with yarn.lock)
  1. manually fixed the conflict in package.json
  1. yarn && yarn dedupe
* Merge conflicts in package.json: 

```json
    "@metamask/signature-controller": "^12.0.0",
    "@metamask/smart-transactions-controller": "^10.0.1",
<<<<<<< HEAD
    "@metamask/snaps-controllers": "8.0.0",
    "@metamask/snaps-execution-environments": "6.0.2",
    "@metamask/snaps-rpc-methods": "8.0.0",
    "@metamask/snaps-sdk": "4.0.1",
    "@metamask/snaps-utils": "7.2.0",
    "@metamask/transaction-controller": "^28.1.1",
    "@metamask/user-operation-controller": "^6.0.0",
=======
    "@metamask/snaps-controllers": "^8.1.1",
    "@metamask/snaps-execution-environments": "^6.1.0",
    "@metamask/snaps-rpc-methods": "^9.0.0",
    "@metamask/snaps-sdk": "^4.2.0",
    "@metamask/snaps-utils": "^7.4.0",
    "@metamask/transaction-controller": "^29.0.2",
    "@metamask/user-operation-controller": "^8.0.1",
>>>>>>> 637c0f3a08 (chore: bump transaction-controller to 29.0.2 (#24701))
    "@metamask/utils": "^8.2.1",
    "@ngraveio/bc-ur": "^1.1.12",
```