### PR TITLE
fix: Move the logic to add accounts based on account balance to after onboarding is complete

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -1541,6 +1541,8 @@ export default class MetamaskController extends EventEmitter {
         if (!prevCompletedOnboarding && currCompletedOnboarding) {
           const { address } = this.accountsController.getSelectedAccount();
 
+          this._addAccountsWithBalance();
+
           this.postOnboardingInitialization();
           this.triggerNetworkrequests();
           // execute once the token detection on the post-onboarding
@@ -3933,43 +3935,12 @@ export default class MetamaskController extends EventEmitter {
         this._convertMnemonicToWordlistIndices(seedPhraseAsBuffer),
       );
 
-      // Scan accounts until we find an empty one
-      const { chainId } = this.networkController.state.providerConfig;
-      const ethQuery = new EthQuery(this.provider);
-      const accounts = await this.keyringController.getAccounts();
-      let address = accounts[accounts.length - 1];
+      const { completedOnboarding } =
+        this.onboardingController.store.getState();
 
-      for (let count = accounts.length; ; count++) {
-        const balance = await this.getBalance(address, ethQuery);
-
-        if (balance === '0x0') {
-          // This account has no balance, so check for tokens
-          await this.tokenDetectionController.detectTokens({
-            selectedAddress: address,
-          });
-
-          const tokens =
-            this.tokensController.state.allTokens?.[chainId]?.[address];
-          const detectedTokens =
-            this.tokensController.state.allDetectedTokens?.[chainId]?.[address];
-
-          if (
-            (tokens?.length ?? 0) === 0 &&
-            (detectedTokens?.length ?? 0) === 0
-          ) {
-            // This account has no balance or tokens
-            if (count !== 1) {
-              await this.removeAccount(address);
-            }
-            break;
-          }
-        }
-
-        // This account has assets, so check the next one
-        ({ addedAccountAddress: address } =
-          await this.keyringController.addNewAccount(count));
+      if (completedOnboarding) {
+        await this._addAccountsWithBalance();
       }
-
       // This must be set as soon as possible to communicate to the
       // keyring's iframe and have the setting initialized properly
       // Optimistically called to not block MetaMask login due to
@@ -3979,6 +3950,45 @@ export default class MetamaskController extends EventEmitter {
       return vault;
     } finally {
       releaseLock();
+    }
+  }
+
+  async _addAccountsWithBalance() {
+    // Scan accounts until we find an empty one
+    const { chainId } = this.networkController.state.providerConfig;
+    const ethQuery = new EthQuery(this.provider);
+    const accounts = await this.keyringController.getAccounts();
+    let address = accounts[accounts.length - 1];
+
+    for (let count = accounts.length; ; count++) {
+      const balance = await this.getBalance(address, ethQuery);
+
+      if (balance === '0x0') {
+        // This account has no balance, so check for tokens
+        await this.tokenDetectionController.detectTokens({
+          selectedAddress: address,
+        });
+
+        const tokens =
+          this.tokensController.state.allTokens?.[chainId]?.[address];
+        const detectedTokens =
+          this.tokensController.state.allDetectedTokens?.[chainId]?.[address];
+
+        if (
+          (tokens?.length ?? 0) === 0 &&
+          (detectedTokens?.length ?? 0) === 0
+        ) {
+          // This account has no balance or tokens
+          if (count !== 1) {
+            await this.removeAccount(address);
+          }
+          break;
+        }
+      }
+
+      // This account has assets, so check the next one
+      ({ addedAccountAddress: address } =
+        await this.keyringController.addNewAccount(count));
     }
   }
 

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -3910,6 +3910,9 @@ export default class MetamaskController extends EventEmitter {
   async createNewVaultAndRestore(password, encodedSeedPhrase) {
     const releaseLock = await this.createVaultMutex.acquire();
     try {
+      const { completedOnboarding } =
+        this.onboardingController.store.getState();
+
       const seedPhraseAsBuffer = Buffer.from(encodedSeedPhrase);
 
       // clear permissions
@@ -3927,16 +3930,15 @@ export default class MetamaskController extends EventEmitter {
 
       this.txController.clearUnapprovedTransactions();
 
-      this.tokenDetectionController.enable();
+      if (completedOnboarding) {
+        this.tokenDetectionController.enable();
+      }
 
       // create new vault
       const vault = await this.keyringController.createNewVaultAndRestore(
         password,
         this._convertMnemonicToWordlistIndices(seedPhraseAsBuffer),
       );
-
-      const { completedOnboarding } =
-        this.onboardingController.store.getState();
 
       if (completedOnboarding) {
         await this._addAccountsWithBalance();

--- a/app/scripts/metamask-controller.test.js
+++ b/app/scripts/metamask-controller.test.js
@@ -630,6 +630,10 @@ describe('MetaMaskController', () => {
             }
           });
 
+        jest
+          .spyOn(metamaskController.onboardingController.store, 'getState')
+          .mockReturnValue({ completedOnboarding: true });
+
         // Give account 2 a token
         jest
           .spyOn(metamaskController.tokensController, 'state', 'get')

--- a/test/e2e/tests/onboarding/onboarding.spec.js
+++ b/test/e2e/tests/onboarding/onboarding.spec.js
@@ -479,6 +479,137 @@ describe('MetaMask onboarding @no-mmi', function () {
     );
   });
 
+  it("doesn't make any network requests to infura before onboarding by import is completed", async function () {
+    async function mockInfura(mockServer) {
+      const infuraUrl =
+        'https://mainnet.infura.io/v3/00000000000000000000000000000000';
+      const sampleAddress = '1111111111111111111111111111111111111111';
+
+      return [
+        await mockServer
+          .forPost(infuraUrl)
+          .withJsonBodyIncluding({ method: 'eth_blockNumber' })
+          .thenCallback(() => {
+            return {
+              statusCode: 200,
+              json: {
+                jsonrpc: '2.0',
+                id: '1111111111111111',
+                result: '0x1',
+              },
+            };
+          }),
+        await mockServer
+          .forPost(infuraUrl)
+          .withJsonBodyIncluding({ method: 'eth_getBalance' })
+          .thenCallback(() => {
+            return {
+              statusCode: 200,
+              json: {
+                jsonrpc: '2.0',
+                id: '1111111111111111',
+                result: '0x1',
+              },
+            };
+          }),
+        await mockServer
+          .forPost(infuraUrl)
+          .withJsonBodyIncluding({ method: 'eth_getBlockByNumber' })
+          .thenCallback(() => {
+            return {
+              statusCode: 200,
+              json: {
+                jsonrpc: '2.0',
+                id: '1111111111111111',
+                result: {},
+              },
+            };
+          }),
+        await mockServer
+          .forPost(infuraUrl)
+          .withJsonBodyIncluding({ method: 'eth_call' })
+          .thenCallback(() => {
+            return {
+              statusCode: 200,
+              json: {
+                jsonrpc: '2.0',
+                id: '1111111111111111',
+                result: `0x000000000000000000000000${sampleAddress}`,
+              },
+            };
+          }),
+        await mockServer
+          .forPost(infuraUrl)
+          .withJsonBodyIncluding({ method: 'net_version' })
+          .thenCallback(() => {
+            return {
+              statusCode: 200,
+              json: { id: 8262367391254633, jsonrpc: '2.0', result: '1337' },
+            };
+          }),
+      ];
+    }
+
+    await withFixtures(
+      {
+        fixtures: new FixtureBuilder({ onboarding: true })
+          .withNetworkControllerOnMainnet()
+          .build(),
+        ganacheOptions: defaultGanacheOptions,
+        title: this.test.fullTitle(),
+        testSpecificMock: mockInfura,
+      },
+      async ({ driver, mockedEndpoint: mockedEndpoints }) => {
+        const password = 'password';
+
+        await driver.navigate();
+
+        await importSRPOnboardingFlow(driver, TEST_SEED_PHRASE, password);
+
+        await driver.delay(regularDelayMs);
+
+        for (let i = 0; i < mockedEndpoints.length; i += 1) {
+          const mockedEndpoint = await mockedEndpoints[i];
+          const requests = await mockedEndpoint.getSeenRequests();
+
+          assert.equal(
+            requests.length,
+            0,
+            `${mockedEndpoints[i]} should make no requests before onboarding`,
+          );
+        }
+
+        // complete
+        await driver.clickElement('[data-testid="onboarding-complete-done"]');
+
+        // pin extension
+        await driver.clickElement('[data-testid="pin-extension-next"]');
+        await driver.clickElement('[data-testid="pin-extension-done"]');
+
+        // pin extension walkthrough screen
+        await driver.findElement('[data-testid="account-menu-icon"]');
+        // requests happen here!
+
+        for (let i = 0; i < mockedEndpoints.length; i += 1) {
+          const mockedEndpoint = await mockedEndpoints[i];
+
+          await driver.wait(async () => {
+            const isPending = await mockedEndpoint.isPending();
+            return isPending === false;
+          }, driver.timeout);
+
+          const requests = await mockedEndpoint.getSeenRequests();
+
+          assert.equal(
+            requests.length > 0,
+            true,
+            `${mockedEndpoints[i]} should make requests after onboarding`,
+          );
+        }
+      },
+    );
+  });
+
   it('Provides an onboarding path for a user who has restored their account from state persistence failure', async function () {
     // We don't use onboarding:true here because we want there to be a vault,
     // simulating what will happen when a user eventually restores their vault


### PR DESCRIPTION
## **Description**

If you onboard with the import seed phrase option, the `createNewVaultAndRestore` will try to add new accounts for you. This requires network requests to the provider get account balances. We don't want these network requests to happen before the user has finished onboarding and before they have the option to set their provider in the Advanced Settings of onboarding.

This PR moves the account adding logic to its own method, so that it is only called after onboarding is completed.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/24891?quickstart=1)

## **Manual testing steps**

1. Install and onboard by importing an existing seed phrase, in which at least accounts 1 and 2 have balance on the same network
2. Enter your password during onboarding
3. There should not be network requests to the provider before onboarding is complete
4. During onboarding go into "Advanced Settings". Select the network where accounts 1 and 2 have balance
5. After completing onboarding, you should be able to select between accounts 1 and 2.

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
