### PR TITLE
cherry-pick test: fix flaky test `Import ERC1155 NFT should be... (#24709) into v11.16.1

### DIFF
--- a/test/e2e/mock-e2e.js
+++ b/test/e2e/mock-e2e.js
@@ -577,6 +577,17 @@ async function setupMocking(server, testSpecificMock, { chainId }) {
   await mockLensNameProvider(server);
   await mockTokenNameProvider(server, chainId);
 
+  // IPFS endpoint for NFT metadata
+  await server
+    .forGet(
+      'https://bafybeidxfmwycgzcp4v2togflpqh2gnibuexjy4m4qqwxp7nh3jx5zlh4y.ipfs.dweb.link/1.json',
+    )
+    .thenCallback(() => {
+      return {
+        statusCode: 200,
+      };
+    });
+
   /**
    * Returns an array of alphanumerically sorted hostnames that were requested
    * during the current test suite.


### PR DESCRIPTION
cherry-pick test: fix flaky test `Import ERC1155 NFT should be able to import an … 3ddb0d431865ddec5780e7d9eec88c874b7c1058 (#24709) into v11.16.1

No merge conflicts