### PR TITLE
fix: flaky test flaky `Request Queuing for Multiple Dapps and Txs on different networks. should switch to the dapps network automatically when handling sendTransaction calls`

### DIFF
--- a/test/e2e/tests/request-queuing/ui.spec.js
+++ b/test/e2e/tests/request-queuing/ui.spec.js
@@ -65,6 +65,7 @@ async function openDappAndSwitchChain(driver, dappUrl, chainId) {
 async function selectDappClickSendGetNetwork(driver, dappUrl) {
   await driver.switchToWindowWithUrl(dappUrl);
   const currentWindowHandles = await driver.getAllWindowHandles();
+  const expectedWindowHandles = 3;
   await driver.clickElement('#sendButton');
 
   // Under mv3, we don't need to add to the current number of window handles
@@ -72,8 +73,8 @@ async function selectDappClickSendGetNetwork(driver, dappUrl) {
   // an extra window handle
   const newWindowHandles = await driver.waitUntilXWindowHandles(
     process.env.ENABLE_MV3
-      ? currentWindowHandles.length
-      : currentWindowHandles.length + 1,
+      ? expectedWindowHandles
+      : expectedWindowHandles + 1,
   );
   const [newNotificationWindowHandle] = newWindowHandles.filter(
     (h) => !currentWindowHandles.includes(h),

--- a/test/e2e/tests/request-queuing/ui.spec.js
+++ b/test/e2e/tests/request-queuing/ui.spec.js
@@ -72,9 +72,7 @@ async function selectDappClickSendGetNetwork(driver, dappUrl) {
   // because the offscreen document returned by getAllWindowHandles provides
   // an extra window handle
   const newWindowHandles = await driver.waitUntilXWindowHandles(
-    process.env.ENABLE_MV3
-      ? expectedWindowHandles
-      : expectedWindowHandles + 1,
+    process.env.ENABLE_MV3 ? expectedWindowHandles : expectedWindowHandles + 1,
   );
   const [newNotificationWindowHandle] = newWindowHandles.filter(
     (h) => !currentWindowHandles.includes(h),

--- a/test/e2e/tests/request-queuing/ui.spec.js
+++ b/test/e2e/tests/request-queuing/ui.spec.js
@@ -64,15 +64,19 @@ async function openDappAndSwitchChain(driver, dappUrl, chainId) {
 
 async function selectDappClickSendGetNetwork(driver, dappUrl) {
   await driver.switchToWindowWithUrl(dappUrl);
-  const currentWindowHandles = await driver.getAllWindowHandles();
+  // Windows: MetaMask, TestDapp1, TestDapp2
   const expectedWindowHandles = 3;
+  await driver.waitUntilXWindowHandles(expectedWindowHandles);
+  const currentWindowHandles = await driver.getAllWindowHandles();
   await driver.clickElement('#sendButton');
 
   // Under mv3, we don't need to add to the current number of window handles
   // because the offscreen document returned by getAllWindowHandles provides
   // an extra window handle
   const newWindowHandles = await driver.waitUntilXWindowHandles(
-    process.env.ENABLE_MV3 ? expectedWindowHandles : expectedWindowHandles + 1,
+    process.env.ENABLE_MV3
+      ? currentWindowHandles.length
+      : currentWindowHandles.length + 1,
   );
   const [newNotificationWindowHandle] = newWindowHandles.filter(
     (h) => !currentWindowHandles.includes(h),


### PR DESCRIPTION
## **Description**
This PR fixes the flaky test `Request Queuing for Multiple Dapps and Txs on different networks. should switch to the dapps network automatically when handling sendTransaction calls `.

The problem is that sometimes when we call the  `const currentWindowHandles = await driver.getAllWindowHandles` there is still the previous popup open, meaning that we get the total count of 4 windows.

Right after that, we trigger a send `await driver.clickElement('#sendButton');` and now we wait for the windowHandles to be `currentWindowHandles + 1` meaning we wait until we have 5 windows. However this will never happen as we should wait for 4 windows instead, but the previous windowCount was considering the previous popup, resulting in 1 more window in total.

```
  const currentWindowHandles = await driver.getAllWindowHandles();
  await driver.clickElement('#sendButton');
  const newWindowHandles = await driver.waitUntilXWindowHandles(
    process.env.ENABLE_MV3
      ? currentWindowHandles.length
      : currentWindowHandles.length + 1,
```

The proposed fix is to hardcode the expect number of windows directly, as we know how many there should be and we do this in the majority of the tests. There could be alternative approaches,
- wait for a condition: though in this case the condition of having switched networks is already met in the wallet, so there doesn't seem to be another condition to wait for :thinking: 
- add a delay



## **Related issues**

Fixes: the third item of this list https://github.com/MetaMask/metamask-extension/issues/24603

## **Manual testing steps**

1. Run the test several times `yarn test:e2e:single test/e2e/tests/request-queuing/ui.spec.js --browser=chrome --leave-running --retryUntilFailure --retries=10`
2. Check ci jobs

## **Screenshots/Recordings**
See how at one point, we get current windows as 4 (we expected 3) because the popup was still not closed and the next time we trigger a tx, we would expect 4+1, which will never happen.

https://github.com/MetaMask/metamask-extension/assets/54408225/a3eb7f74-cf2c-43ba-a5bb-0835544b448c




## **Pre-merge author checklist**

- [X] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
