### PR TITLE
cherrypick fix: Fix transaction metric event asset type detection (#24770) into v11.16.1

### DIFF
--- a/app/scripts/lib/transaction/metrics.ts
+++ b/app/scripts/lib/transaction/metrics.ts
@@ -76,12 +76,12 @@ export type TransactionMetricsRequest = {
   getEIP1559GasFeeEstimates(options?: FetchGasFeeEstimateOptions): Promise<any>;
   getParticipateInMetrics: () => boolean;
   getSelectedAddress: () => string;
-  getTokenStandardAndDetails: () => {
+  getTokenStandardAndDetails: () => Promise<{
     decimals?: string;
     balance?: string;
     symbol?: string;
     standard?: TokenStandard;
-  };
+  }>;
   getTransaction: (transactionId: string) => TransactionMeta;
   provider: Provider;
   snapAndHardwareMessenger: SnapAndHardwareMessenger;

--- a/shared/modules/transaction.utils.ts
+++ b/shared/modules/transaction.utils.ts
@@ -198,12 +198,12 @@ export async function determineTransactionType(
   return { type: TransactionType.simpleSend, getCodeResponse: contractCode };
 }
 
-type GetTokenStandardAndDetails = (to: string | undefined) => {
+type GetTokenStandardAndDetails = (to: string | undefined) => Promise<{
   decimals?: string;
   balance?: string;
   symbol?: string;
   standard?: TokenStandard;
-};
+}>;
 /**
  * Given a transaction meta object, determine the asset type that the
  * transaction is dealing with, as well as the standard for the token if it
@@ -254,7 +254,7 @@ export async function determineTransactionAssetType(
     try {
       // We don't need a balance check, so the second parameter to
       // getTokenStandardAndDetails is omitted.
-      const details = getTokenStandardAndDetails(txMeta.txParams.to);
+      const details = await getTokenStandardAndDetails(txMeta.txParams.to);
       if (details.standard) {
         return {
           assetType:


### PR DESCRIPTION
🍒-pick fix: Fix transaction metric event asset type detection c1bba92d8cae5e1842d36252d26747fabb96b931 (#24770) into v11.16.1

Merge conflict in `shared/modules/transaction.utils.ts` (accepted incoming):
```typescript
    try {
      // We don't need a balance check, so the second parameter to
      // getTokenStandardAndDetails is omitted.
<<<<<<< HEAD
      const details = getTokenStandardAndDetails(txMeta.txParams.to);
=======
      const details = await getTokenStandardAndDetails(txMeta.txParams.to);
>>>>>>> c1bba92d8c (fix: Fix transaction metric event asset type detection (#24770))
      if (details.standard) {
        return {
```