### PR TITLE
cherry-pick fix: simulations unavailable native fiat rate (#24910) into v11.16.2

### DIFF
--- a/ui/pages/confirmations/components/simulation-details/useBalanceChanges.test.ts
+++ b/ui/pages/confirmations/components/simulation-details/useBalanceChanges.test.ts
@@ -338,6 +338,19 @@ describe('useBalanceChanges', () => {
       expect(result.current.value[0].fiatAmount).toBe(-663.3337769927953);
     });
 
+    it('handles unavailable native fiat rate', async () => {
+      mockGetConversionRate.mockReturnValue(null);
+      const { result, waitForNextUpdate } = setupHook({
+        ...dummyBalanceChange,
+        difference: DIFFERENCE_ETH_MOCK,
+        isDecrease: true,
+      });
+
+      await waitForNextUpdate();
+
+      expect(result.current.value[0].fiatAmount).toBe(FIAT_UNAVAILABLE);
+    });
+
     it('handles no native balance change', async () => {
       const { result, waitForNextUpdate } = setupHook(undefined);
       await waitForNextUpdate();

--- a/ui/pages/confirmations/components/simulation-details/useBalanceChanges.ts
+++ b/ui/pages/confirmations/components/simulation-details/useBalanceChanges.ts
@@ -113,16 +113,18 @@ async function fetchTokenFiatRates(
 // Compiles the balance change for the native asset
 function getNativeBalanceChange(
   nativeBalanceChange: SimulationBalanceChange | undefined,
-  nativeFiatRate: number,
+  nativeFiatRate: number | undefined,
 ): BalanceChange | undefined {
   if (!nativeBalanceChange) {
     return undefined;
   }
   const asset = NATIVE_ASSET_IDENTIFIER;
   const amount = getAssetAmount(nativeBalanceChange, NATIVE_DECIMALS);
-  const fiatAmount = amount
-    .times(convertNumberToStringWithPrecisionWarning(nativeFiatRate))
-    .toNumber();
+  const fiatAmount = nativeFiatRate
+    ? amount
+        .times(convertNumberToStringWithPrecisionWarning(nativeFiatRate))
+        .toNumber()
+    : FIAT_UNAVAILABLE;
   return { asset, amount, fiatAmount };
 }
 


### PR DESCRIPTION
cherry-pick fix: simulations unavailable native fiat rate cff11d774ec31c101407fba3e601b5f892c3308e (#24910) into v11.16.2

no merge conflicts