### PR TITLE
docs: adding recover-phrase-stories

### DIFF
--- a/ui/pages/onboarding-flow/recovery-phrase/confirm-recovery-phrase.stories.js
+++ b/ui/pages/onboarding-flow/recovery-phrase/confirm-recovery-phrase.stories.js
@@ -1,0 +1,21 @@
+import React from 'react';
+
+import ConfirmRecoveryPhrase from './confirm-recovery-phrase';
+
+export default {
+  title: 'Pages/OnboardingFlow/RecoveryPhrase/ConfirmRecoveryPhrase',
+  component: ConfirmRecoveryPhrase,
+  argTypes: {
+    secretRecoveryPhrase: {
+      control: { type: 'array' },
+    },
+  },
+  args: {
+    secretRecoveryPhrase:
+      'debris dizzy just program just float decrease vacant alarm reduce speak stadium',
+  },
+};
+
+const Template = (args) => <ConfirmRecoveryPhrase {...args} />;
+
+export const Default = Template.bind({});

--- a/ui/pages/onboarding-flow/recovery-phrase/recovery-phrase-chips.stories.js
+++ b/ui/pages/onboarding-flow/recovery-phrase/recovery-phrase-chips.stories.js
@@ -1,5 +1,4 @@
-import React, { useState, useMemo } from 'react';
-import { debounce } from 'lodash';
+import React, { useState } from 'react';
 import RecoveryPhraseChips from './recovery-phrase-chips';
 
 // Define the stories
