### PR TITLE
feat: Add new content on the STX status page

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -820,6 +820,9 @@
   "closeExtension": {
     "message": "Close extension"
   },
+  "closeWindowAnytime": {
+    "message": "You may close this window anytime."
+  },
   "coingecko": {
     "message": "CoinGecko"
   },
@@ -6221,7 +6224,7 @@
     "message": "View on Opensea"
   },
   "viewTransaction": {
-    "message": "View  transaction"
+    "message": "View transaction"
   },
   "viewinCustodianApp": {
     "message": "View in custodian app"

--- a/ui/pages/smart-transactions/smart-transaction-status-page/__snapshots__/smart-transactions-status-page.test.js.snap
+++ b/ui/pages/smart-transactions/smart-transaction-status-page/__snapshots__/smart-transactions-status-page.test.js.snap
@@ -124,7 +124,7 @@ exports[`SmartTransactionStatusPage renders the "cancelled" STX status 1`] = `
             class="mm-box mm-text mm-button-base mm-button-link mm-button-link--size-auto mm-text--body-md-medium mm-box--padding-0 mm-box--padding-right-0 mm-box--padding-left-0 mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-primary-default mm-box--background-color-transparent"
             type="link"
           >
-            View  transaction
+            View transaction
           </button>
         </div>
       </div>
@@ -140,6 +140,73 @@ exports[`SmartTransactionStatusPage renders the "cancelled" STX status 1`] = `
         data-testid="smart-transaction-status-page-footer-close-button"
       >
         View activity
+      </button>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`SmartTransactionStatusPage renders the "cancelled" STX status for a dapp transaction 1`] = `
+<div>
+  <div
+    class="mm-box smart-transaction-status-page mm-box--margin-bottom-0 mm-box--display-flex mm-box--flex-direction-column mm-box--align-items-center mm-box--width-full mm-box--height-full mm-box--border-style-none"
+  >
+    <div
+      class="mm-box mm-box--padding-right-4 mm-box--padding-left-4 mm-box--display-flex mm-box--flex-direction-column mm-box--justify-content-center mm-box--align-items-center mm-box--width-full"
+      style="flex-grow: 1;"
+    >
+      <div
+        class="mm-box mm-box--padding-right-6 mm-box--padding-left-6 mm-box--display-flex mm-box--flex-direction-column mm-box--align-items-center mm-box--width-full"
+      >
+        <div
+          class="mm-box smart-transaction-status-page__background-animation smart-transaction-status-page__background-animation--top mm-box--margin-top-3"
+        />
+        <div
+          class="mm-box mm-box--display-flex"
+          style="font-size: 48px;"
+        >
+          <span
+            class="mm-box mm-icon mm-icon--size-inherit mm-box--margin-bottom-4 mm-box--display-inline-block mm-box--color-error-default"
+            style="mask-image: url('./images/icons/danger.svg');"
+          />
+        </div>
+        <h4
+          class="mm-box mm-text mm-text--heading-md mm-text--font-weight-bold mm-box--color-text-default"
+        >
+          Your transaction was canceled
+        </h4>
+        <div
+          class="mm-box smart-transaction-status-page__description mm-box--display-flex mm-box--flex-direction-column mm-box--align-items-center"
+        >
+          <p
+            class="mm-box mm-text mm-text--body-sm mm-box--margin-top-2 mm-box--color-text-alternative"
+          >
+            Your transaction couldn't be completed, so it was canceled to save you from paying unnecessary gas fees.
+          </p>
+        </div>
+        <div
+          class="mm-box mm-box--margin-top-2 mm-box--display-flex mm-box--flex-direction-column"
+        >
+          <button
+            class="mm-box mm-text mm-button-base mm-button-link mm-button-link--size-auto mm-text--body-md-medium mm-box--padding-0 mm-box--padding-right-0 mm-box--padding-left-0 mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-primary-default mm-box--background-color-transparent"
+            type="link"
+          >
+            View transaction
+          </button>
+        </div>
+      </div>
+      <div
+        class="mm-box smart-transaction-status-page__background-animation smart-transaction-status-page__background-animation--bottom mm-box--margin-top-3"
+      />
+    </div>
+    <div
+      class="mm-box smart-transaction-status-page__footer mm-box--padding-4 mm-box--padding-bottom-0 mm-box--display-flex mm-box--flex-direction-column mm-box--width-full"
+    >
+      <button
+        class="mm-box mm-text mm-button-base mm-button-base--size-md mm-button-secondary mm-text--body-md-medium mm-box--margin-top-3 mm-box--padding-0 mm-box--padding-right-4 mm-box--padding-left-4 mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--width-full mm-box--color-primary-default mm-box--background-color-transparent mm-box--rounded-pill mm-box--border-color-primary-default box--border-style-solid box--border-width-1"
+        data-testid="smart-transaction-status-page-footer-close-button"
+      >
+        Close extension
       </button>
     </div>
   </div>
@@ -191,7 +258,7 @@ exports[`SmartTransactionStatusPage renders the "deadline_missed" STX status 1`]
             class="mm-box mm-text mm-button-base mm-button-link mm-button-link--size-auto mm-text--body-md-medium mm-box--padding-0 mm-box--padding-right-0 mm-box--padding-left-0 mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-primary-default mm-box--background-color-transparent"
             type="link"
           >
-            View  transaction
+            View transaction
           </button>
         </div>
       </div>
@@ -208,6 +275,94 @@ exports[`SmartTransactionStatusPage renders the "deadline_missed" STX status 1`]
       >
         View activity
       </button>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`SmartTransactionStatusPage renders the "pending" STX status for a dapp transaction 1`] = `
