### PR TITLE
fix: (cherry-pick Version v11.16.2) Add L2 support in ConfirmLegacyGasDisplay to support Scroll Network transactions

### DIFF
--- a/ui/pages/confirmations/components/confirm-gas-display/confirm-legacy-gas-display/confirm-legacy-gas-display.js
+++ b/ui/pages/confirmations/components/confirm-gas-display/confirm-legacy-gas-display/confirm-legacy-gas-display.js
@@ -30,6 +30,7 @@ import {
   IconName,
   Text,
 } from '../../../../../components/component-library';
+import { addHexes } from '../../../../../../shared/modules/conversion.utils';
 
 const renderHeartBeatIfNotInTest = () =>
   process.env.IN_TEST ? null : <LoadingHeartBeat />;
@@ -45,14 +46,13 @@ const ConfirmLegacyGasDisplay = ({ 'data-testid': dataTestId } = {}) => {
   const unapprovedTxs = useSelector(getUnapprovedTransactions);
   const transactionData = useDraftTransactionWithTxParams();
   const txData = useSelector((state) => txDataSelector(state));
-  const { id: transactionId, dappSuggestedGasFees } = txData;
+  const { id: transactionId, dappSuggestedGasFees, layer1GasFee } = txData;
   const transaction = Object.keys(transactionData).length
     ? transactionData
     : unapprovedTxs[transactionId] || {};
   const { hexMinimumTransactionFee, hexMaximumTransactionFee } = useSelector(
     (state) => transactionFeeSelector(state, transaction),
   );
-  const { layer1GasFee } = txData;
   const hasLayer1GasFee = layer1GasFee !== undefined;
 
   if (hasLayer1GasFee) {
@@ -89,6 +89,16 @@ const ConfirmLegacyGasDisplay = ({ 'data-testid': dataTestId } = {}) => {
       />,
     ];
   }
+
+  const estimatedHexMinFeeTotal = addHexes(
+    hexMinimumTransactionFee,
+    layer1GasFee ?? '0x0',
+  );
+
+  const estimatedHexMaxFeeTotal = addHexes(
+    hexMaximumTransactionFee,
+    layer1GasFee ?? '0x0',
+  );
 
   return (
     <TransactionDetailItem
@@ -141,7 +151,7 @@ const ConfirmLegacyGasDisplay = ({ 'data-testid': dataTestId } = {}) => {
             {renderHeartBeatIfNotInTest()}
             <UserPreferencedCurrencyDisplay
               type={SECONDARY}
-              value={hexMinimumTransactionFee}
+              value={estimatedHexMinFeeTotal}
               hideLabel={Boolean(useNativeCurrencyAsPrimaryCurrency)}
             />
           </div>
@@ -152,7 +162,7 @@ const ConfirmLegacyGasDisplay = ({ 'data-testid': dataTestId } = {}) => {
           {renderHeartBeatIfNotInTest()}
           <UserPreferencedCurrencyDisplay
             type={PRIMARY}
-            value={hexMinimumTransactionFee}
+            value={estimatedHexMinFeeTotal}
             hideLabel={!useNativeCurrencyAsPrimaryCurrency}
             numberOfDecimals={6}
           />
@@ -168,7 +178,7 @@ const ConfirmLegacyGasDisplay = ({ 'data-testid': dataTestId } = {}) => {
             <UserPreferencedCurrencyDisplay
               key="editGasSubTextFeeAmount"
               type={PRIMARY}
-              value={hexMaximumTransactionFee}
+              value={estimatedHexMaxFeeTotal}
               hideLabel={!useNativeCurrencyAsPrimaryCurrency}
             />
           </div>

--- a/ui/pages/confirmations/components/confirm-gas-display/confirm-legacy-gas-display/confirm-legacy-gas-display.test.js
+++ b/ui/pages/confirmations/components/confirm-gas-display/confirm-legacy-gas-display/confirm-legacy-gas-display.test.js
@@ -111,14 +111,49 @@ describe('ConfirmLegacyGasDisplay', () => {
     });
   });
 
-  it('should contain L1 L2 fee details', async () => {
+  it('displays the Estimated Fee', () => {
+    const { container } = render({
+      ...mmState,
+      confirmTransaction: {
+        ...mmState.confirmTransaction,
+        txData: {
+          ...mmState.confirmTransaction.txData,
+        },
+      },
+    });
+
+    expect(
+      container.querySelector('.currency-display-component__text'),
+    ).toHaveTextContent('0.000021');
+  });
+
+  it('displays the Estimated Fee on L2 Networks', () => {
+    const { container } = render({
+      ...mmState,
+      confirmTransaction: {
+        ...mmState.confirmTransaction,
+        txData: {
+          ...mmState.confirmTransaction.txData,
+          layer1GasFee: '0x0653b2c7980981',
+        },
+      },
+    });
+
+    expect(screen.queryByText('Estimated gas fee')).toBeInTheDocument();
+    expect(screen.queryByText('Max fee:')).toBeInTheDocument();
+    expect(
+      container.querySelector('.currency-display-component__text'),
+    ).toHaveTextContent('0.00180188');
+  });
+
+  it('contains L1 L2 fee details', async () => {
     render({
       ...mmState,
       confirmTransaction: {
         ...mmState.confirmTransaction,
         txData: {
           ...mmState.confirmTransaction.txData,
-          layer1GasFee: '0x1',
+          layer1GasFee: '0x0653b2c7980981',
         },
       },
     });

--- a/ui/pages/confirmations/components/confirm-gas-display/confirm-legacy-gas-display/confirm-legacy-gas-display.test.js
+++ b/ui/pages/confirmations/components/confirm-gas-display/confirm-legacy-gas-display/confirm-legacy-gas-display.test.js
@@ -145,22 +145,4 @@ describe('ConfirmLegacyGasDisplay', () => {
       container.querySelector('.currency-display-component__text'),
     ).toHaveTextContent('0.00180188');
   });
-
-  it('contains L1 L2 fee details', async () => {
-    render({
-      ...mmState,
-      confirmTransaction: {
-        ...mmState.confirmTransaction,
-        txData: {
-          ...mmState.confirmTransaction.txData,
-          layer1GasFee: '0x0653b2c7980981',
-        },
-      },
-    });
-
-    await waitFor(() => {
-      expect(screen.queryByText('Estimated gas fee')).toBeInTheDocument();
-      expect(screen.queryByText('Max fee:')).toBeInTheDocument();
-    });
-  });
 });


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Cherry-pick [85f19c2](https://github.com/MetaMask/metamask-extension/commit/85f19c2a3a3fba42e33758744966e6e36e613086) (https://github.com/MetaMask/metamask-extension/pull/24854) into v11.16.2

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/24866?quickstart=1)

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/24835
was Blocked by: https://github.com/MetaMask/metamask-extension/pull/24871

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
