### PR TITLE
fix: broken UI for transaction insight (Snaps)

### DIFF
--- a/ui/components/ui/tabs/snaps/dropdown-tab/dropdown-tab.js
+++ b/ui/components/ui/tabs/snaps/dropdown-tab/dropdown-tab.js
@@ -90,6 +90,11 @@ export const DropdownTab = ({
         title="Transaction Insights"
         style={{
           pointerEvents: isActive ? 'auto' : 'none',
+          fontFamily: 'var(--typography-s-body-md-font-family)',
+          fontWeight: 'var(--typography-s-body-md-font-weight)',
+          fontSize: 'var(--typography-s-body-md-font-size)',
+          lineHeight: 'var(--typography-s-body-md-line-height)',
+          letterSpacing: 'var(--typography-s-body-md-letter-spacing)',
         }}
       />
     </Box>

--- a/ui/components/ui/tabs/snaps/dropdown-tab/index.scss
+++ b/ui/components/ui/tabs/snaps/dropdown-tab/index.scss
@@ -1,5 +1,5 @@
 %select-box-padding {
-  padding: 8px 20px 0 4px;
+  padding: 8px 20px 6px 4px;
 }
 
 %select-box-text-styles {
@@ -46,6 +46,7 @@
 
   .dropdown__icon-caret-down {
     right: 4px;
+    top: 50% !important;
     cursor: pointer;
   }
 


### PR DESCRIPTION
## **Description**
Because of the changes to font styling/variant introduced in [https://github.com/MetaMask/metamask-extension/pull/23703/files#diff-4d1bf759da8485895dc097680ccf0b8dcd6f211e15a7ef04a92edcdf33a0bbceR48]( #23703), Transaction Insight tab looks off, since other tabs have new styling (new font size).

Raw:
https://github.com/MetaMask/metamask-extension/blob/d324bd27f14b5ff69ea566f370871bd601c86d2b/ui/components/ui/tabs/tab/tab.component.js#L48 

This PR fixes the UI issue.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/24849?quickstart=1)

## **Related issues**
Fixes: n/a

## **Manual testing steps**
1. Install two or more Transaction Insight Snaps
2. Try creating a transaction.
3. Check the UI around transaction insight tab and dropdown, etc.

## **Screenshots/Recordings**

### **Before**
![image](https://github.com/MetaMask/metamask-extension/assets/13301024/0671dfde-cffb-4bef-80a0-364c87c7bec3)

### **After**
![Screenshot 2024-05-29 at 00 12 19](https://github.com/MetaMask/metamask-extension/assets/13301024/28d93f63-0d1e-42dd-b9c7-1b039187d65d)

## **Pre-merge author checklist**
- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