+<div>
+  <div
+    class="mm-box smart-transaction-status-page mm-box--margin-bottom-0 mm-box--display-flex mm-box--flex-direction-column mm-box--align-items-center mm-box--width-full mm-box--height-full mm-box--border-style-none"
+  >
+    <div
+      class="mm-box mm-box--padding-right-4 mm-box--padding-left-4 mm-box--display-flex mm-box--flex-direction-column mm-box--justify-content-center mm-box--align-items-center mm-box--width-full"
+      style="flex-grow: 1;"
+    >
+      <div
+        class="mm-box mm-box--padding-right-6 mm-box--padding-left-6 mm-box--display-flex mm-box--flex-direction-column mm-box--align-items-center mm-box--width-full"
+      >
+        <div
+          class="mm-box smart-transaction-status-page__background-animation smart-transaction-status-page__background-animation--top mm-box--margin-top-3"
+        />
+        <div
+          class="mm-box mm-box--display-flex"
+          style="font-size: 48px;"
+        >
+          <span
+            class="mm-box mm-icon mm-icon--size-inherit mm-box--margin-bottom-4 mm-box--display-inline-block mm-box--color-primary-default"
+            style="mask-image: url('./images/icons/clock.svg');"
+          />
+        </div>
+        <h4
+          class="mm-box mm-text mm-text--heading-md mm-text--font-weight-bold mm-box--color-text-default"
+        >
+          Submitting your transaction
+        </h4>
+        <div
+          class="mm-box mm-box--display-flex mm-box--flex-direction-column mm-box--align-items-center mm-box--width-full"
+        >
+          <div
+            class="smart-transaction-status-page__loading-bar-container"
+          >
+            <div
+              class="smart-transaction-status-page__loading-bar"
+              style="width: 0%;"
+            />
+          </div>
+        </div>
+        <div
+          class="mm-box smart-transaction-status-page__description mm-box--display-flex mm-box--flex-direction-column mm-box--align-items-center"
+        >
+          <p
+            class="mm-box mm-text mm-text--body-sm mm-box--margin-top-2 mm-box--color-text-alternative"
+          >
+            <span>
+               
+              Estimated completion in &lt; 
+              <p
+                class="mm-box mm-text smart-transaction-status-page__countdown mm-text--body-sm mm-text--text-align-center mm-box--display-inline-block mm-box--color-text-alternative"
+              >
+                0:45
+              </p>
+              
+               
+            </span>
+          </p>
+        </div>
+        <div
+          class="mm-box mm-box--margin-top-2 mm-box--display-flex mm-box--flex-direction-column"
+        >
+          <button
+            class="mm-box mm-text mm-button-base mm-button-link mm-button-link--size-auto mm-text--body-md-medium mm-box--padding-0 mm-box--padding-right-0 mm-box--padding-left-0 mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-primary-default mm-box--background-color-transparent"
+            type="link"
+          >
+            View transaction
+          </button>
+        </div>
+      </div>
+      <div
+        class="mm-box smart-transaction-status-page__background-animation smart-transaction-status-page__background-animation--bottom mm-box--margin-top-3"
+      />
+    </div>
+    <div
+      class="mm-box smart-transaction-status-page__footer mm-box--padding-4 mm-box--padding-bottom-0 mm-box--display-flex mm-box--flex-direction-column mm-box--width-full"
+    >
+      <p
+        class="mm-box mm-text mm-text--body-sm mm-box--margin-top-2 mm-box--color-text-alternative"
+      >
+        You may close this window anytime.
+      </p>
     </div>
   </div>
 </div>
