### PR TITLE
feat: Implement the "Manage in settings" variation for the STX Opt In modal

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -1535,9 +1535,6 @@
   "done": {
     "message": "Done"
   },
-  "dontEnableEnhancedProtection": {
-    "message": "Don't enable enhanced protection"
-  },
   "dontShowThisAgain": {
     "message": "Don't show this again"
   },
@@ -2618,6 +2615,9 @@
   "makeSureNoOneWatching": {
     "message": "Make sure nobody is looking",
     "description": "Warning to users to be care while creating and saving their new Secret Recovery Phrase"
+  },
+  "manageInSettings": {
+    "message": "Manage in settings"
   },
   "max": {
     "message": "Max"
@@ -5185,7 +5185,7 @@
     "description": "This message is shown to a user if their swap fails. The $1 will be replaced by support.metamask.io"
   },
   "stxOptInDescription": {
-    "message": "Turn on Smart Transactions for more reliable and secure transactions on ETH Mainnet. $1"
+    "message": "Turn on Smart Transactions for more reliable and secure transactions on Ethereum Mainnet. $1"
   },
   "stxPendingPrivatelySubmittingSwap": {
     "message": "Privately submitting your Swap..."

--- a/test/e2e/mmi/pageObjects/mmi-signup-page.ts
+++ b/test/e2e/mmi/pageObjects/mmi-signup-page.ts
@@ -13,7 +13,7 @@ export class MMISignUpPage {
 
   readonly agreeBtn: Locator;
 
-  readonly noThanksBtn: Locator;
+  readonly enableBtn: Locator;
 
   readonly passwordTxt: Locator;
 
@@ -44,9 +44,7 @@ export class MMISignUpPage {
       'button:has-text("Confirm Secret Recovery Phrase")',
     );
     this.agreeBtn = page.locator('button:has-text("I agree")');
-    this.noThanksBtn = page.locator(
-      'button:has-text("Don\'t enable enhanced protection")',
-    );
+    this.enableBtn = page.locator('button:has-text("Enable")'); // It shows in the Smart Transactions Opt-In Modal.
     this.passwordTxt = page.getByTestId('create-password-new');
     this.passwordConfirmTxt = page.getByTestId('create-password-confirm');
     this.agreeCheck = page.getByTestId('create-new-vault__terms-checkbox');

--- a/test/e2e/vault-decryption-chrome.spec.js
+++ b/test/e2e/vault-decryption-chrome.spec.js
@@ -50,12 +50,13 @@ async function getExtensionStorageFilePath(driver) {
  */
 async function closePopoverIfPresent(driver) {
   const popoverButtonSelector = '[data-testid="popover-close"]';
-  const linkNoThanks = {
-    text: "Don't enable enhanced protection",
+  // It shows in the Smart Transactions Opt-In Modal.
+  const enableButtonSelector = {
+    text: 'Enable',
     tag: 'button',
   };
   await driver.clickElementSafe(popoverButtonSelector);
-  await driver.clickElementSafe(linkNoThanks);
+  await driver.clickElementSafe(enableButtonSelector);
 }
 
 /**

--- a/ui/components/app/smart-transactions/__snapshots__/smart-transactions-opt-in-modal.test.tsx.snap
+++ b/ui/components/app/smart-transactions/__snapshots__/smart-transactions-opt-in-modal.test.tsx.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SmartTransactionsOptInModal displays the correct text in the modal 1`] = `<div />`;

--- a/ui/components/app/smart-transactions/smart-transactions-opt-in-modal.test.tsx
+++ b/ui/components/app/smart-transactions/smart-transactions-opt-in-modal.test.tsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import { fireEvent } from '@testing-library/react';
+import thunk from 'redux-thunk';
+import configureMockStore from 'redux-mock-store';
+import { useHistory } from 'react-router-dom';
+
+import {
+  renderWithProvider,
+  createSwapsMockStore,
+} from '../../../../test/jest';
+import SmartTransactionsOptInModal from './smart-transactions-opt-in-modal';
+import { setSmartTransactionsOptInStatus } from '../../../store/actions';
+import { ADVANCED_ROUTE } from '../../../helpers/constants/routes';
+
+const middleware = [thunk];
+
+jest.mock('../../../store/actions');
+
+describe('SmartTransactionsOptInModal', () => {
+  it('displays the correct text in the modal', () => {
+    const store = configureMockStore(middleware)(createSwapsMockStore());
+    const { getByText, container } = renderWithProvider(
+      <SmartTransactionsOptInModal
+        isOpen={true}
+        hideWhatsNewPopup={() => {}}
+      />,
+      store,
+    );
+    expect(getByText('Enable')).toBeInTheDocument();
+    expect(getByText('Manage in settings')).toBeInTheDocument();
+    expect(container).toMatchSnapshot();
+  });
+
+  it('calls setSmartTransactionsOptInStatus with false when the "Manage in settings" link is clicked and redirects to Advanced Settings', () => {
+    (setSmartTransactionsOptInStatus as jest.Mock).mockImplementationOnce(() =>
+      jest.fn(),
+    );
+    const historyPushMock = jest.fn();
+    (useHistory as jest.Mock).mockImplementationOnce(() => ({
+      push: historyPushMock,
+    }));
+    const store = configureMockStore(middleware)(createSwapsMockStore());
+    const { getByText } = renderWithProvider(
+      <SmartTransactionsOptInModal
+        isOpen={true}
+        hideWhatsNewPopup={() => {}}
+      />,
+      store,
+    );
+    const manageInSettingsLink = getByText('Manage in settings');
+    fireEvent.click(manageInSettingsLink);
+    expect(setSmartTransactionsOptInStatus).toHaveBeenCalledWith(false);
+    expect(historyPushMock).toHaveBeenCalledWith(
+      `${ADVANCED_ROUTE}#smart-transactions`,
+    );
+  });
+
+  it('calls setSmartTransactionsOptInStatus with true when the "Enable" button is clicked', () => {
+    (setSmartTransactionsOptInStatus as jest.Mock).mockImplementationOnce(() =>
+      jest.fn(),
+    );
+    const store = configureMockStore(middleware)(createSwapsMockStore());
+    const { getByText } = renderWithProvider(
+      <SmartTransactionsOptInModal
+        isOpen={true}
+        hideWhatsNewPopup={() => {}}
+      />,
+      store,
+    );
+    const enableButton = getByText('Enable');
+    fireEvent.click(enableButton);
+    expect(setSmartTransactionsOptInStatus).toHaveBeenCalledWith(true);
+  });
+});

--- a/ui/components/app/smart-transactions/smart-transactions-opt-in-modal.test.tsx
+++ b/ui/components/app/smart-transactions/smart-transactions-opt-in-modal.test.tsx
@@ -8,9 +8,9 @@ import {
   renderWithProvider,
   createSwapsMockStore,
 } from '../../../../test/jest';
-import SmartTransactionsOptInModal from './smart-transactions-opt-in-modal';
 import { setSmartTransactionsOptInStatus } from '../../../store/actions';
 import { ADVANCED_ROUTE } from '../../../helpers/constants/routes';
+import SmartTransactionsOptInModal from './smart-transactions-opt-in-modal';
 
 const middleware = [thunk];
 
@@ -22,7 +22,7 @@ describe('SmartTransactionsOptInModal', () => {
     const { getByText, container } = renderWithProvider(
       <SmartTransactionsOptInModal
         isOpen={true}
-        hideWhatsNewPopup={() => {}}
+        hideWhatsNewPopup={jest.fn()}
       />,
       store,
     );
@@ -43,7 +43,7 @@ describe('SmartTransactionsOptInModal', () => {
     const { getByText } = renderWithProvider(
       <SmartTransactionsOptInModal
         isOpen={true}
-        hideWhatsNewPopup={() => {}}
+        hideWhatsNewPopup={jest.fn()}
       />,
       store,
     );
@@ -63,7 +63,7 @@ describe('SmartTransactionsOptInModal', () => {
     const { getByText } = renderWithProvider(
       <SmartTransactionsOptInModal
         isOpen={true}
-        hideWhatsNewPopup={() => {}}
+        hideWhatsNewPopup={jest.fn()}
       />,
       store,
     );

--- a/ui/components/app/smart-transactions/smart-transactions-opt-in-modal.tsx
+++ b/ui/components/app/smart-transactions/smart-transactions-opt-in-modal.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useEffect } from 'react';
+import { useHistory } from 'react-router-dom';
 import { useDispatch } from 'react-redux';
 
 import { useI18nContext } from '../../../hooks/useI18nContext';
@@ -30,6 +31,7 @@ import {
 } from '../../component-library';
 import { setSmartTransactionsOptInStatus } from '../../../store/actions';
 import { SMART_TRANSACTIONS_LEARN_MORE_URL } from '../../../../shared/constants/smartTransactions';
+import { ADVANCED_ROUTE } from '../../../helpers/constants/routes';
 
 export type SmartTransactionsOptInModalProps = {
   isOpen: boolean;
@@ -89,7 +91,7 @@ const NoThanksLink = ({
       width={BlockSize.Full}
       className="mm-smart-transactions-opt-in-modal__no-thanks-link"
     >
-      {t('dontEnableEnhancedProtection')}
+      {t('manageInSettings')}
     </Button>
   );
 };
@@ -164,6 +166,7 @@ export default function SmartTransactionsOptInModal({
 }: SmartTransactionsOptInModalProps) {
   const t = useI18nContext();
   const dispatch = useDispatch();
+  const history = useHistory();
 
   const handleEnableButtonClick = useCallback(() => {
     dispatch(setSmartTransactionsOptInStatus(true));
@@ -171,6 +174,7 @@ export default function SmartTransactionsOptInModal({
 
   const handleNoThanksLinkClick = useCallback(() => {
     dispatch(setSmartTransactionsOptInStatus(false));
+    history.push(`${ADVANCED_ROUTE}#smart-transactions`);
   }, [dispatch]);
 
   useEffect(() => {

--- a/ui/components/app/smart-transactions/smart-transactions-opt-in-modal.tsx
+++ b/ui/components/app/smart-transactions/smart-transactions-opt-in-modal.tsx
@@ -75,10 +75,10 @@ const EnableSmartTransactionsButton = ({
   );
 };
 
-const NoThanksLink = ({
-  handleNoThanksLinkClick,
+const ManageInSettingsLink = ({
+  handleManageInSettingsLinkClick,
 }: {
-  handleNoThanksLinkClick: () => void;
+  handleManageInSettingsLinkClick: () => void;
 }) => {
   const t = useI18nContext();
   return (
@@ -87,7 +87,7 @@ const NoThanksLink = ({
       type="link"
       variant={ButtonVariant.Link}
       color={TextColor.textAlternative}
-      onClick={handleNoThanksLinkClick}
+      onClick={handleManageInSettingsLinkClick}
       width={BlockSize.Full}
       className="mm-smart-transactions-opt-in-modal__no-thanks-link"
     >
@@ -172,7 +172,8 @@ export default function SmartTransactionsOptInModal({
     dispatch(setSmartTransactionsOptInStatus(true));
   }, [dispatch]);
 
-  const handleNoThanksLinkClick = useCallback(() => {
+  const handleManageInSettingsLinkClick = useCallback(() => {
+    // Set the Smart Transactions opt-in status to false, so the opt-in modal is not shown again.
     dispatch(setSmartTransactionsOptInStatus(false));
     history.push(`${ADVANCED_ROUTE}#smart-transactions`);
   }, [dispatch]);
@@ -214,7 +215,9 @@ export default function SmartTransactionsOptInModal({
           <EnableSmartTransactionsButton
             handleEnableButtonClick={handleEnableButtonClick}
           />
-          <NoThanksLink handleNoThanksLinkClick={handleNoThanksLinkClick} />
+          <ManageInSettingsLink
+            handleManageInSettingsLinkClick={handleManageInSettingsLinkClick}
+          />
         </Box>
       </ModalContent>
     </Modal>

--- a/ui/pages/settings/advanced-tab/__snapshots__/advanced-tab.component.test.js.snap
+++ b/ui/pages/settings/advanced-tab/__snapshots__/advanced-tab.component.test.js.snap
@@ -80,7 +80,7 @@ exports[`AdvancedTab Component should match snapshot 1`] = `
         >
           <span>
              
-            Turn on Smart Transactions for more reliable and secure transactions on ETH Mainnet. 
+            Turn on Smart Transactions for more reliable and secure transactions on Ethereum Mainnet. 
             <a
               class="mm-box mm-text mm-button-base mm-button-link mm-button-link--size-inherit mm-text--body-md-medium mm-box--padding-0 mm-box--padding-right-0 mm-box--padding-left-0 mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-primary-default mm-box--background-color-transparent"
               href="https://support.metamask.io/transactions-and-gas/transactions/smart-transactions/"


### PR DESCRIPTION
## **Description**

Slight variation for the STX Opt In modal: Add a link to "Manage in settings"

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/24771?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Install the extension from scratch
2. After the initial setup you will see the STX Opt In modal
3. It will show the "Manage in settings" link. After clicking on it we opt out a user from Smart Transactions, but they will be redirected to Advanced Settings, where they can turn it on if they want or just close the Settings

## **Screenshots/Recordings**

STX Opt In modal:
![image](https://github.com/MetaMask/metamask-extension/assets/80175477/36d061fe-a24e-4d48-a13d-98673b582ce0)

Advanced Settings with STX:
![image](https://github.com/MetaMask/metamask-extension/assets/80175477/6831a84d-2461-430f-a8c7-bc5b100f7a35)


## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
