### PR TITLE
refactor: Decouple the data deletion controller

### DIFF
--- a/app/scripts/controllers/metametrics-data-deletion/metametrics-data-deletion.ts
+++ b/app/scripts/controllers/metametrics-data-deletion/metametrics-data-deletion.ts
@@ -104,7 +104,7 @@ export default class MetaMetricsDataDeletionController extends BaseController<
 > {
   #dataDeletionService: DataDeletionService;
 
-  #getMetaMetricsId: () => string
+  #getMetaMetricsId: () => string;
 
   /**
    * Creates a MetaMetricsDataDeletionController instance.
@@ -113,7 +113,7 @@ export default class MetaMetricsDataDeletionController extends BaseController<
    * @param args.dataDeletionService - The service used for deleting data.
    * @param args.messenger - Messenger used to communicate with BaseV2 controller.
    * @param args.state - Initial state to set on this controller.
-   * @param args.metaMetricsStore
+   * @param args.getMetaMetricsId - A function that returns the current MetaMetrics ID.
    */
   constructor({
     dataDeletionService,

--- a/app/scripts/controllers/metametrics-data-deletion/metametrics-data-deletion.ts
+++ b/app/scripts/controllers/metametrics-data-deletion/metametrics-data-deletion.ts
@@ -104,7 +104,7 @@ export default class MetaMetricsDataDeletionController extends BaseController<
 > {
   #dataDeletionService: DataDeletionService;
 
-  #getMetaMetricsId: () => string;
+  #getMetaMetricsId: () => string | null;
 
   /**
    * Creates a MetaMetricsDataDeletionController instance.
@@ -124,7 +124,7 @@ export default class MetaMetricsDataDeletionController extends BaseController<
     dataDeletionService: DataDeletionService;
     messenger: MetaMetricsDataDeletionControllerMessenger;
     state?: MetaMetricsDataDeletionState;
-    getMetaMetricsId: () => string;
+    getMetaMetricsId: () => string | null;
   }) {
     // Call the constructor of BaseControllerV2
     super({

--- a/app/scripts/controllers/metametrics-data-deletion/metametrics-data-deletion.ts
+++ b/app/scripts/controllers/metametrics-data-deletion/metametrics-data-deletion.ts
@@ -2,8 +2,6 @@ import {
   BaseController,
   RestrictedControllerMessenger,
 } from '@metamask/base-controller';
-import { ObservableStore } from '@metamask/obs-store';
-import { MetaMetricsControllerState } from '../metametrics';
 import type { DataDeletionService } from '../../services/data-deletion-service';
 
 // Unique name for the controller
@@ -104,9 +102,9 @@ export default class MetaMetricsDataDeletionController extends BaseController<
   MetaMetricsDataDeletionState,
   MetaMetricsDataDeletionControllerMessenger
 > {
-  private metaMetricsId;
-
   #dataDeletionService: DataDeletionService;
+
+  #getMetaMetricsId: () => string
 
   /**
    * Creates a MetaMetricsDataDeletionController instance.
@@ -121,12 +119,12 @@ export default class MetaMetricsDataDeletionController extends BaseController<
     dataDeletionService,
     messenger,
     state,
-    metaMetricsStore,
+    getMetaMetricsId,
   }: {
     dataDeletionService: DataDeletionService;
     messenger: MetaMetricsDataDeletionControllerMessenger;
     state?: MetaMetricsDataDeletionState;
-    metaMetricsStore: ObservableStore<MetaMetricsControllerState>;
+    getMetaMetricsId: () => string;
   }) {
     // Call the constructor of BaseControllerV2
     super({
@@ -135,7 +133,7 @@ export default class MetaMetricsDataDeletionController extends BaseController<
       name: controllerName,
       state: { ...defaultState, ...state },
     });
-    this.metaMetricsId = metaMetricsStore.getState().metaMetricsId;
+    this.#getMetaMetricsId = getMetaMetricsId;
     this.#dataDeletionService = dataDeletionService;
   }
 
@@ -154,13 +152,14 @@ export default class MetaMetricsDataDeletionController extends BaseController<
    *
    */
   async createMetaMetricsDataDeletionTask(): Promise<void> {
-    if (!this.metaMetricsId) {
+    const metaMetricsId = this.#getMetaMetricsId();
+    if (!metaMetricsId) {
       throw new Error('MetaMetrics ID not found');
     }
 
     const { data } =
       await this.#dataDeletionService.createDataDeletionRegulationTask(
-        this.metaMetricsId,
+        metaMetricsId,
       );
     this.update((state) => {
       state.metaMetricsDataDeletionId = data?.regulateId;

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -758,7 +758,8 @@ export default class MetamaskController extends EventEmitter {
         dataDeletionService,
         messenger: metaMetricsDataDeletionMessenger,
         state: initState.metaMetricsDataDeletionController,
-        getMetaMetricsId: () => this.metaMetricsController.getMetaMetricsId(),
+        getMetaMetricsId: () =>
+          this.metaMetricsController.store.getState().metaMetricsId,
       });
 
     const gasFeeMessenger = this.controllerMessenger.getRestricted({

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -758,7 +758,7 @@ export default class MetamaskController extends EventEmitter {
         dataDeletionService,
         messenger: metaMetricsDataDeletionMessenger,
         state: initState.metaMetricsDataDeletionController,
-        metaMetricsStore: this.metaMetricsController.store,
+        getMetaMetricsId: () => this.metaMetricsController.getMetaMetricsId(),
       });
 
     const gasFeeMessenger = this.controllerMessenger.getRestricted({


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

The `DataDeletionController` has been decoupled from the `MetaMetricsController` by updating the constructor parameters to expect just a function for getting the MetaMetrics ID, rather than the entire `MetaMetricsController` state. This vastly simplifies the API surface, making it easier to audit and test. It also prevents the `DataDeletionController` from having the capability to make changes to the `MetaMetricsController` state.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/24870?quickstart=1)

## **Related issues**

This is an improvement for #24503

## **Manual testing steps**

N/A

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
