### PR TITLE
fix: adding missing overlay alternative color to helpers

### DIFF
--- a/ui/components/component-library/box/README.mdx
+++ b/ui/components/component-library/box/README.mdx
@@ -142,9 +142,7 @@ import {
 import Box from '../ui/box';
 
 <Box backgroundColor={BackgroundColor.backgroundDefault}>
-  <Typography color={TextColor.textDefault}>
-    BackgroundColor.backgroundDefault
-  </Typography>
+  <Text color={TextColor.textDefault}>BackgroundColor.backgroundDefault</Text>
 </Box>;
 ```
 
@@ -170,9 +168,7 @@ import Box from '../ui/box';
   backgroundColor={BackgroundColor.backgroundDefault}
   borderColor={BorderColor.borderDefault}
 >
-  <Typography color={TextColor.textDefault}>
-    BorderColor.borderDefault
-  </Typography>
+  <Text color={TextColor.textDefault}>BorderColor.borderDefault</Text>
 </Box>;
 ```
 

--- a/ui/components/component-library/box/box.stories.tsx
+++ b/ui/components/component-library/box/box.stories.tsx
@@ -395,6 +395,11 @@ export const BackgroundColorStory = () => {
           BackgroundColor.overlayDefault
         </Text>
       </Box>
+      <Box padding={3} backgroundColor={BackgroundColor.overlayAlternative}>
+        <Text color={TextColor.overlayInverse}>
+          BackgroundColor.overlayAlternative
+        </Text>
+      </Box>
       <Box padding={3} backgroundColor={BackgroundColor.primaryDefault}>
         <Text color={TextColor.primaryInverse}>
           BackgroundColor.primaryDefault

--- a/ui/css/design-system/_colors.scss
+++ b/ui/css/design-system/_colors.scss
@@ -10,6 +10,7 @@ $color-map: (
   'border-default': --color-border-default,
   'border-muted': --color-border-muted,
   'overlay-default': --color-overlay-default,
+  'overlay-alternative': --color-overlay-alternative,
   'overlay-inverse': --color-overlay-inverse,
   'primary-default': --color-primary-default,
   'primary-alternative': --color-primary-alternative,

--- a/ui/helpers/constants/design-system.ts
+++ b/ui/helpers/constants/design-system.ts
@@ -63,6 +63,7 @@ export enum BackgroundColor {
   backgroundDefault = 'background-default',
   backgroundAlternative = 'background-alternative',
   overlayDefault = 'overlay-default',
+  overlayAlternative = 'overlay-alternative',
   primaryDefault = 'primary-default',
   primaryAlternative = 'primary-alternative',
   primaryMuted = 'primary-muted',


### PR DESCRIPTION
### **Description**

This pull request adds a missing overlay alternative color to the design system enums. The inclusion of this color aims to enhance the consistency and completeness of the design system, providing additional options for overlay elements. This improvement helps ensure that all possible overlay scenarios are covered within the design system, making it more robust and flexible for various UI implementations.

### **Related issues**

Fixes: N/A

### **Manual testing steps**

1. Open the Storybook build on this PR or run `yarn storybook`.
2. Navigate to the `Box` background color story.
3. Verify that the new overlay alternative color is available and displays correctly.
4. Check the design system documentation to ensure the new color is listed.

### **Screenshots/Recordings**

#### **Before**

<img width="1510" alt="Screenshot 2024-05-25 at 1 12 15 PM" src="https://github.com/MetaMask/metamask-extension/assets/8112138/a680a249-42e1-42b9-b971-ec2a6de4536f">


#### **After**

<img width="1511" alt="Screenshot 2024-05-25 at 1 11 28 PM" src="https://github.com/MetaMask/metamask-extension/assets/8112138/5de723d6-7cbc-4e27-9956-65b5ac484e0c">


### **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability.
- [x] I’ve included tests if applicable.
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable.
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

### **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g., pulled and built the branch, run the app, tested the code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and/or screenshots.