### PR TITLE
fix(24732): fix error when sending txn from dapp and editing the gas

### DIFF
--- a/test/e2e/tests/transaction/edit-gas-fee.spec.js
+++ b/test/e2e/tests/transaction/edit-gas-fee.spec.js
@@ -182,10 +182,10 @@ describe('Editing Confirm Transaction', function () {
         });
 
         await driver.clickElement('[data-testid="edit-gas-fee-icon"]');
-        await driver.waitForSelector({
-          text: 'sec',
-          tag: 'span',
-        });
+        // -- should render the popover with no error
+        // this is to test in MV3 a racing issue when request for suggestedGasFees is not fetched properly
+        // some data would not be defined yet
+        await driver.waitForSelector('.edit-gas-fee-popover');
         await driver.clickElement(
           '[data-testid="edit-gas-fee-item-dappSuggested"]',
         );

--- a/ui/pages/confirmations/components/edit-gas-fee-popover/edit-gas-item/useCustomTimeEstimate.js
+++ b/ui/pages/confirmations/components/edit-gas-fee-popover/edit-gas-item/useCustomTimeEstimate.js
@@ -62,7 +62,6 @@ export const useCustomTimeEstimate = ({
     return {};
   }
 
-  const { low = {}, medium = {}, high = {} } = gasFeeEstimates;
   let waitTimeEstimate = '';
 
   if (
@@ -73,11 +72,12 @@ export const useCustomTimeEstimate = ({
   ) {
     waitTimeEstimate = Number(customEstimatedTime?.upperTimeBound);
   } else if (
-    Number(maxPriorityFeePerGas) >= Number(medium.suggestedMaxPriorityFeePerGas)
+    Number(maxPriorityFeePerGas) >=
+    Number(gasFeeEstimates?.medium?.suggestedMaxPriorityFeePerGas)
   ) {
-    waitTimeEstimate = high.minWaitTimeEstimate;
+    waitTimeEstimate = gasFeeEstimates?.high?.minWaitTimeEstimate;
   } else {
-    waitTimeEstimate = low.maxWaitTimeEstimate;
+    waitTimeEstimate = gasFeeEstimates?.low?.maxWaitTimeEstimate;
   }
 
   return { waitTimeEstimate };


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
There is a racing condition captured in MV3 build. When sending transaction from dapp directly, if user chooses to edit the gas fee, and when `suggestedGasFees ` request is processing slow, `gasFeeEstimates` could be undefined within hook `useCustomTimeEstimate.js`. The fix is to add a condition for accessing this object before forwarding to UI.


<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/24810?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/24732

## **Manual testing steps**

1. Build in MV3
2. Trigger a txn from dapp
3. Open network panel, and trigger edit gas button before `suggestedGasFees` is finished fetching
4. You should see the network edition panel

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
 by @seaona 

https://github.com/MetaMask/metamask-extension/assets/12678455/f3e660a8-2d7b-4d1d-be31-69d5cd66d374


<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

https://github.com/MetaMask/metamask-extension/assets/12678455/42b2df9d-a861-41ec-914e-89229493e276


- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
