### PR TITLE
fix: flaky test for `Request Queuing for Multiple Dapps and Txs on different networks. should switch to the dapps network automatically when handling sendTransaction calls`

### DIFF
--- a/test/e2e/tests/request-queuing/multiple-networks-dapps-txs.spec.js
+++ b/test/e2e/tests/request-queuing/multiple-networks-dapps-txs.spec.js
@@ -146,14 +146,7 @@ describe('Request Queuing for Multiple Dapps and Txs on different networks.', fu
         await driver.switchToWindowWithTitle(
           WINDOW_TITLES.ExtensionInFullScreenView,
         );
-
-        // TODO: Reload fix to have the confirmations show
-        await driver.executeScript(`window.location.reload()`);
-
-        // Second Switch Network
-        await driver.switchToWindowWithTitle(
-          WINDOW_TITLES.ExtensionInFullScreenView,
-        );
+        await driver.clickElement('[data-testid="home__activity-tab"]');
 
         // Check for unconfirmed transaction in tx list
         await driver.wait(async () => {


### PR DESCRIPTION
## **Description**
This PR fixes the flaky test `Request Queuing for Multiple Dapps and Txs on different networks. should switch to the dapps network automatically when handling sendTransaction calls`.

- Circle ci failure: https://app.circleci.com/pipelines/github/MetaMask/metamask-extension/82995/workflows/51b18b16-f786-4ee8-96d0-9c751af6fa17/jobs/2965502/tests

The test fails at the point of trying to find the unapproved transaction, in the transaction list. The problem is that in the test, we are doing a browser refresh in order for the transaction to show up, but there is a race condition that, if you do a refresh once the unapproved tx is already present, you are redirected to the confirmation screen. This causes that the transaction cannot be found in the activity list and the test fails.

The solution is to change the approach for a more robust one, and instead of doing a browser refresh, we simply go explicitly to the activity tab and wait until the transaction appears.

![Screenshot from 2024-05-28 11-45-58](https://github.com/MetaMask/metamask-extension/assets/54408225/ada34107-3d50-4104-8456-db7d3ffb8d02)

**Circle ci Screenshot**: it's looking for the unapproved-transaction but it cannot find it because after reloading MetaMask, the screen is redirected to the unapproved transaction.

![image](https://github.com/MetaMask/metamask-extension/assets/54408225/5824a4d3-b420-45c3-971f-ec6827c91398)

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/24809?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/24603

## **Manual testing steps**

1. Check ci jobs
2. Run test multiple times `yarn test:e2e:single test/e2e/tests/request-queuing/multiple-networks-dapps-txs.spec.js --browser=firefox --leave-running --retryUntilFailure --retries=10ng/multiple-networks-dapps-txs`

## **Screenshots/Recordings**



Behavior when you reload the browser with the unapproved transaction already present --> see how you are redirected to the confirmation page

https://github.com/MetaMask/metamask-extension/assets/54408225/726911da-a044-48eb-a60f-938099db1176

Solution: no browser refresh but instead, going to the activity tab and wait until tx appears (see last seconds on the video)

https://github.com/MetaMask/metamask-extension/assets/54408225/a757587d-8bfa-4ef4-acc4-78f2489daa83



<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