@@ -258,7 +413,7 @@ exports[`SmartTransactionStatusPage renders the "reverted" STX status 1`] = `
             class="mm-box mm-text mm-button-base mm-button-link mm-button-link--size-auto mm-text--body-md-medium mm-box--padding-0 mm-box--padding-right-0 mm-box--padding-left-0 mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-primary-default mm-box--background-color-transparent"
             type="link"
           >
-            View  transaction
+            View transaction
           </button>
         </div>
       </div>
@@ -316,7 +471,7 @@ exports[`SmartTransactionStatusPage renders the "success" STX status 1`] = `
             class="mm-box mm-text mm-button-base mm-button-link mm-button-link--size-auto mm-text--body-md-medium mm-box--padding-0 mm-box--padding-right-0 mm-box--padding-left-0 mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-primary-default mm-box--background-color-transparent"
             type="link"
           >
-            View  transaction
+            View transaction
           </button>
         </div>
       </div>
@@ -332,6 +487,64 @@ exports[`SmartTransactionStatusPage renders the "success" STX status 1`] = `
         data-testid="smart-transaction-status-page-footer-close-button"
       >
         View activity
+      </button>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`SmartTransactionStatusPage renders the "success" STX status for a dapp transaction 1`] = `
+<div>
+  <div
+    class="mm-box smart-transaction-status-page mm-box--margin-bottom-0 mm-box--display-flex mm-box--flex-direction-column mm-box--align-items-center mm-box--width-full mm-box--height-full mm-box--border-style-none"
+  >
+    <div
+      class="mm-box mm-box--padding-right-4 mm-box--padding-left-4 mm-box--display-flex mm-box--flex-direction-column mm-box--justify-content-center mm-box--align-items-center mm-box--width-full"
+      style="flex-grow: 1;"
+    >
+      <div
+        class="mm-box mm-box--padding-right-6 mm-box--padding-left-6 mm-box--display-flex mm-box--flex-direction-column mm-box--align-items-center mm-box--width-full"
+      >
+        <div
+          class="mm-box smart-transaction-status-page__background-animation smart-transaction-status-page__background-animation--top mm-box--margin-top-3"
+        />
+        <div
+          class="mm-box mm-box--display-flex"
+          style="font-size: 48px;"
+        >
+          <span
+            class="mm-box mm-icon mm-icon--size-inherit mm-box--margin-bottom-4 mm-box--display-inline-block mm-box--color-success-default"
+            style="mask-image: url('./images/icons/confirmation.svg');"
+          />
+        </div>
+        <h4
+          class="mm-box mm-text mm-text--heading-md mm-text--font-weight-bold mm-box--color-text-default"
+        >
+          Your transaction is complete
+        </h4>
+        <div
+          class="mm-box mm-box--margin-top-2 mm-box--display-flex mm-box--flex-direction-column"
+        >
+          <button
+            class="mm-box mm-text mm-button-base mm-button-link mm-button-link--size-auto mm-text--body-md-medium mm-box--padding-0 mm-box--padding-right-0 mm-box--padding-left-0 mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-primary-default mm-box--background-color-transparent"
+            type="link"
+          >
+            View transaction
+          </button>
+        </div>
+      </div>
+      <div
+        class="mm-box smart-transaction-status-page__background-animation smart-transaction-status-page__background-animation--bottom mm-box--margin-top-3"
+      />
+    </div>
+    <div
+      class="mm-box smart-transaction-status-page__footer mm-box--padding-4 mm-box--padding-bottom-0 mm-box--display-flex mm-box--flex-direction-column mm-box--width-full"
+    >
+      <button
+        class="mm-box mm-text mm-button-base mm-button-base--size-md mm-button-secondary mm-text--body-md-medium mm-box--margin-top-3 mm-box--padding-0 mm-box--padding-right-4 mm-box--padding-left-4 mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--width-full mm-box--color-primary-default mm-box--background-color-transparent mm-box--rounded-pill mm-box--border-color-primary-default box--border-style-solid box--border-width-1"
+        data-testid="smart-transaction-status-page-footer-close-button"
+      >
+        Close extension
       </button>
     </div>
   </div>
