### PR TITLE
fix: push Privacy policy date to year 2099

### DIFF
--- a/ui/helpers/constants/privacy-policy.ts
+++ b/ui/helpers/constants/privacy-policy.ts
@@ -1,4 +1,4 @@
 // This date indicates the date of the latest privacy policy document
-const PRIVACY_POLICY_DATE = '2024-06-04T00:00:00Z';
+const PRIVACY_POLICY_DATE = '2099-06-04T00:00:00Z';
 
 export { PRIVACY_POLICY_DATE };

--- a/ui/pages/onboarding-flow/metametrics/metametrics.test.js
+++ b/ui/pages/onboarding-flow/metametrics/metametrics.test.js
@@ -95,7 +95,7 @@ describe('Onboarding Metametrics Component', () => {
   });
 
   it('should render the Onboarding component when the current date is after the new privacy policy date', () => {
-    jest.useFakeTimers().setSystemTime(new Date('2026-01-01'));
+    jest.useFakeTimers().setSystemTime(new Date('2099-11-11'));
     const { queryByTestId } = renderWithProvider(
       <OnboardingMetametrics />,
       mockStore,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Sets the time for the new privacy policy for 2099, so that the feature is not released yet. This is until we figure out a correct date for the feature.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/24829?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
