### PR TITLE
fix: extend patch of @reduxjs/toolkit to EnhancerArray

### DIFF
--- a/.yarn/patches/@reduxjs-toolkit-npm-1.9.7-b14925495c.patch
+++ b/.yarn/patches/@reduxjs-toolkit-npm-1.9.7-b14925495c.patch
@@ -12,7 +12,7 @@ index 6b889a8c93e4c546dd2b1905c968ade143435134..8a63cf3cbc152d84864e1cec07da5c08
 \ No newline at end of file
 +module.exports = require('./redux-toolkit.cjs.development.js')
 diff --git a/dist/redux-toolkit.cjs.development.js b/dist/redux-toolkit.cjs.development.js
-index bb433432ec76331e12d6b62e200f06530055cb16..2738dec3958f9deac89c652f757390ce11abc087 100644
+index bb433432ec76331e12d6b62e200f06530055cb16..9caf4051aa96bd14ee2890ef6c79bf5b0fb685c6 100644
 --- a/dist/redux-toolkit.cjs.development.js
 +++ b/dist/redux-toolkit.cjs.development.js
 @@ -1,3 +1,13 @@
@@ -65,3 +65,30 @@ index bb433432ec76331e12d6b62e200f06530055cb16..2738dec3958f9deac89c652f757390ce
      return MiddlewareArray;
  }(Array));
  var EnhancerArray = /** @class */ (function (_super) {
+@@ -353,14 +363,14 @@ var EnhancerArray = /** @class */ (function (_super) {
+         enumerable: false,
+         configurable: true
+     });
+-    EnhancerArray.prototype.concat = function () {
++    __define(EnhancerArray.prototype, 'concat', function () {
+         var arr = [];
+         for (var _i = 0; _i < arguments.length; _i++) {
+             arr[_i] = arguments[_i];
+         }
+         return _super.prototype.concat.apply(this, arr);
+-    };
+-    EnhancerArray.prototype.prepend = function () {
++    });
++    __define(EnhancerArray.prototype, 'prepend', function () {
+         var arr = [];
+         for (var _i = 0; _i < arguments.length; _i++) {
+             arr[_i] = arguments[_i];
+@@ -369,7 +379,7 @@ var EnhancerArray = /** @class */ (function (_super) {
+             return new (EnhancerArray.bind.apply(EnhancerArray, __spreadArray([void 0], arr[0].concat(this))))();
+         }
+         return new (EnhancerArray.bind.apply(EnhancerArray, __spreadArray([void 0], arr.concat(this))))();
+-    };
++    });
+     return EnhancerArray;
+ }(Array));
+ function freezeDraftable(val) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7597,7 +7597,7 @@ __metadata:
 
 "@reduxjs/toolkit@patch:@reduxjs/toolkit@npm%3A1.9.7#~/.yarn/patches/@reduxjs-toolkit-npm-1.9.7-b14925495c.patch":
   version: 1.9.7
-  resolution: "@reduxjs/toolkit@patch:@reduxjs/toolkit@npm%3A1.9.7#~/.yarn/patches/@reduxjs-toolkit-npm-1.9.7-b14925495c.patch::version=1.9.7&hash=546717"
+  resolution: "@reduxjs/toolkit@patch:@reduxjs/toolkit@npm%3A1.9.7#~/.yarn/patches/@reduxjs-toolkit-npm-1.9.7-b14925495c.patch::version=1.9.7&hash=f36203"
   dependencies:
     immer: "npm:^9.0.21"
     redux: "npm:^4.2.1"
@@ -7611,7 +7611,7 @@ __metadata:
       optional: true
     react-redux:
       optional: true
-  checksum: 2720ea47c2e9b1886713d39f1ddadbb32912c485b0bd830e05344c759519da1283e53877a70092e25061d1aa494e4d345d75ddd56f0ca73b05c2a705dbc53b8d
+  checksum: dc2c6e8429001e4f0251700bce44192aff40c86bde7a8a63642dd7cd06f0fafb76109d024f9fba6e553e75f7b15e4a491789e0447a8d99ddc516d10e61958824
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## **Description**

Fixes regression introduced in #24857.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/24900?quickstart=1)

## **Related issues**

- #24857

## **Manual testing steps**

1. Run `yarn && yarn start`.

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