@@ -383,7 +596,7 @@ exports[`SmartTransactionStatusPage renders the "unknown" STX status 1`] = `
             class="mm-box mm-text mm-button-base mm-button-link mm-button-link--size-auto mm-text--body-md-medium mm-box--padding-0 mm-box--padding-right-0 mm-box--padding-left-0 mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-primary-default mm-box--background-color-transparent"
             type="link"
           >
-            View  transaction
+            View transaction
           </button>
         </div>
       </div>

--- a/ui/pages/smart-transactions/smart-transaction-status-page/smart-transaction-status-page.tsx
+++ b/ui/pages/smart-transactions/smart-transaction-status-page/smart-transaction-status-page.tsx
@@ -302,6 +302,29 @@ const CloseExtensionButton = ({
   );
 };
 
+const FooterText = ({
+  isDapp,
+  isSmartTransactionPending,
+}: {
+  isDapp: boolean;
+  isSmartTransactionPending: boolean;
+}) => {
+  if (!isDapp || !isSmartTransactionPending) {
+    return null;
+  }
+  const t = useI18nContext();
+
+  return (
+    <Text
+      marginTop={2}
+      color={TextColor.textAlternative}
+      variant={TextVariant.bodySm}
+    >
+      {t('closeWindowAnytime')}
+    </Text>
+  );
+};
+
 const ViewActivityButton = ({
   isDapp,
   onViewActivity,
@@ -346,6 +369,10 @@ const SmartTransactionsStatusPageFooter = ({
       padding={4}
       paddingBottom={0}
     >
+      <FooterText
+        isDapp={isDapp}
+        isSmartTransactionPending={isSmartTransactionPending}
+      />
       <CloseExtensionButton
         isDapp={isDapp}
         isSmartTransactionPending={isSmartTransactionPending}

--- a/ui/pages/smart-transactions/smart-transaction-status-page/smart-transaction-status-page.tsx
+++ b/ui/pages/smart-transactions/smart-transaction-status-page/smart-transaction-status-page.tsx
@@ -240,10 +240,10 @@ const PortfolioSmartTransactionStatusUrl = ({
   isSmartTransactionPending: boolean;
   onCloseExtension: () => void;
 }) => {
+  const t = useI18nContext();
   if (!portfolioSmartTransactionStatusUrl) {
     return null;
   }
-
   const handleViewTransactionLinkClick = useCallback(() => {
     const isWiderThanNotificationWidth = window.innerWidth > NOTIFICATION_WIDTH;
     if (!isSmartTransactionPending || isWiderThanNotificationWidth) {
@@ -257,8 +257,6 @@ const PortfolioSmartTransactionStatusUrl = ({
     onCloseExtension,
     portfolioSmartTransactionStatusUrl,
   ]);
-  const t = useI18nContext();
-
   return (
     <Box
       display={Display.Flex}
@@ -285,11 +283,10 @@ const CloseExtensionButton = ({
   isSmartTransactionPending: boolean;
   onCloseExtension: () => void;
 }) => {
+  const t = useI18nContext();
   if (!isDapp || isSmartTransactionPending) {
     return null;
   }
-  const t = useI18nContext();
-
   return (
     <ButtonSecondary
       data-testid="smart-transaction-status-page-footer-close-button"
@@ -309,11 +306,10 @@ const FooterText = ({
   isDapp: boolean;
   isSmartTransactionPending: boolean;
 }) => {
+  const t = useI18nContext();
   if (!isDapp || !isSmartTransactionPending) {
     return null;
   }
-  const t = useI18nContext();
-
   return (
     <Text
       marginTop={2}
@@ -332,11 +328,10 @@ const ViewActivityButton = ({
   isDapp: boolean;
   onViewActivity: () => void;
 }) => {
+  const t = useI18nContext();
   if (isDapp) {
     return null;
   }
-  const t = useI18nContext();
-
   return (
     <ButtonSecondary
       data-testid="smart-transaction-status-page-footer-close-button"

--- a/ui/pages/smart-transactions/smart-transaction-status-page/smart-transactions-status-page.test.js
+++ b/ui/pages/smart-transactions/smart-transaction-status-page/smart-transactions-status-page.test.js
@@ -39,11 +39,15 @@ describe('SmartTransactionStatusPage', () => {
         creationTime: 1519211809934,
       },
     };
-    const { getByText, container } = renderWithProvider(
+    const { queryByText, container } = renderWithProvider(
       <SmartTransactionStatusPage requestState={newRequestState} />,
       store,
     );
-    expect(getByText('Sorry for the wait')).toBeInTheDocument();
+    expect(
+      queryByText('You may close this window anytime.'),
+    ).not.toBeInTheDocument();
+    expect(queryByText('Sorry for the wait')).toBeInTheDocument();
+    expect(queryByText('View activity')).toBeInTheDocument();
     expect(container).toMatchSnapshot();
   });
 
@@ -61,6 +65,8 @@ describe('SmartTransactionStatusPage', () => {
       store,
     );
     expect(getByText('Your transaction is complete')).toBeInTheDocument();
+    expect(getByText('View transaction')).toBeInTheDocument();
+    expect(getByText('View activity')).toBeInTheDocument();
     expect(container).toMatchSnapshot();
   });
 
@@ -78,6 +84,8 @@ describe('SmartTransactionStatusPage', () => {
       store,
     );
     expect(getByText('Your transaction failed')).toBeInTheDocument();
+    expect(getByText('View transaction')).toBeInTheDocument();
+    expect(getByText('View activity')).toBeInTheDocument();
     expect(
       getByText(
         'Sudden market changes can cause failures. If the problem continues, reach out to MetaMask customer support.',
@@ -105,6 +113,8 @@ describe('SmartTransactionStatusPage', () => {
         `Your transaction couldn't be completed, so it was canceled to save you from paying unnecessary gas fees.`,
       ),
     ).toBeInTheDocument();
