### PR TITLE
fix: Prevent token list controller from polling its api on network restart when basic functionality is off

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -5843,6 +5843,7 @@ export default class MetamaskController extends EventEmitter {
 
   toggleExternalServices(useExternal) {
     this.preferencesController.toggleExternalServices(useExternal);
+    this.tokenListController.updatePreventPollingOnNetworkRestart(!useExternal);
     if (useExternal) {
       this.tokenDetectionController.enable();
       this.gasFeeController.enableNonRPCGasFeeApis();

--- a/test/e2e/tests/privacy/basic-functionality.spec.js
+++ b/test/e2e/tests/privacy/basic-functionality.spec.js
@@ -95,7 +95,7 @@ describe('MetaMask onboarding @no-mmi', function () {
 
           assert.equal(
             requests.length,
-            0,
+            1,
             `${mockedEndpoints[i]} should make requests after onboarding`,
           );
         }

--- a/test/e2e/tests/privacy/basic-functionality.spec.js
+++ b/test/e2e/tests/privacy/basic-functionality.spec.js
@@ -1,0 +1,105 @@
+const { strict: assert } = require('assert');
+const {
+  TEST_SEED_PHRASE,
+  withFixtures,
+  importSRPOnboardingFlow,
+  WALLET_PASSWORD,
+  tinyDelayMs,
+  defaultGanacheOptions,
+} = require('../../helpers');
+const FixtureBuilder = require('../../fixture-builder');
+
+async function mockApis(mockServer) {
+  return [
+    await mockServer
+      .forGet('https://token-api.metaswap.codefi.network/tokens/1')
+      .thenCallback(() => {
+        return {
+          statusCode: 200,
+          body: [{ fakedata: true }],
+        };
+      }),
+  ];
+}
+
+describe('MetaMask onboarding @no-mmi', function () {
+  it('should prevent network requests to basic functionality endpoints when the basica functionality toggle is off', async function () {
+    await withFixtures(
+      {
+        fixtures: new FixtureBuilder({ onboarding: true }).build(),
+        ganacheOptions: defaultGanacheOptions,
+        title: this.test.fullTitle(),
+        testSpecificMock: mockApis,
+      },
+      async ({ driver, mockedEndpoint: mockedEndpoints }) => {
+        await driver.navigate();
+        await importSRPOnboardingFlow(
+          driver,
+          TEST_SEED_PHRASE,
+          WALLET_PASSWORD,
+        );
+
+        await driver.clickElement({ text: 'Advanced configuration', tag: 'a' });
+        await driver.clickElement(
+          '[data-testid="basic-functionality-toggle"] .toggle-button',
+        );
+        await driver.clickElement('[id="basic-configuration-checkbox"]');
+        await driver.clickElement({ text: 'Turn off', tag: 'button' });
+        await driver.clickElement({ text: 'Done', tag: 'button' });
+
+        await driver.clickElement('[data-testid="network-display"]');
+
+        await driver.clickElement({ text: 'Ethereum Mainnet', tag: 'p' });
+        await driver.delay(tinyDelayMs);
+
+        for (let i = 0; i < mockedEndpoints.length; i += 1) {
+          const requests = await mockedEndpoints[i].getSeenRequests();
+
+          assert.equal(
+            requests.length,
+            0,
+            `${mockedEndpoints[i]} should make requests after onboarding`,
+          );
+        }
+      },
+    );
+  });
+
+  it('should not prevent network requests to basic functionality endpoints when the basica functionality toggle is on', async function () {
+    await withFixtures(
+      {
+        fixtures: new FixtureBuilder({ onboarding: true }).build(),
+        ganacheOptions: defaultGanacheOptions,
+        title: this.test.fullTitle(),
+        testSpecificMock: mockApis,
+      },
+      async ({ driver, mockedEndpoint: mockedEndpoints }) => {
+        await driver.navigate();
+        await importSRPOnboardingFlow(
+          driver,
+          TEST_SEED_PHRASE,
+          WALLET_PASSWORD,
+        );
+
+        await driver.clickElement({ text: 'Advanced configuration', tag: 'a' });
+
+        await driver.clickElement({ text: 'Done', tag: 'button' });
+
+        await driver.clickElement('[data-testid="network-display"]');
+
+        await driver.clickElement({ text: 'Ethereum Mainnet', tag: 'p' });
+        await driver.delay(tinyDelayMs);
+
+        for (let i = 0; i < mockedEndpoints.length; i += 1) {
+          const requests = await mockedEndpoints[i].getSeenRequests();
+
+          assert.equal(
+            requests.length,
+            0,
+            `${mockedEndpoints[i]} should make requests after onboarding`,
+          );
+        }
+      },
+    );
+  });
+});


### PR DESCRIPTION
… when basic functionality is off

## **Description**

When basic functionality was off, requests were still going to https://token-api.metaswap.codefi.network/tokens/ when networks were switched. This PR prevents that.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/24886?quickstart=1)

## **Manual testing steps**

1. Build this branch
2. Install and onboard
3. go through onboarding and toggle off Basic Functionality in "Advanced Settings"
4. You should not see network requests (in the background console) to https://token-api.metaswap.codefi.network/tokens/ 
5. Switch between a few networks. You still should not see requests to https://token-api.metaswap.codefi.network/tokens/ 
6. Toggle basic functionality on.
7. Switch a network
8. You should now see requests to https://token-api.metaswap.codefi.network/tokens/ 

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