@@ -59,7 +58,6 @@ export const PhraseRevealed = Template.bind({});
 export const ConfirmPhase = (args) => {
   const splitSecretRecoveryPhrase = args.secretRecoveryPhrase;
   const indicesToCheck = [2, 3, 7];
-  const [matching, setMatching] = useState(false);
 
   // Removes seed phrase words from chips corresponding to the
   // indicesToCheck so that user has to complete the phrase and confirm
@@ -75,19 +73,8 @@ export const ConfirmPhase = (args) => {
     initializePhraseElements(),
   );
 
-  const validate = useMemo(
-    () =>
-      debounce((elements) => {
-        setMatching(
-          Object.values(elements).join(' ') === args.secretRecoveryPhrase,
-        );
-      }, 500),
-    [setMatching, args.secretRecoveryPhrase],
-  );
-
   const handleSetPhraseElements = (values) => {
     setPhraseElements(values);
-    validate(values);
   };
   return (
     <RecoveryPhraseChips

--- a/ui/pages/onboarding-flow/recovery-phrase/recovery-phrase-chips.stories.js
+++ b/ui/pages/onboarding-flow/recovery-phrase/recovery-phrase-chips.stories.js
@@ -1,0 +1,104 @@
+import React, { useState, useMemo } from 'react';
+import { debounce } from 'lodash';
+import RecoveryPhraseChips from './recovery-phrase-chips';
+
+// Define the stories
+export default {
+  title: 'Pages/OnboardingFlow/RecoveryPhrase/RecoveryPhraseChips',
+  component: RecoveryPhraseChips,
+  argTypes: {
+    secretRecoveryPhrase: {
+      control: { type: 'array' },
+    },
+    phraseRevealed: {
+      control: { type: 'boolean' },
+    },
+    confirmPhase: {
+      control: { type: 'boolean' },
+    },
+    setInputValue: {
+      control: { type: 'text' },
+    },
+    inputValue: {
+      control: { type: 'text' },
+    },
+    indicesToCheck: {
+      control: { type: 'array' },
+    },
+    hiddenPhrase: {
+      control: { type: 'text' },
+    },
+  },
+  args: {
+    secretRecoveryPhrase: [
+      'apple',
+      'banana',
+      'cherry',
+      'date',
+      'elderberry',
+      'fig',
+      'grape',
+      'honeydew',
+      'kiwi',
+      'lemon',
+      'mango',
+      'nectarine',
+    ],
+  },
+};
+
+const Template = (args) => <RecoveryPhraseChips {...args} />;
+
+export const Default = Template.bind({});
+Default.args = {
+  phraseRevealed: false,
+};
+
+export const PhraseRevealed = Template.bind({});
+
+export const ConfirmPhase = (args) => {
+  const splitSecretRecoveryPhrase = args.secretRecoveryPhrase;
+  const indicesToCheck = [2, 3, 7];
+  const [matching, setMatching] = useState(false);
+
+  // Removes seed phrase words from chips corresponding to the
+  // indicesToCheck so that user has to complete the phrase and confirm
+  // they have saved it.
+  const initializePhraseElements = () => {
+    const phraseElements = { ...splitSecretRecoveryPhrase };
+    indicesToCheck.forEach((i) => {
+      phraseElements[i] = '';
+    });
+    return phraseElements;
+  };
+  const [phraseElements, setPhraseElements] = useState(
+    initializePhraseElements(),
+  );
+
+  const validate = useMemo(
+    () =>
+      debounce((elements) => {
+        setMatching(
+          Object.values(elements).join(' ') === args.secretRecoveryPhrase,
+        );
+      }, 500),
+    [setMatching, args.secretRecoveryPhrase],
+  );
+
+  const handleSetPhraseElements = (values) => {
+    setPhraseElements(values);
+    validate(values);
+  };
+  return (
+    <RecoveryPhraseChips
+      {...args}
+      secretRecoveryPhrase={splitSecretRecoveryPhrase}
+      setInputValue={handleSetPhraseElements}
+      inputValue={phraseElements}
+      indicesToCheck={indicesToCheck}
+    />
+  );
+};
+ConfirmPhase.args = {
+  confirmPhase: true,
+};

--- a/ui/pages/onboarding-flow/recovery-phrase/review-recovery-phrase.stories.js
+++ b/ui/pages/onboarding-flow/recovery-phrase/review-recovery-phrase.stories.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import RecoveryPhrase from './review-recovery-phrase';
+
+export default {
+  title: 'Pages/OnboardingFlow/RecoveryPhrase/ReviewRecoveryPhrase',
+  component: RecoveryPhrase,
+  argTypes: {
+    secretRecoveryPhrase: {
+      control: { type: 'array' },
+    },
+  },
+  args: {
+    secretRecoveryPhrase:
+      'debris dizzy just program just float decrease vacant alarm reduce speak stadium',
+  },
+};
+
+const Template = (args) => <RecoveryPhrase {...args} />;
+
+export const Default = Template.bind({});


### PR DESCRIPTION
### **Description**

This pull request adds three new stories for the recovery phrase components used in the onboarding process. The stories included are for the `ConfirmRecoveryPhrase`, `RecoveryPhraseChips`, and `ReviewRecoveryPhrase` components. These stories will help in visually testing and verifying the behavior of these components during the onboarding process.

### **Related issues**

Fixes: N/A

### **Manual testing steps**

1. Open Storybook.
2. Navigate to the `ConfirmRecoveryPhrase` story.
3. Verify the component displays and behaves correctly.
4. Navigate to the `RecoveryPhraseChips` story.
5. Check that the component is rendered correctly and functions as expected.
6. Navigate to the `ReviewRecoveryPhrase` story.
7. Ensure the component is displayed accurately and operates as intended.

### **Screenshots/Recordings**

#### **Before**

https://github.com/MetaMask/metamask-extension/assets/8112138/97b3c0b5-365b-4c9b-84bc-acd0ead915ce

#### **After**

https://github.com/MetaMask/metamask-extension/assets/8112138/cc7b7e06-6831-4d83-85f1-2d92af4e5b18

### **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability.
- [x] I’ve included tests if applicable.
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable.
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

### **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g., pulled and built the branch, run the app, tested the code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and/or screenshots.