+    expect(getByText('View transaction')).toBeInTheDocument();
+    expect(getByText('View activity')).toBeInTheDocument();
     expect(container).toMatchSnapshot();
   });
 
@@ -123,6 +133,8 @@ describe('SmartTransactionStatusPage', () => {
       store,
     );
     expect(getByText('Your transaction was canceled')).toBeInTheDocument();
+    expect(getByText('View transaction')).toBeInTheDocument();
+    expect(getByText('View activity')).toBeInTheDocument();
     expect(container).toMatchSnapshot();
   });
 
@@ -140,6 +152,74 @@ describe('SmartTransactionStatusPage', () => {
       store,
     );
     expect(getByText('Your transaction failed')).toBeInTheDocument();
+    expect(getByText('View transaction')).toBeInTheDocument();
+    expect(getByText('View activity')).toBeInTheDocument();
+    expect(container).toMatchSnapshot();
+  });
+
+  it('renders the "pending" STX status for a dapp transaction', () => {
+    const mockStore = createSwapsMockStore();
+    const latestSmartTransaction =
+      mockStore.metamask.smartTransactionsState.smartTransactions[
+        CHAIN_IDS.MAINNET
+      ][1];
+    latestSmartTransaction.status = SmartTransactionStatuses.PENDING;
+    requestState.smartTransaction = latestSmartTransaction;
+    requestState.isDapp = true;
+    const store = configureMockStore(middleware)(mockStore);
+    const { queryByText, container } = renderWithProvider(
+      <SmartTransactionStatusPage requestState={requestState} />,
+      store,
+    );
+    expect(
+      queryByText('You may close this window anytime.'),
+    ).toBeInTheDocument();
+    expect(queryByText('View transaction')).toBeInTheDocument();
+    expect(queryByText('View activity')).not.toBeInTheDocument();
+    expect(container).toMatchSnapshot();
+  });
+
+  it('renders the "success" STX status for a dapp transaction', () => {
+    const mockStore = createSwapsMockStore();
+    const latestSmartTransaction =
+      mockStore.metamask.smartTransactionsState.smartTransactions[
+        CHAIN_IDS.MAINNET
+      ][1];
+    latestSmartTransaction.status = SmartTransactionStatuses.SUCCESS;
+    requestState.smartTransaction = latestSmartTransaction;
+    requestState.isDapp = true;
+    const store = configureMockStore(middleware)(mockStore);
+    const { queryByText, container } = renderWithProvider(
+      <SmartTransactionStatusPage requestState={requestState} />,
+      store,
+    );
+    expect(
+      queryByText('You may close this window anytime.'),
+    ).not.toBeInTheDocument();
+    expect(queryByText('View transaction')).toBeInTheDocument();
+    expect(queryByText('Close extension')).toBeInTheDocument();
+    expect(container).toMatchSnapshot();
+  });
+
+  it('renders the "cancelled" STX status for a dapp transaction', () => {
+    const mockStore = createSwapsMockStore();
+    const latestSmartTransaction =
+      mockStore.metamask.smartTransactionsState.smartTransactions[
+        CHAIN_IDS.MAINNET
+      ][1];
+    latestSmartTransaction.status = SmartTransactionStatuses.CANCELLED;
+    requestState.smartTransaction = latestSmartTransaction;
+    requestState.isDapp = true;
+    const store = configureMockStore(middleware)(mockStore);
+    const { queryByText, container } = renderWithProvider(
+      <SmartTransactionStatusPage requestState={requestState} />,
+      store,
+    );
+    expect(
+      queryByText('You may close this window anytime.'),
+    ).not.toBeInTheDocument();
+    expect(queryByText('View transaction')).toBeInTheDocument();
+    expect(queryByText('Close extension')).toBeInTheDocument();
     expect(container).toMatchSnapshot();
   });
 });


### PR DESCRIPTION
## **Description**

On the STX status page you will now see this text for a pending dapp transaction: `You may close this window anytime.`

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to a dapp and submit a transaction with STX enabled
2. On the STX status page you will see this text for a pending dapp transaction: `You may close this window anytime.`
3. The text will be replaced with the `Close extension` button when the transaction is not pending anymore

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->


## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
