### PR TITLE
test: Fix flaky test Update Network: update network details and validate the ui elements

### DIFF
--- a/test/e2e/tests/network/update-network.spec.ts
+++ b/test/e2e/tests/network/update-network.spec.ts
@@ -38,7 +38,8 @@ const selectors = {
 const inputData = {
   networkName: 'Update Network',
   rpcUrl: 'test',
-  chainId: '0x539',
+  chainId_part1: '0x53',
+  chainId_part2: '9',
 };
 
 async function navigateToEditNetwork(driver: Driver) {
@@ -63,7 +64,14 @@ describe('Update Network:', function (this: Suite) {
           selectors.networkNameInputField,
           inputData.networkName,
         );
-        await driver.fill(selectors.chainIdInputField, inputData.chainId);
+
+        // We fill in the chain ID in two steps, allowing the error message time to disappear once the field is correctly completed.
+        await driver.fill(selectors.chainIdInputField, inputData.chainId_part1);
+        const chainIdInputField = await driver.findElement(
+          selectors.chainIdInputField,
+        );
+        await chainIdInputField.sendKeys(inputData.chainId_part2);
+
         await driver.clickElement(selectors.saveButton);
 
         // Validate the network name is updated


### PR DESCRIPTION
## **Description**

This PR addresses a flaky test issue related to the Chain ID input field.

Reason for flakiness: The root cause of the flakiness was identified as the rapid input of the entire Chain ID, which resulted in the error message appearing and persisting even after the correct Chain ID was fully entered.

Observation: When entering the Chain ID manually, the error message correctly displays when incomplete values like "0x53" are input but disappears upon entering the full Chain ID with "9". To mimic more human-like actions in the automated test, I adjusted the test behavior accordingly.

Key Changes:
Split Chain ID Input: The Chain ID input process has been split into two distinct parts (chainId_part1 and chainId_part2). This modification adopts a more human-like approach to entering the Chain ID, allowing the error message sufficient time to respond accurately.

Results:
Before the Fix: The flakiness could be reproduced locally on Firefox with a 50% occurrence rate.
After the Fix: After implementing the changes, I ran the test 20 consecutive times without encountering any flakiness, demonstrating the effectiveness of the fix.

This adjustment ensures that the automated test behaves in a way that closely resembles user interaction, and reduce test flakiness.


[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/24790?quickstart=1)

## **Related issues**

Fixes: #24628 

## **Manual testing steps**

1. Run the test several times yarn test:e2e:single test/e2e/tests/request-queuing/ui.spec.js --browser=firefox --leave-running --retryUntilFailure --retries=10
2. Check ci jobs

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
