### PR TITLE
fix: personal sign to use a fixed `alertKey`

### DIFF
--- a/ui/pages/confirmations/components/confirm/info/personal-sign/personal-sign.tsx
+++ b/ui/pages/confirmations/components/confirm/info/personal-sign/personal-sign.tsx
@@ -38,7 +38,7 @@ const PersonalSignInfo: React.FC = () => {
         marginBottom={4}
       >
         <AlertRow
-          alertKey={'requestFrom'}
+          alertKey="requestFrom"
           ownerId={currentConfirmation.id}
           label={t('requestFrom')}
           tooltip={t('requestFromInfo')}
@@ -53,7 +53,7 @@ const PersonalSignInfo: React.FC = () => {
         marginBottom={4}
       >
         <AlertRow
-          alertKey={'message'}
+          alertKey="message"
           ownerId={currentConfirmation.id}
           label={t('message')}
         >

--- a/ui/pages/confirmations/components/confirm/info/personal-sign/personal-sign.tsx
+++ b/ui/pages/confirmations/components/confirm/info/personal-sign/personal-sign.tsx
@@ -38,7 +38,7 @@ const PersonalSignInfo: React.FC = () => {
         marginBottom={4}
       >
         <AlertRow
-          alertKey={t('requestFrom')}
+          alertKey={'requestFrom'}
           ownerId={currentConfirmation.id}
           label={t('requestFrom')}
           tooltip={t('requestFromInfo')}
@@ -53,7 +53,7 @@ const PersonalSignInfo: React.FC = () => {
         marginBottom={4}
       >
         <AlertRow
-          alertKey={t('message')}
+          alertKey={'message'}
           ownerId={currentConfirmation.id}
           label={t('message')}
         >


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
This PR updates the `alertKey` prop in the `AlertRow` component within the `PersonalSign` component. The key change is replacing the translatable label passed with the correct key 'requestFrom'.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/24817?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

AlertRows are not available to the user.
Test regression for signature and personal sign re-designed confirmations.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
