### PR TITLE
fix: simulations unavailable native fiat rate

### DIFF
--- a/ui/pages/confirmations/components/simulation-details/useBalanceChanges.test.ts
+++ b/ui/pages/confirmations/components/simulation-details/useBalanceChanges.test.ts
@@ -338,6 +338,19 @@ describe('useBalanceChanges', () => {
       expect(result.current.value[0].fiatAmount).toBe(-663.3337769927953);
     });
 
+    it('handles unavailable native fiat rate', async () => {
+      mockGetConversionRate.mockReturnValue(null);
+      const { result, waitForNextUpdate } = setupHook({
+        ...dummyBalanceChange,
+        difference: DIFFERENCE_ETH_MOCK,
+        isDecrease: true,
+      });
+
+      await waitForNextUpdate();
+
+      expect(result.current.value[0].fiatAmount).toBe(FIAT_UNAVAILABLE);
+    });
+
     it('handles no native balance change', async () => {
       const { result, waitForNextUpdate } = setupHook(undefined);
       await waitForNextUpdate();

--- a/ui/pages/confirmations/components/simulation-details/useBalanceChanges.ts
+++ b/ui/pages/confirmations/components/simulation-details/useBalanceChanges.ts
@@ -113,16 +113,18 @@ async function fetchTokenFiatRates(
 // Compiles the balance change for the native asset
 function getNativeBalanceChange(
   nativeBalanceChange: SimulationBalanceChange | undefined,
-  nativeFiatRate: number,
+  nativeFiatRate: number | undefined,
 ): BalanceChange | undefined {
   if (!nativeBalanceChange) {
     return undefined;
   }
   const asset = NATIVE_ASSET_IDENTIFIER;
   const amount = getAssetAmount(nativeBalanceChange, NATIVE_DECIMALS);
-  const fiatAmount = amount
-    .times(convertNumberToStringWithPrecisionWarning(nativeFiatRate))
-    .toNumber();
+  const fiatAmount = nativeFiatRate
+    ? amount
+        .times(convertNumberToStringWithPrecisionWarning(nativeFiatRate))
+        .toNumber()
+    : FIAT_UNAVAILABLE;
   return { asset, amount, fiatAmount };
 }
 


### PR DESCRIPTION
> [!NOTE]
> To be cherry-picked into v11.16.2
## **Description**
`useBalanceChanges` now handles the case  where native fiat conversion rate is null.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/24910?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
